### PR TITLE
Fix missing search aliases after reindex by deleting the concrete index atomically within the alias swap

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/DefaultRecreateHandler.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/DefaultRecreateHandler.java
@@ -163,6 +163,11 @@ public class DefaultRecreateHandler implements RecreateIndexHandler {
 
         aliasesToAttach.removeIf(alias -> alias == null || alias.isBlank());
 
+        if (aliasesToAttach.isEmpty()) {
+          abortPromotionWithoutAliases(entityType, stagedIndex);
+          return;
+        }
+
         Set<String> allEntityIndices = searchClient.listIndicesByPrefix(canonicalIndex);
         Set<String> oldIndicesToDelete = new HashSet<>();
         for (String oldIndex : allEntityIndices) {
@@ -171,44 +176,26 @@ public class DefaultRecreateHandler implements RecreateIndexHandler {
           }
         }
 
-        // After the first reindex, the canonical name is an alias on the previous staged, not a
-        // concrete index. OpenSearch's listIndicesByPrefix returns that alias name as one of its
-        // result keys, which then drives a delete-by-name attempt that fails with
-        // "matches an alias, specify the corresponding concrete indices" and burns ~31s of
-        // exponential backoff per entity (1+2+4+8+16s before giving up). With 60 entity types
-        // a full reindex wastes ~30 minutes in cleanup. Drop the alias name from the cleanup set
-        // when it is currently an alias — it does not need to be deleted; the swap moves the
-        // alias atomically and the underlying old concrete is in oldIndicesToDelete already.
-        if (!searchClient.getIndicesByAlias(canonicalIndex).isEmpty()) {
-          oldIndicesToDelete.remove(canonicalIndex);
-        }
+        Set<String> concreteToRemove =
+            resolveCanonicalRemoval(searchClient, canonicalIndex, oldIndicesToDelete);
 
         LOG.debug(
-            "finalizeReindex entity '{}': aliases={}, oldIndices={}, stagedIndex={}",
+            "finalizeReindex entity '{}': aliases={}, oldIndices={}, stagedIndex={}, "
+                + "concreteToRemove={}",
             entityType,
             aliasesToAttach,
             oldIndicesToDelete,
-            stagedIndex);
+            stagedIndex,
+            concreteToRemove);
 
