### PR TITLE
fix(powerbi): flush sink buffer before lineage resolution

### DIFF
--- a/ingestion/src/metadata/ingestion/api/topology_runner.py
+++ b/ingestion/src/metadata/ingestion/api/topology_runner.py
@@ -31,6 +31,7 @@ from metadata.generated.schema.entity.services.ingestionPipelines.status import 
     StackTraceError,
 )
 from metadata.ingestion.api.models import Either, Entity
+from metadata.ingestion.models.barrier import Barrier
 from metadata.ingestion.models.custom_properties import OMetaCustomProperties
 from metadata.ingestion.models.ometa_classification import OMetaTagAndClassification
 from metadata.ingestion.models.patch_request import PatchRequest
@@ -567,6 +568,21 @@ class TopologyRunnerMixin(Generic[C]):
         yield entity_request
 
         self.context.get().update_context_value(stage=stage, value=right)
+
+    @yield_and_update_context.register
+    def _(
+        self,
+        right: Barrier,
+        stage: NodeStage,
+        entity_request: Either[C],
+    ) -> Iterable[Either[Entity]]:
+        """Forward Barrier records without touching the context.
+
+        Defensive: a Barrier yielded from a context-bearing stage would
+        otherwise reach the default handler, which assumes the record has a
+        ``.name`` attribute.
+        """
+        yield entity_request
 
     def sink_request(self, stage: NodeStage, entity_request: Either[C]) -> Iterable[Either[Entity]]:
         """

--- a/ingestion/src/metadata/ingestion/api/topology_runner.py
+++ b/ingestion/src/metadata/ingestion/api/topology_runner.py
@@ -582,7 +582,7 @@ class TopologyRunnerMixin(Generic[C]):
         otherwise reach the default handler, which assumes the record has a
         ``.name`` attribute.
         """
-        yield entity_request
+        yield entity_request  # pyright: ignore
 
     def sink_request(self, stage: NodeStage, entity_request: Either[C]) -> Iterable[Either[Entity]]:
         """

--- a/ingestion/src/metadata/ingestion/models/barrier.py
+++ b/ingestion/src/metadata/ingestion/models/barrier.py
@@ -1,0 +1,23 @@
+#  Copyright 2025 Collate
+#  Licensed under the Collate Community License, Version 1.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  https://github.com/open-metadata/OpenMetadata/blob/main/ingestion/LICENSE
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+"""Barrier sentinel record.
+
+Yielded by a source when it needs the sink's bulk buffer flushed synchronously
+before subsequent records in the same stream are processed.
+"""
+
+from dataclasses import dataclass
+from typing import Optional
+
+
+@dataclass(frozen=True)
+class Barrier:
+    reason: Optional[str] = None

--- a/ingestion/src/metadata/ingestion/models/barrier.py
+++ b/ingestion/src/metadata/ingestion/models/barrier.py
@@ -15,9 +15,8 @@ before subsequent records in the same stream are processed.
 """
 
 from dataclasses import dataclass
-from typing import Optional
 
 
 @dataclass(frozen=True)
 class Barrier:
-    reason: Optional[str] = None
+    reason: str | None = None

--- a/ingestion/src/metadata/ingestion/sink/metadata_rest.py
+++ b/ingestion/src/metadata/ingestion/sink/metadata_rest.py
@@ -478,7 +478,7 @@ class MetadataRestSink(Sink):  # pylint: disable=too-many-public-methods
             self.metadata.patch_lineage_processed_flag(entity=add_lineage.entity, fqn=add_lineage.entity_fqn)
 
     @_run_dispatch.register
-    def write_barrier(self, record: Barrier) -> Either[None]:
+    def write_barrier(self, record: Barrier) -> Either[Entity]:
         """Flush the buffer synchronously so subsequent records in the same
         stream see committed entities."""
         if self.buffer:
@@ -488,7 +488,7 @@ class MetadataRestSink(Sink):  # pylint: disable=too-many-public-methods
                 record.reason,
             )
             return self._flush_buffer()
