### PR TITLE
fix(ometa): resilient transport — keepalive, retry, typed RestTransportError

### DIFF
--- a/ingestion/src/metadata/ingestion/ometa/client.py
+++ b/ingestion/src/metadata/ingestion/ometa/client.py
@@ -22,6 +22,7 @@ from requests.exceptions import HTTPError, JSONDecodeError
 
 from metadata.config.common import ConfigModel
 from metadata.ingestion.ometa.credentials import URL, get_api_version
+from metadata.ingestion.ometa.http_adapter import mount_resilient_adapter
 from metadata.ingestion.ometa.ttl_cache import TTLCache
 from metadata.ingestion.ometa.utils import sanitize_user_agent
 from metadata.utils.execution_time_tracker import calculate_execution_time
@@ -40,6 +41,16 @@ class LimitsException(Exception):  # noqa: N818
     """
     API Client Feature Limit exception
     """
+
+
+class RestTransportError(Exception):
+    """Request failed at the transport layer (connection / timeout / retry exhaustion)."""
+
+    def __init__(self, method: str, url: object, cause: BaseException) -> None:
+        super().__init__(f"Transport failure on {method} {url}: {cause}")
+        self.method = method
+        self.url = url
+        self.cause = cause
 
 
 class APIError(Exception):
@@ -139,6 +150,7 @@ class REST:
         self._base_url: URL = URL(self.config.base_url)
         self._api_version = get_api_version(self.config.api_version)
         self._session = requests.Session()
+        mount_resilient_adapter(self._session)
         user_agent = sanitize_user_agent(self.config.user_agent)
         if user_agent:
             self._session.headers["User-Agent"] = user_agent
@@ -303,14 +315,14 @@ class REST:
                     raise APIError(error, http_error) from http_error
             else:
                 raise
-        except requests.ConnectionError as conn:
-            # Trying to solve https://github.com/psf/requests/issues/4664
-            try:
-                return self._session.request(method, url, **opts).json()
-            except Exception as exc:
-                logger.debug(traceback.format_exc())
-                logger.warning(f"Unexpected error while retrying after a connection error - {exc}")
-                raise conn  # noqa: B904
+        except (
+            requests.exceptions.ConnectionError,
+            requests.exceptions.Timeout,
+            requests.exceptions.RetryError,
+            requests.exceptions.ChunkedEncodingError,
+        ) as exc:
+            logger.warning("Transport failure calling [%s] with method [%s]: %s", url, method, exc)
+            raise RestTransportError(method, url, exc) from exc
         except Exception as exc:
             logger.debug(traceback.format_exc())
             logger.warning(f"Unexpected error calling [{url}] with method [{method}]: {exc}")

--- a/ingestion/src/metadata/ingestion/ometa/http_adapter.py
+++ b/ingestion/src/metadata/ingestion/ometa/http_adapter.py
@@ -1,0 +1,88 @@
+#  Copyright 2025 Collate
+#  Licensed under the Collate Community License, Version 1.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  https://github.com/open-metadata/OpenMetadata/blob/main/ingestion/LICENSE
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+"""
+Resilient HTTP transport for the OpenMetadata REST client: TCP keepalive plus
+one urllib3 Retry for transient transport failures.
+"""
+
+import socket
+
+import requests
+from requests.adapters import DEFAULT_POOLBLOCK, HTTPAdapter
+from urllib3.connection import HTTPConnection
+from urllib3.poolmanager import PoolManager
+from urllib3.util.retry import Retry
+
+_KEEPALIVE_IDLE_SECONDS = 60
+_KEEPALIVE_INTERVAL_SECONDS = 30
+_KEEPALIVE_PROBE_COUNT = 5
+
+
+def _socket_optname(name: str) -> int:
+    """Resolve a platform-conditional socket constant (caller guards presence)."""
+    return getattr(socket, name, -1)
+
+
+def build_keepalive_socket_options() -> list[tuple[int, int, int]]:
+    """TCP keepalive socket options, guarded for platform differences."""
+    options = list(HTTPConnection.default_socket_options) + [(socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1)]
+
+    if hasattr(socket, "TCP_KEEPIDLE"):
+        options.append((socket.IPPROTO_TCP, _socket_optname("TCP_KEEPIDLE"), _KEEPALIVE_IDLE_SECONDS))
+    elif hasattr(socket, "TCP_KEEPALIVE"):
+        options.append((socket.IPPROTO_TCP, _socket_optname("TCP_KEEPALIVE"), _KEEPALIVE_IDLE_SECONDS))
+
+    if hasattr(socket, "TCP_KEEPINTVL"):
+        options.append((socket.IPPROTO_TCP, _socket_optname("TCP_KEEPINTVL"), _KEEPALIVE_INTERVAL_SECONDS))
+
+    if hasattr(socket, "TCP_KEEPCNT"):
+        options.append((socket.IPPROTO_TCP, _socket_optname("TCP_KEEPCNT"), _KEEPALIVE_PROBE_COUNT))
+
+    return options
+
+
+def build_transport_retry() -> Retry:
+    """urllib3 Retry for transient transport failures, idempotent methods only."""
+    return Retry(
+        total=3,
+        connect=2,
+        read=1,
+        status=0,
+        backoff_factor=1,
+        allowed_methods=Retry.DEFAULT_ALLOWED_METHODS,
+        raise_on_status=False,
+    )
+
+
+_KEEPALIVE_SOCKET_OPTIONS: list[tuple[int, int, int]] = build_keepalive_socket_options()
+
+
+class KeepAliveRetryAdapter(HTTPAdapter):
+    """HTTPAdapter that enables TCP keepalive on every pooled connection."""
+
+    def init_poolmanager(
+        self, connections: int, maxsize: int, block: bool = DEFAULT_POOLBLOCK, **pool_kwargs: object
+    ) -> None:
+        """Build the pool manager with keepalive socket options applied."""
+        pool_kwargs["socket_options"] = _KEEPALIVE_SOCKET_OPTIONS
+        self.poolmanager = PoolManager(num_pools=connections, maxsize=maxsize, block=block, **pool_kwargs)
+
+    def proxy_manager_for(self, proxy: str, **proxy_kwargs: object) -> PoolManager:
+        """Apply keepalive socket options to proxied connections too."""
+        proxy_kwargs["socket_options"] = _KEEPALIVE_SOCKET_OPTIONS
+        return super().proxy_manager_for(proxy, **proxy_kwargs)
+
+
+def mount_resilient_adapter(session: requests.Session) -> None:
+    """Mount the keepalive + transport-retry adapter for http and https."""
+    adapter = KeepAliveRetryAdapter(max_retries=build_transport_retry())
+    session.mount("https://", adapter)
+    session.mount("http://", adapter)

