### PR TITLE
Fixes 4362: preserve secret: prefix during Python SDK serialization

### DIFF
--- a/ingestion/src/metadata/ingestion/models/custom_pydantic.py
+++ b/ingestion/src/metadata/ingestion/models/custom_pydantic.py
@@ -200,10 +200,15 @@ def handle_secret(value: Any, handler, info: SerializationInfo) -> str:
     Handle the secret value in the model.
     """
     if not (info.context is not None and info.context.get("mask_secrets", False)):
+        # Serialization must preserve the raw stored value. For external secret
+        # references (`secret:<id>`) this keeps the reference intact instead of
+        # resolving it, so the payload sent to the server keeps the reference and
+        # is not silently turned into a plain secret. Resolution against the
+        # secrets manager happens at use-time through a direct get_secret_value()
+        # call (e.g. when building a connection).
         if info.mode == "json":
-            # short circuit the json serialization and return the actual value
-            return value.get_secret_value()
-        return handler(value.get_secret_value())
+            return value.get_secret_value(skip_secret_manager=True)
+        return handler(value.get_secret_value(skip_secret_manager=True))
     return str(value)  # use pydantic's logic to mask the secret
 
 

--- a/ingestion/tests/unit/models/test_custom_pydantic.py
+++ b/ingestion/tests/unit/models/test_custom_pydantic.py
@@ -1,6 +1,9 @@
+import json
 import uuid
 from typing import List, Optional  # noqa: UP035
 from unittest import TestCase
+
+import pytest
 
 from metadata.generated.schema.api.data.createDashboardDataModel import (
     CreateDashboardDataModelRequest,
@@ -21,6 +24,18 @@ from metadata.generated.schema.entity.data.table import (
     TableConstraint,
     TableType,
 )
+from metadata.generated.schema.entity.services.connections.database.common.basicAuth import (
+    BasicAuth,
+)
+from metadata.generated.schema.entity.services.connections.database.mysqlConnection import (
+    MysqlConnection,
+)
+from metadata.generated.schema.security.secrets.secretsManagerClientLoader import (
+    SecretsManagerClientLoader,
+)
+from metadata.generated.schema.security.secrets.secretsManagerProvider import (
+    SecretsManagerProvider,
+)
 from metadata.generated.schema.type.basic import (
     EntityExtension,
     EntityName,
@@ -28,7 +43,11 @@ from metadata.generated.schema.type.basic import (
     Markdown,
 )
 from metadata.generated.schema.type.entityReference import EntityReference
+from metadata.ingestion.connections.builders import get_password_secret
 from metadata.ingestion.models.custom_pydantic import BaseModel, CustomSecretStr
+from metadata.utils.secrets.secrets_manager import SecretsManager
+from metadata.utils.secrets.secrets_manager_factory import SecretsManagerFactory
+from metadata.utils.singleton import Singleton
 
 
 class CustomPydanticValidationTest(TestCase):
@@ -770,6 +789,112 @@ class CustomSecretStrExtendedTest(TestCase):
         assert all(
             secret.get_secret_value() in ["password1", "password2", "password3"] for secret in complex_model.secret_list
         )
+
+
+class TestExternalSecretReferenceSerialization:
+    """Regression tests for https://github.com/open-metadata/openmetadata-collate/issues/4362.
+
+    Values prefixed with ``secret:`` are external secret references: the server
+    resolves them against an external secret manager instead of persisting the
+    raw value. The prefix MUST survive SDK serialization. If it is stripped, the
+    reference is sent as a plain secret and ends up stored in Collate's internal
+    secret manager rather than being resolved externally.
+
+    The SDK serializes create/update payloads with
+    ``model_dump_json(context={"mask_secrets": False})`` (see the PUT path in
+    ``metadata.ingestion.ometa.ometa_api``), so these tests exercise that exact
+    serialization with the default ``DBSecretsManager`` active, as it is once an
+    ometa client has been instantiated.
+    """
+
+    EXTERNAL_SECRET_REFERENCE = "secret:/external/path/to/db/password"
+
+    @pytest.fixture(autouse=True)
+    def db_secrets_manager(self):
+        Singleton.clear_all()
+        SecretsManagerFactory(SecretsManagerProvider.db, SecretsManagerClientLoader.noop)
+        yield
+        Singleton.clear_all()
+
+    def test_prefix_preserved_for_custom_secret_str(self):
+        class Connection(BaseModel):
+            password: CustomSecretStr
+
+        connection = Connection(password=self.EXTERNAL_SECRET_REFERENCE)
+
+        serialized = json.loads(connection.model_dump_json(context={"mask_secrets": False}))
+
+        assert serialized["password"] == self.EXTERNAL_SECRET_REFERENCE
+
+    def test_prefix_preserved_for_typed_service_connection(self):
+        connection = MysqlConnection(
+            username="user",
+            authType=BasicAuth(password=self.EXTERNAL_SECRET_REFERENCE),
+            hostPort="localhost:3306",
+        )
+
+        serialized = json.loads(connection.model_dump_json(context={"mask_secrets": False}, by_alias=True))
+
+        assert serialized["authType"]["password"] == self.EXTERNAL_SECRET_REFERENCE
+
+
+RESOLVED_EXTERNAL_SECRET = "resolved-external-password"
+
+
+class _FakeExternalSecretsManager(SecretsManager):
+    """Test double for an external secrets manager (e.g. AWS, Azure).
+
+    Resolves any reference id to a fixed value, so a test can tell real
+    resolution apart from mere ``secret:`` prefix stripping.
+    """
+
+    def get_string_value(self, secret_id: str) -> str:
+        return RESOLVED_EXTERNAL_SECRET
+
+
+class TestExternalSecretReferenceResolution:
+    """Guards the connect-time resolution path against the #4362 fix.
+
+    Preserving the ``secret:`` reference during serialization must NOT change how
+    ingestion resolves that reference when building a connection. Resolution runs
+    through a direct ``get_secret_value()`` call (see
+    ``metadata.ingestion.connections.builders.get_password_secret``), not through
+    serialization, so it stays intact. An external secrets manager is active
+    here, as it would be on a hybrid ingestion runner.
+    """
+
+    EXTERNAL_SECRET_REFERENCE = "secret:/external/path/to/db/password"
+
+    @pytest.fixture(autouse=True)
+    def external_secrets_manager(self):
+        Singleton.clear_all()
+        factory = SecretsManagerFactory(SecretsManagerProvider.db, SecretsManagerClientLoader.noop)
+        factory.secrets_manager = _FakeExternalSecretsManager()
+        yield
+        Singleton.clear_all()
+
+    def test_reference_resolves_for_connection_use(self):
+        connection = MysqlConnection(
+            username="user",
+            authType=BasicAuth(password=self.EXTERNAL_SECRET_REFERENCE),
+            hostPort="localhost:3306",
+        )
+
+        password = get_password_secret(connection)
+
+        assert password.get_secret_value() == RESOLVED_EXTERNAL_SECRET
+
+    def test_reference_is_not_resolved_into_serialized_payload(self):
+        connection = MysqlConnection(
+            username="user",
+            authType=BasicAuth(password=self.EXTERNAL_SECRET_REFERENCE),
+            hostPort="localhost:3306",
+        )
+
+        serialized = json.loads(connection.model_dump_json(context={"mask_secrets": False}, by_alias=True))
+
+        assert serialized["authType"]["password"] == self.EXTERNAL_SECRET_REFERENCE
+        assert serialized["authType"]["password"] != RESOLVED_EXTERNAL_SECRET
 
 
 class DashboardDataModelTransformationTest(TestCase):


### PR DESCRIPTION
Basically, if we created a service with the YAML putting in secret:redshift-pwd, it got sent deserialized with the password as-is, so then the server saved it with the "internal" secret path like "secret:openmetadata-database-red-sm-new-authtype-password"
So you ended up with the service misaligned with how you have your secrets set up locally
So anyway, this cleans up the serde step when we send the payload

### Describe your changes:

Fixes open-metadata/openmetadata-collate#4362

`CustomSecretStr` serialization resolved `secret:<id>` external secret references through the configured secrets manager, stripping the `secret:` prefix from `model_dump` / `model_dump_json` output. On create/update the SDK sent that resolved (or, with the default DB manager, prefix-stripped) value to the server, so external references were stored as plain secrets instead of being preserved. `handle_secret` now serializes with `skip_secret_manager=True`, keeping the raw `secret:<id>` reference intact for transport; resolution still happens at use-time via the direct `get_secret_value()` call when a connection is built, so ingestion keeps resolving references exactly as before.

#
### Type of change:
- [x] Bug fix

#
### High-level design:

N/A — small change (2 files). Serialization (transport) preserves the reference; resolution (use-time, e.g. `builders.get_password_secret`) is a separate, untouched path.

#
### Tests:

#### Use cases covered
- Creating a service via the Python SDK with a `secret:<id>` external reference keeps the reference in the serialized create/update payload (so the server stores it as an external reference, not a plain secret).
- Ingestion still resolves `secret:<id>` against the configured secrets manager when building a connection.

#### Unit tests
- [x] Added unit tests for the changed logic.
- Files: `ingestion/tests/unit/models/test_custom_pydantic.py`
  - `TestExternalSecretReferenceSerialization` — asserts the `secret:` prefix survives `model_dump_json(context={"mask_secrets": False})` for both a plain `CustomSecretStr` model and a typed `MysqlConnection`.
  - `TestExternalSecretReferenceResolution` — guards the connect-time path: with an external secrets manager active, `get_password_secret().get_secret_value()` still resolves the reference, while serialization does not leak the resolved value.

#### Backend integration tests
- [x] Not applicable (no backend API changes).

#### Ingestion integration tests
- [x] Not applicable (covered by unit tests above).

#### Playwright (UI) tests
- [x] Not applicable (no UI changes).

#### Manual testing performed
1. Ran a Redshift metadata ingestion from YAML with `authType.password: secret:redshift-pwd` and a Kubernetes secrets manager.
2. Verified the created service `GET .../databaseServices/name/<svc>?fields=*` returns `authType.password = secret:redshift-pwd` (reference preserved) instead of a server-wrapped `secret:openmetadata-...` plain secret.

#
### UI screen recording / screenshots:

Not applicable.

#
### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] My PR is linked to a GitHub issue via `Fixes` above.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have added tests (unit) and listed them above.
- [x] I have added a test that covers the exact scenario we are fixing (issue #4362 referenced in the test docstrings).