### PR TITLE
ci(security-scan): structured Slack notify with Retire.js summary + thread

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -294,7 +294,7 @@ jobs:
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
           python3 - <<'PY' > header.json
-          import json, os
+          import json, os, pathlib
 
           retire = os.environ["RETIRE_RESULT"]
           snyk = os.environ["SNYK_RESULT"]
@@ -303,6 +303,28 @@ jobs:
 
           def status_icon(s):
               return {"success": "✅", "cancelled": "⚠️ (cancelled)", "skipped": "⚠️ (skipped)"}.get(s, "❌")
+
+          def load_counts(path):
+              p = pathlib.Path(path)
+              if not p.exists():
+                  return None
+              try:
+                  return json.loads(p.read_text())
+              except Exception:
+                  return None
+
+          def totals_line(counts):
+              if not counts:
+                  return ""
+              return (
+                  f"\n🚨 {counts.get('critical', 0)} critical  ·  "
+                  f"🔴 {counts.get('high', 0)} high  ·  "
+                  f"🟠 {counts.get('medium', 0)} medium  ·  "
+                  f"🟡 {counts.get('low', 0)} low"
+              )
+
+          retire_counts = load_counts("retire-report/_retire_counts.json")
+          snyk_counts = load_counts("security-report/_counts.json")
 
           if retire == "success" and snyk == "success":
               overall = "🟢"
@@ -314,8 +336,10 @@ jobs:
           header = (
               f"{overall}  *Security scan* — *OpenMetadata Repo*\n"
               f"_branch_ `{ref_name}`  ·  <{run_url}|Open run details>\n"
-              f"• Vulnerability scan (Retire.js): {status_icon(retire)}\n"
+              f"• Vulnerability scan (Retire.js): {status_icon(retire)}"
+              f"{totals_line(retire_counts)}\n"
               f"• Security scan (Snyk): {status_icon(snyk)}"
+              f"{totals_line(snyk_counts)}"
           )
           fallback = f"{overall} Security scan — OpenMetadata Repo on {ref_name}. {run_url}"
           payload = {

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -373,7 +373,11 @@ jobs:
           if not blocks:
               push("_No detailed scan output was produced._")
 
-          payload = {"thread_ts": thread_ts, "blocks": blocks}
+          payload = {
+              "thread_ts": thread_ts,
+              "text": "Security scan details (thread reply)",
+              "blocks": blocks,
+          }
           print(json.dumps(payload))
           PY
 

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -351,10 +351,9 @@ jobs:
 
       - name: Send Slack — header
         id: send-header
-        # TODO: revert channel-id to ${{ secrets.SLACK_CHANNEL_IDS }} after #vuln-testing validation.
         uses: slackapi/slack-github-action@v1.27.1
         with:
-          channel-id: C0B6Q6KDMJN
+          channel-id: ${{ secrets.SLACK_CHANNEL_IDS }}
           payload-file-path: header.json
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
@@ -407,10 +406,9 @@ jobs:
 
       - name: Send Slack — thread reply
         if: always() && steps.send-header.outputs.ts != '' && steps.build-thread.outcome == 'success'
-        # TODO: revert channel-id to ${{ secrets.SLACK_CHANNEL_IDS }} after #vuln-testing validation.
         uses: slackapi/slack-github-action@v1.27.1
         with:
-          channel-id: C0B6Q6KDMJN
+          channel-id: ${{ secrets.SLACK_CHANNEL_IDS }}
           payload-file-path: thread.json
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -63,6 +63,26 @@ jobs:
           path: openmetadata-ui/src/main/resources/ui/retire-report.json
           retention-days: 30
 
+      - name: Generate Retire.js Slack summary
+        if: always()
+        run: |
+          mkdir -p retire-report
+          python3 scripts/retire_slack_summary.py \
+            openmetadata-ui/src/main/resources/ui/retire-report.json \
+            --counts-file retire-report/_retire_counts.json \
+            --slack-file retire-report/_retire_slack.txt \
+            > /dev/null
+
+      - name: Upload Retire.js Slack artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: retire-slack
+          path: |
+            retire-report/_retire_slack.txt
+            retire-report/_retire_counts.json
+          retention-days: 30
+
       - name: Publish Retire.js Summary
         if: success()
         working-directory: openmetadata-ui/src/main/resources/ui
@@ -257,45 +277,112 @@ jobs:
           path: security-report
         continue-on-error: true
 
-      - name: Build Slack payload
-        id: build
-        run: |
-          retire="${{ needs.vulnerability-scan.result }}"
-          snyk="${{ needs.security-scan.result }}"
-          status_icon() {
-            case "$1" in
-              success)   echo "✅" ;;
-              cancelled) echo "⚠️ (cancelled)" ;;
-              skipped)   echo "⚠️ (skipped)" ;;
-              *)         echo "❌" ;;
-            esac
-          }
-          retire_icon=$(status_icon "$retire")
-          snyk_icon=$(status_icon "$snyk")
-          if [ "$retire" = "success" ] && [ "$snyk" = "success" ]; then
-            icon="🟢"
-          elif [ "$retire" = "failure" ] || [ "$snyk" = "failure" ]; then
-            icon="🚨"
-          else
-            icon="⚠️"
-          fi
-          run_url="https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-          {
-            echo "$icon *Security scan* — *OpenMetadata Repo* on branch \`${{ github.ref_name }}\`"
-            echo "• Vulnerability scan (Retire.js): $retire_icon"
-            echo "• Security scan (Snyk): $snyk_icon"
-            echo "<$run_url|Open run details>"
-            if [ -f security-report/_slack.txt ]; then
-              echo
-              cat security-report/_slack.txt
-            fi
-          } > slack_body.txt
-          jq -Rs '{text: ., mrkdwn: true}' slack_body.txt > payload.json
+      - name: Download Retire.js Slack artifact
+        if: needs.vulnerability-scan.result != 'skipped'
+        uses: actions/download-artifact@v4
+        with:
+          name: retire-slack
+          path: retire-report
+        continue-on-error: true
 
