### PR TITLE
fix(mcp): align McpToolsValidationIT with slim get_entity_lineage shape

### DIFF
--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/mcp/McpToolsValidationIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/mcp/McpToolsValidationIT.java
@@ -577,15 +577,11 @@ public class McpToolsValidationIT extends McpTestBase {
     String responseText = firstResult.get("text").asText();
 
     JsonNode lineageData = OBJECT_MAPPER.readTree(responseText);
-    assertThat(lineageData.has("entity")).isTrue();
+    assertThat(lineageData.has("root")).isTrue();
+    assertThat(lineageData.get("root").asText()).isEqualTo(expectedEntityFqn);
 
-    JsonNode entity = lineageData.get("entity");
-    assertThat(entity.has("fullyQualifiedName")).isTrue();
-    assertThat(entity.get("fullyQualifiedName").asText()).isEqualTo(expectedEntityFqn);
-
-    assertThat(lineageData.has("nodes")).isTrue();
-    assertThat(lineageData.has("upstreamEdges")).isTrue();
-    assertThat(lineageData.has("downstreamEdges")).isTrue();
+    assertThat(lineageData.has("upstream")).isTrue();
+    assertThat(lineageData.has("downstream")).isTrue();
   }
 
   private void validateDeletedFieldPresence(JsonNode result, boolean expectedDeleted)


### PR DESCRIPTION
## Problem
`McpToolsValidationIT` fails on main (2 tests):
```
McpToolsValidationIT.java:181  Expecting value to be true but was false
McpToolsValidationIT.java:228  Expecting value to be true but was false
```
`validateLineageResponse` asserts the old `get_entity_lineage` shape (`entity`, `nodes`, `upstreamEdges`, `downstreamEdges`), but the slim transform (#28618) changed the tool output to `root`/`rootId`/`rootType`/`upstream`/`downstream`. The IT was never updated.

## Fix
Update `validateLineageResponse` to assert the slim shape (`root` == expected FQN, `upstream`, `downstream`).
