### PR TITLE
fix(dq): preserve edition-specific fields when editing a test case

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/AddDataQualityTest/EditTestCaseModal.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/AddDataQualityTest/EditTestCaseModal.tsx
@@ -147,7 +147,10 @@ const EditTestCaseModal: React.FC<EditTestCaseModalProps> = ({
     const jsonPatch = createUpdatedTestCasePatch({
       testCase,
       value,
-      selectedDefinition,
+      createTestCaseObject: testCaseClassBase.getCreateTestCaseObject(
+        value,
+        selectedDefinition
+      ),
       showOnlyParameter,
       isComputeRowCountFieldVisible,
     });

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/AddDataQualityTest/components/EditTestCaseModalV1.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/AddDataQualityTest/components/EditTestCaseModalV1.tsx
@@ -288,7 +288,10 @@ const EditTestCaseModalV1: FC<EditTestCaseModalProps> = ({
     const jsonPatch = createUpdatedTestCasePatch({
       testCase,
       value,
-      selectedDefinition,
+      createTestCaseObject: testCaseClassBase.getCreateTestCaseObject(
+        value,
+        selectedDefinition
+      ),
       showOnlyParameter,
       isComputeRowCountFieldVisible,
     });

--- a/openmetadata-ui/src/main/resources/ui/src/utils/DataQuality/DataQualityUtils.test.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/DataQuality/DataQualityUtils.test.ts
@@ -1117,6 +1117,7 @@ describe('DataQualityUtils', () => {
       const patch = createUpdatedTestCasePatch({
         testCase: baseTestCase,
         value: { ...baseValue, displayName: 'New name' },
+        createTestCaseObject: {},
         isComputeRowCountFieldVisible: false,
       });
 
@@ -1136,6 +1137,7 @@ describe('DataQualityUtils', () => {
           displayName: 'New name',
           tags: [classificationTag],
         },
+        createTestCaseObject: {},
         isComputeRowCountFieldVisible: false,
       });
 
@@ -1151,6 +1153,7 @@ describe('DataQualityUtils', () => {
       const patch = createUpdatedTestCasePatch({
         testCase: { ...baseTestCase, tags: [classificationTag] },
         value: { ...baseValue, tags: [], glossaryTerms: [] },
+        createTestCaseObject: {},
         isComputeRowCountFieldVisible: false,
       });
 
@@ -1161,11 +1164,53 @@ describe('DataQualityUtils', () => {
       const patch = createUpdatedTestCasePatch({
         testCase: { ...baseTestCase, tags: [classificationTag] },
         value: baseValue,
+        createTestCaseObject: {},
         showOnlyParameter: true,
         isComputeRowCountFieldVisible: false,
       });
 
       expect(hasTagsOp(patch)).toBe(false);
+    });
+
+    it('should include fields returned by createTestCaseObject (e.g. Collate useDynamicAssertion)', () => {
+      const patch = createUpdatedTestCasePatch({
+        testCase: baseTestCase,
+        value: baseValue,
+        createTestCaseObject: {
+          parameterValues: [],
+          useDynamicAssertion: true,
+        },
+        isComputeRowCountFieldVisible: false,
+      });
+
+      expect(patch).toContainEqual({
+        op: 'add',
+        path: '/useDynamicAssertion',
+        value: true,
+      });
+    });
+
+    it('should preserve existing dimension fields when only parameters are edited', () => {
+      const patch = createUpdatedTestCasePatch({
+        testCase: {
+          ...baseTestCase,
+          dimensionColumns: ['col_a'],
+          topDimensions: 5,
+        } as TestCase,
+        value: baseValue,
+        createTestCaseObject: {},
+        showOnlyParameter: true,
+        isComputeRowCountFieldVisible: false,
+      });
+
+      expect(
+        patch.some(
+          (op) =>
+            op.path === '/dimensionColumns' ||
+            op.path.startsWith('/dimensionColumns/')
+        )
+      ).toBe(false);
+      expect(patch.some((op) => op.path === '/topDimensions')).toBe(false);
     });
   });
 });

--- a/openmetadata-ui/src/main/resources/ui/src/utils/DataQuality/DataQualityUtils.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/DataQuality/DataQualityUtils.tsx
@@ -43,6 +43,7 @@ import { TEXT_GREY_MUTED } from '../../constants/constants';
 import { DEFAULT_DIMENSIONS_DATA } from '../../constants/DataQuality.constants';
 import { TEST_CASE_FILTERS } from '../../constants/profiler.constant';
 import { TestCaseType } from '../../enums/TestSuite.enum';
+import { CreateTestCase } from '../../generated/api/tests/createTestCase';
 import { Table } from '../../generated/entity/data/table';
 import { TestCaseStatus } from '../../generated/entity/feed/testCaseResult';
 import { DataQualityReport } from '../../generated/tests/dataQualityReport';
@@ -127,7 +128,7 @@ export const createTestCaseParameters = (
 export interface CreateUpdatedTestCasePatchArgs {
   testCase: TestCase;
   value: TestCaseFormType;
-  selectedDefinition?: TestDefinition;
+  createTestCaseObject: Partial<CreateTestCase>;
   showOnlyParameter?: boolean;
   isComputeRowCountFieldVisible: boolean;
 }
@@ -135,7 +136,7 @@ export interface CreateUpdatedTestCasePatchArgs {
 export const createUpdatedTestCasePatch = ({
   testCase,
   value,
-  selectedDefinition,
+  createTestCaseObject,
   showOnlyParameter,
   isComputeRowCountFieldVisible,
 }: CreateUpdatedTestCasePatchArgs): Operation[] => {
@@ -147,7 +148,7 @@ export const createUpdatedTestCasePatch = ({
   ];
   const updatedTestCase = {
     ...testCase,
-    parameterValues: createTestCaseParameters(value.params, selectedDefinition),
+    ...createTestCaseObject,
     description: showOnlyParameter
       ? testCase.description
       : isEmpty(value.description)
@@ -163,8 +164,12 @@ export const createUpdatedTestCasePatch = ({
       showOnlyParameter || (isEmpty(rebuiltTags) && isEmpty(testCase.tags))
         ? testCase.tags
         : rebuiltTags,
-    dimensionColumns: value.dimensionColumns || undefined,
-    topDimensions: value.topDimensions ?? undefined,
+    dimensionColumns: isUndefined(value.dimensionColumns)
+      ? testCase.dimensionColumns
+      : value.dimensionColumns || undefined,
+    topDimensions: isUndefined(value.topDimensions)
+      ? testCase.topDimensions
+      : value.topDimensions ?? undefined,
   };
 
   return compare(testCase, updatedTestCase);


### PR DESCRIPTION
## Problem

Follow-up to #28577. That PR moved the test-case edit patch-builder into `createUpdatedTestCasePatch` but **inlined `createTestCaseParameters`**, bypassing `testCaseClassBase.getCreateTestCaseObject`.

Editions can override `getCreateTestCaseObject` to add fields to the update payload — Collate's `TestCaseClassCollate` adds `useDynamicAssertion`. With the inlined version, editing a test case **dropped that field from the PATCH**, so toggling "Use Dynamic Assertion" during edit was silently not persisted.

## Fix

`createUpdatedTestCasePatch` now takes `createTestCaseObject` from the caller. Both edit modals pass `testCaseClassBase.getCreateTestCaseObject(value, selectedDefinition)`, so any edition override is honored in the generated patch. No circular import (the util stays in `DataQualityUtils`, the modals already hold `testCaseClassBase`).

## Tests

- `DataQualityUtils.test.ts`: new case asserting fields returned by `createTestCaseObject` (e.g. `useDynamicAssertion`) are included in the patch; existing tag cases (tagless / unchanged / cleared / param-only) retained.
- Verified locally: affected suites green, `tsc` clean on changed files, UI checkstyle clean.

## Notes

The create flow (`TestCaseFormV1`) already spreads `getCreateTestCaseObject(...)` directly and is unaffected. Other test-case PATCH builders (incident manager, result tab) don't use this util.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

----
## Summary by Gitar

- **Bug fix:**
  - Preserved dimension settings (`dimensionColumns`, `topDimensions`) during edit to prevent accidental removal of existing values.
  - Added logic to verify if values are undefined before applying updates to avoid incorrect diff operations.

<sub>This will update automatically on new commits.</sub>