### PR TITLE
fix(search): route Table certification through the standard propagation pipeline

### DIFF
--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/TableCertificationPropagationIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/TableCertificationPropagationIT.java
@@ -12,7 +12,6 @@
  */
 package org.openmetadata.it.tests;
 
-import static org.awaitility.Awaitility.await;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -44,15 +43,20 @@ import org.openmetadata.schema.type.TagLabel;
 import org.openmetadata.sdk.client.OpenMetadataClient;
 
 /**
- * Regression for the Table certification cascade bug (issue #28229). When a Table's certification
- * is added, changed, or removed via PATCH, the existing {@code cascadeCertificationToChildren} path
- * in {@code SearchRepository} must propagate the new cert onto every denormalized child search doc
- * (test_case, test_case_result, test_case_resolution_status, test_suite).
+ * Regression for issue #28229: certification changes on a {@link Table} must propagate to every
+ * denormalized child search doc (test_case, test_case_result, test_case_resolution_status,
+ * test_suite, column) — including the cert-only PATCH path that was previously silently broken by
+ * a bad propagation script.
  *
- * <p>Without the fix on {@code TableRepository.getSearchPropagationDescriptors}, the
- * {@code requiresPropagation} gate in {@code SearchRepository.updateEntityIndex} returns
- * {@code false} on a cert-only ChangeDescription, the cascade never fires, and the Data Quality
- * dashboard's Certification filter keeps returning the stale cert until a full reindex.
+ * <p>The cascade is declarative: {@code TableRepository} registers {@code certification} as {@link
+ * org.openmetadata.service.search.PropagationDescriptor.PropagationType#RAW_REPLACE}, the gate in
+ * {@code SearchRepository.updateEntityIndex} opens for the cert field, and {@code
+ * propagateInheritedFieldsToChildren} emits an {@code update_by_query} with {@code Refresh.True}
+ * against the table's child aliases. Because {@code SearchIndexHandler.isAsync()} returns {@code
+ * false} and the {@code update_by_query} uses {@code wait_for_completion=true}, the change is
+ * visible in ES the moment the PATCH HTTP response returns. The test therefore asserts
+ * synchronously — no Awaitility, no polling — and any future regression that re-introduces a race
+ * fails the test deterministically.
  */
 @Execution(ExecutionMode.CONCURRENT)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
