### PR TITLE
test(ui): fix marketplace greeting banner playwright assertion for start-cased name

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/dataMarketplace.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/dataMarketplace.ts
@@ -11,6 +11,7 @@
  *  limitations under the License.
  */
 import { APIRequestContext, expect, Page } from '@playwright/test';
+import { startCase } from 'lodash';
 import { SidebarItem } from '../constant/sidebar';
 import { redirectToHomePage } from './common';
 import { waitForAllLoadersToDisappear } from './entity';
@@ -47,7 +48,9 @@ export const closeSearchPopover = async (page: Page) => {
 
 export const verifyGreetingBanner = async (page: Page, displayName: string) => {
   await expect(page.getByTestId('marketplace-greeting')).toBeVisible();
-  await expect(page.getByTestId('greeting-text')).toContainText(displayName);
+  await expect(page.getByTestId('greeting-text')).toContainText(
+    startCase(displayName)
+  );
 };
 
 export const createAnnouncementViaApi = async (


### PR DESCRIPTION
### Describe your changes:

[#28567](https://github.com/open-metadata/OpenMetadata/pull/28567) wrapped the greeting name in `startCase` inside `MarketplaceGreetingBanner`, but the Playwright helper `verifyGreetingBanner` still asserts the **raw** name via a case-sensitive substring match. This broke two `DataMarketplacePermissions` E2E tests:

- `Admin sees add buttons and customize button` — expected `"admin"`, banner now renders `"Admin"`
- `Data consumer does NOT see add buttons` — expected raw `name`, banner now renders the start-cased form (e.g. `Witty26e82fe1...` → `Witty 26 E 82 Fe 1 ...`)

**Fix:** apply the same `startCase` to the expected value in `verifyGreetingBanner`, keeping the assertion in sync with the rendered output and preserving the intent of #28567 (no revert).

### Type of change:
- [x] Bug fix

### Tests:

#### Playwright (UI) tests
- Re-ran `playwright/e2e/Pages/DataMarketplacePermissions.spec.ts` — both previously-failing tests now pass (5 passed, 1 pre-existing skip).

🤖 Generated with [Claude Code](https://claude.com/claude-code)