### PR TITLE
fixes 27433 in 1.12.9

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/Tasks/TaskNavigation.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/Tasks/TaskNavigation.spec.ts
@@ -1,0 +1,281 @@
+/*
+ *  Copyright 2025 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+import test, { expect } from '@playwright/test';
+import { TableClass } from '../../../support/entity/TableClass';
+import { UserClass } from '../../../support/user/UserClass';
+import { performAdminLogin } from '../../../utils/admin';
+import { getApiContext } from '../../../utils/common';
+import { waitForAllLoadersToDisappear } from '../../../utils/entity';
+import {
+  waitForPageLoaded,
+  waitForTaskListResponse,
+} from '../../../utils/task';
+
+/**
+ * Task Notification Refresh (Issue #27433)
+ *
+ * Single-page scenario:
+ *   1. User navigates directly to a test-owned table entity page.
+ *   2. Opens "Activity Feed & Tasks" tab and stays there.
+ *   3. A task is created via API assigned to the same logged-in user.
+ *   4. User opens the notification bell and clicks the latest task notification,
+ *      which points to the same entity/activity-feed URL already open.
+ *   5. The fix (tasksRefreshKey in navigation state) must trigger a re-fetch so
+ *      the task list updates without a full page reload.
+ */
+test.describe('Task Notification - activity-feed tab refreshes after clicking notification', () => {
+  let adminUser: UserClass;
+  let otherUser: UserClass;
+  let table: TableClass;
+  let taskId: string | undefined;
+
+  test.afterAll(
+    'Delete task, table, admin user and other user',
+    async ({ browser }) => {
+      const { apiContext, afterAction } = await performAdminLogin(browser);
+      try {
+        if (taskId) {
+          await apiContext.delete(`/api/v1/feed/${taskId}`);
+        }
+        await table.delete(apiContext);
+        await adminUser.delete(apiContext);
+        await otherUser.delete(apiContext);
+      } finally {
+        await afterAction();
+      }
+    }
+  );
+
+  test.beforeAll(
+    'Create admin user, other user and table',
+    async ({ browser }) => {
+      adminUser = new UserClass();
+      otherUser = new UserClass();
+      table = new TableClass();
+      const { apiContext, afterAction } = await performAdminLogin(browser);
+      try {
+        await adminUser.create(apiContext);
+        await adminUser.setAdminRole(apiContext);
+        await otherUser.create(apiContext);
+        await table.create(apiContext);
+      } finally {
+        await afterAction();
+      }
+    }
+  );
+
+  test('clicking task notification while on entity task tab refreshes the task list', async ({
+    page,
+  }) => {
+    test.slow();
+
+    await test.step('Log in and navigate to entity page', async () => {
+      await adminUser.login(page);
+      const entityFqn = table.entityResponseData?.fullyQualifiedName ?? '';
+      await page.goto(`/table/${encodeURIComponent(entityFqn)}`);
+      await waitForPageLoaded(page);
+    });
+
+    await test.step('Open Activity Feed & Tasks tab and stay there', async () => {
+      const feedResponse = page.waitForResponse(
+        (r) =>
+          r.url().includes('/api/v1/feed') && r.request().method() === 'GET'
+      );
+      await page.getByTestId('activity_feed').click();
+      await feedResponse;
+      await waitForAllLoadersToDisappear(page);
+    });
+
+    await test.step('Create task via API assigned to the logged-in user', async () => {
+      const entityFqn = table.entityResponseData?.fullyQualifiedName ?? '';
+      const { apiContext, afterAction } = await getApiContext(page);
+      try {
+        const response = await apiContext.post('/api/v1/feed', {
+          data: {
+            from: adminUser.responseData.name,
+            message: `Update description for table ${entityFqn}`,
+            about: `<#E::table::${entityFqn}::description>`,
+            type: 'Task',
+            taskDetails: {
+              type: 'UpdateDescription',
+              assignees: [{ id: adminUser.responseData.id, type: 'user' }],
+              oldValue: '',
+              suggestion: '<p>Test task description</p>',
+            },
+          },
+        });
+        expect(response.ok()).toBeTruthy();
+        const created = await response.json();
+        taskId = created.id;
+      } finally {
+        await afterAction();
+      }
+    });
+
+    await test.step('Open notification bell and click the latest task notification', async () => {
+      const notificationBell = page.getByTestId('task-notifications');
+      await expect(notificationBell).toBeVisible();
+
+      const notifFeedResponse = page.waitForResponse(
+        (r) =>
+          r.url().includes('/api/v1/feed') &&
+          r.url().includes('filterType=ASSIGNED_TO') &&
+          r.url().includes('type=Task') &&
+          r.request().method() === 'GET'
+      );
+      await notificationBell.click();
+      await notifFeedResponse;
+
+      const notificationBox = page.locator('.notification-box');
+      await expect(notificationBox).toBeVisible();
+
+      const latestNotification = notificationBox
+        .locator('li.ant-list-item.notification-dropdown-list-btn')
+        .first();
+      await expect(latestNotification).toBeVisible();
+
+      const taskListRefresh = waitForTaskListResponse(page);
+      await latestNotification.click();
+      await taskListRefresh;
+
+      await waitForAllLoadersToDisappear(page);
+    });
+
+    await test.step('Task list is refreshed with the latest task details', async () => {
+      const taskCards = page.locator('[data-testid="task-feed-card"]');
+
+      await expect
+        .poll(async () => taskCards.count(), {
+          message: 'Waiting for refreshed task list to include the new task',
+          timeout: 30_000,
+          intervals: [1000, 2000, 3000],
+        })
+        .toBeGreaterThanOrEqual(1);
+
+      expect(page.url()).not.toMatch(/\/table\/TASK-/);
+    });
+  });
+
+  test('two sessions: admin on Columns tab creates task, assignee sees refresh on notification click', async ({
+    browser,
+  }) => {
+    test.slow();
+
+    const entityFqn = table.entityResponseData?.fullyQualifiedName ?? '';
+
+    const adminContext = await browser.newContext();
+    const userContext = await browser.newContext();
+    const adminPage = await adminContext.newPage();
+    const userPage = await userContext.newPage();
+
+    try {
+      await test.step('Log in both sessions', async () => {
+        await adminUser.login(adminPage);
+        await otherUser.login(userPage);
+      });
+
+      await test.step('Admin navigates to entity Columns (Schema) tab', async () => {
+        await table.visitEntityPage(adminPage);
+        const schemaTab = adminPage.getByRole('tab', { name: /schema/i });
+        if (await schemaTab.isVisible()) {
+          await schemaTab.click();
+          await waitForAllLoadersToDisappear(adminPage);
+        }
+      });
+
+      await test.step('Other user navigates to entity Activity Feed & Tasks tab', async () => {
+        await userPage.goto(`/table/${encodeURIComponent(entityFqn)}`);
+        await waitForPageLoaded(userPage);
+        const feedResponse = userPage.waitForResponse(
+          (r) =>
+            r.url().includes('/api/v1/feed') && r.request().method() === 'GET'
+        );
+        await userPage.getByTestId('activity_feed').click();
+        await feedResponse;
+        await waitForAllLoadersToDisappear(userPage);
+      });
+
+      await test.step('Admin creates a task via API and assigns to other user', async () => {
+        const { apiContext, afterAction } = await getApiContext(adminPage);
+        try {
+          const response = await apiContext.post('/api/v1/feed', {
+            data: {
+              from: adminUser.responseData.name,
+              message: `Update description for table ${entityFqn}`,
+              about: `<#E::table::${entityFqn}::description>`,
+              type: 'Task',
+              taskDetails: {
+                type: 'UpdateDescription',
+                assignees: [{ id: otherUser.responseData.id, type: 'user' }],
+                oldValue: '',
+                suggestion: '<p>Test task description</p>',
+              },
+            },
+          });
+          expect(response.ok()).toBeTruthy();
+          const created = await response.json();
+          taskId = created.id;
+        } finally {
+          await afterAction();
+        }
+      });
+
+      await test.step('Other user clicks bell icon and latest task notification', async () => {
+        const notificationBell = userPage.getByTestId('task-notifications');
+        await expect(notificationBell).toBeVisible();
+
+        const notifFeedResponse = userPage.waitForResponse(
+          (r) =>
+            r.url().includes('/api/v1/feed') &&
+            r.url().includes('filterType=ASSIGNED_TO') &&
+            r.url().includes('type=Task') &&
+            r.request().method() === 'GET'
+        );
+        await notificationBell.click();
+        await notifFeedResponse;
+
+        const notificationBox = userPage.locator('.notification-box');
+        await expect(notificationBox).toBeVisible();
+
+        const latestNotification = notificationBox
+          .locator('li.ant-list-item.notification-dropdown-list-btn')
+          .first();
+        await expect(latestNotification).toBeVisible();
+
+        const taskListRefresh = waitForTaskListResponse(userPage);
+        await latestNotification.click();
+        await taskListRefresh;
+
+        await waitForAllLoadersToDisappear(userPage);
+      });
+
+      await test.step('Task list is refreshed with the new task on the other user page', async () => {
+        const taskCards = userPage.locator('[data-testid="task-feed-card"]');
+
+        await expect
+          .poll(async () => taskCards.count(), {
+            message: 'Waiting for refreshed task list to include the new task',
+            timeout: 30_000,
+            intervals: [1000, 2000, 3000],
+          })
+          .toBeGreaterThanOrEqual(1);
+
+        expect(userPage.url()).not.toMatch(/\/table\/TASK-/);
+      });
+    } finally {
+      await adminContext.close();
+      await userContext.close();
+    }
+  });
+});

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/task.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/task.ts
@@ -13,6 +13,7 @@
 import { expect, Page } from '@playwright/test';
 import { isUndefined } from 'lodash';
 import { clickOutside, descriptionBox, toastNotification } from './common';
