### PR TITLE
fix(table,dataModel): persist inline column.extension from POST/PUT-create

### DIFF
--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/ColumnCustomPropertiesIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/ColumnCustomPropertiesIT.java
@@ -129,6 +129,158 @@ public class ColumnCustomPropertiesIT {
   }
 
   @Test
+  void test_tableColumn_inlineExtensionInCreatePersists(TestNamespace ns) throws Exception {
+    String propName = ns.prefix("inlineCreateProp");
+    OpenMetadataClient client = SdkClients.adminClient();
+
+    try {
+      addCustomPropertyToColumnType(client, TABLE_COLUMN, propName, STRING_TYPE, null);
+
+      DatabaseService service = DatabaseServiceTestFactory.createPostgres(ns);
+      DatabaseSchema schema = DatabaseSchemaTestFactory.createSimple(ns, service);
+
+      Map<String, Object> idExtension = new HashMap<>();
+      idExtension.put(propName, "inline-on-create-id");
+      Map<String, Object> nameExtension = new HashMap<>();
+      nameExtension.put(propName, "inline-on-create-name");
+
+      Column idColumn =
+          new Column()
+              .withName("id")
+              .withDataType(ColumnDataType.BIGINT)
+              .withExtension(idExtension);
+      Column nameColumn =
+          new Column()
+              .withName("name")
+              .withDataType(ColumnDataType.VARCHAR)
+              .withDataLength(255)
+              .withExtension(nameExtension);
+
+      org.openmetadata.schema.api.data.CreateTable create =
+          new org.openmetadata.schema.api.data.CreateTable()
+              .withName(ns.prefix("inlineCpTable"))
+              .withDatabaseSchema(schema.getFullyQualifiedName())
+              .withColumns(List.of(idColumn, nameColumn));
+      Table created = client.tables().create(create);
+
+      Table reloaded = client.tables().get(created.getId().toString(), "columns,extension");
+      assertNotNull(reloaded.getColumns());
+      assertEquals(2, reloaded.getColumns().size());
+      for (Column c : reloaded.getColumns()) {
+        assertNotNull(
+            c.getExtension(),
+            "column " + c.getName() + " lost its inline extension on POST/PUT-create");
+        @SuppressWarnings("unchecked")
+        Map<String, Object> ext = (Map<String, Object>) c.getExtension();
+        if ("id".equals(c.getName())) {
+          assertEquals("inline-on-create-id", ext.get(propName));
+        } else if ("name".equals(c.getName())) {
+          assertEquals("inline-on-create-name", ext.get(propName));
+        }
+      }
+    } finally {
+      deleteCustomPropertyFromColumnType(client, TABLE_COLUMN, propName);
+    }
+  }
+
+  @Test
+  void test_dashboardColumn_inlineExtensionInCreatePersists(TestNamespace ns) throws Exception {
+    String propName = ns.prefix("inlineDashCreateProp");
+    OpenMetadataClient client = SdkClients.adminClient();
+
+    try {
+      addCustomPropertyToColumnType(
+          client, DASHBOARD_DATA_MODEL_COLUMN, propName, STRING_TYPE, null);
+
+      DashboardService service = DashboardServiceTestFactory.createLooker(ns);
+
+      Map<String, Object> metric1Ext = new HashMap<>();
+      metric1Ext.put(propName, "inline-dash-metric");
+
+      List<Column> columns =
+          Arrays.asList(
+              new Column()
+                  .withName("metric1")
+                  .withDataType(ColumnDataType.BIGINT)
+                  .withExtension(metric1Ext),
+              new Column()
+                  .withName("dimension1")
+                  .withDataType(ColumnDataType.VARCHAR)
+                  .withDataLength(256));
+
+      CreateDashboardDataModel request =
+          new CreateDashboardDataModel()
+              .withName(ns.prefix("inlineCpDataModel"))
+              .withService(service.getFullyQualifiedName())
+              .withDataModelType(DataModelType.LookMlView)
+              .withColumns(columns);
+      DashboardDataModel created = client.dashboardDataModels().create(request);
+
+      DashboardDataModel reloaded =
+          client.dashboardDataModels().get(created.getId().toString(), "columns,extension");
+      Column metric1 =
+          reloaded.getColumns().stream()
+              .filter(c -> "metric1".equals(c.getName()))
+              .findFirst()
+              .orElseThrow();
+      assertNotNull(
+          metric1.getExtension(),
+          "dashboardDataModel column metric1 lost its inline extension on POST");
+      @SuppressWarnings("unchecked")
+      Map<String, Object> ext = (Map<String, Object>) metric1.getExtension();
+      assertEquals("inline-dash-metric", ext.get(propName));
+    } finally {
+      deleteCustomPropertyFromColumnType(client, DASHBOARD_DATA_MODEL_COLUMN, propName);
+    }
+  }
+
+  @Test
+  void test_tableColumn_inlineExtensionOnPutAddedColumnPersists(TestNamespace ns) throws Exception {
+    String propName = ns.prefix("addedColProp");
+    OpenMetadataClient client = SdkClients.adminClient();
+
+    try {
+      addCustomPropertyToColumnType(client, TABLE_COLUMN, propName, STRING_TYPE, null);
+
+      DatabaseService service = DatabaseServiceTestFactory.createPostgres(ns);
+      DatabaseSchema schema = DatabaseSchemaTestFactory.createSimple(ns, service);
+
+      Column idColumn = new Column().withName("id").withDataType(ColumnDataType.BIGINT);
+      org.openmetadata.schema.api.data.CreateTable create =
+          new org.openmetadata.schema.api.data.CreateTable()
+              .withName(ns.prefix("putAddedColTable"))
+              .withDatabaseSchema(schema.getFullyQualifiedName())
+              .withColumns(List.of(idColumn));
+      Table created = client.tables().create(create);
+
+      Map<String, Object> nameExtension = new HashMap<>();
+      nameExtension.put(propName, "added-via-put");
+      Column addedColumn =
+          new Column()
+              .withName("name")
+              .withDataType(ColumnDataType.VARCHAR)
+              .withDataLength(255)
+              .withExtension(nameExtension);
+      created.setColumns(List.of(idColumn, addedColumn));
+      client.tables().update(created.getId().toString(), created);
+
+      Table reloaded = client.tables().get(created.getId().toString(), "columns,extension");
+      Column nameAfter =
+          reloaded.getColumns().stream()
+              .filter(c -> "name".equals(c.getName()))
+              .findFirst()
+              .orElseThrow();
+      assertNotNull(
+          nameAfter.getExtension(), "newly-added column lost its inline extension on PUT-update");
+      @SuppressWarnings("unchecked")
+      Map<String, Object> ext = (Map<String, Object>) nameAfter.getExtension();
+      assertEquals("added-via-put", ext.get(propName));
+    } finally {
+      deleteCustomPropertyFromColumnType(client, TABLE_COLUMN, propName);
+    }
+  }
+
+  @Test
   void test_dashboardColumn_stringCustomProperty(TestNamespace ns) throws Exception {
     String propName = ns.prefix("dashStrProp");
     OpenMetadataClient client = SdkClients.adminClient();

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/DashboardDataModelRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/DashboardDataModelRepository.java
@@ -166,6 +166,11 @@ public class DashboardDataModelRepository extends EntityRepository<DashboardData
   }
 
   @Override
