### PR TITLE
fix: PG cert migration cast (v1125) + v1130 heal for already-affected clusters

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/migration/mysql/v1130/Migration.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/migration/mysql/v1130/Migration.java
@@ -40,7 +40,7 @@ public class Migration extends MigrationProcessImpl {
     try {
       MigrationUtil.healStuckCertificationOnEntityJson(handle, ConnectionType.MYSQL);
     } catch (Exception e) {
-      LOG.error("v1130 heal of stuck certification on entity json failed; re-run to retry.", e);
+      LOG.error("v1130 heal of stuck certification on entity json failed", e);
     }
   }
 }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/migration/mysql/v1130/Migration.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/migration/mysql/v1130/Migration.java
@@ -5,6 +5,7 @@ import static org.openmetadata.service.migration.utils.v1129.MigrationUtil.addTr
 
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
+import org.openmetadata.service.jdbi3.locator.ConnectionType;
 import org.openmetadata.service.migration.api.MigrationProcessImpl;
 import org.openmetadata.service.migration.utils.MigrationFile;
 import org.openmetadata.service.migration.utils.v1130.MigrationUtil;
@@ -36,5 +37,10 @@ public class Migration extends MigrationProcessImpl {
     MigrationUtil.addTableColumnSearchSettings();
     addTriggerOperationToDefaultBotPolicies(collectionDAO);
     addTriggerRuleToDataStewardPolicy(collectionDAO);
+    try {
+      MigrationUtil.healStuckCertificationOnEntityJson(handle, ConnectionType.MYSQL);
+    } catch (Exception e) {
+      LOG.error("v1130 heal of stuck certification on entity json failed; re-run to retry.", e);
+    }
   }
 }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/migration/postgres/v1130/Migration.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/migration/postgres/v1130/Migration.java
@@ -5,6 +5,7 @@ import static org.openmetadata.service.migration.utils.v1129.MigrationUtil.addTr
 
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
+import org.openmetadata.service.jdbi3.locator.ConnectionType;
 import org.openmetadata.service.migration.api.MigrationProcessImpl;
 import org.openmetadata.service.migration.utils.MigrationFile;
 import org.openmetadata.service.migration.utils.v1130.MigrationUtil;
@@ -36,5 +37,10 @@ public class Migration extends MigrationProcessImpl {
     MigrationUtil.addTableColumnSearchSettings();
     addTriggerOperationToDefaultBotPolicies(collectionDAO);
     addTriggerRuleToDataStewardPolicy(collectionDAO);
+    try {
+      MigrationUtil.healStuckCertificationOnEntityJson(handle, ConnectionType.POSTGRES);
+    } catch (Exception e) {
+      LOG.error("v1130 heal of stuck certification on entity json failed; re-run to retry.", e);
+    }
   }
 }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/migration/postgres/v1130/Migration.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/migration/postgres/v1130/Migration.java
@@ -40,7 +40,7 @@ public class Migration extends MigrationProcessImpl {
     try {
       MigrationUtil.healStuckCertificationOnEntityJson(handle, ConnectionType.POSTGRES);
     } catch (Exception e) {
-      LOG.error("v1130 heal of stuck certification on entity json failed; re-run to retry.", e);
+      LOG.error("v1130 heal of stuck certification on entity json failed", e);
     }
   }
 }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/migration/utils/v1125/MigrationUtil.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/migration/utils/v1125/MigrationUtil.java
@@ -251,11 +251,12 @@ public class MigrationUtil {
       return 0;
     }
 
+    // PG won't auto-cast varchar -> json on the metadata column; MySQL JSON accepts a string.
     String insertSql =
         isPostgres
             ? "INSERT INTO tag_usage "
                 + "(source, tagFQN, tagFQNHash, targetFQNHash, labelType, state, appliedBy, appliedAt, metadata) "
-                + "VALUES (:source, :tagFQN, :tagFQNHash, :targetFQNHash, :labelType, :state, 'admin', :appliedAt, :metadata) "
+                + "VALUES (:source, :tagFQN, :tagFQNHash, :targetFQNHash, :labelType, :state, 'admin', :appliedAt, :metadata::json) "
                 + "ON CONFLICT (source, tagFQNHash, targetFQNHash) DO NOTHING"
             : "INSERT IGNORE INTO tag_usage "
                 + "(source, tagFQN, tagFQNHash, targetFQNHash, labelType, state, appliedBy, appliedAt, metadata) "

