### PR TITLE
fix(logging): non-blocking streamable log handler + split flush executors

### DIFF
--- a/ingestion/src/metadata/ingestion/connections/source_api_client.py
+++ b/ingestion/src/metadata/ingestion/connections/source_api_client.py
@@ -25,7 +25,7 @@ Usage:
 """
 
 from time import perf_counter
-from typing import Optional
+from typing import Any, Optional, Union
 
 from metadata.ingestion.ometa.client import REST, ClientConfig
 from metadata.utils.operation_metrics import OperationMetricsState
@@ -119,11 +119,19 @@ class TrackedREST(REST):
             duration_ms = (perf_counter() - start) * 1000
             self._record_api_call("GET", path, duration_ms)
 
-    def post(self, path, data=None, json=None, headers=None):
+    def post(
+        self,
+        path: str,
+        data: Any = None,
+        json: Any = None,
+        headers: Optional[dict] = None,  # noqa: UP045
+        timeout: Optional[Union[float, tuple[float, float]]] = None,  # noqa: UP007, UP045
+        retries: Optional[int] = None,  # noqa: UP045
+    ):
         """POST method with tracking."""
         start = perf_counter()
         try:
-            return super().post(path, data, json, headers)
+            return super().post(path, data, json, headers, timeout=timeout, retries=retries)
         finally:
             duration_ms = (perf_counter() - start) * 1000
             self._record_api_call("POST", path, duration_ms)

--- a/ingestion/src/metadata/ingestion/ometa/client.py
+++ b/ingestion/src/metadata/ingestion/ometa/client.py
@@ -160,8 +160,8 @@ class REST:
         base_url: URL = None,
         api_version: str = None,  # noqa: RUF013
         headers: dict = None,  # noqa: RUF013
-        timeout=None,
-        retries=None,
+        timeout: Optional[Union[float, tuple[float, float]]] = None,  # noqa: UP007, UP045
+        retries: Optional[int] = None,  # noqa: UP045
     ):
         # pylint: disable=too-many-locals
         if path in self._limits_reached:
@@ -324,7 +324,15 @@ class REST:
         return self._request("GET", path, data, headers=headers)
 
     @calculate_execution_time(context="POST")
-    def post(self, path, data=None, json=None, headers=None, timeout=None, retries=None):
+    def post(
+        self,
+        path,
+        data=None,
+        json=None,
+        headers=None,
+        timeout: Optional[Union[float, tuple[float, float]]] = None,  # noqa: UP007, UP045
+        retries: Optional[int] = None,  # noqa: UP045
+    ):
         """
         POST method
 
@@ -350,7 +358,13 @@ class REST:
             retries=retries,
         )
 
-    def post_best_effort(self, path, data=None, headers=None, timeout=None) -> bool:
+    def post_best_effort(
+        self,
+        path,
+        data=None,
+        headers=None,
+        timeout: Optional[Union[float, tuple[float, float]]] = None,  # noqa: UP007, UP045
+    ) -> bool:
         """Quiet POST: no retries, no sleep, no logging. Returns True on 2xx."""
         if path in self._limits_reached:
             return False

--- a/ingestion/src/metadata/ingestion/ometa/client.py
+++ b/ingestion/src/metadata/ingestion/ometa/client.py
@@ -153,13 +153,13 @@ class REST:
 
     def _request(  # noqa: C901, pylint: disable=too-many-arguments,too-many-branches
         self,
-        method,
-        path,
-        data=None,
-        json=None,
-        base_url: URL = None,
-        api_version: str = None,  # noqa: RUF013
-        headers: dict = None,  # noqa: RUF013
+        method: str,
+        path: str,
+        data: Any = None,
+        json: Any = None,
+        base_url: Optional[URL] = None,  # noqa: UP045
+        api_version: Optional[str] = None,  # noqa: UP045
+        headers: Optional[dict] = None,  # noqa: UP045
         timeout: Optional[Union[float, tuple[float, float]]] = None,  # noqa: UP007, UP045
         retries: Optional[int] = None,  # noqa: UP045
     ):
@@ -230,7 +230,7 @@ class REST:
         if retries is not None:
             total_retries = retries if retries > 0 else 0
         else:
-            total_retries = self._retry if self._retry > 0 else 0
+            total_retries = self._retry if self._retry and self._retry > 0 else 0
         retry = total_retries
         while retry >= 0:
             try:
@@ -326,10 +326,10 @@ class REST:
     @calculate_execution_time(context="POST")
     def post(
         self,
-        path,
-        data=None,
-        json=None,
-        headers=None,
+        path: str,
+        data: Any = None,
+        json: Any = None,
+        headers: Optional[dict] = None,  # noqa: UP045
         timeout: Optional[Union[float, tuple[float, float]]] = None,  # noqa: UP007, UP045
         retries: Optional[int] = None,  # noqa: UP045
     ):
@@ -360,9 +360,9 @@ class REST:
 
     def post_best_effort(
         self,
-        path,
-        data=None,
-        headers=None,
+        path: str,
+        data: Any = None,
+        headers: Optional[dict] = None,  # noqa: UP045
         timeout: Optional[Union[float, tuple[float, float]]] = None,  # noqa: UP007, UP045
     ) -> bool:
         """Quiet POST: no retries, no sleep, no logging. Returns True on 2xx."""
@@ -388,7 +388,7 @@ class REST:
             return False
         return 200 <= resp.status_code < 300
 
-    def _build_request_headers(self, headers=None):
+    def _build_request_headers(self, headers: Optional[dict] = None):  # noqa: UP045
         """Reader-only headers builder. Does NOT refresh auth token —
         refresh stays on _request() to avoid concurrent refreshes from
         post_best_effort callers sharing ClientConfig."""

--- a/ingestion/src/metadata/ingestion/ometa/client.py
+++ b/ingestion/src/metadata/ingestion/ometa/client.py
@@ -223,16 +223,10 @@ class REST:
         if self._cert:
             opts["cert"] = self._cert
 
-        # Per-call timeout overrides the instance default. Used by the
-        # streamable log handler so a slow logs endpoint can't tie up the
-        # shipper for the full instance timeout.
         effective_timeout = timeout if timeout is not None else self._timeout
         if effective_timeout:
             opts["timeout"] = effective_timeout
 
-        # Per-call retry override. The streamable log handler passes
-        # retries=0 so a 504/429 from the logs endpoint can't tie up a
-        # post thread inside the RetryException sleep loop below.
         if retries is not None:
             total_retries = retries if retries > 0 else 0
         else:
@@ -357,21 +351,7 @@ class REST:
         )
 
     def post_best_effort(self, path, data=None, headers=None, timeout=None) -> bool:
-        """
-        Quiet POST for fire-and-forget log shipping.
-
-        Bypasses every behavior that could either block or re-enter the
-        streamable log handler:
-        - No retry loop, no exponential-backoff sleep on 429/504.
-        - No second request on ConnectionError (the "try one more time"
-          in _one_request).
-        - No logger.warning/error/debug - those would propagate to the
-          metadata.OMetaAPI logger and feed back into the handler.
-
-        Returns:
-            True on a 2xx response, False on anything else (including
-            timeouts, connection errors, non-2xx status, etc.).
-        """
+        """Quiet POST: no retries, no sleep, no logging. Returns True on 2xx."""
         if path in self._limits_reached:
             return False
         try:
@@ -395,16 +375,9 @@ class REST:
         return 200 <= resp.status_code < 300
 
     def _build_request_headers(self, headers=None):
-        """Build headers for an outgoing request — auth + extra_headers.
-
-        Deliberately does NOT refresh the auth token. The streamable log
-        handler shares ClientConfig with the main metadata client (so
-        token refreshes done by the main client are visible here), but
-        the sender daemon thread MUST NOT also refresh — concurrent
-        _auth_token() calls from two threads can double-refresh against
-        rate-limited or single-use refresh tokens, and introduces a
-        TOCTOU on config.expires_in. Reads only.
-        """
+        """Reader-only headers builder. Does NOT refresh auth token —
+        refresh stays on _request() to avoid concurrent refreshes from
+        post_best_effort callers sharing ClientConfig."""
         if not headers:
             headers = {"Content-type": "application/json"}
         if self.config.auth_header and self.config.access_token:

--- a/ingestion/src/metadata/ingestion/ometa/client.py
+++ b/ingestion/src/metadata/ingestion/ometa/client.py
@@ -151,7 +151,7 @@ class REST:
 
         self._limits_reached = TTLCache(config.ttl_cache)
 