+  protected List<Column> getColumnsForExtensionPersistence(DashboardDataModel entity) {
+    return entity.getColumns();
+  }
+
+  @Override
   protected void clearEntitySpecificRelationshipsForMany(List<DashboardDataModel> entities) {
     if (entities.isEmpty()) return;
     List<UUID> ids = entities.stream().map(DashboardDataModel::getId).toList();

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/EntityRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/EntityRepository.java
@@ -4531,6 +4531,7 @@ public abstract class EntityRepository<T extends EntityInterface> {
     try (var ignored = phase("createStoreEntity")) {
       storeEntity(entity, false);
       storeExtension(entity);
+      storeColumnExtensions(entity.getId(), getColumnsForExtensionPersistence(entity));
     }
     try (var ignored = phase("createStoreRelationships")) {
       storeRelationshipsInternal(entity);
@@ -4982,6 +4983,36 @@ public abstract class EntityRepository<T extends EntityInterface> {
       }
     }
     storeCustomProperties(entityIds, fieldFQNs, jsons);
+  }
+
+  /** Columns whose extensions are persisted on initial create. Default: empty. */
+  protected List<Column> getColumnsForExtensionPersistence(T entity) {
+    return Collections.emptyList();
+  }
+
+  /** Upserts one column's extension. Shared by create and update paths. */
+  protected final void storeColumnExtension(UUID entityId, Column column) {
+    if (entityId == null
+        || column == null
+        || column.getExtension() == null
+        || column.getFullyQualifiedName() == null) {
+      return;
+    }
+    String extensionKey = FullyQualifiedName.buildHash(column.getFullyQualifiedName());
+    daoCollection
+        .entityExtensionDAO()
+        .insert(
+            entityId, extensionKey, "columnExtension", JsonUtils.pojoToJson(column.getExtension()));
+  }
+
+  /** Recursively persists extensions on all columns (and nested children). */
+  protected final void storeColumnExtensions(UUID entityId, List<Column> columns) {
+    if (entityId == null || columns == null || columns.isEmpty()) {
+      return;
+    }
+    for (Column column : EntityUtil.getFlattenedEntityField(columns)) {
+      storeColumnExtension(entityId, column);
+    }
   }
 
   public final void removeExtension(EntityInterface entity) {
@@ -9408,6 +9439,7 @@ public abstract class EntityRepository<T extends EntityInterface> {
         BiPredicate<Column, Column> columnMatch) {
       origColumns = listOrEmpty(origColumns);
       updatedColumns = listOrEmpty(updatedColumns);
+      UUID entityId = updated.getId();
       List<Column> deletedColumns = new ArrayList<>();
       List<Column> addedColumns = new ArrayList<>();
       HashMap<String, String> originalUpdatedColumnFqns = new HashMap<>();
@@ -9434,7 +9466,7 @@ public abstract class EntityRepository<T extends EntityInterface> {
           deleted -> {
             daoCollection.tagUsageDAO().deleteTagsByTarget(deleted.getFullyQualifiedName());
             String extensionKey = FullyQualifiedName.buildHash(deleted.getFullyQualifiedName());
-            daoCollection.entityExtensionDAO().delete(updated.getId(), extensionKey);
+            daoCollection.entityExtensionDAO().delete(entityId, extensionKey);
           });
 
       // Add tags related to newly added columns
@@ -9445,6 +9477,8 @@ public abstract class EntityRepository<T extends EntityInterface> {
                 .toList(),
             added.getFullyQualifiedName());
       }
+      // Added columns are skipped by the existing-column loop below.
+      storeColumnExtensions(entityId, addedColumns);
 
       // Carry forward the user generated metadata from existing columns to new columns
       for (Column updated : updatedColumns) {
@@ -9473,7 +9507,9 @@ public abstract class EntityRepository<T extends EntityInterface> {
             stored.getTags(),
             updated.getTags());
         updateColumnConstraint(columnPrefix, stored, updated);
-        updateColumnExtension(stored, updated);
+        if (!Objects.equals(stored.getExtension(), updated.getExtension())) {
+          storeColumnExtension(entityId, updated);
+        }
 
         if (updated.getChildren() != null && stored.getChildren() != null) {
           updateColumns(columnPrefix, stored.getChildren(), updated.getChildren(), columnMatch);
@@ -9521,19 +9557,6 @@ public abstract class EntityRepository<T extends EntityInterface> {
           EntityUtil.getFieldName(fieldPrefix, "constraint"),
           origColumn.getConstraint(),
           updatedColumn.getConstraint());
-    }
-
-    private void updateColumnExtension(Column origColumn, Column updatedColumn) {
-      if (updatedColumn.getExtension() != null) {
-        String extensionKey = FullyQualifiedName.buildHash(updatedColumn.getFullyQualifiedName());
-        daoCollection
-            .entityExtensionDAO()
-            .insert(
-                updated.getId(),
-                extensionKey,
-                "columnExtension",
-                JsonUtils.pojoToJson(updatedColumn.getExtension()));
-      }
     }
 
     protected void updateColumnDataLength(

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/TableRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/TableRepository.java
@@ -1616,6 +1616,11 @@ public class TableRepository extends EntityRepository<Table> {
   }
 
   @Override
+  protected List<Column> getColumnsForExtensionPersistence(Table entity) {
+    return entity.getColumns();
+  }
+
+  @Override
   protected void clearEntitySpecificRelationshipsForMany(List<Table> entities) {
     if (entities.isEmpty()) return;
     List<UUID> ids = entities.stream().map(Table::getId).toList();


### PR DESCRIPTION
Fixes #28388 

## Summary

POST `/api/v1/tables` (and PUT-as-create) silently drops column-level custom properties when callers inline `extension` inside the `columns` array. The data lands in the table JSON, but every reader — and the PATCH-original reload — looks exclusively in `entity_extension` via `getColumnExtension(entityId, columnFQN)`. With no row there, the column-extension override clobbers the inline value with `null`, leaving the UI's Custom Properties tab blank and causing any JsonPatch op walking `/columns/N/extension/...` on the reloaded original to throw `"contains no mapping for the name 'extension'"`. Same gap on `DashboardDataModelRepository`.

Root cause: `EntityUpdater.updateColumnExtension` is the only writer that puts a column extension into `entity_extension`, and it only runs from `updateColumns` during update operations — never on initial create.

## Fix

**One shared writer for create + update**, lifted out of `EntityUpdater`:

- `EntityRepository.storeColumnExtension(UUID, Column)` — single-column primitive (the body that used to live inside `EntityUpdater.updateColumnExtension`).
- `EntityRepository.storeColumnExtensions(UUID, List<Column>)` — single-entity walker that flattens nested columns via `EntityUtil.getFlattenedEntityField` (same utility column-profile and API-endpoint paths use) and calls the primitive per column.
- `EntityRepository.getColumnsForExtensionPersistence(T)` — overridable hook. `TableRepository` and `DashboardDataModelRepository` override it to return `entity.getColumns()`.

Wired in alongside `storeExtension` in `createNewEntityFlush`. The bulk-create paths (`createManyEntitiesFlush`, `createManyEntitiesForImport`) don't touch column extensions today (CSV import doesn't carry them; `createMany` is only used by Glossary/TestCase which have no columns), so they're left alone — no premature batch helper.

**Update-path simplifications using the same primitive:**

- `updateColumnExtension` (the EntityUpdater-private duplicate) is deleted.
- Existing-column branch now skips the upsert when `Objects.equals(stored.getExtension(), updated.getExtension())` — previously every update rewrote identical JSON for every column with a non-null extension.
- Added-columns branch now persists extensions via the walker. `updateColumns`' main loop skips columns with no `stored` match, so without this fix an inline `column.extension` on a freshly-added column was dropped on PUT-update too.

## Test coverage (`ColumnCustomPropertiesIT`)

- `test_tableColumn_inlineExtensionInCreatePersists` — POST table with inline `column.extension` → assert it survives the round-trip.
- `test_dashboardColumn_inlineExtensionInCreatePersists` — same for dashboard data models.
- `test_tableColumn_inlineExtensionOnPutAddedColumnPersists` — PUT-update that adds a new column with inline extension → assert it persists. Covers the added-columns gap.

Without the fix all three fail with `getExtension() == null`.

## Test plan

- [x] `mvn clean install -DskipTests -pl '!openmetadata-ui,!openmetadata-ui-core-components' -am` clean
- [x] `mvn -pl openmetadata-integration-tests test-compile` clean
- [x] `mvn spotless:apply` clean
- [x] Local repro: POST table with inline `column.extension` → before fix returns `ext: null`; after fix returns the supplied value
- [ ] CI ITs green
- [ ] Backport to 1.12.9 once green on main

## Follow-up (separate PR, main only)

The on-disk shape for column extensions remains per-column blob (one row per column, value = whole `{cp1: ..., cp2: ...}` map, key = MD5-chained hash via `buildHash(columnFQN)`). That asymmetry vs. table-level CPs (per-property row, readable key like `table.customProperties.<propName>`) has two real consequences:

- **Concurrent writes to different CPs on the same column race** — last-write-wins on the whole blob.
- **Any PATCH that touches one CP rewrites all of them** (the diff-skip in this PR helps only when the whole blob is unchanged; touching one CP still triggers a whole-blob upsert).

Migration to per-property storage is tracked separately so this PR can backport cleanly.