### PR TITLE
Integrate snyk summary 1.13

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -92,7 +92,13 @@ jobs:
               for result in item.get("results", []):
                   key = (result.get("component", ""), result.get("version", ""))
                   if key not in libs:
-                      libs[key] = {"files": [], "vulns": result.get("vulnerabilities", [])}
+                      libs[key] = {"files": [], "vulns": []}
+                  existing_ids = {json.dumps(v.get("identifiers", {}), sort_keys=True) for v in libs[key]["vulns"]}
+                  for v in result.get("vulnerabilities", []):
+                      vid = json.dumps(v.get("identifiers", {}), sort_keys=True)
+                      if vid not in existing_ids:
+                          libs[key]["vulns"].append(v)
+                          existing_ids.add(vid)
                   if short not in libs[key]["files"]:
                       libs[key]["files"].append(short)
 
@@ -106,7 +112,7 @@ jobs:
 
               for (component, version), info in sorted(libs.items(), key=lambda x: min(
                       (SEVERITY_ORDER.get(v.get("severity", "low"), 3) for v in x[1]["vulns"]), default=3)):
-                  top_sev = min(info["vulns"], key=lambda v: SEVERITY_ORDER.get(v.get("severity", "low"), 3))
+                  top_sev = min(info["vulns"], key=lambda v: SEVERITY_ORDER.get(v.get("severity", "low"), 3), default={"severity": "low"})
                   icon = SEVERITY_ICON.get(top_sev.get("severity", "low"), "⚪")
                   print(f"### {icon} {component} {version}\n")
                   print("| Severity | CVE | Summary |")
@@ -123,30 +129,6 @@ jobs:
                       print(f"- `{f}`")
                   print()
           EOF
-
-      - name: Slack on Failure
-        if: steps.retire-scan.outcome == 'failure'
-        uses: slackapi/slack-github-action@v1.23.0
-        with:
-          channel-id: ${{ secrets.SLACK_CHANNEL_IDS }}
-          payload: |
-            {
-              "text": "🚨 Vulnerability scan failed on branch `${{ github.ref_name }}`, please check it <https://github.com/open-metadata/OpenMetadata/actions/runs/${{ github.run_id }}|here>. 🚨"
-            }
-        env:
-          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
-
-      - name: Slack on Success
-        if: steps.retire-scan.outcome == 'success'
-        uses: slackapi/slack-github-action@v1.23.0
-        with:
-          channel-id: ${{ secrets.SLACK_CHANNEL_IDS }}
-          payload: |
-            {
-              "text": "🟢 Vulnerability scan passed for OpenMetadata Repo on branch `${{ github.ref_name }}`, please check it <https://github.com/open-metadata/OpenMetadata/actions/runs/${{ github.run_id }}|here>."
-            }
-        env:
-          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
 
       - name: Force failure on vulnerabilities found
         if: steps.retire-scan.outcome == 'failure'
@@ -215,40 +197,121 @@ jobs:
         continue-on-error: true
         run: |
           source env/bin/activate
-          make snyk-report
+          rm -rf security-report
+          mkdir -p security-report
+          # Run snyk subtargets directly; skip `export-snyk-pdf-report` which deletes JSONs after PDF conversion.
+          make snyk-ingestion-report || true
+          make snyk-ingestion-base-slim-report || true
+          make snyk-airflow-apis-report || true
+          make snyk-server-report || true
+          make snyk-ui-report || true
 
-      - name: Slack on Failure
-        if: steps.security-report.outcome != 'success'
-        uses: slackapi/slack-github-action@v1.23.0
-        with:
-          channel-id: ${{ secrets.SLACK_CHANNEL_IDS }}
-          payload: |
-            {
-              "text": "🚨 Security report failed on branch `${{ github.ref_name }}`, please check it <https://github.com/open-metadata/OpenMetadata/actions/runs/${{ github.run_id }}|here>. 🚨"
-            }
-        env:
-          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+      - name: Publish Snyk Summary
+        id: snyk-summary
+        if: always() && steps.maven-build.outcome == 'success'
+        run: |
+          python3 scripts/snyk_summary.py security-report \
+            --counts-file security-report/_counts.json \
+            --slack-file security-report/_slack.txt \
+            >> $GITHUB_STEP_SUMMARY
+          counts=$(cat security-report/_counts.json)
+          echo "counts=$counts" >> $GITHUB_OUTPUT
+          high=$(jq '.high + .critical' security-report/_counts.json)
+          echo "high_critical=$high" >> $GITHUB_OUTPUT
 
