### PR TITLE
fix(mcp): prefer application/json over SSE when client accepts both

### DIFF
--- a/openmetadata-mcp/src/main/java/org/openmetadata/mcp/server/transport/HttpServletStatelessServerTransport.java
+++ b/openmetadata-mcp/src/main/java/org/openmetadata/mcp/server/transport/HttpServletStatelessServerTransport.java
@@ -183,7 +183,7 @@ public class HttpServletStatelessServerTransport extends HttpServlet
                   .block();
 
           String jsonResponseText = jsonMapper.writeValueAsString(jsonrpcResponse);
-          if (acceptsSse) {
+          if (shouldEmitSse(acceptsJson, acceptsSse)) {
             writeSseResponse(response, jsonResponseText);
           } else {
             writeJsonResponse(response, jsonResponseText);
@@ -256,6 +256,17 @@ public class HttpServletStatelessServerTransport extends HttpServlet
     PrintWriter writer = response.getWriter();
     writer.write(jsonError);
     writer.flush();
+  }
+
+  /**
+   * Picks the response media type via Accept-header content negotiation. JSON is preferred whenever
+   * the client accepts it, because the MCP Streamable HTTP spec has clients send {@code Accept:
+   * application/json, text/event-stream} and most (e.g. the ai-sdk Python client) cannot parse an
+   * SSE {@code data: } framed body. SSE is emitted only for clients that accept event-stream but
+   * NOT JSON (e.g. the Databricks Supervisor Agent client).
+   */
+  static boolean shouldEmitSse(boolean acceptsJson, boolean acceptsSse) {
+    return acceptsSse && !acceptsJson;
   }
 
   static void writeJsonResponse(HttpServletResponse response, String jsonResponseText)

--- a/openmetadata-mcp/src/test/java/org/openmetadata/mcp/server/transport/HttpServletStatelessServerTransportTest.java
+++ b/openmetadata-mcp/src/test/java/org/openmetadata/mcp/server/transport/HttpServletStatelessServerTransportTest.java
@@ -124,4 +124,19 @@ class HttpServletStatelessServerTransportTest {
   void responseFlush_writerOnly() {
     verifyNoInteractions(response);
   }
+
+  @Test
+  void shouldEmitSse_acceptsBoth_prefersJson() {
+    assertThat(HttpServletStatelessServerTransport.shouldEmitSse(true, true)).isFalse();
+  }
+
+  @Test
+  void shouldEmitSse_acceptsJsonOnly_emitsJson() {
+    assertThat(HttpServletStatelessServerTransport.shouldEmitSse(true, false)).isFalse();
+  }
+
+  @Test
+  void shouldEmitSse_acceptsSseOnly_emitsSse() {
+    assertThat(HttpServletStatelessServerTransport.shouldEmitSse(false, true)).isTrue();
+  }
 }


### PR DESCRIPTION
- fixes: https://github.com/open-metadata/OpenMetadata/issues/28557
- When a client says it can read both JSON and streaming (SSE) responses, the server now sends plain JSON.
- This fixes a bug from #27917 where the server sent a streaming response (`data: ...`) to clients that expected JSON, so they couldn't read it (e.g. the ai-sdk Python client).
- The server still sends a streaming response to clients that only accept streaming (like Databricks).
