### PR TITLE
fix(logging): port non-blocking handler + sync shutdown + diagnostics to 1.13

### DIFF
--- a/ingestion/docs/design/ingestion-diagnostics.md
+++ b/ingestion/docs/design/ingestion-diagnostics.md
@@ -1,0 +1,483 @@
+# Ingestion Runtime Diagnostics
+
+**Status:** Proposed
+**Author:** Sriharsha Chintalapani
+**Date:** 2026-05-15
+
+---
+
+## TL;DR
+
+OpenMetadata ingestion processes fail in production in two main ways: they **hang** (often silently) and they **OOM**. Today we have no built-in way to answer "what was it doing right before it died?", so we ship fixes based on hypotheses and hope. This doc proposes a small, always-available diagnostics subsystem inside the ingestion framework that — when an operator enables DEBUG logging on the workflow — captures enough runtime state (current operation, in-flight HTTP, memory growth, stage backpressure) that the root cause is in the logs every time. The cost when off: zero. The cost when on: ~500 KB and < 0.01% CPU.
+
+The doc is organized so each component below can ship as an independent PR.
+
+---
+
+## 1. Why we need this — case studies from production
+
+### Case study 1: the "Snowflake hang" that was actually a logging recursion
+
+**Symptom (2026-05).** Snowflake ingestion pods on a customer cluster were hanging indefinitely. From outside the pod:
+- `kubectl logs` returned nothing recent.
+- The OpenMetadata server saw no incoming requests from the connector.
+- No queries appeared in Snowflake `QUERY_HISTORY` for the stuck window.
+- The pod's CPU was pegged.
+
+**Hypothesis-driven fixes that did not help.**
+1. **"HTTP pool is stale, no timeouts."** Shipped PR #28131 to add request timeouts. Hang recurred.
+2. **"Snowflake driver hang."** Considered OCSP, chunk-download, network. Could not falsify without data.
+3. **"Server-side backpressure."** Plausible — but `kubectl logs` showed no inbound requests on the server, so the connector wasn't even reaching it.
+
+**What it actually was.** A py-spy dump (which itself required `kubectl debug --profile=sysadmin` with `SYS_PTRACE` — a 30-minute setup) revealed MainThread sitting **~977 frames deep** in `StreamableLogHandler.emit()`, alternating between `logger.warning("queue is full")` and `logger.error("error in emit")`. The handler was attached to the same logger it was calling, creating infinite recursion as soon as the bounded log queue filled. Every other thread — including the log-shipper itself — was blocked on the Python `logging` module's per-handler `RLock` held by MainThread. No HTTP request was in flight. No timeout could have helped.
+
+**The fix:** route in-handler diagnostics through a separate non-propagating logger (PR #28160).
+
+**Time to root cause:** ~6 hours of investigation, plus one shipped fix that addressed an entirely different theory.
+**Time it should have taken:** seconds, if the process had logged "MainThread stuck for 312 s in `streamable_logger.emit`" on its own.
+
+### Case study 2: connector OOMs without a clear cause
+
+**Symptom (ongoing).** Several connectors — Snowflake, Postgres on large databases, S3-based connectors — die with OOMKill on Kubernetes. The pod restarts. The next run sometimes succeeds, sometimes OOMs again.
+
+**Why we cannot diagnose today.** When the OOMKill fires:
+- We get an exit code (137), no Python traceback, no last-state log.
+- We have no idea which stage was running.
+- We have no idea what type of object was occupying memory.
+- We have no idea whether memory was growing slowly (leak) or spiked at a specific entity (one bad row).
+
+**Suspected contributors, none confirmed.**
+- Entity backlog: when one stage stalls, upstream stages keep producing and accumulate Pydantic entity objects.
+- PyArrow `ResultBatch` objects held by reference longer than necessary.
+- Unbounded internal caches in connector base classes (lineage cache, schema cache).
+- Log queue with very large entries (multi-MB stack traces, formatted entity dumps).
+- HTTP request bodies buffered for shipping batches.
+
+Each of these is a plausible OOM source. Without per-stage memory growth tracking + a snapshot at OOM time, every fix is a guess. We have already shipped PRs to one or two of these on the suspicion that they were "the" cause.
+
+### Case study 3: silent slowness (no logs for hours)
+
+**Symptom.** Long-running ingestion (DBT, lineage) shows no progress in logs for hours, then either completes or is killed by the workflow timeout. Customer asks: "is it stuck, or just slow?"
+
+**Today:** we cannot answer. We tell them to wait, or kill and rerun.
+
+**What we need:** every 30 seconds, a single structured log line saying *exactly* what entity is being processed and how long has been spent on it. The customer (and we) instantly know "it's making progress, table 4732 of 9000" vs "it hasn't moved in 4 hours, kill it."
+
+---
+
+## 2. The principle: stop guessing, start measuring
+
+These cases share a single root cause: **we ask the process to fail silently, then try to reconstruct what happened after the fact.** The instrumentation we keep needing is the same every time:
+
+- What thread was doing what, just before the failure?
+- Was memory growing? At what rate? On which stage?
+- What HTTP requests were in flight?
+- What was the queue depth between stages?
+- What was the last entity successfully yielded by the source / written by the sink?
+
+This information is **cheap to capture** if we capture it as the process runs, instead of trying to recover it from a dead pod. The cost of always-on capture is tiny; the cost of ad-hoc post-mortem debugging is enormous. This doc designs the always-on capture layer.
+
+---
+
+## 3. Scope
+
+### Goals
+
+- Every ingestion process running with `loggerLevel == DEBUG` produces a continuous, low-volume stream of structured diagnostic output (heartbeats, watchdog warnings) and supports on-demand dumps (signal-triggered).
+- The dump from a hung or about-to-OOM process is enough to identify the **stage**, **entity**, **operation**, **HTTP request**, **memory consumer**, and **stack** involved.
+- All of this works with no external tooling: no `py-spy`, no `kubectl debug`, no `ptrace`. The information is in `kubectl logs`.
+- Zero overhead when off. Single existing knob (`loggerLevel`).
+
+### Non-goals
+
+- A general-purpose APM/metrics system.
+- Profiling for throughput optimization.
+- Replacing the existing workflow status counters.
+- Adding any new ingestion config field or env var.
+- Catching every possible failure. We optimize for the common failure modes seen in production (hangs, OOMs, slowness).
+
+### What this is NOT
+
+This is not a substitute for fixing bugs. The point is to **identify which bug to fix**. After this lands, when a customer reports a hang or OOM, we expect:
+1. Look at `kubectl logs`.
+2. Identify the operation/entity/memory pattern.
+3. Open a focused bug fix.
+
+…instead of "let's try adding timeouts and see if it helps."
+
+---
+
+## 4. Activation
+
+Single knob: `workflowConfig.loggerLevel`.
+
+| `loggerLevel` | Diagnostics module behavior |
+|---|---|
+| `DEBUG` | Fully installed: signals, watchdog, heartbeat, memory tracker, HTTP introspection. Output to stderr + structured logs. |
+| `INFO` (or anything else) | Module is dead code. `operation()` is a no-op `contextmanager`. No threads. No signal handlers. Memory cost ≈ 0. |
+
+We deliberately avoid new env vars or new config fields. Diagnostic toggle reuses an existing UI-controllable setting.
+
+Trade-off: **first occurrence of a non-reproducing hang on INFO is undiagnosed.** Mitigation: flip log level → re-run → captured. One cycle on first occurrence, never afterward. Worth it to keep production runs strictly free of overhead.
+
+---
+
+## 5. Architecture
+
+Five components, all under `metadata/ingestion/diagnostics/`. A single `diagnostics.install(workflow)` call in `BaseWorkflow.execute()` activates everything when `loggerLevel == DEBUG`.
+
+### 5.1 Operation registry (`registry.py`)
+
+Per-thread stack of "what am I doing right now":
+
+```python
+from metadata.ingestion.diagnostics import operation
+
+with operation("source.iter", entity_fqn=fqn):
+    with operation("snowflake.query", sql=stmt[:500], query_id=qid):
+        cursor.execute(stmt)
+    with operation("sink.write", entity_type="table"):
+        ometa.create_or_update(table)
+```
+
+State: `{thread_id: [(name, kwargs, started_monotonic), ...]}`.
+
+The registry exposes `snapshot()` which, for each live thread, returns the stack with per-frame durations. This is the ground truth used by every other component (heartbeat, watchdog, signal dump).
+
+**Properties:**
+- Thread-safe via a single fine-grained lock.
+- O(1) push/pop per `operation()` enter/exit.
+- Kwargs are truncated to 2000 chars at registration (a 10 MB DDL string would stay referenced otherwise).
+- Stack depth capped at 20 to guard against runaway nesting.
+- The watchdog garbage-collects entries for dead `thread.ident`s on each tick.
+
+**Cost:** ~1 µs per enter/exit; ~15 KB at peak.
+
+### 5.2 Signal handlers (`signals.py`)
+
+On install, registers `SIGUSR1` and `SIGUSR2` plus `faulthandler.register`. On signal:
+
+| Signal | What gets dumped |
+|---|---|
+| `SIGUSR1` | Full: `faulthandler.dump_traceback(all_threads=True)` + operation registry snapshot + in-flight HTTP requests + memory state + workflow status |
+| `SIGUSR2` | Incremental: registry + HTTP + memory only. Cheap. For periodic polling. |
+
+Operator workflow when something looks stuck:
+```bash
+kubectl exec <pod> -- bash -c 'pkill -SIGUSR1 -f "python.*main.py"'
+kubectl logs <pod> --tail=500
+```
+
+No `py-spy`, no `kubectl debug`, no `ptrace`. Works on any pod, any cluster, any time.
+
+`faulthandler` is stdlib; it captures both Python and native (C extension) frames, runs from a signal handler safely, and writes synchronously.
+
+### 5.3 Watchdog (`watchdog.py`)
+
+A daemon thread that wakes every 10 s. For each live thread:
+- Look up the deepest active operation in the registry.
+- If it has been on the same operation for **> 60 s** → log a structured warning line.
+- If it has been on the same operation for **> 300 s** → trigger a full `SIGUSR1`-style dump.
+
+Re-dump throttle: at most one full dump per `(thread, operation_name)` per 5 minutes.
+
+This is the behavioral change that changes everything: **the process logs its own hangs**. No human has to be watching the pod for the data to be captured.
+
+### 5.4 Heartbeat (`heartbeat.py`)
+
+A daemon thread that emits one structured log line every 30 s while the workflow is running:
+
+```
+diag.heartbeat stage=source step=table progress=4732/9000 current_op=source.iter
+  current_fqn=svc.db.schema.table4732 current_op_age=8s rss=412M rss_delta_30s=+2.1M
+  threads=8 active_http=1 queue_source_to_sink=240/1000
+```
+
+This single line answers, for the operator looking at `kubectl logs`:
+- Am I making progress? (compare two heartbeats)
+- What stage am I on?
+- What entity am I currently processing?
+- Is memory growing? At what rate?
+- Is one stage backed up behind another?
+
+Output cadence is tunable as a constant; 30 s is a sensible default for ingestion that typically runs minutes to hours.
+
+### 5.5 HTTP introspection (`http_introspect.py`)
+
+Wraps the two HTTP surfaces we own:
+
+| Surface | Wrap point | What we record |
+|---|---|---|
+| `OMetaClient` | `REST._request()` | method, URL, started_at, request_id in an active-requests dict, plus an `operation("ometa.http", ...)` registry entry |
+| Snowflake (and other DB connectors) | `cursor.execute()` | SQL (truncated), query_id, started_at, plus an `operation("snowflake.query", ...)` registry entry |
+
+Active-requests dict is keyed by `(thread_id, request_id)`, entries removed in `finally`. On dump, rendered as a table:
+
+```
+diag.dump.http
+  thread=log-shipper-xyz method=POST url=/api/v1/.../logs age=37s
+  thread=MainThread       method=PUT  url=/api/v1/tables    age=2s
+```
+
+For surfaces we don't own (Snowflake's OCSP validator, chunk downloader), we rely on the `faulthandler` thread dump (native + Python frames) to identify the hang location. Those frames have characteristic library paths that are easy to recognize.
+
+### 5.6 Memory tracker (`memory.py`) — NEW, motivated by case study 2
+
+A daemon thread that samples memory every 30 s and maintains a small ring buffer (last ~10 samples). It records:
+
+| Metric | Source |
+|---|---|
+| `rss` | `psutil.Process().memory_info().rss` |
+| `rss_growth_per_sec` | derivative over the ring buffer |
+| `cgroup_current` / `cgroup_max` | `/sys/fs/cgroup/memory.{current,max}` |
+| `cgroup_oom_kill_count` | `/sys/fs/cgroup/memory.events` `oom_kill` field |
+| `gc_collections` | `gc.get_stats()` per generation |
+| `top_object_types` | `gc.get_objects()` aggregated by `type(obj).__name__`, top 10 by count |
+
+On heartbeat, only `rss` and `rss_delta_30s` are emitted. On full dump (SIGUSR1 or watchdog auto-dump), all of the above are emitted including the top-10 object types.
+
+The "top object types" is the OOM debugging breakthrough. Today we can't see which objects are growing. With `gc.get_objects()` aggregated into a Counter, a dump from a process that's growing toward OOM looks like:
+
+```
+diag.dump.memory
+  rss=2841M rss_delta_30s=+45M cgroup=2841M/3072M oom_kills=0
+  gc_gen0=23 gc_gen1=4 gc_gen2=1
+  top_types:
+    Table              182341
+    Column             1843219
+    Tag                94823
+    LineageEdge        451233
+    PyArrowResultBatch 47
+    SnowflakeResultBatch 12
+```
+
+Now we know exactly what's accumulating. If `Table` is in the hundreds of thousands and growing per heartbeat, the sink is the bottleneck. If `PyArrowResultBatch` is growing, the source is holding references. We move from "OOM, unknown why" to "OOM, sink starved, here's the entity backlog."
+
+**Cost.** `gc.get_objects()` is the one expensive call (it iterates all tracked objects). It's invoked only on dump (SIGUSR1 / watchdog auto-dump), not on heartbeat. On heartbeat we only sample `rss`. So the steady-state cost is `psutil.memory_info()` + arithmetic — sub-millisecond.
+
+### 5.7 Stage backpressure visibility (`stage_progress.py`) — NEW
+
+The topology runner moves entities through source → processor → sink stages via internal buffers. Today these buffers are invisible. A common OOM pattern: source produces faster than sink can drain → entities pile up in the in-memory buffer → OOM.
+
+This component adds two small numbers to the heartbeat: queue depth and recent transition rate per inter-stage boundary. Implemented by hooking the topology runner's stage transitions to a tiny counter, not by changing the runner's logic.
+
+Heartbeat then shows:
+
+```
+diag.heartbeat ... stage_queues=source→processor:14/100 processor→sink:240/1000
+```
+
+If `processor→sink` is at capacity for many heartbeats, the sink is starving — and you know to look at the OpenMetadata server / sink-side HTTP, not the source.
+
+---
+
+## 6. Output format (stable, grep-friendly)
+
+All diagnostic output uses a `diag.` prefix:
+
+```
+diag.heartbeat    stage=... rss=... queue=...
+diag.warn.stuck   thread=MainThread op=snowflake.query duration=72s kwargs={...}
+diag.dump.begin   reason=watchdog trigger_op=snowflake.query duration=312s
+diag.dump.threads ...
+diag.dump.ops     ...
+diag.dump.http    ...
+diag.dump.memory  ...
+diag.dump.queues  ...
+diag.dump.end
+```
+
+Filter with `grep '^diag\.'`. Parse with any structured log tool. Same prefix appears in stderr-only output from internal loggers, so the operator sees everything together.
+
+---
+
+## 7. Wire-in points (existing framework code that needs to call `operation()`)
+
+| File | Change | Why |
+|---|---|---|
+| `metadata/workflow/base_workflow.py` | Call `diagnostics.install(self)` if `loggerLevel == DEBUG` | Activation point |
+| `metadata/ingestion/api/steps.py` | Wrap `Source.iter()` / `Processor.run()` / `Sink.write_record()` in `operation(...)` | The three stages |
+| `metadata/ingestion/topology_runner.py` | Notify stage_progress on transitions | Backpressure visibility |
+| `metadata/ingestion/ometa/client.py` | Wrap `REST._request()` in `operation` + active-HTTP register | OMetaClient introspection |
+| `metadata/ingestion/source/database/common_db_source.py` (and DB connectors) | Wrap `cursor.execute()` in `operation` | DB query introspection |
+
+Connector authors writing new connectors do not need to know any of this. They get instrumentation for free at the framework seams.
+
+---
+
+## 8. Defaults (hardcoded; not user-configurable)
+
+| Setting | Value | Rationale |
+|---|---|---|
+| Activation | `loggerLevel == DEBUG` | Reuse existing config |
+| Watchdog tick | 10 s | Responsive, cheap |
+| Stuck-warning threshold | 60 s | Most legit ops < this |
+| Auto-dump threshold | 300 s | True hang |
+| Re-dump throttle | 5 min per (thread, op) | Prevent flooding |
+| Heartbeat cadence | 30 s | Useful, low-noise |
+| Memory sample interval | 30 s (heartbeat) | Cheap |
+| Memory deep-snapshot | only on dump | `gc.get_objects()` is the only expensive call |
+| Kwargs truncation | 2000 chars | Captures normal SQL |
+| Op stack depth cap | 20 | Defensive |
+| Output target | stderr (also routed to `/tmp/openmetadata-diag-<pid>.log`) | Survives log rotation |
+
+Constants live in `diagnostics/__init__.py`. If reality shows them wrong, we change them in code — not config.
+
+---
+
+## 9. Memory and CPU budget
+
+**Off (INFO mode, every production run today):** zero. Dead code.
+
+**On (DEBUG mode):**
+
+| Component | Memory | CPU |
+|---|---|---|
+| Registry | ~15 KB | ~1 µs / op enter+exit |
+| Active HTTP tracker | ~5 KB | ~1 µs / request |
+| Watchdog thread | ~100 KB RSS | ~10 µs / 10 s |
+| Heartbeat thread | ~100 KB RSS | ~100 µs / 30 s |
+| Memory tracker | ~10 KB ring buffer | ~1 ms / 30 s (sample only) |
+| Memory deep-snapshot | 0 ongoing | ~50–500 ms on each dump (rare) |
+| Stage progress | ~5 KB | ~1 µs / transition |
+| `faulthandler` buffer | ~8 KB | 0 until SIGUSR1 |
+| **Total** | **~250 KB** | **< 0.01% CPU** |
+
+The deep memory snapshot (`gc.get_objects()`) is the only expensive call and only fires on actual dump events.
+
+---
+
+## 10. Implementation plan — six small PRs
+
+Each PR is independently reviewable, independently shippable, and each one improves visibility on its own.
+
+### PR 1 — Foundation (~350 LoC)
+- `diagnostics/__init__.py` with public API (`install`, `operation`, `is_active`, `dump`)
+- `diagnostics/registry.py`
+- `diagnostics/signals.py` (SIGUSR1 / SIGUSR2 + faulthandler)
+- Wire `diagnostics.install()` into `BaseWorkflow.execute()`
+- Wrap `Source.iter()` and `Sink.write_record()` in `operation()`
+- Wrap `OMetaClient._request()` + active-HTTP register
+- Unit tests: registry, signal-triggered dump, no-op fallback when not installed
+
+**Ships value:** `kill -SIGUSR1` works for any DEBUG-enabled run. We can dump state on demand.
+
+### PR 2 — Watchdog + heartbeat (~250 LoC)
+- `diagnostics/watchdog.py` with 60 s warn / 300 s auto-dump
+- `diagnostics/heartbeat.py` with 30 s cadence
+- Integration test: install diagnostics, sleep in an `operation()`, assert watchdog logs a stuck line and auto-dumps
+
+**Ships value:** The process auto-detects its own hangs. Heartbeat confirms liveness.
+
+### PR 3 — Memory tracker (~200 LoC)
+- `diagnostics/memory.py`: RSS + cgroup sampling on heartbeat, `gc.get_objects()` top-types on dump
+- Heartbeat output gains `rss=` and `rss_delta_30s=` fields
+- Dump output gains `diag.dump.memory` section
+- Tests: simulate growth, assert top types are reported correctly
+
+**Ships value:** OOMs become diagnosable. We see which object type is growing.
+
+### PR 4 — Stage backpressure visibility (~150 LoC)
+- `diagnostics/stage_progress.py`: small counter hooked into topology runner
+- Heartbeat output gains `stage_queues=` field
+- Test: induce a slow sink, assert queue depth shows up in heartbeat
+
+**Ships value:** We can tell whether the source, processor, or sink is the bottleneck.
+
+### PR 5 — DB connector instrumentation (~200 LoC)
+- Wrap `cursor.execute()` in `common_db_source.py` so every SQL query is in the operation registry with query text + query_id
+- Same pattern can be replicated per-connector when there's a need
+
+**Ships value:** "Stuck on a SQL query" becomes a labeled, visible op.
+
+### PR 6 — Disk-persisted dumps (~50 LoC)
+- Mirror SIGUSR1 dumps to `/tmp/openmetadata-diag-<pid>.log` so they survive container restarts and log rotation
+
+**Ships value:** Post-mortem diagnosis works even if `kubectl logs` rolled over.
+
+After **PR 1** alone we can already diagnose the Snowflake-style hang on the next DEBUG run.
+After **PR 2** we no longer need to be watching the pod.
+After **PR 3** we can diagnose OOMs.
+PRs 4–6 are continuous improvement.
+
+---
+
+## 11. Worked examples — what would these PRs have told us?
+
+### The streamable_logger hang
+
+Before: 6 hours of py-spy + manual analysis + one wrong-theory fix.
+
+With this work installed at the time:
+- Watchdog at 60 s: `diag.warn.stuck thread=MainThread op=source.iter entity_fqn=svc.db.schema.table42 duration=72s` — already pointing at a specific table.
+- Heartbeat at 30 s: would stop firing because MainThread is wedged in the recursion (still useful: the *last* heartbeat tells us where it died).
+- Watchdog auto-dump at 300 s: thread stack via `faulthandler` shows the same 977-deep `emit -> warning -> emit` chain, directly fingering `streamable_logger.py` as the culprit. **Total time to root cause: ~5 minutes from log readout.**
+
+### A future OOM (Case study 2 generalized)
+
+Heartbeat history in `kubectl logs`:
+```
+T+0:00  diag.heartbeat ... rss=400M
+T+5:00  diag.heartbeat ... rss=900M  rss_delta_30s=+50M  stage_queues=source→sink:1000/1000
+T+8:00  diag.heartbeat ... rss=1.8G  rss_delta_30s=+60M  stage_queues=source→sink:1000/1000
+```
+
+The watchdog or the operator's SIGUSR1 gives:
+```
+diag.dump.memory
+  rss=2.6G rss_delta_30s=+50M
+  top_types:
+    Table       423019
+    Column      4109832
+    LineageEdge 8431
+```
+
+Verdict: sink is at capacity, source keeps producing `Table` and `Column` objects, those accumulate. The problem is sink-side throughput, not the source. We open a focused PR on the sink — instead of three speculative ones across the source.
+
+### A "is it stuck or slow?" question
+
+Customer reports an ingestion running for 4 hours with no logs. We say: `kubectl logs | grep diag.heartbeat | tail -5`. They paste:
+```
+T+3:50:00 diag.heartbeat ... stage=source step=table progress=4730/9000 rss=412M
+T+3:50:30 diag.heartbeat ... stage=source step=table progress=4732/9000 rss=413M
+T+3:51:00 diag.heartbeat ... stage=source step=table progress=4734/9000 rss=414M
+```
+
+It's making progress — slowly. We point them at the source's per-entity duration to identify which kind of table is slow. **No "kill and rerun" needed.**
+
+---
+
+## 12. Tradeoffs accepted
+
+1. **First occurrence of a non-reproducing hang on INFO will be undiagnosed.** Mitigated by flipping the workflow's log level and re-running. One redeploy cycle on first occurrence, never afterward.
+2. **DEBUG runs emit more output** (heartbeat every 30 s + HTTP per-request lines). Acceptable — DEBUG is opt-in for investigation.
+3. **No external knobs for thresholds.** If 60 s / 300 s / 30 s prove wrong, we change them in code. We are explicitly trading user-tunability for fewer config knobs.
+4. **Native code in C extensions is captured only via `faulthandler` thread dumps, not the operation registry.** Sufficient for identifying *where* a hang is; not for labeling what the C code is doing semantically.
+5. **`gc.get_objects()` is moderately expensive** (10s of ms on processes with millions of objects). We only call it on dump, not heartbeat.
+
+---
+
+## 13. Open questions
+
+1. **Argo emissary at PID 1.** In Argo workflow pods, the Python process is not PID 1. `kill -SIGUSR1 1` would signal the emissary, not Python. Use `pkill -SIGUSR1 -f python.*main.py` instead. Document this in operator-facing notes.
+2. **Should heartbeat be at INFO level (visible by default) or DEBUG-only?** Leaning toward "INFO when diagnostics is installed" — once an operator opted into DEBUG to install us, heartbeats are exactly what they want to see.
+3. **Should the operation registry also record args for the connector's `_iter` calls?** Probably not — those args can be arbitrarily large (Table objects, schemas). Stick to `entity_fqn` only.
+4. **Auto-dump on `MemoryError` exception?** Lean yes — extremely cheap to wire and exactly the moment we want a snapshot. To be decided in PR 3.
+5. **Disk-persisted dump location.** `/tmp/openmetadata-diag-<pid>.log` is the default; users with custom log volume mounts may want a different path. Reasonable to make this one a hardcoded constant for now; revisit if customer asks.
+
+---
+
+## 14. Anti-patterns this design explicitly rejects
+
+To stay honest, here is what we are NOT building and why:
+
+| Tempting feature | Rejected because |
+|---|---|
+| New env var to toggle diagnostics | Invisible to remote-deployed customers; needs pod redeploy to change |
+| New ingestion config field for diagnostics | Permanent surface area for something almost no customer should touch; reuse `loggerLevel` |
+| Periodic remote shipping of diagnostic state | Would re-create the streamable_logger failure mode (handler-on-itself recursion). All output stays local. |
+| A web dashboard / sidecar | Far more complex than needed; `kubectl logs` already exists |
+| Full APM instrumentation (every function call traced) | Overhead; not necessary for the hangs/OOMs we actually see |
+| Optional drop-in flame graph generator | Different problem space (CPU profiling); see `py-spy record` for that |
+
+The principle throughout: **minimum new surface, maximum information per line of log output.**

--- a/ingestion/src/metadata/ingestion/api/steps.py
+++ b/ingestion/src/metadata/ingestion/api/steps.py
@@ -11,9 +11,11 @@
 """
 Abstract definition of each step
 """
-from abc import ABC, abstractmethod
-from typing import Any, Iterable, Optional
 
+from abc import ABC, abstractmethod
+from typing import Any, Iterable, Optional  # noqa: UP035
+
+from metadata.ingestion import diagnostics
 from metadata.ingestion.api.models import Entity
 from metadata.ingestion.api.step import BulkStep, IterStep, ReturnStep, StageStep
 from metadata.ingestion.ometa.ometa_api import OpenMetadata
@@ -21,12 +23,12 @@ from metadata.utils.execution_time_tracker import (
     calculate_execution_time,
     calculate_execution_time_generator,
 )
-from metadata.utils.logger import ingestion_logger
+from metadata.utils.logger import get_log_name, ingestion_logger
 
 logger = ingestion_logger()
 
 
-class InvalidSourceException(Exception):
+class InvalidSourceException(Exception):  # noqa: N818
     """
     The source config is not getting the expected
     service connection
@@ -56,8 +58,9 @@ class Source(IterStep, ABC):
         return "Source"
 
     @calculate_execution_time_generator(context="Source")
-    def run(self) -> Iterable[Optional[Entity]]:
-        yield from super().run()
+    def run(self) -> Iterable[Optional[Entity]]:  # noqa: UP045
+        with diagnostics.operation("source.iter"):
+            yield from super().run()
 
 
 class Sink(ReturnStep, ABC):
@@ -68,8 +71,9 @@ class Sink(ReturnStep, ABC):
         return "Sink"
 
     @calculate_execution_time(context="Sink")
-    def run(self, record: Entity) -> Optional[Entity]:
-        return super().run(record)
+    def run(self, record: Entity) -> Optional[Entity]:  # noqa: UP045
+        with diagnostics.operation("sink.write", entity=get_log_name(record)):
+            return super().run(record)
 
 
 class Processor(ReturnStep, ABC):
@@ -79,6 +83,10 @@ class Processor(ReturnStep, ABC):
     def name(self) -> str:
         return "Processor"
 
+    def run(self, record: Entity) -> Optional[Entity]:  # noqa: UP045
+        with diagnostics.operation("processor.run", entity=get_log_name(record)):
+            return super().run(record)
+
 
 class Stage(StageStep, ABC):
     """All Stages must inherit this base class."""
@@ -86,6 +94,10 @@ class Stage(StageStep, ABC):
     @property
     def name(self) -> str:
         return "Stage"
+
+    def run(self, record: Entity) -> None:
+        with diagnostics.operation("stage.run", entity=get_log_name(record)):
+            super().run(record)
 
 
 class BulkSink(BulkStep, ABC):
@@ -103,6 +115,7 @@ class BulkSink(BulkStep, ABC):
         """
         self._activate_handler()
         try:
-            super().run()
+            with diagnostics.operation("bulksink.run"):
+                super().run()
         finally:
             self._deactivate_handler()

--- a/ingestion/src/metadata/ingestion/connections/source_api_client.py
+++ b/ingestion/src/metadata/ingestion/connections/source_api_client.py
@@ -24,7 +24,7 @@ Usage:
     response = client.get("/dashboards")  # Automatically tracked
 """
 from time import perf_counter
-from typing import Optional
+from typing import Any, Optional, Union
 
 from metadata.ingestion.ometa.client import REST, ClientConfig
 from metadata.utils.operation_metrics import OperationMetricsState
@@ -118,11 +118,19 @@ class TrackedREST(REST):
             duration_ms = (perf_counter() - start) * 1000
             self._record_api_call("GET", path, duration_ms)
 
-    def post(self, path, data=None, json=None, headers=None):
+    def post(
+        self,
+        path: str,
+        data: Any = None,
+        json: Any = None,
+        headers: Optional[dict] = None,  # noqa: UP045
+        timeout: Optional[Union[float, tuple[float, float]]] = None,  # noqa: UP007, UP045
+        retries: Optional[int] = None,  # noqa: UP045
+    ):
         """POST method with tracking."""
         start = perf_counter()
         try:
-            return super().post(path, data, json, headers)
+            return super().post(path, data, json, headers, timeout=timeout, retries=retries)
         finally:
             duration_ms = (perf_counter() - start) * 1000
             self._record_api_call("POST", path, duration_ms)

--- a/ingestion/src/metadata/ingestion/diagnostics/__init__.py
+++ b/ingestion/src/metadata/ingestion/diagnostics/__init__.py
@@ -1,0 +1,323 @@
+#  Copyright 2025 Collate
+#  Licensed under the Collate Community License, Version 1.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  https://github.com/open-metadata/OpenMetadata/blob/main/ingestion/LICENSE
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+"""
+Runtime diagnostics for ingestion workflows.
+
+When `workflowConfig.loggerLevel == DEBUG`, `install(workflow)` starts:
+  - operation registry  (what each thread is doing right now)
+  - signal handlers     (SIGUSR1/SIGUSR2 -> dump to stderr)
+  - watchdog thread     (auto-detect hangs at 60s, auto-dump at 300s)
+  - heartbeat thread    (one structured progress line every 30s)
+  - memory tracker      (rss/cgroup on heartbeat, gc.get_objects on dump)
+
+When off, `operation()` is a no-op context manager — no threads, no overhead.
+
+Output channels
+---------------
+Regular-thread output (heartbeat, watchdog warn/auto-dump, install banner,
+programmatic `dump()`) is emitted via the `metadata.Diagnostics` logger and
+flows through whatever handlers the workflow has configured:
+
+  * console / `BASE_LOGGING_FORMAT` StreamHandler -> kubectl logs
+  * `StreamableLogHandler` (when `enableStreamableLogs=True`) -> S3
+  * any file or syslog handlers users have attached
+
+If the logger itself errors, the message falls back to a raw stderr write so
+operators on `kubectl logs` still see the line.
+
+Signal-handler output (SIGUSR1 / SIGUSR2 and `faulthandler.dump_traceback`)
+goes straight to stderr because Python's logging module takes per-handler
+RLocks and is not safe to call from signal context.
+"""
+
+import logging
+import sys
+from collections.abc import Iterator
+from contextlib import contextmanager, suppress
+from typing import Any, Optional
+
+from metadata.utils.logger import diag_logger
+
+WATCHDOG_TICK_SECONDS = 10
+STUCK_WARN_SECONDS = 60
+AUTO_DUMP_SECONDS = 300
+REDUMP_THROTTLE_SECONDS = 300
+HEARTBEAT_INTERVAL_SECONDS = 30
+MEMORY_SAMPLE_INTERVAL_SECONDS = 30
+KWARGS_TRUNCATION_CHARS = 2000
+OP_STACK_DEPTH_CAP = 20
+DIAG_LOG_PREFIX = "diag"
+
+# Pre-OOM tripwire thresholds. PSI `some avg10` is a percentage 0..100
+# representing how much of the last 10 s the cgroup was stalled on
+# memory; sustained values >10% reliably predict OOMKill within tens of
+# seconds on gradual leaks (see /proc/pressure docs).
+PRESSURE_PSI_AVG10_THRESHOLD = 10.0
+# Memory-pressure tripwire dumps are throttled to one per reason per
+# 5 minutes so we don't flood the logs with snapshots while pressure is
+# sustained.
+PRESSURE_DUMP_THROTTLE_SECONDS = 300
+
+_state: Optional["_DiagnosticsState"] = None
+
+
+class _DiagnosticsState:
+    """Holds references to the singletons installed by `install()`."""
+
+    def __init__(
+        self,
+        registry: Any,
+        http_tracker: Any,
+        memory_tracker: Any,
+        watchdog: Any,
+        heartbeat: Any,
+        signals_installed: bool,
+        db_introspector: Any,
+        time_sampler: Any,
+    ) -> None:
+        self.registry = registry
+        self.http_tracker = http_tracker
+        self.memory_tracker = memory_tracker
+        self.watchdog = watchdog
+        self.heartbeat = heartbeat
+        self.signals_installed = signals_installed
+        self.db_introspector = db_introspector
+        self.time_sampler = time_sampler
+
+
+def is_active() -> bool:
+    """True when diagnostics has been installed and is running."""
+    return _state is not None
+
+
+@contextmanager
+def operation(name: str, **kwargs: Any) -> Iterator[None]:
+    """Register the current thread as performing `name`.
+
+    When diagnostics is not installed, this is a zero-overhead no-op so
+    callers can sprinkle it through hot paths without worrying.
+    """
+    state = _state
+    if state is None:
+        yield
+        return
+    token = state.registry.push(name, kwargs)
+    try:
+        yield
+    finally:
+        state.registry.pop(token)
+
+
+def install(workflow: Any) -> bool:
+    """Install diagnostics for the given workflow.
+
+    Returns True if diagnostics is now active (whether installed by this
+    call or already running). Returns False when `loggerLevel` is not
+    DEBUG or installation fails. Always best-effort: a diagnostics
+    failure must never bring down the workflow.
+    """
+    global _state  # noqa: PLW0603  module-level singleton
+
+    if _state is not None:
+        return True
+
+    if not _logger_level_is_debug(workflow):
+        return False
+
+    # Imports are deferred to keep `is_active()` / no-op `operation()` callers
+    # from paying the import cost on every workflow start.
+    try:
+        from metadata.ingestion.diagnostics import stage_progress as _stage_progress  # noqa: PLC0415
+        from metadata.ingestion.diagnostics.db_introspect import DbIntrospector  # noqa: PLC0415
+        from metadata.ingestion.diagnostics.heartbeat import HeartbeatThread  # noqa: PLC0415
+        from metadata.ingestion.diagnostics.http_introspect import HttpTracker  # noqa: PLC0415
+        from metadata.ingestion.diagnostics.memory import MemoryTracker  # noqa: PLC0415
+        from metadata.ingestion.diagnostics.registry import OperationRegistry  # noqa: PLC0415
+        from metadata.ingestion.diagnostics.signals import install_signal_handlers  # noqa: PLC0415
+        from metadata.ingestion.diagnostics.time_accounting import TimeAccountingSampler  # noqa: PLC0415
+        from metadata.ingestion.diagnostics.watchdog import WatchdogThread  # noqa: PLC0415
+
+        registry = OperationRegistry()
+        http_tracker = HttpTracker()
+        memory_tracker = MemoryTracker()
+        _stage_progress.install(_stage_progress.StageProgressCollector())
+        db_introspector = DbIntrospector(registry)
+        db_introspector.install()
+        time_sampler = TimeAccountingSampler(registry)
+        time_sampler.start()
+
+        signals_installed = install_signal_handlers(
+            registry=registry,
+            http_tracker=http_tracker,
+            memory_tracker=memory_tracker,
+            workflow=workflow,
+        )
+
+        watchdog = WatchdogThread(
+            registry=registry,
+            http_tracker=http_tracker,
+            memory_tracker=memory_tracker,
+            workflow=workflow,
+        )
+        watchdog.start()
+
+        heartbeat = HeartbeatThread(
+            registry=registry,
+            http_tracker=http_tracker,
+            memory_tracker=memory_tracker,
+            workflow=workflow,
+        )
+        heartbeat.start()
+
+        _state = _DiagnosticsState(
+            registry=registry,
+            http_tracker=http_tracker,
+            memory_tracker=memory_tracker,
+            watchdog=watchdog,
+            heartbeat=heartbeat,
+            signals_installed=signals_installed,
+            db_introspector=db_introspector,
+            time_sampler=time_sampler,
+        )
+    except Exception as exc:
+        # Diagnostics must never break the workflow it is monitoring.
+        _log_install_failure(exc)
+        _state = None
+        return False
+    _log_install_banner()
+    return True
+
+
+def shutdown() -> None:
+    """Stop all diagnostics threads and reset state.
+
+    Called from `BaseWorkflow.stop()` so threads don't outlive the
+    workflow and so a subsequent `install()` (e.g. in a test) starts
+    fresh.
+    """
+    global _state  # noqa: PLW0603  module-level singleton
+    state = _state
+    if state is None:
+        return
+    _state = None
+    # Emit the time-budget summary BEFORE stopping the sampler — gives
+    # the operator one line in `kubectl logs` / S3 explaining where the
+    # workflow actually spent its wall clock.
+    with suppress(Exception):
+        emit_log(logging.INFO, state.time_sampler.summary_log_line())
+    for thread in (state.watchdog, state.heartbeat, state.time_sampler):
+        with suppress(Exception):
+            thread.stop()
+    with suppress(Exception):
+        state.db_introspector.uninstall()
+    with suppress(Exception):
+        from metadata.ingestion.diagnostics import stage_progress  # noqa: PLC0415
+
+        stage_progress.uninstall()
+
+
+def dump(reason: str = "manual") -> None:
+    """Emit a full dump (threads + ops + http + memory) to stderr.
+
+    Safe to call from any thread. Used by signal handlers and by the
+    watchdog auto-dump path.
+    """
+    state = _state
+    if state is None:
+        return
+    from metadata.ingestion.diagnostics.signals import emit_full_dump  # noqa: PLC0415
+
+    emit_full_dump(
+        reason=reason,
+        registry=state.registry,
+        http_tracker=state.http_tracker,
+        memory_tracker=state.memory_tracker,
+    )
+
+
+def dump_on_memory_error():
+    """Context manager wrapping `MemoryError`-raising code with a dump-then-reraise.
+
+    Use it around `BaseWorkflow.execute_internal()` so a Python-side
+    OOM (the allocator failed before the kernel killed us) still
+    produces a dump in the logs / S3 before propagating.
+    """
+    return _DumpOnMemoryError()
+
+
+class _DumpOnMemoryError:
+    def __enter__(self) -> "_DumpOnMemoryError":
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        _tb: Any,
+    ) -> bool:
+        if exc_type is MemoryError:
+            # The dump path itself can fail under severe pressure;
+            # never swallow the original MemoryError.
+            with suppress(Exception):
+                dump(reason=f"memory-error:{exc!r}")
+        return False  # propagate
+
+
+def _logger_level_is_debug(workflow: Any) -> bool:
+    """True if the workflow is configured at DEBUG.
+
+    Defensive — we never want a missing attribute or an unexpected
+    value to crash the workflow at install time.
+    """
+    try:
+        level = workflow.workflow_config.loggerLevel
+        if level is None:
+            return False
+        value = getattr(level, "value", level)
+        return str(value).upper() == "DEBUG"
+    except Exception:
+        return False
+
+
+def emit_log(level: int, message: str) -> None:
+    """Emit a diagnostics line through the `metadata.Diagnostics` logger.
+
+    Belt-and-braces: if the logger itself fails (broken handler, lock
+    contention from the very issue we're diagnosing), fall back to a
+    raw stderr write so the line still reaches `kubectl logs`.
+
+    Must NOT be called from signal-handler context — use
+    `sys.stderr.write` directly for that.
+    """
+    try:
+        diag_logger().log(level, message)
+    except Exception:
+        try:
+            sys.stderr.write(message.rstrip("\n") + "\n")
+            sys.stderr.flush()
+        except Exception:
+            pass
+
+
+def _log_install_banner() -> None:
+    emit_log(
+        logging.INFO,
+        f"{DIAG_LOG_PREFIX}.install ok components=registry,signals,watchdog,heartbeat,memory",
+    )
+
+
+def _log_install_failure(exc: BaseException) -> None:
+    emit_log(logging.ERROR, f"{DIAG_LOG_PREFIX}.install failed err={exc!r}")
+
+
+def _get_state() -> Optional["_DiagnosticsState"]:
+    """Test-only accessor."""
+    return _state

--- a/ingestion/src/metadata/ingestion/diagnostics/db_introspect.py
+++ b/ingestion/src/metadata/ingestion/diagnostics/db_introspect.py
@@ -1,0 +1,148 @@
+#  Copyright 2025 Collate
+#  Licensed under the Collate Community License, Version 1.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  https://github.com/open-metadata/OpenMetadata/blob/main/ingestion/LICENSE
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+"""
+SQLAlchemy event-based DB query instrumentation.
+
+Attaches global `before_cursor_execute` / `after_cursor_execute` /
+`handle_error` listeners on `sqlalchemy.engine.Engine`. Every SQL query
+across every SQLAlchemy-backed connector (Postgres, Snowflake, Redshift,
+MySQL, MSSQL, Trino, BigQuery, Oracle, ...) becomes a labeled
+`{dialect}.query` operation in the registry with truncated SQL text — so
+a stuck DB connector shows up as e.g.
+
+    diag.warn.stuck op=snowflake.query duration=312s
+        sql='SELECT column_name, ...'
+
+instead of the opaque `op=source.iter`.
+
+The token is stored on the SQLAlchemy `ExecutionContext` (unique per
+`cursor.execute`) so before/after/error pair up cleanly without
+thread-locals or cursor-id maps.
+"""
+
+from typing import Any
+
+from metadata.ingestion.diagnostics.registry import OperationRegistry
+
+_TOKEN_ATTR = "_diag_op_token"
+_KWARGS_SQL_MAX_CHARS = 2000
+
+
+class DbIntrospector:
+    """Registers SQLAlchemy event listeners that push ops on the registry."""
+
+    def __init__(self, registry: OperationRegistry) -> None:
+        self._registry = registry
+        self._installed = False
+        self._engine_cls: Any = None  # cached SQLAlchemy `Engine` class
+
+    def install(self) -> bool:
+        """Attach the listeners. Returns True if successful.
+
+        Idempotent and best-effort: if SQLAlchemy isn't importable or
+        event registration fails, returns False and leaves diagnostics
+        otherwise functional.
+        """
+        if self._installed:
+            return True
+        try:
+            from sqlalchemy import event  # noqa: PLC0415
+            from sqlalchemy.engine import Engine  # noqa: PLC0415
+        except ImportError:
+            return False
+
+        try:
+            event.listen(Engine, "before_cursor_execute", self._before)
+            event.listen(Engine, "after_cursor_execute", self._after)
+            event.listen(Engine, "handle_error", self._error)
+        except Exception:
+            return False
+
+        self._engine_cls = Engine
+        self._installed = True
+        return True
+
+    def uninstall(self) -> None:
+        if not self._installed:
+            return
+        try:
+            from sqlalchemy import event  # noqa: PLC0415
+
+            event.remove(self._engine_cls, "before_cursor_execute", self._before)
+            event.remove(self._engine_cls, "after_cursor_execute", self._after)
+            event.remove(self._engine_cls, "handle_error", self._error)
+        except Exception:
+            pass
+        self._installed = False
+
+    # ---- listeners ----
+
+    def _before(
+        self,
+        conn: Any,
+        cursor: Any,
+        statement: Any,
+        parameters: Any,
+        context: Any,
+        executemany: Any,
+    ) -> None:
+        """Push a `{dialect}.query` op for the duration of `cursor.execute`."""
+        try:
+            op_name = self._op_name(conn)
+            sql_short = (statement or "")[:_KWARGS_SQL_MAX_CHARS]
+            token = self._registry.push(
+                op_name,
+                {"sql": sql_short, "executemany": str(bool(executemany))},
+            )
+            if context is not None:
+                setattr(context, _TOKEN_ATTR, token)
+        except Exception:
+            # Never let a diagnostics listener break SQL execution.
+            pass
+
+    def _after(
+        self,
+        conn: Any,
+        cursor: Any,
+        statement: Any,
+        parameters: Any,
+        context: Any,
+        executemany: Any,
+    ) -> None:
+        try:
+            token = getattr(context, _TOKEN_ATTR, None) if context is not None else None
+            if token is not None:
+                self._registry.pop(token)
+                setattr(context, _TOKEN_ATTR, None)
+        except Exception:
+            pass
+
+    def _error(self, exception_context: Any) -> None:
+        """SQLAlchemy fires `handle_error` instead of `after_cursor_execute`
+        when `cursor.execute` raises. Make sure we still pop the op so the
+        stack stays balanced.
+        """
+        try:
+            ctx = getattr(exception_context, "execution_context", None)
+            token = getattr(ctx, _TOKEN_ATTR, None) if ctx is not None else None
+            if token is not None:
+                self._registry.pop(token)
+                setattr(ctx, _TOKEN_ATTR, None)
+        except Exception:
+            pass
+
+    @staticmethod
+    def _op_name(conn: Any) -> str:
+        try:
+            dialect = conn.dialect.name if conn is not None and conn.dialect else "sql"
+        except Exception:
+            dialect = "sql"
+        return f"{dialect}.query"

--- a/ingestion/src/metadata/ingestion/diagnostics/heartbeat.py
+++ b/ingestion/src/metadata/ingestion/diagnostics/heartbeat.py
@@ -1,0 +1,143 @@
+#  Copyright 2025 Collate
+#  Licensed under the Collate Community License, Version 1.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  https://github.com/open-metadata/OpenMetadata/blob/main/ingestion/LICENSE
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+"""
+Heartbeat daemon thread.
+
+Every HEARTBEAT_INTERVAL_SECONDS, emit one structured line to stderr:
+
+  diag.heartbeat rss=412M rss_delta_30s=+2M threads=8 active_http=1 main_op=...
+
+This line answers, on its own, in `kubectl logs`:
+  - Is the process alive? (next heartbeat arrives)
+  - Is it making progress? (compare counters across heartbeats)
+  - Is memory growing? (rss_delta_30s)
+  - What is the main thread doing right now? (main_op)
+"""
+
+import logging
+import os
+import threading
+from typing import Any
+
+from metadata.ingestion.diagnostics import (
+    DIAG_LOG_PREFIX,
+    HEARTBEAT_INTERVAL_SECONDS,
+    emit_log,
+)
+from metadata.ingestion.diagnostics.memory import (
+    MemoryTracker,
+    format_bytes,
+    format_signed_bytes,
+)
+from metadata.ingestion.diagnostics.registry import OperationRegistry
+from metadata.ingestion.diagnostics.stage_progress import format_for_heartbeat
+
+
+class HeartbeatThread(threading.Thread):
+    """Background thread emitting one line per `HEARTBEAT_INTERVAL_SECONDS`."""
+
+    def __init__(
+        self,
+        registry: OperationRegistry,
+        http_tracker: Any,
+        memory_tracker: MemoryTracker,
+        workflow: Any,
+    ) -> None:
+        super().__init__(name="diag-heartbeat", daemon=True)
+        self._registry = registry
+        self._http_tracker = http_tracker
+        self._memory_tracker = memory_tracker
+        self._workflow = workflow
+        self._stop_event = threading.Event()
+        self._ticks = 0
+
+    def stop(self) -> None:
+        self._stop_event.set()
+
+    def run(self) -> None:
+        while not self._stop_event.wait(HEARTBEAT_INTERVAL_SECONDS):
+            try:
+                self._emit()
+            except Exception as exc:
+                emit_log(logging.ERROR, f"{DIAG_LOG_PREFIX}.heartbeat.error err={exc!r}")
+
+    def _emit(self) -> None:
+        self._ticks += 1
+        sample = self._memory_tracker.sample()
+        delta_30s = self._memory_tracker.rss_delta_bytes_since(30.0)
+        main_op = self._format_main_op()
+        steps_summary = self._format_steps()
+        stage_queues = format_for_heartbeat()
+
+        emit_log(
+            logging.INFO,
+            f"{DIAG_LOG_PREFIX}.heartbeat "
+            f"tick={self._ticks} "
+            f"pid={os.getpid()} "
+            f"threads={threading.active_count()} "
+            f"rss={format_bytes(sample.rss)} "
+            f"rss_delta_30s={format_signed_bytes(delta_30s)} "
+            f"cgroup={format_bytes(sample.cgroup_current)}/{format_bytes(sample.cgroup_max)} "
+            f"oom_kills={sample.oom_kill_count if sample.oom_kill_count is not None else '?'} "
+            f"active_http={self._http_tracker.active_count()} "
+            f"main_op={main_op}"
+            f"{steps_summary}"
+            f"{stage_queues}",
+        )
+
+    def _format_main_op(self) -> str:
+        """Render the main-thread's deepest op as `name(age)` or `-`."""
+        main_ident = threading.main_thread().ident
+        if main_ident is None:
+            return "-"
+        deepest = self._registry.deepest_per_thread().get(main_ident)
+        if not deepest:
+            return "-"
+        op_name, _kwargs, age = deepest
+        return f"{op_name}({_fmt_age(age)})"
+
+    def _format_steps(self) -> str:
+        if self._workflow is None:
+            return ""
+        try:
+            steps = self._workflow.workflow_steps()
+        except Exception:
+            return ""
+        if not steps:
+            return ""
+        parts = []
+        for step in steps:
+            try:
+                status = step.get_status()
+                rec = getattr(status, "record_count", None)
+                if rec is None or rec == 0:
+                    records = getattr(status, "records", None)
+                    rec = len(records) if records is not None else 0
+                failures = len(getattr(status, "failures", []) or [])
+                parts.append(f"{step.name}={rec}/{failures}err")
+            except Exception:
+                continue
+        if not parts:
+            return ""
+        return " steps=[" + ",".join(parts) + "]"
+
+
+def _fmt_age(seconds: float | None) -> str:
+    if seconds is None:
+        return "?"
+    if seconds < 60:
+        return f"{seconds:.0f}s"
+    if seconds < 3600:
+        m, s = divmod(int(seconds), 60)
+        return f"{m}m{s:02d}s"
+    h, rem = divmod(int(seconds), 3600)
+    m, _ = divmod(rem, 60)
+    return f"{h}h{m:02d}m"

--- a/ingestion/src/metadata/ingestion/diagnostics/http_introspect.py
+++ b/ingestion/src/metadata/ingestion/diagnostics/http_introspect.py
@@ -1,0 +1,67 @@
+#  Copyright 2025 Collate
+#  Licensed under the Collate Community License, Version 1.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  https://github.com/open-metadata/OpenMetadata/blob/main/ingestion/LICENSE
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+"""
+Track in-flight HTTP requests so a dump shows exactly which call is hung.
+"""
+
+import itertools
+import threading
+import time
+from collections.abc import Iterator
+from contextlib import contextmanager
+from typing import Any
+
+
+class HttpTracker:
+    """In-memory registry of currently-in-flight HTTP requests."""
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        # (thread_id, request_id) -> (method, url, started_monotonic)
+        self._active: dict[tuple[int, int], tuple[str, str, float]] = {}
+        self._ids = itertools.count(1)
+
+    @contextmanager
+    def request(self, method: str, url: str) -> Iterator[None]:
+        """Register an HTTP request for the duration of the with-block."""
+        request_id = next(self._ids)
+        tid = threading.get_ident()
+        key = (tid, request_id)
+        started = time.monotonic()
+        with self._lock:
+            self._active[key] = (str(method).upper(), str(url), started)
+        try:
+            yield
+        finally:
+            with self._lock:
+                self._active.pop(key, None)
+
+    def snapshot(self) -> list[tuple[int, str, str, float]]:
+        """List of `(thread_id, method, url, age_seconds)` for all active requests."""
+        now = time.monotonic()
+        with self._lock:
+            return [(tid, method, url, now - started) for (tid, _rid), (method, url, started) in self._active.items()]
+
+    def active_count(self) -> int:
+        with self._lock:
+            return len(self._active)
+
+
+def get_global_tracker() -> Any:
+    """Return the diagnostics tracker if installed, else None.
+
+    The OMetaClient calls this on every request, so the cost when
+    diagnostics is off is a single attribute read.
+    """
+    from metadata.ingestion.diagnostics import _get_state  # noqa: PLC0415  avoid circular import
+
+    state = _get_state()
+    return state.http_tracker if state is not None else None

--- a/ingestion/src/metadata/ingestion/diagnostics/memory.py
+++ b/ingestion/src/metadata/ingestion/diagnostics/memory.py
@@ -1,0 +1,343 @@
+#  Copyright 2025 Collate
+#  Licensed under the Collate Community License, Version 1.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  https://github.com/open-metadata/OpenMetadata/blob/main/ingestion/LICENSE
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+"""
+Memory tracker — cheap on heartbeat, expensive only on dump.
+
+Sample (cheap, called on every heartbeat tick):
+  - RSS (psutil)
+  - cgroup current/max (from /sys/fs/cgroup, both v1 and v2)
+  - cgroup oom_kill_count (proof of recent OOM siblings)
+
+Deep snapshot (expensive, only on dump):
+  - gc.get_objects() aggregated by type(obj).__name__ — answers
+    "what kind of object is occupying memory?"
+
+The ring buffer (last N samples) gives us a per-second growth rate so
+heartbeats can show whether memory is rising fast.
+"""
+
+import gc
+import os
+import threading
+import time
+from collections import Counter, deque
+
+RING_BUFFER_SIZE = 10
+TOP_TYPES_LIMIT = 10
+# Pre-allocated bytearray reserved at install time and released right
+# before `gc.get_objects()` runs under memory pressure. Gives the deep
+# snapshot ~10MB of headroom so the Counter can build without itself
+# triggering the OOM we're trying to diagnose.
+EMERGENCY_RESERVE_BYTES = 10 * 1024 * 1024
+
+
+class MemorySample:
+    """A single point-in-time memory reading.
+
+    Fields beyond rss/cgroup_current/cgroup_max are pre-OOM tripwire
+    signals — see the watchdog's pressure check.
+    """
+
+    __slots__ = (
+        "cgroup_current",
+        "cgroup_events_high",
+        "cgroup_events_oom",
+        "cgroup_max",
+        "oom_kill_count",
+        "psi_some_avg10",
+        "rss",
+        "ts",
+    )
+
+    def __init__(
+        self,
+        ts: float,
+        rss: int,
+        cgroup_current: int | None,
+        cgroup_max: int | None,
+        oom_kill_count: int | None,
+        cgroup_events_high: int | None = None,
+        cgroup_events_oom: int | None = None,
+        psi_some_avg10: float | None = None,
+    ) -> None:
+        self.ts = ts
+        self.rss = rss
+        self.cgroup_current = cgroup_current
+        self.cgroup_max = cgroup_max
+        self.oom_kill_count = oom_kill_count
+        self.cgroup_events_high = cgroup_events_high
+        self.cgroup_events_oom = cgroup_events_oom
+        self.psi_some_avg10 = psi_some_avg10
+
+
+class MemoryTracker:
+    """Thread-safe rolling memory sampler."""
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._ring: deque[MemorySample] = deque(maxlen=RING_BUFFER_SIZE)
+        self._psutil = _import_psutil()
+        # Cache the Process handle. Construction reads /proc/<pid>/stat;
+        # caching saves that read on every sample. The handle remains
+        # valid for the lifetime of this process.
+        self._process = self._make_process_handle()
+        self._cgroup_paths = _detect_cgroup_paths()
+        self._psi_path = _detect_psi_path()
+        # Reserved bytes — `release_emergency_reserve` drops the reference
+        # so `gc.get_objects()` can allocate. CPython 3.11 large-object
+        # allocations bypass pymalloc and free directly to the OS.
+        self._emergency_reserve: bytearray | None = bytearray(EMERGENCY_RESERVE_BYTES)
+
+    def _make_process_handle(self):
+        if self._psutil is None:
+            return None
+        try:
+            return self._psutil.Process()
+        except Exception:
+            return None
+
+    def sample(self) -> MemorySample:
+        """Take one cheap sample, append to ring, return it.
+
+        Total cost: one rss read (psutil or /proc/self/status), one
+        cgroup memory.current read, one cgroup memory.max read, one
+        consolidated memory.events read (oom_kill + high + oom), and
+        one /proc/pressure/memory read. ~5 tiny syscalls.
+        """
+        events = _read_memory_events(self._cgroup_paths.get("events"))
+        sample = MemorySample(
+            ts=time.monotonic(),
+            rss=self._read_rss(),
+            cgroup_current=_read_int(self._cgroup_paths.get("current")),
+            cgroup_max=_read_cgroup_max(self._cgroup_paths.get("max")),
+            oom_kill_count=events.get("oom_kill"),
+            cgroup_events_high=events.get("high"),
+            cgroup_events_oom=events.get("oom"),
+            psi_some_avg10=_read_psi_some_avg10(self._psi_path),
+        )
+        with self._lock:
+            self._ring.append(sample)
+        return sample
+
+    def latest(self) -> MemorySample | None:
+        with self._lock:
+            return self._ring[-1] if self._ring else None
+
+    def rss_delta_bytes_since(self, seconds_ago: float) -> int | None:
+        """RSS change between the most recent sample and the oldest within `seconds_ago`."""
+        with self._lock:
+            if not self._ring:
+                return None
+            latest = self._ring[-1]
+            cutoff = latest.ts - seconds_ago
+            baseline = None
+            for sample in self._ring:
+                if sample.ts <= cutoff:
+                    baseline = sample
+                else:
+                    break
+            if baseline is None:
+                baseline = self._ring[0]
+        return latest.rss - baseline.rss
+
+    def top_object_types(self, limit: int = TOP_TYPES_LIMIT) -> list[tuple[str, int]]:
+        """gc.get_objects() aggregated by type name.
+
+        Expensive — only call on dump. Releases the emergency reserve
+        first so we have headroom to build the Counter even when we're
+        running this BECAUSE of memory pressure.
+        """
+        self._release_emergency_reserve()
+        try:
+            counter: Counter = Counter()
+            for obj in gc.get_objects():
+                try:
+                    counter[type(obj).__name__] += 1
+                except Exception:
+                    counter["<unknown>"] += 1
+            return counter.most_common(limit)
+        except Exception:
+            return []
+        finally:
+            self._restore_emergency_reserve()
+
+    def _release_emergency_reserve(self) -> None:
+        """Drop the reserve so the deep snapshot has 10MB of headroom."""
+        self._emergency_reserve = None
+
+    def _restore_emergency_reserve(self) -> None:
+        """Re-allocate the reserve. Best-effort — under severe pressure
+        this allocation may itself fail; that's acceptable since the
+        snapshot already ran.
+        """
+        try:
+            if self._emergency_reserve is None:
+                self._emergency_reserve = bytearray(EMERGENCY_RESERVE_BYTES)
+        except MemoryError:
+            self._emergency_reserve = None
+
+    def _read_rss(self) -> int:
+        if self._process is None:
+            return _read_rss_proc_self_status()
+        try:
+            return int(self._process.memory_info().rss)
+        except Exception:
+            return _read_rss_proc_self_status()
+
+
+def _import_psutil():
+    try:
+        import psutil  # noqa: PLC0415  optional dependency probe
+    except ImportError:
+        return None
+    return psutil
+
+
+def _detect_cgroup_paths() -> dict:
+    """Return paths for cgroup memory.current / memory.max / memory.events.
+
+    Tries cgroup v2 first (`/sys/fs/cgroup/memory.*`), then v1
+    (`/sys/fs/cgroup/memory/memory.*`).
+    """
+    paths = {}
+    v2_root = "/sys/fs/cgroup"
+    if os.path.exists(f"{v2_root}/memory.current"):  # noqa: PTH110  cheap probe
+        paths["current"] = f"{v2_root}/memory.current"
+        paths["max"] = f"{v2_root}/memory.max"
+        paths["events"] = f"{v2_root}/memory.events"
+        return paths
+    v1_root = "/sys/fs/cgroup/memory"
+    if os.path.exists(f"{v1_root}/memory.usage_in_bytes"):  # noqa: PTH110  cheap probe
+        paths["current"] = f"{v1_root}/memory.usage_in_bytes"
+        paths["max"] = f"{v1_root}/memory.limit_in_bytes"
+        paths["events"] = None
+    return paths
+
+
+def _read_int(path: str | None) -> int | None:
+    if not path:
+        return None
+    try:
+        with open(path, "rb") as fh:  # noqa: PTH123  binary read of /sys file
+            data = fh.read().strip()
+        return int(data)
+    except (OSError, ValueError):
+        return None
+
+
+def _read_cgroup_max(path: str | None) -> int | None:
+    """cgroup v2 emits the literal string 'max' for unlimited."""
+    if not path:
+        return None
+    try:
+        with open(path, "rb") as fh:  # noqa: PTH123  binary read of /sys file
+            data = fh.read().strip()
+        if data == b"max":
+            return None
+        return int(data)
+    except (OSError, ValueError):
+        return None
+
+
+def _read_memory_events(path: str | None) -> dict[str, int]:
+    """Read cgroup v2 `memory.events` in one shot.
+
+    Returns a dict with keys among `low`, `high`, `max`, `oom`,
+    `oom_kill` (whichever the kernel exposes). Empty dict on missing
+    file or v1 cgroup. The kernel writes one counter per line.
+    """
+    out: dict[str, int] = {}
+    if not path:
+        return out
+    try:
+        with open(path) as fh:  # noqa: PTH123  text read of /sys file
+            for line in fh:
+                key, _, value = line.partition(" ")
+                try:
+                    out[key.strip()] = int(value.strip())
+                except ValueError:
+                    continue
+    except OSError:
+        return {}
+    return out
+
+
+def _detect_psi_path() -> str | None:
+    """Return `/proc/pressure/memory` if present (kernel ≥4.20).
+
+    PSI is the kernel's own "memory is becoming a bottleneck" signal —
+    far more reliable than a static cgroup-ratio threshold.
+    """
+    psi_path = "/proc/pressure/memory"
+    if os.path.exists(psi_path):  # noqa: PTH110  cheap probe
+        return psi_path
+    return None
+
+
+def _read_psi_some_avg10(path: str | None) -> float | None:
+    """Parse the `some avg10` value from `/proc/pressure/memory`.
+
+    The file format is:
+        some avg10=0.10 avg60=0.05 avg300=0.01 total=12345
+        full avg10=0.00 avg60=0.00 avg300=0.00 total=6789
+
+    `some` = % of the last N seconds where ANY task in the cgroup was
+    stalled on memory. `avg10` is the most reactive window.
+    """
+    if not path:
+        return None
+    try:
+        with open(path) as fh:  # noqa: PTH123  text read of /proc file
+            line = fh.readline()
+    except OSError:
+        return None
+    if not line.startswith("some "):
+        return None
+    for token in line.split():
+        if token.startswith("avg10="):
+            try:
+                return float(token.split("=", 1)[1])
+            except ValueError:
+                return None
+    return None
+
+
+def _read_rss_proc_self_status() -> int:
+    """Fallback when psutil is unavailable."""
+    try:
+        with open("/proc/self/status") as fh:  # noqa: PTH123  text read of /proc file
+            for line in fh:
+                if line.startswith("VmRSS:"):
+                    parts = line.split()
+                    return int(parts[1]) * 1024
+    except (OSError, ValueError):
+        pass
+    return 0
+
+
+def format_bytes(n: int | None) -> str:
+    if n is None:
+        return "?"
+    abs_n = abs(n)
+    if abs_n >= 1024 * 1024 * 1024:
+        return f"{n / (1024 * 1024 * 1024):.1f}G"
+    if abs_n >= 1024 * 1024:
+        return f"{n / (1024 * 1024):.0f}M"
+    if abs_n >= 1024:
+        return f"{n / 1024:.0f}K"
+    return f"{n}B"
+
+
+def format_signed_bytes(n: int | None) -> str:
+    if n is None:
+        return "?"
+    sign = "+" if n >= 0 else "-"
+    return sign + format_bytes(abs(n))

--- a/ingestion/src/metadata/ingestion/diagnostics/registry.py
+++ b/ingestion/src/metadata/ingestion/diagnostics/registry.py
@@ -1,0 +1,132 @@
+#  Copyright 2025 Collate
+#  Licensed under the Collate Community License, Version 1.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  https://github.com/open-metadata/OpenMetadata/blob/main/ingestion/LICENSE
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+"""
+Per-thread operation registry.
+
+Each thread maintains a stack of `(name, kwargs, started_monotonic)`. The
+deepest entry is "what this thread is doing right now". The watchdog and
+heartbeat threads call `snapshot()` to see the live state of every thread.
+"""
+
+import threading
+import time
+from typing import Any
+
+from metadata.ingestion.diagnostics import KWARGS_TRUNCATION_CHARS, OP_STACK_DEPTH_CAP
+
+
+class OperationRegistry:
+    """Thread-safe per-thread operation stack."""
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        # thread_id -> list of (name, kwargs, started_monotonic, token)
+        self._stacks: dict[int, list[tuple[str, dict[str, Any], float, int]]] = {}
+        self._token_counter = 0
+
+    def push(self, name: str, kwargs: dict[str, Any]) -> int:
+        """Push a new operation for the calling thread. Returns a token used by pop()."""
+        tid = threading.get_ident()
+        truncated = _truncate_kwargs(kwargs)
+        now = time.monotonic()
+        with self._lock:
+            self._token_counter += 1
+            token = self._token_counter
+            stack = self._stacks.setdefault(tid, [])
+            if len(stack) >= OP_STACK_DEPTH_CAP:
+                # Refuse to grow. Returning -1 means pop() is a no-op for
+                # this entry, but the caller's `with` block still works.
+                return -1
+            stack.append((name, truncated, now, token))
+        return token
+
+    def pop(self, token: int) -> None:
+        """Pop the operation identified by `token`.
+
+        We match by token (not "always the top") so that a misnested
+        operation() — e.g. due to a generator that didn't get fully
+        consumed — doesn't desync the stack permanently.
+        """
+        if token < 0:
+            return
+        tid = threading.get_ident()
+        with self._lock:
+            stack = self._stacks.get(tid)
+            if not stack:
+                return
+            for i in range(len(stack) - 1, -1, -1):
+                if stack[i][3] == token:
+                    del stack[i:]
+                    break
+            if not stack:
+                del self._stacks[tid]
+
+    def snapshot(self) -> dict[int, list[tuple[str, dict[str, Any], float]]]:
+        """Return a copy of every thread's current op stack with `(name, kwargs, age_seconds)`."""
+        now = time.monotonic()
+        out: dict[int, list[tuple[str, dict[str, Any], float]]] = {}
+        with self._lock:
+            for tid, stack in self._stacks.items():
+                out[tid] = [(name, kwargs, now - started) for (name, kwargs, started, _) in stack]
+        return out
+
+    def deepest_per_thread(self) -> dict[int, tuple[str, dict[str, Any], float]]:
+        """For each thread, the bottom-most (most recently entered) operation."""
+        snap = self.snapshot()
+        return {tid: stack[-1] for tid, stack in snap.items() if stack}
+
+    def gc_dead_threads(self, alive_idents: set) -> None:
+        """Drop entries for threads that no longer exist."""
+        with self._lock:
+            dead = [tid for tid in self._stacks if tid not in alive_idents]
+            for tid in dead:
+                del self._stacks[tid]
+
+
+def _truncate_kwargs(kwargs: dict[str, Any]) -> dict[str, Any]:
+    """Keep references small: long strings get truncated, non-str values stringified."""
+    out: dict[str, Any] = {}
+    for key, value in kwargs.items():
+        if isinstance(value, str):
+            if len(value) > KWARGS_TRUNCATION_CHARS:
+                out[key] = value[:KWARGS_TRUNCATION_CHARS] + f"...(+{len(value) - KWARGS_TRUNCATION_CHARS} chars)"
+            else:
+                out[key] = value
+        else:
+            try:
+                s = repr(value)
+            except Exception:
+                s = "<unreprable>"
+            if len(s) > KWARGS_TRUNCATION_CHARS:
+                s = s[:KWARGS_TRUNCATION_CHARS] + f"...(+{len(s) - KWARGS_TRUNCATION_CHARS} chars)"
+            out[key] = s
+    return out
+
+
+def format_op_frame(name: str, kwargs: dict[str, Any], age: float) -> str:
+    """Single-line rendering of one op-stack frame for dump output."""
+    if kwargs:
+        kvs = " ".join(f"{k}={v!r}" for k, v in kwargs.items())
+        return f"{name} ({_fmt_age(age)}) {kvs}"
+    return f"{name} ({_fmt_age(age)})"
+
+
+def _fmt_age(seconds: float) -> str:
+    if seconds < 1:
+        return f"{int(seconds * 1000)}ms"
+    if seconds < 60:
+        return f"{seconds:.1f}s"
+    if seconds < 3600:
+        m, s = divmod(int(seconds), 60)
+        return f"{m}m{s:02d}s"
+    h, rem = divmod(int(seconds), 3600)
+    m, _ = divmod(rem, 60)
+    return f"{h}h{m:02d}m"

--- a/ingestion/src/metadata/ingestion/diagnostics/signals.py
+++ b/ingestion/src/metadata/ingestion/diagnostics/signals.py
@@ -1,0 +1,314 @@
+#  Copyright 2025 Collate
+#  Licensed under the Collate Community License, Version 1.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  https://github.com/open-metadata/OpenMetadata/blob/main/ingestion/LICENSE
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+"""
+Signal-triggered dumps.
+
+SIGUSR1 = full dump (threads + ops + http + memory).
+SIGUSR2 = incremental (ops + http + memory only).
+faulthandler.register(SIGABRT) is a free belt-and-braces for fatal aborts.
+
+Output routing
+--------------
+`emit_full_dump()` / `emit_incremental_dump()` accept a `signal_safe` flag:
+
+  * `signal_safe=False` (default; watchdog auto-dump, programmatic `dump()`):
+    accumulate into an in-memory buffer, then emit as ONE log record via
+    `metadata.Diagnostics`. The whole dump ships through `StreamableLogHandler`
+    as a single payload (no S3 line splitting) and through any other
+    configured handler.
+
+  * `signal_safe=True` (SIGUSR1 / SIGUSR2 handler):
+    write directly to `sys.stderr`. Cannot use the logger from signal
+    context — Python's logging module takes per-handler RLocks, which is
+    not signal-safe (can deadlock against the very thread that was holding
+    the lock when the signal was delivered).
+"""
+
+import faulthandler
+import io
+import logging
+import os
+import signal
+import sys
+import threading
+import time
+import traceback
+from typing import Any
+
+from metadata.ingestion.diagnostics import DIAG_LOG_PREFIX, emit_log
+from metadata.ingestion.diagnostics.memory import (
+    MemoryTracker,
+    format_bytes,
+    format_signed_bytes,
+)
+from metadata.ingestion.diagnostics.registry import OperationRegistry, format_op_frame
+
+
+def install_signal_handlers(
+    registry: OperationRegistry,
+    http_tracker: Any,
+    memory_tracker: MemoryTracker,
+    workflow: Any,
+) -> bool:
+    """Wire SIGUSR1 / SIGUSR2 / faulthandler.
+
+    Returns True on success. On Windows (no SIGUSR1) or when called
+    from a non-main thread, falls back gracefully without raising.
+    """
+    if threading.current_thread() is not threading.main_thread():
+        # Python's signal handlers can only be installed from the main
+        # thread. If the workflow happens to run in a worker thread
+        # (rare but possible), skip signal installation and let the
+        # watchdog/heartbeat do the work.
+        emit_log(logging.WARNING, f"{DIAG_LOG_PREFIX}.install.signals skipped reason=not-main-thread")
+        return False
+
+    installed_any = False
+    try:
+        faulthandler.enable(file=sys.stderr)
+        installed_any = True
+    except Exception as exc:
+        emit_log(logging.WARNING, f"{DIAG_LOG_PREFIX}.install.faulthandler failed err={exc!r}")
+
+    sigusr1 = getattr(signal, "SIGUSR1", None)
+    sigusr2 = getattr(signal, "SIGUSR2", None)
+
+    if sigusr1 is not None:
+        try:
+            signal.signal(
+                sigusr1,
+                _make_full_dump_handler(registry, http_tracker, memory_tracker, workflow),
+            )
+            installed_any = True
+        except (OSError, ValueError) as exc:
+            emit_log(logging.WARNING, f"{DIAG_LOG_PREFIX}.install.sigusr1 failed err={exc!r}")
+
+    if sigusr2 is not None:
+        try:
+            signal.signal(
+                sigusr2,
+                _make_incremental_dump_handler(registry, http_tracker, memory_tracker),
+            )
+            installed_any = True
+        except (OSError, ValueError) as exc:
+            emit_log(logging.WARNING, f"{DIAG_LOG_PREFIX}.install.sigusr2 failed err={exc!r}")
+
+    return installed_any
+
+
+def _make_full_dump_handler(
+    registry: OperationRegistry,
+    http_tracker: Any,
+    memory_tracker: MemoryTracker,
+    workflow: Any,
+) -> Any:
+    def _handler(_signum: int, _frame: Any) -> None:
+        # Signal context -- must NOT use the logger (per-handler RLocks
+        # are not signal-safe). Stay on raw stderr.
+        try:
+            emit_full_dump(
+                reason="sigusr1",
+                registry=registry,
+                http_tracker=http_tracker,
+                memory_tracker=memory_tracker,
+                workflow=workflow,
+                signal_safe=True,
+            )
+        except Exception as exc:
+            sys.stderr.write(f"{DIAG_LOG_PREFIX}.dump.error reason=sigusr1 err={exc!r}\n")
+            sys.stderr.flush()
+
+    return _handler
+
+
+def _make_incremental_dump_handler(
+    registry: OperationRegistry,
+    http_tracker: Any,
+    memory_tracker: MemoryTracker,
+) -> Any:
+    def _handler(_signum: int, _frame: Any) -> None:
+        try:
+            emit_incremental_dump(
+                registry=registry,
+                http_tracker=http_tracker,
+                memory_tracker=memory_tracker,
+                signal_safe=True,
+            )
+        except Exception as exc:
+            sys.stderr.write(f"{DIAG_LOG_PREFIX}.dump.error reason=sigusr2 err={exc!r}\n")
+            sys.stderr.flush()
+
+    return _handler
+
+
+def emit_full_dump(
+    reason: str,
+    registry: OperationRegistry,
+    http_tracker: Any,
+    memory_tracker: MemoryTracker,
+    workflow: Any = None,
+    signal_safe: bool = False,
+) -> None:
+    """Emit the full dump (threads + ops + http + memory + workflow).
+
+    `signal_safe=True` writes synchronously to `sys.stderr` so the call
+    is safe from a signal handler. `signal_safe=False` (the default)
+    accumulates into a buffer and emits the entire block through the
+    diagnostics logger as a single record, so it ships via whatever
+    handlers the workflow has configured (StreamableLogHandler, file,
+    etc.) without splitting across lines.
+    """
+    buf: io.StringIO | None = None if signal_safe else io.StringIO()
+    out = sys.stderr if buf is None else buf
+    out.write(f"{DIAG_LOG_PREFIX}.dump.begin reason={reason} pid={os.getpid()} ts={time.time():.0f}\n")
+    try:
+        _emit_thread_dump(out, signal_safe=signal_safe)
+        _emit_op_dump(out, registry)
+        _emit_http_dump(out, http_tracker)
+        _emit_memory_dump(out, memory_tracker, deep=True)
+        _emit_queues_dump(out)
+        _emit_workflow_dump(out, workflow)
+    except Exception as exc:
+        out.write(f"{DIAG_LOG_PREFIX}.dump.error err={exc!r}\n")
+    out.write(f"{DIAG_LOG_PREFIX}.dump.end reason={reason}\n")
+    if buf is None:
+        out.flush()
+    else:
+        emit_log(logging.WARNING, buf.getvalue().rstrip("\n"))
+
+
+def emit_incremental_dump(
+    registry: OperationRegistry,
+    http_tracker: Any,
+    memory_tracker: MemoryTracker,
+    signal_safe: bool = False,
+) -> None:
+    """Emit ops + http + memory (no thread tracebacks, no top_types).
+
+    Same routing semantics as `emit_full_dump`.
+    """
+    buf: io.StringIO | None = None if signal_safe else io.StringIO()
+    out = sys.stderr if buf is None else buf
+    out.write(f"{DIAG_LOG_PREFIX}.dump.begin reason=sigusr2 pid={os.getpid()} ts={time.time():.0f}\n")
+    _emit_op_dump(out, registry)
+    _emit_http_dump(out, http_tracker)
+    _emit_memory_dump(out, memory_tracker, deep=False)
+    _emit_queues_dump(out)
+    out.write(f"{DIAG_LOG_PREFIX}.dump.end reason=sigusr2\n")
+    if buf is None:
+        out.flush()
+    else:
+        emit_log(logging.INFO, buf.getvalue().rstrip("\n"))
+
+
+def _emit_thread_dump(out: Any, signal_safe: bool) -> None:
+    """Render per-thread stack traces.
+
+    Signal-safe path uses `faulthandler.dump_traceback`, which writes
+    via a real fd and captures both Python and native (C extension)
+    frames. Non-signal-safe path (StringIO target, used when shipping
+    via the logger) uses `sys._current_frames()` +
+    `traceback.format_stack` — Python frames only, but works with any
+    file-like.
+    """
+    out.write(f"{DIAG_LOG_PREFIX}.dump.threads\n")
+    if signal_safe:
+        try:
+            faulthandler.dump_traceback(file=out, all_threads=True)
+        except Exception as exc:
+            out.write(f"{DIAG_LOG_PREFIX}.dump.threads.error err={exc!r}\n")
+        return
+    try:
+        name_by_ident = {t.ident: t.name for t in threading.enumerate() if t.ident}
+        for tid, frame in sys._current_frames().items():
+            thread_name = name_by_ident.get(tid, f"tid-{tid}")
+            out.write(f"  thread={thread_name}({tid})\n")
+            for line in traceback.format_stack(frame):
+                for sub in line.rstrip("\n").splitlines():
+                    out.write(f"    {sub}\n")
+    except Exception as exc:
+        out.write(f"{DIAG_LOG_PREFIX}.dump.threads.error err={exc!r}\n")
+
+
+def _emit_op_dump(out: Any, registry: OperationRegistry) -> None:
+    out.write(f"{DIAG_LOG_PREFIX}.dump.ops\n")
+    snapshot = registry.snapshot()
+    if not snapshot:
+        out.write("  (no active operations)\n")
+        return
+    name_by_ident = {t.ident: t.name for t in threading.enumerate() if t.ident}
+    for tid, stack in snapshot.items():
+        thread_name = name_by_ident.get(tid, f"tid-{tid}")
+        out.write(f"  thread={thread_name}({tid})\n")
+        for name, kwargs, age in stack:
+            out.write(f"    -> {format_op_frame(name, kwargs, age)}\n")
+
+
+def _emit_http_dump(out: Any, http_tracker: Any) -> None:
+    out.write(f"{DIAG_LOG_PREFIX}.dump.http\n")
+    active = http_tracker.snapshot()
+    if not active:
+        out.write("  (no in-flight requests)\n")
+        return
+    name_by_ident = {t.ident: t.name for t in threading.enumerate() if t.ident}
+    for tid, method, url, age in sorted(active, key=lambda r: -r[3]):
+        thread_name = name_by_ident.get(tid, f"tid-{tid}")
+        out.write(f"  thread={thread_name} method={method} url={url} age={age:.1f}s\n")
+
+
+def _emit_memory_dump(out: Any, memory_tracker: MemoryTracker, deep: bool) -> None:
+    out.write(f"{DIAG_LOG_PREFIX}.dump.memory\n")
+    sample = memory_tracker.sample()
+    delta_30s = memory_tracker.rss_delta_bytes_since(30.0)
+    out.write(
+        f"  rss={format_bytes(sample.rss)} "
+        f"rss_delta_30s={format_signed_bytes(delta_30s)} "
+        f"cgroup_current={format_bytes(sample.cgroup_current)} "
+        f"cgroup_max={format_bytes(sample.cgroup_max)} "
+        f"oom_kills={sample.oom_kill_count if sample.oom_kill_count is not None else '?'}\n"
+    )
+    if deep:
+        out.write("  top_types:\n")
+        for type_name, count in memory_tracker.top_object_types():
+            out.write(f"    {type_name:<32} {count}\n")
+
+
+def _emit_queues_dump(out: Any) -> None:
+    """Render inter-stage queue depths + put/processed counters."""
+    from metadata.ingestion.diagnostics import stage_progress  # noqa: PLC0415
+
+    queues = stage_progress.snapshot()
+    if not queues:
+        return
+    out.write(f"{DIAG_LOG_PREFIX}.dump.queues\n")
+    for q in queues:
+        out.write(f"  name={q['name']} depth={q['depth']} put={q['put']} processed={q['processed']}\n")
+
+
+def _emit_workflow_dump(out: Any, workflow: Any) -> None:
+    if workflow is None:
+        return
+    out.write(f"{DIAG_LOG_PREFIX}.dump.workflow\n")
+    try:
+        steps = workflow.workflow_steps() if hasattr(workflow, "workflow_steps") else []
+    except Exception as exc:
+        out.write(f"  (could not enumerate steps: {exc!r})\n")
+        return
+    for step in steps:
+        try:
+            status = step.get_status()
+            out.write(
+                f"  step={step.name} records={getattr(status, 'record_count', '?')} "
+                f"failures={len(getattr(status, 'failures', []))} "
+                f"filtered={len(getattr(status, 'filtered', []))}\n"
+            )
+        except Exception as exc:
+            out.write(f"  step={getattr(step, 'name', '?')} dump_error={exc!r}\n")

--- a/ingestion/src/metadata/ingestion/diagnostics/stage_progress.py
+++ b/ingestion/src/metadata/ingestion/diagnostics/stage_progress.py
@@ -1,0 +1,148 @@
+#  Copyright 2025 Collate
+#  Licensed under the Collate Community License, Version 1.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  https://github.com/open-metadata/OpenMetadata/blob/main/ingestion/LICENSE
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+"""
+Stage backpressure collector.
+
+Tracks the depth and put/processed counts of the inter-stage queues used
+by `TopologyRunnerMixin`, so heartbeats and dumps can show "source
+produced 1000, sink consumed 50, depth 950" — the signal that
+distinguishes a slow source from a slow sink.
+
+The Queue class (in `models/topology.py`) calls the module-level
+`record_put` / `record_processed` / `register_queue` hooks on every
+operation. When diagnostics is OFF those hooks are no-ops with a single
+attribute load, so the queue stays cheap.
+"""
+
+import threading
+import weakref
+from typing import Any
+
+_collector: "StageProgressCollector | None" = None
+
+
+class StageProgressCollector:
+    """In-memory counters for inter-stage queues."""
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        # name -> weak references to live queue instances (one queue may have
+        # several writers in different threads; we keep refs to all)
+        self._queues: dict[str, list[weakref.ref]] = {}
+        # name -> running counters
+        self._counts: dict[str, dict[str, int]] = {}
+
+    def register(self, name: str, queue_obj: Any) -> None:
+        ref = weakref.ref(queue_obj)
+        with self._lock:
+            self._queues.setdefault(name, []).append(ref)
+            self._counts.setdefault(name, {"put": 0, "processed": 0})
+
+    def record_put(self, name: str, n: int = 1) -> None:
+        with self._lock:
+            counts = self._counts.setdefault(name, {"put": 0, "processed": 0})
+            counts["put"] += n
+
+    def record_processed(self, name: str, n: int = 1) -> None:
+        with self._lock:
+            counts = self._counts.setdefault(name, {"put": 0, "processed": 0})
+            counts["processed"] += n
+
+    def snapshot(self) -> list[dict[str, Any]]:
+        """Return per-queue snapshot: name, current depth, totals.
+
+        Also garbage-collects weakrefs to queues that have been
+        deallocated.
+        """
+        out = []
+        with self._lock:
+            for name, refs in list(self._queues.items()):
+                live_refs = []
+                depth = 0
+                for ref in refs:
+                    queue_obj = ref()
+                    if queue_obj is None:
+                        continue
+                    live_refs.append(ref)
+                    depth += _queue_depth(queue_obj)
+                self._queues[name] = live_refs
+                counts = self._counts.get(name, {"put": 0, "processed": 0})
+                out.append(
+                    {
+                        "name": name,
+                        "depth": depth,
+                        "put": counts["put"],
+                        "processed": counts["processed"],
+                    }
+                )
+        return out
+
+
+def _queue_depth(queue_obj: Any) -> int:
+    """Best-effort depth read from a topology Queue wrapper or std queue.Queue."""
+    inner = getattr(queue_obj, "_queue", queue_obj)
+    try:
+        return int(inner.qsize())
+    except Exception:
+        return 0
+
+
+def install(collector: StageProgressCollector) -> None:
+    """Wire the module-level hook so `Queue` operations are tracked."""
+    global _collector  # noqa: PLW0603  module-level singleton
+    _collector = collector
+
+
+def uninstall() -> None:
+    global _collector  # noqa: PLW0603  module-level singleton
+    _collector = None
+
+
+def register_queue(name: str, queue_obj: Any) -> None:
+    """Called from `Queue.__init__`. No-op when diagnostics is off."""
+    collector = _collector
+    if collector is not None:
+        collector.register(name, queue_obj)
+
+
+def record_put(name: str, n: int = 1) -> None:
+    """Called from `Queue.put`. No-op when diagnostics is off."""
+    collector = _collector
+    if collector is not None:
+        collector.record_put(name, n)
+
+
+def record_processed(name: str, n: int = 1) -> None:
+    """Called from `Queue.process` (per item yielded). No-op when off."""
+    collector = _collector
+    if collector is not None:
+        collector.record_processed(name, n)
+
+
+def snapshot() -> list[dict[str, Any]]:
+    """Used by heartbeat + dump rendering."""
+    collector = _collector
+    if collector is None:
+        return []
+    return collector.snapshot()
+
+
+def format_for_heartbeat() -> str:
+    """Render `stage_queues=` field for heartbeat lines.
+
+    Returns empty string when there's nothing to report so heartbeats
+    stay clean.
+    """
+    queues = snapshot()
+    if not queues:
+        return ""
+    parts = [f"{q['name']}:{q['depth']}({q['put']}->{q['processed']})" for q in queues]
+    return " stage_queues=" + ",".join(parts)

--- a/ingestion/src/metadata/ingestion/diagnostics/time_accounting.py
+++ b/ingestion/src/metadata/ingestion/diagnostics/time_accounting.py
@@ -1,0 +1,190 @@
+#  Copyright 2025 Collate
+#  Licensed under the Collate Community License, Version 1.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  https://github.com/open-metadata/OpenMetadata/blob/main/ingestion/LICENSE
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+"""
+Workflow time-accounting via operation-registry sampling.
+
+A daemon thread samples the registry every 100 ms, looks at the deepest
+op on each thread, and credits the elapsed interval to a category
+bucket. At workflow end we emit one `diag.time_budget` line that
+answers, on its own:
+
+  * How long did the workflow take wall-clock?
+  * What fraction of that was "doing something" (active) vs "doing
+    nothing" (idle)?
+  * Within active time, how much was DB queries, OMeta HTTP, source
+    iteration, sink writes, etc.?
+  * Which specific ops took the most time?
+
+Categorization
+--------------
+The deepest op on a thread defines the category:
+
+  * `workflow.execute` (only thing on stack)  -> idle (not credited to
+    any category, but `idle_walltime` is incremented)
+  * `{dialect}.query`                          -> db
+  * `ometa.http`                               -> ometa_http
+  * `source.iter`                              -> source
+  * `sink.write`                               -> sink
+  * `processor.run`                            -> processor
+  * `stage.run` / `bulksink.run`               -> stage / bulksink
+  * anything else                              -> other
+
+If MULTIPLE threads are active in the same tick (e.g., main is iterating
+the source while a worker thread is running a SQL query), each
+contributing category gets credited for that tick. As a result, the
+per-category totals may sum to more than `active_walltime` — that's the
+expected behavior under multithread sources, and the summary line
+documents it.
+
+Perf
+----
+At 100 ms cadence: ~10 ticks/sec x ~5 us per snapshot = ~50 us/sec =
+0.005% CPU. The sampler thread holds the registry's lock only for the
+duration of `snapshot()`, which is O(threads).
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from collections import defaultdict
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from metadata.ingestion.diagnostics.registry import OperationRegistry
+
+TIME_ACCOUNTING_INTERVAL_SECONDS = 0.1
+
+
+def _categorize(op_name: str) -> str:
+    """Map an op name to a coarse category for the time budget."""
+    if op_name == "workflow.execute":
+        return "idle"
+    if op_name == "ometa.http":
+        return "ometa_http"
+    if op_name.endswith(".query"):
+        return "db"
+    if op_name == "source.iter":
+        return "source"
+    if op_name == "sink.write":
+        return "sink"
+    if op_name == "processor.run":
+        return "processor"
+    if op_name == "stage.run":
+        return "stage"
+    if op_name == "bulksink.run":
+        return "bulksink"
+    return "other"
+
+
+class TimeAccountingSampler(threading.Thread):
+    """Daemon thread that samples the registry and accumulates per-category time."""
+
+    def __init__(
+        self,
+        registry: OperationRegistry,
+        interval: float = TIME_ACCOUNTING_INTERVAL_SECONDS,
+    ) -> None:
+        super().__init__(name="diag-time-accounting", daemon=True)
+        self._registry = registry
+        self._interval = interval
+        self._stop_event = threading.Event()
+        self._lock = threading.Lock()
+        self._totals: dict[str, float] = defaultdict(float)
+        self._op_times: dict[str, float] = defaultdict(float)
+        self._active_walltime: float = 0.0
+        self._idle_walltime: float = 0.0
+        self._sample_count: int = 0
+        self._started_at = time.monotonic()
+
+    def stop(self) -> None:
+        self._stop_event.set()
+
+    def run(self) -> None:
+        last_tick = time.monotonic()
+        while not self._stop_event.wait(self._interval):
+            now = time.monotonic()
+            delta = now - last_tick
+            last_tick = now
+            try:
+                self.sample(delta)
+            except Exception:
+                # Diagnostics must never break the workflow it monitors.
+                continue
+
+    def sample(self, delta: float) -> None:
+        """Record one sample worth `delta` seconds.
+
+        Public so tests can drive the sampler with deterministic ticks
+        instead of waiting for the real cadence.
+
+        One lock acquisition for the whole update — sample() runs only
+        from this daemon thread; the lock protects readers from
+        `snapshot()` and ensures they see a consistent post-tick state
+        rather than partial mutations.
+        """
+        deepest = self._registry.deepest_per_thread()
+        active_categories: set[str] = set()
+        with self._lock:
+            for op_name, _kwargs, _age in deepest.values():
+                category = _categorize(op_name)
+                if category != "idle":
+                    active_categories.add(category)
+                self._op_times[op_name] += delta
+            self._sample_count += 1
+            if active_categories:
+                for cat in active_categories:
+                    self._totals[cat] += delta
+                self._active_walltime += delta
+            else:
+                self._idle_walltime += delta
+
+    def snapshot(self) -> dict[str, Any]:
+        with self._lock:
+            elapsed = time.monotonic() - self._started_at
+            return {
+                "elapsed_seconds": elapsed,
+                "samples": self._sample_count,
+                "active_walltime": self._active_walltime,
+                "idle_walltime": self._idle_walltime,
+                "categories": dict(self._totals),
+                "top_ops": sorted(self._op_times.items(), key=lambda kv: -kv[1])[:10],
+            }
+
+    def summary_log_line(self, prefix: str = "diag.time_budget") -> str:
+        """Render the end-of-workflow summary as one structured line."""
+        snap = self.snapshot()
+        elapsed = snap["elapsed_seconds"]
+        if elapsed <= 0 or snap["samples"] == 0:
+            return f"{prefix} elapsed={elapsed:.1f}s samples={snap['samples']} (no data)"
+
+        active = snap["active_walltime"]
+        idle = snap["idle_walltime"]
+        active_pct = active / elapsed * 100
+        idle_pct = idle / elapsed * 100
+
+        cats = snap["categories"]
+        ordered = ("db", "ometa_http", "source", "sink", "processor", "stage", "bulksink", "other")
+        cat_parts = [
+            f"{name}={cats[name]:.1f}s({cats[name] / elapsed * 100:.0f}%)" for name in ordered if cats.get(name, 0) > 0
+        ]
+
+        top_parts = [f"{name}={t:.1f}s" for name, t in snap["top_ops"][:5] if t > 0]
+
+        return (
+            f"{prefix} "
+            f"elapsed={elapsed:.1f}s "
+            f"samples={snap['samples']} "
+            f"active={active:.1f}s({active_pct:.1f}%) "
+            f"idle={idle:.1f}s({idle_pct:.1f}%) "
+            f"by_category=[{','.join(cat_parts)}] "
+            f"top_ops=[{','.join(top_parts)}]"
+        )

--- a/ingestion/src/metadata/ingestion/diagnostics/watchdog.py
+++ b/ingestion/src/metadata/ingestion/diagnostics/watchdog.py
@@ -1,0 +1,226 @@
+#  Copyright 2025 Collate
+#  Licensed under the Collate Community License, Version 1.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  https://github.com/open-metadata/OpenMetadata/blob/main/ingestion/LICENSE
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+"""
+Watchdog daemon thread.
+
+Every WATCHDOG_TICK_SECONDS:
+  - Look at the deepest active operation for each thread.
+  - If a thread has been on the same op for > STUCK_WARN_SECONDS:
+      emit `diag.warn.stuck` (once per (thread, op) per REDUMP_THROTTLE_SECONDS).
+  - If a thread has been on the same op for > AUTO_DUMP_SECONDS:
+      trigger a full dump (once per (thread, op) per REDUMP_THROTTLE_SECONDS).
+
+This is the component that makes hung processes self-diagnose. No human
+needs to be watching the pod for the data to be captured.
+"""
+
+import logging
+import threading
+import time
+from typing import Any
+
+from metadata.ingestion.diagnostics import (
+    AUTO_DUMP_SECONDS,
+    DIAG_LOG_PREFIX,
+    PRESSURE_DUMP_THROTTLE_SECONDS,
+    PRESSURE_PSI_AVG10_THRESHOLD,
+    REDUMP_THROTTLE_SECONDS,
+    STUCK_WARN_SECONDS,
+    WATCHDOG_TICK_SECONDS,
+    emit_log,
+)
+from metadata.ingestion.diagnostics.memory import MemorySample
+from metadata.ingestion.diagnostics.registry import OperationRegistry, format_op_frame
+from metadata.ingestion.diagnostics.signals import emit_full_dump
+
+
+class WatchdogThread(threading.Thread):
+    """Background thread that auto-warns and auto-dumps on hangs."""
+
+    def __init__(
+        self,
+        registry: OperationRegistry,
+        http_tracker: Any,
+        memory_tracker: Any,
+        workflow: Any,
+    ) -> None:
+        super().__init__(name="diag-watchdog", daemon=True)
+        self._registry = registry
+        self._http_tracker = http_tracker
+        self._memory_tracker = memory_tracker
+        self._workflow = workflow
+        self._stop_event = threading.Event()
+        # (thread_id, op_name) -> monotonic timestamp of last action
+        self._last_warned: dict[tuple[int, str], float] = {}
+        self._last_dumped: dict[tuple[int, str], float] = {}
+        # reason -> monotonic timestamp of last pressure-triggered dump.
+        # Reasons live in their own throttle map so a PSI trip and a
+        # cgroup-events.high trip can each fire once per window.
+        self._last_pressure_dumped: dict[str, float] = {}
+        # Last seen cgroup `memory.events.high` counter — used to detect
+        # deltas (the kernel monotonically increments it on throttling).
+        self._last_events_high: int | None = None
+        self._last_events_oom: int | None = None
+
+    def stop(self) -> None:
+        self._stop_event.set()
+
+    def run(self) -> None:
+        while not self._stop_event.wait(WATCHDOG_TICK_SECONDS):
+            try:
+                self._tick()
+            except Exception as exc:
+                emit_log(logging.ERROR, f"{DIAG_LOG_PREFIX}.watchdog.error err={exc!r}")
+
+    def _tick(self) -> None:
+        alive_idents = {t.ident for t in threading.enumerate() if t.ident is not None}
+        self._registry.gc_dead_threads(alive_idents)
+        name_by_ident = {t.ident: t.name for t in threading.enumerate() if t.ident}
+        now = time.monotonic()
+
+        for tid, (op_name, kwargs, age) in self._registry.deepest_per_thread().items():
+            if age < STUCK_WARN_SECONDS:
+                continue
+
+            key = (tid, op_name)
+            thread_name = name_by_ident.get(tid, f"tid-{tid}")
+
+            if age >= AUTO_DUMP_SECONDS and self._should_fire(self._last_dumped, key, now):
+                self._last_dumped[key] = now
+                # A dump implies a warn — track the warn timestamp too so
+                # we don't double-log.
+                self._last_warned[key] = now
+                self._emit_auto_dump(thread_name, op_name, kwargs, age)
+                continue
+
+            if self._should_fire(self._last_warned, key, now):
+                self._last_warned[key] = now
+                self._emit_stuck_warn(thread_name, op_name, kwargs, age)
+
+        # Pre-OOM tripwire — read pressure signals on the same tick.
+        self._check_pressure_tripwires(now)
+
+    def _check_pressure_tripwires(self, now: float) -> None:
+        """Sample memory pressure and dump if any tripwire fires.
+
+        Three signals (in order of reliability):
+          1. PSI `some avg10` > threshold — kernel reports the cgroup
+             stalled on memory for >N% of the last 10 seconds.
+          2. cgroup `memory.events.high` counter incremented since
+             the previous tick — kernel started throttling the cgroup
+             for crossing the `memory.high` soft limit.
+          3. cgroup `memory.events.oom` counter incremented — kernel
+             attempted an OOM resolution inside the cgroup.
+
+        Each signal has its own throttle so a sustained pressure event
+        doesn't loop on dumps.
+        """
+        try:
+            sample = self._memory_tracker.sample()
+        except Exception as exc:
+            emit_log(logging.WARNING, f"{DIAG_LOG_PREFIX}.watchdog.sample_error err={exc!r}")
+            return
+
+        self._check_psi_tripwire(sample, now)
+        self._check_events_high_tripwire(sample, now)
+        self._check_events_oom_tripwire(sample, now)
+
+    def _check_psi_tripwire(self, sample: MemorySample, now: float) -> None:
+        psi = sample.psi_some_avg10
+        if psi is None or psi < PRESSURE_PSI_AVG10_THRESHOLD:
+            return
+        if not self._should_fire_pressure("psi", now):
+            return
+        self._fire_pressure_dump(
+            reason=f"memory-pressure-psi:avg10={psi:.1f}",
+            sample=sample,
+            now=now,
+            throttle_key="psi",
+        )
+
+    def _check_events_high_tripwire(self, sample: MemorySample, now: float) -> None:
+        current = sample.cgroup_events_high
+        if current is None:
+            return
+        previous = self._last_events_high
+        self._last_events_high = current
+        if previous is None or current <= previous:
+            return
+        if not self._should_fire_pressure("events.high", now):
+            return
+        self._fire_pressure_dump(
+            reason=f"memory-pressure-cgroup-high:delta={current - previous}",
+            sample=sample,
+            now=now,
+            throttle_key="events.high",
+        )
+
+    def _check_events_oom_tripwire(self, sample: MemorySample, now: float) -> None:
+        current = sample.cgroup_events_oom
+        if current is None:
+            return
+        previous = self._last_events_oom
+        self._last_events_oom = current
+        if previous is None or current <= previous:
+            return
+        if not self._should_fire_pressure("events.oom", now):
+            return
+        self._fire_pressure_dump(
+            reason=f"memory-pressure-cgroup-oom:delta={current - previous}",
+            sample=sample,
+            now=now,
+            throttle_key="events.oom",
+        )
+
+    def _should_fire_pressure(self, key: str, now: float) -> bool:
+        previous = self._last_pressure_dumped.get(key)
+        return previous is None or (now - previous) >= PRESSURE_DUMP_THROTTLE_SECONDS
+
+    def _fire_pressure_dump(self, reason: str, sample: MemorySample, now: float, throttle_key: str) -> None:
+        self._last_pressure_dumped[throttle_key] = now
+        emit_log(
+            logging.WARNING,
+            f"{DIAG_LOG_PREFIX}.warn.memory_pressure reason={reason} "
+            f"rss={sample.rss} cgroup_current={sample.cgroup_current} "
+            f"cgroup_max={sample.cgroup_max} psi_avg10={sample.psi_some_avg10}",
+        )
+        emit_full_dump(
+            reason=reason,
+            registry=self._registry,
+            http_tracker=self._http_tracker,
+            memory_tracker=self._memory_tracker,
+            workflow=self._workflow,
+        )
+
+    @staticmethod
+    def _should_fire(last_map: dict[tuple[int, str], float], key: tuple[int, str], now: float) -> bool:
+        previous = last_map.get(key)
+        return previous is None or (now - previous) >= REDUMP_THROTTLE_SECONDS
+
+    def _emit_stuck_warn(self, thread_name: str, op_name: str, kwargs: dict, age: float) -> None:
+        frame = format_op_frame(op_name, kwargs, age)
+        emit_log(
+            logging.WARNING,
+            f"{DIAG_LOG_PREFIX}.warn.stuck thread={thread_name} op={op_name} duration={age:.0f}s frame={frame}",
+        )
+
+    def _emit_auto_dump(self, thread_name: str, op_name: str, kwargs: dict, age: float) -> None:
+        emit_log(
+            logging.WARNING,
+            f"{DIAG_LOG_PREFIX}.watchdog.auto_dump thread={thread_name} op={op_name} duration={age:.0f}s",
+        )
+        emit_full_dump(
+            reason=f"watchdog:{op_name}@{thread_name}:{age:.0f}s",
+            registry=self._registry,
+            http_tracker=self._http_tracker,
+            memory_tracker=self._memory_tracker,
+            workflow=self._workflow,
+        )

--- a/ingestion/src/metadata/ingestion/models/topology.py
+++ b/ingestion/src/metadata/ingestion/models/topology.py
@@ -307,10 +307,27 @@ class TopologyContextManager:
 
 
 class Queue:
-    """Small Queue wrapper"""
+    """Small Queue wrapper.
 
-    def __init__(self):
+    Inter-stage buffer used by `TopologyRunnerMixin`. When the diagnostics
+    subsystem is installed, every put/process call is reported to
+    `metadata.ingestion.diagnostics.stage_progress` so heartbeats can
+    render queue depth and source-vs-sink throughput. The hook calls are
+    no-ops with a single attribute load when diagnostics is off.
+    """
+
+    def __init__(self, name: str = "topology"):
         self._queue = queue.Queue()
+        self._name = name
+        # Lazy import — keeps the topology module importable even if the
+        # diagnostics package is not on the path (rare, but defensive).
+        try:
+            from metadata.ingestion.diagnostics import stage_progress  # noqa: PLC0415
+
+            stage_progress.register_queue(name, self)
+            self._stage_progress = stage_progress
+        except Exception:
+            self._stage_progress = None
 
     def has_tasks(self) -> bool:
         """Checks that the Queue is not Empty."""
@@ -321,6 +338,8 @@ class Queue:
         while True:
             try:
                 item = self._queue.get_nowait()
+                if self._stage_progress is not None:
+                    self._stage_progress.record_processed(self._name)
                 yield item
                 self._queue.task_done()
             except queue.Empty:
@@ -329,6 +348,8 @@ class Queue:
     def put(self, item: Any):
         """Puts new item in the Queue."""
         self._queue.put(item)
+        if self._stage_progress is not None:
+            self._stage_progress.record_put(self._name)
 
 
 def get_topology_nodes(topology: ServiceTopology) -> List[TopologyNode]:

--- a/ingestion/src/metadata/ingestion/ometa/client.py
+++ b/ingestion/src/metadata/ingestion/ometa/client.py
@@ -159,15 +159,17 @@ class REST:
 
         self._limits_reached = TTLCache(config.ttl_cache)
 
-    def _request(  # pylint: disable=too-many-arguments,too-many-branches
+    def _request(  # noqa: C901, pylint: disable=too-many-arguments,too-many-branches
         self,
-        method,
-        path,
-        data=None,
-        json=None,
-        base_url: URL = None,
-        api_version: str = None,
-        headers: dict = None,
+        method: str,
+        path: str,
+        data: Any = None,
+        json: Any = None,
+        base_url: Optional[URL] = None,  # noqa: UP045
+        api_version: Optional[str] = None,  # noqa: UP045
+        headers: Optional[dict] = None,  # noqa: UP045
+        timeout: Optional[Union[float, tuple[float, float]]] = None,  # noqa: UP007, UP045
+        retries: Optional[int] = None,  # noqa: UP045
     ):
         # pylint: disable=too-many-locals
         if path in self._limits_reached:
@@ -231,10 +233,14 @@ class REST:
         if self._cert:
             opts["cert"] = self._cert
 
-        if self._timeout:
-            opts["timeout"] = self._timeout
+        effective_timeout = timeout if timeout is not None else self._timeout
+        if effective_timeout:
+            opts["timeout"] = effective_timeout
 
-        total_retries = self._retry if self._retry > 0 else 0
+        if retries is not None:
+            total_retries = retries if retries > 0 else 0
+        else:
+            total_retries = self._retry if self._retry and self._retry > 0 else 0
         retry = total_retries
         while retry >= 0:
             try:
@@ -334,7 +340,15 @@ class REST:
         return self._request("GET", path, data, headers=headers)
 
     @calculate_execution_time(context="POST")
-    def post(self, path, data=None, json=None, headers=None):
+    def post(
+        self,
+        path: str,
+        data: Any = None,
+        json: Any = None,
+        headers: Optional[dict] = None,  # noqa: UP045
+        timeout: Optional[Union[float, tuple[float, float]]] = None,  # noqa: UP007, UP045
+        retries: Optional[int] = None,  # noqa: UP045
+    ):
         """
         POST method
 
@@ -343,11 +357,70 @@ class REST:
             data ():
             json ():
             headers (dict): Optional custom headers to override default headers
+            timeout: Per-call timeout that overrides the instance default
+            retries: Per-call retry budget that overrides the instance default.
+                     Pass 0 to disable the retry/sleep loop entirely.
 
         Returns:
             Response
         """
-        return self._request("POST", path, data, json, headers=headers)
+        return self._request(
+            "POST",
+            path,
+            data,
+            json,
+            headers=headers,
+            timeout=timeout,
+            retries=retries,
+        )
+
+    def post_best_effort(
+        self,
+        path: str,
+        data: Any = None,
+        headers: Optional[dict] = None,  # noqa: UP045
+        timeout: Optional[Union[float, tuple[float, float]]] = None,  # noqa: UP007, UP045
+    ) -> bool:
+        """Quiet POST: no retries, no sleep, no logging. Returns True on 2xx."""
+        if path in self._limits_reached:
+            return False
+        try:
+            url = URL(self._base_url + "/" + self._api_version + path)
+            req_headers = self._build_request_headers(headers)
+            kwargs = {
+                "data": data,
+                "headers": req_headers,
+                "verify": self._verify,
+                "cookies": self._cookies,
+                "allow_redirects": self.config.allow_redirects,
+            }
+            effective_timeout = timeout if timeout is not None else self._timeout
+            if effective_timeout:
+                kwargs["timeout"] = effective_timeout
+            if self._cert:
+                kwargs["cert"] = self._cert
+            resp = self._session.post(url, **kwargs)
+        except Exception:
+            return False
+        return 200 <= resp.status_code < 300
+
+    def _build_request_headers(self, headers: Optional[dict] = None):  # noqa: UP045
+        """Reader-only headers builder. Does NOT refresh auth token —
+        refresh stays on _request() to avoid concurrent refreshes from
+        post_best_effort callers sharing ClientConfig."""
+        if not headers:
+            headers = {"Content-type": "application/json"}
+        if self.config.auth_header and self.config.access_token:
+            headers[self.config.auth_header] = (
+                f"{self._auth_token_mode} {self.config.access_token}"
+                if self._auth_token_mode
+                else self.config.access_token
+            )
+        if self.config.extra_headers:
+            extra_headers: Dict[str, str] = self.config.extra_headers  # noqa: UP006
+            extra_headers = {k: (v % headers) for k, v in extra_headers.items()}
+            headers = {**headers, **extra_headers}
+        return headers
 
     @calculate_execution_time(context="PUT")
     def put(self, path, data=None, json=None, headers=None):

--- a/ingestion/src/metadata/ingestion/ometa/client.py
+++ b/ingestion/src/metadata/ingestion/ometa/client.py
@@ -11,16 +11,21 @@
 """
 Python API REST wrapper and helpers
 """
+
 import time
 import traceback
+from contextlib import nullcontext
 from datetime import datetime, timezone
-from typing import Any, Callable, Dict, List, Optional, Union
+from typing import Any, Callable, Dict, List, Optional, Union  # noqa: UP035
 
 import requests
 from requests.exceptions import HTTPError, JSONDecodeError
 
 from metadata.config.common import ConfigModel
+from metadata.ingestion import diagnostics
+from metadata.ingestion.diagnostics.http_introspect import get_global_tracker
 from metadata.ingestion.ometa.credentials import URL, get_api_version
+from metadata.ingestion.ometa.http_adapter import mount_resilient_adapter
 from metadata.ingestion.ometa.ttl_cache import TTLCache
 from metadata.ingestion.ometa.utils import sanitize_user_agent
 from metadata.utils.execution_time_tracker import calculate_execution_time
@@ -29,16 +34,26 @@ from metadata.utils.logger import ometa_logger
 logger = ometa_logger()
 
 
-class RetryException(Exception):
+class RetryException(Exception):  # noqa: N818
     """
     API Client retry exception
     """
 
 
-class LimitsException(Exception):
+class LimitsException(Exception):  # noqa: N818
     """
     API Client Feature Limit exception
     """
+
+
+class RestTransportError(Exception):
+    """Request failed at the transport layer (connection / timeout / retry exhaustion)."""
+
+    def __init__(self, method: str, url: object, cause: BaseException) -> None:
+        super().__init__(f"Transport failure on {method} {url}: {cause}")
+        self.method = method
+        self.url = url
+        self.cause = cause
 
 
 class APIError(Exception):
@@ -102,28 +117,28 @@ class ClientConfig(ConfigModel):
     """
 
     base_url: str
-    api_version: Optional[str] = "v1"
-    retry: Optional[int] = 3
-    retry_wait: Optional[int] = 30
-    limit_codes: List[int] = [429]
-    retry_codes: List[int] = [504]
-    auth_token: Optional[Callable] = None
-    access_token: Optional[str] = None
-    expires_in: Optional[int] = None
-    auth_header: Optional[str] = None
-    extra_headers: Optional[dict] = None
+    api_version: Optional[str] = "v1"  # noqa: UP045
+    retry: Optional[int] = 3  # noqa: UP045
+    retry_wait: Optional[int] = 30  # noqa: UP045
+    limit_codes: List[int] = [429]  # noqa: RUF012, UP006
+    retry_codes: List[int] = [504]  # noqa: RUF012, UP006
+    auth_token: Optional[Callable] = None  # noqa: UP045
+    access_token: Optional[str] = None  # noqa: UP045
+    expires_in: Optional[int] = None  # noqa: UP045
+    auth_header: Optional[str] = None  # noqa: UP045
+    extra_headers: Optional[dict] = None  # noqa: UP045
     user_agent: Optional[str] = None  # noqa: UP045
-    raw_data: Optional[bool] = False
-    allow_redirects: Optional[bool] = False
-    auth_token_mode: Optional[str] = "Bearer"
-    verify: Optional[Union[bool, str]] = None
-    cookies: Optional[Any] = None
+    raw_data: Optional[bool] = False  # noqa: UP045
+    allow_redirects: Optional[bool] = False  # noqa: UP045
+    auth_token_mode: Optional[str] = "Bearer"  # noqa: UP045
+    verify: Optional[Union[bool, str]] = None  # noqa: UP007, UP045
+    cookies: Optional[Any] = None  # noqa: UP045
     ttl_cache: int = 60
     # (connect, read) seconds. Default prevents indefinite hangs when a pooled
     # socket is silently severed (NAT/LB idle reaping). Override with None to
     # disable, or pass a single int to use the same value for both.
-    timeout: Optional[int | tuple[int, int]] = (10, 300)
-    cert: Optional[Union[str, tuple]] = None
+    timeout: Optional[int | tuple[int, int]] = (10, 300)  # noqa: UP045
+    cert: Optional[Union[str, tuple]] = None  # noqa: UP007, UP045
 
 
 # pylint: disable=too-many-instance-attributes
@@ -138,6 +153,7 @@ class REST:
         self._base_url: URL = URL(self.config.base_url)
         self._api_version = get_api_version(self.config.api_version)
         self._session = requests.Session()
+        mount_resilient_adapter(self._session)
         user_agent = sanitize_user_agent(self.config.user_agent)
         if user_agent:
             self._session.headers["User-Agent"] = user_agent
@@ -182,19 +198,17 @@ class REST:
         url: URL = URL(base_url + "/" + version + path)
         cookies = self._cookies
         if (
-            self.config.expires_in
+            self.config.expires_in  # noqa: RUF021
             and datetime.now(timezone.utc).timestamp() >= self.config.expires_in
-            or not self.config.access_token
+            or not self.config.access_token  # noqa: RUF021
             and self._auth_token
         ):
             self.config.access_token, expiry = self._auth_token()
-            if not self.config.access_token == "no_token":
+            if not self.config.access_token == "no_token":  # noqa: SIM201
                 if isinstance(expiry, datetime):
                     self.config.expires_in = expiry.timestamp() - 120
                 else:
-                    self.config.expires_in = (
-                        datetime.now(timezone.utc).timestamp() + expiry - 120
-                    )
+                    self.config.expires_in = datetime.now(timezone.utc).timestamp() + expiry - 120
 
         if self.config.auth_header:
             headers[self.config.auth_header] = (
@@ -210,7 +224,7 @@ class REST:
         # This will result in the Authorization value being set for the Proxy-Authorization Extra Header
         # Any header which is comming as extra header from client will overwrite the header with same name in headers
         if self.config.extra_headers:
-            extra_headers: Dict[str, str] = self.config.extra_headers
+            extra_headers: Dict[str, str] = self.config.extra_headers  # noqa: UP006
             extra_headers = {k: (v % headers) for k, v in extra_headers.items()}
             headers = {**headers, **extra_headers}
 
@@ -237,32 +251,41 @@ class REST:
         if effective_timeout:
             opts["timeout"] = effective_timeout
 
+        # Per-call `retries` override takes precedence over the client
+        # config. `_retry` / `_retry_wait` are Optional in ClientConfig;
+        # narrow to plain ints here so the loop body type-checks cleanly.
+        total_retries: int
         if retries is not None:
             total_retries = retries if retries > 0 else 0
         else:
             total_retries = self._retry if self._retry and self._retry > 0 else 0
-        retry = total_retries
-        while retry >= 0:
-            try:
-                return self._one_request(method, url, opts, retry)
-            except LimitsException as exc:
-                logger.error(f"Feature limit exceeded for {url}")
-                self._limits_reached.add(path)
-                raise exc
-            except RetryException:
-                retry_wait = self._retry_wait * (total_retries - retry + 1)
-                logger.warning(
-                    "sleep %s seconds and retrying %s %s more time(s)...",
-                    retry_wait,
-                    url,
-                    retry,
-                )
-                time.sleep(retry_wait)
-                retry -= 1
-                if retry == 0:
-                    logger.error(f"No more retries left for {url}")
-                    traceback.format_exc()
-        return None
+        retry: int = total_retries
+        retry_wait_base: int = self._retry_wait or 0
+        http_tracker = get_global_tracker()
+        http_cm = http_tracker.request(method, url) if http_tracker is not None else nullcontext()
+        op_cm = diagnostics.operation("ometa.http", method=method, url=str(url))
+        with http_cm, op_cm:
+            while retry >= 0:
+                try:
+                    return self._one_request(method, url, opts, retry)
+                except LimitsException as exc:
+                    logger.error(f"Feature limit exceeded for {url}")
+                    self._limits_reached.add(path)
+                    raise exc  # noqa: TRY201
+                except RetryException:
+                    retry_wait = retry_wait_base * (total_retries - retry + 1)
+                    logger.warning(
+                        "sleep %s seconds and retrying %s %s more time(s)...",
+                        retry_wait,
+                        url,
+                        retry,
+                    )
+                    time.sleep(retry_wait)
+                    retry -= 1
+                    if retry == 0:
+                        logger.error(f"No more retries left for {url}")
+                        traceback.format_exc()
+            return None
 
     def _one_request(self, method: str, url: URL, opts: dict, retry: int):
         """
@@ -290,9 +313,7 @@ class REST:
                     return resp
                 except Exception as exc:
                     logger.debug(traceback.format_exc())
-                    logger.warning(
-                        f"Unexpected error while returning response {resp} in json format - {exc}"
-                    )
+                    logger.warning(f"Unexpected error while returning response {resp} in json format - {exc}")
 
         except HTTPError as http_error:
             # retry if we hit Rate Limit
@@ -306,21 +327,17 @@ class REST:
                     raise APIError(error, http_error) from http_error
             else:
                 raise
-        except requests.ConnectionError as conn:
-            # Trying to solve https://github.com/psf/requests/issues/4664
-            try:
-                return self._session.request(method, url, **opts).json()
-            except Exception as exc:
-                logger.debug(traceback.format_exc())
-                logger.warning(
-                    f"Unexpected error while retrying after a connection error - {exc}"
-                )
-                raise conn
+        except (
+            requests.exceptions.ConnectionError,
+            requests.exceptions.Timeout,
+            requests.exceptions.RetryError,
+            requests.exceptions.ChunkedEncodingError,
+        ) as exc:
+            logger.warning("Transport failure calling [%s] with method [%s]: %s", url, method, exc)
+            raise RestTransportError(method, url, exc) from exc
         except Exception as exc:
             logger.debug(traceback.format_exc())
-            logger.warning(
-                f"Unexpected error calling [{url}] with method [{method}]: {exc}"
-            )
+            logger.warning(f"Unexpected error calling [{url}] with method [{method}]: {exc}")
 
         return None
 

--- a/ingestion/src/metadata/ingestion/ometa/http_adapter.py
+++ b/ingestion/src/metadata/ingestion/ometa/http_adapter.py
@@ -1,0 +1,88 @@
+#  Copyright 2025 Collate
+#  Licensed under the Collate Community License, Version 1.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  https://github.com/open-metadata/OpenMetadata/blob/main/ingestion/LICENSE
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+"""
+Resilient HTTP transport for the OpenMetadata REST client: TCP keepalive plus
+one urllib3 Retry for transient transport failures.
+"""
+
+import socket
+
+import requests
+from requests.adapters import DEFAULT_POOLBLOCK, HTTPAdapter
+from urllib3.connection import HTTPConnection
+from urllib3.poolmanager import PoolManager
+from urllib3.util.retry import Retry
+
+_KEEPALIVE_IDLE_SECONDS = 60
+_KEEPALIVE_INTERVAL_SECONDS = 30
+_KEEPALIVE_PROBE_COUNT = 5
+
+
+def _socket_optname(name: str) -> int:
+    """Resolve a platform-conditional socket constant (caller guards presence)."""
+    return getattr(socket, name, -1)
+
+
+def build_keepalive_socket_options() -> list[tuple[int, int, int]]:
+    """TCP keepalive socket options, guarded for platform differences."""
+    options = list(HTTPConnection.default_socket_options) + [(socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1)]
+
+    if hasattr(socket, "TCP_KEEPIDLE"):
+        options.append((socket.IPPROTO_TCP, _socket_optname("TCP_KEEPIDLE"), _KEEPALIVE_IDLE_SECONDS))
+    elif hasattr(socket, "TCP_KEEPALIVE"):
+        options.append((socket.IPPROTO_TCP, _socket_optname("TCP_KEEPALIVE"), _KEEPALIVE_IDLE_SECONDS))
+
+    if hasattr(socket, "TCP_KEEPINTVL"):
+        options.append((socket.IPPROTO_TCP, _socket_optname("TCP_KEEPINTVL"), _KEEPALIVE_INTERVAL_SECONDS))
+
+    if hasattr(socket, "TCP_KEEPCNT"):
+        options.append((socket.IPPROTO_TCP, _socket_optname("TCP_KEEPCNT"), _KEEPALIVE_PROBE_COUNT))
+
+    return options
+
+
+def build_transport_retry() -> Retry:
+    """urllib3 Retry for transient transport failures, idempotent methods only."""
+    return Retry(
+        total=3,
+        connect=2,
+        read=1,
+        status=0,
+        backoff_factor=1,
+        allowed_methods=Retry.DEFAULT_ALLOWED_METHODS,
+        raise_on_status=False,
+    )
+
+
+_KEEPALIVE_SOCKET_OPTIONS: list[tuple[int, int, int]] = build_keepalive_socket_options()
+
+
+class KeepAliveRetryAdapter(HTTPAdapter):
+    """HTTPAdapter that enables TCP keepalive on every pooled connection."""
+
+    def init_poolmanager(
+        self, connections: int, maxsize: int, block: bool = DEFAULT_POOLBLOCK, **pool_kwargs: object
+    ) -> None:
+        """Build the pool manager with keepalive socket options applied."""
+        pool_kwargs["socket_options"] = _KEEPALIVE_SOCKET_OPTIONS
+        self.poolmanager = PoolManager(num_pools=connections, maxsize=maxsize, block=block, **pool_kwargs)
+
+    def proxy_manager_for(self, proxy: str, **proxy_kwargs: object) -> PoolManager:
+        """Apply keepalive socket options to proxied connections too."""
+        proxy_kwargs["socket_options"] = _KEEPALIVE_SOCKET_OPTIONS
+        return super().proxy_manager_for(proxy, **proxy_kwargs)
+
+
+def mount_resilient_adapter(session: requests.Session) -> None:
+    """Mount the keepalive + transport-retry adapter for http and https."""
+    adapter = KeepAliveRetryAdapter(max_retries=build_transport_retry())
+    session.mount("https://", adapter)
+    session.mount("http://", adapter)

--- a/ingestion/src/metadata/ingestion/ometa/mixins/logs_mixin.py
+++ b/ingestion/src/metadata/ingestion/ometa/mixins/logs_mixin.py
@@ -22,7 +22,7 @@ import json
 import os
 import socket
 import time
-from typing import Optional
+from typing import Optional, Union
 from uuid import UUID
 
 from metadata.ingestion.ometa.client import REST
@@ -50,6 +50,7 @@ class OMetaLogsMixin:
         run_id: UUID,
         log_content: str,
         compress: bool = False,
+        timeout: Optional[Union[float, tuple[float, float]]] = None,  # noqa: UP007, UP045
     ) -> bool:
         """
         Send logs to S3 storage via OpenMetadata server endpoint.
@@ -59,6 +60,7 @@ class OMetaLogsMixin:
             run_id: Unique identifier for the pipeline run
             log_content: The log content to send
             compress: Whether to compress logs before sending
+            timeout: Per-call HTTP timeout (seconds). Overrides client default.
 
         Returns:
             bool: True if logs were sent successfully, False otherwise
@@ -89,6 +91,7 @@ class OMetaLogsMixin:
             self.client.post(
                 url,
                 data=json.dumps(log_batch),
+                timeout=timeout,
             )
 
             # The REST client returns None for successful requests with empty response body (HTTP 200/201/204)
@@ -115,6 +118,7 @@ class OMetaLogsMixin:
         log_content: str,
         enable_compression: bool = False,
         max_retries: int = 3,
+        timeout: Optional[Union[float, tuple[float, float]]] = None,  # noqa: UP007, UP045
     ) -> dict:
         """
         Send logs batch to S3 storage via OpenMetadata server endpoint with retry logic.
@@ -125,6 +129,9 @@ class OMetaLogsMixin:
             log_content: The log content to send
             enable_compression: Whether to compress logs before sending
             max_retries: Maximum number of retry attempts
+            timeout: Per-call HTTP timeout (seconds). Overrides client default.
+                     Streamable log handler passes a short value here so a
+                     slow server can't tie up the shipper.
 
         Returns:
             dict: Metrics including lines sent and bytes sent
@@ -138,6 +145,7 @@ class OMetaLogsMixin:
                     run_id=run_id,
                     log_content=log_content,
                     compress=enable_compression and len(log_content) > 10240,
+                    timeout=timeout,
                 )
 
                 if success:
@@ -182,6 +190,56 @@ class OMetaLogsMixin:
                     )
 
         return metrics
+
+    def send_logs_batch_best_effort(
+        self,
+        pipeline_fqn: str,
+        run_id: UUID,
+        log_content: str,
+        timeout: Optional[Union[float, tuple[float, float]]] = None,  # noqa: UP007, UP045
+        client: Optional[REST] = None,  # noqa: UP045
+    ) -> bool:
+        """Best-effort log POST: no retries, no logging. Returns True on 2xx."""
+        try:
+            url = f"/services/ingestionPipelines/logs/{pipeline_fqn}/{model_str(run_id)}"
+            log_batch = {
+                "logs": log_content,
+                "timestamp": int(time.time() * 1000),
+                "connectorId": f"{socket.gethostname()}-{os.getpid()}",
+                "compressed": False,
+                "lineCount": log_content.count("\n") + 1,
+            }
+            target = client if client is not None else self.client
+            return target.post_best_effort(
+                url,
+                data=json.dumps(log_batch),
+                timeout=timeout,
+            )
+        except Exception:
+            return False
+
+    def send_close_best_effort(
+        self,
+        pipeline_fqn: str,
+        run_id: UUID,
+        timeout: Optional[Union[float, tuple[float, float]]] = None,  # noqa: UP007, UP045
+        client: Optional[REST] = None,  # noqa: UP045
+    ) -> bool:
+        """Best-effort /close notify. Same guarantees as send_logs_batch_best_effort."""
+        try:
+            url = f"/services/ingestionPipelines/logs/{pipeline_fqn}/{model_str(run_id)}/close"
+            close_data = {
+                "connectorId": f"{socket.gethostname()}-{os.getpid()}",
+                "timestamp": int(time.time() * 1000),
+            }
+            target = client if client is not None else self.client
+            return target.post_best_effort(
+                url,
+                data=json.dumps(close_data),
+                timeout=timeout,
+            )
+        except Exception:
+            return False
 
     def create_log_stream(
         self,

--- a/ingestion/src/metadata/ingestion/ometa/mixins/server_mixin.py
+++ b/ingestion/src/metadata/ingestion/ometa/mixins/server_mixin.py
@@ -84,17 +84,21 @@ class OMetaServerMixin:
     def validate_versions(self) -> None:
         """
         Validate Server & Client versions. They should match.
-        Otherwise, raise VersionMismatchException
+        Otherwise, raise VersionMismatchException.
         """
-        logger.info(
-            f"OpenMetadata client running with Server version [{self.server_version}] and Client version [{self.client_version}]"
-        )
-
         if not match_versions(self.server_version, self.client_version):
             raise VersionMismatchException(
                 f"Server version is {self.server_version} vs. Client version {self.client_version}."
                 f" Major and minor versions should match."
             )
+
+    def log_server_version(self) -> None:
+        """Emit the server/client version line."""
+        logger.info(
+            "OpenMetadata client running with Server version [%s] and Client version [%s]",
+            self.server_version,
+            self.client_version,
+        )
 
     def create_or_update_settings(self, settings: Settings) -> Settings:
         """Create of update setting

--- a/ingestion/src/metadata/utils/logger.py
+++ b/ingestion/src/metadata/utils/logger.py
@@ -18,7 +18,7 @@ from copy import deepcopy
 from enum import Enum
 from functools import singledispatch
 from types import DynamicClassAttribute
-from typing import Any, Dict, Optional, Union
+from typing import Any, Dict, Optional, Union  # noqa: UP035
 
 from metadata.data_quality.api.models import (
     TableAndTests,
@@ -40,9 +40,7 @@ from metadata.ingestion.models.pipeline_status import OMetaPipelineStatus
 from metadata.ingestion.models.user import OMetaUserProfile
 
 METADATA_LOGGER = "metadata"
-BASE_LOGGING_FORMAT = (
-    "[%(asctime)s] %(levelname)-8s {%(name)s:%(module)s:%(lineno)d} - %(message)s"
-)
+BASE_LOGGING_FORMAT = "[%(asctime)s] %(levelname)-8s {%(name)s:%(module)s:%(lineno)d} - %(message)s"
 logging.basicConfig(format=BASE_LOGGING_FORMAT, datefmt="%Y-%m-%d %H:%M:%S")
 
 REDACTED_KEYS = {"serviceConnection", "securityConfig"}
@@ -66,6 +64,7 @@ class Loggers(Enum):
     QUERY_RUNNER = "QueryRunner"
     APP = "App"
     REVERSE_INGESTION = "ReverseIngestion"
+    DIAGNOSTICS = "Diagnostics"
 
     @DynamicClassAttribute
     def value(self):
@@ -189,7 +188,22 @@ def query_runner_logger():
     return logging.getLogger(Loggers.QUERY_RUNNER.value)
 
 
-def set_loggers_level(level: Union[int, str] = logging.INFO):
+def diag_logger():
+    """
+    Method to get the DIAGNOSTICS logger.
+
+    The diagnostics subsystem (heartbeats, watchdog warnings,
+    non-signal-context dumps) emits through this logger so output is
+    picked up by whatever handlers the workflow has configured —
+    console, StreamableLogHandler (S3), file, etc. Signal-handler
+    paths still write to raw stderr because Python's logging module is
+    not signal-safe (per-handler RLocks).
+    """
+
+    return logging.getLogger(Loggers.DIAGNOSTICS.value)
+
+
+def set_loggers_level(level: Union[int, str] = logging.INFO):  # noqa: UP007
     """
     Set all loggers levels
     :param level: logging level
@@ -198,7 +212,7 @@ def set_loggers_level(level: Union[int, str] = logging.INFO):
 
 
 def log_ansi_encoded_string(
-    color: Optional[ANSI] = None,
+    color: Optional[ANSI] = None,  # noqa: UP045
     bold: bool = False,
     message: str = "",
     level=logging.INFO,
@@ -210,10 +224,10 @@ def log_ansi_encoded_string(
 
 
 @singledispatch
-def get_log_name(record: Entity) -> Optional[str]:
+def get_log_name(record: Entity) -> Optional[str]:  # noqa: UP045
     try:
         if hasattr(record, "name"):
-            return f"{type(record).__name__} [{getattr(record, 'name').root}]"
+            return f"{type(record).__name__} [{getattr(record, 'name').root}]"  # noqa: B009
         if hasattr(record, "table") and hasattr(record.table, "name"):
             return f"{type(record).__name__} [{record.table.name.root}]"
         return f"{type(record).__name__} [{record.entity.name.root}]"
@@ -243,9 +257,7 @@ def _(record: AddLineageRequest) -> str:
     type_ = record.edge.fromEntity.type
 
     # name can be informed or not
-    name_str = (
-        f"name: {record.edge.fromEntity.name}, " if record.edge.fromEntity.name else ""
-    )
+    name_str = f"name: {record.edge.fromEntity.name}, " if record.edge.fromEntity.name else ""
 
     return f"{type_} [{name_str}id: {id_}]"
 
@@ -277,7 +289,7 @@ def _(record: TableAndTests) -> str:
 @get_log_name.register
 def _(record: TestCaseResults) -> str:
     """We don't want to log this in the status"""
-    return ",".join(set(result.testCase.name.root for result in record.test_results))
+    return ",".join(set(result.testCase.name.root for result in record.test_results))  # noqa: C401
 
 
 @get_log_name.register
@@ -360,7 +372,7 @@ def sanitize_url_credentials(message: str) -> str:
     return re.sub(r"https://[^@]+@", "https://****@", message)
 
 
-def redacted_config(config: Dict[str, Union[str, dict]]) -> Dict[str, Union[str, dict]]:
+def redacted_config(config: Dict[str, Union[str, dict]]) -> Dict[str, Union[str, dict]]:  # noqa: UP006, UP007
     config_copy = deepcopy(config)
 
     def traverse_and_modify(obj):

--- a/ingestion/src/metadata/utils/streamable_logger.py
+++ b/ingestion/src/metadata/utils/streamable_logger.py
@@ -10,9 +10,11 @@
 #  limitations under the License.
 """Best-effort streamable log handler for OpenMetadata ingestion pipelines."""
 
+import atexit
 import contextlib
 import logging
 import threading
+import time
 from queue import Empty, Full, Queue
 from typing import Optional
 from uuid import UUID
@@ -27,19 +29,22 @@ logger = ingestion_logger()
 # Recursion guard: sender threads set shipping=True so emit() returns
 # immediately if it ever fires from inside the shipping path.
 _shipping_state = threading.local()
-_CLOSE_MARKER = object()
 
 
 class StreamableLogHandler(logging.Handler):
-    """Fire-and-forget log shipper."""
+    """Ship ingestion log records to the OM server.
+
+    Caller invokes shutdown() to flush and close synchronously; an atexit
+    hook covers callers that forget.
+    """
 
     BATCH_SIZE = 500
     BATCH_WAIT_SEC = 2.0
-    SENDER_TICK_SEC = 1.0
-    HTTP_TIMEOUT = (1.0, 2.0)
-    SENDER_WORKERS = 1
-    MAX_PENDING_BATCHES = 4
-    CLOSE_TIMEOUT_SEC = 2.0
+    HTTP_TIMEOUT = (2.0, 10.0)
+    CLOSE_TIMEOUT_SEC = 30.0
+    FLUSH_DEFAULT_SEC = 5.0  # flush() default deadline
+    FLUSH_POLL_SEC = 0.05  # how often flush() rechecks state
+    FORCE_STOP_JOIN_SEC = 2.0  # secondary worker join after force-stop
 
     # pylint: disable=too-many-arguments,too-many-instance-attributes
     def __init__(
@@ -47,7 +52,7 @@ class StreamableLogHandler(logging.Handler):
         metadata: OpenMetadata,
         pipeline_fqn: str,
         run_id: UUID,
-        max_buffer: int = 10000,
+        max_buffer: int = 30_000,
         enable_streaming: bool = True,
     ):
         super().__init__()
@@ -59,11 +64,10 @@ class StreamableLogHandler(logging.Handler):
         self.fallback_handler = logging.StreamHandler()
 
         self._buffer: Queue = Queue(maxsize=max_buffer)
-        self._send_queue: Queue = Queue(maxsize=self.MAX_PENDING_BATCHES)
-        self._stop = threading.Event()
+        self._stop_event = threading.Event()
         self._closed = False
-        self._drainer: Optional[threading.Thread] = None  # noqa: UP045
-        self._senders: list = []
+        self._worker: Optional[threading.Thread] = None  # noqa: UP045
+        self._post_in_flight = threading.Event()
 
         # Isolated session/connection pool; shares ClientConfig so token
         # refresh on the main client is visible here.
@@ -71,66 +75,86 @@ class StreamableLogHandler(logging.Handler):
             REST(metadata.client.config) if enable_streaming else None
         )
 
+        # Counters surfaced at shutdown.
+        self.shipped_records = 0
+        self.shipped_batches = 0
+        self.failed_posts = 0
         self.dropped_overflow = 0
-        self.dropped_saturated = 0
-        self.dropped_shipping = 0
         self.dropped_after_close = 0
+        self.dropped_shipping = 0
         self.dropped_format_error = 0
+        self.flush_timed_out = 0
+        self.shutdown_timed_out = 0
+        self.worker_errors = 0
 
+        self._atexit_registered = False
         if self.enable_streaming:
-            self._start_workers()
-
-    def _start_workers(self):
-        self._drainer = threading.Thread(
-            target=self._drain_loop,
-            daemon=True,
-            name=f"log-drain-{self.pipeline_fqn[:24]}",
-        )
-        self._drainer.start()
-        for i in range(self.SENDER_WORKERS):
-            t = threading.Thread(
-                target=self._sender_loop,
+            # daemon=True so a hung OM can't block process exit; atexit +
+            # shutdown() handle the normal-exit drain.
+            self._worker = threading.Thread(
+                target=self._worker_loop,
                 daemon=True,
-                name=f"log-ship-{self.pipeline_fqn[:16]}-{i}",
+                name=f"log-ship-{self.pipeline_fqn[:24]}",
             )
-            t.start()
-            self._senders.append(t)
+            self._worker.start()
+            atexit.register(self.shutdown)
+            self._atexit_registered = True
 
     def emit(self, record: logging.LogRecord):
-        # Recursion guard must be the very first check.
+        # Recursion guard: shipping thread must not enqueue while shipping.
         if getattr(_shipping_state, "shipping", False):
             self.dropped_shipping += 1
             return
         if self._closed:
             self.dropped_after_close += 1
             return
+        if not self.enable_streaming:
+            self.fallback_handler.emit(record)
+            return
         try:
-            if not self.enable_streaming:
-                self.fallback_handler.emit(record)
-                return
             log_entry = self.format(record)
-            try:
-                self._buffer.put_nowait(log_entry)
-            except Full:
-                self.dropped_overflow += 1
         except Exception:
             self.dropped_format_error += 1
-
-    def _drain_loop(self):
-        while not self._stop.is_set():
-            batch = self._collect_batch()
-            if not batch:
-                continue
-            try:
-                self._send_queue.put_nowait(batch)
-            except Full:
-                self.dropped_saturated += len(batch)
-
-    def _collect_batch(self) -> list:
+            return
+        # Drop fast on full buffer — must not block the producer.
         try:
-            batch = [self._buffer.get(timeout=self.BATCH_WAIT_SEC)]
+            self._buffer.put_nowait(log_entry)
+        except Full:
+            self.dropped_overflow += 1
+
+    def _worker_loop(self):
+        try:
+            while not self._stop_event.is_set():
+                # Catch per-iteration so a single failure can't kill the worker.
+                try:
+                    batch = self._collect_batch(timeout=self.BATCH_WAIT_SEC)
+                    if batch:
+                        self._post_batch(batch)
+                except Exception:
+                    self.worker_errors += 1
+            while True:
+                try:
+                    batch = self._collect_batch(timeout=0)
+                    if not batch:
+                        break
+                    self._post_batch(batch)
+                except Exception:
+                    self.worker_errors += 1
+                    # Persistent failure during drain: bail to avoid infinite loop.
+                    break
+        finally:
+            with contextlib.suppress(Exception):
+                if self._client is not None:
+                    self._client.close()
+
+    def _collect_batch(self, timeout: float) -> list:
+        try:
+            batch = [self._buffer.get(timeout=timeout)] if timeout > 0 else [self._buffer.get_nowait()]
         except Empty:
             return []
+        # Claim "in flight" the moment we own a batch so flush() can't return
+        # in the gap between dequeue and the POST starting.
+        self._post_in_flight.set()
         while len(batch) < self.BATCH_SIZE:
             try:
                 batch.append(self._buffer.get_nowait())
@@ -138,83 +162,149 @@ class StreamableLogHandler(logging.Handler):
                 break
         return batch
 
-    def _sender_loop(self):
-        try:
-            while True:
-                try:
-                    item = self._send_queue.get(timeout=self.SENDER_TICK_SEC)
-                except Empty:
-                    if self._stop.is_set():
-                        return
-                    continue
-                if item is _CLOSE_MARKER:
-                    self._notify_close()
-                    return
-                self._post_batch(item)
-        finally:
-            with contextlib.suppress(Exception):
-                if self._client is not None:
-                    self._client.close()
-
     def _post_batch(self, batch: list):
+        self._post_in_flight.set()
         _shipping_state.shipping = True
         try:
-            self.metadata.send_logs_batch_best_effort(
+            ok = self.metadata.send_logs_batch_best_effort(
                 pipeline_fqn=self.pipeline_fqn,
                 run_id=self.run_id,
                 log_content="\n".join(batch) + "\n",
                 timeout=self.HTTP_TIMEOUT,
                 client=self._client,
             )
+            if ok:
+                self.shipped_records += len(batch)
+                self.shipped_batches += 1
+            else:
+                self.failed_posts += 1
         finally:
             _shipping_state.shipping = False
+            self._post_in_flight.clear()
 
-    def close(self):
+    def flush(self, timeout: float | None = None) -> None:
+        """Block until queue is drained, or until deadline."""
+        if not self.enable_streaming or self._worker is None:
+            return
+        deadline = time.monotonic() + (timeout if timeout is not None else self.FLUSH_DEFAULT_SEC)
+        while time.monotonic() < deadline:
+            if self._buffer.empty() and not self._post_in_flight.is_set():
+                return
+            # Poll: no single condition covers both "buffer drained" and
+            # "in-flight POST returned", so we re-check at FLUSH_POLL_SEC.
+            time.sleep(self.FLUSH_POLL_SEC)
+        self.flush_timed_out += 1
+
+    def shutdown(self, timeout: float | None = None) -> None:
+        """Synchronous flush + close. Idempotent.
+
+        `timeout` bounds the flush + worker-join phases. The post-stop metrics
+        POST and `/close` POST each carry their own HTTP timeouts on top, so
+        the total wall-time can be up to roughly `timeout + 2 * HTTP read`
+        (~`timeout + 32s` with defaults) in pathological cases.
+        """
         if self._closed:
             return
         self._closed = True
 
-        if self.enable_streaming:
-            self._drain_remaining_buffer()
-            with contextlib.suppress(Full):
-                self._send_queue.put_nowait(_CLOSE_MARKER)
+        if self._atexit_registered:
+            with contextlib.suppress(Exception):
+                atexit.unregister(self.shutdown)
+            self._atexit_registered = False
 
-        # Set _stop AFTER enqueueing — sender's get(timeout) Empty branch
-        # checks _stop, so setting it first can race the enqueue and drop
-        # the CLOSE_MARKER on a quiet send queue.
-        self._stop.set()
+        if not self.enable_streaming:
+            self._print_shutdown_metrics(self._format_shutdown_metrics())
+            with contextlib.suppress(Exception):
+                self.fallback_handler.close()
+            super().close()
+            return
 
+        deadline_total = timeout if timeout is not None else self.CLOSE_TIMEOUT_SEC
+        flush_budget = deadline_total / 2
+        self.flush(timeout=flush_budget)
+
+        # Default: worker still owns self._client. If we force-stop the
+        # worker below, we use a LOCAL fresh REST for the post-stop POSTs so
+        # the dying worker's finally (which closes self._client) can't close
+        # the session under the main thread.
+        post_close_client = self._client
+        self._stop_event.set()
+        if self._worker is not None:
+            self._worker.join(timeout=deadline_total - flush_budget)
+            if self._worker.is_alive():
+                self.shutdown_timed_out += 1
+                with contextlib.suppress(Exception):
+                    if self._client is not None:
+                        self._client.close()
+                self._worker.join(timeout=self.FORCE_STOP_JOIN_SEC)
+                with contextlib.suppress(Exception):
+                    post_close_client = REST(self.metadata.client.config)
+
+        metrics_line = self._format_shutdown_metrics()
+        with contextlib.suppress(Exception):
+            _shipping_state.shipping = True
+            try:
+                self.metadata.send_logs_batch_best_effort(
+                    pipeline_fqn=self.pipeline_fqn,
+                    run_id=self.run_id,
+                    log_content=metrics_line + "\n",
+                    timeout=self.HTTP_TIMEOUT,
+                    client=post_close_client,
+                )
+            finally:
+                _shipping_state.shipping = False
+
+        with contextlib.suppress(Exception):
+            _shipping_state.shipping = True
+            try:
+                self.metadata.send_close_best_effort(
+                    pipeline_fqn=self.pipeline_fqn,
+                    run_id=self.run_id,
+                    timeout=(2.0, self.CLOSE_TIMEOUT_SEC),
+                    client=post_close_client,
+                )
+            finally:
+                _shipping_state.shipping = False
+
+        self._print_shutdown_metrics(metrics_line)
         with contextlib.suppress(Exception):
             self.fallback_handler.close()
         super().close()
 
-    def _drain_remaining_buffer(self):
-        while True:
-            batch = []
-            while len(batch) < self.BATCH_SIZE:
-                try:
-                    batch.append(self._buffer.get_nowait())
-                except Empty:
-                    break
-            if not batch:
-                return
-            try:
-                self._send_queue.put_nowait(batch)
-            except Full:
-                self.dropped_saturated += len(batch)
-                return
+    def close(self):
+        self.shutdown()
 
-    def _notify_close(self):
-        _shipping_state.shipping = True
+    def _format_shutdown_metrics(self) -> str:
+        lines = [
+            "streamable_logger shutdown:",
+            f"  shipped:  records={self.shipped_records} batches={self.shipped_batches}",
+            f"  failed:   posts={self.failed_posts}",
+            (
+                f"  dropped:  overflow={self.dropped_overflow}"
+                f" after_close={self.dropped_after_close}"
+                f" shipping={self.dropped_shipping}"
+                f" format_error={self.dropped_format_error}"
+            ),
+            f"  errors:   worker={self.worker_errors}",
+            f"  timeouts: flush={self.flush_timed_out} shutdown={self.shutdown_timed_out}",
+        ]
+        return "\n".join(lines)
+
+    def _print_shutdown_metrics(self, msg: str) -> None:
+        """Print metrics to stderr via the fallback handler."""
         try:
-            self.metadata.send_close_best_effort(
-                pipeline_fqn=self.pipeline_fqn,
-                run_id=self.run_id,
-                timeout=(1.0, self.CLOSE_TIMEOUT_SEC),
-                client=self._client,
+            record = logging.LogRecord(
+                name=METADATA_LOGGER,
+                level=logging.INFO,
+                pathname=__file__,
+                lineno=0,
+                msg=msg,
+                args=None,
+                exc_info=None,
             )
-        finally:
-            _shipping_state.shipping = False
+            self.fallback_handler.emit(record)
+        except Exception:
+            pass
 
 
 class StreamableLogHandlerManager:
@@ -256,8 +346,10 @@ def setup_streamable_logging_for_workflow(
 ) -> Optional[StreamableLogHandler]:  # noqa: UP045
     if not enable_streaming or not pipeline_fqn or not run_id:
         logger.debug(
-            f"Streamable logging not configured: enable={enable_streaming}, "
-            f"pipeline_fqn={pipeline_fqn}, run_id={run_id}"
+            "Streamable logging not configured: enable=%s, pipeline_fqn=%s, run_id=%s",
+            enable_streaming,
+            pipeline_fqn,
+            run_id,
         )
         return None
 
@@ -281,11 +373,15 @@ def setup_streamable_logging_for_workflow(
         metadata_logger.addHandler(handler)
         StreamableLogHandlerManager.set_handler(handler)
 
-        logger.info(f"Streamable logging configured for pipeline: {pipeline_fqn}, run_id: {model_str(run_id)}")
+        logger.info(
+            "Streamable logging configured for pipeline: %s, run_id: %s",
+            pipeline_fqn,
+            model_str(run_id),
+        )
         return handler  # noqa: TRY300
 
     except Exception as e:
-        logger.warning(f"Failed to setup streamable logging: {e}")
+        logger.warning("Failed to setup streamable logging: %s", e)
         return None
 
 

--- a/ingestion/src/metadata/utils/streamable_logger.py
+++ b/ingestion/src/metadata/utils/streamable_logger.py
@@ -8,548 +8,252 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-"""
-Streamable log handler for shipping logs to OpenMetadata server.
+"""Best-effort streamable log handler for OpenMetadata ingestion pipelines."""
 
-This module provides a pluggable logger that can stream ingestion logs
-to the server's S3 storage backend without impacting application traffic.
-
-Configuration:
--------------
-The streamable logger is automatically enabled when:
-1. The IngestionPipeline entity has `enableStreamableLogs` set to true
-2. The ingestion pipeline FQN and run ID are available
-3. The OpenMetadata server has log storage configured (S3 or compatible)
-
-Environment Variables (Optional):
---------------------------------
-- ENABLE_LOG_COMPRESSION: Set to "true" to compress logs before sending (default: "false")
-
-Features:
---------
-- Asynchronous log shipping with buffering
-- Automatic compression for large payloads (>10KB when enabled)
-- Circuit breaker pattern for failure handling
-- Fallback to local logging when remote logging fails
-- Session cookie persistence for ALB sticky sessions
-- Configurable batch size and flush intervals
-
-Usage:
-------
-The streamable logger is automatically configured in the BaseWorkflow class
-when a workflow starts. No manual setup is required if the environment is
-properly configured.
-
-For manual setup (testing):
-```python
-from metadata.utils.streamable_logger import setup_streamable_logging_for_workflow
-
-handler = setup_streamable_logging_for_workflow(
-    metadata=metadata_client,
-    pipeline_fqn="service.pipeline_name",
-    run_id=UUID("..."),
-    log_level=logging.INFO
-)
-```
-"""
-
+import contextlib
 import logging
-import os
-import queue
-import sys
 import threading
-import time
-from enum import Enum
-from typing import Any, Dict, Optional
+from queue import Empty, Full, Queue
+from typing import Optional
 from uuid import UUID
 
+from metadata.ingestion.ometa.client import REST
 from metadata.ingestion.ometa.ometa_api import OpenMetadata
 from metadata.ingestion.ometa.utils import model_str
 from metadata.utils.logger import BASE_LOGGING_FORMAT, METADATA_LOGGER, ingestion_logger
 
 logger = ingestion_logger()
 
-# Internal logger used by this handler's own diagnostics. It MUST NOT propagate
-# to the root logger because `StreamableLogHandler` is attached there — logging
-# through `logger` from inside `emit()` or its callees re-enters this handler
-# and recurses until the Python recursion limit is hit. A separate logger with
-# `propagate=False` writing straight to stderr is the safe channel for any
-# message originating inside this module's hot path.
-_internal_logger = logging.getLogger("metadata.utils.streamable_logger.internal")
-_internal_logger.propagate = False
-if not _internal_logger.handlers:
-    _internal_handler = logging.StreamHandler(sys.stderr)
-    _internal_handler.setFormatter(
-        logging.Formatter(
-            "%(asctime)s [streamable-log-handler] %(levelname)s %(message)s",
-            datefmt="%Y-%m-%d %H:%M:%S",
-        )
-    )
-    _internal_logger.addHandler(_internal_handler)
-    # Filter at the handler so operators can change verbosity at runtime
-    # (e.g. via a debug toggle) without modifying the logger level itself.
-    _internal_handler.setLevel(logging.INFO)
-    _internal_logger.setLevel(logging.DEBUG)
+# Recursion guard: sender threads set shipping=True so emit() returns
+# immediately if it ever fires from inside the shipping path.
+_shipping_state = threading.local()
+_CLOSE_MARKER = object()
 
 
-class CircuitBreakerError(Exception):
-    """Base exception for circuit breaker errors"""
-
-
-class CircuitOpenError(CircuitBreakerError):
-    """Raised when circuit breaker is in OPEN state"""
-
-
-class ServiceCallError(Exception):
-    """Raised when the underlying service call fails"""
-
-
-class CircuitState(Enum):
-    """Circuit breaker states"""
-
-    CLOSED = "closed"  # Normal operation
-    OPEN = "open"  # Failures detected, requests blocked
-    HALF_OPEN = "half_open"  # Testing if service recovered
-
-
-class CircuitBreaker:
-    """
-    Circuit breaker pattern implementation to prevent cascading failures.
-    Fallback to local logging when remote logging fails.
-    """
-
-    def __init__(
-        self,
-        failure_threshold: int = 5,
-        recovery_timeout: int = 60,
-        success_threshold: int = 2,
-    ):
-        self.failure_threshold = failure_threshold
-        self.recovery_timeout = recovery_timeout
-        self.success_threshold = success_threshold
-        self.failure_count = 0
-        self.success_count = 0
-        self.last_failure_time = None
-        self.state = CircuitState.CLOSED
-        self._lock = threading.Lock()
-
-    def call(self, func, *args, **kwargs):
-        """Execute function with circuit breaker protection"""
-        with self._lock:
-            if self.state == CircuitState.OPEN:
-                if self._should_attempt_reset():
-                    self.state = CircuitState.HALF_OPEN
-                    self.success_count = 0
-                else:
-                    raise CircuitOpenError("Circuit breaker is OPEN")
-
-        try:
-            result = func(*args, **kwargs)
-            self._on_success()
-            return result
-        except (CircuitBreakerError, ServiceCallError):
-            raise
-        except Exception as e:
-            self._on_failure()
-            raise ServiceCallError(f"Service call failed: {str(e)}") from e
-
-    def _should_attempt_reset(self) -> bool:
-        """Check if enough time has passed to attempt reset"""
-        return (
-            self.last_failure_time
-            and time.time() - self.last_failure_time >= self.recovery_timeout
-        )
-
-    def _on_success(self):
-        """Handle successful call"""
-        with self._lock:
-            self.failure_count = 0
-            if self.state == CircuitState.HALF_OPEN:
-                self.success_count += 1
-                if self.success_count >= self.success_threshold:
-                    self.state = CircuitState.CLOSED
-
-    def _on_failure(self):
-        """Handle failed call"""
-        with self._lock:
-            self.failure_count += 1
-            self.last_failure_time = time.time()
-
-            if self.failure_count >= self.failure_threshold:
-                self.state = CircuitState.OPEN
-            elif self.state == CircuitState.HALF_OPEN:
-                self.state = CircuitState.OPEN
-
-
-# pylint: disable=too-many-instance-attributes
 class StreamableLogHandler(logging.Handler):
-    """
-    Custom logging handler that streams logs to OpenMetadata server.
+    """Fire-and-forget log shipper."""
 
-    Features:
-    - Async log shipping with buffering
-    - Circuit breaker for failure handling
-    - Automatic fallback to local logging
-    - Configurable batch size and flush intervals
-    """
+    BATCH_SIZE = 500
+    BATCH_WAIT_SEC = 2.0
+    SENDER_TICK_SEC = 1.0
+    HTTP_TIMEOUT = (1.0, 2.0)
+    SENDER_WORKERS = 1
+    MAX_PENDING_BATCHES = 4
+    CLOSE_TIMEOUT_SEC = 2.0
 
-    # pylint: disable=too-many-arguments
+    # pylint: disable=too-many-arguments,too-many-instance-attributes
     def __init__(
         self,
         metadata: OpenMetadata,
         pipeline_fqn: str,
         run_id: UUID,
-        batch_size: int = 500,
-        flush_interval_sec: float = 10.0,
-        max_queue_size: int = 10000,
+        max_buffer: int = 10000,
         enable_streaming: bool = True,
     ):
-        """
-        Initialize the streamable log handler.
-
-        Args:
-            metadata: OpenMetadata client instance
-            pipeline_fqn: Fully qualified name of the pipeline
-            run_id: Unique run identifier
-            batch_size: Number of log entries to batch before sending
-            flush_interval_sec: Time in seconds between automatic flushes
-            max_queue_size: Maximum size of the log queue
-            enable_streaming: Whether to enable log streaming (can be disabled for testing)
-        """
         super().__init__()
-
         self.metadata = metadata
         self.pipeline_fqn = pipeline_fqn
         self.run_id = run_id
-        self.batch_size = batch_size
-        self.flush_interval_sec = flush_interval_sec
         self.enable_streaming = enable_streaming
 
-        # Local fallback handler
         self.fallback_handler = logging.StreamHandler()
-        self.fallback_handler.setFormatter(self.formatter)
 
-        # Circuit breaker for failure handling
-        self.circuit_breaker = CircuitBreaker()
+        self._buffer: Queue = Queue(maxsize=max_buffer)
+        self._send_queue: Queue = Queue(maxsize=self.MAX_PENDING_BATCHES)
+        self._stop = threading.Event()
+        self._closed = False
+        self._drainer: Optional[threading.Thread] = None  # noqa: UP045
+        self._senders: list = []
 
-        # Log queue and worker thread
-        self.log_queue = queue.Queue(maxsize=max_queue_size)
-        self.stop_event = threading.Event()
-        self.worker_thread = None
+        # Isolated session/connection pool; shares ClientConfig so token
+        # refresh on the main client is visible here.
+        self._client: Optional[REST] = (  # noqa: UP045
+            REST(metadata.client.config) if enable_streaming else None
+        )
 
-        # Session ID for log streaming (if server supports it)
-        self.session_id = None
+        self.dropped_overflow = 0
+        self.dropped_saturated = 0
+        self.dropped_shipping = 0
+        self.dropped_after_close = 0
+        self.dropped_format_error = 0
 
-        # Metrics tracking
-        self.metrics = {
-            "logs_sent": 0,
-            "logs_failed": 0,
-            "bytes_sent": 0,
-            "circuit_trips": 0,
-            "fallback_count": 0,
-        }
-
-        # Start worker thread if streaming is enabled
         if self.enable_streaming:
-            self._initialize_log_stream()
-            self._start_worker()
+            self._start_workers()
 
-    def _initialize_log_stream(self):
-        """Initialize log stream with the server"""
-        if hasattr(self.metadata, "create_log_stream"):
-            self.session_id = self.metadata.create_log_stream(
-                self.pipeline_fqn, self.run_id
-            )
-
-    def _start_worker(self):
-        """Start the background worker thread for log shipping"""
-        if self.worker_thread is None or not self.worker_thread.is_alive():
-            self.worker_thread = threading.Thread(
-                target=self._worker_loop,
-                name=f"log-shipper-{self.pipeline_fqn}",
+    def _start_workers(self):
+        self._drainer = threading.Thread(
+            target=self._drain_loop,
+            daemon=True,
+            name=f"log-drain-{self.pipeline_fqn[:24]}",
+        )
+        self._drainer.start()
+        for i in range(self.SENDER_WORKERS):
+            t = threading.Thread(
+                target=self._sender_loop,
                 daemon=True,
+                name=f"log-ship-{self.pipeline_fqn[:16]}-{i}",
             )
-            self.worker_thread.start()
-
-    def _drain_queue_to_buffer(self, buffer: list) -> tuple[list, bool]:
-        """
-        Drain all available items from the queue into the buffer.
-
-        Args:
-            buffer: Current buffer to append items to
-
-        Returns:
-            Updated buffer and whether a flush marker was encountered
-        """
-        timeout = min(1.0, self.flush_interval_sec)
-        flush_requested = False
-
-        # Get items from queue until empty
-        while True:
-            try:
-                # Use timeout for first call, then get_nowait for remaining
-                log_entry = (
-                    self.log_queue.get(timeout=timeout)
-                    if timeout
-                    else self.log_queue.get_nowait()
-                )
-
-                if log_entry is None:
-                    # Flush marker encountered
-                    flush_requested = True
-                else:
-                    buffer.append(log_entry)
-
-                # After first successful get, switch to no timeout for draining
-                timeout = None
-
-            except queue.Empty:
-                break
-
-        return buffer, flush_requested
-
-    def _worker_loop(self):
-        """Background worker that ships logs to the server"""
-        buffer = []
-        last_flush = time.time()
-
-        while not self.stop_event.is_set():
-            try:
-                # Drain all available items from queue
-                buffer, flush_requested = self._drain_queue_to_buffer(buffer)
-
-                # Check if we should flush
-                should_flush = (
-                    flush_requested
-                    or len(buffer) >= self.batch_size
-                    or (time.time() - last_flush) >= self.flush_interval_sec
-                )
-
-                if should_flush and buffer:
-                    self._ship_logs(buffer)
-                    buffer = []
-                    last_flush = time.time()
-
-                # Let's not flush too often
-                time.sleep(1.0)
-
-            except Exception as e:
-                # NEVER use `logger` here — this handler is attached to it and
-                # logging through `logger` would re-enter our own emit().
-                _internal_logger.error("error in log shipping worker: %s", e)
-                # Continue processing to avoid blocking
-
-        # Final cleanup - drain ALL remaining items from the queue
-        buffer, _ = self._drain_queue_to_buffer(buffer)
-
-        # Send any final buffered logs
-        if buffer:
-            self._ship_logs(buffer)
-
-    def _ship_logs(self, logs: list):
-        """Ship logs to the server with circuit breaker protection"""
-        if not logs:
-            return
-
-        log_content = "\n".join(logs) + "\n"  # Ensure newline at end
-
-        try:
-            # Try to send logs with circuit breaker
-            self.circuit_breaker.call(self._send_logs_to_server, log_content)
-        except CircuitOpenError:
-            # Circuit is open, update metrics
-            self.metrics["logs_failed"] += len(logs)
-            self.metrics["circuit_trips"] += 1
-            self.metrics["fallback_count"] += 1
-
-            # NEVER use `logger` here — this handler is attached to it.
-            _internal_logger.debug("circuit breaker is OPEN, falling back to local logging")
-            for log in logs:
-                _internal_logger.info("[FALLBACK] %s", log)
-        except (ServiceCallError, Exception) as e:
-            # Service call failed, update metrics
-            self.metrics["logs_failed"] += len(logs)
-            self.metrics["fallback_count"] += 1
-
-            # Fallback to local logging via the internal (non-propagating)
-            # logger. Using `logger` here would dispatch the message back into
-            # this handler, re-entering shipping and ultimately recursing.
-            _internal_logger.debug("failed to ship logs to server: %s", e)
-            for log in logs:
-                _internal_logger.info("[FALLBACK] %s", log)
-
-    def _send_logs_to_server(self, log_content: str):
-        """Send logs to the OpenMetadata server using the logs mixin"""
-        enable_compression = (
-            os.getenv("ENABLE_LOG_COMPRESSION", "false").lower() == "true"
-        )
-        # Use the centralized logs mixin method which handles both new and legacy approaches
-        metrics = self.metadata.send_logs_batch(
-            pipeline_fqn=self.pipeline_fqn,
-            run_id=self.run_id,
-            log_content=log_content,
-            enable_compression=enable_compression,
-        )
-        # Update handler metrics with returned metrics
-        self.metrics["logs_sent"] += metrics["logs_sent"]
-        self.metrics["bytes_sent"] += metrics["bytes_sent"]
+            t.start()
+            self._senders.append(t)
 
     def emit(self, record: logging.LogRecord):
-        """
-        Emit a log record.
-
-        Puts the log entry in the queue for async shipping.
-        Falls back to local logging if queue is full or streaming is disabled.
-        """
+        # Recursion guard must be the very first check.
+        if getattr(_shipping_state, "shipping", False):
+            self.dropped_shipping += 1
+            return
+        if self._closed:
+            self.dropped_after_close += 1
+            return
         try:
             if not self.enable_streaming:
-                # Direct fallback if streaming is disabled
                 self.fallback_handler.emit(record)
                 return
-
-            # Format the log record
             log_entry = self.format(record)
-
-            # Try to add to queue (non-blocking)
             try:
-                self.log_queue.put_nowait(log_entry)
-            except queue.Full:
-                # Queue is full. CRITICAL: do not call `logger.warning(...)`
-                # here — this handler is attached to `logger`, so any log call
-                # from inside emit() re-enters emit(), recurses against the
-                # still-full queue, and eventually hits the Python recursion
-                # limit. This was the root cause of the production hang where
-                # MainThread sat in 900+ frames of alternating warning/error
-                # emit calls while every other thread was blocked on the
-                # logging module's internal lock.
-                _internal_logger.warning("log queue is full, falling back to local logging")
-                self.fallback_handler.emit(record)
+                self._buffer.put_nowait(log_entry)
+            except Full:
+                self.dropped_overflow += 1
+        except Exception:
+            self.dropped_format_error += 1
 
-        except Exception as e:
-            # Any error, fallback to local logging. Same recursion hazard as
-            # above — must use the non-propagating internal logger.
-            _internal_logger.error("error in emit: %s", e)
+    def _drain_loop(self):
+        while not self._stop.is_set():
+            batch = self._collect_batch()
+            if not batch:
+                continue
             try:
-                self.fallback_handler.emit(record)
-            except Exception:
-                pass  # Last resort: silently drop the log
+                self._send_queue.put_nowait(batch)
+            except Full:
+                self.dropped_saturated += len(batch)
 
-    def flush(self):
-        """Flush any buffered logs"""
-        # Signal worker to flush by adding a None marker
+    def _collect_batch(self) -> list:
         try:
-            self.log_queue.put_nowait(None)
-        except queue.Full:
-            pass
+            batch = [self._buffer.get(timeout=self.BATCH_WAIT_SEC)]
+        except Empty:
+            return []
+        while len(batch) < self.BATCH_SIZE:
+            try:
+                batch.append(self._buffer.get_nowait())
+            except Empty:
+                break
+        return batch
 
-    def get_metrics(self) -> Dict[str, Any]:
-        """Get current metrics for monitoring"""
-        return {
-            **self.metrics,
-            "circuit_state": self.circuit_breaker.state.value,
-            "queue_size": self.log_queue.qsize(),
-            "worker_alive": self.worker_thread.is_alive()
-            if self.worker_thread
-            else False,
-        }
+    def _sender_loop(self):
+        try:
+            while True:
+                try:
+                    item = self._send_queue.get(timeout=self.SENDER_TICK_SEC)
+                except Empty:
+                    if self._stop.is_set():
+                        return
+                    continue
+                if item is _CLOSE_MARKER:
+                    self._notify_close()
+                    return
+                self._post_batch(item)
+        finally:
+            with contextlib.suppress(Exception):
+                if self._client is not None:
+                    self._client.close()
+
+    def _post_batch(self, batch: list):
+        _shipping_state.shipping = True
+        try:
+            self.metadata.send_logs_batch_best_effort(
+                pipeline_fqn=self.pipeline_fqn,
+                run_id=self.run_id,
+                log_content="\n".join(batch) + "\n",
+                timeout=self.HTTP_TIMEOUT,
+                client=self._client,
+            )
+        finally:
+            _shipping_state.shipping = False
 
     def close(self):
-        """Close the handler and cleanup resources"""
-        if self.enable_streaming and self.worker_thread:
-            # Log final metrics via the non-propagating internal logger so
-            # close() cannot trigger a final round of self-recursion.
-            _internal_logger.info("StreamableLogHandler metrics: %s", self.get_metrics())
+        if self._closed:
+            return
+        self._closed = True
 
-            # Signal worker to stop AFTER ensuring any pending flush is processed
-            self.stop_event.set()
+        if self.enable_streaming:
+            self._drain_remaining_buffer()
+            with contextlib.suppress(Full):
+                self._send_queue.put_nowait(_CLOSE_MARKER)
 
-            # Wait for worker to finish (with timeout)
-            if self.worker_thread.is_alive():
-                self.worker_thread.join(timeout=5.0)
+        # Set _stop AFTER enqueueing — sender's get(timeout) Empty branch
+        # checks _stop, so setting it first can race the enqueue and drop
+        # the CLOSE_MARKER on a quiet send queue.
+        self._stop.set()
 
-            # Close the log stream
-            self.metadata.close_log_stream(self.pipeline_fqn, self.run_id)
-
-        # Close fallback handler
-        self.fallback_handler.close()
-
+        with contextlib.suppress(Exception):
+            self.fallback_handler.close()
         super().close()
+
+    def _drain_remaining_buffer(self):
+        while True:
+            batch = []
+            while len(batch) < self.BATCH_SIZE:
+                try:
+                    batch.append(self._buffer.get_nowait())
+                except Empty:
+                    break
+            if not batch:
+                return
+            try:
+                self._send_queue.put_nowait(batch)
+            except Full:
+                self.dropped_saturated += len(batch)
+                return
+
+    def _notify_close(self):
+        _shipping_state.shipping = True
+        try:
+            self.metadata.send_close_best_effort(
+                pipeline_fqn=self.pipeline_fqn,
+                run_id=self.run_id,
+                timeout=(1.0, self.CLOSE_TIMEOUT_SEC),
+                client=self._client,
+            )
+        finally:
+            _shipping_state.shipping = False
 
 
 class StreamableLogHandlerManager:
-    """
-    Manager class to handle StreamableLogHandler instances.
-    This provides better encapsulation than using global variables.
-
-    Note: This manager assumes single-threaded setup/teardown which is
-    typical for workflow initialization. The handler itself is thread-safe.
-    """
-
     _instance: Optional["StreamableLogHandler"] = None
 
     @classmethod
     def get_handler(cls) -> Optional["StreamableLogHandler"]:
-        """Get the current handler instance"""
         return cls._instance
 
     @classmethod
     def set_handler(cls, handler: Optional["StreamableLogHandler"]) -> None:
-        """Set or update the handler instance, closing any existing one"""
-        if cls._instance and cls._instance != handler:
-            try:
+        if cls._instance and cls._instance is not handler:
+            # Detach before close so in-flight emits don't route at a closed handler.
+            with contextlib.suppress(Exception):
+                logging.getLogger(METADATA_LOGGER).removeHandler(cls._instance)
+            with contextlib.suppress(Exception):
                 cls._instance.close()
-            except Exception as e:
-                logger.warning(f"Error closing previous handler: {e}")
         cls._instance = handler
 
     @classmethod
     def cleanup(cls) -> None:
-        """Clean up the current handler, flushing any remaining logs first"""
-        if cls._instance:
-            try:
-                # Force flush any remaining logs before cleanup
-                cls._instance.flush()
-
-                # Close will properly wait for worker thread to finish processing
-                # the flush marker and any remaining buffered logs
+        if not cls._instance:
+            return
+        try:
+            with contextlib.suppress(Exception):
+                logging.getLogger(METADATA_LOGGER).removeHandler(cls._instance)
+            with contextlib.suppress(Exception):
                 cls._instance.close()
-
-                # Only remove handler from logger after worker thread has finished
-                metadata_logger = logging.getLogger(METADATA_LOGGER)
-                metadata_logger.removeHandler(cls._instance)
-
-                logger.debug("Streamable logging handler cleaned up")
-            except Exception as e:
-                logger.warning(f"Error during handler cleanup: {e}")
-            finally:
-                cls._instance = None
+        finally:
+            cls._instance = None
 
 
 def setup_streamable_logging_for_workflow(
     metadata: OpenMetadata,
-    pipeline_fqn: Optional[str] = None,
-    run_id: Optional[UUID] = None,
+    pipeline_fqn: Optional[str] = None,  # noqa: UP045
+    run_id: Optional[UUID] = None,  # noqa: UP045
     log_level: int = logging.INFO,
     enable_streaming: bool = False,
-) -> Optional[StreamableLogHandler]:
-    """
-    Setup streamable logging for a workflow execution.
-    This is automatically called when a workflow starts if:
-    1. The IngestionPipeline has enableStreamableLogs set to true
-    2. The server has log storage configured
-    3. The pipeline FQN and run ID are available
-
-    Args:
-        metadata: OpenMetadata client instance
-        pipeline_fqn: Fully qualified name of the pipeline
-        run_id: Unique run identifier
-        log_level: Logging level
-        enable_streaming: Whether to enable streaming (from IngestionPipeline config)
-
-    Returns:
-        StreamableLogHandler instance if configured, None otherwise
-    """
-    # Check if we have the required parameters
+) -> Optional[StreamableLogHandler]:  # noqa: UP045
     if not enable_streaming or not pipeline_fqn or not run_id:
         logger.debug(
             f"Streamable logging not configured: enable={enable_streaming}, "
@@ -558,41 +262,27 @@ def setup_streamable_logging_for_workflow(
         return None
 
     try:
-        # Check if server supports log storage by trying to get the configuration
-        # This would need to be implemented as an API endpoint
-        # For now, we'll assume it's enabled if the env var is set
+        metadata_logger = logging.getLogger(METADATA_LOGGER)
+        existing = StreamableLogHandlerManager.get_handler()
+        if existing is not None:
+            with contextlib.suppress(Exception):
+                metadata_logger.removeHandler(existing)
 
-        # Clean up any existing handler
-        existing_handler = StreamableLogHandlerManager.get_handler()
-        if existing_handler:
-            existing_handler.close()
-
-        # Create and configure the handler
         handler = StreamableLogHandler(
             metadata=metadata,
             pipeline_fqn=pipeline_fqn,
             run_id=run_id,
             enable_streaming=True,
         )
-
-        # Use the same formatter as the base configuration for consistency
         formatter = logging.Formatter(BASE_LOGGING_FORMAT, datefmt="%Y-%m-%d %H:%M:%S")
         handler.setFormatter(formatter)
         handler.setLevel(log_level)
 
-        # Add handler to the metadata logger (parent of all ingestion loggers)
-        metadata_logger = logging.getLogger(METADATA_LOGGER)
         metadata_logger.addHandler(handler)
-
-        # Register with the manager
         StreamableLogHandlerManager.set_handler(handler)
 
-        logger.info(
-            f"Streamable logging configured for pipeline: {pipeline_fqn}, run_id: {model_str(run_id)}"
-        )
-        metadata.validate_versions()  # Send the version check log
-
-        return handler
+        logger.info(f"Streamable logging configured for pipeline: {pipeline_fqn}, run_id: {model_str(run_id)}")
+        return handler  # noqa: TRY300
 
     except Exception as e:
         logger.warning(f"Failed to setup streamable logging: {e}")
@@ -600,8 +290,4 @@ def setup_streamable_logging_for_workflow(
 
 
 def cleanup_streamable_logging():
-    """
-    Cleanup streamable logging handler.
-    This should be called when the workflow completes.
-    """
     StreamableLogHandlerManager.cleanup()

--- a/ingestion/src/metadata/workflow/base.py
+++ b/ingestion/src/metadata/workflow/base.py
@@ -41,6 +41,7 @@ from metadata.generated.schema.metadataIngestion.workflow import (
 )
 from metadata.generated.schema.tests.testSuite import ServiceType
 from metadata.generated.schema.type.entityReference import EntityReference
+from metadata.ingestion import diagnostics
 from metadata.ingestion.api.step import Step, Summary
 from metadata.ingestion.ometa.client_utils import create_ometa_client
 from metadata.ingestion.ometa.ometa_api import OpenMetadata
@@ -176,6 +177,12 @@ class BaseWorkflow(ABC, WorkflowStatusMixin):
         # it can hung the workflow
         self.timer.stop()
 
+        # Stop diagnostics threads if they were installed. Emits the
+        # `diag.time_budget` summary line through the diag logger before
+        # the threads exit, which gets captured by the streamable
+        # handler's synchronous shutdown in `execute()`'s outer finally.
+        diagnostics.shutdown()
+
         # Reset progress and metrics tracking singletons
         ProgressTrackerState().reset()
         OperationMetricsState().reset()
@@ -273,8 +280,17 @@ class BaseWorkflow(ABC, WorkflowStatusMixin):
         """
         pipeline_state = PipelineState.success
         self.timer.trigger()
+        diagnostics.install(self)
+        # `self.config` is typed Union[Any, Dict]; getattr keeps the static
+        # checker happy without changing behavior (the Dict branch never
+        # carries this attribute at runtime).
+        pipeline_fqn = getattr(self.config, "ingestionPipelineFQN", None)
         try:
-            self.execute_internal()
+            with (
+                diagnostics.operation("workflow.execute", fqn=pipeline_fqn),
+                diagnostics.dump_on_memory_error(),
+            ):
+                self.execute_internal()
 
             if self.workflow_config.successThreshold <= self.calculate_success() < 100:
                 pipeline_state = PipelineState.partialSuccess

--- a/ingestion/src/metadata/workflow/base.py
+++ b/ingestion/src/metadata/workflow/base.py
@@ -132,6 +132,9 @@ class BaseWorkflow(ABC, WorkflowStatusMixin):
                 enable_streaming=True,
             )
 
+        # Emit after the streamable handler is installed so the line is captured.
+        self.metadata.log_server_version()
+
         self._log_workflow_execution_info()
 
         # Set run context for operation metrics tracking
@@ -172,9 +175,6 @@ class BaseWorkflow(ABC, WorkflowStatusMixin):
         # Stop the timer first. This runs in a separate thread and if not properly closed
         # it can hung the workflow
         self.timer.stop()
-
-        # Cleanup streamable logging if it was configured
-        cleanup_streamable_logging()
 
         # Reset progress and metrics tracking singletons
         ProgressTrackerState().reset()
@@ -296,9 +296,13 @@ class BaseWorkflow(ABC, WorkflowStatusMixin):
             ingestion_status = self.build_ingestion_status()
             self.set_ingestion_pipeline_status(pipeline_state, ingestion_status)
             try:
-                self.print_status()
+                try:
+                    self.print_status()
+                finally:
+                    self.stop()
             finally:
-                self.stop()
+                # Must run after every other emitter so the tail is captured.
+                cleanup_streamable_logging()
 
     @property
     def run_id(self) -> str:

--- a/ingestion/tests/unit/conftest.py
+++ b/ingestion/tests/unit/conftest.py
@@ -12,16 +12,20 @@ from pytest import fixture
 import metadata  # noqa: F401
 
 # Prevent unit tests from connecting to the OpenMetadata server.
-# There are two code paths that trigger HTTP calls to localhost:8585:
+# Three code paths trigger HTTP calls to localhost:8585:
 #   1. OpenMetadata.__init__() → validate_versions() → GET /system/version
-#   2. create_ometa_client() → health_check() → GET /system/version
-# Unit tests don't need either — they test transformation logic.
+#   2. Workflow.__init__() → metadata.log_server_version() → GET /system/version
+#   3. create_ometa_client() → health_check() → GET /system/version
+# Unit tests don't need any — they test transformation logic.
 # TODO: Once topology/workflow/profiler tests are migrated from TestCase to pytest,
 #       replace these with a session-scoped fixture.
 _mock_validate = patch(
     "metadata.ingestion.ometa.ometa_api.OpenMetadata.validate_versions"
 )
 _mock_validate.start()
+
+_mock_log_server_version = patch("metadata.ingestion.ometa.ometa_api.OpenMetadata.log_server_version")
+_mock_log_server_version.start()
 
 _mock_health = patch("metadata.ingestion.ometa.ometa_api.OpenMetadata.health_check")
 _mock_health.start()

--- a/ingestion/tests/unit/diagnostics/test_db_introspect.py
+++ b/ingestion/tests/unit/diagnostics/test_db_introspect.py
@@ -1,0 +1,141 @@
+#  Copyright 2025 Collate
+#  Licensed under the Collate Community License, Version 1.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  https://github.com/open-metadata/OpenMetadata/blob/main/ingestion/LICENSE
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+"""SQLAlchemy event-based DB introspection.
+
+These tests use an in-memory SQLite engine to drive real `cursor.execute`
+calls and assert that the diagnostics operation registry sees them as
+`sqlite.query` operations.
+"""
+
+import threading
+
+import pytest
+
+sqlalchemy = pytest.importorskip("sqlalchemy")
+
+# Imports must follow `importorskip` so the module is skipped cleanly
+# in environments without SQLAlchemy.
+from metadata.ingestion.diagnostics.db_introspect import DbIntrospector  # noqa: E402
+from metadata.ingestion.diagnostics.registry import OperationRegistry  # noqa: E402
+
+
+@pytest.fixture()
+def registry():
+    return OperationRegistry()
+
+
+@pytest.fixture()
+def introspector(registry):
+    intro = DbIntrospector(registry)
+    assert intro.install()
+    yield intro
+    intro.uninstall()
+
+
+def test_query_appears_in_registry_during_execution(registry, introspector):
+    """A captured op should be visible in the registry while the query runs."""
+    from sqlalchemy import create_engine, event, text
+
+    engine = create_engine("sqlite:///:memory:")
+
+    seen_ops: list = []
+
+    def _spy(conn, cursor, statement, parameters, context, executemany):
+        # While `before_cursor_execute` listeners are mid-execution, our
+        # introspector's `before` listener has already pushed the op. Sample
+        # the registry at this exact point.
+        seen_ops.append(registry.deepest_per_thread().get(threading.get_ident()))
+
+    event.listen(engine, "before_cursor_execute", _spy)
+
+    try:
+        with engine.connect() as conn:
+            conn.execute(text("SELECT 1"))
+    finally:
+        event.remove(engine, "before_cursor_execute", _spy)
+
+    assert seen_ops, "spy did not capture the in-flight op"
+    op_name, kwargs, _age = seen_ops[-1]
+    assert op_name == "sqlite.query"
+    assert "SELECT 1" in kwargs["sql"]
+
+
+def test_op_is_popped_after_execution(registry, introspector):
+    from sqlalchemy import create_engine, text
+
+    engine = create_engine("sqlite:///:memory:")
+    with engine.connect() as conn:
+        conn.execute(text("SELECT 1"))
+
+    # After the with-block exits, the registry should be empty for this thread.
+    assert registry.deepest_per_thread().get(threading.get_ident()) is None
+
+
+def test_op_is_popped_after_error(registry, introspector):
+    from sqlalchemy import create_engine, text
+    from sqlalchemy.exc import OperationalError
+
+    engine = create_engine("sqlite:///:memory:")
+
+    with pytest.raises(OperationalError), engine.connect() as conn:
+        conn.execute(text("SELECT FROM nonexistent_table_xyz"))
+
+    assert registry.deepest_per_thread().get(threading.get_ident()) is None
+
+
+def test_sql_kwarg_is_truncated(registry, introspector):
+    """A huge SQL string must not be held in the registry verbatim."""
+    from sqlalchemy import create_engine, text
+
+    big_comment = "/* " + ("x" * 5000) + " */ SELECT 1"
+    engine = create_engine("sqlite:///:memory:")
+
+    captured_kwargs: dict = {}
+
+    def _spy(conn, cursor, statement, parameters, context, executemany):
+        captured_kwargs.update(registry.deepest_per_thread().get(threading.get_ident())[1])
+
+    from sqlalchemy import event
+
+    event.listen(engine, "before_cursor_execute", _spy)
+    try:
+        with engine.connect() as conn:
+            conn.execute(text(big_comment))
+    finally:
+        event.remove(engine, "before_cursor_execute", _spy)
+
+    assert "sql" in captured_kwargs
+    # The introspector truncates to 2000 chars before push.
+    assert len(captured_kwargs["sql"]) <= 2100
+
+
+def test_install_returns_false_without_sqlalchemy(registry, monkeypatch):
+    """Robustness: if SQLAlchemy ever became optional, install returns False."""
+    import builtins
+
+    real_import = builtins.__import__
+
+    def _no_sqlalchemy(name, *a, **kw):
+        if name.startswith("sqlalchemy"):
+            raise ImportError("simulated")
+        return real_import(name, *a, **kw)
+
+    monkeypatch.setattr(builtins, "__import__", _no_sqlalchemy)
+
+    intro = DbIntrospector(registry)
+    assert intro.install() is False
+
+
+def test_uninstall_is_idempotent(registry):
+    intro = DbIntrospector(registry)
+    intro.install()
+    intro.uninstall()
+    intro.uninstall()  # must not raise

--- a/ingestion/tests/unit/diagnostics/test_heartbeat.py
+++ b/ingestion/tests/unit/diagnostics/test_heartbeat.py
@@ -1,0 +1,148 @@
+#  Copyright 2025 Collate
+#  Licensed under the Collate Community License, Version 1.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  https://github.com/open-metadata/OpenMetadata/blob/main/ingestion/LICENSE
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+"""Heartbeat output format and step-status rendering.
+
+Heartbeats are emitted through the `metadata.Diagnostics` logger, so
+tests use pytest's `caplog` to capture log records instead of patching
+stderr.
+"""
+
+import logging
+
+from metadata.ingestion.diagnostics.heartbeat import HeartbeatThread
+from metadata.ingestion.diagnostics.http_introspect import HttpTracker
+from metadata.ingestion.diagnostics.memory import MemoryTracker
+from metadata.ingestion.diagnostics.registry import OperationRegistry
+
+
+class _FakeStatus:
+    def __init__(self, record_count=0, records=None, failures=None):
+        self.record_count = record_count
+        self.records = records or []
+        self.failures = failures or []
+
+
+class _FakeStep:
+    def __init__(self, name, status):
+        self.name = name
+        self._status = status
+
+    def get_status(self):
+        return self._status
+
+
+class _FakeWorkflow:
+    def __init__(self, steps):
+        self._steps = steps
+
+    def workflow_steps(self):
+        return self._steps
+
+
+def _emit_once(heartbeat, caplog) -> str:
+    with caplog.at_level(logging.INFO, logger="metadata.Diagnostics"):
+        heartbeat._emit()
+    return "\n".join(record.getMessage() for record in caplog.records)
+
+
+def test_heartbeat_emits_required_fields(caplog):
+    heartbeat = HeartbeatThread(
+        registry=OperationRegistry(),
+        http_tracker=HttpTracker(),
+        memory_tracker=MemoryTracker(),
+        workflow=None,
+    )
+    out = _emit_once(heartbeat, caplog)
+    assert out.startswith("diag.heartbeat")
+    for key in ("tick=", "pid=", "threads=", "rss=", "rss_delta_30s=", "active_http=", "main_op="):
+        assert key in out
+
+
+def test_heartbeat_renders_step_progress(caplog):
+    steps = [
+        _FakeStep("Source", _FakeStatus(record_count=42, failures=["e1"])),
+        _FakeStep("Sink", _FakeStatus(record_count=40, failures=[])),
+    ]
+    heartbeat = HeartbeatThread(
+        registry=OperationRegistry(),
+        http_tracker=HttpTracker(),
+        memory_tracker=MemoryTracker(),
+        workflow=_FakeWorkflow(steps),
+    )
+    out = _emit_once(heartbeat, caplog)
+    assert "steps=[Source=42/1err,Sink=40/0err]" in out
+
+
+def test_heartbeat_renders_main_thread_operation(caplog):
+    registry = OperationRegistry()
+    registry.push("source.iter", {"entity": "x"})
+    heartbeat = HeartbeatThread(
+        registry=registry,
+        http_tracker=HttpTracker(),
+        memory_tracker=MemoryTracker(),
+        workflow=None,
+    )
+    out = _emit_once(heartbeat, caplog)
+    assert "main_op=source.iter(" in out
+
+
+def test_heartbeat_handles_broken_step_status_gracefully(caplog):
+    class _BadStep:
+        name = "Bad"
+
+        def get_status(self):
+            raise RuntimeError("boom")
+
+    heartbeat = HeartbeatThread(
+        registry=OperationRegistry(),
+        http_tracker=HttpTracker(),
+        memory_tracker=MemoryTracker(),
+        workflow=_FakeWorkflow([_BadStep()]),
+    )
+    out = _emit_once(heartbeat, caplog)
+    assert out.startswith("diag.heartbeat")
+
+
+def test_heartbeat_emits_at_info_level(caplog):
+    heartbeat = HeartbeatThread(
+        registry=OperationRegistry(),
+        http_tracker=HttpTracker(),
+        memory_tracker=MemoryTracker(),
+        workflow=None,
+    )
+    with caplog.at_level(logging.INFO, logger="metadata.Diagnostics"):
+        heartbeat._emit()
+    levels = {r.levelname for r in caplog.records if r.message.startswith("diag.heartbeat")}
+    assert levels == {"INFO"}
+
+
+# Backwards-compat: a sanity test that heartbeats DO NOT write to stderr directly
+# (everything must go through the logger so it ships).
+def test_heartbeat_does_not_write_directly_to_stderr(caplog, capsys):
+    heartbeat = HeartbeatThread(
+        registry=OperationRegistry(),
+        http_tracker=HttpTracker(),
+        memory_tracker=MemoryTracker(),
+        workflow=None,
+    )
+    with caplog.at_level(logging.INFO, logger="metadata.Diagnostics"):
+        heartbeat._emit()
+    captured = capsys.readouterr()
+    # The default basicConfig StreamHandler may have written the formatted
+    # log record to stderr — that's fine, the logger is responsible. What
+    # we don't want is a direct sys.stderr.write of the raw "diag.heartbeat ..."
+    # line BYPASSING the logger.
+    if captured.err:
+        # If stderr has output, every line must be a formatted log record
+        # (which always contains the level name).
+        for line in captured.err.splitlines():
+            if line.strip():
+                assert "diag.heartbeat" not in line or "INFO" in line

--- a/ingestion/tests/unit/diagnostics/test_http_introspect.py
+++ b/ingestion/tests/unit/diagnostics/test_http_introspect.py
@@ -1,0 +1,48 @@
+#  Copyright 2025 Collate
+#  Licensed under the Collate Community License, Version 1.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  https://github.com/open-metadata/OpenMetadata/blob/main/ingestion/LICENSE
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+"""HTTP introspection tracker behavior."""
+
+from contextlib import suppress
+
+from metadata.ingestion.diagnostics.http_introspect import HttpTracker, get_global_tracker
+
+
+def test_request_appears_in_snapshot_while_in_flight():
+    tracker = HttpTracker()
+    assert tracker.active_count() == 0
+    with tracker.request("GET", "/api/v1/tables"):
+        assert tracker.active_count() == 1
+        active = tracker.snapshot()
+        assert len(active) == 1
+        _tid, method, url, age = active[0]
+        assert method == "GET"
+        assert url == "/api/v1/tables"
+        assert age >= 0
+    assert tracker.active_count() == 0
+
+
+def test_request_cleared_on_exception():
+    tracker = HttpTracker()
+
+    def _fail() -> None:
+        with tracker.request("POST", "/fail"):
+            raise RuntimeError("boom")
+
+    with suppress(RuntimeError):
+        _fail()
+    assert tracker.active_count() == 0
+
+
+def test_get_global_tracker_returns_none_when_not_installed():
+    from metadata.ingestion import diagnostics
+
+    diagnostics.shutdown()
+    assert get_global_tracker() is None

--- a/ingestion/tests/unit/diagnostics/test_lifecycle.py
+++ b/ingestion/tests/unit/diagnostics/test_lifecycle.py
@@ -1,0 +1,95 @@
+#  Copyright 2025 Collate
+#  Licensed under the Collate Community License, Version 1.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  https://github.com/open-metadata/OpenMetadata/blob/main/ingestion/LICENSE
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+"""Lifecycle tests for the diagnostics public API: install / shutdown / no-op."""
+
+import threading
+
+import pytest
+
+from metadata.ingestion import diagnostics
+
+
+class _FakeLogLevel:
+    def __init__(self, value: str) -> None:
+        self.value = value
+
+
+class _FakeWorkflowConfig:
+    def __init__(self, level: str) -> None:
+        self.loggerLevel = _FakeLogLevel(level)
+
+
+class _FakeWorkflow:
+    def __init__(self, level: str = "DEBUG") -> None:
+        self.workflow_config = _FakeWorkflowConfig(level)
+
+    def workflow_steps(self):
+        return []
+
+
+@pytest.fixture(autouse=True)
+def _reset_state():
+    """Make sure each test starts and ends with diagnostics off."""
+    diagnostics.shutdown()
+    yield
+    diagnostics.shutdown()
+
+
+def test_operation_is_noop_when_not_installed():
+    assert diagnostics.is_active() is False
+    with diagnostics.operation("test.noop", entity="x"):
+        pass
+
+
+def test_dump_is_noop_when_not_installed():
+    diagnostics.dump("not-installed")
+
+
+def test_install_only_when_logger_level_is_debug():
+    assert diagnostics.install(_FakeWorkflow(level="INFO")) is False
+    assert diagnostics.is_active() is False
+
+    assert diagnostics.install(_FakeWorkflow(level="DEBUG")) is True
+    assert diagnostics.is_active() is True
+
+
+def test_install_is_idempotent():
+    assert diagnostics.install(_FakeWorkflow()) is True
+    assert diagnostics.install(_FakeWorkflow()) is True
+    state_first = diagnostics._get_state()
+    diagnostics.install(_FakeWorkflow())
+    assert diagnostics._get_state() is state_first  # same singleton, not replaced
+
+
+def test_shutdown_resets_state_and_stops_threads():
+    assert diagnostics.install(_FakeWorkflow()) is True
+    state = diagnostics._get_state()
+    assert state is not None
+
+    diagnostics.shutdown()
+    assert diagnostics.is_active() is False
+    assert state.watchdog.is_alive() is False or state.watchdog._stop_event.is_set()
+    assert state.heartbeat.is_alive() is False or state.heartbeat._stop_event.is_set()
+
+
+def test_operation_records_in_registry_after_install():
+    diagnostics.install(_FakeWorkflow())
+    with diagnostics.operation("test.recorded", k="v"):
+        state = diagnostics._get_state()
+        deepest = state.registry.deepest_per_thread()
+        assert deepest[threading.get_ident()][0] == "test.recorded"
+
+
+def test_install_handles_missing_logger_level_gracefully():
+    class _NoConfig:
+        pass
+
+    assert diagnostics.install(_NoConfig()) is False

--- a/ingestion/tests/unit/diagnostics/test_memory.py
+++ b/ingestion/tests/unit/diagnostics/test_memory.py
@@ -1,0 +1,65 @@
+#  Copyright 2025 Collate
+#  Licensed under the Collate Community License, Version 1.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  https://github.com/open-metadata/OpenMetadata/blob/main/ingestion/LICENSE
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+"""Memory tracker behavior."""
+
+from metadata.ingestion.diagnostics.memory import (
+    MemoryTracker,
+    format_bytes,
+    format_signed_bytes,
+)
+
+
+def test_sample_returns_nonzero_rss_in_process():
+    tracker = MemoryTracker()
+    sample = tracker.sample()
+    assert sample.rss > 0
+
+
+def test_rss_delta_returns_none_with_single_sample():
+    tracker = MemoryTracker()
+    tracker.sample()
+    delta = tracker.rss_delta_bytes_since(30.0)
+    # With a single sample, delta is 0 (latest - latest) not None.
+    # The current implementation falls back to the oldest sample.
+    assert delta == 0
+
+
+def test_top_object_types_includes_common_python_types():
+    tracker = MemoryTracker()
+    top = tracker.top_object_types(limit=5)
+    type_names = {name for name, _ in top}
+    # `dict` and `function` are always present in a running Python process.
+    assert "dict" in type_names or "function" in type_names
+
+
+def test_format_bytes_renders_human_readable():
+    assert format_bytes(0) == "0B"
+    assert format_bytes(1024) == "1K"
+    assert format_bytes(2 * 1024 * 1024) == "2M"
+    assert format_bytes(3 * 1024 * 1024 * 1024) == "3.0G"
+    assert format_bytes(None) == "?"
+
+
+def test_format_signed_bytes_has_explicit_sign():
+    assert format_signed_bytes(0) == "+0B"
+    assert format_signed_bytes(1024 * 1024) == "+1M"
+    assert format_signed_bytes(-1024 * 1024) == "-1M"
+    assert format_signed_bytes(None) == "?"
+
+
+def test_ring_buffer_captures_growth():
+    tracker = MemoryTracker()
+    # Take two samples — the delta API should not crash regardless of
+    # actual rss growth.
+    tracker.sample()
+    tracker.sample()
+    delta = tracker.rss_delta_bytes_since(30.0)
+    assert isinstance(delta, int)

--- a/ingestion/tests/unit/diagnostics/test_registry.py
+++ b/ingestion/tests/unit/diagnostics/test_registry.py
@@ -1,0 +1,125 @@
+#  Copyright 2025 Collate
+#  Licensed under the Collate Community License, Version 1.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  https://github.com/open-metadata/OpenMetadata/blob/main/ingestion/LICENSE
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+"""Unit tests for the diagnostics operation registry."""
+
+import threading
+import time
+
+from metadata.ingestion.diagnostics.registry import (
+    OperationRegistry,
+    _truncate_kwargs,
+    format_op_frame,
+)
+
+
+def test_push_pop_basic():
+    registry = OperationRegistry()
+    token = registry.push("op.a", {"foo": "bar"})
+    snap = registry.snapshot()
+    tid = threading.get_ident()
+    assert tid in snap
+    assert snap[tid][0][0] == "op.a"
+    assert snap[tid][0][1] == {"foo": "bar"}
+    registry.pop(token)
+    assert tid not in registry.snapshot()
+
+
+def test_nested_push_pop_ordering():
+    registry = OperationRegistry()
+    outer = registry.push("op.outer", {})
+    inner = registry.push("op.inner", {})
+    tid = threading.get_ident()
+    stack = registry.snapshot()[tid]
+    assert [frame[0] for frame in stack] == ["op.outer", "op.inner"]
+    registry.pop(inner)
+    assert [frame[0] for frame in registry.snapshot()[tid]] == ["op.outer"]
+    registry.pop(outer)
+    assert tid not in registry.snapshot()
+
+
+def test_pop_by_token_handles_misnest():
+    """If frames are popped out of order we still desync gracefully."""
+    registry = OperationRegistry()
+    outer = registry.push("op.outer", {})
+    inner = registry.push("op.inner", {})
+    registry.pop(outer)  # outer popped before inner — same as a generator left open
+    tid = threading.get_ident()
+    # Outer + inner both gone — pop drops the slice
+    assert tid not in registry.snapshot()
+    registry.pop(inner)  # second pop is a no-op, must not raise
+
+
+def test_kwargs_truncated_to_keep_references_small():
+    big = "x" * 5000
+    truncated = _truncate_kwargs({"sql": big})
+    assert len(truncated["sql"]) < len(big)
+    assert "+3000 chars" in truncated["sql"]
+
+
+def test_kwargs_non_str_stringified():
+    truncated = _truncate_kwargs({"count": 42, "obj": ["a", "b"]})
+    assert truncated["count"] == "42"
+    assert truncated["obj"] == "['a', 'b']"
+
+
+def test_deepest_per_thread_returns_innermost():
+    registry = OperationRegistry()
+    registry.push("op.outer", {})
+    registry.push("op.inner", {"k": "v"})
+    deepest = registry.deepest_per_thread()
+    tid = threading.get_ident()
+    assert deepest[tid][0] == "op.inner"
+    assert deepest[tid][1] == {"k": "v"}
+
+
+def test_age_is_monotonic_seconds():
+    registry = OperationRegistry()
+    registry.push("op.long", {})
+    time.sleep(0.02)
+    age = registry.snapshot()[threading.get_ident()][0][2]
+    assert age >= 0.02
+
+
+def test_stack_depth_cap_prevents_runaway():
+    registry = OperationRegistry()
+    # Push more than the cap (20 by default)
+    tokens = [registry.push(f"op.{i}", {}) for i in range(30)]
+    tid = threading.get_ident()
+    stack = registry.snapshot()[tid]
+    assert len(stack) <= 20
+    for token in tokens:
+        registry.pop(token)
+
+
+def test_format_op_frame_human_readable():
+    rendered = format_op_frame("ometa.http", {"method": "GET", "url": "/api/v1/tables"}, 0.5)
+    assert "ometa.http" in rendered
+    assert "500ms" in rendered
+    assert "method=" in rendered
+
+
+def test_gc_dead_threads_clears_entries():
+    registry = OperationRegistry()
+    # Register an op from a worker thread, let the thread die
+    done = threading.Event()
+
+    def worker():
+        registry.push("op.worker", {})
+        done.set()
+
+    t = threading.Thread(target=worker)
+    t.start()
+    done.wait()
+    t.join()
+
+    assert t.ident in registry.snapshot()
+    registry.gc_dead_threads({threading.get_ident()})
+    assert t.ident not in registry.snapshot()

--- a/ingestion/tests/unit/diagnostics/test_signals.py
+++ b/ingestion/tests/unit/diagnostics/test_signals.py
@@ -1,0 +1,160 @@
+#  Copyright 2025 Collate
+#  Licensed under the Collate Community License, Version 1.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  https://github.com/open-metadata/OpenMetadata/blob/main/ingestion/LICENSE
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+"""Dump output format and routing.
+
+Non-signal-safe dumps go through the `metadata.Diagnostics` logger as a
+single record (so they ship via StreamableLogHandler and any other
+configured handler). Signal-safe dumps go to raw stderr (signal handler
+context — can't safely call into the logging module).
+"""
+
+import io
+import logging
+import sys
+from unittest.mock import patch
+
+from metadata.ingestion.diagnostics.http_introspect import HttpTracker
+from metadata.ingestion.diagnostics.memory import MemoryTracker
+from metadata.ingestion.diagnostics.registry import OperationRegistry
+from metadata.ingestion.diagnostics.signals import (
+    emit_full_dump,
+    emit_incremental_dump,
+)
+
+
+def _capture_logger_full(registry, http, memory, workflow=None, caplog=None) -> str:
+    with caplog.at_level(logging.WARNING, logger="metadata.Diagnostics"):
+        emit_full_dump(
+            reason="unit-test",
+            registry=registry,
+            http_tracker=http,
+            memory_tracker=memory,
+            workflow=workflow,
+            signal_safe=False,
+        )
+    return "\n".join(r.getMessage() for r in caplog.records)
+
+
+def _capture_stderr_full(registry, http, memory, workflow=None) -> str:
+    stderr = io.StringIO()
+    with patch.object(sys, "stderr", stderr):
+        emit_full_dump(
+            reason="unit-test",
+            registry=registry,
+            http_tracker=http,
+            memory_tracker=memory,
+            workflow=workflow,
+            signal_safe=True,
+        )
+    return stderr.getvalue()
+
+
+# ---------- Non-signal-safe path: goes through the logger ----------
+
+
+def test_full_dump_has_section_markers(caplog):
+    out = _capture_logger_full(OperationRegistry(), HttpTracker(), MemoryTracker(), caplog=caplog)
+    for marker in ("diag.dump.begin", "diag.dump.ops", "diag.dump.http", "diag.dump.memory", "diag.dump.end"):
+        assert marker in out
+
+
+def test_full_dump_is_one_log_record_for_shipping(caplog):
+    """The entire dump must be one log record so StreamableLogHandler ships it as one payload."""
+    with caplog.at_level(logging.WARNING, logger="metadata.Diagnostics"):
+        emit_full_dump(
+            reason="unit",
+            registry=OperationRegistry(),
+            http_tracker=HttpTracker(),
+            memory_tracker=MemoryTracker(),
+            workflow=None,
+            signal_safe=False,
+        )
+    dump_records = [r for r in caplog.records if "diag.dump.begin" in r.getMessage()]
+    assert len(dump_records) == 1
+
+
+def test_full_dump_lists_active_ops(caplog):
+    registry = OperationRegistry()
+    registry.push("source.iter", {"entity": "table42"})
+    out = _capture_logger_full(registry, HttpTracker(), MemoryTracker(), caplog=caplog)
+    assert "source.iter" in out
+    assert "table42" in out
+
+
+def test_full_dump_lists_inflight_http(caplog):
+    http = HttpTracker()
+    with http.request("PUT", "/api/v1/tables"):
+        out = _capture_logger_full(OperationRegistry(), http, MemoryTracker(), caplog=caplog)
+        assert "method=PUT" in out
+        assert "url=/api/v1/tables" in out
+
+
+def test_full_dump_includes_python_thread_frames(caplog):
+    """Logger path uses `sys._current_frames()` (no native frames, but ships)."""
+    out = _capture_logger_full(OperationRegistry(), HttpTracker(), MemoryTracker(), caplog=caplog)
+    assert "diag.dump.threads" in out
+    # The current thread must appear with at least one frame.
+    assert "thread=MainThread" in out
+
+
+def test_incremental_dump_excludes_thread_section(caplog):
+    with caplog.at_level(logging.INFO, logger="metadata.Diagnostics"):
+        emit_incremental_dump(
+            registry=OperationRegistry(),
+            http_tracker=HttpTracker(),
+            memory_tracker=MemoryTracker(),
+            signal_safe=False,
+        )
+    out = "\n".join(r.getMessage() for r in caplog.records)
+    assert "diag.dump.threads" not in out
+    assert "diag.dump.ops" in out
+    assert "diag.dump.memory" in out
+    assert "top_types" not in out  # shallow dump skips the expensive section
+
+
+def test_full_dump_renders_workflow_step_summary(caplog):
+    class _Status:
+        def __init__(self) -> None:
+            self.record_count = 5
+            self.failures: list = []
+            self.filtered: list = []
+
+    class _Step:
+        name = "Source"
+
+        def get_status(self):
+            return _Status()
+
+    class _Workflow:
+        def workflow_steps(self):
+            return [_Step()]
+
+    out = _capture_logger_full(OperationRegistry(), HttpTracker(), MemoryTracker(), workflow=_Workflow(), caplog=caplog)
+    assert "diag.dump.workflow" in out
+    assert "step=Source" in out
+    assert "records=5" in out
+
+
+# ---------- Signal-safe path: writes directly to stderr ----------
+
+
+def test_signal_safe_full_dump_writes_to_stderr():
+    out = _capture_stderr_full(OperationRegistry(), HttpTracker(), MemoryTracker())
+    for marker in ("diag.dump.begin", "diag.dump.ops", "diag.dump.http", "diag.dump.memory", "diag.dump.end"):
+        assert marker in out
+
+
+def test_signal_safe_path_does_not_emit_log_records(caplog):
+    """Signal-handler dumps must NOT go through the logger."""
+    with caplog.at_level(logging.DEBUG, logger="metadata.Diagnostics"):
+        _capture_stderr_full(OperationRegistry(), HttpTracker(), MemoryTracker())
+    dump_records = [r for r in caplog.records if "diag.dump" in r.getMessage()]
+    assert dump_records == []

--- a/ingestion/tests/unit/diagnostics/test_stage_progress.py
+++ b/ingestion/tests/unit/diagnostics/test_stage_progress.py
@@ -1,0 +1,92 @@
+#  Copyright 2025 Collate
+#  Licensed under the Collate Community License, Version 1.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  https://github.com/open-metadata/OpenMetadata/blob/main/ingestion/LICENSE
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+"""Stage backpressure collector.
+
+The Queue class in `models/topology.py` calls into this module for every
+put/process. When the collector is installed, those calls update the
+counters and the heartbeat surfaces queue depths.
+"""
+
+import pytest
+
+from metadata.ingestion.diagnostics import stage_progress
+from metadata.ingestion.models.topology import Queue
+
+
+@pytest.fixture(autouse=True)
+def _reset_collector():
+    """Tests install/uninstall the collector explicitly."""
+    stage_progress.uninstall()
+    yield
+    stage_progress.uninstall()
+
+
+def test_queue_is_no_op_without_collector():
+    q = Queue(name="t")
+    q.put(1)
+    q.put(2)
+    items = list(q.process())
+    assert items == [1, 2]
+    assert stage_progress.snapshot() == []
+
+
+def test_collector_tracks_put_and_processed_counts():
+    stage_progress.install(stage_progress.StageProgressCollector())
+    q = Queue(name="source-to-sink")
+    q.put("a")
+    q.put("b")
+    q.put("c")
+    list(q.process())  # drain
+
+    snap = stage_progress.snapshot()
+    assert len(snap) == 1
+    row = snap[0]
+    assert row["name"] == "source-to-sink"
+    assert row["put"] == 3
+    assert row["processed"] == 3
+    assert row["depth"] == 0
+
+
+def test_depth_reflects_unprocessed_items():
+    stage_progress.install(stage_progress.StageProgressCollector())
+    q = Queue(name="t")
+    q.put("a")
+    q.put("b")
+    snap = stage_progress.snapshot()
+    assert snap[0]["depth"] == 2
+    assert snap[0]["put"] == 2
+    assert snap[0]["processed"] == 0
+
+
+def test_format_for_heartbeat_returns_empty_string_with_no_queues():
+    stage_progress.install(stage_progress.StageProgressCollector())
+    assert stage_progress.format_for_heartbeat() == ""
+
+
+def test_format_for_heartbeat_renders_known_queues():
+    stage_progress.install(stage_progress.StageProgressCollector())
+    q = Queue(name="src2sink")
+    q.put("x")
+    q.put("y")
+    rendered = stage_progress.format_for_heartbeat()
+    assert "stage_queues=src2sink:2(2->0)" in rendered
+
+
+def test_multiple_queues_aggregated():
+    stage_progress.install(stage_progress.StageProgressCollector())
+    q1 = Queue(name="a")
+    q2 = Queue(name="b")
+    q1.put(1)
+    q2.put(2)
+    q2.put(3)
+    names = {row["name"]: row for row in stage_progress.snapshot()}
+    assert names["a"]["put"] == 1
+    assert names["b"]["put"] == 2

--- a/ingestion/tests/unit/diagnostics/test_time_accounting.py
+++ b/ingestion/tests/unit/diagnostics/test_time_accounting.py
@@ -1,0 +1,229 @@
+#  Copyright 2025 Collate
+#  Licensed under the Collate Community License, Version 1.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  https://github.com/open-metadata/OpenMetadata/blob/main/ingestion/LICENSE
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+"""Time-accounting sampler — categorization, active/idle, multi-thread."""
+
+import threading
+import time
+
+import pytest
+
+from metadata.ingestion.diagnostics.registry import OperationRegistry
+from metadata.ingestion.diagnostics.time_accounting import (
+    TimeAccountingSampler,
+    _categorize,
+)
+
+# ---- categorization ----
+
+
+@pytest.mark.parametrize(
+    "op_name,expected",
+    [
+        ("workflow.execute", "idle"),
+        ("ometa.http", "ometa_http"),
+        ("snowflake.query", "db"),
+        ("postgresql.query", "db"),
+        ("redshift.query", "db"),
+        ("sqlite.query", "db"),
+        ("source.iter", "source"),
+        ("sink.write", "sink"),
+        ("processor.run", "processor"),
+        ("stage.run", "stage"),
+        ("bulksink.run", "bulksink"),
+        ("something.else", "other"),
+    ],
+)
+def test_categorize_known_op_names(op_name, expected):
+    assert _categorize(op_name) == expected
+
+
+# ---- sampling: idle ----
+
+
+def test_sampler_credits_idle_when_no_ops():
+    registry = OperationRegistry()
+    sampler = TimeAccountingSampler(registry)
+    sampler.sample(delta=1.0)
+    snap = sampler.snapshot()
+    assert snap["idle_walltime"] == 1.0
+    assert snap["active_walltime"] == 0.0
+    assert snap["categories"] == {}
+
+
+def test_sampler_credits_idle_when_only_workflow_execute_on_stack():
+    """workflow.execute alone means we're in execute_internal but no step is active."""
+    registry = OperationRegistry()
+    registry.push("workflow.execute", {})
+    sampler = TimeAccountingSampler(registry)
+    sampler.sample(delta=2.0)
+    snap = sampler.snapshot()
+    assert snap["idle_walltime"] == 2.0
+    assert snap["active_walltime"] == 0.0
+    # workflow.execute does get op_time credit (for the top_ops breakdown)
+    # but does NOT get category credit.
+    assert "workflow.execute" in dict(snap["top_ops"])
+    assert "idle" not in snap["categories"]
+
+
+# ---- sampling: active ----
+
+
+def test_sampler_credits_db_during_query():
+    registry = OperationRegistry()
+    registry.push("snowflake.query", {"sql": "SELECT 1"})
+    sampler = TimeAccountingSampler(registry)
+    sampler.sample(delta=0.5)
+    snap = sampler.snapshot()
+    assert snap["active_walltime"] == 0.5
+    assert snap["idle_walltime"] == 0.0
+    assert snap["categories"] == {"db": 0.5}
+
+
+def test_sampler_credits_source_during_iter():
+    registry = OperationRegistry()
+    registry.push("workflow.execute", {})
+    registry.push("source.iter", {})
+    sampler = TimeAccountingSampler(registry)
+    sampler.sample(delta=0.3)
+    snap = sampler.snapshot()
+    assert snap["categories"]["source"] == 0.3
+    assert snap["active_walltime"] == 0.3
+
+
+# ---- sampling: multi-thread ----
+
+
+def test_multithread_main_idle_worker_active_counts_as_active():
+    """If a worker is running a query while main is on workflow.execute,
+    the tick is active (any thread doing something)."""
+    registry = OperationRegistry()
+    # Main thread on workflow.execute
+    registry._stacks[threading.get_ident()] = [("workflow.execute", {}, time.monotonic(), 1)]
+    # Worker thread on snowflake.query
+    fake_worker_tid = threading.get_ident() + 1
+    registry._stacks[fake_worker_tid] = [("snowflake.query", {"sql": "x"}, time.monotonic(), 2)]
+
+    sampler = TimeAccountingSampler(registry)
+    sampler.sample(delta=1.0)
+    snap = sampler.snapshot()
+    assert snap["active_walltime"] == 1.0
+    assert snap["idle_walltime"] == 0.0
+    assert snap["categories"].get("db") == 1.0
+    # 'idle' must NOT appear as a category — it's only tracked via
+    # idle_walltime.
+    assert "idle" not in snap["categories"]
+
+
+def test_multithread_two_categories_both_credited():
+    """Source iterating + DB query in parallel: both buckets get the delta."""
+    registry = OperationRegistry()
+    registry._stacks[threading.get_ident()] = [("source.iter", {}, time.monotonic(), 1)]
+    other_tid = threading.get_ident() + 99
+    registry._stacks[other_tid] = [("snowflake.query", {}, time.monotonic(), 2)]
+
+    sampler = TimeAccountingSampler(registry)
+    sampler.sample(delta=0.4)
+    snap = sampler.snapshot()
+    assert snap["categories"]["source"] == 0.4
+    assert snap["categories"]["db"] == 0.4
+    assert snap["active_walltime"] == 0.4
+    # Categories may sum > active_walltime due to parallelism.
+    assert sum(snap["categories"].values()) > snap["active_walltime"]
+
+
+# ---- accumulation across multiple samples ----
+
+
+def test_accumulates_across_samples():
+    registry = OperationRegistry()
+    sampler = TimeAccountingSampler(registry)
+    registry.push("snowflake.query", {})
+    sampler.sample(0.1)
+    sampler.sample(0.1)
+    sampler.sample(0.1)
+    snap = sampler.snapshot()
+    assert snap["categories"]["db"] == pytest.approx(0.3, rel=1e-6)
+    assert snap["samples"] == 3
+
+
+def test_idle_and_active_can_both_accumulate_in_one_run():
+    registry = OperationRegistry()
+    sampler = TimeAccountingSampler(registry)
+    sampler.sample(0.2)  # idle
+    token = registry.push("snowflake.query", {})
+    sampler.sample(0.2)  # db
+    sampler.sample(0.2)  # db
+    registry.pop(token)
+    sampler.sample(0.2)  # idle again
+    snap = sampler.snapshot()
+    assert snap["idle_walltime"] == pytest.approx(0.4, rel=1e-6)
+    assert snap["active_walltime"] == pytest.approx(0.4, rel=1e-6)
+    assert snap["categories"]["db"] == pytest.approx(0.4, rel=1e-6)
+
+
+# ---- top_ops ----
+
+
+def test_top_ops_sorted_by_time():
+    registry = OperationRegistry()
+    sampler = TimeAccountingSampler(registry)
+    t1 = registry.push("snowflake.query", {"sql": "a"})
+    sampler.sample(0.5)
+    registry.pop(t1)
+    t2 = registry.push("ometa.http", {"method": "GET"})
+    sampler.sample(0.1)
+    registry.pop(t2)
+    snap = sampler.snapshot()
+    top = snap["top_ops"]
+    # Both ops appear, snowflake.query first because it accumulated more time
+    names = [name for name, _ in top]
+    assert names[0] == "snowflake.query"
+    assert "ometa.http" in names
+
+
+# ---- summary line ----
+
+
+def test_summary_line_includes_required_fields():
+    registry = OperationRegistry()
+    sampler = TimeAccountingSampler(registry)
+    registry.push("snowflake.query", {})
+    sampler.sample(0.2)
+    sampler.sample(0.2)
+    line = sampler.summary_log_line()
+    for key in ("elapsed=", "samples=", "active=", "idle=", "by_category=", "top_ops="):
+        assert key in line
+    assert "db=" in line
+    assert "snowflake.query=" in line
+
+
+def test_summary_line_handles_zero_samples():
+    """Before any sample is taken, the summary must not divide by zero."""
+    registry = OperationRegistry()
+    sampler = TimeAccountingSampler(registry)
+    line = sampler.summary_log_line()
+    assert "no data" in line
+
+
+# ---- thread lifecycle smoke test ----
+
+
+def test_sampler_run_can_be_stopped_quickly():
+    registry = OperationRegistry()
+    sampler = TimeAccountingSampler(registry, interval=0.05)
+    sampler.start()
+    time.sleep(0.15)  # let it tick 2-3 times
+    sampler.stop()
+    sampler.join(timeout=1.0)
+    assert not sampler.is_alive()
+    snap = sampler.snapshot()
+    # At least one tick should have happened
+    assert snap["samples"] >= 1

--- a/ingestion/tests/unit/diagnostics/test_tripwire.py
+++ b/ingestion/tests/unit/diagnostics/test_tripwire.py
@@ -1,0 +1,298 @@
+#  Copyright 2025 Collate
+#  Licensed under the Collate Community License, Version 1.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  https://github.com/open-metadata/OpenMetadata/blob/main/ingestion/LICENSE
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+"""Pre-OOM tripwire: PSI, cgroup.events.high/oom, MemoryError.
+
+Each trigger should produce a `diag.warn.memory_pressure` + a full dump,
+and subsequent ticks within the throttle window must NOT re-fire.
+"""
+
+import logging
+import time
+
+import pytest
+
+from metadata.ingestion import diagnostics
+from metadata.ingestion.diagnostics import PRESSURE_PSI_AVG10_THRESHOLD
+from metadata.ingestion.diagnostics.http_introspect import HttpTracker
+from metadata.ingestion.diagnostics.memory import MemorySample, MemoryTracker
+from metadata.ingestion.diagnostics.registry import OperationRegistry
+from metadata.ingestion.diagnostics.watchdog import WatchdogThread
+
+
+class _FixedSampleTracker(MemoryTracker):
+    """MemoryTracker whose `sample()` returns a scripted MemorySample."""
+
+    def __init__(self, samples):
+        super().__init__()
+        self._scripted = list(samples)
+
+    def sample(self):  # type: ignore[override]
+        if not self._scripted:
+            return MemorySample(
+                ts=time.monotonic(),
+                rss=1000,
+                cgroup_current=None,
+                cgroup_max=None,
+                oom_kill_count=None,
+            )
+        return self._scripted.pop(0)
+
+
+def _watchdog_with(samples):
+    return WatchdogThread(
+        registry=OperationRegistry(),
+        http_tracker=HttpTracker(),
+        memory_tracker=_FixedSampleTracker(samples),
+        workflow=None,
+    )
+
+
+# ---- PSI tripwire ----
+
+
+def test_psi_below_threshold_does_not_trip(caplog):
+    wd = _watchdog_with(
+        [
+            MemorySample(
+                ts=0,
+                rss=1,
+                cgroup_current=None,
+                cgroup_max=None,
+                oom_kill_count=None,
+                psi_some_avg10=PRESSURE_PSI_AVG10_THRESHOLD - 0.1,
+            )
+        ]
+    )
+    with caplog.at_level(logging.WARNING, logger="metadata.Diagnostics"):
+        wd._tick()
+    assert not any("memory_pressure" in r.getMessage() for r in caplog.records)
+
+
+def test_psi_above_threshold_trips_dump(caplog):
+    wd = _watchdog_with(
+        [
+            MemorySample(
+                ts=0,
+                rss=1,
+                cgroup_current=None,
+                cgroup_max=None,
+                oom_kill_count=None,
+                psi_some_avg10=42.5,
+            )
+        ]
+    )
+    with caplog.at_level(logging.WARNING, logger="metadata.Diagnostics"):
+        wd._tick()
+    out = "\n".join(r.getMessage() for r in caplog.records)
+    assert "diag.warn.memory_pressure" in out
+    assert "memory-pressure-psi:avg10=42.5" in out
+    assert "diag.dump.begin" in out
+
+
+# ---- cgroup memory.events.high ----
+
+
+def test_events_high_increment_trips_dump(caplog):
+    # First tick: baseline. Second tick: counter increased — should trip.
+    wd = _watchdog_with(
+        [
+            MemorySample(
+                ts=0,
+                rss=1,
+                cgroup_current=None,
+                cgroup_max=None,
+                oom_kill_count=None,
+                cgroup_events_high=5,
+            ),
+            MemorySample(
+                ts=1,
+                rss=1,
+                cgroup_current=None,
+                cgroup_max=None,
+                oom_kill_count=None,
+                cgroup_events_high=12,
+            ),
+        ]
+    )
+    with caplog.at_level(logging.WARNING, logger="metadata.Diagnostics"):
+        wd._tick()  # baseline, no trip
+        caplog.clear()
+        wd._tick()  # delta of +7 → trip
+    out = "\n".join(r.getMessage() for r in caplog.records)
+    assert "memory-pressure-cgroup-high:delta=7" in out
+
+
+def test_events_high_unchanged_does_not_trip(caplog):
+    wd = _watchdog_with(
+        [
+            MemorySample(
+                ts=0,
+                rss=1,
+                cgroup_current=None,
+                cgroup_max=None,
+                oom_kill_count=None,
+                cgroup_events_high=5,
+            ),
+            MemorySample(
+                ts=1,
+                rss=1,
+                cgroup_current=None,
+                cgroup_max=None,
+                oom_kill_count=None,
+                cgroup_events_high=5,
+            ),
+        ]
+    )
+    with caplog.at_level(logging.WARNING, logger="metadata.Diagnostics"):
+        wd._tick()
+        wd._tick()
+    assert not any("memory_pressure" in r.getMessage() for r in caplog.records)
+
+
+# ---- cgroup memory.events.oom ----
+
+
+def test_events_oom_increment_trips_dump(caplog):
+    wd = _watchdog_with(
+        [
+            MemorySample(
+                ts=0,
+                rss=1,
+                cgroup_current=None,
+                cgroup_max=None,
+                oom_kill_count=None,
+                cgroup_events_oom=0,
+            ),
+            MemorySample(
+                ts=1,
+                rss=1,
+                cgroup_current=None,
+                cgroup_max=None,
+                oom_kill_count=None,
+                cgroup_events_oom=1,
+            ),
+        ]
+    )
+    with caplog.at_level(logging.WARNING, logger="metadata.Diagnostics"):
+        wd._tick()
+        caplog.clear()
+        wd._tick()
+    out = "\n".join(r.getMessage() for r in caplog.records)
+    assert "memory-pressure-cgroup-oom" in out
+
+
+# ---- throttling ----
+
+
+def test_psi_tripwire_is_throttled(caplog):
+    wd = _watchdog_with(
+        [
+            MemorySample(
+                ts=0,
+                rss=1,
+                cgroup_current=None,
+                cgroup_max=None,
+                oom_kill_count=None,
+                psi_some_avg10=50.0,
+            )
+            for _ in range(5)
+        ]
+    )
+    with caplog.at_level(logging.WARNING, logger="metadata.Diagnostics"):
+        wd._tick()
+        first_count = sum("diag.warn.memory_pressure" in r.getMessage() for r in caplog.records)
+        wd._tick()
+        wd._tick()
+        second_count = sum("diag.warn.memory_pressure" in r.getMessage() for r in caplog.records)
+    assert first_count == 1
+    assert second_count == 1
+
+
+# ---- MemoryError context manager ----
+
+
+@pytest.fixture()
+def _diag_installed():
+    class _Cfg:
+        class loggerLevel:  # noqa: N801
+            value = "DEBUG"
+
+    class _W:
+        workflow_config = _Cfg()
+
+        def workflow_steps(self):
+            return []
+
+    diagnostics.shutdown()
+    assert diagnostics.install(_W())
+    yield
+    diagnostics.shutdown()
+
+
+def test_memory_error_triggers_dump_then_reraises(_diag_installed, caplog):
+    """Python-side MemoryError should produce a dump and propagate."""
+    with (
+        caplog.at_level(logging.WARNING, logger="metadata.Diagnostics"),
+        pytest.raises(MemoryError),
+        diagnostics.dump_on_memory_error(),
+    ):
+        raise MemoryError("simulated")
+    out = "\n".join(r.getMessage() for r in caplog.records)
+    assert "memory-error:" in out
+    assert "diag.dump.begin" in out
+
+
+def test_dump_on_memory_error_passes_through_other_exceptions(_diag_installed):
+    with pytest.raises(RuntimeError), diagnostics.dump_on_memory_error():
+        raise RuntimeError("not a memory error")
+
+
+def test_dump_on_memory_error_noop_when_diagnostics_off(caplog):
+    diagnostics.shutdown()
+    with pytest.raises(MemoryError), diagnostics.dump_on_memory_error():
+        raise MemoryError("simulated")
+    # Diagnostics is off → no `diag.*` records emitted.
+    diag_records = [r for r in caplog.records if "diag" in r.getMessage()]
+    assert diag_records == []
+
+
+# ---- perf smoke test ----
+
+
+def test_sample_is_under_5ms():
+    """Each tracker.sample() should be sub-millisecond on average.
+
+    Five samples must complete in under 25 ms total — well under the
+    10s watchdog tick. This guards against accidental I/O regression
+    in the consolidated readers.
+    """
+    tracker = MemoryTracker()
+    started = time.monotonic()
+    for _ in range(5):
+        tracker.sample()
+    elapsed_ms = (time.monotonic() - started) * 1000
+    assert elapsed_ms < 25, f"5x sample took {elapsed_ms:.1f}ms"
+
+
+def test_emergency_reserve_is_allocated_at_construction():
+    tracker = MemoryTracker()
+    assert tracker._emergency_reserve is not None
+    assert len(tracker._emergency_reserve) == 10 * 1024 * 1024
+
+
+def test_top_object_types_releases_then_restores_reserve():
+    tracker = MemoryTracker()
+    initial = tracker._emergency_reserve
+    assert initial is not None
+    tracker.top_object_types(limit=3)
+    # After the call, the reserve should be back (or None on severe pressure).
+    if tracker._emergency_reserve is not None:
+        assert len(tracker._emergency_reserve) == 10 * 1024 * 1024

--- a/ingestion/tests/unit/diagnostics/test_watchdog.py
+++ b/ingestion/tests/unit/diagnostics/test_watchdog.py
@@ -1,0 +1,94 @@
+#  Copyright 2025 Collate
+#  Licensed under the Collate Community License, Version 1.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  https://github.com/open-metadata/OpenMetadata/blob/main/ingestion/LICENSE
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+"""Watchdog behavior: warn at stuck-threshold, auto-dump at hang-threshold, throttle re-dumps.
+
+Watchdog output goes through the `metadata.Diagnostics` logger; tests use
+`caplog` to read what was emitted.
+"""
+
+import logging
+import threading
+import time as _time
+
+from metadata.ingestion.diagnostics.http_introspect import HttpTracker
+from metadata.ingestion.diagnostics.memory import MemoryTracker
+from metadata.ingestion.diagnostics.registry import OperationRegistry
+from metadata.ingestion.diagnostics.watchdog import WatchdogThread
+
+
+def _make_watchdog():
+    registry = OperationRegistry()
+    http_tracker = HttpTracker()
+    memory_tracker = MemoryTracker()
+    watchdog = WatchdogThread(
+        registry=registry, http_tracker=http_tracker, memory_tracker=memory_tracker, workflow=None
+    )
+    return watchdog, registry
+
+
+def _all_messages(caplog) -> str:
+    return "\n".join(r.getMessage() for r in caplog.records)
+
+
+def test_no_warn_for_short_operation(caplog):
+    watchdog, registry = _make_watchdog()
+    registry.push("op.fast", {})
+
+    with caplog.at_level(logging.WARNING, logger="metadata.Diagnostics"):
+        watchdog._tick()
+    out = _all_messages(caplog)
+    assert "diag.warn.stuck" not in out
+
+
+def test_warn_fires_after_stuck_threshold(caplog):
+    """A stuck op (>60s but <300s) emits a `diag.warn.stuck` line."""
+    watchdog, registry = _make_watchdog()
+    tid = threading.get_ident()
+    started = _time.monotonic() - 100.0
+    registry._stacks[tid] = [("snowflake.query", {"sql": "SELECT *"}, started, 1)]
+
+    with caplog.at_level(logging.WARNING, logger="metadata.Diagnostics"):
+        watchdog._tick()
+    out = _all_messages(caplog)
+    assert "diag.warn.stuck" in out
+    assert "snowflake.query" in out
+    assert "diag.watchdog.auto_dump" not in out
+
+
+def test_auto_dump_fires_after_hang_threshold(caplog):
+    """An op stuck for >300s triggers a full dump (shipped via logger)."""
+    watchdog, registry = _make_watchdog()
+    tid = threading.get_ident()
+    started = _time.monotonic() - 1000.0
+    registry._stacks[tid] = [("source.iter", {"entity": "table42"}, started, 1)]
+
+    with caplog.at_level(logging.WARNING, logger="metadata.Diagnostics"):
+        watchdog._tick()
+    out = _all_messages(caplog)
+    assert "diag.watchdog.auto_dump" in out
+    assert "diag.dump.begin" in out
+    assert "diag.dump.end" in out
+
+
+def test_redump_throttle_prevents_flood(caplog):
+    """Re-ticking before the throttle window expires must not emit another dump."""
+    watchdog, registry = _make_watchdog()
+    tid = threading.get_ident()
+    started = _time.monotonic() - 1000.0
+    registry._stacks[tid] = [("op.hung", {}, started, 1)]
+
+    with caplog.at_level(logging.WARNING, logger="metadata.Diagnostics"):
+        watchdog._tick()
+        first_count = sum("diag.watchdog.auto_dump" in r.getMessage() for r in caplog.records)
+        watchdog._tick()
+        second_count = sum("diag.watchdog.auto_dump" in r.getMessage() for r in caplog.records)
+    assert first_count == 1
+    assert second_count == 1

--- a/ingestion/tests/unit/test_ometa_client_resilience.py
+++ b/ingestion/tests/unit/test_ometa_client_resilience.py
@@ -1,0 +1,122 @@
+#  Copyright 2025 Collate
+#  Licensed under the Collate Community License, Version 1.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  https://github.com/open-metadata/OpenMetadata/blob/main/ingestion/LICENSE
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+"""
+Transport-resilience behavior of the OMeta REST client, exercised against a
+real localhost socket that fails-then-succeeds. Failure is injected at the
+network boundary (not by mocking the session) so the genuine urllib3 Retry
+path through KeepAliveRetryAdapter is what's under test.
+"""
+
+import contextlib
+import json
+import socket
+import threading
+import time
+
+import pytest
+from urllib3.util.retry import Retry
+
+from metadata.ingestion.connections.source_api_client import TrackedREST
+from metadata.ingestion.ometa.client import REST, ClientConfig, RestTransportError
+from metadata.ingestion.ometa.http_adapter import KeepAliveRetryAdapter
+
+_HANG_SECONDS = 1.3  # > client read timeout below
+_CLIENT_TIMEOUT = (2, 1)  # (connect, read) — read=1s keeps the hang test fast
+
+
+class FlakyServer:
+    """Localhost server applying a per-connection behavior: close | hang | ok."""
+
+    def __init__(self, behaviors: list[str], tail: str = "ok") -> None:
+        self._behaviors = list(behaviors)
+        self._tail = tail
+        self._lock = threading.Lock()
+        self.attempts = 0
+        self._stop = False
+        self._sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        self._sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        self._sock.bind(("127.0.0.1", 0))
+        self._sock.listen(16)
+        self.port = self._sock.getsockname()[1]
+        self._thread = threading.Thread(target=self._accept_loop, daemon=True)
+
+    def __enter__(self) -> "FlakyServer":
+        self._thread.start()
+        return self
+
+    def __exit__(self, *_exc: object) -> None:
+        self._stop = True
+        with contextlib.suppress(OSError):
+            self._sock.close()
+
+    def _next_behavior(self) -> str:
+        with self._lock:
+            self.attempts += 1
+            return self._behaviors.pop(0) if self._behaviors else self._tail
+
+    def _accept_loop(self) -> None:
+        while not self._stop:
+            try:
+                conn, _ = self._sock.accept()
+            except OSError:
+                return
+            threading.Thread(target=self._handle, args=(conn, self._next_behavior()), daemon=True).start()
+
+    def _handle(self, conn: socket.socket, behavior: str) -> None:
+        with conn:
+            if behavior == "close":
+                return
+            conn.settimeout(2)
+            with contextlib.suppress(OSError):
+                conn.recv(65535)
+            if behavior == "hang":
+                time.sleep(_HANG_SECONDS)
+                return
+            body = json.dumps({"ok": True}).encode()
+            conn.sendall(
+                b"HTTP/1.1 200 OK\r\n"
+                b"Content-Type: application/json\r\n"
+                b"Content-Length: " + str(len(body)).encode() + b"\r\n"
+                b"Connection: close\r\n\r\n" + body
+            )
+
+
+def _rest(port: int) -> REST:
+    return REST(ClientConfig(base_url=f"http://127.0.0.1:{port}", timeout=_CLIENT_TIMEOUT))
+
+
+def test_rest_and_tracked_rest_carry_keepalive_retry_adapter():
+    rest = REST(ClientConfig(base_url="http://localhost:8585"))
+    tracked = TrackedREST(ClientConfig(base_url="http://localhost:8585"))
+    for client in (rest, tracked):
+        adapter = client._session.get_adapter("https://localhost:8585")
+        assert isinstance(adapter, KeepAliveRetryAdapter)
+        assert isinstance(adapter.max_retries, Retry)
+
+
+def test_read_timeout_is_retried_and_recovers():
+    with FlakyServer(["hang", "ok"]) as srv:
+        out = _rest(srv.port).get("/anything")
+    assert out == {"ok": True}
+    assert srv.attempts >= 2
+
+
+def test_connection_abort_is_retried_and_recovers():
+    with FlakyServer(["close", "ok"]) as srv:
+        out = _rest(srv.port).get("/anything")
+    assert out == {"ok": True}
+    assert srv.attempts >= 2
+
+
+def test_connection_failure_exhausts_to_transport_error():
+    with FlakyServer([], tail="close") as srv, pytest.raises(RestTransportError):
+        _rest(srv.port).get("/anything")
+    assert srv.attempts >= 2

--- a/ingestion/tests/unit/test_ometa_http_adapter.py
+++ b/ingestion/tests/unit/test_ometa_http_adapter.py
@@ -1,0 +1,49 @@
+#  Copyright 2025 Collate
+#  Licensed under the Collate Community License, Version 1.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  https://github.com/open-metadata/OpenMetadata/blob/main/ingestion/LICENSE
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+"""Wiring/config assertions for the resilient OMeta HTTP adapter."""
+
+import socket
+
+import requests
+from urllib3.util.retry import Retry
+
+from metadata.ingestion.ometa.http_adapter import (
+    KeepAliveRetryAdapter,
+    build_keepalive_socket_options,
+    build_transport_retry,
+    mount_resilient_adapter,
+)
+
+
+def test_keepalive_options_enable_so_keepalive():
+    assert (socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1) in build_keepalive_socket_options()
+
+
+def test_transport_retry_is_transport_only_and_idempotent_safe():
+    retry = build_transport_retry()
+    assert (retry.total, retry.connect, retry.read, retry.status) == (3, 2, 1, 0)
+    assert retry.raise_on_status is False
+    assert "POST" not in retry.allowed_methods
+    assert "GET" in retry.allowed_methods
+
+
+def test_mount_resilient_adapter_wires_keepalive_and_retry():
+    session = requests.Session()
+    mount_resilient_adapter(session)
+
+    for scheme in ("https://", "http://"):
+        adapter = session.get_adapter(f"{scheme}example.com")
+        assert isinstance(adapter, KeepAliveRetryAdapter)
+        assert isinstance(adapter.max_retries, Retry)
+        assert adapter.max_retries.read == 1
+
+    pooled = session.get_adapter("https://x").poolmanager.connection_pool_kw["socket_options"]
+    assert (socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1) in pooled

--- a/ingestion/tests/unit/utils/test_streamable_logger.py
+++ b/ingestion/tests/unit/utils/test_streamable_logger.py
@@ -10,12 +10,14 @@
 #  limitations under the License.
 """Unit tests for the streamable logger module."""
 
+import contextlib
 import logging
-import threading
 import time
 import unittest
-from unittest.mock import MagicMock, Mock, patch
+from unittest.mock import Mock, patch
 from uuid import uuid4
+
+import pytest
 
 from metadata.ingestion.ometa.ometa_api import OpenMetadata
 from metadata.utils.streamable_logger import (
@@ -39,482 +41,18 @@ def _make_record(msg="test message", level=logging.INFO):
     )
 
 
-def _make_metadata_mock():
-    """Build a Mock that satisfies StreamableLogHandler's needs:
-    - send_logs_batch_best_effort / send_close_best_effort attrs
-    - .client.config (real ClientConfig) so handler can build its own REST"""
-    from metadata.ingestion.ometa.client import ClientConfig
-
-    metadata = Mock(spec=OpenMetadata)
-    metadata.client = Mock()
-    metadata.client.config = ClientConfig(base_url="http://localhost:8585")
-    metadata.send_logs_batch_best_effort = Mock(return_value=True)
-    metadata.send_close_best_effort = Mock(return_value=True)
-    return metadata
-
-
-def _make_handler(
-    metadata=None,
-    pipeline_fqn="test.pipeline",
-    run_id=None,
-    max_buffer=10000,
-    enable_streaming=False,
-):
-    if metadata is None:
-        metadata = _make_metadata_mock()
+def _make_handler(enable_streaming=False, pipeline_fqn="test.pipeline", run_id=None):
+    """Minimal handler for Manager/setup tests where the worker isn't exercised.
+    enable_streaming=False keeps __init__ from building a REST client or
+    starting the worker thread."""
     if run_id is None:
         run_id = uuid4()
-    handler = StreamableLogHandler(
-        metadata=metadata,
+    return StreamableLogHandler(
+        metadata=Mock(spec=OpenMetadata),
         pipeline_fqn=pipeline_fqn,
         run_id=run_id,
-        max_buffer=max_buffer,
         enable_streaming=enable_streaming,
     )
-    handler.setFormatter(logging.Formatter("%(message)s"))
-    return handler
-
-
-def _stop_workers(handler):
-    """Signal stop and give the drainer/senders a moment to notice.
-    Used in tests that need a quiescent handler. We don't .join() in
-    production close() - see TestNoWaitClose - but in tests we want
-    to be sure background threads aren't going to race assertions."""
-    handler._stop.set()
-    if handler._drainer:
-        handler._drainer.join(timeout=3)
-    for t in handler._senders:
-        t.join(timeout=3)
-
-
-class TestEmitNonBlocking(unittest.TestCase):
-    """emit() must be fast and must never raise."""
-
-    def test_emit_with_streaming_disabled_goes_to_fallback(self):
-        handler = _make_handler(enable_streaming=False)
-        handler.fallback_handler = Mock()
-        record = _make_record()
-
-        handler.emit(record)
-
-        handler.fallback_handler.emit.assert_called_once_with(record)
-
-    def test_emit_with_streaming_enabled_queues_to_buffer(self):
-        handler = _make_handler(enable_streaming=True)
-        _stop_workers(handler)
-
-        handler.emit(_make_record("log A"))
-        handler.emit(_make_record("log B"))
-
-        self.assertEqual(handler._buffer.qsize(), 2)
-        handler.close()
-
-    def test_emit_drops_silently_when_buffer_full(self):
-        """No stderr fallback per record on overflow - only a counter."""
-        handler = _make_handler(max_buffer=1, enable_streaming=True)
-        _stop_workers(handler)
-        handler.fallback_handler = Mock()
-        handler._buffer.put_nowait("already-here")
-
-        start = time.monotonic()
-        handler.emit(_make_record("overflow"))
-        elapsed = time.monotonic() - start
-
-        self.assertLess(elapsed, 0.05, "emit() must return immediately on overflow")
-        handler.fallback_handler.emit.assert_not_called()
-        self.assertEqual(handler.dropped_overflow, 1)
-
-    def test_emit_never_raises_when_format_fails(self):
-        handler = _make_handler(enable_streaming=True)
-        _stop_workers(handler)
-        handler.format = Mock(side_effect=ValueError("boom"))
-
-        handler.emit(_make_record())
-
-        self.assertEqual(handler.dropped_format_error, 1)
-        self.assertEqual(handler.dropped_overflow, 0)
-        handler.close()
-
-    def test_emit_after_close_increments_dedicated_counter(self):
-        handler = _make_handler(enable_streaming=True)
-        handler.close()
-        handler.emit(_make_record("post-close"))
-        self.assertEqual(handler.dropped_after_close, 1)
-        self.assertEqual(handler.dropped_overflow, 0)
-        self.assertEqual(handler.dropped_format_error, 0)
-
-    def test_emit_returns_quickly_under_high_volume(self):
-        handler = _make_handler(max_buffer=10000, enable_streaming=True)
-        _stop_workers(handler)
-
-        start = time.monotonic()
-        for i in range(1000):
-            handler.emit(_make_record(f"msg-{i}"))
-        elapsed = time.monotonic() - start
-
-        self.assertLess(elapsed, 0.5, f"1000 emits took {elapsed:.3f}s - too slow")
-
-
-class TestRecursionGuard(unittest.TestCase):
-    """The thread-local guard prevents emit() from re-entering itself
-    even if a future change reintroduces logging on the shipping path."""
-
-    def tearDown(self):
-        # Make sure the guard is clear after each test.
-        if hasattr(_shipping_state, "shipping"):
-            _shipping_state.shipping = False
-
-    def test_emit_drops_when_shipping_flag_set(self):
-        handler = _make_handler(enable_streaming=True)
-        _stop_workers(handler)
-
-        _shipping_state.shipping = True
-        try:
-            handler.emit(_make_record("would-recurse"))
-        finally:
-            _shipping_state.shipping = False
-
-        self.assertEqual(handler._buffer.qsize(), 0)
-        self.assertEqual(handler.dropped_shipping, 1)
-
-    def test_post_thread_sets_and_clears_shipping_flag(self):
-        seen_flag = {"value": None}
-
-        def capture(*_, **__):
-            seen_flag["value"] = getattr(_shipping_state, "shipping", False)
-            return True
-
-        metadata = _make_metadata_mock()
-        metadata.send_logs_batch_best_effort = Mock(side_effect=capture)
-        metadata.send_close_best_effort = Mock(return_value=True)
-
-        handler = _make_handler(metadata=metadata, enable_streaming=True)
-        handler.emit(_make_record("trigger"))
-        for _ in range(50):
-            if metadata.send_logs_batch_best_effort.called:
-                break
-            time.sleep(0.05)
-
-        self.assertTrue(seen_flag["value"], "shipping flag must be True inside the sender")
-        handler.close()
-        # Flag must be cleared after the sender returns. Give the
-        # sender thread a moment to hit its finally block.
-        time.sleep(0.1)
-        self.assertFalse(getattr(_shipping_state, "shipping", False))
-
-
-class TestSenderPool(unittest.TestCase):
-    """Bounded send queue. Drainer never waits on a POST."""
-
-    def test_drainer_does_not_wait_on_slow_post(self):
-        slow_event = threading.Event()
-        post_started = threading.Event()
-
-        def slow_send(*_, **__):
-            post_started.set()
-            slow_event.wait(timeout=30)
-            return True
-
-        metadata = _make_metadata_mock()
-        metadata.send_logs_batch_best_effort = Mock(side_effect=slow_send)
-        metadata.send_close_best_effort = Mock(return_value=True)
-
-        handler = _make_handler(metadata=metadata, enable_streaming=True)
-        handler.emit(_make_record("first"))
-        self.assertTrue(post_started.wait(timeout=5))
-
-        start = time.monotonic()
-        for i in range(50):
-            handler.emit(_make_record(f"hangs-{i}"))
-        elapsed = time.monotonic() - start
-
-        self.assertLess(elapsed, 0.5, "emits must not block while a POST is hanging")
-
-        handler._stop.set()
-        slow_event.set()
-        handler._drainer.join(timeout=5)
-
-    def test_saturated_sender_drops_batches(self):
-        """When senders + send queue are full on a dead server, the drainer
-        drops new batches and counts them. No unbounded growth."""
-        hang = threading.Event()  # never set during the test
-
-        def block_forever(*_, **__):
-            hang.wait(timeout=30)
-            return True
-
-        metadata = _make_metadata_mock()
-        metadata.send_logs_batch_best_effort = Mock(side_effect=block_forever)
-        metadata.send_close_best_effort = Mock(return_value=True)
-
-        handler = _make_handler(metadata=metadata, enable_streaming=True)
-        # Make the test cycle faster than defaults.
-        handler.BATCH_WAIT_SEC = 0.1
-
-        # Pump 20 separately-timed batches; each wave > BATCH_WAIT_SEC so
-        # the drainer ships each as its own batch. Senders block forever
-        # on the first MAX_PENDING_BATCHES + SENDER_WORKERS; everything
-        # after that must be dropped at drainer-submit time.
-        total_waves = handler.MAX_PENDING_BATCHES + handler.SENDER_WORKERS + 10
-        for wave in range(total_waves):
-            handler.emit(_make_record(f"wave-{wave}"))
-            time.sleep(0.2)
-
-        # At least some batches must have been dropped at the send-queue
-        # boundary - we sent way more than the cap.
-        self.assertGreater(handler.dropped_saturated, 0, "saturated drainer must have dropped at least one batch")
-        # In-flight POSTs bounded by SENDER_WORKERS (others wait in queue
-        # but don't actually call send_logs_batch_best_effort).
-        self.assertLessEqual(
-            metadata.send_logs_batch_best_effort.call_count,
-            handler.SENDER_WORKERS,
-        )
-
-        handler._stop.set()
-        hang.set()
-
-    def test_close_notify_is_ordered_after_in_flight_log_batch(self):
-        """Regression for the close-vs-late-POST race. /close must not
-        overtake an already-started log batch, otherwise the server can
-        finalize logs.txt and then receive a late tail batch."""
-        log_started = threading.Event()
-        release_log = threading.Event()
-        close_called = threading.Event()
-
-        def slow_log_send(*_, **__):
-            log_started.set()
-            release_log.wait(timeout=30)
-            return True
-
-        def close_send(*_, **__):
-            close_called.set()
-            return True
-
-        metadata = _make_metadata_mock()
-        metadata.send_logs_batch_best_effort = Mock(side_effect=slow_log_send)
-        metadata.send_close_best_effort = Mock(side_effect=close_send)
-
-        handler = _make_handler(metadata=metadata, enable_streaming=True)
-        handler.emit(_make_record("first"))
-        self.assertTrue(log_started.wait(timeout=5))
-
-        start = time.monotonic()
-        handler.close()
-        elapsed = time.monotonic() - start
-
-        self.assertLess(elapsed, 0.1, "close() must still return immediately")
-        time.sleep(0.2)
-        self.assertFalse(
-            close_called.is_set(),
-            "/close must wait behind the in-flight log batch in the sender queue",
-        )
-
-        release_log.set()
-        self.assertTrue(close_called.wait(timeout=5))
-
-
-class TestDaemonThreads(unittest.TestCase):
-    """All background threads MUST be daemon, otherwise a wedged sender
-    can keep the ingestion process alive past main-thread exit."""
-
-    def test_drainer_thread_is_daemon(self):
-        handler = _make_handler(enable_streaming=True)
-        self.assertTrue(handler._drainer.daemon, "drainer must be a daemon thread")
-        handler.close()
-
-    def test_sender_threads_are_daemon(self):
-        handler = _make_handler(enable_streaming=True)
-        self.assertEqual(len(handler._senders), handler.SENDER_WORKERS)
-        for t in handler._senders:
-            self.assertTrue(t.daemon, f"sender {t.name} must be daemon")
-        handler.close()
-
-    def test_close_notify_thread_is_daemon(self):
-        """The /close call goes out on a daemon so close() doesn't wait."""
-        seen = {"daemon": None}
-
-        def capture(*_, **__):
-            seen["daemon"] = threading.current_thread().daemon
-            return True
-
-        metadata = _make_metadata_mock()
-        metadata.send_logs_batch_best_effort = Mock(return_value=True)
-        metadata.send_close_best_effort = Mock(side_effect=capture)
-
-        handler = _make_handler(metadata=metadata, enable_streaming=True)
-        handler.close()
-        for _ in range(50):
-            if seen["daemon"] is not None:
-                break
-            time.sleep(0.05)
-        self.assertTrue(seen["daemon"], "close notify must run on a daemon sender thread")
-
-
-class TestIsolatedClient(unittest.TestCase):
-    """The handler must use its OWN REST instance (own session/cookies/
-    connection pool), not the main metadata client's."""
-
-    def test_handler_creates_dedicated_rest_client(self):
-        from metadata.ingestion.ometa.client import REST
-
-        metadata = Mock(spec=OpenMetadata)
-        # Give the mock client a real ClientConfig so REST() can copy it.
-        from metadata.ingestion.ometa.client import ClientConfig
-
-        metadata.client = Mock()
-        metadata.client.config = ClientConfig(base_url="http://localhost:8585")
-        metadata.send_logs_batch_best_effort = Mock(return_value=True)
-        metadata.send_close_best_effort = Mock(return_value=True)
-
-        handler = _make_handler(metadata=metadata, enable_streaming=True)
-
-        self.assertIsInstance(handler._client, REST)
-        self.assertIsNot(handler._client, metadata.client, "handler must own a SEPARATE REST instance")
-        self.assertIsNot(handler._client._session, metadata.client, "handler's session must not be the main client")
-        handler.close()
-
-    def test_handler_passes_isolated_client_to_post(self):
-        """The send_logs_batch_best_effort call must include the handler's
-        own client kwarg so log shipping doesn't go through the main session."""
-        from metadata.ingestion.ometa.client import ClientConfig
-
-        captured = {"client": None}
-
-        def capture(*_, client=None, **__):
-            captured["client"] = client
-            return True
-
-        metadata = Mock(spec=OpenMetadata)
-        metadata.client = Mock()
-        metadata.client.config = ClientConfig(base_url="http://localhost:8585")
-        metadata.send_logs_batch_best_effort = Mock(side_effect=capture)
-        metadata.send_close_best_effort = Mock(return_value=True)
-
-        handler = _make_handler(metadata=metadata, enable_streaming=True)
-        handler.emit(_make_record("trigger"))
-        for _ in range(50):
-            if metadata.send_logs_batch_best_effort.called:
-                break
-            time.sleep(0.05)
-
-        self.assertIs(
-            captured["client"], handler._client, "handler must pass its own _client to send_logs_batch_best_effort"
-        )
-        handler.close()
-
-    @patch("metadata.utils.streamable_logger.REST")
-    def test_handler_reuses_one_isolated_client_for_all_batches(self, mock_rest):
-        """Persistent connection pool guarantee: construct one isolated REST
-        client per handler, pass that same client for every batch, and close
-        it only when the sender exits."""
-        client = Mock()
-        mock_rest.return_value = client
-
-        metadata = Mock(spec=OpenMetadata)
-        metadata.client = Mock()
-        metadata.client.config = Mock()
-        metadata.send_logs_batch_best_effort = Mock(return_value=True)
-        metadata.send_close_best_effort = Mock(return_value=True)
-
-        handler = _make_handler(metadata=metadata, enable_streaming=True)
-
-        handler._post_batch(["first"])
-        handler._post_batch(["second"])
-
-        mock_rest.assert_called_once_with(metadata.client.config)
-        self.assertEqual(metadata.send_logs_batch_best_effort.call_count, 2)
-        first_call, second_call = metadata.send_logs_batch_best_effort.call_args_list
-        self.assertIs(first_call.kwargs["client"], client)
-        self.assertIs(second_call.kwargs["client"], client)
-        client.close.assert_not_called()
-
-        handler.close()
-
-    def test_isolated_client_is_closed_by_sender_thread(self):
-        metadata = _make_metadata_mock()
-        handler = _make_handler(metadata=metadata, enable_streaming=True)
-        handler._client.close = Mock()
-
-        handler.close()
-        for _ in range(50):
-            if handler._client.close.called:
-                break
-            time.sleep(0.05)
-
-        handler._client.close.assert_called()
-
-
-class TestNoWaitClose(unittest.TestCase):
-    """close() must return effectively instantly. It must NOT join the
-    drainer / senders and must NOT wait on the server /close response."""
-
-    def test_close_returns_in_under_100ms_when_idle(self):
-        handler = _make_handler(enable_streaming=True)
-
-        start = time.monotonic()
-        handler.close()
-        elapsed = time.monotonic() - start
-
-        self.assertLess(
-            elapsed,
-            0.1,
-            f"close() took {elapsed * 1000:.1f}ms - must not block",
-        )
-
-    def test_close_returns_quickly_when_close_endpoint_hangs(self):
-        hang = threading.Event()
-
-        def block_forever(*_, **__):
-            hang.wait(timeout=30)
-            return True
-
-        metadata = _make_metadata_mock()
-        metadata.send_logs_batch_best_effort = Mock(return_value=True)
-        metadata.send_close_best_effort = Mock(side_effect=block_forever)
-
-        handler = _make_handler(metadata=metadata, enable_streaming=True)
-
-        start = time.monotonic()
-        handler.close()
-        elapsed = time.monotonic() - start
-
-        self.assertLess(
-            elapsed,
-            0.1,
-            f"close() took {elapsed * 1000:.1f}ms - must not wait on /close response",
-        )
-        hang.set()
-
-    def test_close_signals_stop(self):
-        handler = _make_handler(enable_streaming=True)
-        handler.close()
-        self.assertTrue(handler._stop.is_set())
-
-    def test_close_is_idempotent(self):
-        handler = _make_handler(enable_streaming=True)
-        handler.close()
-        handler.close()  # must not raise
-
-
-class TestQuietClientPath(unittest.TestCase):
-    """The handler uses the best-effort path that bypasses retries and logging."""
-
-    def test_post_uses_best_effort_method(self):
-        metadata = _make_metadata_mock()
-        metadata.send_logs_batch_best_effort = Mock(return_value=True)
-        metadata.send_close_best_effort = Mock(return_value=True)
-
-        handler = _make_handler(metadata=metadata, enable_streaming=True)
-        handler.emit(_make_record("trigger"))
-        for _ in range(50):
-            if metadata.send_logs_batch_best_effort.called:
-                break
-            time.sleep(0.05)
-
-        self.assertTrue(metadata.send_logs_batch_best_effort.called)
-        kwargs = metadata.send_logs_batch_best_effort.call_args.kwargs
-        self.assertEqual(kwargs["timeout"], StreamableLogHandler.HTTP_TIMEOUT)
-        handler.close()
 
 
 class TestStreamableLogHandlerManager(unittest.TestCase):
@@ -606,215 +144,430 @@ class TestStreamableLoggingSetup(unittest.TestCase):
         self.assertIsNone(result)
 
 
-class TestRecursionRegression(unittest.TestCase):
-    """emit() must run exactly once per producer call even when overflow
-    or format failure would historically have triggered recursive logging."""
+# ============================================================================
+# StreamableLogHandler — pytest-style tests using a fake OMeta transport.
+#
+# These tests drive the full handler lifecycle (emit -> buffer -> worker ->
+# flush -> shutdown -> /close) without any real network or infrastructure.
+# A FakeOMeta records every batch and close call; failure modes are simulated
+# via the post_delay / post_returns / post_raises knobs.
+# ============================================================================
 
-    def setUp(self):
-        self.mock_metadata = _make_metadata_mock()
-        self.test_logger = logging.getLogger(f"test_recursion_{id(self)}")
-        self.test_logger.handlers = []
-        self.test_logger.setLevel(logging.DEBUG)
-        self.test_logger.propagate = False
 
-    def tearDown(self):
-        self.test_logger.handlers = []
+class FakeOMeta:
+    """Test double for OpenMetadata exposing only what the handler uses.
 
-    def _make_handler_with_full_buffer(self):
-        handler = _make_handler(
-            metadata=self.mock_metadata,
-            max_buffer=2,
-            enable_streaming=True,
+    Recorded interactions: shipped_batches (log_content per POST),
+    close_calls (one tuple per /close POST).
+
+    Fault injection knobs:
+      - post_delay: seconds each POST blocks before returning
+      - post_returns: True/False return value for send_logs_batch_best_effort
+      - post_raises: exception class to raise (None to disable)
+      - intermittent_pattern: callable(post_count) -> bool overriding post_returns
+    """
+
+    def __init__(self):
+        from metadata.ingestion.ometa.client import ClientConfig
+
+        fake_client = type("_FakeClient", (), {})()
+        fake_client.config = ClientConfig(base_url="http://test")
+        self.client = fake_client
+        self.shipped_batches: list = []
+        self.close_calls: list = []
+        self.post_delay = 0.0
+        self.post_returns = True
+        self.post_raises = None
+        self.intermittent_pattern = None
+        self._post_counter = 0
+
+    def send_logs_batch_best_effort(self, pipeline_fqn, run_id, log_content, timeout=None, client=None):
+        self._post_counter += 1
+        if self.post_delay:
+            time.sleep(self.post_delay)
+        if self.post_raises is not None:
+            raise self.post_raises("simulated failure")
+        if self.intermittent_pattern is not None:
+            ok = self.intermittent_pattern(self._post_counter)
+        else:
+            ok = self.post_returns
+        if ok:
+            self.shipped_batches.append(log_content)
+        return ok
+
+    def send_close_best_effort(self, pipeline_fqn, run_id, timeout=None, client=None):
+        self.close_calls.append((pipeline_fqn, str(run_id)))
+        return True
+
+
+@pytest.fixture
+def fake_ometa():
+    return FakeOMeta()
+
+
+@pytest.fixture
+def fake_atexit(monkeypatch):
+    """Capture atexit register/unregister calls instead of using the real one."""
+    registered = []
+    unregistered = []
+    monkeypatch.setattr(
+        "metadata.utils.streamable_logger.atexit.register",
+        lambda fn, *a, **k: registered.append(fn),
+    )
+    monkeypatch.setattr(
+        "metadata.utils.streamable_logger.atexit.unregister",
+        unregistered.append,
+    )
+    return {"registered": registered, "unregistered": unregistered}
+
+
+@pytest.fixture
+def fake_rest(monkeypatch):
+    """Mock REST so the P1 force-stop fresh-client path doesn't hit network."""
+    calls = []
+
+    class _FakeREST:
+        def __init__(self, config):
+            calls.append(config)
+            self._closed = False
+
+        def close(self):
+            self._closed = True
+
+    monkeypatch.setattr("metadata.utils.streamable_logger.REST", _FakeREST)
+    return calls
+
+
+@pytest.fixture
+def fast_constants(monkeypatch):
+    """Shrink class-level timeouts so tests run in <1s each."""
+    monkeypatch.setattr(StreamableLogHandler, "BATCH_WAIT_SEC", 0.05)
+    monkeypatch.setattr(StreamableLogHandler, "CLOSE_TIMEOUT_SEC", 1.0)
+    monkeypatch.setattr(StreamableLogHandler, "HTTP_TIMEOUT", (0.2, 1.0))
+
+
+@pytest.fixture
+def make_v2(fake_ometa, fake_atexit, fake_rest, fast_constants):
+    """Factory for fully configured V2 handlers. Cleans up after each test."""
+    handlers = []
+
+    def _make(max_buffer=1000, enable_streaming=True):
+        h = StreamableLogHandler(
+            metadata=fake_ometa,
+            pipeline_fqn="test.pipeline",
+            run_id=uuid4(),
+            max_buffer=max_buffer,
+            enable_streaming=enable_streaming,
         )
-        _stop_workers(handler)
-        handler._buffer.put_nowait("a")
-        handler._buffer.put_nowait("b")
-        self.assertTrue(handler._buffer.full())
-        return handler
+        h.setFormatter(logging.Formatter("%(message)s"))
+        handlers.append(h)
+        return h
 
-    def test_emit_does_not_recurse_when_buffer_full(self):
-        handler = self._make_handler_with_full_buffer()
-        self.test_logger.addHandler(handler)
+    yield _make
 
-        emit_calls = {"n": 0}
-        real_emit = handler.emit
-
-        def counting(record):
-            emit_calls["n"] += 1
-            if emit_calls["n"] > 5:
-                raise AssertionError("emit() recursed — single-call regression")
-            real_emit(record)
-
-        handler.emit = counting
-        start = time.monotonic()
-        self.test_logger.warning("trigger overflow")
-        elapsed = time.monotonic() - start
-
-        self.assertEqual(emit_calls["n"], 1)
-        self.assertLess(elapsed, 1.0)
-
-    def test_emit_does_not_recurse_when_format_raises(self):
-        handler = _make_handler(metadata=self.mock_metadata, enable_streaming=True)
-        _stop_workers(handler)
-        handler.format = MagicMock(side_effect=ValueError("boom"))
-
-        self.test_logger.addHandler(handler)
-        emit_calls = {"n": 0}
-        real_emit = handler.emit
-
-        def counting(record):
-            emit_calls["n"] += 1
-            if emit_calls["n"] > 5:
-                raise AssertionError("emit() recursed via format-failure path")
-            real_emit(record)
-
-        handler.emit = counting
-        start = time.monotonic()
-        self.test_logger.error("trigger format failure")
-        elapsed = time.monotonic() - start
-
-        self.assertEqual(emit_calls["n"], 1)
-        self.assertLess(elapsed, 1.0)
+    for h in handlers:
+        if not h._closed:
+            with contextlib.suppress(Exception):
+                h.shutdown(timeout=1.0)
 
 
-class TestQuietClientPostMixin(unittest.TestCase):
-    """The mixin's best-effort methods must NOT log through ometa_logger
-    (which would propagate back to the streamable handler)."""
-
-    def test_send_logs_batch_best_effort_does_not_log_on_failure(self):
-        from metadata.ingestion.ometa.mixins.logs_mixin import OMetaLogsMixin
-
-        # Build a bare instance and stub the client.
-        instance = OMetaLogsMixin()
-        instance.client = Mock()
-        instance.client.post_best_effort = Mock(return_value=False)
-
-        with patch("metadata.ingestion.ometa.mixins.logs_mixin.logger") as mock_logger:
-            ok = instance.send_logs_batch_best_effort(
-                pipeline_fqn="test",
-                run_id=uuid4(),
-                log_content="x",
-                timeout=(1, 2),
-            )
-
-        self.assertFalse(ok)
-        mock_logger.error.assert_not_called()
-        mock_logger.warning.assert_not_called()
-        mock_logger.info.assert_not_called()
-        mock_logger.debug.assert_not_called()
-
-    def test_send_logs_batch_best_effort_does_not_log_on_exception(self):
-        from metadata.ingestion.ometa.mixins.logs_mixin import OMetaLogsMixin
-
-        instance = OMetaLogsMixin()
-        instance.client = Mock()
-        instance.client.post_best_effort = Mock(side_effect=RuntimeError("boom"))
-
-        with patch("metadata.ingestion.ometa.mixins.logs_mixin.logger") as mock_logger:
-            ok = instance.send_logs_batch_best_effort(
-                pipeline_fqn="test",
-                run_id=uuid4(),
-                log_content="x",
-                timeout=(1, 2),
-            )
-
-        self.assertFalse(ok)
-        mock_logger.error.assert_not_called()
-        mock_logger.warning.assert_not_called()
+def _stop_v2_worker(handler):
+    """Halt the worker without going through shutdown — used to test emit
+    behavior with a quiescent buffer that won't be drained."""
+    handler._stop_event.set()
+    if handler._worker is not None:
+        handler._worker.join(timeout=1.0)
 
 
-class TestClientPostBestEffort(unittest.TestCase):
-    """REST.post_best_effort must NOT enter the retry/sleep loop and
-    must NOT log on failure."""
-
-    def _make_client(self):
-        from metadata.ingestion.ometa.client import REST, ClientConfig
-
-        config = ClientConfig(
-            base_url="http://localhost:8585",
-            api_version="v1",
-            auth_token=lambda: ("token", 60),
-        )
-        client = REST(config)
-        client._session = Mock()
-        return client
-
-    def test_post_best_effort_does_not_sleep_on_504(self):
-        client = self._make_client()
-        resp = Mock()
-        resp.status_code = 504
-        client._session.post = Mock(return_value=resp)
-
-        with patch("time.sleep") as mock_sleep:
-            start = time.monotonic()
-            ok = client.post_best_effort("/path", data="x", timeout=(1, 2))
-            elapsed = time.monotonic() - start
-
-        self.assertFalse(ok)
-        mock_sleep.assert_not_called()
-        self.assertLess(elapsed, 0.2, "post_best_effort must NOT sleep on 504")
-
-    def test_post_best_effort_does_not_log_on_failure(self):
-        client = self._make_client()
-        client._session.post = Mock(side_effect=RuntimeError("network down"))
-
-        with patch("metadata.ingestion.ometa.client.logger") as mock_logger:
-            ok = client.post_best_effort("/path", data="x", timeout=(1, 2))
-
-        self.assertFalse(ok)
-        mock_logger.error.assert_not_called()
-        mock_logger.warning.assert_not_called()
-        mock_logger.info.assert_not_called()
-
-    def test_post_best_effort_returns_true_on_2xx(self):
-        client = self._make_client()
-        resp = Mock()
-        resp.status_code = 200
-        client._session.post = Mock(return_value=resp)
-
-        self.assertTrue(client.post_best_effort("/path", data="x"))
-
-    def test_build_request_headers_does_not_refresh_token(self):
-        """Token refresh stays on _request(); concurrent refresh from the
-        sender would race the main thread on shared ClientConfig."""
-        client = self._make_client()
-        client._auth_token = Mock(return_value=("fresh-token", 60))
-        client.config.expires_in = 0
-        client.config.access_token = "stale-token"
-        client.config.auth_header = "Authorization"
-
-        headers = client._build_request_headers()
-
-        client._auth_token.assert_not_called()
-        self.assertEqual(headers["Authorization"], "Bearer stale-token")
-        self.assertEqual(client.config.expires_in, 0)
+# ----- Group 1: emit / buffer behavior -----
 
 
-class TestCloseOrderingRegression(unittest.TestCase):
-    """close() must enqueue CLOSE_MARKER before setting _stop, otherwise
-    the sender's get(timeout) Empty branch can race the enqueue."""
+def test_emit_drops_when_buffer_full(make_v2):
+    handler = make_v2(max_buffer=2)
+    _stop_v2_worker(handler)
 
-    def test_close_enqueues_marker_before_setting_stop(self):
-        metadata = _make_metadata_mock()
-        handler = _make_handler(metadata=metadata, enable_streaming=True)
-        handler.close()
-        for _ in range(50):
-            if metadata.send_close_best_effort.called:
-                break
-            time.sleep(0.05)
-        metadata.send_close_best_effort.assert_called_once()
+    for i in range(5):
+        handler.emit(_make_record(f"log {i}"))
 
-    def test_close_marker_arrives_even_when_sender_was_idle(self):
-        metadata = _make_metadata_mock()
-        handler = _make_handler(metadata=metadata, enable_streaming=True)
-        time.sleep(0.2)  # let sender enter get(timeout=...)
-        handler.close()
-        for _ in range(50):
-            if metadata.send_close_best_effort.called:
-                break
-            time.sleep(0.05)
-        metadata.send_close_best_effort.assert_called_once()
+    assert handler.dropped_overflow == 3
+    assert handler._buffer.qsize() == 2
 
 
-if __name__ == "__main__":
-    unittest.main()
+def test_emit_drops_after_close(make_v2, fake_ometa):
+    handler = make_v2()
+    handler.shutdown(timeout=1.0)
+
+    handler.emit(_make_record("after close"))
+    handler.emit(_make_record("also after"))
+
+    assert handler.dropped_after_close == 2
+    assert all("after close" not in b and "also after" not in b for b in fake_ometa.shipped_batches)
+
+
+def test_emit_handles_format_error(make_v2):
+    handler = make_v2()
+    _stop_v2_worker(handler)
+
+    bad_record = _make_record("bad")
+    # Force format() to raise on this record only.
+    handler.format = Mock(side_effect=ValueError("format boom"))
+    handler.emit(bad_record)
+
+    assert handler.dropped_format_error == 1
+    assert handler._buffer.qsize() == 0
+
+
+def test_recursion_guard_prevents_self_emit(make_v2):
+    handler = make_v2()
+    _stop_v2_worker(handler)
+    _shipping_state.shipping = True
+    try:
+        handler.emit(_make_record("inside shipping"))
+        assert handler.dropped_shipping == 1
+        assert handler._buffer.qsize() == 0
+    finally:
+        _shipping_state.shipping = False
+
+
+# ----- Group 2: flush semantics -----
+
+
+def test_flush_blocks_until_buffer_empty(make_v2, fake_ometa):
+    handler = make_v2()
+    for i in range(50):
+        handler.emit(_make_record(f"log {i}"))
+
+    handler.flush(timeout=2.0)
+
+    assert handler._buffer.empty()
+    # Each batch is a single "\n"-joined log_content; total record count
+    # across all batches must be 50.
+    total = sum(b.count("\n") for b in fake_ometa.shipped_batches)
+    assert total == 50
+
+
+def test_flush_times_out_when_post_is_slow(make_v2, fake_ometa):
+    fake_ometa.post_delay = 1.0
+    handler = make_v2()
+    handler.emit(_make_record("slow"))
+
+    handler.flush(timeout=0.1)
+
+    assert handler.flush_timed_out == 1
+
+
+def test_flush_does_not_return_in_dequeue_post_gap(make_v2, fake_ometa):
+    """Regression: flush() must NOT report drained while a batch the worker
+    just dequeued hasn't started POSTing yet (TOCTOU between buffer.get() and
+    _post_in_flight.set())."""
+    fake_ometa.post_delay = 0.5
+    handler = make_v2()
+    handler.emit(_make_record("payload"))
+
+    # Long enough that the worker has dequeued + started its slow POST.
+    handler.flush(timeout=2.0)
+
+    # If the race fires, flush() returns before the POST runs and the fake
+    # records zero shipped batches.
+    assert len(fake_ometa.shipped_batches) >= 1
+    assert handler.flush_timed_out == 0
+
+
+# ----- Group 3: shutdown lifecycle -----
+
+
+def test_shutdown_is_idempotent(make_v2, fake_ometa):
+    handler = make_v2()
+    handler.shutdown(timeout=1.0)
+    handler.shutdown(timeout=1.0)
+    handler.shutdown(timeout=1.0)
+
+    assert len(fake_ometa.close_calls) == 1
+
+
+def test_shutdown_delivers_close_post(make_v2, fake_ometa):
+    handler = make_v2()
+    handler.emit(_make_record("first"))
+    handler.shutdown(timeout=1.0)
+
+    assert len(fake_ometa.close_calls) == 1
+
+
+def test_shutdown_ships_metrics_before_close(make_v2, fake_ometa):
+    handler = make_v2()
+    handler.emit(_make_record("payload"))
+    handler.shutdown(timeout=1.0)
+
+    # Last shipped batch must be the multi-line metrics block.
+    assert fake_ometa.shipped_batches, "expected at least one shipped batch"
+    last = fake_ometa.shipped_batches[-1]
+    assert "streamable_logger shutdown:" in last
+    assert "shipped:" in last and "failed:" in last
+    # Close must have happened after the metrics POST.
+    assert len(fake_ometa.close_calls) == 1
+
+
+def test_atexit_registered_then_unregistered(make_v2, fake_atexit):
+    handler = make_v2()
+    assert handler.shutdown in fake_atexit["registered"]
+    handler.shutdown(timeout=1.0)
+    assert handler.shutdown in fake_atexit["unregistered"]
+
+
+def test_shutdown_force_stops_on_join_timeout(make_v2, fake_ometa, fake_rest):
+    # Each POST blocks longer than the shutdown deadline → worker can't
+    # finish the drain in its 0.5s budget. P1 force-stop path must fire:
+    #   - shutdown_timed_out increments
+    #   - A second REST(...) is constructed (first one was in __init__)
+    #   - /close is still delivered via the fresh client
+    fake_ometa.post_delay = 0.8
+    handler = make_v2()
+    rest_count_after_init = len(fake_rest)
+    for i in range(5):
+        handler.emit(_make_record(f"log {i}"))
+
+    handler.shutdown(timeout=0.4)
+
+    assert handler.shutdown_timed_out == 1
+    assert len(fake_rest) == rest_count_after_init + 1  # fresh REST was created
+    assert len(fake_ometa.close_calls) == 1
+
+
+# ----- Group 4: worker resilience -----
+
+
+def test_worker_survives_post_exception(make_v2, fake_ometa):
+    fake_ometa.post_raises = RuntimeError
+    handler = make_v2()
+    handler.emit(_make_record("a"))
+    handler.emit(_make_record("b"))
+    time.sleep(0.3)  # give worker a chance to run the loop a couple times
+
+    # Worker should have caught the exception(s) and kept running.
+    assert handler.worker_errors >= 1
+    assert handler._worker.is_alive()
+
+    handler.shutdown(timeout=1.0)
+
+
+def test_worker_survives_collect_exception(make_v2):
+    handler = make_v2()
+    # Patch _collect_batch to raise once, then behave normally.
+    real_collect = handler._collect_batch
+    call_count = {"n": 0}
+
+    def collect_with_one_failure(timeout):
+        call_count["n"] += 1
+        if call_count["n"] == 2:
+            raise RuntimeError("simulated collect failure")
+        return real_collect(timeout)
+
+    handler._collect_batch = collect_with_one_failure
+    handler.emit(_make_record("a"))
+    time.sleep(0.4)
+
+    assert handler.worker_errors >= 1
+    assert handler._worker.is_alive()
+
+
+def test_worker_drain_breaks_on_persistent_failure(make_v2, fake_ometa):
+    # During shutdown's drain phase, persistent _collect_batch failure must
+    # bail out instead of spinning forever.
+    handler = make_v2()
+    handler.emit(_make_record("seed"))
+
+    # Wait for the seed to ship so we can move into drain cleanly.
+    time.sleep(0.2)
+
+    # Now break collect for the drain phase.
+    handler._collect_batch = Mock(side_effect=RuntimeError("persistent"))
+
+    start = time.monotonic()
+    handler.shutdown(timeout=2.0)
+    elapsed = time.monotonic() - start
+
+    # Must exit promptly, not spin until deadline.
+    assert elapsed < 1.5
+    assert handler.worker_errors >= 1
+
+
+# ----- Group 5: network failures / chaos -----
+
+
+def test_failed_posts_increments_on_false_return(make_v2, fake_ometa):
+    fake_ometa.post_returns = False
+    handler = make_v2()
+    for i in range(3):
+        handler.emit(_make_record(f"log {i}"))
+
+    handler.shutdown(timeout=2.0)
+
+    assert handler.failed_posts >= 1
+    assert handler.shipped_records == 0
+
+
+def test_intermittent_failures_counted_correctly(make_v2, fake_ometa):
+    # Alternate True / False every other POST.
+    fake_ometa.intermittent_pattern = lambda n: n % 2 == 1
+    handler = make_v2()
+    for i in range(20):
+        handler.emit(_make_record(f"log {i}"))
+        time.sleep(0.02)  # spread emits so batches form
+
+    handler.shutdown(timeout=2.0)
+
+    # Some succeeded, some failed.
+    assert handler.failed_posts >= 1
+    assert handler.shipped_records >= 1
+
+
+def test_slow_om_shutdown_still_delivers_close(make_v2, fake_ometa, fake_rest):
+    # Full P1 chaos: every POST takes longer than the join budget.
+    fake_ometa.post_delay = 0.6
+    handler = make_v2()
+    rest_count_after_init = len(fake_rest)
+    for i in range(10):
+        handler.emit(_make_record(f"log {i}"))
+
+    handler.shutdown(timeout=0.3)
+
+    # Despite the worker being stuck, /close must have been delivered on
+    # a fresh REST instance (force-stop + fresh client path).
+    assert handler.shutdown_timed_out == 1
+    assert len(fake_rest) == rest_count_after_init + 1
+    assert len(fake_ometa.close_calls) == 1
+
+
+# ----- Group 6: end-to-end lifecycle -----
+
+
+def test_end_to_end_emit_lifecycle(make_v2, fake_ometa):
+    """The whole story in one test: emit a bunch, shutdown, assert clean."""
+    handler = make_v2()
+    for i in range(200):
+        handler.emit(_make_record(f"log line {i}"))
+
+    handler.shutdown(timeout=2.0)
+
+    # Reconstruct what landed on the "server": sum of newlines across all
+    # shipped batches except the multi-line metrics block at the end.
+    payload_batches = fake_ometa.shipped_batches[:-1]
+    metrics_batch = fake_ometa.shipped_batches[-1]
+
+    total_lines = sum(b.count("\n") for b in payload_batches)
+    assert total_lines == 200
+
+    # Metrics line shipped + /close delivered.
+    assert "streamable_logger shutdown:" in metrics_batch
+    assert len(fake_ometa.close_calls) == 1
+
+    # Counters all clean.
+    assert handler.dropped_overflow == 0
+    assert handler.dropped_after_close == 0
+    assert handler.dropped_shipping == 0
+    assert handler.dropped_format_error == 0
+    assert handler.worker_errors == 0
+    assert handler.failed_posts == 0
+    assert handler.flush_timed_out == 0
+    assert handler.shutdown_timed_out == 0
+    assert handler.shipped_records == 200

--- a/ingestion/tests/unit/utils/test_streamable_logger.py
+++ b/ingestion/tests/unit/utils/test_streamable_logger.py
@@ -8,875 +8,611 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-"""
-Unit tests for the streamable logger module.
-"""
+"""Unit tests for the streamable logger module."""
 
 import logging
-import os
+import threading
 import time
 import unittest
-from unittest.mock import Mock, patch
+from unittest.mock import MagicMock, Mock, patch
 from uuid import uuid4
 
 from metadata.ingestion.ometa.ometa_api import OpenMetadata
 from metadata.utils.streamable_logger import (
-    CircuitBreaker,
-    CircuitState,
     StreamableLogHandler,
+    StreamableLogHandlerManager,
+    _shipping_state,
     cleanup_streamable_logging,
     setup_streamable_logging_for_workflow,
 )
 
 
-class TestCircuitBreaker(unittest.TestCase):
-    """Test the circuit breaker implementation"""
-
-    def setUp(self):
-        self.breaker = CircuitBreaker(
-            failure_threshold=3, recovery_timeout=1, success_threshold=2
-        )
-
-    def test_initial_state_is_closed(self):
-        """Test that circuit breaker starts in CLOSED state"""
-        self.assertEqual(self.breaker.state, CircuitState.CLOSED)
-        self.assertEqual(self.breaker.failure_count, 0)
-
-    def test_opens_after_threshold_failures(self):
-        """Test that circuit opens after reaching failure threshold"""
-
-        def failing_func():
-            raise Exception("Test failure")
-
-        for i in range(3):
-            with self.assertRaises(Exception):
-                self.breaker.call(failing_func)
-
-        self.assertEqual(self.breaker.state, CircuitState.OPEN)
-        self.assertEqual(self.breaker.failure_count, 3)
-
-    def test_blocks_calls_when_open(self):
-        """Test that calls are blocked when circuit is open"""
-        # Open the circuit
-        self.breaker.state = CircuitState.OPEN
-        self.breaker.last_failure_time = time.time()
-
-        with self.assertRaises(Exception) as ctx:
-            self.breaker.call(lambda: "success")
-
-        self.assertIn("Circuit breaker is OPEN", str(ctx.exception))
-
-    def test_transitions_to_half_open_after_timeout(self):
-        """Test transition to HALF_OPEN state after recovery timeout"""
-        # Open the circuit
-        self.breaker.state = CircuitState.OPEN
-        self.breaker.last_failure_time = time.time() - 2  # 2 seconds ago
-
-        # Should transition to HALF_OPEN
-        def success_func():
-            return "success"
-
-        result = self.breaker.call(success_func)
-        self.assertEqual(result, "success")
-        self.assertEqual(self.breaker.state, CircuitState.HALF_OPEN)
-
-    def test_closes_after_success_threshold_in_half_open(self):
-        """Test that circuit closes after success threshold in HALF_OPEN"""
-        self.breaker.state = CircuitState.HALF_OPEN
-
-        def success_func():
-            return "success"
-
-        # First success
-        self.breaker.call(success_func)
-        self.assertEqual(self.breaker.state, CircuitState.HALF_OPEN)
-
-        # Second success - should close
-        self.breaker.call(success_func)
-        self.assertEqual(self.breaker.state, CircuitState.CLOSED)
-
-    def test_reopens_on_failure_in_half_open(self):
-        """Test that circuit reopens on failure in HALF_OPEN state"""
-        self.breaker.state = CircuitState.HALF_OPEN
-
-        def failing_func():
-            raise Exception("Test failure")
-
-        with self.assertRaises(Exception):
-            self.breaker.call(failing_func)
-
-        self.assertEqual(self.breaker.state, CircuitState.OPEN)
+def _make_record(msg="test message", level=logging.INFO):
+    return logging.LogRecord(
+        name="test",
+        level=level,
+        pathname="test.py",
+        lineno=1,
+        msg=msg,
+        args=(),
+        exc_info=None,
+    )
 
 
-class TestStreamableLogHandler(unittest.TestCase):
-    """Test the StreamableLogHandler class"""
+def _make_metadata_mock():
+    """Build a Mock that satisfies StreamableLogHandler's needs:
+    - send_logs_batch_best_effort / send_close_best_effort attrs
+    - .client.config (real ClientConfig) so handler can build its own REST"""
+    from metadata.ingestion.ometa.client import ClientConfig
 
-    def setUp(self):
-        """Set up test fixtures"""
-        self.mock_metadata = Mock(spec=OpenMetadata)
-        self.mock_metadata.config = Mock()
-        self.mock_metadata.config.host_port = "http://localhost:8585"
-        self.mock_metadata.config.auth_token = "test-token"
-        # Mock the _auth_header method
-        self.mock_metadata._auth_header = Mock(
-            return_value={"Authorization": "Bearer test-token"}
-        )
+    metadata = Mock(spec=OpenMetadata)
+    metadata.client = Mock()
+    metadata.client.config = ClientConfig(base_url="http://localhost:8585")
+    metadata.send_logs_batch_best_effort = Mock(return_value=True)
+    metadata.send_close_best_effort = Mock(return_value=True)
+    return metadata
 
-        self.pipeline_fqn = "test.pipeline"
-        self.run_id = uuid4()
+
+def _make_handler(
+    metadata=None,
+    pipeline_fqn="test.pipeline",
+    run_id=None,
+    max_buffer=10000,
+    enable_streaming=False,
+):
+    if metadata is None:
+        metadata = _make_metadata_mock()
+    if run_id is None:
+        run_id = uuid4()
+    handler = StreamableLogHandler(
+        metadata=metadata,
+        pipeline_fqn=pipeline_fqn,
+        run_id=run_id,
+        max_buffer=max_buffer,
+        enable_streaming=enable_streaming,
+    )
+    handler.setFormatter(logging.Formatter("%(message)s"))
+    return handler
+
+
+def _stop_workers(handler):
+    """Signal stop and give the drainer/senders a moment to notice.
+    Used in tests that need a quiescent handler. We don't .join() in
+    production close() - see TestNoWaitClose - but in tests we want
+    to be sure background threads aren't going to race assertions."""
+    handler._stop.set()
+    if handler._drainer:
+        handler._drainer.join(timeout=3)
+    for t in handler._senders:
+        t.join(timeout=3)
+
+
+class TestEmitNonBlocking(unittest.TestCase):
+    """emit() must be fast and must never raise."""
+
+    def test_emit_with_streaming_disabled_goes_to_fallback(self):
+        handler = _make_handler(enable_streaming=False)
+        handler.fallback_handler = Mock()
+        record = _make_record()
+
+        handler.emit(record)
+
+        handler.fallback_handler.emit.assert_called_once_with(record)
+
+    def test_emit_with_streaming_enabled_queues_to_buffer(self):
+        handler = _make_handler(enable_streaming=True)
+        _stop_workers(handler)
+
+        handler.emit(_make_record("log A"))
+        handler.emit(_make_record("log B"))
+
+        self.assertEqual(handler._buffer.qsize(), 2)
+        handler.close()
+
+    def test_emit_drops_silently_when_buffer_full(self):
+        """No stderr fallback per record on overflow - only a counter."""
+        handler = _make_handler(max_buffer=1, enable_streaming=True)
+        _stop_workers(handler)
+        handler.fallback_handler = Mock()
+        handler._buffer.put_nowait("already-here")
+
+        start = time.monotonic()
+        handler.emit(_make_record("overflow"))
+        elapsed = time.monotonic() - start
+
+        self.assertLess(elapsed, 0.05, "emit() must return immediately on overflow")
+        handler.fallback_handler.emit.assert_not_called()
+        self.assertEqual(handler.dropped_overflow, 1)
+
+    def test_emit_never_raises_when_format_fails(self):
+        handler = _make_handler(enable_streaming=True)
+        _stop_workers(handler)
+        handler.format = Mock(side_effect=ValueError("boom"))
+
+        handler.emit(_make_record())
+
+        self.assertEqual(handler.dropped_format_error, 1)
+        self.assertEqual(handler.dropped_overflow, 0)
+        handler.close()
+
+    def test_emit_after_close_increments_dedicated_counter(self):
+        handler = _make_handler(enable_streaming=True)
+        handler.close()
+        handler.emit(_make_record("post-close"))
+        self.assertEqual(handler.dropped_after_close, 1)
+        self.assertEqual(handler.dropped_overflow, 0)
+        self.assertEqual(handler.dropped_format_error, 0)
+
+    def test_emit_returns_quickly_under_high_volume(self):
+        handler = _make_handler(max_buffer=10000, enable_streaming=True)
+        _stop_workers(handler)
+
+        start = time.monotonic()
+        for i in range(1000):
+            handler.emit(_make_record(f"msg-{i}"))
+        elapsed = time.monotonic() - start
+
+        self.assertLess(elapsed, 0.5, f"1000 emits took {elapsed:.3f}s - too slow")
+
+
+class TestRecursionGuard(unittest.TestCase):
+    """The thread-local guard prevents emit() from re-entering itself
+    even if a future change reintroduces logging on the shipping path."""
 
     def tearDown(self):
-        """Clean up after tests"""
-        # Ensure any handlers are properly closed
-        if hasattr(self, "handler") and self.handler:
-            self.handler.close()
+        # Make sure the guard is clear after each test.
+        if hasattr(_shipping_state, "shipping"):
+            _shipping_state.shipping = False
 
-    def test_handler_initialization(self):
-        """Test handler initialization"""
-        handler = StreamableLogHandler(
-            metadata=self.mock_metadata,
-            pipeline_fqn=self.pipeline_fqn,
-            run_id=self.run_id,
-            enable_streaming=False,  # Disable for unit test
+    def test_emit_drops_when_shipping_flag_set(self):
+        handler = _make_handler(enable_streaming=True)
+        _stop_workers(handler)
+
+        _shipping_state.shipping = True
+        try:
+            handler.emit(_make_record("would-recurse"))
+        finally:
+            _shipping_state.shipping = False
+
+        self.assertEqual(handler._buffer.qsize(), 0)
+        self.assertEqual(handler.dropped_shipping, 1)
+
+    def test_post_thread_sets_and_clears_shipping_flag(self):
+        seen_flag = {"value": None}
+
+        def capture(*_, **__):
+            seen_flag["value"] = getattr(_shipping_state, "shipping", False)
+            return True
+
+        metadata = _make_metadata_mock()
+        metadata.send_logs_batch_best_effort = Mock(side_effect=capture)
+        metadata.send_close_best_effort = Mock(return_value=True)
+
+        handler = _make_handler(metadata=metadata, enable_streaming=True)
+        handler.emit(_make_record("trigger"))
+        for _ in range(50):
+            if metadata.send_logs_batch_best_effort.called:
+                break
+            time.sleep(0.05)
+
+        self.assertTrue(seen_flag["value"], "shipping flag must be True inside the sender")
+        handler.close()
+        # Flag must be cleared after the sender returns. Give the
+        # sender thread a moment to hit its finally block.
+        time.sleep(0.1)
+        self.assertFalse(getattr(_shipping_state, "shipping", False))
+
+
+class TestSenderPool(unittest.TestCase):
+    """Bounded send queue. Drainer never waits on a POST."""
+
+    def test_drainer_does_not_wait_on_slow_post(self):
+        slow_event = threading.Event()
+        post_started = threading.Event()
+
+        def slow_send(*_, **__):
+            post_started.set()
+            slow_event.wait(timeout=30)
+            return True
+
+        metadata = _make_metadata_mock()
+        metadata.send_logs_batch_best_effort = Mock(side_effect=slow_send)
+        metadata.send_close_best_effort = Mock(return_value=True)
+
+        handler = _make_handler(metadata=metadata, enable_streaming=True)
+        handler.emit(_make_record("first"))
+        self.assertTrue(post_started.wait(timeout=5))
+
+        start = time.monotonic()
+        for i in range(50):
+            handler.emit(_make_record(f"hangs-{i}"))
+        elapsed = time.monotonic() - start
+
+        self.assertLess(elapsed, 0.5, "emits must not block while a POST is hanging")
+
+        handler._stop.set()
+        slow_event.set()
+        handler._drainer.join(timeout=5)
+
+    def test_saturated_sender_drops_batches(self):
+        """When senders + send queue are full on a dead server, the drainer
+        drops new batches and counts them. No unbounded growth."""
+        hang = threading.Event()  # never set during the test
+
+        def block_forever(*_, **__):
+            hang.wait(timeout=30)
+            return True
+
+        metadata = _make_metadata_mock()
+        metadata.send_logs_batch_best_effort = Mock(side_effect=block_forever)
+        metadata.send_close_best_effort = Mock(return_value=True)
+
+        handler = _make_handler(metadata=metadata, enable_streaming=True)
+        # Make the test cycle faster than defaults.
+        handler.BATCH_WAIT_SEC = 0.1
+
+        # Pump 20 separately-timed batches; each wave > BATCH_WAIT_SEC so
+        # the drainer ships each as its own batch. Senders block forever
+        # on the first MAX_PENDING_BATCHES + SENDER_WORKERS; everything
+        # after that must be dropped at drainer-submit time.
+        total_waves = handler.MAX_PENDING_BATCHES + handler.SENDER_WORKERS + 10
+        for wave in range(total_waves):
+            handler.emit(_make_record(f"wave-{wave}"))
+            time.sleep(0.2)
+
+        # At least some batches must have been dropped at the send-queue
+        # boundary - we sent way more than the cap.
+        self.assertGreater(handler.dropped_saturated, 0, "saturated drainer must have dropped at least one batch")
+        # In-flight POSTs bounded by SENDER_WORKERS (others wait in queue
+        # but don't actually call send_logs_batch_best_effort).
+        self.assertLessEqual(
+            metadata.send_logs_batch_best_effort.call_count,
+            handler.SENDER_WORKERS,
         )
 
-        self.assertEqual(handler.pipeline_fqn, self.pipeline_fqn)
-        self.assertEqual(handler.run_id, self.run_id)
-        self.assertEqual(handler.batch_size, 500)
-        self.assertEqual(handler.flush_interval_sec, 10.0)
-        self.assertFalse(handler.enable_streaming)
-        self.assertIsNone(handler.worker_thread)
+        handler._stop.set()
+        hang.set()
+
+    def test_close_notify_is_ordered_after_in_flight_log_batch(self):
+        """Regression for the close-vs-late-POST race. /close must not
+        overtake an already-started log batch, otherwise the server can
+        finalize logs.txt and then receive a late tail batch."""
+        log_started = threading.Event()
+        release_log = threading.Event()
+        close_called = threading.Event()
+
+        def slow_log_send(*_, **__):
+            log_started.set()
+            release_log.wait(timeout=30)
+            return True
+
+        def close_send(*_, **__):
+            close_called.set()
+            return True
+
+        metadata = _make_metadata_mock()
+        metadata.send_logs_batch_best_effort = Mock(side_effect=slow_log_send)
+        metadata.send_close_best_effort = Mock(side_effect=close_send)
+
+        handler = _make_handler(metadata=metadata, enable_streaming=True)
+        handler.emit(_make_record("first"))
+        self.assertTrue(log_started.wait(timeout=5))
+
+        start = time.monotonic()
+        handler.close()
+        elapsed = time.monotonic() - start
+
+        self.assertLess(elapsed, 0.1, "close() must still return immediately")
+        time.sleep(0.2)
+        self.assertFalse(
+            close_called.is_set(),
+            "/close must wait behind the in-flight log batch in the sender queue",
+        )
+
+        release_log.set()
+        self.assertTrue(close_called.wait(timeout=5))
+
+
+class TestDaemonThreads(unittest.TestCase):
+    """All background threads MUST be daemon, otherwise a wedged sender
+    can keep the ingestion process alive past main-thread exit."""
+
+    def test_drainer_thread_is_daemon(self):
+        handler = _make_handler(enable_streaming=True)
+        self.assertTrue(handler._drainer.daemon, "drainer must be a daemon thread")
+        handler.close()
+
+    def test_sender_threads_are_daemon(self):
+        handler = _make_handler(enable_streaming=True)
+        self.assertEqual(len(handler._senders), handler.SENDER_WORKERS)
+        for t in handler._senders:
+            self.assertTrue(t.daemon, f"sender {t.name} must be daemon")
+        handler.close()
+
+    def test_close_notify_thread_is_daemon(self):
+        """The /close call goes out on a daemon so close() doesn't wait."""
+        seen = {"daemon": None}
+
+        def capture(*_, **__):
+            seen["daemon"] = threading.current_thread().daemon
+            return True
+
+        metadata = _make_metadata_mock()
+        metadata.send_logs_batch_best_effort = Mock(return_value=True)
+        metadata.send_close_best_effort = Mock(side_effect=capture)
+
+        handler = _make_handler(metadata=metadata, enable_streaming=True)
+        handler.close()
+        for _ in range(50):
+            if seen["daemon"] is not None:
+                break
+            time.sleep(0.05)
+        self.assertTrue(seen["daemon"], "close notify must run on a daemon sender thread")
+
+
+class TestIsolatedClient(unittest.TestCase):
+    """The handler must use its OWN REST instance (own session/cookies/
+    connection pool), not the main metadata client's."""
+
+    def test_handler_creates_dedicated_rest_client(self):
+        from metadata.ingestion.ometa.client import REST
+
+        metadata = Mock(spec=OpenMetadata)
+        # Give the mock client a real ClientConfig so REST() can copy it.
+        from metadata.ingestion.ometa.client import ClientConfig
+
+        metadata.client = Mock()
+        metadata.client.config = ClientConfig(base_url="http://localhost:8585")
+        metadata.send_logs_batch_best_effort = Mock(return_value=True)
+        metadata.send_close_best_effort = Mock(return_value=True)
+
+        handler = _make_handler(metadata=metadata, enable_streaming=True)
+
+        self.assertIsInstance(handler._client, REST)
+        self.assertIsNot(handler._client, metadata.client, "handler must own a SEPARATE REST instance")
+        self.assertIsNot(handler._client._session, metadata.client, "handler's session must not be the main client")
+        handler.close()
+
+    def test_handler_passes_isolated_client_to_post(self):
+        """The send_logs_batch_best_effort call must include the handler's
+        own client kwarg so log shipping doesn't go through the main session."""
+        from metadata.ingestion.ometa.client import ClientConfig
+
+        captured = {"client": None}
+
+        def capture(*_, client=None, **__):
+            captured["client"] = client
+            return True
+
+        metadata = Mock(spec=OpenMetadata)
+        metadata.client = Mock()
+        metadata.client.config = ClientConfig(base_url="http://localhost:8585")
+        metadata.send_logs_batch_best_effort = Mock(side_effect=capture)
+        metadata.send_close_best_effort = Mock(return_value=True)
+
+        handler = _make_handler(metadata=metadata, enable_streaming=True)
+        handler.emit(_make_record("trigger"))
+        for _ in range(50):
+            if metadata.send_logs_batch_best_effort.called:
+                break
+            time.sleep(0.05)
+
+        self.assertIs(
+            captured["client"], handler._client, "handler must pass its own _client to send_logs_batch_best_effort"
+        )
+        handler.close()
+
+    @patch("metadata.utils.streamable_logger.REST")
+    def test_handler_reuses_one_isolated_client_for_all_batches(self, mock_rest):
+        """Persistent connection pool guarantee: construct one isolated REST
+        client per handler, pass that same client for every batch, and close
+        it only when the sender exits."""
+        client = Mock()
+        mock_rest.return_value = client
+
+        metadata = Mock(spec=OpenMetadata)
+        metadata.client = Mock()
+        metadata.client.config = Mock()
+        metadata.send_logs_batch_best_effort = Mock(return_value=True)
+        metadata.send_close_best_effort = Mock(return_value=True)
+
+        handler = _make_handler(metadata=metadata, enable_streaming=True)
+
+        handler._post_batch(["first"])
+        handler._post_batch(["second"])
+
+        mock_rest.assert_called_once_with(metadata.client.config)
+        self.assertEqual(metadata.send_logs_batch_best_effort.call_count, 2)
+        first_call, second_call = metadata.send_logs_batch_best_effort.call_args_list
+        self.assertIs(first_call.kwargs["client"], client)
+        self.assertIs(second_call.kwargs["client"], client)
+        client.close.assert_not_called()
 
         handler.close()
 
-    def test_fallback_when_streaming_disabled(self):
-        """Test that logs fallback to local when streaming is disabled"""
-        handler = StreamableLogHandler(
-            metadata=self.mock_metadata,
-            pipeline_fqn=self.pipeline_fqn,
-            run_id=self.run_id,
-            enable_streaming=False,
-        )
-
-        # Mock the fallback handler
-        handler.fallback_handler = Mock()
-
-        # Create a log record
-        record = logging.LogRecord(
-            name="test",
-            level=logging.INFO,
-            pathname="test.py",
-            lineno=1,
-            msg="Test message",
-            args=(),
-            exc_info=None,
-        )
-
-        handler.emit(record)
-
-        # Should have called fallback handler
-        handler.fallback_handler.emit.assert_called_once_with(record)
+    def test_isolated_client_is_closed_by_sender_thread(self):
+        metadata = _make_metadata_mock()
+        handler = _make_handler(metadata=metadata, enable_streaming=True)
+        handler._client.close = Mock()
 
         handler.close()
+        for _ in range(50):
+            if handler._client.close.called:
+                break
+            time.sleep(0.05)
 
-    def test_log_compression(self):
-        """Test log compression for large payloads"""
-        handler = StreamableLogHandler(
-            metadata=self.mock_metadata,
-            pipeline_fqn=self.pipeline_fqn,
-            run_id=self.run_id,
-            enable_streaming=False,  # We'll test _send_logs_to_server directly
+        handler._client.close.assert_called()
+
+
+class TestNoWaitClose(unittest.TestCase):
+    """close() must return effectively instantly. It must NOT join the
+    drainer / senders and must NOT wait on the server /close response."""
+
+    def test_close_returns_in_under_100ms_when_idle(self):
+        handler = _make_handler(enable_streaming=True)
+
+        start = time.monotonic()
+        handler.close()
+        elapsed = time.monotonic() - start
+
+        self.assertLess(
+            elapsed,
+            0.1,
+            f"close() took {elapsed * 1000:.1f}ms - must not block",
         )
 
-        # Large log content (> 10KB to trigger compression)
-        large_log = "x" * 11000
+    def test_close_returns_quickly_when_close_endpoint_hangs(self):
+        hang = threading.Event()
 
-        # Mock send_logs_batch to capture the call
-        with patch.object(self.mock_metadata, "send_logs_batch") as mock_send_logs:
-            mock_send_logs.return_value = {"logs_sent": 1, "bytes_sent": len(large_log)}
+        def block_forever(*_, **__):
+            hang.wait(timeout=30)
+            return True
 
-            with patch.dict(os.environ, {"ENABLE_LOG_COMPRESSION": "true"}):
-                handler._send_logs_to_server(large_log)
+        metadata = _make_metadata_mock()
+        metadata.send_logs_batch_best_effort = Mock(return_value=True)
+        metadata.send_close_best_effort = Mock(side_effect=block_forever)
 
-            # Verify send_logs_batch was called with compression enabled
-            mock_send_logs.assert_called_once_with(
-                pipeline_fqn=self.pipeline_fqn,
-                run_id=self.run_id,
-                log_content=large_log,
-                enable_compression=True,
-            )
+        handler = _make_handler(metadata=metadata, enable_streaming=True)
 
+        start = time.monotonic()
+        handler.close()
+        elapsed = time.monotonic() - start
+
+        self.assertLess(
+            elapsed,
+            0.1,
+            f"close() took {elapsed * 1000:.1f}ms - must not wait on /close response",
+        )
+        hang.set()
+
+    def test_close_signals_stop(self):
+        handler = _make_handler(enable_streaming=True)
+        handler.close()
+        self.assertTrue(handler._stop.is_set())
+
+    def test_close_is_idempotent(self):
+        handler = _make_handler(enable_streaming=True)
+        handler.close()
+        handler.close()  # must not raise
+
+
+class TestQuietClientPath(unittest.TestCase):
+    """The handler uses the best-effort path that bypasses retries and logging."""
+
+    def test_post_uses_best_effort_method(self):
+        metadata = _make_metadata_mock()
+        metadata.send_logs_batch_best_effort = Mock(return_value=True)
+        metadata.send_close_best_effort = Mock(return_value=True)
+
+        handler = _make_handler(metadata=metadata, enable_streaming=True)
+        handler.emit(_make_record("trigger"))
+        for _ in range(50):
+            if metadata.send_logs_batch_best_effort.called:
+                break
+            time.sleep(0.05)
+
+        self.assertTrue(metadata.send_logs_batch_best_effort.called)
+        kwargs = metadata.send_logs_batch_best_effort.call_args.kwargs
+        self.assertEqual(kwargs["timeout"], StreamableLogHandler.HTTP_TIMEOUT)
         handler.close()
 
-    def test_no_compression_for_small_logs(self):
-        """Test that small logs are not compressed"""
-        handler = StreamableLogHandler(
-            metadata=self.mock_metadata,
-            pipeline_fqn=self.pipeline_fqn,
-            run_id=self.run_id,
-            enable_streaming=False,
-        )
 
-        # Small log content (< 1KB)
-        small_log = "Small log message"
-
-        # Mock send_logs_batch to capture the call
-        with patch.object(self.mock_metadata, "send_logs_batch") as mock_send_logs:
-            mock_send_logs.return_value = {"logs_sent": 1, "bytes_sent": len(small_log)}
-
-            with patch.dict(os.environ, {"ENABLE_LOG_COMPRESSION": "true"}):
-                handler._send_logs_to_server(small_log)
-
-            # Verify send_logs_batch was called with compression enabled
-            # Note: The actual compression decision is made inside send_logs_batch
-            mock_send_logs.assert_called_once_with(
-                pipeline_fqn=self.pipeline_fqn,
-                run_id=self.run_id,
-                log_content=small_log,
-                enable_compression=True,
-            )
-
-        handler.close()
-
-    def test_session_maintains_cookies(self):
-        """Test that session maintains cookies for ALB stickiness"""
-        handler = StreamableLogHandler(
-            metadata=self.mock_metadata,
-            pipeline_fqn=self.pipeline_fqn,
-            run_id=self.run_id,
-            enable_streaming=False,
-        )
-
-        # Mock send_logs_batch to capture the calls
-        with patch.object(self.mock_metadata, "send_logs_batch") as mock_send_logs:
-            mock_send_logs.return_value = {"logs_sent": 1, "bytes_sent": 100}
-
-            # Send multiple log batches
-            handler._send_logs_to_server("Log batch 1")
-            handler._send_logs_to_server("Log batch 2")
-
-            # Two requests should be made with the same metadata instance
-            self.assertEqual(mock_send_logs.call_count, 2)
-            # Verify both calls used the same metadata instance
-            calls = mock_send_logs.call_args_list
-            for call in calls:
-                self.assertEqual(call.kwargs["pipeline_fqn"], self.pipeline_fqn)
-                self.assertEqual(call.kwargs["run_id"], self.run_id)
-
-        handler.close()
-
-    def test_circuit_breaker_on_failures(self):
-        """Test circuit breaker behavior on repeated failures"""
-        handler = StreamableLogHandler(
-            metadata=self.mock_metadata,
-            pipeline_fqn=self.pipeline_fqn,
-            run_id=self.run_id,
-            enable_streaming=False,
-        )
-
-        # Mock _send_logs_to_server to always fail
-        handler._send_logs_to_server = Mock(side_effect=Exception("Network error"))
-
-        logs = ["log1", "log2", "log3"]
-
-        # First few failures should attempt to send
-        for _ in range(5):
-            handler._ship_logs(logs)
-
-        # Circuit should be open now
-        self.assertEqual(handler.circuit_breaker.state, CircuitState.OPEN)
-
-        handler.close()
-
-    def test_queue_overflow_fallback(self):
-        """Test fallback behavior when queue is full"""
-        handler = StreamableLogHandler(
-            metadata=self.mock_metadata,
-            pipeline_fqn=self.pipeline_fqn,
-            run_id=self.run_id,
-            max_queue_size=1,
-            enable_streaming=True,
-        )
-
-        # Fill the queue
-        handler.log_queue.put("existing_log")
-
-        # Mock the fallback handler
-        handler.fallback_handler = Mock()
-
-        # Try to emit when queue is full
-        record = logging.LogRecord(
-            name="test",
-            level=logging.INFO,
-            pathname="test.py",
-            lineno=1,
-            msg="Overflow message",
-            args=(),
-            exc_info=None,
-        )
-
-        handler.emit(record)
-
-        # Should have called fallback handler
-        handler.fallback_handler.emit.assert_called_once_with(record)
-
-        handler.close()
-
-    @patch("metadata.utils.streamable_logger.threading.Thread")
-    def test_worker_thread_lifecycle(self, mock_thread_class):
-        """Test worker thread start and stop"""
-        mock_thread = Mock()
-        mock_thread.is_alive.return_value = False
-        mock_thread_class.return_value = mock_thread
-
-        handler = StreamableLogHandler(
-            metadata=self.mock_metadata,
-            pipeline_fqn=self.pipeline_fqn,
-            run_id=self.run_id,
-            enable_streaming=True,
-        )
-
-        # Worker thread should be started
-        mock_thread.start.assert_called_once()
-
-        # Close handler
-        handler.close()
-
-        # Stop event should be set
-        self.assertTrue(handler.stop_event.is_set())
-
-    def test_auth_header_included(self):
-        """Test that auth header is included when available"""
-        handler = StreamableLogHandler(
-            metadata=self.mock_metadata,
-            pipeline_fqn=self.pipeline_fqn,
-            run_id=self.run_id,
-            enable_streaming=False,
-        )
-
-        # Mock the send_logs_batch method to verify it's called with correct parameters
-        with patch.object(self.mock_metadata, "send_logs_batch") as mock_send_logs:
-            mock_send_logs.return_value = {"logs_sent": 1, "bytes_sent": 100}
-
-            handler._send_logs_to_server("Test log")
-
-            # Verify send_logs_batch was called with the correct parameters
-            mock_send_logs.assert_called_once_with(
-                pipeline_fqn=self.pipeline_fqn,
-                run_id=self.run_id,
-                log_content="Test log",
-                enable_compression=False,
-            )
-
-        handler.close()
-
-    def test_drain_queue_to_buffer_empty_queue(self):
-        """Test _drain_queue_to_buffer with empty queue"""
-        handler = StreamableLogHandler(
-            metadata=self.mock_metadata,
-            pipeline_fqn=self.pipeline_fqn,
-            run_id=self.run_id,
-            enable_streaming=False,
-        )
-
-        buffer = []
-        result_buffer, flush_requested = handler._drain_queue_to_buffer(buffer)
-
-        # Buffer should be unchanged and no flush requested
-        self.assertEqual(result_buffer, [])
-        self.assertFalse(flush_requested)
-
-        handler.close()
-
-    def test_drain_queue_to_buffer_with_logs(self):
-        """Test _drain_queue_to_buffer with regular log entries"""
-        handler = StreamableLogHandler(
-            metadata=self.mock_metadata,
-            pipeline_fqn=self.pipeline_fqn,
-            run_id=self.run_id,
-            enable_streaming=False,
-        )
-
-        # Add some log entries to queue
-        handler.log_queue.put("log entry 1")
-        handler.log_queue.put("log entry 2")
-        handler.log_queue.put("log entry 3")
-
-        buffer = ["existing log"]
-        result_buffer, flush_requested = handler._drain_queue_to_buffer(buffer)
-
-        # Buffer should contain all logs
-        expected_buffer = ["existing log", "log entry 1", "log entry 2", "log entry 3"]
-        self.assertEqual(result_buffer, expected_buffer)
-        self.assertFalse(flush_requested)
-
-        handler.close()
-
-    def test_drain_queue_to_buffer_with_flush_marker(self):
-        """Test _drain_queue_to_buffer handles flush markers correctly"""
-        handler = StreamableLogHandler(
-            metadata=self.mock_metadata,
-            pipeline_fqn=self.pipeline_fqn,
-            run_id=self.run_id,
-            enable_streaming=False,
-        )
-
-        # Add log entries and a flush marker
-        handler.log_queue.put("log entry 1")
-        handler.log_queue.put(None)  # Flush marker
-        handler.log_queue.put("log entry 2")
-
-        buffer = []
-        result_buffer, flush_requested = handler._drain_queue_to_buffer(buffer)
-
-        # Buffer should contain only log entries, not the flush marker
-        expected_buffer = ["log entry 1", "log entry 2"]
-        self.assertEqual(result_buffer, expected_buffer)
-        self.assertTrue(flush_requested)
-
-        handler.close()
-
-    def test_drain_queue_to_buffer_multiple_flush_markers(self):
-        """Test _drain_queue_to_buffer with multiple flush markers"""
-        handler = StreamableLogHandler(
-            metadata=self.mock_metadata,
-            pipeline_fqn=self.pipeline_fqn,
-            run_id=self.run_id,
-            enable_streaming=False,
-        )
-
-        # Add multiple flush markers
-        handler.log_queue.put("log entry 1")
-        handler.log_queue.put(None)  # First flush marker
-        handler.log_queue.put("log entry 2")
-        handler.log_queue.put(None)  # Second flush marker
-        handler.log_queue.put("log entry 3")
-
-        buffer = []
-        result_buffer, flush_requested = handler._drain_queue_to_buffer(buffer)
-
-        # Buffer should contain all log entries
-        expected_buffer = ["log entry 1", "log entry 2", "log entry 3"]
-        self.assertEqual(result_buffer, expected_buffer)
-        self.assertTrue(flush_requested)
-
-        handler.close()
-
-    @patch("time.time")
-    def test_worker_loop_flush_logic(self, mock_time):
-        """Test worker loop flush decision logic"""
-        # Set up consistent time for testing
-        mock_time.return_value = 1000.0
-
-        handler = StreamableLogHandler(
-            metadata=self.mock_metadata,
-            pipeline_fqn=self.pipeline_fqn,
-            run_id=self.run_id,
-            enable_streaming=False,
-            batch_size=3,
-            flush_interval_sec=5.0,
-        )
-
-        # Mock the shipping method
-        handler._ship_logs = Mock()
-
-        # Test flush due to batch size
-        handler.log_queue.put("log1")
-        handler.log_queue.put("log2")
-        handler.log_queue.put("log3")
-
-        # Simulate one iteration of worker loop logic
-        buffer = []
-        last_flush = mock_time.return_value
-
-        buffer, flush_requested = handler._drain_queue_to_buffer(buffer)
-        should_flush = (
-            flush_requested
-            or len(buffer) >= handler.batch_size
-            or (mock_time.return_value - last_flush) >= handler.flush_interval_sec
-        )
-
-        self.assertTrue(should_flush)  # Should flush due to batch size
-        self.assertEqual(len(buffer), 3)
-
-        handler.close()
-
-    @patch("time.time")
-    def test_worker_loop_time_based_flush(self, mock_time):
-        """Test worker loop time-based flush logic"""
-        handler = StreamableLogHandler(
-            metadata=self.mock_metadata,
-            pipeline_fqn=self.pipeline_fqn,
-            run_id=self.run_id,
-            enable_streaming=False,
-            batch_size=10,
-            flush_interval_sec=5.0,
-        )
-
-        # Add one log (below batch size)
-        handler.log_queue.put("single log")
-
-        # Set up time progression: first call returns 1000.0, subsequent calls return 1006.0
-        mock_time.side_effect = [
-            1000.0,
-            1006.0,
-            1006.0,
-        ]  # Allow for multiple time() calls
-
-        # Simulate worker loop logic with time progression
-        buffer = []
-        last_flush = 1000.0  # Initial time
-
-        buffer, flush_requested = handler._drain_queue_to_buffer(buffer)
-        current_time = 1006.0  # Time after drainage
-
-        should_flush = (
-            flush_requested
-            or len(buffer) >= handler.batch_size
-            or (current_time - last_flush) >= handler.flush_interval_sec
-        )
-
-        self.assertTrue(should_flush)  # Should flush due to time interval (6 > 5)
-        self.assertEqual(len(buffer), 1)
-
-        handler.close()
-
-    def test_flush_marker_triggers_immediate_flush(self):
-        """Test that flush markers trigger immediate flush regardless of batch size or time"""
-        handler = StreamableLogHandler(
-            metadata=self.mock_metadata,
-            pipeline_fqn=self.pipeline_fqn,
-            run_id=self.run_id,
-            enable_streaming=False,
-            batch_size=10,  # Large batch size
-            flush_interval_sec=60.0,  # Long time interval
-        )
-
-        # Add just one log and a flush marker
-        handler.log_queue.put("single log")
-        handler.log_queue.put(None)  # Flush marker
-
-        buffer = []
-        buffer, flush_requested = handler._drain_queue_to_buffer(buffer)
-
-        # Should request flush despite small buffer and short time
-        self.assertTrue(flush_requested)
-        self.assertEqual(len(buffer), 1)
-
-        handler.close()
-
-    def test_worker_loop_final_drainage_on_shutdown(self):
-        """Test that worker loop drains queue completely on shutdown"""
-        handler = StreamableLogHandler(
-            metadata=self.mock_metadata,
-            pipeline_fqn="test.pipeline",
-            run_id=uuid4(),
-            enable_streaming=False,
-        )
-
-        # Mock _ship_logs to track what gets shipped
-        shipped_logs = []
-
-        def mock_ship_logs(logs):
-            shipped_logs.extend(logs)
-
-        handler._ship_logs = mock_ship_logs
-
-        # Add logs to queue after stop event is set (simulating final drainage)
-        handler.log_queue.put("final log 1")
-        handler.log_queue.put("final log 2")
-        handler.log_queue.put(None)  # Flush marker
-        handler.log_queue.put("final log 3")
-
-        # Simulate final cleanup drainage
-        buffer, _ = handler._drain_queue_to_buffer([])
-        if buffer:
-            handler._ship_logs(buffer)
-
-        # All logs should be shipped
-        expected_logs = ["final log 1", "final log 2", "final log 3"]
-        self.assertEqual(shipped_logs, expected_logs)
-
-        handler.close()
-
-    def test_flush_method_adds_marker_to_queue(self):
-        """Test that flush method properly adds None marker to queue"""
-        handler = StreamableLogHandler(
-            metadata=self.mock_metadata,
-            pipeline_fqn="test.pipeline",
-            run_id=uuid4(),
-            enable_streaming=False,
-        )
-
-        # Flush should add None marker
-        handler.flush()
-
-        # Verify marker was added
-        marker = handler.log_queue.get_nowait()
-        self.assertIsNone(marker)
-
-        handler.close()
-
-    def test_close_waits_for_worker_thread(self):
-        """Test that close method properly waits for worker thread"""
-        with patch("threading.Thread") as mock_thread_class:
-            mock_thread = Mock()
-            mock_thread.is_alive.return_value = True
-            mock_thread_class.return_value = mock_thread
-
-            handler = StreamableLogHandler(
-                metadata=self.mock_metadata,
-                pipeline_fqn="test.pipeline",
-                run_id=uuid4(),
-                enable_streaming=True,
-            )
-
-            # Close handler
-            handler.close()
-
-            # Verify stop event was set and thread join was called
-            self.assertTrue(handler.stop_event.is_set())
-            mock_thread.join.assert_called_once_with(timeout=5.0)
+class TestStreamableLogHandlerManager(unittest.TestCase):
+    def tearDown(self):
+        StreamableLogHandlerManager._instance = None
+
+    def test_set_handler_removes_previous_from_metadata_logger(self):
+        """set_handler must detach the old handler from the metadata logger
+        before closing it - otherwise records can still route at it during
+        close, and a closed handler stays attached after."""
+        from metadata.utils.logger import METADATA_LOGGER
+
+        first = _make_handler(enable_streaming=False)
+        second = _make_handler(enable_streaming=False)
+        metadata_logger = logging.getLogger(METADATA_LOGGER)
+        metadata_logger.addHandler(first)
+
+        StreamableLogHandlerManager.set_handler(first)
+        StreamableLogHandlerManager.set_handler(second)
+
+        self.assertNotIn(first, metadata_logger.handlers, "previous handler must be removed before being closed")
+        # Cleanup.
+        metadata_logger.handlers = [h for h in metadata_logger.handlers if not isinstance(h, StreamableLogHandler)]
+
+    def test_cleanup_clears_singleton(self):
+        handler = _make_handler(enable_streaming=False)
+        StreamableLogHandlerManager.set_handler(handler)
+        StreamableLogHandlerManager.cleanup()
+        self.assertIsNone(StreamableLogHandlerManager.get_handler())
 
 
 class TestStreamableLoggingSetup(unittest.TestCase):
-    """Test the setup and cleanup functions"""
-
     def tearDown(self):
-        """Clean up any handlers that were added to loggers during tests"""
-        # Clean up any handlers from the metadata logger
-        import logging
-
         from metadata.utils.logger import METADATA_LOGGER
-        from metadata.utils.streamable_logger import StreamableLogHandlerManager
 
         metadata_logger = logging.getLogger(METADATA_LOGGER)
-        # Remove any mock handlers
         metadata_logger.handlers = [
-            h for h in metadata_logger.handlers if not isinstance(h, Mock)
+            h for h in metadata_logger.handlers if not isinstance(h, (Mock, StreamableLogHandler))
         ]
-
-        # Also clean up the manager
         StreamableLogHandlerManager._instance = None
 
     @patch("logging.getLogger")
     @patch("metadata.utils.streamable_logger.logger")
     @patch("metadata.utils.streamable_logger.StreamableLogHandler")
-    def test_setup_with_valid_config(
-        self, mock_handler_class, mock_logger, mock_get_logger
-    ):
-        """Test setup with valid configuration"""
+    def test_setup_with_valid_config(self, mock_handler_cls, mock_logger, mock_get_logger):
         mock_metadata = Mock(spec=OpenMetadata)
-        mock_metadata.config = Mock()
-        mock_metadata.config.host_port = "http://localhost:8585"
-
         mock_handler = Mock()
-        mock_handler.level = logging.INFO  # Add level attribute
-        mock_handler_class.return_value = mock_handler
-
-        pipeline_fqn = "test.pipeline"
-        run_id = uuid4()
-
-        # Setup mock logger to prevent handler from being added to real logger
+        mock_handler.level = logging.INFO
+        mock_handler_cls.return_value = mock_handler
         mock_metadata_logger = Mock()
         mock_get_logger.return_value = mock_metadata_logger
 
-        # Test with enable_streaming=True (from IngestionPipeline config)
-        result = setup_streamable_logging_for_workflow(
-            metadata=mock_metadata,
-            pipeline_fqn=pipeline_fqn,
-            run_id=run_id,
-            enable_streaming=True,  # This would come from IngestionPipeline.enableStreamableLogs
-        )
-
-        self.assertIsNotNone(result)
-        mock_handler_class.assert_called_once_with(
-            metadata=mock_metadata,
-            pipeline_fqn=pipeline_fqn,
-            run_id=run_id,
-            enable_streaming=True,
-        )
-
-        # Cleanup
-        cleanup_streamable_logging()
-
-    def test_setup_disabled_by_config(self):
-        """Test that setup returns None when disabled by config"""
-        mock_metadata = Mock(spec=OpenMetadata)
-
-        # Test with enable_streaming=False (from IngestionPipeline config)
         result = setup_streamable_logging_for_workflow(
             metadata=mock_metadata,
             pipeline_fqn="test.pipeline",
             run_id=uuid4(),
-            enable_streaming=False,  # This would come from IngestionPipeline.enableStreamableLogs
+            enable_streaming=True,
         )
 
+        self.assertIsNotNone(result)
+        mock_metadata_logger.addHandler.assert_called_once_with(mock_handler)
+        cleanup_streamable_logging()
+
+    def test_setup_returns_none_when_disabled(self):
+        result = setup_streamable_logging_for_workflow(
+            metadata=Mock(spec=OpenMetadata),
+            pipeline_fqn="test.pipeline",
+            run_id=uuid4(),
+            enable_streaming=False,
+        )
         self.assertIsNone(result)
 
-    def test_setup_missing_parameters(self):
-        """Test that setup returns None when parameters are missing"""
-        mock_metadata = Mock(spec=OpenMetadata)
-
-        # Missing pipeline_fqn
+    def test_setup_returns_none_when_pipeline_fqn_missing(self):
         result = setup_streamable_logging_for_workflow(
-            metadata=mock_metadata,
+            metadata=Mock(spec=OpenMetadata),
             pipeline_fqn=None,
             run_id=uuid4(),
             enable_streaming=True,
         )
         self.assertIsNone(result)
 
-        # Missing run_id
+    def test_setup_returns_none_when_run_id_missing(self):
         result = setup_streamable_logging_for_workflow(
-            metadata=mock_metadata,
+            metadata=Mock(spec=OpenMetadata),
             pipeline_fqn="test.pipeline",
             run_id=None,
             enable_streaming=True,
         )
         self.assertIsNone(result)
 
-    @patch("logging.getLogger")
-    @patch("metadata.utils.streamable_logger.logger")
-    @patch("metadata.utils.streamable_logger.StreamableLogHandler")
-    def test_cleanup_removes_handler(
-        self, mock_handler_class, mock_logger, mock_get_logger
-    ):
-        """Test that cleanup properly removes the handler"""
-        mock_metadata = Mock(spec=OpenMetadata)
-        mock_metadata.config = Mock()
-        mock_metadata.config.host_port = "http://localhost:8585"
 
-        mock_handler = Mock()
-        mock_handler.level = logging.INFO  # Add level attribute to prevent TypeError
-        mock_handler_class.return_value = mock_handler
-
-        # Setup mock logger to prevent handler from being added to real logger
-        mock_metadata_logger = Mock()
-        mock_get_logger.return_value = mock_metadata_logger
-
-        # Setup
-        handler = setup_streamable_logging_for_workflow(
-            metadata=mock_metadata,
-            pipeline_fqn="test.pipeline",
-            run_id=uuid4(),
-            enable_streaming=True,
-        )
-
-        # Cleanup
-        cleanup_streamable_logging()
-
-        mock_metadata_logger.removeHandler.assert_called_once_with(mock_handler)
-        mock_handler.close.assert_called_once()
-
-    @patch("logging.getLogger")
-    @patch("metadata.utils.streamable_logger.logger")
-    @patch("metadata.utils.streamable_logger.StreamableLogHandler")
-    def test_setup_replaces_existing_handler(
-        self, mock_handler_class, mock_logger, mock_get_logger
-    ):
-        """Test that setup properly replaces existing handler"""
-        mock_metadata = Mock(spec=OpenMetadata)
-        mock_metadata.config = Mock()
-        mock_metadata.config.host_port = "http://localhost:8585"
-
-        mock_handler1 = Mock()
-        mock_handler1.level = logging.INFO  # Add level attribute
-        mock_handler2 = Mock()
-        mock_handler2.level = logging.INFO  # Add level attribute
-        mock_handler_class.side_effect = [mock_handler1, mock_handler2]
-
-        # Setup mock logger to prevent handler from being added to real logger
-        mock_metadata_logger = Mock()
-        mock_get_logger.return_value = mock_metadata_logger
-
-        # First setup
-        handler1 = setup_streamable_logging_for_workflow(
-            metadata=mock_metadata,
-            pipeline_fqn="test.pipeline1",
-            run_id=uuid4(),
-            enable_streaming=True,
-        )
-
-        # Second setup should close first handler
-        handler2 = setup_streamable_logging_for_workflow(
-            metadata=mock_metadata,
-            pipeline_fqn="test.pipeline2",
-            run_id=uuid4(),
-            enable_streaming=True,
-        )
-
-        # The first handler should be closed when the second one is set
-        mock_handler1.close.assert_called()
-
-        # Cleanup
-        cleanup_streamable_logging()
-
-    @patch("logging.getLogger")
-    @patch("metadata.utils.streamable_logger.logger")
-    @patch("metadata.utils.streamable_logger.StreamableLogHandler")
-    def test_cleanup_flushes_before_closing(
-        self, mock_handler_class, mock_logger, mock_get_logger
-    ):
-        """Test that cleanup calls flush before closing handler"""
-        mock_metadata = Mock(spec=OpenMetadata)
-        mock_metadata.config = Mock()
-        mock_metadata.config.host_port = "http://localhost:8585"
-
-        mock_handler = Mock()
-        mock_handler.level = logging.INFO
-        # Mock the specific methods that should be called
-        mock_handler.flush = Mock()
-        mock_handler.close = Mock()
-        mock_handler_class.return_value = mock_handler
-
-        # Setup mock logger
-        mock_metadata_logger = Mock()
-        mock_get_logger.return_value = mock_metadata_logger
-
-        # Setup handler
-        handler = setup_streamable_logging_for_workflow(
-            metadata=mock_metadata,
-            pipeline_fqn="test.pipeline",
-            run_id=uuid4(),
-            enable_streaming=True,
-        )
-
-        # Verify handler was created and returned
-        self.assertIsNotNone(handler)
-        self.assertEqual(handler, mock_handler)
-
-        # Cleanup and verify order of operations
-        cleanup_streamable_logging()
-
-        # Verify flush was called
-        mock_handler.flush.assert_called_once()
-
-        # Verify close was called
-        mock_handler.close.assert_called_once()
-
-        # Verify handler was removed from logger
-        mock_metadata_logger.removeHandler.assert_called_once_with(mock_handler)
-
-
-class TestStreamableLogHandlerRecursionRegression(unittest.TestCase):
-    """
-    Regression test for the production hang where StreamableLogHandler.emit()
-    called logger.warning() / logger.error() from inside the handler's own
-    dispatch path. Because the handler is attached to that very same logger,
-    every internal log call re-entered emit(), recursing against a still-full
-    queue until the Python recursion limit was hit on MainThread while every
-    other thread was blocked on the logging module's internal lock.
-
-    The fix is to use a dedicated `_internal_logger` with `propagate=False`
-    for any message originating inside this module's hot path. These tests
-    fail if anyone re-introduces a `logger.*` call inside emit / _ship_logs /
-    _worker_loop.
-    """
+class TestRecursionRegression(unittest.TestCase):
+    """emit() must run exactly once per producer call even when overflow
+    or format failure would historically have triggered recursive logging."""
 
     def setUp(self):
-        self.mock_metadata = Mock(spec=OpenMetadata)
-        self.test_logger = logging.getLogger(f"test_streamable_recursion_{id(self)}")
+        self.mock_metadata = _make_metadata_mock()
+        self.test_logger = logging.getLogger(f"test_recursion_{id(self)}")
         self.test_logger.handlers = []
         self.test_logger.setLevel(logging.DEBUG)
         self.test_logger.propagate = False
@@ -884,104 +620,200 @@ class TestStreamableLogHandlerRecursionRegression(unittest.TestCase):
     def tearDown(self):
         self.test_logger.handlers = []
 
-    def _make_handler(self, max_queue_size=2):
-        handler = StreamableLogHandler(
+    def _make_handler_with_full_buffer(self):
+        handler = _make_handler(
             metadata=self.mock_metadata,
-            pipeline_fqn="test.pipeline",
-            run_id=uuid4(),
-            max_queue_size=max_queue_size,
+            max_buffer=2,
             enable_streaming=True,
         )
-        # Stop the background worker so the queue cannot drain during the test.
-        handler.stop_event.set()
-        if handler.worker_thread:
-            handler.worker_thread.join(timeout=2.0)
-        # Make the local fallback a Mock so we can assert it was called once.
-        handler.fallback_handler = Mock()
+        _stop_workers(handler)
+        handler._buffer.put_nowait("a")
+        handler._buffer.put_nowait("b")
+        self.assertTrue(handler._buffer.full())
         return handler
 
-    def test_emit_does_not_recurse_when_queue_full(self):
-        """
-        emit() must complete in a single call when the queue is full.
-        Before the fix this exploded into ~1000 recursive emit() calls.
-        """
-        handler = self._make_handler(max_queue_size=2)
-        handler.log_queue.put_nowait("entry-1")
-        handler.log_queue.put_nowait("entry-2")
-        self.assertTrue(handler.log_queue.full())
-
+    def test_emit_does_not_recurse_when_buffer_full(self):
+        handler = self._make_handler_with_full_buffer()
         self.test_logger.addHandler(handler)
 
-        call_count = {"n": 0}
+        emit_calls = {"n": 0}
         real_emit = handler.emit
 
-        def counting_emit(record):
-            call_count["n"] += 1
-            if call_count["n"] > 5:
-                raise AssertionError(
-                    "emit() recursed — regression of the streamable_logger hang. "
-                    "Check that nothing inside emit / _ship_logs / _worker_loop "
-                    "calls the module-level `logger`; use `_internal_logger` instead."
-                )
+        def counting(record):
+            emit_calls["n"] += 1
+            if emit_calls["n"] > 5:
+                raise AssertionError("emit() recursed — single-call regression")
             real_emit(record)
 
-        handler.emit = counting_emit
-
+        handler.emit = counting
         start = time.monotonic()
-        # Before the fix this call would never return — MainThread would sit
-        # recursing until Python raised RecursionError, then the outer except
-        # would log.error() which would recurse again.
-        self.test_logger.warning("trigger the overflow path")
+        self.test_logger.warning("trigger overflow")
         elapsed = time.monotonic() - start
 
-        self.assertEqual(call_count["n"], 1, "emit() must be invoked exactly once per log call")
-        self.assertLess(elapsed, 1.0, "emit() must return in bounded time when queue is full")
-        handler.fallback_handler.emit.assert_called_once()
-
-    def test_emit_does_not_recurse_when_format_raises(self):
-        """
-        If self.format(record) raises, the outer except in emit() must NOT
-        route the error back through `logger` (which would recurse).
-        """
-        handler = self._make_handler(max_queue_size=10)
-        handler.format = Mock(side_effect=ValueError("boom"))
-
-        self.test_logger.addHandler(handler)
-
-        call_count = {"n": 0}
-        real_emit = handler.emit
-
-        def counting_emit(record):
-            call_count["n"] += 1
-            if call_count["n"] > 5:
-                raise AssertionError("emit() recursed via the outer except branch — regression.")
-            real_emit(record)
-
-        handler.emit = counting_emit
-
-        start = time.monotonic()
-        self.test_logger.error("trigger the format-failure path")
-        elapsed = time.monotonic() - start
-
-        self.assertEqual(call_count["n"], 1)
+        self.assertEqual(emit_calls["n"], 1)
         self.assertLess(elapsed, 1.0)
 
-    def test_internal_logger_is_isolated_from_root(self):
-        """
-        The `_internal_logger` must not propagate, otherwise its messages
-        would still reach the root logger (and therefore re-enter this
-        handler if it is attached there).
-        """
-        from metadata.utils.streamable_logger import _internal_logger
+    def test_emit_does_not_recurse_when_format_raises(self):
+        handler = _make_handler(metadata=self.mock_metadata, enable_streaming=True)
+        _stop_workers(handler)
+        handler.format = MagicMock(side_effect=ValueError("boom"))
 
-        self.assertFalse(
-            _internal_logger.propagate,
-            "_internal_logger.propagate must be False to prevent recursion",
+        self.test_logger.addHandler(handler)
+        emit_calls = {"n": 0}
+        real_emit = handler.emit
+
+        def counting(record):
+            emit_calls["n"] += 1
+            if emit_calls["n"] > 5:
+                raise AssertionError("emit() recursed via format-failure path")
+            real_emit(record)
+
+        handler.emit = counting
+        start = time.monotonic()
+        self.test_logger.error("trigger format failure")
+        elapsed = time.monotonic() - start
+
+        self.assertEqual(emit_calls["n"], 1)
+        self.assertLess(elapsed, 1.0)
+
+
+class TestQuietClientPostMixin(unittest.TestCase):
+    """The mixin's best-effort methods must NOT log through ometa_logger
+    (which would propagate back to the streamable handler)."""
+
+    def test_send_logs_batch_best_effort_does_not_log_on_failure(self):
+        from metadata.ingestion.ometa.mixins.logs_mixin import OMetaLogsMixin
+
+        # Build a bare instance and stub the client.
+        instance = OMetaLogsMixin()
+        instance.client = Mock()
+        instance.client.post_best_effort = Mock(return_value=False)
+
+        with patch("metadata.ingestion.ometa.mixins.logs_mixin.logger") as mock_logger:
+            ok = instance.send_logs_batch_best_effort(
+                pipeline_fqn="test",
+                run_id=uuid4(),
+                log_content="x",
+                timeout=(1, 2),
+            )
+
+        self.assertFalse(ok)
+        mock_logger.error.assert_not_called()
+        mock_logger.warning.assert_not_called()
+        mock_logger.info.assert_not_called()
+        mock_logger.debug.assert_not_called()
+
+    def test_send_logs_batch_best_effort_does_not_log_on_exception(self):
+        from metadata.ingestion.ometa.mixins.logs_mixin import OMetaLogsMixin
+
+        instance = OMetaLogsMixin()
+        instance.client = Mock()
+        instance.client.post_best_effort = Mock(side_effect=RuntimeError("boom"))
+
+        with patch("metadata.ingestion.ometa.mixins.logs_mixin.logger") as mock_logger:
+            ok = instance.send_logs_batch_best_effort(
+                pipeline_fqn="test",
+                run_id=uuid4(),
+                log_content="x",
+                timeout=(1, 2),
+            )
+
+        self.assertFalse(ok)
+        mock_logger.error.assert_not_called()
+        mock_logger.warning.assert_not_called()
+
+
+class TestClientPostBestEffort(unittest.TestCase):
+    """REST.post_best_effort must NOT enter the retry/sleep loop and
+    must NOT log on failure."""
+
+    def _make_client(self):
+        from metadata.ingestion.ometa.client import REST, ClientConfig
+
+        config = ClientConfig(
+            base_url="http://localhost:8585",
+            api_version="v1",
+            auth_token=lambda: ("token", 60),
         )
-        self.assertTrue(
-            _internal_logger.handlers,
-            "_internal_logger must have its own handler so messages still reach stderr",
-        )
+        client = REST(config)
+        client._session = Mock()
+        return client
+
+    def test_post_best_effort_does_not_sleep_on_504(self):
+        client = self._make_client()
+        resp = Mock()
+        resp.status_code = 504
+        client._session.post = Mock(return_value=resp)
+
+        with patch("time.sleep") as mock_sleep:
+            start = time.monotonic()
+            ok = client.post_best_effort("/path", data="x", timeout=(1, 2))
+            elapsed = time.monotonic() - start
+
+        self.assertFalse(ok)
+        mock_sleep.assert_not_called()
+        self.assertLess(elapsed, 0.2, "post_best_effort must NOT sleep on 504")
+
+    def test_post_best_effort_does_not_log_on_failure(self):
+        client = self._make_client()
+        client._session.post = Mock(side_effect=RuntimeError("network down"))
+
+        with patch("metadata.ingestion.ometa.client.logger") as mock_logger:
+            ok = client.post_best_effort("/path", data="x", timeout=(1, 2))
+
+        self.assertFalse(ok)
+        mock_logger.error.assert_not_called()
+        mock_logger.warning.assert_not_called()
+        mock_logger.info.assert_not_called()
+
+    def test_post_best_effort_returns_true_on_2xx(self):
+        client = self._make_client()
+        resp = Mock()
+        resp.status_code = 200
+        client._session.post = Mock(return_value=resp)
+
+        self.assertTrue(client.post_best_effort("/path", data="x"))
+
+    def test_build_request_headers_does_not_refresh_token(self):
+        """Token refresh stays on _request(); concurrent refresh from the
+        sender would race the main thread on shared ClientConfig."""
+        client = self._make_client()
+        client._auth_token = Mock(return_value=("fresh-token", 60))
+        client.config.expires_in = 0
+        client.config.access_token = "stale-token"
+        client.config.auth_header = "Authorization"
+
+        headers = client._build_request_headers()
+
+        client._auth_token.assert_not_called()
+        self.assertEqual(headers["Authorization"], "Bearer stale-token")
+        self.assertEqual(client.config.expires_in, 0)
+
+
+class TestCloseOrderingRegression(unittest.TestCase):
+    """close() must enqueue CLOSE_MARKER before setting _stop, otherwise
+    the sender's get(timeout) Empty branch can race the enqueue."""
+
+    def test_close_enqueues_marker_before_setting_stop(self):
+        metadata = _make_metadata_mock()
+        handler = _make_handler(metadata=metadata, enable_streaming=True)
+        handler.close()
+        for _ in range(50):
+            if metadata.send_close_best_effort.called:
+                break
+            time.sleep(0.05)
+        metadata.send_close_best_effort.assert_called_once()
+
+    def test_close_marker_arrives_even_when_sender_was_idle(self):
+        metadata = _make_metadata_mock()
+        handler = _make_handler(metadata=metadata, enable_streaming=True)
+        time.sleep(0.2)  # let sender enter get(timeout=...)
+        handler.close()
+        for _ in range(50):
+            if metadata.send_close_best_effort.called:
+                break
+            time.sleep(0.05)
+        metadata.send_close_best_effort.assert_called_once()
 
 
 if __name__ == "__main__":

--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/IngestionPipelineLogStreamingResourceIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/IngestionPipelineLogStreamingResourceIT.java
@@ -310,6 +310,40 @@ public class IngestionPipelineLogStreamingResourceIT {
   }
 
   @Test
+  @Order(115)
+  void testLateLogsAfterCloseDoNotClobberFinalLogs(TestNamespace ns) throws OpenMetadataException {
+    IngestionPipeline pipeline = createTestPipeline(ns);
+    UUID runId = UUID.randomUUID();
+    String pipelineFQN = pipeline.getFullyQualifiedName();
+    String beforeClose = "before-close-marker-" + runId;
+    String afterClose = "after-close-marker-" + runId;
+
+    postLogs(pipelineFQN, runId, beforeClose + "\n");
+    postClose(pipelineFQN, runId);
+    postLogs(pipelineFQN, runId, afterClose + "\n");
+    postClose(pipelineFQN, runId);
+
+    String body = getLogs(pipelineFQN, runId);
+    if (body == null || body.isEmpty()) {
+      return; // Storage didn't persist (DefaultLogStorage with no Airflow/k8s).
+    }
+    Map<String, Object> result = parseJsonResponse(body);
+    if (result == null || result.get("logs") == null) {
+      return;
+    }
+    String logs = String.valueOf(result.get("logs"));
+    Object total = result.get("total");
+    boolean storageHasContent =
+        total != null && !"0".equals(String.valueOf(total)) && !logs.isEmpty();
+    if (!storageHasContent) {
+      return; // Tolerant: backend in this test env doesn't actually persist.
+    }
+    assertTrue(
+        logs.contains(beforeClose),
+        "Late post-close logs must not clobber finalized logs.txt, got: " + logs);
+  }
+
+  @Test
   @Order(120)
   void testCloseIsIdempotent(TestNamespace ns) throws OpenMetadataException {
     IngestionPipeline pipeline = createTestPipeline(ns);

--- a/openmetadata-service/src/main/java/org/openmetadata/service/logstorage/S3LogStorage.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/logstorage/S3LogStorage.java
@@ -26,6 +26,7 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -38,6 +39,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
@@ -53,6 +55,7 @@ import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.core.ResponseInputStream;
 import software.amazon.awssdk.core.async.AsyncRequestBody;
+import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3AsyncClient;
 import software.amazon.awssdk.services.s3.S3AsyncClientBuilder;
@@ -85,6 +88,7 @@ import software.amazon.awssdk.services.s3.model.NoSuchKeyException;
 import software.amazon.awssdk.services.s3.model.ObjectIdentifier;
 import software.amazon.awssdk.services.s3.model.PutBucketLifecycleConfigurationRequest;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.model.S3Exception;
 import software.amazon.awssdk.services.s3.model.S3Object;
 import software.amazon.awssdk.services.s3.model.ServerSideEncryption;
 import software.amazon.awssdk.services.s3.model.StorageClass;
@@ -114,6 +118,8 @@ public class S3LogStorage implements LogStorageInterface {
   private static final int DEFAULT_EXPIRATION_DAYS = 30;
   private static final long MIN_MPU_PART_BYTES = 5L * 1024 * 1024;
   private static final int LOCK_STRIPE_COUNT = 256;
+  private static final Duration S3_API_CALL_TIMEOUT = Duration.ofSeconds(30);
+  private static final Duration S3_API_CALL_ATTEMPT_TIMEOUT = Duration.ofSeconds(10);
 
   private S3Client s3Client;
   private S3AsyncClient s3AsyncClient;
@@ -140,17 +146,17 @@ public class S3LogStorage implements LogStorageInterface {
   private final Map<String, StreamContext> activeStreams = new ConcurrentHashMap<>();
   // Per-stream coordination via a fixed-stripe lock keyed on `<fqn>/<runId>`. The stripe
   // count caps memory at LOCK_STRIPE_COUNT regardless of completed-run accumulation, and
-  // the same key always maps to the same lock instance — so we never need a remove path
+  // the same key always maps to the same lock instance - so we never need a remove path
   // (which would race acquire vs. remove and break mutual exclusion). False-contention
   // across stripes is bounded by max-concurrent-streams << stripe count.
   private final Striped<Lock> streamLocks = Striped.lock(LOCK_STRIPE_COUNT);
 
   // Lines accumulated since the last successful partial.txt PUT, per stream. Drained by the
-  // periodic / watermark-driven flush. Values are plain ArrayList — NOT independently
+  // periodic / watermark-driven flush. Values are plain ArrayList - NOT independently
   // thread-safe. MUST be accessed only while holding the corresponding per-stream lock.
   private final Map<String, List<String>> pendingFlush = new ConcurrentHashMap<>();
 
-  // Bytes pending in pendingFlush, per stream — drives the early-flush watermark. Entries are
+  // Bytes pending in pendingFlush, per stream - drives the early-flush watermark. Entries are
   // removed when the stream is finalized.
   private final Map<String, AtomicLong> pendingFlushBytes = new ConcurrentHashMap<>();
 
@@ -162,8 +168,12 @@ public class S3LogStorage implements LogStorageInterface {
   // Per-stream consecutive flush failure count for alerting. Incremented on each failed PUT and
   // reset on success. Entries are removed when the stream is finalized.
   private final Map<String, AtomicInteger> consecutiveFlushFailures = new ConcurrentHashMap<>();
+  private final Set<String> scheduledPartialFlushes = ConcurrentHashMap.newKeySet();
+  private Cache<String, Boolean> closedStreams;
 
-  private ScheduledExecutorService cleanupExecutor;
+  // Split so a stuck cleanup task cannot starve partial flush.
+  private ScheduledExecutorService partialFlushExecutor;
+  private ScheduledExecutorService abandonedCleanupExecutor;
 
   private final Cache<String, SimpleLogBuffer> recentLogsCache =
       Caffeine.newBuilder().maximumSize(200).expireAfterAccess(30, TimeUnit.MINUTES).build();
@@ -234,8 +244,16 @@ public class S3LogStorage implements LogStorageInterface {
               ? s3Config.getPendingFlushAlertAfterFailures()
               : DEFAULT_PENDING_FLUSH_ALERT_AFTER_FAILURES;
 
+      this.closedStreams =
+          Caffeine.newBuilder()
+              .maximumSize(10000)
+              .expireAfterWrite(Math.max(1, streamTimeoutMinutes), TimeUnit.MINUTES)
+              .build();
+
       S3ClientBuilder s3Builder =
-          S3Client.builder().region(Region.of(s3Config.getAwsConfig().getAwsRegion()));
+          S3Client.builder()
+              .region(Region.of(s3Config.getAwsConfig().getAwsRegion()))
+              .overrideConfiguration(s3ClientOverrideConfiguration());
 
       URI customEndpoint = s3Config.getAwsConfig().getEndPointURL();
       if (!nullOrEmpty(customEndpoint)) {
@@ -257,7 +275,8 @@ public class S3LogStorage implements LogStorageInterface {
       S3AsyncClientBuilder asyncBuilder =
           S3AsyncClient.builder()
               .region(Region.of(s3Config.getAwsConfig().getAwsRegion()))
-              .credentialsProvider(credentialsProvider);
+              .credentialsProvider(credentialsProvider)
+              .overrideConfiguration(s3ClientOverrideConfiguration());
 
       if (!nullOrEmpty(customEndpoint)) {
         asyncBuilder.endpointOverride(java.net.URI.create(customEndpoint.toString()));
@@ -275,23 +294,20 @@ public class S3LogStorage implements LogStorageInterface {
             "Error accessing S3 bucket: " + bucketName + ". Validate AWS configuration.", e);
       }
 
-      this.cleanupExecutor =
+      this.partialFlushExecutor =
+          Executors.newSingleThreadScheduledExecutor(namedDaemonFactory("s3-log-partial-flush"));
+      this.abandonedCleanupExecutor =
           Executors.newSingleThreadScheduledExecutor(
-              r -> {
-                Thread thread = new Thread(r);
-                thread.setName("s3-log-cleanup");
-                thread.setDaemon(true);
-                return thread;
-              });
+              namedDaemonFactory("s3-log-abandoned-cleanup"));
 
-      cleanupExecutor.scheduleWithFixedDelay(
-          this::cleanupAbandonedStreams,
+      abandonedCleanupExecutor.scheduleWithFixedDelay(
+          safeScheduledTask("cleanupAbandonedStreams", this::cleanupAbandonedStreams),
           cleanupIntervalMinutes,
           cleanupIntervalMinutes,
           TimeUnit.MINUTES);
 
-      cleanupExecutor.scheduleWithFixedDelay(
-          this::writePartialLogs,
+      partialFlushExecutor.scheduleWithFixedDelay(
+          safeScheduledTask("writePartialLogs", this::writePartialLogs),
           partialFlushIntervalMinutes,
           partialFlushIntervalMinutes,
           TimeUnit.MINUTES);
@@ -339,6 +355,23 @@ public class S3LogStorage implements LogStorageInterface {
     }
   }
 
+  private ClientOverrideConfiguration s3ClientOverrideConfiguration() {
+    return ClientOverrideConfiguration.builder()
+        .apiCallTimeout(S3_API_CALL_TIMEOUT)
+        .apiCallAttemptTimeout(S3_API_CALL_ATTEMPT_TIMEOUT)
+        .build();
+  }
+
+  private boolean isStreamClosed(String streamKey) {
+    return closedStreams != null && closedStreams.getIfPresent(streamKey) != null;
+  }
+
+  private void markStreamClosed(String streamKey) {
+    if (closedStreams != null) {
+      closedStreams.put(streamKey, Boolean.TRUE);
+    }
+  }
+
   @Override
   public void appendLogs(String pipelineFQN, UUID runId, String logContent) throws IOException {
     if (nullOrEmpty(logContent)) {
@@ -354,11 +387,16 @@ public class S3LogStorage implements LogStorageInterface {
     String streamKey = pipelineFQN + "/" + runId;
     Lock lock = acquireStreamLock(streamKey);
     try {
+      if (isStreamClosed(streamKey)) {
+        LOG.debug("Dropping late logs for already closed stream {}", streamKey);
+        return;
+      }
+
       // Update memory cache for real-time log viewing
       SimpleLogBuffer recentLogs = recentLogsCache.get(streamKey, k -> new SimpleLogBuffer(1000));
       recentLogs.append(logContent);
 
-      // Track the run as live (no multipart upload here — bytes flow through pendingFlush ->
+      // Track the run as live (no multipart upload here - bytes flow through pendingFlush ->
       // partial.txt).
       StreamContext ctx =
           activeStreams.computeIfAbsent(
@@ -382,9 +420,18 @@ public class S3LogStorage implements LogStorageInterface {
         }
         bytes.addAndGet(addedBytes);
         counter.addAndGet(lineCount);
-        if (bytes.get() >= earlyFlushWatermarkBytes) {
+        if (bytes.get() >= earlyFlushWatermarkBytes && scheduledPartialFlushes.add(streamKey)) {
           final String key = streamKey;
-          cleanupExecutor.execute(() -> writePartialLogsForStream(key));
+          partialFlushExecutor.execute(
+              safeScheduledTask(
+                  "writePartialLogsForStream",
+                  () -> {
+                    try {
+                      writePartialLogsForStream(key);
+                    } finally {
+                      scheduledPartialFlushes.remove(key);
+                    }
+                  }));
         }
       }
 
@@ -678,6 +725,9 @@ public class S3LogStorage implements LogStorageInterface {
     Lock lock = acquireStreamLock(streamKey);
     try {
       dropStreamState(streamKey);
+      if (closedStreams != null) {
+        closedStreams.invalidate(streamKey);
+      }
     } finally {
       releaseStreamLock(streamKey, lock);
     }
@@ -722,6 +772,9 @@ public class S3LogStorage implements LogStorageInterface {
 
     recentLogsCache.asMap().keySet().removeIf(streamKey -> streamKey.startsWith(streamKeyPrefix));
     activeListeners.keySet().removeIf(streamKey -> streamKey.startsWith(streamKeyPrefix));
+    if (closedStreams != null) {
+      closedStreams.asMap().keySet().removeIf(streamKey -> streamKey.startsWith(streamKeyPrefix));
+    }
 
     try {
       ListObjectsV2Request request =
@@ -780,21 +833,48 @@ public class S3LogStorage implements LogStorageInterface {
     return "s3";
   }
 
+  private static ThreadFactory namedDaemonFactory(String threadName) {
+    return r -> {
+      Thread t = new Thread(r);
+      t.setName(threadName);
+      t.setDaemon(true);
+      return t;
+    };
+  }
+
+  /** Swallow Throwables so a scheduled task that throws is not silently de-scheduled. */
+  private Runnable safeScheduledTask(String name, Runnable task) {
+    return () -> {
+      try {
+        task.run();
+      } catch (Throwable t) { // NOSONAR
+        LOG.error("Scheduled task {} threw - swallowing so the scheduler keeps running", name, t);
+      }
+    };
+  }
+
+  private void shutdownExecutor(ScheduledExecutorService executor, String name) {
+    if (executor == null) {
+      return;
+    }
+    executor.shutdown();
+    try {
+      if (!executor.awaitTermination(5, TimeUnit.SECONDS)) {
+        executor.shutdownNow();
+      }
+    } catch (InterruptedException e) {
+      LOG.debug("Interrupted while shutting down executor {}", name);
+      executor.shutdownNow();
+      Thread.currentThread().interrupt();
+    }
+  }
+
   @Override
   public void close() {
     activeStreams.clear();
 
-    if (cleanupExecutor != null) {
-      cleanupExecutor.shutdown();
-      try {
-        if (!cleanupExecutor.awaitTermination(5, TimeUnit.SECONDS)) {
-          cleanupExecutor.shutdownNow();
-        }
-      } catch (InterruptedException e) {
-        cleanupExecutor.shutdownNow();
-        Thread.currentThread().interrupt();
-      }
-    }
+    shutdownExecutor(partialFlushExecutor, "s3-log-partial-flush");
+    shutdownExecutor(abandonedCleanupExecutor, "s3-log-abandoned-cleanup");
 
     if (s3Client != null) {
       s3Client.close();
@@ -896,6 +976,9 @@ public class S3LogStorage implements LogStorageInterface {
   }
 
   void cleanupAbandonedStreams() {
+    if (metrics != null) {
+      metrics.recordAbandonedCleanupHeartbeat();
+    }
     long now = System.currentTimeMillis();
     long timeoutMs = streamTimeoutMinutes * 60L * 1000L;
 
@@ -928,7 +1011,7 @@ public class S3LogStorage implements LogStorageInterface {
 
     Lock lock = acquireStreamLock(streamKey);
     try {
-      // Re-check expiration under the lock — appendLogs may have bumped lastAccessTime.
+      // Re-check expiration under the lock - appendLogs may have bumped lastAccessTime.
       StreamContext ctx = activeStreams.get(streamKey);
       long timeoutMs = streamTimeoutMinutes * 60L * 1000L;
       if (ctx == null || System.currentTimeMillis() - ctx.lastAccessTime <= timeoutMs) {
@@ -975,28 +1058,44 @@ public class S3LogStorage implements LogStorageInterface {
         // Best-effort.
       }
 
+      markStreamClosed(streamKey);
       dropStreamState(streamKey);
     } finally {
       releaseStreamLock(streamKey, lock);
     }
   }
 
-  /**
-   * Periodically write accumulated logs to partial files for active streams
-   * This allows reading complete logs even while ingestion is still running
-   */
+  /** Scheduled tick: flush each active stream's pendingFlush to partial.txt. */
   private void writePartialLogs() {
+    if (metrics != null) {
+      metrics.recordPartialFlushHeartbeat();
+    }
+    long totalBytes = 0;
+    long totalLines = 0;
     for (String streamKey : activeStreams.keySet()) {
       try {
         writePartialLogsForStream(streamKey);
       } catch (Exception e) {
         LOG.warn("Failed to write partial logs for stream: {}", streamKey, e);
       }
+      AtomicLong b = pendingFlushBytes.get(streamKey);
+      if (b != null) {
+        totalBytes += b.get();
+      }
+      List<String> q = pendingFlush.get(streamKey);
+      if (q != null) {
+        totalLines += q.size();
+      }
+    }
+    if (metrics != null) {
+      metrics.updatePendingStreamsCount(activeStreams.size());
+      metrics.updatePendingFlushBytes(totalBytes);
+      metrics.updatePendingFlushLines(totalLines);
     }
   }
 
   private void writePartialLogsForStream(String streamKey) {
-    // Parse the streamKey before acquiring the lock — these are pure local string ops
+    // Parse the streamKey before acquiring the lock - these are pure local string ops
     // that don't need protection and let us validate the key shape before any I/O.
     int lastSlashIndex = streamKey.lastIndexOf('/');
     if (lastSlashIndex == -1) {
@@ -1061,6 +1160,7 @@ public class S3LogStorage implements LogStorageInterface {
       }
       if (metrics != null) {
         metrics.recordS3Write();
+        metrics.recordPartialFlushSuccess();
       }
       consecutiveFlushFailures.computeIfAbsent(streamKey, k -> new AtomicInteger(0)).set(0);
       return true;
@@ -1082,7 +1182,7 @@ public class S3LogStorage implements LogStorageInterface {
 
   // Probes partial.txt via a single GetObject. For small files we read the body now and let
   // the caller PUT a merged body. For files >= MIN_MPU_PART_BYTES we abort the body stream and
-  // signal the caller to concatenate server-side via Multipart Upload + UploadPartCopy — this
+  // signal the caller to concatenate server-side via Multipart Upload + UploadPartCopy - this
   // avoids holding the full existing body in JVM heap and re-uploading it on every flush.
   private PartialProbe probeAndReadPartial(String partialKey) throws IOException {
     try {
@@ -1258,6 +1358,7 @@ public class S3LogStorage implements LogStorageInterface {
     }
     if (metrics != null) {
       metrics.recordS3Error();
+      metrics.recordFlushFailure();
     }
   }
 
@@ -1291,7 +1392,7 @@ public class S3LogStorage implements LogStorageInterface {
     try {
       // Final flush: drain remaining pendingFlush to partial.txt.
       if (!writePartialLogsForStreamLocked(streamKey, pipelineFQN, runId)) {
-        // Final flush failed — partial.txt may be stale; do not produce logs.txt.
+        // Final flush failed - partial.txt may be stale; do not produce logs.txt.
         // pendingFlush has been restored. Caller should retry.
         throw new IOException(
             "Failed to flush remaining logs to partial.txt for "
@@ -1305,6 +1406,7 @@ public class S3LogStorage implements LogStorageInterface {
       } catch (NoSuchKeyException e) {
         // Idempotent close: partial.txt already absent (likely a retry of a prior /close).
         LOG.debug("closeStream no-op for {}: partial.txt already absent", streamKey);
+        markStreamClosed(streamKey);
         dropStreamState(streamKey);
         return;
       } catch (Exception e) {
@@ -1338,6 +1440,7 @@ public class S3LogStorage implements LogStorageInterface {
         // Best-effort.
       }
 
+      markStreamClosed(streamKey);
       dropStreamState(streamKey);
     } finally {
       releaseStreamLock(streamKey, lock);
@@ -1347,6 +1450,13 @@ public class S3LogStorage implements LogStorageInterface {
   private void copyPartialToLogs(String pipelineFQN, UUID runId) {
     String partialKey = buildPartialS3Key(pipelineFQN, runId);
     String logsKey = buildS3Key(pipelineFQN, runId);
+    if (objectExists(logsKey)) {
+      LOG.warn(
+          "logs.txt already exists for {}/{}; deleting late partial.txt without overwriting logs.txt",
+          pipelineFQN,
+          runId);
+      return;
+    }
     CopyObjectRequest.Builder builder =
         CopyObjectRequest.builder()
             .sourceBucket(bucketName)
@@ -1360,12 +1470,28 @@ public class S3LogStorage implements LogStorageInterface {
     }
   }
 
+  private boolean objectExists(String key) {
+    try {
+      HeadObjectResponse response =
+          s3Client.headObject(HeadObjectRequest.builder().bucket(bucketName).key(key).build());
+      return response != null;
+    } catch (NoSuchKeyException e) {
+      return false;
+    } catch (S3Exception e) {
+      if (e.statusCode() == 404) {
+        return false;
+      }
+      throw e;
+    }
+  }
+
   private void dropStreamState(String streamKey) {
     activeStreams.remove(streamKey);
     pendingFlush.remove(streamKey);
     pendingFlushBytes.remove(streamKey);
     totalLinesAppended.remove(streamKey);
     consecutiveFlushFailures.remove(streamKey);
+    scheduledPartialFlushes.remove(streamKey);
     recentLogsCache.invalidate(streamKey);
     activeListeners.remove(streamKey);
   }
@@ -1551,7 +1677,7 @@ public class S3LogStorage implements LogStorageInterface {
       appendPendingFlushUnderLock(pipelineFQN, runId, allLines);
     } else {
       // No partial.txt yet (run hasn't had its first flush). Use pendingFlush as the
-      // canonical source — it holds the complete set of unflushed lines. recentLogsCache
+      // canonical source - it holds the complete set of unflushed lines. recentLogsCache
       // is for SSE live tail and may have evicted the oldest lines at its 1000-line cap.
       appendPendingFlushUnderLock(pipelineFQN, runId, allLines);
       if (allLines.isEmpty()) {

--- a/openmetadata-service/src/main/java/org/openmetadata/service/monitoring/StreamableLogsMetrics.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/monitoring/StreamableLogsMetrics.java
@@ -59,6 +59,15 @@ public class StreamableLogsMetrics {
   private final Counter ingestionLogsDropped;
   private final Counter ingestionFallbackActive;
 
+  // Server-side flush observability.
+  private final AtomicLong lastPartialFlushTimestamp;
+  private final AtomicLong partialFlushHeartbeat;
+  private final AtomicLong abandonedCleanupHeartbeat;
+  private final AtomicInteger pendingStreamsCount;
+  private final AtomicLong pendingFlushBytes;
+  private final AtomicLong pendingFlushLines;
+  private final Counter flushFailuresCounter;
+
   public static final int STATE_CLOSED = 0;
   public static final int STATE_OPEN = 1;
   public static final int STATE_HALF_OPEN = 2;
@@ -198,6 +207,104 @@ public class StreamableLogsMetrics {
         Counter.builder("om_ingestion_fallback_active_total")
             .description("Number of times fallback to local logging was activated")
             .register(meterRegistry);
+
+    this.lastPartialFlushTimestamp = new AtomicLong(0);
+    Gauge.builder(
+            "om_streamable_logs_last_partial_flush_ts_ms",
+            lastPartialFlushTimestamp,
+            AtomicLong::get)
+        .description("Epoch millis of the last successful partial.txt flush")
+        .register(meterRegistry);
+
+    this.partialFlushHeartbeat = new AtomicLong(0);
+    Gauge.builder(
+            "om_streamable_logs_partial_flush_heartbeat_ms", partialFlushHeartbeat, AtomicLong::get)
+        .description("Epoch millis of last partial-flush scheduled tick")
+        .register(meterRegistry);
+
+    this.abandonedCleanupHeartbeat = new AtomicLong(0);
+    Gauge.builder(
+            "om_streamable_logs_abandoned_cleanup_heartbeat_ms",
+            abandonedCleanupHeartbeat,
+            AtomicLong::get)
+        .description("Epoch millis of last abandoned-cleanup scheduled tick")
+        .register(meterRegistry);
+
+    this.pendingStreamsCount = new AtomicInteger(0);
+    Gauge.builder("om_streamable_logs_pending_streams", pendingStreamsCount, AtomicInteger::get)
+        .description("Number of active streams with pending log data on the server")
+        .register(meterRegistry);
+
+    this.pendingFlushBytes = new AtomicLong(0);
+    Gauge.builder("om_streamable_logs_pending_flush_bytes", pendingFlushBytes, AtomicLong::get)
+        .description("Total bytes queued for partial-flush across all active streams")
+        .register(meterRegistry);
+
+    this.pendingFlushLines = new AtomicLong(0);
+    Gauge.builder("om_streamable_logs_pending_flush_lines", pendingFlushLines, AtomicLong::get)
+        .description("Total log lines queued for partial-flush across all active streams")
+        .register(meterRegistry);
+
+    this.flushFailuresCounter =
+        Counter.builder("om_streamable_logs_flush_failures_total")
+            .description("Total partial-flush failures (server side)")
+            .register(meterRegistry);
+  }
+
+  public void recordPartialFlushSuccess() {
+    lastPartialFlushTimestamp.set(System.currentTimeMillis());
+  }
+
+  public void recordPartialFlushHeartbeat() {
+    partialFlushHeartbeat.set(System.currentTimeMillis());
+  }
+
+  public void recordAbandonedCleanupHeartbeat() {
+    abandonedCleanupHeartbeat.set(System.currentTimeMillis());
+  }
+
+  public void recordFlushFailure() {
+    flushFailuresCounter.increment();
+  }
+
+  public void updatePendingStreamsCount(int count) {
+    pendingStreamsCount.set(count);
+  }
+
+  public void updatePendingFlushBytes(long bytes) {
+    pendingFlushBytes.set(bytes);
+  }
+
+  public void updatePendingFlushLines(long lines) {
+    pendingFlushLines.set(lines);
+  }
+
+  public long getLastPartialFlushTimestamp() {
+    return lastPartialFlushTimestamp.get();
+  }
+
+  public long getPartialFlushHeartbeat() {
+    return partialFlushHeartbeat.get();
+  }
+
+  public long getAbandonedCleanupHeartbeat() {
+    return abandonedCleanupHeartbeat.get();
+  }
+
+  public int getPendingStreamsCount() {
+    return pendingStreamsCount.get();
+  }
+
+  public long getPendingFlushBytes() {
+    return pendingFlushBytes.get();
+  }
+
+  public long getPendingFlushLines() {
+    return pendingFlushLines.get();
+  }
+
+  public long getFlushFailuresCount() {
+    return (long) flushFailuresCounter.count();
   }
 
   public void recordLogsSent(int count) {

--- a/openmetadata-service/src/test/java/org/openmetadata/service/logstorage/S3LogStorageTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/logstorage/S3LogStorageTest.java
@@ -44,6 +44,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.locks.Lock;
 import org.junit.jupiter.api.BeforeEach;
@@ -56,6 +57,7 @@ import org.openmetadata.schema.api.configuration.LogStorageConfiguration;
 import org.openmetadata.schema.security.credentials.AWSCredentials;
 import software.amazon.awssdk.core.ResponseInputStream;
 import software.amazon.awssdk.core.async.AsyncRequestBody;
+import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration;
 import software.amazon.awssdk.http.AbortableInputStream;
 import software.amazon.awssdk.services.s3.S3AsyncClient;
 import software.amazon.awssdk.services.s3.S3AsyncClientBuilder;
@@ -83,6 +85,7 @@ import software.amazon.awssdk.services.s3.model.NoSuchBucketException;
 import software.amazon.awssdk.services.s3.model.NoSuchKeyException;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import software.amazon.awssdk.services.s3.model.PutObjectResponse;
+import software.amazon.awssdk.services.s3.model.S3Exception;
 import software.amazon.awssdk.services.s3.model.S3Object;
 import software.amazon.awssdk.services.s3.model.UploadPartCopyRequest;
 import software.amazon.awssdk.services.s3.model.UploadPartCopyResponse;
@@ -124,12 +127,16 @@ public class S3LogStorageTest {
       S3ClientBuilder mockBuilder = mock(S3ClientBuilder.class);
       when(S3Client.builder()).thenReturn(mockBuilder);
       when(mockBuilder.region(any())).thenReturn(mockBuilder);
+      when(mockBuilder.overrideConfiguration(any(ClientOverrideConfiguration.class)))
+          .thenReturn(mockBuilder);
       when(mockBuilder.credentialsProvider(any())).thenReturn(mockBuilder);
       when(mockBuilder.build()).thenReturn(mockS3Client);
 
       S3AsyncClientBuilder mockAsyncBuilder = mock(S3AsyncClientBuilder.class);
       when(S3AsyncClient.builder()).thenReturn(mockAsyncBuilder);
       when(mockAsyncBuilder.region(any())).thenReturn(mockAsyncBuilder);
+      when(mockAsyncBuilder.overrideConfiguration(any(ClientOverrideConfiguration.class)))
+          .thenReturn(mockAsyncBuilder);
       when(mockAsyncBuilder.credentialsProvider(any())).thenReturn(mockAsyncBuilder);
       when(mockAsyncBuilder.build()).thenReturn(mockS3AsyncClient);
 
@@ -160,6 +167,40 @@ public class S3LogStorageTest {
   void testS3LogStorageInitialization() {
     assertNotNull(s3LogStorage);
     assertEquals("s3", s3LogStorage.getStorageType());
+  }
+
+  @Test
+  void testS3ClientsUseApiCallTimeouts() throws Exception {
+    try (MockedStatic<S3Client> s3ClientMock = mockStatic(S3Client.class);
+        MockedStatic<S3AsyncClient> s3AsyncClientMock = mockStatic(S3AsyncClient.class)) {
+
+      S3ClientBuilder mockBuilder = mock(S3ClientBuilder.class);
+      when(S3Client.builder()).thenReturn(mockBuilder);
+      when(mockBuilder.region(any())).thenReturn(mockBuilder);
+      when(mockBuilder.overrideConfiguration(any(ClientOverrideConfiguration.class)))
+          .thenReturn(mockBuilder);
+      when(mockBuilder.credentialsProvider(any())).thenReturn(mockBuilder);
+      when(mockBuilder.build()).thenReturn(mockS3Client);
+
+      S3AsyncClientBuilder mockAsyncBuilder = mock(S3AsyncClientBuilder.class);
+      when(S3AsyncClient.builder()).thenReturn(mockAsyncBuilder);
+      when(mockAsyncBuilder.region(any())).thenReturn(mockAsyncBuilder);
+      when(mockAsyncBuilder.overrideConfiguration(any(ClientOverrideConfiguration.class)))
+          .thenReturn(mockAsyncBuilder);
+      when(mockAsyncBuilder.credentialsProvider(any())).thenReturn(mockAsyncBuilder);
+      when(mockAsyncBuilder.build()).thenReturn(mockS3AsyncClient);
+      when(mockS3Client.headBucket(any(HeadBucketRequest.class)))
+          .thenReturn(HeadBucketResponse.builder().build());
+
+      S3LogStorage storage = new S3LogStorage();
+      Map<String, Object> config = new HashMap<>();
+      config.put("config", testConfig);
+      storage.initialize(config);
+
+      verify(mockBuilder).overrideConfiguration(any(ClientOverrideConfiguration.class));
+      verify(mockAsyncBuilder).overrideConfiguration(any(ClientOverrideConfiguration.class));
+      storage.close();
+    }
   }
 
   @Test
@@ -234,6 +275,126 @@ public class S3LogStorageTest {
   }
 
   @Test
+  void testLateAppendAfterCloseIsDropped() throws Exception {
+    String streamKey = testPipelineFQN + "/" + testRunId;
+    String partialKey =
+        testPrefix
+            + "/"
+            + testPipelineFQN.replaceAll("[^a-zA-Z0-9_-]", "_")
+            + "/"
+            + testRunId
+            + "/partial.txt";
+
+    mockAsyncPutObject();
+    when(mockS3Client.getObject(
+            argThat((GetObjectRequest req) -> req != null && partialKey.equals(req.key()))))
+        .thenThrow(NoSuchKeyException.builder().build());
+    when(mockS3Client.putObject(
+            any(PutObjectRequest.class), any(software.amazon.awssdk.core.sync.RequestBody.class)))
+        .thenReturn(PutObjectResponse.builder().build());
+    when(mockS3Client.copyObject(any(CopyObjectRequest.class)))
+        .thenReturn(software.amazon.awssdk.services.s3.model.CopyObjectResponse.builder().build());
+    when(mockS3Client.deleteObject(any(DeleteObjectRequest.class)))
+        .thenReturn(DeleteObjectResponse.builder().build());
+
+    s3LogStorage.appendLogs(testPipelineFQN, testRunId, "before-close\n");
+    s3LogStorage.closeStream(testPipelineFQN, testRunId);
+
+    clearInvocations(mockS3Client);
+    s3LogStorage.appendLogs(testPipelineFQN, testRunId, "late-after-close\n");
+
+    @SuppressWarnings("unchecked")
+    Map<String, List<String>> pending =
+        (Map<String, List<String>>) getPrivateField(s3LogStorage, "pendingFlush");
+    assertFalse(
+        pending.containsKey(streamKey),
+        "late append after close must not recreate pendingFlush for the completed stream");
+    verify(mockS3Client, never())
+        .putObject(
+            any(PutObjectRequest.class), any(software.amazon.awssdk.core.sync.RequestBody.class));
+  }
+
+  @Test
+  void testLatePartialDoesNotOverwriteExistingLogsTxt() throws Exception {
+    String partialKey =
+        testPrefix
+            + "/"
+            + testPipelineFQN.replaceAll("[^a-zA-Z0-9_-]", "_")
+            + "/"
+            + testRunId
+            + "/partial.txt";
+    String logsKey =
+        testPrefix
+            + "/"
+            + testPipelineFQN.replaceAll("[^a-zA-Z0-9_-]", "_")
+            + "/"
+            + testRunId
+            + "/logs.txt";
+
+    mockAsyncPutObject();
+    when(mockS3Client.getObject(
+            argThat((GetObjectRequest req) -> req != null && partialKey.equals(req.key()))))
+        .thenThrow(NoSuchKeyException.builder().build());
+    when(mockS3Client.putObject(
+            any(PutObjectRequest.class), any(software.amazon.awssdk.core.sync.RequestBody.class)))
+        .thenReturn(PutObjectResponse.builder().build());
+    when(mockS3Client.headObject(
+            argThat((HeadObjectRequest req) -> req != null && logsKey.equals(req.key()))))
+        .thenReturn(HeadObjectResponse.builder().build());
+    when(mockS3Client.deleteObject(any(DeleteObjectRequest.class)))
+        .thenReturn(DeleteObjectResponse.builder().build());
+
+    s3LogStorage.appendLogs(testPipelineFQN, testRunId, "late-tail\n");
+    s3LogStorage.closeStream(testPipelineFQN, testRunId);
+
+    verify(mockS3Client, never()).copyObject(any(CopyObjectRequest.class));
+    verify(mockS3Client, atLeastOnce())
+        .deleteObject(
+            argThat((DeleteObjectRequest req) -> req != null && partialKey.equals(req.key())));
+  }
+
+  @Test
+  void testLogsTxtHeadObjectGeneric404IsTreatedAsMissing() throws Exception {
+    String partialKey =
+        testPrefix
+            + "/"
+            + testPipelineFQN.replaceAll("[^a-zA-Z0-9_-]", "_")
+            + "/"
+            + testRunId
+            + "/partial.txt";
+    String logsKey =
+        testPrefix
+            + "/"
+            + testPipelineFQN.replaceAll("[^a-zA-Z0-9_-]", "_")
+            + "/"
+            + testRunId
+            + "/logs.txt";
+
+    mockAsyncPutObject();
+    when(mockS3Client.getObject(
+            argThat((GetObjectRequest req) -> req != null && partialKey.equals(req.key()))))
+        .thenThrow(NoSuchKeyException.builder().build());
+    when(mockS3Client.putObject(
+            any(PutObjectRequest.class), any(software.amazon.awssdk.core.sync.RequestBody.class)))
+        .thenReturn(PutObjectResponse.builder().build());
+    when(mockS3Client.headObject(
+            argThat((HeadObjectRequest req) -> req != null && logsKey.equals(req.key()))))
+        .thenThrow(S3Exception.builder().statusCode(404).message("Not Found").build());
+    when(mockS3Client.copyObject(any(CopyObjectRequest.class)))
+        .thenReturn(software.amazon.awssdk.services.s3.model.CopyObjectResponse.builder().build());
+    when(mockS3Client.deleteObject(any(DeleteObjectRequest.class)))
+        .thenReturn(DeleteObjectResponse.builder().build());
+
+    s3LogStorage.appendLogs(testPipelineFQN, testRunId, "tail\n");
+    s3LogStorage.closeStream(testPipelineFQN, testRunId);
+
+    verify(mockS3Client)
+        .copyObject(
+            argThat(
+                (CopyObjectRequest req) -> req != null && logsKey.equals(req.destinationKey())));
+  }
+
+  @Test
   void testCloseStreamIsIdempotent() throws Exception {
     mockAsyncPutObject();
     // First close: flush writes partial.txt, then copy succeeds, then delete
@@ -250,8 +411,8 @@ public class S3LogStorageTest {
     s3LogStorage.appendLogs(testPipelineFQN, testRunId, "x\n");
     s3LogStorage.closeStream(testPipelineFQN, testRunId);
 
-    // Second close: no pending lines → writePartialLogsForStreamLocked is no-op,
-    // then copyPartialToLogs throws NoSuchKeyException → idempotent path returns.
+    // Second close: no pending lines -> writePartialLogsForStreamLocked is no-op,
+    // then copyPartialToLogs throws NoSuchKeyException -> idempotent path returns.
     when(mockS3Client.copyObject(any(CopyObjectRequest.class)))
         .thenThrow(NoSuchKeyException.builder().build());
 
@@ -535,12 +696,16 @@ public class S3LogStorageTest {
       S3ClientBuilder mockBuilder = mock(S3ClientBuilder.class);
       when(S3Client.builder()).thenReturn(mockBuilder);
       when(mockBuilder.region(any())).thenReturn(mockBuilder);
+      when(mockBuilder.overrideConfiguration(any(ClientOverrideConfiguration.class)))
+          .thenReturn(mockBuilder);
       when(mockBuilder.credentialsProvider(any())).thenReturn(mockBuilder);
       when(mockBuilder.build()).thenReturn(mockS3Client);
 
       S3AsyncClientBuilder mockAsyncBuilder = mock(S3AsyncClientBuilder.class);
       when(S3AsyncClient.builder()).thenReturn(mockAsyncBuilder);
       when(mockAsyncBuilder.region(any())).thenReturn(mockAsyncBuilder);
+      when(mockAsyncBuilder.overrideConfiguration(any(ClientOverrideConfiguration.class)))
+          .thenReturn(mockAsyncBuilder);
       when(mockAsyncBuilder.credentialsProvider(any())).thenReturn(mockAsyncBuilder);
       when(mockAsyncBuilder.build()).thenReturn(mockS3AsyncClient);
 
@@ -572,6 +737,8 @@ public class S3LogStorageTest {
       S3ClientBuilder mockBuilder = mock(S3ClientBuilder.class);
       when(S3Client.builder()).thenReturn(mockBuilder);
       when(mockBuilder.region(any())).thenReturn(mockBuilder);
+      when(mockBuilder.overrideConfiguration(any(ClientOverrideConfiguration.class)))
+          .thenReturn(mockBuilder);
 
       S3LogStorage storage = new S3LogStorage();
       Map<String, Object> config = new HashMap<>();
@@ -596,12 +763,16 @@ public class S3LogStorageTest {
       S3ClientBuilder mockBuilder = mock(S3ClientBuilder.class);
       when(S3Client.builder()).thenReturn(mockBuilder);
       when(mockBuilder.region(any())).thenReturn(mockBuilder);
+      when(mockBuilder.overrideConfiguration(any(ClientOverrideConfiguration.class)))
+          .thenReturn(mockBuilder);
       when(mockBuilder.credentialsProvider(any())).thenReturn(mockBuilder);
       when(mockBuilder.build()).thenReturn(mockS3Client);
 
       S3AsyncClientBuilder mockAsyncBuilder = mock(S3AsyncClientBuilder.class);
       when(S3AsyncClient.builder()).thenReturn(mockAsyncBuilder);
       when(mockAsyncBuilder.region(any())).thenReturn(mockAsyncBuilder);
+      when(mockAsyncBuilder.overrideConfiguration(any(ClientOverrideConfiguration.class)))
+          .thenReturn(mockAsyncBuilder);
       when(mockAsyncBuilder.credentialsProvider(any())).thenReturn(mockAsyncBuilder);
       when(mockAsyncBuilder.build()).thenReturn(mockS3AsyncClient);
 
@@ -659,7 +830,7 @@ public class S3LogStorageTest {
     Map<String, AtomicLong> counters =
         (Map<String, AtomicLong>) getPrivateField(s3LogStorage, "totalLinesAppended");
 
-    // "line A\nline B\n" → split → ["line A", "line B", ""] → trim → 2 lines
+    // "line A\nline B\n" -> split -> ["line A", "line B", ""] -> trim -> 2 lines
     assertEquals(2, pending.get(streamKey).size(), "trailing newline must not yield an empty line");
     assertEquals(2L, counters.get(streamKey).get());
   }
@@ -1048,6 +1219,218 @@ public class S3LogStorageTest {
     Map<String, java.util.List<String>> pending =
         (Map<String, java.util.List<String>>) getPrivateField(s3LogStorage, "pendingFlush");
     assertEquals(1, pending.get(testPipelineFQN + "/" + testRunId).size());
+  }
+
+  @Test
+  void testPartialFlushAndAbandonedCleanupExecutorsAreSeparate() throws Exception {
+    Object partial = getPrivateField(s3LogStorage, "partialFlushExecutor");
+    Object cleanup = getPrivateField(s3LogStorage, "abandonedCleanupExecutor");
+    assertNotNull(partial);
+    assertNotNull(cleanup);
+    assertFalse(partial == cleanup, "executors must be distinct");
+  }
+
+  @Test
+  void testSafeScheduledTaskSwallowsThrowableSoSchedulerKeepsRunning() throws Exception {
+    java.lang.reflect.Method safe =
+        S3LogStorage.class.getDeclaredMethod("safeScheduledTask", String.class, Runnable.class);
+    safe.setAccessible(true);
+
+    final boolean[] ran = {false};
+    Runnable thrower =
+        () -> {
+          ran[0] = true;
+          throw new RuntimeException("boom");
+        };
+
+    Runnable wrapped = (Runnable) safe.invoke(s3LogStorage, "test-task", thrower);
+
+    assertDoesNotThrow(wrapped::run);
+    assertTrue(ran[0]);
+    assertDoesNotThrow(wrapped::run);
+  }
+
+  @Test
+  void testWritePartialLogsContinuesEvenIfOneStreamFails() throws Exception {
+    String runIdA = UUID.randomUUID().toString();
+    String runIdB = UUID.randomUUID().toString();
+    String streamA = testPipelineFQN + "/" + runIdA;
+    String streamB = testPipelineFQN + "/" + runIdB;
+
+    mockAsyncPutObject();
+    s3LogStorage.appendLogs(testPipelineFQN, UUID.fromString(runIdA), "from-A\n");
+    s3LogStorage.appendLogs(testPipelineFQN, UUID.fromString(runIdB), "from-B\n");
+
+    String partialKeyA =
+        testPrefix
+            + "/"
+            + testPipelineFQN.replaceAll("[^a-zA-Z0-9_-]", "_")
+            + "/"
+            + runIdA
+            + "/partial.txt";
+    String partialKeyB =
+        testPrefix
+            + "/"
+            + testPipelineFQN.replaceAll("[^a-zA-Z0-9_-]", "_")
+            + "/"
+            + runIdB
+            + "/partial.txt";
+
+    // Stream A: probe throws - its flush will be marked failed.
+    when(mockS3Client.getObject(
+            argThat((GetObjectRequest req) -> req != null && partialKeyA.equals(req.key()))))
+        .thenThrow(new RuntimeException("simulated S3 failure for stream A"));
+    // Stream B: probe returns no existing partial.txt, succeeds.
+    when(mockS3Client.getObject(
+            argThat((GetObjectRequest req) -> req != null && partialKeyB.equals(req.key()))))
+        .thenThrow(NoSuchKeyException.builder().build());
+    when(mockS3Client.putObject(
+            any(PutObjectRequest.class), any(software.amazon.awssdk.core.sync.RequestBody.class)))
+        .thenReturn(PutObjectResponse.builder().build());
+
+    // Direct call to the scheduled body - verifies the loop's per-stream
+    // exception handling, NOT the executor.
+    java.lang.reflect.Method writePartial =
+        S3LogStorage.class.getDeclaredMethod("writePartialLogs");
+    writePartial.setAccessible(true);
+    assertDoesNotThrow(() -> writePartial.invoke(s3LogStorage));
+
+    // Stream B's PUT must have happened despite A's failure.
+    org.mockito.ArgumentCaptor<PutObjectRequest> reqCap =
+        org.mockito.ArgumentCaptor.forClass(PutObjectRequest.class);
+    verify(mockS3Client, atLeastOnce())
+        .putObject(reqCap.capture(), any(software.amazon.awssdk.core.sync.RequestBody.class));
+    boolean sawBPut = reqCap.getAllValues().stream().anyMatch(r -> partialKeyB.equals(r.key()));
+    assertTrue(sawBPut, "stream B must have been flushed even though stream A failed");
+  }
+
+  @Test
+  void testWritePartialLogsUpdatesPendingMetricsAndHeartbeat() throws Exception {
+    io.micrometer.core.instrument.simple.SimpleMeterRegistry registry =
+        new io.micrometer.core.instrument.simple.SimpleMeterRegistry();
+    org.openmetadata.service.monitoring.StreamableLogsMetrics testMetrics =
+        new org.openmetadata.service.monitoring.StreamableLogsMetrics(registry);
+
+    Field metricsField = S3LogStorage.class.getDeclaredField("metrics");
+    metricsField.setAccessible(true);
+    metricsField.set(s3LogStorage, testMetrics);
+
+    long beforeHeartbeat = testMetrics.getPartialFlushHeartbeat();
+    mockAsyncPutObject();
+    s3LogStorage.appendLogs(testPipelineFQN, testRunId, "alpha\nbeta\ngamma\n");
+
+    java.lang.reflect.Method writePartial =
+        S3LogStorage.class.getDeclaredMethod("writePartialLogs");
+    writePartial.setAccessible(true);
+    writePartial.invoke(s3LogStorage);
+
+    assertTrue(testMetrics.getPartialFlushHeartbeat() > beforeHeartbeat);
+    assertEquals(1, testMetrics.getPendingStreamsCount());
+  }
+
+  @Test
+  void testFlushSuccessUpdatesLastPartialFlushTimestamp() throws Exception {
+    io.micrometer.core.instrument.simple.SimpleMeterRegistry registry =
+        new io.micrometer.core.instrument.simple.SimpleMeterRegistry();
+    org.openmetadata.service.monitoring.StreamableLogsMetrics testMetrics =
+        new org.openmetadata.service.monitoring.StreamableLogsMetrics(registry);
+    Field metricsField = S3LogStorage.class.getDeclaredField("metrics");
+    metricsField.setAccessible(true);
+    metricsField.set(s3LogStorage, testMetrics);
+
+    String streamKey = testPipelineFQN + "/" + testRunId;
+    String partialKey =
+        testPrefix
+            + "/"
+            + testPipelineFQN.replaceAll("[^a-zA-Z0-9_-]", "_")
+            + "/"
+            + testRunId
+            + "/partial.txt";
+
+    when(mockS3Client.getObject(
+            argThat((GetObjectRequest req) -> req != null && partialKey.equals(req.key()))))
+        .thenThrow(NoSuchKeyException.builder().build());
+    when(mockS3Client.putObject(
+            any(PutObjectRequest.class), any(software.amazon.awssdk.core.sync.RequestBody.class)))
+        .thenReturn(PutObjectResponse.builder().build());
+    mockAsyncPutObject();
+
+    assertEquals(0L, testMetrics.getLastPartialFlushTimestamp());
+
+    s3LogStorage.appendLogs(testPipelineFQN, testRunId, "x\ny\n");
+    java.lang.reflect.Method writeStream =
+        S3LogStorage.class.getDeclaredMethod("writePartialLogsForStream", String.class);
+    writeStream.setAccessible(true);
+    writeStream.invoke(s3LogStorage, streamKey);
+
+    assertTrue(testMetrics.getLastPartialFlushTimestamp() > 0L);
+  }
+
+  @Test
+  void testFlushFailureIncrementsFailureCounter() throws Exception {
+    io.micrometer.core.instrument.simple.SimpleMeterRegistry registry =
+        new io.micrometer.core.instrument.simple.SimpleMeterRegistry();
+    org.openmetadata.service.monitoring.StreamableLogsMetrics testMetrics =
+        new org.openmetadata.service.monitoring.StreamableLogsMetrics(registry);
+    Field metricsField = S3LogStorage.class.getDeclaredField("metrics");
+    metricsField.setAccessible(true);
+    metricsField.set(s3LogStorage, testMetrics);
+
+    String partialKey =
+        testPrefix
+            + "/"
+            + testPipelineFQN.replaceAll("[^a-zA-Z0-9_-]", "_")
+            + "/"
+            + testRunId
+            + "/partial.txt";
+
+    when(mockS3Client.getObject(
+            argThat((GetObjectRequest req) -> req != null && partialKey.equals(req.key()))))
+        .thenThrow(new RuntimeException("simulated S3 outage"));
+
+    mockAsyncPutObject();
+    s3LogStorage.appendLogs(testPipelineFQN, testRunId, "z\n");
+
+    java.lang.reflect.Method writeStream =
+        S3LogStorage.class.getDeclaredMethod("writePartialLogsForStream", String.class);
+    writeStream.setAccessible(true);
+    writeStream.invoke(s3LogStorage, testPipelineFQN + "/" + testRunId);
+
+    assertTrue(testMetrics.getFlushFailuresCount() >= 1);
+  }
+
+  @Test
+  void testWatermarkFlushSchedulesOnlyOnceWhileFlushAlreadyQueued() throws Exception {
+    ScheduledExecutorService executor = mock(ScheduledExecutorService.class);
+    Field executorField = S3LogStorage.class.getDeclaredField("partialFlushExecutor");
+    executorField.setAccessible(true);
+    executorField.set(s3LogStorage, executor);
+
+    Field watermarkField = S3LogStorage.class.getDeclaredField("earlyFlushWatermarkBytes");
+    watermarkField.setAccessible(true);
+    watermarkField.setLong(s3LogStorage, 1L);
+
+    mockAsyncPutObject();
+    s3LogStorage.appendLogs(testPipelineFQN, testRunId, "first\n");
+    s3LogStorage.appendLogs(testPipelineFQN, testRunId, "second\n");
+    s3LogStorage.appendLogs(testPipelineFQN, testRunId, "third\n");
+
+    verify(executor, times(1)).execute(any(Runnable.class));
+  }
+
+  @Test
+  void testCleanupHeartbeatUpdates() throws Exception {
+    io.micrometer.core.instrument.simple.SimpleMeterRegistry registry =
+        new io.micrometer.core.instrument.simple.SimpleMeterRegistry();
+    org.openmetadata.service.monitoring.StreamableLogsMetrics testMetrics =
+        new org.openmetadata.service.monitoring.StreamableLogsMetrics(registry);
+    Field metricsField = S3LogStorage.class.getDeclaredField("metrics");
+    metricsField.setAccessible(true);
+    metricsField.set(s3LogStorage, testMetrics);
+
+    long before = testMetrics.getAbandonedCleanupHeartbeat();
+    s3LogStorage.cleanupAbandonedStreams();
+    assertTrue(testMetrics.getAbandonedCleanupHeartbeat() > before);
   }
 
   private static Object getPrivateField(Object target, String name) throws Exception {


### PR DESCRIPTION
## Summary

Cherry-picks four PRs from `main` onto `1.13` to bring streamable-logger correctness, OMeta transport resilience, and runtime observability up to date:

1. **#28198** — non-blocking streamable log handler + split flush executors (server-side)
2. **#28273** — synchronous shutdown captures full streamable log tail
3. **#28161** — runtime diagnostics subsystem
4. **#28256** — OMeta resilient transport (keepalive + urllib3 Retry adapter, typed `RestTransportError`)

After these picks, 1.13's `streamable_logger.py`, `test_streamable_logger.py`, `client.py`, `http_adapter.py`, `api/steps.py`, and `utils/logger.py` are **byte-identical to main and 1.12.9**.

## Why these four together

- **#28198** introduced the non-blocking queue+worker handler design that **retired the CircuitBreaker** approach 1.13 still had. Required before #28273.
- **#28273** adds synchronous `flush()` / `shutdown()` so the workflow tail (Execution Time Summary, Workflow Summary, "Workflow finished in time") is reliably captured in S3/MinIO. Bug fix.
- **#28161** adds the runtime diagnostics subsystem (heartbeat, memory introspection, signals, watchdog, time accounting). The streamable handler's `cleanup_streamable_logging` lifecycle in `base.py` interleaves with `diagnostics.shutdown()`; bringing them both keeps the file aligned with main.
- **#28256** adds the `http_adapter` module + `mount_resilient_adapter()`. **Required transitively** — main's `client.py` (which we cherry-picked from #28198) calls `mount_resilient_adapter`. Without #28256 the import fails at module load (`ModuleNotFoundError: metadata.ingestion.ometa.http_adapter`) and every Python unit test errors out during collection. Caught by CI failure on the first push.

## Cherry-pick commits

| Cherry-picked SHA | Source on main | What it does |
|---|---|---|
| `982aea45e0` | `d3430d6abb` (#28198) | Replaces 1.13's CircuitBreaker with non-blocking queue+worker; splits server-side `s3-log-cleanup` into `s3-log-partial-flush` + `s3-log-abandoned-cleanup`; adds `StreamableLogsMetrics` counters |
| `cfb0fbcaa2` | `ef9017a896` (#28273) | Sync `flush(timeout)` + `shutdown(timeout)` + `atexit`; force-stop worker on join timeout with fresh REST for `/close`; decouples `log_server_version()` from `validate_versions()` |
| `4f0971baf9` | `e41544764b` (#28161) | New `metadata.ingestion.diagnostics` subsystem (heartbeat, http_introspect, memory, registry, signals, stage_progress, time_accounting, watchdog); wires `diagnostics.operation(...)` context managers into `Source.run()`, `Sink.run()`, `REST._request()`, `Workflow.stop()` |
| `26595b4f0c` | `3b2b0ed71a` (#28256) | New `http_adapter.py` with `mount_resilient_adapter` (keepalive + single urllib3 `Retry`); raises typed `RestTransportError` from `client._one_request` on ConnectionError/Timeout/RetryError; drops the now-redundant inline ConnectionError one-shot |

## Conflicts resolved during cherry-pick

| Cherry-pick | File | Resolution |
|---|---|---|
| #28198 | `streamable_logger.py`, `test_streamable_logger.py` | `--theirs` — wholesale replace 1.13's CircuitBreaker design |
| #28198 | `client.py` (one hunk) | Hand-merge: accepted the typed `_request` signature + new `timeout`/`retries` kwargs |
| #28273 | (auto-merged 3 files) | No conflicts after #28198 was in place |
| #28161 | `api/steps.py`, `utils/logger.py`, `client.py` | `--theirs` — purely additive (`diagnostics.operation(...)` context managers + new `diag_logger()` function) |
| #28161 | `.basedpyright/baseline.json` | Removed (1.13 doesn't carry this file) |
| #28256 | `client.py` | Auto-merged cleanly on top of the prior cherry-picks |

## Divergence vs main (after these cherry-picks)

| File | vs main (diff lines) | Status |
|---|---|---|
| `streamable_logger.py` | **0** | byte-identical |
| `test_streamable_logger.py` | **0** | byte-identical |
| `client.py` | **0** | byte-identical |
| `http_adapter.py` | **0** | byte-identical |
| `api/steps.py` | **0** | byte-identical |
| `utils/logger.py` | **0** | byte-identical |
| 4 Java files (S3LogStorage, etc.) | **0** | byte-identical |
| `workflow/base.py` | 228 (cosmetic) | residual ruff formatter chores from #27774/#27739 |
| `server_mixin.py`, `logs_mixin.py`, `source_api_client.py`, `conftest.py` | residual cosmetic | same reason |

Residual divergence is entirely formatter chores (`# noqa:` markers, line-wrap collapse from ruff migration). No behavioral diff.

## Test plan

- [x] Cherry-pick conflicts resolved without dropping any 1.13-specific code
- [x] Streamable handler + transport files byte-identical to main + 1.12.9
- [ ] CI: unit tests pass (initial run failed on missing `http_adapter` import — fixed by adding #28256)
- [ ] CI: server-side Java tests pass (the executor-split test additions from #28198)
- [ ] Manual: streamable logs verified end-to-end against a real OM/MinIO setup
