### PR TITLE
fix(playwright): page through cursor in 'List tasks by status' test

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/Tasks.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/Tasks.spec.ts
@@ -15,6 +15,7 @@ import { TaskClass } from '../../support/entity/TaskClass';
 import { UserClass } from '../../support/user/UserClass';
 import { authenticateAdminPage } from '../../utils/admin';
 import { getApiContext } from '../../utils/common';
+import { findTaskInList } from '../../utils/taskAPI';
 
 test.describe('Task Entity API Tests', () => {
   const user1 = new UserClass();
@@ -212,25 +213,14 @@ test.describe('Task Entity API Tests', () => {
     // Verify the task was created
     expect(openTask.responseData?.id).toBeDefined();
 
-    // Poll until task appears in the list (may take time for indexing)
-    let foundTask: { id: string } | undefined;
-    for (let i = 0; i < 15; i++) {
-      // Try without status filter first since tasks might use different status values
-      const response = await apiContext.get('/api/v1/tasks', {
-        params: { limit: 100 },
-      });
-      const data = await response.json();
-
-      expect(data.data).toBeDefined();
-      expect(Array.isArray(data.data)).toBe(true);
-
-      foundTask = data.data.find(
-        (t: { id: string }) => t.id === openTask.responseData?.id
-      );
-      if (foundTask) break;
-
-      await new Promise((resolve) => setTimeout(resolve, 1000));
-    }
+    const foundTask = await findTaskInList(
+      apiContext,
+      openTask.responseData?.id ?? '',
+      {
+        status: 'Open',
+        createdById: openTask.responseData?.createdById,
+      }
+    );
 
     expect(foundTask).toBeDefined();
 

--- a/openmetadata-ui/src/main/resources/ui/playwright/support/entity/TaskClass.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/support/entity/TaskClass.ts
@@ -38,6 +38,7 @@ export interface TaskResponseData {
   status: string;
   priority?: string;
   createdBy?: { id: string; name: string };
+  createdById?: string;
   assignees?: { id: string; name: string }[];
 }
 

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/taskAPI.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/taskAPI.ts
@@ -1,0 +1,97 @@
+/*
+ *  Copyright 2026 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+import { APIRequestContext, expect } from '@playwright/test';
+
+const DEFAULT_PAGE_SIZE = 100;
+const DEFAULT_MAX_ATTEMPTS = 15;
+const DEFAULT_DELAY_MS = 1000;
+
+interface TaskListItem {
+  id: string;
+  [key: string]: unknown;
+}
+
+interface TaskListResponse {
+  data: TaskListItem[];
+  paging?: { after?: string; before?: string; total?: number };
+}
+
+export interface FindTaskInListOptions {
+  status?: string;
+  createdById?: string;
+  pageSize?: number;
+  maxAttempts?: number;
+  delayMs?: number;
+}
+
+/**
+ * `GET /api/v1/tasks` is cursor-paginated and sorted by `(name, id)`, not by
+ * recency. On populated environments a freshly-created task can sit on a
+ * page past the first one, so a single-page lookup is unreliable.
+ *
+ * This helper scopes the list with whatever filters the caller passes
+ * (typically `status` and `createdById`) and walks every page with the
+ * `after` cursor before giving up on an attempt. The outer retry exists
+ * only to absorb a genuine post-create indexing delay.
+ *
+ * Returns the matching task or `undefined` if it never appears within the
+ * retry budget.
+ */
+export const findTaskInList = async (
+  apiContext: APIRequestContext,
+  taskId: string,
+  options: FindTaskInListOptions = {}
+): Promise<TaskListItem | undefined> => {
+  const {
+    status,
+    createdById,
+    pageSize = DEFAULT_PAGE_SIZE,
+    maxAttempts = DEFAULT_MAX_ATTEMPTS,
+    delayMs = DEFAULT_DELAY_MS,
+  } = options;
+
+  for (let attempt = 0; attempt < maxAttempts; attempt++) {
+    let after: string | undefined;
+    do {
+      const params: Record<string, string | number> = { limit: pageSize };
+      if (status) {
+        params.status = status;
+      }
+      if (createdById) {
+        params.createdById = createdById;
+      }
+      if (after) {
+        params.after = after;
+      }
+
+      const response = await apiContext.get('/api/v1/tasks', { params });
+      const data = (await response.json()) as TaskListResponse;
+
+      expect(data.data).toBeDefined();
+      expect(Array.isArray(data.data)).toBe(true);
+
+      const match = data.data.find((t) => t.id === taskId);
+      if (match) {
+        return match;
+      }
+
+      after = data.paging?.after;
+    } while (after);
+
+    if (attempt < maxAttempts - 1) {
+      await new Promise((resolve) => setTimeout(resolve, delayMs));
+    }
+  }
+
+  return undefined;
+};


### PR DESCRIPTION
## Summary

Nightly Playwright test `Task Entity API Tests > List tasks by status` (`openmetadata-ui/.../playwright/e2e/Pages/Tasks.spec.ts:202`, added in #25894) fails on populated environments because `GET /api/v1/tasks` is cursor-paginated and sorted by `(name, id)` — not by recency. The test creates a `pw-task-<uuid>` task and then expects to find it in the very first `limit=100` page of an unfiltered list. On the failing nightly env (28,834 existing tasks) the new task sits past page 1, the 15-retry outer loop keeps requesting the same first page, and the assertion at line 235 fires with `Received: undefined`.

Captured trace evidence: all 15 `GET /api/v1/tasks?limit=100` responses returned identical 224,306-byte bodies covering names `"API Validation Test Task - ..."` → `"Incident: pw_test_case_76fbfb17"`. `pw-task-<uuid>` sorts alphabetically beyond `"Incident:"`, so it never appears.

## Repro

On a freshly-seeded local docker OM (only 9 tasks, default), the test passes. Reproduced the nightly failure by seeding 120 tasks named `AAA-seed-####` to push `pw-task-*` off page 1 — same exact `expect(foundTask).toBeDefined()` failure at line 235.

## Fix

- **New** `playwright/utils/taskAPI.ts` with `findTaskInList(apiContext, taskId, { status, createdById })`. It scopes the listing with whatever filters the caller passes and walks `paging.after` to the end of the result set before retrying with a delay. The outer retry exists only to absorb a genuine post-create indexing lag.
- The spec now calls `findTaskInList(apiContext, openTask.responseData?.id, { status: 'Open', createdById: openTask.responseData?.createdById })`. `status: 'Open'` matches the test's title (the old comment "Try without status filter first since tasks might use different status values" was self-flagged as a stop-gap); `createdById` scopes to tasks this run could plausibly have created.
- Added `createdById?: string` to `TaskResponseData` — already on the API response payload, just missing from the TS interface.

## Verification (local)

```bash
cd openmetadata-ui/src/main/resources/ui
PLAYWRIGHT_TEST_BASE_URL=http://localhost:8585 \
  npx playwright test playwright/e2e/Pages/Tasks.spec.ts -g "List tasks by status" \
  --project=chromium --workers=1 --repeat-each=3
```

- Un-fixed spec against 129-task seeded env → fails with the same nightly error at line 235.
- Fixed spec against the same 129-task seeded env → **3/3 passes in ~3s each**.
- Full `Task Entity API Tests` describe (9 tests) → **9/9 pass**, no sibling regressions.

## Test plan

- [ ] Nightly Playwright run is green for `Task Entity API Tests > List tasks by status`
- [ ] No regressions in sibling tests of the same describe
- [ ] `findTaskInList` is reusable by future task-API tests that need to look up a freshly-created task on a populated env

🤖 Generated with [Claude Code](https://claude.com/claude-code)