### PR TITLE
fix(logging): synchronous shutdown captures full streamable log tail

### DIFF
--- a/ingestion/src/metadata/ingestion/ometa/mixins/server_mixin.py
+++ b/ingestion/src/metadata/ingestion/ometa/mixins/server_mixin.py
@@ -85,17 +85,21 @@ class OMetaServerMixin:
     def validate_versions(self) -> None:
         """
         Validate Server & Client versions. They should match.
-        Otherwise, raise VersionMismatchException
+        Otherwise, raise VersionMismatchException.
         """
-        logger.info(
-            f"OpenMetadata client running with Server version [{self.server_version}] and Client version [{self.client_version}]"
-        )
-
         if not match_versions(self.server_version, self.client_version):
             raise VersionMismatchException(
                 f"Server version is {self.server_version} vs. Client version {self.client_version}."
                 f" Major and minor versions should match."
             )
+
+    def log_server_version(self) -> None:
+        """Emit the server/client version line."""
+        logger.info(
+            "OpenMetadata client running with Server version [%s] and Client version [%s]",
+            self.server_version,
+            self.client_version,
+        )
 
     def create_or_update_settings(self, settings: Settings) -> Settings:
         """Create of update setting

--- a/ingestion/src/metadata/utils/streamable_logger.py
+++ b/ingestion/src/metadata/utils/streamable_logger.py
@@ -149,6 +149,9 @@ class StreamableLogHandler(logging.Handler):
             batch = [self._buffer.get(timeout=timeout)] if timeout > 0 else [self._buffer.get_nowait()]
         except Empty:
             return []
+        # Claim "in flight" the moment we own a batch so flush() can't return
+        # in the gap between dequeue and the POST starting.
+        self._post_in_flight.set()
         while len(batch) < self.BATCH_SIZE:
             try:
                 batch.append(self._buffer.get_nowait())

--- a/ingestion/src/metadata/utils/streamable_logger.py
+++ b/ingestion/src/metadata/utils/streamable_logger.py
@@ -42,6 +42,9 @@ class StreamableLogHandler(logging.Handler):
     BATCH_WAIT_SEC = 2.0
     HTTP_TIMEOUT = (2.0, 10.0)
     CLOSE_TIMEOUT_SEC = 30.0
+    FLUSH_DEFAULT_SEC = 5.0  # flush() default deadline
+    FLUSH_POLL_SEC = 0.05  # how often flush() rechecks state
+    FORCE_STOP_JOIN_SEC = 2.0  # secondary worker join after force-stop
 
     # pylint: disable=too-many-arguments,too-many-instance-attributes
     def __init__(
@@ -179,15 +182,17 @@ class StreamableLogHandler(logging.Handler):
             _shipping_state.shipping = False
             self._post_in_flight.clear()
 
-    def flush(self, timeout: float = 5.0) -> None:
+    def flush(self, timeout: float | None = None) -> None:
         """Block until queue is drained, or until deadline."""
         if not self.enable_streaming or self._worker is None:
             return
-        deadline = time.monotonic() + timeout
+        deadline = time.monotonic() + (timeout if timeout is not None else self.FLUSH_DEFAULT_SEC)
         while time.monotonic() < deadline:
             if self._buffer.empty() and not self._post_in_flight.is_set():
                 return
-            time.sleep(0.05)
+            # Poll: no single condition covers both "buffer drained" and
+            # "in-flight POST returned", so we re-check at FLUSH_POLL_SEC.
+            time.sleep(self.FLUSH_POLL_SEC)
         self.flush_timed_out += 1
 
     def shutdown(self, timeout: float | None = None) -> None:
@@ -224,7 +229,7 @@ class StreamableLogHandler(logging.Handler):
                 with contextlib.suppress(Exception):
                     if self._client is not None:
                         self._client.close()
-                self._worker.join(timeout=2.0)
+                self._worker.join(timeout=self.FORCE_STOP_JOIN_SEC)
                 with contextlib.suppress(Exception):
                     self._client = REST(self.metadata.client.config)
 

--- a/ingestion/src/metadata/utils/streamable_logger.py
+++ b/ingestion/src/metadata/utils/streamable_logger.py
@@ -10,9 +10,11 @@
 #  limitations under the License.
 """Best-effort streamable log handler for OpenMetadata ingestion pipelines."""
 
+import atexit
 import contextlib
 import logging
 import threading
+import time
 from queue import Empty, Full, Queue
 from typing import Optional
 from uuid import UUID
@@ -27,19 +29,19 @@ logger = ingestion_logger()
 # Recursion guard: sender threads set shipping=True so emit() returns
 # immediately if it ever fires from inside the shipping path.
 _shipping_state = threading.local()
-_CLOSE_MARKER = object()
 
 
 class StreamableLogHandler(logging.Handler):
-    """Fire-and-forget log shipper."""
+    """Ship ingestion log records to the OM server.
+
+    Caller invokes shutdown() to flush and close synchronously; an atexit
+    hook covers callers that forget.
+    """
 
     BATCH_SIZE = 500
     BATCH_WAIT_SEC = 2.0
-    SENDER_TICK_SEC = 1.0
-    HTTP_TIMEOUT = (1.0, 2.0)
-    SENDER_WORKERS = 1
-    MAX_PENDING_BATCHES = 4
-    CLOSE_TIMEOUT_SEC = 2.0
+    HTTP_TIMEOUT = (2.0, 10.0)
+    CLOSE_TIMEOUT_SEC = 30.0
 
     # pylint: disable=too-many-arguments,too-many-instance-attributes
     def __init__(
@@ -47,7 +49,7 @@ class StreamableLogHandler(logging.Handler):
         metadata: OpenMetadata,
         pipeline_fqn: str,
         run_id: UUID,
-        max_buffer: int = 10000,
+        max_buffer: int = 30_000,
         enable_streaming: bool = True,
     ):
         super().__init__()
@@ -59,11 +61,10 @@ class StreamableLogHandler(logging.Handler):
         self.fallback_handler = logging.StreamHandler()
 
         self._buffer: Queue = Queue(maxsize=max_buffer)
-        self._send_queue: Queue = Queue(maxsize=self.MAX_PENDING_BATCHES)
-        self._stop = threading.Event()
+        self._stop_event = threading.Event()
         self._closed = False
-        self._drainer: Optional[threading.Thread] = None  # noqa: UP045
-        self._senders: list = []
+        self._worker: Optional[threading.Thread] = None  # noqa: UP045
+        self._post_in_flight = threading.Event()
 
         # Isolated session/connection pool; shares ClientConfig so token
         # refresh on the main client is visible here.
@@ -71,64 +72,81 @@ class StreamableLogHandler(logging.Handler):
             REST(metadata.client.config) if enable_streaming else None
         )
 
+        # Counters surfaced at shutdown.
+        self.shipped_records = 0
+        self.shipped_batches = 0
+        self.failed_posts = 0
         self.dropped_overflow = 0
-        self.dropped_saturated = 0
-        self.dropped_shipping = 0
         self.dropped_after_close = 0
+        self.dropped_shipping = 0
         self.dropped_format_error = 0
+        self.flush_timed_out = 0
+        self.shutdown_timed_out = 0
+        self.worker_errors = 0
 
+        self._atexit_registered = False
         if self.enable_streaming:
-            self._start_workers()
-
-    def _start_workers(self):
-        self._drainer = threading.Thread(
-            target=self._drain_loop,
-            daemon=True,
-            name=f"log-drain-{self.pipeline_fqn[:24]}",
-        )
-        self._drainer.start()
-        for i in range(self.SENDER_WORKERS):
-            t = threading.Thread(
-                target=self._sender_loop,
+            # daemon=True so a hung OM can't block process exit; atexit +
+            # shutdown() handle the normal-exit drain.
+            self._worker = threading.Thread(
+                target=self._worker_loop,
                 daemon=True,
-                name=f"log-ship-{self.pipeline_fqn[:16]}-{i}",
+                name=f"log-ship-{self.pipeline_fqn[:24]}",
             )
-            t.start()
-            self._senders.append(t)
+            self._worker.start()
+            atexit.register(self.shutdown)
+            self._atexit_registered = True
 
     def emit(self, record: logging.LogRecord):
-        # Recursion guard must be the very first check.
+        # Recursion guard: shipping thread must not enqueue while shipping.
         if getattr(_shipping_state, "shipping", False):
             self.dropped_shipping += 1
             return
         if self._closed:
             self.dropped_after_close += 1
             return
+        if not self.enable_streaming:
+            self.fallback_handler.emit(record)
+            return
         try:
-            if not self.enable_streaming:
-                self.fallback_handler.emit(record)
-                return
             log_entry = self.format(record)
-            try:
-                self._buffer.put_nowait(log_entry)
-            except Full:
-                self.dropped_overflow += 1
         except Exception:
             self.dropped_format_error += 1
-
-    def _drain_loop(self):
-        while not self._stop.is_set():
-            batch = self._collect_batch()
-            if not batch:
-                continue
-            try:
-                self._send_queue.put_nowait(batch)
-            except Full:
-                self.dropped_saturated += len(batch)
-
-    def _collect_batch(self) -> list:
+            return
+        # Drop fast on full buffer — must not block the producer.
         try:
-            batch = [self._buffer.get(timeout=self.BATCH_WAIT_SEC)]
+            self._buffer.put_nowait(log_entry)
+        except Full:
+            self.dropped_overflow += 1
+
+    def _worker_loop(self):
+        try:
+            while not self._stop_event.is_set():
+                # Catch per-iteration so a single failure can't kill the worker.
+                try:
+                    batch = self._collect_batch(timeout=self.BATCH_WAIT_SEC)
+                    if batch:
+                        self._post_batch(batch)
+                except Exception:
+                    self.worker_errors += 1
+            while True:
+                try:
+                    batch = self._collect_batch(timeout=0)
+                    if not batch:
+                        break
+                    self._post_batch(batch)
+                except Exception:
+                    self.worker_errors += 1
+                    # Persistent failure during drain: bail to avoid infinite loop.
+                    break
+        finally:
+            with contextlib.suppress(Exception):
+                if self._client is not None:
+                    self._client.close()
+
+    def _collect_batch(self, timeout: float) -> list:
+        try:
+            batch = [self._buffer.get(timeout=timeout)] if timeout > 0 else [self._buffer.get_nowait()]
         except Empty:
             return []
         while len(batch) < self.BATCH_SIZE:
@@ -138,83 +156,140 @@ class StreamableLogHandler(logging.Handler):
                 break
         return batch
 
-    def _sender_loop(self):
-        try:
-            while True:
-                try:
-                    item = self._send_queue.get(timeout=self.SENDER_TICK_SEC)
-                except Empty:
-                    if self._stop.is_set():
-                        return
-                    continue
-                if item is _CLOSE_MARKER:
-                    self._notify_close()
-                    return
-                self._post_batch(item)
-        finally:
-            with contextlib.suppress(Exception):
-                if self._client is not None:
-                    self._client.close()
-
     def _post_batch(self, batch: list):
+        self._post_in_flight.set()
         _shipping_state.shipping = True
         try:
-            self.metadata.send_logs_batch_best_effort(
+            ok = self.metadata.send_logs_batch_best_effort(
                 pipeline_fqn=self.pipeline_fqn,
                 run_id=self.run_id,
                 log_content="\n".join(batch) + "\n",
                 timeout=self.HTTP_TIMEOUT,
                 client=self._client,
             )
+            if ok:
+                self.shipped_records += len(batch)
+                self.shipped_batches += 1
+            else:
+                self.failed_posts += 1
         finally:
             _shipping_state.shipping = False
+            self._post_in_flight.clear()
 
-    def close(self):
+    def flush(self, timeout: float = 5.0) -> None:
+        """Block until queue is drained, or until deadline."""
+        if not self.enable_streaming or self._worker is None:
+            return
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            if self._buffer.empty() and not self._post_in_flight.is_set():
+                return
+            time.sleep(0.05)
+        self.flush_timed_out += 1
+
+    def shutdown(self, timeout: float | None = None) -> None:
+        """Synchronous flush + close. Idempotent."""
         if self._closed:
             return
         self._closed = True
 
-        if self.enable_streaming:
-            self._drain_remaining_buffer()
-            with contextlib.suppress(Full):
-                self._send_queue.put_nowait(_CLOSE_MARKER)
+        if self._atexit_registered:
+            with contextlib.suppress(Exception):
+                atexit.unregister(self.shutdown)
+            self._atexit_registered = False
 
-        # Set _stop AFTER enqueueing — sender's get(timeout) Empty branch
-        # checks _stop, so setting it first can race the enqueue and drop
-        # the CLOSE_MARKER on a quiet send queue.
-        self._stop.set()
+        if not self.enable_streaming:
+            self._print_shutdown_metrics(self._format_shutdown_metrics())
+            with contextlib.suppress(Exception):
+                self.fallback_handler.close()
+            super().close()
+            return
 
+        deadline_total = timeout if timeout is not None else self.CLOSE_TIMEOUT_SEC
+        flush_budget = deadline_total / 2
+        self.flush(timeout=flush_budget)
+
+        self._stop_event.set()
+        if self._worker is not None:
+            self._worker.join(timeout=deadline_total - flush_budget)
+            if self._worker.is_alive():
+                self.shutdown_timed_out += 1
+                # Force-stop the worker by closing its session so any in-flight
+                # POST raises; the worker then exits via _stop_event. Open a
+                # fresh REST so the metrics + /close POSTs below have a session
+                # that the dying worker can't race.
+                with contextlib.suppress(Exception):
+                    if self._client is not None:
+                        self._client.close()
+                self._worker.join(timeout=2.0)
+                with contextlib.suppress(Exception):
+                    self._client = REST(self.metadata.client.config)
+
+        metrics_line = self._format_shutdown_metrics()
+        with contextlib.suppress(Exception):
+            _shipping_state.shipping = True
+            try:
+                self.metadata.send_logs_batch_best_effort(
+                    pipeline_fqn=self.pipeline_fqn,
+                    run_id=self.run_id,
+                    log_content=metrics_line + "\n",
+                    timeout=self.HTTP_TIMEOUT,
+                    client=self._client,
+                )
+            finally:
+                _shipping_state.shipping = False
+
+        with contextlib.suppress(Exception):
+            _shipping_state.shipping = True
+            try:
+                self.metadata.send_close_best_effort(
+                    pipeline_fqn=self.pipeline_fqn,
+                    run_id=self.run_id,
+                    timeout=(2.0, self.CLOSE_TIMEOUT_SEC),
+                    client=self._client,
+                )
+            finally:
+                _shipping_state.shipping = False
+
+        self._print_shutdown_metrics(metrics_line)
         with contextlib.suppress(Exception):
             self.fallback_handler.close()
         super().close()
 
-    def _drain_remaining_buffer(self):
-        while True:
-            batch = []
-            while len(batch) < self.BATCH_SIZE:
-                try:
-                    batch.append(self._buffer.get_nowait())
-                except Empty:
-                    break
-            if not batch:
-                return
-            try:
-                self._send_queue.put_nowait(batch)
-            except Full:
-                self.dropped_saturated += len(batch)
-                return
+    def close(self):
+        self.shutdown()
 
-    def _notify_close(self):
-        _shipping_state.shipping = True
+    def _format_shutdown_metrics(self) -> str:
+        lines = [
+            "streamable_logger shutdown:",
+            f"  shipped:  records={self.shipped_records} batches={self.shipped_batches}",
+            f"  failed:   posts={self.failed_posts}",
+            (
+                f"  dropped:  overflow={self.dropped_overflow}"
+                f" after_close={self.dropped_after_close}"
+                f" shipping={self.dropped_shipping}"
+                f" format_error={self.dropped_format_error}"
+            ),
+            f"  errors:   worker={self.worker_errors}",
+            f"  timeouts: flush={self.flush_timed_out} shutdown={self.shutdown_timed_out}",
+        ]
+        return "\n".join(lines)
+
+    def _print_shutdown_metrics(self, msg: str) -> None:
+        """Print metrics to stderr via the fallback handler."""
         try:
-            self.metadata.send_close_best_effort(
-                pipeline_fqn=self.pipeline_fqn,
-                run_id=self.run_id,
-                timeout=(1.0, self.CLOSE_TIMEOUT_SEC),
-                client=self._client,
+            record = logging.LogRecord(
+                name=METADATA_LOGGER,
+                level=logging.INFO,
+                pathname=__file__,
+                lineno=0,
+                msg=msg,
+                args=None,
+                exc_info=None,
             )
-        finally:
-            _shipping_state.shipping = False
+            self.fallback_handler.emit(record)
+        except Exception:
+            pass
 
 
 class StreamableLogHandlerManager:
@@ -256,8 +331,10 @@ def setup_streamable_logging_for_workflow(
 ) -> Optional[StreamableLogHandler]:  # noqa: UP045
     if not enable_streaming or not pipeline_fqn or not run_id:
         logger.debug(
-            f"Streamable logging not configured: enable={enable_streaming}, "
-            f"pipeline_fqn={pipeline_fqn}, run_id={run_id}"
+            "Streamable logging not configured: enable=%s, pipeline_fqn=%s, run_id=%s",
+            enable_streaming,
+            pipeline_fqn,
+            run_id,
         )
         return None
 
@@ -281,11 +358,15 @@ def setup_streamable_logging_for_workflow(
         metadata_logger.addHandler(handler)
         StreamableLogHandlerManager.set_handler(handler)
 
-        logger.info(f"Streamable logging configured for pipeline: {pipeline_fqn}, run_id: {model_str(run_id)}")
+        logger.info(
+            "Streamable logging configured for pipeline: %s, run_id: %s",
+            pipeline_fqn,
+            model_str(run_id),
+        )
         return handler  # noqa: TRY300
 
     except Exception as e:
-        logger.warning(f"Failed to setup streamable logging: {e}")
+        logger.warning("Failed to setup streamable logging: %s", e)
         return None
 
 

--- a/ingestion/src/metadata/utils/streamable_logger.py
+++ b/ingestion/src/metadata/utils/streamable_logger.py
@@ -196,7 +196,13 @@ class StreamableLogHandler(logging.Handler):
         self.flush_timed_out += 1
 
     def shutdown(self, timeout: float | None = None) -> None:
-        """Synchronous flush + close. Idempotent."""
+        """Synchronous flush + close. Idempotent.
+
+        `timeout` bounds the flush + worker-join phases. The post-stop metrics
+        POST and `/close` POST each carry their own HTTP timeouts on top, so
+        the total wall-time can be up to roughly `timeout + 2 * HTTP read`
+        (~`timeout + 32s` with defaults) in pathological cases.
+        """
         if self._closed:
             return
         self._closed = True
@@ -217,21 +223,22 @@ class StreamableLogHandler(logging.Handler):
         flush_budget = deadline_total / 2
         self.flush(timeout=flush_budget)
 
+        # Default: worker still owns self._client. If we force-stop the
+        # worker below, we use a LOCAL fresh REST for the post-stop POSTs so
+        # the dying worker's finally (which closes self._client) can't close
+        # the session under the main thread.
+        post_close_client = self._client
         self._stop_event.set()
         if self._worker is not None:
             self._worker.join(timeout=deadline_total - flush_budget)
             if self._worker.is_alive():
                 self.shutdown_timed_out += 1
-                # Force-stop the worker by closing its session so any in-flight
-                # POST raises; the worker then exits via _stop_event. Open a
-                # fresh REST so the metrics + /close POSTs below have a session
-                # that the dying worker can't race.
                 with contextlib.suppress(Exception):
                     if self._client is not None:
                         self._client.close()
                 self._worker.join(timeout=self.FORCE_STOP_JOIN_SEC)
                 with contextlib.suppress(Exception):
-                    self._client = REST(self.metadata.client.config)
+                    post_close_client = REST(self.metadata.client.config)
 
         metrics_line = self._format_shutdown_metrics()
         with contextlib.suppress(Exception):
@@ -242,7 +249,7 @@ class StreamableLogHandler(logging.Handler):
                     run_id=self.run_id,
                     log_content=metrics_line + "\n",
                     timeout=self.HTTP_TIMEOUT,
-                    client=self._client,
+                    client=post_close_client,
                 )
             finally:
                 _shipping_state.shipping = False
@@ -254,7 +261,7 @@ class StreamableLogHandler(logging.Handler):
                     pipeline_fqn=self.pipeline_fqn,
                     run_id=self.run_id,
                     timeout=(2.0, self.CLOSE_TIMEOUT_SEC),
-                    client=self._client,
+                    client=post_close_client,
                 )
             finally:
                 _shipping_state.shipping = False

--- a/ingestion/src/metadata/workflow/base.py
+++ b/ingestion/src/metadata/workflow/base.py
@@ -128,6 +128,9 @@ class BaseWorkflow(ABC, WorkflowStatusMixin):
                 enable_streaming=True,
             )
 
+        # Emit after the streamable handler is installed so the line is captured.
+        self.metadata.log_server_version()
+
         self._log_workflow_execution_info()
 
         # Set run context for operation metrics tracking
@@ -166,9 +169,6 @@ class BaseWorkflow(ABC, WorkflowStatusMixin):
         # Stop the timer first. This runs in a separate thread and if not properly closed
         # it can hung the workflow
         self.timer.stop()
-
-        # Cleanup streamable logging if it was configured
-        cleanup_streamable_logging()
 
         # Reset progress and metrics tracking singletons
         ProgressTrackerState().reset()
@@ -280,9 +280,13 @@ class BaseWorkflow(ABC, WorkflowStatusMixin):
             ingestion_status = self.build_ingestion_status()
             self.set_ingestion_pipeline_status(pipeline_state, ingestion_status)
             try:
-                self.print_status()
+                try:
+                    self.print_status()
+                finally:
+                    self.stop()
             finally:
-                self.stop()
+                # Must run after every other emitter so the tail is captured.
+                cleanup_streamable_logging()
 
     @property
     def run_id(self) -> str:

--- a/ingestion/tests/unit/conftest.py
+++ b/ingestion/tests/unit/conftest.py
@@ -12,14 +12,18 @@ from pytest import fixture
 import metadata  # noqa: F401
 
 # Prevent unit tests from connecting to the OpenMetadata server.
-# There are two code paths that trigger HTTP calls to localhost:8585:
+# Three code paths trigger HTTP calls to localhost:8585:
 #   1. OpenMetadata.__init__() → validate_versions() → GET /system/version
-#   2. create_ometa_client() → health_check() → GET /system/version
-# Unit tests don't need either — they test transformation logic.
+#   2. Workflow.__init__() → metadata.log_server_version() → GET /system/version
+#   3. create_ometa_client() → health_check() → GET /system/version
+# Unit tests don't need any — they test transformation logic.
 # TODO: Once topology/workflow/profiler tests are migrated from TestCase to pytest,
 #       replace these with a session-scoped fixture.
 _mock_validate = patch("metadata.ingestion.ometa.ometa_api.OpenMetadata.validate_versions")
 _mock_validate.start()
+
+_mock_log_server_version = patch("metadata.ingestion.ometa.ometa_api.OpenMetadata.log_server_version")
+_mock_log_server_version.start()
 
 _mock_health = patch("metadata.ingestion.ometa.ometa_api.OpenMetadata.health_check")
 _mock_health.start()

--- a/ingestion/tests/unit/utils/test_streamable_logger.py
+++ b/ingestion/tests/unit/utils/test_streamable_logger.py
@@ -356,6 +356,23 @@ def test_flush_times_out_when_post_is_slow(make_v2, fake_ometa):
     assert handler.flush_timed_out == 1
 
 
+def test_flush_does_not_return_in_dequeue_post_gap(make_v2, fake_ometa):
+    """Regression: flush() must NOT report drained while a batch the worker
+    just dequeued hasn't started POSTing yet (TOCTOU between buffer.get() and
+    _post_in_flight.set())."""
+    fake_ometa.post_delay = 0.5
+    handler = make_v2()
+    handler.emit(_make_record("payload"))
+
+    # Long enough that the worker has dequeued + started its slow POST.
+    handler.flush(timeout=2.0)
+
+    # If the race fires, flush() returns before the POST runs and the fake
+    # records zero shipped batches.
+    assert len(fake_ometa.shipped_batches) >= 1
+    assert handler.flush_timed_out == 0
+
+
 # ----- Group 3: shutdown lifecycle -----
 
 

--- a/ingestion/tests/unit/utils/test_streamable_logger.py
+++ b/ingestion/tests/unit/utils/test_streamable_logger.py
@@ -10,12 +10,14 @@
 #  limitations under the License.
 """Unit tests for the streamable logger module."""
 
+import contextlib
 import logging
-import threading
 import time
 import unittest
-from unittest.mock import MagicMock, Mock, patch
+from unittest.mock import Mock, patch
 from uuid import uuid4
+
+import pytest
 
 from metadata.ingestion.ometa.ometa_api import OpenMetadata
 from metadata.utils.streamable_logger import (
@@ -39,482 +41,18 @@ def _make_record(msg="test message", level=logging.INFO):
     )
 
 
-def _make_metadata_mock():
-    """Build a Mock that satisfies StreamableLogHandler's needs:
-    - send_logs_batch_best_effort / send_close_best_effort attrs
-    - .client.config (real ClientConfig) so handler can build its own REST"""
-    from metadata.ingestion.ometa.client import ClientConfig
-
-    metadata = Mock(spec=OpenMetadata)
-    metadata.client = Mock()
-    metadata.client.config = ClientConfig(base_url="http://localhost:8585")
-    metadata.send_logs_batch_best_effort = Mock(return_value=True)
-    metadata.send_close_best_effort = Mock(return_value=True)
-    return metadata
-
-
-def _make_handler(
-    metadata=None,
-    pipeline_fqn="test.pipeline",
-    run_id=None,
-    max_buffer=10000,
-    enable_streaming=False,
-):
-    if metadata is None:
-        metadata = _make_metadata_mock()
+def _make_handler(enable_streaming=False, pipeline_fqn="test.pipeline", run_id=None):
+    """Minimal handler for Manager/setup tests where the worker isn't exercised.
+    enable_streaming=False keeps __init__ from building a REST client or
+    starting the worker thread."""
     if run_id is None:
         run_id = uuid4()
-    handler = StreamableLogHandler(
-        metadata=metadata,
+    return StreamableLogHandler(
+        metadata=Mock(spec=OpenMetadata),
         pipeline_fqn=pipeline_fqn,
         run_id=run_id,
-        max_buffer=max_buffer,
         enable_streaming=enable_streaming,
     )
-    handler.setFormatter(logging.Formatter("%(message)s"))
-    return handler
-
-
-def _stop_workers(handler):
-    """Signal stop and give the drainer/senders a moment to notice.
-    Used in tests that need a quiescent handler. We don't .join() in
-    production close() - see TestNoWaitClose - but in tests we want
-    to be sure background threads aren't going to race assertions."""
-    handler._stop.set()
-    if handler._drainer:
-        handler._drainer.join(timeout=3)
-    for t in handler._senders:
-        t.join(timeout=3)
-
-
-class TestEmitNonBlocking(unittest.TestCase):
-    """emit() must be fast and must never raise."""
-
-    def test_emit_with_streaming_disabled_goes_to_fallback(self):
-        handler = _make_handler(enable_streaming=False)
-        handler.fallback_handler = Mock()
-        record = _make_record()
-
-        handler.emit(record)
-
-        handler.fallback_handler.emit.assert_called_once_with(record)
-
-    def test_emit_with_streaming_enabled_queues_to_buffer(self):
-        handler = _make_handler(enable_streaming=True)
-        _stop_workers(handler)
-
-        handler.emit(_make_record("log A"))
-        handler.emit(_make_record("log B"))
-
-        self.assertEqual(handler._buffer.qsize(), 2)
-        handler.close()
-
-    def test_emit_drops_silently_when_buffer_full(self):
-        """No stderr fallback per record on overflow - only a counter."""
-        handler = _make_handler(max_buffer=1, enable_streaming=True)
-        _stop_workers(handler)
-        handler.fallback_handler = Mock()
-        handler._buffer.put_nowait("already-here")
-
-        start = time.monotonic()
-        handler.emit(_make_record("overflow"))
-        elapsed = time.monotonic() - start
-
-        self.assertLess(elapsed, 0.05, "emit() must return immediately on overflow")
-        handler.fallback_handler.emit.assert_not_called()
-        self.assertEqual(handler.dropped_overflow, 1)
-
-    def test_emit_never_raises_when_format_fails(self):
-        handler = _make_handler(enable_streaming=True)
-        _stop_workers(handler)
-        handler.format = Mock(side_effect=ValueError("boom"))
-
-        handler.emit(_make_record())
-
-        self.assertEqual(handler.dropped_format_error, 1)
-        self.assertEqual(handler.dropped_overflow, 0)
-        handler.close()
-
-    def test_emit_after_close_increments_dedicated_counter(self):
-        handler = _make_handler(enable_streaming=True)
-        handler.close()
-        handler.emit(_make_record("post-close"))
-        self.assertEqual(handler.dropped_after_close, 1)
-        self.assertEqual(handler.dropped_overflow, 0)
-        self.assertEqual(handler.dropped_format_error, 0)
-
-    def test_emit_returns_quickly_under_high_volume(self):
-        handler = _make_handler(max_buffer=10000, enable_streaming=True)
-        _stop_workers(handler)
-
-        start = time.monotonic()
-        for i in range(1000):
-            handler.emit(_make_record(f"msg-{i}"))
-        elapsed = time.monotonic() - start
-
-        self.assertLess(elapsed, 0.5, f"1000 emits took {elapsed:.3f}s - too slow")
-
-
-class TestRecursionGuard(unittest.TestCase):
-    """The thread-local guard prevents emit() from re-entering itself
-    even if a future change reintroduces logging on the shipping path."""
-
-    def tearDown(self):
-        # Make sure the guard is clear after each test.
-        if hasattr(_shipping_state, "shipping"):
-            _shipping_state.shipping = False
-
-    def test_emit_drops_when_shipping_flag_set(self):
-        handler = _make_handler(enable_streaming=True)
-        _stop_workers(handler)
-
-        _shipping_state.shipping = True
-        try:
-            handler.emit(_make_record("would-recurse"))
-        finally:
-            _shipping_state.shipping = False
-
-        self.assertEqual(handler._buffer.qsize(), 0)
-        self.assertEqual(handler.dropped_shipping, 1)
-
-    def test_post_thread_sets_and_clears_shipping_flag(self):
-        seen_flag = {"value": None}
-
-        def capture(*_, **__):
-            seen_flag["value"] = getattr(_shipping_state, "shipping", False)
-            return True
-
-        metadata = _make_metadata_mock()
-        metadata.send_logs_batch_best_effort = Mock(side_effect=capture)
-        metadata.send_close_best_effort = Mock(return_value=True)
-
-        handler = _make_handler(metadata=metadata, enable_streaming=True)
-        handler.emit(_make_record("trigger"))
-        for _ in range(50):
-            if metadata.send_logs_batch_best_effort.called:
-                break
-            time.sleep(0.05)
-
-        self.assertTrue(seen_flag["value"], "shipping flag must be True inside the sender")
-        handler.close()
-        # Flag must be cleared after the sender returns. Give the
-        # sender thread a moment to hit its finally block.
-        time.sleep(0.1)
-        self.assertFalse(getattr(_shipping_state, "shipping", False))
-
-
-class TestSenderPool(unittest.TestCase):
-    """Bounded send queue. Drainer never waits on a POST."""
-
-    def test_drainer_does_not_wait_on_slow_post(self):
-        slow_event = threading.Event()
-        post_started = threading.Event()
-
-        def slow_send(*_, **__):
-            post_started.set()
-            slow_event.wait(timeout=30)
-            return True
-
-        metadata = _make_metadata_mock()
-        metadata.send_logs_batch_best_effort = Mock(side_effect=slow_send)
-        metadata.send_close_best_effort = Mock(return_value=True)
-
-        handler = _make_handler(metadata=metadata, enable_streaming=True)
-        handler.emit(_make_record("first"))
-        self.assertTrue(post_started.wait(timeout=5))
-
-        start = time.monotonic()
-        for i in range(50):
-            handler.emit(_make_record(f"hangs-{i}"))
-        elapsed = time.monotonic() - start
-
-        self.assertLess(elapsed, 0.5, "emits must not block while a POST is hanging")
-
-        handler._stop.set()
-        slow_event.set()
-        handler._drainer.join(timeout=5)
-
-    def test_saturated_sender_drops_batches(self):
-        """When senders + send queue are full on a dead server, the drainer
-        drops new batches and counts them. No unbounded growth."""
-        hang = threading.Event()  # never set during the test
-
-        def block_forever(*_, **__):
-            hang.wait(timeout=30)
-            return True
-
-        metadata = _make_metadata_mock()
-        metadata.send_logs_batch_best_effort = Mock(side_effect=block_forever)
-        metadata.send_close_best_effort = Mock(return_value=True)
-
-        handler = _make_handler(metadata=metadata, enable_streaming=True)
-        # Make the test cycle faster than defaults.
-        handler.BATCH_WAIT_SEC = 0.1
-
-        # Pump 20 separately-timed batches; each wave > BATCH_WAIT_SEC so
-        # the drainer ships each as its own batch. Senders block forever
-        # on the first MAX_PENDING_BATCHES + SENDER_WORKERS; everything
-        # after that must be dropped at drainer-submit time.
-        total_waves = handler.MAX_PENDING_BATCHES + handler.SENDER_WORKERS + 10
-        for wave in range(total_waves):
-            handler.emit(_make_record(f"wave-{wave}"))
-            time.sleep(0.2)
-
-        # At least some batches must have been dropped at the send-queue
-        # boundary - we sent way more than the cap.
-        self.assertGreater(handler.dropped_saturated, 0, "saturated drainer must have dropped at least one batch")
-        # In-flight POSTs bounded by SENDER_WORKERS (others wait in queue
-        # but don't actually call send_logs_batch_best_effort).
-        self.assertLessEqual(
-            metadata.send_logs_batch_best_effort.call_count,
-            handler.SENDER_WORKERS,
-        )
-
-        handler._stop.set()
-        hang.set()
-
-    def test_close_notify_is_ordered_after_in_flight_log_batch(self):
-        """Regression for the close-vs-late-POST race. /close must not
-        overtake an already-started log batch, otherwise the server can
-        finalize logs.txt and then receive a late tail batch."""
-        log_started = threading.Event()
-        release_log = threading.Event()
-        close_called = threading.Event()
-
-        def slow_log_send(*_, **__):
-            log_started.set()
-            release_log.wait(timeout=30)
-            return True
-
-        def close_send(*_, **__):
-            close_called.set()
-            return True
-
-        metadata = _make_metadata_mock()
-        metadata.send_logs_batch_best_effort = Mock(side_effect=slow_log_send)
-        metadata.send_close_best_effort = Mock(side_effect=close_send)
-
-        handler = _make_handler(metadata=metadata, enable_streaming=True)
-        handler.emit(_make_record("first"))
-        self.assertTrue(log_started.wait(timeout=5))
-
-        start = time.monotonic()
-        handler.close()
-        elapsed = time.monotonic() - start
-
-        self.assertLess(elapsed, 0.1, "close() must still return immediately")
-        time.sleep(0.2)
-        self.assertFalse(
-            close_called.is_set(),
-            "/close must wait behind the in-flight log batch in the sender queue",
-        )
-
-        release_log.set()
-        self.assertTrue(close_called.wait(timeout=5))
-
-
-class TestDaemonThreads(unittest.TestCase):
-    """All background threads MUST be daemon, otherwise a wedged sender
-    can keep the ingestion process alive past main-thread exit."""
-
-    def test_drainer_thread_is_daemon(self):
-        handler = _make_handler(enable_streaming=True)
-        self.assertTrue(handler._drainer.daemon, "drainer must be a daemon thread")
-        handler.close()
-
-    def test_sender_threads_are_daemon(self):
-        handler = _make_handler(enable_streaming=True)
-        self.assertEqual(len(handler._senders), handler.SENDER_WORKERS)
-        for t in handler._senders:
-            self.assertTrue(t.daemon, f"sender {t.name} must be daemon")
-        handler.close()
-
-    def test_close_notify_thread_is_daemon(self):
-        """The /close call goes out on a daemon so close() doesn't wait."""
-        seen = {"daemon": None}
-
-        def capture(*_, **__):
-            seen["daemon"] = threading.current_thread().daemon
-            return True
-
-        metadata = _make_metadata_mock()
-        metadata.send_logs_batch_best_effort = Mock(return_value=True)
-        metadata.send_close_best_effort = Mock(side_effect=capture)
-
-        handler = _make_handler(metadata=metadata, enable_streaming=True)
-        handler.close()
-        for _ in range(50):
-            if seen["daemon"] is not None:
-                break
-            time.sleep(0.05)
-        self.assertTrue(seen["daemon"], "close notify must run on a daemon sender thread")
-
-
-class TestIsolatedClient(unittest.TestCase):
-    """The handler must use its OWN REST instance (own session/cookies/
-    connection pool), not the main metadata client's."""
-
-    def test_handler_creates_dedicated_rest_client(self):
-        from metadata.ingestion.ometa.client import REST
-
-        metadata = Mock(spec=OpenMetadata)
-        # Give the mock client a real ClientConfig so REST() can copy it.
-        from metadata.ingestion.ometa.client import ClientConfig
-
-        metadata.client = Mock()
-        metadata.client.config = ClientConfig(base_url="http://localhost:8585")
-        metadata.send_logs_batch_best_effort = Mock(return_value=True)
-        metadata.send_close_best_effort = Mock(return_value=True)
-
-        handler = _make_handler(metadata=metadata, enable_streaming=True)
-
-        self.assertIsInstance(handler._client, REST)
-        self.assertIsNot(handler._client, metadata.client, "handler must own a SEPARATE REST instance")
-        self.assertIsNot(handler._client._session, metadata.client, "handler's session must not be the main client")
-        handler.close()
-
-    def test_handler_passes_isolated_client_to_post(self):
-        """The send_logs_batch_best_effort call must include the handler's
-        own client kwarg so log shipping doesn't go through the main session."""
-        from metadata.ingestion.ometa.client import ClientConfig
-
-        captured = {"client": None}
-
-        def capture(*_, client=None, **__):
-            captured["client"] = client
-            return True
-
-        metadata = Mock(spec=OpenMetadata)
-        metadata.client = Mock()
-        metadata.client.config = ClientConfig(base_url="http://localhost:8585")
-        metadata.send_logs_batch_best_effort = Mock(side_effect=capture)
-        metadata.send_close_best_effort = Mock(return_value=True)
-
-        handler = _make_handler(metadata=metadata, enable_streaming=True)
-        handler.emit(_make_record("trigger"))
-        for _ in range(50):
-            if metadata.send_logs_batch_best_effort.called:
-                break
-            time.sleep(0.05)
-
-        self.assertIs(
-            captured["client"], handler._client, "handler must pass its own _client to send_logs_batch_best_effort"
-        )
-        handler.close()
-
-    @patch("metadata.utils.streamable_logger.REST")
-    def test_handler_reuses_one_isolated_client_for_all_batches(self, mock_rest):
-        """Persistent connection pool guarantee: construct one isolated REST
-        client per handler, pass that same client for every batch, and close
-        it only when the sender exits."""
-        client = Mock()
-        mock_rest.return_value = client
-
-        metadata = Mock(spec=OpenMetadata)
-        metadata.client = Mock()
-        metadata.client.config = Mock()
-        metadata.send_logs_batch_best_effort = Mock(return_value=True)
-        metadata.send_close_best_effort = Mock(return_value=True)
-
-        handler = _make_handler(metadata=metadata, enable_streaming=True)
-
-        handler._post_batch(["first"])
-        handler._post_batch(["second"])
-
-        mock_rest.assert_called_once_with(metadata.client.config)
-        self.assertEqual(metadata.send_logs_batch_best_effort.call_count, 2)
-        first_call, second_call = metadata.send_logs_batch_best_effort.call_args_list
-        self.assertIs(first_call.kwargs["client"], client)
-        self.assertIs(second_call.kwargs["client"], client)
-        client.close.assert_not_called()
-
-        handler.close()
-
-    def test_isolated_client_is_closed_by_sender_thread(self):
-        metadata = _make_metadata_mock()
-        handler = _make_handler(metadata=metadata, enable_streaming=True)
-        handler._client.close = Mock()
-
-        handler.close()
-        for _ in range(50):
-            if handler._client.close.called:
-                break
-            time.sleep(0.05)
-
-        handler._client.close.assert_called()
-
-
-class TestNoWaitClose(unittest.TestCase):
-    """close() must return effectively instantly. It must NOT join the
-    drainer / senders and must NOT wait on the server /close response."""
-
-    def test_close_returns_in_under_100ms_when_idle(self):
-        handler = _make_handler(enable_streaming=True)
-
-        start = time.monotonic()
-        handler.close()
-        elapsed = time.monotonic() - start
-
-        self.assertLess(
-            elapsed,
-            0.1,
-            f"close() took {elapsed * 1000:.1f}ms - must not block",
-        )
-
-    def test_close_returns_quickly_when_close_endpoint_hangs(self):
-        hang = threading.Event()
-
-        def block_forever(*_, **__):
-            hang.wait(timeout=30)
-            return True
-
-        metadata = _make_metadata_mock()
-        metadata.send_logs_batch_best_effort = Mock(return_value=True)
-        metadata.send_close_best_effort = Mock(side_effect=block_forever)
-
-        handler = _make_handler(metadata=metadata, enable_streaming=True)
-
-        start = time.monotonic()
-        handler.close()
-        elapsed = time.monotonic() - start
-
-        self.assertLess(
-            elapsed,
-            0.1,
-            f"close() took {elapsed * 1000:.1f}ms - must not wait on /close response",
-        )
-        hang.set()
-
-    def test_close_signals_stop(self):
-        handler = _make_handler(enable_streaming=True)
-        handler.close()
-        self.assertTrue(handler._stop.is_set())
-
-    def test_close_is_idempotent(self):
-        handler = _make_handler(enable_streaming=True)
-        handler.close()
-        handler.close()  # must not raise
-
-
-class TestQuietClientPath(unittest.TestCase):
-    """The handler uses the best-effort path that bypasses retries and logging."""
-
-    def test_post_uses_best_effort_method(self):
-        metadata = _make_metadata_mock()
-        metadata.send_logs_batch_best_effort = Mock(return_value=True)
-        metadata.send_close_best_effort = Mock(return_value=True)
-
-        handler = _make_handler(metadata=metadata, enable_streaming=True)
-        handler.emit(_make_record("trigger"))
-        for _ in range(50):
-            if metadata.send_logs_batch_best_effort.called:
-                break
-            time.sleep(0.05)
-
-        self.assertTrue(metadata.send_logs_batch_best_effort.called)
-        kwargs = metadata.send_logs_batch_best_effort.call_args.kwargs
-        self.assertEqual(kwargs["timeout"], StreamableLogHandler.HTTP_TIMEOUT)
-        handler.close()
 
 
 class TestStreamableLogHandlerManager(unittest.TestCase):
