### PR TITLE
fix(alerts): guard isBot() against deleted users to avoid aborting change-event batches

### DIFF
--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/AlertsRuleEvaluatorResourceIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/AlertsRuleEvaluatorResourceIT.java
@@ -491,7 +491,7 @@ public class AlertsRuleEvaluatorResourceIT {
 
   @Test
   void test_isBot_returnsFalseWhenActorUserDeleted(TestNamespace ns) {
-    String userName = ns.prefix("isbot-actor");
+    String userName = ns.uniqueShortId();
     CreateUser createUser =
         new CreateUser().withName(userName).withEmail(userName + "@test.openmetadata.org");
     User createdUser = SdkClients.adminClient().users().create(createUser);

--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/AlertsRuleEvaluatorResourceIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/AlertsRuleEvaluatorResourceIT.java
@@ -18,11 +18,13 @@ import org.openmetadata.it.util.SdkClients;
 import org.openmetadata.it.util.TestNamespace;
 import org.openmetadata.it.util.TestNamespaceExtension;
 import org.openmetadata.schema.api.data.CreateTable;
+import org.openmetadata.schema.api.teams.CreateUser;
 import org.openmetadata.schema.api.tests.CreateTestCase;
 import org.openmetadata.schema.entity.data.DataContract;
 import org.openmetadata.schema.entity.data.DatabaseSchema;
 import org.openmetadata.schema.entity.data.Table;
 import org.openmetadata.schema.entity.services.DatabaseService;
+import org.openmetadata.schema.entity.teams.User;
 import org.openmetadata.schema.tests.TestCase;
 import org.openmetadata.schema.tests.TestCaseParameterValue;
 import org.openmetadata.schema.tests.TestSuite;
@@ -485,6 +487,31 @@ public class AlertsRuleEvaluatorResourceIT {
 
     assertTrue(evaluateExpression("matchUpdatedBy('testUser')", evaluationContext));
     assertFalse(evaluateExpression("matchUpdatedBy('otherUser')", evaluationContext));
+  }
+
+  @Test
+  void test_isBot_returnsFalseWhenActorUserDeleted(TestNamespace ns) {
+    String userName = ns.prefix("isbot-actor");
+    CreateUser createUser =
+        new CreateUser().withName(userName).withEmail(userName + "@test.openmetadata.org");
+    User createdUser = SdkClients.adminClient().users().create(createUser);
+
+    ChangeEvent changeEvent = new ChangeEvent();
+    changeEvent.setEntityType(Entity.TABLE);
+    changeEvent.setUserName(createdUser.getName());
+
+    AlertsRuleEvaluator alertsRuleEvaluator = new AlertsRuleEvaluator(changeEvent);
+    EvaluationContext evaluationContext =
+        SimpleEvaluationContext.forReadOnlyDataBinding()
+            .withInstanceMethods()
+            .withRootObject(alertsRuleEvaluator)
+            .build();
+
+    assertFalse(evaluateExpression("isBot()", evaluationContext));
+
+    SdkClients.adminClient().users().delete(createdUser.getId());
+
+    assertFalse(evaluateExpression("isBot()", evaluationContext));
   }
 
   @Test

--- a/openmetadata-service/src/main/java/org/openmetadata/service/events/subscription/AlertsRuleEvaluator.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/events/subscription/AlertsRuleEvaluator.java
@@ -362,7 +362,7 @@ public class AlertsRuleEvaluator {
     String entityUpdatedBy = changeEvent.getUserName();
     try {
       User user = Entity.getEntityByName(Entity.USER, entityUpdatedBy, "id", Include.NON_DELETED);
-      return user.getIsBot();
+      return Boolean.TRUE.equals(user.getIsBot());
     } catch (EntityNotFoundException e) {
       return false;
     }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/events/subscription/AlertsRuleEvaluator.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/events/subscription/AlertsRuleEvaluator.java
@@ -42,6 +42,7 @@ import org.openmetadata.schema.type.Post;
 import org.openmetadata.schema.type.StatusType;
 import org.openmetadata.schema.utils.JsonUtils;
 import org.openmetadata.service.Entity;
+import org.openmetadata.service.exception.EntityNotFoundException;
 import org.openmetadata.service.formatter.util.FormatterUtil;
 import org.openmetadata.service.resources.feeds.MessageParser;
 
@@ -359,8 +360,12 @@ public class AlertsRuleEvaluator {
       return false;
     }
     String entityUpdatedBy = changeEvent.getUserName();
-    User user = Entity.getEntityByName(Entity.USER, entityUpdatedBy, "id", Include.NON_DELETED);
-    return user.getIsBot();
+    try {
+      User user = Entity.getEntityByName(Entity.USER, entityUpdatedBy, "id", Include.NON_DELETED);
+      return user.getIsBot();
+    } catch (EntityNotFoundException e) {
+      return false;
+    }
   }
 
   @Function(

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/ActivityAPI.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/ActivityAPI.spec.ts
@@ -40,10 +40,7 @@ import {
 } from '../../utils/entity';
 import { test } from '../fixtures/pages';
 
-// Investigation needed:
-// 1. Profile actual event propagation time — measure how long it typically takes from a PATCH/PUT call to the event appearing in /api/v1/activity, then tighten the ceiling.
-// 2. If synchronous flushing is not feasible, restructure tests to assert entity state directly via the entity API, seed a pre-built activity event, and verify only that the UI renders it decoupling UI assertions from event latency.
-test.describe.fixme(
+test.describe(
   'Activity API - Entity Changes',
   { tag: [DOMAIN_TAGS.DISCOVERY] },
   () => {


### PR DESCRIPTION
## Bug

`AlertsRuleEvaluator.isBot()` calls `Entity.getEntityByName(USER, name, "id", Include.NON_DELETED)` without a try/catch. When a change event's `userName` points at a user that has since been deleted, this throws `EntityNotFoundException`.

The exception escapes the SpEL filter, propagates through `AlertUtil.getFilteredEvents`, and is caught in `AbstractEventConsumer.execute` (~line 410):

```
ERROR ... Error in polling events for alert : Entity not found: user "..." , Offset : 12375 , Batch Size : 100
```

The outer catch logs and the `finally` block still advances the offset by `batchSize`. Net effect: **every event in a batch that contains a single deleted-user-actor event is silently dropped**.

Every subscription whose filter uses `isBot()` is affected. The seed `ActivityFeedAlert` filter uses it, so the activity-stream pipeline stops producing rows for any batch with a poison event.

Second, smaller issue in the same method: `user.getIsBot()` returns boxed `Boolean`. If the field is null on the resolved user record, the existing `return user.getIsBot();` NPEs during auto-unbox.

## Repro

Production trace from nightly run `26147363936` (2026-05-20):

| Time | Worker | Offset | Deleted user blamed |
| --- | --- | --- | --- |
| 08:34:41Z | Worker-3 | 12375 | `brave4fa8f819.wolf3cb7aa85.1779265757332` |
| 08:35:11Z | Worker-4 | 12475 | `brave4fa8f819.wolf3cb7aa85.1779265757332` |
| 08:35:41Z | Worker-1 | 12575 | `eager37c89d43.panda10d281bc.1779265806761` |
| 08:36:11Z | Worker-5 | 12675 | `eager37c89d43.panda10d281bc.1779265806761` |

Four consecutive batches of 100 events skipped over the failure window. `ActivityAPI.spec.ts` polls `/api/v1/activity/entity/...` for 75s and times out because its change event was inside one of those dropped batches.

## Fix

1. `AlertsRuleEvaluator.isBot()`: catch `EntityNotFoundException` and treat an unresolvable actor as not-a-bot; use `Boolean.TRUE.equals(user.getIsBot())` to null-safely unbox.
2. New IT `AlertsRuleEvaluatorResourceIT#test_isBot_returnsFalseWhenActorUserDeleted` — create a user, evaluate `isBot()` (false), delete the user, evaluate `isBot()` again and assert it still returns `false` instead of throwing.
3. Remove `test.describe.fixme` from `ActivityAPI.spec.ts` so the spec runs again now that the underlying batch-abort is fixed.
