### PR TITLE
fix(spec): apply policyAgentConfig defaults via allOf + backfill existing services

### DIFF
--- a/bootstrap/sql/migrations/native/2.0.1/mysql/postDataMigrationSQLScript.sql
+++ b/bootstrap/sql/migrations/native/2.0.1/mysql/postDataMigrationSQLScript.sql
@@ -27,3 +27,105 @@ WHERE name = 'RdfIndexApp';
 UPDATE apps_marketplace
 SET json = JSON_SET(json, '$.appConfiguration.recreateIndex', CAST('true' AS JSON))
 WHERE name = 'RdfIndexApp';
+
+-- Backfill policyAgentConfig defaults on existing Snowflake services. The schema-level
+-- defaults in snowflakeConnection.json only apply at create-time deserialization; rows
+-- already persisted carry the previous all-false shape and won't pick up the new defaults
+-- without this rewrite. Only fields that are currently false are flipped — any operator-set
+-- true value is preserved.
+UPDATE dbservice_entity
+SET json = JSON_SET(json, '$.connection.config.policyAgentConfig.enabled', true)
+WHERE serviceType = 'Snowflake'
+  AND JSON_EXTRACT(json, '$.connection.config.policyAgentConfig.enabled') = false;
+
+UPDATE dbservice_entity
+SET json = JSON_SET(json, '$.connection.config.policyAgentConfig.supportsFullAccess', true)
+WHERE serviceType = 'Snowflake'
+  AND JSON_EXTRACT(json, '$.connection.config.policyAgentConfig.supportsFullAccess') = false;
+
+UPDATE dbservice_entity
+SET json = JSON_SET(json, '$.connection.config.policyAgentConfig.supportsMaskedAccess', true)
+WHERE serviceType = 'Snowflake'
+  AND JSON_EXTRACT(json, '$.connection.config.policyAgentConfig.supportsMaskedAccess') = false;
+
+-- Services that pre-date the policyAgentConfig field entirely (older rows where the whole
+-- object is missing) — write the full block in one shot. JSON_SET creates the key path.
+UPDATE dbservice_entity
+SET json = JSON_SET(
+    json,
+    '$.connection.config.policyAgentConfig',
+    JSON_OBJECT(
+        'enabled', true,
+        'supportsColumnAccess', false,
+        'supportsFullAccess', true,
+        'supportsMaskedAccess', true
+    )
+)
+WHERE serviceType = 'Snowflake'
+  AND JSON_EXTRACT(json, '$.connection.config.policyAgentConfig') IS NULL;
+
+-- Databricks: same target shape as Snowflake — enabled/Full/Masked default to true,
+-- Column stays false. Three guarded flips + one full-object write for legacy rows.
+UPDATE dbservice_entity
+SET json = JSON_SET(json, '$.connection.config.policyAgentConfig.enabled', true)
+WHERE serviceType = 'Databricks'
+  AND JSON_EXTRACT(json, '$.connection.config.policyAgentConfig.enabled') = false;
+
+UPDATE dbservice_entity
+SET json = JSON_SET(json, '$.connection.config.policyAgentConfig.supportsFullAccess', true)
+WHERE serviceType = 'Databricks'
+  AND JSON_EXTRACT(json, '$.connection.config.policyAgentConfig.supportsFullAccess') = false;
+
+UPDATE dbservice_entity
+SET json = JSON_SET(json, '$.connection.config.policyAgentConfig.supportsMaskedAccess', true)
+WHERE serviceType = 'Databricks'
+  AND JSON_EXTRACT(json, '$.connection.config.policyAgentConfig.supportsMaskedAccess') = false;
+
+UPDATE dbservice_entity
+SET json = JSON_SET(
+    json,
+    '$.connection.config.policyAgentConfig',
+    JSON_OBJECT(
+        'enabled', true,
+        'supportsColumnAccess', false,
+        'supportsFullAccess', true,
+        'supportsMaskedAccess', true
+    )
+)
+WHERE serviceType = 'Databricks'
+  AND JSON_EXTRACT(json, '$.connection.config.policyAgentConfig') IS NULL;
+
+-- Postgres: all four flags default to true. Four guarded flips + one full-object write.
+UPDATE dbservice_entity
+SET json = JSON_SET(json, '$.connection.config.policyAgentConfig.enabled', true)
+WHERE serviceType = 'Postgres'
+  AND JSON_EXTRACT(json, '$.connection.config.policyAgentConfig.enabled') = false;
+
+UPDATE dbservice_entity
+SET json = JSON_SET(json, '$.connection.config.policyAgentConfig.supportsColumnAccess', true)
+WHERE serviceType = 'Postgres'
+  AND JSON_EXTRACT(json, '$.connection.config.policyAgentConfig.supportsColumnAccess') = false;
+
+UPDATE dbservice_entity
+SET json = JSON_SET(json, '$.connection.config.policyAgentConfig.supportsFullAccess', true)
+WHERE serviceType = 'Postgres'
+  AND JSON_EXTRACT(json, '$.connection.config.policyAgentConfig.supportsFullAccess') = false;
+
+UPDATE dbservice_entity
+SET json = JSON_SET(json, '$.connection.config.policyAgentConfig.supportsMaskedAccess', true)
+WHERE serviceType = 'Postgres'
+  AND JSON_EXTRACT(json, '$.connection.config.policyAgentConfig.supportsMaskedAccess') = false;
+
+UPDATE dbservice_entity
+SET json = JSON_SET(
+    json,
+    '$.connection.config.policyAgentConfig',
+    JSON_OBJECT(
+        'enabled', true,
+        'supportsColumnAccess', true,
+        'supportsFullAccess', true,
+        'supportsMaskedAccess', true
+    )
+)
+WHERE serviceType = 'Postgres'
+  AND JSON_EXTRACT(json, '$.connection.config.policyAgentConfig') IS NULL;

--- a/bootstrap/sql/migrations/native/2.0.1/postgres/postDataMigrationSQLScript.sql
+++ b/bootstrap/sql/migrations/native/2.0.1/postgres/postDataMigrationSQLScript.sql
@@ -28,3 +28,134 @@ WHERE name = 'RdfIndexApp';
 UPDATE apps_marketplace
 SET json = jsonb_set(json::jsonb, '{appConfiguration,recreateIndex}', 'true')
 WHERE name = 'RdfIndexApp';
