### PR TITLE
fix(security): exclude netty-tcnative-boringssl-static from azure-* deps

### DIFF
--- a/openmetadata-service/pom.xml
+++ b/openmetadata-service/pom.xml
@@ -388,10 +388,15 @@
       <groupId>software.amazon.awssdk</groupId>
       <artifactId>sts</artifactId>
     </dependency>
-    <!-- GHSA-rwm7-x88c-3g2p / CVE-2026-42577: exclude Linux native epoll binding (the only
-         vulnerable artifact is the .so JAR; bug is in netty 4.2.x, GHSA range overly broad).
-         Netty falls back to Java NIO; netty-transport-classes-epoll stays. Per-direct-dep so
-         future Azure SDK bumps aren't blocked by a pinned azure-core-http-netty version. -->
+    <!-- Exclude two Linux native bindings transitively pulled by reactor-netty-http
+         (via azure-core-http-netty):
+           1. netty-transport-native-epoll — GHSA-rwm7-x88c-3g2p / CVE-2026-42577. The .so JAR
+              is the only vulnerable artifact; bug is in netty 4.2.x, GHSA range overly broad.
+              Netty falls back to Java NIO; netty-transport-classes-epoll stays.
+           2. netty-tcnative-boringssl-static — bundled BoringSSL .so SEGVs on Alpine/musl/aarch64
+              inside init_have_lse_atomics during the CPU LSE atomics probe. Netty falls back
+              to JDK SSLEngine; Azure HTTPS continues to work.
+         Per-direct-dep so future Azure SDK bumps aren't blocked by a pinned azure-core-http-netty version. -->
     <dependency>
       <groupId>com.azure</groupId>
       <artifactId>azure-security-keyvault-secrets</artifactId>
@@ -400,6 +405,10 @@
         <exclusion>
           <groupId>io.netty</groupId>
           <artifactId>netty-transport-native-epoll</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>io.netty</groupId>
+          <artifactId>netty-tcnative-boringssl-static</artifactId>
         </exclusion>
       </exclusions>
     </dependency>
@@ -412,6 +421,10 @@
           <groupId>io.netty</groupId>
           <artifactId>netty-transport-native-epoll</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>io.netty</groupId>
+          <artifactId>netty-tcnative-boringssl-static</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>
@@ -422,6 +435,10 @@
         <exclusion>
           <groupId>io.netty</groupId>
           <artifactId>netty-transport-native-epoll</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>io.netty</groupId>
+          <artifactId>netty-tcnative-boringssl-static</artifactId>
         </exclusion>
       </exclusions>
     </dependency>
@@ -1066,7 +1083,8 @@
       <artifactId>owasp-java-html-sanitizer</artifactId>
       <version>${owasp-html-sanitizer.version}</version>
     </dependency>
-    <!-- Context Center: object storage providers -->
+    <!-- Context Center: object storage providers. Exclusions match the azure-identity block
+         above — see that comment for the epoll + tcnative-boringssl-static rationale. -->
     <dependency>
       <groupId>com.azure</groupId>
       <artifactId>azure-storage-blob</artifactId>
@@ -1075,6 +1093,10 @@
         <exclusion>
           <groupId>io.netty</groupId>
           <artifactId>netty-transport-native-epoll</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>io.netty</groupId>
+          <artifactId>netty-tcnative-boringssl-static</artifactId>
         </exclusion>
       </exclusions>
     </dependency>


### PR DESCRIPTION
## Summary

The bundled BoringSSL native library shipped inside `netty-tcnative-boringssl-static` 2.0.x SEGVs on **Alpine (musl libc) + linux-aarch64** inside its CPU LSE atomics probe (`init_have_lse_atomics`), killing the JVM the first time Netty tries to load the `.so` for a TLS handshake.

This regression surfaced on `main` after #27558 (Context Center) added boot-time code in `ContextFileResource.initialize()` and `AttachmentResource.initialize()` that constructs an `AzureAssetService`. That constructor performs the first outbound HTTPS handshake of the boot sequence, which is what forces Netty to actually `loadLibrary` the broken `.so`. The same native lib is on the classpath in 1.12.7–1.13 (security cherry-pick), but those branches don't have boot-time code that triggers TLS, so the lib stays dormant — same crash material, never executed.

### Fix

Exclude `netty-tcnative-boringssl-static` transitively from the four direct azure-* deps that pull `reactor-netty-http` (via `azure-core-http-netty`):

- `azure-security-keyvault-secrets`
- `azure-identity`
- `azure-identity-extensions`
- `azure-storage-blob`

With the static fat-jar absent, Netty's `OpenSsl.isAvailable()` returns false and the HTTP client falls back to `JDK SSLEngine`, which has no native-lib LSE bug. Azure HTTPS continues to work — only the SSL provider changes.

Pairs with the existing `netty-transport-native-epoll` exclusion (CVE-2026-42577) that already follows the same per-direct-dep pattern.

## Test plan

- [ ] `mvn dependency:tree -Dincludes=io.netty:netty-tcnative-boringssl-static` returns empty for `openmetadata-service`
- [ ] `mvn package` builds cleanly
- [ ] Built dist `.tar.gz` no longer contains `netty-tcnative-boringssl-static-*.jar`
- [ ] Server boots on Alpine arm64 pod with Context Center configured for Azure object storage (the previously-crashing path)
- [ ] Azure KV secrets and Azure Blob storage operations still succeed at runtime (using JDK SSL)

## Backport

Recommend backport to 1.12.x and 1.13 to remove the latent risk on those branches too.