### PR TITLE
Fixes 28267: Preserve test case suite search membership

### DIFF
--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/TestCaseResourceIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/TestCaseResourceIT.java
@@ -7,13 +7,20 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import es.co.elastic.clients.transport.rest5_client.low_level.Request;
+import es.co.elastic.clients.transport.rest5_client.low_level.Response;
+import es.co.elastic.clients.transport.rest5_client.low_level.Rest5Client;
 import io.github.resilience4j.core.IntervalFunction;
 import io.github.resilience4j.retry.Retry;
 import io.github.resilience4j.retry.RetryConfig;
+import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 import org.awaitility.Awaitility;
@@ -21,6 +28,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
 import org.openmetadata.it.bootstrap.SharedEntities;
+import org.openmetadata.it.bootstrap.TestSuiteBootstrap;
 import org.openmetadata.it.util.SdkClients;
 import org.openmetadata.it.util.TestNamespace;
 import org.openmetadata.schema.api.classification.CreateClassification;
@@ -63,6 +71,7 @@ import org.slf4j.LoggerFactory;
 @Execution(ExecutionMode.CONCURRENT)
 public class TestCaseResourceIT extends BaseEntityIT<TestCase, CreateTestCase> {
   private static final Logger LOG = LoggerFactory.getLogger(TestCaseResourceIT.class);
+  private static final ObjectMapper MAPPER = new ObjectMapper();
   private static final RetryConfig DEADLOCK_RETRY_CONFIG =
       RetryConfig.custom()
           .maxAttempts(3)
@@ -1351,6 +1360,59 @@ public class TestCaseResourceIT extends BaseEntityIT<TestCase, CreateTestCase> {
                   fetched.getTestSuites().stream()
                       .anyMatch(ts -> ts.getId().equals(logicalSuite.getId())));
             });
+  }
+
+  @Test
+  void test_putPreservesLogicalSuiteSearchMembership(TestNamespace ns) throws Exception {
+    OpenMetadataClient client = SdkClients.adminClient();
+    Table table = createTable(ns);
+
+    CreateTestCase createRequest =
+        TestCaseBuilder.create(client)
+            .name(ns.prefix("put_logical_suite"))
+            .description("initial description")
+            .forTable(table)
+            .testDefinition("tableRowCountToEqual")
+            .parameter("value", "100")
+            .build();
+    TestCase testCase = client.testCases().create(createRequest);
+
+    CreateTestSuite suiteReq = new CreateTestSuite();
+    suiteReq.setName(ns.prefix("logical_put_suite"));
+    TestSuite logicalSuite = client.testSuites().create(suiteReq);
+    addTestCasesToLogicalTestSuite(client, logicalSuite.getId(), List.of(testCase.getId()));
+
+    try (Rest5Client searchClient = TestSuiteBootstrap.createSearchClient()) {
+      Awaitility.await("logical suite membership indexed before PUT")
+          .atMost(Duration.ofSeconds(30))
+          .pollInterval(Duration.ofSeconds(2))
+          .untilAsserted(
+              () ->
+                  assertSearchDocContainsTestSuite(
+                      queryTestCaseSearchSource(searchClient, testCase.getId()),
+                      logicalSuite.getId()));
+
+      String updatedDescription = "updated via PUT " + System.currentTimeMillis();
+      createRequest.setDescription(updatedDescription);
+      client.testCases().upsert(createRequest);
+
+      TestCase fetched = client.testCases().get(testCase.getId().toString(), "testSuites");
+      assertTrue(
+          fetched.getTestSuites().stream()
+              .anyMatch(suite -> suite.getId().equals(logicalSuite.getId())),
+          "PUT should preserve the logical suite graph relationship");
+
+      Awaitility.await("PUT preserves logical suite membership in search")
+          .atMost(Duration.ofSeconds(30))
+          .pollInterval(Duration.ofSeconds(2))
+          .untilAsserted(
+              () -> {
+                JsonNode source = queryTestCaseSearchSource(searchClient, testCase.getId());
+                assertNotNull(source);
+                assertEquals(updatedDescription, source.path("description").asText());
+                assertSearchDocContainsTestSuite(source, logicalSuite.getId());
+              });
+    }
   }
 
   @Test
