### PR TITLE
ci(airflow-apis-tests): migrate Sonar step to sonarqube-scan-action@v7 with retry + add workflow_dispatch

### DIFF
--- a/.github/workflows/airflow-apis-tests.yml
+++ b/.github/workflows/airflow-apis-tests.yml
@@ -16,6 +16,7 @@ on:
     types: [labeled, opened, synchronize, reopened, ready_for_review]
     paths:
       - 'openmetadata-airflow-apis/**'
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -124,7 +125,7 @@ jobs:
 
     - name: Push Results in PR to Sonar
       id: push-to-sonar
-      if: ${{ github.event_name == 'pull_request_target' }}
+      if: ${{ github.event_name == 'pull_request_target' || github.event_name == 'workflow_dispatch' }}
       continue-on-error: true
       uses: SonarSource/sonarqube-scan-action@v7
       env:
@@ -136,13 +137,13 @@ jobs:
 
     # next two steps are for retrying "Push Results in PR to Sonar" step in case it fails
     - name: Wait to retry 'Push Results in PR to Sonar'
-      if: ${{ github.event_name == 'pull_request_target' && steps.push-to-sonar.outcome != 'success' }}
+      if: ${{ (github.event_name == 'pull_request_target' || github.event_name == 'workflow_dispatch') && steps.push-to-sonar.outcome != 'success' }}
       run: sleep 20s
       shell: bash
 
     - name: Retry 'Push Results in PR to Sonar'
       uses: SonarSource/sonarqube-scan-action@v7
-      if: ${{ github.event_name == 'pull_request_target' && steps.push-to-sonar.outcome != 'success' }}
+      if: ${{ (github.event_name == 'pull_request_target' || github.event_name == 'workflow_dispatch') && steps.push-to-sonar.outcome != 'success' }}
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         SONAR_TOKEN: ${{ secrets.AIRFLOW_APIS_SONAR_TOKEN }}

--- a/.github/workflows/airflow-apis-tests.yml
+++ b/.github/workflows/airflow-apis-tests.yml
@@ -125,7 +125,7 @@ jobs:
 
     - name: Push Results in PR to Sonar
       id: push-to-sonar
-      if: ${{ github.event_name == 'pull_request_target' || github.event_name == 'workflow_dispatch' }}
+      if: ${{ github.event_name == 'pull_request_target' }}
       continue-on-error: true
       uses: SonarSource/sonarqube-scan-action@v7
       env:
@@ -137,13 +137,13 @@ jobs:
 
     # next two steps are for retrying "Push Results in PR to Sonar" step in case it fails
     - name: Wait to retry 'Push Results in PR to Sonar'
-      if: ${{ (github.event_name == 'pull_request_target' || github.event_name == 'workflow_dispatch') && steps.push-to-sonar.outcome != 'success' }}
+      if: ${{ github.event_name == 'pull_request_target' && steps.push-to-sonar.outcome != 'success' }}
       run: sleep 20s
       shell: bash
 
     - name: Retry 'Push Results in PR to Sonar'
       uses: SonarSource/sonarqube-scan-action@v7
-      if: ${{ (github.event_name == 'pull_request_target' || github.event_name == 'workflow_dispatch') && steps.push-to-sonar.outcome != 'success' }}
+      if: ${{ github.event_name == 'pull_request_target' && steps.push-to-sonar.outcome != 'success' }}
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         SONAR_TOKEN: ${{ secrets.AIRFLOW_APIS_SONAR_TOKEN }}

--- a/.github/workflows/airflow-apis-tests.yml
+++ b/.github/workflows/airflow-apis-tests.yml
@@ -20,9 +20,19 @@ on:
 permissions:
   contents: read
 
-concurrency: 
+concurrency:
   group: airflow-apis-tests-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: true
+
+env:
+  SONAR_OPTS: >-
+    -Dproject.settings=openmetadata-airflow-apis/sonar-project.properties
+    -Dsonar.pullrequest.key=${{ github.event.pull_request.number }}
+    -Dsonar.pullrequest.branch=${{ github.event.pull_request.head.ref }}
+    -Dsonar.pullrequest.github.repository=OpenMetadata
+    -Dsonar.scm.revision=${{ github.event.pull_request.head.sha }}
+    -Dsonar.pullrequest.provider=github
+
 jobs:
   airflow-apis-tests:
     runs-on: ubuntu-latest
