### PR TITLE
fix(search): restore search by nested field names for topics and API endpoints (#28610)

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/indexes/APIEndpointIndex.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/indexes/APIEndpointIndex.java
@@ -123,10 +123,10 @@ public class APIEndpointIndex implements SearchIndex {
     Map<String, Float> fields = SearchIndex.getDefaultFields();
     fields.put("requestSchema.schemaFields.name.keyword", 5.0f);
     fields.put("requestSchema.schemaFields.description", 1.0f);
-    fields.put("requestSchema.schemaFields.children.name", 7.0f);
+    fields.put("request_field_namesFuzzy", 7.0f);
     fields.put("responseSchema.schemaFields.name.keyword", 5.0f);
     fields.put("responseSchema.schemaFields.description", 1.0f);
-    fields.put("responseSchema.schemaFields.children.name", 7.0f);
+    fields.put("response_field_namesFuzzy", 7.0f);
     return fields;
   }
 }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/indexes/TopicIndex.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/indexes/TopicIndex.java
@@ -107,7 +107,7 @@ public class TopicIndex implements SearchIndex {
     fields.put(ES_MESSAGE_SCHEMA_FIELD, 7.0f);
     fields.put("messageSchema.schemaFields.name.keyword", 5.0f);
     fields.put("messageSchema.schemaFields.description", 1.0f);
-    fields.put("messageSchema.schemaFields.children.name", 7.0f);
+    fields.put("fieldNamesFuzzy", 7.0f);
     return fields;
   }
 }

--- a/openmetadata-spec/src/main/resources/elasticsearch/en/api_endpoint_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/en/api_endpoint_index_mapping.json
@@ -303,6 +303,14 @@
           }
         }
       },
+      "request_field_namesFuzzy": {
+        "type": "text",
+        "analyzer": "om_analyzer"
+      },
+      "response_field_namesFuzzy": {
+        "type": "text",
+        "analyzer": "om_analyzer"
+      },
       "requestSchema": {
         "properties": {
           "schemaFields": {

--- a/openmetadata-spec/src/main/resources/elasticsearch/en/topic_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/en/topic_index_mapping.json
@@ -323,6 +323,10 @@
       "fieldNames": {
         "type": "keyword"
       },
+      "fieldNamesFuzzy": {
+        "type": "text",
+        "analyzer": "om_analyzer"
+      },
       "cleanupPolicies": {
         "type": "keyword"
       },

--- a/openmetadata-spec/src/main/resources/elasticsearch/jp/api_endpoint_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/jp/api_endpoint_index_mapping.json
@@ -299,6 +299,14 @@
           }
         }
       },
+      "request_field_namesFuzzy": {
+        "type": "text",
+        "analyzer": "om_analyzer"
+      },
+      "response_field_namesFuzzy": {
+        "type": "text",
+        "analyzer": "om_analyzer"
+      },
       "requestSchema": {
         "properties": {
           "schemaFields": {

--- a/openmetadata-spec/src/main/resources/elasticsearch/jp/topic_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/jp/topic_index_mapping.json
@@ -383,6 +383,10 @@
       "fieldNames": {
         "type": "keyword"
       },
+      "fieldNamesFuzzy": {
+        "type": "text",
+        "analyzer": "om_analyzer"
+      },
       "cleanupPolicies": {
         "type": "keyword"
       },

--- a/openmetadata-spec/src/main/resources/elasticsearch/ru/api_endpoint_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/ru/api_endpoint_index_mapping.json
@@ -321,6 +321,14 @@
           }
         }
       },
+      "request_field_namesFuzzy": {
+        "type": "text",
+        "analyzer": "om_analyzer"
+      },
+      "response_field_namesFuzzy": {
+        "type": "text",
+        "analyzer": "om_analyzer"
+      },
       "requestSchema": {
         "properties": {
           "schemaFields": {

--- a/openmetadata-spec/src/main/resources/elasticsearch/ru/topic_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/ru/topic_index_mapping.json
@@ -341,6 +341,10 @@
       "fieldNames": {
         "type": "keyword"
       },
+      "fieldNamesFuzzy": {
+        "type": "text",
+        "analyzer": "om_analyzer"
+      },
       "cleanupPolicies": {
         "type": "keyword"
       },

--- a/openmetadata-spec/src/main/resources/elasticsearch/zh/api_endpoint_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/zh/api_endpoint_index_mapping.json
@@ -298,6 +298,14 @@
           }
         }
       },
+      "request_field_namesFuzzy": {
+        "type": "text",
+        "analyzer": "om_analyzer"
+      },
+      "response_field_namesFuzzy": {
+        "type": "text",
+        "analyzer": "om_analyzer"
+      },
       "requestSchema": {
         "properties": {
           "schemaFields": {

--- a/openmetadata-spec/src/main/resources/elasticsearch/zh/topic_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/zh/topic_index_mapping.json
@@ -320,6 +320,10 @@
       "fieldNames": {
         "type": "keyword"
       },
+      "fieldNamesFuzzy": {
+        "type": "text",
+        "analyzer": "om_analyzer"
+      },
       "cleanupPolicies": {
         "type": "keyword"
       },


### PR DESCRIPTION
Cherry-pick of #28610 to 1.12.10.

## Summary

- **`TopicIndex.java`** — `getFields()` now points at `fieldNamesFuzzy` instead of the non-indexed `messageSchema.schemaFields.children.name`
- **`APIEndpointIndex.java`** — same swap for `request_field_namesFuzzy` / `response_field_namesFuzzy`
- **8 index mapping files** (en/jp/ru/zh × topic + api_endpoint) — add `om_analyzer` text field declaration for the fuzzy fields so tokenization works on reindex

Searching topics and API endpoints by their nested field names stopped working after the nested `children` field was made non-indexed. This restores it by pointing at the flattened `fieldNamesFuzzy` / `request_field_namesFuzzy` / `response_field_namesFuzzy` fields with an explicit `om_analyzer` declaration.

**Requires a reindex.**

> Note: `EntitySpecificFieldsTest.java` was not cherry-picked as it does not exist on 1.12.10.