### PR TITLE
fix(mcp): surface custom properties (extension) in get_entity_details

### DIFF
--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/mcp/McpIntegrationIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/mcp/McpIntegrationIT.java
@@ -90,6 +90,45 @@ public class McpIntegrationIT extends McpTestBase {
   }
 
   @Test
+  void testGetEntityDetailsSurfacesCustomProperties() throws Exception {
+    String propertyName = "mcpCustomProperty";
+    String propertyValue = "mcp-value-" + UUID.randomUUID().toString().substring(0, 8);
+    addStringCustomProperty(Entity.TABLE, propertyName);
+
+    String jsonPatch =
+        String.format(
+            "[{\"op\":\"add\",\"path\":\"/extension\",\"value\":{\"%s\":\"%s\"}}]",
+            propertyName, propertyValue);
+    patch("tables/" + testTable.getId(), jsonPatch);
+
+    Map<String, Object> toolCallRequest =
+        McpTestUtils.createGetEntityToolCall(Entity.TABLE, testTable.getFullyQualifiedName());
+    JsonNode responseJson = executeMcpRequest(toolCallRequest);
+
+    String responseText = responseJson.get("result").get("content").get(0).get("text").asText();
+    assertThat(responseText).contains("extension");
+    assertThat(responseText).contains(propertyValue);
+  }
+
+  private static void addStringCustomProperty(String entityType, String propertyName)
+      throws Exception {
+    JsonNode entityTypeNode =
+        get("metadata/types/name/" + entityType + "?category=Field", JsonNode.class);
+    JsonNode stringTypeNode = get("metadata/types/name/string", JsonNode.class);
+
+    Map<String, Object> propertyType = new HashMap<>();
+    propertyType.put("id", stringTypeNode.get("id").asText());
+    propertyType.put("type", "type");
+
+    Map<String, Object> customProperty = new HashMap<>();
+    customProperty.put("name", propertyName);
+    customProperty.put("description", "MCP custom property test");
+    customProperty.put("propertyType", propertyType);
+
+    put("metadata/types/" + entityTypeNode.get("id").asText(), customProperty, JsonNode.class);
+  }
+
+  @Test
   void testMcpToolCall() throws Exception {
     Map<String, Object> toolCallRequest =
         McpTestUtils.createSearchMetadataToolCall("test", 5, Entity.TABLE);

--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/mcp/McpTestBase.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/mcp/McpTestBase.java
@@ -120,6 +120,57 @@ public abstract class McpTestBase {
     return OBJECT_MAPPER.readValue(response.body(), responseType);
   }
 
+  protected static <T> T get(String path, Class<T> responseType) throws Exception {
+    String baseUrl = TestSuiteBootstrap.getBaseUrl();
+    HttpRequest request =
+        HttpRequest.newBuilder()
+            .uri(URI.create(baseUrl + "/api/v1/" + path))
+            .header("Authorization", authToken)
+            .GET()
+            .timeout(Duration.ofSeconds(30))
+            .build();
+    HttpResponse<String> response = HTTP_CLIENT.send(request, HttpResponse.BodyHandlers.ofString());
+    if (response.statusCode() != 200) {
+      throw new RuntimeException("HTTP " + response.statusCode() + ": " + response.body());
+    }
+    return OBJECT_MAPPER.readValue(response.body(), responseType);
+  }
+
+  protected static <T> T put(String path, Object body, Class<T> responseType) throws Exception {
+    String baseUrl = TestSuiteBootstrap.getBaseUrl();
+    String jsonBody = OBJECT_MAPPER.writeValueAsString(body);
+    HttpRequest request =
+        HttpRequest.newBuilder()
+            .uri(URI.create(baseUrl + "/api/v1/" + path))
+            .header("Content-Type", "application/json")
+            .header("Authorization", authToken)
+            .PUT(HttpRequest.BodyPublishers.ofString(jsonBody))
+            .timeout(Duration.ofSeconds(30))
+            .build();
+    HttpResponse<String> response = HTTP_CLIENT.send(request, HttpResponse.BodyHandlers.ofString());
+    if (response.statusCode() != 200 && response.statusCode() != 201) {
+      throw new RuntimeException("HTTP " + response.statusCode() + ": " + response.body());
+    }
+    return OBJECT_MAPPER.readValue(response.body(), responseType);
+  }
+
+  protected static JsonNode patch(String path, String jsonPatch) throws Exception {
+    String baseUrl = TestSuiteBootstrap.getBaseUrl();
+    HttpRequest request =
+        HttpRequest.newBuilder()
+            .uri(URI.create(baseUrl + "/api/v1/" + path))
+            .header("Content-Type", "application/json-patch+json")
+            .header("Authorization", authToken)
+            .method("PATCH", HttpRequest.BodyPublishers.ofString(jsonPatch))
+            .timeout(Duration.ofSeconds(30))
+            .build();
+    HttpResponse<String> response = HTTP_CLIENT.send(request, HttpResponse.BodyHandlers.ofString());
+    if (response.statusCode() != 200) {
+      throw new RuntimeException("HTTP " + response.statusCode() + ": " + response.body());
+    }
+    return OBJECT_MAPPER.readTree(response.body());
+  }
+
   protected static void delete(String path) throws Exception {
     String baseUrl = TestSuiteBootstrap.getBaseUrl();
     HttpRequest request =

--- a/openmetadata-mcp/src/main/java/org/openmetadata/mcp/tools/GetEntityTool.java
+++ b/openmetadata-mcp/src/main/java/org/openmetadata/mcp/tools/GetEntityTool.java
@@ -43,8 +43,7 @@ public class GetEntityTool implements McpTool {
           "descriptionSources",
           "columnDescriptionStatus",
           "descriptionStatus",
-          "embeddings",
-          "extension");
+          "embeddings");
 
   @Override
   public Map<String, Object> execute(

--- a/openmetadata-mcp/src/main/resources/json/data/mcp/tools.json
+++ b/openmetadata-mcp/src/main/resources/json/data/mcp/tools.json
@@ -162,7 +162,7 @@
     },
     {
       "name": "get_entity_details",
-      "description": "Get detailed information about a specific entity by its fully qualified name. IMPORTANT: Use the 'fullyQualifiedName' and 'entityType' values directly from search_metadata or semantic_search results — do not construct the FQN manually. Response is optimized for LLM context by excluding verbose metadata fields.",
+      "description": "Get detailed information about a specific entity by its fully qualified name, including its custom properties (returned under the 'extension' field). IMPORTANT: Use the 'fullyQualifiedName' and 'entityType' values directly from search_metadata or semantic_search results — do not construct the FQN manually. Response is optimized for LLM context by excluding verbose metadata fields.",
       "parameters": {
         "description": "Use 'fullyQualifiedName' and 'entityType' from search results directly.",
         "type": "object",


### PR DESCRIPTION
fixes: https://github.com/open-metadata/openmetadata-collate/issues/4146

## What

The `get_entity_details` MCP tool was not returning an entity's **custom properties**. Custom property values are stored in the entity's `extension` field, but `extension` was listed in `GetEntityTool.EXCLUDE_FIELDS` and stripped from every response.

## Why

The exclusion was introduced in #25300 ("optimize MCP tool responses to prevent LLM context overflow"), which added a batch of verbose fields (`version`, `changeDescription`, `usageSummary`, `embeddings`, …) to the exclude list. 

## Change

- Remove `"extension"` from `GetEntityTool.EXCLUDE_FIELDS` so custom properties are returned under the `extension` key.
- Update the `get_entity_details` tool description to document that custom properties are surfaced under `extension`.
- Add an integration test (`testGetEntityDetailsSurfacesCustomProperties`) that defines a custom property on the table type, sets a value, calls the MCP tool over HTTP, and asserts the value appears. Adds `get`/`put`/`patch` HTTP helpers to `McpTestBase` mirroring the existing `post`/`delete` pattern.

`getEntityByName(type, fqn, "*", …)` already populates `extension` (it is part of `allowedFields`), so removing the exclusion is sufficient — no fetch-path changes needed.
