### PR TITLE
chore(security): pin tools.jackson 3.1.3 BOM to clear jsonschema2pojo transitive CVEs [1.13]

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -243,6 +243,17 @@
         <artifactId>jackson-module-blackbird</artifactId>
         <version>${jackson.version}</version>
       </dependency>
+      <!-- Jackson 3.x BOM — overrides the 3.0.2 chain that jsonschema2pojo-core
+           pulls in (GHSA-72hv-8253-57qq, CVE-2026-29062, GHSA-2m67-wjpj-xhg9).
+           jsonschema2pojo-core is scope=provided in common/pom.xml, but Snyk's
+           Maven scanner still walks the provided tree, so pin the safe line. -->
+      <dependency>
+        <groupId>tools.jackson</groupId>
+        <artifactId>jackson-bom</artifactId>
+        <version>3.1.3</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
       <dependency>
         <groupId>io.dropwizard</groupId>
         <artifactId>dropwizard-core</artifactId>


### PR DESCRIPTION
Backport of #28277 to the 1.13 release branch.

## Summary

Pins `tools.jackson:jackson-bom 3.1.3` in the root `<dependencyManagement>` to override the vulnerable 3.0.2 chain that `jsonschema2pojo-core 1.3.1` pulls in transitively.

## Root cause

`jsonschema2pojo-core 1.3.1`'s parent pom hard-pins `jackson3.version=3.0.2`, dragging in:

- `tools.jackson.core:jackson-core@3.0.2`
- `tools.jackson.core:jackson-databind@3.0.2`

`common/pom.xml` already marks `jsonschema2pojo-core` as `<scope>provided</scope>` to keep it out of runtime/dist packaging — but **Snyk's Maven scanner walks the provided tree** and flags 3 highs in `org.open-metadata:common`:

| ID | Title |
|----|----|
| GHSA-72hv-8253-57qq | Allocation of Resources Without Limits or Throttling |
| CVE-2026-29062 | Allocation of Resources Without Limits or Throttling |
| GHSA-2m67-wjpj-xhg9 | Allocation of Resources Without Limits or Throttling |

Importing `tools.jackson:jackson-bom 3.1.3` first in our depMgmt makes our pin win over `jsonschema2pojo-parent`'s transitive depMgmt.

## Verification

`mvn dependency:tree -pl common -am -Dincludes=tools.jackson.core` after the change:

```
[INFO] org.open-metadata:common:jar:1.13.0-SNAPSHOT
[INFO] \- org.jsonschema2pojo:jsonschema2pojo-core:jar:1.3.1:provided
[INFO]    \- tools.jackson.core:jackson-databind:jar:3.1.3:provided
[INFO]       \- tools.jackson.core:jackson-core:jar:3.1.3:provided
```

## No new transitive deps introduced

Importing `tools.jackson:jackson-bom 3.1.3` only overrides the version of artifacts that were already on the classpath (via the same `jackson3.version=3.0.2` chain from `jsonschema2pojo-parent`). No new modules pulled in — every change in the resolved tree is a version bump on an artifact already present.

## New version safety (Sonatype OSS Index)

| Artifact | Version | Critical | High | Medium | Low |
|----|----|----|----|----|----|
| `tools.jackson.core:jackson-core` | 3.1.3 | 0 | 0 | 0 | 0 |
| `tools.jackson.core:jackson-databind` | 3.1.3 | 0 | 0 | 0 | 0 |

3.1.3 is the latest non-vulnerable line published by FasterXML.

Sources:
- https://guide.sonatype.com/component/maven/tools.jackson.core%3Ajackson-core/3.1.3
- https://guide.sonatype.com/component/maven/tools.jackson.core%3Ajackson-databind/3.1.3

## Test plan

- [ ] CI: `mvn clean install -DskipTests`
- [ ] Snyk re-scan on 1.13 shows the three `tools.jackson.core` highs cleared