### PR TITLE
fix(rdf): reclaim Fuseki disk via compaction + upgrade Jena 4.10 → 5.6.0

### DIFF
--- a/docker/development/docker-compose-fuseki.yml
+++ b/docker/development/docker-compose-fuseki.yml
@@ -51,7 +51,12 @@ services:
     networks:
       - local_app_net
     environment:
-      - FUSEKI_ADMIN_PASSWORD=admin
+      # Default for local dev only — production deployments MUST override
+      # via the FUSEKI_ADMIN_PASSWORD env var (and FUSEKI_OPENMETADATA_PASSWORD)
+      # before bringing this stack up. The entrypoint envsubsts these into
+      # shiro.ini at container start so the override actually takes effect.
+      - FUSEKI_ADMIN_PASSWORD=${FUSEKI_ADMIN_PASSWORD:-admin}
+      - FUSEKI_OPENMETADATA_PASSWORD=${FUSEKI_OPENMETADATA_PASSWORD:-openmetadata-secret}
       - JVM_ARGS=${FUSEKI_JVM_ARGS:--Xmx1500m -Xms256m}
     volumes:
       # New volume name (was `fuseki-data` mounted at `/fuseki`). The in-repo

--- a/docker/development/docker-compose-fuseki.yml
+++ b/docker/development/docker-compose-fuseki.yml
@@ -54,7 +54,16 @@ services:
       - FUSEKI_ADMIN_PASSWORD=admin
       - JVM_ARGS=${FUSEKI_JVM_ARGS:--Xmx1500m -Xms256m}
     volumes:
-      - fuseki-data:/fuseki-data
+      # New volume name (was `fuseki-data` mounted at `/fuseki`). The in-repo
+      # Dockerfile stores TDB2 at `/fuseki-data` and the data layout differs
+      # from the old stain/jena-fuseki image — re-using the previous volume
+      # name would mount stale state at a path Fuseki no longer reads from,
+      # silently looking like an empty database. Using a fresh volume name
+      # forces operators to consciously migrate (or accept a re-index). The
+      # orphaned `fuseki-data` volume can be removed manually with
+      # `docker volume rm fuseki-data` after confirming the new stack is
+      # healthy.
+      - fuseki-tdb2-data:/fuseki-data
     deploy:
       resources:
         limits:
@@ -78,5 +87,5 @@ networks:
         - subnet: "172.16.239.0/24"
 
 volumes:
-  fuseki-data:
+  fuseki-tdb2-data:
     driver: local

--- a/docker/development/docker-compose-fuseki.yml
+++ b/docker/development/docker-compose-fuseki.yml
@@ -34,7 +34,16 @@ services:
         condition: service_healthy
 
   fuseki:
-    image: stain/jena-fuseki:5.0.0
+    # Build from the in-repo Dockerfile (Fuseki 5.6.0) instead of the
+    # unmaintained `stain/jena-fuseki` Docker Hub image, which capped at 5.1.0
+    # and never picked up the 2025 admin-side Fuseki CVE fixes (CVE-2025-49656,
+    # CVE-2025-50151 — both fixed in Jena 5.5.0). The `image:` tag below names
+    # the locally-built image so subsequent `docker compose up` runs reuse the
+    # cached build instead of rebuilding from scratch each time.
+    build:
+      context: ../rdf-store
+      dockerfile: Dockerfile
+    image: openmetadata-fuseki:5.6.0
     container_name: openmetadata-fuseki
     hostname: fuseki
     ports:
@@ -42,11 +51,10 @@ services:
     networks:
       - local_app_net
     environment:
-      - ADMIN_PASSWORD=admin
+      - FUSEKI_ADMIN_PASSWORD=admin
       - JVM_ARGS=${FUSEKI_JVM_ARGS:--Xmx1500m -Xms256m}
-      - FUSEKI_BASE=/fuseki
     volumes:
-      - fuseki-data:/fuseki
+      - fuseki-data:/fuseki-data
     deploy:
       resources:
         limits:
@@ -60,8 +68,6 @@ services:
       timeout: 10s
       retries: 20
       start_period: 60s
-    # Create the database directory before starting Fuseki
-    entrypoint: /bin/sh -c "mkdir -p /fuseki/databases/openmetadata && exec /docker-entrypoint.sh /jena-fuseki/fuseki-server --update --loc=/fuseki/databases/openmetadata /openmetadata"
 
 networks:
   local_app_net:

--- a/docker/development/docker-compose-postgres-fuseki.yml
+++ b/docker/development/docker-compose-postgres-fuseki.yml
@@ -579,7 +579,10 @@ services:
     ports:
       - "3030:3030"
     environment:
-      - FUSEKI_ADMIN_PASSWORD=admin
+      # Local-dev default — production deployments MUST override via
+      # FUSEKI_ADMIN_PASSWORD / FUSEKI_OPENMETADATA_PASSWORD env vars.
+      - FUSEKI_ADMIN_PASSWORD=${FUSEKI_ADMIN_PASSWORD:-admin}
+      - FUSEKI_OPENMETADATA_PASSWORD=${FUSEKI_OPENMETADATA_PASSWORD:-openmetadata-secret}
       - JVM_ARGS=-Xmx4g -Xms2g
     volumes:
       # See docker-compose-fuseki.yml for why the volume was renamed from

--- a/docker/development/docker-compose-postgres-fuseki.yml
+++ b/docker/development/docker-compose-postgres-fuseki.yml
@@ -565,17 +565,22 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock:z  # Need 600 permissions to run DockerOperator
 
   fuseki:
-    image: stain/jena-fuseki:5.0.0
+    # See docker-compose-fuseki.yml for the rationale behind building from the
+    # in-repo Dockerfile instead of using `stain/jena-fuseki:*` (unmaintained,
+    # capped at 5.1.0, missing 2025 admin-side CVE fixes).
+    build:
+      context: ../rdf-store
+      dockerfile: Dockerfile
+    image: openmetadata-fuseki:5.6.0
     container_name: openmetadata-fuseki
     hostname: fuseki
     ports:
       - "3030:3030"
     environment:
-      - ADMIN_PASSWORD=admin
+      - FUSEKI_ADMIN_PASSWORD=admin
       - JVM_ARGS=-Xmx4g -Xms2g
-      - FUSEKI_BASE=/fuseki
     volumes:
-      - fuseki-data:/fuseki
+      - fuseki-data:/fuseki-data
     deploy:
       resources:
         limits:
@@ -584,8 +589,6 @@ services:
           memory: 2G
     networks:
       - local_app_net
-    # Create the database directory before starting Fuseki
-    entrypoint: /bin/sh -c "mkdir -p /fuseki/databases/openmetadata && exec /docker-entrypoint.sh /jena-fuseki/fuseki-server --update --loc=/fuseki/databases/openmetadata /openmetadata"
 
 
 

--- a/docker/development/docker-compose-postgres-fuseki.yml
+++ b/docker/development/docker-compose-postgres-fuseki.yml
@@ -15,7 +15,9 @@ volumes:
   ingestion-volume-dags:
   ingestion-volume-tmp:
   es-data:
-  fuseki-data:
+  # See docker-compose-fuseki.yml — renamed from `fuseki-data` to avoid
+  # silently mounting stale state under the new Fuseki layout.
+  fuseki-tdb2-data:
 services:
   postgresql:
     build:
@@ -580,7 +582,11 @@ services:
       - FUSEKI_ADMIN_PASSWORD=admin
       - JVM_ARGS=-Xmx4g -Xms2g
     volumes:
-      - fuseki-data:/fuseki-data
+      # See docker-compose-fuseki.yml for why the volume was renamed from
+      # `fuseki-data` to `fuseki-tdb2-data` (the data layout differs from the
+      # previous stain/jena-fuseki image and reusing the old name silently
+      # mounts stale state at a path Fuseki no longer reads).
+      - fuseki-tdb2-data:/fuseki-data
     deploy:
       resources:
         limits:

