### PR TITLE
fix(mcp): optimize get_entity_lineage tool payload size (#28562)

### DIFF
--- a/openmetadata-mcp/src/main/java/org/openmetadata/mcp/tools/GetLineageTool.java
+++ b/openmetadata-mcp/src/main/java/org/openmetadata/mcp/tools/GetLineageTool.java
@@ -2,10 +2,24 @@ package org.openmetadata.mcp.tools;
 
 import static org.openmetadata.common.utils.CommonUtil.nullOrEmpty;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.google.common.annotations.VisibleForTesting;
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
 import lombok.extern.slf4j.Slf4j;
+import org.openmetadata.schema.type.ColumnLineage;
+import org.openmetadata.schema.type.Edge;
+import org.openmetadata.schema.type.EntityLineage;
+import org.openmetadata.schema.type.EntityReference;
+import org.openmetadata.schema.type.LineageDetails;
 import org.openmetadata.schema.type.MetadataOperation;
+import org.openmetadata.schema.type.TempLineageTable;
 import org.openmetadata.schema.utils.JsonUtils;
 import org.openmetadata.service.Entity;
 import org.openmetadata.service.limits.Limits;
@@ -14,6 +28,14 @@ import org.openmetadata.service.security.auth.CatalogSecurityContext;
 import org.openmetadata.service.security.policyevaluator.OperationContext;
 import org.openmetadata.service.security.policyevaluator.ResourceContext;
 
+/**
+ * Returns a compact, LLM-friendly lineage graph. The raw {@link EntityLineage} from the repository
+ * is intentionally verbose (full SQL, column-level mappings, node descriptions) and can reach
+ * hundreds of KB for even a couple of nodes. This tool slims it to identity + relationship info,
+ * folding node details into edge endpoints. Column lineage and full SQL are dropped by default and
+ * only surfaced on request, keeping the default response table-level. All slimming happens here in
+ * the tool — the repository and its UI/RCA callers are untouched.
+ */
 @Slf4j
 public class GetLineageTool implements McpTool {
 
@@ -21,43 +43,251 @@ public class GetLineageTool implements McpTool {
   private static final int DEFAULT_DEPTH = 3;
   // Maximum depth to prevent exponential response growth (lineage graphs can explode)
   private static final int MAX_DEPTH = 10;
+  // SQL is the single heaviest field; keep the gist of the transform, cap the size
+  private static final int SQL_MAX_LENGTH = 500;
+  // Free-text markdown (pipeline / edge descriptions) is capped for the same reason as SQL:
+  // a single long pipeline doc string can be shared across many edges and reintroduce bloat
+  private static final int TEXT_MAX_LENGTH = 500;
+  // Final safety net mirroring SearchMetadataTool: even slimmed, a wide graph can blow the limit
+  private static final int MAX_RESPONSE_CHARS = 100_000;
+  private static final String RELATIONSHIP_SQL = "sql";
+
+  @JsonInclude(JsonInclude.Include.NON_NULL)
+  record SlimEdge(
+      String fromFQN,
+      String toFQN,
+      String fromName,
+      String toName,
+      String fromType,
+      String toType,
+      String relationshipType,
+      String pipelineFQN,
+      String pipelineDescription,
+      String edgeDescription,
+      String source,
+      Integer assetEdges,
+      String sqlQuery,
+      Boolean sqlTruncated,
+      List<TempLineageTable> tempLineageTables,
+      Long updatedAt,
+      String updatedBy,
+      List<ColumnLineage> columnsLineage) {}
+
+  @JsonInclude(JsonInclude.Include.NON_NULL)
+  record SlimLineage(
+      String root,
+      String rootId,
+      String rootType,
+      List<SlimEdge> upstream,
+      List<SlimEdge> downstream) {}
+
+  private record SqlText(String value, Boolean truncated) {}
 
   @Override
   public Map<String, Object> execute(
-      Authorizer authorizer, CatalogSecurityContext securityContext, Map<String, Object> params) {
-    try {
-      if (nullOrEmpty(params)) {
-        throw new IllegalArgumentException("Parameters cannot be null or empty");
-      }
-      String entityType = (String) params.get("entityType");
-      String fqn = (String) params.get("fqn");
+      Authorizer authorizer, CatalogSecurityContext securityContext, Map<String, Object> params)
+      throws IOException {
+    validateParams(params);
+    String entityType = (String) params.get("entityType");
+    String fqn = (String) params.get("fqn");
+    authorizer.authorize(
+        securityContext,
+        new OperationContext(entityType, MetadataOperation.VIEW_BASIC),
+        new ResourceContext<>(entityType));
+    int upstreamDepth = parseDepthParameter(params.get("upstreamDepth"), DEFAULT_DEPTH);
+    int downstreamDepth = parseDepthParameter(params.get("downstreamDepth"), DEFAULT_DEPTH);
+    boolean includeColumnLineage = parseBooleanParameter(params.get("includeColumnLineage"));
+    LOG.info(
+        "Getting lineage for entity type: {}, FQN: {}, upstreamDepth: {}, downstreamDepth: {}, "
+            + "includeColumnLineage: {}",
+        entityType,
+        fqn,
+        upstreamDepth,
+        downstreamDepth,
+        includeColumnLineage);
+    EntityLineage lineage =
+        Entity.getLineageRepository().getByName(entityType, fqn, upstreamDepth, downstreamDepth);
+    return enforceSizeBudget(toSlim(lineage, includeColumnLineage));
+  }
 
-      if (nullOrEmpty(entityType) || nullOrEmpty(fqn)) {
-        throw new IllegalArgumentException("Parameters 'entityType' and 'fqn' are required");
-      }
-
-      authorizer.authorize(
-          securityContext,
-          new OperationContext(entityType, MetadataOperation.VIEW_BASIC),
-          new ResourceContext<>(entityType));
-
-      // Parse and validate upstream depth with default and max limits
-      int upstreamDepth = parseDepthParameter(params.get("upstreamDepth"), DEFAULT_DEPTH);
-      // Parse and validate downstream depth with default and max limits
-      int downstreamDepth = parseDepthParameter(params.get("downstreamDepth"), DEFAULT_DEPTH);
-
-      LOG.info(
-          "Getting lineage for entity type: {}, FQN: {}, upstreamDepth: {}, downstreamDepth: {}",
-          entityType,
-          fqn,
-          upstreamDepth,
-          downstreamDepth);
-
-      return JsonUtils.getMap(
-          Entity.getLineageRepository().getByName(entityType, fqn, upstreamDepth, downstreamDepth));
-    } catch (Exception e) {
-      return Map.of("error", e.getMessage());
+  private static void validateParams(Map<String, Object> params) {
+    if (nullOrEmpty(params)) {
+      throw new IllegalArgumentException("Parameters cannot be null or empty");
     }
+    String entityType = (String) params.get("entityType");
+    String fqn = (String) params.get("fqn");
+    if (nullOrEmpty(entityType) || nullOrEmpty(fqn)) {
+      throw new IllegalArgumentException("Parameters 'entityType' and 'fqn' are required");
+    }
+  }
+
+  @VisibleForTesting
+  static SlimLineage toSlim(EntityLineage lineage, boolean includeColumnLineage) {
+    Map<UUID, EntityReference> nodeIndex = buildNodeIndex(lineage);
+    List<SlimEdge> upstream =
+        slimEdges(lineage.getUpstreamEdges(), nodeIndex, includeColumnLineage);
+    List<SlimEdge> downstream =
+        slimEdges(lineage.getDownstreamEdges(), nodeIndex, includeColumnLineage);
+    EntityReference root = lineage.getEntity();
+    return new SlimLineage(
+        refFqn(root),
+        root != null && root.getId() != null ? root.getId().toString() : null,
+        refType(root),
+        upstream,
+        downstream);
+  }
+
+  private static Map<UUID, EntityReference> buildNodeIndex(EntityLineage lineage) {
+    Map<UUID, EntityReference> index = new HashMap<>();
+    if (lineage.getEntity() != null) {
+      index.put(lineage.getEntity().getId(), lineage.getEntity());
+    }
+    if (!nullOrEmpty(lineage.getNodes())) {
+      lineage.getNodes().forEach(node -> index.put(node.getId(), node));
+    }
+    return index;
+  }
+
+  private static List<SlimEdge> slimEdges(
+      List<Edge> edges, Map<UUID, EntityReference> nodeIndex, boolean includeColumnLineage) {
+    // The repository dedups nodes but not edges: a node reachable via multiple paths has its
+    // upstream/downstream edges re-added on each recursion. Identical slim edges carry no extra
+    // information, so collapse them with a LinkedHashSet (record equality), preserving order.
+    Set<SlimEdge> deduped = new LinkedHashSet<>();
+    if (!nullOrEmpty(edges)) {
+      edges.forEach(edge -> deduped.add(buildSlimEdge(edge, nodeIndex, includeColumnLineage)));
+    }
+    return new ArrayList<>(deduped);
+  }
+
+  private static SlimEdge buildSlimEdge(
+      Edge edge, Map<UUID, EntityReference> nodeIndex, boolean includeColumns) {
+    // computeLineage adds every edge endpoint to nodes (or it is the root), so nodeIndex
+    // resolves both ends. If that invariant ever breaks (a partial/cached graph), the endpoint
+    // fields come back null and identical anonymous edges dedup-collapse — warn instead of
+    // silently emitting a linkless edge.
+    EntityReference from = nodeIndex.get(edge.getFromEntity());
+    EntityReference to = nodeIndex.get(edge.getToEntity());
+    if (from == null || to == null) {
+      LOG.warn(
+          "Lineage edge endpoint missing from node index (from={}, to={}); emitting partial edge",
+          edge.getFromEntity(),
+          edge.getToEntity());
+    }
+    LineageDetails details = edge.getLineageDetails();
+    EntityReference pipeline = details != null ? details.getPipeline() : null;
+    SqlText sql = truncateSqlQuery(details);
+    return new SlimEdge(
+        refFqn(from),
+        refFqn(to),
+        refName(from),
+        refName(to),
+        refType(from),
+        refType(to),
+        relationshipType(pipeline),
+        pipeline != null ? pipeline.getFullyQualifiedName() : null,
+        truncateText(pipeline != null ? pipeline.getDescription() : null),
+        truncateText(details != null ? details.getDescription() : null),
+        sourceValue(details),
+        details != null ? details.getAssetEdges() : null,
+        sql.value(),
+        sql.truncated(),
+        details != null ? details.getTempLineageTables() : null,
+        details != null ? details.getUpdatedAt() : null,
+        details != null ? details.getUpdatedBy() : null,
+        columnsLineageOf(details, includeColumns));
+  }
+
+  private static List<ColumnLineage> columnsLineageOf(
+      LineageDetails details, boolean includeColumns) {
+    List<ColumnLineage> columns = null;
+    if (includeColumns && details != null && !nullOrEmpty(details.getColumnsLineage())) {
+      columns = details.getColumnsLineage();
+    }
+    return columns;
+  }
+
+  private static String relationshipType(EntityReference pipeline) {
+    return pipeline != null ? pipeline.getType() + ":" + pipeline.getName() : RELATIONSHIP_SQL;
+  }
+
+  private static String truncateText(String text) {
+    String result = text;
+    if (text != null && text.length() > TEXT_MAX_LENGTH) {
+      result = text.substring(0, TEXT_MAX_LENGTH) + "...";
+    }
+    return result;
+  }
+
+  private static String sourceValue(LineageDetails details) {
+    return details != null && details.getSource() != null ? details.getSource().value() : null;
+  }
+
+  private static SqlText truncateSqlQuery(LineageDetails details) {
+    String sql = details != null ? details.getSqlQuery() : null;
+    SqlText result = new SqlText(null, null);
+    if (sql != null) {
+      boolean tooLong = sql.length() > SQL_MAX_LENGTH;
+      String value = tooLong ? sql.substring(0, SQL_MAX_LENGTH) + "..." : sql;
+      result = new SqlText(value, tooLong ? Boolean.TRUE : null);
+    }
+    return result;
+  }
+
+  private static String refFqn(EntityReference ref) {
+    return ref != null ? ref.getFullyQualifiedName() : null;
+  }
+
+  private static String refType(EntityReference ref) {
+    return ref != null ? ref.getType() : null;
+  }
+
+  private static String refName(EntityReference ref) {
+    String name = null;
+    if (ref != null) {
+      name = ref.getDisplayName() != null ? ref.getDisplayName() : ref.getName();
+    }
+    return name;
+  }
+
+  @VisibleForTesting
+  static Map<String, Object> enforceSizeBudget(SlimLineage slim) {
+    Map<String, Object> response = JsonUtils.getMap(slim);
+    int responseSize = JsonUtils.pojoToJson(response).length();
+    Map<String, Object> result = response;
+    if (responseSize > MAX_RESPONSE_CHARS) {
+      result = oversizedHint(slim, responseSize);
+    }
+    return result;
+  }
+
+  private static Map<String, Object> oversizedHint(SlimLineage slim, int size) {
+    Map<String, Object> hint = new HashMap<>();
+    hint.put("root", slim.root());
+    hint.put("upstreamCount", slim.upstream().size());
+    hint.put("downstreamCount", slim.downstream().size());
+    hint.put("responseSizeChars", size);
+    // Machine-detectable marker so a programmatic client can tell a capped graph from a complete
+    // one without parsing the message. Stays on the success path — this is a deliberate cap, not an
+    // error the caller can fix by retrying.
+    hint.put("truncated", Boolean.TRUE);
+    hint.put(
+        "message",
+        String.format(
+            "Lineage response exceeded %d characters (was %d). Reduce upstreamDepth/downstreamDepth,"
+                + " or keep includeColumnLineage disabled, to get a smaller graph.",
+            MAX_RESPONSE_CHARS, size));
+    return hint;
+  }
+
+  private static boolean parseBooleanParameter(Object value) {
+    boolean result = false;
+    if (value instanceof Boolean bool) {
+      result = bool;
+    } else if (value instanceof String string) {
+      result = Boolean.parseBoolean(string);
+    }
+    return result;
   }
 
   /**
@@ -65,21 +295,23 @@ public class GetLineageTool implements McpTool {
    * response sizes that could overwhelm LLM context.
    */
   private static int parseDepthParameter(Object depthObj, int defaultValue) {
-    if (depthObj == null) {
-      return Math.min(Math.max(defaultValue, 1), MAX_DEPTH);
-    }
     int depth = defaultValue;
     if (depthObj instanceof Number number) {
       depth = number.intValue();
     } else if (depthObj instanceof String string) {
-      try {
-        depth = Integer.parseInt(string);
-      } catch (NumberFormatException e) {
-        depth = defaultValue;
-      }
+      depth = parseDepthString(string, defaultValue);
     }
-    // Enforce maximum depth to prevent exponential response growth
     return Math.min(Math.max(depth, 1), MAX_DEPTH);
+  }
+
+  private static int parseDepthString(String value, int defaultValue) {
+    int depth = defaultValue;
+    try {
+      depth = Integer.parseInt(value);
+    } catch (NumberFormatException e) {
+      depth = defaultValue;
+    }
+    return depth;
   }
 
   @Override

--- a/openmetadata-mcp/src/main/resources/json/data/mcp/tools.json
+++ b/openmetadata-mcp/src/main/resources/json/data/mcp/tools.json
@@ -295,7 +295,7 @@
     },
     {
       "name": "get_entity_lineage",
-      "description": "Get detailed information about lineage (upstream/downstream dependencies) of a specific entity. Use this for root cause (upstream entities) or impact (downstream entities) analysis and explaining dependencies between entities.",
+      "description": "Get a compact lineage graph (upstream/downstream dependencies) of a specific entity. Use this for root cause (upstream entities) or impact (downstream entities) analysis and explaining dependencies between entities. By default the response is table-level and optimized for size: each edge carries the connected assets' names, FQNs, types and relationship info (pipeline or sql), with long SQL truncated. Set includeColumnLineage=true only when the user explicitly asks about column-level lineage.",
       "parameters": {
         "description": "Fqn is the fully qualified name of the entity. Entity type could be table, topic etc.",
         "type": "object",
@@ -317,6 +317,11 @@
             "type": "integer",
             "description": "Number of downstream hops to traverse. Default is 3, maximum is 10 to prevent excessive response size.",
             "default": 3
+          },
+          "includeColumnLineage": {
+            "type": "boolean",
+            "description": "Include column-level lineage mappings on each edge. Defaults to false to keep the response table-level and small. Set to true only when the user explicitly needs column-to-column lineage, as it can significantly increase response size on wide tables.",
+            "default": false
           }
         },
         "required": [

--- a/openmetadata-mcp/src/test/java/org/openmetadata/mcp/tools/GetLineageToolTest.java
+++ b/openmetadata-mcp/src/test/java/org/openmetadata/mcp/tools/GetLineageToolTest.java
@@ -1,0 +1,243 @@
+package org.openmetadata.mcp.tools;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.openmetadata.schema.type.ColumnLineage;
+import org.openmetadata.schema.type.Edge;
+import org.openmetadata.schema.type.EntityLineage;
+import org.openmetadata.schema.type.EntityReference;
+import org.openmetadata.schema.type.LineageDetails;
+import org.openmetadata.schema.type.TempLineageTable;
+
+/**
+ * Unit tests for {@link GetLineageTool} slimming. These exercise the pure transform against
+ * hand-built {@link EntityLineage} fixtures (no DB/repository) and assert that the response is
+ * table-level by default, that heavy fields are trimmed, and that the size-cap safeguard fires.
+ */
+class GetLineageToolTest {
+
+  private static EntityReference ref(String name, String fqn) {
+    return new EntityReference()
+        .withId(UUID.randomUUID())
+        .withType("table")
+        .withName(name)
+        .withFullyQualifiedName(fqn)
+        .withDisplayName(name + " Display")
+        .withDescription("A long markdown description that should never reach the LLM payload.");
+  }
+
+  private static LineageDetails details(String sql, List<ColumnLineage> columns) {
+    return new LineageDetails()
+        .withSqlQuery(sql)
+        .withColumnsLineage(columns)
+        .withSource(LineageDetails.Source.QUERY_LINEAGE)
+        .withTempLineageTables(
+            List.of(new TempLineageTable().withFromEntity("src").withToEntity("staging")))
+        .withUpdatedAt(123L)
+        .withUpdatedBy("bob")
+        .withAssetEdges(2);
+  }
+
+  private static EntityLineage singleUpstreamEdge(String sql, List<ColumnLineage> columns) {
+    EntityReference root = ref("orders", "db.public.orders");
+    EntityReference upstream = ref("raw_orders", "db.raw.raw_orders");
+    Edge edge =
+        new Edge()
+            .withFromEntity(upstream.getId())
+            .withToEntity(root.getId())
+            .withLineageDetails(details(sql, columns));
+    return new EntityLineage()
+        .withEntity(root)
+        .withNodes(List.of(upstream))
+        .withUpstreamEdges(List.of(edge))
+        .withDownstreamEdges(List.of());
+  }
+
+  @SuppressWarnings("unchecked")
+  private static Map<String, Object> firstUpstreamEdge(Map<String, Object> response) {
+    List<Map<String, Object>> upstream = (List<Map<String, Object>>) response.get("upstream");
+    return upstream.getFirst();
+  }
+
+  @Test
+  void slimsToTableLevelByDefault() {
+    EntityLineage lineage = singleUpstreamEdge("SELECT 1", List.of());
+    Map<String, Object> response =
+        GetLineageTool.enforceSizeBudget(GetLineageTool.toSlim(lineage, false));
+
+    assertEquals("db.public.orders", response.get("root"));
+    assertFalse(response.containsKey("nodes"), "standalone nodes array must be folded into edges");
+
+    Map<String, Object> edge = firstUpstreamEdge(response);
+    assertEquals("db.raw.raw_orders", edge.get("fromFQN"));
+    assertEquals("db.public.orders", edge.get("toFQN"));
+    assertEquals("raw_orders Display", edge.get("fromName"));
+    assertEquals("sql", edge.get("relationshipType"));
+    assertEquals("QueryLineage", edge.get("source"));
+    assertTrue(edge.containsKey("tempLineageTables"), "temp-table path must be preserved");
+    assertFalse(edge.containsKey("columnsLineage"), "column lineage must be off by default");
+  }
+
+  @Test
+  void truncatesLongSqlAndMarksIt() {
+    String longSql = "SELECT ".repeat(200);
+    Map<String, Object> response =
+        GetLineageTool.enforceSizeBudget(
+            GetLineageTool.toSlim(singleUpstreamEdge(longSql, List.of()), false));
+    Map<String, Object> edge = firstUpstreamEdge(response);
+
+    String sql = (String) edge.get("sqlQuery");
+    assertTrue(sql.endsWith("..."), "long SQL should be truncated with an ellipsis");
+    assertTrue(sql.length() <= 503, "truncated SQL should respect the cap");
+    assertEquals(Boolean.TRUE, edge.get("sqlTruncated"));
+  }
+
+  @Test
+  void keepsShortSqlWithoutTruncationFlag() {
+    Map<String, Object> response =
+        GetLineageTool.enforceSizeBudget(
+            GetLineageTool.toSlim(singleUpstreamEdge("SELECT 1", List.of()), false));
+    Map<String, Object> edge = firstUpstreamEdge(response);
+
+    assertEquals("SELECT 1", edge.get("sqlQuery"));
+    assertNull(edge.get("sqlTruncated"), "short SQL must not carry a truncation flag");
+  }
+
+  @Test
+  void includesColumnLineageWhenRequested() {
+    ColumnLineage column =
+        new ColumnLineage()
+            .withFromColumns(List.of("db.raw.raw_orders.id"))
+            .withToColumn("db.public.orders.id");
+    Map<String, Object> response =
+        GetLineageTool.enforceSizeBudget(
+            GetLineageTool.toSlim(singleUpstreamEdge("SELECT 1", List.of(column)), true));
+    Map<String, Object> edge = firstUpstreamEdge(response);
+
+    assertTrue(edge.containsKey("columnsLineage"), "column lineage must appear when opted in");
+  }
+
+  @Test
+  void omitsEmptyColumnLineageEvenWhenOptedIn() {
+    Map<String, Object> response =
+        GetLineageTool.enforceSizeBudget(
+            GetLineageTool.toSlim(singleUpstreamEdge("SELECT 1", List.of()), true));
+    Map<String, Object> edge = firstUpstreamEdge(response);
+
+    assertFalse(
+        edge.containsKey("columnsLineage"),
+        "empty column lineage must be omitted to avoid per-edge noise");
+  }
+
+  @Test
+  void defaultSlimResponseIsAFractionOfRawPayload() {
+    String fatSql = "SELECT col_a, col_b, col_c FROM upstream JOIN other USING (id) ".repeat(40);
+    EntityReference root = ref("orders", "db.public.orders");
+    List<Edge> edges = new java.util.ArrayList<>();
+    List<EntityReference> nodes = new java.util.ArrayList<>();
+    for (int i = 0; i < 20; i++) {
+      EntityReference upstream = ref("raw_orders_" + i, "db.raw.raw_orders_" + i);
+      nodes.add(upstream);
+      edges.add(
+          new Edge()
+              .withFromEntity(upstream.getId())
+              .withToEntity(root.getId())
+              .withLineageDetails(details(fatSql, buildHeavyColumns())));
+    }
+    EntityLineage lineage =
+        new EntityLineage()
+            .withEntity(root)
+            .withNodes(nodes)
+            .withUpstreamEdges(edges)
+            .withDownstreamEdges(List.of());
+
+    int rawSize = org.openmetadata.schema.utils.JsonUtils.pojoToJson(lineage).length();
+    int slimSize =
+        org.openmetadata.schema.utils.JsonUtils.pojoToJson(
+                GetLineageTool.enforceSizeBudget(GetLineageTool.toSlim(lineage, false)))
+            .length();
+
+    assertTrue(
+        slimSize < rawSize * 0.15,
+        "default slim payload (" + slimSize + ") should be < 15% of raw (" + rawSize + ")");
+  }
+
+  @Test
+  void collapsesDuplicateEdges() {
+    EntityReference root = ref("orders", "db.public.orders");
+    EntityReference upstream = ref("raw_orders", "db.raw.raw_orders");
+    Edge edge =
+        new Edge()
+            .withFromEntity(upstream.getId())
+            .withToEntity(root.getId())
+            .withLineageDetails(details("SELECT 1", List.of()));
+    EntityLineage lineage =
+        new EntityLineage()
+            .withEntity(root)
+            .withNodes(List.of(upstream))
+            .withUpstreamEdges(List.of(edge, edge, edge))
+            .withDownstreamEdges(List.of());
+
+    @SuppressWarnings("unchecked")
+    List<Map<String, Object>> upstreamEdges =
+        (List<Map<String, Object>>)
+            GetLineageTool.enforceSizeBudget(GetLineageTool.toSlim(lineage, false)).get("upstream");
+
+    assertEquals(1, upstreamEdges.size(), "identical edges must be collapsed to one");
+  }
+
+  @Test
+  void oversizedGraphReturnsHintInsteadOfData() {
+    List<ColumnLineage> heavyColumns = buildHeavyColumns();
+    EntityReference root = ref("orders", "db.public.orders");
+    List<Edge> edges = new java.util.ArrayList<>();
+    List<EntityReference> nodes = new java.util.ArrayList<>();
+    for (int i = 0; i < 40; i++) {
+      EntityReference upstream =
+          ref("raw_orders_" + i, "db.raw.raw_orders_with_a_long_qualified_name_" + i);
+      nodes.add(upstream);
+      edges.add(
+          new Edge()
+              .withFromEntity(upstream.getId())
+              .withToEntity(root.getId())
+              .withLineageDetails(details("SELECT 1", heavyColumns)));
+    }
+    EntityLineage lineage =
+        new EntityLineage()
+            .withEntity(root)
+            .withNodes(nodes)
+            .withUpstreamEdges(edges)
+            .withDownstreamEdges(List.of());
+
+    Map<String, Object> response =
+        GetLineageTool.enforceSizeBudget(GetLineageTool.toSlim(lineage, true));
+
+    assertFalse(
+        response.containsKey("upstream"), "oversized response must not carry the full graph");
+    assertTrue(response.containsKey("message"), "oversized response must carry a guidance message");
+    assertEquals(
+        Boolean.TRUE, response.get("truncated"), "oversized response must be machine-flagged");
+    assertEquals(40, response.get("upstreamCount"));
+  }
+
+  private static List<ColumnLineage> buildHeavyColumns() {
+    List<ColumnLineage> columns = new java.util.ArrayList<>();
+    for (int i = 0; i < 60; i++) {
+      columns.add(
+          new ColumnLineage()
+              .withFromColumns(
+                  List.of(
+                      "db.raw.raw_orders.column_with_a_fairly_long_qualified_name_" + i,
+                      "db.raw.raw_orders.another_long_qualified_column_name_" + i))
+              .withToColumn("db.public.orders.derived_column_with_a_long_name_" + i));
+    }
+    return columns;
+  }
+}


### PR DESCRIPTION
## Description

Fixes #28562 — the `get_entity_lineage` MCP tool returned ~250k chars for even 2 nodes, tripping agents with *"too much data to handle."*

It now slims the verbose `EntityLineage` into a compact graph **inside the tool**; `LineageRepository` and its UI/RCA callers are untouched.

### What changed
- Folds node identity into each edge (drops the standalone `nodes[]` array and per-node descriptions).
- Truncates `sqlQuery` and pipeline/edge descriptions to 500 chars.
- Column-level lineage is **opt-in** via a new `includeColumnLineage` param (default `false`); default stays table-level.
- Dedupes identical edges; keeps `tempLineageTables`; preserves `relationshipType` (`pipeline:`/`storedProcedure:`/`sql`) + `source` so the "how" survives.
- 100k-char safety net: oversized graphs return a `{truncated, message, counts}` hint instead of throwing.
- Removed the local `catch` that reported failures as success — errors now propagate and are marked `isError=true`.

### Note for reviewers
`get_entity_lineage` failures now return `isError=true` + `statusCode` (was `isError=false` `{error}`). No existing test/consumer relied on the old shape.