### PR TITLE
test:fix SearchSeparation failure

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/SearchSeparation/ApiEndpoint.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/SearchSeparation/ApiEndpoint.spec.ts
@@ -13,7 +13,7 @@
 
 import { test } from '@playwright/test';
 import { ApiEndpointClass } from '../../../support/entity/ApiEndpointClass';
-import { registerFilterSeparationSuite } from './searchSeparationSuite';
+import { registerFilterSeparationSuite } from './SearchSeparationSuite';
 
 test.use({ storageState: 'playwright/.auth/admin.json' });
 

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/SearchSeparation/Container.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/SearchSeparation/Container.spec.ts
@@ -13,7 +13,7 @@
 
 import { test } from '@playwright/test';
 import { ContainerClass } from '../../../support/entity/ContainerClass';
-import { registerFilterSeparationSuite } from './searchSeparationSuite';
+import { registerFilterSeparationSuite } from './SearchSeparationSuite';
 
 test.use({ storageState: 'playwright/.auth/admin.json' });
 

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/SearchSeparation/Dashboard.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/SearchSeparation/Dashboard.spec.ts
@@ -13,7 +13,7 @@
 
 import { test } from '@playwright/test';
 import { DashboardClass } from '../../../support/entity/DashboardClass';
-import { registerFilterSeparationSuite } from './searchSeparationSuite';
+import { registerFilterSeparationSuite } from './SearchSeparationSuite';
 
 test.use({ storageState: 'playwright/.auth/admin.json' });
 

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/SearchSeparation/Database.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/SearchSeparation/Database.spec.ts
@@ -13,7 +13,7 @@
 
 import { test } from '@playwright/test';
 import { DatabaseClass } from '../../../support/entity/DatabaseClass';
-import { registerFilterSeparationSuite } from './searchSeparationSuite';
+import { registerFilterSeparationSuite } from './SearchSeparationSuite';
 
 test.use({ storageState: 'playwright/.auth/admin.json' });
 

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/SearchSeparation/DatabaseSchema.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/SearchSeparation/DatabaseSchema.spec.ts
@@ -13,7 +13,7 @@
 
 import { test } from '@playwright/test';
 import { DatabaseSchemaClass } from '../../../support/entity/DatabaseSchemaClass';
-import { registerFilterSeparationSuite } from './searchSeparationSuite';
+import { registerFilterSeparationSuite } from './SearchSeparationSuite';
 
 test.use({ storageState: 'playwright/.auth/admin.json' });
 

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/SearchSeparation/ExploreFilterSeparation.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/SearchSeparation/ExploreFilterSeparation.spec.ts
@@ -20,7 +20,7 @@
 
 import { test } from '@playwright/test';
 import { TableClass } from '../../../support/entity/TableClass';
-import { registerFilterSeparationSuite } from './searchSeparationSuite';
+import { registerFilterSeparationSuite } from './SearchSeparationSuite';
 
 test.use({ storageState: 'playwright/.auth/admin.json' });
 

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/SearchSeparation/Metric.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/SearchSeparation/Metric.spec.ts
@@ -13,7 +13,7 @@
 
 import { test } from '@playwright/test';
 import { MetricClass } from '../../../support/entity/MetricClass';
-import { registerFilterSeparationSuite } from './searchSeparationSuite';
+import { registerFilterSeparationSuite } from './SearchSeparationSuite';
 
 test.use({ storageState: 'playwright/.auth/admin.json' });
 

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/SearchSeparation/MlModel.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/SearchSeparation/MlModel.spec.ts
@@ -13,7 +13,7 @@
 
 import { test } from '@playwright/test';
 import { MlModelClass } from '../../../support/entity/MlModelClass';
-import { registerFilterSeparationSuite } from './searchSeparationSuite';
+import { registerFilterSeparationSuite } from './SearchSeparationSuite';
 
 test.use({ storageState: 'playwright/.auth/admin.json' });
 

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/SearchSeparation/Pipeline.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/SearchSeparation/Pipeline.spec.ts
@@ -13,7 +13,7 @@
 
 import { test } from '@playwright/test';
 import { PipelineClass } from '../../../support/entity/PipelineClass';
