### PR TITLE
perf(alerts): compile filter expression once and validate combined condition at save

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/events/subscription/AlertUtil.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/events/subscription/AlertUtil.java
@@ -20,6 +20,8 @@ import static org.openmetadata.service.Entity.THREAD;
 import static org.openmetadata.service.apps.bundles.changeEvent.AbstractEventConsumer.OFFSET_EXTENSION;
 import static org.openmetadata.service.security.policyevaluator.CompiledRule.parseExpression;
 
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
 import jakarta.ws.rs.BadRequestException;
 import java.net.URI;
 import java.util.ArrayList;
@@ -53,6 +55,11 @@ import org.springframework.expression.spel.support.SimpleEvaluationContext;
 
 @Slf4j
 public final class AlertUtil {
+  // Reuse compiled filter expressions across events; the condition string is the cache key.
+  // Bounded + thread-safe — also evaluated from EventSubscriptionScheduler parallel streams.
+  private static final Cache<String, Expression> COMPILED_CONDITIONS =
+      Caffeine.newBuilder().maximumSize(1000).build();
+
   private AlertUtil() {}
 
   public static <T> void validateExpression(String condition, Class<T> clz) {
@@ -82,7 +89,8 @@ public final class AlertUtil {
       boolean result;
       String completeCondition = buildCompleteCondition(alertFilterRules);
       AlertsRuleEvaluator ruleEvaluator = new AlertsRuleEvaluator(changeEvent);
-      Expression expression = parseExpression(completeCondition);
+      Expression expression =
+          COMPILED_CONDITIONS.get(completeCondition, condition -> parseExpression(condition));
       SimpleEvaluationContext context =
           SimpleEvaluationContext.forReadOnlyDataBinding()
               .withInstanceMethods()

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/EventSubscriptionRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/EventSubscriptionRepository.java
@@ -154,6 +154,10 @@ public class EventSubscriptionRepository extends EntityRepository<EventSubscript
         AlertUtil.validateExpression(rule.getCondition(), Boolean.class);
       }
       rules.sort(Comparator.comparing(EventFilterRule::getName));
+      if (!rules.isEmpty()) {
+        // Reject a bad rule combination at save time, not per event at runtime.
+        AlertUtil.validateExpression(AlertUtil.buildCompleteCondition(rules), Boolean.class);
+      }
     }
   }
 

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/EventSubscriptionRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/EventSubscriptionRepository.java
@@ -155,7 +155,8 @@ public class EventSubscriptionRepository extends EntityRepository<EventSubscript
       }
       rules.sort(Comparator.comparing(EventFilterRule::getName));
       if (!rules.isEmpty()) {
-        // Reject a bad rule combination at save time, not per event at runtime.
+        // Validate the combined condition too (each rule is validated above), so a bad
+        // combination is caught here instead of when it is first compiled at runtime.
         AlertUtil.validateExpression(AlertUtil.buildCompleteCondition(rules), Boolean.class);
       }
     }

--- a/openmetadata-service/src/test/java/org/openmetadata/service/events/subscription/AlertUtilTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/events/subscription/AlertUtilTest.java
@@ -3,11 +3,18 @@ package org.openmetadata.service.events.subscription;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.CALLS_REAL_METHODS;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.times;
 
 import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
 import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.openmetadata.schema.entity.events.ArgumentsInput;
+import org.openmetadata.schema.entity.events.EventFilterRule;
 import org.openmetadata.schema.entity.events.FilteringRules;
 import org.openmetadata.schema.entity.feed.Thread;
 import org.openmetadata.schema.type.ChangeEvent;
@@ -15,6 +22,7 @@ import org.openmetadata.schema.type.EntityReference;
 import org.openmetadata.schema.type.EventType;
 import org.openmetadata.schema.type.ThreadType;
 import org.openmetadata.service.Entity;
