### PR TITLE
fix(search): add opt-in relevance ordering to /search/aggregate

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/search/SearchResource.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/search/SearchResource.java
@@ -729,7 +729,17 @@ public class SearchResource {
       @DefaultValue("false") @QueryParam("deleted") boolean deleted,
       @Parameter(description = "Free-text search query to scope aggregation results")
           @QueryParam("queryText")
-          String queryText)
+          String queryText,
+      @Parameter(
+              description =
+                  "Bucket ordering mode. 'key' (default) sorts alphabetically. "
+                      + "'relevance' ranks buckets by closeness to the typed literal "
+                      + "in `value` (exact > prefix > substring). Relevance ordering "
+                      + "activates only when `value` is wildcard-wrapped as .*<literal>.*; "
+                      + "otherwise falls back to 'key'.")
+          @DefaultValue("key")
+          @QueryParam("orderBy")
+          String orderBy)
       throws IOException {
 
     AggregationRequest aggregationRequest =
@@ -741,7 +751,8 @@ public class SearchResource {
             .withFieldValue(value)
             .withSourceFields(SearchUtils.sourceFields(sourceFieldsParam))
             .withDeleted(deleted)
-            .withQueryText(queryText);
+            .withQueryText(queryText)
+            .withOrderBy(AggregationRequest.OrderBy.fromValue(orderBy));
 
     return searchRepository.aggregate(aggregationRequest);
   }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/elasticsearch/ElasticSearchAggregationManager.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/elasticsearch/ElasticSearchAggregationManager.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import es.co.elastic.clients.elasticsearch.ElasticsearchClient;
+import es.co.elastic.clients.elasticsearch._types.Script;
 import es.co.elastic.clients.elasticsearch._types.SortOrder;
 import es.co.elastic.clients.elasticsearch._types.aggregations.Aggregation;
 import es.co.elastic.clients.elasticsearch._types.query_dsl.Query;
@@ -22,6 +23,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import lombok.extern.slf4j.Slf4j;
 import org.openmetadata.common.utils.CommonUtil;
 import org.openmetadata.schema.api.search.SearchSettings;
@@ -63,6 +66,33 @@ public class ElasticSearchAggregationManager implements AggregationManagementCli
     this.isClientAvailable = client != null;
     this.rbacConditionEvaluator = rbacConditionEvaluator;
     mapper = new ObjectMapper();
+  }
+
+  private static final Pattern WRAPPED_LITERAL = Pattern.compile("^\\.\\*(.+)\\.\\*$");
+
+  private static Optional<String> extractLiteralForRelevance(String includeValue) {
+    if (includeValue == null || includeValue.isEmpty() || ".*".equals(includeValue)) {
+      return Optional.empty();
+    }
+    Matcher m = WRAPPED_LITERAL.matcher(includeValue);
+    if (!m.matches()) {
+      return Optional.empty();
+    }
+    String inner = m.group(1);
+    for (int i = 0; i < inner.length(); i++) {
+      char c = inner.charAt(i);
+      if (c == '.' || c == '*' || c == '\\' || c == '[' || c == ']' || c == '(' || c == ')'
+          || c == '|' || c == '?' || c == '+' || c == '^' || c == '$' || c == '{' || c == '}') {
+        return Optional.empty();
+      }
+    }
+    return Optional.of(inner);
+  }
+
+  private static Query buildRelevanceScoringClause(String field, String literal) {
+    Query exact = Query.of(q -> q.term(t -> t.field(field).value(literal).boost(100f)));
+    Query prefix = Query.of(q -> q.prefix(p -> p.field(field).value(literal).boost(10f)));
+    return Query.of(q -> q.bool(b -> b.should(exact).should(prefix)));
   }
 
   private String praseJsonQuery(String jsonQuery) throws JsonProcessingException {
@@ -138,10 +168,6 @@ public class ElasticSearchAggregationManager implements AggregationManagementCli
         }
       }
 
