### PR TITLE
fix(search): backport immense-term children mapping fix to 1.12.10

### DIFF
--- a/bootstrap/sql/migrations/native/1.12.10/mysql/schemaChanges.sql
+++ b/bootstrap/sql/migrations/native/1.12.10/mysql/schemaChanges.sql
@@ -1,0 +1,3 @@
+-- Placeholder for 1.12.10 MySQL schema changes
+-- No DDL changes required; this version only carries a data migration
+-- (scrub of stale flattened-children references from SearchSettings).

--- a/bootstrap/sql/migrations/native/1.12.10/postgres/schemaChanges.sql
+++ b/bootstrap/sql/migrations/native/1.12.10/postgres/schemaChanges.sql
@@ -1,0 +1,3 @@
+-- Placeholder for 1.12.10 Postgres schema changes
+-- No DDL changes required; this version only carries a data migration
+-- (scrub of stale flattened-children references from SearchSettings).

--- a/openmetadata-service/src/main/java/org/openmetadata/service/migration/mysql/v11210/Migration.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/migration/mysql/v11210/Migration.java
@@ -1,0 +1,33 @@
+/*
+ *  Copyright 2024 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.openmetadata.service.migration.mysql.v11210;
+
+import lombok.SneakyThrows;
+import lombok.extern.slf4j.Slf4j;
+import org.openmetadata.service.migration.api.MigrationProcessImpl;
+import org.openmetadata.service.migration.utils.MigrationFile;
+import org.openmetadata.service.migration.utils.v11210.MigrationUtil;
+
+@Slf4j
+public class Migration extends MigrationProcessImpl {
+
+  public Migration(MigrationFile migrationFile) {
+    super(migrationFile);
+  }
+
+  @Override
+  @SneakyThrows
+  public void runDataMigration() {
+    MigrationUtil.removeFlattenedChildrenSearchSettings();
+  }
+}

--- a/openmetadata-service/src/main/java/org/openmetadata/service/migration/postgres/v11210/Migration.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/migration/postgres/v11210/Migration.java
@@ -1,0 +1,33 @@
+/*
+ *  Copyright 2024 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.openmetadata.service.migration.postgres.v11210;
+
+import lombok.SneakyThrows;
+import lombok.extern.slf4j.Slf4j;
+import org.openmetadata.service.migration.api.MigrationProcessImpl;
+import org.openmetadata.service.migration.utils.MigrationFile;
+import org.openmetadata.service.migration.utils.v11210.MigrationUtil;
+
+@Slf4j
+public class Migration extends MigrationProcessImpl {
+
+  public Migration(MigrationFile migrationFile) {
+    super(migrationFile);
+  }
+
+  @Override
+  @SneakyThrows
+  public void runDataMigration() {
+    MigrationUtil.removeFlattenedChildrenSearchSettings();
+  }
+}

--- a/openmetadata-service/src/main/java/org/openmetadata/service/migration/utils/v11210/MigrationUtil.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/migration/utils/v11210/MigrationUtil.java
@@ -1,0 +1,118 @@
+/*
+ *  Copyright 2024 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.openmetadata.service.migration.utils.v11210;
+
+import static org.openmetadata.common.utils.CommonUtil.listOrEmpty;
+import static org.openmetadata.common.utils.CommonUtil.nullOrEmpty;
+
+import java.util.List;
+import java.util.Set;
+import lombok.extern.slf4j.Slf4j;
+import org.openmetadata.schema.api.search.AllowedSearchFields;
+import org.openmetadata.schema.api.search.AssetTypeConfiguration;
+import org.openmetadata.schema.api.search.FieldBoost;
+import org.openmetadata.schema.api.search.SearchSettings;
+import org.openmetadata.schema.settings.Settings;
+import org.openmetadata.service.migration.utils.SearchSettingsMergeUtil;
+
+@Slf4j
+public class MigrationUtil {
+  private MigrationUtil() {}
+
+  // The recursive column/schema children subtree was remapped from flattened to
+  // object/enabled:false. Its indexed leaves no longer exist so references to
+  // columns.children.name, dataModel.columns.children.name, and the schemaFields
+  // variants in highlightFields, searchFields, and allowedFields are now dead weight.
+  // Upgraded clusters keep the stale entries because the additive settings merge
+  // preserves stored asset config wholesale; this scrub removes exactly those entries.
+  private static final Set<String> STALE_FLATTENED_CHILDREN_FIELDS =
+      Set.of(
+          "columns.children.name",
+          "columns.children.description",
+          "dataModel.columns.children.name",
+          "messageSchema.schemaFields.children.name",
+          "requestSchema.schemaFields.children.name",
+          "responseSchema.schemaFields.children.name");
+
+  /**
+   * Removes every reference to the now non-indexed {@code *.children} fields from the DB-stored
+   * SearchSettings on clusters upgrading to 1.12.10. The recursive column/schema {@code children}
+   * subtree is mapped {@code object} with {@code "enabled": false} — stored for display, not
+   * indexed — so its leaves no longer resolve. Idempotent; safe to call on every reprocessing pass.
+   */
+  public static void removeFlattenedChildrenSearchSettings() {
+    try {
+      Settings searchSettings = SearchSettingsMergeUtil.getSearchSettingsFromDatabase();
+      if (searchSettings == null) {
+        LOG.warn("Search settings not found in database; skipping flattened-children scrub");
+      } else {
+        SearchSettings currentSettings = SearchSettingsMergeUtil.loadSearchSettings(searchSettings);
+        if (stripFlattenedChildrenReferences(currentSettings)) {
+          SearchSettingsMergeUtil.saveSearchSettings(searchSettings, currentSettings);
+          LOG.info("Removed stale flattened children references from search settings");
+        } else {
+          LOG.info("No stale flattened children references found in search settings");
+        }
+      }
+    } catch (Exception e) {
+      LOG.error("Error removing stale flattened children references from search settings", e);
+    }
+  }
+
+  public static boolean stripFlattenedChildrenReferences(SearchSettings settings) {
+    boolean changed = false;
+    if (settings != null) {
+      if (settings.getGlobalSettings() != null) {
+        changed = removeStaleHighlightFields(settings.getGlobalSettings().getHighlightFields());
+      }
+      for (AssetTypeConfiguration assetConfig :
+          listOrEmpty(settings.getAssetTypeConfigurations())) {
+        changed |= removeStaleHighlightFields(assetConfig.getHighlightFields());
+        changed |= removeStaleSearchFields(assetConfig.getSearchFields());
+      }
+      changed |= removeStaleAllowedFields(settings.getAllowedFields());
+    }
+    return changed;
+  }
+
+  private static boolean removeStaleHighlightFields(List<String> highlightFields) {
+    boolean removed = false;
+    if (!nullOrEmpty(highlightFields)) {
+      removed = highlightFields.removeIf(STALE_FLATTENED_CHILDREN_FIELDS::contains);
+    }
+    return removed;
+  }
+
+  private static boolean removeStaleSearchFields(List<FieldBoost> searchFields) {
+    boolean removed = false;
+    if (!nullOrEmpty(searchFields)) {
+      removed =
+          searchFields.removeIf(
+              field -> STALE_FLATTENED_CHILDREN_FIELDS.contains(field.getField()));
+    }
+    return removed;
+  }
+
+  private static boolean removeStaleAllowedFields(List<AllowedSearchFields> allowedFields) {
+    boolean removed = false;
+    for (AllowedSearchFields allowedField : listOrEmpty(allowedFields)) {
+      if (!nullOrEmpty(allowedField.getFields())) {
+        removed |=
+            allowedField
+                .getFields()
+                .removeIf(field -> STALE_FLATTENED_CHILDREN_FIELDS.contains(field.getName()));
+      }
+    }
+    return removed;
+  }
+}

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/indexes/ContainerIndex.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/indexes/ContainerIndex.java
@@ -73,7 +73,7 @@ public record ContainerIndex(Container container) implements ColumnIndex {
     fields.put(DATA_MODEL_COLUMNS_NAME_KEYWORD, 10.0f);
     fields.put("dataModel.columns.displayName", 2.0f);
     fields.put("dataModel.columns.description", 1.0f);
-    fields.put("dataModel.columns.children.name", 2.0f);
+    fields.put("columnNamesFuzzy", 2.0f);
     return fields;
   }
 }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/indexes/DashboardDataModelIndex.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/indexes/DashboardDataModelIndex.java
