### PR TITLE
feat(mysql): support custom queryHistoryTable for usage & lineage

### DIFF
--- a/ingestion/src/metadata/ingestion/source/database/mysql/connection.py
+++ b/ingestion/src/metadata/ingestion/source/database/mysql/connection.py
@@ -137,10 +137,15 @@ class MySQLConnection(BaseConnection[MySQLConnectionConfig, Engine]):
         Test connection. This can be executed either as part
         of a metadata workflow or during an Automation Workflow
         """
+        if self.service_connection.useSlowLogs:
+            test_query_template = MYSQL_TEST_GET_QUERIES_SLOW_LOGS
+            default_query_history_table = "mysql.slow_log"
+        else:
+            test_query_template = MYSQL_TEST_GET_QUERIES
+            default_query_history_table = "mysql.general_log"
+        query_history_table = self.service_connection.queryHistoryTable or default_query_history_table
         queries = {
-            "GetQueries": MYSQL_TEST_GET_QUERIES
-            if not self.service_connection.useSlowLogs
-            else MYSQL_TEST_GET_QUERIES_SLOW_LOGS,
+            "GetQueries": test_query_template.format(query_history_table=query_history_table),
         }
         return test_connection_db_schema_sources(
             metadata=metadata,

--- a/ingestion/src/metadata/ingestion/source/database/mysql/queries.py
+++ b/ingestion/src/metadata/ingestion/source/database/mysql/queries.py
@@ -26,8 +26,8 @@ SELECT
     NULL `query_type`,
     NULL `user_name`,
     NULL `aborted`
-FROM mysql.general_log
-WHERE command_type = 'Query' 
+FROM {query_history_table}
+WHERE command_type = 'Query'
     AND event_time between '{start_time}' and '{end_time}'
     AND argument NOT LIKE '/* {{"app": "OpenMetadata", %%}} */%%'
     AND argument NOT LIKE '/* {{"app": "dbt", %%}} */%%'
@@ -50,7 +50,7 @@ SELECT
     NULL `query_type`,
     NULL `user_name`,
     NULL `aborted`
-FROM mysql.slow_log
+FROM {query_history_table}
 WHERE start_time between '{start_time}' and '{end_time}'
     AND sql_text NOT LIKE '/* {{"app": "OpenMetadata", %%}} */%%'
     AND sql_text NOT LIKE '/* {{"app": "dbt", %%}} */%%'
@@ -62,13 +62,13 @@ LIMIT {result_limit};
 
 MYSQL_TEST_GET_QUERIES = textwrap.dedent(
     """
-SELECT `argument` from mysql.general_log limit 1;
+SELECT `argument` from {query_history_table} limit 1;
 """
 )
 
 MYSQL_TEST_GET_QUERIES_SLOW_LOGS = textwrap.dedent(
     """
-SELECT `sql_text` from mysql.slow_log limit 1;
+SELECT `sql_text` from {query_history_table} limit 1;
 """
 )
 

--- a/ingestion/src/metadata/ingestion/source/database/mysql/query_parser.py
+++ b/ingestion/src/metadata/ingestion/source/database/mysql/query_parser.py
@@ -55,13 +55,17 @@ class MysqlQueryParserSource(QueryParserSource, ABC):
         """
         if self.service_connection.useSlowLogs:
             self.sql_stmt = MYSQL_SQL_STATEMENT_SLOW_LOGS
+            default_query_history_table = "mysql.slow_log"
         else:
             self.sql_stmt = MYSQL_SQL_STATEMENT
+            default_query_history_table = "mysql.general_log"
+        query_history_table = self.service_connection.queryHistoryTable or default_query_history_table
         return self.sql_stmt.format(
             start_time=start_time,
             end_time=end_time,
             filters=self.get_filters(),
             result_limit=self.source_config.resultLimit,  # pyright: ignore[reportAttributeAccessIssue]
+            query_history_table=query_history_table,
         )
 
     def get_filters(self) -> str:

--- a/ingestion/src/metadata/sdk/examples/builder_end_to_end.py
+++ b/ingestion/src/metadata/sdk/examples/builder_end_to_end.py
@@ -106,6 +106,7 @@ class DatabaseServiceBuilderPy:
                 supportsUsageExtraction=None,
                 supportsLineageExtraction=None,
                 useSlowLogs=False,
+                queryHistoryTable=None,
             )
         )
         self.connection_val = conn

