### PR TITLE
Fixes #28245: ingest valueless Databricks/Unity Catalog tags

### DIFF
--- a/ingestion/src/metadata/ingestion/source/database/databricks/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/database/databricks/metadata.py
@@ -760,8 +760,8 @@ class DatabricksSource(ExternalTableLineageMixin, CommonDbSourceService, MultiDB
     def _ometa_tag_call_args(tag_name: str, tag_value: str | None) -> dict:
         """Map a Databricks (tag_name, tag_value) pair onto OM's
         classification/tag pair, falling back to DATABRICKS_VALUELESS_CLASSIFICATION
-        when tag_value is empty."""
-        if tag_value:
+        when tag_value is empty or whitespace-only."""
+        if tag_value and str(tag_value).strip():
             return {
                 "tags": [tag_value],
                 "classification_name": tag_name,
@@ -876,6 +876,8 @@ class DatabricksSource(ExternalTableLineageMixin, CommonDbSourceService, MultiDB
         try:
             catalog_tags = self.catalog_tags.get(database_name, [])
             for tag_name, tag_value in catalog_tags:
+                if not tag_name:
+                    continue
                 yield from get_ometa_tag_and_classification(
                     tag_fqn=fqn.build(
                         self.metadata,
@@ -904,6 +906,8 @@ class DatabricksSource(ExternalTableLineageMixin, CommonDbSourceService, MultiDB
         try:
             schema_tags = self.schema_tags.get((self.context.get().database, schema_name), [])
             for tag_name, tag_value in schema_tags:
+                if not tag_name:
+                    continue
                 yield from get_ometa_tag_and_classification(
                     tag_fqn=fqn.build(
                         self.metadata,
@@ -941,6 +945,8 @@ class DatabricksSource(ExternalTableLineageMixin, CommonDbSourceService, MultiDB
                 [],
             )
             for tag_name, tag_value in table_tags:
+                if not tag_name:
+                    continue
                 yield from get_ometa_tag_and_classification(
                     tag_fqn=fqn.build(
                         self.metadata,
@@ -965,6 +971,8 @@ class DatabricksSource(ExternalTableLineageMixin, CommonDbSourceService, MultiDB
             )
             for column_name, tags in column_tags.items():
                 for tag_name, tag_value in tags or []:
+                    if not tag_name:
+                        continue
                     yield from get_ometa_tag_and_classification(
                         tag_fqn=fqn.build(
                             self.metadata,

--- a/ingestion/src/metadata/ingestion/source/database/databricks/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/database/databricks/metadata.py
@@ -89,7 +89,8 @@ logger = ingestion_logger()
 
 DATABRICKS_TAG = "DATABRICKS TAG"
 DATABRICKS_TAG_CLASSIFICATION = "DATABRICKS TAG CLASSIFICATION"
-DEFAULT_TAG_VALUE = "NONE"
+DATABRICKS_VALUELESS_CLASSIFICATION = "DATABRICKS_TAGS"
+DATABRICKS_VALUELESS_CLASSIFICATION_DESCRIPTION = "Databricks tags ingested as key-only (no associated value)."
 
 
 class STRUCT(String):
@@ -749,11 +750,30 @@ class DatabricksSource(ExternalTableLineageMixin, CommonDbSourceService, MultiDB
         self.schema_tags.clear()
         self.column_tags.clear()
 
-    def _add_to_tag_cache(self, tag_dict: dict, key: Union[str, Tuple], value: Tuple[str, str]):  # noqa: UP006, UP007
+    def _add_to_tag_cache(self, tag_dict: dict, key: Union[str, Tuple], value: Tuple[str, str | None]):  # noqa: UP006, UP007
         if tag_dict.get(key):
             tag_dict.get(key).append(value)
         else:
             tag_dict[key] = [value]
+
+    @staticmethod
+    def _ometa_tag_call_args(tag_name: str, tag_value: str | None) -> dict:
+        """Map a Databricks (tag_name, tag_value) pair onto OM's
+        classification/tag pair, falling back to DATABRICKS_VALUELESS_CLASSIFICATION
+        when tag_value is empty."""
+        if tag_value:
+            return {
+                "tags": [tag_value],
+                "classification_name": tag_name,
+                "tag_description": DATABRICKS_TAG,
+                "classification_description": DATABRICKS_TAG_CLASSIFICATION,
+            }
+        return {
+            "tags": [tag_name],
+            "classification_name": DATABRICKS_VALUELESS_CLASSIFICATION,
+            "tag_description": DATABRICKS_VALUELESS_CLASSIFICATION_DESCRIPTION,
+            "classification_description": DATABRICKS_VALUELESS_CLASSIFICATION_DESCRIPTION,
+        }
 
     def populate_tags_cache(self, database_name: str) -> None:
         """
@@ -769,8 +789,7 @@ class DatabricksSource(ExternalTableLineageMixin, CommonDbSourceService, MultiDB
                 self._add_to_tag_cache(
                     self.catalog_tags,
                     tag.catalog_name,
-                    # tag value is an optional field, if tag value is not available use default tag value
-                    (tag.tag_name, tag.tag_value or DEFAULT_TAG_VALUE),
+                    (tag.tag_name, tag.tag_value),
                 )
         except Exception as exc:
             logger.debug(f"Failed to fetch catalog tags due to - {exc}")
@@ -781,8 +800,7 @@ class DatabricksSource(ExternalTableLineageMixin, CommonDbSourceService, MultiDB
                 self._add_to_tag_cache(
                     self.schema_tags,
                     (tag.catalog_name, tag.schema_name),
-                    # tag value is an optional field, if tag value is not available use default tag value
-                    (tag.tag_name, tag.tag_value or DEFAULT_TAG_VALUE),
+                    (tag.tag_name, tag.tag_value),
                 )
         except Exception as exc:
             logger.debug(f"Failed to fetch schema tags due to - {exc}")
@@ -793,8 +811,7 @@ class DatabricksSource(ExternalTableLineageMixin, CommonDbSourceService, MultiDB
                 self._add_to_tag_cache(
                     self.table_tags,
                     (tag.catalog_name, tag.schema_name, tag.table_name),
-                    # tag value is an optional field, if tag value is not available use default tag value
-                    (tag.tag_name, tag.tag_value or DEFAULT_TAG_VALUE),
+                    (tag.tag_name, tag.tag_value),
                 )
         except Exception as exc:
             logger.debug(f"Failed to fetch table tags due to - {exc}")
@@ -807,18 +824,10 @@ class DatabricksSource(ExternalTableLineageMixin, CommonDbSourceService, MultiDB
                     self._add_to_tag_cache(
                         self.column_tags.get(tag_table_id),
                         tag.column_name,
-                        # tag value is an optional field, if tag value is not available use default tag value
-                        (tag.tag_name, tag.tag_value or DEFAULT_TAG_VALUE),
+                        (tag.tag_name, tag.tag_value),
                     )
                 else:
-                    self.column_tags[tag_table_id] = {
-                        tag.column_name: [
-                            (
-                                tag.tag_name,
-                                tag.tag_value or DEFAULT_TAG_VALUE,
-                            )
-                        ]
-                    }
+                    self.column_tags[tag_table_id] = {tag.column_name: [(tag.tag_name, tag.tag_value)]}
         except Exception as exc:
             logger.debug(f"Failed to fetch column tags due to - {exc}")
 
@@ -874,10 +883,7 @@ class DatabricksSource(ExternalTableLineageMixin, CommonDbSourceService, MultiDB
                         service_name=self.context.get().database_service,
                         database_name=database_name,
                     ),
-                    tags=[tag_value],
-                    classification_name=tag_name,
-                    tag_description=DATABRICKS_TAG,
-                    classification_description=DATABRICKS_TAG_CLASSIFICATION,
+                    **self._ometa_tag_call_args(tag_name, tag_value),
                     metadata=self.metadata,
                     system_tags=True,
                 )
@@ -906,10 +912,7 @@ class DatabricksSource(ExternalTableLineageMixin, CommonDbSourceService, MultiDB
                         database_name=self.context.get().database,
                         schema_name=schema_name,
                     ),
-                    tags=[tag_value],
-                    classification_name=tag_name,
-                    tag_description=DATABRICKS_TAG,
-                    classification_description=DATABRICKS_TAG_CLASSIFICATION,
+                    **self._ometa_tag_call_args(tag_name, tag_value),
                     metadata=self.metadata,
                     system_tags=True,
                 )
@@ -947,10 +950,7 @@ class DatabricksSource(ExternalTableLineageMixin, CommonDbSourceService, MultiDB
                         schema_name=self.context.get().database_schema,
                         table_name=table_name,
                     ),
-                    tags=[tag_value],
-                    classification_name=tag_name,
-                    tag_description=DATABRICKS_TAG,
-                    classification_description=DATABRICKS_TAG_CLASSIFICATION,
+                    **self._ometa_tag_call_args(tag_name, tag_value),
                     metadata=self.metadata,
                     system_tags=True,
                 )
@@ -975,10 +975,7 @@ class DatabricksSource(ExternalTableLineageMixin, CommonDbSourceService, MultiDB
                             table_name=table_name,
                             column_name=column_name,
                         ),
-                        tags=[tag_value],
-                        classification_name=tag_name,
-                        tag_description=DATABRICKS_TAG,
-                        classification_description=DATABRICKS_TAG_CLASSIFICATION,
+                        **self._ometa_tag_call_args(tag_name, tag_value),
                         metadata=self.metadata,
                         system_tags=True,
                     )

--- a/ingestion/src/metadata/ingestion/source/database/unitycatalog/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/database/unitycatalog/metadata.py
@@ -95,6 +95,8 @@ logger = ingestion_logger()
 
 UNITY_CATALOG_TAG = "UNITY CATALOG TAG"
 UNITY_CATALOG_TAG_CLASSIFICATION = "UNITY CATALOG TAG CLASSIFICATION"
+UNITY_CATALOG_VALUELESS_CLASSIFICATION = "UNITY_CATALOG_TAGS"
+UNITY_CATALOG_VALUELESS_CLASSIFICATION_DESCRIPTION = "Unity Catalog tags ingested as key-only (no associated value)."
 
 
 # pylint: disable=protected-access
@@ -558,6 +560,25 @@ class UnitycatalogSource(ExternalTableLineageMixin, DatabaseServiceSource, Multi
             )
             yield parsed_column
 
+    @staticmethod
+    def _ometa_tag_call_args(tag_name: str, tag_value: str | None) -> dict:
+        """Map a Unity Catalog (tag_name, tag_value) pair onto OM's
+        classification/tag pair, falling back to UNITY_CATALOG_VALUELESS_CLASSIFICATION
+        when tag_value is empty."""
+        if tag_value:
+            return {
+                "tags": [tag_value],
+                "classification_name": tag_name,
+                "tag_description": UNITY_CATALOG_TAG,
+                "classification_description": UNITY_CATALOG_TAG_CLASSIFICATION,
+            }
+        return {
+            "tags": [tag_name],
+            "classification_name": UNITY_CATALOG_VALUELESS_CLASSIFICATION,
+            "tag_description": UNITY_CATALOG_VALUELESS_CLASSIFICATION_DESCRIPTION,
+            "classification_description": UNITY_CATALOG_VALUELESS_CLASSIFICATION_DESCRIPTION,
+        }
+
     def yield_database_tag(self, database_name: str) -> Iterable[Either[OMetaTagAndClassification]]:
         """Get Unity Catalog database/catalog tags using SQL query"""
         query_tag_fqn_builder_mapping = (
@@ -577,16 +598,14 @@ class UnitycatalogSource(ExternalTableLineageMixin, DatabaseServiceSource, Multi
         try:
             for query, tag_fqn_builder in query_tag_fqn_builder_mapping:
                 for tag in self.sql_connection.execute(text(query)):
-                    if tag.tag_value:
-                        yield from get_ometa_tag_and_classification(
-                            tag_fqn=FullyQualifiedEntityName(fqn._build(*tag_fqn_builder(tag))),
-                            tags=[tag.tag_value],
-                            classification_name=tag.tag_name,
-                            tag_description=UNITY_CATALOG_TAG,
-                            classification_description=UNITY_CATALOG_TAG_CLASSIFICATION,
-                            metadata=self.metadata,
-                            system_tags=True,
-                        )
+                    if not tag.tag_name:
+                        continue
+                    yield from get_ometa_tag_and_classification(
+                        tag_fqn=FullyQualifiedEntityName(fqn._build(*tag_fqn_builder(tag))),
+                        **self._ometa_tag_call_args(tag.tag_name, tag.tag_value),
+                        metadata=self.metadata,
+                        system_tags=True,
+                    )
         except Exception as exc:
             logger.debug(traceback.format_exc())
             logger.warning(f"Error getting tags for catalog/schema {database_name}: {exc}")
@@ -618,16 +637,14 @@ class UnitycatalogSource(ExternalTableLineageMixin, DatabaseServiceSource, Multi
         try:
             for query, tag_fqn_builder in query_tag_fqn_builder_mapping:
                 for tag in self.sql_connection.execute(text(query)):
-                    if tag.tag_value:
-                        yield from get_ometa_tag_and_classification(
-                            tag_fqn=FullyQualifiedEntityName(fqn._build(*tag_fqn_builder(tag))),
-                            tags=[tag.tag_value],
-                            classification_name=tag.tag_name,
-                            tag_description=UNITY_CATALOG_TAG,
-                            classification_description=UNITY_CATALOG_TAG_CLASSIFICATION,
-                            metadata=self.metadata,
-                            system_tags=True,
-                        )
+                    if not tag.tag_name:
+                        continue
+                    yield from get_ometa_tag_and_classification(
+                        tag_fqn=FullyQualifiedEntityName(fqn._build(*tag_fqn_builder(tag))),
+                        **self._ometa_tag_call_args(tag.tag_name, tag.tag_value),
+                        metadata=self.metadata,
+                        system_tags=True,
+                    )
         except Exception as exc:
             logger.debug(traceback.format_exc())
             logger.warning(f"Error getting tags for schema {schema_name}: {exc}")

--- a/ingestion/src/metadata/ingestion/source/database/unitycatalog/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/database/unitycatalog/metadata.py
@@ -564,8 +564,8 @@ class UnitycatalogSource(ExternalTableLineageMixin, DatabaseServiceSource, Multi
     def _ometa_tag_call_args(tag_name: str, tag_value: str | None) -> dict:
         """Map a Unity Catalog (tag_name, tag_value) pair onto OM's
         classification/tag pair, falling back to UNITY_CATALOG_VALUELESS_CLASSIFICATION
-        when tag_value is empty."""
-        if tag_value:
+        when tag_value is empty or whitespace-only."""
+        if tag_value and str(tag_value).strip():
             return {
                 "tags": [tag_value],
                 "classification_name": tag_name,

--- a/ingestion/tests/unit/topology/database/test_databricks_valueless_tags.py
+++ b/ingestion/tests/unit/topology/database/test_databricks_valueless_tags.py
@@ -17,6 +17,8 @@ to support Databricks system-generated / user-defined tags that carry only a
 name and no value (issue #28245).
 """
 
+from unittest.mock import MagicMock, patch
+
 from metadata.ingestion.source.database.databricks.metadata import (
     DATABRICKS_TAG,
     DATABRICKS_TAG_CLASSIFICATION,
@@ -57,6 +59,12 @@ class TestDatabricksOmetaTagCallArgs:
         assert args["classification_name"] == DATABRICKS_VALUELESS_CLASSIFICATION
         assert args["tags"] == ["plain_tag"]
 
+    def test_whitespace_only_tag_value_is_treated_as_valueless(self):
+        args = DatabricksSource._ometa_tag_call_args("plain_tag", "   ")
+
+        assert args["classification_name"] == DATABRICKS_VALUELESS_CLASSIFICATION
+        assert args["tags"] == ["plain_tag"]
+
     def test_valueless_tag_without_dot_uses_tag_name_verbatim(self):
         args = DatabricksSource._ometa_tag_call_args("simple_label", None)
 
@@ -65,3 +73,27 @@ class TestDatabricksOmetaTagCallArgs:
 
     def test_valueless_classification_constant_value(self):
         assert DATABRICKS_VALUELESS_CLASSIFICATION == "DATABRICKS_TAGS"
+
+
+class TestDatabricksYieldSkipsEmptyTagName:
+    """Rows with an empty/None tag_name are skipped so an empty classification
+    name is never sent to the API (parity with the Unity Catalog connector).
+    """
+
+    @patch(
+        "metadata.ingestion.source.database.databricks.metadata.get_ometa_tag_and_classification",
+        return_value=[],
+    )
+    @patch("metadata.ingestion.source.database.databricks.metadata.fqn")
+    def test_empty_or_none_tag_name_is_skipped(self, mock_fqn, mock_get_tag):
+        source = DatabricksSource.__new__(DatabricksSource)
+        source.metadata = MagicMock()
+        source.context = MagicMock()
+        source.catalog_tags = {"db": [("", "value"), (None, None), ("real_tag", None)]}
+
+        list(source.yield_database_tag("db"))
+
+        assert mock_get_tag.call_count == 1
+        _, kwargs = mock_get_tag.call_args
+        assert kwargs["classification_name"] == DATABRICKS_VALUELESS_CLASSIFICATION
+        assert kwargs["tags"] == ["real_tag"]

--- a/ingestion/tests/unit/topology/database/test_databricks_valueless_tags.py
+++ b/ingestion/tests/unit/topology/database/test_databricks_valueless_tags.py
@@ -1,0 +1,67 @@
+#  Copyright 2025 Collate
+#  Licensed under the Collate Community License, Version 1.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  https://github.com/open-metadata/OpenMetadata/blob/main/ingestion/LICENSE
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+"""
+Tests for Databricks valueless-tag handling.
+
+Covers the (tag_name, tag_value) -> (classification, tag) mapping introduced
+to support Databricks system-generated / user-defined tags that carry only a
+name and no value (issue #28245).
+"""
+
+from metadata.ingestion.source.database.databricks.metadata import (
+    DATABRICKS_TAG,
+    DATABRICKS_TAG_CLASSIFICATION,
+    DATABRICKS_VALUELESS_CLASSIFICATION,
+    DATABRICKS_VALUELESS_CLASSIFICATION_DESCRIPTION,
+    DatabricksSource,
+)
+
+
+class TestDatabricksOmetaTagCallArgs:
+    """_ometa_tag_call_args maps Databricks (tag_name, tag_value) onto the
+    classification/tag arguments passed to get_ometa_tag_and_classification.
+    """
+
+    def test_valued_tag_uses_tag_name_as_classification(self):
+        args = DatabricksSource._ometa_tag_call_args("pii", "ssn")
+
+        assert args == {
+            "tags": ["ssn"],
+            "classification_name": "pii",
+            "tag_description": DATABRICKS_TAG,
+            "classification_description": DATABRICKS_TAG_CLASSIFICATION,
+        }
+
+    def test_valueless_tag_falls_back_to_valueless_classification(self):
+        args = DatabricksSource._ometa_tag_call_args("class.us_ssn", None)
+
+        assert args == {
+            "tags": ["class.us_ssn"],
+            "classification_name": DATABRICKS_VALUELESS_CLASSIFICATION,
+            "tag_description": DATABRICKS_VALUELESS_CLASSIFICATION_DESCRIPTION,
+            "classification_description": DATABRICKS_VALUELESS_CLASSIFICATION_DESCRIPTION,
+        }
+
+    def test_empty_string_tag_value_is_treated_as_valueless(self):
+        args = DatabricksSource._ometa_tag_call_args("plain_tag", "")
+
+        assert args["classification_name"] == DATABRICKS_VALUELESS_CLASSIFICATION
+        assert args["tags"] == ["plain_tag"]
+
+    def test_valueless_tag_without_dot_uses_tag_name_verbatim(self):
+        args = DatabricksSource._ometa_tag_call_args("simple_label", None)
+
+        assert args["classification_name"] == DATABRICKS_VALUELESS_CLASSIFICATION
+        assert args["tags"] == ["simple_label"]
+
+    def test_valueless_classification_constant_value(self):
+        assert DATABRICKS_VALUELESS_CLASSIFICATION == "DATABRICKS_TAGS"

--- a/ingestion/tests/unit/topology/database/test_unitycatalog_valueless_tags.py
+++ b/ingestion/tests/unit/topology/database/test_unitycatalog_valueless_tags.py
@@ -1,0 +1,67 @@
+#  Copyright 2025 Collate
+#  Licensed under the Collate Community License, Version 1.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  https://github.com/open-metadata/OpenMetadata/blob/main/ingestion/LICENSE
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+"""
+Tests for Unity Catalog valueless-tag handling.
+
+Covers the (tag_name, tag_value) -> (classification, tag) mapping introduced
+to support Unity Catalog system-generated / user-defined tags that carry only
+a name and no value (issue #28245).
+"""
+
+from metadata.ingestion.source.database.unitycatalog.metadata import (
+    UNITY_CATALOG_TAG,
+    UNITY_CATALOG_TAG_CLASSIFICATION,
+    UNITY_CATALOG_VALUELESS_CLASSIFICATION,
+    UNITY_CATALOG_VALUELESS_CLASSIFICATION_DESCRIPTION,
+    UnitycatalogSource,
+)
+
+
+class TestUnitycatalogOmetaTagCallArgs:
+    """_ometa_tag_call_args maps Unity Catalog (tag_name, tag_value) onto the
+    classification/tag arguments passed to get_ometa_tag_and_classification.
+    """
+
+    def test_valued_tag_uses_tag_name_as_classification(self):
+        args = UnitycatalogSource._ometa_tag_call_args("pii", "ssn")
+
+        assert args == {
+            "tags": ["ssn"],
+            "classification_name": "pii",
+            "tag_description": UNITY_CATALOG_TAG,
+            "classification_description": UNITY_CATALOG_TAG_CLASSIFICATION,
+        }
+
+    def test_valueless_tag_falls_back_to_valueless_classification(self):
+        args = UnitycatalogSource._ometa_tag_call_args("class.us_ssn", None)
+
+        assert args == {
+            "tags": ["class.us_ssn"],
+            "classification_name": UNITY_CATALOG_VALUELESS_CLASSIFICATION,
+            "tag_description": UNITY_CATALOG_VALUELESS_CLASSIFICATION_DESCRIPTION,
+            "classification_description": UNITY_CATALOG_VALUELESS_CLASSIFICATION_DESCRIPTION,
+        }
+
+    def test_empty_string_tag_value_is_treated_as_valueless(self):
+        args = UnitycatalogSource._ometa_tag_call_args("plain_tag", "")
+
+        assert args["classification_name"] == UNITY_CATALOG_VALUELESS_CLASSIFICATION
+        assert args["tags"] == ["plain_tag"]
+
+    def test_valueless_tag_without_dot_uses_tag_name_verbatim(self):
+        args = UnitycatalogSource._ometa_tag_call_args("simple_label", None)
+
+        assert args["classification_name"] == UNITY_CATALOG_VALUELESS_CLASSIFICATION
+        assert args["tags"] == ["simple_label"]
+
+    def test_valueless_classification_constant_value(self):
+        assert UNITY_CATALOG_VALUELESS_CLASSIFICATION == "UNITY_CATALOG_TAGS"

--- a/ingestion/tests/unit/topology/database/test_unitycatalog_valueless_tags.py
+++ b/ingestion/tests/unit/topology/database/test_unitycatalog_valueless_tags.py
@@ -57,6 +57,12 @@ class TestUnitycatalogOmetaTagCallArgs:
         assert args["classification_name"] == UNITY_CATALOG_VALUELESS_CLASSIFICATION
         assert args["tags"] == ["plain_tag"]
 
+    def test_whitespace_only_tag_value_is_treated_as_valueless(self):
+        args = UnitycatalogSource._ometa_tag_call_args("plain_tag", "   ")
+
+        assert args["classification_name"] == UNITY_CATALOG_VALUELESS_CLASSIFICATION
+        assert args["tags"] == ["plain_tag"]
+
     def test_valueless_tag_without_dot_uses_tag_name_verbatim(self):
         args = UnitycatalogSource._ometa_tag_call_args("simple_label", None)
 


### PR DESCRIPTION
## Problem

Databricks Unity Catalog exposes system-generated tags (and some user-defined ones) as `(tag_name, tag_value=null)` — e.g. `class.us_ssn` with no value. The Databricks and Unity Catalog connectors map OpenMetadata's two-level `Classification.Tag` model as `tag_name → Classification`, `tag_value → Tag`. When `tag_value` is empty:

- **Unity Catalog** skipped the tag entirely (`if tag.tag_value:` guard).
- **Databricks** coerced it to a sentinel `"NONE"`, producing `<tag_name>.NONE`, which conflates a real `NONE` value with "no value".

Closes #28245.

## Fix

When `tag_value` is empty/null, fall back to a dedicated **per-connector** catch-all classification and use `tag_name` **verbatim** as the tag under it (no dot-splitting — valueless tags don't necessarily contain dots, and may be either system- or user-defined):

- Databricks → `DATABRICKS_TAGS`
- Unity Catalog → `UNITY_CATALOG_TAGS`

| `tag_value` | classification | tag |
|---|---|---|
| non-empty (unchanged) | `tag_name` | `tag_value` |
| empty / null | `DATABRICKS_TAGS` / `UNITY_CATALOG_TAGS` | `tag_name` |

The mapping is centralized in a small `_ometa_tag_call_args` helper per connector; the shared `get_ometa_tag_and_classification` utility is unchanged (it already skips empty/whitespace tag entries, guarding the `tag_name`-also-empty edge case).

## Naming note

The fallback classification is intentionally **neutral** (`*_TAGS`, not `*_SYSTEM_TAGS`): a valueless tag can be user-defined as well as system-generated, so the name must not claim "system".

## Trade-off (acknowledged, out of scope)

If a tag transitions `tag_value=null → <value>` between ingestions, the column ends up with **both** `DATABRICKS_TAGS.<tag_name>` (old) and `<tag_name>.<value>` (new) labels — OpenMetadata doesn't reconcile cross-classification renames. This is rare for system tags and not addressed here.

## Tests

Added `tests/unit/topology/database/test_databricks_valueless_tags.py` and `test_unitycatalog_valueless_tags.py` (10 tests, all passing) covering: valued mapping unchanged, `None`/empty-string → fallback classification with `tag_name` as tag, dotless valueless name kept verbatim, and the fallback constant values.

🤖 Generated with [Claude Code](https://claude.com/claude-code)