### PR TITLE
Fixes #28440: Reprocess previous migration train

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/migration/api/MigrationWorkflow.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/migration/api/MigrationWorkflow.java
@@ -249,11 +249,11 @@ public class MigrationWorkflow {
 
     @Override
     public int compareTo(ReleaseTrain another) {
-      int majorComparison = Integer.compare(major, another.major);
-      if (majorComparison != 0) {
-        return majorComparison;
+      int result = Integer.compare(major, another.major);
+      if (result == 0) {
+        result = Integer.compare(minor, another.minor);
       }
-      return Integer.compare(minor, another.minor);
+      return result;
     }
   }
 
@@ -495,10 +495,11 @@ public class MigrationWorkflow {
   }
 
   private boolean shouldRunDataMigration(MigrationProcess process) {
-    if (!process.isReprocessing() || currentMaxMigrationVersion.isEmpty()) {
-      return true;
+    boolean result = true;
+    if (process.isReprocessing() && currentMaxMigrationVersion.isPresent()) {
+      result = compareVersions(process.getVersion(), currentMaxMigrationVersion.get()) == 0;
     }
-    return compareVersions(process.getVersion(), currentMaxMigrationVersion.get()) == 0;
+    return result;
   }
 
   private void runSchemaChanges(List<String> row, MigrationProcess process) {

--- a/openmetadata-service/src/main/java/org/openmetadata/service/migration/api/MigrationWorkflow.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/migration/api/MigrationWorkflow.java
@@ -48,6 +48,7 @@ import org.openmetadata.service.util.AsciiTable;
 public class MigrationWorkflow {
   public static final String SUCCESS_MSG = "Success";
   public static final String FAILED_MSG = "Failed due to : ";
+  public static final String SKIPPED_MSG = "Skipped";
   public static final String CURRENT = "Current";
   private List<MigrationProcess> migrations;
   private final String nativeSQLScriptRootPath;
@@ -240,6 +241,22 @@ public class MigrationWorkflow {
     return !version.contains("-");
   }
 
+  private record ReleaseTrain(int major, int minor) implements Comparable<ReleaseTrain> {
+    private static ReleaseTrain fromVersion(String version) {
+      int[] parts = parseVersion(version);
+      return new ReleaseTrain(parts[0], parts[1]);
+    }
+
+    @Override
+    public int compareTo(ReleaseTrain another) {
+      int majorComparison = Integer.compare(major, another.major);
+      if (majorComparison != 0) {
+        return majorComparison;
+      }
+      return Integer.compare(minor, another.minor);
+    }
+  }
+
   /*
    * Parse a version string into an array of integers
    * Follows the format major.minor.patch, patch can contain -extension
@@ -301,18 +318,14 @@ public class MigrationWorkflow {
       Set<String> executedMigrations, List<MigrationFile> availableMigrations) {
     List<MigrationFile> nativeMigrations =
         availableMigrations.stream().filter(m -> !m.isExtension).toList();
-    Set<String> nativeVersions = nativeMigrations.stream().map(m -> m.version).collect(toSet());
-    Optional<String> maxExecuted =
-        executedMigrations.stream()
-            .filter(nativeVersions::contains)
-            .max(MigrationWorkflow::compareReprocessingCandidates);
-    if (maxExecuted.isEmpty()) {
+    Set<String> reprocessingVersions =
+        getReprocessingVersions(executedMigrations, nativeMigrations);
+    if (reprocessingVersions.isEmpty()) {
       return nativeMigrations;
     }
-    String maxVer = maxExecuted.get();
     List<MigrationFile> result = new ArrayList<>();
     for (MigrationFile migration : nativeMigrations) {
-      if (migration.version.equals(maxVer)) {
+      if (reprocessingVersions.contains(migration.version)) {
         result.add(migration.copyWithReprocessing(true));
       } else if (!executedMigrations.contains(migration.version)) {
         result.add(migration.copyWithReprocessing(false));
@@ -325,22 +338,63 @@ public class MigrationWorkflow {
       Set<String> executedMigrations, List<MigrationFile> availableMigrations) {
     List<MigrationFile> extensionMigrations =
         availableMigrations.stream().filter(migration -> migration.isExtension).toList();
-    Set<String> extensionVersions =
-        extensionMigrations.stream().map(migration -> migration.version).collect(toSet());
-    Optional<String> maxExecutedExtension =
-        executedMigrations.stream()
-            .filter(extensionVersions::contains)
-            .max(MigrationWorkflow::compareReprocessingCandidates);
+    Set<String> reprocessingVersions =
+        getReprocessingVersions(executedMigrations, extensionMigrations);
     List<MigrationFile> result = new ArrayList<>();
     for (MigrationFile migration : extensionMigrations) {
-      if (maxExecutedExtension.isPresent()
-          && migration.version.equals(maxExecutedExtension.get())) {
+      if (reprocessingVersions.contains(migration.version)) {
         result.add(migration.copyWithReprocessing(true));
       } else if (!executedMigrations.contains(migration.version)) {
         result.add(migration.copyWithReprocessing(false));
       }
     }
     return result;
+  }
+
+  private Set<String> getReprocessingVersions(
+      Set<String> executedMigrations, List<MigrationFile> availableMigrations) {
+    Set<String> availableVersions =
+        availableMigrations.stream().map(migration -> migration.version).collect(toSet());
+    Optional<String> maxExecuted =
+        executedMigrations.stream()
+            .filter(availableVersions::contains)
+            .max(MigrationWorkflow::compareReprocessingCandidates);
+    if (maxExecuted.isEmpty()) {
+      return Set.of();
+    }
+
+    Set<String> reprocessingVersions = new HashSet<>();
+    ReleaseTrain currentReleaseTrain = ReleaseTrain.fromVersion(maxExecuted.get());
+    getMaxExecutedVersionForReleaseTrain(
+            currentReleaseTrain, executedMigrations, availableMigrations)
+        .ifPresent(reprocessingVersions::add);
+
+    getPreviousReleaseTrain(currentReleaseTrain, availableMigrations)
+        .flatMap(
+            releaseTrain ->
+                getMaxExecutedVersionForReleaseTrain(
+                    releaseTrain, executedMigrations, availableMigrations))
+        .ifPresent(reprocessingVersions::add);
+    return reprocessingVersions;
+  }
+
+  private Optional<String> getMaxExecutedVersionForReleaseTrain(
+      ReleaseTrain releaseTrain,
+      Set<String> executedMigrations,
+      List<MigrationFile> availableMigrations) {
+    return availableMigrations.stream()
+        .filter(migration -> ReleaseTrain.fromVersion(migration.version).equals(releaseTrain))
+        .map(migration -> migration.version)
+        .filter(executedMigrations::contains)
+        .max(MigrationWorkflow::compareReprocessingCandidates);
+  }
+
+  private Optional<ReleaseTrain> getPreviousReleaseTrain(
+      ReleaseTrain currentReleaseTrain, List<MigrationFile> availableMigrations) {
+    return availableMigrations.stream()
+        .map(migration -> ReleaseTrain.fromVersion(migration.version))
+        .filter(releaseTrain -> releaseTrain.compareTo(currentReleaseTrain) < 0)
+        .max(ReleaseTrain::compareTo);
   }
 
   public void printMigrationInfo() {
@@ -404,9 +458,14 @@ public class MigrationWorkflow {
             // Schema Changes
             runSchemaChanges(row, process);
 
-            // Reprocessing can rerun Java migrations when new SQL is appended to the current
-            // version. Implementations must remain idempotent, same as force mode.
-            runStepAndAddStatus(row, process::runDataMigration);
+            if (shouldRunDataMigration(process)) {
+              runStepAndAddStatus(row, process::runDataMigration);
+            } else {
+              LOG.info(
+                  "[MigrationWorkflow] Skipping data migration for reprocessed previous release train version: {}",
+                  process.getVersion());
+              row.add(SKIPPED_MSG);
+            }
 
             // Post DDL Scripts
             runPostDDLChanges(row, process);
@@ -433,6 +492,13 @@ public class MigrationWorkflow {
       }
     }
     LOG.info("[MigrationWorkflow] WorkFlow Completed");
+  }
+
+  private boolean shouldRunDataMigration(MigrationProcess process) {
+    if (!process.isReprocessing() || currentMaxMigrationVersion.isEmpty()) {
+      return true;
+    }
+    return compareVersions(process.getVersion(), currentMaxMigrationVersion.get()) == 0;
   }
 
   private void runSchemaChanges(List<String> row, MigrationProcess process) {

--- a/openmetadata-service/src/test/java/org/openmetadata/service/migration/api/MigrationWorkflowTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/migration/api/MigrationWorkflowTest.java
@@ -219,6 +219,67 @@ class MigrationWorkflowTest {
   }
 
   @Test
+  void loadMigrationsReprocessesPreviousMinorLatestWhenNewSqlAddedAfterCurrentRelease()
+      throws Exception {
+    Path nativeRoot = Files.createDirectories(tempDir.resolve("native"));
+    createMigrationDir(nativeRoot, "1.12.9", "SELECT 12;");
+    createMigrationDir(nativeRoot, "1.13.0", "SELECT 13;");
+    when(migrationDAO.getMigrationVersions()).thenReturn(List.of("1.12.9", "1.13.0"));
+    when(migrationDAO.checkIfQueryPreviouslyRan(anyString()))
+        .thenAnswer(
+            invocation -> {
+              String checksum = invocation.getArgument(0);
+              if (checksum.equals(hash("SELECT 13"))) {
+                return "SELECT 13";
+              }
+              return null;
+            });
+
+    MigrationWorkflow workflow =
+        new MigrationWorkflow(
+            jdbi, nativeRoot.toString(), ConnectionType.POSTGRES, null, null, config, false);
+
+    workflow.loadMigrations();
+
+    assertEquals(List.of("1.12.9"), getMigrationVersions(workflow));
+  }
+
+  @Test
+  void loadMigrationsReprocessesPreviousMinorRunsPendingPatchAndCurrentVersion() throws Exception {
+    Path nativeRoot = Files.createDirectories(tempDir.resolve("native"));
+    createMigrationDir(nativeRoot, "1.12.9", "SELECT 129;");
+    createMigrationDir(nativeRoot, "1.12.10", "SELECT 1210;");
+    createMigrationDir(nativeRoot, "1.13.0", "SELECT 130;");
+    when(migrationDAO.getMigrationVersions()).thenReturn(List.of("1.12.9", "1.13.0"));
+    when(migrationDAO.checkIfQueryPreviouslyRan(anyString())).thenReturn(null);
+
+    MigrationWorkflow workflow =
+        new MigrationWorkflow(
+            jdbi, nativeRoot.toString(), ConnectionType.POSTGRES, null, null, config, false);
+
+    workflow.loadMigrations();
+
+    assertEquals(List.of("1.12.9", "1.12.10", "1.13.0"), getMigrationVersions(workflow));
+  }
+
+  @Test
+  void loadMigrationsSkipsPreviousMinorReprocessingWhenAllSqlAlreadyRan() throws Exception {
+    Path nativeRoot = Files.createDirectories(tempDir.resolve("native"));
+    createMigrationDir(nativeRoot, "1.12.9", "SELECT 12;");
+    createMigrationDir(nativeRoot, "1.13.0", "SELECT 13;");
+    when(migrationDAO.getMigrationVersions()).thenReturn(List.of("1.12.9", "1.13.0"));
+    when(migrationDAO.checkIfQueryPreviouslyRan(anyString())).thenReturn("already ran");
+
+    MigrationWorkflow workflow =
+        new MigrationWorkflow(
+            jdbi, nativeRoot.toString(), ConnectionType.POSTGRES, null, null, config, false);
+
+    workflow.loadMigrations();
+
+    assertEquals(List.of(), getMigrationVersions(workflow));
+  }
+
+  @Test
   void loadMigrationsFallsBackToNoOpWhenNoExtensionProviderHandlesVersion() throws Exception {
     // Regression: a Collate version directory without a registered Java provider must resolve to
     // MigrationProcessImpl (no-op data migration), NOT to OM's same-numeric-version migration
@@ -400,13 +461,225 @@ class MigrationWorkflowTest {
         .thenReturn(Map.of("CREATE INDEX", new QueryStatus(QueryStatus.Status.SUCCESS, "ok")));
 
     setMigrations(workflow, List.of(process));
-    setCurrentMaxVersion(workflow, Optional.of("1.0.0"));
+    setCurrentMaxVersion(workflow, Optional.of("1.1.0"));
 
     try (var ignored = mockConstruction(MigrationWorkflowContext.class, this::mockContext)) {
       workflow.runMigrationWorkflows(false);
     }
 
     verify(process).runDataMigration();
+  }
+
+  @Test
+  void runMigrationWorkflowsSkipsDataMigrationForPreviousReleaseTrainReprocessing()
+      throws Exception {
+    MigrationWorkflow workflow =
+        new MigrationWorkflow(
+            jdbi,
+            tempDir.resolve("native").toString(),
+            ConnectionType.POSTGRES,
+            null,
+            null,
+            config,
+            false);
+    MigrationProcess process = mock(MigrationProcess.class);
+    when(process.getVersion()).thenReturn("1.12.9");
+    when(process.getDatabaseConnectionType()).thenReturn("postgres");
+    when(process.getMigrationsPath()).thenReturn("/tmp/1.12.9");
+    when(process.isReprocessing()).thenReturn(true);
+    when(process.runSchemaChanges(false))
+        .thenReturn(Map.of("ALTER TABLE", new QueryStatus(QueryStatus.Status.SUCCESS, "ok")));
+    when(process.runPostDDLScripts(false))
+        .thenReturn(Map.of("CREATE INDEX", new QueryStatus(QueryStatus.Status.SUCCESS, "ok")));
+
+    setMigrations(workflow, List.of(process));
+    setCurrentMaxVersion(workflow, Optional.of("1.13.0"));
+
+    try (var ignored = mockConstruction(MigrationWorkflowContext.class, this::mockContext)) {
+      workflow.runMigrationWorkflows(false);
+    }
+
+    verify(process, never()).runDataMigration();
+    verify(process).runPostDDLScripts(false);
+    verify(migrationDAO)
+        .upsertServerMigration(eq("1.12.9"), eq("/tmp/1.12.9"), anyString(), anyString());
+  }
+
+  @Test
+  void getMigrationsToApplyReprocessesCurrentAndPreviousReleaseTrainLatestVersions()
+      throws Exception {
+    List<String> executedMigrations = List.of("1.12.9", "1.13.0");
+    List<MigrationFile> availableMigrations =
+        List.of(createMigrationFile("1.12.9", false), createMigrationFile("1.13.0", false));
+
+    MigrationWorkflow workflow =
+        new MigrationWorkflow(
+            jdbi, tempDir.toString(), ConnectionType.MYSQL, null, null, config, false);
+
+    List<MigrationFile> result =
+        workflow.getMigrationsToApply(executedMigrations, availableMigrations);
+
+    assertEquals(List.of("1.12.9", "1.13.0"), result.stream().map(m -> m.version).toList());
+    assertTrue(result.stream().allMatch(MigrationFile::isReprocessing));
+  }
+
+  @Test
+  void getMigrationsToApplyReprocessesPreviousTrainMaxExecutedWhenLatestPatchIsPending()
+      throws Exception {
+    List<String> executedMigrations = List.of("1.12.9", "1.13.0");
+    List<MigrationFile> availableMigrations =
+        List.of(
+            createMigrationFile("1.12.9", false),
+            createMigrationFile("1.12.10", false),
+            createMigrationFile("1.13.0", false));
+
+    MigrationWorkflow workflow =
+        new MigrationWorkflow(
+            jdbi, tempDir.toString(), ConnectionType.MYSQL, null, null, config, false);
+
+    List<MigrationFile> result =
+        workflow.getMigrationsToApply(executedMigrations, availableMigrations);
+
+    assertEquals(
+        List.of("1.12.9", "1.12.10", "1.13.0"), result.stream().map(m -> m.version).toList());
+    assertTrue(
+        result.stream()
+            .filter(m -> m.version.equals("1.12.9"))
+            .findFirst()
+            .orElseThrow()
+            .isReprocessing());
+    assertFalse(
+        result.stream()
+            .filter(m -> m.version.equals("1.12.10"))
+            .findFirst()
+            .orElseThrow()
+            .isReprocessing());
+    assertTrue(
+        result.stream()
+            .filter(m -> m.version.equals("1.13.0"))
+            .findFirst()
+            .orElseThrow()
+            .isReprocessing());
+  }
+
+  @Test
+  void getMigrationsToApplyReprocessesPartiallyCompletedPreviousPatchAndCurrentVersion()
+      throws Exception {
+    List<String> executedMigrations = List.of("1.12.9", "1.12.10", "1.13.0");
+    List<MigrationFile> availableMigrations =
+        List.of(
+            createMigrationFile("1.12.9", false),
+            createMigrationFile("1.12.10", false),
+            createMigrationFile("1.13.0", false));
+
+    MigrationWorkflow workflow =
+        new MigrationWorkflow(
+            jdbi, tempDir.toString(), ConnectionType.MYSQL, null, null, config, false);
+
+    List<MigrationFile> result =
+        workflow.getMigrationsToApply(executedMigrations, availableMigrations);
+
+    assertEquals(List.of("1.12.10", "1.13.0"), result.stream().map(m -> m.version).toList());
+    assertTrue(result.stream().allMatch(MigrationFile::isReprocessing));
+  }
+
+  @Test
+  void getMigrationsToApplyDoesNotReprocessOlderThanPreviousReleaseTrain() throws Exception {
+    List<String> executedMigrations = List.of("1.11.10", "1.12.9", "1.13.0");
+    List<MigrationFile> availableMigrations =
+        List.of(
+            createMigrationFile("1.11.10", false),
+            createMigrationFile("1.12.9", false),
+            createMigrationFile("1.13.0", false));
+
+    MigrationWorkflow workflow =
+        new MigrationWorkflow(
+            jdbi, tempDir.toString(), ConnectionType.MYSQL, null, null, config, false);
+
+    List<MigrationFile> result =
+        workflow.getMigrationsToApply(executedMigrations, availableMigrations);
+
+    assertEquals(List.of("1.12.9", "1.13.0"), result.stream().map(m -> m.version).toList());
+    assertFalse(result.stream().anyMatch(m -> m.version.equals("1.11.10")));
+    assertTrue(result.stream().allMatch(MigrationFile::isReprocessing));
+  }
+
+  @Test
+  void getMigrationsToApplyReprocessesPreviousReleaseTrainAcrossMajorBoundary() throws Exception {
+    List<String> executedMigrations = List.of("1.13.5", "2.0.0");
+    List<MigrationFile> availableMigrations =
+        List.of(createMigrationFile("1.13.5", false), createMigrationFile("2.0.0", false));
+
+    MigrationWorkflow workflow =
+        new MigrationWorkflow(
+            jdbi, tempDir.toString(), ConnectionType.MYSQL, null, null, config, false);
+
+    List<MigrationFile> result =
+        workflow.getMigrationsToApply(executedMigrations, availableMigrations);
+
+    assertEquals(List.of("1.13.5", "2.0.0"), result.stream().map(m -> m.version).toList());
+    assertTrue(result.stream().allMatch(MigrationFile::isReprocessing));
+  }
+
+  @Test
+  void getMigrationsToApplyReprocessesCurrentAndPreviousExtensionReleaseTrainVersions()
+      throws Exception {
+    List<String> executedMigrations = List.of("1.12.9-collate", "1.13.0-collate");
+    List<MigrationFile> availableMigrations =
+        List.of(
+            createMigrationFile("1.12.9-collate", true),
+            createMigrationFile("1.13.0-collate", true));
+
+    MigrationWorkflow workflow =
+        new MigrationWorkflow(
+            jdbi, tempDir.toString(), ConnectionType.MYSQL, null, null, config, false);
+
+    List<MigrationFile> result =
+        workflow.getMigrationsToApply(executedMigrations, availableMigrations);
+
+    assertEquals(
+        List.of("1.12.9-collate", "1.13.0-collate"), result.stream().map(m -> m.version).toList());
+    assertTrue(result.stream().allMatch(MigrationFile::isReprocessing));
+  }
+
+  @Test
+  void getMigrationsToApplyReprocessesPreviousExtensionTrainAndRunsPendingExtensionPatch()
+      throws Exception {
+    List<String> executedMigrations = List.of("1.12.9-collate", "1.13.0-collate");
+    List<MigrationFile> availableMigrations =
+        List.of(
+            createMigrationFile("1.12.9-collate", true),
+            createMigrationFile("1.12.10-collate", true),
+            createMigrationFile("1.13.0-collate", true));
+
+    MigrationWorkflow workflow =
+        new MigrationWorkflow(
+            jdbi, tempDir.toString(), ConnectionType.MYSQL, null, null, config, false);
+
+    List<MigrationFile> result =
+        workflow.getMigrationsToApply(executedMigrations, availableMigrations);
+
+    assertEquals(
+        List.of("1.12.9-collate", "1.12.10-collate", "1.13.0-collate"),
+        result.stream().map(m -> m.version).toList());
+    assertTrue(
+        result.stream()
+            .filter(m -> m.version.equals("1.12.9-collate"))
+            .findFirst()
+            .orElseThrow()
+            .isReprocessing());
+    assertFalse(
+        result.stream()
+            .filter(m -> m.version.equals("1.12.10-collate"))
+            .findFirst()
+            .orElseThrow()
+            .isReprocessing());
+    assertTrue(
+        result.stream()
+            .filter(m -> m.version.equals("1.13.0-collate"))
+            .findFirst()
+            .orElseThrow()
+            .isReprocessing());
   }
 
   @Test
@@ -429,7 +702,13 @@ class MigrationWorkflowTest {
         workflow.getMigrationsToApply(executedMigrations, availableMigrations);
 
     List<String> versions = result.stream().map(m -> m.version).toList();
-    assertEquals(List.of("1.11.11", "1.11.12", "1.12.1", "1.12.2"), versions);
+    assertEquals(List.of("1.11.10", "1.11.11", "1.11.12", "1.12.1", "1.12.2"), versions);
+    assertTrue(
+        result.stream()
+            .filter(m -> m.version.equals("1.11.10"))
+            .findFirst()
+            .orElseThrow()
+            .isReprocessing());
     assertFalse(
         result.stream()
             .filter(m -> m.version.equals("1.11.11"))
@@ -480,8 +759,9 @@ class MigrationWorkflowTest {
     List<String> extensionVersions =
         result.stream().filter(m -> m.isExtension).map(m -> m.version).toList();
 
-    assertEquals(List.of("1.11.11", "1.12.1", "1.12.2"), nativeVersions);
+    assertEquals(List.of("1.11.10", "1.11.11", "1.12.1", "1.12.2"), nativeVersions);
     assertEquals(List.of("1.12.1-collate"), extensionVersions);
+    assertTrue(result.stream().anyMatch(m -> m.version.equals("1.11.10") && m.isReprocessing()));
     assertTrue(result.stream().anyMatch(m -> m.version.equals("1.12.1") && m.isReprocessing()));
     assertTrue(
         result.stream().anyMatch(m -> m.version.equals("1.12.1-collate") && !m.isReprocessing()));
@@ -511,8 +791,9 @@ class MigrationWorkflowTest {
     List<String> extensionVersions =
         result.stream().filter(m -> m.isExtension).map(m -> m.version).toList();
 
-    assertEquals(List.of("1.12.1", "1.12.2"), nativeVersions);
+    assertEquals(List.of("1.11.10", "1.12.1", "1.12.2"), nativeVersions);
     assertEquals(List.of("1.12.1-collate"), extensionVersions);
+    assertTrue(result.stream().anyMatch(m -> m.version.equals("1.11.10") && m.isReprocessing()));
     assertTrue(result.stream().anyMatch(m -> m.version.equals("1.12.1") && m.isReprocessing()));
     assertTrue(
         result.stream().anyMatch(m -> m.version.equals("1.12.1-collate") && m.isReprocessing()));
@@ -649,7 +930,14 @@ class MigrationWorkflowTest {
         workflow.getMigrationsToApply(executedMigrations, availableMigrations);
 
     List<String> versions = result.stream().map(m -> m.version).toList();
-    assertEquals(List.of("1.10.6", "1.11.1", "1.11.1-collate", "1.12.1", "1.12.2"), versions);
+    assertEquals(
+        List.of("1.10.6", "1.11.0", "1.11.1", "1.11.1-collate", "1.12.1", "1.12.2"), versions);
+    assertTrue(
+        result.stream()
+            .filter(m -> m.version.equals("1.11.0"))
+            .findFirst()
+            .orElseThrow()
+            .isReprocessing());
     assertTrue(
         result.stream()
             .filter(m -> m.version.equals("1.12.1"))
@@ -680,10 +968,16 @@ class MigrationWorkflowTest {
         workflow.getMigrationsToApply(executedMigrations, availableMigrations);
 
     List<String> versions = result.stream().map(m -> m.version).toList();
-    assertEquals(List.of("1.5.15", "1.10.5"), versions);
+    assertEquals(List.of("1.5.15", "1.9.1", "1.10.5"), versions);
     assertFalse(
         result.stream()
             .filter(m -> m.version.equals("1.5.15"))
+            .findFirst()
+            .orElseThrow()
+            .isReprocessing());
+    assertTrue(
+        result.stream()
+            .filter(m -> m.version.equals("1.9.1"))
             .findFirst()
             .orElseThrow()
             .isReprocessing());


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:

Fixes #28440

Reprocess the max executed migration in the current release train and the immediate previous release train, for both native and extension migrations, so newly appended SQL in a still-active previous minor release is picked up after a newer minor has already run.
Previous-release-train reprocessing skips Java data migrations and still relies on `SERVER_MIGRATION_SQL_LOGS` checksums to avoid rerunning SQL statements that already executed.

#
### Type of change:
- [x] Bug fix

#
### High-level design:

N/A - small migration workflow change.

#
### Tests:

#### Use cases covered

| Scenario | Executed migrations | Available migrations | Expected migration candidates | Test coverage |
| --- | --- | --- | --- | --- |
| New SQL appended to previous minor after current minor already ran | `1.12.9`, `1.13.0` | `1.12.9`, `1.13.0` | Reprocess `1.12.9`; skip `1.13.0` when its SQL checksum already exists | `loadMigrationsReprocessesPreviousMinorLatestWhenNewSqlAddedAfterCurrentRelease` |
| Previous minor has pending patch after current minor already ran | `1.12.9`, `1.13.0` | `1.12.9`, `1.12.10`, `1.13.0` | Reprocess `1.12.9`; run pending `1.12.10`; reprocess `1.13.0` | `loadMigrationsReprocessesPreviousMinorRunsPendingPatchAndCurrentVersion`, `getMigrationsToApplyReprocessesPreviousTrainMaxExecutedWhenLatestPatchIsPending` |
| Previous minor and current minor already fully executed with no new SQL | `1.12.9`, `1.13.0` | `1.12.9`, `1.13.0` | No migrations after SQL checksum filtering | `loadMigrationsSkipsPreviousMinorReprocessingWhenAllSqlAlreadyRan` |
| Current and previous release trains both need reprocessing | `1.12.9`, `1.13.0` | `1.12.9`, `1.13.0` | Reprocess `1.12.9` and `1.13.0` | `getMigrationsToApplyReprocessesCurrentAndPreviousReleaseTrainLatestVersions` |
| Previous patch was partially completed before current minor | `1.12.9`, `1.12.10`, `1.13.0` | `1.12.9`, `1.12.10`, `1.13.0` | Reprocess max executed previous train `1.12.10` and current train `1.13.0` | `getMigrationsToApplyReprocessesPartiallyCompletedPreviousPatchAndCurrentVersion` |
| Older-than-previous release trains should not be reprocessed | `1.11.10`, `1.12.9`, `1.13.0` | `1.11.10`, `1.12.9`, `1.13.0` | Reprocess only `1.12.9` and `1.13.0`; do not reprocess `1.11.10` | `getMigrationsToApplyDoesNotReprocessOlderThanPreviousReleaseTrain` |
| Major-version boundary | `1.13.5`, `2.0.0` | `1.13.5`, `2.0.0` | Reprocess previous train `1.13.5` and current train `2.0.0` | `getMigrationsToApplyReprocessesPreviousReleaseTrainAcrossMajorBoundary` |
| Collate extension previous and current trains | `1.12.9-collate`, `1.13.0-collate` | `1.12.9-collate`, `1.13.0-collate` | Reprocess `1.12.9-collate` and `1.13.0-collate` | `getMigrationsToApplyReprocessesCurrentAndPreviousExtensionReleaseTrainVersions` |
| Collate extension pending previous-minor patch | `1.12.9-collate`, `1.13.0-collate` | `1.12.9-collate`, `1.12.10-collate`, `1.13.0-collate` | Reprocess `1.12.9-collate`; run pending `1.12.10-collate`; reprocess `1.13.0-collate` | `getMigrationsToApplyReprocessesPreviousExtensionTrainAndRunsPendingExtensionPatch` |
| Extension migrations remain separated from native migrations | Native `1.12.0`, `1.12.1`; extension not executed | Native `1.12.0`, `1.12.1`, `1.12.2`; extension `1.12.1-collate`, `1.12.2-collate` | Native and extension candidates are selected independently | `getMigrationsToApplyExtensionMigrationsProcessedSeparately`, `getMigrationsToApplyCollateVersionsAreIncluded`, `getMigrationsToApplyReprocessesCurrentNativeAndExtensionVersionsSeparately` |
| Backported lower-minor versions are still picked up | `1.11.10`, `1.12.0`, `1.12.1` | `1.11.10`, `1.11.11`, `1.11.12`, `1.12.0`, `1.12.1`, `1.12.2` | Reprocess max executed previous train `1.11.10`; run pending `1.11.11`, `1.11.12`; reprocess `1.12.1`; run pending `1.12.2` | `getMigrationsToApplyBackportedLowerMinorVersionsAreIncluded` |
| Multiple lower trains with historical gaps | `1.5.0`, `1.5.11`, `1.9.0`, `1.9.1`, `1.10.0`, `1.10.5` | Same plus pending `1.5.15` | Run pending historical gap `1.5.15`; reprocess immediate previous train `1.9.1`; reprocess current train `1.10.5` | `getMigrationsToApplyHistoricalGapBelowMaxIsBackfilled` |
| Same-minor forward upgrade | `1.11.10` | `1.11.10`, `1.11.11`, `1.11.12`, `1.12.0` | Reprocess `1.11.10`; run pending `1.11.11`, `1.11.12`, `1.12.0` | `getMigrationsToApplySameMinorBackfillsAreIncluded` |
| No executed migrations | none | `1.11.10`, `1.12.0`, `1.12.0-collate` | Run all available migrations normally | `getMigrationsToApplyNoExecutedMigrationsReturnsAll` |
| All migrations already executed in a train | `1.12.0`, `1.12.1`, `1.12.1-collate` | Same | Reprocess max executed native version only | `getMigrationsToApplyAllMigrationsAlreadyExecuted` |
| SQL statement-level filtering | Some statement checksums already present in `SERVER_MIGRATION_SQL_LOGS` | Same migration file with old and new SQL | Only SQL statements without existing checksums remain in parsed migration operations | `testContinuousDeploymentNewSqlPickedUp`, `testContinuousDeploymentNoNewSql`, `testReprocessingVersionDroppedWhenNoNewSql` |
| Java data migration safety | Reprocessed previous train `1.12.9` while current max is `1.13.0` | Workflow executes `1.12.9` SQL/post-DDL | Skip Java data migration for previous-release-train reprocessing | `runMigrationWorkflowsSkipsDataMigrationForPreviousReleaseTrainReprocessing` |

#### Unit tests
- [x] I added unit tests for the new/changed logic.
- Files updated: `openmetadata-service/src/test/java/org/openmetadata/service/migration/api/MigrationWorkflowTest.java`
- Coverage %: Not run.

#### Backend integration tests
- [x] Not applicable (no backend API changes).

#### Ingestion integration tests
- [x] Not applicable (no ingestion changes).

#### Playwright (UI) tests
- [x] Not applicable (no UI changes).

#### Manual testing performed
1. `mvn -pl openmetadata-service spotless:apply`
2. `mvn -pl openmetadata-service -Dtest=MigrationWorkflowTest,MigrationWorkflowReprocessingTest,MigrationProcessImplTest test`

#
### UI screen recording / screenshots:

Not applicable.

#
### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] My PR title is `Fixes <issue-number>: <short explanation>`
- [x] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.
- [ ] For UI changes: I attached a screen recording and/or screenshots above.
- [x] I have added tests (unit / integration / Playwright as applicable) and listed them above.

<!-- Bug fix -->
- [x] I have added a test that covers the exact scenario we are fixing.