--- a/ingestion/tests/unit/topology/database/test_mysql_query_parser.py
+++ b/ingestion/tests/unit/topology/database/test_mysql_query_parser.py
@@ -1,0 +1,150 @@
+#  Copyright 2025 Collate
+#  Licensed under the Collate Community License, Version 1.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  https://github.com/open-metadata/OpenMetadata/blob/main/ingestion/LICENSE
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+"""
+Tests for MysqlQueryParserSource.get_sql_statement override behavior driven
+by the optional `queryHistoryTable` connection field.
+"""
+
+from datetime import datetime
+from types import SimpleNamespace
+
+import pytest
+
+from metadata.ingestion.source.database.mysql.queries import (
+    MYSQL_TEST_GET_QUERIES,
+    MYSQL_TEST_GET_QUERIES_SLOW_LOGS,
+)
+from metadata.ingestion.source.database.mysql.query_parser import (
+    MysqlQueryParserSource,
+)
+
+START_TIME = datetime(2026, 1, 1, 0, 0, 0)
+END_TIME = datetime(2026, 1, 2, 0, 0, 0)
+
+
+def _make_stub(
+    *,
+    use_slow_logs: bool,
+    query_history_table: str | None,
+    filters: str = "",
+    filter_condition: str | None = None,
+    result_limit: int = 100,
+) -> SimpleNamespace:
+    """Build a minimal self-like stub for MysqlQueryParserSource methods."""
+    stub = SimpleNamespace(
+        service_connection=SimpleNamespace(
+            useSlowLogs=use_slow_logs,
+            queryHistoryTable=query_history_table,
+        ),
+        source_config=SimpleNamespace(
+            resultLimit=result_limit,
+            filterCondition=filter_condition,
+        ),
+        filters=filters,
+    )
+    stub.get_filters = lambda: MysqlQueryParserSource.get_filters(stub)
+    return stub
+
+
+class TestGetSqlStatementDefaults:
+    def test_general_log_default_table(self):
+        stub = _make_stub(use_slow_logs=False, query_history_table=None)
+        sql = MysqlQueryParserSource.get_sql_statement(stub, START_TIME, END_TIME)
+
+        assert "FROM mysql.general_log" in sql
+        assert "mysql.slow_log" not in sql
+
+    def test_slow_log_default_table(self):
+        stub = _make_stub(use_slow_logs=True, query_history_table=None)
+        sql = MysqlQueryParserSource.get_sql_statement(stub, START_TIME, END_TIME)
+
+        assert "FROM mysql.slow_log" in sql
+        assert "mysql.general_log" not in sql
+
+    def test_empty_string_falls_back_to_default(self):
+        stub = _make_stub(use_slow_logs=True, query_history_table="")
+        sql = MysqlQueryParserSource.get_sql_statement(stub, START_TIME, END_TIME)
+
+        assert "FROM mysql.slow_log" in sql
+
+
+class TestGetSqlStatementCustomTable:
+    def test_custom_table_overrides_general_log(self):
+        stub = _make_stub(
+            use_slow_logs=False,
+            query_history_table="audit_db.query_log_view",
+        )
+        sql = MysqlQueryParserSource.get_sql_statement(stub, START_TIME, END_TIME)
+
+        assert "FROM audit_db.query_log_view" in sql
+        assert "mysql.general_log" not in sql
+        assert "mysql.slow_log" not in sql
+
+    def test_custom_table_overrides_slow_log(self):
+        stub = _make_stub(
+            use_slow_logs=True,
+            query_history_table="audit_db.slow_log_view",
+        )
+        sql = MysqlQueryParserSource.get_sql_statement(stub, START_TIME, END_TIME)
+
+        assert "FROM audit_db.slow_log_view" in sql
+        assert "mysql.slow_log" not in sql
+        assert "mysql.general_log" not in sql
+
+    def test_general_log_uses_argument_column(self):
+        stub = _make_stub(
+            use_slow_logs=False,
+            query_history_table="audit_db.query_log_view",
+        )
+        sql = MysqlQueryParserSource.get_sql_statement(stub, START_TIME, END_TIME)
+
+        assert "argument `query_text`" in sql
+
+    def test_slow_log_uses_sql_text_column(self):
+        stub = _make_stub(
+            use_slow_logs=True,
+            query_history_table="audit_db.slow_log_view",
+        )
+        sql = MysqlQueryParserSource.get_sql_statement(stub, START_TIME, END_TIME)
+
+        assert "sql_text `query_text`" in sql
+
+
+@pytest.mark.parametrize(
+    "use_slow_logs,expected_default",
+    [
+        (False, "mysql.general_log"),
+        (True, "mysql.slow_log"),
+    ],
+)
+def test_time_window_interpolated(use_slow_logs: bool, expected_default: str):
+    stub = _make_stub(use_slow_logs=use_slow_logs, query_history_table=None)
+    sql = MysqlQueryParserSource.get_sql_statement(stub, START_TIME, END_TIME)
+
+    assert "2026-01-01 00:00:00" in sql
+    assert "2026-01-02 00:00:00" in sql
+    assert f"FROM {expected_default}" in sql
+
+
+class TestTestConnectionProbeTemplates:
+    """Probe queries used by MySQLConnection.test_connection must accept the
+    same query_history_table substitution."""
+
+    def test_general_log_probe_accepts_custom_table(self):
+        rendered = MYSQL_TEST_GET_QUERIES.format(query_history_table="custom.tbl")
+        assert "from custom.tbl" in rendered
+        assert "`argument`" in rendered
+
+    def test_slow_log_probe_accepts_custom_table(self):
+        rendered = MYSQL_TEST_GET_QUERIES_SLOW_LOGS.format(query_history_table="custom.tbl")
+        assert "from custom.tbl" in rendered
+        assert "`sql_text`" in rendered