+
+-- Backfill policyAgentConfig defaults on existing Snowflake services. The schema-level
+-- defaults in snowflakeConnection.json only apply at create-time deserialization; rows
+-- already persisted carry the previous all-false shape and won't pick up the new defaults
+-- without this rewrite. Only fields that are currently false are flipped — any operator-set
+-- true value is preserved.
+UPDATE dbservice_entity
+SET json = jsonb_set(
+    json::jsonb,
+    '{connection,config,policyAgentConfig,enabled}',
+    to_jsonb(true)
+)
+WHERE serviceType = 'Snowflake'
+  AND json::jsonb #> '{connection,config,policyAgentConfig,enabled}' = 'false'::jsonb;
+
+UPDATE dbservice_entity
+SET json = jsonb_set(
+    json::jsonb,
+    '{connection,config,policyAgentConfig,supportsFullAccess}',
+    to_jsonb(true)
+)
+WHERE serviceType = 'Snowflake'
+  AND json::jsonb #> '{connection,config,policyAgentConfig,supportsFullAccess}' = 'false'::jsonb;
+
+UPDATE dbservice_entity
+SET json = jsonb_set(
+    json::jsonb,
+    '{connection,config,policyAgentConfig,supportsMaskedAccess}',
+    to_jsonb(true)
+)
+WHERE serviceType = 'Snowflake'
+  AND json::jsonb #> '{connection,config,policyAgentConfig,supportsMaskedAccess}' = 'false'::jsonb;
+
+-- Services that pre-date the policyAgentConfig field entirely (older rows where the whole
+-- object is missing) — write the full block in one shot. `jsonb_set(..., true)` creates the
+-- key if absent.
+UPDATE dbservice_entity
+SET json = jsonb_set(
+    json::jsonb,
+    '{connection,config,policyAgentConfig}',
+    '{"enabled":true,"supportsColumnAccess":false,"supportsFullAccess":true,"supportsMaskedAccess":true}'::jsonb,
+    true
+)
+WHERE serviceType = 'Snowflake'
+  AND json::jsonb #> '{connection,config,policyAgentConfig}' IS NULL;
+
+-- Databricks: same target shape as Snowflake — enabled/Full/Masked default to true,
+-- Column stays false. Three guarded flips + one full-object write for legacy rows.
+UPDATE dbservice_entity
+SET json = jsonb_set(
+    json::jsonb,
+    '{connection,config,policyAgentConfig,enabled}',
+    to_jsonb(true)
+)
+WHERE serviceType = 'Databricks'
+  AND json::jsonb #> '{connection,config,policyAgentConfig,enabled}' = 'false'::jsonb;
+
+UPDATE dbservice_entity
+SET json = jsonb_set(
+    json::jsonb,
+    '{connection,config,policyAgentConfig,supportsFullAccess}',
+    to_jsonb(true)
+)
+WHERE serviceType = 'Databricks'
+  AND json::jsonb #> '{connection,config,policyAgentConfig,supportsFullAccess}' = 'false'::jsonb;
+
+UPDATE dbservice_entity
+SET json = jsonb_set(
+    json::jsonb,
+    '{connection,config,policyAgentConfig,supportsMaskedAccess}',
+    to_jsonb(true)
+)
+WHERE serviceType = 'Databricks'
+  AND json::jsonb #> '{connection,config,policyAgentConfig,supportsMaskedAccess}' = 'false'::jsonb;
+
+UPDATE dbservice_entity
+SET json = jsonb_set(
+    json::jsonb,
+    '{connection,config,policyAgentConfig}',
+    '{"enabled":true,"supportsColumnAccess":false,"supportsFullAccess":true,"supportsMaskedAccess":true}'::jsonb,
+    true
+)
+WHERE serviceType = 'Databricks'
+  AND json::jsonb #> '{connection,config,policyAgentConfig}' IS NULL;
+
+-- Postgres: all four flags default to true. Four guarded flips + one full-object write.
+UPDATE dbservice_entity
+SET json = jsonb_set(
+    json::jsonb,
+    '{connection,config,policyAgentConfig,enabled}',
+    to_jsonb(true)
+)
+WHERE serviceType = 'Postgres'
+  AND json::jsonb #> '{connection,config,policyAgentConfig,enabled}' = 'false'::jsonb;
+
+UPDATE dbservice_entity
+SET json = jsonb_set(
+    json::jsonb,
+    '{connection,config,policyAgentConfig,supportsColumnAccess}',
+    to_jsonb(true)
+)
+WHERE serviceType = 'Postgres'
+  AND json::jsonb #> '{connection,config,policyAgentConfig,supportsColumnAccess}' = 'false'::jsonb;
+
+UPDATE dbservice_entity
+SET json = jsonb_set(
+    json::jsonb,
+    '{connection,config,policyAgentConfig,supportsFullAccess}',
+    to_jsonb(true)
+)
+WHERE serviceType = 'Postgres'
+  AND json::jsonb #> '{connection,config,policyAgentConfig,supportsFullAccess}' = 'false'::jsonb;
+
+UPDATE dbservice_entity
+SET json = jsonb_set(
+    json::jsonb,
+    '{connection,config,policyAgentConfig,supportsMaskedAccess}',
+    to_jsonb(true)
+)
+WHERE serviceType = 'Postgres'
+  AND json::jsonb #> '{connection,config,policyAgentConfig,supportsMaskedAccess}' = 'false'::jsonb;
+
+UPDATE dbservice_entity
+SET json = jsonb_set(
+    json::jsonb,
+    '{connection,config,policyAgentConfig}',
+    '{"enabled":true,"supportsColumnAccess":true,"supportsFullAccess":true,"supportsMaskedAccess":true}'::jsonb,
+    true
+)
+WHERE serviceType = 'Postgres'
+  AND json::jsonb #> '{connection,config,policyAgentConfig}' IS NULL;

--- a/openmetadata-spec/src/main/resources/json/schema/entity/services/connections/connectionBasicType.json
+++ b/openmetadata-spec/src/main/resources/json/schema/entity/services/connections/connectionBasicType.json
@@ -98,33 +98,23 @@
         "enabled": {
           "title": "Enabled",
           "description": "Enable policy agent extraction.",
-          "type": "boolean",
-          "default": false
+          "type": "boolean"
         },
         "supportsColumnAccess": {
           "title": "Supports Column Access",
           "description": "Supports column-level access policy extraction.",
-          "type": "boolean",
-          "default": false
+          "type": "boolean"
         },
         "supportsFullAccess": {
           "title": "Supports Full Access",
           "description": "Supports full access policy extraction.",
-          "type": "boolean",
-          "default": false
+          "type": "boolean"
         },
         "supportsMaskedAccess": {
           "title": "Supports Masked Access",
           "description": "Supports masked access policy extraction.",
-          "type": "boolean",
-          "default": false
+          "type": "boolean"
         }
-      },
-      "default": {
-        "enabled": false,
-        "supportsColumnAccess": false,
-        "supportsFullAccess": false,
-        "supportsMaskedAccess": false
       },
       "additionalProperties": false
     },

