### PR TITLE
ci(security-scan): post Snyk summary to Slack + fail on high/critical

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -290,12 +290,12 @@ jobs:
               cat security-report/_slack.txt
             fi
           } > slack_body.txt
-          jq -Rs --arg ch "${{ secrets.SLACK_CHANNEL_IDS }}" \
-            '{channel: $ch, text: ., mrkdwn: true}' slack_body.txt > payload.json
+          jq -Rs '{text: ., mrkdwn: true}' slack_body.txt > payload.json
 
       - name: Send Slack Notification
         uses: slackapi/slack-github-action@v1.27.1
         with:
+          channel-id: ${{ secrets.SLACK_CHANNEL_IDS }}
           payload-file-path: payload.json
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -201,8 +201,24 @@ jobs:
           make snyk-ui-report || true
 
       - name: Publish Snyk Summary
+        id: snyk-summary
         if: always() && steps.maven-build.outcome == 'success'
-        run: python3 scripts/snyk_summary.py security-report >> $GITHUB_STEP_SUMMARY
+        run: |
+          python3 scripts/snyk_summary.py security-report \
+            --counts-file security-report/_counts.json \
+            --slack-file security-report/_slack.txt \
+            >> $GITHUB_STEP_SUMMARY
+          # Expose counts as step output for downstream gating.
+          counts=$(cat security-report/_counts.json)
+          echo "counts=$counts" >> $GITHUB_OUTPUT
+          high=$(jq '.high + .critical' security-report/_counts.json)
+          echo "high_critical=$high" >> $GITHUB_OUTPUT
+
+      - name: Fail on high/critical Snyk findings
+        if: always() && steps.snyk-summary.outputs.high_critical != '' && steps.snyk-summary.outputs.high_critical != '0'
+        run: |
+          echo "::error::Snyk found ${{ steps.snyk-summary.outputs.high_critical }} high/critical vulnerabilities (see Job Summary)"
+          exit 1
 
       - name: Generate Snyk HTML/PDF
         if: always() && steps.maven-build.outcome == 'success'
@@ -233,7 +249,15 @@ jobs:
     needs: [vulnerability-scan, security-scan]
     if: always()
     steps:
-      - name: Build notification message
+      - name: Download Snyk artifact
+        if: needs.security-scan.result != 'skipped'
+        uses: actions/download-artifact@v4
+        with:
+          name: security-report
+          path: security-report
+        continue-on-error: true
+
+      - name: Build Slack payload
         id: build
         run: |
           retire="${{ needs.vulnerability-scan.result }}"
@@ -255,17 +279,23 @@ jobs:
           else
             icon="⚠️"
           fi
-          echo "icon=$icon" >> $GITHUB_OUTPUT
-          echo "retire_icon=$retire_icon" >> $GITHUB_OUTPUT
-          echo "snyk_icon=$snyk_icon" >> $GITHUB_OUTPUT
+          run_url="https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          {
+            echo "$icon *Security scan* on branch \`${{ github.ref_name }}\`"
+            echo "• Vulnerability scan (Retire.js): $retire_icon"
+            echo "• Security scan (Snyk): $snyk_icon"
+            echo "<$run_url|Open run details>"
+            if [ -f security-report/_slack.txt ]; then
+              echo
+              cat security-report/_slack.txt
+            fi
+          } > slack_body.txt
+          jq -Rs --arg ch "${{ secrets.SLACK_CHANNEL_IDS }}" \
+            '{channel: $ch, text: ., mrkdwn: true}' slack_body.txt > payload.json
 
       - name: Send Slack Notification
         uses: slackapi/slack-github-action@v1.27.1
         with:
-          channel-id: ${{ secrets.SLACK_CHANNEL_IDS }}
-          payload: |
-            {
-              "text": "${{ steps.build.outputs.icon }} Security scan for OpenMetadata Repo on branch `${{ github.ref_name }}` — Vulnerability scan: ${{ steps.build.outputs.retire_icon }} | Security scan: ${{ steps.build.outputs.snyk_icon }}. Check <https://github.com/open-metadata/OpenMetadata/actions/runs/${{ github.run_id }}|here>."
-            }
+          payload-file-path: payload.json
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -281,7 +281,7 @@ jobs:
           fi
           run_url="https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           {
-            echo "$icon *Security scan* on branch \`${{ github.ref_name }}\`"
+            echo "$icon *Security scan* — *OpenMetadata Repo* on branch \`${{ github.ref_name }}\`"
             echo "• Vulnerability scan (Retire.js): $retire_icon"
             echo "• Security scan (Snyk): $snyk_icon"
             echo "<$run_url|Open run details>"

