### PR TITLE
Fixes #24294: support re-parenting a Container via PATCH

### DIFF
--- a/ingestion/src/metadata/sdk/entities/containers.py
+++ b/ingestion/src/metadata/sdk/entities/containers.py
@@ -2,12 +2,13 @@
 Containers entity SDK with fluent API
 """
 
-from typing import List, Type  # noqa: UP035
+from typing import Any, List, Optional, Type, cast  # noqa: UP035
 
 from metadata.generated.schema.api.data.createContainer import CreateContainerRequest
 from metadata.generated.schema.entity.data.container import Container
 from metadata.generated.schema.type.entityReference import EntityReference
 from metadata.sdk.entities.base import BaseEntity, EntityList
+from metadata.sdk.types import UuidLike
 
 
 class Containers(BaseEntity[Container, CreateContainerRequest]):
@@ -17,6 +18,54 @@ class Containers(BaseEntity[Container, CreateContainerRequest]):
     def entity_type(cls) -> Type[Container]:  # noqa: UP006
         """Return the Container entity type"""
         return Container
+
+    @classmethod
+    def set_parent(
+        cls,
+        container_id: UuidLike,
+        parent: EntityReference,
+    ) -> Container:
+        """
+        Re-parent an existing container via PATCH (issue #24294).
+
+        The backend cascades the FQN change to every descendant container, nested
+        column FQN, tag-usage row, entity-link, policy condition, and search-index
+        document. The new ``parent`` must be a Container under the same
+        StorageService — cross-service moves are rejected with HTTP 400.
+        """
+        return cls._patch_parent(container_id, parent)
+
+    @classmethod
+    def clear_parent(cls, container_id: UuidLike) -> Container:
+        """
+        Promote the container to be a direct child of its StorageService by
+        clearing its ``parent`` field via PATCH.
+        """
+        return cls._patch_parent(container_id, None)
+
+    @classmethod
+    def _patch_parent(
+        cls,
+        container_id: UuidLike,
+        parent: Optional[EntityReference],  # noqa: UP045
+    ) -> Container:
+        client = cls._get_client()
+        current = client.get_by_id(
+            entity=Container,
+            entity_id=cls._stringify_identifier(container_id),
+            fields=["parent"],
+        )
+
+        working = getattr(current, "model_copy", None)
+        working = working(deep=True) if callable(working) else current
+        setattr(working, "parent", parent)  # noqa: B010
+
+        updated = cast(Any, client).patch(  # noqa: TC006
+            entity=Container,
+            source=current,
+            destination=working,
+        )
+        return cls._coerce_entity(updated)
 
     @classmethod
     def list_children(

--- a/ingestion/tests/unit/sdk/test_container_entity.py
+++ b/ingestion/tests/unit/sdk/test_container_entity.py
@@ -283,6 +283,76 @@ class TestContainerEntity(unittest.TestCase):
 
         self.assertIn("Container not found", str(context.exception))
 
+    def test_set_parent_calls_patch_with_new_parent(self):
+        """Issue #24294 — re-parent via PATCH builds a source/destination diff."""
+        new_parent_id = UUID("750e8400-e29b-41d4-a716-446655440003")
+        new_parent_ref = EntityReference(
+            id=new_parent_id,
+            type="container",
+            name="new-bucket",
+            fullyQualifiedName="s3-prod.new-bucket",
+        )
+
+        current = MagicMock(spec=ContainerEntity)
+        current.id = UUID(self.container_id)
+        current.parent = EntityReference(
+            id=UUID("550e8400-e29b-41d4-a716-446655440000"),
+            type="container",
+            name="old-bucket",
+        )
+        working = MagicMock(spec=ContainerEntity)
+        working.id = current.id
+        working.parent = current.parent
+        current.model_copy = MagicMock(return_value=working)
+        self.mock_ometa.get_by_id.return_value = current
+
+        moved = MagicMock(spec=ContainerEntity)
+        moved.id = current.id
+        moved.parent = new_parent_ref
+        self.mock_ometa.patch.return_value = moved
+
+        result = Containers.set_parent(self.container_id, new_parent_ref)
+
+        self.assertIsNotNone(result.parent)
+        self.assertEqual(result.parent.id.root, new_parent_id)
+        self.mock_ometa.get_by_id.assert_called_once()
+        self.mock_ometa.patch.assert_called_once()
+
+        _, patch_kwargs = self.mock_ometa.patch.call_args
+        self.assertIs(patch_kwargs["entity"], ContainerEntity)
+        self.assertIs(patch_kwargs["source"], current)
+        destination = patch_kwargs["destination"]
+        self.assertEqual(destination.parent.id.root, new_parent_id)
+
+    def test_clear_parent_removes_parent(self):
+        """clear_parent promotes the container to be a direct child of its service."""
+        current = MagicMock(spec=ContainerEntity)
+        current.id = UUID(self.container_id)
+        current.parent = EntityReference(
+            id=UUID("550e8400-e29b-41d4-a716-446655440000"),
+            type="container",
+            name="old-bucket",
+        )
+        working = MagicMock(spec=ContainerEntity)
+        working.id = current.id
+        working.parent = current.parent
+        current.model_copy = MagicMock(return_value=working)
+        self.mock_ometa.get_by_id.return_value = current
+
+        promoted = MagicMock(spec=ContainerEntity)
+        promoted.id = current.id
+        promoted.parent = None
+        self.mock_ometa.patch.return_value = promoted
+
+        result = Containers.clear_parent(self.container_id)
+
+        self.assertIsNone(result.parent)
+        self.mock_ometa.patch.assert_called_once()
+
+        _, patch_kwargs = self.mock_ometa.patch.call_args
+        destination = patch_kwargs["destination"]
+        self.assertIsNone(destination.parent)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/ContainerResourceIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/ContainerResourceIT.java
@@ -2,6 +2,7 @@ package org.openmetadata.it.tests;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -2828,6 +2829,280 @@ public class ContainerResourceIT extends BaseEntityIT<Container, CreateContainer
     assertTrue(
         piiColumn.getTags().stream()
             .anyMatch(t -> t.getTagFQN().equals(shared.PII_SENSITIVE_TAG_LABEL.getTagFQN())));
+  }
+
+  // ===================================================================
+  // PATCH PARENT UPDATE (issue #24294)
+  // ===================================================================
+
+  private Container createUnderService(TestNamespace ns, StorageService service, String name) {
+    CreateContainer request = new CreateContainer();
+    request.setName(ns.prefix(name));
+    request.setService(service.getFullyQualifiedName());
+    return createEntity(request);
+  }
+
+  private Container createUnderParent(
+      TestNamespace ns, StorageService service, Container parent, String name) {
+    CreateContainer request = new CreateContainer();
+    request.setName(ns.prefix(name));
+    request.setService(service.getFullyQualifiedName());
+    request.setParent(
+        new EntityReference()
+            .withId(parent.getId())
+            .withType("container")
+            .withFullyQualifiedName(parent.getFullyQualifiedName()));
+    return createEntity(request);
+  }
+
+  private static EntityReference parentRefOf(Container parent) {
+    return new EntityReference()
+        .withId(parent.getId())
+        .withType("container")
+        .withFullyQualifiedName(parent.getFullyQualifiedName());
+  }
+
+  @Test
+  void patch_containerParent_movesContainer_200(TestNamespace ns) {
+    StorageService service = StorageServiceTestFactory.createS3(ns);
+    Container parentA = createUnderService(ns, service, "moveA");
+    Container parentB = createUnderService(ns, service, "moveB");
+    Container child = createUnderParent(ns, service, parentA, "moveChild");
+
+    assertEquals(parentA.getId(), child.getParent().getId());
+    String oldFqn = child.getFullyQualifiedName();
+
+    child.setParent(parentRefOf(parentB));
+    Container moved = patchEntity(child.getId().toString(), child);
+
+    assertNotNull(moved.getParent());
+    assertEquals(parentB.getId(), moved.getParent().getId());
+    assertTrue(
+        moved.getFullyQualifiedName().startsWith(parentB.getFullyQualifiedName() + "."),
+        "child FQN should now nest under new parent " + parentB.getFullyQualifiedName());
+    assertNotEquals(oldFqn, moved.getFullyQualifiedName());
+
+    Container refetched = getEntityWithFields(moved.getId().toString(), "parent");
+    assertEquals(parentB.getId(), refetched.getParent().getId());
+  }
+
+  @Test
+  void patch_containerParent_preservesMetadata_200(TestNamespace ns) {
+    SharedEntities shared = SharedEntities.get();
+    StorageService service = StorageServiceTestFactory.createS3(ns);
+    Container parentA = createUnderService(ns, service, "metaA");
+    Container parentB = createUnderService(ns, service, "metaB");
+
+    CreateContainer childRequest = new CreateContainer();
+    childRequest.setName(ns.prefix("metaChild"));
+    childRequest.setService(service.getFullyQualifiedName());
+    childRequest.setParent(parentRefOf(parentA));
+    childRequest.setDescription("Keep me through the move");
+    childRequest.setTags(new ArrayList<>(List.of(shared.PII_SENSITIVE_TAG_LABEL)));
+    Container child = createEntity(childRequest);
+
+    Container loaded =
+        SdkClients.adminClient()
+            .containers()
+            .get(child.getId().toString(), "tags,description,parent");
+
+    loaded.setParent(parentRefOf(parentB));
+    Container moved = patchEntity(loaded.getId().toString(), loaded);
+
+    Container refetched =
+        SdkClients.adminClient()
+            .containers()
+            .get(moved.getId().toString(), "tags,description,parent");
+    assertEquals(parentB.getId(), refetched.getParent().getId());
+    assertEquals("Keep me through the move", refetched.getDescription());
+    assertNotNull(refetched.getTags());
+    assertTrue(
+        refetched.getTags().stream()
+            .anyMatch(t -> t.getTagFQN().equals(shared.PII_SENSITIVE_TAG_LABEL.getTagFQN())),
+        "PII tag must survive parent reassignment");
+  }
+
+  @Test
+  void patch_containerParent_cascadesFqnToChildren_200(TestNamespace ns) {
+    StorageService service = StorageServiceTestFactory.createS3(ns);
+    Container parentA = createUnderService(ns, service, "cascA");
+    Container parentB = createUnderService(ns, service, "cascB");
+    Container child = createUnderParent(ns, service, parentA, "cascChild");
+    Container grandchild = createUnderParent(ns, service, child, "cascGrandchild");
+
+    String oldGrandFqn = grandchild.getFullyQualifiedName();
+    assertTrue(oldGrandFqn.startsWith(parentA.getFullyQualifiedName() + "."));
+
+    child.setParent(parentRefOf(parentB));
+    Container moved = patchEntity(child.getId().toString(), child);
+
+    Container refetchedGrand = getEntity(grandchild.getId().toString());
+    assertNotNull(refetchedGrand);
+    assertTrue(
+        refetchedGrand.getFullyQualifiedName().startsWith(moved.getFullyQualifiedName() + "."),
+        "grandchild FQN should cascade under moved child: "
+            + refetchedGrand.getFullyQualifiedName());
+    assertNotEquals(oldGrandFqn, refetchedGrand.getFullyQualifiedName());
+  }
+
+  @Test
+  void patch_containerParent_cascadesToColumnFqns_200(TestNamespace ns) {
+    StorageService service = StorageServiceTestFactory.createS3(ns);
+    Container parentA = createUnderService(ns, service, "colA");
+    Container parentB = createUnderService(ns, service, "colB");
+
+    List<Column> columns =
+        Arrays.asList(
+            new Column().withName("colOne").withDataType(ColumnDataType.INT),
+            new Column().withName("colTwo").withDataType(ColumnDataType.STRING));
+    ContainerDataModel dataModel =
+        new ContainerDataModel().withIsPartitioned(false).withColumns(columns);
+
+    CreateContainer childRequest = new CreateContainer();
+    childRequest.setName(ns.prefix("colChild"));
+    childRequest.setService(service.getFullyQualifiedName());
+    childRequest.setParent(parentRefOf(parentA));
+    childRequest.setDataModel(dataModel);
+    Container child = createEntity(childRequest);
+
+    Container loaded =
+        SdkClients.adminClient().containers().get(child.getId().toString(), "dataModel,parent");
+    loaded.setParent(parentRefOf(parentB));
+    Container moved = patchEntity(loaded.getId().toString(), loaded);
+
+    Container refetched =
+        SdkClients.adminClient().containers().get(moved.getId().toString(), "dataModel,parent");
+    assertNotNull(refetched.getDataModel());
+    assertEquals(2, refetched.getDataModel().getColumns().size());
+    String expectedColumnPrefix = refetched.getFullyQualifiedName() + ".";
+    for (Column c : refetched.getDataModel().getColumns()) {
+      assertNotNull(c.getFullyQualifiedName(), "column must have an FQN");
+      assertTrue(
+          c.getFullyQualifiedName().startsWith(expectedColumnPrefix),
+          "column FQN should cascade under new container FQN: " + c.getFullyQualifiedName());
+    }
+  }
+
+  @Test
+  void patch_containerParent_toNull_promotesToTopLevel_200(TestNamespace ns) {
+    StorageService service = StorageServiceTestFactory.createS3(ns);
+    Container parentA = createUnderService(ns, service, "promA");
+    Container child = createUnderParent(ns, service, parentA, "promChild");
+    assertNotNull(child.getParent());
+
+    // Pre-fetch with `parent` so the SDK's JSON-diff sees the original parent and emits a
+    // proper "remove /parent" operation. Without this, the SDK's NON_NULL serialization
+    // omits the cleared `parent` from the patch document and the change is lost.
+    Container loaded =
+        SdkClients.adminClient().containers().get(child.getId().toString(), "parent");
+    loaded.setParent(null);
+    Container moved = patchEntity(loaded.getId().toString(), loaded);
+
+    assertNull(moved.getParent(), "parent should be cleared");
+    assertTrue(
+        moved.getFullyQualifiedName().startsWith(service.getFullyQualifiedName() + "."),
+        "FQN should now sit directly under the service: " + moved.getFullyQualifiedName());
+    assertFalse(
+        moved.getFullyQualifiedName().contains(parentA.getName()),
+        "FQN should no longer reference the old parent");
+  }
+
+  @Test
+  void patch_containerParent_fromNull_assignsParent_200(TestNamespace ns) {
+    StorageService service = StorageServiceTestFactory.createS3(ns);
+    Container top = createUnderService(ns, service, "topLvl");
+    Container target = createUnderService(ns, service, "newParent");
+    assertNull(top.getParent());
+
+    top.setParent(parentRefOf(target));
+    Container moved = patchEntity(top.getId().toString(), top);
+
+    assertNotNull(moved.getParent());
+    assertEquals(target.getId(), moved.getParent().getId());
+    assertTrue(
+        moved.getFullyQualifiedName().startsWith(target.getFullyQualifiedName() + "."),
+        "FQN should now nest under the new parent");
+  }
+
+  @Test
+  void patch_containerParent_rejectsCycle_400(TestNamespace ns) {
+    StorageService service = StorageServiceTestFactory.createS3(ns);
+    Container root = createUnderService(ns, service, "cycRoot");
+    Container child = createUnderParent(ns, service, root, "cycChild");
+
+    // Try to make root.parent = child (cycle: root → child → root)
+    root.setParent(parentRefOf(child));
+    assertThrows(
+        Exception.class,
+        () -> patchEntity(root.getId().toString(), root),
+        "moving a container under its own descendant must be rejected");
+
+    Container refetched = getEntity(root.getId().toString());
+    assertNull(refetched.getParent(), "rejected PATCH must not mutate root");
+  }
+
+  @Test
+  void patch_containerParent_rejectsSelfParent_400(TestNamespace ns) {
+    StorageService service = StorageServiceTestFactory.createS3(ns);
+    Container c = createUnderService(ns, service, "selfRef");
+
+    c.setParent(parentRefOf(c));
+    assertThrows(
+        Exception.class,
+        () -> patchEntity(c.getId().toString(), c),
+        "self-parent must be rejected");
+  }
+
+  @Test
+  void patch_containerParent_rejectsCrossServiceParent_400(TestNamespace ns) {
+    StorageService serviceA = StorageServiceTestFactory.createS3(ns);
+    StorageService serviceB = StorageServiceTestFactory.createS3(ns);
+    Container child = createUnderService(ns, serviceA, "xsChild");
+    Container parentInB = createUnderService(ns, serviceB, "xsParent");
+
+    child.setParent(parentRefOf(parentInB));
+    assertThrows(
+        Exception.class,
+        () -> patchEntity(child.getId().toString(), child),
+        "reparenting across StorageServices must be rejected");
+  }
+
+  @Test
+  void patch_containerParent_rejectsNonExistentParent_404(TestNamespace ns) {
+    StorageService service = StorageServiceTestFactory.createS3(ns);
+    Container c = createUnderService(ns, service, "noParent");
+
+    c.setParent(new EntityReference().withId(UUID.randomUUID()).withType("container"));
+    assertThrows(
+        Exception.class,
+        () -> patchEntity(c.getId().toString(), c),
+        "non-existent parent must be rejected");
+  }
+
+  @Test
+  void patch_containerParent_emitsChangeDescription_200(TestNamespace ns) {
+    StorageService service = StorageServiceTestFactory.createS3(ns);
+    Container parentA = createUnderService(ns, service, "cdA");
+    Container parentB = createUnderService(ns, service, "cdB");
+    Container child = createUnderParent(ns, service, parentA, "cdChild");
+    Double initialVersion = child.getVersion();
+
+    child.setParent(parentRefOf(parentB));
+    Container moved = patchEntity(child.getId().toString(), child);
+
+    assertNotNull(moved.getChangeDescription(), "change description should be populated");
+    assertTrue(
+        moved.getVersion() > initialVersion,
+        "version should bump after parent change: " + initialVersion + " -> " + moved.getVersion());
+    boolean parentInChangeDescription =
+        moved.getChangeDescription().getFieldsUpdated().stream()
+                .anyMatch(f -> "parent".equals(f.getName()))
+            || moved.getChangeDescription().getFieldsAdded().stream()
+                .anyMatch(f -> "parent".equals(f.getName()))
+            || moved.getChangeDescription().getFieldsDeleted().stream()
+                .anyMatch(f -> "parent".equals(f.getName()));
+    assertTrue(
+        parentInChangeDescription, "change description should record the parent field change");
   }
 
   // ===================================================================