--- a/openmetadata-spec/src/main/resources/json/schema/entity/services/connections/database/databricksConnection.json
+++ b/openmetadata-spec/src/main/resources/json/schema/entity/services/connections/database/databricksConnection.json
@@ -149,12 +149,12 @@
     "policyAgentConfig": {
       "title": "Policy Agent Config",
       "description": "Policy agent configuration for access control extraction.",
-      "allOf": [{"$ref": "../connectionBasicType.json#/definitions/policyAgentConfig"}],
-      "properties": {
-        "enabled": {"type": "boolean", "default": true},
-        "supportsColumnAccess": {"type": "boolean", "default": false},
-        "supportsFullAccess": {"type": "boolean", "default": true},
-        "supportsMaskedAccess": {"type": "boolean", "default": true}
+      "$ref": "../connectionBasicType.json#/definitions/policyAgentConfig",
+      "default": {
+        "enabled": true,
+        "supportsColumnAccess": false,
+        "supportsFullAccess": true,
+        "supportsMaskedAccess": true
       }
     },
     "sampleDataStorageConfig": {

--- a/openmetadata-spec/src/main/resources/json/schema/entity/services/connections/database/databricksConnection.json
+++ b/openmetadata-spec/src/main/resources/json/schema/entity/services/connections/database/databricksConnection.json
@@ -148,12 +148,13 @@
     },
     "policyAgentConfig": {
       "title": "Policy Agent Config",
-      "$ref": "../connectionBasicType.json#/definitions/policyAgentConfig",
-      "default": {
-        "enabled": true,
-        "supportsColumnAccess": false,
-        "supportsFullAccess": true,
-        "supportsMaskedAccess": true
+      "description": "Policy agent configuration for access control extraction.",
+      "allOf": [{"$ref": "../connectionBasicType.json#/definitions/policyAgentConfig"}],
+      "properties": {
+        "enabled": {"type": "boolean", "default": true},
+        "supportsColumnAccess": {"type": "boolean", "default": false},
+        "supportsFullAccess": {"type": "boolean", "default": true},
+        "supportsMaskedAccess": {"type": "boolean", "default": true}
       }
     },
     "sampleDataStorageConfig": {

--- a/openmetadata-spec/src/main/resources/json/schema/entity/services/connections/database/postgresConnection.json
+++ b/openmetadata-spec/src/main/resources/json/schema/entity/services/connections/database/postgresConnection.json
@@ -163,12 +163,13 @@
     },
     "policyAgentConfig": {
       "title": "Policy Agent Config",
-      "$ref": "../connectionBasicType.json#/definitions/policyAgentConfig",
-      "default": {
-        "enabled": true,
-        "supportsColumnAccess": true,
-        "supportsFullAccess": true,
-        "supportsMaskedAccess": true
+      "description": "Policy agent configuration for access control extraction.",
+      "allOf": [{"$ref": "../connectionBasicType.json#/definitions/policyAgentConfig"}],
+      "properties": {
+        "enabled": {"type": "boolean", "default": true},
+        "supportsColumnAccess": {"type": "boolean", "default": true},
+        "supportsFullAccess": {"type": "boolean", "default": true},
+        "supportsMaskedAccess": {"type": "boolean", "default": true}
       }
     }
   },

--- a/openmetadata-spec/src/main/resources/json/schema/entity/services/connections/database/postgresConnection.json
+++ b/openmetadata-spec/src/main/resources/json/schema/entity/services/connections/database/postgresConnection.json
@@ -164,12 +164,12 @@
     "policyAgentConfig": {
       "title": "Policy Agent Config",
       "description": "Policy agent configuration for access control extraction.",
-      "allOf": [{"$ref": "../connectionBasicType.json#/definitions/policyAgentConfig"}],
-      "properties": {
-        "enabled": {"type": "boolean", "default": true},
-        "supportsColumnAccess": {"type": "boolean", "default": true},
-        "supportsFullAccess": {"type": "boolean", "default": true},
-        "supportsMaskedAccess": {"type": "boolean", "default": true}
+      "$ref": "../connectionBasicType.json#/definitions/policyAgentConfig",
+      "default": {
+        "enabled": true,
+        "supportsColumnAccess": true,
+        "supportsFullAccess": true,
+        "supportsMaskedAccess": true
       }
     }
   },

--- a/openmetadata-spec/src/main/resources/json/schema/entity/services/connections/database/snowflakeConnection.json
+++ b/openmetadata-spec/src/main/resources/json/schema/entity/services/connections/database/snowflakeConnection.json
@@ -215,12 +215,12 @@
     "policyAgentConfig": {
       "title": "Policy Agent Config",
       "description": "Policy agent configuration for access control extraction.",
-      "allOf": [{"$ref": "../connectionBasicType.json#/definitions/policyAgentConfig"}],
-      "properties": {
-        "enabled": {"type": "boolean", "default": true},
-        "supportsColumnAccess": {"type": "boolean", "default": false},
-        "supportsFullAccess": {"type": "boolean", "default": true},
-        "supportsMaskedAccess": {"type": "boolean", "default": true}
+      "$ref": "../connectionBasicType.json#/definitions/policyAgentConfig",
+      "default": {
+        "enabled": true,
+        "supportsColumnAccess": false,
+        "supportsFullAccess": true,
+        "supportsMaskedAccess": true
       }
     }
   },

--- a/openmetadata-spec/src/main/resources/json/schema/entity/services/connections/database/snowflakeConnection.json
+++ b/openmetadata-spec/src/main/resources/json/schema/entity/services/connections/database/snowflakeConnection.json
@@ -214,12 +214,13 @@
     },
     "policyAgentConfig": {
       "title": "Policy Agent Config",
-      "$ref": "../connectionBasicType.json#/definitions/policyAgentConfig",
-      "default": {
-        "enabled": true,
-        "supportsColumnAccess": false,
-        "supportsFullAccess": true,
-        "supportsMaskedAccess": true
+      "description": "Policy agent configuration for access control extraction.",
+      "allOf": [{"$ref": "../connectionBasicType.json#/definitions/policyAgentConfig"}],
+      "properties": {
+        "enabled": {"type": "boolean", "default": true},
+        "supportsColumnAccess": {"type": "boolean", "default": false},
+        "supportsFullAccess": {"type": "boolean", "default": true},
+        "supportsMaskedAccess": {"type": "boolean", "default": true}
       }
     }
   },

--- a/openmetadata-ui/src/main/resources/ui/src/generated/api/automations/createWorkflow.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/api/automations/createWorkflow.ts
@@ -1175,8 +1175,11 @@ export interface ConfigObject {
     /**
      * Databricks compute resources URL.
      */
-    httpPath?:          string;
-    policyAgentConfig?: PolicyAgentConfig;
+    httpPath?: string;
+    /**
+     * Policy agent configuration for access control extraction.
+     */
+    policyAgentConfig?: PolicyAgentConfigClass;
     /**
      * Table name to fetch the query history.
      *
@@ -3755,7 +3758,10 @@ export interface ConfigConnection {
      * this.
      */
     ingestAllDatabases?: boolean;
-    policyAgentConfig?:  PolicyAgentConfig;
+    /**
+     * Policy agent configuration for access control extraction.
+     */
+    policyAgentConfig?: PolicyAgentConfig;
     /**
      * Fully qualified name of the view or table to use for query logs. If not provided,
      * defaults to pg_stat_statements. Use this to configure a custom view (e.g.,
@@ -4460,7 +4466,10 @@ export interface HiveMetastoreConnectionDetails {
      * this.
      */
     ingestAllDatabases?: boolean;
-    policyAgentConfig?:  PolicyAgentConfig;
+    /**
+     * Policy agent configuration for access control extraction.
+     */
+    policyAgentConfig?: PolicyAgentConfig;
     /**
      * Fully qualified name of the view or table to use for query logs. If not provided,
      * defaults to pg_stat_statements. Use this to configure a custom view (e.g.,
@@ -4725,6 +4734,28 @@ export interface BucketDetails {
      * Path of the folder where the .pbit files are stored
      */
     objectPrefix?: string;
+}
+
+/**
+ * Policy agent configuration for access control extraction.
+ */
+export interface PolicyAgentConfigClass {
+    /**
+     * Enable policy agent extraction.
+     */
+    enabled?: boolean;
+    /**
+     * Supports column-level access policy extraction.
+     */
+    supportsColumnAccess?: boolean;
+    /**
+     * Supports full access policy extraction.
+     */
+    supportsFullAccess?: boolean;
+    /**
+     * Supports masked access policy extraction.
+     */
+    supportsMaskedAccess?: boolean;
 }
 
 /**

--- a/openmetadata-ui/src/main/resources/ui/src/generated/api/automations/createWorkflow.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/api/automations/createWorkflow.ts
@@ -1179,7 +1179,7 @@ export interface ConfigObject {
     /**
      * Policy agent configuration for access control extraction.
      */
-    policyAgentConfig?: PolicyAgentConfigClass;
+    policyAgentConfig?: PolicyAgentConfig;
     /**
      * Table name to fetch the query history.
      *
@@ -4734,28 +4734,6 @@ export interface BucketDetails {
      * Path of the folder where the .pbit files are stored
      */
     objectPrefix?: string;
-}
-
-/**
- * Policy agent configuration for access control extraction.
- */
-export interface PolicyAgentConfigClass {
-    /**
-     * Enable policy agent extraction.
-     */
-    enabled?: boolean;
-    /**
-     * Supports column-level access policy extraction.
-     */
-    supportsColumnAccess?: boolean;
-    /**
-     * Supports full access policy extraction.
-     */
-    supportsFullAccess?: boolean;
-    /**
-     * Supports masked access policy extraction.
-     */
-    supportsMaskedAccess?: boolean;
 }
 
 /**

--- a/openmetadata-ui/src/main/resources/ui/src/generated/api/services/createDashboardService.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/api/services/createDashboardService.ts
@@ -727,7 +727,10 @@ export interface SupersetConnection {
      * this.
      */
     ingestAllDatabases?: boolean;
-    policyAgentConfig?:  PolicyAgentConfig;
+    /**
+     * Policy agent configuration for access control extraction.
+     */
+    policyAgentConfig?: PolicyAgentConfig;
     /**
      * Fully qualified name of the view or table to use for query logs. If not provided,
      * defaults to pg_stat_statements. Use this to configure a custom view (e.g.,

--- a/openmetadata-ui/src/main/resources/ui/src/generated/api/services/createDatabaseService.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/api/services/createDatabaseService.ts
@@ -688,8 +688,11 @@ export interface Connection {
     /**
      * Databricks compute resources URL.
      */
-    httpPath?:          string;
-    policyAgentConfig?: PolicyAgentConfig;
+    httpPath?: string;
+    /**
+     * Policy agent configuration for access control extraction.
+     */
+    policyAgentConfig?: PolicyAgentConfigClass;
     /**
      * Table name to fetch the query history.
      *
@@ -1947,7 +1950,10 @@ export interface HiveMetastoreConnectionDetails {
      * this.
      */
     ingestAllDatabases?: boolean;
-    policyAgentConfig?:  PolicyAgentConfig;
+    /**
+     * Policy agent configuration for access control extraction.
+     */
+    policyAgentConfig?: PolicyAgentConfig;
     /**
      * Fully qualified name of the view or table to use for query logs. If not provided,
      * defaults to pg_stat_statements. Use this to configure a custom view (e.g.,
@@ -2243,6 +2249,28 @@ export interface OracleConnectionType {
      */
     oracleTNSConnection?: string;
     [property: string]: any;
+}
+
+/**
+ * Policy agent configuration for access control extraction.
+ */
+export interface PolicyAgentConfigClass {
+    /**
+     * Enable policy agent extraction.
+     */
+    enabled?: boolean;
+    /**
+     * Supports column-level access policy extraction.
+     */
+    supportsColumnAccess?: boolean;
+    /**
+     * Supports full access policy extraction.
+     */
+    supportsFullAccess?: boolean;
+    /**
+     * Supports masked access policy extraction.
+     */
+    supportsMaskedAccess?: boolean;
 }
 
 /**

--- a/openmetadata-ui/src/main/resources/ui/src/generated/api/services/createDatabaseService.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/api/services/createDatabaseService.ts
@@ -692,7 +692,7 @@ export interface Connection {
     /**
      * Policy agent configuration for access control extraction.
      */
-    policyAgentConfig?: PolicyAgentConfigClass;
+    policyAgentConfig?: PolicyAgentConfig;
     /**
      * Table name to fetch the query history.
      *
@@ -2249,28 +2249,6 @@ export interface OracleConnectionType {
      */
     oracleTNSConnection?: string;
     [property: string]: any;
-}
-
-/**
- * Policy agent configuration for access control extraction.
- */
-export interface PolicyAgentConfigClass {
-    /**
-     * Enable policy agent extraction.
-     */
-    enabled?: boolean;
-    /**
-     * Supports column-level access policy extraction.
-     */
-    supportsColumnAccess?: boolean;
-    /**
-     * Supports full access policy extraction.
-     */
-    supportsFullAccess?: boolean;
-    /**
-     * Supports masked access policy extraction.
-     */
-    supportsMaskedAccess?: boolean;
 }
 
 /**

--- a/openmetadata-ui/src/main/resources/ui/src/generated/api/services/createMetadataService.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/api/services/createMetadataService.ts
@@ -418,7 +418,10 @@ export interface AlationDatabaseConnection {
      * this.
      */
     ingestAllDatabases?: boolean;