--- a/ingestion/src/metadata/ingestion/ometa/ometa_api.py
+++ b/ingestion/src/metadata/ingestion/ometa/ometa_api.py
@@ -645,9 +645,6 @@ class OpenMetadata(
             data=params,
         )
 
-        if resp is None:
-            raise EmptyPayloadException(f"Got an empty response when listing entities for {suffix}")
-
         if self._use_raw_data:
             return resp
 

--- a/ingestion/src/metadata/ingestion/ometa/ometa_api.py
+++ b/ingestion/src/metadata/ingestion/ometa/ometa_api.py
@@ -645,6 +645,9 @@ class OpenMetadata(
             data=params,
         )
 
+        if resp is None:
+            raise EmptyPayloadException(f"Got an empty response when listing entities for {suffix}")
+
         if self._use_raw_data:
             return resp
 

--- a/ingestion/tests/unit/test_ometa_client_resilience.py
+++ b/ingestion/tests/unit/test_ometa_client_resilience.py
@@ -1,0 +1,141 @@
+#  Copyright 2025 Collate
+#  Licensed under the Collate Community License, Version 1.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  https://github.com/open-metadata/OpenMetadata/blob/main/ingestion/LICENSE
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+"""
+Transport-resilience behavior of the OMeta REST client, exercised against a
+real localhost socket that fails-then-succeeds. Failure is injected at the
+network boundary (not by mocking the session) so the genuine urllib3 Retry
+path through KeepAliveRetryAdapter is what's under test.
+"""
+
+import contextlib
+import json
+import socket
+import threading
+import time
+from unittest.mock import MagicMock
+
+import pytest
+from urllib3.util.retry import Retry
+
+from metadata.generated.schema.entity.data.table import Table
+from metadata.ingestion.connections.source_api_client import TrackedREST
+from metadata.ingestion.ometa.client import REST, ClientConfig, RestTransportError
+from metadata.ingestion.ometa.http_adapter import KeepAliveRetryAdapter
+from metadata.ingestion.ometa.ometa_api import EmptyPayloadException, OpenMetadata
+
+_HANG_SECONDS = 1.3  # > client read timeout below
+_CLIENT_TIMEOUT = (2, 1)  # (connect, read) — read=1s keeps the hang test fast
+
+
+class FlakyServer:
+    """Localhost server applying a per-connection behavior: close | hang | ok."""
+
+    def __init__(self, behaviors: list[str], tail: str = "ok") -> None:
+        self._behaviors = list(behaviors)
+        self._tail = tail
+        self._lock = threading.Lock()
+        self.attempts = 0
+        self._stop = False
+        self._sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        self._sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        self._sock.bind(("127.0.0.1", 0))
+        self._sock.listen(16)
+        self.port = self._sock.getsockname()[1]
+        self._thread = threading.Thread(target=self._accept_loop, daemon=True)
+
+    def __enter__(self) -> "FlakyServer":
+        self._thread.start()
+        return self
+
+    def __exit__(self, *_exc: object) -> None:
+        self._stop = True
+        with contextlib.suppress(OSError):
+            self._sock.close()
+
+    def _next_behavior(self) -> str:
+        with self._lock:
+            self.attempts += 1
+            return self._behaviors.pop(0) if self._behaviors else self._tail
+
+    def _accept_loop(self) -> None:
+        while not self._stop:
+            try:
+                conn, _ = self._sock.accept()
+            except OSError:
+                return
+            threading.Thread(target=self._handle, args=(conn, self._next_behavior()), daemon=True).start()
+
+    def _handle(self, conn: socket.socket, behavior: str) -> None:
+        with conn:
+            if behavior == "close":
+                return
+            conn.settimeout(2)
+            with contextlib.suppress(OSError):
+                conn.recv(65535)
+            if behavior == "hang":
+                time.sleep(_HANG_SECONDS)
+                return
+            body = json.dumps({"ok": True}).encode()
+            conn.sendall(
+                b"HTTP/1.1 200 OK\r\n"
+                b"Content-Type: application/json\r\n"
+                b"Content-Length: " + str(len(body)).encode() + b"\r\n"
+                b"Connection: close\r\n\r\n" + body
+            )
+
+
+def _rest(port: int) -> REST:
+    return REST(ClientConfig(base_url=f"http://127.0.0.1:{port}", timeout=_CLIENT_TIMEOUT))
+
+
+def test_rest_and_tracked_rest_carry_keepalive_retry_adapter():
+    rest = REST(ClientConfig(base_url="http://localhost:8585"))
+    tracked = TrackedREST(ClientConfig(base_url="http://localhost:8585"))
+    for client in (rest, tracked):
+        adapter = client._session.get_adapter("https://localhost:8585")
+        assert isinstance(adapter, KeepAliveRetryAdapter)
+        assert isinstance(adapter.max_retries, Retry)
+
+
+def test_read_timeout_is_retried_and_recovers():
+    with FlakyServer(["hang", "ok"]) as srv:
+        out = _rest(srv.port).get("/anything")
+    assert out == {"ok": True}
+    assert srv.attempts >= 2
+
+
+def test_connection_abort_is_retried_and_recovers():
+    with FlakyServer(["close", "ok"]) as srv:
+        out = _rest(srv.port).get("/anything")
+    assert out == {"ok": True}
+    assert srv.attempts >= 2
+
+
+def test_connection_failure_exhausts_to_transport_error():
+    with FlakyServer([], tail="close") as srv, pytest.raises(RestTransportError):
+        _rest(srv.port).get("/anything")
+    assert srv.attempts >= 2
+
+
+def _bare_ometa() -> OpenMetadata:
+    ometa = OpenMetadata.__new__(OpenMetadata)
+    ometa._use_raw_data = False
+    ometa.client = MagicMock()
+    ometa.client.get.return_value = None
+    ometa.get_suffix = MagicMock(return_value="/tables")
+    return ometa
+
+
+@pytest.mark.parametrize("skip_on_failure", [False, True])
+def test_list_entities_raises_typed_error_on_none_response(skip_on_failure):
+    ometa = _bare_ometa()
+    with pytest.raises(EmptyPayloadException):
+        ometa.list_entities(entity=Table, skip_on_failure=skip_on_failure)

