### PR TITLE
fix(security): authorize test-connection workflow triggers (#26760)

### DIFF
--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/WorkflowTriggerPermissionsIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/WorkflowTriggerPermissionsIT.java
@@ -1,0 +1,274 @@
+package org.openmetadata.it.tests;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.openmetadata.it.auth.JwtAuthProvider;
+import org.openmetadata.it.bootstrap.SharedEntities;
+import org.openmetadata.it.util.SdkClients;
+import org.openmetadata.it.util.TestNamespace;
+import org.openmetadata.it.util.TestNamespaceExtension;
+import org.openmetadata.schema.api.services.CreateDatabaseService;
+import org.openmetadata.schema.api.services.DatabaseConnection;
+import org.openmetadata.schema.entity.automations.CreateWorkflow;
+import org.openmetadata.schema.entity.automations.QueryRunnerRequest;
+import org.openmetadata.schema.entity.automations.TestServiceConnectionRequest;
+import org.openmetadata.schema.entity.automations.Workflow;
+import org.openmetadata.schema.entity.automations.WorkflowType;
+import org.openmetadata.schema.entity.services.DatabaseService;
+import org.openmetadata.schema.entity.services.ServiceType;
+import org.openmetadata.schema.services.connections.database.MysqlConnection;
+import org.openmetadata.schema.services.connections.database.common.basicAuth;
+import org.openmetadata.schema.type.EntityReference;
+import org.openmetadata.sdk.client.OpenMetadataClient;
+
+/**
+ * Integration tests for trigger-endpoint authorization on
+ * {@code POST /v1/automations/workflows/trigger/{id}}.
+ *
+ * <p>Covers the authorization branches added in {@code WorkflowResource#authorizeWorkflowTrigger}:
+ *
+ * <ul>
+ *   <li>TEST_CONNECTION with {@code serviceName} set — authorized via ANY of EDIT_ALL on the
+ *       service OR CREATE on INGESTION_PIPELINE.
+ *   <li>TEST_CONNECTION with no {@code serviceName} — authorized via CREATE on INGESTION_PIPELINE.
+ *   <li>Other workflow types — intentionally NOT gated by this authorizer (scope limited to
+ *       TEST_CONNECTION per issue #26760); they retain their prior trigger behavior.
+ * </ul>
+ */
+@Execution(ExecutionMode.CONCURRENT)
+@ExtendWith(TestNamespaceExtension.class)
+public class WorkflowTriggerPermissionsIT {
+
+  private static final HttpClient HTTP_CLIENT = HttpClient.newHttpClient();
+  private static final String TRIGGER_PATH = "/v1/automations/workflows/trigger/";
+  private static final long TOKEN_TTL_SECONDS = 3600;
+
+  @Test
+  void test_triggerWorkflow_noAuth_returns401(TestNamespace ns) throws Exception {
+    HttpRequest request =
+        HttpRequest.newBuilder()
+            .uri(URI.create(SdkClients.getServerUrl() + TRIGGER_PATH + UUID.randomUUID()))
+            .header("Content-Type", "application/json")
+            .POST(HttpRequest.BodyPublishers.noBody())
+            .build();
+
+    HttpResponse<String> response = HTTP_CLIENT.send(request, HttpResponse.BodyHandlers.ofString());
+
+    assertEquals(401, response.statusCode(), "Trigger without auth header must return 401");
+  }
+
+  @Test
+  void test_triggerTestConnection_admin_withServiceName_authPasses(TestNamespace ns)
+      throws Exception {
+    OpenMetadataClient admin = SdkClients.adminClient();
+    DatabaseService service = createMysqlService(admin, ns.prefix("svc-admin-trig"), null);
+    Workflow workflow =
+        admin
+            .workflows()
+            .create(testConnectionRequest(ns.prefix("admin-with-svc"), service.getName()));
+
+    HttpResponse<String> response = triggerWorkflow(workflow.getId(), SdkClients.getAdminToken());
+
+    assertAuthPassed(response, "admin must pass auth on TEST_CONNECTION with serviceName");
+  }
+
+  @Test
+  void test_triggerTestConnection_admin_withoutServiceName_authPasses(TestNamespace ns)
+      throws Exception {
+    OpenMetadataClient admin = SdkClients.adminClient();
+    Workflow workflow =
+        admin.workflows().create(testConnectionRequest(ns.prefix("admin-no-svc"), null));
+
+    HttpResponse<String> response = triggerWorkflow(workflow.getId(), SdkClients.getAdminToken());
+
+    assertAuthPassed(response, "admin must pass auth on TEST_CONNECTION without serviceName");
+  }
+
+  @Test
+  void test_triggerTestConnection_serviceOwner_authPasses(TestNamespace ns) throws Exception {
+    OpenMetadataClient admin = SdkClients.adminClient();
+    EntityReference owner = SharedEntities.get().USER2_REF;
+    DatabaseService ownedService =
+        createMysqlService(admin, ns.prefix("owned-svc"), List.of(owner));
+    Workflow workflow =
+        admin
+            .workflows()
+            .create(testConnectionRequest(ns.prefix("owner-trig"), ownedService.getName()));
+
+    String ownerToken = tokenFor("shared_user2@test.openmetadata.org", new String[] {});
+    HttpResponse<String> response = triggerWorkflow(workflow.getId(), ownerToken);
+
+    assertAuthPassed(
+        response,
+        "service owner must pass auth via EDIT_ALL on owned service (got "
+            + response.statusCode()
+            + ")");
+  }
+
+  @Test
+  void test_triggerTestConnection_nonOwner_returns403(TestNamespace ns) throws Exception {
+    OpenMetadataClient admin = SdkClients.adminClient();
+    EntityReference owner = SharedEntities.get().USER2_REF;
+    DatabaseService ownedService =
+        createMysqlService(admin, ns.prefix("user2-svc"), List.of(owner));
+    Workflow workflow =
+        admin
+            .workflows()
+            .create(testConnectionRequest(ns.prefix("nonowner-trig"), ownedService.getName()));
+
+    String nonOwnerToken = tokenFor("shared_user3@test.openmetadata.org", new String[] {});
+    HttpResponse<String> response = triggerWorkflow(workflow.getId(), nonOwnerToken);
+
+    assertEquals(
+        403,
+        response.statusCode(),
+        "user without service ownership or pipeline perms must be denied");
+  }
+
+  @Test
+  void test_triggerTestConnection_dataConsumer_withServiceName_returns403(TestNamespace ns)
+      throws Exception {
+    OpenMetadataClient admin = SdkClients.adminClient();
+    DatabaseService service = createMysqlService(admin, ns.prefix("svc-dc"), null);
+    Workflow workflow =
+        admin
+            .workflows()
+            .create(testConnectionRequest(ns.prefix("dc-with-svc"), service.getName()));
+
+    HttpResponse<String> response = triggerWorkflow(workflow.getId(), dataConsumerToken());
+
+    assertEquals(
+        403, response.statusCode(), "DataConsumer must be denied on TEST_CONNECTION with service");
+  }
+
+  @Test
+  void test_triggerTestConnection_dataConsumer_withoutServiceName_returns403(TestNamespace ns)
+      throws Exception {
+    OpenMetadataClient admin = SdkClients.adminClient();
+    Workflow workflow =
+        admin.workflows().create(testConnectionRequest(ns.prefix("dc-no-svc"), null));
+
+    HttpResponse<String> response = triggerWorkflow(workflow.getId(), dataConsumerToken());
+
+    assertEquals(
+        403,
+        response.statusCode(),
+        "DataConsumer must be denied on TEST_CONNECTION without serviceName "
+            + "(falls back to INGESTION_PIPELINE CREATE)");
+  }
+
+  @Test
+  void test_triggerNonTestConnection_admin_authPasses(TestNamespace ns) throws Exception {
+    OpenMetadataClient admin = SdkClients.adminClient();
+    Workflow workflow = admin.workflows().create(queryRunnerRequest(ns.prefix("qr-admin")));
+
+    HttpResponse<String> response = triggerWorkflow(workflow.getId(), SdkClients.getAdminToken());
+
+    assertAuthPassed(response, "admin must pass auth on QUERY_RUNNER workflow");
+  }
+
+  @Test
+  void test_triggerNonTestConnection_notGatedByTestConnectionAuth(TestNamespace ns)
+      throws Exception {
+    OpenMetadataClient admin = SdkClients.adminClient();
+    Workflow workflow = admin.workflows().create(queryRunnerRequest(ns.prefix("qr-dc")));
+
+    HttpResponse<String> response = triggerWorkflow(workflow.getId(), dataConsumerToken());
+
+    assertAuthPassed(
+        response,
+        "non-TEST_CONNECTION triggers are intentionally out of scope for the test-connection "
+            + "authorizer (issue #26760) and must not be blocked by it");
+  }
+
+  private CreateWorkflow testConnectionRequest(String name, String serviceName) {
+    TestServiceConnectionRequest request =
+        new TestServiceConnectionRequest()
+            .withServiceType(ServiceType.DATABASE)
+            .withConnectionType("Mysql")
+            .withConnection(
+                new DatabaseConnection()
+                    .withConfig(
+                        new MysqlConnection()
+                            .withHostPort("mysql:3306")
+                            .withUsername("openmetadata_user")
+                            .withAuthType(new basicAuth().withPassword("openmetadata_password"))));
+    if (serviceName != null) {
+      request.setServiceName(serviceName);
+    }
+    return new CreateWorkflow()
+        .withName(name)
+        .withDescription(name)
+        .withWorkflowType(WorkflowType.TEST_CONNECTION)
+        .withRequest(request);
+  }
+
+  private CreateWorkflow queryRunnerRequest(String name) {
+    QueryRunnerRequest request =
+        new QueryRunnerRequest().withConnectionType("Mysql").withQuery("SELECT 1");
+    return new CreateWorkflow()
+        .withName(name)
+        .withDescription(name)
+        .withWorkflowType(WorkflowType.QUERY_RUNNER)
+        .withRequest(request);
+  }
+
+  private DatabaseService createMysqlService(
+      OpenMetadataClient client, String name, List<EntityReference> owners) {
+    CreateDatabaseService create =
+        new CreateDatabaseService()
+            .withName(name)
+            .withServiceType(CreateDatabaseService.DatabaseServiceType.Mysql)
+            .withConnection(
+                new DatabaseConnection()
+                    .withConfig(
+                        new MysqlConnection()
+                            .withHostPort("mysql:3306")
+                            .withUsername("openmetadata_user")
+                            .withAuthType(new basicAuth().withPassword("openmetadata_password"))));
+    if (owners != null && !owners.isEmpty()) {
+      create.setOwners(owners);
+    }
+    return client.databaseServices().create(create);
+  }
+
+  private HttpResponse<String> triggerWorkflow(UUID workflowId, String token) throws Exception {
+    HttpRequest request =
+        HttpRequest.newBuilder()
+            .uri(URI.create(SdkClients.getServerUrl() + TRIGGER_PATH + workflowId))
+            .header("Authorization", "Bearer " + token)
+            .header("Content-Type", "application/json")
+            .POST(HttpRequest.BodyPublishers.noBody())
+            .build();
+    return HTTP_CLIENT.send(request, HttpResponse.BodyHandlers.ofString());
+  }
+
+  private static void assertAuthPassed(HttpResponse<String> response, String message) {
+    int code = response.statusCode();
+    assertNotEquals(401, code, message + " (got 401 — unauthenticated)");
+    assertNotEquals(403, code, message + " (got 403 — forbidden)");
+  }
+
+  private static String dataConsumerToken() {
+    return JwtAuthProvider.tokenFor(
+        "data-consumer@open-metadata.org",
+        "data-consumer@open-metadata.org",
+        new String[] {"DataConsumer"},
+        TOKEN_TTL_SECONDS);
+  }
+
+  private static String tokenFor(String email, String[] roles) {
+    return JwtAuthProvider.tokenFor(email, email, roles, TOKEN_TTL_SECONDS);
+  }
+}

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/automations/WorkflowResource.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/automations/WorkflowResource.java
@@ -593,6 +593,13 @@ public class WorkflowResource extends EntityResource<Workflow, WorkflowRepositor
           (Workflow) ClassConverterFactory.getConverter(Workflow.class).convert(workflow);
       if (converted.getRequest() instanceof TestServiceConnectionRequest testRequest) {
         authorizeTestConnection(securityContext, testRequest);
+      } else {
+        // Fail closed: deny the trigger if a TEST_CONNECTION request cannot be resolved to a
+        // TestServiceConnectionRequest, rather than letting it run unauthorized.
+        throw new AuthorizationException(
+            String.format(
+                "Cannot authorize TEST_CONNECTION trigger for workflow [%s]: request is not a valid TestServiceConnectionRequest",
+                workflow.getId()));
       }
     }
   }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/automations/WorkflowResource.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/automations/WorkflowResource.java