-import { registerFilterSeparationSuite } from './searchSeparationSuite';
+import { registerFilterSeparationSuite } from './SearchSeparationSuite';
 
 test.use({ storageState: 'playwright/.auth/admin.json' });
 

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/SearchSeparation/SearchSeparationSuite.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/SearchSeparation/SearchSeparationSuite.ts
@@ -40,7 +40,10 @@ import { TagClass } from '../../../support/tag/TagClass';
 import { createAdminApiContext } from '../../../utils/admin';
 import { redirectToHomePage } from '../../../utils/common';
 import { searchAndClickOnOption } from '../../../utils/explore';
-import { checkExploreSearchFilter, waitForAllLoadersToDisappear } from '../../../utils/entity';
+import {
+  checkExploreSearchFilter,
+  waitForAllLoadersToDisappear,
+} from '../../../utils/entity';
 import { sidebarClick } from '../../../utils/sidebar';
 
 const TIER_FQN = 'Tier.Tier1';
@@ -166,12 +169,13 @@ export function registerFilterSeparationSuite(
 
       expect(reindexRes.status()).toBeLessThan(400);
 
-      const { serviceDisplayName } = await assertReindexedDocPreservesSeparation(
-        apiContext,
-        entity,
-        classificationTag,
-        glossaryTerm
-      );
+      const { serviceDisplayName } =
+        await assertReindexedDocPreservesSeparation(
+          apiContext,
+          entity,
+          classificationTag,
+          glossaryTerm
+        );
 
       await afterAction();
       await redirectToHomePage(page);
@@ -379,7 +383,11 @@ async function checkExploreFilterWithServiceBase(
   await page.getByTestId('search-dropdown-Service').click();
   await searchAndClickOnOption(
     page,
-    { label: 'Service', key: 'service.displayName.keyword', value: serviceName },
+    {
+      label: 'Service',
+      key: 'service.displayName.keyword',
+      value: serviceName,
+    },
     true
   );
   await page.click('[data-testid="update-btn"]');
@@ -413,9 +421,7 @@ async function assertAllFourFiltersWork(
 ): Promise<void> {
   const svcData = entity.serviceResponseData;
   const serviceName =
-    serviceDisplayName ||
-    svcData?.displayName ||
-    svcData?.name;
+    serviceDisplayName || svcData?.displayName || svcData?.name;
 
   const filters: Array<{ label: string; key: string; value: string }> = [
     { label: 'Tier', key: 'tier.tagFQN', value: TIER_FQN },

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/SearchSeparation/SearchSeparationSuite.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/SearchSeparation/SearchSeparationSuite.ts
@@ -163,7 +163,7 @@ export function registerFilterSeparationSuite(
 
       await afterAction();
       await redirectToHomePage(page);
-      await assertAllFourFiltersWork(
+      await assertAllFourFiltersWorkWithRetry(
         page,
         entity,
         classificationTag,
@@ -283,12 +283,47 @@ async function assertReindexedDocPreservesSeparation(
     });
 }
 
+async function assertAllFourFiltersWorkWithRetry(
+  page: Page,
+  entity: FilterSeparationEntity,
+  classificationTag: TagClass,
+  glossaryTerm: GlossaryTerm,
+  maxAttempts = 3
+): Promise<void> {
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    try {
+      await assertAllFourFiltersWork(page, entity, classificationTag, glossaryTerm);
+
+      return;
+    } catch (err) {
+      if (attempt === maxAttempts) {
+        throw err;
+      }
+      await new Promise((resolve) => setTimeout(resolve, 8_000));
+    }
+  }
+}
+
 async function assertAllFourFiltersWork(
   page: Page,
   entity: FilterSeparationEntity,
   classificationTag: TagClass,
   glossaryTerm: GlossaryTerm
 ): Promise<void> {
+  const responseData = entity.entityResponseData as Record<string, unknown>;
+  const serviceName = (responseData?.service as { name?: string } | undefined)
+    ?.name;
+
+  if (serviceName) {
+    await checkExploreSearchFilter(
+      page,
+      'Service',
+      'service.displayName.keyword',
+      serviceName,
+      entity
+    );
+  }
+
   await checkExploreSearchFilter(page, 'Tier', 'tier.tagFQN', TIER_FQN, entity);
   await checkExploreSearchFilter(
     page,

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/SearchSeparation/SearchSeparationSuite.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/SearchSeparation/SearchSeparationSuite.ts
@@ -39,11 +39,11 @@ import { ClassificationClass } from '../../../support/tag/ClassificationClass';
 import { TagClass } from '../../../support/tag/TagClass';
 import { createAdminApiContext } from '../../../utils/admin';
 import { redirectToHomePage } from '../../../utils/common';
-import { searchAndClickOnOption } from '../../../utils/explore';
 import {
   checkExploreSearchFilter,
   waitForAllLoadersToDisappear,
 } from '../../../utils/entity';
+import { searchAndClickOnOption } from '../../../utils/explore';
 import { sidebarClick } from '../../../utils/sidebar';
 
 const TIER_FQN = 'Tier.Tier1';

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/SearchSeparation/SearchSeparationSuite.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/SearchSeparation/SearchSeparationSuite.ts
@@ -31,6 +31,7 @@
 
 import { APIRequestContext, expect, Page, test } from '@playwright/test';
 import { Operation } from 'fast-json-patch';
+import { SidebarItem } from '../../../constant/sidebar';
 import { EntityClass } from '../../../support/entity/EntityClass';
 import { Glossary } from '../../../support/glossary/Glossary';
 import { GlossaryTerm } from '../../../support/glossary/GlossaryTerm';
@@ -38,7 +39,9 @@ import { ClassificationClass } from '../../../support/tag/ClassificationClass';
 import { TagClass } from '../../../support/tag/TagClass';
 import { createAdminApiContext } from '../../../utils/admin';
 import { redirectToHomePage } from '../../../utils/common';
-import { checkExploreSearchFilter } from '../../../utils/entity';
+import { searchAndClickOnOption } from '../../../utils/explore';
+import { checkExploreSearchFilter, waitForAllLoadersToDisappear } from '../../../utils/entity';
+import { sidebarClick } from '../../../utils/sidebar';
 
 const TIER_FQN = 'Tier.Tier1';
 const CERTIFICATION_FQN = 'Certification.Gold';
@@ -122,12 +125,20 @@ export function registerFilterSeparationSuite(
     test('live indexing produces searchable separation for all four facets', async ({
       page,
     }) => {
+      const { apiContext, afterAction } = await createAdminApiContext();
+      let serviceDisplayName: string | undefined;
+      try {
+        ({ serviceDisplayName } = await waitForLiveIndex(apiContext, entity));
+      } finally {
+        await afterAction();
+      }
       await redirectToHomePage(page);
       await assertAllFourFiltersWork(
         page,
         entity,
         classificationTag,
-        glossaryTerm
+        glossaryTerm,
+        serviceDisplayName
       );
     });
 
@@ -154,7 +165,7 @@ export function registerFilterSeparationSuite(
 
       expect(reindexRes.status()).toBeLessThan(400);
 
-      await assertReindexedDocPreservesSeparation(
+      const { serviceDisplayName } = await assertReindexedDocPreservesSeparation(
         apiContext,
         entity,
         classificationTag,
@@ -167,7 +178,8 @@ export function registerFilterSeparationSuite(
         page,
         entity,
         classificationTag,
-        glossaryTerm
+        glossaryTerm,
+        serviceDisplayName
       );
     });
   });
@@ -229,12 +241,49 @@ async function applyAllFacets(
   });
 }
 
+async function waitForLiveIndex(
+  apiContext: APIRequestContext,
+  entity: FilterSeparationEntity
+): Promise<{ serviceDisplayName?: string }> {
+  let serviceDisplayName: string | undefined;
+
+  await expect
+    .poll(
+      async () => {
+        const res = await apiContext.get(
+          `/api/v1/search/query?q=fullyQualifiedName:%22${encodeURIComponent(
+            entity.entityResponseData.fullyQualifiedName ?? ''
+          )}%22&index=dataAsset`
+        );
+        if (res.status() !== 200) {
+          return undefined;
+        }
+        const body = await res.json();
+        const source = body?.hits?.hits?.[0]?._source;
+        if (source?.service?.displayName) {
+          serviceDisplayName = source.service.displayName as string;
+        }
+
+        return source?.tier?.tagFQN;
+      },
+      {
+        message: 'waiting for live indexing to propagate tier to ES',
+        timeout: 60_000,
+      }
+    )
+    .toEqual(TIER_FQN);
+
+  return { serviceDisplayName };
+}
+
 async function assertReindexedDocPreservesSeparation(
   apiContext: APIRequestContext,
   entity: FilterSeparationEntity,
   classificationTag: TagClass,
   glossaryTerm: GlossaryTerm
-): Promise<void> {
+): Promise<{ serviceDisplayName?: string }> {
+  let serviceDisplayName: string | undefined;
+
   await expect
     .poll(
       async () => {
@@ -250,6 +299,9 @@ async function assertReindexedDocPreservesSeparation(
         const source = body?.hits?.hits?.[0]?._source;
         if (!source) {
           return undefined;
+        }
+        if (source?.service?.displayName) {
+          serviceDisplayName = source.service.displayName as string;
         }
 
         return {
@@ -281,6 +333,8 @@ async function assertReindexedDocPreservesSeparation(
       hasGlossaryTag: true,
       tierNotInTagsBag: true,
     });
+
+  return { serviceDisplayName };
 }
 
 async function assertAllFourFiltersWorkWithRetry(
@@ -288,11 +342,18 @@ async function assertAllFourFiltersWorkWithRetry(
   entity: FilterSeparationEntity,
   classificationTag: TagClass,
   glossaryTerm: GlossaryTerm,
+  serviceDisplayName?: string,
   maxAttempts = 3
 ): Promise<void> {
   for (let attempt = 1; attempt <= maxAttempts; attempt++) {
     try {
-      await assertAllFourFiltersWork(page, entity, classificationTag, glossaryTerm);
+      await assertAllFourFiltersWork(
+        page,
+        entity,
+        classificationTag,
+        glossaryTerm,
+        serviceDisplayName
+      );
 
       return;
     } catch (err) {
@@ -304,15 +365,61 @@ async function assertAllFourFiltersWorkWithRetry(
   }
 }
 
+async function checkExploreFilterWithServiceBase(
+  page: Page,
+  filterLabel: string,
+  filterKey: string,
+  filterValue: string,
+  entity: FilterSeparationEntity,
+  serviceName: string
+): Promise<void> {
+  await sidebarClick(page, SidebarItem.EXPLORE);
+
+  await page.getByTestId('search-dropdown-Service').click();
+  await searchAndClickOnOption(
+    page,
+    { label: 'Service', key: 'service.displayName.keyword', value: serviceName },
+    true
+  );
+  await page.click('[data-testid="update-btn"]');
+  await waitForAllLoadersToDisappear(page);
+
+  await page.getByTestId(`search-dropdown-${filterLabel}`).click();
+  await searchAndClickOnOption(
+    page,
+    { label: filterLabel, key: filterKey, value: filterValue },
+    true
+  );
+  await page.click('[data-testid="update-btn"]');
+  await waitForAllLoadersToDisappear(page);
+
+  await expect(
+    page.getByTestId(
+      `table-data-card_${entity.entityResponseData.fullyQualifiedName}`
+    )
+  ).toBeVisible();
+
+  await page.click('[data-testid="clear-filters"]');
+  await entity.visitEntityPage(page);
+}
+
 async function assertAllFourFiltersWork(
   page: Page,
   entity: FilterSeparationEntity,
   classificationTag: TagClass,
-  glossaryTerm: GlossaryTerm
+  glossaryTerm: GlossaryTerm,
+  serviceDisplayName?: string
 ): Promise<void> {
-  const responseData = entity.entityResponseData as Record<string, unknown>;
-  const serviceName = (responseData?.service as { name?: string } | undefined)
-    ?.name;
+  const entityRecord = entity as unknown as Record<string, unknown>;
+  const svcData =
+    (entityRecord.serviceResponseData as Record<string, unknown> | undefined) ??
+    ((entity.entityResponseData as Record<string, unknown>).service as
+      | Record<string, unknown>
+      | undefined);
+  const serviceName =
+    serviceDisplayName ||
+    (svcData?.displayName as string | undefined) ||
+    (svcData?.name as string | undefined);
 
   if (serviceName) {
     await checkExploreSearchFilter(
@@ -322,28 +429,66 @@ async function assertAllFourFiltersWork(
       serviceName,
       entity
     );
+    await checkExploreFilterWithServiceBase(
+      page,
+      'Tier',
+      'tier.tagFQN',
+      TIER_FQN,
+      entity,
+      serviceName
+    );
+    await checkExploreFilterWithServiceBase(
+      page,
+      'Certification',
+      'certification.tagLabel.tagFQN',
+      CERTIFICATION_FQN,
+      entity,
+      serviceName
+    );
+    await checkExploreFilterWithServiceBase(
+      page,
+      'Tag',
+      'tags.tagFQN',
+      classificationTag.responseData.fullyQualifiedName,
+      entity,
+      serviceName
+    );
+    await checkExploreFilterWithServiceBase(
+      page,
+      'Tag',
+      'tags.tagFQN',
+      glossaryTerm.responseData.fullyQualifiedName,
+      entity,
+      serviceName
+    );
+  } else {
+    await checkExploreSearchFilter(
+      page,
+      'Tier',
+      'tier.tagFQN',
+      TIER_FQN,
+      entity
+    );
+    await checkExploreSearchFilter(
+      page,
+      'Certification',
+      'certification.tagLabel.tagFQN',
+      CERTIFICATION_FQN,
+      entity
+    );
+    await checkExploreSearchFilter(
+      page,
+      'Tag',
+      'tags.tagFQN',
+      classificationTag.responseData.fullyQualifiedName,
+      entity
+    );
+    await checkExploreSearchFilter(
+      page,
+      'Tag',
+      'tags.tagFQN',
+      glossaryTerm.responseData.fullyQualifiedName,
+      entity
+    );
   }
-
-  await checkExploreSearchFilter(page, 'Tier', 'tier.tagFQN', TIER_FQN, entity);
-  await checkExploreSearchFilter(
-    page,
-    'Certification',
-    'certification.tagLabel.tagFQN',
-    CERTIFICATION_FQN,
-    entity
-  );
-  await checkExploreSearchFilter(
-    page,
-    'Tag',
-    'tags.tagFQN',
-    classificationTag.responseData.fullyQualifiedName,
-    entity
-  );
-  await checkExploreSearchFilter(
-    page,
-    'Tag',
-    'tags.tagFQN',
-    glossaryTerm.responseData.fullyQualifiedName,
-    entity
-  );
 }

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/SearchSeparation/SearchSeparationSuite.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/SearchSeparation/SearchSeparationSuite.ts
@@ -53,6 +53,7 @@ const CERTIFICATION_FQN = 'Certification.Gold';
  */
 export type FilterSeparationEntity = EntityClass & {
   entityResponseData: { id: string; fullyQualifiedName?: string };
+  serviceResponseData?: { name?: string; displayName?: string };
   create(apiContext: APIRequestContext): Promise<unknown>;
   delete(apiContext: APIRequestContext): Promise<unknown>;
   patch(opts: {
@@ -410,16 +411,30 @@ async function assertAllFourFiltersWork(
   glossaryTerm: GlossaryTerm,
   serviceDisplayName?: string
 ): Promise<void> {
-  const entityRecord = entity as unknown as Record<string, unknown>;
-  const svcData =
-    (entityRecord.serviceResponseData as Record<string, unknown> | undefined) ??
-    ((entity.entityResponseData as Record<string, unknown>).service as
-      | Record<string, unknown>
-      | undefined);
+  const svcData = entity.serviceResponseData;
   const serviceName =
     serviceDisplayName ||
-    (svcData?.displayName as string | undefined) ||
-    (svcData?.name as string | undefined);
+    svcData?.displayName ||
+    svcData?.name;
+
+  const filters: Array<{ label: string; key: string; value: string }> = [
+    { label: 'Tier', key: 'tier.tagFQN', value: TIER_FQN },
+    {
+      label: 'Certification',
+      key: 'certification.tagLabel.tagFQN',
+      value: CERTIFICATION_FQN,
+    },
+    {
+      label: 'Tag',
+      key: 'tags.tagFQN',
+      value: classificationTag.responseData.fullyQualifiedName,
+    },
+    {
+      label: 'Tag',
+      key: 'tags.tagFQN',
+      value: glossaryTerm.responseData.fullyQualifiedName,
+    },
+  ];
 
   if (serviceName) {
     await checkExploreSearchFilter(
@@ -429,66 +444,25 @@ async function assertAllFourFiltersWork(
       serviceName,
       entity
     );
-    await checkExploreFilterWithServiceBase(
-      page,
-      'Tier',
-      'tier.tagFQN',
-      TIER_FQN,
-      entity,
-      serviceName
-    );
-    await checkExploreFilterWithServiceBase(
-      page,
-      'Certification',
-      'certification.tagLabel.tagFQN',
-      CERTIFICATION_FQN,
-      entity,
-      serviceName
-    );
-    await checkExploreFilterWithServiceBase(
-      page,
-      'Tag',
-      'tags.tagFQN',
-      classificationTag.responseData.fullyQualifiedName,
-      entity,
-      serviceName
-    );
-    await checkExploreFilterWithServiceBase(
-      page,
-      'Tag',
-      'tags.tagFQN',
-      glossaryTerm.responseData.fullyQualifiedName,
-      entity,
-      serviceName
-    );
+    for (const filter of filters) {
+      await checkExploreFilterWithServiceBase(
+        page,
+        filter.label,
+        filter.key,
+        filter.value,
+        entity,
+        serviceName
+      );
+    }
   } else {
-    await checkExploreSearchFilter(
-      page,
-      'Tier',
-      'tier.tagFQN',
-      TIER_FQN,
-      entity
-    );
-    await checkExploreSearchFilter(
-      page,
-      'Certification',
-      'certification.tagLabel.tagFQN',
-      CERTIFICATION_FQN,
-      entity
-    );
-    await checkExploreSearchFilter(
-      page,
-      'Tag',
-      'tags.tagFQN',
-      classificationTag.responseData.fullyQualifiedName,
-      entity
-    );
-    await checkExploreSearchFilter(
-      page,
-      'Tag',
-      'tags.tagFQN',
-      glossaryTerm.responseData.fullyQualifiedName,
-      entity
-    );
+    for (const filter of filters) {
+      await checkExploreSearchFilter(
+        page,
+        filter.label,
+        filter.key,
+        filter.value,
+        entity
+      );
+    }
   }
 }

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/SearchSeparation/StoredProcedure.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/SearchSeparation/StoredProcedure.spec.ts
@@ -13,7 +13,7 @@
 
 import { test } from '@playwright/test';
 import { StoredProcedureClass } from '../../../support/entity/StoredProcedureClass';
-import { registerFilterSeparationSuite } from './searchSeparationSuite';
+import { registerFilterSeparationSuite } from './SearchSeparationSuite';
 
 test.use({ storageState: 'playwright/.auth/admin.json' });
 

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/SearchSeparation/Topic.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/SearchSeparation/Topic.spec.ts
@@ -22,4 +22,3 @@ registerFilterSeparationSuite({
   reindexEntityType: 'topic',
   entityFactory: () => new TopicClass(),
 });
-

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/SearchSeparation/Topic.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/SearchSeparation/Topic.spec.ts
@@ -13,7 +13,7 @@
 
 import { test } from '@playwright/test';
 import { TopicClass } from '../../../support/entity/TopicClass';
-import { registerFilterSeparationSuite } from './searchSeparationSuite';
+import { registerFilterSeparationSuite } from './SearchSeparationSuite';
 
 test.use({ storageState: 'playwright/.auth/admin.json' });
 
@@ -22,3 +22,4 @@ registerFilterSeparationSuite({
   reindexEntityType: 'topic',
   entityFactory: () => new TopicClass(),
 });
+


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:

Playwright tests were intermittently failing for entity types  due to the target entity is not on page 1, and toBeVisible() times out. 

This PR adds proper server-side filtering support for all entity types, including filters like service and tier, so only the required entities are fetched and displayed on the first page during test execution.

----
## Summary by Gitar

- **Test infrastructure:**
  - Added `SearchSeparationSuite.ts` as a centralized, reusable factory for verifying search index parity (live update vs. full reindex).
  - Fixed import casing in 11 entity test specs to align with the new filename `SearchSeparationSuite.ts`.
- **Search validation logic:**
  - Implemented `waitForLiveIndex` to verify propagation of tier tags to Elasticsearch.
  - Added `checkExploreFilterWithServiceBase` to validate faceted search filtering across Tier, Certification, and Tag categories.
  - Enhanced `assertReindexedDocPreservesSeparation` to dynamically extract service display names during indexing checks.


<sub>This will update automatically on new commits.</sub>