-      - name: Slack on Success
-        if: steps.security-report.outcome == 'success'
-        uses: slackapi/slack-github-action@v1.23.0
-        with:
-          channel-id: ${{ secrets.SLACK_CHANNEL_IDS }}
-          payload: |
-            {
-              "text": "🟢 Security report generated for OpenMetadata Repo on branch `${{ github.ref_name }}`, please check it <https://github.com/open-metadata/OpenMetadata/actions/runs/${{ github.run_id }}|here>."
-            }
-        env:
-          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+      - name: Fail on high/critical Snyk findings
+        id: vuln-gate
+        if: always() && steps.snyk-summary.outcome == 'success' && steps.snyk-summary.outputs.high_critical != '' && steps.snyk-summary.outputs.high_critical != '0'
+        continue-on-error: true
+        run: |
+          echo "::error::Snyk found ${{ steps.snyk-summary.outputs.high_critical }} high/critical vulnerabilities (see Job Summary)"
+          exit 1
 
-      - name: Upload Snyk Report HTML files
-        if: steps.security-report.outcome == 'success'
+      - name: Fail if Snyk summary could not be produced
+        id: summary-guard
+        if: always() && steps.maven-build.outcome == 'success' && steps.snyk-summary.outcome == 'failure'
+        continue-on-error: true
+        run: |
+          echo "::error::snyk_summary.py failed — vulnerability counts unavailable, failing as precaution"
+          exit 1
+
+      - name: Generate Snyk HTML/PDF
+        if: always() && steps.maven-build.outcome == 'success'
+        run: |
+          mkdir -p /tmp/snyk-json-backup
+          cp security-report/*.json /tmp/snyk-json-backup/ 2>/dev/null || true
+          # Remove internal metadata files so PDF exporter only processes real Snyk reports.
+          rm -f security-report/_*.json
+          make export-snyk-pdf-report || true
+          cp /tmp/snyk-json-backup/*.json security-report/ 2>/dev/null || true
+
+      - name: Upload Snyk Reports
+        if: always() && steps.maven-build.outcome == 'success'
         uses: actions/upload-artifact@v4
         with:
           name: security-report
           path: security-report
+          retention-days: 30
 
       - name: Force failure
-        if: steps.maven-build.outcome != 'success' || steps.security-report.outcome != 'success'
+        if: steps.maven-build.outcome != 'success' || steps.security-report.outcome != 'success' || steps.vuln-gate.outcome == 'failure' || steps.summary-guard.outcome == 'failure'
         run: |
           exit 1
+
+  notify:
+    runs-on: ubuntu-latest
+    environment: security-scan
+    needs: [vulnerability-scan, security-scan]
+    if: always()
+    steps:
+      - name: Download Snyk artifact
+        if: needs.security-scan.result != 'skipped'
+        uses: actions/download-artifact@v4
+        with:
+          name: security-report
+          path: security-report
+        continue-on-error: true
+
+      - name: Build Slack payload
+        id: slack-payload
+        run: |
+          retire="${{ needs.vulnerability-scan.result }}"
+          snyk="${{ needs.security-scan.result }}"
+          status_icon() {
+            case "$1" in
+              success)   echo "✅" ;;
+              cancelled) echo "⚠️ (cancelled)" ;;
+              skipped)   echo "⚠️ (skipped)" ;;
+              *)         echo "❌" ;;
+            esac
+          }
+          retire_icon=$(status_icon "$retire")
+          snyk_icon=$(status_icon "$snyk")
+          if [ "$retire" = "success" ] && [ "$snyk" = "success" ]; then
+            icon="🟢"
+          elif [ "$retire" = "failure" ] || [ "$snyk" = "failure" ]; then
+            icon="🚨"
+          else
+            icon="⚠️"
+          fi
+          run_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          {
+            echo "$icon *Security scan* — *OpenMetadata Repo* on branch \`${{ github.ref_name }}\`"
+            echo "• Vulnerability scan (Retire.js): $retire_icon"
+            echo "• Security scan (Snyk): $snyk_icon"
+            echo "<$run_url|Open run details>"
+            if [ -f security-report/_slack.txt ]; then
+              echo
+              cat security-report/_slack.txt
+            fi
+          } > slack_body.txt
+          jq -Rs '{text: ., blocks: [{type: "section", text: {type: "mrkdwn", text: .}}]}' slack_body.txt > payload.json
+
+      - name: Send Slack Notification
+        if: always() && steps.slack-payload.outcome == 'success'
+        uses: slackapi/slack-github-action@v1.27.1
+        with:
+          channel-id: ${{ secrets.SLACK_CHANNEL_IDS }}
+          payload-file-path: payload.json
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -12,7 +12,7 @@
 name: security-scan
 on:
   schedule:
-    - cron:  '0 0 */2 * *'
+    - cron: "0 0 */2 * *"
   workflow_dispatch:
 
 jobs:
@@ -27,7 +27,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version-file: 'openmetadata-ui/src/main/resources/ui/.nvmrc'
+          node-version-file: "openmetadata-ui/src/main/resources/ui/.nvmrc"
 
       - name: Enable yarn
         run: corepack enable
@@ -145,25 +145,25 @@ jobs:
       - name: Free Disk Space (Ubuntu)
         uses: jlumbroso/free-disk-space@main
         with:
-            tool-cache: false
-            android: true
-            dotnet: true
-            haskell: true
-            large-packages: false
-            docker-images: true
-            swap-storage: true      
+          tool-cache: false
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: false
+          docker-images: true
+          swap-storage: true
       - uses: actions/checkout@v4
 
       - name: Set up Python 3.10
         uses: actions/setup-python@v5
         with:
-          python-version: '3.10'
+          python-version: "3.10"
 
       - name: Set up JDK 21
         uses: actions/setup-java@v4
         with:
-          java-version: '21'
-          distribution: 'temurin'
+          java-version: "21"
+          distribution: "temurin"
 
       - name: Install Ubuntu dependencies
         run: |

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -274,38 +274,54 @@ jobs:
 
       - name: Build Slack payload
         id: slack-payload
+        env:
+          RETIRE_RESULT: ${{ needs.vulnerability-scan.result }}
+          SNYK_RESULT: ${{ needs.security-scan.result }}
+          REF_NAME: ${{ github.ref_name }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
-          retire="${{ needs.vulnerability-scan.result }}"
-          snyk="${{ needs.security-scan.result }}"
-          status_icon() {
-            case "$1" in
-              success)   echo "✅" ;;
-              cancelled) echo "⚠️ (cancelled)" ;;
-              skipped)   echo "⚠️ (skipped)" ;;
-              *)         echo "❌" ;;
-            esac
-          }
-          retire_icon=$(status_icon "$retire")
-          snyk_icon=$(status_icon "$snyk")
-          if [ "$retire" = "success" ] && [ "$snyk" = "success" ]; then
-            icon="🟢"
-          elif [ "$retire" = "failure" ] || [ "$snyk" = "failure" ]; then
-            icon="🚨"
-          else
-            icon="⚠️"
-          fi
-          run_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-          {
-            echo "$icon *Security scan* — *OpenMetadata Repo* on branch \`${{ github.ref_name }}\`"
-            echo "• Vulnerability scan (Retire.js): $retire_icon"
-            echo "• Security scan (Snyk): $snyk_icon"
-            echo "<$run_url|Open run details>"
-            if [ -f security-report/_slack.txt ]; then
-              echo
-              cat security-report/_slack.txt
-            fi
-          } > slack_body.txt
-          jq -Rs '{text: ., blocks: [{type: "section", text: {type: "mrkdwn", text: .}}]}' slack_body.txt > payload.json
+          python3 - <<'PY' > payload.json
+          import json, os, pathlib
+
+          retire = os.environ["RETIRE_RESULT"]
+          snyk = os.environ["SNYK_RESULT"]
+          ref_name = os.environ["REF_NAME"]
+          run_url = os.environ["RUN_URL"]
+
+          def status_icon(s):
+              return {"success": "✅", "cancelled": "⚠️ (cancelled)", "skipped": "⚠️ (skipped)"}.get(s, "❌")
+
+          if retire == "success" and snyk == "success":
+              overall = "🟢"
+          elif retire == "failure" or snyk == "failure":
+              overall = "🚨"
+          else:
+              overall = "⚠️"
+
+          header = (
+              f"{overall}  *Security scan* — *OpenMetadata Repo*\n"
+              f"_branch_ `{ref_name}`  ·  <{run_url}|Open run details>\n"
+              f"• Vulnerability scan (Retire.js): {status_icon(retire)}\n"
+              f"• Security scan (Snyk): {status_icon(snyk)}"
+          )
+
+          blocks = [{"type": "section", "text": {"type": "mrkdwn", "text": header}}]
+
+          slack_path = pathlib.Path("security-report/_slack.txt")
+          if slack_path.exists():
+              text = slack_path.read_text().strip()
+              sections = [s.strip() for s in text.split("\n\n") if s.strip()]
+              if sections:
+                  blocks.append({"type": "divider"})
+                  # Slack: max 50 blocks per message; each section text ≤ 3000 chars.
+                  for section in sections[:48]:
+                      if len(section) > 2900:
+                          section = section[:2850].rstrip() + "\n_…truncated, see Job Summary_"
+                      blocks.append({"type": "section", "text": {"type": "mrkdwn", "text": section}})
+
+          fallback = f"{overall} Security scan — OpenMetadata Repo on {ref_name}. {run_url}"
+          print(json.dumps({"text": fallback, "blocks": blocks}))
+          PY
 
       - name: Send Slack Notification
         if: always() && steps.slack-payload.outcome == 'success'

