### PR TITLE
fix(powerbi): use TSQL dialect for Sql.Database m query lineage parsing

### DIFF
--- a/ingestion/src/metadata/ingestion/source/dashboard/powerbi/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/dashboard/powerbi/metadata.py
@@ -1853,8 +1853,10 @@ class PowerbiSource(DashboardServiceSource):
         server: Optional[str],  # noqa: UP045
     ) -> Optional[List[dict]]:  # noqa: UP006, UP045
         """
-        Extract table references from a SQL query found in a dataflow M expression.
-        Uses LineageParser to parse the SQL and extract source tables.
+        Extract table references from a T-SQL query found in a dataflow M expression
+        sourced from the Power Query Sql.Database / Value.NativeQuery connector
+        (SQL Server / Azure SQL). Uses LineageParser with the TSQL dialect so
+        bracket-quoted identifiers like [Column Name] parse correctly.
         """
         try:
             # Clean PowerBI special characters
@@ -1869,7 +1871,7 @@ class PowerbiSource(DashboardServiceSource):
             try:
                 parser = LineageParser(
                     cleaned_sql,
-                    dialect=Dialect.ANSI,
+                    dialect=Dialect.TSQL,
                     timeout_seconds=30,
                     parser_type=self.get_query_parser_type(),
                 )
@@ -1878,7 +1880,7 @@ class PowerbiSource(DashboardServiceSource):
                 return None
 
             if not parser.source_tables:
-                logger.debug("No source tables found in dataflow SQL query")
+                logger.debug("No source tables found in Power Query M SQL")
                 return None
 
             lineage_tables = []

--- a/ingestion/tests/unit/topology/dashboard/test_powerbi.py
+++ b/ingestion/tests/unit/topology/dashboard/test_powerbi.py
@@ -2235,39 +2235,47 @@ class PowerBIUnitTest(TestCase):
         assert len(dash_3_result.charts) == 0
 
     @pytest.mark.order(51)
-    def test_extract_tables_from_sql_uses_tsql_dialect(self):
+    def test_tsql_dialect_required_for_bracket_quoted_identifiers(self):
         """
-        Regression guard: `_extract_tables_from_sql` must invoke `LineageParser`
-        with `Dialect.TSQL`, not `Dialect.ANSI`. PowerBI's `Sql.Database` /
-        `Value.NativeQuery` connectors are SQL Server / Azure SQL, whose
-        bracket-quoted identifiers fail to parse under ANSI but succeed under
-        TSQL. Reverting this to ANSI silently regresses lineage extraction.
+        Regression guard, outcome-based: the queries PowerBI dataflows produce
+        through `Sql.Database` / `Value.NativeQuery` use T-SQL bracket-quoted
+        identifiers (e.g. [Column Name], [db].[schema].[table]). Parsing
+        these under ANSI fails at the sqlglot/sqlfluff layer; parsing under
+        TSQL succeeds. `_extract_tables_from_sql` must therefore use TSQL.
+
+        We cannot observe this difference through `_parse_sql_source`'s return
+        value alone: LineageParser falls back to the permissive SqlParse
+        analyzer, which recovers source tables even when the higher-fidelity
+        parsers fail. Instead we run LineageParser directly on the
+        representative queries and assert that the connector's chosen dialect
+        is the one for which the real parsers succeed.
         """
         from metadata.ingestion.lineage.models import Dialect
+        from metadata.ingestion.lineage.parser import LineageParser
 
-        sql = "SELECT [Year] FROM cub.v_md_Time_Detailed"
-        m_expression = (
-            f'TestEntity = let\n  Source = Sql.Database("server", "db", [Query = "{sql}"])\nin\n  Source;\r\n'
-        )
+        bracket_queries = [
+            "SELECT CE_UNIQUE_ID, [FUNCT_ACCOUNT ALT_L2] FROM cub.v_md_FunctAccount_with_CostElement",
+            "SELECT ORGANIZATION_ID, [Level], [ORGANIZATION ID AND DESCRIPTION] FROM cub.v_md_Organization_FLAT",
+            "SELECT * FROM [NBS_GENIE].[QS].[Company_v2]",
+            "SELECT SORT_ORDER, SOURCE FROM cub.[v_md_SourceSystem (FAC)]",
+            "SELECT TOP 100 IBI_DETAILS_ID, [YEAR] FROM cub.v_fact_IBI_vs_BPC_Delta WHERE [YEAR] = 2024",
+        ]
 
