### PR TITLE
fix(ui): strip cross-discriminator fields from profileSampleConfig payload

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DataQuality/ProfilerIngestionForm.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DataQuality/ProfilerIngestionForm.spec.ts
@@ -10,111 +10,17 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-import { expect, Page } from '@playwright/test';
-import { SERVICE_TYPE } from '../../../constant/service';
+import { expect } from '@playwright/test';
 import { DatabaseServiceClass } from '../../../support/entity/service/DatabaseServiceClass';
 import { performAdminLogin } from '../../../utils/admin';
-import { redirectToHomePage } from '../../../utils/common';
-import { waitForAllLoadersToDisappear } from '../../../utils/entity';
-import { visitServiceDetailsPage } from '../../../utils/service';
+import {
+  openProfilerForm,
+  selectSampleConfigType,
+  submitAndCaptureCreatePayload,
+} from '../../../utils/profilerForm';
 import { test } from '../../fixtures/pages';
 
-const PROFILE_PIPELINES_URL = '/api/v1/services/ingestionPipelines';
-
-type ProfileSampleConfig =
-  | undefined
-  | {
-      sampleConfigType?: 'STATIC' | 'DYNAMIC';
-      config?: Record<string, unknown>;
-    };
-
 const service = new DatabaseServiceClass();
