### PR TITLE
fix(logging): non-blocking streamable log handler (ingestion-only cherry-pick of #28198) [1.12.9]

### DIFF
--- a/ingestion/src/metadata/ingestion/ometa/client.py
+++ b/ingestion/src/metadata/ingestion/ometa/client.py
@@ -159,15 +159,17 @@ class REST:
 
         self._limits_reached = TTLCache(config.ttl_cache)
 
-    def _request(  # pylint: disable=too-many-arguments,too-many-branches
+    def _request(  # noqa: C901, pylint: disable=too-many-arguments,too-many-branches
         self,
-        method,
-        path,
-        data=None,
-        json=None,
-        base_url: URL = None,
-        api_version: str = None,
-        headers: dict = None,
+        method: str,
+        path: str,
+        data: Any = None,
+        json: Any = None,
+        base_url: Optional[URL] = None,  # noqa: UP045
+        api_version: Optional[str] = None,  # noqa: UP045
+        headers: Optional[dict] = None,  # noqa: UP045
+        timeout: Optional[Union[float, tuple[float, float]]] = None,  # noqa: UP007, UP045
+        retries: Optional[int] = None,  # noqa: UP045
     ):
         # pylint: disable=too-many-locals
         if path in self._limits_reached:
@@ -231,10 +233,14 @@ class REST:
         if self._cert:
             opts["cert"] = self._cert
 
-        if self._timeout:
-            opts["timeout"] = self._timeout
+        effective_timeout = timeout if timeout is not None else self._timeout
+        if effective_timeout:
+            opts["timeout"] = effective_timeout
 
-        total_retries = self._retry if self._retry > 0 else 0
+        if retries is not None:
+            total_retries = retries if retries > 0 else 0
+        else:
+            total_retries = self._retry if self._retry and self._retry > 0 else 0
         retry = total_retries
         while retry >= 0:
             try:
@@ -333,7 +339,15 @@ class REST:
         return self._request("GET", path, data, headers=headers)
 
     @calculate_execution_time(context="POST")
-    def post(self, path, data=None, json=None, headers=None):
+    def post(
+        self,
+        path: str,
+        data: Any = None,
+        json: Any = None,
+        headers: Optional[dict] = None,  # noqa: UP045
+        timeout: Optional[Union[float, tuple[float, float]]] = None,  # noqa: UP007, UP045
+        retries: Optional[int] = None,  # noqa: UP045
+    ):
         """
         POST method
 
@@ -342,11 +356,70 @@ class REST:
             data ():
             json ():
             headers (dict): Optional custom headers to override default headers
+            timeout: Per-call timeout that overrides the instance default
+            retries: Per-call retry budget that overrides the instance default.
+                     Pass 0 to disable the retry/sleep loop entirely.
 
         Returns:
             Response
         """
-        return self._request("POST", path, data, json, headers=headers)
+        return self._request(
+            "POST",
+            path,
+            data,
+            json,
+            headers=headers,
+            timeout=timeout,
+            retries=retries,
+        )
+
+    def post_best_effort(
+        self,
+        path: str,
+        data: Any = None,
+        headers: Optional[dict] = None,  # noqa: UP045
+        timeout: Optional[Union[float, tuple[float, float]]] = None,  # noqa: UP007, UP045
+    ) -> bool:
+        """Quiet POST: no retries, no sleep, no logging. Returns True on 2xx."""
+        if path in self._limits_reached:
+            return False
+        try:
+            url = URL(self._base_url + "/" + self._api_version + path)
+            req_headers = self._build_request_headers(headers)
+            kwargs = {
+                "data": data,
+                "headers": req_headers,
+                "verify": self._verify,
+                "cookies": self._cookies,
+                "allow_redirects": self.config.allow_redirects,
+            }
+            effective_timeout = timeout if timeout is not None else self._timeout
+            if effective_timeout:
+                kwargs["timeout"] = effective_timeout
+            if self._cert:
+                kwargs["cert"] = self._cert
+            resp = self._session.post(url, **kwargs)
+        except Exception:
+            return False
+        return 200 <= resp.status_code < 300
+
+    def _build_request_headers(self, headers: Optional[dict] = None):  # noqa: UP045
+        """Reader-only headers builder. Does NOT refresh auth token —
+        refresh stays on _request() to avoid concurrent refreshes from
+        post_best_effort callers sharing ClientConfig."""
+        if not headers:
+            headers = {"Content-type": "application/json"}
+        if self.config.auth_header and self.config.access_token:
+            headers[self.config.auth_header] = (
+                f"{self._auth_token_mode} {self.config.access_token}"
+                if self._auth_token_mode
+                else self.config.access_token
+            )
+        if self.config.extra_headers:
+            extra_headers: Dict[str, str] = self.config.extra_headers  # noqa: UP006
+            extra_headers = {k: (v % headers) for k, v in extra_headers.items()}
+            headers = {**headers, **extra_headers}
+        return headers
 
     @calculate_execution_time(context="PUT")
     def put(self, path, data=None, json=None, headers=None):

--- a/ingestion/src/metadata/ingestion/ometa/mixins/logs_mixin.py
+++ b/ingestion/src/metadata/ingestion/ometa/mixins/logs_mixin.py
@@ -22,7 +22,7 @@ import json
 import os
 import socket
 import time
-from typing import Optional
+from typing import Optional, Union
 from uuid import UUID
 
 from metadata.ingestion.ometa.client import REST
@@ -50,6 +50,7 @@ class OMetaLogsMixin:
         run_id: UUID,
         log_content: str,
         compress: bool = False,
+        timeout: Optional[Union[float, tuple[float, float]]] = None,  # noqa: UP007, UP045
     ) -> bool:
         """
         Send logs to S3 storage via OpenMetadata server endpoint.
@@ -59,6 +60,7 @@ class OMetaLogsMixin:
             run_id: Unique identifier for the pipeline run
             log_content: The log content to send
             compress: Whether to compress logs before sending
+            timeout: Per-call HTTP timeout (seconds). Overrides client default.
 
         Returns:
             bool: True if logs were sent successfully, False otherwise
@@ -89,6 +91,7 @@ class OMetaLogsMixin:
             self.client.post(
                 url,
                 data=json.dumps(log_batch),
+                timeout=timeout,
             )
 
             # The REST client returns None for successful requests with empty response body (HTTP 200/201/204)
@@ -115,6 +118,7 @@ class OMetaLogsMixin:
         log_content: str,
         enable_compression: bool = False,
         max_retries: int = 3,
+        timeout: Optional[Union[float, tuple[float, float]]] = None,  # noqa: UP007, UP045
     ) -> dict:
         """
         Send logs batch to S3 storage via OpenMetadata server endpoint with retry logic.
@@ -125,6 +129,9 @@ class OMetaLogsMixin:
             log_content: The log content to send
             enable_compression: Whether to compress logs before sending
             max_retries: Maximum number of retry attempts
+            timeout: Per-call HTTP timeout (seconds). Overrides client default.
+                     Streamable log handler passes a short value here so a
+                     slow server can't tie up the shipper.
 
         Returns:
             dict: Metrics including lines sent and bytes sent
@@ -138,6 +145,7 @@ class OMetaLogsMixin:
                     run_id=run_id,
                     log_content=log_content,
                     compress=enable_compression and len(log_content) > 10240,
+                    timeout=timeout,
                 )
 
                 if success:
@@ -182,6 +190,56 @@ class OMetaLogsMixin:
                     )
 
         return metrics