@@ -67,7 +67,7 @@ public record DashboardDataModelIndex(DashboardDataModel dashboardDataModel)
     fields.put("columns.name", 2.0f);
     fields.put("columns.displayName", 1.0f);
     fields.put("columns.description", 1.0f);
-    fields.put("columns.children.name", 2.0f);
+    fields.put("columnNamesFuzzy", 2.0f);
     return fields;
   }
 }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/indexes/TableIndex.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/indexes/TableIndex.java
@@ -98,7 +98,7 @@ public record TableIndex(Table table) implements ColumnIndex {
     fields.put("columns.name", 5.0f);
     fields.put("columns.displayName", 5.0f);
     fields.put("columns.description", 2.0f);
-    fields.put("columns.children.name", 3.0f);
+    fields.put("columnNamesFuzzy", 3.0f);
     return fields;
   }
 }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/indexes/WorksheetIndex.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/indexes/WorksheetIndex.java
@@ -83,7 +83,7 @@ public record WorksheetIndex(Worksheet worksheet) implements ColumnIndex {
     fields.put("columns.name", 5.0f);
     fields.put("columns.displayName", 5.0f);
     fields.put("columns.description", 2.0f);
-    fields.put("columns.children.name", 3.0f);
+    fields.put("columnNamesFuzzy", 3.0f);
     return fields;
   }
 }

