### PR TITLE
ci: set AUTHENTICATION_MAX_ACTIVE_SESSIONS_PER_USER=1000 for nightly playwright

### DIFF
--- a/.github/workflows/mysql-nightly-e2e.yml
+++ b/.github/workflows/mysql-nightly-e2e.yml
@@ -33,6 +33,12 @@ jobs:
   pw-ci-mysql-branch:
     runs-on: ubuntu-latest
     environment: test
+    env:
+      # Playwright logs the admin user in many times (performAdminLogin per test, parallel
+      # workers, retries). The production default of 5 active sessions per user would evict the
+      # long-lived storageState session the page fixtures rely on and 401 every request. Raise
+      # the cap for E2E only; docker compose reads this for ${AUTHENTICATION_MAX_ACTIVE_SESSIONS_PER_USER:-5}.
+      AUTHENTICATION_MAX_ACTIVE_SESSIONS_PER_USER: "1000"
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/postgresql-nightly-e2e.yml
+++ b/.github/workflows/postgresql-nightly-e2e.yml
@@ -33,6 +33,12 @@ jobs:
   pw-ci-postgresql-branch:
     runs-on: ubuntu-latest
     environment: test
+    env:
+      # Playwright logs the admin user in many times (performAdminLogin per test, parallel
+      # workers, retries). The production default of 5 active sessions per user would evict the
+      # long-lived storageState session the page fixtures rely on and 401 every request. Raise
+      # the cap for E2E only; docker compose reads this for ${AUTHENTICATION_MAX_ACTIVE_SESSIONS_PER_USER:-5}.
+      AUTHENTICATION_MAX_ACTIVE_SESSIONS_PER_USER: "1000"
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## Summary
- Targets branch `issue-21971` of [#26314](https://github.com/open-metadata/OpenMetadata/pull/26314). Mirrors the env block that PR already added to `playwright-mysql-e2e.yml` / `playwright-postgresql-e2e.yml` onto the nightly counterparts:
  - `.github/workflows/mysql-nightly-e2e.yml`
  - `.github/workflows/postgresql-nightly-e2e.yml`
- Without this, the nightly runs would hit the new production default of 5 active sessions per user and 401 once the long-lived admin `storageState` is evicted across shards/retries.

## Notes
- Followup from Slack thread; cc @harshach @mohitdeuex @chiragmadlani.
- Did not touch `playwright-search-nightly.yml`, `playwright-sso-login-nightly.yml`, or `java-playwright-nightly.yml` — happy to extend if reviewers want those covered too.

## Test plan
- [ ] Confirm both nightly workflows lint / run after merge into `issue-21971`

🤖 Generated with [Claude Code](https://claude.com/claude-code)