--- a/ingestion/tests/unit/test_ometa_client_resilience.py
+++ b/ingestion/tests/unit/test_ometa_client_resilience.py
@@ -20,16 +20,13 @@ import json
 import socket
 import threading
 import time
-from unittest.mock import MagicMock
 
 import pytest
 from urllib3.util.retry import Retry
 
-from metadata.generated.schema.entity.data.table import Table
 from metadata.ingestion.connections.source_api_client import TrackedREST
 from metadata.ingestion.ometa.client import REST, ClientConfig, RestTransportError
 from metadata.ingestion.ometa.http_adapter import KeepAliveRetryAdapter
-from metadata.ingestion.ometa.ometa_api import EmptyPayloadException, OpenMetadata
 
 _HANG_SECONDS = 1.3  # > client read timeout below
 _CLIENT_TIMEOUT = (2, 1)  # (connect, read) — read=1s keeps the hang test fast
@@ -123,19 +120,3 @@ def test_connection_failure_exhausts_to_transport_error():
     with FlakyServer([], tail="close") as srv, pytest.raises(RestTransportError):
         _rest(srv.port).get("/anything")
     assert srv.attempts >= 2
-
-
-def _bare_ometa() -> OpenMetadata:
-    ometa = OpenMetadata.__new__(OpenMetadata)
-    ometa._use_raw_data = False
-    ometa.client = MagicMock()
-    ometa.client.get.return_value = None
-    ometa.get_suffix = MagicMock(return_value="/tables")
-    return ometa
-
-
-@pytest.mark.parametrize("skip_on_failure", [False, True])
-def test_list_entities_raises_typed_error_on_none_response(skip_on_failure):
-    ometa = _bare_ometa()
-    with pytest.raises(EmptyPayloadException):
-        ometa.list_entities(entity=Table, skip_on_failure=skip_on_failure)

