### PR TITLE
fix(activity-stream): hash entity FQN + tolerate unresolvable actors

### DIFF
--- a/bootstrap/sql/migrations/native/2.0.0/mysql/schemaChanges.sql
+++ b/bootstrap/sql/migrations/native/2.0.0/mysql/schemaChanges.sql
@@ -95,7 +95,8 @@ CREATE TABLE IF NOT EXISTS activity_stream (
     entityFqnHash varchar(768) CHARACTER SET ascii COLLATE ascii_bin,
     about varchar(2048),
     aboutFqnHash varchar(768) CHARACTER SET ascii COLLATE ascii_bin,
-    actorId varchar(36) NOT NULL,
+    -- Nullable for system events and hard-deleted users; actorName is the display fallback.
+    actorId varchar(36),
     actorName varchar(256),
     timestamp bigint NOT NULL,
     summary varchar(500),

--- a/bootstrap/sql/migrations/native/2.0.0/postgres/schemaChanges.sql
+++ b/bootstrap/sql/migrations/native/2.0.0/postgres/schemaChanges.sql
@@ -68,7 +68,8 @@ CREATE TABLE IF NOT EXISTS activity_stream (
     entityfqnhash character varying(768),
     about character varying(2048),
     aboutfqnhash character varying(768),
-    actorid character varying(36) NOT NULL,
+    -- Nullable for system events and hard-deleted users; actorname is the display fallback.
+    actorid character varying(36),
     actorname character varying(256),
     timestamp bigint NOT NULL,
     summary character varying(500),

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/ActivityStreamRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/ActivityStreamRepository.java
@@ -15,6 +15,7 @@ package org.openmetadata.service.jdbi3;
 
 import static org.openmetadata.common.utils.CommonUtil.nullOrEmpty;
 
+import io.micrometer.core.instrument.Metrics;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
@@ -44,6 +45,7 @@ import org.openmetadata.service.util.FullyQualifiedName;
 @Slf4j
 public class ActivityStreamRepository {
   private static final int MAX_STORED_SUMMARY_LENGTH = 500;
+  private static final String UNRESOLVED_ACTOR_METRIC = "activity_stream.unresolved_actor";
 
   private final CollectionDAO.ActivityStreamDAO activityStreamDAO;
 
@@ -473,12 +475,15 @@ public class ActivityStreamRepository {
 
   private EntityReference buildActorReference(String userName) {
     EntityReference result = null;
-    if (!nullOrEmpty(userName)) {
+    if (nullOrEmpty(userName)) {
+      Metrics.counter(UNRESOLVED_ACTOR_METRIC, "kind", "system_event").increment();
+    } else {
       try {
         // Include.ALL keeps soft-deleted users resolvable with their real id.
         result = Entity.getEntityReferenceByName(Entity.USER, userName, Include.ALL);
       } catch (EntityNotFoundException ignored) {
         // Hard-deleted: keep the name for display, actorId stays null (no FK target).
+        Metrics.counter(UNRESOLVED_ACTOR_METRIC, "kind", "hard_deleted").increment();
         result = new EntityReference().withType(Entity.USER).withName(userName);
       }
     }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/ActivityStreamRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/ActivityStreamRepository.java
@@ -31,6 +31,7 @@ import org.openmetadata.schema.type.ReactionType;
 import org.openmetadata.schema.utils.JsonUtils;
 import org.openmetadata.service.Entity;
 import org.openmetadata.service.exception.EntityNotFoundException;
+import org.openmetadata.service.resources.feeds.MessageParser;
 import org.openmetadata.service.util.FullyQualifiedName;
 
 /**
@@ -144,10 +145,12 @@ public class ActivityStreamRepository {
       domainsJson = JsonUtils.pojoToJson(domainIds);
     }
 
-    String aboutFqnHash = null;
-    if (event.getAbout() != null) {
-      aboutFqnHash = FullyQualifiedName.buildHash(event.getAbout());
-    }
+    // about is an EntityLink, not an FQN — parse first, then hash the FQN portion.
+    String aboutFqnHash =
+        nullOrEmpty(event.getAbout())
+            ? null
+            : FullyQualifiedName.buildHash(
+                MessageParser.EntityLink.parse(event.getAbout()).getEntityFQN());
 
     activityStreamDAO.insert(
         event.getId().toString(),
@@ -296,7 +299,11 @@ public class ActivityStreamRepository {
 
   /** List activity events by EntityLink (about field). */
   public List<ActivityEvent> listByAbout(String entityLink, long afterTimestamp, int limit) {
-    String aboutFqnHash = FullyQualifiedName.buildHash(entityLink);
+    String aboutFqnHash =
+        nullOrEmpty(entityLink)
+            ? null
+            : FullyQualifiedName.buildHash(
+                MessageParser.EntityLink.parse(entityLink).getEntityFQN());
     List<String> jsonList = activityStreamDAO.listByAbout(aboutFqnHash, afterTimestamp, limit);
     return jsonList.stream().map(json -> JsonUtils.readValue(json, ActivityEvent.class)).toList();
   }
@@ -308,7 +315,11 @@ public class ActivityStreamRepository {
       return listByAbout(entityLink, afterTimestamp, limit);
     }
 
-    String aboutFqnHash = FullyQualifiedName.buildHash(entityLink);
+    String aboutFqnHash =
+        nullOrEmpty(entityLink)
+            ? null
+            : FullyQualifiedName.buildHash(
+                MessageParser.EntityLink.parse(entityLink).getEntityFQN());
     List<String> domainIdStrings = domainIds.stream().map(UUID::toString).toList();
     String domainJson = JsonUtils.pojoToJson(domainIdStrings);
     List<String> jsonList =

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/ActivityStreamRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/ActivityStreamRepository.java
@@ -26,6 +26,7 @@ import org.openmetadata.schema.type.ChangeDescription;
 import org.openmetadata.schema.type.ChangeEvent;
 import org.openmetadata.schema.type.EntityReference;
 import org.openmetadata.schema.type.FieldChange;
+import org.openmetadata.schema.type.Include;
 import org.openmetadata.schema.type.Reaction;
 import org.openmetadata.schema.type.ReactionType;
 import org.openmetadata.schema.utils.JsonUtils;
@@ -162,8 +163,10 @@ public class ActivityStreamRepository {
             : null,
         event.getAbout(),
         aboutFqnHash,
-        event.getActor().getId().toString(),
-        event.getActor().getName(),
+        event.getActor() != null && event.getActor().getId() != null
+            ? event.getActor().getId().toString()
+            : null,
+        event.getActor() != null ? event.getActor().getName() : null,
         event.getTimestamp(),
         truncateSummaryForStorage(event.getSummary()),
         event.getFieldName(),
@@ -469,15 +472,17 @@ public class ActivityStreamRepository {
   }
 
   private EntityReference buildActorReference(String userName) {
-    if (nullOrEmpty(userName)) {
-      return new EntityReference().withType(Entity.USER).withName("system");
+    EntityReference result = null;
+    if (!nullOrEmpty(userName)) {
+      try {
+        // Include.ALL keeps soft-deleted users resolvable with their real id.
+        result = Entity.getEntityReferenceByName(Entity.USER, userName, Include.ALL);
+      } catch (EntityNotFoundException ignored) {
+        // Hard-deleted: keep the name for display, actorId stays null (no FK target).
+        result = new EntityReference().withType(Entity.USER).withName(userName);
+      }
     }
-    try {
-      return Entity.getEntityReferenceByName(Entity.USER, userName, null);
-    } catch (Exception e) {
-      // User might not exist (e.g., system operations)
-      return new EntityReference().withType(Entity.USER).withName(userName);
-    }
+    return result;
   }
 
   private String buildSummary(

--- a/openmetadata-service/src/main/java/org/openmetadata/service/migration/utils/v200/MigrationUtil.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/migration/utils/v200/MigrationUtil.java
@@ -1,5 +1,7 @@
 package org.openmetadata.service.migration.utils.v200;
 
+import static org.openmetadata.common.utils.CommonUtil.nullOrEmpty;
+
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.io.IOException;
@@ -1133,7 +1135,10 @@ public class MigrationUtil {
             ? FullyQualifiedName.buildHash(event.getEntity().getFullyQualifiedName())
             : null;
     String aboutFqnHash =
-        event.getAbout() != null ? FullyQualifiedName.buildHash(event.getAbout()) : null;
+        nullOrEmpty(event.getAbout())
+            ? null
+            : FullyQualifiedName.buildHash(
+                MessageParser.EntityLink.parse(event.getAbout()).getEntityFQN());
     String domains =
         event.getDomains() == null || event.getDomains().isEmpty()
             ? null

--- a/openmetadata-service/src/main/java/org/openmetadata/service/util/FullyQualifiedName.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/util/FullyQualifiedName.java
@@ -39,6 +39,9 @@ public class FullyQualifiedName {
   // Quoted name of format "sss" or unquoted string sss
   private static final Pattern namePattern = Pattern.compile("^(\")([^\"]+)(\")$|^(.*)$");
 
+  // EntityLink-shaped input would bail the FQN ANTLR parser with no message; reject it explicitly.
+  private static final String ENTITY_LINK_PREFIX = "<#E::";
+
   private FullyQualifiedName() {
     /* Utility class with private constructor */
   }
@@ -66,6 +69,12 @@ public class FullyQualifiedName {
   }
 
   public static String buildHash(String fullyQualifiedName) {
+    if (fullyQualifiedName != null && fullyQualifiedName.startsWith(ENTITY_LINK_PREFIX)) {
+      throw new IllegalArgumentException(
+          "FullyQualifiedName.buildHash expects a plain FQN, got an EntityLink: "
+              + fullyQualifiedName
+              + ". Parse the EntityLink first via MessageParser.EntityLink.parse(...).getEntityFQN().");
+    }
     if (fullyQualifiedName != null && !fullyQualifiedName.isEmpty()) {
       String[] split = split(fullyQualifiedName);
       return buildHash(split);

--- a/openmetadata-service/src/test/java/org/openmetadata/service/jdbi3/ActivityStreamRepositoryTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/jdbi3/ActivityStreamRepositoryTest.java
@@ -14,21 +14,105 @@
 package org.openmetadata.service.jdbi3;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.anyLong;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.verify;
 
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.Metrics;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.util.UUID;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.openmetadata.schema.EntityInterface;
 import org.openmetadata.schema.entity.activity.ActivityEvent;
+import org.openmetadata.schema.entity.data.Table;
 import org.openmetadata.schema.type.ActivityEventType;
+import org.openmetadata.schema.type.ChangeEvent;
 import org.openmetadata.schema.type.EntityReference;
+import org.openmetadata.schema.type.EventType;
+import org.openmetadata.schema.type.Include;
 import org.openmetadata.service.Entity;
+import org.openmetadata.service.exception.EntityNotFoundException;
 
 class ActivityStreamRepositoryTest {
+
+  private SimpleMeterRegistry meterRegistry;
+
+  @BeforeEach
+  void registerMeters() {
+    meterRegistry = new SimpleMeterRegistry();
+    Metrics.addRegistry(meterRegistry);
+  }
+
+  @AfterEach
+  void unregisterMeters() {
+    Metrics.removeRegistry(meterRegistry);
+    meterRegistry.close();
+  }
+
+  @Test
+  void buildActorReferenceCountsSystemEventWhenUserNameMissing() {
+    CollectionDAO.ActivityStreamDAO dao = mock(CollectionDAO.ActivityStreamDAO.class);
+    ActivityStreamRepository repository = new ActivityStreamRepository(dao);
+
+    ChangeEvent changeEvent = changeEventWith(/* userName */ null);
+    EntityInterface entity = tableEntity();
+
+    repository.createFromChangeEvent(changeEvent, entity);
+
+    Counter counter =
+        meterRegistry
+            .find("activity_stream.unresolved_actor")
+            .tag("kind", "system_event")
+            .counter();
+    assertEquals(1.0, counter.count());
+  }
+
+  @Test
+  void buildActorReferenceCountsHardDeletedWhenUserNotFound() {
+    CollectionDAO.ActivityStreamDAO dao = mock(CollectionDAO.ActivityStreamDAO.class);
+    ActivityStreamRepository repository = new ActivityStreamRepository(dao);
+
+    ChangeEvent changeEvent = changeEventWith("ghost-user");
+    EntityInterface entity = tableEntity();
+
+    try (MockedStatic<Entity> entityMock = mockStatic(Entity.class)) {
+      entityMock
+          .when(() -> Entity.getEntityReferenceByName(Entity.USER, "ghost-user", Include.ALL))
+          .thenThrow(new EntityNotFoundException("ghost"));
+
+      repository.createFromChangeEvent(changeEvent, entity);
+    }
+
+    Counter counter =
+        meterRegistry
+            .find("activity_stream.unresolved_actor")
+            .tag("kind", "hard_deleted")
+            .counter();
+    assertEquals(1.0, counter.count());
+  }
+
+  private static ChangeEvent changeEventWith(String userName) {
+    return new ChangeEvent()
+        .withId(UUID.randomUUID())
+        .withEventType(EventType.ENTITY_CREATED)
+        .withEntityType(Entity.TABLE)
+        .withEntityId(UUID.randomUUID())
+        .withTimestamp(System.currentTimeMillis())
+        .withUserName(userName);
+  }
+
+  private static EntityInterface tableEntity() {
+    return new Table().withId(UUID.randomUUID()).withFullyQualifiedName("svc.db.schema.table");
+  }
 
   @Test
   void insertBindsNullActorIdWhenActorIsAbsent() {

--- a/openmetadata-service/src/test/java/org/openmetadata/service/jdbi3/ActivityStreamRepositoryTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/jdbi3/ActivityStreamRepositoryTest.java
@@ -1,0 +1,108 @@
+/*
+ *  Copyright 2024 Collate
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.openmetadata.service.jdbi3;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.anyLong;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.openmetadata.schema.entity.activity.ActivityEvent;
+import org.openmetadata.schema.type.ActivityEventType;
+import org.openmetadata.schema.type.EntityReference;
+import org.openmetadata.service.Entity;
+
+class ActivityStreamRepositoryTest {
+
+  @Test
+  void insertBindsNullActorIdWhenActorIsAbsent() {
+    CollectionDAO.ActivityStreamDAO dao = mock(CollectionDAO.ActivityStreamDAO.class);
+    ActivityStreamRepository repository = new ActivityStreamRepository(dao);
+
+    ActivityEvent event =
+        baseEvent()
+            // actor omitted entirely — null
+            .withActor(null);
+
+    assertDoesNotThrow(() -> repository.insert(event));
+
+    verify(dao)
+        .insert(
+            eq(event.getId().toString()),
+            eq(ActivityEventType.ENTITY_CREATED.value()),
+            any(),
+            any(),
+            any(),
+            any(),
+            any(),
+            isNull(), // actorId
+            isNull(), // actorName
+            anyLong(),
+            any(),
+            any(),
+            any(),
+            any(),
+            any(),
+            any());
+  }
+
+  @Test
+  void insertBindsNullActorIdButPreservesActorNameWhenIdMissing() {
+    CollectionDAO.ActivityStreamDAO dao = mock(CollectionDAO.ActivityStreamDAO.class);
+    ActivityStreamRepository repository = new ActivityStreamRepository(dao);
+
+    // Hard-deleted-user shape: actor reference carries the userName but no id.
+    ActivityEvent event =
+        baseEvent().withActor(new EntityReference().withType(Entity.USER).withName("ghost-user"));
+
+    assertDoesNotThrow(() -> repository.insert(event));
+
+    verify(dao)
+        .insert(
+            eq(event.getId().toString()),
+            eq(ActivityEventType.ENTITY_CREATED.value()),
+            any(),
+            any(),
+            any(),
+            any(),
+            any(),
+            isNull(), // actorId
+            eq("ghost-user"), // actorName preserved
+            anyLong(),
+            any(),
+            any(),
+            any(),
+            any(),
+            any(),
+            any());
+  }
+
+  private ActivityEvent baseEvent() {
+    EntityReference entityRef =
+        new EntityReference()
+            .withId(UUID.randomUUID())
+            .withType(Entity.TABLE)
+            .withFullyQualifiedName("svc.db.schema.table");
+    return new ActivityEvent()
+        .withId(UUID.randomUUID())
+        .withEventType(ActivityEventType.ENTITY_CREATED)
+        .withEntity(entityRef)
+        .withTimestamp(System.currentTimeMillis());
+  }
+}

--- a/openmetadata-service/src/test/java/org/openmetadata/service/util/FullyQualifiedNameTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/util/FullyQualifiedNameTest.java
@@ -71,6 +71,28 @@ class FullyQualifiedNameTest {
   }
 
   @Test
+  void test_buildHash_rejectsEntityLink() {
+    // Plain FQNs (including quoted-dot names) are hashed as before.
+    assertEquals(
+        FullyQualifiedName.buildHash("svc.db.schema.table"),
+        FullyQualifiedName.buildHash("svc.db.schema.table"));
+    // Should not throw — quoted-dot FQN is a valid FQN.
+    FullyQualifiedName.buildHash("\"a.1\".b.c");
+
+    // EntityLink-shaped input is rejected fast with a clear message,
+    // rather than bailing inside the ANTLR parser with a null message.
+    IllegalArgumentException ex =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> FullyQualifiedName.buildHash("<#E::table::svc.db.s.t::description>"));
+    assertTrue(ex.getMessage().contains("EntityLink"));
+    assertTrue(ex.getMessage().contains("MessageParser"));
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> FullyQualifiedName.buildHash("<#E::table::\"PW%domain.x\">"));
+  }
+
+  @Test
   void test_getParentFQN() {
     assertEquals("a.b.c", FullyQualifiedName.getParentFQN("a.b.c.d"));
     assertEquals("\"a.b\"", FullyQualifiedName.getParentFQN("\"a.b\".c"));

--- a/openmetadata-spec/src/main/resources/json/schema/entity/activity/activityEvent.json
+++ b/openmetadata-spec/src/main/resources/json/schema/entity/activity/activityEvent.json
@@ -52,7 +52,7 @@
       "$ref": "../../type/entityReferenceList.json"
     },
     "actor": {
-      "description": "User or bot who performed the action.",
+      "description": "User or bot who performed the action. May be absent for system events or hard-deleted users.",
       "$ref": "../../type/entityReference.json"
     },
     "timestamp": {
@@ -88,6 +88,6 @@
       "$ref": "../../type/reaction.json#/definitions/reactionList"
     }
   },
-  "required": ["id", "eventType", "entity", "actor", "timestamp"],
+  "required": ["id", "eventType", "entity", "timestamp"],
   "additionalProperties": false
 }

--- a/openmetadata-ui/src/main/resources/ui/src/generated/entity/activity/activityEvent.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/entity/activity/activityEvent.ts
@@ -22,9 +22,10 @@ export interface ActivityEvent {
      */
     about?: string;
     /**
-     * User or bot who performed the action.
+     * User or bot who performed the action. May be absent for system events or hard-deleted
+     * users.
      */
-    actor: EntityReference;
+    actor?: EntityReference;
     /**
      * Optional structured change description with field-level details.
      */
@@ -73,7 +74,8 @@ export interface ActivityEvent {
 }
 
 /**
- * User or bot who performed the action.
+ * User or bot who performed the action. May be absent for system events or hard-deleted
+ * users.
  *
  * This schema defines the EntityReference type used for referencing an entity.
  * EntityReference is used for capturing relationships from one entity to another. For


### PR DESCRIPTION
Fixes #28540

## Summary

- **Bug 1** — `aboutFqnHash` was hashed from the raw EntityLink (`<#E::…>`) instead of the entity FQN; the ANTLR FQN parser bailed on quoted-dot names. Parse the EntityLink first, hash only the FQN portion. Same misuse fixed in `MigrationUtil.v200`; added a defensive guard in `buildHash` itself.
- **Bug 2** — `buildActorReference` returned id-less `EntityReference`s for system events and hard-deleted users; `insert()` NPE'd on `getActor().getId().toString()`. Relaxed `actorId NOT NULL`, made `actor` optional in the schema, switched to `Include.ALL` so soft-deleted users still resolve with their real id, null-safe the insert. UI already falls back to `actorName` when actor.id is absent.
- **Observability** — `activity_stream.unresolved_actor{kind=system_event|hard_deleted}` Micrometer counter on the global registry (wired to Prometheus). Spikes are now alertable; previously the case was entirely silent.
- **Regression guards** — `ActivityStreamPublisherIT` exercises both fixes via PATCH → poll → assert against the live worker pipeline. Unit tests cover the `buildHash` guard, EntityLink parse, `insert()` null-safety, and counter increments.

## Test plan

- [x] **Unit tests — 27/27 pass.** `mvn -pl openmetadata-service test -Dtest=FullyQualifiedNameTest,MessageParserTest,ActivityStreamPublisherTest,ActivityStreamRepositoryTest`.
- [x] **Integration tests — 2/2 pass in ~30s.** `ActivityStreamPublisherIT` end-to-end against a freshly-rebuilt local stack.
- [x] **Manual reproduction of both bugs on a fresh DB.** Dotted-name domain creates and lands its activity_stream row; deleted-actor PATCH lands with `actorId=NULL` + `actorName` preserved. Zero NPE / `ParseCancellationException` across 770 events processed during verification.
- [x] CI's `ActivityAPI.spec.ts` (currently times out from queue backlog) passes within budget.
