### PR TITLE
fix(glossary): include cardinality on default term relation types

### DIFF
--- a/bootstrap/sql/migrations/native/1.13.1/mysql/postDataMigrationSQLScript.sql
+++ b/bootstrap/sql/migrations/native/1.13.1/mysql/postDataMigrationSQLScript.sql
@@ -1,0 +1,2 @@
+-- Post data migration script for OpenMetadata 1.13.1
+-- Backfill for glossaryTermRelationSettings cardinality runs in the Java migration step.

--- a/bootstrap/sql/migrations/native/1.13.1/mysql/schemaChanges.sql
+++ b/bootstrap/sql/migrations/native/1.13.1/mysql/schemaChanges.sql
@@ -1,0 +1,2 @@
+-- Schema changes for OpenMetadata 1.13.1
+-- No DDL changes; data backfill runs in the Java migration step.

--- a/bootstrap/sql/migrations/native/1.13.1/postgres/postDataMigrationSQLScript.sql
+++ b/bootstrap/sql/migrations/native/1.13.1/postgres/postDataMigrationSQLScript.sql
@@ -1,0 +1,2 @@
+-- Post data migration script for OpenMetadata 1.13.1
+-- Backfill for glossaryTermRelationSettings cardinality runs in the Java migration step.

--- a/bootstrap/sql/migrations/native/1.13.1/postgres/schemaChanges.sql
+++ b/bootstrap/sql/migrations/native/1.13.1/postgres/schemaChanges.sql
@@ -1,0 +1,2 @@
+-- Schema changes for OpenMetadata 1.13.1
+-- No DDL changes; data backfill runs in the Java migration step.

--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/GlossaryTermRelationSettingsIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/GlossaryTermRelationSettingsIT.java
@@ -102,6 +102,9 @@ public class GlossaryTermRelationSettingsIT {
       assertNotNull(relationType.get("category"), "category should exist for " + name);
       assertNotNull(relationType.get("isSymmetric"), "isSymmetric should exist for " + name);
       assertNotNull(relationType.get("isTransitive"), "isTransitive should exist for " + name);
+      JsonNode cardinalityNode = relationType.get("cardinality");
+      assertNotNull(cardinalityNode, "cardinality should exist for " + name);
+      assertFalse(cardinalityNode.isNull(), "cardinality should not be null for " + name);
     }
 
     assertTrue(hasRelatedTo, "Should have 'relatedTo' relation type");

--- a/openmetadata-service/src/main/java/org/openmetadata/service/migration/mysql/v1131/Migration.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/migration/mysql/v1131/Migration.java
@@ -1,0 +1,20 @@
+package org.openmetadata.service.migration.mysql.v1131;
+
+import lombok.SneakyThrows;
+import org.openmetadata.service.migration.api.MigrationProcessImpl;
+import org.openmetadata.service.migration.utils.MigrationFile;
+import org.openmetadata.service.migration.utils.v1131.MigrationUtil;
+
+public class Migration extends MigrationProcessImpl {
+
+  public Migration(MigrationFile migrationFile) {
+    super(migrationFile);
+  }
+
+  @Override
+  @SneakyThrows
+  public void runDataMigration() {
+    MigrationUtil migrationUtil = new MigrationUtil(handle);
+    migrationUtil.backfillGlossaryTermRelationCardinality();
+  }
+}

--- a/openmetadata-service/src/main/java/org/openmetadata/service/migration/postgres/v1131/Migration.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/migration/postgres/v1131/Migration.java
@@ -1,0 +1,20 @@
+package org.openmetadata.service.migration.postgres.v1131;
+
+import lombok.SneakyThrows;
+import org.openmetadata.service.migration.api.MigrationProcessImpl;
+import org.openmetadata.service.migration.utils.MigrationFile;
+import org.openmetadata.service.migration.utils.v1131.MigrationUtil;
+
+public class Migration extends MigrationProcessImpl {
+
+  public Migration(MigrationFile migrationFile) {
+    super(migrationFile);
+  }
+
+  @Override
+  @SneakyThrows
+  public void runDataMigration() {
+    MigrationUtil migrationUtil = new MigrationUtil(handle);
+    migrationUtil.backfillGlossaryTermRelationCardinality();
+  }
+}