@@ -33,6 +33,7 @@ import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.SecurityContext;
 import jakarta.ws.rs.core.UriInfo;
+import java.util.List;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
@@ -64,9 +65,12 @@ import org.openmetadata.service.secrets.SecretsManager;
 import org.openmetadata.service.secrets.SecretsManagerFactory;
 import org.openmetadata.service.secrets.converter.ClassConverterFactory;
 import org.openmetadata.service.secrets.masker.EntityMaskerFactory;
+import org.openmetadata.service.security.AuthRequest;
 import org.openmetadata.service.security.AuthorizationException;
+import org.openmetadata.service.security.AuthorizationLogic;
 import org.openmetadata.service.security.Authorizer;
 import org.openmetadata.service.security.policyevaluator.OperationContext;
+import org.openmetadata.service.security.policyevaluator.ResourceContext;
 import org.openmetadata.service.util.EntityUtil;
 import org.openmetadata.service.util.OpenMetadataConnectionBuilder;
 
@@ -378,6 +382,7 @@ public class WorkflowResource extends EntityResource<Workflow, WorkflowRepositor
       @Context SecurityContext securityContext) {
     EntityUtil.Fields fields = getFields(FIELD_OWNERS);
     Workflow workflow = repository.get(uriInfo, id, fields);
+    authorizeWorkflowTrigger(securityContext, workflow);
     workflow.setOpenMetadataServerConnection(
         new OpenMetadataConnectionBuilder(openMetadataApplicationConfig).build());
     /*
@@ -580,6 +585,46 @@ public class WorkflowResource extends EntityResource<Workflow, WorkflowRepositor
     return Response.fromResponse(response)
         .entity(decryptOrNullify(securityContext, (Workflow) response.getEntity()))
         .build();
+  }
+
+  private void authorizeWorkflowTrigger(SecurityContext securityContext, Workflow workflow) {
+    if (WorkflowType.TEST_CONNECTION.equals(workflow.getWorkflowType())) {
+      Workflow converted =
+          (Workflow) ClassConverterFactory.getConverter(Workflow.class).convert(workflow);
+      if (converted.getRequest() instanceof TestServiceConnectionRequest testRequest) {
+        authorizeTestConnection(securityContext, testRequest);
+      }
+    }
+  }
+
+  private void authorizeTestConnection(
+      SecurityContext securityContext, TestServiceConnectionRequest testRequest) {
+    String serviceName = testRequest.getServiceName();
+
+    if (serviceName != null && testRequest.getServiceType() != null) {
+      String serviceEntityType =
+          Entity.getServiceEntityRepository(testRequest.getServiceType()).getEntityType();
+      OperationContext serviceOpCtx =
+          new OperationContext(serviceEntityType, MetadataOperation.EDIT_ALL);
+      ResourceContext<?> serviceResourceCtx =
+          new ResourceContext<>(serviceEntityType, null, serviceName);
+
+      OperationContext pipelineOpCtx =
+          new OperationContext(Entity.INGESTION_PIPELINE, MetadataOperation.CREATE);
+      ResourceContext<?> pipelineResourceCtx = new ResourceContext<>(Entity.INGESTION_PIPELINE);
+
+      authorizer.authorizeRequests(
+          securityContext,
+          List.of(
+              new AuthRequest(serviceOpCtx, serviceResourceCtx),
+              new AuthRequest(pipelineOpCtx, pipelineResourceCtx)),
+          AuthorizationLogic.ANY);
+    } else {
+      OperationContext operationContext =
+          new OperationContext(Entity.INGESTION_PIPELINE, MetadataOperation.CREATE);
+      ResourceContext<?> resourceContext = new ResourceContext<>(Entity.INGESTION_PIPELINE);
+      authorizer.authorize(securityContext, operationContext, resourceContext);
+    }
   }
 
   private Workflow unmask(Workflow workflow) {


### PR DESCRIPTION
## What

Adds authorization to the workflow trigger endpoint (`POST /v1/automations/workflows/trigger/{id}`) for `TEST_CONNECTION` workflows. Closes #26760.

## Why

The trigger endpoint performed **no authorization**, so any authenticated user could trigger a `TEST_CONNECTION` workflow against any service and probe its connectivity/credentials, regardless of ownership or pipeline permissions.

## How

`authorizeWorkflowTrigger`, for `TEST_CONNECTION` only:

1. Converts the workflow via `ClassConverterFactory` before the type check. The stored `Workflow.request` is an untyped `LinkedHashMap`, so `instanceof TestServiceConnectionRequest` only matches **after** conversion — the same pattern the existing unmask/decrypt paths already use. Without this the check silently falls through.
2. Requires **ANY** of:
   - admin (short-circuits), or
   - `EDIT_ALL` on the target service (covers the service owner), or
   - `CREATE` on `INGESTION_PIPELINE`.
3. When no `serviceName` is present, falls back to `CREATE` on `INGESTION_PIPELINE`.

`workflowType` is checked **before** converting, so non-test-connection triggers skip the (secrets-decrypting) conversion entirely.

### Scope

`QUERY_RUNNER`, `REVERSE_INGESTION`, and `TEST_SPARK_ENGINE_CONNECTION` are intentionally left **unchanged** (no trigger-level authz, as before) to keep this change scoped to #26760. Locking those down — `QUERY_RUNNER` in particular executes arbitrary SQL — is worth a separate follow-up.

## Testing

Adds `WorkflowTriggerPermissionsIT`. Verified end-to-end against a local Docker deployment:

| Scenario | Result |
|----------|--------|
| admin → TEST_CONNECTION | 200 |
| non-owner, no perms → TEST_CONNECTION | 403 |
| service owner → TEST_CONNECTION | 200 |
| non-owner + `ingestionPipeline:Create` → TEST_CONNECTION | 200 |
| QUERY_RUNNER (non-owner) | not gated |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
