### PR TITLE
fix(mcp): remove temp-table lineage refs on 1.12.10 (schema not backported)

### DIFF
--- a/openmetadata-mcp/src/main/java/org/openmetadata/mcp/tools/GetLineageTool.java
+++ b/openmetadata-mcp/src/main/java/org/openmetadata/mcp/tools/GetLineageTool.java
@@ -19,7 +19,6 @@ import org.openmetadata.schema.type.EntityLineage;
 import org.openmetadata.schema.type.EntityReference;
 import org.openmetadata.schema.type.LineageDetails;
 import org.openmetadata.schema.type.MetadataOperation;
-import org.openmetadata.schema.type.TempLineageTable;
 import org.openmetadata.schema.utils.JsonUtils;
 import org.openmetadata.service.Entity;
 import org.openmetadata.service.limits.Limits;
@@ -68,7 +67,6 @@ public class GetLineageTool implements McpTool {
       Integer assetEdges,
       String sqlQuery,
       Boolean sqlTruncated,
-      List<TempLineageTable> tempLineageTables,
       Long updatedAt,
       String updatedBy,
       List<ColumnLineage> columnsLineage) {}
@@ -192,7 +190,6 @@ public class GetLineageTool implements McpTool {
         details != null ? details.getAssetEdges() : null,
         sql.value(),
         sql.truncated(),
-        details != null ? details.getTempLineageTables() : null,
         details != null ? details.getUpdatedAt() : null,
         details != null ? details.getUpdatedBy() : null,
         columnsLineageOf(details, includeColumns));

--- a/openmetadata-mcp/src/test/java/org/openmetadata/mcp/tools/GetLineageToolTest.java
+++ b/openmetadata-mcp/src/test/java/org/openmetadata/mcp/tools/GetLineageToolTest.java
@@ -14,7 +14,6 @@ import org.openmetadata.schema.type.Edge;
 import org.openmetadata.schema.type.EntityLineage;
 import org.openmetadata.schema.type.EntityReference;
 import org.openmetadata.schema.type.LineageDetails;
-import org.openmetadata.schema.type.TempLineageTable;
 
 /**
  * Unit tests for {@link GetLineageTool} slimming. These exercise the pure transform against
@@ -38,8 +37,6 @@ class GetLineageToolTest {
         .withSqlQuery(sql)
         .withColumnsLineage(columns)
         .withSource(LineageDetails.Source.QUERY_LINEAGE)
-        .withTempLineageTables(
-            List.of(new TempLineageTable().withFromEntity("src").withToEntity("staging")))
         .withUpdatedAt(123L)
         .withUpdatedBy("bob")
         .withAssetEdges(2);
@@ -81,7 +78,6 @@ class GetLineageToolTest {
     assertEquals("raw_orders Display", edge.get("fromName"));
     assertEquals("sql", edge.get("relationshipType"));
     assertEquals("QueryLineage", edge.get("source"));
-    assertTrue(edge.containsKey("tempLineageTables"), "temp-table path must be preserved");
     assertFalse(edge.containsKey("columnsLineage"), "column lineage must be off by default");
   }
 


### PR DESCRIPTION
## Problem
OM `1.12.10` doesn't compile. `GetLineageTool` references `TempLineageTable`, but the schema that generates it (#26487) was never backported to 1.12.10 (intentional — no 1.13 UI, per @ulixius9).

```
GetLineageTool.java:[22,36] cannot find symbol: class TempLineageTable
```

Breaks every build on `1.12.10` (OM #28636) and Collate builds pulling the OM submodule (#4380).

## Fix
Remove the temp-table-lineage refs from `GetLineageTool` and its test. No schema changed → no codegen needed.

## Verification
- `mvn clean install -DskipTests -pl '!openmetadata-ui'` → BUILD SUCCESS
- `GetLineageToolTest`: 8/8 pass

`main` is unaffected.