--- a/openmetadata-spec/src/main/resources/json/schema/entity/services/connections/database/mysqlConnection.json
+++ b/openmetadata-spec/src/main/resources/json/schema/entity/services/connections/database/mysqlConnection.json
@@ -146,6 +146,11 @@
       "description": "Use slow logs to extract lineage.",
       "type": "boolean",
       "default": false
+    },
+    "queryHistoryTable": {
+      "title": "Query History Table",
+      "description": "Table name to fetch the query history. When set, this overrides the default 'mysql.general_log' (or 'mysql.slow_log' when 'useSlowLogs' is enabled). The custom table must expose columns compatible with the selected log path.",
+      "type": "string"
     }
   },
   "additionalProperties": false,

--- a/openmetadata-ui/src/main/resources/ui/src/generated/api/automations/createWorkflow.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/api/automations/createWorkflow.ts
@@ -1178,6 +1178,10 @@ export interface ConfigObject {
     httpPath?: string;
     /**
      * Table name to fetch the query history.
+     *
+     * Table name to fetch the query history. When set, this overrides the default
+     * 'mysql.general_log' (or 'mysql.slow_log' when 'useSlowLogs' is enabled). The custom table
+     * must expose columns compatible with the selected log path.
      */
     queryHistoryTable?: string;
     /**
@@ -3773,6 +3777,12 @@ export interface ConfigConnection {
      */
     databaseName?: string;
     /**
+     * Table name to fetch the query history. When set, this overrides the default
+     * 'mysql.general_log' (or 'mysql.slow_log' when 'useSlowLogs' is enabled). The custom table
+     * must expose columns compatible with the selected log path.
+     */
+    queryHistoryTable?: string;
+    /**
      * Use slow logs to extract lineage.
      */
     useSlowLogs?: boolean;
@@ -4472,6 +4482,12 @@ export interface HiveMetastoreConnectionDetails {
      * attempts to scan all the schemas.
      */
     databaseSchema?: string;
+    /**
+     * Table name to fetch the query history. When set, this overrides the default
+     * 'mysql.general_log' (or 'mysql.slow_log' when 'useSlowLogs' is enabled). The custom table
+     * must expose columns compatible with the selected log path.
+     */
+    queryHistoryTable?: string;
     /**
      * Use slow logs to extract lineage.
      */

--- a/openmetadata-ui/src/main/resources/ui/src/generated/api/services/createDashboardService.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/api/services/createDashboardService.ts
@@ -776,6 +776,12 @@ export interface SupersetConnection {
      */
     databaseSchema?: string;
     /**
+     * Table name to fetch the query history. When set, this overrides the default
+     * 'mysql.general_log' (or 'mysql.slow_log' when 'useSlowLogs' is enabled). The custom table
+     * must expose columns compatible with the selected log path.
+     */
+    queryHistoryTable?: string;
+    /**
      * Use slow logs to extract lineage.
      */
     useSlowLogs?: boolean;

--- a/openmetadata-ui/src/main/resources/ui/src/generated/api/services/createDatabaseService.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/api/services/createDatabaseService.ts
@@ -691,6 +691,10 @@ export interface Connection {
     httpPath?: string;
     /**
      * Table name to fetch the query history.
+     *
+     * Table name to fetch the query history. When set, this overrides the default
+     * 'mysql.general_log' (or 'mysql.slow_log' when 'useSlowLogs' is enabled). The custom table
+     * must expose columns compatible with the selected log path.
      */
     queryHistoryTable?: string;
     /**
@@ -1988,6 +1992,12 @@ export interface HiveMetastoreConnectionDetails {
      * attempts to scan all the schemas.
      */
     databaseSchema?: string;
+    /**
+     * Table name to fetch the query history. When set, this overrides the default
+     * 'mysql.general_log' (or 'mysql.slow_log' when 'useSlowLogs' is enabled). The custom table
+     * must expose columns compatible with the selected log path.
+     */
+    queryHistoryTable?: string;
     /**
      * Use slow logs to extract lineage.
      */

--- a/openmetadata-ui/src/main/resources/ui/src/generated/api/services/createMetadataService.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/api/services/createMetadataService.ts
@@ -479,6 +479,12 @@ export interface AlationDatabaseConnection {
      */
     databaseSchema?: string;
     /**
+     * Table name to fetch the query history. When set, this overrides the default
+     * 'mysql.general_log' (or 'mysql.slow_log' when 'useSlowLogs' is enabled). The custom table
+     * must expose columns compatible with the selected log path.
+     */
+    queryHistoryTable?: string;
+    /**
      * Use slow logs to extract lineage.
      */
     useSlowLogs?: boolean;

--- a/openmetadata-ui/src/main/resources/ui/src/generated/api/services/createPipelineService.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/api/services/createPipelineService.ts
@@ -773,7 +773,13 @@ export interface ConnectionClass {
      *
      * Matillion Host
      */
-    hostPort?:                string;
+    hostPort?: string;
+    /**
+     * Table name to fetch the query history. When set, this overrides the default
+     * 'mysql.general_log' (or 'mysql.slow_log' when 'useSlowLogs' is enabled). The custom table
+     * must expose columns compatible with the selected log path.
+     */
+    queryHistoryTable?:       string;
     sampleDataStorageConfig?: SampleDataStorageConfig;
     /**
      * Regex to only include/exclude schemas that matches the pattern.

--- a/openmetadata-ui/src/main/resources/ui/src/generated/api/services/ingestionPipelines/createIngestionPipeline.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/api/services/ingestionPipelines/createIngestionPipeline.ts
@@ -4435,6 +4435,10 @@ export interface ConfigObject {
     httpPath?: string;
     /**
      * Table name to fetch the query history.
+     *
+     * Table name to fetch the query history. When set, this overrides the default
+     * 'mysql.general_log' (or 'mysql.slow_log' when 'useSlowLogs' is enabled). The custom table
+     * must expose columns compatible with the selected log path.
      */
     queryHistoryTable?: string;
     /**
@@ -6409,6 +6413,12 @@ export interface ConfigConnection {
      */
     databaseSchema?: string;
     /**
+     * Table name to fetch the query history. When set, this overrides the default
+     * 'mysql.general_log' (or 'mysql.slow_log' when 'useSlowLogs' is enabled). The custom table
+     * must expose columns compatible with the selected log path.
+     */
+    queryHistoryTable?: string;
+    /**
      * Use slow logs to extract lineage.
      */
     useSlowLogs?: boolean;
@@ -7130,6 +7140,12 @@ export interface HiveMetastoreConnectionDetails {
      * attempts to scan all the schemas.
      */
     databaseSchema?: string;
+    /**
+     * Table name to fetch the query history. When set, this overrides the default
+     * 'mysql.general_log' (or 'mysql.slow_log' when 'useSlowLogs' is enabled). The custom table
+     * must expose columns compatible with the selected log path.
+     */
+    queryHistoryTable?: string;
     /**
      * Use slow logs to extract lineage.
      */

--- a/openmetadata-ui/src/main/resources/ui/src/generated/entity/automations/testServiceConnection.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/entity/automations/testServiceConnection.ts
@@ -1060,6 +1060,10 @@ export interface ConfigObject {
     httpPath?: string;
     /**
      * Table name to fetch the query history.
+     *
+     * Table name to fetch the query history. When set, this overrides the default
+     * 'mysql.general_log' (or 'mysql.slow_log' when 'useSlowLogs' is enabled). The custom table
+     * must expose columns compatible with the selected log path.
      */
     queryHistoryTable?: string;
     /**
@@ -3655,6 +3659,12 @@ export interface ConfigConnection {
      */
     databaseName?: string;
     /**
+     * Table name to fetch the query history. When set, this overrides the default
+     * 'mysql.general_log' (or 'mysql.slow_log' when 'useSlowLogs' is enabled). The custom table
+     * must expose columns compatible with the selected log path.
+     */
+    queryHistoryTable?: string;
+    /**
      * Use slow logs to extract lineage.
      */
     useSlowLogs?: boolean;
@@ -4354,6 +4364,12 @@ export interface HiveMetastoreConnectionDetails {
      * attempts to scan all the schemas.
      */
     databaseSchema?: string;
+    /**
+     * Table name to fetch the query history. When set, this overrides the default
+     * 'mysql.general_log' (or 'mysql.slow_log' when 'useSlowLogs' is enabled). The custom table
+     * must expose columns compatible with the selected log path.
+     */
+    queryHistoryTable?: string;
     /**
      * Use slow logs to extract lineage.
      */

--- a/openmetadata-ui/src/main/resources/ui/src/generated/entity/automations/workflow.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/entity/automations/workflow.ts
@@ -1731,6 +1731,10 @@ export interface ConfigObject {
     httpPath?: string;
     /**
      * Table name to fetch the query history.
+     *
+     * Table name to fetch the query history. When set, this overrides the default
+     * 'mysql.general_log' (or 'mysql.slow_log' when 'useSlowLogs' is enabled). The custom table
+     * must expose columns compatible with the selected log path.
      */
     queryHistoryTable?: string;
     /**
@@ -4179,6 +4183,12 @@ export interface ConfigConnection {
      */
     databaseName?: string;
     /**
+     * Table name to fetch the query history. When set, this overrides the default
+     * 'mysql.general_log' (or 'mysql.slow_log' when 'useSlowLogs' is enabled). The custom table
+     * must expose columns compatible with the selected log path.
+     */
+    queryHistoryTable?: string;
+    /**
      * Use slow logs to extract lineage.
      */
     useSlowLogs?: boolean;
@@ -4862,6 +4872,12 @@ export interface HiveMetastoreConnectionDetails {
      * attempts to scan all the schemas.
      */
     databaseSchema?: string;
+    /**
+     * Table name to fetch the query history. When set, this overrides the default
+     * 'mysql.general_log' (or 'mysql.slow_log' when 'useSlowLogs' is enabled). The custom table
+     * must expose columns compatible with the selected log path.
+     */
+    queryHistoryTable?: string;
     /**
      * Use slow logs to extract lineage.
      */

--- a/openmetadata-ui/src/main/resources/ui/src/generated/entity/services/connections/dashboard/supersetConnection.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/entity/services/connections/dashboard/supersetConnection.ts
@@ -191,6 +191,12 @@ export interface SupersetConnectionClass {
      */
     databaseSchema?: string;
     /**
+     * Table name to fetch the query history. When set, this overrides the default
+     * 'mysql.general_log' (or 'mysql.slow_log' when 'useSlowLogs' is enabled). The custom table
+     * must expose columns compatible with the selected log path.
+     */
+    queryHistoryTable?: string;
+    /**
      * Use slow logs to extract lineage.
      */
     useSlowLogs?: boolean;

--- a/openmetadata-ui/src/main/resources/ui/src/generated/entity/services/connections/database/hiveConnection.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/entity/services/connections/database/hiveConnection.ts
@@ -230,6 +230,12 @@ export interface HiveMetastoreConnectionDetails {
      */
     databaseSchema?: string;
     /**
+     * Table name to fetch the query history. When set, this overrides the default
+     * 'mysql.general_log' (or 'mysql.slow_log' when 'useSlowLogs' is enabled). The custom table
+     * must expose columns compatible with the selected log path.
+     */
+    queryHistoryTable?: string;
+    /**
      * Use slow logs to extract lineage.
      */
     useSlowLogs?: boolean;

--- a/openmetadata-ui/src/main/resources/ui/src/generated/entity/services/connections/database/mysqlConnection.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/entity/services/connections/database/mysqlConnection.ts
@@ -39,7 +39,13 @@ export interface MysqlConnection {
      * Host and port of the MySQL service. For GCP CloudSQL, use the instance connection name in
      * the format 'project_id:region:instance_name'.
      */
-    hostPort:                 string;
+    hostPort: string;
+    /**
+     * Table name to fetch the query history. When set, this overrides the default
+     * 'mysql.general_log' (or 'mysql.slow_log' when 'useSlowLogs' is enabled). The custom table
+     * must expose columns compatible with the selected log path.
+     */
+    queryHistoryTable?:       string;
     sampleDataStorageConfig?: SampleDataStorageConfig;
     /**
      * Regex to only include/exclude schemas that matches the pattern.

--- a/openmetadata-ui/src/main/resources/ui/src/generated/entity/services/connections/metadata/alationConnection.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/entity/services/connections/metadata/alationConnection.ts
@@ -210,6 +210,12 @@ export interface AlationDatabaseConnection {
      */
     databaseSchema?: string;
     /**
+     * Table name to fetch the query history. When set, this overrides the default
+     * 'mysql.general_log' (or 'mysql.slow_log' when 'useSlowLogs' is enabled). The custom table
+     * must expose columns compatible with the selected log path.
+     */
+    queryHistoryTable?: string;
+    /**
      * Use slow logs to extract lineage.
      */
     useSlowLogs?: boolean;

--- a/openmetadata-ui/src/main/resources/ui/src/generated/entity/services/connections/pipeline/airflowConnection.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/entity/services/connections/pipeline/airflowConnection.ts
@@ -102,7 +102,13 @@ export interface AirflowConnectionClass {
      *
      * Host and port of the SQLite service. Blank for in-memory database.
      */
-    hostPort?:                string;
+    hostPort?: string;
+    /**
+     * Table name to fetch the query history. When set, this overrides the default
+     * 'mysql.general_log' (or 'mysql.slow_log' when 'useSlowLogs' is enabled). The custom table
+     * must expose columns compatible with the selected log path.
+     */
+    queryHistoryTable?:       string;
     sampleDataStorageConfig?: SampleDataStorageConfig;
     /**
      * Regex to only include/exclude schemas that matches the pattern.

--- a/openmetadata-ui/src/main/resources/ui/src/generated/entity/services/connections/serviceConnection.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/entity/services/connections/serviceConnection.ts
@@ -1345,6 +1345,10 @@ export interface ConfigObject {
     httpPath?: string;
     /**
      * Table name to fetch the query history.
+     *
+     * Table name to fetch the query history. When set, this overrides the default
+     * 'mysql.general_log' (or 'mysql.slow_log' when 'useSlowLogs' is enabled). The custom table
+     * must expose columns compatible with the selected log path.
      */
     queryHistoryTable?: string;
     /**
@@ -3660,6 +3664,12 @@ export interface ConfigConnection {
      */
     databaseSchema?: string;
     /**
+     * Table name to fetch the query history. When set, this overrides the default
+     * 'mysql.general_log' (or 'mysql.slow_log' when 'useSlowLogs' is enabled). The custom table
+     * must expose columns compatible with the selected log path.
+     */
+    queryHistoryTable?: string;
+    /**
      * Use slow logs to extract lineage.
      */
     useSlowLogs?: boolean;
@@ -4394,6 +4404,12 @@ export interface HiveMetastoreConnectionDetails {
      * attempts to scan all the schemas.
      */
     databaseSchema?: string;
+    /**
+     * Table name to fetch the query history. When set, this overrides the default
+     * 'mysql.general_log' (or 'mysql.slow_log' when 'useSlowLogs' is enabled). The custom table
+     * must expose columns compatible with the selected log path.
+     */
+    queryHistoryTable?: string;
     /**
      * Use slow logs to extract lineage.
      */

--- a/openmetadata-ui/src/main/resources/ui/src/generated/entity/services/dashboardService.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/entity/services/dashboardService.ts
@@ -905,6 +905,12 @@ export interface SupersetConnection {
      */
     databaseSchema?: string;
     /**
+     * Table name to fetch the query history. When set, this overrides the default
+     * 'mysql.general_log' (or 'mysql.slow_log' when 'useSlowLogs' is enabled). The custom table
+     * must expose columns compatible with the selected log path.
+     */
+    queryHistoryTable?: string;
+    /**
      * Use slow logs to extract lineage.
      */
     useSlowLogs?: boolean;

--- a/openmetadata-ui/src/main/resources/ui/src/generated/entity/services/databaseService.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/entity/services/databaseService.ts
@@ -822,6 +822,10 @@ export interface Connection {
     httpPath?: string;
     /**
      * Table name to fetch the query history.
+     *
+     * Table name to fetch the query history. When set, this overrides the default
+     * 'mysql.general_log' (or 'mysql.slow_log' when 'useSlowLogs' is enabled). The custom table
+     * must expose columns compatible with the selected log path.
      */
     queryHistoryTable?: string;
     /**
@@ -2119,6 +2123,12 @@ export interface HiveMetastoreConnectionDetails {
      * attempts to scan all the schemas.
      */
     databaseSchema?: string;
+    /**
+     * Table name to fetch the query history. When set, this overrides the default
+     * 'mysql.general_log' (or 'mysql.slow_log' when 'useSlowLogs' is enabled). The custom table
+     * must expose columns compatible with the selected log path.
+     */
+    queryHistoryTable?: string;
     /**
      * Use slow logs to extract lineage.
      */

--- a/openmetadata-ui/src/main/resources/ui/src/generated/entity/services/ingestionPipelines/ingestionPipeline.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/entity/services/ingestionPipelines/ingestionPipeline.ts
@@ -4967,6 +4967,10 @@ export interface ConfigObject {
     httpPath?: string;
     /**
      * Table name to fetch the query history.
+     *
+     * Table name to fetch the query history. When set, this overrides the default
+     * 'mysql.general_log' (or 'mysql.slow_log' when 'useSlowLogs' is enabled). The custom table
+     * must expose columns compatible with the selected log path.
      */
     queryHistoryTable?: string;
     /**
@@ -6922,6 +6926,12 @@ export interface ConfigConnection {
      */
     databaseSchema?: string;
     /**
+     * Table name to fetch the query history. When set, this overrides the default
+     * 'mysql.general_log' (or 'mysql.slow_log' when 'useSlowLogs' is enabled). The custom table
+     * must expose columns compatible with the selected log path.
+     */
+    queryHistoryTable?: string;
+    /**
      * Use slow logs to extract lineage.
      */
     useSlowLogs?: boolean;
@@ -7643,6 +7653,12 @@ export interface HiveMetastoreConnectionDetails {
      * attempts to scan all the schemas.
      */
     databaseSchema?: string;
+    /**
+     * Table name to fetch the query history. When set, this overrides the default
+     * 'mysql.general_log' (or 'mysql.slow_log' when 'useSlowLogs' is enabled). The custom table
+     * must expose columns compatible with the selected log path.
+     */
+    queryHistoryTable?: string;
     /**
      * Use slow logs to extract lineage.
      */

--- a/openmetadata-ui/src/main/resources/ui/src/generated/entity/services/metadataService.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/entity/services/metadataService.ts
@@ -607,6 +607,12 @@ export interface AlationDatabaseConnection {
      */
     databaseSchema?: string;
     /**
+     * Table name to fetch the query history. When set, this overrides the default
+     * 'mysql.general_log' (or 'mysql.slow_log' when 'useSlowLogs' is enabled). The custom table
+     * must expose columns compatible with the selected log path.
+     */
+    queryHistoryTable?: string;
+    /**
      * Use slow logs to extract lineage.
      */
     useSlowLogs?: boolean;

--- a/openmetadata-ui/src/main/resources/ui/src/generated/entity/services/pipelineService.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/entity/services/pipelineService.ts
@@ -895,7 +895,13 @@ export interface ConnectionClass {
      *
      * Matillion Host
      */
-    hostPort?:                string;
+    hostPort?: string;
+    /**
+     * Table name to fetch the query history. When set, this overrides the default
+     * 'mysql.general_log' (or 'mysql.slow_log' when 'useSlowLogs' is enabled). The custom table
+     * must expose columns compatible with the selected log path.
+     */
+    queryHistoryTable?:       string;
     sampleDataStorageConfig?: SampleDataStorageConfig;
     /**
      * Regex to only include/exclude schemas that matches the pattern.

--- a/openmetadata-ui/src/main/resources/ui/src/generated/metadataIngestion/testSuitePipeline.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/metadataIngestion/testSuitePipeline.ts
@@ -1443,6 +1443,10 @@ export interface ConfigObject {
     httpPath?: string;
     /**
      * Table name to fetch the query history.
+     *
+     * Table name to fetch the query history. When set, this overrides the default
+     * 'mysql.general_log' (or 'mysql.slow_log' when 'useSlowLogs' is enabled). The custom table
+     * must expose columns compatible with the selected log path.
      */
     queryHistoryTable?: string;
     /**
@@ -3758,6 +3762,12 @@ export interface ConfigConnection {
      */
     databaseSchema?: string;
     /**
+     * Table name to fetch the query history. When set, this overrides the default
+     * 'mysql.general_log' (or 'mysql.slow_log' when 'useSlowLogs' is enabled). The custom table
+     * must expose columns compatible with the selected log path.
+     */
+    queryHistoryTable?: string;
+    /**
      * Use slow logs to extract lineage.
      */
     useSlowLogs?: boolean;
@@ -4492,6 +4502,12 @@ export interface HiveMetastoreConnectionDetails {
      * attempts to scan all the schemas.
      */
     databaseSchema?: string;
+    /**
+     * Table name to fetch the query history. When set, this overrides the default
+     * 'mysql.general_log' (or 'mysql.slow_log' when 'useSlowLogs' is enabled). The custom table
+     * must expose columns compatible with the selected log path.
+     */
+    queryHistoryTable?: string;
     /**
      * Use slow logs to extract lineage.
      */

--- a/openmetadata-ui/src/main/resources/ui/src/generated/metadataIngestion/workflow.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/metadataIngestion/workflow.ts
@@ -1434,6 +1434,10 @@ export interface ConfigObject {
     httpPath?: string;
     /**
      * Table name to fetch the query history.
+     *
+     * Table name to fetch the query history. When set, this overrides the default
+     * 'mysql.general_log' (or 'mysql.slow_log' when 'useSlowLogs' is enabled). The custom table
+     * must expose columns compatible with the selected log path.
      */
     queryHistoryTable?: string;
     /**
@@ -3772,6 +3776,12 @@ export interface ConfigConnection {
      */
     databaseSchema?: string;
     /**
+     * Table name to fetch the query history. When set, this overrides the default
+     * 'mysql.general_log' (or 'mysql.slow_log' when 'useSlowLogs' is enabled). The custom table
+     * must expose columns compatible with the selected log path.
+     */
+    queryHistoryTable?: string;
+    /**
      * Use slow logs to extract lineage.
      */
     useSlowLogs?: boolean;
@@ -4511,6 +4521,12 @@ export interface HiveMetastoreConnectionDetails {
      * attempts to scan all the schemas.
      */
     databaseSchema?: string;
+    /**
+     * Table name to fetch the query history. When set, this overrides the default
+     * 'mysql.general_log' (or 'mysql.slow_log' when 'useSlowLogs' is enabled). The custom table
+     * must expose columns compatible with the selected log path.
+     */
+    queryHistoryTable?: string;
     /**
      * Use slow logs to extract lineage.
      */


### PR DESCRIPTION
  ## Summary

  - Adds an optional `queryHistoryTable` field to the MySQL connection schema, mirroring the existing Trino field.
  - When set, the configured table replaces the hardcoded source for query-history reads — both `mysql.general_log` (default path) and
  `mysql.slow_log` (when `useSlowLogs=true`) — and is also used by the test-connection probe.
  - When unset, behavior is unchanged.

  Fixes #28089

  ## Implementation Notes

  - Schema: `openmetadata-spec/.../mysqlConnection.json` adds `queryHistoryTable` (optional string, no default).
  - `queries.py`: `MYSQL_SQL_STATEMENT`, `MYSQL_SQL_STATEMENT_SLOW_LOGS`, and the two `MYSQL_TEST_GET_QUERIES*` probes parameterize the
  `FROM` clause with `{query_history_table}`.
  - `query_parser.py`: `MysqlQueryParserSource.get_sql_statement` resolves `service_connection.queryHistoryTable or <default>`; default
  is `mysql.slow_log` when `useSlowLogs=true`, `mysql.general_log` otherwise.
  - `connection.py`: `test_connection` does the same resolution and formats the chosen probe before passing it to
  `test_connection_db_schema_sources`.
  - Column expectations (`argument`/`event_time` vs `sql_text`/`start_time`) still follow `useSlowLogs`; the custom table must expose
  compatible columns.

  ## Test plan

  - [x] 11 unit tests in `ingestion/tests/unit/topology/database/test_mysql_query_parser.py`.
  - [x] `make py_format_check` clean.
  - [x] Local E2E: seeded `audit_db.my_query_log` (general_log schema) with queries against `openmetadata_db.*` tables, ran the lineage
  workflow with `queryHistoryTable: audit_db.my_query_log`, confirmed lineage edges in the UI (`table_entity` → `entity_usage`,
  `entity_extension`, `entity_relationship`).
  - [x] Reviewer: verify against `useSlowLogs=true` + a slow-log-shaped custom table.

----
## Summary by Gitar

- **Generated types:**
  - Updated TypeScript definitions in `openmetadata-ui` to reflect the new `queryHistoryTable` field in the connection schema.

<sub>This will update automatically on new commits.</sub>