### PR TITLE
fix(ui): return 404 for unknown service category instead of fallback to databases

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/pages/ServicesPage/ServicesPage.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/ServicesPage/ServicesPage.test.tsx
@@ -113,6 +113,22 @@ describe('ServicesPage', () => {
     ).toBeInTheDocument();
   });
 
+  it('should redirect to 404 when tab is an unknown service category', async () => {
+    await act(async () => {
+      render(
+        <MemoryRouter initialEntries={['/services/mcp']}>
+          <Routes>
+            <Route element={<ServicesPage />} path="/services/:tab" />
+            <Route element={<>mockNotFound</>} path="/404" />
+          </Routes>
+        </MemoryRouter>
+      );
+    });
+
+    expect(await screen.findByText('mockNotFound')).toBeInTheDocument();
+    expect(screen.queryByText('mockServices')).not.toBeInTheDocument();
+  });
+
   it('should render ErrorPlaceholder when user does not have permission', async () => {
     (userPermissions.hasViewPermissions as jest.Mock).mockImplementationOnce(
       jest.fn().mockReturnValue(false)

--- a/openmetadata-ui/src/main/resources/ui/src/pages/ServicesPage/ServicesPage.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/ServicesPage/ServicesPage.test.tsx
@@ -136,7 +136,7 @@ describe('ServicesPage', () => {
 
     await act(async () => {
       render(
-        <MemoryRouter initialEntries={['/services/services']}>
+        <MemoryRouter initialEntries={['/services/databases']}>
           <Routes>
             <Route element={<ServicesPage />} path="/services/:tab" />
           </Routes>

--- a/openmetadata-ui/src/main/resources/ui/src/pages/ServicesPage/ServicesPage.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/ServicesPage/ServicesPage.tsx
@@ -18,12 +18,12 @@ import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Navigate, useNavigate } from 'react-router-dom';
 import ErrorPlaceHolder from '../../components/common/ErrorWithPlaceholder/ErrorPlaceHolder';
-import { ROUTES } from '../../constants/constants';
 import TitleBreadcrumb from '../../components/common/TitleBreadcrumb/TitleBreadcrumb.component';
 import { TitleBreadcrumbProps } from '../../components/common/TitleBreadcrumb/TitleBreadcrumb.interface';
 import PageLayoutV1 from '../../components/PageLayoutV1/PageLayoutV1';
 import { IngestionPipelineList } from '../../components/Settings/Services/Ingestion/IngestionPipelineList/IngestionPipelineList.component';
 import Services from '../../components/Settings/Services/Services';
+import { ROUTES } from '../../constants/constants';
 import {
   GlobalSettingOptions,
   GlobalSettingsMenuCategory,

--- a/openmetadata-ui/src/main/resources/ui/src/pages/ServicesPage/ServicesPage.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/ServicesPage/ServicesPage.tsx
@@ -16,8 +16,9 @@ import { capitalize, isEmpty, startCase } from 'lodash';
 import qs from 'qs';
 import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useNavigate } from 'react-router-dom';
+import { Navigate, useNavigate } from 'react-router-dom';
 import ErrorPlaceHolder from '../../components/common/ErrorWithPlaceholder/ErrorPlaceHolder';
+import { ROUTES } from '../../constants/constants';
 import TitleBreadcrumb from '../../components/common/TitleBreadcrumb/TitleBreadcrumb.component';
 import { TitleBreadcrumbProps } from '../../components/common/TitleBreadcrumb/TitleBreadcrumb.interface';
 import PageLayoutV1 from '../../components/PageLayoutV1/PageLayoutV1';
@@ -55,6 +56,10 @@ const ServicesPage = () => {
     (tab === GlobalSettingOptions.DATA_OBSERVABILITY
       ? 'pipelines'
       : 'services');
+
+  const isValidTab =
+    tab === GlobalSettingOptions.DATA_OBSERVABILITY ||
+    Boolean(SERVICE_CATEGORY[tab]);
 
   const serviceName = useMemo(
     () =>
@@ -109,6 +114,10 @@ const ServicesPage = () => {
 
     return crumbs;
   }, [tab, t, isEmbedded]);
+
+  if (!isValidTab) {
+    return <Navigate replace to={ROUTES.NOT_FOUND} />;
+  }
 
   return viewAllPermission ? (
     <PageLayoutV1 pageTitle={serviceName}>


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:

Fixes #28287 
<!--
Linking an issue is REQUIRED. Replace <issue-number> with the GitHub issue number this PR addresses
(e.g., `Fixes #12345`). GitHub will auto-link it. If no issue exists, please open one first so the
problem and design can be discussed before review.
-->

<!--
Short blurb explaining:
- What changes did you make?
- Why did you make them?
-->

## Summary
- Unknown service category slugs in `/settings/services/:tab` (e.g. `/settings/services/mcp`) silently fell back to `ServiceCategory.DATABASE_SERVICES`, rendering the Databases list under a misleading breadcrumb.
- `ServicesPage` now validates `:tab` against `SERVICE_CATEGORY` keys (plus `DATA_OBSERVABILITY`) and redirects to `ROUTES.NOT_FOUND` when invalid.

## Changes
- `pages/ServicesPage/ServicesPage.tsx`: add `isValidTab` check; render `<Navigate replace to={ROUTES.NOT_FOUND} />` on unknown tab.
- `pages/ServicesPage/ServicesPage.test.tsx`: add test asserting redirect to `/404` for unknown service category (`mcp`).

## Before / After
- Before: `/settings/services/mcp` → breadcrumb `Settings / Services / Mcp`, body shows Databases.
- After: `/settings/services/mcp` → redirect to `/404`.


https://github.com/user-attachments/assets/133d2548-83d3-4e01-96c2-66ddbb734c62



#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### High-level design:
<!--
REQUIRED for large PRs (new features, refactors, breaking changes, or anything touching >5 files).
Skip for small bug fixes and trivial changes.

Cover:
- Architecture / approach you took and why
- Key components or files added/changed and how they interact
- Alternatives considered and why you rejected them
- Any migration, backward-compatibility, or rollout concerns
- Diagrams or links to design docs / RFCs if available
-->

N/A — small change. <!-- Or fill in the design above -->

#
### Tests:

#### Use cases covered
<!--
List the user-visible scenarios this PR exercises. Example:
- User with Admin role can create a Glossary Term with a parent term
- Ingestion run for Snowflake correctly extracts row counts for partitioned tables
-->

#### Unit tests
<!--
- [ ] I added unit tests for the new/changed logic.
- Files added/updated:
- Coverage on changed classes (run `mvn jacoco:report` for backend, `yarn test:coverage` for UI,
  `make unit_ingestion` for ingestion). Target is 90% line coverage on changed classes.
- Coverage %: <e.g., 92% on EntityRepository.java>
-->

#### Backend integration tests
<!--
- [ ] I added integration tests in `openmetadata-integration-tests/` for new/changed API endpoints.
- [ ] Not applicable (no backend API changes).
- Files added/updated:
-->

#### Ingestion integration tests
<!--
- [ ] I added/updated ingestion integration tests for connector changes.
- [ ] Not applicable (no ingestion changes).
- Files added/updated:
-->

#### Playwright (UI) tests
<!--
- [ ] I added Playwright E2E tests under `openmetadata-ui/.../ui/playwright/` for UI changes.
- [ ] Not applicable (no UI changes).
- Files added/updated:
-->

#### Manual testing performed
<!--
List the manual test steps you performed before requesting review. Example:
1. Started local stack via `./docker/run_local_docker.sh -m ui -d mysql`
2. Logged in as admin, created entity X, verified Y appears in the UI
3. Triggered ingestion for Snowflake source, confirmed lineage edges in the explore page
-->

#
### UI screen recording / screenshots:
<!--
REQUIRED for any PR that changes the UI. Drag-and-drop a short screen recording (.mov / .mp4 / .gif)
demonstrating the change end-to-end, plus before/after screenshots where relevant.
Mark "Not applicable" if there are no UI changes.
-->

Not applicable. <!-- Or attach recording/screenshots above -->

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.
- [ ] For UI changes: I attached a screen recording and/or screenshots above.
- [ ] I have added tests (unit / integration / Playwright as applicable) and listed them above.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->
