### PR TITLE
Fix EntityReference deserialization error when listing entities with sortBy

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/EntityRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/EntityRepository.java
@@ -246,6 +246,7 @@ import org.openmetadata.service.resources.tags.TagLabelUtil;
 import org.openmetadata.service.resources.teams.RoleResource;
 import org.openmetadata.service.rules.RuleEngine;
 import org.openmetadata.service.search.PropagationDescriptor;
+import org.openmetadata.service.search.SearchIndexUtils;
 import org.openmetadata.service.search.SearchListFilter;
 import org.openmetadata.service.search.SearchRepository;
 import org.openmetadata.service.search.SearchResultListMapper;
@@ -4208,6 +4209,7 @@ public abstract class EntityRepository<T extends EntityInterface> {
               subjectContext);
       total = results.getTotal();
       for (Map<String, Object> json : results.getResults()) {
+        SearchIndexUtils.normalizeFollowers(json);
         T entity = JsonUtils.readOrConvertValueLenient(json, entityClass);
         entityList.add(withHref(uriInfo, entity));
       }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/SearchIndexUtils.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/SearchIndexUtils.java
@@ -19,6 +19,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.UUID;
 import java.util.stream.Collectors;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
@@ -36,6 +37,7 @@ import org.openmetadata.schema.type.TagLabel;
 import org.openmetadata.schema.type.change.ChangeSource;
 import org.openmetadata.schema.type.change.ChangeSummary;
 import org.openmetadata.schema.utils.JsonUtils;
+import org.openmetadata.service.Entity;
 import org.openmetadata.service.TypeRegistry;
 import org.openmetadata.service.util.Utilities;
 
@@ -164,6 +166,32 @@ public final class SearchIndexUtils {
       return Collections.emptyList();
     }
     return followersRef.stream().map(item -> item.getId().toString()).toList();