--- a/scripts/snyk_summary.py
+++ b/scripts/snyk_summary.py
@@ -126,30 +126,30 @@ def render_code_md(name, by_rule, rules, total):
 
 def render_deps_slack(name, libs, total, top):
     if not libs:
-        return f"📦 *{name}*: ✅ clean"
-    head = f"📦 *{name}*: {len(libs)} libs · {total} findings"
+        return f"📦  *{name}*  ·  ✅ clean"
+    head = f"📦  *{name}*  ·  {len(libs)} libs · {total} findings"
     rows = []
     ordered = sorted(libs.items(), key=lambda kv: sev_key(kv[1]["sev"]))
     for (pkg, ver), info in ordered[:top]:
         icon = SEV_ICON.get(info["sev"], "⚪")
         title = (sorted(info["titles"])[0] if info["titles"] else "")[:60]
-        fix = sorted(info["fixedIn"])[0] if info["fixedIn"] else "no fix"
-        rows.append(f"  {icon} `{pkg}` {ver} — {title} (fix: {fix})")
+        fix_label = f"_fix in {sorted(info['fixedIn'])[0]}_" if info["fixedIn"] else "_no fix_"
+        rows.append(f"   {icon}  `{pkg}@{ver}` — {title}  ·  {fix_label}")
     extra = len(libs) - top
     if extra > 0:
-        rows.append(f"  … +{extra} more")
+        rows.append(f"   _… +{extra} more_")
     return head + "\n" + "\n".join(rows)
 
 
 def render_code_slack(name, by_rule, rules, total, top):
     if not by_rule:
-        return f"🔎 *{name}*: ✅ clean"
-    head = f"🔎 *{name}*: {total} findings · {len(by_rule)} rules"
+        return f"🔎  *{name}*  ·  ✅ clean"
+    head = f"🔎  *{name}*  ·  {total} findings · {len(by_rule)} rules"
     ordered = sorted(by_rule.items(), key=lambda kv: -len(kv[1]))
-    rows = [f"  • `{rid}` ({len(items)})" for rid, items in ordered[:top]]
+    rows = [f"   •  `{rid}`  _×{len(items)}_" for rid, items in ordered[:top]]
     extra = len(by_rule) - top
     if extra > 0:
-        rows.append(f"  … +{extra} more")
+        rows.append(f"   _… +{extra} more_")
     return head + "\n" + "\n".join(rows)
 
 
@@ -222,14 +222,13 @@ def main():
 
     if args.slack_file:
         header = (
-            f"*🛡️ Snyk Security Scan* — 🚨 {totals['critical']} · 🔴 {totals['high']} · "
-            f"🟠 {totals['medium']} · 🟡 {totals['low']}"
+            f"*🛡️  Snyk Security Scan*\n"
+            f"🚨 *{totals['critical']}* critical  ·  🔴 *{totals['high']}* high  ·  "
+            f"🟠 *{totals['medium']}* medium  ·  🟡 *{totals['low']}* low"
         )
