### PR TITLE
Improvement: Mover alert bar to drawer for success and error message

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/OntologyExplorer/OntologyEntityPanel.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/OntologyExplorer/OntologyEntityPanel.tsx
@@ -1,0 +1,113 @@
+/*
+ *  Copyright 2025 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+import { SlideoutMenu } from '@openmetadata/ui-core-components';
+import { ReactNode, useEffect, useLayoutEffect, useState } from 'react';
+import { useAlertStore } from '../../hooks/useAlertStore';
+import { EntityData } from '../../pages/TasksPage/TasksPage.interface';
+import AlertBar from '../AlertBar/AlertBar';
+import EntitySummaryPanel from '../Explore/EntitySummaryPanel/EntitySummaryPanel.component';
+import { EntityDetailsObjectInterface } from '../Explore/ExplorePage.interface';
+
+const PANEL_WIDTH = 576;
+
+interface OntologyEntityPanelProps {
+  readonly isOpen: boolean;
+  readonly entityDetails: EntityDetailsObjectInterface;
+  readonly panelPath: string;
+  readonly sideDrawerOverviewOnly?: boolean;
+  readonly ontologyRelationsSlot?: ReactNode;
+  readonly onClose: () => void;
+  readonly afterEntityUpdate?: (updatedData: EntityData) => void;
+}
+
+export const OntologyEntityPanel = ({
+  isOpen,
+  entityDetails,
+  panelPath,
+  sideDrawerOverviewOnly = false,
+  ontologyRelationsSlot,
+  onClose,
+  afterEntityUpdate,
+}: OntologyEntityPanelProps) => {
+  const { alert, resetAlert } = useAlertStore();
+  const [localToast, setLocalToast] = useState<{
+    open: boolean;
+    message: string;
+    type: 'success' | 'error';
+  }>({ message: '', open: false, type: 'success' });
+
+  // Intercept global alerts when the panel is open so they show inside
+  // the slideout instead of on the background page via PageLayoutV1.
+  useLayoutEffect(() => {
+    if (!alert || !isOpen) {
+      return;
+    }
+    setLocalToast({
+      message: typeof alert.message === 'string' ? alert.message : '',
+      open: true,
+      type: alert.type === 'error' ? 'error' : 'success',
+    });
+    resetAlert();
+  }, [alert, isOpen, resetAlert]);
+
+  useEffect(() => {
+    if (!localToast.open) {
+      return undefined;
+    }
+    const timer = setTimeout(
+      () => setLocalToast((prev) => ({ ...prev, open: false })),
+      3000
+    );
+
+    return () => clearTimeout(timer);
+  }, [localToast]);
+
+  return (
+    <SlideoutMenu
+      isDismissable
+      className="tw:z-2"
+      dialogClassName="tw:gap-0 tw:items-stretch tw:min-h-0 tw:overflow-hidden tw:p-0"
+      isOpen={isOpen}
+      width={PANEL_WIDTH}
+      onOpenChange={(open) => {
+        if (!open) {
+          onClose();
+        }
+      }}>
+      {() => (
+        <>
+          {localToast.open && (
+            <div className="tw:mt-2 tw:mx-3">
+              <AlertBar
+                defaultExpand
+                className="show-alert"
+                message={localToast.message}
+                type={localToast.type}
+              />
+            </div>
+          )}
+          <EntitySummaryPanel
+            isSideDrawer
+            afterEntityUpdate={afterEntityUpdate}
+            entityDetails={entityDetails}
+            handleClosePanel={onClose}
+            ontologyExplorerRelationsSlot={ontologyRelationsSlot}
+            panelPath={panelPath}
+            sideDrawerOverviewOnly={sideDrawerOverviewOnly}
+          />
+        </>
+      )}
+    </SlideoutMenu>
+  );
+};

--- a/openmetadata-ui/src/main/resources/ui/src/components/OntologyExplorer/OntologyEntityPanel.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/OntologyExplorer/OntologyEntityPanel.tsx
@@ -43,7 +43,7 @@ export const OntologyEntityPanel = ({
   const { alert, resetAlert } = useAlertStore();
   const [localToast, setLocalToast] = useState<{
     open: boolean;
-    message: string;
+    message: string | JSX.Element;
     type: 'success' | 'error';
   }>({ message: '', open: false, type: 'success' });
 
@@ -54,7 +54,7 @@ export const OntologyEntityPanel = ({
       return;
     }
     setLocalToast({
-      message: typeof alert.message === 'string' ? alert.message : '',
+      message: alert.message,
       open: true,
       type: alert.type === 'error' ? 'error' : 'success',
     });

--- a/openmetadata-ui/src/main/resources/ui/src/components/OntologyExplorer/OntologyExplorer.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/OntologyExplorer/OntologyExplorer.tsx
@@ -25,7 +25,6 @@ import { useTranslation } from 'react-i18next';
 import { GlossaryTerm } from '../../generated/entity/data/glossaryTerm';
 import { useGenericContext } from '../Customization/GenericProvider/GenericProvider';
 import { buildOntologySlideoutEntityDetails } from './buildOntologySlideoutEntityDetails';
-import { OntologyEntityPanel } from './OntologyEntityPanel';
 import ExportGraphPanel from './ExportGraphPanel';
 import FilterToolbar from './FilterToolbar';
 import GraphSettingsPanel from './GraphSettingsPanel';
@@ -34,6 +33,7 @@ import {
   useOntologyExplorer,
 } from './hooks/useOntologyExplorer';
 import OntologyControlButtons from './OntologyControlButtons';
+import { OntologyEntityPanel } from './OntologyEntityPanel';
 import { withoutOntologyAutocompleteAll } from './OntologyExplorer.constants';
 import {
   ExplorationMode,
@@ -53,7 +53,6 @@ const ONTOLOGY_GRAPH_BACKDROP_CLASS =
 
 const ONTOLOGY_TOOLBAR_CARD_CLASS =
   'tw:z-1 tw:border tw:border-utility-gray-blue-100 tw:ring-0 tw:shadow-md';
-
 
 interface GraphEmptyStateProps {
   readonly message: string;

--- a/openmetadata-ui/src/main/resources/ui/src/components/OntologyExplorer/OntologyExplorer.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/OntologyExplorer/OntologyExplorer.tsx
@@ -14,7 +14,6 @@
 import {
   Card,
   Input,
-  SlideoutMenu,
   Tabs,
   Typography,
 } from '@openmetadata/ui-core-components';
@@ -25,8 +24,8 @@ import { ErrorBoundary } from 'react-error-boundary';
 import { useTranslation } from 'react-i18next';
 import { GlossaryTerm } from '../../generated/entity/data/glossaryTerm';
 import { useGenericContext } from '../Customization/GenericProvider/GenericProvider';
-import EntitySummaryPanel from '../Explore/EntitySummaryPanel/EntitySummaryPanel.component';
 import { buildOntologySlideoutEntityDetails } from './buildOntologySlideoutEntityDetails';
+import { OntologyEntityPanel } from './OntologyEntityPanel';
 import ExportGraphPanel from './ExportGraphPanel';
 import FilterToolbar from './FilterToolbar';
 import GraphSettingsPanel from './GraphSettingsPanel';
@@ -55,7 +54,6 @@ const ONTOLOGY_GRAPH_BACKDROP_CLASS =
 const ONTOLOGY_TOOLBAR_CARD_CLASS =
   'tw:z-1 tw:border tw:border-utility-gray-blue-100 tw:ring-0 tw:shadow-md';
 
-const ONTOLOGY_ENTITY_SUMMARY_SLIDEOUT_WIDTH = 576;
 
 interface GraphEmptyStateProps {
   readonly message: string;
@@ -143,6 +141,11 @@ const OntologyExplorer: React.FC<OntologyExplorerProps> = ({
   });
 
   const [searchInput, setSearchInput] = useState(filters.searchQuery);
+  const lastSelectedNodeRef = useRef(selectedNode);
+  if (selectedNode) {
+    lastSelectedNodeRef.current = selectedNode;
+  }
+  const activeNode = selectedNode ?? lastSelectedNodeRef.current;
   const searchInputRef = useRef(searchInput);
   searchInputRef.current = searchInput;
 
@@ -472,56 +475,42 @@ const OntologyExplorer: React.FC<OntologyExplorerProps> = ({
             {renderGraphContent()}
           </div>
 
-          {selectedNode && (
-            <SlideoutMenu
-              isDismissable
-              isOpen
-              className="tw:z-2"
-              dialogClassName="tw:gap-0 tw:items-stretch tw:min-h-0 tw:overflow-hidden tw:p-0"
-              width={ONTOLOGY_ENTITY_SUMMARY_SLIDEOUT_WIDTH}
-              onOpenChange={(isOpen) => {
-                if (!isOpen) {
-                  setSelectedNode(null);
-                }
-              }}>
-              {({ close }) => (
-                <EntitySummaryPanel
-                  isSideDrawer
-                  afterEntityUpdate={(updatedData) => {
-                    if (selectedNode) {
-                      handleNodeDataUpdate(selectedNode.id, updatedData);
-                    }
-                  }}
-                  entityDetails={buildOntologySlideoutEntityDetails(
-                    selectedNode
+          <OntologyEntityPanel
+            afterEntityUpdate={
+              selectedNode
+                ? (updatedData) =>
+                    handleNodeDataUpdate(selectedNode.id, updatedData)
+                : undefined
+            }
+            entityDetails={
+              activeNode
+                ? buildOntologySlideoutEntityDetails(activeNode)
+                : { details: {} as never }
+            }
+            isOpen={Boolean(selectedNode)}
+            key={selectedNode?.id}
+            ontologyRelationsSlot={
+              selectedNode && !isDataAssetLikeNode(selectedNode) ? (
+                <OntologyNodeRelationsContent
+                  edges={(filteredGraphData?.edges ?? []).filter(
+                    (e) => e.relationType !== ASSET_RELATION_TYPE
                   )}
-                  handleClosePanel={() => {
-                    setSelectedNode(null);
-                    close();
-                  }}
-                  key={selectedNode.id}
-                  ontologyExplorerRelationsSlot={
-                    isDataAssetLikeNode(selectedNode) ? undefined : (
-                      <OntologyNodeRelationsContent
-                        edges={(filteredGraphData?.edges ?? []).filter(
-                          (e) => e.relationType !== ASSET_RELATION_TYPE
-                        )}
-                        node={selectedNode}
-                        nodes={filteredGraphData?.nodes ?? []}
-                        relationTypes={relationTypes}
-                      />
-                    )
-                  }
-                  panelPath={
-                    isDataAssetLikeNode(selectedNode)
-                      ? 'glossary-term-assets-tab'
-                      : 'ontology-explorer'
-                  }
-                  sideDrawerOverviewOnly={isDataAssetLikeNode(selectedNode)}
+                  node={selectedNode}
+                  nodes={filteredGraphData?.nodes ?? []}
+                  relationTypes={relationTypes}
                 />
-              )}
-            </SlideoutMenu>
-          )}
+              ) : undefined
+            }
+            panelPath={
+              selectedNode && isDataAssetLikeNode(selectedNode)
+                ? 'glossary-term-assets-tab'
+                : 'ontology-explorer'
+            }
+            sideDrawerOverviewOnly={
+              selectedNode ? isDataAssetLikeNode(selectedNode) : false
+            }
+            onClose={() => setSelectedNode(null)}
+          />
         </div>
       </div>
     </div>


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:
Moved the alert bar inside the entity details drawer to properly display update success and error messages.


https://github.com/user-attachments/assets/438ed852-6d4f-4c4c-becc-a055470a2792

----
## Summary by Gitar

- **Component refactoring:**
  - Encapsulated `SlideoutMenu` logic into a new `OntologyEntityPanel` component.
- **Alert management:**
  - Integrated `AlertBar` within the drawer to intercept and display global alerts locally when the panel is active.
  - Added auto-dismissal for local alert messages after 3 seconds.
  - Updated `localToast` state to support `JSX.Element` for more flexible alert messaging.
- **State management:**
  - Introduced `lastSelectedNodeRef` in `OntologyExplorer` to maintain context for the active node during panel transitions.

<sub>This will update automatically on new commits.</sub>