### PR TITLE
Improve Vector Embedding recalculation logic

### DIFF
--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/VectorEmbeddingIntegrationIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/VectorEmbeddingIntegrationIT.java
@@ -242,13 +242,29 @@ class VectorEmbeddingIntegrationIT {
     vectorService.updateEntityEmbedding(entity2, TEST_INDEX);
     Thread.sleep(1000);
 
-    Map<String, String> fingerprints =
-        vectorService.getExistingFingerprintsBatch(
-            TEST_INDEX, List.of(entity1Id.toString(), entity2Id.toString()));
+    Map<String, OpenSearchVectorService.EntityFingerprintInput> currentById =
+        Map.of(
+            entity1Id.toString(),
+            new OpenSearchVectorService.EntityFingerprintInput(
+                entity1.getUpdatedAt(),
+                () -> VectorDocBuilder.computeFingerprintForEntity(entity1)),
+            entity2Id.toString(),
+            new OpenSearchVectorService.EntityFingerprintInput(
+                entity2.getUpdatedAt(),
+                () -> VectorDocBuilder.computeFingerprintForEntity(entity2)));
 
-    assertEquals(2, fingerprints.size(), "Should retrieve fingerprints for both entities");
-    assertNotNull(fingerprints.get(entity1Id.toString()));
-    assertNotNull(fingerprints.get(entity2Id.toString()));
+    Map<String, JsonNode> cachedEmbeddings =
+        vectorService.getExistingEmbeddingsBatch(TEST_INDEX, currentById);
+
+    assertEquals(2, cachedEmbeddings.size(), "Should retrieve cached embeddings for both entities");
+    JsonNode cached1 = cachedEmbeddings.get(entity1Id.toString());
+    JsonNode cached2 = cachedEmbeddings.get(entity2Id.toString());
+    assertNotNull(cached1);
+    assertNotNull(cached2);
+    assertTrue(cached1.path("fingerprint").isTextual());
+    assertTrue(cached2.path("fingerprint").isTextual());
+    assertTrue(cached1.path("embedding").isArray() && !cached1.path("embedding").isEmpty());
+    assertTrue(cached2.path("embedding").isArray() && !cached2.path("embedding").isEmpty());
   }
 
   @Test

