### PR TITLE
fix(delete): handle time-series children in bulk hard-delete cascade

### DIFF
--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/AIApplicationResourceIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/AIApplicationResourceIT.java
@@ -15,8 +15,12 @@ import org.openmetadata.it.util.SdkClients;
 import org.openmetadata.it.util.TestNamespace;
 import org.openmetadata.it.util.TestNamespaceExtension;
 import org.openmetadata.schema.entity.ai.AIApplication;
+import org.openmetadata.schema.entity.ai.AgentExecution;
 import org.openmetadata.schema.entity.ai.ApplicationType;
+import org.openmetadata.schema.entity.ai.ExecutionStatus;
 import org.openmetadata.sdk.fluent.AIApplications;
+import org.openmetadata.sdk.network.HttpMethod;
+import org.openmetadata.sdk.network.RequestOptions;
 
 /**
  * Integration tests for AIApplication entity using SDK fluent API.
@@ -242,6 +246,51 @@ public class AIApplicationResourceIT {
         Exception.class,
         () -> AIApplications.get(created.getId().toString()),
         "Hard deleted AI application should not be retrievable");
+  }
+
+  @Test
+  void test_recursiveHardDeleteCascadesPastAgentExecutionChildren(TestNamespace ns)
+      throws Exception {
+    AIApplication app =
+        AIApplications.create()
+            .name(ns.prefix("agentExecCascadeApp"))
+            .withApplicationType(ApplicationType.Chatbot)
+            .withDescription("App for agent-execution cascade delete test")
+            .execute();
+
+    // Writes an AI_APPLICATION --CONTAINS--> agentExecution row. agentExecution is a time-series
+    // entity (registered in ENTITY_TS_REPOSITORY_MAP, not ENTITY_REPOSITORY_MAP), so the bulk
+    // hard-delete cascade used to throw EntityRepositoryNotFound the moment it walked CONTAINS
+    // children of an AI Application.
+    AgentExecution execution =
+        new AgentExecution()
+            .withAgent(app.getEntityReference())
+            .withAgentId(app.getId())
+            .withTimestamp(System.currentTimeMillis())
+            .withStatus(ExecutionStatus.Success)
+            .withInput("cascade-delete test")
+            .withOutput("cascade-delete test");
+    SdkClients.adminClient()
+        .getHttpClient()
+        .executeForString(
+            HttpMethod.POST, "/v1/agentExecutions", execution, RequestOptions.builder().build());
+
+    String appId = app.getId().toString();
+    SdkClients.adminClient()
+        .getHttpClient()
+        .executeForString(
+            HttpMethod.DELETE,
+            "/v1/aiApplications/" + appId,
+            null,
+            RequestOptions.builder()
+                .queryParam("recursive", "true")
+                .queryParam("hardDelete", "true")
+                .build());
+
+    assertThrows(
+        Exception.class,
+        () -> AIApplications.get(appId),
+        "AI Application should be deleted along with its agent-execution children");
   }
 
   @Test

--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/McpServerResourceIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/McpServerResourceIT.java
@@ -32,6 +32,8 @@ import org.openmetadata.it.util.TestNamespaceExtension;
 import org.openmetadata.schema.api.ai.CreateMcpServer;
 import org.openmetadata.schema.api.services.CreateMcpService;
 import org.openmetadata.schema.entity.ai.McpDevelopmentStage;
+import org.openmetadata.schema.entity.ai.McpExecution;
+import org.openmetadata.schema.entity.ai.McpExecutionStatus;
 import org.openmetadata.schema.entity.ai.McpGovernanceMetadata;
 import org.openmetadata.schema.entity.ai.McpPrompt;
 import org.openmetadata.schema.entity.ai.McpResource;
@@ -422,6 +424,50 @@ public class McpServerResourceIT {
         Exception.class,
         () -> getMcpServer(created.getId().toString()),
         "Hard deleted server should not be retrievable");
+  }
+
+  @Test
+  void testRecursiveHardDeleteCascadesPastMcpExecutionChildren(TestNamespace ns) throws Exception {
+    CreateMcpServer create =
+        new CreateMcpServer()
+            .withName(ns.prefix("mcp-cascade-delete"))
+            .withServerType(McpServerType.DataAccess)
+            .withTransportType(McpTransportType.Stdio)
+            .withDescription("Server for execution cascade delete test");
+
+    McpServer created = createMcpServer(create);
+
+    // Writes an MCP_SERVER --CONTAINS--> mcpExecution row. mcpExecution is a time-series entity
+    // (registered in ENTITY_TS_REPOSITORY_MAP, not ENTITY_REPOSITORY_MAP), so the bulk
+    // hard-delete cascade used to throw EntityRepositoryNotFound the moment it walked CONTAINS
+    // children of an MCP Server.
+    McpExecution execution =
+        new McpExecution()
+            .withServer(created.getEntityReference())
+            .withServerId(created.getId())
+            .withTimestamp(System.currentTimeMillis())
+            .withStatus(McpExecutionStatus.Success);
+    SdkClients.adminClient()
+        .getHttpClient()
+        .executeForString(
+            HttpMethod.POST, "/v1/mcpExecutions", execution, RequestOptions.builder().build());
+
+    String serverId = created.getId().toString();
+    SdkClients.adminClient()
+        .getHttpClient()
+        .executeForString(
+            HttpMethod.DELETE,
+            "/v1/mcpServers/" + serverId,
+            null,
+            RequestOptions.builder()
+                .queryParam("recursive", "true")
+                .queryParam("hardDelete", "true")
+                .build());
+
+    assertThrows(
+        Exception.class,
+        () -> getMcpServer(serverId),
+        "MCP Server should be deleted along with its mcp-execution children");
   }
 
   @Test

--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/TestCaseResourceIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/TestCaseResourceIT.java
@@ -1661,6 +1661,43 @@ public class TestCaseResourceIT extends BaseEntityIT<TestCase, CreateTestCase> {
   }
 
   @Test
+  void test_recursiveHardDeleteCascadesPastResolutionStatusChildren(TestNamespace ns) {
+    OpenMetadataClient client = SdkClients.adminClient();
+    Table table = createTable(ns);
+
+    TestCase testCase =
+        TestCaseBuilder.create(client)
+            .name(ns.prefix("tcrs_cascade_delete"))
+            .forTable(table)
+            .testDefinition("tableRowCountToEqual")
+            .parameter("value", "100")
+            .create();
+
+    // Writes a TEST_CASE --PARENT_OF--> testCaseResolutionStatus row. testCaseResolutionStatus
+    // is a time-series entity (registered in ENTITY_TS_REPOSITORY_MAP, not
+    // ENTITY_REPOSITORY_MAP), so the bulk hard-delete cascade used to throw
+    // EntityRepositoryNotFound the moment it walked PARENT_OF children of a test case.
+    org.openmetadata.schema.api.tests.CreateTestCaseResolutionStatus newStatus =
+        new org.openmetadata.schema.api.tests.CreateTestCaseResolutionStatus();
+    newStatus.setTestCaseResolutionStatusType(
+        org.openmetadata.schema.tests.type.TestCaseResolutionStatusTypes.New);
+    newStatus.setTestCaseReference(testCase.getFullyQualifiedName());
+    client.testCaseResolutionStatuses().create(newStatus);
+
+    String testCaseId = testCase.getId().toString();
+
+    Map<String, String> params = new HashMap<>();
+    params.put("hardDelete", "true");
+    params.put("recursive", "true");
+    client.tables().delete(table.getId().toString(), params);
+
+    assertThrows(
+        Exception.class,
+        () -> getEntity(testCaseId),
+        "Test case should be deleted along with its resolution-status children");
+  }
+
+  @Test
   void test_testCaseInheritsFromTestDefinition(TestNamespace ns) {
     OpenMetadataClient client = SdkClients.adminClient();
     Table table = createTable(ns);

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/EntityRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/EntityRepository.java
@@ -4353,6 +4353,10 @@ public abstract class EntityRepository<T extends EntityInterface> {
     // write + one batched change-event insert per type, regardless of descendant count.
     // For hard delete, bulkHardDeleteSubtree replaces the legacy per-entity cleanup loop
     // that opened an independent JDBI transaction per descendant.
+    //
+    // Time-series children are intentionally skipped — see dispatchToContainedChildren
+    // for the rationale (millions-of-rows lock risk, orphans cleaned offline by
+    // DataRetention).
     Map<String, List<UUID>> idsByType =
         children.stream()
             .collect(
@@ -4360,11 +4364,14 @@ public abstract class EntityRepository<T extends EntityInterface> {
                     EntityRelationshipRecord::getType,
                     Collectors.mapping(EntityRelationshipRecord::getId, Collectors.toList())));
     for (var entry : idsByType.entrySet()) {
-      EntityRepository<?> repo = Entity.getEntityRepository(entry.getKey());
-      if (hardDelete) {
-        repo.bulkHardDeleteSubtree(entry.getValue(), updatedBy);
-      } else {
-        repo.bulkSoftDeleteSubtree(entry.getValue(), updatedBy);
+      String childType = entry.getKey();
+      if (!Entity.isTimeSeriesEntity(childType)) {
+        EntityRepository<?> repo = Entity.getEntityRepository(childType);
+        if (hardDelete) {
+          repo.bulkHardDeleteSubtree(entry.getValue(), updatedBy);
+        } else {
+          repo.bulkSoftDeleteSubtree(entry.getValue(), updatedBy);
+        }
       }
     }
   }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/EntityRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/EntityRepository.java
@@ -5709,8 +5709,7 @@ public abstract class EntityRepository<T extends EntityInterface> {
     dispatchToContainedChildren(
         entities,
         "bulkRestoreFindChildren",
-        (childRepo, childIds) -> childRepo.bulkRestoreSubtree(childIds, updatedBy),
-        null);
+        (childRepo, childIds) -> childRepo.bulkRestoreSubtree(childIds, updatedBy));
 
     List<T> deletedEntities =
         entities.stream().filter(e -> Boolean.TRUE.equals(e.getDeleted())).toList();
@@ -5765,18 +5764,21 @@ public abstract class EntityRepository<T extends EntityInterface> {
    * bulk soft-delete and bulk hard-delete; the only thing that varies is the terminal call on the
    * child repo.
    *
-   * <p>{@code timeSeriesDispatcher} handles time-series children (e.g.,
-   * {@code TestCase --PARENT_OF--> testCaseResolutionStatus}) that aren't registered in
-   * {@code ENTITY_REPOSITORY_MAP} and would otherwise crash the regular dispatcher with
-   * {@code EntityRepositoryNotFound}. Restore and soft-delete pass {@code null} because
-   * time-series rows are immutable and have no deleted state to flip; hard-delete passes a
-   * dispatcher that purges the time-series row directly.
+   * <p>Time-series children (e.g., {@code TestCase --PARENT_OF--> testCaseResolutionStatus},
+   * {@code AIApplication --CONTAINS--> agentExecution}, {@code McpServer --CONTAINS-->
+   * mcpExecution}) are intentionally not walked here. Restore and soft-delete have nothing to
+   * do — time-series rows are immutable and carry no {@code deleted} state. Hard-delete also
+   * skips: the tables can hold millions of rows per parent under active ingestion (agent /
+   * MCP executions, profile + queryCost time-series), and a synchronous bulk DELETE would
+   * lock those tables for the duration of the parent cascade and stall the delete request.
+   * Orphan rows whose parent ref no longer resolves degrade safely via
+   * {@code getFromEntityRef} returning {@code null} + the per-repo
+   * {@code shouldSkipSearchResultOnInheritedFieldError} guard. The {@code DataRetention} app
+   * is responsible for sweeping these orphans on its regular cadence (see TODO #28367 for
+   * the orphan time-series cleanup follow-up).
    */
   private void dispatchToContainedChildren(
-      List<T> parents,
-      String phaseName,
-      BiConsumer<EntityRepository<?>, List<UUID>> dispatcher,
-      BiConsumer<EntityTimeSeriesRepository<?>, List<UUID>> timeSeriesDispatcher) {
+      List<T> parents, String phaseName, BiConsumer<EntityRepository<?>, List<UUID>> dispatcher) {
     List<String> parentIds = new ArrayList<>(parents.size());
     for (T parent : parents) {
       parentIds.add(parent.getId().toString());
@@ -5801,15 +5803,10 @@ public abstract class EntityRepository<T extends EntityInterface> {
     for (var entry : idsByChildType.entrySet()) {
       String childType = entry.getKey();
       List<UUID> childIds = entry.getValue();
-      if (Entity.isTimeSeriesEntity(childType)) {
-        if (timeSeriesDispatcher != null) {
-          EntityTimeSeriesRepository<?> tsRepo = Entity.getEntityTimeSeriesRepository(childType);
-          timeSeriesDispatcher.accept(tsRepo, childIds);
-        }
-        continue;
+      if (!Entity.isTimeSeriesEntity(childType)) {
+        EntityRepository<?> repo = Entity.getEntityRepository(childType);
+        dispatcher.accept(repo, childIds);
       }
-      EntityRepository<?> repo = Entity.getEntityRepository(childType);
-      dispatcher.accept(repo, childIds);
     }
   }
 
@@ -5867,8 +5864,7 @@ public abstract class EntityRepository<T extends EntityInterface> {
     dispatchToContainedChildren(
         allEntities,
         "bulkSoftDeleteFindChildren",
-        (childRepo, childIds) -> childRepo.bulkSoftDeleteSubtree(childIds, updatedBy),
-        null);
+        (childRepo, childIds) -> childRepo.bulkSoftDeleteSubtree(childIds, updatedBy));
     applyBulkSoftDelete(entities, updatedBy);
     // Always run per-entity hooks even when nothing at THIS level needed flipping —
     // descendants restored independently before the cascade still need to be re-deleted
@@ -5980,12 +5976,7 @@ public abstract class EntityRepository<T extends EntityInterface> {
     dispatchToContainedChildren(
         entities,
         "bulkHardDeleteFindChildren",
-        (childRepo, childIds) -> childRepo.bulkHardDeleteSubtree(childIds, updatedBy),
-        (tsRepo, childIds) -> {
-          for (UUID childId : childIds) {
-            tsRepo.deleteById(childId, true);
-          }
-        });
+        (childRepo, childIds) -> childRepo.bulkHardDeleteSubtree(childIds, updatedBy));
     bulkEntitySpecificCleanup(entities);
     // Run BEFORE bulkCleanupReferences: hooks like DashboardRepository.cascadeChartCleanup
     // walk HAS relationships to discover linked entities, and bulkCleanupReferences wipes

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/EntityRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/EntityRepository.java
@@ -5709,7 +5709,8 @@ public abstract class EntityRepository<T extends EntityInterface> {
     dispatchToContainedChildren(
         entities,
         "bulkRestoreFindChildren",
-        (childRepo, childIds) -> childRepo.bulkRestoreSubtree(childIds, updatedBy));
+        (childRepo, childIds) -> childRepo.bulkRestoreSubtree(childIds, updatedBy),
+        null);
 
     List<T> deletedEntities =
         entities.stream().filter(e -> Boolean.TRUE.equals(e.getDeleted())).toList();
@@ -5763,9 +5764,19 @@ public abstract class EntityRepository<T extends EntityInterface> {
    * database that's 12k DB hits collapsed into one per tree level. Shared between bulk restore,
    * bulk soft-delete and bulk hard-delete; the only thing that varies is the terminal call on the
    * child repo.
+   *
+   * <p>{@code timeSeriesDispatcher} handles time-series children (e.g.,
+   * {@code TestCase --PARENT_OF--> testCaseResolutionStatus}) that aren't registered in
+   * {@code ENTITY_REPOSITORY_MAP} and would otherwise crash the regular dispatcher with
+   * {@code EntityRepositoryNotFound}. Restore and soft-delete pass {@code null} because
+   * time-series rows are immutable and have no deleted state to flip; hard-delete passes a
+   * dispatcher that purges the time-series row directly.
    */
   private void dispatchToContainedChildren(
-      List<T> parents, String phaseName, BiConsumer<EntityRepository<?>, List<UUID>> dispatcher) {
+      List<T> parents,
+      String phaseName,
+      BiConsumer<EntityRepository<?>, List<UUID>> dispatcher,
+      BiConsumer<EntityTimeSeriesRepository<?>, List<UUID>> timeSeriesDispatcher) {
     List<String> parentIds = new ArrayList<>(parents.size());
     for (T parent : parents) {
       parentIds.add(parent.getId().toString());
@@ -5788,8 +5799,17 @@ public abstract class EntityRepository<T extends EntityInterface> {
           .add(UUID.fromString(rel.getToId()));
     }
     for (var entry : idsByChildType.entrySet()) {
-      EntityRepository<?> repo = Entity.getEntityRepository(entry.getKey());
-      dispatcher.accept(repo, entry.getValue());
+      String childType = entry.getKey();
+      List<UUID> childIds = entry.getValue();
+      if (Entity.isTimeSeriesEntity(childType)) {
+        if (timeSeriesDispatcher != null) {
+          EntityTimeSeriesRepository<?> tsRepo = Entity.getEntityTimeSeriesRepository(childType);
+          timeSeriesDispatcher.accept(tsRepo, childIds);
+        }
+        continue;
+      }
+      EntityRepository<?> repo = Entity.getEntityRepository(childType);
+      dispatcher.accept(repo, childIds);
     }
   }
 
@@ -5847,7 +5867,8 @@ public abstract class EntityRepository<T extends EntityInterface> {
     dispatchToContainedChildren(
         allEntities,
         "bulkSoftDeleteFindChildren",
-        (childRepo, childIds) -> childRepo.bulkSoftDeleteSubtree(childIds, updatedBy));
+        (childRepo, childIds) -> childRepo.bulkSoftDeleteSubtree(childIds, updatedBy),
+        null);
     applyBulkSoftDelete(entities, updatedBy);
     // Always run per-entity hooks even when nothing at THIS level needed flipping —
     // descendants restored independently before the cascade still need to be re-deleted
@@ -5959,7 +5980,12 @@ public abstract class EntityRepository<T extends EntityInterface> {
     dispatchToContainedChildren(
         entities,
         "bulkHardDeleteFindChildren",
-        (childRepo, childIds) -> childRepo.bulkHardDeleteSubtree(childIds, updatedBy));
+        (childRepo, childIds) -> childRepo.bulkHardDeleteSubtree(childIds, updatedBy),
+        (tsRepo, childIds) -> {
+          for (UUID childId : childIds) {
+            tsRepo.deleteById(childId, true);
+          }
+        });
     bulkEntitySpecificCleanup(entities);
     // Run BEFORE bulkCleanupReferences: hooks like DashboardRepository.cascadeChartCleanup
     // walk HAS relationships to discover linked entities, and bulkCleanupReferences wipes

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/ai/AIApplicationResource.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/ai/AIApplicationResource.java
@@ -479,10 +479,15 @@ public class AIApplicationResource extends EntityResource<AIApplication, AIAppli
           @QueryParam("hardDelete")
           @DefaultValue("false")
           boolean hardDelete,
+      @Parameter(
+              description = "Recursively delete this entity and it's children. (Default `false`)")
+          @QueryParam("recursive")
+          @DefaultValue("false")
+          boolean recursive,
       @Parameter(description = "Id of the AI Application", schema = @Schema(type = "UUID"))
           @PathParam("id")
           UUID id) {
-    return delete(uriInfo, securityContext, id, false, hardDelete);
+    return delete(uriInfo, securityContext, id, recursive, hardDelete);
   }
 
   @DELETE
@@ -504,10 +509,15 @@ public class AIApplicationResource extends EntityResource<AIApplication, AIAppli
           @QueryParam("hardDelete")
           @DefaultValue("false")
           boolean hardDelete,
+      @Parameter(
+              description = "Recursively delete this entity and it's children. (Default `false`)")
+          @QueryParam("recursive")
+          @DefaultValue("false")
+          boolean recursive,
       @Parameter(description = "Id of the AI Application", schema = @Schema(type = "UUID"))
           @PathParam("id")
           UUID id) {
-    return deleteByIdAsync(uriInfo, securityContext, id, false, hardDelete);
+    return deleteByIdAsync(uriInfo, securityContext, id, recursive, hardDelete);
   }
 
   @DELETE
@@ -537,7 +547,7 @@ public class AIApplicationResource extends EntityResource<AIApplication, AIAppli
       @Parameter(description = "Name of the AI Application", schema = @Schema(type = "string"))
           @PathParam("fqn")
           String fqn) {
-    return deleteByName(uriInfo, securityContext, fqn, false, hardDelete);
+    return deleteByName(uriInfo, securityContext, fqn, recursive, hardDelete);
   }
 
   @PUT


### PR DESCRIPTION
## Summary

`bulkHardDeleteSubtree` walks CONTAINS + PARENT_OF children at every level and calls `Entity.getEntityRepository` on each child type. Time-series entities (e.g. `testCaseResolutionStatus`, stored as `TestCase --PARENT_OF--> testCaseResolutionStatus`) are registered in `ENTITY_TS_REPOSITORY_MAP`, not `ENTITY_REPOSITORY_MAP`, so the cascade crashed with `Entity repository for testCaseResolutionStatus not found. Is the ENTITY_TYPE_MAP initialized?` the moment it reached a test case that had at least one resolution-status row.

This regressed in #27997, which rewrote the recursive hard-delete cascade. The pre-existing per-entity path was unaffected because `TestCaseRepository.deleteChildren` correctly routed the cleanup through `getEntityTimeSeriesRepository`.

Fix: `dispatchToContainedChildren` now takes an optional `timeSeriesDispatcher`. Hard-delete passes one that purges each row via `EntityTimeSeriesRepository.deleteById(id, true)`; bulk restore / soft-delete pass `null` since time-series rows are immutable and have no deleted state.

## Test plan

- [ ] New `TestCaseResourceIT#test_recursiveHardDeleteCascadesPastResolutionStatusChildren` — fails before the fix with `EntityRepositoryNotFound`, passes after.
- [ ] Existing `TestCaseResourceIT#test_deleteTableDeletesTestCases` still passes (no resolution-status rows on the test case).
- [ ] Existing `RestoreHierarchyIT` (added in #27997) still passes — restore path was not behaviorally changed for non-time-series children, and time-series children are correctly skipped.

----
## Summary by Gitar

- **Refactored core logic:**
  - Simplified `dispatchToContainedChildren` by removing the `timeSeriesDispatcher` parameter as a cleaner alternative to explicit handling.
- **Updated deletion cascade:**
  - Explicitly skip time-series entities in bulk operations to prevent `EntityRepositoryNotFound` errors and avoid table locking.
  - Delegated orphan time-series row cleanup to `DataRetention` app, consistent with handling for large-scale execution logs.
- **Enhanced integration test coverage:**
  - Added `test_recursiveHardDeleteCascadesPastAgentExecutionChildren` in `AIApplicationResourceIT.java` to verify cascade stability.
  - Added `testRecursiveHardDeleteCascadesPastMcpExecutionChildren` in `McpServerResourceIT.java` to ensure proper handling of `mcpExecution` relationships.
- **AI Application API:**
  - Exposed `recursive` flag in `AIApplicationResource` endpoints to enable recursive subtree deletion for AI entities.

<sub>This will update automatically on new commits.</sub>