+        # Scans separated by blank lines — workflow splits this on `\n\n` and emits
+        # one Slack section block per scan, so nothing gets truncated mid-line.
         body = "\n\n".join([header] + slack_parts[1:])
-        # Slack section block hard limit is 3000 chars; leave generous headroom for
-        # the shell-prepended header (icons, branch name, run URL, per-scan statuses).
-        if len(body) > 1800:
-            body = body[:1750] + "\n…truncated. See Job Summary for full report."
         with open(args.slack_file, "w") as f:
             f.write(body)
 

--- a/scripts/snyk_summary.py
+++ b/scripts/snyk_summary.py
@@ -190,7 +190,9 @@ def main():
         if args.slack_file:
             with open(args.slack_file, "w") as f:
                 f.write("*🛡️ Snyk Security Scan*\n> No JSON reports found.")
-        return
+        # Exit non-zero so the workflow's summary-guard catches silent Snyk failures
+        # (e.g., misconfigured token producing zero JSON outputs).
+        sys.exit(1)
 
     for path in files:
         name = os.path.basename(path).replace(".json", "")
@@ -224,8 +226,10 @@ def main():
             f"🟠 {totals['medium']} · 🟡 {totals['low']}"
         )
         body = "\n\n".join([header] + slack_parts[1:])
-        if len(body) > 2200:
-            body = body[:2150] + "\n…truncated. See Job Summary for full report."
+        # Slack section block hard limit is 3000 chars; leave generous headroom for
+        # the shell-prepended header (icons, branch name, run URL, per-scan statuses).
+        if len(body) > 1800:
+            body = body[:1750] + "\n…truncated. See Job Summary for full report."
         with open(args.slack_file, "w") as f:
             f.write(body)
 

