### PR TITLE
Fixes #28229: cascade Table certification PATCH to child search docs

### DIFF
--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/TableCertificationPropagationIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/TableCertificationPropagationIT.java
@@ -54,7 +54,7 @@ import org.openmetadata.sdk.client.OpenMetadataClient;
  * {@code false} on a cert-only ChangeDescription, the cascade never fires, and the Data Quality
  * dashboard's Certification filter keeps returning the stale cert until a full reindex.
  */
-@Execution(ExecutionMode.SAME_THREAD)
+@Execution(ExecutionMode.CONCURRENT)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class TableCertificationPropagationIT {
 

--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/TableCertificationPropagationIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/TableCertificationPropagationIT.java
@@ -1,0 +1,205 @@
+/*
+ *  Copyright 2026 Collate
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.openmetadata.it.tests;
+
+import static org.awaitility.Awaitility.await;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.openmetadata.it.bootstrap.SharedEntities;
+import org.openmetadata.it.util.SdkClients;
+import org.openmetadata.schema.api.data.CreateDatabase;
+import org.openmetadata.schema.api.data.CreateDatabaseSchema;
+import org.openmetadata.schema.api.data.CreateTable;
+import org.openmetadata.schema.api.tests.CreateTestCase;
+import org.openmetadata.schema.entity.data.Database;
+import org.openmetadata.schema.entity.data.DatabaseSchema;
+import org.openmetadata.schema.entity.data.Table;
+import org.openmetadata.schema.tests.TestCase;
+import org.openmetadata.schema.tests.TestCaseParameterValue;
+import org.openmetadata.schema.type.AssetCertification;
+import org.openmetadata.schema.type.Column;
+import org.openmetadata.schema.type.ColumnDataType;
+import org.openmetadata.schema.type.TagLabel;
+import org.openmetadata.sdk.client.OpenMetadataClient;
+
+/**
+ * Regression for the Table certification cascade bug (issue #28229). When a Table's certification
+ * is added, changed, or removed via PATCH, the existing {@code cascadeCertificationToChildren} path
+ * in {@code SearchRepository} must propagate the new cert onto every denormalized child search doc
+ * (test_case, test_case_result, test_case_resolution_status, test_suite).
+ *
+ * <p>Without the fix on {@code TableRepository.getSearchPropagationDescriptors}, the
+ * {@code requiresPropagation} gate in {@code SearchRepository.updateEntityIndex} returns
+ * {@code false} on a cert-only ChangeDescription, the cascade never fires, and the Data Quality
+ * dashboard's Certification filter keeps returning the stale cert until a full reindex.
+ */
+@Execution(ExecutionMode.SAME_THREAD)
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class TableCertificationPropagationIT {
+
+  private static final ObjectMapper MAPPER = new ObjectMapper();
+  private static final String CERTIFICATION_GOLD = "Certification.Gold";
+  private static final String CERTIFICATION_SILVER = "Certification.Silver";
+  private static final Duration AWAIT_TIMEOUT = Duration.ofMinutes(1);
+  private static final Duration POLL_INTERVAL = Duration.ofSeconds(2);
+
+  @Test
+  void certChangeOnTable_cascadesToTestCaseSearchDoc() throws Exception {
+    OpenMetadataClient client = SdkClients.adminClient();
+    long ts = System.currentTimeMillis();
+    Database database = null;
+    try {
+      database =
+          client
+              .databases()
+              .create(
+                  new CreateDatabase()
+                      .withName("cert_prop_db_" + ts)
+                      .withService(SharedEntities.get().MYSQL_SERVICE.getFullyQualifiedName()));
+      DatabaseSchema schema =
+          client
+              .databaseSchemas()
+              .create(
+                  new CreateDatabaseSchema()
+                      .withName("cert_prop_schema_" + ts)
+                      .withDatabase(database.getFullyQualifiedName()));
+      Table table =
+          client
+              .tables()
+              .create(
+                  new CreateTable()
+                      .withName("cert_prop_table_" + ts)
+                      .withDatabaseSchema(schema.getFullyQualifiedName())
+                      .withColumns(
+                          List.of(
+                              new Column().withName("id").withDataType(ColumnDataType.BIGINT))));
+
+      long now = System.currentTimeMillis();
+      long expiry = now + Duration.ofDays(30).toMillis();
+      table.setCertification(buildCertification(CERTIFICATION_GOLD, now, expiry));
+      client.tables().update(table.getId().toString(), table);
+
+      TestCase testCase =
+          client
+              .testCases()
+              .create(
+                  new CreateTestCase()
+                      .withName("cert_prop_tc_" + ts)
+                      .withEntityLink("<#E::table::" + table.getFullyQualifiedName() + ">")
+                      .withTestDefinition("tableRowCountToEqual")
+                      .withParameterValues(
+                          List.of(
+                              new TestCaseParameterValue().withName("value").withValue("100"))));
+
+      awaitTestCaseCertification(client, testCase.getFullyQualifiedName(), CERTIFICATION_GOLD);
+
+      table = client.tables().get(table.getId().toString(), "certification");
+      table.setCertification(buildCertification(CERTIFICATION_SILVER, now, expiry));
+      client.tables().update(table.getId().toString(), table);
+
+      awaitTestCaseCertification(client, testCase.getFullyQualifiedName(), CERTIFICATION_SILVER);
+
+      table = client.tables().get(table.getId().toString(), "certification");
+      table.setCertification(null);
+      client.tables().update(table.getId().toString(), table);
+
+      awaitTestCaseCertificationAbsent(client, testCase.getFullyQualifiedName());
+    } finally {
+      if (database != null) {
+        try {
+          client
+              .databases()
+              .delete(
+                  database.getId().toString(), Map.of("hardDelete", "true", "recursive", "true"));
+        } catch (Exception ignored) {
+          // best-effort cleanup; assertion failures take precedence
+        }
+      }
+    }
+  }
+
+  private static void awaitTestCaseCertification(
+      OpenMetadataClient client, String testCaseFqn, String expectedFqn) {
+    await("test_case_search_index reflects cert " + expectedFqn + " for " + testCaseFqn)
+        .atMost(AWAIT_TIMEOUT)
+        .pollInterval(POLL_INTERVAL)
+        .ignoreExceptions()
+        .untilAsserted(
+            () -> {
+              JsonNode src = fetchTestCaseSource(client, testCaseFqn);
+              JsonNode certFqn = src.path("certification").path("tagLabel").path("tagFQN");
+              assertEquals(
+                  expectedFqn,
+                  certFqn.asText(),
+                  () ->
+                      "test_case search doc certification mismatch; cert was: "
+                          + src.path("certification"));
+            });
+  }
+
+  private static void awaitTestCaseCertificationAbsent(
+      OpenMetadataClient client, String testCaseFqn) {
+    await("test_case_search_index has no certification for " + testCaseFqn)
+        .atMost(AWAIT_TIMEOUT)
+        .pollInterval(POLL_INTERVAL)
+        .ignoreExceptions()
+        .untilAsserted(
+            () -> {
+              JsonNode src = fetchTestCaseSource(client, testCaseFqn);
+              JsonNode cert = src.path("certification");
+              assertTrue(
+                  cert.isMissingNode() || cert.isNull(),
+                  () -> "test_case search doc still carries certification: " + cert);
+            });
+  }
+
+  private static JsonNode fetchTestCaseSource(OpenMetadataClient client, String testCaseFqn)
+      throws Exception {
+    String rawJson =
+        client
+            .search()
+            .query("fullyQualifiedName.keyword:\"" + testCaseFqn + "\"")
+            .index("test_case_search_index")
+            .size(1)
+            .execute();
+    JsonNode root = MAPPER.readTree(rawJson);
+    JsonNode hits = root.path("hits").path("hits");
+    assertNotNull(hits, "search response missing hits");
+    assertTrue(
+        hits.isArray() && hits.size() > 0,
+        () -> "test case " + testCaseFqn + " not yet indexed; raw=" + rawJson);
+    return hits.get(0).path("_source");
+  }
+
+  private static AssetCertification buildCertification(String fqn, long appliedDate, long expiry) {
+    return new AssetCertification()
+        .withTagLabel(
+            new TagLabel()
+                .withTagFQN(fqn)
+                .withSource(TagLabel.TagSource.CLASSIFICATION)
+                .withLabelType(TagLabel.LabelType.MANUAL))
+        .withAppliedDate(appliedDate)
+        .withExpiryDate(expiry);
+  }
+}

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/TableRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/TableRepository.java
@@ -24,6 +24,7 @@ import static org.openmetadata.csv.CsvUtil.addTagLabels;
 import static org.openmetadata.schema.type.Include.ALL;
 import static org.openmetadata.schema.type.Include.NON_DELETED;
 import static org.openmetadata.service.Entity.DATABASE_SCHEMA;
+import static org.openmetadata.service.Entity.FIELD_CERTIFICATION;
 import static org.openmetadata.service.Entity.FIELD_DATA_PRODUCTS;
 import static org.openmetadata.service.Entity.FIELD_OWNERS;
 import static org.openmetadata.service.Entity.FIELD_TAGS;
@@ -1724,6 +1725,13 @@ public class TableRepository extends EntityRepository<Table> {
             FIELD_DATA_PRODUCTS,
             PropagationDescriptor.PropagationType.ENTITY_REFERENCE_LIST,
             null));