--- a/openmetadata-service/src/main/java/org/openmetadata/service/migration/utils/v1131/MigrationUtil.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/migration/utils/v1131/MigrationUtil.java
@@ -1,0 +1,114 @@
+package org.openmetadata.service.migration.utils.v1131;
+
+import java.util.HashMap;
+import java.util.Map;
+import lombok.extern.slf4j.Slf4j;
+import org.jdbi.v3.core.Handle;
+import org.openmetadata.schema.configuration.GlossaryTermRelationSettings;
+import org.openmetadata.schema.configuration.GlossaryTermRelationType;
+import org.openmetadata.schema.configuration.RelationCardinality;
+import org.openmetadata.schema.utils.JsonUtils;
+
+@Slf4j
+public class MigrationUtil {
+
+  private static final String GLOSSARY_TERM_RELATION_SETTINGS = "glossaryTermRelationSettings";
+
+  private static final Map<String, RelationCardinality> SYSTEM_DEFAULT_CARDINALITIES =
+      systemDefaultCardinalities();
+
+  private final Handle handle;
+
+  public MigrationUtil(Handle handle) {
+    this.handle = handle;
+  }
+
+  public void backfillGlossaryTermRelationCardinality() {
+    String json =
+        handle
+            .createQuery("SELECT json FROM openmetadata_settings WHERE configType = :configType")
+            .bind("configType", GLOSSARY_TERM_RELATION_SETTINGS)
+            .mapTo(String.class)
+            .findOne()
+            .orElse(null);
+    if (json == null) {
+      LOG.info("No glossaryTermRelationSettings row found; skipping cardinality backfill");
+      return;
+    }
+
+    GlossaryTermRelationSettings settings =
+        JsonUtils.readValue(json, GlossaryTermRelationSettings.class);
+    if (settings == null || settings.getRelationTypes() == null) {
+      return;
+    }
+
+    boolean changed = false;
+    for (GlossaryTermRelationType relationType : settings.getRelationTypes()) {
+      if (relationType == null
+          || !Boolean.TRUE.equals(relationType.getIsSystemDefined())
+          || relationType.getCardinality() != null) {
+        continue;
+      }
+      RelationCardinality expected = SYSTEM_DEFAULT_CARDINALITIES.get(relationType.getName());
+      if (expected == null) {
+        continue;
+      }
+      relationType.setCardinality(expected);
+      applyCardinalityBounds(relationType, expected);
+      changed = true;
+      LOG.info(
+          "Backfilled cardinality {} on system relation '{}'", expected, relationType.getName());
+    }
+
+    if (!changed) {
+      return;
+    }
+
+    handle
+        .createUpdate(
+            "UPDATE openmetadata_settings SET json = :json WHERE configType = :configType")
+        .bind("configType", GLOSSARY_TERM_RELATION_SETTINGS)
+        .bind("json", JsonUtils.pojoToJson(settings))
+        .execute();
+  }
+
+  private static Map<String, RelationCardinality> systemDefaultCardinalities() {
+    Map<String, RelationCardinality> defaults = new HashMap<>();
+    defaults.put("relatedTo", RelationCardinality.MANY_TO_MANY);
+    defaults.put("synonym", RelationCardinality.MANY_TO_MANY);
+    defaults.put("antonym", RelationCardinality.MANY_TO_MANY);
+    defaults.put("broader", RelationCardinality.ONE_TO_MANY);
+    defaults.put("narrower", RelationCardinality.MANY_TO_ONE);
+    defaults.put("partOf", RelationCardinality.MANY_TO_MANY);
+    defaults.put("hasPart", RelationCardinality.MANY_TO_MANY);
+    defaults.put("calculatedFrom", RelationCardinality.MANY_TO_MANY);
+    defaults.put("usedToCalculate", RelationCardinality.MANY_TO_MANY);
+    defaults.put("seeAlso", RelationCardinality.MANY_TO_MANY);
+    return defaults;
+  }
+
+  private static void applyCardinalityBounds(
+      GlossaryTermRelationType relationType, RelationCardinality cardinality) {
+    switch (cardinality) {
+      case ONE_TO_ONE -> {
+        relationType.setSourceMax(1);
+        relationType.setTargetMax(1);
+      }
+      case ONE_TO_MANY -> {
+        relationType.setSourceMax(1);
+        relationType.setTargetMax(null);
+      }
+      case MANY_TO_ONE -> {
+        relationType.setSourceMax(null);
+        relationType.setTargetMax(1);
+      }
+      case MANY_TO_MANY -> {
+        relationType.setSourceMax(null);
+        relationType.setTargetMax(null);
+      }
+      default -> {
+        // CUSTOM or unknown: keep explicit source/target values as-is.
+      }
+    }
+  }
+}

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/settings/SettingsCache.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/settings/SettingsCache.java
@@ -61,6 +61,7 @@ import org.openmetadata.schema.configuration.GlossaryTermRelationSettings;
 import org.openmetadata.schema.configuration.GlossaryTermRelationType;
 import org.openmetadata.schema.configuration.HistoryCleanUpConfiguration;
 import org.openmetadata.schema.configuration.OpenLineageSettings;
