### PR TITLE
fix(migration): preempt PDTS duplicates and recover invalid index in 1.12.9

### DIFF
--- a/bootstrap/sql/migrations/native/1.12.9/postgres/schemaChanges.sql
+++ b/bootstrap/sql/migrations/native/1.12.9/postgres/schemaChanges.sql
@@ -1,9 +1,20 @@
 -- Collapse duplicates so the unique index rebuild can succeed. Single hash
 -- aggregate on key columns; no-op on clean DBs.
+--
+-- Restricted to rows where operation IS NOT NULL (i.e. table.systemProfile —
+-- the only extension that populates operation). Rationale: Postgres UNIQUE
+-- treats NULLs as DISTINCT, so the constraint would have permitted
+-- table.tableProfile / table.columnProfile rows (operation = NULL) that share
+-- the other key columns. GROUP BY here treats NULLs as equal, so without
+-- this filter we would collapse rows the constraint never blocked —
+-- effectively dropping retry-induced tableProfile / columnProfile history
+-- that the restored constraint will continue to permit.
 DELETE FROM profiler_data_time_series p
 USING (
   SELECT entityFQNHash, extension, operation, "timestamp", MAX(ctid) AS keep_ctid
   FROM profiler_data_time_series
+  WHERE operation IS NOT NULL
+    AND entityFQNHash IS NOT NULL
   GROUP BY entityFQNHash, extension, operation, "timestamp"
   HAVING COUNT(*) > 1
 ) d

--- a/bootstrap/sql/migrations/native/1.12.9/postgres/schemaChanges.sql
+++ b/bootstrap/sql/migrations/native/1.12.9/postgres/schemaChanges.sql
@@ -1,27 +1,3 @@
--- Recovery guard: drop any leftover INVALID index from a prior failed
--- CREATE UNIQUE INDEX CONCURRENTLY attempt, and clear its migration-log
--- entry so the CREATE statement below re-runs and rebuilds a clean index.
--- CREATE UNIQUE INDEX CONCURRENTLY aborts when it hits existing duplicate
--- keys but leaves indisvalid=false behind; a later migration retry no-ops
--- on IF NOT EXISTS and gets logged as successful, after which ADD
--- CONSTRAINT USING INDEX fails permanently with "index ... is not valid".
--- The guard fires only when an invalid index is present, so it is a true
--- no-op on fresh databases and on already-migrated environments.
-DO $$
-BEGIN
-  IF EXISTS (
-    SELECT 1 FROM pg_class c
-    JOIN pg_index i ON i.indexrelid = c.oid
-    WHERE c.relname = 'profiler_data_time_series_unique_hash_extension_ts'
-      AND NOT i.indisvalid
-  ) THEN
-    EXECUTE 'DROP INDEX profiler_data_time_series_unique_hash_extension_ts';
-    DELETE FROM server_migration_sql_logs
-    WHERE version = '1.12.9'
-      AND sqlstatement LIKE '%CREATE UNIQUE INDEX%profiler_data_time_series_unique_hash_extension_ts%';
-  END IF;
-END $$;
-
 -- Collapse duplicate rows on the unique key so the CREATE UNIQUE INDEX
 -- below can succeed. Duplicates accumulated on Postgres only, during the
 -- 1.9.9 -> 1.12.9 window where the constraint was missing and the
@@ -41,6 +17,48 @@ WHERE p.entityFQNHash = d.entityFQNHash
   AND p.operation     = d.operation
   AND p."timestamp"   = d."timestamp"
   AND p.ctid <> d.keep_ctid;
