### PR TITLE
feat(ingestion): capture third-party logs, warnings, and uncaught exceptions in streamable logger (#28533)

### DIFF
--- a/ingestion/src/metadata/utils/streamable_logger.py
+++ b/ingestion/src/metadata/utils/streamable_logger.py
@@ -13,6 +13,7 @@
 import atexit
 import contextlib
 import logging
+import sys
 import threading
 import time
 from queue import Empty, Full, Queue
@@ -29,6 +30,10 @@ logger = ingestion_logger()
 # Recursion guard: sender threads set shipping=True so emit() returns
 # immediately if it ever fires from inside the shipping path.
 _shipping_state = threading.local()
+
+# Idempotency guard for one-shot global capture installation. Process is
+# one-shot (single workflow per pod), so we install once and never restore.
+_global_capture_installed = False
 
 
 class StreamableLogHandler(logging.Handler):
@@ -66,12 +71,12 @@ class StreamableLogHandler(logging.Handler):
         self._buffer: Queue = Queue(maxsize=max_buffer)
         self._stop_event = threading.Event()
         self._closed = False
-        self._worker: Optional[threading.Thread] = None  # noqa: UP045
+        self._worker: Optional[threading.Thread] = None
         self._post_in_flight = threading.Event()
 
         # Isolated session/connection pool; shares ClientConfig so token
         # refresh on the main client is visible here.
-        self._client: Optional[REST] = (  # noqa: UP045
+        self._client: Optional[REST] = (
             REST(metadata.client.config) if enable_streaming else None
         )
 
@@ -149,7 +154,11 @@ class StreamableLogHandler(logging.Handler):
 
     def _collect_batch(self, timeout: float) -> list:
         try:
-            batch = [self._buffer.get(timeout=timeout)] if timeout > 0 else [self._buffer.get_nowait()]
+            batch = (
+                [self._buffer.get(timeout=timeout)]
+                if timeout > 0
+                else [self._buffer.get_nowait()]
+            )
         except Empty:
             return []
         # Claim "in flight" the moment we own a batch so flush() can't return
@@ -186,7 +195,9 @@ class StreamableLogHandler(logging.Handler):
         """Block until queue is drained, or until deadline."""
         if not self.enable_streaming or self._worker is None:
             return
-        deadline = time.monotonic() + (timeout if timeout is not None else self.FLUSH_DEFAULT_SEC)
+        deadline = time.monotonic() + (
+            timeout if timeout is not None else self.FLUSH_DEFAULT_SEC
+        )
         while time.monotonic() < deadline:
             if self._buffer.empty() and not self._post_in_flight.is_set():
                 return
@@ -319,7 +330,7 @@ class StreamableLogHandlerManager:
         if cls._instance and cls._instance is not handler:
             # Detach before close so in-flight emits don't route at a closed handler.
             with contextlib.suppress(Exception):
-                logging.getLogger(METADATA_LOGGER).removeHandler(cls._instance)
+                logging.getLogger().removeHandler(cls._instance)
             with contextlib.suppress(Exception):
                 cls._instance.close()
         cls._instance = handler
@@ -330,7 +341,7 @@ class StreamableLogHandlerManager:
             return
         try:
             with contextlib.suppress(Exception):
-                logging.getLogger(METADATA_LOGGER).removeHandler(cls._instance)
+                logging.getLogger().removeHandler(cls._instance)
             with contextlib.suppress(Exception):
                 cls._instance.close()
         finally:
@@ -339,11 +350,11 @@ class StreamableLogHandlerManager:
 
 def setup_streamable_logging_for_workflow(
     metadata: OpenMetadata,
-    pipeline_fqn: Optional[str] = None,  # noqa: UP045
-    run_id: Optional[UUID] = None,  # noqa: UP045
+    pipeline_fqn: Optional[str] = None,
+    run_id: Optional[UUID] = None,
     log_level: int = logging.INFO,
     enable_streaming: bool = False,
-) -> Optional[StreamableLogHandler]:  # noqa: UP045
+) -> Optional[StreamableLogHandler]:
     if not enable_streaming or not pipeline_fqn or not run_id:
         logger.debug(
             "Streamable logging not configured: enable=%s, pipeline_fqn=%s, run_id=%s",
@@ -354,11 +365,11 @@ def setup_streamable_logging_for_workflow(
         return None
 
     try:
-        metadata_logger = logging.getLogger(METADATA_LOGGER)
+        root_logger = logging.getLogger()
         existing = StreamableLogHandlerManager.get_handler()
         if existing is not None:
             with contextlib.suppress(Exception):
-                metadata_logger.removeHandler(existing)
+                root_logger.removeHandler(existing)
 
         handler = StreamableLogHandler(
             metadata=metadata,
@@ -370,7 +381,8 @@ def setup_streamable_logging_for_workflow(
         handler.setFormatter(formatter)
         handler.setLevel(log_level)
 
-        metadata_logger.addHandler(handler)
+        root_logger.addHandler(handler)
+        _install_global_capture(handler)
         StreamableLogHandlerManager.set_handler(handler)
 
         logger.info(
@@ -378,11 +390,50 @@ def setup_streamable_logging_for_workflow(
             pipeline_fqn,
             model_str(run_id),
         )
-        return handler  # noqa: TRY300
+        return handler
 
     except Exception as e:
         logger.warning("Failed to setup streamable logging: %s", e)
         return None
+
+
+def _install_global_capture(handler: "StreamableLogHandler") -> None:
+    """Route uncaught exceptions and `warnings` records to the logger. Idempotent."""
+    global _global_capture_installed
+    if _global_capture_installed:
+        return
+
+    prev_sys_excepthook = sys.excepthook
+
+    def _sys_excepthook(exc_type, exc, tb):
+        try:
+            logger.error(
+                "Workflow terminated with uncaught exception",
+                exc_info=(exc_type, exc, tb),
+            )
+            with contextlib.suppress(Exception):
+                handler.flush(timeout=5.0)
+        finally:
+            prev_sys_excepthook(exc_type, exc, tb)
+
+    prev_threading_excepthook = threading.excepthook
+
+    def _threading_excepthook(args):
+        # Worker self-crash: skip logging to avoid re-entering the dead worker
+        # via emit() (would deadlock the flush attempt and never ship).
+        if args.thread is handler._worker:
+            return prev_threading_excepthook(args)
+        logger.error(
+            "Uncaught exception in thread %s",
+            args.thread.name if args.thread is not None else "<unknown>",
+            exc_info=(args.exc_type, args.exc_value, args.exc_traceback),
+        )
+        return prev_threading_excepthook(args)
+
+    sys.excepthook = _sys_excepthook
+    threading.excepthook = _threading_excepthook
+    logging.captureWarnings(True)
+    _global_capture_installed = True
 
 
 def cleanup_streamable_logging():

--- a/ingestion/tests/unit/utils/test_streamable_logger.py
+++ b/ingestion/tests/unit/utils/test_streamable_logger.py
@@ -12,14 +12,18 @@
 
 import contextlib
 import logging
+import sys
+import threading
 import time
 import unittest
+import warnings
 from unittest.mock import Mock, patch
 from uuid import uuid4
 
 import pytest
 
 from metadata.ingestion.ometa.ometa_api import OpenMetadata
+from metadata.utils import streamable_logger as streamable_logger_mod
 from metadata.utils.streamable_logger import (
     StreamableLogHandler,
     StreamableLogHandlerManager,
@@ -58,24 +62,26 @@ def _make_handler(enable_streaming=False, pipeline_fqn="test.pipeline", run_id=N
 class TestStreamableLogHandlerManager(unittest.TestCase):
     def tearDown(self):
         StreamableLogHandlerManager._instance = None
+        root = logging.getLogger()
+        root.handlers = [
+            h for h in root.handlers if not isinstance(h, StreamableLogHandler)
+        ]
 
-    def test_set_handler_removes_previous_from_metadata_logger(self):
-        """set_handler must detach the old handler from the metadata logger
+    def test_set_handler_removes_previous_from_root_logger(self):
+        """set_handler must detach the old handler from the root logger
         before closing it - otherwise records can still route at it during
         close, and a closed handler stays attached after."""
-        from metadata.utils.logger import METADATA_LOGGER
-
         first = _make_handler(enable_streaming=False)
         second = _make_handler(enable_streaming=False)
-        metadata_logger = logging.getLogger(METADATA_LOGGER)
-        metadata_logger.addHandler(first)
+        root = logging.getLogger()
+        root.addHandler(first)
 
         StreamableLogHandlerManager.set_handler(first)
         StreamableLogHandlerManager.set_handler(second)
 
-        self.assertNotIn(first, metadata_logger.handlers, "previous handler must be removed before being closed")
-        # Cleanup.
-        metadata_logger.handlers = [h for h in metadata_logger.handlers if not isinstance(h, StreamableLogHandler)]
+        self.assertNotIn(
+            first, root.handlers, "previous handler must be removed before being closed"
+        )
 
     def test_cleanup_clears_singleton(self):
         handler = _make_handler(enable_streaming=False)
@@ -83,21 +89,33 @@ class TestStreamableLogHandlerManager(unittest.TestCase):
         StreamableLogHandlerManager.cleanup()
         self.assertIsNone(StreamableLogHandlerManager.get_handler())
 
+    def test_cleanup_removes_handler_from_root(self):
+        """cleanup_streamable_logging must detach the handler from the root
+        logger so subsequent records don't route at the closed handler."""
+        handler = _make_handler(enable_streaming=False)
+        root = logging.getLogger()
+        root.addHandler(handler)
+        StreamableLogHandlerManager.set_handler(handler)
+
+        cleanup_streamable_logging()
+
+        self.assertNotIn(handler, root.handlers)
+
 
 class TestStreamableLoggingSetup(unittest.TestCase):
     def tearDown(self):
-        from metadata.utils.logger import METADATA_LOGGER
-
-        metadata_logger = logging.getLogger(METADATA_LOGGER)
-        metadata_logger.handlers = [
-            h for h in metadata_logger.handlers if not isinstance(h, (Mock, StreamableLogHandler))
+        root = logging.getLogger()
+        root.handlers = [
+            h for h in root.handlers if not isinstance(h, (Mock, StreamableLogHandler))
         ]
         StreamableLogHandlerManager._instance = None
 
     @patch("logging.getLogger")
     @patch("metadata.utils.streamable_logger.logger")
     @patch("metadata.utils.streamable_logger.StreamableLogHandler")
-    def test_setup_with_valid_config(self, mock_handler_cls, mock_logger, mock_get_logger):
+    def test_setup_with_valid_config(
+        self, mock_handler_cls, mock_logger, mock_get_logger
+    ):
         mock_metadata = Mock(spec=OpenMetadata)
         mock_handler = Mock()
         mock_handler.level = logging.INFO
@@ -181,7 +199,9 @@ class FakeOMeta:
         self.intermittent_pattern = None
         self._post_counter = 0
 
-    def send_logs_batch_best_effort(self, pipeline_fqn, run_id, log_content, timeout=None, client=None):
+    def send_logs_batch_best_effort(
+        self, pipeline_fqn, run_id, log_content, timeout=None, client=None
+    ):
         self._post_counter += 1
         if self.post_delay:
             time.sleep(self.post_delay)
@@ -198,6 +218,31 @@ class FakeOMeta:
     def send_close_best_effort(self, pipeline_fqn, run_id, timeout=None, client=None):
         self.close_calls.append((pipeline_fqn, str(run_id)))
         return True
+
+
+@pytest.fixture(autouse=True)
+def _restore_global_capture_state():
+    """Snapshot & restore process-global state mutated by setup_streamable_*.
+
+    Production never restores excepthooks (one-shot process), so tests must.
+    Covers: sys.excepthook, threading.excepthook, warnings.showwarning,
+    root logger handlers, and the module-level install-once flag.
+    """
+    prev_sys_hook = sys.excepthook
+    prev_thread_hook = threading.excepthook
+    prev_show_warning = warnings.showwarning
+    root = logging.getLogger()
+    prev_root_handlers = list(root.handlers)
+    prev_installed_flag = streamable_logger_mod._global_capture_installed
+
+    yield
+
+    sys.excepthook = prev_sys_hook
+    threading.excepthook = prev_thread_hook
+    warnings.showwarning = prev_show_warning
+    root.handlers = prev_root_handlers
+    streamable_logger_mod._global_capture_installed = prev_installed_flag
+    StreamableLogHandlerManager._instance = None
 
 
 @pytest.fixture
@@ -301,7 +346,10 @@ def test_emit_drops_after_close(make_v2, fake_ometa):
     handler.emit(_make_record("also after"))
 
     assert handler.dropped_after_close == 2
-    assert all("after close" not in b and "also after" not in b for b in fake_ometa.shipped_batches)
+    assert all(
+        "after close" not in b and "also after" not in b
+        for b in fake_ometa.shipped_batches
+    )
 
 
 def test_emit_handles_format_error(make_v2):
@@ -571,3 +619,170 @@ def test_end_to_end_emit_lifecycle(make_v2, fake_ometa):
     assert handler.flush_timed_out == 0
     assert handler.shutdown_timed_out == 0
     assert handler.shipped_records == 200
+
+
+# ============================================================================
+# Group 7: global capture installed by setup_streamable_logging_for_workflow
+#
+# Verifies that setup() ships records from arbitrary loggers (root attach),
+# from the warnings module (captureWarnings), and from unhandled exceptions
+# (sys.excepthook + threading.excepthook). All via the same FakeOMeta path.
+# ============================================================================
+
+
+@pytest.fixture
+def installed_handler(fake_ometa, fake_atexit, fake_rest, fast_constants):
+    """Run the real setup() so root attach + excepthooks + captureWarnings
+    fire. The autouse _restore_global_capture_state fixture undoes all of it
+    after each test, regardless of failure."""
+    handler = setup_streamable_logging_for_workflow(
+        metadata=fake_ometa,
+        pipeline_fqn="test.pipeline",
+        run_id=uuid4(),
+        enable_streaming=True,
+    )
+    assert handler is not None
+    yield handler
+    with contextlib.suppress(Exception):
+        handler.shutdown(timeout=1.0)
+
+
+def test_setup_attaches_to_root_logger(installed_handler):
+    """Handler must be on the root logger, not the metadata logger only.
+    Without root attach, third-party loggers (tableauserverclient, urllib3)
+    are invisible."""
+    assert installed_handler in logging.getLogger().handlers
+
+
+def test_setup_ships_records_from_third_party_logger(installed_handler, fake_ometa):
+    """A logger that isn't in the metadata.* tree (e.g. tableauserverclient)
+    must reach the shipped batch via root propagation."""
+    third_party = logging.getLogger("tableauserverclient")
+    third_party.setLevel(logging.INFO)
+    third_party.info("401001 fake auth failure")
+
+    installed_handler.flush(timeout=2.0)
+
+    joined = "\n".join(fake_ometa.shipped_batches)
+    assert "401001 fake auth failure" in joined
+
+
+def test_setup_enables_capture_warnings(installed_handler):
+    """setup() must call logging.captureWarnings(True) so warnings emitted
+    in production reach the logger. Verified via stdlib's tracker variable
+    (pytest's per-test catch_warnings would mask a behavioral assertion)."""
+    assert (
+        logging._warnings_showwarning is not None
+    ), "captureWarnings(True) did not run during setup_streamable_logging_for_workflow"
+
+
+def test_py_warnings_logger_records_reach_handler(installed_handler, fake_ometa):
+    """Once captureWarnings is on, warnings.warn() funnels into the
+    py.warnings logger. Verify records on that logger propagate through
+    root to our handler. (We emit directly on the logger to bypass
+    pytest's warning capture, which intercepts warnings.warn calls.)"""
+    logging.getLogger("py.warnings").warning("pydantic shadow warning")
+
+    installed_handler.flush(timeout=2.0)
+
+    joined = "\n".join(fake_ometa.shipped_batches)
+    assert "pydantic shadow warning" in joined
+
+
+def test_sys_excepthook_ships_traceback_and_chains(installed_handler, fake_ometa):
+    """Uncaught exception must (a) be logged with exc_info so traceback
+    reaches the batch, and (b) chain to the previous excepthook so Argo
+    stderr still gets it as a backup."""
+    chained = []
+    prev = sys.excepthook
+    sys.excepthook = lambda *args: chained.append(args)
+    # Re-install our hook AFTER the chain-spy, so our hook calls into spy.
+    streamable_logger_mod._global_capture_installed = False
+    streamable_logger_mod._install_global_capture(installed_handler)
+
+    def _raise_boom():
+        raise RuntimeError("boom from main thread")
+
+    try:
+        _raise_boom()
+    except RuntimeError:
+        sys.excepthook(*sys.exc_info())
+
+    installed_handler.flush(timeout=2.0)
+
+    joined = "\n".join(fake_ometa.shipped_batches)
+    assert "Workflow terminated with uncaught exception" in joined
+    assert "RuntimeError" in joined
+    assert "boom from main thread" in joined
+    assert len(chained) == 1, "previous sys.excepthook must be chained"
+
+    # Restore the spy hook so the autouse fixture's snapshot is what it expects.
+    sys.excepthook = prev
+
+
+def test_threading_excepthook_skips_when_thread_is_worker(installed_handler):
+    """Worker thread crash must NOT re-enter the logger (it can't ship
+    anyway) - the hook short-circuits to the previous handler instead."""
+    chained = []
+    prev = threading.excepthook
+    threading.excepthook = chained.append
+    streamable_logger_mod._global_capture_installed = False
+    streamable_logger_mod._install_global_capture(installed_handler)
+
+    fake_args = type("_A", (), {})()
+    fake_args.thread = installed_handler._worker
+    fake_args.exc_type = RuntimeError
+    fake_args.exc_value = RuntimeError("worker died")
+    fake_args.exc_traceback = None
+    pre_shipped_count = (
+        len(installed_handler._buffer.queue) + installed_handler.shipped_records
+    )
+
+    threading.excepthook(fake_args)
+
+    # No record was enqueued for the worker crash; only the prev hook ran.
+    post_shipped_count = (
+        len(installed_handler._buffer.queue) + installed_handler.shipped_records
+    )
+    assert post_shipped_count == pre_shipped_count
+    assert len(chained) == 1
+
+    threading.excepthook = prev
+
+
+def test_threading_excepthook_logs_for_non_worker_thread(installed_handler, fake_ometa):
+    """A non-worker thread crash must be logged (with exc_info) and chained."""
+    chained = []
+    prev = threading.excepthook
+    threading.excepthook = chained.append
+    streamable_logger_mod._global_capture_installed = False
+    streamable_logger_mod._install_global_capture(installed_handler)
+
+    fake_thread = threading.Thread(target=lambda: None, name="random-worker")
+    fake_args = type("_A", (), {})()
+    fake_args.thread = fake_thread
+    fake_args.exc_type = ValueError
+    fake_args.exc_value = ValueError("connector died")
+    fake_args.exc_traceback = None
+
+    threading.excepthook(fake_args)
+    installed_handler.flush(timeout=2.0)
+
+    joined = "\n".join(fake_ometa.shipped_batches)
+    assert "Uncaught exception in thread random-worker" in joined
+    assert len(chained) == 1, "previous threading.excepthook must be chained"
+
+    threading.excepthook = prev
+
+
+def test_install_global_capture_is_idempotent(installed_handler):
+    """Second call must not double-wrap excepthooks. Without the guard,
+    each setup() during a retry would chain on top of its own previous
+    install and grow a stack of hooks."""
+    sys_hook_after_first = sys.excepthook
+    thread_hook_after_first = threading.excepthook
+
+    streamable_logger_mod._install_global_capture(installed_handler)
+
+    assert sys.excepthook is sys_hook_after_first
+    assert threading.excepthook is thread_hook_after_first


### PR DESCRIPTION
Backport of #28533 to `1.13`.

The streamable handler was attached only to the `metadata` logger tree, so third-party loggers (tableauserverclient, urllib3), warnings, and uncaught exception tracebacks never reached the UI — users only saw a couple of INFO lines and the workflow appeared to vanish on crash.

Attach the handler at the root logger, enable `logging.captureWarnings`, and install `sys.excepthook` + `threading.excepthook` to route uncaught exceptions through the same shipping path. Worker self-crash short-circuits to avoid re-entering the dead worker via emit(). Existing `_shipping_state` recursion guard already prevents self-capture from urllib3 / OM client logs emitted during the POST.

Cherry-picked from fb619406; ruff `# noqa` directives stripped (1.13 is pre-ruff) and reformatted with black to match the release branch.