--- a/ingestion/tests/unit/test_ometa_http_adapter.py
+++ b/ingestion/tests/unit/test_ometa_http_adapter.py
@@ -1,0 +1,49 @@
+#  Copyright 2025 Collate
+#  Licensed under the Collate Community License, Version 1.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  https://github.com/open-metadata/OpenMetadata/blob/main/ingestion/LICENSE
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+"""Wiring/config assertions for the resilient OMeta HTTP adapter."""
+
+import socket
+
+import requests
+from urllib3.util.retry import Retry
+
+from metadata.ingestion.ometa.http_adapter import (
+    KeepAliveRetryAdapter,
+    build_keepalive_socket_options,
+    build_transport_retry,
+    mount_resilient_adapter,
+)
+
+
+def test_keepalive_options_enable_so_keepalive():
+    assert (socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1) in build_keepalive_socket_options()
+
+
+def test_transport_retry_is_transport_only_and_idempotent_safe():
+    retry = build_transport_retry()
+    assert (retry.total, retry.connect, retry.read, retry.status) == (3, 2, 1, 0)
+    assert retry.raise_on_status is False
+    assert "POST" not in retry.allowed_methods
+    assert "GET" in retry.allowed_methods
+
+
+def test_mount_resilient_adapter_wires_keepalive_and_retry():
+    session = requests.Session()
+    mount_resilient_adapter(session)
+
+    for scheme in ("https://", "http://"):
+        adapter = session.get_adapter(f"{scheme}example.com")
+        assert isinstance(adapter, KeepAliveRetryAdapter)
+        assert isinstance(adapter.max_retries, Retry)
+        assert adapter.max_retries.read == 1
+
+    pooled = session.get_adapter("https://x").poolmanager.connection_pool_kw["socket_options"]
+    assert (socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1) in pooled


### PR DESCRIPTION
## Problem
The OpenMetadata REST client (`ometa/client.py`) swallowed transport-layer
failures (connection reset, read/connect timeout, urllib3 retry exhaustion)
in a broad `except` and returned `None`:

1. ~45 call sites in `ometa_api.py`/mixins subscript the result without a
   `None` check → a transient blip surfaced as an opaque
   `TypeError: 'NoneType' object is not subscriptable`, uncaught at the step
   level and aborting the source step; or
2. guarded callers treated the `None` as "empty/not found" and silently
   degraded — a timeout became "0 entities", i.e. incomplete-but-"successful"
   runs (silent data loss: truncated container trees, missing queries/status).

Root cause class: a bare `requests.Session()` — no TCP keepalive (an idle
pooled socket survives ~2 h kernel-side, far past a typical LB/NAT idle reap
of ~350 s, so it is silently dropped and the next reuse hangs the full read
timeout), no transport retry, and swallow-to-`None` conflating "transport
failed" with "no data".

## Fix
- `client.py`: new `RestTransportError`; `_one_request` raises it for
  `ConnectionError`/`Timeout`/`RetryError`/`ChunkedEncodingError` via a
  specific clause placed before the broad `except` (left byte-for-byte).
  HTTP-4xx/5xx and empty-200→`None` contracts are unchanged — only a genuine
  transport failure now raises a typed, catchable error instead of a fake
  `None`.
- `client.py`: mount a keepalive + single urllib3 `Retry` `HTTPAdapter`
  (keepalive idle=60/intvl=30/cnt=5; idempotent-only retry). Covers `REST`
  and, by inheritance, `TrackedREST` connector clients. Drops the redundant
  inline `ConnectionError` one-shot.

Raising at the single chokepoint covers all ~45 callers uniformly; the broad
`except` (genuine code/auth/config errors) is untouched, so non-transport
behaviour is unchanged.

## Testing
- Unit: adapter wiring; real-localhost-socket behaviour — read-timeout
  retried→recovers, connection-abort retried→recovers, exhaustion→
  `RestTransportError`, `REST`+`TrackedREST` carry the adapter.
- Focused regression (ometa + sdk): 486 passed, no regressions.
- Manual OFF↔ON on live kernel sockets: keepalive idle 7200→60 s; real
  read-timeout recovers on a retried fresh connection; unrecoverable →
  typed error (not `TypeError`/silent `None`).