--- a/openmetadata-service/src/main/resources/json/data/settings/searchSettings.json
+++ b/openmetadata-service/src/main/resources/json/data/settings/searchSettings.json
@@ -335,11 +335,6 @@
           "matchType": "exact"
         },
         {
-          "field": "columns.children.name",
-          "boost": 1.0,
-          "matchType": "exact"
-        },
-        {
           "field": "columnNamesFuzzy",
           "boost": 1.5,
           "matchType": "standard"
@@ -602,11 +597,6 @@
         },
         {
           "field": "messageSchema.schemaFields.name.keyword",
-          "boost": 1.0,
-          "matchType": "exact"
-        },
-        {
-          "field": "messageSchema.schemaFields.children.name",
           "boost": 1.0,
           "matchType": "exact"
         },
@@ -1284,18 +1274,8 @@
           "matchType": "exact"
         },
         {
-          "field": "responseSchema.schemaFields.children.name",
-          "boost": 5.0,
-          "matchType": "exact"
-        },
-        {
           "field": "requestSchema.schemaFields.name.keyword",
           "boost": 8.0,
-          "matchType": "exact"
-        },
-        {
-          "field": "requestSchema.schemaFields.children.name",
-          "boost": 5.0,
           "matchType": "exact"
         }
       ],
@@ -2358,10 +2338,6 @@
           "description": "Exact match on column display names. Useful for finding tables with columns having specific user-friendly names."
         },
         {
-          "name": "columns.children.name",
-          "description": "Search for nested columns within complex data types. Helps find tables with specific nested fields."
-        },
-        {
           "name": "tags.tagFQN.text",
           "description": "Search within parts of tag names. Use this to find tables with tags containing specific terms like 'Sensitive' or 'PII', regardless of the full tag hierarchy."
         },
@@ -2384,10 +2360,6 @@
         {
           "name": "columns.description",
           "description": "Full-text search on column descriptions to find tables based on specific column purposes or contents."
-        },
-        {
-          "name": "columns.children.description",
-          "description": "Search on descriptions of nested columns within complex data types. Helps find tables with nested fields serving specific purposes."
         }
       ]
     },
@@ -2547,10 +2519,6 @@
         {
           "name": "messageSchema.schemaFields.description",
           "description": "Search within field descriptions in the message schema to find topics with fields serving specific purposes."
-        },
-        {
-          "name": "messageSchema.schemaFields.children.name",
-          "description": "Search on nested field names within complex schema structures."
         },
         {
           "name": "tags.tagFQN.text",
@@ -2725,10 +2693,6 @@
         {
           "name": "columns.description",
           "description": "Search on column descriptions to find data models with fields serving specific purposes."
-        },
-        {
-          "name": "columns.children.name",
-          "description": "Search on nested field names within complex column structures."
         },
         {
           "name": "tags.tagFQN.text",
@@ -2999,10 +2963,6 @@
           "description": "Search on column descriptions to find containers with fields serving specific purposes."
         },
         {
-          "name": "dataModel.columns.children.name",
-          "description": "Search on nested field names within complex data structures in the container."
-        },
-        {
           "name": "tags.tagFQN.text",
           "description": "Search within parts of tag names. Use this to find containers with tags containing specific terms like 'Sensitive' or 'PII', regardless of the full tag hierarchy."
         },
@@ -3072,10 +3032,6 @@
           "description": "Search on field descriptions in the response schema to find endpoints with fields serving specific purposes."
         },
         {
-          "name": "responseSchema.schemaFields.children.name",
-          "description": "Search on nested field names within complex response schema structures."
-        },
-        {
           "name": "requestSchema.schemaFields.name",
           "description": "Search on field names in the API request schema to find endpoints accepting specific data fields."
         },