+    // Required so SearchRepository.requiresPropagation opens the gate on a cert-only PATCH;
+    // the actual cascade onto child docs (test_case, test_case_result, test_case_resolution_status,
+    // test_suite, column) is handled by SearchRepository.cascadeCertificationToChildren, not by
+    // the generic descriptor-driven script.
+    descriptors.add(
+        new PropagationDescriptor(
+            FIELD_CERTIFICATION, PropagationDescriptor.PropagationType.EXTERNAL_HANDLER, null));
     return descriptors;
   }
 

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/PropagationDescriptor.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/PropagationDescriptor.java
@@ -11,6 +11,12 @@ public record PropagationDescriptor(
     TAG_LABEL_LIST,
     NESTED_FIELD,
     SIMPLE_VALUE,
-    RAW_REPLACE
+    RAW_REPLACE,
+    // Field is gated for propagation but the actual cascade is driven by a dedicated handler
+    // in SearchRepository (e.g. propagateCertificationTags / cascadeCertificationToChildren),
+    // because the generic descriptor-driven scripts can't express its semantics — cert, for
+    // example, needs full-object replace on add/update and explicit removal on delete, which
+    // RAW_REPLACE can't do (RAW_REPLACE restores the old value on delete).
+    EXTERNAL_HANDLER
   }
 }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/SearchRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/SearchRepository.java
