### PR TITLE
fix(1.12.9): persist inline column.extension from POST/PUT-create (backport of #28328)

### DIFF
--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/ColumnCustomPropertiesIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/ColumnCustomPropertiesIT.java
@@ -129,6 +129,158 @@ public class ColumnCustomPropertiesIT {
   }
 
   @Test
+  void test_tableColumn_inlineExtensionInCreatePersists(TestNamespace ns) throws Exception {
+    String propName = ns.prefix("inlineCreateProp");
+    OpenMetadataClient client = SdkClients.adminClient();
+
+    try {
+      addCustomPropertyToColumnType(client, TABLE_COLUMN, propName, STRING_TYPE, null);
+
+      DatabaseService service = DatabaseServiceTestFactory.createPostgres(ns);
+      DatabaseSchema schema = DatabaseSchemaTestFactory.createSimple(ns, service);
+
+      Map<String, Object> idExtension = new HashMap<>();
+      idExtension.put(propName, "inline-on-create-id");
+      Map<String, Object> nameExtension = new HashMap<>();
+      nameExtension.put(propName, "inline-on-create-name");
+
+      Column idColumn =
+          new Column()
+              .withName("id")
+              .withDataType(ColumnDataType.BIGINT)
+              .withExtension(idExtension);
+      Column nameColumn =
+          new Column()
+              .withName("name")
+              .withDataType(ColumnDataType.VARCHAR)
+              .withDataLength(255)
+              .withExtension(nameExtension);
+
+      org.openmetadata.schema.api.data.CreateTable create =
+          new org.openmetadata.schema.api.data.CreateTable()
+              .withName(ns.prefix("inlineCpTable"))
+              .withDatabaseSchema(schema.getFullyQualifiedName())
+              .withColumns(List.of(idColumn, nameColumn));
+      Table created = client.tables().create(create);
+
+      Table reloaded = client.tables().get(created.getId().toString(), "columns,extension");
+      assertNotNull(reloaded.getColumns());
+      assertEquals(2, reloaded.getColumns().size());
+      for (Column c : reloaded.getColumns()) {
+        assertNotNull(
+            c.getExtension(),
+            "column " + c.getName() + " lost its inline extension on POST/PUT-create");
+        @SuppressWarnings("unchecked")
+        Map<String, Object> ext = (Map<String, Object>) c.getExtension();
+        if ("id".equals(c.getName())) {
+          assertEquals("inline-on-create-id", ext.get(propName));
+        } else if ("name".equals(c.getName())) {
+          assertEquals("inline-on-create-name", ext.get(propName));
+        }
+      }
+    } finally {
+      deleteCustomPropertyFromColumnType(client, TABLE_COLUMN, propName);
+    }
+  }
+
+  @Test
+  void test_dashboardColumn_inlineExtensionInCreatePersists(TestNamespace ns) throws Exception {
+    String propName = ns.prefix("inlineDashCreateProp");
+    OpenMetadataClient client = SdkClients.adminClient();
+
+    try {
+      addCustomPropertyToColumnType(
+          client, DASHBOARD_DATA_MODEL_COLUMN, propName, STRING_TYPE, null);
+
+      DashboardService service = DashboardServiceTestFactory.createLooker(ns);
+
+      Map<String, Object> metric1Ext = new HashMap<>();
+      metric1Ext.put(propName, "inline-dash-metric");
+
+      List<Column> columns =
+          Arrays.asList(
+              new Column()
+                  .withName("metric1")
+                  .withDataType(ColumnDataType.BIGINT)
+                  .withExtension(metric1Ext),
+              new Column()
+                  .withName("dimension1")
+                  .withDataType(ColumnDataType.VARCHAR)
+                  .withDataLength(256));
+
+      CreateDashboardDataModel request =
+          new CreateDashboardDataModel()
+              .withName(ns.prefix("inlineCpDataModel"))
+              .withService(service.getFullyQualifiedName())
+              .withDataModelType(DataModelType.LookMlView)
+              .withColumns(columns);
+      DashboardDataModel created = client.dashboardDataModels().create(request);
+
+      DashboardDataModel reloaded =
+          client.dashboardDataModels().get(created.getId().toString(), "columns,extension");
+      Column metric1 =
+          reloaded.getColumns().stream()
+              .filter(c -> "metric1".equals(c.getName()))
+              .findFirst()
+              .orElseThrow();
+      assertNotNull(
+          metric1.getExtension(),
+          "dashboardDataModel column metric1 lost its inline extension on POST");
+      @SuppressWarnings("unchecked")
+      Map<String, Object> ext = (Map<String, Object>) metric1.getExtension();
+      assertEquals("inline-dash-metric", ext.get(propName));
+    } finally {
+      deleteCustomPropertyFromColumnType(client, DASHBOARD_DATA_MODEL_COLUMN, propName);
+    }
+  }
+
+  @Test
+  void test_tableColumn_inlineExtensionOnPutAddedColumnPersists(TestNamespace ns) throws Exception {
+    String propName = ns.prefix("addedColProp");
+    OpenMetadataClient client = SdkClients.adminClient();
+
+    try {
+      addCustomPropertyToColumnType(client, TABLE_COLUMN, propName, STRING_TYPE, null);
+
+      DatabaseService service = DatabaseServiceTestFactory.createPostgres(ns);
+      DatabaseSchema schema = DatabaseSchemaTestFactory.createSimple(ns, service);
+
+      Column idColumn = new Column().withName("id").withDataType(ColumnDataType.BIGINT);
+      org.openmetadata.schema.api.data.CreateTable create =
+          new org.openmetadata.schema.api.data.CreateTable()
+              .withName(ns.prefix("putAddedColTable"))
+              .withDatabaseSchema(schema.getFullyQualifiedName())
+              .withColumns(List.of(idColumn));
+      Table created = client.tables().create(create);
+
+      Map<String, Object> nameExtension = new HashMap<>();
+      nameExtension.put(propName, "added-via-put");
+      Column addedColumn =
+          new Column()
+              .withName("name")
+              .withDataType(ColumnDataType.VARCHAR)
+              .withDataLength(255)
+              .withExtension(nameExtension);
+      created.setColumns(List.of(idColumn, addedColumn));
+      client.tables().update(created.getId().toString(), created);
+
+      Table reloaded = client.tables().get(created.getId().toString(), "columns,extension");
+      Column nameAfter =
+          reloaded.getColumns().stream()
+              .filter(c -> "name".equals(c.getName()))
+              .findFirst()
+              .orElseThrow();
+      assertNotNull(
+          nameAfter.getExtension(), "newly-added column lost its inline extension on PUT-update");
+      @SuppressWarnings("unchecked")
+      Map<String, Object> ext = (Map<String, Object>) nameAfter.getExtension();
+      assertEquals("added-via-put", ext.get(propName));
+    } finally {
+      deleteCustomPropertyFromColumnType(client, TABLE_COLUMN, propName);
+    }
+  }
+
+  @Test
   void test_dashboardColumn_stringCustomProperty(TestNamespace ns) throws Exception {
     String propName = ns.prefix("dashStrProp");
     OpenMetadataClient client = SdkClients.adminClient();

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/DashboardDataModelRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/DashboardDataModelRepository.java
@@ -178,6 +178,11 @@ public class DashboardDataModelRepository extends EntityRepository<DashboardData
   }
 
   @Override
+  protected List<Column> getColumnsForExtensionPersistence(DashboardDataModel entity) {
+    return entity.getColumns();
+  }
+
+  @Override
   protected void clearEntitySpecificRelationshipsForMany(List<DashboardDataModel> entities) {
     if (entities.isEmpty()) return;
     List<UUID> ids = entities.stream().map(DashboardDataModel::getId).toList();

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/EntityRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/EntityRepository.java
@@ -3031,6 +3031,7 @@ public abstract class EntityRepository<T extends EntityInterface> {
   protected T createNewEntity(T entity) {
     storeEntity(entity, false);
     storeExtension(entity);
+    storeColumnExtensions(entity.getId(), getColumnsForExtensionPersistence(entity));
     storeRelationshipsInternal(entity);
     setInheritedFields(entity, new Fields(allowedFields));
     postCreate(entity);
@@ -3517,6 +3518,36 @@ public abstract class EntityRepository<T extends EntityInterface> {
       }
     }
     storeCustomProperties(entityIds, fieldFQNs, jsons);
+  }
+
+  /** Columns whose extensions are persisted on initial create. Default: empty. */
+  protected List<Column> getColumnsForExtensionPersistence(T entity) {
+    return Collections.emptyList();
+  }
+
+  /** Upserts one column's extension. Shared by create and update paths. */
+  protected final void storeColumnExtension(UUID entityId, Column column) {
+    if (entityId == null
+        || column == null
+        || column.getExtension() == null
+        || column.getFullyQualifiedName() == null) {
+      return;
+    }
+    String extensionKey = FullyQualifiedName.buildHash(column.getFullyQualifiedName());
+    daoCollection
+        .entityExtensionDAO()
+        .insert(
+            entityId, extensionKey, "columnExtension", JsonUtils.pojoToJson(column.getExtension()));
+  }
+
+  /** Recursively persists extensions on all columns (and nested children). */
+  protected final void storeColumnExtensions(UUID entityId, List<Column> columns) {
+    if (entityId == null || columns == null || columns.isEmpty()) {
+      return;
+    }
+    for (Column column : EntityUtil.getFlattenedEntityField(columns)) {
+      storeColumnExtension(entityId, column);
+    }
   }
 
   public final void removeExtension(EntityInterface entity) {
@@ -6699,6 +6730,7 @@ public abstract class EntityRepository<T extends EntityInterface> {
         BiPredicate<Column, Column> columnMatch) {
       origColumns = listOrEmpty(origColumns);
       updatedColumns = listOrEmpty(updatedColumns);
+      UUID entityId = updated.getId();
       List<Column> deletedColumns = new ArrayList<>();
       List<Column> addedColumns = new ArrayList<>();
       HashMap<String, String> originalUpdatedColumnFqns = new HashMap<>();
@@ -6725,7 +6757,7 @@ public abstract class EntityRepository<T extends EntityInterface> {
           deleted -> {
             daoCollection.tagUsageDAO().deleteTagsByTarget(deleted.getFullyQualifiedName());
             String extensionKey = FullyQualifiedName.buildHash(deleted.getFullyQualifiedName());
-            daoCollection.entityExtensionDAO().delete(updated.getId(), extensionKey);
+            daoCollection.entityExtensionDAO().delete(entityId, extensionKey);
           });
 
       // Add tags related to newly added columns
@@ -6736,6 +6768,8 @@ public abstract class EntityRepository<T extends EntityInterface> {
                 .toList(),
             added.getFullyQualifiedName());
       }
+      // Added columns are skipped by the existing-column loop below.
+      storeColumnExtensions(entityId, addedColumns);
 
       // Carry forward the user generated metadata from existing columns to new columns
       for (Column updated : updatedColumns) {
@@ -6762,7 +6796,9 @@ public abstract class EntityRepository<T extends EntityInterface> {
             stored.getTags(),
             updated.getTags());
         updateColumnConstraint(stored, updated);
-        updateColumnExtension(stored, updated);
+        if (!Objects.equals(stored.getExtension(), updated.getExtension())) {
+          storeColumnExtension(entityId, updated);
+        }
 
         if (updated.getChildren() != null && stored.getChildren() != null) {
           String childrenFieldName = EntityUtil.getFieldName(fieldName, updated.getName());
@@ -6807,19 +6843,6 @@ public abstract class EntityRepository<T extends EntityInterface> {
     private void updateColumnConstraint(Column origColumn, Column updatedColumn) {
       String columnField = getColumnField(origColumn, "constraint");
       recordChange(columnField, origColumn.getConstraint(), updatedColumn.getConstraint());
-    }
-
-    private void updateColumnExtension(Column origColumn, Column updatedColumn) {
-      if (updatedColumn.getExtension() != null) {
-        String extensionKey = FullyQualifiedName.buildHash(updatedColumn.getFullyQualifiedName());
-        daoCollection
-            .entityExtensionDAO()
-            .insert(
-                updated.getId(),
-                extensionKey,
-                "columnExtension",
-                JsonUtils.pojoToJson(updatedColumn.getExtension()));
-      }
     }
 
     protected void updateColumnDataLength(Column origColumn, Column updatedColumn) {

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/TableRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/TableRepository.java
@@ -1258,6 +1258,11 @@ public class TableRepository extends EntityRepository<Table> {
   }
 
   @Override
+  protected List<Column> getColumnsForExtensionPersistence(Table entity) {
+    return entity.getColumns();
+  }
+
+  @Override
   protected void clearEntitySpecificRelationshipsForMany(List<Table> entities) {
     if (entities.isEmpty()) return;
     List<UUID> ids = entities.stream().map(Table::getId).toList();


### PR DESCRIPTION
Backport of #28328 to `1.12.9`.

## Summary

POST `/api/v1/tables` (and PUT-as-create) silently drops column-level custom properties when callers inline `extension` inside the `columns` array. The data lands in the table JSON, but every reader — and the PATCH-original reload — looks exclusively in `entity_extension` via `getColumnExtension(entityId, columnFQN)`. With no row there, the column-extension override clobbers the inline value with `null`, leaving the UI's Custom Properties tab blank and causing any JsonPatch op walking `/columns/N/extension/...` on the reloaded original to throw `"contains no mapping for the name 'extension'"`. Same gap on `DashboardDataModelRepository`.

See #28328 for full root cause / design notes.

## Cherry-pick conflicts resolved

Three conflicts in `EntityRepository.java`, all caused by main-only refactors that are out of scope for this fix:

1. **`createNewEntityFlush` doesn't exist on 1.12.9.** Wired `storeColumnExtensions(entity.getId(), getColumnsForExtensionPersistence(entity))` into the existing `createNewEntity` (right after `storeExtension`) instead. The `phase()` timing wrappers from the main-only method body were dropped.
2. **`updateColumnConstraint(columnPrefix, stored, updated)` 3-arg signature is main-only.** Kept 1.12.9's `updateColumnConstraint(stored, updated)`; applied the diff-aware `storeColumnExtension(entityId, updated)` call.
3. **`updateColumnDataLength(fieldPrefix, ...)` 3-arg signature is main-only.** Kept 1.12.9's 2-arg form. Still deleted the now-redundant private `updateColumnExtension(Column, Column)` from `EntityUpdater` as the PR intended.

`TableRepository`, `DashboardDataModelRepository`, and `ColumnCustomPropertiesIT` auto-merged cleanly.

## Test plan

- [x] `mvn clean install -DskipTests -pl '!openmetadata-ui,!openmetadata-ui-core-components' -am` clean
- [x] `mvn -pl openmetadata-integration-tests test-compile` clean
- [x] `mvn spotless:apply` clean
- [ ] CI ITs green on 1.12.9