@@ -3086,10 +3042,6 @@
         {
           "name": "requestSchema.schemaFields.description",
           "description": "Search on field descriptions in the request schema to find endpoints with fields serving specific purposes."
-        },
-        {
-          "name": "requestSchema.schemaFields.children.name",
-          "description": "Search on nested field names within complex request schema structures."
         },
         {
           "name": "tags.tagFQN.text",

--- a/openmetadata-spec/src/main/resources/elasticsearch/en/api_endpoint_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/en/api_endpoint_index_mapping.json
@@ -351,7 +351,8 @@
                 }
               },
               "children": {
-                "type": "flattened"
+                "type": "object",
+                "enabled": false
               }
             }
           }
@@ -405,7 +406,8 @@
                 }
               },
               "children": {
-                "type": "flattened"
+                "type": "object",
+                "enabled": false
               }
             }
           }

--- a/openmetadata-spec/src/main/resources/elasticsearch/en/container_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/en/container_index_mapping.json
@@ -423,7 +423,8 @@
                 }
               },
               "children": {
-                "type": "flattened"
+                "type": "object",
+                "enabled": false
               }
             }
           }

--- a/openmetadata-spec/src/main/resources/elasticsearch/en/container_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/en/container_index_mapping.json
@@ -800,6 +800,10 @@
       "columnNames": {
         "type": "keyword"
       },
+      "columnNamesFuzzy": {
+        "type": "text",
+        "analyzer": "om_analyzer"
+      },
       "serviceType": {
         "type": "keyword",
         "normalizer": "lowercase_normalizer"

--- a/openmetadata-spec/src/main/resources/elasticsearch/en/dashboard_data_model_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/en/dashboard_data_model_index_mapping.json
@@ -600,6 +600,10 @@
       "columnNames": {
         "type": "keyword"
       },
+      "columnNamesFuzzy": {
+        "type": "text",
+        "analyzer": "om_analyzer"
+      },
       "project": {
         "type": "text",
         "fields": {

--- a/openmetadata-spec/src/main/resources/elasticsearch/en/dashboard_data_model_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/en/dashboard_data_model_index_mapping.json
@@ -592,7 +592,8 @@
             }
           },
           "children": {
-            "type": "flattened"
+            "type": "object",
+            "enabled": false
           }
         }
       },

--- a/openmetadata-spec/src/main/resources/elasticsearch/en/search_entity_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/en/search_entity_index_mapping.json
@@ -234,7 +234,8 @@
             }
           },
           "children": {
-            "type": "flattened"
+            "type": "object",
+            "enabled": false
           }
         }
       },

--- a/openmetadata-spec/src/main/resources/elasticsearch/en/table_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/en/table_index_mapping.json
@@ -294,6 +294,10 @@
       "columnNames": {
         "type": "keyword"
       },
+      "columnNamesFuzzy": {
+        "type": "text",
+        "analyzer": "om_analyzer"
+      },
       "databaseSchema": {
         "properties": {
           "id": {

--- a/openmetadata-spec/src/main/resources/elasticsearch/en/table_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/en/table_index_mapping.json
@@ -286,7 +286,8 @@
             }
           },
           "children": {
-            "type": "flattened"
+            "type": "object",
+            "enabled": false
           }
         }
       },

--- a/openmetadata-spec/src/main/resources/elasticsearch/en/topic_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/en/topic_index_mapping.json
@@ -313,7 +313,8 @@
                 }
               },
               "children": {
-                "type": "flattened"
+                "type": "object",
+                "enabled": false
               }
             }
           }

--- a/openmetadata-spec/src/main/resources/elasticsearch/en/worksheet_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/en/worksheet_index_mapping.json
@@ -457,7 +457,8 @@
             }
           },
           "children": {
-            "type": "flattened"
+            "type": "object",
+            "enabled": false
           }
         }
       },

--- a/openmetadata-spec/src/main/resources/elasticsearch/jp/api_endpoint_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/jp/api_endpoint_index_mapping.json
@@ -352,7 +352,8 @@
                 }
               },
               "children": {
-                "type": "flattened"
+                "type": "object",
+                "enabled": false
               }
             }
           }
@@ -405,7 +406,8 @@
                 }
               },
               "children": {
-                "type": "flattened"
+                "type": "object",
+                "enabled": false
               }
             }
           }

