### PR TITLE
fix(apps): apply YAML-declared appSchedule when installed App has none

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/apps/ApplicationHandler.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/apps/ApplicationHandler.java
@@ -84,6 +84,14 @@ public class ApplicationHandler {
           && appPrivateConfig.getParameters().getAdditionalProperties() != null) {
         app.setPrivateConfiguration(appPrivateConfig.getParameters().getAdditionalProperties());
       }
+      // Apply the YAML-declared schedule only when the persisted App has none, so an
+      // admin-configured schedule via the UI/API is never clobbered. Without this, the
+      // schedule: block in applications/<AppName>/config.yaml parses into AppPrivateConfig
+      // but is dropped — leaving installed apps with appSchedule=null unscheduled even
+      // when their config.yaml ships a default cron.
+      if (app.getAppSchedule() == null && appPrivateConfig.getSchedule() != null) {
+        app.setAppSchedule(appPrivateConfig.getSchedule());
+      }
     } catch (IOException e) {
       LOG.debug("Config file for app {} not found: ", app.getName(), e);
     } catch (ConfigurationException e) {


### PR DESCRIPTION
## Summary

`ApplicationHandler.setAppRuntimeProperties` reads `AppPrivateConfig` from `applications/<AppName>/config.yaml` but applies only `enabled` and `parameters` to the App entity — `AppPrivateConfig.schedule` is parsed and then dropped. Any default cron declared in `config.yaml` is dead weight.

This bit a Collate app (`TelemetryApplication`) whose `config.yaml` declares a daily 1 AM UTC cron with an env-var override:

```yaml
schedule:
  cronExpression: ${TELEMETRY_SCHEDULE_CRON_EXPRESSION:-0 1 * * *}
  scheduleTimeline: Custom
```

…but `AbstractNativeApplication.install()` bails out when `app.getAppSchedule() == null` and the Quartz trigger never gets created. Customer-visible symptom: silently empty telemetry table with no UI schedule and no logs.

## Change

Apply the YAML schedule only when the persisted App has none:

```java
if (app.getAppSchedule() == null && appPrivateConfig.getSchedule() != null) {
  app.setAppSchedule(appPrivateConfig.getSchedule());
}
```

- **Admin-configured cron is preserved** — the `getAppSchedule() == null` guard means a schedule set via UI/API always wins.
- Runs in `runAppInit` before `install()` / `scheduleInternal()`, so the existing scheduler path picks up the YAML value transparently. No scheduler logic changes.
- The value isn't persisted back to `installed_apps` — matching the existing pattern where `setAppRuntimeProperties` only mutates in-memory runtime state. `install()` registers the Quartz trigger from the in-memory value on every restart, so the YAML default is **self-healing** if `installed_apps.json.appSchedule` is ever wiped again.

## Why this matters beyond TelemetryApplication

Any future native app whose `config.yaml` declares a default `schedule:` gets it for free. Today only TelemetryApplication ships one (the field exists in the `AppPrivateConfig` JSON schema but is unused elsewhere), so the change is low-blast-radius — but it unblocks shipping a default cron via YAML the same way `enabled` and `parameters` are.

## Test plan

- [ ] Server starts, `setAppRuntimeProperties` applies `TelemetryApplication`'s YAML schedule, Quartz trigger registered, daily cron visible in UI Schedule tab
- [ ] If `installed_apps.json.appSchedule` is already set (admin-configured), restart does NOT overwrite it
- [ ] Apps without a `schedule:` block in their `config.yaml` see no behavior change (`appPrivateConfig.getSchedule()` is null → guard skips)
- [ ] Apps without a `config.yaml` at all: `IOException` caught at line 88, no behavior change