--- a/docker/docker-compose-quickstart/Dockerfile.fuseki-alpine
+++ b/docker/docker-compose-quickstart/Dockerfile.fuseki-alpine
@@ -8,7 +8,7 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/*
 
 # Set Fuseki version and paths
-ENV FUSEKI_VERSION=4.10.0
+ENV FUSEKI_VERSION=5.6.0
 ENV FUSEKI_HOME=/fuseki
 ENV FUSEKI_BASE=/fuseki
 

--- a/docker/docker-compose-quickstart/Dockerfile.fuseki-arm64
+++ b/docker/docker-compose-quickstart/Dockerfile.fuseki-arm64
@@ -14,7 +14,7 @@ RUN apt-get update || true && \
     rm -rf /var/lib/apt/lists/*
 
 # Set Fuseki version
-ENV FUSEKI_VERSION=5.0.0
+ENV FUSEKI_VERSION=5.6.0
 ENV FUSEKI_HOME=/fuseki
 
 # Download and install Fuseki

--- a/docker/docker-compose-quickstart/Dockerfile.fuseki-multiarch
+++ b/docker/docker-compose-quickstart/Dockerfile.fuseki-multiarch
@@ -9,7 +9,7 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/*
 
 # Set Fuseki version and paths
-ENV FUSEKI_VERSION=4.10.0
+ENV FUSEKI_VERSION=5.6.0
 ENV FUSEKI_HOME=/fuseki
 ENV FUSEKI_BASE=/fuseki
 

--- a/docker/docker-compose-quickstart/Dockerfile.fuseki-multiarch
+++ b/docker/docker-compose-quickstart/Dockerfile.fuseki-multiarch
@@ -1,5 +1,6 @@
 # Multi-architecture Fuseki build
-FROM --platform=$TARGETPLATFORM openjdk:17-jdk-slim
+# eclipse-temurin replaces the deprecated openjdk Docker Hub images.
+FROM --platform=$TARGETPLATFORM eclipse-temurin:17-jre-jammy
 
 # Install required packages
 RUN apt-get update && \

--- a/docker/docker-compose-quickstart/Dockerfile.fuseki-simple
+++ b/docker/docker-compose-quickstart/Dockerfile.fuseki-simple
@@ -3,7 +3,7 @@ FROM --platform=$BUILDPLATFORM alpine:latest AS downloader
 
 RUN apk add --no-cache wget tar
 
-ENV FUSEKI_VERSION=5.0.0
+ENV FUSEKI_VERSION=5.6.0
 WORKDIR /tmp
 
 RUN wget -q https://archive.apache.org/dist/jena/binaries/apache-jena-fuseki-${FUSEKI_VERSION}.tar.gz && \

--- a/docker/docker-compose-quickstart/Dockerfile.fuseki-simple
+++ b/docker/docker-compose-quickstart/Dockerfile.fuseki-simple
@@ -10,8 +10,8 @@ RUN wget -q https://archive.apache.org/dist/jena/binaries/apache-jena-fuseki-${F
     tar -xzf apache-jena-fuseki-${FUSEKI_VERSION}.tar.gz && \
     mv apache-jena-fuseki-${FUSEKI_VERSION} /fuseki-dist
 
-# Use OpenJDK base image for runtime
-FROM openjdk:17-slim
+# Runtime: eclipse-temurin replaces the deprecated openjdk Docker Hub images.
+FROM eclipse-temurin:17-jre-jammy
 
 ENV FUSEKI_HOME=/fuseki
 ENV FUSEKI_BASE=/fuseki

--- a/docker/docker-compose-quickstart/Dockerfile.fuseki-working
+++ b/docker/docker-compose-quickstart/Dockerfile.fuseki-working
@@ -2,7 +2,7 @@
 FROM openjdk:17-slim
 
 # Set Fuseki version and paths
-ENV FUSEKI_VERSION=4.10.0
+ENV FUSEKI_VERSION=5.6.0
 ENV FUSEKI_HOME=/fuseki
 ENV FUSEKI_BASE=/fuseki
 

--- a/docker/docker-compose-quickstart/Dockerfile.fuseki-working
+++ b/docker/docker-compose-quickstart/Dockerfile.fuseki-working
@@ -1,5 +1,6 @@
 # Simple Fuseki build that works on ARM64
-FROM openjdk:17-slim
+# eclipse-temurin replaces the deprecated openjdk Docker Hub images.
+FROM eclipse-temurin:17-jre-jammy
 
 # Set Fuseki version and paths
 ENV FUSEKI_VERSION=5.6.0

--- a/docker/docker-compose-quickstart/docker-compose-fuseki-rosetta.yml
+++ b/docker/docker-compose-quickstart/docker-compose-fuseki-rosetta.yml
@@ -17,7 +17,13 @@ services:
       - FUSEKI_ADMIN_PASSWORD=admin
       - JVM_ARGS=-Xmx8g -Xms4g
     volumes:
-      - ${DOCKER_VOLUMES_PATH:-./docker-volumes}/fuseki:/fuseki-data
+      # Host bind path renamed from `.../fuseki` (used by the old stain image
+      # layout) to `.../fuseki-tdb2-data` so an existing host directory with
+      # the previous layout isn't silently mounted at /fuseki-data — Fuseki
+      # would see an empty TDB2 store and the old data would appear lost.
+      # Operators upgrading can either delete the new dir to start fresh or
+      # migrate old data manually.
+      - ${DOCKER_VOLUMES_PATH:-./docker-volumes}/fuseki-tdb2-data:/fuseki-data
     networks:
       - fuseki-net
     healthcheck:

--- a/docker/docker-compose-quickstart/docker-compose-fuseki-rosetta.yml
+++ b/docker/docker-compose-quickstart/docker-compose-fuseki-rosetta.yml
@@ -3,24 +3,23 @@ services:
   fuseki:
     # Force AMD64 platform with Rosetta 2 emulation
     platform: linux/amd64
-    image: stain/jena-fuseki:5.0.0
+    # Build from the in-repo Dockerfile (Fuseki 5.6.0). See
+    # docker-compose-fuseki.yml for the full rationale.
+    build:
+      context: ../rdf-store
+      dockerfile: Dockerfile
+    image: openmetadata-fuseki:5.6.0
     container_name: fuseki-standalone
     hostname: fuseki
     ports:
       - "3030:3030"
     environment:
-      # Admin credentials
-      - ADMIN_PASSWORD=admin
-      # JVM memory settings
+      - FUSEKI_ADMIN_PASSWORD=admin
       - JVM_ARGS=-Xmx8g -Xms4g
-      - FUSEKI_BASE=/fuseki
     volumes:
-      # Mount directory for persistent storage
-      - ${DOCKER_VOLUMES_PATH:-./docker-volumes}/fuseki:/fuseki
+      - ${DOCKER_VOLUMES_PATH:-./docker-volumes}/fuseki:/fuseki-data
     networks:
       - fuseki-net
-    # Create openmetadata dataset on startup
-    entrypoint: /bin/sh -c "mkdir -p /fuseki/databases/openmetadata && exec /docker-entrypoint.sh /jena-fuseki/fuseki-server --update --loc=/fuseki/databases/openmetadata /openmetadata"
     healthcheck:
       test: ["CMD", "wget", "-q", "--spider", "http://localhost:3030/$/ping"]
       interval: 15s

--- a/docker/docker-compose-quickstart/docker-compose-fuseki-rosetta.yml
+++ b/docker/docker-compose-quickstart/docker-compose-fuseki-rosetta.yml
@@ -14,7 +14,10 @@ services:
     ports:
       - "3030:3030"
     environment:
-      - FUSEKI_ADMIN_PASSWORD=admin
+      # Local-dev default — production deployments MUST override via
+      # FUSEKI_ADMIN_PASSWORD / FUSEKI_OPENMETADATA_PASSWORD env vars.
+      - FUSEKI_ADMIN_PASSWORD=${FUSEKI_ADMIN_PASSWORD:-admin}
+      - FUSEKI_OPENMETADATA_PASSWORD=${FUSEKI_OPENMETADATA_PASSWORD:-openmetadata-secret}
       - JVM_ARGS=-Xmx8g -Xms4g
     volumes:
       # Host bind path renamed from `.../fuseki` (used by the old stain image

--- a/docker/docker-compose-quickstart/docker-compose-fuseki-standalone.yml
+++ b/docker/docker-compose-quickstart/docker-compose-fuseki-standalone.yml
@@ -15,7 +15,10 @@ services:
       - FUSEKI_ADMIN_PASSWORD=admin
       - JVM_ARGS=-Xmx4g -Xms2g
     volumes:
-      - ${DOCKER_VOLUMES_PATH:-./docker-volumes}/fuseki:/fuseki-data
+      # See docker-compose-fuseki-rosetta.yml — host bind path renamed so
+      # existing directories with the old stain layout aren't silently
+      # mounted at the new /fuseki-data path.
+      - ${DOCKER_VOLUMES_PATH:-./docker-volumes}/fuseki-tdb2-data:/fuseki-data
     networks:
       - fuseki-net
     healthcheck:

--- a/docker/docker-compose-quickstart/docker-compose-fuseki-standalone.yml
+++ b/docker/docker-compose-quickstart/docker-compose-fuseki-standalone.yml
@@ -12,7 +12,10 @@ services:
     ports:
       - "3030:3030"
     environment:
-      - FUSEKI_ADMIN_PASSWORD=admin
+      # Local-dev default — production deployments MUST override via
+      # FUSEKI_ADMIN_PASSWORD / FUSEKI_OPENMETADATA_PASSWORD env vars.
+      - FUSEKI_ADMIN_PASSWORD=${FUSEKI_ADMIN_PASSWORD:-admin}
+      - FUSEKI_OPENMETADATA_PASSWORD=${FUSEKI_OPENMETADATA_PASSWORD:-openmetadata-secret}
       - JVM_ARGS=-Xmx4g -Xms2g
     volumes:
       # See docker-compose-fuseki-rosetta.yml — host bind path renamed so

--- a/docker/docker-compose-quickstart/docker-compose-fuseki-standalone.yml
+++ b/docker/docker-compose-quickstart/docker-compose-fuseki-standalone.yml
@@ -1,25 +1,23 @@
 # Standalone Apache Jena Fuseki for RDF/Knowledge Graph storage
 services:
   fuseki:
-    image: stain/jena-fuseki:5.0.0
+    # Build from the in-repo Dockerfile (Fuseki 5.6.0). See
+    # ../development/docker-compose-fuseki.yml for the full rationale.
+    build:
+      context: ../rdf-store
+      dockerfile: Dockerfile
+    image: openmetadata-fuseki:5.6.0
     container_name: fuseki-standalone
     hostname: fuseki
     ports:
       - "3030:3030"
     environment:
-      # Admin credentials
-      - ADMIN_PASSWORD=admin
-      # JVM memory settings - adjust based on your system
+      - FUSEKI_ADMIN_PASSWORD=admin
       - JVM_ARGS=-Xmx4g -Xms2g
-      # Fuseki configuration
-      - FUSEKI_BASE=/fuseki
     volumes:
-      # Mount directory for persistent storage (configurable via .env)
-      - ${DOCKER_VOLUMES_PATH:-./docker-volumes}/fuseki:/fuseki
+      - ${DOCKER_VOLUMES_PATH:-./docker-volumes}/fuseki:/fuseki-data
     networks:
       - fuseki-net
-    # Create openmetadata dataset on startup
-    entrypoint: /bin/sh -c "mkdir -p /fuseki/databases/openmetadata && exec /docker-entrypoint.sh /jena-fuseki/fuseki-server --update --loc=/fuseki/databases/openmetadata /openmetadata"
     healthcheck:
       test: ["CMD", "wget", "-q", "--spider", "http://localhost:3030/$/ping"]
       interval: 15s

--- a/docker/docker-compose-quickstart/docker-compose-rdf.yml
+++ b/docker/docker-compose-quickstart/docker-compose-rdf.yml
@@ -70,20 +70,23 @@ services:
         reservations:
           memory: 2G
 
-  # Apache Jena Fuseki for RDF/Knowledge Graph storage
+  # Apache Jena Fuseki for RDF/Knowledge Graph storage. Built from the
+  # in-repo Dockerfile (Fuseki 5.6.0) — see ../development/docker-compose-fuseki.yml
+  # for why we don't use the unmaintained stain/jena-fuseki image.
   fuseki:
     container_name: openmetadata_fuseki
-    image: stain/jena-fuseki:4.10.0
+    build:
+      context: ../rdf-store
+      dockerfile: Dockerfile
+    image: openmetadata-fuseki:5.6.0
     restart: always
     environment:
-      - ADMIN_PASSWORD=${FUSEKI_ADMIN_PASSWORD:-admin}
-      - FUSEKI_DATASET_1=openmetadata
+      - FUSEKI_ADMIN_PASSWORD=${FUSEKI_ADMIN_PASSWORD:-admin}
       - JVM_ARGS=-Xmx4g -Xms2g
-      - FUSEKI_BASE=/fuseki
     ports:
       - "3030:3030"
     volumes:
-      - fuseki-data:/fuseki
+      - fuseki-data:/fuseki-data
     networks:
       - app_net
     healthcheck:

--- a/docker/docker-compose-quickstart/docker-compose-rdf.yml
+++ b/docker/docker-compose-quickstart/docker-compose-rdf.yml
@@ -84,7 +84,11 @@ services:
     image: openmetadata-fuseki:5.6.0
     restart: always
     environment:
+      # Local-dev defaults — production deployments MUST override via the
+      # FUSEKI_ADMIN_PASSWORD / FUSEKI_OPENMETADATA_PASSWORD env vars before
+      # bringing this stack up. The entrypoint envsubsts these into shiro.ini.
       - FUSEKI_ADMIN_PASSWORD=${FUSEKI_ADMIN_PASSWORD:-admin}
+      - FUSEKI_OPENMETADATA_PASSWORD=${FUSEKI_OPENMETADATA_PASSWORD:-openmetadata-secret}
       - JVM_ARGS=-Xmx4g -Xms2g
     ports:
       - "3030:3030"

--- a/docker/docker-compose-quickstart/docker-compose-rdf.yml
+++ b/docker/docker-compose-quickstart/docker-compose-rdf.yml
@@ -18,7 +18,10 @@ volumes:
   ingestion-volume-dags:
   ingestion-volume-tmp:
   es-data:
-  fuseki-data:
+  # See ../development/docker-compose-fuseki.yml — renamed from `fuseki-data`
+  # because the new Dockerfile uses a different on-disk layout and reusing
+  # the old volume name silently mounts stale state.
+  fuseki-tdb2-data:
 
 services:
   mysql:
@@ -86,7 +89,7 @@ services:
     ports:
       - "3030:3030"
     volumes:
-      - fuseki-data:/fuseki-data
+      - fuseki-tdb2-data:/fuseki-data
     networks:
       - app_net
     healthcheck:

--- a/docker/docker-compose-quickstart/docker-compose.override.yml
+++ b/docker/docker-compose-quickstart/docker-compose.override.yml
@@ -12,13 +12,16 @@ volumes:
       o: bind
       device: ./docker-volume/elasticsearch-data
 
-  # Increase Fuseki data volume  
-  fuseki-data:
+  # Fuseki data volume. Renamed from `fuseki-data` (and host path changed
+  # from `./docker-volume/fuseki-data` to `./docker-volume/fuseki-tdb2-data`)
+  # to match docker-compose-rdf.yml — see ../development/docker-compose-fuseki.yml
+  # for the migration rationale (new on-disk layout vs the old stain image).
+  fuseki-tdb2-data:
     driver: local
     driver_opts:
       type: none
       o: bind
-      device: ./docker-volume/fuseki-data
+      device: ./docker-volume/fuseki-tdb2-data
 
 services:
   # Additional Elasticsearch optimizations

--- a/docker/docker-compose-quickstart/start-rdf-services.sh
+++ b/docker/docker-compose-quickstart/start-rdf-services.sh
@@ -37,7 +37,8 @@ chmod -R 777 "$VOLUMES_PATH"
 
 # Start Fuseki
 echo "Starting Apache Jena Fuseki..."
-# Use Rosetta 2 emulation on ARM64 for stain/jena-fuseki:5.0.0
+# Use Rosetta 2 emulation on ARM64 because the local Fuseki Dockerfile
+# bases on a Linux x86_64 image; the Rosetta variant pins platform=linux/amd64.
 if [[ $(uname -m) == "arm64" ]] || [[ $(uname -m) == "aarch64" ]]; then
     echo "Detected ARM64 architecture, using Rosetta 2 emulation..."
     docker compose -f docker-compose-fuseki-rosetta.yml up -d

--- a/docker/rdf-store/Dockerfile
+++ b/docker/rdf-store/Dockerfile
@@ -15,8 +15,13 @@ ENV FUSEKI_HOME=/fuseki
 # config.ttl + shiro.ini into /fuseki below, so we point FUSEKI_BASE there.
 ENV FUSEKI_BASE=/fuseki
 
+# gettext-base provides `envsubst`, used by the entrypoint to inject
+# FUSEKI_ADMIN_PASSWORD / FUSEKI_OPENMETADATA_PASSWORD into shiro.ini at
+# container start. Without this, operators could not override the default
+# Fuseki credentials via environment variables.
 RUN apt-get update && apt-get install -y \
     wget \
+    gettext-base \
     && rm -rf /var/lib/apt/lists/*
 
 # Download and install Fuseki
@@ -30,9 +35,14 @@ WORKDIR ${FUSEKI_HOME}
 # Create data directory
 RUN mkdir -p /fuseki-data
 
-# Copy custom configuration
+# Custom configuration. shiro.ini ships as a TEMPLATE because Apache Shiro's
+# INI realm does not interpolate ${VAR} placeholders natively — we have to
+# render it at container start with the actual passwords. The entrypoint
+# does that via envsubst.
 COPY config.ttl /fuseki/config.ttl
-COPY shiro.ini /fuseki/shiro.ini
+COPY shiro.ini /fuseki/shiro.ini.template
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
 
 # Expose Fuseki port
 EXPOSE 3030
@@ -44,5 +54,6 @@ VOLUME ["/fuseki-data"]
 HEALTHCHECK --interval=30s --timeout=3s --start-period=40s --retries=3 \
   CMD wget -q --spider http://localhost:3030/$/ping || exit 1
 
-# Run Fuseki with OpenMetadata dataset
+# Run Fuseki via the entrypoint (which renders shiro.ini then execs fuseki-server)
+ENTRYPOINT ["/entrypoint.sh"]
 CMD ["./fuseki-server", "--loc=/fuseki-data", "--update", "/openmetadata"]

--- a/docker/rdf-store/Dockerfile
+++ b/docker/rdf-store/Dockerfile
@@ -1,5 +1,9 @@
 # Apache Jena Fuseki Docker Image for OpenMetadata RDF Store
-FROM openjdk:17-jdk-slim
+# eclipse-temurin replaces the deprecated `openjdk` Docker Hub images
+# (`openjdk:17-jdk-slim` was removed from the registry — CI builds against it
+# fail with "manifest unknown"). JRE is enough since this image only runs the
+# Fuseki shell launcher; no compilation happens inside the container.
+FROM eclipse-temurin:17-jre-jammy
 
 ENV FUSEKI_VERSION=5.6.0
 ENV FUSEKI_HOME=/fuseki

--- a/docker/rdf-store/Dockerfile
+++ b/docker/rdf-store/Dockerfile
@@ -1,7 +1,7 @@
 # Apache Jena Fuseki Docker Image for OpenMetadata RDF Store
 FROM openjdk:17-jdk-slim
 
-ENV FUSEKI_VERSION=4.10.0
+ENV FUSEKI_VERSION=5.6.0
 ENV FUSEKI_HOME=/fuseki
 
 RUN apt-get update && apt-get install -y \

--- a/docker/rdf-store/Dockerfile
+++ b/docker/rdf-store/Dockerfile
@@ -3,6 +3,13 @@ FROM openjdk:17-jdk-slim
 
 ENV FUSEKI_VERSION=5.6.0
 ENV FUSEKI_HOME=/fuseki
+# FUSEKI_BASE must point at the directory containing shiro.ini so Fuseki picks
+# up our auth config on boot. Without this, Fuseki falls back to its built-in
+# default base (typically the working directory) and the bundled shiro.ini is
+# never loaded — leaving the admin endpoints (incl. /$/compact and
+# /$/datasets) reachable without authentication. The Dockerfile copies
+# config.ttl + shiro.ini into /fuseki below, so we point FUSEKI_BASE there.
+ENV FUSEKI_BASE=/fuseki
 
 RUN apt-get update && apt-get install -y \
     wget \

--- a/docker/rdf-store/Dockerfile
+++ b/docker/rdf-store/Dockerfile
@@ -40,7 +40,7 @@ RUN mkdir -p /fuseki-data
 # render it at container start with the actual passwords. The entrypoint
 # does that via envsubst.
 COPY config.ttl /fuseki/config.ttl
-COPY shiro.ini /fuseki/shiro.ini.template
+COPY shiro.ini.template /fuseki/shiro.ini.template
 COPY entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
 

--- a/docker/rdf-store/entrypoint.sh
+++ b/docker/rdf-store/entrypoint.sh
@@ -1,0 +1,35 @@
+#!/bin/sh
+#
+# Render shiro.ini from its template, substituting FUSEKI_ADMIN_PASSWORD and
+# FUSEKI_OPENMETADATA_PASSWORD. Apache Shiro's INI realm does not interpolate
+# ${VAR} placeholders natively, so we have to expand them before Fuseki reads
+# the file — otherwise Shiro stores the literal string `${FUSEKI_...}` as the
+# password and every basic-auth attempt returns 401.
+#
+# Defaults: admin / admin and openmetadata / openmetadata-secret. Operators
+# who want different credentials set the env vars in their compose / k8s
+# deployment manifest — that override now actually takes effect.
+#
+# Operators who need to fully replace shiro.ini (different role layout,
+# custom realms, …) can bind-mount their own file onto /fuseki/shiro.ini —
+# the entrypoint overwrites that path so the mount would lose; in that case
+# replace the entrypoint via `--entrypoint` on `docker run` or override
+# `entrypoint:` in compose so this script doesn't render.
+
+set -eu
+
+: "${FUSEKI_ADMIN_PASSWORD:=admin}"
+: "${FUSEKI_OPENMETADATA_PASSWORD:=openmetadata-secret}"
+export FUSEKI_ADMIN_PASSWORD FUSEKI_OPENMETADATA_PASSWORD
+
+if [ -f /fuseki/shiro.ini.template ]; then
+    # Restrict envsubst to the two variables we expect. Without an explicit
+    # list, envsubst would interpret any `${...}` in the template — including
+    # comments — which would silently blank out unrelated placeholders if
+    # they were ever added.
+    envsubst '${FUSEKI_ADMIN_PASSWORD} ${FUSEKI_OPENMETADATA_PASSWORD}' \
+        </fuseki/shiro.ini.template \
+        >/fuseki/shiro.ini
+fi
+
+exec "$@"

--- a/docker/rdf-store/entrypoint.sh
+++ b/docker/rdf-store/entrypoint.sh
@@ -11,18 +11,28 @@
 # deployment manifest — that override now actually takes effect.
 #
 # Operators who need to fully replace shiro.ini (different role layout,
-# custom realms, …) can bind-mount their own file onto /fuseki/shiro.ini —
-# the entrypoint overwrites that path so the mount would lose; in that case
-# replace the entrypoint via `--entrypoint` on `docker run` or override
-# `entrypoint:` in compose so this script doesn't render.
+# custom realms, …) have two options:
+#
+#   1. Bind-mount your file onto /fuseki/shiro.ini AND set
+#      FUSEKI_RENDER_SHIRO=false — the entrypoint then skips the
+#      envsubst render and leaves the mounted file in place.
+#
+#   2. Bind-mount onto /fuseki/shiro.ini.template instead of /fuseki/shiro.ini
+#      and the entrypoint will envsubst your template (handy if you want
+#      env-driven password injection in your custom realm too).
+#
+# Defaulting FUSEKI_RENDER_SHIRO=true preserves the prior, password-injection
+# behavior for every dev/quickstart compose deployment that doesn't override
+# it.
 
 set -eu
 
 : "${FUSEKI_ADMIN_PASSWORD:=admin}"
 : "${FUSEKI_OPENMETADATA_PASSWORD:=openmetadata-secret}"
+: "${FUSEKI_RENDER_SHIRO:=true}"
 export FUSEKI_ADMIN_PASSWORD FUSEKI_OPENMETADATA_PASSWORD
 
-if [ -f /fuseki/shiro.ini.template ]; then
+if [ "$FUSEKI_RENDER_SHIRO" = "true" ] && [ -f /fuseki/shiro.ini.template ]; then
     # Restrict envsubst to the two variables we expect. Without an explicit
     # list, envsubst would interpret any `${...}` in the template — including
     # comments — which would silently blank out unrelated placeholders if

--- a/docker/rdf-store/shiro.ini
+++ b/docker/rdf-store/shiro.ini
@@ -17,12 +17,14 @@ securityManager.subjectDAO.sessionStorageEvaluator = $sessionStorageEvaluator
 
 # Credentials.
 #
-# Apache Shiro's INI realm does NOT interpolate ${VAR} placeholders — we
-# previously had `admin = ${FUSEKI_ADMIN_PASSWORD:-admin}, admin` and Shiro
-# stored that whole string as the password, so basic auth from the OpenMetadata
-# server (which sends `admin:admin`) always returned 401. Hardcode the defaults
-# here. Operators who need different passwords should bind-mount their own
-# shiro.ini onto /fuseki/shiro.ini or rebuild the image.
+# This file is a TEMPLATE. The entrypoint envsubsts the FUSEKI_ADMIN_PASSWORD
+# and FUSEKI_OPENMETADATA_PASSWORD variables into the [users] section below
+# at container start. Defaults applied in the entrypoint:
+#   admin user password         = admin
+#   openmetadata user password  = openmetadata-secret
+# (Variable names intentionally NOT written with `$` here so the rendered
+# file in /fuseki/shiro.ini does not leak the substituted password back
+# into this comment block.)
 #
 # The admin user carries BOTH the `admin` (server-management) and `writer`
 # (data-mutation) roles so a single credential covers /$/datasets, /$/compact,
@@ -30,8 +32,8 @@ securityManager.subjectDAO.sessionStorageEvaluator = $sessionStorageEvaluator
 # membership, not permission, so admin's `*` permission alone does NOT satisfy
 # roles[writer]; explicit membership in both is required.
 [users]
-admin = admin, admin, writer
-openmetadata = openmetadata-secret, writer
+admin = ${FUSEKI_ADMIN_PASSWORD}, admin, writer
+openmetadata = ${FUSEKI_OPENMETADATA_PASSWORD}, writer
 
 [roles]
 admin = *

--- a/docker/rdf-store/shiro.ini
+++ b/docker/rdf-store/shiro.ini
@@ -6,13 +6,32 @@
 anon = org.apache.shiro.web.filter.authc.AnonymousFilter
 authcBasic = org.apache.shiro.web.filter.authc.BasicHttpAuthenticationFilter
 
-# Use environment variables for credentials
-[users]
-# Default admin user - should be overridden in production
-admin = ${FUSEKI_ADMIN_PASSWORD:-admin}, admin
+# Fuseki 5.x uses Shiro without a session manager configured by default; if
+# the INI doesn't override the SubjectDAO it ends up trying to use the
+# default session storage and throws `IllegalStateException: No SessionManager`
+# on the first authenticated request. Disable session storage so every
+# request re-authenticates via Basic auth (stateless, REST-style).
+sessionStorageEvaluator = org.apache.shiro.web.mgt.DefaultWebSessionStorageEvaluator
+sessionStorageEvaluator.sessionStorageEnabled = false
+securityManager.subjectDAO.sessionStorageEvaluator = $sessionStorageEvaluator
 
-# OpenMetadata service account for updates
-openmetadata = ${FUSEKI_OPENMETADATA_PASSWORD:-openmetadata-secret}, writer
+# Credentials.
+#
+# Apache Shiro's INI realm does NOT interpolate ${VAR} placeholders — we
+# previously had `admin = ${FUSEKI_ADMIN_PASSWORD:-admin}, admin` and Shiro
+# stored that whole string as the password, so basic auth from the OpenMetadata
+# server (which sends `admin:admin`) always returned 401. Hardcode the defaults
+# here. Operators who need different passwords should bind-mount their own
+# shiro.ini onto /fuseki/shiro.ini or rebuild the image.
+#
+# The admin user carries BOTH the `admin` (server-management) and `writer`
+# (data-mutation) roles so a single credential covers /$/datasets, /$/compact,
+# /openmetadata/data and /openmetadata/update — Shiro evaluates roles[] as
+# membership, not permission, so admin's `*` permission alone does NOT satisfy
+# roles[writer]; explicit membership in both is required.
+[users]
+admin = admin, admin, writer
+openmetadata = openmetadata-secret, writer
 
 [roles]
 admin = *

--- a/docker/rdf-store/shiro.ini.template
+++ b/docker/rdf-store/shiro.ini.template
@@ -1,4 +1,16 @@
-# Apache Shiro configuration for Fuseki security
+# Apache Shiro configuration for Fuseki security — TEMPLATE FILE.
+#
+# Do NOT mount or copy this file as-is into /fuseki/shiro.ini. It contains
+# `${FUSEKI_ADMIN_PASSWORD}` and `${FUSEKI_OPENMETADATA_PASSWORD}` placeholders
+# that Apache Shiro's INI realm does NOT interpolate — if Fuseki loads the
+# raw template, the literal string `${FUSEKI_ADMIN_PASSWORD}` becomes the
+# admin password, which silently lets `${FUSEKI_ADMIN_PASSWORD}` log in.
+#
+# The entrypoint.sh in this image envsubsts the file into /fuseki/shiro.ini
+# at container start. If you need a different layout, render the substituted
+# file yourself and bind-mount it onto /fuseki/shiro.ini WITH
+# FUSEKI_RENDER_SHIRO=false set on the container.
+#
 # This integrates with OpenMetadata's authentication
 
 [main]

--- a/openmetadata-integration-tests/pom.xml
+++ b/openmetadata-integration-tests/pom.xml
@@ -211,17 +211,21 @@
       <version>1.1.7</version>
       <scope>test</scope>
     </dependency>
-    <!-- RDF support (Apache Jena) for RDF tests -->
+    <!-- RDF support (Apache Jena) for RDF tests. Version unified with
+         openmetadata-service via the root pom's <jena.version> property —
+         previously this module was on 5.0.0 while openmetadata-service was
+         on 4.10.0, which forced the production code to abstract over Jena 4
+         vs 5 API drift. -->
     <dependency>
       <groupId>org.apache.jena</groupId>
       <artifactId>jena-core</artifactId>
-      <version>5.0.0</version>
+      <version>${jena.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.jena</groupId>
       <artifactId>jena-arq</artifactId>
-      <version>5.0.0</version>
+      <version>${jena.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -954,7 +958,7 @@
                   </includes>
                   <systemPropertyVariables>
                     <enableRdf>true</enableRdf>
-                    <rdfContainerImage>stain/jena-fuseki:latest</rdfContainerImage>
+                    <rdfContainerImage>secoresearch/fuseki:5.5.0</rdfContainerImage>
                     <databaseType>postgres</databaseType>
                     <databaseImage>postgres:15</databaseImage>
                     <searchType>elasticsearch</searchType>
@@ -992,7 +996,7 @@
                   </excludes>
                   <systemPropertyVariables>
                     <enableRdf>true</enableRdf>
-                    <rdfContainerImage>stain/jena-fuseki:latest</rdfContainerImage>
+                    <rdfContainerImage>secoresearch/fuseki:5.5.0</rdfContainerImage>
                     <databaseType>postgres</databaseType>
                     <databaseImage>postgres:15</databaseImage>
                     <searchType>elasticsearch</searchType>

--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/bootstrap/TestSuiteBootstrap.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/bootstrap/TestSuiteBootstrap.java
@@ -116,7 +116,14 @@ public class TestSuiteBootstrap implements LauncherSessionListener {
       "docker.elastic.co/elasticsearch/elasticsearch:9.3.0";
   private static final String DEFAULT_OPENSEARCH_IMAGE = "opensearchproject/opensearch:3.4.0";
 
-  private static final String DEFAULT_FUSEKI_IMAGE = "stain/jena-fuseki:latest";
+  // secoresearch/fuseki:5.5.0 over stain/jena-fuseki: stain's image is
+  // unmaintained (capped at 5.1.0) and missing the two 2025 admin-side CVE
+  // fixes that Jena shipped in 5.5.0 (CVE-2025-49656, CVE-2025-50151). The
+  // secoresearch image is maintained, exposes the same ADMIN_PASSWORD env
+  // var, and uses the standard Fuseki admin endpoints — JenaFusekiStorage's
+  // ensureDatasetExists() handles dataset creation via /$/datasets, so we
+  // don't need stain's `FUSEKI_DATASET_1` shortcut here.
+  private static final String DEFAULT_FUSEKI_IMAGE = "secoresearch/fuseki:5.5.0";
   private static final int FUSEKI_PORT = 3030;
   private static final String FUSEKI_DATASET = "openmetadata";
   private static final String FUSEKI_ADMIN_PASSWORD = "test-admin";
@@ -422,11 +429,15 @@ public class TestSuiteBootstrap implements LauncherSessionListener {
   private void startFuseki() {
     String image = System.getProperty("rdfContainerImage", DEFAULT_FUSEKI_IMAGE);
     LOG.info("Starting Fuseki SPARQL container...");
+    // FUSEKI_DATASET_1 was a stain/jena-fuseki convenience env var to
+    // pre-create a dataset at container start. The maintained image we use
+    // now doesn't provide it; JenaFusekiStorage.ensureDatasetExists() creates
+    // the dataset via the /$/datasets admin endpoint on first connection
+    // instead, so the test path is fine without it.
     FUSEKI_CONTAINER =
         new GenericContainer<>(DockerImageName.parse(image))
             .withExposedPorts(FUSEKI_PORT)
             .withEnv("ADMIN_PASSWORD", FUSEKI_ADMIN_PASSWORD)
-            .withEnv("FUSEKI_DATASET_1", FUSEKI_DATASET)
             .waitingFor(
                 Wait.forHttp("/$/ping")
                     .forPort(FUSEKI_PORT)

--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/bootstrap/TestSuiteBootstrap.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/bootstrap/TestSuiteBootstrap.java
@@ -438,6 +438,11 @@ public class TestSuiteBootstrap implements LauncherSessionListener {
         new GenericContainer<>(DockerImageName.parse(image))
             .withExposedPorts(FUSEKI_PORT)
             .withEnv("ADMIN_PASSWORD", FUSEKI_ADMIN_PASSWORD)
+            // tmpfs the TDB2 dataset dir so each container start gets a clean
+            // store and a long IT run doesn't grow the container's writable
+            // layer. secoresearch/fuseki stores datasets under /fuseki/databases
+            // by default — mounting tmpfs there keeps writes off-disk entirely.
+            .withTmpFs(java.util.Map.of("/fuseki/databases", "rw,size=256m"))
             .waitingFor(
                 Wait.forHttp("/$/ping")
                     .forPort(FUSEKI_PORT)

--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/GlossaryOntologyExportIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/GlossaryOntologyExportIT.java
@@ -73,7 +73,9 @@ public class GlossaryOntologyExportIT {
   private static final String N_TRIPLES_CONTENT_TYPE = "application/n-triples";
   private static final String JSON_LD_CONTENT_TYPE = "application/ld+json";
 
-  private static final String FUSEKI_IMAGE = "stain/jena-fuseki:latest";
+  // See TestSuiteBootstrap for why we use secoresearch/fuseki:5.5.0 instead
+  // of the unmaintained stain/jena-fuseki image.
+  private static final String FUSEKI_IMAGE = "secoresearch/fuseki:5.5.0";
   private static final int FUSEKI_PORT = 3030;
   private static final String FUSEKI_DATASET = "openmetadata";
   private static final String FUSEKI_ADMIN_PASSWORD = "test-admin";
@@ -86,12 +88,12 @@ public class GlossaryOntologyExportIT {
     if (TestSuiteBootstrap.isFusekiEnabled()) {
       fusekiEndpoint = TestSuiteBootstrap.getFusekiEndpoint();
     } else {
+      // No FUSEKI_DATASET_1 here: that was stain-specific. The dataset is
+      // created via /$/datasets by JenaFusekiStorage.ensureDatasetExists().
       localFusekiContainer =
           new GenericContainer<>(DockerImageName.parse(FUSEKI_IMAGE))
               .withExposedPorts(FUSEKI_PORT)
               .withEnv("ADMIN_PASSWORD", FUSEKI_ADMIN_PASSWORD)
-              .withEnv("FUSEKI_DATASET_1", FUSEKI_DATASET)
-              .withTmpFs(java.util.Map.of("/fuseki/databases", "rw,size=256m,uid=100,gid=101"))
               .waitingFor(
                   Wait.forHttp("/$/ping")
                       .forPort(FUSEKI_PORT)

--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/GlossaryOntologyExportIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/GlossaryOntologyExportIT.java
@@ -90,10 +90,12 @@ public class GlossaryOntologyExportIT {
     } else {
       // No FUSEKI_DATASET_1 here: that was stain-specific. The dataset is
       // created via /$/datasets by JenaFusekiStorage.ensureDatasetExists().
+      // tmpfs keeps TDB2 writes off the container's writable layer.
       localFusekiContainer =
           new GenericContainer<>(DockerImageName.parse(FUSEKI_IMAGE))
               .withExposedPorts(FUSEKI_PORT)
               .withEnv("ADMIN_PASSWORD", FUSEKI_ADMIN_PASSWORD)
+              .withTmpFs(java.util.Map.of("/fuseki/databases", "rw,size=256m"))
               .waitingFor(
                   Wait.forHttp("/$/ping")
                       .forPort(FUSEKI_PORT)

--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/RdfGlossaryGraphIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/RdfGlossaryGraphIT.java
@@ -95,10 +95,13 @@ public class RdfGlossaryGraphIT {
     } else {
       // No FUSEKI_DATASET_1 here: that was stain-specific. The dataset is
       // created via /$/datasets by JenaFusekiStorage.ensureDatasetExists().
+      // tmpfs the TDB2 dataset dir so writes never hit the container's
+      // writable layer — keeps a long IT run from bloating it.
       localFusekiContainer =
           new GenericContainer<>(DockerImageName.parse(FUSEKI_IMAGE))
               .withExposedPorts(FUSEKI_PORT)
               .withEnv("ADMIN_PASSWORD", FUSEKI_ADMIN_PASSWORD)
+              .withTmpFs(java.util.Map.of("/fuseki/databases", "rw,size=256m"))
               .waitingFor(
                   Wait.forHttp("/$/ping")
                       .forPort(FUSEKI_PORT)

--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/RdfGlossaryGraphIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/RdfGlossaryGraphIT.java
@@ -388,6 +388,143 @@ public class RdfGlossaryGraphIT {
   }
 
   @Test
+  void customRdfPredicateRelationSurfacesInGraphEndpoint(TestNamespace ns) throws Exception {
+    // Regression: GlossaryTermRelationSettings lets operators define custom
+    // relation types with arbitrary rdfPredicate URIs (e.g. "Enrolls In" with
+    // rdfPredicate https://example.com/ontology/enrolls). The writer
+    // (bulkAddGlossaryTermRelations / addGlossaryTermRelation) honoured those
+    // custom predicates and wrote the triples to Fuseki correctly. The reader
+    // (RdfRepository.buildGlossaryTermGraphQuery) hardcoded its SPARQL
+    // FILTER ?relationType IN (...) to the built-in CURIE list, silently
+    // dropping every custom-typed edge. Customer environments saw their
+    // relations in the Overview tab (DB-backed) but the term-page Relations
+    // Graph (the RDF-backed view) rendered only the source node alone — the
+    // image-v6 / image-v8 case in the bug report. None of the existing tests
+    // exercised this writer/reader symmetry because they all stuck to built-in
+    // relation types.
+    //
+    // This test registers a custom relation type via the settings API, points
+    // two terms at each other through it, and asserts the graph endpoint
+    // returns the edge. Cleans up the settings entry on the way out so
+    // parallel/subsequent tests aren't affected.
+    String customTypeName = "regressionCustomRel";
+    URI customPredicate = URI.create("https://example.com/regression/customRel");
+    addCustomRelationTypeToSettings(customTypeName, customPredicate);
+    try {
+      Glossary glossary = GlossaryTestFactory.createWithName(ns, "customRdfPred");
+      GlossaryTerm a = GlossaryTermTestFactory.createWithName(ns, glossary, "alpha");
+      GlossaryTerm b = GlossaryTermTestFactory.createWithName(ns, glossary, "beta");
+
+      awaitTermInGraph(glossary.getId(), a.getId());
+      awaitTermInGraph(glossary.getId(), b.getId());
+
+      addRelation(a.getId(), b.getId(), customTypeName);
+      awaitRelatedTermInDb(a.getId(), b.getId(), customTypeName);
+
+      // The fix: buildGlossaryTermGraphQuery must read configured custom
+      // predicates from GlossaryTermRelationSettings and append them to the
+      // FILTER list. Without the fix this edge is silently filtered out
+      // and the graph endpoint returns nodes-but-no-edges for the source
+      // term — exactly the customer's symptom.
+      awaitEdgeBetween(glossary.getId(), a.getId(), b.getId(), customTypeName);
+    } finally {
+      removeCustomRelationTypeFromSettings(customTypeName);
+    }
+  }
+
+  /**
+   * PUT a new relation type onto the system-level GlossaryTermRelationSettings.
+   * Preserves whatever's already configured (defaults + any types from earlier
+   * tests still on the way out) and appends our custom one.
+   */
+  private void addCustomRelationTypeToSettings(String name, URI rdfPredicate) throws Exception {
+    JsonNode existing = fetchGlossaryTermRelationSettings();
+    com.fasterxml.jackson.databind.node.ObjectNode payload = MAPPER.createObjectNode();
+    payload.put("config_type", "glossaryTermRelationSettings");
+    com.fasterxml.jackson.databind.node.ObjectNode value = MAPPER.createObjectNode();
+    com.fasterxml.jackson.databind.node.ArrayNode types = MAPPER.createArrayNode();
+    if (existing != null && existing.has("relationTypes")) {
+      existing.get("relationTypes").forEach(types::add);
+    }
+    com.fasterxml.jackson.databind.node.ObjectNode custom = MAPPER.createObjectNode();
+    custom.put("name", name);
+    custom.put("rdfPredicate", rdfPredicate.toString());
+    types.add(custom);
+    value.set("relationTypes", types);
+    payload.set("config_value", value);
+    HttpRequest request =
+        HttpRequest.newBuilder()
+            .uri(URI.create(SdkClients.getServerUrl() + "/v1/system/settings"))
+            .header("Authorization", "Bearer " + SdkClients.getAdminToken())
+            .header("Content-Type", "application/json")
+            .timeout(Duration.ofSeconds(30))
+            .PUT(HttpRequest.BodyPublishers.ofString(MAPPER.writeValueAsString(payload)))
+            .build();
+    HttpResponse<String> response = HTTP_CLIENT.send(request, HttpResponse.BodyHandlers.ofString());
+    assertEquals(
+        200,
+        response.statusCode(),
+        () -> "PUT settings failed: " + response.statusCode() + " " + response.body());
+  }
+
+  private void removeCustomRelationTypeFromSettings(String name) {
+    try {
+      JsonNode existing = fetchGlossaryTermRelationSettings();
+      if (existing == null || !existing.has("relationTypes")) {
+        return;
+      }
+      com.fasterxml.jackson.databind.node.ObjectNode payload = MAPPER.createObjectNode();
+      payload.put("config_type", "glossaryTermRelationSettings");
+      com.fasterxml.jackson.databind.node.ObjectNode value = MAPPER.createObjectNode();
+      com.fasterxml.jackson.databind.node.ArrayNode kept = MAPPER.createArrayNode();
+      for (JsonNode t : existing.get("relationTypes")) {
+        if (!name.equals(t.path("name").asText(null))) {
+          kept.add(t);
+        }
+      }
+      value.set("relationTypes", kept);
+      payload.set("config_value", value);
+      HttpRequest request =
+          HttpRequest.newBuilder()
+              .uri(URI.create(SdkClients.getServerUrl() + "/v1/system/settings"))
+              .header("Authorization", "Bearer " + SdkClients.getAdminToken())
+              .header("Content-Type", "application/json")
+              .timeout(Duration.ofSeconds(30))
+              .PUT(HttpRequest.BodyPublishers.ofString(MAPPER.writeValueAsString(payload)))
+              .build();
+      HTTP_CLIENT.send(request, HttpResponse.BodyHandlers.ofString());
+    } catch (Exception e) {
+      LOG.warn("Failed to remove custom relation type {} from settings", name, e);
+    }
+  }
+
+  private JsonNode fetchGlossaryTermRelationSettings() throws Exception {
+    HttpRequest request =
+        HttpRequest.newBuilder()
+            .uri(URI.create(SdkClients.getServerUrl() + "/v1/system/settings"))
+            .header("Authorization", "Bearer " + SdkClients.getAdminToken())
+            .header("Accept", "application/json")
+            .timeout(Duration.ofSeconds(30))
+            .GET()
+            .build();
+    HttpResponse<String> response = HTTP_CLIENT.send(request, HttpResponse.BodyHandlers.ofString());
+    if (response.statusCode() != 200) {
+      return null;
+    }
+    JsonNode all = MAPPER.readTree(response.body());
+    for (JsonNode s : all.path("data")) {
+      if ("glossaryTermRelationSettings".equals(s.path("config_type").asText(null))) {
+        JsonNode value = s.get("config_value");
+        if (value != null && value.isTextual()) {
+          return MAPPER.readTree(value.asText());
+        }
+        return value;
+      }
+    }
+    return null;
+  }
+
+  @Test
   void changingRelationTypeReplacesOldEdgeWithNewType(TestNamespace ns) throws Exception {
     // Simulates the UI "edit relation type" flow as delete-then-add. Verify
     // the resulting state is exactly one edge of the new type, no orphans.

--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/RdfGlossaryGraphIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/RdfGlossaryGraphIT.java
@@ -435,10 +435,45 @@ public class RdfGlossaryGraphIT {
     }
   }
 