-        captured = {}
+        for sql in bracket_queries:
+            ansi_parser = LineageParser(sql, dialect=Dialect.ANSI, timeout_seconds=10)
+            tsql_parser = LineageParser(sql, dialect=Dialect.TSQL, timeout_seconds=10)
 
-        class _DialectCapturingParser:
-            def __init__(self, query, dialect, timeout_seconds, parser_type):
-                captured["dialect"] = dialect
-                self.source_tables = []
-
-        with patch(
-            "metadata.ingestion.source.dashboard.powerbi.metadata.LineageParser",
-            _DialectCapturingParser,
-        ):
-            self.powerbi._parse_sql_source(m_expression)
-
-        assert captured.get("dialect") == Dialect.TSQL, (
-            f"Expected Dialect.TSQL, got {captured.get('dialect')}. "
-            "PowerBI Sql.Database queries are T-SQL — reverting to ANSI "
-            "regresses bracket-identifier parsing."
-        )
+            assert ansi_parser.query_parsing_success is False, (
+                f"Expected ANSI to fail on bracket-quoted T-SQL: {sql!r}. "
+                "If ANSI now parses this, the dialect choice in "
+                "_extract_tables_from_sql may no longer matter and this "
+                "test should be re-evaluated."
+            )
+            assert tsql_parser.query_parsing_success is True, (
+                f"Expected TSQL to parse bracket-quoted T-SQL: {sql!r}. "
+                "If this fails, the underlying parsers (sqlglot/sqlfluff) "
+                "have regressed and PowerBI dataflow lineage will be lost."
+            )
 
     @pytest.mark.order(52)
     def test_extract_tables_from_sql_tsql_bracket_queries(self):

--- a/ingestion/tests/unit/topology/dashboard/test_powerbi.py
+++ b/ingestion/tests/unit/topology/dashboard/test_powerbi.py
@@ -2233,3 +2233,91 @@ class PowerBIUnitTest(TestCase):
 
         dash_3_result = next(d for d in dashboards if d.name.root == "dash-3")
         assert len(dash_3_result.charts) == 0
