### PR TITLE
fix(playwright): register pipeline list response listener before navigation

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/TestSuiteMultiPipeline.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/TestSuiteMultiPipeline.spec.ts
@@ -43,7 +43,7 @@ test(
     const { apiContext, afterAction } = await getApiContext(page);
     const table = new TableClass(`multi pipeline !@#$%^&*()_-+=test-${uuid()}`);
     await table.create(apiContext);
-    await table.visitEntityPage(page, table.entity.name);
+    await table.visitEntityPage(page, table.entity.displayName);
     const testCaseName = `multi-pipeline-test-${uuid()}`;
     const pipelineName = `test suite pipeline 2`;
 
@@ -149,7 +149,9 @@ test(
         )
         .click();
 
-      await expect(page.getByRole('checkbox').first()).toBeVisible();
+      await expect(
+        page.getByTestId('week-segment-day-option-container')
+      ).toBeVisible();
 
       await page
         .getByTestId('week-segment-day-option-container')
@@ -249,7 +251,7 @@ test(
       apiContext,
       testCaseNames
     );
-    await table.visitEntityPage(page, table.entity.name);
+    await table.visitEntityPage(page, table.entity.displayName);
     await page.getByText('Data Observability').click();
     await page.getByRole('tab', { name: 'Data Quality' }).click();
 

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/TestSuiteMultiPipeline.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/TestSuiteMultiPipeline.spec.ts
@@ -304,11 +304,9 @@ test(
       /has been updated and deployed successfully/
     );
 
-    await page.getByTestId('view-service-button').click();
-
     const ingestionPipelinesListResponse2 =
       waitForTestSuiteIngestionPipelinesListResponse(page);
-    await page.getByRole('tab', { name: 'Pipeline' }).click();
+    await page.getByTestId('view-service-button').click();
     await ingestionPipelinesListResponse2;
 
     // Verify the pipeline now shows count "1" after unchecking one test case


### PR DESCRIPTION
## Summary
- `waitForTestSuiteIngestionPipelinesListResponse` was registered **after** `view-service-button` click in the "Edit the pipeline's test case" test
- After clicking the button, the app navigates back and the Pipeline tab is already active — no new request fires
- Listener missed the response → `waitForResponse` timed out after 180s
<img width="985" height="387" alt="Screenshot 2026-05-29 at 11 57 49 AM" src="https://github.com/user-attachments/assets/25ee25c5-585d-4b8b-b596-8f15a7652bb0" />



**Fix:** move listener registration to before the button click so it captures the response fired during navigation.

## Test plan
- [ ] Run `TestSuiteMultiPipeline.spec.ts` — "Edit the pipeline's test case" should pass without timeout

🤖 Generated with [Claude Code](https://claude.com/claude-code)


----
## Summary by Gitar

- **Bug fixes:**
  - Added rejection logic for deleting system-defined relation types in the glossary module.
- **Playwright tests:**
  - Adjusted registration of `waitForTestSuiteIngestionPipelinesListResponse` to prevent race conditions during pipeline navigation.
  - Updated `TestSuiteMultiPipeline.spec.ts` to visit entity pages using `table.entity.displayName` and verify `week-segment-day-option-container` visibility.

<sub>This will update automatically on new commits.</sub>