### PR TITLE
Fix  backend server Vulnerabilty for OSS 1.13

### DIFF
--- a/common/pom.xml
+++ b/common/pom.xml
@@ -55,6 +55,13 @@
       <artifactId>jsonschema2pojo-core</artifactId>
       <version>${jsonschema2pojo.version}</version>
       <scope>provided</scope>
+      <exclusions>
+        <!-- commons-lang 2.x is EOL with no fix for CVE-2025-48924; we use commons-lang3 instead -->
+        <exclusion>
+          <groupId>commons-lang</groupId>
+          <artifactId>commons-lang</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -684,7 +684,7 @@
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-bom</artifactId>
-        <version>4.1.132.Final</version>
+        <version>4.1.133.Final</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -108,7 +108,7 @@
     <openapiswagger.version>2.2.25</openapiswagger.version>
     <httpclient.version>4.5.14</httpclient.version>
     <spring.version>6.2.18</spring.version>
-    <log4j.version>2.25.3</log4j.version>
+    <log4j.version>2.25.4</log4j.version>
     <org.junit.jupiter.version>5.11.4</org.junit.jupiter.version>
     <org.junit.platform.version>1.11.4</org.junit.platform.version>
     <dropwizard-health.version>5.0.0</dropwizard-health.version>


### PR DESCRIPTION
## Summary

Closes all 6 high-severity findings (41 paths) flagged by the `server-dep-scan` / `server-docker-scan` reports against the 1.13 backend.

## Vulnerabilities addressed

| Package | Was | Now | CVEs | Paths | Fix |
|---|---|---|---|---|---|
| `commons-lang:commons-lang` | 2.6 | _excluded_ | CVE-2025-48924 (Uncontrolled Recursion) | 1 | Exclusion in `common/pom.xml` on `jsonschema2pojo-core` (the only remaining transitive path; we use `commons-lang3` at runtime) |
| `io.netty:netty-codec` | 4.1.132.Final | 4.1.133.Final | CVE-2026-42583, CVE-2026-42587 (Allocation of Resources Without Limits / Throttling) | 8 | `netty-bom` bump in root `pom.xml` |
| `io.netty:netty-codec-http` | 4.1.132.Final | 4.1.133.Final | CVE-2026-42581, CVE-2026-42584, CVE-2026-42585 (HTTP Request Smuggling) | 12 | `netty-bom` bump |
| `io.netty:netty-codec-http2` | 4.1.132.Final | 4.1.133.Final | CVE-2026-42587 (Data Amplification on highly compressed data) | 4 | `netty-bom` bump |
| `io.netty:netty-codec-dns` | 4.1.132.Final | 4.1.133.Final | CVE-2026-42579 (Poison Null Byte) | 4 | `netty-bom` bump |
| `org.apache.logging.log4j:log4j-core` | 2.25.3 | 2.25.4 | CVE-2026-34478 (Rfc5424Layout log injection), CVE-2026-34479 / CVE-2026-34480 (silent log-event loss in XML layouts) | 12 | `log4j.version` property bump in root `pom.xml` |

**Total: 6 libraries / 41 paths → 0.**

## Changes

- `common/pom.xml` — exclude `commons-lang:commons-lang` from `jsonschema2pojo-core` (build-time only, `<scope>provided</scope>`, but the EOL 2.6 jar was still showing up in the resolved tree).
- `pom.xml` — bump `netty-bom` `4.1.132.Final` → `4.1.133.Final`.
- `pom.xml` — bump `<log4j.version>` `2.25.3` → `2.25.4`.

## Verification

Resolved the full Maven dependency graph (`mvn dependency:tree`, `mvn dependency:list`) on both `1.13` base and this branch:

- `commons-lang:commons-lang:jar:2.6` — **0 paths remain** in the resolved tree (compile/provided/test all clean).
- Every `io.netty:*` artifact (codec, codec-http, codec-http2, codec-dns, plus buffer, common, handler, transport, resolver, codec-socks, handler-proxy, …) resolves to **4.1.133.Final**.
- `log4j-api` and `log4j-core` both resolve to **2.25.4** across every module.
- Set-diff of the resolved dep lists shows **no new transitive dependencies introduced** — only the netty version line moved 132→133 and the commons-lang 2.6 line is removed. No other artifacts added or removed.
- Backend build (`mvn clean install -DskipTests -pl '!openmetadata-ui,!openmetadata-ui-core-components' -am`) completes successfully and produces a healthy `openmetadata-service-1.13.0.jar`.

## Notes

- log4j 2.25.4 fix versions confirmed against Apache's security advisory page and NVD entries for the three CVEs — the scanner's "Fix in: —" column was stale.
- Netty 4.1.133.Final is the listed fix for all four netty CVE rows; staying on the 4.1.x line keeps the upgrade patch-level (no API breakage risk vs. jumping to 4.2.x).

## Type of change

- [x] Bug fix (security)