-      if (query != null) {
-        searchRequestBuilder.query(query);
-      }
-
       String aggregationField =
           SearchSourceBuilderFactory.resolveFieldForSortOrAggregation(request.getFieldName());
       if (aggregationField == null || aggregationField.isBlank()) {
@@ -151,49 +177,65 @@ public class ElasticSearchAggregationManager implements AggregationManagementCli
       int bucketSize = request.getSize();
       String includeValue = request.getFieldValue().toLowerCase();
 
+      boolean wantsRelevance = AggregationRequest.OrderBy.RELEVANCE.equals(request.getOrderBy());
+      Optional<String> relevanceLiteral =
+          wantsRelevance ? extractLiteralForRelevance(includeValue) : Optional.empty();
+
+      if (relevanceLiteral.isPresent()) {
+        Query scoringClause = buildRelevanceScoringClause(aggregationField, relevanceLiteral.get());
+        if (query != null) {
+          final Query existing = query;
+          query = Query.of(q -> q.bool(b -> b.must(existing).should(scoringClause)));
+        } else {
+          query = Query.of(q -> q.bool(b -> b.should(scoringClause)));
+        }
+      }
+
+      if (query != null) {
+        searchRequestBuilder.query(query);
+      }
+
       Map<String, Aggregation> aggregations = new HashMap<>();
 
-      Aggregation termsAgg;
+      List<NamedValue<SortOrder>> termsOrder =
+          relevanceLiteral.isPresent()
+              ? Collections.singletonList(NamedValue.of("max_score", SortOrder.Desc))
+              : Collections.singletonList(NamedValue.of("_key", SortOrder.Asc));
 
+      Map<String, Aggregation> subAggs = new HashMap<>();
       if (request.getSourceFields() != null && !request.getSourceFields().isEmpty()) {
         List<String> topHitFields = request.getSourceFields();
         int topHitSize = request.getTopHits() != null ? request.getTopHits().getSize() : 10;
-
-        termsAgg =
+        subAggs.put(
+            "top",
             Aggregation.of(
-                a ->
-                    a.terms(
-                            t ->
-                                t.field(aggregationField)
-                                    .size(bucketSize)
-                                    .order(
-                                        Collections.singletonList(
-                                            NamedValue.of("_key", SortOrder.Asc)))
-                                    .include(tb -> tb.regexp(includeValue)))
-                        .aggregations(
-                            "top",
-                            Aggregation.of(
-                                th ->
-                                    th.topHits(
-                                        topHit ->
-                                            topHit
-                                                .size(topHitSize)
-                                                .source(
-                                                    s ->
-                                                        s.filter(
-                                                            f -> f.includes(topHitFields)))))));
-      } else {
-        termsAgg =
-            Aggregation.of(
-                a ->
-                    a.terms(
-                        t ->
-                            t.field(aggregationField)
-                                .size(bucketSize)
-                                .order(
-                                    Collections.singletonList(NamedValue.of("_key", SortOrder.Asc)))
-                                .include(tb -> tb.regexp(includeValue))));
+                th ->
+                    th.topHits(
+                        topHit ->
+                            topHit
+                                .size(topHitSize)
+                                .source(s -> s.filter(f -> f.includes(topHitFields))))));
       }
+      if (relevanceLiteral.isPresent()) {
+        subAggs.put(
+            "max_score",
+            Aggregation.of(
+                a ->
+                    a.max(
+                        mx ->
+                            mx.script(Script.of(s -> s.source(ss -> ss.scriptString("_score")))))));
+      }
+
+      Aggregation termsAgg =
+          Aggregation.of(
+              a ->
+                  a.terms(
+                          t ->
+                              t.field(aggregationField)
+                                  .size(bucketSize)
+                                  .order(termsOrder)
+                                  .include(tb -> tb.regexp(includeValue)))
+                      .aggregations(subAggs));
 
       aggregations.put(aggregationField, termsAgg);
 

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/opensearch/OpenSearchAggregationManager.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/opensearch/OpenSearchAggregationManager.java
@@ -13,6 +13,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import lombok.extern.slf4j.Slf4j;
 import org.openmetadata.common.utils.CommonUtil;
 import org.openmetadata.schema.api.search.SearchSettings;
@@ -62,6 +64,34 @@ public class OpenSearchAggregationManager implements AggregationManagementClient
     this.isClientAvailable = client != null;
     this.rbacConditionEvaluator = rbacConditionEvaluator;
     mapper = new ObjectMapper();
