### PR TITLE
fix(bulk-assets)(1.12.9): enforce dryRun on tag/glossary/dataProduct/team remove (#28005)

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/DataProductRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/DataProductRepository.java
@@ -596,8 +596,9 @@ public class DataProductRepository extends EntityRepository<DataProduct> {
       BulkAssets request,
       boolean isAdd,
       String userName) {
+    boolean dryRun = Boolean.TRUE.equals(request.getDryRun());
     BulkOperationResult result =
-        new BulkOperationResult().withStatus(ApiStatus.SUCCESS).withDryRun(false);
+        new BulkOperationResult().withStatus(ApiStatus.SUCCESS).withDryRun(dryRun);
     List<BulkResponse> success = new ArrayList<>();
     List<BulkResponse> failed = new ArrayList<>();
 
@@ -614,7 +615,7 @@ public class DataProductRepository extends EntityRepository<DataProduct> {
       assetsByType.computeIfAbsent(asset.getType(), k -> new ArrayList<>()).add(asset);
     }
 
-    // Fetch all asset entities grouped by type for validation
+    // Fetch all asset entities grouped by type so add-validation can still run during dryRun
     Map<UUID, EntityInterface> assetEntitiesMap = new HashMap<>();
     if (isAdd && !assets.isEmpty()) {
       for (Map.Entry<String, List<EntityReference>> entry : assetsByType.entrySet()) {
@@ -636,6 +637,15 @@ public class DataProductRepository extends EntityRepository<DataProduct> {
             throw new IllegalStateException("Asset entity not found for ID: " + ref.getId());
           }
           validateAssetDataProductAssignment(assetEntity, dataProductRef);
+        }
+
+        if (dryRun) {
+          success.add(new BulkResponse().withRequest(ref));
+          result.setNumberOfRowsPassed(result.getNumberOfRowsPassed() + 1);
+          continue;
+        }
+
+        if (isAdd) {
           addRelationship(entityId, ref.getId(), fromEntity, ref.getType(), relationship);
         } else {
           deleteRelationship(entityId, fromEntity, ref.getId(), ref.getType(), relationship);
@@ -671,8 +681,8 @@ public class DataProductRepository extends EntityRepository<DataProduct> {
       result.setStatus(ApiStatus.FAILURE);
     }
 
-    // Create a Change Event on successful operations
-    if (!success.isEmpty()) {
+    // Create a Change Event on successful operations (skip when dryRun makes no changes)
+    if (!dryRun && !success.isEmpty()) {
       EntityInterface entityInterface = Entity.getEntity(fromEntity, entityId, "id", ALL);
       List<EntityReference> successfulAssets = new ArrayList<>();
       for (BulkResponse response : success) {

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/DomainRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/DomainRepository.java
@@ -281,8 +281,9 @@ public class DomainRepository extends EntityRepository<Domain> {
       BulkAssets request,
       boolean isAdd,
       String userName) {
+    boolean dryRun = Boolean.TRUE.equals(request.getDryRun());
     BulkOperationResult result =
-        new BulkOperationResult().withStatus(ApiStatus.SUCCESS).withDryRun(false);
+        new BulkOperationResult().withStatus(ApiStatus.SUCCESS).withDryRun(dryRun);
     List<BulkResponse> success = new ArrayList<>();
 
     if (nullOrEmpty(request.getAssets())) {
@@ -295,6 +296,12 @@ public class DomainRepository extends EntityRepository<Domain> {
 
     for (EntityReference ref : request.getAssets()) {
       result.setNumberOfRowsProcessed(result.getNumberOfRowsProcessed() + 1);
+
+      if (dryRun) {
+        success.add(new BulkResponse().withRequest(ref));
+        result.setNumberOfRowsPassed(result.getNumberOfRowsPassed() + 1);
+        continue;
+      }
 
       cleanupOldDomain(ref, fromEntity, relationship);
       cleanupDataProducts(entityId, ref, relationship, isAdd);
@@ -313,8 +320,7 @@ public class DomainRepository extends EntityRepository<Domain> {
 
     result.withSuccessRequest(success);
 
-    // Create a Change Event on successful addition/removal of assets
-    if (result.getStatus().equals(ApiStatus.SUCCESS)) {
+    if (!dryRun && result.getStatus().equals(ApiStatus.SUCCESS)) {
       EntityInterface entityInterface = Entity.getEntity(fromEntity, entityId, "id", ALL);
       ChangeDescription change =
           addBulkAddRemoveChangeDescription(

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/DomainRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/DomainRepository.java
@@ -14,6 +14,7 @@
 package org.openmetadata.service.jdbi3;
 
 import static org.openmetadata.common.utils.CommonUtil.listOrEmpty;
+import static org.openmetadata.common.utils.CommonUtil.nullOrEmpty;
 import static org.openmetadata.schema.type.Include.ALL;
 import static org.openmetadata.schema.type.Include.NON_DELETED;
 import static org.openmetadata.service.Entity.DATA_PRODUCT;
@@ -283,6 +284,12 @@ public class DomainRepository extends EntityRepository<Domain> {
     BulkOperationResult result =
         new BulkOperationResult().withStatus(ApiStatus.SUCCESS).withDryRun(false);
     List<BulkResponse> success = new ArrayList<>();
+
+    if (nullOrEmpty(request.getAssets())) {
+      // Nothing to Validate — schema marks assets optional, so a request without it is valid
+      return result.withSuccessRequest(
+          List.of(new BulkResponse().withMessage("Nothing to Validate.")));
+    }
 
     EntityUtil.populateEntityReferences(request.getAssets());
 

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/EntityRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/EntityRepository.java
@@ -4690,15 +4690,29 @@ public abstract class EntityRepository<T extends EntityInterface> {
       BulkAssets request,
       boolean isAdd,
       String userName) {
+    boolean dryRun = Boolean.TRUE.equals(request.getDryRun());
     BulkOperationResult result =
-        new BulkOperationResult().withStatus(ApiStatus.SUCCESS).withDryRun(false);
+        new BulkOperationResult().withStatus(ApiStatus.SUCCESS).withDryRun(dryRun);
     List<BulkResponse> success = new ArrayList<>();
+
+    if (nullOrEmpty(request.getAssets())) {
+      // Nothing to Validate — schema marks assets optional, so a request without it is valid
+      return result.withSuccessRequest(
+          List.of(new BulkResponse().withMessage("Nothing to Validate.")));
+    }
+
     // Validate Assets
     EntityUtil.populateEntityReferences(request.getAssets());
 
     for (EntityReference ref : request.getAssets()) {
       // Update Result Processed
       result.setNumberOfRowsProcessed(result.getNumberOfRowsProcessed() + 1);
+
+      if (dryRun) {
+        success.add(new BulkResponse().withRequest(ref));
+        result.setNumberOfRowsPassed(result.getNumberOfRowsPassed() + 1);
+        continue;
+      }
 
       if (isAdd) {
         addRelationship(entityId, ref.getId(), fromEntity, ref.getType(), relationship);
@@ -4715,8 +4729,8 @@ public abstract class EntityRepository<T extends EntityInterface> {
 
     result.withSuccessRequest(success);
 
-    // Create a Change Event on successful addition/removal of assets
-    if (result.getStatus().equals(ApiStatus.SUCCESS)) {
+    // Create a Change Event on successful addition/removal of assets (skip when dryRun)
+    if (!dryRun && result.getStatus().equals(ApiStatus.SUCCESS)) {
       EntityInterface entityInterface = Entity.getEntity(fromEntity, entityId, "id", ALL);
       ChangeDescription change =
           addBulkAddRemoveChangeDescription(

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/GlossaryTermRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/GlossaryTermRepository.java
@@ -525,9 +525,7 @@ public class GlossaryTermRepository extends EntityRepository<GlossaryTerm> {
     List<BulkResponse> failures = new ArrayList<>();
     List<BulkResponse> success = new ArrayList<>();
 
-    if (dryRun
-        && (CommonUtil.nullOrEmpty(glossary.getTags())
-            || CommonUtil.nullOrEmpty(request.getAssets()))) {
+    if (CommonUtil.nullOrEmpty(request.getAssets())) {
       // Nothing to Validate
       return result
           .withStatus(ApiStatus.SUCCESS)
@@ -738,11 +736,19 @@ public class GlossaryTermRepository extends EntityRepository<GlossaryTerm> {
 
   public BulkOperationResult bulkRemoveGlossaryToAssets(
       UUID glossaryTermId, AddGlossaryToAssetsRequest request) {
+    boolean dryRun = Boolean.TRUE.equals(request.getDryRun());
+
     GlossaryTerm term = this.get(null, glossaryTermId, getFields("id,tags"));
 
     BulkOperationResult result =
-        new BulkOperationResult().withStatus(ApiStatus.SUCCESS).withDryRun(false);
+        new BulkOperationResult().withStatus(ApiStatus.SUCCESS).withDryRun(dryRun);
     List<BulkResponse> success = new ArrayList<>();
+
+    if (nullOrEmpty(request.getAssets())) {
+      // Nothing to Validate
+      return result.withSuccessRequest(
+          List.of(new BulkResponse().withMessage("Nothing to Validate.")));
+    }
 
     // Validation for entityReferences
     EntityUtil.populateEntityReferences(request.getAssets());
@@ -755,15 +761,21 @@ public class GlossaryTermRepository extends EntityRepository<GlossaryTerm> {
       EntityInterface asset =
           entityRepository.get(null, ref.getId(), entityRepository.getFields("id"));
 
-      daoCollection
-          .tagUsageDAO()
-          .deleteTagsByTagAndTargetEntity(
-              term.getFullyQualifiedName(), asset.getFullyQualifiedName());
+      // Skip the destructive tag_usage delete + ES update on dryRun so the preview
+      // surfaces the same lookup errors a real call would without mutating state.
+      if (!dryRun) {
+        daoCollection
+            .tagUsageDAO()
+            .deleteTagsByTagAndTargetEntity(
+                term.getFullyQualifiedName(), asset.getFullyQualifiedName());
+      }
       success.add(new BulkResponse().withRequest(ref));
       result.setNumberOfRowsPassed(result.getNumberOfRowsPassed() + 1);
 
-      // Update ES
-      searchRepository.updateEntity(ref);
+      if (!dryRun) {
+        // Update ES
+        searchRepository.updateEntity(ref);
+      }
     }
 
     return result.withSuccessRequest(success);

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/TagRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/TagRepository.java
@@ -357,7 +357,7 @@ public class TagRepository extends EntityRepository<Tag> {
     List<BulkResponse> failures = new ArrayList<>();
     List<BulkResponse> success = new ArrayList<>();
 
-    if (dryRun || nullOrEmpty(request.getAssets())) {
+    if (nullOrEmpty(request.getAssets())) {
       // Nothing to Validate
       return result
           .withStatus(ApiStatus.SUCCESS)
@@ -397,8 +397,9 @@ public class TagRepository extends EntityRepository<Tag> {
         result.withFailedRequest(failures);
         result.setNumberOfRowsFailed(result.getNumberOfRowsFailed() + 1);
       }
-      // Validate and Store Tags
-      if (nullOrEmpty(result.getFailedRequest())) {
+      // Validate and Store Tags — skip the write side-effects on dryRun so the preview
+      // surfaces the same validation outcome a real call would without mutating state.
+      if (!dryRun && nullOrEmpty(result.getFailedRequest())) {
         List<TagLabel> tempList = new ArrayList<>(asset.getTags());
         tempList.add(tagLabel);
         // Apply Tags to Entities
@@ -426,11 +427,20 @@ public class TagRepository extends EntityRepository<Tag> {
   @Override
   public BulkOperationResult bulkRemoveAndValidateTagsToAssets(
       UUID classificationTagId, BulkAssetsRequestInterface request) {
+    AddTagToAssetsRequest assetsRequest = (AddTagToAssetsRequest) request;
+    boolean dryRun = Boolean.TRUE.equals(assetsRequest.getDryRun());
+
     Tag tag = this.get(null, classificationTagId, getFields("id"));
 
     BulkOperationResult result =
-        new BulkOperationResult().withStatus(ApiStatus.SUCCESS).withDryRun(false);
+        new BulkOperationResult().withStatus(ApiStatus.SUCCESS).withDryRun(dryRun);
     List<BulkResponse> success = new ArrayList<>();
+
+    if (nullOrEmpty(request.getAssets())) {
+      // Nothing to Validate
+      return result.withSuccessRequest(
+          List.of(new BulkResponse().withMessage("Nothing to Validate.")));
+    }
 
     // Validation for entityReferences
     EntityUtil.populateEntityReferences(request.getAssets());
@@ -443,15 +453,21 @@ public class TagRepository extends EntityRepository<Tag> {
       EntityInterface asset =
           entityRepository.get(null, ref.getId(), entityRepository.getFields("id"));
 
-      daoCollection
-          .tagUsageDAO()
-          .deleteTagsByTagAndTargetEntity(
-              tag.getFullyQualifiedName(), asset.getFullyQualifiedName());
+      // Skip the destructive tag_usage delete + ES update on dryRun so the preview
+      // surfaces the same lookup errors a real call would without mutating state.
+      if (!dryRun) {
+        daoCollection
+            .tagUsageDAO()
+            .deleteTagsByTagAndTargetEntity(
+                tag.getFullyQualifiedName(), asset.getFullyQualifiedName());
+      }
       success.add(new BulkResponse().withRequest(ref));
       result.setNumberOfRowsPassed(result.getNumberOfRowsPassed() + 1);
 
-      // Update ES
-      searchRepository.updateEntity(ref);
+      if (!dryRun) {
+        // Update ES
+        searchRepository.updateEntity(ref);
+      }
     }
 
     return result.withSuccessRequest(success);

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/TeamRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/TeamRepository.java
@@ -427,30 +427,21 @@ public class TeamRepository extends EntityRepository<Team> {
 
   public BulkOperationResult bulkAddAssets(String teamName, BulkAssets request, String userName) {
     Team team = getByName(null, teamName, getFields("id"));
-
-    // Validate all to be users
     validateAllRefUsers(request.getAssets());
-
-    for (EntityReference asset : request.getAssets()) {
-      if (!Objects.equals(asset.getType(), Entity.USER)) {
-        throw new IllegalArgumentException("Only users can be added to a Team");
-      }
-    }
-
     return bulkAssetsOperation(team.getId(), TEAM, Relationship.HAS, request, true, userName);
   }
 
   public BulkOperationResult bulkRemoveAssets(
-      String domainName, BulkAssets request, String userName) {
-    Team team = getByName(null, domainName, getFields("id"));
-
-    // Validate all to be users
+      String teamName, BulkAssets request, String userName) {
+    Team team = getByName(null, teamName, getFields("id"));
     validateAllRefUsers(request.getAssets());
-
     return bulkAssetsOperation(team.getId(), TEAM, Relationship.HAS, request, false, userName);
   }
 
   private void validateAllRefUsers(List<EntityReference> refs) {
+    if (nullOrEmpty(refs)) {
+      return;
+    }
     for (EntityReference asset : refs) {
       if (!Objects.equals(asset.getType(), Entity.USER)) {
         throw new IllegalArgumentException("Only users can be added to a Team");

--- a/openmetadata-service/src/test/java/org/openmetadata/service/resources/domains/DomainResourceTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/resources/domains/DomainResourceTest.java
@@ -46,6 +46,7 @@ import org.openmetadata.schema.entity.type.Style;
 import org.openmetadata.schema.type.ChangeDescription;
 import org.openmetadata.schema.type.EntityReference;
 import org.openmetadata.schema.type.api.BulkAssets;
+import org.openmetadata.schema.type.api.BulkOperationResult;
 import org.openmetadata.schema.utils.JsonUtils;
 import org.openmetadata.schema.utils.ResultList;
 import org.openmetadata.service.Entity;
@@ -681,6 +682,66 @@ public class DomainResourceTest extends EntityResourceTest<Domain, CreateDomain>
       throws HttpResponseException {
     WebTarget target = getResource("domains/" + domainName + "/assets/remove");
     TestUtils.put(target, request, Status.OK, ADMIN_AUTH_HEADERS);
+  }
+
+  private BulkOperationResult bulkAddAssetsResult(String domainName, BulkAssets request)
+      throws HttpResponseException {
+    WebTarget target = getResource("domains/" + domainName + "/assets/add");
+    return TestUtils.put(target, request, BulkOperationResult.class, Status.OK, ADMIN_AUTH_HEADERS);
+  }
+
+  private BulkOperationResult bulkRemoveAssetsResult(String domainName, BulkAssets request)
+      throws HttpResponseException {
+    WebTarget target = getResource("domains/" + domainName + "/assets/remove");
+    return TestUtils.put(target, request, BulkOperationResult.class, Status.OK, ADMIN_AUTH_HEADERS);
+  }
+
+  @Test
+  void test_bulkAddAssets_dryRunTrue_doesNotApply(TestInfo test) throws IOException {
+    Domain domain = createEntity(createRequest(test), ADMIN_AUTH_HEADERS);
+
+    TableResourceTest tableTest = new TableResourceTest();
+    Table table =
+        tableTest.createEntity(tableTest.createRequest(getEntityName(test, 1)), ADMIN_AUTH_HEADERS);
+
+    BulkOperationResult result =
+        bulkAddAssetsResult(
+            domain.getFullyQualifiedName(),
+            new BulkAssets().withDryRun(true).withAssets(List.of(table.getEntityReference())));
+
+    assertEquals(Boolean.TRUE, result.getDryRun());
+    assertEquals(1, result.getNumberOfRowsProcessed());
+    assertEquals(1, result.getNumberOfRowsPassed());
+
+    ResultList<EntityReference> assets = getAssets(domain.getId(), 100, 0, ADMIN_AUTH_HEADERS);
+    assertEquals(0, assets.getData().size(), "dryRun must not attach the asset");
+  }
+
+  @Test
+  void test_bulkRemoveAssets_dryRunTrue_doesNotApply(TestInfo test) throws IOException {
+    Domain domain = createEntity(createRequest(test), ADMIN_AUTH_HEADERS);
+
+    TableResourceTest tableTest = new TableResourceTest();
+    Table table =
+        tableTest.createEntity(tableTest.createRequest(getEntityName(test, 1)), ADMIN_AUTH_HEADERS);
+
+    bulkAddAssets(
+        domain.getFullyQualifiedName(),
+        new BulkAssets().withAssets(List.of(table.getEntityReference())));
+    assertEquals(1, getAssets(domain.getId(), 100, 0, ADMIN_AUTH_HEADERS).getData().size());
+
+    BulkOperationResult result =
+        bulkRemoveAssetsResult(
+            domain.getFullyQualifiedName(),
+            new BulkAssets().withDryRun(true).withAssets(List.of(table.getEntityReference())));
+
+    assertEquals(Boolean.TRUE, result.getDryRun());
+    assertEquals(1, result.getNumberOfRowsProcessed());
+    assertEquals(1, result.getNumberOfRowsPassed());
+
+    ResultList<EntityReference> assets = getAssets(domain.getId(), 100, 0, ADMIN_AUTH_HEADERS);
+    assertEquals(1, assets.getData().size(), "dryRun must not detach the asset");
+    assertTrue(assets.getData().stream().anyMatch(a -> a.getId().equals(table.getId())));
   }
 
   @Test

--- a/openmetadata-spec/src/main/resources/json/schema/api/bulkAssets.json
+++ b/openmetadata-spec/src/main/resources/json/schema/api/bulkAssets.json
@@ -9,6 +9,11 @@
     "assets": {
       "description": "List of assets to be created against which the glossary needs to be added.",
       "$ref": "../type/entityReferenceList.json"
+    },
+    "dryRun": {
+      "description": "If true, returns a preview of what would change without applying any modifications.",
+      "type": "boolean",
+      "default": false
     }
   },
   "additionalProperties": false

--- a/openmetadata-ui/src/main/resources/ui/src/generated/api/automations/createWorkflow.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/api/automations/createWorkflow.ts
@@ -1204,9 +1204,8 @@ export interface ConfigObject {
      *
      * Choose between API or database connection fetch metadata from superset.
      *
-     * Underlying database connection. See
-     * https://airflow.apache.org/docs/apache-airflow/stable/howto/set-up-database.html for
-     * supported backends.
+     * Choose between database connection or REST API connection to fetch metadata from
+     * Airflow.
      *
      * Matillion Auth Configuration
      *
@@ -1415,19 +1414,6 @@ export interface ConfigObject {
      * Source Python Class Name to instantiated by the ingestion workflow
      */
     sourcePythonClass?: string;
-    /**
-     * Choose between Database connection or HDB User Store connection.
-     *
-     * Choose between API or database connection fetch metadata from superset.
-     *
-     * Choose between database connection or REST API connection to fetch metadata from
-     * Airflow.
-     *
-     * Matillion Auth Configuration
-     *
-     * Choose between mysql and postgres connection for alation database
-     */
-    connection?: ConfigConnection;
     /**
      * Couchbase connection Bucket options.
      */
@@ -4123,6 +4109,7 @@ export enum ConnectionType {
     Mysql = "Mysql",
     Postgres = "Postgres",
     RESTAPI = "RestAPI",
+    S3 = "S3",
     SQLite = "SQLite",
 }
 

--- a/openmetadata-ui/src/main/resources/ui/src/generated/api/bulkAssets.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/api/bulkAssets.ts
@@ -18,6 +18,10 @@ export interface BulkAssets {
      * List of assets to be created against which the glossary needs to be added.
      */
     assets?: EntityReference[];
+    /**
+     * If true, returns a preview of what would change without applying any modifications.
+     */
+    dryRun?: boolean;
 }
 
 /**

--- a/openmetadata-ui/src/main/resources/ui/src/generated/api/services/ingestionPipelines/createIngestionPipeline.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/api/services/ingestionPipelines/createIngestionPipeline.ts
@@ -6360,6 +6360,7 @@ export enum ConnectionType {
     Mysql = "Mysql",
     Postgres = "Postgres",
     RESTAPI = "RestAPI",
+    S3 = "S3",
     SQLite = "SQLite",
 }
 

--- a/openmetadata-ui/src/main/resources/ui/src/generated/entity/automations/testServiceConnection.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/entity/automations/testServiceConnection.ts
@@ -1086,9 +1086,8 @@ export interface ConfigObject {
      *
      * Choose between API or database connection fetch metadata from superset.
      *
-     * Underlying database connection. See
-     * https://airflow.apache.org/docs/apache-airflow/stable/howto/set-up-database.html for
-     * supported backends.
+     * Choose between database connection or REST API connection to fetch metadata from
+     * Airflow.
      *
      * Matillion Auth Configuration
      *
@@ -1297,19 +1296,6 @@ export interface ConfigObject {
      * Source Python Class Name to instantiated by the ingestion workflow
      */
     sourcePythonClass?: string;
-    /**
-     * Choose between Database connection or HDB User Store connection.
-     *
-     * Choose between API or database connection fetch metadata from superset.
-     *
-     * Choose between database connection or REST API connection to fetch metadata from
-     * Airflow.
-     *
-     * Matillion Auth Configuration
-     *
-     * Choose between mysql and postgres connection for alation database
-     */
-    connection?: ConfigConnection;
     /**
      * Couchbase connection Bucket options.
      */
@@ -4005,6 +3991,7 @@ export enum ConnectionType {
     Mysql = "Mysql",
     Postgres = "Postgres",
     RESTAPI = "RestAPI",
+    S3 = "S3",
     SQLite = "SQLite",
 }
 

--- a/openmetadata-ui/src/main/resources/ui/src/generated/entity/automations/workflow.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/entity/automations/workflow.ts
@@ -1734,9 +1734,8 @@ export interface ConfigObject {
      *
      * Choose between API or database connection fetch metadata from superset.
      *
-     * Underlying database connection. See
-     * https://airflow.apache.org/docs/apache-airflow/stable/howto/set-up-database.html for
-     * supported backends.
+     * Choose between database connection or REST API connection to fetch metadata from
+     * Airflow.
      *
      * Matillion Auth Configuration
      *
@@ -1945,19 +1944,6 @@ export interface ConfigObject {
      * Source Python Class Name to instantiated by the ingestion workflow
      */
     sourcePythonClass?: string;
-    /**
-     * Choose between Database connection or HDB User Store connection.
-     *
-     * Choose between API or database connection fetch metadata from superset.
-     *
-     * Choose between database connection or REST API connection to fetch metadata from
-     * Airflow.
-     *
-     * Matillion Auth Configuration
-     *
-     * Choose between mysql and postgres connection for alation database
-     */
-    connection?: ConfigConnection;
     /**
      * Couchbase connection Bucket options.
      */
@@ -4512,6 +4498,7 @@ export enum ConnectionType {
     Mysql = "Mysql",
     Postgres = "Postgres",
     RESTAPI = "RestAPI",
+    S3 = "S3",
     SQLite = "SQLite",
 }
 

--- a/openmetadata-ui/src/main/resources/ui/src/generated/entity/services/apiService.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/entity/services/apiService.ts
@@ -363,13 +363,6 @@ export enum VerifySSL {
 }
 
 /**
- * Reference to the data contract for this entity.
- *
- * This schema defines the EntityReference type used for referencing an entity.
- * EntityReference is used for capturing relationships from one entity to another. For
- * example, a table has an attribute called database of type EntityReference that captures
- * the relationship of a table `belongs to a` database.
- *
  * List of data products this entity is part of.
  *
  * This schema defines the EntityReferenceList type used for referencing an entity.

--- a/openmetadata-ui/src/main/resources/ui/src/generated/entity/services/connections/serviceConnection.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/entity/services/connections/serviceConnection.ts
@@ -3974,6 +3974,7 @@ export enum ConnectionType {
     Mysql = "Mysql",
     Postgres = "Postgres",
     RESTAPI = "RestAPI",
+    S3 = "S3",
     SQLite = "SQLite",
 }
 

--- a/openmetadata-ui/src/main/resources/ui/src/generated/entity/services/ingestionPipelines/ingestionPipeline.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/entity/services/ingestionPipelines/ingestionPipeline.ts
@@ -6849,6 +6849,7 @@ export enum ConnectionType {
     Mysql = "Mysql",
     Postgres = "Postgres",
     RESTAPI = "RestAPI",
+    S3 = "S3",
     SQLite = "SQLite",
 }
 

--- a/openmetadata-ui/src/main/resources/ui/src/generated/metadataIngestion/testSuitePipeline.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/metadataIngestion/testSuitePipeline.ts
@@ -4018,6 +4018,7 @@ export enum ConnectionType {
     Mysql = "Mysql",
     Postgres = "Postgres",
     RESTAPI = "RestAPI",
+    S3 = "S3",
     SQLite = "SQLite",
 }
 

--- a/openmetadata-ui/src/main/resources/ui/src/generated/metadataIngestion/workflow.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/metadataIngestion/workflow.ts
@@ -4076,6 +4076,7 @@ export enum ConnectionType {
     Mysql = "Mysql",
     Postgres = "Postgres",
     RESTAPI = "RestAPI",
+    S3 = "S3",
     SQLite = "SQLite",
 }
 

--- a/openmetadata-ui/src/main/resources/ui/src/generated/settings/settings.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/settings/settings.ts
@@ -2161,10 +2161,6 @@ export interface NaturalLanguageSearch {
      */
     enabled?: boolean;
     /**
-     * Weight for BM25 keyword search results in hybrid RRF pipeline (0.0-1.0)
-     */
-    keywordWeight?: number;
-    /**
      * Maximum number of concurrent embedding API requests. Controls the semaphore used to
      * throttle calls to the embedding provider and prevent overwhelming HTTP/2 connection
      * limits.


### PR DESCRIPTION
## Summary

Cherry-pick of #28005 onto `1.12.9`.

Fixes the security/correctness bug where `dryRun=true` on the bulk remove endpoints (tags, glossary, data products, teams) was silently ignored and the destructive write happened anyway. Five repositories now read the flag, propagate it onto `BulkOperationResult`, and short-circuit before the `tag_usage` delete / `entity_relationship` delete / `searchRepository.updateEntity` / change-event emit.

## Differences from main

- **Schema prerequisite added inline.** `bulkAssets.json` on 1.12.9 doesn't yet have the `dryRun` field (that came from #27141, which is not on 1.12.9 and pulls in 30+ unrelated UI/locale files). To keep this cherry-pick minimal, the single-line `dryRun: boolean` property is added to the schema here; the rest of #27141 is intentionally out of scope.
- **Column-asset code dropped.** 1.12.9 doesn't have the `TABLE_COLUMN` bulk-asset feature, so the per-column dispatch in `bulkAddAndValidateTagsToAssets` / `bulkRemoveAndValidateTagsToAssets` and the `addTagToColumn` / `removeTagFromColumn` helpers from the original PR are not included. The dryRun fix to the non-column paths is unchanged.
- **IT tests dropped.** The new tests in `TagResourceIT` / `GlossaryTermResourceIT` / `DataProductResourceIT` / `TeamResourceIT` reference SDK fluent APIs and helper factories that have diverged on 1.12.9; bringing them in would expand the scope significantly. The repository fix itself is the security-relevant change.

## Build verification

`mvn clean install -DskipTests -pl '!openmetadata-ui,!openmetadata-ui-core-components' -am` → BUILD SUCCESS.

## Test plan

- [ ] CI green
- [ ] Smoke-test `PUT /v1/tags/{id}/assets/remove` with `{"dryRun": true, "assets":[...]}` returns success without removing the tag
- [ ] Smoke-test `PUT /v1/glossaryTerms/{id}/assets/remove` with `dryRun=true` leaves the term attached
- [ ] Smoke-test `PUT /v1/dataProducts/{name}/assets/remove` with `dryRun=true` leaves the relationship intact
- [ ] Smoke-test `PUT /v1/teams/{name}/assets/remove` with `dryRun=true` leaves the membership intact

----
## Summary by Gitar

- **JDBI persistence logic:**
  - Added `storeColumnExtensions` and `storeColumnExtension` to `EntityRepository` to handle column metadata persistence.
  - Refactored `updateColumns` to properly handle adding, updating, and deleting column extensions using the new helper methods.
- **TypeScript types:**
  - Updated `bulkAssets.ts` to include the `dryRun` property definition.
  - Applied minor synchronization updates to multiple generated `entity` and `api` definition files.

<sub>This will update automatically on new commits.</sub>