### PR TITLE
Move user profile menu items to navbar classbase

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/Settings/Users/UserProfileIcon/UserProfileIcon.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Settings/Users/UserProfileIcon/UserProfileIcon.component.tsx
@@ -11,9 +11,8 @@
  *  limitations under the License.
  */
 import { Button, Dropdown, Radio, Tag, Tooltip, Typography } from 'antd';
-import { ItemType } from 'antd/lib/menu/hooks/useItems';
 import { isEmpty, orderBy } from 'lodash';
-import { ReactNode, useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router-dom';
 import { ReactComponent as DropDownIcon } from '../../../../assets/svg/drop-down.svg';
@@ -22,10 +21,11 @@ import { ReactComponent as PersonaIcon } from '../../../../assets/svg/ic-persona
 import { ReactComponent as RoleIcon } from '../../../../assets/svg/ic-roles.svg';
 import { ReactComponent as LogoutIcon } from '../../../../assets/svg/logout.svg';
 import { ReactComponent as TeamIcon } from '../../../../assets/svg/teams-grey.svg';
-import { TERM_ADMIN, TERM_USER } from '../../../../constants/constants';
+import { TERM_ADMIN } from '../../../../constants/constants';
 import { EntityReference } from '../../../../generated/entity/type';
 import { useApplicationStore } from '../../../../hooks/useApplicationStore';
 import { getEntityName } from '../../../../utils/EntityUtils';
+import navbarUtilClassBase from '../../../../utils/NavbarUtilClassBase';
 import {
   getImageWithResolutionAndFallback,
   ImageQuality,
@@ -34,59 +34,9 @@ import {
   getTeamAndUserDetailsPath,
   getUserPath,
 } from '../../../../utils/RouterUtils';
-import { getEmptyTextFromUserProfileItem } from '../../../../utils/Users.util';
 import { useAuthProvider } from '../../../Auth/AuthProviders/AuthProvider';
 import ProfilePicture from '../../../common/ProfilePicture/ProfilePicture';
 import './user-profile-icon.less';
-
-type ListMenuItemProps = {
-  listItems: EntityReference[];
-  labelRenderer: (item: EntityReference) => ReactNode;
-  readMoreLabelRenderer: (count: number) => ReactNode;
-  readMoreKey: string;
-  sizeLimit?: number;
-  itemKey: string;
-};
-
-const renderLimitedListMenuItem = ({
-  listItems,
-  labelRenderer,
-  readMoreLabelRenderer,
-  sizeLimit = 2,
-  readMoreKey,
-  itemKey,
-}: ListMenuItemProps) => {
-  const remainingCount =
-    listItems.length ?? 0 > sizeLimit
-      ? (listItems.length ?? sizeLimit) - sizeLimit
-      : 0;
-
-  const items = listItems.slice(0, sizeLimit);
-
-  return isEmpty(items)
-    ? [
-        {
-          label: getEmptyTextFromUserProfileItem(itemKey),
-          key: readMoreKey.replace('more', 'no'),
-          disabled: true,
-        },
-      ]
-    : [
-        ...(items?.map((item) => ({
-          label: labelRenderer(item),
-          key: item.id,
-          disabled: ['roles', 'inheritedRoles'].includes(itemKey),
-        })) ?? []),
-        ...[
-          remainingCount > 0
-            ? {
-                label: readMoreLabelRenderer(remainingCount),
-                key: readMoreKey ?? 'more-item',
-              }
-            : null,
-        ],
-      ];
-};
 
 export const UserProfileIcon = () => {
   const { currentUser, selectedPersona, setSelectedPersona } =
@@ -109,9 +59,12 @@ export const UserProfileIcon = () => {
     return false;
   }, []);
 
-  const handleSelectedPersonaChange = async (persona: EntityReference) => {
-    setSelectedPersona(persona);
-  };
+  const handleSelectedPersonaChange = useCallback(
+    (persona: EntityReference) => {
+      setSelectedPersona(persona);
+    },
+    [setSelectedPersona]
+  );
 
   useEffect(() => {
     if (profilePicture) {
@@ -121,11 +74,8 @@ export const UserProfileIcon = () => {
     }
   }, [profilePicture]);
 
-  const { userName, teams, roles, inheritedRoles, personas } = useMemo(() => {
-    const userName = getEntityName(currentUser) || TERM_USER;
-
+  const { teams, roles, inheritedRoles, personas } = useMemo(() => {
     return {
-      userName,
       roles: currentUser?.isAdmin
         ? [
             ...(currentUser?.roles ?? []),
@@ -250,12 +200,10 @@ export const UserProfileIcon = () => {
     ];
   }, [personas, defaultPersona?.id, selectedPersona?.id]);
 
-  const items: ItemType[] = useMemo(
-    () => [
-      {
-        key: 'user',
-        icon: '',
-        label: (
+  const items = useMemo(
+    () =>
+      navbarUtilClassBase.getUserProfileIconMenuItems({
+        userLabel: (
           <Link
             data-testid="user-name"
             to={getUserPath(currentUser?.name as string)}
@@ -267,23 +215,7 @@ export const UserProfileIcon = () => {
             </Typography.Paragraph>
           </Link>
         ),
-        type: 'group',
-      },
-      {
-        type: 'divider',
-      },
-      {
-        key: 'personas',
-        icon: '',
-        children: renderLimitedListMenuItem({
-          listItems: sortedPersonas,
-          readMoreKey: 'more-persona',
-          sizeLimit: showAllPersona ? sortedPersonas.length : 2,
-          labelRenderer: personaLabelRenderer,
-          readMoreLabelRenderer: (count) => readMoreTeamRenderer(count, true),
-          itemKey: 'personas',
-        }),
-        label: (
+        personaLabel: (
           <div className="d-flex items-center gap-2">
             <PersonaIcon className="text-base-color" height={20} width={20} />
             <span className="font-medium text-grey-900">
@@ -291,22 +223,7 @@ export const UserProfileIcon = () => {
             </span>
           </div>
         ),
-        type: 'group',
-      },
-      {
-        type: 'divider',
-      },
-      {
-        key: 'roles',
-        icon: '',
-        children: renderLimitedListMenuItem({
-          listItems: roles ?? [],
-          labelRenderer: getEntityName,
-          readMoreLabelRenderer: readMoreTeamRenderer,
-          readMoreKey: 'more-roles',
-          itemKey: 'roles',
-        }),
-        label: (
+        roleLabel: (
           <div className="text-base-color d-flex items-center gap-2">
             <RoleIcon height={20} width={20} />
             <span className="font-medium text-grey-900">
@@ -314,22 +231,7 @@ export const UserProfileIcon = () => {
             </span>
           </div>
         ),
-        type: 'group',
-      },
-      {
-        type: 'divider',
-      },
-      {
-        key: 'inheritedRoles',
-        icon: '',
-        children: renderLimitedListMenuItem({
-          listItems: inheritedRoles ?? [],
-          labelRenderer: getEntityName,
-          readMoreLabelRenderer: readMoreTeamRenderer,
-          readMoreKey: 'more-inherited-roles',
-          itemKey: 'inheritedRoles',
-        }),
-        label: (
+        inheritedRoleLabel: (
           <div className="d-flex items-center gap-2">
             <IconStruct className="text-base-color" height={20} width={20} />
             <span className="font-medium text-grey-900">
@@ -337,25 +239,7 @@ export const UserProfileIcon = () => {
             </span>
           </div>
         ),
-        type: 'group',
-      },
-      {
-        type: 'divider',
-      },
-      {
-        type: 'divider',
-      },
-      {
-        key: 'teams',
-        icon: '',
-        children: renderLimitedListMenuItem({
-          listItems: teams ?? [],
-          readMoreKey: 'more-teams',
-          labelRenderer: teamLabelRenderer,
-          readMoreLabelRenderer: readMoreTeamRenderer,
-          itemKey: 'teams',
-        }),
-        label: (
+        teamLabel: (
           <div className="d-flex items-center gap-2">
             <TeamIcon className="text-base-color" height={20} width={20} />
             <span className="font-medium text-grey-900">
@@ -363,15 +247,7 @@ export const UserProfileIcon = () => {
             </span>
           </div>
         ),
-        type: 'group',
-      },
-      {
-        type: 'divider',
-      },
-      {
-        key: 'logout',
-        icon: '',
-        label: (
+        logoutLabel: (
           <Button
             className="text-primary d-flex items-center gap-2 p-0 font-medium"
             type="text"
@@ -380,20 +256,28 @@ export const UserProfileIcon = () => {
             {t('label.logout')}
           </Button>
         ),
-        type: 'group',
-      },
-    ],
+        inheritedRoles: inheritedRoles ?? [],
+        personaLabelRenderer,
+        personas: sortedPersonas,
+        readMoreLabelRenderer: readMoreTeamRenderer,
+        roles: roles ?? [],
+        showAllPersona,
+        teamLabelRenderer,
+        teams: teams ?? [],
+      }),
     [
-      currentUser,
-      userName,
-      selectedPersona,
-      teams,
+      currentUser?.name,
+      handleCloseDropdown,
+      inheritedRoles,
+      onLogoutHandler,
+      personaLabelRenderer,
+      readMoreTeamRenderer,
       roles,
-      personas,
       showAllPersona,
       sortedPersonas,
-      inheritedRoles,
       t,
+      teamLabelRenderer,
+      teams,
     ]
   );
 
@@ -401,7 +285,8 @@ export const UserProfileIcon = () => {
     <Dropdown
       menu={{
         items,
-        defaultOpenKeys: ['personas', 'roles', 'inheritedRoles', 'teams'],
+        defaultOpenKeys:
+          navbarUtilClassBase.getUserProfileIconDefaultOpenKeys(),
         rootClassName: 'profile-dropdown w-68 p-x-md p-y-sm',
       }}
       open={isDropdownOpen}

--- a/openmetadata-ui/src/main/resources/ui/src/components/Settings/Users/UserProfileIcon/UserProfileIcon.interface.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Settings/Users/UserProfileIcon/UserProfileIcon.interface.ts
@@ -1,0 +1,40 @@
+/*
+ *  Copyright 2026 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+import { ReactNode } from 'react';
+import { EntityReference } from '../../../../generated/entity/type';
+
+export type ListMenuItemProps = {
+  listItems: EntityReference[];
+  labelRenderer: (item: EntityReference) => ReactNode;
+  readMoreLabelRenderer: (count: number) => ReactNode;
+  readMoreKey: string;
+  sizeLimit?: number;
+  itemKey: string;
+};
+
+export interface UserProfileIconMenuItemsProps {
+  inheritedRoleLabel: ReactNode;
+  inheritedRoles: EntityReference[];
+  logoutLabel: ReactNode;
+  personaLabel: ReactNode;
+  personaLabelRenderer: (item: EntityReference) => ReactNode;
+  personas: EntityReference[];
+  readMoreLabelRenderer: (count: number, isPersona?: boolean) => ReactNode;
+  roleLabel: ReactNode;
+  roles: EntityReference[];
+  showAllPersona: boolean;
+  teamLabel: ReactNode;
+  teamLabelRenderer: (item: EntityReference) => ReactNode;
+  teams: EntityReference[];
+  userLabel: ReactNode;
+}

--- a/openmetadata-ui/src/main/resources/ui/src/utils/NavbarUtilClassBase.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/NavbarUtilClassBase.ts
@@ -10,11 +10,164 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
+import { ItemType } from 'antd/lib/menu/hooks/useItems';
+import { isEmpty } from 'lodash';
+import type {
+  ListMenuItemProps,
+  UserProfileIconMenuItemsProps,
+} from '../components/Settings/Users/UserProfileIcon/UserProfileIcon.interface';
 import { HELP_ITEMS } from '../constants/Navbar.constants';
+import { getEntityName } from './EntityUtils';
+import { getEmptyTextFromUserProfileItem } from './Users.util';
+
+const renderLimitedListMenuItem = ({
+  listItems,
+  labelRenderer,
+  readMoreLabelRenderer,
+  sizeLimit = 2,
+  readMoreKey,
+  itemKey,
+}: ListMenuItemProps) => {
+  const remainingCount =
+    listItems.length > sizeLimit ? listItems.length - sizeLimit : 0;
+
+  const items = listItems.slice(0, sizeLimit);
+
+  return isEmpty(items)
+    ? [
+        {
+          label: getEmptyTextFromUserProfileItem(itemKey),
+          key: readMoreKey.replace('more', 'no'),
+          disabled: true,
+        },
+      ]
+    : [
+        ...items.map((item) => ({
+          label: labelRenderer(item),
+          key: item.id,
+          disabled: ['roles', 'inheritedRoles'].includes(itemKey),
+        })),
+        ...[
+          remainingCount > 0
+            ? {
+                label: readMoreLabelRenderer(remainingCount),
+                key: readMoreKey ?? 'more-item',
+              }
+            : null,
+        ],
+      ];
+};
 
 class NavbarUtilClassBase {
   public getHelpItems() {
     return HELP_ITEMS;
+  }
+
+  public getUserProfileIconDefaultOpenKeys(): string[] {
+    return ['personas', 'roles', 'inheritedRoles', 'teams'];
+  }
+
+  public getUserProfileIconMenuItems({
+    inheritedRoleLabel,
+    inheritedRoles,
+    logoutLabel,
+    personaLabel,
+    personaLabelRenderer,
+    personas,
+    readMoreLabelRenderer,
+    roleLabel,
+    roles,
+    showAllPersona,
+    teamLabel,
+    teamLabelRenderer,
+    teams,
+    userLabel,
+  }: UserProfileIconMenuItemsProps): ItemType[] {
+    return [
+      {
+        key: 'user',
+        icon: '',
+        label: userLabel,
+        type: 'group',
+      },
+      {
+        type: 'divider',
+      },
+      {
+        key: 'personas',
+        icon: '',
+        children: renderLimitedListMenuItem({
+          listItems: personas,
+          readMoreKey: 'more-persona',
+          sizeLimit: showAllPersona ? personas.length : 2,
+          labelRenderer: personaLabelRenderer,
+          readMoreLabelRenderer: (count) => readMoreLabelRenderer(count, true),
+          itemKey: 'personas',
+        }),
+        label: personaLabel,
+        type: 'group',
+      },
+      {
+        type: 'divider',
+      },
+      {
+        key: 'roles',
+        icon: '',
+        children: renderLimitedListMenuItem({
+          listItems: roles,
+          labelRenderer: getEntityName,
+          readMoreLabelRenderer,
+          readMoreKey: 'more-roles',
+          itemKey: 'roles',
+        }),
+        label: roleLabel,
+        type: 'group',
+      },
+      {
+        type: 'divider',
+      },
+      {
+        key: 'inheritedRoles',
+        icon: '',
+        children: renderLimitedListMenuItem({
+          listItems: inheritedRoles,
+          labelRenderer: getEntityName,
+          readMoreLabelRenderer,
+          readMoreKey: 'more-inherited-roles',
+          itemKey: 'inheritedRoles',
+        }),
+        label: inheritedRoleLabel,
+        type: 'group',
+      },
+      {
+        type: 'divider',
+      },
+      {
+        type: 'divider',
+      },
+      {
+        key: 'teams',
+        icon: '',
+        children: renderLimitedListMenuItem({
+          listItems: teams,
+          readMoreKey: 'more-teams',
+          labelRenderer: teamLabelRenderer,
+          readMoreLabelRenderer,
+          itemKey: 'teams',
+        }),
+        label: teamLabel,
+        type: 'group',
+      },
+      {
+        type: 'divider',
+      },
+      {
+        key: 'logout',
+        icon: '',
+        label: logoutLabel,
+        type: 'group',
+      },
+    ];
   }
 }
 


### PR DESCRIPTION
## Description
- Move UserProfileIcon dropdown menu item construction into NavbarUtilClassBase
- Add a dedicated UserProfileIcon.interface.ts for menu item prop types
- Keep UserProfileIcon responsible for state and JSX render fragments only

## Tests
- PATH="/Users/deuex/.nvm/versions/node/v22.17.0/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/pkg/env/global/bin:/Users/deuex/.codex/tmp/arg0/codex-arg0lDw3Zx:/Users/deuex/.antigravity/antigravity/bin:/Users/deuex/.nvm/versions/node/v22.22.2/bin:/Users/deuex/Library/Application Support/com.conductor.app/./bin" yarn test src/components/Settings/Users/UserProfileIcon/UserProfileIcon.test.tsx src/utils/NavbarUtilClassBase.test.tsx --runInBand
- organize-imports-cli, eslint --fix, prettier --write on touched UI files