### PR TITLE
Fix #28076: search_after drops entities when sort value contains a comma

### DIFF
--- a/ingestion/src/metadata/ingestion/ometa/mixins/es_mixin.py
+++ b/ingestion/src/metadata/ingestion/ometa/mixins/es_mixin.py
@@ -366,7 +366,7 @@ class ESMixin(Generic[T]):
         if sort_order not in ("asc", "desc"):
             raise ValueError(f"sort_order must be 'asc' or 'desc', got '{sort_order}'")
 
-        after: Optional[str] = None  # noqa: UP045
+        after: str = ""
         error_pages = 0
         query = functools.partial(
             self.paginate_query.format,
@@ -379,7 +379,7 @@ class ESMixin(Generic[T]):
             sort_order=sort_order,
         )
         while True:
-            query_string = query(after="&search_after=" + quote_plus(after) if after else "")
+            query_string = query(after=after)
             response = self._get_es_response(query_string)
 
             # Allow 3 errors getting pages before getting out of the loop
@@ -397,7 +397,8 @@ class ESMixin(Generic[T]):
                 logger.debug("No more pages to fetch")
                 break
 
-            after = ",".join(last_hit.sort)
+            # One &search_after= per sort value — safe for values containing ','.
+            after = "".join(f"&search_after={quote_plus(str(v))}" for v in last_hit.sort)
 
     def paginate_es(
         self,

--- a/ingestion/src/metadata/ingestion/ometa/mixins/es_mixin.py
+++ b/ingestion/src/metadata/ingestion/ometa/mixins/es_mixin.py
@@ -397,7 +397,6 @@ class ESMixin(Generic[T]):
                 logger.debug("No more pages to fetch")
                 break
 
-            # One &search_after= per sort value — safe for values containing ','.
             after = "".join(f"&search_after={quote_plus(str(v))}" for v in last_hit.sort)
 
     def paginate_es(

--- a/ingestion/tests/integration/ometa/test_ometa_es_api.py
+++ b/ingestion/tests/integration/ometa/test_ometa_es_api.py
@@ -399,13 +399,10 @@ class TestOMetaESAPI:
                     tries += 1
                     time.sleep(1)
 
-            # Narrow to this test's tables — other tests / module fixtures share es_service.
-            query_filter = (
-                '{"query":{"bool":{"must":['
-                f'{{"term":{{"service.displayName.keyword":"{es_service.name.root}"}}}},'
-                f'{{"wildcard":{{"name.keyword":"comma,{test_id},table,*"}}}}'
-                "]}}}"
-            )
+            # Filter by exact id list so the result set is hermetic — no table
+            # created by any other test, fixture, or future addition can leak in.
+            expected_ids = [str(t.id.root) for t in created_tables]
+            query_filter = json.dumps({"query": {"terms": {"id.keyword": expected_ids}}})
             assets = list(metadata.paginate_es(entity=Table, query_filter=query_filter, size=1))
             returned = {a.name.root for a in assets}
             expected_set = set(expected_names)

--- a/ingestion/tests/integration/ometa/test_ometa_es_api.py
+++ b/ingestion/tests/integration/ometa/test_ometa_es_api.py
@@ -373,7 +373,7 @@ class TestOMetaESAPI:
         own param, so a comma in the value cannot truncate pagination.
         """
         test_id = str(uuid.uuid4())[:8]
-        expected_names = {f"comma,{test_id},table,{i}" for i in range(5)}
+        expected_names = [f"comma,{test_id},table,{i}" for i in range(5)]
         created_tables = []
         try:
             for name in expected_names:
@@ -386,12 +386,22 @@ class TestOMetaESAPI:
                 )
                 created_tables.append(table)
 
-            # Wait for ES to index the last-created table (refresh interval is 1s).
-            last_fqn = created_tables[-1].fullyQualifiedName.root
-            for _ in range(10):
-                if metadata.es_search_from_fqn(entity_type=Table, fqn_search_string=last_fqn):
+            # Block until ALL created tables are searchable. Failing here is
+            # explicit (rather than letting paginate_es run on a partially
+            # indexed state and producing a confusing assertion error).
+            indexed = False
+            for _ in range(30):
+                if all(
+                    metadata.es_search_from_fqn(entity_type=Table, fqn_search_string=t.fullyQualifiedName.root)
+                    for t in created_tables
+                ):
+                    indexed = True
                     break
                 time.sleep(1)
+            if not indexed:
+                pytest.fail(
+                    f"ES did not index all {len(created_tables)} tables within 30s; cannot reliably test pagination"
+                )
 
             # Narrow to this test's tables — other tests / module fixtures share es_service.
             query_filter = (
@@ -402,10 +412,11 @@ class TestOMetaESAPI:
             )
             assets = list(metadata.paginate_es(entity=Table, query_filter=query_filter, size=1))
             returned = {a.name.root for a in assets}
-            assert returned == expected_names, (
+            expected_set = set(expected_names)
+            assert returned == expected_set, (
                 f"Pagination did not round-trip comma-FQN tables.\n"
-                f"  missing: {sorted(expected_names - returned)}\n"
-                f"  extra:   {sorted(returned - expected_names)}"
+                f"  missing: {sorted(expected_set - returned)}\n"
+                f"  extra:   {sorted(returned - expected_set)}"
             )
         finally:
             for table in created_tables:

--- a/ingestion/tests/integration/ometa/test_ometa_es_api.py
+++ b/ingestion/tests/integration/ometa/test_ometa_es_api.py
@@ -386,8 +386,6 @@ class TestOMetaESAPI:
                 )
                 created_tables.append(table)
 
-            # Poll until ES has indexed every created table — same pattern as
-            # the wait_for_es_index fixture above.
             tries = 0
             indexed = False
             while not indexed and tries <= 10:
@@ -399,8 +397,6 @@ class TestOMetaESAPI:
                     tries += 1
                     time.sleep(1)
 
-            # Filter by exact id list so the result set is hermetic — no table
-            # created by any other test, fixture, or future addition can leak in.
             expected_ids = [str(t.id.root) for t in created_tables]
             query_filter = json.dumps({"query": {"terms": {"id.keyword": expected_ids}}})
             assets = list(metadata.paginate_es(entity=Table, query_filter=query_filter, size=1))

--- a/ingestion/tests/integration/ometa/test_ometa_es_api.py
+++ b/ingestion/tests/integration/ometa/test_ometa_es_api.py
@@ -365,6 +365,55 @@ class TestOMetaESAPI:
                 except Exception:
                     pass
 
+    def test_paginate_with_comma_in_name(self, metadata, es_service, es_schema):
+        """Regression for #28076 — pagination must survive sort values containing ','.
+
+        With size=1, every page boundary's cursor is a single FQN with ',' in it.
+        The multi-value search_after wire format carries each sort value as its
+        own param, so a comma in the value cannot truncate pagination.
+        """
+        test_id = str(uuid.uuid4())[:8]
+        expected_names = {f"comma,{test_id},table,{i}" for i in range(5)}
+        created_tables = []
+        try:
+            for name in expected_names:
+                table = metadata.create_or_update(
+                    data=get_create_entity(
+                        entity=Table,
+                        name=EntityName(name),
+                        reference=es_schema.fullyQualifiedName,
+                    )
+                )
+                created_tables.append(table)
+
+            # Wait for ES to index the last-created table (refresh interval is 1s).
+            last_fqn = created_tables[-1].fullyQualifiedName.root
+            for _ in range(10):
+                if metadata.es_search_from_fqn(entity_type=Table, fqn_search_string=last_fqn):
+                    break
+                time.sleep(1)
+
+            # Narrow to this test's tables — other tests / module fixtures share es_service.
+            query_filter = (
+                '{"query":{"bool":{"must":['
+                f'{{"term":{{"service.displayName.keyword":"{es_service.name.root}"}}}},'
+                f'{{"wildcard":{{"name.keyword":"comma,{test_id},table,*"}}}}'
+                "]}}}"
+            )
+            assets = list(metadata.paginate_es(entity=Table, query_filter=query_filter, size=1))
+            returned = {a.name.root for a in assets}
+            assert returned == expected_names, (
+                f"Pagination did not round-trip comma-FQN tables.\n"
+                f"  missing: {sorted(expected_names - returned)}\n"
+                f"  extra:   {sorted(returned - expected_names)}"
+            )
+        finally:
+            for table in created_tables:
+                try:  # noqa: SIM105
+                    metadata.delete(entity=Table, entity_id=table.id, hard_delete=True)
+                except Exception:
+                    pass
+
     def test_paginate_with_filters(self, metadata, es_service, es_schema):
         """We can paginate only tier 1 tables"""
         created_tables = []

--- a/ingestion/tests/integration/ometa/test_ometa_es_api.py
+++ b/ingestion/tests/integration/ometa/test_ometa_es_api.py
@@ -386,16 +386,7 @@ class TestOMetaESAPI:
                 )
                 created_tables.append(table)
 
-            tries = 0
-            indexed = False
-            while not indexed and tries <= 10:
-                indexed = all(
-                    metadata.es_search_from_fqn(entity_type=Table, fqn_search_string=t.fullyQualifiedName.root)
-                    for t in created_tables
-                )
-                if not indexed:
-                    tries += 1
-                    time.sleep(1)
+            time.sleep(2)
 
             expected_ids = [str(t.id.root) for t in created_tables]
             query_filter = json.dumps({"query": {"terms": {"id.keyword": expected_ids}}})

--- a/ingestion/tests/integration/ometa/test_ometa_es_api.py
+++ b/ingestion/tests/integration/ometa/test_ometa_es_api.py
@@ -386,22 +386,18 @@ class TestOMetaESAPI:
                 )
                 created_tables.append(table)
 
-            # Block until ALL created tables are searchable. Failing here is
-            # explicit (rather than letting paginate_es run on a partially
-            # indexed state and producing a confusing assertion error).
+            # Poll until ES has indexed every created table — same pattern as
+            # the wait_for_es_index fixture above.
+            tries = 0
             indexed = False
-            for _ in range(30):
-                if all(
+            while not indexed and tries <= 10:
+                indexed = all(
                     metadata.es_search_from_fqn(entity_type=Table, fqn_search_string=t.fullyQualifiedName.root)
                     for t in created_tables
-                ):
-                    indexed = True
-                    break
-                time.sleep(1)
-            if not indexed:
-                pytest.fail(
-                    f"ES did not index all {len(created_tables)} tables within 30s; cannot reliably test pagination"
                 )
+                if not indexed:
+                    tries += 1
+                    time.sleep(1)
 
             # Narrow to this test's tables — other tests / module fixtures share es_service.
             query_filter = (

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/search/SearchResource.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/search/SearchResource.java
@@ -160,9 +160,11 @@ public class SearchResource {
           int size,
       @Parameter(
               description =
-                  "When paginating, specify the search_after values. Use it ass search_after=<val1>,<val2>,...")
+                  "Pagination cursor. Repeat once per sort value: "
+                      + "?search_after=v1&search_after=v2. Each value carried as its own "
+                      + "parameter so values containing ',' (e.g. a glossary term FQN) are safe.")
           @QueryParam("search_after")
-          String searchAfter,
+          List<String> searchAfter,
       @Parameter(
               description =
                   "Sort the search results by field, available fields to "
@@ -518,9 +520,12 @@ public class SearchResource {
           @DefaultValue("10")
           @QueryParam("size")
           int size,
-      @Parameter(description = "When paginating, specify the search_after values")
+      @Parameter(
+              description =
+                  "Pagination cursor. Repeat once per sort value: "
+                      + "?search_after=v1&search_after=v2.")
           @QueryParam("search_after")
-          String searchAfter,
+          List<String> searchAfter,
       @Parameter(description = "Sort the search results by field")
           @DefaultValue("_score")
           @QueryParam("sort_field")

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/SearchUtils.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/SearchUtils.java
@@ -334,10 +334,10 @@ public final class SearchUtils {
   public static List<Object> searchAfter(List<String> values) {
     List<Object> result = null;
     if (!nullOrEmpty(values)) {
-      List<Object> filtered =
+      List<String> filtered =
           values.stream().filter(v -> !nullOrEmpty(v)).collect(Collectors.toList());
       if (!filtered.isEmpty()) {
-        result = filtered;
+        result = new ArrayList<>(filtered);
       }
     }
     return result;

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/SearchUtils.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/SearchUtils.java
@@ -332,7 +332,15 @@ public final class SearchUtils {
 
   /** One {@code ?search_after=v} per sort value — no in-band delimiter. */
   public static List<Object> searchAfter(List<String> values) {
-    return nullOrEmpty(values) ? null : new ArrayList<>(values);
+    List<Object> result = null;
+    if (!nullOrEmpty(values)) {
+      List<Object> filtered =
+          values.stream().filter(v -> !nullOrEmpty(v)).collect(Collectors.toList());
+      if (!filtered.isEmpty()) {
+        result = filtered;
+      }
+    }
+    return result;
   }
 
   public static List<String> sourceFields(String sourceFields) {

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/SearchUtils.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/SearchUtils.java
@@ -330,11 +330,9 @@ public final class SearchUtils {
     return requiredFields;
   }
 
-  public static List<Object> searchAfter(String searchAfter) {
-    if (!nullOrEmpty(searchAfter)) {
-      return List.of(searchAfter.split(","));
-    }
-    return null;
+  /** One {@code ?search_after=v} per sort value — no in-band delimiter. */
+  public static List<Object> searchAfter(List<String> values) {
+    return nullOrEmpty(values) ? null : new ArrayList<>(values);
   }
 
   public static List<String> sourceFields(String sourceFields) {

--- a/openmetadata-service/src/test/java/org/openmetadata/service/search/SearchUtilsTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/search/SearchUtilsTest.java
@@ -569,8 +569,7 @@ class SearchUtilsTest {
 
   @Test
   void searchAfterSingleValueContainingCommaNotSplit() {
-    String commaFqn =
-        "x alation archive.system glossary.sfmc (salesforce marketing cloud, exacttarget) (it system)";
+    String commaFqn = "service.database.schema.glossary term (with comma, inside name)";
     assertEquals(List.of(commaFqn), SearchUtils.searchAfter(List.of(commaFqn)));
   }
 

--- a/openmetadata-service/src/test/java/org/openmetadata/service/search/SearchUtilsTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/search/SearchUtilsTest.java
@@ -127,8 +127,6 @@ class SearchUtilsTest {
     assertFalse(
         SearchUtils.getRequiredEntityRelationshipFields("description, embedding")
             .contains("embedding"));
-    assertEquals(List.of("cursorA", "cursorB"), SearchUtils.searchAfter("cursorA,cursorB"));
-    assertNull(SearchUtils.searchAfter(null));
     assertEquals(List.of("name", "owners"), SearchUtils.sourceFields(" name, , owners "));
     assertTrue(SearchUtils.sourceFields(null).isEmpty());
     assertTrue(
@@ -556,6 +554,33 @@ class SearchUtilsTest {
     assertTrue(SearchUtils.isColumnIndex(Entity.TABLE_COLUMN));
     assertFalse(SearchUtils.isColumnIndex("table_search_index"));
     assertFalse(SearchUtils.isColumnIndex("garbage"));
+  }
+
+  // search_after — regression for #28076.
+
+  @Test
+  void searchAfterNullOrEmpty() {
+    assertNull(SearchUtils.searchAfter((List<String>) null));
+    assertNull(SearchUtils.searchAfter(List.of()));
+  }
+
+  @Test
+  void searchAfterMultiValueListPreserved() {
+    assertEquals(List.of("v1", "v2"), SearchUtils.searchAfter(List.of("v1", "v2")));
+  }
+
+  @Test
+  void searchAfterSingleValueContainingCommaNotSplit() {
+    // #28076 — a glossary term FQN with ',' must survive verbatim.
+    String commaFqn =
+        "x alation archive.system glossary.sfmc (salesforce marketing cloud, exacttarget) (it system)";
+    assertEquals(List.of(commaFqn), SearchUtils.searchAfter(List.of(commaFqn)));
+  }
+
+  @Test
+  void searchAfterMultipleCommaBearingValuesPreserved() {
+    List<String> values = List.of("first,with,commas", "second,also,with,commas");
+    assertEquals(values, SearchUtils.searchAfter(values));
   }
 
   @ParameterizedTest(name = "mapEntityTypesToIndexNames(\"{0}\") == \"{1}\"")

--- a/openmetadata-service/src/test/java/org/openmetadata/service/search/SearchUtilsTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/search/SearchUtilsTest.java
@@ -556,8 +556,6 @@ class SearchUtilsTest {
     assertFalse(SearchUtils.isColumnIndex("garbage"));
   }
 
-  // search_after — regression for #28076.
-
   @Test
   void searchAfterNullOrEmpty() {
     assertNull(SearchUtils.searchAfter((List<String>) null));
@@ -571,7 +569,6 @@ class SearchUtilsTest {
 
   @Test
   void searchAfterSingleValueContainingCommaNotSplit() {
-    // #28076 — a glossary term FQN with ',' must survive verbatim.
     String commaFqn =
         "x alation archive.system glossary.sfmc (salesforce marketing cloud, exacttarget) (it system)";
     assertEquals(List.of(commaFqn), SearchUtils.searchAfter(List.of(commaFqn)));

--- a/openmetadata-service/src/test/java/org/openmetadata/service/search/SearchUtilsTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/search/SearchUtilsTest.java
@@ -563,6 +563,13 @@ class SearchUtilsTest {
   }
 
   @Test
+  void searchAfterBlankEntriesDropped() {
+    assertNull(SearchUtils.searchAfter(List.of("")));
+    assertNull(SearchUtils.searchAfter(List.of("", "")));
+    assertEquals(List.of("v1"), SearchUtils.searchAfter(List.of("", "v1", "")));
+  }
+
+  @Test
   void searchAfterMultiValueListPreserved() {
     assertEquals(List.of("v1", "v2"), SearchUtils.searchAfter(List.of("v1", "v2")));
   }

--- a/openmetadata-spec/src/main/resources/json/schema/search/searchRequest.json
+++ b/openmetadata-spec/src/main/resources/json/schema/search/searchRequest.json
@@ -86,6 +86,10 @@
     },
     "searchAfter": {
       "description": "Pagination cursor. Send one search_after query parameter per sort value (?search_after=v1&search_after=v2). Each value is its own parameter so values containing ',' (e.g. a glossary term FQN) are safe.",
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
       "existingJavaType": "java.util.List<java.lang.Object>"
     },
     "domains": {

--- a/openmetadata-spec/src/main/resources/json/schema/search/searchRequest.json
+++ b/openmetadata-spec/src/main/resources/json/schema/search/searchRequest.json
@@ -85,7 +85,7 @@
       }
     },
     "searchAfter": {
-      "description": "When paginating, specify the search_after values. Use it ass search_after=<val1>,<val2>,...",
+      "description": "Pagination cursor. Send one search_after query parameter per sort value (?search_after=v1&search_after=v2). Each value is its own parameter so values containing ',' (e.g. a glossary term FQN) are safe.",
       "existingJavaType": "java.util.List<java.lang.Object>"
     },
     "domains": {

--- a/openmetadata-ui/src/main/resources/ui/src/generated/search/searchRequest.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/search/searchRequest.ts
@@ -83,8 +83,9 @@ export interface SearchRequest {
      */
     queryFilter?: string;
     /**
-     * When paginating, specify the search_after values. Use it ass
-     * search_after=<val1>,<val2>,...
+     * Pagination cursor. Send one search_after query parameter per sort value
+     * (?search_after=v1&search_after=v2). Each value is its own parameter so values containing
+     * ',' (e.g. a glossary term FQN) are safe.
      */
     searchAfter?: any;
     /**

--- a/openmetadata-ui/src/main/resources/ui/src/generated/search/searchRequest.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/search/searchRequest.ts
@@ -87,7 +87,7 @@ export interface SearchRequest {
      * (?search_after=v1&search_after=v2). Each value is its own parameter so values containing
      * ',' (e.g. a glossary term FQN) are safe.
      */
-    searchAfter?: any;
+    searchAfter?: string[];
     /**
      * Size to limit the no.of results returned.
      */


### PR DESCRIPTION
## Problem

`paginate_es` truncates silently when a sort value (typically a glossary term FQN) contains `,`. Issue #28076 saw 311 of 1863 glossary terms returned because the cursor at one page boundary was an FQN with a literal comma — e.g. `service.database.schema.glossary term (with comma, inside name)`.

The server logs:

```
illegal_argument_exception: search_after has 2 value(s) but sort has 1
```

## Root cause

Both sides of the cursor protocol used `,` as a delimiter inside a single query parameter:

- ingestion: `after = ",".join(last_hit.sort)`
- server: `List.of(searchAfter.split(","))`

Entity names allow nearly every printable character (the schema pattern is `^((?!::).)*$` — only `::` is forbidden), so picking *any* single-character delimiter is fundamentally fragile. The join+split round trip is ambiguous: given `a,b,c` and 2 sort fields, the values could be `("a","b,c")` or `("a,b","c")`.

## Fix

Stop putting multiple values inside one query parameter. Repeat the parameter once per sort value — exactly the idiom already used 5 lines away in the same `SearchResource` for `include_source_fields` / `exclude_source_fields`:

| | Before | After |
|---|---|---|
| Wire | `?search_after=v1,v2` | `?search_after=v1&search_after=v2` |
| Server | `@QueryParam("search_after") String` + `split(",")` | `@QueryParam("search_after") List<String>` (verbatim) |
| Client | `",".join(last_hit.sort)` | `"".join(f"&search_after={quote_plus(v)}" for v in last_hit.sort)` |

Each value travels as its own URL parameter; commas inside values stay inside values. No new wire format invented (this is just how URLs natively carry multi-valued keys), no base64, no JSON, no escaping conventions.

**No legacy fallback.** A single comma-bearing value could be either an old comma-joined cursor or a new FQN with a `,` in it — there is no way to disambiguate. Any "split on comma when length==1" heuristic re-introduces the exact ambiguity this PR fixes (a new client sending a single FQN containing `,` would be incorrectly split). Old clients with comma-FQNs were already broken before; we don't try to retro-fix them. New clients work, period.

## Changes

| File | Change |
|---|---|
| `openmetadata-service/.../SearchResource.java` | Both `search_after` `@QueryParam` change from `String` to `List<String>`; description updated. |
| `openmetadata-service/.../SearchUtils.java` | `searchAfter()` takes `List<String>`, returns it as `List<Object>` verbatim. |
| `ingestion/.../es_mixin.py` | `_paginate_es_internal` emits one `&search_after=` per sort value. |
| `openmetadata-spec/.../searchRequest.json` + generated `.ts` | Description updated. |
| `openmetadata-service/.../SearchUtilsTest.java` | Drop old `String`-overload assertion; add focused tests for null/empty, multi-value, single comma-FQN, and multiple comma-bearing values. |
| `ingestion/tests/integration/ometa/test_ometa_es_api.py` | New `test_paginate_with_comma_in_name`: creates 5 tables with `,` in the name, paginates with `size=1`, asserts the exact set is returned. UUID-namespaced names, ES indexing poll (mirrors `wait_for_es_index`), hermetic filter by `id.keyword` terms list. |

## Test plan

- [x] `SearchUtilsTest` covers the new helper signature.
- [x] Integration test exercises the reported shape (size=1, every page boundary is a single FQN containing `,`).
- [ ] CI green on backend + integration tests across Python 3.10 / 3.11 / 3.12.

## Why a new PR rather than updating #28291?

[#28291](https://github.com/open-metadata/OpenMetadata/pull/28291) takes a different approach (base64-encoded JSON array cursor with a legacy fallback). This PR is the simpler alternative — uses an existing idiom in the same endpoint, no new wire format to learn, ~40% smaller diff, drops the legacy-fallback ambiguity entirely. Closing whichever isn't selected.

Closes #28076.