### PR TITLE
fix(snyk): drop ingestion/ prefix on CWD-relative exclude paths

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -5,9 +5,9 @@ patch: {}
 exclude:
   global:
     - ingestion/examples/**
-    - ingestion/src/metadata/sdk/examples/**
+    - src/metadata/sdk/examples/**
     - ingestion/tests/**
     - openmetadata-ui/src/main/resources/ui/src/pages/service/mocks/**
     - openmetadata-ui/src/main/resources/ui/src/components/common/TestConnection/TestConnection.mock.ts
     - openmetadata-service/src/test/**
-    - ingestion/src/_openmetadata_testutils/**
+    - src/_openmetadata_testutils/**

--- a/.snyk
+++ b/.snyk
@@ -4,10 +4,16 @@ ignore: {}
 patch: {}
 exclude:
   global:
-    - ingestion/examples/**
+    # Ingestion exclusions. Paths drop the `ingestion/` prefix because the
+    # Makefile runs this scan as `cd ingestion; snyk code test ...`, so
+    # Snyk emits SARIF paths relative to ingestion/, not the repo root.
+    # A pattern of `ingestion/src/...` would never match `src/...`.
+    - examples/**
+    - tests/**
     - src/metadata/sdk/examples/**
-    - ingestion/tests/**
+    - src/_openmetadata_testutils/**
+    # UI / server exclusions — these scans run from the repo root, so
+    # paths here are repo-root-relative.
     - openmetadata-ui/src/main/resources/ui/src/pages/service/mocks/**
     - openmetadata-ui/src/main/resources/ui/src/components/common/TestConnection/TestConnection.mock.ts
     - openmetadata-service/src/test/**
-    - src/_openmetadata_testutils/**

--- a/.snyk
+++ b/.snyk
@@ -12,8 +12,6 @@ exclude:
     - tests/**
     - src/metadata/sdk/examples/**
     - src/_openmetadata_testutils/**
-    # UI / server exclusions — these scans run from the repo root, so
-    # paths here are repo-root-relative.
     - openmetadata-ui/src/main/resources/ui/src/pages/service/mocks/**
     - openmetadata-ui/src/main/resources/ui/src/components/common/TestConnection/TestConnection.mock.ts
     - openmetadata-service/src/test/**


### PR DESCRIPTION
## Summary

The Makefile runs the ingestion Snyk scan from `ingestion/`:

```make
snyk-ingestion-report:
    cd ingestion; \
        snyk code test $(SNYK_ARGS) --json > ../security-report/ingestion-code-scan.json | true;
```

So paths in the resulting SARIF are CWD-relative (e.g. `src/metadata/sdk/examples/dq_as_code_example.py`), not repo-root-relative. The two `.snyk` patterns below were written with an `ingestion/` prefix that can never match those paths, so the excludes were silently no-ops:

- `ingestion/src/metadata/sdk/examples/**` → `src/metadata/sdk/examples/**`
- `ingestion/src/_openmetadata_testutils/**` → `src/_openmetadata_testutils/**`
