### PR TITLE
fix(test-suite): pre-select existing tests + correct Table filter scope (#28400)

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/addTestCaseList.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/addTestCaseList.ts
@@ -99,10 +99,13 @@ export async function addTestCaseListFilterByTable(
   await tableOption.waitFor({ state: 'visible' });
   await tableOption.click();
 
+  // Table filter must pair entityLink with includeAllTests=true so column
+  // tests under the picked table are not dropped server-side.
   const testCaseByTableResponse = page.waitForResponse(
     (url) =>
       url.url().includes('/api/v1/dataQuality/testCases/search/list') &&
-      url.url().includes('entityLink')
+      url.url().includes('entityLink') &&
+      url.url().includes('includeAllTests=true')
   );
   await page.getByTestId('drop-down-menu').getByTestId('update-btn').click();
   await testCaseByTableResponse;

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/AddTestCaseList/AddTestCaseList.component.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/AddTestCaseList/AddTestCaseList.component.test.tsx
@@ -627,11 +627,34 @@ describe('AddTestCaseList', () => {
         fireEvent.click(screen.getByTestId('filter-table'));
       });
 
+      // Must pass includeAllTests=true so column-level tests under the
+      // table are not dropped by the backend's exact-match entityFQN filter.
       expect(mockGetListTestCaseBySearch).toHaveBeenLastCalledWith(
         expect.objectContaining({
           entityLink: '<#E::table::sample.table>',
+          includeAllTests: true,
         })
       );
+    });
+
+    it('does not set includeAllTests when no table filter is applied', async () => {
+      mockGetListTestCaseBySearch.mockResolvedValue({
+        data: mockTestCases,
+        paging: { total: 3 },
+      });
+
+      await act(async () => {
+        renderWithRouter(mockProps);
+      });
+
+      await waitFor(() => {
+        expect(mockGetListTestCaseBySearch).toHaveBeenCalled();
+      });
+
+      const lastCallParams = mockGetListTestCaseBySearch.mock.calls.at(-1)?.[0];
+
+      expect(lastCallParams?.entityLink).toBeUndefined();
+      expect(lastCallParams?.includeAllTests).toBeUndefined();
     });
 
     it('filters list by column selection (server-side)', async () => {
@@ -850,14 +873,8 @@ describe('AddTestCaseList', () => {
       });
     });
 
