### PR TITLE
Refactor: reflect entity edits on graph nodes without full reload

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/Explore/EntitySummaryPanel/EntitySummaryPanel.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Explore/EntitySummaryPanel/EntitySummaryPanel.component.tsx
@@ -139,6 +139,7 @@ export default function EntitySummaryPanel({
   pipelineViewMode,
   nodesPerLayer,
   onEntityUpdate,
+  afterEntityUpdate,
   ontologyExplorerRelationsSlot,
   sideDrawerOverviewOnly = false,
 }: Readonly<EntitySummaryPanelProps>) {
@@ -357,6 +358,11 @@ export default function EntitySummaryPanel({
       const fetchFn = entityFetchMap[entityType];
       if (fetchFn) {
         entityPromise = fetchFn(fqn);
+      } else if (entityType === EntityType.TABLE_COLUMN) {
+        setEntityData(entityDetails.details as EntityData);
+        setIsEntityDataLoading(false);
+
+        return;
       } else if (entityType === EntityType.KNOWLEDGE_PAGE) {
         entityPromise = entityUtilClassBase.getEntityByFqn(
           entityType,
@@ -490,16 +496,15 @@ export default function EntitySummaryPanel({
       if (onEntityUpdate) {
         onEntityUpdate(updatedData);
       } else {
-        setEntityData(
-          (prev) =>
-            ({
-              ...(prev ?? entityDetails.details),
-              ...updatedData,
-            } as EntityData)
-        );
+        const newData = {
+          ...(entityData ?? entityDetails.details),
+          ...updatedData,
+        } as EntityData;
+        setEntityData(newData);
+        afterEntityUpdate?.(newData);
       }
     },
-    [entityDetails.details, onEntityUpdate]
+    [entityData, entityDetails.details, onEntityUpdate, afterEntityUpdate]
   );
 
   const handleOwnerUpdate = useCallback(
@@ -522,13 +527,12 @@ export default function EntitySummaryPanel({
       entityLabel: string,
       returnValue?: T
     ): T | undefined => {
-      setEntityData(
-        (prev) =>
-          ({
-            ...(prev || entityDetails.details),
-            ...result,
-          } as EntityData)
-      );
+      const newData = {
+        ...(entityData || entityDetails.details),
+        ...result,
+      } as EntityData;
+      setEntityData(newData);
+      afterEntityUpdate?.(newData);
 
       showSuccessToast(
         t('server.update-entity-success', {
@@ -538,7 +542,7 @@ export default function EntitySummaryPanel({
 
       return returnValue;
     },
-    [entityDetails.details, t]
+    [entityData, entityDetails.details, afterEntityUpdate, t]
   );
 
   const handleTagsUpdate = useCallback(

--- a/openmetadata-ui/src/main/resources/ui/src/components/Explore/EntitySummaryPanel/EntitySummaryPanel.interface.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Explore/EntitySummaryPanel/EntitySummaryPanel.interface.ts
@@ -39,6 +39,7 @@ export interface EntitySummaryPanelProps {
   readonly downstreamDepth?: number;
   readonly nodesPerLayer?: number;
   readonly onEntityUpdate?: (updatedEntity: Partial<EntityData>) => void;
+  readonly afterEntityUpdate?: (updatedData: EntityData) => void;
   readonly ontologyExplorerRelationsSlot?: ReactNode;
   readonly sideDrawerOverviewOnly?: boolean;
 }

--- a/openmetadata-ui/src/main/resources/ui/src/components/OntologyExplorer/OntologyExplorer.interface.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/components/OntologyExplorer/OntologyExplorer.interface.ts
@@ -44,6 +44,7 @@ export interface OntologyNode {
   group?: string;
   glossaryId?: string;
   entityRef?: EntityReference;
+  searchSource?: Record<string, unknown>;
   owners?: EntityReference[];
   termId?: string;
   originalGlossary?: string;

--- a/openmetadata-ui/src/main/resources/ui/src/components/OntologyExplorer/OntologyExplorer.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/OntologyExplorer/OntologyExplorer.tsx
@@ -132,6 +132,7 @@ const OntologyExplorer: React.FC<OntologyExplorerProps> = ({
     handleGraphNodeClick,
     handleGraphNodeDoubleClick,
     handleGraphPaneClick,
+    handleNodeDataUpdate,
   } = useOntologyExplorer({
     scope,
     entityId,
@@ -372,7 +373,9 @@ const OntologyExplorer: React.FC<OntologyExplorerProps> = ({
             relationTypes={relationTypes}
             totalTermCount={totalTermCount}
             viewModeDisabled={explorationMode === 'data'}
-            onClearAll={() => setFilters(DEFAULT_FILTERS)}
+            onClearAll={() =>
+              setFilters((prev) => ({ ...DEFAULT_FILTERS, viewMode: prev.viewMode }))
+            }
             onFiltersChange={handleFiltersChange}
             onLoadMore={handleLoadMore}
             onViewModeChange={handleViewModeChange}
@@ -481,6 +484,11 @@ const OntologyExplorer: React.FC<OntologyExplorerProps> = ({
               {({ close }) => (
                 <EntitySummaryPanel
                   isSideDrawer
+                  afterEntityUpdate={(updatedData) => {
+                    if (selectedNode) {
+                      handleNodeDataUpdate(selectedNode.id, updatedData);
+                    }
+                  }}
                   entityDetails={buildOntologySlideoutEntityDetails(
                     selectedNode
                   )}

--- a/openmetadata-ui/src/main/resources/ui/src/components/OntologyExplorer/OntologyExplorer.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/OntologyExplorer/OntologyExplorer.tsx
@@ -374,7 +374,10 @@ const OntologyExplorer: React.FC<OntologyExplorerProps> = ({
             totalTermCount={totalTermCount}
             viewModeDisabled={explorationMode === 'data'}
             onClearAll={() =>
-              setFilters((prev) => ({ ...DEFAULT_FILTERS, viewMode: prev.viewMode }))
+              setFilters((prev) => ({
+                ...DEFAULT_FILTERS,
+                viewMode: prev.viewMode,
+              }))
             }
             onFiltersChange={handleFiltersChange}
             onLoadMore={handleLoadMore}

--- a/openmetadata-ui/src/main/resources/ui/src/components/OntologyExplorer/buildOntologySlideoutEntityDetails.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/components/OntologyExplorer/buildOntologySlideoutEntityDetails.ts
@@ -27,6 +27,7 @@ export function buildOntologySlideoutEntityDetails(
     if (ref?.id && ref.fullyQualifiedName && ref.type) {
       return {
         details: {
+          ...(node.searchSource ?? {}),
           id: ref.id,
           fullyQualifiedName: ref.fullyQualifiedName,
           entityType: ref.type as EntityType,

--- a/openmetadata-ui/src/main/resources/ui/src/components/OntologyExplorer/hooks/useOntologyExplorer.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/components/OntologyExplorer/hooks/useOntologyExplorer.ts
@@ -74,6 +74,7 @@ import {
   METRIC_NODE_TYPE,
   searchHitSourceToEntityRef,
 } from '../utils/graphBuilders';
+import { EntityData } from '../../../pages/TasksPage/TasksPage.interface';
 import { useOntologyGraphDerived } from './useOntologyGraphDerived';
 
 const MODEL_TERM_FIELDS = [
@@ -504,6 +505,7 @@ export function useOntologyExplorer({
             fullyQualifiedName: entityRef.fullyQualifiedName,
             description: entityRef.description,
             entityRef,
+            searchSource: hit._source as Record<string, unknown>,
           });
           newEdges.push({
             from: entityRef.id,
@@ -1294,6 +1296,7 @@ export function useOntologyExplorer({
 
   const handleRefresh = useCallback(() => {
     if (explorationMode === 'data') {
+      setExpandedTermIds(new Set());
       if (scope === 'global') {
         setDataModeRefreshKey((k) => k + 1);
       } else {
@@ -1307,11 +1310,14 @@ export function useOntologyExplorer({
       fetchAllGlossaryData();
     } else if (scope === 'glossary' && glossaryId) {
       fetchAllGlossaryData(glossaryId);
+    } else if (scope === 'term') {
+      fetchAllGlossaryData(termGlossaryId);
     }
   }, [
     explorationMode,
     scope,
     glossaryId,
+    termGlossaryId,
     fetchAllGlossaryData,
     loadAssetsForDataMode,
   ]);
@@ -1476,6 +1482,37 @@ export function useOntologyExplorer({
     setSelectedNode(null);
   }, []);
 
+  const handleNodeDataUpdate = useCallback(
+    (nodeId: string, updatedData: EntityData) => {
+      const flatData = updatedData as unknown as Record<string, unknown>;
+      const applyToNode = (node: OntologyNode): OntologyNode => {
+        if (node.id !== nodeId) {
+          return node;
+        }
+        const newLabel = updatedData.displayName || updatedData.name || node.label;
+
+        return {
+          ...node,
+          label: newLabel,
+          originalLabel: newLabel,
+          description: updatedData.description ?? node.description,
+          searchSource: { ...node.searchSource, ...flatData },
+        };
+      };
+
+      setAssetGraphData((prev) =>
+        prev ? { ...prev, nodes: prev.nodes.map(applyToNode) } : prev
+      );
+
+      setGraphData((prev) =>
+        prev ? { ...prev, nodes: prev.nodes.map(applyToNode) } : prev
+      );
+
+      setSelectedNode((prev) => (prev ? applyToNode(prev) : prev));
+    },
+    []
+  );
+
   return {
     graphRef,
     loading,
@@ -1520,5 +1557,6 @@ export function useOntologyExplorer({
     handleGraphNodeClick,
     handleGraphNodeDoubleClick,
     handleGraphPaneClick,
+    handleNodeDataUpdate,
   };
 }

--- a/openmetadata-ui/src/main/resources/ui/src/components/OntologyExplorer/hooks/useOntologyExplorer.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/components/OntologyExplorer/hooks/useOntologyExplorer.ts
@@ -1495,20 +1495,12 @@ export function useOntologyExplorer({
           ...node,
           label: newLabel,
           originalLabel: newLabel,
-          description: updatedData.description ?? node.description,
+          ...('description' in updatedData && {
+            description: updatedData.description,
+          }),
           searchSource: {
             ...node.searchSource,
-            displayName:
-              updatedData.displayName ?? node.searchSource?.displayName,
-            name: updatedData.name ?? node.searchSource?.name,
-            description:
-              updatedData.description ?? node.searchSource?.description,
-            owners: updatedData.owners ?? node.searchSource?.owners,
-            tags: updatedData.tags ?? node.searchSource?.tags,
-            domains: updatedData.domains ?? node.searchSource?.domains,
-            dataProducts:
-              updatedData.dataProducts ?? node.searchSource?.dataProducts,
-            extension: updatedData.extension ?? node.searchSource?.extension,
+            ...(updatedData as unknown as Record<string, unknown>),
           },
         };
       };

--- a/openmetadata-ui/src/main/resources/ui/src/components/OntologyExplorer/hooks/useOntologyExplorer.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/components/OntologyExplorer/hooks/useOntologyExplorer.ts
@@ -20,6 +20,7 @@ import { SearchIndex } from '../../../enums/search.enum';
 import { Glossary } from '../../../generated/entity/data/glossary';
 import { GlossaryTerm } from '../../../generated/entity/data/glossaryTerm';
 import { Metric } from '../../../generated/entity/data/metric';
+import { EntityData } from '../../../pages/TasksPage/TasksPage.interface';
 import {
   getGlossariesList,
   getGlossaryTerms,
@@ -74,7 +75,6 @@ import {
   METRIC_NODE_TYPE,
   searchHitSourceToEntityRef,
 } from '../utils/graphBuilders';
-import { EntityData } from '../../../pages/TasksPage/TasksPage.interface';
 import { useOntologyGraphDerived } from './useOntologyGraphDerived';
 
 const MODEL_TERM_FIELDS = [
@@ -1489,7 +1489,8 @@ export function useOntologyExplorer({
         if (node.id !== nodeId) {
           return node;
         }
-        const newLabel = updatedData.displayName || updatedData.name || node.label;
+        const newLabel =
+          updatedData.displayName || updatedData.name || node.label;
 
         return {
           ...node,

--- a/openmetadata-ui/src/main/resources/ui/src/components/OntologyExplorer/hooks/useOntologyExplorer.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/components/OntologyExplorer/hooks/useOntologyExplorer.ts
@@ -1484,7 +1484,6 @@ export function useOntologyExplorer({
 
   const handleNodeDataUpdate = useCallback(
     (nodeId: string, updatedData: EntityData) => {
-      const flatData = updatedData as unknown as Record<string, unknown>;
       const applyToNode = (node: OntologyNode): OntologyNode => {
         if (node.id !== nodeId) {
           return node;
@@ -1497,7 +1496,17 @@ export function useOntologyExplorer({
           label: newLabel,
           originalLabel: newLabel,
           description: updatedData.description ?? node.description,
-          searchSource: { ...node.searchSource, ...flatData },
+          searchSource: {
+            ...node.searchSource,
+            displayName: updatedData.displayName,
+            name: updatedData.name,
+            description: updatedData.description,
+            owners: updatedData.owners,
+            tags: updatedData.tags,
+            domains: updatedData.domains,
+            dataProducts: updatedData.dataProducts,
+            extension: updatedData.extension,
+          },
         };
       };
 

--- a/openmetadata-ui/src/main/resources/ui/src/components/OntologyExplorer/hooks/useOntologyExplorer.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/components/OntologyExplorer/hooks/useOntologyExplorer.ts
@@ -1498,14 +1498,17 @@ export function useOntologyExplorer({
           description: updatedData.description ?? node.description,
           searchSource: {
             ...node.searchSource,
-            displayName: updatedData.displayName,
-            name: updatedData.name,
-            description: updatedData.description,
-            owners: updatedData.owners,
-            tags: updatedData.tags,
-            domains: updatedData.domains,
-            dataProducts: updatedData.dataProducts,
-            extension: updatedData.extension,
+            displayName:
+              updatedData.displayName ?? node.searchSource?.displayName,
+            name: updatedData.name ?? node.searchSource?.name,
+            description:
+              updatedData.description ?? node.searchSource?.description,
+            owners: updatedData.owners ?? node.searchSource?.owners,
+            tags: updatedData.tags ?? node.searchSource?.tags,
+            domains: updatedData.domains ?? node.searchSource?.domains,
+            dataProducts:
+              updatedData.dataProducts ?? node.searchSource?.dataProducts,
+            extension: updatedData.extension ?? node.searchSource?.extension,
           },
         };
       };


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:

- When editing an entity (display name, description, tags, owners) via the OntologyExplorer slideout panel, the graph node did not update  users had  to manually refresh to see their changes reflected.
- "Clear All" filters was resetting `viewMode`, causing an unintended mode switch

https://github.com/user-attachments/assets/e4690ce3-baa4-4c7e-9096-14e598293b6e


https://github.com/user-attachments/assets/71acb866-a5b0-49d6-ae37-b390cf139bbe


