### PR TITLE
perf(activity): batch activity_stream inserts per change event

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/apps/bundles/changeEvent/feed/ActivityStreamPublisher.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/apps/bundles/changeEvent/feed/ActivityStreamPublisher.java
@@ -101,9 +101,9 @@ public class ActivityStreamPublisher implements Destination<ChangeEvent> {
         return;
       }
 
-      // Create activity events from the change event
       List<ActivityEvent> events =
           activityStreamRepository.createFieldEventsFromChangeEvent(changeEvent, entity);
+      activityStreamRepository.insertBatch(events);
 
       // Broadcast via WebSocket for real-time updates
       for (ActivityEvent event : events) {

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/ActivityStreamRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/ActivityStreamRepository.java
@@ -96,7 +96,6 @@ public class ActivityStreamRepository {
       // No field-level changes, create a single event
       ActivityEvent event = convertChangeEventToActivityEvent(changeEvent, entity);
       if (event != null) {
-        insert(event);
         events.add(event);
       }
       return events;
@@ -117,9 +116,7 @@ public class ActivityStreamRepository {
     for (FieldChange fieldChange : allChanges) {
       ActivityEventType eventType = mapFieldToEventType(fieldChange.getName());
       if (eventType != null) {
-        ActivityEvent event = buildActivityEvent(changeEvent, entity, eventType, fieldChange);
-        insert(event);
-        events.add(event);
+        events.add(buildActivityEvent(changeEvent, entity, eventType, fieldChange));
       }
     }
 
@@ -127,7 +124,6 @@ public class ActivityStreamRepository {
     if (events.isEmpty()) {
       ActivityEvent event = convertChangeEventToActivityEvent(changeEvent, entity);
       if (event != null) {
-        insert(event);
         events.add(event);
       }
     }
@@ -135,47 +131,67 @@ public class ActivityStreamRepository {
     return events;
   }
 
-  /** Insert an ActivityEvent into the database. */
+  /** Insert a single ActivityEvent into the database. */
   public void insert(ActivityEvent event) {
     if (event == null) {
       return;
     }
+    insertBatch(List.of(event));
+  }
 
-    String domainsJson = null;
-    if (event.getDomains() != null && !event.getDomains().isEmpty()) {
-      List<String> domainIds =
-          event.getDomains().stream().map(ref -> ref.getId().toString()).toList();
-      domainsJson = JsonUtils.pojoToJson(domainIds);
+  /** Batch-insert ActivityEvents in a single round-trip instead of one per row. */
+  public void insertBatch(List<ActivityEvent> events) {
+    if (nullOrEmpty(events)) {
+      return;
     }
+    List<CollectionDAO.ActivityStreamRow> rows =
+        events.stream().filter(event -> event != null).map(this::toRow).toList();
+    if (!rows.isEmpty()) {
+      activityStreamDAO.insertBatch(rows);
+    }
+  }
 
-    // about is an EntityLink, not an FQN — parse first, then hash the FQN portion.
-    String aboutFqnHash =
-        nullOrEmpty(event.getAbout())
-            ? null
-            : FullyQualifiedName.buildHash(
-                MessageParser.EntityLink.parse(event.getAbout()).getEntityFQN());
+  private CollectionDAO.ActivityStreamRow toRow(ActivityEvent event) {
+    return CollectionDAO.ActivityStreamRow.builder()
+        .id(event.getId().toString())
+        .eventType(event.getEventType().value())
+        .entityType(event.getEntity().getType())
+        .entityId(event.getEntity().getId().toString())
+        .entityFqnHash(
+            event.getEntity().getFullyQualifiedName() != null
+                ? FullyQualifiedName.buildHash(event.getEntity().getFullyQualifiedName())
+                : null)
+        .about(event.getAbout())
+        .aboutFqnHash(buildAboutFqnHash(event.getAbout()))
+        .actorId(
+            event.getActor() != null && event.getActor().getId() != null
+                ? event.getActor().getId().toString()
+                : null)
+        .actorName(event.getActor() != null ? event.getActor().getName() : null)
+        .timestamp(event.getTimestamp())
+        .summary(truncateSummaryForStorage(event.getSummary()))
+        .fieldName(event.getFieldName())
+        .oldValue(event.getOldValue())
+        .newValue(event.getNewValue())
+        .domains(buildDomainsJson(event))
+        .json(JsonUtils.pojoToJson(event))
+        .build();
+  }
 
-    activityStreamDAO.insert(
-        event.getId().toString(),
-        event.getEventType().value(),
-        event.getEntity().getType(),
-        event.getEntity().getId().toString(),
-        event.getEntity().getFullyQualifiedName() != null
-            ? FullyQualifiedName.buildHash(event.getEntity().getFullyQualifiedName())
-            : null,
-        event.getAbout(),
-        aboutFqnHash,
-        event.getActor() != null && event.getActor().getId() != null
-            ? event.getActor().getId().toString()
-            : null,
-        event.getActor() != null ? event.getActor().getName() : null,
-        event.getTimestamp(),
-        truncateSummaryForStorage(event.getSummary()),
-        event.getFieldName(),
-        event.getOldValue(),
-        event.getNewValue(),
-        domainsJson,
-        JsonUtils.pojoToJson(event));
+  private static String buildDomainsJson(ActivityEvent event) {
+    if (event.getDomains() == null || event.getDomains().isEmpty()) {
+      return null;
+    }
+    List<String> domainIds =
+        event.getDomains().stream().map(ref -> ref.getId().toString()).toList();
+    return JsonUtils.pojoToJson(domainIds);
+  }
+
+  // about is an EntityLink, not an FQN — parse first, then hash the FQN portion.
+  private static String buildAboutFqnHash(String about) {
+    return nullOrEmpty(about)
+        ? null
+        : FullyQualifiedName.buildHash(MessageParser.EntityLink.parse(about).getEntityFQN());
   }
 
   /** List recent activity events. */

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/CollectionDAO.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/CollectionDAO.java
@@ -58,6 +58,7 @@ import org.jdbi.v3.sqlobject.customizer.BindBean;
 import org.jdbi.v3.sqlobject.customizer.BindBeanList;
 import org.jdbi.v3.sqlobject.customizer.BindList;
 import org.jdbi.v3.sqlobject.customizer.BindMap;
+import org.jdbi.v3.sqlobject.customizer.BindMethods;
 import org.jdbi.v3.sqlobject.customizer.Define;
 import org.jdbi.v3.sqlobject.statement.SqlBatch;
 import org.jdbi.v3.sqlobject.statement.SqlQuery;
@@ -13333,6 +13334,25 @@ public interface CollectionDAO {
     }
   }
 
+  @Builder
+  record ActivityStreamRow(
+      String id,
+      String eventType,
+      String entityType,
+      String entityId,
+      String entityFqnHash,
+      String about,
+      String aboutFqnHash,
+      String actorId,
+      String actorName,
+      Long timestamp,
+      String summary,
+      String fieldName,
+      String oldValue,
+      String newValue,
+      String domains,
+      String json) {}
+
   interface ActivityStreamDAO {
     @ConnectionAwareSqlUpdate(
         value =
@@ -13365,6 +13385,24 @@ public interface CollectionDAO {
         @Bind("newValue") String newValue,
         @Bind("domains") String domains,
         @Bind("json") String json);
+
+    // Batch insert for activity events - one round-trip per change event instead of one per row
+    @Transaction
+    @ConnectionAwareSqlBatch(
+        value =
+            "INSERT INTO activity_stream(id, eventType, entityType, entityId, entityFqnHash, "
+                + "about, aboutFqnHash, actorId, actorName, timestamp, summary, fieldName, oldValue, newValue, domains, json) "
+                + "VALUES (:id, :eventType, :entityType, :entityId, :entityFqnHash, "
+                + ":about, :aboutFqnHash, :actorId, :actorName, :timestamp, :summary, :fieldName, :oldValue, :newValue, :domains, :json)",
+        connectionType = MYSQL)
+    @ConnectionAwareSqlBatch(
+        value =
+            "INSERT INTO activity_stream(id, eventtype, entitytype, entityid, entityfqnhash, "
+                + "about, aboutfqnhash, actorid, actorname, timestamp, summary, fieldname, oldvalue, newvalue, domains, json) "
+                + "VALUES (:id, :eventType, :entityType, :entityId, :entityFqnHash, "
+                + ":about, :aboutFqnHash, :actorId, :actorName, :timestamp, :summary, :fieldName, :oldValue, :newValue, :domains::jsonb, :json::jsonb)",
+        connectionType = POSTGRES)
+    void insertBatch(@BindMethods List<ActivityStreamRow> rows);
 
     @ConnectionAwareSqlQuery(
         value =

--- a/openmetadata-service/src/test/java/org/openmetadata/service/apps/bundles/changeEvent/feed/ActivityStreamPublisherTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/apps/bundles/changeEvent/feed/ActivityStreamPublisherTest.java
@@ -106,13 +106,14 @@ class ActivityStreamPublisherTest {
   }
 
   @Test
-  void sendMessageCreatesActivityEvents() throws EventPublisherException {
+  void sendMessageBuildsAndPersistsActivityEventsInOneBatch() throws EventPublisherException {
+    List<ActivityEvent> built = List.of(new ActivityEvent().withId(UUID.randomUUID()));
     try (MockedConstruction<ActivityStreamRepository> repositoryConstruction =
         mockConstruction(
             ActivityStreamRepository.class,
             (repository, context) ->
                 when(repository.createFieldEventsFromChangeEvent(any(), any()))
-                    .thenReturn(List.of(new ActivityEvent().withId(UUID.randomUUID()))))) {
+                    .thenReturn(built))) {
       ActivityStreamPublisher publisher =
           new ActivityStreamPublisher(eventSubscription, subscriptionDestination);
 
@@ -122,6 +123,7 @@ class ActivityStreamPublisherTest {
 
       ActivityStreamRepository repository = repositoryConstruction.constructed().getFirst();
       verify(repository).createFieldEventsFromChangeEvent(any(), any());
+      verify(repository).insertBatch(built);
     }
   }
 

--- a/openmetadata-service/src/test/java/org/openmetadata/service/jdbi3/ActivityStreamRepositoryTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/jdbi3/ActivityStreamRepositoryTest.java
@@ -15,21 +15,23 @@ package org.openmetadata.service.jdbi3;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.ArgumentMatchers.isNull;
-import static org.mockito.Mockito.anyLong;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.Metrics;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.util.Arrays;
+import java.util.List;
 import java.util.UUID;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.mockito.MockedStatic;
 import org.openmetadata.schema.EntityInterface;
 import org.openmetadata.schema.entity.activity.ActivityEvent;
@@ -126,24 +128,11 @@ class ActivityStreamRepositoryTest {
 
     assertDoesNotThrow(() -> repository.insert(event));
 
-    verify(dao)
-        .insert(
-            eq(event.getId().toString()),
-            eq(ActivityEventType.ENTITY_CREATED.value()),
-            any(),
-            any(),
-            any(),
-            any(),
-            any(),
-            isNull(), // actorId
-            isNull(), // actorName
-            anyLong(),
-            any(),
-            any(),
-            any(),
-            any(),
-            any(),
-            any());
+    CollectionDAO.ActivityStreamRow row = captureSingleRow(dao);
+    assertEquals(event.getId().toString(), row.id());
+    assertEquals(ActivityEventType.ENTITY_CREATED.value(), row.eventType());
+    assertNull(row.actorId());
+    assertNull(row.actorName());
   }
 
   @Test
@@ -157,24 +146,49 @@ class ActivityStreamRepositoryTest {
 
     assertDoesNotThrow(() -> repository.insert(event));
 
-    verify(dao)
-        .insert(
-            eq(event.getId().toString()),
-            eq(ActivityEventType.ENTITY_CREATED.value()),
-            any(),
-            any(),
-            any(),
-            any(),
-            any(),
-            isNull(), // actorId
-            eq("ghost-user"), // actorName preserved
-            anyLong(),
-            any(),
-            any(),
-            any(),
-            any(),
-            any(),
-            any());
+    CollectionDAO.ActivityStreamRow row = captureSingleRow(dao);
+    assertNull(row.actorId());
+    assertEquals("ghost-user", row.actorName());
+  }
+
+  @Test
+  void insertDelegatesToSingleElementBatch() {
+    CollectionDAO.ActivityStreamDAO dao = mock(CollectionDAO.ActivityStreamDAO.class);
+    ActivityStreamRepository repository = new ActivityStreamRepository(dao);
+
+    repository.insert(baseEvent());
+
+    assertEquals(1, captureRows(dao).size());
+  }
+
+  @Test
+  void insertBatchSkipsNullsAndNoOpsOnEmpty() {
+    CollectionDAO.ActivityStreamDAO dao = mock(CollectionDAO.ActivityStreamDAO.class);
+    ActivityStreamRepository repository = new ActivityStreamRepository(dao);
+
+    repository.insertBatch(Arrays.asList(baseEvent(), null, baseEvent()));
+    assertEquals(2, captureRows(dao).size());
+
+    repository.insertBatch(List.of());
+    repository.insertBatch(null);
+    // empty/null are no-ops
+    verify(dao, times(1)).insertBatch(any());
+  }
+
+  private static CollectionDAO.ActivityStreamRow captureSingleRow(
+      CollectionDAO.ActivityStreamDAO dao) {
+    List<CollectionDAO.ActivityStreamRow> rows = captureRows(dao);
+    assertEquals(1, rows.size());
+    return rows.get(0);
+  }
+
+  @SuppressWarnings("unchecked")
+  private static List<CollectionDAO.ActivityStreamRow> captureRows(
+      CollectionDAO.ActivityStreamDAO dao) {
+    ArgumentCaptor<List<CollectionDAO.ActivityStreamRow>> captor =
+        ArgumentCaptor.forClass(List.class);
+    verify(dao).insertBatch(captor.capture());
+    return captor.getValue();
   }
 
   private ActivityEvent baseEvent() {


### PR DESCRIPTION
## Problem

For each change event the activity feed wrote **one INSERT per field-change row** — `ActivityStreamRepository.createFieldEventsFromChangeEvent` looped `insert()` per significant field change — even though the sibling success-record path in the same consumer already batches via `@ConnectionAwareSqlBatch`. Under load this multiplies DB round-trips on the `ActivityFeedAlert` consumer.

## Change

- Add `ActivityStreamDAO.insertBatch(@BindMethods List<ActivityStreamRow>)` (`@ConnectionAwareSqlBatch`, MySQL + Postgres), mirroring `batchUpsertSuccessfulChangeEvents`. Rows are carried by an immutable `ActivityStreamRow` record.
- `ActivityStreamRepository.insertBatch(List<ActivityEvent>)` maps each event to one row; `insert` delegates to it (single derivation path); `createFieldEventsFromChangeEvent` builds the rows and the publisher persists them in **one batch per change event**.
- Net: a change event with N significant field changes now does **1 INSERT instead of N**. Failure semantics unchanged (each event stays atomic → DLQ on failure); no shared event-pipeline interface touched.

## Testing

- Unit tests updated/added (`ActivityStreamRepositoryTest`, `ActivityStreamPublisherTest`).
- The batch SQL gets real-DB coverage for free via existing `ActivityResourceIT` (test-insert → `repo.insert` → `insertBatch`), exercised on both MySQL and Postgres in CI.

Follow-up from the event-pipeline throughput analysis (the AUT test-cadence fix is #28661).
