### PR TITLE
fix(test-cli-e2e): repair sink-status regex after Execution Time Summary removal

### DIFF
--- a/ingestion/tests/cli_e2e/base/test_cli.py
+++ b/ingestion/tests/cli_e2e/base/test_cli.py
@@ -128,7 +128,7 @@ class CliBase(ABC):
         output_clean = re.sub(" +", " ", output_clean)
         output_clean_ansi = re.compile(r"\x1b[^m]*m")
         output_clean = output_clean_ansi.sub("", output_clean)
-        regex = r".*OpenMetadata Status:%(log)s(.*?)%(log)sExecution.*Summary.*" % REGEX_AUX  # noqa: UP031
+        regex = r".*OpenMetadata Status:%(log)s(.*?)%(log)sWorkflow.*Summary.*" % REGEX_AUX  # noqa: UP031
         output_clean_regex = re.findall(regex, output_clean.strip())[0].strip()
         try:
             return Status.model_validate(literal_eval(output_clean_regex))


### PR DESCRIPTION
## Summary

- Every connector job on the nightly **`py-cli-e2e-tests`** workflow has been failing since 2026-05-29 with `IndexError: list index out of range` inside `extract_sink_status` (e.g. [run 26698847063](https://github.com/open-metadata/OpenMetadata/actions/runs/26698847063)).
- Root cause: [#28439](https://github.com/open-metadata/OpenMetadata/pull/28439) (`refactor(diagnostics): finish v2 framework + remove legacy ExecutionTimeTracker`) deleted `_print_execution_time_summary()` from `WorkflowOutputHandler`, so the literal `Execution Time Summary` line — used as the trailing anchor by the regex in `ingestion/tests/cli_e2e/base/test_cli.py` — is no longer emitted between the per-step `OpenMetadata Status:` debug block and the per-step `Workflow <name> Summary:` block.
- Update the trailing anchor to `Workflow.*Summary`, which is the next line the workflow emits after the debug-mode sink status block (`Workflow <source-name> Summary:` from `_print_summary()`).

Trailing-anchor change only — no production code touched, only the test parser.

## Test plan

- [x] Locally validated the new regex against a representative DEBUG-mode workflow output: it captures the sink's `as_string()` dict and `literal_eval(...)` + `Status.model_validate(...)` still round-trip cleanly.
- [x] Verified the existing `extract_source_status` regex (which already keys off the next step's `Status:` line) keeps working unchanged.
- [ ] Re-run `py-cli-e2e-tests` on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)