--- a/openmetadata-spec/src/main/resources/elasticsearch/jp/container_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/jp/container_index_mapping.json
@@ -463,7 +463,8 @@
                 "type": "integer"
               },
               "children": {
-                "type": "flattened"
+                "type": "object",
+                "enabled": false
               }
             }
           }

--- a/openmetadata-spec/src/main/resources/elasticsearch/jp/container_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/jp/container_index_mapping.json
@@ -726,6 +726,10 @@
       "columnNames": {
         "type": "keyword"
       },
+      "columnNamesFuzzy": {
+        "type": "text",
+        "analyzer": "om_analyzer"
+      },
       "serviceType": {
         "type": "keyword",
         "normalizer": "lowercase_normalizer"

--- a/openmetadata-spec/src/main/resources/elasticsearch/jp/dashboard_data_model_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/jp/dashboard_data_model_index_mapping.json
@@ -557,6 +557,10 @@
       "columnNames": {
         "type": "keyword"
       },
+      "columnNamesFuzzy": {
+        "type": "text",
+        "analyzer": "om_analyzer"
+      },
       "project": {
         "type": "text",
         "fields": {

--- a/openmetadata-spec/src/main/resources/elasticsearch/jp/dashboard_data_model_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/jp/dashboard_data_model_index_mapping.json
@@ -549,7 +549,8 @@
             "type": "integer"
           },
           "children": {
-            "type": "flattened"
+            "type": "object",
+            "enabled": false
           }
         }
       },

--- a/openmetadata-spec/src/main/resources/elasticsearch/jp/search_entity_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/jp/search_entity_index_mapping.json
@@ -233,7 +233,8 @@
             }
           },
           "children": {
-            "type": "flattened"
+            "type": "object",
+            "enabled": false
           }
         }
       },

--- a/openmetadata-spec/src/main/resources/elasticsearch/jp/table_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/jp/table_index_mapping.json
@@ -230,7 +230,8 @@
             "type": "integer"
           },
           "children": {
-            "type": "flattened"
+            "type": "object",
+            "enabled": false
           }
         }
       },

--- a/openmetadata-spec/src/main/resources/elasticsearch/jp/table_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/jp/table_index_mapping.json
@@ -238,6 +238,10 @@
       "columnNames": {
         "type": "keyword"
       },
+      "columnNamesFuzzy": {
+        "type": "text",
+        "analyzer": "om_analyzer"
+      },
       "databaseSchema": {
         "properties": {
           "id": {

--- a/openmetadata-spec/src/main/resources/elasticsearch/jp/topic_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/jp/topic_index_mapping.json
@@ -373,7 +373,8 @@
                 }
               },
               "children": {
-                "type": "flattened"
+                "type": "object",
+                "enabled": false
               }
             }
           }

--- a/openmetadata-spec/src/main/resources/elasticsearch/jp/worksheet_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/jp/worksheet_index_mapping.json
@@ -236,7 +236,8 @@
             "type": "integer"
           },
           "children": {
-            "type": "flattened"
+            "type": "object",
+            "enabled": false
           }
         }
       },

--- a/openmetadata-spec/src/main/resources/elasticsearch/ru/api_endpoint_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/ru/api_endpoint_index_mapping.json
@@ -369,7 +369,8 @@
                 }
               },
               "children": {
-                "type": "flattened"
+                "type": "object",
+                "enabled": false
               }
             }
           }
@@ -423,7 +424,8 @@
                 }
               },
               "children": {
-                "type": "flattened"
+                "type": "object",
+                "enabled": false
               }
             }
           }

--- a/openmetadata-spec/src/main/resources/elasticsearch/ru/container_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/ru/container_index_mapping.json
@@ -764,6 +764,10 @@
       "columnNames": {
         "type": "keyword"
       },
+      "columnNamesFuzzy": {
+        "type": "text",
+        "analyzer": "om_analyzer"
+      },
       "serviceType": {
         "type": "keyword",
         "normalizer": "lowercase_normalizer"

--- a/openmetadata-spec/src/main/resources/elasticsearch/ru/container_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/ru/container_index_mapping.json
@@ -388,7 +388,8 @@
                 "type": "integer"
               },
               "children": {
-                "type": "flattened"
+                "type": "object",
+                "enabled": false
               }
             }
           }

