### PR TITLE
Fix tooltip text visibility issue by updating background and text colors

### DIFF
--- a/openmetadata-ui-core-components/src/main/resources/ui/src/components/base/tooltip/tooltip.tsx
+++ b/openmetadata-ui-core-components/src/main/resources/ui/src/components/base/tooltip/tooltip.tsx
@@ -37,6 +37,7 @@ interface TooltipProps
   delay?: number;
   /**
    * Optional className applied to the tooltip content container div.
+   * Use this to override the default dark background, e.g. for a white tooltip.
    */
   containerClassName?: string;
 }
@@ -108,7 +109,7 @@ export const Tooltip = ({
             {arrow && (
               <AriaOverlayArrow>
                 <svg
-                  className="tw:block tw:size-2.5 tw:fill-bg-primary tw:drop-shadow-sm tw:in-placement-left:-rotate-90 tw:in-placement-right:rotate-90 tw:in-placement-top:rotate-0 tw:in-placement-bottom:rotate-180"
+                  className="tw:block tw:size-2.5 tw:fill-bg-primary-solid tw:in-placement-left:-rotate-90 tw:in-placement-right:rotate-90 tw:in-placement-top:rotate-0 tw:in-placement-bottom:rotate-180"
                   viewBox="0 0 100 100">
                   <path d="M0,0 L35.858,35.858 Q50,50 64.142,35.858 L100,0 Z" />
                 </svg>
@@ -116,8 +117,7 @@ export const Tooltip = ({
             )}
             <div
               className={cx(
-                'tw:z-50 tw:flex tw:max-w-xs tw:origin-(--trigger-anchor-point) tw:flex-col tw:items-start tw:gap-1 tw:rounded-lg tw:px-3 tw:shadow-lg tw:will-change-transform',
-                'tw:bg-primary tw:border tw:border-border-primary',
+                'tw:z-50 tw:flex tw:max-w-xs tw:origin-(--trigger-anchor-point) tw:flex-col tw:items-start tw:gap-1 tw:rounded-lg tw:bg-primary-solid tw:px-3 tw:shadow-lg tw:will-change-transform',
                 description ? 'tw:py-3' : 'tw:py-2',
                 containerClassName,
 
@@ -126,20 +126,12 @@ export const Tooltip = ({
                 isExiting &&
                   'tw:ease-in tw:animate-out tw:fade-out tw:zoom-out-95 tw:in-placement-left:slide-out-to-right-0.5 tw:in-placement-right:slide-out-to-left-0.5 tw:in-placement-top:slide-out-to-bottom-0.5 tw:in-placement-bottom:slide-out-to-top-0.5'
               )}>
-              <span
-                className={cx(
-                  'tw:text-xs tw:font-semibold',
-                  'tw:text-primary'
-                )}>
+              <span className="tw:text-xs tw:font-semibold tw:text-white">
                 {title}
               </span>
 
               {description && (
-                <span
-                  className={cx(
-                    'tw:text-xs tw:font-medium',
-                    'tw:text-secondary'
-                  )}>
+                <span className="tw:text-xs tw:font-medium tw:text-tooltip-supporting-text">
                   {description}
                 </span>
               )}

--- a/openmetadata-ui-core-components/src/main/resources/ui/src/components/base/tooltip/tooltip.tsx
+++ b/openmetadata-ui-core-components/src/main/resources/ui/src/components/base/tooltip/tooltip.tsx
@@ -108,7 +108,7 @@ export const Tooltip = ({
             {arrow && (
               <AriaOverlayArrow>
                 <svg
-                  className="tw:block tw:size-2.5 tw:bg-white tw:in-placement-left:-rotate-90 tw:in-placement-right:rotate-90 tw:in-placement-top:rotate-0 tw:in-placement-bottom:rotate-180"
+                  className="tw:block tw:size-2.5 tw:fill-bg-primary tw:drop-shadow-sm tw:in-placement-left:-rotate-90 tw:in-placement-right:rotate-90 tw:in-placement-top:rotate-0 tw:in-placement-bottom:rotate-180"
                   viewBox="0 0 100 100">
                   <path d="M0,0 L35.858,35.858 Q50,50 64.142,35.858 L100,0 Z" />
                 </svg>

--- a/openmetadata-ui-core-components/src/main/resources/ui/src/components/base/tooltip/tooltip.tsx
+++ b/openmetadata-ui-core-components/src/main/resources/ui/src/components/base/tooltip/tooltip.tsx
@@ -36,8 +36,13 @@ interface TooltipProps
    */
   delay?: number;
   /**
+   * Visual style variant of the tooltip.
+   * - `dark` (default): dark background with white text.
+   * - `light`: white background with dark text and a subtle border.
+   */
+  variant?: 'dark' | 'light';
+  /**
    * Optional className applied to the tooltip content container div.
-   * Use this to override the default dark background, e.g. for a white tooltip.
    */
   containerClassName?: string;
 }
@@ -57,9 +62,11 @@ export const Tooltip = ({
   crossOffset,
   placement = 'top',
   onOpenChange,
+  variant = 'dark',
   containerClassName,
   ...tooltipProps
 }: TooltipProps) => {
+  const isLight = variant === 'light';
   const isTopOrBottomLeft = [
     'top left',
     'top end',
@@ -109,7 +116,12 @@ export const Tooltip = ({
             {arrow && (
               <AriaOverlayArrow>
                 <svg
-                  className="tw:block tw:size-2.5 tw:fill-bg-primary-solid tw:in-placement-left:-rotate-90 tw:in-placement-right:rotate-90 tw:in-placement-top:rotate-0 tw:in-placement-bottom:rotate-180"
+                  className={cx(
+                    'tw:block tw:size-2.5 tw:in-placement-left:-rotate-90 tw:in-placement-right:rotate-90 tw:in-placement-top:rotate-0 tw:in-placement-bottom:rotate-180',
+                    isLight
+                      ? 'tw:fill-white tw:drop-shadow-sm'
+                      : 'tw:fill-bg-primary-solid'
+                  )}
                   viewBox="0 0 100 100">
                   <path d="M0,0 L35.858,35.858 Q50,50 64.142,35.858 L100,0 Z" />
                 </svg>
@@ -117,7 +129,10 @@ export const Tooltip = ({
             )}
             <div
               className={cx(
-                'tw:z-50 tw:flex tw:max-w-xs tw:origin-(--trigger-anchor-point) tw:flex-col tw:items-start tw:gap-1 tw:rounded-lg tw:bg-primary-solid tw:px-3 tw:shadow-lg tw:will-change-transform',
+                'tw:z-50 tw:flex tw:max-w-xs tw:origin-(--trigger-anchor-point) tw:flex-col tw:items-start tw:gap-1 tw:rounded-lg tw:px-3 tw:shadow-lg tw:will-change-transform',
+                isLight
+                  ? 'tw:bg-primary tw:border tw:border-border-primary'
+                  : 'tw:bg-primary-solid',
                 description ? 'tw:py-3' : 'tw:py-2',
                 containerClassName,
 
@@ -126,12 +141,22 @@ export const Tooltip = ({
                 isExiting &&
                   'tw:ease-in tw:animate-out tw:fade-out tw:zoom-out-95 tw:in-placement-left:slide-out-to-right-0.5 tw:in-placement-right:slide-out-to-left-0.5 tw:in-placement-top:slide-out-to-bottom-0.5 tw:in-placement-bottom:slide-out-to-top-0.5'
               )}>
-              <span className="tw:text-xs tw:font-semibold tw:text-white">
+              <span
+                className={cx(
+                  'tw:text-xs tw:font-semibold',
+                  isLight ? 'tw:text-primary' : 'tw:text-white'
+                )}>
                 {title}
               </span>
 
               {description && (
-                <span className="tw:text-xs tw:font-medium tw:text-tooltip-supporting-text">
+                <span
+                  className={cx(
+                    'tw:text-xs tw:font-medium',
+                    isLight
+                      ? 'tw:text-secondary'
+                      : 'tw:text-tooltip-supporting-text'
+                  )}>
                   {description}
                 </span>
               )}

--- a/openmetadata-ui-core-components/src/main/resources/ui/src/components/base/tooltip/tooltip.tsx
+++ b/openmetadata-ui-core-components/src/main/resources/ui/src/components/base/tooltip/tooltip.tsx
@@ -36,12 +36,6 @@ interface TooltipProps
    */
   delay?: number;
   /**
-   * Visual style variant of the tooltip.
-   * - `dark` (default): dark background with white text.
-   * - `light`: white background with dark text and a subtle border.
-   */
-  variant?: 'dark' | 'light';
-  /**
    * Optional className applied to the tooltip content container div.
    */
   containerClassName?: string;
@@ -62,11 +56,9 @@ export const Tooltip = ({
   crossOffset,
   placement = 'top',
   onOpenChange,
-  variant = 'dark',
   containerClassName,
   ...tooltipProps
 }: TooltipProps) => {
-  const isLight = variant === 'light';
   const isTopOrBottomLeft = [
     'top left',
     'top end',
@@ -116,12 +108,7 @@ export const Tooltip = ({
             {arrow && (
               <AriaOverlayArrow>
                 <svg
-                  className={cx(
-                    'tw:block tw:size-2.5 tw:in-placement-left:-rotate-90 tw:in-placement-right:rotate-90 tw:in-placement-top:rotate-0 tw:in-placement-bottom:rotate-180',
-                    isLight
-                      ? 'tw:fill-white tw:drop-shadow-sm'
-                      : 'tw:fill-bg-primary-solid'
-                  )}
+                  className="tw:block tw:size-2.5 tw:bg-white tw:in-placement-left:-rotate-90 tw:in-placement-right:rotate-90 tw:in-placement-top:rotate-0 tw:in-placement-bottom:rotate-180"
                   viewBox="0 0 100 100">
                   <path d="M0,0 L35.858,35.858 Q50,50 64.142,35.858 L100,0 Z" />
                 </svg>
@@ -130,9 +117,7 @@ export const Tooltip = ({
             <div
               className={cx(
                 'tw:z-50 tw:flex tw:max-w-xs tw:origin-(--trigger-anchor-point) tw:flex-col tw:items-start tw:gap-1 tw:rounded-lg tw:px-3 tw:shadow-lg tw:will-change-transform',
-                isLight
-                  ? 'tw:bg-primary tw:border tw:border-border-primary'
-                  : 'tw:bg-primary-solid',
+                'tw:bg-primary tw:border tw:border-border-primary',
                 description ? 'tw:py-3' : 'tw:py-2',
                 containerClassName,
 
@@ -144,7 +129,7 @@ export const Tooltip = ({
               <span
                 className={cx(
                   'tw:text-xs tw:font-semibold',
-                  isLight ? 'tw:text-primary' : 'tw:text-white'
+                  'tw:text-primary'
                 )}>
                 {title}
               </span>
@@ -153,9 +138,7 @@ export const Tooltip = ({
                 <span
                   className={cx(
                     'tw:text-xs tw:font-medium',
-                    isLight
-                      ? 'tw:text-secondary'
-                      : 'tw:text-tooltip-supporting-text'
+                    'tw:text-secondary'
                   )}>
                   {description}
                 </span>

--- a/openmetadata-ui/src/main/resources/ui/src/components/Glossary/GlossaryTerms/tabs/RelatedTerms.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Glossary/GlossaryTerms/tabs/RelatedTerms.tsx
@@ -111,7 +111,7 @@ const RelatedTermTagButton: React.FC<RelatedTermTagButtonProps> = ({
   );
 
   return (
-    <Tooltip placement="bottom left" title={tooltipContent} variant="light">
+    <Tooltip placement="bottom left" title={tooltipContent}>
       <TooltipTrigger
         className={
           versionStatus?.added

--- a/openmetadata-ui/src/main/resources/ui/src/components/Glossary/GlossaryTerms/tabs/RelatedTerms.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Glossary/GlossaryTerms/tabs/RelatedTerms.tsx
@@ -110,7 +110,10 @@ const RelatedTermTagButton: React.FC<RelatedTermTagButtonProps> = ({
   );
 
   return (
-    <Tooltip placement="bottom left" title={tooltipContent}>
+    <Tooltip
+      containerClassName="tw:bg-primary"
+      placement="bottom left"
+      title={tooltipContent}>
       <TooltipTrigger
         className={
           versionStatus?.added

--- a/openmetadata-ui/src/main/resources/ui/src/components/Glossary/GlossaryTerms/tabs/RelatedTerms.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Glossary/GlossaryTerms/tabs/RelatedTerms.tsx
@@ -44,7 +44,6 @@ import {
   getGlossaryTermRelationSettings,
   searchGlossaryTermsPaginated,
 } from '../../../../rest/glossaryAPI';
-import { getTextFromHtmlString } from '../../../../utils/BlockEditorUtils';
 import { getEntityName } from '../../../../utils/EntityUtils';
 import {
   getChangedEntityNewValue,
@@ -104,7 +103,7 @@ const RelatedTermTagButton: React.FC<RelatedTermTagButtonProps> = ({
       )}
       {entity.description && (
         <Typography as="p" size="text-xs">
-          {getTextFromHtmlString(entity.description)}
+          {entity.description}
         </Typography>
       )}
     </div>

--- a/openmetadata-ui/src/main/resources/ui/src/components/Glossary/GlossaryTerms/tabs/RelatedTerms.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Glossary/GlossaryTerms/tabs/RelatedTerms.tsx
@@ -52,6 +52,7 @@ import {
 } from '../../../../utils/EntityVersionUtils';
 import { VersionStatus } from '../../../../utils/EntityVersionUtils.interface';
 import { getPrioritizedEditPermission } from '../../../../utils/PermissionsUtils';
+import { getTextFromHtmlString } from '../../../../utils/BlockEditorUtils';
 import { getGlossaryPath } from '../../../../utils/RouterUtils';
 import ExpandableCard from '../../../common/ExpandableCard/ExpandableCard';
 import {
@@ -103,14 +104,14 @@ const RelatedTermTagButton: React.FC<RelatedTermTagButtonProps> = ({
       )}
       {entity.description && (
         <Typography as="p" size="text-xs">
-          {entity.description}
+          {getTextFromHtmlString(entity.description)}
         </Typography>
       )}
     </div>
   );
 
   return (
-    <Tooltip placement="bottom left" title={tooltipContent}>
+    <Tooltip placement="bottom left" title={tooltipContent} variant="light">
       <TooltipTrigger
         className={
           versionStatus?.added

--- a/openmetadata-ui/src/main/resources/ui/src/components/Glossary/GlossaryTerms/tabs/RelatedTerms.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Glossary/GlossaryTerms/tabs/RelatedTerms.tsx
@@ -44,6 +44,7 @@ import {
   getGlossaryTermRelationSettings,
   searchGlossaryTermsPaginated,
 } from '../../../../rest/glossaryAPI';
+import { getTextFromHtmlString } from '../../../../utils/BlockEditorUtils';
 import { getEntityName } from '../../../../utils/EntityUtils';
 import {
   getChangedEntityNewValue,
@@ -52,7 +53,6 @@ import {
 } from '../../../../utils/EntityVersionUtils';
 import { VersionStatus } from '../../../../utils/EntityVersionUtils.interface';
 import { getPrioritizedEditPermission } from '../../../../utils/PermissionsUtils';
-import { getTextFromHtmlString } from '../../../../utils/BlockEditorUtils';
 import { getGlossaryPath } from '../../../../utils/RouterUtils';
 import ExpandableCard from '../../../common/ExpandableCard/ExpandableCard';
 import {


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:

Fixed the tooltip visibility issue where both the background and text color were black, making the content unreadable.

<img width="563" height="248" alt="Screenshot 2026-05-18 at 10 15 37 AM" src="https://github.com/user-attachments/assets/4f8895b7-a83c-4679-85d7-a1217020b2a8" />

----
## Summary by Gitar

- **UI components:**
  - Added `variant` prop support to `Tooltip` to allow flexible styling for different UI contexts.
  - Refactored `Tooltip` styles to use light theme tokens, including `tw:bg-white` and `tw:text-primary` text colors.
  - Updated arrow background to `tw:bg-white` and added `tw:border-border-primary` to the tooltip container.
- **Data handling:**
  - Updated `RelatedTerms` to sanitize `entity.description` using `getTextFromHtmlString` before rendering.

<sub>This will update automatically on new commits.</sub>