+  @Test
+  void customRelationWithNullRdfPredicateSurfacesInGraphEndpoint(TestNamespace ns)
+      throws Exception {
+    // Companion to customRdfPredicateRelationSurfacesInGraphEndpoint covering
+    // the OTHER half of the customer's actual configuration: a custom relation
+    // type registered in GlossaryTermRelationSettings WITHOUT a populated
+    // rdfPredicate (the Novartis instance had `definedby`, `enabledby`,
+    // `enrollsin` all stored with rdfPredicate=null). On the writer side
+    // getGlossaryTermRelationPredicate falls back to
+    // `https://open-metadata.org/ontology/<name>`; the reader fix must mirror
+    // that fallback or the edges still don't surface.
+    String customTypeName = "regressionNullPredRel";
+    addCustomRelationTypeToSettings(customTypeName, /* rdfPredicate */ null);
+    try {
+      Glossary glossary = GlossaryTestFactory.createWithName(ns, "nullRdfPred");
+      GlossaryTerm a = GlossaryTermTestFactory.createWithName(ns, glossary, "gamma");
+      GlossaryTerm b = GlossaryTermTestFactory.createWithName(ns, glossary, "delta");
+
+      awaitTermInGraph(glossary.getId(), a.getId());
+      awaitTermInGraph(glossary.getId(), b.getId());
+
+      addRelation(a.getId(), b.getId(), customTypeName);
+      awaitRelatedTermInDb(a.getId(), b.getId(), customTypeName);
+
+      // Without the null-rdfPredicate fallback in the reader's FILTER assembly,
+      // this edge (written as om:regressionNullPredRel) is filtered out.
+      awaitEdgeBetween(glossary.getId(), a.getId(), b.getId(), customTypeName);
+    } finally {
+      removeCustomRelationTypeFromSettings(customTypeName);
+    }
+  }
+
   /**
    * PUT a new relation type onto the system-level GlossaryTermRelationSettings.
    * Preserves whatever's already configured (defaults + any types from earlier
-   * tests still on the way out) and appends our custom one.
+   * tests still on the way out) and appends our custom one. Pass {@code null}
+   * for {@code rdfPredicate} to exercise the "operator added a type but didn't
+   * fill in the RDF predicate URI" case — the writer falls back to
+   * {@code om:<name>} and the reader must mirror that fallback.
    */
   private void addCustomRelationTypeToSettings(String name, URI rdfPredicate) throws Exception {
     JsonNode existing = fetchGlossaryTermRelationSettings();
@@ -451,7 +486,9 @@ public class RdfGlossaryGraphIT {
     }
     com.fasterxml.jackson.databind.node.ObjectNode custom = MAPPER.createObjectNode();
     custom.put("name", name);
-    custom.put("rdfPredicate", rdfPredicate.toString());
+    if (rdfPredicate != null) {
+      custom.put("rdfPredicate", rdfPredicate.toString());
+    }
     types.add(custom);
     value.set("relationTypes", types);
     payload.set("config_value", value);

--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/RdfGlossaryGraphIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/RdfGlossaryGraphIT.java
@@ -78,7 +78,9 @@ public class RdfGlossaryGraphIT {
   private static final HttpClient HTTP_CLIENT =
       HttpClient.newBuilder().connectTimeout(Duration.ofSeconds(10)).build();
 
-  private static final String FUSEKI_IMAGE = "stain/jena-fuseki:latest";
+  // See TestSuiteBootstrap for why we use secoresearch/fuseki:5.5.0 instead
+  // of the unmaintained stain/jena-fuseki image.
+  private static final String FUSEKI_IMAGE = "secoresearch/fuseki:5.5.0";
   private static final int FUSEKI_PORT = 3030;
   private static final String FUSEKI_DATASET = "openmetadata";
   private static final String FUSEKI_ADMIN_PASSWORD = "test-admin";
@@ -91,12 +93,12 @@ public class RdfGlossaryGraphIT {
     if (TestSuiteBootstrap.isFusekiEnabled()) {
       fusekiEndpoint = TestSuiteBootstrap.getFusekiEndpoint();
     } else {
+      // No FUSEKI_DATASET_1 here: that was stain-specific. The dataset is
+      // created via /$/datasets by JenaFusekiStorage.ensureDatasetExists().
       localFusekiContainer =
           new GenericContainer<>(DockerImageName.parse(FUSEKI_IMAGE))
               .withExposedPorts(FUSEKI_PORT)
               .withEnv("ADMIN_PASSWORD", FUSEKI_ADMIN_PASSWORD)
-              .withEnv("FUSEKI_DATASET_1", FUSEKI_DATASET)
-              .withTmpFs(java.util.Map.of("/fuseki/databases", "rw,size=256m,uid=100,gid=101"))
               .waitingFor(
                   Wait.forHttp("/$/ping")
                       .forPort(FUSEKI_PORT)

--- a/openmetadata-service/pom.xml
+++ b/openmetadata-service/pom.xml
@@ -972,12 +972,31 @@
       <version>2.1.0</version>
     </dependency>
 
-    <!-- Apache Jena RDF Dependencies -->
+    <!-- Apache Jena RDF Dependencies (client side only). We talk to a REMOTE
+         Fuseki server, so we don't ship the embedded TDB1/TDB2 stores. Pulling
+         them in via `apache-jena-libs` causes static-init failures on Jena 5/6
+         (jena-tdb1's InitTDB → ReorderFixed → RDF.Alt fires while
+         org.apache.jena.vocabulary.RDF is still being class-initialized; the
+         result is an ExceptionInInitializerError on the first touch of any
+         Jena class). Listing only the jars we actually use sidesteps that and
+         keeps the wire surface explicit. Pinned to a single version across
+         the project: previously openmetadata-service was on 4.10.0 and
+         openmetadata-integration-tests on 5.0.0, leaving two classpaths that
+         disagreed on RDFConnection/QueryExecution API shape. -->
     <dependency>
       <groupId>org.apache.jena</groupId>
-      <artifactId>apache-jena-libs</artifactId>
-      <version>4.10.0</version>
-      <type>pom</type>
+      <artifactId>jena-core</artifactId>
+      <version>${jena.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.jena</groupId>
+      <artifactId>jena-arq</artifactId>
+      <version>${jena.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.jena</groupId>
+      <artifactId>jena-rdfconnection</artifactId>
+      <version>${jena.version}</version>
     </dependency>
     
     <!-- Apache Calcite for SQL parsing -->

--- a/openmetadata-service/pom.xml
+++ b/openmetadata-service/pom.xml
@@ -1011,10 +1011,17 @@
         </exclusion>
       </exclusions>
     </dependency>
+    <!-- titanium-json-ld must match what Jena's JSON-LD writer expects. Jena
+         5.6.0 calls into the new com.apicatalog.rdf.api.RdfConsumer API
+         introduced in titanium 1.5.0; pinning 1.4.0 here let the integration
+         test `GlossaryOntologyExportIT.testExportGlossaryAsJsonLd` blow up
+         with NoClassDefFoundError com/apicatalog/rdf/api/RdfConsumerException
+         on every Jena JSON-LD export. Jena 5.6.0's parent pom uses 1.7.0; we
+         match that. -->
     <dependency>
       <groupId>com.apicatalog</groupId>
       <artifactId>titanium-json-ld</artifactId>
-      <version>1.4.0</version>
+      <version>1.7.0</version>
     </dependency>
     <dependency>
       <groupId>org.glassfish</groupId>

--- a/openmetadata-service/src/main/java/org/openmetadata/service/apps/bundles/rdf/RdfBatchProcessor.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/apps/bundles/rdf/RdfBatchProcessor.java
@@ -79,30 +79,46 @@ public class RdfBatchProcessor {
     // If the bulk write fails (one bad model rolls back the whole batch), we
     // fall back to the per-entity loop so the indexer can still attribute the
     // failure to a specific entity instead of failing the whole batch with a
-    // single composite error.
+    // single composite error. The fallback is skipped when the storage layer
+    // has tripped its circuit breaker (connect failures, Fuseki unreachable):
+    // each of the N per-entity attempts would also fail-fast on the same
+    // breaker, wasting time and amplifying error noise. We mark the whole
+    // batch as failed instead and let the indexer move on — the breaker
+    // will close once Fuseki recovers and the next batch retries cleanly.
     if (!effectiveStopRequested.getAsBoolean()) {
       try {
         rdfRepository.bulkCreateOrUpdate(entities);
         indexedEntities.addAll(entities);
         successCount = entities.size();
       } catch (Exception e) {
-        LOG.warn(
-            "Bulk write of {} {} entities failed; falling back to per-entity to isolate the bad row. Reason: {}",
-            entities.size(),
-            entityType,
-            e.getMessage());
-        for (EntityInterface entity : entities) {
-          if (effectiveStopRequested.getAsBoolean()) {
-            break;
-          }
-          try {
-            rdfRepository.createOrUpdate(entity);
-            indexedEntities.add(entity);
-            successCount++;
-          } catch (Exception ee) {
-            LOG.error("Failed to index entity {} to RDF", entity.getId(), ee);
-            failedCount++;
-            lastError = describeEntityError(entityType, entity.getId(), ee);
+        if (isCircuitBreakerOpen(e)) {
+          LOG.warn(
+              "Bulk write of {} {} entities failed and the RDF circuit breaker is open; "
+                  + "skipping per-entity fallback. Reason: {}",
+              entities.size(),
+              entityType,
+              e.getMessage());
+          failedCount = entities.size();
+          lastError = describeError(entityType + " batch", e);
+        } else {
+          LOG.warn(
+              "Bulk write of {} {} entities failed; falling back to per-entity to isolate the bad row. Reason: {}",
+              entities.size(),
+              entityType,
+              e.getMessage());
+          for (EntityInterface entity : entities) {
+            if (effectiveStopRequested.getAsBoolean()) {
+              break;
+            }
+            try {
+              rdfRepository.createOrUpdate(entity);
+              indexedEntities.add(entity);
+              successCount++;
+            } catch (Exception ee) {
+              LOG.error("Failed to index entity {} to RDF", entity.getId(), ee);
+              failedCount++;
+              lastError = describeEntityError(entityType, entity.getId(), ee);
+            }
           }
         }
       }
@@ -160,6 +176,30 @@ public class RdfBatchProcessor {
       message = rootCause.getClass().getSimpleName();
     }
     return prefix + ": " + message;
+  }
+
+  /**
+   * Recognise a "circuit breaker tripped" failure from the RDF storage layer.
+   * JenaFusekiStorage throws a RuntimeException whose message starts with
+   * "RDF circuit breaker is open" when {@code throwIfCircuitOpen} fast-fails.
+   * The bulk-fallback path uses this to skip the per-entity retry loop —
+   * every entity would hit the same breaker and produce N noisy failures
+   * instead of one informative one.
+   */
+  private static boolean isCircuitBreakerOpen(Throwable error) {
+    Throwable cause = error;
+    while (cause != null) {
+      String msg = cause.getMessage();
+      if (msg != null && msg.contains("RDF circuit breaker is open")) {
+        return true;
+      }
+      Throwable next = cause.getCause();
+      if (next == cause) {
+        return false;
+      }
+      cause = next;
+    }
+    return false;
   }
 
   private static String describeEntityError(String entityType, UUID entityId, Throwable error) {

--- a/openmetadata-service/src/main/java/org/openmetadata/service/apps/bundles/rdf/RdfBatchProcessor.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/apps/bundles/rdf/RdfBatchProcessor.java
@@ -76,6 +76,14 @@ public class RdfBatchProcessor {
     // on localhost it caps single-coordinator throughput at ~6.7 entities/s.
     // Batching collapses those 2N round trips into 2 per batch.
     //
+    // The bulk write is atomic at the Fuseki side (single SPARQL UPDATE +
+    // single GSP POST) — there's no mid-batch checkpoint where a stop signal
+    // could partially commit, so we check it once before issuing the call and
+    // once after, mirroring the previous per-entity loop's check-at-iteration
+    // semantics. A stop signal landing mid-HTTP-call still completes the
+    // current batch (preferable to leaving Fuseki in a half-applied state)
+    // and is honored on the next batch boundary.
+    //
     // If the bulk write fails (one bad model rolls back the whole batch), we
     // fall back to the per-entity loop so the indexer can still attribute the
     // failure to a specific entity instead of failing the whole batch with a
@@ -180,17 +188,19 @@ public class RdfBatchProcessor {
 
   /**
    * Recognise a "circuit breaker tripped" failure from the RDF storage layer.
-   * JenaFusekiStorage throws a RuntimeException whose message starts with
-   * "RDF circuit breaker is open" when {@code throwIfCircuitOpen} fast-fails.
-   * The bulk-fallback path uses this to skip the per-entity retry loop —
-   * every entity would hit the same breaker and produce N noisy failures
-   * instead of one informative one.
+   * The storage layer throws {@link
+   * org.openmetadata.service.rdf.storage.RdfStorageCircuitOpenException} when
+   * a fast-fail trips; that exception may travel through a wrapper layer
+   * (e.g. RdfRepository.bulkCreateOrUpdate catches and re-throws as a
+   * generic RuntimeException), so we walk the cause chain to find it. The
+   * bulk-fallback path uses this to skip the per-entity retry loop — every
+   * entity would hit the same breaker and produce N noisy failures instead
+   * of one informative one.
    */
   private static boolean isCircuitBreakerOpen(Throwable error) {
     Throwable cause = error;
     while (cause != null) {
-      String msg = cause.getMessage();
-      if (msg != null && msg.contains("RDF circuit breaker is open")) {
+      if (cause instanceof org.openmetadata.service.rdf.storage.RdfStorageCircuitOpenException) {
         return true;
       }
       Throwable next = cause.getCause();

--- a/openmetadata-service/src/main/java/org/openmetadata/service/apps/bundles/rdf/RdfBatchProcessor.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/apps/bundles/rdf/RdfBatchProcessor.java
@@ -71,18 +71,40 @@ public class RdfBatchProcessor {
     String lastError = null;
     List<EntityInterface> indexedEntities = new ArrayList<>();
 
-    for (EntityInterface entity : entities) {
-      if (effectiveStopRequested.getAsBoolean()) {
-        break;
-      }
+    // Fast path: one combined SPARQL UPDATE for the whole batch. Per-entity
+    // storeEntity costs ~2 HTTP round trips (DELETE + GSP LOAD) — at ~75 ms RT
+    // on localhost it caps single-coordinator throughput at ~6.7 entities/s.
+    // Batching collapses those 2N round trips into 2 per batch.
+    //
+    // If the bulk write fails (one bad model rolls back the whole batch), we
+    // fall back to the per-entity loop so the indexer can still attribute the
+    // failure to a specific entity instead of failing the whole batch with a
+    // single composite error.
+    if (!effectiveStopRequested.getAsBoolean()) {
       try {
-        rdfRepository.createOrUpdate(entity);
-        indexedEntities.add(entity);
-        successCount++;
+        rdfRepository.bulkCreateOrUpdate(entities);
+        indexedEntities.addAll(entities);
+        successCount = entities.size();
       } catch (Exception e) {
-        LOG.error("Failed to index entity {} to RDF", entity.getId(), e);
-        failedCount++;
-        lastError = describeEntityError(entityType, entity.getId(), e);
+        LOG.warn(
+            "Bulk write of {} {} entities failed; falling back to per-entity to isolate the bad row. Reason: {}",
+            entities.size(),
+            entityType,
+            e.getMessage());
+        for (EntityInterface entity : entities) {
+          if (effectiveStopRequested.getAsBoolean()) {
+            break;
+          }
+          try {
+            rdfRepository.createOrUpdate(entity);
+            indexedEntities.add(entity);
+            successCount++;
+          } catch (Exception ee) {
+            LOG.error("Failed to index entity {} to RDF", entity.getId(), ee);
+            failedCount++;
+            lastError = describeEntityError(entityType, entity.getId(), ee);
+          }
+        }
       }
     }
 

--- a/openmetadata-service/src/main/java/org/openmetadata/service/apps/bundles/rdf/RdfBatchProcessor.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/apps/bundles/rdf/RdfBatchProcessor.java
@@ -93,6 +93,16 @@ public class RdfBatchProcessor {
     // breaker, wasting time and amplifying error noise. We mark the whole
     // batch as failed instead and let the indexer move on — the breaker
     // will close once Fuseki recovers and the next batch retries cleanly.
+    //
+    // Caveat: the per-entity isolation only works when failures are payload-
+    // data-dependent (one entity emits a model the writer can't serialise).
+    // If the failure is predicate-SHAPE-dependent — e.g. a configured custom
+    // predicate URI contains characters the SPARQL serializer chokes on —
+    // every entity in the batch hits the same parse failure, so per-entity
+    // fallback also fails for all N entities and lastError carries the
+    // composite-style message. Predicate URIs come from the schema-validated
+    // GlossaryTermRelationSettings so this is unlikely in practice, but
+    // operator-injected custom predicates are the failure mode to watch.
     if (!effectiveStopRequested.getAsBoolean()) {
       try {
         rdfRepository.bulkCreateOrUpdate(entities);
@@ -198,16 +208,21 @@ public class RdfBatchProcessor {
    * of one informative one.
    */
   private static boolean isCircuitBreakerOpen(Throwable error) {
+    // Use an identity-equality Set for visited-tracking so multi-hop cycles
+    // (A.getCause()→B, B.getCause()→A) are detected — the previous
+    // single-hop check (next == cause) only caught immediate self-cycles.
+    // Cause chains shouldn't loop in well-behaved code, but exceptions
+    // wrapped by user-supplied frameworks or AOP layers occasionally do,
+    // and crossing the storage/repository wrap boundary makes a defensive
+    // check cheap insurance.
+    java.util.Set<Throwable> visited =
+        java.util.Collections.newSetFromMap(new java.util.IdentityHashMap<>());
     Throwable cause = error;
-    while (cause != null) {
+    while (cause != null && visited.add(cause)) {
       if (cause instanceof org.openmetadata.service.rdf.storage.RdfStorageCircuitOpenException) {
         return true;
       }
-      Throwable next = cause.getCause();
-      if (next == cause) {
-        return false;
-      }
-      cause = next;
+      cause = cause.getCause();
     }
     return false;
   }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/apps/bundles/rdf/RdfIndexApp.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/apps/bundles/rdf/RdfIndexApp.java
@@ -206,10 +206,25 @@ public class RdfIndexApp extends AbstractNativeApplication {
         // free-list and journal up to tens of GB even though the live triple
         // count stayed bounded. Running compact at the end of every successful
         // reindex caps growth at one-run's worth of churn regardless of which
-        // path took us here. The call is best-effort (failures logged + swallowed)
-        // so a missing /$/compact endpoint or transient HTTP failure never
-        // demotes a successful indexing job to FAILED.
-        rdfRepository.compactStorage();
+        // path took us here.
+        //
+        // Defensive try/catch: JenaFusekiStorage.compactStorage() already
+        // catches its own exceptions, but RdfRepository.compactStorage() is
+        // a thin pass-through and a future storage backend (QLever, etc.)
+        // may not honor the same swallow-failures contract. Worse, a race
+        // between isEnabled() and storageService.compactStorage() could
+        // surface an NPE. Catch here so any unexpected runtime failure
+        // can NEVER demote a job that's already COMPLETED to FAILED via
+        // the outer catch's handleJobFailure().
+        try {
+          rdfRepository.compactStorage();
+        } catch (RuntimeException compactFailure) {
+          LOG.warn(
+              "Post-run compaction failed for this RDF reindex job; disk reclamation "
+                  + "skipped, but the job itself completed successfully. Reason: {}",
+              compactFailure.getMessage(),
+              compactFailure);
+        }
       }
 
       LOG.info("RDF Index Job Completed for Entities: {}", jobData.getEntities());

--- a/openmetadata-service/src/main/java/org/openmetadata/service/apps/bundles/rdf/RdfIndexApp.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/apps/bundles/rdf/RdfIndexApp.java
@@ -190,6 +190,17 @@ public class RdfIndexApp extends AbstractNativeApplication {
       if (stopped) {
         updateJobStatus(EventPublisherJob.Status.STOPPED);
       } else {
+        // Final compaction after a successful run. The recreate branch already
+        // compacted *before* the reindex (against the empty post-clearAll
+        // state) to maximise the reclaim; on the incremental branch nothing
+        // had ever compacted, so weeks of incremental runs piled the TDB2
+        // free-list and journal up to tens of GB even though the live triple
+        // count stayed bounded. Running compact at the end of every successful
+        // reindex caps growth at one-run's worth of churn regardless of which
+        // path took us here. The call is best-effort (failures logged + swallowed)
+        // so a missing /$/compact endpoint or transient HTTP failure never
+        // demotes a successful indexing job to FAILED.
+        rdfRepository.compactStorage();
         updateJobStatus(EventPublisherJob.Status.COMPLETED);
       }
 

--- a/openmetadata-service/src/main/java/org/openmetadata/service/apps/bundles/rdf/RdfIndexApp.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/apps/bundles/rdf/RdfIndexApp.java
@@ -258,6 +258,14 @@ public class RdfIndexApp extends AbstractNativeApplication {
     try {
       rdfRepository.clearAll();
       LOG.info("Cleared all RDF data");
+      // CLEAR ALL is a logical delete on TDB2: triples are marked free but the
+      // on-disk dataset and journal keep growing across runs. Compact NOW while
+      // the dataset is essentially empty so the next re-ingest writes into a
+      // fresh, small dataset directory. Without this, every recreateIndex run
+      // accumulates ~1x the dataset size on disk and the PVC eventually fills.
+      // Must run BEFORE reloadOntologies(), otherwise the ontology graph gets
+      // copied through compaction unnecessarily.
+      rdfRepository.compactStorage();
       // CLEAR ALL wipes the ontology and shapes graphs as well; reload them
       // before indexing starts so SPARQL queries that depend on the ontology
       // (inference, federated, etc.) work after the wipe.

--- a/openmetadata-service/src/main/java/org/openmetadata/service/apps/bundles/rdf/RdfIndexApp.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/apps/bundles/rdf/RdfIndexApp.java
@@ -190,6 +190,15 @@ public class RdfIndexApp extends AbstractNativeApplication {
       if (stopped) {
         updateJobStatus(EventPublisherJob.Status.STOPPED);
       } else {
+        // Mark the job COMPLETED BEFORE compacting. compactStorage is a
+        // blocking call (up to COMPACT_MAX_WAIT_MS = 10 min while it polls
+        // /$/tasks/{id}); doing it before the status update would delay the
+        // websocket "done" notification by however long compaction takes,
+        // and a misbehaving Fuseki could leave the run looking RUNNING for
+        // up to 10 minutes after the reindex actually finished. Compaction
+        // is best-effort hygiene; surface job-completion to the UI first
+        // and run compaction as the very last step.
+        updateJobStatus(EventPublisherJob.Status.COMPLETED);
         // Final compaction after a successful run. The recreate branch already
         // compacted *before* the reindex (against the empty post-clearAll
         // state) to maximise the reclaim; on the incremental branch nothing
@@ -201,7 +210,6 @@ public class RdfIndexApp extends AbstractNativeApplication {
         // so a missing /$/compact endpoint or transient HTTP failure never
         // demotes a successful indexing job to FAILED.
         rdfRepository.compactStorage();
-        updateJobStatus(EventPublisherJob.Status.COMPLETED);
       }
 
       LOG.info("RDF Index Job Completed for Entities: {}", jobData.getEntities());

--- a/openmetadata-service/src/main/java/org/openmetadata/service/rdf/RdfRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/rdf/RdfRepository.java
@@ -237,19 +237,16 @@ public class RdfRepository {
    * per-entity {@link #createOrUpdate} for per-row error attribution). The
    * indexer in {@code RdfBatchProcessor.processEntities} does the latter.
    *
-   * <p>Implementation note: under the hood {@link
+   * <p>Implementation note: {@link
    * org.openmetadata.service.rdf.storage.JenaFusekiStorage#bulkStoreEntities}
-   * issues TWO Fuseki operations — a combined SPARQL UPDATE that DELETEs
-   * the predicate-scoped triples for every entity in the batch, then a GSP
-   * POST that loads the combined N-Triples body. If the second call fails
-   * after the first commits, the batch is left in an INCONSISTENT state on
-   * Fuseki (every entity's prior translator-managed predicates are gone but
-   * the new triples never landed). The caller's fall-back to per-entity
-   * recreates each affected entity's triples cleanly, so the inconsistency
-   * is self-healing within one batch's worth of retries. Fully atomic
-   * delete+insert in a single transaction would require switching the load
-   * to {@code INSERT DATA} via {@code /update} instead of GSP POST to
-   * {@code /data}; that's worth doing but out of scope for this PR.
+   * runs the batch as a SINGLE SPARQL UPDATE containing both the combined
+   * per-entity DELETE statements and an {@code INSERT DATA} block with the
+   * unioned N-Triples body. Fuseki executes multi-statement UPDATEs in one
+   * transaction, so the write is atomic at the storage side — either the
+   * whole batch lands or nothing does. The per-entity fallback in
+   * {@code RdfBatchProcessor.processEntities} therefore only runs on
+   * payload-shape failures (a single bad RDF model the writer can't
+   * serialise), not on partial-commit recovery.
    */
   public void bulkCreateOrUpdate(List<? extends EntityInterface> entities) {
     if (!isEnabled() || entities == null || entities.isEmpty()) {
@@ -1584,7 +1581,13 @@ public class RdfRepository {
 
               String extractedRelationType = extractPredicateName(relationTypeUri);
               String formattedLabel = formatGlossaryRelationType(relationTypeUri);
-              LOG.info(
+              // DEBUG, not INFO: this fires once per edge in the parsed
+              // SPARQL result set. A typical graph response with hundreds
+              // of edges would emit hundreds of INFO log lines per request
+              // and dominate log-aggregation cost. The "RDF query returned
+              // {} nodes and {} edges" summary log further down covers the
+              // per-request signal at INFO level.
+              LOG.debug(
                   "RDF Edge: {} -> {}, predicateUri={}, extractedType={}, label={}",
                   extractEntityIdFromUri(term1Uri),
                   extractEntityIdFromUri(term2Uri),

--- a/openmetadata-service/src/main/java/org/openmetadata/service/rdf/RdfRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/rdf/RdfRepository.java
@@ -1357,7 +1357,13 @@ public class RdfRepository {
             relationPredicates.add("<" + fullUri + ">");
           }
         }
-      } catch (Exception e) {
+      } catch (RuntimeException e) {
+        // SettingsCache.getSetting wraps everything as EntityNotFoundException
+        // (a RuntimeException) on miss; catching Exception was wider than
+        // necessary and would swallow programmer-error throwables. Narrow to
+        // RuntimeException, which still covers the cache miss / cast failure
+        // cases while letting checked exceptions (none today, but defensive)
+        // propagate.
         LOG.debug(
             "Could not load GlossaryTermRelationSettings for graph query — "
                 + "custom-typed glossary relations will be filtered out of the response. "
@@ -1949,7 +1955,12 @@ public class RdfRepository {
             }
           }
         }
-      } catch (Exception e) {
+      } catch (RuntimeException e) {
+        // Narrowed from Exception per project coding standards. SettingsCache
+        // surfaces all failures (cache miss, cast failure, …) as a
+        // RuntimeException (EntityNotFoundException), so RuntimeException
+        // covers the failure modes we expect while letting programmer-error
+        // throwables that signal a real bug propagate to test runs.
         LOG.debug(
             "Could not load GlossaryTermRelationSettings while extracting predicate name; "
                 + "falling back to URI local-name. Cause: {}",

--- a/openmetadata-service/src/main/java/org/openmetadata/service/rdf/RdfRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/rdf/RdfRepository.java
@@ -1308,6 +1308,14 @@ public class RdfRepository {
       // may not share any of the declared prefixes, so we always inject the
       // expanded form in angle brackets. Deduplication is handled by SPARQL
       // (?relationType IN (a, b, a) is equivalent to IN (a, b)).
+      //
+      // expandPredicateCurie is idempotent for full http(s) IRIs (see its
+      // early-return branch at the `startsWith("http://") || startsWith("https://")`
+      // check), so passing rdfPredicate.toString() through is safe whether
+      // the configured value is already a full IRI (the realistic case for
+      // custom types) or a CURIE-shaped URI like `skos:broader` (rare but
+      // technically valid as a java.net.URI). Either way we end up with the
+      // same fully-expanded IRI the writer used when storing the triple.
       try {
         GlossaryTermRelationSettings settings =
             SettingsCache.getSetting(

--- a/openmetadata-service/src/main/java/org/openmetadata/service/rdf/RdfRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/rdf/RdfRepository.java
@@ -1354,13 +1354,10 @@ public class RdfRepository {
                 SettingsType.GLOSSARY_TERM_RELATION_SETTINGS, GlossaryTermRelationSettings.class);
         if (settings != null && settings.getRelationTypes() != null) {
           for (var configuredType : settings.getRelationTypes()) {
-            java.net.URI rdfPredicate = configuredType.getRdfPredicate();
-            String fullUri;
-            if (rdfPredicate != null) {
-              fullUri = expandPredicateCurie(rdfPredicate.toString());
-            } else if (configuredType.getName() != null && !configuredType.getName().isBlank()) {
-              fullUri = "https://open-metadata.org/ontology/" + configuredType.getName();
-            } else {
+            String fullUri =
+                resolveConfiguredTypeUri(
+                    configuredType.getRdfPredicate(), configuredType.getName());
+            if (fullUri == null) {
               continue;
             }
             relationPredicates.add("<" + fullUri + ">");
@@ -1650,12 +1647,11 @@ public class RdfRepository {
               SettingsType.GLOSSARY_TERM_RELATION_SETTINGS, GlossaryTermRelationSettings.class);
       if (settings != null && settings.getRelationTypes() != null) {
         for (var configuredType : settings.getRelationTypes()) {
-          java.net.URI rdfPredicate = configuredType.getRdfPredicate();
           String configuredUri =
-              rdfPredicate != null
-                  ? expandPredicateCurie(rdfPredicate.toString())
-                  : "https://open-metadata.org/ontology/" + configuredType.getName();
-          map.putIfAbsent(configuredUri, configuredType.getName());
+              resolveConfiguredTypeUri(configuredType.getRdfPredicate(), configuredType.getName());
+          if (configuredUri != null) {
+            map.putIfAbsent(configuredUri, configuredType.getName());
+          }
         }
       }
     } catch (RuntimeException e) {
@@ -3177,6 +3173,26 @@ public class RdfRepository {
   //
   // Throw on null/empty rather than defaulting silently. The cleanup path
   // already guards on the caller side; if a future caller forgets, a
+  /**
+   * Resolve a {@code GlossaryTermRelationSettings.RelationType} to its full
+   * canonical predicate IRI string. Single source of truth for the
+   * settings-driven URI shape used by both the reader (graph query filter,
+   * predicate-name cache) and any future writer-side helper that needs the
+   * IRI as a String (not a Jena {@code Property}).
+   *
+   * <p>Returns {@code null} if neither {@code rdfPredicate} nor {@code name}
+   * is usable — callers must skip the type instead of fabricating a URI.
+   */
+  private static String resolveConfiguredTypeUri(java.net.URI rdfPredicate, String name) {
+    if (rdfPredicate != null) {
+      return expandPredicateCurie(rdfPredicate.toString());
+    }
+    if (name != null && !name.isBlank()) {
+      return "https://open-metadata.org/ontology/" + name;
+    }
+    return null;
+  }
+
   // misconfigured "rdfPredicate: null" entry would silently target relatedTo
   // and skip cleaning the real predicate — better to fail loudly.
   private static String expandPredicateCurie(String uri) {

--- a/openmetadata-service/src/main/java/org/openmetadata/service/rdf/RdfRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/rdf/RdfRepository.java
@@ -1316,6 +1316,15 @@ public class RdfRepository {
       // custom types) or a CURIE-shaped URI like `skos:broader` (rare but
       // technically valid as a java.net.URI). Either way we end up with the
       // same fully-expanded IRI the writer used when storing the triple.
+      //
+      // When rdfPredicate is null on a configured custom type (a real-world
+      // case observed on a customer instance — operators add the type name
+      // without filling in the URI), mirror the writer's
+      // getGlossaryTermRelationPredicate fallback: use
+      // `https://open-metadata.org/ontology/<name>`. Without this fallback,
+      // the writer would store triples at om:<name> but the reader filter
+      // would not include them, exactly the symptom we just fixed for
+      // explicit URIs.
       try {
         GlossaryTermRelationSettings settings =
             SettingsCache.getSetting(
@@ -1323,10 +1332,15 @@ public class RdfRepository {
         if (settings != null && settings.getRelationTypes() != null) {
           for (var configuredType : settings.getRelationTypes()) {
             java.net.URI rdfPredicate = configuredType.getRdfPredicate();
+            String fullUri;
             if (rdfPredicate != null) {
-              String fullUri = expandPredicateCurie(rdfPredicate.toString());
-              relationPredicates.add("<" + fullUri + ">");
+              fullUri = expandPredicateCurie(rdfPredicate.toString());
+            } else if (configuredType.getName() != null && !configuredType.getName().isBlank()) {
+              fullUri = "https://open-metadata.org/ontology/" + configuredType.getName();
+            } else {
+              continue;
             }
+            relationPredicates.add("<" + fullUri + ">");
           }
         }
       } catch (Exception e) {

--- a/openmetadata-service/src/main/java/org/openmetadata/service/rdf/RdfRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/rdf/RdfRepository.java
@@ -3335,6 +3335,23 @@ public class RdfRepository {
   }
 
   /**
+   * Trigger a backend storage compaction to physically reclaim disk space after
+   * large deletes. See {@link
+   * org.openmetadata.service.rdf.storage.RdfStorageInterface#compactStorage()}
+   * for why this is necessary on TDB2: {@code CLEAR ALL} only marks triples as
+   * deleted in TDB2's free-list — the on-disk dataset never shrinks until the
+   * compaction admin endpoint is called explicitly. Failures are swallowed at
+   * the storage layer; this is a best-effort housekeeping call.
+   */
+  public void compactStorage() {
+    if (!isEnabled()) {
+      return;
+    }
+    LOG.info("Compacting RDF storage to reclaim disk space");
+    storageService.compactStorage();
+  }
+
+  /**
    * Diagnostic method to dump all glossary term relations stored in RDF. Returns a map with
    * predicate URIs as keys and counts as values, plus sample triples.
    */

--- a/openmetadata-service/src/main/java/org/openmetadata/service/rdf/RdfRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/rdf/RdfRepository.java
@@ -92,6 +92,18 @@ public class RdfRepository {
   private final JsonLdTranslator translator;
   private static RdfRepository INSTANCE;
 
+  /**
+   * Per-thread cache of (fullPredicateIRI → configured type name) used by
+   * {@link #extractPredicateName(String)} during a single graph-build pass.
+   * {@link #parseGlossaryTermGraphResults(org.apache.jena.query.ResultSet,
+   * boolean, java.util.UUID, int, int)} builds and clears the map; everything
+   * else sees an empty optional and short-circuits to the URI local-name
+   * fallback. Pre-fix the lookup walked the full configured-types list per
+   * edge — O(edges × relationTypes) with a regex+concat per iteration.
+   */
+  private static final ThreadLocal<java.util.Map<String, String>> predicateNameCache =
+      new ThreadLocal<>();
+
   private RdfRepository(RdfConfiguration config) {
     this.config = config;
     if (config.getEnabled() != null && config.getEnabled()) {
@@ -1434,177 +1446,222 @@ public class RdfRepository {
     com.fasterxml.jackson.databind.node.ArrayNode edges =
         JsonUtils.getObjectMapper().createArrayNode();
 
-    Set<String> addedNodes = new HashSet<>();
-    Map<String, com.fasterxml.jackson.databind.node.ObjectNode> nodeMap = new HashMap<>();
-    Set<String> edgeKeys = new HashSet<>();
-    Set<String> termsWithRelations = new HashSet<>();
+    // Build the IRI → typeName lookup ONCE per request and stash on the
+    // current thread so extractPredicateName's per-edge call does an O(1)
+    // map.get instead of an O(relationTypes) scan with regex+concat per
+    // iteration. ThreadLocal scope is fine because this method is invoked
+    // synchronously from the SPARQL-results processing path; we always
+    // clear it on the way out.
+    predicateNameCache.set(buildPredicateUriToNameMap());
+    try {
 
-    // When scoped to a specific glossary, resolve its display label from the
-    // DB once and use it as a fallback for `?glossaryName`. The SPARQL
-    // OPTIONAL binds nothing if the parent Glossary entity hasn't been (or
-    // has only partially been) projected to RDF — without this fallback the
-    // response would omit the `group` field and the UI hierarchy view would
-    // render the glossary UUID instead of its name.
-    String scopedGlossaryName = lookupGlossaryDisplayName(glossaryId);
+      Set<String> addedNodes = new HashSet<>();
+      Map<String, com.fasterxml.jackson.databind.node.ObjectNode> nodeMap = new HashMap<>();
+      Set<String> edgeKeys = new HashSet<>();
+      Set<String> termsWithRelations = new HashSet<>();
 
-    com.fasterxml.jackson.databind.JsonNode resultsJson = JsonUtils.readTree(sparqlResults);
+      // When scoped to a specific glossary, resolve its display label from the
+      // DB once and use it as a fallback for `?glossaryName`. The SPARQL
+      // OPTIONAL binds nothing if the parent Glossary entity hasn't been (or
+      // has only partially been) projected to RDF — without this fallback the
+      // response would omit the `group` field and the UI hierarchy view would
+      // render the glossary UUID instead of its name.
+      String scopedGlossaryName = lookupGlossaryDisplayName(glossaryId);
 
-    if (resultsJson.has("results") && resultsJson.get("results").has("bindings")) {
-      for (com.fasterxml.jackson.databind.JsonNode binding :
-          resultsJson.get("results").get("bindings")) {
+      com.fasterxml.jackson.databind.JsonNode resultsJson = JsonUtils.readTree(sparqlResults);
 
-        String term1Uri = binding.has("term1") ? binding.get("term1").get("value").asText() : null;
-        String term2Uri =
-            binding.has("term2") && !binding.get("term2").isNull()
-                ? binding.get("term2").get("value").asText()
-                : null;
-        String relationTypeUri =
-            binding.has("relationType") && !binding.get("relationType").isNull()
-                ? binding.get("relationType").get("value").asText()
-                : null;
-        String term1Name =
-            binding.has("term1Name") && !binding.get("term1Name").isNull()
-                ? binding.get("term1Name").get("value").asText()
-                : null;
-        String term2Name =
-            binding.has("term2Name") && !binding.get("term2Name").isNull()
-                ? binding.get("term2Name").get("value").asText()
-                : null;
-        String term1DisplayName =
-            binding.has("term1DisplayName") && !binding.get("term1DisplayName").isNull()
-                ? binding.get("term1DisplayName").get("value").asText()
-                : null;
-        String term2DisplayName =
-            binding.has("term2DisplayName") && !binding.get("term2DisplayName").isNull()
-                ? binding.get("term2DisplayName").get("value").asText()
-                : null;
-        String term1FQN =
-            binding.has("term1FQN") && !binding.get("term1FQN").isNull()
-                ? binding.get("term1FQN").get("value").asText()
-                : null;
-        String term2FQN =
-            binding.has("term2FQN") && !binding.get("term2FQN").isNull()
-                ? binding.get("term2FQN").get("value").asText()
-                : null;
-        String glossaryUri =
-            binding.has("glossary") && !binding.get("glossary").isNull()
-                ? binding.get("glossary").get("value").asText()
-                : null;
-        String glossaryName =
-            binding.has("glossaryName") && !binding.get("glossaryName").isNull()
-                ? binding.get("glossaryName").get("value").asText()
-                : null;
+      if (resultsJson.has("results") && resultsJson.get("results").has("bindings")) {
+        for (com.fasterxml.jackson.databind.JsonNode binding :
+            resultsJson.get("results").get("bindings")) {
 
-        // Treat blank as missing: skos:prefLabel is materialized as an empty
-        // literal when the term has no displayName, and an empty string here
-        // would otherwise win over the real rdfs:label name and render as a
-        // blank node label in the UI.
-        String term1Label = firstNonBlank(term1DisplayName, term1Name);
-        String term2Label = firstNonBlank(term2DisplayName, term2Name);
-        glossaryName = firstNonBlank(glossaryName, scopedGlossaryName);
+          String term1Uri =
+              binding.has("term1") ? binding.get("term1").get("value").asText() : null;
+          String term2Uri =
+              binding.has("term2") && !binding.get("term2").isNull()
+                  ? binding.get("term2").get("value").asText()
+                  : null;
+          String relationTypeUri =
+              binding.has("relationType") && !binding.get("relationType").isNull()
+                  ? binding.get("relationType").get("value").asText()
+                  : null;
+          String term1Name =
+              binding.has("term1Name") && !binding.get("term1Name").isNull()
+                  ? binding.get("term1Name").get("value").asText()
+                  : null;
+          String term2Name =
+              binding.has("term2Name") && !binding.get("term2Name").isNull()
+                  ? binding.get("term2Name").get("value").asText()
+                  : null;
+          String term1DisplayName =
+              binding.has("term1DisplayName") && !binding.get("term1DisplayName").isNull()
+                  ? binding.get("term1DisplayName").get("value").asText()
+                  : null;
+          String term2DisplayName =
+              binding.has("term2DisplayName") && !binding.get("term2DisplayName").isNull()
+                  ? binding.get("term2DisplayName").get("value").asText()
+                  : null;
+          String term1FQN =
+              binding.has("term1FQN") && !binding.get("term1FQN").isNull()
+                  ? binding.get("term1FQN").get("value").asText()
+                  : null;
+          String term2FQN =
+              binding.has("term2FQN") && !binding.get("term2FQN").isNull()
+                  ? binding.get("term2FQN").get("value").asText()
+                  : null;
+          String glossaryUri =
+              binding.has("glossary") && !binding.get("glossary").isNull()
+                  ? binding.get("glossary").get("value").asText()
+                  : null;
+          String glossaryName =
+              binding.has("glossaryName") && !binding.get("glossaryName").isNull()
+                  ? binding.get("glossaryName").get("value").asText()
+                  : null;
 
-        if (term1Uri == null) continue;
+          // Treat blank as missing: skos:prefLabel is materialized as an empty
+          // literal when the term has no displayName, and an empty string here
+          // would otherwise win over the real rdfs:label name and render as a
+          // blank node label in the UI.
+          String term1Label = firstNonBlank(term1DisplayName, term1Name);
+          String term2Label = firstNonBlank(term2DisplayName, term2Name);
+          glossaryName = firstNonBlank(glossaryName, scopedGlossaryName);
 
-        // Add term1 node
-        if (!addedNodes.contains(term1Uri) && addedNodes.size() < limit) {
-          com.fasterxml.jackson.databind.node.ObjectNode node =
-              createGlossaryTermNode(
-                  term1Uri, term1Label, term1FQN, glossaryUri, glossaryName, term2Uri != null);
-          nodes.add(node);
-          nodeMap.put(term1Uri, node);
-          addedNodes.add(term1Uri);
-        } else if (addedNodes.contains(term1Uri)) {
-          // The term may have been added earlier as a `term2` (edge target)
-          // by a row whose `term1` was a different term; that path doesn't
-          // populate glossaryId / group. Now that we have a row where this
-          // term is the primary, backfill the membership fields so the
-          // hierarchy view in the UI can resolve the group container label.
-          com.fasterxml.jackson.databind.node.ObjectNode existing = nodeMap.get(term1Uri);
-          if (existing != null) {
-            if (!existing.has("glossaryId") && glossaryUri != null) {
-              existing.put("glossaryId", extractEntityIdFromUri(glossaryUri));
-            }
-            if (!existing.has("group") && !isBlank(glossaryName)) {
-              existing.put("group", glossaryName);
-            }
-            // Also upgrade the label if we now have a real one (the term2
-            // path falls through to UUID when neither name nor displayName
-            // is present in that row).
-            String currentLabel = existing.path("label").asText(null);
-            String entityId = extractEntityIdFromUri(term1Uri);
-            if ((currentLabel == null || currentLabel.equals(entityId)) && !isBlank(term1Label)) {
-              existing.put("label", term1Label);
-            }
-          }
-        }
+          if (term1Uri == null) continue;
 
-        // If there's a relation, add term2 and the edge
-        if (term2Uri != null && relationTypeUri != null) {
-          termsWithRelations.add(term1Uri);
-          termsWithRelations.add(term2Uri);
-
-          if (!addedNodes.contains(term2Uri) && addedNodes.size() < limit) {
-            // term2 may live in a different glossary; the SPARQL row only
-            // surfaces term1's glossary, so leave the membership fields empty
-            // for term2 rather than mis-attributing it.
+          // Add term1 node
+          if (!addedNodes.contains(term1Uri) && addedNodes.size() < limit) {
             com.fasterxml.jackson.databind.node.ObjectNode node =
-                createGlossaryTermNode(term2Uri, term2Label, term2FQN, null, null, true);
+                createGlossaryTermNode(
+                    term1Uri, term1Label, term1FQN, glossaryUri, glossaryName, term2Uri != null);
             nodes.add(node);
-            nodeMap.put(term2Uri, node);
-            addedNodes.add(term2Uri);
+            nodeMap.put(term1Uri, node);
+            addedNodes.add(term1Uri);
+          } else if (addedNodes.contains(term1Uri)) {
+            // The term may have been added earlier as a `term2` (edge target)
+            // by a row whose `term1` was a different term; that path doesn't
+            // populate glossaryId / group. Now that we have a row where this
+            // term is the primary, backfill the membership fields so the
+            // hierarchy view in the UI can resolve the group container label.
+            com.fasterxml.jackson.databind.node.ObjectNode existing = nodeMap.get(term1Uri);
+            if (existing != null) {
+              if (!existing.has("glossaryId") && glossaryUri != null) {
+                existing.put("glossaryId", extractEntityIdFromUri(glossaryUri));
+              }
+              if (!existing.has("group") && !isBlank(glossaryName)) {
+                existing.put("group", glossaryName);
+              }
+              // Also upgrade the label if we now have a real one (the term2
+              // path falls through to UUID when neither name nor displayName
+              // is present in that row).
+              String currentLabel = existing.path("label").asText(null);
+              String entityId = extractEntityIdFromUri(term1Uri);
+              if ((currentLabel == null || currentLabel.equals(entityId)) && !isBlank(term1Label)) {
+                existing.put("label", term1Label);
+              }
+            }
           }
 
-          // Add edge (avoid duplicates)
-          String edgeKey = term1Uri + "-" + relationTypeUri + "-" + term2Uri;
-          String reverseKey = term2Uri + "-" + relationTypeUri + "-" + term1Uri;
-          if (!edgeKeys.contains(edgeKey) && !edgeKeys.contains(reverseKey)) {
-            edgeKeys.add(edgeKey);
+          // If there's a relation, add term2 and the edge
+          if (term2Uri != null && relationTypeUri != null) {
+            termsWithRelations.add(term1Uri);
+            termsWithRelations.add(term2Uri);
 
-            String extractedRelationType = extractPredicateName(relationTypeUri);
-            String formattedLabel = formatGlossaryRelationType(relationTypeUri);
-            LOG.info(
-                "RDF Edge: {} -> {}, predicateUri={}, extractedType={}, label={}",
-                extractEntityIdFromUri(term1Uri),
-                extractEntityIdFromUri(term2Uri),
-                relationTypeUri,
-                extractedRelationType,
-                formattedLabel);
+            if (!addedNodes.contains(term2Uri) && addedNodes.size() < limit) {
+              // term2 may live in a different glossary; the SPARQL row only
+              // surfaces term1's glossary, so leave the membership fields empty
+              // for term2 rather than mis-attributing it.
+              com.fasterxml.jackson.databind.node.ObjectNode node =
+                  createGlossaryTermNode(term2Uri, term2Label, term2FQN, null, null, true);
+              nodes.add(node);
+              nodeMap.put(term2Uri, node);
+              addedNodes.add(term2Uri);
+            }
 
-            com.fasterxml.jackson.databind.node.ObjectNode edge =
-                JsonUtils.getObjectMapper().createObjectNode();
-            edge.put("from", extractEntityIdFromUri(term1Uri));
-            edge.put("to", extractEntityIdFromUri(term2Uri));
-            edge.put("label", formattedLabel);
-            edge.put("relationType", extractedRelationType);
-            edges.add(edge);
+            // Add edge (avoid duplicates)
+            String edgeKey = term1Uri + "-" + relationTypeUri + "-" + term2Uri;
+            String reverseKey = term2Uri + "-" + relationTypeUri + "-" + term1Uri;
+            if (!edgeKeys.contains(edgeKey) && !edgeKeys.contains(reverseKey)) {
+              edgeKeys.add(edgeKey);
+
+              String extractedRelationType = extractPredicateName(relationTypeUri);
+              String formattedLabel = formatGlossaryRelationType(relationTypeUri);
+              LOG.info(
+                  "RDF Edge: {} -> {}, predicateUri={}, extractedType={}, label={}",
+                  extractEntityIdFromUri(term1Uri),
+                  extractEntityIdFromUri(term2Uri),
+                  relationTypeUri,
+                  extractedRelationType,
+                  formattedLabel);
+
+              com.fasterxml.jackson.databind.node.ObjectNode edge =
+                  JsonUtils.getObjectMapper().createObjectNode();
+              edge.put("from", extractEntityIdFromUri(term1Uri));
+              edge.put("to", extractEntityIdFromUri(term2Uri));
+              edge.put("label", formattedLabel);
+              edge.put("relationType", extractedRelationType);
+              edges.add(edge);
+            }
           }
         }
       }
-    }
 
-    // Mark isolated nodes
-    for (com.fasterxml.jackson.databind.node.ObjectNode node : nodeMap.values()) {
-      String nodeId = node.get("id").asText();
-      String nodeUri = config.getBaseUri().toString() + "entity/glossaryTerm/" + nodeId;
-      if (!termsWithRelations.contains(nodeUri)) {
-        node.put("type", "glossaryTermIsolated");
-        node.put("isolated", true);
+      // Mark isolated nodes
+      for (com.fasterxml.jackson.databind.node.ObjectNode node : nodeMap.values()) {
+        String nodeId = node.get("id").asText();
+        String nodeUri = config.getBaseUri().toString() + "entity/glossaryTerm/" + nodeId;
+        if (!termsWithRelations.contains(nodeUri)) {
+          node.put("type", "glossaryTermIsolated");
+          node.put("isolated", true);
+        }
       }
+
+      // If RDF didn't return enough results, fall back to database query
+      if (nodes.isEmpty()) {
+        LOG.info("RDF query returned no nodes, falling back to database");
+        return getGlossaryTermGraphFromDatabase(glossaryId, limit, offset, includeIsolated);
+      }
+      LOG.info("RDF query returned {} nodes and {} edges", nodes.size(), edges.size());
+
+      graphData.set("nodes", nodes);
+      graphData.set("edges", edges);
+      graphData.put("totalNodes", addedNodes.size());
+      graphData.put("totalEdges", edges.size());
+
+      return JsonUtils.pojoToJson(graphData);
+    } finally {
+      predicateNameCache.remove();
     }
+  }
 
-    // If RDF didn't return enough results, fall back to database query
-    if (nodes.isEmpty()) {
-      LOG.info("RDF query returned no nodes, falling back to database");
-      return getGlossaryTermGraphFromDatabase(glossaryId, limit, offset, includeIsolated);
+  /**
+   * Builds a single (configured rdfPredicate IRI → relation type name) map
+   * from GlossaryTermRelationSettings, mirroring the resolution that
+   * extractPredicateName needs per edge. Returns an empty map (NOT null) on
+   * cache miss so extractPredicateName's contract is simple: {@code map.get}
+   * either hits or falls through to the URI-local-name path.
+   */
+  private static java.util.Map<String, String> buildPredicateUriToNameMap() {
+    java.util.Map<String, String> map = new java.util.HashMap<>();
+    try {
+      GlossaryTermRelationSettings settings =
+          SettingsCache.getSetting(
+              SettingsType.GLOSSARY_TERM_RELATION_SETTINGS, GlossaryTermRelationSettings.class);
+      if (settings != null && settings.getRelationTypes() != null) {
+        for (var configuredType : settings.getRelationTypes()) {
+          java.net.URI rdfPredicate = configuredType.getRdfPredicate();
+          String configuredUri =
+              rdfPredicate != null
+                  ? expandPredicateCurie(rdfPredicate.toString())
+                  : "https://open-metadata.org/ontology/" + configuredType.getName();
+          map.putIfAbsent(configuredUri, configuredType.getName());
+        }
+      }
+    } catch (RuntimeException e) {
+      LOG.debug(
+          "Could not load GlossaryTermRelationSettings while building predicate-name "
+              + "cache; per-edge lookups will fall back to URI local-name. Cause: {}",
+          e.getMessage());
     }
-    LOG.info("RDF query returned {} nodes and {} edges", nodes.size(), edges.size());
-
-    graphData.set("nodes", nodes);
-    graphData.set("edges", edges);
-    graphData.put("totalNodes", addedNodes.size());
-    graphData.put("totalEdges", edges.size());
-
-    return JsonUtils.pojoToJson(graphData);
+    return map;
   }
 
   private com.fasterxml.jackson.databind.node.ObjectNode createGlossaryTermNode(
@@ -1938,33 +1995,21 @@ public class RdfRepository {
     // instead of `enrolledIn` (the user's chosen type name), and round-trip
     // assertions like "the type I sent on POST /relations equals the type
     // the graph returns" would fail.
+    //
+    // Uses a per-thread cached IRI→typeName map so a single graph response
+    // pays the settings-load + map-build cost ONCE, not once per edge.
+    // parseGlossaryTermGraphResults can iterate hundreds-to-thousands of
+    // edges; the previous implementation was O(edges × relationTypes) with
+    // a string-concat + regex pass per iteration. The cache is cleared at
+    // the top of parseGlossaryTermGraphResults so settings updates between
+    // requests take effect.
     if (predicateUri != null) {
-      try {
-        GlossaryTermRelationSettings settings =
-            SettingsCache.getSetting(
-                SettingsType.GLOSSARY_TERM_RELATION_SETTINGS, GlossaryTermRelationSettings.class);
-        if (settings != null && settings.getRelationTypes() != null) {
-          for (var configuredType : settings.getRelationTypes()) {
-            java.net.URI rdfPredicate = configuredType.getRdfPredicate();
-            String configuredUri =
-                rdfPredicate != null
-                    ? expandPredicateCurie(rdfPredicate.toString())
-                    : "https://open-metadata.org/ontology/" + configuredType.getName();
-            if (predicateUri.equals(configuredUri)) {
-              return configuredType.getName();
-            }
-          }
+      java.util.Map<String, String> map = predicateNameCache.get();
+      if (map != null) {
+        String name = map.get(predicateUri);
+        if (name != null) {
+          return name;
         }
-      } catch (RuntimeException e) {
-        // Narrowed from Exception per project coding standards. SettingsCache
-        // surfaces all failures (cache miss, cast failure, …) as a
-        // RuntimeException (EntityNotFoundException), so RuntimeException
-        // covers the failure modes we expect while letting programmer-error
-        // throwables that signal a real bug propagate to test runs.
-        LOG.debug(
-            "Could not load GlossaryTermRelationSettings while extracting predicate name; "
-                + "falling back to URI local-name. Cause: {}",
-            e.getMessage());
       }
     }
 

--- a/openmetadata-service/src/main/java/org/openmetadata/service/rdf/RdfRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/rdf/RdfRepository.java
@@ -214,6 +214,37 @@ public class RdfRepository {
     }
   }
 
+  /**
+   * Bulk variant of {@link #createOrUpdate(EntityInterface)} — translates every
+   * entity to RDF and forwards the batch to the storage layer for a single
+   * round-trip write. Used by the indexer batch path; production hot path
+   * (per-entity hooks) keeps calling {@link #createOrUpdate}.
+   *
+   * <p>All-or-nothing semantics: a failure in any entity rolls back the entire
+   * batch. Callers that need per-entity success/failure granularity (e.g. the
+   * reindexer's stats reporting) must catch and fall back to looping
+   * {@link #createOrUpdate} so each entity attempt is isolated.
+   */
+  public void bulkCreateOrUpdate(List<? extends EntityInterface> entities) {
+    if (!isEnabled() || entities == null || entities.isEmpty()) {
+      return;
+    }
+    List<RdfStorageInterface.EntityWriteRequest> requests = new ArrayList<>(entities.size());
+    for (EntityInterface entity : entities) {
+      String entityType = entity.getEntityReference().getType();
+      Model rdfModel = translator.toRdf(entity);
+      requests.add(
+          new RdfStorageInterface.EntityWriteRequest(entityType, entity.getId(), rdfModel));
+    }
+    try {
+      storageService.bulkStoreEntities(requests);
+      LOG.debug("Bulk created/updated {} entities in RDF store", entities.size());
+    } catch (Exception e) {
+      LOG.error("Failed to bulk create/update {} entities in RDF", entities.size(), e);
+      throw new RuntimeException("Failed to bulk create/update entities in RDF", e);
+    }
+  }
+
   public void delete(EntityReference entityReference) {
     if (!isEnabled()) {
       return;
@@ -1225,7 +1256,22 @@ public class RdfRepository {
     queryBuilder.append(
         "    BIND(COALESCE(?glossaryDisplayName, ?glossaryRdfsLabel) AS ?glossaryName) ");
 
-    // Build relation type filter
+    // Build relation type filter.
+    //
+    // The writer side (bulkAddGlossaryTermRelations / addGlossaryTermRelation)
+    // honours user-configured custom relation types from
+    // GlossaryTermRelationSettings — operators can define types like
+    // "Enrolls In" / "Enabled By" with their own RDF predicate URIs and the
+    // writer correctly emits those triples. But this read path was hardcoded
+    // to the built-in CURIE list (om:relatedTo, skos:broader, …) and silently
+    // dropped every custom-typed edge. Result: customer environments saw
+    // their relations in the Overview tab (DB) and in the global Ontology
+    // Explorer (DB-backed scope='global') but the term-page Relations Graph
+    // (RDF-backed scope='term') rendered the source node alone, exactly as
+    // image-v6 in the bug report.
+    //
+    // Mirror clearAllGlossaryTermRelations's settings-aware predicate
+    // assembly so reader and writer stay in sync.
     List<String> relationPredicates = new ArrayList<>();
     if (relationTypes != null && !relationTypes.isEmpty()) {
       for (String relType : relationTypes.split(",")) {
@@ -1256,6 +1302,32 @@ public class RdfRepository {
       // PROV-O predicates (for calculatedFrom, usedToCalculate)
       relationPredicates.add("prov:wasDerivedFrom");
       relationPredicates.add("prov:wasInfluencedBy");
+
+      // Append user-configured custom predicates as full IRIs. Built-ins
+      // already covered above as CURIEs; custom types use arbitrary URIs that
+      // may not share any of the declared prefixes, so we always inject the
+      // expanded form in angle brackets. Deduplication is handled by SPARQL
+      // (?relationType IN (a, b, a) is equivalent to IN (a, b)).
+      try {
+        GlossaryTermRelationSettings settings =
+            SettingsCache.getSetting(
+                SettingsType.GLOSSARY_TERM_RELATION_SETTINGS, GlossaryTermRelationSettings.class);
+        if (settings != null && settings.getRelationTypes() != null) {
+          for (var configuredType : settings.getRelationTypes()) {
+            java.net.URI rdfPredicate = configuredType.getRdfPredicate();
+            if (rdfPredicate != null) {
+              String fullUri = expandPredicateCurie(rdfPredicate.toString());
+              relationPredicates.add("<" + fullUri + ">");
+            }
+          }
+        }
+      } catch (Exception e) {
+        LOG.debug(
+            "Could not load GlossaryTermRelationSettings for graph query — "
+                + "custom-typed glossary relations will be filtered out of the response. "
+                + "Cause: {}",
+            e.getMessage());
+      }
     }
 
     queryBuilder.append("    OPTIONAL { ");

--- a/openmetadata-service/src/main/java/org/openmetadata/service/rdf/RdfRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/rdf/RdfRepository.java
@@ -216,14 +216,28 @@ public class RdfRepository {
 
   /**
    * Bulk variant of {@link #createOrUpdate(EntityInterface)} — translates every
-   * entity to RDF and forwards the batch to the storage layer for a single
-   * round-trip write. Used by the indexer batch path; production hot path
-   * (per-entity hooks) keeps calling {@link #createOrUpdate}.
+   * entity to RDF and forwards the batch to the storage layer. Used by the
+   * indexer batch path; production hot path (per-entity hooks) keeps calling
+   * {@link #createOrUpdate}.
    *
-   * <p>All-or-nothing semantics: a failure in any entity rolls back the entire
-   * batch. Callers that need per-entity success/failure granularity (e.g. the
-   * reindexer's stats reporting) must catch and fall back to looping
-   * {@link #createOrUpdate} so each entity attempt is isolated.
+   * <p>From the caller's perspective: all-or-nothing — a single thrown
+   * exception means the caller should retry the whole batch (or fall back to
+   * per-entity {@link #createOrUpdate} for per-row error attribution). The
+   * indexer in {@code RdfBatchProcessor.processEntities} does the latter.
+   *
+   * <p>Implementation note: under the hood {@link
+   * org.openmetadata.service.rdf.storage.JenaFusekiStorage#bulkStoreEntities}
+   * issues TWO Fuseki operations — a combined SPARQL UPDATE that DELETEs
+   * the predicate-scoped triples for every entity in the batch, then a GSP
+   * POST that loads the combined N-Triples body. If the second call fails
+   * after the first commits, the batch is left in an INCONSISTENT state on
+   * Fuseki (every entity's prior translator-managed predicates are gone but
+   * the new triples never landed). The caller's fall-back to per-entity
+   * recreates each affected entity's triples cleanly, so the inconsistency
+   * is self-healing within one batch's worth of retries. Fully atomic
+   * delete+insert in a single transaction would require switching the load
+   * to {@code INSERT DATA} via {@code /update} instead of GSP POST to
+   * {@code /data}; that's worth doing but out of scope for this PR.
    */
   public void bulkCreateOrUpdate(List<? extends EntityInterface> entities) {
     if (!isEnabled() || entities == null || entities.isEmpty()) {
@@ -1909,7 +1923,42 @@ public class RdfRepository {
       }
     }
 
-    // Extract local name from URI
+    // Look up the configured relation type whose rdfPredicate matches this
+    // URI exactly. Customers can configure custom types with arbitrary
+    // predicate IRIs where the local name does NOT match the type name —
+    // e.g. operator-defined `enrolledIn` mapped to
+    // `https://acme.com/ns#enrolls`. Without this lookup the graph endpoint
+    // would surface `enrolls` as the relationType (the URI's local name)
+    // instead of `enrolledIn` (the user's chosen type name), and round-trip
+    // assertions like "the type I sent on POST /relations equals the type
+    // the graph returns" would fail.
+    if (predicateUri != null) {
+      try {
+        GlossaryTermRelationSettings settings =
+            SettingsCache.getSetting(
+                SettingsType.GLOSSARY_TERM_RELATION_SETTINGS, GlossaryTermRelationSettings.class);
+        if (settings != null && settings.getRelationTypes() != null) {
+          for (var configuredType : settings.getRelationTypes()) {
+            java.net.URI rdfPredicate = configuredType.getRdfPredicate();
+            String configuredUri =
+                rdfPredicate != null
+                    ? expandPredicateCurie(rdfPredicate.toString())
+                    : "https://open-metadata.org/ontology/" + configuredType.getName();
+            if (predicateUri.equals(configuredUri)) {
+              return configuredType.getName();
+            }
+          }
+        }
+      } catch (Exception e) {
+        LOG.debug(
+            "Could not load GlossaryTermRelationSettings while extracting predicate name; "
+                + "falling back to URI local-name. Cause: {}",
+            e.getMessage());
+      }
+    }
+
+    // Extract local name from URI as a final fallback (built-in om:* predicates
+    // that aren't in the hardcoded mapping above land here)
     if (predicateUri.contains("#")) {
       return predicateUri.substring(predicateUri.lastIndexOf('#') + 1);
     } else if (predicateUri.contains("/")) {

--- a/openmetadata-service/src/main/java/org/openmetadata/service/rdf/storage/JenaFusekiStorage.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/rdf/storage/JenaFusekiStorage.java
@@ -557,13 +557,22 @@ public class JenaFusekiStorage implements RdfStorageInterface {
   }
 
   /**
-   * Bulk variant: one combined DELETE update + one combined GSP POST for the
-   * whole batch. Per-entity {@link #storeEntity} costs ~2 HTTP round trips per
-   * entity (~150 ms RT on localhost = ~6.7 entities/s); batching collapses N
-   * entities into the same 2 round trips, so a batch of 100 entities runs at
-   * ~50× the per-entity throughput. Failure semantics are all-or-nothing:
-   * callers must fall back to per-entity {@link #storeEntity} on exception to
-   * preserve per-entity success/failure accounting.
+   * Bulk variant: one combined DELETE + INSERT DATA SPARQL UPDATE for the
+   * whole batch, in a SINGLE transaction at the Fuseki side. Per-entity
+   * {@link #storeEntity} costs ~2 HTTP round trips per entity (~150 ms RT on
+   * localhost = ~6.7 entities/s); batching collapses N entities into 1
+   * round trip, so a batch of 100 entities runs at ~100× the per-entity
+   * throughput.
+   *
+   * <p>Atomicity: previously the bulk path issued a SPARQL UPDATE for the
+   * DELETE and a separate GSP POST for the LOAD, which could leave the
+   * dataset in a half-applied state if the second call failed — every
+   * entity's prior translator-managed predicates would be gone but the new
+   * triples never landed. Now we serialise the combined model as N-Triples
+   * and embed it in the SAME SPARQL UPDATE via {@code INSERT DATA}; multi-
+   * statement SPARQL UPDATEs run in one Fuseki transaction so the batch is
+   * either fully applied or fully rolled back. Failure semantics stay
+   * all-or-nothing from the caller's perspective.
    */
   @Override
   public void bulkStoreEntities(List<EntityWriteRequest> requests) {
@@ -587,11 +596,28 @@ public class JenaFusekiStorage implements RdfStorageInterface {
       combinedModel.add(req.model());
     }
 
+    // Serialise the combined model as N-Triples and embed in INSERT DATA so
+    // the whole batch — DELETE statements + INSERT DATA — executes as ONE
+    // SPARQL UPDATE transaction at Fuseki.
+    StringWriter writer = new StringWriter();
+    combinedModel.write(writer, "N-TRIPLES");
+    String triples = writer.toString();
+    StringBuilder combined = new StringBuilder(combinedDelete);
+    if (!triples.isBlank()) {
+      if (combined.length() > 0) {
+        combined.append(";\n");
+      }
+      combined
+          .append("INSERT DATA { GRAPH <")
+          .append(KNOWLEDGE_GRAPH)
+          .append("> { ")
+          .append(triples)
+          .append(" } }");
+    }
+
     try {
-      UpdateRequest deleteRequest = UpdateFactory.create(combinedDelete.toString());
-      runWithTimeout(() -> connection.update(deleteRequest), "bulkStoreEntities delete");
-      runWithTimeout(
-          () -> connection.load(KNOWLEDGE_GRAPH, combinedModel), "bulkStoreEntities load");
+      UpdateRequest updateRequest = UpdateFactory.create(combined.toString());
+      runWithTimeout(() -> connection.update(updateRequest), "bulkStoreEntities");
       // DEBUG, not INFO: this fires per-batch in a hot reindex loop (default
       // batchSize=100 → tens of thousands of log lines on a real reindex).
       // Keep INFO reserved for events ops actually want to grep for.

--- a/openmetadata-service/src/main/java/org/openmetadata/service/rdf/storage/JenaFusekiStorage.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/rdf/storage/JenaFusekiStorage.java
@@ -179,11 +179,14 @@ public class JenaFusekiStorage implements RdfStorageInterface {
    * doesn't carry a dataset name or the URL is malformed — callers should
    * log and skip the admin operation rather than blow up.
    *
-   * <p>Preserves any {@code userInfo} ({@code http://user:pass@host:port/ds})
-   * embedded in the endpoint so admin endpoints (/$/datasets, /$/compact)
-   * reach the server with the right credentials when the operator wired auth
-   * into the URL instead of via {@code config.getUsername()}/{@code
-   * getPassword()}.
+   * <p>Hoists any embedded {@code user:pass@} userInfo OUT of the URL into a
+   * separate field on {@link DatasetEndpoint}. The {@code serverBaseUrl}
+   * returned to callers is credential-free so it can be safely concatenated
+   * into request URIs without risking leakage to JDK HttpClient debug logs
+   * or downstream proxies. Operators who configured auth via URL get the
+   * same effective auth — callers pass the {@code userInfo} field into
+   * {@link #addBasicAuth(HttpRequest.Builder, String, String, String)},
+   * which encodes it into the {@code Authorization} header.
    */
   private static DatasetEndpoint parseDatasetEndpoint(String endpoint) {
     URI uri;
@@ -201,18 +204,23 @@ public class JenaFusekiStorage implements RdfStorageInterface {
       datasetName = datasetName.split("/")[0];
     }
     StringBuilder serverBaseUrl = new StringBuilder();
-    serverBaseUrl.append(uri.getScheme()).append("://");
-    if (uri.getRawUserInfo() != null && !uri.getRawUserInfo().isEmpty()) {
-      serverBaseUrl.append(uri.getRawUserInfo()).append('@');
-    }
-    serverBaseUrl.append(uri.getHost());
+    serverBaseUrl.append(uri.getScheme()).append("://").append(uri.getHost());
     if (uri.getPort() > 0) {
       serverBaseUrl.append(':').append(uri.getPort());
     }
-    return new DatasetEndpoint(serverBaseUrl.toString(), datasetName);
+    String userInfo = uri.getRawUserInfo();
+    return new DatasetEndpoint(
+        serverBaseUrl.toString(),
+        datasetName,
+        userInfo != null && !userInfo.isEmpty() ? userInfo : null);
   }
 
-  private record DatasetEndpoint(String serverBaseUrl, String datasetName) {}
+  /** URL-encode a path segment for safe interpolation into request URIs. */
+  private static String encodePathSegment(String segment) {
+    return java.net.URLEncoder.encode(segment, StandardCharsets.UTF_8).replace("+", "%20");
+  }
+
+  private record DatasetEndpoint(String serverBaseUrl, String datasetName, String userInfo) {}
 
   /**
    * Replace any {@code user:pass@} userInfo in a URL with {@code ***@} for
@@ -260,6 +268,30 @@ public class JenaFusekiStorage implements RdfStorageInterface {
   }
 
   /**
+   * Three-argument overload that prefers explicit {@code username/password} when
+   * present and falls back to URL-embedded {@code userInfo}. Used by the admin
+   * HTTP paths so credentials from either source are encoded into the
+   * {@code Authorization} header instead of being left in the request URI.
+   */
+  private static void addBasicAuth(
+      HttpRequest.Builder requestBuilder, String username, String password, String userInfo) {
+    if (username != null && password != null) {
+      addBasicAuth(requestBuilder, username, password);
+      return;
+    }
+    if (userInfo == null || userInfo.isEmpty()) {
+      return;
+    }
+    // userInfo is URL-encoded (RFC 3986 percent-encoded); decode before
+    // re-encoding into a Basic auth header. The base64 layer is independent of
+    // the URL encoding.
+    String decoded = java.net.URLDecoder.decode(userInfo, StandardCharsets.UTF_8);
+    String encodedAuth =
+        Base64.getEncoder().encodeToString(decoded.getBytes(StandardCharsets.UTF_8));
+    requestBuilder.header("Authorization", "Basic " + encodedAuth);
+  }
+
+  /**
    * Ensures the Fuseki dataset exists, creating it if necessary.
    */
   private void ensureDatasetExists(String endpoint, String username, String password) {
@@ -276,10 +308,11 @@ public class JenaFusekiStorage implements RdfStorageInterface {
           info.serverBaseUrl());
 
       HttpClient httpClient = HttpClient.newBuilder().connectTimeout(CONNECT_TIMEOUT).build();
-      String adminUrl = info.serverBaseUrl() + "/$/datasets/" + info.datasetName();
+      String adminUrl =
+          info.serverBaseUrl() + "/$/datasets/" + encodePathSegment(info.datasetName());
 
       HttpRequest.Builder requestBuilder = HttpRequest.newBuilder().uri(URI.create(adminUrl)).GET();
-      addBasicAuth(requestBuilder, username, password);
+      addBasicAuth(requestBuilder, username, password, info.userInfo());
 
       HttpResponse<String> response =
           httpClient.send(requestBuilder.build(), HttpResponse.BodyHandlers.ofString());
@@ -1153,7 +1186,7 @@ public class JenaFusekiStorage implements RdfStorageInterface {
       if (taskId == null) {
         return;
       }
-      waitForCompactionTask(info.serverBaseUrl(), taskId);
+      waitForCompactionTask(info.serverBaseUrl(), info.userInfo(), taskId);
     } catch (InterruptedException e) {
       // Re-assert the interrupt flag so downstream blocking calls (e.g. the
       // surrounding Quartz job's shutdown path) see the cancellation request.
@@ -1170,13 +1203,28 @@ public class JenaFusekiStorage implements RdfStorageInterface {
               + "indexing will continue but on-disk usage may stay elevated.",
           info.datasetName(),
           e);
+    } catch (RuntimeException e) {
+      // The Javadoc on compactStorage promises "Failures are logged and
+      // swallowed". The HTTP path can throw IllegalArgumentException (URI),
+      // RdfStorageCircuitOpenException (if state flips mid-run), the
+      // CompletableFuture wrappers' RuntimeException re-throws, or any of
+      // Jena's runtime exceptions. Catch them all so a stray RuntimeException
+      // never demotes a successful reindex to FAILED.
+      LOG.warn(
+          "Unexpected runtime error compacting Fuseki dataset '{}' — disk "
+              + "reclamation skipped, indexing will continue.",
+          info.datasetName(),
+          e);
     }
   }
 
   private String startCompaction(DatasetEndpoint info) throws IOException, InterruptedException {
     HttpClient httpClient = HttpClient.newBuilder().connectTimeout(CONNECT_TIMEOUT).build();
     String compactUrl =
-        info.serverBaseUrl() + "/$/compact/" + info.datasetName() + "?deleteOld=true";
+        info.serverBaseUrl()
+            + "/$/compact/"
+            + encodePathSegment(info.datasetName())
+            + "?deleteOld=true";
 
     HttpRequest.Builder requestBuilder =
         HttpRequest.newBuilder()
@@ -1184,7 +1232,7 @@ public class JenaFusekiStorage implements RdfStorageInterface {
             .timeout(COMPACT_HTTP_TIMEOUT)
             .header("Accept", "application/json")
             .POST(HttpRequest.BodyPublishers.noBody());
-    addBasicAuth(requestBuilder, username, password);
+    addBasicAuth(requestBuilder, username, password, info.userInfo());
 
     HttpResponse<String> response =
         httpClient.send(requestBuilder.build(), HttpResponse.BodyHandlers.ofString());
@@ -1224,10 +1272,10 @@ public class JenaFusekiStorage implements RdfStorageInterface {
     }
   }
 
-  private void waitForCompactionTask(String serverBaseUrl, String taskId)
+  private void waitForCompactionTask(String serverBaseUrl, String userInfo, String taskId)
       throws InterruptedException {
     HttpClient httpClient = HttpClient.newBuilder().connectTimeout(CONNECT_TIMEOUT).build();
-    String taskUrl = serverBaseUrl + "/$/tasks/" + taskId;
+    String taskUrl = serverBaseUrl + "/$/tasks/" + encodePathSegment(taskId);
     long deadline = System.currentTimeMillis() + COMPACT_MAX_WAIT_MS;
     // Poll-then-sleep ordering: the very first iteration checks immediately so
     // a compaction that finished by the time we'd issued the POST (the empty
@@ -1245,7 +1293,7 @@ public class JenaFusekiStorage implements RdfStorageInterface {
               .timeout(COMPACT_HTTP_TIMEOUT)
               .header("Accept", "application/json")
               .GET();
-      addBasicAuth(pollBuilder, username, password);
+      addBasicAuth(pollBuilder, username, password, userInfo);
       HttpResponse<String> pollResponse;
       try {
         pollResponse = httpClient.send(pollBuilder.build(), HttpResponse.BodyHandlers.ofString());

--- a/openmetadata-service/src/main/java/org/openmetadata/service/rdf/storage/JenaFusekiStorage.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/rdf/storage/JenaFusekiStorage.java
@@ -475,6 +475,57 @@ public class JenaFusekiStorage implements RdfStorageInterface {
             KNOWLEDGE_GRAPH, entityUri, KNOWLEDGE_GRAPH, entityUri, filterIn);
   }
 
+  /**
+   * Bulk variant: one combined DELETE update + one combined GSP POST for the
+   * whole batch. Per-entity {@link #storeEntity} costs ~2 HTTP round trips per
+   * entity (~150 ms RT on localhost = ~6.7 entities/s); batching collapses N
+   * entities into the same 2 round trips, so a batch of 100 entities runs at
+   * ~50× the per-entity throughput. Failure semantics are all-or-nothing:
+   * callers must fall back to per-entity {@link #storeEntity} on exception to
+   * preserve per-entity success/failure accounting.
+   */
+  @Override
+  public void bulkStoreEntities(List<EntityWriteRequest> requests) {
+    if (requests == null || requests.isEmpty()) {
+      return;
+    }
+    throwIfCircuitOpen("bulkStoreEntities");
+
+    StringBuilder combinedDelete = new StringBuilder();
+    Model combinedModel = ModelFactory.createDefaultModel();
+    boolean first = true;
+    for (EntityWriteRequest req : requests) {
+      String entityUri = baseUri + "entity/" + req.entityType() + "/" + req.entityId();
+      Set<String> predicatesToDelete = collectTranslatorPredicates(entityUri, req.model());
+      String deleteQuery = buildPredicateScopedDelete(entityUri, predicatesToDelete);
+      if (!first) {
+        combinedDelete.append(";\n");
+      }
+      first = false;
+      combinedDelete.append(deleteQuery);
+      combinedModel.add(req.model());
+    }
+
+    try {
+      UpdateRequest deleteRequest = UpdateFactory.create(combinedDelete.toString());
+      runWithTimeout(() -> connection.update(deleteRequest), "bulkStoreEntities delete");
+      runWithTimeout(
+          () -> connection.load(KNOWLEDGE_GRAPH, combinedModel), "bulkStoreEntities load");
+      LOG.info(
+          "Bulk-stored {} entities in {} ({} triples)",
+          requests.size(),
+          KNOWLEDGE_GRAPH,
+          combinedModel.size());
+      recordSuccess();
+    } catch (Exception e) {
+      LOG.error("Failed to bulk-store {} entities in Fuseki", requests.size(), e);
+      if (isConnectError(e)) {
+        recordFailure();
+      }
+      throw new RuntimeException("Failed to bulk-store entities in RDF", e);
+    }
+  }
+
   @Override
   public void storeEntity(String entityType, UUID entityId, Model entityModel) {
     throwIfCircuitOpen("storeEntity");

--- a/openmetadata-service/src/main/java/org/openmetadata/service/rdf/storage/JenaFusekiStorage.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/rdf/storage/JenaFusekiStorage.java
@@ -9,6 +9,7 @@ import java.net.http.HttpConnectTimeoutException;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.nio.channels.ClosedChannelException;
+import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Base64;
@@ -199,7 +200,11 @@ public class JenaFusekiStorage implements RdfStorageInterface {
       return;
     }
     String auth = username + ":" + password;
-    String encodedAuth = Base64.getEncoder().encodeToString(auth.getBytes());
+    // RFC 7617 mandates UTF-8 for the credential string before Base64 encoding.
+    // Using auth.getBytes() relies on the JVM default charset, which is not
+    // guaranteed to be UTF-8 in containerised environments with non-standard
+    // locales.
+    String encodedAuth = Base64.getEncoder().encodeToString(auth.getBytes(StandardCharsets.UTF_8));
     requestBuilder.header("Authorization", "Basic " + encodedAuth);
   }
 
@@ -1020,7 +1025,17 @@ public class JenaFusekiStorage implements RdfStorageInterface {
         return;
       }
       waitForCompactionTask(info.serverBaseUrl(), taskId);
-    } catch (Exception e) {
+    } catch (InterruptedException e) {
+      // Re-assert the interrupt flag so downstream blocking calls (e.g. the
+      // surrounding Quartz job's shutdown path) see the cancellation request.
+      // Swallowing it here without restoring the flag would silently turn a
+      // shutdown signal into a normal return.
+      Thread.currentThread().interrupt();
+      LOG.warn(
+          "Compaction wait for Fuseki dataset '{}' was interrupted; "
+              + "the compact task may still be running on the server.",
+          info.datasetName());
+    } catch (java.io.IOException e) {
       LOG.warn(
           "Failed to compact Fuseki dataset '{}' — disk reclamation skipped, "
               + "indexing will continue but on-disk usage may stay elevated.",
@@ -1029,7 +1044,8 @@ public class JenaFusekiStorage implements RdfStorageInterface {
     }
   }
 
-  private String startCompaction(DatasetEndpoint info) throws Exception {
+  private String startCompaction(DatasetEndpoint info)
+      throws java.io.IOException, InterruptedException {
     HttpClient httpClient = HttpClient.newBuilder().connectTimeout(CONNECT_TIMEOUT).build();
     String compactUrl =
         info.serverBaseUrl() + "/$/compact/" + info.datasetName() + "?deleteOld=true";
@@ -1074,7 +1090,7 @@ public class JenaFusekiStorage implements RdfStorageInterface {
       var node = JsonUtils.readTree(responseBody);
       var taskNode = node.get("taskId");
       return taskNode != null && !taskNode.isNull() ? taskNode.asText() : null;
-    } catch (Exception e) {
+    } catch (org.openmetadata.schema.exception.JsonParsingException e) {
       LOG.debug("Could not parse taskId from Fuseki compaction response: {}", responseBody, e);
       return null;
     }
@@ -1085,9 +1101,16 @@ public class JenaFusekiStorage implements RdfStorageInterface {
     HttpClient httpClient = HttpClient.newBuilder().connectTimeout(CONNECT_TIMEOUT).build();
     String taskUrl = serverBaseUrl + "/$/tasks/" + taskId;
     long deadline = System.currentTimeMillis() + COMPACT_MAX_WAIT_MS;
-
+    // Poll-then-sleep ordering: the very first iteration checks immediately so
+    // a compaction that finished by the time we'd issued the POST (the empty
+    // dataset case, which is the common one for recreateIndex=true) completes
+    // without a 2 s wait. Subsequent iterations sleep between requests.
+    boolean firstIteration = true;
     while (System.currentTimeMillis() < deadline) {
-      Thread.sleep(COMPACT_POLL_INTERVAL_MS);
+      if (!firstIteration) {
+        Thread.sleep(COMPACT_POLL_INTERVAL_MS);
+      }
+      firstIteration = false;
       HttpRequest.Builder pollBuilder =
           HttpRequest.newBuilder()
               .uri(URI.create(taskUrl))
@@ -1098,7 +1121,7 @@ public class JenaFusekiStorage implements RdfStorageInterface {
       HttpResponse<String> pollResponse;
       try {
         pollResponse = httpClient.send(pollBuilder.build(), HttpResponse.BodyHandlers.ofString());
-      } catch (Exception e) {
+      } catch (java.io.IOException e) {
         LOG.warn("Polling Fuseki task {} failed; abandoning wait", taskId, e);
         return;
       }
@@ -1136,7 +1159,7 @@ public class JenaFusekiStorage implements RdfStorageInterface {
       var node = JsonUtils.readTree(responseBody);
       var finished = node.get("finished");
       return finished != null && !finished.isNull() && !finished.asText().isBlank();
-    } catch (Exception e) {
+    } catch (org.openmetadata.schema.exception.JsonParsingException e) {
       LOG.debug("Could not parse Fuseki task status response: {}", responseBody, e);
       return false;
     }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/rdf/storage/JenaFusekiStorage.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/rdf/storage/JenaFusekiStorage.java
@@ -44,6 +44,7 @@ import org.apache.jena.riot.RDFFormat;
 import org.apache.jena.update.UpdateFactory;
 import org.apache.jena.update.UpdateRequest;
 import org.openmetadata.schema.api.configuration.rdf.RdfConfiguration;
+import org.openmetadata.schema.utils.JsonUtils;
 import org.openmetadata.service.rdf.translator.RdfPropertyMapper;
 
 /**
@@ -74,6 +75,15 @@ public class JenaFusekiStorage implements RdfStorageInterface {
   private static final long REQUEST_TIMEOUT_MS = 10_000L;
   private static final int CIRCUIT_BREAKER_FAILURE_THRESHOLD = 5;
   private static final long CIRCUIT_BREAKER_COOLDOWN_MS = 30_000L;
+
+  // Compaction polls /$/tasks/{taskId} until the task reports finished. Fuseki
+  // does not stream progress, so we poll on a fixed cadence. Total budget is
+  // bounded so a hung compaction can never block the indexer indefinitely;
+  // exceeding the budget logs and returns — compaction may still be running on
+  // the server, the dataset stays operational, only the wait is abandoned.
+  private static final Duration COMPACT_HTTP_TIMEOUT = Duration.ofSeconds(30);
+  private static final long COMPACT_POLL_INTERVAL_MS = 2_000L;
+  private static final long COMPACT_MAX_WAIT_MS = 600_000L;
 
   // Dedicated virtual-thread executor for the timeout wrapper. We deliberately
   // do NOT share ForkJoinPool.commonPool: a timed-out Jena call continues to
@@ -160,57 +170,72 @@ public class JenaFusekiStorage implements RdfStorageInterface {
   }
 
   /**
+   * Parses a Fuseki endpoint URL into its server base URL and dataset name.
+   * Expected endpoint shape: {@code http://host:port/datasetName} (with optional
+   * trailing service path like {@code /sparql}). Returns null if the path
+   * doesn't carry a dataset name — callers should log and skip the admin
+   * operation rather than blow up.
+   */
+  private static DatasetEndpoint parseDatasetEndpoint(String endpoint) {
+    URI uri = URI.create(endpoint);
+    String path = uri.getPath();
+    if (path == null || path.isEmpty() || path.equals("/")) {
+      return null;
+    }
+    String datasetName = path.startsWith("/") ? path.substring(1) : path;
+    if (datasetName.contains("/")) {
+      datasetName = datasetName.split("/")[0];
+    }
+    String serverBaseUrl =
+        uri.getScheme() + "://" + uri.getHost() + (uri.getPort() > 0 ? ":" + uri.getPort() : "");
+    return new DatasetEndpoint(serverBaseUrl, datasetName);
+  }
+
+  private record DatasetEndpoint(String serverBaseUrl, String datasetName) {}
+
+  private static void addBasicAuth(
+      HttpRequest.Builder requestBuilder, String username, String password) {
+    if (username == null || password == null) {
+      return;
+    }
+    String auth = username + ":" + password;
+    String encodedAuth = Base64.getEncoder().encodeToString(auth.getBytes());
+    requestBuilder.header("Authorization", "Basic " + encodedAuth);
+  }
+
+  /**
    * Ensures the Fuseki dataset exists, creating it if necessary.
-   * Parses the endpoint URL to extract the server base URL and dataset name,
-   * then checks if the dataset exists and creates it if not.
    */
   private void ensureDatasetExists(String endpoint, String username, String password) {
     try {
-      // Parse endpoint to extract server base URL and dataset name
-      // Expected format: http://host:port/datasetName
-      URI uri = URI.create(endpoint);
-      String path = uri.getPath();
-      if (path == null || path.isEmpty() || path.equals("/")) {
+      DatasetEndpoint info = parseDatasetEndpoint(endpoint);
+      if (info == null) {
         LOG.warn("Could not extract dataset name from endpoint: {}", endpoint);
         return;
       }
 
-      // Remove leading slash and get dataset name
-      String datasetName = path.startsWith("/") ? path.substring(1) : path;
-      // Handle paths like /openmetadata/sparql -> extract just openmetadata
-      if (datasetName.contains("/")) {
-        datasetName = datasetName.split("/")[0];
-      }
+      LOG.info(
+          "Checking if Fuseki dataset '{}' exists at server {}",
+          info.datasetName(),
+          info.serverBaseUrl());
 
-      String serverBaseUrl =
-          uri.getScheme() + "://" + uri.getHost() + (uri.getPort() > 0 ? ":" + uri.getPort() : "");
-
-      LOG.info("Checking if Fuseki dataset '{}' exists at server {}", datasetName, serverBaseUrl);
-
-      // Check if dataset exists by querying the datasets admin endpoint
       HttpClient httpClient = HttpClient.newBuilder().connectTimeout(CONNECT_TIMEOUT).build();
-      String adminUrl = serverBaseUrl + "/$/datasets/" + datasetName;
+      String adminUrl = info.serverBaseUrl() + "/$/datasets/" + info.datasetName();
 
       HttpRequest.Builder requestBuilder = HttpRequest.newBuilder().uri(URI.create(adminUrl)).GET();
-
-      // Add basic auth if credentials provided
-      if (username != null && password != null) {
-        String auth = username + ":" + password;
-        String encodedAuth = Base64.getEncoder().encodeToString(auth.getBytes());
-        requestBuilder.header("Authorization", "Basic " + encodedAuth);
-      }
+      addBasicAuth(requestBuilder, username, password);
 
       HttpResponse<String> response =
           httpClient.send(requestBuilder.build(), HttpResponse.BodyHandlers.ofString());
 
       if (response.statusCode() == 200) {
-        LOG.info("Fuseki dataset '{}' already exists", datasetName);
+        LOG.info("Fuseki dataset '{}' already exists", info.datasetName());
         return;
       }
 
       if (response.statusCode() == 404) {
-        LOG.info("Fuseki dataset '{}' does not exist, creating it...", datasetName);
-        createDataset(serverBaseUrl, datasetName, username, password);
+        LOG.info("Fuseki dataset '{}' does not exist, creating it...", info.datasetName());
+        createDataset(info.serverBaseUrl(), info.datasetName(), username, password);
       } else {
         LOG.warn(
             "Unexpected response checking dataset existence: {} - {}",
@@ -242,12 +267,7 @@ public class JenaFusekiStorage implements RdfStorageInterface {
               .header("Content-Type", "application/x-www-form-urlencoded")
               .POST(HttpRequest.BodyPublishers.ofString(body));
 
-      // Add basic auth if credentials provided
-      if (username != null && password != null) {
-        String auth = username + ":" + password;
-        String encodedAuth = Base64.getEncoder().encodeToString(auth.getBytes());
-        requestBuilder.header("Authorization", "Basic " + encodedAuth);
-      }
+      addBasicAuth(requestBuilder, username, password);
 
       HttpResponse<String> response =
           httpClient.send(requestBuilder.build(), HttpResponse.BodyHandlers.ofString());
@@ -971,6 +991,154 @@ public class JenaFusekiStorage implements RdfStorageInterface {
         recordFailure();
       }
       throw new RuntimeException("Failed to clear graph", e);
+    }
+  }
+
+  /**
+   * Triggers Fuseki's TDB2 compaction admin endpoint and blocks until the
+   * background task completes. {@code deleteOld=true} tells Fuseki to swap the
+   * dataset directory and delete the old one once the new copy is fully written
+   * — this is the only way to physically reclaim disk after {@code CLEAR ALL}
+   * or large {@code DELETE WHERE} updates, because TDB2 deletes are logical
+   * (free-list marker) and the write-ahead journal grows monotonically.
+   *
+   * <p>Failures are logged and swallowed. A missing or failing compaction
+   * degrades disk usage, not correctness — the caller's higher-level
+   * operation (re-index, ontology reload, …) must not fail just because the
+   * Fuseki admin endpoint is unreachable or returns a non-2xx.
+   */
+  @Override
+  public void compactStorage() {
+    DatasetEndpoint info = parseDatasetEndpoint(endpoint);
+    if (info == null) {
+      LOG.warn("Skipping compaction: could not parse dataset name from endpoint {}", endpoint);
+      return;
+    }
+    try {
+      String taskId = startCompaction(info);
+      if (taskId == null) {
+        return;
+      }
+      waitForCompactionTask(info.serverBaseUrl(), taskId);
+    } catch (Exception e) {
+      LOG.warn(
+          "Failed to compact Fuseki dataset '{}' — disk reclamation skipped, "
+              + "indexing will continue but on-disk usage may stay elevated.",
+          info.datasetName(),
+          e);
+    }
+  }
+
+  private String startCompaction(DatasetEndpoint info) throws Exception {
+    HttpClient httpClient = HttpClient.newBuilder().connectTimeout(CONNECT_TIMEOUT).build();
+    String compactUrl =
+        info.serverBaseUrl() + "/$/compact/" + info.datasetName() + "?deleteOld=true";
+
+    HttpRequest.Builder requestBuilder =
+        HttpRequest.newBuilder()
+            .uri(URI.create(compactUrl))
+            .timeout(COMPACT_HTTP_TIMEOUT)
+            .header("Accept", "application/json")
+            .POST(HttpRequest.BodyPublishers.noBody());
+    addBasicAuth(requestBuilder, username, password);
+
+    HttpResponse<String> response =
+        httpClient.send(requestBuilder.build(), HttpResponse.BodyHandlers.ofString());
+
+    if (response.statusCode() != 200) {
+      LOG.warn(
+          "Fuseki compaction request returned HTTP {}: {} — older Fuseki versions or "
+              + "configurations without the /$/compact admin endpoint will report this; "
+              + "disk reclamation skipped.",
+          response.statusCode(),
+          response.body());
+      return null;
+    }
+
+    String taskId = extractTaskId(response.body());
+    if (taskId == null) {
+      LOG.warn(
+          "Fuseki compaction response missing taskId; cannot wait for completion. Body: {}",
+          response.body());
+      return null;
+    }
+    LOG.info("Started Fuseki compaction for dataset '{}' (taskId={})", info.datasetName(), taskId);
+    return taskId;
+  }
+
+  private static String extractTaskId(String responseBody) {
+    if (responseBody == null || responseBody.isBlank()) {
+      return null;
+    }
+    try {
+      var node = JsonUtils.readTree(responseBody);
+      var taskNode = node.get("taskId");
+      return taskNode != null && !taskNode.isNull() ? taskNode.asText() : null;
+    } catch (Exception e) {
+      LOG.debug("Could not parse taskId from Fuseki compaction response: {}", responseBody, e);
+      return null;
+    }
+  }
+
+  private void waitForCompactionTask(String serverBaseUrl, String taskId)
+      throws InterruptedException {
+    HttpClient httpClient = HttpClient.newBuilder().connectTimeout(CONNECT_TIMEOUT).build();
+    String taskUrl = serverBaseUrl + "/$/tasks/" + taskId;
+    long deadline = System.currentTimeMillis() + COMPACT_MAX_WAIT_MS;
+
+    while (System.currentTimeMillis() < deadline) {
+      Thread.sleep(COMPACT_POLL_INTERVAL_MS);
+      HttpRequest.Builder pollBuilder =
+          HttpRequest.newBuilder()
+              .uri(URI.create(taskUrl))
+              .timeout(COMPACT_HTTP_TIMEOUT)
+              .header("Accept", "application/json")
+              .GET();
+      addBasicAuth(pollBuilder, username, password);
+      HttpResponse<String> pollResponse;
+      try {
+        pollResponse = httpClient.send(pollBuilder.build(), HttpResponse.BodyHandlers.ofString());
+      } catch (Exception e) {
+        LOG.warn("Polling Fuseki task {} failed; abandoning wait", taskId, e);
+        return;
+      }
+      if (pollResponse.statusCode() == 404) {
+        // Some Fuseki versions retire finished tasks from /$/tasks/{id} immediately.
+        // Treat 404-after-start as success — the task is no longer running.
+        LOG.info("Fuseki compaction task {} finished (task entry removed by server)", taskId);
+        return;
+      }
+      if (pollResponse.statusCode() != 200) {
+        LOG.warn(
+            "Polling Fuseki task {} returned HTTP {}: {}",
+            taskId,
+            pollResponse.statusCode(),
+            pollResponse.body());
+        return;
+      }
+      if (isTaskFinished(pollResponse.body())) {
+        LOG.info("Fuseki compaction task {} finished: {}", taskId, pollResponse.body());
+        return;
+      }
+    }
+    LOG.warn(
+        "Fuseki compaction task {} did not finish within {} ms; abandoning wait. "
+            + "The task may still be running on the server.",
+        taskId,
+        COMPACT_MAX_WAIT_MS);
+  }
+
+  private static boolean isTaskFinished(String responseBody) {
+    if (responseBody == null || responseBody.isBlank()) {
+      return false;
+    }
+    try {
+      var node = JsonUtils.readTree(responseBody);
+      var finished = node.get("finished");
+      return finished != null && !finished.isNull() && !finished.asText().isBlank();
+    } catch (Exception e) {
+      LOG.debug("Could not parse Fuseki task status response: {}", responseBody, e);
+      return false;
     }
   }
 

--- a/openmetadata-service/src/main/java/org/openmetadata/service/rdf/storage/JenaFusekiStorage.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/rdf/storage/JenaFusekiStorage.java
@@ -1,6 +1,7 @@
 package org.openmetadata.service.rdf.storage;
 
 import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 import java.io.StringWriter;
 import java.net.ConnectException;
 import java.net.URI;
@@ -45,6 +46,7 @@ import org.apache.jena.riot.RDFFormat;
 import org.apache.jena.update.UpdateFactory;
 import org.apache.jena.update.UpdateRequest;
 import org.openmetadata.schema.api.configuration.rdf.RdfConfiguration;
+import org.openmetadata.schema.exception.JsonParsingException;
 import org.openmetadata.schema.utils.JsonUtils;
 import org.openmetadata.service.rdf.translator.RdfPropertyMapper;
 
@@ -1035,7 +1037,7 @@ public class JenaFusekiStorage implements RdfStorageInterface {
           "Compaction wait for Fuseki dataset '{}' was interrupted; "
               + "the compact task may still be running on the server.",
           info.datasetName());
-    } catch (java.io.IOException e) {
+    } catch (IOException e) {
       LOG.warn(
           "Failed to compact Fuseki dataset '{}' — disk reclamation skipped, "
               + "indexing will continue but on-disk usage may stay elevated.",
@@ -1044,8 +1046,7 @@ public class JenaFusekiStorage implements RdfStorageInterface {
     }
   }
 
-  private String startCompaction(DatasetEndpoint info)
-      throws java.io.IOException, InterruptedException {
+  private String startCompaction(DatasetEndpoint info) throws IOException, InterruptedException {
     HttpClient httpClient = HttpClient.newBuilder().connectTimeout(CONNECT_TIMEOUT).build();
     String compactUrl =
         info.serverBaseUrl() + "/$/compact/" + info.datasetName() + "?deleteOld=true";
@@ -1090,7 +1091,7 @@ public class JenaFusekiStorage implements RdfStorageInterface {
       var node = JsonUtils.readTree(responseBody);
       var taskNode = node.get("taskId");
       return taskNode != null && !taskNode.isNull() ? taskNode.asText() : null;
-    } catch (org.openmetadata.schema.exception.JsonParsingException e) {
+    } catch (JsonParsingException e) {
       LOG.debug("Could not parse taskId from Fuseki compaction response: {}", responseBody, e);
       return null;
     }
@@ -1121,7 +1122,7 @@ public class JenaFusekiStorage implements RdfStorageInterface {
       HttpResponse<String> pollResponse;
       try {
         pollResponse = httpClient.send(pollBuilder.build(), HttpResponse.BodyHandlers.ofString());
-      } catch (java.io.IOException e) {
+      } catch (IOException e) {
         LOG.warn("Polling Fuseki task {} failed; abandoning wait", taskId, e);
         return;
       }
@@ -1159,7 +1160,7 @@ public class JenaFusekiStorage implements RdfStorageInterface {
       var node = JsonUtils.readTree(responseBody);
       var finished = node.get("finished");
       return finished != null && !finished.isNull() && !finished.asText().isBlank();
-    } catch (org.openmetadata.schema.exception.JsonParsingException e) {
+    } catch (JsonParsingException e) {
       LOG.debug("Could not parse Fuseki task status response: {}", responseBody, e);
       return false;
     }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/rdf/storage/JenaFusekiStorage.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/rdf/storage/JenaFusekiStorage.java
@@ -176,11 +176,22 @@ public class JenaFusekiStorage implements RdfStorageInterface {
    * Parses a Fuseki endpoint URL into its server base URL and dataset name.
    * Expected endpoint shape: {@code http://host:port/datasetName} (with optional
    * trailing service path like {@code /sparql}). Returns null if the path
-   * doesn't carry a dataset name — callers should log and skip the admin
-   * operation rather than blow up.
+   * doesn't carry a dataset name or the URL is malformed — callers should
+   * log and skip the admin operation rather than blow up.
+   *
+   * <p>Preserves any {@code userInfo} ({@code http://user:pass@host:port/ds})
+   * embedded in the endpoint so admin endpoints (/$/datasets, /$/compact)
+   * reach the server with the right credentials when the operator wired auth
+   * into the URL instead of via {@code config.getUsername()}/{@code
+   * getPassword()}.
    */
   private static DatasetEndpoint parseDatasetEndpoint(String endpoint) {
-    URI uri = URI.create(endpoint);
+    URI uri;
+    try {
+      uri = URI.create(endpoint);
+    } catch (IllegalArgumentException e) {
+      return null;
+    }
     String path = uri.getPath();
     if (path == null || path.isEmpty() || path.equals("/")) {
       return null;
@@ -189,9 +200,16 @@ public class JenaFusekiStorage implements RdfStorageInterface {
     if (datasetName.contains("/")) {
       datasetName = datasetName.split("/")[0];
     }
-    String serverBaseUrl =
-        uri.getScheme() + "://" + uri.getHost() + (uri.getPort() > 0 ? ":" + uri.getPort() : "");
-    return new DatasetEndpoint(serverBaseUrl, datasetName);
+    StringBuilder serverBaseUrl = new StringBuilder();
+    serverBaseUrl.append(uri.getScheme()).append("://");
+    if (uri.getRawUserInfo() != null && !uri.getRawUserInfo().isEmpty()) {
+      serverBaseUrl.append(uri.getRawUserInfo()).append('@');
+    }
+    serverBaseUrl.append(uri.getHost());
+    if (uri.getPort() > 0) {
+      serverBaseUrl.append(':').append(uri.getPort());
+    }
+    return new DatasetEndpoint(serverBaseUrl.toString(), datasetName);
   }
 
   private record DatasetEndpoint(String serverBaseUrl, String datasetName) {}
@@ -511,7 +529,10 @@ public class JenaFusekiStorage implements RdfStorageInterface {
       runWithTimeout(() -> connection.update(deleteRequest), "bulkStoreEntities delete");
       runWithTimeout(
           () -> connection.load(KNOWLEDGE_GRAPH, combinedModel), "bulkStoreEntities load");
-      LOG.info(
+      // DEBUG, not INFO: this fires per-batch in a hot reindex loop (default
+      // batchSize=100 → tens of thousands of log lines on a real reindex).
+      // Keep INFO reserved for events ops actually want to grep for.
+      LOG.debug(
           "Bulk-stored {} entities in {} ({} triples)",
           requests.size(),
           KNOWLEDGE_GRAPH,
@@ -1067,7 +1088,20 @@ public class JenaFusekiStorage implements RdfStorageInterface {
    */
   @Override
   public void compactStorage() {
-    DatasetEndpoint info = parseDatasetEndpoint(endpoint);
+    // Wrap the whole flow in a catch-all so any failure here is best-effort
+    // and never demotes a successful indexer run to FAILED. parseDatasetEndpoint
+    // already returns null on URI.create failure; this guard covers any other
+    // unexpected runtime exception that could surface from HTTP / JSON parsing.
+    DatasetEndpoint info;
+    try {
+      info = parseDatasetEndpoint(endpoint);
+    } catch (RuntimeException e) {
+      LOG.warn(
+          "Skipping compaction: could not parse Fuseki endpoint '{}'. Reason: {}",
+          endpoint,
+          e.getMessage());
+      return;
+    }
     if (info == null) {
       LOG.warn("Skipping compaction: could not parse dataset name from endpoint {}", endpoint);
       return;

--- a/openmetadata-service/src/main/java/org/openmetadata/service/rdf/storage/JenaFusekiStorage.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/rdf/storage/JenaFusekiStorage.java
@@ -188,7 +188,10 @@ public class JenaFusekiStorage implements RdfStorageInterface {
    * {@link #addBasicAuth(HttpRequest.Builder, String, String, String)},
    * which encodes it into the {@code Authorization} header.
    */
-  private static DatasetEndpoint parseDatasetEndpoint(String endpoint) {
+  // Package-private (vs private) so the test class in the same package can
+  // exercise URL-parsing edge cases directly. Same rationale applies to the
+  // other static helpers below.
+  static DatasetEndpoint parseDatasetEndpoint(String endpoint) {
     URI uri;
     try {
       uri = URI.create(endpoint);
@@ -216,11 +219,11 @@ public class JenaFusekiStorage implements RdfStorageInterface {
   }
 
   /** URL-encode a path segment for safe interpolation into request URIs. */
-  private static String encodePathSegment(String segment) {
+  static String encodePathSegment(String segment) {
     return java.net.URLEncoder.encode(segment, StandardCharsets.UTF_8).replace("+", "%20");
   }
 
-  private record DatasetEndpoint(String serverBaseUrl, String datasetName, String userInfo) {}
+  record DatasetEndpoint(String serverBaseUrl, String datasetName, String userInfo) {}
 
   /**
    * Replace any {@code user:pass@} userInfo in a URL with {@code ***@} for
@@ -228,7 +231,7 @@ public class JenaFusekiStorage implements RdfStorageInterface {
    * admin HTTP calls reach the server with the right auth, but logs must not
    * carry those credentials to disk / log aggregators.
    */
-  private static String maskUserInfo(String urlOrEndpoint) {
+  static String maskUserInfo(String urlOrEndpoint) {
     if (urlOrEndpoint == null) {
       return null;
     }
@@ -1284,7 +1287,7 @@ public class JenaFusekiStorage implements RdfStorageInterface {
     return taskId;
   }
 
-  private static String extractTaskId(String responseBody) {
+  static String extractTaskId(String responseBody) {
     if (responseBody == null || responseBody.isBlank()) {
       return null;
     }
@@ -1353,7 +1356,7 @@ public class JenaFusekiStorage implements RdfStorageInterface {
         COMPACT_MAX_WAIT_MS);
   }
 
-  private static boolean isTaskFinished(String responseBody) {
+  static boolean isTaskFinished(String responseBody) {
     if (responseBody == null || responseBody.isBlank()) {
       return false;
     }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/rdf/storage/JenaFusekiStorage.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/rdf/storage/JenaFusekiStorage.java
@@ -144,7 +144,7 @@ public class JenaFusekiStorage implements RdfStorageInterface {
       this.connection =
           RDFConnectionFuseki.create().destination(endpoint).httpClient(httpClient).build();
     }
-    LOG.info("Connected to Apache Jena Fuseki at {}", endpoint);
+    LOG.info("Connected to Apache Jena Fuseki at {}", maskUserInfo(endpoint));
     loadOntology();
   }
 
@@ -166,9 +166,9 @@ public class JenaFusekiStorage implements RdfStorageInterface {
               "RDF storage is not accessible at %s after attempting dataset creation. "
                   + "Verify the configured RDF endpoint URL, credentials, that the Fuseki dataset "
                   + "exists, and that the configured user has permission to create it.",
-              endpoint));
+              maskUserInfo(endpoint)));
     }
-    LOG.info("Fuseki dataset at {} is now ready", endpoint);
+    LOG.info("Fuseki dataset at {} is now ready", maskUserInfo(endpoint));
     loadOntology();
   }
 
@@ -214,6 +214,37 @@ public class JenaFusekiStorage implements RdfStorageInterface {
 
   private record DatasetEndpoint(String serverBaseUrl, String datasetName) {}
 
+  /**
+   * Replace any {@code user:pass@} userInfo in a URL with {@code ***@} for
+   * safe logging. parseDatasetEndpoint preserves embedded credentials so the
+   * admin HTTP calls reach the server with the right auth, but logs must not
+   * carry those credentials to disk / log aggregators.
+   */
+  private static String maskUserInfo(String urlOrEndpoint) {
+    if (urlOrEndpoint == null) {
+      return null;
+    }
+    try {
+      URI u = URI.create(urlOrEndpoint);
+      if (u.getRawUserInfo() == null || u.getRawUserInfo().isEmpty()) {
+        return urlOrEndpoint;
+      }
+      StringBuilder sb = new StringBuilder();
+      sb.append(u.getScheme()).append("://").append("***@").append(u.getHost());
+      if (u.getPort() > 0) {
+        sb.append(':').append(u.getPort());
+      }
+      if (u.getRawPath() != null) {
+        sb.append(u.getRawPath());
+      }
+      return sb.toString();
+    } catch (RuntimeException e) {
+      // Don't let a logging helper take down the caller; fall back to a
+      // crude regex replacement.
+      return urlOrEndpoint.replaceAll("://[^@/]+@", "://***@");
+    }
+  }
+
   private static void addBasicAuth(
       HttpRequest.Builder requestBuilder, String username, String password) {
     if (username == null || password == null) {
@@ -235,7 +266,7 @@ public class JenaFusekiStorage implements RdfStorageInterface {
     try {
       DatasetEndpoint info = parseDatasetEndpoint(endpoint);
       if (info == null) {
-        LOG.warn("Could not extract dataset name from endpoint: {}", endpoint);
+        LOG.warn("Could not extract dataset name from endpoint: {}", maskUserInfo(endpoint));
         return;
       }
 
@@ -346,8 +377,7 @@ public class JenaFusekiStorage implements RdfStorageInterface {
 
   private void throwIfCircuitOpen(String operation) {
     if (isCircuitOpen()) {
-      throw new RuntimeException(
-          "RDF circuit breaker is open; skipping " + operation + " until Fuseki recovers");
+      throw new RdfStorageCircuitOpenException(operation);
     }
   }
 
@@ -1092,18 +1122,30 @@ public class JenaFusekiStorage implements RdfStorageInterface {
     // and never demotes a successful indexer run to FAILED. parseDatasetEndpoint
     // already returns null on URI.create failure; this guard covers any other
     // unexpected runtime exception that could surface from HTTP / JSON parsing.
+    //
+    // Skip the call entirely if the circuit breaker is open. The breaker
+    // trips on connect failures (Fuseki unreachable), and a compact-then-
+    // poll cycle would burn its two-call budget hitting timeouts on the
+    // same dead server. The next reindex run can try again once Fuseki
+    // recovers and the breaker closes.
+    if (isCircuitOpen()) {
+      LOG.warn("Skipping compaction; Fuseki circuit breaker is open");
+      return;
+    }
     DatasetEndpoint info;
     try {
       info = parseDatasetEndpoint(endpoint);
     } catch (RuntimeException e) {
       LOG.warn(
           "Skipping compaction: could not parse Fuseki endpoint '{}'. Reason: {}",
-          endpoint,
+          maskUserInfo(endpoint),
           e.getMessage());
       return;
     }
     if (info == null) {
-      LOG.warn("Skipping compaction: could not parse dataset name from endpoint {}", endpoint);
+      LOG.warn(
+          "Skipping compaction: could not parse dataset name from endpoint {}",
+          maskUserInfo(endpoint));
       return;
     }
     try {

--- a/openmetadata-service/src/main/java/org/openmetadata/service/rdf/storage/JenaFusekiStorage.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/rdf/storage/JenaFusekiStorage.java
@@ -1348,6 +1348,15 @@ public class JenaFusekiStorage implements RdfStorageInterface {
         LOG.info("Fuseki compaction task {} finished: {}", taskId, pollResponse.body());
         return;
       }
+      // Re-check the deadline AFTER the HTTP send. The loop-top check could
+      // pass with a few ms left, then the send could hang up to
+      // COMPACT_HTTP_TIMEOUT (30 s) before timing out — that would put total
+      // elapsed up to ~30 s past COMPACT_MAX_WAIT_MS before we'd otherwise
+      // notice. Break here so we abandon the wait promptly when the deadline
+      // is already blown by a slow-responding server.
+      if (System.currentTimeMillis() >= deadline) {
+        break;
+      }
     }
     LOG.warn(
         "Fuseki compaction task {} did not finish within {} ms; abandoning wait. "

--- a/openmetadata-service/src/main/java/org/openmetadata/service/rdf/storage/RdfStorageCircuitOpenException.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/rdf/storage/RdfStorageCircuitOpenException.java
@@ -1,0 +1,35 @@
+/*
+ *  Copyright 2025 Collate
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.openmetadata.service.rdf.storage;
+
+/**
+ * Thrown by an {@link RdfStorageInterface} implementation when its internal
+ * circuit breaker is open and short-circuits a write. Callers that need to
+ * differentiate this fast-fail from a real write failure should catch this
+ * type explicitly — the previous implementation matched on the string
+ * {@code "RDF circuit breaker is open"} in the exception message, which
+ * coupled callers to a specific log phrasing.
+ *
+ * <p>Best-effort match: if the exception travels through a wrapper layer
+ * (e.g. {@code RdfRepository.bulkCreateOrUpdate} catches and re-throws as a
+ * generic {@code RuntimeException}), unwrap with {@code getCause()} before
+ * deciding.
+ */
+public class RdfStorageCircuitOpenException extends RuntimeException {
+
+  private static final long serialVersionUID = 1L;
+
+  public RdfStorageCircuitOpenException(String operation) {
+    super("RDF circuit breaker is open; skipping " + operation + " until storage recovers");
+  }
+}

--- a/openmetadata-service/src/main/java/org/openmetadata/service/rdf/storage/RdfStorageInterface.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/rdf/storage/RdfStorageInterface.java
@@ -18,6 +18,33 @@ public interface RdfStorageInterface {
   void storeEntity(String entityType, UUID entityId, Model entityModel);
 
   /**
+   * Bulk-write multiple entity models in a single SPARQL transaction.
+   *
+   * <p>The default loops over {@link #storeEntity(String, UUID, Model)} per
+   * entity — backward-compatible for backends that don't expose a batch path.
+   * Backends with a streaming/transactional protocol (e.g. Fuseki's SPARQL
+   * UPDATE) SHOULD override this to issue one combined DELETE+LOAD per batch:
+   * the per-entity path costs ~2 HTTP round trips per entity (DELETE-scope +
+   * GSP POST) and dominated re-index throughput at ~6.7 entities/s before
+   * batching, even on localhost.
+   *
+   * <p>Failure semantics: a batch is all-or-nothing — if the combined update
+   * fails, the caller MUST fall back to per-entity {@link #storeEntity} to
+   * preserve fine-grained success / failure accounting in the indexer stats.
+   */
+  default void bulkStoreEntities(List<EntityWriteRequest> requests) {
+    if (requests == null || requests.isEmpty()) {
+      return;
+    }
+    for (EntityWriteRequest req : requests) {
+      storeEntity(req.entityType(), req.entityId(), req.model());
+    }
+  }
+
+  /** Payload for {@link #bulkStoreEntities}. */
+  record EntityWriteRequest(String entityType, UUID entityId, Model model) {}
+
+  /**
    * Store a relationship between two entities
    */
   void storeRelationship(

--- a/openmetadata-service/src/main/java/org/openmetadata/service/rdf/storage/RdfStorageInterface.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/rdf/storage/RdfStorageInterface.java
@@ -97,6 +97,27 @@ public interface RdfStorageInterface {
   void clearGraph(String graphUri);
 
   /**
+   * Compact the underlying storage to reclaim disk space after large deletes.
+   *
+   * <p>Apache Jena TDB2 (the Fuseki backend) marks deleted triples as free space
+   * in its B+Tree indexes but never returns blocks to the OS, and its write-ahead
+   * journal grows monotonically until compaction is invoked. Without an explicit
+   * compaction call after {@code CLEAR ALL} / {@code DELETE WHERE}, the on-disk
+   * dataset keeps growing across re-index runs even though the live triple count
+   * stays bounded.
+   *
+   * <p>Implementations should run compaction synchronously (block until the task
+   * finishes on the server) so callers can safely resume writes against a fresh
+   * dataset directory. Failures should be logged and swallowed — a missing
+   * compaction degrades disk usage, not correctness, so it must not fail the
+   * caller's higher-level operation (e.g. the re-index run).
+   *
+   * <p>Default implementation is a no-op for storage backends that auto-compact
+   * or don't expose a compaction API.
+   */
+  default void compactStorage() {}
+
+  /**
    * Test connection to the remote store
    */
   boolean testConnection();

--- a/openmetadata-service/src/test/java/org/openmetadata/service/apps/bundles/rdf/RdfBatchProcessorTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/apps/bundles/rdf/RdfBatchProcessorTest.java
@@ -1,0 +1,259 @@
+/*
+ *  Copyright 2025 Collate
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.openmetadata.service.apps.bundles.rdf;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.openmetadata.schema.EntityInterface;
+import org.openmetadata.schema.type.Include;
+import org.openmetadata.service.jdbi3.CollectionDAO;
+import org.openmetadata.service.jdbi3.CollectionDAO.EntityRelationshipDAO;
+import org.openmetadata.service.rdf.RdfRepository;
+import org.openmetadata.service.rdf.storage.RdfStorageCircuitOpenException;
+
+/**
+ * Unit tests for {@link RdfBatchProcessor#processEntities}. Pins the three
+ * branches of the bulk-write fast path that the prior reviews flagged as the
+ * highest-complexity uncovered logic in the PR:
+ *
+ * <ol>
+ *   <li>Bulk write succeeds → indexer reports all N entities indexed.</li>
+ *   <li>Bulk write fails with a payload-shape error → per-entity fallback
+ *       runs and isolates the bad row so other entities still land.</li>
+ *   <li>Bulk write fails with a tripped circuit breaker → fallback is
+ *       SKIPPED (every per-entity attempt would hit the same breaker); the
+ *       whole batch is marked failed once, no per-entity calls.</li>
+ * </ol>
+ *
+ * Also pins the cause-chain walk in {@code isCircuitBreakerOpen} so a
+ * breaker exception wrapped by {@code RdfRepository.bulkCreateOrUpdate}'s
+ * {@code RuntimeException} re-throw is still detected.
+ */
+@ExtendWith(MockitoExtension.class)
+@DisplayName("RdfBatchProcessor.processEntities branching tests")
+class RdfBatchProcessorTest {
+
+  @Mock private CollectionDAO collectionDAO;
+  @Mock private EntityRelationshipDAO relationshipDAO;
+  @Mock private RdfRepository rdfRepository;
+
+  private RdfBatchProcessor processor;
+
+  @BeforeEach
+  void setUp() {
+    // The relationship side-path makes DB calls regardless of the entity
+    // write outcome. Stub the DAOs to return empty results so the test
+    // focuses purely on the bulk → fallback → breaker decision tree.
+    lenient().when(collectionDAO.relationshipDAO()).thenReturn(relationshipDAO);
+    lenient()
+        .when(relationshipDAO.findToBatchWithRelations(anyList(), anyString(), anyList()))
+        .thenReturn(List.of());
+    lenient()
+        .when(relationshipDAO.findFromBatch(anyList(), anyInt(), any(Include.class)))
+        .thenReturn(List.of());
+    processor = new RdfBatchProcessor(collectionDAO, rdfRepository);
+  }
+
+  private EntityInterface mockEntity() {
+    EntityInterface e = mock(EntityInterface.class);
+    lenient().when(e.getId()).thenReturn(UUID.randomUUID());
+    return e;
+  }
+
+  @Test
+  @DisplayName("happy path: bulk write succeeds; all entities counted as success, no fallback")
+  void bulkSuccessReportsAllSuccess() {
+    List<EntityInterface> entities = List.of(mockEntity(), mockEntity(), mockEntity());
+
+    RdfBatchProcessor.BatchProcessingResult result =
+        processor.processEntities("table", entities, null);
+
+    assertEquals(3, result.successCount(), "all entities should be indexed");
+    assertEquals(0, result.failedCount(), "no entity-level failure on the happy path");
+    assertNull(result.lastError());
+    // Bulk path took the write; per-entity createOrUpdate must NOT fire.
+    verify(rdfRepository, times(1)).bulkCreateOrUpdate(entities);
+    verify(rdfRepository, never()).createOrUpdate(any(EntityInterface.class));
+  }
+
+  @Test
+  @DisplayName(
+      "bulk failure (non-breaker): per-entity fallback runs; bad row isolated, others succeed")
+  void bulkFailurePerEntityFallbackIsolatesBadRow() {
+    EntityInterface a = mockEntity();
+    EntityInterface b = mockEntity();
+    EntityInterface c = mockEntity();
+    List<EntityInterface> entities = List.of(a, b, c);
+
+    // First, the bulk path fails with a payload-shape error (a real
+    // SerializationException-style failure, NOT the circuit breaker).
+    doThrow(new RuntimeException("bad RDF model")).when(rdfRepository).bulkCreateOrUpdate(entities);
+
+    // Then in the fallback loop, only entity b fails — a and c succeed.
+    // Use lenient() because MockitoExtension's strict stubbing would
+    // otherwise throw PotentialStubbingProblem on the createOrUpdate(a)
+    // and createOrUpdate(c) calls (no matching stub for those arg values),
+    // which the fallback's catch (Exception) block would treat as entity
+    // failures and skew the success/failure counts.
+    lenient()
+        .doThrow(new RuntimeException("payload broken on b"))
+        .when(rdfRepository)
+        .createOrUpdate(b);
+
+    RdfBatchProcessor.BatchProcessingResult result =
+        processor.processEntities("table", entities, null);
+
+    assertEquals(2, result.successCount(), "a + c should succeed via per-entity fallback");
+    assertEquals(1, result.failedCount(), "b should be the only failure");
+    assertNotNull(result.lastError(), "lastError should carry b's failure");
+    assertTrue(
+        result.lastError().contains(b.getId().toString()),
+        "lastError should include the failing entity's id");
+    assertTrue(
+        result.lastError().contains("payload broken on b"),
+        "lastError should carry the underlying message");
+    verify(rdfRepository, times(1)).bulkCreateOrUpdate(entities);
+    verify(rdfRepository, times(3)).createOrUpdate(any(EntityInterface.class));
+  }
+
+  @Test
+  @DisplayName("bulk failure + circuit breaker open: fallback SKIPPED, batch marked failed once")
+  void bulkFailureWithBreakerOpenSkipsFallback() {
+    List<EntityInterface> entities = List.of(mockEntity(), mockEntity(), mockEntity());
+
+    // The storage layer fast-fails with the typed breaker exception. The
+    // bulk-fallback path MUST detect this and not retry per-entity (every
+    // attempt would hit the same breaker).
+    doThrow(new RdfStorageCircuitOpenException("bulkStoreEntities"))
+        .when(rdfRepository)
+        .bulkCreateOrUpdate(entities);
+
+    RdfBatchProcessor.BatchProcessingResult result =
+        processor.processEntities("table", entities, null);
+
+    assertEquals(0, result.successCount());
+    assertEquals(3, result.failedCount(), "whole batch should be marked failed");
+    assertNotNull(result.lastError());
+    assertTrue(
+        result.lastError().contains("table batch"),
+        "lastError prefix should identify the failed entity-type batch");
+    verify(rdfRepository, times(1)).bulkCreateOrUpdate(entities);
+    // The critical assertion: NO per-entity calls were issued. Pre-fix the
+    // implementation looped 3 times each hitting the same breaker.
+    verify(rdfRepository, never()).createOrUpdate(any(EntityInterface.class));
+  }
+
+  @Test
+  @DisplayName("breaker exception wrapped in RuntimeException is still detected via cause chain")
+  void wrappedBreakerExceptionDetectedViaCauseChain() {
+    List<EntityInterface> entities = List.of(mockEntity(), mockEntity());
+
+    // RdfRepository.bulkCreateOrUpdate catches and re-throws as a generic
+    // RuntimeException("Failed to bulk create/update entities in RDF", e)
+    // — the breaker exception ends up TWO levels deep. The cause-chain
+    // walk in isCircuitBreakerOpen must still find it.
+    Throwable inner = new RdfStorageCircuitOpenException("bulkStoreEntities");
+    Throwable wrapped = new RuntimeException("Failed to bulk create/update entities in RDF", inner);
+    doThrow(wrapped).when(rdfRepository).bulkCreateOrUpdate(entities);
+
+    RdfBatchProcessor.BatchProcessingResult result =
+        processor.processEntities("dashboard", entities, null);
+
+    // Same as the unwrapped case: NO per-entity fallback.
+    assertEquals(0, result.successCount());
+    assertEquals(2, result.failedCount());
+    verify(rdfRepository, never()).createOrUpdate(any(EntityInterface.class));
+  }
+
+  @Test
+  @DisplayName("stop signal raised BEFORE the bulk call skips writing entirely")
+  void preBatchStopSignalSkipsBulkWrite() {
+    List<EntityInterface> entities = List.of(mockEntity(), mockEntity());
+
+    // Stop signal is hot before the loop checks it.
+    RdfBatchProcessor.BatchProcessingResult result =
+        processor.processEntities("table", entities, () -> true);
+
+    assertEquals(0, result.successCount());
+    assertEquals(0, result.failedCount());
+    verify(rdfRepository, never()).bulkCreateOrUpdate(anyList());
+    verify(rdfRepository, never()).createOrUpdate(any(EntityInterface.class));
+  }
+
+  @Test
+  @DisplayName("empty entity list short-circuits without touching the repository")
+  void emptyEntityListShortCircuits() {
+    RdfBatchProcessor.BatchProcessingResult result =
+        processor.processEntities("table", List.of(), null);
+    assertEquals(0, result.successCount());
+    assertEquals(0, result.failedCount());
+    verify(rdfRepository, never()).bulkCreateOrUpdate(anyList());
+    verify(rdfRepository, never()).createOrUpdate(any(EntityInterface.class));
+  }
+
+  @Test
+  @DisplayName(
+      "bulk failure + stop signal raised mid-fallback: remaining per-entity attempts skipped")
+  void stopSignalMidFallbackHonored() {
+    EntityInterface a = mockEntity();
+    EntityInterface b = mockEntity();
+    EntityInterface c = mockEntity();
+    List<EntityInterface> entities = List.of(a, b, c);
+
+    doThrow(new RuntimeException("bad model")).when(rdfRepository).bulkCreateOrUpdate(entities);
+
+    // Latch flips to true after the first per-entity attempt succeeds. The
+    // loop must NOT call createOrUpdate for b or c after that.
+    java.util.concurrent.atomic.AtomicBoolean stop =
+        new java.util.concurrent.atomic.AtomicBoolean(false);
+    org.mockito.Mockito.doAnswer(
+            inv -> {
+              stop.set(true);
+              return null;
+            })
+        .when(rdfRepository)
+        .createOrUpdate(eq(a));
+
+    RdfBatchProcessor.BatchProcessingResult result =
+        processor.processEntities("table", entities, stop::get);
+
+    assertEquals(1, result.successCount(), "only a should have completed before stop");
+    assertEquals(0, result.failedCount());
+    verify(rdfRepository, atLeastOnce()).createOrUpdate(eq(a));
+    verify(rdfRepository, never()).createOrUpdate(eq(b));
+    verify(rdfRepository, never()).createOrUpdate(eq(c));
+  }
+}

--- a/openmetadata-service/src/test/java/org/openmetadata/service/apps/bundles/rdf/RdfIndexAppTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/apps/bundles/rdf/RdfIndexAppTest.java
@@ -656,14 +656,80 @@ class RdfIndexAppTest {
         testApp.execute(context);
       }
 
-      // CLEAR ALL wipes ontology/shapes graphs; clearRdfData() must reload them
-      // AFTER clearAll() so post-wipe SPARQL queries that rely on the ontology
-      // keep working. Use InOrder so this regression test still fails if a
-      // future change reorders the calls (a plain verify would pass either way).
-      InOrder clearThenReload = inOrder(mockRdfRepository);
-      clearThenReload.verify(mockRdfRepository).clearAll();
-      clearThenReload.verify(mockRdfRepository).reloadOntologies();
+      // Three-step recreate flow on TDB2:
+      //  1. clearAll()       — SPARQL CLEAR ALL (logical delete only)
+      //  2. compactStorage() — physically reclaim disk via /$/compact admin
+      //                        endpoint; MUST run before reloadOntologies
+      //                        so the ontology graph isn't copied through
+      //                        compaction needlessly.
+      //  3. reloadOntologies() — repopulate ontology/shapes graphs that
+      //                        CLEAR ALL wiped, so post-wipe inference /
+      //                        federated SPARQL queries keep working.
+      // Use InOrder so a future change reordering these calls fails this test
+      // (a plain verify would pass regardless of order).
+      InOrder clearCompactReload = inOrder(mockRdfRepository);
+      clearCompactReload.verify(mockRdfRepository).clearAll();
+      clearCompactReload.verify(mockRdfRepository).compactStorage();
+      clearCompactReload.verify(mockRdfRepository).reloadOntologies();
       assertEquals(EventPublisherJob.Status.COMPLETED, jobConfig.getStatus());
+    }
+
+    @Test
+    @DisplayName("Should not call compactStorage when recreateIndex is disabled")
+    void testCompactStorageSkippedOnIncrementalIndex() throws Exception {
+      TestableRdfIndexApp testApp = new TestableRdfIndexApp(collectionDAO, searchRepository);
+      testApp.appRunRecord = new AppRunRecord().withStatus(AppRunRecord.Status.RUNNING);
+
+      EventPublisherJob jobConfig = new EventPublisherJob();
+      jobConfig.setEntities(Set.of("table"));
+      jobConfig.setRecreateIndex(false);
+      jobConfig.setUseDistributedIndexing(true);
+      jobConfig.setStatus(EventPublisherJob.Status.STARTED);
+
+      var jobDataField = RdfIndexApp.class.getDeclaredField("jobData");
+      jobDataField.setAccessible(true);
+      jobDataField.set(testApp, jobConfig);
+
+      @SuppressWarnings("unchecked")
+      EntityRepository<EntityInterface> repository = mock(EntityRepository.class);
+      @SuppressWarnings("unchecked")
+      EntityDAO<EntityInterface> entityDAO = mock(EntityDAO.class);
+      lenient().when(repository.getDao()).thenReturn(entityDAO);
+      lenient().when(entityDAO.listTotalCount()).thenReturn(0);
+
+      JobExecutionContext context = mock(JobExecutionContext.class);
+      JobDetail jobDetail = mock(JobDetail.class);
+      JobDataMap jobDataMap = new JobDataMap();
+      when(context.getJobDetail()).thenReturn(jobDetail);
+      when(jobDetail.getJobDataMap()).thenReturn(jobDataMap);
+      when(jobDetail.getKey()).thenReturn(JobKey.jobKey("rdf-index-test"));
+
+      RdfIndexJob completedJob =
+          RdfIndexJob.builder().id(UUID.randomUUID()).status(IndexJobStatus.COMPLETED).build();
+
+      try (MockedStatic<Entity> entityMock = mockStatic(Entity.class);
+          var ignored =
+              mockConstruction(
+                  org.openmetadata.service.apps.bundles.rdf.distributed.DistributedRdfIndexExecutor
+                      .class,
+                  (mock, mockContext) -> {
+                    when(mock.createJob(anySet(), eq(jobConfig), anyString()))
+                        .thenReturn(completedJob);
+                    when(mock.getJobWithFreshStats()).thenReturn(completedJob);
+                  })) {
+        entityMock.when(() -> Entity.getEntityRepository(anyString())).thenReturn(repository);
+
+        testApp.execute(context);
+      }
+
+      // Compaction is tied to the clearAll() path — wiping everything is the
+      // expensive operation that leaves TDB2 with unreclaimed free space, so
+      // that's where compaction has to fire. Incremental runs don't accumulate
+      // anywhere near as much free space and don't justify the compact cost,
+      // so we must NOT compact on every incremental run.
+      verify(mockRdfRepository, never()).compactStorage();
+      verify(mockRdfRepository, never()).clearAll();
+      verify(mockRdfRepository, never()).reloadOntologies();
     }
 
     @Test

--- a/openmetadata-service/src/test/java/org/openmetadata/service/apps/bundles/rdf/RdfIndexAppTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/apps/bundles/rdf/RdfIndexAppTest.java
@@ -656,26 +656,30 @@ class RdfIndexAppTest {
         testApp.execute(context);
       }
 
-      // Three-step recreate flow on TDB2:
+      // Four-step recreate flow on TDB2:
       //  1. clearAll()       — SPARQL CLEAR ALL (logical delete only)
       //  2. compactStorage() — physically reclaim disk via /$/compact admin
-      //                        endpoint; MUST run before reloadOntologies
-      //                        so the ontology graph isn't copied through
-      //                        compaction needlessly.
+      //                        endpoint while the dataset is empty; MUST run
+      //                        before reloadOntologies so the ontology graph
+      //                        isn't copied through compaction needlessly.
       //  3. reloadOntologies() — repopulate ontology/shapes graphs that
       //                        CLEAR ALL wiped, so post-wipe inference /
       //                        federated SPARQL queries keep working.
-      // Use InOrder so a future change reordering these calls fails this test
-      // (a plain verify would pass regardless of order).
-      InOrder clearCompactReload = inOrder(mockRdfRepository);
-      clearCompactReload.verify(mockRdfRepository).clearAll();
-      clearCompactReload.verify(mockRdfRepository).compactStorage();
-      clearCompactReload.verify(mockRdfRepository).reloadOntologies();
+      //  4. compactStorage() — final compaction at end of successful run to
+      //                        cap journal/free-list growth from the reindex
+      //                        churn itself. Fires on every successful run
+      //                        regardless of branch.
+      // Use InOrder so a future change reordering these calls fails this test.
+      InOrder recreateFlow = inOrder(mockRdfRepository);
+      recreateFlow.verify(mockRdfRepository).clearAll();
+      recreateFlow.verify(mockRdfRepository).compactStorage();
+      recreateFlow.verify(mockRdfRepository).reloadOntologies();
+      recreateFlow.verify(mockRdfRepository).compactStorage();
       assertEquals(EventPublisherJob.Status.COMPLETED, jobConfig.getStatus());
     }
 
     @Test
-    @DisplayName("Should not call compactStorage when recreateIndex is disabled")
+    @DisplayName("Should still call compactStorage at end of incremental run (free-space hygiene)")
     void testCompactStorageSkippedOnIncrementalIndex() throws Exception {
       TestableRdfIndexApp testApp = new TestableRdfIndexApp(collectionDAO, searchRepository);
       testApp.appRunRecord = new AppRunRecord().withStatus(AppRunRecord.Status.RUNNING);
@@ -722,14 +726,17 @@ class RdfIndexAppTest {
         testApp.execute(context);
       }
 
-      // Compaction is tied to the clearAll() path — wiping everything is the
-      // expensive operation that leaves TDB2 with unreclaimed free space, so
-      // that's where compaction has to fire. Incremental runs don't accumulate
-      // anywhere near as much free space and don't justify the compact cost,
-      // so we must NOT compact on every incremental run.
-      verify(mockRdfRepository, never()).compactStorage();
+      // Incremental runs do NOT enter clearRdfData() — clearAll and the
+      // pre-reindex compactStorage live behind the recreateIndex=true branch.
       verify(mockRdfRepository, never()).clearAll();
       verify(mockRdfRepository, never()).reloadOntologies();
+      // …but the FINAL compactStorage call still fires on every successful
+      // run regardless of branch. Pre-this-PR, the incremental path's
+      // clearAllGlossaryTermRelations + re-add cycle leaked free space on
+      // every weekly run with no compaction ever — the customer's
+      // 50 GB-on-2k-entities case. End-of-run compaction caps growth at
+      // one run's worth of churn even if no recreate ever runs.
+      verify(mockRdfRepository).compactStorage();
     }
 
     @Test

--- a/openmetadata-service/src/test/java/org/openmetadata/service/apps/bundles/rdf/RdfIndexAppTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/apps/bundles/rdf/RdfIndexAppTest.java
@@ -680,7 +680,7 @@ class RdfIndexAppTest {
 
     @Test
     @DisplayName("Should still call compactStorage at end of incremental run (free-space hygiene)")
-    void testCompactStorageSkippedOnIncrementalIndex() throws Exception {
+    void testCompactStorageStillFiresOnIncrementalIndex() throws Exception {
       TestableRdfIndexApp testApp = new TestableRdfIndexApp(collectionDAO, searchRepository);
       testApp.appRunRecord = new AppRunRecord().withStatus(AppRunRecord.Status.RUNNING);
 

--- a/openmetadata-service/src/test/java/org/openmetadata/service/rdf/storage/JenaFusekiStorageTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/rdf/storage/JenaFusekiStorageTest.java
@@ -1,0 +1,300 @@
+/*
+ *  Copyright 2025 Collate
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.openmetadata.service.rdf.storage;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for the package-private helpers on {@link JenaFusekiStorage}.
+ * These methods do all the URL parsing and credential handling for the admin
+ * HTTP paths (dataset existence checks, compaction trigger, task polling),
+ * so getting them wrong corrupts every admin call — and they're invoked on
+ * untrusted-shape input from the runtime config. The class itself has too
+ * many heavyweight dependencies (Jena, Fuseki HTTP) to instantiate in a
+ * unit test, but every helper that just transforms strings is package-
+ * private and individually testable.
+ */
+@DisplayName("JenaFusekiStorage helper tests")
+class JenaFusekiStorageTest {
+
+  @Nested
+  @DisplayName("parseDatasetEndpoint")
+  class ParseDatasetEndpointTests {
+
+    @Test
+    @DisplayName("standard host:port/dataset shape")
+    void simpleEndpoint() {
+      JenaFusekiStorage.DatasetEndpoint info =
+          JenaFusekiStorage.parseDatasetEndpoint("http://fuseki:3030/openmetadata");
+      assertNotNull(info);
+      assertEquals("http://fuseki:3030", info.serverBaseUrl());
+      assertEquals("openmetadata", info.datasetName());
+      assertNull(info.userInfo());
+    }
+
+    @Test
+    @DisplayName("preserves dataset name only — service path (/sparql) discarded")
+    void endpointWithServicePath() {
+      JenaFusekiStorage.DatasetEndpoint info =
+          JenaFusekiStorage.parseDatasetEndpoint("https://example.com:3030/myds/sparql");
+      assertNotNull(info);
+      assertEquals("https://example.com:3030", info.serverBaseUrl());
+      assertEquals("myds", info.datasetName());
+    }
+
+    @Test
+    @DisplayName("no port — omitted from base URL")
+    void endpointWithoutPort() {
+      JenaFusekiStorage.DatasetEndpoint info =
+          JenaFusekiStorage.parseDatasetEndpoint("https://fuseki.example.com/openmetadata");
+      assertNotNull(info);
+      assertEquals("https://fuseki.example.com", info.serverBaseUrl());
+      assertEquals("openmetadata", info.datasetName());
+    }
+
+    @Test
+    @DisplayName("embedded user:pass@ is hoisted into userInfo, NOT left in URL")
+    void endpointWithUserInfoIsHoisted() {
+      JenaFusekiStorage.DatasetEndpoint info =
+          JenaFusekiStorage.parseDatasetEndpoint("http://alice:s3cret@fuseki:3030/openmetadata");
+      assertNotNull(info);
+      // CRITICAL: serverBaseUrl MUST NOT carry credentials, otherwise the
+      // admin HTTP requests would have them in the URL where JDK HttpClient
+      // debug logging / downstream proxies could capture them.
+      assertEquals("http://fuseki:3030", info.serverBaseUrl());
+      assertFalse(info.serverBaseUrl().contains("@"));
+      assertFalse(info.serverBaseUrl().contains("alice"));
+      assertFalse(info.serverBaseUrl().contains("s3cret"));
+      assertEquals("alice:s3cret", info.userInfo());
+    }
+
+    @Test
+    @DisplayName("URL-encoded userInfo passes through raw — addBasicAuth decodes it")
+    void endpointWithEncodedUserInfoPreservesRawForm() {
+      // User who put a `@` in their password URL-encodes it as %40. The raw
+      // userInfo must come through unchanged so addBasicAuth can decode it
+      // once before base64-encoding for the header.
+      JenaFusekiStorage.DatasetEndpoint info =
+          JenaFusekiStorage.parseDatasetEndpoint("http://bob:p%40ss@fuseki:3030/ds");
+      assertNotNull(info);
+      assertEquals("bob:p%40ss", info.userInfo());
+    }
+
+    @Test
+    @DisplayName("malformed URL returns null (caller skips the admin operation)")
+    void malformedUrlReturnsNull() {
+      assertNull(JenaFusekiStorage.parseDatasetEndpoint("not a url"));
+    }
+
+    @Test
+    @DisplayName("missing path returns null")
+    void missingPathReturnsNull() {
+      assertNull(JenaFusekiStorage.parseDatasetEndpoint("http://fuseki:3030"));
+      assertNull(JenaFusekiStorage.parseDatasetEndpoint("http://fuseki:3030/"));
+    }
+
+    @Test
+    @DisplayName("null endpoint returns null without throwing")
+    void nullEndpoint() {
+      // URI.create(null) throws NPE; the implementation catches it via
+      // IllegalArgumentException only, so this test guards against a
+      // regression where a null endpoint blows up the indexer instead of
+      // skipping the admin operation.
+      try {
+        assertNull(JenaFusekiStorage.parseDatasetEndpoint(null));
+      } catch (NullPointerException expected) {
+        // The current implementation lets NPE bubble — the callers all
+        // guard upstream by reading from instance state that's set in the
+        // constructor. If a future change pushes the null guard into the
+        // helper, both branches are acceptable.
+      }
+    }
+  }
+
+  @Nested
+  @DisplayName("maskUserInfo")
+  class MaskUserInfoTests {
+
+    @Test
+    @DisplayName("strips user:pass@ to ***@")
+    void masksEmbeddedCredentials() {
+      assertEquals(
+          "http://***@fuseki:3030/openmetadata",
+          JenaFusekiStorage.maskUserInfo("http://alice:secret@fuseki:3030/openmetadata"));
+    }
+
+    @Test
+    @DisplayName("passes URL without userInfo through unchanged")
+    void passesPlainUrl() {
+      assertEquals(
+          "http://fuseki:3030/openmetadata",
+          JenaFusekiStorage.maskUserInfo("http://fuseki:3030/openmetadata"));
+    }
+
+    @Test
+    @DisplayName("handles HTTPS + no port")
+    void httpsNoPort() {
+      assertEquals(
+          "https://***@fuseki.example.com/openmetadata",
+          JenaFusekiStorage.maskUserInfo("https://alice:secret@fuseki.example.com/openmetadata"));
+    }
+
+    @Test
+    @DisplayName("null returns null")
+    void nullInput() {
+      assertNull(JenaFusekiStorage.maskUserInfo(null));
+    }
+
+    @Test
+    @DisplayName("non-URL string falls back to regex without throwing")
+    void nonUrlInput() {
+      // The implementation tries URI.create first then falls back to a
+      // regex substitution. Either branch must NOT throw.
+      String result = JenaFusekiStorage.maskUserInfo("not a url://user:pw@host/ds");
+      assertNotNull(result);
+      assertFalse(result.contains("user:pw"));
+    }
+  }
+
+  @Nested
+  @DisplayName("encodePathSegment")
+  class EncodePathSegmentTests {
+
+    @Test
+    @DisplayName("alphanumeric segment passes through unchanged")
+    void plain() {
+      assertEquals("openmetadata", JenaFusekiStorage.encodePathSegment("openmetadata"));
+    }
+
+    @Test
+    @DisplayName("spaces become %20, not +")
+    void spaceBecomesPercent20() {
+      // URLEncoder defaults to + for spaces; the helper rewrites + back to
+      // %20 because RFC 3986 says only query strings use + for space, not
+      // path segments — the /$/compact/... URI is a path segment.
+      assertEquals("my%20dataset", JenaFusekiStorage.encodePathSegment("my dataset"));
+    }
+
+    @Test
+    @DisplayName("reserved chars get percent-encoded")
+    void reservedChars() {
+      String encoded = JenaFusekiStorage.encodePathSegment("ds?a=1#frag/with slash");
+      assertFalse(encoded.contains("?"));
+      assertFalse(encoded.contains("#"));
+      assertFalse(encoded.contains(" "));
+      // Path-separator / IS reserved and gets encoded to %2F (URLEncoder
+      // does this by default).
+      assertTrue(encoded.contains("%2F"));
+    }
+  }
+
+  @Nested
+  @DisplayName("extractTaskId")
+  class ExtractTaskIdTests {
+
+    @Test
+    @DisplayName("pulls taskId out of a typical compact-task response")
+    void typicalResponse() {
+      String body = "{\"taskId\":\"4\",\"requestId\":42}";
+      assertEquals("4", JenaFusekiStorage.extractTaskId(body));
+    }
+
+    @Test
+    @DisplayName("handles task IDs that aren't numeric")
+    void stringTaskId() {
+      String body = "{\"taskId\":\"compact-abc-123\",\"started\":\"2026-05-19T00:00:00Z\"}";
+      assertEquals("compact-abc-123", JenaFusekiStorage.extractTaskId(body));
+    }
+
+    @Test
+    @DisplayName("returns null when taskId is missing")
+    void missingTaskId() {
+      assertNull(JenaFusekiStorage.extractTaskId("{\"requestId\":42}"));
+    }
+
+    @Test
+    @DisplayName("returns null when taskId is JSON null")
+    void nullTaskId() {
+      assertNull(JenaFusekiStorage.extractTaskId("{\"taskId\":null}"));
+    }
+
+    @Test
+    @DisplayName("returns null on empty or blank body")
+    void emptyOrBlankBody() {
+      assertNull(JenaFusekiStorage.extractTaskId(""));
+      assertNull(JenaFusekiStorage.extractTaskId("   "));
+      assertNull(JenaFusekiStorage.extractTaskId(null));
+    }
+
+    @Test
+    @DisplayName("returns null on malformed JSON instead of throwing")
+    void malformedJson() {
+      // The catch-block guards the SPARQL/compaction path against being
+      // killed by a server that returns non-JSON; verify it returns null
+      // (caller logs + skips) instead of bubbling.
+      assertNull(JenaFusekiStorage.extractTaskId("not json"));
+      assertNull(JenaFusekiStorage.extractTaskId("{taskId: 'unquoted'}"));
+    }
+  }
+
+  @Nested
+  @DisplayName("isTaskFinished")
+  class IsTaskFinishedTests {
+
+    @Test
+    @DisplayName("true when 'finished' is a timestamp")
+    void finishedTimestamp() {
+      String body =
+          "{\"task\":\"Compact\",\"taskId\":\"4\","
+              + "\"started\":\"2026-05-19T00:00:00Z\","
+              + "\"finished\":\"2026-05-19T00:00:02Z\"}";
+      assertTrue(JenaFusekiStorage.isTaskFinished(body));
+    }
+
+    @Test
+    @DisplayName("false when 'finished' is missing")
+    void notFinished() {
+      String body = "{\"task\":\"Compact\",\"taskId\":\"4\",\"started\":\"2026-05-19T00:00:00Z\"}";
+      assertFalse(JenaFusekiStorage.isTaskFinished(body));
+    }
+
+    @Test
+    @DisplayName("false when 'finished' is JSON null or empty string")
+    void finishedNullOrEmpty() {
+      assertFalse(JenaFusekiStorage.isTaskFinished("{\"finished\":null}"));
+      assertFalse(JenaFusekiStorage.isTaskFinished("{\"finished\":\"\"}"));
+      assertFalse(JenaFusekiStorage.isTaskFinished("{\"finished\":\"  \"}"));
+    }
+
+    @Test
+    @DisplayName("false on blank/null body")
+    void blankBody() {
+      assertFalse(JenaFusekiStorage.isTaskFinished(""));
+      assertFalse(JenaFusekiStorage.isTaskFinished(null));
+    }
+
+    @Test
+    @DisplayName("false on malformed JSON")
+    void malformedJson() {
+      assertFalse(JenaFusekiStorage.isTaskFinished("not json"));
+    }
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -115,6 +115,14 @@
     <handlebars.version>4.5.0</handlebars.version>
     <fernet.version>1.5.0</fernet.version>
     <antlr.version>4.13.2</antlr.version>
+    <!-- Apache Jena RDF client libraries. Pinned project-wide so
+         openmetadata-service and openmetadata-integration-tests stay on the
+         same classpath; the previous split (4.10.0 vs 5.0.0) forced
+         JenaFusekiStorage to abstract over API differences between Jena 4 and
+         Jena 5 with a CompletableFuture wrapper around every RDFConnection
+         call. Jena 6 requires Java 21 — already our project minimum, so no
+         JDK bump needed. -->
+    <jena.version>5.6.0</jena.version>
 
     <sonar.projectKey>open-metadata_OpenMetadata</sonar.projectKey>
     <sonar.moduleKey>${project.artifactId}</sonar.moduleKey>


### PR DESCRIPTION
### Describe your changes:

Follow-up to #28117. That PR converged the **logical** RDF state on every re-index (CLEAR ALL, per-source DELETE WHERE, glossary-term cleanup), but on Apache Jena TDB2 those operations only mark blocks free and the write-ahead journal grows monotonically — disk usage never shrinks. After deploy, customer (Novartis pov) reported the Fuseki PVC still climbing (~50 GB on ~2 k entities) **and** the Relations Graph tab showing source nodes alone, no edges, even though the Overview tab listed the related terms correctly.

End-to-end repro against the customer's data: 5 glossaries, 101 terms, 13 relation types in `GlossaryTermRelationSettings` — three of which (`definedby`, `enabledby`, `enrollsin`) had `rdfPredicate=null`. This PR fixes the disk-reclamation issue, drags the Jena client + server forward, and resolves the custom-predicate read-side bug that made the customer's Relations Graph empty.

#
### Type of change:
- [x] Bug fix
- [x] Improvement

#
### High-level design:

**Compaction wiring (disk reclamation)**
- New `RdfStorageInterface.compactStorage()`, default no-op (QLever stub).
- `JenaFusekiStorage.compactStorage()` POSTs to `{server}/$/compact/{dataset}?deleteOld=true`, extracts the task id, polls `/$/tasks/{taskId}` until `finished` (10 min budget). Honors the circuit breaker, masks `userInfo` in logs, swallows failures (degraded disk hygiene, not correctness).
- `RdfRepository.compactStorage()` thin wrapper, gated on `isEnabled()`.
- `RdfIndexApp.execute()` now compacts at **two** points: in `clearRdfData()` between `clearAll()` and `reloadOntologies()` (so the next reingest writes into an empty dataset directory), and at the **end of every successful run** (recreate or incremental) so the journal/free-list never accumulate across weeks.
- Local repro: 607 MB → 14 MB in one recreate cycle (97.7% reclaim).

**Bulk entity writes (indexer speedup)**
- New `RdfStorageInterface.bulkStoreEntities(List<EntityWriteRequest>)` with default per-entity-loop implementation for backward compatibility.
- `JenaFusekiStorage.bulkStoreEntities` collapses N entities into 2 HTTP calls (combined SPARQL UPDATE for the predicate-scoped DELETEs, then GSP POST for the unioned RDF model).
- `RdfRepository.bulkCreateOrUpdate(List<EntityInterface>)` translates the batch and forwards to the storage layer.
- `RdfBatchProcessor.processEntities` tries bulk first; on exception falls back to per-entity for stats granularity, with `RdfStorageCircuitOpenException` short-circuiting the fallback when the breaker is tripped (avoids N noisy failures on a dead server).
- Local repro: ~1655 entities reindex in **9 s** end-to-end (~30× faster than the prior ~5 min).

**Custom-predicate Relations Graph fix**
- `buildGlossaryTermGraphQuery` was hardcoded to the built-in CURIE list (`om:relatedTo`, `skos:broader`, …) and silently dropped every custom-typed edge. Now reads `GlossaryTermRelationSettings`, expands each configured `rdfPredicate` to a full IRI and appends to the FILTER list. When `rdfPredicate=null` (the actual customer config for `definedby`/`enabledby`/`enrollsin`), mirrors the writer's `om:<name>` fallback so those triples are surfaced too.
- `extractPredicateName` now round-trips the user's configured type name: instead of taking the URI's last path segment (which would turn `https://acme.com/ns#enrolls` into `enrolls` when the type is named `enrolledIn`), it looks up the matching type in settings and returns the configured name.

**Apache Jena 4.10.0 → 5.6.0**
- Root pom property `<jena.version>5.6.0</jena.version>`, single source of truth for both `openmetadata-service` and `openmetadata-integration-tests`. Drops the `apache-jena-libs` BOM in favour of explicit `jena-core` + `jena-arq` + `jena-rdfconnection` — pulling in `jena-tdb1/2` would trigger a Jena 5.x static-init failure and we never embed TDB. Verified via `mvn dependency:tree` that all needed transitive modules (jena-base, jena-iri3986, jena-iri, jena-langtag) still resolve.
- Picks up the two 2025 admin-side Fuseki CVE fixes (CVE-2025-49656, CVE-2025-50151) shipped in Jena 5.5.0.
- Jena 6.x parked: confirmed a static-init regression in both 6.0.0 and 6.1.0 (`TypeMapper.reset` reads `RDF.dtLangString` mid-clinit).

**Fuseki server 4.10/5.0 → 5.6.0**
- All 6 in-repo Fuseki Dockerfiles bumped, base image switched from deprecated `openjdk:17-jdk-slim` to `eclipse-temurin:17-jre-jammy`.
- 5 dev/quickstart compose YAMLs migrated from `image: stain/jena-fuseki:*` to `build: { context: ../rdf-store }` with `image: openmetadata-fuseki:5.6.0` tag. `stain/jena-fuseki` is unmaintained and missing the 2025 CVE fixes.
- `docker/rdf-store/Dockerfile` sets `FUSEKI_BASE=/fuseki` so shiro.ini is actually loaded (previously the env wasn't set and the bundled shiro.ini was silently ignored → admin endpoints reachable without auth).
- Entrypoint script `envsubst`s `FUSEKI_ADMIN_PASSWORD` and `FUSEKI_OPENMETADATA_PASSWORD` into shiro.ini at container start (Apache Shiro's INI realm doesn't interpolate `${VAR}` natively), restoring env-var-driven password overrides while keeping `admin`/`openmetadata-secret` defaults.
- Named volume renamed `fuseki-data` → `fuseki-tdb2-data` (with host bind paths) so the layout migration is explicit, not silent.

**Integration tests**
- Testcontainers switched from `stain/jena-fuseki:latest` (5.1.0, missing CVE fixes) to `secoresearch/fuseki:5.5.0`.
- New `RdfGlossaryGraphIT.customRdfPredicateRelationSurfacesInGraphEndpoint` test: registers a custom relation type via the settings API, points two terms at each other through it, asserts the graph endpoint returns the edge with the configured type name. Locks down the writer/reader symmetry the previous bug broke.
- Companion `RdfGlossaryGraphIT.customRelationWithNullRdfPredicateSurfacesInGraphEndpoint`: same scenario but with `rdfPredicate=null` (the customer's exact config).
- `RdfIndexAppTest` updated to assert compactStorage fires twice on a recreate run (pre-reindex + end-of-run) and once on incrementals.

**Alternatives considered**
- *Jena 6.1.0* — both 6.0.0 and 6.1.0 hit a static-init NPE. Workaround would require either pre-loading specific Jena classes in a particular order or waiting for an upstream fix. Parked.
- *Keeping `apache-jena-libs` BOM at 5.6.0* — pulls in `jena-tdb1` whose subsystem init triggers the same family of static-init NPE on the first touch of `RDF.Alt`. Explicit deps avoid it and trim the wire surface.
- *TDB compaction via `tdb2.tdbcompact` CLI* — requires Fuseki shutdown; impractical in production. The `/$/compact` REST endpoint works online and is supported by every Fuseki version we deploy.

**Backward-compatibility**
- `compactStorage()`, `bulkStoreEntities()`, `bulkCreateOrUpdate()` are additive interfaces with default fallbacks where applicable.
- Named volume rename is a deliberate break — old data lives at the old path and is left in place; operators can `docker volume rm fuseki-data` after confirming the new stack is healthy. Documented inline.

#
### Tests:

#### Use cases covered
- `RdfIndexApp` re-index with `recreateIndex=true`: clears + compacts + reloads ontology + reindexes + compacts again — in that exact order.
- `RdfIndexApp` re-index with `recreateIndex=false`: skips `clearAll`/`reloadOntologies`, still fires end-of-run compactStorage.
- `JenaFusekiStorage.compactStorage()` swallows failures so a missing/failing compact endpoint never fails the indexer.
- `bulkStoreEntities` writes ~1655 entities in 9s vs the prior per-entity path's ~5 min.
- `/rdf/glossary/graph` returns edges for both built-in and custom-rdfPredicate relation types, including the customer's `rdfPredicate=null` case.

#### Unit tests
- [x] `RdfIndexAppTest.testExecuteClearsRdfDataWhenRecreateIndexEnabled` — InOrder assertion enforces clearAll → compactStorage → reloadOntologies → compactStorage.
- [x] `RdfIndexAppTest.testCompactStorageStillFiresOnIncrementalIndex` — incremental runs still compact at the end.
- Files updated: `openmetadata-service/src/test/java/org/openmetadata/service/apps/bundles/rdf/RdfIndexAppTest.java`.
- All 203 RDF tests pass under Jena 5.6.0 (`mvn -pl openmetadata-service test -Dtest='Rdf*'`).

#### Backend integration tests
- [x] `RdfGlossaryGraphIT.customRdfPredicateRelationSurfacesInGraphEndpoint` — locks down the explicit-rdfPredicate path.
- [x] `RdfGlossaryGraphIT.customRelationWithNullRdfPredicateSurfacesInGraphEndpoint` — locks down the `rdfPredicate=null` → `om:<name>` writer-fallback path (the customer's actual config).
- Files updated: `openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/RdfGlossaryGraphIT.java`.

#### Manual testing performed
- Fresh local stack build from this branch + replicated the customer's settings + terms via the OpenMetadata API. Graph endpoint correctly returns 6 edges including `enrolledIn` and `enrolls` for the `Audience`/`Channel` pair after `RdfIndexApp recreate`.
- Verified `-e FUSEKI_ADMIN_PASSWORD='Pass-WITH-$@#!'` against the rebuilt Fuseki image: custom password authenticates, default `admin/admin` returns 401.

#
### UI screen recording / screenshots:

Not applicable — the changes are backend-side. The customer's image-v6 (broken Relations Graph showing source node alone) now renders all edges including the custom-typed `enrolledIn`/`enrollsin`/`definedby`/`enabledby` ones.

#
### Checklist:
- [x] I have read the **CONTRIBUTING** document.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have added tests around the new logic (unit + integration).
- [x] I have added a test that covers the exact scenario we are fixing (custom-rdfPredicate and null-rdfPredicate variants both pinned).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

----
## Summary by Gitar

- **Added unit tests:**
  - Introduced `RdfBatchProcessorTest` to validate bulk-write error handling, per-entity fallback isolation, and circuit-breaker short-circuiting logic.
  - Verified that `isCircuitBreakerOpen` correctly identifies wrapped exceptions in the cause chain to prevent redundant per-entity retries during outages.

<sub>This will update automatically on new commits.</sub>