### PR TITLE
Pass service details to ingeation menu items

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/Settings/Services/Ingestion/MetadataAgentsWidget/MetadataAgentsWidget.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Settings/Services/Ingestion/MetadataAgentsWidget/MetadataAgentsWidget.tsx
@@ -80,9 +80,10 @@ function MetadataAgentsWidget({
       serviceUtilClassBase.getExtraIngestionMenuItems(
         serviceCategory as ServiceCategory,
         serviceName,
-        navigate
+        navigate,
+        serviceDetails
       ),
-    [navigate, serviceCategory, serviceName]
+    [navigate, serviceCategory, serviceDetails, serviceName]
   );
 
   const handlePipelineIdToFetchStatus = useCallback((pipelineId?: string) => {

--- a/openmetadata-ui/src/main/resources/ui/src/utils/ServiceUtilClassBase.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/ServiceUtilClassBase.ts
@@ -563,7 +563,8 @@ class ServiceUtilClassBase {
   public getExtraIngestionMenuItems(
     _serviceCategory: ServiceCategory,
     _serviceName?: string,
-    _navigate?: (path: string) => void
+    _navigate?: (path: string) => void,
+    _serviceDetails?: ServicesType
   ): MenuProps['items'] {
     return [];
   }

--- a/openmetadata-ui/src/main/resources/ui/src/utils/ServiceUtilsClassBase.test.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/ServiceUtilsClassBase.test.ts
@@ -11,6 +11,8 @@
  *  limitations under the License.
  */
 import { ExplorePageTabs } from '../enums/Explore.enum';
+import { ServiceCategory } from '../enums/service.enum';
+import { ServicesType } from '../interface/service.interface';
 import serviceUtilClassBase, {
   ServiceUtilClassBase,
 } from './ServiceUtilClassBase';
@@ -115,5 +117,89 @@ describe('ServiceUtilClassBase', () => {
     );
 
     expect(result).toEqual(ExplorePageTabs.TABLES);
+  });
+
+  describe('getExtraIngestionMenuItems', () => {
+    it('returns empty array when called with only serviceCategory', () => {
+      const result = serviceUtilClassBase.getExtraIngestionMenuItems(
+        ServiceCategory.DATABASE_SERVICES
+      );
+
+      expect(result).toEqual([]);
+    });
+
+    it('returns empty array when called with serviceCategory, serviceName and navigate', () => {
+      const result = serviceUtilClassBase.getExtraIngestionMenuItems(
+        ServiceCategory.DATABASE_SERVICES,
+        'my-service',
+        jest.fn()
+      );
+
+      expect(result).toEqual([]);
+    });
+
+    it('returns empty array when serviceDetails is provided', () => {
+      const serviceDetails = {
+        serviceType: 'Snowflake',
+        connection: {
+          config: {
+            type: 'Snowflake',
+            policyAgentConfig: { enabled: true },
+          },
+        },
+      } as unknown as ServicesType;
+
+      const result = serviceUtilClassBase.getExtraIngestionMenuItems(
+        ServiceCategory.DATABASE_SERVICES,
+        'my-snowflake-service',
+        jest.fn(),
+        serviceDetails
+      );
+
+      expect(result).toEqual([]);
+    });
+
+    it('allows a subclass override to receive and use serviceDetails', () => {
+      class TestOverride extends ServiceUtilClassBase {
+        public getExtraIngestionMenuItems(
+          _serviceCategory: ServiceCategory,
+          _serviceName?: string,
+          _navigate?: (path: string) => void,
+          serviceDetails?: ServicesType
+        ) {
+          const config = (
+            serviceDetails as {
+              connection?: { config?: { policyAgentConfig?: { enabled?: boolean } } };
+            }
+          )?.connection?.config;
+          const enabled = config?.policyAgentConfig?.enabled;
+
+          return enabled ? [{ key: 'custom-item', label: 'Custom' }] : [];
+        }
+      }
+
+      const override = new TestOverride();
+
+      const withEnabled = override.getExtraIngestionMenuItems(
+        ServiceCategory.DATABASE_SERVICES,
+        'svc',
+        jest.fn(),
+        {
+          connection: { config: { policyAgentConfig: { enabled: true } } },
+        } as unknown as ServicesType
+      );
+
+      const withDisabled = override.getExtraIngestionMenuItems(
+        ServiceCategory.DATABASE_SERVICES,
+        'svc',
+        jest.fn(),
+        {
+          connection: { config: { policyAgentConfig: { enabled: false } } },
+        } as unknown as ServicesType
+      );
+
+      expect(withEnabled).toHaveLength(1);
+      expect(withDisabled).toHaveLength(0);
+    });
   });
 });

--- a/openmetadata-ui/src/main/resources/ui/src/utils/ServiceUtilsClassBase.test.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/ServiceUtilsClassBase.test.ts
@@ -169,7 +169,9 @@ describe('ServiceUtilClassBase', () => {
         ) {
           const config = (
             serviceDetails as {
-              connection?: { config?: { policyAgentConfig?: { enabled?: boolean } } };
+              connection?: {
+                config?: { policyAgentConfig?: { enabled?: boolean } };
+              };
             }
           )?.connection?.config;
           const enabled = config?.policyAgentConfig?.enabled;


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:

This updates the ingestion menu extension point to provide full service details to downstream overrides.
Previously, the extension point only exposed the service category and service name, which was not enough for custom implementations to make decisions based on service configuration.

With this change, custom implementations can now access the complete service details and conditionally show menu options based on service-specific configurations.

### Use Case
Collate introduced a Policy Agent feature for database services. The “Add Policy Agent” option should only appear when the feature is enabled for a specific service.

This change allows the override to check the service configuration and display the option only for supported services.
