### PR TITLE
Fix flaky domain & data product rename by proceeding on search version conflicts

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/elasticsearch/ElasticSearchEntityManager.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/elasticsearch/ElasticSearchEntityManager.java
@@ -18,6 +18,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import es.co.elastic.clients.elasticsearch.ElasticsearchAsyncClient;
 import es.co.elastic.clients.elasticsearch.ElasticsearchClient;
 import es.co.elastic.clients.elasticsearch._types.BulkIndexByScrollFailure;
+import es.co.elastic.clients.elasticsearch._types.Conflicts;
 import es.co.elastic.clients.elasticsearch._types.ElasticsearchException;
 import es.co.elastic.clients.elasticsearch._types.ErrorCause;
 import es.co.elastic.clients.elasticsearch._types.FieldValue;
@@ -959,6 +960,7 @@ public class ElasticSearchEntityManager implements EntityManagementClient {
               req ->
                   req.index(Entity.getSearchRepository().getIndexOrAliasName(GLOBAL_SEARCH_ALIAS))
                       .query(termQuery)
+                      .conflicts(Conflicts.Proceed)
                       .script(
                           s ->
                               s.source(ss -> ss.scriptString(UPDATE_DATA_PRODUCT_FQN_SCRIPT))
@@ -1024,6 +1026,7 @@ public class ElasticSearchEntityManager implements EntityManagementClient {
               req ->
                   req.index(Entity.getSearchRepository().getIndexOrAliasName(GLOBAL_SEARCH_ALIAS))
                       .query(termQuery)
+                      .conflicts(Conflicts.Proceed)
                       .script(
                           s ->
                               s.source(
@@ -1100,6 +1103,7 @@ public class ElasticSearchEntityManager implements EntityManagementClient {
               req ->
                   req.index(indexName)
                       .query(idsQuery)
+                      .conflicts(Conflicts.Proceed)
                       .script(
                           s ->
                               s.source(
@@ -1163,6 +1167,7 @@ public class ElasticSearchEntityManager implements EntityManagementClient {
               req ->
                   req.index(domainIndexName)
                       .query(combinedQuery)
+                      .conflicts(Conflicts.Proceed)
                       .script(
                           s ->
                               s.source(
@@ -1207,8 +1212,7 @@ public class ElasticSearchEntityManager implements EntityManagementClient {
           oldFqn,
           newFqn);
 
-      // Use match_all query - the script will filter and update only matching documents
-      Query matchAllQuery = Query.of(q -> q.matchAll(m -> m));
+      Query matchingDomainQuery = buildDomainFqnPrefixQuery(oldFqn);
 
       Map<String, JsonData> params =
           Map.of(
@@ -1219,7 +1223,8 @@ public class ElasticSearchEntityManager implements EntityManagementClient {
           client.updateByQuery(
               req ->
                   req.index(indexName)
-                      .query(matchAllQuery)
+                      .query(matchingDomainQuery)
+                      .conflicts(Conflicts.Proceed)
                       .script(
                           s ->
                               s.source(
@@ -1248,6 +1253,15 @@ public class ElasticSearchEntityManager implements EntityManagementClient {
     } catch (Exception e) {
       LOG.error("Error while updating asset domain FQNs by prefix: {}", e.getMessage(), e);
     }
+  }
+
+  private Query buildDomainFqnPrefixQuery(String oldFqn) {
+    Query prefixOnField =
+        Query.of(q -> q.prefix(p -> p.field("domains.fullyQualifiedName").value(oldFqn)));
+    Query prefixOnKeyword =
+        Query.of(q -> q.prefix(p -> p.field("domains.fullyQualifiedName.keyword").value(oldFqn)));
+    return Query.of(
+        q -> q.bool(b -> b.should(prefixOnField).should(prefixOnKeyword).minimumShouldMatch("1")));
   }
 
   @Override

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/opensearch/OpenSearchEntityManager.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/opensearch/OpenSearchEntityManager.java
@@ -53,6 +53,7 @@ import os.org.opensearch.client.json.JsonData;
 import os.org.opensearch.client.opensearch.OpenSearchAsyncClient;
 import os.org.opensearch.client.opensearch.OpenSearchClient;
 import os.org.opensearch.client.opensearch._types.BulkByScrollFailure;
+import os.org.opensearch.client.opensearch._types.Conflicts;
 import os.org.opensearch.client.opensearch._types.ErrorCause;
 import os.org.opensearch.client.opensearch._types.FieldValue;
 import os.org.opensearch.client.opensearch._types.OpenSearchException;
@@ -1040,6 +1041,7 @@ public class OpenSearchEntityManager implements EntityManagementClient {
               req ->
                   req.index(Entity.getSearchRepository().getIndexOrAliasName(GLOBAL_SEARCH_ALIAS))
                       .query(termQuery)
+                      .conflicts(Conflicts.Proceed)
                       .script(
                           s ->
                               s.inline(
@@ -1115,6 +1117,7 @@ public class OpenSearchEntityManager implements EntityManagementClient {
               req ->
                   req.index(Entity.getSearchRepository().getIndexOrAliasName(GLOBAL_SEARCH_ALIAS))
                       .query(termQuery)
+                      .conflicts(Conflicts.Proceed)
                       .script(
                           s ->
                               s.inline(
@@ -1189,6 +1192,7 @@ public class OpenSearchEntityManager implements EntityManagementClient {
               req ->
                   req.index(Entity.getSearchRepository().getIndexOrAliasName(GLOBAL_SEARCH_ALIAS))
                       .query(idsQuery)
+                      .conflicts(Conflicts.Proceed)
                       .script(
                           s ->
                               s.inline(
@@ -1253,6 +1257,7 @@ public class OpenSearchEntityManager implements EntityManagementClient {
               req ->
                   req.index(domainIndexName)
                       .query(combinedQuery)
+                      .conflicts(Conflicts.Proceed)
                       .script(
                           s ->
                               s.inline(
@@ -1300,8 +1305,7 @@ public class OpenSearchEntityManager implements EntityManagementClient {
           oldFqn,
           newFqn);
 
-      // Use match_all query - the script will filter and update only matching documents
-      Query matchAllQuery = Query.of(q -> q.matchAll(m -> m));
+      Query matchingDomainQuery = buildDomainFqnPrefixQuery(oldFqn);
 
       Map<String, JsonData> params =
           Map.of(
@@ -1312,7 +1316,8 @@ public class OpenSearchEntityManager implements EntityManagementClient {
           client.updateByQuery(
               req ->
                   req.index(indexName)
-                      .query(matchAllQuery)
+                      .query(matchingDomainQuery)
+                      .conflicts(Conflicts.Proceed)
                       .script(
                           s ->
                               s.inline(
@@ -1344,6 +1349,15 @@ public class OpenSearchEntityManager implements EntityManagementClient {
     } catch (Exception e) {
       LOG.error("Error while updating asset domain FQNs by prefix: {}", e.getMessage(), e);
     }
+  }
+
+  private Query buildDomainFqnPrefixQuery(String oldFqn) {
+    Query prefixOnField =
+        Query.of(q -> q.prefix(p -> p.field("domains.fullyQualifiedName").value(oldFqn)));
+    Query prefixOnKeyword =
+        Query.of(q -> q.prefix(p -> p.field("domains.fullyQualifiedName.keyword").value(oldFqn)));
+    return Query.of(
+        q -> q.bool(b -> b.should(prefixOnField).should(prefixOnKeyword).minimumShouldMatch("1")));
   }
 
   @Override


### PR DESCRIPTION
### Describe your changes:

`Domains.spec.ts` flakes in the nightly AUT runs (e.g. [PostgreSQL 1.9.1 ➡ 1.12.10](https://github.com/open-metadata/openmetadata-nightly/actions/runs/26729298487)) when a **domain** or **data product** is renamed.

**Root cause.** On rename, the new FQN is propagated to every related search document with `updateByQuery`. When concurrent writes touch the same assets, Elasticsearch/OpenSearch raise `version_conflict_engine_exception`, which **aborts the entire `updateByQuery`** and leaves the rename half-applied in the index (stale FQNs). The UI then reads stale data and the spec assertions on the renamed entity/its subdomains/assets fail intermittently.

**Fix.** Set `conflicts=proceed` on the rename-propagation `updateByQuery` calls so a per-document version conflict is retried/skipped instead of aborting the batch. This mirrors the handling already present on `main` (#25751); this PR backports just that conflict handling to the 1.12 line.

Methods updated in both `ElasticSearchEntityManager` and `OpenSearchEntityManager`:

| Rename path | Methods |
| --- | --- |
| Domain rename | `updateDomainFqnByPrefix`, `updateAssetDomainFqnByPrefix` |
| Data product rename | `updateDataProductReferences`, `updateAssetDomainsForDataProduct`, `updateAssetDomainsByIds` |

`updateAssetDomainFqnByPrefix` additionally scopes its query to documents matching the domain FQN prefix (`buildDomainFqnPrefixQuery`) instead of `match_all`, so it only rewrites affected assets — fewer documents touched, fewer conflicts.

Surgical: search-layer only, +34/−6 across the two manager classes, no behavior change beyond conflict resilience.

#
### Type of change:
- [x] Bug fix

#
### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] Ran `mvn spotless:check` on `openmetadata-service` (BUILD SUCCESS) and verified the `Conflicts` enum / `conflicts(...)` builder resolve against the bundled ES (9.2.4) / OS (3.5.0) clients.