### PR TITLE
feat(sdk): add getLogLocation hook on PipelineServiceClientInterface

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/clients/pipeline/MeteredPipelineServiceClient.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/clients/pipeline/MeteredPipelineServiceClient.java
@@ -137,6 +137,11 @@ public class MeteredPipelineServiceClient implements PipelineServiceClientInterf
   }
 
   @Override
+  public String getLogLocation(IngestionPipeline ingestionPipeline, String runId) {
+    return decoratedClient.getLogLocation(ingestionPipeline, runId);
+  }
+
+  @Override
   public Map<String, String> getIngestionLogs(
       IngestionPipeline ingestionPipeline, String after, String runId) {
     return executeWithMetering(

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/IngestionPipelineRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/IngestionPipelineRepository.java
@@ -1050,6 +1050,22 @@ public class IngestionPipelineRepository extends EntityRepository<IngestionPipel
     }
   }
 
+  /**
+   * Resolve the storage location of a run's logs via the configured pipeline service client (e.g.
+   * the Argo artifact's {@code s3://bucket/key}). Returns {@code null} when the client is
+   * unavailable or cannot resolve a static location for this run (e.g. live-only hybrid logs, a
+   * running workflow, or a garbage-collected one). Streamable-S3 locations are derived elsewhere
+   * from {@link #getLogStorageConfiguration()}; this method covers the non-streamable case while
+   * keeping the pipeline service client encapsulated inside the repository.
+   */
+  public String getLogLocationFromPipelineService(IngestionPipeline pipeline, UUID runId) {
+    if (pipelineServiceClient == null || pipeline == null) {
+      return null;
+    }
+    return pipelineServiceClient.getLogLocation(
+        pipeline, runId == null ? null : runId.toString());
+  }
+
   private Map<String, Object> getLogsFromPipelineService(String pipelineFQN, String afterCursor) {
     // Fall back to traditional pipeline service logs (Airflow/Argo)
     IngestionPipeline pipeline =

--- a/openmetadata-spec/src/main/java/org/openmetadata/sdk/PipelineServiceClientInterface.java
+++ b/openmetadata-spec/src/main/java/org/openmetadata/sdk/PipelineServiceClientInterface.java
@@ -127,6 +127,15 @@ public interface PipelineServiceClientInterface {
   /* Get the all last run logs of a deployed pipeline */
   Map<String, String> getLastIngestionLogs(IngestionPipeline ingestionPipeline, String after);
 
+  /**
+   * Returns the storage location (e.g. an {@code s3://bucket/key} URI) of a run's logs without
+   * downloading them. When runId is null, the latest run is used. Clients that expose no
+   * addressable location return {@code null}.
+   */
+  default String getLogLocation(IngestionPipeline ingestionPipeline, String runId) {
+    return null;
+  }
+
   /* Get logs for a specific pipeline run identified by runId.
    * When runId is null or blank, falls back to getLastIngestionLogs (latest run). */
   default Map<String, String> getIngestionLogs(


### PR DESCRIPTION
## Summary

Adds a default `String getLogLocation(IngestionPipeline, String runId)` method to `PipelineServiceClientInterface` so any pipeline-service client can opt-in to exposing the storage location of a run's logs (e.g. an `s3://bucket/key` URI) without downloading them. The default returns `null`, so existing clients (Airflow, K8s, Noop) are unaffected.

## Why

Operators need the real S3 location of pipeline run logs so they can fetch the file directly. Streamable pipelines already have a deterministic S3 key derived from `LogStorageConfiguration`. Non-streamable clients (Argo in particular) write logs to their own artifact location that is only knowable per-run from the workflow status — this PR adds the generic hook so each client can expose that. First consumer is an admin-ops endpoint in `openmetadata-collate`.

## Changes

- **`PipelineServiceClientInterface`** — new `default String getLogLocation(IngestionPipeline ingestionPipeline, String runId) { return null; }`. When `runId` is `null`, the latest run is used.
- **`MeteredPipelineServiceClient`** — `@Override` forwarding to `decoratedClient.getLogLocation(...)` so the metering decorator doesn't swallow the call.
- **`IngestionPipelineRepository`** — new public `getLogLocationFromPipelineService(IngestionPipeline, UUID)` wrapper that keeps `pipelineServiceClient` encapsulated. Streamable-S3 locations remain derived from `getLogStorageConfiguration()` elsewhere; this covers the non-streamable case.

## Backward compatibility

No-op for existing clients (default returns `null`). Purely additive — no method signatures changed, no behavior changes for any path that doesn't override.

## Testing

- Suggested unit tests:
  - `MeteredPipelineServiceClientTest` — verify `getLogLocation` forwards to the delegate with the same args.
  - `IngestionPipelineRepositoryTest.getLogLocationFromPipelineService` — null client / null pipeline / forwards to client; UUID-to-String conversion.
- No existing tests are affected (additive).