### PR TITLE
fix(playwright): Fix DataQuality dashboard test flakiness & tooltip intercept

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DataQuality/DataQualityDashboard.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DataQuality/DataQualityDashboard.spec.ts
@@ -237,114 +237,134 @@ const waitForDashboardApiResponses = (page: Page, key: string) => {
 test('DataQualityDashboardTab', async ({ page }) => {
   test.slow();
 
-  await goToDataQualityDashboard(page);
-  await waitForAllLoadersToDisappear(page);
-  await page.getByRole('button', { name: 'Owner' }).click();
+  await test.step('Navigate to Data Quality dashboard', async () => {
+    await goToDataQualityDashboard(page);
+    await waitForAllLoadersToDisappear(page);
+  });
 
-  await expect(page.locator("[data-testid='select-owner-tabs']")).toBeVisible();
+  await test.step('Filter by Owner', async () => {
+    await page.getByRole('button', { name: 'Owner' }).click();
+    await expect(
+      page.locator("[data-testid='select-owner-tabs']")
+    ).toBeVisible();
+    await waitForAllLoadersToDisappear(page);
+    await page.getByRole('tab', { name: 'Users' }).click();
+    await waitForAllLoadersToDisappear(page);
 
-  await waitForAllLoadersToDisappear(page);
-  await page.getByRole('tab', { name: 'Users' }).click();
-  await waitForAllLoadersToDisappear(page);
+    const searchOwner = page.waitForResponse(
+      'api/v1/search/query?q=*&index=user*'
+    );
+    await page.locator('[data-testid="owner-select-users-search-bar"]').clear();
+    await page.fill(
+      '[data-testid="owner-select-users-search-bar"]',
+      user1.getUserDisplayName()
+    );
+    await searchOwner;
+    await waitForAllLoadersToDisappear(page);
 
-  const searchOwner = page.waitForResponse(
-    'api/v1/search/query?q=*&index=user*'
-  );
-  await page.locator('[data-testid="owner-select-users-search-bar"]').clear();
-  await page.fill(
-    '[data-testid="owner-select-users-search-bar"]',
-    user1.getUserDisplayName()
-  );
-  await searchOwner;
-  await waitForAllLoadersToDisappear(page);
-  const ownerApiResponse = waitForDashboardApiResponses(
-    page,
-    user1.responseData.name
-  );
-  await page
-    .getByRole('listitem', { name: user1.getUserDisplayName() })
-    .click();
-  for (const apiRes of ownerApiResponse) {
-    const responseData = await apiRes;
+    const ownerApiResponse = waitForDashboardApiResponses(
+      page,
+      user1.responseData.name
+    );
+    await page
+      .getByRole('listitem', { name: user1.getUserDisplayName() })
+      .click();
+    for (const apiRes of ownerApiResponse) {
+      const responseData = await apiRes;
 
-    expect(responseData.ok()).toBeTruthy();
-  }
+      expect(responseData.ok()).toBeTruthy();
+    }
+  });
 
-  await page.getByRole('button', { name: 'Tier' }).click();
-  await page.getByTestId('search-input').click();
-  await page
-    .getByTestId('search-input')
-    .fill(tier.responseData.fullyQualifiedName);
-  await page.getByTestId(tier.responseData.fullyQualifiedName).click();
-  const tierApiResponse = waitForDashboardApiResponses(
-    page,
-    tier.responseData.fullyQualifiedName
-  );
-  await page.getByTestId('update-btn').click();
-  for (const apiRes of tierApiResponse) {
-    const responseData = await apiRes;
+  await test.step('Filter by Tier', async () => {
+    await page.getByRole('button', { name: 'Tier' }).click();
+    await page.getByTestId('search-input').click();
+    await page
+      .getByTestId('search-input')
+      .fill(tier.responseData.fullyQualifiedName);
+    await page.getByTestId(tier.responseData.fullyQualifiedName).click();
 
-    expect(responseData.ok()).toBeTruthy();
-  }
+    const tierApiResponse = waitForDashboardApiResponses(
+      page,
+      tier.responseData.fullyQualifiedName
+    );
+    await page.getByTestId('update-btn').click();
+    for (const apiRes of tierApiResponse) {
+      const responseData = await apiRes;
 
-  await page.getByRole('button', { name: 'Tag' }).click();
-  await page.getByTestId('search-input').click();
-  await page.getByTestId('search-input').fill(tag.data.name);
-  await page.getByText(tag.responseData.fullyQualifiedName).click();
-  const tagApiResponse = waitForDashboardApiResponses(
-    page,
-    tag.responseData.fullyQualifiedName
-  );
-  await page.getByTestId('update-btn').click();
-  for (const apiRes of tagApiResponse) {
-    const responseData = await apiRes;
+      expect(responseData.ok()).toBeTruthy();
+    }
+  });
 
-    expect(responseData.ok()).toBeTruthy();
-  }
+  await test.step('Filter by Tag', async () => {
+    await page.getByRole('button', { name: 'Tag' }).click();
+    await page.getByTestId('search-input').click();
+    await page.getByTestId('search-input').fill(tag.data.name);
+    await page.getByText(tag.responseData.fullyQualifiedName).click();
 
-  await page.getByRole('button', { name: 'Glossary Term' }).click();
-  await page.getByTestId('search-input').click();
-  const glossaryTermSearchApi = page.waitForResponse(
-    '/api/v1/search/query?*q=*index=glossaryTerm*'
-  );
-  await page.getByTestId('search-input').fill(glossaryTerm.data.name);
-  await glossaryTermSearchApi;
-  await page.getByText(glossaryTerm.responseData.fullyQualifiedName).click();
-  const glossaryTermApiResponse = waitForDashboardApiResponses(
-    page,
-    encodeURIComponent(glossaryTerm.responseData.name)
-  );
-  await page.getByTestId('update-btn').click();
-  for (const apiRes of glossaryTermApiResponse) {
-    const responseData = await apiRes;
+    const tagApiResponse = waitForDashboardApiResponses(
+      page,
+      tag.responseData.fullyQualifiedName
+    );
+    await page.getByTestId('update-btn').click();
+    for (const apiRes of tagApiResponse) {
+      const responseData = await apiRes;
 
-    expect(responseData.ok()).toBeTruthy();
-  }
+      expect(responseData.ok()).toBeTruthy();
+    }
+  });
 
-  await page.getByRole('button', { name: 'Data Product' }).click();
-  await page.getByTestId('search-input').click();
-  const dataProductSearchApi = page.waitForResponse(
-    '/api/v1/search/query?*q=*index=dataProduct*'
-  );
-  await page
-    .getByTestId('search-input')
-    .fill(dataProduct.responseData.displayName ?? dataProduct.data.displayName);
-  await dataProductSearchApi;
-  await page
-    .getByText(
-      dataProduct.responseData.displayName ?? dataProduct.data.displayName
-    )
-    .click();
-  const dataProductApiResponse = waitForDashboardApiResponses(
-    page,
-    encodeURIComponent(dataProduct.data.name)
-  );
-  await page.getByTestId('update-btn').click();
-  for (const apiRes of dataProductApiResponse) {
-    const responseData = await apiRes;
+  await test.step('Filter by Glossary Term', async () => {
+    await page.getByRole('button', { name: 'Glossary Term' }).click();
+    await page.getByTestId('search-input').click();
+    const glossaryTermSearchApi = page.waitForResponse(
+      '/api/v1/search/query?*q=*index=glossaryTerm*'
+    );
+    await page.getByTestId('search-input').fill(glossaryTerm.data.name);
+    await glossaryTermSearchApi;
+    await page.getByText(glossaryTerm.responseData.fullyQualifiedName).click();
 
-    expect(responseData.ok()).toBeTruthy();
-  }
+    const glossaryTermApiResponse = waitForDashboardApiResponses(
+      page,
+      encodeURIComponent(glossaryTerm.responseData.name)
+    );
+    await page.getByTestId('update-btn').click();
+    for (const apiRes of glossaryTermApiResponse) {
+      const responseData = await apiRes;
+
+      expect(responseData.ok()).toBeTruthy();
+    }
+  });
+
+  await test.step('Filter by Data Product', async () => {
+    await page.getByRole('button', { name: 'Data Product' }).click();
+    await page.getByTestId('search-input').click();
+    const dataProductSearchApi = page.waitForResponse(
+      '/api/v1/search/query?*q=*index=dataProduct*'
+    );
+    await page
+      .getByTestId('search-input')
+      .fill(
+        dataProduct.responseData.displayName ?? dataProduct.data.displayName
+      );
+    await dataProductSearchApi;
+    await page
+      .getByText(
+        dataProduct.responseData.displayName ?? dataProduct.data.displayName
+      )
+      .click();
+
+    const dataProductApiResponse = waitForDashboardApiResponses(
+      page,
+      encodeURIComponent(dataProduct.data.name)
+    );
+    await page.getByTestId('update-btn').click();
+    for (const apiRes of dataProductApiResponse) {
+      const responseData = await apiRes;
+
+      expect(responseData.ok()).toBeTruthy();
+    }
+  });
 });
 
 test('Dimension card click should redirect to test cases with applied filters', async ({
@@ -352,12 +372,13 @@ test('Dimension card click should redirect to test cases with applied filters', 
 }) => {
   test.slow();
 
-  await goToDataQualityDashboard(page);
-
-  await page.waitForSelector('[data-testid="status-data-widget"]', {
-    state: 'visible',
+  await test.step('Navigate to Data Quality dashboard', async () => {
+    await goToDataQualityDashboard(page);
+    await expect(
+      page.locator('[data-testid="status-data-widget"]').first()
+    ).toBeVisible();
+    await waitForAllLoadersToDisappear(page);
   });
-  await waitForAllLoadersToDisappear(page);
 
   const dimensions = [
     { displayText: 'Accuracy', urlValue: 'Accuracy' },
@@ -371,60 +392,63 @@ test('Dimension card click should redirect to test cases with applied filters', 
   ];
 
   for (const dimension of dimensions) {
-    const currentUrl = page.url();
-    if (!currentUrl.includes('/data-quality/dashboard')) {
-      await goToDataQualityDashboard(page);
-      await page.waitForSelector('[data-testid="status-data-widget"]', {
-        state: 'visible',
-      });
-      await waitForAllLoadersToDisappear(page);
-    }
+    await test.step(`Click ${dimension.displayText} dimension card and verify redirect`, async () => {
+      if (!page.url().includes('/data-quality/dashboard')) {
+        await goToDataQualityDashboard(page);
+        await expect(
+          page.locator('[data-testid="status-data-widget"]').first()
+        ).toBeVisible();
+        await waitForAllLoadersToDisappear(page);
+      }
 
-    const dimensionCard = page
-      .locator('[data-testid="status-data-widget"]')
-      .filter({ hasText: dimension.displayText })
-      .first();
+      const dimensionCard = page
+        .locator('[data-testid="status-data-widget"]')
+        .filter({ hasText: dimension.displayText })
+        .first();
 
-    const cardCount = await dimensionCard.count();
-    if (cardCount > 0) {
-      await expect(dimensionCard).toBeVisible();
+      const cardCount = await dimensionCard.count();
+      if (cardCount > 0) {
+        await expect(dimensionCard).toBeVisible();
 
-      const navigationPromise = page.waitForURL(
-        new RegExp(
-          `/data-quality/test-cases.*dataQualityDimension=${encodeURIComponent(
-            dimension.urlValue
-          )}`
-        )
-      );
-      await dimensionCard.click();
-      await navigationPromise;
+        const navigationPromise = page.waitForURL(
+          new RegExp(
+            `/data-quality/test-cases.*dataQualityDimension=${encodeURIComponent(
+              dimension.urlValue
+            )}`
+          )
+        );
+        await dimensionCard.click();
+        await navigationPromise;
 
-      const url = page.url();
-
-      expect(url).toContain(
-        `dataQualityDimension=${encodeURIComponent(dimension.urlValue)}`
-      );
-      expect(url).toContain('/data-quality/test-cases');
-    }
+        expect(page.url()).toContain(
+          `dataQualityDimension=${encodeURIComponent(dimension.urlValue)}`
+        );
+        expect(page.url()).toContain('/data-quality/test-cases');
+      }
+    });
   }
 });
 
 test('Entity Health pie chart segment click redirects to Test Cases with correct status', async ({
   page,
 }) => {
-  await goToDataQualityDashboard(page);
-  await expect(
-    page.locator(`#${ENTITY_HEALTH_PIE_CHART_TEST_ID}`)
-  ).toBeVisible();
-  await waitForAllLoadersToDisappear(page);
+  await test.step('Navigate to Data Quality dashboard', async () => {
+    await goToDataQualityDashboard(page);
+    await expect(
+      page.locator(`#${ENTITY_HEALTH_PIE_CHART_TEST_ID}`)
+    ).toBeVisible();
+    await waitForAllLoadersToDisappear(page);
+  });
 
-  const navFailed = page.waitForURL(
-    /\/data-quality\/test-cases.*testCaseStatus=Failed/
-  );
-  await clickPieChartSegmentByIndex(page, ENTITY_HEALTH_PIE_CHART_TEST_ID, 1);
-  await navFailed;
-  await expect(page).toHaveURL(/\/data-quality\/test-cases/);
-  expect(page.url()).toContain('testCaseStatus=Failed');
+  await test.step('Click failed segment and verify redirect to failed test cases', async () => {
+    const navFailed = page.waitForURL(
+      /\/data-quality\/test-cases.*testCaseStatus=Failed/
+    );
+    await clickPieChartSegmentByIndex(page, ENTITY_HEALTH_PIE_CHART_TEST_ID, 1);
+    await navFailed;
+    await expect(page).toHaveURL(/\/data-quality\/test-cases/);
+    expect(page.url()).toContain('testCaseStatus=Failed');
+  });
 });
 
 test('Test Case Result pie chart segment click redirects to Test Cases with correct status', async ({
@@ -432,59 +456,71 @@ test('Test Case Result pie chart segment click redirects to Test Cases with corr
 }) => {
   test.slow();
 
-  await goToDataQualityDashboard(page);
-  await expect(
-    page.locator(`#${TEST_CASE_STATUS_PIE_CHART_TEST_ID}`)
-  ).toBeVisible();
-  await waitForAllLoadersToDisappear(page);
+  await test.step('Navigate to Data Quality dashboard', async () => {
+    await goToDataQualityDashboard(page);
+    await expect(
+      page.locator(`#${TEST_CASE_STATUS_PIE_CHART_TEST_ID}`)
+    ).toBeVisible();
+    await waitForAllLoadersToDisappear(page);
+  });
 
-  const navSuccess = page.waitForURL(
-    /\/data-quality\/test-cases.*testCaseStatus=Success/
-  );
-  await clickPieChartSegmentByIndex(
-    page,
-    TEST_CASE_STATUS_PIE_CHART_TEST_ID,
-    0
-  );
-  await navSuccess;
-  await expect(page).toHaveURL(/\/data-quality\/test-cases/);
-  expect(page.url()).toContain('testCaseStatus=Success');
+  await test.step('Click success segment and verify redirect', async () => {
+    const navSuccess = page.waitForURL(
+      /\/data-quality\/test-cases.*testCaseStatus=Success/
+    );
+    await clickPieChartSegmentByIndex(
+      page,
+      TEST_CASE_STATUS_PIE_CHART_TEST_ID,
+      0
+    );
+    await navSuccess;
+    await expect(page).toHaveURL(/\/data-quality\/test-cases/);
+    expect(page.url()).toContain('testCaseStatus=Success');
+  });
 
-  await goToDataQualityDashboard(page);
-  await expect(
-    page.locator(`#${TEST_CASE_STATUS_PIE_CHART_TEST_ID}`)
-  ).toBeVisible();
-  await waitForAllLoadersToDisappear(page);
+  await test.step('Navigate back to Data Quality dashboard', async () => {
+    await goToDataQualityDashboard(page);
+    await expect(
+      page.locator(`#${TEST_CASE_STATUS_PIE_CHART_TEST_ID}`)
+    ).toBeVisible();
+    await waitForAllLoadersToDisappear(page);
+  });
 
-  const navFailed = page.waitForURL(
-    /\/data-quality\/test-cases.*testCaseStatus=Failed/
-  );
-  await clickPieChartSegmentByIndex(
-    page,
-    TEST_CASE_STATUS_PIE_CHART_TEST_ID,
-    1
-  );
-  await navFailed;
-  await expect(page).toHaveURL(/\/data-quality\/test-cases/);
-  expect(page.url()).toContain('testCaseStatus=Failed');
+  await test.step('Click failed segment and verify redirect', async () => {
+    const navFailed = page.waitForURL(
+      /\/data-quality\/test-cases.*testCaseStatus=Failed/
+    );
+    await clickPieChartSegmentByIndex(
+      page,
+      TEST_CASE_STATUS_PIE_CHART_TEST_ID,
+      1
+    );
+    await navFailed;
+    await expect(page).toHaveURL(/\/data-quality\/test-cases/);
+    expect(page.url()).toContain('testCaseStatus=Failed');
+  });
 
-  await goToDataQualityDashboard(page);
-  await expect(
-    page.locator(`#${TEST_CASE_STATUS_PIE_CHART_TEST_ID}`)
-  ).toBeVisible();
-  await waitForAllLoadersToDisappear(page);
+  await test.step('Navigate back to Data Quality dashboard', async () => {
+    await goToDataQualityDashboard(page);
+    await expect(
+      page.locator(`#${TEST_CASE_STATUS_PIE_CHART_TEST_ID}`)
+    ).toBeVisible();
+    await waitForAllLoadersToDisappear(page);
+  });
 
-  const navAborted = page.waitForURL(
-    /\/data-quality\/test-cases.*testCaseStatus=Aborted/
-  );
-  await clickPieChartSegmentByIndex(
-    page,
-    TEST_CASE_STATUS_PIE_CHART_TEST_ID,
-    2
-  );
-  await navAborted;
-  await expect(page).toHaveURL(/\/data-quality\/test-cases/);
-  expect(page.url()).toContain('testCaseStatus=Aborted');
+  await test.step('Click aborted segment and verify redirect', async () => {
+    const navAborted = page.waitForURL(
+      /\/data-quality\/test-cases.*testCaseStatus=Aborted/
+    );
+    await clickPieChartSegmentByIndex(
+      page,
+      TEST_CASE_STATUS_PIE_CHART_TEST_ID,
+      2
+    );
+    await navAborted;
+    await expect(page).toHaveURL(/\/data-quality\/test-cases/);
+    expect(page.url()).toContain('testCaseStatus=Aborted');
+  });
 });
 
 test('Data Assets Coverage pie chart segment click redirects to Test Suites and Explore', async ({
@@ -492,33 +528,41 @@ test('Data Assets Coverage pie chart segment click redirects to Test Suites and 
 }) => {
   test.slow();
 
-  await goToDataQualityDashboard(page);
-  await expect(
-    page.locator(`#${DATA_ASSETS_COVERAGE_PIE_CHART_TEST_ID}`)
-  ).toBeVisible();
-  await waitForAllLoadersToDisappear(page);
+  await test.step('Navigate to Data Quality dashboard', async () => {
+    await goToDataQualityDashboard(page);
+    await expect(
+      page.locator(`#${DATA_ASSETS_COVERAGE_PIE_CHART_TEST_ID}`)
+    ).toBeVisible();
+    await waitForAllLoadersToDisappear(page);
+  });
 
-  const navTestSuites = page.waitForURL(/\/data-quality\/test-suites/);
-  await clickPieChartSegmentByIndex(
-    page,
-    DATA_ASSETS_COVERAGE_PIE_CHART_TEST_ID,
-    0
-  );
-  await navTestSuites;
-  await expect(page).toHaveURL(/\/data-quality\/test-suites/);
+  await test.step('Click covered segment and verify redirect to Test Suites', async () => {
+    const navTestSuites = page.waitForURL(/\/data-quality\/test-suites/);
+    await clickPieChartSegmentByIndex(
+      page,
+      DATA_ASSETS_COVERAGE_PIE_CHART_TEST_ID,
+      0
+    );
+    await navTestSuites;
+    await expect(page).toHaveURL(/\/data-quality\/test-suites/);
+  });
 
-  await goToDataQualityDashboard(page);
-  await expect(
-    page.locator(`#${DATA_ASSETS_COVERAGE_PIE_CHART_TEST_ID}`)
-  ).toBeVisible();
-  await waitForAllLoadersToDisappear(page);
+  await test.step('Navigate back to Data Quality dashboard', async () => {
+    await goToDataQualityDashboard(page);
+    await expect(
+      page.locator(`#${DATA_ASSETS_COVERAGE_PIE_CHART_TEST_ID}`)
+    ).toBeVisible();
+    await waitForAllLoadersToDisappear(page);
+  });
 
-  const navExplore = page.waitForURL(/\/explore/);
-  await clickPieChartSegmentByIndex(
-    page,
-    DATA_ASSETS_COVERAGE_PIE_CHART_TEST_ID,
-    1
-  );
-  await navExplore;
-  await expect(page).toHaveURL(/\/explore/);
+  await test.step('Click not covered segment and verify redirect to Explore', async () => {
+    const navExplore = page.waitForURL(/\/explore/);
+    await clickPieChartSegmentByIndex(
+      page,
+      DATA_ASSETS_COVERAGE_PIE_CHART_TEST_ID,
+      1
+    );
+    await navExplore;
+    await expect(page).toHaveURL(/\/explore/);
+  });
 });

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/sidebar.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/sidebar.ts
@@ -30,6 +30,7 @@ export const clickOnLogo = async (page: Page) => {
 export const sidebarClick = async (page: Page, id: string) => {
   const items = SIDEBAR_LIST_ITEMS[id as keyof typeof SIDEBAR_LIST_ITEMS];
   if (items) {
+    await page.mouse.move(0, 0); // Dismiss any open tooltips before interacting with sidebar
     await page.hover('[data-testid="left-sidebar"]');
     await page.click(`[data-testid="${items[0]}"]`);
 


### PR DESCRIPTION
## Summary

- Fix strict mode violation: `[data-testid="status-data-widget"]` resolved to 8 elements — replace `.waitFor()` with `expect().toBeVisible()` on `.first()` to avoid strict mode error
- Fix tooltip intercept: `Data Consumer` badge was floating over the sidebar during `sidebarClick`, causing `page.hover` to time out — add `page.mouse.move(0, 0)` before hover to dismiss open tooltips
- Wrap all test bodies in `test.step()` for better readability and granular failure reporting in Playwright trace viewer

## Root Cause

Two separate failures in `DataQualityDashboard.spec.ts > Dimension card click should redirect to test cases with applied filters`:

1. `locator.waitFor()` enforces strict mode (exactly 1 match) — the dimension cards section renders 8 `[data-testid="status-data-widget"]` elements
2. A user tooltip triggered by a previous interaction was floating over the sidebar, intercepting pointer events when `sidebarClick` tried to hover `[data-testid="left-sidebar"]`

## Test Plan

- [ ] `DataQualityDashboard.spec.ts > Dimension card click should redirect to test cases with applied filters` passes
- [ ] No regressions in other DataQuality dashboard tests

Fixes https://github.com/open-metadata/openmetadata-collate/issues/4132