### PR TITLE
fix(ui): use isNLPActive in ExploreQuickFilters to stop wrong NLQ endpoint hits

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/Explore/ExploreQuickFilters.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Explore/ExploreQuickFilters.test.tsx
@@ -64,9 +64,15 @@ jest.mock('../SearchDropdown/SearchDropdown', () => ({
     hideCounts,
     independent,
     showSelectedCounts,
+    singleSelect,
+    index: dropdownIndex,
   }: SearchDropdownProps) => (
     <div data-testid={`search-dropdown-${searchKey}`} title="search-dropdown">
       <span data-testid={`label-${searchKey}`}>{searchKey}</span>
+      <span data-testid={`single-select-${searchKey}`}>
+        {singleSelect ? 'true' : 'false'}
+      </span>
+      <span data-testid={`index-${searchKey}`}>{dropdownIndex}</span>
       <span data-testid={`has-null-option-${searchKey}`}>
         {hasNullOption ? 'true' : 'false'}
       </span>
@@ -162,7 +168,7 @@ describe('ExploreQuickFilters component', () => {
     jest.clearAllMocks();
     mockUseCustomLocation.mockReturnValue({ search: '' });
     mockUseAdvanceSearch.mockReturnValue({ queryFilter: mockQueryFilter });
-    mockUseSearchStore.mockReturnValue({ isNLPEnabled: false });
+    mockUseSearchStore.mockReturnValue({ isNLPActive: false });
     (getAggregationOptions as jest.Mock).mockImplementation(
       mockGetAggregationOptions
     );
@@ -528,8 +534,8 @@ describe('ExploreQuickFilters component', () => {
       });
     });
 
-    it('should call NLQ aggregate endpoint when NLP is enabled', async () => {
-      mockUseSearchStore.mockReturnValue({ isNLPEnabled: true });
+    it('should call NLQ aggregate endpoint when NLP is active', async () => {
+      mockUseSearchStore.mockReturnValue({ isNLPActive: true });
       mockGetAggregationOptions.mockResolvedValue(
         mockAdvancedFieldDefaultOptions
       );
@@ -751,6 +757,208 @@ describe('ExploreQuickFilters component', () => {
       expect(
         screen.getByTestId('selected-count-tier.tagFQN')
       ).toHaveTextContent('1');
+    });
+  });
+
+  describe('Static options (field.options)', () => {
+    it('should use static field options without calling API on initial open', async () => {
+      const staticFields: ExploreQuickFilterField[] = [
+        {
+          label: 'Status',
+          key: 'status',
+          value: undefined,
+          options: [
+            { key: 'active', label: 'Active' },
+            { key: 'inactive', label: 'Inactive' },
+          ],
+        },
+      ];
+
+      render(<ExploreQuickFilters {...mockProps} fields={staticFields} />);
+
+      const initialButton = screen.getByTestId('onGetInitialOptions-status');
+
+      await act(async () => {
+        userEvent.click(initialButton);
+      });
+
+      expect(getAggregationOptions).not.toHaveBeenCalled();
+    });
+
+    it('should filter static options by search value (case-insensitive)', async () => {
+      const staticFields: ExploreQuickFilterField[] = [
+        {
+          label: 'Status',
+          key: 'status',
+          value: undefined,
+          options: [
+            { key: 'active', label: 'Active' },
+            { key: 'inactive', label: 'Inactive' },
+          ],
+        },
+      ];
+
+      render(<ExploreQuickFilters {...mockProps} fields={staticFields} />);
+
+      const searchButton = screen.getByTestId('onSearch-status');
+
+      await act(async () => {
+        userEvent.click(searchButton);
+      });
+
+      expect(getAggregationOptions).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Field-specific searchIndex and searchKey', () => {
+    it('should use field.searchIndex and field.searchKey when provided', async () => {
+      mockGetAggregationOptions.mockResolvedValue(
+        mockAdvancedFieldDefaultOptions
+      );
+
+      const customFields: ExploreQuickFilterField[] = [
+        {
+          label: 'Custom',
+          key: 'custom.key',
+          value: undefined,
+          searchIndex: SearchIndex.TOPIC,
+          searchKey: 'remapped.key',
+        },
+      ];
+
+      render(<ExploreQuickFilters {...mockProps} fields={customFields} />);
+
+      const searchButton = screen.getByTestId('onSearch-custom.key');
+
+      await act(async () => {
+        userEvent.click(searchButton);
+      });
+
+      await waitFor(() => {
+        expect(getAggregationOptions).toHaveBeenCalledWith(
+          SearchIndex.TOPIC,
+          'remapped.key',
+          'test',
+          expect.any(String),
+          false,
+          false,
+          undefined,
+          false,
+          ''
+        );
+      });
+    });
+
+    it('should fall back to default index/key when field-specific not provided', async () => {
+      mockGetAggregationOptions.mockResolvedValue(
+        mockAdvancedFieldDefaultOptions
+      );
+
+      render(<ExploreQuickFilters {...mockProps} aggregations={undefined} />);
+
+      const initialButton = screen.getByTestId(
+        'onGetInitialOptions-database.name'
+      );
+
+      await act(async () => {
+        userEvent.click(initialButton);
+      });
+
+      await waitFor(() => {
+        expect(getAggregationOptions).toHaveBeenCalledWith(
+          SearchIndex.TABLE,
+          'database.name',
+          expect.any(String),
+          expect.any(String),
+          false,
+          false,
+          undefined,
+          false,
+          ''
+        );
+      });
+    });
+  });
+
+  describe('showDeleted URL flag', () => {
+    it('should pass showDeleted=true to getAggregationOptions when set in URL', async () => {
+      mockUseCustomLocation.mockReturnValue({ search: '?showDeleted=true' });
+      mockGetAggregationOptions.mockResolvedValue(
+        mockAdvancedFieldDefaultOptions
+      );
+
+      render(<ExploreQuickFilters {...mockProps} />);
+
+      const searchButton = screen.getByTestId('onSearch-database.name');
+
+      await act(async () => {
+        userEvent.click(searchButton);
+      });
+
+      await waitFor(() => {
+        expect(getAggregationOptions).toHaveBeenCalledWith(
+          SearchIndex.TABLE,
+          'database.name',
+          'test',
+          expect.any(String),
+          false,
+          true,
+          undefined,
+          false,
+          ''
+        );
+      });
+    });
+  });
+
+  describe('singleSelect propagation', () => {
+    it('should pass singleSelect flag from field config to SearchDropdown', () => {
+      const singleSelectFields: ExploreQuickFilterField[] = [
+        {
+          label: 'Database',
+          key: 'database.name',
+          value: undefined,
+          singleSelect: true,
+        },
+      ];
+
+      render(
+        <ExploreQuickFilters {...mockProps} fields={singleSelectFields} />
+      );
+
+      expect(
+        screen.getByTestId('single-select-database.name')
+      ).toHaveTextContent('true');
+    });
+  });
+
+  describe('Multi-index display', () => {
+    it('should pass first index as display index to SearchDropdown', () => {
+      const multiIndexProps = {
+        ...mockProps,
+        index: [SearchIndex.TABLE, SearchIndex.TOPIC] as unknown as SearchIndex,
+      };
+
+      render(<ExploreQuickFilters {...multiIndexProps} />);
+
+      expect(screen.getByTestId('index-database.name')).toHaveTextContent(
+        SearchIndex.TABLE
+      );
+    });
+  });
+
+  describe('additionalActions', () => {
+    it('should render additionalActions content', () => {
+      render(
+        <ExploreQuickFilters
+          {...mockProps}
+          additionalActions={
+            <button data-testid="extra-action">Extra Action</button>
+          }
+        />
+      );
+
+      expect(screen.getByTestId('extra-action')).toBeInTheDocument();
     });
   });
 });

--- a/openmetadata-ui/src/main/resources/ui/src/components/Explore/ExploreQuickFilters.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Explore/ExploreQuickFilters.tsx
@@ -51,7 +51,7 @@ const ExploreQuickFilters: FC<ExploreQuickFiltersProps> = ({
   const [options, setOptions] = useState<SearchDropdownOption[]>();
   const [isOptionsLoading, setIsOptionsLoading] = useState<boolean>(false);
   const { queryFilter } = useAdvanceSearch();
-  const { isNLPEnabled } = useSearchStore();
+  const { isNLPActive } = useSearchStore();
   const getStaticOptions = useCallback(
     (key: string) => fields.find((item) => item.key === key)?.options,
     [fields]
@@ -116,7 +116,7 @@ const ExploreQuickFilters: FC<ExploreQuickFiltersProps> = ({
         independent,
         showDeleted,
         optionPageSize,
-        isNLPEnabled,
+        isNLPActive,
         searchText
       );
 
@@ -187,7 +187,7 @@ const ExploreQuickFilters: FC<ExploreQuickFiltersProps> = ({
         independent,
         showDeleted,
         undefined,
-        isNLPEnabled,
+        isNLPActive,
         searchText
       );
 


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:

Fixes #28409

<!--
Linking an issue is REQUIRED. Replace <issue-number> with the GitHub issue number this PR addresses
(e.g., `Fixes #12345`). GitHub will auto-link it. If no issue exists, please open one first so the
problem and design can be discussed before review.
-->

<!--
Short blurb explaining:
- What changes did you make?
- Why did you make them?
-->

### Summary

`ExploreQuickFilters` destructured `isNLPEnabled` from `useSearchStore`, but store exposes `isNLPActive`. Flag passed to `getAggregationOptions` always `undefined` → quick filter aggregation requests routed to `/api/v1/nlq/search` instead of `/api/v1/search/aggregate`.

### Root Cause

[ExploreQuickFilters.tsx:54](openmetadata-ui/src/main/resources/ui/src/components/Explore/ExploreQuickFilters.tsx#L54) — wrong key destructured. Passed at lines 119 and 190 as `isNLPEnabled` arg.

### Fix

Rename `isNLPEnabled` → `isNLPActive` in destructure + both `getAggregationOptions` call sites.

### Reproduction

1. Open Explore page.
2. Change any Data Assets quick filter (Database / Service / Owner).
3. Network tab → request hits `/nlq/search` instead of `/search/aggregate`.


#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### High-level design:
<!--
REQUIRED for large PRs (new features, refactors, breaking changes, or anything touching >5 files).
Skip for small bug fixes and trivial changes.

Cover:
- Architecture / approach you took and why
- Key components or files added/changed and how they interact
- Alternatives considered and why you rejected them
- Any migration, backward-compatibility, or rollout concerns
- Diagrams or links to design docs / RFCs if available
-->

N/A — small change. <!-- Or fill in the design above -->

#
### Tests:

#### Use cases covered
<!--
List the user-visible scenarios this PR exercises. Example:
- User with Admin role can create a Glossary Term with a parent term
- Ingestion run for Snowflake correctly extracts row counts for partitioned tables
-->

#### Unit tests
<!--
- [ ] I added unit tests for the new/changed logic.
- Files added/updated:
- Coverage on changed classes (run `mvn jacoco:report` for backend, `yarn test:coverage` for UI,
  `make unit_ingestion` for ingestion). Target is 90% line coverage on changed classes.
- Coverage %: <e.g., 92% on EntityRepository.java>
-->

#### Backend integration tests
<!--
- [ ] I added integration tests in `openmetadata-integration-tests/` for new/changed API endpoints.
- [ ] Not applicable (no backend API changes).
- Files added/updated:
-->

#### Ingestion integration tests
<!--
- [ ] I added/updated ingestion integration tests for connector changes.
- [ ] Not applicable (no ingestion changes).
- Files added/updated:
-->

#### Playwright (UI) tests
<!--
- [ ] I added Playwright E2E tests under `openmetadata-ui/.../ui/playwright/` for UI changes.
- [ ] Not applicable (no UI changes).
- Files added/updated:
-->

#### Manual testing performed
<!--
List the manual test steps you performed before requesting review. Example:
1. Started local stack via `./docker/run_local_docker.sh -m ui -d mysql`
2. Logged in as admin, created entity X, verified Y appears in the UI
3. Triggered ingestion for Snowflake source, confirmed lineage edges in the explore page
-->

#
### UI screen recording / screenshots:
<!--
REQUIRED for any PR that changes the UI. Drag-and-drop a short screen recording (.mov / .mp4 / .gif)
demonstrating the change end-to-end, plus before/after screenshots where relevant.
Mark "Not applicable" if there are no UI changes.
-->

Not applicable. <!-- Or attach recording/screenshots above -->

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.
- [ ] For UI changes: I attached a screen recording and/or screenshots above.
- [ ] I have added tests (unit / integration / Playwright as applicable) and listed them above.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->