-    policyAgentConfig?:  PolicyAgentConfig;
+    /**
+     * Policy agent configuration for access control extraction.
+     */
+    policyAgentConfig?: PolicyAgentConfig;
     /**
      * Fully qualified name of the view or table to use for query logs. If not provided,
      * defaults to pg_stat_statements. Use this to configure a custom view (e.g.,

--- a/openmetadata-ui/src/main/resources/ui/src/generated/api/services/createPipelineService.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/api/services/createPipelineService.ts
@@ -840,7 +840,10 @@ export interface ConnectionClass {
      * this.
      */
     ingestAllDatabases?: boolean;
-    policyAgentConfig?:  PolicyAgentConfig;
+    /**
+     * Policy agent configuration for access control extraction.
+     */
+    policyAgentConfig?: PolicyAgentConfig;
     /**
      * Fully qualified name of the view or table to use for query logs. If not provided,
      * defaults to pg_stat_statements. Use this to configure a custom view (e.g.,

--- a/openmetadata-ui/src/main/resources/ui/src/generated/api/services/ingestionPipelines/createIngestionPipeline.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/api/services/ingestionPipelines/createIngestionPipeline.ts
@@ -4452,7 +4452,7 @@ export interface ConfigObject {
     /**
      * Policy agent configuration for access control extraction.
      */
-    policyAgentConfig?: PolicyAgentConfigClass;
+    policyAgentConfig?: PolicyAgentConfig;
     /**
      * Table name to fetch the query history.
      *
@@ -7408,28 +7408,6 @@ export interface BucketDetails {
      * Path of the folder where the .pbit files are stored
      */
     objectPrefix?: string;
-}
-
-/**
- * Policy agent configuration for access control extraction.
- */
-export interface PolicyAgentConfigClass {
-    /**
-     * Enable policy agent extraction.
-     */
-    enabled?: boolean;
-    /**
-     * Supports column-level access policy extraction.
-     */
-    supportsColumnAccess?: boolean;
-    /**
-     * Supports full access policy extraction.
-     */
-    supportsFullAccess?: boolean;
-    /**
-     * Supports masked access policy extraction.
-     */
-    supportsMaskedAccess?: boolean;
 }
 
 /**

--- a/openmetadata-ui/src/main/resources/ui/src/generated/api/services/ingestionPipelines/createIngestionPipeline.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/api/services/ingestionPipelines/createIngestionPipeline.ts
@@ -4448,8 +4448,11 @@ export interface ConfigObject {
     /**
      * Databricks compute resources URL.
      */
-    httpPath?:          string;
-    policyAgentConfig?: PolicyAgentConfig;
+    httpPath?: string;
+    /**
+     * Policy agent configuration for access control extraction.
+     */
+    policyAgentConfig?: PolicyAgentConfigClass;
     /**
      * Table name to fetch the query history.
      *
@@ -6391,7 +6394,10 @@ export interface ConfigConnection {
      * this.
      */
     ingestAllDatabases?: boolean;
-    policyAgentConfig?:  PolicyAgentConfig;
+    /**
+     * Policy agent configuration for access control extraction.
+     */
+    policyAgentConfig?: PolicyAgentConfig;
     /**
      * Fully qualified name of the view or table to use for query logs. If not provided,
      * defaults to pg_stat_statements. Use this to configure a custom view (e.g.,
@@ -7134,7 +7140,10 @@ export interface HiveMetastoreConnectionDetails {
      * this.
      */
     ingestAllDatabases?: boolean;
-    policyAgentConfig?:  PolicyAgentConfig;
+    /**
+     * Policy agent configuration for access control extraction.
+     */
+    policyAgentConfig?: PolicyAgentConfig;
     /**
      * Fully qualified name of the view or table to use for query logs. If not provided,
      * defaults to pg_stat_statements. Use this to configure a custom view (e.g.,
@@ -7399,6 +7408,28 @@ export interface BucketDetails {
      * Path of the folder where the .pbit files are stored
      */
     objectPrefix?: string;
+}
+
+/**
+ * Policy agent configuration for access control extraction.
+ */
+export interface PolicyAgentConfigClass {
+    /**
+     * Enable policy agent extraction.
+     */
+    enabled?: boolean;
+    /**
+     * Supports column-level access policy extraction.
+     */
+    supportsColumnAccess?: boolean;
+    /**
+     * Supports full access policy extraction.
+     */
+    supportsFullAccess?: boolean;
+    /**
+     * Supports masked access policy extraction.
+     */
+    supportsMaskedAccess?: boolean;
 }
 
 /**

--- a/openmetadata-ui/src/main/resources/ui/src/generated/entity/automations/testServiceConnection.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/entity/automations/testServiceConnection.ts
@@ -1061,7 +1061,7 @@ export interface ConfigObject {
     /**
      * Policy agent configuration for access control extraction.
      */
-    policyAgentConfig?: PolicyAgentConfigClass;
+    policyAgentConfig?: PolicyAgentConfig;
     /**
      * Table name to fetch the query history.
      *
@@ -4616,28 +4616,6 @@ export interface BucketDetails {
      * Path of the folder where the .pbit files are stored
      */
     objectPrefix?: string;
-}
-
-/**
- * Policy agent configuration for access control extraction.
- */
-export interface PolicyAgentConfigClass {
-    /**
-     * Enable policy agent extraction.
-     */
-    enabled?: boolean;
-    /**
-     * Supports column-level access policy extraction.
-     */
-    supportsColumnAccess?: boolean;
-    /**
-     * Supports full access policy extraction.
-     */
-    supportsFullAccess?: boolean;
-    /**
-     * Supports masked access policy extraction.
-     */
-    supportsMaskedAccess?: boolean;
 }
 
 /**

--- a/openmetadata-ui/src/main/resources/ui/src/generated/entity/automations/testServiceConnection.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/entity/automations/testServiceConnection.ts
@@ -1057,8 +1057,11 @@ export interface ConfigObject {
     /**
      * Databricks compute resources URL.
      */
-    httpPath?:          string;
-    policyAgentConfig?: PolicyAgentConfig;
+    httpPath?: string;
+    /**
+     * Policy agent configuration for access control extraction.
+     */
+    policyAgentConfig?: PolicyAgentConfigClass;
     /**
      * Table name to fetch the query history.
      *
@@ -3637,7 +3640,10 @@ export interface ConfigConnection {
      * this.
      */
     ingestAllDatabases?: boolean;
-    policyAgentConfig?:  PolicyAgentConfig;
+    /**
+     * Policy agent configuration for access control extraction.
+     */
+    policyAgentConfig?: PolicyAgentConfig;
     /**
      * Fully qualified name of the view or table to use for query logs. If not provided,
      * defaults to pg_stat_statements. Use this to configure a custom view (e.g.,
@@ -4342,7 +4348,10 @@ export interface HiveMetastoreConnectionDetails {
      * this.
      */
     ingestAllDatabases?: boolean;
-    policyAgentConfig?:  PolicyAgentConfig;
+    /**
+     * Policy agent configuration for access control extraction.
+     */
+    policyAgentConfig?: PolicyAgentConfig;
     /**
      * Fully qualified name of the view or table to use for query logs. If not provided,
      * defaults to pg_stat_statements. Use this to configure a custom view (e.g.,
@@ -4607,6 +4616,28 @@ export interface BucketDetails {
      * Path of the folder where the .pbit files are stored
      */
     objectPrefix?: string;
+}
+
+/**
+ * Policy agent configuration for access control extraction.
+ */
+export interface PolicyAgentConfigClass {
+    /**
+     * Enable policy agent extraction.
+     */
+    enabled?: boolean;
+    /**
+     * Supports column-level access policy extraction.
+     */
+    supportsColumnAccess?: boolean;
+    /**
+     * Supports full access policy extraction.
+     */
+    supportsFullAccess?: boolean;
+    /**
+     * Supports masked access policy extraction.
+     */
+    supportsMaskedAccess?: boolean;
 }
 
 /**

--- a/openmetadata-ui/src/main/resources/ui/src/generated/entity/automations/workflow.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/entity/automations/workflow.ts
@@ -1732,7 +1732,7 @@ export interface ConfigObject {
     /**
      * Policy agent configuration for access control extraction.
      */
-    policyAgentConfig?: PolicyAgentConfigClass;
+    policyAgentConfig?: PolicyAgentConfig;
     /**
      * Table name to fetch the query history.
      *
@@ -5124,28 +5124,6 @@ export interface BucketDetails {
      * Path of the folder where the .pbit files are stored
      */
     objectPrefix?: string;