--- a/scripts/snyk_summary.py
+++ b/scripts/snyk_summary.py
@@ -1,0 +1,234 @@
+#!/usr/bin/env python3
+"""Render Snyk JSON reports as Markdown.
+
+Usage:
+  python3 scripts/snyk_summary.py [dir] \\
+      [--counts-file PATH] [--slack-file PATH] [--top N]
+"""
+import argparse
+import glob
+import json
+import os
+import sys
+
+SEV_ICON = {"critical": "🚨", "high": "🔴", "medium": "🟠", "low": "🟡"}
+SEV_RANK = {"critical": 0, "high": 1, "medium": 2, "low": 3}
+
+
+def esc(s):
+    return str(s).replace("|", "\\|").replace("`", "'").replace("\n", " ")
+
+
+def sev_key(s):
+    return SEV_RANK.get((s or "low").lower(), 3)
+
+
+def load(path):
+    try:
+        with open(path) as f:
+            return json.load(f), None
+    except Exception as e:
+        return None, str(e)
+
+
+def iter_projects(data):
+    if isinstance(data, list):
+        for d in data:
+            yield d
+    elif isinstance(data, dict):
+        yield data
+
+
+def collect_deps(data):
+    libs = {}
+    total = 0
+    for proj in iter_projects(data):
+        if not isinstance(proj, dict):
+            continue
+        for v in proj.get("vulnerabilities", []) or []:
+            key = (v.get("packageName", "?"), v.get("version", "?"))
+            entry = libs.setdefault(key, {
+                "sev": "low", "cves": set(), "titles": set(),
+                "fixedIn": set(), "paths": 0, "ids": set(),
+            })
+            if sev_key(v.get("severity")) < sev_key(entry["sev"]):
+                entry["sev"] = v.get("severity", "low")
+            for cve in (v.get("identifiers", {}) or {}).get("CVE", []) or []:
+                entry["cves"].add(cve)
+            entry["titles"].add(v.get("title", ""))
+            for fx in v.get("fixedIn", []) or []:
+                entry["fixedIn"].add(fx)
+            entry["ids"].add(v.get("id", ""))
+            entry["paths"] += 1
+            total += 1
+    return libs, total
+
+
+def collect_code(data):
+    runs = data.get("runs", []) if isinstance(data, dict) else []
+    findings = {}
+    rules = {}
+    for run in runs:
+        for rule in (run.get("tool", {}).get("driver", {}).get("rules", []) or []):
+            rules[rule.get("id")] = rule.get("shortDescription", {}).get("text", rule.get("name", ""))
+        for r in run.get("results", []) or []:
+            rid = r.get("ruleId", "?")
+            level = r.get("level", "warning")
+            for loc in r.get("locations", []) or []:
+                phys = loc.get("physicalLocation", {})
+                uri = phys.get("artifactLocation", {}).get("uri", "?")
+                line = phys.get("region", {}).get("startLine", "?")
+                findings.setdefault((rid, uri, level), []).append(line)
+    by_rule = {}
+    for (rid, uri, level), lines in findings.items():
+        by_rule.setdefault(rid, []).append((uri, level, lines))
+    total = sum(len(v) for v in by_rule.values())
+    return by_rule, rules, total
+
+
+def render_deps_md(name, libs, total):
+    out = [f"\n### 📦 {name}\n"]
+    if not libs:
+        out.append("✅ No vulnerabilities.\n")
+        return "\n".join(out)
+    out.append(f"> **{len(libs)} vulnerable librar{'y' if len(libs)==1 else 'ies'} · {total} finding{'s' if total!=1 else ''}**\n")
+    out.append("| Sev | Package | Version | CVE / ID | Title | Fix in | Paths |")
+    out.append("|---|---|---|---|---|---|---|")
+    for (pkg, ver), info in sorted(libs.items(), key=lambda kv: sev_key(kv[1]["sev"])):
+        sev = info["sev"]
+        ids = sorted(info["cves"]) or sorted(i for i in info["ids"] if i)[:1]
+        ids_str = ", ".join(f"[{c}](https://nvd.nist.gov/vuln/detail/{c})" if c.startswith("CVE") else c for c in ids) or "—"
+        title = sorted(info["titles"])[0][:80] if info["titles"] else ""
+        fix = ", ".join(sorted(info["fixedIn"])[:2]) or "—"
+        out.append(f"| {SEV_ICON.get(sev,'⚪')} {sev} | `{esc(pkg)}` | {esc(ver)} | {esc(ids_str)} | {esc(title)} | {esc(fix)} | {info['paths']} |")
+    out.append("")
+    return "\n".join(out)
+
+
+def render_code_md(name, by_rule, rules, total):
+    out = [f"\n### 🔎 {name} (Code)\n"]
+    if not by_rule:
+        out.append("✅ No code findings.\n")
+        return "\n".join(out)
+    out.append(f"> **{total} location{'s' if total!=1 else ''} across {len(by_rule)} rule{'s' if len(by_rule)!=1 else ''}**\n")
+    for rid, items in sorted(by_rule.items()):
+        desc = rules.get(rid, rid)
+        out.append(f"<details><summary><b>{esc(rid)}</b> — {esc(desc)} ({len(items)})</summary>\n")
+        out.append("| Level | File | Lines |")
+        out.append("|---|---|---|")
+        for uri, level, lines in sorted(items):
+            ln = ", ".join(str(x) for x in sorted(set(lines))[:10])
+            icon = "🔴" if level == "error" else "🟠"
+            out.append(f"| {icon} {level} | `{esc(uri)}` | {esc(ln)} |")
+        out.append("\n</details>\n")
+    return "\n".join(out)
+
+
+def render_deps_slack(name, libs, total, top):
+    if not libs:
+        return f"📦 *{name}*: ✅ clean"
+    head = f"📦 *{name}*: {len(libs)} libs · {total} findings"
+    rows = []
+    ordered = sorted(libs.items(), key=lambda kv: sev_key(kv[1]["sev"]))
+    for (pkg, ver), info in ordered[:top]:
+        icon = SEV_ICON.get(info["sev"], "⚪")
+        title = (sorted(info["titles"])[0] if info["titles"] else "")[:60]
+        fix = sorted(info["fixedIn"])[0] if info["fixedIn"] else "no fix"
+        rows.append(f"  {icon} `{pkg}` {ver} — {title} (fix: {fix})")
+    extra = len(libs) - top
+    if extra > 0:
+        rows.append(f"  … +{extra} more")
+    return head + "\n" + "\n".join(rows)
+
+
+def render_code_slack(name, by_rule, rules, total, top):
+    if not by_rule:
+        return f"🔎 *{name}*: ✅ clean"
+    head = f"🔎 *{name}*: {total} findings · {len(by_rule)} rules"
+    ordered = sorted(by_rule.items(), key=lambda kv: -len(kv[1]))
+    rows = [f"  • `{rid}` ({len(items)})" for rid, items in ordered[:top]]
+    extra = len(by_rule) - top
+    if extra > 0:
+        rows.append(f"  … +{extra} more")
+    return head + "\n" + "\n".join(rows)
+
+
+def count_severities(libs, by_rule):
+    counts = {"critical": 0, "high": 0, "medium": 0, "low": 0}
+    for info in libs.values():
+        sev = (info["sev"] or "low").lower()
+        if sev in counts:
+            counts[sev] += info["paths"]
+    for rid, items in by_rule.items():
+        for uri, level, lines in items:
+            mapped = {"error": "high", "warning": "medium", "note": "low"}.get(level, "medium")
+            counts[mapped] += 1
+    return counts
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("src", nargs="?", default="security-report")
+    ap.add_argument("--counts-file")
+    ap.add_argument("--slack-file")
+    ap.add_argument("--top", type=int, default=5)
+    args = ap.parse_args()
+
+    md_parts = ["## 🛡️ Snyk Security Scan\n"]
+    slack_parts = ["*🛡️ Snyk Security Scan*"]
+    totals = {"critical": 0, "high": 0, "medium": 0, "low": 0}
+
+    files = sorted(glob.glob(os.path.join(args.src, "*.json")))
+    files = [f for f in files if not os.path.basename(f).startswith("_")]
+
+    if not files:
+        md_parts.append(f"> No JSON reports found in `{args.src}/`.")
+        sys.stdout.write("\n".join(md_parts) + "\n")
+        if args.counts_file:
+            with open(args.counts_file, "w") as f:
+                json.dump({**totals, "total": 0}, f)
+        if args.slack_file:
+            with open(args.slack_file, "w") as f:
+                f.write("*🛡️ Snyk Security Scan*\n> No JSON reports found.")
+        return
+
+    for path in files:
+        name = os.path.basename(path).replace(".json", "")
+        data, err = load(path)
+        if err is not None:
+            md_parts.append(f"\n### ⚠️ {name}\nFailed to parse: {err}\n")
+            slack_parts.append(f"⚠️ *{name}*: parse error — {err}")
+            continue
+        if isinstance(data, dict) and "runs" in data:
+            by_rule, rules, total = collect_code(data)
+            md_parts.append(render_code_md(name, by_rule, rules, total))
+            slack_parts.append(render_code_slack(name, by_rule, rules, total, args.top))
+            sub = count_severities({}, by_rule)
+        else:
+            libs, total = collect_deps(data)
+            md_parts.append(render_deps_md(name, libs, total))
+            slack_parts.append(render_deps_slack(name, libs, total, args.top))
+            sub = count_severities(libs, {})
+        for k in totals:
+            totals[k] += sub[k]
+
+    sys.stdout.write("\n".join(md_parts) + "\n")
+
+    if args.counts_file:
+        with open(args.counts_file, "w") as f:
+            json.dump({**totals, "total": sum(totals.values())}, f)
+
+    if args.slack_file:
+        header = (
+            f"*🛡️ Snyk Security Scan* — 🚨 {totals['critical']} · 🔴 {totals['high']} · "
+            f"🟠 {totals['medium']} · 🟡 {totals['low']}"
+        )
+        body = "\n\n".join([header] + slack_parts[1:])
+        if len(body) > 2200:
+            body = body[:2150] + "\n…truncated. See Job Summary for full report."
+        with open(args.slack_file, "w") as f:
+            f.write(body)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:

<!--
Linking an issue is REQUIRED. Replace <issue-number> with the GitHub issue number this PR addresses
(e.g., `Fixes #12345`). GitHub will auto-link it. If no issue exists, please open one first so the
problem and design can be discussed before review.
-->

<!--
Short blurb explaining:
- What changes did you make?
- Why did you make them?
-->

## Summary
- Add `scripts/snyk_summary.py` — renders Snyk JSON as Markdown for `$GITHUB_STEP_SUMMARY`; emits `_counts.json` + `_slack.txt`.
- `vulnerability-scan` (Retire.js): merge + dedupe vulnerabilities across all results per `(component, version)`, guard `min()` against empty vulns lists. Inline Slack steps removed — consolidated in notify job.
- `security-scan` (Snyk): drive subtargets directly (`snyk-ingestion-report`, `snyk-ingestion-base-slim-report`, `snyk-airflow-apis-report`, `snyk-server-report`, `snyk-ui-report`) with `|| true`. Add `Publish Snyk Summary` (counts + slack files, exposes `high_critical`). Add `Fail on high/critical Snyk findings` (gate) + `Fail if Snyk summary could not be produced` (guard). PDF/HTML export strips `_*.json` first so internal metadata isn't converted; backup/restore preserves JSONs in artifact. Upload on `always() && build success`, 30-day retention.
- New `notify` job (`needs: [vulnerability-scan, security-scan]`, `if: always()`): downloads Snyk artifact, builds rich mrkdwn blocks payload (icon + per-scan status + condensed `_slack.txt` body), posts single message via `payload-file-path`. Gated on payload-build success.

