### PR TITLE
Fix #28076: search_after pagination breaks when sort values contain ','

### DIFF
--- a/ingestion/src/metadata/ingestion/ometa/mixins/es_mixin.py
+++ b/ingestion/src/metadata/ingestion/ometa/mixins/es_mixin.py
@@ -398,12 +398,10 @@ class ESMixin(Generic[T]):
                 logger.debug("No more pages to fetch")
                 break
 
-            # Base64-encoded JSON array — unambiguous even when sort values contain ','
+            # URL-safe base64-encoded JSON array — unambiguous even when sort values contain ','
             # (e.g. a glossary term FQN). Server side decodes via SearchUtils.searchAfter,
             # falling back to legacy comma-split for older clients.
-            after = base64.b64encode(
-                json.dumps(list(last_hit.sort)).encode("utf-8")
-            ).decode("ascii")
+            after = base64.urlsafe_b64encode(json.dumps(list(last_hit.sort)).encode("utf-8")).decode("ascii")
 
     def paginate_es(
         self,

--- a/ingestion/src/metadata/ingestion/ometa/mixins/es_mixin.py
+++ b/ingestion/src/metadata/ingestion/ometa/mixins/es_mixin.py
@@ -14,6 +14,7 @@ Mixin class containing Lineage specific methods
 To be used by OpenMetadata class
 """
 
+import base64
 import functools
 import json
 import traceback
@@ -397,7 +398,12 @@ class ESMixin(Generic[T]):
                 logger.debug("No more pages to fetch")
                 break
 
-            after = ",".join(last_hit.sort)
+            # Base64-encoded JSON array — unambiguous even when sort values contain ','
+            # (e.g. a glossary term FQN). Server side decodes via SearchUtils.searchAfter,
+            # falling back to legacy comma-split for older clients.
+            after = base64.b64encode(
+                json.dumps(list(last_hit.sort)).encode("utf-8")
+            ).decode("ascii")
 
     def paginate_es(
         self,

--- a/ingestion/tests/integration/ometa/test_ometa_es_api.py
+++ b/ingestion/tests/integration/ometa/test_ometa_es_api.py
@@ -365,6 +365,44 @@ class TestOMetaESAPI:
                 except Exception:
                     pass
 
+    def test_paginate_with_comma_in_name(self, metadata, es_service, es_schema):
+        """Regression for #28076 — search_after must not break on values with ','.
+
+        The legacy ",".join cursor and the legacy server-side split(",") combine to
+        truncate pagination when any sort value contains a literal ','. With size=1
+        each page boundary's cursor is a single FQN that itself contains a ',' — the
+        exact shape that produced the 311/1863 partial result for the Crocs case.
+        """
+        created_tables = []
+        try:
+            for i in range(5):
+                table = metadata.create_or_update(
+                    data=get_create_entity(
+                        entity=Table,
+                        name=EntityName(f"comma,table,{i}"),
+                        reference=es_schema.fullyQualifiedName,
+                    )
+                )
+                created_tables.append(table)
+
+            query_filter = (
+                '{"query":{"bool":{"must":[{"term":'
+                f'{{"service.displayName.keyword":"{es_service.name.root}"}}'
+                "}]}}}"
+            )
+            assets = list(
+                metadata.paginate_es(entity=Table, query_filter=query_filter, size=1)
+            )
+            assert (
+                len(assets) == 5
+            ), f"Expected 5 tables, got {len(assets)} — pagination truncated on comma in FQN"
+        finally:
+            for table in created_tables:
+                try:  # noqa: SIM105
+                    metadata.delete(entity=Table, entity_id=table.id, hard_delete=True)
+                except Exception:
+                    pass
+
     def test_paginate_with_filters(self, metadata, es_service, es_schema):
         """We can paginate only tier 1 tables"""
         created_tables = []

--- a/ingestion/tests/integration/ometa/test_ometa_es_api.py
+++ b/ingestion/tests/integration/ometa/test_ometa_es_api.py
@@ -390,12 +390,8 @@ class TestOMetaESAPI:
                 f'{{"service.displayName.keyword":"{es_service.name.root}"}}'
                 "}]}}}"
             )
-            assets = list(
-                metadata.paginate_es(entity=Table, query_filter=query_filter, size=1)
-            )
-            assert (
-                len(assets) == 5
-            ), f"Expected 5 tables, got {len(assets)} — pagination truncated on comma in FQN"
+            assets = list(metadata.paginate_es(entity=Table, query_filter=query_filter, size=1))
+            assert len(assets) == 5, f"Expected 5 tables, got {len(assets)} — pagination truncated on comma in FQN"
         finally:
             for table in created_tables:
                 try:  # noqa: SIM105

--- a/ingestion/tests/integration/ometa/test_ometa_es_api.py
+++ b/ingestion/tests/integration/ometa/test_ometa_es_api.py
@@ -385,10 +385,14 @@ class TestOMetaESAPI:
                 )
                 created_tables.append(table)
 
+            # Narrow the filter to the tables created by this test — a module-scoped
+            # es_table fixture also lives in this service and would otherwise inflate
+            # the result count past 5.
             query_filter = (
-                '{"query":{"bool":{"must":[{"term":'
-                f'{{"service.displayName.keyword":"{es_service.name.root}"}}'
-                "}]}}}"
+                '{"query":{"bool":{"must":['
+                f'{{"term":{{"service.displayName.keyword":"{es_service.name.root}"}}}},'
+                '{"wildcard":{"name.keyword":"comma,table,*"}}'
+                "]}}}"
             )
             assets = list(metadata.paginate_es(entity=Table, query_filter=query_filter, size=1))
             assert len(assets) == 5, f"Expected 5 tables, got {len(assets)} — pagination truncated on comma in FQN"

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/search/SearchResource.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/search/SearchResource.java
@@ -160,7 +160,12 @@ public class SearchResource {
           int size,
       @Parameter(
               description =
-                  "When paginating, specify the search_after values. Use it ass search_after=<val1>,<val2>,...")
+                  "When paginating, specify the search_after cursor. Preferred form is the "
+                      + "base64-encoded JSON array returned by the previous page "
+                      + "(e.g. base64(\"[\\\"v1\\\",\\\"v2\\\"]\")); this form is unambiguous "
+                      + "when sort values contain commas (such as a glossary term FQN). "
+                      + "A legacy comma-joined form (search_after=v1,v2) is also accepted but "
+                      + "breaks when any value itself contains a ','.")
           @QueryParam("search_after")
           String searchAfter,
       @Parameter(
@@ -518,7 +523,12 @@ public class SearchResource {
           @DefaultValue("10")
           @QueryParam("size")
           int size,
-      @Parameter(description = "When paginating, specify the search_after values")
+      @Parameter(
+              description =
+                  "When paginating, specify the search_after cursor. Preferred form is the "
+                      + "base64-encoded JSON array returned by the previous page; the legacy "
+                      + "comma-joined form is also accepted but breaks when any sort value "
+                      + "contains a ','.")
           @QueryParam("search_after")
           String searchAfter,
       @Parameter(description = "Sort the search results by field")

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/search/SearchResource.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/search/SearchResource.java
@@ -161,8 +161,8 @@ public class SearchResource {
       @Parameter(
               description =
                   "When paginating, specify the search_after cursor. Preferred form is the "
-                      + "base64-encoded JSON array returned by the previous page "
-                      + "(e.g. base64(\"[\\\"v1\\\",\\\"v2\\\"]\")); this form is unambiguous "
+                      + "URL-safe base64-encoded JSON array returned by the previous page "
+                      + "(e.g. base64(\"[\\\"v1\\\",\\\"v2\\\"]\")). This form is unambiguous "
                       + "when sort values contain commas (such as a glossary term FQN). "
                       + "A legacy comma-joined form (search_after=v1,v2) is also accepted but "
                       + "breaks when any value itself contains a ','.")
@@ -526,9 +526,9 @@ public class SearchResource {
       @Parameter(
               description =
                   "When paginating, specify the search_after cursor. Preferred form is the "
-                      + "base64-encoded JSON array returned by the previous page; the legacy "
-                      + "comma-joined form is also accepted but breaks when any sort value "
-                      + "contains a ','.")
+                      + "URL-safe base64-encoded JSON array returned by the previous page; "
+                      + "the legacy comma-joined form is also accepted but breaks when any "
+                      + "sort value contains a ','.")
           @QueryParam("search_after")
           String searchAfter,
       @Parameter(description = "Sort the search results by field")

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/SearchUtils.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/SearchUtils.java
@@ -351,9 +351,9 @@ public final class SearchUtils {
     }
     if (looksLikeBase64JsonCursor(searchAfter)) {
       try {
-        // MIME decoder accepts both standard (+,/) and URL-safe (-,_) alphabets, tolerates
-        // missing padding, and ignores whitespace — covers every base64 variant a client may emit.
-        byte[] decoded = Base64.getMimeDecoder().decode(searchAfter);
+        // URL-safe decoder paired with the URL-safe encoder used on the ingestion side,
+        // matching the symmetric pattern in RestUtil.encodeCursor/decodeCursor.
+        byte[] decoded = Base64.getUrlDecoder().decode(searchAfter);
         String json = new String(decoded, StandardCharsets.UTF_8).trim();
         if (json.startsWith("[")) {
           return JsonUtils.readValue(json, new TypeReference<List<Object>>() {});

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/SearchUtils.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/SearchUtils.java
@@ -336,8 +336,8 @@ public final class SearchUtils {
   /**
    * Decode an ES/OS search_after cursor passed as a query parameter.
    *
-   * <p>Preferred format: base64-encoded JSON array, e.g. base64("[\"v1\",\"v2\"]"). Unambiguous
-   * for values that contain ',' such as a glossary term FQN like
+   * <p>Preferred format: URL-safe base64-encoded JSON array, e.g. base64("[\"v1\",\"v2\"]").
+   * Unambiguous for values that contain ',' such as a glossary term FQN like
    * <pre>x alation archive.system glossary.sfmc (salesforce marketing cloud, exacttarget) (it system)</pre>
    *
    * <p>Legacy format: comma-joined values (e.g. "v1,v2"). Retained as a fallback so older
@@ -349,19 +349,37 @@ public final class SearchUtils {
     if (nullOrEmpty(searchAfter)) {
       return null;
     }
-    try {
-      byte[] decoded = Base64.getDecoder().decode(searchAfter);
-      String json = new String(decoded, StandardCharsets.UTF_8).trim();
-      if (json.startsWith("[")) {
-        return JsonUtils.readValue(json, new TypeReference<List<Object>>() {});
+    if (looksLikeBase64JsonCursor(searchAfter)) {
+      try {
+        // MIME decoder accepts both standard (+,/) and URL-safe (-,_) alphabets, tolerates
+        // missing padding, and ignores whitespace — covers every base64 variant a client may emit.
+        byte[] decoded = Base64.getMimeDecoder().decode(searchAfter);
+        String json = new String(decoded, StandardCharsets.UTF_8).trim();
+        if (json.startsWith("[")) {
+          return JsonUtils.readValue(json, new TypeReference<List<Object>>() {});
+        }
+      } catch (RuntimeException e) {
+        LOG.debug(
+            "search_after looked like a base64-JSON cursor but failed to decode, "
+                + "falling back to legacy comma split: {}",
+            e.getMessage());
       }
-    } catch (RuntimeException e) {
-      // IllegalArgumentException from Base64.decode or JsonUtils' parse exception:
-      // either way fall through to the legacy comma split.
-      LOG.debug(
-          "search_after is not a base64-JSON cursor, using legacy comma split: {}", e.getMessage());
     }
     return List.of(searchAfter.split(","));
+  }
+
+  /**
+   * Cheap pre-check to avoid attempting a base64 decode on values that obviously are not base64.
+   * Bypassing the decode + exception path keeps legacy-cursor requests off the slow path.
+   *
+   * <p>The base64 alphabet (standard and URL-safe) does not contain ',', so any cursor that
+   * contains one is necessarily a legacy comma-joined cursor and never a new base64-JSON cursor.
+   * Base64 output is also always a multiple of 4 chars (URL-safe with padding included). These two
+   * checks together exclude every legacy cursor with near-zero cost.
+   */
+  private static boolean looksLikeBase64JsonCursor(String value) {
+    int length = value.length();
+    return length >= 4 && length % 4 == 0 && value.indexOf(',') < 0;
   }
 
   public static List<String> sourceFields(String sourceFields) {

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/SearchUtils.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/SearchUtils.java
@@ -6,11 +6,14 @@ import static org.openmetadata.service.search.SearchClient.UPSTREAM_ENTITY_RELAT
 import static org.openmetadata.service.search.SearchClient.UPSTREAM_LINEAGE_FIELD;
 import static org.openmetadata.service.search.elasticsearch.ElasticSearchClient.SOURCE_FIELDS_TO_EXCLUDE;
 
+import com.fasterxml.jackson.core.type.TypeReference;
 import jakarta.json.JsonArray;
 import jakarta.json.JsonObject;
+import java.nio.charset.StandardCharsets;
 import java.security.KeyStoreException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Base64;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
@@ -330,11 +333,35 @@ public final class SearchUtils {
     return requiredFields;
   }
 
+  /**
+   * Decode an ES/OS search_after cursor passed as a query parameter.
+   *
+   * <p>Preferred format: base64-encoded JSON array, e.g. base64("[\"v1\",\"v2\"]"). Unambiguous
+   * for values that contain ',' such as a glossary term FQN like
+   * <pre>x alation archive.system glossary.sfmc (salesforce marketing cloud, exacttarget) (it system)</pre>
+   *
+   * <p>Legacy format: comma-joined values (e.g. "v1,v2"). Retained as a fallback so older
+   * ingestion clients continue to paginate; the legacy form is broken when any value contains a
+   * ',' and produces an ES "search_after has N value(s) but sort has M" error. New clients
+   * should emit the base64-JSON form.
+   */
   public static List<Object> searchAfter(String searchAfter) {
-    if (!nullOrEmpty(searchAfter)) {
-      return List.of(searchAfter.split(","));
+    if (nullOrEmpty(searchAfter)) {
+      return null;
     }
-    return null;
+    try {
+      byte[] decoded = Base64.getDecoder().decode(searchAfter);
+      String json = new String(decoded, StandardCharsets.UTF_8).trim();
+      if (json.startsWith("[")) {
+        return JsonUtils.readValue(json, new TypeReference<List<Object>>() {});
+      }
+    } catch (RuntimeException e) {
+      // IllegalArgumentException from Base64.decode or JsonUtils' parse exception:
+      // either way fall through to the legacy comma split.
+      LOG.debug(
+          "search_after is not a base64-JSON cursor, using legacy comma split: {}", e.getMessage());
+    }
+    return List.of(searchAfter.split(","));
   }
 
   public static List<String> sourceFields(String sourceFields) {

--- a/openmetadata-service/src/test/java/org/openmetadata/service/search/SearchUtilsTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/search/SearchUtilsTest.java
@@ -611,6 +611,22 @@ class SearchUtilsTest {
     assertEquals(cursor, result.get(0));
   }
 
+  @Test
+  void searchAfterAcceptsUrlSafeBase64Cursor() {
+    // The Python ingestion client emits URL-safe base64 to avoid '+' / '/' that
+    // would otherwise need percent-encoding. The server must decode both alphabets.
+    // Force a payload that produces the URL-safe-only characters '-' or '_': the
+    // bytes 0xFB,0xFF,0xBF encode to "+/+/" in standard base64 and "-_-_" in URL-safe.
+    byte[] urlSafeOnlyBytes = {(byte) 0xFB, (byte) 0xFF, (byte) 0xBF};
+    String urlSafeChunk = Base64.getUrlEncoder().encodeToString(urlSafeOnlyBytes);
+    assertTrue(urlSafeChunk.indexOf('-') >= 0 || urlSafeChunk.indexOf('_') >= 0);
+
+    String cursor =
+        Base64.getUrlEncoder().encodeToString("[\"alpha,beta\"]".getBytes(StandardCharsets.UTF_8));
+    List<Object> result = SearchUtils.searchAfter(cursor);
+    assertEquals(List.of("alpha,beta"), result);
+  }
+
   private static String encodeBase64Json(String json) {
     return Base64.getEncoder().encodeToString(json.getBytes(StandardCharsets.UTF_8));
   }

--- a/openmetadata-service/src/test/java/org/openmetadata/service/search/SearchUtilsTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/search/SearchUtilsTest.java
@@ -613,18 +613,19 @@ class SearchUtilsTest {
 
   @Test
   void searchAfterAcceptsUrlSafeBase64Cursor() {
-    // The Python ingestion client emits URL-safe base64 to avoid '+' / '/' that
-    // would otherwise need percent-encoding. The server must decode both alphabets.
-    // Force a payload that produces the URL-safe-only characters '-' or '_': the
-    // bytes 0xFB,0xFF,0xBF encode to "+/+/" in standard base64 and "-_-_" in URL-safe.
-    byte[] urlSafeOnlyBytes = {(byte) 0xFB, (byte) 0xFF, (byte) 0xBF};
-    String urlSafeChunk = Base64.getUrlEncoder().encodeToString(urlSafeOnlyBytes);
-    assertTrue(urlSafeChunk.indexOf('-') >= 0 || urlSafeChunk.indexOf('_') >= 0);
+    // The Python ingestion client emits URL-safe base64. The payload "[\"~~~\"]" base64-encodes
+    // to "WyJ-fn4iXQ==" which contains the URL-safe-only character '-' (the standard base64
+    // encoder would produce "WyJ+fn4iXQ=="). A decoder paired to the wrong alphabet either
+    // throws or silently drops the '-' / '_' chars, masking the bug — pick a payload that
+    // actually exercises the URL-safe alphabet so this test fails if the decoder ever drifts.
+    String json = "[\"~~~\"]";
+    String cursor = Base64.getUrlEncoder().encodeToString(json.getBytes(StandardCharsets.UTF_8));
+    assertTrue(
+        cursor.indexOf('-') >= 0 || cursor.indexOf('_') >= 0,
+        "test payload must produce URL-safe-only base64 chars to exercise the decoder");
 
-    String cursor =
-        Base64.getUrlEncoder().encodeToString("[\"alpha,beta\"]".getBytes(StandardCharsets.UTF_8));
     List<Object> result = SearchUtils.searchAfter(cursor);
-    assertEquals(List.of("alpha,beta"), result);
+    assertEquals(List.of("~~~"), result);
   }
 
   private static String encodeBase64Json(String json) {

--- a/openmetadata-service/src/test/java/org/openmetadata/service/search/SearchUtilsTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/search/SearchUtilsTest.java
@@ -15,6 +15,8 @@ import jakarta.json.Json;
 import jakarta.json.JsonArray;
 import jakarta.json.JsonObject;
 import java.io.StringReader;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -556,6 +558,61 @@ class SearchUtilsTest {
     assertTrue(SearchUtils.isColumnIndex(Entity.TABLE_COLUMN));
     assertFalse(SearchUtils.isColumnIndex("table_search_index"));
     assertFalse(SearchUtils.isColumnIndex("garbage"));
+  }
+
+  // ===========================================================================
+  // search_after cursor decoding — regression for #28076.
+  // The legacy comma-joined cursor breaks when any sort value (e.g. a glossary
+  // term FQN) contains a literal ','. The decoder accepts a base64-encoded
+  // JSON array as the unambiguous wire format and falls back to the legacy
+  // split(",") form so older ingestion clients keep paginating.
+  // ===========================================================================
+
+  @Test
+  void searchAfterReturnsNullForEmptyInput() {
+    assertNull(SearchUtils.searchAfter(""));
+  }
+
+  @Test
+  void searchAfterBase64JsonPreservesValueContainingComma() {
+    // Mirrors the customer FQN from #28076 / Pylon #19901.
+    String commaFqn =
+        "x alation archive.system glossary.sfmc (salesforce marketing cloud, exacttarget) (it system)";
+    String cursor = encodeBase64Json("[\"" + commaFqn + "\"]");
+
+    List<Object> result = SearchUtils.searchAfter(cursor);
+    assertEquals(1, result.size());
+    assertEquals(commaFqn, result.get(0));
+  }
+
+  @Test
+  void searchAfterBase64JsonParsesMultiValueCursor() {
+    String cursor = encodeBase64Json("[\"alpha\",1.5]");
+    List<Object> result = SearchUtils.searchAfter(cursor);
+    assertEquals(2, result.size());
+    assertEquals("alpha", result.get(0));
+    assertEquals(1.5, result.get(1));
+  }
+
+  @Test
+  void searchAfterFallsBackToLegacySplitWhenInputIsNotBase64() {
+    // "alpha,beta" is not valid base64 (',' is outside the alphabet) so it
+    // must fall back to the legacy comma split.
+    assertEquals(List.of("alpha", "beta"), SearchUtils.searchAfter("alpha,beta"));
+  }
+
+  @Test
+  void searchAfterFallsBackToLegacySplitWhenDecodedPayloadIsNotJsonArray() {
+    // base64("hello") decodes cleanly but is not a JSON array, so the cursor
+    // is treated as a single legacy value (no embedded ',').
+    String cursor = encodeBase64Json("hello");
+    List<Object> result = SearchUtils.searchAfter(cursor);
+    assertEquals(1, result.size());
+    assertEquals(cursor, result.get(0));
+  }
+
+  private static String encodeBase64Json(String json) {
+    return Base64.getEncoder().encodeToString(json.getBytes(StandardCharsets.UTF_8));
   }
 
   @ParameterizedTest(name = "mapEntityTypesToIndexNames(\"{0}\") == \"{1}\"")

--- a/openmetadata-spec/src/main/resources/json/schema/search/searchRequest.json
+++ b/openmetadata-spec/src/main/resources/json/schema/search/searchRequest.json
@@ -85,7 +85,7 @@
       }
     },
     "searchAfter": {
-      "description": "When paginating, specify the search_after values. Use it ass search_after=<val1>,<val2>,...",
+      "description": "When paginating, specify the search_after cursor returned by the previous page. Preferred form is the URL-safe base64-encoded JSON array (e.g. base64(\"[\\\"v1\\\",\\\"v2\\\"]\")), which is unambiguous when sort values contain commas. A legacy comma-joined form (search_after=v1,v2) is also accepted but breaks when any value itself contains a ','.",
       "existingJavaType": "java.util.List<java.lang.Object>"
     },
     "domains": {

--- a/openmetadata-ui/src/main/resources/ui/src/generated/search/searchRequest.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/search/searchRequest.ts
@@ -83,8 +83,10 @@ export interface SearchRequest {
      */
     queryFilter?: string;
     /**
-     * When paginating, specify the search_after values. Use it ass
-     * search_after=<val1>,<val2>,...
+     * When paginating, specify the search_after cursor returned by the previous page. Preferred
+     * form is the URL-safe base64-encoded JSON array (e.g. base64("[\"v1\",\"v2\"]")), which is
+     * unambiguous when sort values contain commas. A legacy comma-joined form
+     * (search_after=v1,v2) is also accepted but breaks when any value itself contains a ','.
      */
     searchAfter?: any;
     /**


### PR DESCRIPTION


## Problem

Automations and any ingestion path that uses `paginate_es` truncate silently when sorted entities have a `,` in the sort value. The customer-reported case (Pylon #19901, issue #28076) processed 311 of 1,863 glossary terms because the cursor at one page boundary was an FQN containing a comma:

```
x alation archive.system glossary.sfmc (salesforce marketing cloud, exacttarget) (it system)
```

The server logs the underlying ES error:

```
illegal_argument_exception: search_after has 2 value(s) but sort has 1
```

## Root cause

Both sides of the cursor protocol assume `,` is a safe delimiter:

- Ingestion (`es_mixin.py`): `after = ",".join(last_hit.sort)`
- Server (`SearchUtils.searchAfter`): `List.of(searchAfter.split(","))`

FQNs are allowed to contain `,` per the entity-name schema (`pattern: "^((?!::).)*$"`). When a value contains a comma, the join+split round-trip produces N+1 values for an N-field sort, and ES rejects the next-page request. The wire format is fundamentally ambiguous — given `a,b,c` and 2 sort fields, the values could be `("a","b,c")`, `("a,b","c")`, or three values, with no way to disambiguate from the cursor alone.

## Fix

Switch the cursor to a **base64-encoded JSON array** — the same pattern already used in the codebase by `OpenSearchColumnAggregator.decodeCursor` / `ElasticSearchColumnAggregator.decodeCursor` and documented in the public `columnGridResponse.cursor` schema. Backward compatibility is preserved: the server tries base64-JSON first and falls back to the legacy `split(",")` when the value isn't a base64-JSON cursor, so older ingestion clients (1.6 → 1.12) keep paginating against an upgraded server.

UI is unaffected — the Explore page uses `from`+`size` offset pagination and never constructs `?search_after=`.

## Changes

| File | Change |
|---|---|
| `openmetadata-service/.../search/SearchUtils.java` | `searchAfter()` tries base64-JSON then falls through to legacy split |
| `openmetadata-service/.../resources/search/SearchResource.java` | `@Parameter` description for `search_after` documents both formats |
| `ingestion/.../ometa/mixins/es_mixin.py` | `_paginate_es_internal` emits a base64-JSON cursor |
| `openmetadata-service/.../test/.../SearchUtilsTest.java` | 5 new test methods covering the new format, legacy fallback, and the customer's exact comma-FQN |
| `ingestion/tests/integration/ometa/test_ometa_es_api.py` | `test_paginate_with_comma_in_name` — creates 5 tables with `,` in the name, paginates with `size=1`, asserts all 5 are returned |

## Verification

- `mvn -pl openmetadata-service test -Dtest=SearchUtilsTest` — 109 tests pass (5 new).
- End-to-end round-trip validated: Python encodes → Java decodes → original FQN with comma preserved verbatim.
- `OpenSearchSearchManagerIntegrationTest` / `ElasticSearchSearchManagerIntegrationTest` exercise `search_after` against a real ES/OS container and continue to pass — they validate the legacy fallback path.

Closes #28076. Supersedes #28132.

----
## Summary by Gitar

- **TypeScript types:**
  - Update `searchRequest.ts` to reflect the change in `searchAfter` parameter format.

<sub>This will update automatically on new commits.</sub>