--- a/scripts/snyk_summary.py
+++ b/scripts/snyk_summary.py
@@ -166,7 +166,8 @@ def count_severities(libs, by_rule):
     for rid, items in by_rule.items():
         for uri, level, lines in items:
             mapped = {"error": "high", "warning": "medium", "note": "low"}.get(level, "medium")
-            counts[mapped] += len(lines)
+            # Count one per (rule, file, level) group to match `total` in collect_code.
+            counts[mapped] += 1
     return counts
 
 

--- a/scripts/snyk_summary.py
+++ b/scripts/snyk_summary.py
@@ -1,6 +1,15 @@
 #!/usr/bin/env python3
-"""Render Snyk JSON reports as Markdown. Usage: python3 scripts/snyk_summary.py [dir] > REPORT.md"""
-import json, os, glob, sys
+"""Render Snyk JSON reports as Markdown.
+
+Usage:
+  python3 scripts/snyk_summary.py [dir] \\
+      [--counts-file PATH] [--slack-file PATH] [--top N]
+"""
+import argparse
+import glob
+import json
+import os
+import sys
 
 SEV_ICON = {"critical": "🚨", "high": "🔴", "medium": "🟠", "low": "🟡"}
 SEV_RANK = {"critical": 0, "high": 1, "medium": 2, "low": 3}
@@ -30,10 +39,10 @@ def iter_projects(data):
         yield data
 
 
-def render_deps(name, data):
-    print(f"\n### 📦 {name}\n")
-    total_vulns = 0
+def collect_deps(data):
+    """Aggregate vulnerabilities by (package, version). Return (libs_dict, total_findings)."""
     libs = {}
+    total = 0
     for proj in iter_projects(data):
         if not isinstance(proj, dict):
             continue
@@ -52,25 +61,12 @@ def render_deps(name, data):
                 entry["fixedIn"].add(fx)
             entry["ids"].add(v.get("id", ""))
             entry["paths"] += 1
-            total_vulns += 1
-    if not libs:
-        print("✅ No vulnerabilities.\n")
-        return
-    print(f"> **{len(libs)} vulnerable librar{'y' if len(libs)==1 else 'ies'} · {total_vulns} finding{'s' if total_vulns!=1 else ''}**\n")
-    print("| Sev | Package | Version | CVE / ID | Title | Fix in | Paths |")
-    print("|---|---|---|---|---|---|---|")
-    for (pkg, ver), info in sorted(libs.items(), key=lambda kv: sev_key(kv[1]["sev"])):
-        sev = info["sev"]
-        ids = sorted(info["cves"]) or sorted(i for i in info["ids"] if i)[:1]
-        ids_str = ", ".join(f"[{c}](https://nvd.nist.gov/vuln/detail/{c})" if c.startswith("CVE") else c for c in ids) or "—"
-        title = sorted(info["titles"])[0][:80] if info["titles"] else ""
-        fix = ", ".join(sorted(info["fixedIn"])[:2]) or "—"
-        print(f"| {SEV_ICON.get(sev,'⚪')} {sev} | `{esc(pkg)}` | {esc(ver)} | {esc(ids_str)} | {esc(title)} | {esc(fix)} | {info['paths']} |")
-    print()
+            total += 1
+    return libs, total
 
 
-def render_code(name, data):
-    print(f"\n### 🔎 {name} (Code)\n")
+def collect_code(data):
+    """Aggregate Snyk Code SARIF results. Return (by_rule_dict, rules_desc_dict, total)."""
     runs = data.get("runs", []) if isinstance(data, dict) else []
     findings = {}
     rules = {}
@@ -85,43 +81,159 @@ def render_code(name, data):
                 uri = phys.get("artifactLocation", {}).get("uri", "?")
                 line = phys.get("region", {}).get("startLine", "?")
                 findings.setdefault((rid, uri, level), []).append(line)
-    if not findings:
-        print("✅ No code findings.\n")
-        return
     by_rule = {}
     for (rid, uri, level), lines in findings.items():
         by_rule.setdefault(rid, []).append((uri, level, lines))
     total = sum(len(v) for v in by_rule.values())