-}
-
-/**
- * Policy agent configuration for access control extraction.
- */
-export interface PolicyAgentConfigClass {
-    /**
-     * Enable policy agent extraction.
-     */
-    enabled?: boolean;
-    /**
-     * Supports column-level access policy extraction.
-     */
-    supportsColumnAccess?: boolean;
-    /**
-     * Supports full access policy extraction.
-     */
-    supportsFullAccess?: boolean;
-    /**
-     * Supports masked access policy extraction.
-     */
-    supportsMaskedAccess?: boolean;
 }
 
 /**

--- a/openmetadata-ui/src/main/resources/ui/src/generated/entity/automations/workflow.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/entity/automations/workflow.ts
@@ -1728,8 +1728,11 @@ export interface ConfigObject {
     /**
      * Databricks compute resources URL.
      */
-    httpPath?:          string;
-    policyAgentConfig?: PolicyAgentConfig;
+    httpPath?: string;
+    /**
+     * Policy agent configuration for access control extraction.
+     */
+    policyAgentConfig?: PolicyAgentConfigClass;
     /**
      * Table name to fetch the query history.
      *
@@ -4161,7 +4164,10 @@ export interface ConfigConnection {
      * this.
      */
     ingestAllDatabases?: boolean;
-    policyAgentConfig?:  PolicyAgentConfig;
+    /**
+     * Policy agent configuration for access control extraction.
+     */
+    policyAgentConfig?: PolicyAgentConfig;
     /**
      * Fully qualified name of the view or table to use for query logs. If not provided,
      * defaults to pg_stat_statements. Use this to configure a custom view (e.g.,
@@ -4850,7 +4856,10 @@ export interface HiveMetastoreConnectionDetails {
      * this.
      */
     ingestAllDatabases?: boolean;
-    policyAgentConfig?:  PolicyAgentConfig;
+    /**
+     * Policy agent configuration for access control extraction.
+     */
+    policyAgentConfig?: PolicyAgentConfig;
     /**
      * Fully qualified name of the view or table to use for query logs. If not provided,
      * defaults to pg_stat_statements. Use this to configure a custom view (e.g.,
@@ -5115,6 +5124,28 @@ export interface BucketDetails {
      * Path of the folder where the .pbit files are stored
      */
     objectPrefix?: string;
+}
+
+/**
+ * Policy agent configuration for access control extraction.
+ */
+export interface PolicyAgentConfigClass {
+    /**
+     * Enable policy agent extraction.
+     */
+    enabled?: boolean;
+    /**
+     * Supports column-level access policy extraction.
+     */
+    supportsColumnAccess?: boolean;
+    /**
+     * Supports full access policy extraction.
+     */
+    supportsFullAccess?: boolean;
+    /**
+     * Supports masked access policy extraction.
+     */
+    supportsMaskedAccess?: boolean;
 }
 
 /**

--- a/openmetadata-ui/src/main/resources/ui/src/generated/entity/services/connections/dashboard/supersetConnection.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/entity/services/connections/dashboard/supersetConnection.ts
@@ -142,7 +142,10 @@ export interface SupersetConnectionClass {
      * this.
      */
     ingestAllDatabases?: boolean;
-    policyAgentConfig?:  PolicyAgentConfig;
+    /**
+     * Policy agent configuration for access control extraction.
+     */
+    policyAgentConfig?: PolicyAgentConfig;
     /**
      * Fully qualified name of the view or table to use for query logs. If not provided,
      * defaults to pg_stat_statements. Use this to configure a custom view (e.g.,

--- a/openmetadata-ui/src/main/resources/ui/src/generated/entity/services/connections/database/databricksConnection.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/entity/services/connections/database/databricksConnection.ts
@@ -49,7 +49,10 @@ export interface DatabricksConnection {
     /**
      * Databricks compute resources URL.
      */
-    httpPath:           string;
+    httpPath: string;
+    /**
+     * Policy agent configuration for access control extraction.
+     */
     policyAgentConfig?: PolicyAgentConfig;
     /**
      * Table name to fetch the query history.

--- a/openmetadata-ui/src/main/resources/ui/src/generated/entity/services/connections/database/hiveConnection.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/entity/services/connections/database/hiveConnection.ts
@@ -169,7 +169,10 @@ export interface HiveMetastoreConnectionDetails {
      * this.
      */
     ingestAllDatabases?: boolean;
-    policyAgentConfig?:  PolicyAgentConfig;
+    /**
+     * Policy agent configuration for access control extraction.
+     */
+    policyAgentConfig?: PolicyAgentConfig;
     /**
      * Fully qualified name of the view or table to use for query logs. If not provided,
      * defaults to pg_stat_statements. Use this to configure a custom view (e.g.,

--- a/openmetadata-ui/src/main/resources/ui/src/generated/entity/services/connections/database/postgresConnection.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/entity/services/connections/database/postgresConnection.ts
@@ -43,7 +43,10 @@ export interface PostgresConnection {
      * this.
      */
     ingestAllDatabases?: boolean;
-    policyAgentConfig?:  PolicyAgentConfig;
+    /**
+     * Policy agent configuration for access control extraction.
+     */
+    policyAgentConfig?: PolicyAgentConfig;
     /**
      * Fully qualified name of the view or table to use for query logs. If not provided,
      * defaults to pg_stat_statements. Use this to configure a custom view (e.g.,

--- a/openmetadata-ui/src/main/resources/ui/src/generated/entity/services/connections/database/snowflakeConnection.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/entity/services/connections/database/snowflakeConnection.ts
@@ -68,7 +68,10 @@ export interface SnowflakeConnection {
     /**
      * Password to connect to Snowflake.
      */
-    password?:          string;
+    password?: string;
+    /**
+     * Policy agent configuration for access control extraction.
+     */
     policyAgentConfig?: PolicyAgentConfig;
     /**
      * Connection to Snowflake instance via Private Key

--- a/openmetadata-ui/src/main/resources/ui/src/generated/entity/services/connections/metadata/alationConnection.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/entity/services/connections/metadata/alationConnection.ts
@@ -149,7 +149,10 @@ export interface AlationDatabaseConnection {
      * this.
      */
     ingestAllDatabases?: boolean;
-    policyAgentConfig?:  PolicyAgentConfig;
+    /**
+     * Policy agent configuration for access control extraction.
+     */
+    policyAgentConfig?: PolicyAgentConfig;
     /**
      * Fully qualified name of the view or table to use for query logs. If not provided,
      * defaults to pg_stat_statements. Use this to configure a custom view (e.g.,

--- a/openmetadata-ui/src/main/resources/ui/src/generated/entity/services/connections/pipeline/airflowConnection.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/entity/services/connections/pipeline/airflowConnection.ts
@@ -166,7 +166,10 @@ export interface AirflowConnectionClass {
      * this.
      */
     ingestAllDatabases?: boolean;
-    policyAgentConfig?:  PolicyAgentConfig;
+    /**
+     * Policy agent configuration for access control extraction.
+     */
+    policyAgentConfig?: PolicyAgentConfig;
     /**
      * Fully qualified name of the view or table to use for query logs. If not provided,
      * defaults to pg_stat_statements. Use this to configure a custom view (e.g.,

--- a/openmetadata-ui/src/main/resources/ui/src/generated/entity/services/connections/serviceConnection.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/entity/services/connections/serviceConnection.ts
@@ -1346,7 +1346,7 @@ export interface ConfigObject {
     /**
      * Policy agent configuration for access control extraction.
      */
-    policyAgentConfig?: PolicyAgentConfigClass;
+    policyAgentConfig?: PolicyAgentConfig;
     /**
      * Table name to fetch the query history.
      *
@@ -4656,28 +4656,6 @@ export interface BucketDetails {
      * Path of the folder where the .pbit files are stored
      */
     objectPrefix?: string;
-}
-
-/**
- * Policy agent configuration for access control extraction.
- */
-export interface PolicyAgentConfigClass {
-    /**
-     * Enable policy agent extraction.
-     */
-    enabled?: boolean;
-    /**
-     * Supports column-level access policy extraction.
-     */
-    supportsColumnAccess?: boolean;
-    /**
-     * Supports full access policy extraction.
-     */
-    supportsFullAccess?: boolean;
-    /**
-     * Supports masked access policy extraction.
-     */
-    supportsMaskedAccess?: boolean;
 }
 
 /**

--- a/openmetadata-ui/src/main/resources/ui/src/generated/entity/services/connections/serviceConnection.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/entity/services/connections/serviceConnection.ts
@@ -1342,8 +1342,11 @@ export interface ConfigObject {
     /**
      * Databricks compute resources URL.
      */
-    httpPath?:          string;
-    policyAgentConfig?: PolicyAgentConfig;
+    httpPath?: string;
+    /**
+     * Policy agent configuration for access control extraction.
+     */
+    policyAgentConfig?: PolicyAgentConfigClass;
     /**
      * Table name to fetch the query history.
      *
@@ -3626,7 +3629,10 @@ export interface ConfigConnection {
      * this.
      */
     ingestAllDatabases?: boolean;
