### PR TITLE
fix(ci): bump lewagon/wait-on-check-action to v1.7.0

### DIFF
--- a/.github/workflows/airflow-apis-tests.yml
+++ b/.github/workflows/airflow-apis-tests.yml
@@ -50,7 +50,7 @@ jobs:
           docker-images: false
           swap-storage: true
     - name: Wait for the labeler
-      uses: lewagon/wait-on-check-action@v1.3.4
+      uses: lewagon/wait-on-check-action@v1.7.0
       if: ${{ github.event_name == 'pull_request_target' }}
       with:
         ref: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/docker-k8s-operator.yml
+++ b/.github/workflows/docker-k8s-operator.yml
@@ -89,7 +89,7 @@ jobs:
     needs: [ maven-build ]
     steps:
       - name: Wait for the labeler
-        uses: lewagon/wait-on-check-action@v1.3.4
+        uses: lewagon/wait-on-check-action@v1.7.0
         if: ${{ github.event_name == 'pull_request_target' }}
         with:
           ref: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/integration-tests-mysql-elasticsearch.yml
+++ b/.github/workflows/integration-tests-mysql-elasticsearch.yml
@@ -77,7 +77,7 @@ jobs:
           swap-storage: true
 
       - name: Wait for the labeler
-        uses: lewagon/wait-on-check-action@v1.3.4
+        uses: lewagon/wait-on-check-action@v1.7.0
         if: ${{ github.event_name == 'pull_request_target' }}
         with:
           ref: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/integration-tests-postgres-elasticsearch-redis.yml
+++ b/.github/workflows/integration-tests-postgres-elasticsearch-redis.yml
@@ -92,7 +92,7 @@ jobs:
           swap-storage: true
 
       - name: Wait for the labeler
-        uses: lewagon/wait-on-check-action@v1.3.4
+        uses: lewagon/wait-on-check-action@v1.7.0
         if: ${{ github.event_name == 'pull_request_target' }}
         with:
           ref: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/integration-tests-postgres-opensearch.yml
+++ b/.github/workflows/integration-tests-postgres-opensearch.yml
@@ -77,7 +77,7 @@ jobs:
           swap-storage: true
 
       - name: Wait for the labeler
-        uses: lewagon/wait-on-check-action@v1.3.4
+        uses: lewagon/wait-on-check-action@v1.7.0
         if: ${{ github.event_name == 'pull_request_target' }}
         with:
           ref: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/java-checkstyle.yml
+++ b/.github/workflows/java-checkstyle.yml
@@ -49,7 +49,7 @@ jobs:
             swap-storage: true
             docker-images: false
       - name: Wait for the labeler
-        uses: lewagon/wait-on-check-action@v1.3.4
+        uses: lewagon/wait-on-check-action@v1.7.0
         if: ${{ github.event_name == 'pull_request_target' }}
         with:
           ref: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/maven-build-collate.yml
+++ b/.github/workflows/maven-build-collate.yml
@@ -53,7 +53,7 @@ jobs:
     if: ${{ !github.event.pull_request.draft }}
     steps:
       - name: Wait for the labeler
-        uses: lewagon/wait-on-check-action@v1.3.4
+        uses: lewagon/wait-on-check-action@v1.7.0
         if: ${{ github.event_name == 'pull_request_target' }}
         with:
           ref: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/maven-sonar-build.yml
+++ b/.github/workflows/maven-sonar-build.yml
@@ -40,7 +40,7 @@ jobs:
     if: ${{ !github.event.pull_request.draft }}
     steps:
       - name: Wait for the labeler
-        uses: lewagon/wait-on-check-action@v1.3.4
+        uses: lewagon/wait-on-check-action@v1.7.0
         if: ${{ github.event_name == 'pull_request_target' }}
         with:
           ref: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/playwright-integration-tests-mysql.yml
+++ b/.github/workflows/playwright-integration-tests-mysql.yml
@@ -42,7 +42,7 @@ jobs:
           swap-storage: true
           docker-images: false
       - name: Wait for the labeler
