### PR TITLE
docs: fix typos in ingestion docstrings

### DIFF
--- a/ingestion/src/metadata/profiler/metrics/system/snowflake/system.py
+++ b/ingestion/src/metadata/profiler/metrics/system/snowflake/system.py
@@ -86,7 +86,7 @@ class SnowflakeTableResovler:
     - The public schema
 
     This can be altered by changing the SEARCH_PATH session parameter. If the users change
-    this paramter, this resolver will might return wrong values.
+    this parameter, this resolver will might return wrong values.
 
     There is no way to extract the SEARCH_PATH from the query after it has been executed. Hence, we can
     only rely on the default behavior and maybe allow the users to configure the search path

--- a/ingestion/tests/integration/trino/conftest.py
+++ b/ingestion/tests/integration/trino/conftest.py
@@ -252,8 +252,8 @@ def create_test_data_from_sql(engine: Engine, file_path: Path):
 
 def custom_insert(self, conn, keys: list[str], data_iter):
     """
-    Hack pandas.io.sql.SQLTable._execute_insert_multi to retry untill rows are inserted.
-    This is required becauase using trino with pd.to_sql in our setup us unreliable.
+    Hack pandas.io.sql.SQLTable._execute_insert_multi to retry until rows are inserted.
+    This is required because using trino with pd.to_sql in our setup is unreliable.
     """
     rowcount = 0
     max_tries = 20


### PR DESCRIPTION
Spotted while reading through the ingestion module:

- `paramter` -> `parameter` in [snowflake/system.py:89](ingestion/src/metadata/profiler/metrics/system/snowflake/system.py#L89)
- `untill` -> `until`, `becauase` -> `because`, `us` -> `is` in [trino/conftest.py:255-256](ingestion/tests/integration/trino/conftest.py#L255)

Docstrings only, no behavior change.