-    policyAgentConfig?:  PolicyAgentConfig;
+    /**
+     * Policy agent configuration for access control extraction.
+     */
+    policyAgentConfig?: PolicyAgentConfig;
     /**
      * Fully qualified name of the view or table to use for query logs. If not provided,
      * defaults to pg_stat_statements. Use this to configure a custom view (e.g.,
@@ -4382,7 +4388,10 @@ export interface HiveMetastoreConnectionDetails {
      * this.
      */
     ingestAllDatabases?: boolean;
-    policyAgentConfig?:  PolicyAgentConfig;
+    /**
+     * Policy agent configuration for access control extraction.
+     */
+    policyAgentConfig?: PolicyAgentConfig;
     /**
      * Fully qualified name of the view or table to use for query logs. If not provided,
      * defaults to pg_stat_statements. Use this to configure a custom view (e.g.,
@@ -4647,6 +4656,28 @@ export interface BucketDetails {
      * Path of the folder where the .pbit files are stored
      */
     objectPrefix?: string;
+}
+
+/**
+ * Policy agent configuration for access control extraction.
+ */
+export interface PolicyAgentConfigClass {
+    /**
+     * Enable policy agent extraction.
+     */
+    enabled?: boolean;
+    /**
+     * Supports column-level access policy extraction.
+     */
+    supportsColumnAccess?: boolean;
+    /**
+     * Supports full access policy extraction.
+     */
+    supportsFullAccess?: boolean;
+    /**
+     * Supports masked access policy extraction.
+     */
+    supportsMaskedAccess?: boolean;
 }
 
 /**

--- a/openmetadata-ui/src/main/resources/ui/src/generated/entity/services/dashboardService.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/entity/services/dashboardService.ts
@@ -856,7 +856,10 @@ export interface SupersetConnection {
      * this.
      */
     ingestAllDatabases?: boolean;
-    policyAgentConfig?:  PolicyAgentConfig;
+    /**
+     * Policy agent configuration for access control extraction.
+     */
+    policyAgentConfig?: PolicyAgentConfig;
     /**
      * Fully qualified name of the view or table to use for query logs. If not provided,
      * defaults to pg_stat_statements. Use this to configure a custom view (e.g.,

--- a/openmetadata-ui/src/main/resources/ui/src/generated/entity/services/databaseService.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/entity/services/databaseService.ts
@@ -823,7 +823,7 @@ export interface Connection {
     /**
      * Policy agent configuration for access control extraction.
      */
-    policyAgentConfig?: PolicyAgentConfigClass;
+    policyAgentConfig?: PolicyAgentConfig;
     /**
      * Table name to fetch the query history.
      *
@@ -2380,28 +2380,6 @@ export interface OracleConnectionType {
      */
     oracleTNSConnection?: string;
     [property: string]: any;
-}
-
-/**
- * Policy agent configuration for access control extraction.
- */
-export interface PolicyAgentConfigClass {
-    /**
-     * Enable policy agent extraction.
-     */
-    enabled?: boolean;
-    /**
-     * Supports column-level access policy extraction.
-     */
-    supportsColumnAccess?: boolean;
-    /**
-     * Supports full access policy extraction.
-     */
-    supportsFullAccess?: boolean;
-    /**
-     * Supports masked access policy extraction.
-     */
-    supportsMaskedAccess?: boolean;
 }
 
 /**

--- a/openmetadata-ui/src/main/resources/ui/src/generated/entity/services/databaseService.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/entity/services/databaseService.ts
@@ -819,8 +819,11 @@ export interface Connection {
     /**
      * Databricks compute resources URL.
      */
-    httpPath?:          string;
-    policyAgentConfig?: PolicyAgentConfig;
+    httpPath?: string;
+    /**
+     * Policy agent configuration for access control extraction.
+     */
+    policyAgentConfig?: PolicyAgentConfigClass;
     /**
      * Table name to fetch the query history.
      *
@@ -2078,7 +2081,10 @@ export interface HiveMetastoreConnectionDetails {
      * this.
      */
     ingestAllDatabases?: boolean;
-    policyAgentConfig?:  PolicyAgentConfig;
+    /**
+     * Policy agent configuration for access control extraction.
+     */
+    policyAgentConfig?: PolicyAgentConfig;
     /**
      * Fully qualified name of the view or table to use for query logs. If not provided,
      * defaults to pg_stat_statements. Use this to configure a custom view (e.g.,
@@ -2374,6 +2380,28 @@ export interface OracleConnectionType {
      */
     oracleTNSConnection?: string;
     [property: string]: any;
+}
+
+/**
+ * Policy agent configuration for access control extraction.
+ */
+export interface PolicyAgentConfigClass {
+    /**
+     * Enable policy agent extraction.
+     */
+    enabled?: boolean;
+    /**
+     * Supports column-level access policy extraction.
+     */
+    supportsColumnAccess?: boolean;
+    /**
+     * Supports full access policy extraction.
+     */
+    supportsFullAccess?: boolean;
+    /**
+     * Supports masked access policy extraction.
+     */
+    supportsMaskedAccess?: boolean;
 }
 
 /**

--- a/openmetadata-ui/src/main/resources/ui/src/generated/entity/services/ingestionPipelines/ingestionPipeline.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/entity/services/ingestionPipelines/ingestionPipeline.ts
@@ -4984,7 +4984,7 @@ export interface ConfigObject {
     /**
      * Policy agent configuration for access control extraction.
      */
-    policyAgentConfig?: PolicyAgentConfigClass;
+    policyAgentConfig?: PolicyAgentConfig;
     /**
      * Table name to fetch the query history.
      *
@@ -7921,28 +7921,6 @@ export interface BucketDetails {
      * Path of the folder where the .pbit files are stored
      */
     objectPrefix?: string;
-}
-
-/**
- * Policy agent configuration for access control extraction.
- */
-export interface PolicyAgentConfigClass {
-    /**
-     * Enable policy agent extraction.
-     */
-    enabled?: boolean;
-    /**
-     * Supports column-level access policy extraction.
-     */
-    supportsColumnAccess?: boolean;
-    /**
-     * Supports full access policy extraction.
-     */
-    supportsFullAccess?: boolean;
-    /**
-     * Supports masked access policy extraction.
-     */
-    supportsMaskedAccess?: boolean;
 }
 
 /**

--- a/openmetadata-ui/src/main/resources/ui/src/generated/entity/services/ingestionPipelines/ingestionPipeline.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/entity/services/ingestionPipelines/ingestionPipeline.ts
@@ -4980,8 +4980,11 @@ export interface ConfigObject {
     /**
      * Databricks compute resources URL.
      */
-    httpPath?:          string;
-    policyAgentConfig?: PolicyAgentConfig;
+    httpPath?: string;
+    /**
+     * Policy agent configuration for access control extraction.
+     */
+    policyAgentConfig?: PolicyAgentConfigClass;
     /**
      * Table name to fetch the query history.
      *
@@ -6904,7 +6907,10 @@ export interface ConfigConnection {
      * this.
      */
     ingestAllDatabases?: boolean;
-    policyAgentConfig?:  PolicyAgentConfig;
+    /**
+     * Policy agent configuration for access control extraction.
+     */
+    policyAgentConfig?: PolicyAgentConfig;
     /**
      * Fully qualified name of the view or table to use for query logs. If not provided,
      * defaults to pg_stat_statements. Use this to configure a custom view (e.g.,
@@ -7647,7 +7653,10 @@ export interface HiveMetastoreConnectionDetails {
      * this.
      */
     ingestAllDatabases?: boolean;
-    policyAgentConfig?:  PolicyAgentConfig;
+    /**
+     * Policy agent configuration for access control extraction.
+     */
+    policyAgentConfig?: PolicyAgentConfig;
     /**
      * Fully qualified name of the view or table to use for query logs. If not provided,
      * defaults to pg_stat_statements. Use this to configure a custom view (e.g.,
@@ -7912,6 +7921,28 @@ export interface BucketDetails {
      * Path of the folder where the .pbit files are stored
      */
     objectPrefix?: string;
+}
+
+/**
+ * Policy agent configuration for access control extraction.
+ */
+export interface PolicyAgentConfigClass {
+    /**
+     * Enable policy agent extraction.
+     */
+    enabled?: boolean;
+    /**
+     * Supports column-level access policy extraction.
+     */
+    supportsColumnAccess?: boolean;
+    /**
+     * Supports full access policy extraction.
+     */
+    supportsFullAccess?: boolean;
+    /**
+     * Supports masked access policy extraction.
+     */
+    supportsMaskedAccess?: boolean;
 }
 
 /**

--- a/openmetadata-ui/src/main/resources/ui/src/generated/entity/services/metadataService.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/entity/services/metadataService.ts
@@ -546,7 +546,10 @@ export interface AlationDatabaseConnection {
      * this.
      */
     ingestAllDatabases?: boolean;