+  }
+
+  /**
+   * Search documents store {@code followers} as a flat list of user-id strings (see {@link
+   * #parseFollowers}). When a search hit is converted back into an entity, that string list cannot
+   * be deserialized into the entity's {@code List<EntityReference> followers} field. This rebuilds
+   * each id into a user {@link EntityReference} so the entity deserializes cleanly.
+   */
+  public static void normalizeFollowers(Map<String, Object> sourceAsMap) {
+    Object followers = sourceAsMap.get(EntityBuilderConstant.FIELD_FOLLOWERS);
+    if (followers instanceof List<?> followerList && !followerList.isEmpty()) {
+      sourceAsMap.put(EntityBuilderConstant.FIELD_FOLLOWERS, expandFollowerIds(followerList));
+    }
+  }
+
+  private static List<Object> expandFollowerIds(List<?> followerList) {
+    List<Object> followers = new ArrayList<>();
+    for (Object follower : followerList) {
+      if (follower instanceof String followerId) {
+        followers.add(
+            new EntityReference().withId(UUID.fromString(followerId)).withType(Entity.USER));
+      } else {
+        followers.add(follower);
+      }
+    }
+    return followers;
   }
 
   public static List<String> parseOwners(List<EntityReference> ownersRef) {

--- a/openmetadata-service/src/test/java/org/openmetadata/service/search/SearchIndexUtilsTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/search/SearchIndexUtilsTest.java
@@ -13,6 +13,7 @@ import java.util.Set;
 import java.util.UUID;
 import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;
+import org.openmetadata.schema.entity.data.Page;
 import org.openmetadata.schema.entity.data.Table;
 import org.openmetadata.schema.entity.data.Topic;
 import org.openmetadata.schema.tests.DataQualityReport;
@@ -25,6 +26,8 @@ import org.openmetadata.schema.type.EntityReference;
 import org.openmetadata.schema.type.TagLabel;
 import org.openmetadata.schema.type.change.ChangeSource;
 import org.openmetadata.schema.type.change.ChangeSummary;
+import org.openmetadata.schema.utils.JsonUtils;
+import org.openmetadata.service.Entity;
 import org.openmetadata.service.TypeRegistry;
 
 class SearchIndexUtilsTest {
@@ -61,6 +64,41 @@ class SearchIndexUtilsTest {
     assertFalse(column1.containsKey("description"));
     assertFalse(column2.containsKey("description"));
     assertFalse(doc.containsKey("simple"));
+  }
+
+  @Test
+  void testNormalizeFollowersExpandsIdStringsIntoEntityReferences() {
+    UUID followerId = UUID.randomUUID();
+    Map<String, Object> source = new HashMap<>();
+    source.put("id", UUID.randomUUID().toString());
+    source.put("name", "test-page");
+    source.put("pageType", "Article");
+    source.put("followers", new ArrayList<>(List.of(followerId.toString())));
+
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> JsonUtils.readOrConvertValueLenient(source, Page.class));
+
+    SearchIndexUtils.normalizeFollowers(source);
+    Page page = JsonUtils.readOrConvertValueLenient(source, Page.class);
+
+    assertEquals(1, page.getFollowers().size());
+    EntityReference follower = page.getFollowers().getFirst();
+    assertEquals(followerId, follower.getId());
+    assertEquals(Entity.USER, follower.getType());
+  }
+
+  @Test
+  void testNormalizeFollowersLeavesEmptyOrMissingFollowersUntouched() {
+    Map<String, Object> missing = new HashMap<>();
+    missing.put("name", "no-followers");
+    SearchIndexUtils.normalizeFollowers(missing);
+    assertFalse(missing.containsKey("followers"));
+
+    Map<String, Object> empty = new HashMap<>();
+    empty.put("followers", new ArrayList<>());
+    SearchIndexUtils.normalizeFollowers(empty);
+    assertEquals(List.of(), empty.get("followers"));
   }
 
   @Test


### PR DESCRIPTION
### Describe your changes:

Fixes #28615

I fixed a `400` error returned when listing entities with `sortBy` (e.g. `GET /v1/contextCenter/pages?sortBy=updatedAt&fields=followers`). `sortBy` routes the request to the search-index list path, which rebuilds each entity from the Elasticsearch `_source`; that document stores `followers` as a flat list of UUID strings (a `keyword` field), which Jackson cannot deserialize into the entity's `List<EntityReference> followers`. The fix normalizes those follower IDs back into user `EntityReference`s in `EntityRepository.listFromSearchWithOffset` before deserialization, so the keyword-ID index format that the follow/unfollow painless scripts rely on is preserved and no reindex is needed. The fix is generic and applies to every entity that uses this search-based list path.

#
### Type of change:
- [x] Bug fix

#
### High-level design:

N/A — small change.

#
### Tests:

#### Use cases covered
- Listing knowledge pages with `?sortBy=updatedAt&fields=followers` on a page that has followers no longer returns a `400` deserialization error.

#### Unit tests
- [x] I added unit tests for the changed logic.
- Files added/updated: `openmetadata-service/src/test/java/org/openmetadata/service/search/SearchIndexUtilsTest.java`
  - `testNormalizeFollowersExpandsIdStringsIntoEntityReferences` asserts the raw search `_source` throws on deserialization (bug repro) and succeeds after normalization.
  - `testNormalizeFollowersLeavesEmptyOrMissingFollowersUntouched`.

#### Backend integration tests
- [x] Not applicable (no new/changed API endpoints — internal deserialization fix on an existing path).

#### Ingestion integration tests
- [x] Not applicable (no ingestion changes).

#### Playwright (UI) tests
- [x] Not applicable (no UI changes).

#
### UI screen recording / screenshots:

Not applicable.

#
### Checklist:
- [x] I have read the **CONTRIBUTING** document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] For JSON Schema changes: not needed (no schema changes).
- [x] For UI changes: not applicable.
- [x] I have added tests and listed them above.
- [x] I have added a test that covers the exact scenario we are fixing.
