### PR TITLE
fix(ci): backport #27849 — remove stale 'stateful' project from nightly workflows (1.13)

### DIFF
--- a/.github/workflows/mysql-nightly-e2e.yml
+++ b/.github/workflows/mysql-nightly-e2e.yml
@@ -88,21 +88,14 @@ jobs:
               --project=DataAssetRulesEnabled \
               --project=DataAssetRulesDisabled
 
-          elif [ "${{ matrix.shardIndex }}" -eq "6" ]; then
-            echo "🔹 Running stateful Playwright tests serially on shard 6"
-            npx playwright test \
-              --project=stateful \
-              --workers=1
-
           else
-            # Shards 2-5 handle chromium tests (4 shards total)
+            # Shards 2-6 handle chromium tests (5 shards total)
             CHROMIUM_SHARD=$(( ${{ matrix.shardIndex }} - 1 ))
-            echo "🔹 Running all tests (excluding DataAssetRules/stateful) on chromium shard ${CHROMIUM_SHARD}/4"
+            echo "🔹 Running all tests (excluding DataAssetRules) on chromium shard ${CHROMIUM_SHARD}/5"
             npx playwright test \
               --project=chromium \
               --grep-invert @dataAssetRules \
-              --shard=${CHROMIUM_SHARD}/4 \
-              --workers=50%
+              --shard=${CHROMIUM_SHARD}/5
           fi
 
         env:

--- a/.github/workflows/postgresql-nightly-e2e.yml
+++ b/.github/workflows/postgresql-nightly-e2e.yml
@@ -88,21 +88,14 @@ jobs:
               --project=DataAssetRulesEnabled \
               --project=DataAssetRulesDisabled
 
-          elif [ "${{ matrix.shardIndex }}" -eq "6" ]; then
-            echo "🔹 Running stateful Playwright tests serially on shard 6"
-            npx playwright test \
-              --project=stateful \
-              --workers=1
-
           else
-            # Shards 2-5 handle chromium tests (4 shards total)
+            # Shards 2-5 handle chromium tests (5 shards total)
             CHROMIUM_SHARD=$(( ${{ matrix.shardIndex }} - 1 ))
-            echo "🔹 Running all tests (excluding DataAssetRules/stateful) on chromium shard ${CHROMIUM_SHARD}/4"
+            echo "🔹 Running all tests (excluding DataAssetRules) on chromium shard ${CHROMIUM_SHARD}/5"
             npx playwright test \
               --project=chromium \
               --grep-invert @dataAssetRules \
-              --shard=${CHROMIUM_SHARD}/4 \
-              --workers=50%
+              --shard=${CHROMIUM_SHARD}/5
           fi
 
         env:


### PR DESCRIPTION
## What

Backport of #27849 to the `1.13` release branch.

Cherry-picks `d095413ed1bd4dee12f0341bd69252cf40cd98c8` (squash merge of #27849, _"fix(ci): nightly workflow running stale project getting failed"_).

## Why

Shard 6/6 of `mysql-nightly-e2e` (and `postgresql-nightly-e2e`) has been failing on `1.13` since the branch was cut. The workflow hardcodes shard 6 to:

```bash
npx playwright test --project=stateful --workers=1
```

but `playwright.config.ts` on `1.13` defines no `stateful` project, so Playwright errors out before running any test:

```
Error: Project(s) "stateful" not found.
##[error]Process completed with exit code 1.
```

The `--project=stateful` reference was added by #25751 (2026-03-13) and was already broken on `main`; #27849 fixed it on `main` (2026-05-04) but was never backported to `1.13`. As a result every nightly + manual run on `1.13` has been red. Example: https://github.com/open-metadata/OpenMetadata/actions/runs/26377347172/job/77639879476

## Change

Removes the stale shard-6 `stateful` branch; shards 2–6 now run chromium shards 1/5–5/5 (matching `main`). CI-only, `[skip-ci]`-style change, no product code touched.