-    policyAgentConfig?:  PolicyAgentConfig;
+    /**
+     * Policy agent configuration for access control extraction.
+     */
+    policyAgentConfig?: PolicyAgentConfig;
     /**
      * Fully qualified name of the view or table to use for query logs. If not provided,
      * defaults to pg_stat_statements. Use this to configure a custom view (e.g.,

--- a/openmetadata-ui/src/main/resources/ui/src/generated/entity/services/pipelineService.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/entity/services/pipelineService.ts
@@ -962,7 +962,10 @@ export interface ConnectionClass {
      * this.
      */
     ingestAllDatabases?: boolean;
-    policyAgentConfig?:  PolicyAgentConfig;
+    /**
+     * Policy agent configuration for access control extraction.
+     */
+    policyAgentConfig?: PolicyAgentConfig;
     /**
      * Fully qualified name of the view or table to use for query logs. If not provided,
      * defaults to pg_stat_statements. Use this to configure a custom view (e.g.,

--- a/openmetadata-ui/src/main/resources/ui/src/generated/metadataIngestion/testSuitePipeline.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/metadataIngestion/testSuitePipeline.ts
@@ -1444,7 +1444,7 @@ export interface ConfigObject {
     /**
      * Policy agent configuration for access control extraction.
      */
-    policyAgentConfig?: PolicyAgentConfigClass;
+    policyAgentConfig?: PolicyAgentConfig;
     /**
      * Table name to fetch the query history.
      *
@@ -4754,28 +4754,6 @@ export interface BucketDetails {
      * Path of the folder where the .pbit files are stored
      */
     objectPrefix?: string;
-}
-
-/**
- * Policy agent configuration for access control extraction.
- */
-export interface PolicyAgentConfigClass {
-    /**
-     * Enable policy agent extraction.
-     */
-    enabled?: boolean;
-    /**
-     * Supports column-level access policy extraction.
-     */
-    supportsColumnAccess?: boolean;
-    /**
-     * Supports full access policy extraction.
-     */
-    supportsFullAccess?: boolean;
-    /**
-     * Supports masked access policy extraction.
-     */
-    supportsMaskedAccess?: boolean;
 }
 
 /**

--- a/openmetadata-ui/src/main/resources/ui/src/generated/metadataIngestion/testSuitePipeline.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/metadataIngestion/testSuitePipeline.ts
@@ -1440,8 +1440,11 @@ export interface ConfigObject {
     /**
      * Databricks compute resources URL.
      */
-    httpPath?:          string;
-    policyAgentConfig?: PolicyAgentConfig;
+    httpPath?: string;
+    /**
+     * Policy agent configuration for access control extraction.
+     */
+    policyAgentConfig?: PolicyAgentConfigClass;
     /**
      * Table name to fetch the query history.
      *
@@ -3724,7 +3727,10 @@ export interface ConfigConnection {
      * this.
      */
     ingestAllDatabases?: boolean;
-    policyAgentConfig?:  PolicyAgentConfig;
+    /**
+     * Policy agent configuration for access control extraction.
+     */
+    policyAgentConfig?: PolicyAgentConfig;
     /**
      * Fully qualified name of the view or table to use for query logs. If not provided,
      * defaults to pg_stat_statements. Use this to configure a custom view (e.g.,
@@ -4480,7 +4486,10 @@ export interface HiveMetastoreConnectionDetails {
      * this.
      */
     ingestAllDatabases?: boolean;
-    policyAgentConfig?:  PolicyAgentConfig;
+    /**
+     * Policy agent configuration for access control extraction.
+     */
+    policyAgentConfig?: PolicyAgentConfig;
     /**
      * Fully qualified name of the view or table to use for query logs. If not provided,
      * defaults to pg_stat_statements. Use this to configure a custom view (e.g.,
@@ -4745,6 +4754,28 @@ export interface BucketDetails {
      * Path of the folder where the .pbit files are stored
      */
     objectPrefix?: string;
+}
+
+/**
+ * Policy agent configuration for access control extraction.
+ */
+export interface PolicyAgentConfigClass {
+    /**
+     * Enable policy agent extraction.
+     */
+    enabled?: boolean;
+    /**
+     * Supports column-level access policy extraction.
+     */
+    supportsColumnAccess?: boolean;
+    /**
+     * Supports full access policy extraction.
+     */
+    supportsFullAccess?: boolean;
+    /**
+     * Supports masked access policy extraction.
+     */
+    supportsMaskedAccess?: boolean;
 }
 
 /**

--- a/openmetadata-ui/src/main/resources/ui/src/generated/metadataIngestion/workflow.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/metadataIngestion/workflow.ts
@@ -1431,8 +1431,11 @@ export interface ConfigObject {
     /**
      * Databricks compute resources URL.
      */
-    httpPath?:          string;
-    policyAgentConfig?: PolicyAgentConfig;
+    httpPath?: string;
+    /**
+     * Policy agent configuration for access control extraction.
+     */
+    policyAgentConfig?: PolicyAgentConfigClass;
     /**
      * Table name to fetch the query history.
      *
@@ -3738,7 +3741,10 @@ export interface ConfigConnection {
      * this.
      */
     ingestAllDatabases?: boolean;
-    policyAgentConfig?:  PolicyAgentConfig;
+    /**
+     * Policy agent configuration for access control extraction.
+     */
+    policyAgentConfig?: PolicyAgentConfig;
     /**
      * Fully qualified name of the view or table to use for query logs. If not provided,
      * defaults to pg_stat_statements. Use this to configure a custom view (e.g.,
@@ -4499,7 +4505,10 @@ export interface HiveMetastoreConnectionDetails {
      * this.
      */
     ingestAllDatabases?: boolean;
-    policyAgentConfig?:  PolicyAgentConfig;
+    /**
+     * Policy agent configuration for access control extraction.
+     */
+    policyAgentConfig?: PolicyAgentConfig;
     /**
      * Fully qualified name of the view or table to use for query logs. If not provided,
      * defaults to pg_stat_statements. Use this to configure a custom view (e.g.,
@@ -4764,6 +4773,28 @@ export interface BucketDetails {
      * Path of the folder where the .pbit files are stored
      */
     objectPrefix?: string;
+}
+
+/**
+ * Policy agent configuration for access control extraction.
+ */
+export interface PolicyAgentConfigClass {
+    /**
+     * Enable policy agent extraction.
+     */
+    enabled?: boolean;
+    /**
+     * Supports column-level access policy extraction.
+     */
+    supportsColumnAccess?: boolean;
+    /**
+     * Supports full access policy extraction.
+     */
+    supportsFullAccess?: boolean;
+    /**
+     * Supports masked access policy extraction.
+     */
+    supportsMaskedAccess?: boolean;
 }
 
 /**

--- a/openmetadata-ui/src/main/resources/ui/src/generated/metadataIngestion/workflow.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/metadataIngestion/workflow.ts
@@ -1435,7 +1435,7 @@ export interface ConfigObject {
     /**
      * Policy agent configuration for access control extraction.
      */
-    policyAgentConfig?: PolicyAgentConfigClass;
+    policyAgentConfig?: PolicyAgentConfig;
     /**
      * Table name to fetch the query history.
      *
@@ -4773,28 +4773,6 @@ export interface BucketDetails {
      * Path of the folder where the .pbit files are stored
      */
     objectPrefix?: string;
