### PR TITLE
enhancement: Add server-side search support for Tier and Certification filters in Data Quality Dashboard

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DataQuality/DataQualityDashboard.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DataQuality/DataQualityDashboard.spec.ts
@@ -25,6 +25,7 @@ import { TagClass } from '../../../support/tag/TagClass';
 import { UserClass } from '../../../support/user/UserClass';
 import { createNewPage, uuid } from '../../../utils/common';
 import {
+  applyDashboardCertificationFilter,
   applyDashboardTagFilter,
   applyDashboardTierFilter,
   assertDimensionCard,
@@ -478,23 +479,21 @@ test.describe(
 
       await test.step('Filter by Owner and verify all API responses succeed', async () => {
         await page.getByRole('button', { name: 'Owner' }).click();
-        await expect(
-          page.locator("[data-testid='select-owner-tabs']")
-        ).toBeVisible();
+        await expect(page.getByTestId('select-owner-tabs')).toBeVisible();
         await waitForAllLoadersToDisappear(page);
         await page.getByRole('tab', { name: 'Users' }).click();
         await waitForAllLoadersToDisappear(page);
+        await expect(
+          page.getByTestId('owner-select-users-search-bar')
+        ).toBeVisible();
 
         const searchOwner = page.waitForResponse(
           'api/v1/search/query?q=*&index=user*'
         );
+        await page.getByTestId('owner-select-users-search-bar').clear();
         await page
-          .locator('[data-testid="owner-select-users-search-bar"]')
-          .clear();
-        await page.fill(
-          '[data-testid="owner-select-users-search-bar"]',
-          user1.getUserDisplayName()
-        );
+          .getByTestId('owner-select-users-search-bar')
+          .pressSequentially(user1.getUserDisplayName());
         await searchOwner;
         await waitForAllLoadersToDisappear(page);
 
@@ -706,20 +705,11 @@ test.describe(
         await goToDataQualityDashboard(page);
         await waitForAllLoadersToDisappear(page);
 
-        await page.getByRole('button', { name: 'Certification' }).click();
-        await page.getByTestId('search-input').fill(cert2.data.name);
-        await page.getByTestId(cert2.responseData.fullyQualifiedName).click();
-        const certApiDone = page.waitForResponse(
-          (res) =>
-            res.url().includes('/dataQualityReport') &&
-            res
-              .url()
-              .includes(
-                encodeURIComponent(cert2.responseData.fullyQualifiedName)
-              )
+        await applyDashboardCertificationFilter(
+          page,
+          cert2.data.name,
+          cert2.responseData.fullyQualifiedName
         );
-        await page.getByTestId('update-btn').click();
-        await certApiDone;
         await waitForAllLoadersToDisappear(page);
 
         // table4 has exactly one test case: Uniqueness → Failed

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/dataQuality.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/dataQuality.ts
@@ -412,49 +412,72 @@ export function captureReports(page: Page): CapturedReport[] {
   return captured;
 }
 
-/**
- * Opens the Tier filter dropdown on the Data Quality dashboard, selects the
- * given tier FQN, clicks Update, and waits for the first matching
- * dataQualityReport response to complete.
- */
+async function applyDashboardTagBasedFilter(
+  page: Page,
+  options: {
+    buttonName: 'Tier' | 'Tag' | 'Certification';
+    searchText: string;
+    optionFqn: string;
+  }
+): Promise<void> {
+  const { buttonName, searchText, optionFqn } = options;
+
+  await page.getByRole('button', { name: buttonName }).click();
+  await page.getByTestId('search-input').click();
+
+  const searchRes = page.waitForResponse(
+    (res) =>
+      res.url().includes('/api/v1/search/query') &&
+      res.url().includes('index=tag') &&
+      res.url().includes(`*${encodeURIComponent(searchText)}*`)
+  );
+  await page.getByTestId('search-input').fill(searchText);
+  await searchRes;
+
+  await page.getByTestId(optionFqn).click();
+
+  const reportRes = page.waitForResponse(
+    (res) =>
+      res.url().includes('/dataQualityReport') &&
+      res.url().includes(encodeURIComponent(optionFqn))
+  );
+  await page.getByTestId('update-btn').click();
+  await reportRes;
+}
+
 export async function applyDashboardTierFilter(
   page: Page,
   tierFqn: string
 ): Promise<void> {
-  await page.getByRole('button', { name: 'Tier' }).click();
-  await page.getByTestId('search-input').click();
-  await page.getByTestId('search-input').fill(tierFqn);
-  await page.getByTestId(tierFqn).click();
-  const apiResponse = page.waitForResponse(
-    (res) =>
-      res.url().includes('/dataQualityReport') &&
-      res.url().includes(encodeURIComponent(tierFqn))
-  );
-  await page.getByTestId('update-btn').click();
-  await apiResponse;
+  await applyDashboardTagBasedFilter(page, {
+    buttonName: 'Tier',
+    searchText: tierFqn,
+    optionFqn: tierFqn,
+  });
 }
 
-/**
- * Opens the Tag filter dropdown on the Data Quality dashboard, searches by
- * tag name, selects the option by FQN, clicks Update, and waits for the first
- * matching dataQualityReport response to complete.
- */
 export async function applyDashboardTagFilter(
   page: Page,
   tagName: string,
   tagFqn: string
 ): Promise<void> {
-  await page.getByRole('button', { name: 'Tag' }).click();
-  await page.getByTestId('search-input').click();
-  await page.getByTestId('search-input').fill(tagName);
-  await page.getByText(tagFqn).click();
-  const apiResponse = page.waitForResponse(
-    (res) =>
-      res.url().includes('/dataQualityReport') &&
-      res.url().includes(encodeURIComponent(tagFqn))
-  );
-  await page.getByTestId('update-btn').click();
-  await apiResponse;
+  await applyDashboardTagBasedFilter(page, {
+    buttonName: 'Tag',
+    searchText: tagName,
+    optionFqn: tagFqn,
+  });
+}
+
+export async function applyDashboardCertificationFilter(
+  page: Page,
+  certName: string,
+  certFqn: string
+): Promise<void> {
+  await applyDashboardTagBasedFilter(page, {
+    buttonName: 'Certification',
+    searchText: certName,
+    optionFqn: certFqn,
+  });
 }
 
 /**

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/dataQuality.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/dataQuality.ts
@@ -425,12 +425,16 @@ async function applyDashboardTagBasedFilter(
   await page.getByRole('button', { name: buttonName }).click();
   await page.getByTestId('search-input').click();
 
-  const searchRes = page.waitForResponse(
-    (res) =>
-      res.url().includes('/api/v1/search/query') &&
-      res.url().includes('index=tag') &&
-      res.url().includes(`*${encodeURIComponent(searchText)}*`)
-  );
+  const searchRes = page.waitForResponse((res) => {
+    if (!res.url().includes('/api/v1/search/query')) {
+      return false;
+    }
+    const parsed = new URL(res.url());
+    return (
+      parsed.searchParams.get('index') === 'tag' &&
+      (parsed.searchParams.get('q') ?? '').includes(`*${searchText}*`)
+    );
+  });
   await page.getByTestId('search-input').fill(searchText);
   await searchRes;
 

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/DataQualityDashboard/DataQualityDashboard.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/DataQualityDashboard/DataQualityDashboard.component.tsx
@@ -421,7 +421,7 @@ const DataQualityDashboard = ({
     if (isEmpty(query)) {
       setTierOptions((prev) => ({
         ...prev,
-        options: prev.defaultOptions,
+        options: [...selectedTierFilter, ...prev.defaultOptions],
       }));
     } else {
       setIsTierLoading(true);
@@ -463,7 +463,7 @@ const DataQualityDashboard = ({
     if (isEmpty(query)) {
       setCertificationOptions((prev) => ({
         ...prev,
-        options: prev.defaultOptions,
+        options: [...selectedCertificationFilter, ...prev.defaultOptions],
       }));
     } else {
       setIsCertificationLoading(true);

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/DataQualityDashboard/DataQualityDashboard.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/DataQualityDashboard/DataQualityDashboard.component.tsx
@@ -41,13 +41,11 @@ import {
 } from '../../../constants/DataQuality.constants';
 import { PROFILER_FILTER_RANGE } from '../../../constants/profiler.constant';
 import { SearchIndex } from '../../../enums/search.enum';
-import { Tag } from '../../../generated/entity/classification/tag';
 import { TestCaseStatus } from '../../../generated/tests/testCase';
 import { TestCaseResolutionStatusTypes } from '../../../generated/tests/testCaseResolutionStatus';
 import { EntityReference } from '../../../generated/type/entityReference';
 import { DataQualityPageTabs } from '../../../pages/DataQuality/DataQualityPage.interface';
 import { searchQuery } from '../../../rest/searchAPI';
-import { getTags } from '../../../rest/tagAPI';
 import { getSelectedOptionLabelString } from '../../../utils/AdvancedSearchUtils';
 import {
   formatDate,
@@ -165,29 +163,27 @@ const DataQualityDashboard = ({
   >([]);
   const [selectedCertificationFilter, setSelectedCertificationFilter] =
     useState<SearchDropdownOption[]>([]);
-  const [certification, setCertification] = useState<{
-    tags: Tag[];
-    isLoading: boolean;
+  const [certificationOptions, setCertificationOptions] = useState<{
+    defaultOptions: SearchDropdownOption[];
     options: SearchDropdownOption[];
   }>({
-    tags: [],
-    isLoading: true,
+    defaultOptions: [],
     options: [],
   });
+  const [isCertificationLoading, setIsCertificationLoading] = useState(false);
   const [selectedOwnerFilter, setSelectedOwnerFilter] =
     useState<EntityReference[]>();
 
   const [dateRangeObject, setDateRangeObject] =
     useState<DateRangeObject>(DEFAULT_RANGE_DATA);
-  const [tier, setTier] = useState<{
-    tags: Tag[];
-    isLoading: boolean;
+  const [tierOptions, setTierOptions] = useState<{
+    defaultOptions: SearchDropdownOption[];
     options: SearchDropdownOption[];
   }>({
-    tags: [],
-    isLoading: true,
+    defaultOptions: [],
     options: [],
   });
+  const [isTierLoading, setIsTierLoading] = useState(false);
   const [chartFilter, setChartFilter] = useState<DqDashboardChartFilters>({
     startTs: DEFAULT_RANGE_DATA.startTs,
     endTs: DEFAULT_RANGE_DATA.endTs,
@@ -236,20 +232,6 @@ const DataQualityDashboard = ({
       })) ?? []
     );
   }, [selectedOwnerFilter]);
-
-  const defaultTierOptions = useMemo(() => {
-    return tier.tags.map((op) => ({
-      key: op.fullyQualifiedName ?? op.name,
-      label: getEntityName(op),
-    }));
-  }, [tier]);
-
-  const defaultCertificationOptions = useMemo(() => {
-    return certification.tags.map((op) => ({
-      key: op.fullyQualifiedName ?? op.name,
-      label: getEntityName(op),
-    }));
-  }, [certification]);
 
   const handleTierChange = (tiers: SearchDropdownOption[] = []) => {
     setSelectedTierFilter(tiers);
@@ -415,43 +397,87 @@ const DataQualityDashboard = ({
     }
   };
 
+  const fetchTierOptions = async (query = WILD_CARD_CHAR) => {
+    const response = await searchQuery({
+      searchIndex: SearchIndex.TAG,
+      query: query === WILD_CARD_CHAR ? query : `*${query}*`,
+      filters: 'disabled:false AND classification.name:Tier',
+      pageSize: PAGE_SIZE_BASE,
+    });
+    const hits = response.hits.hits;
+    const tierFilterOptions = hits.map((hit) => {
+      const source = hit._source;
+
+      return {
+        key: source.fullyQualifiedName ?? source.name,
+        label: getEntityName(source),
+      };
+    });
+
+    return tierFilterOptions;
+  };
+
   const handleTierSearch = async (query: string) => {
-    if (query) {
-      setTier((prev) => ({
+    if (isEmpty(query)) {
+      setTierOptions((prev) => ({
         ...prev,
-        options: prev.options.filter(
-          (value) =>
-            value.label
-              .toLocaleLowerCase()
-              .includes(query.toLocaleLowerCase()) ||
-            value.key.toLocaleLowerCase().includes(query.toLocaleLowerCase())
-        ),
+        options: prev.defaultOptions,
       }));
     } else {
-      setTier((prev) => ({
-        ...prev,
-        options: defaultTierOptions,
-      }));
+      setIsTierLoading(true);
+      try {
+        const response = await fetchTierOptions(query);
+        setTierOptions((prev) => ({
+          ...prev,
+          options: response,
+        }));
+      } catch {
+        // we will not show the toast error message for suggestion API
+      } finally {
+        setIsTierLoading(false);
+      }
     }
   };
 
+  const fetchCertificationOptions = async (query = WILD_CARD_CHAR) => {
+    const response = await searchQuery({
+      searchIndex: SearchIndex.TAG,
+      query: query === WILD_CARD_CHAR ? query : `*${query}*`,
+      filters: 'disabled:false AND classification.name:Certification',
+      pageSize: PAGE_SIZE_BASE,
+    });
+    const hits = response.hits.hits;
+    const certificationFilterOptions = hits.map((hit) => {
+      const source = hit._source;
+
+      return {
+        key: source.fullyQualifiedName ?? source.name,
+        label: getEntityName(source),
+      };
+    });
+
+    return certificationFilterOptions;
+  };
+
   const handleCertificationSearch = async (query: string) => {
-    if (query) {
-      setCertification((prev) => ({
+    if (isEmpty(query)) {
+      setCertificationOptions((prev) => ({
         ...prev,
-        options: defaultCertificationOptions.filter(
-          (value) =>
-            value.label
-              .toLocaleLowerCase()
-              .includes(query.toLocaleLowerCase()) ||
-            value.key.toLocaleLowerCase().includes(query.toLocaleLowerCase())
-        ),
+        options: prev.defaultOptions,
       }));
     } else {
-      setCertification((prev) => ({
-        ...prev,
-        options: defaultCertificationOptions,
-      }));
+      setIsCertificationLoading(true);
+      try {
+        const response = await fetchCertificationOptions(query);
+        setCertificationOptions((prev) => ({
+          ...prev,
+          options: response,
+        }));
+      } catch {
+        // we will not show the toast error message for suggestion API
+      } finally {
+        setIsCertificationLoading(false);
+      }
     }
   };
 
@@ -552,62 +578,54 @@ const DataQualityDashboard = ({
     }
   };
 
-  const getTierTag = async () => {
-    setTier((prev) => ({ ...prev, isLoading: true }));
-    try {
-      const { data } = await getTags({
-        parent: 'Tier',
-      });
-
-      setTier((prev) => ({
+  const fetchDefaultTierOptions = async () => {
+    if (tierOptions.defaultOptions.length) {
+      setTierOptions((prev) => ({
         ...prev,
-        tags: data,
-        options: data.map((op) => ({
-          key: op.fullyQualifiedName ?? op.name,
-          label: getEntityName(op),
-        })),
+        options: [...selectedTierFilter, ...prev.defaultOptions],
+      }));
+
+      return;
+    }
+
+    try {
+      setIsTierLoading(true);
+      const response = await fetchTierOptions();
+      setTierOptions((prev) => ({
+        ...prev,
+        defaultOptions: response,
+        options: response,
       }));
     } catch {
-      // error
+      // we will not show the toast error message for search API
     } finally {
-      setTier((prev) => ({ ...prev, isLoading: false }));
+      setIsTierLoading(false);
     }
   };
 
-  const fetchDefaultTierOptions = () => {
-    setTier((prev) => ({
-      ...prev,
-      options: defaultTierOptions,
-    }));
-  };
-
-  const getCertificationTag = async () => {
-    setCertification((prev) => ({ ...prev, isLoading: true }));
-    try {
-      const { data } = await getTags({
-        parent: 'Certification',
-      });
-
-      setCertification((prev) => ({
+  const fetchDefaultCertificationOptions = async () => {
+    if (certificationOptions.defaultOptions.length) {
+      setCertificationOptions((prev) => ({
         ...prev,
-        tags: data,
-        options: data.map((op) => ({
-          key: op.fullyQualifiedName ?? op.name,
-          label: getEntityName(op),
-        })),
+        options: [...selectedCertificationFilter, ...prev.defaultOptions],
+      }));
+
+      return;
+    }
+
+    try {
+      setIsCertificationLoading(true);
+      const response = await fetchCertificationOptions();
+      setCertificationOptions((prev) => ({
+        ...prev,
+        defaultOptions: response,
+        options: response,
       }));
     } catch {
-      // error
+      // we will not show the toast error message for search API
     } finally {
-      setCertification((prev) => ({ ...prev, isLoading: false }));
+      setIsCertificationLoading(false);
     }
-  };
-
-  const fetchDefaultCertificationOptions = () => {
-    setCertification((prev) => ({
-      ...prev,
-      options: defaultCertificationOptions,
-    }));
   };
 
   const handleOwnerChange = (owners: EntityReference[] = []) => {
@@ -642,10 +660,10 @@ const DataQualityDashboard = ({
       return;
     }
     if (showTierFilter) {
-      getTierTag();
+      fetchDefaultTierOptions();
     }
     if (showCertificationFilter) {
-      getCertificationTag();
+      fetchDefaultCertificationOptions();
     }
     if (showTagsFilter) {
       fetchDefaultTagOptions();
@@ -689,26 +707,26 @@ const DataQualityDashboard = ({
 
   const tierFilter = useMemo(
     () => ({
-      options: tier.options,
+      options: uniqBy(tierOptions.options, 'key'),
       selectedKeys: selectedTierFilter,
       onChange: handleTierChange,
       onGetInitialOptions: fetchDefaultTierOptions,
       onSearch: handleTierSearch,
-      isSuggestionsLoading: tier.isLoading,
+      isSuggestionsLoading: isTierLoading,
     }),
-    [selectedTierFilter, tier]
+    [isTierLoading, tierOptions, selectedTierFilter]
   );
 
   const certificationFilter = useMemo(
     () => ({
-      options: certification.options,
+      options: uniqBy(certificationOptions.options, 'key'),
       selectedKeys: selectedCertificationFilter,
       onChange: handleCertificationChange,
       onGetInitialOptions: fetchDefaultCertificationOptions,
       onSearch: handleCertificationSearch,
-      isSuggestionsLoading: certification.isLoading,
+      isSuggestionsLoading: isCertificationLoading,
     }),
-    [selectedCertificationFilter, certification]
+    [isCertificationLoading, certificationOptions, selectedCertificationFilter]
   );
 
   const dataProducts = useMemo(

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/DataQualityDashboard/DataQualityDashboard.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/DataQualityDashboard/DataQualityDashboard.test.tsx
@@ -1088,7 +1088,7 @@ describe('DataQualityDashboard', () => {
       ).toBeInTheDocument();
     });
 
-    it('does not call getTags API when both tier and certification are in hiddenFilters', async () => {
+    it('does not call getTags API when tier is in hiddenFilters', async () => {
       render(
         <DataQualityDashboard hiddenFilters={['tier', 'certification']} />,
         { wrapper: MemoryRouter }
@@ -1103,19 +1103,23 @@ describe('DataQualityDashboard', () => {
       expect(mockGetTags).not.toHaveBeenCalled();
     });
 
-    it('fetches only Certification (not Tier) when tier is in hiddenFilters', async () => {
+    it('fetches Certification via searchQuery when tier is in hiddenFilters', async () => {
       render(<DataQualityDashboard hiddenFilters={['tier']} />, {
         wrapper: MemoryRouter,
       });
 
       await waitFor(() => {
-        expect(mockGetTags).toHaveBeenCalledWith({ parent: 'Certification' });
+        expect(mockSearchQuery).toHaveBeenCalledWith(
+          expect.objectContaining({
+            filters: 'disabled:false AND classification.name:Certification',
+          })
+        );
       });
 
       expect(mockGetTags).not.toHaveBeenCalledWith({ parent: 'Tier' });
     });
 
-    it('fetches only Tier (not Certification) when certification is in hiddenFilters', async () => {
+    it('does not fetch Certification when certification is in hiddenFilters', async () => {
       render(<DataQualityDashboard hiddenFilters={['certification']} />, {
         wrapper: MemoryRouter,
       });
@@ -1124,7 +1128,11 @@ describe('DataQualityDashboard', () => {
         expect(mockGetTags).toHaveBeenCalledWith({ parent: 'Tier' });
       });
 
-      expect(mockGetTags).not.toHaveBeenCalledWith({ parent: 'Certification' });
+      expect(mockSearchQuery).not.toHaveBeenCalledWith(
+        expect.objectContaining({
+          filters: 'disabled:false AND classification.name:Certification',
+        })
+      );
     });
 
     it('does not call tag search API when tags is in hiddenFilters', async () => {
@@ -1141,8 +1149,8 @@ describe('DataQualityDashboard', () => {
         ).toBeInTheDocument();
       });
 
-      // only glossaryTerms fetch runs — searchQuery called once, not twice
-      expect(mockSearchQuery).toHaveBeenCalledTimes(1);
+      // certification + glossaryTerms fetches run — searchQuery called twice
+      expect(mockSearchQuery).toHaveBeenCalledTimes(2);
     });
 
     it('does not call glossary term search API when glossaryTerms is in hiddenFilters', async () => {
@@ -1161,8 +1169,8 @@ describe('DataQualityDashboard', () => {
         ).toBeInTheDocument();
       });
 
-      // only tags fetch runs — searchQuery called once, not twice
-      expect(mockSearchQuery).toHaveBeenCalledTimes(1);
+      // certification + tags fetches run — searchQuery called twice
+      expect(mockSearchQuery).toHaveBeenCalledTimes(2);
     });
 
     it('hideFilterBar is a hard override — hides the entire bar even when hiddenFilters is set', () => {
@@ -1384,7 +1392,7 @@ describe('DataQualityDashboard', () => {
           (args[0] as Record<string, unknown>).query === '***'
       );
 
-      expect(wildcardCalls.length).toBeGreaterThanOrEqual(3); // tags + glossaryTerms + data products
+      expect(wildcardCalls.length).toBeGreaterThanOrEqual(4); // tags + glossaryTerms + data products + certification
       expect(tripleStarCalls).toHaveLength(0);
     });
 

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/DataQualityDashboard/DataQualityDashboard.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/DataQualityDashboard/DataQualityDashboard.test.tsx
@@ -26,13 +26,6 @@ import { getDataQualityPagePath } from '../../../utils/RouterUtils';
 import { IncidentTimeMetricsType } from '../DataQuality.interface';
 import DataQualityDashboard from './DataQualityDashboard.component';
 
-const mockGetTags = jest.fn().mockResolvedValue({
-  data: [
-    { id: '1', name: 'Tier1', fullyQualifiedName: 'Tier.Tier1' },
-    { id: '2', name: 'Tier2', fullyQualifiedName: 'Tier.Tier2' },
-  ],
-});
-
 const mockSearchQuery = jest.fn().mockResolvedValue({
   hits: {
     hits: [
@@ -101,10 +94,6 @@ jest.mock('../../../utils/RouterUtils', () => ({
 jest.mock('../../../components/PageHeader/PageHeader.component', () =>
   jest.fn().mockImplementation(() => <div data-testid="page-header" />)
 );
-
-jest.mock('../../../rest/tagAPI', () => ({
-  getTags: (...args: unknown[]) => mockGetTags(...args),
-}));
 
 jest.mock('../../../rest/searchAPI', () => ({
   searchQuery: (...args: unknown[]) => mockSearchQuery(...args),
@@ -672,7 +661,7 @@ describe('DataQualityDashboard', () => {
     });
 
     it('should handle API errors gracefully for tag fetching', async () => {
-      mockGetTags.mockRejectedValueOnce(new Error('API Error'));
+      mockSearchQuery.mockRejectedValueOnce(new Error('API Error'));
 
       render(<DataQualityDashboard />, { wrapper: MemoryRouter });
 
@@ -841,7 +830,6 @@ describe('DataQualityDashboard', () => {
         ).toBeInTheDocument();
       });
 
-      expect(mockGetTags).not.toHaveBeenCalled();
       expect(mockSearchQuery).not.toHaveBeenCalled();
     });
 
@@ -856,7 +844,6 @@ describe('DataQualityDashboard', () => {
         ).toBeInTheDocument();
       });
 
-      expect(mockGetTags).not.toHaveBeenCalled();
       expect(mockSearchQuery).not.toHaveBeenCalled();
     });
 
@@ -864,7 +851,6 @@ describe('DataQualityDashboard', () => {
       render(<DataQualityDashboard />, { wrapper: MemoryRouter });
 
       await waitFor(() => {
-        expect(mockGetTags).toHaveBeenCalled();
         expect(mockSearchQuery).toHaveBeenCalled();
       });
     });
@@ -1088,7 +1074,7 @@ describe('DataQualityDashboard', () => {
       ).toBeInTheDocument();
     });
 
-    it('does not call getTags API when tier is in hiddenFilters', async () => {
+    it('does not fetch Tier or Certification when both are in hiddenFilters', async () => {
       render(
         <DataQualityDashboard hiddenFilters={['tier', 'certification']} />,
         { wrapper: MemoryRouter }
@@ -1100,10 +1086,19 @@ describe('DataQualityDashboard', () => {
         ).toBeInTheDocument();
       });
 
-      expect(mockGetTags).not.toHaveBeenCalled();
+      expect(mockSearchQuery).not.toHaveBeenCalledWith(
+        expect.objectContaining({
+          filters: 'disabled:false AND classification.name:Tier',
+        })
+      );
+      expect(mockSearchQuery).not.toHaveBeenCalledWith(
+        expect.objectContaining({
+          filters: 'disabled:false AND classification.name:Certification',
+        })
+      );
     });
 
-    it('fetches Certification via searchQuery when tier is in hiddenFilters', async () => {
+    it('fetches Certification but not Tier when tier is in hiddenFilters', async () => {
       render(<DataQualityDashboard hiddenFilters={['tier']} />, {
         wrapper: MemoryRouter,
       });
@@ -1116,16 +1111,24 @@ describe('DataQualityDashboard', () => {
         );
       });
 
-      expect(mockGetTags).not.toHaveBeenCalledWith({ parent: 'Tier' });
+      expect(mockSearchQuery).not.toHaveBeenCalledWith(
+        expect.objectContaining({
+          filters: 'disabled:false AND classification.name:Tier',
+        })
+      );
     });
 
-    it('does not fetch Certification when certification is in hiddenFilters', async () => {
+    it('fetches Tier but not Certification when certification is in hiddenFilters', async () => {
       render(<DataQualityDashboard hiddenFilters={['certification']} />, {
         wrapper: MemoryRouter,
       });
 
       await waitFor(() => {
-        expect(mockGetTags).toHaveBeenCalledWith({ parent: 'Tier' });
+        expect(mockSearchQuery).toHaveBeenCalledWith(
+          expect.objectContaining({
+            filters: 'disabled:false AND classification.name:Tier',
+          })
+        );
       });
 
       expect(mockSearchQuery).not.toHaveBeenCalledWith(
@@ -1149,8 +1152,8 @@ describe('DataQualityDashboard', () => {
         ).toBeInTheDocument();
       });
 
-      // certification + glossaryTerms fetches run — searchQuery called twice
-      expect(mockSearchQuery).toHaveBeenCalledTimes(2);
+      // tier + certification + glossaryTerms fetches run — searchQuery called 3x
+      expect(mockSearchQuery).toHaveBeenCalledTimes(3);
     });
 
     it('does not call glossary term search API when glossaryTerms is in hiddenFilters', async () => {
@@ -1169,8 +1172,8 @@ describe('DataQualityDashboard', () => {
         ).toBeInTheDocument();
       });
 
-      // certification + tags fetches run — searchQuery called twice
-      expect(mockSearchQuery).toHaveBeenCalledTimes(2);
+      // tier + certification + tags fetches run — searchQuery called 3x
+      expect(mockSearchQuery).toHaveBeenCalledTimes(3);
     });
 
     it('hideFilterBar is a hard override — hides the entire bar even when hiddenFilters is set', () => {


### PR DESCRIPTION
### Describe your changes:

## Demo


https://github.com/user-attachments/assets/dc25f980-a638-451e-b216-436ef55cd540



Fixes [open-metadata/openmetadata-collate#4283](https://github.com/open-metadata/openmetadata-collate/issues/4283)

Migrate the **Tier** and **Certification** filters on the Data Quality dashboard from client-side filtering to server-side search, matching the pattern already used by the **Tag**, **Glossary Term**, and **Data Product** filters next to them.

**Before:** both filters call `GET /api/v1/tags?parent=<Tier|Certification>` once on mount, store the result in component state, and the dropdown searches that in-memory array with `String.includes()`. Anything past the first page is unreachable from the filter.

**After:** both filters hit `/api/v1/search/query` (`SearchIndex.TAG`) with `disabled:false AND classification.name:<Tier|Certification>`, wildcarding the typed query as `*<query>*`. Identical caching/loading behavior to the existing tag/glossary/data-product filters.

#
### Type of change:
- [x] Improvement

#
### High-level design:

- Replaced `getTierTag()` / `getCertificationTag()` (using `getTags({ parent: ... })`) with `fetchTierOptions(query)` / `fetchCertificationOptions(query)` calling `searchQuery({ searchIndex: SearchIndex.TAG, query, filters: 'disabled:false AND classification.name:<X>', pageSize: PAGE_SIZE_BASE })`.
- Restructured the `tier` / `certification` state from `{ tags, isLoading, options }` to `{ defaultOptions, options }` + separate `isTierLoading` / `isCertificationLoading` booleans — mirrors `tagOptions` / `glossaryTermOptions` / `dataProductOptions`.
- Dropped the `defaultTierOptions` / `defaultCertificationOptions` `useMemo`s — `defaultOptions` now lives in state.
- Wired the new `fetchDefaultTierOptions` / `fetchDefaultCertificationOptions` into the existing `useEffect` initial-load block.
- Removed the now-unused `getTags` and `Tag` imports from `DataQualityDashboard.component.tsx`.

#
### Tests:

#### Use cases covered
- Open the Tier dropdown on the Data Quality dashboard → wildcard `searchQuery` populates defaults, typing narrows via server search.
- Open the Certification dropdown → same flow with `classification.name:Certification`.
- Tier and Certification dropdowns each load the **full** catalog as the user types, not just the first 15 tags.
- Selected tiers/certifications remain visible when the dropdown is re-opened after a search clears.
- No regression on Tag, Glossary Term, Data Product, or Owner filters.

#### Unit tests
- [x] Updated `DataQualityDashboard.test.tsx`:
  - Three assertions that checked `mockGetTags` was called with `{ parent: 'Tier' }` / `{ parent: 'Certification' }` now check `mockSearchQuery` was called with the matching classification filter.
  - Two `mockSearchQuery` call-count assertions bumped from 1 → 2 (tier + certification both go through `searchQuery` now).
  - Wildcard-on-mount assertion bumped from `>= 3` → `>= 4` to include the new certification call.
- All 61 existing tests still pass.

#### Playwright (UI) tests
- [x] Updated `playwright/utils/dataQuality.ts`:
  - `applyDashboardTierFilter` / `applyDashboardTagFilter` now wait for the typed `/api/v1/search/query?...index=tag&q=*<text>*...` response before clicking the option, so they don't race the server response now that all three filters are async.
  - New `applyDashboardCertificationFilter` helper following the same shape.
  - DRY'd the three helpers into a single private `applyDashboardTagBasedFilter` — they were 95% duplicated.
- Updated `DataQualityDashboard.spec.ts`:
  - Replaced the inline Certification filter block with `applyDashboardCertificationFilter`.
- Full DQ dashboard suite re-run: **10/11 tests pass**. The one remaining failure is an unrelated pie-chart navigation race (`Test Case Result pie chart segment click redirects to Test Cases with correct status`) that fails on `main` too.

#### Manual testing performed
1. Seeded 30 certification tags via `POST /api/v1/tags` so the classification has well over the previous 15-tag page-size limit.
2. Opened **Data Quality → Dashboard**, expanded the **Certification** dropdown, and typed substrings of tags that previously sat outside the first page (e.g. `ISO`, `SOC`, `FedRAMP`) — they now show up via the server search.
3. Same flow for Tier filter with custom tiers added.
4. Verified selected items are restored when the dropdown is re-opened with an empty query.

#
### UI screen recording / screenshots:

Not applicable — behavior matches the existing Tag / Glossary Term filter dropdowns visually; only the data-fetch path changed.

#
### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [x] For UI changes: covered by existing screenshots of the unchanged dropdown — no visual diff.
- [x] I have added tests (unit + Playwright) and listed them above.
- [x] Improvement: tests added around the new logic.