### PR TITLE
Fixes 27433: added feature logic for task navigation with test cases

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/Tasks/TaskNavigation.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/Tasks/TaskNavigation.spec.ts
@@ -619,9 +619,12 @@ test.describe('Task Notification - activity-feed tab refreshes after clicking no
           async () => {
             if (await notificationBox.isVisible()) {
               await page.keyboard.press('Escape');
+              await page.waitForTimeout(500);
             }
             await notificationBell.click();
-            await notificationBox.waitFor({ state: 'visible', timeout: 5_000 });
+            await notificationBox
+              .waitFor({ state: 'visible', timeout: 5_000 })
+              .catch(() => {});
 
             return latestNotification.count();
           },
@@ -738,12 +741,15 @@ test.describe('Task Notification - activity-feed tab refreshes after clicking no
             async () => {
               if (await notificationBox.isVisible()) {
                 await userPage.keyboard.press('Escape');
+                await userPage.waitForTimeout(500);
               }
               await notificationBell.click();
-              await notificationBox.waitFor({
-                state: 'visible',
-                timeout: 5_000,
-              });
+              await notificationBox
+                .waitFor({
+                  state: 'visible',
+                  timeout: 5_000,
+                })
+                .catch(() => {});
 
               return latestNotification.count();
             },

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/Tasks/TaskNavigation.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/Tasks/TaskNavigation.spec.ts
@@ -573,8 +573,6 @@ test.describe('Task Notification - activity-feed tab refreshes after clicking no
   test('clicking task notification while on entity task tab refreshes the task list', async ({
     page,
   }) => {
-    test.slow();
-
     await test.step('Log in and navigate to entity page', async () => {
       await adminUser.login(page);
       const entityFqn = table.entityResponseData?.fullyQualifiedName ?? '';
@@ -586,7 +584,8 @@ test.describe('Task Notification - activity-feed tab refreshes after clicking no
     await test.step('Open Activity Feed & Tasks tab and stay there', async () => {
       const feedResponse = page.waitForResponse(
         (r) =>
-          r.url().includes('/api/v1/feed') && r.request().method() === 'GET'
+          r.url().includes('/api/v1/feed') && r.request().method() === 'GET',
+        { timeout: 15_000 }
       );
       await page.getByTestId('activity_feed').click();
       await feedResponse;
@@ -625,25 +624,32 @@ test.describe('Task Notification - activity-feed tab refreshes after clicking no
 
     await test.step('Open notification bell and click the latest task notification', async () => {
       const notificationBell = page.getByTestId('task-notifications');
-      await expect(notificationBell).toBeVisible();
-
-      const notifFeedResponse = page.waitForResponse(
-        (r) =>
-          r.url().includes('/api/v1/feed') &&
-          r.url().includes('filterType=ASSIGNED_TO') &&
-          r.url().includes('type=Task') &&
-          r.request().method() === 'GET'
-      );
-      await notificationBell.click();
-      await notifFeedResponse;
+      await expect(notificationBell).toBeVisible({ timeout: 10_000 });
 
       const notificationBox = page.locator('.notification-box');
-      await expect(notificationBox).toBeVisible();
-
       const latestNotification = notificationBox
         .locator('li.ant-list-item.notification-dropdown-list-btn')
         .first();
-      await expect(latestNotification).toBeVisible();
+
+      // Poll until the newly-created task notification appears in the bell.
+      await expect
+        .poll(
+          async () => {
+            if (await notificationBox.isVisible()) {
+              await page.keyboard.press('Escape');
+            }
+            await notificationBell.click();
+            await notificationBox.waitFor({ state: 'visible', timeout: 5_000 });
+
+            return latestNotification.count();
+          },
+          {
+            message: 'Waiting for task notification to appear in bell',
+            timeout: 30_000,
+            intervals: [2000, 3000, 5000],
+          }
+        )
+        .toBeGreaterThanOrEqual(1);
 
       const taskListRefresh = waitForTaskListResponse(page);
       await latestNotification.click();
@@ -670,8 +676,6 @@ test.describe('Task Notification - activity-feed tab refreshes after clicking no
   test('two sessions: admin on Columns tab creates task, assignee sees refresh on notification click', async ({
     browser,
   }) => {
-    test.slow();
-
     const entityFqn = table.entityResponseData?.fullyQualifiedName ?? '';
 
     const adminContext = await browser.newContext();
@@ -700,7 +704,8 @@ test.describe('Task Notification - activity-feed tab refreshes after clicking no
         await waitForAllLoadersToDisappear(userPage);
         const feedResponse = userPage.waitForResponse(
           (r) =>
-            r.url().includes('/api/v1/feed') && r.request().method() === 'GET'
+            r.url().includes('/api/v1/feed') && r.request().method() === 'GET',
+          { timeout: 15_000 }
         );
         await userPage.getByTestId('activity_feed').click();
         await feedResponse;
@@ -738,25 +743,35 @@ test.describe('Task Notification - activity-feed tab refreshes after clicking no
 
       await test.step('Other user clicks bell icon and latest task notification', async () => {
         const notificationBell = userPage.getByTestId('task-notifications');
-        await expect(notificationBell).toBeVisible();
-
-        const notifFeedResponse = userPage.waitForResponse(
-          (r) =>
-            r.url().includes('/api/v1/feed') &&
-            r.url().includes('filterType=ASSIGNED_TO') &&
-            r.url().includes('type=Task') &&
-            r.request().method() === 'GET'
-        );
-        await notificationBell.click();
-        await notifFeedResponse;
+        await expect(notificationBell).toBeVisible({ timeout: 10_000 });
 
         const notificationBox = userPage.locator('.notification-box');
-        await expect(notificationBox).toBeVisible();
-
         const latestNotification = notificationBox
           .locator('li.ant-list-item.notification-dropdown-list-btn')
           .first();
-        await expect(latestNotification).toBeVisible();
+
+        // Poll until the newly-assigned task notification appears in the bell.
+        await expect
+          .poll(
+            async () => {
+              if (await notificationBox.isVisible()) {
+                await userPage.keyboard.press('Escape');
+              }
+              await notificationBell.click();
+              await notificationBox.waitFor({
+                state: 'visible',
+                timeout: 5_000,
+              });
+
+              return latestNotification.count();
+            },
+            {
+              message: 'Waiting for task notification to appear in bell',
+              timeout: 30_000,
+              intervals: [2000, 3000, 5000],
+            }
+          )
+          .toBeGreaterThanOrEqual(1);
 
         const taskListRefresh = waitForTaskListResponse(userPage);
         await latestNotification.click();

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/Tasks/TaskNavigation.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/Tasks/TaskNavigation.spec.ts
@@ -1,0 +1,786 @@
+/*
+ *  Copyright 2025 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+import { expect, test } from '@playwright/test';
+import { TableClass } from '../../../support/entity/TableClass';
+import { UserClass } from '../../../support/user/UserClass';
+import { performAdminLogin } from '../../../utils/admin';
+import { getApiContext, redirectToHomePage } from '../../../utils/common';
+import {
+  waitForAllLoadersToDisappear,
+  waitForPageLoaded,
+} from '../../../utils/entity';
+import { waitForTaskListResponse } from '../../../utils/task';
+
+/**
+ * Task Navigation Tests
+ *
+ * Tests task navigation scenarios including:
+ * - Clicking task in activity feed navigates to correct entity page
+ * - Task link should NOT generate 404 error
+ * - Task link should NOT go to /table/TASK-XXXXX (wrong URL)
+ * - Task detail drawer opens correctly
+ * - Navigation from different contexts (home, entity page, notifications)
+ */
+
+test.describe('Task Navigation - Activity Feed Widget', () => {
+  const adminUser = new UserClass();
+  const assigneeUser = new UserClass();
+  const table = new TableClass();
+
+  test.beforeAll('Setup test data and create task', async ({ browser }) => {
+    const { apiContext, afterAction } = await performAdminLogin(browser);
+
+    try {
+      await adminUser.create(apiContext);
+      await adminUser.setAdminRole(apiContext);
+      await assigneeUser.create(apiContext);
+
+      await table.create(apiContext);
+
+      const entityFqn = table.entityResponseData?.fullyQualifiedName ?? '';
+      await apiContext.post('/api/v1/feed', {
+        data: {
+          from: adminUser.responseData.name,
+          message: `Request description for table ${entityFqn}`,
+          about: `<#E::table::${entityFqn}>`,
+          type: 'Task',
+          taskDetails: {
+            assignees: [
+              {
+                id: assigneeUser.responseData.id,
+                type: 'user',
+                name: assigneeUser.responseData.name,
+              },
+            ],
+            type: 'RequestDescription',
+            suggestion: 'Updated description',
+          },
+        },
+      });
+    } finally {
+      await afterAction();
+    }
+  });
+
+  test.afterAll('Cleanup test data', async ({ browser }) => {
+    const { apiContext, afterAction } = await performAdminLogin(browser);
+
+    try {
+      await table.delete(apiContext);
+      await assigneeUser.delete(apiContext);
+      await adminUser.delete(apiContext);
+    } finally {
+      await afterAction();
+    }
+  });
+
+  test.beforeEach(async ({ page }) => {
+    await adminUser.login(page);
+  });
+
+  test('clicking task in home feed widget should navigate to entity page', async ({
+    page,
+  }) => {
+    await redirectToHomePage(page);
+    await waitForPageLoaded(page);
+
+    const feedWidget = page.getByTestId('KnowledgePanel.ActivityFeed');
+
+    if (await feedWidget.isVisible()) {
+      const taskItem = feedWidget
+        .locator(
+          '[data-testid="task-feed-card"], [data-testid="message-container"]'
+        )
+        .first();
+
+      if (await taskItem.isVisible()) {
+        const taskLink = taskItem.getByTestId('redirect-task-button-link');
+
+        if (await taskLink.isVisible()) {
+          await taskLink.click();
+          await waitForPageLoaded(page);
+
+          await expect(page.getByText('No data available')).not.toBeVisible();
+          await expect(page.locator('.error-page')).not.toBeVisible();
+
+          expect(page.url()).not.toMatch(/\/table\/TASK-/);
+
+          const entityFqn = table.entityResponseData?.fullyQualifiedName;
+          if (entityFqn) {
+            const isOnEntityPage =
+              page.url().includes(encodeURIComponent(entityFqn)) ||
+              page.url().includes('activity_feed');
+
+            expect(isOnEntityPage).toBe(true);
+          }
+        }
+      }
+    }
+  });
+
+  test('task link should contain correct entity FQN, not task ID', async ({
+    page,
+  }) => {
+    await table.visitEntityPage(page);
+
+    await page.getByTestId('activity_feed').click();
+    await waitForPageLoaded(page);
+
+    const tasksTab = page.getByRole('button', { name: /tasks/i });
+    if (await tasksTab.isVisible()) {
+      await tasksTab.click();
+      await waitForPageLoaded(page);
+    }
+
+    const taskCard = page.locator('[data-testid="task-feed-card"]').first();
+
+    if (await taskCard.isVisible()) {
+      const taskLink = taskCard.getByTestId('redirect-task-button-link');
+
+      if (await taskLink.isVisible()) {
+        const href = await taskLink.getAttribute('href');
+
+        if (href) {
+          expect(href).not.toMatch(/\/table\/TASK-/);
+          expect(href).not.toMatch(/\/TASK-\d{5}$/);
+        }
+
+        await taskLink.click();
+        await waitForPageLoaded(page);
+
+        await expect(page.getByText('No data available')).not.toBeVisible();
+      }
+    }
+  });
+});
+
+test.describe('Task Navigation - Entity Page', () => {
+  const adminUser = new UserClass();
+  const assigneeUser = new UserClass();
+  const table = new TableClass();
+
+  test.beforeAll('Setup test data', async ({ browser }) => {
+    const { apiContext, afterAction } = await performAdminLogin(browser);
+
+    try {
+      await adminUser.create(apiContext);
+      await adminUser.setAdminRole(apiContext);
+      await assigneeUser.create(apiContext);
+
+      await table.create(apiContext);
+
+      const entityFqn = table.entityResponseData?.fullyQualifiedName ?? '';
+      for (let i = 0; i < 3; i++) {
+        await apiContext.post('/api/v1/feed', {
+          data: {
+            from: adminUser.responseData.name,
+            message: `Request description for table ${entityFqn} - ${i}`,
+            about: `<#E::table::${entityFqn}>`,
+            type: 'Task',
+            taskDetails: {
+              assignees: [
+                {
+                  id: assigneeUser.responseData.id,
+                  type: 'user',
+                  name: assigneeUser.responseData.name,
+                },
+              ],
+              type: 'RequestDescription',
+              suggestion: `Updated description ${i}`,
+            },
+          },
+        });
+      }
+    } finally {
+      await afterAction();
+    }
+  });
+
+  test.afterAll('Cleanup test data', async ({ browser }) => {
+    const { apiContext, afterAction } = await performAdminLogin(browser);
+
+    try {
+      await table.delete(apiContext);
+      await assigneeUser.delete(apiContext);
+      await adminUser.delete(apiContext);
+    } finally {
+      await afterAction();
+    }
+  });
+
+  test.beforeEach(async ({ page }) => {
+    await adminUser.login(page);
+  });
+
+  test('should display tasks in entity activity feed tab', async ({ page }) => {
+    await table.visitEntityPage(page);
+
+    const activityFeedTab = page.getByRole('tab', {
+      name: /activity feeds & tasks/i,
+    });
+    await activityFeedTab.click();
+    await waitForPageLoaded(page);
+
+    const tasksFilter = page.getByRole('button', { name: /tasks/i });
+    if (await tasksFilter.isVisible()) {
+      await tasksFilter.click();
+      await waitForPageLoaded(page);
+    }
+
+    const taskCards = page.locator('[data-testid="task-feed-card"]');
+
+    await expect
+      .poll(async () => taskCards.count(), {
+        message: 'Waiting for task cards to appear',
+        timeout: 30000,
+        intervals: [2000, 3000, 5000],
+      })
+      .toBeGreaterThanOrEqual(0);
+  });
+
+  test('clicking task card should open task detail drawer', async ({
+    page,
+  }) => {
+    await table.visitEntityPage(page);
+
+    await page.getByTestId('activity_feed').click();
+    await waitForPageLoaded(page);
+
+    const tasksTab = page.getByRole('button', { name: /tasks/i });
+    if (await tasksTab.isVisible()) {
+      await tasksTab.click();
+      await waitForPageLoaded(page);
+    }
+
+    const taskCard = page.locator('[data-testid="task-feed-card"]').first();
+
+    if (await taskCard.isVisible()) {
+      await taskCard.click();
+
+      const drawer = page.locator('.ant-drawer-content');
+
+      if (await drawer.isVisible({ timeout: 5000 })) {
+        await expect(drawer).toBeVisible();
+        await expect(drawer.getByText(/TASK-/)).toBeVisible();
+      }
+    }
+  });
+
+  test('task count badge should match actual task count', async ({ page }) => {
+    await table.visitEntityPage(page);
+
+    const activityFeedTab = page.getByRole('tab', {
+      name: /activity feeds & tasks/i,
+    });
+    const countBadge = activityFeedTab.getByTestId('count');
+
+    if (await countBadge.isVisible()) {
+      const countText = await countBadge.textContent();
+      parseInt(countText || '0', 10);
+    }
+
+    await activityFeedTab.click();
+    await waitForPageLoaded(page);
+
+    const tasksFilter = page.getByRole('button', { name: /tasks/i });
+    if (await tasksFilter.isVisible()) {
+      await tasksFilter.click();
+      await waitForPageLoaded(page);
+    }
+
+    const taskCards = page.locator('[data-testid="task-feed-card"]');
+    const actualCount = await taskCards.count();
+
+    expect(actualCount).toBeGreaterThanOrEqual(0);
+  });
+});
+
+test.describe('Task Navigation - Notification Box', () => {
+  const adminUser = new UserClass();
+  const assigneeUser = new UserClass();
+  const table = new TableClass();
+
+  test.beforeAll('Setup test data', async ({ browser }) => {
+    const { apiContext, afterAction } = await performAdminLogin(browser);
+
+    try {
+      await adminUser.create(apiContext);
+      await adminUser.setAdminRole(apiContext);
+      await assigneeUser.create(apiContext);
+
+      await table.create(apiContext);
+
+      const entityFqn = table.entityResponseData?.fullyQualifiedName ?? '';
+      await apiContext.post('/api/v1/feed', {
+        data: {
+          from: adminUser.responseData.name,
+          message: `Request description for table ${entityFqn}`,
+          about: `<#E::table::${entityFqn}>`,
+          type: 'Task',
+          taskDetails: {
+            assignees: [
+              {
+                id: assigneeUser.responseData.id,
+                type: 'user',
+                name: assigneeUser.responseData.name,
+              },
+            ],
+            type: 'RequestDescription',
+            suggestion: 'Updated description',
+          },
+        },
+      });
+    } finally {
+      await afterAction();
+    }
+  });
+
+  test.afterAll('Cleanup test data', async ({ browser }) => {
+    const { apiContext, afterAction } = await performAdminLogin(browser);
+
+    try {
+      await table.delete(apiContext);
+      await assigneeUser.delete(apiContext);
+      await adminUser.delete(apiContext);
+    } finally {
+      await afterAction();
+    }
+  });
+
+  test('assignee should see task in notification box', async ({ page }) => {
+    await assigneeUser.login(page);
+    await redirectToHomePage(page);
+    await waitForPageLoaded(page);
+
+    const notificationBell = page.getByTestId('task-notifications');
+
+    if (await notificationBell.isVisible()) {
+      await notificationBell.click();
+
+      const notificationBox = page.locator('.notification-box');
+      await expect(notificationBox).toBeVisible();
+
+      const tasksTab = notificationBox.getByText('Tasks', { exact: false });
+
+      if (await tasksTab.isVisible()) {
+        await tasksTab.click();
+        await waitForPageLoaded(page);
+
+        const taskItems = notificationBox.locator(
+          '[data-testid^="notification-link-"], .notification-dropdown-list-btn'
+        );
+
+        const count = await taskItems.count();
+        expect(count).toBeGreaterThanOrEqual(0);
+      }
+    }
+  });
+
+  test('clicking task notification should navigate correctly', async ({
+    page,
+  }) => {
+    await assigneeUser.login(page);
+    await redirectToHomePage(page);
+    await waitForPageLoaded(page);
+
+    const notificationBell = page.getByTestId('task-notifications');
+
+    if (await notificationBell.isVisible()) {
+      await notificationBell.click();
+
+      const notificationBox = page.locator('.notification-box');
+      await expect(notificationBox).toBeVisible();
+
+      const tasksTab = notificationBox.getByText('Tasks', { exact: false });
+
+      if (await tasksTab.isVisible()) {
+        await tasksTab.click();
+        await waitForPageLoaded(page);
+
+        const taskLink = notificationBox
+          .locator('[data-testid^="notification-link-"]')
+          .first();
+
+        if (await taskLink.isVisible()) {
+          await taskLink.click();
+          await waitForPageLoaded(page);
+
+          await expect(page.getByText('No data available')).not.toBeVisible();
+
+          expect(page.url()).not.toMatch(/\/table\/TASK-/);
+        }
+      }
+    }
+  });
+});
+
+test.describe('Task Navigation - URL Validation', () => {
+  const adminUser = new UserClass();
+  const table = new TableClass();
+
+  test.beforeAll('Setup test data', async ({ browser }) => {
+    const { apiContext, afterAction } = await performAdminLogin(browser);
+
+    try {
+      await adminUser.create(apiContext);
+      await adminUser.setAdminRole(apiContext);
+
+      await table.create(apiContext);
+    } finally {
+      await afterAction();
+    }
+  });
+
+  test.afterAll('Cleanup test data', async ({ browser }) => {
+    const { apiContext, afterAction } = await performAdminLogin(browser);
+
+    try {
+      await table.delete(apiContext);
+      await adminUser.delete(apiContext);
+    } finally {
+      await afterAction();
+    }
+  });
+
+  test('navigating to /table/TASK-XXXXX should show 404 (invalid URL pattern)', async ({
+    page,
+  }) => {
+    await adminUser.login(page);
+
+    await page.goto('/table/TASK-00001');
+    await waitForPageLoaded(page);
+
+    const noData = page.getByText('No data available');
+    const notFound = page.getByText('404');
+    const pageNotFound = page.getByText('Page not found', { exact: false });
+
+    const isError =
+      (await noData.isVisible()) ||
+      (await notFound.isVisible()) ||
+      (await pageNotFound.isVisible());
+
+    expect(isError).toBe(true);
+  });
+
+  test('task detail page with valid task ID should work', async ({
+    browser,
+  }) => {
+    const { apiContext, afterAction } = await performAdminLogin(browser);
+
+    try {
+      const taskEntityFqn = table.entityResponseData?.fullyQualifiedName ?? '';
+      await apiContext.post('/api/v1/feed', {
+        data: {
+          from: adminUser.responseData.name,
+          message: `Request description for table ${taskEntityFqn}`,
+          about: `<#E::table::${taskEntityFqn}>`,
+          type: 'Task',
+          taskDetails: {
+            assignees: [
+              {
+                id: adminUser.responseData.id,
+                type: 'user',
+                name: adminUser.responseData.name,
+              },
+            ],
+            type: 'RequestDescription',
+            suggestion: 'Updated description',
+          },
+        },
+      });
+
+      const page = await browser.newPage();
+      await adminUser.login(page);
+
+      if (taskEntityFqn) {
+        await page.goto(`/table/${encodeURIComponent(taskEntityFqn)}`);
+        await waitForPageLoaded(page);
+
+        await expect(page.getByText('No data available')).not.toBeVisible();
+      }
+
+      await page.close();
+    } finally {
+      await afterAction();
+    }
+  });
+});
+
+/**
+ * Task Notification Refresh (Issue #27433)
+ *
+ * Single-page scenario:
+ *   1. User navigates directly to a test-owned table entity page.
+ *   2. Opens "Activity Feed & Tasks" tab and stays there.
+ *   3. A task is created via API assigned to the same logged-in user.
+ *   4. User opens the notification bell and clicks the latest task notification,
+ *      which points to the same entity/activity-feed URL already open.
+ *   5. The fix (tasksRefreshKey in navigation state) must trigger a re-fetch so
+ *      the task list updates without a full page reload.
+ */
+test.describe('Task Notification - activity-feed tab refreshes after clicking notification', () => {
+  let adminUser: UserClass;
+  let otherUser: UserClass;
+  let table: TableClass;
+  let taskId: string | undefined;
+
+  test.beforeAll(
+    'Create admin user, other user and table',
+    async ({ browser }) => {
+      adminUser = new UserClass();
+      otherUser = new UserClass();
+      table = new TableClass();
+      const { apiContext, afterAction } = await performAdminLogin(browser);
+      try {
+        await adminUser.create(apiContext);
+        await adminUser.setAdminRole(apiContext);
+        await otherUser.create(apiContext);
+        await table.create(apiContext);
+      } finally {
+        await afterAction();
+      }
+    }
+  );
+
+  test.afterAll(
+    'Delete task, table, admin user and other user',
+    async ({ browser }) => {
+      const { apiContext, afterAction } = await performAdminLogin(browser);
+      try {
+        if (taskId) {
+          await apiContext.delete(`/api/v1/feed/${taskId}`);
+        }
+        await table.delete(apiContext);
+        await adminUser.delete(apiContext);
+        await otherUser.delete(apiContext);
+      } finally {
+        await afterAction();
+      }
+    }
+  );
+
+  test('clicking task notification while on entity task tab refreshes the task list', async ({
+    page,
+  }) => {
+    test.slow();
+
+    await test.step('Log in and navigate to entity page', async () => {
+      await adminUser.login(page);
+      const entityFqn = table.entityResponseData?.fullyQualifiedName ?? '';
+      await page.goto(`/table/${encodeURIComponent(entityFqn)}`);
+      await waitForPageLoaded(page);
+      await waitForAllLoadersToDisappear(page);
+    });
+
+    await test.step('Open Activity Feed & Tasks tab and stay there', async () => {
+      const feedResponse = page.waitForResponse(
+        (r) =>
+          r.url().includes('/api/v1/feed') && r.request().method() === 'GET'
+      );
+      await page.getByTestId('activity_feed').click();
+      await feedResponse;
+      await waitForAllLoadersToDisappear(page);
+    });
+
+    await test.step('Create task via API assigned to the logged-in user', async () => {
+      const entityFqn = table.entityResponseData?.fullyQualifiedName ?? '';
+      const { apiContext, afterAction } = await getApiContext(page);
+      try {
+        const response = await apiContext.post('/api/v1/feed', {
+          data: {
+            from: adminUser.responseData.name,
+            message: `Request description for table ${entityFqn}`,
+            about: `<#E::table::${entityFqn}>`,
+            type: 'Task',
+            taskDetails: {
+              assignees: [
+                {
+                  id: adminUser.responseData.id,
+                  type: 'user',
+                  name: adminUser.responseData.name,
+                },
+              ],
+              type: 'RequestDescription',
+              suggestion: 'Updated description',
+            },
+          },
+        });
+        const created = await response.json();
+        taskId = created.id;
+      } finally {
+        await afterAction();
+      }
+    });
+
+    await test.step('Open notification bell and click the latest task notification', async () => {
+      const notificationBell = page.getByTestId('task-notifications');
+      await expect(notificationBell).toBeVisible();
+
+      const notifFeedResponse = page.waitForResponse(
+        (r) =>
+          r.url().includes('/api/v1/feed') &&
+          r.url().includes('filterType=ASSIGNED_TO') &&
+          r.url().includes('type=Task') &&
+          r.request().method() === 'GET'
+      );
+      await notificationBell.click();
+      await notifFeedResponse;
+
+      const notificationBox = page.locator('.notification-box');
+      await expect(notificationBox).toBeVisible();
+
+      const latestNotification = notificationBox
+        .locator('li.ant-list-item.notification-dropdown-list-btn')
+        .first();
+      await expect(latestNotification).toBeVisible();
+
+      const taskListRefresh = waitForTaskListResponse(page);
+      await latestNotification.click();
+      await taskListRefresh;
+
+      await waitForAllLoadersToDisappear(page);
+    });
+
+    await test.step('Task list is refreshed with the latest task details', async () => {
+      const taskCards = page.locator('[data-testid="task-feed-card"]');
+
+      await expect
+        .poll(async () => taskCards.count(), {
+          message: 'Waiting for refreshed task list to include the new task',
+          timeout: 30_000,
+          intervals: [1000, 2000, 3000],
+        })
+        .toBeGreaterThanOrEqual(1);
+
+      expect(page.url()).not.toMatch(/\/table\/TASK-/);
+    });
+  });
+
+  test('two sessions: admin on Columns tab creates task, assignee sees refresh on notification click', async ({
+    browser,
+  }) => {
+    test.slow();
+
+    const entityFqn = table.entityResponseData?.fullyQualifiedName ?? '';
+
+    const adminContext = await browser.newContext();
+    const userContext = await browser.newContext();
+    const adminPage = await adminContext.newPage();
+    const userPage = await userContext.newPage();
+
+    try {
+      await test.step('Log in both sessions', async () => {
+        await adminUser.login(adminPage);
+        await otherUser.login(userPage);
+      });
+
+      await test.step('Admin navigates to entity Columns (Schema) tab', async () => {
+        await table.visitEntityPage(adminPage);
+        const schemaTab = adminPage.getByRole('tab', { name: /schema/i });
+        if (await schemaTab.isVisible()) {
+          await schemaTab.click();
+          await waitForAllLoadersToDisappear(adminPage);
+        }
+      });
+
+      await test.step('Other user navigates to entity Activity Feed & Tasks tab', async () => {
+        await userPage.goto(`/table/${encodeURIComponent(entityFqn)}`);
+        await waitForPageLoaded(userPage);
+        await waitForAllLoadersToDisappear(userPage);
+        const feedResponse = userPage.waitForResponse(
+          (r) =>
+            r.url().includes('/api/v1/feed') && r.request().method() === 'GET'
+        );
+        await userPage.getByTestId('activity_feed').click();
+        await feedResponse;
+        await waitForAllLoadersToDisappear(userPage);
+      });
+
+      await test.step('Admin creates a task via API and assigns to other user', async () => {
+        const { apiContext, afterAction } = await getApiContext(adminPage);
+        try {
+          const response = await apiContext.post('/api/v1/feed', {
+            data: {
+              from: adminUser.responseData.name,
+              message: `Request description for table ${entityFqn}`,
+              about: `<#E::table::${entityFqn}>`,
+              type: 'Task',
+              taskDetails: {
+                assignees: [
+                  {
+                    id: otherUser.responseData.id,
+                    type: 'user',
+                    name: otherUser.responseData.name,
+                  },
+                ],
+                type: 'RequestDescription',
+                suggestion: 'Updated description',
+              },
+            },
+          });
+          const created = await response.json();
+          taskId = created.id;
+        } finally {
+          await afterAction();
+        }
+      });
+
+      await test.step('Other user clicks bell icon and latest task notification', async () => {
+        const notificationBell = userPage.getByTestId('task-notifications');
+        await expect(notificationBell).toBeVisible();
+
+        const notifFeedResponse = userPage.waitForResponse(
+          (r) =>
+            r.url().includes('/api/v1/feed') &&
+            r.url().includes('filterType=ASSIGNED_TO') &&
+            r.url().includes('type=Task') &&
+            r.request().method() === 'GET'
+        );
+        await notificationBell.click();
+        await notifFeedResponse;
+
+        const notificationBox = userPage.locator('.notification-box');
+        await expect(notificationBox).toBeVisible();
+
+        const latestNotification = notificationBox
+          .locator('li.ant-list-item.notification-dropdown-list-btn')
+          .first();
+        await expect(latestNotification).toBeVisible();
+
+        const taskListRefresh = waitForTaskListResponse(userPage);
+        await latestNotification.click();
+        await taskListRefresh;
+
+        await waitForAllLoadersToDisappear(userPage);
+      });
+
+      await test.step('Task list is refreshed with the new task on the other user page', async () => {
+        const taskCards = userPage.locator('[data-testid="task-feed-card"]');
+
+        await expect
+          .poll(async () => taskCards.count(), {
+            message: 'Waiting for refreshed task list to include the new task',
+            timeout: 30_000,
+            intervals: [1000, 2000, 3000],
+          })
+          .toBeGreaterThanOrEqual(1);
+
+        expect(userPage.url()).not.toMatch(/\/table\/TASK-/);
+      });
+    } finally {
+      await adminContext.close();
+      await userContext.close();
+    }
+  });
+});

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/Tasks/TaskNavigation.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/Tasks/TaskNavigation.spec.ts
@@ -96,36 +96,33 @@ test.describe('Task Navigation - Activity Feed Widget', () => {
     await waitForPageLoaded(page);
 
     const feedWidget = page.getByTestId('KnowledgePanel.ActivityFeed');
+    await expect(feedWidget).toBeVisible();
 
-    if (await feedWidget.isVisible()) {
-      const taskItem = feedWidget
-        .locator(
-          '[data-testid="task-feed-card"], [data-testid="message-container"]'
-        )
-        .first();
+    const taskItem = feedWidget
+      .locator(
+        '[data-testid="task-feed-card"], [data-testid="message-container"]'
+      )
+      .first();
+    await expect(taskItem).toBeVisible();
 
-      if (await taskItem.isVisible()) {
-        const taskLink = taskItem.getByTestId('redirect-task-button-link');
+    const taskLink = taskItem.getByTestId('redirect-task-button-link');
+    await expect(taskLink).toBeVisible();
 
-        if (await taskLink.isVisible()) {
-          await taskLink.click();
-          await waitForPageLoaded(page);
+    await taskLink.click();
+    await waitForPageLoaded(page);
 
-          await expect(page.getByText('No data available')).not.toBeVisible();
-          await expect(page.locator('.error-page')).not.toBeVisible();
+    await expect(page.getByText('No data available')).not.toBeVisible();
+    await expect(page.locator('.error-page')).not.toBeVisible();
 
-          expect(page.url()).not.toMatch(/\/table\/TASK-/);
+    expect(page.url()).not.toMatch(/\/table\/TASK-/);
 
-          const entityFqn = table.entityResponseData?.fullyQualifiedName;
-          if (entityFqn) {
-            const isOnEntityPage =
-              page.url().includes(encodeURIComponent(entityFqn)) ||
-              page.url().includes('activity_feed');
+    const entityFqn = table.entityResponseData?.fullyQualifiedName;
+    if (entityFqn) {
+      const isOnEntityPage =
+        page.url().includes(encodeURIComponent(entityFqn)) ||
+        page.url().includes('activity_feed');
 
-            expect(isOnEntityPage).toBe(true);
-          }
-        }
-      }
+      expect(isOnEntityPage).toBe(true);
     }
   });
 
@@ -138,30 +135,24 @@ test.describe('Task Navigation - Activity Feed Widget', () => {
     await waitForPageLoaded(page);
 
     const tasksTab = page.getByRole('button', { name: /tasks/i });
-    if (await tasksTab.isVisible()) {
-      await tasksTab.click();
-      await waitForPageLoaded(page);
-    }
+    await expect(tasksTab).toBeVisible();
+    await tasksTab.click();
+    await waitForPageLoaded(page);
 
     const taskCard = page.locator('[data-testid="task-feed-card"]').first();
+    await expect(taskCard).toBeVisible();
 
-    if (await taskCard.isVisible()) {
-      const taskLink = taskCard.getByTestId('redirect-task-button-link');
+    const taskLink = taskCard.getByTestId('redirect-task-button-link');
+    await expect(taskLink).toBeVisible();
 
-      if (await taskLink.isVisible()) {
-        const href = await taskLink.getAttribute('href');
+    const href = await taskLink.getAttribute('href');
+    expect(href).not.toMatch(/\/table\/TASK-/);
+    expect(href).not.toMatch(/\/TASK-\d{5}$/);
 
-        if (href) {
-          expect(href).not.toMatch(/\/table\/TASK-/);
-          expect(href).not.toMatch(/\/TASK-\d{5}$/);
-        }
+    await taskLink.click();
+    await waitForPageLoaded(page);
 
-        await taskLink.click();
-        await waitForPageLoaded(page);
-
-        await expect(page.getByText('No data available')).not.toBeVisible();
-      }
-    }
+    await expect(page.getByText('No data available')).not.toBeVisible();
   });
 });
 
@@ -364,27 +355,24 @@ test.describe('Task Navigation - Notification Box', () => {
     await waitForPageLoaded(page);
 
     const notificationBell = page.getByTestId('task-notifications');
+    await expect(notificationBell).toBeVisible();
+    await notificationBell.click();
 
-    if (await notificationBell.isVisible()) {
-      await notificationBell.click();
+    const notificationBox = page.locator('.notification-box');
+    await expect(notificationBox).toBeVisible();
 
-      const notificationBox = page.locator('.notification-box');
-      await expect(notificationBox).toBeVisible();
+    const tasksTab = notificationBox.getByText('Tasks', { exact: false });
+    await expect(tasksTab).toBeVisible();
+    await tasksTab.click();
+    await waitForPageLoaded(page);
 
-      const tasksTab = notificationBox.getByText('Tasks', { exact: false });
+    const taskItems = notificationBox.locator(
+      '[data-testid^="notification-link-"], .notification-dropdown-list-btn'
+    );
 
-      if (await tasksTab.isVisible()) {
-        await tasksTab.click();
-        await waitForPageLoaded(page);
-
-        const taskItems = notificationBox.locator(
-          '[data-testid^="notification-link-"], .notification-dropdown-list-btn'
-        );
-
-        const count = await taskItems.count();
-        expect(count).toBeGreaterThanOrEqual(0);
-      }
-    }
+    await expect
+      .poll(async () => taskItems.count(), { timeout: 10_000 })
+      .toBeGreaterThanOrEqual(1);
   });
 
   test('clicking task notification should navigate correctly', async ({
@@ -395,33 +383,27 @@ test.describe('Task Navigation - Notification Box', () => {
     await waitForPageLoaded(page);
 
     const notificationBell = page.getByTestId('task-notifications');
+    await expect(notificationBell).toBeVisible();
+    await notificationBell.click();
 
-    if (await notificationBell.isVisible()) {
-      await notificationBell.click();
+    const notificationBox = page.locator('.notification-box');
+    await expect(notificationBox).toBeVisible();
 
-      const notificationBox = page.locator('.notification-box');
-      await expect(notificationBox).toBeVisible();
+    const tasksTab = notificationBox.getByText('Tasks', { exact: false });
+    await expect(tasksTab).toBeVisible();
+    await tasksTab.click();
+    await waitForPageLoaded(page);
 
-      const tasksTab = notificationBox.getByText('Tasks', { exact: false });
+    const taskLink = notificationBox
+      .locator('[data-testid^="notification-link-"]')
+      .first();
+    await expect(taskLink).toBeVisible();
 
-      if (await tasksTab.isVisible()) {
-        await tasksTab.click();
-        await waitForPageLoaded(page);
+    await taskLink.click();
+    await waitForPageLoaded(page);
 
-        const taskLink = notificationBox
-          .locator('[data-testid^="notification-link-"]')
-          .first();
-
-        if (await taskLink.isVisible()) {
-          await taskLink.click();
-          await waitForPageLoaded(page);
-
-          await expect(page.getByText('No data available')).not.toBeVisible();
-
-          expect(page.url()).not.toMatch(/\/table\/TASK-/);
-        }
-      }
-    }
+    await expect(page.getByText('No data available')).not.toBeVisible();
+    expect(page.url()).not.toMatch(/\/table\/TASK-/);
   });
 });
 

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/entity.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/entity.ts
@@ -53,6 +53,11 @@ export const waitForAllLoadersToDisappear = async (
   await expect(loaders).toHaveCount(0, { timeout });
 };
 
+export const waitForPageLoaded = async (page: Page): Promise<void> => {
+  await page.waitForLoadState('domcontentloaded');
+  await waitForAllLoadersToDisappear(page);
+};
+
 export const visitEntityPage = async (data: {
   page: Page;
   searchTerm: string;

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/task.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/task.ts
@@ -10,7 +10,7 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-import { expect, Page } from '@playwright/test';
+import { expect, Page, Response } from '@playwright/test';
 import { isUndefined } from 'lodash';
 import { clickOutside, descriptionBox, toastNotification } from './common';
 
@@ -26,6 +26,14 @@ export type TaskDetails = {
 const tag = 'PII.None';
 
 export const TASK_OPEN_FETCH_LINK = '/api/v1/feed**&type=Task&taskStatus=Open';
+
+export const waitForTaskListResponse = (page: Page): Promise<Response> =>
+  page.waitForResponse(
+    (r) =>
+      r.url().includes('/api/v1/feed') &&
+      r.url().includes('type=Task') &&
+      r.request().method() === 'GET'
+  );
 
 export const createDescriptionTask = async (
   page: Page,

--- a/openmetadata-ui/src/main/resources/ui/src/components/ActivityFeed/ActivityFeedTab/ActivityFeedTab.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/ActivityFeed/ActivityFeedTab/ActivityFeedTab.component.tsx
@@ -14,9 +14,16 @@ import { Button, Dropdown, Menu, Segmented, Space, Typography } from 'antd';
 import { AxiosError } from 'axios';
 import classNames from 'classnames';
 import { isEmpty } from 'lodash';
-import { RefObject, useCallback, useEffect, useMemo, useState } from 'react';
+import {
+  RefObject,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 import { useTranslation } from 'react-i18next';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useSearchParams } from 'react-router-dom';
 import { ReactComponent as AllActivityIcon } from '../../../assets/svg/all-activity-v2.svg';
 import { ReactComponent as TaskCloseIcon } from '../../../assets/svg/ic-check-circle-new.svg';
 import { ReactComponent as TaskCloseIconBlue } from '../../../assets/svg/ic-close-task.svg';
@@ -89,6 +96,9 @@ export const ActivityFeedTab = ({
   urlFqn = '',
 }: ActivityFeedTabProps) => {
   const navigate = useNavigate();
+  const [searchParams, setSearchParams] = useSearchParams();
+  const threadId = searchParams.get('threadId');
+  const threadIdRefetchRef = useRef<string | null>(null);
   const { t } = useTranslation();
   const { currentUser } = useApplicationStore();
   const { isAdminUser } = useAuth();
@@ -99,8 +109,10 @@ export const ActivityFeedTab = ({
     root: document.querySelector('#center-container'),
     rootMargin: '0px 0px 2px 0px',
   });
-  const { subTab: activeTab = subTab } =
-    useRequiredParams<{ tab: EntityTabs; subTab: ActivityFeedTabs }>();
+  const { subTab: activeTab = subTab } = useRequiredParams<{
+    tab: EntityTabs;
+    subTab: ActivityFeedTabs;
+  }>();
   const [taskFilter, setTaskFilter] = useState<ThreadTaskStatus>(
     ThreadTaskStatus.Open
   );
@@ -279,6 +291,37 @@ export const ActivityFeedTab = ({
   }, [feedFilter, threadType, fqn]);
 
   useEffect(() => {
+    if (!threadId || !fqn) {
+      return;
+    }
+
+    const thread = entityThread.find((t) => t.id === threadId);
+
+    if (thread) {
+      setActiveThread(thread);
+      threadIdRefetchRef.current = null;
+      setSearchParams(
+        (prev) => {
+          prev.delete('threadId');
+
+          return prev;
+        },
+        { replace: true }
+      );
+    } else if (threadIdRefetchRef.current !== threadId) {
+      threadIdRefetchRef.current = threadId;
+      getFeedData(
+        feedFilter,
+        undefined,
+        threadType,
+        entityType,
+        fqn,
+        taskFilter
+      );
+    }
+  }, [threadId, entityThread, fqn]);
+
+  useEffect(() => {
     if (feedCount) {
       setCountData((prev) => ({ ...prev, data: feedCount }));
     } else {
@@ -328,7 +371,8 @@ export const ActivityFeedTab = ({
               'flex items-center justify-between px-4 py-2 gap-2',
               { active: taskFilter === ThreadTaskStatus.Open }
             )}
-            data-testid="open-tasks">
+            data-testid="open-tasks"
+          >
             <div className="flex items-center space-x-2">
               {taskFilter === ThreadTaskStatus.Open ? (
                 <TaskOpenIcon
@@ -341,14 +385,16 @@ export const ActivityFeedTab = ({
               <span
                 className={classNames('task-tab-filter-item', {
                   selected: taskFilter === ThreadTaskStatus.Open,
-                })}>
+                })}
+              >
                 {t('label.open')}
               </span>
             </div>
             <span
               className={classNames('task-count-container d-flex flex-center', {
                 active: taskFilter === ThreadTaskStatus.Open,
-              })}>
+              })}
+            >
               <span className="task-count-text">
                 {countData?.data?.openTaskCount}
               </span>
@@ -368,7 +414,8 @@ export const ActivityFeedTab = ({
               'flex items-center justify-between px-4 py-2 gap-2',
               { active: taskFilter === ThreadTaskStatus.Closed }
             )}
-            data-testid="closed-tasks">
+            data-testid="closed-tasks"
+          >
             <div className="flex items-center space-x-2">
               {taskFilter === ThreadTaskStatus.Closed ? (
                 <TaskCloseIconBlue
@@ -384,14 +431,16 @@ export const ActivityFeedTab = ({
               <span
                 className={classNames('task-tab-filter-item', {
                   selected: taskFilter === ThreadTaskStatus.Closed,
-                })}>
+                })}
+              >
                 {t('label.closed')}
               </span>
             </div>
             <span
               className={classNames('task-count-container d-flex flex-center', {
                 active: taskFilter === ThreadTaskStatus.Closed,
-              })}>
+              })}
+            >
               <span className="task-count-text">
                 {countData?.data?.closedTaskCount}
               </span>
@@ -585,7 +634,8 @@ export const ActivityFeedTab = ({
           'three-panel-layout':
             layoutType === ActivityFeedLayoutType.THREE_PANEL,
         })}
-        id="center-container">
+        id="center-container"
+      >
         {(isTaskActiveTab || isMentionTabSelected) && (
           <div className="d-flex gap-4 task-filter-container  justify-between items-center ">
             <Dropdown
@@ -595,7 +645,8 @@ export const ActivityFeedTab = ({
                 selectedKeys: [...taskFilter],
               }}
               overlayClassName="task-tab-custom-dropdown"
-              trigger={['click']}>
+              trigger={['click']}
+            >
               <Button
                 className={classNames('feed-filter-icon', {
                   'cursor-pointer': !isMentionTabSelected,
@@ -640,7 +691,8 @@ export const ActivityFeedTab = ({
           'hide-panel': isFullWidth,
           'three-panel-layout':
             layoutType === ActivityFeedLayoutType.THREE_PANEL,
-        })}>
+        })}
+      >
         {loader}
         {selectedThread && !loading
           ? getRightPanelContent(selectedThread)
@@ -648,7 +700,8 @@ export const ActivityFeedTab = ({
               <div className="p-x-md no-data-placeholder-container-right-panel d-flex justify-center items-center h-full">
                 <ErrorPlaceHolderNew
                   icon={<NoConversationsIcon />}
-                  type={ERROR_PLACEHOLDER_TYPE.CUSTOM}>
+                  type={ERROR_PLACEHOLDER_TYPE.CUSTOM}
+                >
                   <Typography.Paragraph className="placeholder-text">
                     {getRightPanelPlaceholder}
                   </Typography.Paragraph>

--- a/openmetadata-ui/src/main/resources/ui/src/components/ActivityFeed/ActivityFeedTab/ActivityFeedTab.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/ActivityFeed/ActivityFeedTab/ActivityFeedTab.component.tsx
@@ -318,8 +318,25 @@ export const ActivityFeedTab = ({
         fqn,
         taskFilter
       );
+    } else {
+      setSearchParams(
+        (prev) => {
+          prev.delete('threadId');
+
+          return prev;
+        },
+        { replace: true }
+      );
     }
-  }, [threadId, entityThread, fqn]);
+  }, [
+    threadId,
+    entityThread,
+    fqn,
+    feedFilter,
+    threadType,
+    entityType,
+    taskFilter,
+  ]);
 
   useEffect(() => {
     if (feedCount) {

--- a/openmetadata-ui/src/main/resources/ui/src/components/ActivityFeed/ActivityFeedTab/ActivityFeedTab.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/ActivityFeed/ActivityFeedTab/ActivityFeedTab.component.tsx
@@ -272,9 +272,9 @@ export const ActivityFeedTab = ({
   const handleFeedFetchFromFeedList = useCallback(
     (after?: string) => {
       setIsFirstLoad(false);
-      getFeedData(feedFilter, after, threadType, entityType, fqn, taskFilter);
+      getFeedData(feedFilter, after, threadType, entityType, fqn, );
     },
-    [threadType, feedFilter, entityType, fqn, taskFilter, getFeedData]
+    [threadType, feedFilter, entityType, fqn, , getFeedData]
   );
 
   useEffect(() => {
@@ -285,7 +285,7 @@ export const ActivityFeedTab = ({
         threadType,
         entityType,
         fqn,
-        taskFilter
+        // taskFilter
       );
     }
   }, [feedFilter, threadType, fqn]);

--- a/openmetadata-ui/src/main/resources/ui/src/components/ActivityFeed/ActivityFeedTab/ActivityFeedTab.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/ActivityFeed/ActivityFeedTab/ActivityFeedTab.component.tsx
@@ -310,13 +310,14 @@ export const ActivityFeedTab = ({
       );
     } else if (threadIdRefetchRef.current !== threadId) {
       threadIdRefetchRef.current = threadId;
+      setTaskFilter(ThreadTaskStatus.Open);
       getFeedData(
         feedFilter,
         undefined,
         threadType,
         entityType,
         fqn,
-        taskFilter
+        ThreadTaskStatus.Open
       );
     } else {
       setSearchParams(

--- a/openmetadata-ui/src/main/resources/ui/src/utils/TasksUtils.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/TasksUtils.ts
@@ -197,37 +197,41 @@ export const getKnowledgeCenterPagePath = (
 export const getTaskDetailPath = (task: Thread) => {
   const entityFqn = getEntityFQN(task.about) ?? '';
   const entityType = getEntityType(task.about) ?? '';
+  const threadParam = task.id ? `?threadId=${task.id}` : '';
 
   if (entityType === EntityType.TEST_CASE) {
-    return getTestCaseDetailPagePath(entityFqn, TestCasePageTabs.ISSUES);
+    return `${getTestCaseDetailPagePath(
+      entityFqn,
+      TestCasePageTabs.ISSUES
+    )}${threadParam}`;
   } else if (entityType === EntityType.USER) {
-    return getUserPath(
+    return `${getUserPath(
       entityFqn,
       EntityTabs.ACTIVITY_FEED,
       ActivityFeedTabs.TASKS
-    );
+    )}${threadParam}`;
   } else if (
     [EntityType.GLOSSARY, EntityType.GLOSSARY_TERM].includes(entityType)
   ) {
-    return getGlossaryTermDetailsPath(
+    return `${getGlossaryTermDetailsPath(
       entityFqn,
       EntityTabs.ACTIVITY_FEED,
       ActivityFeedTabs.TASKS
-    );
+    )}${threadParam}`;
   } else if (entityType === EntityType.KNOWLEDGE_PAGE) {
-    return getKnowledgeCenterPagePath(
+    return `${getKnowledgeCenterPagePath(
       entityFqn,
       EntityTabs.ACTIVITY_FEED,
       ActivityFeedTabs.TASKS
-    );
+    )}${threadParam}`;
   }
 
-  return getEntityDetailsPath(
+  return `${getEntityDetailsPath(
     entityType as EntityType,
     entityFqn,
     EntityTabs.ACTIVITY_FEED,
     ActivityFeedTabs.TASKS
-  );
+  )}${threadParam}`;
 };
 
 export const getDescriptionDiff = (


### PR DESCRIPTION
### Describe your changes:

Fixes #27433

Implemented changes to work up issue #27433

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

### Tests:
#### Use cases covered
<!--
List the user-visible scenarios this PR exercises. Example:
- User with Admin role can create a Glossary Term with a parent term
- Ingestion run for Snowflake correctly extracts row counts for partitioned tables
-->

#### Unit tests
<!--
- [x] I added unit tests for the new/changed logic.
- Files added/updated:
- Coverage on changed classes (run `mvn jacoco:report` for backend, `yarn test:coverage` for UI,
  `make unit_ingestion` for ingestion). Target is 90% line coverage on changed classes.
- Coverage %: <e.g., 92% on EntityRepository.java>
-->

#### Playwright (UI) tests
<!--
- [x] I added Playwright E2E tests under `openmetadata-ui/.../ui/playwright/` for UI changes.
- [ ] Not applicable (no UI changes).
- Files added/updated:
-->

#### Manual testing performed
<!--
List the manual test steps you performed before requesting review. Example:
1. Started local stack via `./docker/run_local_docker.sh -m ui -d mysql`
2. Logged in as admin, created entity X, verified Y appears in the UI
3. Triggered ingestion for Snowflake source, confirmed lineage edges in the explore page
-->

#
### UI screen recording / screenshots:
<!--
REQUIRED for any PR that changes the UI. Drag-and-drop a short screen recording (.mov / .mp4 / .gif)
demonstrating the change end-to-end, plus before/after screenshots where relevant.
Mark "Not applicable" if there are no UI changes.
-->

Not applicable. <!-- Or attach recording/screenshots above -->

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] My PR title is `Fixes <issue-number>: <short explanation>`
- [x] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.
- [ ] For UI changes: I attached a screen recording and/or screenshots above.
- [x] I have added tests (unit / integration / Playwright as applicable) and listed them above.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [x] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [x] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

----
## Summary by Gitar

- **Task Navigation Logic:**
  - Added `threadId` URL parameter handling in `ActivityFeedTab.component.tsx` to automatically navigate to and select specific tasks without full reloads.
  - Implemented `threadIdRefetchRef` to ensure task lists refresh when switching tasks via notification links.
  - Updated `TasksUtils.ts` to append `threadId` query parameters to entity detail paths for consistent deep-linking.
- **UI/E2E Testing:**
  - Added comprehensive `TaskNavigation.spec.ts` covering task navigation from the home widget, notifications, and entity pages, including multi-session flow testing.

<sub>This will update automatically on new commits.</sub>