### PR TITLE
fix(search): scrub stale flattened-children highlight field on v1130 upgrade (#1B container search 500)

### DIFF
--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/FlattenedChildrenHighlightSearchIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/FlattenedChildrenHighlightSearchIT.java
@@ -1,0 +1,218 @@
+/*
+ *  Copyright 2024 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.openmetadata.it.tests;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.net.URI;
+import java.net.URLEncoder;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import lombok.extern.slf4j.Slf4j;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.parallel.Isolated;
+import org.openmetadata.it.factories.StorageServiceTestFactory;
+import org.openmetadata.it.util.SdkClients;
+import org.openmetadata.it.util.TestNamespace;
+import org.openmetadata.it.util.TestNamespaceExtension;
+import org.openmetadata.schema.api.data.CreateContainer;
+import org.openmetadata.schema.api.search.AssetTypeConfiguration;
+import org.openmetadata.schema.api.search.SearchSettings;
+import org.openmetadata.schema.entity.data.Container;
+import org.openmetadata.schema.entity.services.StorageService;
+import org.openmetadata.schema.settings.Settings;
+import org.openmetadata.schema.settings.SettingsType;
+import org.openmetadata.schema.type.Column;
+import org.openmetadata.schema.type.ColumnDataType;
+import org.openmetadata.schema.type.ContainerDataModel;
+import org.openmetadata.schema.utils.JsonUtils;
+import org.openmetadata.sdk.client.OpenMetadataClient;
+import org.openmetadata.service.migration.utils.v1130.MigrationUtil;
+import org.openmetadata.service.resources.settings.SettingsCache;
+
+/**
+ * End-to-end reproduction of the container search 500 ("Field
+ * [dataModel.columns.children.name] has no associated analyzer") that surfaces on OpenSearch after
+ * an upgrade carries the stale highlight field forward in the DB-stored SearchSettings, and proof
+ * that the v1130 scrub migration ({@link MigrationUtil#removeFlattenedChildrenHighlightFields()})
+ * resolves it.
+ *
+ * <p>OpenSearch only: Elasticsearch silently degrades the bad highlight to an HTTP 200, so the test
+ * is skipped unless the suite runs with {@code -DsearchType=opensearch}. It mutates the global
+ * SearchSettings, so it is marked {@link Isolated}.
+ */
+@Slf4j
+@Isolated
+@ExtendWith(TestNamespaceExtension.class)
+public class FlattenedChildrenHighlightSearchIT {
+
+  private static final String STALE_HIGHLIGHT_FIELD = "dataModel.columns.children.name";
+  private static final String CONTAINER_ASSET_TYPE = "container";
+  private static final HttpClient HTTP_CLIENT =
+      HttpClient.newBuilder().connectTimeout(Duration.ofSeconds(10)).build();
+
+  @Test
+  void containerHighlight500IsReproducedAndFixedByScrub(TestNamespace ns) throws Exception {
+    Assumptions.assumeTrue(
+        "opensearch".equalsIgnoreCase(System.getProperty("searchType", "elasticsearch")),
+        "Highlight analyzer 500 only manifests on OpenSearch");
+
+    OpenMetadataClient client = SdkClients.adminClient();
+    String originalSettings = getSearchSettingsJson();
+    String token = ns.prefix("reprohl").replaceAll("[^a-zA-Z0-9]", "").toLowerCase();
+    // Hyphenated term forces the query_string parse path (like the incident's pw\-container\-...),
+    // where per-field match attribution breaks down and the highlighter attempts every configured
+    // highlight field - including the flattened children field.
+    String searchTerm = "repro-hl-" + token;
+
+    try {
+      StorageService service = StorageServiceTestFactory.createS3(ns);
+      Column childColumn =
+          new Column().withName("child_" + token).withDataType(ColumnDataType.STRING);
+      Column structColumn =
+          new Column()
+              .withName("col1")
+              .withDataType(ColumnDataType.STRUCT)
+              .withChildren(List.of(childColumn));
+      ContainerDataModel dataModel = new ContainerDataModel().withColumns(List.of(structColumn));
+      CreateContainer request = new CreateContainer();
+      request.setName(ns.prefix("repro-container"));
+      request.setService(service.getFullyQualifiedName());
+      request.setDescription(searchTerm);
+      request.setDataModel(dataModel);
+      Container container = client.containers().create(request);
+      log.info("Created container {} for highlight repro", container.getId());
+
+      awaitContainerSearchable(searchTerm);
+
+      injectStaleContainerHighlightField();
+
+      HttpResponse<String> poisoned = searchContainers(searchTerm);
+      log.info(
+          "Poisoned container search -> status={} body={}",
+          poisoned.statusCode(),
+          truncate(poisoned.body()));
+      assertEquals(
+          500,
+          poisoned.statusCode(),
+          "With the stale flattened-children highlight field, OpenSearch must fail the search");
+      assertTrue(
+          poisoned.body().contains("analyzer") || poisoned.body().contains("all shards failed"),
+          "500 must be the 'no associated analyzer' shard failure, body="
+              + truncate(poisoned.body()));
+
+      MigrationUtil.removeFlattenedChildrenHighlightFields();
+      SettingsCache.invalidateSettings(SettingsType.SEARCH_SETTINGS.value());
+
+      HttpResponse<String> healed = searchContainers(searchTerm);
+      log.info("Post-scrub container search -> status={}", healed.statusCode());
+      assertEquals(
+          200,
+          healed.statusCode(),
+          "After the v1130 scrub removes the stale highlight field, the search must succeed");
+      assertTrue(
+          healed.body().contains(token), "Healed search should still return the indexed container");
+    } finally {
+      restoreSearchSettings(originalSettings);
+    }
+  }
+
+  private void injectStaleContainerHighlightField() throws Exception {
+    Settings settings = JsonUtils.readValue(getSearchSettingsJson(), Settings.class);
+    SearchSettings config = JsonUtils.convertValue(settings.getConfigValue(), SearchSettings.class);
+    for (AssetTypeConfiguration assetConfig : config.getAssetTypeConfigurations()) {
+      if (CONTAINER_ASSET_TYPE.equalsIgnoreCase(assetConfig.getAssetType())
+          && !assetConfig.getHighlightFields().contains(STALE_HIGHLIGHT_FIELD)) {
+        assetConfig.getHighlightFields().add(STALE_HIGHLIGHT_FIELD);
+      }
+    }
+    settings.setConfigValue(config);
+    putSearchSettings(JsonUtils.pojoToJson(settings));
+  }
+
+  private void awaitContainerSearchable(String token) {
+    Awaitility.await("container indexed in search")
+        .atMost(180, TimeUnit.SECONDS)
+        .pollInterval(1, TimeUnit.SECONDS)
+        .ignoreExceptions()
+        .untilAsserted(
+            () -> {
+              HttpResponse<String> response = searchContainers(token);
+              assertEquals(200, response.statusCode());
+              assertTrue(response.body().contains(token));
+            });
+  }
+
+  private HttpResponse<String> searchContainers(String token) throws Exception {
+    String path =
+        "/v1/search/query?q="
+            + URLEncoder.encode(token, StandardCharsets.UTF_8)
+            + "&index="
+            + CONTAINER_ASSET_TYPE
+            + "&from=0&size=10&deleted=false";
+    return httpGet(path, "application/json");
+  }
+
+  private String getSearchSettingsJson() throws Exception {
+    return httpGet(
+            "/v1/system/settings/" + SettingsType.SEARCH_SETTINGS.value(), "application/json")
+        .body();
+  }
+
+  private void putSearchSettings(String body) throws Exception {
+    HttpRequest request =
+        baseRequest("/v1/system/settings", "application/json")
+            .PUT(HttpRequest.BodyPublishers.ofString(body))
+            .build();
+    HttpResponse<String> response = HTTP_CLIENT.send(request, HttpResponse.BodyHandlers.ofString());
+    assertTrue(
+        response.statusCode() >= 200 && response.statusCode() < 300,
+        "Settings PUT should succeed, status=" + response.statusCode());
+  }
+
+  private void restoreSearchSettings(String originalSettings) throws Exception {
+    putSearchSettings(originalSettings);
+    SettingsCache.invalidateSettings(SettingsType.SEARCH_SETTINGS.value());
+  }
+
+  private HttpResponse<String> httpGet(String path, String accept) throws Exception {
+    HttpRequest request = baseRequest(path, accept).GET().build();
+    return HTTP_CLIENT.send(request, HttpResponse.BodyHandlers.ofString());
+  }
+
+  private HttpRequest.Builder baseRequest(String path, String accept) {
+    return HttpRequest.newBuilder()
+        .uri(URI.create(SdkClients.getServerUrl() + path))
+        .header("Authorization", "Bearer " + SdkClients.getAdminToken())
+        .header("Content-Type", "application/json")
+        .header("Accept", accept)
+        .timeout(Duration.ofSeconds(30));
+  }
+
+  private static String truncate(String body) {
+    String result = body;
+    if (body != null && body.length() > 400) {
+      result = body.substring(0, 400);
+    }
+    return result;
+  }
+}

--- a/openmetadata-service/src/main/java/org/openmetadata/service/migration/mysql/v1130/Migration.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/migration/mysql/v1130/Migration.java
@@ -35,6 +35,7 @@ public class Migration extends MigrationProcessImpl {
       LOG.error("v1130 glossaryTerm version relatedTerms transform failed; re-run to retry.", e);
     }
     MigrationUtil.addTableColumnSearchSettings();
+    MigrationUtil.removeFlattenedChildrenHighlightFields();
     addTriggerOperationToDefaultBotPolicies(collectionDAO);
     addTriggerRuleToDataStewardPolicy(collectionDAO);
     try {

--- a/openmetadata-service/src/main/java/org/openmetadata/service/migration/postgres/v1130/Migration.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/migration/postgres/v1130/Migration.java
@@ -35,6 +35,7 @@ public class Migration extends MigrationProcessImpl {
       LOG.error("v1130 glossaryTerm version relatedTerms transform failed; re-run to retry.", e);
     }
     MigrationUtil.addTableColumnSearchSettings();
+    MigrationUtil.removeFlattenedChildrenHighlightFields();
     addTriggerOperationToDefaultBotPolicies(collectionDAO);
     addTriggerRuleToDataStewardPolicy(collectionDAO);
     try {

--- a/openmetadata-service/src/main/java/org/openmetadata/service/migration/utils/v1130/MigrationUtil.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/migration/utils/v1130/MigrationUtil.java
@@ -342,48 +342,6 @@ public class MigrationUtil {
    * <p>Idempotent: each helper returns false when the entry is already present, and the DB write
    * is skipped if neither addition was needed. Safe to call on every reprocessing pass.
    */
-  public static void removeFlattenedChildrenHighlightFields() {
-    try {
-      Settings searchSettings = SearchSettingsMergeUtil.getSearchSettingsFromDatabase();
-      if (searchSettings == null) {
-        LOG.warn(
-            "Search settings not found in database; skipping flattened-children highlight scrub");
-        return;
-      }
-      SearchSettings currentSettings = SearchSettingsMergeUtil.loadSearchSettings(searchSettings);
-      if (stripFlattenedChildrenHighlightFields(currentSettings)) {
-        SearchSettingsMergeUtil.saveSearchSettings(searchSettings, currentSettings);
-        LOG.info("Removed stale flattened children highlight fields from search settings");
-      } else {
-        LOG.info("No stale flattened children highlight fields found in search settings");
-      }
-    } catch (Exception e) {
-      LOG.error("Error removing stale flattened children highlight fields from search settings", e);
-    }
-  }
-
-  public static boolean stripFlattenedChildrenHighlightFields(SearchSettings settings) {
-    boolean changed = false;
-    if (settings != null) {
-      if (settings.getGlobalSettings() != null) {
-        changed = removeStaleHighlightFields(settings.getGlobalSettings().getHighlightFields());
-      }
-      for (AssetTypeConfiguration assetConfig :
-          listOrEmpty(settings.getAssetTypeConfigurations())) {
-        changed |= removeStaleHighlightFields(assetConfig.getHighlightFields());
-      }
-    }
-    return changed;
-  }
-
-  private static boolean removeStaleHighlightFields(List<String> highlightFields) {
-    boolean removed = false;
-    if (!nullOrEmpty(highlightFields)) {
-      removed = highlightFields.removeIf(STALE_FLATTENED_CHILDREN_HIGHLIGHT_FIELDS::contains);
-    }
-    return removed;
-  }
-
   public static void addTableColumnSearchSettings() {
     try {
       LOG.info("Adding tableColumn search settings configuration for column search support");
@@ -425,6 +383,56 @@ public class MigrationUtil {
       // so the migration step doesn't abort the rest of v1130's reprocessing.
       LOG.error("Error adding tableColumn search settings", e);
     }
+  }
+
+  /**
+   * Removes the stale {@code dataModel.columns.children.name} highlight field from the DB-stored
+   * SearchSettings on upgraded clusters. PR #28214 flattened container
+   * {@code dataModel.columns.children} and dropped that entry from the searchSettings.json seed,
+   * but the additive settings merge preserves a cluster's stored config, so the now-unhighlightable
+   * field survives and breaks container search on OpenSearch ("no associated analyzer"). Idempotent;
+   * safe to call on every reprocessing pass.
+   */
+  public static void removeFlattenedChildrenHighlightFields() {
+    try {
+      Settings searchSettings = SearchSettingsMergeUtil.getSearchSettingsFromDatabase();
+      if (searchSettings == null) {
+        LOG.warn(
+            "Search settings not found in database; skipping flattened-children highlight scrub");
+        return;
+      }
+      SearchSettings currentSettings = SearchSettingsMergeUtil.loadSearchSettings(searchSettings);
+      if (stripFlattenedChildrenHighlightFields(currentSettings)) {
+        SearchSettingsMergeUtil.saveSearchSettings(searchSettings, currentSettings);
+        LOG.info("Removed stale flattened children highlight fields from search settings");
+      } else {
+        LOG.info("No stale flattened children highlight fields found in search settings");
+      }
+    } catch (Exception e) {
+      LOG.error("Error removing stale flattened children highlight fields from search settings", e);
+    }
+  }
+
+  public static boolean stripFlattenedChildrenHighlightFields(SearchSettings settings) {
+    boolean changed = false;
+    if (settings != null) {
+      if (settings.getGlobalSettings() != null) {
+        changed = removeStaleHighlightFields(settings.getGlobalSettings().getHighlightFields());
+      }
+      for (AssetTypeConfiguration assetConfig :
+          listOrEmpty(settings.getAssetTypeConfigurations())) {
+        changed |= removeStaleHighlightFields(assetConfig.getHighlightFields());
+      }
+    }
+    return changed;
+  }
+
+  private static boolean removeStaleHighlightFields(List<String> highlightFields) {
+    boolean removed = false;
+    if (!nullOrEmpty(highlightFields)) {
+      removed = highlightFields.removeIf(STALE_FLATTENED_CHILDREN_HIGHLIGHT_FIELDS::contains);
+    }
+    return removed;
   }
 
   // Entity tables that v1125 attempted to drain of inline certification into tag_usage.

--- a/openmetadata-service/src/main/java/org/openmetadata/service/migration/utils/v1130/MigrationUtil.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/migration/utils/v1130/MigrationUtil.java
@@ -1,5 +1,6 @@
 package org.openmetadata.service.migration.utils.v1130;
 
+import static org.openmetadata.common.utils.CommonUtil.listOrEmpty;
 import static org.openmetadata.common.utils.CommonUtil.nullOrEmpty;
 
 import com.fasterxml.jackson.databind.JsonNode;
@@ -9,9 +10,11 @@ import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import lombok.extern.slf4j.Slf4j;
 import org.jdbi.v3.core.Handle;
 import org.jdbi.v3.core.statement.PreparedBatch;
+import org.openmetadata.schema.api.search.AssetTypeConfiguration;
 import org.openmetadata.schema.api.search.SearchSettings;
 import org.openmetadata.schema.dataInsight.custom.DataInsightCustomChart;
 import org.openmetadata.schema.entity.events.SubscriptionDestination;
@@ -36,6 +39,14 @@ public class MigrationUtil {
   private static final String OLD_FIELD = "owners.name.keyword";
   private static final String NEW_FIELD = "ownerName";
   private static final String TABLE_COLUMN_ASSET_TYPE = "tableColumn";
+
+  // Highlight fields dropped from the searchSettings.json seed when the underlying mapping field
+  // was converted to flattened (PR #28214 flattened container dataModel.columns.children). On
+  // OpenSearch, highlighting a flattened field throws "no associated analyzer", failing the search.
+  // Upgraded clusters keep their stored asset config wholesale, so the seed fix never reaches them;
+  // this scrub removes exactly the seed-removed entries from the DB-stored settings.
+  private static final Set<String> STALE_FLATTENED_CHILDREN_HIGHLIGHT_FIELDS =
+      Set.of("dataModel.columns.children.name");
 
   public static void updateOwnerChartFormulas() {
     DataInsightSystemChartRepository repository = new DataInsightSystemChartRepository();
@@ -331,6 +342,48 @@ public class MigrationUtil {
    * <p>Idempotent: each helper returns false when the entry is already present, and the DB write
    * is skipped if neither addition was needed. Safe to call on every reprocessing pass.
    */
+  public static void removeFlattenedChildrenHighlightFields() {
+    try {
+      Settings searchSettings = SearchSettingsMergeUtil.getSearchSettingsFromDatabase();
+      if (searchSettings == null) {
+        LOG.warn(
+            "Search settings not found in database; skipping flattened-children highlight scrub");
+        return;
+      }
+      SearchSettings currentSettings = SearchSettingsMergeUtil.loadSearchSettings(searchSettings);
+      if (stripFlattenedChildrenHighlightFields(currentSettings)) {
+        SearchSettingsMergeUtil.saveSearchSettings(searchSettings, currentSettings);
+        LOG.info("Removed stale flattened children highlight fields from search settings");
+      } else {
+        LOG.info("No stale flattened children highlight fields found in search settings");
+      }
+    } catch (Exception e) {
+      LOG.error("Error removing stale flattened children highlight fields from search settings", e);
+    }
+  }
+
+  public static boolean stripFlattenedChildrenHighlightFields(SearchSettings settings) {
+    boolean changed = false;
+    if (settings != null) {
+      if (settings.getGlobalSettings() != null) {
+        changed = removeStaleHighlightFields(settings.getGlobalSettings().getHighlightFields());
+      }
+      for (AssetTypeConfiguration assetConfig :
+          listOrEmpty(settings.getAssetTypeConfigurations())) {
+        changed |= removeStaleHighlightFields(assetConfig.getHighlightFields());
+      }
+    }
+    return changed;
+  }
+
+  private static boolean removeStaleHighlightFields(List<String> highlightFields) {
+    boolean removed = false;
+    if (!nullOrEmpty(highlightFields)) {
+      removed = highlightFields.removeIf(STALE_FLATTENED_CHILDREN_HIGHLIGHT_FIELDS::contains);
+    }
+    return removed;
+  }
+
   public static void addTableColumnSearchSettings() {
     try {
       LOG.info("Adding tableColumn search settings configuration for column search support");

--- a/openmetadata-service/src/test/java/org/openmetadata/service/migration/utils/v1130/FlattenedChildrenHighlightScrubTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/migration/utils/v1130/FlattenedChildrenHighlightScrubTest.java
@@ -1,0 +1,123 @@
+/*
+ *  Copyright 2024 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.openmetadata.service.migration.utils.v1130;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.openmetadata.schema.api.search.AssetTypeConfiguration;
+import org.openmetadata.schema.api.search.GlobalSettings;
+import org.openmetadata.schema.api.search.SearchSettings;
+
+class FlattenedChildrenHighlightScrubTest {
+
+  private static final String CONTAINER_CHILDREN_HIGHLIGHT = "dataModel.columns.children.name";
+
+  private AssetTypeConfiguration assetConfig(String assetType, String... highlightFields) {
+    AssetTypeConfiguration config = new AssetTypeConfiguration();
+    config.setAssetType(assetType);
+    config.setHighlightFields(new ArrayList<>(List.of(highlightFields)));
+    return config;
+  }
+
+  @Test
+  void stripRemovesContainerChildrenHighlightAndPreservesValidFields() {
+    SearchSettings settings = new SearchSettings();
+    settings.setAssetTypeConfigurations(
+        new ArrayList<>(
+            List.of(
+                assetConfig(
+                    "container",
+                    "name",
+                    "displayName",
+                    "description",
+                    "dataModel.columns.name",
+                    CONTAINER_CHILDREN_HIGHLIGHT))));
+
+    boolean changed = MigrationUtil.stripFlattenedChildrenHighlightFields(settings);
+
+    assertTrue(changed, "Scrub should report a change when a children highlight field is present");
+    List<String> highlights = settings.getAssetTypeConfigurations().getFirst().getHighlightFields();
+    assertEquals(
+        List.of("name", "displayName", "description", "dataModel.columns.name"),
+        highlights,
+        "Only the flattened children highlight field should be removed");
+  }
+
+  @Test
+  void stripRemovesOnlySeedRemovedFieldAndPreservesOtherChildrenPaths() {
+    SearchSettings settings = new SearchSettings();
+    GlobalSettings global = new GlobalSettings();
+    global.setHighlightFields(
+        new ArrayList<>(List.of("name", "messageSchema.schemaFields.children.name")));
+    settings.setGlobalSettings(global);
+    settings.setAssetTypeConfigurations(
+        new ArrayList<>(
+            List.of(
+                assetConfig("container", "name", CONTAINER_CHILDREN_HIGHLIGHT),
+                assetConfig("table", "displayName", "columns.children.name"),
+                assetConfig("topic", "name", "messageSchema.schemaFields.children.name"))));
+
+    boolean changed = MigrationUtil.stripFlattenedChildrenHighlightFields(settings);
+
+    assertTrue(changed);
+    assertEquals(
+        List.of("name"),
+        settings.getAssetTypeConfigurations().get(0).getHighlightFields(),
+        "Only the exact seed-removed container highlight field is scrubbed");
+    assertEquals(
+        List.of("displayName", "columns.children.name"),
+        settings.getAssetTypeConfigurations().get(1).getHighlightFields(),
+        "table columns.children.name was never removed from the seed - must be preserved");
+    assertEquals(
+        List.of("name", "messageSchema.schemaFields.children.name"),
+        settings.getAssetTypeConfigurations().get(2).getHighlightFields(),
+        "topic schemaFields.children.name was never removed from the seed - must be preserved");
+    assertEquals(
+        List.of("name", "messageSchema.schemaFields.children.name"),
+        settings.getGlobalSettings().getHighlightFields(),
+        "global children paths were never removed from the seed - must be preserved");
+  }
+
+  @Test
+  void stripPreservesUserCustomHighlightFields() {
+    SearchSettings settings = new SearchSettings();
+    settings.setAssetTypeConfigurations(
+        new ArrayList<>(
+            List.of(assetConfig("container", "name", "customExtension.value", "tags.tagFQN"))));
+
+    boolean changed = MigrationUtil.stripFlattenedChildrenHighlightFields(settings);
+
+    assertFalse(changed, "Scrub must not touch settings without flattened children references");
+    assertEquals(
+        List.of("name", "customExtension.value", "tags.tagFQN"),
+        settings.getAssetTypeConfigurations().getFirst().getHighlightFields());
+  }
+
+  @Test
+  void stripHandlesNullAndEmptyGracefully() {
+    assertFalse(MigrationUtil.stripFlattenedChildrenHighlightFields(null));
+
+    SearchSettings empty = new SearchSettings();
+    assertFalse(MigrationUtil.stripFlattenedChildrenHighlightFields(empty));
+
+    SearchSettings nullHighlights = new SearchSettings();
+    nullHighlights.setAssetTypeConfigurations(new ArrayList<>(List.of(assetConfig("container"))));
+    nullHighlights.getAssetTypeConfigurations().getFirst().setHighlightFields(null);
+    assertFalse(MigrationUtil.stripFlattenedChildrenHighlightFields(nullHighlights));
+  }
+}


### PR DESCRIPTION
## Problem

On **OpenSearch**, after upgrading a cluster from `<= 1.12.x` to `1.13`, container search fails with HTTP 500:

```
[search_phase_execution_exception] all shards failed | Root cause:
[illegal_argument_exception: Field [dataModel.columns.children.name] has no associated analyzer]
```

Surfaced as a 1.13 release blocker during migration AUTs. **OpenSearch only** — Elasticsearch silently degrades the bad highlight to a 200, so the same broken config is invisible there.

## Culprit PR

#28214 (*flatten nested children to avoid ES mapping depth limit*, fixes open-metadata/openmetadata-collate#4122) converted `dataModel.columns.children` (and sibling `*.children`) from `nested` to `flattened` (`flat_object` on OpenSearch) to escape the mapping depth limit. A `flattened` field has **no analyzer**, so it can no longer be highlighted. #28214 correctly removed `dataModel.columns.children.name` from the **seed** `searchSettings.json` container `highlightFields`.

## Root cause

The seed fix never reaches upgraded clusters. `SearchSettings` is read from the **DB** at runtime; on upgrade, `SearchSettingsHandler.mergeAssetTypeConfigurations` is **additive** — it keeps a cluster's stored per-asset config **wholesale** and only adds asset types that are missing. So any cluster that initialized on `<= 1.12.x` keeps the stale `dataModel.columns.children.name` in its container `highlightFields`.

When a container search runs a `query_string`-style query (special chars such as hyphens — common in names/FQNs/IDs), per-field match attribution breaks down and the highlighter attempts **every** configured highlight field, including the now-`flattened` one → no analyzer → 500.

Per-asset `highlightFields` are admin-customizable (via the search settings UI), so force-overriding them from the seed on every boot would wipe customizations — hence a targeted one-time scrub rather than a merge change.

## Reproduction

Confirmed end-to-end on a real `1.11.13 -> 1.13` upgrade (OpenSearch) and via an automated IT.

All of the following must hold (miss any one and you get a misleading 200):
1. Backend is **OpenSearch** (ES degrades silently).
2. Stale `dataModel.columns.children.name` present in container `highlightFields` (carried from `<= 1.12.x`).
3. A container with a column that **has children** (so the field is populated in the indexed doc).
4. Reindex ran post-upgrade (mapping is now `flattened`) **and** the search term triggers the `query_string` path (hyphen / special char).

Steps:
1. Fresh `1.11.13` on OpenSearch; create a storage service + a container with a `STRUCT` column that has children.
2. Upgrade to `1.13`: `openmetadata-ops.sh migrate` then `reindex`.
3. `GET /api/v1/search/query?q=repro\-container\-001&index=container` -> **500** (analyzer error above).

## Fix

One-time `v1130` data migration `MigrationUtil.removeFlattenedChildrenHighlightFields()`:
- Reads `SearchSettings` from the DB and removes **only** the exact seed-removed entry (`dataModel.columns.children.name`) from any `highlightFields` (global + per-asset), preserving every other field and all user customizations, then saves it back.
- Wired into both `mysql` and `postgres` `v1130` `runDataMigration()` (wrapped so it can't abort the migration chain).
- Touches **no mappings** — the #28214 indexing change is unaffected. Idempotent (re-running finds nothing to remove).

After the migration the same search returns **200** and the stale ref is gone from the DB config.

## Testing

- `FlattenedChildrenHighlightScrubTest` (unit): proves only the seed-removed field is stripped, other `.children.` paths (table/topic searchFields-style entries) and user customizations are preserved, and null/empty inputs are safe.
- `FlattenedChildrenHighlightSearchIT` (OpenSearch IT, `@Isolated`): poisoned container search -> 500 (`no associated analyzer`); after the scrub -> 200. Skipped on Elasticsearch.
- **Manually verified** on a genuine `1.11.13 -> 1.13` upgrade: 500 reproduced, then 200 after the v1130 scrub ran (stale field confirmed removed from the DB settings).

## Notes

- Upgrade keying: `v1130` runs during the upgrade to 1.13, so clusters upgrading to GA get the heal automatically. (Clusters that already ran an earlier `v1130` build would need `migrate --force`, same as other v1130 heals.)
- Follow-up (not in this PR): `children.name` also appears in **searchFields** for `table` / `topic` / `apiEndpoint` in the current seed (e.g. `columns.children.name`). That is a separate potential path (multi_match on a flattened sub-field) and was not reproduced/addressed here — flagged for a follow-up investigation.