+import org.openmetadata.service.security.policyevaluator.CompiledRule;
 
 class AlertUtilTest {
 
@@ -236,7 +244,47 @@ class AlertUtilTest {
     assertFalse(AlertUtil.shouldTriggerAlert(event, config));
   }
 
+  // ---- evaluateAlertConditions: compile-once cache --------------------------
+
+  @Test
+  void evaluateAlertConditionsCompilesEachConditionOnce() {
+    // Unique condition isolates this test from the shared static cache.
+    EventFilterRule rule = includeRule("matchAnySource({'src-" + UUID.randomUUID() + "'})");
+    ChangeEvent event = entityChangeEvent("table");
+
+    try (MockedStatic<CompiledRule> compiledRule =
+        mockStatic(CompiledRule.class, CALLS_REAL_METHODS)) {
+      AlertUtil.evaluateAlertConditions(event, List.of(rule));
+      AlertUtil.evaluateAlertConditions(event, List.of(rule));
+      AlertUtil.evaluateAlertConditions(event, List.of(rule));
+
+      compiledRule.verify(() -> CompiledRule.parseExpression(anyString()), times(1));
+    }
+  }
+
+  @Test
+  void evaluateAlertConditionsReusesCompiledExpressionPerEvent() {
+    EventFilterRule rule = includeRule("matchAnyEventType({'entityUpdated'})");
+
+    ChangeEvent updated = entityChangeEvent("table"); // ENTITY_UPDATED
+    assertTrue(AlertUtil.evaluateAlertConditions(updated, List.of(rule)));
+
+    ChangeEvent created =
+        new ChangeEvent()
+            .withId(UUID.randomUUID())
+            .withEventType(EventType.ENTITY_CREATED)
+            .withEntityType("table");
+    assertFalse(AlertUtil.evaluateAlertConditions(created, List.of(rule)));
+  }
+
   // ---- helpers ---------------------------------------------------------------
+
+  private static EventFilterRule includeRule(String condition) {
+    return new EventFilterRule()
+        .withName("rule")
+        .withEffect(ArgumentsInput.Effect.INCLUDE)
+        .withCondition(condition);
+  }
 
   private static ChangeEvent entityChangeEvent(String entityType) {
     return new ChangeEvent()

--- a/openmetadata-service/src/test/java/org/openmetadata/service/security/policyevaluator/ExpressionValidatorTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/security/policyevaluator/ExpressionValidatorTest.java
@@ -49,6 +49,23 @@ public class ExpressionValidatorTest {
     }
   }
 
+  @Test
+  void combinedBooleanWrappedConditionIsSafe() {
+    // Boolean wrappers (()/&&/||/!) only add safe nodes, so combining safe fragments stays safe.
+    assertDoesNotThrow(
+        () ->
+            ExpressionValidator.validateExpressionSafety(
+                "(matchAnyTag('Tier.Tier1')) && (!noOwner()) || (isOwner())"),
+        "Boolean-wrapped combination of safe fragments should stay safe");
+
+    assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            ExpressionValidator.validateExpressionSafety(
+                "(isOwner()) && (T(java.lang.Runtime).getRuntime())"),
+        "Unsafe fragment in a combined condition must still be blocked");
+  }
+
   // T( - SpEL Type Reference
   @Test
   void testTypeReference_Positive() {


### PR DESCRIPTION
## Problem

`AlertUtil.evaluateAlertConditions` rebuilt and **re-parsed the SpEL filter expression for every change event** (and `ExpressionValidator` parsed it a second time for safety), even though the condition is identical for every event of a subscription.

## Change

- Add a bounded, thread-safe **Caffeine** cache (`maximumSize(1000)`) keyed by the complete-condition string; the hot path reuses the compiled `Expression` instead of parsing per event. Thread-safe because the filter is also evaluated from `EventSubscriptionScheduler` parallel streams; the condition string *is* the cache key, so an edited filter naturally yields a new key (old entry ages out — no explicit invalidation).
- Validate the **combined** condition at save time (`EventSubscriptionRepository.validateFilterRules`) so a bad combination is rejected on create/update and the runtime cache is never poisoned.
- `CompiledRule` is untouched — the policy evaluator keeps full validation; the (rare) cache-miss compile still parses + safety-validates once per distinct condition.

## Testing

- `AlertUtilTest`: compile-once (parse invoked once across N evaluations) + cache correctness (same compiled expression re-evaluates per event).
- `ExpressionValidatorTest`: combined boolean-wrapped condition stays safe; an unsafe fragment in a combined condition is still rejected.

Follow-up from the event-pipeline throughput analysis (the AUT test-cadence fix is #28661).