+  }
+
+  private static final Pattern WRAPPED_LITERAL = Pattern.compile("^\\.\\*(.+)\\.\\*$");
+
+  private static Optional<String> extractLiteralForRelevance(String includeValue) {
+    if (includeValue == null || includeValue.isEmpty() || ".*".equals(includeValue)) {
+      return Optional.empty();
+    }
+    Matcher m = WRAPPED_LITERAL.matcher(includeValue);
+    if (!m.matches()) {
+      return Optional.empty();
+    }
+    String inner = m.group(1);
+    for (int i = 0; i < inner.length(); i++) {
+      char c = inner.charAt(i);
+      if (c == '.' || c == '*' || c == '\\' || c == '[' || c == ']' || c == '(' || c == ')'
+          || c == '|' || c == '?' || c == '+' || c == '^' || c == '$' || c == '{' || c == '}') {
+        return Optional.empty();
+      }
+    }
+    return Optional.of(inner);
+  }
+
+  private static Query buildRelevanceScoringClause(String field, String literal) {
+    Query exact =
+        Query.of(q -> q.term(t -> t.field(field).value(FieldValue.of(literal)).boost(100f)));
+    Query prefix = Query.of(q -> q.prefix(p -> p.field(field).value(literal).boost(10f)));
+    return Query.of(q -> q.bool(b -> b.should(exact).should(prefix)));
   }
 
   private String praseJsonQuery(String jsonQuery) throws JsonProcessingException {
@@ -138,10 +168,6 @@ public class OpenSearchAggregationManager implements AggregationManagementClient
         }
       }
 
-      if (query != null) {
-        searchRequestBuilder.query(query);
-      }
-
       String aggregationField =
           SearchSourceBuilderFactory.resolveFieldForSortOrAggregation(request.getFieldName());
       if (aggregationField == null || aggregationField.isBlank()) {
@@ -151,46 +177,61 @@ public class OpenSearchAggregationManager implements AggregationManagementClient
       int bucketSize = request.getSize();
       String includeValue = request.getFieldValue().toLowerCase();
 
+      boolean wantsRelevance = AggregationRequest.OrderBy.RELEVANCE.equals(request.getOrderBy());
+      Optional<String> relevanceLiteral =
+          wantsRelevance ? extractLiteralForRelevance(includeValue) : Optional.empty();
+
+      if (relevanceLiteral.isPresent()) {
+        Query scoringClause = buildRelevanceScoringClause(aggregationField, relevanceLiteral.get());
+        if (query != null) {
+          final Query existing = query;
+          query = Query.of(q -> q.bool(b -> b.must(existing).should(scoringClause)));
+        } else {
+          query = Query.of(q -> q.bool(b -> b.should(scoringClause)));
+        }
+      }
+
+      if (query != null) {
+        searchRequestBuilder.query(query);
+      }
+
       Map<String, Aggregation> aggregations = new HashMap<>();
 
-      Aggregation termsAgg;
+      Map<String, SortOrder> termsOrder =
+          relevanceLiteral.isPresent()
+              ? Collections.singletonMap("max_score", SortOrder.Desc)
+              : Collections.singletonMap("_key", SortOrder.Asc);
 
+      Map<String, Aggregation> subAggs = new HashMap<>();
       if (request.getSourceFields() != null && !request.getSourceFields().isEmpty()) {
         List<String> topHitFields = request.getSourceFields();
         int topHitSize = request.getTopHits() != null ? request.getTopHits().getSize() : 10;
-
-        termsAgg =
+        subAggs.put(
+            "top",
             Aggregation.of(
-                a ->
-                    a.terms(
-                            t ->
-                                t.field(aggregationField)
-                                    .size(bucketSize)
-                                    .order(Collections.singletonMap("_key", SortOrder.Asc))
-                                    .include(tb -> tb.regexp(includeValue)))
-                        .aggregations(
-                            "top",
-                            Aggregation.of(
-                                th ->
-                                    th.topHits(
-                                        topHit ->
-                                            topHit
-                                                .size(topHitSize)
-                                                .source(
-                                                    s ->
-                                                        s.filter(
-                                                            f -> f.includes(topHitFields)))))));
-      } else {
-        termsAgg =
-            Aggregation.of(
-                a ->
-                    a.terms(
-                        t ->
-                            t.field(aggregationField)
-                                .size(bucketSize)
-                                .order(Collections.singletonMap("_key", SortOrder.Asc))
-                                .include(tb -> tb.regexp(includeValue))));
+                th ->
+                    th.topHits(
+                        topHit ->
+                            topHit
+                                .size(topHitSize)
+                                .source(s -> s.filter(f -> f.includes(topHitFields))))));
       }