-      - name: Send Slack Notification
+      - name: Build Slack header payload
+        id: build-header
+        env:
+          RETIRE_RESULT: ${{ needs.vulnerability-scan.result }}
+          SNYK_RESULT: ${{ needs.security-scan.result }}
+          REF_NAME: ${{ github.ref_name }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          python3 - <<'PY' > header.json
+          import json, os
+
+          retire = os.environ["RETIRE_RESULT"]
+          snyk = os.environ["SNYK_RESULT"]
+          ref_name = os.environ["REF_NAME"]
+          run_url = os.environ["RUN_URL"]
+
+          def status_icon(s):
+              return {"success": "✅", "cancelled": "⚠️ (cancelled)", "skipped": "⚠️ (skipped)"}.get(s, "❌")
+
+          if retire == "success" and snyk == "success":
+              overall = "🟢"
+          elif retire == "failure" or snyk == "failure":
+              overall = "🚨"
+          else:
+              overall = "⚠️"
+
+          header = (
+              f"{overall}  *Security scan* — *OpenMetadata Repo*\n"
+              f"_branch_ `{ref_name}`  ·  <{run_url}|Open run details>\n"
+              f"• Vulnerability scan (Retire.js): {status_icon(retire)}\n"
+              f"• Security scan (Snyk): {status_icon(snyk)}"
+          )
+          fallback = f"{overall} Security scan — OpenMetadata Repo on {ref_name}. {run_url}"
+          payload = {
+              "text": fallback,
+              "blocks": [{"type": "section", "text": {"type": "mrkdwn", "text": header}}],
+          }
+          print(json.dumps(payload))
+          PY
+
+      - name: Send Slack — header
+        id: send-header
+        # TODO: revert channel-id to ${{ secrets.SLACK_CHANNEL_IDS }} after #vuln-testing validation.
         uses: slackapi/slack-github-action@v1.27.1
         with:
-          channel-id: ${{ secrets.SLACK_CHANNEL_IDS }}
-          payload-file-path: payload.json
+          channel-id: C0B6Q6KDMJN
+          payload-file-path: header.json
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+
+      - name: Build Slack thread payload
+        id: build-thread
+        if: always() && steps.send-header.outputs.ts != ''
+        env:
+          THREAD_TS: ${{ steps.send-header.outputs.ts }}
+        run: |
+          python3 - <<'PY' > thread.json
+          import json, os, pathlib
+
+          thread_ts = os.environ["THREAD_TS"]
+
+          def read_sections(path):
+              p = pathlib.Path(path)
+              if not p.exists():
+                  return []
+              text = p.read_text().strip()
+              return [s.strip() for s in text.split("\n\n") if s.strip()]
+
+          retire_sections = read_sections("retire-report/_retire_slack.txt")
+          snyk_sections = read_sections("security-report/_slack.txt")
+
+          blocks = []
+          MAX_TEXT = 2850
+
+          def push(section):
+              text = section if len(section) <= MAX_TEXT else section[:MAX_TEXT].rstrip() + "\n_…truncated, see Job Summary_"
+              blocks.append({"type": "section", "text": {"type": "mrkdwn", "text": text}})
+
+          for section in retire_sections[:24]:
+              push(section)
+          if retire_sections and snyk_sections:
+              blocks.append({"type": "divider"})
+          for section in snyk_sections[:23]:
+              push(section)
+
+          if not blocks:
+              push("_No detailed scan output was produced._")
+
+          payload = {"thread_ts": thread_ts, "blocks": blocks}
+          print(json.dumps(payload))
+          PY
+
+      - name: Send Slack — thread reply
+        if: always() && steps.send-header.outputs.ts != '' && steps.build-thread.outcome == 'success'
+        # TODO: revert channel-id to ${{ secrets.SLACK_CHANNEL_IDS }} after #vuln-testing validation.
+        uses: slackapi/slack-github-action@v1.27.1
+        with:
+          channel-id: C0B6Q6KDMJN
+          payload-file-path: thread.json
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}

