### PR TITLE
test: add TaskAuthorPolicy to test data consumer role

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/constant/permission.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/constant/permission.ts
@@ -21,6 +21,10 @@ export const DEFAULT_POLICIES = {
   teamOnlyAccessPolicy: 'Team only access Policy',
 };
 
+export const SYSTEM_POLICY_NAMES = {
+  taskAuthorPolicy: 'TaskAuthorPolicy',
+};
+
 export const RULE_DETAILS = {
   resources: 'All',
   operations: 'All',

--- a/openmetadata-ui/src/main/resources/ui/playwright/support/user/UserClass.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/support/user/UserClass.ts
@@ -15,6 +15,7 @@ import { Operation } from 'fast-json-patch';
 import {
   DATA_CONSUMER_RULES,
   DATA_STEWARD_RULES,
+  SYSTEM_POLICY_NAMES,
 } from '../../constant/permission';
 import { generateRandomUsername, uuid } from '../../utils/common';
 import { PolicyClass, PolicyRulesType } from '../access-control/PoliciesClass';
@@ -167,6 +168,7 @@ export class UserClass {
     await dataConsumerPolicy.create(apiContext, DATA_CONSUMER_RULES);
     await dataConsumerRoles.create(apiContext, [
       dataConsumerPolicy.responseData.name,
+      SYSTEM_POLICY_NAMES.taskAuthorPolicy,
     ]);
     const dataConsumerTeam = new TeamClass({
       name: `PW%data_consumer_team-${id}`,


### PR DESCRIPTION
PR [#28315](https://github.com/open-metadata/OpenMetadata/pull/28315) replaced manual assignee checks with a policy-based authorization system. Resolving a task now requires TaskAuthorPolicy in the user's policy chain, which provides the rule

The built-in DataConsumer role was updated to include TaskAuthorPolicy, but the test data consumer in Playwright is given a custom role via setDataConsumerRole() — not the built-in role. That custom role only had DATA_CONSUMER_RULES (view/edit permissions), with no task-related rules, so the policy engine found no ALLOW rule for ResolveTask.

Fix:-

Updated data consumer role to include TaskAuthorPolicy alongside the custom data consumer policy mirroring how the built-in DataConsumer role is configured in production

I've validated related test are passing here - https://github.com/open-metadata/openmetadata-collate/actions/runs/26278943684/job/77350031672?pr=4215