### PR TITLE
fix(glossary): reject deletion of system-defined relation types

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/system/SystemResource.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/system/SystemResource.java
@@ -1175,6 +1175,23 @@ public class SystemResource {
       return;
     }
 
+    // System-defined relation types are part of the seeded contract and must never be deleted,
+    // even when no glossary term currently references them. The "in-use" check below is not
+    // enough on its own — a settings update submitted before any term uses the type would
+    // otherwise silently strip it from the cached settings.
+    List<String> removedSystemDefinedTypes =
+        currentConfig.getRelationTypes().stream()
+            .filter(rt -> !newRelationTypeNames.contains(rt.getName()))
+            .filter(rt -> Boolean.TRUE.equals(rt.getIsSystemDefined()))
+            .map(GlossaryTermRelationType::getName)
+            .toList();
+
+    if (!removedSystemDefinedTypes.isEmpty()) {
+      throw new SystemSettingsException(
+          "Cannot delete system-defined relation types: "
+              + String.join(", ", removedSystemDefinedTypes));
+    }
+
     GlossaryTermRepository glossaryTermRepository =
         (GlossaryTermRepository) Entity.getEntityRepository(Entity.GLOSSARY_TERM);
     Map<String, Integer> usageCounts = glossaryTermRepository.getRelationTypeUsageCounts();


### PR DESCRIPTION
### Describe your changes:

\`validateGlossaryTermRelationSettingsUpdate\` only blocked removal of relation types that were *currently in use* by a glossary term. System-defined types (\`relatedTo\`, \`synonym\`, \`broader\`, \`narrower\`, \`antonym\`, \`partOf\`, \`hasPart\`, \`calculatedFrom\`, \`usedToCalculate\`, \`seeAlso\`) — seeded by \`SettingsCache\` with \`isSystemDefined=true\` — could still be silently deleted by any settings update submitted before any term referenced them. Add an \`isSystemDefined\` check ahead of the in-use check.

### Type of change:
- [x] Bug fix

### Tests:

#### Use cases covered
- A PUT to \`/v1/system/settings\` with \`GLOSSARY_TERM_RELATION_SETTINGS\` that omits any system-defined relation type now returns 400 with \`Cannot delete system-defined relation types: <names>\`.
- The existing \`GlossaryTermRelationSettingsIT.test_systemDefinedRelationTypeCannotBeDeleted\` asserts exactly this contract — it had been a flaky pass-or-mass-fail depending on parallel ordering. With this fix it passes deterministically.

#### Backend integration tests
- No new tests. \`test_systemDefinedRelationTypeCannotBeDeleted\` already encodes the contract; previously it could pass accidentally (when a parallel test had created a \`relatedTo\` relation first, the in-use check would block deletion) or fail loudly (when the destructive test won the race, the deletion went through and cascaded 400s into \`GlossaryTermRelationAdvancedIT\`, \`GlossaryCsvRelationTypesIT\`, \`GlossaryResourceIT.test_importCsv_withApprovedRelatedTerm_succeeds\`, etc.).

### Why now

The bug shipped with \`6d99ba2dc0 Glossary relations (#25886)\` in March — the test was added alongside production code that doesn't enforce the contract it asserts. It became a visible CI-wide flake this week after \`d3d61cb36f Java playwrights for Reindex and SSO (#28008)\` reshuffled the parallel surefire schedule, making the destructive test more likely to land first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)