@@ -2062,6 +2062,9 @@ public class SearchRepository {
         script.append(
             String.format("ctx._source.%s = params.%s", field.getName(), field.getName()));
       }
+      case EXTERNAL_HANDLER -> {
+        // No-op: a dedicated handler (e.g. propagateCertificationTags) drives the cascade.
+      }
     }
     script.append(" ");
   }
@@ -2112,6 +2115,9 @@ public class SearchRepository {
         data.put(field.getName(), field.getOldValue());
         script.append(
             String.format("ctx._source.%s = params.%s", field.getName(), field.getName()));
+      }
+      case EXTERNAL_HANDLER -> {
+        // No-op: a dedicated handler (e.g. propagateCertificationTags) drives the cascade.
       }
     }
     script.append(" ");
@@ -2175,6 +2181,9 @@ public class SearchRepository {
         data.put(field.getName(), field.getNewValue());
         script.append(
             String.format("ctx._source.%s = params.%s", field.getName(), field.getName()));
+      }
+      case EXTERNAL_HANDLER -> {
+        // No-op: a dedicated handler (e.g. propagateCertificationTags) drives the cascade.
       }
     }
     script.append(" ");

--- a/openmetadata-service/src/test/java/org/openmetadata/service/search/SearchRepositoryBehaviorTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/search/SearchRepositoryBehaviorTest.java
@@ -297,6 +297,9 @@ class SearchRepositoryBehaviorTest {
               Entity.FIELD_DATA_PRODUCTS,
               PropagationDescriptor.PropagationType.ENTITY_REFERENCE_LIST,
               null));
