### PR TITLE
fix(entity): null-safe updateColumns for entities without columns (#28047) [1.12.9]

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/EntityRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/EntityRepository.java
@@ -6697,6 +6697,8 @@ public abstract class EntityRepository<T extends EntityInterface> {
         List<Column> origColumns,
         List<Column> updatedColumns,
         BiPredicate<Column, Column> columnMatch) {
+      origColumns = listOrEmpty(origColumns);
+      updatedColumns = listOrEmpty(updatedColumns);
       List<Column> deletedColumns = new ArrayList<>();
       List<Column> addedColumns = new ArrayList<>();
       HashMap<String, String> originalUpdatedColumnFqns = new HashMap<>();
@@ -6729,7 +6731,9 @@ public abstract class EntityRepository<T extends EntityInterface> {
       // Add tags related to newly added columns
       for (Column added : addedColumns) {
         applyTags(
-            added.getTags().stream().map(tag -> tag.withAppliedBy(updatingUser.getName())).toList(),
+            listOrEmpty(added.getTags()).stream()
+                .map(tag -> tag.withAppliedBy(updatingUser.getName()))
+                .toList(),
             added.getFullyQualifiedName());
       }
 


### PR DESCRIPTION
Cherry-pick of #28047 to 1.12.9 — code-only subset.

## Summary

PATCH on a File without columns (PDF/image/etc.) returns 500 with
`NullPointerException: Cannot invoke java.util.List.iterator() because updatedColumns is null`.
Any edit — tags, glossary terms, description, owner — triggers it because
`FileRepository.entitySpecificUpdate` unconditionally calls
`updateColumns(..., original.getColumns(), updated.getColumns(), ...)`.

Fix: null-coalesce `origColumns` and `updatedColumns` at the top of
`ColumnEntityUpdater.updateColumns`, plus guard `added.getTags().stream()`
with `listOrEmpty` so a tag-less added column doesn't NPE either.

## Scope vs main PR

Only `EntityRepository.java` carried over. The rest of #28047 doesn't apply to 1.12.9:

- `FolderResource.java`, `FolderService.java`, `FolderResourceIT.java` — the Folder entity (PR #27558 "Context center") isn't on 1.12.9.
- `BaseEntityIT.java` + Directory/File/Spreadsheet IT migrations — IT-infrastructure refactor, not part of the bug fix.

## Test plan

- [x] `mvn -pl openmetadata-service -am compile` passes locally
- [ ] CI green
- [ ] Manual: PATCH /api/v1/drives/files/{id} on a PDF file (no columns) returns 200