### PR TITLE
fix(object-storage): remove legacy Azure config and validate provider

### DIFF
--- a/.github/workflows/integration-tests-mysql-elasticsearch.yml
+++ b/.github/workflows/integration-tests-mysql-elasticsearch.yml
@@ -25,6 +25,7 @@ on:
       - "common/**"
       - "pom.xml"
       - "bootstrap/**"
+      - "conf/**"
   pull_request_target:
     types: [labeled, opened, synchronize, reopened, ready_for_review]
 
@@ -59,6 +60,7 @@ jobs:
               - 'common/**'
               - 'pom.xml'
               - 'bootstrap/**'
+              - 'conf/**'
 
   integration-tests-mysql-elasticsearch:
     needs: changes

--- a/.github/workflows/integration-tests-postgres-elasticsearch-redis.yml
+++ b/.github/workflows/integration-tests-postgres-elasticsearch-redis.yml
@@ -37,6 +37,7 @@ on:
       - "common/**"
       - "pom.xml"
       - "bootstrap/**"
+      - "conf/**"
   # `pull_request_target` is intentional and required so the workflow runs against PRs from
   # forks (which `pull_request` cannot for security reasons). The `safe to test` label gate
   # below is what makes this safe — see security note in the file header.
@@ -74,6 +75,7 @@ jobs:
               - 'common/**'
               - 'pom.xml'
               - 'bootstrap/**'
+              - 'conf/**'
 
   integration-tests-postgres-elasticsearch-redis:
     needs: changes

--- a/.github/workflows/integration-tests-postgres-opensearch.yml
+++ b/.github/workflows/integration-tests-postgres-opensearch.yml
@@ -25,6 +25,7 @@ on:
       - "common/**"
       - "pom.xml"
       - "bootstrap/**"
+      - "conf/**"
   pull_request_target:
     types: [labeled, opened, synchronize, reopened, ready_for_review]
 
@@ -59,6 +60,7 @@ jobs:
               - 'common/**'
               - 'pom.xml'
               - 'bootstrap/**'
+              - 'conf/**'
 
   integration-tests-postgres-opensearch:
     needs: changes

--- a/.github/workflows/maven-build-collate.yml
+++ b/.github/workflows/maven-build-collate.yml
@@ -32,6 +32,7 @@ on:
       - "yarn.lock"
       - "Makefile"
       - "bootstrap/**"
+      - "conf/**"
   pull_request_target:
     types: [opened, synchronize, labeled, ready_for_review]
     paths:
@@ -43,6 +44,7 @@ on:
       - "openmetadata-spec/src/main/resources/json/schema/**"
       - "openmetadata-integration-tests/**"
       - "openmetadata-mcp/**"
+      - "conf/**"
 
 permissions:
   contents: read

--- a/.github/workflows/maven-sonar-build.yml
+++ b/.github/workflows/maven-sonar-build.yml
@@ -26,6 +26,7 @@ on:
       - "yarn.lock"
       - "Makefile"
       - "bootstrap/**"
+      - "conf/**"
 
 permissions:
   contents: read

--- a/.github/workflows/openmetadata-service-unit-tests.yml
+++ b/.github/workflows/openmetadata-service-unit-tests.yml
@@ -61,6 +61,7 @@ jobs:
               - 'pom.xml'
               - 'Makefile'
               - 'bootstrap/**'
+              - 'conf/**'
             k8s_operator:
               - 'openmetadata-k8s-operator/**'
 

--- a/openmetadata-service/src/main/java/org/openmetadata/service/config/AzureConfiguration.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/config/AzureConfiguration.java
@@ -1,11 +1,9 @@
 package org.openmetadata.service.config;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import jakarta.validation.constraints.AssertTrue;
 import jakarta.validation.constraints.NotBlank;
 import lombok.Getter;
 import lombok.Setter;
-import org.apache.commons.lang3.StringUtils;
 
 @Getter
 @Setter
@@ -44,20 +42,4 @@ public class AzureConfiguration {
 
   @JsonProperty("blobEndpoint")
   private String blobEndpoint;
-
-  @AssertTrue(
-      message =
-          "Either useManagedIdentity must be true, or a connectionString must be provided, "
-              + "or all service principal details (clientId, tenantId, clientSecret) must be provided")
-  public boolean isValidAzureCredentials() {
-    if (useManagedIdentity) {
-      return true;
-    } else if (StringUtils.isNotBlank(connectionString)) {
-      return true;
-    } else {
-      return StringUtils.isNotBlank(clientId)
-          && StringUtils.isNotBlank(tenantId)
-          && StringUtils.isNotBlank(clientSecret);
-    }
-  }
 }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/config/AzureConfiguration.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/config/AzureConfiguration.java
