### PR TITLE
refactor(search): always recreate on reindex; drop the recreateIndex …

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/apps/bundles/searchIndex/ElasticSearchBulkSink.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/apps/bundles/searchIndex/ElasticSearchBulkSink.java
@@ -203,7 +203,6 @@ public class ElasticSearchBulkSink implements BulkSink {
       throw new IllegalArgumentException("Entity type is required in context data");
     }
 
-    Boolean recreateIndex = (Boolean) contextData.getOrDefault("recreateIndex", false);
     ReindexContext reindexContext =
         contextData.containsKey(RECREATE_CONTEXT)
             ? (ReindexContext) contextData.get(RECREATE_CONTEXT)
@@ -264,9 +263,7 @@ public class ElasticSearchBulkSink implements BulkSink {
                 .map(
                     entity ->
                         CompletableFuture.runAsync(
-                            () ->
-                                addEntity(
-                                    entity, indexName, recreateIndex, tracker, docBuildContexts),
+                            () -> addEntity(entity, indexName, tracker, docBuildContexts),
                             DOC_BUILD_EXECUTOR))
                 .toList();
         CompletableFuture.allOf(futures.toArray(CompletableFuture[]::new)).join();
@@ -276,8 +273,7 @@ public class ElasticSearchBulkSink implements BulkSink {
           for (EntityInterface entity : entityInterfaces) {
             CompletableFuture<Void> future =
                 CompletableFuture.runAsync(
-                        () -> indexTableColumns(entity, recreateIndex, reindexContext),
-                        DOC_BUILD_EXECUTOR)
+                        () -> indexTableColumns(entity, reindexContext), DOC_BUILD_EXECUTOR)
                     .exceptionally(
                         ex -> {
                           LOG.error("Failed to index columns for table {}", entity.getName(), ex);
@@ -323,7 +319,6 @@ public class ElasticSearchBulkSink implements BulkSink {
   private void addEntity(
       EntityInterface entity,
       String indexName,
-      boolean recreateIndex,
       StageStatsTracker tracker,
       Map<UUID, DocBuildContext> docBuildContexts) {
     try {
@@ -369,29 +364,14 @@ public class ElasticSearchBulkSink implements BulkSink {
       }
 
       final String indexableJson = json;
-      BulkOperation operation;
-      if (recreateIndex) {
-        operation =
-            BulkOperation.of(
-                op ->
-                    op.index(
-                        idx ->
-                            idx.index(indexName)
-                                .id(docId)
-                                .document(EsUtils.toJsonData(indexableJson))));
-      } else {
-        operation =
-            BulkOperation.of(
-                op ->
-                    op.update(
-                        upd ->
-                            upd.index(indexName)
-                                .id(docId)
-                                .action(
-                                    a ->
-                                        a.doc(EsUtils.toJsonData(indexableJson))
-                                            .docAsUpsert(true))));
-      }
+      BulkOperation operation =
+          BulkOperation.of(
+              op ->
+                  op.index(
+                      idx ->
+                          idx.index(indexName)
+                              .id(docId)
+                              .document(EsUtils.toJsonData(indexableJson))));
       if (tracker != null) {
         tracker.incrementPendingSink();
       }
@@ -536,8 +516,7 @@ public class ElasticSearchBulkSink implements BulkSink {
     }
   }
 
-  private void indexTableColumns(
-      EntityInterface entity, boolean recreateIndex, ReindexContext reindexContext) {
+  private void indexTableColumns(EntityInterface entity, ReindexContext reindexContext) {
     if (!(entity instanceof Table table)) {
       return;
     }
@@ -565,26 +544,14 @@ public class ElasticSearchBulkSink implements BulkSink {
         String json = JsonUtils.pojoToJson(searchIndexDoc);
         String docId = searchIndexDoc.get("id").toString();
 
-        BulkOperation operation;
-        if (recreateIndex) {
-          operation =
-              BulkOperation.of(
-                  op ->
-                      op.index(
-                          idx ->
-                              idx.index(columnIndexName)
-                                  .id(docId)
-                                  .document(EsUtils.toJsonData(json))));
-        } else {
-          operation =
-              BulkOperation.of(
-                  op ->
-                      op.update(
-                          upd ->
-                              upd.index(columnIndexName)
-                                  .id(docId)
-                                  .action(a -> a.doc(EsUtils.toJsonData(json)).docAsUpsert(true))));
-        }
+        BulkOperation operation =
+            BulkOperation.of(
+                op ->
+                    op.index(
+                        idx ->
+                            idx.index(columnIndexName)
+                                .id(docId)
+                                .document(EsUtils.toJsonData(json))));
         long estimatedSize =
             (long) json.getBytes(StandardCharsets.UTF_8).length + BULK_OPERATION_METADATA_OVERHEAD;
         columnBulkProcessor.add(operation, docId, Entity.TABLE_COLUMN, null, estimatedSize);

--- a/openmetadata-service/src/main/java/org/openmetadata/service/apps/bundles/searchIndex/OpenSearchBulkSink.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/apps/bundles/searchIndex/OpenSearchBulkSink.java
@@ -224,8 +224,6 @@ public class OpenSearchBulkSink implements BulkSink {
       throw new IllegalArgumentException("Entity type is required in context data");
     }
 
-    Boolean recreateIndex = (Boolean) contextData.getOrDefault("recreateIndex", false);
-
     // Extract StageStatsTracker from context for stats recording
     StageStatsTracker tracker = extractTracker(contextData);
 
@@ -318,7 +316,6 @@ public class OpenSearchBulkSink implements BulkSink {
                                 addEntity(
                                     entity,
                                     indexName,
-                                    recreateIndex,
                                     reindexContext,
                                     tracker,
                                     embeddingsEnabled,
@@ -333,8 +330,7 @@ public class OpenSearchBulkSink implements BulkSink {
           for (EntityInterface entity : entityInterfaces) {
             CompletableFuture<Void> future =
                 CompletableFuture.runAsync(
-                        () -> indexTableColumns(entity, recreateIndex, reindexContext),
-                        DOC_BUILD_EXECUTOR)
+                        () -> indexTableColumns(entity, reindexContext), DOC_BUILD_EXECUTOR)
                     .exceptionally(
                         ex -> {
                           LOG.error("Failed to index columns for table {}", entity.getName(), ex);
@@ -380,7 +376,6 @@ public class OpenSearchBulkSink implements BulkSink {
   private void addEntity(
       EntityInterface entity,
       String indexName,
-      boolean recreateIndex,
       ReindexContext reindexContext,
       StageStatsTracker tracker,
       boolean embeddingsEnabled,
@@ -435,27 +430,14 @@ public class OpenSearchBulkSink implements BulkSink {
       }
 
       final String indexableJson = finalJson;
-      BulkOperation operation;
-      if (recreateIndex) {
-        operation =
-            BulkOperation.of(
-                op ->
-                    op.index(
-                        idx ->
-                            idx.index(indexName)
-                                .id(docId)
-                                .document(OsUtils.toJsonData(indexableJson))));
-      } else {
-        operation =
-            BulkOperation.of(
-                op ->
-                    op.update(
-                        upd ->
-                            upd.index(indexName)
-                                .id(docId)
-                                .document(OsUtils.toJsonData(indexableJson))
-                                .docAsUpsert(true)));
-      }
+      BulkOperation operation =
+          BulkOperation.of(
+              op ->
+                  op.index(
+                      idx ->
+                          idx.index(indexName)
+                              .id(docId)
+                              .document(OsUtils.toJsonData(indexableJson))));
       if (tracker != null) {
         tracker.incrementPendingSink();
       }
@@ -600,8 +582,7 @@ public class OpenSearchBulkSink implements BulkSink {
     }
   }
 
-  private void indexTableColumns(
-      EntityInterface entity, boolean recreateIndex, ReindexContext reindexContext) {
+  private void indexTableColumns(EntityInterface entity, ReindexContext reindexContext) {
     if (!(entity instanceof Table table)) {
       return;
     }
@@ -629,27 +610,14 @@ public class OpenSearchBulkSink implements BulkSink {
         String json = JsonUtils.pojoToJson(searchIndexDoc);
         String docId = searchIndexDoc.get("id").toString();
 
-        BulkOperation operation;
-        if (recreateIndex) {
-          operation =
-              BulkOperation.of(
-                  op ->
-                      op.index(
-                          idx ->
-                              idx.index(columnIndexName)
-                                  .id(docId)
-                                  .document(OsUtils.toJsonData(json))));
-        } else {
-          operation =
-              BulkOperation.of(
-                  op ->
-                      op.update(
-                          upd ->
-                              upd.index(columnIndexName)
-                                  .id(docId)
-                                  .document(OsUtils.toJsonData(json))
-                                  .docAsUpsert(true)));
-        }
+        BulkOperation operation =
+            BulkOperation.of(
+                op ->
+                    op.index(
+                        idx ->
+                            idx.index(columnIndexName)
+                                .id(docId)
+                                .document(OsUtils.toJsonData(json))));
         long estimatedSize =
             (long) json.getBytes(StandardCharsets.UTF_8).length + BULK_OPERATION_METADATA_OVERHEAD;
         columnBulkProcessor.add(operation, docId, Entity.TABLE_COLUMN, null, estimatedSize);

--- a/openmetadata-service/src/main/java/org/openmetadata/service/apps/bundles/searchIndex/distributed/PartitionWorker.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/apps/bundles/searchIndex/distributed/PartitionWorker.java
@@ -55,9 +55,6 @@ public class PartitionWorker {
   /** Context key for entity type */
   private static final String ENTITY_TYPE_KEY = "entityType";
 
-  /** Context key used by search sinks to write into staged indexes. */
-  private static final String STAGED_WRITE_KEY = "recreateIndex";
-
   /** Context key for staged index context. */
   private static final String STAGED_CONTEXT_KEY = "recreateContext";
 
@@ -713,7 +710,6 @@ public class PartitionWorker {
     String normalizedEntityType = SearchIndexEntityTypes.normalizeEntityType(entityType);
     Map<String, Object> contextData = new java.util.HashMap<>();
     contextData.put(ENTITY_TYPE_KEY, normalizedEntityType);
-    contextData.put(STAGED_WRITE_KEY, true);
 
     if (statsTracker != null) {
       contextData.put(BulkSink.STATS_TRACKER_CONTEXT_KEY, statsTracker);

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/search/SearchResource.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/search/SearchResource.java
@@ -853,12 +853,6 @@ public class SearchResource {
   public Response reindexEntities(
       @Context UriInfo uriInfo,
       @Context SecurityContext securityContext,
-      @Parameter(
-              description =
-                  "Recreate flag: if true, remove existing entity from ES first then add updated one")
-          @DefaultValue("false")
-          @QueryParam("recreate")
-          boolean recreate,
       @Parameter(description = "Job timeout in minutes (default: 30, max: 60)")
           @DefaultValue("5")
           @QueryParam("timeoutMinutes")
@@ -905,9 +899,8 @@ public class SearchResource {
                   long startTime = System.currentTimeMillis();
 
                   LOG.info(
-                      "Starting reindex job for {} entities. Recreate mode: {}, Timeout: {} minutes",
+                      "Starting reindex job for {} entities. Timeout: {} minutes",
                       totalEntities,
-                      recreate,
                       timeoutMinutes);
 
                   for (EntityReference ref : entities) {
@@ -976,27 +969,18 @@ public class SearchResource {
                             reducedSize);
                       }
 
-                      if (recreate) {
-                        searchRepository.getSearchClient().deleteEntity(indexName, entityId);
-                        LOG.debug(
-                            "Deleted entity {} ({}) from index {}",
-                            ref.getFullyQualifiedName(),
-                            entityId,
-                            indexName);
-                        searchRepository.getSearchClient().createEntity(indexName, entityId, doc);
-                        LOG.debug(
-                            "Recreated entity {} ({}) in index {}",
-                            ref.getFullyQualifiedName(),
-                            entityId,
-                            indexName);
-                      } else {
-                        searchRepository.updateEntityIndex(entity);
-                        LOG.debug(
-                            "Updated entity {} ({}) in index {}",
-                            ref.getFullyQualifiedName(),
-                            entityId,
-                            indexName);
-                      }
+                      searchRepository.getSearchClient().deleteEntity(indexName, entityId);
+                      LOG.debug(
+                          "Deleted entity {} ({}) from index {}",
+                          ref.getFullyQualifiedName(),
+                          entityId,
+                          indexName);
+                      searchRepository.getSearchClient().createEntity(indexName, entityId, doc);
+                      LOG.debug(
+                          "Recreated entity {} ({}) in index {}",
+                          ref.getFullyQualifiedName(),
+                          entityId,
+                          indexName);
 
                       successCount++;
 

--- a/openmetadata-service/src/main/java/org/openmetadata/service/util/OpenMetadataOperations.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/util/OpenMetadataOperations.java
@@ -1304,11 +1304,6 @@ public class OpenMetadataOperations implements Callable<Integer> {
               description = "Maximum size of the payload in bytes.")
           long payloadSize,
       @Option(
-              names = {"--recreate-indexes"},
-              defaultValue = "true",
-              description = "Flag to determine if indexes should be recreated.")
-          boolean recreateIndexes,
-      @Option(
               names = {"--producer-threads"},
               defaultValue = "10",
               description = "Number of threads to use for processing.")
@@ -1371,11 +1366,10 @@ public class OpenMetadataOperations implements Callable<Integer> {
           String slackChannel) {
     try {
       LOG.info(
-          "Running Reindexing with Entities:{} , Batch Size: {}, Payload Size: {}, Recreate-Index: {}, Producer threads: {}, Consumer threads: {}, Queue Size: {}, Back-off: {}, Max Back-off: {}, Max Requests: {}, Retries: {}, Auto-tune: {}",
+          "Running Reindexing with Entities:{} , Batch Size: {}, Payload Size: {}, Producer threads: {}, Consumer threads: {}, Queue Size: {}, Back-off: {}, Max Back-off: {}, Max Requests: {}, Retries: {}, Auto-tune: {}",
           entityStr,
           batchSize,
           payloadSize,
-          recreateIndexes,
           producerThreads,
           consumerThreads,
           queueSize,
@@ -1410,7 +1404,6 @@ public class OpenMetadataOperations implements Callable<Integer> {
           entities,
           batchSize,
           payloadSize,
-          recreateIndexes,
           producerThreads,
           consumerThreads,
           queueSize,
@@ -1778,7 +1771,6 @@ public class OpenMetadataOperations implements Callable<Integer> {
       Set<String> entities,
       int batchSize,
       long payloadSize,
-      boolean recreateIndexes,
       int producerThreads,
       int consumerThreads,
       int queueSize,
@@ -1797,8 +1789,9 @@ public class OpenMetadataOperations implements Callable<Integer> {
     IndexMappingVersionTracker versionTracker = null;
     boolean shouldUpdateVersions = false;
     ReindexingProgressMonitor progressMonitor = null;
+    boolean shouldReindex = true;
 
-    if (!force && recreateIndexes) {
+    if (!force) {
       try {
         String version = System.getProperty("project.version", "1.8.0-SNAPSHOT");
         versionTracker = new IndexMappingVersionTracker(collectionDAO, version, "system");
@@ -1807,7 +1800,7 @@ public class OpenMetadataOperations implements Callable<Integer> {
 
         if (changedMappings.isEmpty()) {
           LOG.info("✅ Smart reindexing: No index mapping changes detected, skipping reindex");
-          recreateIndexes = false;
+          shouldReindex = false;
 
           // Send Slack notification if configured
           if (slackBotToken != null
@@ -1836,7 +1829,7 @@ public class OpenMetadataOperations implements Callable<Integer> {
             if (requestedAndChanged.isEmpty()) {
               LOG.info(
                   "✅ Smart reindexing: None of the requested entities have mapping changes, skipping reindex");
-              recreateIndexes = false;
+              shouldReindex = false;
               shouldUpdateVersions = false;
 
               // Send Slack notification if configured
@@ -1859,7 +1852,7 @@ public class OpenMetadataOperations implements Callable<Integer> {
           }
 
           // Initialize progress monitor for entities that will be reindexed
-          if (recreateIndexes) {
+          if (shouldReindex) {
             progressMonitor = new ReindexingProgressMonitor(entities.stream().sorted().toList());
             progressMonitor.printInitialSummary();
           }
@@ -1871,7 +1864,7 @@ public class OpenMetadataOperations implements Callable<Integer> {
     }
 
     // Initialize progress monitor for force mode as well to get clean output
-    if (progressMonitor == null && recreateIndexes && force) {
+    if (progressMonitor == null && force) {
       progressMonitor = new ReindexingProgressMonitor(entities.stream().sorted().toList());
       LOG.info("");
       LOG.info("🔄 Force Reindexing");
@@ -1881,8 +1874,8 @@ public class OpenMetadataOperations implements Callable<Integer> {
       LOG.info("");
     }
 
-    // If recreateIndexes is false, we should not proceed with reindexing
-    if (!recreateIndexes) {
+    // If no mapping changes were detected, we should not proceed with reindexing
+    if (!shouldReindex) {
       LOG.info("Reindexing skipped - no changes detected");
       return 0; // Success - no reindexing needed
     }
@@ -1892,7 +1885,6 @@ public class OpenMetadataOperations implements Callable<Integer> {
             .withEntities(entities)
             .withBatchSize(batchSize)
             .withPayLoadSize(payloadSize)
-            .withRecreateIndex(recreateIndexes)
             .withProducerThreads(producerThreads)
             .withConsumerThreads(consumerThreads)
             .withQueueSize(queueSize)

--- a/openmetadata-service/src/test/java/org/openmetadata/service/apps/bundles/searchIndex/ElasticSearchBulkSinkBehaviorTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/apps/bundles/searchIndex/ElasticSearchBulkSinkBehaviorTest.java
@@ -121,12 +121,9 @@ class ElasticSearchBulkSinkBehaviorTest {
       invokePrivate(
           sink,
           "addEntity",
-          new Class<?>[] {
-            EntityInterface.class, String.class, boolean.class, StageStatsTracker.class, Map.class
-          },
+          new Class<?>[] {EntityInterface.class, String.class, StageStatsTracker.class, Map.class},
           entity,
           "table_index",
-          false,
           tracker,
           Collections.emptyMap());
 
@@ -162,12 +159,9 @@ class ElasticSearchBulkSinkBehaviorTest {
       invokePrivate(
           sink,
           "addEntity",
-          new Class<?>[] {
-            EntityInterface.class, String.class, boolean.class, StageStatsTracker.class, Map.class
-          },
+          new Class<?>[] {EntityInterface.class, String.class, StageStatsTracker.class, Map.class},
           entity,
           "table_index",
-          true,
           tracker,
           Collections.emptyMap());
 
@@ -335,12 +329,9 @@ class ElasticSearchBulkSinkBehaviorTest {
       invokePrivate(
           sink,
           "addEntity",
-          new Class<?>[] {
-            EntityInterface.class, String.class, boolean.class, StageStatsTracker.class, Map.class
-          },
+          new Class<?>[] {EntityInterface.class, String.class, StageStatsTracker.class, Map.class},
           entity,
           "table_index",
-          false,
           null,
           docBuildContexts);
 
@@ -368,12 +359,9 @@ class ElasticSearchBulkSinkBehaviorTest {
       invokePrivate(
           sink,
           "addEntity",
-          new Class<?>[] {
-            EntityInterface.class, String.class, boolean.class, StageStatsTracker.class, Map.class
-          },
+          new Class<?>[] {EntityInterface.class, String.class, StageStatsTracker.class, Map.class},
           entity,
           "table_index",
-          false,
           null,
           Collections.emptyMap());
 

--- a/openmetadata-service/src/test/java/org/openmetadata/service/apps/bundles/searchIndex/OpenSearchBulkSinkBehaviorTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/apps/bundles/searchIndex/OpenSearchBulkSinkBehaviorTest.java
@@ -130,7 +130,6 @@ class OpenSearchBulkSinkBehaviorTest {
           new Class<?>[] {
             EntityInterface.class,
             String.class,
-            boolean.class,
             ReindexContext.class,
             StageStatsTracker.class,
             boolean.class,
@@ -139,7 +138,6 @@ class OpenSearchBulkSinkBehaviorTest {
           },
           entity,
           "table_index",
-          false,
           null,
           tracker,
           false,
@@ -181,7 +179,6 @@ class OpenSearchBulkSinkBehaviorTest {
           new Class<?>[] {
             EntityInterface.class,
             String.class,
-            boolean.class,
             ReindexContext.class,
             StageStatsTracker.class,
             boolean.class,
@@ -190,7 +187,6 @@ class OpenSearchBulkSinkBehaviorTest {
           },
           entity,
           "table_index",
-          true,
           null,
           tracker,
           false,
@@ -368,7 +364,6 @@ class OpenSearchBulkSinkBehaviorTest {
           new Class<?>[] {
             EntityInterface.class,
             String.class,
-            boolean.class,
             ReindexContext.class,
             StageStatsTracker.class,
             boolean.class,
@@ -377,7 +372,6 @@ class OpenSearchBulkSinkBehaviorTest {
           },
           entity,
           "table_index",
-          false,
           null,
           null,
           false,
@@ -467,7 +461,6 @@ class OpenSearchBulkSinkBehaviorTest {
           new Class<?>[] {
             EntityInterface.class,
             String.class,
-            boolean.class,
             ReindexContext.class,
             StageStatsTracker.class,
             boolean.class,
@@ -476,7 +469,6 @@ class OpenSearchBulkSinkBehaviorTest {
           },
           entity,
           "table_index",
-          false,
           null,
           null,
           false,

--- a/openmetadata-service/src/test/java/org/openmetadata/service/apps/bundles/searchIndex/distributed/PartitionWorkerTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/apps/bundles/searchIndex/distributed/PartitionWorkerTest.java
@@ -418,7 +418,6 @@ class PartitionWorkerTest {
                 statsTracker);
 
     assertEquals("table", contextData.get("entityType"));
-    assertEquals(Boolean.TRUE, contextData.get("recreateIndex"));
     assertEquals(statsTracker, contextData.get(BulkSink.STATS_TRACKER_CONTEXT_KEY));
     assertEquals(stagedIndexContext, contextData.get("recreateContext"));
     assertEquals("table_staging", contextData.get("targetIndex"));
@@ -489,7 +488,6 @@ class PartitionWorkerTest {
     verify(bulkSink).write(entitiesCaptor.capture(), contextCaptor.capture());
     assertEquals(List.of(entityOne, entityTwo), entitiesCaptor.getValue());
     assertEquals("table", contextCaptor.getValue().get("entityType"));
-    assertEquals(Boolean.TRUE, contextCaptor.getValue().get("recreateIndex"));
     assertEquals(statsTracker, contextCaptor.getValue().get(BulkSink.STATS_TRACKER_CONTEXT_KEY));
   }
 


### PR DESCRIPTION
…flag

The search reindex always runs in recreate mode (the orchestrator unconditionally stages new indexes via RecreateIndexHandler and PartitionWorker always wrote to the staged index), so the recreateIndex boolean was effectively dead in the only reachable path while still carrying an in-place-upsert branch that nothing exercised. Remove the flag from the search path:

- OpenSearch/ElasticSearch bulk sinks: drop the recreateIndex read + method params; always emit the `index` op (overwrite-by-id, correct for a full rebuild) and delete the unused update/upsert branches.
- PartitionWorker: drop the now-dead contextData.put("recreateIndex", true) and its constant.
- SearchResource: remove the ?recreate query param from the per-entity reindex endpoint — it always deletes then recreates the doc.
- OpenMetadataOperations: remove the --recreate-indexes CLI option; preserve the "skip when no mapping changes" optimization under a dedicated shouldReindex local instead of overloading the recreate flag.

The staged-rebuild machinery (RecreateIndexHandler, RECREATE_CONTEXT, alias promotion) is unchanged — that is the always-on path. eventPublisherJob's recreateIndex schema field is left in place because RdfIndexApp still reads it, and SearchIndexAppConfigSanitizer keeps stripping the flag from persisted configs so legacy values are ignored. RDF and DataInsights recreate flags are out of scope and untouched.

<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:

Fixes #<issue-number>
<!--
Linking an issue is REQUIRED. Replace <issue-number> with the GitHub issue number this PR addresses
(e.g., `Fixes #12345`). GitHub will auto-link it. If no issue exists, please open one first so the
problem and design can be discussed before review.
-->

<!--
Short blurb explaining:
- What changes did you make?
- Why did you make them?
-->

I worked on ... because ...

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### High-level design:
<!--
REQUIRED for large PRs (new features, refactors, breaking changes, or anything touching >5 files).
Skip for small bug fixes and trivial changes.

Cover:
- Architecture / approach you took and why
- Key components or files added/changed and how they interact
- Alternatives considered and why you rejected them
- Any migration, backward-compatibility, or rollout concerns
- Diagrams or links to design docs / RFCs if available
-->

N/A — small change. <!-- Or fill in the design above -->

#
### Tests:

#### Use cases covered
<!--
List the user-visible scenarios this PR exercises. Example:
- User with Admin role can create a Glossary Term with a parent term
- Ingestion run for Snowflake correctly extracts row counts for partitioned tables
-->

#### Unit tests
<!--
- [ ] I added unit tests for the new/changed logic.
- Files added/updated:
- Coverage on changed classes (run `mvn jacoco:report` for backend, `yarn test:coverage` for UI,
  `make unit_ingestion` for ingestion). Target is 90% line coverage on changed classes.
- Coverage %: <e.g., 92% on EntityRepository.java>
-->

#### Backend integration tests
<!--
- [ ] I added integration tests in `openmetadata-integration-tests/` for new/changed API endpoints.
- [ ] Not applicable (no backend API changes).
- Files added/updated:
-->

#### Ingestion integration tests
<!--
- [ ] I added/updated ingestion integration tests for connector changes.
- [ ] Not applicable (no ingestion changes).
- Files added/updated:
-->

#### Playwright (UI) tests
<!--
- [ ] I added Playwright E2E tests under `openmetadata-ui/.../ui/playwright/` for UI changes.
- [ ] Not applicable (no UI changes).
- Files added/updated:
-->

#### Manual testing performed
<!--
List the manual test steps you performed before requesting review. Example:
1. Started local stack via `./docker/run_local_docker.sh -m ui -d mysql`
2. Logged in as admin, created entity X, verified Y appears in the UI
3. Triggered ingestion for Snowflake source, confirmed lineage edges in the explore page
-->

#
### UI screen recording / screenshots:
<!--
REQUIRED for any PR that changes the UI. Drag-and-drop a short screen recording (.mov / .mp4 / .gif)
demonstrating the change end-to-end, plus before/after screenshots where relevant.
Mark "Not applicable" if there are no UI changes.
-->

Not applicable. <!-- Or attach recording/screenshots above -->

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.
- [ ] For UI changes: I attached a screen recording and/or screenshots above.
- [ ] I have added tests (unit / integration / Playwright as applicable) and listed them above.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->
