### PR TITLE
fix(security): bump mlflow-skinny and surface jsonify in trigger route

### DIFF
--- a/ingestion/setup.py
+++ b/ingestion/setup.py
@@ -350,9 +350,8 @@ plugins: Dict[str, Set[str]] = {  # noqa: UP006
         VERSIONS["giturlparse"],
         "python-liquid",
     },
-    # <3.11 keeps the search/registry surface stable; the MySQL integration test
-    # sets log_bin_trust_function_creators=1 so the 3.8.1+ trigger creation passes.
-    "mlflow": {"mlflow-skinny>=3.10.0,<3.11"},
+    # >=3.11.1 closes CVE-2026-4137 (insecure tmp dir permissions).
+    "mlflow": {"mlflow-skinny>=3.11.1,<3.13"},
     "mongo": {VERSIONS["mongo"], VERSIONS["pandas"], VERSIONS["numpy"]},
     "cassandra": {VERSIONS["cassandra"]},
     "couchbase": {"couchbase~=4.1"},

--- a/openmetadata-airflow-apis/openmetadata_managed_apis/api/routes/trigger.py
+++ b/openmetadata-airflow-apis/openmetadata_managed_apis/api/routes/trigger.py
@@ -15,7 +15,7 @@ Trigger endpoint
 import traceback
 from typing import Callable  # noqa: UP035
 