--- a/scripts/retire_slack_summary.py
+++ b/scripts/retire_slack_summary.py
@@ -186,7 +186,10 @@ def render_slack(libs, totals, top):
     ]
     body = "\n\n".join([header] + sections)
     if len(body) > 2800:
-        body = body[:2750] + "\n…truncated. See Job Summary for full report."
+        cut = body.rfind("\n", 0, 2750)
+        if cut < 0:
+            cut = 2750
+        body = body[:cut].rstrip() + "\n…truncated. See Job Summary for full report."
     return body
 
 

--- a/scripts/retire_slack_summary.py
+++ b/scripts/retire_slack_summary.py
@@ -173,8 +173,9 @@ def render_lib_slack(component, version, info, top):
 
 def render_slack(libs, totals, top):
     header = (
-        f"*🛡️ Vulnerability JS Scan* — 🚨 {totals['critical']} · "
-        f"🔴 {totals['high']} · 🟠 {totals['medium']} · 🟡 {totals['low']}"
+        f"*🛡️ Vulnerability JS Scan*\n"
+        f"🚨 {totals['critical']} critical  ·  🔴 {totals['high']} high  ·  "
+        f"🟠 {totals['medium']} medium  ·  🟡 {totals['low']} low"
     )
     if not libs:
         return f"{header}\n> ✅ No vulnerable libraries found."