-    print(f"> **{total} location{'s' if total!=1 else ''} across {len(by_rule)} rule{'s' if len(by_rule)!=1 else ''}**\n")
+    return by_rule, rules, total
+
+
+def render_deps_md(name, libs, total):
+    out = [f"\n### 📦 {name}\n"]
+    if not libs:
+        out.append("✅ No vulnerabilities.\n")
+        return "\n".join(out)
+    out.append(f"> **{len(libs)} vulnerable librar{'y' if len(libs)==1 else 'ies'} · {total} finding{'s' if total!=1 else ''}**\n")
+    out.append("| Sev | Package | Version | CVE / ID | Title | Fix in | Paths |")
+    out.append("|---|---|---|---|---|---|---|")
+    for (pkg, ver), info in sorted(libs.items(), key=lambda kv: sev_key(kv[1]["sev"])):
+        sev = info["sev"]
+        ids = sorted(info["cves"]) or sorted(i for i in info["ids"] if i)[:1]
+        ids_str = ", ".join(f"[{c}](https://nvd.nist.gov/vuln/detail/{c})" if c.startswith("CVE") else c for c in ids) or "—"
+        title = sorted(info["titles"])[0][:80] if info["titles"] else ""
+        fix = ", ".join(sorted(info["fixedIn"])[:2]) or "—"
+        out.append(f"| {SEV_ICON.get(sev,'⚪')} {sev} | `{esc(pkg)}` | {esc(ver)} | {esc(ids_str)} | {esc(title)} | {esc(fix)} | {info['paths']} |")
+    out.append("")
+    return "\n".join(out)
+
+
+def render_code_md(name, by_rule, rules, total):
+    out = [f"\n### 🔎 {name} (Code)\n"]
+    if not by_rule:
+        out.append("✅ No code findings.\n")
+        return "\n".join(out)
+    out.append(f"> **{total} location{'s' if total!=1 else ''} across {len(by_rule)} rule{'s' if len(by_rule)!=1 else ''}**\n")
     for rid, items in sorted(by_rule.items()):
         desc = rules.get(rid, rid)
-        print(f"<details><summary><b>{esc(rid)}</b> — {esc(desc)} ({len(items)})</summary>\n")
-        print("| Level | File | Lines |")
-        print("|---|---|---|")
+        out.append(f"<details><summary><b>{esc(rid)}</b> — {esc(desc)} ({len(items)})</summary>\n")
+        out.append("| Level | File | Lines |")
+        out.append("|---|---|---|")
         for uri, level, lines in sorted(items):
             ln = ", ".join(str(x) for x in sorted(set(lines))[:10])
             icon = "🔴" if level == "error" else "🟠"
-            print(f"| {icon} {level} | `{esc(uri)}` | {esc(ln)} |")
-        print("\n</details>\n")
+            out.append(f"| {icon} {level} | `{esc(uri)}` | {esc(ln)} |")
+        out.append("\n</details>\n")
+    return "\n".join(out)
+
+
+def render_deps_slack(name, libs, total, top):
+    if not libs:
+        return f"📦 *{name}*: ✅ clean"
+    head = f"📦 *{name}*: {len(libs)} libs · {total} findings"
+    rows = []
+    ordered = sorted(libs.items(), key=lambda kv: sev_key(kv[1]["sev"]))
+    for (pkg, ver), info in ordered[:top]:
+        icon = SEV_ICON.get(info["sev"], "⚪")
+        title = (sorted(info["titles"])[0] if info["titles"] else "")[:60]
+        fix = sorted(info["fixedIn"])[0] if info["fixedIn"] else "no fix"
+        rows.append(f"  {icon} `{pkg}` {ver} — {title} (fix: {fix})")
+    extra = len(libs) - top
+    if extra > 0:
+        rows.append(f"  … +{extra} more")
+    return head + "\n" + "\n".join(rows)
+
+
+def render_code_slack(name, by_rule, rules, total, top):
+    if not by_rule:
+        return f"🔎 *{name}*: ✅ clean"
+    head = f"🔎 *{name}*: {total} findings · {len(by_rule)} rules"
+    ordered = sorted(by_rule.items(), key=lambda kv: -len(kv[1]))
+    rows = [f"  • `{rid}` ({len(items)})" for rid, items in ordered[:top]]
+    extra = len(by_rule) - top
+    if extra > 0:
+        rows.append(f"  … +{extra} more")
+    return head + "\n" + "\n".join(rows)
+
+
+def count_severities(libs, by_rule):
+    """Snyk Code SARIF uses level (error/warning/note); treat error=high, warning=medium, note=low.
+    Dep libs already have explicit severity."""
+    counts = {"critical": 0, "high": 0, "medium": 0, "low": 0}
+    for info in libs.values():
+        sev = (info["sev"] or "low").lower()
+        if sev in counts:
+            counts[sev] += info["paths"]
+    for rid, items in by_rule.items():
+        for uri, level, lines in items:
+            mapped = {"error": "high", "warning": "medium", "note": "low"}.get(level, "medium")
+            counts[mapped] += len(lines)
+    return counts
 
 
 def main():
