### PR TITLE
Stabilize REST AutoPilot OpenAPI fixture

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/support/entity/ingestion/ApiIngestionClass.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/support/entity/ingestion/ApiIngestionClass.ts
@@ -52,7 +52,8 @@ class ApiIngestionClass extends ServiceBaseClass {
   }
 
   async fillConnectionDetails(page: Page) {
-    const openAPISchemaURL = 'https://petstore3.swagger.io/api/v3/openapi.json';
+    const openAPISchemaURL =
+      'https://sandbox-beta.open-metadata.org/swagger.json';
 
     await page
       .locator('#root\\/openAPISchemaConnection\\/openAPISchemaURL')


### PR DESCRIPTION
## Summary
- Update the REST AutoPilot Playwright fixture to use the OpenMetadata-hosted Swagger schema URL already used by nearby API entity tests.
- Avoid relying on the public Petstore OpenAPI endpoint for the REST service connection precondition.

## Root Cause
The PostgreSQL Playwright shard failed while creating the REST AutoPilot service because the connection test rendered a failure state instead of a success or warning badge. The test was using `https://petstore3.swagger.io/api/v3/openapi.json`, making the CI path dependent on a third-party live endpoint and its validation behavior from GitHub Actions.

## Validation
- Ran UI checkstyle sequence on `playwright/support/entity/ingestion/ApiIngestionClass.ts`:
  - `organize-imports-cli`
  - `eslint --fix`
  - `prettier --write`
- Ran `git diff --check`
- Confirmed `https://sandbox-beta.open-metadata.org/swagger.json` returns HTTP 200
