### PR TITLE
feat(ui): allow admins to set default landing-page panel color

### DIFF
--- a/openmetadata-spec/src/main/resources/json/schema/configuration/themeConfiguration.json
+++ b/openmetadata-spec/src/main/resources/json/schema/configuration/themeConfiguration.json
@@ -40,6 +40,11 @@
       "description": "Color used for informational messages in the UI, in hex code format or empty",
       "type": "string",
       "pattern": "^#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})$|^$"
+    },
+    "panelBackgroundColor": {
+      "description": "Default background color for the landing page welcome panel, in hex code format or empty. Users and personas can still override this on a per-persona basis.",
+      "type": "string",
+      "pattern": "^#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})$|^$"
     }
   },
   "required": ["primaryColor", "errorColor", "successColor","warningColor","infoColor"],

--- a/openmetadata-spec/src/main/resources/json/schema/configuration/themeConfiguration.json
+++ b/openmetadata-spec/src/main/resources/json/schema/configuration/themeConfiguration.json
@@ -42,7 +42,7 @@
       "pattern": "^#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})$|^$"
     },
     "panelBackgroundColor": {
-      "description": "Default background color for the landing page welcome panel, in hex code format or empty. Users and personas can still override this on a per-persona basis.",
+      "description": "Default background color for the landing page welcome panel, in hex code format or empty. Individual users and per-persona settings can still override this value.",
       "type": "string",
       "pattern": "^#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})$|^$"
     }

--- a/openmetadata-ui/src/main/resources/ui/src/components/MyData/CustomizableComponents/CustomiseLandingPageHeader/CustomiseLandingPageHeader.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/MyData/CustomizableComponents/CustomiseLandingPageHeader/CustomiseLandingPageHeader.test.tsx
@@ -18,7 +18,10 @@ import CustomiseLandingPageHeader from './CustomiseLandingPageHeader';
 
 jest.mock('../../../../hooks/useApplicationStore');
 jest.mock('../../../../utils/ServiceUtilClassBase');
-jest.mock('../../../../utils/CommonUtils');
+jest.mock('../../../../utils/CommonUtils', () => ({
+  ...jest.requireActual('../../../../utils/CommonUtils'),
+  getRecentlyViewedData: jest.fn(),
+}));
 
 // Create typed mocks
 const mockUseApplicationStore = useApplicationStore as jest.MockedFunction<
@@ -139,5 +142,57 @@ describe('CustomiseLandingPageHeader', () => {
     render(<CustomiseLandingPageHeader hideCustomiseButton={false} />);
 
     expect(screen.getByTestId('customise-header-btn')).toBeInTheDocument();
+  });
+
+  describe('background color precedence', () => {
+    const TEST_ID = 'header-bg-test';
+
+    it('uses the backgroundColor prop when provided, overriding admin theme', () => {
+      mockUseApplicationStore.mockReturnValue({
+        currentUser: mockCurrentUser,
+        applicationConfig: {
+          customTheme: { panelBackgroundColor: '#aaaaaa' },
+        },
+      });
+
+      render(
+        <CustomiseLandingPageHeader
+          backgroundColor="#bbbbbb"
+          dataTestId={TEST_ID}
+        />
+      );
+
+      expect(screen.getByTestId(TEST_ID)).toHaveStyle({
+        backgroundColor: '#bbbbbb',
+      });
+    });
+
+    it('falls back to admin theme panelBackgroundColor when prop is absent', () => {
+      mockUseApplicationStore.mockReturnValue({
+        currentUser: mockCurrentUser,
+        applicationConfig: {
+          customTheme: { panelBackgroundColor: '#cccccc' },
+        },
+      });
+
+      render(<CustomiseLandingPageHeader dataTestId={TEST_ID} />);
+
+      expect(screen.getByTestId(TEST_ID)).toHaveStyle({
+        backgroundColor: '#cccccc',
+      });
+    });
+
+    it('falls back to the default gradient when neither prop nor admin theme is set', () => {
+      mockUseApplicationStore.mockReturnValue({
+        currentUser: mockCurrentUser,
+        applicationConfig: { customTheme: {} },
+      });
+
+      render(<CustomiseLandingPageHeader dataTestId={TEST_ID} />);
+
+      expect(screen.getByTestId(TEST_ID)).toHaveStyle({
+        backgroundBlendMode: 'overlay',
+      });
+    });
   });
 });