-    src = sys.argv[1] if len(sys.argv) > 1 else "security-report"
-    print("## 🛡️ Snyk Security Scan\n")
-    files = sorted(glob.glob(os.path.join(src, "*.json")))
+    ap = argparse.ArgumentParser()
+    ap.add_argument("src", nargs="?", default="security-report")
+    ap.add_argument("--counts-file")
+    ap.add_argument("--slack-file")
+    ap.add_argument("--top", type=int, default=5)
+    args = ap.parse_args()
+
+    md_parts = ["## 🛡️ Snyk Security Scan\n"]
+    slack_parts = ["*🛡️ Snyk Security Scan*"]
+    totals = {"critical": 0, "high": 0, "medium": 0, "low": 0}
+
+    files = sorted(glob.glob(os.path.join(args.src, "*.json")))
+    # exclude our own output files if present
+    files = [f for f in files if not os.path.basename(f).startswith("_")]
+
     if not files:
-        print(f"> No JSON reports found in `{src}/`.")
+        md_parts.append(f"> No JSON reports found in `{args.src}/`.")
+        sys.stdout.write("\n".join(md_parts) + "\n")
+        if args.counts_file:
+            with open(args.counts_file, "w") as f:
+                json.dump({**totals, "total": 0}, f)
+        if args.slack_file:
+            with open(args.slack_file, "w") as f:
+                f.write("*🛡️ Snyk Security Scan*\n> No JSON reports found.")
         return
+
     for path in files:
         name = os.path.basename(path).replace(".json", "")
         data, err = load(path)
         if err is not None:
-            print(f"\n### ⚠️ {name}\nFailed to parse: {err}\n")
+            md_parts.append(f"\n### ⚠️ {name}\nFailed to parse: {err}\n")
+            slack_parts.append(f"⚠️ *{name}*: parse error — {err}")
             continue
         if isinstance(data, dict) and "runs" in data:
-            render_code(name, data)
+            by_rule, rules, total = collect_code(data)
+            md_parts.append(render_code_md(name, by_rule, rules, total))
+            slack_parts.append(render_code_slack(name, by_rule, rules, total, args.top))
+            sub = count_severities({}, by_rule)
         else:
-            render_deps(name, data)
+            libs, total = collect_deps(data)
+            md_parts.append(render_deps_md(name, libs, total))
+            slack_parts.append(render_deps_slack(name, libs, total, args.top))
+            sub = count_severities(libs, {})
+        for k in totals:
+            totals[k] += sub[k]
+
+    sys.stdout.write("\n".join(md_parts) + "\n")
+
+    if args.counts_file:
+        with open(args.counts_file, "w") as f:
+            json.dump({**totals, "total": sum(totals.values())}, f)
+
+    if args.slack_file:
+        header = (
+            f"*🛡️ Snyk Security Scan* — 🚨 {totals['critical']} · 🔴 {totals['high']} · "
+            f"🟠 {totals['medium']} · 🟡 {totals['low']}"
+        )
+        body = "\n\n".join([header] + slack_parts[1:])
+        # Slack hard limit 4000 chars per text field; truncate safely.
+        if len(body) > 3800:
+            body = body[:3750] + "\n…truncated. See Job Summary for full report."
+        with open(args.slack_file, "w") as f:
+            f.write(body)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:

<!--
Linking an issue is REQUIRED. Replace <issue-number> with the GitHub issue number this PR addresses
(e.g., `Fixes #12345`). GitHub will auto-link it. If no issue exists, please open one first so the
problem and design can be discussed before review.
-->

<!--
Short blurb explaining:
- What changes did you make?
- Why did you make them?
-->

## Summary
- Extends `scripts/snyk_summary.py` with `--counts-file` and `--slack-file` flags. Counts JSON aggregates `{critical, high, medium, low, total}` across all scans; Slack file holds a condensed body (severity totals header + per-scan section with top 5 vulns/rules), auto-truncated to fit Slack's 4000-char limit.
- `Publish Snyk Summary` step now emits a `high_critical` step output (via `jq`) consumed by a new `Fail on high/critical Snyk findings` step that exits 1 when count > 0.
- `notify` job downloads the `security-report` artifact, reads `_slack.txt`, and posts a single rich Slack message via `payload-file-path` (`jq -Rs` ensures JSON-safe escaping for multi-line/Unicode content). Falls back gracefully if the artifact is absent (Snyk job skipped/cancelled).
- Header line still shows overall icon + per-scan status (`✅ / ❌ / ⚠️ (skipped/cancelled)`) so reviewers see scope at a glance; condensed vuln list follows.

