### PR TITLE
perf(ui): optimize frontend bundle — lazy imports, code splitting, vendor chunking

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/ActivityFeed/ActivityFeedCard/FeedCardBody/FeedCardBodyNew.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/ActivityFeed/ActivityFeedCard/FeedCardBody/FeedCardBodyNew.tsx
@@ -14,7 +14,7 @@
 import { Button, Card, Typography } from 'antd';
 import classNames from 'classnames';
 import { isUndefined } from 'lodash';
-import { useCallback, useMemo, useState } from 'react';
+import { lazy, Suspense, useCallback, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { ASSET_CARD_STYLES } from '../../../../constants/Feeds.constants';
 import { ActivityEventType } from '../../../../generated/entity/activity/activityEvent';
@@ -32,9 +32,12 @@ import ActivityOwnersFeed from '../../ActivityFeedCardV2/FeedCardBody/OwnerFeed/
 import OwnersFeed from '../../ActivityFeedCardV2/FeedCardBody/OwnerFeed/OwnersFeed';
 import ActivityTagsFeed from '../../ActivityFeedCardV2/FeedCardBody/TagsFeed/ActivityTagsFeed';
 import TagsFeed from '../../ActivityFeedCardV2/FeedCardBody/TagsFeed/TagsFeed';
-import ActivityFeedEditor from '../../ActivityFeedEditor/ActivityFeedEditor';
 import './feed-card-body-v1.less';
 import { FeedCardBodyV1Props } from './FeedCardBodyV1.interface';
+
+const ActivityFeedEditor = lazy(
+  () => import('../../ActivityFeedEditor/ActivityFeedEditor')
+);
 
 const FeedCardBodyNew = ({
   isPost = false,
@@ -158,34 +161,36 @@ const FeedCardBodyNew = ({
   const feedBodyRender = useMemo(() => {
     if (isEditPost) {
       return (
-        <ActivityFeedEditor
-          focused
-          className="mb-8"
-          defaultValue={getDefaultValue(message)}
-          editAction={
-            <div className="d-flex justify-end gap-2 m-r-xss">
-              <Button
-                className="border border-primary text-primary rounded-4"
-                data-testid="cancel-button"
-                size="small"
-                onClick={onEditCancel}>
-                {t('label.cancel')}
-              </Button>
-              <Button
-                className="rounded-4"
-                data-testid="save-button"
-                disabled={!message.length}
-                size="small"
-                type="primary"
-                onClick={handleSave}>
-                {t('label.save')}
-              </Button>
-            </div>
-          }
-          editorClass="is_edit_post"
-          onSave={handleSave}
-          onTextChange={(message) => setPostMessage(message)}
-        />
+        <Suspense fallback={null}>
+          <ActivityFeedEditor
+            focused
+            className="mb-8"
+            defaultValue={getDefaultValue(message)}
+            editAction={
+              <div className="d-flex justify-end gap-2 m-r-xss">
+                <Button
+                  className="border border-primary text-primary rounded-4"
+                  data-testid="cancel-button"
+                  size="small"
+                  onClick={onEditCancel}>
+                  {t('label.cancel')}
+                </Button>
+                <Button
+                  className="rounded-4"
+                  data-testid="save-button"
+                  disabled={!message.length}
+                  size="small"
+                  type="primary"
+                  onClick={handleSave}>
+                  {t('label.save')}
+                </Button>
+              </div>
+            }
+            editorClass="is_edit_post"
+            onSave={handleSave}
+            onTextChange={(message) => setPostMessage(message)}
+          />
+        </Suspense>
       );
     }
 

--- a/openmetadata-ui/src/main/resources/ui/src/components/ActivityFeed/ActivityFeedCardNew/ActivityFeedcardNew.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/ActivityFeed/ActivityFeedCardNew/ActivityFeedcardNew.component.tsx
@@ -14,7 +14,7 @@ import { Card, Col, Input, Skeleton, Space, Tooltip, Typography } from 'antd';
 import classNames from 'classnames';
 import { compare } from 'fast-json-patch';
 import { isUndefined, orderBy } from 'lodash';
-import { useEffect, useMemo, useState } from 'react';
+import { lazy, Suspense, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router-dom';
 import { ASSET_CARD_STYLES } from '../../../constants/Feeds.constants';
@@ -44,10 +44,12 @@ import ProfilePicture from '../../common/ProfilePicture/ProfilePicture';
 import FeedCardBodyNew from '../ActivityFeedCard/FeedCardBody/FeedCardBodyNew';
 import ActivityEventFooter from '../ActivityFeedCardV2/FeedCardFooter/ActivityEventFooter';
 import FeedCardFooterNew from '../ActivityFeedCardV2/FeedCardFooter/FeedCardFooterNew';
-import ActivityFeedEditorNew from '../ActivityFeedEditor/ActivityFeedEditorNew';
 import { useActivityFeedProvider } from '../ActivityFeedProvider/ActivityFeedProvider';
 import '../ActivityFeedTab/activity-feed-tab.less';
 import CommentCard from './CommentCard.component';
+const ActivityFeedEditorNew = lazy(
+  () => import('../ActivityFeedEditor/ActivityFeedEditorNew')
+);
 
 interface ActivityFeedCardNewProps {
   feed?: Thread;
@@ -532,17 +534,19 @@ const ActivityFeedCardNew = ({
             </Typography.Text>
           )}
           {showFeedEditor ? (
-            <ActivityFeedEditorNew
-              className={classNames(
-                'm-t-md feed-editor activity-feed-editor-container-new',
-                {
-                  'm-b-md':
-                    (showActivityFeedEditor && feed?.posts?.length === 0) ||
-                    isOpenInDrawer,
-                }
-              )}
-              onSave={onSave}
-            />
+            <Suspense fallback={null}>
+              <ActivityFeedEditorNew
+                className={classNames(
+                  'm-t-md feed-editor activity-feed-editor-container-new',
+                  {
+                    'm-b-md':
+                      (showActivityFeedEditor && feed?.posts?.length === 0) ||
+                      isOpenInDrawer,
+                  }
+                )}
+                onSave={onSave}
+              />
+            </Suspense>
           ) : (
             <div className="d-flex gap-2">
               <div>

--- a/openmetadata-ui/src/main/resources/ui/src/components/AppRouter/AuthenticatedRoutes.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/AppRouter/AuthenticatedRoutes.tsx
@@ -12,18 +12,37 @@
  */
 
 import { isEmpty } from 'lodash';
+import { lazy } from 'react';
 import { Navigate, Route, Routes } from 'react-router-dom';
 import { useShallow } from 'zustand/react/shallow';
 import { APP_ROUTER_ROUTES } from '../../constants/router.constants';
 import { useApplicationStore } from '../../hooks/useApplicationStore';
-import AccessNotAllowedPage from '../../pages/AccessNotAllowedPage/AccessNotAllowedPage';
-import { LogoutPage } from '../../pages/LogoutPage/LogoutPage';
-import PageNotFound from '../../pages/PageNotFound/PageNotFound';
-import SamlCallback from '../../pages/SamlCallback';
-import SignUpPage from '../../pages/SignUp/SignUpPage';
-import AppContainer from '../AppContainer/AppContainer';
 import { useApplicationsProvider } from '../Settings/Applications/ApplicationsProvider/ApplicationsProvider';
 import { RoutePosition } from '../Settings/Applications/plugins/AppPlugin';
+import withSuspenseFallback from './withSuspenseFallback';
+
+const AccessNotAllowedPage = withSuspenseFallback(
+  lazy(() => import('../../pages/AccessNotAllowedPage/AccessNotAllowedPage'))
+);
+const LogoutPage = withSuspenseFallback(
+  lazy(() =>
+    import('../../pages/LogoutPage/LogoutPage').then((m) => ({
+      default: m.LogoutPage,
+    }))
+  )
+);
+const PageNotFound = withSuspenseFallback(
+  lazy(() => import('../../pages/PageNotFound/PageNotFound'))
+);
+const SamlCallback = withSuspenseFallback(
+  lazy(() => import('../../pages/SamlCallback'))
+);
+const SignUpPage = withSuspenseFallback(
+  lazy(() => import('../../pages/SignUp/SignUpPage'))
+);
+const AppContainer = withSuspenseFallback(
+  lazy(() => import('../AppContainer/AppContainer'))
+);
 
 export const AuthenticatedRoutes = () => {
   const { currentUser } = useApplicationStore(

--- a/openmetadata-ui/src/main/resources/ui/src/components/BlockEditor/Extensions/MathEquation/MathEquationComponent.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/BlockEditor/Extensions/MathEquation/MathEquationComponent.tsx
@@ -16,11 +16,12 @@ import { Button, Input, Space, Tooltip } from 'antd';
 import { TextAreaRef } from 'antd/lib/input/TextArea';
 import classNames from 'classnames';
 import 'katex/dist/katex.min.css';
-import { FC, useRef, useState } from 'react';
+import { FC, lazy, Suspense, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import Latex from 'react-latex-next';
 import { ReactComponent as EditIcon } from '../../../../assets/svg/edit-new.svg';
 import './math-equation.less';
+
+const Latex = lazy(() => import('react-latex-next'));
 
 export const MathEquationComponent: FC<NodeViewProps> = ({
   node,
@@ -75,7 +76,9 @@ export const MathEquationComponent: FC<NodeViewProps> = ({
             </Space>
           </div>
         ) : (
-          <Latex>{equation}</Latex>
+          <Suspense fallback={null}>
+            <Latex>{equation}</Latex>
+          </Suspense>
         )}
         {/* Show edit button only when the editor is editable */}
         {!isEditing && editor.isEditable && (

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataAssets/AssetsSelectionModal/useAssetSelectionContent.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataAssets/AssetsSelectionModal/useAssetSelectionContent.tsx
@@ -68,7 +68,6 @@ import {
 } from '../../../rest/glossaryAPI';
 import { searchQuery } from '../../../rest/searchAPI';
 import { addAssetsToTags, getTagByFqn } from '../../../rest/tagAPI';
-import { getAssetsPageQuickFilters } from '../../../utils/AdvancedSearchUtils';
 import { getDomainDryRunImpacts } from '../../../utils/Domain/DomainDryRunUtils';
 import { getEntityReferenceFromEntity } from '../../../utils/EntityUtils';
 import { getCombinedQueryFilterObject } from '../../../utils/ExplorePage/ExplorePageUtils';
@@ -77,6 +76,7 @@ import {
   getQuickFilterQuery,
 } from '../../../utils/ExploreUtils';
 import { showNotistackError } from '../../../utils/NotistackUtils';
+import { getAssetsPageQuickFilters } from '../../../utils/SearchDropdownUtils';
 import { showErrorToast } from '../../../utils/ToastUtils';
 import Banner from '../../common/Banner/Banner';
 import ErrorPlaceHolder from '../../common/ErrorWithPlaceholder/ErrorPlaceHolder';

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataProducts/InputOutputPortsTab/PortsLineageView/PortsLineageView.types.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataProducts/InputOutputPortsTab/PortsLineageView/PortsLineageView.types.ts
@@ -11,7 +11,7 @@
  *  limitations under the License.
  */
 
-import { NodeProps } from 'reactflow';
+import type { NodeProps } from 'reactflow';
 import { DataProduct } from '../../../../generated/entity/domains/dataProduct';
 import { SearchedDataProps } from '../../../SearchedData/SearchedData.interface';
 

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/DataQualityDashboard/DataQualityDashboard.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/DataQualityDashboard/DataQualityDashboard.component.tsx
@@ -48,7 +48,6 @@ import { EntityReference } from '../../../generated/type/entityReference';
 import { DataQualityPageTabs } from '../../../pages/DataQuality/DataQualityPage.interface';
 import { searchQuery } from '../../../rest/searchAPI';
 import { getTags } from '../../../rest/tagAPI';
-import { getSelectedOptionLabelString } from '../../../utils/AdvancedSearchUtils';
 import {
   formatDate,
   getCurrentMillis,
@@ -58,6 +57,7 @@ import {
 } from '../../../utils/date-time/DateTimeUtils';
 import { getEntityName } from '../../../utils/EntityUtils';
 import observabilityRouterClassBase from '../../../utils/ObservabilityRouterClassBase';
+import { getSelectedOptionLabelString } from '../../../utils/SearchDropdownUtils';
 import DataAssetsCoveragePieChartWidget from '../ChartWidgets/DataAssetsCoveragePieChartWidget/DataAssetsCoveragePieChartWidget.component';
 import EntityHealthStatusPieChartWidget from '../ChartWidgets/EntityHealthStatusPieChartWidget/EntityHealthStatusPieChartWidget.component';
 import IncidentTimeChartWidget from '../ChartWidgets/IncidentTimeChartWidget/IncidentTimeChartWidget.component';

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/DataQualityDashboard/DataQualityDashboard.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/DataQualityDashboard/DataQualityDashboard.test.tsx
@@ -163,7 +163,7 @@ jest.mock('../../../components/SearchDropdown/SearchDropdown', () =>
       </div>
     ))
 );
-jest.mock('../../../utils/AdvancedSearchUtils', () => {
+jest.mock('../../../utils/SearchDropdownUtils', () => {
   return {
     getSelectedOptionLabelString: jest
       .fn()

--- a/openmetadata-ui/src/main/resources/ui/src/components/Entity/EntityInfoDrawer/EntityInfoDrawer.interface.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Entity/EntityInfoDrawer/EntityInfoDrawer.interface.ts
@@ -11,7 +11,7 @@
  *  limitations under the License.
  */
 
-import { Edge, Node } from 'reactflow';
+import type { Edge, Node } from 'reactflow';
 import { AddLineage } from '../../../generated/api/lineage/addLineage';
 import { SourceType } from '../../SearchedData/SearchedData.interface';
 

--- a/openmetadata-ui/src/main/resources/ui/src/components/Entity/EntityLineage/EntityLineage.interface.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Entity/EntityLineage/EntityLineage.interface.ts
@@ -13,7 +13,7 @@
 
 import { LoadingState } from 'Models';
 import { ReactNode } from 'react';
-import { Edge as FlowEdge, Node } from 'reactflow';
+import type { Edge as FlowEdge, Node } from 'reactflow';
 import { LineageDirection } from '../../../generated/api/lineage/lineageDirection';
 import { LineageSettings } from '../../../generated/configuration/lineageSettings';
 import { EntityReference } from '../../../generated/entity/type';

--- a/openmetadata-ui/src/main/resources/ui/src/components/Explore/AdvanceSearchProvider/AdvanceSearchProvider.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Explore/AdvanceSearchProvider/AdvanceSearchProvider.component.tsx
@@ -18,6 +18,7 @@ import {
   OldJsonTree,
   Utils as QbUtils,
 } from '@react-awesome-query-builder/antd';
+import '@react-awesome-query-builder/antd/css/styles.css';
 import { isEmpty, isEqual, isNil, isString } from 'lodash';
 import Qs from 'qs';
 import {

--- a/openmetadata-ui/src/main/resources/ui/src/components/Explore/ExploreQuickFilters.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Explore/ExploreQuickFilters.tsx
@@ -21,13 +21,13 @@ import { SearchIndex } from '../../enums/search.enum';
 import useCustomLocation from '../../hooks/useCustomLocation/useCustomLocation';
 import { useSearchStore } from '../../hooks/useSearchStore';
 import { QueryFilterInterface } from '../../pages/ExplorePage/ExplorePage.interface';
-import { getOptionsFromAggregationBucket } from '../../utils/AdvancedSearchUtils';
 import {
   getCombinedQueryFilterObject,
   getQuickFilterWithDeletedFlag,
 } from '../../utils/ExplorePage/ExplorePageUtils';
 import { getAggregationOptions } from '../../utils/ExploreUtils';
 import { translateWithNestedKeys } from '../../utils/i18next/LocalUtil';
+import { getOptionsFromAggregationBucket } from '../../utils/SearchDropdownUtils';
 import { showErrorToast } from '../../utils/ToastUtils';
 import SearchDropdown from '../SearchDropdown/SearchDropdown';
 import { SearchDropdownOption } from '../SearchDropdown/SearchDropdown.interface';

--- a/openmetadata-ui/src/main/resources/ui/src/components/ExploreV1/ExploreV1.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/ExploreV1/ExploreV1.component.tsx
@@ -58,7 +58,6 @@ import {
   exportSearchResultsCsvStream,
   searchQuery,
 } from '../../rest/searchAPI';
-import { getDropDownItems } from '../../utils/AdvancedSearchUtils';
 import { parseExportErrorMessage } from '../../utils/APIUtils';
 import { highlightEntityNameAndDescription } from '../../utils/EntityUtils';
 import { getCombinedQueryFilterObject } from '../../utils/ExplorePage/ExplorePageUtils';
@@ -67,6 +66,7 @@ import {
   getSelectedValuesFromQuickFilter,
 } from '../../utils/ExploreUtils';
 import searchClassBase from '../../utils/SearchClassBase';
+import { getDropDownItems } from '../../utils/SearchDropdownUtils';
 import FilterErrorPlaceHolder from '../common/ErrorWithPlaceholder/FilterErrorPlaceHolder';
 import Loader from '../common/Loader/Loader';
 import ResizableLeftPanels from '../common/ResizablePanels/ResizableLeftPanels';

--- a/openmetadata-ui/src/main/resources/ui/src/components/ExploreV1/ExploreV1.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/ExploreV1/ExploreV1.test.tsx
@@ -245,7 +245,7 @@ jest.mock('react-i18next', () => ({
   Trans: ({ children }: { children: React.ReactNode }) => <>{children}</>,
 }));
 
-jest.mock('../../utils/AdvancedSearchUtils', () => ({
+jest.mock('../../utils/SearchDropdownUtils', () => ({
   getDropDownItems: jest.fn().mockReturnValue([]),
 }));
 

--- a/openmetadata-ui/src/main/resources/ui/src/components/Glossary/GlossaryTerms/tabs/AssetsTabs.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Glossary/GlossaryTerms/tabs/AssetsTabs.component.tsx
@@ -74,7 +74,6 @@ import {
 } from '../../../../rest/glossaryAPI';
 import { searchQuery } from '../../../../rest/searchAPI';
 import { getTagByFqn, removeAssetsFromTags } from '../../../../rest/tagAPI';
-import { getAssetsPageQuickFilters } from '../../../../utils/AdvancedSearchUtils';
 import { getEntityTypeString } from '../../../../utils/Assets/AssetsUtils';
 import { getDomainDryRunImpacts } from '../../../../utils/Domain/DomainDryRunUtils';
 import {
@@ -87,6 +86,7 @@ import {
   getQuickFilterQuery,
 } from '../../../../utils/ExploreUtils';
 import { translateWithNestedKeys } from '../../../../utils/i18next/LocalUtil';
+import { getAssetsPageQuickFilters } from '../../../../utils/SearchDropdownUtils';
 import { getTermQuery } from '../../../../utils/SearchUtils';
 import {
   escapeESReservedCharacters,

--- a/openmetadata-ui/src/main/resources/ui/src/components/Lineage/Lineage.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Lineage/Lineage.component.tsx
@@ -28,6 +28,8 @@ import ReactFlow, {
   Panel,
   ReactFlowProvider,
 } from 'reactflow';
+import 'reactflow/dist/base.css';
+import 'reactflow/dist/style.css';
 import {
   MAX_ZOOM_VALUE,
   MIN_ZOOM_VALUE,

--- a/openmetadata-ui/src/main/resources/ui/src/components/MyData/Widgets/CuratedAssetsWidget/CuratedAssetsWidget.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/MyData/Widgets/CuratedAssetsWidget/CuratedAssetsWidget.test.tsx
@@ -110,6 +110,9 @@ jest.mock(
 jest.mock(
   '../../../Explore/AdvanceSearchProvider/AdvanceSearchProvider.component',
   () => ({
+    AdvanceSearchProvider: jest
+      .fn()
+      .mockImplementation(({ children }) => children),
     useAdvanceSearch: jest.fn().mockReturnValue({
       config: {},
     }),

--- a/openmetadata-ui/src/main/resources/ui/src/components/MyData/Widgets/CuratedAssetsWidget/CuratedAssetsWidget.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/MyData/Widgets/CuratedAssetsWidget/CuratedAssetsWidget.tsx
@@ -58,7 +58,10 @@ import searchClassBase from '../../../../utils/SearchClassBase';
 import serviceUtilClassBase from '../../../../utils/ServiceUtilClassBase';
 import { showErrorToast } from '../../../../utils/ToastUtils';
 import CertificationTag from '../../../common/CertificationTag/CertificationTag';
-import { useAdvanceSearch } from '../../../Explore/AdvanceSearchProvider/AdvanceSearchProvider.component';
+import {
+  AdvanceSearchProvider,
+  useAdvanceSearch,
+} from '../../../Explore/AdvanceSearchProvider/AdvanceSearchProvider.component';
 import WidgetEmptyState from '../Common/WidgetEmptyState/WidgetEmptyState';
 import WidgetFooter from '../Common/WidgetFooter/WidgetFooter';
 import WidgetHeader from '../Common/WidgetHeader/WidgetHeader';
@@ -70,7 +73,7 @@ import {
   CURATED_ASSETS_SORT_BY_OPTIONS,
 } from './CuratedAssetsWidget.constants';
 
-const CuratedAssetsWidget = ({
+const CuratedAssetsWidgetInner = ({
   isEditView,
   handleRemoveWidget,
   widgetKey,
@@ -504,5 +507,11 @@ const CuratedAssetsWidget = ({
     </>
   );
 };
+
+const CuratedAssetsWidget = (props: WidgetCommonProps) => (
+  <AdvanceSearchProvider isExplorePage={false} updateURL={false}>
+    <CuratedAssetsWidgetInner {...props} />
+  </AdvanceSearchProvider>
+);
 
 export default CuratedAssetsWidget;

--- a/openmetadata-ui/src/main/resources/ui/src/components/NavBar/NavBar.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/NavBar/NavBar.tsx
@@ -26,7 +26,15 @@ import classNames from 'classnames';
 import { CookieStorage } from 'cookie-storage';
 import { startCase, upperCase } from 'lodash';
 import { MenuInfo } from 'rc-menu/lib/interface';
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import {
+  lazy,
+  Suspense,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
 import { ReactComponent as DropDownIcon } from '../../assets/svg/drop-down.svg';
@@ -83,10 +91,13 @@ import DomainSelectableList from '../common/DomainSelectableList/DomainSelectabl
 import { useEntityExportModalProvider } from '../Entity/EntityExportModalProvider/EntityExportModalProvider.component';
 import { CSVExportWebsocketResponse } from '../Entity/EntityExportModalProvider/EntityExportModalProvider.interface';
 import { GlobalSearchBar } from '../GlobalSearchBar/GlobalSearchBar';
-import NotificationBox from '../NotificationBox/NotificationBox.component';
 import { UserProfileIcon } from '../Settings/Users/UserProfileIcon/UserProfileIcon.component';
 import './nav-bar.less';
 import popupAlertsCardsClassBase from './PopupAlertClassBase';
+
+const NotificationBox = lazy(
+  () => import('../NotificationBox/NotificationBox.component')
+);
 
 const cookieStorage = new CookieStorage();
 
@@ -549,16 +560,18 @@ const NavBar = () => {
               destroyPopupOnHide
               className="cursor-pointer"
               dropdownRender={() => (
-                <NotificationBox
-                  activeTab={activeTab}
-                  hasMentionNotification={hasMentionNotification}
-                  hasTaskNotification={hasTaskNotification}
-                  onMarkMentionsNotificationRead={
-                    handleMentionsNotificationRead
-                  }
-                  onMarkTaskNotificationRead={handleTaskNotificationRead}
-                  onTabChange={handleActiveTab}
-                />
+                <Suspense>
+                  <NotificationBox
+                    activeTab={activeTab}
+                    hasMentionNotification={hasMentionNotification}
+                    hasTaskNotification={hasTaskNotification}
+                    onMarkMentionsNotificationRead={
+                      handleMentionsNotificationRead
+                    }
+                    onMarkTaskNotificationRead={handleTaskNotificationRead}
+                    onTabChange={handleActiveTab}
+                  />
+                </Suspense>
               )}
               overlayStyle={{
                 width: '425px',

--- a/openmetadata-ui/src/main/resources/ui/src/components/Pipeline/TasksDAGView/TasksDAGView.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Pipeline/TasksDAGView/TasksDAGView.tsx
@@ -20,6 +20,8 @@ import ReactFlow, {
   useEdgesState,
   useNodesState,
 } from 'reactflow';
+import 'reactflow/dist/base.css';
+import 'reactflow/dist/style.css';
 import {
   MAX_ZOOM_VALUE,
   MIN_ZOOM_VALUE,

--- a/openmetadata-ui/src/main/resources/ui/src/components/SearchDropdown/SearchDropdown.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/SearchDropdown/SearchDropdown.tsx
@@ -40,12 +40,12 @@ import {
 import { useTranslation } from 'react-i18next';
 import { ReactComponent as DropDown } from '../../assets/svg/drop-down.svg';
 import { NULL_OPTION_KEY } from '../../constants/AdvancedSearch.constants';
+import searchClassBase from '../../utils/SearchClassBase';
 import {
   generateSearchDropdownLabel,
   getSearchDropdownLabels,
   getSelectedOptionLabelString,
-} from '../../utils/AdvancedSearchUtils';
-import searchClassBase from '../../utils/SearchClassBase';
+} from '../../utils/SearchDropdownUtils';
 import Loader from '../common/Loader/Loader';
 import './search-dropdown.less';
 import {

--- a/openmetadata-ui/src/main/resources/ui/src/components/WorkflowDefinitions/Workflows/workflows.interface.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/components/WorkflowDefinitions/Workflows/workflows.interface.ts
@@ -10,7 +10,7 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-import { Edge, Node } from 'reactflow';
+import type { Edge, Node } from 'reactflow';
 import { StartEvent } from '../../../generated/governance/workflows/elements/nodes/startEvent/startEvent';
 import { WorkflowDefinition } from '../../../generated/governance/workflows/workflowDefinition';
 

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/TestConnection/ConnectionStepCard/ConnectionStepCard.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/TestConnection/ConnectionStepCard/ConnectionStepCard.tsx
@@ -12,11 +12,10 @@
  */
 import { InfoCircleOutlined } from '@ant-design/icons';
 import Icon from '@ant-design/icons/lib/components/Icon';
-import { LazyLog } from '@melloware/react-logviewer';
 import { Button, Collapse, Divider, Space, Tooltip, Typography } from 'antd';
 import classNames from 'classnames';
 import { isUndefined } from 'lodash';
-import React from 'react';
+import React, { lazy, Suspense } from 'react';
 import { useTranslation } from 'react-i18next';
 import { ReactComponent as AttentionIcon } from '../../../../assets/svg/attention.svg';
 import { ReactComponent as FailIcon } from '../../../../assets/svg/fail-badge.svg';
@@ -27,6 +26,10 @@ import { TestConnectionStep } from '../../../../generated/entity/services/connec
 import { useClipboard } from '../../../../hooks/useClipBoard';
 import { requiredField } from '../../../../utils/CommonUtils';
 import './connection-step-card.less';
+
+const LazyLog = lazy(() =>
+  import('@melloware/react-logviewer').then((m) => ({ default: m.LazyLog }))
+);
 
 const { Panel } = Collapse;
 
@@ -166,14 +169,16 @@ const ConnectionStepCard = ({
                   }
                   header={t('label.show-log-plural')}
                   key="show-log">
-                  <LazyLog
-                    caseInsensitive
-                    enableSearch
-                    selectableLines
-                    extraLines={1} // 1 is to be add so that linux users can see last line of the log
-                    height={300}
-                    text={logs}
-                  />
+                  <Suspense fallback={null}>
+                    <LazyLog
+                      caseInsensitive
+                      enableSearch
+                      selectableLines
+                      extraLines={1}
+                      height={300}
+                      text={logs}
+                    />
+                  </Suspense>
                 </Panel>
               </Collapse>
             </>

--- a/openmetadata-ui/src/main/resources/ui/src/context/LineageProvider/LineageProvider.interface.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/context/LineageProvider/LineageProvider.interface.tsx
@@ -12,7 +12,7 @@
  */
 import { LoadingState } from 'Models';
 import { Dispatch, DragEvent, ReactNode, SetStateAction } from 'react';
-import {
+import type {
   Connection,
   Edge,
   EdgeChange,

--- a/openmetadata-ui/src/main/resources/ui/src/hooks/useCanvasMouseEvents.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/hooks/useCanvasMouseEvents.ts
@@ -11,7 +11,7 @@
  *  limitations under the License.
  */
 import { MutableRefObject, RefObject, useCallback } from 'react';
-import { Edge } from 'reactflow';
+import type { Edge } from 'reactflow';
 import { CanvasButton } from '../utils/CanvasButtonUtils';
 
 interface UseCanvasMouseEventsProps {

--- a/openmetadata-ui/src/main/resources/ui/src/hooks/useLineageStore.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/hooks/useLineageStore.ts
@@ -11,7 +11,7 @@
  *  limitations under the License.
  */
 import { uniq } from 'lodash';
-import { Edge, Node } from 'reactflow';
+import type { Edge, Node } from 'reactflow';
 import { create } from 'zustand';
 import { LineageConfig } from '../components/Entity/EntityLineage/EntityLineage.interface';
 import { SourceType } from '../components/SearchedData/SearchedData.interface';

--- a/openmetadata-ui/src/main/resources/ui/src/hooks/useMapBasedNodesEdges.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/hooks/useMapBasedNodesEdges.ts
@@ -11,7 +11,7 @@
  *  limitations under the License.
  */
 import { useCallback, useMemo, useState } from 'react';
-import { Edge, Node, OnEdgesChange, OnNodesChange } from 'reactflow';
+import type { Edge, Node, OnEdgesChange, OnNodesChange } from 'reactflow';
 import { getClassifiedEdge } from '../utils/EntityLineageUtils';
 
 interface UseMapBasedNodesEdgesReturn {

--- a/openmetadata-ui/src/main/resources/ui/src/hooks/useWorkflowHistory.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/hooks/useWorkflowHistory.ts
@@ -12,7 +12,7 @@
  */
 
 import { useCallback, useState } from 'react';
-import { Edge, Node } from 'reactflow';
+import type { Edge, Node } from 'reactflow';
 
 interface WorkflowState {
   nodes: Node[];

--- a/openmetadata-ui/src/main/resources/ui/src/interface/workflow-builder-components.interface.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/interface/workflow-builder-components.interface.ts
@@ -12,7 +12,7 @@
  */
 
 import React from 'react';
-import {
+import type {
   Connection,
   Edge,
   Node,

--- a/openmetadata-ui/src/main/resources/ui/src/pages/LogsViewerPage/LogsViewerPage.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/LogsViewerPage/LogsViewerPage.tsx
@@ -67,10 +67,8 @@ import {
   getIngestionPipelineLogById,
 } from '../../rest/ingestionPipelineAPI';
 import { ExtraInfoLabel } from '../../utils/DataAssetsHeader.utils';
-import {
-  getEpochMillisForPastDays,
-  getScheduleDescriptionTexts,
-} from '../../utils/date-time/DateTimeUtils';
+import { getScheduleDescriptionTexts } from '../../utils/date-time/CronDescriptionUtils';
+import { getEpochMillisForPastDays } from '../../utils/date-time/DateTimeUtils';
 import { getEntityName } from '../../utils/EntityUtils';
 import {
   downloadAppLogs,

--- a/openmetadata-ui/src/main/resources/ui/src/pages/MyDataPage/MyDataPage.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/MyDataPage/MyDataPage.component.tsx
@@ -18,7 +18,6 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 import RGL, { ReactGridLayoutProps, WidthProvider } from 'react-grid-layout';
 import { useTranslation } from 'react-i18next';
 import Loader from '../../components/common/Loader/Loader';
-import { AdvanceSearchProvider } from '../../components/Explore/AdvanceSearchProvider/AdvanceSearchProvider.component';
 import CustomiseLandingPageHeader from '../../components/MyData/CustomizableComponents/CustomiseLandingPageHeader/CustomiseLandingPageHeader';
 import WelcomeScreen from '../../components/MyData/WelcomeScreen/WelcomeScreen.component';
 import PageLayoutV1 from '../../components/PageLayoutV1/PageLayoutV1';
@@ -259,45 +258,43 @@ const MyDataPage = () => {
   }
 
   return (
-    <AdvanceSearchProvider isExplorePage={false} updateURL={false}>
-      <PageLayoutV1
-        className="p-b-lg"
-        mainContainerClassName="p-t-0 my-data-page-main-container"
-        pageTitle={t('label.my-data')}>
-        {/* Explicitly set the direction to ltr to avoid issues with react-grid-layout in rtl mode */}
-        {/*
-            ReactGridLayout has known issues with RTL layouts, 
+    <PageLayoutV1
+      className="p-b-lg"
+      mainContainerClassName="p-t-0 my-data-page-main-container"
+      pageTitle={t('label.my-data')}>
+      {/* Explicitly set the direction to ltr to avoid issues with react-grid-layout in rtl mode */}
+      {/*
+            ReactGridLayout has known issues with RTL layouts,
             setting dir="ltr" on the container ensures correct behavior
             without affecting the overall RTL layout of the page
         */}
-        <div className="grid-wrapper" dir="ltr">
-          <CustomiseLandingPageHeader
-            overlappedContainer
-            backgroundColor={backgroundColor}
-            dataTestId="landing-page-header"
-            hideCustomiseButton={!selectedPersona}
-            onHomePage
-            onBackgroundColorUpdate={handleBackgroundColorUpdate}
-          />
-          <ReactGridLayout
-            className="grid-container p-x-box"
-            cols={customizePageClassBase.landingPageMaxGridSize}
-            containerPadding={[0, 0]}
-            isDraggable={false}
-            isResizable={false}
-            margin={[
-              customizePageClassBase.landingPageWidgetMargin,
-              customizePageClassBase.landingPageWidgetMargin,
-            ]}
-            rowHeight={customizePageClassBase.landingPageRowHeight}>
-            {widgets}
-          </ReactGridLayout>
-        </div>
-        <LimitWrapper resource="dataAssets">
-          <br />
-        </LimitWrapper>
-      </PageLayoutV1>
-    </AdvanceSearchProvider>
+      <div className="grid-wrapper" dir="ltr">
+        <CustomiseLandingPageHeader
+          overlappedContainer
+          backgroundColor={backgroundColor}
+          dataTestId="landing-page-header"
+          hideCustomiseButton={!selectedPersona}
+          onHomePage
+          onBackgroundColorUpdate={handleBackgroundColorUpdate}
+        />
+        <ReactGridLayout
+          className="grid-container p-x-box"
+          cols={customizePageClassBase.landingPageMaxGridSize}
+          containerPadding={[0, 0]}
+          isDraggable={false}
+          isResizable={false}
+          margin={[
+            customizePageClassBase.landingPageWidgetMargin,
+            customizePageClassBase.landingPageWidgetMargin,
+          ]}
+          rowHeight={customizePageClassBase.landingPageRowHeight}>
+          {widgets}
+        </ReactGridLayout>
+      </div>
+      <LimitWrapper resource="dataAssets">
+        <br />
+      </LimitWrapper>
+    </PageLayoutV1>
   );
 };
 

--- a/openmetadata-ui/src/main/resources/ui/src/services/WorkflowValidationService.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/services/WorkflowValidationService.ts
@@ -13,7 +13,7 @@
 
 import { AxiosError } from 'axios';
 import i18next from 'i18next';
-import { Edge, Node } from 'reactflow';
+import type { Edge, Node } from 'reactflow';
 import {
   ScheduleConfig,
   WorkflowType,

--- a/openmetadata-ui/src/main/resources/ui/src/styles/index.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/styles/index.ts
@@ -25,9 +25,6 @@ import '@fontsource/inter/700.css'; // Font 700
 import '@fontsource/inter/800.css'; // Font 800
 import '@fontsource/inter/900.css'; // Font 900
 
-import '@react-awesome-query-builder/antd/css/styles.css';
-import 'reactflow/dist/base.css';
-import 'reactflow/dist/style.css';
 import './antd-master.less';
 import './app.less';
 import './components/add-edit-form-steps.less';

--- a/openmetadata-ui/src/main/resources/ui/src/utils/AdvancedSearchUtils.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/AdvancedSearchUtils.test.tsx
@@ -30,16 +30,11 @@ import { EntityType } from '../enums/entity.enum';
 import { SearchIndex } from '../enums/search.enum';
 import advancedSearchClassBase from './AdvancedSearchClassBase';
 import {
-  getAssetsPageQuickFilters,
   getChartsOptions,
   getColumnsOptions,
   getEmptyJsonTree,
   getEmptyJsonTreeForQueryBuilder,
-  getOptionsFromAggregationBucket,
   getSchemaFieldOptions,
-  getSearchDropdownLabels,
-  getSearchLabel,
-  getSelectedOptionLabelString,
   getServiceOptions,
   getTasksOptions,
   processCustomPropertyField,
@@ -65,6 +60,13 @@ import {
   mockOptionsArray,
   mockShortOptionsArray,
 } from './mocks/AdvancedSearchUtils.mock';
+import {
+  getAssetsPageQuickFilters,
+  getOptionsFromAggregationBucket,
+  getSearchDropdownLabels,
+  getSearchLabel,
+  getSelectedOptionLabelString,
+} from './SearchDropdownUtils';
 
 jest.mock('./AdvancedSearchClassBase', () => ({
   __esModule: true,

--- a/openmetadata-ui/src/main/resources/ui/src/utils/EdgeStyleUtils.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/EdgeStyleUtils.ts
@@ -11,7 +11,7 @@
  *  limitations under the License.
  */
 import { Theme } from '@mui/material';
-import { Edge } from 'reactflow';
+import type { Edge } from 'reactflow';
 
 export interface EdgeStyle {
   stroke: string;

--- a/openmetadata-ui/src/main/resources/ui/src/utils/EntityUtils.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/EntityUtils.tsx
@@ -16,7 +16,7 @@ import { isEmpty, isUndefined, lowerCase, startCase } from 'lodash';
 import { EntityDetailUnion } from 'Models';
 import { Fragment } from 'react';
 import { Link } from 'react-router-dom';
-import { Node } from 'reactflow';
+import type { Node } from 'reactflow';
 import { TitleLink } from '../components/common/TitleBreadcrumb/TitleBreadcrumb.interface';
 import { DataAssetsWithoutServiceField } from '../components/DataAssets/DataAssetsHeader/DataAssetsHeader.interface';
 import { QueryVoteType } from '../components/Database/TableQueries/TableQueries.interface';

--- a/openmetadata-ui/src/main/resources/ui/src/utils/IngestionListTableUtils.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/IngestionListTableUtils.tsx
@@ -23,7 +23,7 @@ import {
   IngestionPipeline,
   PipelineType,
 } from '../generated/entity/services/ingestionPipelines/ingestionPipeline';
-import { getScheduleDescriptionTexts } from './date-time/DateTimeUtils';
+import { getScheduleDescriptionTexts } from './date-time/CronDescriptionUtils';
 import { getEntityName, highlightSearchText } from './EntityUtils';
 import { t } from './i18next/LocalUtil';
 import { stringToHTML } from './StringsUtils';

--- a/openmetadata-ui/src/main/resources/ui/src/utils/NodeUtils.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/NodeUtils.ts
@@ -11,7 +11,7 @@
  *  limitations under the License.
  */
 
-import { Node } from 'reactflow';
+import type { Node } from 'reactflow';
 import {
   CONNECTION_MODAL_RULES,
   NODE_TYPE_MAPPINGS,

--- a/openmetadata-ui/src/main/resources/ui/src/utils/SearchDropdownUtils.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/SearchDropdownUtils.tsx
@@ -1,0 +1,181 @@
+/*
+ *  Copyright 2022 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+import { Checkbox, MenuProps, Radio, Space, Typography } from 'antd';
+import { isArray } from 'lodash';
+import { Bucket } from 'Models';
+import ProfilePicture from '../components/common/ProfilePicture/ProfilePicture';
+import { ExploreQuickFilterField } from '../components/Explore/ExplorePage.interface';
+import { AssetsOfEntity } from '../components/Glossary/GlossaryTerms/tabs/AssetsTabs.interface';
+import { SearchDropdownOption } from '../components/SearchDropdown/SearchDropdown.interface';
+import {
+  COMMON_DROPDOWN_ITEMS,
+  DOMAIN_DATAPRODUCT_DROPDOWN_ITEMS,
+  GLOSSARY_ASSETS_DROPDOWN_ITEMS,
+  LINEAGE_DROPDOWN_ITEMS,
+  TAG_ASSETS_DROPDOWN_ITEMS,
+} from '../constants/AdvancedSearch.constants';
+import { NOT_INCLUDE_AGGREGATION_QUICK_FILTER } from '../constants/explore.constants';
+import { EntityType } from '../enums/entity.enum';
+import { getCountBadge } from '../utils/CommonUtils';
+import searchClassBase from './SearchClassBase';
+
+export const getDropDownItems = (index: string): ExploreQuickFilterField[] => {
+  return searchClassBase.getDropDownItems(index);
+};
+
+export const getAssetsPageQuickFilters = (type?: AssetsOfEntity) => {
+  switch (type) {
+    case AssetsOfEntity.DOMAIN:
+    case AssetsOfEntity.DATA_PRODUCT:
+    case AssetsOfEntity.DATA_PRODUCT_INPUT_PORT:
+    case AssetsOfEntity.DATA_PRODUCT_OUTPUT_PORT:
+      return [...DOMAIN_DATAPRODUCT_DROPDOWN_ITEMS];
+
+    case AssetsOfEntity.GLOSSARY:
+      return [...GLOSSARY_ASSETS_DROPDOWN_ITEMS];
+
+    case AssetsOfEntity.TAG:
+      return [...TAG_ASSETS_DROPDOWN_ITEMS];
+
+    case AssetsOfEntity.LINEAGE:
+      return [...LINEAGE_DROPDOWN_ITEMS];
+
+    default:
+      return [...COMMON_DROPDOWN_ITEMS];
+  }
+};
+
+export const getSearchLabel = (itemLabel: string, searchKey: string) => {
+  const regex = new RegExp(searchKey, 'gi');
+  if (searchKey) {
+    const result = itemLabel.replace(regex, (match) => `<mark>${match}</mark>`);
+
+    return result;
+  } else {
+    return itemLabel;
+  }
+};
+
+export const generateSearchDropdownLabel = (
+  option: SearchDropdownOption,
+  checked: boolean,
+  searchKey: string,
+  showProfilePicture: boolean,
+  hideCounts = false,
+  singleSelect = false
+) => {
+  const InputComponent = singleSelect ? Radio : Checkbox;
+
+  return (
+    <div className="d-flex justify-between">
+      <Space align="start" className="m-x-sm" data-testid={option.key} size={8}>
+        <InputComponent
+          checked={checked}
+          data-testid={`${option.key}-${singleSelect ? 'radio' : 'checkbox'}`}
+          style={option.description ? { marginTop: 4 } : undefined}
+        />
+        {showProfilePicture && (
+          <ProfilePicture
+            displayName={option.label}
+            name={option.label || ''}
+            width="18"
+          />
+        )}
+        <div>
+          <Typography.Text
+            ellipsis
+            className="dropdown-option-label"
+            title={option.label}>
+            <span
+              dangerouslySetInnerHTML={{
+                __html: getSearchLabel(option.label, searchKey),
+              }}
+            />
+          </Typography.Text>
+          {option.description && (
+            <Typography.Text
+              className="text-xs d-block"
+              data-testid={`${option.key}-description`}
+              type="secondary">
+              {option.description}
+            </Typography.Text>
+          )}
+        </div>
+      </Space>
+      {!hideCounts && getCountBadge(option.count, 'm-r-sm', false)}
+    </div>
+  );
+};
+
+export const getSearchDropdownLabels = (
+  optionsArray: SearchDropdownOption[],
+  checked: boolean,
+  searchKey = '',
+  showProfilePicture = false,
+  hideCounts = false,
+  singleSelect = false
+): MenuProps['items'] => {
+  if (isArray(optionsArray)) {
+    const sortedOptions = optionsArray.sort(
+      (a, b) => (b.count ?? 0) - (a.count ?? 0)
+    );
+
+    return sortedOptions.map((option) => ({
+      key: option.key,
+      label: generateSearchDropdownLabel(
+        option,
+        checked,
+        searchKey,
+        showProfilePicture,
+        hideCounts,
+        singleSelect
+      ),
+    }));
+  } else {
+    return [];
+  }
+};
+
+export const getSelectedOptionLabelString = (
+  selectedOptions: SearchDropdownOption[],
+  showAllOptions = false
+) => {
+  if (isArray(selectedOptions)) {
+    const stringifiedOptions = selectedOptions.map((op) => op.label).join(', ');
+    if (stringifiedOptions.length < 15 || showAllOptions) {
+      return stringifiedOptions;
+    } else {
+      return `${stringifiedOptions.slice(0, 11)}...`;
+    }
+  } else {
+    return '';
+  }
+};
+
+export const getOptionsFromAggregationBucket = (buckets: Bucket[]) => {
+  if (!buckets) {
+    return [];
+  }
+
+  return buckets
+    .filter(
+      (item) =>
+        !NOT_INCLUDE_AGGREGATION_QUICK_FILTER.includes(item.key as EntityType)
+    )
+    .map((option) => ({
+      key: option.key,
+      label: option.key,
+      count: option.doc_count ?? 0,
+    }));
+};

--- a/openmetadata-ui/src/main/resources/ui/src/utils/ViewportUtils.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/ViewportUtils.ts
@@ -11,7 +11,7 @@
  *  limitations under the License.
  */
 import { CSSProperties } from 'react';
-import { Viewport } from 'reactflow';
+import type { Viewport } from 'reactflow';
 
 export function getAbsolutePosition(
   x: number,

--- a/openmetadata-ui/src/main/resources/ui/src/utils/date-time/CronDescriptionUtils.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/date-time/CronDescriptionUtils.ts
@@ -1,0 +1,39 @@
+/*
+ *  Copyright 2023 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+import cronstrue from 'cronstrue';
+import { capitalize } from 'lodash';
+import { getCurrentLocaleForConstrue } from '../i18next/i18nextUtil';
+
+export const getScheduleDescriptionTexts = (scheduleInterval: string) => {
+  try {
+    const scheduleDescription = cronstrue.toString(scheduleInterval, {
+      use24HourTimeFormat: false,
+      verbose: true,
+      locale: getCurrentLocaleForConstrue(),
+    });
+
+    const firstSentenceEndIndex = scheduleDescription.indexOf(',');
+
+    const descriptionFirstPart = scheduleDescription
+      .slice(0, firstSentenceEndIndex)
+      .trim();
+
+    const descriptionSecondPart = capitalize(
+      scheduleDescription.slice(firstSentenceEndIndex + 1).trim()
+    );
+
+    return { descriptionFirstPart, descriptionSecondPart };
+  } catch {
+    return { descriptionFirstPart: '', descriptionSecondPart: '' };
+  }
+};

--- a/openmetadata-ui/src/main/resources/ui/src/utils/date-time/DateTimeUtils.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/date-time/DateTimeUtils.ts
@@ -10,7 +10,6 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-import cronstrue from 'cronstrue';
 import { capitalize, isNaN, isNil, toInteger, toNumber } from 'lodash';
 import { DateTime, Duration } from 'luxon';
 import {
@@ -21,7 +20,6 @@ import {
   YEAR_SECONDS,
 } from '../../constants/Date.constants';
 import { DATE_TIME_SHORT_UNITS } from '../../enums/common.enum';
-import { getCurrentLocaleForConstrue } from '../i18next/i18nextUtil';
 import i18next from '../i18next/LocalUtil';
 
 export const DATE_TIME_12_HOUR_FORMAT = 'MMM dd, yyyy, hh:mm a'; // e.g. Jan 01, 12:00 AM
@@ -512,28 +510,4 @@ export const getSevenDaysStartGMTArrayInMillis = () => {
   }
 
   return sevenDaysStartGMTArrayInMillis;
-};
-
-export const getScheduleDescriptionTexts = (scheduleInterval: string) => {
-  try {
-    const scheduleDescription = cronstrue.toString(scheduleInterval, {
-      use24HourTimeFormat: false,
-      verbose: true,
-      locale: getCurrentLocaleForConstrue(), // To get localized string
-    });
-
-    const firstSentenceEndIndex = scheduleDescription.indexOf(',');
-
-    const descriptionFirstPart = scheduleDescription
-      .slice(0, firstSentenceEndIndex)
-      .trim();
-
-    const descriptionSecondPart = capitalize(
-      scheduleDescription.slice(firstSentenceEndIndex + 1).trim()
-    );
-
-    return { descriptionFirstPart, descriptionSecondPart };
-  } catch {
-    return { descriptionFirstPart: '', descriptionSecondPart: '' };
-  }
 };

--- a/openmetadata-ui/src/main/resources/ui/vite.config.ts
+++ b/openmetadata-ui/src/main/resources/ui/vite.config.ts
@@ -193,6 +193,7 @@ export default defineConfig(({ mode }) => {
             return `assets/[name]-[hash][extname]`;
           },
           manualChunks: (id) => {
+            // Vendor chunks
             if (id.includes('node_modules')) {
               if (id.includes('antd')) {
                 return 'vendor-antd';
@@ -203,6 +204,51 @@ export default defineConfig(({ mode }) => {
               if (id.includes('@untitledui/icons')) {
                 return 'vendor-untitled-icons';
               }
+              if (id.includes('recharts')) {
+                return 'vendor-recharts';
+              }
+              if (id.includes('@react-awesome-query-builder')) {
+                return 'vendor-query-builder';
+              }
+              if (id.includes('reactflow') || id.includes('@xyflow')) {
+                return 'vendor-reactflow';
+              }
+              if (id.includes('@antv/g6') || id.includes('@antv/g')) {
+                return 'vendor-g6';
+              }
+              if (id.includes('elkjs') || id.includes('@dagrejs/dagre')) {
+                return 'vendor-graph-layout';
+              }
+              if (id.includes('@tiptap')) {
+                return 'vendor-tiptap';
+              }
+              if (id.includes('/codemirror/') || id.includes('@codemirror/')) {
+                return 'vendor-codemirror';
+              }
+              if (id.includes('quill')) {
+                return 'vendor-quill';
+              }
+              if (id.includes('@rjsf/')) {
+                return 'vendor-rjsf';
+              }
+              if (id.includes('@mui/x-') || id.includes('@mui/lab')) {
+                return 'vendor-mui-x';
+              }
+              if (id.includes('@mui/') || id.includes('@emotion/')) {
+                return 'vendor-mui';
+              }
+              if (id.includes('antlr4')) {
+                return 'vendor-antlr';
+              }
+              if (id.includes('showdown') || id.includes('turndown')) {
+                return 'vendor-markdown';
+              }
+            }
+
+            // Connection schema JSONs (~6.4MB raw) — pure data,
+            // only needed on service configuration pages
+            if (id.includes('/jsons/connectionSchemas/')) {
+              return 'app-connection-schemas';
             }
           },
         },


### PR DESCRIPTION
## Summary

- Convert heavy component imports to `React.lazy()` (NotificationBox, LazyLog, Latex, ActivityFeedEditor) to defer loading until actually needed
- Use `import type` for reactflow types across 15+ files to eliminate runtime bundle contamination from type-only imports
- Extract `SearchDropdownUtils` from `AdvancedSearchUtils` to break `@react-awesome-query-builder` dependency chain for non-query-builder consumers
- Split `CronDescriptionUtils` from `DateTimeUtils` to isolate `cronstrue` dependency
- Move feature-specific CSS (ReactFlow, RAQB) from global `styles/index.ts` to feature components that actually use them
- Add Vite `manualChunks` for antlr4, showdown/turndown, and connection schemas to improve cache efficiency and chunk isolation
- Lazy-load page routes in `AuthenticatedRoutes` for better code splitting
- Self-provide `AdvanceSearchProvider` in `CuratedAssetsWidget` instead of wrapping entire `MyDataPage`

## Changes

| Category | What | Files |
|----------|------|-------|
| **Lazy components** | `React.lazy()` for NotificationBox, LazyLog, Latex, ActivityFeedEditor | NavBar, ConnectionStepCard, MathEquationComponent, FeedCardBodyNew, ActivityFeedcardNew |
| **Type-only imports** | `import type` for reactflow Edge/Node/etc | 15 files (hooks, interfaces, utils) |
| **Util splitting** | SearchDropdownUtils extracted from AdvancedSearchUtils | New file + 8 importers updated |
| **Util splitting** | CronDescriptionUtils extracted from DateTimeUtils | New file + 2 importers updated |
| **CSS relocation** | ReactFlow + RAQB CSS moved to feature components | styles/index.ts, Lineage, TasksDAGView, AdvanceSearchProvider |
| **Vendor chunking** | antlr4, markdown, connection-schemas manual chunks | vite.config.ts |
| **Route splitting** | Lazy page imports in AuthenticatedRoutes | AuthenticatedRoutes.tsx |
| **Provider scoping** | AdvanceSearchProvider scoped to CuratedAssetsWidget | MyDataPage, CuratedAssetsWidget |

## Test plan

- [ ] Verify `/my-data` page loads correctly
- [ ] Verify Explore page filters work (SearchDropdownUtils split)
- [ ] Verify notification bell dropdown renders (lazy NotificationBox)
- [ ] Verify lineage page renders correctly (CSS relocation + type imports)
- [ ] Verify cron schedules display correctly in ingestion list (CronDescriptionUtils split)
- [ ] Verify test connection step card shows logs (lazy LazyLog)
- [ ] Verify math equations render in block editor (lazy Latex)
- [ ] Run existing unit tests pass (`yarn test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

----
## Summary by Gitar

- **Refactored ExploreV1 UI:**
  - Replaced legacy Antd components and buttons with modern `ui-core-components` and `Dropdown` menus.
  - Updated export and filter controls flow, moving legacy "Export" button into a consolidated "Tools" dropdown.


<sub>This will update automatically on new commits.</sub>