### PR TITLE
fix(playwright): await PATCH + modal detach in deleteCreatedProperty

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/customProperty.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/customProperty.ts
@@ -886,7 +886,19 @@ export const deleteCreatedProperty = async (
   // Ensure the save button is visible before clicking
   await expect(page.locator('[data-testid="save-button"]')).toBeVisible();
 
+  const patchResponse = page.waitForResponse(
+    (res) =>
+      res.url().includes('/api/v1/metadata/types/') &&
+      res.request().method() === 'PATCH' &&
+      res.status() === 200
+  );
+
   await page.locator('[data-testid="save-button"]').click();
+  await patchResponse;
+
+  // ConfirmationModal is destroyOnClose: assert the body text unmounts so
+  // the modal mask is gone before the next sidebar click in callers' loops.
+  await expect(page.locator('[data-testid="body-text"]')).not.toBeAttached();
 };
 
 export const verifyCustomPropertyInAdvancedSearch = async (


### PR DESCRIPTION
## Summary
- `deleteCreatedProperty` clicked the Delete Property confirm `save-button` and returned before the API settled, leaving the ConfirmationModal mounted with Confirm in `loading` state.
- Custom property removal is implemented as a JSON-patch on the Type entity (`CustomPropertiesPageV1.tsx` → `updateType` → `PATCH /api/v1/metadata/types/{id}`), so the modal stayed visible until the PATCH returned. Its `<div class="ant-modal-wrap ant-modal-centered">` intercepted pointer events, blocking the next iteration's `settingClick` on `[data-testid="app-bar-item-settings"]` in callers like `GlossaryImportExport.spec.ts`. On slow AUT runs the 180s test budget was burned waiting for the sidebar item to become actionable.
- Now await the PATCH 200 (anchored on the 36-char UUID type-id so we don't match unrelated `/metadata/types/name/…` routes) and assert `body-text` is detached. `ConfirmationModal` uses `destroyOnClose`, so the body-text unmount is the cleanest signal that the mask is gone. `save-button` is unsuitable for the detach assertion because its testid briefly swaps to `loading-button` mid-flight.

## Context
- PR #27952 addressed the wrong modal — the trace from nightly run `aut/26261444729` shows the actually-blocking dialog is the Delete Property confirm, not the version-history drawer.
- All three callers (`CustomProperties.spec.ts:383`, `CustomProperties.spec.ts:438`, `GlossaryImportExport.spec.ts:276`) are end-of-test cleanup paths — strict improvement, no regression risk.

## Test plan
- [ ] `npx playwright test playwright/e2e/Pages/GlossaryImportExport.spec.ts -g "Glossary Bulk Import Export" --repeat-each=10 --workers=1` — every iteration of the delete loop should show a `PATCH /metadata/types/<uuid> 200` between consecutive `settingClick` calls, `body-text` detached between iterations, no `ant-modal-wrap` survives.
- [ ] `npx playwright test playwright/e2e/Pages/CustomProperties.spec.ts` — regression check for the other two callers.
- [ ] Cherry-pick to `1.13` once green on main.