-
-const openProfilerForm = async (page: Page) => {
-  await redirectToHomePage(page);
-  await visitServiceDetailsPage(
-    page,
-    {
-      type: SERVICE_TYPE.Database,
-      name: service.entity.name,
-      displayName: service.entity.name,
-    },
-    false
-  );
-
-  await page.click('[data-testid="agents"]');
-  await page.getByTestId('ingestion-details-container').waitFor();
-
-  const metadataTab = page.locator('[data-testid="metadata-sub-tab"]');
-  if (await metadataTab.isVisible()) {
-    await metadataTab.click();
-  }
-
-  await page.click('[data-testid="add-new-ingestion-button"]');
-  await page
-    .locator('.ant-dropdown:visible [data-menu-id*="profiler"]')
-    .waitFor();
-  await page.click('[data-menu-id*="profiler"]');
-
-  await waitForAllLoadersToDisappear(page);
-  await expandAdvancedConfig(page);
-
-  await expect(page.getByTestId('sample-config-type-select')).toBeVisible();
-};
-
-const expandAdvancedConfig = async (page: Page) => {
-  const collapseHeader = page
-    .locator('.advanced-properties-collapse .ant-collapse-header')
-    .first();
-  await collapseHeader.waitFor();
-  const isExpanded =
-    (await collapseHeader.getAttribute('aria-expanded')) === 'true';
-  if (!isExpanded) {
-    await collapseHeader.click();
-  }
-};
-
-const selectSampleConfigType = async (
-  page: Page,
-  type: 'STATIC' | 'DYNAMIC'
-) => {
-  await page.getByTestId('sample-config-type-select').click();
-  await page.locator(`[data-key="${type}"]`).click();
-};
-
-const isCreatePipelineCall = (url: string, method: string) =>
-  method === 'POST' &&
-  url.endsWith(PROFILE_PIPELINES_URL) &&
-  !url.includes('/deploy/');
-
-const submitAndCaptureCreatePayload = async (
-  page: Page
-): Promise<ProfileSampleConfig> => {
-  await page.click('[data-testid="submit-btn"]');
-
-  await page.getByTestId('schedular-card-container').waitFor();
-  await page
-    .getByTestId('schedular-card-container')
-    .getByText('On Demand')
-    .click();
-
-  const createResponsePromise = page.waitForResponse((response) =>
-    isCreatePipelineCall(response.url(), response.request().method())
-  );
-
-  await page.click('[data-testid="deploy-button"]');
-
-  const createResponse = await createResponsePromise;
-
-  expect(
-    createResponse.ok(),
-    `Create pipeline call returned ${createResponse.status()}: ${await createResponse.text()}`
-  ).toBe(true);
-
-  const body = JSON.parse(createResponse.request().postData() ?? '{}');
-
-  return body?.sourceConfig?.config?.profileSampleConfig;
-};
 
 test.describe('Profiler ingestion form — profile sample config', () => {
   test.beforeAll(async ({ browser }) => {
@@ -130,29 +36,27 @@ test.describe('Profiler ingestion form — profile sample config', () => {
   });
 
   test.beforeEach(async ({ page }) => {
-    await openProfilerForm(page);
+    await openProfilerForm(page, service);
   });
 
-  test('STATIC config sends only profileSample under config', async ({
+  test('STATIC config sends profileSample and no DYNAMIC-only keys', async ({
     page,
   }) => {
     await selectSampleConfigType(page, 'STATIC');
-
     await page.getByTestId('profile-sample-input').locator('input').fill('10');
 
     const profileSampleConfig = await submitAndCaptureCreatePayload(page);
 
-    expect(profileSampleConfig).toEqual({
-      sampleConfigType: 'STATIC',
-      config: { profileSample: 10 },
-    });
+    expect(profileSampleConfig?.sampleConfigType).toBe('STATIC');
+    expect(profileSampleConfig?.config).toMatchObject({ profileSample: 10 });
+    expect(profileSampleConfig?.config).not.toHaveProperty('smartSampling');
+    expect(profileSampleConfig?.config).not.toHaveProperty('thresholds');
   });
 
   test('STATIC config sends all three static-only fields when set', async ({
     page,
   }) => {
     await selectSampleConfigType(page, 'STATIC');
-
     await page.getByTestId('profile-sample-input').locator('input').fill('25');
 
     await page.getByTestId('profile-sample-type-select').click();
@@ -163,17 +67,17 @@ test.describe('Profiler ingestion form — profile sample config', () => {
 
     const profileSampleConfig = await submitAndCaptureCreatePayload(page);
 
-    expect(profileSampleConfig).toEqual({
-      sampleConfigType: 'STATIC',
-      config: {
-        profileSample: 25,
-        profileSampleType: 'ROWS',
-        samplingMethodType: 'SYSTEM',
-      },
+    expect(profileSampleConfig?.sampleConfigType).toBe('STATIC');
+    expect(profileSampleConfig?.config).toMatchObject({
+      profileSample: 25,
+      profileSampleType: 'ROWS',
+      samplingMethodType: 'SYSTEM',
     });
+    expect(profileSampleConfig?.config).not.toHaveProperty('smartSampling');
+    expect(profileSampleConfig?.config).not.toHaveProperty('thresholds');
   });
 
-  test('DYNAMIC with smart sampling ON sends only smartSampling', async ({
+  test('DYNAMIC with smart sampling ON sends only DYNAMIC keys', async ({
     page,
   }) => {
     await selectSampleConfigType(page, 'DYNAMIC');
@@ -184,17 +88,20 @@ test.describe('Profiler ingestion form — profile sample config', () => {
     const profileSampleConfig = await submitAndCaptureCreatePayload(page);
 
     expect(profileSampleConfig?.sampleConfigType).toBe('DYNAMIC');
-    expect(profileSampleConfig?.config).toEqual({
+    expect(profileSampleConfig?.config).toMatchObject({
       smartSampling: true,
       thresholds: [],
     });
+    expect(profileSampleConfig?.config).not.toHaveProperty('profileSample');
+    expect(profileSampleConfig?.config).not.toHaveProperty(
+      'samplingMethodType'
+    );
   });
 
   test('DYNAMIC with smart sampling OFF and thresholds sends thresholds array', async ({
     page,
   }) => {
     await selectSampleConfigType(page, 'DYNAMIC');
-
     await page.getByTestId('smart-sampling-toggle').click();
 
     await page.getByTestId('add-threshold-btn').click();
@@ -215,10 +122,20 @@ test.describe('Profiler ingestion form — profile sample config', () => {
 
     expect(profileSampleConfig?.sampleConfigType).toBe('DYNAMIC');
     expect(profileSampleConfig?.config?.smartSampling).toBe(false);
-    expect(profileSampleConfig?.config?.thresholds).toEqual([
-      { rowCountThreshold: 1000000, profileSample: 10 },
-      { rowCountThreshold: 500000, profileSample: 25 },
-    ]);
+
+    const thresholds = profileSampleConfig?.config?.thresholds as Array<
+      Record<string, unknown>
+    >;
+    expect(thresholds).toHaveLength(2);
+    expect(thresholds[0]).toMatchObject({
+      rowCountThreshold: 1000000,
+      profileSample: 10,
+    });
+    expect(thresholds[1]).toMatchObject({
+      rowCountThreshold: 500000,
+      profileSample: 25,
+    });
+    expect(profileSampleConfig?.config).not.toHaveProperty('profileSample');
   });
 
   test('DYNAMIC threshold remove drops only the selected row', async ({
@@ -252,10 +169,18 @@ test.describe('Profiler ingestion form — profile sample config', () => {
 
     const profileSampleConfig = await submitAndCaptureCreatePayload(page);
 
-    expect(profileSampleConfig?.config?.thresholds).toEqual([
-      { rowCountThreshold: 1000000, profileSample: 10 },
-      { rowCountThreshold: 100000, profileSample: 50 },
-    ]);
+    const thresholds = profileSampleConfig?.config?.thresholds as Array<
+      Record<string, unknown>
+    >;
+    expect(thresholds).toHaveLength(2);
+    expect(thresholds[0]).toMatchObject({
+      rowCountThreshold: 1000000,
+      profileSample: 10,
+    });
+    expect(thresholds[1]).toMatchObject({
+      rowCountThreshold: 100000,
+      profileSample: 50,
+    });
   });
 
   test('switching DYNAMIC → STATIC does not leak smartSampling or thresholds', async ({
@@ -265,13 +190,12 @@ test.describe('Profiler ingestion form — profile sample config', () => {
     await expect(page.getByTestId('smart-sampling-toggle')).toBeVisible();
 
     await selectSampleConfigType(page, 'STATIC');
-
     await page.getByTestId('profile-sample-input').locator('input').fill('40');
 
     const profileSampleConfig = await submitAndCaptureCreatePayload(page);
 
     expect(profileSampleConfig?.sampleConfigType).toBe('STATIC');
-    expect(profileSampleConfig?.config).toEqual({ profileSample: 40 });
+    expect(profileSampleConfig?.config).toMatchObject({ profileSample: 40 });
     expect(profileSampleConfig?.config).not.toHaveProperty('smartSampling');
     expect(profileSampleConfig?.config).not.toHaveProperty('thresholds');
   });

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DataQuality/ProfilerIngestionForm.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DataQuality/ProfilerIngestionForm.spec.ts
@@ -1,0 +1,282 @@
+/*
+ *  Copyright 2026 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+import { expect, Page, test } from '@playwright/test';
+import { SERVICE_TYPE } from '../../../constant/service';
+import { DatabaseServiceClass } from '../../../support/entity/service/DatabaseServiceClass';
+import { performAdminLogin } from '../../../utils/admin';
+import { redirectToHomePage } from '../../../utils/common';
+import { waitForAllLoadersToDisappear } from '../../../utils/entity';
+import { visitServiceDetailsPage } from '../../../utils/service';
+
+const PROFILE_PIPELINES_URL = '/api/v1/services/ingestionPipelines';
+
+type ProfileSampleConfig =
+  | undefined
+  | {
+      sampleConfigType?: 'STATIC' | 'DYNAMIC';
+      config?: Record<string, unknown>;
+    };
+
+const service = new DatabaseServiceClass();
+
+const openProfilerForm = async (page: Page) => {
+  await redirectToHomePage(page);
+  await visitServiceDetailsPage(
+    page,
+    {
+      type: SERVICE_TYPE.Database,
+      name: service.entity.name,
+      displayName: service.entity.name,
+    },
+    false
+  );
+
+  await page.click('[data-testid="agents"]');
+  await page.getByTestId('ingestion-details-container').waitFor();
+
+  const metadataTab = page.locator('[data-testid="metadata-sub-tab"]');
+  if (await metadataTab.isVisible()) {
+    await metadataTab.click();
+  }
+
+  await page.click('[data-testid="add-new-ingestion-button"]');
+  await page
+    .locator('.ant-dropdown:visible [data-menu-id*="profiler"]')
+    .waitFor();
+  await page.click('[data-menu-id*="profiler"]');
+
+  await waitForAllLoadersToDisappear(page);
+  await page
+    .locator('.advanced-properties-collapse')
+    .getByText('Advanced Config')
+    .click();
+
+  await expect(page.getByTestId('sample-config-type-select')).toBeVisible();
+};
+
+const selectSampleConfigType = async (
+  page: Page,
+  type: 'STATIC' | 'DYNAMIC'
+) => {
+  await page.getByTestId('sample-config-type-select').click();
+  await page.locator(`[data-key="${type}"]`).click();
+};
+
+const submitAndCaptureCreatePayload = async (
+  page: Page
+): Promise<ProfileSampleConfig> => {
+  await page.click('[data-testid="submit-btn"]');
+
+  await page.getByTestId('schedular-card-container').waitFor();
+  await page
+    .getByTestId('schedular-card-container')
+    .getByText('On Demand')
+    .click();
+
+  const createRequestPromise = page.waitForRequest(
+    (req) =>
+      req.method() === 'POST' &&
+      req.url().endsWith(PROFILE_PIPELINES_URL) &&
+      !req.url().includes('/deploy/')
+  );
+
+  await page.click('[data-testid="deploy-button"]');
+
+  const createRequest = await createRequestPromise;
+  const body = JSON.parse(createRequest.postData() ?? '{}');
+
+  return body?.sourceConfig?.config?.profileSampleConfig;
+};
+
+test.describe('Profiler ingestion form — profile sample config', () => {
+  test.beforeAll(async ({ browser }) => {
+    const { apiContext, afterAction } = await performAdminLogin(browser);
+    await service.create(apiContext);
+    await afterAction();
+  });
+
+  test.afterAll(async ({ browser }) => {
+    const { apiContext, afterAction } = await performAdminLogin(browser);
+    await service.delete(apiContext);
+    await afterAction();
+  });
+
+  test.beforeEach(async ({ page }) => {
+    await openProfilerForm(page);
+  });
+
+  test('STATIC config sends only profileSample under config', async ({
+    page,
+  }) => {
+    await selectSampleConfigType(page, 'STATIC');
+
+    await page.getByTestId('profile-sample-input').locator('input').fill('10');
+
+    const profileSampleConfig = await submitAndCaptureCreatePayload(page);
+
+    expect(profileSampleConfig).toEqual({
+      sampleConfigType: 'STATIC',
+      config: { profileSample: 10 },
+    });
+  });
+
+  test('STATIC config sends all three static-only fields when set', async ({
+    page,
+  }) => {
+    await selectSampleConfigType(page, 'STATIC');
+
+    await page.getByTestId('profile-sample-input').locator('input').fill('25');
+
+    await page.getByTestId('profile-sample-type-select').click();
+    await page.locator('[data-key="ROWS"]').click();
+
+    await page.getByTestId('sampling-method-type-select').click();
+    await page.locator('[data-key="SYSTEM"]').click();
+
+    const profileSampleConfig = await submitAndCaptureCreatePayload(page);
+
+    expect(profileSampleConfig).toEqual({
+      sampleConfigType: 'STATIC',
+      config: {
+        profileSample: 25,
+        profileSampleType: 'ROWS',
+        samplingMethodType: 'SYSTEM',
+      },
+    });
+  });
+
+  test('DYNAMIC with smart sampling ON sends only smartSampling', async ({
+    page,
+  }) => {
+    await selectSampleConfigType(page, 'DYNAMIC');
+
+    await expect(page.getByTestId('smart-sampling-toggle')).toBeVisible();
+    await expect(page.getByTestId('add-threshold-btn')).not.toBeVisible();
+
+    const profileSampleConfig = await submitAndCaptureCreatePayload(page);
+
+    expect(profileSampleConfig?.sampleConfigType).toBe('DYNAMIC');
+    expect(profileSampleConfig?.config).toEqual({
+      smartSampling: true,
+      thresholds: [],
+    });
+  });
+
+  test('DYNAMIC with smart sampling OFF and thresholds sends thresholds array', async ({
+    page,
+  }) => {
+    await selectSampleConfigType(page, 'DYNAMIC');
+
+    await page.getByTestId('smart-sampling-toggle').click();
+
+    await page.getByTestId('add-threshold-btn').click();
+    await page
+      .getByTestId('row-count-threshold-0')
+      .locator('input')
+      .fill('1000000');
+    await page.getByTestId('profile-sample-0').locator('input').fill('10');
+
+    await page.getByTestId('add-threshold-btn').click();
+    await page
+      .getByTestId('row-count-threshold-1')
+      .locator('input')
+      .fill('500000');
+    await page.getByTestId('profile-sample-1').locator('input').fill('25');
+
+    const profileSampleConfig = await submitAndCaptureCreatePayload(page);
+
+    expect(profileSampleConfig?.sampleConfigType).toBe('DYNAMIC');
+    expect(profileSampleConfig?.config?.smartSampling).toBe(false);
+    expect(profileSampleConfig?.config?.thresholds).toEqual([
+      { rowCountThreshold: 1000000, profileSample: 10 },
+      { rowCountThreshold: 500000, profileSample: 25 },
+    ]);
+  });
+
+  test('DYNAMIC threshold remove drops only the selected row', async ({
+    page,
+  }) => {
+    await selectSampleConfigType(page, 'DYNAMIC');
+    await page.getByTestId('smart-sampling-toggle').click();
+
+    await page.getByTestId('add-threshold-btn').click();
+    await page
+      .getByTestId('row-count-threshold-0')
+      .locator('input')
+      .fill('1000000');
+    await page.getByTestId('profile-sample-0').locator('input').fill('10');
+
+    await page.getByTestId('add-threshold-btn').click();
+    await page
+      .getByTestId('row-count-threshold-1')
+      .locator('input')
+      .fill('500000');
+    await page.getByTestId('profile-sample-1').locator('input').fill('25');
+
+    await page.getByTestId('add-threshold-btn').click();
+    await page
+      .getByTestId('row-count-threshold-2')
+      .locator('input')
+      .fill('100000');
+    await page.getByTestId('profile-sample-2').locator('input').fill('50');
+
+    await page.getByTestId('remove-threshold-1').click();
+
+    const profileSampleConfig = await submitAndCaptureCreatePayload(page);
+
+    expect(profileSampleConfig?.config?.thresholds).toEqual([
+      { rowCountThreshold: 1000000, profileSample: 10 },
+      { rowCountThreshold: 100000, profileSample: 50 },
+    ]);
+  });
+
+  test('switching DYNAMIC → STATIC does not leak smartSampling or thresholds', async ({
+    page,
+  }) => {
+    await selectSampleConfigType(page, 'DYNAMIC');
+    await expect(page.getByTestId('smart-sampling-toggle')).toBeVisible();
+
+    await selectSampleConfigType(page, 'STATIC');
+
+    await page.getByTestId('profile-sample-input').locator('input').fill('40');
+
+    const profileSampleConfig = await submitAndCaptureCreatePayload(page);
+
+    expect(profileSampleConfig?.sampleConfigType).toBe('STATIC');
+    expect(profileSampleConfig?.config).toEqual({ profileSample: 40 });
+    expect(profileSampleConfig?.config).not.toHaveProperty('smartSampling');
+    expect(profileSampleConfig?.config).not.toHaveProperty('thresholds');
+  });
+
+  test('switching STATIC → DYNAMIC does not leak static-only fields', async ({
+    page,
+  }) => {
+    await selectSampleConfigType(page, 'STATIC');
+    await page.getByTestId('profile-sample-input').locator('input').fill('70');
+
+    await page.getByTestId('profile-sample-type-select').click();
+    await page.locator('[data-key="PERCENTAGE"]').click();
+
+    await selectSampleConfigType(page, 'DYNAMIC');
+    await expect(page.getByTestId('smart-sampling-toggle')).toBeVisible();
+
+    const profileSampleConfig = await submitAndCaptureCreatePayload(page);
+
+    expect(profileSampleConfig?.sampleConfigType).toBe('DYNAMIC');
+    expect(profileSampleConfig?.config).not.toHaveProperty('profileSample');
+    expect(profileSampleConfig?.config).not.toHaveProperty('profileSampleType');
+    expect(profileSampleConfig?.config).not.toHaveProperty(
+      'samplingMethodType'
+    );
+  });
+});

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DataQuality/ProfilerIngestionForm.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DataQuality/ProfilerIngestionForm.spec.ts
@@ -10,13 +10,14 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-import { expect, Page, test } from '@playwright/test';
+import { expect, Page } from '@playwright/test';
 import { SERVICE_TYPE } from '../../../constant/service';
 import { DatabaseServiceClass } from '../../../support/entity/service/DatabaseServiceClass';
 import { performAdminLogin } from '../../../utils/admin';
 import { redirectToHomePage } from '../../../utils/common';
 import { waitForAllLoadersToDisappear } from '../../../utils/entity';
 import { visitServiceDetailsPage } from '../../../utils/service';
+import { test } from '../../fixtures/pages';
 
 const PROFILE_PIPELINES_URL = '/api/v1/services/ingestionPipelines';
 
@@ -56,12 +57,21 @@ const openProfilerForm = async (page: Page) => {
   await page.click('[data-menu-id*="profiler"]');
 
   await waitForAllLoadersToDisappear(page);
-  await page
-    .locator('.advanced-properties-collapse')
-    .getByText('Advanced Config')
-    .click();
+  await expandAdvancedConfig(page);
 
   await expect(page.getByTestId('sample-config-type-select')).toBeVisible();
+};
+
+const expandAdvancedConfig = async (page: Page) => {
+  const collapseHeader = page
+    .locator('.advanced-properties-collapse .ant-collapse-header')
+    .first();
+  await collapseHeader.waitFor();
+  const isExpanded =
+    (await collapseHeader.getAttribute('aria-expanded')) === 'true';
+  if (!isExpanded) {
+    await collapseHeader.click();
+  }
 };
 
 const selectSampleConfigType = async (
@@ -71,6 +81,11 @@ const selectSampleConfigType = async (
   await page.getByTestId('sample-config-type-select').click();
   await page.locator(`[data-key="${type}"]`).click();
 };
+
+const isCreatePipelineCall = (url: string, method: string) =>
+  method === 'POST' &&
+  url.endsWith(PROFILE_PIPELINES_URL) &&
+  !url.includes('/deploy/');
 
 const submitAndCaptureCreatePayload = async (
   page: Page
@@ -83,17 +98,20 @@ const submitAndCaptureCreatePayload = async (
     .getByText('On Demand')
     .click();
 
-  const createRequestPromise = page.waitForRequest(
-    (req) =>
-      req.method() === 'POST' &&
-      req.url().endsWith(PROFILE_PIPELINES_URL) &&
-      !req.url().includes('/deploy/')
+  const createResponsePromise = page.waitForResponse((response) =>
+    isCreatePipelineCall(response.url(), response.request().method())
   );
 
   await page.click('[data-testid="deploy-button"]');
 
-  const createRequest = await createRequestPromise;
-  const body = JSON.parse(createRequest.postData() ?? '{}');
+  const createResponse = await createResponsePromise;
+
+  expect(
+    createResponse.ok(),
+    `Create pipeline call returned ${createResponse.status()}: ${await createResponse.text()}`
+  ).toBe(true);
+
+  const body = JSON.parse(createResponse.request().postData() ?? '{}');
 
   return body?.sourceConfig?.config?.profileSampleConfig;
 };

--- a/openmetadata-ui/src/main/resources/ui/playwright/support/entity/ingestion/MySqlIngestionClass.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/support/entity/ingestion/MySqlIngestionClass.ts
@@ -137,11 +137,11 @@ class MysqlIngestionClass extends ServiceBaseClass {
       }
       await page.click('[data-testid="add-new-ingestion-button"]');
 
-      await page
-        .locator('.ant-dropdown:visible [data-menu-id*="profiler"]')
-        .waitFor();
-
-      await page.click('[data-menu-id*="profiler"]');
+      const profilerMenuItem = page
+        .locator('.ant-dropdown:visible')
+        .getByTestId('agent-item-profiler');
+      await expect(profilerMenuItem).toBeVisible();
+      await profilerMenuItem.click();
 
       await waitForAllLoadersToDisappear(page);
       const advancedConfigHeader = page

--- a/openmetadata-ui/src/main/resources/ui/playwright/support/entity/ingestion/MySqlIngestionClass.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/support/entity/ingestion/MySqlIngestionClass.ts
@@ -29,6 +29,7 @@ import {
   visitEntityPage,
   waitForAllLoadersToDisappear,
 } from '../../../utils/entity';
+import { expandAdvancedConfig } from '../../../utils/profilerForm';
 import { visitServiceDetailsPage } from '../../../utils/service';
 import {
   checkServiceFieldSectionHighlighting,
@@ -144,15 +145,7 @@ class MysqlIngestionClass extends ServiceBaseClass {
       await profilerMenuItem.click();
 
       await waitForAllLoadersToDisappear(page);
-      const advancedConfigHeader = page
-        .locator('.advanced-properties-collapse .ant-collapse-header')
-        .first();
-      await advancedConfigHeader.waitFor();
-      const isAdvancedConfigExpanded =
-        (await advancedConfigHeader.getAttribute('aria-expanded')) === 'true';
-      if (!isAdvancedConfigExpanded) {
-        await advancedConfigHeader.click();
-      }
+      await expandAdvancedConfig(page);
 
       const sampleConfigTypeSelect = page.getByTestId(
         'sample-config-type-select'

--- a/openmetadata-ui/src/main/resources/ui/playwright/support/entity/ingestion/MySqlIngestionClass.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/support/entity/ingestion/MySqlIngestionClass.ts
@@ -144,10 +144,15 @@ class MysqlIngestionClass extends ServiceBaseClass {
       await page.click('[data-menu-id*="profiler"]');
 
       await waitForAllLoadersToDisappear(page);
-      await page
-        .locator('.advanced-properties-collapse')
-        .getByText('Advanced Config')
-        .click();
+      const advancedConfigHeader = page
+        .locator('.advanced-properties-collapse .ant-collapse-header')
+        .first();
+      await advancedConfigHeader.waitFor();
+      const isAdvancedConfigExpanded =
+        (await advancedConfigHeader.getAttribute('aria-expanded')) === 'true';
+      if (!isAdvancedConfigExpanded) {
+        await advancedConfigHeader.click();
+      }
 
       const sampleConfigTypeSelect = page.getByTestId(
         'sample-config-type-select'

--- a/openmetadata-ui/src/main/resources/ui/playwright/support/entity/ingestion/MySqlIngestionClass.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/support/entity/ingestion/MySqlIngestionClass.ts
@@ -144,6 +144,10 @@ class MysqlIngestionClass extends ServiceBaseClass {
       await page.click('[data-menu-id*="profiler"]');
 
       await waitForAllLoadersToDisappear(page);
+      await page
+        .locator('.advanced-properties-collapse')
+        .getByText('Advanced Config')
+        .click();
 
       const sampleConfigTypeSelect = page.getByTestId(
         'sample-config-type-select'

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/profilerForm.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/profilerForm.ts
@@ -43,8 +43,8 @@ export const openProfilerForm = async (
   service: DatabaseServiceClass
 ) => {
   await redirectToHomePage(page);
-  const serviceDetailResponse = page.waitForResponse(
-    '/api/v1/services/databaseServices/name/*'
+  const serviceDetailResponse = page.waitForResponse((response) =>
+    response.url().includes('/api/v1/services/databaseServices/name/')
   );
   await visitServiceDetailsPage(
     page,

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/profilerForm.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/profilerForm.ts
@@ -1,0 +1,122 @@
+/*
+ *  Copyright 2026 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+import { expect, Page } from '@playwright/test';
+import { SERVICE_TYPE } from '../constant/service';
+import { DatabaseServiceClass } from '../support/entity/service/DatabaseServiceClass';
+import { redirectToHomePage } from './common';
+import { waitForAllLoadersToDisappear } from './entity';
+import { visitServiceDetailsPage } from './service';
+
+export const PROFILE_PIPELINES_URL = '/api/v1/services/ingestionPipelines';
+
+export type ProfileSampleConfig =
+  | undefined
+  | {
+      sampleConfigType?: 'STATIC' | 'DYNAMIC';
+      config?: Record<string, unknown>;
+    };
+
+export const expandAdvancedConfig = async (page: Page) => {
+  const collapseHeader = page
+    .locator('.advanced-properties-collapse .ant-collapse-header')
+    .first();
+  await collapseHeader.waitFor();
+  const isExpanded =
+    (await collapseHeader.getAttribute('aria-expanded')) === 'true';
+  if (!isExpanded) {
+    await collapseHeader.click();
+  }
+};
+
+export const openProfilerForm = async (
+  page: Page,
+  service: DatabaseServiceClass
+) => {
+  await redirectToHomePage(page);
+  const serviceDetailResponse = page.waitForResponse(
+    '/api/v1/services/databaseServices/name/*'
+  );
+  await visitServiceDetailsPage(
+    page,
+    {
+      type: SERVICE_TYPE.Database,
+      name: service.entity.name,
+      displayName: service.entity.name,
+    },
+    true,
+    false
+  );
+  await serviceDetailResponse;
+  await expect(page.getByTestId('agents')).toBeVisible();
+  await page.getByTestId('agents').click();
+  await page.getByTestId('ingestion-details-container').waitFor();
+
+  const metadataTab = page.locator('[data-testid="metadata-sub-tab"]');
+  if (await metadataTab.isVisible()) {
+    await metadataTab.click();
+  }
+
+  await page.getByTestId('add-new-ingestion-button').click();
+  const profilerMenuItem = page
+    .locator('.ant-dropdown:visible')
+    .getByTestId('agent-item-profiler');
+  await expect(profilerMenuItem).toBeVisible();
+  await profilerMenuItem.click();
+
+  await waitForAllLoadersToDisappear(page);
+  await expandAdvancedConfig(page);
+
+  await expect(page.getByTestId('sample-config-type-select')).toBeVisible();
+};
+
+export const selectSampleConfigType = async (
+  page: Page,
+  type: 'STATIC' | 'DYNAMIC'
+) => {
+  await page.getByTestId('sample-config-type-select').click();
+  await page.locator(`[data-key="${type}"]`).click();
+};
+
+export const isCreatePipelineCall = (url: string, method: string) =>
+  method === 'POST' &&
+  url.endsWith(PROFILE_PIPELINES_URL) &&
+  !url.includes('/deploy/');
+
+export const submitAndCaptureCreatePayload = async (
+  page: Page
+): Promise<ProfileSampleConfig> => {
+  await page.click('[data-testid="submit-btn"]');
+
+  await page.getByTestId('schedular-card-container').waitFor();
+  await page
+    .getByTestId('schedular-card-container')
+    .getByText('On Demand')
+    .click();
+
+  const createResponsePromise = page.waitForResponse((response) =>
+    isCreatePipelineCall(response.url(), response.request().method())
+  );
+
+  await page.click('[data-testid="deploy-button"]');
+
+  const createResponse = await createResponsePromise;
+
+  expect(
+    createResponse.ok(),
+    `Create pipeline call returned ${createResponse.status()}: ${await createResponse.text()}`
+  ).toBe(true);
+
+  const body = JSON.parse(createResponse.request().postData() ?? '{}');
+
+  return body?.sourceConfig?.config?.profileSampleConfig;
+};

--- a/openmetadata-ui/src/main/resources/ui/src/components/Settings/Services/Ingestion/IngestionWorkflowForm/ProfileSampleConfigField.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Settings/Services/Ingestion/IngestionWorkflowForm/ProfileSampleConfigField.test.tsx
@@ -469,6 +469,58 @@ describe('ProfileSampleConfigField', () => {
     });
   });
 
+  describe('Cross-discriminator field leakage', () => {
+    it('drops Dynamic-only keys when sampleConfigType is STATIC', () => {
+      const polluted: ProfileSampleConfig = {
+        sampleConfigType: SampleConfigType.Static,
+        config: {
+          smartSampling: true,
+          thresholds: [],
+          profileSample: 10,
+        },
+      };
+
+      render(
+        <ProfileSampleConfigField {...baseFieldProps} formData={polluted} />
+      );
+
+      fireEvent.change(screen.getByTestId('profile-sample-input'), {
+        target: { value: '25' },
+      });
+
+      expect(mockOnChange).toHaveBeenCalledWith({
+        sampleConfigType: SampleConfigType.Static,
+        config: { profileSample: 25 },
+      });
+    });
+
+    it('drops Static-only keys when sampleConfigType is DYNAMIC', () => {
+      const polluted: ProfileSampleConfig = {
+        sampleConfigType: SampleConfigType.Dynamic,
+        config: {
+          smartSampling: false,
+          thresholds: [],
+          profileSample: 10,
+          profileSampleType: ProfileSampleType.Percentage,
+        } as ProfileSampleConfig['config'],
+      };
+
+      render(
+        <ProfileSampleConfigField {...baseFieldProps} formData={polluted} />
+      );
+
+      fireEvent.click(screen.getByTestId('add-threshold-btn'));
+
+      expect(mockOnChange).toHaveBeenCalledWith({
+        sampleConfigType: SampleConfigType.Dynamic,
+        config: {
+          smartSampling: false,
+          thresholds: [{ rowCountThreshold: 1, profileSample: 100 }],
+        },
+      });
+    });
+  });
+
   describe('Label rendering', () => {
     it('renders all field labels in STATIC mode', () => {
       render(

--- a/openmetadata-ui/src/main/resources/ui/src/components/Settings/Services/Ingestion/IngestionWorkflowForm/ProfileSampleConfigField.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Settings/Services/Ingestion/IngestionWorkflowForm/ProfileSampleConfigField.tsx
@@ -32,56 +32,13 @@ import {
   SamplingMethodType,
   Threshold,
 } from '../../../../../generated/metadataIngestion/databaseServiceProfilerPipeline';
-
-const SAMPLE_CONFIG_TYPE_OPTIONS = [
-  { id: SampleConfigType.Static, label: 'STATIC' },
-  { id: SampleConfigType.Dynamic, label: 'DYNAMIC' },
-];
-
-const PROFILE_SAMPLE_TYPE_OPTIONS = [
-  { id: ProfileSampleType.Percentage, label: 'PERCENTAGE' },
-  { id: ProfileSampleType.Rows, label: 'ROWS' },
-];
-
-const SAMPLING_METHOD_TYPE_OPTIONS = [
-  { id: SamplingMethodType.Bernoulli, label: 'BERNOULLI' },
-  { id: SamplingMethodType.System, label: 'SYSTEM' },
-];
-
-const DEFAULT_THRESHOLD: Threshold = {
-  rowCountThreshold: 1,
-  profileSample: 100,
-};
-
-const STATIC_CONFIG_KEYS: ReadonlyArray<keyof ICSamplingConfig> = [
-  'profileSample',
-  'profileSampleType',
-  'samplingMethodType',
-];
-
-const DYNAMIC_CONFIG_KEYS: ReadonlyArray<keyof ICSamplingConfig> = [
-  'smartSampling',
-  'thresholds',
-];
-
-const pickConfigForType = (
-  config: ICSamplingConfig | undefined,
-  type: SampleConfigType
-): ICSamplingConfig => {
-  if (!config) {
-    return {};
-  }
-  const allowedKeys =
-    type === SampleConfigType.Static ? STATIC_CONFIG_KEYS : DYNAMIC_CONFIG_KEYS;
-  const result: ICSamplingConfig = {};
-  for (const key of allowedKeys) {
-    if (config[key] !== undefined) {
-      (result as Record<string, unknown>)[key] = config[key];
-    }
-  }
-
-  return result;
-};
+import {
+  DEFAULT_THRESHOLD,
+  pickConfigForType,
+  PROFILE_SAMPLE_TYPE_OPTIONS,
+  SAMPLE_CONFIG_TYPE_OPTIONS,
+  SAMPLING_METHOD_TYPE_OPTIONS,
+} from '../../../../../utils/ProfileSampleConfigUtils';
 
 const ProfileSampleConfigField = (props: FieldProps<ProfileSampleConfig>) => {
   const { formData, onChange } = props;

--- a/openmetadata-ui/src/main/resources/ui/src/components/Settings/Services/Ingestion/IngestionWorkflowForm/ProfileSampleConfigField.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Settings/Services/Ingestion/IngestionWorkflowForm/ProfileSampleConfigField.tsx
@@ -53,15 +53,46 @@ const DEFAULT_THRESHOLD: Threshold = {
   profileSample: 100,
 };
 
+const STATIC_CONFIG_KEYS: ReadonlyArray<keyof ICSamplingConfig> = [
+  'profileSample',
+  'profileSampleType',
+  'samplingMethodType',
+];
+
+const DYNAMIC_CONFIG_KEYS: ReadonlyArray<keyof ICSamplingConfig> = [
+  'smartSampling',
+  'thresholds',
+];
+
+const pickConfigForType = (
+  config: ICSamplingConfig | undefined,
+  type: SampleConfigType
+): ICSamplingConfig => {
+  if (!config) {
+    return {};
+  }
+  const allowedKeys =
+    type === SampleConfigType.Static ? STATIC_CONFIG_KEYS : DYNAMIC_CONFIG_KEYS;
+  const result: ICSamplingConfig = {};
+  for (const key of allowedKeys) {
+    if (config[key] !== undefined) {
+      (result as Record<string, unknown>)[key] = config[key];
+    }
+  }
+
+  return result;
+};
+
 const ProfileSampleConfigField = (props: FieldProps<ProfileSampleConfig>) => {
   const { formData, onChange } = props;
   const { t } = useTranslation();
 
   const sampleConfigType =
     formData?.sampleConfigType ?? SampleConfigType.Dynamic;
-  const config: ICSamplingConfig = formData?.config ?? {
-    smartSampling: true,
-  };
+  const config: ICSamplingConfig = pickConfigForType(
+    formData?.config,
+    sampleConfigType
+  );
 
   const handleConfigTypeChange = useCallback(
     (type: string | number | null) => {

--- a/openmetadata-ui/src/main/resources/ui/src/components/Settings/Services/Ingestion/IngestionWorkflowForm/ProfileSampleConfigField.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Settings/Services/Ingestion/IngestionWorkflowForm/ProfileSampleConfigField.tsx
@@ -32,17 +32,31 @@ import {
   SamplingMethodType,
   Threshold,
 } from '../../../../../generated/metadataIngestion/databaseServiceProfilerPipeline';
-import {
-  DEFAULT_THRESHOLD,
-  pickConfigForType,
-  PROFILE_SAMPLE_TYPE_OPTIONS,
-  SAMPLE_CONFIG_TYPE_OPTIONS,
-  SAMPLING_METHOD_TYPE_OPTIONS,
-} from '../../../../../utils/ProfileSampleConfigUtils';
+import { pickConfigForType } from '../../../../../utils/ProfileSampleConfigUtils';
+
+const DEFAULT_THRESHOLD: Threshold = {
+  rowCountThreshold: 1,
+  profileSample: 100,
+};
+
+const SAMPLING_METHOD_TYPE_OPTIONS = [
+  { id: SamplingMethodType.Bernoulli, label: 'BERNOULLI' },
+  { id: SamplingMethodType.System, label: 'SYSTEM' },
+];
 
 const ProfileSampleConfigField = (props: FieldProps<ProfileSampleConfig>) => {
   const { formData, onChange } = props;
   const { t } = useTranslation();
+
+  const SAMPLE_CONFIG_TYPE_OPTIONS = [
+    { id: SampleConfigType.Static, label: t('label.static') },
+    { id: SampleConfigType.Dynamic, label: t('label.dynamic') },
+  ];
+
+  const PROFILE_SAMPLE_TYPE_OPTIONS = [
+    { id: ProfileSampleType.Percentage, label: t('label.percentage') },
+    { id: ProfileSampleType.Rows, label: t('label.row-plural') },
+  ];
 
   const sampleConfigType =
     formData?.sampleConfigType ?? SampleConfigType.Dynamic;

--- a/openmetadata-ui/src/main/resources/ui/src/components/Settings/Services/Ingestion/IngestionWorkflowForm/ProfileSampleConfigField.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Settings/Services/Ingestion/IngestionWorkflowForm/ProfileSampleConfigField.tsx
@@ -22,7 +22,7 @@ import {
 import { FieldProps } from '@rjsf/utils';
 import { Plus, Trash01 } from '@untitledui/icons';
 import { Form, Switch } from 'antd';
-import { useCallback } from 'react';
+import { useCallback, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import {
   ICSamplingConfig,
@@ -48,15 +48,21 @@ const ProfileSampleConfigField = (props: FieldProps<ProfileSampleConfig>) => {
   const { formData, onChange } = props;
   const { t } = useTranslation();
 
-  const SAMPLE_CONFIG_TYPE_OPTIONS = [
-    { id: SampleConfigType.Static, label: t('label.static') },
-    { id: SampleConfigType.Dynamic, label: t('label.dynamic') },
-  ];
+  const SAMPLE_CONFIG_TYPE_OPTIONS = useMemo(
+    () => [
+      { id: SampleConfigType.Static, label: t('label.static') },
+      { id: SampleConfigType.Dynamic, label: t('label.dynamic') },
+    ],
+    [t]
+  );
 
-  const PROFILE_SAMPLE_TYPE_OPTIONS = [
-    { id: ProfileSampleType.Percentage, label: t('label.percentage') },
-    { id: ProfileSampleType.Rows, label: t('label.row-plural') },
-  ];
+  const PROFILE_SAMPLE_TYPE_OPTIONS = useMemo(
+    () => [
+      { id: ProfileSampleType.Percentage, label: t('label.percentage') },
+      { id: ProfileSampleType.Rows, label: t('label.row-plural') },
+    ],
+    [t]
+  );
 
   const sampleConfigType =
     formData?.sampleConfigType ?? SampleConfigType.Dynamic;

--- a/openmetadata-ui/src/main/resources/ui/src/utils/ProfileSampleConfigUtils.test.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/ProfileSampleConfigUtils.test.ts
@@ -17,45 +17,13 @@ import {
   SamplingMethodType,
 } from '../generated/metadataIngestion/databaseServiceProfilerPipeline';
 import {
-  DEFAULT_THRESHOLD,
   DYNAMIC_CONFIG_KEYS,
   pickConfigForType,
-  PROFILE_SAMPLE_TYPE_OPTIONS,
-  SAMPLE_CONFIG_TYPE_OPTIONS,
-  SAMPLING_METHOD_TYPE_OPTIONS,
   STATIC_CONFIG_KEYS,
 } from './ProfileSampleConfigUtils';
 
 describe('ProfileSampleConfigUtils', () => {
-  describe('option constants', () => {
-    it('SAMPLE_CONFIG_TYPE_OPTIONS exposes STATIC and DYNAMIC ids', () => {
-      expect(SAMPLE_CONFIG_TYPE_OPTIONS.map((o) => o.id)).toEqual([
-        SampleConfigType.Static,
-        SampleConfigType.Dynamic,
-      ]);
-    });
-
-    it('PROFILE_SAMPLE_TYPE_OPTIONS exposes PERCENTAGE and ROWS ids', () => {
-      expect(PROFILE_SAMPLE_TYPE_OPTIONS.map((o) => o.id)).toEqual([
-        ProfileSampleType.Percentage,
-        ProfileSampleType.Rows,
-      ]);
-    });
-
-    it('SAMPLING_METHOD_TYPE_OPTIONS exposes BERNOULLI and SYSTEM ids', () => {
-      expect(SAMPLING_METHOD_TYPE_OPTIONS.map((o) => o.id)).toEqual([
-        SamplingMethodType.Bernoulli,
-        SamplingMethodType.System,
-      ]);
-    });
-
-    it('DEFAULT_THRESHOLD has rowCountThreshold=1 and profileSample=100', () => {
-      expect(DEFAULT_THRESHOLD).toEqual({
-        rowCountThreshold: 1,
-        profileSample: 100,
-      });
-    });
-
+  describe('discriminator key constants', () => {
     it('STATIC_CONFIG_KEYS contains only static-side fields', () => {
       expect(STATIC_CONFIG_KEYS).toEqual([
         'profileSample',

--- a/openmetadata-ui/src/main/resources/ui/src/utils/ProfileSampleConfigUtils.test.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/ProfileSampleConfigUtils.test.ts
@@ -1,0 +1,158 @@
+/*
+ *  Copyright 2026 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+import {
+  ICSamplingConfig,
+  ProfileSampleType,
+  SampleConfigType,
+  SamplingMethodType,
+} from '../generated/metadataIngestion/databaseServiceProfilerPipeline';
+import {
+  DEFAULT_THRESHOLD,
+  DYNAMIC_CONFIG_KEYS,
+  pickConfigForType,
+  PROFILE_SAMPLE_TYPE_OPTIONS,
+  SAMPLE_CONFIG_TYPE_OPTIONS,
+  SAMPLING_METHOD_TYPE_OPTIONS,
+  STATIC_CONFIG_KEYS,
+} from './ProfileSampleConfigUtils';
+
+describe('ProfileSampleConfigUtils', () => {
+  describe('option constants', () => {
+    it('SAMPLE_CONFIG_TYPE_OPTIONS exposes STATIC and DYNAMIC ids', () => {
+      expect(SAMPLE_CONFIG_TYPE_OPTIONS.map((o) => o.id)).toEqual([
+        SampleConfigType.Static,
+        SampleConfigType.Dynamic,
+      ]);
+    });
+
+    it('PROFILE_SAMPLE_TYPE_OPTIONS exposes PERCENTAGE and ROWS ids', () => {
+      expect(PROFILE_SAMPLE_TYPE_OPTIONS.map((o) => o.id)).toEqual([
+        ProfileSampleType.Percentage,
+        ProfileSampleType.Rows,
+      ]);
+    });
+
+    it('SAMPLING_METHOD_TYPE_OPTIONS exposes BERNOULLI and SYSTEM ids', () => {
+      expect(SAMPLING_METHOD_TYPE_OPTIONS.map((o) => o.id)).toEqual([
+        SamplingMethodType.Bernoulli,
+        SamplingMethodType.System,
+      ]);
+    });
+
+    it('DEFAULT_THRESHOLD has rowCountThreshold=1 and profileSample=100', () => {
+      expect(DEFAULT_THRESHOLD).toEqual({
+        rowCountThreshold: 1,
+        profileSample: 100,
+      });
+    });
+
+    it('STATIC_CONFIG_KEYS contains only static-side fields', () => {
+      expect(STATIC_CONFIG_KEYS).toEqual([
+        'profileSample',
+        'profileSampleType',
+        'samplingMethodType',
+      ]);
+    });
+
+    it('DYNAMIC_CONFIG_KEYS contains only dynamic-side fields', () => {
+      expect(DYNAMIC_CONFIG_KEYS).toEqual(['smartSampling', 'thresholds']);
+    });
+
+    it('STATIC_CONFIG_KEYS and DYNAMIC_CONFIG_KEYS are disjoint', () => {
+      const intersection = STATIC_CONFIG_KEYS.filter((key) =>
+        (DYNAMIC_CONFIG_KEYS as ReadonlyArray<string>).includes(key)
+      );
+
+      expect(intersection).toEqual([]);
+    });
+  });
+
+  describe('pickConfigForType', () => {
+    it('returns an empty object when config is undefined (STATIC)', () => {
+      expect(pickConfigForType(undefined, SampleConfigType.Static)).toEqual({});
+    });
+
+    it('returns an empty object when config is undefined (DYNAMIC)', () => {
+      expect(pickConfigForType(undefined, SampleConfigType.Dynamic)).toEqual(
+        {}
+      );
+    });
+
+    it('returns an empty object when config has no recognised keys (STATIC)', () => {
+      expect(pickConfigForType({}, SampleConfigType.Static)).toEqual({});
+    });
+
+    it('STATIC drops smartSampling and thresholds, keeps profileSample', () => {
+      const polluted: ICSamplingConfig = {
+        smartSampling: true,
+        thresholds: [],
+        profileSample: 10,
+      };
+
+      expect(pickConfigForType(polluted, SampleConfigType.Static)).toEqual({
+        profileSample: 10,
+      });
+    });
+
+    it('STATIC preserves all three static-only fields when present', () => {
+      const config: ICSamplingConfig = {
+        profileSample: 25,
+        profileSampleType: ProfileSampleType.Rows,
+        samplingMethodType: SamplingMethodType.System,
+      };
+
+      expect(pickConfigForType(config, SampleConfigType.Static)).toEqual(
+        config
+      );
+    });
+
+    it('DYNAMIC drops profileSample/profileSampleType/samplingMethodType, keeps smartSampling and thresholds', () => {
+      const polluted: ICSamplingConfig = {
+        smartSampling: false,
+        thresholds: [{ rowCountThreshold: 1000, profileSample: 50 }],
+        profileSample: 10,
+        profileSampleType: ProfileSampleType.Percentage,
+        samplingMethodType: SamplingMethodType.Bernoulli,
+      };
+
+      expect(pickConfigForType(polluted, SampleConfigType.Dynamic)).toEqual({
+        smartSampling: false,
+        thresholds: [{ rowCountThreshold: 1000, profileSample: 50 }],
+      });
+    });
+
+    it('skips keys whose value is undefined', () => {
+      const config: ICSamplingConfig = {
+        profileSample: undefined,
+        profileSampleType: ProfileSampleType.Percentage,
+      };
+
+      expect(pickConfigForType(config, SampleConfigType.Static)).toEqual({
+        profileSampleType: ProfileSampleType.Percentage,
+      });
+    });
+
+    it('does not mutate the input config', () => {
+      const original: ICSamplingConfig = {
+        smartSampling: true,
+        thresholds: [],
+        profileSample: 10,
+      };
+      const snapshot = JSON.stringify(original);
+
+      pickConfigForType(original, SampleConfigType.Static);
+
+      expect(JSON.stringify(original)).toBe(snapshot);
+    });
+  });
+});

--- a/openmetadata-ui/src/main/resources/ui/src/utils/ProfileSampleConfigUtils.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/ProfileSampleConfigUtils.ts
@@ -1,0 +1,69 @@
+/*
+ *  Copyright 2026 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+import {
+  ICSamplingConfig,
+  ProfileSampleType,
+  SampleConfigType,
+  SamplingMethodType,
+  Threshold,
+} from '../generated/metadataIngestion/databaseServiceProfilerPipeline';
+
+export const SAMPLE_CONFIG_TYPE_OPTIONS = [
+  { id: SampleConfigType.Static, label: 'STATIC' },
+  { id: SampleConfigType.Dynamic, label: 'DYNAMIC' },
+];
+
+export const PROFILE_SAMPLE_TYPE_OPTIONS = [
+  { id: ProfileSampleType.Percentage, label: 'PERCENTAGE' },
+  { id: ProfileSampleType.Rows, label: 'ROWS' },
+];
+
+export const SAMPLING_METHOD_TYPE_OPTIONS = [
+  { id: SamplingMethodType.Bernoulli, label: 'BERNOULLI' },
+  { id: SamplingMethodType.System, label: 'SYSTEM' },
+];
+
+export const DEFAULT_THRESHOLD: Threshold = {
+  rowCountThreshold: 1,
+  profileSample: 100,
+};
+
+export const STATIC_CONFIG_KEYS: ReadonlyArray<keyof ICSamplingConfig> = [
+  'profileSample',
+  'profileSampleType',
+  'samplingMethodType',
+];
+
+export const DYNAMIC_CONFIG_KEYS: ReadonlyArray<keyof ICSamplingConfig> = [
+  'smartSampling',
+  'thresholds',
+];
+
+export const pickConfigForType = (
+  config: ICSamplingConfig | undefined,
+  type: SampleConfigType
+): ICSamplingConfig => {
+  if (!config) {
+    return {};
+  }
+  const allowedKeys =
+    type === SampleConfigType.Static ? STATIC_CONFIG_KEYS : DYNAMIC_CONFIG_KEYS;
+  const result: ICSamplingConfig = {};
+  for (const key of allowedKeys) {
+    if (config[key] !== undefined) {
+      (result as Record<string, unknown>)[key] = config[key];
+    }
+  }
+
+  return result;
+};

--- a/openmetadata-ui/src/main/resources/ui/src/utils/ProfileSampleConfigUtils.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/ProfileSampleConfigUtils.ts
@@ -12,31 +12,8 @@
  */
 import {
   ICSamplingConfig,
-  ProfileSampleType,
   SampleConfigType,
-  SamplingMethodType,
-  Threshold,
 } from '../generated/metadataIngestion/databaseServiceProfilerPipeline';
-
-export const SAMPLE_CONFIG_TYPE_OPTIONS = [
-  { id: SampleConfigType.Static, label: 'STATIC' },
-  { id: SampleConfigType.Dynamic, label: 'DYNAMIC' },
-];
-
-export const PROFILE_SAMPLE_TYPE_OPTIONS = [
-  { id: ProfileSampleType.Percentage, label: 'PERCENTAGE' },
-  { id: ProfileSampleType.Rows, label: 'ROWS' },
-];
-
-export const SAMPLING_METHOD_TYPE_OPTIONS = [
-  { id: SamplingMethodType.Bernoulli, label: 'BERNOULLI' },
-  { id: SamplingMethodType.System, label: 'SYSTEM' },
-];
-
-export const DEFAULT_THRESHOLD: Threshold = {
-  rowCountThreshold: 1,
-  profileSample: 100,
-};
 
 export const STATIC_CONFIG_KEYS: ReadonlyArray<keyof ICSamplingConfig> = [
   'profileSample',


### PR DESCRIPTION

## Demo

https://github.com/user-attachments/assets/295360c7-3ce8-4c5f-bef3-ebb74f5720cc



## Summary

The profiler ingestion form sends a `profileSampleConfig.config` object containing fields from **both** sampling discriminator branches, causing every profiler-pipeline deploy to fail with:

```
3 validation errors for DatabaseServiceProfilerPipeline
profileSampleConfig.config.function-after[parse_name(), DynamicSamplingConfig].profileSample
  Extra inputs are not permitted [input_value=10, input_type=int]
profileSampleConfig.config.function-after[parse_name(), StaticSamplingConfig].thresholds
  Extra inputs are not permitted [input_value=[], input_type=list]
profileSampleConfig.config.function-after[parse_name(), StaticSamplingConfig].smartSampling
  Extra inputs are not permitted [input_value=True, input_type=bool]
```

`Static/DynamicSamplingConfig` both declare `additionalProperties: false`, which Pydantic translates to `extra='forbid'` — so the deploy bounces at airflow validation.

## Root cause

`ProfileSampleConfigField` reads `config` from `formData.config` and uses `{ ...config, [field]: value }` on every static-field edit. When the form initializes with the schema default (`sampleConfigType: "DYNAMIC"`), RJSF default-fills `{ smartSampling: true, thresholds: [] }`. After the user switches to STATIC and sets `profileSample`, the spread carries the stale Dynamic keys into the STATIC payload — producing the mixed object the backend rejects.

The trigger that made this stale-spread visible was #27912, which (a) added `smartSampling` to `DynamicSamplingConfig` and (b) flipped the schema default from `STATIC` to `DYNAMIC`. Pre-#27912 the form opened in STATIC with no Dynamic defaults to leak.

## Fix

Filter `formData.config` to only the keys belonging to the active `sampleConfigType` discriminator (`pickConfigForType`). All downstream handlers then naturally produce a clean payload regardless of how `formData.config` arrived. The change is localized to the field component; no schema or backend changes.

## Changes

- `ProfileSampleConfigField.tsx` — `STATIC_CONFIG_KEYS` / `DYNAMIC_CONFIG_KEYS` whitelists + `pickConfigForType` helper used to derive `config`.
- `ProfileSampleConfigField.test.tsx` — two regression tests, one per leak direction.
- `playwright/e2e/Features/DataQuality/ProfilerIngestionForm.spec.ts` — new E2E coverage:
  - STATIC default + STATIC with all three static fields.
  - DYNAMIC + smart sampling ON.
  - DYNAMIC + smart sampling OFF with multiple thresholds.
  - DYNAMIC threshold add/remove.
  - STATIC ↔ DYNAMIC switch (regression for the leak above).
- `MySqlIngestionClass.ts` — expand `Advanced Config` before reaching `sample-config-type-select` (the section is now collapsed by default).

## Test plan

- [x] `yarn jest src/components/Settings/Services/Ingestion/IngestionWorkflowForm/ProfileSampleConfigField.test.tsx` → 21/21 passing (19 existing + 2 new regression).
- [x] UI checkstyle: `organize-imports:cli`, `lint:fix`, `pretty:base`, `lint:playwright` all clean on the changed files.
- [x] `yarn playwright test playwright/e2e/Features/DataQuality/ProfilerIngestionForm.spec.ts` (needs a live local stack).
- [x] Manual: create a profiler ingestion in the UI, switch to STATIC, set Profile Sample = 10, deploy — should succeed; the `POST /ingestionPipelines` payload should be `{ sampleConfigType: "STATIC", config: { profileSample: 10 } }`.

## Related

Tracked downstream as [openmetadata-collate#4294](https://github.com/open-metadata/openmetadata-collate/issues/4294).