### PR TITLE
fix(snowflake): log discovered databases and filter-out reasons

### DIFF
--- a/ingestion/src/metadata/ingestion/source/database/snowflake/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/database/snowflake/metadata.py
@@ -387,8 +387,10 @@ class SnowflakeSource(
         results = self.connection.execute(text(SNOWFLAKE_GET_DATABASES)).fetchall()
         database_names = [list(res)[1] for res in results]
         logger.info(
-            f"SHOW DATABASES returned {len(database_names)} database(s) visible to the ingestion role: {database_names}"
+            "SHOW DATABASES returned %d database(s) visible to the ingestion role",
+            len(database_names),
         )
+        logger.debug("Databases visible to the ingestion role: %s", database_names)
         yield from database_names
 
     def get_database_names(self) -> Iterable[str]:
@@ -412,15 +414,19 @@ class SnowflakeSource(
                     database_name=new_database,
                 )
 
-                filter_name = database_fqn if self.source_config.useFqnForFiltering else new_database
+                filter_name: str = (
+                    database_fqn if self.source_config.useFqnForFiltering and database_fqn else new_database
+                )
                 if filter_by_database(
                     self.source_config.databaseFilterPattern,
                     filter_name,
                 ):
                     logger.info(
-                        f"Filtering out database '{new_database}': did not pass "
-                        f"databaseFilterPattern (matched against '{filter_name}', "
-                        f"useFqnForFiltering={self.source_config.useFqnForFiltering})"
+                        "Filtering out database '%s': did not pass databaseFilterPattern "
+                        "(matched against '%s', useFqnForFiltering=%s)",
+                        new_database,
+                        filter_name,
+                        self.source_config.useFqnForFiltering,
                     )
                     self.status.filter(database_fqn, "Database Filtered Out")
                     continue

--- a/ingestion/src/metadata/ingestion/source/database/snowflake/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/database/snowflake/metadata.py
@@ -385,9 +385,11 @@ class SnowflakeSource(
 
     def get_database_names_raw(self) -> Iterable[str]:
         results = self.connection.execute(text(SNOWFLAKE_GET_DATABASES)).fetchall()
-        for res in results:
-            row = list(res)
-            yield row[1]
+        database_names = [list(res)[1] for res in results]
+        logger.info(
+            f"SHOW DATABASES returned {len(database_names)} database(s) visible to the ingestion role: {database_names}"
+        )
+        yield from database_names
 
     def get_database_names(self) -> Iterable[str]:
         configured_db = self.config.serviceConnection.root.config.database  # pyright: ignore[reportAttributeAccessIssue]
@@ -410,10 +412,16 @@ class SnowflakeSource(
                     database_name=new_database,
                 )
 
+                filter_name = database_fqn if self.source_config.useFqnForFiltering else new_database
                 if filter_by_database(
                     self.source_config.databaseFilterPattern,
-                    (database_fqn if self.source_config.useFqnForFiltering else new_database),
+                    filter_name,
                 ):
+                    logger.info(
+                        f"Filtering out database '{new_database}': did not pass "
+                        f"databaseFilterPattern (matched against '{filter_name}', "
+                        f"useFqnForFiltering={self.source_config.useFqnForFiltering})"
+                    )
                     self.status.filter(database_fqn, "Database Filtered Out")
                     continue
 


### PR DESCRIPTION
## Problem

When a Snowflake ingestion surfaces fewer databases than expected, the
logs give no way to tell *why*:

- `get_database_names_raw` runs `SHOW DATABASES` but never logs the
  result. `SHOW DATABASES` is scoped to what the ingestion role can see,
  so a database missing here points to a privilege or data-share gap on
  the role — invisible today.
- Filtered databases are recorded via `status.filter()`, which only
  appends to the status summary (truncated for display). There is no
  live log line and no indication of *which* pattern matched or whether
  FQN-based filtering was in effect.

The result is indistinguishable outcomes: "Snowflake never returned it"
vs "we returned it and filtered it out" look identical in the logs.

## Change

- `get_database_names_raw`: log the `SHOW DATABASES` result at INFO
  (count + names), labelled as the set visible to the ingestion role.
- `get_database_names`: when a database is filtered out, log at INFO the
  database name, the value matched against `databaseFilterPattern`, and
  the `useFqnForFiltering` setting. Pulled the FQN-vs-name expression
  into a `filter_name` local so the same value feeds the filter call and
  the log.

No behavioural change — purely additional observability. `status.filter()`
is retained so the status summary and UI are unaffected.

## Example logs

```
SHOW DATABASES returned 12 database(s) visible to the ingestion role: ['DB_A', 'DB_B', ...]
Filtering out database 'DB_X': did not pass databaseFilterPattern (matched against 'DB_X', useFqnForFiltering=False)
```

## Testing

- `ruff check` / `ruff format` clean (line-length 120)
- `py_compile` passes
