### PR TITLE
test(playwright): skip flaky Propagated badge changeSummary test

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/ChangeSummaryBadge.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/ChangeSummaryBadge.spec.ts
@@ -280,7 +280,11 @@ test.describe(
       });
     });
 
-    test('Propagated badge should appear on entity description with Propagated source', async ({
+    // Skipped: backend consolidation bug resets the description's changeSource
+    // from Propagated to Manual when the async entityStatus governance workflow
+    // re-saves the entity in the same session. See
+    // https://github.com/open-metadata/openmetadata-collate/issues/4256
+    test.skip('Propagated badge should appear on entity description with Propagated source', async ({
       browser,
       page,
     }) => {


### PR DESCRIPTION
## What

Skips the `ChangeSummary DescriptionSourceBadge › Propagated badge should appear on entity description with Propagated source` Playwright test.

## Why

The test is flaky due to a **backend change-summary consolidation bug**, not a test or frontend issue. After the test patches the description with `changeSource=Propagated`, the async `entityStatus` governance workflow re-saves the entity within the same session. That write consolidates against the create version (v0.1), re-diffs the `description` field, and re-stamps its `changeSummary` with the workflow's empty change source (`null` → `Manual`) — discarding the `Propagated` source recorded on the intermediate version. The badge then never renders for the page load.

This affects any `Suggested`/`Automated`/`Propagated` field source, not just `Propagated`; the sibling tests pass only by timing luck.

