### PR TITLE
test(ui): stabilize glossary name/FQN rename e2e

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/Glossary.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/Glossary.spec.ts
@@ -2765,18 +2765,19 @@ test.describe('Glossary tests', () => {
 
       const updateNameResponse = page.waitForResponse('/api/v1/glossaries/*');
       await page.click('[data-testid="save-button"]');
-      await updateNameResponse;
+      const renamedGlossary = await (await updateNameResponse).json();
 
-      await waitForAllLoadersToDisappear(page);
+      expect(renamedGlossary.name).toBe(newName);
 
-      // Verify the name was updated in the header
-      await expect(
-        page.locator('[data-testid="entity-header-name"]')
-      ).toHaveText(newName);
+      glossary.responseData.name = renamedGlossary.name;
+      glossary.responseData.fullyQualifiedName =
+        renamedGlossary.fullyQualifiedName;
 
-      // Update glossary object for cleanup
-      glossary.responseData.name = newName;
-      glossary.responseData.fullyQualifiedName = newName;
+      await expect(async () => {
+        await visitGlossaryPage(page, glossary.data.displayName);
+
+        expect(page.url()).toContain('-renamed');
+      }).toPass({ intervals: [2_000, 4_000, 6_000], timeout: 60_000 });
     } finally {
       await glossary.delete(apiContext);
       await afterAction();


### PR DESCRIPTION
## Problem

The e2e test **`Glossary.spec.ts` → "Update glossary display name via rename modal"** is flaky/failing. It renames a glossary's `name` (which changes its `fullyQualifiedName`) and then asserts:

```ts
await expect(page.locator('[data-testid="entity-header-name"]')).toHaveText(newName);
```

This can't reliably pass for two reasons:

1. **`entity-header-name` renders `displayName`** (`getEntityName()` → `displayName ?? name`). The fixture creates the glossary *with* a display name, and a `name` edit doesn't change it — so the header never equals the new `name`.
2. **After the FQN change, the glossary page can briefly reset its active selection to the first glossary** in the sidebar (e.g. *Critical Data Elements*) while the glossary list refetches, so the assertion often runs against the wrong glossary.

The rename `PATCH /api/v1/glossaries/{id}` itself returns `200` with the correct `name`/FQN — this is a test-robustness issue, not a product bug.

## Change (scoped to this spec only)

- Capture the **rename response** and assert `renamedGlossary.name === newName` (the authoritative check that the name/FQN edit took).
- Reload the renamed glossary via `visitGlossaryPage(displayName)` (display name is unchanged) and **retry a couple of times with `toPass`** until its route resolves — a fresh load fetches the full list before navigating, so it lands on the renamed glossary rather than the reset-to-first one.
- Fix cleanup: delete by the real quoted `fullyQualifiedName` from the response instead of the bare `newName` (the old value would 404 and leak the glossary).

No app/product code is touched.

## Testing

- [ ] `yarn playwright:run` → `Glossary.spec.ts` "Update glossary display name via rename modal"
- [ ] `yarn lint`

🤖 Generated with [Claude Code](https://claude.com/claude-code)