@@ -4458,5 +4520,73 @@ public class TestCaseResourceIT extends BaseEntityIT<TestCase, CreateTestCase> {
     // Verify the displayName was actually set
     TestCase updated = getEntity(created.getId().toString());
     assertEquals("Updated Display Name", updated.getDisplayName());
+  }
+
+  private void addTestCasesToLogicalTestSuite(
+      OpenMetadataClient client, UUID testSuiteId, List<UUID> testCaseIds) {
+    Map<String, Object> request = new HashMap<>();
+    request.put("testSuiteId", testSuiteId.toString());
+    request.put("testCaseIds", testCaseIds.stream().map(UUID::toString).toList());
+
+    client
+        .getHttpClient()
+        .executeForString(
+            HttpMethod.PUT,
+            "/v1/dataQuality/testCases/logicalTestCases",
+            request,
+            RequestOptions.builder().build());
+  }
+
+  private JsonNode queryTestCaseSearchSource(Rest5Client searchClient, UUID testCaseId)
+      throws Exception {
+    refreshTestCaseSearchIndex(searchClient);
+
+    String query =
+        """
+        {
+          "size": 1,
+          "query": {
+            "bool": {
+              "must": [
+                { "term": { "_id": "%s" } }
+              ]
+            }
+          }
+        }
+        """
+            .formatted(testCaseId);
+
+    Request request = new Request("POST", "/" + getTestCaseSearchIndexName() + "/_search");
+    request.setJsonEntity(query);
+    Response response = searchClient.performRequest(request);
+
+    assertEquals(200, response.getStatusCode());
+    String body =
+        new String(response.getEntity().getContent().readAllBytes(), StandardCharsets.UTF_8);
+    JsonNode hits = MAPPER.readTree(body).path("hits").path("hits");
+    return hits.size() == 0 ? null : hits.get(0).path("_source");
+  }
+
+  private void assertSearchDocContainsTestSuite(JsonNode source, UUID testSuiteId) {
+    assertNotNull(source);
+    JsonNode testSuites = source.path("testSuites");
+    assertTrue(testSuites.isArray(), "testSuites should be indexed in the search document");
+    boolean found = false;
+    for (JsonNode suite : testSuites) {
+      if (testSuiteId.toString().equals(suite.path("id").asText())) {
+        found = true;
+        break;
+      }
+    }
+    assertTrue(found, "search document testSuites should contain " + testSuiteId);
+  }
+
+  private String getTestCaseSearchIndexName() {
+    return "openmetadata_test_case_search_index";
+  }
+
+  private void refreshTestCaseSearchIndex(Rest5Client searchClient) throws Exception {
+    Request request = new Request("POST", "/" + getTestCaseSearchIndexName() + "/_refresh");
+    searchClient.performRequest(request);
   }
 }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/TestCaseRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/TestCaseRepository.java