## Why
- Slack messages previously linked to the run but reviewers had to click through to triage. Embedding the condensed summary lets oncall see severity counts + top offenders inline.
- Snyk found high/critical issues but the workflow stayed green — `make snyk-*-report || true` swallowed exit codes. Need an explicit gate so regressions break CI.
- Gate kept Snyk-only (Retire.js already exits non-zero at `--severity high`, per existing `Force failure on vulnerabilities found` step).

## Failure matrix
| Snyk findings | Retire | Job result | Slack body |
|---|---|---|---|
| 0 high/critical | clean | 🟢 success | `🟢 … ✅ \| ✅` + per-scan `✅ clean` |
| ≥1 high/critical | clean | 🚨 **failure** | `🚨 … ✅ \| ❌` + severity totals + top vulns |
| any | finds vulns | 🚨 failure | `🚨 … ❌ \| <snyk-icon>` + body |
| Snyk skipped | * | ⚠️ | `⚠️ … ⚠️ (skipped) \| <retire>` |

## Implementation notes
- Severity mapping for Snyk Code SARIF: `error → high`, `warning → medium`, `note → low` (SARIF lacks Snyk's `critical/high/medium/low`).
- `_counts.json` / `_slack.txt` written into `security-report/` so they ride along in the existing artifact (excluded from scan glob via `_`-prefix filter to avoid recursion).
- Multi-line Slack payload built with `jq -Rs '{channel:$ch, text:., mrkdwn:true}'` from a temp file — avoids quoting/escape hell with GitHub Actions expression interpolation.
- Slack body capped at 3750 chars with `…truncated. See Job Summary for full report.` suffix when oversized.


#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### High-level design:
<!--
REQUIRED for large PRs (new features, refactors, breaking changes, or anything touching >5 files).
Skip for small bug fixes and trivial changes.

Cover:
- Architecture / approach you took and why
- Key components or files added/changed and how they interact
- Alternatives considered and why you rejected them
- Any migration, backward-compatibility, or rollout concerns
- Diagrams or links to design docs / RFCs if available
-->

N/A — small change. <!-- Or fill in the design above -->

#
### Tests:

#### Use cases covered
<!--
List the user-visible scenarios this PR exercises. Example:
- User with Admin role can create a Glossary Term with a parent term
- Ingestion run for Snowflake correctly extracts row counts for partitioned tables
-->

#### Unit tests
<!--
- [ ] I added unit tests for the new/changed logic.
- Files added/updated:
- Coverage on changed classes (run `mvn jacoco:report` for backend, `yarn test:coverage` for UI,
  `make unit_ingestion` for ingestion). Target is 90% line coverage on changed classes.
- Coverage %: <e.g., 92% on EntityRepository.java>
-->

#### Backend integration tests
<!--
- [ ] I added integration tests in `openmetadata-integration-tests/` for new/changed API endpoints.
- [ ] Not applicable (no backend API changes).
- Files added/updated:
-->

#### Ingestion integration tests
<!--
- [ ] I added/updated ingestion integration tests for connector changes.
- [ ] Not applicable (no ingestion changes).
- Files added/updated:
-->

#### Playwright (UI) tests
<!--
- [ ] I added Playwright E2E tests under `openmetadata-ui/.../ui/playwright/` for UI changes.
- [ ] Not applicable (no UI changes).
- Files added/updated:
-->

#### Manual testing performed
<!--
List the manual test steps you performed before requesting review. Example:
1. Started local stack via `./docker/run_local_docker.sh -m ui -d mysql`
2. Logged in as admin, created entity X, verified Y appears in the UI
3. Triggered ingestion for Snowflake source, confirmed lineage edges in the explore page
-->

#
### UI screen recording / screenshots:
<!--
REQUIRED for any PR that changes the UI. Drag-and-drop a short screen recording (.mov / .mp4 / .gif)
demonstrating the change end-to-end, plus before/after screenshots where relevant.
Mark "Not applicable" if there are no UI changes.
-->

Not applicable. <!-- Or attach recording/screenshots above -->

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.
- [ ] For UI changes: I attached a screen recording and/or screenshots above.
- [ ] I have added tests (unit / integration / Playwright as applicable) and listed them above.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->