-        uses: lewagon/wait-on-check-action@v1.3.4
+        uses: lewagon/wait-on-check-action@v1.7.0
         if: ${{ github.event_name == 'pull_request_target' }}
         with:
           ref: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/playwright-integration-tests-postgres.yml
+++ b/.github/workflows/playwright-integration-tests-postgres.yml
@@ -42,7 +42,7 @@ jobs:
           swap-storage: true
           docker-images: false
       - name: Wait for the labeler
-        uses: lewagon/wait-on-check-action@v1.3.4
+        uses: lewagon/wait-on-check-action@v1.7.0
         if: ${{ github.event_name == 'pull_request_target' }}
         with:
           ref: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/playwright-mysql-e2e.yml
+++ b/.github/workflows/playwright-mysql-e2e.yml
@@ -60,7 +60,7 @@ jobs:
           swap-storage: true
           docker-images: false
       - name: Wait for the labeler
-        uses: lewagon/wait-on-check-action@v1.3.4
+        uses: lewagon/wait-on-check-action@v1.7.0
         if: ${{ github.event_name == 'pull_request_target' }}
         with:
           ref: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/playwright-postgresql-e2e.yml
+++ b/.github/workflows/playwright-postgresql-e2e.yml
@@ -47,7 +47,7 @@ jobs:
     if: ${{ !github.event.pull_request.draft }}
     steps:
       - name: Wait for the labeler
-        uses: lewagon/wait-on-check-action@v1.3.4
+        uses: lewagon/wait-on-check-action@v1.7.0
         if: ${{ github.event_name == 'pull_request_target' }}
         with:
           ref: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/playwright-sso-tests.yml
+++ b/.github/workflows/playwright-sso-tests.yml
@@ -95,7 +95,7 @@ jobs:
           docker-images: false
 
       - name: Wait for the labeler
-        uses: lewagon/wait-on-check-action@v1.3.4
+        uses: lewagon/wait-on-check-action@v1.7.0
         if: ${{ github.event_name == 'pull_request_target' }}
         with:
           ref: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/py-checkstyle.yml
+++ b/.github/workflows/py-checkstyle.yml
@@ -37,7 +37,7 @@ jobs:
 
     steps:
       - name: Wait for the labeler
-        uses: lewagon/wait-on-check-action@v1.3.4
+        uses: lewagon/wait-on-check-action@v1.7.0
         if: ${{ github.event_name == 'pull_request_target' }}
         with:
           ref: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/py-operator-build-test.yml
+++ b/.github/workflows/py-operator-build-test.yml
@@ -45,7 +45,7 @@ jobs:
           docker-images: false
 
       - name: Wait for the labeler
-        uses: lewagon/wait-on-check-action@v1.3.4
+        uses: lewagon/wait-on-check-action@v1.7.0
         if: ${{ github.event_name == 'pull_request_target' }}
         with:
           ref: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/py-tests-postgres.yml
+++ b/.github/workflows/py-tests-postgres.yml
@@ -84,7 +84,7 @@ jobs:
           docker-images: false
 
       - name: Wait for the labeler
-        uses: lewagon/wait-on-check-action@v1.3.4
+        uses: lewagon/wait-on-check-action@v1.7.0
         if: ${{ github.event_name == 'pull_request_target' }}
         with:
           ref: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/py-tests.yml
+++ b/.github/workflows/py-tests.yml
@@ -70,7 +70,7 @@ jobs:
     steps:
 
       - name: Wait for the labeler
-        uses: lewagon/wait-on-check-action@v1.3.4
+        uses: lewagon/wait-on-check-action@v1.7.0
         if: ${{ github.event_name == 'pull_request_target' }}
         with:
           ref: ${{ github.event.pull_request.head.sha }}
@@ -163,7 +163,7 @@ jobs:
           docker-images: false
 
       - name: Wait for the labeler
-        uses: lewagon/wait-on-check-action@v1.3.4
+        uses: lewagon/wait-on-check-action@v1.7.0
         if: ${{ github.event_name == 'pull_request_target' }}
         with:
           ref: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/typescript-type-generation.yml
