### PR TITLE
fix(search): cap oversize leaf values to prevent reindex failures

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/SearchIndexUtils.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/SearchIndexUtils.java
@@ -73,65 +73,54 @@ public final class SearchIndexUtils {
    */
   private static final int MAX_UTF8_BYTES_PER_CHAR = 3;
 
-  private static final String EXTENSION_FIELD = "extension";
-  private static final String CHILDREN_FIELD = "children";
-
-  /**
-   * Parent fields under which a recursive {@code children} sub-field is mapped as {@code flattened}
-   * / {@code flat_object} (e.g. {@code columns.children}, {@code schemaFields.children},
-   * {@code fields.children}). A {@code children} under any other parent — top-level {@code children}
-   * on glossaryTerm / knowledgePage / container — is a normal {@code object} with {@code text}
-   * leaves and must be left untouched. {@code extension} is {@code flattened} everywhere, so it is
-   * matched by name regardless of parent.
-   */
-  private static final Set<String> FLATTENED_CHILDREN_PARENTS =
-      Set.of("columns", "schemaFields", "fields");
-
   /**
    * Caps oversize string values inside the {@code flat_object} fields of a search document so a
-   * single leaf cannot exceed Lucene's per-term byte limit and reject the entire document. Only
-   * {@code flat_object} subtrees are trimmed (recursively) — {@code extension}, and {@code children}
-   * only when it sits under a {@link #FLATTENED_CHILDREN_PARENTS} field; {@code text}/{@code keyword}
-   * fields (including {@code object}-mapped {@code children}) are left as-is. Trimming is in place,
-   * on a character boundary; the full value is preserved on the source entity (database/API), so
-   * entity pages and APIs are unaffected.
+   * single leaf cannot exceed Lucene's per-term byte limit and reject the entire document. Only the
+   * subtrees whose dot-path is in {@code flattenedFieldPaths} are trimmed (recursively) — that set
+   * is derived from the index mappings ({@code "type": "flattened"}), so it covers exactly the
+   * fields at risk and stays in sync with the mappings. {@code text}/{@code keyword} fields
+   * (including {@code object}-mapped {@code children}) are left as-is. Trimming is in place, on a
+   * character boundary; the full value is preserved on the source entity (database/API), so entity
+   * pages and APIs are unaffected.
    *
    * <p>{@code entityContext} is resolved lazily and only when a value is actually trimmed, so the
    * common (no-trim) bulk-reindex path never builds the context string.
    */
-  public static void capOversizeValues(final Object node, final Supplier<String> entityContext) {
-    capOversizeValues(node, null, entityContext);
+  public static void capOversizeValues(
+      final Object node,
+      final Set<String> flattenedFieldPaths,
+      final Supplier<String> entityContext) {
+    if (flattenedFieldPaths.isEmpty()) {
+      return;
+    }
+    capOversizeValues(node, "", flattenedFieldPaths, entityContext);
   }
 
   private static void capOversizeValues(
-      final Object node, final String parentKey, final Supplier<String> entityContext) {
+      final Object node,
+      final String path,
+      final Set<String> flattenedFieldPaths,
+      final Supplier<String> entityContext) {
     if (node instanceof Map<?, ?> rawMap) {
       @SuppressWarnings("unchecked")
       Map<String, Object> map = (Map<String, Object>) rawMap;
       for (Map.Entry<String, Object> entry : map.entrySet()) {
-        String key = entry.getKey();
-        if (isFlattenedField(key, parentKey)) {
+        String childPath = path.isEmpty() ? entry.getKey() : path + "." + entry.getKey();
+        if (flattenedFieldPaths.contains(childPath)) {
           trimAllStrings(
               entry.getValue(),
-              new StringBuilder(key),
-              key.getBytes(StandardCharsets.UTF_8).length,
+              new StringBuilder(childPath),
+              childPath.getBytes(StandardCharsets.UTF_8).length,
               entityContext);
         } else {
-          capOversizeValues(entry.getValue(), key, entityContext);
+          capOversizeValues(entry.getValue(), childPath, flattenedFieldPaths, entityContext);
         }
       }
     } else if (node instanceof List<?> rawList) {
       for (Object item : rawList) {
-        capOversizeValues(item, parentKey, entityContext);
+        capOversizeValues(item, path, flattenedFieldPaths, entityContext);
       }
     }
-  }
-
-  private static boolean isFlattenedField(final String key, final String parentKey) {
-    return EXTENSION_FIELD.equals(key)
-        || (CHILDREN_FIELD.equals(key)
-            && parentKey != null
-            && FLATTENED_CHILDREN_PARENTS.contains(parentKey));
   }
 
   private static void trimAllStrings(

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/SearchIndexUtils.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/SearchIndexUtils.java
@@ -62,43 +62,63 @@ public final class SearchIndexUtils {
   private static final int MAX_INDEXED_VALUE_BYTES = 32000;
 
   /**
-   * Caps oversize string values in a search document so a single leaf cannot exceed Lucene's
-   * per-term byte limit and reject the entire document. Walks the document in place and trims any
-   * string whose UTF-8 length exceeds {@link #MAX_INDEXED_VALUE_BYTES}, on a character boundary.
-   * The full value is preserved on the source entity (database/API); only the indexed copy is
-   * trimmed, so entity pages and APIs are unaffected.
+   * Fields mapped as {@code flattened} (ES) / {@code flat_object} (OpenSearch). Their leaves are
+   * indexed as single un-tokenized keyword terms with no length cap, so they are the only fields
+   * that can trip Lucene's per-term limit. {@code text} and capped {@code keyword} fields are safe
+   * and are intentionally left untouched.
+   */
+  private static final Set<String> FLAT_OBJECT_FIELDS = Set.of("children", "extension");
+
+  /**
+   * Caps oversize string values inside the {@code flat_object} fields of a search document so a
+   * single leaf cannot exceed Lucene's per-term byte limit and reject the entire document. Only the
+   * {@link #FLAT_OBJECT_FIELDS} subtrees are trimmed (recursively); {@code text}/{@code keyword}
+   * fields elsewhere are left as-is. Trimming is in place, on a character boundary; the full value
+   * is preserved on the source entity (database/API), so entity pages and APIs are unaffected.
    */
   public static void capOversizeValues(final Object node, final String entityContext) {
     if (node instanceof Map<?, ?> rawMap) {
-      capMapValues(rawMap, entityContext);
+      @SuppressWarnings("unchecked")
+      Map<String, Object> map = (Map<String, Object>) rawMap;
+      for (Map.Entry<String, Object> entry : map.entrySet()) {
+        if (FLAT_OBJECT_FIELDS.contains(entry.getKey())) {
+          trimAllStrings(entry.getValue(), entry.getKey(), entityContext);
+        } else {
+          capOversizeValues(entry.getValue(), entityContext);
+        }
+      }
     } else if (node instanceof List<?> rawList) {
-      capListValues(rawList, entityContext);
+      for (Object item : rawList) {
+        capOversizeValues(item, entityContext);
+      }
     }
   }
 
-  private static void capMapValues(final Map<?, ?> rawMap, final String entityContext) {
-    @SuppressWarnings("unchecked")
-    Map<String, Object> map = (Map<String, Object>) rawMap;
-    for (Map.Entry<String, Object> entry : map.entrySet()) {
-      Object value = entry.getValue();
-      Object trimmed = trimIfOversized(value, entry.getKey(), entityContext);
-      if (trimmed != value) {
-        entry.setValue(trimmed);
+  private static void trimAllStrings(
+      final Object node, final String fieldPath, final String entityContext) {
+    if (node instanceof Map<?, ?> rawMap) {
+      @SuppressWarnings("unchecked")
+      Map<String, Object> map = (Map<String, Object>) rawMap;
+      for (Map.Entry<String, Object> entry : map.entrySet()) {
+        Object value = entry.getValue();
+        String childPath = fieldPath + "." + entry.getKey();
+        Object trimmed = trimIfOversized(value, childPath, entityContext);
+        if (trimmed != value) {
+          entry.setValue(trimmed);
+        }
+        trimAllStrings(value, childPath, entityContext);
       }
-      capOversizeValues(value, entityContext);
-    }
-  }
-
-  private static void capListValues(final List<?> rawList, final String entityContext) {
-    @SuppressWarnings("unchecked")
-    List<Object> list = (List<Object>) rawList;
-    for (int index = 0; index < list.size(); index++) {
-      Object value = list.get(index);
-      Object trimmed = trimIfOversized(value, "[" + index + "]", entityContext);
-      if (trimmed != value) {
-        list.set(index, trimmed);
+    } else if (node instanceof List<?> rawList) {
+      @SuppressWarnings("unchecked")
+      List<Object> list = (List<Object>) rawList;
+      for (int index = 0; index < list.size(); index++) {
+        Object value = list.get(index);
+        Object trimmed = trimIfOversized(value, fieldPath, entityContext);
+        if (trimmed != value) {
+          list.set(index, trimmed);
+        }
+        trimAllStrings(value, fieldPath, entityContext);
       }
-      capOversizeValues(value, entityContext);
     }
   }
 

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/SearchIndexUtils.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/SearchIndexUtils.java
@@ -70,15 +70,35 @@ public final class SearchIndexUtils {
    */
   public static void capOversizeValues(final Object node) {
     if (node instanceof Map<?, ?> rawMap) {
-      @SuppressWarnings("unchecked")
-      Map<String, Object> map = (Map<String, Object>) rawMap;
-      map.replaceAll((key, value) -> trimIfOversized(value));
-      map.values().forEach(SearchIndexUtils::capOversizeValues);
+      capMapValues(rawMap);
     } else if (node instanceof List<?> rawList) {
-      @SuppressWarnings("unchecked")
-      List<Object> list = (List<Object>) rawList;
-      list.replaceAll(SearchIndexUtils::trimIfOversized);
-      list.forEach(SearchIndexUtils::capOversizeValues);
+      capListValues(rawList);
+    }
+  }
+
+  private static void capMapValues(final Map<?, ?> rawMap) {
+    @SuppressWarnings("unchecked")
+    Map<String, Object> map = (Map<String, Object>) rawMap;
+    for (Map.Entry<String, Object> entry : map.entrySet()) {
+      Object value = entry.getValue();
+      Object trimmed = trimIfOversized(value);
+      if (trimmed != value) {
+        entry.setValue(trimmed);
+      }
+      capOversizeValues(value);
+    }
+  }
+
+  private static void capListValues(final List<?> rawList) {
+    @SuppressWarnings("unchecked")
+    List<Object> list = (List<Object>) rawList;
+    for (int index = 0; index < list.size(); index++) {
+      Object value = list.get(index);
+      Object trimmed = trimIfOversized(value);
+      if (trimmed != value) {
+        list.set(index, trimmed);
+      }
+      capOversizeValues(value);
     }
   }
 

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/SearchIndexUtils.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/SearchIndexUtils.java
@@ -90,10 +90,20 @@ public final class SearchIndexUtils {
       final Object node,
       final Set<String> flattenedFieldPaths,
       final Supplier<String> entityContext) {
-    if (flattenedFieldPaths.isEmpty()) {
+    if (flattenedFieldPaths == null || flattenedFieldPaths.isEmpty()) {
       return;
     }
-    capOversizeValues(node, "", flattenedFieldPaths, entityContext);
+    try {
+      capOversizeValues(node, "", flattenedFieldPaths, entityContext);
+    } catch (RuntimeException e) {
+      // Best-effort safety net: a defect here must never drop an otherwise-valid document from
+      // search. Log and continue — if the document still holds an oversized leaf the engine will
+      // reject it as before, but capping must never itself be the cause of an indexing failure.
+      LOG.warn(
+          "Skipped oversize-value capping for [{}] due to: {}",
+          entityContext == null ? "unknown" : entityContext.get(),
+          e.toString());
+    }
   }
 
   private static void capOversizeValues(

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/SearchIndexUtils.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/SearchIndexUtils.java
@@ -106,22 +106,21 @@ public final class SearchIndexUtils {
       final Object value, final String fieldName, final String entityContext) {
     Object result = value;
     if (value instanceof String text) {
-      int byteLength = text.getBytes(StandardCharsets.UTF_8).length;
-      if (byteLength > MAX_INDEXED_VALUE_BYTES) {
-        result = trimToByteLimit(text);
+      byte[] bytes = text.getBytes(StandardCharsets.UTF_8);
+      if (bytes.length > MAX_INDEXED_VALUE_BYTES) {
+        result = trimToByteLimit(bytes);
         LOG.warn(
             "Trimmed oversize search value [entity={}, field={}] from {} to {} bytes to stay under the index term limit",
             entityContext,
             fieldName,
-            byteLength,
+            bytes.length,
             MAX_INDEXED_VALUE_BYTES);
       }
     }
     return result;
   }
 
-  private static String trimToByteLimit(final String value) {
-    final byte[] bytes = value.getBytes(StandardCharsets.UTF_8);
+  private static String trimToByteLimit(final byte[] bytes) {
     final CharsetDecoder decoder =
         StandardCharsets.UTF_8
             .newDecoder()

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/SearchIndexUtils.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/SearchIndexUtils.java
@@ -68,49 +68,54 @@ public final class SearchIndexUtils {
    * The full value is preserved on the source entity (database/API); only the indexed copy is
    * trimmed, so entity pages and APIs are unaffected.
    */
-  public static void capOversizeValues(final Object node) {
+  public static void capOversizeValues(final Object node, final String entityContext) {
     if (node instanceof Map<?, ?> rawMap) {
-      capMapValues(rawMap);
+      capMapValues(rawMap, entityContext);
     } else if (node instanceof List<?> rawList) {
-      capListValues(rawList);
+      capListValues(rawList, entityContext);
     }
   }
 
-  private static void capMapValues(final Map<?, ?> rawMap) {
+  private static void capMapValues(final Map<?, ?> rawMap, final String entityContext) {
     @SuppressWarnings("unchecked")
     Map<String, Object> map = (Map<String, Object>) rawMap;
     for (Map.Entry<String, Object> entry : map.entrySet()) {
       Object value = entry.getValue();
-      Object trimmed = trimIfOversized(value);
+      Object trimmed = trimIfOversized(value, entry.getKey(), entityContext);
       if (trimmed != value) {
         entry.setValue(trimmed);
       }
-      capOversizeValues(value);
+      capOversizeValues(value, entityContext);
     }
   }
 
-  private static void capListValues(final List<?> rawList) {
+  private static void capListValues(final List<?> rawList, final String entityContext) {
     @SuppressWarnings("unchecked")
     List<Object> list = (List<Object>) rawList;
     for (int index = 0; index < list.size(); index++) {
       Object value = list.get(index);
-      Object trimmed = trimIfOversized(value);
+      Object trimmed = trimIfOversized(value, "[" + index + "]", entityContext);
       if (trimmed != value) {
         list.set(index, trimmed);
       }
-      capOversizeValues(value);
+      capOversizeValues(value, entityContext);
     }
   }
 
-  private static Object trimIfOversized(final Object value) {
+  private static Object trimIfOversized(
+      final Object value, final String fieldName, final String entityContext) {
     Object result = value;
-    if (value instanceof String text
-        && text.getBytes(StandardCharsets.UTF_8).length > MAX_INDEXED_VALUE_BYTES) {
-      result = trimToByteLimit(text);
-      LOG.warn(
-          "Trimmed an oversize search value from {} to {} bytes to stay under the index term limit",
-          text.getBytes(StandardCharsets.UTF_8).length,
-          MAX_INDEXED_VALUE_BYTES);
+    if (value instanceof String text) {
+      int byteLength = text.getBytes(StandardCharsets.UTF_8).length;
+      if (byteLength > MAX_INDEXED_VALUE_BYTES) {
+        result = trimToByteLimit(text);
+        LOG.warn(
+            "Trimmed oversize search value [entity={}, field={}] from {} to {} bytes to stay under the index term limit",
+            entityContext,
+            fieldName,
+            byteLength,
+            MAX_INDEXED_VALUE_BYTES);
+      }
     }
     return result;
   }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/SearchIndexUtils.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/SearchIndexUtils.java
@@ -9,6 +9,10 @@ import jakarta.json.JsonNumber;
 import jakarta.json.JsonObject;
 import jakarta.json.JsonString;
 import jakarta.json.JsonValue;
+import java.nio.ByteBuffer;
+import java.nio.charset.CharacterCodingException;
+import java.nio.charset.CharsetDecoder;
+import java.nio.charset.CodingErrorAction;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -47,6 +51,65 @@ public final class SearchIndexUtils {
       List.of("collateaiapplicationbot", "collateaiqualityagentapplicationbot");
 
   private SearchIndexUtils() {}
+
+  /**
+   * Lucene rejects any indexed term whose UTF-8 encoding exceeds 32766 bytes. Values inside a
+   * {@code flattened} / {@code flat_object} field (e.g. the recursive {@code columns.children}
+   * subtree) are indexed as single un-tokenized keyword terms, so one oversized leaf — such as a
+   * long PowerBI DAX expression stored in a column description — fails the whole document with an
+   * "immense term" error. Kept under the limit with margin for the {@code _valueAndPath} subfield.
+   */
+  private static final int MAX_INDEXED_VALUE_BYTES = 32000;
+
+  /**
+   * Caps oversize string values in a search document so a single leaf cannot exceed Lucene's
+   * per-term byte limit and reject the entire document. Walks the document in place and trims any
+   * string whose UTF-8 length exceeds {@link #MAX_INDEXED_VALUE_BYTES}, on a character boundary.
+   * The full value is preserved on the source entity (database/API); only the indexed copy is
+   * trimmed, so entity pages and APIs are unaffected.
+   */
+  public static void capOversizeValues(final Object node) {
+    if (node instanceof Map<?, ?> rawMap) {
+      @SuppressWarnings("unchecked")
+      Map<String, Object> map = (Map<String, Object>) rawMap;
+      map.replaceAll((key, value) -> trimIfOversized(value));
+      map.values().forEach(SearchIndexUtils::capOversizeValues);
+    } else if (node instanceof List<?> rawList) {
+      @SuppressWarnings("unchecked")
+      List<Object> list = (List<Object>) rawList;
+      list.replaceAll(SearchIndexUtils::trimIfOversized);
+      list.forEach(SearchIndexUtils::capOversizeValues);
+    }
+  }
+
+  private static Object trimIfOversized(final Object value) {
+    Object result = value;
+    if (value instanceof String text
+        && text.getBytes(StandardCharsets.UTF_8).length > MAX_INDEXED_VALUE_BYTES) {
+      result = trimToByteLimit(text);
+      LOG.warn(
+          "Trimmed an oversize search value from {} to {} bytes to stay under the index term limit",
+          text.getBytes(StandardCharsets.UTF_8).length,
+          MAX_INDEXED_VALUE_BYTES);
+    }
+    return result;
+  }
+
+  private static String trimToByteLimit(final String value) {
+    final byte[] bytes = value.getBytes(StandardCharsets.UTF_8);
+    final CharsetDecoder decoder =
+        StandardCharsets.UTF_8
+            .newDecoder()
+            .onMalformedInput(CodingErrorAction.IGNORE)
+            .onUnmappableCharacter(CodingErrorAction.IGNORE);
+    String trimmed;
+    try {
+      trimmed = decoder.decode(ByteBuffer.wrap(bytes, 0, MAX_INDEXED_VALUE_BYTES)).toString();
+    } catch (CharacterCodingException e) {
+      trimmed = new String(bytes, 0, MAX_INDEXED_VALUE_BYTES, StandardCharsets.UTF_8);
+    }
+    return trimmed;
+  }
 
   /**
    * Deduplicates identical SQL queries across lineage edges in-place.

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/SearchIndexUtils.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/SearchIndexUtils.java
@@ -57,9 +57,17 @@ public final class SearchIndexUtils {
    * {@code flattened} / {@code flat_object} field (e.g. the recursive {@code columns.children}
    * subtree) are indexed as single un-tokenized keyword terms, so one oversized leaf — such as a
    * long PowerBI DAX expression stored in a column description — fails the whole document with an
-   * "immense term" error. Kept under the limit with margin for the {@code _valueAndPath} subfield.
+   * "immense term" error.
    */
-  private static final int MAX_INDEXED_VALUE_BYTES = 32000;
+  private static final int LUCENE_MAX_TERM_BYTES = 32766;
+
+  /**
+   * Headroom reserved below the Lucene limit. A {@code flat_object} also indexes a
+   * {@code _valueAndPath} term (the leaf path prefixed to the value), so the value budget is the
+   * limit minus this margin minus the path length; the margin covers delimiters and engine
+   * overhead beyond the path we compute.
+   */
+  private static final int TERM_SAFETY_MARGIN_BYTES = 512;
 
   /**
    * Fields mapped as {@code flattened} (ES) / {@code flat_object} (OpenSearch). Their leaves are
@@ -123,24 +131,35 @@ public final class SearchIndexUtils {
   }
 
   private static Object trimIfOversized(
-      final Object value, final String fieldName, final String entityContext) {
+      final Object value, final String fieldPath, final String entityContext) {
     Object result = value;
     if (value instanceof String text) {
       byte[] bytes = text.getBytes(StandardCharsets.UTF_8);
-      if (bytes.length > MAX_INDEXED_VALUE_BYTES) {
-        result = trimToByteLimit(bytes);
+      int budget = valueByteBudget(fieldPath);
+      if (bytes.length > budget) {
+        result = trimToByteLimit(bytes, budget);
         LOG.warn(
             "Trimmed oversize search value [entity={}, field={}] from {} to {} bytes to stay under the index term limit",
             entityContext,
-            fieldName,
+            fieldPath,
             bytes.length,
-            MAX_INDEXED_VALUE_BYTES);
+            budget);
       }
     }
     return result;
   }
 
-  private static String trimToByteLimit(final byte[] bytes) {
+  /**
+   * Budget for a single value so that both the {@code _value} term and the path-prefixed
+   * {@code _valueAndPath} term stay under {@link #LUCENE_MAX_TERM_BYTES}, accounting for the leaf
+   * path which grows with nesting depth.
+   */
+  private static int valueByteBudget(final String fieldPath) {
+    int pathBytes = fieldPath == null ? 0 : fieldPath.getBytes(StandardCharsets.UTF_8).length;
+    return Math.max(0, LUCENE_MAX_TERM_BYTES - TERM_SAFETY_MARGIN_BYTES - pathBytes);
+  }
+
+  private static String trimToByteLimit(final byte[] bytes, final int limit) {
     final CharsetDecoder decoder =
         StandardCharsets.UTF_8
             .newDecoder()
@@ -148,9 +167,9 @@ public final class SearchIndexUtils {
             .onUnmappableCharacter(CodingErrorAction.IGNORE);
     String trimmed;
     try {
-      trimmed = decoder.decode(ByteBuffer.wrap(bytes, 0, MAX_INDEXED_VALUE_BYTES)).toString();
+      trimmed = decoder.decode(ByteBuffer.wrap(bytes, 0, limit)).toString();
     } catch (CharacterCodingException e) {
-      trimmed = new String(bytes, 0, MAX_INDEXED_VALUE_BYTES, StandardCharsets.UTF_8);
+      trimmed = new String(bytes, 0, limit, StandardCharsets.UTF_8);
     }
     return trimmed;
   }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/SearchIndexUtils.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/SearchIndexUtils.java
@@ -9,10 +9,6 @@ import jakarta.json.JsonNumber;
 import jakarta.json.JsonObject;
 import jakarta.json.JsonString;
 import jakarta.json.JsonValue;
-import java.nio.ByteBuffer;
-import java.nio.charset.CharacterCodingException;
-import java.nio.charset.CharsetDecoder;
-import java.nio.charset.CodingErrorAction;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -23,6 +19,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
@@ -70,81 +67,159 @@ public final class SearchIndexUtils {
   private static final int TERM_SAFETY_MARGIN_BYTES = 512;
 
   /**
-   * Fields mapped as {@code flattened} (ES) / {@code flat_object} (OpenSearch). Their leaves are
-   * indexed as single un-tokenized keyword terms with no length cap, so they are the only fields
-   * that can trip Lucene's per-term limit. {@code text} and capped {@code keyword} fields are safe
-   * and are intentionally left untouched.
+   * A Java {@code char} encodes to at most 3 UTF-8 bytes (supplementary code points use a surrogate
+   * pair — 2 chars — for 4 bytes, i.e. 2 bytes/char), so {@code length() * 3} is a safe upper bound
+   * on a string's UTF-8 size. Used as an allocation-free pre-check before encoding a value.
    */
-  private static final Set<String> FLAT_OBJECT_FIELDS = Set.of("children", "extension");
+  private static final int MAX_UTF8_BYTES_PER_CHAR = 3;
+
+  private static final String EXTENSION_FIELD = "extension";
+  private static final String CHILDREN_FIELD = "children";
+
+  /**
+   * Parent fields under which a recursive {@code children} sub-field is mapped as {@code flattened}
+   * / {@code flat_object} (e.g. {@code columns.children}, {@code schemaFields.children},
+   * {@code fields.children}). A {@code children} under any other parent — top-level {@code children}
+   * on glossaryTerm / knowledgePage / container — is a normal {@code object} with {@code text}
+   * leaves and must be left untouched. {@code extension} is {@code flattened} everywhere, so it is
+   * matched by name regardless of parent.
+   */
+  private static final Set<String> FLATTENED_CHILDREN_PARENTS =
+      Set.of("columns", "schemaFields", "fields");
 
   /**
    * Caps oversize string values inside the {@code flat_object} fields of a search document so a
-   * single leaf cannot exceed Lucene's per-term byte limit and reject the entire document. Only the
-   * {@link #FLAT_OBJECT_FIELDS} subtrees are trimmed (recursively); {@code text}/{@code keyword}
-   * fields elsewhere are left as-is. Trimming is in place, on a character boundary; the full value
-   * is preserved on the source entity (database/API), so entity pages and APIs are unaffected.
+   * single leaf cannot exceed Lucene's per-term byte limit and reject the entire document. Only
+   * {@code flat_object} subtrees are trimmed (recursively) — {@code extension}, and {@code children}
+   * only when it sits under a {@link #FLATTENED_CHILDREN_PARENTS} field; {@code text}/{@code keyword}
+   * fields (including {@code object}-mapped {@code children}) are left as-is. Trimming is in place,
+   * on a character boundary; the full value is preserved on the source entity (database/API), so
+   * entity pages and APIs are unaffected.
+   *
+   * <p>{@code entityContext} is resolved lazily and only when a value is actually trimmed, so the
+   * common (no-trim) bulk-reindex path never builds the context string.
    */
-  public static void capOversizeValues(final Object node, final String entityContext) {
+  public static void capOversizeValues(final Object node, final Supplier<String> entityContext) {
+    capOversizeValues(node, null, entityContext);
+  }
+
+  private static void capOversizeValues(
+      final Object node, final String parentKey, final Supplier<String> entityContext) {
     if (node instanceof Map<?, ?> rawMap) {
       @SuppressWarnings("unchecked")
       Map<String, Object> map = (Map<String, Object>) rawMap;
       for (Map.Entry<String, Object> entry : map.entrySet()) {
-        if (FLAT_OBJECT_FIELDS.contains(entry.getKey())) {
-          trimAllStrings(entry.getValue(), entry.getKey(), entityContext);
+        String key = entry.getKey();
+        if (isFlattenedField(key, parentKey)) {
+          trimAllStrings(
+              entry.getValue(),
+              new StringBuilder(key),
+              key.getBytes(StandardCharsets.UTF_8).length,
+              entityContext);
         } else {
-          capOversizeValues(entry.getValue(), entityContext);
+          capOversizeValues(entry.getValue(), key, entityContext);
         }
       }
     } else if (node instanceof List<?> rawList) {
       for (Object item : rawList) {
-        capOversizeValues(item, entityContext);
+        capOversizeValues(item, parentKey, entityContext);
       }
     }
+  }
+
+  private static boolean isFlattenedField(final String key, final String parentKey) {
+    return EXTENSION_FIELD.equals(key)
+        || (CHILDREN_FIELD.equals(key)
+            && parentKey != null
+            && FLATTENED_CHILDREN_PARENTS.contains(parentKey));
   }
 
   private static void trimAllStrings(
-      final Object node, final String fieldPath, final String entityContext) {
+      final Object node,
+      final StringBuilder path,
+      final int pathBytes,
+      final Supplier<String> entityContext) {
     if (node instanceof Map<?, ?> rawMap) {
-      @SuppressWarnings("unchecked")
-      Map<String, Object> map = (Map<String, Object>) rawMap;
-      for (Map.Entry<String, Object> entry : map.entrySet()) {
-        Object value = entry.getValue();
-        String childPath = fieldPath + "." + entry.getKey();
-        Object trimmed = trimIfOversized(value, childPath, entityContext);
-        if (trimmed != value) {
-          entry.setValue(trimmed);
-        }
-        trimAllStrings(value, childPath, entityContext);
-      }
+      trimMapStrings(rawMap, path, pathBytes, entityContext);
     } else if (node instanceof List<?> rawList) {
-      @SuppressWarnings("unchecked")
-      List<Object> list = (List<Object>) rawList;
-      for (int index = 0; index < list.size(); index++) {
-        Object value = list.get(index);
-        Object trimmed = trimIfOversized(value, fieldPath, entityContext);
-        if (trimmed != value) {
-          list.set(index, trimmed);
-        }
-        trimAllStrings(value, fieldPath, entityContext);
-      }
+      trimListStrings(rawList, path, pathBytes, entityContext);
     }
   }
 
+  private static void trimMapStrings(
+      final Map<?, ?> rawMap,
+      final StringBuilder path,
+      final int pathBytes,
+      final Supplier<String> entityContext) {
+    @SuppressWarnings("unchecked")
+    Map<String, Object> map = (Map<String, Object>) rawMap;
+    for (Map.Entry<String, Object> entry : map.entrySet()) {
+      String key = entry.getKey();
+      int mark = path.length();
+      path.append('.').append(key);
+      int childBytes = pathBytes + 1 + key.getBytes(StandardCharsets.UTF_8).length;
+      Object value = entry.getValue();
+      Object trimmed = trimIfOversized(value, path, childBytes, entityContext);
+      if (trimmed != value) {
+        entry.setValue(trimmed);
+      }
+      trimAllStrings(value, path, childBytes, entityContext);
+      path.setLength(mark);
+    }
+  }
+
+  private static void trimListStrings(
+      final List<?> rawList,
+      final StringBuilder path,
+      final int pathBytes,
+      final Supplier<String> entityContext) {
+    @SuppressWarnings("unchecked")
+    List<Object> list = (List<Object>) rawList;
+    for (int index = 0; index < list.size(); index++) {
+      Object value = list.get(index);
+      Object trimmed = trimIfOversized(value, path, pathBytes, entityContext);
+      if (trimmed != value) {
+        list.set(index, trimmed);
+      }
+      trimAllStrings(value, path, pathBytes, entityContext);
+    }
+  }
+
+  /**
+   * Pre-checks by char count before encoding: a {@code String} is at most {@code 3} UTF-8 bytes per
+   * char, so a value short enough by {@code length()} cannot exceed the budget and is skipped
+   * without allocating a {@code byte[]}. Only candidates that might be oversize are encoded.
+   */
   private static Object trimIfOversized(
-      final Object value, final String fieldPath, final String entityContext) {
+      final Object value,
+      final CharSequence fieldPath,
+      final int pathBytes,
+      final Supplier<String> entityContext) {
     Object result = value;
     if (value instanceof String text) {
-      byte[] bytes = text.getBytes(StandardCharsets.UTF_8);
-      int budget = valueByteBudget(fieldPath);
-      if (bytes.length > budget) {
-        result = trimToByteLimit(bytes, budget);
-        LOG.warn(
-            "Trimmed oversize search value [entity={}, field={}] from {} to {} bytes to stay under the index term limit",
-            entityContext,
-            fieldPath,
-            bytes.length,
-            budget);
+      int budget = valueByteBudget(pathBytes);
+      if ((long) text.length() * MAX_UTF8_BYTES_PER_CHAR > budget) {
+        result = encodeAndTrim(text, budget, fieldPath, entityContext);
       }
+    }
+    return result;
+  }
+
+  private static Object encodeAndTrim(
+      final String text,
+      final int budget,
+      final CharSequence fieldPath,
+      final Supplier<String> entityContext) {
+    byte[] bytes = text.getBytes(StandardCharsets.UTF_8);
+    Object result = text;
+    if (bytes.length > budget) {
+      result = trimToByteLimit(bytes, budget);
+      LOG.warn(
+          "Trimmed oversize search value [entity={}, field={}] from {} to {} bytes to stay under the index term limit",
+          entityContext.get(),
+          fieldPath.toString(),
+          bytes.length,
+          budget);
     }
     return result;
   }
@@ -152,26 +227,23 @@ public final class SearchIndexUtils {
   /**
    * Budget for a single value so that both the {@code _value} term and the path-prefixed
    * {@code _valueAndPath} term stay under {@link #LUCENE_MAX_TERM_BYTES}, accounting for the leaf
-   * path which grows with nesting depth.
+   * path (UTF-8 bytes) which grows with nesting depth.
    */
-  private static int valueByteBudget(final String fieldPath) {
-    int pathBytes = fieldPath == null ? 0 : fieldPath.getBytes(StandardCharsets.UTF_8).length;
+  private static int valueByteBudget(final int pathBytes) {
     return Math.max(0, LUCENE_MAX_TERM_BYTES - TERM_SAFETY_MARGIN_BYTES - pathBytes);
   }
 
+  /**
+   * Truncates UTF-8 {@code bytes} to at most {@code limit} bytes, backing off any trailing
+   * continuation byte ({@code 10xxxxxx}) so a multi-byte character is never split. The source string
+   * is always valid UTF-8, so the retained prefix re-decodes without loss or replacement characters.
+   */
   private static String trimToByteLimit(final byte[] bytes, final int limit) {
-    final CharsetDecoder decoder =
-        StandardCharsets.UTF_8
-            .newDecoder()
-            .onMalformedInput(CodingErrorAction.IGNORE)
-            .onUnmappableCharacter(CodingErrorAction.IGNORE);
-    String trimmed;
-    try {
-      trimmed = decoder.decode(ByteBuffer.wrap(bytes, 0, limit)).toString();
-    } catch (CharacterCodingException e) {
-      trimmed = new String(bytes, 0, limit, StandardCharsets.UTF_8);
+    int cut = Math.min(limit, bytes.length);
+    while (cut > 0 && cut < bytes.length && (bytes[cut] & 0xC0) == 0x80) {
+      cut--;
     }
-    return trimmed;
+    return new String(bytes, 0, cut, StandardCharsets.UTF_8);
   }
 
   /**

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/SearchRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/SearchRepository.java
@@ -158,6 +158,9 @@ public class SearchRepository {
 
   @Getter private Map<String, IndexMapping> entityIndexMap;
 
+  /** Dot-paths of {@code flattened}/{@code flat_object} fields, derived from the loaded mappings. */
+  @Getter private Set<String> flattenedFieldPaths = Set.of();
+
   /**
    * Staged index names being populated by an in-flight reindex, keyed by the canonical index name
    * the alias normally points at (e.g. {@code openmetadata_table_search_index}). While an entry
@@ -279,6 +282,7 @@ public class SearchRepository {
   private void loadIndexMappings() {
     IndexMappingLoader mappingLoader = IndexMappingLoader.getInstance();
     entityIndexMap = mappingLoader.getIndexMapping();
+    flattenedFieldPaths = mappingLoader.getFlattenedFieldPaths();
   }
 
   public SearchClient buildSearchClient(ElasticSearchConfiguration config) {

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/indexes/APIEndpointIndex.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/indexes/APIEndpointIndex.java
@@ -86,12 +86,9 @@ public class APIEndpointIndex implements DataAssetIndex {
 
     mergeChildTags(doc, childTags);
 
-    doc.put(
-        "requestSchema",
-        apiEndpoint.getRequestSchema() != null ? apiEndpoint.getRequestSchema() : null);
-    doc.put(
-        "responseSchema",
-        apiEndpoint.getResponseSchema() != null ? apiEndpoint.getResponseSchema() : null);
+    // request/responseSchema are already present as nested Maps via JsonUtils.getMap(entity). Do
+    // NOT re-put them as raw POJOs: that would stop the oversize-value cap (which walks Map/List)
+    // from descending into the flattened *.schemaFields.children.
     return doc;
   }
 

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/indexes/SearchIndex.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/indexes/SearchIndex.java
@@ -128,7 +128,8 @@ public interface SearchIndex {
                     "type=%s id=%s fqn=%s",
                     getEntityTypeName(), ei.getId(), ei.getFullyQualifiedName())
             : this::getEntityTypeName;
-    SearchIndexUtils.capOversizeValues(esDoc, entityContext);
+    SearchIndexUtils.capOversizeValues(
+        esDoc, Entity.getSearchRepository().getFlattenedFieldPaths(), entityContext);
 
     return esDoc;
   }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/indexes/SearchIndex.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/indexes/SearchIndex.java
@@ -119,6 +119,9 @@ public interface SearchIndex {
     // Phase 5: Cleanup
     removeNonIndexableFields(esDoc);
 
+    // Phase 6: cap oversize values so a single leaf cannot exceed Lucene's per-term limit
+    SearchIndexUtils.capOversizeValues(esDoc);
+
     return esDoc;
   }
 

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/indexes/SearchIndex.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/indexes/SearchIndex.java
@@ -24,6 +24,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import org.openmetadata.schema.EntityInterface;
 import org.openmetadata.schema.api.lineage.EsLineageData;
@@ -120,11 +121,13 @@ public interface SearchIndex {
     removeNonIndexableFields(esDoc);
 
     // Phase 6: cap oversize values so a single leaf cannot exceed Lucene's per-term limit
-    String entityContext =
+    Supplier<String> entityContext =
         entity instanceof EntityInterface ei
-            ? String.format(
-                "type=%s id=%s fqn=%s", getEntityTypeName(), ei.getId(), ei.getFullyQualifiedName())
-            : getEntityTypeName();
+            ? () ->
+                String.format(
+                    "type=%s id=%s fqn=%s",
+                    getEntityTypeName(), ei.getId(), ei.getFullyQualifiedName())
+            : this::getEntityTypeName;
     SearchIndexUtils.capOversizeValues(esDoc, entityContext);
 
     return esDoc;

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/indexes/SearchIndex.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/indexes/SearchIndex.java
@@ -120,7 +120,12 @@ public interface SearchIndex {
     removeNonIndexableFields(esDoc);
 
     // Phase 6: cap oversize values so a single leaf cannot exceed Lucene's per-term limit
-    SearchIndexUtils.capOversizeValues(esDoc);
+    String entityContext =
+        entity instanceof EntityInterface ei
+            ? String.format(
+                "type=%s id=%s fqn=%s", getEntityTypeName(), ei.getId(), ei.getFullyQualifiedName())
+            : getEntityTypeName();
+    SearchIndexUtils.capOversizeValues(esDoc, entityContext);
 
     return esDoc;
   }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/indexes/TopicIndex.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/indexes/TopicIndex.java
@@ -73,7 +73,9 @@ public class TopicIndex implements DataAssetIndex {
       mergeChildTags(doc, childTags);
     }
 
-    doc.put("messageSchema", topic.getMessageSchema() != null ? topic.getMessageSchema() : null);
+    // messageSchema is already present as a nested Map via JsonUtils.getMap(entity). Do NOT re-put
+    // it as a raw POJO: that would stop the oversize-value cap (which walks Map/List) from
+    // descending into the flattened messageSchema.schemaFields.children.
     return doc;
   }
 

--- a/openmetadata-service/src/test/java/org/openmetadata/service/search/IndexMappingNestedFieldConsistencyTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/search/IndexMappingNestedFieldConsistencyTest.java
@@ -1,5 +1,6 @@
 package org.openmetadata.service.search;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -12,6 +13,7 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.openmetadata.schema.utils.JsonUtils;
@@ -66,6 +68,20 @@ class IndexMappingNestedFieldConsistencyTest {
             + "Using 'keyword' or 'object' will cause reindex failures when custom properties "
             + "(entityExtension) contain object/map values. Violations: "
             + violations);
+  }
+
+  @Test
+  void flattenedFieldPathsAreDerivedFromMappings() {
+    Set<String> paths = IndexMappingLoader.getInstance().getFlattenedFieldPaths();
+    // extension is flattened in every index
+    assertTrue(paths.contains("extension"), "extension should be derived as a flattened path");
+    // recursive children mapped as flattened under columns
+    assertTrue(
+        paths.contains("columns.children"), "columns.children should be derived as flattened");
+    // object-mapped top-level children (glossaryTerm / knowledgePage) must NOT be treated as
+    // flattened — otherwise their text leaves would be wrongly trimmed
+    assertFalse(
+        paths.contains("children"), "top-level object 'children' must not be derived as flattened");
   }
 
   @Test

--- a/openmetadata-service/src/test/java/org/openmetadata/service/search/SearchIndexUtilsTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/search/SearchIndexUtilsTest.java
@@ -30,7 +30,7 @@ import org.openmetadata.service.TypeRegistry;
 
 class SearchIndexUtilsTest {
 
-  private static final int MAX_INDEXED_VALUE_BYTES = 32000;
+  private static final int LUCENE_MAX_TERM_BYTES = 32766;
 
   @Test
   void capOversizeValuesTrimsLongLeafButKeepsShortOnes() {
@@ -49,7 +49,7 @@ class SearchIndexUtilsTest {
 
     Map<String, Object> trimmedChild = firstChild(doc);
     String trimmedDesc = (String) trimmedChild.get("description");
-    assertTrue(trimmedDesc.getBytes(StandardCharsets.UTF_8).length <= MAX_INDEXED_VALUE_BYTES);
+    assertTrue(trimmedDesc.getBytes(StandardCharsets.UTF_8).length <= LUCENE_MAX_TERM_BYTES);
     assertTrue(trimmedDesc.startsWith("Expression : "));
     assertEquals("Total Sales", trimmedChild.get("name"));
     assertEquals("Sales Model", doc.get("displayName"));
@@ -79,7 +79,7 @@ class SearchIndexUtilsTest {
     }
     String trimmed = (String) deepest.get("description");
     byte[] trimmedBytes = trimmed.getBytes(StandardCharsets.UTF_8);
-    assertTrue(trimmedBytes.length <= MAX_INDEXED_VALUE_BYTES);
+    assertTrue(trimmedBytes.length <= LUCENE_MAX_TERM_BYTES);
     assertEquals(trimmed, new String(trimmedBytes, StandardCharsets.UTF_8));
   }
 
@@ -104,7 +104,7 @@ class SearchIndexUtilsTest {
     assertEquals(List.of("id-1", "id-2"), doc.get("followers"));
     assertEquals(List.of("owner-1"), doc.get("owners"));
     String trimmedDesc = (String) firstChild(doc).get("description");
-    assertTrue(trimmedDesc.getBytes(StandardCharsets.UTF_8).length <= MAX_INDEXED_VALUE_BYTES);
+    assertTrue(trimmedDesc.getBytes(StandardCharsets.UTF_8).length <= LUCENE_MAX_TERM_BYTES);
   }
 
   @Test
@@ -123,7 +123,7 @@ class SearchIndexUtilsTest {
     assertEquals(huge, doc.get("schemaDefinition"));
     @SuppressWarnings("unchecked")
     String trimmedExt = (String) ((Map<String, Object>) doc.get("extension")).get("customProp");
-    assertTrue(trimmedExt.getBytes(StandardCharsets.UTF_8).length <= MAX_INDEXED_VALUE_BYTES);
+    assertTrue(trimmedExt.getBytes(StandardCharsets.UTF_8).length <= LUCENE_MAX_TERM_BYTES);
   }
 
   private Map<String, Object> firstChild(Map<String, Object> doc) {

--- a/openmetadata-service/src/test/java/org/openmetadata/service/search/SearchIndexUtilsTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/search/SearchIndexUtilsTest.java
@@ -161,6 +161,19 @@ class SearchIndexUtilsTest {
     assertNotEquals(huge, trimmed);
   }
 
+  @Test
+  void capOversizeValuesNeverFailsIndexingOnError() {
+    // An oversized value inside an UNMODIFIABLE map (Map.of) would make entry.setValue throw;
+    // the cap is a best-effort safety net and must swallow it rather than fail the whole document.
+    Map<String, Object> doc = new HashMap<>();
+    doc.put("extension", Map.of("customProp", "x".repeat(50_000)));
+
+    assertDoesNotThrow(
+        () ->
+            SearchIndexUtils.capOversizeValues(
+                doc, EXTENSION, () -> "type=table id=test fqn=test.model"));
+  }
+
   private Map<String, Object> firstChild(Map<String, Object> doc) {
     Map<String, Object> column = (Map<String, Object>) ((List<?>) doc.get("columns")).get(0);
     return (Map<String, Object>) ((List<?>) column.get("children")).get(0);

--- a/openmetadata-service/src/test/java/org/openmetadata/service/search/SearchIndexUtilsTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/search/SearchIndexUtilsTest.java
@@ -107,6 +107,25 @@ class SearchIndexUtilsTest {
     assertTrue(trimmedDesc.getBytes(StandardCharsets.UTF_8).length <= MAX_INDEXED_VALUE_BYTES);
   }
 
+  @Test
+  void capOversizeValuesOnlyTouchesFlatObjectFields() {
+    String huge = "x".repeat(50_000);
+    Map<String, Object> extension = new HashMap<>();
+    extension.put("customProp", huge);
+    Map<String, Object> doc = new HashMap<>();
+    doc.put("description", huge); // top-level text field — must NOT be trimmed
+    doc.put("schemaDefinition", huge); // text field — must NOT be trimmed
+    doc.put("extension", extension); // flat_object — MUST be trimmed
+
+    SearchIndexUtils.capOversizeValues(doc, "type=table id=test fqn=test.model");
+
+    assertEquals(huge, doc.get("description"));
+    assertEquals(huge, doc.get("schemaDefinition"));
+    @SuppressWarnings("unchecked")
+    String trimmedExt = (String) ((Map<String, Object>) doc.get("extension")).get("customProp");
+    assertTrue(trimmedExt.getBytes(StandardCharsets.UTF_8).length <= MAX_INDEXED_VALUE_BYTES);
+  }
+
   private Map<String, Object> firstChild(Map<String, Object> doc) {
     Map<String, Object> column = (Map<String, Object>) ((List<?>) doc.get("columns")).get(0);
     return (Map<String, Object>) ((List<?>) column.get("children")).get(0);

--- a/openmetadata-service/src/test/java/org/openmetadata/service/search/SearchIndexUtilsTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/search/SearchIndexUtilsTest.java
@@ -174,6 +174,35 @@ class SearchIndexUtilsTest {
                 doc, EXTENSION, () -> "type=table id=test fqn=test.model"));
   }
 
+  @Test
+  void capOversizeValuesTrimsTopicSchemaFieldsChildren() {
+    // Mirrors Topic/APIEndpoint: messageSchema (object Map) -> schemaFields (list) -> field ->
+    // children (flattened). messageSchema must be a Map (not a re-put POJO) for the cap to descend.
+    Map<String, Object> child = new HashMap<>();
+    child.put("name", "calc");
+    child.put("description", "Expression : " + "a".repeat(50_000));
+    Map<String, Object> field = new HashMap<>();
+    field.put("name", "rec");
+    field.put("children", new ArrayList<>(List.of(child)));
+    Map<String, Object> messageSchema = new HashMap<>();
+    messageSchema.put("schemaFields", new ArrayList<>(List.of(field)));
+    Map<String, Object> doc = new HashMap<>();
+    doc.put("messageSchema", messageSchema);
+
+    SearchIndexUtils.capOversizeValues(
+        doc, Set.of("messageSchema.schemaFields.children"), () -> "type=topic id=t fqn=t");
+
+    @SuppressWarnings("unchecked")
+    Map<String, Object> ms = (Map<String, Object>) doc.get("messageSchema");
+    @SuppressWarnings("unchecked")
+    Map<String, Object> f = (Map<String, Object>) ((List<?>) ms.get("schemaFields")).get(0);
+    @SuppressWarnings("unchecked")
+    Map<String, Object> trimmedChild = (Map<String, Object>) ((List<?>) f.get("children")).get(0);
+    String desc = (String) trimmedChild.get("description");
+    assertTrue(desc.getBytes(StandardCharsets.UTF_8).length <= MAX_VALUE_BUDGET);
+    assertTrue(desc.startsWith("Expression : "));
+  }
+
   private Map<String, Object> firstChild(Map<String, Object> doc) {
     Map<String, Object> column = (Map<String, Object>) ((List<?>) doc.get("columns")).get(0);
     return (Map<String, Object>) ((List<?>) column.get("children")).get(0);

--- a/openmetadata-service/src/test/java/org/openmetadata/service/search/SearchIndexUtilsTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/search/SearchIndexUtilsTest.java
@@ -45,7 +45,7 @@ class SearchIndexUtilsTest {
     doc.put("columns", new ArrayList<>(List.of(column)));
     doc.put("displayName", "Sales Model");
 
-    SearchIndexUtils.capOversizeValues(doc, "type=table id=test fqn=test.model");
+    SearchIndexUtils.capOversizeValues(doc, () -> "type=table id=test fqn=test.model");
 
     Map<String, Object> trimmedChild = firstChild(doc);
     String trimmedDesc = (String) trimmedChild.get("description");
@@ -71,7 +71,7 @@ class SearchIndexUtilsTest {
     doc.put("columns", new ArrayList<>(List.of(node)));
 
     assertDoesNotThrow(
-        () -> SearchIndexUtils.capOversizeValues(doc, "type=table id=test fqn=test.model"));
+        () -> SearchIndexUtils.capOversizeValues(doc, () -> "type=table id=test fqn=test.model"));
 
     Map<String, Object> deepest = node;
     while (deepest.get("children") != null) {
@@ -99,7 +99,7 @@ class SearchIndexUtilsTest {
     doc.put("columns", new ArrayList<>(List.of(column)));
 
     assertDoesNotThrow(
-        () -> SearchIndexUtils.capOversizeValues(doc, "type=table id=test fqn=test.model"));
+        () -> SearchIndexUtils.capOversizeValues(doc, () -> "type=table id=test fqn=test.model"));
 
     assertEquals(List.of("id-1", "id-2"), doc.get("followers"));
     assertEquals(List.of("owner-1"), doc.get("owners"));
@@ -117,13 +117,39 @@ class SearchIndexUtilsTest {
     doc.put("schemaDefinition", huge); // text field — must NOT be trimmed
     doc.put("extension", extension); // flat_object — MUST be trimmed
 
-    SearchIndexUtils.capOversizeValues(doc, "type=table id=test fqn=test.model");
+    SearchIndexUtils.capOversizeValues(doc, () -> "type=table id=test fqn=test.model");
 
     assertEquals(huge, doc.get("description"));
     assertEquals(huge, doc.get("schemaDefinition"));
     @SuppressWarnings("unchecked")
     String trimmedExt = (String) ((Map<String, Object>) doc.get("extension")).get("customProp");
     assertTrue(trimmedExt.getBytes(StandardCharsets.UTF_8).length <= LUCENE_MAX_TERM_BYTES);
+  }
+
+  @Test
+  void capOversizeValuesSkipsObjectChildrenButTrimsColumnsChildren() {
+    String huge = "x".repeat(50_000);
+    // top-level object children (knowledgePage/glossaryTerm/container style) — must NOT be trimmed
+    Map<String, Object> objectChild = new HashMap<>();
+    objectChild.put("description", huge);
+    // columns.children (flat_object) — MUST be trimmed
+    Map<String, Object> colChild = new HashMap<>();
+    colChild.put("description", huge);
+    Map<String, Object> column = new HashMap<>();
+    column.put("children", new ArrayList<>(List.of(colChild)));
+    Map<String, Object> doc = new HashMap<>();
+    doc.put("children", new ArrayList<>(List.of(objectChild)));
+    doc.put("columns", new ArrayList<>(List.of(column)));
+
+    SearchIndexUtils.capOversizeValues(doc, () -> "type=table id=test fqn=test.model");
+
+    @SuppressWarnings("unchecked")
+    String objectDesc =
+        (String) ((Map<String, Object>) ((List<?>) doc.get("children")).get(0)).get("description");
+    assertEquals(huge, objectDesc);
+    String trimmed = (String) firstChild(doc).get("description");
+    assertTrue(trimmed.getBytes(StandardCharsets.UTF_8).length <= LUCENE_MAX_TERM_BYTES);
+    assertNotEquals(huge, trimmed);
   }
 
   private Map<String, Object> firstChild(Map<String, Object> doc) {

--- a/openmetadata-service/src/test/java/org/openmetadata/service/search/SearchIndexUtilsTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/search/SearchIndexUtilsTest.java
@@ -82,6 +82,29 @@ class SearchIndexUtilsTest {
     assertEquals(trimmed, new String(trimmedBytes, StandardCharsets.UTF_8));
   }
 
+  @Test
+  void capOversizeValuesHandlesUnmodifiableListsFromDocBuilder() {
+    // parseFollowers/parseOwners return unmodifiable lists (Stream.toList()/List.of); the doc
+    // builder also yields List.of(...) collections. These must not break the in-place walk.
+    Map<String, Object> child = new HashMap<>();
+    child.put("name", "Total Sales");
+    child.put("description", "Expression : " + "a".repeat(50_000));
+    Map<String, Object> column = new HashMap<>();
+    column.put("name", "Measures");
+    column.put("children", new ArrayList<>(List.of(child)));
+    Map<String, Object> doc = new HashMap<>();
+    doc.put("followers", List.of("id-1", "id-2"));
+    doc.put("owners", List.of("owner-1"));
+    doc.put("columns", new ArrayList<>(List.of(column)));
+
+    assertDoesNotThrow(() -> SearchIndexUtils.capOversizeValues(doc));
+
+    assertEquals(List.of("id-1", "id-2"), doc.get("followers"));
+    assertEquals(List.of("owner-1"), doc.get("owners"));
+    String trimmedDesc = (String) firstChild(doc).get("description");
+    assertTrue(trimmedDesc.getBytes(StandardCharsets.UTF_8).length <= MAX_INDEXED_VALUE_BYTES);
+  }
+
   private Map<String, Object> firstChild(Map<String, Object> doc) {
     Map<String, Object> column = (Map<String, Object>) ((List<?>) doc.get("columns")).get(0);
     return (Map<String, Object>) ((List<?>) column.get("children")).get(0);

--- a/openmetadata-service/src/test/java/org/openmetadata/service/search/SearchIndexUtilsTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/search/SearchIndexUtilsTest.java
@@ -32,6 +32,8 @@ class SearchIndexUtilsTest {
 
   private static final int LUCENE_MAX_TERM_BYTES = 32766;
   private static final int MAX_VALUE_BUDGET = LUCENE_MAX_TERM_BYTES - 512;
+  private static final Set<String> COLUMNS_CHILDREN = Set.of("columns.children");
+  private static final Set<String> EXTENSION = Set.of("extension");
 
   @Test
   void capOversizeValuesTrimsLongLeafButKeepsShortOnes() {
@@ -46,7 +48,8 @@ class SearchIndexUtilsTest {
     doc.put("columns", new ArrayList<>(List.of(column)));
     doc.put("displayName", "Sales Model");
 
-    SearchIndexUtils.capOversizeValues(doc, () -> "type=table id=test fqn=test.model");
+    SearchIndexUtils.capOversizeValues(
+        doc, COLUMNS_CHILDREN, () -> "type=table id=test fqn=test.model");
 
     Map<String, Object> trimmedChild = firstChild(doc);
     String trimmedDesc = (String) trimmedChild.get("description");
@@ -72,7 +75,9 @@ class SearchIndexUtilsTest {
     doc.put("columns", new ArrayList<>(List.of(node)));
 
     assertDoesNotThrow(
-        () -> SearchIndexUtils.capOversizeValues(doc, () -> "type=table id=test fqn=test.model"));
+        () ->
+            SearchIndexUtils.capOversizeValues(
+                doc, COLUMNS_CHILDREN, () -> "type=table id=test fqn=test.model"));
 
     Map<String, Object> deepest = node;
     while (deepest.get("children") != null) {
@@ -100,7 +105,9 @@ class SearchIndexUtilsTest {
     doc.put("columns", new ArrayList<>(List.of(column)));
 
     assertDoesNotThrow(
-        () -> SearchIndexUtils.capOversizeValues(doc, () -> "type=table id=test fqn=test.model"));
+        () ->
+            SearchIndexUtils.capOversizeValues(
+                doc, COLUMNS_CHILDREN, () -> "type=table id=test fqn=test.model"));
 
     assertEquals(List.of("id-1", "id-2"), doc.get("followers"));
     assertEquals(List.of("owner-1"), doc.get("owners"));
@@ -118,7 +125,7 @@ class SearchIndexUtilsTest {
     doc.put("schemaDefinition", huge); // text field — must NOT be trimmed
     doc.put("extension", extension); // flat_object — MUST be trimmed
 
-    SearchIndexUtils.capOversizeValues(doc, () -> "type=table id=test fqn=test.model");
+    SearchIndexUtils.capOversizeValues(doc, EXTENSION, () -> "type=table id=test fqn=test.model");
 
     assertEquals(huge, doc.get("description"));
     assertEquals(huge, doc.get("schemaDefinition"));
@@ -142,7 +149,8 @@ class SearchIndexUtilsTest {
     doc.put("children", new ArrayList<>(List.of(objectChild)));
     doc.put("columns", new ArrayList<>(List.of(column)));
 
-    SearchIndexUtils.capOversizeValues(doc, () -> "type=table id=test fqn=test.model");
+    SearchIndexUtils.capOversizeValues(
+        doc, COLUMNS_CHILDREN, () -> "type=table id=test fqn=test.model");
 
     @SuppressWarnings("unchecked")
     String objectDesc =

--- a/openmetadata-service/src/test/java/org/openmetadata/service/search/SearchIndexUtilsTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/search/SearchIndexUtilsTest.java
@@ -31,6 +31,7 @@ import org.openmetadata.service.TypeRegistry;
 class SearchIndexUtilsTest {
 
   private static final int LUCENE_MAX_TERM_BYTES = 32766;
+  private static final int MAX_VALUE_BUDGET = LUCENE_MAX_TERM_BYTES - 512;
 
   @Test
   void capOversizeValuesTrimsLongLeafButKeepsShortOnes() {
@@ -49,7 +50,7 @@ class SearchIndexUtilsTest {
 
     Map<String, Object> trimmedChild = firstChild(doc);
     String trimmedDesc = (String) trimmedChild.get("description");
-    assertTrue(trimmedDesc.getBytes(StandardCharsets.UTF_8).length <= LUCENE_MAX_TERM_BYTES);
+    assertTrue(trimmedDesc.getBytes(StandardCharsets.UTF_8).length <= MAX_VALUE_BUDGET);
     assertTrue(trimmedDesc.startsWith("Expression : "));
     assertEquals("Total Sales", trimmedChild.get("name"));
     assertEquals("Sales Model", doc.get("displayName"));
@@ -79,7 +80,7 @@ class SearchIndexUtilsTest {
     }
     String trimmed = (String) deepest.get("description");
     byte[] trimmedBytes = trimmed.getBytes(StandardCharsets.UTF_8);
-    assertTrue(trimmedBytes.length <= LUCENE_MAX_TERM_BYTES);
+    assertTrue(trimmedBytes.length < MAX_VALUE_BUDGET);
     assertEquals(trimmed, new String(trimmedBytes, StandardCharsets.UTF_8));
   }
 
@@ -104,7 +105,7 @@ class SearchIndexUtilsTest {
     assertEquals(List.of("id-1", "id-2"), doc.get("followers"));
     assertEquals(List.of("owner-1"), doc.get("owners"));
     String trimmedDesc = (String) firstChild(doc).get("description");
-    assertTrue(trimmedDesc.getBytes(StandardCharsets.UTF_8).length <= LUCENE_MAX_TERM_BYTES);
+    assertTrue(trimmedDesc.getBytes(StandardCharsets.UTF_8).length <= MAX_VALUE_BUDGET);
   }
 
   @Test
@@ -123,7 +124,7 @@ class SearchIndexUtilsTest {
     assertEquals(huge, doc.get("schemaDefinition"));
     @SuppressWarnings("unchecked")
     String trimmedExt = (String) ((Map<String, Object>) doc.get("extension")).get("customProp");
-    assertTrue(trimmedExt.getBytes(StandardCharsets.UTF_8).length <= LUCENE_MAX_TERM_BYTES);
+    assertTrue(trimmedExt.getBytes(StandardCharsets.UTF_8).length <= MAX_VALUE_BUDGET);
   }
 
   @Test
@@ -148,7 +149,7 @@ class SearchIndexUtilsTest {
         (String) ((Map<String, Object>) ((List<?>) doc.get("children")).get(0)).get("description");
     assertEquals(huge, objectDesc);
     String trimmed = (String) firstChild(doc).get("description");
-    assertTrue(trimmed.getBytes(StandardCharsets.UTF_8).length <= LUCENE_MAX_TERM_BYTES);
+    assertTrue(trimmed.getBytes(StandardCharsets.UTF_8).length <= MAX_VALUE_BUDGET);
     assertNotEquals(huge, trimmed);
   }
 

--- a/openmetadata-service/src/test/java/org/openmetadata/service/search/SearchIndexUtilsTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/search/SearchIndexUtilsTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.*;
 
 import jakarta.json.Json;
 import jakarta.json.JsonObject;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -28,6 +29,63 @@ import org.openmetadata.schema.type.change.ChangeSummary;
 import org.openmetadata.service.TypeRegistry;
 
 class SearchIndexUtilsTest {
+
+  private static final int MAX_INDEXED_VALUE_BYTES = 32000;
+
+  @Test
+  void capOversizeValuesTrimsLongLeafButKeepsShortOnes() {
+    String hugeDax = "Expression : " + "a".repeat(50_000);
+    Map<String, Object> child = new HashMap<>();
+    child.put("name", "Total Sales");
+    child.put("description", hugeDax);
+    Map<String, Object> column = new HashMap<>();
+    column.put("name", "Measures");
+    column.put("children", new ArrayList<>(List.of(child)));
+    Map<String, Object> doc = new HashMap<>();
+    doc.put("columns", new ArrayList<>(List.of(column)));
+    doc.put("displayName", "Sales Model");
+
+    SearchIndexUtils.capOversizeValues(doc);
+
+    Map<String, Object> trimmedChild = firstChild(doc);
+    String trimmedDesc = (String) trimmedChild.get("description");
+    assertTrue(trimmedDesc.getBytes(StandardCharsets.UTF_8).length <= MAX_INDEXED_VALUE_BYTES);
+    assertTrue(trimmedDesc.startsWith("Expression : "));
+    assertEquals("Total Sales", trimmedChild.get("name"));
+    assertEquals("Sales Model", doc.get("displayName"));
+  }
+
+  @Test
+  void capOversizeValuesIsMultiByteSafeAndHandlesDeepNesting() {
+    String multiByte = "和".repeat(20_000);
+    Map<String, Object> node = new HashMap<>();
+    node.put("name", "leaf");
+    node.put("description", multiByte);
+    for (int level = 0; level < 30; level++) {
+      Map<String, Object> parent = new HashMap<>();
+      parent.put("name", "c" + level);
+      parent.put("children", new ArrayList<>(List.of(node)));
+      node = parent;
+    }
+    Map<String, Object> doc = new HashMap<>();
+    doc.put("columns", new ArrayList<>(List.of(node)));
+
+    assertDoesNotThrow(() -> SearchIndexUtils.capOversizeValues(doc));
+
+    Map<String, Object> deepest = node;
+    while (deepest.get("children") != null) {
+      deepest = (Map<String, Object>) ((List<?>) deepest.get("children")).get(0);
+    }
+    String trimmed = (String) deepest.get("description");
+    byte[] trimmedBytes = trimmed.getBytes(StandardCharsets.UTF_8);
+    assertTrue(trimmedBytes.length <= MAX_INDEXED_VALUE_BYTES);
+    assertEquals(trimmed, new String(trimmedBytes, StandardCharsets.UTF_8));
+  }
+
+  private Map<String, Object> firstChild(Map<String, Object> doc) {
+    Map<String, Object> column = (Map<String, Object>) ((List<?>) doc.get("columns")).get(0);
+    return (Map<String, Object>) ((List<?>) column.get("children")).get(0);
+  }
 
   @Test
   void testParseHelpersAndRemoveFieldByPathSupportsNestedLists() {

--- a/openmetadata-service/src/test/java/org/openmetadata/service/search/SearchIndexUtilsTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/search/SearchIndexUtilsTest.java
@@ -45,7 +45,7 @@ class SearchIndexUtilsTest {
     doc.put("columns", new ArrayList<>(List.of(column)));
     doc.put("displayName", "Sales Model");
 
-    SearchIndexUtils.capOversizeValues(doc);
+    SearchIndexUtils.capOversizeValues(doc, "type=table id=test fqn=test.model");
 
     Map<String, Object> trimmedChild = firstChild(doc);
     String trimmedDesc = (String) trimmedChild.get("description");
@@ -70,7 +70,8 @@ class SearchIndexUtilsTest {
     Map<String, Object> doc = new HashMap<>();
     doc.put("columns", new ArrayList<>(List.of(node)));
 
-    assertDoesNotThrow(() -> SearchIndexUtils.capOversizeValues(doc));
+    assertDoesNotThrow(
+        () -> SearchIndexUtils.capOversizeValues(doc, "type=table id=test fqn=test.model"));
 
     Map<String, Object> deepest = node;
     while (deepest.get("children") != null) {
@@ -97,7 +98,8 @@ class SearchIndexUtilsTest {
     doc.put("owners", List.of("owner-1"));
     doc.put("columns", new ArrayList<>(List.of(column)));
 
-    assertDoesNotThrow(() -> SearchIndexUtils.capOversizeValues(doc));
+    assertDoesNotThrow(
+        () -> SearchIndexUtils.capOversizeValues(doc, "type=table id=test fqn=test.model"));
 
     assertEquals(List.of("id-1", "id-2"), doc.get("followers"));
     assertEquals(List.of("owner-1"), doc.get("owners"));

--- a/openmetadata-spec/src/main/java/org/openmetadata/search/IndexMappingLoader.java
+++ b/openmetadata-spec/src/main/java/org/openmetadata/search/IndexMappingLoader.java
@@ -4,6 +4,7 @@ import jakarta.json.JsonObject;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import lombok.Getter;
@@ -28,6 +29,14 @@ public class IndexMappingLoader {
   @Getter Map<String, IndexMapping> indexMapping = new HashMap<>();
   @Getter Map<String, Map<String, Object>> entityIndexMapping = new HashMap<>();
 
+  /**
+   * Dot-paths of every field mapped as {@code "type": "flattened"} across all entity mappings (e.g.
+   * {@code columns.children}, {@code extension}). These index leaves as single keyword terms with
+   * no length cap, so they are the only fields that can trip Lucene's per-term limit. Derived from
+   * the loaded mappings so it never drifts from the source of truth.
+   */
+  @Getter final Set<String> flattenedFieldPaths = new HashSet<>();
+
   private IndexMappingLoader(ElasticSearchConfiguration elasticSearchConfiguration)
       throws IOException {
     this.elasticSearchConfiguration = elasticSearchConfiguration;
@@ -39,12 +48,14 @@ public class IndexMappingLoader {
     }
     loadIndexMapping();
     loadEntityIndexMapping();
+    loadFlattenedFieldPaths();
   }
 
   private IndexMappingLoader() throws IOException {
     this.searchIndexMappingLanguage = "en";
     loadIndexMapping();
     loadEntityIndexMapping();
+    loadFlattenedFieldPaths();
   }
 
   public static void init(ElasticSearchConfiguration elasticSearchConfiguration)
@@ -133,6 +144,29 @@ public class IndexMappingLoader {
         entityIndexMapping.put(entityName, jsonMap);
       } catch (Exception e) {
         throw new JsonParsingException("Failed to load index mapping for " + entityName, e);
+      }
+    }
+  }
+
+  private void loadFlattenedFieldPaths() {
+    for (Map<String, Object> mapping : entityIndexMapping.values()) {
+      if (mapping.get("mappings") instanceof Map<?, ?> mappings
+          && mappings.get("properties") instanceof Map<?, ?> properties) {
+        collectFlattenedPaths(properties, "", flattenedFieldPaths);
+      }
+    }
+  }
+
+  private static void collectFlattenedPaths(Map<?, ?> properties, String prefix, Set<String> out) {
+    for (Map.Entry<?, ?> entry : properties.entrySet()) {
+      if (!(entry.getValue() instanceof Map<?, ?> field)) {
+        continue;
+      }
+      String path = prefix.isEmpty() ? entry.getKey().toString() : prefix + "." + entry.getKey();
+      if ("flattened".equals(field.get("type"))) {
+        out.add(path);
+      } else if (field.get("properties") instanceof Map<?, ?> nested) {
+        collectFlattenedPaths(nested, path, out);
       }
     }
   }

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/SearchIndexImmenseTerm.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/SearchIndexImmenseTerm.spec.ts
@@ -1,0 +1,167 @@
+/*
+ *  Copyright 2026 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+/**
+ * Reproduces the "immense term" reindex failure: a single nested column leaf
+ * longer than Lucene's 32,766-byte keyword limit is flattened into
+ * `columns.children` and fails the search-index bulk insert, so the entity never
+ * lands in the index.
+ *
+ * The original leaf was a ~50 KB Looker measure expression containing CJK
+ * characters, so the payload mirrors both the field (`dataTypeDisplay`) and the
+ * multi-byte content to exercise the byte-vs-char distinction that ASCII-only
+ * fixtures miss.
+ *
+ * The test reindexes ONLY this entity via `/search/reindexEntities`, then tracks
+ * the outcome with `/search/get/{index}/doc/{id}`:
+ *   - 200 → the document indexed successfully.
+ *   - 404 → it failed to index (the oversize leaf was rejected).
+ * While the bug is present the document never indexes (404) and this fails RED.
+ * Once the oversize leaf is capped/dropped at index-build time, the document
+ * indexes (200) and the test goes green.
+ */
+
+import { APIRequestContext, expect, test } from '@playwright/test';
+import { DashboardDataModelClass } from '../../support/entity/DashboardDataModelClass';
+import { createAdminApiContext } from '../../utils/admin';
+
+test.use({ storageState: 'playwright/.auth/admin.json' });
+
+const LUCENE_MAX_TERM_BYTES = 32766;
+const REINDEX_ENTITY_TYPE = 'dashboardDataModel';
+
+const buildOversizeExpression = (targetBytes = 50586): string => {
+  const unit =
+    'Expression : //Par_MQY_Time 時間 SUM(CASE WHEN revenue > 0 THEN revenue END) / ';
+  let value = '';
+
+  while (Buffer.byteLength(value, 'utf8') < targetBytes) {
+    value += unit;
+  }
+
+  return value;
+};
+
+const buildOversizeColumns = () => {
+  const oversizeExpression = buildOversizeExpression();
+
+  return [
+    {
+      name: 'metrics',
+      dataType: 'STRUCT',
+      dataTypeDisplay: 'struct',
+      description: 'Computed metrics for the data model.',
+      children: [
+        {
+          name: 'revenue_measure',
+          dataType: 'STRUCT',
+          dataTypeDisplay: 'struct',
+          description: 'Revenue measure with a large derived expression.',
+          children: [
+            {
+              name: 'derived_expression',
+              dataType: 'VARCHAR',
+              dataLength: 256,
+              dataTypeDisplay: oversizeExpression,
+              description:
+                'Looker measure expression exceeding the Lucene term limit.',
+            },
+          ],
+        },
+      ],
+    },
+  ];
+};
+
+const reindexEntity = async (
+  apiContext: APIRequestContext,
+  entityId: string,
+  fullyQualifiedName: string
+): Promise<void> => {
+  const response = await apiContext.post('/api/v1/search/reindexEntities', {
+    data: [{ id: entityId, type: REINDEX_ENTITY_TYPE, fullyQualifiedName }],
+  });
+
+  expect(response.status()).toBe(200);
+};
+
+const getIndexedDocStatus = async (
+  apiContext: APIRequestContext,
+  entityId: string
+): Promise<number> => {
+  const response = await apiContext.get(
+    `/api/v1/search/get/${REINDEX_ENTITY_TYPE}/doc/${entityId}`
+  );
+
+  return response.status();
+};
+
+test.describe('Search Index - oversized nested column reindex', () => {
+  const dataModel = new DashboardDataModelClass();
+
+  test.beforeAll(async () => {
+    const { apiContext, afterAction } = await createAdminApiContext();
+    const oversizeColumns = buildOversizeColumns();
+    dataModel.children = oversizeColumns;
+    dataModel.entity.columns = oversizeColumns;
+
+    await dataModel.create(apiContext);
+    await afterAction();
+  });
+
+  test.afterAll(async () => {
+    const { apiContext, afterAction } = await createAdminApiContext();
+    await dataModel.delete(apiContext);
+    await afterAction();
+  });
+
+  test('reindex of a >32KB nested column leaf indexes the document', async () => {
+    test.slow();
+
+    const { apiContext, afterAction } = await createAdminApiContext();
+
+    try {
+      const entityId = dataModel.entityResponseData.id;
+      const fullyQualifiedName =
+        dataModel.entityResponseData.fullyQualifiedName ?? '';
+
+      expect(
+        Buffer.byteLength(
+          dataModel.entity.columns[0].children?.[0].children?.[0]
+            .dataTypeDisplay ?? '',
+          'utf8'
+        )
+      ).toBeGreaterThan(LUCENE_MAX_TERM_BYTES);
+
+      await test.step('Reindex only this entity', async () => {
+        await reindexEntity(apiContext, entityId, fullyQualifiedName);
+      });
+
+      await test.step('Document is present in the search index', async () => {
+        // 404 means the oversize columns.children leaf was rejected (immense
+        // term) and the document never indexed. reindexEntities swallows the
+        // engine error, so the indexed/not-indexed outcome is the signal here.
+        await expect
+          .poll(() => getIndexedDocStatus(apiContext, entityId), {
+            message:
+              'expected the reindexed data model to be present in the index (404 = oversize columns.children leaf rejected, document not indexed)',
+            intervals: [2_000, 3_000, 5_000, 10_000],
+            timeout: 60_000,
+          })
+          .toBe(200);
+      });
+    } finally {
+      await afterAction();
+    }
+  });
+});


### PR DESCRIPTION
### Describe your changes:

Entities with a **single field value larger than Lucene's per-term limit (32766 bytes)** silently fail to index — the whole document is rejected:

```
# OpenSearch
Document contains at least one immense term in field="columns.children._value"
(whose UTF8 encoding is longer than the max length 32766) ... got 50586
# Elasticsearch (same root cause, different wording)
document_parsing_exception ... failed to parse field [columns.children] of type [flattened]
```

**Root cause:** PowerBI dashboard data models store each calculated measure's **DAX expression in a nested column `description`**. The recursive `columns.children` subtree is mapped as `flattened` (`flat_object` on OpenSearch) — done in #28214 to avoid the ES `index.mapping.depth.limit`. A `flattened`/`flat_object` field indexes every leaf as a **single un-tokenized keyword term**, so one oversized leaf (~50 KB) exceeds Lucene's limit and the entire entity is dropped from search.

**Fix:** cap oversize string values inside flattened fields at document-build time, in the shared `SearchIndex.buildSearchIndexDoc` (covers real-time indexing **and** bulk reindex). The full value is preserved on the source entity (database/API); only the indexed copy is trimmed, so entity pages and APIs are unaffected.

#
### Type of change:
- [x] Bug fix

#
### Works identically on Elasticsearch and OpenSearch:
- The 32766-byte limit is **Lucene's**, and both engines run Lucene — the threshold is byte-for-byte identical.
- The cap runs at **document build**, upstream of both the ES and OS clients, so neither engine ever receives an oversized term. ES reports the failure as `document_parsing_exception`/`failed to parse flattened`, OpenSearch as `immense term in …_value` — different messages, one shared cause and one shared fix.

#
### Design (final):
- **Flattened paths are derived from the mappings (single source of truth).** `IndexMappingLoader` scans every parsed index mapping once at startup and collects the dot-paths where `"type": "flattened"` (e.g. `columns.children`, `dataModel.columns.children`, `schemaFields.children`, `fields.children`, `extension`). `SearchRepository` exposes the set; the cap consults it by matching each field's full path. No hardcoded field names, so a new flattened field in any mapping is picked up automatically and `object`-mapped `children` (glossaryTerm / knowledgePage / container top-level) is never touched.
- **Depth-aware byte budget.** A `flat_object` also indexes a `_valueAndPath` term (leaf path + value), and the path grows with nesting depth, so the budget is `32766 − margin − pathBytes`; both the `_value` and `_valueAndPath` terms stay under the limit at any depth.
- **Trims on a UTF-8 character boundary** (multi-byte safe), in place, and only when a value actually changes (so unmodifiable collections from the doc builder — `parseFollowers`/`parseOwners` `Stream.toList()`, `List.of(...)` — are never written back).
- **Best-effort guard.** The cap runs inside the doc builder, so a defect in it would itself drop a valid entity from search; it is wrapped in `try/catch` and null-guarded so it logs and continues instead of failing indexing — a safety net must never be the cause of a failure.
- Trim events log the entity (`type`/`id`/`fqn`) and field for traceability (internal tracking only; expected to be rare — only values > ~32 KB).

#
### Alternatives considered (and why not):

We are boxed in by **two independent Lucene/ES limits on the same `children` field**: object depth ≤ 20 (forces `flat_object`) and term length ≤ 32766 bytes (what this PR addresses).

1. **`ignore_above` on the mapping (the earlier attempt, #28509):** OpenSearch doesn't support it on `flat_object`, so the index gets created without its mapping and aggregations/sorting break — this is what caused the 221 Playwright failures.
2. **Revert `children` back to a nested object:** brings back the 20-level depth-limit failure that #28214 fixed.
3. **Map `children` as `object` with `enabled: false`:** the entity still indexes, but the children are not indexed at all — we'd lose nested column-name search.
4. **Raise `index.mapping.depth.limit`:** only defers the problem and bloats mappings; already rejected in #28214.
5. **Hardcode the flattened field names/parents in Java:** works, but couples to the mappings with nothing enforcing the coupling — a future flattened field would silently miss the cap and fail. Replaced by deriving the paths from the mappings.
6. **Generic document-layer value cap, scoped to mapping-derived flattened paths (chosen):** caps by size, only where the mappings say a field is `flattened`, identically on ES and OpenSearch.

#
### Tests:
- `SearchIndexUtilsTest` — oversized nested `description` trimmed while short siblings kept; multi-byte (CJK) trimmed on a character boundary; deep (30-level) nesting respects the depth-aware budget; unmodifiable `followers`/`owners` lists don't break the walk; only flattened paths are trimmed (`text` fields left intact); object `children` skipped while `columns.children` trimmed; the cap swallows internal errors and never fails indexing.
- `IndexMappingNestedFieldConsistencyTest` — asserts the derived flattened-path set (from the real mappings) includes `columns.children` and `extension` and excludes bare object `children`.
- Manually verified on local Elasticsearch 9.3.0 and OpenSearch 3.4.0: a document with a 50 KB nested leaf is rejected without the fix and indexes successfully with it on both engines.

#### Backend integration tests
- [ ] Not applicable (search document-build change; covered by unit tests + mapping-consistency tests + manual ES/OpenSearch verification)

#
### Notes:
- This replaces the `ignore_above` mapping approach in #28509, which breaks OpenSearch index creation.

----
## Summary by Gitar

- **Search indexing fixes:**
  - Updated `APIEndpointIndex` and `TopicIndex` to stop overwriting schema fields with raw POJOs, ensuring the recursive value-cap logic can successfully traverse nested maps.


<sub>This will update automatically on new commits.</sub>