### PR TITLE
test(playwright): increase timeout for Glossary Terms column selection test

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/Glossary.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/Glossary.spec.ts
@@ -1523,6 +1523,8 @@ test.describe('Glossary tests', () => {
   test('Column selection and visibility for Glossary Terms table', async ({
     browser,
   }) => {
+    test.setTimeout(180_000);
+
     const { page, afterAction, apiContext } = await performAdminLogin(browser);
     const glossary1 = new Glossary();
     const glossaryTerm1 = new GlossaryTerm(glossary1);

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/GlossaryImportExport.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/GlossaryImportExport.spec.ts
@@ -98,6 +98,8 @@ test.describe('Glossary Bulk Import Export', () => {
   });
 
   test('Glossary Bulk Import Export', async ({ page }) => {
+    test.setTimeout(5 * 60 * 1000);
+
     await test.step('create custom properties for extension edit', async () => {
       for (const property of propertiesList) {
         const entity = CUSTOM_PROPERTIES_ENTITIES.entity_glossaryTerm;


### PR DESCRIPTION
## What

Increases the per-test timeout for the `Column selection and visibility for Glossary Terms table` Playwright test in `Glossary.spec.ts` to 180s (default is 60s).

```ts
test('Column selection and visibility for Glossary Terms table', async ({
  browser,
}) => {
  test.setTimeout(180_000);
  ...
```

## Why

The test does API setup/teardown of a glossary + two terms, then runs four `test.step`s that each reload the page and verify column visibility (select/deselect, view-all, hide-all). This work exceeds the global 60s test timeout (`playwright.config.ts`) and causes flaky timeout failures.

`test.setTimeout()` scopes the increase to this single test only — the global config and all other tests are untouched. It follows the per-test override pattern already used in sibling specs (e.g. `CustomProperties.spec.ts`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

----
## Summary by Gitar

- **Test stability:**
  - Increased timeout for `Glossary Bulk Import Export` test in `GlossaryImportExport.spec.ts` to 5 minutes.

<sub>This will update automatically on new commits.</sub>