@@ -606,215 +144,413 @@ class TestStreamableLoggingSetup(unittest.TestCase):
         self.assertIsNone(result)
 
 
-class TestRecursionRegression(unittest.TestCase):
-    """emit() must run exactly once per producer call even when overflow
-    or format failure would historically have triggered recursive logging."""
+# ============================================================================
+# StreamableLogHandler — pytest-style tests using a fake OMeta transport.
+#
+# These tests drive the full handler lifecycle (emit -> buffer -> worker ->
+# flush -> shutdown -> /close) without any real network or infrastructure.
+# A FakeOMeta records every batch and close call; failure modes are simulated
+# via the post_delay / post_returns / post_raises knobs.
+# ============================================================================
 
-    def setUp(self):
-        self.mock_metadata = _make_metadata_mock()
-        self.test_logger = logging.getLogger(f"test_recursion_{id(self)}")
-        self.test_logger.handlers = []
-        self.test_logger.setLevel(logging.DEBUG)
-        self.test_logger.propagate = False
 
-    def tearDown(self):
-        self.test_logger.handlers = []
+class FakeOMeta:
+    """Test double for OpenMetadata exposing only what the handler uses.
 
-    def _make_handler_with_full_buffer(self):
-        handler = _make_handler(
-            metadata=self.mock_metadata,
-            max_buffer=2,
-            enable_streaming=True,
+    Recorded interactions: shipped_batches (log_content per POST),
+    close_calls (one tuple per /close POST).
+
+    Fault injection knobs:
+      - post_delay: seconds each POST blocks before returning
+      - post_returns: True/False return value for send_logs_batch_best_effort
+      - post_raises: exception class to raise (None to disable)
+      - intermittent_pattern: callable(post_count) -> bool overriding post_returns
+    """
+
+    def __init__(self):
+        from metadata.ingestion.ometa.client import ClientConfig
+
+        fake_client = type("_FakeClient", (), {})()
+        fake_client.config = ClientConfig(base_url="http://test")
+        self.client = fake_client
+        self.shipped_batches: list = []
+        self.close_calls: list = []
+        self.post_delay = 0.0
+        self.post_returns = True
+        self.post_raises = None
+        self.intermittent_pattern = None
+        self._post_counter = 0
+
+    def send_logs_batch_best_effort(self, pipeline_fqn, run_id, log_content, timeout=None, client=None):
+        self._post_counter += 1
+        if self.post_delay:
+            time.sleep(self.post_delay)
+        if self.post_raises is not None:
+            raise self.post_raises("simulated failure")
+        if self.intermittent_pattern is not None:
+            ok = self.intermittent_pattern(self._post_counter)
+        else:
+            ok = self.post_returns
+        if ok:
+            self.shipped_batches.append(log_content)
+        return ok
+
+    def send_close_best_effort(self, pipeline_fqn, run_id, timeout=None, client=None):
+        self.close_calls.append((pipeline_fqn, str(run_id)))
+        return True
+
+
+@pytest.fixture
+def fake_ometa():
+    return FakeOMeta()
+
+
+@pytest.fixture
+def fake_atexit(monkeypatch):
+    """Capture atexit register/unregister calls instead of using the real one."""
+    registered = []
+    unregistered = []
+    monkeypatch.setattr(
+        "metadata.utils.streamable_logger.atexit.register",
+        lambda fn, *a, **k: registered.append(fn),
+    )
+    monkeypatch.setattr(
+        "metadata.utils.streamable_logger.atexit.unregister",
+        unregistered.append,
+    )
+    return {"registered": registered, "unregistered": unregistered}
+
+
+@pytest.fixture
+def fake_rest(monkeypatch):
+    """Mock REST so the P1 force-stop fresh-client path doesn't hit network."""
+    calls = []
+
+    class _FakeREST:
+        def __init__(self, config):
+            calls.append(config)
+            self._closed = False
+
+        def close(self):
+            self._closed = True
+
+    monkeypatch.setattr("metadata.utils.streamable_logger.REST", _FakeREST)
+    return calls
+
+
+@pytest.fixture
+def fast_constants(monkeypatch):
+    """Shrink class-level timeouts so tests run in <1s each."""
+    monkeypatch.setattr(StreamableLogHandler, "BATCH_WAIT_SEC", 0.05)
+    monkeypatch.setattr(StreamableLogHandler, "CLOSE_TIMEOUT_SEC", 1.0)
+    monkeypatch.setattr(StreamableLogHandler, "HTTP_TIMEOUT", (0.2, 1.0))
+
+
+@pytest.fixture
+def make_v2(fake_ometa, fake_atexit, fake_rest, fast_constants):
+    """Factory for fully configured V2 handlers. Cleans up after each test."""
+    handlers = []
+
+    def _make(max_buffer=1000, enable_streaming=True):
+        h = StreamableLogHandler(
+            metadata=fake_ometa,
+            pipeline_fqn="test.pipeline",
+            run_id=uuid4(),
+            max_buffer=max_buffer,
+            enable_streaming=enable_streaming,
         )