-    def _request(  # pylint: disable=too-many-arguments,too-many-branches
+    def _request(  # noqa: C901, pylint: disable=too-many-arguments,too-many-branches
         self,
         method,
         path,
@@ -160,6 +160,8 @@ class REST:
         base_url: URL = None,
         api_version: str = None,  # noqa: RUF013
         headers: dict = None,  # noqa: RUF013
+        timeout=None,
+        retries=None,
     ):
         # pylint: disable=too-many-locals
         if path in self._limits_reached:
@@ -221,10 +223,20 @@ class REST:
         if self._cert:
             opts["cert"] = self._cert
 
-        if self._timeout:
-            opts["timeout"] = self._timeout
+        # Per-call timeout overrides the instance default. Used by the
+        # streamable log handler so a slow logs endpoint can't tie up the
+        # shipper for the full instance timeout.
+        effective_timeout = timeout if timeout is not None else self._timeout
+        if effective_timeout:
+            opts["timeout"] = effective_timeout
 
-        total_retries = self._retry if self._retry > 0 else 0
+        # Per-call retry override. The streamable log handler passes
+        # retries=0 so a 504/429 from the logs endpoint can't tie up a
+        # post thread inside the RetryException sleep loop below.
+        if retries is not None:
+            total_retries = retries if retries > 0 else 0
+        else:
+            total_retries = self._retry if self._retry > 0 else 0
         retry = total_retries
         while retry >= 0:
             try:
@@ -318,7 +330,7 @@ class REST:
         return self._request("GET", path, data, headers=headers)
 
     @calculate_execution_time(context="POST")
-    def post(self, path, data=None, json=None, headers=None):
+    def post(self, path, data=None, json=None, headers=None, timeout=None, retries=None):
         """
         POST method
 
@@ -327,11 +339,93 @@ class REST:
             data ():
             json ():
             headers (dict): Optional custom headers to override default headers
+            timeout: Per-call timeout that overrides the instance default
+            retries: Per-call retry budget that overrides the instance default.
+                     Pass 0 to disable the retry/sleep loop entirely.
 
         Returns:
             Response
         """
-        return self._request("POST", path, data, json, headers=headers)
+        return self._request(
+            "POST",
+            path,
+            data,
+            json,
+            headers=headers,
+            timeout=timeout,
+            retries=retries,
+        )
+
+    def post_best_effort(self, path, data=None, headers=None, timeout=None) -> bool:
+        """
+        Quiet POST for fire-and-forget log shipping.
+
+        Bypasses every behavior that could either block or re-enter the
+        streamable log handler:
+        - No retry loop, no exponential-backoff sleep on 429/504.
+        - No second request on ConnectionError (the "try one more time"
+          in _one_request).
+        - No logger.warning/error/debug - those would propagate to the
+          metadata.OMetaAPI logger and feed back into the handler.
+
+        Returns:
+            True on a 2xx response, False on anything else (including
+            timeouts, connection errors, non-2xx status, etc.).
+        """
+        if path in self._limits_reached:
+            return False
+        try:
+            url = URL(self._base_url + "/" + self._api_version + path)
+            req_headers = self._build_request_headers(headers)
+            kwargs = {
+                "data": data,
+                "headers": req_headers,
+                "verify": self._verify,
+                "cookies": self._cookies,
+                "allow_redirects": self.config.allow_redirects,
+            }
+            effective_timeout = timeout if timeout is not None else self._timeout
+            if effective_timeout:
+                kwargs["timeout"] = effective_timeout
+            if self._cert:
+                kwargs["cert"] = self._cert
+            resp = self._session.post(url, **kwargs)
+        except Exception:
+            return False
+        return 200 <= resp.status_code < 300
+
+    def _build_request_headers(self, headers=None):
+        """Build headers + auth + extra_headers for an outgoing request.
+
+        Mirrors what _request() does inline so post_best_effort() and any
+        future quiet path can reuse the same auth/extras pipeline without
+        going through the retry/log machinery.
+        """
+        if not headers:
+            headers = {"Content-type": "application/json"}
+        if (
+            self.config.expires_in  # noqa: RUF021
+            and datetime.now(timezone.utc).timestamp() >= self.config.expires_in
+            or not self.config.access_token  # noqa: RUF021
+            and self._auth_token
+        ):
+            self.config.access_token, expiry = self._auth_token()
+            if not self.config.access_token == "no_token":  # noqa: SIM201
+                if isinstance(expiry, datetime):
+                    self.config.expires_in = expiry.timestamp() - 120
+                else:
+                    self.config.expires_in = datetime.now(timezone.utc).timestamp() + expiry - 120
+        if self.config.auth_header:
+            headers[self.config.auth_header] = (
+                f"{self._auth_token_mode} {self.config.access_token}"
+                if self._auth_token_mode
+                else self.config.access_token
+            )
+        if self.config.extra_headers:
+            extra_headers: Dict[str, str] = self.config.extra_headers  # noqa: UP006
+            extra_headers = {k: (v % headers) for k, v in extra_headers.items()}
+            headers = {**headers, **extra_headers}
+        return headers
 
     @calculate_execution_time(context="PUT")
     def put(self, path, data=None, json=None, headers=None):

--- a/ingestion/src/metadata/ingestion/ometa/client.py
+++ b/ingestion/src/metadata/ingestion/ometa/client.py
@@ -395,27 +395,19 @@ class REST:
         return 200 <= resp.status_code < 300
 
     def _build_request_headers(self, headers=None):
-        """Build headers + auth + extra_headers for an outgoing request.
+        """Build headers for an outgoing request — auth + extra_headers.
 
-        Mirrors what _request() does inline so post_best_effort() and any
-        future quiet path can reuse the same auth/extras pipeline without
-        going through the retry/log machinery.
+        Deliberately does NOT refresh the auth token. The streamable log
+        handler shares ClientConfig with the main metadata client (so
+        token refreshes done by the main client are visible here), but
+        the sender daemon thread MUST NOT also refresh — concurrent
+        _auth_token() calls from two threads can double-refresh against
+        rate-limited or single-use refresh tokens, and introduces a
+        TOCTOU on config.expires_in. Reads only.
         """
         if not headers:
             headers = {"Content-type": "application/json"}
-        if (
-            self.config.expires_in  # noqa: RUF021
-            and datetime.now(timezone.utc).timestamp() >= self.config.expires_in
-            or not self.config.access_token  # noqa: RUF021
-            and self._auth_token
-        ):
-            self.config.access_token, expiry = self._auth_token()
-            if not self.config.access_token == "no_token":  # noqa: SIM201
-                if isinstance(expiry, datetime):
-                    self.config.expires_in = expiry.timestamp() - 120
-                else:
-                    self.config.expires_in = datetime.now(timezone.utc).timestamp() + expiry - 120
-        if self.config.auth_header:
+        if self.config.auth_header and self.config.access_token:
             headers[self.config.auth_header] = (
                 f"{self._auth_token_mode} {self.config.access_token}"
                 if self._auth_token_mode

--- a/ingestion/src/metadata/ingestion/ometa/mixins/logs_mixin.py
+++ b/ingestion/src/metadata/ingestion/ometa/mixins/logs_mixin.py
@@ -50,6 +50,7 @@ class OMetaLogsMixin:
         run_id: UUID,
         log_content: str,
         compress: bool = False,
+        timeout=None,
     ) -> bool:
         """
         Send logs to S3 storage via OpenMetadata server endpoint.
@@ -59,6 +60,7 @@ class OMetaLogsMixin:
             run_id: Unique identifier for the pipeline run
             log_content: The log content to send
             compress: Whether to compress logs before sending
+            timeout: Per-call HTTP timeout (seconds). Overrides client default.
 
         Returns:
             bool: True if logs were sent successfully, False otherwise
@@ -87,6 +89,7 @@ class OMetaLogsMixin:
             self.client.post(
                 url,
                 data=json.dumps(log_batch),
+                timeout=timeout,
             )
 
             # The REST client returns None for successful requests with empty response body (HTTP 200/201/204)
@@ -111,6 +114,7 @@ class OMetaLogsMixin:
         log_content: str,
         enable_compression: bool = False,
         max_retries: int = 3,
+        timeout=None,
     ) -> dict:
         """
         Send logs batch to S3 storage via OpenMetadata server endpoint with retry logic.
@@ -121,6 +125,9 @@ class OMetaLogsMixin:
             log_content: The log content to send
             enable_compression: Whether to compress logs before sending
             max_retries: Maximum number of retry attempts
+            timeout: Per-call HTTP timeout (seconds). Overrides client default.
+                     Streamable log handler passes a short value here so a
+                     slow server can't tie up the shipper.
 
         Returns:
             dict: Metrics including lines sent and bytes sent
@@ -134,6 +141,7 @@ class OMetaLogsMixin:
                     run_id=run_id,
                     log_content=log_content,
                     compress=enable_compression and len(log_content) > 10240,
+                    timeout=timeout,
                 )
 
                 if success:
@@ -174,6 +182,74 @@ class OMetaLogsMixin:
                     )
 
         return metrics
+
+    def send_logs_batch_best_effort(
+        self,
+        pipeline_fqn: str,
+        run_id: UUID,
+        log_content: str,
+        timeout=None,
+        client=None,
+    ) -> bool:
+        """
+        Quiet log-upload path used by StreamableLogHandler.
+
+        Goes through ``client.post_best_effort`` rather than ``client.post`` so:
+        - no retry loop, no sleep on 504/429
+        - no second request on ConnectionError
+        - no logging through ``ometa_logger`` (would propagate back to the
+          streamable handler that's attached to the metadata logger)
+
+        ``client`` lets the caller pass an isolated REST instance so log
+        shipping does not share a ``requests.Session`` / connection pool /
+        cookie jar with normal ingestion API calls. Defaults to the
+        instance client for backwards compatibility.
+
+        Returns True on 2xx, False on anything else.
+        """
+        try:
+            url = f"/services/ingestionPipelines/logs/{pipeline_fqn}/{model_str(run_id)}"
+            log_batch = {
+                "logs": log_content,
+                "timestamp": int(time.time() * 1000),
+                "connectorId": f"{socket.gethostname()}-{os.getpid()}",
+                "compressed": False,
+                "lineCount": log_content.count("\n") + 1,
+            }
+            target = client if client is not None else self.client
+            return target.post_best_effort(
+                url,
+                data=json.dumps(log_batch),
+                timeout=timeout,
+            )
+        except Exception:
+            return False
+
+    def send_close_best_effort(
+        self,
+        pipeline_fqn: str,
+        run_id: UUID,
+        timeout=None,
+        client=None,
+    ) -> bool:
+        """Quiet close-stream notify used by StreamableLogHandler.close().
+
+        Same guarantees and ``client`` kwarg as send_logs_batch_best_effort.
+        """
+        try:
+            url = f"/services/ingestionPipelines/logs/{pipeline_fqn}/{model_str(run_id)}/close"
+            close_data = {
+                "connectorId": f"{socket.gethostname()}-{os.getpid()}",
+                "timestamp": int(time.time() * 1000),
+            }
+            target = client if client is not None else self.client
+            return target.post_best_effort(
+                url,
+                data=json.dumps(close_data),
+                timeout=timeout,
+            )
+        except Exception:
+            return False
 
     def create_log_stream(
         self,

--- a/ingestion/src/metadata/ingestion/ometa/mixins/logs_mixin.py
+++ b/ingestion/src/metadata/ingestion/ometa/mixins/logs_mixin.py
@@ -191,22 +191,7 @@ class OMetaLogsMixin:
         timeout=None,
         client=None,
     ) -> bool:
-        """
-        Quiet log-upload path used by StreamableLogHandler.
-
-        Goes through ``client.post_best_effort`` rather than ``client.post`` so:
-        - no retry loop, no sleep on 504/429
-        - no second request on ConnectionError
-        - no logging through ``ometa_logger`` (would propagate back to the
-          streamable handler that's attached to the metadata logger)
-
-        ``client`` lets the caller pass an isolated REST instance so log
-        shipping does not share a ``requests.Session`` / connection pool /
-        cookie jar with normal ingestion API calls. Defaults to the
-        instance client for backwards compatibility.
-
-        Returns True on 2xx, False on anything else.
-        """
+        """Best-effort log POST: no retries, no logging. Returns True on 2xx."""
         try:
             url = f"/services/ingestionPipelines/logs/{pipeline_fqn}/{model_str(run_id)}"
             log_batch = {
@@ -232,10 +217,7 @@ class OMetaLogsMixin:
         timeout=None,
         client=None,
     ) -> bool:
-        """Quiet close-stream notify used by StreamableLogHandler.close().
-
-        Same guarantees and ``client`` kwarg as send_logs_batch_best_effort.
-        """
+        """Best-effort /close notify. Same guarantees as send_logs_batch_best_effort."""
         try:
             url = f"/services/ingestionPipelines/logs/{pipeline_fqn}/{model_str(run_id)}/close"
             close_data = {

--- a/ingestion/src/metadata/ingestion/ometa/mixins/logs_mixin.py
+++ b/ingestion/src/metadata/ingestion/ometa/mixins/logs_mixin.py
@@ -22,7 +22,7 @@ import json
 import os
 import socket
 import time
-from typing import Optional
+from typing import Optional, Union
 from uuid import UUID
 
 from metadata.ingestion.ometa.client import REST
@@ -50,7 +50,7 @@ class OMetaLogsMixin:
         run_id: UUID,
         log_content: str,
         compress: bool = False,
-        timeout=None,
+        timeout: Optional[Union[float, tuple[float, float]]] = None,  # noqa: UP007, UP045
     ) -> bool:
         """
         Send logs to S3 storage via OpenMetadata server endpoint.
@@ -114,7 +114,7 @@ class OMetaLogsMixin:
         log_content: str,
         enable_compression: bool = False,
         max_retries: int = 3,
-        timeout=None,
+        timeout: Optional[Union[float, tuple[float, float]]] = None,  # noqa: UP007, UP045
     ) -> dict:
         """
         Send logs batch to S3 storage via OpenMetadata server endpoint with retry logic.
@@ -188,8 +188,8 @@ class OMetaLogsMixin:
         pipeline_fqn: str,
         run_id: UUID,
         log_content: str,
-        timeout=None,
-        client=None,
+        timeout: Optional[Union[float, tuple[float, float]]] = None,  # noqa: UP007, UP045
+        client: Optional[REST] = None,  # noqa: UP045
     ) -> bool:
         """Best-effort log POST: no retries, no logging. Returns True on 2xx."""
         try:
@@ -214,8 +214,8 @@ class OMetaLogsMixin:
         self,
         pipeline_fqn: str,
         run_id: UUID,
-        timeout=None,
-        client=None,
+        timeout: Optional[Union[float, tuple[float, float]]] = None,  # noqa: UP007, UP045
+        client: Optional[REST] = None,  # noqa: UP045
     ) -> bool:
         """Best-effort /close notify. Same guarantees as send_logs_batch_best_effort."""
         try:

--- a/ingestion/src/metadata/utils/streamable_logger.py
+++ b/ingestion/src/metadata/utils/streamable_logger.py
@@ -256,12 +256,20 @@ class StreamableLogHandler(logging.Handler):
         if self._closed:
             return
         self._closed = True
-        self._stop.set()
 
         if self.enable_streaming:
             self._drain_remaining_buffer()
             with contextlib.suppress(Full):
                 self._send_queue.put_nowait(_CLOSE_MARKER)
+
+        # Signal stop AFTER the remaining batches and CLOSE_MARKER are
+        # in the send queue. The sender's loop checks _stop only on an
+        # Empty timeout; setting stop first creates a race where the
+        # sender's in-flight get(timeout=1s) returns Empty in the narrow
+        # window between set() and enqueue, exits, and never processes
+        # either the remaining batches or the CLOSE_MARKER. Enqueue first,
+        # then set — preserves the ordering guarantee in docstring point 7.
+        self._stop.set()
 
         with contextlib.suppress(Exception):
             self.fallback_handler.close()

--- a/ingestion/src/metadata/utils/streamable_logger.py
+++ b/ingestion/src/metadata/utils/streamable_logger.py
@@ -9,507 +9,331 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 """
-Streamable log handler for shipping logs to OpenMetadata server.
+Best-effort streamable log handler for OpenMetadata ingestion pipelines.
 
-This module provides a pluggable logger that can stream ingestion logs
-to the server's S3 storage backend without impacting application traffic.
+Design contract (in order of importance):
 
-Configuration:
--------------
-The streamable logger is automatically enabled when:
-1. The IngestionPipeline entity has `enableStreamableLogs` set to true
-2. The ingestion pipeline FQN and run ID are available
-3. The OpenMetadata server has log storage configured (S3 or compatible)
+1. emit() never blocks the producer. Format -> put_nowait -> return.
+   On overflow we increment a counter and drop the record. We do NOT
+   write the dropped record to stderr from inside emit() - that would
+   add synchronous stderr I/O to every producer log under backpressure.
 
-Environment Variables (Optional):
---------------------------------
-- ENABLE_LOG_COMPRESSION: Set to "true" to compress logs before sending (default: "false")
+2. emit() can NEVER re-enter itself. A thread-local flag is set on the
+   sender thread; if emit() sees it, it returns immediately. This is a
+   belt-and-suspenders backstop to the PR #28160 fix: even if a future
+   change reintroduces logging on the shipping path, the recursion
+   simply can't happen.
 
-Features:
---------
-- Asynchronous log shipping with buffering
-- Automatic compression for large payloads (>10KB when enabled)
-- Circuit breaker pattern for failure handling
-- Fallback to local logging when remote logging fails
-- Session cookie persistence for ALB sticky sessions
-- Configurable batch size and flush intervals
+3. ALL background threads are DAEMON. Drainer and senders alike. If
+   the connector main thread exits while a sender is wedged on a slow
+   DNS / TLS / auth call, the process still terminates. Logging will
+   never keep a pod alive.
 
-Usage:
-------
-The streamable logger is automatically configured in the BaseWorkflow class
-when a workflow starts. No manual setup is required if the environment is
-properly configured.
+4. The sender pool is bounded by a fixed-size send queue. If all sender
+   slots are occupied (slow / dead server), the drainer drops new
+   batches and increments a counter. No unbounded thread / memory
+   growth regardless of how long the server takes.
 
-For manual setup (testing):
-```python
-from metadata.utils.streamable_logger import setup_streamable_logging_for_workflow
+5. The HTTP POST goes through a dedicated quiet path
+   (``send_logs_batch_best_effort`` -> ``client.post_best_effort``):
+   no retries, no sleep, no connection-error retry, no logging through
+   ``ometa_logger``. Failure is a silent bool - counted, not logged.
 
-handler = setup_streamable_logging_for_workflow(
-    metadata=metadata_client,
-    pipeline_fqn="service.pipeline_name",
-    run_id=UUID("..."),
-    log_level=logging.INFO
-)
-```
+6. The handler uses an ISOLATED ``REST`` client (own ``requests.Session``,
+   own connection pool, own cookie jar). Shares ``ClientConfig`` with
+   the main metadata client so auth-token refreshes done by the main
+   client are picked up here too - but log shipping can never interfere
+   with normal ingestion API traffic.
+
+7. close() does NOT block on the server and does NOT join workers.
+   It signals the drainer/senders to stop, enqueues a close marker
+   behind already-queued log batches, and returns.
+
+No locks. No sleeps beyond ``queue.get(timeout=...)`` in the drainer/
+senders, which is necessary so they're not in a tight loop when idle.
 """
 
+import contextlib
 import logging
-import os
-import queue
-import sys
 import threading
-import time
-from enum import Enum
-from typing import Any, Dict, Optional  # noqa: UP035
+from queue import Empty, Full, Queue
+from typing import Optional
 from uuid import UUID
 
+from metadata.ingestion.ometa.client import REST
 from metadata.ingestion.ometa.ometa_api import OpenMetadata
 from metadata.ingestion.ometa.utils import model_str
 from metadata.utils.logger import BASE_LOGGING_FORMAT, METADATA_LOGGER, ingestion_logger
 
 logger = ingestion_logger()
 
-# Internal logger used by this handler's own diagnostics. It MUST NOT propagate
-# to the root logger because `StreamableLogHandler` is attached there — logging
-# through `logger` from inside `emit()` or its callees re-enters this handler
-# and recurses until the Python recursion limit is hit. A separate logger with
-# `propagate=False` writing straight to stderr is the safe channel for any
-# message originating inside this module's hot path.
-_internal_logger = logging.getLogger("metadata.utils.streamable_logger.internal")
-_internal_logger.propagate = False
-if not _internal_logger.handlers:
-    _internal_handler = logging.StreamHandler(sys.stderr)
-    _internal_handler.setFormatter(
-        logging.Formatter(
-            "%(asctime)s [streamable-log-handler] %(levelname)s %(message)s",
-            datefmt="%Y-%m-%d %H:%M:%S",
-        )
-    )
-    _internal_logger.addHandler(_internal_handler)
-    # Filter at the handler so operators can change verbosity at runtime
-    # (e.g. via a debug toggle) without modifying the logger level itself.
-    _internal_handler.setLevel(logging.INFO)
-    _internal_logger.setLevel(logging.DEBUG)
+# Thread-local recursion guard. Sender threads set ``shipping = True``
+# before doing any work. If emit() sees this flag (i.e. someone logged
+# from inside the shipping path), it returns immediately. This protects
+# us even if a future refactor reintroduces logging in the POST path.
+_shipping_state = threading.local()
+_CLOSE_MARKER = object()
 
 
-class CircuitBreakerError(Exception):
-    """Base exception for circuit breaker errors"""
-
-
-class CircuitOpenError(CircuitBreakerError):
-    """Raised when circuit breaker is in OPEN state"""
-
-
-class ServiceCallError(Exception):
-    """Raised when the underlying service call fails"""
-
-
-class CircuitState(Enum):
-    """Circuit breaker states"""
-
-    CLOSED = "closed"  # Normal operation
-    OPEN = "open"  # Failures detected, requests blocked
-    HALF_OPEN = "half_open"  # Testing if service recovered
-
-
-class CircuitBreaker:
-    """
-    Circuit breaker pattern implementation to prevent cascading failures.
-    Fallback to local logging when remote logging fails.
-    """
-
-    def __init__(
-        self,
-        failure_threshold: int = 5,
-        recovery_timeout: int = 60,
-        success_threshold: int = 2,
-    ):
-        self.failure_threshold = failure_threshold
-        self.recovery_timeout = recovery_timeout
-        self.success_threshold = success_threshold
-        self.failure_count = 0
-        self.success_count = 0
-        self.last_failure_time = None
-        self.state = CircuitState.CLOSED
-        self._lock = threading.Lock()
-
-    def call(self, func, *args, **kwargs):
-        """Execute function with circuit breaker protection"""
-        with self._lock:
-            if self.state == CircuitState.OPEN:
-                if self._should_attempt_reset():
-                    self.state = CircuitState.HALF_OPEN
-                    self.success_count = 0
-                else:
-                    raise CircuitOpenError("Circuit breaker is OPEN")
-
-        try:
-            result = func(*args, **kwargs)
-            self._on_success()
-            return result  # noqa: TRY300
-        except (CircuitBreakerError, ServiceCallError):
-            raise
-        except Exception as e:
-            self._on_failure()
-            raise ServiceCallError(f"Service call failed: {str(e)}") from e  # noqa: RUF010
-
-    def _should_attempt_reset(self) -> bool:
-        """Check if enough time has passed to attempt reset"""
-        return self.last_failure_time and time.time() - self.last_failure_time >= self.recovery_timeout
-
-    def _on_success(self):
-        """Handle successful call"""
-        with self._lock:
-            self.failure_count = 0
-            if self.state == CircuitState.HALF_OPEN:
-                self.success_count += 1
-                if self.success_count >= self.success_threshold:
-                    self.state = CircuitState.CLOSED
-
-    def _on_failure(self):
-        """Handle failed call"""
-        with self._lock:
-            self.failure_count += 1
-            self.last_failure_time = time.time()
-
-            if self.failure_count >= self.failure_threshold:
-                self.state = CircuitState.OPEN
-            elif self.state == CircuitState.HALF_OPEN:
-                self.state = CircuitState.OPEN
-
-
-# pylint: disable=too-many-instance-attributes
 class StreamableLogHandler(logging.Handler):
-    """
-    Custom logging handler that streams logs to OpenMetadata server.
+    """Fire-and-forget log shipper. See module docstring for the contract."""
 
-    Features:
-    - Async log shipping with buffering
-    - Circuit breaker for failure handling
-    - Automatic fallback to local logging
-    - Configurable batch size and flush intervals
-    """
+    # Tunables. None affect correctness - only loss rate and how many
+    # sender threads can be in flight at once. Conservative defaults.
+    BATCH_SIZE = 500
+    BATCH_WAIT_SEC = 2.0
+    SENDER_TICK_SEC = 1.0
+    HTTP_TIMEOUT = (1.0, 2.0)  # (connect, read) seconds
+    SENDER_WORKERS = 1  # single daemon sender preserves logs -> close ordering
+    MAX_PENDING_BATCHES = 4  # bounded send-queue depth
+    CLOSE_TIMEOUT_SEC = 2.0  # for the fire-and-forget /close call
 
-    # pylint: disable=too-many-arguments
+    # pylint: disable=too-many-arguments,too-many-instance-attributes
     def __init__(
         self,
         metadata: OpenMetadata,
         pipeline_fqn: str,
         run_id: UUID,
-        batch_size: int = 500,
-        flush_interval_sec: float = 10.0,
-        max_queue_size: int = 10000,
+        max_buffer: int = 10000,
         enable_streaming: bool = True,
     ):
-        """
-        Initialize the streamable log handler.
-
-        Args:
-            metadata: OpenMetadata client instance
-            pipeline_fqn: Fully qualified name of the pipeline
-            run_id: Unique run identifier
-            batch_size: Number of log entries to batch before sending
-            flush_interval_sec: Time in seconds between automatic flushes
-            max_queue_size: Maximum size of the log queue
-            enable_streaming: Whether to enable log streaming (can be disabled for testing)
-        """
         super().__init__()
-
         self.metadata = metadata
         self.pipeline_fqn = pipeline_fqn
         self.run_id = run_id
-        self.batch_size = batch_size
-        self.flush_interval_sec = flush_interval_sec
         self.enable_streaming = enable_streaming
 
-        # Local fallback handler
+        # Used only when streaming is disabled - direct passthrough.
         self.fallback_handler = logging.StreamHandler()
-        self.fallback_handler.setFormatter(self.formatter)
 
-        # Circuit breaker for failure handling
-        self.circuit_breaker = CircuitBreaker()
+        # Producer-side bounded buffer; drainer drains, senders POST.
+        self._buffer: Queue = Queue(maxsize=max_buffer)
+        # Send queue is the in-flight cap. Drainer put_nowait - drop on Full.
+        self._send_queue: Queue = Queue(maxsize=self.MAX_PENDING_BATCHES)
+        self._stop = threading.Event()
+        self._closed = False
+        self._drainer: Optional[threading.Thread] = None  # noqa: UP045
+        self._senders: list = []
 
-        # Log queue and worker thread
-        self.log_queue = queue.Queue(maxsize=max_queue_size)
-        self.stop_event = threading.Event()
-        self.worker_thread = None
-
-        # Session ID for log streaming (if server supports it)
-        self.session_id = None
-
-        # Metrics tracking
-        self.metrics = {
-            "logs_sent": 0,
-            "logs_failed": 0,
-            "bytes_sent": 0,
-            "circuit_trips": 0,
-            "fallback_count": 0,
-        }
-
-        # Start worker thread if streaming is enabled
-        if self.enable_streaming:
-            self._initialize_log_stream()
-            self._start_worker()
-
-    def _initialize_log_stream(self):
-        """Initialize log stream with the server"""
-        if hasattr(self.metadata, "create_log_stream"):
-            self.session_id = self.metadata.create_log_stream(self.pipeline_fqn, self.run_id)
-
-    def _start_worker(self):
-        """Start the background worker thread for log shipping"""
-        if self.worker_thread is None or not self.worker_thread.is_alive():
-            self.worker_thread = threading.Thread(
-                target=self._worker_loop,
-                name=f"log-shipper-{self.pipeline_fqn}",
-                daemon=True,
-            )
-            self.worker_thread.start()
-
-    def _drain_queue_to_buffer(self, buffer: list) -> tuple[list, bool]:
-        """
-        Drain all available items from the queue into the buffer.
-
-        Args:
-            buffer: Current buffer to append items to
-
-        Returns:
-            Updated buffer and whether a flush marker was encountered
-        """
-        timeout = min(1.0, self.flush_interval_sec)
-        flush_requested = False
-
-        # Get items from queue until empty
-        while True:
-            try:
-                # Use timeout for first call, then get_nowait for remaining
-                log_entry = self.log_queue.get(timeout=timeout) if timeout else self.log_queue.get_nowait()
-
-                if log_entry is None:
-                    # Flush marker encountered
-                    flush_requested = True
-                else:
-                    buffer.append(log_entry)
-
-                # After first successful get, switch to no timeout for draining
-                timeout = None
-
-            except queue.Empty:
-                break
-
-        return buffer, flush_requested
-
-    def _worker_loop(self):
-        """Background worker that ships logs to the server"""
-        buffer = []
-        last_flush = time.time()
-
-        while not self.stop_event.is_set():
-            try:
-                # Drain all available items from queue
-                buffer, flush_requested = self._drain_queue_to_buffer(buffer)
-
-                # Check if we should flush
-                should_flush = (
-                    flush_requested
-                    or len(buffer) >= self.batch_size
-                    or (time.time() - last_flush) >= self.flush_interval_sec
-                )
-
-                if should_flush and buffer:
-                    self._ship_logs(buffer)
-                    buffer = []
-                    last_flush = time.time()
-
-                # Let's not flush too often
-                time.sleep(1.0)
-
-            except Exception as e:
-                # NEVER use `logger` here — this handler is attached to it and
-                # logging through `logger` would re-enter our own emit().
-                _internal_logger.error("error in log shipping worker: %s", e)
-                # Continue processing to avoid blocking
-
-        # Final cleanup - drain ALL remaining items from the queue
-        buffer, _ = self._drain_queue_to_buffer(buffer)
-
-        # Send any final buffered logs
-        if buffer:
-            self._ship_logs(buffer)
-
-    def _ship_logs(self, logs: list):
-        """Ship logs to the server with circuit breaker protection"""
-        if not logs:
-            return
-
-        log_content = "\n".join(logs) + "\n"  # Ensure newline at end
-
-        try:
-            # Try to send logs with circuit breaker
-            self.circuit_breaker.call(self._send_logs_to_server, log_content)
-        except CircuitOpenError:
-            # Circuit is open, update metrics
-            self.metrics["logs_failed"] += len(logs)
-            self.metrics["circuit_trips"] += 1
-            self.metrics["fallback_count"] += 1
-
-            # NEVER use `logger` here — this handler is attached to it.
-            _internal_logger.debug("circuit breaker is OPEN, falling back to local logging")
-            for log in logs:
-                _internal_logger.info("[FALLBACK] %s", log)
-        except (ServiceCallError, Exception) as e:
-            # Service call failed, update metrics
-            self.metrics["logs_failed"] += len(logs)
-            self.metrics["fallback_count"] += 1
-
-            # Fallback to local logging via the internal (non-propagating)
-            # logger. Using `logger` here would dispatch the message back into
-            # this handler, re-entering shipping and ultimately recursing.
-            _internal_logger.debug("failed to ship logs to server: %s", e)
-            for log in logs:
-                _internal_logger.info("[FALLBACK] %s", log)
-
-    def _send_logs_to_server(self, log_content: str):
-        """Send logs to the OpenMetadata server using the logs mixin"""
-        enable_compression = os.getenv("ENABLE_LOG_COMPRESSION", "false").lower() == "true"
-        # Use the centralized logs mixin method which handles both new and legacy approaches
-        metrics = self.metadata.send_logs_batch(
-            pipeline_fqn=self.pipeline_fqn,
-            run_id=self.run_id,
-            log_content=log_content,
-            enable_compression=enable_compression,
+        # Isolated REST client. Same ClientConfig (token refresh visible)
+        # but distinct requests.Session / connection pool / cookie jar.
+        # Log shipping cannot interfere with normal ingestion API traffic.
+        self._client: Optional[REST] = (  # noqa: UP045
+            REST(metadata.client.config) if enable_streaming else None
         )
-        # Update handler metrics with returned metrics
-        self.metrics["logs_sent"] += metrics["logs_sent"]
-        self.metrics["bytes_sent"] += metrics["bytes_sent"]
+
+        # Diagnostic counters (plain ints - the GIL makes ++ monotonic-safe).
+        self.dropped_overflow = 0  # buffer Full at emit()
+        self.dropped_saturated = 0  # send_queue Full at drain()
+        self.dropped_shipping = 0  # recursion guard tripped
+
+        if self.enable_streaming:
+            self._start_workers()
+
+    def _start_workers(self):
+        """All daemon. Drainer + N senders. Process can exit at any time
+        without waiting for them - that's the explicit non-blocking goal."""
+        self._drainer = threading.Thread(
+            target=self._drain_loop,
+            daemon=True,
+            name=f"log-drain-{self.pipeline_fqn[:24]}",
+        )
+        self._drainer.start()
+        for i in range(self.SENDER_WORKERS):
+            t = threading.Thread(
+                target=self._sender_loop,
+                daemon=True,
+                name=f"log-ship-{self.pipeline_fqn[:16]}-{i}",
+            )
+            t.start()
+            self._senders.append(t)
 
     def emit(self, record: logging.LogRecord):
-        """
-        Emit a log record.
+        """Producer entry point. MUST be fast and MUST NOT raise.
 
-        Puts the log entry in the queue for async shipping.
-        Falls back to local logging if queue is full or streaming is disabled.
+        Order of guards:
+        1. Recursion guard - if this thread is currently shipping, drop
+           silently. Prevents any future logging-from-shipping bug.
+        2. Streaming disabled - direct passthrough to fallback.
+        3. Format + put_nowait. On Full, count and drop.
         """
+        # (1) must be the very first check
+        if getattr(_shipping_state, "shipping", False):
+            self.dropped_shipping += 1
+            return
+        if self._closed:
+            self.dropped_overflow += 1
+            return
         try:
+            # (2)
             if not self.enable_streaming:
-                # Direct fallback if streaming is disabled
                 self.fallback_handler.emit(record)
                 return
-
-            # Format the log record
+            # (3)
             log_entry = self.format(record)
-
-            # Try to add to queue (non-blocking)
             try:
-                self.log_queue.put_nowait(log_entry)
-            except queue.Full:
-                # Queue is full. CRITICAL: do not call `logger.warning(...)`
-                # here — this handler is attached to `logger`, so any log call
-                # from inside emit() re-enters emit(), recurses against the
-                # still-full queue, and eventually hits the Python recursion
-                # limit. This was the root cause of the production hang where
-                # MainThread sat in 900+ frames of alternating warning/error
-                # emit calls while every other thread was blocked on the
-                # logging module's internal lock.
-                _internal_logger.warning("log queue is full, falling back to local logging")
-                self.fallback_handler.emit(record)
+                self._buffer.put_nowait(log_entry)
+            except Full:
+                self.dropped_overflow += 1
+        except Exception:
+            # Format/attr error. Don't re-enter the logger; just count.
+            self.dropped_overflow += 1
 
-        except Exception as e:
-            # Any error, fallback to local logging. Same recursion hazard as
-            # above — must use the non-propagating internal logger.
-            _internal_logger.error("error in emit: %s", e)
-            try:  # noqa: SIM105
-                self.fallback_handler.emit(record)
-            except Exception:
-                pass  # Last resort: silently drop the log
+    def _drain_loop(self):
+        """Drain buffer -> batch -> send_queue.put_nowait. Drop if Full.
 
-    def flush(self):
-        """Flush any buffered logs"""
-        # Signal worker to flush by adding a None marker
-        try:  # noqa: SIM105
-            self.log_queue.put_nowait(None)
-        except queue.Full:
-            pass
+        Never blocks on the senders. If all sender slots are busy (slow/
+        dead server), the batch is dropped immediately and counted.
+        """
+        while not self._stop.is_set():
+            batch = self._collect_batch()
+            if not batch:
+                continue
+            if self._closed:
+                self.dropped_saturated += len(batch)
+                continue
+            try:
+                self._send_queue.put_nowait(batch)
+            except Full:
+                self.dropped_saturated += len(batch)
 
-    def get_metrics(self) -> Dict[str, Any]:  # noqa: UP006
-        """Get current metrics for monitoring"""
-        return {
-            **self.metrics,
-            "circuit_state": self.circuit_breaker.state.value,
-            "queue_size": self.log_queue.qsize(),
-            "worker_alive": self.worker_thread.is_alive() if self.worker_thread else False,
-        }
+    def _collect_batch(self) -> list:
+        """Pull up to BATCH_SIZE entries. Waits at most BATCH_WAIT_SEC
+        for the first entry - the only blocking point in the drainer."""
+        try:
+            batch = [self._buffer.get(timeout=self.BATCH_WAIT_SEC)]
+        except Empty:
+            return []
+        while len(batch) < self.BATCH_SIZE:
+            try:
+                batch.append(self._buffer.get_nowait())
+            except Empty:
+                break
+        return batch
+
+    def _sender_loop(self):
+        """Daemon-thread worker. Drains send_queue and POSTs each batch."""
+        try:
+            while True:
+                try:
+                    item = self._send_queue.get(timeout=self.SENDER_TICK_SEC)
+                except Empty:
+                    if self._stop.is_set():
+                        return
+                    continue
+                if item is _CLOSE_MARKER:
+                    self._notify_close()
+                    return
+                self._post_batch(item)
+        finally:
+            with contextlib.suppress(Exception):
+                if self._client is not None:
+                    self._client.close()
+
+    def _post_batch(self, batch: list):
+        """Sender entry point. Sets the recursion guard, ships via the
+        quiet client path, clears the guard."""
+        _shipping_state.shipping = True
+        try:
+            self.metadata.send_logs_batch_best_effort(
+                pipeline_fqn=self.pipeline_fqn,
+                run_id=self.run_id,
+                log_content="\n".join(batch) + "\n",
+                timeout=self.HTTP_TIMEOUT,
+                client=self._client,
+            )
+        finally:
+            _shipping_state.shipping = False
 
     def close(self):
-        """Close the handler and cleanup resources"""
-        if self.enable_streaming and self.worker_thread:
-            # Log final metrics via the non-propagating internal logger so
-            # close() cannot trigger a final round of self-recursion.
-            _internal_logger.info("StreamableLogHandler metrics: %s", self.get_metrics())
+        """Stop workers and enqueue /close behind already queued batches.
 
-            # Signal worker to stop AFTER ensuring any pending flush is processed
-            self.stop_event.set()
+        Returns immediately - does NOT join daemon workers and does NOT
+        wait on the server response. The /close marker uses the same
+        bounded send queue as log batches; if the queue is saturated, we
+        skip /close and rely on server-side abandoned-stream cleanup.
+        """
+        if self._closed:
+            return
+        self._closed = True
+        self._stop.set()
 
-            # Wait for worker to finish (with timeout)
-            if self.worker_thread.is_alive():
-                self.worker_thread.join(timeout=5.0)
+        if self.enable_streaming:
+            self._drain_remaining_buffer()
+            with contextlib.suppress(Full):
+                self._send_queue.put_nowait(_CLOSE_MARKER)
 
-            # Close the log stream
-            self.metadata.close_log_stream(self.pipeline_fqn, self.run_id)
-
-        # Close fallback handler
-        self.fallback_handler.close()
-
+        with contextlib.suppress(Exception):
+            self.fallback_handler.close()
         super().close()
+
+    def _drain_remaining_buffer(self):
+        """Best-effort transfer of producer buffer into the send queue.
+
+        Runs only from close(); never waits. If the send queue is already
+        full, remaining logs are dropped and /close is skipped by the full
+        queue check in close().
+        """
+        while True:
+            batch = []
+            while len(batch) < self.BATCH_SIZE:
+                try:
+                    batch.append(self._buffer.get_nowait())
+                except Empty:
+                    break
+            if not batch:
+                return
+            try:
+                self._send_queue.put_nowait(batch)
+            except Full:
+                self.dropped_saturated += len(batch)
+                return
+
+    def _notify_close(self):
+        """Daemon-thread tail call for close()."""
+        _shipping_state.shipping = True
+        try:
+            self.metadata.send_close_best_effort(
+                pipeline_fqn=self.pipeline_fqn,
+                run_id=self.run_id,
+                timeout=(1.0, self.CLOSE_TIMEOUT_SEC),
+                client=self._client,
+            )
+        finally:
+            _shipping_state.shipping = False
 
 
 class StreamableLogHandlerManager:
-    """
-    Manager class to handle StreamableLogHandler instances.
-    This provides better encapsulation than using global variables.
-
-    Note: This manager assumes single-threaded setup/teardown which is
-    typical for workflow initialization. The handler itself is thread-safe.
-    """
+    """Process-wide singleton holding the active handler instance."""
 
     _instance: Optional["StreamableLogHandler"] = None
 
     @classmethod
     def get_handler(cls) -> Optional["StreamableLogHandler"]:
-        """Get the current handler instance"""
         return cls._instance
 
     @classmethod
     def set_handler(cls, handler: Optional["StreamableLogHandler"]) -> None:
-        """Set or update the handler instance, closing any existing one"""
-        if cls._instance and cls._instance != handler:
-            try:
+        if cls._instance and cls._instance is not handler:
+            # Detach the old one from the metadata logger BEFORE closing -
+            # otherwise records can still be routed at it during close.
+            with contextlib.suppress(Exception):
+                logging.getLogger(METADATA_LOGGER).removeHandler(cls._instance)
+            with contextlib.suppress(Exception):
                 cls._instance.close()
-            except Exception as e:
-                logger.warning(f"Error closing previous handler: {e}")
         cls._instance = handler
 
     @classmethod
     def cleanup(cls) -> None:
-        """Clean up the current handler, flushing any remaining logs first"""
-        if cls._instance:
-            try:
-                # Force flush any remaining logs before cleanup
-                cls._instance.flush()
-
-                # Close will properly wait for worker thread to finish processing
-                # the flush marker and any remaining buffered logs
+        if not cls._instance:
+            return
+        try:
+            with contextlib.suppress(Exception):
+                logging.getLogger(METADATA_LOGGER).removeHandler(cls._instance)
+            with contextlib.suppress(Exception):
                 cls._instance.close()
-
-                # Only remove handler from logger after worker thread has finished
-                metadata_logger = logging.getLogger(METADATA_LOGGER)
-                metadata_logger.removeHandler(cls._instance)
-
-                logger.debug("Streamable logging handler cleaned up")
-            except Exception as e:
-                logger.warning(f"Error during handler cleanup: {e}")
-            finally:
-                cls._instance = None
+        finally:
+            cls._instance = None
 
 
 def setup_streamable_logging_for_workflow(
@@ -519,24 +343,7 @@ def setup_streamable_logging_for_workflow(
     log_level: int = logging.INFO,
     enable_streaming: bool = False,
 ) -> Optional[StreamableLogHandler]:  # noqa: UP045
-    """
-    Setup streamable logging for a workflow execution.
-    This is automatically called when a workflow starts if:
-    1. The IngestionPipeline has enableStreamableLogs set to true
-    2. The server has log storage configured
-    3. The pipeline FQN and run ID are available
-
-    Args:
-        metadata: OpenMetadata client instance
-        pipeline_fqn: Fully qualified name of the pipeline
-        run_id: Unique run identifier
-        log_level: Logging level
-        enable_streaming: Whether to enable streaming (from IngestionPipeline config)
-
-    Returns:
-        StreamableLogHandler instance if configured, None otherwise
-    """
-    # Check if we have the required parameters
+    """Wire up the handler onto the metadata logger, replacing any existing one."""
     if not enable_streaming or not pipeline_fqn or not run_id:
         logger.debug(
             f"Streamable logging not configured: enable={enable_streaming}, "
@@ -545,38 +352,26 @@ def setup_streamable_logging_for_workflow(
         return None
 
     try:
-        # Check if server supports log storage by trying to get the configuration
-        # This would need to be implemented as an API endpoint
-        # For now, we'll assume it's enabled if the env var is set
+        metadata_logger = logging.getLogger(METADATA_LOGGER)
+        existing = StreamableLogHandlerManager.get_handler()
+        if existing is not None:
+            with contextlib.suppress(Exception):
+                metadata_logger.removeHandler(existing)
 
-        # Clean up any existing handler
-        existing_handler = StreamableLogHandlerManager.get_handler()
-        if existing_handler:
-            existing_handler.close()
-
-        # Create and configure the handler
         handler = StreamableLogHandler(
             metadata=metadata,
             pipeline_fqn=pipeline_fqn,
             run_id=run_id,
             enable_streaming=True,
         )
-
-        # Use the same formatter as the base configuration for consistency
         formatter = logging.Formatter(BASE_LOGGING_FORMAT, datefmt="%Y-%m-%d %H:%M:%S")
         handler.setFormatter(formatter)
         handler.setLevel(log_level)
 
-        # Add handler to the metadata logger (parent of all ingestion loggers)
-        metadata_logger = logging.getLogger(METADATA_LOGGER)
         metadata_logger.addHandler(handler)
-
-        # Register with the manager
         StreamableLogHandlerManager.set_handler(handler)
 
         logger.info(f"Streamable logging configured for pipeline: {pipeline_fqn}, run_id: {model_str(run_id)}")
-        metadata.validate_versions()  # Send the version check log
-
         return handler  # noqa: TRY300
 
     except Exception as e:
@@ -585,8 +380,5 @@ def setup_streamable_logging_for_workflow(
 
 
 def cleanup_streamable_logging():
-    """
-    Cleanup streamable logging handler.
-    This should be called when the workflow completes.
-    """
+    """Remove the active handler. Safe to call multiple times."""
     StreamableLogHandlerManager.cleanup()

--- a/ingestion/src/metadata/utils/streamable_logger.py
+++ b/ingestion/src/metadata/utils/streamable_logger.py
@@ -74,6 +74,8 @@ class StreamableLogHandler(logging.Handler):
         self.dropped_overflow = 0
         self.dropped_saturated = 0
         self.dropped_shipping = 0
+        self.dropped_after_close = 0
+        self.dropped_format_error = 0
 
         if self.enable_streaming:
             self._start_workers()
@@ -100,7 +102,7 @@ class StreamableLogHandler(logging.Handler):
             self.dropped_shipping += 1
             return
         if self._closed:
-            self.dropped_overflow += 1
+            self.dropped_after_close += 1
             return
         try:
             if not self.enable_streaming:
@@ -112,15 +114,12 @@ class StreamableLogHandler(logging.Handler):
             except Full:
                 self.dropped_overflow += 1
         except Exception:
-            self.dropped_overflow += 1
+            self.dropped_format_error += 1
 
     def _drain_loop(self):
         while not self._stop.is_set():
             batch = self._collect_batch()
             if not batch:
-                continue
-            if self._closed:
-                self.dropped_saturated += len(batch)
                 continue
             try:
                 self._send_queue.put_nowait(batch)

--- a/ingestion/src/metadata/utils/streamable_logger.py
+++ b/ingestion/src/metadata/utils/streamable_logger.py
@@ -8,50 +8,7 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-"""
-Best-effort streamable log handler for OpenMetadata ingestion pipelines.
-
-Design contract (in order of importance):
-
-1. emit() never blocks the producer. Format -> put_nowait -> return.
-   On overflow we increment a counter and drop the record. We do NOT
-   write the dropped record to stderr from inside emit() - that would
-   add synchronous stderr I/O to every producer log under backpressure.
-
-2. emit() can NEVER re-enter itself. A thread-local flag is set on the
-   sender thread; if emit() sees it, it returns immediately. This is a
-   belt-and-suspenders backstop to the PR #28160 fix: even if a future
-   change reintroduces logging on the shipping path, the recursion
-   simply can't happen.
-
-3. ALL background threads are DAEMON. Drainer and senders alike. If
-   the connector main thread exits while a sender is wedged on a slow
-   DNS / TLS / auth call, the process still terminates. Logging will
-   never keep a pod alive.
-
-4. The sender pool is bounded by a fixed-size send queue. If all sender
-   slots are occupied (slow / dead server), the drainer drops new
-   batches and increments a counter. No unbounded thread / memory
-   growth regardless of how long the server takes.
-
-5. The HTTP POST goes through a dedicated quiet path
-   (``send_logs_batch_best_effort`` -> ``client.post_best_effort``):
-   no retries, no sleep, no connection-error retry, no logging through
-   ``ometa_logger``. Failure is a silent bool - counted, not logged.
-
-6. The handler uses an ISOLATED ``REST`` client (own ``requests.Session``,
-   own connection pool, own cookie jar). Shares ``ClientConfig`` with
-   the main metadata client so auth-token refreshes done by the main
-   client are picked up here too - but log shipping can never interfere
-   with normal ingestion API traffic.
-
-7. close() does NOT block on the server and does NOT join workers.
-   It signals the drainer/senders to stop, enqueues a close marker
-   behind already-queued log batches, and returns.
-
-No locks. No sleeps beyond ``queue.get(timeout=...)`` in the drainer/
-senders, which is necessary so they're not in a tight loop when idle.
-"""
+"""Best-effort streamable log handler for OpenMetadata ingestion pipelines."""
 
 import contextlib
 import logging
@@ -67,26 +24,22 @@ from metadata.utils.logger import BASE_LOGGING_FORMAT, METADATA_LOGGER, ingestio
 
 logger = ingestion_logger()
 
-# Thread-local recursion guard. Sender threads set ``shipping = True``
-# before doing any work. If emit() sees this flag (i.e. someone logged
-# from inside the shipping path), it returns immediately. This protects
-# us even if a future refactor reintroduces logging in the POST path.
+# Recursion guard: sender threads set shipping=True so emit() returns
+# immediately if it ever fires from inside the shipping path.
 _shipping_state = threading.local()
 _CLOSE_MARKER = object()
 
 
 class StreamableLogHandler(logging.Handler):
-    """Fire-and-forget log shipper. See module docstring for the contract."""
+    """Fire-and-forget log shipper."""
 
-    # Tunables. None affect correctness - only loss rate and how many
-    # sender threads can be in flight at once. Conservative defaults.
     BATCH_SIZE = 500
     BATCH_WAIT_SEC = 2.0
     SENDER_TICK_SEC = 1.0
-    HTTP_TIMEOUT = (1.0, 2.0)  # (connect, read) seconds
-    SENDER_WORKERS = 1  # single daemon sender preserves logs -> close ordering
-    MAX_PENDING_BATCHES = 4  # bounded send-queue depth
-    CLOSE_TIMEOUT_SEC = 2.0  # for the fire-and-forget /close call
+    HTTP_TIMEOUT = (1.0, 2.0)
+    SENDER_WORKERS = 1
+    MAX_PENDING_BATCHES = 4
+    CLOSE_TIMEOUT_SEC = 2.0
 
     # pylint: disable=too-many-arguments,too-many-instance-attributes
     def __init__(
@@ -103,36 +56,29 @@ class StreamableLogHandler(logging.Handler):
         self.run_id = run_id
         self.enable_streaming = enable_streaming
 
-        # Used only when streaming is disabled - direct passthrough.
         self.fallback_handler = logging.StreamHandler()
 
-        # Producer-side bounded buffer; drainer drains, senders POST.
         self._buffer: Queue = Queue(maxsize=max_buffer)
-        # Send queue is the in-flight cap. Drainer put_nowait - drop on Full.
         self._send_queue: Queue = Queue(maxsize=self.MAX_PENDING_BATCHES)
         self._stop = threading.Event()
         self._closed = False
         self._drainer: Optional[threading.Thread] = None  # noqa: UP045
         self._senders: list = []
 
-        # Isolated REST client. Same ClientConfig (token refresh visible)
-        # but distinct requests.Session / connection pool / cookie jar.
-        # Log shipping cannot interfere with normal ingestion API traffic.
+        # Isolated session/connection pool; shares ClientConfig so token
+        # refresh on the main client is visible here.
         self._client: Optional[REST] = (  # noqa: UP045
             REST(metadata.client.config) if enable_streaming else None
         )
 
-        # Diagnostic counters (plain ints - the GIL makes ++ monotonic-safe).
-        self.dropped_overflow = 0  # buffer Full at emit()
-        self.dropped_saturated = 0  # send_queue Full at drain()
-        self.dropped_shipping = 0  # recursion guard tripped
+        self.dropped_overflow = 0
+        self.dropped_saturated = 0
+        self.dropped_shipping = 0
 
         if self.enable_streaming:
             self._start_workers()
 
     def _start_workers(self):
-        """All daemon. Drainer + N senders. Process can exit at any time
-        without waiting for them - that's the explicit non-blocking goal."""
         self._drainer = threading.Thread(
             target=self._drain_loop,
             daemon=True,
@@ -149,15 +95,7 @@ class StreamableLogHandler(logging.Handler):
             self._senders.append(t)
 
     def emit(self, record: logging.LogRecord):
-        """Producer entry point. MUST be fast and MUST NOT raise.
-
-        Order of guards:
-        1. Recursion guard - if this thread is currently shipping, drop
-           silently. Prevents any future logging-from-shipping bug.
-        2. Streaming disabled - direct passthrough to fallback.
-        3. Format + put_nowait. On Full, count and drop.
-        """
-        # (1) must be the very first check
+        # Recursion guard must be the very first check.
         if getattr(_shipping_state, "shipping", False):
             self.dropped_shipping += 1
             return
@@ -165,26 +103,18 @@ class StreamableLogHandler(logging.Handler):
             self.dropped_overflow += 1
             return
         try:
-            # (2)
             if not self.enable_streaming:
                 self.fallback_handler.emit(record)
                 return
-            # (3)
             log_entry = self.format(record)
             try:
                 self._buffer.put_nowait(log_entry)
             except Full:
                 self.dropped_overflow += 1
         except Exception:
-            # Format/attr error. Don't re-enter the logger; just count.
             self.dropped_overflow += 1
 
     def _drain_loop(self):
-        """Drain buffer -> batch -> send_queue.put_nowait. Drop if Full.
-
-        Never blocks on the senders. If all sender slots are busy (slow/
-        dead server), the batch is dropped immediately and counted.
-        """
         while not self._stop.is_set():
             batch = self._collect_batch()
             if not batch:
@@ -198,8 +128,6 @@ class StreamableLogHandler(logging.Handler):
                 self.dropped_saturated += len(batch)
 
     def _collect_batch(self) -> list:
-        """Pull up to BATCH_SIZE entries. Waits at most BATCH_WAIT_SEC
-        for the first entry - the only blocking point in the drainer."""
         try:
             batch = [self._buffer.get(timeout=self.BATCH_WAIT_SEC)]
         except Empty:
@@ -212,7 +140,6 @@ class StreamableLogHandler(logging.Handler):
         return batch
 
     def _sender_loop(self):
-        """Daemon-thread worker. Drains send_queue and POSTs each batch."""
         try:
             while True:
                 try:
@@ -231,8 +158,6 @@ class StreamableLogHandler(logging.Handler):
                     self._client.close()
 
     def _post_batch(self, batch: list):
-        """Sender entry point. Sets the recursion guard, ships via the
-        quiet client path, clears the guard."""
         _shipping_state.shipping = True
         try:
             self.metadata.send_logs_batch_best_effort(
@@ -246,13 +171,6 @@ class StreamableLogHandler(logging.Handler):
             _shipping_state.shipping = False
 
     def close(self):
-        """Stop workers and enqueue /close behind already queued batches.
-
-        Returns immediately - does NOT join daemon workers and does NOT
-        wait on the server response. The /close marker uses the same
-        bounded send queue as log batches; if the queue is saturated, we
-        skip /close and rely on server-side abandoned-stream cleanup.
-        """
         if self._closed:
             return
         self._closed = True
@@ -262,13 +180,9 @@ class StreamableLogHandler(logging.Handler):
             with contextlib.suppress(Full):
                 self._send_queue.put_nowait(_CLOSE_MARKER)
 
-        # Signal stop AFTER the remaining batches and CLOSE_MARKER are
-        # in the send queue. The sender's loop checks _stop only on an
-        # Empty timeout; setting stop first creates a race where the
-        # sender's in-flight get(timeout=1s) returns Empty in the narrow
-        # window between set() and enqueue, exits, and never processes
-        # either the remaining batches or the CLOSE_MARKER. Enqueue first,
-        # then set — preserves the ordering guarantee in docstring point 7.
+        # Set _stop AFTER enqueueing — sender's get(timeout) Empty branch
+        # checks _stop, so setting it first can race the enqueue and drop
+        # the CLOSE_MARKER on a quiet send queue.
         self._stop.set()
 
         with contextlib.suppress(Exception):
@@ -276,12 +190,6 @@ class StreamableLogHandler(logging.Handler):
         super().close()
 
     def _drain_remaining_buffer(self):
-        """Best-effort transfer of producer buffer into the send queue.
-
-        Runs only from close(); never waits. If the send queue is already
-        full, remaining logs are dropped and /close is skipped by the full
-        queue check in close().
-        """
         while True:
             batch = []
             while len(batch) < self.BATCH_SIZE:
@@ -298,7 +206,6 @@ class StreamableLogHandler(logging.Handler):
                 return
 
     def _notify_close(self):
-        """Daemon-thread tail call for close()."""
         _shipping_state.shipping = True
         try:
             self.metadata.send_close_best_effort(
@@ -312,8 +219,6 @@ class StreamableLogHandler(logging.Handler):
 
 
 class StreamableLogHandlerManager:
-    """Process-wide singleton holding the active handler instance."""
-
     _instance: Optional["StreamableLogHandler"] = None
 
     @classmethod
@@ -323,8 +228,7 @@ class StreamableLogHandlerManager:
     @classmethod
     def set_handler(cls, handler: Optional["StreamableLogHandler"]) -> None:
         if cls._instance and cls._instance is not handler:
-            # Detach the old one from the metadata logger BEFORE closing -
-            # otherwise records can still be routed at it during close.
+            # Detach before close so in-flight emits don't route at a closed handler.
             with contextlib.suppress(Exception):
                 logging.getLogger(METADATA_LOGGER).removeHandler(cls._instance)
             with contextlib.suppress(Exception):
@@ -351,7 +255,6 @@ def setup_streamable_logging_for_workflow(
     log_level: int = logging.INFO,
     enable_streaming: bool = False,
 ) -> Optional[StreamableLogHandler]:  # noqa: UP045
-    """Wire up the handler onto the metadata logger, replacing any existing one."""
     if not enable_streaming or not pipeline_fqn or not run_id:
         logger.debug(
             f"Streamable logging not configured: enable={enable_streaming}, "
@@ -388,5 +291,4 @@ def setup_streamable_logging_for_workflow(
 
 
 def cleanup_streamable_logging():
-    """Remove the active handler. Safe to call multiple times."""
     StreamableLogHandlerManager.cleanup()

--- a/ingestion/tests/unit/utils/test_streamable_logger.py
+++ b/ingestion/tests/unit/utils/test_streamable_logger.py
@@ -777,6 +777,71 @@ class TestClientPostBestEffort(unittest.TestCase):
 
         self.assertTrue(client.post_best_effort("/path", data="x"))
 
+    def test_build_request_headers_does_not_refresh_token(self):
+        """Regression for PR #28198 review finding #1.
+
+        The streamable handler's sender thread MUST NOT race the main
+        ingestion thread on token refresh. _build_request_headers reads
+        config.access_token; it never invokes _auth_token() or mutates
+        config.expires_in. Token refresh is owned exclusively by the
+        main client's _request() path.
+        """
+        client = self._make_client()
+        # Track whether the auth_token callable is invoked.
+        client._auth_token = Mock(return_value=("fresh-token", 60))
+        # Make the config look like a refresh is needed.
+        client.config.expires_in = 0  # expired
+        client.config.access_token = "stale-token"
+        client.config.auth_header = "Authorization"
+
+        headers = client._build_request_headers()
+
+        # auth_token() must NOT have been called — refresh is the main
+        # thread's job, this is just a reader.
+        client._auth_token.assert_not_called()
+        # Header reads from whatever access_token is currently set.
+        self.assertEqual(headers["Authorization"], "Bearer stale-token")
+        # expires_in must not have been mutated.
+        self.assertEqual(client.config.expires_in, 0)
+
+
+class TestCloseOrderingRegression(unittest.TestCase):
+    """Regression for PR #28198 review finding #2.
+
+    close() must enqueue remaining batches + the CLOSE_MARKER BEFORE
+    setting the stop event. Otherwise the sender's get(timeout=1s) can
+    return Empty in the narrow window between set() and enqueue, see
+    _stop, and exit without ever processing the marker — meaning /close
+    is silently lost under light load."""
+
+    def test_close_enqueues_marker_before_setting_stop(self):
+        metadata = _make_metadata_mock()
+        handler = _make_handler(metadata=metadata, enable_streaming=True)
+        handler.close()
+        # Marker must be drained by the sender, which then calls
+        # send_close_best_effort. Wait briefly.
+        for _ in range(50):
+            if metadata.send_close_best_effort.called:
+                break
+            time.sleep(0.05)
+        metadata.send_close_best_effort.assert_called_once()
+
+    def test_close_marker_arrives_even_when_sender_was_idle(self):
+        """Light-load scenario that triggers the original race: sender
+        is sitting in get(timeout=1s) with an empty queue when close()
+        fires. If _stop.set() runs before put_nowait, the sender exits
+        on the Empty/stop check and the marker is never processed."""
+        metadata = _make_metadata_mock()
+        handler = _make_handler(metadata=metadata, enable_streaming=True)
+        # Let the sender enter its get() and wait.
+        time.sleep(0.2)
+        handler.close()
+        for _ in range(50):
+            if metadata.send_close_best_effort.called:
+                break
+            time.sleep(0.05)
+        metadata.send_close_best_effort.assert_called_once()
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/ingestion/tests/unit/utils/test_streamable_logger.py
+++ b/ingestion/tests/unit/utils/test_streamable_logger.py
@@ -131,8 +131,17 @@ class TestEmitNonBlocking(unittest.TestCase):
 
         handler.emit(_make_record())
 
-        self.assertEqual(handler.dropped_overflow, 1)
+        self.assertEqual(handler.dropped_format_error, 1)
+        self.assertEqual(handler.dropped_overflow, 0)
         handler.close()
+
+    def test_emit_after_close_increments_dedicated_counter(self):
+        handler = _make_handler(enable_streaming=True)
+        handler.close()
+        handler.emit(_make_record("post-close"))
+        self.assertEqual(handler.dropped_after_close, 1)
+        self.assertEqual(handler.dropped_overflow, 0)
+        self.assertEqual(handler.dropped_format_error, 0)
 
     def test_emit_returns_quickly_under_high_volume(self):
         handler = _make_handler(max_buffer=10000, enable_streaming=True)

--- a/ingestion/tests/unit/utils/test_streamable_logger.py
+++ b/ingestion/tests/unit/utils/test_streamable_logger.py
@@ -10,859 +10,612 @@
 #  limitations under the License.
 """
 Unit tests for the streamable logger module.
+
+Design under test (see streamable_logger module docstring):
+- emit() never blocks; overflow is counted, not stderr-fallback-emitted
+- emit() has a thread-local recursion guard
+- drainer hands batches to a bounded daemon sender queue
+- POSTs go through send_logs_batch_best_effort (no retries, no logging)
+- close() does NOT block on the server
 """
 
 import logging
-import os
+import threading
 import time
 import unittest
-from unittest.mock import Mock, patch
+from unittest.mock import MagicMock, Mock, patch
 from uuid import uuid4
 
 from metadata.ingestion.ometa.ometa_api import OpenMetadata
 from metadata.utils.streamable_logger import (
-    CircuitBreaker,
-    CircuitState,
     StreamableLogHandler,
+    StreamableLogHandlerManager,
+    _shipping_state,
     cleanup_streamable_logging,
     setup_streamable_logging_for_workflow,
 )
 
 
-class TestCircuitBreaker(unittest.TestCase):
-    """Test the circuit breaker implementation"""
-
-    def setUp(self):
-        self.breaker = CircuitBreaker(failure_threshold=3, recovery_timeout=1, success_threshold=2)
-
-    def test_initial_state_is_closed(self):
-        """Test that circuit breaker starts in CLOSED state"""
-        self.assertEqual(self.breaker.state, CircuitState.CLOSED)
-        self.assertEqual(self.breaker.failure_count, 0)
-
-    def test_opens_after_threshold_failures(self):
-        """Test that circuit opens after reaching failure threshold"""
-
-        def failing_func():
-            raise Exception("Test failure")  # noqa: TRY002
-
-        for i in range(3):  # noqa: B007
-            with self.assertRaises(Exception):  # noqa: B017
-                self.breaker.call(failing_func)
-
-        self.assertEqual(self.breaker.state, CircuitState.OPEN)
-        self.assertEqual(self.breaker.failure_count, 3)
-
-    def test_blocks_calls_when_open(self):
-        """Test that calls are blocked when circuit is open"""
-        # Open the circuit
-        self.breaker.state = CircuitState.OPEN
-        self.breaker.last_failure_time = time.time()
-
-        with self.assertRaises(Exception) as ctx:
-            self.breaker.call(lambda: "success")
-
-        self.assertIn("Circuit breaker is OPEN", str(ctx.exception))
-
-    def test_transitions_to_half_open_after_timeout(self):
-        """Test transition to HALF_OPEN state after recovery timeout"""
-        # Open the circuit
-        self.breaker.state = CircuitState.OPEN
-        self.breaker.last_failure_time = time.time() - 2  # 2 seconds ago
-
-        # Should transition to HALF_OPEN
-        def success_func():
-            return "success"
-
-        result = self.breaker.call(success_func)
-        self.assertEqual(result, "success")
-        self.assertEqual(self.breaker.state, CircuitState.HALF_OPEN)
-
-    def test_closes_after_success_threshold_in_half_open(self):
-        """Test that circuit closes after success threshold in HALF_OPEN"""
-        self.breaker.state = CircuitState.HALF_OPEN
-
-        def success_func():
-            return "success"
-
-        # First success
-        self.breaker.call(success_func)
-        self.assertEqual(self.breaker.state, CircuitState.HALF_OPEN)
-
-        # Second success - should close
-        self.breaker.call(success_func)
-        self.assertEqual(self.breaker.state, CircuitState.CLOSED)
-
-    def test_reopens_on_failure_in_half_open(self):
-        """Test that circuit reopens on failure in HALF_OPEN state"""
-        self.breaker.state = CircuitState.HALF_OPEN
-
-        def failing_func():
-            raise Exception("Test failure")  # noqa: TRY002
-
-        with self.assertRaises(Exception):  # noqa: B017
-            self.breaker.call(failing_func)
-
-        self.assertEqual(self.breaker.state, CircuitState.OPEN)
+def _make_record(msg="test message", level=logging.INFO):
+    return logging.LogRecord(
+        name="test",
+        level=level,
+        pathname="test.py",
+        lineno=1,
+        msg=msg,
+        args=(),
+        exc_info=None,
+    )
 
 
-class TestStreamableLogHandler(unittest.TestCase):
-    """Test the StreamableLogHandler class"""
+def _make_metadata_mock():
+    """Build a Mock that satisfies StreamableLogHandler's needs:
+    - send_logs_batch_best_effort / send_close_best_effort attrs
+    - .client.config (real ClientConfig) so handler can build its own REST"""
+    from metadata.ingestion.ometa.client import ClientConfig
 
-    def setUp(self):
-        """Set up test fixtures"""
-        self.mock_metadata = Mock(spec=OpenMetadata)
-        self.mock_metadata.config = Mock()
-        self.mock_metadata.config.host_port = "http://localhost:8585"
-        self.mock_metadata.config.auth_token = "test-token"
-        # Mock the _auth_header method
-        self.mock_metadata._auth_header = Mock(return_value={"Authorization": "Bearer test-token"})
+    metadata = Mock(spec=OpenMetadata)
+    metadata.client = Mock()
+    metadata.client.config = ClientConfig(base_url="http://localhost:8585")
+    metadata.send_logs_batch_best_effort = Mock(return_value=True)
+    metadata.send_close_best_effort = Mock(return_value=True)
+    return metadata
 
-        self.pipeline_fqn = "test.pipeline"
-        self.run_id = uuid4()
+
+def _make_handler(
+    metadata=None,
+    pipeline_fqn="test.pipeline",
+    run_id=None,
+    max_buffer=10000,
+    enable_streaming=False,
+):
+    if metadata is None:
+        metadata = _make_metadata_mock()
+    if run_id is None:
+        run_id = uuid4()
+    handler = StreamableLogHandler(
+        metadata=metadata,
+        pipeline_fqn=pipeline_fqn,
+        run_id=run_id,
+        max_buffer=max_buffer,
+        enable_streaming=enable_streaming,
+    )
+    handler.setFormatter(logging.Formatter("%(message)s"))
+    return handler
+
+
+def _stop_workers(handler):
+    """Signal stop and give the drainer/senders a moment to notice.
+    Used in tests that need a quiescent handler. We don't .join() in
+    production close() - see TestNoWaitClose - but in tests we want
+    to be sure background threads aren't going to race assertions."""
+    handler._stop.set()
+    if handler._drainer:
+        handler._drainer.join(timeout=3)
+    for t in handler._senders:
+        t.join(timeout=3)
+
+
+class TestEmitNonBlocking(unittest.TestCase):
+    """emit() must be fast and must never raise."""
+
+    def test_emit_with_streaming_disabled_goes_to_fallback(self):
+        handler = _make_handler(enable_streaming=False)
+        handler.fallback_handler = Mock()
+        record = _make_record()
+
+        handler.emit(record)
+
+        handler.fallback_handler.emit.assert_called_once_with(record)
+
+    def test_emit_with_streaming_enabled_queues_to_buffer(self):
+        handler = _make_handler(enable_streaming=True)
+        _stop_workers(handler)
+
+        handler.emit(_make_record("log A"))
+        handler.emit(_make_record("log B"))
+
+        self.assertEqual(handler._buffer.qsize(), 2)
+        handler.close()
+
+    def test_emit_drops_silently_when_buffer_full(self):
+        """No stderr fallback per record on overflow - only a counter."""
+        handler = _make_handler(max_buffer=1, enable_streaming=True)
+        _stop_workers(handler)
+        handler.fallback_handler = Mock()
+        handler._buffer.put_nowait("already-here")
+
+        start = time.monotonic()
+        handler.emit(_make_record("overflow"))
+        elapsed = time.monotonic() - start
+
+        self.assertLess(elapsed, 0.05, "emit() must return immediately on overflow")
+        handler.fallback_handler.emit.assert_not_called()
+        self.assertEqual(handler.dropped_overflow, 1)
+
+    def test_emit_never_raises_when_format_fails(self):
+        handler = _make_handler(enable_streaming=True)
+        _stop_workers(handler)
+        handler.format = Mock(side_effect=ValueError("boom"))
+
+        handler.emit(_make_record())
+
+        self.assertEqual(handler.dropped_overflow, 1)
+        handler.close()
+
+    def test_emit_returns_quickly_under_high_volume(self):
+        handler = _make_handler(max_buffer=10000, enable_streaming=True)
+        _stop_workers(handler)
+
+        start = time.monotonic()
+        for i in range(1000):
+            handler.emit(_make_record(f"msg-{i}"))
+        elapsed = time.monotonic() - start
+
+        self.assertLess(elapsed, 0.5, f"1000 emits took {elapsed:.3f}s - too slow")
+
+
+class TestRecursionGuard(unittest.TestCase):
+    """The thread-local guard prevents emit() from re-entering itself
+    even if a future change reintroduces logging on the shipping path."""
 
     def tearDown(self):
-        """Clean up after tests"""
-        # Ensure any handlers are properly closed
-        if hasattr(self, "handler") and self.handler:
-            self.handler.close()
+        # Make sure the guard is clear after each test.
+        if hasattr(_shipping_state, "shipping"):
+            _shipping_state.shipping = False
 
-    def test_handler_initialization(self):
-        """Test handler initialization"""
-        handler = StreamableLogHandler(
-            metadata=self.mock_metadata,
-            pipeline_fqn=self.pipeline_fqn,
-            run_id=self.run_id,
-            enable_streaming=False,  # Disable for unit test
+    def test_emit_drops_when_shipping_flag_set(self):
+        handler = _make_handler(enable_streaming=True)
+        _stop_workers(handler)
+
+        _shipping_state.shipping = True
+        try:
+            handler.emit(_make_record("would-recurse"))
+        finally:
+            _shipping_state.shipping = False
+
+        self.assertEqual(handler._buffer.qsize(), 0)
+        self.assertEqual(handler.dropped_shipping, 1)
+
+    def test_post_thread_sets_and_clears_shipping_flag(self):
+        seen_flag = {"value": None}
+
+        def capture(*_, **__):
+            seen_flag["value"] = getattr(_shipping_state, "shipping", False)
+            return True
+
+        metadata = _make_metadata_mock()
+        metadata.send_logs_batch_best_effort = Mock(side_effect=capture)
+        metadata.send_close_best_effort = Mock(return_value=True)
+
+        handler = _make_handler(metadata=metadata, enable_streaming=True)
+        handler.emit(_make_record("trigger"))
+        for _ in range(50):
+            if metadata.send_logs_batch_best_effort.called:
+                break
+            time.sleep(0.05)
+
+        self.assertTrue(seen_flag["value"], "shipping flag must be True inside the sender")
+        handler.close()
+        # Flag must be cleared after the sender returns. Give the
+        # sender thread a moment to hit its finally block.
+        time.sleep(0.1)
+        self.assertFalse(getattr(_shipping_state, "shipping", False))
+
+
+class TestSenderPool(unittest.TestCase):
+    """Bounded send queue. Drainer never waits on a POST."""
+
+    def test_drainer_does_not_wait_on_slow_post(self):
+        slow_event = threading.Event()
+        post_started = threading.Event()
+
+        def slow_send(*_, **__):
+            post_started.set()
+            slow_event.wait(timeout=30)
+            return True
+
+        metadata = _make_metadata_mock()
+        metadata.send_logs_batch_best_effort = Mock(side_effect=slow_send)
+        metadata.send_close_best_effort = Mock(return_value=True)
+
+        handler = _make_handler(metadata=metadata, enable_streaming=True)
+        handler.emit(_make_record("first"))
+        self.assertTrue(post_started.wait(timeout=5))
+
+        start = time.monotonic()
+        for i in range(50):
+            handler.emit(_make_record(f"hangs-{i}"))
+        elapsed = time.monotonic() - start
+
+        self.assertLess(elapsed, 0.5, "emits must not block while a POST is hanging")
+
+        handler._stop.set()
+        slow_event.set()
+        handler._drainer.join(timeout=5)
+
+    def test_saturated_sender_drops_batches(self):
+        """When senders + send queue are full on a dead server, the drainer
+        drops new batches and counts them. No unbounded growth."""
+        hang = threading.Event()  # never set during the test
+
+        def block_forever(*_, **__):
+            hang.wait(timeout=30)
+            return True
+
+        metadata = _make_metadata_mock()
+        metadata.send_logs_batch_best_effort = Mock(side_effect=block_forever)
+        metadata.send_close_best_effort = Mock(return_value=True)
+
+        handler = _make_handler(metadata=metadata, enable_streaming=True)
+        # Make the test cycle faster than defaults.
+        handler.BATCH_WAIT_SEC = 0.1
+
+        # Pump 20 separately-timed batches; each wave > BATCH_WAIT_SEC so
+        # the drainer ships each as its own batch. Senders block forever
+        # on the first MAX_PENDING_BATCHES + SENDER_WORKERS; everything
+        # after that must be dropped at drainer-submit time.
+        total_waves = handler.MAX_PENDING_BATCHES + handler.SENDER_WORKERS + 10
+        for wave in range(total_waves):
+            handler.emit(_make_record(f"wave-{wave}"))
+            time.sleep(0.2)
+
+        # At least some batches must have been dropped at the send-queue
+        # boundary - we sent way more than the cap.
+        self.assertGreater(handler.dropped_saturated, 0, "saturated drainer must have dropped at least one batch")
+        # In-flight POSTs bounded by SENDER_WORKERS (others wait in queue
+        # but don't actually call send_logs_batch_best_effort).
+        self.assertLessEqual(
+            metadata.send_logs_batch_best_effort.call_count,
+            handler.SENDER_WORKERS,
         )
 
-        self.assertEqual(handler.pipeline_fqn, self.pipeline_fqn)
-        self.assertEqual(handler.run_id, self.run_id)
-        self.assertEqual(handler.batch_size, 500)
-        self.assertEqual(handler.flush_interval_sec, 10.0)
-        self.assertFalse(handler.enable_streaming)
-        self.assertIsNone(handler.worker_thread)
+        handler._stop.set()
+        hang.set()
+
+    def test_close_notify_is_ordered_after_in_flight_log_batch(self):
+        """Regression for the close-vs-late-POST race. /close must not
+        overtake an already-started log batch, otherwise the server can
+        finalize logs.txt and then receive a late tail batch."""
+        log_started = threading.Event()
+        release_log = threading.Event()
+        close_called = threading.Event()
+
+        def slow_log_send(*_, **__):
+            log_started.set()
+            release_log.wait(timeout=30)
+            return True
+
+        def close_send(*_, **__):
+            close_called.set()
+            return True
+
+        metadata = _make_metadata_mock()
+        metadata.send_logs_batch_best_effort = Mock(side_effect=slow_log_send)
+        metadata.send_close_best_effort = Mock(side_effect=close_send)
+
+        handler = _make_handler(metadata=metadata, enable_streaming=True)
+        handler.emit(_make_record("first"))
+        self.assertTrue(log_started.wait(timeout=5))
+
+        start = time.monotonic()
+        handler.close()
+        elapsed = time.monotonic() - start
+
+        self.assertLess(elapsed, 0.1, "close() must still return immediately")
+        time.sleep(0.2)
+        self.assertFalse(
+            close_called.is_set(),
+            "/close must wait behind the in-flight log batch in the sender queue",
+        )
+
+        release_log.set()
+        self.assertTrue(close_called.wait(timeout=5))
+
+
+class TestDaemonThreads(unittest.TestCase):
+    """All background threads MUST be daemon, otherwise a wedged sender
+    can keep the ingestion process alive past main-thread exit."""
+
+    def test_drainer_thread_is_daemon(self):
+        handler = _make_handler(enable_streaming=True)
+        self.assertTrue(handler._drainer.daemon, "drainer must be a daemon thread")
+        handler.close()
+
+    def test_sender_threads_are_daemon(self):
+        handler = _make_handler(enable_streaming=True)
+        self.assertEqual(len(handler._senders), handler.SENDER_WORKERS)
+        for t in handler._senders:
+            self.assertTrue(t.daemon, f"sender {t.name} must be daemon")
+        handler.close()
+
+    def test_close_notify_thread_is_daemon(self):
+        """The /close call goes out on a daemon so close() doesn't wait."""
+        seen = {"daemon": None}
+
+        def capture(*_, **__):
+            seen["daemon"] = threading.current_thread().daemon
+            return True
+
+        metadata = _make_metadata_mock()
+        metadata.send_logs_batch_best_effort = Mock(return_value=True)
+        metadata.send_close_best_effort = Mock(side_effect=capture)
+
+        handler = _make_handler(metadata=metadata, enable_streaming=True)
+        handler.close()
+        for _ in range(50):
+            if seen["daemon"] is not None:
+                break
+            time.sleep(0.05)
+        self.assertTrue(seen["daemon"], "close notify must run on a daemon sender thread")
+
+
+class TestIsolatedClient(unittest.TestCase):
+    """The handler must use its OWN REST instance (own session/cookies/
+    connection pool), not the main metadata client's."""
+
+    def test_handler_creates_dedicated_rest_client(self):
+        from metadata.ingestion.ometa.client import REST
+
+        metadata = Mock(spec=OpenMetadata)
+        # Give the mock client a real ClientConfig so REST() can copy it.
+        from metadata.ingestion.ometa.client import ClientConfig
+
+        metadata.client = Mock()
+        metadata.client.config = ClientConfig(base_url="http://localhost:8585")
+        metadata.send_logs_batch_best_effort = Mock(return_value=True)
+        metadata.send_close_best_effort = Mock(return_value=True)
+
+        handler = _make_handler(metadata=metadata, enable_streaming=True)
+
+        self.assertIsInstance(handler._client, REST)
+        self.assertIsNot(handler._client, metadata.client, "handler must own a SEPARATE REST instance")
+        self.assertIsNot(handler._client._session, metadata.client, "handler's session must not be the main client")
+        handler.close()
+
+    def test_handler_passes_isolated_client_to_post(self):
+        """The send_logs_batch_best_effort call must include the handler's
+        own client kwarg so log shipping doesn't go through the main session."""
+        from metadata.ingestion.ometa.client import ClientConfig
+
+        captured = {"client": None}
+
+        def capture(*_, client=None, **__):
+            captured["client"] = client
+            return True
+
+        metadata = Mock(spec=OpenMetadata)
+        metadata.client = Mock()
+        metadata.client.config = ClientConfig(base_url="http://localhost:8585")
+        metadata.send_logs_batch_best_effort = Mock(side_effect=capture)
+        metadata.send_close_best_effort = Mock(return_value=True)
+
+        handler = _make_handler(metadata=metadata, enable_streaming=True)
+        handler.emit(_make_record("trigger"))
+        for _ in range(50):
+            if metadata.send_logs_batch_best_effort.called:
+                break
+            time.sleep(0.05)
+
+        self.assertIs(
+            captured["client"], handler._client, "handler must pass its own _client to send_logs_batch_best_effort"
+        )
+        handler.close()
+
+    @patch("metadata.utils.streamable_logger.REST")
+    def test_handler_reuses_one_isolated_client_for_all_batches(self, mock_rest):
+        """Persistent connection pool guarantee: construct one isolated REST
+        client per handler, pass that same client for every batch, and close
+        it only when the sender exits."""
+        client = Mock()
+        mock_rest.return_value = client
+
+        metadata = Mock(spec=OpenMetadata)
+        metadata.client = Mock()
+        metadata.client.config = Mock()
+        metadata.send_logs_batch_best_effort = Mock(return_value=True)
+        metadata.send_close_best_effort = Mock(return_value=True)
+
+        handler = _make_handler(metadata=metadata, enable_streaming=True)
+
+        handler._post_batch(["first"])
+        handler._post_batch(["second"])
+
+        mock_rest.assert_called_once_with(metadata.client.config)
+        self.assertEqual(metadata.send_logs_batch_best_effort.call_count, 2)
+        first_call, second_call = metadata.send_logs_batch_best_effort.call_args_list
+        self.assertIs(first_call.kwargs["client"], client)
+        self.assertIs(second_call.kwargs["client"], client)
+        client.close.assert_not_called()
 
         handler.close()
 
-    def test_fallback_when_streaming_disabled(self):
-        """Test that logs fallback to local when streaming is disabled"""
-        handler = StreamableLogHandler(
-            metadata=self.mock_metadata,
-            pipeline_fqn=self.pipeline_fqn,
-            run_id=self.run_id,
-            enable_streaming=False,
-        )
-
-        # Mock the fallback handler
-        handler.fallback_handler = Mock()
-
-        # Create a log record
-        record = logging.LogRecord(
-            name="test",
-            level=logging.INFO,
-            pathname="test.py",
-            lineno=1,
-            msg="Test message",
-            args=(),
-            exc_info=None,
-        )
-
-        handler.emit(record)
-
-        # Should have called fallback handler
-        handler.fallback_handler.emit.assert_called_once_with(record)
+    def test_isolated_client_is_closed_by_sender_thread(self):
+        metadata = _make_metadata_mock()
+        handler = _make_handler(metadata=metadata, enable_streaming=True)
+        handler._client.close = Mock()
 
         handler.close()
+        for _ in range(50):
+            if handler._client.close.called:
+                break
+            time.sleep(0.05)
 
-    def test_log_compression(self):
-        """Test log compression for large payloads"""
-        handler = StreamableLogHandler(
-            metadata=self.mock_metadata,
-            pipeline_fqn=self.pipeline_fqn,
-            run_id=self.run_id,
-            enable_streaming=False,  # We'll test _send_logs_to_server directly
+        handler._client.close.assert_called()
+
+
+class TestNoWaitClose(unittest.TestCase):
+    """close() must return effectively instantly. It must NOT join the
+    drainer / senders and must NOT wait on the server /close response."""
+
+    def test_close_returns_in_under_100ms_when_idle(self):
+        handler = _make_handler(enable_streaming=True)
+
+        start = time.monotonic()
+        handler.close()
+        elapsed = time.monotonic() - start
+
+        self.assertLess(
+            elapsed,
+            0.1,
+            f"close() took {elapsed * 1000:.1f}ms - must not block",
         )
 
-        # Large log content (> 10KB to trigger compression)
-        large_log = "x" * 11000
+    def test_close_returns_quickly_when_close_endpoint_hangs(self):
+        hang = threading.Event()
 
-        # Mock send_logs_batch to capture the call
-        with patch.object(self.mock_metadata, "send_logs_batch") as mock_send_logs:
-            mock_send_logs.return_value = {"logs_sent": 1, "bytes_sent": len(large_log)}
+        def block_forever(*_, **__):
+            hang.wait(timeout=30)
+            return True
 
-            with patch.dict(os.environ, {"ENABLE_LOG_COMPRESSION": "true"}):
-                handler._send_logs_to_server(large_log)
+        metadata = _make_metadata_mock()
+        metadata.send_logs_batch_best_effort = Mock(return_value=True)
+        metadata.send_close_best_effort = Mock(side_effect=block_forever)
 
-            # Verify send_logs_batch was called with compression enabled
-            mock_send_logs.assert_called_once_with(
-                pipeline_fqn=self.pipeline_fqn,
-                run_id=self.run_id,
-                log_content=large_log,
-                enable_compression=True,
-            )
+        handler = _make_handler(metadata=metadata, enable_streaming=True)
 
+        start = time.monotonic()
+        handler.close()
+        elapsed = time.monotonic() - start
+
+        self.assertLess(
+            elapsed,
+            0.1,
+            f"close() took {elapsed * 1000:.1f}ms - must not wait on /close response",
+        )
+        hang.set()
+
+    def test_close_signals_stop(self):
+        handler = _make_handler(enable_streaming=True)
+        handler.close()
+        self.assertTrue(handler._stop.is_set())
+
+    def test_close_is_idempotent(self):
+        handler = _make_handler(enable_streaming=True)
+        handler.close()
+        handler.close()  # must not raise
+
+
+class TestQuietClientPath(unittest.TestCase):
+    """The handler uses the best-effort path that bypasses retries and logging."""
+
+    def test_post_uses_best_effort_method(self):
+        metadata = _make_metadata_mock()
+        metadata.send_logs_batch_best_effort = Mock(return_value=True)
+        metadata.send_close_best_effort = Mock(return_value=True)
+
+        handler = _make_handler(metadata=metadata, enable_streaming=True)
+        handler.emit(_make_record("trigger"))
+        for _ in range(50):
+            if metadata.send_logs_batch_best_effort.called:
+                break
+            time.sleep(0.05)
+
+        self.assertTrue(metadata.send_logs_batch_best_effort.called)
+        kwargs = metadata.send_logs_batch_best_effort.call_args.kwargs
+        self.assertEqual(kwargs["timeout"], StreamableLogHandler.HTTP_TIMEOUT)
         handler.close()
 
-    def test_no_compression_for_small_logs(self):
-        """Test that small logs are not compressed"""
-        handler = StreamableLogHandler(
-            metadata=self.mock_metadata,
-            pipeline_fqn=self.pipeline_fqn,
-            run_id=self.run_id,
-            enable_streaming=False,
-        )
 
-        # Small log content (< 1KB)
-        small_log = "Small log message"
-
-        # Mock send_logs_batch to capture the call
-        with patch.object(self.mock_metadata, "send_logs_batch") as mock_send_logs:
-            mock_send_logs.return_value = {"logs_sent": 1, "bytes_sent": len(small_log)}
-
-            with patch.dict(os.environ, {"ENABLE_LOG_COMPRESSION": "true"}):
-                handler._send_logs_to_server(small_log)
-
-            # Verify send_logs_batch was called with compression enabled
-            # Note: The actual compression decision is made inside send_logs_batch
-            mock_send_logs.assert_called_once_with(
-                pipeline_fqn=self.pipeline_fqn,
-                run_id=self.run_id,
-                log_content=small_log,
-                enable_compression=True,
-            )
-
-        handler.close()
-
-    def test_session_maintains_cookies(self):
-        """Test that session maintains cookies for ALB stickiness"""
-        handler = StreamableLogHandler(
-            metadata=self.mock_metadata,
-            pipeline_fqn=self.pipeline_fqn,
-            run_id=self.run_id,
-            enable_streaming=False,
-        )
-
-        # Mock send_logs_batch to capture the calls
-        with patch.object(self.mock_metadata, "send_logs_batch") as mock_send_logs:
-            mock_send_logs.return_value = {"logs_sent": 1, "bytes_sent": 100}
-
-            # Send multiple log batches
-            handler._send_logs_to_server("Log batch 1")
-            handler._send_logs_to_server("Log batch 2")
-
-            # Two requests should be made with the same metadata instance
-            self.assertEqual(mock_send_logs.call_count, 2)
-            # Verify both calls used the same metadata instance
-            calls = mock_send_logs.call_args_list
-            for call in calls:
-                self.assertEqual(call.kwargs["pipeline_fqn"], self.pipeline_fqn)
-                self.assertEqual(call.kwargs["run_id"], self.run_id)
-
-        handler.close()
-
-    def test_circuit_breaker_on_failures(self):
-        """Test circuit breaker behavior on repeated failures"""
-        handler = StreamableLogHandler(
-            metadata=self.mock_metadata,
-            pipeline_fqn=self.pipeline_fqn,
-            run_id=self.run_id,
-            enable_streaming=False,
-        )
-
-        # Mock _send_logs_to_server to always fail
-        handler._send_logs_to_server = Mock(side_effect=Exception("Network error"))
-
-        logs = ["log1", "log2", "log3"]
-
-        # First few failures should attempt to send
-        for _ in range(5):
-            handler._ship_logs(logs)
-
-        # Circuit should be open now
-        self.assertEqual(handler.circuit_breaker.state, CircuitState.OPEN)
-
-        handler.close()
-
-    def test_queue_overflow_fallback(self):
-        """Test fallback behavior when queue is full"""
-        handler = StreamableLogHandler(
-            metadata=self.mock_metadata,
-            pipeline_fqn=self.pipeline_fqn,
-            run_id=self.run_id,
-            max_queue_size=1,
-            enable_streaming=True,
-        )
-
-        # Fill the queue
-        handler.log_queue.put("existing_log")
-
-        # Mock the fallback handler
-        handler.fallback_handler = Mock()
-
-        # Try to emit when queue is full
-        record = logging.LogRecord(
-            name="test",
-            level=logging.INFO,
-            pathname="test.py",
-            lineno=1,
-            msg="Overflow message",
-            args=(),
-            exc_info=None,
-        )
-
-        handler.emit(record)
-
-        # Should have called fallback handler
-        handler.fallback_handler.emit.assert_called_once_with(record)
-
-        handler.close()
-
-    @patch("metadata.utils.streamable_logger.threading.Thread")
-    def test_worker_thread_lifecycle(self, mock_thread_class):
-        """Test worker thread start and stop"""
-        mock_thread = Mock()
-        mock_thread.is_alive.return_value = False
-        mock_thread_class.return_value = mock_thread
-
-        handler = StreamableLogHandler(
-            metadata=self.mock_metadata,
-            pipeline_fqn=self.pipeline_fqn,
-            run_id=self.run_id,
-            enable_streaming=True,
-        )
-
-        # Worker thread should be started
-        mock_thread.start.assert_called_once()
-
-        # Close handler
-        handler.close()
-
-        # Stop event should be set
-        self.assertTrue(handler.stop_event.is_set())
-
-    def test_auth_header_included(self):
-        """Test that auth header is included when available"""
-        handler = StreamableLogHandler(
-            metadata=self.mock_metadata,
-            pipeline_fqn=self.pipeline_fqn,
-            run_id=self.run_id,
-            enable_streaming=False,
-        )
-
-        # Mock the send_logs_batch method to verify it's called with correct parameters
-        with patch.object(self.mock_metadata, "send_logs_batch") as mock_send_logs:
-            mock_send_logs.return_value = {"logs_sent": 1, "bytes_sent": 100}
-
-            handler._send_logs_to_server("Test log")
-
-            # Verify send_logs_batch was called with the correct parameters
-            mock_send_logs.assert_called_once_with(
-                pipeline_fqn=self.pipeline_fqn,
-                run_id=self.run_id,
-                log_content="Test log",
-                enable_compression=False,
-            )
-
-        handler.close()
-
-    def test_drain_queue_to_buffer_empty_queue(self):
-        """Test _drain_queue_to_buffer with empty queue"""
-        handler = StreamableLogHandler(
-            metadata=self.mock_metadata,
-            pipeline_fqn=self.pipeline_fqn,
-            run_id=self.run_id,
-            enable_streaming=False,
-        )
-
-        buffer = []
-        result_buffer, flush_requested = handler._drain_queue_to_buffer(buffer)
-
-        # Buffer should be unchanged and no flush requested
-        self.assertEqual(result_buffer, [])
-        self.assertFalse(flush_requested)
-
-        handler.close()
-
-    def test_drain_queue_to_buffer_with_logs(self):
-        """Test _drain_queue_to_buffer with regular log entries"""
-        handler = StreamableLogHandler(
-            metadata=self.mock_metadata,
-            pipeline_fqn=self.pipeline_fqn,
-            run_id=self.run_id,
-            enable_streaming=False,
-        )
-
-        # Add some log entries to queue
-        handler.log_queue.put("log entry 1")
-        handler.log_queue.put("log entry 2")
-        handler.log_queue.put("log entry 3")
-
-        buffer = ["existing log"]
-        result_buffer, flush_requested = handler._drain_queue_to_buffer(buffer)
-
-        # Buffer should contain all logs
-        expected_buffer = ["existing log", "log entry 1", "log entry 2", "log entry 3"]
-        self.assertEqual(result_buffer, expected_buffer)
-        self.assertFalse(flush_requested)
-
-        handler.close()
-
-    def test_drain_queue_to_buffer_with_flush_marker(self):
-        """Test _drain_queue_to_buffer handles flush markers correctly"""
-        handler = StreamableLogHandler(
-            metadata=self.mock_metadata,
-            pipeline_fqn=self.pipeline_fqn,
-            run_id=self.run_id,
-            enable_streaming=False,
-        )
-
-        # Add log entries and a flush marker
-        handler.log_queue.put("log entry 1")
-        handler.log_queue.put(None)  # Flush marker
-        handler.log_queue.put("log entry 2")
-
-        buffer = []
-        result_buffer, flush_requested = handler._drain_queue_to_buffer(buffer)
-
-        # Buffer should contain only log entries, not the flush marker
-        expected_buffer = ["log entry 1", "log entry 2"]
-        self.assertEqual(result_buffer, expected_buffer)
-        self.assertTrue(flush_requested)
-
-        handler.close()
-
-    def test_drain_queue_to_buffer_multiple_flush_markers(self):
-        """Test _drain_queue_to_buffer with multiple flush markers"""
-        handler = StreamableLogHandler(
-            metadata=self.mock_metadata,
-            pipeline_fqn=self.pipeline_fqn,
-            run_id=self.run_id,
-            enable_streaming=False,
-        )
-
-        # Add multiple flush markers
-        handler.log_queue.put("log entry 1")
-        handler.log_queue.put(None)  # First flush marker
-        handler.log_queue.put("log entry 2")
-        handler.log_queue.put(None)  # Second flush marker
-        handler.log_queue.put("log entry 3")
-
-        buffer = []
-        result_buffer, flush_requested = handler._drain_queue_to_buffer(buffer)
-
-        # Buffer should contain all log entries
-        expected_buffer = ["log entry 1", "log entry 2", "log entry 3"]
-        self.assertEqual(result_buffer, expected_buffer)
-        self.assertTrue(flush_requested)
-
-        handler.close()
-
-    @patch("time.time")
-    def test_worker_loop_flush_logic(self, mock_time):
-        """Test worker loop flush decision logic"""
-        # Set up consistent time for testing
-        mock_time.return_value = 1000.0
-
-        handler = StreamableLogHandler(
-            metadata=self.mock_metadata,
-            pipeline_fqn=self.pipeline_fqn,
-            run_id=self.run_id,
-            enable_streaming=False,
-            batch_size=3,
-            flush_interval_sec=5.0,
-        )
-
-        # Mock the shipping method
-        handler._ship_logs = Mock()
-
-        # Test flush due to batch size
-        handler.log_queue.put("log1")
-        handler.log_queue.put("log2")
-        handler.log_queue.put("log3")
-
-        # Simulate one iteration of worker loop logic
-        buffer = []
-        last_flush = mock_time.return_value
-
-        buffer, flush_requested = handler._drain_queue_to_buffer(buffer)
-        should_flush = (
-            flush_requested
-            or len(buffer) >= handler.batch_size
-            or (mock_time.return_value - last_flush) >= handler.flush_interval_sec
-        )
-
-        self.assertTrue(should_flush)  # Should flush due to batch size
-        self.assertEqual(len(buffer), 3)
-
-        handler.close()
-
-    @patch("time.time")
-    def test_worker_loop_time_based_flush(self, mock_time):
-        """Test worker loop time-based flush logic"""
-        handler = StreamableLogHandler(
-            metadata=self.mock_metadata,
-            pipeline_fqn=self.pipeline_fqn,
-            run_id=self.run_id,
-            enable_streaming=False,
-            batch_size=10,
-            flush_interval_sec=5.0,
-        )
-
-        # Add one log (below batch size)
-        handler.log_queue.put("single log")
-
-        # Set up time progression: first call returns 1000.0, subsequent calls return 1006.0
-        mock_time.side_effect = [
-            1000.0,
-            1006.0,
-            1006.0,
-        ]  # Allow for multiple time() calls
-
-        # Simulate worker loop logic with time progression
-        buffer = []
-        last_flush = 1000.0  # Initial time
-
-        buffer, flush_requested = handler._drain_queue_to_buffer(buffer)
-        current_time = 1006.0  # Time after drainage
-
-        should_flush = (
-            flush_requested
-            or len(buffer) >= handler.batch_size
-            or (current_time - last_flush) >= handler.flush_interval_sec
-        )
-
-        self.assertTrue(should_flush)  # Should flush due to time interval (6 > 5)
-        self.assertEqual(len(buffer), 1)
-
-        handler.close()
-
-    def test_flush_marker_triggers_immediate_flush(self):
-        """Test that flush markers trigger immediate flush regardless of batch size or time"""
-        handler = StreamableLogHandler(
-            metadata=self.mock_metadata,
-            pipeline_fqn=self.pipeline_fqn,
-            run_id=self.run_id,
-            enable_streaming=False,
-            batch_size=10,  # Large batch size
-            flush_interval_sec=60.0,  # Long time interval
-        )
-
-        # Add just one log and a flush marker
-        handler.log_queue.put("single log")
-        handler.log_queue.put(None)  # Flush marker
-
-        buffer = []
-        buffer, flush_requested = handler._drain_queue_to_buffer(buffer)
-
-        # Should request flush despite small buffer and short time
-        self.assertTrue(flush_requested)
-        self.assertEqual(len(buffer), 1)
-
-        handler.close()
-
-    def test_worker_loop_final_drainage_on_shutdown(self):
-        """Test that worker loop drains queue completely on shutdown"""
-        handler = StreamableLogHandler(
-            metadata=self.mock_metadata,
-            pipeline_fqn="test.pipeline",
-            run_id=uuid4(),
-            enable_streaming=False,
-        )
-
-        # Mock _ship_logs to track what gets shipped
-        shipped_logs = []
-
-        def mock_ship_logs(logs):
-            shipped_logs.extend(logs)
-
-        handler._ship_logs = mock_ship_logs
-
-        # Add logs to queue after stop event is set (simulating final drainage)
-        handler.log_queue.put("final log 1")
-        handler.log_queue.put("final log 2")
-        handler.log_queue.put(None)  # Flush marker
-        handler.log_queue.put("final log 3")
-
-        # Simulate final cleanup drainage
-        buffer, _ = handler._drain_queue_to_buffer([])
-        if buffer:
-            handler._ship_logs(buffer)
-
-        # All logs should be shipped
-        expected_logs = ["final log 1", "final log 2", "final log 3"]
-        self.assertEqual(shipped_logs, expected_logs)
-
-        handler.close()
-
-    def test_flush_method_adds_marker_to_queue(self):
-        """Test that flush method properly adds None marker to queue"""
-        handler = StreamableLogHandler(
-            metadata=self.mock_metadata,
-            pipeline_fqn="test.pipeline",
-            run_id=uuid4(),
-            enable_streaming=False,
-        )
-
-        # Flush should add None marker
-        handler.flush()
-
-        # Verify marker was added
-        marker = handler.log_queue.get_nowait()
-        self.assertIsNone(marker)
-
-        handler.close()
-
-    def test_close_waits_for_worker_thread(self):
-        """Test that close method properly waits for worker thread"""
-        with patch("threading.Thread") as mock_thread_class:
-            mock_thread = Mock()
-            mock_thread.is_alive.return_value = True
-            mock_thread_class.return_value = mock_thread
-
-            handler = StreamableLogHandler(
-                metadata=self.mock_metadata,
-                pipeline_fqn="test.pipeline",
-                run_id=uuid4(),
-                enable_streaming=True,
-            )
-
-            # Close handler
-            handler.close()
-
-            # Verify stop event was set and thread join was called
-            self.assertTrue(handler.stop_event.is_set())
-            mock_thread.join.assert_called_once_with(timeout=5.0)
+class TestStreamableLogHandlerManager(unittest.TestCase):
+    def tearDown(self):
+        StreamableLogHandlerManager._instance = None
+
+    def test_set_handler_removes_previous_from_metadata_logger(self):
+        """set_handler must detach the old handler from the metadata logger
+        before closing it - otherwise records can still route at it during
+        close, and a closed handler stays attached after."""
+        from metadata.utils.logger import METADATA_LOGGER
+
+        first = _make_handler(enable_streaming=False)
+        second = _make_handler(enable_streaming=False)
+        metadata_logger = logging.getLogger(METADATA_LOGGER)
+        metadata_logger.addHandler(first)
+
+        StreamableLogHandlerManager.set_handler(first)
+        StreamableLogHandlerManager.set_handler(second)
+
+        self.assertNotIn(first, metadata_logger.handlers, "previous handler must be removed before being closed")
+        # Cleanup.
+        metadata_logger.handlers = [h for h in metadata_logger.handlers if not isinstance(h, StreamableLogHandler)]
+
+    def test_cleanup_clears_singleton(self):
+        handler = _make_handler(enable_streaming=False)
+        StreamableLogHandlerManager.set_handler(handler)
+        StreamableLogHandlerManager.cleanup()
+        self.assertIsNone(StreamableLogHandlerManager.get_handler())
 
 
 class TestStreamableLoggingSetup(unittest.TestCase):
-    """Test the setup and cleanup functions"""
-
     def tearDown(self):
-        """Clean up any handlers that were added to loggers during tests"""
-        # Clean up any handlers from the metadata logger
-        import logging
-
         from metadata.utils.logger import METADATA_LOGGER
-        from metadata.utils.streamable_logger import StreamableLogHandlerManager
 
         metadata_logger = logging.getLogger(METADATA_LOGGER)
-        # Remove any mock handlers
-        metadata_logger.handlers = [h for h in metadata_logger.handlers if not isinstance(h, Mock)]
-
-        # Also clean up the manager
+        metadata_logger.handlers = [
+            h for h in metadata_logger.handlers if not isinstance(h, (Mock, StreamableLogHandler))
+        ]
         StreamableLogHandlerManager._instance = None
 
     @patch("logging.getLogger")
     @patch("metadata.utils.streamable_logger.logger")
     @patch("metadata.utils.streamable_logger.StreamableLogHandler")
-    def test_setup_with_valid_config(self, mock_handler_class, mock_logger, mock_get_logger):
-        """Test setup with valid configuration"""
+    def test_setup_with_valid_config(self, mock_handler_cls, mock_logger, mock_get_logger):
         mock_metadata = Mock(spec=OpenMetadata)
-        mock_metadata.config = Mock()
-        mock_metadata.config.host_port = "http://localhost:8585"
-
         mock_handler = Mock()
-        mock_handler.level = logging.INFO  # Add level attribute
-        mock_handler_class.return_value = mock_handler
-
-        pipeline_fqn = "test.pipeline"
-        run_id = uuid4()
-
-        # Setup mock logger to prevent handler from being added to real logger
+        mock_handler.level = logging.INFO
+        mock_handler_cls.return_value = mock_handler
         mock_metadata_logger = Mock()
         mock_get_logger.return_value = mock_metadata_logger
 
-        # Test with enable_streaming=True (from IngestionPipeline config)
-        result = setup_streamable_logging_for_workflow(
-            metadata=mock_metadata,
-            pipeline_fqn=pipeline_fqn,
-            run_id=run_id,
-            enable_streaming=True,  # This would come from IngestionPipeline.enableStreamableLogs
-        )
-
-        self.assertIsNotNone(result)
-        mock_handler_class.assert_called_once_with(
-            metadata=mock_metadata,
-            pipeline_fqn=pipeline_fqn,
-            run_id=run_id,
-            enable_streaming=True,
-        )
-
-        # Cleanup
-        cleanup_streamable_logging()
-
-    def test_setup_disabled_by_config(self):
-        """Test that setup returns None when disabled by config"""
-        mock_metadata = Mock(spec=OpenMetadata)
-
-        # Test with enable_streaming=False (from IngestionPipeline config)
         result = setup_streamable_logging_for_workflow(
             metadata=mock_metadata,
             pipeline_fqn="test.pipeline",
             run_id=uuid4(),
-            enable_streaming=False,  # This would come from IngestionPipeline.enableStreamableLogs
+            enable_streaming=True,
         )
 
+        self.assertIsNotNone(result)
+        mock_metadata_logger.addHandler.assert_called_once_with(mock_handler)
+        cleanup_streamable_logging()
+
+    def test_setup_returns_none_when_disabled(self):
+        result = setup_streamable_logging_for_workflow(
+            metadata=Mock(spec=OpenMetadata),
+            pipeline_fqn="test.pipeline",
+            run_id=uuid4(),
+            enable_streaming=False,
+        )
         self.assertIsNone(result)
 
-    def test_setup_missing_parameters(self):
-        """Test that setup returns None when parameters are missing"""
-        mock_metadata = Mock(spec=OpenMetadata)
-
-        # Missing pipeline_fqn
+    def test_setup_returns_none_when_pipeline_fqn_missing(self):
         result = setup_streamable_logging_for_workflow(
-            metadata=mock_metadata,
+            metadata=Mock(spec=OpenMetadata),
             pipeline_fqn=None,
             run_id=uuid4(),
             enable_streaming=True,
         )
         self.assertIsNone(result)
 
-        # Missing run_id
+    def test_setup_returns_none_when_run_id_missing(self):
         result = setup_streamable_logging_for_workflow(
-            metadata=mock_metadata,
+            metadata=Mock(spec=OpenMetadata),
             pipeline_fqn="test.pipeline",
             run_id=None,
             enable_streaming=True,
         )
         self.assertIsNone(result)
 
-    @patch("logging.getLogger")
-    @patch("metadata.utils.streamable_logger.logger")
-    @patch("metadata.utils.streamable_logger.StreamableLogHandler")
-    def test_cleanup_removes_handler(self, mock_handler_class, mock_logger, mock_get_logger):
-        """Test that cleanup properly removes the handler"""
-        mock_metadata = Mock(spec=OpenMetadata)
-        mock_metadata.config = Mock()
-        mock_metadata.config.host_port = "http://localhost:8585"
 
-        mock_handler = Mock()
-        mock_handler.level = logging.INFO  # Add level attribute to prevent TypeError
-        mock_handler_class.return_value = mock_handler
-
-        # Setup mock logger to prevent handler from being added to real logger
-        mock_metadata_logger = Mock()
-        mock_get_logger.return_value = mock_metadata_logger
-
-        # Setup
-        handler = setup_streamable_logging_for_workflow(  # noqa: F841
-            metadata=mock_metadata,
-            pipeline_fqn="test.pipeline",
-            run_id=uuid4(),
-            enable_streaming=True,
-        )
-
-        # Cleanup
-        cleanup_streamable_logging()
-
-        mock_metadata_logger.removeHandler.assert_called_once_with(mock_handler)
-        mock_handler.close.assert_called_once()
-
-    @patch("logging.getLogger")
-    @patch("metadata.utils.streamable_logger.logger")
-    @patch("metadata.utils.streamable_logger.StreamableLogHandler")
-    def test_setup_replaces_existing_handler(self, mock_handler_class, mock_logger, mock_get_logger):
-        """Test that setup properly replaces existing handler"""
-        mock_metadata = Mock(spec=OpenMetadata)
-        mock_metadata.config = Mock()
-        mock_metadata.config.host_port = "http://localhost:8585"
-
-        mock_handler1 = Mock()
-        mock_handler1.level = logging.INFO  # Add level attribute
-        mock_handler2 = Mock()
-        mock_handler2.level = logging.INFO  # Add level attribute
-        mock_handler_class.side_effect = [mock_handler1, mock_handler2]
-
-        # Setup mock logger to prevent handler from being added to real logger
-        mock_metadata_logger = Mock()
-        mock_get_logger.return_value = mock_metadata_logger
-
-        # First setup
-        handler1 = setup_streamable_logging_for_workflow(  # noqa: F841
-            metadata=mock_metadata,
-            pipeline_fqn="test.pipeline1",
-            run_id=uuid4(),
-            enable_streaming=True,
-        )
-
-        # Second setup should close first handler
-        handler2 = setup_streamable_logging_for_workflow(  # noqa: F841
-            metadata=mock_metadata,
-            pipeline_fqn="test.pipeline2",
-            run_id=uuid4(),
-            enable_streaming=True,
-        )
-
-        # The first handler should be closed when the second one is set
-        mock_handler1.close.assert_called()
-
-        # Cleanup
-        cleanup_streamable_logging()
-
-    @patch("logging.getLogger")
-    @patch("metadata.utils.streamable_logger.logger")
-    @patch("metadata.utils.streamable_logger.StreamableLogHandler")
-    def test_cleanup_flushes_before_closing(self, mock_handler_class, mock_logger, mock_get_logger):
-        """Test that cleanup calls flush before closing handler"""
-        mock_metadata = Mock(spec=OpenMetadata)
-        mock_metadata.config = Mock()
-        mock_metadata.config.host_port = "http://localhost:8585"
-
-        mock_handler = Mock()
-        mock_handler.level = logging.INFO
-        # Mock the specific methods that should be called
-        mock_handler.flush = Mock()
-        mock_handler.close = Mock()
-        mock_handler_class.return_value = mock_handler
-
-        # Setup mock logger
-        mock_metadata_logger = Mock()
-        mock_get_logger.return_value = mock_metadata_logger
-
-        # Setup handler
-        handler = setup_streamable_logging_for_workflow(
-            metadata=mock_metadata,
-            pipeline_fqn="test.pipeline",
-            run_id=uuid4(),
-            enable_streaming=True,
-        )
-
-        # Verify handler was created and returned
-        self.assertIsNotNone(handler)
-        self.assertEqual(handler, mock_handler)
-
-        # Cleanup and verify order of operations
-        cleanup_streamable_logging()
-
-        # Verify flush was called
-        mock_handler.flush.assert_called_once()
-
-        # Verify close was called
-        mock_handler.close.assert_called_once()
-
-        # Verify handler was removed from logger
-        mock_metadata_logger.removeHandler.assert_called_once_with(mock_handler)
-
-
-class TestStreamableLogHandlerRecursionRegression(unittest.TestCase):
-    """
-    Regression test for the production hang where StreamableLogHandler.emit()
-    called logger.warning() / logger.error() from inside the handler's own
-    dispatch path. Because the handler is attached to that very same logger,
-    every internal log call re-entered emit(), recursing against a still-full
-    queue until the Python recursion limit was hit on MainThread while every
-    other thread was blocked on the logging module's internal lock.
-
-    The fix is to use a dedicated `_internal_logger` with `propagate=False`
-    for any message originating inside this module's hot path. These tests
-    fail if anyone re-introduces a `logger.*` call inside emit / _ship_logs /
-    _worker_loop.
-    """
+class TestRecursionRegression(unittest.TestCase):
+    """Regression for PR #28160. The production hang was caused by
+    StreamableLogHandler.emit() calling logger.warning() / logger.error()
+    from inside its own dispatch path. These tests prove that the
+    rewrite cannot reproduce it - emit() runs exactly once per producer
+    call even in the overflow and format-failure paths."""
 
     def setUp(self):
-        self.mock_metadata = Mock(spec=OpenMetadata)
-        self.test_logger = logging.getLogger(f"test_streamable_recursion_{id(self)}")
+        self.mock_metadata = _make_metadata_mock()
+        self.test_logger = logging.getLogger(f"test_recursion_{id(self)}")
         self.test_logger.handlers = []
         self.test_logger.setLevel(logging.DEBUG)
         self.test_logger.propagate = False
@@ -870,104 +623,159 @@ class TestStreamableLogHandlerRecursionRegression(unittest.TestCase):
     def tearDown(self):
         self.test_logger.handlers = []
 
-    def _make_handler(self, max_queue_size=2):
-        handler = StreamableLogHandler(
+    def _make_handler_with_full_buffer(self):
+        handler = _make_handler(
             metadata=self.mock_metadata,
-            pipeline_fqn="test.pipeline",
-            run_id=uuid4(),
-            max_queue_size=max_queue_size,
+            max_buffer=2,
             enable_streaming=True,
         )
-        # Stop the background worker so the queue cannot drain during the test.
-        handler.stop_event.set()
-        if handler.worker_thread:
-            handler.worker_thread.join(timeout=2.0)
-        # Make the local fallback a Mock so we can assert it was called once.
-        handler.fallback_handler = Mock()
+        _stop_workers(handler)
+        handler._buffer.put_nowait("a")
+        handler._buffer.put_nowait("b")
+        self.assertTrue(handler._buffer.full())
         return handler
 
-    def test_emit_does_not_recurse_when_queue_full(self):
-        """
-        emit() must complete in a single call when the queue is full.
-        Before the fix this exploded into ~1000 recursive emit() calls.
-        """
-        handler = self._make_handler(max_queue_size=2)
-        handler.log_queue.put_nowait("entry-1")
-        handler.log_queue.put_nowait("entry-2")
-        self.assertTrue(handler.log_queue.full())
-
+    def test_emit_does_not_recurse_when_buffer_full(self):
+        handler = self._make_handler_with_full_buffer()
         self.test_logger.addHandler(handler)
 
-        call_count = {"n": 0}
+        emit_calls = {"n": 0}
         real_emit = handler.emit
 
-        def counting_emit(record):
-            call_count["n"] += 1
-            if call_count["n"] > 5:
-                raise AssertionError(
-                    "emit() recursed — regression of the streamable_logger hang. "
-                    "Check that nothing inside emit / _ship_logs / _worker_loop "
-                    "calls the module-level `logger`; use `_internal_logger` instead."
-                )
+        def counting(record):
+            emit_calls["n"] += 1
+            if emit_calls["n"] > 5:
+                raise AssertionError("emit() recursed - regression of PR #28160")
             real_emit(record)
 
-        handler.emit = counting_emit
-
+        handler.emit = counting
         start = time.monotonic()
-        # Before the fix this call would never return — MainThread would sit
-        # recursing until Python raised RecursionError, then the outer except
-        # would log.error() which would recurse again.
-        self.test_logger.warning("trigger the overflow path")
+        self.test_logger.warning("trigger overflow")
         elapsed = time.monotonic() - start
 
-        self.assertEqual(call_count["n"], 1, "emit() must be invoked exactly once per log call")
-        self.assertLess(elapsed, 1.0, "emit() must return in bounded time when queue is full")
-        handler.fallback_handler.emit.assert_called_once()
-
-    def test_emit_does_not_recurse_when_format_raises(self):
-        """
-        If self.format(record) raises, the outer except in emit() must NOT
-        route the error back through `logger` (which would recurse).
-        """
-        handler = self._make_handler(max_queue_size=10)
-        handler.format = Mock(side_effect=ValueError("boom"))
-
-        self.test_logger.addHandler(handler)
-
-        call_count = {"n": 0}
-        real_emit = handler.emit
-
-        def counting_emit(record):
-            call_count["n"] += 1
-            if call_count["n"] > 5:
-                raise AssertionError("emit() recursed via the outer except branch — regression.")
-            real_emit(record)
-
-        handler.emit = counting_emit
-
-        start = time.monotonic()
-        self.test_logger.error("trigger the format-failure path")
-        elapsed = time.monotonic() - start
-
-        self.assertEqual(call_count["n"], 1)
+        self.assertEqual(emit_calls["n"], 1)
         self.assertLess(elapsed, 1.0)
 
-    def test_internal_logger_is_isolated_from_root(self):
-        """
-        The `_internal_logger` must not propagate, otherwise its messages
-        would still reach the root logger (and therefore re-enter this
-        handler if it is attached there).
-        """
-        from metadata.utils.streamable_logger import _internal_logger
+    def test_emit_does_not_recurse_when_format_raises(self):
+        handler = _make_handler(metadata=self.mock_metadata, enable_streaming=True)
+        _stop_workers(handler)
+        handler.format = MagicMock(side_effect=ValueError("boom"))
 
-        self.assertFalse(
-            _internal_logger.propagate,
-            "_internal_logger.propagate must be False to prevent recursion",
+        self.test_logger.addHandler(handler)
+        emit_calls = {"n": 0}
+        real_emit = handler.emit
+
+        def counting(record):
+            emit_calls["n"] += 1
+            if emit_calls["n"] > 5:
+                raise AssertionError("emit() recursed via format-failure path")
+            real_emit(record)
+
+        handler.emit = counting
+        start = time.monotonic()
+        self.test_logger.error("trigger format failure")
+        elapsed = time.monotonic() - start
+
+        self.assertEqual(emit_calls["n"], 1)
+        self.assertLess(elapsed, 1.0)
+
+
+class TestQuietClientPostMixin(unittest.TestCase):
+    """The mixin's best-effort methods must NOT log through ometa_logger
+    (which would propagate back to the streamable handler)."""
+
+    def test_send_logs_batch_best_effort_does_not_log_on_failure(self):
+        from metadata.ingestion.ometa.mixins.logs_mixin import OMetaLogsMixin
+
+        # Build a bare instance and stub the client.
+        instance = OMetaLogsMixin()
+        instance.client = Mock()
+        instance.client.post_best_effort = Mock(return_value=False)
+
+        with patch("metadata.ingestion.ometa.mixins.logs_mixin.logger") as mock_logger:
+            ok = instance.send_logs_batch_best_effort(
+                pipeline_fqn="test",
+                run_id=uuid4(),
+                log_content="x",
+                timeout=(1, 2),
+            )
+
+        self.assertFalse(ok)
+        mock_logger.error.assert_not_called()
+        mock_logger.warning.assert_not_called()
+        mock_logger.info.assert_not_called()
+        mock_logger.debug.assert_not_called()
+
+    def test_send_logs_batch_best_effort_does_not_log_on_exception(self):
+        from metadata.ingestion.ometa.mixins.logs_mixin import OMetaLogsMixin
+
+        instance = OMetaLogsMixin()
+        instance.client = Mock()
+        instance.client.post_best_effort = Mock(side_effect=RuntimeError("boom"))
+
+        with patch("metadata.ingestion.ometa.mixins.logs_mixin.logger") as mock_logger:
+            ok = instance.send_logs_batch_best_effort(
+                pipeline_fqn="test",
+                run_id=uuid4(),
+                log_content="x",
+                timeout=(1, 2),
+            )
+
+        self.assertFalse(ok)
+        mock_logger.error.assert_not_called()
+        mock_logger.warning.assert_not_called()
+
+
+class TestClientPostBestEffort(unittest.TestCase):
+    """REST.post_best_effort must NOT enter the retry/sleep loop and
+    must NOT log on failure."""
+
+    def _make_client(self):
+        from metadata.ingestion.ometa.client import REST, ClientConfig
+
+        config = ClientConfig(
+            base_url="http://localhost:8585",
+            api_version="v1",
+            auth_token=lambda: ("token", 60),
         )
-        self.assertTrue(
-            _internal_logger.handlers,
-            "_internal_logger must have its own handler so messages still reach stderr",
-        )
+        client = REST(config)
+        client._session = Mock()
+        return client
+
+    def test_post_best_effort_does_not_sleep_on_504(self):
+        client = self._make_client()
+        resp = Mock()
+        resp.status_code = 504
+        client._session.post = Mock(return_value=resp)
+
+        with patch("time.sleep") as mock_sleep:
+            start = time.monotonic()
+            ok = client.post_best_effort("/path", data="x", timeout=(1, 2))
+            elapsed = time.monotonic() - start
+
+        self.assertFalse(ok)
+        mock_sleep.assert_not_called()
+        self.assertLess(elapsed, 0.2, "post_best_effort must NOT sleep on 504")
+
+    def test_post_best_effort_does_not_log_on_failure(self):
+        client = self._make_client()
+        client._session.post = Mock(side_effect=RuntimeError("network down"))
+
+        with patch("metadata.ingestion.ometa.client.logger") as mock_logger:
+            ok = client.post_best_effort("/path", data="x", timeout=(1, 2))
+
+        self.assertFalse(ok)
+        mock_logger.error.assert_not_called()
+        mock_logger.warning.assert_not_called()
+        mock_logger.info.assert_not_called()
+
+    def test_post_best_effort_returns_true_on_2xx(self):
+        client = self._make_client()
+        resp = Mock()
+        resp.status_code = 200
+        client._session.post = Mock(return_value=resp)
+
+        self.assertTrue(client.post_best_effort("/path", data="x"))
 
 
 if __name__ == "__main__":

--- a/ingestion/tests/unit/utils/test_streamable_logger.py
+++ b/ingestion/tests/unit/utils/test_streamable_logger.py
@@ -8,16 +8,7 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-"""
-Unit tests for the streamable logger module.
-
-Design under test (see streamable_logger module docstring):
-- emit() never blocks; overflow is counted, not stderr-fallback-emitted
-- emit() has a thread-local recursion guard
-- drainer hands batches to a bounded daemon sender queue
-- POSTs go through send_logs_batch_best_effort (no retries, no logging)
-- close() does NOT block on the server
-"""
+"""Unit tests for the streamable logger module."""
 
 import logging
 import threading
@@ -607,11 +598,8 @@ class TestStreamableLoggingSetup(unittest.TestCase):
 
 
 class TestRecursionRegression(unittest.TestCase):
-    """Regression for PR #28160. The production hang was caused by
-    StreamableLogHandler.emit() calling logger.warning() / logger.error()
-    from inside its own dispatch path. These tests prove that the
-    rewrite cannot reproduce it - emit() runs exactly once per producer
-    call even in the overflow and format-failure paths."""
+    """emit() must run exactly once per producer call even when overflow
+    or format failure would historically have triggered recursive logging."""
 
     def setUp(self):
         self.mock_metadata = _make_metadata_mock()
@@ -645,7 +633,7 @@ class TestRecursionRegression(unittest.TestCase):
         def counting(record):
             emit_calls["n"] += 1
             if emit_calls["n"] > 5:
-                raise AssertionError("emit() recursed - regression of PR #28160")
+                raise AssertionError("emit() recursed — single-call regression")
             real_emit(record)
 
         handler.emit = counting
@@ -778,48 +766,29 @@ class TestClientPostBestEffort(unittest.TestCase):
         self.assertTrue(client.post_best_effort("/path", data="x"))
 
     def test_build_request_headers_does_not_refresh_token(self):
-        """Regression for PR #28198 review finding #1.
-
-        The streamable handler's sender thread MUST NOT race the main
-        ingestion thread on token refresh. _build_request_headers reads
-        config.access_token; it never invokes _auth_token() or mutates
-        config.expires_in. Token refresh is owned exclusively by the
-        main client's _request() path.
-        """
+        """Token refresh stays on _request(); concurrent refresh from the
+        sender would race the main thread on shared ClientConfig."""
         client = self._make_client()
-        # Track whether the auth_token callable is invoked.
         client._auth_token = Mock(return_value=("fresh-token", 60))
-        # Make the config look like a refresh is needed.
-        client.config.expires_in = 0  # expired
+        client.config.expires_in = 0
         client.config.access_token = "stale-token"
         client.config.auth_header = "Authorization"
 
         headers = client._build_request_headers()
 
-        # auth_token() must NOT have been called — refresh is the main
-        # thread's job, this is just a reader.
         client._auth_token.assert_not_called()
-        # Header reads from whatever access_token is currently set.
         self.assertEqual(headers["Authorization"], "Bearer stale-token")
-        # expires_in must not have been mutated.
         self.assertEqual(client.config.expires_in, 0)
 
 
 class TestCloseOrderingRegression(unittest.TestCase):
-    """Regression for PR #28198 review finding #2.
-
-    close() must enqueue remaining batches + the CLOSE_MARKER BEFORE
-    setting the stop event. Otherwise the sender's get(timeout=1s) can
-    return Empty in the narrow window between set() and enqueue, see
-    _stop, and exit without ever processing the marker — meaning /close
-    is silently lost under light load."""
+    """close() must enqueue CLOSE_MARKER before setting _stop, otherwise
+    the sender's get(timeout) Empty branch can race the enqueue."""
 
     def test_close_enqueues_marker_before_setting_stop(self):
         metadata = _make_metadata_mock()
         handler = _make_handler(metadata=metadata, enable_streaming=True)
         handler.close()
-        # Marker must be drained by the sender, which then calls
-        # send_close_best_effort. Wait briefly.
         for _ in range(50):
             if metadata.send_close_best_effort.called:
                 break
@@ -827,14 +796,9 @@ class TestCloseOrderingRegression(unittest.TestCase):
         metadata.send_close_best_effort.assert_called_once()
 
     def test_close_marker_arrives_even_when_sender_was_idle(self):
-        """Light-load scenario that triggers the original race: sender
-        is sitting in get(timeout=1s) with an empty queue when close()
-        fires. If _stop.set() runs before put_nowait, the sender exits
-        on the Empty/stop check and the marker is never processed."""
         metadata = _make_metadata_mock()
         handler = _make_handler(metadata=metadata, enable_streaming=True)
-        # Let the sender enter its get() and wait.
-        time.sleep(0.2)
+        time.sleep(0.2)  # let sender enter get(timeout=...)
         handler.close()
         for _ in range(50):
             if metadata.send_close_best_effort.called:

--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/IngestionPipelineLogStreamingResourceIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/IngestionPipelineLogStreamingResourceIT.java
@@ -310,6 +310,40 @@ public class IngestionPipelineLogStreamingResourceIT {
   }
 
   @Test
+  @Order(115)
+  void testLateLogsAfterCloseDoNotClobberFinalLogs(TestNamespace ns) throws OpenMetadataException {
+    IngestionPipeline pipeline = createTestPipeline(ns);
+    UUID runId = UUID.randomUUID();
+    String pipelineFQN = pipeline.getFullyQualifiedName();
+    String beforeClose = "before-close-marker-" + runId;
+    String afterClose = "after-close-marker-" + runId;
+
+    postLogs(pipelineFQN, runId, beforeClose + "\n");
+    postClose(pipelineFQN, runId);
+    postLogs(pipelineFQN, runId, afterClose + "\n");
+    postClose(pipelineFQN, runId);
+
+    String body = getLogs(pipelineFQN, runId);
+    if (body == null || body.isEmpty()) {
+      return; // Storage didn't persist (DefaultLogStorage with no Airflow/k8s).
+    }
+    Map<String, Object> result = parseJsonResponse(body);
+    if (result == null || result.get("logs") == null) {
+      return;
+    }
+    String logs = String.valueOf(result.get("logs"));
+    Object total = result.get("total");
+    boolean storageHasContent =
+        total != null && !"0".equals(String.valueOf(total)) && !logs.isEmpty();
+    if (!storageHasContent) {
+      return; // Tolerant: backend in this test env doesn't actually persist.
+    }
+    assertTrue(
+        logs.contains(beforeClose),
+        "Late post-close logs must not clobber finalized logs.txt, got: " + logs);
+  }
+
+  @Test
   @Order(120)
   void testCloseIsIdempotent(TestNamespace ns) throws OpenMetadataException {
     IngestionPipeline pipeline = createTestPipeline(ns);

--- a/openmetadata-service/src/main/java/org/openmetadata/service/logstorage/S3LogStorage.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/logstorage/S3LogStorage.java
@@ -864,7 +864,7 @@ public class S3LogStorage implements LogStorageInterface {
    * would permanently disable partial.txt flushing for the lifetime of the JVM,
    * which is exactly the silent-stall failure mode we shipped this PR to prevent.
    */
-  Runnable safeScheduledTask(String name, Runnable task) {
+  private Runnable safeScheduledTask(String name, Runnable task) {
     return () -> {
       try {
         task.run();

--- a/openmetadata-service/src/main/java/org/openmetadata/service/logstorage/S3LogStorage.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/logstorage/S3LogStorage.java
@@ -26,6 +26,7 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -38,6 +39,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
@@ -53,6 +55,7 @@ import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.core.ResponseInputStream;
 import software.amazon.awssdk.core.async.AsyncRequestBody;
+import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3AsyncClient;
 import software.amazon.awssdk.services.s3.S3AsyncClientBuilder;
@@ -85,6 +88,7 @@ import software.amazon.awssdk.services.s3.model.NoSuchKeyException;
 import software.amazon.awssdk.services.s3.model.ObjectIdentifier;
 import software.amazon.awssdk.services.s3.model.PutBucketLifecycleConfigurationRequest;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.model.S3Exception;
 import software.amazon.awssdk.services.s3.model.S3Object;
 import software.amazon.awssdk.services.s3.model.ServerSideEncryption;
 import software.amazon.awssdk.services.s3.model.StorageClass;
@@ -114,6 +118,8 @@ public class S3LogStorage implements LogStorageInterface {
   private static final int DEFAULT_EXPIRATION_DAYS = 30;
   private static final long MIN_MPU_PART_BYTES = 5L * 1024 * 1024;
   private static final int LOCK_STRIPE_COUNT = 256;
+  private static final Duration S3_API_CALL_TIMEOUT = Duration.ofSeconds(30);
+  private static final Duration S3_API_CALL_ATTEMPT_TIMEOUT = Duration.ofSeconds(10);
 
   private S3Client s3Client;
   private S3AsyncClient s3AsyncClient;
@@ -140,17 +146,17 @@ public class S3LogStorage implements LogStorageInterface {
   private final Map<String, StreamContext> activeStreams = new ConcurrentHashMap<>();
   // Per-stream coordination via a fixed-stripe lock keyed on `<fqn>/<runId>`. The stripe
   // count caps memory at LOCK_STRIPE_COUNT regardless of completed-run accumulation, and
-  // the same key always maps to the same lock instance — so we never need a remove path
+  // the same key always maps to the same lock instance - so we never need a remove path
   // (which would race acquire vs. remove and break mutual exclusion). False-contention
   // across stripes is bounded by max-concurrent-streams << stripe count.
   private final Striped<Lock> streamLocks = Striped.lock(LOCK_STRIPE_COUNT);
 
   // Lines accumulated since the last successful partial.txt PUT, per stream. Drained by the
-  // periodic / watermark-driven flush. Values are plain ArrayList — NOT independently
+  // periodic / watermark-driven flush. Values are plain ArrayList - NOT independently
   // thread-safe. MUST be accessed only while holding the corresponding per-stream lock.
   private final Map<String, List<String>> pendingFlush = new ConcurrentHashMap<>();
 
-  // Bytes pending in pendingFlush, per stream — drives the early-flush watermark. Entries are
+  // Bytes pending in pendingFlush, per stream - drives the early-flush watermark. Entries are
   // removed when the stream is finalized.
   private final Map<String, AtomicLong> pendingFlushBytes = new ConcurrentHashMap<>();
 
@@ -162,8 +168,15 @@ public class S3LogStorage implements LogStorageInterface {
   // Per-stream consecutive flush failure count for alerting. Incremented on each failed PUT and
   // reset on success. Entries are removed when the stream is finalized.
   private final Map<String, AtomicInteger> consecutiveFlushFailures = new ConcurrentHashMap<>();
+  private final Set<String> scheduledPartialFlushes = ConcurrentHashMap.newKeySet();
+  private Cache<String, Boolean> closedStreams;
 
-  private ScheduledExecutorService cleanupExecutor;
+  // Split executors so a stuck/slow abandoned-stream cleanup task cannot
+  // starve the partial.txt flush schedule. Each runs on its own
+  // single-thread scheduler with its own thread name for easy
+  // identification in stack traces.
+  private ScheduledExecutorService partialFlushExecutor;
+  private ScheduledExecutorService abandonedCleanupExecutor;
 
   private final Cache<String, SimpleLogBuffer> recentLogsCache =
       Caffeine.newBuilder().maximumSize(200).expireAfterAccess(30, TimeUnit.MINUTES).build();
@@ -234,8 +247,16 @@ public class S3LogStorage implements LogStorageInterface {
               ? s3Config.getPendingFlushAlertAfterFailures()
               : DEFAULT_PENDING_FLUSH_ALERT_AFTER_FAILURES;
 
+      this.closedStreams =
+          Caffeine.newBuilder()
+              .maximumSize(10000)
+              .expireAfterWrite(Math.max(1, streamTimeoutMinutes), TimeUnit.MINUTES)
+              .build();
+
       S3ClientBuilder s3Builder =
-          S3Client.builder().region(Region.of(s3Config.getAwsConfig().getAwsRegion()));
+          S3Client.builder()
+              .region(Region.of(s3Config.getAwsConfig().getAwsRegion()))
+              .overrideConfiguration(s3ClientOverrideConfiguration());
 
       URI customEndpoint = s3Config.getAwsConfig().getEndPointURL();
       if (!nullOrEmpty(customEndpoint)) {
@@ -257,7 +278,8 @@ public class S3LogStorage implements LogStorageInterface {
       S3AsyncClientBuilder asyncBuilder =
           S3AsyncClient.builder()
               .region(Region.of(s3Config.getAwsConfig().getAwsRegion()))
-              .credentialsProvider(credentialsProvider);
+              .credentialsProvider(credentialsProvider)
+              .overrideConfiguration(s3ClientOverrideConfiguration());
 
       if (!nullOrEmpty(customEndpoint)) {
         asyncBuilder.endpointOverride(java.net.URI.create(customEndpoint.toString()));
@@ -275,23 +297,25 @@ public class S3LogStorage implements LogStorageInterface {
             "Error accessing S3 bucket: " + bucketName + ". Validate AWS configuration.", e);
       }
 
-      this.cleanupExecutor =
+      // Two single-thread schedulers. A blocked abandoned-cleanup task
+      // (long S3 deletes, slow list-objects) MUST NOT delay the partial
+      // flush schedule - the partial flush is what makes new logs
+      // visible on S3, and stalling it is exactly the symptom we
+      // shipped this change to prevent.
+      this.partialFlushExecutor =
+          Executors.newSingleThreadScheduledExecutor(namedDaemonFactory("s3-log-partial-flush"));
+      this.abandonedCleanupExecutor =
           Executors.newSingleThreadScheduledExecutor(
-              r -> {
-                Thread thread = new Thread(r);
-                thread.setName("s3-log-cleanup");
-                thread.setDaemon(true);
-                return thread;
-              });
+              namedDaemonFactory("s3-log-abandoned-cleanup"));
 
-      cleanupExecutor.scheduleWithFixedDelay(
-          this::cleanupAbandonedStreams,
+      abandonedCleanupExecutor.scheduleWithFixedDelay(
+          safeScheduledTask("cleanupAbandonedStreams", this::cleanupAbandonedStreams),
           cleanupIntervalMinutes,
           cleanupIntervalMinutes,
           TimeUnit.MINUTES);
 
-      cleanupExecutor.scheduleWithFixedDelay(
-          this::writePartialLogs,
+      partialFlushExecutor.scheduleWithFixedDelay(
+          safeScheduledTask("writePartialLogs", this::writePartialLogs),
           partialFlushIntervalMinutes,
           partialFlushIntervalMinutes,
           TimeUnit.MINUTES);
@@ -339,6 +363,23 @@ public class S3LogStorage implements LogStorageInterface {
     }
   }
 
+  private ClientOverrideConfiguration s3ClientOverrideConfiguration() {
+    return ClientOverrideConfiguration.builder()
+        .apiCallTimeout(S3_API_CALL_TIMEOUT)
+        .apiCallAttemptTimeout(S3_API_CALL_ATTEMPT_TIMEOUT)
+        .build();
+  }
+
+  private boolean isStreamClosed(String streamKey) {
+    return closedStreams != null && closedStreams.getIfPresent(streamKey) != null;
+  }
+
+  private void markStreamClosed(String streamKey) {
+    if (closedStreams != null) {
+      closedStreams.put(streamKey, Boolean.TRUE);
+    }
+  }
+
   @Override
   public void appendLogs(String pipelineFQN, UUID runId, String logContent) throws IOException {
     if (nullOrEmpty(logContent)) {
@@ -354,11 +395,16 @@ public class S3LogStorage implements LogStorageInterface {
     String streamKey = pipelineFQN + "/" + runId;
     Lock lock = acquireStreamLock(streamKey);
     try {
+      if (isStreamClosed(streamKey)) {
+        LOG.debug("Dropping late logs for already closed stream {}", streamKey);
+        return;
+      }
+
       // Update memory cache for real-time log viewing
       SimpleLogBuffer recentLogs = recentLogsCache.get(streamKey, k -> new SimpleLogBuffer(1000));
       recentLogs.append(logContent);
 
-      // Track the run as live (no multipart upload here — bytes flow through pendingFlush ->
+      // Track the run as live (no multipart upload here - bytes flow through pendingFlush ->
       // partial.txt).
       StreamContext ctx =
           activeStreams.computeIfAbsent(
@@ -382,9 +428,21 @@ public class S3LogStorage implements LogStorageInterface {
         }
         bytes.addAndGet(addedBytes);
         counter.addAndGet(lineCount);
-        if (bytes.get() >= earlyFlushWatermarkBytes) {
+        if (bytes.get() >= earlyFlushWatermarkBytes && scheduledPartialFlushes.add(streamKey)) {
           final String key = streamKey;
-          cleanupExecutor.execute(() -> writePartialLogsForStream(key));
+          // Watermark-triggered flush must land on the partial-flush
+          // executor (NOT the abandoned-cleanup executor) - otherwise a
+          // backed-up cleanup queue delays bytes from reaching S3.
+          partialFlushExecutor.execute(
+              safeScheduledTask(
+                  "writePartialLogsForStream",
+                  () -> {
+                    try {
+                      writePartialLogsForStream(key);
+                    } finally {
+                      scheduledPartialFlushes.remove(key);
+                    }
+                  }));
         }
       }
 
@@ -678,6 +736,9 @@ public class S3LogStorage implements LogStorageInterface {
     Lock lock = acquireStreamLock(streamKey);
     try {
       dropStreamState(streamKey);
+      if (closedStreams != null) {
+        closedStreams.invalidate(streamKey);
+      }
     } finally {
       releaseStreamLock(streamKey, lock);
     }
@@ -722,6 +783,9 @@ public class S3LogStorage implements LogStorageInterface {
 
     recentLogsCache.asMap().keySet().removeIf(streamKey -> streamKey.startsWith(streamKeyPrefix));
     activeListeners.keySet().removeIf(streamKey -> streamKey.startsWith(streamKeyPrefix));
+    if (closedStreams != null) {
+      closedStreams.asMap().keySet().removeIf(streamKey -> streamKey.startsWith(streamKeyPrefix));
+    }
 
     try {
       ListObjectsV2Request request =
@@ -780,21 +844,58 @@ public class S3LogStorage implements LogStorageInterface {
     return "s3";
   }
 
+  /** Build a daemon-thread factory with a stable name for stack traces. */
+  private static ThreadFactory namedDaemonFactory(String threadName) {
+    return r -> {
+      Thread t = new Thread(r);
+      t.setName(threadName);
+      t.setDaemon(true);
+      return t;
+    };
+  }
+
+  /**
+   * Wrap a Runnable so that any Throwable (including Error / RuntimeException)
+   * is caught and logged, NOT propagated.
+   *
+   * <p>This matters because {@link java.util.concurrent.ScheduledExecutorService#scheduleWithFixedDelay}
+   * silently stops re-running a task if it ever throws. Without this wrapper a
+   * single transient error (e.g. an S3 SDK retry exhaustion in writePartialLogs)
+   * would permanently disable partial.txt flushing for the lifetime of the JVM,
+   * which is exactly the silent-stall failure mode we shipped this PR to prevent.
+   */
+  Runnable safeScheduledTask(String name, Runnable task) {
+    return () -> {
+      try {
+        task.run();
+      } catch (Throwable t) { // NOSONAR - intentional catch-all on a scheduler boundary
+        LOG.error("Scheduled task {} threw - swallowing so the scheduler keeps running", name, t);
+      }
+    };
+  }
+
+  private void shutdownExecutor(ScheduledExecutorService executor, String name) {
+    if (executor == null) {
+      return;
+    }
+    executor.shutdown();
+    try {
+      if (!executor.awaitTermination(5, TimeUnit.SECONDS)) {
+        executor.shutdownNow();
+      }
+    } catch (InterruptedException e) {
+      LOG.debug("Interrupted while shutting down executor {}", name);
+      executor.shutdownNow();
+      Thread.currentThread().interrupt();
+    }
+  }
+
   @Override
   public void close() {
     activeStreams.clear();
 
-    if (cleanupExecutor != null) {
-      cleanupExecutor.shutdown();
-      try {
-        if (!cleanupExecutor.awaitTermination(5, TimeUnit.SECONDS)) {
-          cleanupExecutor.shutdownNow();
-        }
-      } catch (InterruptedException e) {
-        cleanupExecutor.shutdownNow();
-        Thread.currentThread().interrupt();
-      }
-    }
+    shutdownExecutor(partialFlushExecutor, "s3-log-partial-flush");
+    shutdownExecutor(abandonedCleanupExecutor, "s3-log-abandoned-cleanup");
 
     if (s3Client != null) {
       s3Client.close();
@@ -896,6 +997,9 @@ public class S3LogStorage implements LogStorageInterface {
   }
 
   void cleanupAbandonedStreams() {
+    if (metrics != null) {
+      metrics.recordAbandonedCleanupHeartbeat();
+    }
     long now = System.currentTimeMillis();
     long timeoutMs = streamTimeoutMinutes * 60L * 1000L;
 
@@ -928,7 +1032,7 @@ public class S3LogStorage implements LogStorageInterface {
 
     Lock lock = acquireStreamLock(streamKey);
     try {
-      // Re-check expiration under the lock — appendLogs may have bumped lastAccessTime.
+      // Re-check expiration under the lock - appendLogs may have bumped lastAccessTime.
       StreamContext ctx = activeStreams.get(streamKey);
       long timeoutMs = streamTimeoutMinutes * 60L * 1000L;
       if (ctx == null || System.currentTimeMillis() - ctx.lastAccessTime <= timeoutMs) {
@@ -975,6 +1079,7 @@ public class S3LogStorage implements LogStorageInterface {
         // Best-effort.
       }
 
+      markStreamClosed(streamKey);
       dropStreamState(streamKey);
     } finally {
       releaseStreamLock(streamKey, lock);
@@ -982,21 +1087,43 @@ public class S3LogStorage implements LogStorageInterface {
   }
 
   /**
-   * Periodically write accumulated logs to partial files for active streams
-   * This allows reading complete logs even while ingestion is still running
+   * Periodically write accumulated logs to partial files for active streams.
+   * This allows reading complete logs even while ingestion is still running.
+   *
+   * <p>Emits a heartbeat on every tick (whether or not any stream had work)
+   * and snapshots pendingFlush totals so an operator can answer "is the
+   * flush executor alive AND making progress" from metrics alone.
    */
   private void writePartialLogs() {
+    if (metrics != null) {
+      metrics.recordPartialFlushHeartbeat();
+    }
+    long totalBytes = 0;
+    long totalLines = 0;
     for (String streamKey : activeStreams.keySet()) {
       try {
         writePartialLogsForStream(streamKey);
       } catch (Exception e) {
         LOG.warn("Failed to write partial logs for stream: {}", streamKey, e);
       }
+      AtomicLong b = pendingFlushBytes.get(streamKey);
+      if (b != null) {
+        totalBytes += b.get();
+      }
+      List<String> q = pendingFlush.get(streamKey);
+      if (q != null) {
+        totalLines += q.size();
+      }
+    }
+    if (metrics != null) {
+      metrics.updatePendingStreamsCount(activeStreams.size());
+      metrics.updatePendingFlushBytes(totalBytes);
+      metrics.updatePendingFlushLines(totalLines);
     }
   }
 
   private void writePartialLogsForStream(String streamKey) {
-    // Parse the streamKey before acquiring the lock — these are pure local string ops
+    // Parse the streamKey before acquiring the lock - these are pure local string ops
     // that don't need protection and let us validate the key shape before any I/O.
     int lastSlashIndex = streamKey.lastIndexOf('/');
     if (lastSlashIndex == -1) {
@@ -1061,6 +1188,7 @@ public class S3LogStorage implements LogStorageInterface {
       }
       if (metrics != null) {
         metrics.recordS3Write();
+        metrics.recordPartialFlushSuccess();
       }
       consecutiveFlushFailures.computeIfAbsent(streamKey, k -> new AtomicInteger(0)).set(0);
       return true;
@@ -1082,7 +1210,7 @@ public class S3LogStorage implements LogStorageInterface {
 
   // Probes partial.txt via a single GetObject. For small files we read the body now and let
   // the caller PUT a merged body. For files >= MIN_MPU_PART_BYTES we abort the body stream and
-  // signal the caller to concatenate server-side via Multipart Upload + UploadPartCopy — this
+  // signal the caller to concatenate server-side via Multipart Upload + UploadPartCopy - this
   // avoids holding the full existing body in JVM heap and re-uploading it on every flush.
   private PartialProbe probeAndReadPartial(String partialKey) throws IOException {
     try {
@@ -1258,6 +1386,7 @@ public class S3LogStorage implements LogStorageInterface {
     }
     if (metrics != null) {
       metrics.recordS3Error();
+      metrics.recordFlushFailure();
     }
   }
 
@@ -1291,7 +1420,7 @@ public class S3LogStorage implements LogStorageInterface {
     try {
       // Final flush: drain remaining pendingFlush to partial.txt.
       if (!writePartialLogsForStreamLocked(streamKey, pipelineFQN, runId)) {
-        // Final flush failed — partial.txt may be stale; do not produce logs.txt.
+        // Final flush failed - partial.txt may be stale; do not produce logs.txt.
         // pendingFlush has been restored. Caller should retry.
         throw new IOException(
             "Failed to flush remaining logs to partial.txt for "
@@ -1305,6 +1434,7 @@ public class S3LogStorage implements LogStorageInterface {
       } catch (NoSuchKeyException e) {
         // Idempotent close: partial.txt already absent (likely a retry of a prior /close).
         LOG.debug("closeStream no-op for {}: partial.txt already absent", streamKey);
+        markStreamClosed(streamKey);
         dropStreamState(streamKey);
         return;
       } catch (Exception e) {
@@ -1338,6 +1468,7 @@ public class S3LogStorage implements LogStorageInterface {
         // Best-effort.
       }
 
+      markStreamClosed(streamKey);
       dropStreamState(streamKey);
     } finally {
       releaseStreamLock(streamKey, lock);
@@ -1347,6 +1478,13 @@ public class S3LogStorage implements LogStorageInterface {
   private void copyPartialToLogs(String pipelineFQN, UUID runId) {
     String partialKey = buildPartialS3Key(pipelineFQN, runId);
     String logsKey = buildS3Key(pipelineFQN, runId);
+    if (objectExists(logsKey)) {
+      LOG.warn(
+          "logs.txt already exists for {}/{}; deleting late partial.txt without overwriting logs.txt",
+          pipelineFQN,
+          runId);
+      return;
+    }
     CopyObjectRequest.Builder builder =
         CopyObjectRequest.builder()
             .sourceBucket(bucketName)
@@ -1360,12 +1498,28 @@ public class S3LogStorage implements LogStorageInterface {
     }
   }
 
+  private boolean objectExists(String key) {
+    try {
+      HeadObjectResponse response =
+          s3Client.headObject(HeadObjectRequest.builder().bucket(bucketName).key(key).build());
+      return response != null;
+    } catch (NoSuchKeyException e) {
+      return false;
+    } catch (S3Exception e) {
+      if (e.statusCode() == 404) {
+        return false;
+      }
+      throw e;
+    }
+  }
+
   private void dropStreamState(String streamKey) {
     activeStreams.remove(streamKey);
     pendingFlush.remove(streamKey);
     pendingFlushBytes.remove(streamKey);
     totalLinesAppended.remove(streamKey);
     consecutiveFlushFailures.remove(streamKey);
+    scheduledPartialFlushes.remove(streamKey);
     recentLogsCache.invalidate(streamKey);
     activeListeners.remove(streamKey);
   }
@@ -1551,7 +1705,7 @@ public class S3LogStorage implements LogStorageInterface {
       appendPendingFlushUnderLock(pipelineFQN, runId, allLines);
     } else {
       // No partial.txt yet (run hasn't had its first flush). Use pendingFlush as the
-      // canonical source — it holds the complete set of unflushed lines. recentLogsCache
+      // canonical source - it holds the complete set of unflushed lines. recentLogsCache
       // is for SSE live tail and may have evicted the oldest lines at its 1000-line cap.
       appendPendingFlushUnderLock(pipelineFQN, runId, allLines);
       if (allLines.isEmpty()) {

--- a/openmetadata-service/src/main/java/org/openmetadata/service/logstorage/S3LogStorage.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/logstorage/S3LogStorage.java
@@ -171,10 +171,7 @@ public class S3LogStorage implements LogStorageInterface {
   private final Set<String> scheduledPartialFlushes = ConcurrentHashMap.newKeySet();
   private Cache<String, Boolean> closedStreams;
 
-  // Split executors so a stuck/slow abandoned-stream cleanup task cannot
-  // starve the partial.txt flush schedule. Each runs on its own
-  // single-thread scheduler with its own thread name for easy
-  // identification in stack traces.
+  // Split so a stuck cleanup task cannot starve partial flush.
   private ScheduledExecutorService partialFlushExecutor;
   private ScheduledExecutorService abandonedCleanupExecutor;
 
@@ -297,11 +294,6 @@ public class S3LogStorage implements LogStorageInterface {
             "Error accessing S3 bucket: " + bucketName + ". Validate AWS configuration.", e);
       }
 
-      // Two single-thread schedulers. A blocked abandoned-cleanup task
-      // (long S3 deletes, slow list-objects) MUST NOT delay the partial
-      // flush schedule - the partial flush is what makes new logs
-      // visible on S3, and stalling it is exactly the symptom we
-      // shipped this change to prevent.
       this.partialFlushExecutor =
           Executors.newSingleThreadScheduledExecutor(namedDaemonFactory("s3-log-partial-flush"));
       this.abandonedCleanupExecutor =
@@ -430,9 +422,6 @@ public class S3LogStorage implements LogStorageInterface {
         counter.addAndGet(lineCount);
         if (bytes.get() >= earlyFlushWatermarkBytes && scheduledPartialFlushes.add(streamKey)) {
           final String key = streamKey;
-          // Watermark-triggered flush must land on the partial-flush
-          // executor (NOT the abandoned-cleanup executor) - otherwise a
-          // backed-up cleanup queue delays bytes from reaching S3.
           partialFlushExecutor.execute(
               safeScheduledTask(
                   "writePartialLogsForStream",
@@ -844,7 +833,6 @@ public class S3LogStorage implements LogStorageInterface {
     return "s3";
   }
 
-  /** Build a daemon-thread factory with a stable name for stack traces. */
   private static ThreadFactory namedDaemonFactory(String threadName) {
     return r -> {
       Thread t = new Thread(r);
@@ -854,21 +842,12 @@ public class S3LogStorage implements LogStorageInterface {
     };
   }
 
-  /**
-   * Wrap a Runnable so that any Throwable (including Error / RuntimeException)
-   * is caught and logged, NOT propagated.
-   *
-   * <p>This matters because {@link java.util.concurrent.ScheduledExecutorService#scheduleWithFixedDelay}
-   * silently stops re-running a task if it ever throws. Without this wrapper a
-   * single transient error (e.g. an S3 SDK retry exhaustion in writePartialLogs)
-   * would permanently disable partial.txt flushing for the lifetime of the JVM,
-   * which is exactly the silent-stall failure mode we shipped this PR to prevent.
-   */
+  /** Swallow Throwables so a scheduled task that throws is not silently de-scheduled. */
   private Runnable safeScheduledTask(String name, Runnable task) {
     return () -> {
       try {
         task.run();
-      } catch (Throwable t) { // NOSONAR - intentional catch-all on a scheduler boundary
+      } catch (Throwable t) { // NOSONAR
         LOG.error("Scheduled task {} threw - swallowing so the scheduler keeps running", name, t);
       }
     };
@@ -1086,14 +1065,7 @@ public class S3LogStorage implements LogStorageInterface {
     }
   }
 
-  /**
-   * Periodically write accumulated logs to partial files for active streams.
-   * This allows reading complete logs even while ingestion is still running.
-   *
-   * <p>Emits a heartbeat on every tick (whether or not any stream had work)
-   * and snapshots pendingFlush totals so an operator can answer "is the
-   * flush executor alive AND making progress" from metrics alone.
-   */
+  /** Scheduled tick: flush each active stream's pendingFlush to partial.txt. */
   private void writePartialLogs() {
     if (metrics != null) {
       metrics.recordPartialFlushHeartbeat();

--- a/openmetadata-service/src/main/java/org/openmetadata/service/monitoring/StreamableLogsMetrics.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/monitoring/StreamableLogsMetrics.java
@@ -59,6 +59,24 @@ public class StreamableLogsMetrics {
   private final Counter ingestionLogsDropped;
   private final Counter ingestionFallbackActive;
 
+  // ---- Server-side flush observability ----
+  // Last successful partial.txt PUT (epoch millis). Stays at 0 until the
+  // first partial flush succeeds. Going stale (no updates for several
+  // partialFlushIntervalMinutes) is the canonical signal that the flush
+  // executor is wedged.
+  private final AtomicLong lastPartialFlushTimestamp;
+  // Tick timestamps for each scheduled task. Used to verify the
+  // executor itself is still running. If this goes stale while pending
+  // bytes grow, the flush task is blocked or no longer being scheduled.
+  private final AtomicLong partialFlushHeartbeat;
+  private final AtomicLong abandonedCleanupHeartbeat;
+  // Aggregate state across all active streams. Sampled by the partial
+  // flush task on each tick.
+  private final AtomicInteger pendingStreamsCount;
+  private final AtomicLong pendingFlushBytes;
+  private final AtomicLong pendingFlushLines;
+  private final Counter flushFailuresCounter;
+
   public static final int STATE_CLOSED = 0;
   public static final int STATE_OPEN = 1;
   public static final int STATE_HALF_OPEN = 2;
@@ -198,6 +216,107 @@ public class StreamableLogsMetrics {
         Counter.builder("om_ingestion_fallback_active_total")
             .description("Number of times fallback to local logging was activated")
             .register(meterRegistry);
+
+    this.lastPartialFlushTimestamp = new AtomicLong(0);
+    Gauge.builder(
+            "om_streamable_logs_last_partial_flush_ts_ms",
+            lastPartialFlushTimestamp,
+            AtomicLong::get)
+        .description("Epoch millis of the last successful partial.txt flush")
+        .register(meterRegistry);
+
+    this.partialFlushHeartbeat = new AtomicLong(0);
+    Gauge.builder(
+            "om_streamable_logs_partial_flush_heartbeat_ms", partialFlushHeartbeat, AtomicLong::get)
+        .description("Epoch millis of last partial-flush scheduled tick")
+        .register(meterRegistry);
+
+    this.abandonedCleanupHeartbeat = new AtomicLong(0);
+    Gauge.builder(
+            "om_streamable_logs_abandoned_cleanup_heartbeat_ms",
+            abandonedCleanupHeartbeat,
+            AtomicLong::get)
+        .description("Epoch millis of last abandoned-cleanup scheduled tick")
+        .register(meterRegistry);
+
+    this.pendingStreamsCount = new AtomicInteger(0);
+    Gauge.builder("om_streamable_logs_pending_streams", pendingStreamsCount, AtomicInteger::get)
+        .description("Number of active streams with pending log data on the server")
+        .register(meterRegistry);
+
+    this.pendingFlushBytes = new AtomicLong(0);
+    Gauge.builder("om_streamable_logs_pending_flush_bytes", pendingFlushBytes, AtomicLong::get)
+        .description("Total bytes queued for partial-flush across all active streams")
+        .register(meterRegistry);
+
+    this.pendingFlushLines = new AtomicLong(0);
+    Gauge.builder("om_streamable_logs_pending_flush_lines", pendingFlushLines, AtomicLong::get)
+        .description("Total log lines queued for partial-flush across all active streams")
+        .register(meterRegistry);
+
+    this.flushFailuresCounter =
+        Counter.builder("om_streamable_logs_flush_failures_total")
+            .description("Total partial-flush failures (server side)")
+            .register(meterRegistry);
+  }
+
+  // ---- Server-side flush observability hooks ----
+
+  public void recordPartialFlushSuccess() {
+    lastPartialFlushTimestamp.set(System.currentTimeMillis());
+  }
+
+  public void recordPartialFlushHeartbeat() {
+    partialFlushHeartbeat.set(System.currentTimeMillis());
+  }
+
+  public void recordAbandonedCleanupHeartbeat() {
+    abandonedCleanupHeartbeat.set(System.currentTimeMillis());
+  }
+
+  public void recordFlushFailure() {
+    flushFailuresCounter.increment();
+  }
+
+  public void updatePendingStreamsCount(int count) {
+    pendingStreamsCount.set(count);
+  }
+
+  public void updatePendingFlushBytes(long bytes) {
+    pendingFlushBytes.set(bytes);
+  }
+
+  public void updatePendingFlushLines(long lines) {
+    pendingFlushLines.set(lines);
+  }
+
+  // Getters for tests / health-check.
+  public long getLastPartialFlushTimestamp() {
+    return lastPartialFlushTimestamp.get();
+  }
+
+  public long getPartialFlushHeartbeat() {
+    return partialFlushHeartbeat.get();
+  }
+
+  public long getAbandonedCleanupHeartbeat() {
+    return abandonedCleanupHeartbeat.get();
+  }
+
+  public int getPendingStreamsCount() {
+    return pendingStreamsCount.get();
+  }
+
+  public long getPendingFlushBytes() {
+    return pendingFlushBytes.get();
+  }
+
+  public long getPendingFlushLines() {
+    return pendingFlushLines.get();
+  }
+
+  public long getFlushFailuresCount() {
+    return (long) flushFailuresCounter.count();
   }
 
   public void recordLogsSent(int count) {

--- a/openmetadata-service/src/main/java/org/openmetadata/service/monitoring/StreamableLogsMetrics.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/monitoring/StreamableLogsMetrics.java
@@ -59,19 +59,10 @@ public class StreamableLogsMetrics {
   private final Counter ingestionLogsDropped;
   private final Counter ingestionFallbackActive;
 
-  // ---- Server-side flush observability ----
-  // Last successful partial.txt PUT (epoch millis). Stays at 0 until the
-  // first partial flush succeeds. Going stale (no updates for several
-  // partialFlushIntervalMinutes) is the canonical signal that the flush
-  // executor is wedged.
+  // Server-side flush observability.
   private final AtomicLong lastPartialFlushTimestamp;
-  // Tick timestamps for each scheduled task. Used to verify the
-  // executor itself is still running. If this goes stale while pending
-  // bytes grow, the flush task is blocked or no longer being scheduled.
   private final AtomicLong partialFlushHeartbeat;
   private final AtomicLong abandonedCleanupHeartbeat;
-  // Aggregate state across all active streams. Sampled by the partial
-  // flush task on each tick.
   private final AtomicInteger pendingStreamsCount;
   private final AtomicLong pendingFlushBytes;
   private final AtomicLong pendingFlushLines;
@@ -260,8 +251,6 @@ public class StreamableLogsMetrics {
             .register(meterRegistry);
   }
 
-  // ---- Server-side flush observability hooks ----
-
   public void recordPartialFlushSuccess() {
     lastPartialFlushTimestamp.set(System.currentTimeMillis());
   }
@@ -290,7 +279,6 @@ public class StreamableLogsMetrics {
     pendingFlushLines.set(lines);
   }
 
-  // Getters for tests / health-check.
   public long getLastPartialFlushTimestamp() {
     return lastPartialFlushTimestamp.get();
   }

--- a/openmetadata-service/src/test/java/org/openmetadata/service/logstorage/S3LogStorageTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/logstorage/S3LogStorageTest.java
@@ -44,6 +44,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.locks.Lock;
 import org.junit.jupiter.api.BeforeEach;
@@ -56,6 +57,7 @@ import org.openmetadata.schema.api.configuration.LogStorageConfiguration;
 import org.openmetadata.schema.security.credentials.AWSCredentials;
 import software.amazon.awssdk.core.ResponseInputStream;
 import software.amazon.awssdk.core.async.AsyncRequestBody;
+import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration;
 import software.amazon.awssdk.http.AbortableInputStream;
 import software.amazon.awssdk.services.s3.S3AsyncClient;
 import software.amazon.awssdk.services.s3.S3AsyncClientBuilder;
@@ -83,6 +85,7 @@ import software.amazon.awssdk.services.s3.model.NoSuchBucketException;
 import software.amazon.awssdk.services.s3.model.NoSuchKeyException;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import software.amazon.awssdk.services.s3.model.PutObjectResponse;
+import software.amazon.awssdk.services.s3.model.S3Exception;
 import software.amazon.awssdk.services.s3.model.S3Object;
 import software.amazon.awssdk.services.s3.model.UploadPartCopyRequest;
 import software.amazon.awssdk.services.s3.model.UploadPartCopyResponse;
@@ -124,12 +127,16 @@ public class S3LogStorageTest {
       S3ClientBuilder mockBuilder = mock(S3ClientBuilder.class);
       when(S3Client.builder()).thenReturn(mockBuilder);
       when(mockBuilder.region(any())).thenReturn(mockBuilder);
+      when(mockBuilder.overrideConfiguration(any(ClientOverrideConfiguration.class)))
+          .thenReturn(mockBuilder);
       when(mockBuilder.credentialsProvider(any())).thenReturn(mockBuilder);
       when(mockBuilder.build()).thenReturn(mockS3Client);
 
       S3AsyncClientBuilder mockAsyncBuilder = mock(S3AsyncClientBuilder.class);
       when(S3AsyncClient.builder()).thenReturn(mockAsyncBuilder);
       when(mockAsyncBuilder.region(any())).thenReturn(mockAsyncBuilder);
+      when(mockAsyncBuilder.overrideConfiguration(any(ClientOverrideConfiguration.class)))
+          .thenReturn(mockAsyncBuilder);
       when(mockAsyncBuilder.credentialsProvider(any())).thenReturn(mockAsyncBuilder);
       when(mockAsyncBuilder.build()).thenReturn(mockS3AsyncClient);
 
@@ -160,6 +167,40 @@ public class S3LogStorageTest {
   void testS3LogStorageInitialization() {
     assertNotNull(s3LogStorage);
     assertEquals("s3", s3LogStorage.getStorageType());
+  }
+
+  @Test
+  void testS3ClientsUseApiCallTimeouts() throws Exception {
+    try (MockedStatic<S3Client> s3ClientMock = mockStatic(S3Client.class);
+        MockedStatic<S3AsyncClient> s3AsyncClientMock = mockStatic(S3AsyncClient.class)) {
+
+      S3ClientBuilder mockBuilder = mock(S3ClientBuilder.class);
+      when(S3Client.builder()).thenReturn(mockBuilder);
+      when(mockBuilder.region(any())).thenReturn(mockBuilder);
+      when(mockBuilder.overrideConfiguration(any(ClientOverrideConfiguration.class)))
+          .thenReturn(mockBuilder);
+      when(mockBuilder.credentialsProvider(any())).thenReturn(mockBuilder);
+      when(mockBuilder.build()).thenReturn(mockS3Client);
+
+      S3AsyncClientBuilder mockAsyncBuilder = mock(S3AsyncClientBuilder.class);
+      when(S3AsyncClient.builder()).thenReturn(mockAsyncBuilder);
+      when(mockAsyncBuilder.region(any())).thenReturn(mockAsyncBuilder);
+      when(mockAsyncBuilder.overrideConfiguration(any(ClientOverrideConfiguration.class)))
+          .thenReturn(mockAsyncBuilder);
+      when(mockAsyncBuilder.credentialsProvider(any())).thenReturn(mockAsyncBuilder);
+      when(mockAsyncBuilder.build()).thenReturn(mockS3AsyncClient);
+      when(mockS3Client.headBucket(any(HeadBucketRequest.class)))
+          .thenReturn(HeadBucketResponse.builder().build());
+
+      S3LogStorage storage = new S3LogStorage();
+      Map<String, Object> config = new HashMap<>();
+      config.put("config", testConfig);
+      storage.initialize(config);
+
+      verify(mockBuilder).overrideConfiguration(any(ClientOverrideConfiguration.class));
+      verify(mockAsyncBuilder).overrideConfiguration(any(ClientOverrideConfiguration.class));
+      storage.close();
+    }
   }
 
   @Test
@@ -234,6 +275,126 @@ public class S3LogStorageTest {
   }
 
   @Test
+  void testLateAppendAfterCloseIsDropped() throws Exception {
+    String streamKey = testPipelineFQN + "/" + testRunId;
+    String partialKey =
+        testPrefix
+            + "/"
+            + testPipelineFQN.replaceAll("[^a-zA-Z0-9_-]", "_")
+            + "/"
+            + testRunId
+            + "/partial.txt";
+
+    mockAsyncPutObject();
+    when(mockS3Client.getObject(
+            argThat((GetObjectRequest req) -> req != null && partialKey.equals(req.key()))))
+        .thenThrow(NoSuchKeyException.builder().build());
+    when(mockS3Client.putObject(
+            any(PutObjectRequest.class), any(software.amazon.awssdk.core.sync.RequestBody.class)))
+        .thenReturn(PutObjectResponse.builder().build());
+    when(mockS3Client.copyObject(any(CopyObjectRequest.class)))
+        .thenReturn(software.amazon.awssdk.services.s3.model.CopyObjectResponse.builder().build());
+    when(mockS3Client.deleteObject(any(DeleteObjectRequest.class)))
+        .thenReturn(DeleteObjectResponse.builder().build());
+
+    s3LogStorage.appendLogs(testPipelineFQN, testRunId, "before-close\n");
+    s3LogStorage.closeStream(testPipelineFQN, testRunId);
+
+    clearInvocations(mockS3Client);
+    s3LogStorage.appendLogs(testPipelineFQN, testRunId, "late-after-close\n");
+
+    @SuppressWarnings("unchecked")
+    Map<String, List<String>> pending =
+        (Map<String, List<String>>) getPrivateField(s3LogStorage, "pendingFlush");
+    assertFalse(
+        pending.containsKey(streamKey),
+        "late append after close must not recreate pendingFlush for the completed stream");
+    verify(mockS3Client, never())
+        .putObject(
+            any(PutObjectRequest.class), any(software.amazon.awssdk.core.sync.RequestBody.class));
+  }
+
+  @Test
+  void testLatePartialDoesNotOverwriteExistingLogsTxt() throws Exception {
+    String partialKey =
+        testPrefix
+            + "/"
+            + testPipelineFQN.replaceAll("[^a-zA-Z0-9_-]", "_")
+            + "/"
+            + testRunId
+            + "/partial.txt";
+    String logsKey =
+        testPrefix
+            + "/"
+            + testPipelineFQN.replaceAll("[^a-zA-Z0-9_-]", "_")
+            + "/"
+            + testRunId
+            + "/logs.txt";
+
+    mockAsyncPutObject();
+    when(mockS3Client.getObject(
+            argThat((GetObjectRequest req) -> req != null && partialKey.equals(req.key()))))
+        .thenThrow(NoSuchKeyException.builder().build());
+    when(mockS3Client.putObject(
+            any(PutObjectRequest.class), any(software.amazon.awssdk.core.sync.RequestBody.class)))
+        .thenReturn(PutObjectResponse.builder().build());
+    when(mockS3Client.headObject(
+            argThat((HeadObjectRequest req) -> req != null && logsKey.equals(req.key()))))
+        .thenReturn(HeadObjectResponse.builder().build());
+    when(mockS3Client.deleteObject(any(DeleteObjectRequest.class)))
+        .thenReturn(DeleteObjectResponse.builder().build());
+
+    s3LogStorage.appendLogs(testPipelineFQN, testRunId, "late-tail\n");
+    s3LogStorage.closeStream(testPipelineFQN, testRunId);
+
+    verify(mockS3Client, never()).copyObject(any(CopyObjectRequest.class));
+    verify(mockS3Client, atLeastOnce())
+        .deleteObject(
+            argThat((DeleteObjectRequest req) -> req != null && partialKey.equals(req.key())));
+  }
+
+  @Test
+  void testLogsTxtHeadObjectGeneric404IsTreatedAsMissing() throws Exception {
+    String partialKey =
+        testPrefix
+            + "/"
+            + testPipelineFQN.replaceAll("[^a-zA-Z0-9_-]", "_")
+            + "/"
+            + testRunId
+            + "/partial.txt";
+    String logsKey =
+        testPrefix
+            + "/"
+            + testPipelineFQN.replaceAll("[^a-zA-Z0-9_-]", "_")
+            + "/"
+            + testRunId
+            + "/logs.txt";
+
+    mockAsyncPutObject();
+    when(mockS3Client.getObject(
+            argThat((GetObjectRequest req) -> req != null && partialKey.equals(req.key()))))
+        .thenThrow(NoSuchKeyException.builder().build());
+    when(mockS3Client.putObject(
+            any(PutObjectRequest.class), any(software.amazon.awssdk.core.sync.RequestBody.class)))
+        .thenReturn(PutObjectResponse.builder().build());
+    when(mockS3Client.headObject(
+            argThat((HeadObjectRequest req) -> req != null && logsKey.equals(req.key()))))
+        .thenThrow(S3Exception.builder().statusCode(404).message("Not Found").build());
+    when(mockS3Client.copyObject(any(CopyObjectRequest.class)))
+        .thenReturn(software.amazon.awssdk.services.s3.model.CopyObjectResponse.builder().build());
+    when(mockS3Client.deleteObject(any(DeleteObjectRequest.class)))
+        .thenReturn(DeleteObjectResponse.builder().build());
+
+    s3LogStorage.appendLogs(testPipelineFQN, testRunId, "tail\n");
+    s3LogStorage.closeStream(testPipelineFQN, testRunId);
+
+    verify(mockS3Client)
+        .copyObject(
+            argThat(
+                (CopyObjectRequest req) -> req != null && logsKey.equals(req.destinationKey())));
+  }
+
+  @Test
   void testCloseStreamIsIdempotent() throws Exception {
     mockAsyncPutObject();
     // First close: flush writes partial.txt, then copy succeeds, then delete
@@ -250,8 +411,8 @@ public class S3LogStorageTest {
     s3LogStorage.appendLogs(testPipelineFQN, testRunId, "x\n");
     s3LogStorage.closeStream(testPipelineFQN, testRunId);
 
-    // Second close: no pending lines → writePartialLogsForStreamLocked is no-op,
-    // then copyPartialToLogs throws NoSuchKeyException → idempotent path returns.
+    // Second close: no pending lines -> writePartialLogsForStreamLocked is no-op,
+    // then copyPartialToLogs throws NoSuchKeyException -> idempotent path returns.
     when(mockS3Client.copyObject(any(CopyObjectRequest.class)))
         .thenThrow(NoSuchKeyException.builder().build());
 
@@ -535,12 +696,16 @@ public class S3LogStorageTest {
       S3ClientBuilder mockBuilder = mock(S3ClientBuilder.class);
       when(S3Client.builder()).thenReturn(mockBuilder);
       when(mockBuilder.region(any())).thenReturn(mockBuilder);
+      when(mockBuilder.overrideConfiguration(any(ClientOverrideConfiguration.class)))
+          .thenReturn(mockBuilder);
       when(mockBuilder.credentialsProvider(any())).thenReturn(mockBuilder);
       when(mockBuilder.build()).thenReturn(mockS3Client);
 
       S3AsyncClientBuilder mockAsyncBuilder = mock(S3AsyncClientBuilder.class);
       when(S3AsyncClient.builder()).thenReturn(mockAsyncBuilder);
       when(mockAsyncBuilder.region(any())).thenReturn(mockAsyncBuilder);
+      when(mockAsyncBuilder.overrideConfiguration(any(ClientOverrideConfiguration.class)))
+          .thenReturn(mockAsyncBuilder);
       when(mockAsyncBuilder.credentialsProvider(any())).thenReturn(mockAsyncBuilder);
       when(mockAsyncBuilder.build()).thenReturn(mockS3AsyncClient);
 
@@ -572,6 +737,8 @@ public class S3LogStorageTest {
       S3ClientBuilder mockBuilder = mock(S3ClientBuilder.class);
       when(S3Client.builder()).thenReturn(mockBuilder);
       when(mockBuilder.region(any())).thenReturn(mockBuilder);
+      when(mockBuilder.overrideConfiguration(any(ClientOverrideConfiguration.class)))
+          .thenReturn(mockBuilder);
 
       S3LogStorage storage = new S3LogStorage();
       Map<String, Object> config = new HashMap<>();
@@ -596,12 +763,16 @@ public class S3LogStorageTest {
       S3ClientBuilder mockBuilder = mock(S3ClientBuilder.class);
       when(S3Client.builder()).thenReturn(mockBuilder);
       when(mockBuilder.region(any())).thenReturn(mockBuilder);
+      when(mockBuilder.overrideConfiguration(any(ClientOverrideConfiguration.class)))
+          .thenReturn(mockBuilder);
       when(mockBuilder.credentialsProvider(any())).thenReturn(mockBuilder);
       when(mockBuilder.build()).thenReturn(mockS3Client);
 
       S3AsyncClientBuilder mockAsyncBuilder = mock(S3AsyncClientBuilder.class);
       when(S3AsyncClient.builder()).thenReturn(mockAsyncBuilder);
       when(mockAsyncBuilder.region(any())).thenReturn(mockAsyncBuilder);
+      when(mockAsyncBuilder.overrideConfiguration(any(ClientOverrideConfiguration.class)))
+          .thenReturn(mockAsyncBuilder);
       when(mockAsyncBuilder.credentialsProvider(any())).thenReturn(mockAsyncBuilder);
       when(mockAsyncBuilder.build()).thenReturn(mockS3AsyncClient);
 
@@ -659,7 +830,7 @@ public class S3LogStorageTest {
     Map<String, AtomicLong> counters =
         (Map<String, AtomicLong>) getPrivateField(s3LogStorage, "totalLinesAppended");
 
-    // "line A\nline B\n" → split → ["line A", "line B", ""] → trim → 2 lines
+    // "line A\nline B\n" -> split -> ["line A", "line B", ""] -> trim -> 2 lines
     assertEquals(2, pending.get(streamKey).size(), "trailing newline must not yield an empty line");
     assertEquals(2L, counters.get(streamKey).get());
   }
@@ -1048,6 +1219,249 @@ public class S3LogStorageTest {
     Map<String, java.util.List<String>> pending =
         (Map<String, java.util.List<String>>) getPrivateField(s3LogStorage, "pendingFlush");
     assertEquals(1, pending.get(testPipelineFQN + "/" + testRunId).size());
+  }
+
+  // ============================================================
+  // Server-side hardening: executor split, throwable guard, metrics.
+  // Each verifies a guarantee the diff was made to provide.
+  // ============================================================
+
+  @Test
+  void testPartialFlushAndAbandonedCleanupExecutorsAreSeparate() throws Exception {
+    Object partial = getPrivateField(s3LogStorage, "partialFlushExecutor");
+    Object cleanup = getPrivateField(s3LogStorage, "abandonedCleanupExecutor");
+    assertNotNull(partial, "partial flush executor must exist");
+    assertNotNull(cleanup, "abandoned cleanup executor must exist");
+    assertFalse(
+        partial == cleanup,
+        "partial-flush and abandoned-cleanup MUST be distinct executors so a "
+            + "stuck cleanup task cannot starve partial.txt writes");
+  }
+
+  @Test
+  void testSafeScheduledTaskSwallowsThrowableSoSchedulerKeepsRunning() throws Exception {
+    java.lang.reflect.Method safe =
+        S3LogStorage.class.getDeclaredMethod("safeScheduledTask", String.class, Runnable.class);
+    safe.setAccessible(true);
+
+    final boolean[] ran = {false};
+    Runnable thrower =
+        () -> {
+          ran[0] = true;
+          throw new RuntimeException("boom - must not escape the scheduler boundary");
+        };
+
+    Runnable wrapped = (Runnable) safe.invoke(s3LogStorage, "test-task", thrower);
+
+    // run() must complete normally - propagating an exception out of a
+    // scheduled task is what makes ScheduledExecutorService silently
+    // stop re-running the task, which is the failure mode this guards.
+    assertDoesNotThrow(wrapped::run, "safeScheduledTask must NOT propagate throwables");
+    assertTrue(ran[0], "the inner runnable must have actually run");
+
+    // And a second invocation must also succeed - proves the wrapper
+    // is reusable and didn't get poisoned by the first failure.
+    assertDoesNotThrow(wrapped::run);
+  }
+
+  @Test
+  void testWritePartialLogsContinuesEvenIfOneStreamFails() throws Exception {
+    // Two active streams. The first one's flush will throw at the lock-acquire
+    // boundary by mocking S3 getObject to throw. The second must still get
+    // flushed - failure of stream A must not poison the loop for stream B.
+    String runIdA = UUID.randomUUID().toString();
+    String runIdB = UUID.randomUUID().toString();
+    String streamA = testPipelineFQN + "/" + runIdA;
+    String streamB = testPipelineFQN + "/" + runIdB;
+
+    mockAsyncPutObject();
+    s3LogStorage.appendLogs(testPipelineFQN, UUID.fromString(runIdA), "from-A\n");
+    s3LogStorage.appendLogs(testPipelineFQN, UUID.fromString(runIdB), "from-B\n");
+
+    String partialKeyA =
+        testPrefix
+            + "/"
+            + testPipelineFQN.replaceAll("[^a-zA-Z0-9_-]", "_")
+            + "/"
+            + runIdA
+            + "/partial.txt";
+    String partialKeyB =
+        testPrefix
+            + "/"
+            + testPipelineFQN.replaceAll("[^a-zA-Z0-9_-]", "_")
+            + "/"
+            + runIdB
+            + "/partial.txt";
+
+    // Stream A: probe throws - its flush will be marked failed.
+    when(mockS3Client.getObject(
+            argThat((GetObjectRequest req) -> req != null && partialKeyA.equals(req.key()))))
+        .thenThrow(new RuntimeException("simulated S3 failure for stream A"));
+    // Stream B: probe returns no existing partial.txt, succeeds.
+    when(mockS3Client.getObject(
+            argThat((GetObjectRequest req) -> req != null && partialKeyB.equals(req.key()))))
+        .thenThrow(NoSuchKeyException.builder().build());
+    when(mockS3Client.putObject(
+            any(PutObjectRequest.class), any(software.amazon.awssdk.core.sync.RequestBody.class)))
+        .thenReturn(PutObjectResponse.builder().build());
+
+    // Direct call to the scheduled body - verifies the loop's per-stream
+    // exception handling, NOT the executor.
+    java.lang.reflect.Method writePartial =
+        S3LogStorage.class.getDeclaredMethod("writePartialLogs");
+    writePartial.setAccessible(true);
+    assertDoesNotThrow(() -> writePartial.invoke(s3LogStorage));
+
+    // Stream B's PUT must have happened despite A's failure.
+    org.mockito.ArgumentCaptor<PutObjectRequest> reqCap =
+        org.mockito.ArgumentCaptor.forClass(PutObjectRequest.class);
+    verify(mockS3Client, atLeastOnce())
+        .putObject(reqCap.capture(), any(software.amazon.awssdk.core.sync.RequestBody.class));
+    boolean sawBPut = reqCap.getAllValues().stream().anyMatch(r -> partialKeyB.equals(r.key()));
+    assertTrue(sawBPut, "stream B must have been flushed even though stream A failed");
+  }
+
+  @Test
+  void testWritePartialLogsUpdatesPendingMetricsAndHeartbeat() throws Exception {
+    io.micrometer.core.instrument.simple.SimpleMeterRegistry registry =
+        new io.micrometer.core.instrument.simple.SimpleMeterRegistry();
+    org.openmetadata.service.monitoring.StreamableLogsMetrics testMetrics =
+        new org.openmetadata.service.monitoring.StreamableLogsMetrics(registry);
+
+    // Inject the metrics into the handler.
+    Field metricsField = S3LogStorage.class.getDeclaredField("metrics");
+    metricsField.setAccessible(true);
+    metricsField.set(s3LogStorage, testMetrics);
+
+    long beforeHeartbeat = testMetrics.getPartialFlushHeartbeat();
+    mockAsyncPutObject();
+    s3LogStorage.appendLogs(testPipelineFQN, testRunId, "alpha\nbeta\ngamma\n");
+
+    java.lang.reflect.Method writePartial =
+        S3LogStorage.class.getDeclaredMethod("writePartialLogs");
+    writePartial.setAccessible(true);
+    writePartial.invoke(s3LogStorage);
+
+    // Heartbeat MUST advance on every tick regardless of S3 outcome.
+    assertTrue(
+        testMetrics.getPartialFlushHeartbeat() > beforeHeartbeat,
+        "partial flush heartbeat must advance on every tick");
+    // pendingStreamsCount reflects the single active stream we just pushed to.
+    assertEquals(1, testMetrics.getPendingStreamsCount());
+  }
+
+  @Test
+  void testFlushSuccessUpdatesLastPartialFlushTimestamp() throws Exception {
+    io.micrometer.core.instrument.simple.SimpleMeterRegistry registry =
+        new io.micrometer.core.instrument.simple.SimpleMeterRegistry();
+    org.openmetadata.service.monitoring.StreamableLogsMetrics testMetrics =
+        new org.openmetadata.service.monitoring.StreamableLogsMetrics(registry);
+    Field metricsField = S3LogStorage.class.getDeclaredField("metrics");
+    metricsField.setAccessible(true);
+    metricsField.set(s3LogStorage, testMetrics);
+
+    String streamKey = testPipelineFQN + "/" + testRunId;
+    String partialKey =
+        testPrefix
+            + "/"
+            + testPipelineFQN.replaceAll("[^a-zA-Z0-9_-]", "_")
+            + "/"
+            + testRunId
+            + "/partial.txt";
+
+    // First flush from empty - succeeds.
+    when(mockS3Client.getObject(
+            argThat((GetObjectRequest req) -> req != null && partialKey.equals(req.key()))))
+        .thenThrow(NoSuchKeyException.builder().build());
+    when(mockS3Client.putObject(
+            any(PutObjectRequest.class), any(software.amazon.awssdk.core.sync.RequestBody.class)))
+        .thenReturn(PutObjectResponse.builder().build());
+    mockAsyncPutObject();
+
+    long before = testMetrics.getLastPartialFlushTimestamp();
+    assertEquals(0L, before, "last flush ts starts at 0");
+
+    s3LogStorage.appendLogs(testPipelineFQN, testRunId, "x\ny\n");
+    java.lang.reflect.Method writeStream =
+        S3LogStorage.class.getDeclaredMethod("writePartialLogsForStream", String.class);
+    writeStream.setAccessible(true);
+    writeStream.invoke(s3LogStorage, streamKey);
+
+    assertTrue(
+        testMetrics.getLastPartialFlushTimestamp() > 0L,
+        "successful partial flush must update lastPartialFlushTimestamp");
+  }
+
+  @Test
+  void testFlushFailureIncrementsFailureCounter() throws Exception {
+    io.micrometer.core.instrument.simple.SimpleMeterRegistry registry =
+        new io.micrometer.core.instrument.simple.SimpleMeterRegistry();
+    org.openmetadata.service.monitoring.StreamableLogsMetrics testMetrics =
+        new org.openmetadata.service.monitoring.StreamableLogsMetrics(registry);
+    Field metricsField = S3LogStorage.class.getDeclaredField("metrics");
+    metricsField.setAccessible(true);
+    metricsField.set(s3LogStorage, testMetrics);
+
+    String partialKey =
+        testPrefix
+            + "/"
+            + testPipelineFQN.replaceAll("[^a-zA-Z0-9_-]", "_")
+            + "/"
+            + testRunId
+            + "/partial.txt";
+
+    // Make the probe throw so the flush fails.
+    when(mockS3Client.getObject(
+            argThat((GetObjectRequest req) -> req != null && partialKey.equals(req.key()))))
+        .thenThrow(new RuntimeException("simulated S3 outage"));
+
+    mockAsyncPutObject();
+    s3LogStorage.appendLogs(testPipelineFQN, testRunId, "z\n");
+
+    java.lang.reflect.Method writeStream =
+        S3LogStorage.class.getDeclaredMethod("writePartialLogsForStream", String.class);
+    writeStream.setAccessible(true);
+    writeStream.invoke(s3LogStorage, testPipelineFQN + "/" + testRunId);
+
+    assertTrue(
+        testMetrics.getFlushFailuresCount() >= 1,
+        "flush failure must increment om_streamable_logs_flush_failures_total");
+  }
+
+  @Test
+  void testWatermarkFlushSchedulesOnlyOnceWhileFlushAlreadyQueued() throws Exception {
+    ScheduledExecutorService executor = mock(ScheduledExecutorService.class);
+    Field executorField = S3LogStorage.class.getDeclaredField("partialFlushExecutor");
+    executorField.setAccessible(true);
+    executorField.set(s3LogStorage, executor);
+
+    Field watermarkField = S3LogStorage.class.getDeclaredField("earlyFlushWatermarkBytes");
+    watermarkField.setAccessible(true);
+    watermarkField.setLong(s3LogStorage, 1L);
+
+    mockAsyncPutObject();
+    s3LogStorage.appendLogs(testPipelineFQN, testRunId, "first\n");
+    s3LogStorage.appendLogs(testPipelineFQN, testRunId, "second\n");
+    s3LogStorage.appendLogs(testPipelineFQN, testRunId, "third\n");
+
+    verify(executor, times(1)).execute(any(Runnable.class));
+  }
+
+  @Test
+  void testCleanupHeartbeatUpdates() throws Exception {
+    io.micrometer.core.instrument.simple.SimpleMeterRegistry registry =
+        new io.micrometer.core.instrument.simple.SimpleMeterRegistry();
+    org.openmetadata.service.monitoring.StreamableLogsMetrics testMetrics =
+        new org.openmetadata.service.monitoring.StreamableLogsMetrics(registry);
+    Field metricsField = S3LogStorage.class.getDeclaredField("metrics");
+    metricsField.setAccessible(true);
+    metricsField.set(s3LogStorage, testMetrics);
+
+    long before = testMetrics.getAbandonedCleanupHeartbeat();
+    s3LogStorage.cleanupAbandonedStreams();
+    assertTrue(
+        testMetrics.getAbandonedCleanupHeartbeat() > before,
+        "abandoned-cleanup heartbeat must advance on each invocation");
   }
 
   private static Object getPrivateField(Object target, String name) throws Exception {

--- a/openmetadata-service/src/test/java/org/openmetadata/service/logstorage/S3LogStorageTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/logstorage/S3LogStorageTest.java
@@ -1221,21 +1221,13 @@ public class S3LogStorageTest {
     assertEquals(1, pending.get(testPipelineFQN + "/" + testRunId).size());
   }
 
-  // ============================================================
-  // Server-side hardening: executor split, throwable guard, metrics.
-  // Each verifies a guarantee the diff was made to provide.
-  // ============================================================
-
   @Test
   void testPartialFlushAndAbandonedCleanupExecutorsAreSeparate() throws Exception {
     Object partial = getPrivateField(s3LogStorage, "partialFlushExecutor");
     Object cleanup = getPrivateField(s3LogStorage, "abandonedCleanupExecutor");
-    assertNotNull(partial, "partial flush executor must exist");
-    assertNotNull(cleanup, "abandoned cleanup executor must exist");
-    assertFalse(
-        partial == cleanup,
-        "partial-flush and abandoned-cleanup MUST be distinct executors so a "
-            + "stuck cleanup task cannot starve partial.txt writes");
+    assertNotNull(partial);
+    assertNotNull(cleanup);
+    assertFalse(partial == cleanup, "executors must be distinct");
   }
 
   @Test
@@ -1248,27 +1240,18 @@ public class S3LogStorageTest {
     Runnable thrower =
         () -> {
           ran[0] = true;
-          throw new RuntimeException("boom - must not escape the scheduler boundary");
+          throw new RuntimeException("boom");
         };
 
     Runnable wrapped = (Runnable) safe.invoke(s3LogStorage, "test-task", thrower);
 
-    // run() must complete normally - propagating an exception out of a
-    // scheduled task is what makes ScheduledExecutorService silently
-    // stop re-running the task, which is the failure mode this guards.
-    assertDoesNotThrow(wrapped::run, "safeScheduledTask must NOT propagate throwables");
-    assertTrue(ran[0], "the inner runnable must have actually run");
-
-    // And a second invocation must also succeed - proves the wrapper
-    // is reusable and didn't get poisoned by the first failure.
+    assertDoesNotThrow(wrapped::run);
+    assertTrue(ran[0]);
     assertDoesNotThrow(wrapped::run);
   }
 
   @Test
   void testWritePartialLogsContinuesEvenIfOneStreamFails() throws Exception {
-    // Two active streams. The first one's flush will throw at the lock-acquire
-    // boundary by mocking S3 getObject to throw. The second must still get
-    // flushed - failure of stream A must not poison the loop for stream B.
     String runIdA = UUID.randomUUID().toString();
     String runIdB = UUID.randomUUID().toString();
     String streamA = testPipelineFQN + "/" + runIdA;
@@ -1328,7 +1311,6 @@ public class S3LogStorageTest {
     org.openmetadata.service.monitoring.StreamableLogsMetrics testMetrics =
         new org.openmetadata.service.monitoring.StreamableLogsMetrics(registry);
 
-    // Inject the metrics into the handler.
     Field metricsField = S3LogStorage.class.getDeclaredField("metrics");
     metricsField.setAccessible(true);
     metricsField.set(s3LogStorage, testMetrics);
@@ -1342,11 +1324,7 @@ public class S3LogStorageTest {
     writePartial.setAccessible(true);
     writePartial.invoke(s3LogStorage);
 
-    // Heartbeat MUST advance on every tick regardless of S3 outcome.
-    assertTrue(
-        testMetrics.getPartialFlushHeartbeat() > beforeHeartbeat,
-        "partial flush heartbeat must advance on every tick");
-    // pendingStreamsCount reflects the single active stream we just pushed to.
+    assertTrue(testMetrics.getPartialFlushHeartbeat() > beforeHeartbeat);
     assertEquals(1, testMetrics.getPendingStreamsCount());
   }
 
@@ -1369,7 +1347,6 @@ public class S3LogStorageTest {
             + testRunId
             + "/partial.txt";
 
-    // First flush from empty - succeeds.
     when(mockS3Client.getObject(
             argThat((GetObjectRequest req) -> req != null && partialKey.equals(req.key()))))
         .thenThrow(NoSuchKeyException.builder().build());
@@ -1378,8 +1355,7 @@ public class S3LogStorageTest {
         .thenReturn(PutObjectResponse.builder().build());
     mockAsyncPutObject();
 
-    long before = testMetrics.getLastPartialFlushTimestamp();
-    assertEquals(0L, before, "last flush ts starts at 0");
+    assertEquals(0L, testMetrics.getLastPartialFlushTimestamp());
 
     s3LogStorage.appendLogs(testPipelineFQN, testRunId, "x\ny\n");
     java.lang.reflect.Method writeStream =
@@ -1387,9 +1363,7 @@ public class S3LogStorageTest {
     writeStream.setAccessible(true);
     writeStream.invoke(s3LogStorage, streamKey);
 
-    assertTrue(
-        testMetrics.getLastPartialFlushTimestamp() > 0L,
-        "successful partial flush must update lastPartialFlushTimestamp");
+    assertTrue(testMetrics.getLastPartialFlushTimestamp() > 0L);
   }
 
   @Test
@@ -1410,7 +1384,6 @@ public class S3LogStorageTest {
             + testRunId
             + "/partial.txt";
 
-    // Make the probe throw so the flush fails.
     when(mockS3Client.getObject(
             argThat((GetObjectRequest req) -> req != null && partialKey.equals(req.key()))))
         .thenThrow(new RuntimeException("simulated S3 outage"));
@@ -1423,9 +1396,7 @@ public class S3LogStorageTest {
     writeStream.setAccessible(true);
     writeStream.invoke(s3LogStorage, testPipelineFQN + "/" + testRunId);
 
-    assertTrue(
-        testMetrics.getFlushFailuresCount() >= 1,
-        "flush failure must increment om_streamable_logs_flush_failures_total");
+    assertTrue(testMetrics.getFlushFailuresCount() >= 1);
   }
 
   @Test
@@ -1459,9 +1430,7 @@ public class S3LogStorageTest {
 
     long before = testMetrics.getAbandonedCleanupHeartbeat();
     s3LogStorage.cleanupAbandonedStreams();
-    assertTrue(
-        testMetrics.getAbandonedCleanupHeartbeat() > before,
-        "abandoned-cleanup heartbeat must advance on each invocation");
+    assertTrue(testMetrics.getAbandonedCleanupHeartbeat() > before);
   }
 
   private static Object getPrivateField(Object target, String name) throws Exception {


### PR DESCRIPTION
### Describe your changes:

Snowflake-InternalProd (and other high-volume connectors) were observed hanging on the Python logger after the queue saturated, and even after the recursion fix in #28160 the partial.txt file on S3 stopped updating despite continuous successful POSTs. This PR makes streamable logging best-effort on both ends: the connector can never be blocked or stuck by the log shipper, and the server can never silently stop flushing partial.txt.

#
### Type of change:
- [x] Bug fix

#
### High-level design:

**Client (ingestion).** `StreamableLogHandler` is rewritten as a fire-and-forget pipeline. `emit()` is a straight-line `format → put_nowait → return`; on overflow it increments a counter and drops (no more synchronous stderr fallback per record). A daemon drainer batches the buffer and hands batches to a single daemon sender via a bounded `send_queue`; the sender does the HTTP POST via a dedicated quiet path (`REST.post_best_effort`) that bypasses the retry loop, the connection-error second-try, and all logging through `ometa_logger` (the feedback loop that was making failed log uploads queue more log records). A thread-local `_shipping_state.shipping` flag is a belt-and-suspenders guard against any future logging-from-shipping bug. The handler owns its own `REST` instance, so the `requests.Session` / connection pool / cookie jar are isolated from normal ingestion API traffic but share `ClientConfig` so token refreshes flow through. `close()` returns immediately — it enqueues a `_CLOSE_MARKER` behind already-queued batches so `/close` cannot overtake an in-flight log POST.

**Server.** The single `s3-log-cleanup` `ScheduledExecutorService` is split into `s3-log-partial-flush` and `s3-log-abandoned-cleanup`. A stuck or slow abandoned-cleanup task can no longer starve the partial-flush schedule, which is the path that actually makes logs visible on S3. Every scheduled task is wrapped with `safeScheduledTask(name, runnable)` that catches `Throwable` so a single tick that throws cannot silently de-schedule the executor for the JVM lifetime. `StreamableLogsMetrics` gets six new observability signals (`lastPartialFlushTimestamp`, `partialFlushHeartbeat`, `abandonedCleanupHeartbeat`, `pendingStreamsCount`, `pendingFlushBytes`, `pendingFlushLines`, `flushFailuresCounter`) wired into `writePartialLogs`, `writePartialLogsForStreamLocked`, `cleanupAbandonedStreams`, and `recordFlushFailure` so an operator can answer 'is the executor alive AND is it making progress' from metrics alone.

Backward compatibility: `REST._request` / `REST.post` gain `timeout=` and `retries=` kwargs defaulting to `None`, which preserves the original behavior bit-for-bit for every existing caller.

#
### Tests:

#### Use cases covered
- High-volume connector (Snowflake metadata) generates logs faster than the server accepts them: producer thread never blocks, no stuck pod.
- Server log endpoint is slow / dead / returns 504: no retry sleep on sender thread, no thread accumulation, batches are dropped after the bounded send queue saturates.
- Pod shutdown while a log POST is in flight: `close()` returns under 100ms; `/close` waits behind the in-flight batch in the sender queue, then fires.
- Server-side partial-flush executor: a Throwable from one tick does not de-schedule the executor; a stuck abandoned-cleanup task does not delay partial.txt writes.
- Metrics: operators can detect 'POSTs land but partial.txt does not update' from `last_partial_flush_ts_ms` and the heartbeat gauges, without reading server logs.

#### Unit tests
- `ingestion/tests/unit/utils/test_streamable_logger.py` — 35 tests across emit-non-blocking, recursion guard, sender saturation, daemon threads, isolated client, no-wait close, close ordering, mixin quiet path, REST quiet path, PR #28160 regression
- `openmetadata-service/src/test/java/org/openmetadata/service/logstorage/S3LogStorageTest.java` — 46 tests, new ones cover executor split, `safeScheduledTask` Throwable absorption, per-stream failure does not poison the loop, partial-flush updates pending metrics + heartbeat, success updates `lastPartialFlushTimestamp`, failure increments `flushFailuresCounter`, abandoned-cleanup updates its heartbeat.

#### Backend integration tests
- `openmetadata-integration-tests/.../IngestionPipelineLogStreamingResourceIT.java` — added `testLateLogsAfterCloseDoNotClobberFinalLogs` exercising the late-POST-after-close race.

#### Manual testing performed
1. Ran `python -m pytest ingestion/tests/unit/utils/test_streamable_logger.py ingestion/tests/unit/metadata/ingestion/ometa/test_rest_client_headers.py ingestion/tests/unit/metadata/ingestion/ometa/test_task_announcement_feed_mixins.py` — 57/57 pass; existing REST/mixin tests pass unmodified, proving no behavior change for non-log API calls.
2. Ran `mvn -pl openmetadata-service test -Dtest=S3LogStorageTest` — 46/46 pass.
3. Ran a stress reproduction (`/tmp/test_fire_and_forget.py`) with a server stubbed to take 2s per POST and 1000 logs pumped at line-rate: producer-side pump completed in 8ms; no log loss when buffer was sized for the burst; verified `dropped_overflow` counter increments cleanly on undersized buffers; verified `dropped_saturated` increments when senders are wedged.

#
### UI screen recording / screenshots:

Not applicable.

#
### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have added tests (unit / integration as applicable) and listed them above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

----
## Summary by Gitar

- **Fixed concurrency bugs:**
  - Prevented token refresh race in `StreamableLogHandler` by removing `_auth_token` calls from `_build_request_headers`.
  - Fixed `close()` ordering in `StreamableLogHandler` to ensure `_CLOSE_MARKER` is enqueued before triggering the stop event.
- **Refined observability:**
  - Added specific counters `dropped_after_close` and `dropped_format_error` to `StreamableLogHandler` to better track distinct log emission failures.
- **Refined test coverage:**
  - Added regression tests in `test_streamable_logger.py` for token refresh atomicity, sender exit race conditions, and error counter accuracy.

<sub>This will update automatically on new commits.</sub>