### PR TITLE
fix(scim): let the SCIM bot update displayName via per-entity PUT

### DIFF
--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/BaseEntityIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/BaseEntityIT.java
@@ -24,6 +24,7 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.openmetadata.it.auth.JwtAuthProvider;
 import org.openmetadata.it.bootstrap.SharedEntities;
 import org.openmetadata.it.util.BulkApi;
 import org.openmetadata.it.util.EntityValidation;
@@ -32,8 +33,19 @@ import org.openmetadata.it.util.TestNamespace;
 import org.openmetadata.it.util.TestNamespaceExtension;
 import org.openmetadata.it.util.UpdateType;
 import org.openmetadata.schema.EntityInterface;
+import org.openmetadata.schema.api.policies.CreatePolicy;
+import org.openmetadata.schema.api.teams.CreateRole;
+import org.openmetadata.schema.api.teams.CreateUser;
+import org.openmetadata.schema.auth.JWTAuthMechanism;
+import org.openmetadata.schema.auth.JWTTokenExpiry;
+import org.openmetadata.schema.entity.policies.Policy;
+import org.openmetadata.schema.entity.policies.accessControl.Rule;
+import org.openmetadata.schema.entity.teams.AuthenticationMechanism;
+import org.openmetadata.schema.entity.teams.Role;
+import org.openmetadata.schema.entity.teams.User;
 import org.openmetadata.schema.type.ApiStatus;
 import org.openmetadata.schema.type.ChangeDescription;
+import org.openmetadata.schema.type.MetadataOperation;
 import org.openmetadata.schema.type.TagLabel;
 import org.openmetadata.schema.type.api.BulkOperationResult;
 import org.openmetadata.schema.type.api.BulkResponse;
@@ -43,6 +55,9 @@ import org.openmetadata.sdk.client.OpenMetadataClient;
 import org.openmetadata.sdk.exceptions.InvalidRequestException;
 import org.openmetadata.sdk.fluent.Users;
 import org.openmetadata.sdk.network.HttpMethod;
+import org.openmetadata.sdk.services.policies.PolicyService;
+import org.openmetadata.sdk.services.teams.RoleService;
+import org.openmetadata.sdk.services.teams.UserService;
 import org.openmetadata.service.util.TestUtils;
 
 /**
@@ -4845,31 +4860,23 @@ public abstract class BaseEntityIT<T extends EntityInterface, K> {
   }
 
   /**
-   * Test: A bot's single-entity PUT (createOrUpdate) MUST be able to update {@code displayName}.
-   *
-   * <p>This is the path the SCIM bot uses to sync identity attributes: it applies the change to the
-   * entity and calls the repository's createOrUpdate (PUT) as a bot, bypassing the per-entity
-   * authorization (it is authorized at the SCIM layer instead). A single-entity PUT is an explicit
-   * write that should apply, so the bot-preservation guard in {@code EntityRepository#updateDisplayName}
-   * must NOT revert it.
-   *
-   * <p>Regression: PR #28155 added an in-code guard that reverted displayName for ANY bot PUT, which
-   * silently broke SCIM displayName sync - the SCIM PATCH returned 200 but the value never changed.
-   * The fix scopes that guard to the bulk path; the per-entity path is governed by policy
-   * ({@code DisplayName-Deny} denies the ingestion bot on PATCH, while the SCIM bot's policy allows
-   * it). Contrast with {@link #test_bulkUpdate_bot_preservesUserDisplayName}: the same bot going
-   * through the bulk endpoint MUST instead preserve the user value.
+   * Test: A bot whose policy DENIES {@code EditDisplayName} (the ingestion bot, via
+   * {@code IngestionBotPolicy}/{@code DefaultBotPolicy}) must NOT overwrite a user-curated
+   * {@code displayName} through a single-entity PUT.
    *
    * <p>A per-entity PUT on an existing entity authorizes with the coarse {@code EDIT_ALL} operation,
-   * which does not intersect the field-level {@code EditDisplayName} deny - so the ingestion bot used
-   * here reaches the repository guard exactly as the SCIM bot does.
+   * which does not intersect the field-level {@code EditDisplayName} deny - so the bot reaches the
+   * repository, where {@code EntityRepository#updateDisplayName} re-applies that field-level deny and
+   * preserves the user value. This is the per-entity counterpart of
+   * {@link #test_bulkUpdate_bot_preservesUserDisplayName}, and the regression guard for the bug where
+   * scoping the in-code check to the bulk path let any bot clobber displayName via per-entity PUT.
    */
   @Test