-        _stop_workers(handler)
-        handler._buffer.put_nowait("a")
-        handler._buffer.put_nowait("b")
-        self.assertTrue(handler._buffer.full())
-        return handler
+        h.setFormatter(logging.Formatter("%(message)s"))
+        handlers.append(h)
+        return h
 
-    def test_emit_does_not_recurse_when_buffer_full(self):
-        handler = self._make_handler_with_full_buffer()
-        self.test_logger.addHandler(handler)
+    yield _make
 
-        emit_calls = {"n": 0}
-        real_emit = handler.emit
-
-        def counting(record):
-            emit_calls["n"] += 1
-            if emit_calls["n"] > 5:
-                raise AssertionError("emit() recursed — single-call regression")
-            real_emit(record)
-
-        handler.emit = counting
-        start = time.monotonic()
-        self.test_logger.warning("trigger overflow")
-        elapsed = time.monotonic() - start
-
-        self.assertEqual(emit_calls["n"], 1)
-        self.assertLess(elapsed, 1.0)
-
-    def test_emit_does_not_recurse_when_format_raises(self):
-        handler = _make_handler(metadata=self.mock_metadata, enable_streaming=True)
-        _stop_workers(handler)
-        handler.format = MagicMock(side_effect=ValueError("boom"))
-
-        self.test_logger.addHandler(handler)
-        emit_calls = {"n": 0}
-        real_emit = handler.emit
-
-        def counting(record):
-            emit_calls["n"] += 1
-            if emit_calls["n"] > 5:
-                raise AssertionError("emit() recursed via format-failure path")
-            real_emit(record)
-
-        handler.emit = counting
-        start = time.monotonic()
-        self.test_logger.error("trigger format failure")
-        elapsed = time.monotonic() - start
-
-        self.assertEqual(emit_calls["n"], 1)
-        self.assertLess(elapsed, 1.0)
+    for h in handlers:
+        if not h._closed:
+            with contextlib.suppress(Exception):
+                h.shutdown(timeout=1.0)
 
 
-class TestQuietClientPostMixin(unittest.TestCase):
-    """The mixin's best-effort methods must NOT log through ometa_logger
-    (which would propagate back to the streamable handler)."""
-
-    def test_send_logs_batch_best_effort_does_not_log_on_failure(self):
-        from metadata.ingestion.ometa.mixins.logs_mixin import OMetaLogsMixin
-
-        # Build a bare instance and stub the client.
-        instance = OMetaLogsMixin()
-        instance.client = Mock()
-        instance.client.post_best_effort = Mock(return_value=False)
-
-        with patch("metadata.ingestion.ometa.mixins.logs_mixin.logger") as mock_logger:
-            ok = instance.send_logs_batch_best_effort(
-                pipeline_fqn="test",
-                run_id=uuid4(),
-                log_content="x",
-                timeout=(1, 2),
-            )
-
-        self.assertFalse(ok)
-        mock_logger.error.assert_not_called()
-        mock_logger.warning.assert_not_called()
-        mock_logger.info.assert_not_called()
-        mock_logger.debug.assert_not_called()
-
-    def test_send_logs_batch_best_effort_does_not_log_on_exception(self):
-        from metadata.ingestion.ometa.mixins.logs_mixin import OMetaLogsMixin
-
-        instance = OMetaLogsMixin()
-        instance.client = Mock()
-        instance.client.post_best_effort = Mock(side_effect=RuntimeError("boom"))
-
-        with patch("metadata.ingestion.ometa.mixins.logs_mixin.logger") as mock_logger:
-            ok = instance.send_logs_batch_best_effort(
-                pipeline_fqn="test",
-                run_id=uuid4(),
-                log_content="x",
-                timeout=(1, 2),
-            )
-
-        self.assertFalse(ok)
-        mock_logger.error.assert_not_called()
-        mock_logger.warning.assert_not_called()
+def _stop_v2_worker(handler):
+    """Halt the worker without going through shutdown — used to test emit
+    behavior with a quiescent buffer that won't be drained."""
+    handler._stop_event.set()
+    if handler._worker is not None:
+        handler._worker.join(timeout=1.0)
 
 
-class TestClientPostBestEffort(unittest.TestCase):
-    """REST.post_best_effort must NOT enter the retry/sleep loop and
-    must NOT log on failure."""
-
-    def _make_client(self):
-        from metadata.ingestion.ometa.client import REST, ClientConfig
-
-        config = ClientConfig(
-            base_url="http://localhost:8585",
-            api_version="v1",
-            auth_token=lambda: ("token", 60),
-        )
-        client = REST(config)
-        client._session = Mock()
-        return client
-
-    def test_post_best_effort_does_not_sleep_on_504(self):
-        client = self._make_client()
-        resp = Mock()
-        resp.status_code = 504
-        client._session.post = Mock(return_value=resp)
-
-        with patch("time.sleep") as mock_sleep:
-            start = time.monotonic()
-            ok = client.post_best_effort("/path", data="x", timeout=(1, 2))
-            elapsed = time.monotonic() - start
-
-        self.assertFalse(ok)
-        mock_sleep.assert_not_called()
-        self.assertLess(elapsed, 0.2, "post_best_effort must NOT sleep on 504")
-
-    def test_post_best_effort_does_not_log_on_failure(self):
-        client = self._make_client()
-        client._session.post = Mock(side_effect=RuntimeError("network down"))
-
-        with patch("metadata.ingestion.ometa.client.logger") as mock_logger:
-            ok = client.post_best_effort("/path", data="x", timeout=(1, 2))
-
-        self.assertFalse(ok)
-        mock_logger.error.assert_not_called()
-        mock_logger.warning.assert_not_called()
-        mock_logger.info.assert_not_called()
-
-    def test_post_best_effort_returns_true_on_2xx(self):
-        client = self._make_client()
-        resp = Mock()
-        resp.status_code = 200
-        client._session.post = Mock(return_value=resp)
-
-        self.assertTrue(client.post_best_effort("/path", data="x"))
-
-    def test_build_request_headers_does_not_refresh_token(self):
-        """Token refresh stays on _request(); concurrent refresh from the
-        sender would race the main thread on shared ClientConfig."""
-        client = self._make_client()
-        client._auth_token = Mock(return_value=("fresh-token", 60))
-        client.config.expires_in = 0
-        client.config.access_token = "stale-token"
-        client.config.auth_header = "Authorization"
-
-        headers = client._build_request_headers()
-
-        client._auth_token.assert_not_called()
-        self.assertEqual(headers["Authorization"], "Bearer stale-token")
-        self.assertEqual(client.config.expires_in, 0)
+# ----- Group 1: emit / buffer behavior -----
 
 
-class TestCloseOrderingRegression(unittest.TestCase):
-    """close() must enqueue CLOSE_MARKER before setting _stop, otherwise
-    the sender's get(timeout) Empty branch can race the enqueue."""
+def test_emit_drops_when_buffer_full(make_v2):
+    handler = make_v2(max_buffer=2)
+    _stop_v2_worker(handler)
 
