### PR TITLE
fix(workflows): GitHub Sink + event-based workflows silently reject all entities

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/governance/workflows/elements/triggers/impl/FilterEntityImpl.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/governance/workflows/elements/triggers/impl/FilterEntityImpl.java
@@ -8,6 +8,7 @@ import static org.openmetadata.service.governance.workflows.elements.triggers.Ev
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
@@ -229,15 +230,18 @@ public class FilterEntityImpl implements JavaDelegate {
               || passesFieldBasedFilter(changedFields, includeFields, excludedFilter);
     }
 
-    // Apply JSON filter
-    boolean passesJsonFilter = true;
-    if (filterLogic != null && !filterLogic.trim().isEmpty()) {
-      passesJsonFilter =
-          Boolean.TRUE.equals(
-              RuleEngine.getInstance().apply(filterLogic, JsonUtils.getMap(entity)));
-    }
+    boolean passesJsonFilter = applyJsonFilter(filterLogic, JsonUtils.getMap(entity));
 
     return fieldBasedFilter && passesJsonFilter;
+  }
+
+  private static boolean applyJsonFilter(String filterLogic, Map<String, Object> entityMap) {
+    boolean result = true;
+    if (filterLogic != null && !filterLogic.trim().isEmpty()) {
+      Object ruleResult = RuleEngine.getInstance().apply(filterLogic, entityMap);
+      result = !Boolean.TRUE.equals(ruleResult);
+    }
+    return result;
   }
 
   private List<FieldChange> getAllChangedFields(ChangeDescription changeDescription) {

--- a/openmetadata-service/src/test/java/org/openmetadata/service/governance/workflows/elements/triggers/impl/FilterEntityImplTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/governance/workflows/elements/triggers/impl/FilterEntityImplTest.java
@@ -18,6 +18,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.lang.reflect.Method;
 import java.util.List;
+import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.openmetadata.schema.type.FieldChange;
@@ -26,6 +27,7 @@ class FilterEntityImplTest {
 
   private FilterEntityImpl filterEntity;
   private Method passesFieldBasedFilter;
+  private Method applyJsonFilter;
 
   @BeforeEach
   void setUp() throws Exception {
@@ -34,6 +36,9 @@ class FilterEntityImplTest {
         FilterEntityImpl.class.getDeclaredMethod(
             "passesFieldBasedFilter", List.class, List.class, List.class);
     passesFieldBasedFilter.setAccessible(true);
+    applyJsonFilter =
+        FilterEntityImpl.class.getDeclaredMethod("applyJsonFilter", String.class, Map.class);
+    applyJsonFilter.setAccessible(true);
   }
 
   @Test
@@ -209,9 +214,50 @@ class FilterEntityImplTest {
         passesFieldBasedFilter.invoke(filterEntity, changedFields, includeFields, excludeFields);
   }
 
+  private boolean invokeApplyJsonFilter(String filterLogic, Map<String, Object> entityMap)
+      throws Exception {
+    return (boolean) applyJsonFilter.invoke(null, filterLogic, entityMap);
+  }
+
   private FieldChange fieldChange(String name) {
     FieldChange fc = new FieldChange();
     fc.setName(name);
     return fc;
+  }
+
+  @Test
+  void testApplyJsonFilterPassesWhenFilterLogicIsNull() throws Exception {
+    assertTrue(invokeApplyJsonFilter(null, Map.of("name", "mysql_sample")));
+  }
+
+  @Test
+  void testApplyJsonFilterPassesWhenFilterLogicIsEmpty() throws Exception {
+    assertTrue(invokeApplyJsonFilter("", Map.of("name", "mysql_sample")));
+    assertTrue(invokeApplyJsonFilter("   ", Map.of("name", "mysql_sample")));
+  }
+
+  @Test
+  void testApplyJsonFilterPassesWhenFilterIsNotJsonLogic() throws Exception {
+    String esQuery =
+        "{\"query\":{\"bool\":{\"must\":[{\"term\":{\"name.keyword\":\"mysql_sample\"}}]}}}";
+    Map<String, Object> entity = Map.of("name", "mysql_sample", "entityType", "databaseService");
+
+    assertTrue(invokeApplyJsonFilter(esQuery, entity));
+  }
+
+  @Test
+  void testApplyJsonFilterExcludesWhenJsonLogicMatches() throws Exception {
+    String jsonLogic = "{\"==\":[{\"var\":\"name\"},\"mysql_sample\"]}";
+    Map<String, Object> entity = Map.of("name", "mysql_sample");
+
+    assertFalse(invokeApplyJsonFilter(jsonLogic, entity));
+  }
+
+  @Test
+  void testApplyJsonFilterPassesWhenJsonLogicDoesNotMatch() throws Exception {
+    String jsonLogic = "{\"==\":[{\"var\":\"name\"},\"other_service\"]}";
+    Map<String, Object> entity = Map.of("name", "mysql_sample");
+
+    assertTrue(invokeApplyJsonFilter(jsonLogic, entity));
   }
 }


### PR DESCRIPTION
## Fix

Restore the `!` in `FilterEntityImpl.passesExcludedFilter()` so non-JsonLogic filter input passes through correctly. Extract the JSON-filter evaluation into a small `applyJsonFilter` helper so the behavior can be unit-tested.

```diff
- passesJsonFilter =  Boolean.TRUE.equals(RuleEngine.apply(filterLogic, ...))
+ passesJsonFilter = !Boolean.TRUE.equals(RuleEngine.apply(filterLogic, ...))
```

## Why the `!` is required

`RuleEngine.apply()` returns `false` when `filterLogic` cannot be evaluated as JsonLogic — its catch branch is annotated *"falls back to triggering workflow"*. Event-based workflow triggers pass Elasticsearch query DSL through this code path, so the consumer must treat any non-`TRUE` result as "pass through". The `!` provides that semantic.

## Impact

Without the `!`, every event-based workflow with an ES-style filter (Git Sink, EventBased approval, custom user workflows) is filtered out at the trigger gate:

- Trigger workflow ends at `endEvent` in <100ms via the `${!passesFilter}` branch
- The `CallActivity` to the main workflow is skipped
- `ACT_HI_PROCINST` shows only `*Trigger` rows; the main workflow never starts
- No exception or error is surfaced

## Regression source

The `!` was originally added by [#25272](https://github.com/open-metadata/OpenMetadata/pull/25272) ("Show Relevant Exclude Fields in EventBased Workflows") and inadvertently removed by [#25894](https://github.com/open-metadata/OpenMetadata/pull/25894) ("Task redesign") — a 498-file refactor where this one-character change in `FilterEntityImpl.java` (+1/-1) was easy to miss in review.

## Why this wasn't caught by existing tests

- `FilterEntityImplTest` — 17 existing tests, all targeting `passesFieldBasedFilter`. The JSON-filter branch (`passesJsonFilter` / `RuleEngine.apply`) had no coverage.
- Integration tests (`*IT.java`) — verify workflows deploy correctly; they don't assert that a matching event drives the workflow to its terminal side effect.
- Playwright E2E — covers Workflow Builder UI flows; doesn't exercise event-driven dispatch end-to-end.

## Tests added (same PR, existing reflection pattern)

Five new tests in `FilterEntityImplTest` exercise `applyJsonFilter` via reflection — same pattern used by the existing tests for `passesFieldBasedFilter`. Uses the real `RuleEngine` (no mocks).

- `testApplyJsonFilterPassesWhenFilterLogicIsNull`
- `testApplyJsonFilterPassesWhenFilterLogicIsEmpty`
- `testApplyJsonFilterPassesWhenFilterIsNotJsonLogic` — regression test; fails if `!` is removed again
- `testApplyJsonFilterExcludesWhenJsonLogicMatches` — pins the "matching rule excludes" semantic
- `testApplyJsonFilterPassesWhenJsonLogicDoesNotMatch`

## Verification

| Before | After |
|---|---|
| Workflow ends in 50-100ms with no side effect | Workflow runs in 2-6s and produces its side effect |
| Main workflow process never starts | Main workflow runs through `CallActivity → sinkTask → endEvent` |

Test run: `mvn test -pl openmetadata-service -Dtest=FilterEntityImplTest` → **22/22 green** (17 existing + 5 new). Verified end-to-end against a Git Sink workflow with an ES filter on `databaseService` / `table` / `glossaryTerm`.