@@ -113,26 +123,39 @@ jobs:
         sed -i 's/openmetadata_managed_apis/\/github\/workspace\/openmetadata-airflow-apis\/openmetadata_managed_apis/g' openmetadata-airflow-apis/ci-coverage.xml
 
     - name: Push Results in PR to Sonar
-      uses: sonarsource/sonarcloud-github-action@master
+      id: push-to-sonar
       if: ${{ github.event_name == 'pull_request_target' }}
+      continue-on-error: true
+      uses: SonarSource/sonarqube-scan-action@v7
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         SONAR_TOKEN: ${{ secrets.AIRFLOW_APIS_SONAR_TOKEN }}
       with:
         projectBaseDir: openmetadata-airflow-apis/
-        args: >
-          -Dproject.settings=openmetadata-airflow-apis/sonar-project.properties
-          -Dsonar.pullrequest.key=${{ github.event.pull_request.number }}
-          -Dsonar.pullrequest.branch=${{ github.event.pull_request.head.ref }}
-          -Dsonar.pullrequest.github.repository=OpenMetadata
-          -Dsonar.scm.revision=${{ github.event.pull_request.head.sha }}
-          -Dsonar.pullrequest.provider=github
+        args: ${{ env.SONAR_OPTS }}
+
+    # next two steps are for retrying "Push Results in PR to Sonar" step in case it fails
+    - name: Wait to retry 'Push Results in PR to Sonar'
+      if: ${{ github.event_name == 'pull_request_target' && steps.push-to-sonar.outcome != 'success' }}
+      run: sleep 20s
+      shell: bash
+
+    - name: Retry 'Push Results in PR to Sonar'
+      uses: SonarSource/sonarqube-scan-action@v7
+      if: ${{ github.event_name == 'pull_request_target' && steps.push-to-sonar.outcome != 'success' }}
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        SONAR_TOKEN: ${{ secrets.AIRFLOW_APIS_SONAR_TOKEN }}
+      with:
+        projectBaseDir: openmetadata-airflow-apis/
+        args: ${{ env.SONAR_OPTS }}
 
     - name: Push Results to Sonar
-      uses: sonarsource/sonarcloud-github-action@master
+      uses: SonarSource/sonarqube-scan-action@v7
       if: ${{ github.event_name == 'push' }}
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         SONAR_TOKEN: ${{ secrets.AIRFLOW_APIS_SONAR_TOKEN }}
       with:
         projectBaseDir: openmetadata-airflow-apis/
+        args: -Dproject.settings=openmetadata-airflow-apis/sonar-project.properties


### PR DESCRIPTION
## Problem
`airflow-apis-tests` fails intermittently on the `Push Results in PR to
Sonar` step with `Failed to query JRE metadata: …` — a transient flake of
Sonar's JRE-provisioning endpoint. The step ran the **deprecated**
`sonarsource/sonarcloud-github-action@master` as a single shot with no
retry, so one bad first attempt = red PR. Example:
https://github.com/open-metadata/OpenMetadata/actions/runs/26016191312/job/76466628143

## Fix
Mirror the pattern `py-tests.yml` already uses successfully:
- Migrate the Sonar step from the deprecated `sonarsource/sonarcloud-github-action@master` to **`SonarSource/sonarqube-scan-action@v7`** (also for the `push` event variant).
- Mark the PR scan `continue-on-error: true` and add a `sleep 20s` + retry step so a transient JRE-provisioning flake no longer fails the job on first attempt.
- Hoist the shared Sonar args into a workflow-level `SONAR_OPTS` env so the PR step and its retry don't duplicate flags.
- Add a `workflow_dispatch:` trigger and extend the Sonar PR step's `if:` to run on dispatch — lets us exercise the retry path from the Actions UI without needing a PR.

Build/test surface is unchanged — only the Sonar reporting tail and the new manual trigger were touched.

## Validation
- Same project key (`open-metadata-airflow-apis`) and org (`open-metadata`) → same SonarCloud target py-tests already publishes to with `@v7`.
- After merge, dispatch from the Actions UI (`airflow-apis-tests` → Run workflow) to verify the new retry path on a real run.
- Next organic airflow-apis PR that hits a JRE-provisioning flake should now recover on the retry instead of failing.

----
## Summary by Gitar

- **CI Configuration:**
  - Scoped Sonar scan steps to `pull_request_target` only in `.github/workflows/airflow-apis-tests.yml` by removing `workflow_dispatch` trigger logic.

<sub>This will update automatically on new commits.</sub>