--- a/openmetadata-spec/src/main/resources/elasticsearch/ru/dashboard_data_model_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/ru/dashboard_data_model_index_mapping.json
@@ -564,7 +564,8 @@
             "type": "integer"
           },
           "children": {
-            "type": "flattened"
+            "type": "object",
+            "enabled": false
           }
         }
       },

--- a/openmetadata-spec/src/main/resources/elasticsearch/ru/dashboard_data_model_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/ru/dashboard_data_model_index_mapping.json
@@ -572,6 +572,10 @@
       "columnNames": {
         "type": "keyword"
       },
+      "columnNamesFuzzy": {
+        "type": "text",
+        "analyzer": "om_analyzer"
+      },
       "project": {
         "type": "text",
         "fields": {

--- a/openmetadata-spec/src/main/resources/elasticsearch/ru/search_entity_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/ru/search_entity_index_mapping.json
@@ -252,7 +252,8 @@
             }
           },
           "children": {
-            "type": "flattened"
+            "type": "object",
+            "enabled": false
           }
         }
       },

--- a/openmetadata-spec/src/main/resources/elasticsearch/ru/table_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/ru/table_index_mapping.json
@@ -259,6 +259,10 @@
       "columnNames": {
         "type": "keyword"
       },
+      "columnNamesFuzzy": {
+        "type": "text",
+        "analyzer": "om_analyzer"
+      },
       "databaseSchema": {
         "properties": {
           "id": {

--- a/openmetadata-spec/src/main/resources/elasticsearch/ru/table_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/ru/table_index_mapping.json
@@ -251,7 +251,8 @@
             "type": "integer"
           },
           "children": {
-            "type": "flattened"
+            "type": "object",
+            "enabled": false
           }
         }
       },

--- a/openmetadata-spec/src/main/resources/elasticsearch/ru/topic_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/ru/topic_index_mapping.json
@@ -331,7 +331,8 @@
                 }
               },
               "children": {
-                "type": "flattened"
+                "type": "object",
+                "enabled": false
               }
             }
           }

--- a/openmetadata-spec/src/main/resources/elasticsearch/ru/worksheet_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/ru/worksheet_index_mapping.json
@@ -333,7 +333,8 @@
             "type": "integer"
           },
           "children": {
-            "type": "flattened"
+            "type": "object",
+            "enabled": false
           }
         }
       },

--- a/openmetadata-spec/src/main/resources/elasticsearch/zh/api_endpoint_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/zh/api_endpoint_index_mapping.json
@@ -346,7 +346,8 @@
                 }
               },
               "children": {
-                "type": "flattened"
+                "type": "object",
+                "enabled": false
               }
             }
           }
@@ -400,7 +401,8 @@
                 }
               },
               "children": {
-                "type": "flattened"
+                "type": "object",
+                "enabled": false
               }
             }
           }

--- a/openmetadata-spec/src/main/resources/elasticsearch/zh/container_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/zh/container_index_mapping.json
@@ -367,7 +367,8 @@
                 "type": "integer"
               },
               "children": {
-                "type": "flattened"
+                "type": "object",
+                "enabled": false
               }
             }
           }

--- a/openmetadata-spec/src/main/resources/elasticsearch/zh/container_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/zh/container_index_mapping.json
@@ -728,6 +728,10 @@
       "columnNames": {
         "type": "keyword"
       },
+      "columnNamesFuzzy": {
+        "type": "text",
+        "analyzer": "om_analyzer"
+      },
       "serviceType": {
         "type": "keyword",
         "normalizer": "lowercase_normalizer"

--- a/openmetadata-spec/src/main/resources/elasticsearch/zh/dashboard_data_model_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/zh/dashboard_data_model_index_mapping.json
@@ -558,6 +558,10 @@
       "columnNames": {
         "type": "keyword"
       },
+      "columnNamesFuzzy": {
+        "type": "text",
+        "analyzer": "om_analyzer"
+      },
       "project": {
         "type": "text",
         "fields": {

--- a/openmetadata-spec/src/main/resources/elasticsearch/zh/dashboard_data_model_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/zh/dashboard_data_model_index_mapping.json
@@ -550,7 +550,8 @@
             "type": "integer"
           },
           "children": {
-            "type": "flattened"
+            "type": "object",
+            "enabled": false
           }
         }
       },

--- a/openmetadata-spec/src/main/resources/elasticsearch/zh/search_entity_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/zh/search_entity_index_mapping.json
@@ -200,7 +200,8 @@
             }
           },
           "children": {
-            "type": "flattened"
+            "type": "object",
+            "enabled": false
           }
         }
       },