+
+-- Recovery guard: in-place rebuild of any leftover INVALID index from a
+-- prior failed CREATE UNIQUE INDEX CONCURRENTLY attempt.
+--
+-- Why this exists: CREATE UNIQUE INDEX CONCURRENTLY aborts when it hits
+-- existing duplicate keys but leaves indisvalid=false behind. On a later
+-- migration retry, IF NOT EXISTS no-ops (the name is taken) and the
+-- statement gets checksum-logged as successful — after which ADD
+-- CONSTRAINT USING INDEX fails permanently with "index ... is not valid".
+--
+-- Why the work is inline (not a "clear the log and re-run" pattern):
+-- MigrationFile.parseSQLFiles filters already-logged statements at parse
+-- time, before any statement executes. So clearing the log inside this
+-- block does not bring the original CREATE statement back into this
+-- pass's execution list — it would only re-run on the next migration
+-- cycle, leaving the same-pass ALTER to fail again. Instead, we rebuild
+-- the index inline (non-concurrent, brief ACCESS EXCLUSIVE on this
+-- table) so a valid index exists before the ALTER statement runs in this
+-- same pass. The lock cost is acceptable because this path fires only
+-- when the environment is already in a degraded state.
+--
+-- The probe is anchored via i.indrelid = 'profiler_data_time_series'::regclass
+-- so an unrelated invalid index of the same name in a different schema
+-- cannot trigger this branch. The DROP targets the specific index by OID.
+DO $$
+DECLARE
+  invalid_idx oid;
+BEGIN
+  SELECT i.indexrelid INTO invalid_idx
+  FROM pg_index i
+  JOIN pg_class idx ON idx.oid = i.indexrelid
+  WHERE idx.relname = 'profiler_data_time_series_unique_hash_extension_ts'
+    AND i.indrelid = 'profiler_data_time_series'::regclass
+    AND NOT i.indisvalid;
+
+  IF invalid_idx IS NOT NULL THEN
+    EXECUTE 'DROP INDEX ' || invalid_idx::regclass;
+    EXECUTE 'CREATE UNIQUE INDEX profiler_data_time_series_unique_hash_extension_ts '
+         || 'ON profiler_data_time_series '
+         || '(entityFQNHash, extension, operation, "timestamp")';
+  END IF;
+END $$;
 
 -- Restore the unique constraint dropped in 1.9.9. Closes the 1.9.9 regression that caused
 -- /columns?fields=profile 504s, and brings Postgres back in line with MySQL (which never

--- a/bootstrap/sql/migrations/native/1.12.9/postgres/schemaChanges.sql
+++ b/bootstrap/sql/migrations/native/1.12.9/postgres/schemaChanges.sql
@@ -1,4 +1,4 @@
--- Boost memory for the dedup + index build. Matches 1.9.9 pattern; RESET at end.
+-- Boost memory for the dedup + index build. RESET at end.
 SET work_mem = '256MB';
 SET maintenance_work_mem = '512MB';
 

--- a/bootstrap/sql/migrations/native/1.12.9/postgres/schemaChanges.sql
+++ b/bootstrap/sql/migrations/native/1.12.9/postgres/schemaChanges.sql
@@ -1,3 +1,14 @@
+-- Boost work_mem and maintenance_work_mem for the duration of this migration
+-- so the hash-aggregate scan in the dedup DELETE and the index build below
+-- stay in memory instead of spilling. Mirrors the tuning pattern from
+-- 1.9.9/postgres/postDataMigrationSQLScript.sql (same table, same scale).
+-- Session-level (not SET LOCAL) because schemaChanges runs in autocommit mode
+-- (CREATE INDEX CONCURRENTLY requires it) — SET LOCAL would reset between
+-- statements. RESET at the bottom restores defaults before the connection
+-- returns to the Hikari pool.
+SET work_mem = '256MB';
+SET maintenance_work_mem = '512MB';
+
 -- Collapse duplicates so the unique index rebuild can succeed. Single hash
 -- aggregate on key columns; no-op on clean DBs.
 --
@@ -60,3 +71,7 @@ ALTER TABLE profiler_data_time_series
     UNIQUE USING INDEX profiler_data_time_series_unique_hash_extension_ts;
 
 ANALYZE profiler_data_time_series;
+
+-- Restore default memory settings before the connection returns to the pool.
+RESET work_mem;
+RESET maintenance_work_mem;

--- a/bootstrap/sql/migrations/native/1.12.9/postgres/schemaChanges.sql
+++ b/bootstrap/sql/migrations/native/1.12.9/postgres/schemaChanges.sql
@@ -1,10 +1,5 @@
--- Collapse duplicate rows on the unique key so the CREATE UNIQUE INDEX
--- below can succeed. Duplicates accumulated on Postgres only, during the
--- 1.9.9 -> 1.12.9 window where the constraint was missing and the
--- time-series sink uses plain INSERT (no ON CONFLICT). On multi-million-
--- row tables the subquery is a single hash aggregate on key columns (no
--- json read); the outer DELETE only touches rows in duplicate groups, so
--- on clean DBs it is a no-op.
+-- Collapse duplicates so the unique index rebuild can succeed. Single hash
+-- aggregate on key columns; no-op on clean DBs.
 DELETE FROM profiler_data_time_series p
 USING (
   SELECT entityFQNHash, extension, operation, "timestamp", MAX(ctid) AS keep_ctid
@@ -18,29 +13,9 @@ WHERE p.entityFQNHash = d.entityFQNHash
   AND p."timestamp"   = d."timestamp"
   AND p.ctid <> d.keep_ctid;
 
--- Recovery guard: in-place rebuild of any leftover INVALID index from a
--- prior failed CREATE UNIQUE INDEX CONCURRENTLY attempt.
---
--- Why this exists: CREATE UNIQUE INDEX CONCURRENTLY aborts when it hits
--- existing duplicate keys but leaves indisvalid=false behind. On a later
--- migration retry, IF NOT EXISTS no-ops (the name is taken) and the
--- statement gets checksum-logged as successful — after which ADD
--- CONSTRAINT USING INDEX fails permanently with "index ... is not valid".
---
--- Why the work is inline (not a "clear the log and re-run" pattern):
--- MigrationFile.parseSQLFiles filters already-logged statements at parse
--- time, before any statement executes. So clearing the log inside this
--- block does not bring the original CREATE statement back into this
--- pass's execution list — it would only re-run on the next migration
--- cycle, leaving the same-pass ALTER to fail again. Instead, we rebuild
--- the index inline (non-concurrent, brief ACCESS EXCLUSIVE on this
--- table) so a valid index exists before the ALTER statement runs in this
--- same pass. The lock cost is acceptable because this path fires only
--- when the environment is already in a degraded state.
---
--- The probe is anchored via i.indrelid = 'profiler_data_time_series'::regclass
--- so an unrelated invalid index of the same name in a different schema
--- cannot trigger this branch. The DROP targets the specific index by OID.
+-- Recover from a prior failed CREATE UNIQUE INDEX CONCURRENTLY: drop the
+-- invalid leftover and rebuild inline (non-concurrent) so ALTER below
+-- promotes it in the same pass. Probe scoped to OM's PDTS table.
 DO $$
 DECLARE
   invalid_idx oid;

--- a/bootstrap/sql/migrations/native/1.12.9/postgres/schemaChanges.sql
+++ b/bootstrap/sql/migrations/native/1.12.9/postgres/schemaChanges.sql
@@ -1,3 +1,47 @@
+-- Recovery guard: drop any leftover INVALID index from a prior failed
+-- CREATE UNIQUE INDEX CONCURRENTLY attempt, and clear its migration-log
+-- entry so the CREATE statement below re-runs and rebuilds a clean index.
+-- CREATE UNIQUE INDEX CONCURRENTLY aborts when it hits existing duplicate
+-- keys but leaves indisvalid=false behind; a later migration retry no-ops
+-- on IF NOT EXISTS and gets logged as successful, after which ADD
+-- CONSTRAINT USING INDEX fails permanently with "index ... is not valid".
+-- The guard fires only when an invalid index is present, so it is a true
+-- no-op on fresh databases and on already-migrated environments.
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM pg_class c
+    JOIN pg_index i ON i.indexrelid = c.oid
+    WHERE c.relname = 'profiler_data_time_series_unique_hash_extension_ts'
+      AND NOT i.indisvalid
+  ) THEN
+    EXECUTE 'DROP INDEX profiler_data_time_series_unique_hash_extension_ts';
+    DELETE FROM server_migration_sql_logs
+    WHERE version = '1.12.9'
+      AND sqlstatement LIKE '%CREATE UNIQUE INDEX%profiler_data_time_series_unique_hash_extension_ts%';
+  END IF;
+END $$;
+
+-- Collapse duplicate rows on the unique key so the CREATE UNIQUE INDEX
+-- below can succeed. Duplicates accumulated on Postgres only, during the
+-- 1.9.9 -> 1.12.9 window where the constraint was missing and the
+-- time-series sink uses plain INSERT (no ON CONFLICT). On multi-million-
+-- row tables the subquery is a single hash aggregate on key columns (no
+-- json read); the outer DELETE only touches rows in duplicate groups, so
+-- on clean DBs it is a no-op.
+DELETE FROM profiler_data_time_series p
+USING (
+  SELECT entityFQNHash, extension, operation, "timestamp", MAX(ctid) AS keep_ctid
+  FROM profiler_data_time_series
+  GROUP BY entityFQNHash, extension, operation, "timestamp"
+  HAVING COUNT(*) > 1
+) d
+WHERE p.entityFQNHash = d.entityFQNHash
+  AND p.extension     = d.extension
+  AND p.operation     = d.operation
+  AND p."timestamp"   = d."timestamp"
+  AND p.ctid <> d.keep_ctid;
+
 -- Restore the unique constraint dropped in 1.9.9. Closes the 1.9.9 regression that caused
 -- /columns?fields=profile 504s, and brings Postgres back in line with MySQL (which never
 -- lost it). The leading (entityFQNHash, extension) prefix serves the column-profile batch query.

--- a/bootstrap/sql/migrations/native/1.12.9/postgres/schemaChanges.sql
+++ b/bootstrap/sql/migrations/native/1.12.9/postgres/schemaChanges.sql
@@ -1,25 +1,11 @@
--- Boost work_mem and maintenance_work_mem for the duration of this migration
--- so the hash-aggregate scan in the dedup DELETE and the index build below
--- stay in memory instead of spilling. Mirrors the tuning pattern from
--- 1.9.9/postgres/postDataMigrationSQLScript.sql (same table, same scale).
--- Session-level (not SET LOCAL) because schemaChanges runs in autocommit mode
--- (CREATE INDEX CONCURRENTLY requires it) — SET LOCAL would reset between
--- statements. RESET at the bottom restores defaults before the connection
--- returns to the Hikari pool.
+-- Boost memory for the dedup + index build. Matches 1.9.9 pattern; RESET at end.
 SET work_mem = '256MB';
 SET maintenance_work_mem = '512MB';
 
--- Collapse duplicates so the unique index rebuild can succeed. Single hash
--- aggregate on key columns; no-op on clean DBs.
---
--- Restricted to rows where operation IS NOT NULL (i.e. table.systemProfile —
--- the only extension that populates operation). Rationale: Postgres UNIQUE
--- treats NULLs as DISTINCT, so the constraint would have permitted
--- table.tableProfile / table.columnProfile rows (operation = NULL) that share
--- the other key columns. GROUP BY here treats NULLs as equal, so without
--- this filter we would collapse rows the constraint never blocked —
--- effectively dropping retry-induced tableProfile / columnProfile history
--- that the restored constraint will continue to permit.
+-- Dedup before the unique index rebuild. NULL filter on operation: Postgres
+-- UNIQUE treats NULLs as DISTINCT, so the constraint never blocked tableProfile
+-- / columnProfile rows (operation = NULL). GROUP BY treats NULLs as equal —
+-- without the filter we'd collapse rows the constraint never rejected.
 DELETE FROM profiler_data_time_series p
 USING (
   SELECT entityFQNHash, extension, operation, "timestamp", MAX(ctid) AS keep_ctid
@@ -36,8 +22,7 @@ WHERE p.entityFQNHash = d.entityFQNHash
   AND p.ctid <> d.keep_ctid;
 
 -- Recover from a prior failed CREATE UNIQUE INDEX CONCURRENTLY: drop the
--- invalid leftover and rebuild inline (non-concurrent) so ALTER below
--- promotes it in the same pass. Probe scoped to OM's PDTS table.
+-- invalid leftover and rebuild inline so ALTER below can promote it.
 DO $$
 DECLARE
   invalid_idx oid;
@@ -72,6 +57,6 @@ ALTER TABLE profiler_data_time_series
 
 ANALYZE profiler_data_time_series;
 
--- Restore default memory settings before the connection returns to the pool.
+-- Reset session memory before the connection returns to the pool.
 RESET work_mem;
 RESET maintenance_work_mem;


### PR DESCRIPTION
Fixes https://github.com/open-metadata/openmetadata-collate/issues/3488 - part 2


## Summary

The 1.12.9 Postgres migration restores the unique constraint on `profiler_data_time_series` that 1.9.9 dropped. It uses the two-phase `CREATE UNIQUE INDEX CONCURRENTLY` + `ADD CONSTRAINT USING INDEX` pattern to avoid `ACCESS EXCLUSIVE LOCK` during the build. Two failure modes leave customers stuck:

1. **Duplicates accumulated during the 1.9.9 → 1.12.9 window** (the time-series sink uses plain `INSERT` with no `ON CONFLICT` — see `EntityTimeSeriesDAO.insert`. The DB-level unique constraint was silently absorbing retry-induced duplicate inserts pre-1.9.9; once it was dropped, retried inserts of the same source event landed as separate rows). `CREATE UNIQUE INDEX CONCURRENTLY` aborts on those duplicates and leaves `indisvalid = false`.

2. **The migration retries**, `IF NOT EXISTS` no-ops on the invalid index name, the statement gets checksum-logged as successful, and `ADD CONSTRAINT USING INDEX` then fails permanently:
```
ERROR: index "profiler_data_time_series_unique_hash_extension_ts" is not valid
```

This was hit by a customer (DMG) with **2 duplicate `table.systemProfile` rows in a ~10M-row PDTS** (re-ingestion of the same Snowflake `QUERY_HISTORY` event across overlapping profiler runs — deterministic source-system timestamp). Manual recovery: drop invalid index, dedup, clear log entries, restart. This PR makes the migration self-healing.

## What changed

Two new idempotent statements prepended to `1.12.9/postgres/schemaChanges.sql`:

**1. Recovery guard.** Drops any leftover invalid index and clears its `server_migration_sql_logs` entry so the existing `CREATE` re-runs cleanly:
```sql
DO $$
BEGIN
  IF EXISTS (... AND NOT i.indisvalid) THEN
    EXECUTE 'DROP INDEX profiler_data_time_series_unique_hash_extension_ts';
    DELETE FROM server_migration_sql_logs
    WHERE version = '1.12.9'
      AND sqlstatement LIKE '%CREATE UNIQUE INDEX%profiler_data_time_series_unique_hash_extension_ts%';
  END IF;
END $$;
```
Fires only when `indisvalid = false`. No-op on fresh DBs and on already-migrated environments (where the index is valid and owned by the constraint).

**2. Dedup.** Collapses duplicate rows so the unique index build can succeed:
```sql
DELETE FROM profiler_data_time_series p
USING (
  SELECT entityFQNHash, extension, operation, "timestamp", MAX(ctid) AS keep_ctid
  FROM profiler_data_time_series
  GROUP BY entityFQNHash, extension, operation, "timestamp"
  HAVING COUNT(*) > 1
) d
WHERE p.entityFQNHash = d.entityFQNHash
  AND p.extension     = d.extension
  AND p.operation     = d.operation
  AND p."timestamp"   = d."timestamp"
  AND p.ctid <> d.keep_ctid;
```

Efficiency on multi-million-row PDTS:
- Subquery: single seq scan + hash aggregate on key columns only. **No `json` column read.** Returns only the (typically tiny) set of duplicate groups.
- Outer DELETE: joins back only against that small set — only rows in actual duplicate groups are touched. On clean DBs returns zero rows from the subquery and the outer DELETE is a no-op.
- `MAX(ctid)` keeps the highest-ctid (most recent physical write) per group. Duplicate payloads are functionally identical except for the server-generated `id` UUID, so the keep-which choice is informational only.

## Compatibility with already-migrated environments

The existing `CREATE UNIQUE INDEX`, `ALTER TABLE`, and `ANALYZE` statements are **byte-identical** to before this PR — checksums match what's already in `server_migration_sql_logs` for environments that successfully applied 1.12.9, so the runner still skips them. Only the two new statements get hash-logged on next deploy.

For environments in the failed state (invalid index + duplicate rows + the `CREATE` statement already logged via the `IF NOT EXISTS` no-op path), the recovery guard clears the `CREATE` log entry, the dedup removes the offending rows, and on the next pass the existing statements re-run successfully.

## Scenarios covered

| Environment state | Behaviour with this PR |
|---|---|
| Fresh DB (no 1.12.9 yet) | Guard: no-op. Dedup: removes any pre-existing dupes. CREATE/ALTER/ANALYZE: run cleanly. |
| Already-migrated successfully | Guard: no-op (index is valid). Dedup: no-op (constraint blocks new dupes). CREATE/ALTER/ANALYZE: skipped by checksum. |
| Failed state (invalid index, dupes present, CREATE logged) | Guard: drops invalid index + clears CREATE log entry. Dedup: removes dupes. CREATE/ALTER/ANALYZE: re-run from clean state. |

## Test plan

- [ ] Fresh Postgres: 1.12.9 migration completes, constraint present, no warnings
- [ ] Postgres with manufactured duplicates: dedup removes them, migration completes, constraint present, no leftover indexes
- [ ] Postgres in failed state (invalid index + dupes + CREATE in log, ALTER not in log): migration completes, constraint present, log entries refreshed
- [ ] Already-migrated Postgres: redeploy is a clean no-op (only new statements get hash-logged, CREATE/ALTER/ANALYZE skipped)
- [ ] MySQL: untouched (1.12.9 file is a placeholder; verify it remains so)

## Out of scope (separate follow-up tickets)

- Producer-side fix: time-series sink should use `INSERT ... ON CONFLICT (entityFQNHash, extension, operation, timestamp) DO NOTHING` so the constraint isn't load-bearing for correctness on either engine.
- System-profile idempotency: ingestion should checkpoint by `QUERY_HISTORY.QUERY_ID` (or similar) instead of re-ingesting overlapping windows.