### PR TITLE
Fix MySQL lineage query parsing for MEDIUMBLOB logs

### DIFF
--- a/ingestion/src/metadata/ingestion/source/database/mysql/lineage.py
+++ b/ingestion/src/metadata/ingestion/source/database/mysql/lineage.py
@@ -27,3 +27,6 @@ class MysqlLineageSource(MysqlQueryParserSource, LineageSource):
             OR LOWER(CONVERT({sql_column} USING utf8mb4)) LIKE '%%merge%%'
         )
     """
+
+    def format_query(self, query: bytes) -> str:
+        return query.decode(errors="ignore").replace("\\n", "\n")


### PR DESCRIPTION
### Describe your changes:

Fixes #28029

Added MySQL lineage query normalization for `MEDIUMBLOB` query logs.

I worked on this because the MySQL usage pipeline already handled byte-based query logs using `format_query()`, but the lineage pipeline did not. When `mysql.general_log.argument` is returned as `MEDIUMBLOB`, the lineage parser may receive `bytes` instead of `str`, which can cause query parsing failures.

This change adds `format_query()` to `MysqlLineageSource` to decode byte-based queries before lineage parsing.

#

### Type of change:

* [x] Bug fix
* [ ] Improvement
* [ ] New feature
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ] Documentation

#

### High-level design:

N/A — small change.

#

### Tests:

#### Use cases covered

* MySQL lineage ingestion when `query_text` is returned as bytes (`MEDIUMBLOB`)
* Query normalization before lineage parsing

#### Unit tests

* [ ] I added unit tests for the new/changed logic.

#### Backend integration tests

* [x] Not applicable (no backend API changes).

#### Ingestion integration tests

* [ ] Not applicable (small ingestion change, manually validated).

#### Playwright (UI) tests

* [x] Not applicable (no UI changes).

#### Manual testing performed

1. Traced MySQL lineage ingestion flow
2. Compared usage and lineage query normalization behavior
3. Added `format_query()` implementation to `MysqlLineageSource`
4. Verified Python syntax using:
   `python -m py_compile ingestion/src/metadata/ingestion/source/database/mysql/lineage.py`

#

### UI screen recording / screenshots:

Not applicable.

#

### Checklist:

* [x] I have read the [**[CONTRIBUTING](https://docs.open-metadata.org/developers/contribute)**](https://docs.open-metadata.org/developers/contribute) document.
* [x] My PR title is `Fixes  #28029'
Added MySQL lineage query normalization for `MEDIUMBLOB` query logs.
* [x] My PR is linked to a GitHub issue via `Fixes #28029 ` above.
* [ ] I have commented on my code, particularly in hard-to-understand areas.
* []For UI changes: I attached a screen recording and/or screenshots above.
* [ ] I have added tests (unit / integration / Playwright as applicable) and listed them above.