+
+    @pytest.mark.order(51)
+    def test_extract_tables_from_sql_uses_tsql_dialect(self):
+        """
+        Regression guard: `_extract_tables_from_sql` must invoke `LineageParser`
+        with `Dialect.TSQL`, not `Dialect.ANSI`. PowerBI's `Sql.Database` /
+        `Value.NativeQuery` connectors are SQL Server / Azure SQL, whose
+        bracket-quoted identifiers fail to parse under ANSI but succeed under
+        TSQL. Reverting this to ANSI silently regresses lineage extraction.
+        """
+        from metadata.ingestion.lineage.models import Dialect
+
+        sql = "SELECT [Year] FROM cub.v_md_Time_Detailed"
+        m_expression = (
+            f'TestEntity = let\n  Source = Sql.Database("server", "db", [Query = "{sql}"])\nin\n  Source;\r\n'
+        )
+
+        captured = {}
+
+        class _DialectCapturingParser:
+            def __init__(self, query, dialect, timeout_seconds, parser_type):
+                captured["dialect"] = dialect
+                self.source_tables = []
+
+        with patch(
+            "metadata.ingestion.source.dashboard.powerbi.metadata.LineageParser",
+            _DialectCapturingParser,
+        ):
+            self.powerbi._parse_sql_source(m_expression)
+
+        assert captured.get("dialect") == Dialect.TSQL, (
+            f"Expected Dialect.TSQL, got {captured.get('dialect')}. "
+            "PowerBI Sql.Database queries are T-SQL — reverting to ANSI "
+            "regresses bracket-identifier parsing."
+        )
+
+    @pytest.mark.order(52)
+    def test_extract_tables_from_sql_tsql_bracket_queries(self):
+        """
+        End-to-end smoke test: 5 representative T-SQL queries from the
+        production PowerBI ingestion log that previously failed parsing under
+        the ANSI dialect. With the TSQL dialect, each must successfully parse
+        and yield the expected source table.
+
+        Cases:
+          1. Bracket-quoted column with embedded space  ([FUNCT_ACCOUNT ALT_L2])
+          2. Multi-word bracket-quoted column           ([ORGANIZATION ID AND DESCRIPTION])
+          3. Three-part fully-bracketed table reference ([db].[schema].[table])
+          4. Bracket-quoted table with space + parens   (cub.[v_md_SourceSystem (FAC)])
+          5. T-SQL TOP clause with bracket-quoted col   (SELECT TOP n ... [YEAR])
+        """
+        cases = [
+            (
+                "bracket-quoted column with space",
+                "SELECT CE_UNIQUE_ID, [FUNCT_ACCOUNT ALT_L2] FROM cub.v_md_FunctAccount_with_CostElement",
+                "v_md_FunctAccount_with_CostElement",
+            ),
+            (
+                "multi-word bracket-quoted column",
+                "SELECT ORGANIZATION_ID, [Level], [ORGANIZATION ID AND DESCRIPTION] FROM cub.v_md_Organization_FLAT",
+                "v_md_Organization_FLAT",
+            ),
+            (
+                "three-part bracketed table reference",
+                "SELECT * FROM [NBS_GENIE].[QS].[Company_v2]",
+                "Company_v2",
+            ),
+            (
+                "bracketed table name with space and parens",
+                "SELECT SORT_ORDER, SOURCE FROM cub.[v_md_SourceSystem (FAC)]",
+                "v_md_SourceSystem (FAC)",
+            ),
+            (
+                "T-SQL TOP clause with bracket-quoted reserved word",
+                "SELECT TOP 100 IBI_DETAILS_ID, [YEAR] FROM cub.v_fact_IBI_vs_BPC_Delta WHERE [YEAR] = 2024",
+                "v_fact_IBI_vs_BPC_Delta",
+            ),
+        ]
+
+        for label, sql, expected_table in cases:
+            m_expression = (
+                f'TestEntity = let\n  Source = Sql.Database("server", "db", [Query = "{sql}"])\nin\n  Source;\r\n'
+            )
+            result = self.powerbi._parse_sql_source(m_expression)
+            assert result is not None, f"[{label}] _parse_sql_source returned None"
+            assert any(expected_table.lower() in t["table"].lower() for t in result), (
+                f"[{label}] expected table '{expected_table}' not found in result {[t['table'] for t in result]}"
+            )


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:

## Summary

- PowerBI dataflow lineage parsing was failing for SQL Server / Azure SQL
sources whose queries use T-SQL bracket-quoted identifiers like
`[Column Name]`, `[db].[schema].[table]`, or `SELECT TOP n`. The
`_extract_tables_from_sql` helper hard-coded `Dialect.ANSI`, which
neither sqlglot nor sqlfluff can parse for these syntaxes — they fail
with `InvalidSyntaxException: Expected ]`. The parser then degraded to
the permissive SqlParse fallback (lower-quality lineage) or returned no
source tables at all, silently dropping lineage edges.

- `_extract_tables_from_sql` is only reachable from `_parse_sql_source`'s
`Sql.Database` / `Value.NativeQuery(Source=Sql.Database(...))` branches,
which are SQL Server / Azure SQL by construction in Power Query M.
T-SQL is the correct dialect and is a strict superset of ANSI for the
SQL shapes these connectors produce.