+      if (relevanceLiteral.isPresent()) {
+        subAggs.put(
+            "max_score",
+            Aggregation.of(a -> a.max(mx -> mx.script(s -> s.inline(i -> i.source("_score"))))));
+      }
+
+      Aggregation termsAgg =
+          Aggregation.of(
+              a ->
+                  a.terms(
+                          t ->
+                              t.field(aggregationField)
+                                  .size(bucketSize)
+                                  .order(termsOrder)
+                                  .include(tb -> tb.regexp(includeValue)))
+                      .aggregations(subAggs));
 
       aggregations.put(aggregationField, termsAgg);
 

--- a/openmetadata-spec/src/main/resources/json/schema/search/aggregationRequest.json
+++ b/openmetadata-spec/src/main/resources/json/schema/search/aggregationRequest.json
@@ -36,6 +36,12 @@
       "type": "integer",
       "default": 10
     },
+    "orderBy": {
+      "description": "Ordering mode for terms aggregation buckets. 'key' (default) sorts alphabetically by term value and preserves existing behavior for all callers. 'relevance' ranks buckets so that exact matches against the typed literal in fieldValue surface first, followed by prefix matches, then substring matches. Relevance ordering activates only when fieldValue is a wildcard-wrapped literal of the form '.*<literal>.*' (the convention used by the OpenMetadata UI autocomplete dropdowns); otherwise the request silently falls back to 'key' ordering.",
+      "type": "string",
+      "enum": ["key", "relevance"],
+      "default": "key"
+    },
     "sourceFields": {
       "description": "List of fields to include from _source in the response (outside of top_hits).",
       "type": "array",

--- a/openmetadata-ui/src/main/resources/ui/src/generated/search/aggregationRequest.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/search/aggregationRequest.ts
@@ -31,6 +31,16 @@ export interface AggregationRequest {
      */
     index?: string;
     /**
+     * Ordering mode for terms aggregation buckets. 'key' (default) sorts alphabetically by term
+     * value and preserves existing behavior for all callers. 'relevance' ranks buckets so that
+     * exact matches against the typed literal in fieldValue surface first, followed by prefix
+     * matches, then substring matches. Relevance ordering activates only when fieldValue is a
+     * wildcard-wrapped literal of the form '.*<literal>.*' (the convention used by the
+     * OpenMetadata UI autocomplete dropdowns); otherwise the request silently falls back to
+     * 'key' ordering.
+     */
+    orderBy?: OrderBy;
+    /**
      * Query string to be sent to the search engine.
      */
     query?: string;
@@ -50,6 +60,20 @@ export interface AggregationRequest {
      * Optional top_hits sub-aggregation to fetch selected source fields per bucket.
      */
     topHits?: TopHits;
+}
+
+/**
+ * Ordering mode for terms aggregation buckets. 'key' (default) sorts alphabetically by term
+ * value and preserves existing behavior for all callers. 'relevance' ranks buckets so that
+ * exact matches against the typed literal in fieldValue surface first, followed by prefix
+ * matches, then substring matches. Relevance ordering activates only when fieldValue is a
+ * wildcard-wrapped literal of the form '.*<literal>.*' (the convention used by the
+ * OpenMetadata UI autocomplete dropdowns); otherwise the request silently falls back to
+ * 'key' ordering.
+ */
+export enum OrderBy {
+    Key = "key",
+    Relevance = "relevance",
 }
 
 /**


### PR DESCRIPTION
## The bug

`/api/v1/search/aggregate` always orders terms-aggregation buckets by `_key ASC`. For autocomplete dropdowns (advanced-search builder, Explore quick filters) this means typing `name` in the Columns dropdown returns alphabetically-earlier substring matches above the literal `name` bucket:

> ```
> address_name, customer_name, first_name, ..., name, surname, ...
> ```

Reported via the sandbox URL:
`/api/v1/search/aggregate?index=dataAsset&field=columns.name.keyword&value=.*name.*&q=&deleted=false`

Affects ~41 advanced-search dropdowns (every `asyncFetch` in `AdvancedSearchClassBase.autocomplete`) plus the Explore quick-filter typing path (`ExploreQuickFilters.getFilterOptions`). All of them flow through `getAggregateFieldOptions` / `postAggregateFieldOptions` in `miscAPI.ts` with the convention `value = .*${typed}.*`.

## Why it happens

Both backends explicitly override Elasticsearch's default ordering with `_key ASC`:

```java
// OpenSearchAggregationManager.java / ElasticSearchAggregationManager.java
.order(Collections.singletonMap("_key", SortOrder.Asc))
```

Terms aggregations have no native `_score` ordering — buckets are values, not docs, so there's no per-bucket score unless you aggregate one with a sub-aggregation. The only native ES mechanisms are `_count`, `_key`, or a metric sub-aggregation.

## Fix

Add an opt-in `orderBy=relevance` mode that ranks buckets by `max(_score)` from a sub-aggregation. The scoring clause is derived **server-side** from the wildcard-wrapped `value` (UI continues to send `.*${typed}.*`; server extracts the literal). The clause is a flat `bool should` of:

- `term: { <field>: <literal>, boost: 100 }` — exact match wins
- `prefix: { <field>: <literal>, boost: 10 }` — prefix match next

Composes with the existing `q` / `queryText` / `deleted` filters via `bool.must`, so the bucket set (regex `include` filter) is unchanged — only the ranking changes. Flat term/prefix queries work on any keyword field across the `dataAsset` alias regardless of whether `columns` is nested on `table_search_index` or flat elsewhere.

### Backwards compatibility

- Default `orderBy=key` preserves today's behavior byte-for-byte for **every existing API consumer** (external integrations, datainsight, anything that doesn't pass `orderBy`).
- Even with `orderBy=relevance`, the request **silently falls back** to `_key ASC` when:
  - `value` is empty / `".*"` (browse mode — initial dropdown open, nothing to rank by)
  - `value`'s middle contains regex metachars (`. * \\ [ ] ( ) | ? + ^ $ { }`) — can't safely treat as a literal

So opening a dropdown to "see all values" still gives alphabetical ordering; only the typing path gets relevance.

## How it composes with `queryText`

`queryText` (added in a prior change) already builds a search-config-driven scoring query and composes via `bool.must`. The new relevance scoring clause adds its `should` to whichever query layer exists at that point, so all four can stack: caller's `q` + `queryText` + `deleted` + relevance `should`.

## Test plan

- [x] `mvn clean install -DskipTests -pl openmetadata-service -am` — passes
- [x] `mvn spotless:apply` — applied
- [ ] **Manual on sandbox**:
  - GET `…/search/aggregate?index=dataAsset&field=columns.name.keyword&value=.*name.*` → today's alphabetical order (default `orderBy=key`)
  - GET `…/search/aggregate?index=dataAsset&field=columns.name.keyword&value=.*name.*&orderBy=relevance` → `name` first, prefix matches (`namespace`, `named`) next, substring matches last
  - GET `…/search/aggregate?index=dataAsset&field=columns.name.keyword&value=.*&orderBy=relevance` → alphabetical (browse-mode fallback verified)
- [ ] **Integration tests to add** (follow-up):
  - Browse mode unchanged (regression guard for default callers)
  - Relevance with exact match → exact wins
  - Relevance with prefix-only match → prefix tier wins
  - Relevance with empty literal → falls back to `_key ASC`
  - Relevance with metachars → falls back to `_key ASC`

## UI opt-in (follow-up PR)

Two lines in `openmetadata-ui/src/main/resources/ui/src/rest/miscAPI.ts`:

```diff
// getAggregateFieldOptions GET params
   const params = {
     index, field, value: withWildCardValue, q, sourceFields, deleted,
+    orderBy: 'relevance',
   };

// postAggregateFieldOptions POST body
   const body: SearchRequest = {
     fieldValue: withWildCardValue,
+    orderBy: 'relevance',
     ...rest,
   };
```

That single edit covers all 41 advanced-search dropdowns AND both Explore quick-filter call sites simultaneously. Holding it as a separate PR so the server change can ship/roll back independently.

## Out of scope (deliberately)

- Typo tolerance (would need `fuzzy` query or completion suggester — separate decision)
- Mapping changes / reindex (none required — this is purely query-side)
- Changing the wire convention for `value` (kept compatible with all callers)

## Open questions for review

1. **Tie-break inside relevance tier**: currently single-key `max_score DESC`. Worth adding secondary `_count DESC` for deterministic ordering of substring-only matches?
2. **Field-type guard**: should we also fall back to `_key` when `aggregationField` doesn't end in `.keyword`? Today's `.toLowerCase()` on the include implicitly assumes keyword + lowercase normalizer; matching that constraint may be safer than the current "try anyway" behavior.