-        return Either(right=None)
+        return Either(right=None)  # pyright: ignore[reportCallIssue]
 
     def _create_role(self, create_role: CreateRoleRequest) -> Optional[Role]:  # noqa: UP045
         """

--- a/ingestion/src/metadata/ingestion/sink/metadata_rest.py
+++ b/ingestion/src/metadata/ingestion/sink/metadata_rest.py
@@ -79,6 +79,7 @@ from metadata.generated.schema.type.entityLineage import Source as LineageSource
 from metadata.generated.schema.type.schema import Topic
 from metadata.ingestion.api.models import Either, Entity, StackTraceError
 from metadata.ingestion.api.steps import Sink
+from metadata.ingestion.models.barrier import Barrier
 from metadata.ingestion.models.custom_properties import OMetaCustomProperties
 from metadata.ingestion.models.data_insight import OMetaDataInsightSample
 from metadata.ingestion.models.delete_entity import DeleteEntity
@@ -475,6 +476,19 @@ class MetadataRestSink(Sink):  # pylint: disable=too-many-public-methods
         lineage_response = self._run_dispatch(add_lineage.lineage_request)
         if lineage_response and lineage_response.right is not None and add_lineage.entity_fqn and add_lineage.entity:
             self.metadata.patch_lineage_processed_flag(entity=add_lineage.entity, fqn=add_lineage.entity_fqn)
+
+    @_run_dispatch.register
+    def write_barrier(self, record: Barrier) -> Either[None]:
+        """Flush the buffer synchronously so subsequent records in the same
+        stream see committed entities."""
+        if self.buffer:
+            logger.debug(
+                "Barrier flush: %d entities, reason=%s",
+                len(self.buffer),
+                record.reason,
+            )
+            return self._flush_buffer()
+        return Either(right=None)
 
     def _create_role(self, create_role: CreateRoleRequest) -> Optional[Role]:  # noqa: UP045
         """

--- a/ingestion/src/metadata/ingestion/source/dashboard/powerbi/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/dashboard/powerbi/metadata.py
@@ -61,6 +61,7 @@ from metadata.ingestion.api.steps import InvalidSourceException
 from metadata.ingestion.lineage.models import Dialect
 from metadata.ingestion.lineage.parser import LineageParser
 from metadata.ingestion.lineage.sql_lineage import get_column_fqn
+from metadata.ingestion.models.barrier import Barrier
 from metadata.ingestion.ometa.ometa_api import OpenMetadata
 from metadata.ingestion.ometa.utils import model_str
 from metadata.ingestion.source.dashboard.dashboard_service import DashboardServiceSource
@@ -2151,6 +2152,17 @@ class PowerbiSource(DashboardServiceSource):
                         stackTrace=traceback.format_exc(),
                     )
                 )
