### PR TITLE
fix(ui): add space between day and month in X-axis date format

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/MyData/Widgets/KPIWidget/KPIWidget.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/MyData/Widgets/KPIWidget/KPIWidget.component.tsx
@@ -340,7 +340,7 @@ const KPIWidget = ({
                 interval="preserveStartEnd"
                 tick={{ fill: '#888', fontSize: 12 }}
                 tickFormatter={(value: number) =>
-                  customFormatDateTime(value, 'dMMM, yy')
+                  customFormatDateTime(value, 'd MMM, yy')
                 }
                 tickLine={false}
                 tickMargin={10}


### PR DESCRIPTION
## Summary

- KPI widget X-axis ticks were rendering dates as `30Apr, 26` (no space between day and month)
- Changed date format string from `'dMMM, yy'` to `'d MMM, yy'` in `KPIWidget.component.tsx`
- Dates now render correctly as `30 Apr, 26`
<img width="460" height="443" alt="Screenshot 2026-05-21 at 11 20 27 AM" src="https://github.com/user-attachments/assets/e2877e67-6321-4264-b659-ae525f1aef8a" />



Fixes open-metadata/openmetadata-collate#4184

## Test plan

- [ ] Load the KPI widget on the dashboard
- [ ] Verify X-axis date ticks show space between day and month (e.g. `30 Apr, 26`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)