-  void test_singleEntityPut_bot_canUpdateDisplayName(TestNamespace ns) {
+  void test_singleEntityPut_bot_preservesUserDisplayName(TestNamespace ns) {
     if (!supportsBulkAPI) return;
     if (!hasField("setDisplayName", String.class)) return;
 
-    K request = createRequest(ns.prefix("put_botdn_"), ns);
+    K request = createRequest(ns.prefix("put_denydn_"), ns);
     T created = createEntity(request);
     String fqn = created.getFullyQualifiedName();
 
@@ -4878,18 +4885,65 @@ public abstract class BaseEntityIT<T extends EntityInterface, K> {
     entity.setDisplayName(userDisplayName);
     patchEntity(entity.getId().toString(), entity);
 
-    String botDisplayName = "SCIM Bot Updated Display Name";
-    invoke(request, "setDisplayName", String.class, botDisplayName);
-    HttpResponse<String> response = putAsBot(request);
+    invoke(request, "setDisplayName", String.class, "Bot attempted to overwrite");
+    HttpResponse<String> response = putAs(request, BulkApi.botToken());
     assertTrue(
         response.statusCode() == 200 || response.statusCode() == 201,
-        "Bot single-entity PUT should succeed: " + response.statusCode() + " " + response.body());
+        "Bot single-entity PUT should be authorized via EDIT_ALL: "
+            + response.statusCode()
+            + " "
+            + response.body());
+
+    T result = getEntityByName(fqn);
+    assertEquals(
+        userDisplayName,
+        result.getDisplayName(),
+        "Ingestion bot (EditDisplayName denied) must NOT overwrite user displayName via PUT: "
+            + fqn);
+  }
+
+  /**
+   * Test: A bot whose policy does NOT deny {@code EditDisplayName} (modeling the SCIM bot, whose
+   * {@code ScimBotPolicy} carries no {@code DisplayName-Deny}) CAN update {@code displayName} through
+   * a single-entity PUT - the behavior PR #28155 inadvertently broke for all bots and this PR
+   * restores for policy-allowed bots.
+   *
+   * <p>The real SCIM bot reaches {@code EntityRepository#updateDisplayName} through the SCIM endpoint
+   * (which bypasses entity-level authorization and is enterprise-only); this test drives the same
+   * repository code path with an equivalent bot - {@code isBot=true} with a policy that allows
+   * {@code EditAll} and does not deny {@code EditDisplayName}. Contrast with
+   * {@link #test_singleEntityPut_bot_preservesUserDisplayName}: the difference is purely the bot's
+   * policy, which is exactly what the in-code guard now keys on.
+   */
+  @Test
+  void test_singleEntityPut_displayNameAllowedBot_updatesDisplayName(TestNamespace ns) {
+    if (!supportsBulkAPI) return;
+    if (!hasField("setDisplayName", String.class)) return;
+
+    K request = createRequest(ns.prefix("put_allowdn_"), ns);
+    T created = createEntity(request);
+    String fqn = created.getFullyQualifiedName();
+
+    String userDisplayName = "User Curated Display Name";
+    T entity = getEntityByName(fqn);
+    entity.setDisplayName(userDisplayName);
+    patchEntity(entity.getId().toString(), entity);
+
+    String botDisplayName = "SCIM-like Bot Display Name";
+    invoke(request, "setDisplayName", String.class, botDisplayName);
+    HttpResponse<String> response = putAs(request, displayNameAllowedBotToken());
+    assertTrue(
+        response.statusCode() == 200 || response.statusCode() == 201,
+        "Allowed-bot single-entity PUT should succeed: "
+            + response.statusCode()
+            + " "
+            + response.body());
 
     T result = getEntityByName(fqn);
     assertEquals(
         botDisplayName,
         result.getDisplayName(),
-        "Bot single-entity PUT must update displayName (SCIM sync path): " + fqn);
+        "Bot allowed EditDisplayName (SCIM-like) must update displayName via PUT: " + fqn);
   }
 
   /**
@@ -5013,11 +5067,11 @@ public abstract class BaseEntityIT<T extends EntityInterface, K> {
   }
 
   /**
-   * Single-entity createOrUpdate (PUT) over raw HTTP using the ingestion-bot JWT. Models the SCIM
-   * bot's per-entity write - the SDK fluent clients always authenticate as admin, so the raw call is
-   * how a test drives a single-entity PUT as a bot.
+   * Single-entity createOrUpdate (PUT) over raw HTTP using the given bearer token. The SDK fluent
+   * clients always authenticate as admin, so the raw call is how a test drives a per-entity PUT as a
+   * specific bot identity.
    */
