### PR TITLE
fix(ingestion): cap kubernetes client below 36.0.0

### DIFF
--- a/ingestion/setup.py
+++ b/ingestion/setup.py
@@ -151,7 +151,7 @@ base_requirements = {
     "importlib-metadata>=4.13.0",  # From airflow constraints
     "Jinja2>=2.11.3",
     "jsonpatch<2.0, >=1.24",
-    "kubernetes>=21.0.0",  # Kubernetes client for secrets manager
+    "kubernetes>=21.0.0,<36",  # 36.0.0 regressed in-cluster auth (https://github.com/kubernetes-client/python/issues/2582)
     "memory-profiler",
     "mypy_extensions>=0.4.3",
     VERSIONS["pydantic"],


### PR DESCRIPTION
## Summary

One-line dependency cap to recover the KubernetesSecretsManager in the hybrid runner. The unbounded `>=21.0.0` pin let the post-2026-05-19 image build pull `kubernetes==36.0.0`, which regressed in-cluster auth.

```diff
- "kubernetes>=21.0.0",  # Kubernetes client for secrets manager
+ "kubernetes>=21.0.0,<36",  # 36.0.0 regressed in-cluster auth (https://github.com/kubernetes-client/python/issues/2582)
```

## Why

`kubernetes==36.0.0` broke the KubernetesSecretsManager:

- `Configuration.auth_settings()` (v36) looks up the bearer token under `api_key['BearerToken']`, but `load_incluster_config()` / `load_kube_config()` still write it to `api_key['authorization']`.
- The mismatch means no `Authorization` header is sent. The API treats the request as `system:anonymous` → **403 Forbidden** when reading the secret, which surfaces to the caller as `password authentication failed`.

### Proof it's the client, not env / RBAC

- `curl` with the same mounted SA token returns **200**.
- `kubernetes==35.0.0` works.
- `kubernetes==36.0.0` doesn't.

### Upstream tracking (open, unfixed)

- https://github.com/kubernetes-client/python/issues/2582 — *load_incluster_config sets api_key['authorization'] but auth_settings expects api_key['BearerToken'] in v36*
- https://github.com/kubernetes-client/python/issues/2584

## Why `<36` and not `!=36.0.0`

`<36` keeps the resolver on the known-good 35.x line and protects against any other 36.x regression discovered before upstream fixes 2582. Once upstream ships a fix, this becomes `!=36.0.0` or a fixed `>=36.x`.

## Test plan

- [x] Diff is the one line shown above
- [ ] CI re-resolves dependencies to a 35.x kubernetes
- [ ] Image build no longer pulls 36.0.0
- [ ] Hybrid runner can read secrets again (verify in staging)