+import { waitForAllLoadersToDisappear } from './entity';
 
 export type TaskDetails = {
   term: string;
@@ -173,4 +174,18 @@ export const checkTaskCountInActivityFeed = async (
     .last();
 
   expect(await closedTaskItem.textContent()).toBe(String(closedTask));
+};
+
+export const waitForTaskListResponse = (page: Page) =>
+  page.waitForResponse(
+    (response) =>
+      response.request().method() === 'GET' &&
+      response.url().includes('/api/v1/feed') &&
+      response.url().includes('entityLink='),
+    { timeout: 30_000 }
+  );
+
+export const waitForPageLoaded = async (page: Page) => {
+  await page.waitForLoadState('domcontentloaded');
+  await waitForAllLoadersToDisappear(page);
 };

--- a/openmetadata-ui/src/main/resources/ui/src/components/ActivityFeed/ActivityFeedTab/ActivityFeedTab.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/ActivityFeed/ActivityFeedTab/ActivityFeedTab.component.tsx
@@ -14,9 +14,16 @@ import { Button, Dropdown, Menu, Segmented, Space, Typography } from 'antd';
 import { AxiosError } from 'axios';
 import classNames from 'classnames';
 import { isEmpty } from 'lodash';
-import { RefObject, useCallback, useEffect, useMemo, useState } from 'react';
+import {
+  RefObject,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 import { useTranslation } from 'react-i18next';
-import { useNavigate } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
 import { ReactComponent as AllActivityIcon } from '../../../assets/svg/all-activity-v2.svg';
 import { ReactComponent as TaskCloseIcon } from '../../../assets/svg/ic-check-circle-new.svg';
 import { ReactComponent as TaskCloseIconBlue } from '../../../assets/svg/ic-close-task.svg';
@@ -89,6 +96,7 @@ export const ActivityFeedTab = ({
   urlFqn = '',
 }: ActivityFeedTabProps) => {
   const navigate = useNavigate();
+  const location = useLocation();
   const { t } = useTranslation();
   const { currentUser } = useApplicationStore();
   const { isAdminUser } = useAuth();
@@ -99,8 +107,10 @@ export const ActivityFeedTab = ({
     root: document.querySelector('#center-container'),
     rootMargin: '0px 0px 2px 0px',
   });
-  const { subTab: activeTab = subTab } =
-    useRequiredParams<{ tab: EntityTabs; subTab: ActivityFeedTabs }>();
+  const { subTab: activeTab = subTab } = useRequiredParams<{
+    tab: EntityTabs;
+    subTab: ActivityFeedTabs;
+  }>();
   const [taskFilter, setTaskFilter] = useState<ThreadTaskStatus>(
     ThreadTaskStatus.Open
   );
@@ -113,6 +123,7 @@ export const ActivityFeedTab = ({
     data: FEED_COUNT_INITIAL_DATA,
   });
   const [isFirstLoad, setIsFirstLoad] = useState<boolean>(true);
+  const processedRefreshKeyRef = useRef<number | undefined>(undefined);
 
   const {
     selectedThread,
@@ -257,6 +268,39 @@ export const ActivityFeedTab = ({
     };
   }, [activeTab, isUserEntity, currentUser]);
 
+  useEffect(() => {
+    const refreshKey = (location.state as { tasksRefreshKey?: number } | null)
+      ?.tasksRefreshKey;
+    if (
+      refreshKey !== undefined &&
+      refreshKey !== processedRefreshKeyRef.current &&
+      fqn &&
+      isTaskActiveTab
+    ) {
+      processedRefreshKeyRef.current = refreshKey;
+      getFeedData(
+        feedFilter,
+        undefined,
+        threadType,
+        entityType,
+        fqn,
+        taskFilter
+      );
+      navigate('.', { replace: true, state: {} });
+    }
+  }, [
+    entityType,
+    feedFilter,
+    fqn,
+    getFeedData,
+    isTaskActiveTab,
+    location.key,
+    location.state,
+    navigate,
+    taskFilter,
+    threadType,
+  ]);
+
   const handleFeedFetchFromFeedList = useCallback(
     (after?: string) => {
       setIsFirstLoad(false);
@@ -328,7 +372,8 @@ export const ActivityFeedTab = ({
               'flex items-center justify-between px-4 py-2 gap-2',
               { active: taskFilter === ThreadTaskStatus.Open }
             )}
-            data-testid="open-tasks">
+            data-testid="open-tasks"
+          >
             <div className="flex items-center space-x-2">
               {taskFilter === ThreadTaskStatus.Open ? (
                 <TaskOpenIcon
@@ -341,14 +386,16 @@ export const ActivityFeedTab = ({
               <span
                 className={classNames('task-tab-filter-item', {
                   selected: taskFilter === ThreadTaskStatus.Open,
-                })}>
+                })}
+              >
                 {t('label.open')}
               </span>
             </div>
             <span
               className={classNames('task-count-container d-flex flex-center', {
                 active: taskFilter === ThreadTaskStatus.Open,
-              })}>
+              })}
+            >
               <span className="task-count-text">
                 {countData?.data?.openTaskCount}
               </span>
@@ -368,7 +415,8 @@ export const ActivityFeedTab = ({
               'flex items-center justify-between px-4 py-2 gap-2',
               { active: taskFilter === ThreadTaskStatus.Closed }
             )}
-            data-testid="closed-tasks">
+            data-testid="closed-tasks"
+          >
             <div className="flex items-center space-x-2">
               {taskFilter === ThreadTaskStatus.Closed ? (
                 <TaskCloseIconBlue
@@ -384,14 +432,16 @@ export const ActivityFeedTab = ({
               <span
                 className={classNames('task-tab-filter-item', {
                   selected: taskFilter === ThreadTaskStatus.Closed,
-                })}>
+                })}
+              >
                 {t('label.closed')}
               </span>
             </div>
             <span
               className={classNames('task-count-container d-flex flex-center', {
                 active: taskFilter === ThreadTaskStatus.Closed,
-              })}>
+              })}
+            >
               <span className="task-count-text">
                 {countData?.data?.closedTaskCount}
               </span>
@@ -585,7 +635,8 @@ export const ActivityFeedTab = ({
           'three-panel-layout':
             layoutType === ActivityFeedLayoutType.THREE_PANEL,
         })}
