### PR TITLE
[codex] Fix RDF Fuseki bulk write timeouts

### DIFF
--- a/conf/openmetadata.yaml
+++ b/conf/openmetadata.yaml
@@ -735,6 +735,13 @@ rdf:
   baseUri: ${RDF_BASE_URI:-"https://open-metadata.org/"}
   storageType: ${RDF_STORAGE_TYPE:-"FUSEKI"}
   remoteEndpoint: ${RDF_ENDPOINT:-"http://localhost:3030/openmetadata"}
+  connectTimeoutMs: ${RDF_CONNECT_TIMEOUT_MS:-2000}
+  requestTimeoutMs: ${RDF_REQUEST_TIMEOUT_MS:-60000}
+  writeMaxRetries: ${RDF_WRITE_MAX_RETRIES:-2}
+  writeRetryInitialBackoffMs: ${RDF_WRITE_RETRY_INITIAL_BACKOFF_MS:-250}
+  writeRetryMaxBackoffMs: ${RDF_WRITE_RETRY_MAX_BACKOFF_MS:-2000}
+  bulkEntityBatchSize: ${RDF_BULK_ENTITY_BATCH_SIZE:-50}
+  bulkRelationshipSourceBatchSize: ${RDF_BULK_RELATIONSHIP_SOURCE_BATCH_SIZE:-25}
   username: ${RDF_REMOTE_USERNAME:-"admin"}
   password: ${RDF_REMOTE_PASSWORD:-"admin"}
   dataset: ${RDF_DATASET:-"openmetadata"}

