### PR TITLE
chore(ci): Snyk Job Summary + high/critical gate + rich Slack notify

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -277,40 +277,57 @@ jobs:
 
       - name: Build Slack payload
         id: slack-payload
+        env:
+          RETIRE_RESULT: ${{ needs.vulnerability-scan.result }}
+          SNYK_RESULT: ${{ needs.security-scan.result }}
+          REF_NAME: ${{ github.ref_name }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
-          retire="${{ needs.vulnerability-scan.result }}"
-          snyk="${{ needs.security-scan.result }}"
-          status_icon() {
-            case "$1" in
-              success)   echo "✅" ;;
-              cancelled) echo "⚠️ (cancelled)" ;;
-              skipped)   echo "⚠️ (skipped)" ;;
-              *)         echo "❌" ;;
-            esac
-          }
-          retire_icon=$(status_icon "$retire")
-          snyk_icon=$(status_icon "$snyk")
-          if [ "$retire" = "success" ] && [ "$snyk" = "success" ]; then
-            icon="🟢"
-          elif [ "$retire" = "failure" ] || [ "$snyk" = "failure" ]; then
-            icon="🚨"
-          else
-            icon="⚠️"
-          fi
-          run_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-          {
-            echo "$icon *Security scan* — *OpenMetadata Repo* on branch \`${{ github.ref_name }}\`"
-            echo "• Vulnerability scan (Retire.js): $retire_icon"
-            echo "• Security scan (Snyk): $snyk_icon"
-            echo "<$run_url|Open run details>"
-            if [ -f security-report/_slack.txt ]; then
-              echo
-              cat security-report/_slack.txt
-            fi
-          } > slack_body.txt
-          jq -Rs '{text: ., blocks: [{type: "section", text: {type: "mrkdwn", text: .}}]}' slack_body.txt > payload.json
+          python3 - <<'PY' > payload.json
+          import json, os, pathlib
+
+          retire = os.environ["RETIRE_RESULT"]
+          snyk = os.environ["SNYK_RESULT"]
+          ref_name = os.environ["REF_NAME"]
+          run_url = os.environ["RUN_URL"]
+
+          def status_icon(s):
+              return {"success": "✅", "cancelled": "⚠️ (cancelled)", "skipped": "⚠️ (skipped)"}.get(s, "❌")
+
+          if retire == "success" and snyk == "success":
+              overall = "🟢"
+          elif retire == "failure" or snyk == "failure":
+              overall = "🚨"
+          else:
+              overall = "⚠️"
+
+          header = (
+              f"{overall}  *Security scan* — *OpenMetadata Repo*\n"
+              f"_branch_ `{ref_name}`  ·  <{run_url}|Open run details>\n"
+              f"• Vulnerability scan (Retire.js): {status_icon(retire)}\n"
+              f"• Security scan (Snyk): {status_icon(snyk)}"
+          )
+
+          blocks = [{"type": "section", "text": {"type": "mrkdwn", "text": header}}]
+
+          slack_path = pathlib.Path("security-report/_slack.txt")
+          if slack_path.exists():
+              text = slack_path.read_text().strip()
+              sections = [s.strip() for s in text.split("\n\n") if s.strip()]
+              if sections:
+                  blocks.append({"type": "divider"})
+                  # Slack: max 50 blocks per message; each section text ≤ 3000 chars.
+                  for section in sections[:48]:
+                      if len(section) > 2900:
+                          section = section[:2850].rstrip() + "\n_…truncated, see Job Summary_"
+                      blocks.append({"type": "section", "text": {"type": "mrkdwn", "text": section}})
+
+          fallback = f"{overall} Security scan — OpenMetadata Repo on {ref_name}. {run_url}"
+          print(json.dumps({"text": fallback, "blocks": blocks}))
+          PY
 
       - name: Send Slack Notification