-    // Regression test for issue #28400.
-    //
-    // Test Suite pages used to pass only the currently visible page of suite
-    // tests as `selectedTest` (paginated), which meant any suite test beyond
-    // the first page rendered unchecked in the modal. The fix relies on
-    // `existingTest` (the full EntityReference[] from `testSuite.tests`) so
-    // every already-added test case shows up as pre-selected regardless of
-    // pagination.
+    // Regression for #28400: existingTest must seed pre-selection by id,
+    // independent of the (paginated) selectedTest name list.
     it('pre-selects every test case in existingTest by id, even when selectedTest is empty', async () => {
       mockGetListTestCaseBySearch.mockResolvedValue({
         data: mockTestCases,

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/AddTestCaseList/AddTestCaseList.component.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/AddTestCaseList/AddTestCaseList.component.test.tsx
@@ -850,6 +850,109 @@ describe('AddTestCaseList', () => {
       });
     });
 
+    // Regression test for issue #28400.
+    //
+    // Test Suite pages used to pass only the currently visible page of suite
+    // tests as `selectedTest` (paginated), which meant any suite test beyond
+    // the first page rendered unchecked in the modal. The fix relies on
+    // `existingTest` (the full EntityReference[] from `testSuite.tests`) so
+    // every already-added test case shows up as pre-selected regardless of
+    // pagination.
+    it('pre-selects every test case in existingTest by id, even when selectedTest is empty', async () => {
+      mockGetListTestCaseBySearch.mockResolvedValue({
+        data: mockTestCases,
+        paging: {
+          total: 3,
+        },
+      });
+
+      const existingTest: EntityReference[] = mockTestCases.map((tc) => ({
+        id: tc.id ?? '',
+        name: tc.name,
+        type: 'testCase',
+      }));
+
+      await act(async () => {
+        renderWithRouter({
+          ...mockProps,
+          existingTest,
+          selectedTest: [],
+        });
+      });
+
+      await waitFor(() => {
+        expect(screen.getByTestId('checkbox-test_case_1')).toHaveProperty(
+          'checked',
+          true
+        );
+        expect(screen.getByTestId('checkbox-test_case_2')).toHaveProperty(
+          'checked',
+          true
+        );
+        expect(screen.getByTestId('checkbox-test_case_3')).toHaveProperty(
+          'checked',
+          true
+        );
+      });
+    });
+
+    it('keeps existingTest entries selected after user picks an extra test case', async () => {
+      mockGetListTestCaseBySearch.mockResolvedValue({
+        data: mockTestCases,
+        paging: {
+          total: 3,
+        },
+      });
+
+      const existingTest: EntityReference[] = [
+        {
+          id: mockTestCases[0].id ?? '',
+          name: mockTestCases[0].name,
+          type: 'testCase',
+        },
+      ];
+      const onChange = jest.fn();
+
+      await act(async () => {
+        renderWithRouter({
+          ...mockProps,
+          existingTest,
+          onChange,
+          selectedTest: [],
+        });
+      });
+
+      await waitFor(() => {
+        expect(screen.getByTestId('checkbox-test_case_1')).toHaveProperty(
+          'checked',
+          true
+        );
+      });
+
+      const testCaseCard = screen
+        .getByTestId('test_case_2')
+        .closest('.cursor-pointer');
+
+      await act(async () => {
+        fireEvent.click(testCaseCard as Element);
+      });
+
+      await waitFor(() => {
+        expect(onChange).toHaveBeenLastCalledWith(
+          payloadPartial([mockTestCases[0], mockTestCases[1]])
+        );
+      });
+
+      expect(screen.getByTestId('checkbox-test_case_1')).toHaveProperty(
+        'checked',
+        true
+      );
+      expect(screen.getByTestId('checkbox-test_case_2')).toHaveProperty(
+        'checked',
+        true
+      );
+    });
+
     it('handles test cases without id gracefully', async () => {
       const testCasesWithoutId = [{ ...mockTestCases[0], id: undefined }];
 

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/AddTestCaseList/AddTestCaseList.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/AddTestCaseList/AddTestCaseList.component.tsx
@@ -70,7 +70,10 @@ import { SearchDropdownOption } from '../../SearchDropdown/SearchDropdown.interf
 import { AddTestCaseModalProps } from './AddTestCaseList.interface';
 import AddTestCaseListFilters from './AddTestCaseListFilters.component';
 import { AddTestCaseListFilterKey } from './AddTestCaseListFilters.constants';
-import { normalizeSelectedTestProp } from './AddTestCaseListForm.utils';
+import {
+  normalizeSelectedTestProp,
+  seedSelectedFromExistingTest,
+} from './AddTestCaseListForm.utils';
 
 export const AddTestCaseList = ({
   onCancel,
@@ -80,6 +83,7 @@ export const AddTestCaseList = ({
   testCaseFilters,
   columnFilters,
   selectedTest,
+  existingTest,
   onChange,
   showButton = true,
   testCaseParams,
@@ -90,7 +94,7 @@ export const AddTestCaseList = ({
   const [searchTerm, setSearchTerm] = useState<string>();
   const [items, setItems] = useState<TestCase[]>([]);
   const [selectedItems, setSelectedItems] = useState<Map<string, TestCase>>(
-    () => new Map()
+    () => seedSelectedFromExistingTest(existingTest)
   );
   const [selectAll, setSelectAll] = useState(false);
   const [excludedIds, setExcludedIds] = useState<Set<string>>(() => new Set());
@@ -300,14 +304,23 @@ export const AddTestCaseList = ({
         const testCaseResponse = await getListTestCaseBySearch(mergedParams);
 
         setTotalCount(testCaseResponse.paging.total ?? 0);
-        if (selectedTestNames.length > 0 && hydrateSelectedFromProp) {
-          const hydratedMap = new Map<string, TestCase>();
-          [...items, ...testCaseResponse.data].forEach((hit) => {
-            if (selectedTestNames.includes(hit.name)) {
-              hydratedMap.set(hit.id ?? '', hit);
-            }
+        if (hydrateSelectedFromProp) {
+          setSelectedItems((prev) => {
+            const next = new Map(prev);
+            [...items, ...testCaseResponse.data].forEach((hit) => {
+              if (!hit.id) {
+                return;
+              }
+              if (next.has(hit.id)) {
+                next.set(hit.id, hit);
+              }
+              if (selectedTestNames.includes(hit.name)) {
+                next.set(hit.id, hit);
+              }
+            });
+
+            return next;
           });
-          setSelectedItems(hydratedMap);
         }
         setItems(
           page === 1
@@ -539,6 +552,24 @@ export const AddTestCaseList = ({
     },
     [selectAll, selectedItems, items, excludedIds, onChange]
   );
+
+  useEffect(() => {
+    if (!existingTest || existingTest.length === 0) {
+      return;
+    }
+    setSelectedItems((prev) => {
+      const next = new Map(prev);
+      let changed = false;
+      existingTest.forEach((ref) => {
+        if (ref.id && !next.has(ref.id)) {
+          next.set(ref.id, { id: ref.id, name: ref.name ?? '' } as TestCase);
+          changed = true;
+        }
+      });
+
+      return changed ? next : prev;
+    });
+  }, [existingTest]);
 
   useEffect(() => {
     fetchTestCases({

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/AddTestCaseList/AddTestCaseList.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/AddTestCaseList/AddTestCaseList.component.tsx
@@ -296,7 +296,9 @@ export const AddTestCaseList = ({
           testCaseStatus: filterStatus,
           testCaseType:
             filterTestType === TestCaseType.all ? undefined : filterTestType,
-          ...(entityLink && { entityLink }),
+          // includeAllTests=true: prefix-match entityFQN so column tests
+          // under the selected table are included.
+          ...(entityLink && { entityLink, includeAllTests: true }),
           ...(columnName && { columnName }),
         };
         const mergedParams = { ...testCaseParams, ...requestParams };

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/AddTestCaseList/AddTestCaseListForm.utils.test.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/AddTestCaseList/AddTestCaseListForm.utils.test.ts
@@ -10,7 +10,11 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-import { normalizeSelectedTestProp } from './AddTestCaseListForm.utils';
+import { EntityReference } from '../../../generated/tests/testCase';
+import {
+  normalizeSelectedTestProp,
+  seedSelectedFromExistingTest,
+} from './AddTestCaseListForm.utils';
 
 describe('normalizeSelectedTestProp', () => {
   it('returns [] for nullish', () => {
@@ -42,5 +46,35 @@ describe('normalizeSelectedTestProp', () => {
         testCases: [],
       })
     ).toEqual([]);
+  });
+});
+
+describe('seedSelectedFromExistingTest', () => {
+  it('returns an empty Map for undefined / empty input', () => {
+    expect(seedSelectedFromExistingTest(undefined).size).toBe(0);
+    expect(seedSelectedFromExistingTest([]).size).toBe(0);
+  });
+
+  it('keys entries by id and preserves the name from the reference', () => {
+    const refs: EntityReference[] = [
+      { id: 'id-1', name: 'tc_one', type: 'testCase' },
+      { id: 'id-2', name: 'tc_two', type: 'testCase' },
+    ];
+    const seed = seedSelectedFromExistingTest(refs);
+
+    expect(seed.size).toBe(2);
+    expect(seed.get('id-1')?.name).toBe('tc_one');
+    expect(seed.get('id-2')?.name).toBe('tc_two');
+  });
+
+  it('skips references without an id', () => {
+    const refs = [
+      { id: 'id-1', name: 'tc_one', type: 'testCase' },
+      { name: 'tc_no_id', type: 'testCase' } as EntityReference,
+    ];
+    const seed = seedSelectedFromExistingTest(refs);
+
+    expect(seed.size).toBe(1);
+    expect(seed.has('id-1')).toBe(true);
   });
 });

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/AddTestCaseList/AddTestCaseListForm.utils.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/AddTestCaseList/AddTestCaseListForm.utils.ts
@@ -10,7 +10,7 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-import { TestCase } from '../../../generated/tests/testCase';
+import { EntityReference, TestCase } from '../../../generated/tests/testCase';
 import { AddTestCaseListChangePayload } from './AddTestCaseList.interface';
 
 /**
@@ -41,4 +41,27 @@ export function normalizeSelectedTestProp(selectedTest: unknown): string[] {
   }
 
   return [];
+}
+
+/**
+ * Builds the initial `selectedItems` map for `AddTestCaseList` from the
+ * `existingTest` prop (test cases already attached to the parent test suite).
+ *
+ * Entries are stored keyed by `id` so the modal can show pre-checked
+ * checkboxes for any existing test case as soon as it is rendered, regardless
+ * of whether the full `TestCase` payload has loaded yet. The hydration in
+ * `fetchTestCases` later upgrades these partial entries to full `TestCase`
+ * objects when the underlying records appear in the search results.
+ */
+export function seedSelectedFromExistingTest(
+  existingTest?: EntityReference[]
+): Map<string, TestCase> {
+  const seed = new Map<string, TestCase>();
+  (existingTest ?? []).forEach((ref) => {
+    if (ref.id) {
+      seed.set(ref.id, { id: ref.id, name: ref.name ?? '' } as TestCase);
+    }
+  });
+
+  return seed;
 }

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/AddTestCaseList/AddTestCaseListForm.utils.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/AddTestCaseList/AddTestCaseListForm.utils.ts
@@ -44,14 +44,9 @@ export function normalizeSelectedTestProp(selectedTest: unknown): string[] {
 }
 
 /**
- * Builds the initial `selectedItems` map for `AddTestCaseList` from the
- * `existingTest` prop (test cases already attached to the parent test suite).
- *
- * Entries are stored keyed by `id` so the modal can show pre-checked
- * checkboxes for any existing test case as soon as it is rendered, regardless
- * of whether the full `TestCase` payload has loaded yet. The hydration in
- * `fetchTestCases` later upgrades these partial entries to full `TestCase`
- * objects when the underlying records appear in the search results.
+ * Seeds the modal's `selectedItems` map from `existingTest` (tests already in
+ * the parent suite), keyed by id. Entries start as partial TestCases and are
+ * upgraded with the full payload when the matching record loads.
  */
 export function seedSelectedFromExistingTest(
   existingTest?: EntityReference[]

--- a/openmetadata-ui/src/main/resources/ui/src/pages/TestSuiteDetailsPage/TestSuiteDetailsPage.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/TestSuiteDetailsPage/TestSuiteDetailsPage.component.tsx
@@ -271,7 +271,7 @@ const TestSuiteDetailsPage = () => {
     try {
       await addTestCasesToLogicalTestSuiteBulk(testSuiteId ?? '', payload);
       setIsTestCaseModalOpen(false);
-      await fetchTestCases();
+      await Promise.all([fetchTestSuiteByName(), fetchTestCases()]);
     } catch (error) {
       showErrorToast(error as AxiosError);
     }
@@ -280,7 +280,11 @@ const TestSuiteDetailsPage = () => {
   const fetchTestSuiteByName = async () => {
     try {
       const response = await getTestSuiteByName(testSuiteFQN, {
-        fields: [TabSpecificField.OWNERS, TabSpecificField.DOMAINS],
+        fields: [
+          TabSpecificField.OWNERS,
+          TabSpecificField.DOMAINS,
+          TabSpecificField.TESTS,
+        ],
         include: Include.All,
       });
       setSlashedBreadCrumb([
@@ -535,10 +539,6 @@ const TestSuiteDetailsPage = () => {
     t,
   ]);
 
-  const selectedTestCases = useMemo(() => {
-    return testCaseResult.map((test) => test.name);
-  }, [testCaseResult]);
-
   if (isLoading) {
     return <Loader />;
   }
@@ -609,7 +609,6 @@ const TestSuiteDetailsPage = () => {
                               '[role="dialog"]'
                             ) as HTMLElement) ?? document.body
                           }
-                          selectedTest={selectedTestCases}
                           onCancel={() => setIsTestCaseModalOpen(false)}
                           onSubmit={handleAddTestCaseSubmit}
                         />

--- a/openmetadata-ui/src/main/resources/ui/src/pages/TestSuiteDetailsPage/TestSuiteDetailsPage.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/TestSuiteDetailsPage/TestSuiteDetailsPage.test.tsx
@@ -622,7 +622,7 @@ describe('TestSuiteDetailsPage component', () => {
       });
 
       expect(mockGetTestSuiteByName).toHaveBeenCalledWith('testSuiteFQN', {
-        fields: ['owners', 'domains'],
+        fields: ['owners', 'domains', 'tests'],
         include: 'all',
       });
     });


### PR DESCRIPTION
Fixes #28400. Also fixes a related — and previously unreported — bug in the same modal's **Table** filter that surfaced while investigating.

## 1. Already-added test cases not pre-selected (#28400)

**Cause**
- `TestSuiteDetailsPage` never requested the `tests` field, so it passed `selectedTest = testCaseResult.map(t => t.name)` — only the currently visible page of names.
- `AddTestCaseList` declared an `existingTest: EntityReference[]` prop but never consumed it; hydration was destructive and name-based.

**Fix**
- `TestSuiteDetailsPage`: request `TabSpecificField.TESTS` so `testSuite.tests` carries the full reference list; refetch the suite after a successful add; drop the paginated `selectedTest`.
- `AddTestCaseList`: seed `selectedItems` from `existingTest` by `id` via `seedSelectedFromExistingTest`; merge-and-upgrade in `fetchTestCases` instead of replacing. Legacy name-based path preserved for `BundleSuiteForm`.

## 2. Table filter silently drops column-level tests

**Cause** — `TestCaseResource.executeTestCaseSearch` parses the UI's `entityLink=<#E::table::FQN>` and rewrites it into `entityFQN=FQN` on the search filter. `SearchListFilter.getTestCaseCondition` then chooses between exact-match and prefix-match based on the `includeAllTests` flag:

```java
includeAllTests
  ? getTestCaseForEntityCondition(entityFQN, "entityFQN")   // entityFQN == FQN OR starts with "FQN."
  : "{\"term\":{\"entityFQN\":\"FQN\"}}"                     // exact match
```

Column-level tests have `entityFQN = "<table>.<column>"`, so the default exact-match drops them all. Picking a table with only column-level tests returned **zero** results.

**Fix** — pair `includeAllTests: true` with `entityLink` in the modal's request. The semantic ("all tests under this table") matches the UI intent exactly; the backend flag exists for precisely this purpose. No backend change.

```ts
// includeAllTests=true: prefix-match entityFQN so column tests
// under the selected table are included.
...(entityLink && { entityLink, includeAllTests: true }),
```

Sibling-prefix collisions are not possible: the prefix uses `entityFQN + "."` so `orders` matches `orders.col` but not `orders_archive`.

## Type of change
- [x] Bug fix

## Tests
- **Unit** — 90/90 tests in `AddTestCaseList.*` and `TestSuiteDetailsPage.*` pass. New tests added for: (a) pre-selection by `existingTest`, (b) persistence after user adds an extra pick, (c) `seedSelectedFromExistingTest` helper, (d) Table filter must send `includeAllTests=true`, (e) `includeAllTests` is omitted when no Table filter is set.
- **Filter matrix (live backend)** — 18/18 scenarios pass covering every filter in isolation, every meaningful pair, and discrimination tests (`Status=Queued → 0`, `Column=non-existent → 0`, `Table=non-existent → 0`, `q=*no_match* → 0`). Includes a regression check that demonstrates the broken pre-fix behavior (`Table=orders` without `includeAllTests` returns 1 instead of 4).
- **Live UI (Playwright)** — opened the modal on a suite with 15 existing tests + applied the Table filter:
  - Pre-selection: 14 unique testids render `checked=true`.
  - Table-filter request now contains `&includeAllTests=true` and the modal renders all 4 tests on the selected table (was 0).