--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/ContainerResourceIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/ContainerResourceIT.java
@@ -17,6 +17,7 @@ import java.util.UUID;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.junit.jupiter.api.parallel.ResourceLock;
 import org.openmetadata.it.bootstrap.SharedEntities;
 import org.openmetadata.it.factories.StorageServiceTestFactory;
 import org.openmetadata.it.util.SdkClients;
@@ -40,6 +41,7 @@ import org.openmetadata.sdk.models.ListResponse;
 import org.openmetadata.sdk.network.HttpMethod;
 import org.openmetadata.service.Entity;
 import org.openmetadata.service.jdbi3.CollectionDAO;
+import org.openmetadata.service.jdbi3.ContainerRepository;
 
 /**
  * Integration tests for Container entity operations.
@@ -3080,12 +3082,14 @@ public class ContainerResourceIT extends BaseEntityIT<Container, CreateContainer
   }
 
   @Test
+  @ResourceLock(value = ContainerRepository.MAX_REPARENT_DESCENDANTS_TEST_LOCK)
   void patch_containerParent_rejectsOversizedSubtree_400(TestNamespace ns) {
-    // Force a tiny threshold for this test only so we can exercise the guard without
-    // creating 10,000+ containers. The server reads this on every PATCH so the override
-    // takes effect immediately; restored in `finally` so concurrent tests see the default.
-    String property = "openmetadata.container.maxReparentDescendants";
-    String previous = System.setProperty(property, "2");
+    // Force a tiny threshold for this test only via a package-private test override. The
+    // override is read on every PATCH so it takes effect immediately. We do NOT use
+    // System.setProperty because the property is JVM-global and concurrent tests doing other
+    // re-parents would observe the artificially low value. @ResourceLock above serializes any
+    // test that mutates this override.
+    ContainerRepository.setMaxReparentDescendantsForTest(2);
     try {
       StorageService service = StorageServiceTestFactory.createS3(ns);
       Container parentA = createUnderService(ns, service, "bigA");
@@ -3115,20 +3119,16 @@ public class ContainerResourceIT extends BaseEntityIT<Container, CreateContainer
       Container refetched = getEntityWithFields(child.getId().toString(), "parent");
       assertEquals(parentA.getId(), refetched.getParent().getId());
     } finally {
-      if (previous == null) {
-        System.clearProperty(property);
-      } else {
-        System.setProperty(property, previous);
-      }
+      ContainerRepository.clearMaxReparentDescendantsForTest();
     }
   }
 
   @Test
+  @ResourceLock(value = ContainerRepository.MAX_REPARENT_DESCENDANTS_TEST_LOCK)
   void patch_containerParent_allowsMoveAtConfiguredLimit_200(TestNamespace ns) {
     // Exactly at the limit (descendantCount == max) must still be allowed — the guard uses
-    // strict `>` not `>=`.
-    String property = "openmetadata.container.maxReparentDescendants";
-    String previous = System.setProperty(property, "2");
+    // strict `>` not `>=`. Same package-private test override mechanism as above.
+    ContainerRepository.setMaxReparentDescendantsForTest(2);
     try {
       StorageService service = StorageServiceTestFactory.createS3(ns);
       Container parentA = createUnderService(ns, service, "limA");
@@ -3141,11 +3141,7 @@ public class ContainerResourceIT extends BaseEntityIT<Container, CreateContainer
       Container moved = patchEntity(child.getId().toString(), child);
       assertEquals(parentB.getId(), moved.getParent().getId());
     } finally {
-      if (previous == null) {
-        System.clearProperty(property);
-      } else {
-        System.setProperty(property, previous);
-      }
+      ContainerRepository.clearMaxReparentDescendantsForTest();
     }
   }
 

--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/ContainerResourceIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/ContainerResourceIT.java
@@ -3080,6 +3080,76 @@ public class ContainerResourceIT extends BaseEntityIT<Container, CreateContainer
   }
 
   @Test
+  void patch_containerParent_rejectsOversizedSubtree_400(TestNamespace ns) {
+    // Force a tiny threshold for this test only so we can exercise the guard without
+    // creating 10,000+ containers. The server reads this on every PATCH so the override
+    // takes effect immediately; restored in `finally` so concurrent tests see the default.
+    String property = "openmetadata.container.maxReparentDescendants";
+    String previous = System.setProperty(property, "2");
+    try {
+      StorageService service = StorageServiceTestFactory.createS3(ns);
+      Container parentA = createUnderService(ns, service, "bigA");
+      Container parentB = createUnderService(ns, service, "bigB");
+      Container child = createUnderParent(ns, service, parentA, "bigChild");
+      // 3 grandchildren — exceeds the threshold of 2 descendants.
+      createUnderParent(ns, service, child, "gc1");
+      createUnderParent(ns, service, child, "gc2");
+      createUnderParent(ns, service, child, "gc3");
+
+      child.setParent(parentRefOf(parentB));
+      Exception ex =
+          assertThrows(
+              Exception.class,
+              () -> patchEntity(child.getId().toString(), child),
+              "subtree of 3 descendants must exceed the configured limit of 2");
+      String message = ex.getMessage();
+      assertNotNull(message);
+      assertTrue(
+          message.contains("subtree has 3 descendant"),
+          "error message should report the actual descendant count: " + message);
+      assertTrue(
+          message.contains("maximum of 2"),
+          "error message should report the configured maximum: " + message);
+
+      // The rejection must not have partially mutated state: child still points at parentA.
+      Container refetched = getEntityWithFields(child.getId().toString(), "parent");
+      assertEquals(parentA.getId(), refetched.getParent().getId());
+    } finally {
+      if (previous == null) {
+        System.clearProperty(property);
+      } else {
+        System.setProperty(property, previous);
+      }
+    }
+  }
+
+  @Test
+  void patch_containerParent_allowsMoveAtConfiguredLimit_200(TestNamespace ns) {
+    // Exactly at the limit (descendantCount == max) must still be allowed — the guard uses
+    // strict `>` not `>=`.
+    String property = "openmetadata.container.maxReparentDescendants";
+    String previous = System.setProperty(property, "2");
+    try {
+      StorageService service = StorageServiceTestFactory.createS3(ns);
+      Container parentA = createUnderService(ns, service, "limA");
+      Container parentB = createUnderService(ns, service, "limB");
+      Container child = createUnderParent(ns, service, parentA, "limChild");
+      createUnderParent(ns, service, child, "lgc1");
+      createUnderParent(ns, service, child, "lgc2");
+
+      child.setParent(parentRefOf(parentB));
+      Container moved = patchEntity(child.getId().toString(), child);
+      assertEquals(parentB.getId(), moved.getParent().getId());
+    } finally {
+      if (previous == null) {
+        System.clearProperty(property);
+      } else {
+        System.setProperty(property, previous);
+      }
+    }
+  }
+
+  @Test
   void patch_containerParent_emitsChangeDescription_200(TestNamespace ns) {
     StorageService service = StorageServiceTestFactory.createS3(ns);
     Container parentA = createUnderService(ns, service, "cdA");

--- a/openmetadata-sdk/src/main/java/org/openmetadata/sdk/fluent/Containers.java
+++ b/openmetadata-sdk/src/main/java/org/openmetadata/sdk/fluent/Containers.java
@@ -148,6 +148,33 @@ public final class Containers {
       return this;
     }
 
+    /**
+     * Create the container as a child of {@code parent}. Mirrors {@code GlossaryTerms.under(...)}.
+     * The parent must belong to the same StorageService as set via {@link #in(String)}.
+     */
+    public ContainerCreator under(Container parent) {
+      if (parent == null) {
+        request.setParent(null);
+        return this;
+      }
+      return under(
+          new EntityReference()
+              .withId(parent.getId())
+              .withType("container")
+              .withFullyQualifiedName(parent.getFullyQualifiedName()));
+    }
+
+    public ContainerCreator under(EntityReference parentRef) {
+      request.setParent(parentRef);
+      return this;
+    }
+
+    public ContainerCreator underFqn(String parentFqn) {
+      request.setParent(
+          new EntityReference().withType("container").withFullyQualifiedName(parentFqn));
+      return this;
+    }
+
     public Container execute() {
       return client.containers().create(request);
     }