-        if (oldIndicesToDelete.contains(canonicalIndex)) {
-          if (searchClient.indexExists(canonicalIndex)) {
-            searchClient.deleteIndexWithBackoff(canonicalIndex);
-            oldIndicesToDelete.remove(canonicalIndex);
-            LOG.info("Cleaned up old index '{}' for entity '{}'.", canonicalIndex, entityType);
-          }
-        }
-
-        if (!aliasesToAttach.isEmpty()) {
-          boolean swapSuccess =
-              searchClient.swapAliases(oldIndicesToDelete, stagedIndex, aliasesToAttach);
-          if (!swapSuccess) {
-            LOG.error(
-                "Failed to atomically swap aliases for entity '{}'. Old indices will not be deleted.",
-                entityType);
-            return;
-          }
-        } else {
-          LOG.warn("Entity '{}': aliasesToAttach is empty, skipping alias swap", entityType);
+        boolean swapSuccess =
+            searchClient.swapAliases(
+                oldIndicesToDelete, stagedIndex, aliasesToAttach, concreteToRemove);
+        if (!swapSuccess) {
+          LOG.error(
+              "Failed to atomically swap aliases for entity '{}'. Old indices will not be deleted.",
+              entityType);
+          return;
         }
 
         LOG.info(
@@ -353,6 +340,11 @@ public class DefaultRecreateHandler implements RecreateIndexHandler {
       Set<String> aliasesToAttach =
           getAliasesFromMapping(indexMapping, searchRepository.getClusterAlias());
 
+      if (aliasesToAttach.isEmpty()) {
+        abortPromotionWithoutAliases(entityType, stagedIndex);
+        return;
+      }
+
       Set<String> allEntityIndices = searchClient.listIndicesByPrefix(canonicalIndex);
       Set<String> oldIndicesToDelete = new HashSet<>();
       for (String oldIndex : allEntityIndices) {
@@ -361,36 +353,29 @@ public class DefaultRecreateHandler implements RecreateIndexHandler {
         }
       }
 
+      Set<String> concreteToRemove =
+          resolveCanonicalRemoval(searchClient, canonicalIndex, oldIndicesToDelete);
+
       LOG.debug(
-          "promoteEntityIndex '{}': aliases={}, oldIndices={}, stagedIndex={}",
+          "promoteEntityIndex '{}': aliases={}, oldIndices={}, stagedIndex={}, concreteToRemove={}",
           entityType,
           aliasesToAttach,
           oldIndicesToDelete,
-          stagedIndex);
+          stagedIndex,
+          concreteToRemove);
 
-      if (oldIndicesToDelete.contains(canonicalIndex)) {
-        if (searchClient.indexExists(canonicalIndex)) {
-          searchClient.deleteIndexWithBackoff(canonicalIndex);
-          oldIndicesToDelete.remove(canonicalIndex);
-          LOG.info("Cleaned up old index '{}' for entity '{}'.", canonicalIndex, entityType);
-        }
-      }
-
-      if (!aliasesToAttach.isEmpty()) {
-        boolean swapSuccess =
-            searchClient.swapAliases(oldIndicesToDelete, stagedIndex, aliasesToAttach);
-        if (!swapSuccess) {
-          LOG.error(
-              "Failed to atomically swap aliases for entity '{}'. "
-                  + "oldIndices={}, stagedIndex={}, aliases={}",
-              entityType,
-              oldIndicesToDelete,
-              stagedIndex,
-              aliasesToAttach);
-          return;
-        }
-      } else {
-        LOG.warn("Entity '{}': aliasesToAttach is empty, skipping alias swap", entityType);
+      boolean swapSuccess =
+          searchClient.swapAliases(
+              oldIndicesToDelete, stagedIndex, aliasesToAttach, concreteToRemove);
+      if (!swapSuccess) {
+        LOG.error(
+            "Failed to atomically swap aliases for entity '{}'. "
+                + "oldIndices={}, stagedIndex={}, aliases={}",
+            entityType,
+            oldIndicesToDelete,
+            stagedIndex,
+            aliasesToAttach);
+        return;
       }
 
       LOG.info(
@@ -426,6 +411,60 @@ public class DefaultRecreateHandler implements RecreateIndexHandler {
     } finally {
       searchRepository.unregisterStagedIndex(entityType, stagedIndex);
     }
+  }
+
+  /**
+   * Aborts promotion when no aliases resolved for the staged index. Critically this skips the
+   * old-index cleanup: deleting the previously serving index while no alias points at the staged
+   * index would orphan the canonical alias and surface to users as
+   * "Failed to find index openmetadata_*_search_index". The staged index is retained (its routing
+   * is cleared by the caller's finally block) so a subsequent reindex can recover.
+   */
+  private void abortPromotionWithoutAliases(String entityType, String stagedIndex) {
+    LOG.error(
+        "Entity '{}': no aliases resolved for staged index '{}'. Skipping alias swap and old-index "
+            + "cleanup to avoid orphaning the canonical alias. Staged index retained; reindex must "
+            + "be retried.",
+        entityType,
+        stagedIndex);
+    ReindexingMetrics metrics = ReindexingMetrics.getInstance();
+    if (metrics != null) {
+      metrics.recordPromotionFailure(entityType);
+    }
+  }
+
+  /**
+   * Resolves how the canonical index name participates in the alias swap and prunes it from {@code
+   * oldIndicesToDelete}.
+   *
+   * <ul>
+   *   <li><b>Concrete index sharing the alias name</b> (the first-install / post-orphan shape): it
+   *       is returned so the caller hands it to {@link SearchClient#swapAliases(Set, String, Set,
+   *       Set)} for an atomic {@code remove_index}. Deleting it in a separate step before the swap
+   *       opens a window where the index is gone but the alias is not yet attached — if the alias
+   *       add then fails (e.g. the delete has not propagated, so OS/ES still sees an index with the
+   *       alias name), the canonical name resolves to nothing and users hit "Failed to find index
+   *       openmetadata_*_search_index".
+   *   <li><b>Already an alias</b>: it is simply dropped from the delete set — the swap moves it
+   *       atomically, and a delete-by-name on an alias would fail ("matches an alias") and burn
+   *       retry backoff.
+   * </ul>
+   *
+   * @return the concrete indices (0 or 1) to remove atomically within the swap
+   */
+  private Set<String> resolveCanonicalRemoval(
+      SearchClient searchClient, String canonicalIndex, Set<String> oldIndicesToDelete) {
+    Set<String> concreteToRemove = new HashSet<>();
+    if (oldIndicesToDelete.contains(canonicalIndex)) {
+      boolean isConcreteIndex =
+          searchClient.getIndicesByAlias(canonicalIndex).isEmpty()
+              && searchClient.indexExists(canonicalIndex);
+      if (isConcreteIndex) {
+        concreteToRemove.add(canonicalIndex);
+      }
+      oldIndicesToDelete.remove(canonicalIndex);
+    }
+    return concreteToRemove;
   }
 
   /**

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/DefaultRecreateHandler.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/DefaultRecreateHandler.java
@@ -86,11 +86,8 @@ public class DefaultRecreateHandler implements RecreateIndexHandler {
   public void finalizeReindex(EntityReindexContext context, boolean reindexSuccess) {
     String entityType = context.getEntityType();
     String canonicalIndex = context.getCanonicalIndex();
-    String activeIndex = context.getActiveIndex();
     String stagedIndex = context.getStagedIndex();
-    Set<String> existingAliases = context.getExistingAliases();
-    String canonicalAlias = context.getCanonicalAliases();
-    Set<String> parentAliases = context.getParentAliases();
+    Set<String> aliasesFromMapping = context.getExistingAliases();
 
     SearchRepository searchRepository = Entity.getSearchRepository();
     SearchClient searchClient = searchRepository.getSearchClient();
@@ -147,21 +144,15 @@ public class DefaultRecreateHandler implements RecreateIndexHandler {
       //                         is strictly worse than the writes going back to the canonical
       //                         alias target. Operators need to retry the reindex either way.
       try {
+        // The alias set was derived from indexMapping.json at recreate time via
+        // getAliasesFromMapping; finalize just attaches that captured set. Nothing is read from the
+        // live cluster, so the set is deterministic and matches the distributed promotion path.
         Set<String> aliasesToAttach = new HashSet<>();
-
-        existingAliases.stream()
-            .filter(alias -> alias != null && !alias.isBlank())
-            .forEach(aliasesToAttach::add);
-
-        if (!nullOrEmpty(canonicalAlias)) {
-          aliasesToAttach.add(canonicalAlias);
+        if (aliasesFromMapping != null) {
+          aliasesFromMapping.stream()
+              .filter(alias -> alias != null && !alias.isBlank())
+              .forEach(aliasesToAttach::add);
         }
-
-        parentAliases.stream()
-            .filter(alias -> alias != null && !alias.isBlank())
-            .forEach(aliasesToAttach::add);
-
-        aliasesToAttach.removeIf(alias -> alias == null || alias.isBlank());
 
         if (aliasesToAttach.isEmpty()) {
           abortPromotionWithoutAliases(entityType, stagedIndex);
@@ -549,18 +540,18 @@ public class DefaultRecreateHandler implements RecreateIndexHandler {
     applyBulkBuildSettings(searchClient, stagedIndexName, entityType);
     searchRepository.registerStagedIndex(entityType, stagedIndexName);
 
-    Set<String> existingAliases =
-        activeIndexName != null ? searchClient.getAliases(activeIndexName) : new HashSet<>();
-
-    // Add the default index
-    existingAliases.add(indexMapping.getAlias(clusterAlias));
-    existingAliases.add(indexMapping.getIndexName(clusterAlias));
+    // Aliases to attach come solely from indexMapping.json (short alias + parent aliases + raw
+    // canonical index name) — never from whatever happens to be on the live index in ES. Reading
+    // existing aliases off the cluster is non-deterministic (it propagates stray/leftover aliases),
+    // adds a cluster round-trip and failure point, and diverges from the distributed promotion path
+    // (promoteEntityIndex). Both paths now funnel through the same getAliasesFromMapping helper.
+    Set<String> aliasesFromMapping = getAliasesFromMapping(indexMapping, clusterAlias);
     context.add(
         entityType,
         canonicalIndexName,
         activeIndexName,
         stagedIndexName,
-        existingAliases,
+        aliasesFromMapping,
         indexMapping.getAlias(clusterAlias),
         indexMapping.getParentAliases(clusterAlias));
 

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/IndexManagementClient.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/IndexManagementClient.java
@@ -98,16 +98,30 @@ public interface IndexManagementClient {
   void removeAliases(String indexName, Set<String> aliases);
 
   /**
-   * Atomically swap aliases from old indices to a new index.
-   * This operation removes the specified aliases from any old indices and adds them to the new index
-   * in a single atomic operation, ensuring zero-downtime during index promotion.
+   * Atomically swap aliases from old indices to a new index, optionally deleting concrete indices
+   * in the same request. Removing the aliases from old indices, deleting any {@code indicesToRemove}
+   * (via {@code remove_index}) and adding the aliases to the new index all happen in a single atomic
+   * {@code updateAliases} call.
+   *
+   * <p>{@code indicesToRemove} is for the first-install / post-orphan shape where the canonical name
+   * (e.g. {@code table_search_index}) is still a <em>concrete</em> index sharing the alias name.
+   * Deleting it separately before the swap would orphan the alias if the alias add then failed;
+   * folding the delete into the atomic request means a failure is a no-op — the concrete index and
+   * its live aliases survive — instead of leaving the canonical name pointing at nothing.
    *
    * @param oldIndices the set of old index names to remove aliases from
    * @param newIndex the new index name to add aliases to
    * @param aliases the set of aliases to swap
+   * @param indicesToRemove concrete indices to delete atomically within the same request
    * @return true if the swap was successful, false otherwise
    */
-  boolean swapAliases(Set<String> oldIndices, String newIndex, Set<String> aliases);
+  boolean swapAliases(
+      Set<String> oldIndices, String newIndex, Set<String> aliases, Set<String> indicesToRemove);
+
+  /** Swap aliases without atomically removing any concrete index. */
+  default boolean swapAliases(Set<String> oldIndices, String newIndex, Set<String> aliases) {
+    return swapAliases(oldIndices, newIndex, aliases, Set.of());
+  }
 
   /**
    * Get all aliases for an index.

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/elasticsearch/ElasticSearchClient.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/elasticsearch/ElasticSearchClient.java
@@ -263,8 +263,9 @@ public class ElasticSearchClient implements SearchClient {
   }
 
   @Override
-  public boolean swapAliases(Set<String> oldIndices, String newIndex, Set<String> aliases) {
-    return indexManager.swapAliases(oldIndices, newIndex, aliases);
+  public boolean swapAliases(
+      Set<String> oldIndices, String newIndex, Set<String> aliases, Set<String> indicesToRemove) {
+    return indexManager.swapAliases(oldIndices, newIndex, aliases, indicesToRemove);
   }
 
   @Override

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/elasticsearch/ElasticSearchIndexManager.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/elasticsearch/ElasticSearchIndexManager.java
@@ -330,35 +330,43 @@ public class ElasticSearchIndexManager implements IndexManagementClient {
   }
 
   @Override
-  public boolean swapAliases(Set<String> oldIndices, String newIndex, Set<String> aliases) {
+  public boolean swapAliases(
+      Set<String> oldIndices, String newIndex, Set<String> aliases, Set<String> indicesToRemove) {
     if (!isClientAvailable) {
       LOG.error("ElasticSearch client is not available. Cannot swap aliases.");
       return false;
     }
-    if (aliases == null || aliases.isEmpty()) {
-      LOG.debug("No aliases to swap for index {}", newIndex);
+    Set<String> finalAliases = aliases == null ? Set.of() : aliases;
+    Set<String> finalIndicesToRemove = indicesToRemove == null ? Set.of() : indicesToRemove;
+    if (finalAliases.isEmpty() && finalIndicesToRemove.isEmpty()) {
+      LOG.debug("No aliases to swap and no indices to remove for index {}", newIndex);
       return true;
     }
-    if (oldIndices == null) {
-      oldIndices = new HashSet<>();
-    }
-
-    Set<String> finalOldIndices = oldIndices;
+    Set<String> finalOldIndices = oldIndices == null ? new HashSet<>() : oldIndices;
     try {
       UpdateAliasesRequest request =
           UpdateAliasesRequest.of(
               updateBuilder -> {
                 // First, remove aliases from all old indices
                 for (String oldIndex : finalOldIndices) {
-                  for (String alias : aliases) {
+                  for (String alias : finalAliases) {
                     updateBuilder.actions(
                         actionBuilder ->
                             actionBuilder.remove(
                                 removeBuilder -> removeBuilder.index(oldIndex).alias(alias)));
                   }
                 }
-                // Then, add aliases to the new index
-                for (String alias : aliases) {
+                // Then delete any concrete index sharing the alias name, atomically, so the alias
+                // add below cannot race a separate delete and orphan the canonical name.
+                for (String indexToRemove : finalIndicesToRemove) {
+                  updateBuilder.actions(
+                      actionBuilder ->
+                          actionBuilder.removeIndex(
+                              removeIndexBuilder ->
+                                  removeIndexBuilder.index(indexToRemove).mustExist(false)));
+                }
+                // Finally, add aliases to the new index
+                for (String alias : finalAliases) {
                   updateBuilder.actions(
                       actionBuilder ->
                           actionBuilder.add(addBuilder -> addBuilder.index(newIndex).alias(alias)));
@@ -370,25 +378,18 @@ public class ElasticSearchIndexManager implements IndexManagementClient {
 
       if (response.acknowledged()) {
         LOG.info(
-            "Atomically swapped aliases {} from indices {} to index {}",
-            aliases,
-            finalOldIndices,
-            newIndex);
+            "Atomically swapped aliases {} to index {} (removed indices {}, detached from {})",
+            finalAliases,
+            newIndex,
+            finalIndicesToRemove,
+            finalOldIndices);
         return true;
       } else {
-        LOG.warn(
-            "Alias swap from indices {} to index {} was not acknowledged",
-            finalOldIndices,
-            newIndex);
+        LOG.warn("Alias swap to index {} was not acknowledged", newIndex);
         return false;
       }
     } catch (Exception e) {
-      LOG.error(
-          "Failed to swap aliases {} from indices {} to index {}",
-          aliases,
-          finalOldIndices,
-          newIndex,
-          e);
+      LOG.error("Failed to swap aliases {} to index {}", finalAliases, newIndex, e);
       return false;
     }
   }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/opensearch/OpenSearchClient.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/opensearch/OpenSearchClient.java
@@ -250,8 +250,9 @@ public class OpenSearchClient implements SearchClient {
   }
 
   @Override
-  public boolean swapAliases(Set<String> oldIndices, String newIndex, Set<String> aliases) {
-    return indexManager.swapAliases(oldIndices, newIndex, aliases);
+  public boolean swapAliases(
+      Set<String> oldIndices, String newIndex, Set<String> aliases, Set<String> indicesToRemove) {
+    return indexManager.swapAliases(oldIndices, newIndex, aliases, indicesToRemove);
   }
 
   @Override

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/opensearch/OpenSearchIndexManager.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/opensearch/OpenSearchIndexManager.java
@@ -411,35 +411,42 @@ public class OpenSearchIndexManager implements IndexManagementClient {
   }
 
   @Override
-  public boolean swapAliases(Set<String> oldIndices, String newIndex, Set<String> aliases) {
+  public boolean swapAliases(
+      Set<String> oldIndices, String newIndex, Set<String> aliases, Set<String> indicesToRemove) {
     if (!isClientAvailable) {
       LOG.error("OpenSearch client is not available. Cannot swap aliases.");
       return false;
     }
-    if (aliases == null || aliases.isEmpty()) {
-      LOG.debug("No aliases to swap for index {}", newIndex);
+    Set<String> finalAliases = aliases == null ? Set.of() : aliases;
+    Set<String> finalIndicesToRemove = indicesToRemove == null ? Set.of() : indicesToRemove;
+    if (finalAliases.isEmpty() && finalIndicesToRemove.isEmpty()) {
+      LOG.debug("No aliases to swap and no indices to remove for index {}", newIndex);
       return true;
     }
-    if (oldIndices == null) {
-      oldIndices = new HashSet<>();
-    }
-
-    Set<String> finalOldIndices = oldIndices;
+    Set<String> finalOldIndices = oldIndices == null ? new HashSet<>() : oldIndices;
     try {
       UpdateAliasesRequest request =
           UpdateAliasesRequest.of(
               updateBuilder -> {
                 // First, remove aliases from all old indices
                 for (String oldIndex : finalOldIndices) {
-                  for (String alias : aliases) {
+                  for (String alias : finalAliases) {
                     updateBuilder.actions(
                         actionBuilder ->
                             actionBuilder.remove(
                                 removeBuilder -> removeBuilder.index(oldIndex).alias(alias)));
                   }
                 }
-                // Then, add aliases to the new index
-                for (String alias : aliases) {
+                // Then delete any concrete index sharing the alias name, atomically, so the alias
+                // add below cannot race a separate delete and orphan the canonical name.
+                for (String indexToRemove : finalIndicesToRemove) {
+                  updateBuilder.actions(
+                      actionBuilder ->
+                          actionBuilder.removeIndex(
+                              removeIndexBuilder -> removeIndexBuilder.index(indexToRemove)));
+                }
+                // Finally, add aliases to the new index
+                for (String alias : finalAliases) {
                   updateBuilder.actions(
                       actionBuilder ->
                           actionBuilder.add(addBuilder -> addBuilder.index(newIndex).alias(alias)));
@@ -451,25 +458,18 @@ public class OpenSearchIndexManager implements IndexManagementClient {
 
       if (response.acknowledged()) {
         LOG.info(
-            "Atomically swapped aliases {} from indices {} to index {}",
-            aliases,
-            finalOldIndices,
-            newIndex);
+            "Atomically swapped aliases {} to index {} (removed indices {}, detached from {})",
+            finalAliases,
+            newIndex,
+            finalIndicesToRemove,
+            finalOldIndices);
         return true;
       } else {
-        LOG.warn(
-            "Alias swap from indices {} to index {} was not acknowledged",
-            finalOldIndices,
-            newIndex);
+        LOG.warn("Alias swap to index {} was not acknowledged", newIndex);
         return false;
       }
     } catch (Exception e) {
-      LOG.error(
-          "Failed to swap aliases {} from indices {} to index {}",
-          aliases,
-          finalOldIndices,
-          newIndex,
-          e);
+      LOG.error("Failed to swap aliases {} to index {}", finalAliases, newIndex, e);
       return false;
     }
   }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/opensearch/OpenSearchIndexManager.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/opensearch/OpenSearchIndexManager.java
@@ -443,7 +443,8 @@ public class OpenSearchIndexManager implements IndexManagementClient {
                   updateBuilder.actions(
                       actionBuilder ->
                           actionBuilder.removeIndex(
-                              removeIndexBuilder -> removeIndexBuilder.index(indexToRemove)));
+                              removeIndexBuilder ->
+                                  removeIndexBuilder.index(indexToRemove).mustExist(false)));
                 }
                 // Finally, add aliases to the new index
                 for (String alias : finalAliases) {

--- a/openmetadata-service/src/test/java/org/openmetadata/service/search/DefaultRecreateHandlerTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/search/DefaultRecreateHandlerTest.java
@@ -113,7 +113,9 @@ class DefaultRecreateHandlerTest {
         "Should promote partial data and record success metrics when failed reindex has documents")
     void testPromoteEntityIndexPromotesPartialData() {
       AliasState aliasState = new AliasState();
-      aliasState.put("table_search_index", Set.of("table_search_index"));
+      // First-install shape: canonical is a concrete index (OS/ES forbid an alias and a concrete
+      // index sharing the same name, so it carries no self-alias).
+      aliasState.put("table_search_index", Set.of());
       aliasState.put("table_search_index_rebuild_old", Set.of("legacy"));
       aliasState.put("table_search_index_rebuild_new", new HashSet<>());
 
@@ -279,7 +281,7 @@ class DefaultRecreateHandlerTest {
       aliasState.put("table_search_index_rebuild_new", new HashSet<>());
 
       SearchClient client = aliasState.toMock();
-      when(client.swapAliases(anySet(), anyString(), anySet())).thenReturn(false);
+      when(client.swapAliases(anySet(), anyString(), anySet(), anySet())).thenReturn(false);
 
       SearchRepository repo = mock(SearchRepository.class);
       when(repo.getSearchClient()).thenReturn(client);
@@ -308,6 +310,45 @@ class DefaultRecreateHandlerTest {
 
       assertFalse(aliasState.deletedIndices.contains("table_search_index_rebuild_old"));
       assertTrue(aliasState.indexAliases.get("table_search_index_rebuild_new").isEmpty());
+    }
+
+    @Test
+    @DisplayName("Should NOT delete old serving index when no aliases resolve (orphan-alias guard)")
+    void testPromoteEntityIndexDoesNotOrphanAliasWhenMappingHasNoAliases() {
+      AliasState aliasState = new AliasState();
+      aliasState.put(
+          "table_search_index_rebuild_old",
+          new HashSet<>(Set.of("table", "table_search_index", "all")));
+      aliasState.put("table_search_index_rebuild_new", new HashSet<>());
+
+      SearchClient client = aliasState.toMock();
+      SearchRepository repo = mock(SearchRepository.class);
+      when(repo.getSearchClient()).thenReturn(client);
+      when(repo.getClusterAlias()).thenReturn("");
+      when(repo.getIndexMapping("table")).thenReturn(null);
+
+      try (MockedStatic<Entity> entityMock = mockStatic(Entity.class)) {
+        entityMock.when(Entity::getSearchRepository).thenReturn(repo);
+
+        EntityReindexContext context =
+            EntityReindexContext.builder()
+                .entityType("table")
+                .canonicalIndex("table_search_index")
+                .stagedIndex("table_search_index_rebuild_new")
+                .build();
+
+        new DefaultRecreateHandler().promoteEntityIndex(context, true);
+      }
+
+      assertFalse(
+          aliasState.deletedIndices.contains("table_search_index_rebuild_old"),
+          "Old serving index must not be deleted when no alias was attached to the staged index");
+      assertTrue(
+          aliasState
+              .indexAliases
+              .get("table_search_index_rebuild_old")
+              .contains("table_search_index"),
+          "Canonical alias must remain resolvable on the old index after an aborted promotion");
     }
 
     @Test
@@ -614,7 +655,7 @@ class DefaultRecreateHandlerTest {
       aliasState.put("table_search_index_rebuild_new", new HashSet<>());
 
       SearchClient client = aliasState.toMock();
-      when(client.swapAliases(anySet(), anyString(), anySet())).thenReturn(false);
+      when(client.swapAliases(anySet(), anyString(), anySet(), anySet())).thenReturn(false);
 
       SearchRepository repo = mock(SearchRepository.class);
       when(repo.getSearchClient()).thenReturn(client);
@@ -637,6 +678,118 @@ class DefaultRecreateHandlerTest {
 
       assertFalse(aliasState.deletedIndices.contains("table_search_index_rebuild_old"));
       assertTrue(aliasState.indexAliases.get("table_search_index_rebuild_new").isEmpty());
+    }
+
+    @Test
+    @DisplayName("Should NOT delete old serving index when finalize resolves no aliases")
+    void testFinalizeReindexDoesNotOrphanAliasWhenNoAliasesResolved() {
+      AliasState aliasState = new AliasState();
+      aliasState.put(
+          "table_search_index_rebuild_old",
+          new HashSet<>(Set.of("table", "table_search_index", "all")));
+      aliasState.put("table_search_index_rebuild_new", new HashSet<>());
+
+      SearchClient client = aliasState.toMock();
+      SearchRepository repo = mock(SearchRepository.class);
+      when(repo.getSearchClient()).thenReturn(client);
+
+      try (MockedStatic<Entity> entityMock = mockStatic(Entity.class)) {
+        entityMock.when(Entity::getSearchRepository).thenReturn(repo);
+
+        EntityReindexContext context =
+            EntityReindexContext.builder()
+                .entityType("table")
+                .canonicalIndex("table_search_index")
+                .stagedIndex("table_search_index_rebuild_new")
+                .existingAliases(new HashSet<>(List.of("", " ")))
+                .canonicalAliases("")
+                .parentAliases(new HashSet<>(List.of(" ")))
+                .build();
+
+        new DefaultRecreateHandler().finalizeReindex(context, true);
+      }
+
+      assertFalse(
+          aliasState.deletedIndices.contains("table_search_index_rebuild_old"),
+          "Old serving index must not be deleted when finalize resolved no aliases");
+      assertTrue(
+          aliasState
+              .indexAliases
+              .get("table_search_index_rebuild_old")
+              .contains("table_search_index"),
+          "Canonical alias must remain resolvable on the old index after an aborted finalize");
+    }
+
+    @Test
+    @DisplayName("First-install concrete canonical is removed atomically inside the swap")
+    void testFinalizeReindexRemovesConcreteCanonicalAtomically() {
+      AliasState aliasState = new AliasState();
+      aliasState.put("table_search_index", new HashSet<>(Set.of("table", "all")));
+      aliasState.put("table_search_index_rebuild_new", new HashSet<>());
+
+      SearchClient client = aliasState.toMock();
+      SearchRepository repo = mock(SearchRepository.class);
+      when(repo.getSearchClient()).thenReturn(client);
+
+      try (MockedStatic<Entity> entityMock = mockStatic(Entity.class)) {
+        entityMock.when(Entity::getSearchRepository).thenReturn(repo);
+
+        EntityReindexContext context =
+            EntityReindexContext.builder()
+                .entityType("table")
+                .canonicalIndex("table_search_index")
+                .activeIndex("table_search_index")
+                .stagedIndex("table_search_index_rebuild_new")
+                .existingAliases(new HashSet<>(Set.of("table", "table_search_index")))
+                .canonicalAliases("table")
+                .parentAliases(new HashSet<>(Set.of("all")))
+                .build();
+
+        new DefaultRecreateHandler().finalizeReindex(context, true);
+      }
+
+      verify(client, never()).deleteIndexWithBackoff("table_search_index");
+      assertFalse(aliasState.indexAliases.containsKey("table_search_index"));
+      Set<String> stagedAliases = aliasState.indexAliases.get("table_search_index_rebuild_new");
+      assertTrue(stagedAliases.contains("table_search_index"));
+      assertTrue(stagedAliases.contains("table"));
+      assertTrue(stagedAliases.contains("all"));
+    }
+
+    @Test
+    @DisplayName("First-install: a failed atomic swap leaves the concrete index intact (no orphan)")
+    void testFinalizeReindexFailedSwapDoesNotOrphanConcreteCanonical() {
+      AliasState aliasState = new AliasState();
+      aliasState.put("table_search_index", new HashSet<>(Set.of("table", "all")));
+      aliasState.put("table_search_index_rebuild_new", new HashSet<>());
+
+      SearchClient client = aliasState.toMock();
+      when(client.swapAliases(anySet(), anyString(), anySet(), anySet())).thenReturn(false);
+
+      SearchRepository repo = mock(SearchRepository.class);
+      when(repo.getSearchClient()).thenReturn(client);
+
+      try (MockedStatic<Entity> entityMock = mockStatic(Entity.class)) {
+        entityMock.when(Entity::getSearchRepository).thenReturn(repo);
+
+        EntityReindexContext context =
+            EntityReindexContext.builder()
+                .entityType("table")
+                .canonicalIndex("table_search_index")
+                .activeIndex("table_search_index")
+                .stagedIndex("table_search_index_rebuild_new")
+                .existingAliases(new HashSet<>(Set.of("table", "table_search_index")))
+                .canonicalAliases("table")
+                .parentAliases(new HashSet<>(Set.of("all")))
+                .build();
+
+        new DefaultRecreateHandler().finalizeReindex(context, true);
+      }
+
+      verify(client, never()).deleteIndexWithBackoff("table_search_index");
+      assertTrue(aliasState.indexAliases.containsKey("table_search_index"));
+      assertTrue(aliasState.indexAliases.get("table_search_index").contains("table"));
+      assertFalse(aliasState.deletedIndices.contains("table_search_index"));
     }
 
     @Test
@@ -916,33 +1069,6 @@ class DefaultRecreateHandlerTest {
           .when(client)
           .addAliases(anyString(), anySet());
 
-      // Mock swapAliases - atomically remove aliases from old indices and add to new index
-      lenient()
-          .doAnswer(
-              invocation -> {
-                @SuppressWarnings("unchecked")
-                Set<String> oldIndices = invocation.getArgument(0);
-                String newIndex = invocation.getArgument(1);
-                @SuppressWarnings("unchecked")
-                Set<String> aliases = new HashSet<>(invocation.getArgument(2));
-
-                // Remove aliases from old indices
-                for (String oldIndex : oldIndices) {
-                  indexAliases.computeIfPresent(
-                      oldIndex,
-                      (k, v) -> {
-                        v.removeAll(aliases);
-                        return v;
-                      });
-                }
-
-                // Add aliases to new index
-                indexAliases.computeIfAbsent(newIndex, k -> new HashSet<>()).addAll(aliases);
-                return true;
-              })
-          .when(client)
-          .swapAliases(anySet(), anyString(), anySet());
-
       lenient()
           .doAnswer(
               invocation -> {
@@ -965,6 +1091,8 @@ class DefaultRecreateHandlerTest {
           .when(client)
           .deleteIndexWithBackoff(anyString());
 
+      // Atomic swap: remove aliases from old indices, delete any concrete indicesToRemove
+      // (remove_index) and add aliases to the new index — all or nothing.
       lenient()
           .doAnswer(
               invocation -> {
@@ -973,8 +1101,9 @@ class DefaultRecreateHandlerTest {
                 String newIndex = invocation.getArgument(1);
                 @SuppressWarnings("unchecked")
                 Set<String> aliases = new HashSet<>(invocation.getArgument(2));
+                @SuppressWarnings("unchecked")
+                Set<String> indicesToRemove = invocation.getArgument(3);
 
-                // Remove aliases from old indices
                 for (String oldIndex : oldIndices) {
                   Set<String> oldAliases = indexAliases.get(oldIndex);
                   if (oldAliases != null) {
@@ -982,13 +1111,16 @@ class DefaultRecreateHandlerTest {
                   }
                 }
 
-                // Add aliases to new index
-                indexAliases.computeIfAbsent(newIndex, k -> new HashSet<>()).addAll(aliases);
+                for (String indexToRemove : indicesToRemove) {
+                  indexAliases.remove(indexToRemove);
+                  deletedIndices.add(indexToRemove);
+                }
 
+                indexAliases.computeIfAbsent(newIndex, k -> new HashSet<>()).addAll(aliases);
                 return true;
               })
           .when(client)
-          .swapAliases(anySet(), anyString(), anySet());
+          .swapAliases(anySet(), anyString(), anySet(), anySet());
 
       return client;
     }

--- a/openmetadata-service/src/test/java/org/openmetadata/service/search/DefaultRecreateHandlerTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/search/DefaultRecreateHandlerTest.java
@@ -600,7 +600,7 @@ class DefaultRecreateHandlerTest {
                 .canonicalIndex("table_search_index")
                 .activeIndex("table_search_index")
                 .stagedIndex("table_search_index_rebuild_new")
-                .existingAliases(new HashSet<>(List.of("legacyAlias", "", " ")))
+                .existingAliases(new HashSet<>(List.of("legacyAlias", "table", "all", "", " ")))
                 .canonicalAliases("table")
                 .parentAliases(new HashSet<>(List.of("all", "", " ")))
                 .build();
@@ -740,7 +740,7 @@ class DefaultRecreateHandlerTest {
                 .canonicalIndex("table_search_index")
                 .activeIndex("table_search_index")
                 .stagedIndex("table_search_index_rebuild_new")
-                .existingAliases(new HashSet<>(Set.of("table", "table_search_index")))
+                .existingAliases(new HashSet<>(Set.of("table", "table_search_index", "all")))
                 .canonicalAliases("table")
                 .parentAliases(new HashSet<>(Set.of("all")))
                 .build();
@@ -778,7 +778,7 @@ class DefaultRecreateHandlerTest {
                 .canonicalIndex("table_search_index")
                 .activeIndex("table_search_index")
                 .stagedIndex("table_search_index_rebuild_new")
-                .existingAliases(new HashSet<>(Set.of("table", "table_search_index")))
+                .existingAliases(new HashSet<>(Set.of("table", "table_search_index", "all")))
                 .canonicalAliases("table")
                 .parentAliases(new HashSet<>(Set.of("all")))
                 .build();
@@ -885,12 +885,11 @@ class DefaultRecreateHandlerTest {
   class RecreateIndexFromMappingTests {
 
     @Test
-    @DisplayName("Should resolve existing alias targets and populate context")
+    @DisplayName("Should derive aliases from the mapping only, never from the live index in ES")
     void testRecreateIndexFromMappingUsesAliasTargetAsActiveIndex() {
       SearchClient client = mock(SearchClient.class);
       when(client.indexExists("table_search_index")).thenReturn(false);
       when(client.getIndicesByAlias("table")).thenReturn(Set.of("table_search_index_v1"));
-      when(client.getAliases("table_search_index_v1")).thenReturn(new HashSet<>(Set.of("legacy")));
 
       SearchRepository repo = mock(SearchRepository.class);
       when(repo.getClusterAlias()).thenReturn("");
@@ -914,7 +913,9 @@ class DefaultRecreateHandlerTest {
 
       assertEquals("table_search_index", context.getCanonicalIndex("table").orElseThrow());
       assertEquals("table_search_index_v1", context.getOriginalIndex("table").orElseThrow());
-      assertTrue(context.getExistingAliases("table").contains("legacy"));
+      // Aliases come purely from the mapping (short alias + raw index name); stray aliases on the
+      // live index are never read or carried forward.
+      verify(client, never()).getAliases(anyString());
       assertTrue(context.getExistingAliases("table").contains("table"));
       assertTrue(context.getExistingAliases("table").contains("table_search_index"));
       assertTrue(context.getParentAliases("table").contains("all"));


### PR DESCRIPTION
### Describe your changes:

Fixes the recurring **"Failed to find index `openmetadata_*_search_index`"** error caused by canonical search aliases going missing or pointing at nothing after a "Recreate Indexes" reindex.

#### Symptom

Users see, typically after the daily reindex:

```
Failed to find index openmetadata_table_search_index, openmetadata_topic_search_index,
openmetadata_dashboard_search_index, ...
```

The Elasticsearch/OpenSearch cluster is healthy and the data is intact — a `*_search_index_rebuild_<ts>` index exists with all documents, but the canonical alias (`*_search_index`) is attached to **nothing**. It is intermittent: re-running "Recreate Indexes" *sometimes* fixes it, and the only consistent manual workaround is to repoint the alias at the live `_rebuild_*` index by hand.

#### Root cause

The zero-downtime recreate flow builds `*_rebuild_<ts>` and then swaps the canonical alias onto it. On a **fresh install** (and after any prior orphaning), the canonical name `table_search_index` exists as a **concrete index**, not an alias — and OS/ES forbid an alias sharing a name with an existing index. So the handler did **two separate cluster operations**:

```java
searchClient.deleteIndexWithBackoff(canonicalIndex);   // 1) delete the concrete index
...
searchClient.swapAliases(oldIndices, stagedIndex, aliases); // 2) add the alias (separate request)
```

If step 2 fails or is interrupted between the two — e.g. the index delete hasn't fully propagated and ES/OS still rejects the alias-add with *"an index exists with the same name as the alias"* — the concrete index is gone, the alias is not attached, and the canonical name resolves to nothing → **orphan**. Because it's a propagation race it's intermittent, and `createMissingIndexes()` (run on every server boot) recreates the canonical as a concrete index again, re-arming the same window each cycle.

Two secondary issues made this worse / harder to reason about:
1. If the alias set ever resolved empty, the swap was skipped **but the old index was still deleted**, orphaning the alias.
2. `finalizeReindex` read the alias set off the live cluster (`getAliases(activeIndexName)`), which is non-deterministic (propagates stray aliases), adds a round-trip, and diverged from the distributed promotion path that already derived aliases from `indexMapping.json`.

#### Changes

1. **Atomic concrete-index removal during the swap.** Added an overload `swapAliases(oldIndices, newIndex, aliases, indicesToRemove)` that emits a `remove_index` action (ES with `mustExist(false)`) **in the same `updateAliases` request** as the alias add. The concrete canonical index is now deleted and the alias attached in one atomic operation — so a failure is a no-op (the concrete index and its live aliases survive and the reindex simply retries) instead of an orphan. The old 3-arg signature is kept as a default delegating with an empty removal set. `DefaultRecreateHandler` no longer calls `deleteIndexWithBackoff(canonicalIndex)` before the swap; it uses `resolveCanonicalRemoval(...)` to decide what to hand to the atomic swap.

2. **Never delete the old index when no aliases resolve.** `finalizeReindex` / `promoteEntityIndex` now abort (`abortPromotionWithoutAliases`) and record a promotion failure if the alias set comes up empty — the old serving index is left intact for a retry instead of being deleted into a void.

3. **Aliases come solely from `indexMapping.json`.** Removed the `getAliases(activeIndexName)` cluster read. Both the recreate and finalize paths now derive the set via the single `getAliasesFromMapping` helper (`{ parent aliases, short alias, raw index name }`), matching what `promoteEntityIndex` already did. The set is deterministic and the two promotion paths are unified.

#
### Type of change:
- [x] Bug fix

#
### High-level design:

- `IndexManagementClient`: new atomic `swapAliases(..., indicesToRemove)`; old 3-arg is now a `default` delegating with `Set.of()`.
- `ElasticSearchIndexManager` / `OpenSearchIndexManager`: build a single `UpdateAliasesRequest` containing `remove` (alias from old indices) + `remove_index` (concrete) + `add` (alias to staged) actions.
- `ElasticSearchClient` / `OpenSearchClient`: delegate the 4-arg overload to their managers.
- `DefaultRecreateHandler`:
  - `resolveCanonicalRemoval(...)` — returns the concrete canonical index (if any) to remove atomically and prunes the alias name from the delete set.
  - `abortPromotionWithoutAliases(...)` — guards the empty-alias case without deleting the old index.
  - `recreateIndexFromMapping` / `finalizeReindex` derive aliases via `getAliasesFromMapping`; no cluster read.

#
### Test plan:

Added/updated unit tests in `DefaultRecreateHandlerTest` (all 33 pass):
- `testFinalizeReindexRemovesConcreteCanonicalAtomically` — the concrete canonical is removed inside the atomic swap, never via a separate `deleteIndexWithBackoff`.
- `testFinalizeReindexFailedSwapDoesNotOrphanConcreteCanonical` — on a failed atomic swap the concrete index and its aliases survive (no orphan). This is the regression guard for the reported bug.
- `testPromoteEntityIndexDoesNotOrphanAliasWhenMappingHasNoAliases` / `testFinalizeReindexDoesNotOrphanAliasWhenNoAliasesResolved` — empty alias set never deletes the old serving index.
- `testRecreateIndexFromMappingUsesAliasTargetAsActiveIndex` — asserts `verify(never()).getAliases(...)`; aliases are derived from the mapping only.

The orphan was reproduced deterministically against the pre-fix code (concrete canonical + forced swap failure → concrete deleted, alias resolves to nothing) and confirmed gone after the fix.

#
### UI changes:

Not applicable.

#
### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have added tests (unit) and listed them above.
- [x] I have added a test that covers the exact scenario we are fixing.