### PR TITLE
fix(table,dataModel): keep column.extension out of stored JSON; entity_extension is source of truth

### DIFF
--- a/bootstrap/sql/migrations/native/1.13.1/mysql/schemaChanges.sql
+++ b/bootstrap/sql/migrations/native/1.13.1/mysql/schemaChanges.sql
@@ -1,0 +1,5 @@
+-- 1.13.1 schema changes
+-- The column.extension cleanup (backfill entity_extension + strip inline from
+-- table_entity.json / dashboard_data_model_entity.json) is performed in the
+-- Java migration org.openmetadata.service.migration.mysql.v1131.Migration,
+-- because the per-column recursion is cleaner in Java than in SQL.

--- a/bootstrap/sql/migrations/native/1.13.1/postgres/schemaChanges.sql
+++ b/bootstrap/sql/migrations/native/1.13.1/postgres/schemaChanges.sql
@@ -1,0 +1,5 @@
+-- 1.13.1 schema changes
+-- The column.extension cleanup (backfill entity_extension + strip inline from
+-- table_entity.json / dashboard_data_model_entity.json) is performed in the
+-- Java migration org.openmetadata.service.migration.postgres.v1131.Migration,
+-- because the per-column recursion is cleaner in Java than in SQL.

--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/ColumnCustomPropertiesIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/ColumnCustomPropertiesIT.java
@@ -6,16 +6,19 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import org.jdbi.v3.core.Jdbi;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.openmetadata.it.bootstrap.TestSuiteBootstrap;
 import org.openmetadata.it.factories.DashboardServiceTestFactory;
 import org.openmetadata.it.factories.DatabaseSchemaTestFactory;
 import org.openmetadata.it.factories.DatabaseServiceTestFactory;
