### PR TITLE
fix(playwright): mark observability alert tests as slow to prevent timeout failures

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Flow/ObservabilityAlerts.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Flow/ObservabilityAlerts.spec.ts
@@ -187,6 +187,7 @@ test.beforeEach(async ({ page }) => {
 });
 
 test('Pipeline Alert', async ({ page }) => {
+  test.slow();
   const ALERT_NAME = generateAlertName();
 
   await test.step('Create alert', async () => {
@@ -277,6 +278,7 @@ const observabilityDetailsBySource = new Map<
 
 for (const { source, sourceDisplayName } of OBSERVABILITY_SOURCES) {
   test(`${sourceDisplayName} alert`, async ({ page }) => {
+    test.slow();
     const alertDetails = observabilityDetailsBySource.get(source);
     if (!alertDetails) {
       throw new Error(


### PR DESCRIPTION
## Summary

Error: The test timed out, added the screenshot below
<img width="1259" height="930" alt="Screenshot 2026-05-28 at 7 50 08 PM" src="https://github.com/user-attachments/assets/ed1597eb-8ea2-49c8-a280-c45417c56ec7" />

- Adds `test.slow()` to two tests in `ObservabilityAlerts.spec.ts` to triple the default timeout
- Prevents flaky timeout failures in CI for observability alert flow tests that take longer than the default threshold

<img width="889" height="784" alt="Screenshot 2026-05-28 at 5 36 33 PM" src="https://github.com/user-attachments/assets/1ae6168b-8e95-4457-9df2-1e7e983fb319" />


## Test plan

- [ ] Verify CI Playwright runs pass for `ObservabilityAlerts.spec.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)