### PR TITLE
test: fix flacky test for ontology behaviour

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/Glossary/GlossaryTermRelationsGraph.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/Glossary/GlossaryTermRelationsGraph.spec.ts
@@ -13,18 +13,20 @@
 import { expect, test } from '@playwright/test';
 import { Glossary } from '../../../support/glossary/Glossary';
 import { GlossaryTerm } from '../../../support/glossary/GlossaryTerm';
-import { AdminClass } from '../../../support/user/AdminClass';
-import { performAdminLogin } from '../../../utils/admin';
 import { redirectToHomePage } from '../../../utils/common';
 import { waitForAllLoadersToDisappear } from '../../../utils/entity';
 import {
   addTermRelation,
+  createApiContext,
+  deleteEntities,
+  disposeApiContext,
   readGraphEdges,
   readNodePositions,
   waitForGraphLoaded,
 } from '../../../utils/ontologyExplorer';
 
-const adminUser = new AdminClass();
+test.use({ storageState: 'playwright/.auth/admin.json' });
+
 const glossary = new Glossary();
 const termA = new GlossaryTerm(glossary);
 const termB = new GlossaryTerm(glossary);
@@ -37,7 +39,7 @@ const termInX = new GlossaryTerm(glossaryX);
 const termInY = new GlossaryTerm(glossaryY);
 
 test.beforeAll('Seed test data', async ({ browser }) => {
-  const { apiContext, afterAction } = await performAdminLogin(browser);
+  const { page, apiContext } = await createApiContext(browser);
 
   await glossary.create(apiContext);
   await termA.create(apiContext);
@@ -53,32 +55,32 @@ test.beforeAll('Seed test data', async ({ browser }) => {
   await termInY.create(apiContext);
   await addTermRelation(apiContext, termInX, termInY, 'relatedTo');
 
-  await afterAction();
+  await disposeApiContext(page, apiContext);
 });
 
 test.afterAll('Cleanup test data', async ({ browser }) => {
-  const { apiContext, afterAction } = await performAdminLogin(browser);
+  const { page, apiContext } = await createApiContext(browser);
 
-  await termA.delete(apiContext);
-  await termB.delete(apiContext);
-  await termC.delete(apiContext);
-  await termD.delete(apiContext);
+  await deleteEntities(
+    apiContext,
+    termA,
+    termB,
+    termC,
+    termD,
+    termInX,
+    termInY
+  );
   await glossary.delete(apiContext);
-  await termInX.delete(apiContext);
-  await termInY.delete(apiContext);
   await glossaryX.delete(apiContext);
   await glossaryY.delete(apiContext);
 
-  await afterAction();
+  await disposeApiContext(page, apiContext);
 });
 
 test.describe('Glossary Term — Relations Graph tab', () => {
   test('Relations Graph tab renders the ontology explorer for a term with a same-glossary relation', async ({
-    browser,
+    page,
   }) => {
-    const page = await browser.newPage();
-    await adminUser.login(page);
-
     await redirectToHomePage(page);
     await termA.visitEntityPage(page);
     await waitForAllLoadersToDisappear(page);
@@ -86,16 +88,11 @@ test.describe('Glossary Term — Relations Graph tab', () => {
     await page.getByRole('tab', { name: 'Relations Graph' }).click();
     await expect(page.getByTestId('ontology-explorer')).toBeVisible();
     await waitForGraphLoaded(page);
-
-    await page.close();
   });
 
   test('the term itself appears as a node in the Relations Graph', async ({
-    browser,
+    page,
   }) => {
-    const page = await browser.newPage();
-    await adminUser.login(page);
-
     await redirectToHomePage(page);
     await termA.visitEntityPage(page);
     await waitForAllLoadersToDisappear(page);
@@ -110,16 +107,11 @@ test.describe('Glossary Term — Relations Graph tab', () => {
       positions[termA.responseData.id],
       'termA (the viewed term) must be present as a node in the graph'
     ).toBeDefined();
-
-    await page.close();
   });
 
   test('the directly related term appears as a node in the Relations Graph', async ({
-    browser,
+    page,
   }) => {
-    const page = await browser.newPage();
-    await adminUser.login(page);
-
     await redirectToHomePage(page);
     await termA.visitEntityPage(page);
     await waitForAllLoadersToDisappear(page);
@@ -134,16 +126,11 @@ test.describe('Glossary Term — Relations Graph tab', () => {
       positions[termB.responseData.id],
       'termB (directly related via relatedTo) must appear as a node'
     ).toBeDefined();
-
-    await page.close();
   });
 
   test('an edge with the correct relationType exists between the term and its related term', async ({
-    browser,
+    page,
   }) => {
-    const page = await browser.newPage();
-    await adminUser.login(page);
-
     await redirectToHomePage(page);
     await termA.visitEntityPage(page);
     await waitForAllLoadersToDisappear(page);
@@ -169,16 +156,11 @@ test.describe('Glossary Term — Relations Graph tab', () => {
       edge?.relationType,
       'The edge relationType must be "relatedTo"'
     ).toBe('relatedTo');
-
-    await page.close();
   });
 
   test('all relation types from the same term appear as separate edges', async ({
-    browser,
+    page,
   }) => {
-    const page = await browser.newPage();
-    await adminUser.login(page);
-
     await redirectToHomePage(page);
     await termA.visitEntityPage(page);
     await waitForAllLoadersToDisappear(page);
@@ -223,16 +205,11 @@ test.describe('Glossary Term — Relations Graph tab', () => {
       seeAlsoEdge,
       'A seeAlso edge to termD must be rendered'
     ).toBeDefined();
-
-    await page.close();
   });
 
   test('cross-glossary related term appears as a node in the Relations Graph', async ({
-    browser,
+    page,
   }) => {
-    const page = await browser.newPage();
-    await adminUser.login(page);
-
     await redirectToHomePage(page);
     await termInX.visitEntityPage(page);
     await waitForAllLoadersToDisappear(page);
@@ -247,17 +224,12 @@ test.describe('Glossary Term — Relations Graph tab', () => {
       positions[termInY.responseData.id],
       'termInY (from a different glossary) must appear as a node when it is related to termInX'
     ).toBeDefined();
-
-    await page.close();
   });
 
   test('cross-glossary related term has an edge to the viewed term', async ({
-    browser,
+    page,
   }) => {
     test.slow();
-    const page = await browser.newPage();
-    await adminUser.login(page);
-
     await redirectToHomePage(page);
     await termInX.visitEntityPage(page);
     await waitForAllLoadersToDisappear(page);
@@ -279,16 +251,11 @@ test.describe('Glossary Term — Relations Graph tab', () => {
       hasEdge,
       'An edge between termInX and the cross-glossary termInY must be rendered'
     ).toBe(true);
-
-    await page.close();
   });
 
   test('unrelated term from the same glossary is NOT shown in the Relations Graph', async ({
-    browser,
+    page,
   }) => {
-    const page = await browser.newPage();
-    await adminUser.login(page);
-
     await redirectToHomePage(page);
     await termA.visitEntityPage(page);
     await waitForAllLoadersToDisappear(page);
@@ -312,16 +279,11 @@ test.describe('Glossary Term — Relations Graph tab', () => {
       positions[termB.responseData.id],
       'termB (directly related to termA) must be present'
     ).toBeDefined();
-
-    await page.close();
   });
 
   test('a term with no relations shows only itself as a node with no edges', async ({
-    browser,
+    page,
   }) => {
-    const page = await browser.newPage();
-    await adminUser.login(page);
-
     await redirectToHomePage(page);
     await termC.visitEntityPage(page);
     await waitForAllLoadersToDisappear(page);
@@ -331,7 +293,7 @@ test.describe('Glossary Term — Relations Graph tab', () => {
     await waitForGraphLoaded(page);
 
     const positions = await readNodePositions(page);
-    const edges = await readGraphEdges(page);
+    const edges = await readGraphEdges(page, 0);
 
     expect(
       positions[termC.responseData.id],
@@ -341,17 +303,12 @@ test.describe('Glossary Term — Relations Graph tab', () => {
       edges.length,
       'There must be no edges for a term with zero relations'
     ).toBe(0);
-
-    await page.close();
   });
 
   test('clicking a node in the Relations Graph opens the entity summary panel', async ({
-    browser,
+    page,
   }) => {
     test.slow();
-    const page = await browser.newPage();
-    await adminUser.login(page);
-
     await redirectToHomePage(page);
     await termA.visitEntityPage(page);
     await waitForAllLoadersToDisappear(page);
@@ -369,16 +326,11 @@ test.describe('Glossary Term — Relations Graph tab', () => {
     await expect(
       page.getByTestId('entity-summary-panel-container')
     ).toBeVisible();
-
-    await page.close();
   });
 
   test('search in the Relations Graph filters to matching node and its neighbours', async ({
-    browser,
+    page,
   }) => {
-    const page = await browser.newPage();
-    await adminUser.login(page);
-
     await redirectToHomePage(page);
     await termA.visitEntityPage(page);
     await waitForAllLoadersToDisappear(page);
@@ -408,17 +360,12 @@ test.describe('Glossary Term — Relations Graph tab', () => {
     expect(Object.keys(restoredPositions).length).toBeGreaterThanOrEqual(
       Object.keys(positions).length
     );
-
-    await page.close();
   });
 
   test('search in the term Relations Graph returns empty state when no term matches', async ({
-    browser,
+    page,
   }) => {
     test.slow();
-    const page = await browser.newPage();
-    await adminUser.login(page);
-
     await redirectToHomePage(page);
     await termA.visitEntityPage(page);
     await waitForAllLoadersToDisappear(page);
@@ -436,7 +383,5 @@ test.describe('Glossary Term — Relations Graph tab', () => {
 
     await searchInput.clear();
     await expect(page.getByTestId('ontology-graph-empty')).not.toBeVisible();
-
-    await page.close();
   });
 });

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/OntologyExplorerCardinality.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/OntologyExplorerCardinality.spec.ts
@@ -30,12 +30,14 @@ import {
 
 test.use({ storageState: 'playwright/.auth/admin.json' });
 
+// Unique suffix per worker/repeat so parallel runs don't share relation type names.
+const RUN_ID = Math.random().toString(36).slice(2, 8);
 const CUSTOM_RELATION_NAMES = {
-  ONE_TO_ONE: 'pw-cardinality-oto',
-  ONE_TO_MANY: 'pw-cardinality-otm',
-  MANY_TO_ONE: 'pw-cardinality-mto',
-  MANY_TO_MANY: 'pw-cardinality-mtm',
-  CUSTOM_1_M: 'pw-cardinality-custom',
+  ONE_TO_ONE: `pw-c-oto-${RUN_ID}`,
+  ONE_TO_MANY: `pw-c-otm-${RUN_ID}`,
+  MANY_TO_ONE: `pw-c-mto-${RUN_ID}`,
+  MANY_TO_MANY: `pw-c-mtm-${RUN_ID}`,
+  CUSTOM_1_M: `pw-c-cus-${RUN_ID}`,
 } as const;
 
 // Each relation type gets its own isolated source-target pair so no single
@@ -101,11 +103,36 @@ test.describe('Ontology Explorer - Cardinality Labels', () => {
       targetMax: null,
     });
 
-    await addTermRelation(apiContext, otoSrc, otoDst, CUSTOM_RELATION_NAMES.ONE_TO_ONE);
-    await addTermRelation(apiContext, otmSrc, otmDst, CUSTOM_RELATION_NAMES.ONE_TO_MANY);
-    await addTermRelation(apiContext, mtoSrc, mtoDst, CUSTOM_RELATION_NAMES.MANY_TO_ONE);
-    await addTermRelation(apiContext, mtmSrc, mtmDst, CUSTOM_RELATION_NAMES.MANY_TO_MANY);
-    await addTermRelation(apiContext, cusSrc, cusDst, CUSTOM_RELATION_NAMES.CUSTOM_1_M);
+    await addTermRelation(
+      apiContext,
+      otoSrc,
+      otoDst,
+      CUSTOM_RELATION_NAMES.ONE_TO_ONE
+    );
+    await addTermRelation(
+      apiContext,
+      otmSrc,
+      otmDst,
+      CUSTOM_RELATION_NAMES.ONE_TO_MANY
+    );
+    await addTermRelation(
+      apiContext,
+      mtoSrc,
+      mtoDst,
+      CUSTOM_RELATION_NAMES.MANY_TO_ONE
+    );
+    await addTermRelation(
+      apiContext,
+      mtmSrc,
+      mtmDst,
+      CUSTOM_RELATION_NAMES.MANY_TO_MANY
+    );
+    await addTermRelation(
+      apiContext,
+      cusSrc,
+      cusDst,
+      CUSTOM_RELATION_NAMES.CUSTOM_1_M
+    );
     await addTermRelation(apiContext, relSrc, relDst, 'relatedTo');
 
     await disposeApiContext(page, apiContext);

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/OntologyExplorerCardinality.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/OntologyExplorerCardinality.spec.ts
@@ -38,23 +38,40 @@ const CUSTOM_RELATION_NAMES = {
   CUSTOM_1_M: 'pw-cardinality-custom',
 } as const;
 
+// Each relation type gets its own isolated source-target pair so no single
+// term accumulates multiple cardinality-constrained relations, which would
+// trigger backend re-validation failures on the second PATCH.
 const glossary = new Glossary();
-const termA = new GlossaryTerm(glossary);
-const termB = new GlossaryTerm(glossary);
-const termC = new GlossaryTerm(glossary);
-const termD = new GlossaryTerm(glossary);
-const termE = new GlossaryTerm(glossary);
+const otoSrc = new GlossaryTerm(glossary);
+const otoDst = new GlossaryTerm(glossary);
+const otmSrc = new GlossaryTerm(glossary);
+const otmDst = new GlossaryTerm(glossary);
+const mtoSrc = new GlossaryTerm(glossary);
+const mtoDst = new GlossaryTerm(glossary);
+const mtmSrc = new GlossaryTerm(glossary);
+const mtmDst = new GlossaryTerm(glossary);
+const cusSrc = new GlossaryTerm(glossary);
+const cusDst = new GlossaryTerm(glossary);
+const relSrc = new GlossaryTerm(glossary);
+const relDst = new GlossaryTerm(glossary);
 
 test.describe('Ontology Explorer - Cardinality Labels', () => {
   test.beforeAll(async ({ browser }) => {
     const { page, apiContext } = await createApiContext(browser);
 
     await glossary.create(apiContext);
-    await termA.create(apiContext);
-    await termB.create(apiContext);
-    await termC.create(apiContext);
-    await termD.create(apiContext);
-    await termE.create(apiContext);
+    await otoSrc.create(apiContext);
+    await otoDst.create(apiContext);
+    await otmSrc.create(apiContext);
+    await otmDst.create(apiContext);
+    await mtoSrc.create(apiContext);
+    await mtoDst.create(apiContext);
+    await mtmSrc.create(apiContext);
+    await mtmDst.create(apiContext);
+    await cusSrc.create(apiContext);
+    await cusDst.create(apiContext);
+    await relSrc.create(apiContext);
+    await relDst.create(apiContext);
 
     await addRelationTypeWithCardinality(apiContext, {
       name: CUSTOM_RELATION_NAMES.ONE_TO_ONE,
@@ -84,30 +101,12 @@ test.describe('Ontology Explorer - Cardinality Labels', () => {
       targetMax: null,
     });
 
-    await addTermRelation(
-      apiContext,
-      termA,
-      termB,
-      CUSTOM_RELATION_NAMES.ONE_TO_ONE
-    );
-    await addTermRelation(
-      apiContext,
-      termA,
-      termC,
-      CUSTOM_RELATION_NAMES.ONE_TO_MANY
-    );
-    await addTermRelation(
-      apiContext,
-      termA,
-      termD,
-      CUSTOM_RELATION_NAMES.MANY_TO_ONE
-    );
-    await addTermRelation(
-      apiContext,
-      termA,
-      termE,
-      CUSTOM_RELATION_NAMES.MANY_TO_MANY
-    );
+    await addTermRelation(apiContext, otoSrc, otoDst, CUSTOM_RELATION_NAMES.ONE_TO_ONE);
+    await addTermRelation(apiContext, otmSrc, otmDst, CUSTOM_RELATION_NAMES.ONE_TO_MANY);
+    await addTermRelation(apiContext, mtoSrc, mtoDst, CUSTOM_RELATION_NAMES.MANY_TO_ONE);
+    await addTermRelation(apiContext, mtmSrc, mtmDst, CUSTOM_RELATION_NAMES.MANY_TO_MANY);
+    await addTermRelation(apiContext, cusSrc, cusDst, CUSTOM_RELATION_NAMES.CUSTOM_1_M);
+    await addTermRelation(apiContext, relSrc, relDst, 'relatedTo');
 
     await disposeApiContext(page, apiContext);
   });
@@ -117,11 +116,18 @@ test.describe('Ontology Explorer - Cardinality Labels', () => {
 
     await deleteEntities(
       apiContext,
-      termA,
-      termB,
-      termC,
-      termD,
-      termE,
+      otoSrc,
+      otoDst,
+      otmSrc,
+      otmDst,
+      mtoSrc,
+      mtoDst,
+      mtmSrc,
+      mtmDst,
+      cusSrc,
+      cusDst,
+      relSrc,
+      relDst,
       glossary
     );
 

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/OntologyExplorerCardinality.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/OntologyExplorerCardinality.spec.ts
@@ -177,7 +177,10 @@ test.describe('Ontology Explorer - Cardinality Labels', () => {
     test('ONE_TO_ONE relation type should have label "1" on both ends', async ({
       page,
     }) => {
-      const cardinalityMap = await readCardinalityMap(page);
+      const cardinalityMap = await readCardinalityMap(
+        page,
+        CUSTOM_RELATION_NAMES.ONE_TO_ONE
+      );
 
       expect(cardinalityMap[CUSTOM_RELATION_NAMES.ONE_TO_ONE]).toEqual({
         startLabelText: '1',
@@ -188,7 +191,10 @@ test.describe('Ontology Explorer - Cardinality Labels', () => {
     test('ONE_TO_MANY relation type should have "1" at source and "M" at target', async ({
       page,
     }) => {
-      const cardinalityMap = await readCardinalityMap(page);
+      const cardinalityMap = await readCardinalityMap(
+        page,
+        CUSTOM_RELATION_NAMES.ONE_TO_MANY
+      );
 
       expect(cardinalityMap[CUSTOM_RELATION_NAMES.ONE_TO_MANY]).toEqual({
         startLabelText: '1',
@@ -199,7 +205,10 @@ test.describe('Ontology Explorer - Cardinality Labels', () => {
     test('MANY_TO_ONE relation type should have "M" at source and "1" at target', async ({
       page,
     }) => {
-      const cardinalityMap = await readCardinalityMap(page);
+      const cardinalityMap = await readCardinalityMap(
+        page,
+        CUSTOM_RELATION_NAMES.MANY_TO_ONE
+      );
 
       expect(cardinalityMap[CUSTOM_RELATION_NAMES.MANY_TO_ONE]).toEqual({
         startLabelText: 'M',
@@ -210,7 +219,10 @@ test.describe('Ontology Explorer - Cardinality Labels', () => {
     test('MANY_TO_MANY relation type should have label "M" on both ends', async ({
       page,
     }) => {
-      const cardinalityMap = await readCardinalityMap(page);
+      const cardinalityMap = await readCardinalityMap(
+        page,
+        CUSTOM_RELATION_NAMES.MANY_TO_MANY
+      );
 
       expect(cardinalityMap[CUSTOM_RELATION_NAMES.MANY_TO_MANY]).toEqual({
         startLabelText: 'M',
@@ -221,7 +233,10 @@ test.describe('Ontology Explorer - Cardinality Labels', () => {
     test('CUSTOM relation type with sourceMax=1 and no targetMax should produce "1" → "M"', async ({
       page,
     }) => {
-      const cardinalityMap = await readCardinalityMap(page);
+      const cardinalityMap = await readCardinalityMap(
+        page,
+        CUSTOM_RELATION_NAMES.CUSTOM_1_M
+      );
 
       expect(cardinalityMap[CUSTOM_RELATION_NAMES.CUSTOM_1_M]).toEqual({
         startLabelText: '1',
@@ -232,7 +247,7 @@ test.describe('Ontology Explorer - Cardinality Labels', () => {
     test('built-in relation type shows M:M cardinality in the cardinality map', async ({
       page,
     }) => {
-      const cardinalityMap = await readCardinalityMap(page);
+      const cardinalityMap = await readCardinalityMap(page, 'relatedTo');
 
       expect(cardinalityMap['relatedTo']).toEqual({
         startLabelText: 'M',
@@ -245,7 +260,8 @@ test.describe('Ontology Explorer - Cardinality Labels', () => {
     test('edges for cardinality-typed relations appear in the graph edge data', async ({
       page,
     }) => {
-      const edges = await readGraphEdges(page);
+      // Wait for at least 5 edges so all custom-cardinality types are present.
+      const edges = await readGraphEdges(page, 5);
       const relationTypes = new Set(edges.map((e) => e.relationType));
 
       expect(

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/OntologyExplorerE2E.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/OntologyExplorerE2E.spec.ts
@@ -31,7 +31,9 @@ import {
 
 test.use({ storageState: 'playwright/.auth/admin.json' });
 
-const CUSTOM_OWNS_RELATION = 'pw-gp-owns';
+// Unique suffix per worker/repeat so parallel runs don't share relation type names.
+const RUN_ID = Math.random().toString(36).slice(2, 8);
+const CUSTOM_OWNS_RELATION = `pw-gp-owns-${RUN_ID}`;
 
 const catalog = new Glossary();
 const termProduct = new GlossaryTerm(catalog);
@@ -209,7 +211,8 @@ test.describe('Ontology Explorer — E2E', () => {
     await page.getByRole('option', { name: 'Overview' }).click();
 
     await expect(page.getByTestId('ontology-explorer-stats')).toContainText(
-      '6 Relations'
+      '6 Relations',
+      { timeout: 45000 }
     );
   });
 

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/OntologyExplorerE2E.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/OntologyExplorerE2E.spec.ts
@@ -207,7 +207,6 @@ test.describe('Ontology Explorer — E2E', () => {
 
     await page.getByTestId('view-mode-select').click();
     await page.getByRole('option', { name: 'Overview' }).click();
-    await waitForGraphLoaded(page);
 
     await expect(page.getByTestId('ontology-explorer-stats')).toContainText(
       '6 Relations'

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/OntologyExplorerE2E.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/OntologyExplorerE2E.spec.ts
@@ -117,7 +117,7 @@ test.describe('Ontology Explorer — E2E', () => {
   test('graph edges contain all four expected relation types', async ({
     page,
   }) => {
-    const edges = await readGraphEdges(page);
+    const edges = await readGraphEdges(page, 4);
     const types = new Set(
       edges.flatMap((e) =>
         e.inverseRelationType
@@ -134,7 +134,7 @@ test.describe('Ontology Explorer — E2E', () => {
   test('custom ONE_TO_MANY relation shows "1" at source and "M" at target', async ({
     page,
   }) => {
-    const map = await readCardinalityMap(page);
+    const map = await readCardinalityMap(page, CUSTOM_OWNS_RELATION);
 
     expect(map[CUSTOM_OWNS_RELATION]).toEqual({
       startLabelText: '1',
@@ -145,7 +145,7 @@ test.describe('Ontology Explorer — E2E', () => {
   test('built-in relations show M:M cardinality in the cardinality map', async ({
     page,
   }) => {
-    const map = await readCardinalityMap(page);
+    const map = await readCardinalityMap(page, ['relatedTo', 'partOf']);
 
     expect(map['relatedTo']).toEqual({
       startLabelText: 'M',
@@ -294,7 +294,7 @@ test.describe('Ontology Explorer — E2E', () => {
     await expect(toggle).toHaveAttribute('data-selected', 'true');
     await page.getByTestId('graph-settings-close').click();
 
-    const map = await readCardinalityMap(page);
+    const map = await readCardinalityMap(page, CUSTOM_OWNS_RELATION);
     expect(map[CUSTOM_OWNS_RELATION]).toEqual({
       startLabelText: '1',
       endLabelText: 'M',

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/OntologyExplorerFilters.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/OntologyExplorerFilters.spec.ts
@@ -17,6 +17,7 @@ import { GlossaryTerm } from '../../support/glossary/GlossaryTerm';
 import {
   addTermRelation,
   applyGlossaryFilter,
+  applyMultiGlossaryFilter,
   applyRelationTypeFilter,
   createApiContext,
   deleteEntities,
@@ -311,10 +312,11 @@ test.describe('Ontology Explorer - Filters and Tabs', () => {
     }) => {
       await waitForGraphLoaded(page);
 
-      await page.getByTestId('search-dropdown-Glossary').click();
-      await page.getByTestId(glossary.responseData.id).click();
-      await page.getByTestId(glossary2.responseData.id).click();
-      await page.getByTestId('update-btn').click();
+      await applyMultiGlossaryFilter(
+        page,
+        glossary.responseData.id,
+        glossary2.responseData.id
+      );
       await waitForGraphLoaded(page);
 
       await expect(page.getByTestId('ontology-explorer-stats')).toContainText(
@@ -327,15 +329,15 @@ test.describe('Ontology Explorer - Filters and Tabs', () => {
     }) => {
       await waitForGraphLoaded(page);
 
-      await page.getByTestId('search-dropdown-Glossary').click();
-      await page.getByTestId(glossary.responseData.id).click();
-      await page.getByTestId(glossary2.responseData.id).click();
-      await page.getByTestId('update-btn').click();
+      await applyMultiGlossaryFilter(
+        page,
+        glossary.responseData.id,
+        glossary2.responseData.id
+      );
       await waitForGraphLoaded(page);
 
-      await page.getByTestId('search-dropdown-Glossary').click();
-      await page.getByTestId(glossary2.responseData.id).click();
-      await page.getByTestId('update-btn').click();
+      // Deselect glossary2 — clicks the already-selected ID to uncheck it.
+      await applyMultiGlossaryFilter(page, glossary2.responseData.id);
       await waitForGraphLoaded(page);
 
       await expect(page.getByTestId('ontology-explorer-stats')).toContainText(

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/OntologyExplorerIntegration.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/OntologyExplorerIntegration.spec.ts
@@ -18,6 +18,7 @@ import { GlossaryTerm } from '../../support/glossary/GlossaryTerm';
 import { getAuthContext, getToken, uuid } from '../../utils/common';
 import {
   addTermRelation,
+  applyMultiGlossaryFilter,
   applyRelationTypeFilter,
   clickDataModeAssetBadge,
   createApiContext,
@@ -254,10 +255,11 @@ test.describe('Ontology Explorer - Cross Glossary Edges', () => {
     await navigateToOntologyExplorer(page);
     await waitForGraphLoaded(page);
 
-    await page.getByTestId('search-dropdown-Glossary').click();
-    await page.getByTestId(crossGlossary1.responseData.id).click();
-    await page.getByTestId(crossGlossary2.responseData.id).click();
-    await page.getByTestId('update-btn').click();
+    await applyMultiGlossaryFilter(
+      page,
+      crossGlossary1.responseData.id,
+      crossGlossary2.responseData.id
+    );
     await waitForGraphLoaded(page);
 
     await page.getByTestId('view-mode-select').click();
@@ -276,10 +278,11 @@ test.describe('Ontology Explorer - Cross Glossary Edges', () => {
     await navigateToOntologyExplorer(page);
     await waitForGraphLoaded(page);
 
-    await page.getByTestId('search-dropdown-Glossary').click();
-    await page.getByTestId(crossGlossary1.responseData.id).click();
-    await page.getByTestId(crossGlossary2.responseData.id).click();
-    await page.getByTestId('update-btn').click();
+    await applyMultiGlossaryFilter(
+      page,
+      crossGlossary1.responseData.id,
+      crossGlossary2.responseData.id
+    );
     await waitForGraphLoaded(page);
 
     // In overview mode crossTerm3 should be visible (has a same-glossary edge).

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/OntologyExplorerInteractions.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/OntologyExplorerInteractions.spec.ts
@@ -82,7 +82,6 @@ test.describe('Isolated nodes + relation filter combo', () => {
     page,
   }) => {
     await page.getByTestId('ontology-isolated-toggle').click();
-    await waitForGraphLoaded(page);
     await applyRelationTypeFilter(page, 'Synonym');
 
     await expect(page.getByTestId('ontology-graph-no-relations')).toBeVisible();
@@ -93,10 +92,8 @@ test.describe('Isolated nodes + relation filter combo', () => {
     page,
   }) => {
     await page.getByTestId('ontology-isolated-toggle').click();
-    await waitForGraphLoaded(page);
     await applyRelationTypeFilter(page, 'Synonym');
     await applyRelationTypeFilter(page, 'Synonym');
-    await waitForGraphLoaded(page);
 
     await expect(
       page.getByTestId('ontology-graph-no-relations')
@@ -110,11 +107,9 @@ test.describe('Isolated nodes + relation filter combo', () => {
     page,
   }) => {
     await page.getByTestId('ontology-isolated-toggle').click();
-    await waitForGraphLoaded(page);
     await applyRelationTypeFilter(page, 'Synonym');
 
     await page.getByTestId('ontology-isolated-toggle').click();
-    await waitForGraphLoaded(page);
 
     await expect(page.getByTestId('ontology-graph-no-relations')).toBeVisible();
   });

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/OntologyExplorerIsolatedToggle.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/OntologyExplorerIsolatedToggle.spec.ts
@@ -20,7 +20,8 @@ import {
   disposeApiContext,
   navigateAndFilterByGlossary,
   readNodePositions,
-  waitForGraphLoaded,
+  waitForNodeAbsent,
+  waitForNodePresent,
 } from '../../utils/ontologyExplorer';
 
 test.use({ storageState: 'playwright/.auth/admin.json' });
@@ -58,6 +59,7 @@ test.describe('Ontology Explorer — isolated nodes toggle', () => {
   test('isolated term is visible by default (showIsolatedNodes = true)', async ({
     page,
   }) => {
+    test.slow();
     await navigateAndFilterByGlossary(page, toggleGlossary.responseData.id);
 
     const positions = await readNodePositions(page);
@@ -79,10 +81,11 @@ test.describe('Ontology Explorer — isolated nodes toggle', () => {
   test('toggling isolated nodes OFF hides the isolated term', async ({
     page,
   }) => {
+    test.slow();
     await navigateAndFilterByGlossary(page, toggleGlossary.responseData.id);
 
     await page.getByTestId('ontology-isolated-toggle').click();
-    await waitForGraphLoaded(page);
+    await waitForNodeAbsent(page, toggleTermIso.responseData.id);
 
     const positions = await readNodePositions(page);
 
@@ -103,13 +106,14 @@ test.describe('Ontology Explorer — isolated nodes toggle', () => {
   test('toggling isolated nodes back ON restores the isolated term', async ({
     page,
   }) => {
+    test.slow();
     await navigateAndFilterByGlossary(page, toggleGlossary.responseData.id);
 
-    // Toggle OFF then back ON.
     await page.getByTestId('ontology-isolated-toggle').click();
-    await waitForGraphLoaded(page);
+    await waitForNodeAbsent(page, toggleTermIso.responseData.id);
+
     await page.getByTestId('ontology-isolated-toggle').click();
-    await waitForGraphLoaded(page);
+    await waitForNodePresent(page, toggleTermIso.responseData.id);
 
     const positions = await readNodePositions(page);
 

--- a/openmetadata-ui/src/main/resources/ui/playwright/support/glossary/GlossaryTerm.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/support/glossary/GlossaryTerm.ts
@@ -126,7 +126,9 @@ export class GlossaryTerm extends EntityClass {
     if (!response.ok()) {
       const body = await response.text();
       throw new Error(
-        `GlossaryTerm.patch failed for ${this.responseData.id}: HTTP ${response.status()} — ${body}`
+        `GlossaryTerm.patch failed for ${
+          this.responseData.id
+        }: HTTP ${response.status()} — ${body}`
       );
     }
 

--- a/openmetadata-ui/src/main/resources/ui/playwright/support/glossary/GlossaryTerm.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/support/glossary/GlossaryTerm.ts
@@ -123,6 +123,13 @@ export class GlossaryTerm extends EntityClass {
       }
     );
 
+    if (!response.ok()) {
+      const body = await response.text();
+      throw new Error(
+        `GlossaryTerm.patch failed for ${this.responseData.id}: HTTP ${response.status()} — ${body}`
+      );
+    }
+
     this.responseData = await response.json();
   }
 

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/ontologyExplorer.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/ontologyExplorer.ts
@@ -21,7 +21,16 @@ import { sidebarClick } from '../utils/sidebar';
 export async function applyGlossaryFilter(page: Page, glossaryId: string) {
   await page.getByTestId('search-dropdown-Glossary').click();
   await page.getByTestId(glossaryId).click();
+  const termsResponse = page
+    .waitForResponse(
+      (response) =>
+        response.url().includes('/api/v1/glossaryTerms') &&
+        response.status() === 200,
+      { timeout: 30000 }
+    )
+    .catch(() => null);
   await page.getByTestId('update-btn').click();
+  await termsResponse;
 }
 
 export async function navigateToOntologyExplorer(page: Page) {
@@ -84,8 +93,15 @@ export async function readGraphEdges(page: Page): Promise<RenderedEdge[]> {
   await page.waitForFunction(
     () => {
       const el = document.querySelector<HTMLElement>('.ontology-g6-container');
-
-      return typeof el?.dataset.edges === 'string';
+      const raw = el?.dataset.edges;
+      if (typeof raw !== 'string') {
+        return false;
+      }
+      try {
+        return (JSON.parse(raw) as unknown[]).length > 0;
+      } catch {
+        return false;
+      }
     },
     { timeout: 20000 }
   );
@@ -214,9 +230,18 @@ export async function readCardinalityMap(
   page: Page
 ): Promise<Record<string, CardinalityLabels>> {
   await page.waitForFunction(
-    () =>
-      typeof document.querySelector<HTMLElement>('.ontology-g6-container')
-        ?.dataset.cardinalityMap === 'string',
+    () => {
+      const el = document.querySelector<HTMLElement>('.ontology-g6-container');
+      const raw = el?.dataset.cardinalityMap;
+      if (typeof raw !== 'string') {
+        return false;
+      }
+      try {
+        return Object.keys(JSON.parse(raw)).length > 0;
+      } catch {
+        return false;
+      }
+    },
     { timeout: 20000 }
   );
 
@@ -374,5 +399,70 @@ export async function waitForMoreNodesThan(
     },
     count,
     { timeout: 30000 }
+  );
+}
+export async function applyMultiGlossaryFilter(
+  page: Page,
+  ...glossaryIds: string[]
+): Promise<void> {
+  await page.getByTestId('search-dropdown-Glossary').click();
+  for (const id of glossaryIds) {
+    await page.getByTestId(id).click();
+  }
+  const termsResponse = page
+    .waitForResponse(
+      (response) =>
+        response.url().includes('/api/v1/glossaryTerms') &&
+        response.status() === 200,
+      { timeout: 30000 }
+    )
+    .catch(() => null);
+  await page.getByTestId('update-btn').click();
+  await termsResponse;
+}
+
+export async function waitForNodePresent(
+  page: Page,
+  termId: string
+): Promise<void> {
+  await page.waitForFunction(
+    (id) => {
+      const el = document.querySelector<HTMLElement>('.ontology-g6-container');
+      const raw = el?.dataset.nodePositions;
+      if (!raw) {
+        return false;
+      }
+      try {
+        return id in JSON.parse(raw);
+      } catch {
+        return false;
+      }
+    },
+    termId,
+    { timeout: 20000 }
+  );
+}
+
+export async function waitForNodeAbsent(
+  page: Page,
+  termId: string
+): Promise<void> {
+  await page.waitForFunction(
+    (id) => {
+      const el = document.querySelector<HTMLElement>('.ontology-g6-container');
+      const raw = el?.dataset.nodePositions;
+      if (!raw) {
+        return false;
+      }
+      try {
+        const positions = JSON.parse(raw);
+
+        return !(id in positions) && Object.keys(positions).length > 0;
+      } catch {
+        return false;
+      }
+    },
+    termId,
+    { timeout: 20000 }
   );
 }

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/ontologyExplorer.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/ontologyExplorer.ts
@@ -101,7 +101,9 @@ export async function readGraphEdges(
         return false;
       }
       try {
-        return (JSON.parse(raw) as unknown[]).length >= min;
+        const count = (JSON.parse(raw) as unknown[]).length;
+
+        return min === 0 ? true : count >= min;
       } catch {
         return false;
       }

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/ontologyExplorer.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/ontologyExplorer.ts
@@ -150,32 +150,32 @@ export async function addTermRelation(
   toTerm: GlossaryTerm,
   relationType: string
 ) {
+  const toTermRef = {
+    id: toTerm.responseData.id,
+    type: 'glossaryTerm',
+    name: toTerm.responseData.name,
+    displayName: toTerm.responseData.displayName,
+    fullyQualifiedName: toTerm.responseData.fullyQualifiedName,
+  };
   const termRes = await apiContext.get(
     `/api/v1/glossaryTerms/${fromTerm.responseData.id}?fields=relatedTerms`
   );
   const termData = await termRes.json();
-  const existingRelations: Array<Record<string, unknown>> =
-    termData.relatedTerms ?? [];
+  const hasExisting =
+    Array.isArray(termData.relatedTerms) && termData.relatedTerms.length > 0;
+  const patchOp = hasExisting
+    ? {
+        op: 'add',
+        path: '/relatedTerms/-',
+        value: { relationType, term: toTermRef },
+      }
+    : {
+        op: 'add',
+        path: '/relatedTerms',
+        value: [{ relationType, term: toTermRef }],
+      };
 
-  await fromTerm.patch(apiContext, [
-    {
-      op: 'add',
-      path: '/relatedTerms',
-      value: [
-        ...existingRelations,
-        {
-          relationType,
-          term: {
-            id: toTerm.responseData.id,
-            type: 'glossaryTerm',
-            name: toTerm.responseData.name,
-            displayName: toTerm.responseData.displayName,
-            fullyQualifiedName: toTerm.responseData.fullyQualifiedName,
-          },
-        },
-      ],
-    },
-  ]);
+  await fromTerm.patch(apiContext, [patchOp]);
 }
 
 export async function navigateAndFilterByGlossary(

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/ontologyExplorer.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/ontologyExplorer.ts
@@ -89,20 +89,24 @@ export interface RenderedEdge {
   inverseRelationType?: string;
 }
 
-export async function readGraphEdges(page: Page): Promise<RenderedEdge[]> {
+export async function readGraphEdges(
+  page: Page,
+  minCount = 1
+): Promise<RenderedEdge[]> {
   await page.waitForFunction(
-    () => {
+    (min) => {
       const el = document.querySelector<HTMLElement>('.ontology-g6-container');
       const raw = el?.dataset.edges;
       if (typeof raw !== 'string') {
         return false;
       }
       try {
-        return (JSON.parse(raw) as unknown[]).length > 0;
+        return (JSON.parse(raw) as unknown[]).length >= min;
       } catch {
         return false;
       }
     },
+    minCount,
     { timeout: 20000 }
   );
 
@@ -227,21 +231,29 @@ export type CardinalityLabels = {
 };
 
 export async function readCardinalityMap(
-  page: Page
+  page: Page,
+  waitForKeys: string | string[] = []
 ): Promise<Record<string, CardinalityLabels>> {
+  const keys = Array.isArray(waitForKeys) ? waitForKeys : [waitForKeys];
+
   await page.waitForFunction(
-    () => {
+    (requiredKeys) => {
       const el = document.querySelector<HTMLElement>('.ontology-g6-container');
       const raw = el?.dataset.cardinalityMap;
       if (typeof raw !== 'string') {
         return false;
       }
       try {
-        return Object.keys(JSON.parse(raw)).length > 0;
+        const parsed = JSON.parse(raw) as Record<string, unknown>;
+
+        return requiredKeys.length === 0
+          ? Object.keys(parsed).length > 0
+          : requiredKeys.every((k) => k in parsed);
       } catch {
         return false;
       }
     },
+    keys,
     { timeout: 20000 }
   );
 


### PR DESCRIPTION
Fix flacky test for ontology explorer behaviour

----
## Summary by Gitar

- **Test stability improvements:**
  - Optimized E2E login flow by utilizing `test.use({ storageState })` instead of manual `AdminClass` login for each test.
  - Streamlined test cleanup using a centralized `deleteEntities` utility in `afterAll` blocks.
  - Updated `readGraphEdges` to support validation of empty edge sets, preventing false-negative timeouts in tests with no relations.

<sub>This will update automatically on new commits.</sub>