+      descriptors.add(
+          new PropagationDescriptor(
+              "certification", PropagationDescriptor.PropagationType.EXTERNAL_HANDLER, null));
     } else if (Entity.GLOSSARY_TERM.equals(entityType)) {
       descriptors.add(
           new PropagationDescriptor(
@@ -1806,6 +1809,52 @@ class SearchRepositoryBehaviorTest {
                 List.of()),
             Entity.TAG,
             tag));
+  }
+
+  @Test
+  void requiresPropagationReturnsTrueForTableCertificationUpdate() throws Exception {
+    // Regression for issue #28229: a cert-only PATCH on a Table must open the propagation gate
+    // so cascadeCertificationToChildren can push the new cert onto every denormalized child doc
+    // (test_case, test_case_result, test_case_resolution_status, test_suite, column).
+    EntityInterface table = mockEntity(Entity.TABLE, UUID.randomUUID(), "orders");
+    assertTrue(
+        invokeRequiresPropagation(
+            changeDescription(
+                List.of(),
+                List.of(
+                    new FieldChange()
+                        .withName("certification")
+                        .withOldValue("{}")
+                        .withNewValue("{}")),
+                List.of()),
+            Entity.TABLE,
+            table));
+  }
+
+  @Test
+  void requiresPropagationReturnsTrueForTableCertificationAdded() throws Exception {
+    EntityInterface table = mockEntity(Entity.TABLE, UUID.randomUUID(), "orders");
+    assertTrue(
+        invokeRequiresPropagation(
+            changeDescription(
+                List.of(new FieldChange().withName("certification").withNewValue("{}")),
+                List.of(),
+                List.of()),
+            Entity.TABLE,
+            table));
+  }
+
+  @Test
+  void requiresPropagationReturnsTrueForTableCertificationRemoved() throws Exception {
+    EntityInterface table = mockEntity(Entity.TABLE, UUID.randomUUID(), "orders");
+    assertTrue(
+        invokeRequiresPropagation(
+            changeDescription(
+                List.of(),
+                List.of(),
+                List.of(new FieldChange().withName("certification").withOldValue("{}"))),
+            Entity.TABLE,
+            table));
   }
 
   @Test


### PR DESCRIPTION
### Describe your changes:

Fixes #28229

When a Table's certification is added, changed, or removed via PATCH, the existing `cascadeCertificationToChildren` path never fires because `SearchRepository.requiresPropagation` returns `false` on a cert-only `ChangeDescription` — `TableRepository.getSearchPropagationDescriptors()` never listed `certification`. The DQ dashboard's Certification filter therefore kept returning the stale cert on `test_case`, `test_case_result`, `test_case_resolution_status`, `test_suite`, and `column` docs until a full reindex.

This PR adds an `EXTERNAL_HANDLER` `PropagationType` for fields whose cascade is driven by a dedicated `SearchRepository` handler rather than the generic descriptor-driven script (cert needs full-object replace on add/update and explicit removal on delete, which `RAW_REPLACE` can't express — it restores the old value on delete), registers `certification` with this type on `TableRepository`, and adds no-op cases in the three `appendAdd/Update/DeleteScript` switches.

#
### Type of change:
- [x] Bug fix

#
### High-level design:

N/A — small change.

#
### Tests:

#### Use cases covered
- Cert added on a Table → `test_case` search doc inherits the cert (already worked at index time).
- Cert PATCHed Gold → Silver on a Table → child `test_case` search doc reflects Silver within the await window.
- Cert removed on a Table → child `test_case` search doc loses the cert.

#### Unit tests
- [x] Added unit tests for the new/changed logic.
- Files updated: `openmetadata-service/src/test/java/org/openmetadata/service/search/SearchRepositoryBehaviorTest.java` — three new tests (`requiresPropagationReturnsTrueForTableCertification{Update,Added,Removed}`) and updated mock descriptors to mirror production.

#### Backend integration tests
- [x] Added integration tests in `openmetadata-integration-tests/` for the cascade behavior.
- Files added: `openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/TableCertificationPropagationIT.java`. The IT fails on `main` (`expected: <Certification.Silver> but was: <Certification.Gold>`) and passes after this fix.

#### Ingestion integration tests
- [x] Not applicable (no ingestion changes).

#### Playwright (UI) tests
- [x] Not applicable (no UI changes).

#### Manual testing performed
Ran `mvn test -pl openmetadata-service -Dtest=SearchRepositoryBehaviorTest` (108/108 pass) and `mvn test -pl openmetadata-integration-tests -Dtest=TableCertificationPropagationIT` (passes after fix; fails on `main` HEAD).

#
### UI screen recording / screenshots:

Not applicable.

#
### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] My PR title is `Fixes <issue-number>: <short explanation>`
- [x] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have added tests (unit / integration / Playwright as applicable) and listed them above.
- [x] I have added a test that covers the exact scenario we are fixing.