-}
-
-/**
- * Policy agent configuration for access control extraction.
- */
-export interface PolicyAgentConfigClass {
-    /**
-     * Enable policy agent extraction.
-     */
-    enabled?: boolean;
-    /**
-     * Supports column-level access policy extraction.
-     */
-    supportsColumnAccess?: boolean;
-    /**
-     * Supports full access policy extraction.
-     */
-    supportsFullAccess?: boolean;
-    /**
-     * Supports masked access policy extraction.
-     */
-    supportsMaskedAccess?: boolean;
 }
 
 /**


### PR DESCRIPTION
## Problem

Connector schemas (`snowflakeConnection.json`, `databricksConnection.json`,
`postgresConnection.json`) declared per-connector defaults for
`policyAgentConfig` like:

```json
"policyAgentConfig": {
  "$ref": "../connectionBasicType.json#/definitions/policyAgentConfig",
  "default": { "enabled": true, "supportsFullAccess": true, ... }
}
```
<p style="white-space: pre-wrap; margin-top: 0.1em; margin-bottom: 0.2em; color: rgb(204, 204, 204); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(24, 24, 24); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Per JSON Schema, <strong>sibling keywords next to <code style="font-family: monospace; color: rgb(208, 208, 208); background-color: rgb(60, 60, 60); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">$ref</code> are ignored</strong> — so the
<code style="font-family: monospace; color: rgb(208, 208, 208); background-color: rgb(60, 60, 60); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">default</code> block was dead. Generated POJOs (Java + Python Pydantic) used the
field defaults from the shared <code style="font-family: monospace; color: rgb(208, 208, 208); background-color: rgb(60, 60, 60); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">connectionBasicType.json#/definitions/policyAgentConfig</code>,
which are all <code style="font-family: monospace; color: rgb(208, 208, 208); background-color: rgb(60, 60, 60); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">false</code>. Result: every fresh Snowflake / Databricks / Postgres
service got persisted as:</p><div class="codeBlockWrapper_-a7MRw" style="position: relative; margin: 8px 0px; color: rgb(204, 204, 204); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(24, 24, 24); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><button class="copyButton_CEmTFw copyButton_-a7MRw" title="Copy code" aria-label="Copy code to clipboard" style="color: rgb(204, 204, 204); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; background: none 0% 0% / auto repeat scroll padding-box border-box rgb(31, 31, 31); border-color: rgba(204, 204, 204, 0.2); border-style: solid; border-width: 1px; border-image: none 100% / 1 / 0 stretch; cursor: pointer; opacity: 0; display: flex; border-radius: 4px; justify-content: center; align-items: center; padding: 4px; transition: opacity 0.15s, background 0.15s; position: absolute; top: 4px; right: 4px;"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true" data-slot="icon" class="copyIcon_CEmTFw"><path fill-rule="evenodd" d="M15.988 3.012A2.25 2.25 0 0 1 18 5.25v6.5A2.25 2.25 0 0 1 15.75 14H13.5v-3.379a3 3 0 0 0-.879-2.121l-3.12-3.121a3 3 0 0 0-1.402-.791 2.252 2.252 0 0 1 1.913-1.576A2.25 2.25 0 0 1 12.25 1h1.5a2.25 2.25 0 0 1 2.238 2.012ZM11.5 3.25a.75.75 0 0 1 .75-.75h1.5a.75.75 0 0 1 .75.75v.25h-3v-.25Z" clip-rule="evenodd"></path><path d="M3.5 6A1.5 1.5 0 0 0 2 7.5v9A1.5 1.5 0 0 0 3.5 18h7a1.5 1.5 0 0 0 1.5-1.5v-5.879a1.5 1.5 0 0 0-.44-1.06L8.44 6.439A1.5 1.5 0 0 0 7.378 6H3.5Z"></path></svg></button><pre style="overflow-x: auto; white-space: pre; box-sizing: border-box; border-radius: 4px; max-width: 100%; margin: 0px; padding: 8px;"><code class="language-json" style="font-family: monospace; color: rgb(208, 208, 208); background-color: rgb(60, 60, 60); padding: 0px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">"policyAgentConfig": {
  "enabled": false,
  "supportsColumnAccess": false,
  "supportsFullAccess": false,
  "supportsMaskedAccess": false
}
</code></pre></div><p style="white-space: pre-wrap; margin-top: 0.1em; margin-bottom: 0.2em; color: rgb(204, 204, 204); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(24, 24, 24); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Even though the connectors actually support the policy agent.</p><h2 style="color: rgb(204, 204, 204); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(24, 24, 24); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Fix</h2><h3 style="color: rgb(204, 204, 204); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(24, 24, 24); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Schema (codegen-time fix for new services)</h3><p style="white-space: pre-wrap; margin-top: 0.1em; margin-bottom: 0.2em; color: rgb(204, 204, 204); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(24, 24, 24); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Replace <code style="font-family: monospace; color: rgb(208, 208, 208); background-color: rgb(60, 60, 60); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">$ref</code> with <code style="font-family: monospace; color: rgb(208, 208, 208); background-color: rgb(60, 60, 60); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">allOf</code> + an inline <code style="font-family: monospace; color: rgb(208, 208, 208); background-color: rgb(60, 60, 60); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">properties</code> block per connector. The
<code style="font-family: monospace; color: rgb(208, 208, 208); background-color: rgb(60, 60, 60); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">allOf</code> composition keeps the shared shape (description, <code style="font-family: monospace; color: rgb(208, 208, 208); background-color: rgb(60, 60, 60); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">javaType</code>,
<code style="font-family: monospace; color: rgb(208, 208, 208); background-color: rgb(60, 60, 60); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">additionalProperties</code>), and the sibling <code style="font-family: monospace; color: rgb(208, 208, 208); background-color: rgb(60, 60, 60); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">properties</code> block is now honored —
the leaf-level <code style="font-family: monospace; color: rgb(208, 208, 208); background-color: rgb(60, 60, 60); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">default</code> values propagate into the generated POJO.</p><p style="white-space: pre-wrap; margin-top: 0.1em; margin-bottom: 0.2em; color: rgb(204, 204, 204); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(24, 24, 24); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Connector defaults declared:</p>
Connector | enabled | Column | Full | Masked
-- | -- | -- | -- | --
Snowflake | true | false | true | true
Databricks | true | false | true | true
Postgres | true | true | true | true

<h3 style="color: rgb(204, 204, 204); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(24, 24, 24); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Data migration (runtime fix for existing services)</h3><p style="white-space: pre-wrap; margin-top: 0.1em; margin-bottom: 0.2em; color: rgb(204, 204, 204); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(24, 24, 24); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Existing rows in <code style="font-family: monospace; color: rgb(208, 208, 208); background-color: rgb(60, 60, 60); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">dbservice_entity</code> were persisted with all-false flags and
won't pick up the new schema defaults — those only apply at deserialization
of payloads that omit the field. Adds <code style="font-family: monospace; color: rgb(208, 208, 208); background-color: rgb(60, 60, 60); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">postDataMigrationSQLScript.sql</code> blocks
under <code style="font-family: monospace; color: rgb(208, 208, 208); background-color: rgb(60, 60, 60); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">bootstrap/sql/migrations/native/2.0.1/{postgres,mysql}/</code> that:</p><ul style="padding-inline-start: 2em; color: rgb(204, 204, 204); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(24, 24, 24); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><li>Flip each leaf flag from<span> </span><code style="font-family: monospace; color: rgb(208, 208, 208); background-color: rgb(60, 60, 60); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">false</code><span> </span>→<span> </span><code style="font-family: monospace; color: rgb(208, 208, 208); background-color: rgb(60, 60, 60); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">true</code><span> </span>per connector (guarded so any operator-set<span> </span><code style="font-family: monospace; color: rgb(208, 208, 208); background-color: rgb(60, 60, 60); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">true</code><span> </span>is preserved — idempotent and safe to re-run).</li><li>Write the full object on legacy rows where<span> </span><code style="font-family: monospace; color: rgb(208, 208, 208); background-color: rgb(60, 60, 60); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">policyAgentConfig</code><span> </span>is absent entirely (<code style="font-family: monospace; color: rgb(208, 208, 208); background-color: rgb(60, 60, 60); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">jsonb_set(..., true)</code><span> </span>/<span> </span><code style="font-family: monospace; color: rgb(208, 208, 208); background-color: rgb(60, 60, 60); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">JSON_SET</code><span> </span>both create the missing path).</li><li>Scope every UPDATE by<span> </span><code style="font-family: monospace; color: rgb(208, 208, 208); background-color: rgb(60, 60, 60); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">serviceType</code><span> </span>so connectors are independent.</li></ul><h2 style="color: rgb(204, 204, 204); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(24, 24, 24); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Files</h2><ul style="padding-inline-start: 2em; color: rgb(204, 204, 204); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(24, 24, 24); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><li><code style="font-family: monospace; color: rgb(208, 208, 208); background-color: rgb(60, 60, 60); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">openmetadata-spec/.../snowflakeConnection.json</code></li><li><code style="font-family: monospace; color: rgb(208, 208, 208); background-color: rgb(60, 60, 60); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">openmetadata-spec/.../databricksConnection.json</code></li><li><code style="font-family: monospace; color: rgb(208, 208, 208); background-color: rgb(60, 60, 60); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">openmetadata-spec/.../postgresConnection.json</code></li><li><code style="font-family: monospace; color: rgb(208, 208, 208); background-color: rgb(60, 60, 60); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">bootstrap/sql/migrations/native/2.0.1/postgres/postDataMigrationSQLScript.sql</code></li><li><code style="font-family: monospace; color: rgb(208, 208, 208); background-color: rgb(60, 60, 60); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">bootstrap/sql/migrations/native/2.0.1/mysql/postDataMigrationSQLScript.sql</code></li></ul><br class="Apple-interchange-newline">

----
## Summary by Gitar

- **Codegen updates:**
  - Updated generated TypeScript models in `openmetadata-ui/src/main/resources/ui/src/generated/` to reflect the schema changes in `policyAgentConfig`.
  - Regenerated API and entity interfaces for services, workflows, and ingestion pipelines to include new schema definitions.


<sub>This will update automatically on new commits.</sub>