### PR TITLE
fix(ui): keep glossary selected after rename instead of redirecting to first glossary

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/pages/Glossary/GlossaryPage/GlossaryPage.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/Glossary/GlossaryPage/GlossaryPage.component.tsx
@@ -292,19 +292,25 @@ const GlossaryPage = () => {
 
   useEffect(() => {
     if (glossaries.length && isGlossaryActive) {
-      setActiveGlossary(
-        glossaries.find(
-          (glossary) => glossary.fullyQualifiedName === glossaryFqn
-        ) || glossaries[0]
+      const matchedGlossary = glossaries.find(
+        (glossary) => glossary.fullyQualifiedName === glossaryFqn
       );
 
-      if (isEmpty(glossaryFqn) && glossaries[0].fullyQualifiedName) {
-        navigate(getGlossaryPath(glossaries[0].fullyQualifiedName), {
-          replace: true,
-        });
+      if (isEmpty(glossaryFqn)) {
+        setActiveGlossary(glossaries[0]);
+
+        if (glossaries[0].fullyQualifiedName) {
+          navigate(getGlossaryPath(glossaries[0].fullyQualifiedName), {
+            replace: true,
+          });
+        }
+      } else if (matchedGlossary) {
+        setActiveGlossary(matchedGlossary);
+      } else if (!isLoading) {
+        setActiveGlossary(glossaries[0]);
       }
     }
-  }, [isGlossaryActive, glossaryFqn, glossaries]);
+  }, [isGlossaryActive, glossaryFqn, glossaries, isLoading]);
 
   const isRightPanelLoading = useMemo(() => {
     if (!glossaries.length) {


### PR DESCRIPTION
## Problem

Renaming a glossary via the rename modal (changing its `name`) makes the page jump to a **different** glossary — the first one in the sidebar (e.g. *Critical Data Elements*) — instead of staying on the renamed glossary. Surfaced by the flaky e2e **`Glossary.spec.ts` → "Update glossary display name via rename modal"**, where the header assertion received `Critical Data Elements` instead of the renamed value.

## Root cause (frontend only — backend is correct)

Changing a glossary's `name` changes its `fullyQualifiedName`. On save, `updateGlossary` navigates to the new FQN route and refetches the glossary list. The selection effect resolved the active glossary with:

```ts
glossaries.find((g) => g.fullyQualifiedName === glossaryFqn) || glossaries[0]
```

There's a race: `navigate(...)` flips `glossaryFqn` to the **new** FQN immediately, but `fetchGlossaryList()` is async. In that window `glossaries` still holds the **stale** list (without the renamed entry), so `find()` misses and the `|| glossaries[0]` fallback selects the first glossary — clobbering the renamed one. With special-character names the mismatch is easy to hit and the page stays stuck.

The rename `PATCH /api/v1/glossaries/{id}` returns `200` with the correct `name`/FQN; there are no 4xx/5xx in the trace. This is purely a client-side routing/selection issue.

## Fix

Branch the selection effect explicitly instead of `find() || glossaries[0]`:

- **No FQN requested** → default to the first glossary + redirect (unchanged).
- **FQN found in the list** → select it.
- **FQN not found while the list is still loading** → do nothing; keep the current (renamed) glossary and wait for the refreshed list.
- **FQN not found after the list has settled (`!isLoading`)** → fall back to the first glossary (preserves the genuine deleted/missing-glossary behavior).

`isLoading` is added to the effect dependencies so the fallback re-evaluates once the refetch completes.

## Testing

- [ ] `yarn lint` / `npx tsc --noEmit`
- [ ] Playwright: `Glossary.spec.ts` "Update glossary display name via rename modal"
- [ ] Manual: rename a glossary → page stays on it with the updated name; deep-linking to a deleted glossary still falls back to the first one; empty `/glossary` still redirects to the first glossary.

> Note: should be cherry-picked to `1.12.9` (where it was reported) once merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)