### PR TITLE
fix(e2e): fix 9-min timeout and empty FQN in ObservabilityAlerts

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Flow/ObservabilityAlerts.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Flow/ObservabilityAlerts.spec.ts
@@ -48,12 +48,12 @@ import {
 import { waitForSearchIndexed } from '../../utils/polling';
 import { test as base } from '../fixtures/pages';
 
-const table1 = new TableClass();
-const table2 = new TableClass();
-const pipeline = new PipelineClass();
 const user1 = new UserClass();
 const user2 = new UserClass();
-const domain = new Domain();
+let table1: TableClass;
+let table2: TableClass;
+let pipeline: PipelineClass;
+let domain: Domain;
 
 const SOURCE_NAME_1 = 'container';
 const SOURCE_DISPLAY_NAME_1 = 'Container';
@@ -93,6 +93,10 @@ const data = {
 };
 
 test.beforeAll(async ({ browser }) => {
+  table1 = new TableClass();
+  table2 = new TableClass();
+  pipeline = new PipelineClass();
+  domain = new Domain();
   const { afterAction, apiContext } = await performAdminLogin(browser);
   await commonPrerequisites({
     apiContext,
@@ -183,7 +187,6 @@ test.beforeEach(async ({ page }) => {
 });
 
 test('Pipeline Alert', async ({ page }) => {
-  test.slow();
   const ALERT_NAME = generateAlertName();
 
   await test.step('Create alert', async () => {


### PR DESCRIPTION
## Problem

The `Pipeline Alert` test in `ObservabilityAlerts.spec.ts` ran for ~9 minutes instead of the expected ~3 minutes.

**Root cause 1 — stacked `test.slow()`:**
`Pipeline Alert` called `test.slow()` inside the test body. This stacks multiplicatively with any outer timeout, producing `3 × 60s = 180s` per step and 9+ minutes total. Removed the redundant call.

**Root cause 2 — stale entity FQNs (empty `title` selector):**
`table1`, `table2`, `pipeline`, `domain` were declared as module-level `const` instances constructed at import time. Their `fullyQualifiedName` fields were empty until `beforeAll` called the API. When `getObservabilityCreationDetails` used those values to build filter `inputValue`, it passed an empty string, causing `[title=""]` selectors to never match → timeout → page closed.

Moved all entity declarations to `let` and instantiated them at the top of `beforeAll` so they always reflect actual API responses.

## Changes

- `playwright/e2e/Flow/ObservabilityAlerts.spec.ts`
  - Remove `test.slow()` from `Pipeline Alert`
  - Convert `const table1/table2/pipeline/domain` to `let`, initialise inside `beforeAll`

## Test plan

- [ ] `Pipeline Alert` completes in under 3 minutes
- [ ] `Ingestion Pipeline alert` no longer fails with empty `[title=""]` selector
- [ ] All other observability alert tests unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

----
## Summary by Gitar

- **E2E Test Fixes:**
  - Adjusted `performTestCaseExport` to initialize `downloadPromise` before the trigger action to resolve potential race conditions.

<sub>This will update automatically on new commits.</sub>