--- a/scripts/retire_slack_summary.py
+++ b/scripts/retire_slack_summary.py
@@ -1,0 +1,243 @@
+#!/usr/bin/env python3
+"""Render a Retire.js JSON report as Markdown + Slack-friendly summary.
+
+Usage:
+  python3 scripts/retire_slack_summary.py <retire-report.json | dir> \\
+      [--counts-file PATH] [--slack-file PATH] [--top N]
+
+Mirrors the surface of scripts/snyk_summary.py so the notify job can
+consume `_retire_counts.json` and `_retire_slack.txt` identically.
+"""
+import argparse
+import json
+import os
+import sys
+
+SEV_ICON = {"critical": "🚨", "high": "🔴", "medium": "🟠", "low": "🟡"}
+SEV_RANK = {"critical": 0, "high": 1, "medium": 2, "low": 3}
+NM = "node_modules/"
+
+
+def esc(s):
+    return str(s).replace("|", "\\|").replace("`", "'").replace("\n", " ")
+
+
+def sev_key(s):
+    return SEV_RANK.get((s or "low").lower(), 3)
+
+
+def resolve_report_path(src):
+    if os.path.isdir(src):
+        return os.path.join(src, "retire-report.json")
+    return src
+
+
+def short_path(filepath):
+    if NM in filepath:
+        return filepath[filepath.find(NM) + len(NM):]
+    return filepath
+
+
+def vuln_id(vuln):
+    """Stable identifier for dedup across files."""
+    ids = vuln.get("identifiers") or {}
+    return json.dumps(ids, sort_keys=True)
+
+
+def vuln_title(vuln):
+    ids = vuln.get("identifiers") or {}
+    cves = ids.get("CVE") or []
+    if cves:
+        return cves[0]
+    ghsa = ids.get("githubID")
+    if ghsa:
+        return ghsa
+    summary = ids.get("summary") or ""
+    return summary.split("\n")[0][:60] or "—"
+
+
+def vuln_summary(vuln):
+    ids = vuln.get("identifiers") or {}
+    summary = ids.get("summary") or ""
+    return summary.split("\n")[0][:80]
+
+
+def vuln_fix(vuln):
+    """Retire.js encodes fix as `below: <first-fixed-version>`."""
+    below = vuln.get("below")
+    if below:
+        return str(below)
+    return "no fix"
+
+
+def collect_libs(data):
+    """Aggregate vulnerabilities per (component, version), deduped."""
+    libs = {}
+    findings = data.get("data") or []
+    for item in findings:
+        filepath = item.get("file", "")
+        short = short_path(filepath)
+        for result in item.get("results") or []:
+            key = (result.get("component", "?"), result.get("version", "?"))
+            entry = libs.setdefault(key, {
+                "files": [],
+                "vulns": [],
+                "seen": set(),
+            })
+            if short and short not in entry["files"]:
+                entry["files"].append(short)
+            for v in result.get("vulnerabilities") or []:
+                vid = vuln_id(v)
+                if vid in entry["seen"]:
+                    continue
+                entry["seen"].add(vid)
+                entry["vulns"].append(v)
+    return libs
+
+
+def lib_top_severity(info):
+    if not info["vulns"]:
+        return "low"
+    return min(
+        (v.get("severity", "low") for v in info["vulns"]),
+        key=sev_key,
+    )
+
+
+def count_severities(libs):
+    counts = {"critical": 0, "high": 0, "medium": 0, "low": 0}
+    for info in libs.values():
+        for v in info["vulns"]:
+            sev = (v.get("severity") or "low").lower()
+            if sev in counts:
+                counts[sev] += 1
+    return counts
+
+
+def render_md(libs):
+    out = ["## 🛡️ Vulnerability JS Scan\n"]
+    if not libs:
+        out.append("✅ No vulnerable libraries found.\n")
+        return "\n".join(out)
+    total_vulns = sum(len(info["vulns"]) for info in libs.values())
+    out.append(
+        f"> **{len(libs)} vulnerable librar"
+        f"{'y' if len(libs) == 1 else 'ies'} · {total_vulns} "
+        f"CVE{'s' if total_vulns != 1 else ''} found**\n"
+    )
+    ordered = sorted(libs.items(), key=lambda kv: sev_key(lib_top_severity(kv[1])))
+    for (component, version), info in ordered:
+        top_icon = SEV_ICON.get(lib_top_severity(info), "⚪")
+        out.append(f"### {top_icon} {component} {version}\n")
+        out.append("| Severity | CVE | Summary | Fix |")
+        out.append("|---|---|---|---|")
+        for v in sorted(info["vulns"], key=lambda x: sev_key(x.get("severity"))):
+            sev = v.get("severity", "")
+            icon = SEV_ICON.get(sev, "⚪")
+            ids = v.get("identifiers") or {}
+            cves = ids.get("CVE") or []
+            if cves:
+                cve_str = ", ".join(
+                    f"[{c}](https://nvd.nist.gov/vuln/detail/{c})" for c in cves
+                )
+            else:
+                cve_str = ids.get("githubID") or "—"
+            summary = vuln_summary(v) or "—"
+            fix = vuln_fix(v)
+            out.append(
+                f"| {icon} {sev} | {esc(cve_str)} | {esc(summary)} | {esc(fix)} |"
+            )
+        if info["files"]:
+            out.append("\n**Bundled in:**")
+            for f in info["files"]:
+                out.append(f"- `{f}`")
+        out.append("")
+    return "\n".join(out)
+
+
+def render_lib_slack(component, version, info, top):
+    head = f"📦 *{component}@{version}* — {len(info['vulns'])} CVE{'s' if len(info['vulns']) != 1 else ''}"
+    rows = []
+    ordered = sorted(info["vulns"], key=lambda v: sev_key(v.get("severity")))
+    for v in ordered[:top]:
+        icon = SEV_ICON.get(v.get("severity", "low"), "⚪")
+        title = vuln_title(v)
+        fix = vuln_fix(v)
+        fix_label = "no fix" if fix == "no fix" else f"fix in {fix}"
+        rows.append(f"  {icon} {title} · {fix_label}")
+    extra = len(info["vulns"]) - top
+    if extra > 0:
+        rows.append(f"  … +{extra} more")
+    return head + "\n" + "\n".join(rows) if rows else head
+
+
+def render_slack(libs, totals, top):
+    header = (
+        f"*🛡️ Vulnerability JS Scan* — 🚨 {totals['critical']} · "
+        f"🔴 {totals['high']} · 🟠 {totals['medium']} · 🟡 {totals['low']}"
+    )
+    if not libs:
+        return f"{header}\n> ✅ No vulnerable libraries found."
+    ordered = sorted(libs.items(), key=lambda kv: sev_key(lib_top_severity(kv[1])))
+    sections = [
+        render_lib_slack(component, version, info, top)
+        for (component, version), info in ordered
+    ]
+    body = "\n\n".join([header] + sections)
+    if len(body) > 2800:
+        body = body[:2750] + "\n…truncated. See Job Summary for full report."
+    return body
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("src", nargs="?", default="retire-report.json")
+    ap.add_argument("--counts-file")
+    ap.add_argument("--slack-file")
+    ap.add_argument("--top", type=int, default=5)
+    args = ap.parse_args()
+
+    path = resolve_report_path(args.src)
+    totals = {"critical": 0, "high": 0, "medium": 0, "low": 0}
+
+    if not os.path.exists(path):
+        md = f"## 🛡️ Vulnerability JS Scan\n\n> Report file not found at `{path}`.\n"
+        sys.stdout.write(md)
+        if args.counts_file:
+            with open(args.counts_file, "w") as f:
+                json.dump({**totals, "total": 0}, f)
+        if args.slack_file:
+            with open(args.slack_file, "w") as f:
+                f.write("*🛡️ Vulnerability JS Scan*\n> Report file not found.")
+        return
+
+    try:
+        with open(path) as f:
+            data = json.load(f)
+    except Exception as e:
+        md = f"## 🛡️ Vulnerability JS Scan\n\n> Failed to parse `{path}`: {e}\n"
+        sys.stdout.write(md)
+        if args.counts_file:
+            with open(args.counts_file, "w") as f:
+                json.dump({**totals, "total": 0}, f)
+        if args.slack_file:
+            with open(args.slack_file, "w") as f:
+                f.write(f"*🛡️ Vulnerability JS Scan*\n> Parse error: {e}")
+        return
+
+    libs = collect_libs(data)
+    totals.update(count_severities(libs))
+
+    sys.stdout.write(render_md(libs) + "\n")
+
+    if args.counts_file:
+        with open(args.counts_file, "w") as f:
+            json.dump({**totals, "total": sum(totals.values())}, f)
+
+    if args.slack_file:
+        with open(args.slack_file, "w") as f:
+            f.write(render_slack(libs, totals, args.top))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/snyk_summary.py
+++ b/scripts/snyk_summary.py
@@ -231,8 +231,13 @@ def main():
         )
         body = "\n\n".join([header] + slack_parts[1:])
         # Slack section block text limit 3000 chars; leave headroom for shell-added header lines.
