### PR TITLE
fix(ui): restore files deleted by cherry-pick that are still in use on 1.13

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/ActivityFeed/ActivityFeedCard/FeedCardBody/FeedCardBodyV1.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/ActivityFeed/ActivityFeedCard/FeedCardBody/FeedCardBodyV1.tsx
@@ -1,0 +1,207 @@
+/*
+ *  Copyright 2023 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+import { Button, Col, Row, Typography } from 'antd';
+import classNames from 'classnames';
+import { isUndefined } from 'lodash';
+import { useCallback, useMemo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Link } from 'react-router-dom';
+import ActivityFeedEditor from '../../../../components/ActivityFeed/ActivityFeedEditor/ActivityFeedEditor';
+import { ASSET_CARD_STYLES } from '../../../../constants/Feeds.constants';
+import { EntityType } from '../../../../enums/entity.enum';
+import { CardStyle } from '../../../../generated/entity/feed/thread';
+import {
+  AlertType,
+  EventSubscription,
+} from '../../../../generated/events/eventSubscription';
+import { formatDateTime } from '../../../../utils/date-time/DateTimeUtils';
+import entityUtilClassBase from '../../../../utils/EntityUtilClassBase';
+import {
+  getEntityFQN,
+  getEntityType,
+  getFrontEndFormat,
+  MarkdownToHTMLConverter,
+} from '../../../../utils/FeedUtils';
+import RichTextEditorPreviewerV1 from '../../../common/RichTextEditor/RichTextEditorPreviewerV1';
+import ExploreSearchCard from '../../../ExploreV1/ExploreSearchCard/ExploreSearchCard';
+import DescriptionFeed from '../../ActivityFeedCardV2/FeedCardBody/DescriptionFeed/DescriptionFeed';
+import TagsFeed from '../../ActivityFeedCardV2/FeedCardBody/TagsFeed/TagsFeed';
+import './feed-card-body-v1.less';
+import { FeedCardBodyV1Props } from './FeedCardBodyV1.interface';
+
+const FeedCardBodyV1 = ({
+  isPost = false,
+  feed,
+  isEditPost,
+  className,
+  showSchedule = true,
+  message,
+  announcement,
+  onUpdate,
+  onEditCancel,
+}: FeedCardBodyV1Props) => {
+  const { t } = useTranslation();
+  const [postMessage, setPostMessage] = useState<string>(message);
+
+  const { entityFQN, entityType, cardStyle } = useMemo(() => {
+    return {
+      entityFQN: getEntityFQN(feed.about) ?? '',
+      entityType: getEntityType(feed.about) ?? '',
+      cardStyle: feed.cardStyle ?? '',
+    };
+  }, [feed]);
+
+  const handleSave = useCallback(() => {
+    onUpdate?.(postMessage ?? '');
+  }, [onUpdate, postMessage]);
+
+  const getDefaultValue = (defaultMessage: string) => {
+    return MarkdownToHTMLConverter.makeHtml(getFrontEndFormat(defaultMessage));
+  };
+
+  const feedBodyStyleCardsRender = useMemo(() => {
+    if (!isPost) {
+      if (cardStyle === CardStyle.Description) {
+        return <DescriptionFeed feed={feed} />;
+      }
+
+      if (cardStyle === CardStyle.Tags) {
+        return <TagsFeed feed={feed} />;
+      }
+
+      if (ASSET_CARD_STYLES.includes(cardStyle as CardStyle)) {
+        const entityInfo = feed.feedInfo?.entitySpecificInfo?.entity;
+        const isExecutableTestSuite =
+          entityType === EntityType.TEST_SUITE && entityInfo.basic;
+        const isObservabilityAlert =
+          entityType === EntityType.EVENT_SUBSCRIPTION &&
+          (entityInfo as EventSubscription).alertType ===
+            AlertType.Observability;
+
+        const entityCard = (
+          <ExploreSearchCard
+            className="asset-info-card"
+            id={`tabledatacard${entityInfo.id}`}
+            showTags={false}
+            source={{ ...entityInfo, entityType }}
+          />
+        );
+
+        return cardStyle === CardStyle.EntityDeleted ? (
+          <div className="deleted-entity">{entityCard}</div>
+        ) : (
+          <Link
+            className="no-underline text-body text-hover-body"
+            to={entityUtilClassBase.getEntityLink(
+              entityType,
+              entityFQN,
+              '',
+              '',
+              isExecutableTestSuite,
+              isObservabilityAlert
+            )}>
+            {entityCard}
+          </Link>
+        );
+      }
+    }
+
+    return (
+      <RichTextEditorPreviewerV1
+        className="text-wrap"
+        markdown={getFrontEndFormat(message)}
+      />
+    );
+  }, [isPost, message, postMessage, cardStyle, feed, entityType, entityFQN]);
+
+  const feedBodyRender = useMemo(() => {
+    if (isEditPost) {
+      return (
+        <ActivityFeedEditor
+          focused
+          className="mb-8"
+          defaultValue={getDefaultValue(message)}
+          editAction={
+            <div className="d-flex justify-end gap-2 m-r-xss">
+              <Button
+                className="border border-primary text-primary rounded-4"
+                data-testid="cancel-button"
+                size="small"
+                onClick={onEditCancel}>
+                {t('label.cancel')}
+              </Button>
+              <Button
+                className="rounded-4"
+                data-testid="save-button"
+                disabled={!message.length}
+                size="small"
+                type="primary"
+                onClick={handleSave}>
+                {t('label.save')}
+              </Button>
+            </div>
+          }
+          editorClass="is_edit_post"
+          onSave={handleSave}
+          onTextChange={(message) => setPostMessage(message)}
+        />
+      );
+    }
+
+    return feedBodyStyleCardsRender;
+  }, [isEditPost, message, feedBodyStyleCardsRender]);
+
+  return (
+    <div
+      className={classNames('p-y-sm rounded-6', isEditPost ? '' : className)}>
+      <div className="feed-message">
+        {!isUndefined(announcement) ? (
+          <>
+            <Row>
+              <Col span={24}>
+                {showSchedule && (
+                  <Typography.Text className="feed-body-schedule text-xs text-grey-muted">
+                    {t('label.schedule')}{' '}
+                    {formatDateTime(announcement.startTime)}{' '}
+                    {t('label.to-lowercase')}{' '}
+                    {formatDateTime(announcement.endTime)}
+                  </Typography.Text>
+                )}
+              </Col>
+            </Row>
+            <Row>
+              <Col span={24}>
+                <Typography.Text className="font-semibold">
+                  {message}
+                </Typography.Text>
+              </Col>
+            </Row>
+            <Row>
+              <Col span={24}>
+                <RichTextEditorPreviewerV1
+                  className="text-wrap"
+                  markdown={announcement.description ?? ''}
+                />
+              </Col>
+            </Row>
+          </>
+        ) : (
+          feedBodyRender
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default FeedCardBodyV1;

--- a/openmetadata-ui/src/main/resources/ui/src/components/ActivityFeed/ActivityFeedCardV2/ActivityFeedCardV2.interface.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/components/ActivityFeed/ActivityFeedCardV2/ActivityFeedCardV2.interface.ts
@@ -1,0 +1,28 @@
+/*
+ *  Copyright 2024 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+import { Post, Thread } from '../../../generated/entity/feed/thread';
+
+export interface ActivityFeedCardV2Props {
+  post: Post;
+  feed: Thread;
+  className?: string;
+  isPost?: boolean;
+  isOpenInDrawer?: boolean;
+  showThread?: boolean;
+  isActive?: boolean;
+  componentsVisibility?: {
+    showThreadIcon?: boolean;
+    showRepliesContainer?: boolean;
+  };
+}

--- a/openmetadata-ui/src/main/resources/ui/src/components/ActivityFeed/ActivityFeedCardV2/ActivityFeedCardV2.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/ActivityFeed/ActivityFeedCardV2/ActivityFeedCardV2.tsx
@@ -1,0 +1,161 @@
+/*
+ *  Copyright 2024 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+import { Col, Row } from 'antd';
+import classNames from 'classnames';
+import { compare } from 'fast-json-patch';
+import { useMemo, useState } from 'react';
+import { EntityField } from '../../../constants/Feeds.constants';
+import { GeneratedBy } from '../../../generated/entity/feed/thread';
+import ProfilePicture from '../../common/ProfilePicture/ProfilePicture';
+import FeedCardBodyV1 from '../ActivityFeedCard/FeedCardBody/FeedCardBodyV1';
+import { useActivityFeedProvider } from '../ActivityFeedProvider/ActivityFeedProvider';
+import ActivityFeedActions from '../Shared/ActivityFeedActions';
+import './activity-feed-card-v2.less';
+import { ActivityFeedCardV2Props } from './ActivityFeedCardV2.interface';
+import FeedCardFooter from './FeedCardFooter/FeedCardFooter';
+import FeedCardHeaderV2 from './FeedCardHeader/FeedCardHeaderV2';
+
+const ActivityFeedCardV2 = ({
+  post,
+  feed,
+  className = '',
+  isPost = false,
+  isActive = false,
+  showThread = false,
+  isOpenInDrawer = false,
+  componentsVisibility = {
+    showThreadIcon: true,
+    showRepliesContainer: true,
+  },
+}: Readonly<ActivityFeedCardV2Props>) => {
+  const [isEditPost, setIsEditPost] = useState<boolean>(false);
+  const [showActions, setShowActions] = useState(false);
+  const { updateFeed } = useActivityFeedProvider();
+
+  const postLength = useMemo(
+    () => feed?.posts?.length ?? 0,
+    [feed?.posts?.length]
+  );
+
+  const onEditPost = () => {
+    setIsEditPost(!isEditPost);
+  };
+
+  const handleMouseEnter = () => {
+    setShowActions(true);
+  };
+
+  const handleMouseLeave = () => {
+    setShowActions(false);
+  };
+
+  const onUpdate = (message: string) => {
+    const updatedPost = { ...feed, message };
+    const patch = compare(feed, updatedPost);
+    updateFeed(feed.id, post.id, !isPost, patch);
+    setIsEditPost(!isEditPost);
+  };
+
+  return (
+    <div
+      className={classNames(
+        'feed-card-v2-container p-sm',
+        {
+          active: isActive,
+        },
+        className
+      )}>
+      <div
+        className={classNames('feed-card-v2-sidebar', {
+          'feed-card-v2-post-sidebar': isPost,
+        })}>
+        <ProfilePicture
+          avatarType="outlined"
+          name={post.from}
+          size={isPost ? 28 : 30}
+          width={isPost ? '28' : '30'}
+        />
+      </div>
+      <Row className="w-full" gutter={[0, 10]}>
+        <Col
+          className={classNames('feed-card-v2', {
+            'feed-reply-card-v2': isPost,
+            'drawer-feed-card-v2': isOpenInDrawer,
+          })}
+          span={24}
+          onMouseEnter={handleMouseEnter}
+          onMouseLeave={handleMouseLeave}>
+          <Row className="w-full">
+            <Col span={24}>
+              <FeedCardHeaderV2
+                about={!isPost ? feed.about : undefined}
+                cardStyle={feed.cardStyle}
+                createdBy={post.from}
+                feed={feed}
+                fieldName={feed.feedInfo?.fieldName as EntityField}
+                fieldOperation={feed.fieldOperation}
+                isEntityFeed={isPost}
+                timeStamp={post.postTs}
+              />
+            </Col>
+            <Col span={24}>
+              <FeedCardBodyV1
+                announcement={!isPost ? feed.announcement : undefined}
+                feed={feed}
+                isEditPost={isEditPost}
+                isPost={isPost}
+                message={post.message}
+                onEditCancel={() => setIsEditPost(false)}
+                onUpdate={onUpdate}
+              />
+            </Col>
+            <Col span={24}>
+              <FeedCardFooter
+                componentsVisibility={componentsVisibility}
+                feed={feed}
+                isPost={isPost}
+                post={post}
+              />
+            </Col>
+          </Row>
+          {showActions &&
+            (feed.generatedBy !== GeneratedBy.System || isPost) && (
+              <ActivityFeedActions
+                feed={feed}
+                isPost={isPost}
+                post={post}
+                onEditPost={onEditPost}
+              />
+            )}
+        </Col>
+        {showThread && postLength > 0 && (
+          <Col className="feed-replies" data-testid="feed-replies" span={24}>
+            {feed?.posts?.map((reply) => (
+              <ActivityFeedCardV2
+                isPost
+                componentsVisibility={componentsVisibility}
+                feed={feed}
+                isOpenInDrawer={isOpenInDrawer}
+                key={reply.id}
+                post={reply}
+              />
+            ))}
+          </Col>
+        )}
+      </Row>
+    </div>
+  );
+};
+
+export default ActivityFeedCardV2;

--- a/openmetadata-ui/src/main/resources/ui/src/components/ActivityFeed/ActivityFeedCardV2/FeedCardFooter/FeedCardFooter.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/ActivityFeed/ActivityFeedCardV2/FeedCardFooter/FeedCardFooter.tsx
@@ -1,0 +1,140 @@
+/*
+ *  Copyright 2024 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+import { Avatar, Button, Col, Row, Space, Tooltip, Typography } from 'antd';
+import { min, noop, sortBy } from 'lodash';
+import { useCallback, useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
+import { ReactComponent as ThreadIcon } from '../../../../assets/svg/thread-icon.svg';
+import { ReactionOperation } from '../../../../enums/reactions.enum';
+import { ReactionType } from '../../../../generated/type/reaction';
+import {
+  formatDateTime,
+  getRelativeTime,
+} from '../../../../utils/date-time/DateTimeUtils';
+import ProfilePicture from '../../../common/ProfilePicture/ProfilePicture';
+import { useActivityFeedProvider } from '../../ActivityFeedProvider/ActivityFeedProvider';
+import Reactions from '../../Reactions/Reactions';
+import { FeedCardFooterProps } from './FeedCardFooter.interface';
+
+function FeedCardFooter({
+  feed,
+  post,
+  isPost = false,
+  componentsVisibility = {
+    showThreadIcon: true,
+    showRepliesContainer: true,
+  },
+}: Readonly<FeedCardFooterProps>) {
+  const { t } = useTranslation();
+  const { showDrawer, updateReactions, fetchUpdatedThread } =
+    useActivityFeedProvider();
+
+  // The number of posts in the thread
+  const postLength = useMemo(() => feed?.postsCount ?? 0, [feed?.postsCount]);
+
+  // The latest reply timestamp and the list of unique users who replied
+  const { latestReplyTimeStamp, repliedUniqueUsersList } = useMemo(() => {
+    const posts = sortBy(feed?.posts, 'postTs').reverse();
+    const latestReplyTimeStamp = posts[0]?.postTs;
+
+    const repliedUsers = [...new Set((feed?.posts ?? []).map((f) => f.from))];
+
+    const repliedUniqueUsersList = repliedUsers.slice(
+      0,
+      min([3, repliedUsers.length])
+    );
+
+    return { latestReplyTimeStamp, repliedUniqueUsersList };
+  }, [feed?.posts]);
+
+  const onReactionUpdate = useCallback(
+    async (reaction: ReactionType, operation: ReactionOperation) => {
+      await updateReactions(post, feed.id, !isPost, reaction, operation);
+      await fetchUpdatedThread(feed.id);
+    },
+    [updateReactions, post, feed.id, isPost, fetchUpdatedThread]
+  );
+
+  const showReplies = useCallback(() => {
+    showDrawer?.(feed);
+  }, [showDrawer, feed]);
+
+  return (
+    <Row>
+      <Col span={24}>
+        <Space className="p-xss" size={8}>
+          {componentsVisibility.showThreadIcon && postLength === 0 && (
+            <Button
+              className="flex-center p-0"
+              data-testid="thread-count"
+              icon={<ThreadIcon width={18} />}
+              shape="circle"
+              size="small"
+              type="text"
+              onClick={showReplies}
+            />
+          )}
+          <Reactions
+            reactions={post.reactions ?? []}
+            onReactionSelect={onReactionUpdate ?? noop}
+          />
+        </Space>
+      </Col>
+      <Col span={24}>
+        {componentsVisibility.showRepliesContainer && postLength !== 0 && (
+          <Button
+            className="flex items-center gap-2 p-x-xss w-full rounded-8"
+            type="text"
+            onClick={componentsVisibility.showThreadIcon ? showReplies : noop}>
+            {postLength > 0 && (
+              <Avatar.Group>
+                {repliedUniqueUsersList.map((user) => (
+                  <ProfilePicture
+                    avatarType="outlined"
+                    key={user}
+                    name={user}
+                    size={20}
+                  />
+                ))}
+              </Avatar.Group>
+            )}
+            <Typography.Text
+              className="text-xs font-medium text-primary"
+              data-testid="reply-count">
+              {postLength <= 1
+                ? t('label.one-reply')
+                : t('label.number-reply-plural', {
+                    number: postLength,
+                  })}
+            </Typography.Text>
+            {latestReplyTimeStamp && (
+              <Tooltip
+                color="white"
+                overlayClassName="timestamp-tooltip"
+                title={formatDateTime(latestReplyTimeStamp)}>
+                <span
+                  className="feed-card-header-v2-timestamp"
+                  data-testid="timestamp">
+                  {getRelativeTime(latestReplyTimeStamp)}
+                </span>
+              </Tooltip>
+            )}
+          </Button>
+        )}
+      </Col>
+    </Row>
+  );
+}
+
+export default FeedCardFooter;

--- a/openmetadata-ui/src/main/resources/ui/src/components/ActivityFeed/Shared/TaskBadge.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/ActivityFeed/Shared/TaskBadge.tsx
@@ -1,0 +1,46 @@
+/*
+ *  Copyright 2022 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+import Icon from '@ant-design/icons';
+import { Space, Tooltip, Typography } from 'antd';
+import { isEqual } from 'lodash';
+import { useTranslation } from 'react-i18next';
+import { ReactComponent as IconTaskClose } from '../../../assets/svg/complete.svg';
+import { ReactComponent as IconTaskOpen } from '../../../assets/svg/in-progress.svg';
+import { TEXT_BODY_COLOR } from '../../../constants/constants';
+import { ThreadTaskStatus } from '../../../generated/entity/feed/thread';
+import './task-badge.less';
+
+const TaskBadge = ({ status }: { status: ThreadTaskStatus }) => {
+  const { t } = useTranslation();
+  const isTaskOpen = isEqual(status, ThreadTaskStatus.Open);
+
+  const tooltipContent = isTaskOpen
+    ? `${t('label.status')}: ${t('label.open-lowercase')}`
+    : `${t('label.status')}: ${t('label.closed-lowercase')}`;
+
+  return (
+    <Tooltip align={{ targetOffset: [0, -15] }} title={tooltipContent}>
+      <Space align="center" className="task-badge" size={4}>
+        <Icon
+          alt="task-status"
+          component={isTaskOpen ? IconTaskOpen : IconTaskClose}
+          style={{ fontSize: '12px', color: TEXT_BODY_COLOR }}
+        />
+        <Typography.Text>{t('label.task')}</Typography.Text>
+      </Space>
+    </Tooltip>
+  );
+};
+
+export default TaskBadge;

--- a/openmetadata-ui/src/main/resources/ui/src/components/Entity/EntityList/EntityList.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Entity/EntityList/EntityList.tsx
@@ -1,0 +1,101 @@
+/*
+ *  Copyright 2022 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+import { Button, Col, Row, Typography } from 'antd';
+import { isEmpty } from 'lodash';
+import { FunctionComponent } from 'react';
+import { Link } from 'react-router-dom';
+import { EntityReference } from '../../../generated/entity/type';
+import entityUtilClassBase from '../../../utils/EntityUtilClassBase';
+import { getEntityName } from '../../../utils/EntityUtils';
+import searchClassBase from '../../../utils/SearchClassBase';
+import EntityListSkeleton from '../../common/Skeleton/MyData/EntityListSkeleton/EntityListSkeleton.component';
+import './entity.less';
+
+interface AntdEntityListProp {
+  loading?: boolean;
+  entityList: Array<EntityReference>;
+  headerText?: string | JSX.Element;
+  headerTextLabel: string;
+  noDataPlaceholder: JSX.Element;
+  testIDText: string;
+}
+
+export const EntityListWithV1: FunctionComponent<AntdEntityListProp> = ({
+  entityList = [],
+  headerText,
+  headerTextLabel,
+  noDataPlaceholder,
+  testIDText,
+  loading,
+}: AntdEntityListProp) => {
+  return (
+    <EntityListSkeleton
+      dataLength={entityList.length !== 0 ? entityList.length : 5}
+      loading={Boolean(loading)}>
+      <>
+        <Row className="m-b-xs" justify="space-between">
+          <Col>
+            <Typography.Text className="text-lg font-semibold">
+              {headerTextLabel}
+            </Typography.Text>
+          </Col>
+          <Col>
+            <Typography.Text>{headerText}</Typography.Text>
+          </Col>
+        </Row>
+        {isEmpty(entityList) ? (
+          <div className="flex-center h-full">{noDataPlaceholder}</div>
+        ) : (
+          <div className="entity-list-body">
+            {entityList.map((item) => {
+              return (
+                <div
+                  className="right-panel-list-item flex items-center justify-between"
+                  data-testid={`${testIDText}-${item.name}`}
+                  key={item.id}>
+                  <div className="flex items-center">
+                    <Link
+                      className="font-medium"
+                      to={entityUtilClassBase.getEntityLink(
+                        item.type || '',
+                        item.fullyQualifiedName ?? ''
+                      )}>
+                      <Button
+                        className="entity-button flex-center p-0 m--ml-1"
+                        icon={
+                          <div className="entity-button-icon m-r-xs">
+                            {searchClassBase.getEntityIcon(item.type || '')}
+                          </div>
+                        }
+                        title={getEntityName(
+                          item as unknown as EntityReference
+                        )}
+                        type="text">
+                        <Typography.Text
+                          className="w-72 text-left text-xs"
+                          ellipsis={{ tooltip: true }}>
+                          {getEntityName(item as unknown as EntityReference)}
+                        </Typography.Text>
+                      </Button>
+                    </Link>
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        )}
+      </>
+    </EntityListSkeleton>
+  );
+};

--- a/openmetadata-ui/src/main/resources/ui/src/components/Entity/Task/TaskTabIncidentManagerHeader/TasktabIncidentManagerHeaderNew.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Entity/Task/TaskTabIncidentManagerHeader/TasktabIncidentManagerHeaderNew.tsx
@@ -1,0 +1,251 @@
+/*
+ *  Copyright 2023 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+import { Col, Row, Skeleton, Steps, Typography } from 'antd';
+import { last, toLower } from 'lodash';
+import { ReactNode, useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
+import { ReactComponent as AssigneesIcon } from '../../../../assets/svg/ic-assignees.svg';
+import { ReactComponent as FailureCommentIcon } from '../../../../assets/svg/ic-failure-comment.svg';
+import { ReactComponent as FailureReasonIcon } from '../../../../assets/svg/ic-failure-reason.svg';
+import { ReactComponent as SeverityIcon } from '../../../../assets/svg/ic-severity.svg';
+import { ReactComponent as UserIcon } from '../../../../assets/svg/ic-user-profile.svg';
+import { NO_DATA_PLACEHOLDER } from '../../../../constants/constants';
+import {
+  TEST_CASE_RESOLUTION_STATUS_LABELS,
+  TEST_CASE_STATUS,
+} from '../../../../constants/TestSuite.constant';
+import { Thread } from '../../../../generated/entity/feed/thread';
+import { TestCaseResolutionStatusTypes } from '../../../../generated/tests/testCaseResolutionStatus';
+import { formatDateTime } from '../../../../utils/date-time/DateTimeUtils';
+import { getEntityName } from '../../../../utils/EntityUtils';
+import { useActivityFeedProvider } from '../../../ActivityFeed/ActivityFeedProvider/ActivityFeedProvider';
+
+import { OwnerType } from '../../../../enums/user.enum';
+import { OwnerLabel } from '../../../common/OwnerLabel/OwnerLabel.component';
+import UserPopOverCard from '../../../common/PopOverCard/UserPopOverCard';
+import ProfilePicture from '../../../common/ProfilePicture/ProfilePicture';
+import RichTextEditorPreviewerV1 from '../../../common/RichTextEditor/RichTextEditorPreviewerV1';
+import Severity from '../../../DataQuality/IncidentManager/Severity/Severity.component';
+import './task-tab-incident-manager-header.style.less';
+
+const TaskTabIncidentManagerHeaderNew = ({ thread }: { thread: Thread }) => {
+  const { t } = useTranslation();
+  const { testCaseResolutionStatus, isTestCaseResolutionLoading } =
+    useActivityFeedProvider();
+  const testCaseResolutionStepper = useMemo(() => {
+    const updatedData = [...testCaseResolutionStatus];
+    const lastStatusType = last(
+      testCaseResolutionStatus
+    )?.testCaseResolutionStatusType;
+
+    if (lastStatusType && TEST_CASE_STATUS[lastStatusType]) {
+      updatedData.push(
+        ...TEST_CASE_STATUS[lastStatusType].map((type) => ({
+          testCaseResolutionStatusType: type,
+        }))
+      );
+    }
+
+    return updatedData.map((status) => {
+      let details: ReactNode = null;
+
+      switch (status.testCaseResolutionStatusType) {
+        case TestCaseResolutionStatusTypes.ACK:
+          details = status.updatedBy ? (
+            <Typography.Text className="text-grey-muted text-xss">
+              {`${t('label.by-entity', {
+                entity: getEntityName(status.updatedBy),
+              })} ${t('label.on-lowercase')} `}
+            </Typography.Text>
+          ) : null;
+
+          break;
+        case TestCaseResolutionStatusTypes.Assigned:
+          details = status.testCaseResolutionStatusDetails?.assignee ? (
+            <Typography.Text className="text-grey-muted text-xss">
+              {`${t('label.to-lowercase')} ${getEntityName(
+                status.testCaseResolutionStatusDetails?.assignee
+              )} ${t('label.on-lowercase')} `}
+            </Typography.Text>
+          ) : null;
+
+          break;
+        case TestCaseResolutionStatusTypes.Resolved:
+          details = status.testCaseResolutionStatusDetails?.resolvedBy ? (
+            <Typography.Text className="text-grey-muted text-xss">
+              {`${t('label.by-entity', {
+                entity: getEntityName(
+                  status.testCaseResolutionStatusDetails.resolvedBy
+                ),
+              })} ${t('label.on-lowercase')} `}
+            </Typography.Text>
+          ) : null;
+
+          break;
+
+        default:
+          break;
+      }
+
+      return {
+        className: toLower(status.testCaseResolutionStatusType),
+        title: (
+          <div className="incident-title">
+            <Typography.Paragraph className="m-b-0">
+              {
+                TEST_CASE_RESOLUTION_STATUS_LABELS[
+                  status.testCaseResolutionStatusType
+                ]
+              }
+            </Typography.Paragraph>
+            <Typography.Paragraph className="m-b-0 incident-details">
+              {details}
+              {status.updatedAt && (
+                <Typography.Text className="text-grey-muted text-xss">
+                  {formatDateTime(status.updatedAt)}
+                </Typography.Text>
+              )}
+            </Typography.Paragraph>
+          </div>
+        ),
+        key: status.testCaseResolutionStatusType,
+      };
+    });
+  }, [testCaseResolutionStatus, t]);
+
+  const latestTestCaseResolutionStatus = useMemo(
+    () => last(testCaseResolutionStatus),
+    [testCaseResolutionStatus]
+  );
+
+  const isResolved =
+    latestTestCaseResolutionStatus?.testCaseResolutionStatusType ===
+    TestCaseResolutionStatusTypes.Resolved;
+
+  return (
+    <Row data-testid="incident-manager-task-header-container" gutter={[8, 16]}>
+      <Row className="m-l-0" gutter={[16, 16]}>
+        <Col className="flex items-center gap-2 text-grey-muted" span={8}>
+          <UserIcon height={16} />
+          <Typography.Text className="incident-manager-details-label @grey-8">
+            {t('label.created-by')}
+          </Typography.Text>
+        </Col>
+        <Col className="flex items-center gap-2" span={16}>
+          <UserPopOverCard userName={thread.createdBy ?? ''}>
+            <div className="d-flex items-center">
+              <ProfilePicture name={thread.createdBy ?? ''} width="24" />
+            </div>
+          </UserPopOverCard>
+          <Typography.Text>{thread.createdBy}</Typography.Text>
+        </Col>
+        <Col className="flex items-center gap-2 text-grey-muted" span={8}>
+          <AssigneesIcon height={16} />
+          <Typography.Text className="incident-manager-details-label @grey-8">
+            {`${t('label.assignee-plural')} `}
+          </Typography.Text>
+        </Col>
+        <Col className="flex items-center gap-2" span={16}>
+          {thread?.task?.assignees?.length === 1 ? (
+            <div className="d-flex items-center gap-2">
+              <UserPopOverCard
+                type={thread?.task?.assignees[0]?.type as OwnerType}
+                userName={thread?.task?.assignees[0].name ?? ''}>
+                <div className="d-flex items-center">
+                  <ProfilePicture
+                    name={thread?.task?.assignees[0].name ?? ''}
+                    width="24"
+                  />
+                </div>
+              </UserPopOverCard>
+              <Typography.Text className="text-grey-body">
+                {getEntityName(thread?.task?.assignees[0])}
+              </Typography.Text>
+            </div>
+          ) : (
+            <OwnerLabel
+              isCompactView={false}
+              owners={thread?.task?.assignees}
+              showLabel={false}
+            />
+          )}
+        </Col>
+
+        <Col className="flex items-center gap-2 text-grey-muted" span={8}>
+          <SeverityIcon height={16} />
+          <Typography.Text className="incident-manager-details-label">
+            {' '}
+            {`${t('label.severity')} `}
+          </Typography.Text>
+        </Col>
+        <Col className="flex items-center gap-2" span={16}>
+          <Severity severity={latestTestCaseResolutionStatus?.severity} />
+        </Col>
+
+        {isResolved && (
+          <Col className="flex items-center gap-2 text-grey-muted" span={8}>
+            <FailureReasonIcon height={16} />
+            <Typography.Text className="incident-manager-details-label">{`${t(
+              'label.failure-reason'
+            )}: `}</Typography.Text>
+          </Col>
+        )}
+        {isResolved && (
+          <Col className="flex items-center gap-2" span={16}>
+            <Typography.Text className="text-sm incident-manager-text">
+              {latestTestCaseResolutionStatus?.testCaseResolutionStatusDetails
+                ?.testCaseFailureReason ?? NO_DATA_PLACEHOLDER}
+            </Typography.Text>
+          </Col>
+        )}
+        {isResolved && (
+          <Col className="flex items-center gap-2 text-grey-muted" span={8}>
+            <FailureCommentIcon height={16} />
+            <Typography.Text className="incident-manager-details-label">
+              {' '}
+              {`${t('label.failure-comment')} `}
+            </Typography.Text>
+          </Col>
+        )}
+        {isResolved && (
+          <Col className="flex items-center gap-2 " span={16}>
+            <RichTextEditorPreviewerV1
+              markdown={
+                latestTestCaseResolutionStatus?.testCaseResolutionStatusDetails
+                  ?.testCaseFailureComment ?? ''
+              }
+            />
+          </Col>
+        )}
+        <Col className="p-l-0" span={24}>
+          <div className="task-resolution-steps-container-new">
+            {isTestCaseResolutionLoading ? (
+              <Skeleton active />
+            ) : (
+              <Steps
+                className="task-resolution-steps w-full"
+                current={testCaseResolutionStatus.length}
+                data-testid="task-resolution-steps"
+                items={testCaseResolutionStepper}
+                labelPlacement="vertical"
+                size="small"
+              />
+            )}
+          </div>
+        </Col>
+      </Row>
+    </Row>
+  );
+};
+
+export default TaskTabIncidentManagerHeaderNew;

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/atoms/table/TagsCell.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/atoms/table/TagsCell.tsx
@@ -1,0 +1,154 @@
+/*
+ *  Copyright 2024 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+import { Box, Chip } from '@mui/material';
+import { useEffect, useLayoutEffect, useRef, useState } from 'react';
+import { TagChip } from '../TagChip';
+
+interface TagsCellProps {
+  tags: Array<{
+    id?: string;
+    name?: string;
+    tagFQN?: string;
+    displayName?: string;
+  }>;
+  chipSize?: 'small' | 'large';
+}
+
+const TagsCell = ({ tags, chipSize = 'small' }: TagsCellProps) => {
+  const [visibleCount, setVisibleCount] = useState(tags.length);
+  const [measured, setMeasured] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const measureRef = useRef<HTMLDivElement>(null);
+
+  useLayoutEffect(() => {
+    if (!containerRef.current || !measureRef.current || measured) {
+      return;
+    }
+
+    const containerWidth = containerRef.current.offsetWidth;
+    const GAP = 8;
+    const COUNT_CHIP_WIDTH = 60;
+
+    const chipElements = measureRef.current.querySelectorAll('.measure-chip');
+    let accumulatedWidth = 0;
+    let fitCount = 0;
+
+    chipElements.forEach((chip, index) => {
+      const chipWidth = (chip as HTMLElement).offsetWidth;
+      const totalWidth = accumulatedWidth + (index > 0 ? GAP : 0) + chipWidth;
+
+      const remainingTags = tags.length - index - 1;
+      const needsCountSpace = remainingTags > 0;
+      const maxAllowedWidth = needsCountSpace
+        ? containerWidth - COUNT_CHIP_WIDTH - GAP
+        : containerWidth;
+
+      if (totalWidth <= maxAllowedWidth) {
+        accumulatedWidth = totalWidth;
+        fitCount++;
+      }
+    });
+
+    setVisibleCount(Math.max(1, Math.min(fitCount, 2)));
+    setMeasured(true);
+  }, [tags, measured]);
+
+  useEffect(() => {
+    setMeasured(false);
+    setVisibleCount(tags.length);
+  }, [tags]);
+
+  const hiddenCount = tags.length - visibleCount;
+
+  return (
+    <Box
+      ref={containerRef}
+      sx={{
+        display: 'flex',
+        gap: 1,
+        width: '100%',
+        alignItems: 'center',
+        position: 'relative',
+        minHeight: chipSize === 'small' ? 24 : 32,
+      }}>
+      {!measured && (
+        <Box
+          ref={measureRef}
+          sx={{
+            display: 'flex',
+            gap: 1,
+            position: 'absolute',
+            visibility: 'hidden',
+            top: 0,
+            left: 0,
+            width: '100%',
+          }}>
+          {tags.map((tag, index) => (
+            <TagChip
+              className="measure-chip"
+              key={`measure-${tag.id || index}`}
+              label={tag.name || tag.tagFQN || ''}
+              showEllipsis={false}
+              size={chipSize}
+              sx={{
+                flexShrink: 0,
+                '& .MuiChip-label': {
+                  whiteSpace: 'nowrap',
+                },
+              }}
+            />
+          ))}
+        </Box>
+      )}
+
+      {measured && (
+        <>
+          {tags.slice(0, visibleCount).map((tag, index) => {
+            const isSingleTag = visibleCount === 1;
+
+            let maxWidth = '200px';
+            if (isSingleTag) {
+              maxWidth = hiddenCount > 0 ? 'calc(100% - 70px)' : '100%';
+            }
+
+            return (
+              <TagChip
+                key={tag.id || `${tag.tagFQN}-${index}`}
+                label={tag.displayName || tag.name || tag.tagFQN || ''}
+                maxWidth={maxWidth}
+                size={chipSize}
+              />
+            );
+          })}
+
+          {hiddenCount > 0 && (
+            <Chip
+              color="primary"
+              label={`+${hiddenCount}`}
+              size={chipSize}
+              sx={{
+                border: 'none',
+                fontWeight: 500,
+                flexShrink: 0,
+                minWidth: 'auto',
+              }}
+            />
+          )}
+        </>
+      )}
+    </Box>
+  );
+};
+
+export default TagsCell;


### PR DESCRIPTION
## Summary

- Commit `1fba441489` (lazy load home page widgets) was cherry-picked and deleted files it considered "unused"
- Several of those files are still actively imported in the `1.13` branch, causing broken imports
- Restores 8 files to their last known state before the cherry-pick

**Restored files:**
- `ActivityFeedCard/FeedCardBody/FeedCardBodyV1.tsx` — used by `AnnouncementsWidget`, `FeedCardBodyNew`
- `ActivityFeedCardV2/ActivityFeedCardV2.tsx` + `.interface.ts` — used by `CommentCard`, `ActivityFeedCardNew`
- `ActivityFeedCardV2/FeedCardFooter/FeedCardFooter.tsx` — used by `ActivityThreadList`, `CommentCard`
- `ActivityFeed/Shared/TaskBadge.tsx` — used by `ActivityThreadList`
- `Entity/EntityList/EntityList.tsx` — used by `ApplicationsClassBase`, widget tests
- `Entity/Task/TaskTabIncidentManagerHeader/TasktabIncidentManagerHeaderNew.tsx` — used by `TaskTabNew`
- `common/atoms/table/TagsCell.tsx` — used by domain card/table column renderers

## Test plan

- [ ] Verify no broken import errors in affected components
- [ ] Smoke test ActivityFeed, EntityList, TaskTab, and domain table views

🤖 Generated with [Claude Code](https://claude.com/claude-code)