### PR TITLE
fix(search): enable vector embeddings on context_memory_search_index

### DIFF
--- a/openmetadata-spec/src/main/resources/elasticsearch/en/context_memory_search_index.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/en/context_memory_search_index.json
@@ -613,6 +613,21 @@
       "extension": {
         "type": "flattened"
       },
+      "fingerprint": {
+        "type": "keyword"
+      },
+      "textToEmbed": {
+        "type": "text"
+      },
+      "chunkIndex": {
+        "type": "integer"
+      },
+      "chunkCount": {
+        "type": "integer"
+      },
+      "parentId": {
+        "type": "keyword"
+      },
       "suggest": {
         "type": "completion",
         "contexts": [

--- a/openmetadata-spec/src/main/resources/elasticsearch/indexMapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/indexMapping.json
@@ -615,7 +615,7 @@
     "indexName": "context_memory_search_index",
     "indexMappingFile": "/elasticsearch/%s/context_memory_search_index.json",
     "alias": "contextMemory",
-    "parentAliases": ["all"],
+    "parentAliases": ["all", "dataAssetEmbeddings"],
     "childAliases": []
   }
 }

--- a/openmetadata-spec/src/main/resources/elasticsearch/jp/context_memory_search_index.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/jp/context_memory_search_index.json
@@ -613,6 +613,21 @@
       "extension": {
         "type": "flattened"
       },
+      "fingerprint": {
+        "type": "keyword"
+      },
+      "textToEmbed": {
+        "type": "text"
+      },
+      "chunkIndex": {
+        "type": "integer"
+      },
+      "chunkCount": {
+        "type": "integer"
+      },
+      "parentId": {
+        "type": "keyword"
+      },
       "suggest": {
         "type": "completion",
         "contexts": [

--- a/openmetadata-spec/src/main/resources/elasticsearch/ru/context_memory_search_index.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/ru/context_memory_search_index.json
@@ -613,6 +613,21 @@
       "extension": {
         "type": "flattened"
       },
+      "fingerprint": {
+        "type": "keyword"
+      },
+      "textToEmbed": {
+        "type": "text"
+      },
+      "chunkIndex": {
+        "type": "integer"
+      },
+      "chunkCount": {
+        "type": "integer"
+      },
+      "parentId": {
+        "type": "keyword"
+      },
       "suggest": {
         "type": "completion",
         "contexts": [

--- a/openmetadata-spec/src/main/resources/elasticsearch/zh/context_memory_search_index.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/zh/context_memory_search_index.json
@@ -613,6 +613,21 @@
       "extension": {
         "type": "flattened"
       },
+      "fingerprint": {
+        "type": "keyword"
+      },
+      "textToEmbed": {
+        "type": "text"
+      },
+      "chunkIndex": {
+        "type": "integer"
+      },
+      "chunkCount": {
+        "type": "integer"
+      },
+      "parentId": {
+        "type": "keyword"
+      },
       "suggest": {
         "type": "completion",
         "contexts": [


### PR DESCRIPTION
### Describe your changes:

I worked on enabling vector / semantic search for the `contextMemory` entity because the existing `context_memory_search_index` was missing both of the gates that OpenMetadata requires for an index to participate in embeddings.

**Gate 1 — index-level:** `OsUtils.addKnnVectorSettings()` keys off the presence of a `fingerprint` field to decide whether to inject the `knn_vector` `embedding` field and the `knn` index settings. The context memory mapping had none of the embedding-related fields (`fingerprint`, `textToEmbed`, `chunkIndex`, `chunkCount`, `parentId`), so the check returned early and the index was never KNN-enabled.

**Gate 2 — cluster-level:** `OpenSearchVectorService.search()` issues queries against the `dataAssetEmbeddings` alias. The `contextMemory` entry in `indexMapping.json` only had `parentAliases: ["all"]`, so even if the embeddings had been generated, the search would never have fanned out to the context memory index.

This PR adds the 5 embedding fields to all four locale variants of `context_memory_search_index.json` (en / jp / ru / zh) and adds `dataAssetEmbeddings` to the `parentAliases`. The rest of the wiring (`AvailableEntityTypes` registration, `ContextMemoryBodyTextContributor`) was already in place — a reindex is all that's needed to populate the embeddings.

#
### Type of change:
- [x] Bug fix

#
### Tests:

#### Manual testing performed
- Validated all 5 modified JSON files parse cleanly with `python3 -m json.tool`
- Verified the four locale variants of `context_memory_search_index.json` remain byte-identical after the edits

#
### UI screen recording / screenshots:

Not applicable.

#
### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.