+        # Truncate at the last newline before the limit so we don't cut a Slack mrkdwn link
+        # (`<url|text>`) or a multi-codepoint emoji sequence mid-token.
         if len(body) > 2800:
-            body = body[:2750] + "\n…truncated. See Job Summary for full report."
+            cut = body.rfind("\n", 0, 2750)
+            if cut < 0:
+                cut = 2750
+            body = body[:cut].rstrip() + "\n…truncated. See Job Summary for full report."
         with open(args.slack_file, "w") as f:
             f.write(body)
 

--- a/scripts/snyk_summary.py
+++ b/scripts/snyk_summary.py
@@ -166,8 +166,7 @@ def count_severities(libs, by_rule):
     for rid, items in by_rule.items():
         for uri, level, lines in items:
             mapped = {"error": "high", "warning": "medium", "note": "low"}.get(level, "medium")
-            # Count one per (rule, file, level) group to match `total` in collect_code.
-            counts[mapped] += 1
+            counts[mapped] += 1  # count locations to match render_code_md total
     return counts
 
 
@@ -226,13 +225,14 @@ def main():
 
     if args.slack_file:
         header = (
-            f"*🛡️ Snyk Security Scan* — 🚨 {totals['critical']} · 🔴 {totals['high']} · "
-            f"🟠 {totals['medium']} · 🟡 {totals['low']}"
+            f"*🛡️ Snyk Security Scan*\n"
+            f"🚨 {totals['critical']} critical  ·  🔴 {totals['high']} high  ·  "
+            f"🟠 {totals['medium']} medium  ·  🟡 {totals['low']} low"
         )
         body = "\n\n".join([header] + slack_parts[1:])
