### PR TITLE
Minor: Add Data Insights lifecycle logging

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/apps/bundles/insights/DataInsightsApp.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/apps/bundles/insights/DataInsightsApp.java
@@ -12,6 +12,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.Supplier;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.exception.ExceptionUtils;
@@ -53,6 +54,7 @@ import org.quartz.JobExecutionContext;
 @Slf4j
 public class DataInsightsApp extends AbstractNativeApplication {
   public static final String DATA_ASSET_INDEX_PREFIX = "di-data-assets";
+  private static final String DATA_INSIGHTS_LOG_PREFIX = "[Data Insights]";
   @Getter private Long timestamp;
   @Getter private int batchSize;
 
@@ -256,37 +258,56 @@ public class DataInsightsApp extends AbstractNativeApplication {
 
   @Override
   public void startApp(JobExecutionContext jobExecutionContext) {
+    long runStartedAt = System.currentTimeMillis();
+    String runType = (String) jobExecutionContext.getJobDetail().getJobDataMap().get("triggerType");
+
     try {
       initializeJob();
+      LOG.info(
+          "{} Lifecycle run started: triggerType={}, batchSize={}, timestamp={}",
+          DATA_INSIGHTS_LOG_PREFIX,
+          runType,
+          batchSize,
+          timestamp);
 
-      LOG.info("Executing DataInsights Job with JobData: {}", jobData);
       jobData.setStatus(EventPublisherJob.Status.RUNNING);
 
-      String runType =
-          (String) jobExecutionContext.getJobDetail().getJobDataMap().get("triggerType");
-
-      if (!runType.equals(ON_DEMAND_JOB)) {
+      if (!ON_DEMAND_JOB.equals(runType)) {
         backfill = Optional.empty();
         recreateDataAssetsIndex = Optional.empty();
       }
 
-      if (recreateDataAssetsIndex.isPresent() && recreateDataAssetsIndex.get().equals(true)) {
+      LOG.info(
+          "{} Effective run settings: backfill={}, recreateDataAssetsIndex={}",
+          DATA_INSIGHTS_LOG_PREFIX,
+          formatBackfill(),
+          Boolean.TRUE.equals(recreateDataAssetsIndex.orElse(false)));
+
+      if (Boolean.TRUE.equals(recreateDataAssetsIndex.orElse(false))) {
+        long recreatePhaseStartedAt = System.currentTimeMillis();
+        LOG.info("{} Phase started: recreateDataAssetsIndex", DATA_INSIGHTS_LOG_PREFIX);
         deleteDataAssetsDataStream();
         createOrUpdateDataAssetsDataStream();
         deleteDataQualityDataIndex();
         createDataQualityDataIndex();
+        LOG.info(
+            "{} Phase completed: recreateDataAssetsIndex, elapsedMs={}",
+            DATA_INSIGHTS_LOG_PREFIX,
+            System.currentTimeMillis() - recreatePhaseStartedAt);
       }
 
-      WorkflowStats webAnalyticsStats = processWebAnalytics();
+      WorkflowStats webAnalyticsStats =
+          runWorkflowPhase("webAnalytics", this::processWebAnalytics);
       updateJobStatsWithWorkflowStats(webAnalyticsStats);
 
-      WorkflowStats costAnalysisStats = processCostAnalysis();
+      WorkflowStats costAnalysisStats = runWorkflowPhase("costAnalysis", this::processCostAnalysis);
       updateJobStatsWithWorkflowStats(costAnalysisStats);
 
-      WorkflowStats dataAssetsStats = processDataAssets();
+      WorkflowStats dataAssetsStats = runWorkflowPhase("dataAssets", this::processDataAssets);
       updateJobStatsWithWorkflowStats(dataAssetsStats);
 
-      WorkflowStats dataQualityStats = processDataQuality();
+      WorkflowStats dataQualityStats =
+          runWorkflowPhase("dataQuality", this::processDataQuality);
       updateJobStatsWithWorkflowStats(dataQualityStats);
 
       if (webAnalyticsStats.hasFailed()
@@ -307,13 +328,18 @@ public class DataInsightsApp extends AbstractNativeApplication {
             new IndexingError()
                 .withErrorSource(IndexingError.ErrorSource.JOB)
                 .withMessage(errorMessage);
-        LOG.error(indexingError.getMessage());
+        LOG.error(
+            "{} Lifecycle run detected workflow failures:{}{}",
+            DATA_INSIGHTS_LOG_PREFIX,
+            System.lineSeparator(),
+            indexingError.getMessage());
         jobData.setStatus(EventPublisherJob.Status.FAILED);
         jobData.setFailure(indexingError);
       }
 
       updateJobStatus();
     } catch (Exception ex) {
+      LOG.error("{} Lifecycle run failed during execution", DATA_INSIGHTS_LOG_PREFIX, ex);
       IndexingError indexingError =
           new IndexingError()
               .withErrorSource(IndexingError.ErrorSource.JOB)
@@ -325,6 +351,7 @@ public class DataInsightsApp extends AbstractNativeApplication {
       jobData.setStatus(EventPublisherJob.Status.FAILED);
       jobData.setFailure(indexingError);
     } finally {
+      logFinalRunSummary(runStartedAt);
       sendUpdates(jobExecutionContext);
     }
   }
@@ -349,6 +376,7 @@ public class DataInsightsApp extends AbstractNativeApplication {
     try {
       workflow.process();
     } catch (SearchIndexException ex) {
+      LOG.error("{} Phase failed: costAnalysis", DATA_INSIGHTS_LOG_PREFIX, ex);
       jobData.setStatus(EventPublisherJob.Status.FAILED);
       jobData.setFailure(ex.getIndexingError());
     }
@@ -373,6 +401,7 @@ public class DataInsightsApp extends AbstractNativeApplication {
     try {
       workflow.process();
     } catch (SearchIndexException ex) {
+      LOG.error("{} Phase failed: dataAssets", DATA_INSIGHTS_LOG_PREFIX, ex);
       jobData.setStatus(EventPublisherJob.Status.FAILED);
       jobData.setFailure(ex.getIndexingError());
     } finally {
@@ -397,6 +426,11 @@ public class DataInsightsApp extends AbstractNativeApplication {
       try {
         workflow.process();
       } catch (SearchIndexException ex) {
+        LOG.error(
+            "{} Phase failed: dataQuality, entityType={}",
+            DATA_INSIGHTS_LOG_PREFIX,
+            entityType,
+            ex);
         jobData.setStatus(EventPublisherJob.Status.FAILED);
         jobData.setFailure(ex.getIndexingError());
       }
@@ -423,6 +457,97 @@ public class DataInsightsApp extends AbstractNativeApplication {
         jobData.setStatus(EventPublisherJob.Status.COMPLETED);
       }
     }
+  }
+
+  private WorkflowStats runWorkflowPhase(
+      String phaseName, Supplier<WorkflowStats> workflowRunner) {
+    long phaseStartedAt = System.currentTimeMillis();
+    LOG.info("{} Phase started: {}", DATA_INSIGHTS_LOG_PREFIX, phaseName);
+    try {
+      WorkflowStats workflowStats = workflowRunner.get();
+      logWorkflowPhaseSummary(phaseName, workflowStats, phaseStartedAt);
+      return workflowStats;
+    } catch (RuntimeException ex) {
+      LOG.error("{} Phase failed: {}", DATA_INSIGHTS_LOG_PREFIX, phaseName, ex);
+      throw ex;
+    }
+  }
+
+  private void logWorkflowPhaseSummary(
+      String phaseName, WorkflowStats workflowStats, long phaseStartedAt) {
+    StepStats workflowSummary = workflowStats.getWorkflowStats();
+    int totalRecords = getStepStatValue(workflowSummary.getTotalRecords());
+    int successRecords = getStepStatValue(workflowSummary.getSuccessRecords());
+    int failedRecords = getStepStatValue(workflowSummary.getFailedRecords());
+    long elapsedMs = System.currentTimeMillis() - phaseStartedAt;
+
+    if (workflowStats.hasFailed()) {
+      LOG.warn(
+          "{} Phase completed with errors: phase={}, elapsedMs={}, total={}, success={}, failed={}, failureCount={}",
+          DATA_INSIGHTS_LOG_PREFIX,
+          phaseName,
+          elapsedMs,
+          totalRecords,
+          successRecords,
+          failedRecords,
+          workflowStats.getFailures().size());
+    } else {
+      LOG.info(
+          "{} Phase completed: phase={}, elapsedMs={}, total={}, success={}, failed={}",
+          DATA_INSIGHTS_LOG_PREFIX,
+          phaseName,
+          elapsedMs,
+          totalRecords,
+          successRecords,
+          failedRecords);
+    }
+  }
+
+  private void logFinalRunSummary(long runStartedAt) {
+    StepStats jobStats = jobData.getStats() != null ? jobData.getStats().getJobStats() : null;
+    int totalRecords = jobStats != null ? getStepStatValue(jobStats.getTotalRecords()) : 0;
+    int successRecords = jobStats != null ? getStepStatValue(jobStats.getSuccessRecords()) : 0;
+    int failedRecords = jobStats != null ? getStepStatValue(jobStats.getFailedRecords()) : 0;
+    long elapsedMs = System.currentTimeMillis() - runStartedAt;
+
+    if (jobData.getStatus() == EventPublisherJob.Status.FAILED) {
+      LOG.error(
+          "{} Lifecycle run finished with failure: status={}, elapsedMs={}, total={}, success={}, failed={}",
+          DATA_INSIGHTS_LOG_PREFIX,
+          jobData.getStatus(),
+          elapsedMs,
+          totalRecords,
+          successRecords,
+          failedRecords);
+    } else if (jobData.getStatus() == EventPublisherJob.Status.STOPPED) {
+      LOG.info(
+          "{} Lifecycle run stopped: status={}, elapsedMs={}, total={}, success={}, failed={}",
+          DATA_INSIGHTS_LOG_PREFIX,
+          jobData.getStatus(),
+          elapsedMs,
+          totalRecords,
+          successRecords,
+          failedRecords);
+    } else {
+      LOG.info(
+          "{} Lifecycle run completed: status={}, elapsedMs={}, total={}, success={}, failed={}",
+          DATA_INSIGHTS_LOG_PREFIX,
+          jobData.getStatus(),
+          elapsedMs,
+          totalRecords,
+          successRecords,
+          failedRecords);
+    }
+  }
+
+  private String formatBackfill() {
+    return backfill
+        .map(value -> String.format("%s..%s", value.startDate(), value.endDate()))
+        .orElse("disabled");
+  }
+
+  private int getStepStatValue(Integer value) {
+    return value == null ? 0 : value;
   }
 
   @Override

--- a/openmetadata-service/src/main/java/org/openmetadata/service/apps/bundles/insights/DataInsightsApp.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/apps/bundles/insights/DataInsightsApp.java
@@ -55,10 +55,47 @@ import org.quartz.JobExecutionContext;
 public class DataInsightsApp extends AbstractNativeApplication {
   public static final String DATA_ASSET_INDEX_PREFIX = "di-data-assets";
   private static final String DATA_INSIGHTS_LOG_PREFIX = "[Data Insights]";
+  private static final String UNKNOWN_TRIGGER_TYPE = "unknown";
+  private static final String PHASE_COMPLETED_LOG =
+      "{} Phase completed: phase={}, elapsedMs={}, total={}, success={}, failed={}";
+  private static final String PHASE_COMPLETED_WITH_ERRORS_LOG =
+      "{} Phase completed with errors: phase={}, elapsedMs={}, total={}, success={}, failed={}, failureCount={}";
+  private static final String RUN_COMPLETED_LOG =
+      "{} Lifecycle run completed: status={}, elapsedMs={}, total={}, success={}, failed={}";
+  private static final String RUN_FAILED_LOG =
+      "{} Lifecycle run finished with failure: status={}, elapsedMs={}, total={}, success={}, failed={}";
+  private static final String RUN_STOPPED_LOG =
+      "{} Lifecycle run stopped: status={}, elapsedMs={}, total={}, success={}, failed={}";
   @Getter private Long timestamp;
   @Getter private int batchSize;
 
   public record Backfill(String startDate, String endDate) {}
+
+  private record LogSummary(long elapsedMs, int totalRecords, int successRecords, int failedRecords) {
+    private Object[] phaseArgs(String phaseName) {
+      return new Object[] {
+        DATA_INSIGHTS_LOG_PREFIX, phaseName, elapsedMs, totalRecords, successRecords, failedRecords
+      };
+    }
+
+    private Object[] phaseErrorArgs(String phaseName, int failureCount) {
+      return new Object[] {
+        DATA_INSIGHTS_LOG_PREFIX,
+        phaseName,
+        elapsedMs,
+        totalRecords,
+        successRecords,
+        failedRecords,
+        failureCount
+      };
+    }
+
+    private Object[] runArgs(EventPublisherJob.Status status) {
+      return new Object[] {
+        DATA_INSIGHTS_LOG_PREFIX, status, elapsedMs, totalRecords, successRecords, failedRecords
+      };
+    }
+  }
 
   private CostAnalysisConfig costAnalysisConfig;
   private DataAssetsConfig dataAssetsConfig;
@@ -259,7 +296,10 @@ public class DataInsightsApp extends AbstractNativeApplication {
   @Override
   public void startApp(JobExecutionContext jobExecutionContext) {
     long runStartedAt = System.currentTimeMillis();
-    String runType = (String) jobExecutionContext.getJobDetail().getJobDataMap().get("triggerType");
+    String runType =
+        Optional.ofNullable(
+                (String) jobExecutionContext.getJobDetail().getJobDataMap().get("triggerType"))
+            .orElse(UNKNOWN_TRIGGER_TYPE);
 
     try {
       initializeJob();
@@ -376,9 +416,7 @@ public class DataInsightsApp extends AbstractNativeApplication {
     try {
       workflow.process();
     } catch (SearchIndexException ex) {
-      LOG.error("{} Phase failed: costAnalysis", DATA_INSIGHTS_LOG_PREFIX, ex);
-      jobData.setStatus(EventPublisherJob.Status.FAILED);
-      jobData.setFailure(ex.getIndexingError());
+      recordSearchIndexFailure(ex);
     }
 
     return workflowStats;
@@ -401,9 +439,7 @@ public class DataInsightsApp extends AbstractNativeApplication {
     try {
       workflow.process();
     } catch (SearchIndexException ex) {
-      LOG.error("{} Phase failed: dataAssets", DATA_INSIGHTS_LOG_PREFIX, ex);
-      jobData.setStatus(EventPublisherJob.Status.FAILED);
-      jobData.setFailure(ex.getIndexingError());
+      recordSearchIndexFailure(ex);
     } finally {
       this.activeDataAssetsWorkflow = null;
     }
@@ -426,13 +462,7 @@ public class DataInsightsApp extends AbstractNativeApplication {
       try {
         workflow.process();
       } catch (SearchIndexException ex) {
-        LOG.error(
-            "{} Phase failed: dataQuality, entityType={}",
-            DATA_INSIGHTS_LOG_PREFIX,
-            entityType,
-            ex);
-        jobData.setStatus(EventPublisherJob.Status.FAILED);
-        jobData.setFailure(ex.getIndexingError());
+        recordSearchIndexFailure(ex);
       }
     }
 
@@ -475,69 +505,53 @@ public class DataInsightsApp extends AbstractNativeApplication {
 
   private void logWorkflowPhaseSummary(
       String phaseName, WorkflowStats workflowStats, long phaseStartedAt) {
-    StepStats workflowSummary = workflowStats.getWorkflowStats();
-    int totalRecords = getStepStatValue(workflowSummary.getTotalRecords());
-    int successRecords = getStepStatValue(workflowSummary.getSuccessRecords());
-    int failedRecords = getStepStatValue(workflowSummary.getFailedRecords());
-    long elapsedMs = System.currentTimeMillis() - phaseStartedAt;
-
+    LogSummary summary = buildLogSummary(workflowStats.getWorkflowStats(), phaseStartedAt);
     if (workflowStats.hasFailed()) {
       LOG.warn(
-          "{} Phase completed with errors: phase={}, elapsedMs={}, total={}, success={}, failed={}, failureCount={}",
-          DATA_INSIGHTS_LOG_PREFIX,
-          phaseName,
-          elapsedMs,
-          totalRecords,
-          successRecords,
-          failedRecords,
-          workflowStats.getFailures().size());
-    } else {
-      LOG.info(
-          "{} Phase completed: phase={}, elapsedMs={}, total={}, success={}, failed={}",
-          DATA_INSIGHTS_LOG_PREFIX,
-          phaseName,
-          elapsedMs,
-          totalRecords,
-          successRecords,
-          failedRecords);
+          PHASE_COMPLETED_WITH_ERRORS_LOG,
+          summary.phaseErrorArgs(phaseName, workflowStats.getFailures().size()));
+      return;
     }
+    LOG.info(PHASE_COMPLETED_LOG, summary.phaseArgs(phaseName));
   }
 
   private void logFinalRunSummary(long runStartedAt) {
-    StepStats jobStats = jobData.getStats() != null ? jobData.getStats().getJobStats() : null;
-    int totalRecords = jobStats != null ? getStepStatValue(jobStats.getTotalRecords()) : 0;
-    int successRecords = jobStats != null ? getStepStatValue(jobStats.getSuccessRecords()) : 0;
-    int failedRecords = jobStats != null ? getStepStatValue(jobStats.getFailedRecords()) : 0;
-    long elapsedMs = System.currentTimeMillis() - runStartedAt;
-
-    if (jobData.getStatus() == EventPublisherJob.Status.FAILED) {
-      LOG.error(
-          "{} Lifecycle run finished with failure: status={}, elapsedMs={}, total={}, success={}, failed={}",
-          DATA_INSIGHTS_LOG_PREFIX,
-          jobData.getStatus(),
-          elapsedMs,
-          totalRecords,
-          successRecords,
-          failedRecords);
-    } else if (jobData.getStatus() == EventPublisherJob.Status.STOPPED) {
-      LOG.info(
-          "{} Lifecycle run stopped: status={}, elapsedMs={}, total={}, success={}, failed={}",
-          DATA_INSIGHTS_LOG_PREFIX,
-          jobData.getStatus(),
-          elapsedMs,
-          totalRecords,
-          successRecords,
-          failedRecords);
-    } else {
-      LOG.info(
-          "{} Lifecycle run completed: status={}, elapsedMs={}, total={}, success={}, failed={}",
-          DATA_INSIGHTS_LOG_PREFIX,
-          jobData.getStatus(),
-          elapsedMs,
-          totalRecords,
-          successRecords,
-          failedRecords);
+    LogSummary summary = buildLogSummary(getJobStats(), runStartedAt);
+    EventPublisherJob.Status status = jobData.getStatus();
+    if (status == EventPublisherJob.Status.FAILED) {
+      LOG.error(RUN_FAILED_LOG, summary.runArgs(status));
+      return;
     }
+    if (status == EventPublisherJob.Status.STOPPED) {
+      LOG.info(RUN_STOPPED_LOG, summary.runArgs(status));
+      return;
+    }
+    LOG.info(RUN_COMPLETED_LOG, summary.runArgs(status));
+  }
+
+  private void recordSearchIndexFailure(SearchIndexException ex) {
+    jobData.setStatus(EventPublisherJob.Status.FAILED);
+    jobData.setFailure(ex.getIndexingError());
+  }
+
+  private LogSummary buildLogSummary(StepStats stats, long startedAt) {
+    if (stats == null) {
+      return buildEmptyLogSummary(startedAt);
+    }
+    long elapsedMs = System.currentTimeMillis() - startedAt;
+    return new LogSummary(
+        elapsedMs,
+        getStepStatValue(stats.getTotalRecords()),
+        getStepStatValue(stats.getSuccessRecords()),
+        getStepStatValue(stats.getFailedRecords()));
+  }
+
+  private LogSummary buildEmptyLogSummary(long startedAt) {
+    return new LogSummary(System.currentTimeMillis() - startedAt, 0, 0, 0);
+  }
+
+  private StepStats getJobStats() {
+    return jobData.getStats() != null ? jobData.getStats().getJobStats() : null;
   }
 
   private String formatBackfill() {

--- a/openmetadata-service/src/main/java/org/openmetadata/service/apps/bundles/insights/DataInsightsApp.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/apps/bundles/insights/DataInsightsApp.java
@@ -72,31 +72,7 @@ public class DataInsightsApp extends AbstractNativeApplication {
   public record Backfill(String startDate, String endDate) {}
 
   private record LogSummary(
-      long elapsedMs, int totalRecords, int successRecords, int failedRecords) {
-    private Object[] phaseArgs(String phaseName) {
-      return new Object[] {
-        DATA_INSIGHTS_LOG_PREFIX, phaseName, elapsedMs, totalRecords, successRecords, failedRecords
-      };
-    }
-
-    private Object[] phaseErrorArgs(String phaseName, int failureCount) {
-      return new Object[] {
-        DATA_INSIGHTS_LOG_PREFIX,
-        phaseName,
-        elapsedMs,
-        totalRecords,
-        successRecords,
-        failedRecords,
-        failureCount
-      };
-    }
-
-    private Object[] runArgs(EventPublisherJob.Status status) {
-      return new Object[] {
-        DATA_INSIGHTS_LOG_PREFIX, status, elapsedMs, totalRecords, successRecords, failedRecords
-      };
-    }
-  }
+      long elapsedMs, int totalRecords, int successRecords, int failedRecords) {}
 
   private CostAnalysisConfig costAnalysisConfig;
   private DataAssetsConfig dataAssetsConfig;
@@ -349,32 +325,8 @@ public class DataInsightsApp extends AbstractNativeApplication {
       WorkflowStats dataQualityStats = runWorkflowPhase("dataQuality", this::processDataQuality);
       updateJobStatsWithWorkflowStats(dataQualityStats);
 
-      if (webAnalyticsStats.hasFailed()
-          || costAnalysisStats.hasFailed()
-          || dataAssetsStats.hasFailed()) {
-        String errorMessage = "Errors Found:\n";
-
-        for (WorkflowStats stats : List.of(webAnalyticsStats, costAnalysisStats, dataAssetsStats)) {
-          if (stats.hasFailed()) {
-            errorMessage = String.format("%s\n  %s\n", errorMessage, stats.getName());
-            for (String failure : stats.getFailures()) {
-              errorMessage = String.format("%s    - %s\n", errorMessage, failure);
-            }
-          }
-        }
-
-        IndexingError indexingError =
-            new IndexingError()
-                .withErrorSource(IndexingError.ErrorSource.JOB)
-                .withMessage(errorMessage);
-        LOG.error(
-            "{} Lifecycle run detected workflow failures:{}{}",
-            DATA_INSIGHTS_LOG_PREFIX,
-            System.lineSeparator(),
-            indexingError.getMessage());
-        jobData.setStatus(EventPublisherJob.Status.FAILED);
-        jobData.setFailure(indexingError);
-      }
+      recordWorkflowFailures(
+          List.of(webAnalyticsStats, costAnalysisStats, dataAssetsStats, dataQualityStats));
 
       updateJobStatus();
     } catch (Exception ex) {
@@ -415,7 +367,7 @@ public class DataInsightsApp extends AbstractNativeApplication {
     try {
       workflow.process();
     } catch (SearchIndexException ex) {
-      recordSearchIndexFailure(ex);
+      recordSearchIndexFailure("costAnalysis", workflowStats, ex);
     }
 
     return workflowStats;
@@ -438,7 +390,7 @@ public class DataInsightsApp extends AbstractNativeApplication {
     try {
       workflow.process();
     } catch (SearchIndexException ex) {
-      recordSearchIndexFailure(ex);
+      recordSearchIndexFailure("dataAssets", workflowStats, ex);
     } finally {
       this.activeDataAssetsWorkflow = null;
     }
@@ -461,7 +413,8 @@ public class DataInsightsApp extends AbstractNativeApplication {
       try {
         workflow.process();
       } catch (SearchIndexException ex) {
-        recordSearchIndexFailure(ex);
+        recordSearchIndexFailure(
+            "dataQuality:" + entityType, DataQualityWorkflow.getWorkflowStats(), ex);
       }
     }
 
@@ -505,31 +458,128 @@ public class DataInsightsApp extends AbstractNativeApplication {
       String phaseName, WorkflowStats workflowStats, long phaseStartedAt) {
     LogSummary summary = buildLogSummary(workflowStats.getWorkflowStats(), phaseStartedAt);
     if (workflowStats.hasFailed()) {
-      LOG.warn(
-          PHASE_COMPLETED_WITH_ERRORS_LOG,
-          summary.phaseErrorArgs(phaseName, workflowStats.getFailures().size()));
+      logPhaseCompletedWithErrors(phaseName, summary, workflowStats.getFailures().size());
       return;
     }
-    LOG.info(PHASE_COMPLETED_LOG, summary.phaseArgs(phaseName));
+    logPhaseCompleted(phaseName, summary);
   }
 
   private void logFinalRunSummary(long runStartedAt) {
     LogSummary summary = buildLogSummary(getJobStats(), runStartedAt);
     EventPublisherJob.Status status = jobData.getStatus();
     if (status == EventPublisherJob.Status.FAILED) {
-      LOG.error(RUN_FAILED_LOG, summary.runArgs(status));
+      logRunFailed(status, summary);
       return;
     }
     if (status == EventPublisherJob.Status.STOPPED) {
-      LOG.info(RUN_STOPPED_LOG, summary.runArgs(status));
+      logRunInfo(RUN_STOPPED_LOG, status, summary);
       return;
     }
-    LOG.info(RUN_COMPLETED_LOG, summary.runArgs(status));
+    logRunInfo(RUN_COMPLETED_LOG, status, summary);
   }
 
-  private void recordSearchIndexFailure(SearchIndexException ex) {
+  private void logPhaseCompleted(String phaseName, LogSummary summary) {
+    LOG.info(
+        PHASE_COMPLETED_LOG,
+        DATA_INSIGHTS_LOG_PREFIX,
+        phaseName,
+        summary.elapsedMs(),
+        summary.totalRecords(),
+        summary.successRecords(),
+        summary.failedRecords());
+  }
+
+  private void logPhaseCompletedWithErrors(String phaseName, LogSummary summary, int failureCount) {
+    LOG.warn(
+        PHASE_COMPLETED_WITH_ERRORS_LOG,
+        DATA_INSIGHTS_LOG_PREFIX,
+        phaseName,
+        summary.elapsedMs(),
+        summary.totalRecords(),
+        summary.successRecords(),
+        summary.failedRecords(),
+        failureCount);
+  }
+
+  private void logRunFailed(EventPublisherJob.Status status, LogSummary summary) {
+    LOG.error(
+        RUN_FAILED_LOG,
+        DATA_INSIGHTS_LOG_PREFIX,
+        status,
+        summary.elapsedMs(),
+        summary.totalRecords(),
+        summary.successRecords(),
+        summary.failedRecords());
+  }
+
+  private void logRunInfo(String logTemplate, EventPublisherJob.Status status, LogSummary summary) {
+    LOG.info(
+        logTemplate,
+        DATA_INSIGHTS_LOG_PREFIX,
+        status,
+        summary.elapsedMs(),
+        summary.totalRecords(),
+        summary.successRecords(),
+        summary.failedRecords());
+  }
+
+  private void recordWorkflowFailures(List<WorkflowStats> workflowStats) {
+    if (workflowStats.stream().noneMatch(WorkflowStats::hasFailed)) {
+      return;
+    }
+
+    IndexingError indexingError = buildWorkflowFailureError(workflowStats);
+    LOG.error(
+        "{} Lifecycle run detected workflow failures:{}{}",
+        DATA_INSIGHTS_LOG_PREFIX,
+        System.lineSeparator(),
+        indexingError.getMessage());
+    setJobFailed(indexingError);
+  }
+
+  private IndexingError buildWorkflowFailureError(List<WorkflowStats> workflowStats) {
+    return new IndexingError()
+        .withErrorSource(IndexingError.ErrorSource.JOB)
+        .withMessage(buildWorkflowFailureMessage(workflowStats));
+  }
+
+  private String buildWorkflowFailureMessage(List<WorkflowStats> workflowStats) {
+    StringBuilder errorMessage = new StringBuilder("Errors Found:\n");
+    for (WorkflowStats stats : workflowStats) {
+      if (stats.hasFailed()) {
+        errorMessage.append("\n  ").append(stats.getName()).append("\n");
+        for (String failure : stats.getFailures()) {
+          errorMessage.append("    - ").append(failure).append("\n");
+        }
+      }
+    }
+    return errorMessage.toString();
+  }
+
+  private void recordSearchIndexFailure(
+      String phaseName, WorkflowStats workflowStats, SearchIndexException ex) {
+    LOG.error("{} Phase failed: {}", DATA_INSIGHTS_LOG_PREFIX, phaseName, ex);
+    IndexingError indexingError = getSearchIndexError(ex);
+    workflowStats.addFailure(formatSearchIndexFailure(phaseName, indexingError));
+    setJobFailed(indexingError);
+  }
+
+  private IndexingError getSearchIndexError(SearchIndexException ex) {
+    if (ex.getIndexingError() != null) {
+      return ex.getIndexingError();
+    }
+    return new IndexingError()
+        .withErrorSource(IndexingError.ErrorSource.JOB)
+        .withMessage(ExceptionUtils.getMessage(ex));
+  }
+
+  private String formatSearchIndexFailure(String phaseName, IndexingError indexingError) {
+    return String.format("Failed processing %s: %s", phaseName, indexingError.getMessage());
+  }
+
+  private void setJobFailed(IndexingError indexingError) {
     jobData.setStatus(EventPublisherJob.Status.FAILED);
-    jobData.setFailure(ex.getIndexingError());
+    jobData.setFailure(indexingError);
   }
 
   private LogSummary buildLogSummary(StepStats stats, long startedAt) {

--- a/openmetadata-service/src/main/java/org/openmetadata/service/apps/bundles/insights/DataInsightsApp.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/apps/bundles/insights/DataInsightsApp.java
@@ -8,6 +8,7 @@ import static org.openmetadata.service.workflows.searchIndex.ReindexingUtil.getI
 
 import es.co.elastic.clients.transport.rest5_client.low_level.Rest5Client;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -27,6 +28,7 @@ import org.openmetadata.schema.entity.applications.configuration.internal.DataAs
 import org.openmetadata.schema.entity.applications.configuration.internal.DataInsightsAppConfig;
 import org.openmetadata.schema.entity.applications.configuration.internal.DataQualityConfig;
 import org.openmetadata.schema.service.configuration.elasticsearch.ElasticSearchConfiguration;
+import org.openmetadata.schema.system.EntityError;
 import org.openmetadata.schema.system.EntityStats;
 import org.openmetadata.schema.system.EventPublisherJob;
 import org.openmetadata.schema.system.IndexingError;
@@ -536,7 +538,7 @@ public class DataInsightsApp extends AbstractNativeApplication {
         DATA_INSIGHTS_LOG_PREFIX,
         System.lineSeparator(),
         indexingError.getMessage());
-    setJobFailedIfUnset(indexingError);
+    setJobFailedWithWorkflowFailure(indexingError);
   }
 
   private IndexingError buildWorkflowFailureError(List<WorkflowStats> workflowStats) {
@@ -584,11 +586,56 @@ public class DataInsightsApp extends AbstractNativeApplication {
     jobData.setFailure(indexingError);
   }
 
-  private void setJobFailedIfUnset(IndexingError indexingError) {
+  private void setJobFailedWithWorkflowFailure(IndexingError workflowFailure) {
     jobData.setStatus(EventPublisherJob.Status.FAILED);
-    if (jobData.getFailure() == null) {
-      jobData.setFailure(indexingError);
+    jobData.setFailure(mergeWithExistingFailure(workflowFailure));
+  }
+
+  private IndexingError mergeWithExistingFailure(IndexingError workflowFailure) {
+    IndexingError existingFailure = jobData.getFailure();
+    if (existingFailure == null) {
+      return workflowFailure;
     }
+    IndexingError mergedFailure = copyIndexingError(existingFailure);
+    mergedFailure.setMessage(
+        buildMergedFailureMessage(existingFailure.getMessage(), workflowFailure.getMessage()));
+    if (mergedFailure.getErrorSource() == null) {
+      mergedFailure.setErrorSource(workflowFailure.getErrorSource());
+    }
+    return mergedFailure;
+  }
+
+  private IndexingError copyIndexingError(IndexingError indexingError) {
+    IndexingError copy =
+        new IndexingError()
+            .withErrorSource(indexingError.getErrorSource())
+            .withLastFailedCursor(indexingError.getLastFailedCursor())
+            .withMessage(indexingError.getMessage())
+            .withFailedEntities(copyFailedEntities(indexingError))
+            .withReason(indexingError.getReason())
+            .withStackTrace(indexingError.getStackTrace())
+            .withSubmittedCount(indexingError.getSubmittedCount())
+            .withSuccessCount(indexingError.getSuccessCount())
+            .withFailedCount(indexingError.getFailedCount());
+    indexingError.getAdditionalProperties().forEach(copy::setAdditionalProperty);
+    return copy;
+  }
+
+  private List<EntityError> copyFailedEntities(IndexingError indexingError) {
+    if (indexingError.getFailedEntities() == null) {
+      return null;
+    }
+    return new ArrayList<>(indexingError.getFailedEntities());
+  }
+
+  private String buildMergedFailureMessage(String existingMessage, String workflowMessage) {
+    if (existingMessage == null || existingMessage.isBlank()) {
+      return workflowMessage;
+    }
+    if (workflowMessage == null || workflowMessage.isBlank()) {
+      return existingMessage;
+    }
+    return existingMessage + System.lineSeparator() + System.lineSeparator() + workflowMessage;
   }
 
   private LogSummary buildLogSummary(StepStats stats, long startedAt) {

--- a/openmetadata-service/src/main/java/org/openmetadata/service/apps/bundles/insights/DataInsightsApp.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/apps/bundles/insights/DataInsightsApp.java
@@ -399,6 +399,7 @@ public class DataInsightsApp extends AbstractNativeApplication {
   }
 
   private WorkflowStats processDataQuality() {
+    DataQualityWorkflow.resetWorkflowStats();
     for (String entityType : dataQualityEntities) {
       DataQualityWorkflow workflow =
           new DataQualityWorkflow(

--- a/openmetadata-service/src/main/java/org/openmetadata/service/apps/bundles/insights/DataInsightsApp.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/apps/bundles/insights/DataInsightsApp.java
@@ -71,7 +71,8 @@ public class DataInsightsApp extends AbstractNativeApplication {
 
   public record Backfill(String startDate, String endDate) {}
 
-  private record LogSummary(long elapsedMs, int totalRecords, int successRecords, int failedRecords) {
+  private record LogSummary(
+      long elapsedMs, int totalRecords, int successRecords, int failedRecords) {
     private Object[] phaseArgs(String phaseName) {
       return new Object[] {
         DATA_INSIGHTS_LOG_PREFIX, phaseName, elapsedMs, totalRecords, successRecords, failedRecords
@@ -336,8 +337,7 @@ public class DataInsightsApp extends AbstractNativeApplication {
             System.currentTimeMillis() - recreatePhaseStartedAt);
       }
 
-      WorkflowStats webAnalyticsStats =
-          runWorkflowPhase("webAnalytics", this::processWebAnalytics);
+      WorkflowStats webAnalyticsStats = runWorkflowPhase("webAnalytics", this::processWebAnalytics);
       updateJobStatsWithWorkflowStats(webAnalyticsStats);
 
       WorkflowStats costAnalysisStats = runWorkflowPhase("costAnalysis", this::processCostAnalysis);
@@ -346,8 +346,7 @@ public class DataInsightsApp extends AbstractNativeApplication {
       WorkflowStats dataAssetsStats = runWorkflowPhase("dataAssets", this::processDataAssets);
       updateJobStatsWithWorkflowStats(dataAssetsStats);
 
-      WorkflowStats dataQualityStats =
-          runWorkflowPhase("dataQuality", this::processDataQuality);
+      WorkflowStats dataQualityStats = runWorkflowPhase("dataQuality", this::processDataQuality);
       updateJobStatsWithWorkflowStats(dataQualityStats);
 
       if (webAnalyticsStats.hasFailed()
@@ -489,8 +488,7 @@ public class DataInsightsApp extends AbstractNativeApplication {
     }
   }
 
-  private WorkflowStats runWorkflowPhase(
-      String phaseName, Supplier<WorkflowStats> workflowRunner) {
+  private WorkflowStats runWorkflowPhase(String phaseName, Supplier<WorkflowStats> workflowRunner) {
     long phaseStartedAt = System.currentTimeMillis();
     LOG.info("{} Phase started: {}", DATA_INSIGHTS_LOG_PREFIX, phaseName);
     try {

--- a/openmetadata-service/src/main/java/org/openmetadata/service/apps/bundles/insights/DataInsightsApp.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/apps/bundles/insights/DataInsightsApp.java
@@ -536,7 +536,7 @@ public class DataInsightsApp extends AbstractNativeApplication {
         DATA_INSIGHTS_LOG_PREFIX,
         System.lineSeparator(),
         indexingError.getMessage());
-    setJobFailed(indexingError);
+    setJobFailedIfUnset(indexingError);
   }
 
   private IndexingError buildWorkflowFailureError(List<WorkflowStats> workflowStats) {
@@ -582,6 +582,13 @@ public class DataInsightsApp extends AbstractNativeApplication {
   private void setJobFailed(IndexingError indexingError) {
     jobData.setStatus(EventPublisherJob.Status.FAILED);
     jobData.setFailure(indexingError);
+  }
+
+  private void setJobFailedIfUnset(IndexingError indexingError) {
+    jobData.setStatus(EventPublisherJob.Status.FAILED);
+    if (jobData.getFailure() == null) {
+      jobData.setFailure(indexingError);
+    }
   }
 
   private LogSummary buildLogSummary(StepStats stats, long startedAt) {

--- a/openmetadata-service/src/main/java/org/openmetadata/service/apps/bundles/insights/DataInsightsApp.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/apps/bundles/insights/DataInsightsApp.java
@@ -399,7 +399,7 @@ public class DataInsightsApp extends AbstractNativeApplication {
   }
 
   private WorkflowStats processDataQuality() {
-    DataQualityWorkflow.resetWorkflowStats();
+    WorkflowStats dataQualityStats = new WorkflowStats("DataQualityWorkflow");
     for (String entityType : dataQualityEntities) {
       DataQualityWorkflow workflow =
           new DataQualityWorkflow(
@@ -410,16 +410,17 @@ public class DataInsightsApp extends AbstractNativeApplication {
               entityType,
               collectionDAO,
               searchRepository);
+      WorkflowStats workflowStats = workflow.getWorkflowStats();
 
       try {
         workflow.process();
       } catch (SearchIndexException ex) {
-        recordSearchIndexFailure(
-            "dataQuality:" + entityType, DataQualityWorkflow.getWorkflowStats(), ex);
+        recordSearchIndexFailure("dataQuality:" + entityType, workflowStats, ex);
       }
+      dataQualityStats.merge(workflowStats);
     }
 
-    return DataQualityWorkflow.getWorkflowStats();
+    return dataQualityStats;
   }
 
   private void updateJobStatsWithWorkflowStats(WorkflowStats workflowStats) {

--- a/openmetadata-service/src/main/java/org/openmetadata/service/apps/bundles/insights/workflows/WorkflowStats.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/apps/bundles/insights/workflows/WorkflowStats.java
@@ -40,6 +40,23 @@ public class WorkflowStats {
     workflowStats.setWarningRecords(0);
   }
 
+  public void merge(WorkflowStats other) {
+    failures.addAll(other.getFailures());
+    workflowStepStats.putAll(other.getWorkflowStepStats());
+    workflowStats.setTotalRecords(
+        getStepStatValue(workflowStats.getTotalRecords())
+            + getStepStatValue(other.getWorkflowStats().getTotalRecords()));
+    workflowStats.setSuccessRecords(
+        getStepStatValue(workflowStats.getSuccessRecords())
+            + getStepStatValue(other.getWorkflowStats().getSuccessRecords()));
+    workflowStats.setFailedRecords(
+        getStepStatValue(workflowStats.getFailedRecords())
+            + getStepStatValue(other.getWorkflowStats().getFailedRecords()));
+    workflowStats.setWarningRecords(
+        getStepStatValue(workflowStats.getWarningRecords())
+            + getStepStatValue(other.getWorkflowStats().getWarningRecords()));
+  }
+
   public Boolean hasFailed() {
     return !failures.isEmpty();
   }
@@ -50,5 +67,9 @@ public class WorkflowStats {
 
   public void updateWorkflowStepStats(String stepName, StepStats newStepStats) {
     workflowStepStats.put(stepName, newStepStats);
+  }
+
+  private int getStepStatValue(Integer value) {
+    return value == null ? 0 : value;
   }
 }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/apps/bundles/insights/workflows/WorkflowStats.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/apps/bundles/insights/workflows/WorkflowStats.java
@@ -89,40 +89,44 @@ public class WorkflowStats {
   }
 
   private StepStats mergeStepStats(StepStats currentStats, StepStats newStats) {
-    currentStats.setTotalRecords(
-        getStepStatValue(currentStats.getTotalRecords())
-            + getStepStatValue(newStats.getTotalRecords()));
-    currentStats.setSuccessRecords(
-        getStepStatValue(currentStats.getSuccessRecords())
-            + getStepStatValue(newStats.getSuccessRecords()));
-    currentStats.setFailedRecords(
-        getStepStatValue(currentStats.getFailedRecords())
-            + getStepStatValue(newStats.getFailedRecords()));
-    currentStats.setWarningRecords(
-        getStepStatValue(currentStats.getWarningRecords())
-            + getStepStatValue(newStats.getWarningRecords()));
-    currentStats.setVectorSuccessRecords(
-        getStepStatValue(currentStats.getVectorSuccessRecords())
-            + getStepStatValue(newStats.getVectorSuccessRecords()));
-    currentStats.setVectorFailedRecords(
-        getStepStatValue(currentStats.getVectorFailedRecords())
-            + getStepStatValue(newStats.getVectorFailedRecords()));
-    currentStats.setTotalTimeMs(
-        getStepStatValue(currentStats.getTotalTimeMs())
-            + getStepStatValue(newStats.getTotalTimeMs()));
-    currentStats.setReaderTimeMs(
-        getStepStatValue(currentStats.getReaderTimeMs())
-            + getStepStatValue(newStats.getReaderTimeMs()));
-    currentStats.setProcessTimeMs(
-        getStepStatValue(currentStats.getProcessTimeMs())
-            + getStepStatValue(newStats.getProcessTimeMs()));
-    currentStats.setSinkTimeMs(
-        getStepStatValue(currentStats.getSinkTimeMs())
-            + getStepStatValue(newStats.getSinkTimeMs()));
-    currentStats.setVectorTimeMs(
-        getStepStatValue(currentStats.getVectorTimeMs())
-            + getStepStatValue(newStats.getVectorTimeMs()));
+    mergeRecordCounts(currentStats, newStats);
+    mergeVectorCounts(currentStats, newStats);
+    mergeTimings(currentStats, newStats);
     return currentStats;
+  }
+
+  private void mergeRecordCounts(StepStats currentStats, StepStats newStats) {
+    currentStats.setTotalRecords(sum(currentStats.getTotalRecords(), newStats.getTotalRecords()));
+    currentStats.setSuccessRecords(
+        sum(currentStats.getSuccessRecords(), newStats.getSuccessRecords()));
+    currentStats.setFailedRecords(
+        sum(currentStats.getFailedRecords(), newStats.getFailedRecords()));
+    currentStats.setWarningRecords(
+        sum(currentStats.getWarningRecords(), newStats.getWarningRecords()));
+  }
+
+  private void mergeVectorCounts(StepStats currentStats, StepStats newStats) {
+    currentStats.setVectorSuccessRecords(
+        sum(currentStats.getVectorSuccessRecords(), newStats.getVectorSuccessRecords()));
+    currentStats.setVectorFailedRecords(
+        sum(currentStats.getVectorFailedRecords(), newStats.getVectorFailedRecords()));
+  }
+
+  private void mergeTimings(StepStats currentStats, StepStats newStats) {
+    currentStats.setTotalTimeMs(sum(currentStats.getTotalTimeMs(), newStats.getTotalTimeMs()));
+    currentStats.setReaderTimeMs(sum(currentStats.getReaderTimeMs(), newStats.getReaderTimeMs()));
+    currentStats.setProcessTimeMs(
+        sum(currentStats.getProcessTimeMs(), newStats.getProcessTimeMs()));
+    currentStats.setSinkTimeMs(sum(currentStats.getSinkTimeMs(), newStats.getSinkTimeMs()));
+    currentStats.setVectorTimeMs(sum(currentStats.getVectorTimeMs(), newStats.getVectorTimeMs()));
+  }
+
+  private int sum(Integer currentValue, Integer newValue) {
+    return getStepStatValue(currentValue) + getStepStatValue(newValue);
+  }
+
+  private long sum(Long currentValue, Long newValue) {
+    return getStepStatValue(currentValue) + getStepStatValue(newValue);
   }
 
   private long getStepStatValue(Long value) {

--- a/openmetadata-service/src/main/java/org/openmetadata/service/apps/bundles/insights/workflows/WorkflowStats.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/apps/bundles/insights/workflows/WorkflowStats.java
@@ -38,23 +38,23 @@ public class WorkflowStats {
     workflowStats.setSuccessRecords(0);
     workflowStats.setFailedRecords(0);
     workflowStats.setWarningRecords(0);
+    workflowStats.setVectorSuccessRecords(0);
+    workflowStats.setVectorFailedRecords(0);
+    workflowStats.setTotalTimeMs(0L);
+    workflowStats.setReaderTimeMs(0L);
+    workflowStats.setProcessTimeMs(0L);
+    workflowStats.setSinkTimeMs(0L);
+    workflowStats.setVectorTimeMs(0L);
   }
 
   public void merge(WorkflowStats other) {
     failures.addAll(other.getFailures());
-    workflowStepStats.putAll(other.getWorkflowStepStats());
-    workflowStats.setTotalRecords(
-        getStepStatValue(workflowStats.getTotalRecords())
-            + getStepStatValue(other.getWorkflowStats().getTotalRecords()));
-    workflowStats.setSuccessRecords(
-        getStepStatValue(workflowStats.getSuccessRecords())
-            + getStepStatValue(other.getWorkflowStats().getSuccessRecords()));
-    workflowStats.setFailedRecords(
-        getStepStatValue(workflowStats.getFailedRecords())
-            + getStepStatValue(other.getWorkflowStats().getFailedRecords()));
-    workflowStats.setWarningRecords(
-        getStepStatValue(workflowStats.getWarningRecords())
-            + getStepStatValue(other.getWorkflowStats().getWarningRecords()));
+    other
+        .getWorkflowStepStats()
+        .forEach(
+            (stepName, stepStats) ->
+                workflowStepStats.merge(stepName, copyStepStats(stepStats), this::mergeStepStats));
+    mergeStepStats(workflowStats, other.getWorkflowStats());
   }
 
   public Boolean hasFailed() {
@@ -70,6 +70,62 @@ public class WorkflowStats {
   }
 
   private int getStepStatValue(Integer value) {
+    return value == null ? 0 : value;
+  }
+
+  private StepStats copyStepStats(StepStats stats) {
+    return new StepStats()
+        .withTotalRecords(stats.getTotalRecords())
+        .withSuccessRecords(stats.getSuccessRecords())
+        .withFailedRecords(stats.getFailedRecords())
+        .withWarningRecords(stats.getWarningRecords())
+        .withVectorSuccessRecords(stats.getVectorSuccessRecords())
+        .withVectorFailedRecords(stats.getVectorFailedRecords())
+        .withTotalTimeMs(stats.getTotalTimeMs())
+        .withReaderTimeMs(stats.getReaderTimeMs())
+        .withProcessTimeMs(stats.getProcessTimeMs())
+        .withSinkTimeMs(stats.getSinkTimeMs())
+        .withVectorTimeMs(stats.getVectorTimeMs());
+  }
+
+  private StepStats mergeStepStats(StepStats currentStats, StepStats newStats) {
+    currentStats.setTotalRecords(
+        getStepStatValue(currentStats.getTotalRecords())
+            + getStepStatValue(newStats.getTotalRecords()));
+    currentStats.setSuccessRecords(
+        getStepStatValue(currentStats.getSuccessRecords())
+            + getStepStatValue(newStats.getSuccessRecords()));
+    currentStats.setFailedRecords(
+        getStepStatValue(currentStats.getFailedRecords())
+            + getStepStatValue(newStats.getFailedRecords()));
+    currentStats.setWarningRecords(
+        getStepStatValue(currentStats.getWarningRecords())
+            + getStepStatValue(newStats.getWarningRecords()));
+    currentStats.setVectorSuccessRecords(
+        getStepStatValue(currentStats.getVectorSuccessRecords())
+            + getStepStatValue(newStats.getVectorSuccessRecords()));
+    currentStats.setVectorFailedRecords(
+        getStepStatValue(currentStats.getVectorFailedRecords())
+            + getStepStatValue(newStats.getVectorFailedRecords()));
+    currentStats.setTotalTimeMs(
+        getStepStatValue(currentStats.getTotalTimeMs())
+            + getStepStatValue(newStats.getTotalTimeMs()));
+    currentStats.setReaderTimeMs(
+        getStepStatValue(currentStats.getReaderTimeMs())
+            + getStepStatValue(newStats.getReaderTimeMs()));
+    currentStats.setProcessTimeMs(
+        getStepStatValue(currentStats.getProcessTimeMs())
+            + getStepStatValue(newStats.getProcessTimeMs()));
+    currentStats.setSinkTimeMs(
+        getStepStatValue(currentStats.getSinkTimeMs())
+            + getStepStatValue(newStats.getSinkTimeMs()));
+    currentStats.setVectorTimeMs(
+        getStepStatValue(currentStats.getVectorTimeMs())
+            + getStepStatValue(newStats.getVectorTimeMs()));
+    return currentStats;
+  }
+
+  private long getStepStatValue(Long value) {
     return value == null ? 0 : value;
   }
 }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/apps/bundles/insights/workflows/WorkflowStats.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/apps/bundles/insights/workflows/WorkflowStats.java
@@ -31,6 +31,15 @@ public class WorkflowStats {
     failures.add(msg);
   }
 
+  public void reset() {
+    failures.clear();
+    workflowStepStats.clear();
+    workflowStats.setTotalRecords(0);
+    workflowStats.setSuccessRecords(0);
+    workflowStats.setFailedRecords(0);
+    workflowStats.setWarningRecords(0);
+  }
+
   public Boolean hasFailed() {
     return !failures.isEmpty();
   }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/apps/bundles/insights/workflows/dataQuality/DataQualityWorkflow.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/apps/bundles/insights/workflows/dataQuality/DataQualityWorkflow.java
@@ -55,12 +55,7 @@ public class DataQualityWorkflow {
   Processor entityProcessor;
   Sink searchIndexSink;
 
-  @Getter
-  private static final WorkflowStats workflowStats = new WorkflowStats("DataQualityWorkflow");
-
-  public static void resetWorkflowStats() {
-    workflowStats.reset();
-  }
+  @Getter private final WorkflowStats workflowStats = new WorkflowStats("DataQualityWorkflow");
 
   public DataQualityWorkflow(
       DataQualityConfig dataQualityConfig,

--- a/openmetadata-service/src/main/java/org/openmetadata/service/apps/bundles/insights/workflows/dataQuality/DataQualityWorkflow.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/apps/bundles/insights/workflows/dataQuality/DataQualityWorkflow.java
@@ -58,6 +58,10 @@ public class DataQualityWorkflow {
   @Getter
   private static final WorkflowStats workflowStats = new WorkflowStats("DataQualityWorkflow");
 
+  public static void resetWorkflowStats() {
+    workflowStats.reset();
+  }
+
   public DataQualityWorkflow(
       DataQualityConfig dataQualityConfig,
       Long timestamp,

--- a/openmetadata-service/src/test/java/org/openmetadata/service/apps/bundles/insights/workflows/WorkflowStatsTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/apps/bundles/insights/workflows/WorkflowStatsTest.java
@@ -1,0 +1,44 @@
+/*
+ *  Copyright 2026 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ *  except in compliance with the License. You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software distributed under the License
+ *  is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and limitations under
+ *  the License.
+ */
+package org.openmetadata.service.apps.bundles.insights.workflows;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+import org.openmetadata.schema.system.StepStats;
+
+class WorkflowStatsTest {
+
+  @Test
+  void resetClearsFailuresStepStatsAndAggregateCounters() {
+    WorkflowStats stats = new WorkflowStats("testWorkflow");
+    stats.addFailure("previous failure");
+    stats.updateWorkflowStepStats(
+        "previousStep",
+        new StepStats().withTotalRecords(5).withSuccessRecords(3).withFailedRecords(2));
+    stats.getWorkflowStats().setTotalRecords(5);
+    stats.getWorkflowStats().setSuccessRecords(3);
+    stats.getWorkflowStats().setFailedRecords(2);
+    stats.getWorkflowStats().setWarningRecords(1);
+
+    stats.reset();
+
+    assertFalse(stats.hasFailed());
+    assertTrue(stats.getFailures().isEmpty());
+    assertTrue(stats.getWorkflowStepStats().isEmpty());
+    assertEquals(0, stats.getWorkflowStats().getTotalRecords());
+    assertEquals(0, stats.getWorkflowStats().getSuccessRecords());
+    assertEquals(0, stats.getWorkflowStats().getFailedRecords());
+    assertEquals(0, stats.getWorkflowStats().getWarningRecords());
+  }
+}

--- a/openmetadata-service/src/test/java/org/openmetadata/service/apps/bundles/insights/workflows/WorkflowStatsTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/apps/bundles/insights/workflows/WorkflowStatsTest.java
@@ -41,4 +41,40 @@ class WorkflowStatsTest {
     assertEquals(0, stats.getWorkflowStats().getFailedRecords());
     assertEquals(0, stats.getWorkflowStats().getWarningRecords());
   }
+
+  @Test
+  void mergeAggregatesFailuresStepStatsAndCounters() {
+    WorkflowStats target = new WorkflowStats("mergedWorkflow");
+    target.getWorkflowStats().setTotalRecords(4);
+    target.getWorkflowStats().setSuccessRecords(3);
+    target.getWorkflowStats().setFailedRecords(1);
+    target.updateWorkflowStepStats(
+        "existingStep",
+        new StepStats().withTotalRecords(4).withSuccessRecords(3).withFailedRecords(1));
+
+    WorkflowStats source = new WorkflowStats("sourceWorkflow");
+    source.addFailure("source failure");
+    source.getWorkflowStats().setTotalRecords(6);
+    source.getWorkflowStats().setSuccessRecords(5);
+    source.getWorkflowStats().setFailedRecords(1);
+    source.getWorkflowStats().setWarningRecords(2);
+    source.updateWorkflowStepStats(
+        "sourceStep",
+        new StepStats()
+            .withTotalRecords(6)
+            .withSuccessRecords(5)
+            .withFailedRecords(1)
+            .withWarningRecords(2));
+
+    target.merge(source);
+
+    assertTrue(target.hasFailed());
+    assertEquals("source failure", target.getFailures().get(0));
+    assertTrue(target.getWorkflowStepStats().containsKey("existingStep"));
+    assertTrue(target.getWorkflowStepStats().containsKey("sourceStep"));
+    assertEquals(10, target.getWorkflowStats().getTotalRecords());
+    assertEquals(8, target.getWorkflowStats().getSuccessRecords());
+    assertEquals(2, target.getWorkflowStats().getFailedRecords());
+    assertEquals(2, target.getWorkflowStats().getWarningRecords());
+  }
 }

--- a/openmetadata-service/src/test/java/org/openmetadata/service/apps/bundles/insights/workflows/WorkflowStatsTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/apps/bundles/insights/workflows/WorkflowStatsTest.java
@@ -30,6 +30,13 @@ class WorkflowStatsTest {
     stats.getWorkflowStats().setSuccessRecords(3);
     stats.getWorkflowStats().setFailedRecords(2);
     stats.getWorkflowStats().setWarningRecords(1);
+    stats.getWorkflowStats().setVectorSuccessRecords(4);
+    stats.getWorkflowStats().setVectorFailedRecords(1);
+    stats.getWorkflowStats().setTotalTimeMs(50L);
+    stats.getWorkflowStats().setReaderTimeMs(10L);
+    stats.getWorkflowStats().setProcessTimeMs(20L);
+    stats.getWorkflowStats().setSinkTimeMs(15L);
+    stats.getWorkflowStats().setVectorTimeMs(5L);
 
     stats.reset();
 
@@ -40,17 +47,43 @@ class WorkflowStatsTest {
     assertEquals(0, stats.getWorkflowStats().getSuccessRecords());
     assertEquals(0, stats.getWorkflowStats().getFailedRecords());
     assertEquals(0, stats.getWorkflowStats().getWarningRecords());
+    assertEquals(0, stats.getWorkflowStats().getVectorSuccessRecords());
+    assertEquals(0, stats.getWorkflowStats().getVectorFailedRecords());
+    assertEquals(0L, stats.getWorkflowStats().getTotalTimeMs());
+    assertEquals(0L, stats.getWorkflowStats().getReaderTimeMs());
+    assertEquals(0L, stats.getWorkflowStats().getProcessTimeMs());
+    assertEquals(0L, stats.getWorkflowStats().getSinkTimeMs());
+    assertEquals(0L, stats.getWorkflowStats().getVectorTimeMs());
   }
 
   @Test
-  void mergeAggregatesFailuresStepStatsAndCounters() {
+  void mergeAggregatesFailuresStepStatsAndCountersWithoutOverwritingDuplicateSteps() {
     WorkflowStats target = new WorkflowStats("mergedWorkflow");
     target.getWorkflowStats().setTotalRecords(4);
     target.getWorkflowStats().setSuccessRecords(3);
     target.getWorkflowStats().setFailedRecords(1);
+    target.getWorkflowStats().setWarningRecords(1);
+    target.getWorkflowStats().setVectorSuccessRecords(2);
+    target.getWorkflowStats().setVectorFailedRecords(1);
+    target.getWorkflowStats().setTotalTimeMs(10L);
+    target.getWorkflowStats().setReaderTimeMs(2L);
+    target.getWorkflowStats().setProcessTimeMs(3L);
+    target.getWorkflowStats().setSinkTimeMs(4L);
+    target.getWorkflowStats().setVectorTimeMs(5L);
     target.updateWorkflowStepStats(
         "existingStep",
-        new StepStats().withTotalRecords(4).withSuccessRecords(3).withFailedRecords(1));
+        new StepStats()
+            .withTotalRecords(4)
+            .withSuccessRecords(3)
+            .withFailedRecords(1)
+            .withWarningRecords(1)
+            .withVectorSuccessRecords(2)
+            .withVectorFailedRecords(1)
+            .withTotalTimeMs(10L)
+            .withReaderTimeMs(2L)
+            .withProcessTimeMs(3L)
+            .withSinkTimeMs(4L)
+            .withVectorTimeMs(5L));
 
     WorkflowStats source = new WorkflowStats("sourceWorkflow");
     source.addFailure("source failure");
@@ -58,23 +91,56 @@ class WorkflowStatsTest {
     source.getWorkflowStats().setSuccessRecords(5);
     source.getWorkflowStats().setFailedRecords(1);
     source.getWorkflowStats().setWarningRecords(2);
+    source.getWorkflowStats().setVectorSuccessRecords(4);
+    source.getWorkflowStats().setVectorFailedRecords(2);
+    source.getWorkflowStats().setTotalTimeMs(20L);
+    source.getWorkflowStats().setReaderTimeMs(3L);
+    source.getWorkflowStats().setProcessTimeMs(4L);
+    source.getWorkflowStats().setSinkTimeMs(5L);
+    source.getWorkflowStats().setVectorTimeMs(6L);
     source.updateWorkflowStepStats(
-        "sourceStep",
+        "existingStep",
         new StepStats()
             .withTotalRecords(6)
             .withSuccessRecords(5)
             .withFailedRecords(1)
-            .withWarningRecords(2));
+            .withWarningRecords(2)
+            .withVectorSuccessRecords(4)
+            .withVectorFailedRecords(2)
+            .withTotalTimeMs(20L)
+            .withReaderTimeMs(3L)
+            .withProcessTimeMs(4L)
+            .withSinkTimeMs(5L)
+            .withVectorTimeMs(6L));
 
     target.merge(source);
 
     assertTrue(target.hasFailed());
     assertEquals("source failure", target.getFailures().get(0));
     assertTrue(target.getWorkflowStepStats().containsKey("existingStep"));
-    assertTrue(target.getWorkflowStepStats().containsKey("sourceStep"));
     assertEquals(10, target.getWorkflowStats().getTotalRecords());
     assertEquals(8, target.getWorkflowStats().getSuccessRecords());
     assertEquals(2, target.getWorkflowStats().getFailedRecords());
-    assertEquals(2, target.getWorkflowStats().getWarningRecords());
+    assertEquals(3, target.getWorkflowStats().getWarningRecords());
+    assertEquals(6, target.getWorkflowStats().getVectorSuccessRecords());
+    assertEquals(3, target.getWorkflowStats().getVectorFailedRecords());
+    assertEquals(30L, target.getWorkflowStats().getTotalTimeMs());
+    assertEquals(5L, target.getWorkflowStats().getReaderTimeMs());
+    assertEquals(7L, target.getWorkflowStats().getProcessTimeMs());
+    assertEquals(9L, target.getWorkflowStats().getSinkTimeMs());
+    assertEquals(11L, target.getWorkflowStats().getVectorTimeMs());
+
+    StepStats mergedStep = target.getWorkflowStepStats().get("existingStep");
+    assertEquals(10, mergedStep.getTotalRecords());
+    assertEquals(8, mergedStep.getSuccessRecords());
+    assertEquals(2, mergedStep.getFailedRecords());
+    assertEquals(3, mergedStep.getWarningRecords());
+    assertEquals(6, mergedStep.getVectorSuccessRecords());
+    assertEquals(3, mergedStep.getVectorFailedRecords());
+    assertEquals(30L, mergedStep.getTotalTimeMs());
+    assertEquals(5L, mergedStep.getReaderTimeMs());
+    assertEquals(7L, mergedStep.getProcessTimeMs());
+    assertEquals(9L, mergedStep.getSinkTimeMs());
+    assertEquals(11L, mergedStep.getVectorTimeMs());
   }
 }


### PR DESCRIPTION
## What changed
- add lifecycle logging to the Data Insights app run entrypoint
- log effective run settings, phase start/end, phase failures, and final run summary
- log explicit failures for cost analysis, data assets, and data quality phases

## Why
Data Insights did not emit consistent operator-facing lifecycle logs across the phases it executes. This made long-running or partially failing jobs harder to diagnose.

## Impact
Operators now get clearer lifecycle visibility for Data Insights runs, including phase boundaries, errors, and final status summaries.

## Validation
- `git -C OpenMetadata diff --check -- openmetadata-service/src/main/java/org/openmetadata/service/apps/bundles/insights/DataInsightsApp.java`
- `mvn -pl openmetadata-service -am -DskipTests compile` ❌

## Validation notes
The full `openmetadata-service` compile is currently blocked in this worktree by broader existing Elasticsearch client dependency resolution errors across multiple OpenMetadata search classes, including files outside this change.

----
## Summary by Gitar

- **Enhanced lifecycle tracking:**
  - Integrated `WorkflowStats` reset and merge capabilities to ensure accurate per-run telemetry.
- **Improved error handling:**
  - Centralized failure logging via `recordWorkflowFailures` to prevent redundant error reporting.
  - Updated `DataQualityWorkflow` to instance-based stats tracking, replacing static state to improve reliability.
- **Test coverage:**
  - Added `WorkflowStatsTest` to verify correct reset and aggregation of workflow statistics.


<sub>This will update automatically on new commits.</sub>