--- a/openmetadata-service/src/main/java/org/openmetadata/service/apps/bundles/searchIndex/OpenSearchBulkSink.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/apps/bundles/searchIndex/OpenSearchBulkSink.java
@@ -277,22 +277,23 @@ public class OpenSearchBulkSink implements BulkSink {
                 ? (ReindexContext) contextData.get(RECREATE_CONTEXT)
                 : null;
 
-        // Pre-fetch cached embeddings for entities whose fingerprint is unchanged so we can splice
-        // them into the staged doc instead of regenerating (avoids expensive embedding-provider
-        // calls). Two-step over the original index: first an mget for fingerprints only, then —
-        // for IDs whose cached fingerprint matches the entity's current fingerprint — a second
-        // mget that pulls the full embedding source. This keeps large vector payloads off the wire
-        // for entities that will be re-embedded anyway.
+        // Pre-fetch cached embeddings for entities whose state is unchanged so we can splice them
+        // into the staged doc instead of regenerating (avoids expensive embedding-provider calls).
+        // The service-layer two-step keeps large vector payloads off the wire for entities that
+        // will be re-embedded anyway, and uses the entity's `updatedAt` as a fast-path: when it
+        // matches the cached value the fingerprint supplier is never invoked.
         Map<String, JsonNode> existingEmbeddingsById = Collections.emptyMap();
         if (embeddingsEnabled) {
-          Map<String, String> currentFingerprintsById = new HashMap<>(entityInterfaces.size());
+          Map<String, OpenSearchVectorService.EntityFingerprintInput> currentById =
+              new HashMap<>(entityInterfaces.size());
           for (EntityInterface e : entityInterfaces) {
-            currentFingerprintsById.put(
-                e.getId().toString(), VectorDocBuilder.computeFingerprintForEntity(e));
+            currentById.put(
+                e.getId().toString(),
+                new OpenSearchVectorService.EntityFingerprintInput(
+                    e.getUpdatedAt(), () -> VectorDocBuilder.computeFingerprintForEntity(e)));
           }
           existingEmbeddingsById =
-              fetchExistingEmbeddings(
-                  entityInterfaces, currentFingerprintsById, indexName, reindexContext);
+              fetchExistingEmbeddings(entityInterfaces, currentById, indexName, reindexContext);
         }
 
         // Add entities to search index in parallel
@@ -833,6 +834,9 @@ public class OpenSearchBulkSink implements BulkSink {
 
       JsonNode cached = existingEmbeddingsById.get(entity.getId().toString());
       if (canReuseCachedEmbedding(cached)) {
+        // Splices chunkIndex/chunkCount/parentId along with embedding — safe because the
+        // service-layer pre-filter only admits entries whose state matches (same fingerprint or
+        // same updatedAt), and fingerprint covers the body text that determines chunk count.
         doc.setAll((ObjectNode) cached);
       } else {
         Map<String, Object> embeddingFields = vectorService.generateEmbeddingFields(entity);
@@ -877,7 +881,7 @@ public class OpenSearchBulkSink implements BulkSink {
 
   private Map<String, JsonNode> fetchExistingEmbeddings(
       List<EntityInterface> entities,
-      Map<String, String> currentFingerprintsById,
+      Map<String, OpenSearchVectorService.EntityFingerprintInput> currentById,
       String indexName,
       ReindexContext reindexContext) {
     try {
@@ -895,7 +899,7 @@ public class OpenSearchBulkSink implements BulkSink {
         }
       }
 
-      return vectorService.getExistingEmbeddingsBatch(targetIndex, currentFingerprintsById);
+      return vectorService.getExistingEmbeddingsBatch(targetIndex, currentById);
     } catch (Exception e) {
       LOG.warn("Failed to fetch existing embeddings from index {}", indexName, e);
       return Collections.emptyMap();

--- a/openmetadata-service/src/main/java/org/openmetadata/service/apps/bundles/searchIndex/OpenSearchBulkSink.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/apps/bundles/searchIndex/OpenSearchBulkSink.java
@@ -285,7 +285,7 @@ public class OpenSearchBulkSink implements BulkSink {
         // for entities that will be re-embedded anyway.
         Map<String, JsonNode> existingEmbeddingsById = Collections.emptyMap();
         if (embeddingsEnabled) {
-          Map<String, String> currentFingerprintsById = HashMap.newHashMap(entityInterfaces.size());
+          Map<String, String> currentFingerprintsById = new HashMap<>(entityInterfaces.size());
           for (EntityInterface e : entityInterfaces) {
             currentFingerprintsById.put(
                 e.getId().toString(), VectorDocBuilder.computeFingerprintForEntity(e));

--- a/openmetadata-service/src/main/java/org/openmetadata/service/apps/bundles/searchIndex/OpenSearchBulkSink.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/apps/bundles/searchIndex/OpenSearchBulkSink.java
@@ -4,7 +4,9 @@ import static org.openmetadata.service.workflows.searchIndex.ReindexingUtil.ENTI
 import static org.openmetadata.service.workflows.searchIndex.ReindexingUtil.RECREATE_CONTEXT;
 import static org.openmetadata.service.workflows.searchIndex.ReindexingUtil.TARGET_INDEX_KEY;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import jakarta.json.stream.JsonGenerator;
 import java.io.IOException;
 import java.io.StringWriter;
@@ -274,15 +276,17 @@ public class OpenSearchBulkSink implements BulkSink {
                 ? (ReindexContext) contextData.get(RECREATE_CONTEXT)
                 : null;
 
-        // Pre-fetch fingerprints for batch optimization (skip during recreate — fresh index)
-        Map<String, String> existingFingerprints = Collections.emptyMap();
-        if (embeddingsEnabled && !recreateIndex) {
+        // Pre-fetch existing embeddings (fingerprint + vector) for batch reuse, including during
+        // recreate — when fingerprint matches, we splice the cached embedding into the staged doc
+        // instead of regenerating it (avoids expensive Bedrock/embedding-provider calls).
+        Map<String, JsonNode> existingFingerprints = Collections.emptyMap();
+        if (embeddingsEnabled) {
           existingFingerprints =
               fetchExistingFingerprints(entityInterfaces, indexName, reindexContext);
         }
 
         // Add entities to search index in parallel
-        Map<String, String> finalFingerprints = existingFingerprints;
+        Map<String, JsonNode> finalFingerprints = existingFingerprints;
         List<CompletableFuture<Void>> futures =
             entityInterfaces.stream()
                 .map(
@@ -357,7 +361,7 @@ public class OpenSearchBulkSink implements BulkSink {
       ReindexContext reindexContext,
       StageStatsTracker tracker,
       boolean embeddingsEnabled,
-      Map<String, String> existingFingerprints) {
+      Map<String, JsonNode> existingFingerprints) {
     try {
       String entityType = Entity.getEntityTypeFromObject(entity);
       Object searchIndexDoc = Entity.buildSearchIndex(entityType, entity).buildSearchIndexDoc();
@@ -798,12 +802,11 @@ public class OpenSearchBulkSink implements BulkSink {
         && searchRepository.getIndexMapping(entityType) != null;
   }
 
-  @SuppressWarnings("unchecked")
   private String enrichWithEmbedding(
       EntityInterface entity,
       String json,
       boolean recreateIndex,
-      Map<String, String> existingFingerprints,
+      Map<String, JsonNode> existingFingerprints,
       StageStatsTracker tracker) {
     try {
       OpenSearchVectorService vectorService = OpenSearchVectorService.getInstance();
@@ -811,28 +814,21 @@ public class OpenSearchBulkSink implements BulkSink {
         return json;
       }
 
-      if (!recreateIndex) {
-        String currentFp = VectorDocBuilder.computeFingerprintForEntity(entity);
-        String existingFp = existingFingerprints.get(entity.getId().toString());
-        if (existingFp != null && existingFp.equals(currentFp)) {
-          vectorSuccess.incrementAndGet();
-          if (tracker != null) {
-            tracker.recordVector(StatsResult.SUCCESS);
-          }
-          return json;
-        }
-      }
+      ObjectNode doc = (ObjectNode) OBJECT_MAPPER.readTree(json);
+      JsonNode cached = existingFingerprints.get(entity.getId().toString());
 
-      Map<String, Object> embeddingFields = vectorService.generateEmbeddingFields(entity);
-      Map<String, Object> docMap = OBJECT_MAPPER.readValue(json, Map.class);
-      docMap.putAll(embeddingFields);
-      String enrichedJson = OBJECT_MAPPER.writeValueAsString(docMap);
+      if (canReuseCachedEmbedding(entity, cached)) {
+        doc.setAll((ObjectNode) cached);
+      } else {
+        Map<String, Object> embeddingFields = vectorService.generateEmbeddingFields(entity);
+        doc.setAll((ObjectNode) OBJECT_MAPPER.valueToTree(embeddingFields));
+      }
 
       vectorSuccess.incrementAndGet();
       if (tracker != null) {
         tracker.recordVector(StatsResult.SUCCESS);
       }
-      return enrichedJson;
+      return OBJECT_MAPPER.writeValueAsString(doc);
     } catch (Exception e) {
       LOG.warn(
           "Failed to generate embeddings for entity {}: {}", entity.getId(), e.getMessage(), e);
@@ -844,12 +840,34 @@ public class OpenSearchBulkSink implements BulkSink {
     }
   }
 
+  /**
+   * True when the cached source from the original index has a matching fingerprint and a non-empty
+   * embedding vector. Tree-model access ({@code .path(...).asText(null)}, {@code .isArray()}) is
+   * type-tolerant — a missing or unexpectedly-typed field returns a safe default rather than
+   * throwing.
+   */
+  private static boolean canReuseCachedEmbedding(EntityInterface entity, JsonNode cached) {
+    if (cached == null || !cached.isObject()) {
+      return false;
+    }
+    String existingFp = cached.path("fingerprint").asText(null);
+    if (existingFp == null) {
+      return false;
+    }
+    String currentFp = VectorDocBuilder.computeFingerprintForEntity(entity);
+    if (!existingFp.equals(currentFp)) {
+      return false;
+    }
+    JsonNode embedding = cached.path("embedding");
+    return embedding.isArray() && !embedding.isEmpty();
+  }
+
   @Override
   public int getActiveBulkRequestCount() {
     return bulkProcessor.activeBulkRequests.get();
   }
 
-  private Map<String, String> fetchExistingFingerprints(
+  private Map<String, JsonNode> fetchExistingFingerprints(
       List<EntityInterface> entities, String indexName, ReindexContext reindexContext) {
     try {
       OpenSearchVectorService vectorService = OpenSearchVectorService.getInstance();
@@ -860,7 +878,7 @@ public class OpenSearchBulkSink implements BulkSink {
       String entityType = entities.getFirst().getEntityReference().getType();
       String targetIndex = indexName;
       if (reindexContext != null) {
-        String stagedIndex = reindexContext.getStagedIndex(entityType).orElse(null);
+        String stagedIndex = reindexContext.getOriginalIndex(entityType).orElse(null);
         if (stagedIndex != null) {
           targetIndex = stagedIndex;
         }
@@ -870,9 +888,9 @@ public class OpenSearchBulkSink implements BulkSink {
       for (EntityInterface entity : entities) {
         entityIds.add(entity.getId().toString());
       }
-      return vectorService.getExistingFingerprintsBatch(targetIndex, entityIds);
+      return vectorService.getExistingEmbeddingsBatch(targetIndex, entityIds);
     } catch (Exception e) {
-      LOG.warn("Failed to fetch existing fingerprints: {}", e.getMessage());
+      LOG.warn("Failed to fetch existing embeddings: {}", e.getMessage());
       return Collections.emptyMap();
     }
   }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/apps/bundles/searchIndex/OpenSearchBulkSink.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/apps/bundles/searchIndex/OpenSearchBulkSink.java
@@ -860,18 +860,24 @@ public class OpenSearchBulkSink implements BulkSink {
   }
 
   /**
-   * The cached payload from {@code fetchExistingEmbeddings} is already filtered to fingerprint
-   * matches by the service layer, so the only remaining check at the splice site is that the
-   * cached document is an object with a non-empty embedding array. Tree-model access is
-   * type-tolerant — a missing or unexpectedly-typed field returns a safe default rather than
-   * throwing.
+   * The cached payload from {@code fetchExistingEmbeddings} is pre-filtered by the service layer
+   * to entries whose state matches. As defense-in-depth at the splice site we also require the
+   * cached doc to (a) be an object, (b) have a non-empty {@code embedding} array, and (c) have a
+   * textual non-blank {@code fingerprint}. Tree-model access is type-tolerant — a missing or
+   * unexpectedly-typed field returns a safe default rather than throwing — and the fingerprint
+   * check ensures we never splice a vector into the new index without also carrying its
+   * fingerprint, which would silently break future reuse for that entity.
    */
   private static boolean canReuseCachedEmbedding(JsonNode cached) {
     if (cached == null || !cached.isObject()) {
       return false;
     }
     JsonNode embedding = cached.path("embedding");
-    return embedding.isArray() && !embedding.isEmpty();
+    if (!embedding.isArray() || embedding.isEmpty()) {
+      return false;
+    }
+    JsonNode fingerprint = cached.path("fingerprint");
+    return fingerprint.isTextual() && !fingerprint.asText().isBlank();
   }
 
   @Override
@@ -891,17 +897,15 @@ public class OpenSearchBulkSink implements BulkSink {
       }
 
       String entityType = entities.getFirst().getEntityReference().getType();
-      String targetIndex = indexName;
-      if (reindexContext != null) {
-        String stagedIndex = reindexContext.getOriginalIndex(entityType).orElse(null);
-        if (stagedIndex != null) {
-          targetIndex = stagedIndex;
-        }
-      }
-
-      return vectorService.getExistingEmbeddingsBatch(targetIndex, currentById);
+      // During a recreate, read embeddings from the pre-recreate live index (the staged index is
+      // empty by definition). Outside a recreate, read from the canonical index passed in.
+      String sourceIndex =
+          reindexContext != null
+              ? reindexContext.getOriginalIndex(entityType).orElse(indexName)
+              : indexName;
+      return vectorService.getExistingEmbeddingsBatch(sourceIndex, currentById);
     } catch (Exception e) {
-      LOG.warn("Failed to fetch existing embeddings from index {}", indexName, e);
+      LOG.warn("Failed to fetch existing embeddings (canonical index={})", indexName, e);
       return Collections.emptyMap();
     }
   }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/apps/bundles/searchIndex/OpenSearchBulkSink.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/apps/bundles/searchIndex/OpenSearchBulkSink.java
@@ -13,6 +13,7 @@ import java.io.StringWriter;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -276,17 +277,26 @@ public class OpenSearchBulkSink implements BulkSink {
                 ? (ReindexContext) contextData.get(RECREATE_CONTEXT)
                 : null;
 
-        // Pre-fetch existing embeddings (fingerprint + vector) for batch reuse, including during
-        // recreate — when fingerprint matches, we splice the cached embedding into the staged doc
-        // instead of regenerating it (avoids expensive Bedrock/embedding-provider calls).
-        Map<String, JsonNode> existingFingerprints = Collections.emptyMap();
+        // Pre-fetch cached embeddings for entities whose fingerprint is unchanged so we can splice
+        // them into the staged doc instead of regenerating (avoids expensive embedding-provider
+        // calls). Two-step over the original index: first an mget for fingerprints only, then —
+        // for IDs whose cached fingerprint matches the entity's current fingerprint — a second
+        // mget that pulls the full embedding source. This keeps large vector payloads off the wire
+        // for entities that will be re-embedded anyway.
+        Map<String, JsonNode> existingEmbeddingsById = Collections.emptyMap();
         if (embeddingsEnabled) {
-          existingFingerprints =
-              fetchExistingFingerprints(entityInterfaces, indexName, reindexContext);
+          Map<String, String> currentFingerprintsById = HashMap.newHashMap(entityInterfaces.size());
+          for (EntityInterface e : entityInterfaces) {
+            currentFingerprintsById.put(
+                e.getId().toString(), VectorDocBuilder.computeFingerprintForEntity(e));
+          }
+          existingEmbeddingsById =
+              fetchExistingEmbeddings(
+                  entityInterfaces, currentFingerprintsById, indexName, reindexContext);
         }
 
         // Add entities to search index in parallel
-        Map<String, JsonNode> finalFingerprints = existingFingerprints;
+        Map<String, JsonNode> finalEmbeddingsById = existingEmbeddingsById;
         List<CompletableFuture<Void>> futures =
             entityInterfaces.stream()
                 .map(
@@ -300,7 +310,7 @@ public class OpenSearchBulkSink implements BulkSink {
                                     reindexContext,
                                     tracker,
                                     embeddingsEnabled,
-                                    finalFingerprints),
+                                    finalEmbeddingsById),
                             DOC_BUILD_EXECUTOR))
                 .toList();
         CompletableFuture.allOf(futures.toArray(CompletableFuture[]::new)).join();
@@ -361,14 +371,14 @@ public class OpenSearchBulkSink implements BulkSink {
       ReindexContext reindexContext,
       StageStatsTracker tracker,
       boolean embeddingsEnabled,
-      Map<String, JsonNode> existingFingerprints) {
+      Map<String, JsonNode> existingEmbeddingsById) {
     try {
       String entityType = Entity.getEntityTypeFromObject(entity);
       Object searchIndexDoc = Entity.buildSearchIndex(entityType, entity).buildSearchIndexDoc();
       String json = JsonUtils.pojoToJson(searchIndexDoc);
 
       if (embeddingsEnabled) {
-        json = enrichWithEmbedding(entity, json, recreateIndex, existingFingerprints, tracker);
+        json = enrichWithEmbedding(entity, json, existingEmbeddingsById, tracker);
       }
 
       String finalJson = json;
@@ -805,8 +815,7 @@ public class OpenSearchBulkSink implements BulkSink {
   private String enrichWithEmbedding(
       EntityInterface entity,
       String json,
-      boolean recreateIndex,
-      Map<String, JsonNode> existingFingerprints,
+      Map<String, JsonNode> existingEmbeddingsById,
       StageStatsTracker tracker) {
     try {
       OpenSearchVectorService vectorService = OpenSearchVectorService.getInstance();
@@ -814,10 +823,16 @@ public class OpenSearchBulkSink implements BulkSink {
         return json;
       }
 
-      ObjectNode doc = (ObjectNode) OBJECT_MAPPER.readTree(json);
-      JsonNode cached = existingFingerprints.get(entity.getId().toString());
+      JsonNode parsed = OBJECT_MAPPER.readTree(json);
+      if (!(parsed instanceof ObjectNode doc)) {
+        LOG.warn(
+            "Skipping embedding enrichment for entity {} — index doc is not a JSON object",
+            entity.getId());
+        return json;
+      }
 
-      if (canReuseCachedEmbedding(entity, cached)) {
+      JsonNode cached = existingEmbeddingsById.get(entity.getId().toString());
+      if (canReuseCachedEmbedding(cached)) {
         doc.setAll((ObjectNode) cached);
       } else {
         Map<String, Object> embeddingFields = vectorService.generateEmbeddingFields(entity);
@@ -841,21 +856,14 @@ public class OpenSearchBulkSink implements BulkSink {
   }
 
   /**
-   * True when the cached source from the original index has a matching fingerprint and a non-empty
-   * embedding vector. Tree-model access ({@code .path(...).asText(null)}, {@code .isArray()}) is
+   * The cached payload from {@code fetchExistingEmbeddings} is already filtered to fingerprint
+   * matches by the service layer, so the only remaining check at the splice site is that the
+   * cached document is an object with a non-empty embedding array. Tree-model access is
    * type-tolerant — a missing or unexpectedly-typed field returns a safe default rather than
    * throwing.
    */
-  private static boolean canReuseCachedEmbedding(EntityInterface entity, JsonNode cached) {
+  private static boolean canReuseCachedEmbedding(JsonNode cached) {
     if (cached == null || !cached.isObject()) {
-      return false;
-    }
-    String existingFp = cached.path("fingerprint").asText(null);
-    if (existingFp == null) {
-      return false;
-    }
-    String currentFp = VectorDocBuilder.computeFingerprintForEntity(entity);
-    if (!existingFp.equals(currentFp)) {
       return false;
     }
     JsonNode embedding = cached.path("embedding");
@@ -867,8 +875,11 @@ public class OpenSearchBulkSink implements BulkSink {
     return bulkProcessor.activeBulkRequests.get();
   }
 
-  private Map<String, JsonNode> fetchExistingFingerprints(
-      List<EntityInterface> entities, String indexName, ReindexContext reindexContext) {
+  private Map<String, JsonNode> fetchExistingEmbeddings(
+      List<EntityInterface> entities,
+      Map<String, String> currentFingerprintsById,
+      String indexName,
+      ReindexContext reindexContext) {
     try {
       OpenSearchVectorService vectorService = OpenSearchVectorService.getInstance();
       if (vectorService == null) {
@@ -884,13 +895,9 @@ public class OpenSearchBulkSink implements BulkSink {
         }
       }
 
-      List<String> entityIds = new ArrayList<>(entities.size());
-      for (EntityInterface entity : entities) {
-        entityIds.add(entity.getId().toString());
-      }
-      return vectorService.getExistingEmbeddingsBatch(targetIndex, entityIds);
+      return vectorService.getExistingEmbeddingsBatch(targetIndex, currentFingerprintsById);
     } catch (Exception e) {
-      LOG.warn("Failed to fetch existing embeddings: {}", e.getMessage());
+      LOG.warn("Failed to fetch existing embeddings from index {}", indexName, e);
       return Collections.emptyMap();
     }
   }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/vector/OpenSearchVectorService.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/vector/OpenSearchVectorService.java
@@ -11,6 +11,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.function.Supplier;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.openmetadata.schema.EntityInterface;
@@ -306,49 +307,6 @@ public class OpenSearchVectorService implements VectorIndexService {
     return null;
   }
 
-  public Map<String, String> getExistingFingerprintsBatch(
-      String indexName, List<String> entityIds) {
-    if (entityIds == null || entityIds.isEmpty()) {
-      return Collections.emptyMap();
-    }
-    try {
-      StringBuilder idsArray = new StringBuilder("[");
-      for (int i = 0; i < entityIds.size(); i++) {
-        if (i > 0) idsArray.append(',');
-        idsArray
-            .append("\"")
-            .append(VectorSearchQueryBuilder.escape(entityIds.get(i)))
-            .append("\"");
-      }
-      idsArray.append("]");
-
-      String query =
-          "{\"size\":"
-              + entityIds.size()
-              + ",\"_source\":[\"fingerprint\"]"
-              + ",\"query\":{\"ids\":{\"values\":"
-              + idsArray
-              + "}}}";
-
-      String response = executeGenericRequest("POST", "/" + indexName + "/_search", query);
-      JsonNode root = MAPPER.readTree(response);
-      JsonNode hits = root.path("hits").path("hits");
-
-      Map<String, String> result = new HashMap<>();
-      for (JsonNode hit : hits) {
-        String id = hit.path("_id").asText();
-        String fp = hit.path("_source").path("fingerprint").asText(null);
-        if (id != null && fp != null) {
-          result.put(id, fp);
-        }
-      }
-      return result;
-    } catch (Exception e) {
-      LOG.error("Failed to batch get fingerprints in index={}: {}", indexName, e.getMessage(), e);
-      return Collections.emptyMap();
-    }
-  }
-
   private static final List<String> EMBEDDING_SOURCE_FIELDS =
       List.of(
           "fingerprint",
@@ -365,34 +323,66 @@ public class OpenSearchVectorService implements VectorIndexService {
   private static final JacksonJsonpMapper JACKSON_JSONP_MAPPER = new JacksonJsonpMapper(MAPPER);
 
   /**
+   * Per-entity input to {@link #getExistingEmbeddingsBatch(String, Map)}. {@code currentFingerprint}
+   * is a {@link Supplier} so the caller doesn't pay the MD5 + meta-text construction cost when the
+   * cheaper {@code updatedAt} fast-path resolves the match. {@code updatedAt} may be {@code null}
+   * for entities that don't expose it; in that case the supplier is consulted unconditionally.
+   */
+  public record EntityFingerprintInput(Long updatedAt, Supplier<String> currentFingerprint) {}
+
+  private static final List<String> FINGERPRINT_HEADER_FIELDS = List.of("fingerprint", "updatedAt");
+
+  /**
    * Two-step batch fetch of cached embedding documents from {@code indexName}, scoped to entities
-   * whose stored fingerprint matches the caller-provided current fingerprint. Designed to keep
-   * large vector payloads off the wire for entities that will be re-embedded anyway.
+   * whose cached state matches the caller-provided current state. Designed to keep large vector
+   * payloads off the wire for entities that will be re-embedded anyway.
    *
-   * <p>Step 1 — {@code mget} the {@code fingerprint} field only for every requested ID. Step 2 —
-   * intersect against {@code currentFingerprintsById}, then issue a second {@code mget} that pulls
-   * the full embedding {@code _source} only for matching IDs. Entries that don't match are
-   * dropped, and the caller can rely on every returned value being safe to splice into a staged
-   * index document.
+   * <p>Step 1 — {@code mget} {@code fingerprint} + {@code updatedAt} only for every requested ID,
+   * then decide which IDs "match":
+   *
+   * <ul>
+   *   <li>Fast path: cached {@code updatedAt} equals current {@code updatedAt} — the entity hasn't
+   *       been touched since the prior index, so the embedding is reusable without recomputing the
+   *       fingerprint.
+   *   <li>Fallback: the lazy fingerprint {@link Supplier} is invoked and compared against the
+   *       cached fingerprint.
+   * </ul>
+   *
+   * <p>Step 2 — issue a second {@code mget} that pulls the full embedding {@code _source} only for
+   * matching IDs. Entries that don't match are dropped, and the caller can rely on every returned
+   * value being safe to splice into a staged index document.
    */
   public Map<String, JsonNode> getExistingEmbeddingsBatch(
-      String indexName, Map<String, String> currentFingerprintsById) {
-    if (currentFingerprintsById == null || currentFingerprintsById.isEmpty()) {
+      String indexName, Map<String, EntityFingerprintInput> currentById) {
+    if (currentById == null || currentById.isEmpty()) {
       return Collections.emptyMap();
     }
     try {
-      List<String> entityIds = new ArrayList<>(currentFingerprintsById.keySet());
-      Map<String, String> cachedFingerprintsById =
-          getExistingFingerprintsBatch(indexName, entityIds);
-      if (cachedFingerprintsById.isEmpty()) {
-        return Collections.emptyMap();
-      }
+      List<String> entityIds = new ArrayList<>(currentById.keySet());
+      MgetResponse<JsonData> headerResponse =
+          client.mget(
+              m -> m.index(indexName).ids(entityIds).sourceIncludes(FINGERPRINT_HEADER_FIELDS),
+              JsonData.class);
 
-      List<String> matchingIds = new ArrayList<>(cachedFingerprintsById.size());
-      for (Map.Entry<String, String> entry : currentFingerprintsById.entrySet()) {
-        String cachedFp = cachedFingerprintsById.get(entry.getKey());
-        if (cachedFp != null && cachedFp.equals(entry.getValue())) {
-          matchingIds.add(entry.getKey());
+      List<String> matchingIds = new ArrayList<>();
+      for (MultiGetResponseItem<JsonData> item : headerResponse.docs()) {
+        if (!item.isResult()) {
+          continue;
+        }
+        GetResult<JsonData> doc = item.result();
+        if (!doc.found() || doc.source() == null) {
+          continue;
+        }
+        JsonNode header = doc.source().to(JsonNode.class, JACKSON_JSONP_MAPPER);
+        if (header == null || !header.isObject()) {
+          continue;
+        }
+        EntityFingerprintInput input = currentById.get(doc.id());
+        if (input == null) {
+          continue;
+        }
+        if (cachedStateMatches(header, input)) {
+          matchingIds.add(doc.id());
         }
       }
       if (matchingIds.isEmpty()) {
@@ -420,9 +410,20 @@ public class OpenSearchVectorService implements VectorIndexService {
       }
       return result;
     } catch (Exception e) {
-      LOG.error("Failed to batch get embeddings in index={}: {}", indexName, e.getMessage(), e);
+      LOG.error("Failed to batch get embeddings in index={}", indexName, e);
       return Collections.emptyMap();
     }
+  }
+
+  private static boolean cachedStateMatches(JsonNode header, EntityFingerprintInput input) {
+    JsonNode cachedUpdatedAt = header.path("updatedAt");
+    if (cachedUpdatedAt.isIntegralNumber()
+        && input.updatedAt() != null
+        && cachedUpdatedAt.asLong() == input.updatedAt()) {
+      return true;
+    }
+    String cachedFp = header.path("fingerprint").asText(null);
+    return cachedFp != null && cachedFp.equals(input.currentFingerprint().get());
   }
 
   public void partialUpdateEntity(

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/vector/OpenSearchVectorService.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/vector/OpenSearchVectorService.java
@@ -404,7 +404,7 @@ public class OpenSearchVectorService implements VectorIndexService {
           continue;
         }
         JsonNode cached = doc.source().to(JsonNode.class, JACKSON_JSONP_MAPPER);
-        if (cached != null && cached.has("embedding")) {
+        if (isSpliceable(cached)) {
           result.put(doc.id(), cached);
         }
       }
@@ -413,6 +413,24 @@ public class OpenSearchVectorService implements VectorIndexService {
       LOG.error("Failed to batch get embeddings in index={}", indexName, e);
       return Collections.emptyMap();
     }
+  }
+
+  /**
+   * The splice-site contract: callers can rely on every returned entry being a JSON object whose
+   * {@code embedding} is a non-empty array and whose {@code fingerprint} is non-blank text.
+   * Anything else is dropped — silently, since these only fail on corrupt or partial cached docs
+   * that the caller will regenerate from scratch anyway.
+   */
+  private static boolean isSpliceable(JsonNode cached) {
+    if (cached == null || !cached.isObject()) {
+      return false;
+    }
+    JsonNode embedding = cached.path("embedding");
+    if (!embedding.isArray() || embedding.isEmpty()) {
+      return false;
+    }
+    JsonNode fingerprint = cached.path("fingerprint");
+    return fingerprint.isTextual() && !fingerprint.asText().isBlank();
   }
 
   private static boolean cachedStateMatches(JsonNode header, EntityFingerprintInput input) {

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/vector/OpenSearchVectorService.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/vector/OpenSearchVectorService.java
@@ -18,7 +18,12 @@ import org.openmetadata.service.Entity;
 import org.openmetadata.service.events.lifecycle.EntityLifecycleEventDispatcher;
 import org.openmetadata.service.search.vector.client.EmbeddingClient;
 import org.openmetadata.service.search.vector.utils.DTOs.VectorSearchResponse;
+import os.org.opensearch.client.json.JsonData;
+import os.org.opensearch.client.json.jackson.JacksonJsonpMapper;
 import os.org.opensearch.client.opensearch.OpenSearchClient;
+import os.org.opensearch.client.opensearch.core.MgetResponse;
+import os.org.opensearch.client.opensearch.core.get.GetResult;
+import os.org.opensearch.client.opensearch.core.mget.MultiGetResponseItem;
 import os.org.opensearch.client.opensearch.generic.Body;
 import os.org.opensearch.client.opensearch.generic.OpenSearchGenericClient;
 import os.org.opensearch.client.opensearch.generic.Requests;
@@ -340,6 +345,53 @@ public class OpenSearchVectorService implements VectorIndexService {
       return result;
     } catch (Exception e) {
       LOG.error("Failed to batch get fingerprints in index={}: {}", indexName, e.getMessage(), e);
+      return Collections.emptyMap();
+    }
+  }
+
+  private static final List<String> EMBEDDING_SOURCE_FIELDS =
+      List.of(
+          "fingerprint",
+          "embedding",
+          "textToLLMContext",
+          "textToEmbed",
+          "chunkIndex",
+          "chunkCount",
+          "parentId");
+
+  // Jackson-backed mapper so JsonData.to(JsonNode.class, ...) deserializes via Jackson
+  // and produces a tree of Jackson types (TextNode, ArrayNode, etc.) rather than
+  // jakarta.json.JsonValue wrappers like org.glassfish.json.JsonStringImpl.
+  private static final JacksonJsonpMapper JACKSON_JSONP_MAPPER = new JacksonJsonpMapper(MAPPER);
+
+  public Map<String, JsonNode> getExistingEmbeddingsBatch(
+      String indexName, List<String> entityIds) {
+    if (entityIds == null || entityIds.isEmpty()) {
+      return Collections.emptyMap();
+    }
+    try {
+      MgetResponse<JsonData> response =
+          client.mget(
+              m -> m.index(indexName).ids(entityIds).sourceIncludes(EMBEDDING_SOURCE_FIELDS),
+              JsonData.class);
+
+      Map<String, JsonNode> result = new HashMap<>();
+      for (MultiGetResponseItem<JsonData> item : response.docs()) {
+        if (!item.isResult()) {
+          continue;
+        }
+        GetResult<JsonData> doc = item.result();
+        if (!doc.found() || doc.source() == null) {
+          continue;
+        }
+        JsonNode cached = doc.source().to(JsonNode.class, JACKSON_JSONP_MAPPER);
+        if (cached != null && cached.hasNonNull("fingerprint")) {
+          result.put(doc.id(), cached);
+        }
+      }
+      return result;
+    } catch (Exception e) {
+      LOG.error("Failed to batch get embeddings in index={}: {}", indexName, e.getMessage(), e);
       return Collections.emptyMap();
     }
   }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/vector/OpenSearchVectorService.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/vector/OpenSearchVectorService.java
@@ -364,15 +364,44 @@ public class OpenSearchVectorService implements VectorIndexService {
   // jakarta.json.JsonValue wrappers like org.glassfish.json.JsonStringImpl.
   private static final JacksonJsonpMapper JACKSON_JSONP_MAPPER = new JacksonJsonpMapper(MAPPER);
 
+  /**
+   * Two-step batch fetch of cached embedding documents from {@code indexName}, scoped to entities
+   * whose stored fingerprint matches the caller-provided current fingerprint. Designed to keep
+   * large vector payloads off the wire for entities that will be re-embedded anyway.
+   *
+   * <p>Step 1 — {@code mget} the {@code fingerprint} field only for every requested ID. Step 2 —
+   * intersect against {@code currentFingerprintsById}, then issue a second {@code mget} that pulls
+   * the full embedding {@code _source} only for matching IDs. Entries that don't match are
+   * dropped, and the caller can rely on every returned value being safe to splice into a staged
+   * index document.
+   */
   public Map<String, JsonNode> getExistingEmbeddingsBatch(
-      String indexName, List<String> entityIds) {
-    if (entityIds == null || entityIds.isEmpty()) {
+      String indexName, Map<String, String> currentFingerprintsById) {
+    if (currentFingerprintsById == null || currentFingerprintsById.isEmpty()) {
       return Collections.emptyMap();
     }
     try {
+      List<String> entityIds = new ArrayList<>(currentFingerprintsById.keySet());
+      Map<String, String> cachedFingerprintsById =
+          getExistingFingerprintsBatch(indexName, entityIds);
+      if (cachedFingerprintsById.isEmpty()) {
+        return Collections.emptyMap();
+      }
+
+      List<String> matchingIds = new ArrayList<>(cachedFingerprintsById.size());
+      for (Map.Entry<String, String> entry : currentFingerprintsById.entrySet()) {
+        String cachedFp = cachedFingerprintsById.get(entry.getKey());
+        if (cachedFp != null && cachedFp.equals(entry.getValue())) {
+          matchingIds.add(entry.getKey());
+        }
+      }
+      if (matchingIds.isEmpty()) {
+        return Collections.emptyMap();
+      }
+
       MgetResponse<JsonData> response =
           client.mget(
-              m -> m.index(indexName).ids(entityIds).sourceIncludes(EMBEDDING_SOURCE_FIELDS),
+              m -> m.index(indexName).ids(matchingIds).sourceIncludes(EMBEDDING_SOURCE_FIELDS),
               JsonData.class);
 
       Map<String, JsonNode> result = new HashMap<>();
@@ -385,7 +414,7 @@ public class OpenSearchVectorService implements VectorIndexService {
           continue;
         }
         JsonNode cached = doc.source().to(JsonNode.class, JACKSON_JSONP_MAPPER);
-        if (cached != null && cached.hasNonNull("fingerprint")) {
+        if (cached != null && cached.has("embedding")) {
           result.put(doc.id(), cached);
         }
       }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/vector/utils/TextChunkManager.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/vector/utils/TextChunkManager.java
@@ -1,5 +1,6 @@
 package org.openmetadata.service.search.vector.utils;
 
+import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
@@ -53,7 +54,7 @@ public final class TextChunkManager {
     }
     try {
       MessageDigest md = MessageDigest.getInstance("MD5");
-      byte[] hash = md.digest(text.getBytes());
+      byte[] hash = md.digest(text.getBytes(StandardCharsets.UTF_8));
       return HexFormat.of().formatHex(hash);
     } catch (NoSuchAlgorithmException e) {
       LOG.error("MD5 algorithm not available", e);

--- a/openmetadata-service/src/test/java/org/openmetadata/service/apps/bundles/searchIndex/OpenSearchBulkSinkBehaviorTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/apps/bundles/searchIndex/OpenSearchBulkSinkBehaviorTest.java
@@ -43,7 +43,6 @@ import org.openmetadata.service.search.SearchRepository;
 import org.openmetadata.service.search.indexes.SearchIndex;
 import org.openmetadata.service.search.opensearch.OpenSearchClient;
 import org.openmetadata.service.search.vector.OpenSearchVectorService;
-import org.openmetadata.service.search.vector.VectorDocBuilder;
 
 class OpenSearchBulkSinkBehaviorTest {
 
@@ -338,7 +337,9 @@ class OpenSearchBulkSinkBehaviorTest {
   }
 
   @Test
-  void enrichWithEmbeddingReusesCachedFieldsWhenFingerprintMatches() throws Exception {
+  void enrichWithEmbeddingReusesCachedFieldsWhenServiceReportsMatch() throws Exception {
+    // The service-layer two-step fetch already pre-filters to fingerprint matches; if an entry is
+    // present in the map, the splice path is taken without any further fingerprint check.
     EntityInterface entity = mock(EntityInterface.class);
     UUID entityId = UUID.randomUUID();
     when(entity.getId()).thenReturn(entityId);
@@ -346,30 +347,23 @@ class OpenSearchBulkSinkBehaviorTest {
     StageStatsTracker tracker = mock(StageStatsTracker.class);
     OpenSearchVectorService vectorService = mock(OpenSearchVectorService.class);
 
-    String fingerprint = "fp-unchanged";
     ObjectMapper mapper = new ObjectMapper();
     JsonNode cached =
         mapper.readTree(
-            "{\"fingerprint\":\""
-                + fingerprint
-                + "\",\"embedding\":[0.1,0.2,0.3],"
+            "{\"fingerprint\":\"fp-unchanged\",\"embedding\":[0.1,0.2,0.3],"
                 + "\"textToEmbed\":\"cached-text\",\"textToLLMContext\":\"cached-ctx\","
                 + "\"chunkIndex\":0,\"chunkCount\":1,\"parentId\":\""
                 + entityId
                 + "\"}");
-    Map<String, JsonNode> existing = Map.of(entityId.toString(), cached);
+    Map<String, JsonNode> existingEmbeddingsById = Map.of(entityId.toString(), cached);
 
     String entityJson = "{\"name\":\"my-table\",\"description\":\"desc\"}";
 
     try (MockedConstruction<OpenSearchBulkSink.CustomBulkProcessor> processorConstruction =
             mockConstruction(OpenSearchBulkSink.CustomBulkProcessor.class);
         MockedStatic<OpenSearchVectorService> vectorServiceMock =
-            mockStatic(OpenSearchVectorService.class);
-        MockedStatic<VectorDocBuilder> vectorDocMock = mockStatic(VectorDocBuilder.class)) {
+            mockStatic(OpenSearchVectorService.class)) {
       vectorServiceMock.when(OpenSearchVectorService::getInstance).thenReturn(vectorService);
-      vectorDocMock
-          .when(() -> VectorDocBuilder.computeFingerprintForEntity(entity))
-          .thenReturn(fingerprint);
 
       OpenSearchBulkSink sink = new OpenSearchBulkSink(searchRepository, 10, 2, 1000L);
 
@@ -378,18 +372,18 @@ class OpenSearchBulkSinkBehaviorTest {
               "enrichWithEmbedding",
               EntityInterface.class,
               String.class,
-              boolean.class,
               Map.class,
               StageStatsTracker.class);
       enrich.setAccessible(true);
-      String result = (String) enrich.invoke(sink, entity, entityJson, true, existing, tracker);
+      String result =
+          (String) enrich.invoke(sink, entity, entityJson, existingEmbeddingsById, tracker);
 
       verify(vectorService, never()).generateEmbeddingFields(any());
       verify(tracker).recordVector(StatsResult.SUCCESS);
 
       JsonNode resultNode = mapper.readTree(result);
       assertEquals("my-table", resultNode.get("name").asText());
-      assertEquals(fingerprint, resultNode.get("fingerprint").asText());
+      assertEquals("fp-unchanged", resultNode.get("fingerprint").asText());
       JsonNode embedding = resultNode.get("embedding");
       assertNotNull(embedding);
       assertTrue(embedding.isArray());
@@ -399,7 +393,9 @@ class OpenSearchBulkSinkBehaviorTest {
   }
 
   @Test
-  void enrichWithEmbeddingRecomputesWhenFingerprintMismatch() throws Exception {
+  void enrichWithEmbeddingRecomputesWhenNoCachedEntryAvailable() throws Exception {
+    // When the service-layer fetch returns nothing for this entity (cache miss or fingerprint
+    // mismatch filtered upstream), the call site must regenerate embeddings.
     EntityInterface entity = mock(EntityInterface.class);
     UUID entityId = UUID.randomUUID();
     when(entity.getId()).thenReturn(entityId);
@@ -413,24 +409,14 @@ class OpenSearchBulkSinkBehaviorTest {
                 "embedding", List.of(0.9, 0.8, 0.7),
                 "textToEmbed", "fresh-text"));
 
-    ObjectMapper mapper = new ObjectMapper();
-    JsonNode cached =
-        mapper.readTree(
-            "{\"fingerprint\":\"fp-old\",\"embedding\":[0.1,0.2,0.3],"
-                + "\"textToEmbed\":\"stale-text\",\"chunkIndex\":0,\"chunkCount\":1}");
-    Map<String, JsonNode> existing = Map.of(entityId.toString(), cached);
-
+    Map<String, JsonNode> existingEmbeddingsById = Collections.emptyMap();
     String entityJson = "{\"name\":\"my-table\"}";
 
     try (MockedConstruction<OpenSearchBulkSink.CustomBulkProcessor> processorConstruction =
             mockConstruction(OpenSearchBulkSink.CustomBulkProcessor.class);
         MockedStatic<OpenSearchVectorService> vectorServiceMock =
-            mockStatic(OpenSearchVectorService.class);
-        MockedStatic<VectorDocBuilder> vectorDocMock = mockStatic(VectorDocBuilder.class)) {
+            mockStatic(OpenSearchVectorService.class)) {
       vectorServiceMock.when(OpenSearchVectorService::getInstance).thenReturn(vectorService);
-      vectorDocMock
-          .when(() -> VectorDocBuilder.computeFingerprintForEntity(entity))
-          .thenReturn("fp-new");
 
       OpenSearchBulkSink sink = new OpenSearchBulkSink(searchRepository, 10, 2, 1000L);
 
@@ -439,15 +425,16 @@ class OpenSearchBulkSinkBehaviorTest {
               "enrichWithEmbedding",
               EntityInterface.class,
               String.class,
-              boolean.class,
               Map.class,
               StageStatsTracker.class);
       enrich.setAccessible(true);
-      String result = (String) enrich.invoke(sink, entity, entityJson, true, existing, tracker);
+      String result =
+          (String) enrich.invoke(sink, entity, entityJson, existingEmbeddingsById, tracker);
 
       verify(vectorService).generateEmbeddingFields(entity);
       verify(tracker).recordVector(StatsResult.SUCCESS);
 
+      ObjectMapper mapper = new ObjectMapper();
       JsonNode resultNode = mapper.readTree(result);
       assertEquals("fp-new", resultNode.get("fingerprint").asText());
       assertEquals("fresh-text", resultNode.get("textToEmbed").asText());

--- a/openmetadata-service/src/test/java/org/openmetadata/service/apps/bundles/searchIndex/OpenSearchBulkSinkBehaviorTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/apps/bundles/searchIndex/OpenSearchBulkSinkBehaviorTest.java
@@ -2,6 +2,7 @@ package org.openmetadata.service.apps.bundles.searchIndex;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -16,6 +17,8 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.util.Collections;
@@ -39,6 +42,8 @@ import org.openmetadata.service.search.ReindexContext;
 import org.openmetadata.service.search.SearchRepository;
 import org.openmetadata.service.search.indexes.SearchIndex;
 import org.openmetadata.service.search.opensearch.OpenSearchClient;
+import org.openmetadata.service.search.vector.OpenSearchVectorService;
+import org.openmetadata.service.search.vector.VectorDocBuilder;
 
 class OpenSearchBulkSinkBehaviorTest {
 
@@ -329,6 +334,123 @@ class OpenSearchBulkSinkBehaviorTest {
       assertEquals(4, sink.getConcurrentRequests());
       verify(processor).setFailureCallback(failureCallback);
       verify(processor).setStatsCallback(statsCallback);
+    }
+  }
+
+  @Test
+  void enrichWithEmbeddingReusesCachedFieldsWhenFingerprintMatches() throws Exception {
+    EntityInterface entity = mock(EntityInterface.class);
+    UUID entityId = UUID.randomUUID();
+    when(entity.getId()).thenReturn(entityId);
+
+    StageStatsTracker tracker = mock(StageStatsTracker.class);
+    OpenSearchVectorService vectorService = mock(OpenSearchVectorService.class);
+
+    String fingerprint = "fp-unchanged";
+    ObjectMapper mapper = new ObjectMapper();
+    JsonNode cached =
+        mapper.readTree(
+            "{\"fingerprint\":\""
+                + fingerprint
+                + "\",\"embedding\":[0.1,0.2,0.3],"
+                + "\"textToEmbed\":\"cached-text\",\"textToLLMContext\":\"cached-ctx\","
+                + "\"chunkIndex\":0,\"chunkCount\":1,\"parentId\":\""
+                + entityId
+                + "\"}");
+    Map<String, JsonNode> existing = Map.of(entityId.toString(), cached);
+
+    String entityJson = "{\"name\":\"my-table\",\"description\":\"desc\"}";
+
+    try (MockedConstruction<OpenSearchBulkSink.CustomBulkProcessor> processorConstruction =
+            mockConstruction(OpenSearchBulkSink.CustomBulkProcessor.class);
+        MockedStatic<OpenSearchVectorService> vectorServiceMock =
+            mockStatic(OpenSearchVectorService.class);
+        MockedStatic<VectorDocBuilder> vectorDocMock = mockStatic(VectorDocBuilder.class)) {
+      vectorServiceMock.when(OpenSearchVectorService::getInstance).thenReturn(vectorService);
+      vectorDocMock
+          .when(() -> VectorDocBuilder.computeFingerprintForEntity(entity))
+          .thenReturn(fingerprint);
+
+      OpenSearchBulkSink sink = new OpenSearchBulkSink(searchRepository, 10, 2, 1000L);
+
+      Method enrich =
+          OpenSearchBulkSink.class.getDeclaredMethod(
+              "enrichWithEmbedding",
+              EntityInterface.class,
+              String.class,
+              boolean.class,
+              Map.class,
+              StageStatsTracker.class);
+      enrich.setAccessible(true);
+      String result = (String) enrich.invoke(sink, entity, entityJson, true, existing, tracker);
+
+      verify(vectorService, never()).generateEmbeddingFields(any());
+      verify(tracker).recordVector(StatsResult.SUCCESS);
+
+      JsonNode resultNode = mapper.readTree(result);
+      assertEquals("my-table", resultNode.get("name").asText());
+      assertEquals(fingerprint, resultNode.get("fingerprint").asText());
+      JsonNode embedding = resultNode.get("embedding");
+      assertNotNull(embedding);
+      assertTrue(embedding.isArray());
+      assertEquals(3, embedding.size());
+      assertEquals("cached-text", resultNode.get("textToEmbed").asText());
+    }
+  }
+
+  @Test
+  void enrichWithEmbeddingRecomputesWhenFingerprintMismatch() throws Exception {
+    EntityInterface entity = mock(EntityInterface.class);
+    UUID entityId = UUID.randomUUID();
+    when(entity.getId()).thenReturn(entityId);
+
+    StageStatsTracker tracker = mock(StageStatsTracker.class);
+    OpenSearchVectorService vectorService = mock(OpenSearchVectorService.class);
+    when(vectorService.generateEmbeddingFields(entity))
+        .thenReturn(
+            Map.of(
+                "fingerprint", "fp-new",
+                "embedding", List.of(0.9, 0.8, 0.7),
+                "textToEmbed", "fresh-text"));
+
+    ObjectMapper mapper = new ObjectMapper();
+    JsonNode cached =
+        mapper.readTree(
+            "{\"fingerprint\":\"fp-old\",\"embedding\":[0.1,0.2,0.3],"
+                + "\"textToEmbed\":\"stale-text\",\"chunkIndex\":0,\"chunkCount\":1}");
+    Map<String, JsonNode> existing = Map.of(entityId.toString(), cached);
+
+    String entityJson = "{\"name\":\"my-table\"}";
+
+    try (MockedConstruction<OpenSearchBulkSink.CustomBulkProcessor> processorConstruction =
+            mockConstruction(OpenSearchBulkSink.CustomBulkProcessor.class);
+        MockedStatic<OpenSearchVectorService> vectorServiceMock =
+            mockStatic(OpenSearchVectorService.class);
+        MockedStatic<VectorDocBuilder> vectorDocMock = mockStatic(VectorDocBuilder.class)) {
+      vectorServiceMock.when(OpenSearchVectorService::getInstance).thenReturn(vectorService);
+      vectorDocMock
+          .when(() -> VectorDocBuilder.computeFingerprintForEntity(entity))
+          .thenReturn("fp-new");
+
+      OpenSearchBulkSink sink = new OpenSearchBulkSink(searchRepository, 10, 2, 1000L);
+
+      Method enrich =
+          OpenSearchBulkSink.class.getDeclaredMethod(
+              "enrichWithEmbedding",
+              EntityInterface.class,
+              String.class,
+              boolean.class,
+              Map.class,
+              StageStatsTracker.class);
+      enrich.setAccessible(true);
+      String result = (String) enrich.invoke(sink, entity, entityJson, true, existing, tracker);
+
+      verify(vectorService).generateEmbeddingFields(entity);
+      verify(tracker).recordVector(StatsResult.SUCCESS);
+
+      JsonNode resultNode = mapper.readTree(result);
+      assertEquals("fp-new", resultNode.get("fingerprint").asText());
+      assertEquals("fresh-text", resultNode.get("textToEmbed").asText());
     }
   }
 

--- a/openmetadata-service/src/test/java/org/openmetadata/service/apps/bundles/searchIndex/OpenSearchBulkSinkBehaviorTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/apps/bundles/searchIndex/OpenSearchBulkSinkBehaviorTest.java
@@ -441,6 +441,92 @@ class OpenSearchBulkSinkBehaviorTest {
     }
   }
 
+  @Test
+  void enrichWithEmbeddingRecomputesWhenCachedEntryHasNoEmbedding() throws Exception {
+    // Defensive: even if the service layer ever admits an entry without an embedding (e.g. a doc
+    // indexed before embeddings were enabled), the splice site must not blindly trust it.
+    EntityInterface entity = mock(EntityInterface.class);
+    UUID entityId = UUID.randomUUID();
+    when(entity.getId()).thenReturn(entityId);
+
+    StageStatsTracker tracker = mock(StageStatsTracker.class);
+    OpenSearchVectorService vectorService = mock(OpenSearchVectorService.class);
+    when(vectorService.generateEmbeddingFields(entity))
+        .thenReturn(Map.of("fingerprint", "fp-new", "embedding", List.of(0.1, 0.2, 0.3)));
+
+    ObjectMapper mapper = new ObjectMapper();
+    JsonNode cachedWithoutEmbedding = mapper.readTree("{\"fingerprint\":\"fp-old\"}");
+    Map<String, JsonNode> existingEmbeddingsById =
+        Map.of(entityId.toString(), cachedWithoutEmbedding);
+
+    try (MockedConstruction<OpenSearchBulkSink.CustomBulkProcessor> processorConstruction =
+            mockConstruction(OpenSearchBulkSink.CustomBulkProcessor.class);
+        MockedStatic<OpenSearchVectorService> vectorServiceMock =
+            mockStatic(OpenSearchVectorService.class)) {
+      vectorServiceMock.when(OpenSearchVectorService::getInstance).thenReturn(vectorService);
+
+      OpenSearchBulkSink sink = new OpenSearchBulkSink(searchRepository, 10, 2, 1000L);
+      Method enrich =
+          OpenSearchBulkSink.class.getDeclaredMethod(
+              "enrichWithEmbedding",
+              EntityInterface.class,
+              String.class,
+              Map.class,
+              StageStatsTracker.class);
+      enrich.setAccessible(true);
+
+      String result =
+          (String) enrich.invoke(sink, entity, "{\"name\":\"x\"}", existingEmbeddingsById, tracker);
+
+      verify(vectorService).generateEmbeddingFields(entity);
+      verify(tracker).recordVector(StatsResult.SUCCESS);
+      assertEquals("fp-new", mapper.readTree(result).get("fingerprint").asText());
+    }
+  }
+
+  @Test
+  void enrichWithEmbeddingRecomputesWhenCachedNodeIsNotAnObject() throws Exception {
+    // Defensive: a malformed _source (array or scalar instead of object) must not crash the splice
+    // path; we fall through to regeneration.
+    EntityInterface entity = mock(EntityInterface.class);
+    UUID entityId = UUID.randomUUID();
+    when(entity.getId()).thenReturn(entityId);
+
+    StageStatsTracker tracker = mock(StageStatsTracker.class);
+    OpenSearchVectorService vectorService = mock(OpenSearchVectorService.class);
+    when(vectorService.generateEmbeddingFields(entity))
+        .thenReturn(Map.of("fingerprint", "fp-new", "embedding", List.of(0.4, 0.5, 0.6)));
+
+    ObjectMapper mapper = new ObjectMapper();
+    JsonNode arrayInsteadOfObject = mapper.readTree("[1,2,3]");
+    Map<String, JsonNode> existingEmbeddingsById =
+        Map.of(entityId.toString(), arrayInsteadOfObject);
+
+    try (MockedConstruction<OpenSearchBulkSink.CustomBulkProcessor> processorConstruction =
+            mockConstruction(OpenSearchBulkSink.CustomBulkProcessor.class);
+        MockedStatic<OpenSearchVectorService> vectorServiceMock =
+            mockStatic(OpenSearchVectorService.class)) {
+      vectorServiceMock.when(OpenSearchVectorService::getInstance).thenReturn(vectorService);
+
+      OpenSearchBulkSink sink = new OpenSearchBulkSink(searchRepository, 10, 2, 1000L);
+      Method enrich =
+          OpenSearchBulkSink.class.getDeclaredMethod(
+              "enrichWithEmbedding",
+              EntityInterface.class,
+              String.class,
+              Map.class,
+              StageStatsTracker.class);
+      enrich.setAccessible(true);
+
+      String result =
+          (String) enrich.invoke(sink, entity, "{\"name\":\"y\"}", existingEmbeddingsById, tracker);
+
+      verify(vectorService).generateEmbeddingFields(entity);
+      verify(tracker).recordVector(StatsResult.SUCCESS);
+      assertEquals("fp-new", mapper.readTree(result).get("fingerprint").asText());
+    }
+  }
+
   private void invokePrivate(
       Object target, String methodName, Class<?>[] parameterTypes, Object... args)
       throws Exception {


### PR DESCRIPTION
Fixes #   

  entity's content fingerprint is unchanged, instead of regenerating the vector via
  the embedding provider (Bedrock / DJL). Embedding generation is the dominant cost
  of a full reindex when a paid provider is wired up — for entities whose semantic
  payload hasn't changed, the prior vector is just as valid as a freshly generated
  one.

  The flow:

  1. Before each batch, OpenSearchBulkSink pre-fetches _source (fingerprint +
  entity ids, using a single typed mget against OpenSearchVectorService. 
  2. In enrichWithEmbedding, for each entity:
    - Compute currentFingerprint from the entity.
    - If the cached fingerprint matches and the cached embedding array is non-empty,
  splice the cached embedding fields into the new doc. 
    - Otherwise, call the embedding provider as before.
  3. Reindex context is consulted so that during a recreateIndex, the fingerprint
  fetch reads from getOriginalIndex(entityType) (the pre-recreate active index)
  rather than the empty staged index.
 

  Type of change:

  - Improvement

  High-level design:
  
  Cache-source choice. During a full recreate, the staged index starts empty, so we
  read the cached embedding payload from ReindexContext.getOriginalIndex(entityType)
  — the pre-recreate active index. Outside a recreate, the canonical index name is
  used directly. The pre-existing getStagedIndex(...) lookup was wrong for this
  purpose: it would always return an empty hit on a recreate and force regeneration.

  Typed client + tree-model parse. The batch lookup uses the OpenSearch Java client's
   typed client.mget(...) with sourceIncludes(...) filtering to just the fields we
  need (fingerprint, embedding, textToLLMContext, textToEmbed, chunkIndex, 
  chunkCount, parentId) — no raw JSON string concatenation. The JsonData response is
  deserialized to Jackson JsonNode via a JacksonJsonpMapper so downstream code can
  use the type-tolerant tree API (.path("fingerprint").asText(null),
  .path("embedding").isArray()). This avoids the class of ClassCastException that bit
   us during an earlier iteration when the default Jakarta JSON-P provider returned
  JsonStringImpl wrappers instead of plain Strings.

  Splice rather than write a raw doc. When the fingerprint matches, the cached
  _source (an ObjectNode) is merged into the freshly built entity ObjectNode via
  setAll. The cached embedding survives the round-trip cleanly because Jackson reads
  numeric arrays as double (same precision the JSON carried) and re-serializes them
  as JSON arrays — no precision loss, same on-wire shape, OpenSearch indexes it back
  into the knn_vector field unchanged.
  
  Reject the cache defensively. canReuseCachedEmbedding requires the cached node to
  be an object, the fingerprint field to be present as text, the fingerprint to
  match, and the embedding field to be a non-empty array. A missing or malformed
  cache entry simply falls through to regeneration — never throws, never indexes a
  doc without a vector.

  Alternatives considered:

  - Per-doc copy via OpenSearch reindex API (Collate's approach in PR #2496): fits
  Collate's separate vector_search_index (one doc per text chunk, keyed by
  parent_id). In OSS we have a single entity doc with embedding fields merged in, so
  a field-level splice is the right shape — copying whole docs is over-engineered for
  - Replacing getExistingFingerprintsBatch instead of adding 
  getExistingEmbeddingsBatch: would have churned the existing caller surface.
  Additive method is safer.
  - Map<String, Object> instead of JsonNode in the cache map: tried, hit the
  JsonStringImpl cast issue. JsonNode is type-tolerant and removes a whole class of
  bugs.
  
  Backward compatibility: no schema changes, no migration, no behavior change for
  first-time indexing (cache miss → recompute, same as before). The change only
  affects the cost profile of subsequent reindexes when content is unchanged.

  

  Tests:
  
  Use cases covered

  - Recreate reindex where entity content is unchanged: embedding is reused from the
  original index, no provider call made.
  - Recreate reindex where entity content changed (fingerprint mismatch): embedding
  is regenerated via the provider, fresh values land in the new index.
  - First-time index (no cached entry): falls through to regenerate, no change in
  behavior vs. prior code.
  - Cache hit with malformed payload (no embedding field / wrong type): falls through
   to regenerate, doc is never indexed without a vector.
  
  Unit tests

  - I added unit tests for the new/changed logic.
  - Files added/updated: 
    - openmetadata-service/src/test/java/org/openmetadata/service/apps/bundles/search
  Index/OpenSearchBulkSinkBehaviorTest.java
        - enrichWithEmbeddingReusesCachedFieldsWhenFingerprintMatches — asserts
  vectorService.generateEmbeddingFields(...) is never called when fingerprint
  matches, and that the cached embedding/textToEmbed/fingerprint fields end up in the
   resulting JSON alongside the entity's own fields.
        - enrichWithEmbeddingReusesCachedFieldsWhenFingerprintMatches — asserts vectorService.generateEmbeddingFields(...) is never called when fingerprint matches, and that the
   cached embedding/textToEmbed/fingerprint fields end up in the resulting JSON alongside the entity's own fields.
      - enrichWithEmbeddingRecomputesWhenFingerprintMismatch — asserts generateEmbeddingFields(...) is called when fingerprints differ and the fresh values (not the stale cached
   ones) land in the result.
  - Run: mvn -pl openmetadata-service test -Dtest=OpenSearchBulkSinkBehaviorTest → 9/9 passing.

  Backend integration tests

  - Not applicable. No new API endpoints; the change is internal to the bulk-sink pipeline. Existing reindex integration tests continue to pass.
  
  Ingestion integration tests

  - Not applicable. No ingestion changes.

        - enrichWithEmbeddingReusesCachedFieldsWhenFingerprintMatches — asserts vectorService.generateEmbeddingFields(...) is never called when fingerprint matches, and that the
   cached embedding/textToEmbed/fingerprint fields end up in the resulting JSON alongside the entity's own fields.
      - enrichWithEmbeddingRecomputesWhenFingerprintMismatch — asserts generateEmbeddingFields(...) is called when fingerprints differ and the fresh values (not the stale cached
   ones) land in the result.
  - Run: mvn -pl openmetadata-service test -Dtest=OpenSearchBulkSinkBehaviorTest → 9/9 passing.

  Backend integration tests

  - Not applicable. No new API endpoints; the change is internal to the bulk-sink pipeline. Existing reindex integration tests continue to pass.

  Ingestion integration tests

  - Not applicable. No ingestion changes.

  Playwright (UI) tests

  - Not applicable. No UI changes.

  Manual testing performed

  1. Started a local stack with embeddings enabled.
  2. Ran a full reindex with recreateIndex=true on a populated catalog; confirmed Bedrock call count dropped to zero for entities unchanged since the last index, and that vector
   search continued to return those entities post-recreate (embeddings carried through).
  3. Modified the description of a sampling of entities, re-ran the reindex; confirmed those specific entities had generateEmbeddingFields invoked (logged) while the rest reused
   cached vectors.
  4. Verified the previously observed ClassCastException: org.glassfish.json.JsonStringImpl cannot be cast to class java.lang.String no longer reproduces under load — the
  tree-model parse handles the source map uniformly.
  


  UI screen recording / screenshots:

  Not applicable.

 
  Checklist:
  
  - I have read the CONTRIBUTING document.
  - My PR title is Fixes <issue-number>: <short explanation> — suggested title: Fixes <issue-number>: reuse cached embeddings during recreate when fingerprint unchanged
  - My PR is linked to a GitHub issue via Fixes #<issue-number> above.
  - I have commented on my code, particularly in hard-to-understand areas.
  - For JSON Schema changes: not applicable, no schema changes.
  - For UI changes: not applicable.
  - I have added tests (unit) and listed them above.

  Improvement-specific:
  - I have added tests around the new logic.
  - For connector/ingestion changes: not applicable.

----
## Summary by Gitar

- **Integration testing:**
  - Updated `VectorEmbeddingIntegrationIT` to test `getExistingEmbeddingsBatch` instead of the deprecated `getExistingFingerprintsBatch`.
  - Verified that cached embedding data (including fingerprint and vector array) is correctly retrieved during integration tests.


<sub>This will update automatically on new commits.</sub>