-    def test_close_enqueues_marker_before_setting_stop(self):
-        metadata = _make_metadata_mock()
-        handler = _make_handler(metadata=metadata, enable_streaming=True)
-        handler.close()
-        for _ in range(50):
-            if metadata.send_close_best_effort.called:
-                break
-            time.sleep(0.05)
-        metadata.send_close_best_effort.assert_called_once()
+    for i in range(5):
+        handler.emit(_make_record(f"log {i}"))
 
-    def test_close_marker_arrives_even_when_sender_was_idle(self):
-        metadata = _make_metadata_mock()
-        handler = _make_handler(metadata=metadata, enable_streaming=True)
-        time.sleep(0.2)  # let sender enter get(timeout=...)
-        handler.close()
-        for _ in range(50):
-            if metadata.send_close_best_effort.called:
-                break
-            time.sleep(0.05)
-        metadata.send_close_best_effort.assert_called_once()
+    assert handler.dropped_overflow == 3
+    assert handler._buffer.qsize() == 2
 
 
-if __name__ == "__main__":
-    unittest.main()
+def test_emit_drops_after_close(make_v2, fake_ometa):
+    handler = make_v2()
+    handler.shutdown(timeout=1.0)
+
+    handler.emit(_make_record("after close"))
+    handler.emit(_make_record("also after"))
+
+    assert handler.dropped_after_close == 2
+    assert all("after close" not in b and "also after" not in b for b in fake_ometa.shipped_batches)
+
+
+def test_emit_handles_format_error(make_v2):
+    handler = make_v2()
+    _stop_v2_worker(handler)
+
+    bad_record = _make_record("bad")
+    # Force format() to raise on this record only.
+    handler.format = Mock(side_effect=ValueError("format boom"))
+    handler.emit(bad_record)
+
+    assert handler.dropped_format_error == 1
+    assert handler._buffer.qsize() == 0
+
+
+def test_recursion_guard_prevents_self_emit(make_v2):
+    handler = make_v2()
+    _stop_v2_worker(handler)
+    _shipping_state.shipping = True
+    try:
+        handler.emit(_make_record("inside shipping"))
+        assert handler.dropped_shipping == 1
+        assert handler._buffer.qsize() == 0
+    finally:
+        _shipping_state.shipping = False
+
+
+# ----- Group 2: flush semantics -----
+
+
+def test_flush_blocks_until_buffer_empty(make_v2, fake_ometa):
+    handler = make_v2()
+    for i in range(50):
+        handler.emit(_make_record(f"log {i}"))
+
+    handler.flush(timeout=2.0)
+
+    assert handler._buffer.empty()
+    # Each batch is a single "\n"-joined log_content; total record count
+    # across all batches must be 50.
+    total = sum(b.count("\n") for b in fake_ometa.shipped_batches)
+    assert total == 50
+
+
+def test_flush_times_out_when_post_is_slow(make_v2, fake_ometa):
+    fake_ometa.post_delay = 1.0
+    handler = make_v2()
+    handler.emit(_make_record("slow"))
+
+    handler.flush(timeout=0.1)
+
+    assert handler.flush_timed_out == 1
+
+
+# ----- Group 3: shutdown lifecycle -----
+
+
+def test_shutdown_is_idempotent(make_v2, fake_ometa):
+    handler = make_v2()
+    handler.shutdown(timeout=1.0)
+    handler.shutdown(timeout=1.0)
+    handler.shutdown(timeout=1.0)
+
+    assert len(fake_ometa.close_calls) == 1
+
+
+def test_shutdown_delivers_close_post(make_v2, fake_ometa):
+    handler = make_v2()
+    handler.emit(_make_record("first"))
+    handler.shutdown(timeout=1.0)
+
+    assert len(fake_ometa.close_calls) == 1
+
+
+def test_shutdown_ships_metrics_before_close(make_v2, fake_ometa):
+    handler = make_v2()
+    handler.emit(_make_record("payload"))
+    handler.shutdown(timeout=1.0)
+
+    # Last shipped batch must be the multi-line metrics block.
+    assert fake_ometa.shipped_batches, "expected at least one shipped batch"
+    last = fake_ometa.shipped_batches[-1]
+    assert "streamable_logger shutdown:" in last
+    assert "shipped:" in last and "failed:" in last
+    # Close must have happened after the metrics POST.
+    assert len(fake_ometa.close_calls) == 1
+
+
+def test_atexit_registered_then_unregistered(make_v2, fake_atexit):
+    handler = make_v2()
+    assert handler.shutdown in fake_atexit["registered"]
+    handler.shutdown(timeout=1.0)
+    assert handler.shutdown in fake_atexit["unregistered"]
+
+
+def test_shutdown_force_stops_on_join_timeout(make_v2, fake_ometa, fake_rest):
+    # Each POST blocks longer than the shutdown deadline → worker can't
+    # finish the drain in its 0.5s budget. P1 force-stop path must fire:
+    #   - shutdown_timed_out increments
+    #   - A second REST(...) is constructed (first one was in __init__)
+    #   - /close is still delivered via the fresh client
+    fake_ometa.post_delay = 0.8
+    handler = make_v2()
+    rest_count_after_init = len(fake_rest)
+    for i in range(5):
+        handler.emit(_make_record(f"log {i}"))
+
+    handler.shutdown(timeout=0.4)
+
+    assert handler.shutdown_timed_out == 1
+    assert len(fake_rest) == rest_count_after_init + 1  # fresh REST was created
+    assert len(fake_ometa.close_calls) == 1
+
+
+# ----- Group 4: worker resilience -----
+
+
+def test_worker_survives_post_exception(make_v2, fake_ometa):
+    fake_ometa.post_raises = RuntimeError
+    handler = make_v2()
+    handler.emit(_make_record("a"))
+    handler.emit(_make_record("b"))
+    time.sleep(0.3)  # give worker a chance to run the loop a couple times
+
+    # Worker should have caught the exception(s) and kept running.
+    assert handler.worker_errors >= 1
+    assert handler._worker.is_alive()
+
+    handler.shutdown(timeout=1.0)
+
+
+def test_worker_survives_collect_exception(make_v2):
+    handler = make_v2()
+    # Patch _collect_batch to raise once, then behave normally.
+    real_collect = handler._collect_batch
+    call_count = {"n": 0}
+
+    def collect_with_one_failure(timeout):
+        call_count["n"] += 1
+        if call_count["n"] == 2:
+            raise RuntimeError("simulated collect failure")
+        return real_collect(timeout)
+
+    handler._collect_batch = collect_with_one_failure
+    handler.emit(_make_record("a"))
+    time.sleep(0.4)
+
+    assert handler.worker_errors >= 1
+    assert handler._worker.is_alive()
+
+
+def test_worker_drain_breaks_on_persistent_failure(make_v2, fake_ometa):
+    # During shutdown's drain phase, persistent _collect_batch failure must
+    # bail out instead of spinning forever.
+    handler = make_v2()
+    handler.emit(_make_record("seed"))
+
+    # Wait for the seed to ship so we can move into drain cleanly.
+    time.sleep(0.2)
+
+    # Now break collect for the drain phase.
+    handler._collect_batch = Mock(side_effect=RuntimeError("persistent"))
+
+    start = time.monotonic()
+    handler.shutdown(timeout=2.0)
+    elapsed = time.monotonic() - start
+
+    # Must exit promptly, not spin until deadline.
+    assert elapsed < 1.5
+    assert handler.worker_errors >= 1
+
+
+# ----- Group 5: network failures / chaos -----
+
+
+def test_failed_posts_increments_on_false_return(make_v2, fake_ometa):
+    fake_ometa.post_returns = False
+    handler = make_v2()
+    for i in range(3):
+        handler.emit(_make_record(f"log {i}"))
+
+    handler.shutdown(timeout=2.0)
+
+    assert handler.failed_posts >= 1
+    assert handler.shipped_records == 0
+
+
+def test_intermittent_failures_counted_correctly(make_v2, fake_ometa):
+    # Alternate True / False every other POST.
+    fake_ometa.intermittent_pattern = lambda n: n % 2 == 1
+    handler = make_v2()
+    for i in range(20):
+        handler.emit(_make_record(f"log {i}"))
+        time.sleep(0.02)  # spread emits so batches form
+
+    handler.shutdown(timeout=2.0)
+
+    # Some succeeded, some failed.
+    assert handler.failed_posts >= 1
+    assert handler.shipped_records >= 1
+
+
+def test_slow_om_shutdown_still_delivers_close(make_v2, fake_ometa, fake_rest):
+    # Full P1 chaos: every POST takes longer than the join budget.
+    fake_ometa.post_delay = 0.6
+    handler = make_v2()
+    rest_count_after_init = len(fake_rest)
+    for i in range(10):
+        handler.emit(_make_record(f"log {i}"))
+
+    handler.shutdown(timeout=0.3)
+
+    # Despite the worker being stuck, /close must have been delivered on
+    # a fresh REST instance (force-stop + fresh client path).
+    assert handler.shutdown_timed_out == 1
+    assert len(fake_rest) == rest_count_after_init + 1
+    assert len(fake_ometa.close_calls) == 1
+
+
+# ----- Group 6: end-to-end lifecycle -----
+
+
+def test_end_to_end_emit_lifecycle(make_v2, fake_ometa):
+    """The whole story in one test: emit a bunch, shutdown, assert clean."""
+    handler = make_v2()
+    for i in range(200):
+        handler.emit(_make_record(f"log line {i}"))
+
+    handler.shutdown(timeout=2.0)
+
+    # Reconstruct what landed on the "server": sum of newlines across all
+    # shipped batches except the multi-line metrics block at the end.
+    payload_batches = fake_ometa.shipped_batches[:-1]
+    metrics_batch = fake_ometa.shipped_batches[-1]
+
+    total_lines = sum(b.count("\n") for b in payload_batches)
+    assert total_lines == 200
+
+    # Metrics line shipped + /close delivered.
+    assert "streamable_logger shutdown:" in metrics_batch
+    assert len(fake_ometa.close_calls) == 1
+
+    # Counters all clean.
+    assert handler.dropped_overflow == 0
+    assert handler.dropped_after_close == 0
+    assert handler.dropped_shipping == 0
+    assert handler.dropped_format_error == 0
+    assert handler.worker_errors == 0
+    assert handler.failed_posts == 0
+    assert handler.flush_timed_out == 0
+    assert handler.shutdown_timed_out == 0
+    assert handler.shipped_records == 200


