### PR TITLE
fix(mcp): map tool error responses to correct HTTP status codes

### DIFF
--- a/openmetadata-mcp/src/main/java/org/openmetadata/mcp/tools/DefaultToolContext.java
+++ b/openmetadata-mcp/src/main/java/org/openmetadata/mcp/tools/DefaultToolContext.java
@@ -3,9 +3,12 @@ package org.openmetadata.mcp.tools;
 import static org.openmetadata.mcp.McpUtils.getToolProperties;
 
 import io.modelcontextprotocol.spec.McpSchema;
+import java.util.Collections;
+import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.Predicate;
 import lombok.extern.slf4j.Slf4j;
 import org.openmetadata.schema.entity.app.mcp.McpToolCallUsage;
@@ -17,6 +20,13 @@ import org.openmetadata.service.security.auth.CatalogSecurityContext;
 
 @Slf4j
 public class DefaultToolContext {
+  private static final int STATUS_BAD_REQUEST = 400;
+  private static final int STATUS_FORBIDDEN = 403;
+  private static final int STATUS_NOT_FOUND = 404;
+  private static final int STATUS_TOO_MANY_REQUESTS = 429;
+  private static final int STATUS_INTERNAL_ERROR = 500;
+  private static final int STATUS_GATEWAY_TIMEOUT = 504;
+
   public DefaultToolContext() {}
 
   /**
@@ -122,7 +132,11 @@ public class DefaultToolContext {
                       List.of(
                           new McpSchema.TextContent(
                               JsonUtils.pojoToJson(
-                                  Map.of("error", "Unknown function: " + toolName)))))
+                                  Map.of(
+                                      "error",
+                                      "Unknown function: " + toolName,
+                                      "statusCode",
+                                      STATUS_BAD_REQUEST)))))
                   .isError(true)
                   .build(),
               elapsedMs(startNanos),
@@ -148,7 +162,7 @@ public class DefaultToolContext {
                                   "error",
                                   String.format("Authorization error: %s", ex.getMessage()),
                                   "statusCode",
-                                  403)))))
+                                  STATUS_FORBIDDEN)))))
               .isError(true)
               .build(),
           elapsedMs(startNanos),
@@ -165,7 +179,7 @@ public class DefaultToolContext {
                                   "error",
                                   String.format("Error executing tool: %s", ex.getMessage()),
                                   "statusCode",
-                                  500)))))
+                                  resolveStatusCode(ex))))))
               .isError(true)
               .build(),
           elapsedMs(startNanos),
@@ -179,28 +193,42 @@ public class DefaultToolContext {
    * a {@link RuntimeException}. Defaults to {@link McpToolCallUsage.ErrorCategory#INTERNAL} when
    * no specific bucket matches.
    */
-  static McpToolCallUsage.ErrorCategory classifyException(Throwable t) {
-    McpToolCallUsage.ErrorCategory result = McpToolCallUsage.ErrorCategory.INTERNAL;
+  protected static McpToolCallUsage.ErrorCategory classifyException(Throwable t) {
+    CategoryMatcher matched = matchException(t);
+    return matched != null ? matched.category() : McpToolCallUsage.ErrorCategory.INTERNAL;
+  }
+
+  /**
+   * Resolves the HTTP-style status code returned to the client for a failed tool call. Kept
+   * separate from {@link #classifyException} (which buckets for telemetry) because the wire status
+   * is a distinct concern: a missing entity is a 404 and a bad argument is a 400, even though both
+   * bucket as {@code VALIDATION}. Defaults to 500 when no specific matcher applies.
+   */
+  protected static int resolveStatusCode(Throwable t) {
+    CategoryMatcher matched = matchException(t);
+    return matched != null ? matched.statusCode() : STATUS_INTERNAL_ERROR;
+  }
+
+  private static CategoryMatcher matchException(Throwable t) {
+    CategoryMatcher result = null;
+    // Identity-based visited set bounds the walk: a malformed cause cycle (A.cause=B, B.cause=A)
+    // would otherwise spin forever. seen.add returns false on a revisit, ending the loop.
+    Set<Throwable> seen = Collections.newSetFromMap(new IdentityHashMap<>());
     Throwable cursor = t;
-    while (cursor != null && result == McpToolCallUsage.ErrorCategory.INTERNAL) {
-      McpToolCallUsage.ErrorCategory match = matchCategory(cursor);
-      if (match != null) {
-        result = match;
-      } else {
-        Throwable next = cursor.getCause();
-        cursor = (next == null || next == cursor) ? null : next;
-      }
+    while (cursor != null && result == null && seen.add(cursor)) {
+      result = matchSingle(cursor);
+      cursor = cursor.getCause();
     }
     return result;
   }
 
   /**
-   * Pairing of an exception (name, message) predicate with the bucket it should produce. Kept
-   * as a static table so adding a new category (or extending an existing one with a new keyword)
-   * is a one-line change rather than another {@code else if} branch.
+   * Pairing of an exception (name, message) predicate with the telemetry bucket and HTTP status it
+   * should produce. Kept as a static table so adding a new category (or extending an existing one
+   * with a new keyword) is a one-line change rather than another {@code else if} branch.
    */
   private record CategoryMatcher(
-      Predicate<ExceptionMeta> matches, McpToolCallUsage.ErrorCategory category) {}
+      Predicate<ExceptionMeta> matches, McpToolCallUsage.ErrorCategory category, int statusCode) {}
 
   /** Lower-cased name + message pair so each matcher inspects both without re-parsing. */
   private record ExceptionMeta(String name, String message) {}
@@ -216,7 +244,8 @@ public class DefaultToolContext {
       List.of(
           new CategoryMatcher(
               meta -> meta.name().contains("RateLimit") || meta.message().contains("rate limit"),
-              McpToolCallUsage.ErrorCategory.RATE_LIMIT),
+              McpToolCallUsage.ErrorCategory.RATE_LIMIT,
+              STATUS_TOO_MANY_REQUESTS),
           new CategoryMatcher(
               meta ->
                   meta.name().contains("Authorization")
@@ -226,34 +255,43 @@ public class DefaultToolContext {
                       || meta.message().contains("unauthorized")
                       || meta.message().contains("access denied")
                       || meta.message().contains("permission denied"),
-              McpToolCallUsage.ErrorCategory.AUTH),
+              McpToolCallUsage.ErrorCategory.AUTH,
+              STATUS_FORBIDDEN),
+          // Validation by class name runs before the NotFound message heuristic below, so a
+          // bad-argument exception whose message merely contains "not found" (e.g.
+          // IllegalArgumentException("parameter not found")) stays a 400 rather than a 404.
           new CategoryMatcher(
               meta ->
                   meta.name().contains("Validation")
                       || meta.name().contains("IllegalArgument")
                       || meta.name().contains("BadRequest")
                       || meta.message().contains("invalid argument"),
-              McpToolCallUsage.ErrorCategory.VALIDATION),
+              McpToolCallUsage.ErrorCategory.VALIDATION,
+              STATUS_BAD_REQUEST),
+          new CategoryMatcher(
+              meta -> meta.name().contains("NotFound") || meta.message().contains("not found"),
+              McpToolCallUsage.ErrorCategory.VALIDATION,
+              STATUS_NOT_FOUND),
           new CategoryMatcher(
               meta ->
                   meta.name().contains("Timeout")
                       || meta.message().contains("timeout")
                       || meta.message().contains("timed out"),
-              McpToolCallUsage.ErrorCategory.TIMEOUT));
+              McpToolCallUsage.ErrorCategory.TIMEOUT,
+              STATUS_GATEWAY_TIMEOUT));
 
   /**
-   * Returns the category that matches the supplied throwable's name or message, or {@code null}
-   * when no specific bucket applies. Kept separate from {@link #classifyException} so the
+   * Returns the matcher (category + status) for the supplied throwable's name or message, or
+   * {@code null} when no specific bucket applies. Kept separate from {@link #matchException} so the
    * cause-chain walk reads as a single linear loop.
    */