+        if: always() && steps.slack-payload.outcome == 'success'
         uses: slackapi/slack-github-action@v1.27.1
         with:
           channel-id: ${{ secrets.SLACK_CHANNEL_IDS }}

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -124,8 +124,10 @@ jobs:
           # Back up JSONs because html_to_pdf.py deletes them after PDF conversion.
           mkdir -p /tmp/snyk-json-backup
           cp security-report/*.json /tmp/snyk-json-backup/ 2>/dev/null || true
+          # Remove internal metadata files so PDF exporter only processes real Snyk reports.
+          rm -f security-report/_*.json
           make export-snyk-pdf-report || true
-          # Restore JSONs alongside generated PDFs/HTMLs.
+          # Restore all JSONs alongside generated PDFs/HTMLs.
           cp /tmp/snyk-json-backup/*.json security-report/ 2>/dev/null || true
 
       - name: Upload Snyk Reports
@@ -137,7 +139,7 @@ jobs:
           retention-days: 30
 
       - name: Build Slack payload
-        id: build
+        id: slack-payload
         if: always()
         run: |
           build="${{ steps.maven-build.outcome }}"

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -79,40 +79,111 @@ jobs:
         continue-on-error: true
         run: |
           source env/bin/activate
-          make snyk-report
+          rm -rf security-report
+          mkdir -p security-report
+          # Run snyk subtargets directly; skip `export-snyk-pdf-report` which deletes JSONs after PDF conversion.
+          make snyk-ingestion-report || true
+          make snyk-ingestion-base-slim-report || true
+          make snyk-airflow-apis-report || true
+          make snyk-server-report || true
+          make snyk-ui-report || true
 
-      - name: Slack on Failure
-        if: steps.security-report.outcome != 'success'
-        uses: slackapi/slack-github-action@v1.23.0
-        with:
-          channel-id: ${{ secrets.SLACK_CHANNEL_IDS }}
-          payload: |
-            {
-              "text": "🚨 Security report failed, please check it <https://github.com/open-metadata/OpenMetadata/actions/runs/${{ github.run_id }}|here>. 🚨"
-            }
-        env:
-          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+      - name: Publish Snyk Summary
+        id: snyk-summary
+        if: always() && steps.maven-build.outcome == 'success'
+        run: |
+          python3 scripts/snyk_summary.py security-report \
+            --counts-file security-report/_counts.json \
+            --slack-file security-report/_slack.txt \
+            >> $GITHUB_STEP_SUMMARY
+          # Expose counts as step output for downstream gating.
+          counts=$(cat security-report/_counts.json)
+          echo "counts=$counts" >> $GITHUB_OUTPUT
+          high=$(jq '.high + .critical' security-report/_counts.json)
+          echo "high_critical=$high" >> $GITHUB_OUTPUT
 
-      - name: Slack on Success
-        if: steps.security-report.outcome == 'success'
-        uses: slackapi/slack-github-action@v1.23.0
-        with:
-          channel-id: ${{ secrets.SLACK_CHANNEL_IDS }}
-          payload: |
-            {
-              "text": "🟢 Security report generated for OpenMetadata Repo , please check it <https://github.com/open-metadata/OpenMetadata/actions/runs/${{ github.run_id }}|here>."
-            }
-        env:
-          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+      - name: Fail on high/critical Snyk findings
+        id: vuln-gate
+        if: always() && steps.snyk-summary.outcome == 'success' && steps.snyk-summary.outputs.high_critical != '' && steps.snyk-summary.outputs.high_critical != '0'
+        continue-on-error: true
+        run: |
+          echo "::error::Snyk found ${{ steps.snyk-summary.outputs.high_critical }} high/critical vulnerabilities (see Job Summary)"
+          exit 1
 
-      - name: Upload Snyk Report HTML files
-        if: steps.security-report.outcome == 'success'
+      - name: Fail if Snyk summary could not be produced
+        id: summary-guard
+        if: always() && steps.maven-build.outcome == 'success' && steps.snyk-summary.outcome == 'failure'
+        continue-on-error: true
+        run: |
+          echo "::error::snyk_summary.py failed — vulnerability counts unavailable, failing as precaution"
+          exit 1
+
+      - name: Generate Snyk HTML/PDF
+        if: always() && steps.maven-build.outcome == 'success'
+        run: |
+          # Back up JSONs because html_to_pdf.py deletes them after PDF conversion.
+          mkdir -p /tmp/snyk-json-backup
+          cp security-report/*.json /tmp/snyk-json-backup/ 2>/dev/null || true
+          make export-snyk-pdf-report || true
+          # Restore JSONs alongside generated PDFs/HTMLs.
+          cp /tmp/snyk-json-backup/*.json security-report/ 2>/dev/null || true
+
+      - name: Upload Snyk Reports
+        if: always() && steps.maven-build.outcome == 'success'
         uses: actions/upload-artifact@v4
         with:
           name: security-report
           path: security-report
+          retention-days: 30
+
+      - name: Build Slack payload
+        id: build
+        if: always()
+        run: |
+          build="${{ steps.maven-build.outcome }}"
+          scan="${{ steps.security-report.outcome }}"
+          gate="${{ steps.vuln-gate.outcome }}"
+          guard="${{ steps.summary-guard.outcome }}"
+          status_icon() {
+            case "$1" in
+              success)   echo "✅" ;;
+              cancelled) echo "⚠️ (cancelled)" ;;
+              skipped)   echo "⚠️ (skipped)" ;;
+              *)         echo "❌" ;;
+            esac
+          }
+          build_icon=$(status_icon "$build")
+          scan_icon=$(status_icon "$scan")
+          if [ "$build" = "success" ] && [ "$scan" = "success" ] && [ "$gate" != "failure" ] && [ "$guard" != "failure" ]; then
+            icon="🟢"
+          elif [ "$build" = "cancelled" ] || [ "$scan" = "cancelled" ]; then
+            icon="⚠️"
+          else
+            icon="🚨"
+          fi
+          run_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          {
+            echo "$icon *Security scan* — *OpenMetadata Repo* on branch \`${{ github.ref_name }}\`"
+            echo "• Build: $build_icon"
+            echo "• Security scan (Snyk): $scan_icon"
+            echo "<$run_url|Open run details>"
+            if [ -f security-report/_slack.txt ]; then
+              echo
+              cat security-report/_slack.txt
+            fi
+          } > slack_body.txt
+          jq -Rs '{text: ., blocks: [{type: "section", text: {type: "mrkdwn", text: .}}]}' slack_body.txt > payload.json
+
+      - name: Send Slack Notification
+        if: always()
+        uses: slackapi/slack-github-action@v1.27.1
+        with:
+          channel-id: ${{ secrets.SLACK_CHANNEL_IDS }}
+          payload-file-path: payload.json
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
 
       - name: Force failure
-        if: steps.maven-build.outcome != 'success' || steps.security-report.outcome != 'success'
+        if: steps.maven-build.outcome != 'success' || steps.security-report.outcome != 'success' || steps.vuln-gate.outcome == 'failure' || steps.summary-guard.outcome == 'failure'
         run: |
           exit 1

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -16,6 +16,118 @@ on:
   workflow_dispatch:
 
 jobs:
+  vulnerability-scan:
+    runs-on: ubuntu-latest
+    environment: security-scan
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: "openmetadata-ui/src/main/resources/ui/.nvmrc"
+
+      - name: Enable yarn
+        run: corepack enable
+
+      - name: Install UI dependencies
+        working-directory: openmetadata-ui/src/main/resources/ui
+        run: yarn install --frozen-lockfile --ignore-scripts
+
+      - name: Run Retire.js scan
+        id: retire-scan
+        continue-on-error: true
+        working-directory: openmetadata-ui/src/main/resources/ui
+        run: |
+          npx retire@5 \
+            --path node_modules/ \
+            --severity high \
+            --outputformat json \
+            --outputpath retire-report.json
+
+      - name: Verify report was generated
+        working-directory: openmetadata-ui/src/main/resources/ui
+        run: |
+          if [ ! -f retire-report.json ]; then
+            echo '::error::retire-report.json was not generated — retire scan may have crashed'
+            exit 1
+          fi
+
+      - name: Upload Retire.js Report
+        if: success()
+        uses: actions/upload-artifact@v4
+        with:
+          name: retire-js-report
+          path: openmetadata-ui/src/main/resources/ui/retire-report.json
+          retention-days: 30
+
+      - name: Publish Retire.js Summary
+        if: success()
+        working-directory: openmetadata-ui/src/main/resources/ui
+        run: |
+          python3 - << 'EOF' >> $GITHUB_STEP_SUMMARY
+          import json
+
+          SEVERITY_ICON = {"critical": "🚨", "high": "🔴", "medium": "🟠", "low": "🟡"}
+          SEVERITY_ORDER = {"critical": 0, "high": 1, "medium": 2, "low": 3}
+          NM = "node_modules/"
+
+          def escape(text):
+              return str(text).replace('|', '\\|').replace('`', "'")
+
+          try:
+              with open("retire-report.json") as f:
+                  data = json.load(f)
+          except FileNotFoundError:
+              print("## Retire.js Scan Results\n\n> Report file not found — scan may not have run.")
+              raise SystemExit(0)
+
+          findings = data.get("data", [])
+          libs = {}
+          for item in findings:
+              filepath = item.get("file", "")
+              short = filepath[filepath.find(NM) + len(NM):] if NM in filepath else filepath
+              for result in item.get("results", []):
+                  key = (result.get("component", ""), result.get("version", ""))
+                  if key not in libs:
+                      libs[key] = {"files": [], "vulns": result.get("vulnerabilities", [])}
+                  if short not in libs[key]["files"]:
+                      libs[key]["files"].append(short)
+
+          print("## Retire.js Scan Results\n")
+
+          if not libs:
+              print("✅ No vulnerable libraries found.")
+          else:
+              total_vulns = sum(len(v["vulns"]) for v in libs.values())
+              print(f"> **{len(libs)} vulnerable librar{'y' if len(libs) == 1 else 'ies'} · {total_vulns} CVE{'s' if total_vulns != 1 else ''} found**\n")
+
+              for (component, version), info in sorted(libs.items(), key=lambda x: min(
+                      (SEVERITY_ORDER.get(v.get("severity", "low"), 3) for v in x[1]["vulns"]), default=3)):
+                  top_sev = min(info["vulns"], key=lambda v: SEVERITY_ORDER.get(v.get("severity", "low"), 3))
+                  icon = SEVERITY_ICON.get(top_sev.get("severity", "low"), "⚪")
+                  print(f"### {icon} {component} {version}\n")
+                  print("| Severity | CVE | Summary |")
+                  print("|---|---|---|")
+                  for vuln in sorted(info["vulns"], key=lambda v: SEVERITY_ORDER.get(v.get("severity", "low"), 3)):
+                      sev = vuln.get("severity", "")
+                      ids = vuln.get("identifiers", {})
+                      cves = ids.get("CVE", [])
+                      summary = ids.get("summary", "").split("\n")[0][:120]
+                      cve_str = ", ".join(f"[{c}](https://nvd.nist.gov/vuln/detail/{c})" for c in cves) if cves else ids.get("githubID", "—")
+                      print(f"| {SEVERITY_ICON.get(sev, '')} {sev} | {escape(cve_str)} | {escape(summary)} |")
+                  print("\n**Bundled in:**")
+                  for f in info["files"]:
+                      print(f"- `{f}`")
+                  print()
+          EOF
+
+      - name: Force failure on vulnerabilities found
+        if: steps.retire-scan.outcome == 'failure'
+        run: exit 1
+
   security-scan:
     runs-on: ubuntu-latest
     environment: security-scan
@@ -138,14 +250,30 @@ jobs:
           path: security-report
           retention-days: 30
 
+      - name: Force failure
+        if: steps.maven-build.outcome != 'success' || steps.security-report.outcome != 'success' || steps.vuln-gate.outcome == 'failure' || steps.summary-guard.outcome == 'failure'
+        run: |
+          exit 1
+
+  notify:
+    runs-on: ubuntu-latest
+    environment: security-scan
+    needs: [vulnerability-scan, security-scan]
+    if: always()
+    steps:
+      - name: Download Snyk artifact
+        if: needs.security-scan.result != 'skipped'
+        uses: actions/download-artifact@v4
+        with:
+          name: security-report
+          path: security-report
+        continue-on-error: true
+
       - name: Build Slack payload
         id: slack-payload
-        if: always()
         run: |
-          build="${{ steps.maven-build.outcome }}"
-          scan="${{ steps.security-report.outcome }}"
-          gate="${{ steps.vuln-gate.outcome }}"
-          guard="${{ steps.summary-guard.outcome }}"
+          retire="${{ needs.vulnerability-scan.result }}"
+          snyk="${{ needs.security-scan.result }}"
           status_icon() {
             case "$1" in
               success)   echo "✅" ;;
@@ -154,20 +282,20 @@ jobs:
               *)         echo "❌" ;;
             esac
           }
-          build_icon=$(status_icon "$build")
-          scan_icon=$(status_icon "$scan")
-          if [ "$build" = "success" ] && [ "$scan" = "success" ] && [ "$gate" != "failure" ] && [ "$guard" != "failure" ]; then
+          retire_icon=$(status_icon "$retire")
+          snyk_icon=$(status_icon "$snyk")
+          if [ "$retire" = "success" ] && [ "$snyk" = "success" ]; then
             icon="🟢"
-          elif [ "$build" = "cancelled" ] || [ "$scan" = "cancelled" ]; then
-            icon="⚠️"
-          else
+          elif [ "$retire" = "failure" ] || [ "$snyk" = "failure" ]; then
             icon="🚨"
+          else
+            icon="⚠️"
           fi
           run_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           {
             echo "$icon *Security scan* — *OpenMetadata Repo* on branch \`${{ github.ref_name }}\`"
-            echo "• Build: $build_icon"
-            echo "• Security scan (Snyk): $scan_icon"
+            echo "• Vulnerability scan (Retire.js): $retire_icon"
+            echo "• Security scan (Snyk): $snyk_icon"
             echo "<$run_url|Open run details>"
             if [ -f security-report/_slack.txt ]; then
               echo
@@ -177,15 +305,9 @@ jobs:
           jq -Rs '{text: ., blocks: [{type: "section", text: {type: "mrkdwn", text: .}}]}' slack_body.txt > payload.json
 
       - name: Send Slack Notification
-        if: always()
         uses: slackapi/slack-github-action@v1.27.1
         with:
           channel-id: ${{ secrets.SLACK_CHANNEL_IDS }}
           payload-file-path: payload.json
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
-
-      - name: Force failure
-        if: steps.maven-build.outcome != 'success' || steps.security-report.outcome != 'success' || steps.vuln-gate.outcome == 'failure' || steps.summary-guard.outcome == 'failure'
-        run: |
-          exit 1

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -92,7 +92,13 @@ jobs:
               for result in item.get("results", []):
                   key = (result.get("component", ""), result.get("version", ""))
                   if key not in libs:
-                      libs[key] = {"files": [], "vulns": result.get("vulnerabilities", [])}
+                      libs[key] = {"files": [], "vulns": []}
+                  existing_ids = {json.dumps(v.get("identifiers", {}), sort_keys=True) for v in libs[key]["vulns"]}
+                  for v in result.get("vulnerabilities", []):
+                      vid = json.dumps(v.get("identifiers", {}), sort_keys=True)
+                      if vid not in existing_ids:
+                          libs[key]["vulns"].append(v)
+                          existing_ids.add(vid)
                   if short not in libs[key]["files"]:
                       libs[key]["files"].append(short)
 
@@ -106,7 +112,7 @@ jobs:
 
               for (component, version), info in sorted(libs.items(), key=lambda x: min(
                       (SEVERITY_ORDER.get(v.get("severity", "low"), 3) for v in x[1]["vulns"]), default=3)):
-                  top_sev = min(info["vulns"], key=lambda v: SEVERITY_ORDER.get(v.get("severity", "low"), 3))
+                  top_sev = min(info["vulns"], key=lambda v: SEVERITY_ORDER.get(v.get("severity", "low"), 3), default={"severity": "low"})
                   icon = SEVERITY_ICON.get(top_sev.get("severity", "low"), "⚪")
                   print(f"### {icon} {component} {version}\n")
                   print("| Severity | CVE | Summary |")

--- a/scripts/snyk_summary.py
+++ b/scripts/snyk_summary.py
@@ -1,0 +1,240 @@
+#!/usr/bin/env python3
+"""Render Snyk JSON reports as Markdown.
+
+Usage:
+  python3 scripts/snyk_summary.py [dir] \\
+      [--counts-file PATH] [--slack-file PATH] [--top N]
+"""
+import argparse
+import glob
+import json
+import os
+import sys
+
+SEV_ICON = {"critical": "🚨", "high": "🔴", "medium": "🟠", "low": "🟡"}
+SEV_RANK = {"critical": 0, "high": 1, "medium": 2, "low": 3}
+
+
+def esc(s):
+    return str(s).replace("|", "\\|").replace("`", "'").replace("\n", " ")
+
+
+def sev_key(s):
+    return SEV_RANK.get((s or "low").lower(), 3)
+
+
+def load(path):
+    try:
+        with open(path) as f:
+            return json.load(f), None
+    except Exception as e:
+        return None, str(e)
+
+
+def iter_projects(data):
+    if isinstance(data, list):
+        for d in data:
+            yield d
+    elif isinstance(data, dict):
+        yield data
+
+
+def collect_deps(data):
+    """Aggregate vulnerabilities by (package, version). Return (libs_dict, total_findings)."""
+    libs = {}
+    total = 0
+    for proj in iter_projects(data):
+        if not isinstance(proj, dict):
+            continue
+        for v in proj.get("vulnerabilities", []) or []:
+            key = (v.get("packageName", "?"), v.get("version", "?"))
+            entry = libs.setdefault(key, {
+                "sev": "low", "cves": set(), "titles": set(),
+                "fixedIn": set(), "paths": 0, "ids": set(),
+            })
+            if sev_key(v.get("severity")) < sev_key(entry["sev"]):
+                entry["sev"] = v.get("severity", "low")
+            for cve in (v.get("identifiers", {}) or {}).get("CVE", []) or []:
+                entry["cves"].add(cve)
+            entry["titles"].add(v.get("title", ""))
+            for fx in v.get("fixedIn", []) or []:
+                entry["fixedIn"].add(fx)
+            entry["ids"].add(v.get("id", ""))
+            entry["paths"] += 1
+            total += 1
+    return libs, total
+
+
+def collect_code(data):
+    """Aggregate Snyk Code SARIF results. Return (by_rule_dict, rules_desc_dict, total)."""
+    runs = data.get("runs", []) if isinstance(data, dict) else []
+    findings = {}
+    rules = {}
+    for run in runs:
+        for rule in (run.get("tool", {}).get("driver", {}).get("rules", []) or []):
+            rules[rule.get("id")] = rule.get("shortDescription", {}).get("text", rule.get("name", ""))
+        for r in run.get("results", []) or []:
+            rid = r.get("ruleId", "?")
+            level = r.get("level", "warning")
+            for loc in r.get("locations", []) or []:
+                phys = loc.get("physicalLocation", {})
+                uri = phys.get("artifactLocation", {}).get("uri", "?")
+                line = phys.get("region", {}).get("startLine", "?")
+                findings.setdefault((rid, uri, level), []).append(line)
+    by_rule = {}
+    for (rid, uri, level), lines in findings.items():
+        by_rule.setdefault(rid, []).append((uri, level, lines))
+    total = sum(len(v) for v in by_rule.values())
+    return by_rule, rules, total
+
+
+def render_deps_md(name, libs, total):
+    out = [f"\n### 📦 {name}\n"]
+    if not libs:
+        out.append("✅ No vulnerabilities.\n")
+        return "\n".join(out)
+    out.append(f"> **{len(libs)} vulnerable librar{'y' if len(libs)==1 else 'ies'} · {total} finding{'s' if total!=1 else ''}**\n")
+    out.append("| Sev | Package | Version | CVE / ID | Title | Fix in | Paths |")
+    out.append("|---|---|---|---|---|---|---|")
+    for (pkg, ver), info in sorted(libs.items(), key=lambda kv: sev_key(kv[1]["sev"])):
+        sev = info["sev"]
+        ids = sorted(info["cves"]) or sorted(i for i in info["ids"] if i)[:1]
+        ids_str = ", ".join(f"[{c}](https://nvd.nist.gov/vuln/detail/{c})" if c.startswith("CVE") else c for c in ids) or "—"
+        title = sorted(info["titles"])[0][:80] if info["titles"] else ""
+        fix = ", ".join(sorted(info["fixedIn"])[:2]) or "—"
+        out.append(f"| {SEV_ICON.get(sev,'⚪')} {sev} | `{esc(pkg)}` | {esc(ver)} | {esc(ids_str)} | {esc(title)} | {esc(fix)} | {info['paths']} |")
+    out.append("")
+    return "\n".join(out)
+
+
+def render_code_md(name, by_rule, rules, total):
+    out = [f"\n### 🔎 {name} (Code)\n"]
+    if not by_rule:
+        out.append("✅ No code findings.\n")
+        return "\n".join(out)
+    out.append(f"> **{total} location{'s' if total!=1 else ''} across {len(by_rule)} rule{'s' if len(by_rule)!=1 else ''}**\n")
+    for rid, items in sorted(by_rule.items()):
+        desc = rules.get(rid, rid)
+        out.append(f"<details><summary><b>{esc(rid)}</b> — {esc(desc)} ({len(items)})</summary>\n")
+        out.append("| Level | File | Lines |")
+        out.append("|---|---|---|")
+        for uri, level, lines in sorted(items):
+            ln = ", ".join(str(x) for x in sorted(set(lines))[:10])
+            icon = "🔴" if level == "error" else "🟠"
+            out.append(f"| {icon} {level} | `{esc(uri)}` | {esc(ln)} |")
+        out.append("\n</details>\n")
+    return "\n".join(out)
+
+
+def render_deps_slack(name, libs, total, top):
+    if not libs:
+        return f"📦 *{name}*: ✅ clean"
+    head = f"📦 *{name}*: {len(libs)} libs · {total} findings"
+    rows = []
+    ordered = sorted(libs.items(), key=lambda kv: sev_key(kv[1]["sev"]))
+    for (pkg, ver), info in ordered[:top]:
+        icon = SEV_ICON.get(info["sev"], "⚪")
+        title = (sorted(info["titles"])[0] if info["titles"] else "")[:60]
+        fix = sorted(info["fixedIn"])[0] if info["fixedIn"] else "no fix"
+        rows.append(f"  {icon} `{pkg}` {ver} — {title} (fix: {fix})")
+    extra = len(libs) - top
+    if extra > 0:
+        rows.append(f"  … +{extra} more")
+    return head + "\n" + "\n".join(rows)
+
+
+def render_code_slack(name, by_rule, rules, total, top):
+    if not by_rule:
+        return f"🔎 *{name}*: ✅ clean"
+    head = f"🔎 *{name}*: {total} findings · {len(by_rule)} rules"
+    ordered = sorted(by_rule.items(), key=lambda kv: -len(kv[1]))
+    rows = [f"  • `{rid}` ({len(items)})" for rid, items in ordered[:top]]
+    extra = len(by_rule) - top
+    if extra > 0:
+        rows.append(f"  … +{extra} more")
+    return head + "\n" + "\n".join(rows)
+
+
+def count_severities(libs, by_rule):
+    """Snyk Code SARIF uses level (error/warning/note); treat error=high, warning=medium, note=low.
+    Dep libs already have explicit severity."""
+    counts = {"critical": 0, "high": 0, "medium": 0, "low": 0}
+    for info in libs.values():
+        sev = (info["sev"] or "low").lower()
+        if sev in counts:
+            counts[sev] += info["paths"]
+    for rid, items in by_rule.items():
+        for uri, level, lines in items:
+            mapped = {"error": "high", "warning": "medium", "note": "low"}.get(level, "medium")
+            counts[mapped] += 1  # count locations to match render_code_md total
+    return counts
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("src", nargs="?", default="security-report")
+    ap.add_argument("--counts-file")
+    ap.add_argument("--slack-file")
+    ap.add_argument("--top", type=int, default=5)
+    args = ap.parse_args()
+
+    md_parts = ["## 🛡️ Snyk Security Scan\n"]
+    slack_parts = ["*🛡️ Snyk Security Scan*"]
+    totals = {"critical": 0, "high": 0, "medium": 0, "low": 0}
+
+    files = sorted(glob.glob(os.path.join(args.src, "*.json")))
+    # exclude our own output files if present
+    files = [f for f in files if not os.path.basename(f).startswith("_")]
+
+    if not files:
+        md_parts.append(f"> No JSON reports found in `{args.src}/`.")
+        sys.stdout.write("\n".join(md_parts) + "\n")
+        if args.counts_file:
+            with open(args.counts_file, "w") as f:
+                json.dump({**totals, "total": 0}, f)
+        if args.slack_file:
+            with open(args.slack_file, "w") as f:
+                f.write("*🛡️ Snyk Security Scan*\n> No JSON reports found.")
+        return
+
+    for path in files:
+        name = os.path.basename(path).replace(".json", "")
+        data, err = load(path)
+        if err is not None:
+            md_parts.append(f"\n### ⚠️ {name}\nFailed to parse: {err}\n")
+            slack_parts.append(f"⚠️ *{name}*: parse error — {err}")
+            continue
+        if isinstance(data, dict) and "runs" in data:
+            by_rule, rules, total = collect_code(data)
+            md_parts.append(render_code_md(name, by_rule, rules, total))
+            slack_parts.append(render_code_slack(name, by_rule, rules, total, args.top))
+            sub = count_severities({}, by_rule)
+        else:
+            libs, total = collect_deps(data)
+            md_parts.append(render_deps_md(name, libs, total))
+            slack_parts.append(render_deps_slack(name, libs, total, args.top))
+            sub = count_severities(libs, {})
+        for k in totals:
+            totals[k] += sub[k]
+
+    sys.stdout.write("\n".join(md_parts) + "\n")
+
+    if args.counts_file:
+        with open(args.counts_file, "w") as f:
+            json.dump({**totals, "total": sum(totals.values())}, f)
+
+    if args.slack_file:
+        header = (
+            f"*🛡️ Snyk Security Scan* — 🚨 {totals['critical']} · 🔴 {totals['high']} · "
+            f"🟠 {totals['medium']} · 🟡 {totals['low']}"
+        )
+        body = "\n\n".join([header] + slack_parts[1:])
+        # Slack section block text limit 3000 chars; leave headroom for shell-added header lines.
+        if len(body) > 2500:
+            body = body[:2450] + "\n…truncated. See Job Summary for full report."
+        with open(args.slack_file, "w") as f:
+            f.write(body)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/snyk_summary.py
+++ b/scripts/snyk_summary.py
@@ -40,7 +40,6 @@ def iter_projects(data):
 
 
 def collect_deps(data):
-    """Aggregate vulnerabilities by (package, version). Return (libs_dict, total_findings)."""
     libs = {}
     total = 0
     for proj in iter_projects(data):
@@ -66,7 +65,6 @@ def collect_deps(data):
 
 
 def collect_code(data):
-    """Aggregate Snyk Code SARIF results. Return (by_rule_dict, rules_desc_dict, total)."""
     runs = data.get("runs", []) if isinstance(data, dict) else []
     findings = {}
     rules = {}
@@ -128,36 +126,34 @@ def render_code_md(name, by_rule, rules, total):
 
 def render_deps_slack(name, libs, total, top):
     if not libs:
-        return f"📦 *{name}*: ✅ clean"
-    head = f"📦 *{name}*: {len(libs)} libs · {total} findings"
+        return f"📦  *{name}*  ·  ✅ clean"
+    head = f"📦  *{name}*  ·  {len(libs)} libs · {total} findings"
     rows = []
     ordered = sorted(libs.items(), key=lambda kv: sev_key(kv[1]["sev"]))
     for (pkg, ver), info in ordered[:top]:
         icon = SEV_ICON.get(info["sev"], "⚪")
         title = (sorted(info["titles"])[0] if info["titles"] else "")[:60]
-        fix = sorted(info["fixedIn"])[0] if info["fixedIn"] else "no fix"
-        rows.append(f"  {icon} `{pkg}` {ver} — {title} (fix: {fix})")
+        fix_label = f"_fix in {sorted(info['fixedIn'])[0]}_" if info["fixedIn"] else "_no fix_"
+        rows.append(f"   {icon}  `{pkg}@{ver}` — {title}  ·  {fix_label}")
     extra = len(libs) - top
     if extra > 0:
-        rows.append(f"  … +{extra} more")
+        rows.append(f"   _… +{extra} more_")
     return head + "\n" + "\n".join(rows)
 
 
 def render_code_slack(name, by_rule, rules, total, top):
     if not by_rule:
-        return f"🔎 *{name}*: ✅ clean"
-    head = f"🔎 *{name}*: {total} findings · {len(by_rule)} rules"
+        return f"🔎  *{name}*  ·  ✅ clean"
+    head = f"🔎  *{name}*  ·  {total} findings · {len(by_rule)} rules"
     ordered = sorted(by_rule.items(), key=lambda kv: -len(kv[1]))
-    rows = [f"  • `{rid}` ({len(items)})" for rid, items in ordered[:top]]
+    rows = [f"   •  `{rid}`  _×{len(items)}_" for rid, items in ordered[:top]]
     extra = len(by_rule) - top
     if extra > 0:
-        rows.append(f"  … +{extra} more")
+        rows.append(f"   _… +{extra} more_")
     return head + "\n" + "\n".join(rows)
 
 
 def count_severities(libs, by_rule):
-    """Snyk Code SARIF uses level (error/warning/note); treat error=high, warning=medium, note=low.
-    Dep libs already have explicit severity."""
     counts = {"critical": 0, "high": 0, "medium": 0, "low": 0}
     for info in libs.values():
         sev = (info["sev"] or "low").lower()
@@ -166,7 +162,7 @@ def count_severities(libs, by_rule):
     for rid, items in by_rule.items():
         for uri, level, lines in items:
             mapped = {"error": "high", "warning": "medium", "note": "low"}.get(level, "medium")
-            counts[mapped] += 1  # count locations to match render_code_md total
+            counts[mapped] += 1
     return counts
 
 
@@ -179,11 +175,10 @@ def main():
     args = ap.parse_args()
 
     md_parts = ["## 🛡️ Snyk Security Scan\n"]
-    slack_parts = ["*🛡️ Snyk Security Scan*"]
+    slack_parts = ["*🛡️  Snyk Security Scan*"]
     totals = {"critical": 0, "high": 0, "medium": 0, "low": 0}
 
     files = sorted(glob.glob(os.path.join(args.src, "*.json")))
-    # exclude our own output files if present
     files = [f for f in files if not os.path.basename(f).startswith("_")]
 
     if not files:
@@ -194,8 +189,9 @@ def main():
                 json.dump({**totals, "total": 0}, f)
         if args.slack_file:
             with open(args.slack_file, "w") as f:
-                f.write("*🛡️ Snyk Security Scan*\n> No JSON reports found.")
-        return
+                f.write("*🛡️  Snyk Security Scan*\n> No JSON reports found.")
+        # Exit non-zero so the workflow's summary-guard catches silent Snyk failures.
+        sys.exit(1)
 
     for path in files:
         name = os.path.basename(path).replace(".json", "")
@@ -220,18 +216,22 @@ def main():
     sys.stdout.write("\n".join(md_parts) + "\n")
 
     if args.counts_file:
-        with open(args.counts_file, "w") as f:
+        # Atomic write: serialize to temp, then rename so a crash mid-dump
+        # cannot leave a partial file that breaks downstream `jq` parsing.
+        tmp = args.counts_file + ".tmp"
+        with open(tmp, "w") as f:
             json.dump({**totals, "total": sum(totals.values())}, f)
+        os.replace(tmp, args.counts_file)
 
     if args.slack_file:
         header = (
-            f"*🛡️ Snyk Security Scan* — 🚨 {totals['critical']} · 🔴 {totals['high']} · "
-            f"🟠 {totals['medium']} · 🟡 {totals['low']}"
+            f"*🛡️  Snyk Security Scan*\n"
+            f"🚨 *{totals['critical']}* critical  ·  🔴 *{totals['high']}* high  ·  "
+            f"🟠 *{totals['medium']}* medium  ·  🟡 *{totals['low']}* low"
         )
+        # Scans separated by blank lines — workflow splits on `\n\n` and emits one
+        # Slack section block per scan, so nothing gets truncated mid-line.
         body = "\n\n".join([header] + slack_parts[1:])
-        # Slack section block text limit 3000 chars; leave headroom for shell-added header lines.
-        if len(body) > 2500:
-            body = body[:2450] + "\n…truncated. See Job Summary for full report."
         with open(args.slack_file, "w") as f:
             f.write(body)
 


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:

<!--
Linking an issue is REQUIRED. Replace <issue-number> with the GitHub issue number this PR addresses
(e.g., `Fixes #12345`). GitHub will auto-link it. If no issue exists, please open one first so the
problem and design can be discussed before review.
-->

<!--
Short blurb explaining:
- What changes did you make?
- Why did you make them?
-->

## Summary
- Replace verbose Snyk PDF dump with concise GitHub Job Summary (severity-sorted, deduped by package+version, Snyk Code grouped by rule).
- Add `scripts/snyk_summary.py` with `--counts-file`, `--slack-file`, `--top` flags. Counts JSON aggregates `{critical, high, medium, low, total}` across all scans; Slack file holds a condensed body (severity-totals header + per-scan section with top 5 offenders), auto-truncated to fit Slack's 3000-char section block limit.
- `Publish Snyk Summary` step emits a `high_critical` step output (via `jq`) consumed by two gates:
  - **Fail on high/critical Snyk findings** — exits 1 when count > 0.
  - **Fail if Snyk summary could not be produced** — precaution: if the summary step itself errored, fail the build rather than silently passing.
- Single Snyk Makefile target (`make snyk-report`) preserved — ai-platform has no subtargets. (For repos with subtargets like OSS, scans are driven directly with `|| true` per subtarget so one docker-build failure no longer halts the whole report.)
- Collapse two Slack steps (success/failure) into one status-aware notification posted via `payload-file-path`. Body is built into `slack_body.txt`, then wrapped with `jq -Rs '{text: ., blocks: [{type: "section", text: {type: "mrkdwn", text: .}}]}'` so `*bold*`, backticks, and `<url|label>` render as mrkdwn.
- Upload `security-report` artifact on `always() && build success`, 30-day retention.

## Why
- Reviewers had to download artifacts to triage — no signal in Actions UI or Slack.
- Two Slack messages per run added noise; cancelled runs were misreported as failures.
- Snyk found high/critical issues but the workflow stayed green — exit codes were swallowed. Need an explicit gate so regressions break CI.
- If `snyk_summary.py` itself crashes, the gate's `!= ''` check would pass silently — the guard step closes that hole.

## Failure matrix
| Build | Snyk | Gate (high/critical) | Guard (summary script) | Job | Slack icon |
|---|---|---|---|---|---|
| ✅ | ✅ | clean | ok | 🟢 success | 🟢 |
| ✅ | ✅ | ≥1 found | ok | 🚨 failure | 🚨 |
| ✅ | ❌ | — | — | 🚨 failure | 🚨 |
| ✅ | ✅ | — | failed | 🚨 failure | 🚨 |
| ❌ | skipped | — | — | 🚨 failure | 🚨 |
| cancelled | * | — | — | ⚠️ | ⚠️ |

## Implementation notes
- Severity mapping for Snyk Code SARIF: `error → high`, `warning → medium`, `note → low`. Code severity counts use **location groups** (not raw line counts) so the gating metric matches the displayed total in the Job Summary.
- `_counts.json` / `_slack.txt` written into `security-report/` so they ride along in the existing artifact (excluded from scan glob via `_`-prefix filter to avoid recursion).
- Slack body capped at 2500 chars in Python with `…truncated. See Job Summary for full report.` suffix when oversized, leaving ~500-char headroom for the shell-prepended header lines (icon, build status, scan status, run URL) so the combined message stays under Slack's 3000-char section limit.
- `Force failure` step now also fires on `vuln-gate.outcome == 'failure'` or `summary-guard.outcome == 'failure'`, since those gates use `continue-on-error: true` to let the Slack step still post.

Mirrors the OSS OpenMetadata main security-scan pattern.

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### High-level design:
<!--
REQUIRED for large PRs (new features, refactors, breaking changes, or anything touching >5 files).
Skip for small bug fixes and trivial changes.

Cover:
- Architecture / approach you took and why
- Key components or files added/changed and how they interact
- Alternatives considered and why you rejected them
- Any migration, backward-compatibility, or rollout concerns
- Diagrams or links to design docs / RFCs if available
-->

N/A — small change. <!-- Or fill in the design above -->

#
### Tests:

#### Use cases covered
<!--
List the user-visible scenarios this PR exercises. Example:
- User with Admin role can create a Glossary Term with a parent term
- Ingestion run for Snowflake correctly extracts row counts for partitioned tables
-->

#### Unit tests
<!--
- [ ] I added unit tests for the new/changed logic.
- Files added/updated:
- Coverage on changed classes (run `mvn jacoco:report` for backend, `yarn test:coverage` for UI,
  `make unit_ingestion` for ingestion). Target is 90% line coverage on changed classes.
- Coverage %: <e.g., 92% on EntityRepository.java>
-->

#### Backend integration tests
<!--
- [ ] I added integration tests in `openmetadata-integration-tests/` for new/changed API endpoints.
- [ ] Not applicable (no backend API changes).
- Files added/updated:
-->

#### Ingestion integration tests
<!--
- [ ] I added/updated ingestion integration tests for connector changes.
- [ ] Not applicable (no ingestion changes).
- Files added/updated:
-->

#### Playwright (UI) tests
<!--
- [ ] I added Playwright E2E tests under `openmetadata-ui/.../ui/playwright/` for UI changes.
- [ ] Not applicable (no UI changes).
- Files added/updated:
-->

#### Manual testing performed
<!--
List the manual test steps you performed before requesting review. Example:
1. Started local stack via `./docker/run_local_docker.sh -m ui -d mysql`
2. Logged in as admin, created entity X, verified Y appears in the UI
3. Triggered ingestion for Snowflake source, confirmed lineage edges in the explore page
-->

#
### UI screen recording / screenshots:
<!--
REQUIRED for any PR that changes the UI. Drag-and-drop a short screen recording (.mov / .mp4 / .gif)
demonstrating the change end-to-end, plus before/after screenshots where relevant.
Mark "Not applicable" if there are no UI changes.
-->

Not applicable. <!-- Or attach recording/screenshots above -->

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.
- [ ] For UI changes: I attached a screen recording and/or screenshots above.
- [ ] I have added tests (unit / integration / Playwright as applicable) and listed them above.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->

----
## Summary by Gitar

- **Security reporting fixes:**
  - Added deduplication logic for `Retire.js` vulnerability identifiers to prevent duplicate entries in reports.
  - Added a default `low` severity value to `top_sev` calculation in `security-scan.yml` to prevent crashes when components have no vulnerabilities.

<sub>This will update automatically on new commits.</sub>