### PR DESCRIPTION
## Summary

- Redesigns the streamable log handler around a synchronous shutdown so the close-time workflow tail (Execution Time Summary, Workflow Summary, "Workflow finished in time") is reliably captured in S3/MinIO.
- V1's daemon-thread `close()` returned before delivering `/close`, leaving the multipart upload unfinalized — `partial.txt` only, no `logs.txt`. New design uses a single queue + single worker + `threading.Event` control plane + `atexit` safety net, with sync `flush()` / `shutdown()` that block until records are delivered or deadline.
- Surfaces `shipped` / `failed_posts` / `dropped_*` / `*_timed_out` / `worker_errors` counters at shutdown so silent loss becomes loud.

## Guardrails — none of these paths can block the process indefinitely

Every wait in the handler has an explicit deadline; every blocking operation has an escape hatch.

| Guardrail | Bound | What it prevents |
|---|---|---|
| Worker thread `daemon=True` | killed at interpreter exit | Worker outliving the process if every other guard fails |
| `emit()` uses `put_nowait` | 0 — drops fast on full buffer (`dropped_overflow++`) | Producer (ingestion) being slowed by a wedged shipper |
| `HTTP_TIMEOUT = (2.0, 10.0)` | ≤12s per POST (connect + read) | Single hung POST stalling the worker |
| `flush(timeout)` default | 5s | Caller hanging while waiting for the queue to drain |
| `shutdown(timeout)` default `CLOSE_TIMEOUT_SEC` | 30s total: 15s flush + 15s worker join | Shutdown blocking process exit |
| Worker `join(timeout=15s)` | 15s | Worker monopolizing exit if drain is slow |
| Force-stop on join timeout | closes `_client` → in-flight POST raises → worker exits within ~1s | Worker still running while main thread issues `/close` |
| Secondary `join(timeout=2.0)` after force-stop | 2s | Hung worker still racing main thread on `_client` |
| Fresh `REST(...)` for metrics + `/close` after force-stop | n/a — new session, no contention | Concurrent use of a session the dying worker was closing |
| `/close` POST has its own `HTTP_TIMEOUT (2.0, CLOSE_TIMEOUT_SEC)` | ≤32s | `/close` itself hanging |
| Worker loop wraps each iteration in `try/except` (`worker_errors++`) | bounded — loop continues | A single bad batch killing the worker silently |
| Drain phase breaks on persistent failure | bounded iterations | Infinite loop during shutdown drain on Queue-level fault |
| `atexit.register(shutdown)` | runs once on normal interpreter exit | Caller forgetting to call `shutdown()` |
| `_post_in_flight` Event polled by `flush()` with deadline | bounded by `flush(timeout)` | `flush()` returning while a POST is still in flight, but also flush hanging waiting for one |
| `_shipping_state.shipping` recursion guard | drops record (`dropped_shipping++`) | Self-emit deadlock if the POST path ever triggers a log line |
| `_closed` flag checked at top of `emit()` | drops record (`dropped_after_close++`) | Late emits getting silently buffered and never delivered |

Worst-case process-exit time: **~30s** (shutdown deadline) **+ ~2s** (force-stop secondary join) **+ ~32s** (`/close` POST) ≈ **~64s** total in the pathological case where OM server is fully unresponsive. Normal case: ~50ms.

## Test plan

- [x] 24 unit tests covering emit / buffer / flush / shutdown / worker-resilience / chaos paths (including force-stop + fresh REST on join timeout, broader worker exception catch)
- [x] Manual soak: Redshift `sample_data` schema, 4,029 tables, DEBUG, 22.5 MiB, peak 3,303 lines/sec, sustained 2,500+ for 30s — zero drops, all counters clean, `logs.txt` finalized with full tail
- [x] Manual smoke on init-failure path — shutdown still runs cleanly, metrics shipped, `/close` attempted
- [x] `make py_format` clean
- [x] `make static-checks` clean for changed files