+
+    def send_logs_batch_best_effort(
+        self,
+        pipeline_fqn: str,
+        run_id: UUID,
+        log_content: str,
+        timeout: Optional[Union[float, tuple[float, float]]] = None,  # noqa: UP007, UP045
+        client: Optional[REST] = None,  # noqa: UP045
+    ) -> bool:
+        """Best-effort log POST: no retries, no logging. Returns True on 2xx."""
+        try:
+            url = f"/services/ingestionPipelines/logs/{pipeline_fqn}/{model_str(run_id)}"
+            log_batch = {
+                "logs": log_content,
+                "timestamp": int(time.time() * 1000),
+                "connectorId": f"{socket.gethostname()}-{os.getpid()}",
+                "compressed": False,
+                "lineCount": log_content.count("\n") + 1,
+            }
+            target = client if client is not None else self.client
+            return target.post_best_effort(
+                url,
+                data=json.dumps(log_batch),
+                timeout=timeout,
+            )
+        except Exception:
+            return False
+
+    def send_close_best_effort(
+        self,
+        pipeline_fqn: str,
+        run_id: UUID,
+        timeout: Optional[Union[float, tuple[float, float]]] = None,  # noqa: UP007, UP045
+        client: Optional[REST] = None,  # noqa: UP045
+    ) -> bool:
+        """Best-effort /close notify. Same guarantees as send_logs_batch_best_effort."""
+        try:
+            url = f"/services/ingestionPipelines/logs/{pipeline_fqn}/{model_str(run_id)}/close"
+            close_data = {
+                "connectorId": f"{socket.gethostname()}-{os.getpid()}",
+                "timestamp": int(time.time() * 1000),
+            }
+            target = client if client is not None else self.client
+            return target.post_best_effort(
+                url,
+                data=json.dumps(close_data),
+                timeout=timeout,
+            )
+        except Exception:
+            return False
 
     def create_log_stream(
         self,

--- a/ingestion/src/metadata/utils/streamable_logger.py
+++ b/ingestion/src/metadata/utils/streamable_logger.py
@@ -8,548 +8,252 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-"""
-Streamable log handler for shipping logs to OpenMetadata server.
+"""Best-effort streamable log handler for OpenMetadata ingestion pipelines."""
 
-This module provides a pluggable logger that can stream ingestion logs
-to the server's S3 storage backend without impacting application traffic.
-
-Configuration:
--------------
-The streamable logger is automatically enabled when:
-1. The IngestionPipeline entity has `enableStreamableLogs` set to true
-2. The ingestion pipeline FQN and run ID are available
-3. The OpenMetadata server has log storage configured (S3 or compatible)
-
-Environment Variables (Optional):
---------------------------------
-- ENABLE_LOG_COMPRESSION: Set to "true" to compress logs before sending (default: "false")
-
-Features:
---------
-- Asynchronous log shipping with buffering
-- Automatic compression for large payloads (>10KB when enabled)
-- Circuit breaker pattern for failure handling
-- Fallback to local logging when remote logging fails
-- Session cookie persistence for ALB sticky sessions
-- Configurable batch size and flush intervals
-
-Usage:
-------
-The streamable logger is automatically configured in the BaseWorkflow class
-when a workflow starts. No manual setup is required if the environment is
-properly configured.
-
-For manual setup (testing):
-```python
-from metadata.utils.streamable_logger import setup_streamable_logging_for_workflow
-
-handler = setup_streamable_logging_for_workflow(
-    metadata=metadata_client,
-    pipeline_fqn="service.pipeline_name",
-    run_id=UUID("..."),
-    log_level=logging.INFO
-)
-```
-"""
-
+import contextlib
 import logging
-import os
-import queue
-import sys
 import threading
-import time
-from enum import Enum
-from typing import Any, Dict, Optional
+from queue import Empty, Full, Queue
+from typing import Optional
 from uuid import UUID
 
+from metadata.ingestion.ometa.client import REST
 from metadata.ingestion.ometa.ometa_api import OpenMetadata
 from metadata.ingestion.ometa.utils import model_str
 from metadata.utils.logger import BASE_LOGGING_FORMAT, METADATA_LOGGER, ingestion_logger
 
 logger = ingestion_logger()
 
-# Internal logger used by this handler's own diagnostics. It MUST NOT propagate
-# to the root logger because `StreamableLogHandler` is attached there — logging
-# through `logger` from inside `emit()` or its callees re-enters this handler
-# and recurses until the Python recursion limit is hit. A separate logger with
-# `propagate=False` writing straight to stderr is the safe channel for any
-# message originating inside this module's hot path.
-_internal_logger = logging.getLogger("metadata.utils.streamable_logger.internal")
-_internal_logger.propagate = False
-if not _internal_logger.handlers:
-    _internal_handler = logging.StreamHandler(sys.stderr)
-    _internal_handler.setFormatter(
-        logging.Formatter(
-            "%(asctime)s [streamable-log-handler] %(levelname)s %(message)s",
-            datefmt="%Y-%m-%d %H:%M:%S",
-        )
-    )
-    _internal_logger.addHandler(_internal_handler)
-    # Filter at the handler so operators can change verbosity at runtime
-    # (e.g. via a debug toggle) without modifying the logger level itself.
-    _internal_handler.setLevel(logging.INFO)
-    _internal_logger.setLevel(logging.DEBUG)
+# Recursion guard: sender threads set shipping=True so emit() returns
+# immediately if it ever fires from inside the shipping path.
+_shipping_state = threading.local()
+_CLOSE_MARKER = object()
 
 
-class CircuitBreakerError(Exception):
-    """Base exception for circuit breaker errors"""
-
-
-class CircuitOpenError(CircuitBreakerError):
-    """Raised when circuit breaker is in OPEN state"""
-
-
-class ServiceCallError(Exception):
-    """Raised when the underlying service call fails"""
-
-
-class CircuitState(Enum):
-    """Circuit breaker states"""
-
-    CLOSED = "closed"  # Normal operation
-    OPEN = "open"  # Failures detected, requests blocked
-    HALF_OPEN = "half_open"  # Testing if service recovered
-
-
-class CircuitBreaker:
-    """
-    Circuit breaker pattern implementation to prevent cascading failures.
-    Fallback to local logging when remote logging fails.
-    """
-
-    def __init__(
-        self,
-        failure_threshold: int = 5,
-        recovery_timeout: int = 60,
-        success_threshold: int = 2,
-    ):
-        self.failure_threshold = failure_threshold
-        self.recovery_timeout = recovery_timeout
-        self.success_threshold = success_threshold
-        self.failure_count = 0
-        self.success_count = 0
-        self.last_failure_time = None
-        self.state = CircuitState.CLOSED
-        self._lock = threading.Lock()
-
-    def call(self, func, *args, **kwargs):
-        """Execute function with circuit breaker protection"""
-        with self._lock:
-            if self.state == CircuitState.OPEN:
-                if self._should_attempt_reset():
-                    self.state = CircuitState.HALF_OPEN
-                    self.success_count = 0
-                else:
-                    raise CircuitOpenError("Circuit breaker is OPEN")
-
-        try:
-            result = func(*args, **kwargs)
-            self._on_success()
-            return result
-        except (CircuitBreakerError, ServiceCallError):
-            raise
-        except Exception as e:
-            self._on_failure()
-            raise ServiceCallError(f"Service call failed: {str(e)}") from e
-
-    def _should_attempt_reset(self) -> bool:
-        """Check if enough time has passed to attempt reset"""
-        return (
-            self.last_failure_time
-            and time.time() - self.last_failure_time >= self.recovery_timeout
-        )
-
-    def _on_success(self):
-        """Handle successful call"""
-        with self._lock:
-            self.failure_count = 0
-            if self.state == CircuitState.HALF_OPEN:
-                self.success_count += 1
-                if self.success_count >= self.success_threshold:
-                    self.state = CircuitState.CLOSED
-
-    def _on_failure(self):
-        """Handle failed call"""
-        with self._lock:
-            self.failure_count += 1
-            self.last_failure_time = time.time()
-
-            if self.failure_count >= self.failure_threshold:
-                self.state = CircuitState.OPEN
-            elif self.state == CircuitState.HALF_OPEN:
-                self.state = CircuitState.OPEN
-
-
-# pylint: disable=too-many-instance-attributes
 class StreamableLogHandler(logging.Handler):
-    """
-    Custom logging handler that streams logs to OpenMetadata server.
+    """Fire-and-forget log shipper."""
 
-    Features:
-    - Async log shipping with buffering
-    - Circuit breaker for failure handling
-    - Automatic fallback to local logging
-    - Configurable batch size and flush intervals
-    """
+    BATCH_SIZE = 500
+    BATCH_WAIT_SEC = 2.0
+    SENDER_TICK_SEC = 1.0
+    HTTP_TIMEOUT = (1.0, 2.0)
+    SENDER_WORKERS = 1
+    MAX_PENDING_BATCHES = 4
+    CLOSE_TIMEOUT_SEC = 2.0
 
-    # pylint: disable=too-many-arguments
+    # pylint: disable=too-many-arguments,too-many-instance-attributes
     def __init__(
         self,
         metadata: OpenMetadata,
         pipeline_fqn: str,
         run_id: UUID,
-        batch_size: int = 500,
-        flush_interval_sec: float = 10.0,
-        max_queue_size: int = 10000,
+        max_buffer: int = 10000,
         enable_streaming: bool = True,
     ):
-        """
-        Initialize the streamable log handler.
-
-        Args:
-            metadata: OpenMetadata client instance
-            pipeline_fqn: Fully qualified name of the pipeline
-            run_id: Unique run identifier
-            batch_size: Number of log entries to batch before sending
-            flush_interval_sec: Time in seconds between automatic flushes
-            max_queue_size: Maximum size of the log queue
-            enable_streaming: Whether to enable log streaming (can be disabled for testing)
-        """
         super().__init__()
-
         self.metadata = metadata
         self.pipeline_fqn = pipeline_fqn
         self.run_id = run_id
-        self.batch_size = batch_size
-        self.flush_interval_sec = flush_interval_sec
         self.enable_streaming = enable_streaming
 
-        # Local fallback handler
         self.fallback_handler = logging.StreamHandler()
-        self.fallback_handler.setFormatter(self.formatter)
 
-        # Circuit breaker for failure handling
-        self.circuit_breaker = CircuitBreaker()
+        self._buffer: Queue = Queue(maxsize=max_buffer)
+        self._send_queue: Queue = Queue(maxsize=self.MAX_PENDING_BATCHES)
+        self._stop = threading.Event()
+        self._closed = False
+        self._drainer: Optional[threading.Thread] = None  # noqa: UP045
+        self._senders: list = []
 
-        # Log queue and worker thread
-        self.log_queue = queue.Queue(maxsize=max_queue_size)
-        self.stop_event = threading.Event()
-        self.worker_thread = None
+        # Isolated session/connection pool; shares ClientConfig so token
+        # refresh on the main client is visible here.
+        self._client: Optional[REST] = (  # noqa: UP045
+            REST(metadata.client.config) if enable_streaming else None
+        )
 
-        # Session ID for log streaming (if server supports it)
-        self.session_id = None
+        self.dropped_overflow = 0
+        self.dropped_saturated = 0
+        self.dropped_shipping = 0
+        self.dropped_after_close = 0
+        self.dropped_format_error = 0
 
-        # Metrics tracking
-        self.metrics = {
-            "logs_sent": 0,
-            "logs_failed": 0,
-            "bytes_sent": 0,
-            "circuit_trips": 0,
-            "fallback_count": 0,
-        }
-
-        # Start worker thread if streaming is enabled
         if self.enable_streaming:
-            self._initialize_log_stream()
-            self._start_worker()
+            self._start_workers()
 
-    def _initialize_log_stream(self):
-        """Initialize log stream with the server"""
-        if hasattr(self.metadata, "create_log_stream"):
-            self.session_id = self.metadata.create_log_stream(
-                self.pipeline_fqn, self.run_id
-            )
-
-    def _start_worker(self):
-        """Start the background worker thread for log shipping"""
-        if self.worker_thread is None or not self.worker_thread.is_alive():
-            self.worker_thread = threading.Thread(
-                target=self._worker_loop,
-                name=f"log-shipper-{self.pipeline_fqn}",
+    def _start_workers(self):
+        self._drainer = threading.Thread(
+            target=self._drain_loop,
+            daemon=True,
+            name=f"log-drain-{self.pipeline_fqn[:24]}",
+        )
+        self._drainer.start()
+        for i in range(self.SENDER_WORKERS):
+            t = threading.Thread(
+                target=self._sender_loop,
                 daemon=True,
+                name=f"log-ship-{self.pipeline_fqn[:16]}-{i}",
             )
-            self.worker_thread.start()
-
-    def _drain_queue_to_buffer(self, buffer: list) -> tuple[list, bool]:
-        """
-        Drain all available items from the queue into the buffer.
-
-        Args:
-            buffer: Current buffer to append items to
-
-        Returns:
-            Updated buffer and whether a flush marker was encountered
-        """
-        timeout = min(1.0, self.flush_interval_sec)
-        flush_requested = False
-
-        # Get items from queue until empty
-        while True:
-            try:
-                # Use timeout for first call, then get_nowait for remaining
-                log_entry = (
-                    self.log_queue.get(timeout=timeout)
-                    if timeout
-                    else self.log_queue.get_nowait()
-                )
-
-                if log_entry is None:
-                    # Flush marker encountered
-                    flush_requested = True
-                else:
-                    buffer.append(log_entry)
-
-                # After first successful get, switch to no timeout for draining
-                timeout = None
-
-            except queue.Empty:
-                break
-
-        return buffer, flush_requested
-
-    def _worker_loop(self):
-        """Background worker that ships logs to the server"""
-        buffer = []
-        last_flush = time.time()
-
-        while not self.stop_event.is_set():
-            try:
-                # Drain all available items from queue
-                buffer, flush_requested = self._drain_queue_to_buffer(buffer)
-
-                # Check if we should flush
-                should_flush = (
-                    flush_requested
-                    or len(buffer) >= self.batch_size
-                    or (time.time() - last_flush) >= self.flush_interval_sec
-                )
-
-                if should_flush and buffer:
-                    self._ship_logs(buffer)
-                    buffer = []
-                    last_flush = time.time()
-
-                # Let's not flush too often
-                time.sleep(1.0)
-
-            except Exception as e:
-                # NEVER use `logger` here — this handler is attached to it and
-                # logging through `logger` would re-enter our own emit().
-                _internal_logger.error("error in log shipping worker: %s", e)
-                # Continue processing to avoid blocking
-
-        # Final cleanup - drain ALL remaining items from the queue
-        buffer, _ = self._drain_queue_to_buffer(buffer)
-
-        # Send any final buffered logs
-        if buffer:
-            self._ship_logs(buffer)
-
-    def _ship_logs(self, logs: list):
-        """Ship logs to the server with circuit breaker protection"""
-        if not logs:
-            return
-
-        log_content = "\n".join(logs) + "\n"  # Ensure newline at end
-
-        try:
-            # Try to send logs with circuit breaker
-            self.circuit_breaker.call(self._send_logs_to_server, log_content)
-        except CircuitOpenError:
-            # Circuit is open, update metrics
-            self.metrics["logs_failed"] += len(logs)
-            self.metrics["circuit_trips"] += 1
-            self.metrics["fallback_count"] += 1
-
-            # NEVER use `logger` here — this handler is attached to it.
-            _internal_logger.debug("circuit breaker is OPEN, falling back to local logging")
-            for log in logs:
-                _internal_logger.info("[FALLBACK] %s", log)
-        except (ServiceCallError, Exception) as e:
-            # Service call failed, update metrics
-            self.metrics["logs_failed"] += len(logs)
-            self.metrics["fallback_count"] += 1
-
-            # Fallback to local logging via the internal (non-propagating)
-            # logger. Using `logger` here would dispatch the message back into
-            # this handler, re-entering shipping and ultimately recursing.
-            _internal_logger.debug("failed to ship logs to server: %s", e)
-            for log in logs:
-                _internal_logger.info("[FALLBACK] %s", log)
-
-    def _send_logs_to_server(self, log_content: str):
-        """Send logs to the OpenMetadata server using the logs mixin"""
-        enable_compression = (
-            os.getenv("ENABLE_LOG_COMPRESSION", "false").lower() == "true"
-        )
-        # Use the centralized logs mixin method which handles both new and legacy approaches
-        metrics = self.metadata.send_logs_batch(
-            pipeline_fqn=self.pipeline_fqn,
-            run_id=self.run_id,
-            log_content=log_content,
-            enable_compression=enable_compression,
-        )
-        # Update handler metrics with returned metrics
-        self.metrics["logs_sent"] += metrics["logs_sent"]
-        self.metrics["bytes_sent"] += metrics["bytes_sent"]
+            t.start()
+            self._senders.append(t)
 
     def emit(self, record: logging.LogRecord):
-        """
-        Emit a log record.
-
-        Puts the log entry in the queue for async shipping.
-        Falls back to local logging if queue is full or streaming is disabled.
-        """
+        # Recursion guard must be the very first check.
+        if getattr(_shipping_state, "shipping", False):
+            self.dropped_shipping += 1
+            return
+        if self._closed:
+            self.dropped_after_close += 1
+            return
         try:
             if not self.enable_streaming:
-                # Direct fallback if streaming is disabled
                 self.fallback_handler.emit(record)
                 return
-
-            # Format the log record
             log_entry = self.format(record)
-
-            # Try to add to queue (non-blocking)
             try:
-                self.log_queue.put_nowait(log_entry)
-            except queue.Full:
-                # Queue is full. CRITICAL: do not call `logger.warning(...)`
-                # here — this handler is attached to `logger`, so any log call
-                # from inside emit() re-enters emit(), recurses against the
-                # still-full queue, and eventually hits the Python recursion
-                # limit. This was the root cause of the production hang where
-                # MainThread sat in 900+ frames of alternating warning/error
-                # emit calls while every other thread was blocked on the
-                # logging module's internal lock.
-                _internal_logger.warning("log queue is full, falling back to local logging")
-                self.fallback_handler.emit(record)
+                self._buffer.put_nowait(log_entry)
+            except Full:
+                self.dropped_overflow += 1
+        except Exception:
+            self.dropped_format_error += 1
 
-        except Exception as e:
-            # Any error, fallback to local logging. Same recursion hazard as
-            # above — must use the non-propagating internal logger.
-            _internal_logger.error("error in emit: %s", e)
+    def _drain_loop(self):
+        while not self._stop.is_set():
+            batch = self._collect_batch()
+            if not batch:
+                continue
             try:
-                self.fallback_handler.emit(record)
-            except Exception:
-                pass  # Last resort: silently drop the log
+                self._send_queue.put_nowait(batch)
+            except Full:
+                self.dropped_saturated += len(batch)
 
-    def flush(self):
-        """Flush any buffered logs"""
-        # Signal worker to flush by adding a None marker
+    def _collect_batch(self) -> list:
         try:
-            self.log_queue.put_nowait(None)
-        except queue.Full:
-            pass
+            batch = [self._buffer.get(timeout=self.BATCH_WAIT_SEC)]
+        except Empty:
+            return []
+        while len(batch) < self.BATCH_SIZE:
+            try:
+                batch.append(self._buffer.get_nowait())
+            except Empty:
+                break
+        return batch
 
-    def get_metrics(self) -> Dict[str, Any]:
-        """Get current metrics for monitoring"""
-        return {
-            **self.metrics,
-            "circuit_state": self.circuit_breaker.state.value,
-            "queue_size": self.log_queue.qsize(),
-            "worker_alive": self.worker_thread.is_alive()
-            if self.worker_thread
-            else False,
-        }
+    def _sender_loop(self):
+        try:
+            while True:
+                try:
+                    item = self._send_queue.get(timeout=self.SENDER_TICK_SEC)
+                except Empty:
+                    if self._stop.is_set():
+                        return
+                    continue
+                if item is _CLOSE_MARKER:
+                    self._notify_close()
+                    return
+                self._post_batch(item)
+        finally:
+            with contextlib.suppress(Exception):
+                if self._client is not None:
+                    self._client.close()
+
+    def _post_batch(self, batch: list):
+        _shipping_state.shipping = True
+        try:
+            self.metadata.send_logs_batch_best_effort(
+                pipeline_fqn=self.pipeline_fqn,
+                run_id=self.run_id,
+                log_content="\n".join(batch) + "\n",
+                timeout=self.HTTP_TIMEOUT,
+                client=self._client,
+            )
+        finally:
+            _shipping_state.shipping = False
 
     def close(self):
-        """Close the handler and cleanup resources"""
-        if self.enable_streaming and self.worker_thread:
-            # Log final metrics via the non-propagating internal logger so
-            # close() cannot trigger a final round of self-recursion.
-            _internal_logger.info("StreamableLogHandler metrics: %s", self.get_metrics())
+        if self._closed:
+            return
+        self._closed = True
 
-            # Signal worker to stop AFTER ensuring any pending flush is processed
-            self.stop_event.set()
+        if self.enable_streaming:
+            self._drain_remaining_buffer()
+            with contextlib.suppress(Full):
+                self._send_queue.put_nowait(_CLOSE_MARKER)
 
-            # Wait for worker to finish (with timeout)
-            if self.worker_thread.is_alive():
-                self.worker_thread.join(timeout=5.0)
+        # Set _stop AFTER enqueueing — sender's get(timeout) Empty branch
+        # checks _stop, so setting it first can race the enqueue and drop
+        # the CLOSE_MARKER on a quiet send queue.
+        self._stop.set()
 
-            # Close the log stream
-            self.metadata.close_log_stream(self.pipeline_fqn, self.run_id)
-
-        # Close fallback handler
-        self.fallback_handler.close()
-
+        with contextlib.suppress(Exception):
+            self.fallback_handler.close()
         super().close()
+
+    def _drain_remaining_buffer(self):
+        while True:
+            batch = []
+            while len(batch) < self.BATCH_SIZE:
+                try:
+                    batch.append(self._buffer.get_nowait())
+                except Empty:
+                    break
+            if not batch:
+                return
+            try:
+                self._send_queue.put_nowait(batch)
+            except Full:
+                self.dropped_saturated += len(batch)
+                return
+
+    def _notify_close(self):
+        _shipping_state.shipping = True
+        try:
+            self.metadata.send_close_best_effort(
+                pipeline_fqn=self.pipeline_fqn,
+                run_id=self.run_id,
+                timeout=(1.0, self.CLOSE_TIMEOUT_SEC),
+                client=self._client,
+            )
+        finally:
+            _shipping_state.shipping = False
 
 
 class StreamableLogHandlerManager:
-    """
-    Manager class to handle StreamableLogHandler instances.
-    This provides better encapsulation than using global variables.
-
-    Note: This manager assumes single-threaded setup/teardown which is
-    typical for workflow initialization. The handler itself is thread-safe.
-    """
-
     _instance: Optional["StreamableLogHandler"] = None
 
     @classmethod
     def get_handler(cls) -> Optional["StreamableLogHandler"]:
-        """Get the current handler instance"""
         return cls._instance
 
     @classmethod
     def set_handler(cls, handler: Optional["StreamableLogHandler"]) -> None:
-        """Set or update the handler instance, closing any existing one"""
-        if cls._instance and cls._instance != handler:
-            try:
+        if cls._instance and cls._instance is not handler:
+            # Detach before close so in-flight emits don't route at a closed handler.
+            with contextlib.suppress(Exception):
+                logging.getLogger(METADATA_LOGGER).removeHandler(cls._instance)
+            with contextlib.suppress(Exception):
                 cls._instance.close()
-            except Exception as e:
-                logger.warning(f"Error closing previous handler: {e}")
         cls._instance = handler
 
     @classmethod
     def cleanup(cls) -> None:
-        """Clean up the current handler, flushing any remaining logs first"""
-        if cls._instance:
-            try:
-                # Force flush any remaining logs before cleanup
-                cls._instance.flush()
-
-                # Close will properly wait for worker thread to finish processing
-                # the flush marker and any remaining buffered logs
+        if not cls._instance:
+            return
+        try:
+            with contextlib.suppress(Exception):
+                logging.getLogger(METADATA_LOGGER).removeHandler(cls._instance)
+            with contextlib.suppress(Exception):
                 cls._instance.close()
-
-                # Only remove handler from logger after worker thread has finished
-                metadata_logger = logging.getLogger(METADATA_LOGGER)
-                metadata_logger.removeHandler(cls._instance)
-
-                logger.debug("Streamable logging handler cleaned up")
-            except Exception as e:
-                logger.warning(f"Error during handler cleanup: {e}")
-            finally:
-                cls._instance = None
+        finally:
+            cls._instance = None
 
 
 def setup_streamable_logging_for_workflow(
     metadata: OpenMetadata,
-    pipeline_fqn: Optional[str] = None,
-    run_id: Optional[UUID] = None,
+    pipeline_fqn: Optional[str] = None,  # noqa: UP045
+    run_id: Optional[UUID] = None,  # noqa: UP045
     log_level: int = logging.INFO,
     enable_streaming: bool = False,
-) -> Optional[StreamableLogHandler]:
-    """
-    Setup streamable logging for a workflow execution.
-    This is automatically called when a workflow starts if:
-    1. The IngestionPipeline has enableStreamableLogs set to true
-    2. The server has log storage configured
-    3. The pipeline FQN and run ID are available
-
-    Args:
-        metadata: OpenMetadata client instance
-        pipeline_fqn: Fully qualified name of the pipeline
-        run_id: Unique run identifier
-        log_level: Logging level
-        enable_streaming: Whether to enable streaming (from IngestionPipeline config)
-
-    Returns:
-        StreamableLogHandler instance if configured, None otherwise
-    """
-    # Check if we have the required parameters
+) -> Optional[StreamableLogHandler]:  # noqa: UP045
     if not enable_streaming or not pipeline_fqn or not run_id:
         logger.debug(
             f"Streamable logging not configured: enable={enable_streaming}, "
@@ -558,41 +262,27 @@ def setup_streamable_logging_for_workflow(
         return None
 
     try:
-        # Check if server supports log storage by trying to get the configuration
-        # This would need to be implemented as an API endpoint
-        # For now, we'll assume it's enabled if the env var is set
+        metadata_logger = logging.getLogger(METADATA_LOGGER)
+        existing = StreamableLogHandlerManager.get_handler()
+        if existing is not None:
+            with contextlib.suppress(Exception):
+                metadata_logger.removeHandler(existing)
 
-        # Clean up any existing handler
-        existing_handler = StreamableLogHandlerManager.get_handler()
-        if existing_handler:
-            existing_handler.close()
-
-        # Create and configure the handler
         handler = StreamableLogHandler(
             metadata=metadata,
             pipeline_fqn=pipeline_fqn,
             run_id=run_id,
             enable_streaming=True,
         )
-
-        # Use the same formatter as the base configuration for consistency
         formatter = logging.Formatter(BASE_LOGGING_FORMAT, datefmt="%Y-%m-%d %H:%M:%S")
         handler.setFormatter(formatter)
         handler.setLevel(log_level)
 
-        # Add handler to the metadata logger (parent of all ingestion loggers)
-        metadata_logger = logging.getLogger(METADATA_LOGGER)
         metadata_logger.addHandler(handler)
-
-        # Register with the manager
         StreamableLogHandlerManager.set_handler(handler)
 
-        logger.info(
-            f"Streamable logging configured for pipeline: {pipeline_fqn}, run_id: {model_str(run_id)}"
-        )
-        metadata.validate_versions()  # Send the version check log
-
-        return handler
+        logger.info(f"Streamable logging configured for pipeline: {pipeline_fqn}, run_id: {model_str(run_id)}")
+        return handler  # noqa: TRY300
 
     except Exception as e:
         logger.warning(f"Failed to setup streamable logging: {e}")
@@ -600,8 +290,4 @@ def setup_streamable_logging_for_workflow(
 
 
 def cleanup_streamable_logging():
-    """
-    Cleanup streamable logging handler.
-    This should be called when the workflow completes.
-    """
     StreamableLogHandlerManager.cleanup()

--- a/ingestion/tests/unit/utils/test_streamable_logger.py
+++ b/ingestion/tests/unit/utils/test_streamable_logger.py
@@ -8,875 +8,611 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-"""
-Unit tests for the streamable logger module.
-"""
+"""Unit tests for the streamable logger module."""
 
 import logging
-import os
+import threading
 import time
 import unittest
-from unittest.mock import Mock, patch
+from unittest.mock import MagicMock, Mock, patch
 from uuid import uuid4
 
 from metadata.ingestion.ometa.ometa_api import OpenMetadata
 from metadata.utils.streamable_logger import (
-    CircuitBreaker,
-    CircuitState,
     StreamableLogHandler,
+    StreamableLogHandlerManager,
+    _shipping_state,
     cleanup_streamable_logging,
     setup_streamable_logging_for_workflow,
 )
 
 
-class TestCircuitBreaker(unittest.TestCase):
-    """Test the circuit breaker implementation"""
-
-    def setUp(self):
-        self.breaker = CircuitBreaker(
-            failure_threshold=3, recovery_timeout=1, success_threshold=2
-        )
-
-    def test_initial_state_is_closed(self):
-        """Test that circuit breaker starts in CLOSED state"""
-        self.assertEqual(self.breaker.state, CircuitState.CLOSED)
-        self.assertEqual(self.breaker.failure_count, 0)
-
-    def test_opens_after_threshold_failures(self):
-        """Test that circuit opens after reaching failure threshold"""
-
-        def failing_func():
-            raise Exception("Test failure")
-
-        for i in range(3):
-            with self.assertRaises(Exception):
-                self.breaker.call(failing_func)
-
-        self.assertEqual(self.breaker.state, CircuitState.OPEN)
-        self.assertEqual(self.breaker.failure_count, 3)
-
-    def test_blocks_calls_when_open(self):
-        """Test that calls are blocked when circuit is open"""
-        # Open the circuit
-        self.breaker.state = CircuitState.OPEN
-        self.breaker.last_failure_time = time.time()
-
-        with self.assertRaises(Exception) as ctx:
-            self.breaker.call(lambda: "success")
-
-        self.assertIn("Circuit breaker is OPEN", str(ctx.exception))
-
-    def test_transitions_to_half_open_after_timeout(self):
-        """Test transition to HALF_OPEN state after recovery timeout"""
-        # Open the circuit
-        self.breaker.state = CircuitState.OPEN
-        self.breaker.last_failure_time = time.time() - 2  # 2 seconds ago
-
-        # Should transition to HALF_OPEN
-        def success_func():
-            return "success"
-
-        result = self.breaker.call(success_func)
-        self.assertEqual(result, "success")
-        self.assertEqual(self.breaker.state, CircuitState.HALF_OPEN)
-
-    def test_closes_after_success_threshold_in_half_open(self):
-        """Test that circuit closes after success threshold in HALF_OPEN"""
-        self.breaker.state = CircuitState.HALF_OPEN
-
-        def success_func():
-            return "success"
-
-        # First success
-        self.breaker.call(success_func)
-        self.assertEqual(self.breaker.state, CircuitState.HALF_OPEN)
-
-        # Second success - should close
-        self.breaker.call(success_func)
-        self.assertEqual(self.breaker.state, CircuitState.CLOSED)
-
-    def test_reopens_on_failure_in_half_open(self):
-        """Test that circuit reopens on failure in HALF_OPEN state"""
-        self.breaker.state = CircuitState.HALF_OPEN
-
-        def failing_func():
-            raise Exception("Test failure")
-
-        with self.assertRaises(Exception):
-            self.breaker.call(failing_func)
-
-        self.assertEqual(self.breaker.state, CircuitState.OPEN)
+def _make_record(msg="test message", level=logging.INFO):
+    return logging.LogRecord(
+        name="test",
+        level=level,
+        pathname="test.py",
+        lineno=1,
+        msg=msg,
+        args=(),
+        exc_info=None,
+    )
 
 
-class TestStreamableLogHandler(unittest.TestCase):
-    """Test the StreamableLogHandler class"""
+def _make_metadata_mock():
+    """Build a Mock that satisfies StreamableLogHandler's needs:
+    - send_logs_batch_best_effort / send_close_best_effort attrs
+    - .client.config (real ClientConfig) so handler can build its own REST"""
+    from metadata.ingestion.ometa.client import ClientConfig
 
-    def setUp(self):
-        """Set up test fixtures"""
-        self.mock_metadata = Mock(spec=OpenMetadata)
-        self.mock_metadata.config = Mock()
-        self.mock_metadata.config.host_port = "http://localhost:8585"
-        self.mock_metadata.config.auth_token = "test-token"
-        # Mock the _auth_header method
-        self.mock_metadata._auth_header = Mock(
-            return_value={"Authorization": "Bearer test-token"}
-        )
+    metadata = Mock(spec=OpenMetadata)
+    metadata.client = Mock()
+    metadata.client.config = ClientConfig(base_url="http://localhost:8585")
+    metadata.send_logs_batch_best_effort = Mock(return_value=True)
+    metadata.send_close_best_effort = Mock(return_value=True)
+    return metadata
 
-        self.pipeline_fqn = "test.pipeline"
-        self.run_id = uuid4()
+
+def _make_handler(
+    metadata=None,
+    pipeline_fqn="test.pipeline",
+    run_id=None,
+    max_buffer=10000,
+    enable_streaming=False,
+):
+    if metadata is None:
+        metadata = _make_metadata_mock()
+    if run_id is None:
+        run_id = uuid4()
+    handler = StreamableLogHandler(
+        metadata=metadata,
+        pipeline_fqn=pipeline_fqn,
+        run_id=run_id,
+        max_buffer=max_buffer,
+        enable_streaming=enable_streaming,
+    )
+    handler.setFormatter(logging.Formatter("%(message)s"))
+    return handler
+
+
+def _stop_workers(handler):
+    """Signal stop and give the drainer/senders a moment to notice.
+    Used in tests that need a quiescent handler. We don't .join() in
+    production close() - see TestNoWaitClose - but in tests we want
+    to be sure background threads aren't going to race assertions."""
+    handler._stop.set()
+    if handler._drainer:
+        handler._drainer.join(timeout=3)
+    for t in handler._senders:
+        t.join(timeout=3)
+
+
+class TestEmitNonBlocking(unittest.TestCase):
+    """emit() must be fast and must never raise."""
+
+    def test_emit_with_streaming_disabled_goes_to_fallback(self):
+        handler = _make_handler(enable_streaming=False)
+        handler.fallback_handler = Mock()
+        record = _make_record()
+
+        handler.emit(record)
+
+        handler.fallback_handler.emit.assert_called_once_with(record)
+
+    def test_emit_with_streaming_enabled_queues_to_buffer(self):
+        handler = _make_handler(enable_streaming=True)
+        _stop_workers(handler)
+
+        handler.emit(_make_record("log A"))
+        handler.emit(_make_record("log B"))
+
+        self.assertEqual(handler._buffer.qsize(), 2)
+        handler.close()
+
+    def test_emit_drops_silently_when_buffer_full(self):
+        """No stderr fallback per record on overflow - only a counter."""
+        handler = _make_handler(max_buffer=1, enable_streaming=True)
+        _stop_workers(handler)
+        handler.fallback_handler = Mock()
+        handler._buffer.put_nowait("already-here")
+
+        start = time.monotonic()
+        handler.emit(_make_record("overflow"))
+        elapsed = time.monotonic() - start
+
+        self.assertLess(elapsed, 0.05, "emit() must return immediately on overflow")
+        handler.fallback_handler.emit.assert_not_called()
+        self.assertEqual(handler.dropped_overflow, 1)
+
+    def test_emit_never_raises_when_format_fails(self):
+        handler = _make_handler(enable_streaming=True)
+        _stop_workers(handler)
+        handler.format = Mock(side_effect=ValueError("boom"))
+
+        handler.emit(_make_record())
+
+        self.assertEqual(handler.dropped_format_error, 1)
+        self.assertEqual(handler.dropped_overflow, 0)
+        handler.close()
+
+    def test_emit_after_close_increments_dedicated_counter(self):
+        handler = _make_handler(enable_streaming=True)
+        handler.close()
+        handler.emit(_make_record("post-close"))
+        self.assertEqual(handler.dropped_after_close, 1)
+        self.assertEqual(handler.dropped_overflow, 0)
+        self.assertEqual(handler.dropped_format_error, 0)
+
+    def test_emit_returns_quickly_under_high_volume(self):
+        handler = _make_handler(max_buffer=10000, enable_streaming=True)
+        _stop_workers(handler)
+
+        start = time.monotonic()
+        for i in range(1000):
+            handler.emit(_make_record(f"msg-{i}"))
+        elapsed = time.monotonic() - start
+
+        self.assertLess(elapsed, 0.5, f"1000 emits took {elapsed:.3f}s - too slow")
+
+
+class TestRecursionGuard(unittest.TestCase):
+    """The thread-local guard prevents emit() from re-entering itself
+    even if a future change reintroduces logging on the shipping path."""
 
     def tearDown(self):
-        """Clean up after tests"""
-        # Ensure any handlers are properly closed
-        if hasattr(self, "handler") and self.handler:
-            self.handler.close()
+        # Make sure the guard is clear after each test.
+        if hasattr(_shipping_state, "shipping"):
+            _shipping_state.shipping = False
 
-    def test_handler_initialization(self):
-        """Test handler initialization"""
-        handler = StreamableLogHandler(
-            metadata=self.mock_metadata,
-            pipeline_fqn=self.pipeline_fqn,
-            run_id=self.run_id,
-            enable_streaming=False,  # Disable for unit test
+    def test_emit_drops_when_shipping_flag_set(self):
+        handler = _make_handler(enable_streaming=True)
+        _stop_workers(handler)
+
+        _shipping_state.shipping = True
+        try:
+            handler.emit(_make_record("would-recurse"))
+        finally:
+            _shipping_state.shipping = False
+
+        self.assertEqual(handler._buffer.qsize(), 0)
+        self.assertEqual(handler.dropped_shipping, 1)
+
+    def test_post_thread_sets_and_clears_shipping_flag(self):
+        seen_flag = {"value": None}
+
+        def capture(*_, **__):
+            seen_flag["value"] = getattr(_shipping_state, "shipping", False)
+            return True
+
+        metadata = _make_metadata_mock()
+        metadata.send_logs_batch_best_effort = Mock(side_effect=capture)
+        metadata.send_close_best_effort = Mock(return_value=True)
+
+        handler = _make_handler(metadata=metadata, enable_streaming=True)
+        handler.emit(_make_record("trigger"))
+        for _ in range(50):
+            if metadata.send_logs_batch_best_effort.called:
+                break
+            time.sleep(0.05)
+
+        self.assertTrue(seen_flag["value"], "shipping flag must be True inside the sender")
+        handler.close()
+        # Flag must be cleared after the sender returns. Give the
+        # sender thread a moment to hit its finally block.
+        time.sleep(0.1)
+        self.assertFalse(getattr(_shipping_state, "shipping", False))
+
+
+class TestSenderPool(unittest.TestCase):
+    """Bounded send queue. Drainer never waits on a POST."""
+
+    def test_drainer_does_not_wait_on_slow_post(self):
+        slow_event = threading.Event()
+        post_started = threading.Event()
+
+        def slow_send(*_, **__):
+            post_started.set()
+            slow_event.wait(timeout=30)
+            return True
+
+        metadata = _make_metadata_mock()
+        metadata.send_logs_batch_best_effort = Mock(side_effect=slow_send)
+        metadata.send_close_best_effort = Mock(return_value=True)
+
+        handler = _make_handler(metadata=metadata, enable_streaming=True)
+        handler.emit(_make_record("first"))
+        self.assertTrue(post_started.wait(timeout=5))
+
+        start = time.monotonic()
+        for i in range(50):
+            handler.emit(_make_record(f"hangs-{i}"))
+        elapsed = time.monotonic() - start
+
+        self.assertLess(elapsed, 0.5, "emits must not block while a POST is hanging")
+
+        handler._stop.set()
+        slow_event.set()
+        handler._drainer.join(timeout=5)
+
+    def test_saturated_sender_drops_batches(self):
+        """When senders + send queue are full on a dead server, the drainer
+        drops new batches and counts them. No unbounded growth."""
+        hang = threading.Event()  # never set during the test
+
+        def block_forever(*_, **__):
+            hang.wait(timeout=30)
+            return True
+
+        metadata = _make_metadata_mock()
+        metadata.send_logs_batch_best_effort = Mock(side_effect=block_forever)
+        metadata.send_close_best_effort = Mock(return_value=True)
+
+        handler = _make_handler(metadata=metadata, enable_streaming=True)
+        # Make the test cycle faster than defaults.
+        handler.BATCH_WAIT_SEC = 0.1
+
+        # Pump 20 separately-timed batches; each wave > BATCH_WAIT_SEC so
+        # the drainer ships each as its own batch. Senders block forever
+        # on the first MAX_PENDING_BATCHES + SENDER_WORKERS; everything
+        # after that must be dropped at drainer-submit time.
+        total_waves = handler.MAX_PENDING_BATCHES + handler.SENDER_WORKERS + 10
+        for wave in range(total_waves):
+            handler.emit(_make_record(f"wave-{wave}"))
+            time.sleep(0.2)
+
+        # At least some batches must have been dropped at the send-queue
+        # boundary - we sent way more than the cap.
+        self.assertGreater(handler.dropped_saturated, 0, "saturated drainer must have dropped at least one batch")
+        # In-flight POSTs bounded by SENDER_WORKERS (others wait in queue
+        # but don't actually call send_logs_batch_best_effort).
+        self.assertLessEqual(
+            metadata.send_logs_batch_best_effort.call_count,
+            handler.SENDER_WORKERS,
         )
 
-        self.assertEqual(handler.pipeline_fqn, self.pipeline_fqn)
-        self.assertEqual(handler.run_id, self.run_id)
-        self.assertEqual(handler.batch_size, 500)
-        self.assertEqual(handler.flush_interval_sec, 10.0)
-        self.assertFalse(handler.enable_streaming)
-        self.assertIsNone(handler.worker_thread)
+        handler._stop.set()
+        hang.set()
+
+    def test_close_notify_is_ordered_after_in_flight_log_batch(self):
+        """Regression for the close-vs-late-POST race. /close must not
+        overtake an already-started log batch, otherwise the server can
+        finalize logs.txt and then receive a late tail batch."""
+        log_started = threading.Event()
+        release_log = threading.Event()
+        close_called = threading.Event()
+
+        def slow_log_send(*_, **__):
+            log_started.set()
+            release_log.wait(timeout=30)
+            return True
+
+        def close_send(*_, **__):
+            close_called.set()
+            return True
+
+        metadata = _make_metadata_mock()
+        metadata.send_logs_batch_best_effort = Mock(side_effect=slow_log_send)
+        metadata.send_close_best_effort = Mock(side_effect=close_send)
+
+        handler = _make_handler(metadata=metadata, enable_streaming=True)
+        handler.emit(_make_record("first"))
+        self.assertTrue(log_started.wait(timeout=5))
+
+        start = time.monotonic()
+        handler.close()
+        elapsed = time.monotonic() - start
+
+        self.assertLess(elapsed, 0.1, "close() must still return immediately")
+        time.sleep(0.2)
+        self.assertFalse(
+            close_called.is_set(),
+            "/close must wait behind the in-flight log batch in the sender queue",
+        )
+
+        release_log.set()
+        self.assertTrue(close_called.wait(timeout=5))
+
+
+class TestDaemonThreads(unittest.TestCase):
+    """All background threads MUST be daemon, otherwise a wedged sender
+    can keep the ingestion process alive past main-thread exit."""
+
+    def test_drainer_thread_is_daemon(self):
+        handler = _make_handler(enable_streaming=True)
+        self.assertTrue(handler._drainer.daemon, "drainer must be a daemon thread")
+        handler.close()
+
+    def test_sender_threads_are_daemon(self):
+        handler = _make_handler(enable_streaming=True)
+        self.assertEqual(len(handler._senders), handler.SENDER_WORKERS)
+        for t in handler._senders:
+            self.assertTrue(t.daemon, f"sender {t.name} must be daemon")
+        handler.close()
+
+    def test_close_notify_thread_is_daemon(self):
+        """The /close call goes out on a daemon so close() doesn't wait."""
+        seen = {"daemon": None}
+
+        def capture(*_, **__):
+            seen["daemon"] = threading.current_thread().daemon
+            return True
+
+        metadata = _make_metadata_mock()
+        metadata.send_logs_batch_best_effort = Mock(return_value=True)
+        metadata.send_close_best_effort = Mock(side_effect=capture)
+
+        handler = _make_handler(metadata=metadata, enable_streaming=True)
+        handler.close()
+        for _ in range(50):
+            if seen["daemon"] is not None:
+                break
+            time.sleep(0.05)
+        self.assertTrue(seen["daemon"], "close notify must run on a daemon sender thread")
+
+
+class TestIsolatedClient(unittest.TestCase):
+    """The handler must use its OWN REST instance (own session/cookies/
+    connection pool), not the main metadata client's."""
+
+    def test_handler_creates_dedicated_rest_client(self):
+        from metadata.ingestion.ometa.client import REST
+
+        metadata = Mock(spec=OpenMetadata)
+        # Give the mock client a real ClientConfig so REST() can copy it.
+        from metadata.ingestion.ometa.client import ClientConfig
+
+        metadata.client = Mock()
+        metadata.client.config = ClientConfig(base_url="http://localhost:8585")
+        metadata.send_logs_batch_best_effort = Mock(return_value=True)
+        metadata.send_close_best_effort = Mock(return_value=True)
+
+        handler = _make_handler(metadata=metadata, enable_streaming=True)
+
+        self.assertIsInstance(handler._client, REST)
+        self.assertIsNot(handler._client, metadata.client, "handler must own a SEPARATE REST instance")
+        self.assertIsNot(handler._client._session, metadata.client, "handler's session must not be the main client")
+        handler.close()
+
+    def test_handler_passes_isolated_client_to_post(self):
+        """The send_logs_batch_best_effort call must include the handler's
+        own client kwarg so log shipping doesn't go through the main session."""
+        from metadata.ingestion.ometa.client import ClientConfig
+
+        captured = {"client": None}
+
+        def capture(*_, client=None, **__):
+            captured["client"] = client
+            return True
+
+        metadata = Mock(spec=OpenMetadata)
+        metadata.client = Mock()
+        metadata.client.config = ClientConfig(base_url="http://localhost:8585")
+        metadata.send_logs_batch_best_effort = Mock(side_effect=capture)
+        metadata.send_close_best_effort = Mock(return_value=True)
+
+        handler = _make_handler(metadata=metadata, enable_streaming=True)
+        handler.emit(_make_record("trigger"))
+        for _ in range(50):
+            if metadata.send_logs_batch_best_effort.called:
+                break
+            time.sleep(0.05)
+
+        self.assertIs(
+            captured["client"], handler._client, "handler must pass its own _client to send_logs_batch_best_effort"
+        )
+        handler.close()
+
+    @patch("metadata.utils.streamable_logger.REST")
+    def test_handler_reuses_one_isolated_client_for_all_batches(self, mock_rest):
+        """Persistent connection pool guarantee: construct one isolated REST
+        client per handler, pass that same client for every batch, and close
+        it only when the sender exits."""
+        client = Mock()
+        mock_rest.return_value = client
+
+        metadata = Mock(spec=OpenMetadata)
+        metadata.client = Mock()
+        metadata.client.config = Mock()
+        metadata.send_logs_batch_best_effort = Mock(return_value=True)
+        metadata.send_close_best_effort = Mock(return_value=True)
+
+        handler = _make_handler(metadata=metadata, enable_streaming=True)
+
+        handler._post_batch(["first"])
+        handler._post_batch(["second"])
+
+        mock_rest.assert_called_once_with(metadata.client.config)
+        self.assertEqual(metadata.send_logs_batch_best_effort.call_count, 2)
+        first_call, second_call = metadata.send_logs_batch_best_effort.call_args_list
+        self.assertIs(first_call.kwargs["client"], client)
+        self.assertIs(second_call.kwargs["client"], client)
+        client.close.assert_not_called()
 
         handler.close()
 
-    def test_fallback_when_streaming_disabled(self):
-        """Test that logs fallback to local when streaming is disabled"""
-        handler = StreamableLogHandler(
-            metadata=self.mock_metadata,
-            pipeline_fqn=self.pipeline_fqn,
-            run_id=self.run_id,
-            enable_streaming=False,
-        )
-
-        # Mock the fallback handler
-        handler.fallback_handler = Mock()
-
-        # Create a log record
-        record = logging.LogRecord(
-            name="test",
-            level=logging.INFO,
-            pathname="test.py",
-            lineno=1,
-            msg="Test message",
-            args=(),
-            exc_info=None,
-        )
-
-        handler.emit(record)
-
-        # Should have called fallback handler
-        handler.fallback_handler.emit.assert_called_once_with(record)
+    def test_isolated_client_is_closed_by_sender_thread(self):
+        metadata = _make_metadata_mock()
+        handler = _make_handler(metadata=metadata, enable_streaming=True)
+        handler._client.close = Mock()
 
         handler.close()
+        for _ in range(50):
+            if handler._client.close.called:
+                break
+            time.sleep(0.05)
 
-    def test_log_compression(self):
-        """Test log compression for large payloads"""
-        handler = StreamableLogHandler(
-            metadata=self.mock_metadata,
-            pipeline_fqn=self.pipeline_fqn,
-            run_id=self.run_id,
-            enable_streaming=False,  # We'll test _send_logs_to_server directly
+        handler._client.close.assert_called()
+
+
+class TestNoWaitClose(unittest.TestCase):
+    """close() must return effectively instantly. It must NOT join the
+    drainer / senders and must NOT wait on the server /close response."""
+
+    def test_close_returns_in_under_100ms_when_idle(self):
+        handler = _make_handler(enable_streaming=True)
+
+        start = time.monotonic()
+        handler.close()
+        elapsed = time.monotonic() - start
+
+        self.assertLess(
+            elapsed,
+            0.1,
+            f"close() took {elapsed * 1000:.1f}ms - must not block",
         )
 
-        # Large log content (> 10KB to trigger compression)
-        large_log = "x" * 11000
+    def test_close_returns_quickly_when_close_endpoint_hangs(self):
+        hang = threading.Event()
 
-        # Mock send_logs_batch to capture the call
-        with patch.object(self.mock_metadata, "send_logs_batch") as mock_send_logs:
-            mock_send_logs.return_value = {"logs_sent": 1, "bytes_sent": len(large_log)}
+        def block_forever(*_, **__):
+            hang.wait(timeout=30)
+            return True
 
-            with patch.dict(os.environ, {"ENABLE_LOG_COMPRESSION": "true"}):
-                handler._send_logs_to_server(large_log)
+        metadata = _make_metadata_mock()
+        metadata.send_logs_batch_best_effort = Mock(return_value=True)
+        metadata.send_close_best_effort = Mock(side_effect=block_forever)
 
-            # Verify send_logs_batch was called with compression enabled
-            mock_send_logs.assert_called_once_with(
-                pipeline_fqn=self.pipeline_fqn,
-                run_id=self.run_id,
-                log_content=large_log,
-                enable_compression=True,
-            )
+        handler = _make_handler(metadata=metadata, enable_streaming=True)
 
+        start = time.monotonic()
+        handler.close()
+        elapsed = time.monotonic() - start
+
+        self.assertLess(
+            elapsed,
+            0.1,
+            f"close() took {elapsed * 1000:.1f}ms - must not wait on /close response",
+        )
+        hang.set()
+
+    def test_close_signals_stop(self):
+        handler = _make_handler(enable_streaming=True)
+        handler.close()
+        self.assertTrue(handler._stop.is_set())
+
+    def test_close_is_idempotent(self):
+        handler = _make_handler(enable_streaming=True)
+        handler.close()
+        handler.close()  # must not raise
+
+
+class TestQuietClientPath(unittest.TestCase):
+    """The handler uses the best-effort path that bypasses retries and logging."""
+
+    def test_post_uses_best_effort_method(self):
+        metadata = _make_metadata_mock()
+        metadata.send_logs_batch_best_effort = Mock(return_value=True)
+        metadata.send_close_best_effort = Mock(return_value=True)
+
+        handler = _make_handler(metadata=metadata, enable_streaming=True)
+        handler.emit(_make_record("trigger"))
+        for _ in range(50):
+            if metadata.send_logs_batch_best_effort.called:
+                break
+            time.sleep(0.05)
+
+        self.assertTrue(metadata.send_logs_batch_best_effort.called)
+        kwargs = metadata.send_logs_batch_best_effort.call_args.kwargs
+        self.assertEqual(kwargs["timeout"], StreamableLogHandler.HTTP_TIMEOUT)
         handler.close()
 
-    def test_no_compression_for_small_logs(self):
-        """Test that small logs are not compressed"""
-        handler = StreamableLogHandler(
-            metadata=self.mock_metadata,
-            pipeline_fqn=self.pipeline_fqn,
-            run_id=self.run_id,
-            enable_streaming=False,
-        )
 
-        # Small log content (< 1KB)
-        small_log = "Small log message"
-
-        # Mock send_logs_batch to capture the call
-        with patch.object(self.mock_metadata, "send_logs_batch") as mock_send_logs:
-            mock_send_logs.return_value = {"logs_sent": 1, "bytes_sent": len(small_log)}
-
-            with patch.dict(os.environ, {"ENABLE_LOG_COMPRESSION": "true"}):
-                handler._send_logs_to_server(small_log)
-
-            # Verify send_logs_batch was called with compression enabled
-            # Note: The actual compression decision is made inside send_logs_batch
-            mock_send_logs.assert_called_once_with(
-                pipeline_fqn=self.pipeline_fqn,
-                run_id=self.run_id,
-                log_content=small_log,
-                enable_compression=True,
-            )
-
-        handler.close()
-
-    def test_session_maintains_cookies(self):
-        """Test that session maintains cookies for ALB stickiness"""
-        handler = StreamableLogHandler(
-            metadata=self.mock_metadata,
-            pipeline_fqn=self.pipeline_fqn,
-            run_id=self.run_id,
-            enable_streaming=False,
-        )
-
-        # Mock send_logs_batch to capture the calls
-        with patch.object(self.mock_metadata, "send_logs_batch") as mock_send_logs:
-            mock_send_logs.return_value = {"logs_sent": 1, "bytes_sent": 100}
-
-            # Send multiple log batches
-            handler._send_logs_to_server("Log batch 1")
-            handler._send_logs_to_server("Log batch 2")
-
-            # Two requests should be made with the same metadata instance
-            self.assertEqual(mock_send_logs.call_count, 2)
-            # Verify both calls used the same metadata instance
-            calls = mock_send_logs.call_args_list
-            for call in calls:
-                self.assertEqual(call.kwargs["pipeline_fqn"], self.pipeline_fqn)
-                self.assertEqual(call.kwargs["run_id"], self.run_id)
-
-        handler.close()
-
-    def test_circuit_breaker_on_failures(self):
-        """Test circuit breaker behavior on repeated failures"""
-        handler = StreamableLogHandler(
-            metadata=self.mock_metadata,
-            pipeline_fqn=self.pipeline_fqn,
-            run_id=self.run_id,
-            enable_streaming=False,
-        )
-
-        # Mock _send_logs_to_server to always fail
-        handler._send_logs_to_server = Mock(side_effect=Exception("Network error"))
-
-        logs = ["log1", "log2", "log3"]
-
-        # First few failures should attempt to send
-        for _ in range(5):
-            handler._ship_logs(logs)
-
-        # Circuit should be open now
-        self.assertEqual(handler.circuit_breaker.state, CircuitState.OPEN)
-
-        handler.close()
-
-    def test_queue_overflow_fallback(self):
-        """Test fallback behavior when queue is full"""
-        handler = StreamableLogHandler(
-            metadata=self.mock_metadata,
-            pipeline_fqn=self.pipeline_fqn,
-            run_id=self.run_id,
-            max_queue_size=1,
-            enable_streaming=True,
-        )
-
-        # Fill the queue
-        handler.log_queue.put("existing_log")
-
-        # Mock the fallback handler
-        handler.fallback_handler = Mock()
-
-        # Try to emit when queue is full
-        record = logging.LogRecord(
-            name="test",
-            level=logging.INFO,
-            pathname="test.py",
-            lineno=1,
-            msg="Overflow message",
-            args=(),
-            exc_info=None,
-        )
-
-        handler.emit(record)
-
-        # Should have called fallback handler
-        handler.fallback_handler.emit.assert_called_once_with(record)
-
-        handler.close()
-
-    @patch("metadata.utils.streamable_logger.threading.Thread")
-    def test_worker_thread_lifecycle(self, mock_thread_class):
-        """Test worker thread start and stop"""
-        mock_thread = Mock()
-        mock_thread.is_alive.return_value = False
-        mock_thread_class.return_value = mock_thread
-
-        handler = StreamableLogHandler(
-            metadata=self.mock_metadata,
-            pipeline_fqn=self.pipeline_fqn,
-            run_id=self.run_id,
-            enable_streaming=True,
-        )
-
-        # Worker thread should be started
-        mock_thread.start.assert_called_once()
-
-        # Close handler
-        handler.close()
-
-        # Stop event should be set
-        self.assertTrue(handler.stop_event.is_set())
-
-    def test_auth_header_included(self):
-        """Test that auth header is included when available"""
-        handler = StreamableLogHandler(
-            metadata=self.mock_metadata,
-            pipeline_fqn=self.pipeline_fqn,
-            run_id=self.run_id,
-            enable_streaming=False,
-        )
-
-        # Mock the send_logs_batch method to verify it's called with correct parameters
-        with patch.object(self.mock_metadata, "send_logs_batch") as mock_send_logs:
-            mock_send_logs.return_value = {"logs_sent": 1, "bytes_sent": 100}
-
-            handler._send_logs_to_server("Test log")
-
-            # Verify send_logs_batch was called with the correct parameters
-            mock_send_logs.assert_called_once_with(
-                pipeline_fqn=self.pipeline_fqn,
-                run_id=self.run_id,
-                log_content="Test log",
-                enable_compression=False,
-            )
-
-        handler.close()
-
-    def test_drain_queue_to_buffer_empty_queue(self):
-        """Test _drain_queue_to_buffer with empty queue"""
-        handler = StreamableLogHandler(
-            metadata=self.mock_metadata,
-            pipeline_fqn=self.pipeline_fqn,
-            run_id=self.run_id,
-            enable_streaming=False,
-        )
-
-        buffer = []
-        result_buffer, flush_requested = handler._drain_queue_to_buffer(buffer)
-
-        # Buffer should be unchanged and no flush requested
-        self.assertEqual(result_buffer, [])
-        self.assertFalse(flush_requested)
-
-        handler.close()
-
-    def test_drain_queue_to_buffer_with_logs(self):
-        """Test _drain_queue_to_buffer with regular log entries"""
-        handler = StreamableLogHandler(
-            metadata=self.mock_metadata,
-            pipeline_fqn=self.pipeline_fqn,
-            run_id=self.run_id,
-            enable_streaming=False,
-        )
-
-        # Add some log entries to queue
-        handler.log_queue.put("log entry 1")
-        handler.log_queue.put("log entry 2")
-        handler.log_queue.put("log entry 3")
-
-        buffer = ["existing log"]
-        result_buffer, flush_requested = handler._drain_queue_to_buffer(buffer)
-
-        # Buffer should contain all logs
-        expected_buffer = ["existing log", "log entry 1", "log entry 2", "log entry 3"]
-        self.assertEqual(result_buffer, expected_buffer)
-        self.assertFalse(flush_requested)
-
-        handler.close()
-
-    def test_drain_queue_to_buffer_with_flush_marker(self):
-        """Test _drain_queue_to_buffer handles flush markers correctly"""
-        handler = StreamableLogHandler(
-            metadata=self.mock_metadata,
-            pipeline_fqn=self.pipeline_fqn,
-            run_id=self.run_id,
-            enable_streaming=False,
-        )
-
-        # Add log entries and a flush marker
-        handler.log_queue.put("log entry 1")
-        handler.log_queue.put(None)  # Flush marker
-        handler.log_queue.put("log entry 2")
-
-        buffer = []
-        result_buffer, flush_requested = handler._drain_queue_to_buffer(buffer)
-
-        # Buffer should contain only log entries, not the flush marker
-        expected_buffer = ["log entry 1", "log entry 2"]
-        self.assertEqual(result_buffer, expected_buffer)
-        self.assertTrue(flush_requested)
-
-        handler.close()
-
-    def test_drain_queue_to_buffer_multiple_flush_markers(self):
-        """Test _drain_queue_to_buffer with multiple flush markers"""
-        handler = StreamableLogHandler(
-            metadata=self.mock_metadata,
-            pipeline_fqn=self.pipeline_fqn,
-            run_id=self.run_id,
-            enable_streaming=False,
-        )
-
-        # Add multiple flush markers
-        handler.log_queue.put("log entry 1")
-        handler.log_queue.put(None)  # First flush marker
-        handler.log_queue.put("log entry 2")
-        handler.log_queue.put(None)  # Second flush marker
-        handler.log_queue.put("log entry 3")
-
-        buffer = []
-        result_buffer, flush_requested = handler._drain_queue_to_buffer(buffer)
-
-        # Buffer should contain all log entries
-        expected_buffer = ["log entry 1", "log entry 2", "log entry 3"]
-        self.assertEqual(result_buffer, expected_buffer)
-        self.assertTrue(flush_requested)
-
-        handler.close()
-
-    @patch("time.time")
-    def test_worker_loop_flush_logic(self, mock_time):
-        """Test worker loop flush decision logic"""
-        # Set up consistent time for testing
-        mock_time.return_value = 1000.0
-
-        handler = StreamableLogHandler(
-            metadata=self.mock_metadata,
-            pipeline_fqn=self.pipeline_fqn,
-            run_id=self.run_id,
-            enable_streaming=False,
-            batch_size=3,
-            flush_interval_sec=5.0,
-        )
-
-        # Mock the shipping method
-        handler._ship_logs = Mock()
-
-        # Test flush due to batch size
-        handler.log_queue.put("log1")
-        handler.log_queue.put("log2")
-        handler.log_queue.put("log3")
-
-        # Simulate one iteration of worker loop logic
-        buffer = []
-        last_flush = mock_time.return_value
-
-        buffer, flush_requested = handler._drain_queue_to_buffer(buffer)
-        should_flush = (
-            flush_requested
-            or len(buffer) >= handler.batch_size
-            or (mock_time.return_value - last_flush) >= handler.flush_interval_sec
-        )
-
-        self.assertTrue(should_flush)  # Should flush due to batch size
-        self.assertEqual(len(buffer), 3)
-
-        handler.close()
-
-    @patch("time.time")
-    def test_worker_loop_time_based_flush(self, mock_time):
-        """Test worker loop time-based flush logic"""
-        handler = StreamableLogHandler(
-            metadata=self.mock_metadata,
-            pipeline_fqn=self.pipeline_fqn,
-            run_id=self.run_id,
-            enable_streaming=False,
-            batch_size=10,
-            flush_interval_sec=5.0,
-        )
-
-        # Add one log (below batch size)
-        handler.log_queue.put("single log")
-
-        # Set up time progression: first call returns 1000.0, subsequent calls return 1006.0
-        mock_time.side_effect = [
-            1000.0,
-            1006.0,
-            1006.0,
-        ]  # Allow for multiple time() calls
-
-        # Simulate worker loop logic with time progression
-        buffer = []
-        last_flush = 1000.0  # Initial time
-
-        buffer, flush_requested = handler._drain_queue_to_buffer(buffer)
-        current_time = 1006.0  # Time after drainage
-
-        should_flush = (
-            flush_requested
-            or len(buffer) >= handler.batch_size
-            or (current_time - last_flush) >= handler.flush_interval_sec
-        )
-
-        self.assertTrue(should_flush)  # Should flush due to time interval (6 > 5)
-        self.assertEqual(len(buffer), 1)
-
-        handler.close()
-
-    def test_flush_marker_triggers_immediate_flush(self):
-        """Test that flush markers trigger immediate flush regardless of batch size or time"""
-        handler = StreamableLogHandler(
-            metadata=self.mock_metadata,
-            pipeline_fqn=self.pipeline_fqn,
-            run_id=self.run_id,
-            enable_streaming=False,
-            batch_size=10,  # Large batch size
-            flush_interval_sec=60.0,  # Long time interval
-        )
-
-        # Add just one log and a flush marker
-        handler.log_queue.put("single log")
-        handler.log_queue.put(None)  # Flush marker
-
-        buffer = []
-        buffer, flush_requested = handler._drain_queue_to_buffer(buffer)
-
-        # Should request flush despite small buffer and short time
-        self.assertTrue(flush_requested)
-        self.assertEqual(len(buffer), 1)
-
-        handler.close()
-
-    def test_worker_loop_final_drainage_on_shutdown(self):
-        """Test that worker loop drains queue completely on shutdown"""
-        handler = StreamableLogHandler(
-            metadata=self.mock_metadata,
-            pipeline_fqn="test.pipeline",
-            run_id=uuid4(),
-            enable_streaming=False,
-        )
-
-        # Mock _ship_logs to track what gets shipped
-        shipped_logs = []
-
-        def mock_ship_logs(logs):
-            shipped_logs.extend(logs)
-
-        handler._ship_logs = mock_ship_logs
-
-        # Add logs to queue after stop event is set (simulating final drainage)
-        handler.log_queue.put("final log 1")
-        handler.log_queue.put("final log 2")
-        handler.log_queue.put(None)  # Flush marker
-        handler.log_queue.put("final log 3")
-
-        # Simulate final cleanup drainage
-        buffer, _ = handler._drain_queue_to_buffer([])
-        if buffer:
-            handler._ship_logs(buffer)
-
-        # All logs should be shipped
-        expected_logs = ["final log 1", "final log 2", "final log 3"]
-        self.assertEqual(shipped_logs, expected_logs)
-
-        handler.close()
-
-    def test_flush_method_adds_marker_to_queue(self):
-        """Test that flush method properly adds None marker to queue"""
-        handler = StreamableLogHandler(
-            metadata=self.mock_metadata,
-            pipeline_fqn="test.pipeline",
-            run_id=uuid4(),
-            enable_streaming=False,
-        )
-
-        # Flush should add None marker
-        handler.flush()
-
-        # Verify marker was added
-        marker = handler.log_queue.get_nowait()
-        self.assertIsNone(marker)
-
-        handler.close()
-
-    def test_close_waits_for_worker_thread(self):
-        """Test that close method properly waits for worker thread"""
-        with patch("threading.Thread") as mock_thread_class:
-            mock_thread = Mock()
-            mock_thread.is_alive.return_value = True
-            mock_thread_class.return_value = mock_thread
-
-            handler = StreamableLogHandler(
-                metadata=self.mock_metadata,
-                pipeline_fqn="test.pipeline",
-                run_id=uuid4(),
-                enable_streaming=True,
-            )
-
-            # Close handler
-            handler.close()
-
-            # Verify stop event was set and thread join was called
-            self.assertTrue(handler.stop_event.is_set())
-            mock_thread.join.assert_called_once_with(timeout=5.0)
+class TestStreamableLogHandlerManager(unittest.TestCase):
+    def tearDown(self):
+        StreamableLogHandlerManager._instance = None
+
+    def test_set_handler_removes_previous_from_metadata_logger(self):
+        """set_handler must detach the old handler from the metadata logger
+        before closing it - otherwise records can still route at it during
+        close, and a closed handler stays attached after."""
+        from metadata.utils.logger import METADATA_LOGGER
+
+        first = _make_handler(enable_streaming=False)
+        second = _make_handler(enable_streaming=False)
+        metadata_logger = logging.getLogger(METADATA_LOGGER)
+        metadata_logger.addHandler(first)
+
+        StreamableLogHandlerManager.set_handler(first)
+        StreamableLogHandlerManager.set_handler(second)
+
+        self.assertNotIn(first, metadata_logger.handlers, "previous handler must be removed before being closed")
+        # Cleanup.
+        metadata_logger.handlers = [h for h in metadata_logger.handlers if not isinstance(h, StreamableLogHandler)]
+
+    def test_cleanup_clears_singleton(self):
+        handler = _make_handler(enable_streaming=False)
+        StreamableLogHandlerManager.set_handler(handler)
+        StreamableLogHandlerManager.cleanup()
+        self.assertIsNone(StreamableLogHandlerManager.get_handler())
 
 
 class TestStreamableLoggingSetup(unittest.TestCase):
-    """Test the setup and cleanup functions"""
-
     def tearDown(self):
-        """Clean up any handlers that were added to loggers during tests"""
-        # Clean up any handlers from the metadata logger
-        import logging
-
         from metadata.utils.logger import METADATA_LOGGER
-        from metadata.utils.streamable_logger import StreamableLogHandlerManager
 
         metadata_logger = logging.getLogger(METADATA_LOGGER)
-        # Remove any mock handlers
         metadata_logger.handlers = [
-            h for h in metadata_logger.handlers if not isinstance(h, Mock)
+            h for h in metadata_logger.handlers if not isinstance(h, (Mock, StreamableLogHandler))
         ]
-
-        # Also clean up the manager
         StreamableLogHandlerManager._instance = None
 
     @patch("logging.getLogger")
     @patch("metadata.utils.streamable_logger.logger")
     @patch("metadata.utils.streamable_logger.StreamableLogHandler")
-    def test_setup_with_valid_config(
-        self, mock_handler_class, mock_logger, mock_get_logger
-    ):
-        """Test setup with valid configuration"""
+    def test_setup_with_valid_config(self, mock_handler_cls, mock_logger, mock_get_logger):
         mock_metadata = Mock(spec=OpenMetadata)
-        mock_metadata.config = Mock()
-        mock_metadata.config.host_port = "http://localhost:8585"
-
         mock_handler = Mock()
-        mock_handler.level = logging.INFO  # Add level attribute
-        mock_handler_class.return_value = mock_handler
-
-        pipeline_fqn = "test.pipeline"
-        run_id = uuid4()
-
-        # Setup mock logger to prevent handler from being added to real logger
+        mock_handler.level = logging.INFO
+        mock_handler_cls.return_value = mock_handler
         mock_metadata_logger = Mock()
         mock_get_logger.return_value = mock_metadata_logger
 
-        # Test with enable_streaming=True (from IngestionPipeline config)
-        result = setup_streamable_logging_for_workflow(
-            metadata=mock_metadata,
-            pipeline_fqn=pipeline_fqn,
-            run_id=run_id,
-            enable_streaming=True,  # This would come from IngestionPipeline.enableStreamableLogs
-        )
-
-        self.assertIsNotNone(result)
-        mock_handler_class.assert_called_once_with(
-            metadata=mock_metadata,
-            pipeline_fqn=pipeline_fqn,
-            run_id=run_id,
-            enable_streaming=True,
-        )
-
-        # Cleanup
-        cleanup_streamable_logging()
-
-    def test_setup_disabled_by_config(self):
-        """Test that setup returns None when disabled by config"""
-        mock_metadata = Mock(spec=OpenMetadata)
-
-        # Test with enable_streaming=False (from IngestionPipeline config)
         result = setup_streamable_logging_for_workflow(
             metadata=mock_metadata,
             pipeline_fqn="test.pipeline",
             run_id=uuid4(),
-            enable_streaming=False,  # This would come from IngestionPipeline.enableStreamableLogs
+            enable_streaming=True,
         )
 
+        self.assertIsNotNone(result)
+        mock_metadata_logger.addHandler.assert_called_once_with(mock_handler)
+        cleanup_streamable_logging()
+
+    def test_setup_returns_none_when_disabled(self):
+        result = setup_streamable_logging_for_workflow(
+            metadata=Mock(spec=OpenMetadata),
+            pipeline_fqn="test.pipeline",
+            run_id=uuid4(),
+            enable_streaming=False,
+        )
         self.assertIsNone(result)
 
-    def test_setup_missing_parameters(self):
-        """Test that setup returns None when parameters are missing"""
-        mock_metadata = Mock(spec=OpenMetadata)
-
-        # Missing pipeline_fqn
+    def test_setup_returns_none_when_pipeline_fqn_missing(self):
         result = setup_streamable_logging_for_workflow(
-            metadata=mock_metadata,
+            metadata=Mock(spec=OpenMetadata),
             pipeline_fqn=None,
             run_id=uuid4(),
             enable_streaming=True,
         )
         self.assertIsNone(result)
 
-        # Missing run_id
+    def test_setup_returns_none_when_run_id_missing(self):
         result = setup_streamable_logging_for_workflow(
-            metadata=mock_metadata,
+            metadata=Mock(spec=OpenMetadata),
             pipeline_fqn="test.pipeline",
             run_id=None,
             enable_streaming=True,
         )
         self.assertIsNone(result)
 
-    @patch("logging.getLogger")
-    @patch("metadata.utils.streamable_logger.logger")
-    @patch("metadata.utils.streamable_logger.StreamableLogHandler")
-    def test_cleanup_removes_handler(
-        self, mock_handler_class, mock_logger, mock_get_logger
-    ):
-        """Test that cleanup properly removes the handler"""
-        mock_metadata = Mock(spec=OpenMetadata)
-        mock_metadata.config = Mock()
-        mock_metadata.config.host_port = "http://localhost:8585"
 
-        mock_handler = Mock()
-        mock_handler.level = logging.INFO  # Add level attribute to prevent TypeError
-        mock_handler_class.return_value = mock_handler
-
-        # Setup mock logger to prevent handler from being added to real logger
-        mock_metadata_logger = Mock()
-        mock_get_logger.return_value = mock_metadata_logger
-
-        # Setup
-        handler = setup_streamable_logging_for_workflow(
-            metadata=mock_metadata,
-            pipeline_fqn="test.pipeline",
-            run_id=uuid4(),
-            enable_streaming=True,
-        )
-
-        # Cleanup
-        cleanup_streamable_logging()
-
-        mock_metadata_logger.removeHandler.assert_called_once_with(mock_handler)
-        mock_handler.close.assert_called_once()
-
-    @patch("logging.getLogger")
-    @patch("metadata.utils.streamable_logger.logger")
-    @patch("metadata.utils.streamable_logger.StreamableLogHandler")
-    def test_setup_replaces_existing_handler(
-        self, mock_handler_class, mock_logger, mock_get_logger
-    ):
-        """Test that setup properly replaces existing handler"""
-        mock_metadata = Mock(spec=OpenMetadata)
-        mock_metadata.config = Mock()
-        mock_metadata.config.host_port = "http://localhost:8585"
-
-        mock_handler1 = Mock()
-        mock_handler1.level = logging.INFO  # Add level attribute
-        mock_handler2 = Mock()
-        mock_handler2.level = logging.INFO  # Add level attribute
-        mock_handler_class.side_effect = [mock_handler1, mock_handler2]
-
-        # Setup mock logger to prevent handler from being added to real logger
-        mock_metadata_logger = Mock()
-        mock_get_logger.return_value = mock_metadata_logger
-
-        # First setup
-        handler1 = setup_streamable_logging_for_workflow(
-            metadata=mock_metadata,
-            pipeline_fqn="test.pipeline1",
-            run_id=uuid4(),
-            enable_streaming=True,
-        )
-
-        # Second setup should close first handler
-        handler2 = setup_streamable_logging_for_workflow(
-            metadata=mock_metadata,
-            pipeline_fqn="test.pipeline2",
-            run_id=uuid4(),
-            enable_streaming=True,
-        )
-
-        # The first handler should be closed when the second one is set
-        mock_handler1.close.assert_called()
-
-        # Cleanup
-        cleanup_streamable_logging()
-
-    @patch("logging.getLogger")
-    @patch("metadata.utils.streamable_logger.logger")
-    @patch("metadata.utils.streamable_logger.StreamableLogHandler")
-    def test_cleanup_flushes_before_closing(
-        self, mock_handler_class, mock_logger, mock_get_logger
-    ):
-        """Test that cleanup calls flush before closing handler"""
-        mock_metadata = Mock(spec=OpenMetadata)
-        mock_metadata.config = Mock()
-        mock_metadata.config.host_port = "http://localhost:8585"
-
-        mock_handler = Mock()
-        mock_handler.level = logging.INFO
-        # Mock the specific methods that should be called
-        mock_handler.flush = Mock()
-        mock_handler.close = Mock()
-        mock_handler_class.return_value = mock_handler
-
-        # Setup mock logger
-        mock_metadata_logger = Mock()
-        mock_get_logger.return_value = mock_metadata_logger
-
-        # Setup handler
-        handler = setup_streamable_logging_for_workflow(
-            metadata=mock_metadata,
-            pipeline_fqn="test.pipeline",
-            run_id=uuid4(),
-            enable_streaming=True,
-        )
-
-        # Verify handler was created and returned
-        self.assertIsNotNone(handler)
-        self.assertEqual(handler, mock_handler)
-
-        # Cleanup and verify order of operations
-        cleanup_streamable_logging()
-
-        # Verify flush was called
-        mock_handler.flush.assert_called_once()
-
-        # Verify close was called
-        mock_handler.close.assert_called_once()
-
-        # Verify handler was removed from logger
-        mock_metadata_logger.removeHandler.assert_called_once_with(mock_handler)
-
-
-class TestStreamableLogHandlerRecursionRegression(unittest.TestCase):
-    """
-    Regression test for the production hang where StreamableLogHandler.emit()
-    called logger.warning() / logger.error() from inside the handler's own
-    dispatch path. Because the handler is attached to that very same logger,
-    every internal log call re-entered emit(), recursing against a still-full
-    queue until the Python recursion limit was hit on MainThread while every
-    other thread was blocked on the logging module's internal lock.
-
-    The fix is to use a dedicated `_internal_logger` with `propagate=False`
-    for any message originating inside this module's hot path. These tests
-    fail if anyone re-introduces a `logger.*` call inside emit / _ship_logs /
-    _worker_loop.
-    """
+class TestRecursionRegression(unittest.TestCase):
+    """emit() must run exactly once per producer call even when overflow
+    or format failure would historically have triggered recursive logging."""
 
     def setUp(self):
-        self.mock_metadata = Mock(spec=OpenMetadata)
-        self.test_logger = logging.getLogger(f"test_streamable_recursion_{id(self)}")
+        self.mock_metadata = _make_metadata_mock()
+        self.test_logger = logging.getLogger(f"test_recursion_{id(self)}")
         self.test_logger.handlers = []
         self.test_logger.setLevel(logging.DEBUG)
         self.test_logger.propagate = False
@@ -884,104 +620,200 @@ class TestStreamableLogHandlerRecursionRegression(unittest.TestCase):
     def tearDown(self):
         self.test_logger.handlers = []
 
-    def _make_handler(self, max_queue_size=2):
-        handler = StreamableLogHandler(
+    def _make_handler_with_full_buffer(self):
+        handler = _make_handler(
             metadata=self.mock_metadata,
-            pipeline_fqn="test.pipeline",
-            run_id=uuid4(),
-            max_queue_size=max_queue_size,
+            max_buffer=2,
             enable_streaming=True,
         )
-        # Stop the background worker so the queue cannot drain during the test.
-        handler.stop_event.set()
-        if handler.worker_thread:
-            handler.worker_thread.join(timeout=2.0)
-        # Make the local fallback a Mock so we can assert it was called once.
-        handler.fallback_handler = Mock()
+        _stop_workers(handler)
+        handler._buffer.put_nowait("a")
+        handler._buffer.put_nowait("b")
+        self.assertTrue(handler._buffer.full())
         return handler
 
-    def test_emit_does_not_recurse_when_queue_full(self):
-        """
-        emit() must complete in a single call when the queue is full.
-        Before the fix this exploded into ~1000 recursive emit() calls.
-        """
-        handler = self._make_handler(max_queue_size=2)
-        handler.log_queue.put_nowait("entry-1")
-        handler.log_queue.put_nowait("entry-2")
-        self.assertTrue(handler.log_queue.full())
-
+    def test_emit_does_not_recurse_when_buffer_full(self):
+        handler = self._make_handler_with_full_buffer()
         self.test_logger.addHandler(handler)
 
-        call_count = {"n": 0}
+        emit_calls = {"n": 0}
         real_emit = handler.emit
 
-        def counting_emit(record):
-            call_count["n"] += 1
-            if call_count["n"] > 5:
-                raise AssertionError(
-                    "emit() recursed — regression of the streamable_logger hang. "
-                    "Check that nothing inside emit / _ship_logs / _worker_loop "
-                    "calls the module-level `logger`; use `_internal_logger` instead."
-                )
+        def counting(record):
+            emit_calls["n"] += 1
+            if emit_calls["n"] > 5:
+                raise AssertionError("emit() recursed — single-call regression")
             real_emit(record)
 
-        handler.emit = counting_emit
-
+        handler.emit = counting
         start = time.monotonic()
-        # Before the fix this call would never return — MainThread would sit
-        # recursing until Python raised RecursionError, then the outer except
-        # would log.error() which would recurse again.
-        self.test_logger.warning("trigger the overflow path")
+        self.test_logger.warning("trigger overflow")
         elapsed = time.monotonic() - start
 
-        self.assertEqual(call_count["n"], 1, "emit() must be invoked exactly once per log call")
-        self.assertLess(elapsed, 1.0, "emit() must return in bounded time when queue is full")
-        handler.fallback_handler.emit.assert_called_once()
-
-    def test_emit_does_not_recurse_when_format_raises(self):
-        """
-        If self.format(record) raises, the outer except in emit() must NOT
-        route the error back through `logger` (which would recurse).
-        """
-        handler = self._make_handler(max_queue_size=10)
-        handler.format = Mock(side_effect=ValueError("boom"))
-
-        self.test_logger.addHandler(handler)
-
-        call_count = {"n": 0}
-        real_emit = handler.emit
-
-        def counting_emit(record):
-            call_count["n"] += 1
-            if call_count["n"] > 5:
-                raise AssertionError("emit() recursed via the outer except branch — regression.")
-            real_emit(record)
-
-        handler.emit = counting_emit
-
-        start = time.monotonic()
-        self.test_logger.error("trigger the format-failure path")
-        elapsed = time.monotonic() - start
-
-        self.assertEqual(call_count["n"], 1)
+        self.assertEqual(emit_calls["n"], 1)
         self.assertLess(elapsed, 1.0)
 
-    def test_internal_logger_is_isolated_from_root(self):
-        """
-        The `_internal_logger` must not propagate, otherwise its messages
-        would still reach the root logger (and therefore re-enter this
-        handler if it is attached there).
-        """
-        from metadata.utils.streamable_logger import _internal_logger
+    def test_emit_does_not_recurse_when_format_raises(self):
+        handler = _make_handler(metadata=self.mock_metadata, enable_streaming=True)
+        _stop_workers(handler)
+        handler.format = MagicMock(side_effect=ValueError("boom"))
 
-        self.assertFalse(
-            _internal_logger.propagate,
-            "_internal_logger.propagate must be False to prevent recursion",
+        self.test_logger.addHandler(handler)
+        emit_calls = {"n": 0}
+        real_emit = handler.emit
+
+        def counting(record):
+            emit_calls["n"] += 1
+            if emit_calls["n"] > 5:
+                raise AssertionError("emit() recursed via format-failure path")
+            real_emit(record)
+
+        handler.emit = counting
+        start = time.monotonic()
+        self.test_logger.error("trigger format failure")
+        elapsed = time.monotonic() - start
+
+        self.assertEqual(emit_calls["n"], 1)
+        self.assertLess(elapsed, 1.0)
+
+
+class TestQuietClientPostMixin(unittest.TestCase):
+    """The mixin's best-effort methods must NOT log through ometa_logger
+    (which would propagate back to the streamable handler)."""
+
+    def test_send_logs_batch_best_effort_does_not_log_on_failure(self):
+        from metadata.ingestion.ometa.mixins.logs_mixin import OMetaLogsMixin
+
+        # Build a bare instance and stub the client.
+        instance = OMetaLogsMixin()
+        instance.client = Mock()
+        instance.client.post_best_effort = Mock(return_value=False)
+
+        with patch("metadata.ingestion.ometa.mixins.logs_mixin.logger") as mock_logger:
+            ok = instance.send_logs_batch_best_effort(
+                pipeline_fqn="test",
+                run_id=uuid4(),
+                log_content="x",
+                timeout=(1, 2),
+            )
+
+        self.assertFalse(ok)
+        mock_logger.error.assert_not_called()
+        mock_logger.warning.assert_not_called()
+        mock_logger.info.assert_not_called()
+        mock_logger.debug.assert_not_called()
+
+    def test_send_logs_batch_best_effort_does_not_log_on_exception(self):
+        from metadata.ingestion.ometa.mixins.logs_mixin import OMetaLogsMixin
+
+        instance = OMetaLogsMixin()
+        instance.client = Mock()
+        instance.client.post_best_effort = Mock(side_effect=RuntimeError("boom"))
+
+        with patch("metadata.ingestion.ometa.mixins.logs_mixin.logger") as mock_logger:
+            ok = instance.send_logs_batch_best_effort(
+                pipeline_fqn="test",
+                run_id=uuid4(),
+                log_content="x",
+                timeout=(1, 2),
+            )
+
+        self.assertFalse(ok)
+        mock_logger.error.assert_not_called()
+        mock_logger.warning.assert_not_called()
+
+
+class TestClientPostBestEffort(unittest.TestCase):
+    """REST.post_best_effort must NOT enter the retry/sleep loop and
+    must NOT log on failure."""
+
+    def _make_client(self):
+        from metadata.ingestion.ometa.client import REST, ClientConfig
+
+        config = ClientConfig(
+            base_url="http://localhost:8585",
+            api_version="v1",
+            auth_token=lambda: ("token", 60),
         )
-        self.assertTrue(
-            _internal_logger.handlers,
-            "_internal_logger must have its own handler so messages still reach stderr",
-        )
+        client = REST(config)
+        client._session = Mock()
+        return client
+
+    def test_post_best_effort_does_not_sleep_on_504(self):
+        client = self._make_client()
+        resp = Mock()
+        resp.status_code = 504
+        client._session.post = Mock(return_value=resp)
+
+        with patch("time.sleep") as mock_sleep:
+            start = time.monotonic()
+            ok = client.post_best_effort("/path", data="x", timeout=(1, 2))
+            elapsed = time.monotonic() - start
+
+        self.assertFalse(ok)
+        mock_sleep.assert_not_called()
+        self.assertLess(elapsed, 0.2, "post_best_effort must NOT sleep on 504")
+
+    def test_post_best_effort_does_not_log_on_failure(self):
+        client = self._make_client()
+        client._session.post = Mock(side_effect=RuntimeError("network down"))
+
+        with patch("metadata.ingestion.ometa.client.logger") as mock_logger:
+            ok = client.post_best_effort("/path", data="x", timeout=(1, 2))
+
+        self.assertFalse(ok)
+        mock_logger.error.assert_not_called()
+        mock_logger.warning.assert_not_called()
+        mock_logger.info.assert_not_called()
+
+    def test_post_best_effort_returns_true_on_2xx(self):
+        client = self._make_client()
+        resp = Mock()
+        resp.status_code = 200
+        client._session.post = Mock(return_value=resp)
+
+        self.assertTrue(client.post_best_effort("/path", data="x"))
+
+    def test_build_request_headers_does_not_refresh_token(self):
+        """Token refresh stays on _request(); concurrent refresh from the
+        sender would race the main thread on shared ClientConfig."""
+        client = self._make_client()
+        client._auth_token = Mock(return_value=("fresh-token", 60))
+        client.config.expires_in = 0
+        client.config.access_token = "stale-token"
+        client.config.auth_header = "Authorization"
+
+        headers = client._build_request_headers()
+
+        client._auth_token.assert_not_called()
+        self.assertEqual(headers["Authorization"], "Bearer stale-token")
+        self.assertEqual(client.config.expires_in, 0)
+
+
+class TestCloseOrderingRegression(unittest.TestCase):
+    """close() must enqueue CLOSE_MARKER before setting _stop, otherwise
+    the sender's get(timeout) Empty branch can race the enqueue."""
+
+    def test_close_enqueues_marker_before_setting_stop(self):
+        metadata = _make_metadata_mock()
+        handler = _make_handler(metadata=metadata, enable_streaming=True)
+        handler.close()
+        for _ in range(50):
+            if metadata.send_close_best_effort.called:
+                break
+            time.sleep(0.05)
+        metadata.send_close_best_effort.assert_called_once()
+
+    def test_close_marker_arrives_even_when_sender_was_idle(self):
+        metadata = _make_metadata_mock()
+        handler = _make_handler(metadata=metadata, enable_streaming=True)
+        time.sleep(0.2)  # let sender enter get(timeout=...)
+        handler.close()
+        for _ in range(50):
+            if metadata.send_close_best_effort.called:
+                break
+            time.sleep(0.05)
+        metadata.send_close_best_effort.assert_called_once()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Describe your changes:

Backport to **1.12.9** of **only the ingestion-side** changes from #28198.

The connector was observed hanging on the Python logger once the streamable-log queue saturated (Snowflake-InternalProd and other high-volume connectors). #28198 fixed this client-side bug *and* a separate server-side `partial.txt` flush bug — but the server changes there are deltas on top of #27926, which is **not** in 1.12.9. This PR cherry-picks the **client-side fix only**, which is self-contained and sufficient for the connector-hang symptom.

### Type of change:
- [x] Bug fix

### Why this is safe on the 1.12.9 backend

The ingestion changes introduce **no new server contract**:
- Same endpoints: `POST /services/ingestionPipelines/logs/{fqn}/{runId}` and `.../close`
- Same JSON payload and auth headers
- `REST.post_best_effort()` is a plain `session.post()` to the existing URL, minus the retry/logging wrapper
- New `timeout=`/`retries=` kwargs default to `None` → bit-for-bit unchanged behavior for every existing caller
- #27926 itself states it made *"no changes to the Python ingestion client, same API endpoints"* — so the client↔server log protocol is identical between 1.12.9 and post-#27926 `main`

**Out of scope (intentionally excluded):** the Java/server changes in #28198 (`S3LogStorage.java`, `StreamableLogsMetrics.java`, IT). Those target the post-#27926 split-executor design that does not exist in 1.12.9. The server-side "`partial.txt` stops updating" symptom is **not** addressed by this PR.

### Changes (4 ingestion files only)

- `streamable_logger.py` — `StreamableLogHandler` rewritten as fire-and-forget: non-blocking `emit()`, daemon drainer/sender, isolated `REST` instance, no-wait `close()` with ordered `_CLOSE_MARKER`.
- `client.py` — adds `REST.post_best_effort` + `_build_request_headers`; `timeout`/`retries` kwargs on `_request`/`post` (default `None`). Resolved via 3-way merge, **preserving 1.12.9's own `sanitize_user_agent`/`user_agent` code** (not present on `main`).
- `logs_mixin.py` — `send_logs_batch_best_effort` / `send_close_best_effort`; `timeout` passthrough.
- `test_streamable_logger.py` — full client-side suite.

`source_api_client.py` from #28198 is **not** included (1.12.9 has no `TrackedREST.post`; that change is irrelevant to this fix).

### Tests:

- `tests/unit/utils/test_streamable_logger.py` — **39/39 passed**, run against the cherry-picked source on a clean 1.12.9 base (verified `import metadata` resolved to the cherry-picked tree, not an installed copy).
- All 4 changed files byte-compile clean.

### Checklist:
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added/ported tests and listed them above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)