### PR TITLE
feat(1.13): backfill task domains + stamp domains on approval task creation

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/governance/workflows/elements/nodes/userTask/impl/CreateApprovalTaskImpl.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/governance/workflows/elements/nodes/userTask/impl/CreateApprovalTaskImpl.java
@@ -156,6 +156,10 @@ public class CreateApprovalTaskImpl implements TaskListener {
               .withAbout(about.getLinkString())
               .withType(ThreadType.Task)
               .withTask(taskDetails)
+              .withDomains(
+                  entity.getDomains() == null
+                      ? null
+                      : entity.getDomains().stream().map(EntityReference::getId).toList())
               .withUpdatedBy(entity.getUpdatedBy())
               .withUpdatedAt(System.currentTimeMillis());
       ChangePreviewUtils.applyChangePreview(thread, entity, null);

--- a/openmetadata-service/src/main/java/org/openmetadata/service/governance/workflows/elements/nodes/userTask/impl/CreateApprovalTaskImpl.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/governance/workflows/elements/nodes/userTask/impl/CreateApprovalTaskImpl.java
@@ -6,6 +6,7 @@ import static org.openmetadata.service.governance.workflows.Workflow.WORKFLOW_RU
 import static org.openmetadata.service.governance.workflows.WorkflowHandler.getProcessDefinitionKeyFromId;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -158,7 +159,7 @@ public class CreateApprovalTaskImpl implements TaskListener {
               .withTask(taskDetails)
               .withDomains(
                   entity.getDomains() == null
-                      ? null
+                      ? Collections.emptyList()
                       : entity.getDomains().stream().map(EntityReference::getId).toList())
               .withUpdatedBy(entity.getUpdatedBy())
               .withUpdatedAt(System.currentTimeMillis());

--- a/openmetadata-service/src/main/java/org/openmetadata/service/migration/mysql/v1129/Migration.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/migration/mysql/v1129/Migration.java
@@ -1,12 +1,15 @@
 package org.openmetadata.service.migration.mysql.v1129;
 
+import static org.openmetadata.service.jdbi3.locator.ConnectionType.MYSQL;
 import static org.openmetadata.service.migration.utils.v1129.MigrationUtil.addTriggerOperationToDefaultBotPolicies;
 import static org.openmetadata.service.migration.utils.v1129.MigrationUtil.addTriggerRuleToDataStewardPolicy;
 
-import lombok.SneakyThrows;
+import lombok.extern.slf4j.Slf4j;
 import org.openmetadata.service.migration.api.MigrationProcessImpl;
 import org.openmetadata.service.migration.utils.MigrationFile;
+import org.openmetadata.service.migration.utils.v1129.MigrationUtil;
 
+@Slf4j
 public class Migration extends MigrationProcessImpl {
 
   public Migration(MigrationFile migrationFile) {
@@ -14,9 +17,25 @@ public class Migration extends MigrationProcessImpl {
   }
 
   @Override
-  @SneakyThrows
   public void runDataMigration() {
-    addTriggerOperationToDefaultBotPolicies(collectionDAO);
-    addTriggerRuleToDataStewardPolicy(collectionDAO);
+    try {
+      addTriggerOperationToDefaultBotPolicies(collectionDAO);
+      addTriggerRuleToDataStewardPolicy(collectionDAO);
+    } catch (Exception ex) {
+      LOG.error(
+          "Failed to migrate bot/steward trigger policies in v1129 migration. "
+              + "Affected identities may lose trigger access until manually updated.",
+          ex);
+    }
+    try {
+      MigrationUtil migrationUtil = new MigrationUtil(handle, MYSQL);
+      migrationUtil.migrateTaskDomains();
+    } catch (Exception e) {
+      LOG.error(
+          "Failed to migrate task domains in v1129 migration. "
+              + "Domain-scoped users may not see tasks in the activity feed "
+              + "until a manual domain backfill is performed.",
+          e);
+    }
   }
 }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/migration/postgres/v1129/Migration.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/migration/postgres/v1129/Migration.java
@@ -1,12 +1,15 @@
 package org.openmetadata.service.migration.postgres.v1129;
 
+import static org.openmetadata.service.jdbi3.locator.ConnectionType.POSTGRES;
 import static org.openmetadata.service.migration.utils.v1129.MigrationUtil.addTriggerOperationToDefaultBotPolicies;
 import static org.openmetadata.service.migration.utils.v1129.MigrationUtil.addTriggerRuleToDataStewardPolicy;
 
-import lombok.SneakyThrows;
+import lombok.extern.slf4j.Slf4j;
 import org.openmetadata.service.migration.api.MigrationProcessImpl;
 import org.openmetadata.service.migration.utils.MigrationFile;
+import org.openmetadata.service.migration.utils.v1129.MigrationUtil;
 
+@Slf4j
 public class Migration extends MigrationProcessImpl {
 
   public Migration(MigrationFile migrationFile) {
@@ -14,9 +17,25 @@ public class Migration extends MigrationProcessImpl {
   }
 
   @Override
-  @SneakyThrows
   public void runDataMigration() {
-    addTriggerOperationToDefaultBotPolicies(collectionDAO);
-    addTriggerRuleToDataStewardPolicy(collectionDAO);
+    try {
+      addTriggerOperationToDefaultBotPolicies(collectionDAO);
+      addTriggerRuleToDataStewardPolicy(collectionDAO);
+    } catch (Exception ex) {
+      LOG.error(
+          "Failed to migrate bot/steward trigger policies in v1129 migration. "
+              + "Affected identities may lose trigger access until manually updated.",
+          ex);
+    }
+    try {
+      MigrationUtil migrationUtil = new MigrationUtil(handle, POSTGRES);
+      migrationUtil.migrateTaskDomains();
+    } catch (Exception e) {
+      LOG.error(
+          "Failed to migrate task domains in v1129 migration. "
+              + "Domain-scoped users may not see tasks in the activity feed "
+              + "until a manual domain backfill is performed.",
+          e);
+    }
   }
 }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/migration/utils/v1129/MigrationUtil.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/migration/utils/v1129/MigrationUtil.java
@@ -186,10 +186,23 @@ public class MigrationUtil {
   }
 
   private List<String[]> readThreadTaskBatch(int limit) {
+    // Catches three "no domains" states:
+    //   1. key missing               → JSON_EXTRACT / -> returns SQL NULL
+    //   2. "domains": null           → JSON_TYPE = 'NULL' / jsonb_typeof = 'null'
+    //   3. (intentional no-op once $.domains = [] is written by the migration)
+    // Without case 2 the migration silently skips tasks where Jackson serialized
+    // a null domains field — which is the default for any task created before
+    // CreateApprovalTaskImpl was patched to set .withDomains(...).
     String whereClause =
         connectionType == ConnectionType.MYSQL
-            ? "WHERE type = 'Task' AND JSON_EXTRACT(json, '$.domains') IS NULL"
-            : "WHERE type = 'Task' AND json->'domains' IS NULL";
+            ? "WHERE type = 'Task' AND ("
+                + "JSON_EXTRACT(json, '$.domains') IS NULL "
+                + "OR JSON_TYPE(JSON_EXTRACT(json, '$.domains')) = 'NULL'"
+                + ")"
+            : "WHERE type = 'Task' AND ("
+                + "json->'domains' IS NULL "
+                + "OR jsonb_typeof(json->'domains') = 'null'"
+                + ")";
     return handle
         .createQuery(
             "SELECT id, json FROM thread_entity "

--- a/openmetadata-service/src/main/java/org/openmetadata/service/migration/utils/v1129/MigrationUtil.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/migration/utils/v1129/MigrationUtil.java
@@ -358,6 +358,11 @@ public class MigrationUtil {
   }
 
   private String buildMysqlInsertTaskDomainSql() {
+    // NOT EXISTS deliberately does NOT filter on ex.deleted: tasks are hard-deleted only, so
+    // any (domain, task, HAS) row that exists at all should be respected. Filtering on
+    // ex.deleted = FALSE would let the SELECT yield rows that collide with soft-deleted PKs
+    // (deleted is not part of the PK), making INSERT IGNORE's affected-row count drop below
+    // BATCH_SIZE and break the loop prematurely.
     return "INSERT IGNORE INTO entity_relationship "
         + "  (fromId, toId, fromEntity, toEntity, relation) "
         + "SELECT er_domain.fromId, er_about.toId, 'domain', 'task', "
@@ -383,13 +388,13 @@ public class MigrationUtil {
         + "    AND ex.toId = er_about.toId AND ex.toEntity = 'task' "
         + "    AND ex.fromEntity = 'domain' AND ex.relation = "
         + RELATION_HAS
-        + "    AND ex.deleted = FALSE "
         + "  ) "
         + "LIMIT "
         + BATCH_SIZE;
   }
 
   private String buildPostgresInsertTaskDomainSql() {
+    // See note on buildMysqlInsertTaskDomainSql: NOT EXISTS intentionally omits ex.deleted.
     return "INSERT INTO entity_relationship "
         + "  (fromId, toId, fromEntity, toEntity, relation) "
         + "SELECT er_domain.fromId, er_about.toId, 'domain', 'task', "
@@ -415,7 +420,6 @@ public class MigrationUtil {
         + "    AND ex.toId = er_about.toId AND ex.toEntity = 'task' "
         + "    AND ex.fromEntity = 'domain' AND ex.relation = "
         + RELATION_HAS
-        + "    AND ex.deleted = FALSE "
         + "  ) "
         + "LIMIT "
         + BATCH_SIZE

--- a/openmetadata-service/src/main/java/org/openmetadata/service/migration/utils/v1129/MigrationUtil.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/migration/utils/v1129/MigrationUtil.java
@@ -1,23 +1,449 @@
 package org.openmetadata.service.migration.utils.v1129;
 
+import static org.openmetadata.common.utils.CommonUtil.nullOrEmpty;
 import static org.openmetadata.service.migration.utils.v160.MigrationUtil.addOperationsToPolicyRule;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import java.sql.ResultSet;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.UUID;
 import lombok.extern.slf4j.Slf4j;
+import org.jdbi.v3.core.Handle;
+import org.openmetadata.schema.EntityInterface;
 import org.openmetadata.schema.entity.policies.Policy;
 import org.openmetadata.schema.entity.policies.accessControl.Rule;
+import org.openmetadata.schema.type.EntityReference;
 import org.openmetadata.schema.type.Include;
 import org.openmetadata.schema.type.MetadataOperation;
+import org.openmetadata.schema.type.Relationship;
 import org.openmetadata.schema.utils.JsonUtils;
 import org.openmetadata.service.Entity;
 import org.openmetadata.service.exception.EntityNotFoundException;
 import org.openmetadata.service.jdbi3.CollectionDAO;
+import org.openmetadata.service.jdbi3.EntityRepository;
 import org.openmetadata.service.jdbi3.PolicyRepository;
+import org.openmetadata.service.jdbi3.locator.ConnectionType;
+import org.openmetadata.service.resources.feeds.MessageParser;
 
+/**
+ * Migration utility for 1.12.9 — backfills domains on tasks so that domain-scoped users can see
+ * tasks in the activity feed.
+ *
+ * <p>Two storage layouts are handled:
+ *
+ * <ul>
+ *   <li>1.12.x: tasks live in {@code thread_entity} (type='Task'); the {@code about} field is an
+ *       entity link string (e.g. {@code <#E::glossaryTerm::Glossary.Term>}). Domains are a UUID
+ *       array in {@code $.domains}. Entity link is parsed per row, but domain lookups are cached by
+ *       {@code (entityType, entityFQN)} so each unique target entity is resolved only once.
+ *   <li>2.x: tasks live in {@code task_entity}; the about entity is stored as a {@code
+ *       MENTIONED_IN} row in {@code entity_relationship}. Domains are HAS rows in the same table.
+ *       A single INSERT...SELECT walking MENTIONED_IN → HAS handles all missing rows in bulk.
+ * </ul>
+ *
+ * <p>After this migration completes, the search index for tasks must be rebuilt for domain-scoped
+ * feed queries that hit Elasticsearch/OpenSearch to reflect the new domain values. Operators
+ * should trigger a tasks reindex post-upgrade.
+ */
 @Slf4j
 public class MigrationUtil {
 
-  private MigrationUtil() {}
+  private static final int BATCH_SIZE = 500;
+  private static final int RELATION_MENTIONED_IN = Relationship.MENTIONED_IN.ordinal();
+  private static final int RELATION_HAS = Relationship.HAS.ordinal();
+
+  private final Handle handle;
+  private final ConnectionType connectionType;
+
+  public MigrationUtil(Handle handle, ConnectionType connectionType) {
+    this.handle = handle;
+    this.connectionType = connectionType;
+  }
+
+  public void migrateTaskDomains() {
+    int threadUpdated = migrateThreadEntityTaskDomains();
+    int taskEntityUpdated = migrateTaskEntityDomains();
+    LOG.info(
+        "Task domain migration complete. threadEntityUpdated={}, taskEntityUpdated={}",
+        threadUpdated,
+        taskEntityUpdated);
+  }
+
+  // ---------------------------------------------------------------------------
+  // thread_entity migration (1.12.x)
+  //
+  // The `about` field is an entity link string — not a UUID or FQN — so it
+  // cannot be joined in SQL. We parse it in Java with MessageParser, but cache
+  // domain lookups by (entityType, entityFQN) so each unique target entity is
+  // hit only once, even when thousands of tasks point to the same glossary term.
+  //
+  // IMPORTANT: we always query with OFFSET 0. As rows are updated ($.domains set),
+  // they drop out of the WHERE clause (JSON_EXTRACT/-> IS NULL), so the batch
+  // naturally advances without any offset tracking. Using a growing OFFSET would skip rows.
+  // ---------------------------------------------------------------------------
+
+  private int migrateThreadEntityTaskDomains() {
+    if (!tableExists("thread_entity")) {
+      LOG.info("No thread_entity table found, skipping thread task domain migration");
+      return 0;
+    }
+
+    Map<String, List<UUID>> domainCache = new HashMap<>();
+    int withDomains = 0;
+    int markedDone = 0;
+    int markedDoneOnError = 0;
+
+    while (true) {
+      List<String[]> batch = readThreadTaskBatch(BATCH_SIZE);
+      if (batch.isEmpty()) break;
+      int processedInBatch = 0;
+      for (String[] row : batch) {
+        int result = processThreadTaskRow(row[0], row[1], domainCache);
+        if (result == 1) withDomains++;
+        else if (result == 2) markedDone++;
+        else if (result == 3) markedDoneOnError++;
+        if (result != 0) processedInBatch++;
+      }
+      LOG.debug(
+          "Thread task migration progress: withDomains={}, markedDone={}, markedDoneOnError={}",
+          withDomains,
+          markedDone,
+          markedDoneOnError);
+      if (processedInBatch == 0) {
+        LOG.error(
+            "Stalled thread_entity domain migration: a full batch of {} rows produced no updates. "
+                + "Aborting to avoid infinite loop. Inspect ERROR logs above for failing thread IDs.",
+            batch.size());
+        break;
+      }
+    }
+
+    int total = withDomains + markedDone + markedDoneOnError;
+    LOG.info(
+        "Migrated {} thread tasks in thread_entity (withDomains={}, markedDone={}, markedDoneOnError={})",
+        total,
+        withDomains,
+        markedDone,
+        markedDoneOnError);
+    if (markedDoneOnError > 0) {
+      LOG.warn(
+          "{} thread tasks were marked done with empty $.domains because their target entity "
+              + "could not be resolved. Inspect WARN logs above for the specific rows.",
+          markedDoneOnError);
+    }
+    return total;
+  }
+
+  /**
+   * Process a single thread row.
+   *
+   * <p>Returns 1 if domains were written, 2 if marked done with empty domains because the target
+   * entity has none, 3 if marked done with empty domains as a safe fallback because the target
+   * entity could not be resolved.
+   *
+   * <p>Unresolvable rows are still marked done to prevent an infinite loop: the read query selects
+   * on {@code $.domains IS NULL}, so any row left with NULL would be re-fetched in every subsequent
+   * batch and the loop would never terminate. Emitting {@code []} matches the legitimate
+   * "no domains" path and keeps the row out of the WHERE clause.
+   */
+  private int processThreadTaskRow(String id, String json, Map<String, List<UUID>> domainCache) {
+    try {
+      List<UUID> domainIds = resolveThreadTaskDomains(json, domainCache);
+      if (domainIds == null) {
+        LOG.warn(
+            "Could not resolve domains for thread id={}; marking with empty $.domains to avoid migration loop",
+            id);
+        markThreadDomainsMigrated(id);
+        return 3;
+      }
+      if (domainIds.isEmpty()) {
+        markThreadDomainsMigrated(id);
+        return 2;
+      }
+      updateThreadDomains(id, domainIds);
+      return 1;
+    } catch (Exception e) {
+      LOG.warn(
+          "Failed to migrate thread task domains for id={}, marking with empty $.domains: {}",
+          id,
+          e.getMessage());
+      try {
+        markThreadDomainsMigrated(id);
+        return 3;
+      } catch (Exception markEx) {
+        LOG.error(
+            "Failed to mark thread id={} as migrated after error; this row will be retried "
+                + "and may stall the migration: {}",
+            id,
+            markEx.getMessage());
+        return 0;
+      }
+    }
+  }
+
+  private List<String[]> readThreadTaskBatch(int limit) {
+    String whereClause =
+        connectionType == ConnectionType.MYSQL
+            ? "WHERE type = 'Task' AND JSON_EXTRACT(json, '$.domains') IS NULL"
+            : "WHERE type = 'Task' AND json->'domains' IS NULL";
+    return handle
+        .createQuery(
+            "SELECT id, json FROM thread_entity "
+                + whereClause
+                + " ORDER BY createdAt LIMIT :limit")
+        .bind("limit", limit)
+        .map((rs, ctx) -> new String[] {rs.getString("id"), rs.getString("json")})
+        .list();
+  }
+
+  // null = lookup failed (skip row); emptyList = no domains (mark done); non-empty = has domains
+  private List<UUID> resolveThreadTaskDomains(String json, Map<String, List<UUID>> cache) {
+    try {
+      JsonNode node = JsonUtils.readTree(json);
+      JsonNode aboutNode = node.get("about");
+      if (aboutNode == null || aboutNode.isNull()) return Collections.emptyList();
+
+      String about = aboutNode.asText(null);
+      if (nullOrEmpty(about)) return Collections.emptyList();
+
+      MessageParser.EntityLink entityLink = MessageParser.EntityLink.parse(about);
+      String cacheKey = entityLink.getEntityType() + "::" + entityLink.getEntityFQN();
+
+      if (cache.containsKey(cacheKey)) return cache.get(cacheKey);
+      List<UUID> ids = fetchDomainIds(entityLink);
+      cache.put(cacheKey, ids);
+      return ids;
+    } catch (Exception e) {
+      LOG.debug("Could not resolve domains from thread JSON: {}", e.getMessage());
+      return null;
+    }
+  }
+
+  private List<UUID> fetchDomainIds(MessageParser.EntityLink entityLink) {
+    try {
+      EntityRepository<?> repo = Entity.getEntityRepository(entityLink.getEntityType());
+      if (!repo.isSupportsDomains()) return Collections.emptyList();
+
+      EntityReference ref =
+          Entity.getEntityReferenceByName(
+              entityLink.getEntityType(), entityLink.getEntityFQN(), Include.ALL);
+      if (ref == null || ref.getId() == null) return Collections.emptyList();
+
+      Object entity = repo.get(null, ref.getId(), repo.getFields(Entity.FIELD_DOMAINS));
+      if (!(entity instanceof EntityInterface ei)) {
+        return Collections.emptyList();
+      }
+
+      List<EntityReference> domains = ei.getDomains();
+      if (nullOrEmpty(domains)) return Collections.emptyList();
+
+      List<UUID> ids = new ArrayList<>(domains.size());
+      for (EntityReference d : domains) {
+        if (d.getId() != null) ids.add(d.getId());
+      }
+      return ids;
+    } catch (EntityNotFoundException e) {
+      LOG.debug(
+          "Entity not found for {}::{}, treating as no domains",
+          entityLink.getEntityType(),
+          entityLink.getEntityFQN());
+      return Collections.emptyList();
+    }
+  }
+
+  /**
+   * Sets $.domains to an empty array so JSON_EXTRACT(json,'$.domains') returns [] (not SQL NULL),
+   * causing the row to drop out of the WHERE clause and not be re-fetched.
+   */
+  private void markThreadDomainsMigrated(String threadId) {
+    if (connectionType == ConnectionType.MYSQL) {
+      handle
+          .createUpdate(
+              "UPDATE thread_entity "
+                  + "SET json = JSON_SET(json, '$.domains', CAST('[]' AS JSON)) "
+                  + "WHERE id = :id")
+          .bind("id", threadId)
+          .execute();
+    } else {
+      handle
+          .createUpdate(
+              "UPDATE thread_entity "
+                  + "SET json = jsonb_set(json, '{domains}', '[]'::jsonb) "
+                  + "WHERE id = :id")
+          .bind("id", threadId)
+          .execute();
+    }
+  }
+
+  private void updateThreadDomains(String threadId, List<UUID> domainIds) {
+    String domainsJson = buildUuidJsonArray(domainIds);
+    if (connectionType == ConnectionType.MYSQL) {
+      handle
+          .createUpdate(
+              "UPDATE thread_entity "
+                  + "SET json = JSON_SET(json, '$.domains', CAST(:domains AS JSON)) "
+                  + "WHERE id = :id")
+          .bind("domains", domainsJson)
+          .bind("id", threadId)
+          .execute();
+    } else {
+      handle
+          .createUpdate(
+              "UPDATE thread_entity "
+                  + "SET json = jsonb_set(json, '{domains}', :domains::jsonb) "
+                  + "WHERE id = :id")
+          .bind("domains", domainsJson)
+          .bind("id", threadId)
+          .execute();
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // task_entity migration (2.x)
+  //
+  // The about entity is a real entity_relationship row (MENTIONED_IN), so a
+  // bulk INSERT...SELECT joining MENTIONED_IN → HAS correctly resolves all
+  // missing domain relationships without any Java-side entity parsing.
+  //
+  // Column names are unquoted in both MySQL and PostgreSQL — unquoted DDL
+  // names are stored lowercase in PostgreSQL, and unquoted query identifiers
+  // are also folded to lowercase, so they match. Quoted names would break
+  // PostgreSQL since the columns are actually stored as lowercase.
+  //
+  // After each batch the NOT EXISTS eliminates already-inserted rows, so
+  // the loop naturally terminates when no new rows can be inserted.
+  // ---------------------------------------------------------------------------
+
+  private int migrateTaskEntityDomains() {
+    if (!tableExists("task_entity")) {
+      LOG.info("No task_entity table found, skipping task entity domain migration");
+      return 0;
+    }
+
+    int totalInserted = 0;
+    while (true) {
+      int inserted = insertTaskDomainsBatch();
+      totalInserted += inserted;
+      LOG.debug("Task domain migration progress: {} relationships inserted so far", totalInserted);
+      if (inserted < BATCH_SIZE) break;
+    }
+
+    LOG.info("Inserted {} domain relationships for task entities in task_entity", totalInserted);
+    return totalInserted;
+  }
+
+  private int insertTaskDomainsBatch() {
+    String sql =
+        connectionType == ConnectionType.MYSQL
+            ? buildMysqlInsertTaskDomainSql()
+            : buildPostgresInsertTaskDomainSql();
+    return handle.createUpdate(sql).execute();
+  }
+
+  private String buildMysqlInsertTaskDomainSql() {
+    return "INSERT IGNORE INTO entity_relationship "
+        + "  (fromId, toId, fromEntity, toEntity, relation) "
+        + "SELECT er_domain.fromId, er_about.toId, 'domain', 'task', "
+        + RELATION_HAS
+        + " "
+        + "FROM entity_relationship er_about "
+        + "JOIN entity_relationship er_domain "
+        + "  ON er_domain.toId     = er_about.fromId "
+        + "  AND er_domain.toEntity = er_about.fromEntity "
+        + "  AND er_domain.fromEntity = 'domain' "
+        + "  AND er_domain.relation = "
+        + RELATION_HAS
+        + " "
+        + "  AND er_domain.deleted = FALSE "
+        + "WHERE er_about.toEntity = 'task' "
+        + "  AND er_about.relation = "
+        + RELATION_MENTIONED_IN
+        + " "
+        + "  AND er_about.deleted = FALSE "
+        + "  AND NOT EXISTS ("
+        + "    SELECT 1 FROM entity_relationship ex "
+        + "    WHERE ex.fromId = er_domain.fromId "
+        + "    AND ex.toId = er_about.toId AND ex.toEntity = 'task' "
+        + "    AND ex.fromEntity = 'domain' AND ex.relation = "
+        + RELATION_HAS
+        + "    AND ex.deleted = FALSE "
+        + "  ) "
+        + "LIMIT "
+        + BATCH_SIZE;
+  }
+
+  private String buildPostgresInsertTaskDomainSql() {
+    return "INSERT INTO entity_relationship "
+        + "  (fromId, toId, fromEntity, toEntity, relation) "
+        + "SELECT er_domain.fromId, er_about.toId, 'domain', 'task', "
+        + RELATION_HAS
+        + " "
+        + "FROM entity_relationship er_about "
+        + "JOIN entity_relationship er_domain "
+        + "  ON er_domain.toId     = er_about.fromId "
+        + "  AND er_domain.toEntity = er_about.fromEntity "
+        + "  AND er_domain.fromEntity = 'domain' "
+        + "  AND er_domain.relation = "
+        + RELATION_HAS
+        + " "
+        + "  AND er_domain.deleted = FALSE "
+        + "WHERE er_about.toEntity = 'task' "
+        + "  AND er_about.relation = "
+        + RELATION_MENTIONED_IN
+        + " "
+        + "  AND er_about.deleted = FALSE "
+        + "  AND NOT EXISTS ("
+        + "    SELECT 1 FROM entity_relationship ex "
+        + "    WHERE ex.fromId = er_domain.fromId "
+        + "    AND ex.toId = er_about.toId AND ex.toEntity = 'task' "
+        + "    AND ex.fromEntity = 'domain' AND ex.relation = "
+        + RELATION_HAS
+        + "    AND ex.deleted = FALSE "
+        + "  ) "
+        + "LIMIT "
+        + BATCH_SIZE
+        + " ON CONFLICT DO NOTHING";
+  }
+
+  // ---------------------------------------------------------------------------
+  // Helpers
+  // ---------------------------------------------------------------------------
+
+  private String buildUuidJsonArray(List<UUID> ids) {
+    StringBuilder sb = new StringBuilder("[");
+    for (int i = 0; i < ids.size(); i++) {
+      if (i > 0) sb.append(",");
+      sb.append("\"").append(ids.get(i)).append("\"");
+    }
+    sb.append("]");
+    return sb.toString();
+  }
+
+  private boolean tableExists(String tableName) {
+    try (ResultSet tables =
+        handle
+            .getConnection()
+            .getMetaData()
+            .getTables(null, null, tableName, new String[] {"TABLE"})) {
+      while (tables.next()) {
+        if (tableName.equalsIgnoreCase(tables.getString("TABLE_NAME"))) {
+          return true;
+        }
+      }
+      return false;
+    } catch (Exception e) {
+      LOG.warn("Could not check for table '{}': {}", tableName, e.getMessage());
+      return false;
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Policy migrations (static, callable without a Handle)
+  // ---------------------------------------------------------------------------
 
   /**
    * Retrofits seeded bot policies that grant broad {@code EditAll} on {@code ["All"]} resources

--- a/openmetadata-service/src/test/java/org/openmetadata/service/migration/utils/v1129/MigrationUtilTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/migration/utils/v1129/MigrationUtilTest.java
@@ -315,9 +315,14 @@ class MigrationUtilTest {
     ArgumentCaptor<String> sqlCaptor = ArgumentCaptor.forClass(String.class);
     verify(handle, times(1)).createUpdate(sqlCaptor.capture());
     String sql = sqlCaptor.getValue();
+    // er_about and er_domain are filtered on deleted=FALSE so the backfill won't propagate
+    // soft-deleted relationships forward.
     assertTrue(sql.contains("er_about.deleted = FALSE"));
     assertTrue(sql.contains("er_domain.deleted = FALSE"));
-    assertTrue(sql.contains("ex.deleted = FALSE"));
+    // ex (the NOT EXISTS check) must NOT filter on deleted: tasks are hard-deleted only, and
+    // filtering would let INSERT IGNORE collide on the PK with soft-deleted rows and drop the
+    // affected-row count below BATCH_SIZE, breaking the loop early.
+    assertFalse(sql.contains("ex.deleted = FALSE"));
   }
 
   @Test
@@ -335,6 +340,6 @@ class MigrationUtilTest {
     String sql = sqlCaptor.getValue();
     assertTrue(sql.contains("er_about.deleted = FALSE"));
     assertTrue(sql.contains("er_domain.deleted = FALSE"));
-    assertTrue(sql.contains("ex.deleted = FALSE"));
+    assertFalse(sql.contains("ex.deleted = FALSE"));
   }
 }

--- a/openmetadata-service/src/test/java/org/openmetadata/service/migration/utils/v1129/MigrationUtilTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/migration/utils/v1129/MigrationUtilTest.java
@@ -1,0 +1,330 @@
+package org.openmetadata.service.migration.utils.v1129;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Answers.RETURNS_DEEP_STUBS;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.sql.ResultSet;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
+import org.jdbi.v3.core.Handle;
+import org.jdbi.v3.core.mapper.RowMapper;
+import org.jdbi.v3.core.statement.Update;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.openmetadata.service.jdbi3.locator.ConnectionType;
+
+class MigrationUtilTest {
+
+  private Handle mockHandle() {
+    return mock(Handle.class, RETURNS_DEEP_STUBS);
+  }
+
+  private void stubTableExists(Handle handle, String tableName) throws Exception {
+    ResultSet rs = mock(ResultSet.class);
+    when(rs.next()).thenReturn(true, false);
+    when(rs.getString("TABLE_NAME")).thenReturn(tableName);
+    when(handle.getConnection().getMetaData().getTables(any(), any(), eq(tableName), any()))
+        .thenReturn(rs);
+  }
+
+  @SuppressWarnings("unchecked")
+  private void stubBatch(Handle handle, List<String[]>... batches) {
+    when(handle
+            .createQuery(anyString())
+            .bind(anyString(), anyInt())
+            .map(any(RowMapper.class))
+            .list())
+        .thenReturn(batches[0], (List[]) java.util.Arrays.copyOfRange(batches, 1, batches.length));
+  }
+
+  private List<String[]> rows(String... jsons) {
+    List<String[]> result = new ArrayList<>();
+    for (String json : jsons) {
+      result.add(new String[] {UUID.randomUUID().toString(), json});
+    }
+    return result;
+  }
+
+  // ─── thread_entity tests ──────────────────────────────────────────────────
+
+  @Test
+  void bothTablesAbsent_noQueriesOrUpdates() {
+    Handle handle = mockHandle();
+
+    assertDoesNotThrow(() -> new MigrationUtil(handle, ConnectionType.MYSQL).migrateTaskDomains());
+
+    verify(handle, never()).createQuery(anyString());
+    verify(handle, never()).createUpdate(anyString());
+  }
+
+  @Test
+  void threadEntity_emptyBatch_terminatesWithoutUpdates_mysql() throws Exception {
+    Handle handle = mockHandle();
+    stubTableExists(handle, "thread_entity");
+    stubBatch(handle, Collections.emptyList());
+
+    assertDoesNotThrow(() -> new MigrationUtil(handle, ConnectionType.MYSQL).migrateTaskDomains());
+
+    verify(handle, never()).createUpdate(anyString());
+  }
+
+  @Test
+  void threadEntity_emptyBatch_terminatesWithoutUpdates_postgres() throws Exception {
+    Handle handle = mockHandle();
+    stubTableExists(handle, "thread_entity");
+    stubBatch(handle, Collections.emptyList());
+
+    assertDoesNotThrow(
+        () -> new MigrationUtil(handle, ConnectionType.POSTGRES).migrateTaskDomains());
+
+    verify(handle, never()).createUpdate(anyString());
+  }
+
+  @Test
+  void threadEntity_mysqlWhereClauseUsesJsonExtract() throws Exception {
+    Handle handle = mockHandle();
+    stubTableExists(handle, "thread_entity");
+    stubBatch(handle, Collections.emptyList());
+
+    new MigrationUtil(handle, ConnectionType.MYSQL).migrateTaskDomains();
+
+    ArgumentCaptor<String> sqlCaptor = ArgumentCaptor.forClass(String.class);
+    verify(handle, atLeastOnce()).createQuery(sqlCaptor.capture());
+    // stubBatch setup also triggers createQuery; filter to find the real migration SQL
+    assertTrue(
+        sqlCaptor.getAllValues().stream()
+            .anyMatch(s -> s != null && s.contains("JSON_EXTRACT(json, '$.domains') IS NULL")));
+  }
+
+  @Test
+  void threadEntity_postgresWhereClauseUsesJsonArrowOperator() throws Exception {
+    Handle handle = mockHandle();
+    stubTableExists(handle, "thread_entity");
+    stubBatch(handle, Collections.emptyList());
+
+    new MigrationUtil(handle, ConnectionType.POSTGRES).migrateTaskDomains();
+
+    ArgumentCaptor<String> sqlCaptor = ArgumentCaptor.forClass(String.class);
+    verify(handle, atLeastOnce()).createQuery(sqlCaptor.capture());
+    assertTrue(
+        sqlCaptor.getAllValues().stream()
+            .anyMatch(s -> s != null && s.contains("json->'domains' IS NULL")));
+  }
+
+  @Test
+  void threadEntity_rowWithNullAbout_marksAsMigratedWithMysqlSql() throws Exception {
+    Handle handle = mockHandle();
+    stubTableExists(handle, "thread_entity");
+    stubBatch(handle, rows("{\"type\":\"Task\"}"), Collections.emptyList());
+    Update mockUpdate = mock(Update.class, RETURNS_DEEP_STUBS);
+    when(handle.createUpdate(anyString())).thenReturn(mockUpdate);
+
+    assertDoesNotThrow(() -> new MigrationUtil(handle, ConnectionType.MYSQL).migrateTaskDomains());
+
+    ArgumentCaptor<String> sqlCaptor = ArgumentCaptor.forClass(String.class);
+    verify(handle, times(1)).createUpdate(sqlCaptor.capture());
+    String sql = sqlCaptor.getValue();
+    assertTrue(sql.contains("JSON_SET"));
+    assertTrue(sql.contains("'$.domains'"));
+    assertTrue(sql.contains("CAST('[]' AS JSON)"));
+  }
+
+  @Test
+  void threadEntity_rowWithNullAbout_marksAsMigratedWithPostgresSql() throws Exception {
+    Handle handle = mockHandle();
+    stubTableExists(handle, "thread_entity");
+    stubBatch(handle, rows("{\"type\":\"Task\"}"), Collections.emptyList());
+    Update mockUpdate = mock(Update.class, RETURNS_DEEP_STUBS);
+    when(handle.createUpdate(anyString())).thenReturn(mockUpdate);
+
+    assertDoesNotThrow(
+        () -> new MigrationUtil(handle, ConnectionType.POSTGRES).migrateTaskDomains());
+
+    ArgumentCaptor<String> sqlCaptor = ArgumentCaptor.forClass(String.class);
+    verify(handle, times(1)).createUpdate(sqlCaptor.capture());
+    String sql = sqlCaptor.getValue();
+    assertTrue(sql.contains("jsonb_set"));
+    assertTrue(sql.contains("'{domains}'"));
+    assertTrue(sql.contains("'[]'::jsonb"));
+  }
+
+  @Test
+  void threadEntity_rowWithMalformedJson_isMarkedMigratedToAvoidLoop() throws Exception {
+    Handle handle = mockHandle();
+    stubTableExists(handle, "thread_entity");
+    stubBatch(handle, rows("not-valid-json{{{"), Collections.emptyList());
+    Update mockUpdate = mock(Update.class, RETURNS_DEEP_STUBS);
+    when(handle.createUpdate(anyString())).thenReturn(mockUpdate);
+
+    assertDoesNotThrow(() -> new MigrationUtil(handle, ConnectionType.MYSQL).migrateTaskDomains());
+
+    ArgumentCaptor<String> sqlCaptor = ArgumentCaptor.forClass(String.class);
+    verify(handle, times(1)).createUpdate(sqlCaptor.capture());
+    String sql = sqlCaptor.getValue();
+    assertTrue(sql.contains("JSON_SET"));
+    assertTrue(sql.contains("'$.domains'"));
+    assertTrue(sql.contains("CAST('[]' AS JSON)"));
+  }
+
+  @Test
+  void threadEntity_rowWithValidAboutButUnknownEntityType_marksAsMigrated() throws Exception {
+    Handle handle = mockHandle();
+    stubTableExists(handle, "thread_entity");
+    // Entity.getEntityRepository() throws EntityNotFoundException in unit-test context
+    // (no repositories registered) → fetchDomainIds returns [] → markThreadDomainsMigrated
+    stubBatch(
+        handle,
+        rows("{\"about\":\"<#E::glossaryTerm::MyGlossary.MyTerm>\"}"),
+        Collections.emptyList());
+    Update mockUpdate = mock(Update.class, RETURNS_DEEP_STUBS);
+    when(handle.createUpdate(anyString())).thenReturn(mockUpdate);
+
+    assertDoesNotThrow(() -> new MigrationUtil(handle, ConnectionType.MYSQL).migrateTaskDomains());
+
+    verify(handle, times(1)).createUpdate(anyString());
+  }
+
+  @Test
+  void threadEntity_twoRowsSameEntityLink_bothRowsGetMigrated() throws Exception {
+    Handle handle = mockHandle();
+    stubTableExists(handle, "thread_entity");
+    String json = "{\"about\":\"<#E::glossaryTerm::MyGlossary.MyTerm>\"}";
+    stubBatch(
+        handle,
+        rows(json, json), // two rows pointing to the same entity
+        Collections.emptyList());
+    Update mockUpdate = mock(Update.class, RETURNS_DEEP_STUBS);
+    when(handle.createUpdate(anyString())).thenReturn(mockUpdate);
+
+    assertDoesNotThrow(() -> new MigrationUtil(handle, ConnectionType.MYSQL).migrateTaskDomains());
+
+    verify(handle, times(2)).createUpdate(anyString()); // markMigrated once per row
+  }
+
+  // ─── task_entity tests ────────────────────────────────────────────────────
+
+  @Test
+  void taskEntity_insertLessThanBatchSize_terminatesAfterOneBatch_mysql() throws Exception {
+    Handle handle = mockHandle();
+    stubTableExists(handle, "task_entity");
+    Update mockUpdate = mock(Update.class, RETURNS_DEEP_STUBS);
+    when(handle.createUpdate(anyString())).thenReturn(mockUpdate);
+    when(mockUpdate.execute()).thenReturn(42);
+
+    assertDoesNotThrow(() -> new MigrationUtil(handle, ConnectionType.MYSQL).migrateTaskDomains());
+
+    verify(handle, times(1)).createUpdate(anyString());
+  }
+
+  @Test
+  void taskEntity_insertLessThanBatchSize_terminatesAfterOneBatch_postgres() throws Exception {
+    Handle handle = mockHandle();
+    stubTableExists(handle, "task_entity");
+    Update mockUpdate = mock(Update.class, RETURNS_DEEP_STUBS);
+    when(handle.createUpdate(anyString())).thenReturn(mockUpdate);
+    when(mockUpdate.execute()).thenReturn(42);
+
+    assertDoesNotThrow(
+        () -> new MigrationUtil(handle, ConnectionType.POSTGRES).migrateTaskDomains());
+
+    verify(handle, times(1)).createUpdate(anyString());
+  }
+
+  @Test
+  void taskEntity_insertFullBatch_continuesUntilPartialBatch() throws Exception {
+    Handle handle = mockHandle();
+    stubTableExists(handle, "task_entity");
+    Update mockUpdate = mock(Update.class, RETURNS_DEEP_STUBS);
+    when(handle.createUpdate(anyString())).thenReturn(mockUpdate);
+    when(mockUpdate.execute()).thenReturn(500, 0); // BATCH_SIZE then empty
+
+    assertDoesNotThrow(() -> new MigrationUtil(handle, ConnectionType.MYSQL).migrateTaskDomains());
+
+    verify(handle, times(2)).createUpdate(anyString());
+  }
+
+  @Test
+  void taskEntity_mysqlSqlUsesInsertIgnore() throws Exception {
+    Handle handle = mockHandle();
+    stubTableExists(handle, "task_entity");
+    Update mockUpdate = mock(Update.class, RETURNS_DEEP_STUBS);
+    when(handle.createUpdate(anyString())).thenReturn(mockUpdate);
+    when(mockUpdate.execute()).thenReturn(0);
+
+    new MigrationUtil(handle, ConnectionType.MYSQL).migrateTaskDomains();
+
+    ArgumentCaptor<String> sqlCaptor = ArgumentCaptor.forClass(String.class);
+    verify(handle, times(1)).createUpdate(sqlCaptor.capture());
+    assertTrue(sqlCaptor.getValue().contains("INSERT IGNORE"));
+  }
+
+  @Test
+  void taskEntity_postgresSqlUsesBareOnConflictDoNothing() throws Exception {
+    Handle handle = mockHandle();
+    stubTableExists(handle, "task_entity");
+    Update mockUpdate = mock(Update.class, RETURNS_DEEP_STUBS);
+    when(handle.createUpdate(anyString())).thenReturn(mockUpdate);
+    when(mockUpdate.execute()).thenReturn(0);
+
+    new MigrationUtil(handle, ConnectionType.POSTGRES).migrateTaskDomains();
+
+    ArgumentCaptor<String> sqlCaptor = ArgumentCaptor.forClass(String.class);
+    verify(handle, times(1)).createUpdate(sqlCaptor.capture());
+    String sql = sqlCaptor.getValue();
+    assertTrue(sql.contains("ON CONFLICT DO NOTHING"));
+    // Must NOT name a conflict target — the entity_relationship PK shape differs
+    // across releases (3 cols on 1.12.x, 4 cols on 2.x). Bare ON CONFLICT applies
+    // to any unique constraint, keeping the migration portable.
+    assertFalse(sql.contains("ON CONFLICT ("));
+  }
+
+  @Test
+  void taskEntity_mysqlSqlFiltersOutDeletedRelationships() throws Exception {
+    Handle handle = mockHandle();
+    stubTableExists(handle, "task_entity");
+    Update mockUpdate = mock(Update.class, RETURNS_DEEP_STUBS);
+    when(handle.createUpdate(anyString())).thenReturn(mockUpdate);
+    when(mockUpdate.execute()).thenReturn(0);
+
+    new MigrationUtil(handle, ConnectionType.MYSQL).migrateTaskDomains();
+
+    ArgumentCaptor<String> sqlCaptor = ArgumentCaptor.forClass(String.class);
+    verify(handle, times(1)).createUpdate(sqlCaptor.capture());
+    String sql = sqlCaptor.getValue();
+    assertTrue(sql.contains("er_about.deleted = FALSE"));
+    assertTrue(sql.contains("er_domain.deleted = FALSE"));
+    assertTrue(sql.contains("ex.deleted = FALSE"));
+  }
+
+  @Test
+  void taskEntity_postgresSqlFiltersOutDeletedRelationships() throws Exception {
+    Handle handle = mockHandle();
+    stubTableExists(handle, "task_entity");
+    Update mockUpdate = mock(Update.class, RETURNS_DEEP_STUBS);
+    when(handle.createUpdate(anyString())).thenReturn(mockUpdate);
+    when(mockUpdate.execute()).thenReturn(0);
+
+    new MigrationUtil(handle, ConnectionType.POSTGRES).migrateTaskDomains();
+
+    ArgumentCaptor<String> sqlCaptor = ArgumentCaptor.forClass(String.class);
+    verify(handle, times(1)).createUpdate(sqlCaptor.capture());
+    String sql = sqlCaptor.getValue();
+    assertTrue(sql.contains("er_about.deleted = FALSE"));
+    assertTrue(sql.contains("er_domain.deleted = FALSE"));
+    assertTrue(sql.contains("ex.deleted = FALSE"));
+  }
+}

--- a/openmetadata-service/src/test/java/org/openmetadata/service/migration/utils/v1129/MigrationUtilTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/migration/utils/v1129/MigrationUtilTest.java
@@ -95,7 +95,7 @@ class MigrationUtilTest {
   }
 
   @Test
-  void threadEntity_mysqlWhereClauseUsesJsonExtract() throws Exception {
+  void threadEntity_mysqlWhereClauseMatchesMissingAndJsonNull() throws Exception {
     Handle handle = mockHandle();
     stubTableExists(handle, "thread_entity");
     stubBatch(handle, Collections.emptyList());
@@ -104,14 +104,21 @@ class MigrationUtilTest {
 
     ArgumentCaptor<String> sqlCaptor = ArgumentCaptor.forClass(String.class);
     verify(handle, atLeastOnce()).createQuery(sqlCaptor.capture());
-    // stubBatch setup also triggers createQuery; filter to find the real migration SQL
+    // Both cases must be checked: key missing (SQL NULL) AND JSON null
+    // (JSON_TYPE returns 'NULL' for JSON null, not SQL NULL).
     assertTrue(
         sqlCaptor.getAllValues().stream()
             .anyMatch(s -> s != null && s.contains("JSON_EXTRACT(json, '$.domains') IS NULL")));
+    assertTrue(
+        sqlCaptor.getAllValues().stream()
+            .anyMatch(
+                s ->
+                    s != null
+                        && s.contains("JSON_TYPE(JSON_EXTRACT(json, '$.domains')) = 'NULL'")));
   }
 
   @Test
-  void threadEntity_postgresWhereClauseUsesJsonArrowOperator() throws Exception {
+  void threadEntity_postgresWhereClauseMatchesMissingAndJsonNull() throws Exception {
     Handle handle = mockHandle();
     stubTableExists(handle, "thread_entity");
     stubBatch(handle, Collections.emptyList());
@@ -123,6 +130,9 @@ class MigrationUtilTest {
     assertTrue(
         sqlCaptor.getAllValues().stream()
             .anyMatch(s -> s != null && s.contains("json->'domains' IS NULL")));
+    assertTrue(
+        sqlCaptor.getAllValues().stream()
+            .anyMatch(s -> s != null && s.contains("jsonb_typeof(json->'domains') = 'null'")));
   }
 
   @Test


### PR DESCRIPTION
## Summary

Ports the task-domain backfill from PR #28286 (1.12.9) onto the 1.13 release branch. Same `v1129` version is used across 1.12.9 / 1.13 / main so force-migrate on existing 1.13 deployments re-runs the upgraded v1129 to pick up the new task-backfill step on top of the existing policy migrations.

### 1. v1129 migration: task-domain backfill

`MigrationUtil` (v1129) now runs `migrateTaskDomains()` alongside the existing policy migrations.

- **`thread_entity` path (1.13.x):** batches rows where `JSON_EXTRACT(json,'$.domains') IS NULL` / `json->'domains' IS NULL`, resolves domains from the linked entity via `MessageParser.EntityLink`, and patches `$.domains` via `JSON_SET` / `jsonb_set`. Caches `(entityType, entityFQN) -> domainIds` so each unique target entity is resolved only once.
- **`task_entity` path:** guarded by `tableExists()` so it is a no-op on this release line.
- **Loop-termination guard:** any row whose target entity can't be resolved is marked migrated with `$.domains = []` (and counted in `markedDoneOnError`) so the batch always advances.
- **Stall detector:** if a non-empty batch produces zero updates, the loop aborts with an ERROR log.

### 2. Migration runners: non-fatal policy + task backfill

`mysql/v1129/Migration.java` and `postgres/v1129/Migration.java` wrap policy migrations and the task-domain backfill in **separate** try/catch blocks so a failure in either step no longer blocks server startup. `@SneakyThrows` was removed.

### 3. CreateApprovalTaskImpl: stamp domains at creation

`CreateApprovalTaskImpl` now sets `Thread.domains` from `entity.getDomains()` (mapped to UUIDs) at thread-creation time, so newly-created approval tasks carry the correct domain inline.

## Test plan

- [x] `MigrationUtilTest` (v1129) — 17 unit tests covering both DB dialects, `deleted = FALSE` filters, JSON-NULL WHERE-clause shape, loop termination, malformed-JSON-marked-migrated, empty-batch termination, INSERT IGNORE vs bare ON CONFLICT DO NOTHING, full-batch loop continuation. All passing.
- [ ] Existing 1.13 install with domain-tagged entities that have open approval tasks → run force-migrate → confirm domain-scoped users see those tasks in the activity feed.
- [ ] Customer upgrading 1.12.7 → 1.13 directly → v1129 runs fresh → tasks get `$.domains` backfilled.
- [ ] New approval task creation on 1.13 → confirm `Thread.domains` is set to the entity's domains in the persisted row (no future backfill needed for new rows).

Related: PR #28286 (1.12.9), PR #28013 (main).