-  protected HttpResponse<String> putAsBot(K request) {
+  protected HttpResponse<String> putAs(K request, String token) {
     try {
       String url = SdkClients.getServerUrl() + getResourcePath();
       if (url.endsWith("/")) {
@@ -5026,14 +5080,97 @@ public abstract class BaseEntityIT<T extends EntityInterface, K> {
       java.net.http.HttpRequest httpRequest =
           java.net.http.HttpRequest.newBuilder()
               .uri(java.net.URI.create(url))
-              .header("Authorization", "Bearer " + BulkApi.botToken())
+              .header("Authorization", "Bearer " + token)
               .header("Content-Type", "application/json")
               .PUT(java.net.http.HttpRequest.BodyPublishers.ofString(JsonUtils.pojoToJson(request)))
               .build();
       return java.net.http.HttpClient.newHttpClient()
           .send(httpRequest, HttpResponse.BodyHandlers.ofString());
     } catch (Exception e) {
-      throw new RuntimeException("Single-entity PUT as bot failed: " + e.getMessage(), e);
+      throw new RuntimeException("Single-entity PUT failed: " + e.getMessage(), e);
+    }
+  }
+
+  // Lazily provisioned (once per session) bot whose policy allows EditAll and does NOT deny
+  // EditDisplayName, modeling the SCIM bot. API-created bots are force-assigned DefaultBotRole
+  // (which denies EditDisplayName), so that role is stripped via a raw JSON-Patch after creation.
+  private static volatile String displayNameAllowedBotToken;
+
+  protected static synchronized String displayNameAllowedBotToken() {
+    if (displayNameAllowedBotToken == null) {
+      displayNameAllowedBotToken = provisionDisplayNameAllowedBot();
+    }
+    return displayNameAllowedBotToken;
+  }
+
+  private static String provisionDisplayNameAllowedBot() {
+    try {
+      OpenMetadataClient admin = SdkClients.adminClient();
+      String suffix = UUID.randomUUID().toString().substring(0, 8);
+      Policy policy =
+          new PolicyService(admin.getHttpClient())
+              .create(
+                  new CreatePolicy()
+                      .withName("displayNameAllowedBotPolicy_" + suffix)
+                      .withRules(
+                          List.of(
+                              new Rule()
+                                  .withName("AllowEditAll")
+                                  .withResources(List.of("All"))
+                                  .withOperations(
+                                      List.of(
+                                          MetadataOperation.EDIT_ALL,
+                                          MetadataOperation.VIEW_ALL,
+                                          MetadataOperation.CREATE))
+                                  .withEffect(Rule.Effect.ALLOW))));
+      Role role =
+          new RoleService(admin.getHttpClient())
+              .create(
+                  new CreateRole()
+                      .withName("displayNameAllowedBotRole_" + suffix)
+                      .withPolicies(List.of(policy.getName())));
+      String email = "displayname-allowed-bot-" + suffix + "@open-metadata.org";
+      User bot =
+          new UserService(admin.getHttpClient())
+              .create(
+                  new CreateUser()
+                      .withName("displayname-allowed-bot-" + suffix)
+                      .withEmail(email)
+                      .withIsBot(true)
+                      .withAuthenticationMechanism(
+                          new AuthenticationMechanism()
+                              .withAuthType(AuthenticationMechanism.AuthType.JWT)
+                              .withConfig(
+                                  new JWTAuthMechanism()
+                                      .withJWTTokenExpiry(JWTTokenExpiry.Unlimited)))
+                      .withRoles(List.of(role.getId())));
+      stripDefaultBotRole(bot.getId().toString(), role.getId().toString());
+      return JwtAuthProvider.tokenFor(email, email, new String[] {role.getName()}, 86400);
+    } catch (Exception e) {
+      throw new RuntimeException(
+          "Failed to provision displayName-allowed bot: " + e.getMessage(), e);
+    }
+  }
+
+  // Replace the bot's roles (auto-assigned DefaultBotRole + the custom role) with ONLY the custom
+  // role via a raw JSON-Patch, so its effective policy no longer denies EditDisplayName.
+  private static void stripDefaultBotRole(String botId, String roleId) throws Exception {
+    String patch =
+        "[{\"op\":\"replace\",\"path\":\"/roles\",\"value\":[{\"id\":\""
+            + roleId
+            + "\",\"type\":\"role\"}]}]";
+    java.net.http.HttpRequest req =
+        java.net.http.HttpRequest.newBuilder()
+            .uri(java.net.URI.create(SdkClients.getServerUrl() + "/v1/users/" + botId))
+            .header("Authorization", "Bearer " + SdkClients.getAdminToken())
+            .header("Content-Type", "application/json-patch+json")
+            .method("PATCH", java.net.http.HttpRequest.BodyPublishers.ofString(patch))
+            .build();
+    HttpResponse<String> resp =
+        java.net.http.HttpClient.newHttpClient().send(req, HttpResponse.BodyHandlers.ofString());
+    if (resp.statusCode() != 200) {
+      throw new IllegalStateException(
+          "Failed to strip DefaultBotRole: " + resp.statusCode() + " " + resp.body());
     }
   }
 

--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/BaseEntityIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/BaseEntityIT.java
@@ -4845,6 +4845,54 @@ public abstract class BaseEntityIT<T extends EntityInterface, K> {
   }
 
   /**
+   * Test: A bot's single-entity PUT (createOrUpdate) MUST be able to update {@code displayName}.
+   *
+   * <p>This is the path the SCIM bot uses to sync identity attributes: it applies the change to the
+   * entity and calls the repository's createOrUpdate (PUT) as a bot, bypassing the per-entity
+   * authorization (it is authorized at the SCIM layer instead). A single-entity PUT is an explicit
+   * write that should apply, so the bot-preservation guard in {@code EntityRepository#updateDisplayName}
+   * must NOT revert it.
+   *
+   * <p>Regression: PR #28155 added an in-code guard that reverted displayName for ANY bot PUT, which
+   * silently broke SCIM displayName sync - the SCIM PATCH returned 200 but the value never changed.
+   * The fix scopes that guard to the bulk path; the per-entity path is governed by policy
+   * ({@code DisplayName-Deny} denies the ingestion bot on PATCH, while the SCIM bot's policy allows
+   * it). Contrast with {@link #test_bulkUpdate_bot_preservesUserDisplayName}: the same bot going
+   * through the bulk endpoint MUST instead preserve the user value.
+   *
+   * <p>A per-entity PUT on an existing entity authorizes with the coarse {@code EDIT_ALL} operation,
+   * which does not intersect the field-level {@code EditDisplayName} deny - so the ingestion bot used
+   * here reaches the repository guard exactly as the SCIM bot does.
+   */
+  @Test
+  void test_singleEntityPut_bot_canUpdateDisplayName(TestNamespace ns) {
+    if (!supportsBulkAPI) return;
+    if (!hasField("setDisplayName", String.class)) return;
+
+    K request = createRequest(ns.prefix("put_botdn_"), ns);
+    T created = createEntity(request);
+    String fqn = created.getFullyQualifiedName();
+
+    String userDisplayName = "User Curated Display Name";
+    T entity = getEntityByName(fqn);
+    entity.setDisplayName(userDisplayName);
+    patchEntity(entity.getId().toString(), entity);
+
+    String botDisplayName = "SCIM Bot Updated Display Name";
+    invoke(request, "setDisplayName", String.class, botDisplayName);
+    HttpResponse<String> response = putAsBot(request);
+    assertTrue(
+        response.statusCode() == 200 || response.statusCode() == 201,
+        "Bot single-entity PUT should succeed: " + response.statusCode() + " " + response.body());
+
+    T result = getEntityByName(fqn);
+    assertEquals(
+        botDisplayName,
+        result.getDisplayName(),
+        "Bot single-entity PUT must update displayName (SCIM sync path): " + fqn);
+  }
+
+  /**
    * Test: A bot bulk-update merges new tags with existing user-added tags (PUT semantics).
    *
    * <p>Legacy connector behavior with {@code overrideMetadata=true} permitted REPLACE operations
@@ -4961,6 +5009,31 @@ public abstract class BaseEntityIT<T extends EntityInterface, K> {
       return BulkApi.upsert(getBulkCollection(), requests, overrideMetadata, BulkApi.botToken());
     } catch (Exception e) {
       throw new RuntimeException("Bulk upsert as bot failed: " + e.getMessage(), e);
+    }
+  }
+
+  /**
+   * Single-entity createOrUpdate (PUT) over raw HTTP using the ingestion-bot JWT. Models the SCIM
+   * bot's per-entity write - the SDK fluent clients always authenticate as admin, so the raw call is
+   * how a test drives a single-entity PUT as a bot.
+   */
+  protected HttpResponse<String> putAsBot(K request) {
+    try {
+      String url = SdkClients.getServerUrl() + getResourcePath();
+      if (url.endsWith("/")) {
+        url = url.substring(0, url.length() - 1);
+      }
+      java.net.http.HttpRequest httpRequest =
+          java.net.http.HttpRequest.newBuilder()
+              .uri(java.net.URI.create(url))
+              .header("Authorization", "Bearer " + BulkApi.botToken())
+              .header("Content-Type", "application/json")
+              .PUT(java.net.http.HttpRequest.BodyPublishers.ofString(JsonUtils.pojoToJson(request)))
+              .build();
+      return java.net.http.HttpClient.newHttpClient()
+          .send(httpRequest, HttpResponse.BodyHandlers.ofString());
+    } catch (Exception e) {
+      throw new RuntimeException("Single-entity PUT as bot failed: " + e.getMessage(), e);
     }
   }
 

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/EntityRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/EntityRepository.java
@@ -7644,6 +7644,13 @@ public abstract class EntityRepository<T extends EntityInterface> {
     // When set (bulk path with overrideMetadata=true), bot updates are allowed to overwrite
     // user-curated metadata that PUT-as-bot would otherwise preserve (description, displayName).
     @Setter private boolean overrideMetadata;
+
+    // Set only on the bulk ingestion path. The bulk endpoint authorizes with the coarse EDIT_ALL
+    // operation, which does not intersect the field-level EditDisplayName policy deny, so it needs
+    // the in-code displayName guard to stand in for the bypassed policy. A non-bulk bot PUT (for
+    // example the SCIM bot syncing identity attributes through the repository) is governed by the
+    // policy layer instead and must not be caught by that guard. See updateDisplayName().
+    @Setter private boolean bulkOperation;
     private final List<Runnable> deferredReactOperations = new ArrayList<>();
     private boolean deferredReactExecuted;
 
@@ -8152,16 +8159,21 @@ public abstract class EntityRepository<T extends EntityInterface> {
     }
 
     private void updateDisplayName() {
-      if (operation.isPut()
-          && !nullOrEmpty(original.getDisplayName())
-          && updatedByBot()
-          && !overrideMetadata) {
-        // Mirror updateDescription: a bot PUT (for example bulk ingestion) must not clobber a
-        // user-curated displayName. Use a PATCH or overrideMetadata=true to change it.
+      // A bot bulk re-ingestion must not clobber a user-curated displayName. This guard is scoped
+      // to the bulk path on purpose: the per-entity PUT/PATCH path is governed by policy
+      // (DisplayName-Deny), so a bot the policy allows - for example the SCIM bot syncing identity
+      // attributes through the repository - can still update displayName. On the bulk path,
+      // overrideMetadata=true force-syncs it.
+      boolean preserveUserDisplayName =
+          bulkOperation
+              && !nullOrEmpty(original.getDisplayName())
+              && updatedByBot()
+              && !overrideMetadata;
+      if (preserveUserDisplayName) {
         updated.setDisplayName(original.getDisplayName());
-        return;
+      } else {
+        recordChange(FIELD_DISPLAY_NAME, original.getDisplayName(), updated.getDisplayName());
       }
-      recordChange(FIELD_DISPLAY_NAME, original.getDisplayName(), updated.getDisplayName());
     }
 
     private void updateEntityStatus(boolean consolidatingChanges) {
@@ -11540,6 +11552,7 @@ public abstract class EntityRepository<T extends EntityInterface> {
 
           EntityUpdater updater = getUpdater(original, entity, Operation.PUT, null);
           updater.setOverrideMetadata(overrideMetadata);
+          updater.setBulkOperation(true);
           updater.updateWithDeferredStore();
           updaters.add(updater);
         } catch (Exception e) {

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/EntityRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/EntityRepository.java
@@ -196,8 +196,11 @@ import org.openmetadata.schema.type.EventType;
 import org.openmetadata.schema.type.FieldChange;
 import org.openmetadata.schema.type.Include;
 import org.openmetadata.schema.type.LifeCycle;
+import org.openmetadata.schema.type.MetadataOperation;
+import org.openmetadata.schema.type.Permission;
 import org.openmetadata.schema.type.ProviderType;
 import org.openmetadata.schema.type.Relationship;
+import org.openmetadata.schema.type.ResourcePermission;
 import org.openmetadata.schema.type.TagLabel;
 import org.openmetadata.schema.type.TagLabelMetadata;
 import org.openmetadata.schema.type.TaskType;
@@ -252,6 +255,7 @@ import org.openmetadata.service.search.SearchRepository;
 import org.openmetadata.service.search.SearchResultListMapper;
 import org.openmetadata.service.search.SearchSortFilter;
 import org.openmetadata.service.security.AuthorizationException;
+import org.openmetadata.service.security.policyevaluator.PolicyEvaluator;
 import org.openmetadata.service.security.policyevaluator.SubjectContext;
 import org.openmetadata.service.util.EntityETag;
 import org.openmetadata.service.util.EntityFieldUtils;
@@ -7644,13 +7648,6 @@ public abstract class EntityRepository<T extends EntityInterface> {
     // When set (bulk path with overrideMetadata=true), bot updates are allowed to overwrite
     // user-curated metadata that PUT-as-bot would otherwise preserve (description, displayName).
     @Setter private boolean overrideMetadata;
-
-    // Set only on the bulk ingestion path. The bulk endpoint authorizes with the coarse EDIT_ALL
-    // operation, which does not intersect the field-level EditDisplayName policy deny, so it needs
-    // the in-code displayName guard to stand in for the bypassed policy. A non-bulk bot PUT (for
-    // example the SCIM bot syncing identity attributes through the repository) is governed by the
-    // policy layer instead and must not be caught by that guard. See updateDisplayName().
-    @Setter private boolean bulkOperation;
     private final List<Runnable> deferredReactOperations = new ArrayList<>();
     private boolean deferredReactExecuted;
 
@@ -8159,16 +8156,18 @@ public abstract class EntityRepository<T extends EntityInterface> {
     }
 
     private void updateDisplayName() {
-      // A bot bulk re-ingestion must not clobber a user-curated displayName. This guard is scoped
-      // to the bulk path on purpose: the per-entity PUT/PATCH path is governed by policy
-      // (DisplayName-Deny), so a bot the policy allows - for example the SCIM bot syncing identity
-      // attributes through the repository - can still update displayName. On the bulk path,
-      // overrideMetadata=true force-syncs it.
+      // A bot whose policy denies EditDisplayName (e.g. the ingestion bot via DefaultBotPolicy /
+      // IngestionBotPolicy) must not clobber a user-curated displayName. A PUT or bulk update
+      // authorizes with the coarse EDIT_ALL operation, which does not intersect that field-level
+      // deny, so re-apply it here. Bots the policy allows - for example the SCIM bot syncing
+      // identity attributes through the repository - fall through and update it. A bulk force-sync
+      // (overrideMetadata=true) also bypasses this guard.
       boolean preserveUserDisplayName =
-          bulkOperation
+          updatedByBot()
               && !nullOrEmpty(original.getDisplayName())
-              && updatedByBot()
-              && !overrideMetadata;
+              && !overrideMetadata
+              && !Objects.equals(original.getDisplayName(), updated.getDisplayName())
+              && updatingBotDeniedOperation(MetadataOperation.EDIT_DISPLAY_NAME);
       if (preserveUserDisplayName) {
         updated.setDisplayName(original.getDisplayName());
       } else {
@@ -9382,6 +9381,27 @@ public abstract class EntityRepository<T extends EntityInterface> {
 
     public final boolean updatedByBot() {
       return Boolean.TRUE.equals(updatingUser.getIsBot());
+    }
+
+    /**
+     * Whether the bot performing this update is denied {@code operation} by policy. A PUT or bulk
+     * update authorizes with the coarse EDIT_ALL operation, which does not intersect a field-level
+     * deny (e.g. DisplayName-Deny on the ingestion bot), so callers re-apply the field-level check
+     * here. Returns false for users the policy does not explicitly deny (including the SCIM bot).
+     */
+    private boolean updatingBotDeniedOperation(MetadataOperation operation) {
+      boolean denied = false;
+      if (updatingUser != null) {
+        SubjectContext subjectContext = SubjectContext.getSubjectContext(updatingUser.getName());
+        ResourcePermission permission = PolicyEvaluator.getPermission(subjectContext, entityType);
+        denied =
+            permission.getPermissions().stream()
+                .anyMatch(
+                    p ->
+                        operation.equals(p.getOperation())
+                            && Permission.Access.DENY.equals(p.getAccess()));
+      }
+      return denied;
     }
 
     @VisibleForTesting
@@ -11552,7 +11572,6 @@ public abstract class EntityRepository<T extends EntityInterface> {
 
           EntityUpdater updater = getUpdater(original, entity, Operation.PUT, null);
           updater.setOverrideMetadata(overrideMetadata);
-          updater.setBulkOperation(true);
           updater.updateWithDeferredStore();
           updaters.add(updater);
         } catch (Exception e) {


### PR DESCRIPTION
### Describe your changes:

Follow-up to #28155 (fixes a regression introduced there).

PR #28155 added an in-code guard to `EntityRepository.updateDisplayName()` that reverted `displayName` on **any** bot PUT, silently breaking SCIM displayName sync (the SCIM `PATCH` returned 200 but the value never changed). A PUT — per-entity or bulk — authorizes with the coarse `EDIT_ALL` operation, which does not intersect the field-level `EditDisplayName` policy deny, so an in-code guard is needed to re-apply that deny; but it must mirror the policy rather than block every bot. This PR makes the guard **policy-aware**: `updateDisplayName()` preserves a user-curated `displayName` only when the updating bot is actually DENIED `EditDisplayName` by policy (e.g. the ingestion bot via `DefaultBotPolicy`/`IngestionBotPolicy`, where DENY is sticky over `EditAll`); bots the policy allows — notably the SCIM bot (`ScimBotPolicy` has no `DisplayName-Deny`) — update it, and `overrideMetadata=true` still force-syncs on the bulk path. `updateDescription`/`updateOwners` are unchanged.

#
### Type of change:
- [x] Bug fix

#
### Tests:

#### Use cases covered
- An ingestion bot (policy denies `EditDisplayName`) cannot overwrite a user-curated `displayName` via a per-entity PUT **or** the bulk endpoint.
- A bot whose policy allows `EditAll` with no `DisplayName-Deny` (modeling the SCIM bot) updates `displayName` via a per-entity PUT.
- `overrideMetadata=true` still lets a bot force-sync `displayName` on the bulk endpoint.

#### Backend integration tests
- [x] Added in `openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/BaseEntityIT.java`:
  - `test_singleEntityPut_bot_preservesUserDisplayName` (ingestion bot → preserved)
  - `test_singleEntityPut_displayNameAllowedBot_updatesDisplayName` (policy-allowed, SCIM-like bot → updated)
  - existing `test_bulkUpdate_bot_preservesUserDisplayName` / `test_bulkUpdate_overrideMetadata_canOverrideUserDisplayName` continue to pass

#### Ingestion integration tests
- [x] Not applicable (no ingestion changes).

#### Playwright (UI) tests
- [x] Not applicable (no UI changes).

#### Manual testing performed
Ran the four displayName tests against the real testcontainers stack on `DatabaseResourceIT` — all pass; the per-entity preservation test is RED before the fix and GREEN after.

#
### UI screen recording / screenshots:

Not applicable.

#
### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have added tests (unit / integration / Playwright as applicable) and listed them above.
- [x] I have added a test that covers the exact scenario we are fixing.
