### PR TITLE
fix: return 400 for malformed JSON Patch pointers instead of 500

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/exception/CatalogGenericExceptionMapper.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/exception/CatalogGenericExceptionMapper.java
@@ -22,6 +22,7 @@ import static jakarta.ws.rs.core.Response.Status.NOT_FOUND;
 import static jakarta.ws.rs.core.Response.Status.UNAUTHORIZED;
 
 import io.dropwizard.jersey.errors.ErrorMessage;
+import jakarta.json.JsonException;
 import jakarta.ws.rs.BadRequestException;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.ProcessingException;
@@ -48,6 +49,8 @@ public class CatalogGenericExceptionMapper implements ExceptionMapper<Throwable>
     if (ex instanceof RuleValidationException) {
       return getRuleViolationResponse(ex);
     } else if (ex instanceof BadRequestException || ex instanceof IllegalArgumentException) {
+      return getResponse(BAD_REQUEST, ex.getMessage());
+    } else if (ex instanceof JsonException) {
       return getResponse(BAD_REQUEST, ex.getMessage());
     } else if (ex instanceof ProcessingException) {
       return getResponse(BAD_REQUEST, "Invalid request parameter");

--- a/openmetadata-service/src/test/java/org/openmetadata/service/util/JsonUtilsTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/util/JsonUtilsTest.java
@@ -21,10 +21,12 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
 import jakarta.json.Json;
+import jakarta.json.JsonArray;
 import jakarta.json.JsonArrayBuilder;
 import jakarta.json.JsonException;
 import jakarta.json.JsonObject;
 import jakarta.json.JsonObjectBuilder;
+import jakarta.json.JsonPatch;
 import jakarta.json.JsonPatchBuilder;
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -115,6 +117,54 @@ class JsonUtilsTest {
             JsonException.class,
             () -> JsonUtils.applyPatch(original, jsonPatchBuilder2.build(), Team.class));
     assertTrue(jsonException.getMessage().contains("An array item index is out of range"));
+  }
+
+  @Test
+  void applyPatchRejectsMalformedJsonPointerPath() {
+    JsonObjectBuilder teamJson = Json.createObjectBuilder();
+    teamJson.add("id", UUID.randomUUID().toString()).add("name", "finance");
+    Team original = JsonUtils.readValue(teamJson.build().toString(), Team.class);
+
+    JsonArray malformedPatch =
+        Json.createArrayBuilder()
+            .add(
+                Json.createObjectBuilder()
+                    .add("op", "replace")
+                    .add("path", "displayName")
+                    .add("value", "Finance Team"))
+            .build();
+    JsonPatch patch = Json.createPatch(malformedPatch);
+
+    IllegalArgumentException ex =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> JsonUtils.applyPatch(original, patch, Team.class));
+    assertTrue(ex.getMessage().contains("displayName"));
+    assertTrue(ex.getMessage().contains("must begin with '/'"));
+  }
+
+  @Test
+  void applyPatchRejectsMalformedFromPointer() {
+    JsonObjectBuilder teamJson = Json.createObjectBuilder();
+    teamJson.add("id", UUID.randomUUID().toString()).add("name", "finance");
+    Team original = JsonUtils.readValue(teamJson.build().toString(), Team.class);
+
+    JsonArray malformedPatch =
+        Json.createArrayBuilder()
+            .add(
+                Json.createObjectBuilder()
+                    .add("op", "move")
+                    .add("from", "name")
+                    .add("path", "/displayName"))
+            .build();
+    JsonPatch patch = Json.createPatch(malformedPatch);
+
+    IllegalArgumentException ex =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> JsonUtils.applyPatch(original, patch, Team.class));
+    assertTrue(ex.getMessage().contains("from"));
+    assertTrue(ex.getMessage().contains("must begin with '/'"));
   }
 
   @Test

--- a/openmetadata-spec/src/main/java/org/openmetadata/schema/utils/JsonUtils.java
+++ b/openmetadata-spec/src/main/java/org/openmetadata/schema/utils/JsonUtils.java
@@ -335,6 +335,8 @@ public final class JsonUtils {
         continue;
       }
 
+      validateJsonPointer(path, "path");
+
       // Skip operations on read-only auto-generated fields
       if (isReadOnlyPatchPath(path)) {
         continue;
@@ -343,6 +345,9 @@ public final class JsonUtils {
       // For copy/move operations, also check the 'from' field if present
       if (jsonObject.containsKey("from")) {
         String from = jsonObject.getString("from", null);
+        if (from != null) {
+          validateJsonPointer(from, "from");
+        }
         if (isReadOnlyPatchPath(from)) {
           continue;
         }
@@ -364,6 +369,15 @@ public final class JsonUtils {
       currentJson = singlePatch.apply(currentJson);
     }
     return currentJson;
+  }
+
+  private static void validateJsonPointer(String pointer, String fieldName) {
+    if (!pointer.isEmpty() && pointer.charAt(0) != '/') {
+      throw new IllegalArgumentException(
+          String.format(
+              "Invalid JSON Patch '%s' value '%s' - non-empty JSON Pointer must begin with '/' (RFC 6901)",
+              fieldName, pointer));
+    }
   }
 
   private static boolean isReadOnlyPatchPath(String path) {


### PR DESCRIPTION
### Describe your changes:

PATCH requests with malformed JSON Patch pointers (e.g., `path` of `"displayName"` instead of `"/displayName"`) were causing `jakarta.json.JsonException: A non-empty JSON Pointer must begin with a '/'` to surface as unhandled 500s and trigger Sentry alerts on endpoints like `ClassificationResource`.

`JsonUtils.applyPatch` now validates each operation's `path` and `from` upfront, throwing `IllegalArgumentException` with a clear RFC 6901 message before the cryptic library exception fires. `CatalogGenericExceptionMapper` also maps `jakarta.json.JsonException` to 400 as defense in depth — this covers other RFC 6902 violations (out-of-range array index, replace on missing path) that were similarly returning 500.

#
### Type of change:
- [x] Bug fix

#
### Tests:

#### Use cases covered
- Client sends `PATCH /v1/classifications/{fqn}` with a JSON Patch op whose `path` is missing the leading `/` → server returns **400** with a clear "must begin with '/'" message instead of **500**.
- Same protection for `from` on `copy` / `move` operations.

#### Unit tests
- [x] Added `applyPatchRejectsMalformedJsonPointerPath` and `applyPatchRejectsMalformedFromPointer` in `JsonUtilsTest.java`.

#
### Checklist:
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests that cover the exact scenario we are fixing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)