### PR TITLE
fix(workflow-builder): event-based trigger filters silently reject all entities (GitHub Sink + approval workflows)

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/WorkflowDefinitions/WorkflowBuilder/forms/EventTriggerFilterSection.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/WorkflowDefinitions/WorkflowBuilder/forms/EventTriggerFilterSection.test.tsx
@@ -1,0 +1,85 @@
+/*
+ *  Copyright 2025 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+import { render } from '@testing-library/react';
+import { SearchOutputType } from '../../../Explore/AdvanceSearchProvider/AdvanceSearchProvider.interface';
+import { EventTriggerFilterSection } from './EventTriggerFilterSection';
+
+const queryBuilderSectionProps: Array<{ outputType?: SearchOutputType }> = [];
+
+jest.mock('./QueryBuilderSection', () => ({
+  QueryBuilderSection: (props: { outputType?: SearchOutputType }) => {
+    queryBuilderSectionProps.push(props);
+
+    return <div data-testid="mock-query-builder-section" />;
+  },
+}));
+
+jest.mock('../../../../contexts/WorkflowModeContext', () => ({
+  useWorkflowModeContext: jest.fn(() => ({
+    isFormDisabled: false,
+    mode: 'edit',
+    isEditMode: true,
+    isViewMode: false,
+  })),
+}));
+
+jest.mock('@openmetadata/ui-core-components', () => ({
+  Button: (props: { onPress?: () => void; children?: React.ReactNode }) => (
+    <button onClick={props.onPress}>{props.children}</button>
+  ),
+  Card: (props: { children?: React.ReactNode }) => <div>{props.children}</div>,
+}));
+
+jest.mock('@untitledui/icons', () => ({
+  Plus: () => null,
+  XClose: () => null,
+}));
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+describe('EventTriggerFilterSection', () => {
+  beforeEach(() => {
+    queryBuilderSectionProps.length = 0;
+  });
+
+  it('passes outputType=JSONLogic to QueryBuilderSection', () => {
+    render(
+      <EventTriggerFilterSection
+        triggerFilter='{"==":[{"var":"name"},"mysql_sample"]}'
+        onTriggerFilterChange={() => undefined}
+      />
+    );
+
+    expect(queryBuilderSectionProps).toHaveLength(1);
+    expect(queryBuilderSectionProps[0].outputType).toBe(
+      SearchOutputType.JSONLogic
+    );
+  });
+
+  it('does not pass outputType=ElasticSearch — RuleEngine does not accept ES queries and event-based workflows would silently fail', () => {
+    render(
+      <EventTriggerFilterSection
+        triggerFilter='{"==":[{"var":"name"},"x"]}'
+        onTriggerFilterChange={() => undefined}
+      />
+    );
+
+    expect(queryBuilderSectionProps).toHaveLength(1);
+    expect(queryBuilderSectionProps[0].outputType).not.toBe(
+      SearchOutputType.ElasticSearch
+    );
+  });
+});

--- a/openmetadata-ui/src/main/resources/ui/src/components/WorkflowDefinitions/WorkflowBuilder/forms/EventTriggerFilterSection.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/WorkflowDefinitions/WorkflowBuilder/forms/EventTriggerFilterSection.tsx
@@ -94,7 +94,7 @@ export const EventTriggerFilterSection: React.FC<
             entityTypes={entityType}
             forceReadOnly={lockFields}
             label="Filter"
-            outputType={SearchOutputType.ElasticSearch}
+            outputType={SearchOutputType.JSONLogic}
             value={triggerFilter}
             onChange={(value: string) => {
               onTriggerFilterChange?.(value || '');


### PR DESCRIPTION
## Fix

`EventTriggerFilterSection.tsx` was wired to emit Elasticsearch query DSL for event-based trigger filters. The OM schema (`eventBasedEntityTrigger.json`) specifies the filter must be JsonLogic — the filter is evaluated by `RuleEngine.apply()`, which only understands JsonLogic.

```diff
- outputType={SearchOutputType.ElasticSearch}
+ outputType={SearchOutputType.JSONLogic}
```

## Why this breaks event-based workflows on `main`

1. UI saves filter as ES query JSON, e.g. `{"query":{"bool":{"must":[{"term":{"name.keyword":"mysql_sample"}}]}}}`
2. `FilterEntityImpl` passes that string to `RuleEngine.apply()`, which expects JsonLogic
3. `RuleEngine` cannot parse, hits its `try/catch`, returns `false`
4. `passesJsonFilter = Boolean.TRUE.equals(false)` = `false` → entity rejected
5. Trigger workflow takes the `${!passesFilter}` branch to `endEvent` in <100ms; main workflow's `CallActivity` is never invoked
6. No exception surfaced — clean conditional skip

User-visible: event-based workflows (GitHub Sink, EventBased approval workflows, custom event-based workflows) appear deployed and healthy but never fire when entities are created or updated.

## Test added

`EventTriggerFilterSection.test.tsx` (new) — Jest unit test that mocks `QueryBuilderSection` and asserts the `outputType` prop it receives. Two cases:

1. `outputType === SearchOutputType.JSONLogic` (positive — what the fix produces)
2. `outputType !== SearchOutputType.ElasticSearch` (regression guard — fails deterministically if anyone changes it back)

This is the smallest possible test that pins the contract this component has with `QueryBuilderSection`. It would have failed the day the wrong output type was wired in.

## Why this wasn't caught earlier

**Jest unit tests.** No test file existed for `EventTriggerFilterSection.tsx`. Sibling components like `MetadataFormSection`, `SinkTaskForm` had `.test.tsx` files; this one didn't. Coverage gap. **→ Filled by this PR.**

**Backend unit tests.** `FilterEntityImplTest` has 17 tests, all targeting `passesFieldBasedFilter` (field include/exclude lists). The JSON-filter branch — `passesJsonFilter` / `RuleEngine.apply` — has zero coverage in any input format.

**Backend integration tests.** `WorkflowDefinitionResourceIT.test_EntitySpecificFiltering` does cover the full event-based path end-to-end, but the test crafts filters directly via API in correct JsonLogic format. It exercises the OM contract correctly; it cannot catch what the UI emits.

**Playwright e2e.** 20+ workflow Playwright specs exist (`Workflow.utils.ts`, `*Workflow.spec.ts`, `UserApprovalWorkflow.utils.ts`, etc.) but the entire coverage of the event-based trigger filter UI amounts to one line:

```
WorkflowOssRestrictions.spec.ts:509
  test('add-event-filter-button is enabled in OSS')
```

A pure visibility test — checks the "Add Filter" button renders in OSS context vs Collate. It does not click the button, does not build a filter rule via the QueryBuilder widget, does not save, does not assert the saved filter format, and does not fire an entity event to verify the workflow executes (or not, in the negative case). All other workflow Playwright specs exercise approval flows, drag-and-drop, save flows — none of them assert what gets serialized into the trigger config or whether the configured workflow actually fires for a matching entity event.

A focused Playwright spec that creates an event-based workflow via the UI, builds a filter rule, saves, fetches via API, and asserts the saved filter content is JsonLogic (and optionally fires an entity event and asserts execution) is the next gap to fill — left out of this PR to keep the change minimal. Happy to send as a follow-up.

## Verification

End-to-end tested on `main` after the fix, six scenarios:

| Case | Behavior |
|------|----------|
| Equality filter, matching entity | Workflow fires (~2-6s), sink task executes, side effect produced |
| Equality filter, non-matching entity | Workflow short-circuits at filter (~10ms) — filter actually filters |
| `in` operator on string field | Matches/non-matches correctly |
| `and` combination | Short-circuits on first false condition |
| No filter | All entities pass — workflow always fires |
| Multiple entity types in one workflow | Per-type filters honored |

QueryBuilder now saves filters as JsonLogic, e.g. `{"==":[{"var":"name"},"mysql_sample"]}`. New Jest test pinned to assert this contract.

## Migration

Existing workflows saved with the ES-query format will not match after this fix — `RuleEngine` still cannot evaluate them. Users should re-save the trigger filter via the UI to regenerate it in JsonLogic. A targeted DB migration is out of scope for this PR.