@@ -341,6 +368,43 @@ public final class Containers {
 
     public FluentContainer withDisplayName(String displayName) {
       container.setDisplayName(displayName);
+      modified = true;
+      return this;
+    }
+
+    /**
+     * Re-parent this container under {@code parent}. The {@link #save()} call routes through the
+     * service update, which generates a JSON Patch and issues PATCH — the backend (see issue
+     * #24294) cascades the FQN change to descendants, column FQNs, tags, and the search index.
+     * The new parent must belong to the same StorageService.
+     */
+    public FluentContainer withParent(Container parent) {
+      if (parent == null) {
+        return withoutParent();
+      }
+      return withParent(
+          new EntityReference()
+              .withId(parent.getId())
+              .withType("container")
+              .withFullyQualifiedName(parent.getFullyQualifiedName()));
+    }
+
+    public FluentContainer withParent(EntityReference parentRef) {
+      container.setParent(parentRef);
+      modified = true;
+      return this;
+    }
+
+    public FluentContainer withParentFqn(String parentFqn) {
+      container.setParent(
+          new EntityReference().withType("container").withFullyQualifiedName(parentFqn));
+      modified = true;
+      return this;
+    }
+
+    /** Promote this container to be a direct child of its StorageService. */
+    public FluentContainer withoutParent() {
+      container.setParent(null);
       modified = true;
       return this;
     }

--- a/openmetadata-sdk/src/test/java/org/openmetadata/sdk/fluent/ContainersFluentAPITest.java
+++ b/openmetadata-sdk/src/test/java/org/openmetadata/sdk/fluent/ContainersFluentAPITest.java
@@ -1,0 +1,227 @@
+/*
+ *  Copyright 2025 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ *  except in compliance with the License. You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software distributed under the
+ *  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ *  either express or implied. See the License for the specific language governing permissions
+ *  and limitations under the License.
+ */
+package org.openmetadata.sdk.fluent;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.openmetadata.schema.api.data.CreateContainer;
+import org.openmetadata.schema.entity.data.Container;
+import org.openmetadata.schema.type.EntityReference;
+import org.openmetadata.sdk.client.OpenMetadataClient;
+import org.openmetadata.sdk.services.storages.ContainerService;
+
+/**
+ * Tests the fluent SDK surface for re-parenting containers (issue #24294).
+ *
+ * <p>Covers:
+ * <ul>
+ *   <li>{@code Containers.create().under(...)} sets the parent on the create request.
+ *   <li>{@code Containers.find(...).fetch().withParent(...).save()} routes the parent change
+ *       through {@code ContainerService.update}, which generates a PATCH on the wire.
+ *   <li>{@code withoutParent()} clears the parent.
+ * </ul>
+ */
+public class ContainersFluentAPITest {
+
+  @Mock private OpenMetadataClient mockClient;
+  @Mock private ContainerService mockContainerService;
+
+  @BeforeEach
+  void setUp() {
+    MockitoAnnotations.openMocks(this);
+    when(mockClient.containers()).thenReturn(mockContainerService);
+    Containers.setDefaultClient(mockClient);
+  }
+
+  @Test
+  void testCreateContainerUnderParent_setsParentOnRequest() {
+    UUID parentId = UUID.randomUUID();
+    Container parent = new Container();
+    parent.setId(parentId);
+    parent.setFullyQualifiedName("s3.parentBucket");
+
+    Container created = new Container();
+    created.setId(UUID.randomUUID());
+    created.setName("child");
+    created.setFullyQualifiedName("s3.parentBucket.child");
+
+    when(mockContainerService.create(any(CreateContainer.class))).thenReturn(created);
+
+    Container result = Containers.create().name("child").in("s3").under(parent).execute();
+
+    assertNotNull(result);
+    verify(mockContainerService)
+        .create(
+            argThat(
+                (CreateContainer req) ->
+                    req.getParent() != null
+                        && parentId.equals(req.getParent().getId())
+                        && "container".equals(req.getParent().getType())));
+  }
+
+  @Test
+  void testCreateContainerUnderFqn_setsParentOnRequest() {
+    Container created = new Container();
+    created.setId(UUID.randomUUID());
+    when(mockContainerService.create(any(CreateContainer.class))).thenReturn(created);
+
+    Containers.create().name("child").in("s3").underFqn("s3.parentBucket").execute();
+
+    verify(mockContainerService)
+        .create(
+            argThat(
+                (CreateContainer req) ->
+                    req.getParent() != null
+                        && "s3.parentBucket".equals(req.getParent().getFullyQualifiedName())));
+  }
+
+  @Test
+  void testFluentContainerWithParent_callsUpdateWithNewParent() {
+    String containerId = UUID.randomUUID().toString();
+    UUID newParentId = UUID.randomUUID();
+    Container existing = new Container();
+    existing.setId(UUID.fromString(containerId));
+    existing.setName("child");
+    existing.setFullyQualifiedName("s3.oldParent.child");
+
+    when(mockContainerService.get(containerId)).thenReturn(existing);
+
+    Container updated = new Container();
+    updated.setId(existing.getId());
+    updated.setFullyQualifiedName("s3.newParent.child");
+    when(mockContainerService.update(eq(containerId), any(Container.class))).thenReturn(updated);
+
+    EntityReference newParent = new EntityReference().withId(newParentId).withType("container");
+
+    Containers.find(containerId).fetch().withParent(newParent).save();
+
+    verify(mockContainerService)
+        .update(
+            eq(containerId),
+            argThat(c -> c.getParent() != null && newParentId.equals(c.getParent().getId())));
+  }
+
+  @Test
+  void testFluentContainerWithoutParent_callsUpdateWithNullParent() {
+    String containerId = UUID.randomUUID().toString();
+    Container existing = new Container();
+    existing.setId(UUID.fromString(containerId));
+    existing.setName("child");
+    existing.setParent(new EntityReference().withId(UUID.randomUUID()).withType("container"));
+
+    when(mockContainerService.get(containerId)).thenReturn(existing);
+
+    Container updated = new Container();
+    updated.setId(existing.getId());
+    when(mockContainerService.update(eq(containerId), any(Container.class))).thenReturn(updated);
+
+    Containers.find(containerId).fetch().withoutParent().save();
+
+    verify(mockContainerService).update(eq(containerId), argThat(c -> c.getParent() == null));
+  }
+
+  @Test
+  void testFluentContainerWithParentFqn_setsParentRefWithFqn() {
+    String containerId = UUID.randomUUID().toString();
+    Container existing = new Container();
+    existing.setId(UUID.fromString(containerId));
+    existing.setName("child");
+
+    when(mockContainerService.get(containerId)).thenReturn(existing);
+
+    Container updated = new Container();
+    updated.setId(existing.getId());
+    when(mockContainerService.update(eq(containerId), any(Container.class))).thenReturn(updated);
+
+    Containers.find(containerId).fetch().withParentFqn("s3.targetBucket").save();
+
+    verify(mockContainerService)
+        .update(
+            eq(containerId),
+            argThat(
+                c ->
+                    c.getParent() != null
+                        && "s3.targetBucket".equals(c.getParent().getFullyQualifiedName())));
+  }
+
+  @Test
+  void testCreateContainerUnderNullParent_clearsParent() {
+    Container created = new Container();
+    created.setId(UUID.randomUUID());
+    when(mockContainerService.create(any(CreateContainer.class))).thenReturn(created);
+
+    Containers.create().name("topLevel").in("s3").under((Container) null).execute();
+
+    verify(mockContainerService).create(argThat((CreateContainer req) -> req.getParent() == null));
+  }
+
+  @Test
+  void testFluentContainerUnmodified_saveIsNoop() {
+    String containerId = UUID.randomUUID().toString();
+    Container existing = new Container();
+    existing.setId(UUID.fromString(containerId));
+    existing.setName("noChange");
+    when(mockContainerService.get(containerId)).thenReturn(existing);
+
+    Containers.find(containerId).fetch().save();
+
+    // FluentContainer.save short-circuits when not modified.
+    verify(mockContainerService, org.mockito.Mockito.never())
+        .update(eq(containerId), any(Container.class));
+  }
+
+  @Test
+  void testFluentContainerWithParentClearsLater() {
+    String containerId = UUID.randomUUID().toString();
+    Container existing = new Container();
+    existing.setId(UUID.fromString(containerId));
+    when(mockContainerService.get(containerId)).thenReturn(existing);
+
+    Container updated = new Container();
+    updated.setId(existing.getId());
+    when(mockContainerService.update(eq(containerId), any(Container.class))).thenReturn(updated);
+
+    Containers.find(containerId)
+        .fetch()
+        .withParent(new EntityReference().withId(UUID.randomUUID()).withType("container"))
+        .withoutParent()
+        .save();
+
+    // Last call wins; parent should be null when save fires.
+    verify(mockContainerService).update(eq(containerId), argThat(c -> c.getParent() == null));
+  }
+
+  @Test
+  void testNullParentRetrievedAfterMove() {
+    String containerId = UUID.randomUUID().toString();
+    Container moved = new Container();
+    moved.setId(UUID.fromString(containerId));
+    moved.setParent(null);
+
+    when(mockContainerService.get(containerId)).thenReturn(moved);
+
+    Container result = Containers.find(containerId).fetch().get();
+    assertNull(result.getParent());
+    assertEquals(containerId, result.getId().toString());
+  }
+}

--- a/openmetadata-service/src/main/java/org/openmetadata/service/exception/CatalogExceptionMessage.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/exception/CatalogExceptionMessage.java
@@ -375,6 +375,20 @@ public final class CatalogExceptionMessage {
         "Can't move Glossary term %s to its child Glossary term %s", term, newParent);
   }
 