@@ -96,6 +99,48 @@ public class ColumnCustomPropertiesIT {
     ENTITY_REFERENCE_TYPE = getTypeByName(client, "entityReference");
     ENTITY_REFERENCE_LIST_TYPE = getTypeByName(client, "entityReferenceList");
     TIME_INTERVAL_TYPE = getTypeByName(client, "timeInterval");
+  }
+
+  // ========================================================================
+  // STORAGE INVARIANT — column.extension must not be in the stored table JSON.
+  // entity_extension is the single source of truth.
+  // ========================================================================
+
+  @Test
+  void test_tableColumn_extensionNotPersistedInStoredJson(TestNamespace ns) throws Exception {
+    String propName = ns.prefix("storageInvariantProp");
+    OpenMetadataClient client = SdkClients.adminClient();
+
+    try {
+      addCustomPropertyToColumnType(client, TABLE_COLUMN, propName, STRING_TYPE, null);
+
+      Table table = createTestTable(ns);
+      String columnFQN = table.getFullyQualifiedName() + ".id";
+
+      Map<String, Object> extension = new HashMap<>();
+      extension.put(propName, "value-must-only-live-in-entity-extension");
+      updateColumn(client, columnFQN, "table", extension);
+
+      Jdbi jdbi = TestSuiteBootstrap.getJdbi();
+      String storedJson =
+          jdbi.withHandle(
+              h ->
+                  h.createQuery("SELECT json FROM table_entity WHERE id = :id")
+                      .bind("id", table.getId().toString())
+                      .mapTo(String.class)
+                      .one());
+      JsonNode root = OBJECT_MAPPER.readTree(storedJson);
+      for (JsonNode column : root.path("columns")) {
+        assertFalse(
+            column.has("extension"),
+            "column "
+                + column.path("name").asText()
+                + " still has inline extension in table_entity.json: "
+                + column.path("extension"));
+      }
+    } finally {
+      deleteCustomPropertyFromColumnType(client, TABLE_COLUMN, propName);
+    }
   }
 
   // ========================================================================

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/ColumnUtil.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/ColumnUtil.java
@@ -45,7 +45,6 @@ public final class ColumnUtil {
         .withScale(column.getScale())
         .withOrdinalPosition(column.getOrdinalPosition())
         .withJsonSchema(column.getJsonSchema())
-        .withExtension(column.getExtension())
         .withChildren(children);
   }
 

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/DashboardDataModelRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/DashboardDataModelRepository.java
@@ -157,7 +157,17 @@ public class DashboardDataModelRepository extends EntityRepository<DashboardData
 
   @Override
   public void storeEntity(DashboardDataModel dashboardDataModel, boolean update) {
+    // column.extension lives in entity_extension; clone columns without it so
+    // the stored data-model JSON stays clean. Restore the originals on the
+    // in-memory entity so the response carries what the caller sent.
+    List<Column> originalColumns = dashboardDataModel.getColumns();
+    if (originalColumns != null) {
+      dashboardDataModel.setColumns(ColumnUtil.cloneWithoutTags(originalColumns));
+    }
     store(dashboardDataModel, update);
+    if (originalColumns != null) {
+      dashboardDataModel.setColumns(originalColumns);
+    }
   }
 
   @Override

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/TableRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/TableRepository.java
@@ -1605,8 +1605,17 @@ public class TableRepository extends EntityRepository<Table> {
 
   @Override
   public void storeEntity(Table table, boolean update) {
+    // column.extension lives in entity_extension; clone columns without it so
+    // the stored table JSON stays clean. Restore the originals on the in-memory
+    // entity so the response carries what the caller sent.
+    List<Column> originalColumns = table.getColumns();
+    if (originalColumns != null) {
+      table.setColumns(ColumnUtil.cloneWithoutTags(originalColumns));
+    }
     store(table, update);
-    // Store ER relationships based on table constraints
+    if (originalColumns != null) {
+      table.setColumns(originalColumns);
+    }
     addConstraintRelationship(table, table.getTableConstraints());
   }
 

--- a/openmetadata-service/src/main/java/org/openmetadata/service/migration/mysql/v1131/Migration.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/migration/mysql/v1131/Migration.java
@@ -1,0 +1,21 @@
+package org.openmetadata.service.migration.mysql.v1131;
+
+import lombok.SneakyThrows;
+import lombok.extern.slf4j.Slf4j;
+import org.openmetadata.service.migration.api.MigrationProcessImpl;
+import org.openmetadata.service.migration.utils.MigrationFile;
+import org.openmetadata.service.migration.utils.v1131.MigrationUtil;
+
+@Slf4j
+public class Migration extends MigrationProcessImpl {
+
+  public Migration(MigrationFile migrationFile) {
+    super(migrationFile);
+  }
+
+  @Override
+  @SneakyThrows
+  public void runDataMigration() {
+    MigrationUtil.migrateColumnExtensionsToEntityExtension(handle, false);
+  }
+}

--- a/openmetadata-service/src/main/java/org/openmetadata/service/migration/postgres/v1131/Migration.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/migration/postgres/v1131/Migration.java
@@ -1,0 +1,21 @@
+package org.openmetadata.service.migration.postgres.v1131;
+
+import lombok.SneakyThrows;
+import lombok.extern.slf4j.Slf4j;
+import org.openmetadata.service.migration.api.MigrationProcessImpl;
+import org.openmetadata.service.migration.utils.MigrationFile;
+import org.openmetadata.service.migration.utils.v1131.MigrationUtil;
+
+@Slf4j
+public class Migration extends MigrationProcessImpl {
+
+  public Migration(MigrationFile migrationFile) {
+    super(migrationFile);
+  }
+
+  @Override
+  @SneakyThrows
+  public void runDataMigration() {
+    MigrationUtil.migrateColumnExtensionsToEntityExtension(handle, true);
+  }
+}

--- a/openmetadata-service/src/main/java/org/openmetadata/service/migration/utils/v1131/MigrationUtil.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/migration/utils/v1131/MigrationUtil.java
@@ -1,0 +1,152 @@
+package org.openmetadata.service.migration.utils.v1131;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import lombok.extern.slf4j.Slf4j;
+import org.jdbi.v3.core.Handle;
+import org.jdbi.v3.core.statement.PreparedBatch;
+import org.openmetadata.schema.utils.JsonUtils;
+import org.openmetadata.service.util.FullyQualifiedName;
+
+/**
+ * Backfills {@code entity_extension} from any inline {@code column.extension} found in
+ * {@code table_entity.json} / {@code dashboard_data_model_entity.json}, then strips the
+ * inline {@code extension} keys from the JSON so {@code entity_extension} remains the
+ * single source of truth for column custom properties.
+ *
+ * <p>Idempotent: the upsert is {@code ON CONFLICT DO NOTHING} / {@code INSERT IGNORE}
+ * (so a pre-existing {@code entity_extension} row wins), and the row UPDATE only runs
+ * when the JSON actually changed.
+ */
+@Slf4j
+public class MigrationUtil {
+  private MigrationUtil() {}
+
+  private static final int BATCH_SIZE = 200;
+  private static final String COLUMN_EXTENSION_JSON_SCHEMA = "columnExtension";
+
+  private static final List<String> ENTITY_TABLES_WITH_COLUMN_EXTENSIONS =
+      List.of("table_entity", "dashboard_data_model_entity");
+
+  public static void migrateColumnExtensionsToEntityExtension(Handle handle, boolean postgres) {
+    for (String table : ENTITY_TABLES_WITH_COLUMN_EXTENSIONS) {
+      try {
+        migrateOne(handle, postgres, table);
+      } catch (Exception e) {
+        LOG.error("v1131 column-extension migration failed for {}: {}", table, e.getMessage(), e);
+      }
+    }
+  }
+
+  private static void migrateOne(Handle handle, boolean postgres, String tableName) {
+    LOG.info("v1131: migrating inline column.extension for {}", tableName);
+    // ON CONFLICT DO NOTHING / INSERT IGNORE — pre-existing entity_extension rows
+    // win; we only backfill the columns that have no row yet (the buggy-POST case).
+    String backfillSql =
+        postgres
+            ? "INSERT INTO entity_extension(id, extension, jsonSchema, json) "
+                + "VALUES (:id, :ext, :schema, (:json)::jsonb) "
+                + "ON CONFLICT (id, extension) DO NOTHING"
+            : "INSERT IGNORE INTO entity_extension(id, extension, jsonSchema, json) "
+                + "VALUES (:id, :ext, :schema, :json)";
+    String updateSql =
+        postgres
+            ? "UPDATE " + tableName + " SET json = (:json)::jsonb WHERE id = :id"
+            : "UPDATE " + tableName + " SET json = :json WHERE id = :id";
+    String fetchSql =
+        "SELECT id, json FROM " + tableName + " ORDER BY id LIMIT :limit OFFSET :offset";
+
+    int offset = 0;
+    int touched = 0;
+    while (true) {
+      List<Map<String, Object>> rows =
+          handle
+              .createQuery(fetchSql)
+              .bind("limit", BATCH_SIZE)
+              .bind("offset", offset)
+              .mapToMap()
+              .list();
+      if (rows.isEmpty()) {
+        break;
+      }
+      for (Map<String, Object> row : rows) {
+        String entityId = String.valueOf(row.get("id"));
+        Object jsonObj = row.get("json");
+        if (jsonObj == null) continue;
+        try {
+          if (processRow(handle, entityId, jsonObj.toString(), backfillSql, updateSql)) {
+            touched++;
+          }
+        } catch (Exception e) {
+          LOG.error(
+              "v1131: failed to process {} id={}: {}", tableName, entityId, e.getMessage(), e);
+        }
+      }
+      offset += BATCH_SIZE;
+    }
+    LOG.info("v1131: {} done — {} rows had inline column.extension migrated", tableName, touched);
+  }
+
+  /**
+   * Returns true if the row had any inline extension to migrate.
+   * One {@link PreparedBatch} for all (N) backfill inserts plus one row UPDATE — two
+   * round-trips per affected row regardless of how many inline columns it has.
+   */
+  private static boolean processRow(
+      Handle handle, String entityId, String json, String backfillSql, String updateSql) {
+    JsonNode root = JsonUtils.readTree(json);
+    if (!(root instanceof ObjectNode entityNode)) {
+      return false;
+    }
+    JsonNode columns = entityNode.get("columns");
+    if (!(columns instanceof ArrayNode columnsArr) || columnsArr.isEmpty()) {
+      return false;
+    }
+    List<InlineExtension> found = new ArrayList<>();
+    collectAndStrip(columnsArr, found);
+    if (found.isEmpty()) {
+      return false;
+    }
+    PreparedBatch backfill = handle.prepareBatch(backfillSql);
+    for (InlineExtension entry : found) {
+      backfill
+          .bind("id", entityId)
+          .bind("ext", entry.extensionKey)
+          .bind("schema", COLUMN_EXTENSION_JSON_SCHEMA)
+          .bind("json", entry.json)
+          .add();
+    }
+    backfill.execute();
+    handle
+        .createUpdate(updateSql)
+        .bind("json", JsonUtils.pojoToJson(entityNode))
+        .bind("id", entityId)
+        .execute();
+    return true;
+  }
+
+  /** Walks columns (and nested children), records every inline extension, and strips it. */
+  private static void collectAndStrip(ArrayNode columns, List<InlineExtension> found) {
+    for (JsonNode column : columns) {
+      if (!(column instanceof ObjectNode col)) continue;
+      JsonNode ext = col.get("extension");
+      JsonNode fqnNode = col.get("fullyQualifiedName");
+      if (ext != null && !ext.isNull() && fqnNode != null && !fqnNode.isNull()) {
+        found.add(
+            new InlineExtension(
+                FullyQualifiedName.buildHash(fqnNode.asText()), JsonUtils.pojoToJson(ext)));
+        col.remove("extension");
+      }
+      JsonNode children = col.get("children");
+      if (children instanceof ArrayNode childArr && !childArr.isEmpty()) {
+        collectAndStrip(childArr, found);
+      }
+    }
+  }
+
+  private record InlineExtension(String extensionKey, String json) {}
+}


### PR DESCRIPTION
## Background

PR #28328 fixed the create path so column.extension is persisted to `entity_extension`, restoring data visibility. That PR intentionally stayed minimal — it did **not** stop the inline copy from also landing in `table_entity.json` / `dashboard_data_model_entity.json` on every `storeEntity` call.

The inline copy is stale on every subsequent update (the read-path override at `TableRepository.java:205-211` masks it), but its mere presence widens the surface for the kind of read/write asymmetry that produced #19927. Per the post-#28328 discussion: `entity_extension` should be the single source of truth.

## Fix

**Stop writing `column.extension` into the stored JSON** — use the existing nullify-and-restore pattern that `1.12.x` used for `tags` and `service`:

- `ColumnUtil.cloneWithoutTags` — drop the `.withExtension(...)` line PR #25298 added. The clone now produces columns with no tags and no inline extension (same shape as pre-#25298).
- `TableRepository.storeEntity` and `DashboardDataModelRepository.storeEntity` — clone columns via `cloneWithoutTags` before `store(...)`, restore the originals on the in-memory entity after. Response objects still carry the extension the caller sent; only the persisted JSON loses it.

No runtime "strip helper" walking the JSON tree on every save — the swap happens once per `storeEntity` call, on entity-object references, not JSON nodes.

## 1.13.1 migration

Existing rows already have inline `column.extension` in their JSON. For catalogs that used the buggy POST path before #28328 shipped, that's the **only** copy of the data — `entity_extension` is empty. The migration:

1. Walks every row in `table_entity` and `dashboard_data_model_entity`, recursing into nested column `children`.
2. For each column with non-null `extension`, **backfills `entity_extension`** via `PreparedBatch` with `ON CONFLICT DO NOTHING` / `INSERT IGNORE` — pre-existing `entity_extension` rows win, so catalogs that already used the UI / `PUT /columns` path keep their fresh data.
3. **Strips** the inline `extension` keys from the JSON node.
4. Writes the modified JSON back via one `UPDATE`.

Two round-trips per affected row regardless of inline-column count (one batched insert + one update). Rows with no inline data short-circuit to zero round-trips beyond the SELECT page fetch. Idempotent — re-running is a no-op.

| Layout |   |
|---|---|
| `bootstrap/sql/migrations/native/1.13.1/{postgres,mysql}/schemaChanges.sql` | Empty placeholders (framework requirement) — Java does the work |
| `migration/postgres/v1131/Migration.java` | Entry, `postgres=true` |
| `migration/mysql/v1131/Migration.java` | Entry, `postgres=false` |
| `migration/utils/v1131/MigrationUtil.java` | Shared logic |

Picked up automatically by `MigrationFile.getMigrationProcessClassName()` based on the `1.13.1` directory.

## Test coverage

`ColumnCustomPropertiesIT.test_tableColumn_extensionNotPersistedInStoredJson` — sets a column CP, pulls `table_entity.json` straight from the DB via `TestSuiteBootstrap.getJdbi()`, asserts no column has an inline `extension` key. Fails before this PR, passes after.

## Test plan

- [x] `mvn -pl openmetadata-service test-compile`
- [x] `mvn -pl openmetadata-integration-tests test-compile`
- [x] `mvn spotless:apply`
- [ ] CI ITs green
- [ ] Manually run upgrade with seeded inline data and verify entity_extension is backfilled + JSON is clean