### PR TITLE
fix(users): Online Users 'All time' filter returns empty (#28145) [1.13]

### DIFF
--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/UserResourceIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/UserResourceIT.java
@@ -48,10 +48,13 @@ import org.openmetadata.schema.type.EntityHistory;
 import org.openmetadata.schema.type.EntityReference;
 import org.openmetadata.schema.type.ImageList;
 import org.openmetadata.schema.type.Profile;
+import org.openmetadata.schema.utils.ResultList;
 import org.openmetadata.sdk.fluent.Personas;
 import org.openmetadata.sdk.fluent.Users;
 import org.openmetadata.sdk.models.ListParams;
 import org.openmetadata.sdk.models.ListResponse;
+import org.openmetadata.sdk.network.HttpMethod;
+import org.openmetadata.sdk.network.RequestOptions;
 import org.openmetadata.service.security.policyevaluator.SubjectCache;
 import org.openmetadata.service.security.policyevaluator.SubjectContext;
 
@@ -2285,6 +2288,50 @@ public class UserResourceIT extends BaseEntityIT<User, CreateUser> {
     // Cleanup: Remove the test user
     deleteEntity(testUser.getId().toString());
   }
+
+  // ===================================================================
+  // ONLINE USERS ENDPOINT
+  // ===================================================================
+
+  @Test
+  void test_listOnlineUsers_allTimeWindow_includesUserWithNoActivity(TestNamespace ns) {
+    String name = ns.prefix("onlineAllTime");
+    CreateUser createRequest =
+        new CreateUser()
+            .withName(name)
+            .withEmail(toValidEmail(name))
+            .withDescription("User with no login activity for online-users test");
+    User user = createEntity(createRequest);
+    UUID userId = user.getId();
+
+    ResultList<User> withWindow = listOnlineUsers(5, 1_000_000);
+    assertNotNull(withWindow.getData(), "withWindow response must contain a data list");
+    assertFalse(
+        withWindow.getData().stream().anyMatch(u -> userId.equals(u.getId())),
+        "User with null lastLoginTime/lastActivityTime must not appear in a finite-window response");
+
+    ResultList<User> allTime = listOnlineUsers(0, 1_000_000);
+    assertNotNull(allTime.getData(), "allTime response must contain a data list");
+    assertTrue(
+        allTime.getData().stream().anyMatch(u -> userId.equals(u.getId())),
+        "timeWindow=0 must return all non-bot users, including those with no recorded activity");
+    assertTrue(
+        allTime.getData().stream().noneMatch(u -> Boolean.TRUE.equals(u.getIsBot())),
+        "Online users response must exclude bots");
+  }
+
+  private ResultList<User> listOnlineUsers(int timeWindow, int limit) {
+    RequestOptions options =
+        RequestOptions.builder()
+            .queryParam("timeWindow", String.valueOf(timeWindow))
+            .queryParam("limit", String.valueOf(limit))
+            .build();
+    return SdkClients.adminClient()
+        .getHttpClient()
+        .execute(HttpMethod.GET, "/v1/users/online", null, UserResultList.class, options);
+  }
+
+  private static class UserResultList extends ResultList<User> {}
 
   // ===================================================================
   // VERSION HISTORY SUPPORT

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/teams/UserResource.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/teams/UserResource.java
@@ -332,10 +332,11 @@ public class UserResource extends EntityResource<User, UserRepository> {
       @Context SecurityContext securityContext,
       @Parameter(
               description =
-                  "Time window in minutes (default: 5). Examples: 1 (last minute), 5 (last 5 minutes), 60 (last hour), 1440 (last day)",
+                  "Time window in minutes (default: 5). Use 0 for all time. Examples: 0 (all time), 1 (last minute), 5 (last 5 minutes), 60 (last hour), 1440 (last day)",
               schema = @Schema(type = "integer", example = "5"))
           @QueryParam("timeWindow")
           @DefaultValue("5")
+          @Min(value = 0, message = "must be greater than or equal to 0")
           int timeWindow,
       @Parameter(
               description = "Fields requested in the returned resource",
@@ -368,8 +369,10 @@ public class UserResource extends EntityResource<User, UserRepository> {
 
     // Create filter for online users - uses both lastLoginTime and lastActivityTime
     ListFilter filter = new ListFilter(Include.NON_DELETED);
-    filter.addQueryParam("lastActivityTimeGreaterThan", String.valueOf(thresholdTimestamp));
     filter.addQueryParam("isBot", "false"); // Exclude bots from online users
+    if (timeWindow > 0) {
+      filter.addQueryParam("lastActivityTimeGreaterThan", String.valueOf(thresholdTimestamp));
+    }
 
     ResultList<User> users =
         listInternal(uriInfo, securityContext, fieldsParam, filter, limitParam, before, after);


### PR DESCRIPTION
Cherry-pick of #28145 to 1.13.

## Summary

Closes #27993 on the 1.13 release branch.

The `/v1/users/online` endpoint computed the SQL threshold as `now - timeWindow*60*1000`. When the UI sent `timeWindow=0` for the **All time** dropdown option, the threshold collapsed to `now`, producing `lastActivityTime > now` — which matches zero rows. The page therefore rendered empty whenever a user selected *All*.

The fix skips the time predicate entirely when `timeWindow <= 0`, so the filter falls through to "all non-bot users".

### Conflict resolution

`UserResourceIT.java` import block — kept both the existing `SubjectCache`/`SubjectContext` imports (already on 1.13) and the new `HttpMethod`/`RequestOptions` imports the new test needs.

## Test plan

- [x] `mvn -pl openmetadata-service,openmetadata-integration-tests -am test-compile` passes locally
- [ ] CI green
- [ ] Manual: in the UI, open *Settings → Members → Online Users*, select **All time** — list populates