### PR TITLE
fix(mcp): slim root_cause_analysis payload to fit LLM context limits

### DIFF
--- a/openmetadata-mcp/src/main/java/org/openmetadata/mcp/tools/RootCauseAnalysisTool.java
+++ b/openmetadata-mcp/src/main/java/org/openmetadata/mcp/tools/RootCauseAnalysisTool.java
@@ -3,10 +3,14 @@ package org.openmetadata.mcp.tools;
 import static org.openmetadata.mcp.tools.SearchMetadataTool.cleanSearchResponseObject;
 import static org.openmetadata.service.search.SearchUtils.isConnectedVia;
 
+import com.google.common.annotations.VisibleForTesting;
 import jakarta.ws.rs.core.Response;
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -30,7 +34,16 @@ import org.openmetadata.service.security.policyevaluator.ResourceContext;
 @Slf4j
 public class RootCauseAnalysisTool implements McpTool {
 
+  private static final int DEFAULT_DEPTH = 3;
   private static final int MAX_DEPTH = 10;
+  // Slimming budgets mirror GetLineageTool so RCA's lineage-derived payload stays within
+  // LLM/MCP context limits. The backend (searchDataQualityLineage / searchLineageWithDirection)
+  // is shared with the UI LineageResource and is never touched — we only transform the
+  // in-memory result before returning it to the MCP client.
+  private static final int SQL_MAX_LENGTH = 500;
+  private static final int TEXT_MAX_LENGTH = 500;
+  private static final int MAX_RESPONSE_CHARS = 100_000;
+  private static final String RELATIONSHIP_SQL = "sql";
 
   @Override
   public Map<String, Object> execute(
@@ -39,12 +52,12 @@ public class RootCauseAnalysisTool implements McpTool {
       Map<String, Object> parameters) {
     String fqn = (String) parameters.get("fqn");
     String entityType = (String) parameters.getOrDefault("entityType", "table");
-    int upstreamDepth =
-        Math.min(Math.max(parseIntParam(parameters.get("upstreamDepth"), 3), 1), MAX_DEPTH);
+    int upstreamDepth = clampDepth(parseIntParam(parameters.get("upstreamDepth"), DEFAULT_DEPTH));
     int downstreamDepth =
-        Math.min(Math.max(parseIntParam(parameters.get("downstreamDepth"), 3), 1), MAX_DEPTH);
+        clampDepth(parseIntParam(parameters.get("downstreamDepth"), DEFAULT_DEPTH));
     String queryFilter = (String) parameters.get("queryFilter");
     boolean includeDeleted = parseBooleanParam(parameters.get("includeDeleted"), false);
+    boolean includeColumns = parseBooleanParam(parameters.get("includeColumnLineage"), false);
 
     if (fqn == null || fqn.trim().isEmpty()) {
       throw new IllegalArgumentException("Parameter 'fqn' is required and cannot be empty");
@@ -56,125 +69,290 @@ public class RootCauseAnalysisTool implements McpTool {
         new ResourceContext<>(entityType));
 
     try {
-      Map<String, Object> result = new HashMap<>();
-      result.put("fqn", fqn);
-      result.put("upstreamDepth", upstreamDepth);
-      result.put("downstreamDepth", downstreamDepth);
-
-      Response upstreamResponse =
-          Entity.getSearchRepository()
-              .searchDataQualityLineage(fqn.trim(), upstreamDepth, queryFilter, includeDeleted);
-
-      Object upstreamEntity = upstreamResponse.getEntity();
-      Map<String, Object> upstreamAnalysis = new HashMap<>();
-      boolean hasFailures = false;
-      int failureCount = 0;
-
-      if (upstreamEntity instanceof Map) {
-        @SuppressWarnings("unchecked")
-        Map<String, Object> upstreamLineageData = (Map<String, Object>) upstreamEntity;
-
-        Set<?> upstreamEdgesList =
-            upstreamLineageData.get("edges") instanceof Set<?> s ? s : Collections.emptySet();
-        Set<?> upstreamNodesList =
-            upstreamLineageData.get("nodes") instanceof Set<?> s ? s : Collections.emptySet();
-        List<Map<String, Object>> upstreamNodes =
-            upstreamNodesList.stream()
-                .filter(node -> node instanceof Map)
-                .map(node -> cleanSearchResponseObject((Map<String, Object>) node))
-                .toList();
-
-        failureCount = upstreamNodes.size();
-        upstreamAnalysis.put("failingUpstreamNodesCount", failureCount);
-        hasFailures = !upstreamNodes.isEmpty();
-        if (!upstreamNodes.isEmpty()) {
-          upstreamAnalysis.put("failingUpstreamNodes", upstreamNodes);
-          upstreamNodes.forEach(
-              node -> node.put("failingTestCases", addTestCaseResultForTestSuite(node)));
-        }
-
-        upstreamAnalysis.put("failingUpstreamEdgesCount", upstreamEdgesList.size());
-        upstreamAnalysis.put("failingUpstreamEdges", upstreamEdgesList);
-        upstreamAnalysis.put(
-            "description", "Upstream entities that may be causing data quality failures");
-      }
-      result.put("upstreamAnalysis", upstreamAnalysis);
-
-      Map<String, Object> downstreamAnalysis = new HashMap<>();
-      if (hasFailures) {
-        try {
-          SearchLineageRequest downstreamRequest =
-              new SearchLineageRequest()
-                  .withFqn(fqn.trim())
-                  .withDirection(LineageDirection.DOWNSTREAM)
-                  .withUpstreamDepth(0)
-                  .withDownstreamDepth(downstreamDepth)
-                  .withQueryFilter(queryFilter)
-                  .withIsConnectedVia(isConnectedVia(entityType))
-                  .withIncludeDeleted(includeDeleted);
-
-          SearchLineageResult downstreamResult =
-              Entity.getSearchRepository().searchLineageWithDirection(downstreamRequest);
-
-          downstreamAnalysis.put(
-              "description", "Downstream entities that may be impacted by the identified failures");
-
-          if (downstreamResult.getNodes() != null) {
-            downstreamAnalysis.put(
-                "downstreamImpactedNodesCount", downstreamResult.getNodes().size());
-            downstreamAnalysis.put("downstreamNodes", downstreamResult.getNodes());
-          }
-
-          if (downstreamResult.getDownstreamEdges() != null) {
-            downstreamAnalysis.put(
-                "downstreamImpactedEdgesCount", downstreamResult.getDownstreamEdges().size());
-            downstreamAnalysis.put("downstreamEdges", downstreamResult.getDownstreamEdges());
-          }
-
-          LOG.info(
-              "Downstream impact analysis completed for entity: {} with {} downstream depth, found {} nodes and {} edges",
-              fqn,
-              downstreamDepth,
-              downstreamResult.getNodes() != null ? downstreamResult.getNodes().size() : 0,
-              downstreamResult.getDownstreamEdges() != null
-                  ? downstreamResult.getDownstreamEdges().size()
-                  : 0);
-
-        } catch (Exception e) {
-          LOG.warn("Failed to perform downstream impact analysis for entity: {}", fqn, e);
-          downstreamAnalysis.put("error", "Failed to analyze downstream impact: " + e.getMessage());
-        }
-      } else {
-        downstreamAnalysis.put(
-            "reason",
-            "No failures found in upstream analysis, downstream impact analysis not needed");
-      }
-
-      result.put("downstreamAnalysis", downstreamAnalysis);
-
-      result.put("status", hasFailures ? "failed" : "success");
-      result.put(
-          "summary",
-          String.format(
-              "Analyzed upstream causes and downstream impacts for '%s'. Found %d upstream failure(s).",
-              fqn, failureCount));
-
-      LOG.info(
-          "Comprehensive root cause analysis completed for entity: {} - Upstream failures: {}",
-          fqn,
-          hasFailures);
-
-      return result;
-
+      return analyze(
+          fqn.trim(),
+          entityType,
+          upstreamDepth,
+          downstreamDepth,
+          queryFilter,
+          includeDeleted,
+          includeColumns);
     } catch (IOException e) {
       LOG.error("IOException during root cause analysis for entity: {}", fqn, e);
       throw new RuntimeException("Failed to perform root cause analysis: " + e.getMessage(), e);
-
     } catch (Exception e) {
       LOG.error("Unexpected error during root cause analysis for entity: {}", fqn, e);
       throw new RuntimeException(
           "Unexpected error during root cause analysis: " + e.getMessage(), e);
     }
+  }
+
+  private Map<String, Object> analyze(
+      String fqn,
+      String entityType,
+      int upstreamDepth,
+      int downstreamDepth,
+      String queryFilter,
+      boolean includeDeleted,
+      boolean includeColumns)
+      throws IOException {
+    Map<String, Object> result = new HashMap<>();
+    result.put("fqn", fqn);
+    result.put("upstreamDepth", upstreamDepth);
+    result.put("downstreamDepth", downstreamDepth);
+
+    Response upstreamResponse =
+        Entity.getSearchRepository()
+            .searchDataQualityLineage(fqn, upstreamDepth, queryFilter, includeDeleted);
+    Map<String, Object> upstreamAnalysis =
+        buildUpstreamAnalysis(upstreamResponse.getEntity(), includeColumns);
+    result.put("upstreamAnalysis", upstreamAnalysis);
+
+    int failureCount =
+        ((Number) upstreamAnalysis.getOrDefault("failingUpstreamNodesCount", 0)).intValue();
+    boolean hasFailures = failureCount > 0;
+    result.put(
+        "downstreamAnalysis",
+        hasFailures
+            ? buildDownstreamAnalysis(
+                fqn, entityType, downstreamDepth, queryFilter, includeDeleted, includeColumns)
+            : noFailuresDownstream());
+    result.put("status", hasFailures ? "failed" : "success");
+    result.put(
+        "summary",
+        String.format(
+            "Analyzed upstream causes and downstream impacts for '%s'. Found %d upstream failure(s).",
+            fqn, failureCount));
+    return enforceSizeBudget(result);
+  }
+
+  private Map<String, Object> buildUpstreamAnalysis(Object upstreamEntity, boolean includeColumns) {
+    Map<String, Object> upstreamAnalysis = new HashMap<>();
+    if (!(upstreamEntity instanceof Map)) {
+      return upstreamAnalysis;
+    }
+    Map<String, Object> upstreamLineageData = castMap(upstreamEntity);
+    Set<?> rawEdges = asSet(upstreamLineageData.get("edges"));
+    List<Map<String, Object>> nodes = slimUpstreamNodes(asSet(upstreamLineageData.get("nodes")));
+
+    upstreamAnalysis.put("failingUpstreamNodesCount", nodes.size());
+    if (!nodes.isEmpty()) {
+      nodes.forEach(node -> node.put("failingTestCases", addTestCaseResultForTestSuite(node)));
+      upstreamAnalysis.put("failingUpstreamNodes", nodes);
+    }
+    upstreamAnalysis.put("failingUpstreamEdgesCount", rawEdges.size());
+    upstreamAnalysis.put("failingUpstreamEdges", slimEdges(rawEdges, includeColumns));
+    upstreamAnalysis.put(
+        "description", "Upstream entities that may be causing data quality failures");
+    return upstreamAnalysis;
+  }
+
+  private Map<String, Object> buildDownstreamAnalysis(
+      String fqn,
+      String entityType,
+      int downstreamDepth,
+      String queryFilter,
+      boolean includeDeleted,
+      boolean includeColumns) {
+    Map<String, Object> downstreamAnalysis = new HashMap<>();
+    downstreamAnalysis.put(
+        "description", "Downstream entities that may be impacted by the identified failures");
+    try {
+      SearchLineageRequest downstreamRequest =
+          new SearchLineageRequest()
+              .withFqn(fqn)
+              .withDirection(LineageDirection.DOWNSTREAM)
+              .withUpstreamDepth(0)
+              .withDownstreamDepth(downstreamDepth)
+              .withQueryFilter(queryFilter)
+              .withIsConnectedVia(isConnectedVia(entityType))
+              .withIncludeDeleted(includeDeleted);
+      SearchLineageResult downstreamResult =
+          Entity.getSearchRepository().searchLineageWithDirection(downstreamRequest);
+      addDownstreamNodes(downstreamAnalysis, downstreamResult);
+      addDownstreamEdges(downstreamAnalysis, downstreamResult, includeColumns);
+    } catch (Exception e) {
+      LOG.warn("Failed to perform downstream impact analysis for entity: {}", fqn, e);
+      downstreamAnalysis.put("error", "Failed to analyze downstream impact: " + e.getMessage());
+    }
+    return downstreamAnalysis;
+  }
+
+  private static void addDownstreamNodes(
+      Map<String, Object> downstreamAnalysis, SearchLineageResult result) {
+    if (result.getNodes() != null) {
+      downstreamAnalysis.put("downstreamImpactedNodesCount", result.getNodes().size());
+      downstreamAnalysis.put("downstreamNodes", slimDownstreamNodes(result.getNodes()));
+    }
+  }
+
+  private static void addDownstreamEdges(
+      Map<String, Object> downstreamAnalysis, SearchLineageResult result, boolean includeColumns) {
+    if (result.getDownstreamEdges() != null) {
+      downstreamAnalysis.put("downstreamImpactedEdgesCount", result.getDownstreamEdges().size());
+      downstreamAnalysis.put(
+          "downstreamEdges", slimEdgeMap(result.getDownstreamEdges(), includeColumns));
+    }
+  }
+
+  private static Map<String, Object> noFailuresDownstream() {
+    Map<String, Object> downstreamAnalysis = new HashMap<>();
+    downstreamAnalysis.put(
+        "reason", "No failures found in upstream analysis, downstream impact analysis not needed");
+    return downstreamAnalysis;
+  }
+
+  private static List<Map<String, Object>> slimUpstreamNodes(Set<?> rawNodes) {
+    List<Map<String, Object>> nodes = new ArrayList<>();
+    for (Object node : rawNodes) {
+      if (node instanceof Map) {
+        nodes.add(slimNodeEntity(castMap(node)));
+      }
+    }
+    return nodes;
+  }
+
+  @VisibleForTesting
+  static Map<String, Object> slimDownstreamNodes(Map<String, ?> rawNodes) {
+    Map<String, Object> slim = new LinkedHashMap<>();
+    rawNodes.forEach((id, nodeInfo) -> slim.put(id, slimNodeInformation(nodeInfo)));
+    return slim;
+  }
+
+  private static Map<String, Object> slimNodeInformation(Object nodeInfo) {
+    Map<String, Object> info = JsonUtils.getMap(nodeInfo);
+    Map<String, Object> slim = new LinkedHashMap<>();
+    Object entity = info.get("entity");
+    if (entity instanceof Map) {
+      slim.put("entity", slimNodeEntity(castMap(entity)));
+    }
+    putIfPresent(slim, "nodeDepth", info.get("nodeDepth"));
+    return slim;
+  }
+
+  /**
+   * Cleans an entity document the same way upstream nodes are cleaned ({@link
+   * SearchMetadataTool#cleanSearchResponseObject} drops {@code columns}, {@code schemaDefinition},
+   * {@code queries} and other verbose keys) and additionally truncates the markdown description
+   * that the cleaner leaves untouched.
+   */
+  @VisibleForTesting
+  static Map<String, Object> slimNodeEntity(Map<String, Object> node) {
+    Map<String, Object> cleaned = cleanSearchResponseObject(node);
+    truncateDescriptionInPlace(cleaned);
+    return cleaned;
+  }
+
+  @VisibleForTesting
+  static List<Map<String, Object>> slimEdges(Collection<?> rawEdges, boolean includeColumns) {
+    List<Map<String, Object>> edges = new ArrayList<>();
+    for (Object edge : rawEdges) {
+      edges.add(slimEdge(JsonUtils.getMap(edge), includeColumns));
+    }
+    return edges;
+  }
+
+  @VisibleForTesting
+  static Map<String, Object> slimEdgeMap(Map<String, ?> rawEdges, boolean includeColumns) {
+    Map<String, Object> slim = new LinkedHashMap<>();
+    rawEdges.forEach((id, edge) -> slim.put(id, slimEdge(JsonUtils.getMap(edge), includeColumns)));
+    return slim;
+  }
+
+  /**
+   * Reduces a raw {@code EsLineageData} edge to the fields useful for reasoning. Drops {@code
+   * docId}/{@code docUniqueId}/{@code fqnHash}, audit fields and the raw {@code pipeline} blob
+   * (folded into {@code relationshipType}); truncates {@code sqlQuery}; and includes column-level
+   * lineage only when explicitly requested.
+   */
+  @VisibleForTesting
+  static Map<String, Object> slimEdge(Map<String, Object> edge, boolean includeColumns) {
+    Map<String, Object> slim = new LinkedHashMap<>();
+    putIfPresent(slim, "fromEntity", slimRef(edge.get("fromEntity")));
+    putIfPresent(slim, "toEntity", slimRef(edge.get("toEntity")));
+    slim.put("relationshipType", relationshipType(edge.get("pipeline")));
+    putIfPresent(slim, "source", edge.get("source"));
+    putIfPresent(slim, "assetEdges", edge.get("assetEdges"));
+    putIfPresent(slim, "tempLineageTables", edge.get("tempLineageTables"));
+    applyDescription(slim, edge.get("description"));
+    applySqlQuery(slim, edge.get("sqlQuery"));
+    if (includeColumns) {
+      putIfPresent(slim, "columns", edge.get("columns"));
+    }
+    return slim;
+  }
+
+  private static Map<String, Object> slimRef(Object ref) {
+    Map<String, Object> result = null;
+    if (ref instanceof Map) {
+      Map<String, Object> refMap = castMap(ref);
+      result = new LinkedHashMap<>();
+      putIfPresent(result, "id", refMap.get("id"));
+      putIfPresent(result, "fullyQualifiedName", refMap.get("fullyQualifiedName"));
+      putIfPresent(result, "type", refMap.get("type"));
+    }
+    return result;
+  }
+
+  private static String relationshipType(Object pipeline) {
+    String result = RELATIONSHIP_SQL;
+    if (pipeline instanceof Map) {
+      Map<String, Object> pipelineMap = castMap(pipeline);
+      Object type = pipelineMap.get("type");
+      Object name = pipelineMap.get("name");
+      if (type != null && name != null) {
+        result = type + ":" + name;
+      }
+    }
+    return result;
+  }
+
+  private static void applyDescription(Map<String, Object> slim, Object description) {
+    if (description instanceof String text && !text.isEmpty()) {
+      slim.put("description", truncate(text, TEXT_MAX_LENGTH));
+    }
+  }
+
+  private static void applySqlQuery(Map<String, Object> slim, Object sqlQuery) {
+    if (sqlQuery instanceof String sql && !sql.isEmpty()) {
+      slim.put("sqlQuery", truncate(sql, SQL_MAX_LENGTH));
+      if (sql.length() > SQL_MAX_LENGTH) {
+        slim.put("sqlTruncated", Boolean.TRUE);
+      }
+    }
+  }
+
+  private static void truncateDescriptionInPlace(Map<String, Object> map) {
+    Object description = map.get("description");
+    if (description instanceof String text && text.length() > TEXT_MAX_LENGTH) {
+      map.put("description", truncate(text, TEXT_MAX_LENGTH));
+    }
+  }
+
+  private static String truncate(String value, int maxLength) {
+    return value.length() > maxLength ? value.substring(0, maxLength) + "..." : value;
+  }
+
+  @VisibleForTesting
+  static Map<String, Object> enforceSizeBudget(Map<String, Object> result) {
+    Map<String, Object> output = result;
+    if (JsonUtils.pojoToJson(result).length() > MAX_RESPONSE_CHARS) {
+      output = oversizedHint(result);
+    }
+    return output;
+  }
+
+  private static Map<String, Object> oversizedHint(Map<String, Object> result) {
+    Map<String, Object> hint = new LinkedHashMap<>();
+    putIfPresent(hint, "fqn", result.get("fqn"));
+    putIfPresent(hint, "status", result.get("status"));
+    putIfPresent(hint, "summary", result.get("summary"));
+    hint.put("truncated", Boolean.TRUE);
+    hint.put(
+        "message",
+        "Root cause analysis result exceeds the size budget. Reduce upstreamDepth/downstreamDepth, "
+            + "or leave includeColumnLineage off, to get a smaller response.");
+    return hint;
   }
 
   private Map<String, Object> addTestCaseResultForTestSuite(Map<String, Object> node) {
@@ -212,6 +390,25 @@ public class RootCauseAnalysisTool implements McpTool {
     return testCaseResult;
   }
 
+  private static int clampDepth(int depth) {
+    return Math.min(Math.max(depth, 1), MAX_DEPTH);
+  }
+
+  private static Set<?> asSet(Object value) {
+    return value instanceof Set<?> set ? set : Collections.emptySet();
+  }
+
+  @SuppressWarnings("unchecked")
+  private static Map<String, Object> castMap(Object value) {
+    return (Map<String, Object>) value;
+  }
+
+  private static void putIfPresent(Map<String, Object> map, String key, Object value) {
+    if (value != null) {
+      map.put(key, value);
+    }
+  }
+
   private static int parseIntParam(Object value, int defaultValue) {
     if (value == null) {
       return defaultValue;
@@ -233,11 +430,11 @@ public class RootCauseAnalysisTool implements McpTool {
     if (value == null) {
       return defaultValue;
     }
-    if (value instanceof Boolean b) {
-      return b;
+    if (value instanceof Boolean bool) {
+      return bool;
     }
-    if (value instanceof String s) {
-      return "true".equalsIgnoreCase(s);
+    if (value instanceof String string) {
+      return "true".equalsIgnoreCase(string);
     }
     return defaultValue;
   }

--- a/openmetadata-mcp/src/main/java/org/openmetadata/mcp/tools/RootCauseAnalysisTool.java
+++ b/openmetadata-mcp/src/main/java/org/openmetadata/mcp/tools/RootCauseAnalysisTool.java
@@ -68,15 +68,17 @@ public class RootCauseAnalysisTool implements McpTool {
         new OperationContext(entityType, MetadataOperation.VIEW_BASIC),
         new ResourceContext<>(entityType));
 
+    RcaRequest request =
+        new RcaRequest(
+            fqn.trim(),
+            entityType,
+            upstreamDepth,
+            downstreamDepth,
+            queryFilter,
+            includeDeleted,
+            includeColumns);
     try {
-      return analyze(
-          fqn.trim(),
-          entityType,
-          upstreamDepth,
-          downstreamDepth,
-          queryFilter,
-          includeDeleted,
-          includeColumns);
+      return analyze(request);
     } catch (IOException e) {
       LOG.error("IOException during root cause analysis for entity: {}", fqn, e);
       throw new RuntimeException("Failed to perform root cause analysis: " + e.getMessage(), e);
@@ -87,25 +89,31 @@ public class RootCauseAnalysisTool implements McpTool {
     }
   }
 
-  private Map<String, Object> analyze(
+  /** Bundles the parsed and validated tool arguments for a single root cause analysis run. */
+  private record RcaRequest(
       String fqn,
       String entityType,
       int upstreamDepth,
       int downstreamDepth,
       String queryFilter,
       boolean includeDeleted,
-      boolean includeColumns)
-      throws IOException {
+      boolean includeColumns) {}
+
+  private Map<String, Object> analyze(RcaRequest request) throws IOException {
     Map<String, Object> result = new HashMap<>();
-    result.put("fqn", fqn);
-    result.put("upstreamDepth", upstreamDepth);
-    result.put("downstreamDepth", downstreamDepth);
+    result.put("fqn", request.fqn());
+    result.put("upstreamDepth", request.upstreamDepth());
+    result.put("downstreamDepth", request.downstreamDepth());
 
     Response upstreamResponse =
         Entity.getSearchRepository()
-            .searchDataQualityLineage(fqn, upstreamDepth, queryFilter, includeDeleted);
+            .searchDataQualityLineage(
+                request.fqn(),
+                request.upstreamDepth(),
+                request.queryFilter(),
+                request.includeDeleted());
     Map<String, Object> upstreamAnalysis =
-        buildUpstreamAnalysis(upstreamResponse.getEntity(), includeColumns);
+        buildUpstreamAnalysis(upstreamResponse.getEntity(), request.includeColumns());
     result.put("upstreamAnalysis", upstreamAnalysis);
 
     int failureCount =
@@ -113,16 +121,13 @@ public class RootCauseAnalysisTool implements McpTool {
     boolean hasFailures = failureCount > 0;
     result.put(
         "downstreamAnalysis",
-        hasFailures
-            ? buildDownstreamAnalysis(
-                fqn, entityType, downstreamDepth, queryFilter, includeDeleted, includeColumns)
-            : noFailuresDownstream());
+        hasFailures ? buildDownstreamAnalysis(request) : noFailuresDownstream());
     result.put("status", hasFailures ? "failed" : "success");
     result.put(
         "summary",
         String.format(
             "Analyzed upstream causes and downstream impacts for '%s'. Found %d upstream failure(s).",
-            fqn, failureCount));
+            request.fqn(), failureCount));
     return enforceSizeBudget(result);
   }
 
@@ -147,32 +152,26 @@ public class RootCauseAnalysisTool implements McpTool {
     return upstreamAnalysis;
   }
 
-  private Map<String, Object> buildDownstreamAnalysis(
-      String fqn,
-      String entityType,
-      int downstreamDepth,
-      String queryFilter,
-      boolean includeDeleted,
-      boolean includeColumns) {
+  private Map<String, Object> buildDownstreamAnalysis(RcaRequest request) {
     Map<String, Object> downstreamAnalysis = new HashMap<>();
     downstreamAnalysis.put(
         "description", "Downstream entities that may be impacted by the identified failures");
     try {
       SearchLineageRequest downstreamRequest =
           new SearchLineageRequest()
-              .withFqn(fqn)
+              .withFqn(request.fqn())
               .withDirection(LineageDirection.DOWNSTREAM)
               .withUpstreamDepth(0)
-              .withDownstreamDepth(downstreamDepth)
-              .withQueryFilter(queryFilter)
-              .withIsConnectedVia(isConnectedVia(entityType))
-              .withIncludeDeleted(includeDeleted);
+              .withDownstreamDepth(request.downstreamDepth())
+              .withQueryFilter(request.queryFilter())
+              .withIsConnectedVia(isConnectedVia(request.entityType()))
+              .withIncludeDeleted(request.includeDeleted());
       SearchLineageResult downstreamResult =
           Entity.getSearchRepository().searchLineageWithDirection(downstreamRequest);
       addDownstreamNodes(downstreamAnalysis, downstreamResult);
-      addDownstreamEdges(downstreamAnalysis, downstreamResult, includeColumns);
+      addDownstreamEdges(downstreamAnalysis, downstreamResult, request.includeColumns());
     } catch (Exception e) {
-      LOG.warn("Failed to perform downstream impact analysis for entity: {}", fqn, e);
+      LOG.warn("Failed to perform downstream impact analysis for entity: {}", request.fqn(), e);
       downstreamAnalysis.put("error", "Failed to analyze downstream impact: " + e.getMessage());
     }
     return downstreamAnalysis;

--- a/openmetadata-mcp/src/main/java/org/openmetadata/mcp/tools/RootCauseAnalysisTool.java
+++ b/openmetadata-mcp/src/main/java/org/openmetadata/mcp/tools/RootCauseAnalysisTool.java
@@ -221,11 +221,13 @@ public class RootCauseAnalysisTool implements McpTool {
   private static Map<String, Object> slimNodeInformation(Object nodeInfo) {
     Map<String, Object> info = JsonUtils.getMap(nodeInfo);
     Map<String, Object> slim = new LinkedHashMap<>();
-    Object entity = info.get("entity");
-    if (entity instanceof Map) {
-      slim.put("entity", slimNodeEntity(castMap(entity)));
+    if (info != null) {
+      Object entity = info.get("entity");
+      if (entity instanceof Map) {
+        slim.put("entity", slimNodeEntity(castMap(entity)));
+      }
+      putIfPresent(slim, "nodeDepth", info.get("nodeDepth"));
     }
-    putIfPresent(slim, "nodeDepth", info.get("nodeDepth"));
     return slim;
   }
 
@@ -267,16 +269,21 @@ public class RootCauseAnalysisTool implements McpTool {
   @VisibleForTesting
   static Map<String, Object> slimEdge(Map<String, Object> edge, boolean includeColumns) {
     Map<String, Object> slim = new LinkedHashMap<>();
-    putIfPresent(slim, "fromEntity", slimRef(edge.get("fromEntity")));
-    putIfPresent(slim, "toEntity", slimRef(edge.get("toEntity")));
-    slim.put("relationshipType", relationshipType(edge.get("pipeline")));
-    putIfPresent(slim, "source", edge.get("source"));
-    putIfPresent(slim, "assetEdges", edge.get("assetEdges"));
-    putIfPresent(slim, "tempLineageTables", edge.get("tempLineageTables"));
-    applyDescription(slim, edge.get("description"));
-    applySqlQuery(slim, edge.get("sqlQuery"));
-    if (includeColumns) {
-      putIfPresent(slim, "columns", edge.get("columns"));
+    if (edge != null) {
+      putIfPresent(slim, "fromEntity", slimRef(edge.get("fromEntity")));
+      putIfPresent(slim, "toEntity", slimRef(edge.get("toEntity")));
+      slim.put("relationshipType", relationshipType(edge.get("pipeline")));
+      putIfPresent(slim, "source", edge.get("source"));
+      putIfPresent(slim, "assetEdges", edge.get("assetEdges"));
+      putIfPresent(slim, "tempLineageTables", edge.get("tempLineageTables"));
+      applyDescription(slim, edge.get("description"));
+      applySqlQuery(slim, edge.get("sqlQuery"));
+      // For deduplicated SQL the backend empties sqlQuery and stores a pointer into the parent
+      // doc's lineageSqlQueries map; carry the pointer so shared SQL isn't silently lost.
+      putIfPresent(slim, "sqlQueryKey", edge.get("sqlQueryKey"));
+      if (includeColumns) {
+        putIfPresent(slim, "columns", edge.get("columns"));
+      }
     }
     return slim;
   }
@@ -344,6 +351,8 @@ public class RootCauseAnalysisTool implements McpTool {
   private static Map<String, Object> oversizedHint(Map<String, Object> result) {
     Map<String, Object> hint = new LinkedHashMap<>();
     putIfPresent(hint, "fqn", result.get("fqn"));
+    putIfPresent(hint, "upstreamDepth", result.get("upstreamDepth"));
+    putIfPresent(hint, "downstreamDepth", result.get("downstreamDepth"));
     putIfPresent(hint, "status", result.get("status"));
     putIfPresent(hint, "summary", result.get("summary"));
     hint.put("truncated", Boolean.TRUE);

--- a/openmetadata-mcp/src/main/java/org/openmetadata/mcp/tools/SearchMetadataTool.java
+++ b/openmetadata-mcp/src/main/java/org/openmetadata/mcp/tools/SearchMetadataTool.java
@@ -87,7 +87,13 @@ public class SearchMetadataTool implements McpTool {
           "columnNamesFuzzy",
           "descriptionStatus",
           "domains",
-          "embeddings");
+          "embeddings",
+          "embedding",
+          "textToEmbed",
+          "textToLLMContext",
+          "fingerprint",
+          "chunkCount",
+          "chunkIndex");
 
   @Override
   public Map<String, Object> execute(

--- a/openmetadata-mcp/src/main/resources/json/data/mcp/tools.json
+++ b/openmetadata-mcp/src/main/resources/json/data/mcp/tools.json
@@ -758,7 +758,7 @@
     },
     {
       "name": "root_cause_analysis",
-      "description": "Performs comprehensive root cause analysis via data quality lineage. First identifies upstream failures that may be causing issues for the specified asset. If failures are found, automatically analyzes downstream impact to show which assets may be affected. Returns both upstream root causes and downstream impact analysis. In the response 'status' indicates whether upstream failures were found. If 'status' is 'failed', the 'upstreamAnalysis' can be used to identify the nodes and edges leading to failures and downstreamAnalysis can tell what all nodes in downstream are impacted. If 'status' is 'success', it means no upstream failures were found, and downstream impact analysis was not performed.",
+      "description": "Performs comprehensive root cause analysis via data quality lineage. First identifies upstream failures that may be causing issues for the specified asset. If failures are found, automatically analyzes downstream impact to show which assets may be affected. Returns both upstream root causes and downstream impact analysis. In the response 'status' indicates whether upstream failures were found. If 'status' is 'failed', the 'upstreamAnalysis' can be used to identify the nodes and edges leading to failures and downstreamAnalysis can tell what all nodes in downstream are impacted. If 'status' is 'success', it means no upstream failures were found, and downstream impact analysis was not performed. Responses are compact and table-level by default: node and edge details are trimmed and SQL queries truncated to keep the payload within LLM context limits. Set 'includeColumnLineage' to true only when column-level lineage is needed.",
       "parameters": {
         "type": "object",
         "properties": {
@@ -783,6 +783,11 @@
           "includeDeleted": {
             "type": "boolean",
             "description": "Whether to include deleted entities in the analysis. Default is false.",
+            "default": false
+          },
+          "includeColumnLineage": {
+            "type": "boolean",
+            "description": "Whether to include column-level lineage on upstream/downstream edges. Default is false (table-level only) to keep the response compact. Set to true only when column-to-column lineage is required.",
             "default": false
           },
           "entityType": {

--- a/openmetadata-mcp/src/test/java/org/openmetadata/mcp/tools/RootCauseAnalysisToolTest.java
+++ b/openmetadata-mcp/src/test/java/org/openmetadata/mcp/tools/RootCauseAnalysisToolTest.java
@@ -1,0 +1,214 @@
+/*
+ *  Copyright 2025 Collate
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.openmetadata.mcp.tools;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.openmetadata.schema.api.lineage.EsLineageData;
+import org.openmetadata.schema.utils.JsonUtils;
+
+/**
+ * Pins the in-memory slimming that {@link RootCauseAnalysisTool} applies to the raw {@code
+ * EsLineageData} edges and full ES node documents returned by the data-quality lineage search. The
+ * integration test {@code McpToolsValidationIT#testRootCauseAnalysis} only exercises the
+ * no-failure ({@code status:"success"}) path, so the downstream node/edge slim and the size budget
+ * are covered here against hand-built fixtures.
+ */
+class RootCauseAnalysisToolTest {
+
+  private static Map<String, Object> edgeWithSql(String sql) {
+    Map<String, Object> edge = new HashMap<>();
+    edge.put("fromEntity", refMap("up-id", "svc.db.raw", "table", "raw-hash"));
+    edge.put("toEntity", refMap("down-id", "svc.db.orders", "table", "orders-hash"));
+    edge.put("sqlQuery", sql);
+    edge.put("source", "QueryLineage");
+    edge.put("docId", "doc-1");
+    edge.put("docUniqueId", "doc-unique-1");
+    edge.put("createdBy", "ingestion-bot");
+    edge.put("updatedAt", 1700000000000L);
+    return edge;
+  }
+
+  private static Map<String, Object> refMap(String id, String fqn, String type, String fqnHash) {
+    Map<String, Object> ref = new LinkedHashMap<>();
+    ref.put("id", id);
+    ref.put("fullyQualifiedName", fqn);
+    ref.put("type", type);
+    ref.put("fqnHash", fqnHash);
+    return ref;
+  }
+
+  @Test
+  void slimEdgeTruncatesLongSqlAndFlagsIt() {
+    String longSql = "SELECT * FROM orders WHERE ".repeat(80);
+
+    Map<String, Object> slim = RootCauseAnalysisTool.slimEdge(edgeWithSql(longSql), false);
+
+    String sql = (String) slim.get("sqlQuery");
+    assertThat(sql).hasSize(503).endsWith("...");
+    assertThat(slim.get("sqlTruncated")).isEqualTo(Boolean.TRUE);
+  }
+
+  @Test
+  void slimEdgeKeepsShortSqlWithoutTruncationFlag() {
+    Map<String, Object> slim = RootCauseAnalysisTool.slimEdge(edgeWithSql("SELECT 1"), false);
+
+    assertThat(slim.get("sqlQuery")).isEqualTo("SELECT 1");
+    assertThat(slim).doesNotContainKey("sqlTruncated");
+  }
+
+  @Test
+  void slimEdgeDropsNoiseAndSlimsEndpoints() {
+    Map<String, Object> slim = RootCauseAnalysisTool.slimEdge(edgeWithSql("SELECT 1"), false);
+
+    assertThat(slim)
+        .doesNotContainKeys("docId", "docUniqueId", "createdBy", "updatedAt", "pipeline");
+
+    Map<String, Object> from = asMap(slim.get("fromEntity"));
+    assertThat(from).containsKeys("id", "fullyQualifiedName", "type").doesNotContainKey("fqnHash");
+  }
+
+  @Test
+  void slimEdgeDefaultsRelationshipToSqlAndBuildsFromPipeline() {
+    Map<String, Object> sqlEdge = RootCauseAnalysisTool.slimEdge(edgeWithSql("SELECT 1"), false);
+    assertThat(sqlEdge.get("relationshipType")).isEqualTo("sql");
+
+    Map<String, Object> pipelined = edgeWithSql("SELECT 1");
+    pipelined.put("pipeline", Map.of("type", "pipeline", "name", "daily_etl"));
+    Map<String, Object> slim = RootCauseAnalysisTool.slimEdge(pipelined, false);
+    assertThat(slim.get("relationshipType")).isEqualTo("pipeline:daily_etl");
+  }
+
+  @Test
+  void slimEdgeOmitsColumnsByDefaultAndIncludesWhenRequested() {
+    Map<String, Object> edge = edgeWithSql("SELECT 1");
+    edge.put("columns", List.of(Map.of("fromColumns", List.of("a"), "toColumn", "b")));
+
+    assertThat(RootCauseAnalysisTool.slimEdge(edge, false)).doesNotContainKey("columns");
+    assertThat(RootCauseAnalysisTool.slimEdge(edge, true)).containsKey("columns");
+  }
+
+  @Test
+  void slimNodeEntityRemovesColumnsAndTruncatesDescription() {
+    Map<String, Object> node = new HashMap<>();
+    node.put("name", "orders");
+    node.put("fullyQualifiedName", "svc.db.orders");
+    node.put("entityType", "table");
+    node.put("columns", List.of(Map.of("name", "id"), Map.of("name", "amount")));
+    node.put("schemaDefinition", "CREATE TABLE orders ...");
+    node.put("embedding", List.of(0.1, 0.2, 0.3));
+    node.put("textToEmbed", "concatenated text used to build the vector ...");
+    node.put("textToLLMContext", "rag context blob ...");
+    node.put("fingerprint", "abc123");
+    node.put("chunkCount", 4);
+    node.put("chunkIndex", 0);
+    node.put("description", "x".repeat(900));
+
+    Map<String, Object> slim = RootCauseAnalysisTool.slimNodeEntity(node);
+
+    assertThat(slim)
+        .doesNotContainKeys(
+            "columns",
+            "schemaDefinition",
+            "embedding",
+            "textToEmbed",
+            "textToLLMContext",
+            "fingerprint",
+            "chunkCount",
+            "chunkIndex");
+    assertThat(slim).containsKeys("name", "fullyQualifiedName", "entityType");
+    assertThat((String) slim.get("description")).hasSize(503).endsWith("...");
+  }
+
+  @Test
+  void slimDownstreamNodesPreservesIdKeysAndSlimsEntity() {
+    Map<String, Object> entity = new HashMap<>();
+    entity.put("name", "orders");
+    entity.put("columns", List.of(Map.of("name", "id")));
+    Map<String, Object> nodeInfo = new HashMap<>();
+    nodeInfo.put("entity", entity);
+    nodeInfo.put("nodeDepth", 2);
+
+    Map<String, Object> slim =
+        RootCauseAnalysisTool.slimDownstreamNodes(Map.of("node-id", nodeInfo));
+
+    assertThat(slim).containsOnlyKeys("node-id");
+    Map<String, Object> slimNode = asMap(slim.get("node-id"));
+    assertThat(slimNode.get("nodeDepth")).isEqualTo(2);
+    assertThat(asMap(slimNode.get("entity"))).doesNotContainKey("columns");
+  }
+
+  @Test
+  void slimEdgeMatchesRealEsLineageDataKeysAfterRoundTrip() {
+    Map<String, Object> raw = new HashMap<>();
+    raw.put(
+        "fromEntity",
+        refMap("11111111-1111-1111-1111-111111111111", "svc.db.raw", "table", "raw-hash"));
+    raw.put(
+        "toEntity",
+        refMap("22222222-2222-2222-2222-222222222222", "svc.db.orders", "table", "orders-hash"));
+    raw.put("pipeline", Map.of("type", "pipeline", "name", "daily_etl"));
+    raw.put("sqlQuery", "SELECT * FROM raw ".repeat(60));
+    raw.put("source", "QueryLineage");
+    raw.put("docId", "doc-1");
+    raw.put(
+        "columns", List.of(Map.of("toColumn", "svc.db.orders.id", "fromColumns", List.of("a"))));
+
+    EsLineageData typed = JsonUtils.convertValue(raw, EsLineageData.class);
+    Map<String, Object> edgeMap = JsonUtils.getMap(typed);
+
+    Map<String, Object> slim = RootCauseAnalysisTool.slimEdge(edgeMap, false);
+    assertThat(slim.get("relationshipType")).isEqualTo("pipeline:daily_etl");
+    assertThat((String) slim.get("sqlQuery")).hasSize(503).endsWith("...");
+    assertThat(slim.get("sqlTruncated")).isEqualTo(Boolean.TRUE);
+    assertThat(slim.get("source")).isEqualTo("QueryLineage");
+    assertThat(asMap(slim.get("fromEntity")).get("fullyQualifiedName")).isEqualTo("svc.db.raw");
+    assertThat(slim).doesNotContainKeys("docId", "columns");
+    assertThat(RootCauseAnalysisTool.slimEdge(edgeMap, true)).containsKey("columns");
+  }
+
+  @SuppressWarnings("unchecked")
+  private static Map<String, Object> asMap(Object value) {
+    return (Map<String, Object>) value;
+  }
+
+  @Test
+  void enforceSizeBudgetPassesThroughSmallResult() {
+    Map<String, Object> result = new LinkedHashMap<>();
+    result.put("fqn", "svc.db.orders");
+    result.put("status", "success");
+
+    assertThat(RootCauseAnalysisTool.enforceSizeBudget(result)).isSameAs(result);
+  }
+
+  @Test
+  void enforceSizeBudgetReturnsHintWhenOversized() {
+    Map<String, Object> result = new LinkedHashMap<>();
+    result.put("fqn", "svc.db.orders");
+    result.put("status", "failed");
+    result.put("summary", "Found 1 upstream failure(s).");
+    result.put("downstreamAnalysis", Map.of("blob", "z".repeat(200_000)));
+
+    Map<String, Object> output = RootCauseAnalysisTool.enforceSizeBudget(result);
+
+    assertThat(output.get("truncated")).isEqualTo(Boolean.TRUE);
+    assertThat(output).containsKeys("fqn", "status", "summary", "message");
+    assertThat(output).doesNotContainKey("downstreamAnalysis");
+  }
+}

--- a/openmetadata-mcp/src/test/java/org/openmetadata/mcp/tools/RootCauseAnalysisToolTest.java
+++ b/openmetadata-mcp/src/test/java/org/openmetadata/mcp/tools/RootCauseAnalysisToolTest.java
@@ -183,6 +183,33 @@ class RootCauseAnalysisToolTest {
     assertThat(RootCauseAnalysisTool.slimEdge(edgeMap, true)).containsKey("columns");
   }
 
+  @Test
+  void slimEdgeCarriesSqlQueryKeyForDeduplicatedSql() {
+    Map<String, Object> edge = edgeWithSql("");
+    edge.put("sqlQueryKey", "3");
+
+    Map<String, Object> slim = RootCauseAnalysisTool.slimEdge(edge, false);
+
+    assertThat(slim.get("sqlQueryKey")).isEqualTo("3");
+    assertThat(slim).doesNotContainKey("sqlQuery");
+  }
+
+  @Test
+  void slimEdgeHandlesNullEdgeWithoutThrowing() {
+    assertThat(RootCauseAnalysisTool.slimEdge(null, false)).isEmpty();
+  }
+
+  @Test
+  void slimDownstreamNodesHandlesNullNodeInfoWithoutThrowing() {
+    Map<String, Object> withNull = new LinkedHashMap<>();
+    withNull.put("node-id", null);
+
+    Map<String, Object> slim = RootCauseAnalysisTool.slimDownstreamNodes(withNull);
+
+    assertThat(slim).containsOnlyKeys("node-id");
+    assertThat(asMap(slim.get("node-id"))).isEmpty();
+  }
+
   @SuppressWarnings("unchecked")
   private static Map<String, Object> asMap(Object value) {
     return (Map<String, Object>) value;
@@ -205,10 +232,13 @@ class RootCauseAnalysisToolTest {
     result.put("summary", "Found 1 upstream failure(s).");
     result.put("downstreamAnalysis", Map.of("blob", "z".repeat(200_000)));
 
+    result.put("upstreamDepth", 3);
+    result.put("downstreamDepth", 3);
     Map<String, Object> output = RootCauseAnalysisTool.enforceSizeBudget(result);
 
     assertThat(output.get("truncated")).isEqualTo(Boolean.TRUE);
-    assertThat(output).containsKeys("fqn", "status", "summary", "message");
+    assertThat(output)
+        .containsKeys("fqn", "upstreamDepth", "downstreamDepth", "status", "summary", "message");
     assertThat(output).doesNotContainKey("downstreamAnalysis");
   }
 }


### PR DESCRIPTION
`root_cause_analysis` returned raw Elasticsearch docs and full lineage edges — large enough to exceed MCP/LLM context limits. This slims the response in-memory; the lineage/search backend (shared with the UI) is untouched.

- Downstream nodes cleaned like upstream already were — drops `columns`, `schemaDefinition`, and vector/search internals (`embedding`, `textToEmbed`, `textToLLMContext`, `fingerprint`, `chunkCount`, `chunkIndex`)
- Edges trimmed to `fromEntity`/`toEntity`/`relationshipType`/`source`/`sqlQuery`; SQL truncated to 500 chars
- Column-level lineage is now opt-in via a new `includeColumnLineage` param (default false)
- A 100k-char budget returns a compact hint instead of an oversized payload

Tested via `RootCauseAnalysisToolTest` (10 tests, incl. a real `EsLineageData` Jackson round-trip) and live against a table with failing tests: **41k → 12.6k chars**, all paths intact.

Related to https://github.com/open-metadata/OpenMetadata/issues/28629
