### PR TITLE
Fix tooltip visual color option for related terms

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/Glossary/GlossaryTerms/tabs/RelatedTerms.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Glossary/GlossaryTerms/tabs/RelatedTerms.tsx
@@ -95,16 +95,16 @@ const RelatedTermTagButton: React.FC<RelatedTermTagButtonProps> = ({
   const descriptionText = getTextFromHtmlString(entity.description);
   const tooltipContent = (
     <div className="tw:p-2 tw:space-y-1">
-      <Typography as="p" weight="semibold">
+      <Typography as="p" className="tw:text-white" weight="semibold">
         {entity.fullyQualifiedName}
       </Typography>
       {relationType && (
-        <Typography as="p" size="text-xs">
+        <Typography as="p" className="tw:text-white" size="text-xs">
           {getRelationDisplayName(relationType)}
         </Typography>
       )}
       {descriptionText && (
-        <Typography as="p" size="text-xs">
+        <Typography as="p" className="tw:text-white" size="text-xs">
           {descriptionText}
         </Typography>
       )}
@@ -112,10 +112,7 @@ const RelatedTermTagButton: React.FC<RelatedTermTagButtonProps> = ({
   );
 
   return (
-    <Tooltip
-      containerClassName="tw:bg-primary"
-      placement="bottom left"
-      title={tooltipContent}>
+    <Tooltip arrow placement="bottom left" title={tooltipContent}>
       <TooltipTrigger
         className={
           versionStatus?.added


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:

<img width="828" height="474" alt="Screenshot 2026-05-18 at 1 01 46 PM" src="https://github.com/user-attachments/assets/df77d99c-7d23-4ea4-97f3-8cb90902c52f" />

----
## Summary by Gitar

- **UI Improvements:**
  - Added `tw:text-white` to tooltip text elements in `RelatedTerms.tsx` to ensure better visibility.
  - Updated `Tooltip` component to remove custom background styling and include an arrow for consistent UI presentation.

<sub>This will update automatically on new commits.</sub>