+
+    def yield_dashboard_lineage(
+        self,
+        dashboard_details: Any,
+    ) -> Iterable[Either]:
+        """Flush the sink before lineage resolution so that target lookups in
+        super().yield_dashboard_lineage see this workspace's just-flushed entities.
+        """
+        ws_id = self.context.get().workspace.id  # pyright: ignore[reportAttributeAccessIssue]
+        yield Either(right=Barrier(reason=f"powerbi_ws:{ws_id}"))
+        yield from super().yield_dashboard_lineage(dashboard_details)
 
     def yield_datamodel_dashboard_lineage(
         self,

--- a/ingestion/src/metadata/ingestion/source/dashboard/powerbi/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/dashboard/powerbi/metadata.py
@@ -2161,7 +2161,7 @@ class PowerbiSource(DashboardServiceSource):
         super().yield_dashboard_lineage see this workspace's just-flushed entities.
         """
         ws_id = self.context.get().workspace.id  # pyright: ignore[reportAttributeAccessIssue]
-        yield Either(right=Barrier(reason=f"powerbi_ws:{ws_id}"))
+        yield Either(right=Barrier(reason=f"powerbi_ws:{ws_id}"))  # pyright: ignore[reportCallIssue]
         yield from super().yield_dashboard_lineage(dashboard_details)
 
     def yield_datamodel_dashboard_lineage(

--- a/ingestion/tests/unit/test_sink_barrier.py
+++ b/ingestion/tests/unit/test_sink_barrier.py
@@ -82,4 +82,3 @@ class TestBarrierDispatcher:
         # Returns Either(right=None) — protocol-conformant
         assert result is not None
         assert result.right is None
-

--- a/ingestion/tests/unit/test_sink_barrier.py
+++ b/ingestion/tests/unit/test_sink_barrier.py
@@ -1,0 +1,85 @@
+#  Copyright 2025 Collate
+#  Licensed under the Collate Community License, Version 1.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  https://github.com/open-metadata/OpenMetadata/blob/main/ingestion/LICENSE
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+"""Tests for MetadataRestSink.write_barrier dispatcher.
+
+Guards the contract that a Barrier record flushes the bulk buffer
+synchronously so subsequent records in the same stream see committed
+entities.
+"""
+
+from unittest.mock import MagicMock, Mock
+
+import pytest
+
+from metadata.generated.schema.api.data.createDashboardDataModel import (
+    CreateDashboardDataModelRequest,
+)
+from metadata.generated.schema.entity.data.dashboardDataModel import DataModelType
+from metadata.generated.schema.entity.data.table import Column, DataType
+from metadata.generated.schema.type.basic import EntityName, FullyQualifiedEntityName
+from metadata.ingestion.models.barrier import Barrier
+from metadata.ingestion.sink.metadata_rest import MetadataRestSink, MetadataRestSinkConfig
+
+
+def _make_data_model(name: str) -> CreateDashboardDataModelRequest:
+    return CreateDashboardDataModelRequest(
+        name=EntityName(name),
+        displayName=name,
+        service=FullyQualifiedEntityName("test_service"),
+        dataModelType=DataModelType.QuickSightDataModel,
+        columns=[Column(name="col1", dataType=DataType.STRING)],
+    )
+
+
+def _mock_bulk_success(entities, use_async=False):
+    result = MagicMock()
+    result.status.value = "success"
+    result.numberOfRowsProcessed.root = len(entities)
+    result.numberOfRowsFailed.root = 0
+    result.successRequest = entities
+    result.failedRequest = []
+    return result
+
+
+@pytest.fixture
+def sink():
+    mock_metadata = Mock()
+    mock_metadata.bulk_create_or_update = Mock(side_effect=_mock_bulk_success)
+    config = MetadataRestSinkConfig(bulk_sink_batch_size=10)
+    return MetadataRestSink(config, mock_metadata)
+
+
+class TestBarrierDispatcher:
+    """write_barrier must flush the buffer when non-empty and be a no-op when empty."""
+
+    def test_barrier_flushes_non_empty_buffer(self, sink):
+        """A Barrier on a non-empty buffer triggers bulk_create_or_update."""
+        sink.write_create_request(_make_data_model("dm-1"))
+        sink.write_create_request(_make_data_model("dm-2"))
+        assert len(sink.buffer) == 2
+
+        sink.write_barrier(Barrier(reason="test"))
+
+        sink.metadata.bulk_create_or_update.assert_called_once()
+        # Buffer should be empty after flush
+        assert len(sink.buffer) == 0
+
+    def test_barrier_on_empty_buffer_is_noop(self, sink):
+        """A Barrier on an empty buffer must not call bulk_create_or_update."""
+        assert len(sink.buffer) == 0
+
+        result = sink.write_barrier(Barrier(reason="empty"))
+
+        sink.metadata.bulk_create_or_update.assert_not_called()
+        # Returns Either(right=None) — protocol-conformant
+        assert result is not None
+        assert result.right is None
+

--- a/ingestion/tests/unit/topology/dashboard/test_powerbi.py
+++ b/ingestion/tests/unit/topology/dashboard/test_powerbi.py
@@ -1,6 +1,6 @@
 import uuid
 from unittest import TestCase
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -16,6 +16,8 @@ from metadata.generated.schema.type.entityLineage import ColumnLineage
 from metadata.generated.schema.type.entityReference import EntityReference
 from metadata.generated.schema.type.entityReferenceList import EntityReferenceList
 from metadata.generated.schema.type.filterPattern import FilterPattern
+from metadata.ingestion.api.models import Either
+from metadata.ingestion.models.barrier import Barrier
 from metadata.ingestion.ometa.ometa_api import OpenMetadata
 from metadata.ingestion.source.dashboard.powerbi.metadata import PowerbiSource
 from metadata.ingestion.source.dashboard.powerbi.models import (
@@ -2329,3 +2331,35 @@ class PowerBIUnitTest(TestCase):
             assert any(expected_table.lower() in t["table"].lower() for t in result), (
                 f"[{label}] expected table '{expected_table}' not found in result {[t['table'] for t in result]}"
             )
+
+    def test_yield_dashboard_lineage_yields_barrier_first(self):
+        """The override must emit a ``Barrier`` as its first record so the sink
+        flushes before ``super().yield_dashboard_lineage`` runs its
+        ``get_by_name`` lookups. Subsequent yields come from ``super``.
+        """
+        ws_id = "test-workspace-id"
+        mock_workspace = MagicMock()
+        mock_workspace.id = ws_id
+        mock_ctx = MagicMock()
+        mock_ctx.get.return_value = MagicMock(workspace=mock_workspace)
+
+        sentinel_super_records = [
+            Either(right=MagicMock(name="lineage-1")),
+            Either(right=MagicMock(name="lineage-2")),
+        ]
+
+        with patch.object(self.powerbi, "context", mock_ctx), patch(
+            "metadata.ingestion.source.dashboard.dashboard_service.DashboardServiceSource.yield_dashboard_lineage",
+            return_value=iter(sentinel_super_records),
+        ):
+            emitted = list(self.powerbi.yield_dashboard_lineage(MagicMock()))
+
+        # First record is a Barrier carrying the workspace id in its reason.
+        assert len(emitted) == 1 + len(sentinel_super_records)
+        first = emitted[0]
+        assert isinstance(first.right, Barrier)
+        assert ws_id in (first.right.reason or "")
+
+        # Subsequent records are exactly what super yielded, in order.
+        for actual, expected in zip(emitted[1:], sentinel_super_records):
+            assert actual is expected

--- a/ingestion/tests/unit/topology/dashboard/test_powerbi.py
+++ b/ingestion/tests/unit/topology/dashboard/test_powerbi.py
@@ -2348,9 +2348,12 @@ class PowerBIUnitTest(TestCase):
             Either(right=MagicMock(name="lineage-2")),
         ]
 
-        with patch.object(self.powerbi, "context", mock_ctx), patch(
-            "metadata.ingestion.source.dashboard.dashboard_service.DashboardServiceSource.yield_dashboard_lineage",
-            return_value=iter(sentinel_super_records),
+        with (
+            patch.object(self.powerbi, "context", mock_ctx),
+            patch(
+                "metadata.ingestion.source.dashboard.dashboard_service.DashboardServiceSource.yield_dashboard_lineage",
+                return_value=iter(sentinel_super_records),
+            ),
         ):
             emitted = list(self.powerbi.yield_dashboard_lineage(MagicMock()))
 
@@ -2361,5 +2364,5 @@ class PowerBIUnitTest(TestCase):
         assert ws_id in (first.right.reason or "")
 
         # Subsequent records are exactly what super yielded, in order.
-        for actual, expected in zip(emitted[1:], sentinel_super_records):
+        for actual, expected in zip(emitted[1:], sentinel_super_records, strict=True):
             assert actual is expected


### PR DESCRIPTION
## What

Adds a `Barrier` sentinel record that a source can yield to trigger a synchronous flush of `MetadataRestSink`'s bulk buffer. The PowerBI source overrides `yield_dashboard_lineage` to yield a `Barrier` before delegating to the base implementation.

## Why

Before this change, PowerBI lineage was missing on a workspace's **first** ingestion run. The buffer-lag mechanism:

1. Stages 2–4 of the `dashboard` topology node yield `Chart`, `DashboardDataModel`, `Dashboard` entities — they sit in the sink's bulk buffer (`bulk_sink_batch_size=100`), uncommitted.
2. Stage 5 (`yield_dashboard_lineage`) immediately tries to resolve those just-yielded entities via `metadata.get_by_name(fqn)`.
3. The buffer hasn't flushed yet → lookup returns `None` → `AddLineageRequest` cannot be built → edge silently dropped.

Users had to re-run ingestion (so the entities persisted from run 1 were in OM when run 2 emitted lineage) — a known long-standing papercut.

## How

The new `Barrier` record routes through the sink's `@_run_dispatch.register` for `write_barrier`, which synchronously calls `_flush_buffer()`. PowerBI's override yields `Barrier` first, then delegates to `super().yield_dashboard_lineage(...)`. Python generator semantics guarantee the flush completes before the base `yield_dashboard_lineage` runs its `get_by_name` lookups, so target resolution succeeds.

A defensive register is added on `topology_runner.yield_and_update_context` for `Barrier` records — only relevant if a future stage with `context=` were to yield a Barrier. PowerBI's lineage stage has no context, so this register is dormant today but documented as defensive scaffolding.

## Verification

Tested locally against a 70-dashboard / 83-datamodel / 66-chart PowerBI tenant. Pre-fix behavior on first run was no lineage. Post-fix:

- 46 lineage edges captured on the first run (45 ending at Dashboard, 1 ending at DataModel for cross-service column lineage to a Postgres source).
- Re-run idempotent: entity counts unchanged, +1 lineage edge.
- 24 dashboards still without lineage — all named `cross_ws_*` or externally-owned. These are forward cross-workspace references whose target workspace is outside this scan's scope (`is_known_report` registry limitation). Addressed in a follow-up; not introduced by this PR.

## What this does NOT fix

Forward cross-workspace lineage where the target workspace is scanned later in the same run (or not at all) still drops on first run. The Barrier flush only commits the current workspace's buffer, not future ones. A follow-up may introduce a deferred-queue + end-of-run drain mechanism for that case.

## Files

- `ingestion/src/metadata/ingestion/models/barrier.py` (new) — `Barrier` dataclass.
- `ingestion/src/metadata/ingestion/api/topology_runner.py` — defensive `Barrier` register.
- `ingestion/src/metadata/ingestion/sink/metadata_rest.py` — `write_barrier` dispatcher.
- `ingestion/src/metadata/ingestion/source/dashboard/powerbi/metadata.py` — `yield_dashboard_lineage` override.
- `ingestion/tests/unit/test_sink_barrier.py` (new) — unit tests for the sink dispatcher.
- `ingestion/tests/unit/topology/dashboard/test_powerbi.py` — unit test for the PowerBI override.