@@ -1620,6 +1620,7 @@ public class TestCaseRepository extends EntityRepository<TestCase> {
 
   @Override
   public void postUpdate(TestCase original, TestCase updated) {
+    hydrateTestSuiteFieldsForSearch(updated);
     super.postUpdate(original, updated);
     if (EntityStatus.IN_REVIEW.equals(original.getEntityStatus())) {
       if (EntityStatus.APPROVED.equals(updated.getEntityStatus())) {
@@ -1641,6 +1642,10 @@ public class TestCaseRepository extends EntityRepository<TestCase> {
       } catch (EntityNotFoundException ignored) {
       } // No ApprovalTask is present, and thus we don't need to worry about this.
     }
+  }
+
+  private void hydrateTestSuiteFieldsForSearch(TestCase updated) {
+    setFieldsInternal(updated, getFields(TEST_SUITE_FIELD + "," + Entity.FIELD_TEST_SUITES));
   }
 
   private void closeApprovalTask(TestCase entity, String comment) {

--- a/openmetadata-service/src/test/java/org/openmetadata/service/jdbi3/TestCaseRepositoryTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/jdbi3/TestCaseRepositoryTest.java
@@ -14,6 +14,8 @@ import org.openmetadata.schema.tests.TestCase;
 import org.openmetadata.schema.tests.TestSuite;
 import org.openmetadata.schema.type.EntityReference;
 import org.openmetadata.service.Entity;
+import org.openmetadata.service.events.lifecycle.EntityLifecycleEventDispatcher;
+import org.openmetadata.service.rdf.RdfUpdater;
 import org.openmetadata.service.util.EntityUtil.Fields;
 import org.openmetadata.service.util.EntityUtil.RelationIncludes;
 
@@ -24,9 +26,14 @@ class TestCaseRepositoryTest {
     CollectionDAO collectionDAO = mock(CollectionDAO.class);
     when(collectionDAO.testCaseDAO()).thenReturn(mock(CollectionDAO.TestCaseDAO.class));
 
-    try (MockedStatic<Entity> entity = Mockito.mockStatic(Entity.class)) {
+    EntityLifecycleEventDispatcher dispatcher = mock(EntityLifecycleEventDispatcher.class);
+    try (MockedStatic<Entity> entity = Mockito.mockStatic(Entity.class);
+        MockedStatic<EntityLifecycleEventDispatcher> lifecycleDispatcher =
+            Mockito.mockStatic(EntityLifecycleEventDispatcher.class);
+        MockedStatic<RdfUpdater> ignoredRdfUpdater = Mockito.mockStatic(RdfUpdater.class)) {
       entity.when(Entity::getCollectionDAO).thenReturn(collectionDAO);
       entity.when(() -> Entity.getEntityFields(TestCase.class)).thenCallRealMethod();
+      lifecycleDispatcher.when(EntityLifecycleEventDispatcher::getInstance).thenReturn(dispatcher);
 
       EntityReference basicSuiteRef = entityReference(Entity.TEST_SUITE, "basicSuite");
       TestSuite logicalSuite =

--- a/openmetadata-service/src/test/java/org/openmetadata/service/jdbi3/TestCaseRepositoryTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/jdbi3/TestCaseRepositoryTest.java
@@ -1,0 +1,96 @@
+package org.openmetadata.service.jdbi3;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.openmetadata.schema.tests.TestCase;
+import org.openmetadata.schema.tests.TestSuite;
+import org.openmetadata.schema.type.EntityReference;
+import org.openmetadata.service.Entity;
+import org.openmetadata.service.util.EntityUtil.Fields;
+import org.openmetadata.service.util.EntityUtil.RelationIncludes;
+
+class TestCaseRepositoryTest {
+
+  @Test
+  void postUpdateHydratesTestSuitesBeforeLifecycleUpdate() {
+    CollectionDAO collectionDAO = mock(CollectionDAO.class);
+    when(collectionDAO.testCaseDAO()).thenReturn(mock(CollectionDAO.TestCaseDAO.class));
+
+    try (MockedStatic<Entity> entity = Mockito.mockStatic(Entity.class)) {
+      entity.when(Entity::getCollectionDAO).thenReturn(collectionDAO);
+      entity.when(() -> Entity.getEntityFields(TestCase.class)).thenCallRealMethod();
+
+      EntityReference basicSuiteRef = entityReference(Entity.TEST_SUITE, "basicSuite");
+      TestSuite logicalSuite =
+          new TestSuite()
+              .withId(UUID.randomUUID())
+              .withName("logicalSuite")
+              .withFullyQualifiedName("logicalSuite")
+              .withBasic(false);
+      HydratingTestCaseRepository repository =
+          new HydratingTestCaseRepository(basicSuiteRef, List.of(logicalSuite));
+
+      UUID testCaseId = UUID.randomUUID();
+      TestCase original =
+          testCase(testCaseId, "original", basicSuiteRef).withTestSuites(List.of(logicalSuite));
+      TestCase updated = testCase(testCaseId, "updated", basicSuiteRef).withTestSuites(null);
+
+      repository.postUpdate(original, updated);
+
+      assertNotNull(repository.capturedFields);
+      assertTrue(repository.capturedFields.contains(TestCaseRepository.TEST_SUITE_FIELD));
+      assertTrue(repository.capturedFields.contains(Entity.FIELD_TEST_SUITES));
+      assertTrue(
+          updated.getTestSuites().stream()
+              .anyMatch(suite -> suite.getId().equals(logicalSuite.getId())));
+    }
+  }
+
+  private static TestCase testCase(UUID id, String description, EntityReference basicSuiteRef) {
+    return new TestCase()
+        .withId(id)
+        .withName("row_count")
+        .withFullyQualifiedName("service.database.schema.table.row_count")
+        .withDescription(description)
+        .withEntityLink("<#E::table::service.database.schema.table>")
+        .withTestSuite(basicSuiteRef);
+  }
+
+  private static EntityReference entityReference(String type, String name) {
+    return new EntityReference()
+        .withId(UUID.randomUUID())
+        .withType(type)
+        .withName(name)
+        .withFullyQualifiedName(name);
+  }
+
+  private static class HydratingTestCaseRepository extends TestCaseRepository {
+    private final EntityReference basicSuiteRef;
+    private final List<TestSuite> testSuites;
+    private Fields capturedFields;
+
+    private HydratingTestCaseRepository(EntityReference basicSuiteRef, List<TestSuite> testSuites) {
+      this.basicSuiteRef = basicSuiteRef;
+      this.testSuites = testSuites;
+    }
+
+    @Override
+    public void setFields(TestCase test, Fields fields, RelationIncludes relationIncludes) {
+      capturedFields = fields;
+      if (fields.contains(TEST_SUITE_FIELD)) {
+        test.setTestSuite(basicSuiteRef);
+      }
+      if (fields.contains(Entity.FIELD_TEST_SUITES)) {
+        test.setTestSuites(testSuites);
+      }
+    }
+  }
+}


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:

Fixes #28267

I worked on preserving logical test suite membership during test case PUT updates because the live search document was losing `testSuites` until a full reindex.

#
### Type of change:
- [x] Bug fix

#
### High-level design:
N/A - small change.

#
### Tests:

#### Use cases covered
- PUT `/v1/dataQuality/testCases` keeps logical test suite membership in the test case search document.

#### Unit tests
- [x] I added unit tests for the new/changed logic.
- Files added/updated: `openmetadata-service/src/test/java/org/openmetadata/service/jdbi3/TestCaseRepositoryTest.java`
- Coverage %: Not measured.

#### Backend integration tests
- [x] I added integration tests in `openmetadata-integration-tests/` for new/changed API endpoints.
- Files added/updated: `openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/TestCaseResourceIT.java`

#### Ingestion integration tests
- [x] Not applicable (no ingestion changes).

#### Playwright (UI) tests
- [x] Not applicable (no UI changes).

#### Manual testing performed
- `mvn -pl openmetadata-service -Dtest=TestCaseRepositoryTest test`
- `mvn -pl openmetadata-integration-tests -Dit.test=TestCaseResourceIT#test_putPreservesLogicalSuiteSearchMembership -DfailIfNoTests=false verify`
- `mvn -pl openmetadata-service,openmetadata-integration-tests spotless:check`
- `mvn -pl openmetadata-service,openmetadata-integration-tests spotless:apply`

#
### UI screen recording / screenshots:
Not applicable.

#
### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] My PR title is `Fixes <issue-number>: <short explanation>`.
- [x] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [x] JSON Schema changes are not applicable.
- [x] UI screenshots are not applicable.
- [x] I have added tests (unit / integration / Playwright as applicable) and listed them above.
- [x] I have added a test that covers the exact scenario we are fixing.