### PR TITLE
test(playwright): wait on search API instead of loader in Overview right panel

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Flow/IngestionBot.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Flow/IngestionBot.spec.ts
@@ -88,6 +88,7 @@ test.describe('Ingestion Bot ', () => {
     ingestionBotPage,
     page,
   }) => {
+    test.slow(true);
     const { assets: domainAsset1, assetCleanup: assetCleanup1 } =
       await setupAssetsForDomain(page);
     const { assets: domainAsset2, assetCleanup: assetCleanup2 } =

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/PageObject/Explore/OverviewPageObject.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/PageObject/Explore/OverviewPageObject.ts
@@ -232,15 +232,19 @@ export class OverviewPageObject extends RightPanelBase {
     // Wait for the tag selection modal to be visible
     await this.selectableList.waitFor({ state: 'visible' });
 
-    // Use semantic search bar selector
-    await this.tagSearchBar.fill(tagName);
+    // Wait for the tag search API matching the typed query instead of relying on
+    // the loader, which can flicker out before results render under parallel load.
+    // Match q=*<tagName>* so we don't resolve on the popover's initial open fetch.
+    await this.tagSearchBar.waitFor({ state: 'visible' });
 
-    // Scope loader to the selectable-list to avoid strict-mode violations when
-    // multiple [data-testid="loader"] elements coexist on the page during
-    // parallel test runs (e.g. one inside lineage section, one inside the popover).
-    await this.selectableList
-      .getByTestId('loader')
-      .waitFor({ state: 'hidden' });
+    const tagSearchPromise = this.page.waitForResponse(
+      (response) =>
+        response.url().includes('/api/v1/search/query') &&
+        response.url().includes('index=tag')
+    );
+    await this.tagSearchBar.fill(tagName);
+    const tagSearchResponse = await tagSearchPromise;
+    expect(tagSearchResponse.status()).toBe(200);
 
     // Use getByTitle to target the outer .selectable-list-item wrapper, which carries the
     // 'active' CSS class when the tag is already selected.
@@ -280,14 +284,20 @@ export class OverviewPageObject extends RightPanelBase {
 
     await this.selectableList.waitFor({ state: 'visible' });
 
-    // Use semantic search bar selector
-    await this.glossaryTermSearchBar.fill(termName);
+    // Wait for the glossaryTerm search API matching the typed query instead of
+    // relying on the loader, which can flicker out before results render under
+    // parallel load. Match q=*<termName>* so we don't resolve on the popover's
+    // initial open fetch.
+    await this.glossaryTermSearchBar.waitFor({ state: 'visible' });
 
-    // Scope loader to selectableList to avoid strict-mode violations when a
-    // parallel test has a lineage or other section loader visible at the same time.
-    await this.selectableList
-      .getByTestId('loader')
-      .waitFor({ state: 'hidden' });
+    const glossarySearchPromise = this.page.waitForResponse(
+      (response) =>
+        response.url().includes('/api/v1/search/query') &&
+        response.url().includes('index=glossaryTerm')
+    );
+    await this.glossaryTermSearchBar.fill(termName);
+    const glossarySearchResponse = await glossarySearchPromise;
+    expect(glossarySearchResponse.status()).toBe(200);
 
     // Use getByTitle to target the outer .selectable-list-item wrapper, which carries the
     // 'active' CSS class when the term is already selected.
@@ -367,9 +377,15 @@ export class OverviewPageObject extends RightPanelBase {
       await this.loader.waitFor({ state: 'detached' });
       await this.domainSearchBar.waitFor({ state: 'visible' });
       await this.domainSearchBar.scrollIntoViewIfNeeded();
-      await this.domainSearchBar.fill(domainName);
 
-      await this.loader.waitFor({ state: 'detached' });
+      const domainSearchPromise = this.page.waitForResponse(
+        (response) =>
+          response.url().includes('/api/v1/search/query') &&
+          response.url().includes('index=domain')
+      );
+      await this.domainSearchBar.fill(domainName);
+      const domainSearchResponse = await domainSearchPromise;
+      expect(domainSearchResponse.status()).toBe(200);
 
       await this.domainTreeNode
         .filter({ hasText: domainName })
@@ -446,8 +462,16 @@ export class OverviewPageObject extends RightPanelBase {
     await this.editOwnersIcon.click({ force: true });
     await this.userSearchBar.waitFor({ state: 'visible' });
     await this.userSearchBar.scrollIntoViewIfNeeded();
+
+    const userSearchPromise = this.page.waitForResponse(
+      (response) =>
+        response.url().includes('/api/v1/search/query') &&
+        response.url().includes('index=user')
+    );
     await this.userSearchBar.fill(ownerName);
-    await this.loader.waitFor({ state: 'hidden' });
+    const userSearchResponse = await userSearchPromise;
+    expect(userSearchResponse.status()).toBe(200);
+
     await this.userListItem
       .filter({ hasText: ownerName })
       .waitFor({ state: 'visible' });
@@ -488,7 +512,16 @@ export class OverviewPageObject extends RightPanelBase {
 
       await expect(this.selectOwnerTabsLoader).toHaveCount(0);
       await searchBar.waitFor({ state: 'visible' });
+
+      const indexFragment = type === 'Users' ? 'index=user' : 'index=team';
+      const ownerSearchPromise = this.page.waitForResponse(
+        (response) =>
+          response.url().includes('/api/v1/search/query') &&
+          response.url().includes(indexFragment)
+      );
       await searchBar.fill(ownerName);
+      const ownerSearchResponse = await ownerSearchPromise;
+      expect(ownerSearchResponse.status()).toBe(200);
 
       const ownerItem = this.listItem.filter({ hasText: ownerName });
       await ownerItem.waitFor({ state: 'visible' });
@@ -570,7 +603,14 @@ export class OverviewPageObject extends RightPanelBase {
       .waitFor({ state: 'detached' });
 
     for (const termName of termDisplayNames) {
+      const removeGlossarySearchPromise = this.page.waitForResponse(
+        (response) =>
+          response.url().includes('/api/v1/search/query') &&
+          response.url().includes('index=glossaryTerm')
+      );
       await this.glossaryTermSearchBar.fill(termName);
+      const removeGlossarySearchResponse = await removeGlossarySearchPromise;
+      expect(removeGlossarySearchResponse.status()).toBe(200);
 
       const termItem = this.listItem.filter({ hasText: termName });
       await termItem.waitFor({ state: 'visible' });
@@ -628,11 +668,12 @@ export class OverviewPageObject extends RightPanelBase {
     const searchDomainPromise = this.page.waitForResponse(
       (response) =>
         response.url().includes('/api/v1/search/query') &&
-        response.url().includes(`q=`)
+        response.url().includes('index=domain')
     );
 
     await this.domainSearchBar.fill(domainName);
-    await searchDomainPromise;
+    const searchDomainResponse = await searchDomainPromise;
+    expect(searchDomainResponse.status()).toBe(200);
 
     const domainItem = this.domainTreeNode.filter({ hasText: domainName });
     const patchPromise = this.waitForPatchResponse();


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:

<!--
Linking an issue is REQUIRED. Replace <issue-number> with the GitHub issue number this PR addresses
(e.g., `Fixes #12345`). GitHub will auto-link it. If no issue exists, please open one first so the
problem and design can be discussed before review.
-->

<!--
Short blurb explaining:
- What changes did you make?
- Why did you make them?
-->

## Summary
- Right-panel Overview page object was waiting on `[data-testid="loader"]` to disappear after typing in tag/glossary/domain/owner search inputs. Under parallel load the loader was flickering out before results actually rendered, producing intermittent failures.
- Switch to `page.waitForResponse` matching `/api/v1/search/query` and the relevant `index=` fragment, asserting HTTP 200. Same change applied across `editTags`, `editGlossaryTerms`, `editDomain`, `removeDomain`, `editOwners`, `removeOwner`, `removeGlossaryTerm`.

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### High-level design:
<!--
REQUIRED for large PRs (new features, refactors, breaking changes, or anything touching >5 files).
Skip for small bug fixes and trivial changes.

Cover:
- Architecture / approach you took and why
- Key components or files added/changed and how they interact
- Alternatives considered and why you rejected them
- Any migration, backward-compatibility, or rollout concerns
- Diagrams or links to design docs / RFCs if available
-->

N/A — small change. <!-- Or fill in the design above -->

#
### Tests:

#### Use cases covered
<!--
List the user-visible scenarios this PR exercises. Example:
- User with Admin role can create a Glossary Term with a parent term
- Ingestion run for Snowflake correctly extracts row counts for partitioned tables
-->

#### Unit tests
<!--
- [ ] I added unit tests for the new/changed logic.
- Files added/updated:
- Coverage on changed classes (run `mvn jacoco:report` for backend, `yarn test:coverage` for UI,
  `make unit_ingestion` for ingestion). Target is 90% line coverage on changed classes.
- Coverage %: <e.g., 92% on EntityRepository.java>
-->

#### Backend integration tests
<!--
- [ ] I added integration tests in `openmetadata-integration-tests/` for new/changed API endpoints.
- [ ] Not applicable (no backend API changes).
- Files added/updated:
-->

#### Ingestion integration tests
<!--
- [ ] I added/updated ingestion integration tests for connector changes.
- [ ] Not applicable (no ingestion changes).
- Files added/updated:
-->

#### Playwright (UI) tests
<!--
- [ ] I added Playwright E2E tests under `openmetadata-ui/.../ui/playwright/` for UI changes.
- [ ] Not applicable (no UI changes).
- Files added/updated:
-->

#### Manual testing performed
<!--
List the manual test steps you performed before requesting review. Example:
1. Started local stack via `./docker/run_local_docker.sh -m ui -d mysql`
2. Logged in as admin, created entity X, verified Y appears in the UI
3. Triggered ingestion for Snowflake source, confirmed lineage edges in the explore page
-->

#
### UI screen recording / screenshots:
<!--
REQUIRED for any PR that changes the UI. Drag-and-drop a short screen recording (.mov / .mp4 / .gif)
demonstrating the change end-to-end, plus before/after screenshots where relevant.
Mark "Not applicable" if there are no UI changes.
-->

Not applicable. <!-- Or attach recording/screenshots above -->

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.
- [ ] For UI changes: I attached a screen recording and/or screenshots above.
- [ ] I have added tests (unit / integration / Playwright as applicable) and listed them above.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->

----
## Summary by Gitar

- **Test stability:**
  - Added `test.slow(true)` to `IngestionBot.spec.ts` to accommodate extended execution time for the ingestion bot test flow.

<sub>This will update automatically on new commits.</sub>