+import org.openmetadata.schema.configuration.RelationCardinality;
 import org.openmetadata.schema.configuration.RelationCategory;
 import org.openmetadata.schema.configuration.WorkflowSettings;
 import org.openmetadata.schema.email.SmtpSettings;
@@ -365,6 +366,7 @@ public class SettingsCache {
                   RelationCategory.ASSOCIATIVE,
                   true,
                   "#1570ef",
+                  RelationCardinality.MANY_TO_MANY,
                   null,
                   null),
               createRelationType(
@@ -378,6 +380,7 @@ public class SettingsCache {
                   RelationCategory.EQUIVALENCE,
                   true,
                   "#b42318",
+                  RelationCardinality.MANY_TO_MANY,
                   null,
                   null),
               createRelationType(
@@ -391,6 +394,7 @@ public class SettingsCache {
                   RelationCategory.ASSOCIATIVE,
                   true,
                   "#b54708",
+                  RelationCardinality.MANY_TO_MANY,
                   null,
                   null),
               createRelationType(
@@ -404,7 +408,8 @@ public class SettingsCache {
                   RelationCategory.HIERARCHICAL,
                   true,
                   "#067647",
-                  null,
+                  RelationCardinality.ONE_TO_MANY,
+                  1,
                   null),
               createRelationType(
                   "narrower",
@@ -417,8 +422,9 @@ public class SettingsCache {
                   RelationCategory.HIERARCHICAL,
                   true,
                   "#4e5ba6",
+                  RelationCardinality.MANY_TO_ONE,
                   null,
-                  null),
+                  1),
               createRelationType(
                   "partOf",
                   "Part Of",
@@ -430,6 +436,7 @@ public class SettingsCache {
                   RelationCategory.HIERARCHICAL,
                   true,
                   "#026aa2",
+                  RelationCardinality.MANY_TO_MANY,
                   null,
                   null),
               createRelationType(
@@ -443,6 +450,7 @@ public class SettingsCache {
                   RelationCategory.HIERARCHICAL,
                   true,
                   "#155eef",
+                  RelationCardinality.MANY_TO_MANY,
                   null,
                   null),
               createRelationType(
@@ -456,6 +464,7 @@ public class SettingsCache {
                   RelationCategory.ASSOCIATIVE,
                   true,
                   "#6938ef",
+                  RelationCardinality.MANY_TO_MANY,
                   null,
                   null),
               createRelationType(
@@ -469,6 +478,7 @@ public class SettingsCache {
                   RelationCategory.ASSOCIATIVE,
                   true,
                   "#ba24d5",
+                  RelationCardinality.MANY_TO_MANY,
                   null,
                   null),
               createRelationType(
@@ -482,6 +492,7 @@ public class SettingsCache {
                   RelationCategory.ASSOCIATIVE,
                   true,
                   "#c11574",
+                  RelationCardinality.MANY_TO_MANY,
                   null,
                   null));
 
@@ -505,6 +516,7 @@ public class SettingsCache {
       RelationCategory category,
       boolean isSystemDefined,
       String color,
+      RelationCardinality cardinality,
       Integer sourceMax,
       Integer targetMax) {
     return new GlossaryTermRelationType()
@@ -518,6 +530,7 @@ public class SettingsCache {
         .withCategory(category)
         .withIsSystemDefined(isSystemDefined)
         .withColor(color)
+        .withCardinality(cardinality)
         .withSourceMax(sourceMax)
         .withTargetMax(targetMax);
   }


### PR DESCRIPTION
## Summary

Fixes [collate#4212](https://github.com/open-metadata/openmetadata-collate/issues/4212): the GET `/v1/system/settings/glossaryTermRelationSettings` response was missing the `cardinality` field for system-seeded relation types. The UI fell back to `MANY_TO_MANY` and, on the next PUT, persisted that fallback onto the system relations - overwriting whatever the correct value should have been.

### Root cause

`SettingsCache.createRelationType` constructs each system default but never calls `.withCardinality(...)`. The PUT path runs `SystemResource.normalizeGlossaryTermRelationSettings` which derives a default of `MANY_TO_MANY` from null source/target max - but GET has no equivalent. So between server boot and the first PUT, defaults shipped with `cardinality == null`.

### Fix

**1. Set the expected cardinality on each system default in `SettingsCache.java`**

Per-relation values:

| Relation | Cardinality | Reasoning |
|---|---|---|
| `relatedTo` | MANY_TO_MANY | symmetric, associative |
| `synonym` | MANY_TO_MANY | symmetric, equivalence |
| `antonym` | MANY_TO_MANY | symmetric |
| `broader` | **ONE_TO_MANY** | SKOS-strict: each term has at most one broader parent |
| `narrower` | **MANY_TO_ONE** | inverse of broader; each narrower-child has one parent |
| `partOf` | MANY_TO_MANY | schema marks this `isTransitive: false`, signalling loose semantics |
| `hasPart` | MANY_TO_MANY | inverse of partOf |
| `calculatedFrom` | MANY_TO_MANY | a metric can be calculated from many sources |
| `usedToCalculate` | MANY_TO_MANY | inverse |
| `seeAlso` | MANY_TO_MANY | symmetric |

**2. Add a 1.13.1 data migration** (`migration/utils/v1131/MigrationUtil.java` + `mysql|postgres/v1131/Migration.java`) that backfills `cardinality` on existing installs - only for system-defined relations whose `cardinality` is null, only when the relation name matches a known system default. Admin-modified relations and custom relations are left alone.

The IT (`GlossaryTermRelationSettingsIT.test_glossaryTermRelationSettingsExist`) now asserts `cardinality` is present and non-null for every relation type.

## Test plan

- [x] `mvn -pl openmetadata-service compile` - clean compile
- [x] `mvn spotless:apply`
- [ ] `GlossaryTermRelationSettingsIT` (requires full IT environment)
- [ ] Manual: GET on a fresh install returns the per-relation cardinality table above
- [ ] Manual: GET on an upgraded install (seeded before this change, no PUTs) returns the same values after the 1.13.1 migration runs
- [ ] Manual: PUT a custom relation type, GET again, verify system defaults retain their cardinality