-        # Slack hard limit 4000 chars per text field; truncate safely.
-        if len(body) > 3800:
-            body = body[:3750] + "\n…truncated. See Job Summary for full report."
+        # Slack section block text limit 3000 chars; leave headroom for shell-added header lines.
+        if len(body) > 2800:
+            body = body[:2750] + "\n…truncated. See Job Summary for full report."
         with open(args.slack_file, "w") as f:
             f.write(body)
 


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:

<!--
Linking an issue is REQUIRED. Replace <issue-number> with the GitHub issue number this PR addresses
(e.g., `Fixes #12345`). GitHub will auto-link it. If no issue exists, please open one first so the
problem and design can be discussed before review.
-->

<!--
Short blurb explaining:
- What changes did you make?
- Why did you make them?
-->
## Summary
- **New helper** `scripts/retire_slack_summary.py` (mirrors `scripts/snyk_summary.py` CLI): emits `_retire_slack.txt` + `_retire_counts.json`
- **Vulnerability scan job**: generate Retire.js Slack summary, upload as `retire-slack` artifact
- **Retire false-positive suppression**: pass `--ignore node_modules/@mixmark-io/domino/test` — jquery 1.9.1/2.2.0 there are vendored test fixtures, not loaded at runtime
- **Slack notify refactor**:
  - Python-built block payload
  - Header message: status + branch + run link + per-scan severity totals row from `_counts.json` and `_retire_counts.json`
  - Detail Retire.js + Snyk findings as threaded reply (`thread_ts`), divider between sections, 48-block cap, per-section text trimmed at last newline ≤ 2850 chars
  - Both posts include `text` fallback for push notifications + accessibility
- **`scripts/snyk_summary.py`**: header line is title + labeled totals row; truncation snaps to last newline

## Why
Slack was a flat shell+jq blob — no Retire.js detail and only ✅/❌ per scan, no severity counts.
Header in channel + detail in thread keeps the channel scannable; per-tool severity totals make at-a-glance triage possible.


#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### High-level design:
<!--
REQUIRED for large PRs (new features, refactors, breaking changes, or anything touching >5 files).
Skip for small bug fixes and trivial changes.

Cover:
- Architecture / approach you took and why
- Key components or files added/changed and how they interact
- Alternatives considered and why you rejected them
- Any migration, backward-compatibility, or rollout concerns
- Diagrams or links to design docs / RFCs if available
-->

N/A — small change. <!-- Or fill in the design above -->

#
### Tests:

#### Use cases covered
<!--
List the user-visible scenarios this PR exercises. Example:
- User with Admin role can create a Glossary Term with a parent term
- Ingestion run for Snowflake correctly extracts row counts for partitioned tables
-->

#### Unit tests
<!--
- [ ] I added unit tests for the new/changed logic.
- Files added/updated:
- Coverage on changed classes (run `mvn jacoco:report` for backend, `yarn test:coverage` for UI,
  `make unit_ingestion` for ingestion). Target is 90% line coverage on changed classes.
- Coverage %: <e.g., 92% on EntityRepository.java>
-->

#### Backend integration tests
<!--
- [ ] I added integration tests in `openmetadata-integration-tests/` for new/changed API endpoints.
- [ ] Not applicable (no backend API changes).
- Files added/updated:
-->

#### Ingestion integration tests
<!--
- [ ] I added/updated ingestion integration tests for connector changes.
- [ ] Not applicable (no ingestion changes).
- Files added/updated:
-->

#### Playwright (UI) tests
<!--
- [ ] I added Playwright E2E tests under `openmetadata-ui/.../ui/playwright/` for UI changes.
- [ ] Not applicable (no UI changes).
- Files added/updated:
-->

#### Manual testing performed
<!--
List the manual test steps you performed before requesting review. Example:
1. Started local stack via `./docker/run_local_docker.sh -m ui -d mysql`
2. Logged in as admin, created entity X, verified Y appears in the UI
3. Triggered ingestion for Snowflake source, confirmed lineage edges in the explore page
-->

#
### UI screen recording / screenshots:
<!--
REQUIRED for any PR that changes the UI. Drag-and-drop a short screen recording (.mov / .mp4 / .gif)
demonstrating the change end-to-end, plus before/after screenshots where relevant.
Mark "Not applicable" if there are no UI changes.
-->

Not applicable. <!-- Or attach recording/screenshots above -->

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.
- [ ] For UI changes: I attached a screen recording and/or screenshots above.
- [ ] I have added tests (unit / integration / Playwright as applicable) and listed them above.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->
