### PR TITLE
fix(search): search_after drops entities when sort value contains a comma — 1.13 backport (#28415)

### DIFF
--- a/ingestion/src/metadata/ingestion/ometa/mixins/es_mixin.py
+++ b/ingestion/src/metadata/ingestion/ometa/mixins/es_mixin.py
@@ -13,6 +13,7 @@ Mixin class containing Lineage specific methods
 
 To be used by OpenMetadata class
 """
+
 import functools
 import json
 import traceback
@@ -410,7 +411,9 @@ class ESMixin(Generic[T]):
                 logger.debug("No more pages to fetch")
                 break
 
-            after = "".join(f"&search_after={quote_plus(str(v))}" for v in last_hit.sort)
+            after = "".join(
+                f"&search_after={quote_plus(str(v))}" for v in last_hit.sort
+            )
 
     def paginate_es(
         self,

--- a/ingestion/src/metadata/ingestion/ometa/mixins/es_mixin.py
+++ b/ingestion/src/metadata/ingestion/ometa/mixins/es_mixin.py
@@ -379,7 +379,7 @@ class ESMixin(Generic[T]):
         if sort_order not in ("asc", "desc"):
             raise ValueError(f"sort_order must be 'asc' or 'desc', got '{sort_order}'")
 
-        after: Optional[str] = None
+        after: str = ""
         error_pages = 0
         query = functools.partial(
             self.paginate_query.format,
@@ -392,9 +392,7 @@ class ESMixin(Generic[T]):
             sort_order=sort_order,
         )
         while True:
-            query_string = query(
-                after="&search_after=" + quote_plus(after) if after else ""
-            )
+            query_string = query(after=after)
             response = self._get_es_response(query_string)
 
             # Allow 3 errors getting pages before getting out of the loop
@@ -412,7 +410,7 @@ class ESMixin(Generic[T]):
                 logger.debug("No more pages to fetch")
                 break
 
-            after = ",".join(last_hit.sort)
+            after = "".join(f"&search_after={quote_plus(str(v))}" for v in last_hit.sort)
 
     def paginate_es(
         self,

--- a/ingestion/tests/integration/ometa/test_ometa_es_api.py
+++ b/ingestion/tests/integration/ometa/test_ometa_es_api.py
@@ -11,6 +11,7 @@
 """
 OMeta ES Mixin integration tests. The API needs to be up
 """
+
 import json
 import logging
 import time
@@ -398,8 +399,12 @@ class TestOMetaESAPI:
             time.sleep(2)
 
             expected_ids = [str(t.id.root) for t in created_tables]
-            query_filter = json.dumps({"query": {"terms": {"id.keyword": expected_ids}}})
-            assets = list(metadata.paginate_es(entity=Table, query_filter=query_filter, size=1))
+            query_filter = json.dumps(
+                {"query": {"terms": {"id.keyword": expected_ids}}}
+            )
+            assets = list(
+                metadata.paginate_es(entity=Table, query_filter=query_filter, size=1)
+            )
             returned = {a.name.root for a in assets}
             expected_set = set(expected_names)
             assert returned == expected_set, (

--- a/ingestion/tests/integration/ometa/test_ometa_es_api.py
+++ b/ingestion/tests/integration/ometa/test_ometa_es_api.py
@@ -374,6 +374,46 @@ class TestOMetaESAPI:
                 except Exception:
                     pass
 
+    def test_paginate_with_comma_in_name(self, metadata, es_service, es_schema):
+        """Regression for #28076 — pagination must survive sort values containing ','.
+
+        With size=1, every page boundary's cursor is a single FQN with ',' in it.
+        The multi-value search_after wire format carries each sort value as its
+        own param, so a comma in the value cannot truncate pagination.
+        """
+        test_id = str(uuid.uuid4())[:8]
+        expected_names = [f"comma,{test_id},table,{i}" for i in range(5)]
+        created_tables = []
+        try:
+            for name in expected_names:
+                table = metadata.create_or_update(
+                    data=get_create_entity(
+                        entity=Table,
+                        name=EntityName(name),
+                        reference=es_schema.fullyQualifiedName,
+                    )
+                )
+                created_tables.append(table)
+
+            time.sleep(2)
+
+            expected_ids = [str(t.id.root) for t in created_tables]
+            query_filter = json.dumps({"query": {"terms": {"id.keyword": expected_ids}}})
+            assets = list(metadata.paginate_es(entity=Table, query_filter=query_filter, size=1))
+            returned = {a.name.root for a in assets}
+            expected_set = set(expected_names)
+            assert returned == expected_set, (
+                f"Pagination did not round-trip comma-FQN tables.\n"
+                f"  missing: {sorted(expected_set - returned)}\n"
+                f"  extra:   {sorted(returned - expected_set)}"
+            )
+        finally:
+            for table in created_tables:
+                try:  # noqa: SIM105
+                    metadata.delete(entity=Table, entity_id=table.id, hard_delete=True)
+                except Exception:
+                    pass
+
     def test_paginate_with_filters(self, metadata, es_service, es_schema):
         """We can paginate only tier 1 tables"""
         created_tables = []

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/search/SearchResource.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/search/SearchResource.java
@@ -160,9 +160,11 @@ public class SearchResource {
           int size,
       @Parameter(
               description =
-                  "When paginating, specify the search_after values. Use it ass search_after=<val1>,<val2>,...")
+                  "Pagination cursor. Repeat once per sort value: "
+                      + "?search_after=v1&search_after=v2. Each value carried as its own "
+                      + "parameter so values containing ',' (e.g. a glossary term FQN) are safe.")
           @QueryParam("search_after")
-          String searchAfter,
+          List<String> searchAfter,
       @Parameter(
               description =
                   "Sort the search results by field, available fields to "
@@ -461,9 +463,12 @@ public class SearchResource {
           @DefaultValue("10")
           @QueryParam("size")
           int size,
-      @Parameter(description = "When paginating, specify the search_after values")
+      @Parameter(
+              description =
+                  "Pagination cursor. Repeat once per sort value: "
+                      + "?search_after=v1&search_after=v2.")
           @QueryParam("search_after")
-          String searchAfter,
+          List<String> searchAfter,
       @Parameter(description = "Sort the search results by field")
           @DefaultValue("_score")
           @QueryParam("sort_field")

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/SearchUtils.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/SearchUtils.java
@@ -330,11 +330,17 @@ public final class SearchUtils {
     return requiredFields;
   }
 
-  public static List<Object> searchAfter(String searchAfter) {
-    if (!nullOrEmpty(searchAfter)) {
-      return List.of(searchAfter.split(","));
+  /** One {@code ?search_after=v} per sort value — no in-band delimiter. */
+  public static List<Object> searchAfter(List<String> values) {
+    List<Object> result = null;
+    if (!nullOrEmpty(values)) {
+      List<String> filtered =
+          values.stream().filter(v -> !nullOrEmpty(v)).collect(Collectors.toList());
+      if (!filtered.isEmpty()) {
+        result = new ArrayList<>(filtered);
+      }
     }
-    return null;
+    return result;
   }
 
   public static List<String> sourceFields(String sourceFields) {

--- a/openmetadata-service/src/test/java/org/openmetadata/service/search/SearchUtilsTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/search/SearchUtilsTest.java
@@ -127,8 +127,6 @@ class SearchUtilsTest {
     assertFalse(
         SearchUtils.getRequiredEntityRelationshipFields("description, embedding")
             .contains("embedding"));
-    assertEquals(List.of("cursorA", "cursorB"), SearchUtils.searchAfter("cursorA,cursorB"));
-    assertNull(SearchUtils.searchAfter(null));
     assertEquals(List.of("name", "owners"), SearchUtils.sourceFields(" name, , owners "));
     assertTrue(SearchUtils.sourceFields(null).isEmpty());
     assertTrue(
@@ -556,6 +554,36 @@ class SearchUtilsTest {
     assertTrue(SearchUtils.isColumnIndex(Entity.TABLE_COLUMN));
     assertFalse(SearchUtils.isColumnIndex("table_search_index"));
     assertFalse(SearchUtils.isColumnIndex("garbage"));
+  }
+
+  @Test
+  void searchAfterNullOrEmpty() {
+    assertNull(SearchUtils.searchAfter((List<String>) null));
+    assertNull(SearchUtils.searchAfter(List.of()));
+  }
+
+  @Test
+  void searchAfterBlankEntriesDropped() {
+    assertNull(SearchUtils.searchAfter(List.of("")));
+    assertNull(SearchUtils.searchAfter(List.of("", "")));
+    assertEquals(List.of("v1"), SearchUtils.searchAfter(List.of("", "v1", "")));
+  }
+
+  @Test
+  void searchAfterMultiValueListPreserved() {
+    assertEquals(List.of("v1", "v2"), SearchUtils.searchAfter(List.of("v1", "v2")));
+  }
+
+  @Test
+  void searchAfterSingleValueContainingCommaNotSplit() {
+    String commaFqn = "service.database.schema.glossary term (with comma, inside name)";
+    assertEquals(List.of(commaFqn), SearchUtils.searchAfter(List.of(commaFqn)));
+  }
+
+  @Test
+  void searchAfterMultipleCommaBearingValuesPreserved() {
+    List<String> values = List.of("first,with,commas", "second,also,with,commas");
+    assertEquals(values, SearchUtils.searchAfter(values));
   }
 
   @ParameterizedTest(name = "mapEntityTypesToIndexNames(\"{0}\") == \"{1}\"")

--- a/openmetadata-spec/src/main/resources/json/schema/search/searchRequest.json
+++ b/openmetadata-spec/src/main/resources/json/schema/search/searchRequest.json
@@ -85,7 +85,11 @@
       }
     },
     "searchAfter": {
-      "description": "When paginating, specify the search_after values. Use it ass search_after=<val1>,<val2>,...",
+      "description": "Pagination cursor. Send one search_after query parameter per sort value (?search_after=v1&search_after=v2). Each value is its own parameter so values containing ',' (e.g. a glossary term FQN) are safe.",
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
       "existingJavaType": "java.util.List<java.lang.Object>"
     },
     "domains": {

--- a/openmetadata-ui/src/main/resources/ui/src/generated/api/services/ingestionPipelines/createIngestionPipeline.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/api/services/ingestionPipelines/createIngestionPipeline.ts
@@ -2392,52 +2392,6 @@ export interface DBTPrefixConfig {
 }
 
 /**
- * Client SSL configuration
- *
- * SSL Configuration details.
- *
- * CA certificate, client certificate, and private key for SSL validation. Required when
- * verifySSL is 'validate'.
- *
- * SSL Configuration details for DB2 connection. Provide CA certificate for server
- * validation, and optionally client certificate and key for mutual TLS authentication.
- *
- * SSL/TLS certificate configuration for client authentication. Provide CA certificate,
- * client certificate, and private key for mutual TLS authentication.
- *
- * SSL Configuration details. Provide the CA certificate to validate the Informix server
- * certificate. Paste the PEM content directly or upload the certificate file.
- *
- * Consumer Config SSL Config. Configuration for enabling SSL for the Consumer Config
- * connection.
- *
- * Schema Registry SSL Config. Configuration for enabling SSL for the Schema Registry
- * connection.
- *
- * SSL Configuration for OpenMetadata Server
- *
- * SSL certificate configuration for validating the server certificate when fetching dbt
- * artifacts.
- *
- * OpenMetadata Client configured to validate SSL certificates.
- */
-export interface DbtSSLConfigClass {
-    /**
-     * The CA certificate used for SSL validation.
-     */
-    caCertificate?: string;
-    /**
-     * The SSL certificate used for client authentication.
-     */
-    sslCertificate?: string;
-    /**
-     * The private key associated with the SSL certificate.
-     */
-    sslKey?: string;
-}
-
-/**
->>>>>>> b47c219954 (FEATURE: Add SAP S4/HANA Dashboard Connector (#27242))
  * AWS credentials configs.
  *
  * AWS credentials required to access the S3 file.
@@ -2649,25 +2603,6 @@ export interface GCPImpersonateServiceAccountValues {
 }
 
 /**
- * Client SSL verification. Make sure to configure the SSLConfig if enabled.
- *
- * Client SSL verification.
- *
- * Client SSL verification. Use 'no-ssl' for plain HTTP, 'ignore' to skip certificate
- * validation, 'validate' to verify against a CA certificate.
- *
- * Flag to verify SSL Certificate for OpenMetadata Server.
- *
- * SSL/TLS verification mode when fetching dbt artifacts over HTTPS.
- */
-export enum VerifySSL {
-    Ignore = "ignore",
-    NoSSL = "no-ssl",
-    Validate = "validate",
-}
-
-/**
->>>>>>> b47c219954 (FEATURE: Add SAP S4/HANA Dashboard Connector (#27242))
  * Use incremental Metadata extraction after the first execution. This is commonly done by
  * getting the changes from Audit tables on the supporting databases.
  */
@@ -6026,6 +5961,9 @@ export enum KafkaSecurityProtocol {
  *
  * SSL Configuration details.
  *
+ * CA certificate, client certificate, and private key for SSL validation. Required when
+ * verifySSL is 'validate'.
+ *
  * SSL Configuration details for DB2 connection. Provide CA certificate for server
  * validation, and optionally client certificate and key for mutual TLS authentication.
  *
@@ -6739,6 +6677,9 @@ export enum ConnectionType {
  * Client SSL verification. Make sure to configure the SSLConfig if enabled.
  *
  * Client SSL verification.
+ *
+ * Client SSL verification. Use 'no-ssl' for plain HTTP, 'ignore' to skip certificate
+ * validation, 'validate' to verify against a CA certificate.
  *
  * Flag to verify SSL Certificate for OpenMetadata Server.
  */

--- a/openmetadata-ui/src/main/resources/ui/src/generated/entity/services/ingestionPipelines/ingestionPipeline.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/entity/services/ingestionPipelines/ingestionPipeline.ts
@@ -720,8 +720,6 @@ export enum OpenmetadataType {
  *
  * Client SSL verification. Use 'no-ssl' for plain HTTP, 'ignore' to skip certificate
  * validation, 'validate' to verify against a CA certificate.
- *
- * SSL/TLS verification mode when fetching dbt artifacts over HTTPS.
  */
 export enum VerifySSL {
     Ignore = "ignore",

--- a/openmetadata-ui/src/main/resources/ui/src/generated/search/searchRequest.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/search/searchRequest.ts
@@ -83,10 +83,11 @@ export interface SearchRequest {
      */
     queryFilter?: string;
     /**
-     * When paginating, specify the search_after values. Use it ass
-     * search_after=<val1>,<val2>,...
+     * Pagination cursor. Send one search_after query parameter per sort value
+     * (?search_after=v1&search_after=v2). Each value is its own parameter so values containing
+     * ',' (e.g. a glossary term FQN) are safe.
      */
-    searchAfter?: any;
+    searchAfter?: string[];
     /**
      * Size to limit the no.of results returned.
      */


### PR DESCRIPTION
## Summary

Backport of #28415 (Fix #28076) to **1.13**.

When a sort value contained a comma (e.g. a glossary term FQN like `service.database.schema.term name, with comma`), pagination dropped entities because the cursor was joined with `,` and then split again on the server. Switching to the multi-value `&search_after=<v1>&search_after=<v2>` wire format makes commas in sort values safe to carry across pages.

## Backport notes

- Only conflict: `es_mixin.py` — two identical chunks that just differed by formatting (single-line vs multi-line `query(...)` call and `Optional[str] = None` vs `str = ""`); incoming PR version taken.
- All other files (incl. the new `test_paginate_with_comma_in_name` and the 5 new `searchAfter*` Java unit tests) cherry-picked cleanly.

## Test plan

- [x] `mvn clean install -DskipTests -pl '!openmetadata-ui,!openmetadata-ui-core-components' -am` succeeds locally
- [ ] CI green on this PR
- [ ] Manually verify pagination of comma-bearing FQNs against a real 1.13 deployment