-  private static McpToolCallUsage.ErrorCategory matchCategory(Throwable cursor) {
+  private static CategoryMatcher matchSingle(Throwable cursor) {
     ExceptionMeta meta =
         new ExceptionMeta(
             cursor.getClass().getSimpleName(),
             cursor.getMessage() == null ? "" : cursor.getMessage().toLowerCase(Locale.ROOT));
     return CATEGORY_MATCHERS.stream()
         .filter(matcher -> matcher.matches().test(meta))
-        .map(CategoryMatcher::category)
         .findFirst()
         .orElse(null);
   }

--- a/openmetadata-mcp/src/test/java/org/openmetadata/mcp/tools/DefaultToolContextTest.java
+++ b/openmetadata-mcp/src/test/java/org/openmetadata/mcp/tools/DefaultToolContextTest.java
@@ -115,6 +115,78 @@ class DefaultToolContextTest {
         .isEqualTo(McpToolCallUsage.ErrorCategory.RATE_LIMIT);
   }
 
+  @Test
+  void resolveStatusCodeMapsNotFoundTo404() {
+    assertThat(
+            DefaultToolContext.resolveStatusCode(new RuntimeException("Entity not found: table x")))
+        .isEqualTo(404);
+  }
+
+  @Test
+  void resolveStatusCodeMapsValidationTo400() {
+    assertThat(DefaultToolContext.resolveStatusCode(new IllegalArgumentException("bad arg")))
+        .isEqualTo(400);
+  }
+
+  @Test
+  void validationExceptionWithNotFoundMessageStaysA400() {
+    assertThat(
+            DefaultToolContext.resolveStatusCode(
+                new IllegalArgumentException("parameter not found")))
+        .isEqualTo(400);
+    assertThat(
+            DefaultToolContext.classifyException(new IllegalArgumentException("field not found")))
+        .isEqualTo(McpToolCallUsage.ErrorCategory.VALIDATION);
+  }
+
+  @Test
+  void resolveStatusCodeMapsAuthTo403() {
+    assertThat(DefaultToolContext.resolveStatusCode(new AuthorizationException("forbidden")))
+        .isEqualTo(403);
+  }
+
+  @Test
+  void resolveStatusCodeMapsRateLimitTo429() {
+    assertThat(DefaultToolContext.resolveStatusCode(new RuntimeException("rate limit exceeded")))
+        .isEqualTo(429);
+  }
+
+  @Test
+  void resolveStatusCodeMapsTimeoutTo504() {
+    assertThat(DefaultToolContext.resolveStatusCode(new RuntimeException("connection timed out")))
+        .isEqualTo(504);
+  }
+
+  @Test
+  void resolveStatusCodeFallsBackTo500() {
+    assertThat(DefaultToolContext.resolveStatusCode(new RuntimeException("kaboom"))).isEqualTo(500);
+  }
+
+  @Test
+  void resolveStatusCodeWalksCauseChain() {
+    RuntimeException root = new RuntimeException("Entity not found: table x");
+    RuntimeException wrapped = new RuntimeException("tool wrapper failed", root);
+
+    assertThat(DefaultToolContext.resolveStatusCode(wrapped)).isEqualTo(404);
+  }
+
+  @Test
+  void resolveStatusCodeTerminatesOnCyclicCauseChain() {
+    RuntimeException a = new RuntimeException("kaboom");
+    RuntimeException b = new RuntimeException("boom", a);
+    a.initCause(b);
+
+    assertThat(DefaultToolContext.resolveStatusCode(a)).isEqualTo(500);
+    assertThat(DefaultToolContext.classifyException(a))
+        .isEqualTo(McpToolCallUsage.ErrorCategory.INTERNAL);
+  }
+
+  @Test
+  void notFoundStillBucketsAsValidationCategory() {
+    assertThat(DefaultToolContext.classifyException(new RuntimeException("Entity not found: x")))
+        .isEqualTo(McpToolCallUsage.ErrorCategory.VALIDATION);
+  }
+
   private static DefaultToolContext.CallToolOutcome invokeWithToolName(String toolName) {
     CatalogSecurityContext securityContext = mock(CatalogSecurityContext.class);
     Principal principal = mock(Principal.class);


### PR DESCRIPTION
## Description

When an MCP tool fails, the error JSON carries a `statusCode`. Today every failure except authorization returns `500` — a not-found entity, a missing/invalid parameter, and a genuine server bug are indistinguishable.

This derives the status code from the exception so the wire status reflects the actual failure class. related to https://github.com/open-metadata/OpenMetadata/issues/28629

### What changed
- New `resolveStatusCode` (in `DefaultToolContext`) maps: not-found → `404`, validation/bad-args → `400`, rate-limit → `429`, timeout → `504`, auth → `403`, else `500`. It reads the same matcher table as `classifyException`, so HTTP status and telemetry category stay in sync without duplication.
- Telemetry `ErrorCategory` buckets are unchanged.
- `CollateToolContext` dropped a duplicated, diverged `classifyException` and now reuses the parent helpers (`classifyException`/`resolveStatusCode`, made `protected static`).
- Bounded the cause-chain walk with an identity visited-set so a malformed exception cycle can't spin forever.

### Why it helps
- **Correctness** — a bad table name or missing argument is a client error (`4xx`), not a server fault (`500`).
- **Observability** — alerting buckets on status codes; mislabeling client errors as `500` produces false "server down" pages and buries real `5xx`.
- **Programmatic clients** — can branch on the code (`404` → search/retry with a better name, `400` → fix args, `429` → back off, `500` → report/retry).