+  public static String invalidContainerMove(String container, String newParent) {
+    return String.format(
+        "Can't move Container %s to itself or to its descendant Container %s",
+        container, newParent);
+  }
+
+  public static String invalidContainerParentService(
+      String container, String currentService, String parentService) {
+    return String.format(
+        "Can't re-parent Container %s under a Container from a different StorageService. "
+            + "Container belongs to service [%s] but the requested parent belongs to service [%s].",
+        container, currentService, parentService);
+  }
+
   public static String eventPublisherFailedToPublish(
       SubscriptionDestination.SubscriptionType type, ChangeEvent event, String message) {
     return String.format(

--- a/openmetadata-service/src/main/java/org/openmetadata/service/exception/CatalogExceptionMessage.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/exception/CatalogExceptionMessage.java
@@ -389,6 +389,17 @@ public final class CatalogExceptionMessage {
         container, currentService, parentService);
   }
 
+  public static String containerSubtreeTooLarge(
+      String container, int descendantCount, int maxAllowed) {
+    return String.format(
+        "Can't re-parent Container %s: its subtree has %d descendant containers, which exceeds "
+            + "the maximum of %d. Re-parenting at this scale would lock every descendant row and "
+            + "reindex all matching search documents in a single transaction; split the move into "
+            + "smaller subtrees or raise openmetadata.container.maxReparentDescendants if you "
+            + "understand the operational impact.",
+        container, descendantCount, maxAllowed);
+  }
+
   public static String eventPublisherFailedToPublish(
       SubscriptionDestination.SubscriptionType type, ChangeEvent event, String message) {
     return String.format(

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/CollectionDAO.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/CollectionDAO.java
@@ -994,6 +994,15 @@ public interface CollectionDAO {
      * in the JSON document so column FQNs follow their container. {@code WHERE fqnHash LIKE
      * 'oldHash.%'} restricts the update to descendants — the moved row itself updates via the
      * standard {@code storeEntity} path after {@code setFullyQualifiedName} runs in memory.
+     *
+     * <p><b>On SQL interpolation:</b> mirrors the pre-existing {@link EntityDAO#updateFqn}
+     * pattern — values are spliced into the SQL via {@link String#format} because the
+     * connection-aware {@code @SqlUpdate} dispatcher takes the full statement as a single
+     * {@code <mySqlUpdate>}/{@code <postgresUpdate>} bind. The values come from server-side
+     * code (the FQN computed by {@code setFullyQualifiedName}, not user-supplied input), and
+     * {@link ListFilter#escapeApostrophe} handles the only SQL meta-character that can appear
+     * in a validated entity name. If a future code path lets arbitrary strings reach this
+     * method, swap to a parameterised form with {@code @Bind} parameters.
      */
     @Override
     default void updateFqn(String oldPrefix, String newPrefix) {

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/CollectionDAO.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/CollectionDAO.java
@@ -981,6 +981,53 @@ public interface CollectionDAO {
         @Bind("parentHashChild") String parentHashChild,
         @Bind("nameLike") String nameLike,
         @Bind("includeDeleted") String includeDeleted);
+
+    /**
+     * Cascade an FQN rename to every descendant container row when a parent is reassigned
+     * (#24294). The generic {@link EntityDAO#updateFqn(String, String)} only rewrites the
+     * top-level {@code $.fullyQualifiedName} via MySQL {@code JSON_REPLACE}, which leaves
+     * nested column FQNs ({@code $.dataModel.columns[*].fullyQualifiedName}) pointing at the
+     * old parent — silently breaking column lookups on MySQL. Postgres works only by accident
+     * because the base impl does a global {@code REPLACE(json::text, ...)}.
+     *
+     * <p>This override rewrites every {@code "fullyQualifiedName": "OLD_PREFIX..."} occurrence
+     * in the JSON document so column FQNs follow their container. {@code WHERE fqnHash LIKE
+     * 'oldHash.%'} restricts the update to descendants — the moved row itself updates via the
+     * standard {@code storeEntity} path after {@code setFullyQualifiedName} runs in memory.
+     */
+    @Override
+    default void updateFqn(String oldPrefix, String newPrefix) {
+      if (!getNameHashColumn().equals("fqnHash")) {
+        return;
+      }
+      String oldHash = FullyQualifiedName.buildHash(oldPrefix);
+      String newHash = FullyQualifiedName.buildHash(newPrefix);
+      String mySqlUpdate =
+          String.format(
+              "UPDATE %s SET json = CAST(REPLACE(CAST(json AS CHAR), "
+                  + "'\"fullyQualifiedName\": \"%s.', '\"fullyQualifiedName\": \"%s.') AS JSON), "
+                  + "fqnHash = REPLACE(fqnHash, '%s.', '%s.') "
+                  + "WHERE fqnHash LIKE '%s.%%'",
+              getTableName(),
+              escapeApostrophe(oldPrefix),
+              escapeApostrophe(newPrefix),
+              oldHash,
+              newHash,
+              oldHash);
+      String postgresUpdate =
+          String.format(
+              "UPDATE %s SET json = REPLACE(json::text, "
+                  + "'\"fullyQualifiedName\": \"%s.', '\"fullyQualifiedName\": \"%s.')::jsonb, "
+                  + "fqnHash = REPLACE(fqnHash, '%s.', '%s.') "
+                  + "WHERE fqnHash LIKE '%s.%%'",
+              getTableName(),
+              escapeApostrophe(oldPrefix),
+              escapeApostrophe(newPrefix),
+              oldHash,
+              newHash,
+              oldHash);
+      updateFqnInternal(mySqlUpdate, postgresUpdate);
+    }
   }
 
   class ContainerSummaryRowMapper implements RowMapper<Container> {

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/CollectionDAO.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/CollectionDAO.java
@@ -1028,6 +1028,15 @@ public interface CollectionDAO {
               oldHash);
       updateFqnInternal(mySqlUpdate, postgresUpdate);
     }
+
+    /**
+     * Cheap descendant count used by the PATCH re-parent guard (#24294) to short-circuit
+     * absurd subtree moves before any cascade work runs. {@code fqnHash LIKE 'oldHash.%'}
+     * matches every descendant row (excluding the moved container itself) and the index on
+     * {@code fqnHash} makes this an O(log n) lookup.
+     */
+    @SqlQuery("SELECT COUNT(*) FROM storage_container_entity WHERE fqnHash LIKE :prefixLike")
+    int countDescendantsByPrefix(@Bind("prefixLike") String prefixLike);
   }
 
   class ContainerSummaryRowMapper implements RowMapper<Container> {

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/ContainerRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/ContainerRepository.java
@@ -101,11 +101,13 @@ public class ContainerRepository extends EntityRepository<Container> {
   public void setFields(
       Container container, EntityUtil.Fields fields, RelationIncludes relationIncludes) {
     setDefaultFields(container);
-    // Always resolve parent — re-parenting via PATCH (#24294) requires the loaded entity to
-    // carry the current parent so the JSON Patch document can target an existing
-    // `/parent` member. Mirrors `GlossaryTermRepository.setFields`. `clearFields` below still
-    // strips parent from the response payload when the caller did not request it.
-    container.setParent(getContainerParent(container));
+    // Conditional load: relationship lookup only when the caller explicitly asked for the
+    // parent field. PATCH still gets the live parent because `CONTAINER_PATCH_FIELDS`
+    // includes `parent`, so the JSON-Patch flow sees an existing `/parent` member. All
+    // other GETs that don't request `parent` keep the JSON-deserialised value (no extra
+    // round-trip).
+    container.setParent(
+        fields.contains(FIELD_PARENT) ? getContainerParent(container) : container.getParent());
     if (container.getDataModel() != null) {
       populateDataModelColumnTags(
           fields.contains(FIELD_TAGS), container.getDataModel().getColumns());
@@ -1018,20 +1020,41 @@ public class ContainerRepository extends EntityRepository<Container> {
 
   /**
    * Rewrite feed entity-links and field-relationships when a container's FQN changes (parent
-   * move). Mirrors {@code GlossaryTermRepository.updateEntityLinks}. Descendant container
-   * entity-links are also updated by walking children via {@link Relationship#CONTAINS}.
+   * move).
+   *
+   * <p>{@code renamedDescendants} is the snapshot returned by
+   * {@link EntityRepository#invalidateCacheForRenameCascade} — it contains every descendant
+   * id paired with the OLD fqn at the time of capture. We rewrite each descendant's legacy
+   * thread {@code about} link with the corresponding NEW fqn so deep subtrees (grandchildren
+   * and beyond) do not keep stale entityLinks. Direct-children-only is insufficient: a
+   * three-level move would leave grandchild feed threads pointing at the old FQN and break
+   * activity-feed navigation.
    */
-  private void updateEntityLinks(String oldFqn, String newFqn, Container updated) {
+  private void updateEntityLinks(
+      String oldFqn,
+      String newFqn,
+      Container updated,
+      List<EntityDAO.EntityIdFqnPair> renamedDescendants) {
     daoCollection.fieldRelationshipDAO().renameByToFQN(oldFqn, newFqn);
 
     EntityLink newAbout = new EntityLink(CONTAINER, newFqn);
     feedRepository.updateLegacyThreadsAbout(newAbout.getLinkString(), updated.getId().toString());
 
-    List<EntityReference> children =
-        findTo(updated.getId(), CONTAINER, Relationship.CONTAINS, CONTAINER);
-    for (EntityReference child : children) {
-      EntityLink childAbout = new EntityLink(CONTAINER, child.getFullyQualifiedName());
-      feedRepository.updateLegacyThreadsAbout(childAbout.getLinkString(), child.getId().toString());
+    if (renamedDescendants == null || renamedDescendants.isEmpty()) {
+      return;
+    }
+    // Each descendant's old FQN begins with `oldFqn + "."`; the new FQN is obtained by
+    // swapping the prefix. This matches the same prefix-substitution that
+    // ContainerDAO.updateFqn applies at the JSON / fqnHash level, so the entity-link rewrite
+    // stays consistent with the persisted FQN.
+    for (EntityDAO.EntityIdFqnPair descendant : renamedDescendants) {
+      if (descendant.fqn == null || !descendant.fqn.startsWith(oldFqn + ".")) {
+        continue;
+      }
+      String descendantNewFqn = newFqn + descendant.fqn.substring(oldFqn.length());
+      EntityLink descendantAbout = new EntityLink(CONTAINER, descendantNewFqn);
+      feedRepository.updateLegacyThreadsAbout(
+          descendantAbout.getLinkString(), descendant.id.toString());
     }
   }
 
@@ -1336,7 +1359,7 @@ public class ContainerRepository extends EntityRepository<Container> {
           .tagUsageDAO()
           .renameByTargetFQNHash(TagSource.GLOSSARY.ordinal(), oldFqn, newFqn);
 
-      updateEntityLinks(oldFqn, newFqn, updated);
+      updateEntityLinks(oldFqn, newFqn, updated, renamedContainers);
 
       PolicyConditionUpdater.updateAllPolicyConditions(
           condition ->

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/ContainerRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/ContainerRepository.java
@@ -12,6 +12,9 @@ import static org.openmetadata.service.Entity.getEntityReferenceById;
 import static org.openmetadata.service.resources.tags.TagLabelUtil.addDerivedTagsGracefully;
 import static org.openmetadata.service.resources.tags.TagLabelUtil.addDerivedTagsWithPreFetched;
 import static org.openmetadata.service.resources.tags.TagLabelUtil.batchFetchDerivedTags;
+import static org.openmetadata.service.search.SearchClient.GLOBAL_SEARCH_ALIAS;
+import static org.openmetadata.service.util.EntityUtil.compareTagLabel;
+import static org.openmetadata.service.util.EntityUtil.entityReferenceMatch;
 import static org.openmetadata.service.util.EntityUtil.getFlattenedEntityField;
 
 import com.fasterxml.jackson.databind.JsonNode;
@@ -42,6 +45,7 @@ import org.openmetadata.schema.type.Include;
 import org.openmetadata.schema.type.Relationship;
 import org.openmetadata.schema.type.TableData;
 import org.openmetadata.schema.type.TagLabel;
+import org.openmetadata.schema.type.TagLabel.TagSource;
 import org.openmetadata.schema.type.TaskType;
 import org.openmetadata.schema.type.change.ChangeSource;
 import org.openmetadata.schema.utils.JsonUtils;
@@ -50,12 +54,14 @@ import org.openmetadata.service.Entity;
 import org.openmetadata.service.cache.AncestorsCache;
 import org.openmetadata.service.cache.CacheBundle;
 import org.openmetadata.service.cache.ChildrenPageCache;
+import org.openmetadata.service.exception.CatalogExceptionMessage;
 import org.openmetadata.service.jdbi3.FeedRepository.TaskWorkflow;
 import org.openmetadata.service.jdbi3.FeedRepository.ThreadContext;
 import org.openmetadata.service.monitoring.RequestLatencyContext;
 import org.openmetadata.service.resources.feeds.MessageParser.EntityLink;
 import org.openmetadata.service.resources.storages.ContainerResource;
 import org.openmetadata.service.security.mask.PIIMasker;
+import org.openmetadata.service.security.policyevaluator.PolicyConditionUpdater;
 import org.openmetadata.service.util.EntityUtil;
 import org.openmetadata.service.util.EntityUtil.Fields;
 import org.openmetadata.service.util.EntityUtil.RelationIncludes;
@@ -65,10 +71,12 @@ import org.slf4j.LoggerFactory;
 
 public class ContainerRepository extends EntityRepository<Container> {
   private static final Logger LOG = LoggerFactory.getLogger(ContainerRepository.class);
-  private static final String CONTAINER_UPDATE_FIELDS = "dataModel";
-  private static final String CONTAINER_PATCH_FIELDS = "dataModel";
+  private static final String CONTAINER_UPDATE_FIELDS = "dataModel,parent";
+  private static final String CONTAINER_PATCH_FIELDS = "dataModel,parent";
   private static final Set<String> CHANGE_SUMMARY_FIELDS = Set.of("dataModel.columns.description");
   public static final String CONTAINER_SAMPLE_DATA_EXTENSION = "container.sampleData";
+
+  private final FeedRepository feedRepository = Entity.getFeedRepository();
 
   public ContainerRepository() {
     super(
@@ -92,8 +100,11 @@ public class ContainerRepository extends EntityRepository<Container> {
   public void setFields(
       Container container, EntityUtil.Fields fields, RelationIncludes relationIncludes) {
     setDefaultFields(container);
-    container.setParent(
-        fields.contains(FIELD_PARENT) ? getContainerParent(container) : container.getParent());
+    // Always resolve parent — re-parenting via PATCH (#24294) requires the loaded entity to
+    // carry the current parent so the JSON Patch document can target an existing
+    // `/parent` member. Mirrors `GlossaryTermRepository.setFields`. `clearFields` below still
+    // strips parent from the response payload when the caller did not request it.
+    container.setParent(getContainerParent(container));
     if (container.getDataModel() != null) {
       populateDataModelColumnTags(
           fields.contains(FIELD_TAGS), container.getDataModel().getColumns());
@@ -353,8 +364,12 @@ public class ContainerRepository extends EntityRepository<Container> {
 
   @Override
   public void setFullyQualifiedName(Container container) {
-    container.setParent(
-        container.getParent() != null ? container.getParent() : getContainerParent(container));
+    // Trust the in-memory parent — do not re-query the relationship table. The previous
+    // behavior (`parent != null ? parent : getContainerParent(...)`) silently restored the
+    // stored parent when a PATCH explicitly cleared `parent` (#24294), making
+    // "promote to top level" impossible. Create flow already populates parent from the request
+    // via ContainerMapper before this runs, so there's no legitimate caller relying on the
+    // implicit DB lookup here.
     if (container.getParent() != null) {
       container.setFullyQualifiedName(
           FullyQualifiedName.add(
@@ -432,9 +447,10 @@ public class ContainerRepository extends EntityRepository<Container> {
 
   @Override
   public void restorePatchAttributes(Container original, Container updated) {
-    // Patch can't make changes to following fields. Ignore the changes
+    // Service can't change via PATCH; parent is patchable (see #24294 — same-service re-parent
+    // is validated in ContainerUpdater.validateParent).
     super.restorePatchAttributes(original, updated);
-    updated.withService(original.getService()).withParent(original.getParent());
+    updated.withService(original.getService());
   }
 
   // ----------------------------------------------------------------------------------------
@@ -999,6 +1015,68 @@ public class ContainerRepository extends EntityRepository<Container> {
     }
   }
 
+  /**
+   * Rewrite feed entity-links and field-relationships when a container's FQN changes (parent
+   * move). Mirrors {@code GlossaryTermRepository.updateEntityLinks}. Descendant container
+   * entity-links are also updated by walking children via {@link Relationship#CONTAINS}.
+   */
+  private void updateEntityLinks(String oldFqn, String newFqn, Container updated) {
+    daoCollection.fieldRelationshipDAO().renameByToFQN(oldFqn, newFqn);
+
+    EntityLink newAbout = new EntityLink(CONTAINER, newFqn);
+    feedRepository.updateLegacyThreadsAbout(newAbout.getLinkString(), updated.getId().toString());
+
+    List<EntityReference> children =
+        findTo(updated.getId(), CONTAINER, Relationship.CONTAINS, CONTAINER);
+    for (EntityReference child : children) {
+      EntityLink childAbout = new EntityLink(CONTAINER, child.getFullyQualifiedName());
+      feedRepository.updateLegacyThreadsAbout(childAbout.getLinkString(), child.getId().toString());
+    }
+  }
+
+  /**
+   * Rewrite the search-index documents whose {@code fullyQualifiedName} starts with {@code
+   * oldFqn} so they reflect {@code newFqn}. Covers the moved container and every descendant in
+   * one indexed update-by-query.
+   */
+  private void updateAssetIndexes(String oldFqn, String newFqn) {
+    searchRepository
+        .getSearchClient()
+        .updateByFqnPrefix(GLOBAL_SEARCH_ALIAS, oldFqn, newFqn, "fullyQualifiedName");
+  }
+
+  /**
+   * Validate that the {@code updated} container's parent (if set) is in the same StorageService
+   * as the {@code original} and that it doesn't form a cycle. Extracted as a static helper so
+   * the validation logic is unit-testable without bootstrapping an {@link EntityUpdater}.
+   *
+   * <p>Throws {@link IllegalArgumentException} when the parent points at a different service,
+   * at the container itself, or at a descendant of the container.
+   */
+  static void validateContainerParent(Container original, Container updated) {
+    EntityReference newParent = updated.getParent();
+    if (newParent == null) {
+      return;
+    }
+    Container resolvedParent =
+        Entity.getEntity(CONTAINER, newParent.getId(), "service", NON_DELETED);
+    UUID origServiceId = original.getService().getId();
+    UUID parentServiceId = resolvedParent.getService().getId();
+    if (!Objects.equals(origServiceId, parentServiceId)) {
+      throw new IllegalArgumentException(
+          CatalogExceptionMessage.invalidContainerParentService(
+              original.getFullyQualifiedName(),
+              original.getService().getFullyQualifiedName(),
+              resolvedParent.getService().getFullyQualifiedName()));
+    }
+    String origFqn = original.getFullyQualifiedName();
+    String parentFqn = resolvedParent.getFullyQualifiedName();
+    if (Objects.equals(parentFqn, origFqn) || FullyQualifiedName.isParent(parentFqn, origFqn)) {
+      throw new IllegalArgumentException(
+          CatalogExceptionMessage.invalidContainerMove(origFqn, parentFqn));
+    }
+  }
+
   /** Handles entity updated from PUT and POST operations */
   public class ContainerUpdater extends ColumnEntityUpdater {
     public ContainerUpdater(Container original, Container updated, Operation operation) {
@@ -1008,6 +1086,7 @@ public class ContainerRepository extends EntityRepository<Container> {
     @Transaction
     @Override
     public void entitySpecificUpdate(boolean consolidatingChanges) {
+      validateParent();
       compareAndUpdate("dataModel", () -> updateDataModel(original, updated));
       compareAndUpdate(
           "prefix", () -> recordChange("prefix", original.getPrefix(), updated.getPrefix()));
@@ -1066,6 +1145,99 @@ public class ContainerRepository extends EntityRepository<Container> {
                   false,
                   EntityUtil.objectMatch,
                   false));
+      compareAndUpdateAny(() -> updateParent(original, updated), FIELD_PARENT);
+    }
+
+    /**
+     * Reject parent updates that would move the container under a different StorageService,
+     * under itself, or under one of its descendants. Same-service-only is the user-confirmed
+     * scope for #24294; cross-service moves are explicitly out of scope.
+     */
+    void validateParent() {
+      validateContainerParent(original, updated);
+    }
+
+    /**
+     * Re-parent the container and cascade the FQN change to every descendant container,
+     * column FQN, tag-usage row, entity-link, policy condition, and search-index doc.
+     * Mirrors {@link GlossaryTermRepository}'s {@code updateNameAndParent} flow.
+     */
+    private void updateParent(Container original, Container updated) {
+      UUID oldParentId = original.getParent() == null ? null : original.getParent().getId();
+      UUID newParentId = updated.getParent() == null ? null : updated.getParent().getId();
+      if (Objects.equals(oldParentId, newParentId)) {
+        return;
+      }
+
+      String oldFqn = getOriginalFqn();
+      setFullyQualifiedName(updated);
+      String newFqn = updated.getFullyQualifiedName();
+      if (oldFqn.equals(newFqn)) {
+        return;
+      }
+
+      LOG.info("Container FQN changed from {} to {} (parent reassignment)", oldFqn, newFqn);
+
+      List<EntityDAO.EntityIdFqnPair> renamedContainers =
+          invalidateCacheForRenameCascade(CONTAINER, oldFqn);
+      invalidateCacheForTaggedEntitiesAndDescendants(CONTAINER, oldFqn);
+
+      daoCollection.containerDAO().updateFqn(oldFqn, newFqn);
+
+      daoCollection.tagUsageDAO().deleteTagsByTarget(oldFqn);
+      List<TagLabel> updatedTags = listOrEmpty(updated.getTags());
+      if (!updatedTags.isEmpty()) {
+        updatedTags = new ArrayList<>(updatedTags);
+        updatedTags.sort(compareTagLabel);
+        applyTags(updatedTags, newFqn);
+      }
+      daoCollection
+          .tagUsageDAO()
+          .renameByTargetFQNHash(TagSource.CLASSIFICATION.ordinal(), oldFqn, newFqn);
+      daoCollection
+          .tagUsageDAO()
+          .renameByTargetFQNHash(TagSource.GLOSSARY.ordinal(), oldFqn, newFqn);
+
+      updateEntityLinks(oldFqn, newFqn, updated);
+
+      PolicyConditionUpdater.updateAllPolicyConditions(
+          condition ->
+              PolicyConditionUpdater.renamePrefixInCondition(
+                  condition, oldFqn, newFqn, PolicyConditionUpdater.TAG_FUNCTIONS));
+
+      updateParentRelationship(original, updated);
+      recordChange(
+          FIELD_PARENT, original.getParent(), updated.getParent(), true, entityReferenceMatch);
+
+      updateAssetIndexes(oldFqn, newFqn);
+      finishInvalidateCacheForRenameCascade(CONTAINER, renamedContainers);
+    }
+
+    private void updateParentRelationship(Container orig, Container updated) {
+      deleteParentRelationship(orig);
+      addParentRelationship(updated);
+    }
+
+    private void deleteParentRelationship(Container container) {
+      if (container.getParent() != null) {
+        deleteRelationship(
+            container.getParent().getId(),
+            CONTAINER,
+            container.getId(),
+            CONTAINER,
+            Relationship.CONTAINS);
+      }
+    }
+
+    private void addParentRelationship(Container container) {
+      if (container.getParent() != null) {
+        addRelationship(
+            container.getParent().getId(),
+            container.getId(),
+            CONTAINER,
+            CONTAINER,
+            Relationship.CONTAINS);
+      }
     }
 
     private void updateDataModel(Container original, Container updated) {

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/ContainerRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/ContainerRepository.java
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
@@ -1053,17 +1054,53 @@ public class ContainerRepository extends EntityRepository<Container> {
    * row locks on the entire subtree. Past this threshold the operation is functionally a DoS
    * on the cluster, so we reject it at the front door and ask the operator to split the move.
    *
-   * <p>Overridable via the {@code openmetadata.container.maxReparentDescendants} system
-   * property for operators who have measured the impact and accept it; tests use the same
-   * knob to exercise the limit without creating thousands of fixtures.
+   * <p>Operator override: the {@code openmetadata.container.maxReparentDescendants} system
+   * property at JVM startup. Tests must not use that property because it is JVM-global and
+   * other concurrent tests would observe the artificially low value; use
+   * {@link #setMaxReparentDescendantsForTest(int)} instead, which is wrapped in {@code
+   * try/finally} and serialized by {@code @ResourceLock} on the affected tests.
    */
   static final int DEFAULT_MAX_REPARENT_DESCENDANTS = 10_000;
 
   private static final String MAX_REPARENT_DESCENDANTS_PROPERTY =
       "openmetadata.container.maxReparentDescendants";
 
+  /**
+   * Test-only override resource lock identifier. Both the override accessor and IT methods that
+   * mutate it carry {@code @ResourceLock(MAX_REPARENT_DESCENDANTS_TEST_LOCK)} so the JUnit
+   * platform serializes any test that touches the override, even though the class-level
+   * {@code @Execution(ExecutionMode.CONCURRENT)} otherwise runs tests in parallel.
+   */
+  public static final String MAX_REPARENT_DESCENDANTS_TEST_LOCK =
+      "container.maxReparentDescendants.override";
+
+  private static volatile Integer maxReparentDescendantsTestOverride;
+
   static int maxReparentDescendants() {
+    Integer override = maxReparentDescendantsTestOverride;
+    if (override != null) {
+      return override;
+    }
     return Integer.getInteger(MAX_REPARENT_DESCENDANTS_PROPERTY, DEFAULT_MAX_REPARENT_DESCENDANTS);
+  }
+
+  /**
+   * Test-only setter that bypasses the JVM-global system property so concurrent tests can run
+   * with isolated thresholds when paired with {@code @ResourceLock}. Always call {@link
+   * #clearMaxReparentDescendantsForTest()} in a {@code finally} block.
+   *
+   * <p><b>Not for production use.</b> Public so integration tests in
+   * {@code org.openmetadata.it.tests} can reach it; pair with
+   * {@code @ResourceLock(ContainerRepository.MAX_REPARENT_DESCENDANTS_TEST_LOCK)} on every
+   * test that calls this.
+   */
+  public static void setMaxReparentDescendantsForTest(int max) {
+    maxReparentDescendantsTestOverride = max;
+  }
+
+  /** Test-only counterpart to {@link #setMaxReparentDescendantsForTest(int)}. */
+  public static void clearMaxReparentDescendantsForTest() {
+    maxReparentDescendantsTestOverride = null;
   }
 
   /**
@@ -1084,12 +1121,24 @@ public class ContainerRepository extends EntityRepository<Container> {
    * as the {@code original} and that it doesn't form a cycle. Extracted as a static helper so
    * the validation logic is unit-testable without bootstrapping an {@link EntityUpdater}.
    *
+   * <p>Returns silently — without firing the DB lookup — when the parent reference hasn't
+   * changed between {@code original} and {@code updated}. This is the common case for any
+   * non-re-parent PATCH/PUT (description edits, tag additions, etc.) and we don't want to add
+   * a round-trip to every container update.
+   *
    * <p>Throws {@link IllegalArgumentException} when the parent points at a different service,
-   * at the container itself, or at a descendant of the container.
+   * at the container itself, or at a descendant of the container (FQN-prefix check). The
+   * {@link ContainerUpdater#validateAncestorChainCycle} caller adds a second-line ID-based
+   * traversal that doesn't depend on FQN state.
    */
   static void validateContainerParent(Container original, Container updated) {
     EntityReference newParent = updated.getParent();
     if (newParent == null) {
+      return;
+    }
+    UUID oldParentId = original.getParent() == null ? null : original.getParent().getId();
+    if (Objects.equals(oldParentId, newParent.getId())) {
+      // Parent hasn't changed — no need to resolve the reference or revalidate.
       return;
     }
     Container resolvedParent =
@@ -1186,9 +1235,54 @@ public class ContainerRepository extends EntityRepository<Container> {
      * Reject parent updates that would move the container under a different StorageService,
      * under itself, or under one of its descendants. Same-service-only is the user-confirmed
      * scope for #24294; cross-service moves are explicitly out of scope.
+     *
+     * <p>Two-pass cycle check:
+     * <ol>
+     *   <li>{@link ContainerRepository#validateContainerParent} runs an O(1) FQN-prefix check
+     *       against the resolved parent (no chain walk; correct for in-transaction views).
+     *   <li>{@link #validateAncestorChainCycle} then walks the actual CONTAINS edges by ID,
+     *       bypassing any FQN-derived cache, so the check holds even if a descendant's stored
+     *       FQN is briefly stale relative to the relationship table.
+     * </ol>
      */
     void validateParent() {
       validateContainerParent(original, updated);
+      EntityReference newParent = updated.getParent();
+      if (newParent == null) {
+        return;
+      }
+      UUID oldParentId = original.getParent() == null ? null : original.getParent().getId();
+      if (!Objects.equals(oldParentId, newParent.getId())) {
+        validateAncestorChainCycle(newParent.getId());
+      }
+    }
+
+    /**
+     * Walk the new parent's CONTAINS ancestor chain by ID and reject if we encounter
+     * {@code original.getId()} — i.e. the new parent is somewhere downstream of the container
+     * being moved. Cycle-safe via a visited set; bounded by the natural depth of the container
+     * hierarchy. Uses {@code relationshipDAO.findFrom} (direct DB) so a stale FQN on a
+     * descendant cannot bypass the check.
+     */
+    private void validateAncestorChainCycle(UUID newParentId) {
+      Set<UUID> visited = new HashSet<>();
+      visited.add(original.getId());
+      UUID current = newParentId;
+      while (current != null) {
+        if (!visited.add(current)) {
+          throw new IllegalArgumentException(
+              CatalogExceptionMessage.invalidContainerMove(
+                  original.getFullyQualifiedName(), updated.getParent().getFullyQualifiedName()));
+        }
+        List<CollectionDAO.EntityRelationshipRecord> parentRecords =
+            daoCollection
+                .relationshipDAO()
+                .findFrom(current, CONTAINER, Relationship.CONTAINS.ordinal(), CONTAINER);
+        if (parentRecords.isEmpty()) {
+          return;
+        }
+        current = parentRecords.get(0).getId();
+      }
     }
 
     /**

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/ContainerRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/ContainerRepository.java
@@ -1046,6 +1046,40 @@ public class ContainerRepository extends EntityRepository<Container> {
   }
 
   /**
+   * Hard ceiling on how many descendant containers a single PATCH re-parent (#24294) is allowed
+   * to cascade through in one transaction. The whole rewrite — descendant FQNs in
+   * {@code storage_container_entity}, every tag_usage row, every cached entry across all OM
+   * instances, and the search-index update-by-query — runs inside one DB transaction holding
+   * row locks on the entire subtree. Past this threshold the operation is functionally a DoS
+   * on the cluster, so we reject it at the front door and ask the operator to split the move.
+   *
+   * <p>Overridable via the {@code openmetadata.container.maxReparentDescendants} system
+   * property for operators who have measured the impact and accept it; tests use the same
+   * knob to exercise the limit without creating thousands of fixtures.
+   */
+  static final int DEFAULT_MAX_REPARENT_DESCENDANTS = 10_000;
+
+  private static final String MAX_REPARENT_DESCENDANTS_PROPERTY =
+      "openmetadata.container.maxReparentDescendants";
+
+  static int maxReparentDescendants() {
+    return Integer.getInteger(MAX_REPARENT_DESCENDANTS_PROPERTY, DEFAULT_MAX_REPARENT_DESCENDANTS);
+  }
+
+  /**
+   * Pure size check. Extracted so it's unit-testable without a live DAO — the production
+   * caller in {@link ContainerUpdater#updateParent} runs the count query then passes the
+   * result here.
+   */
+  static void validateSubtreeSize(String containerFqn, int descendantCount, int maxAllowed) {
+    if (descendantCount > maxAllowed) {
+      throw new IllegalArgumentException(
+          CatalogExceptionMessage.containerSubtreeTooLarge(
+              containerFqn, descendantCount, maxAllowed));
+    }
+  }
+
+  /**
    * Validate that the {@code updated} container's parent (if set) is in the same StorageService
    * as the {@code original} and that it doesn't form a cycle. Extracted as a static helper so
    * the validation logic is unit-testable without bootstrapping an {@link EntityUpdater}.
@@ -1177,6 +1211,16 @@ public class ContainerRepository extends EntityRepository<Container> {
       }
 
       LOG.info("Container FQN changed from {} to {} (parent reassignment)", oldFqn, newFqn);
+
+      // #24294 — bail out BEFORE any cascade work if the subtree is large enough that the
+      // single-transaction rewrite would lock thousands of rows + reindex hundreds of thousands
+      // of search docs. Cheap indexed COUNT(*); short-circuits before any cache work runs.
+      int maxAllowed = maxReparentDescendants();
+      int descendantCount =
+          daoCollection
+              .containerDAO()
+              .countDescendantsByPrefix(FullyQualifiedName.buildHash(oldFqn) + ".%");
+      validateSubtreeSize(oldFqn, descendantCount, maxAllowed);
 
       List<EntityDAO.EntityIdFqnPair> renamedContainers =
           invalidateCacheForRenameCascade(CONTAINER, oldFqn);

--- a/openmetadata-service/src/test/java/org/openmetadata/service/jdbi3/ContainerRepositoryParentValidationTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/jdbi3/ContainerRepositoryParentValidationTest.java
@@ -205,31 +205,65 @@ class ContainerRepositoryParentValidationTest {
   }
 
   @Test
-  void maxReparentDescendants_defaultsTo10000WhenPropertyUnset() {
-    String previous = System.clearProperty("openmetadata.container.maxReparentDescendants");
+  void maxReparentDescendants_defaultsTo10000WhenNoOverride() {
+    ContainerRepository.clearMaxReparentDescendantsForTest();
+    String previousProperty = System.clearProperty("openmetadata.container.maxReparentDescendants");
     try {
       assertEquals(10_000, ContainerRepository.maxReparentDescendants());
       assertEquals(
           ContainerRepository.DEFAULT_MAX_REPARENT_DESCENDANTS,
           ContainerRepository.maxReparentDescendants());
     } finally {
-      if (previous != null) {
-        System.setProperty("openmetadata.container.maxReparentDescendants", previous);
+      if (previousProperty != null) {
+        System.setProperty("openmetadata.container.maxReparentDescendants", previousProperty);
       }
     }
   }
 
   @Test
-  void maxReparentDescendants_readsSystemPropertyOverride() {
-    String previous = System.setProperty("openmetadata.container.maxReparentDescendants", "42");
+  void maxReparentDescendants_testOverrideTakesPriorityOverSystemProperty() {
+    String previousProperty =
+        System.setProperty("openmetadata.container.maxReparentDescendants", "7");
     try {
+      // Without override, system property wins.
+      ContainerRepository.clearMaxReparentDescendantsForTest();
+      assertEquals(7, ContainerRepository.maxReparentDescendants());
+
+      // With override, override wins.
+      ContainerRepository.setMaxReparentDescendantsForTest(42);
       assertEquals(42, ContainerRepository.maxReparentDescendants());
     } finally {
-      if (previous == null) {
+      ContainerRepository.clearMaxReparentDescendantsForTest();
+      if (previousProperty == null) {
         System.clearProperty("openmetadata.container.maxReparentDescendants");
       } else {
-        System.setProperty("openmetadata.container.maxReparentDescendants", previous);
+        System.setProperty("openmetadata.container.maxReparentDescendants", previousProperty);
       }
+    }
+  }
+
+  @Test
+  void validateParent_shortCircuitsWhenParentUnchanged() {
+    // When the proposed parent has the same ID as the current parent, validateContainerParent
+    // must NOT fire Entity.getEntity (avoids a DB round-trip on every container PATCH/PUT
+    // that doesn't touch the parent).
+    UUID originalId = UUID.randomUUID();
+    UUID parentId = UUID.randomUUID();
+    Container original =
+        container(originalId, SERVICE_A_FQN + ".parent.child", SERVICE_A, SERVICE_A_FQN);
+    original.setParent(parentRef(parentId));
+    Container updated =
+        container(originalId, original.getFullyQualifiedName(), SERVICE_A, SERVICE_A_FQN);
+    updated.setParent(parentRef(parentId));
+
+    try (MockedStatic<Entity> mocked = mockStatic(Entity.class)) {
+      mocked
+          .when(
+              () ->
+                  Entity.getEntity(eq(CONTAINER), any(UUID.class), eq("service"), eq(NON_DELETED)))
+          .thenThrow(
+              new AssertionError("Entity.getEntity must not be called when parent is unchanged"));
+      assertDoesNotThrow(() -> ContainerRepository.validateContainerParent(original, updated));
     }
   }
 

--- a/openmetadata-service/src/test/java/org/openmetadata/service/jdbi3/ContainerRepositoryParentValidationTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/jdbi3/ContainerRepositoryParentValidationTest.java
@@ -1,0 +1,199 @@
+/*
+ *  Copyright 2025 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ *  except in compliance with the License. You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software distributed under the
+ *  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ *  either express or implied. See the License for the specific language governing permissions
+ *  and limitations under the License.
+ */
+package org.openmetadata.service.jdbi3;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mockStatic;
+import static org.openmetadata.schema.type.Include.NON_DELETED;
+import static org.openmetadata.service.Entity.CONTAINER;
+
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.openmetadata.schema.entity.data.Container;
+import org.openmetadata.schema.type.EntityReference;
+import org.openmetadata.service.Entity;
+
+/**
+ * Unit tests for {@link ContainerRepository#validateContainerParent} — the pure validation path
+ * for PATCH-driven container re-parenting (issue #24294).
+ *
+ * <p>{@link Entity#getEntity} is mocked via {@link MockedStatic} so the test can drive
+ * validation without bootstrapping the full repository / DB stack.
+ */
+class ContainerRepositoryParentValidationTest {
+
+  private static final UUID SERVICE_A = UUID.randomUUID();
+  private static final UUID SERVICE_B = UUID.randomUUID();
+  private static final String SERVICE_A_FQN = "s3-prod";
+  private static final String SERVICE_B_FQN = "gcs-prod";
+
+  private static Container container(UUID id, String fqn, UUID serviceId, String serviceFqn) {
+    return new Container()
+        .withId(id)
+        .withFullyQualifiedName(fqn)
+        .withService(
+            new EntityReference()
+                .withId(serviceId)
+                .withType(Entity.STORAGE_SERVICE)
+                .withFullyQualifiedName(serviceFqn));
+  }
+
+  private static EntityReference parentRef(UUID id) {
+    return new EntityReference().withId(id).withType(CONTAINER);
+  }
+
+  @Test
+  void validateParent_allowsNullParent_movingToTopLevel() {
+    Container original =
+        container(UUID.randomUUID(), SERVICE_A_FQN + ".bucket", SERVICE_A, SERVICE_A_FQN);
+    Container updated =
+        container(original.getId(), original.getFullyQualifiedName(), SERVICE_A, SERVICE_A_FQN);
+    updated.setParent(null);
+
+    assertDoesNotThrow(() -> ContainerRepository.validateContainerParent(original, updated));
+  }
+
+  @Test
+  void validateParent_allowsSiblingMoveInSameService() {
+    UUID originalId = UUID.randomUUID();
+    UUID newParentId = UUID.randomUUID();
+    Container original =
+        container(originalId, SERVICE_A_FQN + ".bucketA.child", SERVICE_A, SERVICE_A_FQN);
+    Container updated =
+        container(originalId, original.getFullyQualifiedName(), SERVICE_A, SERVICE_A_FQN);
+    updated.setParent(parentRef(newParentId));
+
+    Container newParent =
+        container(newParentId, SERVICE_A_FQN + ".bucketB", SERVICE_A, SERVICE_A_FQN);
+
+    try (MockedStatic<Entity> mocked = mockStatic(Entity.class)) {
+      mocked
+          .when(
+              () ->
+                  Entity.getEntity(eq(CONTAINER), eq(newParentId), eq("service"), eq(NON_DELETED)))
+          .thenReturn(newParent);
+
+      assertDoesNotThrow(() -> ContainerRepository.validateContainerParent(original, updated));
+    }
+  }
+
+  @Test
+  void validateParent_rejectsSelfParent() {
+    UUID originalId = UUID.randomUUID();
+    Container original =
+        container(originalId, SERVICE_A_FQN + ".bucketA", SERVICE_A, SERVICE_A_FQN);
+    Container updated =
+        container(originalId, original.getFullyQualifiedName(), SERVICE_A, SERVICE_A_FQN);
+    updated.setParent(parentRef(originalId));
+
+    try (MockedStatic<Entity> mocked = mockStatic(Entity.class)) {
+      mocked
+          .when(
+              () -> Entity.getEntity(eq(CONTAINER), eq(originalId), eq("service"), eq(NON_DELETED)))
+          .thenReturn(original);
+
+      IllegalArgumentException ex =
+          assertThrows(
+              IllegalArgumentException.class,
+              () -> ContainerRepository.validateContainerParent(original, updated));
+      assertTrue(ex.getMessage().contains(SERVICE_A_FQN + ".bucketA"));
+      assertTrue(ex.getMessage().contains("itself or to its descendant"));
+    }
+  }
+
+  @Test
+  void validateParent_rejectsDescendantAsParent() {
+    UUID originalId = UUID.randomUUID();
+    UUID descendantId = UUID.randomUUID();
+    Container original =
+        container(originalId, SERVICE_A_FQN + ".bucketA", SERVICE_A, SERVICE_A_FQN);
+    Container updated =
+        container(originalId, original.getFullyQualifiedName(), SERVICE_A, SERVICE_A_FQN);
+    updated.setParent(parentRef(descendantId));
+
+    // Descendant FQN starts with original FQN + "." — would create a cycle.
+    Container descendant =
+        container(
+            descendantId, SERVICE_A_FQN + ".bucketA.subfolder.deep", SERVICE_A, SERVICE_A_FQN);
+
+    try (MockedStatic<Entity> mocked = mockStatic(Entity.class)) {
+      mocked
+          .when(
+              () ->
+                  Entity.getEntity(eq(CONTAINER), eq(descendantId), eq("service"), eq(NON_DELETED)))
+          .thenReturn(descendant);
+
+      IllegalArgumentException ex =
+          assertThrows(
+              IllegalArgumentException.class,
+              () -> ContainerRepository.validateContainerParent(original, updated));
+      assertTrue(ex.getMessage().contains("descendant"));
+    }
+  }
+
+  @Test
+  void validateParent_rejectsCrossServiceParent() {
+    UUID originalId = UUID.randomUUID();
+    UUID newParentId = UUID.randomUUID();
+    Container original =
+        container(originalId, SERVICE_A_FQN + ".bucketA", SERVICE_A, SERVICE_A_FQN);
+    Container updated =
+        container(originalId, original.getFullyQualifiedName(), SERVICE_A, SERVICE_A_FQN);
+    updated.setParent(parentRef(newParentId));
+
+    Container parentInDifferentService =
+        container(newParentId, SERVICE_B_FQN + ".bucketX", SERVICE_B, SERVICE_B_FQN);
+
+    try (MockedStatic<Entity> mocked = mockStatic(Entity.class)) {
+      mocked
+          .when(
+              () ->
+                  Entity.getEntity(eq(CONTAINER), eq(newParentId), eq("service"), eq(NON_DELETED)))
+          .thenReturn(parentInDifferentService);
+
+      IllegalArgumentException ex =
+          assertThrows(
+              IllegalArgumentException.class,
+              () -> ContainerRepository.validateContainerParent(original, updated));
+      assertTrue(ex.getMessage().contains(SERVICE_A_FQN));
+      assertTrue(ex.getMessage().contains(SERVICE_B_FQN));
+      assertTrue(ex.getMessage().contains("different StorageService"));
+    }
+  }
+
+  @Test
+  void validateParent_propagatesEntityLookupFailure() {
+    UUID originalId = UUID.randomUUID();
+    UUID missingParentId = UUID.randomUUID();
+    Container original =
+        container(originalId, SERVICE_A_FQN + ".bucketA", SERVICE_A, SERVICE_A_FQN);
+    Container updated =
+        container(originalId, original.getFullyQualifiedName(), SERVICE_A, SERVICE_A_FQN);
+    updated.setParent(parentRef(missingParentId));
+
+    try (MockedStatic<Entity> mocked = mockStatic(Entity.class)) {
+      mocked
+          .when(
+              () ->
+                  Entity.getEntity(eq(CONTAINER), any(UUID.class), eq("service"), eq(NON_DELETED)))
+          .thenThrow(new RuntimeException("not found"));
+
+      assertThrows(
+          RuntimeException.class,
+          () -> ContainerRepository.validateContainerParent(original, updated));
+    }
+  }
+}

--- a/openmetadata-service/src/test/java/org/openmetadata/service/jdbi3/ContainerRepositoryParentValidationTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/jdbi3/ContainerRepositoryParentValidationTest.java
@@ -11,6 +11,7 @@
 package org.openmetadata.service.jdbi3;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -171,6 +172,64 @@ class ContainerRepositoryParentValidationTest {
       assertTrue(ex.getMessage().contains(SERVICE_A_FQN));
       assertTrue(ex.getMessage().contains(SERVICE_B_FQN));
       assertTrue(ex.getMessage().contains("different StorageService"));
+    }
+  }
+
+  @Test
+  void validateSubtreeSize_allowsUnderLimit() {
+    assertDoesNotThrow(
+        () -> ContainerRepository.validateSubtreeSize(SERVICE_A_FQN + ".bucket", 0, 100));
+    assertDoesNotThrow(
+        () -> ContainerRepository.validateSubtreeSize(SERVICE_A_FQN + ".bucket", 50, 100));
+  }
+
+  @Test
+  void validateSubtreeSize_allowsAtLimit() {
+    // 10 descendants when the limit is exactly 10 is still allowed — the check is strict >.
+    assertDoesNotThrow(
+        () -> ContainerRepository.validateSubtreeSize(SERVICE_A_FQN + ".bucket", 10, 10));
+  }
+
+  @Test
+  void validateSubtreeSize_rejectsOverLimit() {
+    IllegalArgumentException ex =
+        assertThrows(
+            IllegalArgumentException.class,
+            () ->
+                ContainerRepository.validateSubtreeSize(
+                    SERVICE_A_FQN + ".bucket", 1_500_000, 10_000));
+    assertTrue(ex.getMessage().contains(SERVICE_A_FQN + ".bucket"));
+    assertTrue(ex.getMessage().contains("1500000"));
+    assertTrue(ex.getMessage().contains("10000"));
+    assertTrue(ex.getMessage().contains("openmetadata.container.maxReparentDescendants"));
+  }
+
+  @Test
+  void maxReparentDescendants_defaultsTo10000WhenPropertyUnset() {
+    String previous = System.clearProperty("openmetadata.container.maxReparentDescendants");
+    try {
+      assertEquals(10_000, ContainerRepository.maxReparentDescendants());
+      assertEquals(
+          ContainerRepository.DEFAULT_MAX_REPARENT_DESCENDANTS,
+          ContainerRepository.maxReparentDescendants());
+    } finally {
+      if (previous != null) {
+        System.setProperty("openmetadata.container.maxReparentDescendants", previous);
+      }
+    }
+  }
+
+  @Test
+  void maxReparentDescendants_readsSystemPropertyOverride() {
+    String previous = System.setProperty("openmetadata.container.maxReparentDescendants", "42");
+    try {
+      assertEquals(42, ContainerRepository.maxReparentDescendants());
+    } finally {
+      if (previous == null) {
+        System.clearProperty("openmetadata.container.maxReparentDescendants");
+      } else {
+        System.setProperty("openmetadata.container.maxReparentDescendants", previous);
+      }
     }
   }
 


### PR DESCRIPTION
### Describe your changes:

Fixes #24294

Allow the PATCH API to update a Container's `parent` so users can re-parent containers (and their entire subtree) without delete+recreate, preserving followers, likes, ownership, tags, and other metadata.

#
### Type of change:
- [x] New feature

#
### High-level design:

`ContainerRepository.restorePatchAttributes` no longer wipes `parent`, `CONTAINER_PATCH_FIELDS` now includes it, and a new `ContainerUpdater.updateParent` runs the same FQN-cascade flow `GlossaryTermRepository.updateNameAndParent` uses — invalidate descendant caches, bulk-rewrite descendant FQNs, re-apply tags, rename `tag_usage` targets for classification + glossary sources, rewrite entity-links, rewrite policy conditions, swap the `CONTAINS` relationship edge, and reindex the search documents via `updateByFqnPrefix`. `ContainerDAO.updateFqn` is overridden because the generic MySQL `JSON_REPLACE` only rewrites `$.fullyQualifiedName` and silently leaves `dataModel.columns[*].fullyQualifiedName` pointing at the old parent. `setFullyQualifiedName` no longer falls back to the relationship table when `parent` is null in-memory — that fallback was silently restoring the cleared parent on every "promote to top-level" PATCH. Validation is extracted to a package-private static helper `validateContainerParent` and rejects cross-StorageService parents (HTTP 400), self-parent, and descendant-as-parent cycles. Java fluent SDK gains `Containers.create().under(...)` (3 overloads) plus `FluentContainer.withParent(...)`/`withParentFqn`/`withoutParent`; Python fluent SDK gains `Containers.set_parent` and `Containers.clear_parent` following the existing `Tables.add_tag` PATCH idiom — `parent` was already in `ALLOWED_COMMON_PATCH_FIELDS`. Scoped to same-StorageService moves; cross-service is explicitly rejected.

#
### Tests:

#### Use cases covered
- Move a container under a new parent in the same StorageService; followers/tags/owners/description survive the move
- Moving a container cascades the FQN to every descendant container and to nested `dataModel.columns[*].fullyQualifiedName`
- Set parent to `null` to promote a container to top-level under its service; set a parent on a previously top-level container
- Reject cycles (self-parent, descendant-as-parent), cross-service parents, and non-existent parents
- Re-parent emits a proper `changeDescription` with `parent` recorded and bumps the entity version

#### Unit tests
- `openmetadata-service/src/test/java/org/openmetadata/service/jdbi3/ContainerRepositoryParentValidationTest.java` — 6 tests, all pass

#### Backend integration tests
- `openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/ContainerResourceIT.java` — 11 new `@Test` methods; full class is **253/253 passing** (17 pre-existing skipped)

#### Ingestion integration tests
- Not applicable for backend cascade; 2 new Python unit tests added to `ingestion/tests/unit/sdk/test_container_entity.py` for the fluent SDK (14/14 pass)

#### Playwright (UI) tests
- Not applicable (no UI changes)

#### Manual testing performed
- `mvn -DskipTests clean install` (full build)
- `mvn test -pl openmetadata-integration-tests -Dtest=ContainerResourceIT` against the spawned MySQL/OpenSearch test harness — 253/253 passing
- `mvn spotless:check` and `make py_format_check` — both clean

#
### UI screen recording / screenshots:

Not applicable.

#
### Checklist:
- [x] I have read the **CONTRIBUTING** document.
- [x] My PR title is `Fixes <issue-number>: <short explanation>`
- [x] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have added tests (unit / integration / Playwright as applicable) and listed them above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

----
## Summary by Gitar

- **Performance and logic:**
  - Optimized `setFields` to resolve parent only when requested, reducing unnecessary database round-trips for standard GET requests.
- **Data integrity:**
  - Updated `updateEntityLinks` to process all descendants from `renamedContainers` instead of just direct children, ensuring consistent FQN updates for deeply nested feed threads.

<sub>This will update automatically on new commits.</sub>