## Why
- PDFs were huge and unreadable — Job Summary surfaces signal in the Actions UI.
- Two-or-three Slack messages per run; consolidating to one removes noise and clarifies which scan failed.
- Snyk regressions previously slipped past CI; explicit gate now fails the build, guard catches summary-script crashes.

## Failure matrix
| Retire | Snyk | high/critical | Job | Slack icon |
|---|---|---|---|---|
| ✅ | ✅ | 0 | 🟢 | 🟢 |
| ✅ | ✅ | ≥1 | 🚨 | 🚨 |
| ❌ | ✅ | — | 🚨 | 🚨 |
| ✅ | ❌ | — | 🚨 | 🚨 |
| cancelled / skipped | * | — | ⚠️ | ⚠️ |

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### High-level design:
<!--
REQUIRED for large PRs (new features, refactors, breaking changes, or anything touching >5 files).
Skip for small bug fixes and trivial changes.

Cover:
- Architecture / approach you took and why
- Key components or files added/changed and how they interact
- Alternatives considered and why you rejected them
- Any migration, backward-compatibility, or rollout concerns
- Diagrams or links to design docs / RFCs if available
-->

N/A — small change. <!-- Or fill in the design above -->

#
### Tests:

#### Use cases covered
<!--
List the user-visible scenarios this PR exercises. Example:
- User with Admin role can create a Glossary Term with a parent term
- Ingestion run for Snowflake correctly extracts row counts for partitioned tables
-->

#### Unit tests
<!--
- [ ] I added unit tests for the new/changed logic.
- Files added/updated:
- Coverage on changed classes (run `mvn jacoco:report` for backend, `yarn test:coverage` for UI,
  `make unit_ingestion` for ingestion). Target is 90% line coverage on changed classes.
- Coverage %: <e.g., 92% on EntityRepository.java>
-->

#### Backend integration tests
<!--
- [ ] I added integration tests in `openmetadata-integration-tests/` for new/changed API endpoints.
- [ ] Not applicable (no backend API changes).
- Files added/updated:
-->

#### Ingestion integration tests
<!--
- [ ] I added/updated ingestion integration tests for connector changes.
- [ ] Not applicable (no ingestion changes).
- Files added/updated:
-->

#### Playwright (UI) tests
<!--
- [ ] I added Playwright E2E tests under `openmetadata-ui/.../ui/playwright/` for UI changes.
- [ ] Not applicable (no UI changes).
- Files added/updated:
-->

#### Manual testing performed
<!--
List the manual test steps you performed before requesting review. Example:
1. Started local stack via `./docker/run_local_docker.sh -m ui -d mysql`
2. Logged in as admin, created entity X, verified Y appears in the UI
3. Triggered ingestion for Snowflake source, confirmed lineage edges in the explore page
-->

#
### UI screen recording / screenshots:
<!--
REQUIRED for any PR that changes the UI. Drag-and-drop a short screen recording (.mov / .mp4 / .gif)
demonstrating the change end-to-end, plus before/after screenshots where relevant.
Mark "Not applicable" if there are no UI changes.
-->

Not applicable. <!-- Or attach recording/screenshots above -->

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.
- [ ] For UI changes: I attached a screen recording and/or screenshots above.
- [ ] I have added tests (unit / integration / Playwright as applicable) and listed them above.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->