-        id="center-container">
+        id="center-container"
+      >
         {(isTaskActiveTab || isMentionTabSelected) && (
           <div className="d-flex gap-4 task-filter-container  justify-between items-center ">
             <Dropdown
@@ -595,7 +646,8 @@ export const ActivityFeedTab = ({
                 selectedKeys: [...taskFilter],
               }}
               overlayClassName="task-tab-custom-dropdown"
-              trigger={['click']}>
+              trigger={['click']}
+            >
               <Button
                 className={classNames('feed-filter-icon', {
                   'cursor-pointer': !isMentionTabSelected,
@@ -640,7 +692,8 @@ export const ActivityFeedTab = ({
           'hide-panel': isFullWidth,
           'three-panel-layout':
             layoutType === ActivityFeedLayoutType.THREE_PANEL,
-        })}>
+        })}
+      >
         {loader}
         {selectedThread && !loading
           ? getRightPanelContent(selectedThread)
@@ -648,7 +701,8 @@ export const ActivityFeedTab = ({
               <div className="p-x-md no-data-placeholder-container-right-panel d-flex justify-center items-center h-full">
                 <ErrorPlaceHolderNew
                   icon={<NoConversationsIcon />}
-                  type={ERROR_PLACEHOLDER_TYPE.CUSTOM}>
+                  type={ERROR_PLACEHOLDER_TYPE.CUSTOM}
+                >
                   <Typography.Paragraph className="placeholder-text">
                     {getRightPanelPlaceholder}
                   </Typography.Paragraph>

--- a/openmetadata-ui/src/main/resources/ui/src/components/NotificationBox/NotificationFeedCard.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/NotificationBox/NotificationFeedCard.component.tsx
@@ -12,9 +12,10 @@
  */
 
 import { List, Space, Typography } from 'antd';
-import { FC, useMemo } from 'react';
+import { startCase } from 'lodash';
+import { FC, useCallback, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Link } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router-dom';
 import { EntityType } from '../../enums/entity.enum';
 import { TaskType, ThreadType } from '../../generated/entity/feed/thread';
 import {
@@ -39,8 +40,21 @@ const NotificationFeedCard: FC<NotificationFeedProp> = ({
   task,
   isConversationFeed = false,
 }) => {
+  const navigate = useNavigate();
   const { t } = useTranslation();
   const { task: taskDetails } = task ?? {};
+
+  const taskLink = useMemo(() => {
+    return task ? getTaskDetailPath(task) : '';
+  }, [task]);
+
+  const handleTaskLinkClick = useCallback(
+    (e: React.MouseEvent) => {
+      e.preventDefault();
+      navigate(taskLink, { state: { tasksRefreshKey: Date.now() } });
+    },
+    [navigate, taskLink]
+  );
 
   const taskContent = useMemo(() => {
     if (task.task?.type === TaskType.RequestApproval) {
@@ -57,7 +71,8 @@ const NotificationFeedCard: FC<NotificationFeedProp> = ({
               task?.entityRef?.fullyQualifiedName ?? '',
               task?.entityRef?.type as EntityType,
               task?.entityRef as SourceType
-            )}>
+            )}
+          >
             <span className="m-r-xss">{task?.entityRef?.displayName}</span>
           </Link>
           <span>{t('label.of-lowercase')}</span>
@@ -66,7 +81,8 @@ const NotificationFeedCard: FC<NotificationFeedProp> = ({
               Fqn.split(task?.entityRef?.fullyQualifiedName ?? '')[0],
               task?.entityRef?.type as EntityType,
               task?.entityRef as SourceType
-            )}>
+            )}
+          >
             <span className="m-l-xss">
               {Fqn.split(task?.entityRef?.fullyQualifiedName ?? '')[0]}
             </span>
@@ -80,18 +96,26 @@ const NotificationFeedCard: FC<NotificationFeedProp> = ({
         <span className="p-x-xss">
           {t('message.assigned-you-a-new-task-lowercase')}
         </span>
-        <Link to={getTaskDetailPath(task)}>
-          {`#${taskDetails?.id}`} {taskDetails?.type}
+        <Link
+          to={taskLink}
+          onClick={(e) => {
+            e.stopPropagation();
+            handleTaskLinkClick(e);
+          }}
+        >
+          {`#${taskDetails?.id ?? ''} ${startCase(taskDetails?.type ?? '')}`}
         </Link>
       </>
     );
-  }, [entityType, task, taskDetails]);
+  }, [handleTaskLinkClick, t, taskDetails, taskLink]);
 
   const entityName = useMemo(() => {
-    return task?.entityRef
-      ? getEntityName(task?.entityRef)
+    const entityRef = task?.entityRef as SourceType | undefined;
+
+    return entityRef
+      ? getEntityName(entityRef as SourceType)
       : entityDisplayName(entityType, entityFQN);
-  }, [task, entityType, entityFQN]);
+  }, [entityFQN, entityType, task]);
 
   return (
     <Link
@@ -99,8 +123,10 @@ const NotificationFeedCard: FC<NotificationFeedProp> = ({
       to={
         isConversationFeed
           ? prepareFeedLink(entityType, entityFQN, ActivityFeedTabs.ALL)
-          : getTaskDetailPath(task)
-      }>
+          : taskLink
+      }
+      onClick={!isConversationFeed ? handleTaskLinkClick : undefined}
+    >
       <List.Item.Meta
         avatar={<ProfilePicture name={createdBy} width="32" />}
         className="m-0"
@@ -108,10 +134,12 @@ const NotificationFeedCard: FC<NotificationFeedProp> = ({
           <Space
             data-testid={`notification-item-${entityName}`}
             direction="vertical"
-            size={0}>
+            size={0}
+          >
             <Typography.Paragraph
               className="m-0"
-              style={{ color: '#37352F', marginBottom: 0 }}>
+              style={{ color: '#37352F', marginBottom: 0 }}
+            >
               <>{createdBy}</>
               {feedType === ThreadType.Conversation ? (
                 <>
@@ -124,7 +152,8 @@ const NotificationFeedCard: FC<NotificationFeedProp> = ({
                       entityType,
                       entityFQN,
                       ActivityFeedTabs.ALL
-                    )}>
+                    )}
+                  >
                     {entityName}
                   </Link>
                 </>
@@ -134,7 +163,8 @@ const NotificationFeedCard: FC<NotificationFeedProp> = ({
             </Typography.Paragraph>
             <Typography.Text
               style={{ color: '#6B7280', marginTop: '8px', fontSize: '12px' }}
-              title={formatDateTime(timestamp)}>
+              title={formatDateTime(timestamp)}
+            >
               {getRelativeTime(timestamp)}
             </Typography.Text>
           </Space>

--- a/openmetadata-ui/src/main/resources/ui/src/components/NotificationBox/NotificationFeedCard.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/NotificationBox/NotificationFeedCard.test.tsx
@@ -10,7 +10,8 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-import { act, render, screen } from '@testing-library/react';
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import { startCase } from 'lodash';
 import React from 'react';
 import { ThreadType } from '../../generated/api/feed/createThread';
 import { Thread } from '../../generated/entity/feed/thread';
@@ -23,6 +24,8 @@ jest.mock('../../utils/date-time/DateTimeUtils', () => ({
 
 const mockPrepareFeedLink = jest.fn();
 const mockGetTaskDetailPath = jest.fn();
+
+const mockNavigate = jest.fn();
 
 jest.mock('../../utils/FeedUtils', () => ({
   entityDisplayName: jest.fn().mockReturnValue('database.schema.table'),
@@ -40,12 +43,21 @@ jest.mock('react-router-dom', () => ({
   Link: jest
     .fn()
     .mockImplementation(
-      ({ children, to }: { children: React.ReactNode; to: string }) => (
-        <p data-testid="link" data-to={to}>
+      ({
+        children,
+        to,
+        onClick,
+      }: {
+        children: React.ReactNode;
+        to: string;
+        onClick?: (e: React.MouseEvent) => void;
+      }) => (
+        <p data-testid="link" data-to={to} onClick={onClick}>
           {children}
         </p>
       )
     ),
+  useNavigate: jest.fn(() => mockNavigate),
 }));
 jest.mock('../../utils/EntityUtils', () => ({
   getEntityLinkFromType: jest.fn().mockReturnValue('/mock-entity-link'),
@@ -109,6 +121,60 @@ const mockProps = {
   feedType: ThreadType.Task,
 };
 
+it('calls navigate with tasksRefreshKey state when the task notification card is clicked', async () => {
+  mockGetTaskDetailPath.mockReturnValue('/mock-task-link');
+
+  await act(async () => {
+    render(<NotificationFeedCard {...mockProps} />);
+  });
+
+  const outerLink = screen.getAllByTestId('link')[0];
+  fireEvent.click(outerLink);
+
+  expect(mockNavigate).toHaveBeenCalledWith('/mock-task-link', {
+    state: { tasksRefreshKey: expect.any(Number) },
+  });
+});
+
+it('calls navigate with tasksRefreshKey state when the inner task ID link is clicked', async () => {
+  mockGetTaskDetailPath.mockReturnValue('/mock-task-link');
+
+  await act(async () => {
+    render(<NotificationFeedCard {...mockProps} />);
+  });
+
+  const links = screen.getAllByTestId('link');
+  const innerTaskLink = links[links.length - 1];
+  fireEvent.click(innerTaskLink);
+
+  expect(mockNavigate).toHaveBeenCalledWith('/mock-task-link', {
+    state: { tasksRefreshKey: expect.any(Number) },
+  });
+});
+
+it('does not call navigate when a mention notification is clicked', async () => {
+  mockPrepareFeedLink.mockReturnValue('/entity/activity_feed/all');
+
+  await act(async () => {
+    render(
+      <NotificationFeedCard
+        isConversationFeed
+        createdBy="admin"
+        entityFQN="Article_sQDEeTK6"
+        entityType="page"
+        feedType={ThreadType.Conversation}
+        task={mockThread as Thread}
+        timestamp={mockThread.threadTs}
+      />
+    );
+  });
+
+  const outerLink = screen.getAllByTestId('link')[0];
+  fireEvent.click(outerLink);
+
+  expect(mockNavigate).not.toHaveBeenCalled();
+});
+
 describe('Test NotificationFeedCard Component', () => {
   it('Check if it has all child elements', async () => {
     await act(async () => {
@@ -128,7 +194,9 @@ describe('Test NotificationFeedCard Component', () => {
     ).toBeInTheDocument();
 
     expect(
-      screen.getByText(`#${mockThread.task.id} ${mockThread.task.type}`)
+      screen.getByText(
+        `#${mockThread.task.id} ${startCase(mockThread.task.type)}`
+      )
     ).toBeInTheDocument();
   });
 
@@ -258,8 +326,7 @@ describe('Test NotificationFeedCard Component', () => {
         render(<NotificationFeedCard {...conversationProps} />);
       });
 
-      // Should be called twice - once for main link, once for entity name link
-      expect(mockGetTaskDetailPath).toHaveBeenCalledTimes(2);
+      expect(mockGetTaskDetailPath).toHaveBeenCalledTimes(1);
       expect(mockGetTaskDetailPath).toHaveBeenCalledWith(mockThread);
     });
 


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:

Fixes [27433](https://github.com/open-metadata/OpenMetadata/issues/27433)

<!--
Short blurb explaining:
- What changes did you make? => Updated NotificationFeedCard to use navigate with tasksRefreshKey on task notification clicks, and added a useEffect in ActivityFeedTab that re-fetches tasks when that key appears in location state.
- Why did you make them? => Clicking a notification link pointing to the same URL you're already on is silently ignored by React Router, so the task list never refreshed - requiring a hard reload to see the new approval request.
- How did you test your changes? => Added 3 Jest unit tests to NotificationFeedCard.test.tsx verifying that clicking a task notification card (outer and inner link) calls navigate with tasksRefreshKey state, and that mention notifications are unaffected.
-->

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [X] Bug fix

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [X] My PR title is `Fixes <issue-number>: <short explanation>`
- [X] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [X] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [X] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

----
## Summary by Gitar

- **Bug fix:**
  - Updated `NotificationFeedCard` to inject `tasksRefreshKey` into navigation state on task link clicks.
  - Added `useEffect` to `ActivityFeedTab` to listen for `tasksRefreshKey` and trigger a task list re-fetch.
- **Testing:**
  - Added unit tests in `NotificationFeedCard.test.tsx` to verify `navigate` call with required state.
  - Implemented comprehensive E2E test in `TaskNavigation.spec.ts` covering single and dual-session task refresh scenarios.
  - Refactored `TaskNavigation` E2E test setup to include `afterAll` cleanup for proper resource management.

<sub>This will update automatically on new commits.</sub>