### PR TITLE
fix(mcp): return compact entity from create metric/test-case/glossary tools

### DIFF
--- a/openmetadata-mcp/src/main/java/org/openmetadata/mcp/tools/CreateMetricTool.java
+++ b/openmetadata-mcp/src/main/java/org/openmetadata/mcp/tools/CreateMetricTool.java
@@ -187,6 +187,6 @@ public class CreateMetricTool implements McpTool {
     RestUtil.PutResponse<Metric> response =
         repo.createOrUpdate(null, metric, userName, impersonatedBy);
     McpChangeEventUtil.publishChangeEvent(response.getEntity(), response.getChangeType(), userName);
-    return JsonUtils.getMap(response.getEntity());
+    return McpResponseUtils.compact(response.getEntity(), response.getChangeType());
   }
 }

--- a/openmetadata-mcp/src/main/java/org/openmetadata/mcp/tools/CreateTestCaseTool.java
+++ b/openmetadata-mcp/src/main/java/org/openmetadata/mcp/tools/CreateTestCaseTool.java
@@ -120,6 +120,6 @@ public class CreateTestCaseTool implements McpTool {
         repository.createOrUpdate(null, testCase, updatedBy, impersonatedBy);
     McpChangeEventUtil.publishChangeEvent(
         response.getEntity(), response.getChangeType(), updatedBy);
-    return JsonUtils.getMap(response.getEntity());
+    return McpResponseUtils.compact(response.getEntity(), response.getChangeType());
   }
 }

--- a/openmetadata-mcp/src/main/java/org/openmetadata/mcp/tools/GlossaryTermTool.java
+++ b/openmetadata-mcp/src/main/java/org/openmetadata/mcp/tools/GlossaryTermTool.java
@@ -4,7 +4,6 @@ import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
 import org.openmetadata.schema.entity.data.GlossaryTerm;
 import org.openmetadata.schema.type.MetadataOperation;
-import org.openmetadata.schema.utils.JsonUtils;
 import org.openmetadata.service.Entity;
 import org.openmetadata.service.jdbi3.GlossaryTermRepository;
 import org.openmetadata.service.limits.Limits;
@@ -67,6 +66,6 @@ public class GlossaryTermTool implements McpTool {
     RestUtil.PutResponse<GlossaryTerm> response =
         glossaryTermRepository.createOrUpdate(null, glossaryTerm, userName, impersonatedBy);
     McpChangeEventUtil.publishChangeEvent(response.getEntity(), response.getChangeType(), userName);
-    return JsonUtils.getMap(response.getEntity());
+    return McpResponseUtils.compact(response.getEntity(), response.getChangeType());
   }
 }

--- a/openmetadata-mcp/src/main/java/org/openmetadata/mcp/tools/GlossaryTool.java
+++ b/openmetadata-mcp/src/main/java/org/openmetadata/mcp/tools/GlossaryTool.java
@@ -7,7 +7,6 @@ import org.openmetadata.schema.api.data.CreateGlossary;
 import org.openmetadata.schema.entity.data.Glossary;
 import org.openmetadata.schema.type.EntityReference;
 import org.openmetadata.schema.type.MetadataOperation;
-import org.openmetadata.schema.utils.JsonUtils;
 import org.openmetadata.service.Entity;
 import org.openmetadata.service.jdbi3.GlossaryRepository;
 import org.openmetadata.service.limits.Limits;
@@ -75,7 +74,7 @@ public class GlossaryTool implements McpTool {
     RestUtil.PutResponse<Glossary> response =
         glossaryRepository.createOrUpdate(null, glossary, userName, impersonatedBy);
     McpChangeEventUtil.publishChangeEvent(response.getEntity(), response.getChangeType(), userName);
-    return JsonUtils.convertValue(response.getEntity(), Map.class);
+    return McpResponseUtils.compact(response.getEntity(), response.getChangeType());
   }
 
   public static void setReviewers(CreateGlossary entity, Map<String, Object> params) {


### PR DESCRIPTION
The governance create tools (classification/tag/domain/data-product) already return `McpResponseUtils.compact(...)`, but `create_metric`, `create_test_case`, `create_glossary`, and `create_glossary_term` still returned the full raw entity. This makes them consistent — `compact` strips noise fields (`version`, `updatedAt`, `changeDescription`, `followers`, `votes`, `sourceHash`) and tags the operation, keeping responses small for MCP clients.
