### PR TITLE
fix(context-center): pages/memories LIST 404 when related entity is tableColumn

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/EntityRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/EntityRepository.java
@@ -10224,7 +10224,9 @@ public abstract class EntityRepository<T extends EntityInterface> {
     for (CollectionDAO.EntityRelationshipObject record : records) {
       String entityTypeForRef = fromSide ? record.getFromEntity() : record.getToEntity();
       String entityId = fromSide ? record.getFromId() : record.getToId();
-      if (nullOrEmpty(entityTypeForRef) || nullOrEmpty(entityId)) {
+      if (nullOrEmpty(entityTypeForRef)
+          || nullOrEmpty(entityId)
+          || !Entity.hasEntityRepository(entityTypeForRef)) {
         continue;
       }
       idsByType

--- a/openmetadata-service/src/test/java/org/openmetadata/service/jdbi3/EntityRepositoryBulkFieldsTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/jdbi3/EntityRepositoryBulkFieldsTest.java
@@ -1,0 +1,142 @@
+/*
+ *  Copyright 2026 Collate
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.openmetadata.service.jdbi3;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.CALLS_REAL_METHODS;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.openmetadata.schema.entity.data.Pipeline;
+import org.openmetadata.schema.type.EntityReference;
+import org.openmetadata.schema.type.Include;
+import org.openmetadata.schema.type.Relationship;
+import org.openmetadata.service.Entity;
+import org.openmetadata.service.jdbi3.CollectionDAO.EntityRelationshipObject;
+import org.openmetadata.service.util.EntityUtil.Fields;
+import org.openmetadata.service.util.EntityUtil.RelationIncludes;
+
+/**
+ * Regression for the Context Center 404 bug. When a Knowledge Page / Memory linked a column as a
+ * related entity, the {@code entity_relationship} table held a row with {@code fromEntity="tableColumn"}
+ * and {@code relation=HAS}. The bulk relationship loader's HAS query (run when the LIST endpoint
+ * asks for domains/dataProducts) returned that row and called {@code Entity.getEntityReferencesByIds("tableColumn", …)},
+ * which has no registered {@link EntityRepository} — surfacing as a 404 to the client.
+ */
+class EntityRepositoryBulkFieldsTest {
+
+  private CollectionDAO daoCollection;
+  private CollectionDAO.EntityRelationshipDAO relationshipDAO;
+  private CollectionDAO.PipelineDAO pipelineDAO;
+
+  private static class OwnerAwarePipelineRepo extends EntityRepository<Pipeline> {
+    OwnerAwarePipelineRepo(CollectionDAO.PipelineDAO dao) {
+      super("pipelines", Entity.PIPELINE, Pipeline.class, dao, "owners", "owners");
+    }
+
+    @Override
+    protected void setFields(Pipeline entity, Fields fields, RelationIncludes r) {}
+
+    @Override
+    protected void clearFields(Pipeline entity, Fields fields) {}
+
+    @Override
+    protected void prepare(Pipeline entity, boolean update) {}
+
+    @Override
+    protected void storeEntity(Pipeline entity, boolean update) {}
+
+    @Override
+    protected void storeRelationships(Pipeline entity) {}
+  }
+
+  @BeforeEach
+  void setUp() {
+    daoCollection = mock(CollectionDAO.class);
+    relationshipDAO = mock(CollectionDAO.EntityRelationshipDAO.class);
+    pipelineDAO = mock(CollectionDAO.PipelineDAO.class);
+    when(daoCollection.relationshipDAO()).thenReturn(relationshipDAO);
+    Entity.setCollectionDAO(daoCollection);
+  }
+
+  @AfterEach
+  void tearDown() {
+    Entity.cleanup();
+  }
+
+  @Test
+  void resolveRelationshipEntityReferencesByType_skipsUnregisteredEntityType() {
+    OwnerAwarePipelineRepo repo = new OwnerAwarePipelineRepo(pipelineDAO);
+
+    UUID pipelineId = UUID.randomUUID();
+    Pipeline entity =
+        new Pipeline().withId(pipelineId).withName("p").withFullyQualifiedName("svc.p");
+
+    UUID ownerId = UUID.randomUUID();
+    EntityRelationshipObject ownerRecord =
+        EntityRelationshipObject.builder()
+            .fromId(ownerId.toString())
+            .toId(pipelineId.toString())
+            .fromEntity(Entity.USER)
+            .toEntity(Entity.PIPELINE)
+            .relation(Relationship.OWNS.ordinal())
+            .build();
+    EntityRelationshipObject columnRecord =
+        EntityRelationshipObject.builder()
+            .fromId(UUID.randomUUID().toString())
+            .toId(pipelineId.toString())
+            .fromEntity("tableColumn")
+            .toEntity(Entity.PIPELINE)
+            .relation(Relationship.OWNS.ordinal())
+            .build();
+
+    when(relationshipDAO.findFromBatchWithRelations(
+            anyList(), eq(Entity.PIPELINE), anyList(), eq(Include.ALL)))
+        .thenReturn(List.of(ownerRecord, columnRecord));
+
+    EntityReference ownerRef =
+        new EntityReference().withId(ownerId).withType(Entity.USER).withName("alice");
+
+    try (MockedStatic<Entity> entityMock = mockStatic(Entity.class, CALLS_REAL_METHODS)) {
+      entityMock.when(() -> Entity.hasEntityRepository(Entity.USER)).thenReturn(true);
+      entityMock.when(() -> Entity.hasEntityRepository("tableColumn")).thenReturn(false);
+      entityMock
+          .when(() -> Entity.getEntityReferencesByIds(eq(Entity.USER), anyList(), any()))
+          .thenReturn(List.of(ownerRef));
+
+      assertDoesNotThrow(
+          () -> repo.setFieldsInBulk(new Fields(Set.of(Entity.FIELD_OWNERS)), List.of(entity)));
+
+      entityMock.verify(
+          () -> Entity.getEntityReferencesByIds(eq("tableColumn"), anyList(), any()), never());
+    }
+
+    assertNotNull(entity.getOwners());
+    assertEquals(1, entity.getOwners().size());
+    assertEquals(ownerId, entity.getOwners().get(0).getId());
+  }
+}

--- a/openmetadata-service/src/test/java/org/openmetadata/service/jdbi3/EntityRepositoryBulkFieldsTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/jdbi3/EntityRepositoryBulkFieldsTest.java
@@ -42,10 +42,11 @@ import org.openmetadata.service.util.EntityUtil.RelationIncludes;
 
 /**
  * Regression for the Context Center 404 bug. When a Knowledge Page / Memory linked a column as a
- * related entity, the {@code entity_relationship} table held a row with {@code fromEntity="tableColumn"}
- * and {@code relation=HAS}. The bulk relationship loader's HAS query (run when the LIST endpoint
- * asks for domains/dataProducts) returned that row and called {@code Entity.getEntityReferencesByIds("tableColumn", …)},
- * which has no registered {@link EntityRepository} — surfacing as a 404 to the client.
+ * related entity, the {@code entity_relationship} table held a row with
+ * {@code fromEntity="tableColumn"} and {@code relation=HAS}. The bulk relationship loader's HAS
+ * query (run when the LIST endpoint asks for domains/dataProducts) returned that row and called
+ * {@code Entity.getEntityReferencesByIds("tableColumn", …)}, which has no registered
+ * {@link EntityRepository} — surfacing as a 404 to the client.
  */
 class EntityRepositoryBulkFieldsTest {
 
@@ -53,9 +54,9 @@ class EntityRepositoryBulkFieldsTest {
   private CollectionDAO.EntityRelationshipDAO relationshipDAO;
   private CollectionDAO.PipelineDAO pipelineDAO;
 
-  private static class OwnerAwarePipelineRepo extends EntityRepository<Pipeline> {
-    OwnerAwarePipelineRepo(CollectionDAO.PipelineDAO dao) {
-      super("pipelines", Entity.PIPELINE, Pipeline.class, dao, "owners", "owners");
+  private static class DomainAwarePipelineRepo extends EntityRepository<Pipeline> {
+    DomainAwarePipelineRepo(CollectionDAO.PipelineDAO dao) {
+      super("pipelines", Entity.PIPELINE, Pipeline.class, dao, "domains", "domains");
     }
 
     @Override
@@ -90,53 +91,54 @@ class EntityRepositoryBulkFieldsTest {
 
   @Test
   void resolveRelationshipEntityReferencesByType_skipsUnregisteredEntityType() {
-    OwnerAwarePipelineRepo repo = new OwnerAwarePipelineRepo(pipelineDAO);
+    DomainAwarePipelineRepo repo = new DomainAwarePipelineRepo(pipelineDAO);
 
     UUID pipelineId = UUID.randomUUID();
     Pipeline entity =
         new Pipeline().withId(pipelineId).withName("p").withFullyQualifiedName("svc.p");
 
-    UUID ownerId = UUID.randomUUID();
-    EntityRelationshipObject ownerRecord =
+    UUID domainId = UUID.randomUUID();
+    EntityRelationshipObject domainRecord =
         EntityRelationshipObject.builder()
-            .fromId(ownerId.toString())
+            .fromId(domainId.toString())
             .toId(pipelineId.toString())
-            .fromEntity(Entity.USER)
+            .fromEntity(Entity.DOMAIN)
             .toEntity(Entity.PIPELINE)
-            .relation(Relationship.OWNS.ordinal())
+            .relation(Relationship.HAS.ordinal())
             .build();
     EntityRelationshipObject columnRecord =
         EntityRelationshipObject.builder()
             .fromId(UUID.randomUUID().toString())
             .toId(pipelineId.toString())
-            .fromEntity("tableColumn")
+            .fromEntity(Entity.TABLE_COLUMN)
             .toEntity(Entity.PIPELINE)
-            .relation(Relationship.OWNS.ordinal())
+            .relation(Relationship.HAS.ordinal())
             .build();
 
     when(relationshipDAO.findFromBatchWithRelations(
             anyList(), eq(Entity.PIPELINE), anyList(), eq(Include.ALL)))
-        .thenReturn(List.of(ownerRecord, columnRecord));
+        .thenReturn(List.of(domainRecord, columnRecord));
 
-    EntityReference ownerRef =
-        new EntityReference().withId(ownerId).withType(Entity.USER).withName("alice");
+    EntityReference domainRef =
+        new EntityReference().withId(domainId).withType(Entity.DOMAIN).withName("sales");
 
     try (MockedStatic<Entity> entityMock = mockStatic(Entity.class, CALLS_REAL_METHODS)) {
-      entityMock.when(() -> Entity.hasEntityRepository(Entity.USER)).thenReturn(true);
-      entityMock.when(() -> Entity.hasEntityRepository("tableColumn")).thenReturn(false);
+      entityMock.when(() -> Entity.hasEntityRepository(Entity.DOMAIN)).thenReturn(true);
+      entityMock.when(() -> Entity.hasEntityRepository(Entity.TABLE_COLUMN)).thenReturn(false);
       entityMock
-          .when(() -> Entity.getEntityReferencesByIds(eq(Entity.USER), anyList(), any()))
-          .thenReturn(List.of(ownerRef));
+          .when(() -> Entity.getEntityReferencesByIds(eq(Entity.DOMAIN), anyList(), any()))
+          .thenReturn(List.of(domainRef));
 
       assertDoesNotThrow(
-          () -> repo.setFieldsInBulk(new Fields(Set.of(Entity.FIELD_OWNERS)), List.of(entity)));
+          () -> repo.setFieldsInBulk(new Fields(Set.of(Entity.FIELD_DOMAINS)), List.of(entity)));
 
       entityMock.verify(
-          () -> Entity.getEntityReferencesByIds(eq("tableColumn"), anyList(), any()), never());
+          () -> Entity.getEntityReferencesByIds(eq(Entity.TABLE_COLUMN), anyList(), any()),
+          never());
     }
 
-    assertNotNull(entity.getOwners());
-    assertEquals(1, entity.getOwners().size());
-    assertEquals(ownerId, entity.getOwners().get(0).getId());
+    assertNotNull(entity.getDomains());
+    assertEquals(1, entity.getDomains().size());
+    assertEquals(domainId, entity.getDomains().get(0).getId());
   }
 }


### PR DESCRIPTION
### Describe your changes:

<!-- No tracking issue exists for this; happy to open one if reviewers prefer. -->

The LIST endpoints for Knowledge Pages (`/api/v1/contextCenter/pages`) and Memories returned `404 — "Entity repository for tableColumn not found"` whenever a page/memory had a column linked as a related entity. The bulk relationship loader's batched `HAS` query (triggered by requesting `domains` / `dataProducts`) returned the `tableColumn -> page` row, and `EntityRepository.resolveRelationshipEntityReferencesByType` then called `Entity.getEntityReferencesByIds("tableColumn", …)` — which throws because `tableColumn` is a pseudo-type (column-level custom properties / tagging), not a registered `EntityRepository`. The per-entity GET path didn't see this because it goes through `EntityRelationshipRepository.getEntityReferences`, which already has the same defensive fallback.

Filter relationship records by `Entity.hasEntityRepository` before resolution — the downstream `switch` already no-ops on unregistered types, so dropping them earlier costs nothing and matches the defensive pattern used in `EntityRelationshipRepository.getEntityReferences` and `EntityUtil.populateEntityReferences`. Added a focused unit test in `EntityRepositoryBulkFieldsTest` that fails (with the exact bug-report error message) without the fix and passes with it.

#
### Type of change:
- [x] Bug fix

#
### Tests:

#### Use cases covered
- Listing Knowledge Pages with `fields=owners,domains,dataProducts,…` when one of the pages has a `tableColumn` linked as a related entity — previously 404, now returns the page list with the legitimate refs.

#### Unit tests
- [x] I added unit tests for the new/changed logic.
- Files added: `openmetadata-service/src/test/java/org/openmetadata/service/jdbi3/EntityRepositoryBulkFieldsTest.java`

#### Backend integration tests
- [x] Not applicable (no new endpoint; covered by unit test).

#### Ingestion integration tests
- [x] Not applicable.

#### Playwright (UI) tests
- [x] Not applicable.

#### Manual testing performed
Verified unit test fails without the fix with the exact production error (`Entity repository for tableColumn not found. Is the ENTITY_TYPE_MAP initialized?`) and passes after the one-line filter is restored. `mvn spotless:apply` clean.

#
### UI screen recording / screenshots:

Not applicable.

#
### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] I have added tests (unit / integration / Playwright as applicable) and listed them above.
- [x] I have added a test that covers the exact scenario we are fixing.