### PR TITLE
fix(e2e): wait for Resolved incident to be ES-indexed before DQ tab assertion

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DataQuality/DataQualityDashboard.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DataQuality/DataQualityDashboard.spec.ts
@@ -360,6 +360,7 @@ test.describe(
         uniquenessFailTs
       );
 
+      const resolveTs = getCurrentMillis();
       await apiContext.post(
         '/api/v1/dataQuality/testCases/testCaseIncidentStatus',
         {
@@ -368,6 +369,13 @@ test.describe(
             testCaseResolutionStatusType: 'Resolved',
           },
         }
+      );
+
+      await waitForIncidentToBeIndexed(
+        apiContext,
+        uniquenessTestCaseFqn,
+        resolveTs,
+        'Resolved'
       );
 
       await afterAction();

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/dataQuality.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/dataQuality.ts
@@ -462,11 +462,14 @@ export async function applyDashboardTagFilter(
  * within the [failTs-60s, failTs+120s] window.
  * Call this immediately after `addTestCaseResult` to guarantee the incident
  * document is indexed before any UI assertions.
+ * Pass `expectedStatus` to also wait until the incident reaches that resolution
+ * status (e.g. "Resolved") — useful after posting a status transition.
  */
 export async function waitForIncidentToBeIndexed(
   apiContext: APIRequestContext,
   testCaseFqn: string,
-  failTs: number
+  failTs: number,
+  expectedStatus?: string
 ): Promise<void> {
   await expect
     .poll(
@@ -478,9 +481,21 @@ export async function waitForIncidentToBeIndexed(
         );
         const body = await res.json();
 
-        return (body.data ?? []).some(
-          (i: { testCaseReference?: { fullyQualifiedName?: string } }) =>
-            i.testCaseReference?.fullyQualifiedName === testCaseFqn
+        return (
+          body.data ?? []
+        ).some(
+          (i: {
+            testCaseReference?: { fullyQualifiedName?: string };
+            testCaseResolutionStatusType?: string;
+          }) => {
+            if (i.testCaseReference?.fullyQualifiedName !== testCaseFqn) {
+              return false;
+            }
+
+            return expectedStatus
+              ? i.testCaseResolutionStatusType === expectedStatus
+              : true;
+          }
         );
       },
       { timeout: 60_000, intervals: [1_000, 2_000, 5_000] }

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/dataQuality.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/dataQuality.ts
@@ -481,9 +481,7 @@ export async function waitForIncidentToBeIndexed(
         );
         const body = await res.json();
 
-        return (
-          body.data ?? []
-        ).some(
+        return (body.data ?? []).some(
           (i: {
             testCaseReference?: { fullyQualifiedName?: string };
             testCaseResolutionStatusType?: string;


### PR DESCRIPTION
## Problem

`DataQualityDashboard.spec.ts:691` asserted that the uniqueness test-case incident status was `Resolved`, but the locator consistently showed `New`.

**Root cause:** After POSTing `Resolved` to `/api/v1/dataQuality/testCases/testCaseIncidentStatus`, the `beforeAll` hook called `afterAction()` immediately — with no wait for Elasticsearch to index the resolution document. The test then navigated to the DQ tab and lost the race against the indexer.

## Fix

**`playwright/utils/dataQuality.ts`**
- Extended `waitForIncidentToBeIndexed` with an optional `expectedStatus` parameter.
- When provided, the poll predicate also checks `testCaseResolutionStatusType === expectedStatus`, blocking until both the FQN match and the desired status are visible in the API.

**`DataQualityDashboard.spec.ts`** (beforeAll)
- Capture `resolveTs = getCurrentMillis()` before the POST.
- After posting `Resolved`, call `waitForIncidentToBeIndexed(apiContext, uniquenessTestCaseFqn, resolveTs, 'Resolved')` to guarantee the status is indexed before releasing the browser context.

## Test plan

- [ ] Run `DataQualityDashboard.spec.ts › DataQualityDashboardTab` — the `Verify Resolved incident` step should now pass consistently.
- [ ] Existing callers of `waitForIncidentToBeIndexed` without `expectedStatus` are unaffected (parameter is optional, behaviour identical when omitted).

🤖 Generated with [Claude Code](https://claude.com/claude-code)