## Changes
- `ingestion/src/metadata/ingestion/source/dashboard/powerbi/metadata.py`
  - Switch `_extract_tables_from_sql` to `Dialect.TSQL` and update its
    docstring to document the dialect choice and the M connectors it
    serves.
- `ingestion/tests/unit/topology/dashboard/test_powerbi.py`
  - Add `test_extract_tables_from_sql_uses_tsql_dialect` — regression
    guard that patches `LineageParser` and asserts the dialect kwarg is
    `Dialect.TSQL`. Fails clearly if anyone reverts the change.
  - Add `test_extract_tables_from_sql_tsql_bracket_queries` — end-to-end
    smoke test over 5 representative production queries (bracket column
    with space, multi-word bracket column, three-part bracketed table
    reference, bracketed table with space and parens, T-SQL TOP clause).

## Test plan
- [ ] `pytest ingestion/tests/unit/topology/dashboard/test_powerbi.py -k "parse_sql_source or parse_dataflow or extract_tables"` — all 15 tests pass
- [ ] Manually revert `Dialect.TSQL` → `Dialect.ANSI` and confirm
      `test_extract_tables_from_sql_uses_tsql_dialect` fails with the
      expected message
- [ ] Re-run PowerBI ingestion against the affected workspace and
      confirm `InvalidSyntaxException` traces disappear from the log
      and lineage appears for dataflows referencing bracket-quoted T-SQL


#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### High-level design:
<!--
REQUIRED for large PRs (new features, refactors, breaking changes, or anything touching >5 files).
Skip for small bug fixes and trivial changes.

Cover:
- Architecture / approach you took and why
- Key components or files added/changed and how they interact
- Alternatives considered and why you rejected them
- Any migration, backward-compatibility, or rollout concerns
- Diagrams or links to design docs / RFCs if available
-->

N/A — small change. <!-- Or fill in the design above -->

#
### Tests:

#### Use cases covered
<!--
List the user-visible scenarios this PR exercises. Example:
- User with Admin role can create a Glossary Term with a parent term
- Ingestion run for Snowflake correctly extracts row counts for partitioned tables
-->

#### Unit tests
<!--
- [ ] I added unit tests for the new/changed logic.
- Files added/updated:
- Coverage on changed classes (run `mvn jacoco:report` for backend, `yarn test:coverage` for UI,
  `make unit_ingestion` for ingestion). Target is 90% line coverage on changed classes.
- Coverage %: <e.g., 92% on EntityRepository.java>
-->

#### Backend integration tests
<!--
- [ ] I added integration tests in `openmetadata-integration-tests/` for new/changed API endpoints.
- [ ] Not applicable (no backend API changes).
- Files added/updated:
-->

#### Ingestion integration tests
<!--
- [ ] I added/updated ingestion integration tests for connector changes.
- [ ] Not applicable (no ingestion changes).
- Files added/updated:
-->

#### Playwright (UI) tests
<!--
- [ ] I added Playwright E2E tests under `openmetadata-ui/.../ui/playwright/` for UI changes.
- [ ] Not applicable (no UI changes).
- Files added/updated:
-->

#### Manual testing performed
<!--
List the manual test steps you performed before requesting review. Example:
1. Started local stack via `./docker/run_local_docker.sh -m ui -d mysql`
2. Logged in as admin, created entity X, verified Y appears in the UI
3. Triggered ingestion for Snowflake source, confirmed lineage edges in the explore page
-->

#
### UI screen recording / screenshots:
<!--
REQUIRED for any PR that changes the UI. Drag-and-drop a short screen recording (.mov / .mp4 / .gif)
demonstrating the change end-to-end, plus before/after screenshots where relevant.
Mark "Not applicable" if there are no UI changes.
-->

Not applicable. <!-- Or attach recording/screenshots above -->

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.
- [ ] For UI changes: I attached a screen recording and/or screenshots above.
- [ ] I have added tests (unit / integration / Playwright as applicable) and listed them above.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->