@@ -13,6 +13,31 @@ public class AzureConfiguration {
   @NotBlank(message = "Container name must be provided")
   private String containerName;
 
+  /**
+   * Deprecated Azure credential fields are retained only so existing YAML files
+   * continue to deserialize while asset uploads authenticate through
+   * DefaultAzureCredential.
+   */
+  @Deprecated
+  @JsonProperty("connectionString")
+  private String connectionString;
+
+  @Deprecated
+  @JsonProperty("useManagedIdentity")
+  private boolean useManagedIdentity;
+
+  @Deprecated
+  @JsonProperty("clientId")
+  private String clientId;
+
+  @Deprecated
+  @JsonProperty("tenantId")
+  private String tenantId;
+
+  @Deprecated
+  @JsonProperty("clientSecret")
+  private String clientSecret;
+
   @JsonProperty("cdnUrl")
   private String cdnUrl;
 

--- a/openmetadata-service/src/main/java/org/openmetadata/service/config/AzureConfiguration.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/config/AzureConfiguration.java
@@ -1,7 +1,6 @@
 package org.openmetadata.service.config;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import jakarta.validation.constraints.NotBlank;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -10,7 +9,6 @@ import lombok.Setter;
 public class AzureConfiguration {
 
   @JsonProperty("containerName")
-  @NotBlank(message = "Container name must be provided")
   private String containerName;
 
   /**

--- a/openmetadata-service/src/main/java/org/openmetadata/service/config/AzureConfiguration.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/config/AzureConfiguration.java
@@ -13,21 +13,6 @@ public class AzureConfiguration {
   @NotBlank(message = "Container name must be provided")
   private String containerName;
 
-  @JsonProperty("connectionString")
-  private String connectionString;
-
-  @JsonProperty("useManagedIdentity")
-  private boolean useManagedIdentity = false;
-
-  @JsonProperty("clientId")
-  private String clientId;
-
-  @JsonProperty("tenantId")
-  private String tenantId;
-
-  @JsonProperty("clientSecret")
-  private String clientSecret;
-
   @JsonProperty("cdnUrl")
   private String cdnUrl;
 

--- a/openmetadata-service/src/main/java/org/openmetadata/service/config/ObjectStorageConfiguration.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/config/ObjectStorageConfiguration.java
@@ -27,10 +27,15 @@ public class ObjectStorageConfiguration {
   @JsonProperty("azure")
   private AzureConfiguration azureConfiguration;
 
+  @AssertTrue(message = "Object storage provider must be configured when object storage is enabled")
+  public boolean isProviderConfigured() {
+    return !enabled || StringUtils.isNotBlank(provider);
+  }
+
   @AssertTrue(
       message = "Object storage provider must be one of: s3, azure, inmemory, in-memory, noop")
   public boolean isValidProvider() {
-    if (!enabled) {
+    if (!enabled || StringUtils.isBlank(provider)) {
       return true;
     }
     return switch (normalizedProvider()) {

--- a/openmetadata-service/src/main/java/org/openmetadata/service/config/ObjectStorageConfiguration.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/config/ObjectStorageConfiguration.java
@@ -17,9 +17,7 @@ public class ObjectStorageConfiguration {
   @JsonProperty("maxFileSize")
   private long maxFileSize = 5 * 1024 * 1024; // 5MB in bytes
 
-  /**
-   * Provider can be "s3", "azure", or "noop" (for local testing).
-   */
+  /** Provider can be "s3", "azure", "inmemory", "in-memory", or "noop". */
   @JsonProperty("provider")
   private String provider;
 

--- a/openmetadata-service/src/main/java/org/openmetadata/service/config/ObjectStorageConfiguration.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/config/ObjectStorageConfiguration.java
@@ -1,10 +1,11 @@
 package org.openmetadata.service.config;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import jakarta.validation.Valid;
-import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.AssertTrue;
+import java.util.Locale;
 import lombok.Getter;
 import lombok.Setter;
+import org.apache.commons.lang3.StringUtils;
 
 @Getter
 @Setter
@@ -20,14 +21,51 @@ public class ObjectStorageConfiguration {
    * Provider can be "s3", "azure", or "noop" (for local testing).
    */
   @JsonProperty("provider")
-  @NotNull
   private String provider;
 
   @JsonProperty("s3")
-  @Valid
   private S3Configuration s3Configuration;
 
   @JsonProperty("azure")
-  @Valid
   private AzureConfiguration azureConfiguration;
+
+  @AssertTrue(
+      message = "Object storage provider must be one of: s3, azure, inmemory, in-memory, noop")
+  public boolean isValidProvider() {
+    if (!enabled) {
+      return true;
+    }
+    return switch (normalizedProvider()) {
+      case "s3", "azure", "inmemory", "in-memory", "noop" -> true;
+      default -> false;
+    };
+  }
+
+  @AssertTrue(
+      message =
+          "S3 configuration requires bucketName, region, and either useIamRole=true or both"
+              + " accessKey and secretKey")
+  public boolean isValidS3Configuration() {
+    if (!enabled || !"s3".equals(normalizedProvider())) {
+      return true;
+    }
+    return s3Configuration != null
+        && StringUtils.isNotBlank(s3Configuration.getBucketName())
+        && StringUtils.isNotBlank(s3Configuration.getRegion())
+        && s3Configuration.isValidCredentials();
+  }
+
+  @AssertTrue(message = "Azure configuration requires containerName and blobEndpoint")
+  public boolean isValidAzureConfiguration() {
+    if (!enabled || !"azure".equals(normalizedProvider())) {
+      return true;
+    }
+    return azureConfiguration != null
+        && StringUtils.isNotBlank(azureConfiguration.getContainerName())
+        && StringUtils.isNotBlank(azureConfiguration.getBlobEndpoint());
+  }
+
+  private String normalizedProvider() {
+    return provider == null ? "" : provider.trim().toLowerCase(Locale.ROOT);
+  }
 }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/config/S3Configuration.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/config/S3Configuration.java
@@ -1,8 +1,6 @@
 package org.openmetadata.service.config;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import jakarta.validation.constraints.AssertTrue;
-import jakarta.validation.constraints.NotBlank;
 import lombok.Getter;
 import lombok.Setter;
 import org.apache.commons.lang3.StringUtils;
@@ -12,11 +10,9 @@ import org.apache.commons.lang3.StringUtils;
 public class S3Configuration {
 
   @JsonProperty("bucketName")
-  @NotBlank(message = "Bucket name must be provided")
   private String bucketName;
 
   @JsonProperty("region")
-  @NotBlank(message = "Region must be provided")
   private String region;
 
   @JsonProperty("accessKey")
@@ -52,8 +48,6 @@ public class S3Configuration {
   @JsonProperty("kmsKeyId")
   private String kmsKeyId;
 
-  @AssertTrue(
-      message = "Either useIamRole must be true or both accessKey and secretKey must be provided")
   public boolean isValidCredentials() {
     if (useIamRole) {
       return true;

--- a/openmetadata-service/src/test/java/org/openmetadata/service/config/ObjectStorageConfigurationTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/config/ObjectStorageConfigurationTest.java
@@ -43,6 +43,65 @@ class ObjectStorageConfigurationTest {
   }
 
   @Test
+  void minioProviderIsRejectedAsUnsupportedProvider() {
+    ObjectStorageConfiguration config = baseConfig("minio");
+
+    Set<ConstraintViolation<ObjectStorageConfiguration>> violations = validate(config);
+
+    assertEquals(1, violations.size());
+    assertEquals(
+        "Object storage provider must be one of: s3, azure, inmemory, in-memory, noop",
+        message(violations));
+  }
+
+  @Test
+  void providerValidationNormalizesWhitespaceAndCase() {
+    ObjectStorageConfiguration config = baseConfig(" S3 ");
+    config.setS3Configuration(s3Config());
+
+    assertTrue(validate(config).isEmpty());
+  }
+
+  @Test
+  void azureProviderRequiresAzureConfiguration() {
+    ObjectStorageConfiguration config = baseConfig("azure");
+
+    Set<ConstraintViolation<ObjectStorageConfiguration>> violations = validate(config);
+
+    assertEquals(1, violations.size());
+    assertEquals(
+        "Azure configuration requires containerName and blobEndpoint", message(violations));
+  }
+
+  @Test
+  void azureProviderRequiresContainerName() {
+    ObjectStorageConfiguration config = baseConfig("azure");
+    AzureConfiguration azureConfiguration =
+        azureConfigWithoutCredentials("https://account.blob.core.windows.net");
+    azureConfiguration.setContainerName("");
+    config.setAzureConfiguration(azureConfiguration);
+
+    Set<ConstraintViolation<ObjectStorageConfiguration>> violations = validate(config);
+
+    assertEquals(1, violations.size());
+    assertEquals(
+        "Azure configuration requires containerName and blobEndpoint", message(violations));
+  }
+
+  @Test
+  void s3ProviderRequiresS3Configuration() {
+    ObjectStorageConfiguration config = baseConfig("s3");
+
+    Set<ConstraintViolation<ObjectStorageConfiguration>> violations = validate(config);
+
+    assertEquals(1, violations.size());
+    assertEquals(
+        "S3 configuration requires bucketName, region, and either useIamRole=true or both"
+            + " accessKey and secretKey",
+        message(violations));
+  }
+
+  @Test
   void disabledObjectStorageSkipsProviderSpecificValidation() {
     ObjectStorageConfiguration config = new ObjectStorageConfiguration();
     config.setEnabled(false);

--- a/openmetadata-service/src/test/java/org/openmetadata/service/config/ObjectStorageConfigurationTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/config/ObjectStorageConfigurationTest.java
@@ -24,7 +24,8 @@ class ObjectStorageConfigurationTest {
   @Test
   void azureProviderUsesDefaultAzureCredentialAndDoesNotRequireLegacyCredentials() {
     ObjectStorageConfiguration config = baseConfig("azure");
-    config.setAzureConfiguration(azureConfigWithoutCredentials("https://account.blob.core.windows.net"));
+    config.setAzureConfiguration(
+        azureConfigWithoutCredentials("https://account.blob.core.windows.net"));
 
     assertTrue(validate(config).isEmpty());
   }
@@ -37,7 +38,8 @@ class ObjectStorageConfigurationTest {
     Set<ConstraintViolation<ObjectStorageConfiguration>> violations = validate(config);
 
     assertEquals(1, violations.size());
-    assertEquals("Azure configuration requires containerName and blobEndpoint", message(violations));
+    assertEquals(
+        "Azure configuration requires containerName and blobEndpoint", message(violations));
   }
 
   @Test

--- a/openmetadata-service/src/test/java/org/openmetadata/service/config/ObjectStorageConfigurationTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/config/ObjectStorageConfigurationTest.java
@@ -1,15 +1,32 @@
+/*
+ *  Copyright 2021 Collate
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
 package org.openmetadata.service.config;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import jakarta.validation.ConstraintViolation;
 import jakarta.validation.Validation;
 import jakarta.validation.Validator;
+import java.io.IOException;
 import java.util.Set;
 import org.junit.jupiter.api.Test;
 
 class ObjectStorageConfigurationTest {
+  private final ObjectMapper yamlMapper = new ObjectMapper(new YAMLFactory());
   private final Validator validator = Validation.buildDefaultValidatorFactory().getValidator();
 
   @Test
@@ -26,6 +43,27 @@ class ObjectStorageConfigurationTest {
     ObjectStorageConfiguration config = baseConfig("azure");
     config.setAzureConfiguration(
         azureConfigWithoutCredentials("https://account.blob.core.windows.net"));
+
+    assertTrue(validate(config).isEmpty());
+  }
+
+  @Test
+  void legacyAzureCredentialFieldsDeserializeButAreNotRequired() throws IOException {
+    ObjectStorageConfiguration config =
+        yamlMapper.readValue(
+            """
+            enabled: true
+            provider: azure
+            azure:
+              containerName: assets
+              blobEndpoint: https://account.blob.core.windows.net
+              connectionString: DefaultEndpointsProtocol=https;AccountName=legacy;AccountKey=key
+              useManagedIdentity: true
+              clientId: legacy-client
+              tenantId: legacy-tenant
+              clientSecret: legacy-secret
+            """,
+            ObjectStorageConfiguration.class);
 
     assertTrue(validate(config).isEmpty());
   }

--- a/openmetadata-service/src/test/java/org/openmetadata/service/config/ObjectStorageConfigurationTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/config/ObjectStorageConfigurationTest.java
@@ -1,0 +1,82 @@
+package org.openmetadata.service.config;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+class ObjectStorageConfigurationTest {
+  private final Validator validator = Validation.buildDefaultValidatorFactory().getValidator();
+
+  @Test
+  void s3ProviderDoesNotValidateAzureCredentials() {
+    ObjectStorageConfiguration config = baseConfig("s3");
+    config.setS3Configuration(s3Config());
+    config.setAzureConfiguration(azureConfigWithoutCredentials("missing-endpoint"));
+
+    assertTrue(validate(config).isEmpty());
+  }
+
+  @Test
+  void azureProviderUsesDefaultAzureCredentialAndDoesNotRequireLegacyCredentials() {
+    ObjectStorageConfiguration config = baseConfig("azure");
+    config.setAzureConfiguration(azureConfigWithoutCredentials("https://account.blob.core.windows.net"));
+
+    assertTrue(validate(config).isEmpty());
+  }
+
+  @Test
+  void azureProviderRequiresBlobEndpoint() {
+    ObjectStorageConfiguration config = baseConfig("azure");
+    config.setAzureConfiguration(azureConfigWithoutCredentials(""));
+
+    Set<ConstraintViolation<ObjectStorageConfiguration>> violations = validate(config);
+
+    assertEquals(1, violations.size());
+    assertEquals("Azure configuration requires containerName and blobEndpoint", message(violations));
+  }
+
+  @Test
+  void disabledObjectStorageSkipsProviderSpecificValidation() {
+    ObjectStorageConfiguration config = new ObjectStorageConfiguration();
+    config.setEnabled(false);
+
+    assertTrue(validate(config).isEmpty());
+  }
+
+  private Set<ConstraintViolation<ObjectStorageConfiguration>> validate(
+      ObjectStorageConfiguration config) {
+    return validator.validate(config);
+  }
+
+  private ObjectStorageConfiguration baseConfig(String provider) {
+    ObjectStorageConfiguration config = new ObjectStorageConfiguration();
+    config.setEnabled(true);
+    config.setProvider(provider);
+    return config;
+  }
+
+  private S3Configuration s3Config() {
+    S3Configuration config = new S3Configuration();
+    config.setBucketName("assets");
+    config.setRegion("us-east-1");
+    config.setAccessKey("access-key");
+    config.setSecretKey("secret-key");
+    return config;
+  }
+
+  private AzureConfiguration azureConfigWithoutCredentials(String blobEndpoint) {
+    AzureConfiguration config = new AzureConfiguration();
+    config.setContainerName("assets");
+    config.setBlobEndpoint(blobEndpoint);
+    return config;
+  }
+
+  private String message(Set<ConstraintViolation<ObjectStorageConfiguration>> violations) {
+    return violations.iterator().next().getMessage();
+  }
+}

--- a/openmetadata-service/src/test/java/org/openmetadata/service/config/ObjectStorageConfigurationTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/config/ObjectStorageConfigurationTest.java
@@ -24,16 +24,19 @@ import jakarta.validation.Validator;
 import java.io.IOException;
 import java.util.Set;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
 
 class ObjectStorageConfigurationTest {
   private final ObjectMapper yamlMapper = new ObjectMapper(new YAMLFactory());
   private final Validator validator = Validation.buildDefaultValidatorFactory().getValidator();
 
   @Test
-  void s3ProviderDoesNotValidateAzureCredentials() {
+  void s3ProviderIgnoresInvalidAzureConfiguration() {
     ObjectStorageConfiguration config = baseConfig("s3");
     config.setS3Configuration(s3Config());
-    config.setAzureConfiguration(azureConfigWithoutCredentials("missing-endpoint"));
+    config.setAzureConfiguration(new AzureConfiguration());
 
     assertTrue(validate(config).isEmpty());
   }
@@ -92,6 +95,20 @@ class ObjectStorageConfigurationTest {
         message(violations));
   }
 
+  @ParameterizedTest
+  @NullAndEmptySource
+  @ValueSource(strings = {" ", "\t"})
+  void enabledObjectStorageRequiresProvider(String provider) {
+    ObjectStorageConfiguration config = baseConfig(provider);
+
+    Set<ConstraintViolation<ObjectStorageConfiguration>> violations = validate(config);
+
+    assertEquals(1, violations.size());
+    assertEquals(
+        "Object storage provider must be configured when object storage is enabled",
+        message(violations));
+  }
+
   @Test
   void providerValidationNormalizesWhitespaceAndCase() {
     ObjectStorageConfiguration config = baseConfig(" S3 ");
@@ -143,6 +160,14 @@ class ObjectStorageConfigurationTest {
   void disabledObjectStorageSkipsProviderSpecificValidation() {
     ObjectStorageConfiguration config = new ObjectStorageConfiguration();
     config.setEnabled(false);
+
+    assertTrue(validate(config).isEmpty());
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"inmemory", "in-memory", "noop"})
+  void localProvidersSkipS3AndAzureConfigurationValidation(String provider) {
+    ObjectStorageConfiguration config = baseConfig(provider);
 
     assertTrue(validate(config).isEmpty());
   }


### PR DESCRIPTION
## Summary
- Move object storage provider validation to `ObjectStorageConfiguration` so only the configured provider is validated.
- Remove the unused legacy Azure object-storage credential fields from `AzureConfiguration`; Azure uploads authenticate through `DefaultAzureCredential` and still require `containerName` plus `blobEndpoint` at config-validation time.
- Keep disabled object storage and local providers (`noop`, `inmemory`, `in-memory`) free of provider-specific validation.
- Add edge-case coverage for unsupported `minio`, provider normalization, missing active-provider config, missing Azure `containerName`, and missing S3 config.
- Add `conf/**` to the backend/Maven CI path filters so config-only changes run service unit tests, Maven/Sonar, Collate dispatch, and backend integration test workflows.

## Root Cause
`AzureConfiguration` had an unconditional Bean Validation assertion for connection string, managed identity, or service principal credentials. That assertion ran even when `objectStorage.provider` was `s3` or another provider, so removing unused Azure credential YAML keys caused config parsing to fail during migrations.

The legacy Azure object-storage credential fields are not used by the runtime upload path. Keeping them in the POJO made the old contract look supported even though runtime auth is handled by the Azure SDK credential chain.

Related collate issue: https://github.com/open-metadata/openmetadata-collate/issues/4193

## Tests
- `mvn spotless:apply && git diff-files --quiet`
- `rtk mvn -pl openmetadata-spec,openmetadata-shaded-deps/elasticsearch-dep,openmetadata-shaded-deps/opensearch-dep -am -DskipTests clean install`
- `rtk mvn -pl openmetadata-service -Dtest=org.openmetadata.service.config.ObjectStorageConfigurationTest test`
- `rtk mvn -pl openmetadata-service -Dtest=org.openmetadata.service.config.LoggingConfigurationYamlTest test`
- `git diff --check`
- `rg -n "conf/\\*\\*" .github/workflows/openmetadata-service-unit-tests.yml .github/workflows/maven-sonar-build.yml .github/workflows/maven-build-collate.yml .github/workflows/integration-tests-mysql-elasticsearch.yml .github/workflows/integration-tests-postgres-opensearch.yml .github/workflows/integration-tests-postgres-elasticsearch-redis.yml`
- `rg -n "connectionString|useManagedIdentity|clientId|tenantId|clientSecret" openmetadata-service/src/main/java/org/openmetadata/service/config/AzureConfiguration.java` (no matches)

Note: after rebasing onto current `main`, the focused service tests need a clean local install of `openmetadata-spec` and the shaded search dependency jars so Maven uses fresh generated schema classes and relocated search clients.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a misconfigured Bean Validation setup where `AzureConfiguration` had an unconditional credential assertion that fired regardless of the active provider, breaking migrations when unused Azure YAML keys were removed. Validation is now consolidated in `ObjectStorageConfiguration` using provider-aware `@AssertTrue` guards.

- **AzureConfiguration**: removed `@AssertTrue isValidAzureCredentials()` and `@NotBlank` on `containerName`; legacy credential fields are retained with `@Deprecated` so existing YAML still deserializes without errors while authentication is handled by `DefaultAzureCredential` at runtime.
- **ObjectStorageConfiguration**: four `@AssertTrue` methods replace the scattered per-class constraints, with a shared `normalizedProvider()` helper (trim + lowercase) so case/whitespace variants like `" S3 "` are handled uniformly; disabled storage and local providers (`noop`, `inmemory`, `in-memory`) skip all provider-specific checks.
- **CI workflows**: `conf/**` added to path filters across six workflow files so config-only changes trigger unit tests, Maven/Sonar, Collate dispatch, and integration test workflows.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change removes a pre-existing incorrect validation that fired for all providers and replaces it with correctly-scoped guards; existing YAML files continue to deserialize cleanly.

The refactoring is well-contained: validation moves from per-class unconditional constraints to a single provider-aware class, the logic is fully exercised by the new test suite covering null provider, whitespace, normalization, unsupported providers, missing sub-configs, disabled storage, and legacy field deserialization.

No files require special attention.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| openmetadata-service/src/main/java/org/openmetadata/service/config/ObjectStorageConfiguration.java | Validation logic consolidated here via @AssertTrue methods; provider-aware guards prevent double-violations and skip disabled storage cleanly. |
| openmetadata-service/src/main/java/org/openmetadata/service/config/AzureConfiguration.java | Removed unconditional @AssertTrue credential check and @NotBlank on containerName; legacy fields retained with @Deprecated so existing YAML still deserializes. |
| openmetadata-service/src/main/java/org/openmetadata/service/config/S3Configuration.java | Removed @NotBlank and @AssertTrue annotations; isValidCredentials() kept as a plain helper called from ObjectStorageConfiguration validation. |
| openmetadata-service/src/test/java/org/openmetadata/service/config/ObjectStorageConfigurationTest.java | New comprehensive test class covering all validation paths: disabled storage, null/blank/whitespace provider, unsupported provider, S3/Azure config missing, normalization, and legacy field deserialization. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[ObjectStorageConfiguration.validate] --> B{enabled?}
    B -- No --> Z[All validations pass]
    B -- Yes --> C{provider blank?}
    C -- Yes --> D[FAIL: provider must be configured]
    C -- No --> E{normalizedProvider valid?}
    E -- No --> F[FAIL: unsupported provider]
    E -- Yes --> G{provider == s3?}
    G -- Yes --> H{s3Configuration valid?}
    H -- No --> I[FAIL: S3 config invalid]
    H -- Yes --> Z
    G -- No --> J{provider == azure?}
    J -- Yes --> K{azureConfiguration valid?}
    K -- No --> L[FAIL: Azure config invalid]
    K -- Yes --> Z
    J -- No --> M[noop/inmemory/in-memory]
    M --> Z
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[ObjectStorageConfiguration.validate] --> B{enabled?}
    B -- No --> Z[All validations pass]
    B -- Yes --> C{provider blank?}
    C -- Yes --> D[FAIL: provider must be configured]
    C -- No --> E{normalizedProvider valid?}
    E -- No --> F[FAIL: unsupported provider]
    E -- Yes --> G{provider == s3?}
    G -- Yes --> H{s3Configuration valid?}
    H -- No --> I[FAIL: S3 config invalid]
    H -- Yes --> Z
    G -- No --> J{provider == azure?}
    J -- Yes --> K{azureConfiguration valid?}
    K -- No --> L[FAIL: Azure config invalid]
    K -- Yes --> Z
    J -- No --> M[noop/inmemory/in-memory]
    M --> Z
```

</a>
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `openmetadata-service/src/main/java/org/openmetadata/service/config/AzureConfiguration.java`, line 12-14 ([link](https://github.com/open-metadata/openmetadata/blob/a1ee979fcf4d9dd0fc2b38f38c6ddaf31fbeb61f/openmetadata-service/src/main/java/org/openmetadata/service/config/AzureConfiguration.java#L12-L14)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Dead `@NotBlank` constraint on `containerName`**

   `@Valid` was removed from the `azureConfiguration` field in `ObjectStorageConfiguration`, so Bean Validation no longer cascades into `AzureConfiguration`. The `@NotBlank` on `containerName` will therefore never fire during `ObjectStorageConfiguration` validation — the enforcement has been fully moved to `ObjectStorageConfiguration.isValidAzureConfiguration()`. Consider removing `@NotBlank` from this field to avoid misleading future readers into thinking it is automatically enforced, or at minimum add a comment explaining that it is only meaningful if the class is validated in isolation.

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (10): Last reviewed commit: ["fix: remove stale S3 validation annotati..."](https://github.com/open-metadata/openmetadata/commit/c7798a18849c6b1ead99a89ae245db2b9eb9c117) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37814646)</sub>

<!-- /greptile_comment -->