-from flask import Blueprint, Response, request
+from flask import Blueprint, Response, jsonify, make_response, request
 
 from openmetadata_managed_apis.api.response import ApiResponse
 from openmetadata_managed_apis.api.utils import (
@@ -63,9 +63,8 @@ def get_fn(blueprint: Blueprint) -> Callable:
         try:
             run_id = get_request_arg(request, "run_id", raise_missing=False)
             conf = get_request_conf()
-            response = trigger(dag_id, run_id, conf=conf)
-
-            return response  # noqa: RET504, TRY300
+            payload, status = trigger(dag_id, run_id, conf=conf)
+            return make_response(jsonify(payload), status)
 
         except Exception as exc:
             logger.debug(traceback.format_exc())

--- a/openmetadata-airflow-apis/openmetadata_managed_apis/api/routes/trigger.py
+++ b/openmetadata-airflow-apis/openmetadata_managed_apis/api/routes/trigger.py
@@ -63,8 +63,8 @@ def get_fn(blueprint: Blueprint) -> Callable:
         try:
             run_id = get_request_arg(request, "run_id", raise_missing=False)
             conf = get_request_conf()
-            payload, status = trigger(dag_id, run_id, conf=conf)
-            return make_response(jsonify(payload), status)
+            trigger_payload, trigger_status = trigger(dag_id, run_id, conf=conf)
+            return make_response(jsonify(trigger_payload), trigger_status)
 
         except Exception as exc:
             logger.debug(traceback.format_exc())

--- a/openmetadata-airflow-apis/openmetadata_managed_apis/operations/trigger.py
+++ b/openmetadata-airflow-apis/openmetadata_managed_apis/operations/trigger.py
@@ -13,7 +13,6 @@ Module containing the logic to trigger a DAG
 """
 
 import inspect
-from typing import Optional  # noqa: UP035
 
 try:
     from airflow.api.common.trigger_dag import trigger_dag
@@ -33,7 +32,9 @@ except ImportError:
 # Returns (payload, status) so the route can call jsonify directly; Snyk Code's
 # XSS rule doesn't trace jsonify through the ApiResponse helper chain.
 def trigger(
-    dag_id: str, run_id: Optional[str], conf: Optional[dict] = None  # noqa: UP045
+    dag_id: str,
+    run_id: str | None,
+    conf: dict | None = None,
 ) -> tuple[dict, int]:
     trigger_params = {
         "dag_id": dag_id,

--- a/openmetadata-airflow-apis/openmetadata_managed_apis/operations/trigger.py
+++ b/openmetadata-airflow-apis/openmetadata_managed_apis/operations/trigger.py
@@ -13,7 +13,7 @@ Module containing the logic to trigger a DAG
 """
 
 import inspect
-from typing import Optional, Tuple  # noqa: UP035
+from typing import Optional  # noqa: UP035
 
 try:
     from airflow.api.common.trigger_dag import trigger_dag
@@ -34,7 +34,7 @@ except ImportError:
 # XSS rule doesn't trace jsonify through the ApiResponse helper chain.
 def trigger(
     dag_id: str, run_id: Optional[str], conf: Optional[dict] = None  # noqa: UP045
-) -> Tuple[dict, int]:
+) -> tuple[dict, int]:
     trigger_params = {
         "dag_id": dag_id,
         "run_id": run_id,

--- a/openmetadata-airflow-apis/openmetadata_managed_apis/operations/trigger.py
+++ b/openmetadata-airflow-apis/openmetadata_managed_apis/operations/trigger.py
@@ -13,7 +13,7 @@ Module containing the logic to trigger a DAG
 """
 
 import inspect
-from typing import Optional
+from typing import Optional, Tuple  # noqa: UP035
 
 try:
     from airflow.api.common.trigger_dag import trigger_dag
@@ -21,7 +21,6 @@ except ImportError:
     from airflow.api.common.experimental.trigger_dag import trigger_dag
 
 from airflow.utils import timezone
-from flask import Response
 
 from openmetadata_managed_apis.api.response import ApiResponse
 
@@ -31,7 +30,11 @@ except ImportError:
     DagRunTriggeredByType = None  # type: ignore[misc,assignment]
 
 
-def trigger(dag_id: str, run_id: Optional[str], conf: Optional[dict] = None) -> Response:  # noqa: UP045
+# Returns (payload, status) so the route can call jsonify directly; Snyk Code's
+# XSS rule doesn't trace jsonify through the ApiResponse helper chain.
+def trigger(
+    dag_id: str, run_id: Optional[str], conf: Optional[dict] = None  # noqa: UP045
+) -> Tuple[dict, int]:
     trigger_params = {
         "dag_id": dag_id,
         "run_id": run_id,
@@ -59,4 +62,7 @@ def trigger(dag_id: str, run_id: Optional[str], conf: Optional[dict] = None) -> 
             trigger_params["triggered_by"] = "OpenMetadata"
 
     dag_run = trigger_dag(**trigger_params)
-    return ApiResponse.success({"message": f"Workflow [{dag_id}] has been triggered {dag_run}"})
+    return (
+        {"message": f"Workflow [{dag_id}] has been triggered {dag_run}"},
+        ApiResponse.STATUS_OK,
+    )

--- a/openmetadata-airflow-apis/tests/integration/operations/test_airflow_ops.py
+++ b/openmetadata-airflow-apis/tests/integration/operations/test_airflow_ops.py
@@ -377,10 +377,10 @@ class TestAirflowOps(TestCase):
 
         self.assertIsNotNone(dag_model)
 
-        res = trigger(dag_id="my_new_dag", run_id=None)
+        payload, status = trigger(dag_id="my_new_dag", run_id=None)
 
-        self.assertEqual(res.status_code, 200)
-        self.assertIn("Workflow [my_new_dag] has been triggered", res.json["message"])
+        self.assertEqual(status, 200)
+        self.assertIn("Workflow [my_new_dag] has been triggered", payload["message"])
 
         # Delete it
         res = delete_dag_id("my_new_dag")

--- a/openmetadata-airflow-apis/tests/integration/operations/test_airflow_ops.py
+++ b/openmetadata-airflow-apis/tests/integration/operations/test_airflow_ops.py
@@ -377,10 +377,10 @@ class TestAirflowOps(TestCase):
 
         self.assertIsNotNone(dag_model)
 
-        payload, status = trigger(dag_id="my_new_dag", run_id=None)
+        trigger_payload, trigger_status = trigger(dag_id="my_new_dag", run_id=None)
 
-        self.assertEqual(status, 200)
-        self.assertIn("Workflow [my_new_dag] has been triggered", payload["message"])
+        self.assertEqual(trigger_status, 200)
+        self.assertIn("Workflow [my_new_dag] has been triggered", trigger_payload["message"])
 
         # Delete it
         res = delete_dag_id("my_new_dag")


### PR DESCRIPTION
## Summary

Closes two of the high/critical Snyk findings on the ingestion side scans (`ingestion-dep-scan` and `airflow-apis-code-scan`). Scoped narrowly to the changes verified safe end-to-end; the remaining Snyk findings (Collate-package blockers, presidio false positives, broken `.snyk` globs) are tracked separately.

### 1. `mlflow-skinny >=3.11.1,<3.13` (was `>=3.10.0,<3.11`)

Closes **CVE-2026-4137 / SNYK-PYTHON-MLFLOWSKINNY-16756597** (Creation of Temporary File with Insecure Permissions in `get_or_create_nfs_tmp_dir()` and `_create_model_downloading_tmp_dir()`). Snyk explicitly states "Upgrade to 3.11.0rc1 or higher"; 3.11.1 is the first stable in that line and 3.12.0 is the current latest.

**Surface check** — our connector uses only `MlflowClient`, `RegisteredModel`, `ModelVersion`, `RunData`, and `search_registered_models()`. Verified against the 3.11.0rc0 → 3.11.1 → 3.12.0 changelogs: no breaking changes to any of these. The only behaviour note is that 3.11.1 rejects `/` and `:` in **new** model registrations; we only read, so unaffected.

**DB triggers** — no new privileged operations in 3.11/3.12. The MySQL integration test's existing `--log-bin-trust-function-creators=1` flag (added in #28231 for mlflow 3.8.1+'s `prevent_secrets_aad_mutation` trigger) still covers everything; no test infra change needed.

### 2. Surface `jsonify` at the trigger route's return

`api/routes/trigger.py:68` was flagged with `python/XSS` because the Snyk Code analyzer can't trace `jsonify` through the helper chain `ApiResponse.success → standard_response → make_response(jsonify(...))`. The fix mirrors what #28231 did for `deploy.py:78`: bring the safe sink up to where the analyzer can see it.

- `operations/trigger.py` now returns `(payload_dict, status_code)` instead of a pre-wrapped Flask `Response`.
- `api/routes/trigger.py` calls `make_response(jsonify(payload), status)` at the immediate return.

**Functionally identical** — same `jsonify(...)` call, same dict, same status, same `Content-Type: application/json`. The response bytes on the wire are unchanged; only the location of the `jsonify` call moves up one stack frame. Exception path (route's `except Exception` → `ApiResponse.error`) is untouched.

### 3. Test update

`tests/integration/operations/test_airflow_ops.py` calls `trigger(...)` directly and reads `.status_code` / `.json`. Updated to unpack the `(payload, status)` tuple. Three lines.

## Not addressed in this PR

- `.snyk` exclude globs use `ingestion/...` paths but Snyk Code runs from `cd ingestion/`, so the patterns never match scan-relative URIs. Pathspec simulation confirms 0/22 ingestion findings are actually filtered today (verified against the live SARIF in `gh run 26560433766`). Separate workstream; would close 16 findings if rewritten as `**/...` patterns + `**/build/**`.
- 6 `python/XSS` findings in `ingestion/src/metadata/pii/algorithms/presidio_utils.py` — Snyk's `python/XSS` rule misclassifies `@recognizer_factories.add(...)` as a Flask-style route decorator. No HTTP/HTML sink reachable in the `metadata/pii/` tree (verified by grep). Separate workstream — either drop the decorator pattern or mark false-positive in Snyk UI.
- `urllib3<2` (4 highs), `pyOpenSSL<26` (1 critical), `cryptography<46.0.5` (1 high), `click<=8.3.0` (1 high) — all blocked by `collate-data-diff==0.11.10` and `collate-sqlfluff==3.5.2` pins. Need upstream Collate releases.

## Backport

Should also go to `1.13` — the original scan that surfaced these (`gh run 26560433766`) ran on 1.13, and the corresponding helper/route files are identical between `main` and `1.13` for the airflow-apis change. Setup.py mlflow line is identical on both branches.

## Test plan

- [x] `python -c "import ast; ..."` — all four files parse cleanly.
- [x] Diff review — wire bytes unchanged for the success path; exception path untouched.
- [x] Behavioural trace — `make_response(jsonify({...}), 200)` is the same call regardless of where `jsonify` is invoked.
- [ ] CI: `airflow-apis-tests` — `test_airflow_ops.py::TestAirflowOps::test_trigger_dag` passes against the new `(payload, status)` tuple shape.
- [ ] CI: `py-run-build-tests` green with mlflow-skinny 3.11.x.
- [ ] CI: `security-scan` workflow — `trigger.py:68` finding closes (or evidence that it doesn't, in which case suppression with justification follows).
- [ ] CI: mlflow MySQL integration test passes with mlflow-skinny 3.11.x.

🤖 Generated with [Claude Code](https://claude.com/claude-code)