@@ -61,134 +65,187 @@ public class TableCertificationPropagationIT {
   private static final ObjectMapper MAPPER = new ObjectMapper();
   private static final String CERTIFICATION_GOLD = "Certification.Gold";
   private static final String CERTIFICATION_SILVER = "Certification.Silver";
-  private static final Duration AWAIT_TIMEOUT = Duration.ofMinutes(1);
-  private static final Duration POLL_INTERVAL = Duration.ofSeconds(2);
 
   @Test
-  void certChangeOnTable_cascadesToTestCaseSearchDoc() throws Exception {
+  void certLifecycle_cascadesToTestCaseAndOwnSearchDoc() throws Exception {
     OpenMetadataClient client = SdkClients.adminClient();
     long ts = System.currentTimeMillis();
     Database database = null;
     try {
-      database =
-          client
-              .databases()
-              .create(
-                  new CreateDatabase()
-                      .withName("cert_prop_db_" + ts)
-                      .withService(SharedEntities.get().MYSQL_SERVICE.getFullyQualifiedName()));
-      DatabaseSchema schema =
-          client
-              .databaseSchemas()
-              .create(
-                  new CreateDatabaseSchema()
-                      .withName("cert_prop_schema_" + ts)
-                      .withDatabase(database.getFullyQualifiedName()));
-      Table table =
-          client
-              .tables()
-              .create(
-                  new CreateTable()
-                      .withName("cert_prop_table_" + ts)
-                      .withDatabaseSchema(schema.getFullyQualifiedName())
-                      .withColumns(
-                          List.of(
-                              new Column().withName("id").withDataType(ColumnDataType.BIGINT))));
+      database = createDatabase(client, "cert_prop_db_" + ts);
+      DatabaseSchema schema = createSchema(client, database, "cert_prop_schema_" + ts);
+      Table table = createTable(client, schema, "cert_prop_table_" + ts);
+
+      long now = System.currentTimeMillis();
+      long expiry = now + Duration.ofDays(30).toMillis();
+
+      table.setCertification(buildCertification(CERTIFICATION_GOLD, now, expiry));
+      table = client.tables().update(table.getId().toString(), table);
+
+      TestCase testCase = createTestCase(client, table, "cert_prop_tc_" + ts);
+
+      assertTestCaseCertification(client, testCase.getFullyQualifiedName(), CERTIFICATION_GOLD);
+      assertTableCertification(client, table.getId().toString(), CERTIFICATION_GOLD);
+
+      table = client.tables().get(table.getId().toString(), "certification");
+      table.setCertification(buildCertification(CERTIFICATION_SILVER, now, expiry));
+      client.tables().update(table.getId().toString(), table);
+
+      assertTestCaseCertification(client, testCase.getFullyQualifiedName(), CERTIFICATION_SILVER);
+      assertTableCertification(client, table.getId().toString(), CERTIFICATION_SILVER);
+
+      table = client.tables().get(table.getId().toString(), "certification");
+      table.setCertification(null);
+      client.tables().update(table.getId().toString(), table);
+
+      assertTestCaseCertificationAbsent(client, testCase.getFullyQualifiedName());
+      assertTableCertificationAbsent(client, table.getId().toString());
+    } finally {
+      hardDelete(client, database);
+    }
+  }
+
+  @Test
+  void certOnlyPatch_isObservableImmediatelyAfterPatchReturns() throws Exception {
+    // Regression for the specific failure mode in #28229 / #28236: a PATCH that mutates *only*
+    // certification (no other fields) must observably update both the table doc and every child
+    // doc by the time the PATCH response is received. Pre-fix, the descriptor-driven script was
+    // malformed for cert-only changes and the cascade was silently aborted by the outer catch.
+    OpenMetadataClient client = SdkClients.adminClient();
+    long ts = System.currentTimeMillis();
+    Database database = null;
+    try {
+      database = createDatabase(client, "cert_only_db_" + ts);
+      DatabaseSchema schema = createSchema(client, database, "cert_only_schema_" + ts);
+      Table table = createTable(client, schema, "cert_only_table_" + ts);
+      TestCase testCase = createTestCase(client, table, "cert_only_tc_" + ts);
 
       long now = System.currentTimeMillis();
       long expiry = now + Duration.ofDays(30).toMillis();
       table.setCertification(buildCertification(CERTIFICATION_GOLD, now, expiry));
       client.tables().update(table.getId().toString(), table);
 
-      TestCase testCase =
-          client
-              .testCases()
-              .create(
-                  new CreateTestCase()
-                      .withName("cert_prop_tc_" + ts)
-                      .withEntityLink("<#E::table::" + table.getFullyQualifiedName() + ">")
-                      .withTestDefinition("tableRowCountToEqual")
-                      .withParameterValues(
-                          List.of(
-                              new TestCaseParameterValue().withName("value").withValue("100"))));
-
-      awaitTestCaseCertification(client, testCase.getFullyQualifiedName(), CERTIFICATION_GOLD);
-
-      table = client.tables().get(table.getId().toString(), "certification");
-      table.setCertification(buildCertification(CERTIFICATION_SILVER, now, expiry));
-      client.tables().update(table.getId().toString(), table);
-
-      awaitTestCaseCertification(client, testCase.getFullyQualifiedName(), CERTIFICATION_SILVER);
-
-      table = client.tables().get(table.getId().toString(), "certification");
-      table.setCertification(null);
-      client.tables().update(table.getId().toString(), table);
-
-      awaitTestCaseCertificationAbsent(client, testCase.getFullyQualifiedName());
+      assertTableCertification(client, table.getId().toString(), CERTIFICATION_GOLD);
+      assertTestCaseCertification(client, testCase.getFullyQualifiedName(), CERTIFICATION_GOLD);
     } finally {
-      if (database != null) {
-        try {
-          client
-              .databases()
-              .delete(
-                  database.getId().toString(), Map.of("hardDelete", "true", "recursive", "true"));
-        } catch (Exception ignored) {
-          // best-effort cleanup; assertion failures take precedence
-        }
-      }
+      hardDelete(client, database);
     }
   }
 
-  private static void awaitTestCaseCertification(
-      OpenMetadataClient client, String testCaseFqn, String expectedFqn) {
-    await("test_case_search_index reflects cert " + expectedFqn + " for " + testCaseFqn)
-        .atMost(AWAIT_TIMEOUT)
-        .pollInterval(POLL_INTERVAL)
-        .ignoreExceptions()
-        .untilAsserted(
-            () -> {
-              JsonNode src = fetchTestCaseSource(client, testCaseFqn);
-              JsonNode certFqn = src.path("certification").path("tagLabel").path("tagFQN");
-              assertEquals(
-                  expectedFqn,
-                  certFqn.asText(),
-                  () ->
-                      "test_case search doc certification mismatch; cert was: "
-                          + src.path("certification"));
-            });
+  private static Database createDatabase(OpenMetadataClient client, String name) {
+    return client
+        .databases()
+        .create(
+            new CreateDatabase()
+                .withName(name)
+                .withService(SharedEntities.get().MYSQL_SERVICE.getFullyQualifiedName()));
   }
 
-  private static void awaitTestCaseCertificationAbsent(
-      OpenMetadataClient client, String testCaseFqn) {
-    await("test_case_search_index has no certification for " + testCaseFqn)
-        .atMost(AWAIT_TIMEOUT)
-        .pollInterval(POLL_INTERVAL)
-        .ignoreExceptions()
-        .untilAsserted(
-            () -> {
-              JsonNode src = fetchTestCaseSource(client, testCaseFqn);
-              JsonNode cert = src.path("certification");
-              assertTrue(
-                  cert.isMissingNode() || cert.isNull(),
-                  () -> "test_case search doc still carries certification: " + cert);
-            });
+  private static DatabaseSchema createSchema(
+      OpenMetadataClient client, Database database, String name) {
+    return client
+        .databaseSchemas()
+        .create(
+            new CreateDatabaseSchema()
+                .withName(name)
+                .withDatabase(database.getFullyQualifiedName()));
+  }
+
+  private static Table createTable(OpenMetadataClient client, DatabaseSchema schema, String name) {
+    return client
+        .tables()
+        .create(
+            new CreateTable()
+                .withName(name)
+                .withDatabaseSchema(schema.getFullyQualifiedName())
+                .withColumns(
+                    List.of(new Column().withName("id").withDataType(ColumnDataType.BIGINT))));
+  }
+
+  private static TestCase createTestCase(OpenMetadataClient client, Table table, String name) {
+    return client
+        .testCases()
+        .create(
+            new CreateTestCase()
+                .withName(name)
+                .withEntityLink("<#E::table::" + table.getFullyQualifiedName() + ">")
+                .withTestDefinition("tableRowCountToEqual")
+                .withParameterValues(
+                    List.of(new TestCaseParameterValue().withName("value").withValue("100"))));
+  }
+
+  private static void assertTestCaseCertification(
+      OpenMetadataClient client, String testCaseFqn, String expectedFqn) throws Exception {
+    JsonNode certFqn = fetchTestCaseCertificationFqn(client, testCaseFqn);
+    assertEquals(
+        expectedFqn,
+        certFqn.asText(),
+        () -> "test_case search doc certification mismatch; doc cert was: " + certFqn);
+  }
+
+  private static void assertTestCaseCertificationAbsent(
+      OpenMetadataClient client, String testCaseFqn) throws Exception {
+    JsonNode source = fetchTestCaseSource(client, testCaseFqn);
+    JsonNode cert = source.path("certification");
+    assertTrue(
+        cert.isMissingNode() || cert.isNull(),
+        () -> "test_case search doc still carries certification: " + cert);
+  }
+
+  private static void assertTableCertification(
+      OpenMetadataClient client, String tableId, String expectedFqn) throws Exception {
+    JsonNode source = fetchTableSource(client, tableId);
+    JsonNode certFqn = source.path("certification").path("tagLabel").path("tagFQN");
+    assertEquals(
+        expectedFqn,
+        certFqn.asText(),
+        () ->
+            "table search doc certification mismatch; doc cert was: "
+                + source.path("certification"));
+  }
+
+  private static void assertTableCertificationAbsent(OpenMetadataClient client, String tableId)
+      throws Exception {
+    JsonNode source = fetchTableSource(client, tableId);
+    JsonNode cert = source.path("certification");
+    assertTrue(
+        cert.isMissingNode() || cert.isNull(),
+        () -> "table search doc still carries certification: " + cert);
+  }
+
+  private static JsonNode fetchTestCaseCertificationFqn(
+      OpenMetadataClient client, String testCaseFqn) throws Exception {
+    return fetchTestCaseSource(client, testCaseFqn)
+        .path("certification")
+        .path("tagLabel")
+        .path("tagFQN");
   }
 
   private static JsonNode fetchTestCaseSource(OpenMetadataClient client, String testCaseFqn)
       throws Exception {
-    String rawJson =
-        client
-            .search()
-            .query("fullyQualifiedName.keyword:\"" + testCaseFqn + "\"")
-            .index("test_case_search_index")
-            .size(1)
-            .execute();
-    JsonNode root = MAPPER.readTree(rawJson);
-    JsonNode hits = root.path("hits").path("hits");
-    assertNotNull(hits, "search response missing hits");
-    assertTrue(
-        hits.isArray() && hits.size() > 0,
-        () -> "test case " + testCaseFqn + " not yet indexed; raw=" + rawJson);
+    return fetchFirstHitSource(
+        client,
+        "test_case_search_index",
+        "fullyQualifiedName.keyword:\"" + testCaseFqn + "\"",
+        () -> "test case " + testCaseFqn + " not indexed");
+  }
+
+  private static JsonNode fetchTableSource(OpenMetadataClient client, String tableId)
+      throws Exception {
+    return fetchFirstHitSource(
+        client, "table_search_index", "id:" + tableId, () -> "table " + tableId + " not indexed");
+  }
+
+  private static JsonNode fetchFirstHitSource(
+      OpenMetadataClient client,
+      String index,
+      String query,
+      java.util.function.Supplier<String> notFoundMessage)
+      throws Exception {
+    String rawJson = client.search().query(query).index(index).size(1).execute();
+    JsonNode hits = MAPPER.readTree(rawJson).path("hits").path("hits");
+    assertNotNull(hits, "search response missing hits for query: " + query);
+    assertTrue(hits.isArray() && hits.size() > 0, notFoundMessage::get);
     return hits.get(0).path("_source");
   }
 
@@ -201,5 +258,16 @@ public class TableCertificationPropagationIT {
                 .withLabelType(TagLabel.LabelType.MANUAL))
         .withAppliedDate(appliedDate)
         .withExpiryDate(expiry);
+  }
+
+  private static void hardDelete(OpenMetadataClient client, Database database) {
+    if (database == null) return;
+    try {
+      client
+          .databases()
+          .delete(database.getId().toString(), Map.of("hardDelete", "true", "recursive", "true"));
+    } catch (Exception ignored) {
+      // best-effort cleanup; assertion failures take precedence
+    }
   }
 }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/TableRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/TableRepository.java
@@ -1725,13 +1725,9 @@ public class TableRepository extends EntityRepository<Table> {
             FIELD_DATA_PRODUCTS,
             PropagationDescriptor.PropagationType.ENTITY_REFERENCE_LIST,
             null));
-    // Required so SearchRepository.requiresPropagation opens the gate on a cert-only PATCH;
-    // the actual cascade onto child docs (test_case, test_case_result, test_case_resolution_status,
-    // test_suite, column) is handled by SearchRepository.cascadeCertificationToChildren, not by
-    // the generic descriptor-driven script.
     descriptors.add(
         new PropagationDescriptor(
-            FIELD_CERTIFICATION, PropagationDescriptor.PropagationType.EXTERNAL_HANDLER, null));
+            FIELD_CERTIFICATION, PropagationDescriptor.PropagationType.RAW_REPLACE, null));
     return descriptors;
   }
 

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/PropagationDescriptor.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/PropagationDescriptor.java
@@ -11,12 +11,6 @@ public record PropagationDescriptor(
     TAG_LABEL_LIST,
     NESTED_FIELD,
     SIMPLE_VALUE,
-    RAW_REPLACE,
-    // Field is gated for propagation but the actual cascade is driven by a dedicated handler
-    // in SearchRepository (e.g. propagateCertificationTags / cascadeCertificationToChildren),
-    // because the generic descriptor-driven scripts can't express its semantics — cert, for
-    // example, needs full-object replace on add/update and explicit removal on delete, which
-    // RAW_REPLACE can't do (RAW_REPLACE restores the old value on delete).
-    EXTERNAL_HANDLER
+    RAW_REPLACE
   }
 }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/SearchClient.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/SearchClient.java
