### PR TITLE
Fix: resolve any-language recognizers in Presidio AnalyzerEngine

### DIFF
--- a/ingestion/src/metadata/pii/tag_analyzer.py
+++ b/ingestion/src/metadata/pii/tag_analyzer.py
@@ -120,7 +120,7 @@ class TagAnalyzer:
     def _normalize_recognizer_language(
         self, recognizer_obj: EntityRecognizer, effective_language: str
     ) -> EntityRecognizer:
-        """Clone recognizer with 'any' language replaced by effective_language.
+        """Normalize recognizer with 'any' language replaced by effective_language.
 
         Presidio's RecognizerRegistry uses strict equality on supported_language,
         so 'any' will not match specific language codes like 'en'. This method

--- a/ingestion/src/metadata/pii/tag_analyzer.py
+++ b/ingestion/src/metadata/pii/tag_analyzer.py
@@ -117,13 +117,29 @@ class TagAnalyzer:
     def _column_name(self) -> str:
         return self._column.name.root
 
+    def _normalize_recognizer_language(
+        self, recognizer_obj: EntityRecognizer, effective_language: str
+    ) -> EntityRecognizer:
+        """Clone recognizer with 'any' language replaced by effective_language.
+
+        Presidio's RecognizerRegistry uses strict equality on supported_language,
+        so 'any' will not match specific language codes like 'en'. This method
+        translates 'any' to a concrete language for Presidio's filter to work.
+        """
+        if recognizer_obj.supported_language == ClassificationLanguage.any.value:
+            recognizer_obj.supported_language = effective_language
+        return recognizer_obj
+
     def build_analyzer_with(
         self,
         recognizers: list[EntityRecognizer],
         nlp_engine: Optional[NlpEngine] = None,  # noqa: UP045
+        effective_language: Optional[str] = None,  # noqa: UP045
     ) -> AnalyzerEngine:
-        supported_languages = [rec.supported_language for rec in recognizers]
-        recognizer_registry = RecognizerRegistry(recognizers=recognizers, supported_languages=supported_languages)
+        effective_lang = effective_language or self._language.value
+        normalized_recs = [self._normalize_recognizer_language(rec, effective_lang) for rec in recognizers]
+        supported_languages = [rec.supported_language for rec in normalized_recs]
+        recognizer_registry = RecognizerRegistry(recognizers=normalized_recs, supported_languages=supported_languages)
         effective_nlp = nlp_engine if nlp_engine is not None else self._nlp_engine
         return AnalyzerEngine(
             registry=recognizer_registry,
@@ -156,15 +172,23 @@ class TagAnalyzer:
         sorted_recs = sorted(recognizers, key=lambda r: r.supported_language)
         for lang, group in groupby(sorted_recs, key=lambda r: r.supported_language):
             lang_recognizers = list(group)
+            if lang == ClassificationLanguage.any.value:
+                effective_lang = ClassificationLanguage.en.value
+                effective_nlp = load_nlp_engine(classification_language=ClassificationLanguage.en)
+            else:
+                effective_lang = lang
+                effective_nlp = load_nlp_engine(classification_language=ClassificationLanguage(lang))
+
             analyzer = self.build_analyzer_with(
                 lang_recognizers,
-                nlp_engine=load_nlp_engine(classification_language=ClassificationLanguage(lang)),
+                nlp_engine=effective_nlp,
+                effective_language=effective_lang,
             )
             for value in values:
                 results.extend(
                     analyzer.analyze(
                         value,
-                        language=lang,
+                        language=effective_lang,
                         context=context,
                         return_decision_process=True,
                     )

--- a/ingestion/src/metadata/pii/tag_analyzer.py
+++ b/ingestion/src/metadata/pii/tag_analyzer.py
@@ -1,3 +1,4 @@
+import copy
 from itertools import groupby
 from typing import List, Optional, Sequence, final  # noqa: UP035
 
@@ -126,9 +127,11 @@ class TagAnalyzer:
         so 'any' will not match specific language codes like 'en'. This method
         translates 'any' to a concrete language for Presidio's filter to work.
         """
-        if recognizer_obj.supported_language == ClassificationLanguage.any.value:
-            recognizer_obj.supported_language = effective_language
-        return recognizer_obj
+        if recognizer_obj.supported_language != ClassificationLanguage.any.value:
+            return recognizer_obj
+        recognizer_copy = copy.copy(recognizer_obj)
+        recognizer_copy.supported_language = effective_language
+        return recognizer_copy
 
     def build_analyzer_with(
         self,
@@ -137,6 +140,11 @@ class TagAnalyzer:
         effective_language: Optional[str] = None,  # noqa: UP045
     ) -> AnalyzerEngine:
         effective_lang = effective_language or self._language.value
+        if effective_lang == ClassificationLanguage.any.value:
+            raise ValueError(
+                "build_analyzer_with requires a concrete language when the analyzer language is 'any'. "
+                "Pass effective_language explicitly."
+            )
         normalized_recs = [self._normalize_recognizer_language(rec, effective_lang) for rec in recognizers]
         supported_languages = [rec.supported_language for rec in normalized_recs]
         recognizer_registry = RecognizerRegistry(recognizers=normalized_recs, supported_languages=supported_languages)

--- a/ingestion/src/metadata/pii/tag_analyzer.py
+++ b/ingestion/src/metadata/pii/tag_analyzer.py
@@ -1,5 +1,5 @@
 from itertools import groupby
-from typing import List, Optional, Sequence, Union, final  # noqa: UP035
+from typing import List, Optional, Sequence, final  # noqa: UP035
 
 from presidio_analyzer import (
     AnalyzerEngine,
@@ -149,7 +149,7 @@ class TagAnalyzer:
 
     def _analyze_with(
         self,
-        text_or_values: Union[str, Sequence[str]],  # noqa: UP007
+        text_or_values: str | Sequence[str],
         recognizers: list[EntityRecognizer],
         context: Optional[list[str]] = None,  # noqa: UP045
     ) -> list[RecognizerResult]:

--- a/ingestion/tests/unit/metadata/pii/test_tag_analyzer_any_language.py
+++ b/ingestion/tests/unit/metadata/pii/test_tag_analyzer_any_language.py
@@ -274,28 +274,6 @@ class TestAnalyzeWithAnyLanguage:
         assert result.score == 0
         assert result.recognizer_results == []
 
-    def test_any_agent_with_any_recognizer_dispatches_to_en(self, pii_classification, column, mock_nlp_engine):
-        """Agent=any, Recognizer=any → _analyze_with must treat the 'any' group as 'en'."""
-        tag = _make_any_language_tag(pii_classification)
-        analyzer = TagAnalyzer(
-            tag=tag,
-            column=column,
-            nlp_engine=mock_nlp_engine,
-            language=ClassificationLanguage.any,
-        )
-
-        dispatched_languages = []
-        original_build = analyzer.build_analyzer_with
-
-        def tracking_build(recs, nlp_engine=None, effective_language=None):
-            dispatched_languages.append(effective_language)
-            return original_build(recs, nlp_engine=nlp_engine, effective_language=effective_language)
-
-        analyzer.build_analyzer_with = tracking_build
-        analyzer.analyze_content(["user@example.com"])
-
-        assert dispatched_languages == [ClassificationLanguage.en.value]
-
     def test_any_language_analyze_column_no_exception(self, pii_classification, column, mock_nlp_engine):
         en_pattern = PatternFactory.create(
             name="column-pattern",
@@ -452,6 +430,22 @@ class TestAnalyzeWithAnyLanguageRecognizerRealPresidia:
             column=column,
             nlp_engine=nlp,
             language=ClassificationLanguage.fr,
+        )
+        result = analyzer.analyze_content(["user@example.com"])
+        assert result.score > 0
+
+    def test_any_agent_with_any_recognizer_scores_on_match(self, any_language_email_tag, column):
+        """Agent=any, Recognizer=any: 'any' group must be dispatched as 'en', not 'any'.
+
+        If _analyze_with calls analyze(language='any') instead of 'en', Presidio raises
+        ValueError because the recognizer is normalized to supported_language='en' but
+        the registry finds no recognizer for 'any'.
+        """
+        analyzer = TagAnalyzer(
+            tag=any_language_email_tag,
+            column=column,
+            nlp_engine=MagicMock(),
+            language=ClassificationLanguage.any,
         )
         result = analyzer.analyze_content(["user@example.com"])
         assert result.score > 0

--- a/ingestion/tests/unit/metadata/pii/test_tag_analyzer_any_language.py
+++ b/ingestion/tests/unit/metadata/pii/test_tag_analyzer_any_language.py
@@ -274,6 +274,21 @@ class TestAnalyzeWithAnyLanguage:
         assert result.score == 0
         assert result.recognizer_results == []
 
+    def test_build_analyzer_with_raises_when_language_is_any_without_effective_language(
+        self, pii_classification, column, mock_nlp_engine
+    ):
+        """build_analyzer_with must raise ValueError when the analyzer language is 'any'
+        and no effective_language is provided, to prevent silent 'any' propagation to Presidio."""
+        tag = _make_any_language_tag(pii_classification)
+        analyzer = TagAnalyzer(
+            tag=tag,
+            column=column,
+            nlp_engine=mock_nlp_engine,
+            language=ClassificationLanguage.any,
+        )
+        with pytest.raises(ValueError, match="concrete language"):
+            analyzer.build_analyzer_with([])
+
     def test_any_language_analyze_column_no_exception(self, pii_classification, column, mock_nlp_engine):
         en_pattern = PatternFactory.create(
             name="column-pattern",
@@ -340,6 +355,23 @@ class TestNormalizeRecognizerLanguage:
         )
         result = analyzer._normalize_recognizer_language(rec, "fr")
         assert result.supported_language == "en"
+
+    def test_original_not_mutated(self, pii_classification, column, mock_nlp_engine):
+        """_normalize_recognizer_language must not mutate the original recognizer."""
+        analyzer = TagAnalyzer(
+            tag=_make_any_language_tag(pii_classification),
+            column=column,
+            nlp_engine=mock_nlp_engine,
+            language=ClassificationLanguage.en,
+        )
+        rec = PatternRecognizer(
+            supported_entity="EMAIL",
+            supported_language="any",
+            patterns=[Pattern(name="p", regex=r"@", score=0.5)],
+        )
+        result = analyzer._normalize_recognizer_language(rec, "en")
+        assert result.supported_language == "en"
+        assert rec.supported_language == "any"
 
 
 def _make_presidio_nlp_mock_for(language: str):

--- a/ingestion/tests/unit/metadata/pii/test_tag_analyzer_any_language.py
+++ b/ingestion/tests/unit/metadata/pii/test_tag_analyzer_any_language.py
@@ -182,9 +182,9 @@ class TestAnalyzeWithAnyLanguage:
         build_calls = []
         original_build = analyzer.build_analyzer_with
 
-        def tracking_build(recs, nlp_engine=None):
+        def tracking_build(recs, nlp_engine=None, effective_language=None):
             build_calls.append((recs, nlp_engine))
-            return original_build(recs, nlp_engine=nlp_engine)
+            return original_build(recs, nlp_engine=nlp_engine, effective_language=effective_language)
 
         analyzer.build_analyzer_with = tracking_build
 
@@ -256,3 +256,87 @@ class TestAnalyzeWithAnyLanguage:
         )
         result = analyzer.analyze_column()
         assert result is not None
+
+
+def _make_presidio_nlp_mock():
+    """NLP mock that satisfies AnalyzerEngine without requiring real spaCy models.
+
+    PatternRecognizers are regex-only and don't invoke the NLP engine, so this
+    lightweight mock is sufficient to exercise the real Presidio registry/analysis
+    path end-to-end.
+    """
+    nlp = MagicMock()
+    nlp.is_loaded.return_value = True
+    nlp.get_supported_languages.return_value = ["en"]
+    return nlp
+
+
+class TestAnalyzeWithAnyLanguageRecognizerRealPresidia:
+    """Regression tests: any-language pattern recognizers must fire through the real
+    Presidio AnalyzerEngine when the agent is configured with a specific language.
+
+    These tests use a real AnalyzerEngine (not a full mock) to catch the ValueError
+    "No matching recognizers were found" that occurs when build_analyzer_with passes
+    supported_languages=["any"] to Presidio and then calls analyze(language="en").
+    """
+
+    @pytest.fixture
+    def any_language_email_tag(self, pii_classification):
+        email_pattern = PatternFactory.create(
+            name="any-email-pattern",
+            regex=r"[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}",
+            score=0.8,
+        )
+        recognizer_config = PatternRecognizerFactory.create(
+            patterns=[email_pattern],
+            context=[],
+            supportedLanguage=ClassificationLanguage.any,
+        )
+        rec = RecognizerFactory.create(
+            name="any-email",
+            recognizerConfig=recognizer_config,
+            target=recognizer.Target.content,
+        )
+        return TagFactory.create(
+            tag_name="AnyEmail",
+            tag_classification=pii_classification,
+            autoClassificationEnabled=True,
+            recognizers=[rec],
+        )
+
+    def test_any_language_recognizer_does_not_raise_with_specific_language_agent(self, any_language_email_tag, column):
+        """When agent language is 'en' and recognizer is 'any', analyze_content must
+        not raise ValueError from Presidio's registry."""
+        nlp = _make_presidio_nlp_mock()
+        analyzer = TagAnalyzer(
+            tag=any_language_email_tag,
+            column=column,
+            nlp_engine=nlp,
+            language=ClassificationLanguage.en,
+        )
+        result = analyzer.analyze_content(["user@example.com", "not-an-email"])
+        assert result is not None
+
+    def test_any_language_recognizer_matches_content_with_specific_language_agent(self, any_language_email_tag, column):
+        """An any-language pattern recognizer must actually score > 0 when data matches."""
+        nlp = _make_presidio_nlp_mock()
+        analyzer = TagAnalyzer(
+            tag=any_language_email_tag,
+            column=column,
+            nlp_engine=nlp,
+            language=ClassificationLanguage.en,
+        )
+        result = analyzer.analyze_content(["user@example.com"])
+        assert result.score > 0
+
+    def test_any_language_recognizer_no_match_scores_zero(self, any_language_email_tag, column):
+        """When data doesn't match, score must be 0 regardless of language."""
+        nlp = _make_presidio_nlp_mock()
+        analyzer = TagAnalyzer(
+            tag=any_language_email_tag,
+            column=column,
+            nlp_engine=nlp,
+            language=ClassificationLanguage.en,
+        )
+        result = analyzer.analyze_content(["no-match-here", "also-not-an-email"])
+        assert result.score == 0

--- a/ingestion/tests/unit/metadata/pii/test_tag_analyzer_any_language.py
+++ b/ingestion/tests/unit/metadata/pii/test_tag_analyzer_any_language.py
@@ -16,6 +16,7 @@ from unittest.mock import MagicMock
 
 import pytest
 from dirty_equals import Contains, HasAttributes, IsDict
+from presidio_analyzer import Pattern, PatternRecognizer
 
 from _openmetadata_testutils.factories.metadata.generated.schema.entity.classification.classification import (
     ClassificationFactory,
@@ -116,6 +117,31 @@ def _make_fr_tag(pii_classification):
     )
 
 
+def _make_any_language_tag(pii_classification):
+    """Tag with an any-language pattern recognizer (email regex)."""
+    pattern = PatternFactory.create(
+        name="any-email-pattern",
+        regex=r"[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}",
+        score=0.8,
+    )
+    recognizer_config = PatternRecognizerFactory.create(
+        patterns=[pattern],
+        context=[],
+        supportedLanguage=ClassificationLanguage.any,
+    )
+    rec = RecognizerFactory.create(
+        name="any-email",
+        recognizerConfig=recognizer_config,
+        target=recognizer.Target.content,
+    )
+    return TagFactory.create(
+        tag_name="AnyEmail",
+        tag_classification=pii_classification,
+        autoClassificationEnabled=True,
+        recognizers=[rec],
+    )
+
+
 class TestGetRecognizersByAnyLanguage:
     def test_any_language_includes_all_recognizers(self, pii_classification, column, mock_nlp_engine):
         en_tag = _make_en_tag(pii_classification)
@@ -162,6 +188,28 @@ class TestGetRecognizersByAnyLanguage:
             column=column,
             nlp_engine=mock_nlp_engine,
             language=ClassificationLanguage.en,
+        )
+        recognizers = analyzer.get_recognizers_by(recognizer.Target.content)
+        assert len(recognizers) == 1
+
+    def test_en_agent_includes_any_language_recognizer(self, pii_classification, column, mock_nlp_engine):
+        tag = _make_any_language_tag(pii_classification)
+        analyzer = TagAnalyzer(
+            tag=tag,
+            column=column,
+            nlp_engine=mock_nlp_engine,
+            language=ClassificationLanguage.en,
+        )
+        recognizers = analyzer.get_recognizers_by(recognizer.Target.content)
+        assert len(recognizers) == 1
+
+    def test_fr_agent_includes_any_language_recognizer(self, pii_classification, column, mock_nlp_engine):
+        tag = _make_any_language_tag(pii_classification)
+        analyzer = TagAnalyzer(
+            tag=tag,
+            column=column,
+            nlp_engine=mock_nlp_engine,
+            language=ClassificationLanguage.fr,
         )
         recognizers = analyzer.get_recognizers_by(recognizer.Target.content)
         assert len(recognizers) == 1
@@ -226,6 +274,28 @@ class TestAnalyzeWithAnyLanguage:
         assert result.score == 0
         assert result.recognizer_results == []
 
+    def test_any_agent_with_any_recognizer_dispatches_to_en(self, pii_classification, column, mock_nlp_engine):
+        """Agent=any, Recognizer=any → _analyze_with must treat the 'any' group as 'en'."""
+        tag = _make_any_language_tag(pii_classification)
+        analyzer = TagAnalyzer(
+            tag=tag,
+            column=column,
+            nlp_engine=mock_nlp_engine,
+            language=ClassificationLanguage.any,
+        )
+
+        dispatched_languages = []
+        original_build = analyzer.build_analyzer_with
+
+        def tracking_build(recs, nlp_engine=None, effective_language=None):
+            dispatched_languages.append(effective_language)
+            return original_build(recs, nlp_engine=nlp_engine, effective_language=effective_language)
+
+        analyzer.build_analyzer_with = tracking_build
+        analyzer.analyze_content(["user@example.com"])
+
+        assert dispatched_languages == [ClassificationLanguage.en.value]
+
     def test_any_language_analyze_column_no_exception(self, pii_classification, column, mock_nlp_engine):
         en_pattern = PatternFactory.create(
             name="column-pattern",
@@ -258,6 +328,50 @@ class TestAnalyzeWithAnyLanguage:
         assert result is not None
 
 
+class TestNormalizeRecognizerLanguage:
+    """Unit tests for the _normalize_recognizer_language helper."""
+
+    def test_any_language_replaced_by_effective_language(self, pii_classification, column, mock_nlp_engine):
+        """A recognizer with supported_language='any' must be updated to the effective language."""
+        analyzer = TagAnalyzer(
+            tag=_make_any_language_tag(pii_classification),
+            column=column,
+            nlp_engine=mock_nlp_engine,
+            language=ClassificationLanguage.en,
+        )
+        rec = PatternRecognizer(
+            supported_entity="EMAIL",
+            supported_language="any",
+            patterns=[Pattern(name="p", regex=r"@", score=0.5)],
+        )
+        result = analyzer._normalize_recognizer_language(rec, "en")
+        assert result.supported_language == "en"
+
+    def test_specific_language_not_changed(self, pii_classification, column, mock_nlp_engine):
+        """A recognizer with an explicit language must not be overwritten."""
+        analyzer = TagAnalyzer(
+            tag=_make_en_tag(pii_classification),
+            column=column,
+            nlp_engine=mock_nlp_engine,
+            language=ClassificationLanguage.en,
+        )
+        rec = PatternRecognizer(
+            supported_entity="EMAIL",
+            supported_language="en",
+            patterns=[Pattern(name="p", regex=r"@", score=0.5)],
+        )
+        result = analyzer._normalize_recognizer_language(rec, "fr")
+        assert result.supported_language == "en"
+
+
+def _make_presidio_nlp_mock_for(language: str):
+    """NLP mock for a specific language that satisfies AnalyzerEngine without real spaCy models."""
+    nlp = MagicMock()
+    nlp.is_loaded.return_value = True
+    nlp.get_supported_languages.return_value = [language]
+    return nlp
+
+
 def _make_presidio_nlp_mock():
     """NLP mock that satisfies AnalyzerEngine without requiring real spaCy models.
 
@@ -265,10 +379,7 @@ def _make_presidio_nlp_mock():
     lightweight mock is sufficient to exercise the real Presidio registry/analysis
     path end-to-end.
     """
-    nlp = MagicMock()
-    nlp.is_loaded.return_value = True
-    nlp.get_supported_languages.return_value = ["en"]
-    return nlp
+    return _make_presidio_nlp_mock_for("en")
 
 
 class TestAnalyzeWithAnyLanguageRecognizerRealPresidia:
@@ -282,27 +393,7 @@ class TestAnalyzeWithAnyLanguageRecognizerRealPresidia:
 
     @pytest.fixture
     def any_language_email_tag(self, pii_classification):
-        email_pattern = PatternFactory.create(
-            name="any-email-pattern",
-            regex=r"[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}",
-            score=0.8,
-        )
-        recognizer_config = PatternRecognizerFactory.create(
-            patterns=[email_pattern],
-            context=[],
-            supportedLanguage=ClassificationLanguage.any,
-        )
-        rec = RecognizerFactory.create(
-            name="any-email",
-            recognizerConfig=recognizer_config,
-            target=recognizer.Target.content,
-        )
-        return TagFactory.create(
-            tag_name="AnyEmail",
-            tag_classification=pii_classification,
-            autoClassificationEnabled=True,
-            recognizers=[rec],
-        )
+        return _make_any_language_tag(pii_classification)
 
     def test_any_language_recognizer_does_not_raise_with_specific_language_agent(self, any_language_email_tag, column):
         """When agent language is 'en' and recognizer is 'any', analyze_content must
@@ -340,3 +431,27 @@ class TestAnalyzeWithAnyLanguageRecognizerRealPresidia:
         )
         result = analyzer.analyze_content(["no-match-here", "also-not-an-email"])
         assert result.score == 0
+
+    def test_any_language_recognizer_with_fr_agent_does_not_raise(self, any_language_email_tag, column):
+        """Agent=fr, Recognizer=any: must not raise; 'any' normalized to 'fr' before Presidio sees it."""
+        nlp = _make_presidio_nlp_mock_for("fr")
+        analyzer = TagAnalyzer(
+            tag=any_language_email_tag,
+            column=column,
+            nlp_engine=nlp,
+            language=ClassificationLanguage.fr,
+        )
+        result = analyzer.analyze_content(["user@example.com", "not-an-email"])
+        assert result is not None
+
+    def test_any_language_recognizer_matches_content_with_fr_agent(self, any_language_email_tag, column):
+        """Agent=fr, Recognizer=any: pattern must still fire when data matches."""
+        nlp = _make_presidio_nlp_mock_for("fr")
+        analyzer = TagAnalyzer(
+            tag=any_language_email_tag,
+            column=column,
+            nlp_engine=nlp,
+            language=ClassificationLanguage.fr,
+        )
+        result = analyzer.analyze_content(["user@example.com"])
+        assert result.score > 0


### PR DESCRIPTION
Fixes #28883

Completes the fix started by PR #27919 (issue #27911). PR #27919 fixed get_recognizers_by() to include any-language recognizers, but the real crash occurred one layer deeper in build_analyzer_with/Presidio's registry.

Root cause: When any-language recognizers reached build_analyzer_with, they were passed to Presidio's RecognizerRegistry with supported_language="any". Presidio uses strict equality on language codes, so "any" did not match when analyzer.analyze(language="en") was called, causing: ValueError: No matching recognizers were found.

Solution:
1. Add _normalize_recognizer_language() to translate any → effective_language
2. build_analyzer_with() normalizes all recognizers before building the registry, so Presidio's strict-equality filter works correctly
3. In _analyze_with(), when agent language is any and recognizers are grouped by language, "any" recognizers are analyzed with a concrete language (en) and matching NLP engine

Tests: Added TestAnalyzeWithAnyLanguageRecognizerRealPresidia to exercise the real Presidio AnalyzerEngine path end-to-end, catching the original ValueError "No matching recognizers were found". All 90 PII tests pass.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR completes the fix for any-language recognizers in Presidio's `AnalyzerEngine` by normalizing `"any"` language codes to a concrete language before they reach Presidio's strict-equality registry filter, preventing the `ValueError: No matching recognizers were found` crash.

- Adds `_normalize_recognizer_language()` which shallow-copies any-language `EntityRecognizer` objects and rewrites their `supported_language` to the effective concrete language, avoiding in-place mutation of shared recognizer instances.
- Updates `build_analyzer_with()` to accept an `effective_language` parameter, normalizes all recognizers before registry construction, and raises `ValueError` eagerly when language remains `\"any\"` to prevent silent propagation to Presidio.
- Extends `_analyze_with()` so the per-language dispatch loop maps the `\"any\"` group to English NLP, and adds a comprehensive regression test class (`TestAnalyzeWithAnyLanguageRecognizerRealPresidia`) covering both specific-language and any-language agent scenarios end-to-end.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge. The change is a targeted fix to a well-understood crash, the normalization logic is correct across all agent×recognizer-language combinations, and mutations to shared recognizer objects are avoided via shallow copy.

Both previously-raised concerns (in-place mutation and silent 'any' propagation) are fully addressed: _normalize_recognizer_language uses copy.copy() to avoid mutating the original, and build_analyzer_with now raises ValueError eagerly when no concrete language is available. The new regression tests cover the specific crash scenario end-to-end with a real Presidio AnalyzerEngine, making future regressions immediately visible.

No files require special attention.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| ingestion/src/metadata/pii/tag_analyzer.py | Core fix: adds language normalization helper, guards build_analyzer_with against 'any' propagation, and routes the 'any' recognizer group to an English NLP engine in _analyze_with. Logic is correct for all agent×recognizer-language combinations. |
| ingestion/tests/unit/metadata/pii/test_tag_analyzer_any_language.py | New test suite adds real-Presidio regression tests, copy-safety tests for _normalize_recognizer_language, and updated tracking_build signature. Coverage is thorough across en-agent/any-recognizer, fr-agent/any-recognizer, and any-agent/any-recognizer paths. |

</details>

</details>

<details open><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[_analyze_with called] --> B{agent language == any?}
    B -- No --> C[build_analyzer_with with no effective_language]
    C --> D[effective_lang = self._language.value]
    D --> E[normalize: any to effective_lang]
    E --> F[RecognizerRegistry built with effective_lang]
    F --> G[analyze with effective_lang]
    B -- Yes --> H[groupby supported_language]
    H --> I{lang group == any?}
    I -- Yes --> J[effective_lang = en, load English NLP]
    I -- No --> K[effective_lang = lang, load lang NLP]
    J --> L[build_analyzer_with with effective_language]
    K --> L
    L --> M[normalize: any to effective_lang]
    M --> N[RecognizerRegistry built with effective_lang]
    N --> O[analyze with effective_lang]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[_analyze_with called] --> B{agent language == any?}
    B -- No --> C[build_analyzer_with with no effective_language]
    C --> D[effective_lang = self._language.value]
    D --> E[normalize: any to effective_lang]
    E --> F[RecognizerRegistry built with effective_lang]
    F --> G[analyze with effective_lang]
    B -- Yes --> H[groupby supported_language]
    H --> I{lang group == any?}
    I -- Yes --> J[effective_lang = en, load English NLP]
    I -- No --> K[effective_lang = lang, load lang NLP]
    J --> L[build_analyzer_with with effective_language]
    K --> L
    L --> M[normalize: any to effective_lang]
    M --> N[RecognizerRegistry built with effective_lang]
    N --> O[analyze with effective_lang]
```

</a>
</details>

<sub>Reviews (4): Last reviewed commit: ["fix(pii): address code review - copy-on-..."](https://github.com/open-metadata/openmetadata/commit/1c695364a7d2a4601381935f951fecac6320233e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37814467)</sub>

<!-- /greptile_comment -->