### PR TITLE
security: clear jackson-core 3.0.2 & cloudfront 2.30.19 (Snyk high)

### DIFF
--- a/openmetadata-service/pom.xml
+++ b/openmetadata-service/pom.xml
@@ -13,7 +13,6 @@
 
   <properties>
     <dropwizard.swagger.version>4.0.5-1</dropwizard.swagger.version>
-    <awssdk.version>2.41.30</awssdk.version>
     <azure-identity.version>1.15.2</azure-identity.version>
     <azure-kv.version>4.10.7</azure-kv.version>
     <azure-identity-extensions.version>1.0.0</azure-identity-extensions.version>

--- a/openmetadata-service/pom.xml
+++ b/openmetadata-service/pom.xml
@@ -13,7 +13,7 @@
 
   <properties>
     <dropwizard.swagger.version>4.0.5-1</dropwizard.swagger.version>
-    <awssdk.version>2.30.19</awssdk.version>
+    <awssdk.version>2.41.30</awssdk.version>
     <azure-identity.version>1.15.2</azure-identity.version>
     <azure-kv.version>4.10.7</azure-kv.version>
     <azure-identity-extensions.version>1.0.0</azure-identity-extensions.version>

--- a/pom.xml
+++ b/pom.xml
@@ -766,6 +766,29 @@
         <artifactId>bcutil-jdk18on</artifactId>
         <version>1.84</version>
       </dependency>
+      <!-- Jackson 3.x BOM — jsonschema2pojo-core 1.3.1 (provided scope, used by the
+           jsonschema2pojo-maven-plugin) pulls tools.jackson 3.0.2 transitively
+           (SNYK-JAVA-TOOLSJACKSONCORE-15365915 / -15371178 / -15907550). The provided
+           scope keeps it out of the runtime dist, but Snyk's Maven scanner still walks
+           the provided tree, so it reports 3.0.2. Force the patched line (>= 3.1.0). -->
+      <dependency>
+        <groupId>tools.jackson</groupId>
+        <artifactId>jackson-bom</artifactId>
+        <version>3.1.3</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <!-- AWS SDK v2 BOM at root so every module (openmetadata-dist / -mcp /
+           -k8s-operator are siblings that depend on -service, not children of it,
+           so -service's own awssdk.version does not reach them). 2.41.30 clears
+           cloudfront (SNYK-JAVA-SOFTWAREAMAZONAWSSDK-15810116, fix 2.41.30). -->
+      <dependency>
+        <groupId>software.amazon.awssdk</groupId>
+        <artifactId>bom</artifactId>
+        <version>2.41.30</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 

--- a/pom.xml
+++ b/pom.xml
@@ -74,6 +74,9 @@
     <!-- Upgrading slf4j causes dropwizard issues -->
     <slf4j.version>2.0.4</slf4j.version>
     <jackson.version>2.18.7</jackson.version>
+    <!-- Single source for the AWS SDK v2 BOM version, consumed by the root BOM
+         import below and by openmetadata-service's BOM import. -->
+    <awssdk.version>2.41.30</awssdk.version>
     <dropwizard.version>5.0.0</dropwizard.version>
     <dropwizard-jdbi3.version>5.0.0</dropwizard-jdbi3.version>
     <diffMatch.version>1.0</diffMatch.version>
@@ -778,14 +781,14 @@
         <type>pom</type>
         <scope>import</scope>
       </dependency>
-      <!-- AWS SDK v2 BOM at root so every module (openmetadata-dist / -mcp /
-           -k8s-operator are siblings that depend on -service, not children of it,
-           so -service's own awssdk.version does not reach them). 2.41.30 clears
-           cloudfront (SNYK-JAVA-SOFTWAREAMAZONAWSSDK-15810116, fix 2.41.30). -->
+      <!-- AWS SDK v2 BOM at root so every module resolves the patched line.
+           openmetadata-dist / -mcp / -k8s-operator are siblings that depend on
+           -service (not children of it), so -service's BOM alone does not reach
+           them. Clears cloudfront (SNYK-JAVA-SOFTWAREAMAZONAWSSDK-15810116). -->
       <dependency>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>bom</artifactId>
-        <version>2.41.30</version>
+        <version>${awssdk.version}</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>


### PR DESCRIPTION
## What
Two root `dependencyManagement` additions to clear high-severity Snyk dependency findings:

1. **`tools.jackson:jackson-bom 3.1.3`** — `jsonschema2pojo-core 1.3.1` (provided scope) pulls `tools.jackson` 3.0.2 transitively (SNYK-JAVA-TOOLSJACKSONCORE-15365915 / -15371178 / -15907550). Provided scope keeps it out of the runtime dist, but Snyk's Maven scanner still walks the provided tree and reports 3.0.2. The BOM forces the patched line (≥ 3.1.0).
2. **`software.amazon.awssdk:bom 2.41.30`** — `cloudfront 2.30.19` (SNYK-JAVA-SOFTWAREAMAZONAWSSDK-15810116, fix 2.41.30) is declared in `openmetadata-service` and reaches `-dist`/`-mcp`/`-k8s-operator` transitively (siblings, not children, of `-service`). `awssdk.version` is single-sourced at the root and referenced by both BOM imports.

## Verification
- Full backend `mvn -DskipTests -DonlyBackend install -pl '!openmetadata-ui'` — **BUILD SUCCESS**.
- `openmetadata-spec` jsonschema2pojo codegen + compile (1605 files) succeeds with jackson 3.1.3.
- `dependency:tree`: `jackson-core 3.1.3` (was 3.0.2) in `common`; `cloudfront 2.41.30` (was 2.30.19) in `openmetadata-service`.

## Snyk — the upgraded versions carry no known vulnerabilities
Each bumped artifact verified against Snyk's vulnerability DB at the **new** version (the awssdk BOM aligns all AWS SDK v2 artifacts to the 2.41.30 line; `cloudfront` is the flagged one):

| Dependency | Old → New | Snyk @ new version |
|---|---|---|
| `tools.jackson.core:jackson-core` | 3.0.2 → 3.1.3 | ✅ no known vulnerabilities — [link](https://security.snyk.io/package/maven/tools.jackson.core:jackson-core/3.1.3) |
| `tools.jackson.core:jackson-databind` | 3.0.2 → 3.1.3 | ✅ no known vulnerabilities — [link](https://security.snyk.io/package/maven/tools.jackson.core:jackson-databind/3.1.3) |
| `software.amazon.awssdk:cloudfront` | 2.30.19 → 2.41.30 | ✅ no known vulnerabilities (CVE affects `[2.18.33, 2.41.30)`; 2.41.30 is the fix boundary) — [link](https://security.snyk.io/package/maven/software.amazon.awssdk:cloudfront/2.41.30) |

_Supersedes #28611 (which was opened from a fork, breaking the collate cross-repo CI's submodule checkout)._

🤖 Generated with [Claude Code](https://claude.com/claude-code)