@@ -228,18 +228,6 @@ public interface SearchClient
       }
       """;
 
-  // Cascade variant: full-object replace (handles add/update) plus removal on
-  // null params, so child docs stay in sync when a parent's cert is added,
-  // changed, or removed.
-  String CASCADE_CERTIFICATION_SCRIPT =
-      """
-      if (params.certification == null) {
-        ctx._source.remove('certification');
-      } else {
-        ctx._source.certification = params.certification;
-      }
-      """;
-
   String UPDATE_GLOSSARY_TERM_TAG_FQN_BY_PREFIX_SCRIPT =
       """
       if (ctx._source.containsKey('tags')) {

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/SearchRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/SearchRepository.java
@@ -1528,26 +1528,39 @@ public class SearchRepository {
 
       candidates++;
       IndexMapping indexMapping = entityIndexMap.get(entityType);
-      runPropagationStep(
-          "inheritedFields",
-          entity,
-          () ->
-              propagateInheritedFieldsToChildren(
-                  entityType, entity.getId().toString(), changeDescription, indexMapping, entity));
-      runPropagationStep(
-          "glossaryTags",
-          entity,
-          () ->
-              propagateGlossaryTags(entityType, entity.getFullyQualifiedName(), changeDescription));
-      runPropagationStep(
-          "certificationTags",
-          entity,
-          () -> propagateCertificationTags(entityType, entity, changeDescription));
-      runPropagationStep(
-          "relatedEntities",
-          entity,
-          () -> propagateToRelatedEntities(entityType, changeDescription, indexMapping, entity));
-      propagated++;
+      boolean allStepsSucceeded = true;
+      allStepsSucceeded &=
+          runPropagationStep(
+              "inheritedFields",
+              entity,
+              () ->
+                  propagateInheritedFieldsToChildren(
+                      entityType,
+                      entity.getId().toString(),
+                      changeDescription,
+                      indexMapping,
+                      entity));
+      allStepsSucceeded &=
+          runPropagationStep(
+              "glossaryTags",
+              entity,
+              () ->
+                  propagateGlossaryTags(
+                      entityType, entity.getFullyQualifiedName(), changeDescription));
+      allStepsSucceeded &=
+          runPropagationStep(
+              "certificationTags",
+              entity,
+              () -> propagateCertificationTags(entityType, entity, changeDescription));
+      allStepsSucceeded &=
+          runPropagationStep(
+              "relatedEntities",
+              entity,
+              () ->
+                  propagateToRelatedEntities(entityType, changeDescription, indexMapping, entity));
+      if (allStepsSucceeded) {
+        propagated++;
+      }
     }
 
     if (candidates > 0) {
@@ -1674,11 +1687,15 @@ public class SearchRepository {
   /**
    * Runs a single propagation step under its own try/catch so a failure (script compile error,
    * transient ES outage, etc.) cannot abort the other independent propagators for the same entity.
-   * The failure is logged and queued for retry; subsequent propagators run unaffected.
+   * The failure is logged and queued for retry; subsequent propagators run unaffected. Returns
+   * {@code true} on success and {@code false} on failure so callers that track per-entity success
+   * (e.g. the bulk-flush metric) can distinguish "fully propagated" from "attempted".
    */
-  private void runPropagationStep(String stepName, EntityInterface entity, PropagationStep step) {
+  private boolean runPropagationStep(
+      String stepName, EntityInterface entity, PropagationStep step) {
     try {
       step.run();
+      return true;
     } catch (Exception e) {
       LOG.error(
           "Propagation step '{}' failed for entity [{}/{}]: {}",
@@ -1691,6 +1708,7 @@ public class SearchRepository {
           entity.getId() == null ? null : entity.getId().toString(),
           entity.getFullyQualifiedName(),
           SearchIndexRetryQueue.failureReason("propagate:" + stepName, e));
+      return false;
     }
   }
 

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/SearchRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/SearchRepository.java
@@ -18,7 +18,6 @@ import static org.openmetadata.service.Entity.RAW_COST_ANALYSIS_REPORT_DATA;
 import static org.openmetadata.service.Entity.WEB_ANALYTIC_ENTITY_VIEW_REPORT_DATA;
 import static org.openmetadata.service.Entity.WEB_ANALYTIC_USER_ACTIVITY_REPORT_DATA;
 import static org.openmetadata.service.search.SearchClient.ADD_FOLLOWERS_SCRIPT;
-import static org.openmetadata.service.search.SearchClient.CASCADE_CERTIFICATION_SCRIPT;
 import static org.openmetadata.service.search.SearchClient.DATA_ASSET_SEARCH_ALIAS;
 import static org.openmetadata.service.search.SearchClient.DEFAULT_UPDATE_SCRIPT;
 import static org.openmetadata.service.search.SearchClient.GLOBAL_SEARCH_ALIAS;
@@ -110,7 +109,6 @@ import org.openmetadata.schema.service.configuration.elasticsearch.NaturalLangua
 import org.openmetadata.schema.settings.SettingsType;
 import org.openmetadata.schema.tests.DataQualityReport;
 import org.openmetadata.schema.tests.TestSuite;
-import org.openmetadata.schema.type.AssetCertification;
 import org.openmetadata.schema.type.ChangeDescription;
 import org.openmetadata.schema.type.Column;
 import org.openmetadata.schema.type.EntityReference;
@@ -1303,11 +1301,26 @@ public class SearchRepository {
       if (requiresPropagation(changeDescription, entityType, entity)) {
         // Time propagation operations
         startTime = System.currentTimeMillis();
-        propagateInheritedFieldsToChildren(
-            entityType, entityId, changeDescription, indexMapping, entity);
-        propagateGlossaryTags(entityType, entity.getFullyQualifiedName(), changeDescription);
-        propagateCertificationTags(entityType, entity, changeDescription);
-        propagateToRelatedEntities(entityType, changeDescription, indexMapping, entity);
+        runPropagationStep(
+            "inheritedFields",
+            entity,
+            () ->
+                propagateInheritedFieldsToChildren(
+                    entityType, entityId, changeDescription, indexMapping, entity));
+        runPropagationStep(
+            "glossaryTags",
+            entity,
+            () ->
+                propagateGlossaryTags(
+                    entityType, entity.getFullyQualifiedName(), changeDescription));
+        runPropagationStep(
+            "certificationTags",
+            entity,
+            () -> propagateCertificationTags(entityType, entity, changeDescription));
+        runPropagationStep(
+            "relatedEntities",
+            entity,
+            () -> propagateToRelatedEntities(entityType, changeDescription, indexMapping, entity));
         propagateTime = System.currentTimeMillis() - startTime;
 
         LOG.info(
@@ -1514,21 +1527,27 @@ public class SearchRepository {
       }
 
       candidates++;
-      try {
-        IndexMapping indexMapping = entityIndexMap.get(entityType);
-        propagateInheritedFieldsToChildren(
-            entityType, entity.getId().toString(), changeDescription, indexMapping, entity);
-        propagateGlossaryTags(entityType, entity.getFullyQualifiedName(), changeDescription);
-        propagateCertificationTags(entityType, entity, changeDescription);
-        propagateToRelatedEntities(entityType, changeDescription, indexMapping, entity);
-        propagated++;
-      } catch (Exception e) {
-        LOG.error(
-            "Error propagating bulk search updates for entity {} of type {}",
-            entity.getId(),
-            entityType,
-            e);
-      }
+      IndexMapping indexMapping = entityIndexMap.get(entityType);
+      runPropagationStep(
+          "inheritedFields",
+          entity,
+          () ->
+              propagateInheritedFieldsToChildren(
+                  entityType, entity.getId().toString(), changeDescription, indexMapping, entity));
+      runPropagationStep(
+          "glossaryTags",
+          entity,
+          () ->
+              propagateGlossaryTags(entityType, entity.getFullyQualifiedName(), changeDescription));
+      runPropagationStep(
+          "certificationTags",
+          entity,
+          () -> propagateCertificationTags(entityType, entity, changeDescription));
+      runPropagationStep(
+          "relatedEntities",
+          entity,
+          () -> propagateToRelatedEntities(entityType, changeDescription, indexMapping, entity));
+      propagated++;
     }
 
     if (candidates > 0) {
@@ -1647,6 +1666,34 @@ public class SearchRepository {
    * Determines if changes require propagation to child entities.
    * Only propagate when fields that actually affect children have been modified.
    */
+  @FunctionalInterface
+  private interface PropagationStep {
+    void run() throws Exception;
+  }
+
+  /**
+   * Runs a single propagation step under its own try/catch so a failure (script compile error,
+   * transient ES outage, etc.) cannot abort the other independent propagators for the same entity.
+   * The failure is logged and queued for retry; subsequent propagators run unaffected.
+   */
+  private void runPropagationStep(String stepName, EntityInterface entity, PropagationStep step) {
+    try {
+      step.run();
+    } catch (Exception e) {
+      LOG.error(
+          "Propagation step '{}' failed for entity [{}/{}]: {}",
+          stepName,
+          entity.getEntityReference() == null ? "?" : entity.getEntityReference().getType(),
+          entity.getId(),
+          e.getMessage(),
+          e);
+      SearchIndexRetryQueue.enqueue(
+          entity.getId() == null ? null : entity.getId().toString(),
+          entity.getFullyQualifiedName(),
+          SearchIndexRetryQueue.failureReason("propagate:" + stepName, e));
+    }
+  }
+
   private boolean requiresPropagation(
       ChangeDescription changeDescription, String entityType, EntityInterface entity) {
     if (changeDescription == null) return false;
@@ -1678,7 +1725,7 @@ public class SearchRepository {
 
     Pair<String, Map<String, Object>> updates =
         getInheritedFieldChanges(changeDescription, entity, entityType);
-    if (updates.getKey() == null || updates.getKey().isEmpty()) {
+    if (updates.getKey() == null || updates.getKey().isBlank()) {
       return;
     }
 
@@ -1752,20 +1799,19 @@ public class SearchRepository {
     }
   }
 
-  private static final String CERTIFICATION_FIELD = "certification";
   private static final String CERTIFICATION_TAG_FQN_FIELD = "certification.tagLabel.tagFQN";
 
+  /**
+   * Rewrites cached cert pointers when a {@link Tag} entity that represents a certification is
+   * renamed. Entity-level cert add/change/remove propagation is driven declaratively via {@link
+   * PropagationDescriptor.PropagationType#RAW_REPLACE} on each repository's descriptors, not here.
+   */
   public void propagateCertificationTags(
       String entityType, EntityInterface entity, ChangeDescription changeDescription) {
-    if (changeDescription == null) {
+    if (changeDescription == null || !Entity.TAG.equalsIgnoreCase(entityType)) {
       return;
     }
-
-    if (Entity.TAG.equalsIgnoreCase(entityType)) {
-      handleTagEntityUpdate((Tag) entity, changeDescription);
-    } else {
-      handleEntityCertificationUpdate(entity, changeDescription);
-    }
+    handleTagEntityUpdate((Tag) entity, changeDescription);
   }
 
   private void handleTagEntityUpdate(Tag tagEntity, ChangeDescription changeDescription) {
@@ -1809,89 +1855,6 @@ public class SearchRepository {
                 .withValidityPeriod("P30D"),
             AssetCertificationSettings.class)
         .getAllowedClassification();
-  }
-
-  private void handleEntityCertificationUpdate(EntityInterface entity, ChangeDescription change) {
-    if (!isCertificationUpdated(change)) {
-      return;
-    }
-
-    AssetCertification certification = getCertificationFromEntity(entity);
-    updateEntityCertificationInSearch(entity, certification);
-    cascadeCertificationToChildren(entity, certification);
-  }
-
-  // Pushes the cert change onto every child search doc denormalized from this
-  // entity. Without this the cert filter on the DQ dashboard (which queries
-  // children like test_case/test_case_result/test_case_resolution_status by
-  // `certification.tagLabel.tagFQN`) would silently use the stale cert until a
-  // reindex. RAW_REPLACE in PropagationDescriptor can't be used because it
-  // restores the old value on delete; we drive a dedicated script instead.
-  private void cascadeCertificationToChildren(
-      EntityInterface entity, AssetCertification certification) {
-    String type = entity.getEntityReference().getType();
-    if (!Entity.TABLE.equalsIgnoreCase(type)) {
-      // Scope: Table only. Dashboard/ApiCollection children also have cert in
-      // their mappings; extend here when those denormalization paths are added.
-      return;
-    }
-    IndexMapping indexMapping = entityIndexMap.get(Entity.TABLE);
-    if (indexMapping == null) {
-      return;
-    }
-    List<String> childAliases = indexMapping.getChildAliases(clusterAlias);
-    if (nullOrEmpty(childAliases)) {
-      return;
-    }
-
-    Map<String, Object> params = new HashMap<>();
-    params.put("certification", certification); // null when cert was removed
-
-    Pair<String, String> parentMatch = new ImmutablePair<>("table.id", entity.getId().toString());
-
-    try {
-      searchClient.updateChildren(
-          childAliases, parentMatch, new ImmutablePair<>(CASCADE_CERTIFICATION_SCRIPT, params));
-    } catch (Exception e) {
-      LOG.error(
-          "Failed to cascade certification for table [{}]: {}",
-          entity.getFullyQualifiedName(),
-          e.getMessage(),
-          e);
-    }
-  }
-
-  private boolean isCertificationUpdated(ChangeDescription change) {
-    return Stream.concat(
-            Stream.concat(change.getFieldsUpdated().stream(), change.getFieldsAdded().stream()),
-            change.getFieldsDeleted().stream())
-        .anyMatch(fieldChange -> CERTIFICATION_FIELD.equals(fieldChange.getName()));
-  }
-
-  private AssetCertification getCertificationFromEntity(EntityInterface entity) {
-    return (AssetCertification) EntityUtil.getEntityField(entity, CERTIFICATION_FIELD);
-  }
-
-  private void updateEntityCertificationInSearch(
-      EntityInterface entity, AssetCertification certification) {
-    IndexMapping indexMapping = entityIndexMap.get(entity.getEntityReference().getType());
-    String indexName = getWriteIndexName(indexMapping);
-    Map<String, Object> paramMap = new HashMap<>();
-
-    if (certification != null && certification.getTagLabel() != null) {
-      paramMap.put("name", certification.getTagLabel().getName());
-      paramMap.put("description", certification.getTagLabel().getDescription());
-      paramMap.put("tagFQN", certification.getTagLabel().getTagFQN());
-      paramMap.put("style", certification.getTagLabel().getStyle());
-    } else {
-      paramMap.put("name", null);
-      paramMap.put("description", null);
-      paramMap.put("tagFQN", null);
-      paramMap.put("style", null);
-    }
-
-    searchClient.updateEntity(
-        indexName, entity.getId().toString(), paramMap, UPDATE_CERTIFICATION_SCRIPT);
   }
 
   public void propagateToRelatedEntities(
@@ -2057,14 +2020,7 @@ public class SearchRepository {
       case SIMPLE_VALUE -> {
         script.append(String.format(PROPAGATE_FIELD_SCRIPT, field.getName(), field.getNewValue()));
       }
-      case RAW_REPLACE -> {
-        data.put(field.getName(), field.getNewValue());
-        script.append(
-            String.format("ctx._source.%s = params.%s", field.getName(), field.getName()));
-      }
-      case EXTERNAL_HANDLER -> {
-        // No-op: a dedicated handler (e.g. propagateCertificationTags) drives the cascade.
-      }
+      case RAW_REPLACE -> appendReplaceScript(script, data, field, entity);
     }
     script.append(" ");
   }
@@ -2111,14 +2067,7 @@ public class SearchRepository {
       case SIMPLE_VALUE -> {
         script.append(String.format(REMOVE_PROPAGATED_FIELD_SCRIPT, field.getName()));
       }
-      case RAW_REPLACE -> {
-        data.put(field.getName(), field.getOldValue());
-        script.append(
-            String.format("ctx._source.%s = params.%s", field.getName(), field.getName()));
-      }
-      case EXTERNAL_HANDLER -> {
-        // No-op: a dedicated handler (e.g. propagateCertificationTags) drives the cascade.
-      }
+      case RAW_REPLACE -> script.append(String.format("ctx._source.remove('%s')", field.getName()));
     }
     script.append(" ");
   }
@@ -2177,16 +2126,22 @@ public class SearchRepository {
         script.append(
             String.format(PROPAGATE_NESTED_FIELD_SCRIPT, desc.nestPath(), field.getName()));
       }
-      case RAW_REPLACE -> {
-        data.put(field.getName(), field.getNewValue());
-        script.append(
-            String.format("ctx._source.%s = params.%s", field.getName(), field.getName()));
-      }
-      case EXTERNAL_HANDLER -> {
-        // No-op: a dedicated handler (e.g. propagateCertificationTags) drives the cascade.
-      }
+      case RAW_REPLACE -> appendReplaceScript(script, data, field, entity);
     }
     script.append(" ");
+  }
+
+  /**
+   * Materialises {@code field.getName()} from {@code entity} (the post-update value) and emits a
+   * full-object replace into child docs. Reading from the live entity rather than {@code
+   * field.getNewValue()} avoids deserialising the JSON-encoded form that {@link
+   * org.openmetadata.service.jdbi3.EntityRepository.EntityUpdater#recordChange(String, Object,
+   * Object, boolean)} stores for object-typed fields.
+   */
+  private void appendReplaceScript(
+      StringBuilder script, Map<String, Object> data, FieldChange field, EntityInterface entity) {
+    data.put(field.getName(), EntityUtil.getEntityField(entity, field.getName()));
+    script.append(String.format("ctx._source.%s = params.%s", field.getName(), field.getName()));
   }
 
   private List<EntityReference> resolveEntityReferenceList(

--- a/openmetadata-service/src/test/java/org/openmetadata/service/search/SearchRepositoryBehaviorTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/search/SearchRepositoryBehaviorTest.java
@@ -59,6 +59,7 @@ import org.openmetadata.schema.service.configuration.elasticsearch.ElasticSearch
 import org.openmetadata.schema.service.configuration.elasticsearch.NaturalLanguageSearchConfiguration;
 import org.openmetadata.schema.settings.SettingsType;
 import org.openmetadata.schema.tests.DataQualityReport;
+import org.openmetadata.schema.tests.TestCase;
 import org.openmetadata.schema.tests.TestSuite;
 import org.openmetadata.schema.type.AssetCertification;
 import org.openmetadata.schema.type.ChangeDescription;
@@ -156,6 +157,7 @@ class SearchRepositoryBehaviorTest {
           Entity.DOMAIN,
           Entity.DATABASE_SERVICE,
           Entity.DATABASE,
+          Entity.TEST_CASE,
           Entity.TEST_SUITE,
           Entity.GLOSSARY,
           Entity.CLASSIFICATION,
@@ -803,68 +805,6 @@ class SearchRepositoryBehaviorTest {
   }
 
   @Test
-  void propagateCertificationTagsUpdatesEntityCertificationDocument() {
-    Table table = mock(Table.class);
-    UUID entityId = UUID.randomUUID();
-    when(table.getId()).thenReturn(entityId);
-    when(table.getEntityReference())
-        .thenReturn(new EntityReference().withId(entityId).withType(Entity.TABLE));
-    when(table.getCertification())
-        .thenReturn(
-            new AssetCertification()
-                .withTagLabel(
-                    new TagLabel()
-                        .withName("Gold")
-                        .withDescription("Certified")
-                        .withTagFQN("Certification.Gold")));
-    ChangeDescription changeDescription =
-        changeDescription(
-            List.of(),
-            List.of(
-                new FieldChange().withName("certification").withOldValue("{}").withNewValue("{}")),
-            List.of());
-
-    repository.propagateCertificationTags(Entity.TABLE, table, changeDescription);
-
-    verify(searchClient)
-        .updateEntity(
-            eq("cluster_table_search_index"),
-            eq(entityId.toString()),
-            any(Map.class),
-            eq(SearchClient.UPDATE_CERTIFICATION_SCRIPT));
-  }
-
-  @Test
-  void propagateCertificationTagsClearsEntityCertificationDocumentWhenRemoved() {
-    Table table = mock(Table.class);
-    UUID entityId = UUID.randomUUID();
-    when(table.getId()).thenReturn(entityId);
-    when(table.getEntityReference())
-        .thenReturn(new EntityReference().withId(entityId).withType(Entity.TABLE));
-    when(table.getCertification()).thenReturn(null);
-    ChangeDescription changeDescription =
-        changeDescription(
-            List.of(),
-            List.of(),
-            List.of(new FieldChange().withName("certification").withOldValue("{}")));
-
-    repository.propagateCertificationTags(Entity.TABLE, table, changeDescription);
-
-    @SuppressWarnings("unchecked")
-    ArgumentCaptor<Map<String, Object>> paramCaptor = ArgumentCaptor.forClass(Map.class);
-    verify(searchClient)
-        .updateEntity(
-            eq("cluster_table_search_index"),
-            eq(entityId.toString()),
-            paramCaptor.capture(),
-            eq(SearchClient.UPDATE_CERTIFICATION_SCRIPT));
-    assertNull(paramCaptor.getValue().get("name"));
-    assertNull(paramCaptor.getValue().get("description"));
-    assertNull(paramCaptor.getValue().get("tagFQN"));
-    assertNull(paramCaptor.getValue().get("style"));
-  }
-
-  @Test
   void propagateCertificationTagsDoesNothingForNonCertificationTag() {
     Tag tag = mock(Tag.class);
     when(tag.getClassification())
@@ -1061,8 +1001,7 @@ class SearchRepositoryBehaviorTest {
   }
 
   @Test
-  void inheritedFieldChangesHandleUpdatedTestSuitesAndDeletedInheritedReferences()
-      throws Exception {
+  void inheritedFieldChangesHandleMixedAddUpdateAndDeletedInheritedReferences() throws Exception {
     EntityInterface tableEntity = mockEntity(Entity.TABLE, UUID.randomUUID(), "orders");
     when(tableEntity.getOwners())
         .thenReturn(List.of(new EntityReference().withId(UUID.randomUUID()).withType(Entity.USER)));
@@ -1076,9 +1015,6 @@ class SearchRepositoryBehaviorTest {
         changeDescription(
             List.of(),
             List.of(
-                new FieldChange()
-                    .withName(Entity.FIELD_TEST_SUITES)
-                    .withNewValue(List.of("suite1")),
                 new FieldChange().withName(Entity.FIELD_DISPLAY_NAME).withNewValue("Orders Table"),
                 new FieldChange().withName(Entity.FIELD_DISABLED).withNewValue(false)),
             List.of(
@@ -1093,10 +1029,8 @@ class SearchRepositoryBehaviorTest {
     assertTrue(updates.getLeft().contains("removedOwners"));
     assertTrue(updates.getLeft().contains("removedDomains"));
     assertTrue(updates.getLeft().contains("removedFollowers"));
-    assertTrue(updates.getLeft().contains("ctx._source.testSuites = params.testSuites"));
     assertTrue(updates.getLeft().contains("ctx._source.table.displayName = params.displayName"));
     assertTrue(updates.getLeft().contains("ctx._source.remove('disabled')"));
-    assertEquals(List.of("suite1"), updates.getRight().get(Entity.FIELD_TEST_SUITES));
     assertEquals("Orders Table", updates.getRight().get(Entity.FIELD_DISPLAY_NAME));
   }
 
@@ -1404,27 +1338,38 @@ class SearchRepositoryBehaviorTest {
 
   @Test
   void inheritedFieldChangesAddRawReplaceTestSuites() throws Exception {
-    EntityInterface tableEntity = mockEntity(Entity.TABLE, UUID.randomUUID(), "orders");
+    // RAW_REPLACE add/update reads the live value from the entity (via EntityUtil.getEntityField),
+    // not from FieldChange.newValue. Use TestCase since it declares getTestSuites().
+    TestCase testCase = mock(TestCase.class);
+    UUID entityId = UUID.randomUUID();
+    when(testCase.getId()).thenReturn(entityId);
+    when(testCase.getEntityReference())
+        .thenReturn(new EntityReference().withId(entityId).withType(Entity.TEST_CASE));
+    List<TestSuite> currentSuites =
+        List.of(new TestSuite().withName("suite1"), new TestSuite().withName("suite2"));
+    when(testCase.getTestSuites()).thenReturn(currentSuites);
 
     ChangeDescription changeDescription =
         changeDescription(
-            List.of(
-                new FieldChange()
-                    .withName(Entity.FIELD_TEST_SUITES)
-                    .withNewValue(List.of("suite1", "suite2"))),
+            List.of(new FieldChange().withName(Entity.FIELD_TEST_SUITES).withNewValue("ignored")),
             List.of(),
             List.of());
 
     Pair<String, Map<String, Object>> updates =
-        invokeGetInheritedFieldChanges(changeDescription, tableEntity);
+        invokeGetInheritedFieldChanges(changeDescription, testCase);
 
     assertTrue(updates.getLeft().contains("ctx._source.testSuites = params.testSuites"));
-    assertEquals(List.of("suite1", "suite2"), updates.getRight().get(Entity.FIELD_TEST_SUITES));
+    assertSame(currentSuites, updates.getRight().get(Entity.FIELD_TEST_SUITES));
   }
 
   @Test
   void inheritedFieldChangesDeleteRawReplaceTestSuites() throws Exception {
-    EntityInterface tableEntity = mockEntity(Entity.TABLE, UUID.randomUUID(), "orders");
+    // RAW_REPLACE delete emits ctx._source.remove(field), no params required.
+    TestCase testCase = mock(TestCase.class);
+    UUID entityId = UUID.randomUUID();
+    when(testCase.getId()).thenReturn(entityId);
+    when(testCase.getEntityReference())
+        .thenReturn(new EntityReference().withId(entityId).withType(Entity.TEST_CASE));
 
     ChangeDescription changeDescription =
         changeDescription(
@@ -1436,10 +1381,11 @@ class SearchRepositoryBehaviorTest {
                     .withOldValue(List.of("suite1", "suite2"))));
 
     Pair<String, Map<String, Object>> updates =
-        invokeGetInheritedFieldChanges(changeDescription, tableEntity);
+        invokeGetInheritedFieldChanges(changeDescription, testCase);
 
-    assertTrue(updates.getLeft().contains("ctx._source.testSuites = params.testSuites"));
-    assertEquals(List.of("suite1", "suite2"), updates.getRight().get(Entity.FIELD_TEST_SUITES));
+    assertTrue(updates.getLeft().contains("ctx._source.remove('testSuites')"));
+    assertFalse(updates.getLeft().contains("ctx._source.testSuites = params.testSuites"));
+    assertFalse(updates.getRight().containsKey(Entity.FIELD_TEST_SUITES));
   }
 
   @Test

--- a/openmetadata-service/src/test/java/org/openmetadata/service/search/SearchRepositoryBehaviorTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/search/SearchRepositoryBehaviorTest.java
@@ -299,7 +299,7 @@ class SearchRepositoryBehaviorTest {
               null));
       descriptors.add(
           new PropagationDescriptor(
-              "certification", PropagationDescriptor.PropagationType.EXTERNAL_HANDLER, null));
+              "certification", PropagationDescriptor.PropagationType.RAW_REPLACE, null));
     } else if (Entity.GLOSSARY_TERM.equals(entityType)) {
       descriptors.add(
           new PropagationDescriptor(
@@ -901,20 +901,15 @@ class SearchRepositoryBehaviorTest {
   }
 
   @Test
-  void propagateCertificationTagsCascadesToTableChildrenOnAdd() throws IOException {
+  void propagateCertificationTagsIsNoopForNonTagEntities() throws IOException {
+    // Entity-level cert propagation (Table → test_case et al.) is descriptor-driven via
+    // PropagationType.RAW_REPLACE on TableRepository, not by propagateCertificationTags.
+    // This method only rewrites cached cert pointers when a Tag *itself* is renamed.
     Table table = mock(Table.class);
     UUID entityId = UUID.randomUUID();
     when(table.getId()).thenReturn(entityId);
     when(table.getEntityReference())
         .thenReturn(new EntityReference().withId(entityId).withType(Entity.TABLE));
-    AssetCertification cert =
-        new AssetCertification()
-            .withTagLabel(
-                new TagLabel()
-                    .withName("Gold")
-                    .withDescription("Certified")
-                    .withTagFQN("Certification.Gold"));
-    when(table.getCertification()).thenReturn(cert);
 
     ChangeDescription changeDescription =
         changeDescription(
@@ -924,73 +919,10 @@ class SearchRepositoryBehaviorTest {
             List.of());
 
     repository.propagateCertificationTags(Entity.TABLE, table, changeDescription);
-
-    @SuppressWarnings("unchecked")
-    ArgumentCaptor<Pair<String, Map<String, Object>>> updatesCaptor =
-        ArgumentCaptor.forClass(Pair.class);
-    @SuppressWarnings("unchecked")
-    ArgumentCaptor<Pair<String, String>> matchCaptor = ArgumentCaptor.forClass(Pair.class);
-    verify(searchClient)
-        .updateChildren(
-            eq(List.of("cluster_tableColumn")), matchCaptor.capture(), updatesCaptor.capture());
-    assertEquals("table.id", matchCaptor.getValue().getLeft());
-    assertEquals(entityId.toString(), matchCaptor.getValue().getRight());
-    assertEquals(SearchClient.CASCADE_CERTIFICATION_SCRIPT, updatesCaptor.getValue().getLeft());
-    assertSame(cert, updatesCaptor.getValue().getRight().get("certification"));
-  }
-
-  @Test
-  void propagateCertificationTagsCascadesNullToTableChildrenOnRemove() throws IOException {
-    Table table = mock(Table.class);
-    UUID entityId = UUID.randomUUID();
-    when(table.getId()).thenReturn(entityId);
-    when(table.getEntityReference())
-        .thenReturn(new EntityReference().withId(entityId).withType(Entity.TABLE));
-    when(table.getCertification()).thenReturn(null);
-
-    ChangeDescription changeDescription =
-        changeDescription(
-            List.of(),
-            List.of(),
-            List.of(new FieldChange().withName("certification").withOldValue("{}")));
-
-    repository.propagateCertificationTags(Entity.TABLE, table, changeDescription);
-
-    @SuppressWarnings("unchecked")
-    ArgumentCaptor<Pair<String, Map<String, Object>>> updatesCaptor =
-        ArgumentCaptor.forClass(Pair.class);
-    verify(searchClient)
-        .updateChildren(
-            eq(List.of("cluster_tableColumn")), any(Pair.class), updatesCaptor.capture());
-    assertEquals(SearchClient.CASCADE_CERTIFICATION_SCRIPT, updatesCaptor.getValue().getLeft());
-    assertNull(updatesCaptor.getValue().getRight().get("certification"));
-  }
-
-  @Test
-  void propagateCertificationTagsDoesNotCascadeForNonTableEntities() throws IOException {
-    // Pipelines carry a native certification but DQ dashboard cascade is
-    // scoped to Table — children of Pipeline aren't part of the test_case
-    // family. Verify we don't blast an updateByQuery against unrelated
-    // child indices.
-    Pipeline pipeline = mock(Pipeline.class);
-    UUID entityId = UUID.randomUUID();
-    when(pipeline.getId()).thenReturn(entityId);
-    when(pipeline.getEntityReference())
-        .thenReturn(new EntityReference().withId(entityId).withType(Entity.PIPELINE));
-    when(pipeline.getCertification())
-        .thenReturn(
-            new AssetCertification().withTagLabel(new TagLabel().withTagFQN("Certification.Gold")));
-
-    ChangeDescription changeDescription =
-        changeDescription(
-            List.of(),
-            List.of(
-                new FieldChange().withName("certification").withOldValue("{}").withNewValue("{}")),
-            List.of());
-
-    repository.propagateCertificationTags(Entity.PIPELINE, pipeline, changeDescription);
 
     verify(searchClient, never()).updateChildren(any(List.class), any(Pair.class), any(Pair.class));
+    verify(searchClient, never())
+        .updateChildren(any(String.class), any(Pair.class), any(Pair.class));
   }
 
   @Test
@@ -1813,9 +1745,9 @@ class SearchRepositoryBehaviorTest {
 
   @Test
   void requiresPropagationReturnsTrueForTableCertificationUpdate() throws Exception {
-    // Regression for issue #28229: a cert-only PATCH on a Table must open the propagation gate
-    // so cascadeCertificationToChildren can push the new cert onto every denormalized child doc
-    // (test_case, test_case_result, test_case_resolution_status, test_suite, column).
+    // Regression for issue #28229: a cert-only PATCH on a Table must open the propagation gate so
+    // the descriptor-driven RAW_REPLACE cascade pushes the new cert onto every denormalized child
+    // doc (test_case, test_case_result, test_case_resolution_status, test_suite, column).
     EntityInterface table = mockEntity(Entity.TABLE, UUID.randomUUID(), "orders");
     assertTrue(
         invokeRequiresPropagation(


### PR DESCRIPTION
Follow-up to #28236 (which fixed issue #28229). Same problem space: propagating Table certification changes to denormalized child search docs (`test_case`, `test_case_result`, `test_case_resolution_status`, `test_suite`, `column`). This PR routes that propagation through the same machinery already used for owners, tags, domains and data products, instead of a parallel code path.

## Why a follow-up

After #28236 landed, we started seeing the new `TableCertificationPropagationIT` fail intermittently on PRs that touch unrelated code (alerts, vector search, OIDC, etc). Re-runs would often go green. Looks like a flake, but the root cause turned out to be deterministic and load-sensitive.

Server log on a failing run, on the Gold to Silver step:

```
ERROR SearchRepository: Issue updating the search document for entity [<table-id>] and entityType [table]
! ElasticsearchException: [es/update_by_query] failed: [script_exception] compile error
!   at ElasticSearchEntityManager.updateChildren(ElasticSearchEntityManager.java:470)
!   at SearchRepository.propagateInheritedFieldsToChildren(SearchRepository.java:1699)
!   at SearchRepository.updateEntityIndex(SearchRepository.java:1306)
```

The descriptor pipeline was shipping a Painless script that was a single whitespace character. ES rejected it. The exception bubbled up to the outer `try/catch` in `updateEntityIndex`, and that catch wraps **all four** post-write propagators (inherited fields, glossary tags, certification, related entities). So the cert cascade, which is the next call after the one that throws, never ran.

Cert-only PATCH therefore silently lost its cascade. When other concurrent ITs happened to re-index the `test_case` docs during the IT's 60-second polling window, the test looked like it passed. When the runner was busy, it didn't. That's the flake.

## Why a refactor rather than a one-line gate fix

The narrow fix is `isEmpty()` to `isBlank()` in the propagation gate so the whitespace script never ships. That removes the immediate crash. But it leaves three things on the table.

1. The `EXTERNAL_HANDLER` propagation type is doing a job the enum is not designed for. Every other value in `PropagationType` is a strategy: "given this field change, build this script." `EXTERNAL_HANDLER` is a marker that says "skip me, the cascade is implemented elsewhere." Each of the three switches over `PropagationType` had to remember to no-op it. Three of three remembered. Two of three still appended a trailing space afterward. The same class of bug is one PR away.
2. The cascade is implemented twice. Once declaratively in `propagateInheritedFieldsToChildren` (the descriptor pipeline used by owners, tags, domains, data products). Once imperatively in `cascadeCertificationToChildren`. Both compose the same `update_by_query` shape against the same child aliases. Only the Painless script differs.
3. One failing propagator drops the other three, because the outer `try/catch` in `updateEntityIndex` wraps the whole post-write block.

We took the chance to address all three at once.

## What changed

1. `RAW_REPLACE` covers add, update and delete uniformly. On delete it now removes the field from children (`ctx._source.remove('<field>')`). On add/update it reads the live value from the entity via `EntityUtil.getEntityField`, so object-typed fields like `certification` round-trip cleanly without JSON-string deserialisation. Also fixes a latent bug on the existing `RAW_REPLACE` user (`test_suites`): the delete branch wrote the old value back instead of removing the field. No live caller exercises that branch today.

2. `certification` is registered as a regular `RAW_REPLACE` descriptor on `TableRepository`. One line. The descriptor pipeline's `update_by_query` against `table.id` on child aliases is the same code path used by every other propagated field.

3. The parallel cert cascade is removed. Gone: the `EXTERNAL_HANDLER` enum value, `cascadeCertificationToChildren`, `handleEntityCertificationUpdate`, `updateEntityCertificationInSearch`, `CASCADE_CERTIFICATION_SCRIPT`, and the three `case EXTERNAL_HANDLER` no-op branches. `propagateCertificationTags` is now scoped to its only remaining responsibility: rewriting cached cert pointers when a `Tag` entity itself is renamed. That's a different concern (updating FQN references across denormalized docs, not propagating a parent's cert change).

4. Post-write propagators fail independently. Each of `propagateInheritedFieldsToChildren`, `propagateGlossaryTags`, `propagateCertificationTags`, `propagateToRelatedEntities` now runs via a small `runPropagationStep(name, entity, ...)` helper that catches per step, logs with the step name, and enqueues a retry on the `SearchIndexRetryQueue`. A failure in any one of them no longer aborts the other three.

5. The script-empty gate is now `isBlank()` for defense in depth. A future no-op branch that forgets to suppress the trailing space cannot ship a whitespace-only script to ES.

6. The integration test is rewritten as synchronous assertions. `SearchIndexHandler.isAsync` is `false`, `update_by_query` uses `wait_for_completion=true` and `Refresh.True`. By the time the table PATCH HTTP response returns, the cascade is durable and searchable. The previous 60-second Awaitility loop was absorbing the deterministic failure as a polling delay. The new tests assert immediately and add a dedicated case for the cert-only PATCH (the path that was hard to reproduce before), and check the table's own search doc alongside the `test_case` child doc.

## Risks

- `RAW_REPLACE` delete now removes the field rather than restoring the old value. The only existing caller (`AIApplicationRepository`) belongs to an entity that isn't registered in `indexMapping.json`, so `checkIfIndexingIsSupported` short-circuits before the propagation ever runs. The new cert cascade on Table introduced here is the only reachable production path today, and it's covered by the IT. If any future consumer needs the old restore-on-delete, introduce a separate propagation type rather than re-breaking this one.
- Per-step `try/catch` in `updateEntityIndex`. Happy-path behaviour is unchanged. Failure-path behaviour is strictly better: each step's failure is isolated, logged with its step name, and queued for retry independently.