### PR TITLE
Fix #27918: notification links plural alerts path and Query href fallback

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/notifications/template/handlebars/helpers/BuildEntityUrlHelper.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/notifications/template/handlebars/helpers/BuildEntityUrlHelper.java
@@ -52,7 +52,6 @@ public class BuildEntityUrlHelper implements HandlebarsHelper {
   private static final String KEY_SERVICE = "service";
   private static final String KEY_PIPELINE_TYPE = "pipelineType";
   private static final String KEY_ENTITY = "entity";
-  private static final String KEY_QUERY_USED_IN = "queryUsedIn";
   private static final String KEY_ID = "id";
 
   @Override
@@ -163,7 +162,7 @@ public class BuildEntityUrlHelper implements HandlebarsHelper {
           // DATA_CONTRACT: Redirects to the table's contract tab
           buildDataContractUrl(baseUrl, entityMap);
           case Entity.QUERY ->
-          // QUERY: Redirects to the table's queries tab with query parameters
+          // QUERY: /query-view/{queryFqn}/{queryId} (standalone Query page)
           buildQueryUrl(baseUrl, entityMap);
           case Entity.USER ->
           // USER: /users/{fqn}
@@ -172,8 +171,8 @@ public class BuildEntityUrlHelper implements HandlebarsHelper {
           // TEAM: /settings/members/teams/{fqn}
           buildUrl(baseUrl, "settings/members/teams", fqn, "");
           case Entity.EVENT_SUBSCRIPTION ->
-          // EVENT_SUBSCRIPTION: /settings/notifications/alert/{name}/configuration
-          buildUrl(baseUrl, "settings/notifications/alert", fqn, "configuration");
+          // EVENT_SUBSCRIPTION: /settings/notifications/alerts/{name}/configuration
+          buildUrl(baseUrl, "settings/notifications/alerts", fqn, "configuration");
           case Entity.KPI ->
           // KPI: /data-insights/kpi/edit-kpi/{name}
           buildUrl(baseUrl, "data-insights/kpi/edit-kpi", fqn, "");
@@ -300,45 +299,20 @@ public class BuildEntityUrlHelper implements HandlebarsHelper {
   }
 
   /**
-   * Builds URL for query entities
-   * Redirects to the table's queries tab with query parameters
-   * Format: /table/{tableFqn}/table_queries?tableId={tableId}&query={queryId}&queryFrom=1
+   * Builds URL for query entities. Always routes to the standalone Query page
+   * (QUERY_FULL_SCREEN_VIEW = /query-view/{fqn}/{queryId}), which loads the query by id and
+   * already resolves its own parent-table context from the loaded entity's queryUsedIn field.
+   * Using a single shape avoids the previous bug where missing queryUsedIn produced a null URL
+   * and the email template rendered {@code <a href="">…</a>}.
    */
-  @SuppressWarnings("unchecked")
   private String buildQueryUrl(String baseUrl, Map<String, Object> entityMap) {
     try {
+      String queryFqn = getTrimmed(entityMap, KEY_FQN).orElse("");
       String queryId = getTrimmed(entityMap, KEY_ID).orElse("");
-      if (queryId.isEmpty()) {
+      if (queryId.isEmpty() || queryFqn.isEmpty()) {
         return null;
       }
-
-      Object queryUsedInObj = entityMap.get(KEY_QUERY_USED_IN);
-      if (!(queryUsedInObj instanceof List<?> queryUsedInList)) {
-        return null;
-      }
-
-      if (queryUsedInList.isEmpty()) {
-        return null;
-      }
-
-      Object firstTableObj = queryUsedInList.getFirst();
-      if (!(firstTableObj instanceof Map)) {
-        return null;
-      }
-
-      Map<String, Object> tableRefMap = (Map<String, Object>) firstTableObj;
-      String tableFqn = getTrimmed(tableRefMap, KEY_FQN).orElse("");
-      String tableId = getTrimmed(tableRefMap, KEY_ID).orElse("");
-
-      if (tableFqn.isEmpty() || tableId.isEmpty()) {
-        return null;
-      }
-
-      // Build URL: /table/{tableFqn}/table_queries?tableId={tableId}&query={queryId}&queryFrom=1
-      String encodedTableFqn = encodeEntityFqnSafe(tableFqn);
-      return String.format(
-          "%s/table/%s/table_queries?tableId=%s&query=%s&queryFrom=1",
-          baseUrl, encodedTableFqn, tableId, queryId);
+      return String.format("%s/query-view/%s/%s", baseUrl, encodeEntityFqnSafe(queryFqn), queryId);
     } catch (Exception e) {
       LOG.error("Error building query URL", e);
       return null;

--- a/openmetadata-service/src/test/java/org/openmetadata/service/notifications/template/handlebars/helpers/BuildEntityUrlHelperTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/notifications/template/handlebars/helpers/BuildEntityUrlHelperTest.java
@@ -1,0 +1,200 @@
+/*
+ *  Copyright 2026 Collate
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.openmetadata.service.notifications.template.handlebars.helpers;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.github.jknack.handlebars.EscapingStrategy;
+import com.github.jknack.handlebars.Handlebars;
+import com.github.jknack.handlebars.Template;
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.openmetadata.service.Entity;
+
+/**
+ * Focused unit tests for {@link BuildEntityUrlHelper}. Renders the helper through a real
+ * Handlebars instance configured exactly like {@code HandlebarsProvider} (HTML_ENTITY escaping
+ * strategy) and overrides {@code getBaseUrl()} so the tests do not depend on {@code EmailUtil} or
+ * any DB-backed settings.
+ *
+ * <p>Reproduces the two notification-link regressions reported in
+ * https://github.com/open-metadata/OpenMetadata/issues/27918:
+ * <ul>
+ *   <li>EVENT_SUBSCRIPTION links pointed at the singular {@code /settings/notifications/alert/}
+ *       (404) instead of the actual UI route {@code /settings/notifications/alerts/}.
+ *   <li>Query entities produced {@code <a href="">…</a>} whenever the entity payload had no
+ *       {@code queryUsedIn}, which most mail clients render as plain text. The helper now
+ *       always emits the standalone {@code /query-view/{queryFqn}/{queryId}} route, which the
+ *       Query page resolves by id regardless of the FQN segment.
+ * </ul>
+ */
+class BuildEntityUrlHelperTest {
+
+  private static final String BASE_URL = "http://localhost:8585";
+  private static final String TEMPLATE_SRC =
+      "<a href=\"{{buildEntityUrl event.entityType entity}}\">link</a>";
+
+  private Template template;
+
+  @BeforeEach
+  void setUp() throws IOException {
+    Handlebars handlebars = new Handlebars().with(EscapingStrategy.HTML_ENTITY);
+    new BuildEntityUrlHelper() {
+      @Override
+      protected String getBaseUrl() {
+        return BASE_URL;
+      }
+    }.register(handlebars);
+    template = handlebars.compileInline(TEMPLATE_SRC);
+  }
+
+  private String render(String entityType, Map<String, Object> entity) throws IOException {
+    Map<String, Object> ctx = Map.of("event", Map.of("entityType", entityType), "entity", entity);
+    return template.apply(ctx);
+  }
+
+  private String extractHref(String rendered) {
+    int start = rendered.indexOf("href=\"") + 6;
+    int end = rendered.indexOf('"', start);
+    String escaped = rendered.substring(start, end);
+    // The HTML_ENTITY escaping strategy encodes &, = and / inside attribute values; undo that so
+    // assertions can talk about the URL itself rather than its HTML-encoded form.
+    return escaped.replace("&amp;", "&").replace("&#x3D;", "=").replace("&#x2F;", "/");
+  }
+
+  @Test
+  void eventSubscription_usesPluralAlertsPath() throws IOException {
+    Map<String, Object> entity =
+        Map.of(
+            "id", UUID.randomUUID().toString(),
+            "fullyQualifiedName", "OpenMetadata_alert_27918",
+            "name", "OpenMetadata_alert_27918");
+
+    String url = extractHref(render(Entity.EVENT_SUBSCRIPTION, entity));
+
+    assertNotNull(url, "EVENT_SUBSCRIPTION URL must not be null");
+    assertTrue(
+        url.contains("/settings/notifications/alerts/"),
+        () -> "Expected plural 'alerts' segment but got: " + url);
+    assertFalse(
+        url.matches(".*/settings/notifications/alert/.*"),
+        () -> "URL still contains the broken singular 'alert' segment: " + url);
+    assertTrue(url.endsWith("/configuration"), () -> "Expected /configuration suffix: " + url);
+  }
+
+  @Test
+  void query_withEmptyQueryUsedIn_producesQueryViewUrl() throws IOException {
+    String queryId = UUID.randomUUID().toString();
+    String queryFqn = "DWH.test_query_27918";
+    Map<String, Object> entity =
+        Map.of(
+            "id",
+            queryId,
+            "fullyQualifiedName",
+            queryFqn,
+            "name",
+            "test_query_27918",
+            "queryUsedIn",
+            List.of());
+
+    String url = extractHref(render(Entity.QUERY, entity));
+
+    assertFalse(
+        url.isEmpty(),
+        "Query must produce a non-empty href (otherwise renders <a href=\"\">, which mail"
+            + " clients display as plain text)");
+    assertEquals(BASE_URL + "/query-view/" + queryFqn + "/" + queryId, url);
+  }
+
+  @Test
+  void query_withoutQueryUsedInField_producesQueryViewUrl() throws IOException {
+    String queryId = UUID.randomUUID().toString();
+    String queryFqn = "DWH.test_query_no_field";
+    Map<String, Object> entity =
+        Map.of(
+            "id", queryId,
+            "fullyQualifiedName", queryFqn,
+            "name", "test_query_no_field");
+
+    String url = extractHref(render(Entity.QUERY, entity));
+
+    assertEquals(BASE_URL + "/query-view/" + queryFqn + "/" + queryId, url);
+  }
+
+  @Test
+  void query_withQueryUsedIn_stillProducesQueryViewUrl() throws IOException {
+    // Even when the query has an attached table, the helper now emits the standalone
+    // /query-view URL (the Query page resolves its own table context from queryUsedIn).
+    String queryId = UUID.randomUUID().toString();
+    String queryFqn = "DWH.attached_query";
+    String tableFqn = "sample_data.ecommerce_db.shopify.raw_product_catalog";
+
+    Map<String, Object> entity =
+        Map.of(
+            "id",
+            queryId,
+            "fullyQualifiedName",
+            queryFqn,
+            "name",
+            "attached_query",
+            "queryUsedIn",
+            List.of(
+                Map.of(
+                    "id",
+                    UUID.randomUUID().toString(),
+                    "type",
+                    "table",
+                    "fullyQualifiedName",
+                    tableFqn,
+                    "name",
+                    "raw_product_catalog")));
+
+    String url = extractHref(render(Entity.QUERY, entity));
+
+    assertEquals(BASE_URL + "/query-view/" + queryFqn + "/" + queryId, url);
+  }
+
+  @Test
+  void glossaryTerm_usesGlossaryPath() throws IOException {
+    Map<String, Object> entity =
+        Map.of(
+            "id", UUID.randomUUID().toString(),
+            "fullyQualifiedName", "MyGlossary.MyTerm",
+            "name", "MyTerm");
+
+    String url = extractHref(render(Entity.GLOSSARY_TERM, entity));
+
+    assertEquals(BASE_URL + "/glossary/MyGlossary.MyTerm", url);
+  }
+
+  @Test
+  void defaultEntity_buildsByEntityTypeAndFqn() throws IOException {
+    Map<String, Object> entity =
+        Map.of(
+            "id", UUID.randomUUID().toString(),
+            "fullyQualifiedName", "service.db.schema.users",
+            "name", "users");
+
+    String url = extractHref(render("table", entity));
+
+    assertEquals(BASE_URL + "/table/service.db.schema.users", url);
+  }
+}

--- a/openmetadata-service/src/test/java/org/openmetadata/service/notifications/template/handlebars/helpers/NotificationTemplateHelperAdvancedTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/notifications/template/handlebars/helpers/NotificationTemplateHelperAdvancedTest.java
@@ -108,7 +108,7 @@ class NotificationTemplateHelperAdvancedTest {
             + "https://openmetadata.example/tags/PII|"
             + "https://openmetadata.example/service/databaseServices/service.sales/ingestions|"
             + "https://openmetadata.example/table/service.sales.orders/profiler?activeTab=Data%20Quality|"
-            + "https://openmetadata.example/table/service.sales.orders/table_queries?tableId=table-id&query=query-id&queryFrom=1",
+            + "https://openmetadata.example/query-view/service.sales.orders.top_queries/query-id",
         compact(rendered));
   }
 


### PR DESCRIPTION
Fixes [#27918](https://github.com/open-metadata/OpenMetadata/issues/27918).

## What the user reported

After upgrading to 1.12.1, email notifications had two problems:

1. **Alert links 404'd.** Generated URLs pointed at `…/settings/notifications/alert/<NAME>/configuration` (singular). Manually changing `alert` → `alerts` made the page load.
2. **Some entity links were not clickable.** Specifically, `Query` "created" events rendered as plain text (no working hyperlink) instead of a clickable link.

Both regressions traced to the `BuildEntityUrlHelper` Handlebars helper that templates use to build entity URLs.

## What this PR changes

Two changes in `BuildEntityUrlHelper.java`:

1. **EVENT_SUBSCRIPTION** — emit the plural path the UI actually serves:

    ```diff
    - buildUrl(baseUrl, "settings/notifications/alert",  fqn, "configuration")
    + buildUrl(baseUrl, "settings/notifications/alerts", fqn, "configuration")
    ```

    The React route is `NOTIFICATION_ALERT_DETAILS_WITH_TAB = /settings/${NOTIFICATIONS}/${ALERTS}/${fqn}/${tab}` (`constants.ts:313`), where `ALERTS = 'alerts'` (plural).

2. **QUERY** — always emit the standalone Query page route:

    ```
    /query-view/{queryFqn}/{queryId}
    ```

    Previously the helper had two branches: it tried to build `/table/{tableFqn}/table_queries?…` when the entity had `queryUsedIn`, and otherwise returned `null`. The null path caused templates to render `<a href="">…</a>`, which Gmail and most mail clients display as plain text — that's the user's "not clickable" report.

    The Query page (`QueryPage.component.tsx`) loads the query by `queryId` and already resolves its own parent-table context from the loaded entity's `queryUsedIn` field (rendered as "Query used by other tables" at the bottom). So a single URL shape covers both the attached and unattached cases without needing two branches in the helper.

## How it was verified

- New focused unit tests in `BuildEntityUrlHelperTest` (6 tests, all green). With the fix reverted, 3 fail with assertion messages that name the exact bugs.
- End-to-end capture: SMTP-sink container (Mailpit) hooked into a local dev stack; created an EventSubscription alert; before/after emails captured in the same inbox:
    - **Before:** `href="http://localhost:8585/settings/notifications/alert/test-…/configuration"` (404s)
    - **After:** `href="http://localhost:8585/settings/notifications/alerts/test-…/configuration"` (loads)
- For the Query route: manually navigated to the new `/query-view/{queryFqn}/{queryId}` URL in the running stack — the Query page renders the SQL and shows the "Query used by other tables" link.

## Files touched

- `openmetadata-service/src/main/java/.../helpers/BuildEntityUrlHelper.java`
- `openmetadata-service/src/test/java/.../helpers/BuildEntityUrlHelperTest.java` (new — 6 focused tests; overrides `getBaseUrl()` so it does not need DB-backed settings)