+++ b/.github/workflows/typescript-type-generation.yml
@@ -47,7 +47,7 @@ jobs:
           echo "full_repo=$(echo "$PR_DATA" | jq -r '.headRepositoryOwner.login + "/" + .headRepository.name')" >> $GITHUB_OUTPUT
 
       - name: Wait for the labeler
-        uses: lewagon/wait-on-check-action@v1.3.4
+        uses: lewagon/wait-on-check-action@v1.7.0
         if: ${{ github.event_name == 'pull_request_target' && github.actor != 'github-actions[bot]' }}
         with:
           ref: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/ui-checkstyle.yml
+++ b/.github/workflows/ui-checkstyle.yml
@@ -51,7 +51,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Wait for the labeler
-        uses: lewagon/wait-on-check-action@v1.3.4
+        uses: lewagon/wait-on-check-action@v1.7.0
         if: ${{ github.event_name == 'pull_request_target' }}
         with:
           ref: ${{ github.event_name == 'merge_group' && github.sha || github.event.pull_request.head.sha }}

--- a/.github/workflows/validate-jsons-yamls.yml
+++ b/.github/workflows/validate-jsons-yamls.yml
@@ -32,7 +32,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Wait for the labeler
-        uses: lewagon/wait-on-check-action@v1.3.4
+        uses: lewagon/wait-on-check-action@v1.7.0
         if: ${{ github.event_name == 'pull_request_target' }}
         with:
           ref: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/yarn-coverage.yml
+++ b/.github/workflows/yarn-coverage.yml
@@ -29,7 +29,7 @@ jobs:
     if: ${{ !github.event.pull_request.draft }}
     steps:
       - name: Wait for the labeler
-        uses: lewagon/wait-on-check-action@v1.3.4
+        uses: lewagon/wait-on-check-action@v1.7.0
         if: ${{ github.event_name == 'pull_request_target' }}
         with:
           ref: ${{ github.event.pull_request.head.sha }}


### PR DESCRIPTION
## Summary

Bumps `lewagon/wait-on-check-action` from `v1.3.4` → `v1.7.0` across all 21 workflow files (22 references). This fixes CI jobs going red **in post-job cleanup even when all tests pass** — currently most visible on `airflow-apis-tests`.

## Problem

`v1.3.4`'s `action.yml` caches its Ruby gems with an explicit `actions/cache` step keyed on `hashFiles('**/Gemfile.lock')`. At **post-job cleanup**, the runner re-evaluates that template expression, which makes `hashFiles` recursively walk the **entire `$GITHUB_WORKSPACE`** looking for `**/Gemfile.lock`.

If, by that point, the job has left a path the runner can't read — e.g. **root-owned directories created by a Docker stack**, or a broken symlink — `hashFiles` hard-fails:

```
##[error]The template is not valid. lewagon/wait-on-check-action/v1.3.4/action.yml (Line: 57, Col: 14):
hashFiles('**/Gemfile.lock') failed. Fail to hash files under directory '/home/runner/work/OpenMetadata/OpenMetadata'
```

The job is marked failed during cleanup, long after the actual test step succeeded. This is a known `hashFiles` failure mode on unreadable paths / broken symlinks (actions/runner#3015).

`airflow-apis-tests` trips this reliably because it stands up a full Docker stack in the workspace (`run_local_docker.sh`) with no teardown, leaving root-owned dirs behind; the test suite itself passes (`12 passed`) but the job goes red in cleanup.

## Fix

`v1.4.0`+ removed that explicit `actions/cache` step in favor of `ruby/setup-ruby`'s `bundler-cache: true`, which keys its cache off the action's own `Gemfile.lock` instead of a workspace-wide `**` glob. The post-step no longer scans the populated workspace, so the failure can't occur.

## Compatibility

All 22 references use only `ref`, `check-name`, `repo-token`, and `wait-interval`. These inputs are unchanged from `v1.3.4` through `v1.7.0`, so this is a drop-in version bump with no `with:` changes required.

## Changes

- 21 workflow files, 22 references, `@v1.3.4` → `@v1.7.0` (version string only — no other changes)