### PR TITLE
feat(secrets): add contextPlugin connection secret encrypt/decrypt/delete trio

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/secrets/SecretsManager.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/secrets/SecretsManager.java
@@ -224,6 +224,57 @@ public abstract class SecretsManager {
   }
 
   /**
+   * Encrypts a Context Plugin connection's password fields under the path
+   * /{cluster}/contextPlugin/{name}/{field}, mirroring {@link #encryptQueryRunnerConfig}.
+   *
+   * @param connectionConfig An object whose {@code @PasswordField} string fields should be encrypted
+   * @param pluginName The context plugin name
+   * @return The config with password fields replaced by secret references
+   */
+  public Object encryptContextPluginConnection(Object connectionConfig, String pluginName) {
+    if (connectionConfig == null) {
+      return null;
+    }
+    try {
+      return encryptPasswordFields(
+          connectionConfig, buildSecretId(true, "contextPlugin", pluginName), true);
+    } catch (Exception e) {
+      throw new SecretsManagerException(
+          Response.Status.BAD_REQUEST,
+          String.format("Failed to encrypt context plugin connection for plugin [%s]", pluginName));
+    }
+  }
+
+  public Object decryptContextPluginConnection(Object connectionConfig) {
+    if (connectionConfig == null) {
+      return null;
+    }
+    try {
+      return decryptPasswordFields(connectionConfig);
+    } catch (Exception e) {
+      throw new SecretsManagerException(
+          Response.Status.BAD_REQUEST, "Failed to decrypt context plugin connection");
+    }
+  }
+
+  /**
+   * Deletes Context Plugin connection secrets. Same path as {@link
+   * #encryptContextPluginConnection(Object, String)}: /{cluster}/contextPlugin/{pluginName}/{field}.
+   */
+  public void deleteContextPluginConnectionSecrets(Object connectionConfig, String pluginName) {
+    if (connectionConfig != null) {
+      try {
+        deleteSecrets(connectionConfig, buildSecretId(true, "contextPlugin", pluginName));
+      } catch (Exception e) {
+        throw new SecretsManagerException(
+            Response.Status.BAD_REQUEST,
+            String.format(
+                "Failed to delete secrets for context plugin connection [%s]", pluginName));
+      }
+    }
+  }
+
+  /**
    * This is used to handle the JWT Token internally, in the JWTFilter, when
    * calling for the auth-mechanism in the UI, etc.
    * If using SM, we need to decrypt and GET the secret to ensure we are comparing

--- a/openmetadata-service/src/test/java/org/openmetadata/service/secrets/SecretsManagerLifecycleTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/secrets/SecretsManagerLifecycleTest.java
@@ -1,8 +1,10 @@
 package org.openmetadata.service.secrets;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.lenient;
 import static org.openmetadata.schema.api.services.CreateDatabaseService.DatabaseServiceType.Mysql;
@@ -207,5 +209,24 @@ public class SecretsManagerLifecycleTest {
         new SecretsManager.SecretsConfig(
             null, null, List.of("random", "key:value", "random"), null);
     assertEquals(Map.of("key", "value"), SecretsManager.getTags(secretsConfig));
+  }
+
+  @Test
+  void testContextPluginConnectionSecretLifecycle() {
+    String token = "my-mcp-token";
+    basicAuth auth = new basicAuth().withPassword(token);
+    String fieldPath =
+        secretsManager.buildSecretId(true, "contextPlugin", "my-plugin") + "/password";
+
+    basicAuth encrypted =
+        (basicAuth) secretsManager.encryptContextPluginConnection(auth, "my-plugin");
+    assertNotEquals(token, encrypted.getPassword());
+    assertTrue(secretsManager.getSecretsMap().containsKey(fieldPath));
+
+    basicAuth decrypted = (basicAuth) secretsManager.decryptContextPluginConnection(encrypted);
+    assertEquals(DECRYPTED_VALUE, decrypted.getPassword());
+
+    secretsManager.deleteContextPluginConnectionSecrets(encrypted, "my-plugin");
+    assertFalse(secretsManager.getSecretsMap().containsKey(fieldPath));
   }
 }


### PR DESCRIPTION
## Summary

Adds three public methods to `SecretsManager` so a Context Plugin (MCP) connection's password fields can be managed by the configured Secrets Manager, mirroring the existing QueryRunner trio:

- `encryptContextPluginConnection(Object connectionConfig, String pluginName)`
- `decryptContextPluginConnection(Object connectionConfig)`
- `deleteContextPluginConnectionSecrets(Object connectionConfig, String pluginName)`

Secrets are stored under `/{cluster}/contextPlugin/{pluginName}/{field}` via `buildSecretId(true, "contextPlugin", pluginName)`. The low-level `encryptPasswordFields`/`buildSecretId`/`deleteSecrets` helpers are `private`/`protected`, so these public wrappers are required for the Collate side to reuse the machinery.

This is the OpenMetadata-side dependency of the Collate "MCP connection token via Secrets Manager" feature: Collate stores only the MCP auth token (a `format: password` field) as a `secret:/…` reference; ai-platform resolves it at runtime.

## Test Plan

- [x] `SecretsManagerLifecycleTest#testContextPluginConnectionSecretLifecycle` — encrypt lands the secret at `/{prefix}/{cluster}/contextplugin/{name}/{field}`, decrypt round-trips, delete removes it (InMemory SM).
- [x] `mvn spotless:check -pl openmetadata-service`

> Note: branch is based on a recent `main` commit; diff vs `main` is the trio only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)