--- a/openmetadata-service/src/main/java/org/openmetadata/service/migration/utils/v1130/MigrationUtil.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/migration/utils/v1130/MigrationUtil.java
@@ -1,5 +1,7 @@
 package org.openmetadata.service.migration.utils.v1130;
 
+import static org.openmetadata.common.utils.CommonUtil.nullOrEmpty;
+
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
@@ -428,25 +430,27 @@ public class MigrationUtil {
     LOG.info("v1130 heal: total stuck certification rows healed: {}", totalHealed);
   }
 
+  private record BatchResult(int rowsFetched, int healed) {}
+
   private static int healCertificationForTable(
       Handle handle, ConnectionType connType, String table) {
     int totalHealed = 0;
-    while (true) {
-      int batchHealed = healCertificationBatch(handle, connType, table);
-      totalHealed += batchHealed;
-      if (batchHealed < HEAL_BATCH_SIZE) {
-        break;
-      }
+    boolean morePages = true;
+    while (morePages) {
+      BatchResult batch = healCertificationBatch(handle, connType, table);
+      totalHealed += batch.healed();
+      morePages = batch.rowsFetched() == HEAL_BATCH_SIZE;
     }
     return totalHealed;
   }
 
-  private static int healCertificationBatch(Handle handle, ConnectionType connType, String table) {
+  private static BatchResult healCertificationBatch(
+      Handle handle, ConnectionType connType, String table) {
     boolean isPostgres = connType == ConnectionType.POSTGRES;
     int healed = 0;
     List<Map<String, Object>> rows =
         handle.createQuery(buildSelectStuckCertificationSql(table, isPostgres)).mapToMap().list();
-    if (!rows.isEmpty()) {
+    if (!nullOrEmpty(rows)) {
       List<String> selectedIds = new ArrayList<>();
       PreparedBatch batch = handle.prepareBatch(buildInsertTagUsageSql(isPostgres));
       for (Map<String, Object> row : rows) {
@@ -466,7 +470,7 @@ public class MigrationUtil {
               .add();
         }
       }
-      if (!selectedIds.isEmpty()) {
+      if (!nullOrEmpty(selectedIds)) {
         batch.execute();
         handle
             .createUpdate(buildStripCertificationFromJsonSql(table, isPostgres))
@@ -475,7 +479,7 @@ public class MigrationUtil {
         healed = selectedIds.size();
       }
     }
-    return healed;
+    return new BatchResult(rows.size(), healed);
   }
 
   private static String buildSelectStuckCertificationSql(String table, boolean isPostgres) {
@@ -564,8 +568,8 @@ public class MigrationUtil {
       } else {
         try {
           node.put("expiryDate", Long.parseLong(expiryDateVal.toString()));
-        } catch (NumberFormatException ignored) {
-          // Unparseable expiry stays out of metadata; tag_usage row still inserted.
+        } catch (NumberFormatException e) {
+          LOG.warn("Unparseable expiryDate '{}' on heal; omitting from metadata", expiryDateVal);
         }
       }
     }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/migration/utils/v1130/MigrationUtil.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/migration/utils/v1130/MigrationUtil.java
@@ -422,11 +422,7 @@ public class MigrationUtil {
         }
       } catch (Exception e) {
         // Per-table failure shouldn't stop the rest; logged at ERROR so it isn't lost.
-        LOG.error(
-            "v1130 heal failed for table '{}': {}. Re-run the migration to retry.",
-            table,
-            e.getMessage(),
-            e);
+        LOG.error("v1130 heal failed for table '{}': {}", table, e.getMessage(), e);
       }
     }
     LOG.info("v1130 heal: total stuck certification rows healed: {}", totalHealed);
@@ -447,102 +443,115 @@ public class MigrationUtil {
 
   private static int healCertificationBatch(Handle handle, ConnectionType connType, String table) {
     boolean isPostgres = connType == ConnectionType.POSTGRES;
+    int healed = 0;
     List<Map<String, Object>> rows =
         handle.createQuery(buildSelectStuckCertificationSql(table, isPostgres)).mapToMap().list();
-    if (rows.isEmpty()) {
-      return 0;
-    }
-
-    List<String> selectedIds = new ArrayList<>();
-    PreparedBatch batch = handle.prepareBatch(buildInsertTagUsageSql(isPostgres));
-    for (Map<String, Object> row : rows) {
-      String tagFQN = (String) row.get("tagfqn");
-      // SELECT already filters tagFQN NOT NULL, but stay defensive against concurrent edits.
-      if (tagFQN == null) {
-        continue;
+    if (!rows.isEmpty()) {
+      List<String> selectedIds = new ArrayList<>();
+      PreparedBatch batch = handle.prepareBatch(buildInsertTagUsageSql(isPostgres));
+      for (Map<String, Object> row : rows) {
+        String tagFQN = (String) row.get("tagfqn");
+        // SELECT already filters tagFQN NOT NULL, but stay defensive against concurrent edits.
+        if (tagFQN != null) {
+          selectedIds.add(row.get("id").toString());
+          batch
+              .bind("source", CERT_SOURCE)
+              .bind("tagFQN", tagFQN)
+              .bind("tagFQNHash", FullyQualifiedName.buildHash(tagFQN))
+              .bind("targetFQNHash", row.get("fqnhash").toString())
+              .bind("labelType", CERT_LABEL_TYPE)
+              .bind("state", CERT_STATE)
+              .bind("appliedAt", parseEpochMillisToTimestamp(row.get("applieddate")))
+              .bind("metadata", buildCertMetadataJson(row.get("expirydate")))
+              .add();
+        }
       }
-      selectedIds.add(row.get("id").toString());
-      batch
-          .bind("source", CERT_SOURCE)
-          .bind("tagFQN", tagFQN)
-          .bind("tagFQNHash", FullyQualifiedName.buildHash(tagFQN))
-          .bind("targetFQNHash", row.get("fqnhash").toString())
-          .bind("labelType", CERT_LABEL_TYPE)
-          .bind("state", CERT_STATE)
-          .bind("appliedAt", parseEpochMillisToTimestamp(row.get("applieddate")))
-          .bind("metadata", buildCertMetadataJson(row.get("expirydate")))
-          .add();
+      if (!selectedIds.isEmpty()) {
+        batch.execute();
+        handle
+            .createUpdate(buildStripCertificationFromJsonSql(table, isPostgres))
+            .bindList("ids", selectedIds)
+            .execute();
+        healed = selectedIds.size();
+      }
     }
-    if (selectedIds.isEmpty()) {
-      return 0;
-    }
-    batch.execute();
-    handle
-        .createUpdate(buildStripCertificationFromJsonSql(table, isPostgres))
-        .bindList("ids", selectedIds)
-        .execute();
-    return selectedIds.size();
+    return healed;
   }
 
   private static String buildSelectStuckCertificationSql(String table, boolean isPostgres) {
+    String sql;
     if (isPostgres) {
-      return String.format(
-          "SELECT id, fqnHash, "
-              + "json::json -> 'certification' -> 'tagLabel' ->> 'tagFQN' AS tagFQN, "
-              + "json::json -> 'certification' ->> 'expiryDate' AS expiryDate, "
-              + "json::json -> 'certification' ->> 'appliedDate' AS appliedDate "
-              + "FROM %s WHERE json::jsonb ?? 'certification' "
-              + "AND json::json -> 'certification' -> 'tagLabel' ->> 'tagFQN' IS NOT NULL "
-              + "LIMIT %d",
-          table, HEAL_BATCH_SIZE);
+      sql =
+          String.format(
+              "SELECT id, fqnHash, "
+                  + "json::json -> 'certification' -> 'tagLabel' ->> 'tagFQN' AS tagFQN, "
+                  + "json::json -> 'certification' ->> 'expiryDate' AS expiryDate, "
+                  + "json::json -> 'certification' ->> 'appliedDate' AS appliedDate "
+                  + "FROM %s WHERE json::jsonb ?? 'certification' "
+                  + "AND json::json -> 'certification' -> 'tagLabel' ->> 'tagFQN' IS NOT NULL "
+                  + "LIMIT %d",
+              table, HEAL_BATCH_SIZE);
+    } else {
+      sql =
+          String.format(
+              "SELECT id, fqnHash, "
+                  + "JSON_UNQUOTE(JSON_EXTRACT(json, '$.certification.tagLabel.tagFQN')) AS tagFQN, "
+                  + "JSON_UNQUOTE(JSON_EXTRACT(json, '$.certification.expiryDate')) AS expiryDate, "
+                  + "JSON_UNQUOTE(JSON_EXTRACT(json, '$.certification.appliedDate')) AS appliedDate "
+                  + "FROM %s WHERE JSON_CONTAINS_PATH(json, 'one', '$.certification') = 1 "
+                  + "AND JSON_UNQUOTE(JSON_EXTRACT(json, '$.certification.tagLabel.tagFQN')) IS NOT NULL "
+                  + "LIMIT %d",
+              table, HEAL_BATCH_SIZE);
     }
-    return String.format(
-        "SELECT id, fqnHash, "
-            + "JSON_UNQUOTE(JSON_EXTRACT(json, '$.certification.tagLabel.tagFQN')) AS tagFQN, "
-            + "JSON_UNQUOTE(JSON_EXTRACT(json, '$.certification.expiryDate')) AS expiryDate, "
-            + "JSON_UNQUOTE(JSON_EXTRACT(json, '$.certification.appliedDate')) AS appliedDate "
-            + "FROM %s WHERE JSON_CONTAINS_PATH(json, 'one', '$.certification') = 1 "
-            + "AND JSON_UNQUOTE(JSON_EXTRACT(json, '$.certification.tagLabel.tagFQN')) IS NOT NULL "
-            + "LIMIT %d",
-        table, HEAL_BATCH_SIZE);
+    return sql;
   }
 
   private static String buildInsertTagUsageSql(boolean isPostgres) {
     // PG won't auto-cast varchar -> json on the metadata column; MySQL JSON accepts a string.
+    String sql;
     if (isPostgres) {
-      return "INSERT INTO tag_usage "
-          + "(source, tagFQN, tagFQNHash, targetFQNHash, labelType, state, appliedBy, appliedAt, metadata) "
-          + "VALUES (:source, :tagFQN, :tagFQNHash, :targetFQNHash, :labelType, :state, 'admin', :appliedAt, :metadata::json) "
-          + "ON CONFLICT (source, tagFQNHash, targetFQNHash) DO NOTHING";
+      sql =
+          "INSERT INTO tag_usage "
+              + "(source, tagFQN, tagFQNHash, targetFQNHash, labelType, state, appliedBy, appliedAt, metadata) "
+              + "VALUES (:source, :tagFQN, :tagFQNHash, :targetFQNHash, :labelType, :state, 'admin', :appliedAt, :metadata::json) "
+              + "ON CONFLICT (source, tagFQNHash, targetFQNHash) DO NOTHING";
+    } else {
+      sql =
+          "INSERT IGNORE INTO tag_usage "
+              + "(source, tagFQN, tagFQNHash, targetFQNHash, labelType, state, appliedBy, appliedAt, metadata) "
+              + "VALUES (:source, :tagFQN, :tagFQNHash, :targetFQNHash, :labelType, :state, 'admin', :appliedAt, :metadata)";
     }
-    return "INSERT IGNORE INTO tag_usage "
-        + "(source, tagFQN, tagFQNHash, targetFQNHash, labelType, state, appliedBy, appliedAt, metadata) "
-        + "VALUES (:source, :tagFQN, :tagFQNHash, :targetFQNHash, :labelType, :state, 'admin', :appliedAt, :metadata)";
+    return sql;
   }
 
   private static String buildStripCertificationFromJsonSql(String table, boolean isPostgres) {
+    String sql;
     if (isPostgres) {
-      return "UPDATE "
-          + table
-          + " SET json = (json::jsonb - 'certification')::json WHERE id IN (<ids>)";
+      sql =
+          "UPDATE "
+              + table
+              + " SET json = (json::jsonb - 'certification')::json WHERE id IN (<ids>)";
+    } else {
+      sql =
+          "UPDATE "
+              + table
+              + " SET json = JSON_REMOVE(json, '$.certification') WHERE id IN (<ids>)";
     }
-    return "UPDATE "
-        + table
-        + " SET json = JSON_REMOVE(json, '$.certification') WHERE id IN (<ids>)";
+    return sql;
   }
 
   private static Timestamp parseEpochMillisToTimestamp(Object val) {
-    if (val == null) {
-      return null;
+    Timestamp result = null;
+    if (val != null) {
+      try {
+        long epochMillis =
+            val instanceof Number num ? num.longValue() : Long.parseLong(val.toString());
+        result = new Timestamp(epochMillis);
+      } catch (NumberFormatException e) {
+        LOG.warn("Unparseable appliedDate '{}' on heal; binding null", val);
+      }
     }
-    try {
-      long epochMillis =
-          val instanceof Number num ? num.longValue() : Long.parseLong(val.toString());
-      return new Timestamp(epochMillis);
-    } catch (NumberFormatException e) {
-      LOG.warn("Unparseable appliedDate '{}' on heal; binding null", val);
-      return null;
-    }
+    return result;
   }
 
   private static String buildCertMetadataJson(Object expiryDateVal) {

--- a/openmetadata-service/src/main/java/org/openmetadata/service/migration/utils/v1130/MigrationUtil.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/migration/utils/v1130/MigrationUtil.java
@@ -1,7 +1,6 @@
 package org.openmetadata.service.migration.utils.v1130;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.sql.Timestamp;
@@ -404,7 +403,6 @@ public class MigrationUtil {
   private static final int CERT_SOURCE = TagLabel.TagSource.CLASSIFICATION.ordinal();
   private static final int CERT_LABEL_TYPE = TagLabel.LabelType.AUTOMATED.ordinal();
   private static final int CERT_STATE = TagLabel.State.CONFIRMED.ordinal();
-  private static final ObjectMapper CERT_METADATA_MAPPER = new ObjectMapper();
 
   /**
    * Heals installs where certification is still inlined in entity JSON instead of being in
@@ -548,7 +546,7 @@ public class MigrationUtil {
   }
 
   private static String buildCertMetadataJson(Object expiryDateVal) {
-    ObjectNode node = CERT_METADATA_MAPPER.createObjectNode();
+    ObjectNode node = JsonUtils.getObjectNode();
     if (expiryDateVal != null) {
       if (expiryDateVal instanceof Long longVal) {
         node.put("expiryDate", longVal);

--- a/openmetadata-service/src/main/java/org/openmetadata/service/migration/utils/v1130/MigrationUtil.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/migration/utils/v1130/MigrationUtil.java
@@ -1,8 +1,11 @@
 package org.openmetadata.service.migration.utils.v1130;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import java.sql.Timestamp;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
@@ -12,11 +15,14 @@ import org.openmetadata.schema.api.search.SearchSettings;
 import org.openmetadata.schema.dataInsight.custom.DataInsightCustomChart;
 import org.openmetadata.schema.entity.events.SubscriptionDestination;
 import org.openmetadata.schema.settings.Settings;
+import org.openmetadata.schema.type.TagLabel;
 import org.openmetadata.schema.utils.JsonUtils;
 import org.openmetadata.service.jdbi3.DataInsightSystemChartRepository;
+import org.openmetadata.service.jdbi3.locator.ConnectionType;
 import org.openmetadata.service.migration.utils.SearchSettingsMergeUtil;
 import org.openmetadata.service.resources.databases.DatasourceConfig;
 import org.openmetadata.service.util.EntityUtil;
+import org.openmetadata.service.util.FullyQualifiedName;
 
 @Slf4j
 public class MigrationUtil {
@@ -365,5 +371,197 @@ public class MigrationUtil {
       // so the migration step doesn't abort the rest of v1130's reprocessing.
       LOG.error("Error adding tableColumn search settings", e);
     }
+  }
+
+  // Entity tables that v1125 attempted to drain of inline certification into tag_usage.
+  private static final String[] CERTIFIED_ENTITY_TABLES = {
+    "table_entity",
+    "dashboard_entity",
+    "topic_entity",
+    "pipeline_entity",
+    "storage_container_entity",
+    "search_index_entity",
+    "ml_model_entity",
+    "stored_procedure_entity",
+    "dashboard_data_model_entity",
+    "api_endpoint_entity",
+    "api_collection_entity",
+    "database_entity",
+    "database_schema_entity",
+    "data_product_entity",
+    "domain_entity",
+    "chart_entity",
+    "metric_entity",
+    "file_entity",
+    "directory_entity",
+    "spreadsheet_entity",
+    "worksheet_entity",
+    "llm_model_entity",
+    "ai_application_entity"
+  };
+
+  private static final int HEAL_BATCH_SIZE = 500;
+  private static final int CERT_SOURCE = TagLabel.TagSource.CLASSIFICATION.ordinal();
+  private static final int CERT_LABEL_TYPE = TagLabel.LabelType.AUTOMATED.ordinal();
+  private static final int CERT_STATE = TagLabel.State.CONFIRMED.ordinal();
+  private static final ObjectMapper CERT_METADATA_MAPPER = new ObjectMapper();
+
+  /**
+   * Heals installs where certification is still inlined in entity JSON instead of being in
+   * tag_usage. v1125 on PostgreSQL silently failed on a missing varchar->json cast for the
+   * metadata column, leaving any 1.12.5+ PG database stuck. Idempotent: the SELECT filter only
+   * picks rows that still carry certification in JSON, so fresh installs, healthy MySQL, and PG
+   * databases with no certified entities exit at zero rows.
+   */
+  public static void healStuckCertificationOnEntityJson(Handle handle, ConnectionType connType) {
+    int totalHealed = 0;
+    for (String table : CERTIFIED_ENTITY_TABLES) {
+      try {
+        int healed = healCertificationForTable(handle, connType, table);
+        totalHealed += healed;
+        if (healed > 0) {
+          LOG.info("v1130 heal: moved {} stuck certification rows from {}", healed, table);
+        }
+      } catch (Exception e) {
+        // Per-table failure shouldn't stop the rest; logged at ERROR so it isn't lost.
+        LOG.error(
+            "v1130 heal failed for table '{}': {}. Re-run the migration to retry.",
+            table,
+            e.getMessage(),
+            e);
+      }
+    }
+    LOG.info("v1130 heal: total stuck certification rows healed: {}", totalHealed);
+  }
+
+  private static int healCertificationForTable(
+      Handle handle, ConnectionType connType, String table) {
+    int totalHealed = 0;
+    while (true) {
+      int batchHealed = healCertificationBatch(handle, connType, table);
+      totalHealed += batchHealed;
+      if (batchHealed < HEAL_BATCH_SIZE) {
+        break;
+      }
+    }
+    return totalHealed;
+  }
+
+  private static int healCertificationBatch(Handle handle, ConnectionType connType, String table) {
+    boolean isPostgres = connType == ConnectionType.POSTGRES;
+    List<Map<String, Object>> rows =
+        handle.createQuery(buildSelectStuckCertificationSql(table, isPostgres)).mapToMap().list();
+    if (rows.isEmpty()) {
+      return 0;
+    }
+
+    List<String> selectedIds = new ArrayList<>();
+    PreparedBatch batch = handle.prepareBatch(buildInsertTagUsageSql(isPostgres));
+    for (Map<String, Object> row : rows) {
+      String tagFQN = (String) row.get("tagfqn");
+      // SELECT already filters tagFQN NOT NULL, but stay defensive against concurrent edits.
+      if (tagFQN == null) {
+        continue;
+      }
+      selectedIds.add(row.get("id").toString());
+      batch
+          .bind("source", CERT_SOURCE)
+          .bind("tagFQN", tagFQN)
+          .bind("tagFQNHash", FullyQualifiedName.buildHash(tagFQN))
+          .bind("targetFQNHash", row.get("fqnhash").toString())
+          .bind("labelType", CERT_LABEL_TYPE)
+          .bind("state", CERT_STATE)
+          .bind("appliedAt", parseEpochMillisToTimestamp(row.get("applieddate")))
+          .bind("metadata", buildCertMetadataJson(row.get("expirydate")))
+          .add();
+    }
+    if (selectedIds.isEmpty()) {
+      return 0;
+    }
+    batch.execute();
+    handle
+        .createUpdate(buildStripCertificationFromJsonSql(table, isPostgres))
+        .bindList("ids", selectedIds)
+        .execute();
+    return selectedIds.size();
+  }
+
+  private static String buildSelectStuckCertificationSql(String table, boolean isPostgres) {
+    if (isPostgres) {
+      return String.format(
+          "SELECT id, fqnHash, "
+              + "json::json -> 'certification' -> 'tagLabel' ->> 'tagFQN' AS tagFQN, "
+              + "json::json -> 'certification' ->> 'expiryDate' AS expiryDate, "
+              + "json::json -> 'certification' ->> 'appliedDate' AS appliedDate "
+              + "FROM %s WHERE json::jsonb ?? 'certification' "
+              + "AND json::json -> 'certification' -> 'tagLabel' ->> 'tagFQN' IS NOT NULL "
+              + "LIMIT %d",
+          table, HEAL_BATCH_SIZE);
+    }
+    return String.format(
+        "SELECT id, fqnHash, "
+            + "JSON_UNQUOTE(JSON_EXTRACT(json, '$.certification.tagLabel.tagFQN')) AS tagFQN, "
+            + "JSON_UNQUOTE(JSON_EXTRACT(json, '$.certification.expiryDate')) AS expiryDate, "
+            + "JSON_UNQUOTE(JSON_EXTRACT(json, '$.certification.appliedDate')) AS appliedDate "
+            + "FROM %s WHERE JSON_CONTAINS_PATH(json, 'one', '$.certification') = 1 "
+            + "AND JSON_UNQUOTE(JSON_EXTRACT(json, '$.certification.tagLabel.tagFQN')) IS NOT NULL "
+            + "LIMIT %d",
+        table, HEAL_BATCH_SIZE);
+  }
+
+  private static String buildInsertTagUsageSql(boolean isPostgres) {
+    // PG won't auto-cast varchar -> json on the metadata column; MySQL JSON accepts a string.
+    if (isPostgres) {
+      return "INSERT INTO tag_usage "
+          + "(source, tagFQN, tagFQNHash, targetFQNHash, labelType, state, appliedBy, appliedAt, metadata) "
+          + "VALUES (:source, :tagFQN, :tagFQNHash, :targetFQNHash, :labelType, :state, 'admin', :appliedAt, :metadata::json) "
+          + "ON CONFLICT (source, tagFQNHash, targetFQNHash) DO NOTHING";
+    }
+    return "INSERT IGNORE INTO tag_usage "
+        + "(source, tagFQN, tagFQNHash, targetFQNHash, labelType, state, appliedBy, appliedAt, metadata) "
+        + "VALUES (:source, :tagFQN, :tagFQNHash, :targetFQNHash, :labelType, :state, 'admin', :appliedAt, :metadata)";
+  }
+
+  private static String buildStripCertificationFromJsonSql(String table, boolean isPostgres) {
+    if (isPostgres) {
+      return "UPDATE "
+          + table
+          + " SET json = (json::jsonb - 'certification')::json WHERE id IN (<ids>)";
+    }
+    return "UPDATE "
+        + table
+        + " SET json = JSON_REMOVE(json, '$.certification') WHERE id IN (<ids>)";
+  }
+
+  private static Timestamp parseEpochMillisToTimestamp(Object val) {
+    if (val == null) {
+      return null;
+    }
+    try {
+      long epochMillis =
+          val instanceof Number num ? num.longValue() : Long.parseLong(val.toString());
+      return new Timestamp(epochMillis);
+    } catch (NumberFormatException e) {
+      LOG.warn("Unparseable appliedDate '{}' on heal; binding null", val);
+      return null;
+    }
+  }
+
+  private static String buildCertMetadataJson(Object expiryDateVal) {
+    ObjectNode node = CERT_METADATA_MAPPER.createObjectNode();
+    if (expiryDateVal != null) {
+      if (expiryDateVal instanceof Long longVal) {
+        node.put("expiryDate", longVal);
+      } else if (expiryDateVal instanceof Number numberVal) {
+        node.put("expiryDate", numberVal.longValue());
+      } else {
+        try {
+          node.put("expiryDate", Long.parseLong(expiryDateVal.toString()));
+        } catch (NumberFormatException ignored) {
+          // Unparseable expiry stays out of metadata; tag_usage row still inserted.
+        }
+      }
+    }
+    return node.toString();
   }
 }


### PR DESCRIPTION
## Summary

Certification migration has been silently failing on PostgreSQL since 1.12.5. Two commits — one root-cause cast in v1125, one corrective heal step in v1130 for clusters that already ran the broken v1125.

`v1125.MigrationUtil.migrateCertificationToTagUsage` binds `:metadata` as a `String` (varchar) but the PG column is `json`. PG refuses the auto-cast:
```
BatchUpdateException: column "metadata" is of type json but expression is of type character varying
```
The per-table `try/catch` swallows it as a WARN, `runDataMigration()` returns normally, framework marks `v1125 = DONE` in `SERVER_CHANGE_LOG`. Net effect on every 1.12.5+ PG cluster: `tag_usage` has zero certification rows, `entity.json` still carries the `certification` field, v1125 never re-runs. Grafana confirms the WARN has been firing nightly on PG since at least 2026-04-28.

Migration completion is keyed only on `SERVER_CHANGE_LOG.version` (no checksum on Java code), so editing v1125 alone doesn't reach clusters that already ran it. Two parts:

### Part A — root-cause cast in v1125 (commit `b2bf026aef`)
One-line SQL change adding `:metadata::json` on the PG branch. Covers fresh installs and pre-1.12.5 → 1.13 upgrades (v1125 hasn't executed there yet). MySQL branch unchanged — `INSERT IGNORE` accepts a string into a JSON column.

### Part B — corrective step in v1130 (commit `795e062224`)
Adds `healStuckCertificationOnEntityJson(handle, connType)` to `utils/v1130/MigrationUtil.java`, wired in at the end of `runDataMigration()` on both PG and MySQL `v1130/Migration.java`. Self-contained — no cross-version imports. Same 23 entity tables as v1125, same SELECT filter, same INSERT/UPDATE shape — only difference is the `::json` cast baked in from the start.

**Idempotent**: SELECT only matches rows where `entity.json` still carries `certification` with a non-null `tagFQN`. After the UPDATE strips that field, the row stops matching. `ON CONFLICT … DO NOTHING` (PG) / `INSERT IGNORE` (MySQL) covers the case where `tag_usage` already has the row.

| Cluster state | Heal effect |
|---|---|
| Fresh install of next release | SELECT returns 0 → no-op |
| MySQL 1.12.5+ (v1125 succeeded) | SELECT returns 0 → no-op |
| Pre-1.12.5 → 1.13 (any DB) | v1125 (with cast) migrates everything → SELECT returns 0 → no-op |
| **PG 1.12.5+ (stuck)** | SELECT returns stuck rows → INSERT with cast → UPDATE strips JSON → healed |
| Heal re-run for any reason | SELECT returns 0 → no-op |

## Why this stayed hidden for 5 releases

The v1125 code shipping in 1.12.5–1.12.9 is byte-identical for this method. The WARN has been firing on nightly PG runs since at least 2026-04-28 (Grafana). Four overlapping factors kept it invisible:

1. **Two stacked `try/catch` blocks** swallow the `BatchUpdateException` as a WARN; the migration framework records `v1125 = DONE`.
2. **`MigrationUtilTest` is fully mocked.** The PG-variant test passes an empty rows list, so the buggy INSERT path is never sent to a real driver.
3. **MySQL CI is green** because `INSERT IGNORE` accepts strings into JSON columns.
4. **Reads mask the broken state** — `EntityRepository.getCertification` only reads from `tag_usage`, and the entity's cert field is overwritten from `tag_usage` on every read. Affected entities look "uncertified" in the UI, so no escalation.

## Test plan

- [x] `mvn -pl openmetadata-service compile -DskipTests` — clean
- [x] `mvn -pl openmetadata-service test -Dtest=MigrationUtilTest` — 113/113 pass
- [x] `mvn -pl openmetadata-service spotless:apply` — applied