--- a/openmetadata-service/src/main/java/org/openmetadata/service/apps/bundles/rdf/RdfBatchProcessor.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/apps/bundles/rdf/RdfBatchProcessor.java
@@ -71,24 +71,19 @@ public class RdfBatchProcessor {
     String lastError = null;
     List<EntityInterface> indexedEntities = new ArrayList<>();
 
-    // Fast path: one combined SPARQL UPDATE for the whole batch. Per-entity
-    // storeEntity costs ~2 HTTP round trips (DELETE + GSP LOAD) — at ~75 ms RT
-    // on localhost it caps single-coordinator throughput at ~6.7 entities/s.
-    // Batching collapses those 2N round trips into 2 per batch.
+    // Fast path: combined SPARQL UPDATE requests for the batch. Batching
+    // collapses per-entity update requests and Fuseki transactions into a
+    // smaller number of storage-level chunks.
     //
-    // The bulk write is atomic at the Fuseki side (single SPARQL UPDATE +
-    // single GSP POST) — there's no mid-batch checkpoint where a stop signal
-    // could partially commit, so we check it once before issuing the call and
-    // once after, mirroring the previous per-entity loop's check-at-iteration
-    // semantics. A stop signal landing mid-HTTP-call still completes the
-    // current batch (preferable to leaving Fuseki in a half-applied state)
-    // and is honored on the next batch boundary.
+    // Each storage chunk is atomic at the Fuseki side. A stop signal landing
+    // mid-HTTP-call still completes the current chunk and is honored on the
+    // next batch boundary.
     //
     // If the bulk write fails (one bad model rolls back the whole batch), we
     // fall back to the per-entity loop so the indexer can still attribute the
     // failure to a specific entity instead of failing the whole batch with a
     // single composite error. The fallback is skipped when the storage layer
-    // has tripped its circuit breaker (connect failures, Fuseki unreachable):
+    // has tripped its circuit breaker (connect failures, request timeouts):
     // each of the N per-entity attempts would also fail-fast on the same
     // breaker, wasting time and amplifying error noise. We mark the whole
     // batch as failed instead and let the indexer move on — the breaker

--- a/openmetadata-service/src/main/java/org/openmetadata/service/rdf/RdfRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/rdf/RdfRepository.java
@@ -44,6 +44,8 @@ import org.openmetadata.service.resources.settings.SettingsCache;
 public class RdfRepository {
 
   private static final String KNOWLEDGE_GRAPH = "https://open-metadata.org/graph/knowledge";
+  static final int DEFAULT_BULK_ENTITY_BATCH_SIZE = 50;
+  static final int DEFAULT_BULK_RELATIONSHIP_SOURCE_BATCH_SIZE = 25;
 
   // Fallback predicate URIs for clearAllGlossaryTermRelations when
   // GlossaryTermRelationSettings can't be loaded (e.g. DB blip during startup).
@@ -118,6 +120,26 @@ public class RdfRepository {
       this.translator = null;
       LOG.info("RDF Repository disabled");
     }
+  }
+
+  RdfRepository(
+      RdfConfiguration config, RdfStorageInterface storageService, JsonLdTranslator translator) {
+    this.config = config;
+    this.storageService = storageService;
+    this.translator = translator;
+  }
+
+  static int resolveBulkEntityBatchSize(RdfConfiguration config) {
+    return positiveInt(config.getBulkEntityBatchSize(), DEFAULT_BULK_ENTITY_BATCH_SIZE);
+  }
+
+  static int resolveBulkRelationshipSourceBatchSize(RdfConfiguration config) {
+    return positiveInt(
+        config.getBulkRelationshipSourceBatchSize(), DEFAULT_BULK_RELATIONSHIP_SOURCE_BATCH_SIZE);
+  }
+
+  private static int positiveInt(Integer value, int defaultValue) {
+    return value != null && value > 0 ? value : defaultValue;
   }
 
   private void loadOntologies() {
@@ -239,14 +261,12 @@ public class RdfRepository {
    *
    * <p>Implementation note: {@link
    * org.openmetadata.service.rdf.storage.JenaFusekiStorage#bulkStoreEntities}
-   * runs the batch as a SINGLE SPARQL UPDATE containing both the combined
-   * per-entity DELETE statements and an {@code INSERT DATA} block with the
-   * unioned N-Triples body. Fuseki executes multi-statement UPDATEs in one
-   * transaction, so the write is atomic at the storage side — either the
-   * whole batch lands or nothing does. The per-entity fallback in
-   * {@code RdfBatchProcessor.processEntities} therefore only runs on
-   * payload-shape failures (a single bad RDF model the writer can't
-   * serialise), not on partial-commit recovery.
+   * runs each configured repository chunk as a SINGLE SPARQL UPDATE containing
+   * both the combined per-entity DELETE statements and an {@code INSERT DATA}
+   * block with the unioned N-Triples body. Fuseki executes multi-statement
+   * UPDATEs in one transaction, so each chunk is atomic at the storage side.
+   * The per-entity fallback in {@code RdfBatchProcessor.processEntities} keeps
+   * row-level failure attribution when a chunk fails.
    */
   public void bulkCreateOrUpdate(List<? extends EntityInterface> entities) {
     if (!isEnabled() || entities == null || entities.isEmpty()) {
@@ -260,11 +280,22 @@ public class RdfRepository {
           new RdfStorageInterface.EntityWriteRequest(entityType, entity.getId(), rdfModel));
     }
     try {
-      storageService.bulkStoreEntities(requests);
+      bulkStoreEntityRequests(requests);
       LOG.debug("Bulk created/updated {} entities in RDF store", entities.size());
     } catch (Exception e) {
       LOG.error("Failed to bulk create/update {} entities in RDF", entities.size(), e);
       throw new RuntimeException("Failed to bulk create/update entities in RDF", e);
+    }
+  }
+
+  void bulkStoreEntityRequests(List<RdfStorageInterface.EntityWriteRequest> requests) {
+    if (requests == null || requests.isEmpty()) {
+      return;
+    }
+    int chunkSize = resolveBulkEntityBatchSize(config);
+    for (int start = 0; start < requests.size(); start += chunkSize) {
+      int end = Math.min(start + chunkSize, requests.size());
+      storageService.bulkStoreEntities(requests.subList(start, end));
     }
   }
 
@@ -542,20 +573,81 @@ public class RdfRepository {
         tempModel.close();
       }
       if (reconcileSources != null) {
-        String base = config.getBaseUri().toString();
         Set<String> sourceUris = new LinkedHashSet<>();
         for (EntitySourceRef ref : reconcileSources) {
-          sourceUris.add(base + "entity/" + ref.entityType() + "/" + ref.entityId());
+          sourceUris.add(
+              storageService.buildEntityUri(ref.entityType(), ref.entityId().toString()));
         }
-        storageService.bulkStoreRelationships(relationshipDataList, sourceUris);
+        bulkStoreRelationshipData(relationshipDataList, sourceUris);
       } else {
-        storageService.bulkStoreRelationships(relationshipDataList);
+        Set<String> sourceUris = new LinkedHashSet<>();
+        for (RdfStorageInterface.RelationshipData relationshipData : relationshipDataList) {
+          sourceUris.add(
+              storageService.buildEntityUri(
+                  relationshipData.getFromType(), relationshipData.getFromId().toString()));
+        }
+        bulkStoreRelationshipData(relationshipDataList, sourceUris);
       }
       LOG.debug("Bulk added {} relationships to RDF store", relationships.size());
     } catch (Exception e) {
       LOG.error("Failed to bulk add relationships to RDF", e);
       throw new RuntimeException("Failed to bulk add relationships to RDF", e);
     }
+  }
+
+  void bulkStoreRelationshipData(
+      List<RdfStorageInterface.RelationshipData> relationships, Set<String> sourceUris) {
+    Set<String> effectiveSources = sourceUris != null ? sourceUris : Set.of();
+    if (relationships.isEmpty() && effectiveSources.isEmpty()) {
+      return;
+    }
+    if (effectiveSources.isEmpty()) {
+      storageService.bulkStoreRelationships(relationships, Set.of());
+      return;
+    }
+
+    Map<String, List<RdfStorageInterface.RelationshipData>> relationshipsBySource =
+        new LinkedHashMap<>();
+    List<RdfStorageInterface.RelationshipData> outsideSourceRelationships = new ArrayList<>();
+    for (RdfStorageInterface.RelationshipData relationship : relationships) {
+      String relationshipSourceUri =
+          storageService.buildEntityUri(
+              relationship.getFromType(), relationship.getFromId().toString());
+      if (effectiveSources.contains(relationshipSourceUri)) {
+        relationshipsBySource
+            .computeIfAbsent(relationshipSourceUri, ignored -> new ArrayList<>())
+            .add(relationship);
+      } else {
+        outsideSourceRelationships.add(relationship);
+      }
+    }
+
+    int chunkSize = resolveBulkRelationshipSourceBatchSize(config);
+    List<String> sourceChunk = new ArrayList<>(chunkSize);
+    for (String sourceUri : effectiveSources) {
+      sourceChunk.add(sourceUri);
+      if (sourceChunk.size() == chunkSize) {
+        bulkStoreRelationshipSourceChunk(sourceChunk, relationshipsBySource);
+        sourceChunk.clear();
+      }
+    }
+    if (!sourceChunk.isEmpty()) {
+      bulkStoreRelationshipSourceChunk(sourceChunk, relationshipsBySource);
+    }
+    if (!outsideSourceRelationships.isEmpty()) {
+      storageService.bulkStoreRelationships(outsideSourceRelationships, Set.of());
+    }
+  }
+
+  private void bulkStoreRelationshipSourceChunk(
+      List<String> sourceChunk,
+      Map<String, List<RdfStorageInterface.RelationshipData>> relationshipsBySource) {
+    Set<String> chunkSources = new LinkedHashSet<>(sourceChunk);
+    List<RdfStorageInterface.RelationshipData> chunkRelationships = new ArrayList<>();
+    for (String sourceUri : sourceChunk) {
+      chunkRelationships.addAll(relationshipsBySource.getOrDefault(sourceUri, List.of()));
+    }
+    storageService.bulkStoreRelationships(chunkRelationships, chunkSources);
   }
 
   /**

--- a/openmetadata-service/src/main/java/org/openmetadata/service/rdf/storage/JenaFusekiStorage.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/rdf/storage/JenaFusekiStorage.java
@@ -4,11 +4,13 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.StringWriter;
 import java.net.ConnectException;
+import java.net.SocketTimeoutException;
 import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpConnectTimeoutException;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
+import java.net.http.HttpTimeoutException;
 import java.nio.channels.ClosedChannelException;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
@@ -60,10 +62,11 @@ public class JenaFusekiStorage implements RdfStorageInterface {
   private static final String KNOWLEDGE_GRAPH = "https://open-metadata.org/graph/knowledge";
   private static final String METADATA_GRAPH = "https://open-metadata.org/graph/metadata";
 
-  // 2s caps TCP connect (Fuseki down / crash-looping). REQUEST_TIMEOUT_MS
-  // bounds the per-request body via a CompletableFuture wrapper around every
-  // blocking RDFConnection call below — caller thread frees on timeout even
-  // when Fuseki accepts the TCP connection and then stalls on the response.
+  // Defaults keep TCP connect fail-fast while giving production Fuseki enough
+  // time for larger SPARQL UPDATE transactions. The request timeout bounds the
+  // per-request body via a CompletableFuture wrapper around every blocking
+  // RDFConnection call below — caller thread frees on timeout even when Fuseki
+  // accepts the TCP connection and then stalls on the response.
   //
   // We use CompletableFuture rather than Jena's QueryExecution.setTimeout
   // (removed in Jena 5; broke integration tests previously) or Jena's
@@ -72,10 +75,14 @@ public class JenaFusekiStorage implements RdfStorageInterface {
   // versions). The wrapper is Jena-API-agnostic. On timeout the underlying
   // HTTP request continues to leak its (virtual) thread until OS-level TCP
   // give-up; that's bounded by the circuit breaker, which trips after
-  // CIRCUIT_BREAKER_FAILURE_THRESHOLD timeouts and short-circuits new
-  // traffic for CIRCUIT_BREAKER_COOLDOWN_MS.
-  private static final Duration CONNECT_TIMEOUT = Duration.ofSeconds(2);
-  private static final long REQUEST_TIMEOUT_MS = 10_000L;
+  // CIRCUIT_BREAKER_FAILURE_THRESHOLD connect/timeout failures and
+  // short-circuits new traffic for CIRCUIT_BREAKER_COOLDOWN_MS.
+  static final int DEFAULT_CONNECT_TIMEOUT_MS = 2_000;
+  static final long DEFAULT_REQUEST_TIMEOUT_MS = 60_000L;
+  static final int DEFAULT_WRITE_MAX_RETRIES = 2;
+  static final long DEFAULT_WRITE_RETRY_INITIAL_BACKOFF_MS = 250L;
+  static final long DEFAULT_WRITE_RETRY_MAX_BACKOFF_MS = 2_000L;
+
   private static final int CIRCUIT_BREAKER_FAILURE_THRESHOLD = 5;
   private static final long CIRCUIT_BREAKER_COOLDOWN_MS = 30_000L;
 
@@ -103,6 +110,11 @@ public class JenaFusekiStorage implements RdfStorageInterface {
   private final String endpoint;
   private final String username;
   private final String password;
+  private final Duration connectTimeout;
+  private final long requestTimeoutMs;
+  private final int writeMaxRetries;
+  private final long writeRetryInitialBackoffMs;
+  private final long writeRetryMaxBackoffMs;
 
   private final AtomicInteger consecutiveFailures = new AtomicInteger(0);
   private final AtomicLong circuitOpenUntilMs = new AtomicLong(0L);
@@ -117,6 +129,11 @@ public class JenaFusekiStorage implements RdfStorageInterface {
             : "http://openmetadata-fuseki:3030/openmetadata";
     this.username = config.getUsername();
     this.password = config.getPassword();
+    this.connectTimeout = Duration.ofMillis(resolveConnectTimeoutMs(config));
+    this.requestTimeoutMs = resolveRequestTimeoutMs(config);
+    this.writeMaxRetries = resolveWriteMaxRetries(config);
+    this.writeRetryInitialBackoffMs = resolveWriteRetryInitialBackoffMs(config);
+    this.writeRetryMaxBackoffMs = resolveWriteRetryMaxBackoffMs(config);
 
     // Best-effort attempt to create the dataset at startup; callers should invoke
     // ensureStorageReady() before running work to recover from later restarts of the RDF server.
@@ -125,7 +142,7 @@ public class JenaFusekiStorage implements RdfStorageInterface {
     if (username != null && password != null) {
       java.net.http.HttpClient httpClient =
           java.net.http.HttpClient.newBuilder()
-              .connectTimeout(CONNECT_TIMEOUT)
+              .connectTimeout(connectTimeout)
               .authenticator(
                   new java.net.Authenticator() {
                     @Override
@@ -140,12 +157,46 @@ public class JenaFusekiStorage implements RdfStorageInterface {
           RDFConnectionFuseki.create().destination(endpoint).httpClient(httpClient).build();
     } else {
       java.net.http.HttpClient httpClient =
-          java.net.http.HttpClient.newBuilder().connectTimeout(CONNECT_TIMEOUT).build();
+          java.net.http.HttpClient.newBuilder().connectTimeout(connectTimeout).build();
       this.connection =
           RDFConnectionFuseki.create().destination(endpoint).httpClient(httpClient).build();
     }
     LOG.info("Connected to Apache Jena Fuseki at {}", maskUserInfo(endpoint));
     loadOntology();
+  }
+
+  static int resolveConnectTimeoutMs(RdfConfiguration config) {
+    return positiveInt(config.getConnectTimeoutMs(), DEFAULT_CONNECT_TIMEOUT_MS);
+  }
+
+  static long resolveRequestTimeoutMs(RdfConfiguration config) {
+    return positiveLong(config.getRequestTimeoutMs(), DEFAULT_REQUEST_TIMEOUT_MS);
+  }
+
+  static int resolveWriteMaxRetries(RdfConfiguration config) {
+    Integer value = config.getWriteMaxRetries();
+    return value != null && value >= 0 ? value : DEFAULT_WRITE_MAX_RETRIES;
+  }
+
+  static long resolveWriteRetryInitialBackoffMs(RdfConfiguration config) {
+    return nonNegativeLong(
+        config.getWriteRetryInitialBackoffMs(), DEFAULT_WRITE_RETRY_INITIAL_BACKOFF_MS);
+  }
+
+  static long resolveWriteRetryMaxBackoffMs(RdfConfiguration config) {
+    return nonNegativeLong(config.getWriteRetryMaxBackoffMs(), DEFAULT_WRITE_RETRY_MAX_BACKOFF_MS);
+  }
+
+  private static int positiveInt(Integer value, int defaultValue) {
+    return value != null && value > 0 ? value : defaultValue;
+  }
+
+  private static long positiveLong(Integer value, long defaultValue) {
+    return value != null && value > 0 ? value.longValue() : defaultValue;
+  }
+
+  private static long nonNegativeLong(Integer value, long defaultValue) {
+    return value != null && value >= 0 ? value.longValue() : defaultValue;
   }
 
   @Override
@@ -310,7 +361,7 @@ public class JenaFusekiStorage implements RdfStorageInterface {
           info.datasetName(),
           info.serverBaseUrl());
 
-      HttpClient httpClient = HttpClient.newBuilder().connectTimeout(CONNECT_TIMEOUT).build();
+      HttpClient httpClient = HttpClient.newBuilder().connectTimeout(connectTimeout).build();
       String adminUrl =
           info.serverBaseUrl() + "/$/datasets/" + encodePathSegment(info.datasetName());
 
@@ -348,7 +399,7 @@ public class JenaFusekiStorage implements RdfStorageInterface {
   private void createDataset(
       String serverBaseUrl, String datasetName, String username, String password) {
     try {
-      HttpClient httpClient = HttpClient.newBuilder().connectTimeout(CONNECT_TIMEOUT).build();
+      HttpClient httpClient = HttpClient.newBuilder().connectTimeout(connectTimeout).build();
       String adminUrl = serverBaseUrl + "/$/datasets";
 
       String body = "dbName=" + datasetName + "&dbType=tdb2";
@@ -436,6 +487,10 @@ public class JenaFusekiStorage implements RdfStorageInterface {
     }
   }
 
+  static boolean isCircuitBreakerFailure(Throwable t) {
+    return isConnectError(t) || isTimeoutError(t);
+  }
+
   private static boolean isConnectError(Throwable t) {
     Throwable cause = t;
     while (cause != null) {
@@ -453,23 +508,99 @@ public class JenaFusekiStorage implements RdfStorageInterface {
     return false;
   }
 
+  private static boolean isTimeoutError(Throwable t) {
+    Throwable cause = t;
+    while (cause != null) {
+      if (cause instanceof TimeoutException
+          || cause instanceof HttpTimeoutException
+          || cause instanceof SocketTimeoutException) {
+        return true;
+      }
+      Throwable next = cause.getCause();
+      if (next == cause) {
+        return false;
+      }
+      cause = next;
+    }
+    return false;
+  }
+
+  private void runWriteWithRetry(Runnable op, String description) {
+    RuntimeException lastException = null;
+    for (int attempt = 0; attempt <= writeMaxRetries; attempt++) {
+      throwIfCircuitOpen(description);
+      try {
+        op.run();
+        recordSuccess();
+        return;
+      } catch (RuntimeException e) {
+        lastException = e;
+        if (isCircuitBreakerFailure(e)) {
+          recordFailure();
+          if (isCircuitOpen()) {
+            throw new RdfStorageCircuitOpenException(description, e);
+          }
+        }
+        if (attempt >= writeMaxRetries) {
+          throw e;
+        }
+        sleepBeforeRetry(description, attempt + 1, e);
+      }
+    }
+    throw lastException;
+  }
+
+  private void sleepBeforeRetry(String description, int retryNumber, RuntimeException cause) {
+    long waitTime = retryBackoffMs(retryNumber);
+    LOG.debug(
+        "Retrying RDF write {} after {} ms (retry {}/{})",
+        description,
+        waitTime,
+        retryNumber,
+        writeMaxRetries,
+        cause);
+    if (waitTime <= 0) {
+      return;
+    }
+    try {
+      Thread.sleep(waitTime);
+    } catch (InterruptedException ie) {
+      Thread.currentThread().interrupt();
+      throw new RuntimeException("Interrupted while retrying " + description, ie);
+    }
+  }
+
+  private long retryBackoffMs(int retryNumber) {
+    if (writeRetryInitialBackoffMs <= 0 || writeRetryMaxBackoffMs <= 0) {
+      return 0L;
+    }
+    long multiplier = 1L << Math.min(retryNumber - 1, 30);
+    long uncapped;
+    try {
+      uncapped = Math.multiplyExact(writeRetryInitialBackoffMs, multiplier);
+    } catch (ArithmeticException e) {
+      uncapped = Long.MAX_VALUE;
+    }
+    return Math.min(uncapped, writeRetryMaxBackoffMs);
+  }
+
   // Run a blocking RDFConnection call with a request-level deadline.
   // CompletableFuture.runAsync executes the supplier on the common ForkJoinPool;
-  // get(REQUEST_TIMEOUT_MS, …) frees this thread when the deadline hits, even
+  // get(requestTimeoutMs, …) frees this thread when the deadline hits, even
   // if the underlying HTTP request continues blocking until the server
   // responds (or the OS gives up on the socket). Exceptions thrown by the
   // supplier are unwrapped from ExecutionException so the caller sees the
   // original Jena HttpException, IOException, etc. and can decide whether to
   // retry or surface to the circuit breaker.
-  private static <T> T runWithTimeout(Supplier<T> op, String description) {
+  private <T> T runWithTimeout(Supplier<T> op, String description) {
     CompletableFuture<T> future = CompletableFuture.supplyAsync(op, TIMEOUT_EXECUTOR);
     try {
-      return future.get(REQUEST_TIMEOUT_MS, TimeUnit.MILLISECONDS);
+      return future.get(requestTimeoutMs, TimeUnit.MILLISECONDS);
     } catch (TimeoutException te) {
       // Cancellation doesn't actually interrupt Jena's HTTP call, but
       // releases this thread; the leaked task continues until OS TCP timeout.
       future.cancel(true);
-      throw new RuntimeException(description + " timed out after " + REQUEST_TIMEOUT_MS + "ms", te);
+      throw new RuntimeException(description + " timed out after " + requestTimeoutMs + "ms", te);
     } catch (ExecutionException ee) {
       Throwable cause = ee.getCause() != null ? ee.getCause() : ee;
       if (cause instanceof RuntimeException re) {
@@ -482,7 +613,7 @@ public class JenaFusekiStorage implements RdfStorageInterface {
     }
   }
 
-  private static void runWithTimeout(Runnable op, String description) {
+  private void runWithTimeout(Runnable op, String description) {
     runWithTimeout(
         () -> {
           op.run();
@@ -501,7 +632,7 @@ public class JenaFusekiStorage implements RdfStorageInterface {
   // RdfRepository.addRelationship load the existing entity model from Fuseki
   // (which includes hook-managed predicates like om:owns / om:contains) and
   // pass it here; without this exclusion the dynamic walk would pull those
-  // hook predicates into the DELETE scope and the subsequent LOAD would
+  // hook predicates into the DELETE scope and the subsequent INSERT would
   // overwrite them with a possibly-stale snapshot, opening a lost-update
   // race window with concurrent async relationship writes.
   private static Set<String> collectTranslatorPredicates(String entityUri, Model entityModel) {
@@ -559,13 +690,30 @@ public class JenaFusekiStorage implements RdfStorageInterface {
             KNOWLEDGE_GRAPH, entityUri, KNOWLEDGE_GRAPH, entityUri, filterIn);
   }
 
+  static String buildEntityUpsertUpdate(String entityUri, Model entityModel) {
+    Set<String> predicatesToDelete = collectTranslatorPredicates(entityUri, entityModel);
+    String deleteQuery = buildPredicateScopedDelete(entityUri, predicatesToDelete);
+    String triples = serializeModel(entityModel);
+    if (triples.isBlank()) {
+      return deleteQuery;
+    }
+    return deleteQuery + ";\n" + buildInsertData(triples);
+  }
+
+  private static String serializeModel(Model model) {
+    StringWriter writer = new StringWriter();
+    model.write(writer, "N-TRIPLES");
+    return writer.toString();
+  }
+
+  private static String buildInsertData(String triples) {
+    return "INSERT DATA { GRAPH <" + KNOWLEDGE_GRAPH + "> { " + triples + " } }";
+  }
+
   /**
    * Bulk variant: one combined DELETE + INSERT DATA SPARQL UPDATE for the
-   * whole batch, in a SINGLE transaction at the Fuseki side. Per-entity
-   * {@link #storeEntity} costs ~2 HTTP round trips per entity (~150 ms RT on
-   * localhost = ~6.7 entities/s); batching collapses N entities into 1
-   * round trip, so a batch of 100 entities runs at ~100× the per-entity
-   * throughput.
+   * whole batch, in a SINGLE transaction at the Fuseki side. Batching collapses
+   * N per-entity updates into one request per repository chunk.
    *
    * <p>Atomicity: previously the bulk path issued a SPARQL UPDATE for the
    * DELETE and a separate GSP POST for the LOAD, which could leave the
@@ -599,28 +747,20 @@ public class JenaFusekiStorage implements RdfStorageInterface {
       combinedModel.add(req.model());
     }
 
-    // Serialise the combined model as N-Triples and embed in INSERT DATA so
-    // the whole batch — DELETE statements + INSERT DATA — executes as ONE
-    // SPARQL UPDATE transaction at Fuseki.
-    StringWriter writer = new StringWriter();
-    combinedModel.write(writer, "N-TRIPLES");
-    String triples = writer.toString();
+    String triples = serializeModel(combinedModel);
     StringBuilder combined = new StringBuilder(combinedDelete);
     if (!triples.isBlank()) {
       if (combined.length() > 0) {
         combined.append(";\n");
       }
-      combined
-          .append("INSERT DATA { GRAPH <")
-          .append(KNOWLEDGE_GRAPH)
-          .append("> { ")
-          .append(triples)
-          .append(" } }");
+      combined.append(buildInsertData(triples));
     }
 
     try {
       UpdateRequest updateRequest = UpdateFactory.create(combined.toString());
-      runWithTimeout(() -> connection.update(updateRequest), "bulkStoreEntities");
+      runWriteWithRetry(
+          () -> runWithTimeout(() -> connection.update(updateRequest), "bulkStoreEntities"),
+          "bulkStoreEntities");
       // DEBUG, not INFO: this fires per-batch in a hot reindex loop (default
       // batchSize=100 → tens of thousands of log lines on a real reindex).
       // Keep INFO reserved for events ops actually want to grep for.
@@ -629,12 +769,8 @@ public class JenaFusekiStorage implements RdfStorageInterface {
           requests.size(),
           KNOWLEDGE_GRAPH,
           combinedModel.size());
-      recordSuccess();
     } catch (Exception e) {
       LOG.error("Failed to bulk-store {} entities in Fuseki", requests.size(), e);
-      if (isConnectError(e)) {
-        recordFailure();
-      }
       throw new RuntimeException("Failed to bulk-store entities in RDF", e);
     }
   }
@@ -660,58 +796,16 @@ public class JenaFusekiStorage implements RdfStorageInterface {
     //  - the predicates the current model actually emits for <entityUri>
     //    (covers translator-only predicates introduced via the JSON-LD
     //    context that aren't in the static set).
-    Set<String> predicatesToDelete = collectTranslatorPredicates(entityUri, entityModel);
-    String deleteQuery = buildPredicateScopedDelete(entityUri, predicatesToDelete);
-
-    int maxRetries = 3;
-    int retryCount = 0;
-    Exception lastException = null;
-
-    while (retryCount < maxRetries) {
-      try {
-        UpdateRequest deleteRequest = UpdateFactory.create(deleteQuery);
-        runWithTimeout(() -> connection.update(deleteRequest), "storeEntity delete");
-        runWithTimeout(() -> connection.load(KNOWLEDGE_GRAPH, entityModel), "storeEntity load");
-        LOG.debug("Stored entity {} in graph {}", entityId, KNOWLEDGE_GRAPH);
-        recordSuccess();
-        return;
-      } catch (org.apache.jena.atlas.web.HttpException e) {
-        lastException = e;
-        if (isConnectError(e)) {
-          recordFailure();
-          LOG.error("Fuseki unreachable storing entity {}; fast-failing without retry", entityId);
-          throw new RuntimeException("Failed to store entity in RDF (Fuseki unreachable)", e);
-        }
-        retryCount++;
-        if (retryCount < maxRetries) {
-          try {
-            long waitTime = (long) (100 * Math.pow(2, retryCount - 1));
-            LOG.debug(
-                "Retrying entity storage after {} ms (attempt {}/{}, status: {})",
-                waitTime,
-                retryCount + 1,
-                maxRetries,
-                e.getStatusCode());
-            Thread.sleep(waitTime);
-          } catch (InterruptedException ie) {
-            Thread.currentThread().interrupt();
-            throw new RuntimeException("Interrupted while retrying", ie);
-          }
-        } else {
-          LOG.error("Failed to store entity in Fuseki after {} attempts", maxRetries, e);
-          recordFailure();
-          throw new RuntimeException("Failed to store entity in RDF", e);
-        }
-      } catch (Exception e) {
-        LOG.error("Failed to store entity in Fuseki", e);
-        recordFailure();
-        throw new RuntimeException("Failed to store entity in RDF", e);
-      }
+    String upsertQuery = buildEntityUpsertUpdate(entityUri, entityModel);
+    try {
+      UpdateRequest request = UpdateFactory.create(upsertQuery);
+      runWriteWithRetry(
+          () -> runWithTimeout(() -> connection.update(request), "storeEntity"), "storeEntity");
+      LOG.debug("Stored entity {} in graph {}", entityId, KNOWLEDGE_GRAPH);
+    } catch (Exception e) {
+      LOG.error("Failed to store entity in Fuseki", e);
+      throw new RuntimeException("Failed to store entity in RDF", e);
     }
-
-    LOG.error("Failed to store entity after {} retries", maxRetries);
-    recordFailure();
-    throw new RuntimeException("Failed to store entity in RDF after retries", lastException);
   }
 
   @Override
@@ -751,58 +845,17 @@ public class JenaFusekiStorage implements RdfStorageInterface {
             toType,
             toId);
 
-    int maxRetries = 3;
-    int retryCount = 0;
-    Exception lastException = null;
-
-    while (retryCount < maxRetries) {
-      try {
-        LOG.debug("SPARQL Update Query: {}", deleteInsertQuery);
-        UpdateRequest request = UpdateFactory.create(deleteInsertQuery);
-        runWithTimeout(() -> connection.update(request), "storeRelationship");
-        LOG.debug("Stored relationship (idempotent): {} -{}- {}", fromId, relationshipType, toId);
-        recordSuccess();
-        return; // Success
-      } catch (org.apache.jena.atlas.web.HttpException e) {
-        lastException = e;
-        if (isConnectError(e)) {
-          recordFailure();
-          LOG.error(
-              "Fuseki unreachable storing relationship {}->{}; fast-failing without retry",
-              fromId,
-              toId);
-          throw new RuntimeException("Failed to store relationship in RDF (Fuseki unreachable)", e);
-        }
-        retryCount++;
-        if (retryCount < maxRetries) {
-          try {
-            long waitTime = (long) (100 * Math.pow(2, retryCount - 1));
-            LOG.debug(
-                "Retrying relationship storage after {} ms (attempt {}/{}, status: {})",
-                waitTime,
-                retryCount + 1,
-                maxRetries,
-                e.getStatusCode());
-            Thread.sleep(waitTime);
-          } catch (InterruptedException ie) {
-            Thread.currentThread().interrupt();
-            throw new RuntimeException("Interrupted while retrying", ie);
-          }
-        } else {
-          LOG.error("Failed to store relationship in Fuseki after {} attempts", maxRetries, e);
-          recordFailure();
-          throw new RuntimeException("Failed to store relationship in RDF", e);
-        }
-      } catch (Exception e) {
-        LOG.error("Failed to store relationship in Fuseki", e);
-        recordFailure();
-        throw new RuntimeException("Failed to store relationship in RDF", e);
-      }
+    try {
+      LOG.debug("SPARQL Update Query: {}", deleteInsertQuery);
+      UpdateRequest request = UpdateFactory.create(deleteInsertQuery);
+      runWriteWithRetry(
+          () -> runWithTimeout(() -> connection.update(request), "storeRelationship"),
+          "storeRelationship");
+      LOG.debug("Stored relationship (idempotent): {} -{}- {}", fromId, relationshipType, toId);
+    } catch (Exception e) {
+      LOG.error("Failed to store relationship in Fuseki", e);
+      throw new RuntimeException("Failed to store relationship in RDF", e);
     }
-
-    LOG.error("Failed to store relationship after {} retries", maxRetries);
-    recordFailure();
-    throw new RuntimeException("Failed to store relationship in RDF after retries", lastException);
   }
 
   @Override
@@ -910,15 +963,15 @@ public class JenaFusekiStorage implements RdfStorageInterface {
         // above.
       }
       UpdateRequest request = UpdateFactory.create(combined.toString());
-      runWithTimeout(() -> connection.update(request), "bulkStoreRelationships");
+      runWriteWithRetry(
+          () -> runWithTimeout(() -> connection.update(request), "bulkStoreRelationships"),
+          "bulkStoreRelationships");
       LOG.info(
           "Bulk stored {} relationships, reconciled {} source entities",
           relationships.size(),
           effectiveSources.size());
-      recordSuccess();
     } catch (Exception e) {
       LOG.error("Failed to bulk store relationships in Fuseki", e);
-      recordFailure();
       throw new RuntimeException("Failed to bulk store relationships in RDF", e);
     }
   }
@@ -949,7 +1002,7 @@ public class JenaFusekiStorage implements RdfStorageInterface {
       return result.isEmpty() ? null : result;
     } catch (Exception e) {
       LOG.error("Failed to get entity from Fuseki", e);
-      if (isConnectError(e)) {
+      if (isCircuitBreakerFailure(e)) {
         recordFailure();
       }
       return null;
@@ -975,7 +1028,7 @@ public class JenaFusekiStorage implements RdfStorageInterface {
       recordSuccess();
     } catch (Exception e) {
       LOG.error("Failed to delete entity from Fuseki", e);
-      if (isConnectError(e)) {
+      if (isCircuitBreakerFailure(e)) {
         recordFailure();
       }
       throw new RuntimeException("Failed to delete entity from RDF", e);
@@ -992,7 +1045,7 @@ public class JenaFusekiStorage implements RdfStorageInterface {
       return result;
     } catch (Exception e) {
       LOG.error("Failed to execute SPARQL query on Fuseki", e);
-      if (isConnectError(e)) {
+      if (isCircuitBreakerFailure(e)) {
         recordFailure();
       }
       throw new RuntimeException("Failed to execute SPARQL query", e);
@@ -1069,7 +1122,7 @@ public class JenaFusekiStorage implements RdfStorageInterface {
       recordSuccess();
     } catch (Exception e) {
       LOG.error("Failed to execute SPARQL update on Fuseki", e);
-      if (isConnectError(e)) {
+      if (isCircuitBreakerFailure(e)) {
         recordFailure();
       }
       throw new RuntimeException("Failed to execute SPARQL update", e);
@@ -1097,7 +1150,7 @@ public class JenaFusekiStorage implements RdfStorageInterface {
       recordSuccess();
     } catch (Exception e) {
       LOG.error("Failed to load Turtle file into Fuseki", e);
-      if (isConnectError(e)) {
+      if (isCircuitBreakerFailure(e)) {
         recordFailure();
       }
       throw new RuntimeException("Failed to load Turtle file", e);
@@ -1119,7 +1172,7 @@ public class JenaFusekiStorage implements RdfStorageInterface {
           });
       recordSuccess();
     } catch (Exception e) {
-      if (isConnectError(e)) {
+      if (isCircuitBreakerFailure(e)) {
         recordFailure();
       }
       throw e;
@@ -1140,7 +1193,7 @@ public class JenaFusekiStorage implements RdfStorageInterface {
         return results.next().getLiteral("count").getLong();
       }
     } catch (Exception e) {
-      if (isConnectError(e)) {
+      if (isCircuitBreakerFailure(e)) {
         recordFailure();
       }
       throw e;
@@ -1158,7 +1211,7 @@ public class JenaFusekiStorage implements RdfStorageInterface {
       recordSuccess();
     } catch (Exception e) {
       LOG.error("Failed to clear graph on Fuseki", e);
-      if (isConnectError(e)) {
+      if (isCircuitBreakerFailure(e)) {
         recordFailure();
       }
       throw new RuntimeException("Failed to clear graph", e);
@@ -1248,7 +1301,7 @@ public class JenaFusekiStorage implements RdfStorageInterface {
   }
 
   private String startCompaction(DatasetEndpoint info) throws IOException, InterruptedException {
-    HttpClient httpClient = HttpClient.newBuilder().connectTimeout(CONNECT_TIMEOUT).build();
+    HttpClient httpClient = HttpClient.newBuilder().connectTimeout(connectTimeout).build();
     String compactUrl =
         info.serverBaseUrl()
             + "/$/compact/"
@@ -1303,7 +1356,7 @@ public class JenaFusekiStorage implements RdfStorageInterface {
 
   private void waitForCompactionTask(String serverBaseUrl, String userInfo, String taskId)
       throws InterruptedException {
-    HttpClient httpClient = HttpClient.newBuilder().connectTimeout(CONNECT_TIMEOUT).build();
+    HttpClient httpClient = HttpClient.newBuilder().connectTimeout(connectTimeout).build();
     String taskUrl = serverBaseUrl + "/$/tasks/" + encodePathSegment(taskId);
     long deadline = System.currentTimeMillis() + COMPACT_MAX_WAIT_MS;
     // Poll-then-sleep ordering: the very first iteration checks immediately so

--- a/openmetadata-service/src/main/java/org/openmetadata/service/rdf/storage/JenaFusekiStorage.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/rdf/storage/JenaFusekiStorage.java
@@ -29,6 +29,8 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.BooleanSupplier;
+import java.util.function.LongConsumer;
 import java.util.function.Supplier;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.jena.query.Query;
@@ -115,11 +117,16 @@ public class JenaFusekiStorage implements RdfStorageInterface {
   private final int writeMaxRetries;
   private final long writeRetryInitialBackoffMs;
   private final long writeRetryMaxBackoffMs;
+  private final LongConsumer retryDelayMs;
 
   private final AtomicInteger consecutiveFailures = new AtomicInteger(0);
   private final AtomicLong circuitOpenUntilMs = new AtomicLong(0L);
 
   public JenaFusekiStorage(RdfConfiguration config) {
+    this(config, JenaFusekiStorage::sleepRetryDelay);
+  }
+
+  JenaFusekiStorage(RdfConfiguration config, LongConsumer retryDelayMs) {
     this.baseUri =
         config.getBaseUri() != null ? config.getBaseUri().toString() : "https://open-metadata.org/";
 
@@ -134,6 +141,7 @@ public class JenaFusekiStorage implements RdfStorageInterface {
     this.writeMaxRetries = resolveWriteMaxRetries(config);
     this.writeRetryInitialBackoffMs = resolveWriteRetryInitialBackoffMs(config);
     this.writeRetryMaxBackoffMs = resolveWriteRetryMaxBackoffMs(config);
+    this.retryDelayMs = retryDelayMs;
 
     // Best-effort attempt to create the dataset at startup; callers should invoke
     // ensureStorageReady() before running work to recover from later restarts of the RDF server.
@@ -526,32 +534,71 @@ public class JenaFusekiStorage implements RdfStorageInterface {
   }
 
   private void runWriteWithRetry(Runnable op, String description) {
+    runWriteWithRetry(
+        op,
+        description,
+        writeMaxRetries,
+        writeRetryInitialBackoffMs,
+        writeRetryMaxBackoffMs,
+        retryDelayMs,
+        () -> throwIfCircuitOpen(description),
+        this::recordSuccess,
+        this::recordFailure,
+        this::isCircuitOpen);
+  }
+
+  static void runWriteWithRetry(
+      Runnable op,
+      String description,
+      int writeMaxRetries,
+      long writeRetryInitialBackoffMs,
+      long writeRetryMaxBackoffMs,
+      LongConsumer retryDelayMs,
+      Runnable throwIfCircuitOpen,
+      Runnable recordSuccess,
+      Runnable recordFailure,
+      BooleanSupplier isCircuitOpen) {
     RuntimeException lastException = null;
     for (int attempt = 0; attempt <= writeMaxRetries; attempt++) {
-      throwIfCircuitOpen(description);
+      throwIfCircuitOpen.run();
       try {
         op.run();
-        recordSuccess();
+        recordSuccess.run();
         return;
       } catch (RuntimeException e) {
         lastException = e;
-        if (isCircuitBreakerFailure(e)) {
-          recordFailure();
-          if (isCircuitOpen()) {
-            throw new RdfStorageCircuitOpenException(description, e);
-          }
+        if (!isCircuitBreakerFailure(e)) {
+          throw e;
+        }
+        recordFailure.run();
+        if (isCircuitOpen.getAsBoolean()) {
+          throw new RdfStorageCircuitOpenException(description, e);
         }
         if (attempt >= writeMaxRetries) {
           throw e;
         }
-        sleepBeforeRetry(description, attempt + 1, e);
+        sleepBeforeRetry(
+            description,
+            attempt + 1,
+            e,
+            writeMaxRetries,
+            writeRetryInitialBackoffMs,
+            writeRetryMaxBackoffMs,
+            retryDelayMs);
       }
     }
     throw lastException;
   }
 
-  private void sleepBeforeRetry(String description, int retryNumber, RuntimeException cause) {
-    long waitTime = retryBackoffMs(retryNumber);
+  private static void sleepBeforeRetry(
+      String description,
+      int retryNumber,
+      RuntimeException cause,
+      int writeMaxRetries,
+      long writeRetryInitialBackoffMs,
+      long writeRetryMaxBackoffMs,
+      LongConsumer retryDelayMs) {
+    long waitTime = retryBackoffMs(retryNumber, writeRetryInitialBackoffMs, writeRetryMaxBackoffMs);
     LOG.debug(
         "Retrying RDF write {} after {} ms (retry {}/{})",
         description,
@@ -562,15 +609,20 @@ public class JenaFusekiStorage implements RdfStorageInterface {
     if (waitTime <= 0) {
       return;
     }
+    retryDelayMs.accept(waitTime);
+  }
+
+  private static void sleepRetryDelay(long waitTime) {
     try {
       Thread.sleep(waitTime);
     } catch (InterruptedException ie) {
       Thread.currentThread().interrupt();
-      throw new RuntimeException("Interrupted while retrying " + description, ie);
+      throw new RuntimeException("Interrupted while retrying RDF write", ie);
     }
   }
 
-  private long retryBackoffMs(int retryNumber) {
+  private static long retryBackoffMs(
+      int retryNumber, long writeRetryInitialBackoffMs, long writeRetryMaxBackoffMs) {
     if (writeRetryInitialBackoffMs <= 0 || writeRetryMaxBackoffMs <= 0) {
       return 0L;
     }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/rdf/storage/RdfStorageCircuitOpenException.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/rdf/storage/RdfStorageCircuitOpenException.java
@@ -32,4 +32,8 @@ public class RdfStorageCircuitOpenException extends RuntimeException {
   public RdfStorageCircuitOpenException(String operation) {
     super("RDF circuit breaker is open; skipping " + operation + " until storage recovers");
   }
+
+  public RdfStorageCircuitOpenException(String operation, Throwable cause) {
+    super("RDF circuit breaker is open; skipping " + operation + " until storage recovers", cause);
+  }
 }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/rdf/storage/RdfStorageInterface.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/rdf/storage/RdfStorageInterface.java
@@ -23,10 +23,9 @@ public interface RdfStorageInterface {
    * <p>The default loops over {@link #storeEntity(String, UUID, Model)} per
    * entity — backward-compatible for backends that don't expose a batch path.
    * Backends with a streaming/transactional protocol (e.g. Fuseki's SPARQL
-   * UPDATE) SHOULD override this to issue one combined DELETE+LOAD per batch:
-   * the per-entity path costs ~2 HTTP round trips per entity (DELETE-scope +
-   * GSP POST) and dominated re-index throughput at ~6.7 entities/s before
-   * batching, even on localhost.
+   * UPDATE) SHOULD override this to issue one combined DELETE+INSERT per
+   * batch, reducing both request count and Fuseki transaction overhead during
+   * re-indexing.
    *
    * <p>Failure semantics: a batch is all-or-nothing — if the combined update
    * fails, the caller MUST fall back to per-entity {@link #storeEntity} to

--- a/openmetadata-service/src/test/java/org/openmetadata/service/rdf/RdfRepositoryBulkChunkingTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/rdf/RdfRepositoryBulkChunkingTest.java
@@ -1,0 +1,172 @@
+/*
+ *  Copyright 2026 Collate
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.openmetadata.service.rdf;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import java.net.URI;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+import org.apache.jena.rdf.model.ModelFactory;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.openmetadata.schema.api.configuration.rdf.RdfConfiguration;
+import org.openmetadata.service.rdf.storage.RdfStorageInterface;
+
+@DisplayName("RdfRepository bulk chunking")
+class RdfRepositoryBulkChunkingTest {
+
+  private static final String BASE_URI = "https://open-metadata.org/";
+
+  @Test
+  @DisplayName("bulk entity requests are split by configured chunk size")
+  void bulkEntityRequestsAreChunked() {
+    RdfStorageInterface storage = storageMock();
+    RdfRepository repository =
+        new RdfRepository(config().withBulkEntityBatchSize(2), storage, null);
+    List<RdfStorageInterface.EntityWriteRequest> requests =
+        List.of(
+            entityRequest(), entityRequest(), entityRequest(), entityRequest(), entityRequest());
+
+    repository.bulkStoreEntityRequests(requests);
+
+    @SuppressWarnings("unchecked")
+    ArgumentCaptor<List<RdfStorageInterface.EntityWriteRequest>> captor =
+        ArgumentCaptor.forClass(List.class);
+    verify(storage, times(3)).bulkStoreEntities(captor.capture());
+    assertEquals(2, captor.getAllValues().get(0).size());
+    assertEquals(2, captor.getAllValues().get(1).size());
+    assertEquals(1, captor.getAllValues().get(2).size());
+  }
+
+  @Test
+  @DisplayName("zero-edge relationship cleanup still reconciles every source chunk")
+  void zeroEdgeRelationshipCleanupIsChunkedBySource() {
+    RdfStorageInterface storage = storageMock();
+    RdfRepository repository =
+        new RdfRepository(config().withBulkRelationshipSourceBatchSize(2), storage, null);
+    Set<String> sources =
+        new LinkedHashSet<>(
+            List.of(
+                entityUri("table", UUID.randomUUID()),
+                entityUri("table", UUID.randomUUID()),
+                entityUri("table", UUID.randomUUID())));
+
+    repository.bulkStoreRelationshipData(List.of(), sources);
+
+    @SuppressWarnings("unchecked")
+    ArgumentCaptor<List<RdfStorageInterface.RelationshipData>> relationshipsCaptor =
+        ArgumentCaptor.forClass(List.class);
+    @SuppressWarnings("unchecked")
+    ArgumentCaptor<Set<String>> sourcesCaptor = ArgumentCaptor.forClass(Set.class);
+    verify(storage, times(2))
+        .bulkStoreRelationships(relationshipsCaptor.capture(), sourcesCaptor.capture());
+    assertEquals(0, relationshipsCaptor.getAllValues().get(0).size());
+    assertEquals(0, relationshipsCaptor.getAllValues().get(1).size());
+    assertEquals(2, sourcesCaptor.getAllValues().get(0).size());
+    assertEquals(1, sourcesCaptor.getAllValues().get(1).size());
+  }
+
+  @Test
+  @DisplayName("outside-batch incoming relationships are inserted once without reconciliation")
+  void outsideBatchIncomingRelationshipsAreInsertedOnce() {
+    RdfStorageInterface storage = storageMock();
+    RdfRepository repository =
+        new RdfRepository(config().withBulkRelationshipSourceBatchSize(2), storage, null);
+    UUID sourceA = UUID.randomUUID();
+    UUID sourceB = UUID.randomUUID();
+    UUID sourceC = UUID.randomUUID();
+    UUID outsideSource = UUID.randomUUID();
+    Set<String> reconcileSources =
+        new LinkedHashSet<>(
+            List.of(
+                entityUri("table", sourceA),
+                entityUri("table", sourceB),
+                entityUri("table", sourceC)));
+    RdfStorageInterface.RelationshipData ownedA = relationship(sourceA, UUID.randomUUID());
+    RdfStorageInterface.RelationshipData ownedC = relationship(sourceC, UUID.randomUUID());
+    RdfStorageInterface.RelationshipData outside = relationship(outsideSource, UUID.randomUUID());
+
+    repository.bulkStoreRelationshipData(List.of(ownedA, ownedC, outside), reconcileSources);
+
+    @SuppressWarnings("unchecked")
+    ArgumentCaptor<List<RdfStorageInterface.RelationshipData>> relationshipsCaptor =
+        ArgumentCaptor.forClass(List.class);
+    @SuppressWarnings("unchecked")
+    ArgumentCaptor<Set<String>> sourcesCaptor = ArgumentCaptor.forClass(Set.class);
+    verify(storage, times(3))
+        .bulkStoreRelationships(relationshipsCaptor.capture(), sourcesCaptor.capture());
+
+    assertEquals(List.of(ownedA), relationshipsCaptor.getAllValues().get(0));
+    assertEquals(List.of(ownedC), relationshipsCaptor.getAllValues().get(1));
+    assertEquals(List.of(outside), relationshipsCaptor.getAllValues().get(2));
+    assertEquals(2, sourcesCaptor.getAllValues().get(0).size());
+    assertEquals(1, sourcesCaptor.getAllValues().get(1).size());
+    assertEquals(Set.of(), sourcesCaptor.getAllValues().get(2));
+  }
+
+  @Test
+  @DisplayName("unset chunking config uses defaults")
+  void unsetChunkingConfigUsesDefaults() {
+    RdfConfiguration config = config();
+
+    assertEquals(
+        RdfRepository.DEFAULT_BULK_ENTITY_BATCH_SIZE,
+        RdfRepository.resolveBulkEntityBatchSize(config));
+    assertEquals(
+        RdfRepository.DEFAULT_BULK_RELATIONSHIP_SOURCE_BATCH_SIZE,
+        RdfRepository.resolveBulkRelationshipSourceBatchSize(config));
+  }
+
+  private static RdfConfiguration config() {
+    return new RdfConfiguration().withEnabled(true).withBaseUri(URI.create(BASE_URI));
+  }
+
+  private static RdfStorageInterface storageMock() {
+    RdfStorageInterface storage = mock(RdfStorageInterface.class);
+    doAnswer(
+            invocation ->
+                entityUri(
+                    invocation.getArgument(0, String.class),
+                    invocation.getArgument(1, String.class)))
+        .when(storage)
+        .buildEntityUri(anyString(), anyString());
+    return storage;
+  }
+
+  private static RdfStorageInterface.EntityWriteRequest entityRequest() {
+    return new RdfStorageInterface.EntityWriteRequest(
+        "table", UUID.randomUUID(), ModelFactory.createDefaultModel());
+  }
+
+  private static RdfStorageInterface.RelationshipData relationship(UUID fromId, UUID toId) {
+    return new RdfStorageInterface.RelationshipData(
+        "table", fromId, "database", toId, "CONTAINS", BASE_URI + "ontology/contains");
+  }
+
+  private static String entityUri(String entityType, UUID entityId) {
+    return entityUri(entityType, entityId.toString());
+  }
+
+  private static String entityUri(String entityType, String entityId) {
+    return BASE_URI + "entity/" + entityType + "/" + entityId;
+  }
+}

--- a/openmetadata-service/src/test/java/org/openmetadata/service/rdf/storage/JenaFusekiStorageTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/rdf/storage/JenaFusekiStorageTest.java
@@ -18,9 +18,14 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.UUID;
+import java.util.concurrent.TimeoutException;
+import org.apache.jena.rdf.model.Model;
+import org.apache.jena.rdf.model.ModelFactory;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.openmetadata.schema.api.configuration.rdf.RdfConfiguration;
 
 /**
  * Unit tests for the package-private helpers on {@link JenaFusekiStorage}.
@@ -34,6 +39,97 @@ import org.junit.jupiter.api.Test;
  */
 @DisplayName("JenaFusekiStorage helper tests")
 class JenaFusekiStorageTest {
+
+  @Nested
+  @DisplayName("configuration defaults")
+  class ConfigurationDefaultTests {
+
+    @Test
+    @DisplayName("unset values use production-safe defaults")
+    void unsetValuesUseDefaults() {
+      RdfConfiguration config = new RdfConfiguration();
+
+      assertEquals(
+          JenaFusekiStorage.DEFAULT_CONNECT_TIMEOUT_MS,
+          JenaFusekiStorage.resolveConnectTimeoutMs(config));
+      assertEquals(
+          JenaFusekiStorage.DEFAULT_REQUEST_TIMEOUT_MS,
+          JenaFusekiStorage.resolveRequestTimeoutMs(config));
+      assertEquals(
+          JenaFusekiStorage.DEFAULT_WRITE_MAX_RETRIES,
+          JenaFusekiStorage.resolveWriteMaxRetries(config));
+      assertEquals(
+          JenaFusekiStorage.DEFAULT_WRITE_RETRY_INITIAL_BACKOFF_MS,
+          JenaFusekiStorage.resolveWriteRetryInitialBackoffMs(config));
+      assertEquals(
+          JenaFusekiStorage.DEFAULT_WRITE_RETRY_MAX_BACKOFF_MS,
+          JenaFusekiStorage.resolveWriteRetryMaxBackoffMs(config));
+    }
+
+    @Test
+    @DisplayName("positive configured values override defaults")
+    void configuredValuesOverrideDefaults() {
+      RdfConfiguration config =
+          new RdfConfiguration()
+              .withConnectTimeoutMs(1234)
+              .withRequestTimeoutMs(9876)
+              .withWriteMaxRetries(4)
+              .withWriteRetryInitialBackoffMs(55)
+              .withWriteRetryMaxBackoffMs(777);
+
+      assertEquals(1234, JenaFusekiStorage.resolveConnectTimeoutMs(config));
+      assertEquals(9876, JenaFusekiStorage.resolveRequestTimeoutMs(config));
+      assertEquals(4, JenaFusekiStorage.resolveWriteMaxRetries(config));
+      assertEquals(55, JenaFusekiStorage.resolveWriteRetryInitialBackoffMs(config));
+      assertEquals(777, JenaFusekiStorage.resolveWriteRetryMaxBackoffMs(config));
+    }
+  }
+
+  @Nested
+  @DisplayName("request timeout classification")
+  class RequestTimeoutClassificationTests {
+
+    @Test
+    @DisplayName("CompletableFuture timeout wrappers count as circuit-breaker failures")
+    void timeoutExceptionCountsAsCircuitBreakerFailure() {
+      RuntimeException wrapped =
+          new RuntimeException("bulkStoreEntities timed out", new TimeoutException());
+
+      assertTrue(JenaFusekiStorage.isCircuitBreakerFailure(wrapped));
+    }
+
+    @Test
+    @DisplayName("payload failures do not count as circuit-breaker failures")
+    void payloadFailureDoesNotCountAsCircuitBreakerFailure() {
+      assertFalse(
+          JenaFusekiStorage.isCircuitBreakerFailure(new IllegalArgumentException("bad RDF")));
+    }
+  }
+
+  @Nested
+  @DisplayName("entity upsert query")
+  class EntityUpsertQueryTests {
+
+    @Test
+    @DisplayName("storeEntity helper emits one DELETE + INSERT DATA update")
+    void entityUpsertCombinesDeleteAndInsert() {
+      UUID entityId = UUID.randomUUID();
+      String entityUri = "https://open-metadata.org/entity/table/" + entityId;
+      Model model = ModelFactory.createDefaultModel();
+      model
+          .createResource(entityUri)
+          .addProperty(
+              model.createProperty("http://www.w3.org/2000/01/rdf-schema#label"), "orders");
+
+      String update = JenaFusekiStorage.buildEntityUpsertUpdate(entityUri, model);
+
+      assertTrue(update.contains("DELETE { GRAPH <https://open-metadata.org/graph/knowledge>"));
+      assertTrue(
+          update.contains("INSERT DATA { GRAPH <https://open-metadata.org/graph/knowledge>"));
+      assertTrue(update.indexOf("DELETE") < update.indexOf("INSERT DATA"));
+      assertTrue(update.contains("orders"));
+    }
+  }
 
   @Nested
   @DisplayName("parseDatasetEndpoint")

--- a/openmetadata-service/src/test/java/org/openmetadata/service/rdf/storage/JenaFusekiStorageTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/rdf/storage/JenaFusekiStorageTest.java
@@ -16,10 +16,14 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.UUID;
 import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.ModelFactory;
 import org.junit.jupiter.api.DisplayName;
@@ -103,6 +107,74 @@ class JenaFusekiStorageTest {
     void payloadFailureDoesNotCountAsCircuitBreakerFailure() {
       assertFalse(
           JenaFusekiStorage.isCircuitBreakerFailure(new IllegalArgumentException("bad RDF")));
+    }
+  }
+
+  @Nested
+  @DisplayName("write retry policy")
+  class WriteRetryPolicyTests {
+
+    @Test
+    @DisplayName("non-transient write failures are not retried or delayed")
+    void nonTransientWriteFailuresAreNotRetriedOrDelayed() {
+      AtomicInteger attempts = new AtomicInteger();
+      AtomicInteger failureRecords = new AtomicInteger();
+      AtomicLong delayMs = new AtomicLong();
+      IllegalArgumentException failure = new IllegalArgumentException("bad RDF payload");
+
+      IllegalArgumentException thrown =
+          assertThrows(
+              IllegalArgumentException.class,
+              () ->
+                  JenaFusekiStorage.runWriteWithRetry(
+                      () -> {
+                        attempts.incrementAndGet();
+                        throw failure;
+                      },
+                      "testWrite",
+                      2,
+                      250,
+                      2_000,
+                      delayMs::addAndGet,
+                      () -> {},
+                      () -> {},
+                      failureRecords::incrementAndGet,
+                      () -> false));
+
+      assertSame(failure, thrown);
+      assertEquals(1, attempts.get());
+      assertEquals(0, failureRecords.get());
+      assertEquals(0, delayMs.get());
+    }
+
+    @Test
+    @DisplayName("transient write failures are retried with injected delay")
+    void transientWriteFailuresAreRetriedWithInjectedDelay() {
+      AtomicInteger attempts = new AtomicInteger();
+      AtomicInteger successes = new AtomicInteger();
+      AtomicInteger failureRecords = new AtomicInteger();
+      AtomicLong delayMs = new AtomicLong();
+
+      JenaFusekiStorage.runWriteWithRetry(
+          () -> {
+            if (attempts.incrementAndGet() <= 2) {
+              throw new RuntimeException("timed out", new TimeoutException());
+            }
+          },
+          "testWrite",
+          2,
+          250,
+          2_000,
+          delayMs::addAndGet,
+          () -> {},
+          successes::incrementAndGet,
+          failureRecords::incrementAndGet,
+          () -> false);
+
+      assertEquals(3, attempts.get());
+      assertEquals(1, successes.get());
+      assertEquals(2, failureRecords.get());
+      assertEquals(750, delayMs.get());
     }
   }
 

--- a/openmetadata-spec/src/main/resources/json/schema/api/configuration/rdfConfiguration.json
+++ b/openmetadata-spec/src/main/resources/json/schema/api/configuration/rdfConfiguration.json
@@ -30,6 +30,48 @@
       "type": "string",
       "format": "uri"
     },
+    "connectTimeoutMs": {
+      "description": "Timeout in milliseconds for establishing connections to RDF storage.",
+      "type": "integer",
+      "default": 2000,
+      "minimum": 1
+    },
+    "requestTimeoutMs": {
+      "description": "Timeout in milliseconds for individual RDF storage requests.",
+      "type": "integer",
+      "default": 60000,
+      "minimum": 1
+    },
+    "writeMaxRetries": {
+      "description": "Maximum number of retries for idempotent RDF write requests after the initial attempt.",
+      "type": "integer",
+      "default": 2,
+      "minimum": 0
+    },
+    "writeRetryInitialBackoffMs": {
+      "description": "Initial backoff in milliseconds before retrying an RDF write request.",
+      "type": "integer",
+      "default": 250,
+      "minimum": 0
+    },
+    "writeRetryMaxBackoffMs": {
+      "description": "Maximum backoff in milliseconds between RDF write request retries.",
+      "type": "integer",
+      "default": 2000,
+      "minimum": 0
+    },
+    "bulkEntityBatchSize": {
+      "description": "Maximum number of entity models written to RDF storage in a single bulk request.",
+      "type": "integer",
+      "default": 50,
+      "minimum": 1
+    },
+    "bulkRelationshipSourceBatchSize": {
+      "description": "Maximum number of source entities reconciled in a single RDF relationship bulk request.",
+      "type": "integer",
+      "default": 25,
+      "minimum": 1
+    },
     "username": {
       "description": "Username for RDF storage authentication",
       "type": "string"

--- a/openmetadata-ui/src/main/resources/ui/src/generated/api/configuration/rdfConfiguration.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/api/configuration/rdfConfiguration.ts
@@ -19,9 +19,21 @@ export interface RDFConfiguration {
      */
     baseUri?: string;
     /**
+     * Maximum number of entity models written to RDF storage in a single bulk request.
+     */
+    bulkEntityBatchSize?: number;
+    /**
+     * Maximum number of source entities reconciled in a single RDF relationship bulk request.
+     */
+    bulkRelationshipSourceBatchSize?: number;
+    /**
      * Cache inferred triples for better query performance (requires more storage)
      */
     cacheInferredTriples?: boolean;
+    /**
+     * Timeout in milliseconds for establishing connections to RDF storage.
+     */
+    connectTimeoutMs?: number;
     /**
      * Dataset name in RDF storage
      */
@@ -50,6 +62,10 @@ export interface RDFConfiguration {
      */
     remoteEndpoint?: string;
     /**
+     * Timeout in milliseconds for individual RDF storage requests.
+     */
+    requestTimeoutMs?: number;
+    /**
      * Type of RDF storage backend
      */
     storageType: StorageType;
@@ -57,6 +73,18 @@ export interface RDFConfiguration {
      * Username for RDF storage authentication
      */
     username?: string;
+    /**
+     * Maximum number of retries for idempotent RDF write requests after the initial attempt.
+     */
+    writeMaxRetries?: number;
+    /**
+     * Initial backoff in milliseconds before retrying an RDF write request.
+     */
+    writeRetryInitialBackoffMs?: number;
+    /**
+     * Maximum backoff in milliseconds between RDF write request retries.
+     */
+    writeRetryMaxBackoffMs?: number;
 }
 
 /**


### PR DESCRIPTION
### Describe your changes:

Fixes #<issue-number>

I worked on RDF Fuseki bulk write resiliency because production RDF indexing can exceed the previous hardcoded 10s request deadline.
This adds configurable RDF timeouts, bounded retries for idempotent atomic writes, smaller entity and relationship-source chunks, and preserves source-scoped relationship reconciliation so outside-batch lineage sources are not wiped.

#
### Type of change:

- [x] Bug fix
- [x] Improvement

#
### High-level design:

RDF storage now reads safe timeout and retry defaults from `RdfConfiguration`, applies retries only around idempotent write paths, and makes `storeEntity` a single DELETE plus INSERT DATA SPARQL update.
Repository bulk paths split entity writes and relationship source reconciliation into configured chunks while keeping each source chunk atomic and inserting outside-batch incoming lineage edges without adding their sources to reconciliation.

#
### Tests:

#### Use cases covered

- RDF timeout defaults and configured overrides are extracted from `RdfConfiguration`.
- RDF request timeouts are classified as circuit-breaker failures.
- `storeEntity` emits one atomic DELETE plus INSERT DATA update.
- RDF bulk entity writes are chunked by configured batch size.
- Zero-edge relationship cleanup still reconciles every source chunk.
- Outside-batch incoming lineage relationships are inserted once without reconciling those outside sources.

#### Unit tests

- [x] I added unit tests for the new/changed logic.
- Files added/updated:
  - `openmetadata-service/src/test/java/org/openmetadata/service/rdf/storage/JenaFusekiStorageTest.java`
  - `openmetadata-service/src/test/java/org/openmetadata/service/rdf/RdfRepositoryBulkChunkingTest.java`
- Coverage %: Not measured.

#### Backend integration tests

- [x] Not applicable (no backend API changes).

#### Ingestion integration tests

- [x] Not applicable (no ingestion changes).

#### Playwright (UI) tests

- [x] Not applicable (no UI changes).

#### Manual testing performed

- `mvn -pl openmetadata-spec -DskipTests generate-sources`
- `mvn -pl openmetadata-service -DskipTests -DskipITs test-compile`
- `mvn -pl openmetadata-service -Dtest=JenaFusekiStorageTest,RdfRepositoryBulkChunkingTest,RdfBatchProcessorTest,RdfIndexAppTest test`
- `mvn -pl openmetadata-service spotless:apply`
- Re-ran `mvn -pl openmetadata-service -Dtest=JenaFusekiStorageTest,RdfRepositoryBulkChunkingTest,RdfBatchProcessorTest,RdfIndexAppTest test`
- `git diff --check`

#
### UI screen recording / screenshots:

Not applicable.

#
### Checklist:

- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] For JSON Schema changes: I updated the configuration schema; migration scripts are not needed because this is runtime configuration, not persisted entity data.
- [x] For UI changes: Not applicable.
- [x] I have added tests (unit / integration / Playwright as applicable) and listed them above.

<!-- Bug fix -->
- [x] I have added a test that covers the exact scenario we are fixing.

<!-- Improvement -->
- [x] I have added tests around the new logic.