--- a/openmetadata-ui/src/main/resources/ui/src/components/MyData/CustomizableComponents/CustomiseLandingPageHeader/CustomiseLandingPageHeader.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/MyData/CustomizableComponents/CustomiseLandingPageHeader/CustomiseLandingPageHeader.tsx
@@ -76,7 +76,7 @@ const CustomiseLandingPageHeader = ({
   const adminPanelBackgroundColor =
     applicationConfig?.customTheme?.panelBackgroundColor;
   const bgColor =
-    backgroundColor ?? (adminPanelBackgroundColor || DEFAULT_HEADER_BG_COLOR);
+    backgroundColor || adminPanelBackgroundColor || DEFAULT_HEADER_BG_COLOR;
 
   const landingPageStyle = useMemo(() => {
     const backgroundImage = isLinearGradient(bgColor)

--- a/openmetadata-ui/src/main/resources/ui/src/components/MyData/CustomizableComponents/CustomiseLandingPageHeader/CustomiseLandingPageHeader.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/MyData/CustomizableComponents/CustomiseLandingPageHeader/CustomiseLandingPageHeader.tsx
@@ -65,7 +65,7 @@ const CustomiseLandingPageHeader = ({
 }: CustomiseLandingPageHeaderProps) => {
   const { t } = useTranslation();
   const navigate = useNavigate();
-  const { currentUser } = useApplicationStore();
+  const { currentUser, applicationConfig } = useApplicationStore();
   const { activeDomain, activeDomainEntityRef, updateActiveDomain } =
     useDomainStore();
   const [showCustomiseHomeModal, setShowCustomiseHomeModal] = useState(false);
@@ -73,7 +73,10 @@ const CustomiseLandingPageHeader = ({
   const [announcements, setAnnouncements] = useState<AnnouncementEntity[]>([]);
   const [isAnnouncementLoading, setIsAnnouncementLoading] = useState(true);
   const [showAnnouncements, setShowAnnouncements] = useState(false);
-  const bgColor = backgroundColor ?? DEFAULT_HEADER_BG_COLOR;
+  const adminPanelBackgroundColor =
+    applicationConfig?.customTheme?.panelBackgroundColor;
+  const bgColor =
+    backgroundColor ?? (adminPanelBackgroundColor || DEFAULT_HEADER_BG_COLOR);
 
   const landingPageStyle = useMemo(() => {
     const backgroundImage = isLinearGradient(bgColor)

--- a/openmetadata-ui/src/main/resources/ui/src/generated/configuration/themeConfiguration.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/configuration/themeConfiguration.ts
@@ -28,7 +28,7 @@ export interface ThemeConfiguration {
     infoColor: string;
     /**
      * Default background color for the landing page welcome panel, in hex code format or empty.
-     * Users and personas can still override this on a per-persona basis.
+     * Individual users and per-persona settings can still override this value.
      */
     panelBackgroundColor?: string;
     /**

--- a/openmetadata-ui/src/main/resources/ui/src/generated/configuration/themeConfiguration.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/configuration/themeConfiguration.ts
@@ -27,6 +27,11 @@ export interface ThemeConfiguration {
      */
     infoColor: string;
     /**
+     * Default background color for the landing page welcome panel, in hex code format or empty.
+     * Users and personas can still override this on a per-persona basis.
+     */
+    panelBackgroundColor?: string;
+    /**
      * Primary color used in the UI, in hex code format or empty.
      */
     primaryColor: string;

--- a/openmetadata-ui/src/main/resources/ui/src/generated/configuration/uiThemePreference.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/configuration/uiThemePreference.ts
@@ -67,8 +67,8 @@ export interface ThemeConfiguration {
      */
     infoColor: string;
     /**
-     * Default background color for the landing page welcome panel, in hex code format or
-     * empty. Users and personas can still override this on a per-persona basis.
+     * Default background color for the landing page welcome panel, in hex code format or empty.
+     * Users and personas can still override this on a per-persona basis.
      */
     panelBackgroundColor?: string;
     /**

--- a/openmetadata-ui/src/main/resources/ui/src/generated/configuration/uiThemePreference.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/configuration/uiThemePreference.ts
@@ -67,6 +67,11 @@ export interface ThemeConfiguration {
      */
     infoColor: string;
     /**
+     * Default background color for the landing page welcome panel, in hex code format or
+     * empty. Users and personas can still override this on a per-persona basis.
+     */
+    panelBackgroundColor?: string;
+    /**
      * Primary color used in the UI, in hex code format or empty.
      */
     primaryColor: string;

--- a/openmetadata-ui/src/main/resources/ui/src/generated/configuration/uiThemePreference.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/configuration/uiThemePreference.ts
@@ -68,7 +68,7 @@ export interface ThemeConfiguration {
     infoColor: string;
     /**
      * Default background color for the landing page welcome panel, in hex code format or empty.
-     * Users and personas can still override this on a per-persona basis.
+     * Individual users and per-persona settings can still override this value.
      */
     panelBackgroundColor?: string;
     /**

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/ar-sa.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/ar-sa.json
@@ -1529,7 +1529,7 @@
     "page-not-found": "الصفحة غير موجودة",
     "page-plural": "صفحات",
     "page-views-by-data-asset-plural": "مشاهدات الصفحة حسب أصول البيانات",
-    "panel-background-color": "Panel Background Color",
+    "panel-background-color": "لون خلفية اللوحة",
     "parameter": "معامل",
     "parameter-description": "وصف المعامل",
     "parameter-display-name": "اسم العرض للمعامل",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/ar-sa.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/ar-sa.json
@@ -1529,6 +1529,7 @@
     "page-not-found": "الصفحة غير موجودة",
     "page-plural": "صفحات",
     "page-views-by-data-asset-plural": "مشاهدات الصفحة حسب أصول البيانات",
+    "panel-background-color": "Panel Background Color",
     "parameter": "معامل",
     "parameter-description": "وصف المعامل",
     "parameter-display-name": "اسم العرض للمعامل",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/de-de.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/de-de.json
@@ -1529,6 +1529,7 @@
     "page-not-found": "Seite nicht gefunden",
     "page-plural": "Seiten",
     "page-views-by-data-asset-plural": "Seitenaufrufe nach Datenanlage",
+    "panel-background-color": "Panel Background Color",
     "parameter": "Parameter",
     "parameter-description": "Parameterbeschreibung",
     "parameter-display-name": "Anzeigename des Parameters",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/de-de.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/de-de.json
@@ -1529,7 +1529,7 @@
     "page-not-found": "Seite nicht gefunden",
     "page-plural": "Seiten",
     "page-views-by-data-asset-plural": "Seitenaufrufe nach Datenanlage",
-    "panel-background-color": "Panel Background Color",
+    "panel-background-color": "Hintergrundfarbe des Panels",
     "parameter": "Parameter",
     "parameter-description": "Parameterbeschreibung",
     "parameter-display-name": "Anzeigename des Parameters",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/en-us.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/en-us.json
@@ -1529,6 +1529,7 @@
     "page-not-found": "Page Not Found",
     "page-plural": "Pages",
     "page-views-by-data-asset-plural": "Page Views by Data Assets",
+    "panel-background-color": "Panel Background Color",
     "parameter": "Parameter",
     "parameter-description": "Parameter Description",
     "parameter-display-name": "Parameter Display Name",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/es-es.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/es-es.json
@@ -1529,6 +1529,7 @@
     "page-not-found": "Página no encontrada",
     "page-plural": "Páginas",
     "page-views-by-data-asset-plural": "Vistas de página por activos de datos",
+    "panel-background-color": "Panel Background Color",
     "parameter": "Parámetro",
     "parameter-description": "Descripción del parámetro",
     "parameter-display-name": "Nombre para mostrar del parámetro",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/es-es.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/es-es.json
@@ -1529,7 +1529,7 @@
     "page-not-found": "Página no encontrada",
     "page-plural": "Páginas",
     "page-views-by-data-asset-plural": "Vistas de página por activos de datos",
-    "panel-background-color": "Panel Background Color",
+    "panel-background-color": "Color de fondo del panel",
     "parameter": "Parámetro",
     "parameter-description": "Descripción del parámetro",
     "parameter-display-name": "Nombre para mostrar del parámetro",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/fr-fr.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/fr-fr.json
@@ -1529,6 +1529,7 @@
     "page-not-found": "Page Non Trouvée",
     "page-plural": "Pages",
     "page-views-by-data-asset-plural": "Vues de Page par Actif de Données",
+    "panel-background-color": "Panel Background Color",
     "parameter": "Paramètre",
     "parameter-description": "Description du paramètre",
     "parameter-display-name": "Nom d'affichage du paramètre",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/fr-fr.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/fr-fr.json
@@ -1529,7 +1529,7 @@
     "page-not-found": "Page Non Trouvée",
     "page-plural": "Pages",
     "page-views-by-data-asset-plural": "Vues de Page par Actif de Données",
-    "panel-background-color": "Panel Background Color",
+    "panel-background-color": "Couleur d'arrière-plan du panneau",
     "parameter": "Paramètre",
     "parameter-description": "Description du paramètre",
     "parameter-display-name": "Nom d'affichage du paramètre",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/gl-es.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/gl-es.json
@@ -1529,7 +1529,7 @@
     "page-not-found": "Páxina non atopada",
     "page-plural": "Páxinas",
     "page-views-by-data-asset-plural": "Visualizacións de páxinas por activos de datos",
-    "panel-background-color": "Panel Background Color",
+    "panel-background-color": "Cor de fondo do panel",
     "parameter": "Parámetro",
     "parameter-description": "Descrición do parámetro",
     "parameter-display-name": "Nome a amosar do parámetro",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/gl-es.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/gl-es.json
@@ -1529,6 +1529,7 @@
     "page-not-found": "Páxina non atopada",
     "page-plural": "Páxinas",
     "page-views-by-data-asset-plural": "Visualizacións de páxinas por activos de datos",
+    "panel-background-color": "Panel Background Color",
     "parameter": "Parámetro",
     "parameter-description": "Descrición do parámetro",
     "parameter-display-name": "Nome a amosar do parámetro",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/he-he.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/he-he.json
@@ -1529,7 +1529,7 @@
     "page-not-found": "הדף לא נמצא",
     "page-plural": "דפים",
     "page-views-by-data-asset-plural": "צפיות בדפים לפי נכסי נתונים",
-    "panel-background-color": "Panel Background Color",
+    "panel-background-color": "צבע רקע של הפאנל",
     "parameter": "פרמטר",
     "parameter-description": "תיאור פרמטר",
     "parameter-display-name": "שם תצוגה של פרמטר",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/he-he.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/he-he.json
@@ -1529,6 +1529,7 @@
     "page-not-found": "הדף לא נמצא",
     "page-plural": "דפים",
     "page-views-by-data-asset-plural": "צפיות בדפים לפי נכסי נתונים",
+    "panel-background-color": "Panel Background Color",
     "parameter": "פרמטר",
     "parameter-description": "תיאור פרמטר",
     "parameter-display-name": "שם תצוגה של פרמטר",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/ja-jp.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/ja-jp.json
@@ -1529,7 +1529,7 @@
     "page-not-found": "ページが見つかりません",
     "page-plural": "ページ",
     "page-views-by-data-asset-plural": "データアセットごとのページビュー",
-    "panel-background-color": "Panel Background Color",
+    "panel-background-color": "パネルの背景色",
     "parameter": "パラメータ",
     "parameter-description": "パラメータの説明",
     "parameter-display-name": "パラメータの表示名",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/ja-jp.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/ja-jp.json
@@ -1529,6 +1529,7 @@
     "page-not-found": "ページが見つかりません",
     "page-plural": "ページ",
     "page-views-by-data-asset-plural": "データアセットごとのページビュー",
+    "panel-background-color": "Panel Background Color",
     "parameter": "パラメータ",
     "parameter-description": "パラメータの説明",
     "parameter-display-name": "パラメータの表示名",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/ko-kr.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/ko-kr.json
@@ -1529,6 +1529,7 @@
     "page-not-found": "페이지를 찾을 수 없습니다",
     "page-plural": "페이지",
     "page-views-by-data-asset-plural": "데이터 자산별 페이지 조회수",
+    "panel-background-color": "Panel Background Color",
     "parameter": "매개변수",
     "parameter-description": "매개변수 설명",
     "parameter-display-name": "매개변수 표시 이름",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/ko-kr.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/ko-kr.json
@@ -1529,7 +1529,7 @@
     "page-not-found": "페이지를 찾을 수 없습니다",
     "page-plural": "페이지",
     "page-views-by-data-asset-plural": "데이터 자산별 페이지 조회수",
-    "panel-background-color": "Panel Background Color",
+    "panel-background-color": "패널 배경색",
     "parameter": "매개변수",
     "parameter-description": "매개변수 설명",
     "parameter-display-name": "매개변수 표시 이름",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/mr-in.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/mr-in.json
@@ -1529,7 +1529,7 @@
     "page-not-found": "पृष्ठ सापडले नाही",
     "page-plural": "पृष्ठे",
     "page-views-by-data-asset-plural": "डेटा ॲसेट्सने पृष्ठ दृश्ये",
-    "panel-background-color": "Panel Background Color",
+    "panel-background-color": "पॅनेलचा पार्श्वभूमी रंग",
     "parameter": "पॅरामीटर",
     "parameter-description": "पॅरामीटर वर्णन",
     "parameter-display-name": "पॅरामीटर प्रदर्शन नाव",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/mr-in.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/mr-in.json
@@ -1529,6 +1529,7 @@
     "page-not-found": "पृष्ठ सापडले नाही",
     "page-plural": "पृष्ठे",
     "page-views-by-data-asset-plural": "डेटा ॲसेट्सने पृष्ठ दृश्ये",
+    "panel-background-color": "Panel Background Color",
     "parameter": "पॅरामीटर",
     "parameter-description": "पॅरामीटर वर्णन",
     "parameter-display-name": "पॅरामीटर प्रदर्शन नाव",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/nl-nl.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/nl-nl.json
@@ -1529,6 +1529,7 @@
     "page-not-found": "Pagina niet gevonden",
     "page-plural": "Pagina's",
     "page-views-by-data-asset-plural": "Paginaweergaven per data-asset",
+    "panel-background-color": "Panel Background Color",
     "parameter": "Parameter",
     "parameter-description": "Parameterbeschrijving",
     "parameter-display-name": "Weergavenaam van parameter",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/nl-nl.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/nl-nl.json
@@ -1529,7 +1529,7 @@
     "page-not-found": "Pagina niet gevonden",
     "page-plural": "Pagina's",
     "page-views-by-data-asset-plural": "Paginaweergaven per data-asset",
-    "panel-background-color": "Panel Background Color",
+    "panel-background-color": "Achtergrondkleur van paneel",
     "parameter": "Parameter",
     "parameter-description": "Parameterbeschrijving",
     "parameter-display-name": "Weergavenaam van parameter",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/pr-pr.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/pr-pr.json
@@ -1529,6 +1529,7 @@
     "page-not-found": "صفحه یافت نشد",
     "page-plural": "صفحات",
     "page-views-by-data-asset-plural": "بازدیدهای صفحه توسط دارایی‌های داده",
+    "panel-background-color": "Panel Background Color",
     "parameter": "پارامتر",
     "parameter-description": "توضیحات پارامتر",
     "parameter-display-name": "نام نمایشی پارامتر",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/pr-pr.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/pr-pr.json
@@ -1529,7 +1529,7 @@
     "page-not-found": "صفحه یافت نشد",
     "page-plural": "صفحات",
     "page-views-by-data-asset-plural": "بازدیدهای صفحه توسط دارایی‌های داده",
-    "panel-background-color": "Panel Background Color",
+    "panel-background-color": "رنگ پس‌زمینه پنل",
     "parameter": "پارامتر",
     "parameter-description": "توضیحات پارامتر",
     "parameter-display-name": "نام نمایشی پارامتر",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/pt-br.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/pt-br.json
@@ -1529,6 +1529,7 @@
     "page-not-found": "Página Não Encontrada",
     "page-plural": "Páginas",
     "page-views-by-data-asset-plural": "Visualizações de Página por Ativos de Dados",
+    "panel-background-color": "Panel Background Color",
     "parameter": "Parâmetro",
     "parameter-description": "Descrição do parâmetro",
     "parameter-display-name": "Nome de exibição do parâmetro",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/pt-br.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/pt-br.json
@@ -1529,7 +1529,7 @@
     "page-not-found": "Página Não Encontrada",
     "page-plural": "Páginas",
     "page-views-by-data-asset-plural": "Visualizações de Página por Ativos de Dados",
-    "panel-background-color": "Panel Background Color",
+    "panel-background-color": "Cor de fundo do painel",
     "parameter": "Parâmetro",
     "parameter-description": "Descrição do parâmetro",
     "parameter-display-name": "Nome de exibição do parâmetro",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/pt-pt.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/pt-pt.json
@@ -1529,7 +1529,7 @@
     "page-not-found": "Página Não Encontrada",
     "page-plural": "Páginas",
     "page-views-by-data-asset-plural": "Visualizações de Página por Ativos de Dados",
-    "panel-background-color": "Panel Background Color",
+    "panel-background-color": "Cor de fundo do painel",
     "parameter": "Parâmetro",
     "parameter-description": "Descrição do parâmetro",
     "parameter-display-name": "Nome a apresentar do parâmetro",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/pt-pt.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/pt-pt.json
@@ -1529,6 +1529,7 @@
     "page-not-found": "Página Não Encontrada",
     "page-plural": "Páginas",
     "page-views-by-data-asset-plural": "Visualizações de Página por Ativos de Dados",
+    "panel-background-color": "Panel Background Color",
     "parameter": "Parâmetro",
     "parameter-description": "Descrição do parâmetro",
     "parameter-display-name": "Nome a apresentar do parâmetro",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/ru-ru.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/ru-ru.json
@@ -1529,7 +1529,7 @@
     "page-not-found": "Страница не найдена",
     "page-plural": "Страницы",
     "page-views-by-data-asset-plural": "Просмотры объектов данных",
-    "panel-background-color": "Panel Background Color",
+    "panel-background-color": "Цвет фона панели",
     "parameter": "Параметр",
     "parameter-description": "Описание параметра",
     "parameter-display-name": "Отображаемое имя параметра",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/ru-ru.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/ru-ru.json
@@ -1529,6 +1529,7 @@
     "page-not-found": "Страница не найдена",
     "page-plural": "Страницы",
     "page-views-by-data-asset-plural": "Просмотры объектов данных",
+    "panel-background-color": "Panel Background Color",
     "parameter": "Параметр",
     "parameter-description": "Описание параметра",
     "parameter-display-name": "Отображаемое имя параметра",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/th-th.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/th-th.json
@@ -1529,6 +1529,7 @@
     "page-not-found": "ไม่พบหน้า",
     "page-plural": "หน้า",
     "page-views-by-data-asset-plural": "จำนวนการเข้าชมหน้าโดยสินทรัพย์ข้อมูล",
+    "panel-background-color": "Panel Background Color",
     "parameter": "พารามิเตอร์",
     "parameter-description": "คำอธิบายพารามิเตอร์",
     "parameter-display-name": "ชื่อแสดงพารามิเตอร์",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/th-th.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/th-th.json
@@ -1529,7 +1529,7 @@
     "page-not-found": "ไม่พบหน้า",
     "page-plural": "หน้า",
     "page-views-by-data-asset-plural": "จำนวนการเข้าชมหน้าโดยสินทรัพย์ข้อมูล",
-    "panel-background-color": "Panel Background Color",
+    "panel-background-color": "สีพื้นหลังของแผง",
     "parameter": "พารามิเตอร์",
     "parameter-description": "คำอธิบายพารามิเตอร์",
     "parameter-display-name": "ชื่อแสดงพารามิเตอร์",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/tr-tr.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/tr-tr.json
@@ -1529,7 +1529,7 @@
     "page-not-found": "Sayfa Bulunamadı",
     "page-plural": "Sayfalar",
     "page-views-by-data-asset-plural": "Veri Varlıklarına Göre Sayfa Görüntülemeleri",
-    "panel-background-color": "Panel Background Color",
+    "panel-background-color": "Panel Arka Plan Rengi",
     "parameter": "Parametre",
     "parameter-description": "Parametre Açıklaması",
     "parameter-display-name": "Parametre Görünen Adı",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/tr-tr.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/tr-tr.json
@@ -1529,6 +1529,7 @@
     "page-not-found": "Sayfa Bulunamadı",
     "page-plural": "Sayfalar",
     "page-views-by-data-asset-plural": "Veri Varlıklarına Göre Sayfa Görüntülemeleri",
+    "panel-background-color": "Panel Background Color",
     "parameter": "Parametre",
     "parameter-description": "Parametre Açıklaması",
     "parameter-display-name": "Parametre Görünen Adı",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/zh-cn.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/zh-cn.json
@@ -1529,6 +1529,7 @@
     "page-not-found": "没有找到页面",
     "page-plural": "页面",
     "page-views-by-data-asset-plural": "数据资产页面浏览量",
+    "panel-background-color": "Panel Background Color",
     "parameter": "参数",
     "parameter-description": "参数说明",
     "parameter-display-name": "参数显示名称",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/zh-cn.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/zh-cn.json
@@ -1529,7 +1529,7 @@
     "page-not-found": "没有找到页面",
     "page-plural": "页面",
     "page-views-by-data-asset-plural": "数据资产页面浏览量",
-    "panel-background-color": "Panel Background Color",
+    "panel-background-color": "面板背景颜色",
     "parameter": "参数",
     "parameter-description": "参数说明",
     "parameter-display-name": "参数显示名称",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/zh-tw.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/zh-tw.json
@@ -1529,7 +1529,7 @@
     "page-not-found": "找不到頁面",
     "page-plural": "頁面",
     "page-views-by-data-asset-plural": "依資料資產的頁面瀏覽量",
-    "panel-background-color": "Panel Background Color",
+    "panel-background-color": "面板背景顏色",
     "parameter": "參數",
     "parameter-description": "參數描述",
     "parameter-display-name": "參數顯示名稱",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/zh-tw.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/zh-tw.json
@@ -1529,6 +1529,7 @@
     "page-not-found": "找不到頁面",
     "page-plural": "頁面",
     "page-views-by-data-asset-plural": "依資料資產的頁面瀏覽量",
+    "panel-background-color": "Panel Background Color",
     "parameter": "參數",
     "parameter-description": "參數描述",
     "parameter-display-name": "參數顯示名稱",

--- a/openmetadata-ui/src/main/resources/ui/src/pages/AppearanceConfigSettingsPage/AppearanceConfigSettingsPage.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/AppearanceConfigSettingsPage/AppearanceConfigSettingsPage.test.tsx
@@ -58,12 +58,18 @@ describe('Test appearance config page', () => {
     expect(screen.getByTestId('successColor-color-input')).toBeInTheDocument();
     expect(screen.getByTestId('warningColor-color-input')).toBeInTheDocument();
     expect(screen.getByTestId('infoColor-color-input')).toBeInTheDocument();
+    expect(
+      screen.getByTestId('panelBackgroundColor-color-input')
+    ).toBeInTheDocument();
 
     expect(screen.getByTestId('primaryColor-color-picker')).toBeInTheDocument();
     expect(screen.getByTestId('errorColor-color-picker')).toBeInTheDocument();
     expect(screen.getByTestId('successColor-color-picker')).toBeInTheDocument();
     expect(screen.getByTestId('warningColor-color-picker')).toBeInTheDocument();
     expect(screen.getByTestId('infoColor-color-picker')).toBeInTheDocument();
+    expect(
+      screen.getByTestId('panelBackgroundColor-color-picker')
+    ).toBeInTheDocument();
 
     expect(screen.getByTestId('save-btn')).toBeInTheDocument();
     expect(screen.getByTestId('cancel-btn')).toBeInTheDocument();
@@ -104,6 +110,9 @@ describe('Test appearance config page', () => {
       'warningColor-color-input'
     );
     const infoColorColorInput = screen.getByTestId('infoColor-color-input');
+    const panelBackgroundColorInput = screen.getByTestId(
+      'panelBackgroundColor-color-input'
+    );
     const saveButton = screen.getByTestId('save-btn');
 
     fireEvent.change(customLogoUrlPath, {
@@ -136,6 +145,9 @@ describe('Test appearance config page', () => {
     fireEvent.change(infoColorColorInput, {
       target: { value: '#ffffff' },
     });
+    fireEvent.change(panelBackgroundColorInput, {
+      target: { value: '#ffffff' },
+    });
 
     fireEvent.click(saveButton);
 
@@ -156,6 +168,7 @@ describe('Test appearance config page', () => {
             selectedColor: '#ffffff',
             successColor: '#ffffff',
             warningColor: '#ffffff',
+            panelBackgroundColor: '#ffffff',
           },
         },
       })

--- a/openmetadata-ui/src/main/resources/ui/src/pages/AppearanceConfigSettingsPage/AppearanceConfigSettingsPage.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/AppearanceConfigSettingsPage/AppearanceConfigSettingsPage.tsx
@@ -104,6 +104,7 @@ const AppearanceConfigSettingsPage = () => {
           successColor: values?.successColor ?? '',
           warningColor: values?.warningColor ?? '',
           infoColor: values?.infoColor ?? '',
+          panelBackgroundColor: values?.panelBackgroundColor ?? '',
         },
       };
 
@@ -137,6 +138,7 @@ const AppearanceConfigSettingsPage = () => {
           successColor: '',
           warningColor: '',
           infoColor: '',
+          panelBackgroundColor: '',
         },
       };
       const configData = {
@@ -208,6 +210,22 @@ const AppearanceConfigSettingsPage = () => {
       ],
       props: {
         'data-testid': 'hoverColor',
+      },
+    },
+    {
+      name: 'panelBackgroundColor',
+      id: 'panelBackgroundColor',
+      label: t('label.panel-background-color'),
+      required: false,
+      type: FieldTypes.COLOR_PICKER,
+      rules: [
+        {
+          pattern: HEX_COLOR_CODE_REGEX,
+          message: t('message.hex-color-validation'),
+        },
+      ],
+      props: {
+        'data-testid': 'panelBackgroundColor',
       },
     },
     {

--- a/openmetadata-ui/src/main/resources/ui/src/utils/ThemeUtils.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/ThemeUtils.ts
@@ -22,5 +22,6 @@ export const getThemeConfig = (theme?: UIThemePreference['customTheme']) => {
     successColor: theme?.successColor || DEFAULT_THEME.successColor,
     warningColor: theme?.warningColor || DEFAULT_THEME.warningColor,
     infoColor: theme?.infoColor || DEFAULT_THEME.infoColor,
+    panelBackgroundColor: theme?.panelBackgroundColor,
   };
 };


### PR DESCRIPTION
### Describe your changes:

The admin Theme settings page (Settings → Preferences → Theme) lets admins customize logo and theme colors (primary / selected / hover / status), but there was no way to set the default background color of the landing-page welcome panel — it was hard-coded to the blue gradient. This PR adds an optional `panelBackgroundColor` field to `ThemeConfiguration` and a matching color picker on the admin Theme page, and wires it into `CustomiseLandingPageHeader` as a new fallback in the existing precedence chain so that user / persona overrides still win.

### Type of change:
- [x] New feature

### High-level design:

Precedence chain (existing behavior preserved):

`user persona color` → `admin persona color` (existing prop from MyDataPage) → **`admin global theme.panelBackgroundColor` (NEW)** → `DEFAULT_HEADER_BG_COLOR` (gradient).

The new fallback is inserted inside `CustomiseLandingPageHeader` rather than `MyDataPage`, so any other place the header is rendered (preview, customize modal) also picks up the admin default. The field is optional in `themeConfiguration.json` (same hex pattern as the other colors), so existing configs are forward-compatible and the generated Java POJO gains an optional getter/setter only.

### Tests:

#### Use cases covered
- Admin sets a panel color on the Theme settings page → it shows on the home welcome panel for all users who have not customized.
- User customizes their own panel color from the home page → still wins over the admin default.
- Admin customizes a specific persona's panel → still wins over the admin global default.
- Admin clicks Reset → panel color clears and the home page falls back to the gradient default.

#### Manual testing performed
1. Started UI locally and verified the new \"Panel Background Color\" picker renders on Settings → Preferences → Theme.
2. Set a hex color, saved, navigated to Home — banner background updated.
3. Customized panel color from Home (per-user) and confirmed it overrode the admin value.
4. Cleared the user value, switched personas with a persona-level color, confirmed that wins next.
5. Ran \`yarn ui-checkstyle:changed\` and \`tsc --noEmit\` — clean.

### UI screen recording / screenshots:

Not applicable to the diff itself, but the change is a new color picker on Settings → Preferences → Theme that controls the home page welcome panel background.