--- a/openmetadata-spec/src/main/resources/elasticsearch/zh/table_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/zh/table_index_mapping.json
@@ -387,7 +387,8 @@
             "type": "integer"
           },
           "children": {
-            "type": "flattened"
+            "type": "object",
+            "enabled": false
           }
         }
       },

--- a/openmetadata-spec/src/main/resources/elasticsearch/zh/table_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/zh/table_index_mapping.json
@@ -395,6 +395,10 @@
       "columnNames": {
         "type": "keyword"
       },
+      "columnNamesFuzzy": {
+        "type": "text",
+        "analyzer": "om_analyzer"
+      },
       "databaseSchema": {
         "properties": {
           "id": {

--- a/openmetadata-spec/src/main/resources/elasticsearch/zh/topic_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/zh/topic_index_mapping.json
@@ -310,7 +310,8 @@
                 }
               },
               "children": {
-                "type": "flattened"
+                "type": "object",
+                "enabled": false
               }
             }
           }

--- a/openmetadata-spec/src/main/resources/elasticsearch/zh/worksheet_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/zh/worksheet_index_mapping.json
@@ -210,7 +210,8 @@
             "type": "integer"
           },
           "children": {
-            "type": "flattened"
+            "type": "object",
+            "enabled": false
           }
         }
       },

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/SearchIndexNestedColumns.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/SearchIndexNestedColumns.spec.ts
@@ -1,0 +1,136 @@
+/*
+ *  Copyright 2025 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+import test, { expect } from '@playwright/test';
+import { Column, DataType } from '../../../src/generated/entity/data/table';
+import { TableClass } from '../../support/entity/TableClass';
+import { createNewPage, redirectToHomePage, uuid } from '../../utils/common';
+
+test.use({ storageState: 'playwright/.auth/admin.json' });
+
+const LUCENE_MAX_TERM_BYTES = 32766;
+const NESTING_DEPTH = 25;
+
+// word_delimiter fragments alphanumeric runs on letter/digit boundaries, so a token carrying hex
+// digits tokenizes inconsistently between the indexed column name and the query. Letters-only keeps
+// the leaf name a single, exactly-matchable term.
+const lettersToken = (): string => `pw${uuid().replace(/[^a-z]/g, '')}`;
+
+// A >32 KB multi-byte expression (mirrors a real Looker/DAX measure) that, indexed as one keyword
+// term under the flattened children field, tripped Lucene's per-term limit and failed indexing.
+const buildOversizedExpression = (): string => {
+  const unit =
+    'Expression : SUM(CASE WHEN revenue > 0 THEN revenue END) 収益 / ';
+  let value = '';
+  while (Buffer.byteLength(value, 'utf8') < LUCENE_MAX_TERM_BYTES + 20000) {
+    value += unit;
+  }
+
+  return value;
+};
+
+const table = new TableClass();
+const leafColumnName = `deepleaf${lettersToken()}`;
+
+// A struct column nested NESTING_DEPTH levels deep (past index.mapping.depth.limit) whose deepest
+// leaf carries the oversized expression — the combined depth + immense-term worst case.
+const buildDeeplyNestedOversizedColumn = (): Column => {
+  let column = {
+    name: leafColumnName,
+    dataType: DataType.Varchar,
+    dataLength: 256,
+    dataTypeDisplay: 'varchar(256)',
+    description: buildOversizedExpression(),
+  } as Column;
+
+  for (let level = NESTING_DEPTH; level >= 1; level--) {
+    column = {
+      name: `lvl${level}${lettersToken()}`,
+      dataType: DataType.Struct,
+      dataTypeDisplay: 'struct<...>',
+      children: [column],
+    } as Column;
+  }
+
+  return column;
+};
+
+test.describe('Search index - deeply nested oversized columns', () => {
+  test.beforeAll(async ({ browser }) => {
+    const { apiContext, afterAction } = await createNewPage(browser);
+    table.entity.columns = [
+      buildDeeplyNestedOversizedColumn(),
+      ...table.entity.columns,
+    ];
+    await table.create(apiContext);
+
+    // Indexing is async. On the pre-fix flattened mapping the oversized leaf failed the bulk insert
+    // (immense term) and the table never reached the index; object/enabled:false lets it index.
+    await expect
+      .poll(
+        async () => {
+          const response = await apiContext.get(
+            `/api/v1/search/query?q=${encodeURIComponent(
+              table.entity.name
+            )}&index=table&from=0&size=10`
+          );
+          const body = await response.json();
+
+          return (body?.hits?.hits ?? []).some(
+            (hit: { _source?: { name?: string } }) =>
+              hit._source?.name === table.entity.name
+          );
+        },
+        { timeout: 90_000, intervals: [2_000] }
+      )
+      .toBe(true);
+    await afterAction();
+  });
+
+  test.afterAll(async ({ browser }) => {
+    const { apiContext, afterAction } = await createNewPage(browser);
+    await table.delete(apiContext);
+    await afterAction();
+  });
+
+  test.beforeEach(async ({ page }) => {
+    await redirectToHomePage(page);
+  });
+
+  test('25-level oversized nested column indexes and is searchable by its deep column name', async ({
+    page,
+  }) => {
+    const searchInput = page.getByTestId('searchBox');
+    const suggestions = page.locator(
+      '[data-testid="global-search-suggestion-box"]'
+    );
+
+    // Indexing: the table indexed despite the >32 KB nested leaf, so it is found by name.
+    await searchInput.click();
+    const byNameResponse = page.waitForResponse('/api/v1/search/query?*');
+    await searchInput.fill(table.entity.name);
+    await byNameResponse;
+
+    await expect(suggestions).toBeVisible();
+    await expect(suggestions).toContainText(table.entity.name);
+
+    // Searching: the 25-level-deep column name surfaces the table via columnNamesFuzzy - the
+    // mechanism that replaced the dropped flattened columns.children.name search field.
+    await searchInput.clear();
+    const byColumnResponse = page.waitForResponse('/api/v1/search/query?*');
+    await searchInput.fill(leafColumnName);
+    await byColumnResponse;
+
+    await expect(suggestions).toBeVisible();
+    await expect(suggestions).toContainText(table.entity.name);
+  });
+});

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/searchSettingUtils.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/searchSettingUtils.ts
@@ -36,7 +36,6 @@ export const mockEntitySearchConfig = {
     { field: 'fqnParts', boost: 5, matchType: 'standard' },
     { field: 'columns.name.keyword', boost: 2, matchType: 'exact' },
     { field: 'columns.displayName.keyword', boost: 2, matchType: 'exact' },
-    { field: 'columns.children.name', boost: 1, matchType: 'exact' },
     { field: 'columnNamesFuzzy', boost: 1.5, matchType: 'standard' },
   ],
   highlightFields: ['name', 'description', 'displayName'],


### PR DESCRIPTION
## Summary

Backport of main PR #28509 to the 1.12.10 release branch.

- **Mapping change**: Remap `children` from `flattened` → `object/enabled:false` across all 7 affected index mappings (4 locales × 7 indexes). The `flattened` type indexed every nested leaf as a keyword term; a leaf longer than Lucene's 32,766-byte limit (e.g. a large Looker/DAX expression) failed the whole document's reindex. `object/enabled:false` stores the subtree in `_source` for display but never indexes it.
- **Index class fix**: Replace dead `columns.children.name` / `dataModel.columns.children.name` search field with `columnNamesFuzzy` in `TableIndex`, `ContainerIndex`, `DashboardDataModelIndex`, `WorksheetIndex`.
- **SearchSettings seed**: Remove 11 stale `*.children` field entries from `searchSettings.json`.
- **v11210 migration**: Scrub the same stale entries from DB-stored `SearchSettings` on upgrade. Idempotent — `removeIf` on an already-clean list is a no-op, so clusters that later upgrade to 1.13.0 run the scrub again in v1130 safely.
- **Playwright E2E test** (`SearchIndexNestedColumns.spec.ts`): Creates a 25-level-deep column with a >32 KB leaf expression, verifies the table indexes without an `immense_term` failure, and confirms the deep column name is searchable via `columnNamesFuzzy`.

## What's NOT included

- v1130 migration (1.13.0 only)
- Integration tests (`SearchIndexImmenseTermIT`, `FlattenedChildrenHighlightSearchIT`)
- Sample data changes

## Test plan

- [ ] Verify reindex completes without `immense_term` failure on a table/container with deeply nested columns
- [ ] Verify `columns.children.name` / `dataModel.columns.children.name` are absent from search settings after upgrade migration runs
- [ ] Confirm container search returns 200 on OpenSearch after upgrade (no "no associated analyzer" on highlight)
- [ ] `SearchIndexNestedColumns.spec.ts` — 25-level oversized nested column indexes and is searchable by deep column name