### PR TITLE
Hide request data access button to admin role

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/DataAssets/DataAssetsHeader/DataAssetsHeader.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataAssets/DataAssetsHeader/DataAssetsHeader.component.tsx
@@ -620,6 +620,7 @@ export const DataAssetsHeader = ({
       entityType !== EntityType.TABLE ||
       deleted ||
       isOwner ||
+      currentUser?.isAdmin ||
       !canCreateTask
     ) {
       return null;

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataAssets/DataAssetsHeader/DataAssetsHeader.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataAssets/DataAssetsHeader/DataAssetsHeader.test.tsx
@@ -1015,7 +1015,7 @@ describe('DataAssetsHeader component', () => {
       }));
     });
 
-    it('should render when user is admin with canCreateTask permission and is not owner', async () => {
+    it('should not render when user is admin even with canCreateTask permission', async () => {
       const { useApplicationStore } = jest.requireMock(
         '../../../hooks/useApplicationStore'
       );
@@ -1027,8 +1027,8 @@ describe('DataAssetsHeader component', () => {
 
       await waitFor(() => {
         expect(
-          screen.getByTestId('request-data-access-button')
-        ).toBeInTheDocument();
+          screen.queryByTestId('request-data-access-button')
+        ).not.toBeInTheDocument();
       });
 
       (useApplicationStore as jest.Mock).mockReturnValue({
@@ -1036,7 +1036,7 @@ describe('DataAssetsHeader component', () => {
       });
     });
 
-    it('should not render when user is admin with canCreateTask permission but is the owner', async () => {
+    it('should not render when user is admin and is also the owner', async () => {
       const { useApplicationStore } = jest.requireMock(
         '../../../hooks/useApplicationStore'
       );
@@ -1060,6 +1060,16 @@ describe('DataAssetsHeader component', () => {
 
       (useApplicationStore as jest.Mock).mockReturnValue({
         currentUser: { id: 'user-1', name: 'test.user' },
+      });
+    });
+
+    it('should render for non-admin user with canCreateTask permission who is not owner', async () => {
+      render(<DataAssetsHeader {...tableProps} />);
+
+      await waitFor(() => {
+        expect(
+          screen.getByTestId('request-data-access-button')
+        ).toBeInTheDocument();
       });
     });
   });


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:
Hide the request data access button to admin role

<img width="1508" height="667" alt="Screenshot 2026-05-25 at 12 37 18 PM" src="https://github.com/user-attachments/assets/548c402b-dfd8-430f-927d-ab01d5fe7995" />

