### PR TITLE
fix(e2e): fix flaky test case export download capture in Playwright

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/testCases.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/testCases.ts
@@ -342,6 +342,8 @@ export const navigateToGlobalDataQuality = async (page: Page) => {
  * @returns Download object from Playwright
  */
 export const performTestCaseExport = async (page: Page) => {
+  const downloadPromise = page.waitForEvent('download');
+
   await expect(page.getByTestId('export-button')).toBeVisible();
   await page.getByTestId('export-button').click();
   await page.locator('#export-form').waitFor({
@@ -349,8 +351,6 @@ export const performTestCaseExport = async (page: Page) => {
   });
   await expect(page.locator('#export-form')).toBeVisible();
   await expect(page.locator('#submit-button')).not.toBeDisabled();
-
-  const downloadPromise = page.waitForEvent('download');
   await page.locator('#submit-button').click();
   const download = await downloadPromise;
 


### PR DESCRIPTION
## Why

The `performTestCaseExport` Playwright utility was registering `page.waitForEvent('download')` *after* several `await` assertions, creating a narrow but real race window.

### Root cause

Test case export always takes the **async path**: the frontend calls `/exportAsync`, receives a `jobId`, then waits for a WebSocket `COMPLETED` message. When that arrives, `handleCSVExportSuccess` calls `downloadFile`, which programmatically clicks a hidden `<a download href="blob:...">` element to trigger the file download.

`page.waitForEvent('download')` issues an async CDP command to enable Playwright's blob-download capture. For a freshly created table with no test cases the export job completes almost instantly. The WebSocket `COMPLETED` — and the resulting `link.click()` — can fire before that CDP command finishes. When Playwright's download behavior is still in "deny" mode at that moment, Chromium treats the blob-URL click as a same-page navigation instead of a file download, closing the page context:

```
Error: page.waitForEvent: Target page, context or browser has been closed
waiting for event "download"
```

This explains the 8/10 pass rate: the race is only lost when the export job is fast enough to beat Playwright's async CDP setup.

## What changed

Moved `page.waitForEvent('download')` to the **very top** of `performTestCaseExport`, before any click actions. The multiple `await` calls that follow (visibility checks, form wait, button-state assertion) give Playwright ample time to complete its CDP download-capture configuration before the submit click — and therefore before any WebSocket response — can arrive.

```ts
// Before — race-prone
await expect(page.locator('#submit-button')).not.toBeDisabled();
const downloadPromise = page.waitForEvent('download'); // ← too late
await page.locator('#submit-button').click();

// After — race-free
const downloadPromise = page.waitForEvent('download'); // ← registered first
await expect(page.getByTestId('export-button')).toBeVisible();
await page.getByTestId('export-button').click();
// ... awaits give CDP time to finish configuring ...
await page.locator('#submit-button').click();
```

## Test plan

- [ ] Run `should export test cases from Data Quality tab` 10+ times — should pass consistently
- [ ] Verify no other export-related Playwright tests are affected