### PR TITLE
fix(entity): null-safe updateColumns for entities without columns (#28047) [1.13]

### DIFF
--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/FileResourceIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/FileResourceIT.java
@@ -421,4 +421,31 @@ public class FileResourceIT {
     // PDF files should not have columns
     assertNull(createdFile.getColumns());
   }
+
+  @Test
+  void test_patchFileWithoutColumns_doesNotNpe(TestNamespace ns) {
+    // Regression: PATCH on a file without columns must not NPE in
+    // ColumnEntityUpdater.updateColumns. Reproduces the failure seen when
+    // editing tags/description on PDF/image files (no columns defined).
+    DriveService driveService = DriveServiceTestFactory.createGoogleDrive(ns);
+
+    String fileName = ns.prefix("patch_no_columns");
+    File createdFile =
+        Files.create()
+            .name(fileName)
+            .withService(driveService.getFullyQualifiedName())
+            .withFileType(FileType.PDF)
+            .withMimeType("application/pdf")
+            .withDescription("Initial description")
+            .execute();
+
+    assertNull(createdFile.getColumns());
+
+    createdFile.setDescription("Updated description");
+    File patched =
+        SdkClients.adminClient().files().update(createdFile.getId().toString(), createdFile);
+
+    assertEquals("Updated description", patched.getDescription());
+    assertNull(patched.getColumns());
+  }
 }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/EntityRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/EntityRepository.java
@@ -8773,6 +8773,8 @@ public abstract class EntityRepository<T extends EntityInterface> {
         List<Column> origColumns,
         List<Column> updatedColumns,
         BiPredicate<Column, Column> columnMatch) {
+      origColumns = listOrEmpty(origColumns);
+      updatedColumns = listOrEmpty(updatedColumns);
       List<Column> deletedColumns = new ArrayList<>();
       List<Column> addedColumns = new ArrayList<>();
       HashMap<String, String> originalUpdatedColumnFqns = new HashMap<>();
@@ -8805,7 +8807,9 @@ public abstract class EntityRepository<T extends EntityInterface> {
       // Add tags related to newly added columns
       for (Column added : addedColumns) {
         applyTagsAddInFlushAndDeferRdf(
-            added.getTags().stream().map(tag -> tag.withAppliedBy(updatingUser.getName())).toList(),
+            listOrEmpty(added.getTags()).stream()
+                .map(tag -> tag.withAppliedBy(updatingUser.getName()))
+                .toList(),
             added.getFullyQualifiedName());
       }
 


### PR DESCRIPTION
Cherry-pick of #28047 to 1.13 — code + regression test.

## Summary

PATCH on a File without columns (PDF/image/etc.) returns 500 with
`NullPointerException: Cannot invoke java.util.List.iterator() because updatedColumns is null`.
Any edit — tags, glossary terms, description, owner — triggers it because
`FileRepository.entitySpecificUpdate` unconditionally calls
`updateColumns(..., original.getColumns(), updated.getColumns(), ...)`.

Fix: null-coalesce `origColumns` and `updatedColumns` at the top of
`ColumnEntityUpdater.updateColumns`, plus guard `added.getTags().stream()`
with `listOrEmpty` so a tag-less added column doesn't NPE either.

`FileResourceIT.test_patchFileWithoutColumns_doesNotNpe` creates a PDF
file with no columns, PATCHes the description, asserts 200. The test
fails on 1.13 without the fix.

## Scope vs main PR

Skipped from #28047 because the Folder entity (PR #27558 "Context center")
isn't on 1.13:

- `FolderResource.java` (limit validation)
- `FolderService.java` (SDK)
- `FolderResourceIT.java` (Folder tests)

Skipped because they're IT-infrastructure refactors, not part of the bug fix:

- `BaseEntityIT.java` — new generic PATCH-tag tests + Awaitility hard-delete
- `DirectoryResourceIT.java` / `SpreadsheetResourceIT.java` — migration to
  `BaseEntityIT<T, K>`. Massive structural rewrites that don't share intent
  with the NPE fix.
- The `FileResourceIT` migration to `BaseEntityIT` — kept the existing
  standalone harness and just appended the regression test.

## Test plan

- [x] `mvn -pl openmetadata-service,openmetadata-integration-tests -am test-compile` passes locally
- [ ] CI green (FileResourceIT runs the new test)
- [ ] Manual: PATCH /api/v1/drives/files/{id} on a PDF file (no columns) returns 200