### PR TITLE
feat(ui): extract EntityVersion/Diff pure utils and lazy-load version components

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/KnowledgeCenter/KnowledgePageVersion/KnowledgePageVersion.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/KnowledgeCenter/KnowledgePageVersion/KnowledgePageVersion.tsx
@@ -28,15 +28,17 @@ import { TagSource } from '../../../generated/type/tagLabel';
 import { KnowledgePage } from '../../../interface/knowledge-center.interface';
 import contextCenterClassBase from '../../../utils/ContextCenterClassBase';
 import { formatDate } from '../../../utils/date-time/DateTimeUtils';
-import { getEntityName } from '../../../utils/EntityUtils';
 import {
   getChangedEntityNewValue,
   getChangedEntityOldValue,
-  getCommonExtraInfoForVersionDetails,
   getDiffByFieldName,
+} from '../../../utils/EntityDiffPureUtils';
+import { getEntityName } from '../../../utils/EntityUtils';
+import {
+  getCommonExtraInfoForVersionDetails,
   getEntityVersionByField,
   getEntityVersionTags,
-} from '../../../utils/EntityVersionUtils';
+} from '../../../utils/EntityVersionUtilsPure';
 import { VersionEntityTypes } from '../../../utils/EntityVersionUtils.interface';
 import { getFrontEndFormat } from '../../../utils/FeedUtils';
 import i18n from '../../../utils/i18next/LocalUtil';

--- a/openmetadata-ui/src/main/resources/ui/src/components/KnowledgeCenter/KnowledgePageVersion/KnowledgePageVersion.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/KnowledgeCenter/KnowledgePageVersion/KnowledgePageVersion.tsx
@@ -34,12 +34,12 @@ import {
   getDiffByFieldName,
 } from '../../../utils/EntityDiffPureUtils';
 import { getEntityName } from '../../../utils/EntityUtils';
+import { VersionEntityTypes } from '../../../utils/EntityVersionUtils.interface';
 import {
   getCommonExtraInfoForVersionDetails,
   getEntityVersionByField,
   getEntityVersionTags,
 } from '../../../utils/EntityVersionUtilsPure';
-import { VersionEntityTypes } from '../../../utils/EntityVersionUtils.interface';
 import { getFrontEndFormat } from '../../../utils/FeedUtils';
 import i18n from '../../../utils/i18next/LocalUtil';
 import { stringToHTML } from '../../../utils/StringUtils';

--- a/openmetadata-ui/src/main/resources/ui/src/components/KnowledgeCenter/KnowledgePageVersion/KnowledgePageVersion.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/KnowledgeCenter/KnowledgePageVersion/KnowledgePageVersion.tsx
@@ -15,7 +15,7 @@ import { Button, Col, Row, Space, Typography } from 'antd';
 import classNames from 'classnames';
 import { diffWordsWithSpace } from 'diff';
 import { isEmpty, map, toString } from 'lodash';
-import { FC, useMemo } from 'react';
+import { useMemo, type FC } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { ReactComponent as VersionIcon } from '../../../assets/svg/ic-version.svg';
 import BlockEditor from '../../../components/BlockEditor/BlockEditor';
@@ -25,7 +25,7 @@ import TagsContainerV2 from '../../../components/Tag/TagsContainerV2/TagsContain
 import { LayoutType } from '../../../components/Tag/TagsViewer/TagsViewer.interface';
 import { EntityField } from '../../../constants/Feeds.constants';
 import { TagSource } from '../../../generated/type/tagLabel';
-import { KnowledgePage } from '../../../interface/knowledge-center.interface';
+import type { KnowledgePage } from '../../../interface/knowledge-center.interface';
 import contextCenterClassBase from '../../../utils/ContextCenterClassBase';
 import { formatDate } from '../../../utils/date-time/DateTimeUtils';
 import {
@@ -34,7 +34,7 @@ import {
   getDiffByFieldName,
 } from '../../../utils/EntityDiffPureUtils';
 import { getEntityName } from '../../../utils/EntityUtils';
-import { VersionEntityTypes } from '../../../utils/EntityVersionUtils.interface';
+import type { VersionEntityTypes } from '../../../utils/EntityVersionUtils.interface';
 import {
   getCommonExtraInfoForVersionDetails,
   getEntityVersionByField,

--- a/openmetadata-ui/src/main/resources/ui/src/pages/EntityVersionPage/EntityVersionPage.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/EntityVersionPage/EntityVersionPage.component.tsx
@@ -13,12 +13,12 @@
 
 import { isEmpty } from 'lodash';
 import {
-  FunctionComponent,
   Suspense,
   useCallback,
   useEffect,
   useMemo,
   useState,
+  type FunctionComponent,
 } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
@@ -26,31 +26,31 @@ import ErrorPlaceHolder from '../../components/common/ErrorWithPlaceholder/Error
 import Loader from '../../components/common/Loader/Loader';
 import PageLayoutV1 from '../../components/PageLayoutV1/PageLayoutV1';
 import { usePermissionProvider } from '../../context/PermissionProvider/PermissionProvider';
-import {
+import type {
   OperationPermission,
   ResourceEntity,
 } from '../../context/PermissionProvider/PermissionProvider.interface';
 import { ERROR_PLACEHOLDER_TYPE } from '../../enums/common.enum';
 import { EntityTabs, EntityType } from '../../enums/entity.enum';
-import { APIEndpoint } from '../../generated/entity/data/apiEndpoint';
-import { Chart } from '../../generated/entity/data/chart';
-import { Container } from '../../generated/entity/data/container';
-import { Dashboard } from '../../generated/entity/data/dashboard';
-import { DashboardDataModel } from '../../generated/entity/data/dashboardDataModel';
-import { Directory } from '../../generated/entity/data/directory';
-import { File } from '../../generated/entity/data/file';
-import { Metric } from '../../generated/entity/data/metric';
-import { Mlmodel } from '../../generated/entity/data/mlmodel';
-import { Pipeline } from '../../generated/entity/data/pipeline';
-import { SearchIndex } from '../../generated/entity/data/searchIndex';
-import { Spreadsheet } from '../../generated/entity/data/spreadsheet';
-import { StoredProcedure } from '../../generated/entity/data/storedProcedure';
-import { Table } from '../../generated/entity/data/table';
-import { Topic } from '../../generated/entity/data/topic';
-import { Worksheet } from '../../generated/entity/data/worksheet';
-import { EntityHistory } from '../../generated/type/entityHistory';
+import type { APIEndpoint } from '../../generated/entity/data/apiEndpoint';
+import type { Chart } from '../../generated/entity/data/chart';
+import type { Container } from '../../generated/entity/data/container';
+import type { Dashboard } from '../../generated/entity/data/dashboard';
+import type { DashboardDataModel } from '../../generated/entity/data/dashboardDataModel';
+import type { Directory } from '../../generated/entity/data/directory';
+import type { File } from '../../generated/entity/data/file';
+import type { Metric } from '../../generated/entity/data/metric';
+import type { Mlmodel } from '../../generated/entity/data/mlmodel';
+import type { Pipeline } from '../../generated/entity/data/pipeline';
+import type { SearchIndex } from '../../generated/entity/data/searchIndex';
+import type { Spreadsheet } from '../../generated/entity/data/spreadsheet';
+import type { StoredProcedure } from '../../generated/entity/data/storedProcedure';
+import type { Table } from '../../generated/entity/data/table';
+import type { Topic } from '../../generated/entity/data/topic';
+import type { Worksheet } from '../../generated/entity/data/worksheet';
+import type { EntityHistory } from '../../generated/type/entityHistory';
 import { Include } from '../../generated/type/include';
-import { TagLabel } from '../../generated/type/tagLabel';
+import type { TagLabel } from '../../generated/type/tagLabel';
 import { useFqn } from '../../hooks/useFqn';
 import {
   getApiEndPointByFQN,

--- a/openmetadata-ui/src/main/resources/ui/src/pages/EntityVersionPage/EntityVersionPage.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/EntityVersionPage/EntityVersionPage.component.tsx
@@ -14,6 +14,7 @@
 import { isEmpty } from 'lodash';
 import {
   FunctionComponent,
+  Suspense,
   useCallback,
   useEffect,
   useMemo,
@@ -21,26 +22,9 @@ import {
 } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
-import APIEndpointVersion from '../../components/APIEndpoint/APIEndpointVersion/APIEndpointVersion';
-import ChartVersion from '../../components/Chart/ChartVersion/ChartVersion.component';
 import ErrorPlaceHolder from '../../components/common/ErrorWithPlaceholder/ErrorPlaceHolder';
 import Loader from '../../components/common/Loader/Loader';
-import ContainerVersion from '../../components/Container/ContainerVersion/ContainerVersion.component';
-import DashboardVersion from '../../components/Dashboard/DashboardVersion/DashboardVersion.component';
-import DataModelVersion from '../../components/Dashboard/DataModel/DataModelVersion/DataModelVersion.component';
-import StoredProcedureVersion from '../../components/Database/StoredProcedureVersion/StoredProcedureVersion.component';
-import TableVersion from '../../components/Database/TableVersion/TableVersion.component';
-import DataProductsPage from '../../components/DataProducts/DataProductsPage/DataProductsPage.component';
-import DirectoryVersion from '../../components/DriveService/Directory/DirectoryVersion/DirectoryVersion';
-import FileVersion from '../../components/DriveService/File/FileVersion/FileVersion';
-import SpreadsheetVersion from '../../components/DriveService/Spreadsheet/SpreadsheetVersion/SpreadsheetVersion';
-import WorksheetVersion from '../../components/DriveService/Worksheet/WorksheetVersion/WorksheetVersion';
-import MetricVersion from '../../components/Metric/MetricVersion/MetricVersion';
-import MlModelVersion from '../../components/MlModel/MlModelVersion/MlModelVersion.component';
 import PageLayoutV1 from '../../components/PageLayoutV1/PageLayoutV1';
-import PipelineVersion from '../../components/Pipeline/PipelineVersion/PipelineVersion.component';
-import SearchIndexVersion from '../../components/SearchIndexVersion/SearchIndexVersion';
-import TopicVersion from '../../components/Topic/TopicVersion/TopicVersion.component';
 import { usePermissionProvider } from '../../context/PermissionProvider/PermissionProvider';
 import {
   OperationPermission,
@@ -135,13 +119,11 @@ import {
 } from '../../rest/topicsAPI';
 import entityUtilClassBase from '../../utils/EntityUtilClassBase';
 import { getEntityBreadcrumbs, getEntityName } from '../../utils/EntityUtils';
+import entityVersionClassBase from '../../utils/EntityVersionClassBase';
 import { DEFAULT_ENTITY_PERMISSION } from '../../utils/PermissionsUtils';
 import { getEntityDetailsPath, getVersionPath } from '../../utils/RouterUtils';
 import { getTierTags } from '../../utils/TableUtils';
 import { useRequiredParams } from '../../utils/useRequiredParams';
-import APICollectionVersionPage from '../APICollectionPage/APICollectionVersionPage';
-import DatabaseSchemaVersionPage from '../DatabaseSchemaVersionPage/DatabaseSchemaVersionPage';
-import DatabaseVersionPage from '../DatabaseVersionPage/DatabaseVersionPage';
 import './EntityVersionPage.less';
 
 export type VersionData =
@@ -610,336 +592,441 @@ const EntityVersionPage: FunctionComponent = () => {
       );
     }
 
-    let VersionPage = null;
+    const TableVersion = entityVersionClassBase.getEntityVersionComponent(
+      EntityType.TABLE
+    );
+    const TopicVersion = entityVersionClassBase.getEntityVersionComponent(
+      EntityType.TOPIC
+    );
+    const DashboardVersion = entityVersionClassBase.getEntityVersionComponent(
+      EntityType.DASHBOARD
+    );
+    const PipelineVersion = entityVersionClassBase.getEntityVersionComponent(
+      EntityType.PIPELINE
+    );
+    const MlModelVersion = entityVersionClassBase.getEntityVersionComponent(
+      EntityType.MLMODEL
+    );
+    const ContainerVersion = entityVersionClassBase.getEntityVersionComponent(
+      EntityType.CONTAINER
+    );
+    const SearchIndexVersion = entityVersionClassBase.getEntityVersionComponent(
+      EntityType.SEARCH_INDEX
+    );
+    const DataModelVersion = entityVersionClassBase.getEntityVersionComponent(
+      EntityType.DASHBOARD_DATA_MODEL
+    );
+    const StoredProcedureVersion =
+      entityVersionClassBase.getEntityVersionComponent(
+        EntityType.STORED_PROCEDURE
+      );
+    const APIEndpointVersion = entityVersionClassBase.getEntityVersionComponent(
+      EntityType.API_ENDPOINT
+    );
+    const MetricVersion = entityVersionClassBase.getEntityVersionComponent(
+      EntityType.METRIC
+    );
+    const ChartVersion = entityVersionClassBase.getEntityVersionComponent(
+      EntityType.CHART
+    );
+    const DirectoryVersion = entityVersionClassBase.getEntityVersionComponent(
+      EntityType.DIRECTORY
+    );
+    const FileVersion = entityVersionClassBase.getEntityVersionComponent(
+      EntityType.FILE
+    );
+    const SpreadsheetVersion = entityVersionClassBase.getEntityVersionComponent(
+      EntityType.SPREADSHEET
+    );
+    const WorksheetVersion = entityVersionClassBase.getEntityVersionComponent(
+      EntityType.WORKSHEET
+    );
+    const DatabaseVersionPage =
+      entityVersionClassBase.getEntityVersionComponent(EntityType.DATABASE);
+    const DatabaseSchemaVersionPage =
+      entityVersionClassBase.getEntityVersionComponent(
+        EntityType.DATABASE_SCHEMA
+      );
+    const DataProductsPage = entityVersionClassBase.getEntityVersionComponent(
+      EntityType.DATA_PRODUCT
+    );
+    const APICollectionVersionPage =
+      entityVersionClassBase.getEntityVersionComponent(
+        EntityType.API_COLLECTION
+      );
+
+    const wrapSuspense = (node: JSX.Element) => (
+      <Suspense fallback={<Loader />}>{node}</Suspense>
+    );
 
     switch (entityType) {
       case EntityType.TABLE: {
-        return (
-          <TableVersion
-            backHandler={backHandler}
-            currentVersionData={currentVersionData as Table}
-            dataProducts={currentVersionData.dataProducts}
-            deleted={currentVersionData.deleted}
-            domains={domains}
-            entityPermissions={entityPermissions}
-            isVersionLoading={isVersionLoading}
-            owners={owners}
-            slashedTableName={slashedEntityName}
-            tier={tier as TagLabel}
-            version={version}
-            versionHandler={versionHandler}
-            versionList={versionList}
-          />
-        );
+        return TableVersion
+          ? wrapSuspense(
+              <TableVersion
+                backHandler={backHandler}
+                currentVersionData={currentVersionData as Table}
+                dataProducts={currentVersionData.dataProducts}
+                deleted={currentVersionData.deleted}
+                domains={domains}
+                entityPermissions={entityPermissions}
+                isVersionLoading={isVersionLoading}
+                owners={owners}
+                slashedTableName={slashedEntityName}
+                tier={tier as TagLabel}
+                version={version}
+                versionHandler={versionHandler}
+                versionList={versionList}
+              />
+            )
+          : null;
       }
       case EntityType.TOPIC: {
-        return (
-          <TopicVersion
-            backHandler={backHandler}
-            currentVersionData={currentVersionData as Topic}
-            dataProducts={currentVersionData.dataProducts}
-            deleted={currentVersionData.deleted}
-            domains={domains}
-            entityPermissions={entityPermissions}
-            isVersionLoading={isVersionLoading}
-            owners={owners}
-            slashedTopicName={slashedEntityName}
-            tier={tier as TagLabel}
-            version={version}
-            versionHandler={versionHandler}
-            versionList={versionList}
-          />
-        );
+        return TopicVersion
+          ? wrapSuspense(
+              <TopicVersion
+                backHandler={backHandler}
+                currentVersionData={currentVersionData as Topic}
+                dataProducts={currentVersionData.dataProducts}
+                deleted={currentVersionData.deleted}
+                domains={domains}
+                entityPermissions={entityPermissions}
+                isVersionLoading={isVersionLoading}
+                owners={owners}
+                slashedTopicName={slashedEntityName}
+                tier={tier as TagLabel}
+                version={version}
+                versionHandler={versionHandler}
+                versionList={versionList}
+              />
+            )
+          : null;
       }
 
       case EntityType.DASHBOARD: {
-        return (
-          <DashboardVersion
-            backHandler={backHandler}
-            currentVersionData={currentVersionData as Dashboard}
-            dataProducts={currentVersionData.dataProducts}
-            deleted={currentVersionData.deleted}
-            domains={domains}
-            entityPermissions={entityPermissions}
-            isVersionLoading={isVersionLoading}
-            owners={owners}
-            slashedDashboardName={slashedEntityName}
-            tier={tier as TagLabel}
-            version={version}
-            versionHandler={versionHandler}
-            versionList={versionList}
-          />
-        );
+        return DashboardVersion
+          ? wrapSuspense(
+              <DashboardVersion
+                backHandler={backHandler}
+                currentVersionData={currentVersionData as Dashboard}
+                dataProducts={currentVersionData.dataProducts}
+                deleted={currentVersionData.deleted}
+                domains={domains}
+                entityPermissions={entityPermissions}
+                isVersionLoading={isVersionLoading}
+                owners={owners}
+                slashedDashboardName={slashedEntityName}
+                tier={tier as TagLabel}
+                version={version}
+                versionHandler={versionHandler}
+                versionList={versionList}
+              />
+            )
+          : null;
       }
 
       case EntityType.PIPELINE: {
-        return (
-          <PipelineVersion
-            backHandler={backHandler}
-            currentVersionData={currentVersionData as Pipeline}
-            dataProducts={currentVersionData.dataProducts}
-            deleted={currentVersionData.deleted}
-            domains={domains}
-            entityPermissions={entityPermissions}
-            isVersionLoading={isVersionLoading}
-            owners={owners}
-            slashedPipelineName={slashedEntityName}
-            tier={tier as TagLabel}
-            version={version}
-            versionHandler={versionHandler}
-            versionList={versionList}
-          />
-        );
+        return PipelineVersion
+          ? wrapSuspense(
+              <PipelineVersion
+                backHandler={backHandler}
+                currentVersionData={currentVersionData as Pipeline}
+                dataProducts={currentVersionData.dataProducts}
+                deleted={currentVersionData.deleted}
+                domains={domains}
+                entityPermissions={entityPermissions}
+                isVersionLoading={isVersionLoading}
+                owners={owners}
+                slashedPipelineName={slashedEntityName}
+                tier={tier as TagLabel}
+                version={version}
+                versionHandler={versionHandler}
+                versionList={versionList}
+              />
+            )
+          : null;
       }
 
       case EntityType.MLMODEL: {
-        return (
-          <MlModelVersion
-            backHandler={backHandler}
-            currentVersionData={currentVersionData as Mlmodel}
-            dataProducts={currentVersionData.dataProducts}
-            deleted={currentVersionData.deleted}
-            domains={domains}
-            entityPermissions={entityPermissions}
-            isVersionLoading={isVersionLoading}
-            owners={owners}
-            slashedMlModelName={slashedEntityName}
-            tier={tier as TagLabel}
-            version={version}
-            versionHandler={versionHandler}
-            versionList={versionList}
-          />
-        );
+        return MlModelVersion
+          ? wrapSuspense(
+              <MlModelVersion
+                backHandler={backHandler}
+                currentVersionData={currentVersionData as Mlmodel}
+                dataProducts={currentVersionData.dataProducts}
+                deleted={currentVersionData.deleted}
+                domains={domains}
+                entityPermissions={entityPermissions}
+                isVersionLoading={isVersionLoading}
+                owners={owners}
+                slashedMlModelName={slashedEntityName}
+                tier={tier as TagLabel}
+                version={version}
+                versionHandler={versionHandler}
+                versionList={versionList}
+              />
+            )
+          : null;
       }
       case EntityType.CONTAINER: {
-        return (
-          <ContainerVersion
-            backHandler={backHandler}
-            breadCrumbList={slashedEntityName}
-            currentVersionData={currentVersionData as Container}
-            dataProducts={currentVersionData.dataProducts}
-            deleted={currentVersionData.deleted}
-            domains={domains}
-            entityPermissions={entityPermissions}
-            isVersionLoading={isVersionLoading}
-            owners={owners}
-            tier={tier as TagLabel}
-            version={version}
-            versionHandler={versionHandler}
-            versionList={versionList}
-          />
-        );
+        return ContainerVersion
+          ? wrapSuspense(
+              <ContainerVersion
+                backHandler={backHandler}
+                breadCrumbList={slashedEntityName}
+                currentVersionData={currentVersionData as Container}
+                dataProducts={currentVersionData.dataProducts}
+                deleted={currentVersionData.deleted}
+                domains={domains}
+                entityPermissions={entityPermissions}
+                isVersionLoading={isVersionLoading}
+                owners={owners}
+                tier={tier as TagLabel}
+                version={version}
+                versionHandler={versionHandler}
+                versionList={versionList}
+              />
+            )
+          : null;
       }
       case EntityType.SEARCH_INDEX: {
-        return (
-          <SearchIndexVersion
-            backHandler={backHandler}
-            breadCrumbList={slashedEntityName}
-            currentVersionData={currentVersionData as SearchIndex}
-            dataProducts={currentVersionData.dataProducts}
-            deleted={currentVersionData.deleted}
-            domains={domains}
-            entityPermissions={entityPermissions}
-            isVersionLoading={isVersionLoading}
-            owners={owners}
-            tier={tier as TagLabel}
-            version={version}
-            versionHandler={versionHandler}
-            versionList={versionList}
-          />
-        );
+        return SearchIndexVersion
+          ? wrapSuspense(
+              <SearchIndexVersion
+                backHandler={backHandler}
+                breadCrumbList={slashedEntityName}
+                currentVersionData={currentVersionData as SearchIndex}
+                dataProducts={currentVersionData.dataProducts}
+                deleted={currentVersionData.deleted}
+                domains={domains}
+                entityPermissions={entityPermissions}
+                isVersionLoading={isVersionLoading}
+                owners={owners}
+                tier={tier as TagLabel}
+                version={version}
+                versionHandler={versionHandler}
+                versionList={versionList}
+              />
+            )
+          : null;
       }
 
       case EntityType.DASHBOARD_DATA_MODEL: {
-        return (
-          <DataModelVersion
-            backHandler={backHandler}
-            currentVersionData={currentVersionData as DashboardDataModel}
-            dataProducts={currentVersionData.dataProducts}
-            deleted={currentVersionData.deleted}
-            domains={domains}
-            entityPermissions={entityPermissions}
-            isVersionLoading={isVersionLoading}
-            owners={owners}
-            slashedDataModelName={slashedEntityName}
-            tier={tier as TagLabel}
-            version={version}
-            versionHandler={versionHandler}
-            versionList={versionList}
-          />
-        );
+        return DataModelVersion
+          ? wrapSuspense(
+              <DataModelVersion
+                backHandler={backHandler}
+                currentVersionData={currentVersionData as DashboardDataModel}
+                dataProducts={currentVersionData.dataProducts}
+                deleted={currentVersionData.deleted}
+                domains={domains}
+                entityPermissions={entityPermissions}
+                isVersionLoading={isVersionLoading}
+                owners={owners}
+                slashedDataModelName={slashedEntityName}
+                tier={tier as TagLabel}
+                version={version}
+                versionHandler={versionHandler}
+                versionList={versionList}
+              />
+            )
+          : null;
       }
 
       case EntityType.STORED_PROCEDURE: {
-        return (
-          <StoredProcedureVersion
-            backHandler={backHandler}
-            currentVersionData={currentVersionData as StoredProcedure}
-            dataProducts={currentVersionData.dataProducts}
-            deleted={currentVersionData.deleted}
-            domains={domains}
-            entityPermissions={entityPermissions}
-            isVersionLoading={isVersionLoading}
-            owners={owners}
-            slashedTableName={slashedEntityName}
-            tier={tier as TagLabel}
-            version={version}
-            versionHandler={versionHandler}
-            versionList={versionList}
-          />
-        );
+        return StoredProcedureVersion
+          ? wrapSuspense(
+              <StoredProcedureVersion
+                backHandler={backHandler}
+                currentVersionData={currentVersionData as StoredProcedure}
+                dataProducts={currentVersionData.dataProducts}
+                deleted={currentVersionData.deleted}
+                domains={domains}
+                entityPermissions={entityPermissions}
+                isVersionLoading={isVersionLoading}
+                owners={owners}
+                slashedTableName={slashedEntityName}
+                tier={tier as TagLabel}
+                version={version}
+                versionHandler={versionHandler}
+                versionList={versionList}
+              />
+            )
+          : null;
       }
 
       case EntityType.API_ENDPOINT: {
-        return (
-          <APIEndpointVersion
-            backHandler={backHandler}
-            currentVersionData={currentVersionData as APIEndpoint}
-            domains={domains}
-            entityPermissions={entityPermissions}
-            isVersionLoading={isVersionLoading}
-            owners={owners}
-            slashedApiEndpointName={slashedEntityName}
-            tier={tier as TagLabel}
-            version={version}
-            versionHandler={versionHandler}
-            versionList={versionList}
-          />
-        );
+        return APIEndpointVersion
+          ? wrapSuspense(
+              <APIEndpointVersion
+                backHandler={backHandler}
+                currentVersionData={currentVersionData as APIEndpoint}
+                domains={domains}
+                entityPermissions={entityPermissions}
+                isVersionLoading={isVersionLoading}
+                owners={owners}
+                slashedApiEndpointName={slashedEntityName}
+                tier={tier as TagLabel}
+                version={version}
+                versionHandler={versionHandler}
+                versionList={versionList}
+              />
+            )
+          : null;
       }
       case EntityType.METRIC: {
-        return (
-          <MetricVersion
-            backHandler={backHandler}
-            currentVersionData={currentVersionData as Metric}
-            domains={domains}
-            entityPermissions={entityPermissions}
-            isVersionLoading={isVersionLoading}
-            owners={owners}
-            slashedMetricName={slashedEntityName}
-            tier={tier as TagLabel}
-            version={version}
-            versionHandler={versionHandler}
-            versionList={versionList}
-          />
-        );
+        return MetricVersion
+          ? wrapSuspense(
+              <MetricVersion
+                backHandler={backHandler}
+                currentVersionData={currentVersionData as Metric}
+                domains={domains}
+                entityPermissions={entityPermissions}
+                isVersionLoading={isVersionLoading}
+                owners={owners}
+                slashedMetricName={slashedEntityName}
+                tier={tier as TagLabel}
+                version={version}
+                versionHandler={versionHandler}
+                versionList={versionList}
+              />
+            )
+          : null;
       }
       case EntityType.CHART: {
-        return (
-          <ChartVersion
-            backHandler={backHandler}
-            currentVersionData={currentVersionData as Chart}
-            dataProducts={currentVersionData.dataProducts}
-            deleted={currentVersionData.deleted}
-            domains={domains}
-            entityPermissions={entityPermissions}
-            isVersionLoading={isVersionLoading}
-            owners={owners}
-            slashedChartName={slashedEntityName as unknown as string[]}
-            tier={tier as TagLabel}
-            version={version}
-            versionHandler={versionHandler}
-            versionList={versionList}
-          />
-        );
+        return ChartVersion
+          ? wrapSuspense(
+              <ChartVersion
+                backHandler={backHandler}
+                currentVersionData={currentVersionData as Chart}
+                dataProducts={currentVersionData.dataProducts}
+                deleted={currentVersionData.deleted}
+                domains={domains}
+                entityPermissions={entityPermissions}
+                isVersionLoading={isVersionLoading}
+                owners={owners}
+                slashedChartName={slashedEntityName as unknown as string[]}
+                tier={tier as TagLabel}
+                version={version}
+                versionHandler={versionHandler}
+                versionList={versionList}
+              />
+            )
+          : null;
       }
       case EntityType.DIRECTORY: {
-        return (
-          <DirectoryVersion
-            backHandler={backHandler}
-            breadCrumbList={slashedEntityName}
-            currentVersionData={currentVersionData as Directory}
-            dataProducts={currentVersionData.dataProducts}
-            deleted={currentVersionData.deleted}
-            domains={domains}
-            entityPermissions={entityPermissions}
-            isVersionLoading={isVersionLoading}
-            owners={owners}
-            tier={tier as TagLabel}
-            version={version}
-            versionHandler={versionHandler}
-            versionList={versionList}
-          />
-        );
+        return DirectoryVersion
+          ? wrapSuspense(
+              <DirectoryVersion
+                backHandler={backHandler}
+                breadCrumbList={slashedEntityName}
+                currentVersionData={currentVersionData as Directory}
+                dataProducts={currentVersionData.dataProducts}
+                deleted={currentVersionData.deleted}
+                domains={domains}
+                entityPermissions={entityPermissions}
+                isVersionLoading={isVersionLoading}
+                owners={owners}
+                tier={tier as TagLabel}
+                version={version}
+                versionHandler={versionHandler}
+                versionList={versionList}
+              />
+            )
+          : null;
       }
       case EntityType.FILE: {
-        return (
-          <FileVersion
-            backHandler={backHandler}
-            breadCrumbList={slashedEntityName}
-            currentVersionData={currentVersionData as File}
-            dataProducts={currentVersionData.dataProducts}
-            deleted={currentVersionData.deleted}
-            domains={domains}
-            entityPermissions={entityPermissions}
-            isVersionLoading={isVersionLoading}
-            owners={owners}
-            tier={tier as TagLabel}
-            version={version}
-            versionHandler={versionHandler}
-            versionList={versionList}
-          />
-        );
+        return FileVersion
+          ? wrapSuspense(
+              <FileVersion
+                backHandler={backHandler}
+                breadCrumbList={slashedEntityName}
+                currentVersionData={currentVersionData as File}
+                dataProducts={currentVersionData.dataProducts}
+                deleted={currentVersionData.deleted}
+                domains={domains}
+                entityPermissions={entityPermissions}
+                isVersionLoading={isVersionLoading}
+                owners={owners}
+                tier={tier as TagLabel}
+                version={version}
+                versionHandler={versionHandler}
+                versionList={versionList}
+              />
+            )
+          : null;
       }
       case EntityType.SPREADSHEET: {
-        return (
-          <SpreadsheetVersion
-            backHandler={backHandler}
-            breadCrumbList={slashedEntityName}
-            currentVersionData={currentVersionData as Spreadsheet}
-            dataProducts={currentVersionData.dataProducts}
-            deleted={currentVersionData.deleted}
-            domains={domains}
-            entityPermissions={entityPermissions}
-            isVersionLoading={isVersionLoading}
-            owners={owners}
-            tier={tier as TagLabel}
-            version={version}
-            versionHandler={versionHandler}
-            versionList={versionList}
-          />
-        );
+        return SpreadsheetVersion
+          ? wrapSuspense(
+              <SpreadsheetVersion
+                backHandler={backHandler}
+                breadCrumbList={slashedEntityName}
+                currentVersionData={currentVersionData as Spreadsheet}
+                dataProducts={currentVersionData.dataProducts}
+                deleted={currentVersionData.deleted}
+                domains={domains}
+                entityPermissions={entityPermissions}
+                isVersionLoading={isVersionLoading}
+                owners={owners}
+                tier={tier as TagLabel}
+                version={version}
+                versionHandler={versionHandler}
+                versionList={versionList}
+              />
+            )
+          : null;
       }
       case EntityType.WORKSHEET: {
-        return (
-          <WorksheetVersion
-            backHandler={backHandler}
-            breadCrumbList={slashedEntityName}
-            currentVersionData={currentVersionData as Worksheet}
-            dataProducts={currentVersionData.dataProducts}
-            deleted={currentVersionData.deleted}
-            domains={domains}
-            entityPermissions={entityPermissions}
-            isVersionLoading={isVersionLoading}
-            owners={owners}
-            tier={tier as TagLabel}
-            version={version}
-            versionHandler={versionHandler}
-            versionList={versionList}
-          />
-        );
+        return WorksheetVersion
+          ? wrapSuspense(
+              <WorksheetVersion
+                backHandler={backHandler}
+                breadCrumbList={slashedEntityName}
+                currentVersionData={currentVersionData as Worksheet}
+                dataProducts={currentVersionData.dataProducts}
+                deleted={currentVersionData.deleted}
+                domains={domains}
+                entityPermissions={entityPermissions}
+                isVersionLoading={isVersionLoading}
+                owners={owners}
+                tier={tier as TagLabel}
+                version={version}
+                versionHandler={versionHandler}
+                versionList={versionList}
+              />
+            )
+          : null;
       }
 
       case EntityType.DATABASE: {
-        return <DatabaseVersionPage />;
+        return DatabaseVersionPage
+          ? wrapSuspense(<DatabaseVersionPage />)
+          : null;
       }
 
       case EntityType.DATABASE_SCHEMA: {
-        return <DatabaseSchemaVersionPage />;
+        return DatabaseSchemaVersionPage
+          ? wrapSuspense(<DatabaseSchemaVersionPage />)
+          : null;
       }
 
       case EntityType.DATA_PRODUCT: {
-        return <DataProductsPage />;
+        return DataProductsPage ? wrapSuspense(<DataProductsPage />) : null;
       }
 
       case EntityType.API_COLLECTION: {
-        return <APICollectionVersionPage />;
+        return APICollectionVersionPage
+          ? wrapSuspense(<APICollectionVersionPage />)
+          : null;
       }
 
-      default:
-        VersionPage = entityUtilClassBase.getEntityDetailComponent(entityType);
+      default: {
+        const VersionPage =
+          entityVersionClassBase.getEntityDetailComponent(entityType);
 
-        return VersionPage && <VersionPage />;
+        return VersionPage ? <VersionPage /> : null;
+      }
     }
   };
 

--- a/openmetadata-ui/src/main/resources/ui/src/utils/DataAssetsVersionHeaderUtils.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/DataAssetsVersionHeaderUtils.tsx
@@ -26,12 +26,9 @@ import { Metric, UnitOfMeasurement } from '../generated/entity/data/metric';
 import { Pipeline } from '../generated/entity/data/pipeline';
 import { Topic } from '../generated/entity/data/topic';
 import { ChangeDescription } from '../generated/entity/type';
+import { getChangedEntityName, getDiffByFieldName } from './EntityDiffPureUtils';
 import { getEntityName } from './EntityUtils';
-import {
-  getChangedEntityName,
-  getDiffByFieldName,
-  getEntityVersionByField,
-} from './EntityVersionUtils';
+import { getEntityVersionByField } from './EntityVersionUtilsPure';
 import { t } from './i18next/LocalUtil';
 import { stringToHTML } from './StringUtils';
 

--- a/openmetadata-ui/src/main/resources/ui/src/utils/DataAssetsVersionHeaderUtils.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/DataAssetsVersionHeaderUtils.tsx
@@ -26,7 +26,10 @@ import { Metric, UnitOfMeasurement } from '../generated/entity/data/metric';
 import { Pipeline } from '../generated/entity/data/pipeline';
 import { Topic } from '../generated/entity/data/topic';
 import { ChangeDescription } from '../generated/entity/type';
-import { getChangedEntityName, getDiffByFieldName } from './EntityDiffPureUtils';
+import {
+  getChangedEntityName,
+  getDiffByFieldName,
+} from './EntityDiffPureUtils';
 import { getEntityName } from './EntityUtils';
 import { getEntityVersionByField } from './EntityVersionUtilsPure';
 import { t } from './i18next/LocalUtil';

--- a/openmetadata-ui/src/main/resources/ui/src/utils/DataAssetsVersionHeaderUtils.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/DataAssetsVersionHeaderUtils.tsx
@@ -22,7 +22,10 @@ import { EntityField } from '../constants/Feeds.constants';
 import { EntityType } from '../enums/entity.enum';
 import type { Chart } from '../generated/entity/data/chart';
 import type { Dashboard } from '../generated/entity/data/dashboard';
-import type { Metric, UnitOfMeasurement } from '../generated/entity/data/metric';
+import type {
+  Metric,
+  UnitOfMeasurement,
+} from '../generated/entity/data/metric';
 import type { Pipeline } from '../generated/entity/data/pipeline';
 import type { Topic } from '../generated/entity/data/topic';
 import type { ChangeDescription } from '../generated/entity/type';

--- a/openmetadata-ui/src/main/resources/ui/src/utils/DataAssetsVersionHeaderUtils.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/DataAssetsVersionHeaderUtils.tsx
@@ -20,12 +20,12 @@ import { DataAssetsVersionHeaderProps } from '../components/DataAssets/DataAsset
 import { DATA_ASSET_ICON_DIMENSION } from '../constants/constants';
 import { EntityField } from '../constants/Feeds.constants';
 import { EntityType } from '../enums/entity.enum';
-import { Chart } from '../generated/entity/data/chart';
-import { Dashboard } from '../generated/entity/data/dashboard';
-import { Metric, UnitOfMeasurement } from '../generated/entity/data/metric';
-import { Pipeline } from '../generated/entity/data/pipeline';
-import { Topic } from '../generated/entity/data/topic';
-import { ChangeDescription } from '../generated/entity/type';
+import type { Chart } from '../generated/entity/data/chart';
+import type { Dashboard } from '../generated/entity/data/dashboard';
+import type { Metric, UnitOfMeasurement } from '../generated/entity/data/metric';
+import type { Pipeline } from '../generated/entity/data/pipeline';
+import type { Topic } from '../generated/entity/data/topic';
+import type { ChangeDescription } from '../generated/entity/type';
 import {
   getChangedEntityName,
   getDiffByFieldName,

--- a/openmetadata-ui/src/main/resources/ui/src/utils/EntityDiffPureUtils.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/EntityDiffPureUtils.ts
@@ -12,8 +12,8 @@
  */
 
 import { FQN_SEPARATOR_CHAR } from '../constants/char.constants';
-import { ChangeDescription } from '../generated/entity/services/databaseService';
-import {
+import type { ChangeDescription } from '../generated/entity/services/databaseService';
+import type {
   EntityDiffProps,
   EntityDiffWithMultiChanges,
 } from '../interface/EntityVersion.interface';

--- a/openmetadata-ui/src/main/resources/ui/src/utils/EntityDiffPureUtils.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/EntityDiffPureUtils.ts
@@ -1,0 +1,109 @@
+/*
+ *  Copyright 2025 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+import { FQN_SEPARATOR_CHAR } from '../constants/char.constants';
+import { ChangeDescription } from '../generated/entity/services/databaseService';
+import {
+  EntityDiffProps,
+  EntityDiffWithMultiChanges,
+} from '../interface/EntityVersion.interface';
+
+export const getChangedEntityName = (diffObject?: EntityDiffProps) =>
+  diffObject?.added?.name ??
+  diffObject?.deleted?.name ??
+  diffObject?.updated?.name;
+
+export const getChangedEntityOldValue = (diffObject?: EntityDiffProps) =>
+  diffObject?.added?.oldValue ??
+  diffObject?.deleted?.oldValue ??
+  diffObject?.updated?.oldValue;
+
+export const getChangedEntityNewValue = (diffObject?: EntityDiffProps) =>
+  diffObject?.added?.newValue ??
+  diffObject?.deleted?.newValue ??
+  diffObject?.updated?.newValue;
+
+export const getChangeColumnNameFromDiffValue = (name?: string) => {
+  const nameWithoutInternalQuotes = name?.replaceAll(/"/g, '');
+
+  return nameWithoutInternalQuotes?.split(FQN_SEPARATOR_CHAR)?.slice(-2, -1)[0];
+};
+
+export const isEndsWithField = (checkWith: string, name?: string) => {
+  return name?.endsWith(checkWith);
+};
+
+export const getDiffByFieldName = (
+  name: string,
+  changeDescription: ChangeDescription,
+  exactMatch?: boolean
+): EntityDiffProps => {
+  const fieldsAdded = changeDescription?.fieldsAdded ?? [];
+  const fieldsDeleted = changeDescription?.fieldsDeleted ?? [];
+  const fieldsUpdated = changeDescription?.fieldsUpdated ?? [];
+  if (exactMatch) {
+    return {
+      added: fieldsAdded.find((ch) => ch.name === name),
+      deleted: fieldsDeleted.find((ch) => ch.name === name),
+      updated: fieldsUpdated.find((ch) => ch.name === name),
+    };
+  } else {
+    return {
+      added: fieldsAdded.find((ch) => ch.name?.includes(name)),
+      deleted: fieldsDeleted.find((ch) => ch.name?.includes(name)),
+      updated: fieldsUpdated.find((ch) => ch.name?.includes(name)),
+    };
+  }
+};
+
+export const getAllDiffByFieldName = (
+  name: string,
+  changeDescription: ChangeDescription,
+  exactMatch?: boolean
+): EntityDiffWithMultiChanges => {
+  const fieldsAdded = changeDescription?.fieldsAdded ?? [];
+  const fieldsDeleted = changeDescription?.fieldsDeleted ?? [];
+  const fieldsUpdated = changeDescription?.fieldsUpdated ?? [];
+  if (exactMatch) {
+    return {
+      added: fieldsAdded.filter((ch) => ch.name === name),
+      deleted: fieldsDeleted.filter((ch) => ch.name === name),
+      updated: fieldsUpdated.filter((ch) => ch.name === name),
+    };
+  } else {
+    return {
+      added: fieldsAdded.filter((ch) => ch.name?.includes(name)),
+      deleted: fieldsDeleted.filter((ch) => ch.name?.includes(name)),
+      updated: fieldsUpdated.filter((ch) => ch.name?.includes(name)),
+    };
+  }
+};
+
+export const getAllChangedEntityNames = (
+  diffObject: EntityDiffWithMultiChanges
+) => {
+  const changedEntityNames: string[] = [];
+  Object.keys(diffObject).forEach((key) => {
+    const changedValues = diffObject[key as keyof EntityDiffWithMultiChanges];
+
+    if (changedValues) {
+      changedValues.forEach((value) => {
+        if (value.name) {
+          changedEntityNames.push(value.name);
+        }
+      });
+    }
+  });
+
+  return changedEntityNames;
+};

--- a/openmetadata-ui/src/main/resources/ui/src/utils/EntityDiffUtils.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/EntityDiffUtils.tsx
@@ -17,16 +17,17 @@
  * Pure entity diff accessors live in EntityDiffPureUtils.ts.
  */
 
-import { Change, diffWords, diffWordsWithSpace } from 'diff';
+import { diffWords, diffWordsWithSpace } from 'diff';
+import type { Change } from 'diff';
 import { isEmpty, isObject, toString, uniqueId } from 'lodash';
-import { ReactNode } from 'react';
+import type { ReactNode } from 'react';
 import ReactDOMServer from 'react-dom/server';
-import {
+import type {
   ExtentionEntities,
   ExtentionEntitiesKeys,
 } from '../components/common/CustomPropertyTable/CustomPropertyTable.interface';
 import { EntityChangeOperations } from '../enums/VersionPage.enum';
-import { EntityDiffProps } from '../interface/EntityVersion.interface';
+import type { EntityDiffProps } from '../interface/EntityVersion.interface';
 import {
   getChangedEntityNewValue,
   getChangedEntityOldValue,

--- a/openmetadata-ui/src/main/resources/ui/src/utils/EntityDiffUtils.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/EntityDiffUtils.tsx
@@ -1,0 +1,209 @@
+/*
+ *  Copyright 2025 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+/**
+ * Entity diff utilities that depend on React / DOM rendering.
+ *
+ * Pure entity diff accessors live in EntityDiffPureUtils.ts.
+ */
+
+import { Change, diffWords, diffWordsWithSpace } from 'diff';
+import { isEmpty, isObject, toString, uniqueId } from 'lodash';
+import { ReactNode } from 'react';
+import ReactDOMServer from 'react-dom/server';
+import {
+  ExtentionEntities,
+  ExtentionEntitiesKeys,
+} from '../components/common/CustomPropertyTable/CustomPropertyTable.interface';
+import { EntityChangeOperations } from '../enums/VersionPage.enum';
+import { EntityDiffProps } from '../interface/EntityVersion.interface';
+import {
+  getChangedEntityNewValue,
+  getChangedEntityOldValue,
+} from './EntityDiffPureUtils';
+import { t } from './i18next/LocalUtil';
+import { getJSONFromString } from './StringUtils';
+
+export const getDiffValue = (oldValue: string, newValue: string) => {
+  const diff = diffWordsWithSpace(oldValue, newValue);
+
+  return diff.map((part: Change) => {
+    const diffChangeText = part.added ? 'diff-added' : 'diff-removed';
+
+    return (
+      <span
+        className={diffChangeText}
+        data-testid={`${diffChangeText}`}
+        key={part.value}>
+        {part.value}
+      </span>
+    );
+  });
+};
+
+export const getAddedDiffElement = (text: string) => {
+  return (
+    <span
+      className="diff-added text-underline"
+      data-diff="true"
+      data-testid="diff-added"
+      key={uniqueId()}>
+      {text}
+    </span>
+  );
+};
+
+export const getRemovedDiffElement = (text: string) => {
+  return (
+    <span
+      className="text-grey-muted text-line-through"
+      data-diff="true"
+      data-testid="diff-removed"
+      key={uniqueId()}>
+      {text}
+    </span>
+  );
+};
+
+export const getNormalDiffElement = (text: string) => {
+  return (
+    <span data-diff="true" data-testid="diff-normal" key={uniqueId()}>
+      {text}
+    </span>
+  );
+};
+
+export const getTextDiff = (
+  oldText: string,
+  newText: string,
+  latestText?: string
+) => {
+  const imagePlaceholder = 'data:image';
+  if (isEmpty(oldText) && isEmpty(newText)) {
+    return latestText ?? '';
+  }
+
+  if (
+    newText?.includes(imagePlaceholder) ||
+    oldText?.includes(imagePlaceholder)
+  ) {
+    return newText;
+  }
+
+  const diffArr = diffWords(toString(oldText), toString(newText));
+
+  const result = diffArr.map((diff) => {
+    if (diff.added) {
+      return ReactDOMServer.renderToString(getAddedDiffElement(diff.value));
+    }
+    if (diff.removed) {
+      return ReactDOMServer.renderToString(getRemovedDiffElement(diff.value));
+    }
+
+    return ReactDOMServer.renderToString(getNormalDiffElement(diff.value));
+  });
+
+  return result.join('');
+};
+
+const getCustomPropertyValue = (value: unknown) => {
+  if (isObject(value)) {
+    return JSON.stringify(value);
+  }
+
+  return toString(value);
+};
+
+export const getTextDiffCustomProperty = (
+  fieldName: string,
+  oldText: string,
+  newText: string
+) => {
+  if (oldText && newText) {
+    return `* ${t('message.custom-property-is-set-to-message', {
+      fieldName,
+    })} **${getTextDiff(oldText, newText)}**`;
+  }
+
+  const resultArray: unknown = getJSONFromString(oldText || newText);
+
+  if (Array.isArray(resultArray)) {
+    const result = resultArray.map((diff: Record<string, string>) => {
+      const objKeys = Object.keys(diff);
+
+      return `* ${t('message.custom-property-is-set-to-message', {
+        fieldName: objKeys[0],
+      })} **${getCustomPropertyValue(diff[objKeys[0]])}** \n`;
+    });
+
+    return result.join('');
+  }
+
+  return '';
+};
+
+export const getTextDiffElements = (
+  oldText: string,
+  newText: string
+): ReactNode[] => {
+  const diffArr = diffWords(toString(oldText), toString(newText));
+
+  return diffArr.map((diff) => {
+    if (diff.added) {
+      return getAddedDiffElement(diff.value);
+    }
+    if (diff.removed) {
+      return getRemovedDiffElement(diff.value);
+    }
+
+    return getNormalDiffElement(diff.value);
+  });
+};
+
+export const getDiffDisplayValue = (diff: {
+  oldValue: string;
+  newValue: string;
+  status: EntityChangeOperations;
+}) => {
+  switch (diff.status) {
+    case EntityChangeOperations.UPDATED:
+      return getTextDiffElements(diff.oldValue, diff.newValue);
+    case EntityChangeOperations.ADDED:
+      return getAddedDiffElement(diff.newValue);
+    case EntityChangeOperations.DELETED:
+      return getRemovedDiffElement(diff.oldValue);
+    case EntityChangeOperations.NORMAL:
+    default:
+      return diff.oldValue;
+  }
+};
+
+export const getUpdatedExtensionDiffFields = (
+  entityDetails: ExtentionEntities[ExtentionEntitiesKeys],
+  extensionDiff: EntityDiffProps
+) => {
+  const extensionObj = entityDetails.extension;
+  const newValues = getChangedEntityNewValue(extensionDiff);
+  const oldValues = getChangedEntityOldValue(extensionDiff);
+
+  const changedFieldName = extensionDiff.updated?.name?.split('.')[1];
+
+  return extensionObj && changedFieldName
+    ? {
+        extensionObject: {
+          ...extensionObj,
+          [changedFieldName]: getTextDiff(oldValues, newValues),
+        },
+      }
+    : { extensionObject: {} };
+};

--- a/openmetadata-ui/src/main/resources/ui/src/utils/EntityDiffUtils.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/EntityDiffUtils.tsx
@@ -17,8 +17,8 @@
  * Pure entity diff accessors live in EntityDiffPureUtils.ts.
  */
 
-import { diffWords, diffWordsWithSpace } from 'diff';
 import type { Change } from 'diff';
+import { diffWords, diffWordsWithSpace } from 'diff';
 import { isEmpty, isObject, toString, uniqueId } from 'lodash';
 import type { ReactNode } from 'react';
 import ReactDOMServer from 'react-dom/server';

--- a/openmetadata-ui/src/main/resources/ui/src/utils/EntityVersionClassBase.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/EntityVersionClassBase.ts
@@ -1,0 +1,130 @@
+/*
+ *  Copyright 2025 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+import { ComponentType, FC, lazy, LazyExoticComponent } from 'react';
+import { EntityType } from '../enums/entity.enum';
+import entityUtilClassBase from './EntityUtilClassBase';
+
+class EntityVersionClassBase {
+  protected componentMap: Partial<
+    Record<EntityType, LazyExoticComponent<ComponentType<any>>>
+  > = {
+    [EntityType.TABLE]: lazy(
+      () => import('../components/Database/TableVersion/TableVersion.component')
+    ),
+    [EntityType.TOPIC]: lazy(
+      () => import('../components/Topic/TopicVersion/TopicVersion.component')
+    ),
+    [EntityType.DASHBOARD]: lazy(
+      () =>
+        import(
+          '../components/Dashboard/DashboardVersion/DashboardVersion.component'
+        )
+    ),
+    [EntityType.PIPELINE]: lazy(
+      () =>
+        import(
+          '../components/Pipeline/PipelineVersion/PipelineVersion.component'
+        )
+    ),
+    [EntityType.MLMODEL]: lazy(
+      () =>
+        import('../components/MlModel/MlModelVersion/MlModelVersion.component')
+    ),
+    [EntityType.CONTAINER]: lazy(
+      () =>
+        import(
+          '../components/Container/ContainerVersion/ContainerVersion.component'
+        )
+    ),
+    [EntityType.SEARCH_INDEX]: lazy(
+      () => import('../components/SearchIndexVersion/SearchIndexVersion')
+    ),
+    [EntityType.DASHBOARD_DATA_MODEL]: lazy(
+      () =>
+        import(
+          '../components/Dashboard/DataModel/DataModelVersion/DataModelVersion.component'
+        )
+    ),
+    [EntityType.STORED_PROCEDURE]: lazy(
+      () =>
+        import(
+          '../components/Database/StoredProcedureVersion/StoredProcedureVersion.component'
+        )
+    ),
+    [EntityType.API_ENDPOINT]: lazy(
+      () =>
+        import(
+          '../components/APIEndpoint/APIEndpointVersion/APIEndpointVersion'
+        )
+    ),
+    [EntityType.METRIC]: lazy(
+      () => import('../components/Metric/MetricVersion/MetricVersion')
+    ),
+    [EntityType.CHART]: lazy(
+      () => import('../components/Chart/ChartVersion/ChartVersion.component')
+    ),
+    [EntityType.DIRECTORY]: lazy(
+      () =>
+        import(
+          '../components/DriveService/Directory/DirectoryVersion/DirectoryVersion'
+        )
+    ),
+    [EntityType.FILE]: lazy(
+      () => import('../components/DriveService/File/FileVersion/FileVersion')
+    ),
+    [EntityType.SPREADSHEET]: lazy(
+      () =>
+        import(
+          '../components/DriveService/Spreadsheet/SpreadsheetVersion/SpreadsheetVersion'
+        )
+    ),
+    [EntityType.WORKSHEET]: lazy(
+      () =>
+        import(
+          '../components/DriveService/Worksheet/WorksheetVersion/WorksheetVersion'
+        )
+    ),
+    [EntityType.DATABASE]: lazy(
+      () => import('../pages/DatabaseVersionPage/DatabaseVersionPage')
+    ),
+    [EntityType.DATABASE_SCHEMA]: lazy(
+      () =>
+        import('../pages/DatabaseSchemaVersionPage/DatabaseSchemaVersionPage')
+    ),
+    [EntityType.DATA_PRODUCT]: lazy(
+      () =>
+        import(
+          '../components/DataProducts/DataProductsPage/DataProductsPage.component'
+        )
+    ),
+    [EntityType.API_COLLECTION]: lazy(
+      () => import('../pages/APICollectionPage/APICollectionVersionPage')
+    ),
+  };
+
+  public getEntityVersionComponent(
+    entityType: string
+  ): LazyExoticComponent<ComponentType<any>> | null {
+    return this.componentMap[entityType as EntityType] ?? null;
+  }
+
+  public getEntityDetailComponent(entityType: string): FC | null {
+    return entityUtilClassBase.getEntityDetailComponent(entityType);
+  }
+}
+
+const entityVersionClassBase = new EntityVersionClassBase();
+
+export { EntityVersionClassBase };
+export default entityVersionClassBase;

--- a/openmetadata-ui/src/main/resources/ui/src/utils/EntityVersionClassBase.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/EntityVersionClassBase.ts
@@ -11,14 +11,21 @@
  *  limitations under the License.
  */
 
-import { ComponentType, FC, lazy, LazyExoticComponent } from 'react';
+import {
+  ComponentType,
+  FC,
+  lazy,
+  LazyExoticComponent,
+} from 'react';
 import { EntityType } from '../enums/entity.enum';
 import entityUtilClassBase from './EntityUtilClassBase';
 
+type VersionComponentType = LazyExoticComponent<
+  ComponentType<Record<string, unknown>>
+>;
+
 class EntityVersionClassBase {
-  protected componentMap: Partial<
-    Record<EntityType, LazyExoticComponent<ComponentType<any>>>
-  > = {
+  protected componentMap: Partial<Record<EntityType, VersionComponentType>> = {
     [EntityType.TABLE]: lazy(
       () => import('../components/Database/TableVersion/TableVersion.component')
     ),
@@ -115,7 +122,7 @@ class EntityVersionClassBase {
 
   public getEntityVersionComponent(
     entityType: string
-  ): LazyExoticComponent<ComponentType<any>> | null {
+  ): VersionComponentType | null {
     return this.componentMap[entityType as EntityType] ?? null;
   }
 

--- a/openmetadata-ui/src/main/resources/ui/src/utils/EntityVersionClassBase.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/EntityVersionClassBase.ts
@@ -11,12 +11,7 @@
  *  limitations under the License.
  */
 
-import {
-  ComponentType,
-  FC,
-  lazy,
-  LazyExoticComponent,
-} from 'react';
+import { ComponentType, FC, lazy, LazyExoticComponent } from 'react';
 import { EntityType } from '../enums/entity.enum';
 import entityUtilClassBase from './EntityUtilClassBase';
 

--- a/openmetadata-ui/src/main/resources/ui/src/utils/EntityVersionUtils.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/EntityVersionUtils.tsx
@@ -68,7 +68,6 @@ export {
   getDiffByFieldName,
   isEndsWithField,
 } from './EntityDiffPureUtils';
-
 // Re-export everything from EntityDiffUtils for backward compatibility
 export {
   getAddedDiffElement,
@@ -81,7 +80,6 @@ export {
   getTextDiffElements,
   getUpdatedExtensionDiffFields,
 } from './EntityDiffUtils';
-
 // Re-export everything from EntityVersionUtilsPure for backward compatibility
 export {
   addDeletedColumnsDiff,

--- a/openmetadata-ui/src/main/resources/ui/src/utils/EntityVersionUtils.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/EntityVersionUtils.tsx
@@ -13,8 +13,8 @@
 
 import { Divider, Space, Typography } from 'antd';
 import { get, isEmpty, isObject, startCase, toString } from 'lodash';
-import { Fragment, lazy } from 'react';
 import type { ReactNode } from 'react';
+import { Fragment, lazy } from 'react';
 import withSuspenseFallback from '../components/AppRouter/withSuspenseFallback';
 import { VersionButton } from '../components/Entity/EntityVersionTimeLine/EntityVersionTimeLine';
 import { NO_DATA_PLACEHOLDER } from '../constants/constants';

--- a/openmetadata-ui/src/main/resources/ui/src/utils/EntityVersionUtils.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/EntityVersionUtils.tsx
@@ -13,18 +13,19 @@
 
 import { Divider, Space, Typography } from 'antd';
 import { get, isEmpty, isObject, startCase, toString } from 'lodash';
-import { Fragment, lazy, ReactNode } from 'react';
+import { Fragment, lazy } from 'react';
+import type { ReactNode } from 'react';
 import withSuspenseFallback from '../components/AppRouter/withSuspenseFallback';
 import { VersionButton } from '../components/Entity/EntityVersionTimeLine/EntityVersionTimeLine';
 import { NO_DATA_PLACEHOLDER } from '../constants/constants';
 import { TabSpecificField } from '../enums/entity.enum';
 import { EntityChangeOperations } from '../enums/VersionPage.enum';
-import {
+import type {
   ChangeDescription,
   FieldChange,
 } from '../generated/entity/services/databaseService';
-import { EntityReference } from '../generated/entity/type';
-import { TestCaseParameterValue } from '../generated/tests/testCase';
+import type { EntityReference } from '../generated/entity/type';
+import type { TestCaseParameterValue } from '../generated/tests/testCase';
 import {
   getChangedEntityNewValue,
   getChangedEntityOldValue,

--- a/openmetadata-ui/src/main/resources/ui/src/utils/EntityVersionUtils.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/EntityVersionUtils.tsx
@@ -12,383 +12,120 @@
  */
 
 import { Divider, Space, Typography } from 'antd';
-import {
-  ArrayChange,
-  Change,
-  diffArrays,
-  diffWords,
-  diffWordsWithSpace,
-} from 'diff';
-import {
-  cloneDeep,
-  get,
-  isEmpty,
-  isEqual,
-  isObject,
-  isUndefined,
-  startCase,
-  toString,
-  uniqBy,
-  uniqueId,
-} from 'lodash';
-import { Fragment, ReactNode } from 'react';
-import ReactDOMServer from 'react-dom/server';
-import {
-  ExtentionEntities,
-  ExtentionEntitiesKeys,
-} from '../components/common/CustomPropertyTable/CustomPropertyTable.interface';
-import { OwnerLabel } from '../components/common/OwnerLabel/OwnerLabel.component';
-import { BulkImportVersionSummary } from '../components/Entity/EntityVersionTimeLine/BulkImportVersionSummary/BulkImportVersionSummary.component';
+import { get, isEmpty, isObject, startCase, toString } from 'lodash';
+import { Fragment, lazy, ReactNode } from 'react';
+import withSuspenseFallback from '../components/AppRouter/withSuspenseFallback';
 import { VersionButton } from '../components/Entity/EntityVersionTimeLine/EntityVersionTimeLine';
-import { FQN_SEPARATOR_CHAR } from '../constants/char.constants';
 import { NO_DATA_PLACEHOLDER } from '../constants/constants';
-import { EntityField } from '../constants/Feeds.constants';
-import { EntityType, TabSpecificField } from '../enums/entity.enum';
+import { TabSpecificField } from '../enums/entity.enum';
 import { EntityChangeOperations } from '../enums/VersionPage.enum';
-import { Column as ContainerColumn } from '../generated/entity/data/container';
-import { Column as DataModelColumn } from '../generated/entity/data/dashboardDataModel';
-import { Column as TableColumn } from '../generated/entity/data/table';
-import { Field } from '../generated/entity/data/topic';
 import {
   ChangeDescription,
   FieldChange,
 } from '../generated/entity/services/databaseService';
-import { MetadataService } from '../generated/entity/services/metadataService';
 import { EntityReference } from '../generated/entity/type';
 import { TestCaseParameterValue } from '../generated/tests/testCase';
-import { TagLabel } from '../generated/type/tagLabel';
 import {
-  EntityDiffProps,
-  EntityDiffWithMultiChanges,
-} from '../interface/EntityVersion.interface';
-import { getEntityBreadcrumbs, getEntityName } from './EntityUtils';
+  getChangedEntityNewValue,
+  getChangedEntityOldValue,
+  getDiffByFieldName,
+} from './EntityDiffPureUtils';
 import {
-  AssetsChildForVersionPages,
-  TagLabelWithStatus,
-  VersionEntityTypes,
-} from './EntityVersionUtils.interface';
+  getAddedDiffElement,
+  getDiffDisplayValue,
+  getRemovedDiffElement,
+  getTextDiffElements,
+} from './EntityDiffUtils';
+import { getEntityName } from './EntityUtils';
+import * as Pure from './EntityVersionUtilsPure';
 import { t } from './i18next/LocalUtil';
-import { getJSONFromString, isValidJSONString } from './StringUtils';
-import { getTagsWithoutTier, getTierTags } from './TableUtils';
+import { isValidJSONString } from './StringUtils';
 
-type EntityColumn = TableColumn | ContainerColumn | Field;
+const BulkImportVersionSummary = withSuspenseFallback(
+  lazy(() =>
+    import(
+      '../components/Entity/EntityVersionTimeLine/BulkImportVersionSummary/BulkImportVersionSummary.component'
+    ).then((m) => ({ default: m.BulkImportVersionSummary }))
+  )
+);
 
-export const getChangedEntityName = (diffObject?: EntityDiffProps) =>
-  diffObject?.added?.name ??
-  diffObject?.deleted?.name ??
-  diffObject?.updated?.name;
-
-export const getChangedEntityOldValue = (diffObject?: EntityDiffProps) =>
-  diffObject?.added?.oldValue ??
-  diffObject?.deleted?.oldValue ??
-  diffObject?.updated?.oldValue;
-
-export const getChangedEntityNewValue = (diffObject?: EntityDiffProps) =>
-  diffObject?.added?.newValue ??
-  diffObject?.deleted?.newValue ??
-  diffObject?.updated?.newValue;
-
-export const getChangeColumnNameFromDiffValue = (name?: string) => {
-  const nameWithoutInternalQuotes = name?.replaceAll(/"/g, '');
-
-  return nameWithoutInternalQuotes?.split(FQN_SEPARATOR_CHAR)?.slice(-2, -1)[0];
-};
-
-export const isEndsWithField = (checkWith: string, name?: string) => {
-  return name?.endsWith(checkWith);
-};
-
-export const getDiffByFieldName = (
-  name: string,
-  changeDescription: ChangeDescription,
-  exactMatch?: boolean
-): EntityDiffProps => {
-  const fieldsAdded = changeDescription?.fieldsAdded ?? [];
-  const fieldsDeleted = changeDescription?.fieldsDeleted ?? [];
-  const fieldsUpdated = changeDescription?.fieldsUpdated ?? [];
-  if (exactMatch) {
-    return {
-      added: fieldsAdded.find((ch) => ch.name === name),
-      deleted: fieldsDeleted.find((ch) => ch.name === name),
-      updated: fieldsUpdated.find((ch) => ch.name === name),
-    };
-  } else {
-    return {
-      added: fieldsAdded.find((ch) => ch.name?.includes(name)),
-      deleted: fieldsDeleted.find((ch) => ch.name?.includes(name)),
-      updated: fieldsUpdated.find((ch) => ch.name?.includes(name)),
-    };
-  }
-};
-
-export const getDiffValue = (oldValue: string, newValue: string) => {
-  const diff = diffWordsWithSpace(oldValue, newValue);
-
-  return diff.map((part: Change) => {
-    const diffChangeText = part.added ? 'diff-added' : 'diff-removed';
-
-    return (
-      <span
-        className={diffChangeText}
-        data-testid={`${diffChangeText}`}
-        key={part.value}>
-        {part.value}
-      </span>
-    );
-  });
-};
-
-export const getAddedDiffElement = (text: string) => {
-  return (
-    <span
-      className="diff-added text-underline"
-      data-diff="true"
-      data-testid="diff-added"
-      key={uniqueId()}>
-      {text}
-    </span>
-  );
-};
-
-export const getRemovedDiffElement = (text: string) => {
-  return (
-    <span
-      className="text-grey-muted text-line-through"
-      data-diff="true"
-      data-testid="diff-removed"
-      key={uniqueId()}>
-      {text}
-    </span>
-  );
-};
-
-export const getNormalDiffElement = (text: string) => {
-  return (
-    <span data-diff="true" data-testid="diff-normal" key={uniqueId()}>
-      {text}
-    </span>
-  );
-};
-
-export const getTextDiff = (
-  oldText: string,
-  newText: string,
-  latestText?: string
-) => {
-  const imagePlaceholder = 'data:image';
-  if (isEmpty(oldText) && isEmpty(newText)) {
-    return latestText ?? '';
-  }
-
-  if (
-    newText?.includes(imagePlaceholder) ||
-    oldText?.includes(imagePlaceholder)
-  ) {
-    return newText;
-  }
-
-  const diffArr = diffWords(toString(oldText), toString(newText));
-
-  const result = diffArr.map((diff) => {
-    if (diff.added) {
-      return ReactDOMServer.renderToString(getAddedDiffElement(diff.value));
-    }
-    if (diff.removed) {
-      return ReactDOMServer.renderToString(getRemovedDiffElement(diff.value));
-    }
-
-    return ReactDOMServer.renderToString(getNormalDiffElement(diff.value));
-  });
-
-  return result.join('');
-};
-
-const getCustomPropertyValue = (value: unknown) => {
-  if (isObject(value)) {
-    return JSON.stringify(value);
-  }
-
-  return toString(value);
-};
-
-export const getTextDiffCustomProperty = (
-  fieldName: string,
-  oldText: string,
-  newText: string
-) => {
-  if (oldText && newText) {
-    return `* ${t('message.custom-property-is-set-to-message', {
-      fieldName,
-    })} **${getTextDiff(oldText, newText)}**`;
-  }
-
-  const resultArray: unknown = getJSONFromString(oldText || newText);
-
-  if (Array.isArray(resultArray)) {
-    const result = resultArray.map((diff: Record<string, string>) => {
-      const objKeys = Object.keys(diff);
-
-      return `* ${t('message.custom-property-is-set-to-message', {
-        fieldName: objKeys[0],
-      })} **${getCustomPropertyValue(diff[objKeys[0]])}** \n`;
-    });
-
-    return result.join('');
-  }
-
-  return '';
-};
-
-export const getEntityVersionByField = (
-  changeDescription: ChangeDescription,
-  field: string,
-  fallbackText?: string
-) => {
-  const fieldDiff = getDiffByFieldName(field, changeDescription, true);
-  const oldField = getChangedEntityOldValue(fieldDiff);
-  const newField = getChangedEntityNewValue(fieldDiff);
-
-  return getTextDiff(
-    toString(oldField) ?? '',
-    toString(newField),
-    toString(fallbackText)
-  );
-};
-
-export const getTagsDiff = (
-  oldTagList: Array<TagLabel>,
-  newTagList: Array<TagLabel>
-) => {
-  const tagDiff = diffArrays<TagLabel, TagLabel>(oldTagList, newTagList);
-  const result = tagDiff
-    .map((part: ArrayChange<TagLabel>) =>
-      part.value.map((tag) => ({
-        ...tag,
-        added: part.added,
-        removed: part.removed,
-      }))
+const OwnerLabel = withSuspenseFallback(
+  lazy(() =>
+    import('../components/common/OwnerLabel/OwnerLabel.component').then(
+      (m) => ({ default: m.OwnerLabel })
     )
-    ?.flat(Infinity) as Array<TagLabelWithStatus>;
+  )
+);
 
-  return result;
-};
+// Re-export everything from EntityDiffPureUtils for backward compatibility
+export {
+  getAllChangedEntityNames,
+  getAllDiffByFieldName,
+  getChangeColumnNameFromDiffValue,
+  getChangedEntityName,
+  getChangedEntityNewValue,
+  getChangedEntityOldValue,
+  getDiffByFieldName,
+  isEndsWithField,
+} from './EntityDiffPureUtils';
 
-export const getEntityVersionTags = (
-  currentVersionData: VersionEntityTypes,
-  changeDescription: ChangeDescription
+// Re-export everything from EntityDiffUtils for backward compatibility
+export {
+  getAddedDiffElement,
+  getDiffDisplayValue,
+  getDiffValue,
+  getNormalDiffElement,
+  getRemovedDiffElement,
+  getTextDiff,
+  getTextDiffCustomProperty,
+  getTextDiffElements,
+  getUpdatedExtensionDiffFields,
+} from './EntityDiffUtils';
+
+// Re-export everything from EntityVersionUtilsPure for backward compatibility
+export {
+  addDeletedColumnsDiff,
+  getBasicEntityInfoFromVersionData,
+  getChangedEntityStatus,
+  getColumnsDataWithVersionChanges,
+  getColumnsDiff,
+  getCommonDiffsFromVersionData,
+  getCommonExtraInfoForVersionDetails,
+  getConstraintChanges,
+  getDomainDiff,
+  getEntityDescriptionDiff,
+  getEntityReferenceDiffFromFieldName,
+  getEntityTagDiff,
+  getEntityVersionByField,
+  getEntityVersionTags,
+  getGlossaryTermApprovalText,
+  getMutuallyExclusiveDiff,
+  getMutuallyExclusiveDiffLabel,
+  getNewColumnFromColDiff,
+  getOwnerDiff,
+  getParameterValuesDiff,
+  getStringEntityDiff,
+  getSummaryText,
+  getTagsDiff,
+  isMajorVersion,
+  removeDuplicateTags,
+  summaryFormatter,
+} from './EntityVersionUtilsPure';
+
+const getOwnerLabelName = (
+  reviewer: EntityReference,
+  operation: EntityChangeOperations
 ) => {
-  const tagsDiff = getDiffByFieldName('tags', changeDescription, true);
-  const oldTags: Array<TagLabel> = JSON.parse(
-    getChangedEntityOldValue(tagsDiff) ?? '[]'
-  );
-  const newTags: Array<TagLabel> = JSON.parse(
-    getChangedEntityNewValue(tagsDiff) ?? '[]'
-  );
-  const flag: { [x: string]: boolean } = {};
-  const uniqueTags: Array<TagLabelWithStatus> = [];
-
-  [
-    ...(getTagsDiff(oldTags, newTags) ?? []),
-    ...(currentVersionData.tags ?? []),
-  ].forEach((elem) => {
-    if (!flag[elem.tagFQN]) {
-      flag[elem.tagFQN] = true;
-      uniqueTags.push(elem as TagLabelWithStatus);
-    }
-  });
-
-  return getTagsWithoutTier(uniqueTags);
-};
-
-export const summaryFormatter = (fieldChange: FieldChange) => {
-  const newValueJSON = isValidJSONString(fieldChange?.newValue)
-    ? JSON.parse(fieldChange?.newValue)
-    : undefined;
-  const oldValueJSON = isValidJSONString(fieldChange?.oldValue)
-    ? JSON.parse(fieldChange?.oldValue)
-    : {};
-
-  const value = newValueJSON ?? oldValueJSON;
-
-  if (fieldChange.name === EntityField.COLUMNS) {
-    return `${t('label.column-lowercase-plural')} ${value
-      ?.map((val: TableColumn) => val?.name)
-      .join(', ')}`;
-  } else if (
-    fieldChange.name === 'tags' ||
-    fieldChange.name?.endsWith('tags')
-  ) {
-    return `${t('label.tag-lowercase-plural')} ${value
-      ?.map((val: TagLabel) => val?.tagFQN)
-      ?.join(', ')}`;
-  } else if (fieldChange.name === 'owner') {
-    return `${fieldChange.name} ${value.name}`;
-  } else {
-    return fieldChange.name;
+  switch (operation) {
+    case EntityChangeOperations.ADDED:
+      return getAddedDiffElement(getEntityName(reviewer));
+    case EntityChangeOperations.DELETED:
+      return getRemovedDiffElement(getEntityName(reviewer));
+    case EntityChangeOperations.UPDATED:
+    case EntityChangeOperations.NORMAL:
+    default:
+      return getEntityName(reviewer);
   }
-};
-
-const getGlossaryTermApprovalText = (fieldsChanged: FieldChange[]) => {
-  const statusFieldDiff = fieldsChanged.find(
-    (field) => field.name === 'status'
-  );
-  let approvalText = '';
-
-  if (statusFieldDiff) {
-    let statusLabel: string;
-    if (statusFieldDiff.newValue === 'Approved') {
-      statusLabel = t('label.approved');
-    } else if (statusFieldDiff.newValue === 'In Review') {
-      statusLabel = t('label.in-review');
-    } else {
-      statusLabel = t('label.rejected');
-    }
-    approvalText = t('message.glossary-term-status', { status: statusLabel });
-  }
-
-  return approvalText;
-};
-
-const getSummaryText = ({
-  isPrefix,
-  fieldsChanged,
-  actionType,
-  actionText,
-  isGlossaryTerm,
-}: {
-  isPrefix: boolean;
-  fieldsChanged: FieldChange[];
-  actionType: string;
-  actionText: string;
-  isGlossaryTerm?: boolean;
-}) => {
-  const prefix = isPrefix ? `+ ${actionType}` : '';
-  const filteredFieldsChanged = isGlossaryTerm
-    ? fieldsChanged.filter((field) => field.name !== 'status')
-    : fieldsChanged;
-
-  let summaryText = '';
-
-  if (!isEmpty(filteredFieldsChanged)) {
-    const suffix = isPrefix
-      ? ''
-      : t('label.has-been-action-type-lowercase', {
-          actionType: actionText,
-        });
-    summaryText = `${prefix} ${filteredFieldsChanged
-      .map(summaryFormatter)
-      .join(', ')} ${suffix} `;
-  }
-
-  const isGlossaryTermStatusUpdated = fieldsChanged.some(
-    (field) => field.name === 'status'
-  );
-
-  const glossaryTermApprovalText = isGlossaryTermStatusUpdated
-    ? getGlossaryTermApprovalText(fieldsChanged)
-    : '';
-
-  return `${glossaryTermApprovalText} ${summaryText}`;
 };
 
 const getBulkImportSummary = (fieldsUpdated: FieldChange[]) => {
@@ -457,7 +194,7 @@ export const getSummary = ({
       ) : null}
       {fieldsAdded?.length > 0 ? (
         <Typography.Paragraph>
-          {getSummaryText({
+          {Pure.getSummaryText({
             isPrefix,
             fieldsChanged: fieldsAdded,
             actionType: t('label.added'),
@@ -473,7 +210,7 @@ export const getSummary = ({
               {bulkImportSummary}
             </>
           ) : (
-            getSummaryText({
+            Pure.getSummaryText({
               isPrefix,
               fieldsChanged: fieldsUpdated,
               actionType: t('label.edited'),
@@ -485,7 +222,7 @@ export const getSummary = ({
       ) : null}
       {fieldsDeleted?.length ? (
         <Typography.Paragraph>
-          {getSummaryText({
+          {Pure.getSummaryText({
             isPrefix,
             fieldsChanged: fieldsDeleted,
             actionType: t('label.removed'),
@@ -497,620 +234,6 @@ export const getSummary = ({
   );
 };
 
-export const isMajorVersion = (version1: string, version2: string) => {
-  const v1 = Number.parseFloat(version1);
-  const v2 = Number.parseFloat(version2);
-  const flag = !Number.isNaN(v1) && !Number.isNaN(v2);
-  if (flag) {
-    return v1 + 1 === v2;
-  }
-
-  return flag;
-};
-
-// remove tags from a list if same present in b list
-export const removeDuplicateTags = (a: TagLabel[], b: TagLabel[]): TagLabel[] =>
-  a.filter(
-    (item) => !b.map((secondItem) => secondItem.tagFQN).includes(item.tagFQN)
-  );
-
-export function getEntityDescriptionDiff<A extends AssetsChildForVersionPages>(
-  entityDiff: EntityDiffProps,
-  changedEntityName?: string,
-  entityList: A[] = []
-) {
-  const oldDescription = getChangedEntityOldValue(entityDiff);
-  const newDescription = getChangedEntityNewValue(entityDiff);
-
-  const formatEntityData = (arr: Array<A>) => {
-    arr?.forEach((i) => {
-      if (isEqual(i.name, changedEntityName)) {
-        i.description = getTextDiff(
-          oldDescription ?? '',
-          newDescription ?? '',
-          i.description
-        );
-      } else {
-        formatEntityData(i?.children as Array<A>);
-      }
-    });
-  };
-
-  formatEntityData(entityList);
-
-  return entityList;
-}
-
-export function getStringEntityDiff<A extends EntityColumn>(
-  entityDiff: EntityDiffProps,
-  key: EntityField,
-  changedEntityName?: string,
-  entityList: A[] = []
-) {
-  const oldDisplayName = getChangedEntityOldValue(entityDiff);
-  const newDisplayName = getChangedEntityNewValue(entityDiff);
-
-  const formatEntityData = (arr: Array<A>) => {
-    arr?.forEach((i) => {
-      if (isEqual(i.name, changedEntityName)) {
-        i[key as keyof A] = getTextDiff(
-          oldDisplayName ?? '',
-          newDisplayName ?? '',
-          i[key as keyof typeof i] as unknown as string
-        ) as unknown as A[keyof A];
-      } else {
-        formatEntityData(i?.children as Array<A>);
-      }
-    });
-  };
-
-  formatEntityData(entityList);
-
-  return entityList;
-}
-
-export function getEntityTagDiff<A extends EntityColumn>(
-  entityDiff: EntityDiffProps,
-  changedEntityName?: string,
-  entityList?: A[]
-) {
-  const oldTags: TagLabel[] = JSON.parse(
-    getChangedEntityOldValue(entityDiff) ?? '[]'
-  );
-  const newTags: TagLabel[] = JSON.parse(
-    getChangedEntityNewValue(entityDiff) ?? '[]'
-  );
-
-  const formatColumnData = (arr: Array<A>) => {
-    arr?.forEach((i) => {
-      if (isEqual(i.name, changedEntityName)) {
-        const flag: { [x: string]: boolean } = {};
-        const uniqueTags: TagLabelWithStatus[] = [];
-        const tagsDiff = getTagsDiff(oldTags, newTags);
-
-        [...tagsDiff, ...(i.tags as TagLabelWithStatus[])].forEach(
-          (elem: TagLabelWithStatus) => {
-            if (!flag[elem.tagFQN]) {
-              flag[elem.tagFQN] = true;
-              uniqueTags.push(elem);
-            }
-          }
-        );
-        i.tags = uniqueTags;
-      } else {
-        formatColumnData(i?.children as Array<A>);
-      }
-    });
-  };
-
-  formatColumnData(entityList ?? []);
-
-  return entityList ?? [];
-}
-
-export const getEntityReferenceDiffFromFieldName = (
-  fieldName: string,
-  changeDescription: ChangeDescription,
-  entity?: EntityReference
-) => {
-  const entityDiff = getDiffByFieldName(fieldName, changeDescription, true);
-
-  const oldEntity = JSON.parse(getChangedEntityOldValue(entityDiff) ?? '{}');
-  const newEntity = JSON.parse(getChangedEntityNewValue(entityDiff) ?? '{}');
-  const entityPlaceholder = getEntityName(entity);
-
-  let entityRef = entity;
-  let entityDisplayName: ReactNode = getEntityName(entity);
-
-  if (
-    !isUndefined(entityDiff.added) ||
-    !isUndefined(entityDiff.deleted) ||
-    !isUndefined(entityDiff.updated)
-  ) {
-    entityRef = isEmpty(newEntity) ? oldEntity : newEntity;
-    entityDisplayName = getDiffValue(
-      getEntityName(oldEntity),
-      getEntityName(newEntity)
-    );
-  } else if (entity) {
-    entityDisplayName = entityPlaceholder;
-  }
-
-  return {
-    entityRef,
-    entityDisplayName,
-  };
-};
-
-const getOwnerLabelName = (
-  reviewer: EntityReference,
-  operation: EntityChangeOperations
-) => {
-  switch (operation) {
-    case EntityChangeOperations.ADDED:
-      return getAddedDiffElement(getEntityName(reviewer));
-    case EntityChangeOperations.DELETED:
-      return getRemovedDiffElement(getEntityName(reviewer));
-    case EntityChangeOperations.UPDATED:
-    case EntityChangeOperations.NORMAL:
-    default:
-      return getEntityName(reviewer);
-  }
-};
-
-export const getOwnerDiff = (
-  defaultItems: EntityReference[],
-  changeDescription?: ChangeDescription,
-  ownerField = TabSpecificField.OWNERS
-) => {
-  const fieldDiff = getDiffByFieldName(
-    ownerField,
-    changeDescription as ChangeDescription
-  );
-
-  const addedItems: EntityReference[] = JSON.parse(
-    getChangedEntityNewValue(fieldDiff) ?? '[]'
-  );
-  const deletedItems: EntityReference[] = JSON.parse(
-    getChangedEntityOldValue(fieldDiff) ?? '[]'
-  );
-
-  const unchangedItems = defaultItems.filter(
-    (item: EntityReference) =>
-      !addedItems.some((addedItem: EntityReference) => addedItem.id === item.id)
-  );
-
-  const allItems = [
-    ...unchangedItems.map((item) => ({
-      item,
-      operation: EntityChangeOperations.NORMAL,
-    })),
-    ...addedItems.map((item) => ({
-      item,
-      operation: EntityChangeOperations.ADDED,
-    })),
-    ...deletedItems.map((item) => ({
-      item,
-      operation: EntityChangeOperations.DELETED,
-    })),
-  ];
-
-  const ownerDisplayName = new Map<string, ReactNode>();
-
-  allItems.forEach(({ item, operation }) => {
-    const displayName = getOwnerLabelName(item, operation);
-    if (item.name) {
-      ownerDisplayName.set(item.name, displayName);
-    }
-  });
-
-  return {
-    owners: allItems.map(({ item }) => item),
-    ownerDisplayName: ownerDisplayName,
-  };
-};
-
-export const getDomainDiff = (
-  defaultItems: EntityReference[],
-  changeDescription?: ChangeDescription,
-  domainField = TabSpecificField.DOMAINS
-) => {
-  const fieldDiff = getDiffByFieldName(
-    domainField,
-    changeDescription as ChangeDescription
-  );
-
-  const addedItems: EntityReference[] = JSON.parse(
-    getChangedEntityNewValue(fieldDiff) ?? '[]'
-  );
-  const deletedItems: EntityReference[] = JSON.parse(
-    getChangedEntityOldValue(fieldDiff) ?? '[]'
-  );
-
-  const unchangedItems = defaultItems.filter(
-    (item: EntityReference) =>
-      !addedItems.some((addedItem: EntityReference) => addedItem.id === item.id)
-  );
-
-  const allItems = [
-    ...unchangedItems.map((item) => ({
-      item,
-      operation: EntityChangeOperations.NORMAL,
-    })),
-    ...addedItems.map((item) => ({
-      item,
-      operation: EntityChangeOperations.ADDED,
-    })),
-    ...deletedItems.map((item) => ({
-      item,
-      operation: EntityChangeOperations.DELETED,
-    })),
-  ];
-
-  return {
-    domains: allItems.map(({ item }) => item),
-    domainDisplayName: allItems.map(({ item, operation }) =>
-      getOwnerLabelName(item, operation)
-    ),
-  };
-};
-
-export const getCommonExtraInfoForVersionDetails = (
-  changeDescription: ChangeDescription,
-  owners?: EntityReference[],
-  tier?: TagLabel,
-  domains?: EntityReference[]
-) => {
-  const { owners: ownerRef, ownerDisplayName } = getOwnerDiff(
-    owners ?? [],
-    changeDescription
-  );
-
-  const { domains: domainRef, domainDisplayName } = getDomainDiff(
-    domains ?? [],
-    changeDescription
-  );
-
-  const tagsDiff = getDiffByFieldName('tags', changeDescription, true);
-  const newTier = [
-    ...JSON.parse(getChangedEntityNewValue(tagsDiff) ?? '[]'),
-  ].find((t) => (t?.tagFQN as string).startsWith('Tier'));
-
-  const oldTier = [
-    ...JSON.parse(getChangedEntityOldValue(tagsDiff) ?? '[]'),
-  ].find((t) => (t?.tagFQN as string).startsWith('Tier'));
-
-  let tierDisplayName: ReactNode = '';
-
-  if (!isUndefined(newTier) || !isUndefined(oldTier)) {
-    tierDisplayName = getDiffValue(
-      oldTier?.tagFQN?.split(FQN_SEPARATOR_CHAR)[1] ?? '',
-      newTier?.tagFQN?.split(FQN_SEPARATOR_CHAR)[1] ?? ''
-    );
-  } else if (tier?.tagFQN) {
-    tierDisplayName = tier?.tagFQN.split(FQN_SEPARATOR_CHAR)[1];
-  }
-
-  const extraInfo = {
-    ownerRef,
-    ownerDisplayName,
-    domainRef,
-    domainDisplayName,
-    tierDisplayName,
-  };
-
-  return extraInfo;
-};
-
-export function getNewColumnFromColDiff<
-  A extends TableColumn | ContainerColumn
->(newCol: Array<A>): Array<A> {
-  return newCol.map((col) => {
-    let children: Array<A> | undefined;
-    if (!isEmpty(col.children)) {
-      children = getNewColumnFromColDiff(col.children as Array<A>);
-    }
-
-    return {
-      ...col,
-      tags: col.tags?.map((tag) => ({ ...tag, removed: true })),
-      description: getTextDiff(col.description ?? '', ''),
-      dataTypeDisplay: getTextDiff(col.dataTypeDisplay ?? '', ''),
-      name: getTextDiff(col.name, ''),
-      children,
-    };
-  });
-}
-
-function createAddedColumnsDiff<A extends TableColumn | ContainerColumn>(
-  columnsDiff: EntityDiffProps,
-  colList: A[] = []
-) {
-  try {
-    const newCol: Array<A> = JSON.parse(columnsDiff.added?.newValue ?? '[]');
-
-    newCol.forEach((col) => {
-      const formatColumnData = (arr: Array<A>, updateAll?: boolean) => {
-        arr?.forEach((i) => {
-          if (isEqual(i.name, col.name) || updateAll) {
-            i.tags = i.tags?.map((tag) => ({ ...tag, added: true }));
-            i.description = getTextDiff('', i.description ?? '');
-            i.dataTypeDisplay = getTextDiff('', i.dataTypeDisplay ?? '');
-            i.name = getTextDiff('', i.name);
-            if (!isEmpty(i.children)) {
-              formatColumnData(i?.children as Array<A>, true);
-            }
-          } else {
-            formatColumnData(i?.children as Array<A>);
-          }
-        });
-      };
-      formatColumnData(colList);
-    });
-  } catch (err) {
-    // eslint-disable-next-line no-console
-    console.error(err);
-  }
-}
-
-export function addDeletedColumnsDiff<A extends TableColumn | ContainerColumn>(
-  columnsDiff: EntityDiffProps,
-  colList: A[] = [],
-  changedEntity = ''
-) {
-  try {
-    const newCol: Array<A> = JSON.parse(columnsDiff.deleted?.oldValue ?? '[]');
-    const newColumns = getNewColumnFromColDiff(newCol);
-
-    const insertNewColumn = (
-      changedEntityField: string,
-      colArray: Array<TableColumn | ContainerColumn>
-    ) => {
-      const fieldsArray = changedEntityField.split(FQN_SEPARATOR_CHAR);
-      if (isEmpty(changedEntityField)) {
-        const nonExistingColumns = newColumns.filter((newColumn) =>
-          isUndefined(colArray.find((col) => col.name === newColumn.name))
-        );
-        colArray.unshift(...nonExistingColumns);
-      } else {
-        const parentField = fieldsArray.shift();
-        const arr = colArray.find((col) => col.name === parentField)?.children;
-
-        insertNewColumn(fieldsArray.join(FQN_SEPARATOR_CHAR), arr ?? []);
-      }
-    };
-    insertNewColumn(changedEntity, colList);
-  } catch (err) {
-    // eslint-disable-next-line no-console
-    console.error(err);
-  }
-}
-
-export function getColumnsDiff<A extends TableColumn | ContainerColumn>(
-  columnsDiff: EntityDiffProps,
-  colList: A[] = [],
-  changedEntity = ''
-) {
-  if (columnsDiff.added) {
-    createAddedColumnsDiff(columnsDiff, colList);
-  }
-  if (columnsDiff.deleted) {
-    addDeletedColumnsDiff(columnsDiff, colList, changedEntity);
-  }
-
-  return uniqBy(colList, 'name');
-}
-
-export const getAllDiffByFieldName = (
-  name: string,
-  changeDescription: ChangeDescription,
-  exactMatch?: boolean
-): EntityDiffWithMultiChanges => {
-  const fieldsAdded = changeDescription?.fieldsAdded ?? [];
-  const fieldsDeleted = changeDescription?.fieldsDeleted ?? [];
-  const fieldsUpdated = changeDescription?.fieldsUpdated ?? [];
-  if (exactMatch) {
-    return {
-      added: fieldsAdded.filter((ch) => ch.name === name),
-      deleted: fieldsDeleted.filter((ch) => ch.name === name),
-      updated: fieldsUpdated.filter((ch) => ch.name === name),
-    };
-  } else {
-    return {
-      added: fieldsAdded.filter((ch) => ch.name?.includes(name)),
-      deleted: fieldsDeleted.filter((ch) => ch.name?.includes(name)),
-      updated: fieldsUpdated.filter((ch) => ch.name?.includes(name)),
-    };
-  }
-};
-
-export const getAllChangedEntityNames = (
-  diffObject: EntityDiffWithMultiChanges
-) => {
-  const changedEntityNames: string[] = [];
-  Object.keys(diffObject).forEach((key) => {
-    const changedValues = diffObject[key as keyof EntityDiffWithMultiChanges];
-
-    if (changedValues) {
-      changedValues.forEach((value) => {
-        if (value.name) {
-          changedEntityNames.push(value.name);
-        }
-      });
-    }
-  });
-
-  return changedEntityNames;
-};
-
-export function getColumnsDataWithVersionChanges<
-  A extends TableColumn | ContainerColumn | DataModelColumn
->(
-  changeDescription: ChangeDescription,
-  colList?: A[],
-  isContainerEntity?: boolean
-): Array<A> {
-  const columnsDiff = getAllDiffByFieldName(
-    EntityField.COLUMNS,
-    changeDescription
-  );
-
-  const changedFields = getAllChangedEntityNames(columnsDiff);
-
-  let newColumnsList = cloneDeep(colList);
-
-  changedFields?.forEach((changedField) => {
-    const columnDiff = getDiffByFieldName(changedField, changeDescription);
-    const changedEntityName = getChangedEntityName(columnDiff);
-    const changedColName = getChangeColumnNameFromDiffValue(changedEntityName);
-
-    if (isEndsWithField(EntityField.DESCRIPTION, changedEntityName)) {
-      newColumnsList = [
-        ...getEntityDescriptionDiff(columnDiff, changedColName, colList),
-      ];
-    } else if (isEndsWithField(EntityField.TAGS, changedEntityName)) {
-      newColumnsList = [
-        ...getEntityTagDiff(columnDiff, changedColName, colList),
-      ];
-    } else if (isEndsWithField(EntityField.DISPLAYNAME, changedEntityName)) {
-      newColumnsList = [
-        ...getStringEntityDiff(
-          columnDiff,
-          EntityField.DISPLAYNAME,
-          changedColName,
-          colList
-        ),
-      ];
-    } else if (
-      isEndsWithField(EntityField.DATA_TYPE_DISPLAY, changedEntityName)
-    ) {
-      newColumnsList = [
-        ...getStringEntityDiff(
-          columnDiff,
-          EntityField.DATA_TYPE_DISPLAY,
-          changedColName,
-          colList
-        ),
-      ];
-    } else if (!isEndsWithField(EntityField.CONSTRAINT, changedEntityName)) {
-      const changedEntity = changedEntityName
-        ?.split(FQN_SEPARATOR_CHAR)
-        .slice(isContainerEntity ? 2 : 1)
-        .join(FQN_SEPARATOR_CHAR);
-      newColumnsList = [...getColumnsDiff(columnDiff, colList, changedEntity)];
-    }
-  });
-
-  return newColumnsList ?? [];
-}
-
-export const getUpdatedExtensionDiffFields = (
-  entityDetails: ExtentionEntities[ExtentionEntitiesKeys],
-  extensionDiff: EntityDiffProps
-) => {
-  const extensionObj = entityDetails.extension;
-  const newValues = getChangedEntityNewValue(extensionDiff);
-  const oldValues = getChangedEntityOldValue(extensionDiff);
-
-  const changedFieldName = extensionDiff.updated?.name?.split('.')[1];
-
-  return extensionObj && changedFieldName
-    ? {
-        extensionObject: {
-          ...extensionObj,
-          [changedFieldName]: getTextDiff(oldValues, newValues),
-        },
-      }
-    : { extensionObject: {} };
-};
-
-export const getConstraintChanges = (
-  changeDescription: ChangeDescription,
-  fieldName: EntityField
-) => {
-  const constraintAddedDiff = getAllDiffByFieldName(
-    fieldName,
-    changeDescription
-  ).added;
-  const constraintDeletedDiff = getAllDiffByFieldName(
-    fieldName,
-    changeDescription
-  ).deleted;
-  const constraintUpdatedDiff = getAllDiffByFieldName(
-    fieldName,
-    changeDescription
-  ).updated;
-
-  const addedConstraintDiffs: FieldChange[] = [
-    ...(constraintAddedDiff ?? []),
-    ...(constraintUpdatedDiff ?? []),
-  ];
-  const deletedConstraintDiffs: FieldChange[] = [
-    ...(constraintDeletedDiff ?? []),
-    ...(constraintUpdatedDiff ?? []),
-  ];
-
-  return { addedConstraintDiffs, deletedConstraintDiffs };
-};
-
-const getMutuallyExclusiveDiffLabel = (value: boolean) => {
-  if (value) {
-    return t('label.yes');
-  } else {
-    return t('label.no');
-  }
-};
-
-export const getMutuallyExclusiveDiff = (
-  changeDescription: ChangeDescription,
-  field: string,
-  fallbackText?: string
-) => {
-  const fieldDiff = getDiffByFieldName(field, changeDescription, true);
-  const oldField = getChangedEntityOldValue(fieldDiff);
-  const newField = getChangedEntityNewValue(fieldDiff);
-
-  const oldDisplayField = getMutuallyExclusiveDiffLabel(oldField);
-  const newDisplayField = getMutuallyExclusiveDiffLabel(newField);
-
-  return getTextDiff(
-    toString(oldDisplayField) ?? '',
-    toString(newDisplayField),
-    toString(fallbackText)
-  );
-};
-
-export const getBasicEntityInfoFromVersionData = (
-  currentVersionData: VersionEntityTypes,
-  entityType: EntityType
-) => ({
-  tier: getTierTags(currentVersionData.tags ?? []),
-  owners: currentVersionData.owners,
-  domains: (currentVersionData as Exclude<VersionEntityTypes, MetadataService>)
-    .domains,
-  breadcrumbLinks: getEntityBreadcrumbs(currentVersionData, entityType),
-  changeDescription:
-    currentVersionData.changeDescription ?? ({} as ChangeDescription),
-  deleted: Boolean(currentVersionData.deleted),
-});
-
-export const getCommonDiffsFromVersionData = (
-  currentVersionData: VersionEntityTypes,
-  changeDescription: ChangeDescription
-) => ({
-  tags: getEntityVersionTags(currentVersionData, changeDescription),
-  displayName: getEntityVersionByField(
-    changeDescription,
-    EntityField.DISPLAYNAME,
-    currentVersionData.displayName
-  ),
-  description: getEntityVersionByField(
-    changeDescription,
-    EntityField.DESCRIPTION,
-    currentVersionData.description
-  ),
-});
-
 export const renderVersionButton = (
   version: string,
   current: string,
@@ -1120,7 +243,7 @@ export const renderVersionButton = (
   const currV = JSON.parse(version);
 
   const majorVersionChecks = () => {
-    return isMajorVersion(
+    return Pure.isMajorVersion(
       Number.parseFloat(currV?.changeDescription?.previousVersion)
         .toFixed(1)
         .toString(),
@@ -1141,146 +264,11 @@ export const renderVersionButton = (
   );
 };
 
-export const getChangedEntityStatus = (
-  oldValue?: string,
-  newValue?: string
-) => {
-  if (oldValue && newValue) {
-    return oldValue === newValue
-      ? EntityChangeOperations.NORMAL
-      : EntityChangeOperations.UPDATED;
-  } else if (oldValue && !newValue) {
-    return EntityChangeOperations.DELETED;
-  } else if (!oldValue && newValue) {
-    return EntityChangeOperations.ADDED;
-  }
-
-  return EntityChangeOperations.NORMAL;
-};
-
-export const getParameterValuesDiff = (
-  changeDescription: ChangeDescription,
-  defaultValues?: TestCaseParameterValue[]
-): {
-  name: string;
-  oldValue: string;
-  newValue: string;
-  status: EntityChangeOperations;
-}[] => {
-  const fieldDiff = getDiffByFieldName(
-    EntityField.PARAMETER_VALUES,
-    changeDescription,
-    true
-  );
-
-  const oldValues: TestCaseParameterValue[] =
-    getChangedEntityOldValue(fieldDiff) ?? [];
-  const newValues: TestCaseParameterValue[] =
-    getChangedEntityNewValue(fieldDiff) ?? [];
-
-  // If no diffs exist and we have default values, return them as unchanged
-  if (
-    isEmpty(oldValues) &&
-    isEmpty(newValues) &&
-    defaultValues &&
-    !isEmpty(defaultValues)
-  ) {
-    return defaultValues.map((param) => ({
-      name: String(param.name),
-      oldValue: String(param.value),
-      newValue: String(param.value),
-      status: EntityChangeOperations.NORMAL,
-    }));
-  }
-
-  const result: {
-    name: string;
-    oldValue: string;
-    newValue: string;
-    status: EntityChangeOperations;
-  }[] = [];
-
-  // Find all unique parameter names
-  const allNames = Array.from(
-    new Set([...oldValues.map((p) => p.name), ...newValues.map((p) => p.name)])
-  );
-
-  allNames.forEach((name) => {
-    const oldParam = oldValues.find((p) => p.name === name);
-    const newParam = newValues.find((p) => p.name === name);
-
-    if (oldParam && newParam) {
-      result.push({
-        name: String(name),
-        oldValue: String(oldParam.value),
-        newValue: String(newParam.value),
-        status:
-          oldParam.value === newParam.value
-            ? EntityChangeOperations.NORMAL
-            : EntityChangeOperations.UPDATED,
-      });
-    } else if (!oldParam && newParam) {
-      result.push({
-        name: String(name),
-        oldValue: '',
-        newValue: String(newParam.value),
-        status: EntityChangeOperations.ADDED,
-      });
-    } else if (oldParam && !newParam) {
-      result.push({
-        name: String(name),
-        oldValue: String(oldParam.value),
-        newValue: '',
-        status: EntityChangeOperations.DELETED,
-      });
-    }
-  });
-
-  return result;
-};
-
-// New function for React element diff (for parameter value diff only)
-export const getTextDiffElements = (
-  oldText: string,
-  newText: string
-): React.ReactNode[] => {
-  const diffArr = diffWords(toString(oldText), toString(newText));
-
-  return diffArr.map((diff) => {
-    if (diff.added) {
-      return getAddedDiffElement(diff.value);
-    }
-    if (diff.removed) {
-      return getRemovedDiffElement(diff.value);
-    }
-
-    return getNormalDiffElement(diff.value);
-  });
-};
-
-export const getDiffDisplayValue = (diff: {
-  oldValue: string;
-  newValue: string;
-  status: EntityChangeOperations;
-}) => {
-  switch (diff.status) {
-    case EntityChangeOperations.UPDATED:
-      return getTextDiffElements(diff.oldValue, diff.newValue);
-    case EntityChangeOperations.ADDED:
-      return getAddedDiffElement(diff.newValue);
-    case EntityChangeOperations.DELETED:
-      return getRemovedDiffElement(diff.oldValue);
-    case EntityChangeOperations.NORMAL:
-    default:
-      return diff.oldValue;
-  }
-};
-
 export const getParameterValueDiffDisplay = (
   changeDescription: ChangeDescription,
   defaultValues?: TestCaseParameterValue[]
 ): React.ReactNode => {
-  const diffs = getParameterValuesDiff(changeDescription, defaultValues);
+  const diffs = Pure.getParameterValuesDiff(changeDescription, defaultValues);
 
   // Separate sqlExpression from other params
   const sqlParamDiff = diffs.find((diff) => diff.name === 'sqlExpression');
@@ -1341,8 +329,8 @@ export const getComputeRowCountDiffDisplay = (
   const oldValue = getChangedEntityOldValue(fieldDiff);
   const newValue = getChangedEntityNewValue(fieldDiff);
 
-  const isOldValueUndefined = isUndefined(oldValue);
-  const isNewValueUndefined = isUndefined(newValue);
+  const isOldValueUndefined = oldValue === undefined;
+  const isNewValueUndefined = newValue === undefined;
 
   // If there's no diff, return the fallback value as normal text
   if (isOldValueUndefined && isNewValueUndefined) {
@@ -1377,7 +365,7 @@ export const getOwnerVersionLabel = (
   const defaultItems: EntityReference[] = get(entity, ownerField, []);
 
   if (isVersionView) {
-    const { owners, ownerDisplayName } = getOwnerDiff(
+    const { owners, ownerDisplayName } = Pure.getOwnerDiff(
       defaultItems,
       entity.changeDescription,
       ownerField

--- a/openmetadata-ui/src/main/resources/ui/src/utils/EntityVersionUtilsPure.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/EntityVersionUtilsPure.ts
@@ -11,7 +11,7 @@
  *  limitations under the License.
  */
 
-import {type ArrayChange, diffArrays } from 'diff';
+import { diffArrays, type ArrayChange } from 'diff';
 import {
   cloneDeep,
   isEmpty,

--- a/openmetadata-ui/src/main/resources/ui/src/utils/EntityVersionUtilsPure.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/EntityVersionUtilsPure.ts
@@ -1,0 +1,869 @@
+/*
+ *  Copyright 2025 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+import { ArrayChange, diffArrays } from 'diff';
+import {
+  cloneDeep,
+  isEmpty,
+  isEqual,
+  isUndefined,
+  toString,
+  uniqBy,
+} from 'lodash';
+import { ReactNode } from 'react';
+import { FQN_SEPARATOR_CHAR } from '../constants/char.constants';
+import { EntityField } from '../constants/Feeds.constants';
+import { EntityType, TabSpecificField } from '../enums/entity.enum';
+import { EntityChangeOperations } from '../enums/VersionPage.enum';
+import { Column as ContainerColumn } from '../generated/entity/data/container';
+import { Column as DataModelColumn } from '../generated/entity/data/dashboardDataModel';
+import { Column as TableColumn } from '../generated/entity/data/table';
+import { Field } from '../generated/entity/data/topic';
+import {
+  ChangeDescription,
+  FieldChange,
+} from '../generated/entity/services/databaseService';
+import { MetadataService } from '../generated/entity/services/metadataService';
+import { EntityReference } from '../generated/entity/type';
+import { TestCaseParameterValue } from '../generated/tests/testCase';
+import { TagLabel } from '../generated/type/tagLabel';
+import { EntityDiffProps } from '../interface/EntityVersion.interface';
+import {
+  getAllChangedEntityNames,
+  getAllDiffByFieldName,
+  getChangeColumnNameFromDiffValue,
+  getChangedEntityName,
+  getChangedEntityNewValue,
+  getChangedEntityOldValue,
+  getDiffByFieldName,
+  isEndsWithField,
+} from './EntityDiffPureUtils';
+import {
+  getAddedDiffElement,
+  getDiffValue,
+  getRemovedDiffElement,
+  getTextDiff,
+} from './EntityDiffUtils';
+import { getEntityBreadcrumbs, getEntityName } from './EntityUtils';
+import {
+  AssetsChildForVersionPages,
+  TagLabelWithStatus,
+  VersionEntityTypes,
+} from './EntityVersionUtils.interface';
+import { t } from './i18next/LocalUtil';
+import { isValidJSONString } from './StringUtils';
+import { getTagsWithoutTier, getTierTags } from './TableUtils';
+
+type EntityColumn = TableColumn | ContainerColumn | Field;
+
+export const getEntityVersionByField = (
+  changeDescription: ChangeDescription,
+  field: string,
+  fallbackText?: string
+) => {
+  const fieldDiff = getDiffByFieldName(field, changeDescription, true);
+  const oldField = getChangedEntityOldValue(fieldDiff);
+  const newField = getChangedEntityNewValue(fieldDiff);
+
+  return getTextDiff(
+    toString(oldField) ?? '',
+    toString(newField),
+    toString(fallbackText)
+  );
+};
+
+export const getTagsDiff = (
+  oldTagList: Array<TagLabel>,
+  newTagList: Array<TagLabel>
+) => {
+  const tagDiff = diffArrays<TagLabel>(oldTagList, newTagList);
+  const result = tagDiff
+    .map((part: ArrayChange<TagLabel>) =>
+      part.value.map((tag) => ({
+        ...tag,
+        added: part.added,
+        removed: part.removed,
+      }))
+    )
+    ?.flat(Infinity) as Array<TagLabelWithStatus>;
+
+  return result;
+};
+
+export const getEntityVersionTags = (
+  currentVersionData: VersionEntityTypes,
+  changeDescription: ChangeDescription
+) => {
+  const tagsDiff = getDiffByFieldName('tags', changeDescription, true);
+  const oldTags: Array<TagLabel> = JSON.parse(
+    getChangedEntityOldValue(tagsDiff) ?? '[]'
+  );
+  const newTags: Array<TagLabel> = JSON.parse(
+    getChangedEntityNewValue(tagsDiff) ?? '[]'
+  );
+  const flag: { [x: string]: boolean } = {};
+  const uniqueTags: Array<TagLabelWithStatus> = [];
+
+  [
+    ...(getTagsDiff(oldTags, newTags) ?? []),
+    ...(currentVersionData.tags ?? []),
+  ].forEach((elem) => {
+    if (!flag[elem.tagFQN]) {
+      flag[elem.tagFQN] = true;
+      uniqueTags.push(elem as TagLabelWithStatus);
+    }
+  });
+
+  return getTagsWithoutTier(uniqueTags);
+};
+
+export const summaryFormatter = (fieldChange: FieldChange) => {
+  const newValueJSON = isValidJSONString(fieldChange?.newValue)
+    ? JSON.parse(fieldChange?.newValue)
+    : undefined;
+  const oldValueJSON = isValidJSONString(fieldChange?.oldValue)
+    ? JSON.parse(fieldChange?.oldValue)
+    : {};
+
+  const value = newValueJSON ?? oldValueJSON;
+
+  if (fieldChange.name === EntityField.COLUMNS) {
+    return `${t('label.column-lowercase-plural')} ${value
+      ?.map((val: TableColumn) => val?.name)
+      .join(', ')}`;
+  } else if (
+    fieldChange.name === 'tags' ||
+    fieldChange.name?.endsWith('tags')
+  ) {
+    return `${t('label.tag-lowercase-plural')} ${value
+      ?.map((val: TagLabel) => val?.tagFQN)
+      ?.join(', ')}`;
+  } else if (fieldChange.name === 'owner') {
+    return `${fieldChange.name} ${value.name}`;
+  } else {
+    return fieldChange.name;
+  }
+};
+
+export const getGlossaryTermApprovalText = (fieldsChanged: FieldChange[]) => {
+  const statusFieldDiff = fieldsChanged.find(
+    (field) => field.name === 'status'
+  );
+  let approvalText = '';
+
+  if (statusFieldDiff) {
+    let statusLabel: string;
+    if (statusFieldDiff.newValue === 'Approved') {
+      statusLabel = t('label.approved');
+    } else if (statusFieldDiff.newValue === 'In Review') {
+      statusLabel = t('label.in-review');
+    } else {
+      statusLabel = t('label.rejected');
+    }
+    approvalText = t('message.glossary-term-status', { status: statusLabel });
+  }
+
+  return approvalText;
+};
+
+export const getSummaryText = ({
+  isPrefix,
+  fieldsChanged,
+  actionType,
+  actionText,
+  isGlossaryTerm,
+}: {
+  isPrefix: boolean;
+  fieldsChanged: FieldChange[];
+  actionType: string;
+  actionText: string;
+  isGlossaryTerm?: boolean;
+}) => {
+  const prefix = isPrefix ? `+ ${actionType}` : '';
+  const filteredFieldsChanged = isGlossaryTerm
+    ? fieldsChanged.filter((field) => field.name !== 'status')
+    : fieldsChanged;
+
+  let summaryText = '';
+
+  if (!isEmpty(filteredFieldsChanged)) {
+    const suffix = isPrefix
+      ? ''
+      : t('label.has-been-action-type-lowercase', {
+          actionType: actionText,
+        });
+    summaryText = `${prefix} ${filteredFieldsChanged
+      .map(summaryFormatter)
+      .join(', ')} ${suffix} `;
+  }
+
+  const isGlossaryTermStatusUpdated = fieldsChanged.some(
+    (field) => field.name === 'status'
+  );
+
+  const glossaryTermApprovalText = isGlossaryTermStatusUpdated
+    ? getGlossaryTermApprovalText(fieldsChanged)
+    : '';
+
+  return `${glossaryTermApprovalText} ${summaryText}`;
+};
+
+export const isMajorVersion = (version1: string, version2: string) => {
+  const v1 = Number.parseFloat(version1);
+  const v2 = Number.parseFloat(version2);
+  const flag = !Number.isNaN(v1) && !Number.isNaN(v2);
+  if (flag) {
+    return v1 + 1 === v2;
+  }
+
+  return flag;
+};
+
+// remove tags from a list if same present in b list
+export const removeDuplicateTags = (a: TagLabel[], b: TagLabel[]): TagLabel[] =>
+  a.filter(
+    (item) => !b.map((secondItem) => secondItem.tagFQN).includes(item.tagFQN)
+  );
+
+export function getEntityDescriptionDiff<A extends AssetsChildForVersionPages>(
+  entityDiff: EntityDiffProps,
+  changedEntityName?: string,
+  entityList: A[] = []
+) {
+  const oldDescription = getChangedEntityOldValue(entityDiff);
+  const newDescription = getChangedEntityNewValue(entityDiff);
+
+  const formatEntityData = (arr: Array<A>) => {
+    arr?.forEach((i) => {
+      if (isEqual(i.name, changedEntityName)) {
+        i.description = getTextDiff(
+          oldDescription ?? '',
+          newDescription ?? '',
+          i.description
+        );
+      } else {
+        formatEntityData(i?.children as Array<A>);
+      }
+    });
+  };
+
+  formatEntityData(entityList);
+
+  return entityList;
+}
+
+export function getStringEntityDiff<A extends EntityColumn>(
+  entityDiff: EntityDiffProps,
+  key: EntityField,
+  changedEntityName?: string,
+  entityList: A[] = []
+) {
+  const oldDisplayName = getChangedEntityOldValue(entityDiff);
+  const newDisplayName = getChangedEntityNewValue(entityDiff);
+
+  const formatEntityData = (arr: Array<A>) => {
+    arr?.forEach((i) => {
+      if (isEqual(i.name, changedEntityName)) {
+        i[key as keyof A] = getTextDiff(
+          oldDisplayName ?? '',
+          newDisplayName ?? '',
+          i[key as keyof typeof i] as unknown as string
+        ) as unknown as A[keyof A];
+      } else {
+        formatEntityData(i?.children as Array<A>);
+      }
+    });
+  };
+
+  formatEntityData(entityList);
+
+  return entityList;
+}
+
+export function getEntityTagDiff<A extends EntityColumn>(
+  entityDiff: EntityDiffProps,
+  changedEntityName?: string,
+  entityList?: A[]
+) {
+  const oldTags: TagLabel[] = JSON.parse(
+    getChangedEntityOldValue(entityDiff) ?? '[]'
+  );
+  const newTags: TagLabel[] = JSON.parse(
+    getChangedEntityNewValue(entityDiff) ?? '[]'
+  );
+
+  const formatColumnData = (arr: Array<A>) => {
+    arr?.forEach((i) => {
+      if (isEqual(i.name, changedEntityName)) {
+        const flag: { [x: string]: boolean } = {};
+        const uniqueTags: TagLabelWithStatus[] = [];
+        const tagsDiff = getTagsDiff(oldTags, newTags);
+
+        [...tagsDiff, ...(i.tags as TagLabelWithStatus[])].forEach(
+          (elem: TagLabelWithStatus) => {
+            if (!flag[elem.tagFQN]) {
+              flag[elem.tagFQN] = true;
+              uniqueTags.push(elem);
+            }
+          }
+        );
+        i.tags = uniqueTags;
+      } else {
+        formatColumnData(i?.children as Array<A>);
+      }
+    });
+  };
+
+  formatColumnData(entityList ?? []);
+
+  return entityList ?? [];
+}
+
+export const getEntityReferenceDiffFromFieldName = (
+  fieldName: string,
+  changeDescription: ChangeDescription,
+  entity?: EntityReference
+) => {
+  const entityDiff = getDiffByFieldName(fieldName, changeDescription, true);
+
+  const oldEntity = JSON.parse(getChangedEntityOldValue(entityDiff) ?? '{}');
+  const newEntity = JSON.parse(getChangedEntityNewValue(entityDiff) ?? '{}');
+  const entityPlaceholder = getEntityName(entity);
+
+  let entityRef = entity;
+  let entityDisplayName: ReactNode = getEntityName(entity);
+
+  if (
+    !isUndefined(entityDiff.added) ||
+    !isUndefined(entityDiff.deleted) ||
+    !isUndefined(entityDiff.updated)
+  ) {
+    entityRef = isEmpty(newEntity) ? oldEntity : newEntity;
+    entityDisplayName = getDiffValue(
+      getEntityName(oldEntity),
+      getEntityName(newEntity)
+    );
+  } else if (entity) {
+    entityDisplayName = entityPlaceholder;
+  }
+
+  return {
+    entityRef,
+    entityDisplayName,
+  };
+};
+
+const getOwnerLabelName = (
+  reviewer: EntityReference,
+  operation: EntityChangeOperations
+) => {
+  switch (operation) {
+    case EntityChangeOperations.ADDED:
+      return getAddedDiffElement(getEntityName(reviewer));
+    case EntityChangeOperations.DELETED:
+      return getRemovedDiffElement(getEntityName(reviewer));
+    case EntityChangeOperations.UPDATED:
+    case EntityChangeOperations.NORMAL:
+    default:
+      return getEntityName(reviewer);
+  }
+};
+
+export const getOwnerDiff = (
+  defaultItems: EntityReference[],
+  changeDescription?: ChangeDescription,
+  ownerField = TabSpecificField.OWNERS
+) => {
+  const fieldDiff = getDiffByFieldName(
+    ownerField,
+    changeDescription as ChangeDescription
+  );
+
+  const addedItems: EntityReference[] = JSON.parse(
+    getChangedEntityNewValue(fieldDiff) ?? '[]'
+  );
+  const deletedItems: EntityReference[] = JSON.parse(
+    getChangedEntityOldValue(fieldDiff) ?? '[]'
+  );
+
+  const unchangedItems = defaultItems.filter(
+    (item: EntityReference) =>
+      !addedItems.some((addedItem: EntityReference) => addedItem.id === item.id)
+  );
+
+  const allItems = [
+    ...unchangedItems.map((item) => ({
+      item,
+      operation: EntityChangeOperations.NORMAL,
+    })),
+    ...addedItems.map((item) => ({
+      item,
+      operation: EntityChangeOperations.ADDED,
+    })),
+    ...deletedItems.map((item) => ({
+      item,
+      operation: EntityChangeOperations.DELETED,
+    })),
+  ];
+
+  const ownerDisplayName = new Map<string, ReactNode>();
+
+  allItems.forEach(({ item, operation }) => {
+    const displayName = getOwnerLabelName(item, operation);
+    if (item.name) {
+      ownerDisplayName.set(item.name, displayName);
+    }
+  });
+
+  return {
+    owners: allItems.map(({ item }) => item),
+    ownerDisplayName: ownerDisplayName,
+  };
+};
+
+export const getDomainDiff = (
+  defaultItems: EntityReference[],
+  changeDescription?: ChangeDescription,
+  domainField = TabSpecificField.DOMAINS
+) => {
+  const fieldDiff = getDiffByFieldName(
+    domainField,
+    changeDescription as ChangeDescription
+  );
+
+  const addedItems: EntityReference[] = JSON.parse(
+    getChangedEntityNewValue(fieldDiff) ?? '[]'
+  );
+  const deletedItems: EntityReference[] = JSON.parse(
+    getChangedEntityOldValue(fieldDiff) ?? '[]'
+  );
+
+  const unchangedItems = defaultItems.filter(
+    (item: EntityReference) =>
+      !addedItems.some((addedItem: EntityReference) => addedItem.id === item.id)
+  );
+
+  const allItems = [
+    ...unchangedItems.map((item) => ({
+      item,
+      operation: EntityChangeOperations.NORMAL,
+    })),
+    ...addedItems.map((item) => ({
+      item,
+      operation: EntityChangeOperations.ADDED,
+    })),
+    ...deletedItems.map((item) => ({
+      item,
+      operation: EntityChangeOperations.DELETED,
+    })),
+  ];
+
+  return {
+    domains: allItems.map(({ item }) => item),
+    domainDisplayName: allItems.map(({ item, operation }) =>
+      getOwnerLabelName(item, operation)
+    ),
+  };
+};
+
+export const getCommonExtraInfoForVersionDetails = (
+  changeDescription: ChangeDescription,
+  owners?: EntityReference[],
+  tier?: TagLabel,
+  domains?: EntityReference[]
+) => {
+  const { owners: ownerRef, ownerDisplayName } = getOwnerDiff(
+    owners ?? [],
+    changeDescription
+  );
+
+  const { domains: domainRef, domainDisplayName } = getDomainDiff(
+    domains ?? [],
+    changeDescription
+  );
+
+  const tagsDiff = getDiffByFieldName('tags', changeDescription, true);
+  const newTier = [
+    ...JSON.parse(getChangedEntityNewValue(tagsDiff) ?? '[]'),
+  ].find((t) => (t?.tagFQN as string).startsWith('Tier'));
+
+  const oldTier = [
+    ...JSON.parse(getChangedEntityOldValue(tagsDiff) ?? '[]'),
+  ].find((t) => (t?.tagFQN as string).startsWith('Tier'));
+
+  let tierDisplayName: ReactNode = '';
+
+  if (!isUndefined(newTier) || !isUndefined(oldTier)) {
+    tierDisplayName = getDiffValue(
+      oldTier?.tagFQN?.split(FQN_SEPARATOR_CHAR)[1] ?? '',
+      newTier?.tagFQN?.split(FQN_SEPARATOR_CHAR)[1] ?? ''
+    );
+  } else if (tier?.tagFQN) {
+    tierDisplayName = tier?.tagFQN.split(FQN_SEPARATOR_CHAR)[1];
+  }
+
+  const extraInfo = {
+    ownerRef,
+    ownerDisplayName,
+    domainRef,
+    domainDisplayName,
+    tierDisplayName,
+  };
+
+  return extraInfo;
+};
+
+export function getNewColumnFromColDiff<
+  A extends TableColumn | ContainerColumn
+>(newCol: Array<A>): Array<A> {
+  return newCol.map((col) => {
+    let children: Array<A> | undefined;
+    if (!isEmpty(col.children)) {
+      children = getNewColumnFromColDiff(col.children as Array<A>);
+    }
+
+    return {
+      ...col,
+      tags: col.tags?.map((tag) => ({ ...tag, removed: true })),
+      description: getTextDiff(col.description ?? '', ''),
+      dataTypeDisplay: getTextDiff(col.dataTypeDisplay ?? '', ''),
+      name: getTextDiff(col.name, ''),
+      children,
+    };
+  });
+}
+
+function createAddedColumnsDiff<A extends TableColumn | ContainerColumn>(
+  columnsDiff: EntityDiffProps,
+  colList: A[] = []
+) {
+  try {
+    const newCol: Array<A> = JSON.parse(columnsDiff.added?.newValue ?? '[]');
+
+    newCol.forEach((col) => {
+      const formatColumnData = (arr: Array<A>, updateAll?: boolean) => {
+        arr?.forEach((i) => {
+          if (isEqual(i.name, col.name) || updateAll) {
+            i.tags = i.tags?.map((tag) => ({ ...tag, added: true }));
+            i.description = getTextDiff('', i.description ?? '');
+            i.dataTypeDisplay = getTextDiff('', i.dataTypeDisplay ?? '');
+            i.name = getTextDiff('', i.name);
+            if (!isEmpty(i.children)) {
+              formatColumnData(i?.children as Array<A>, true);
+            }
+          } else {
+            formatColumnData(i?.children as Array<A>);
+          }
+        });
+      };
+      formatColumnData(colList);
+    });
+  } catch (err) {
+    // eslint-disable-next-line no-console
+    console.error(err);
+  }
+}
+
+export function addDeletedColumnsDiff<A extends TableColumn | ContainerColumn>(
+  columnsDiff: EntityDiffProps,
+  colList: A[] = [],
+  changedEntity = ''
+) {
+  try {
+    const newCol: Array<A> = JSON.parse(columnsDiff.deleted?.oldValue ?? '[]');
+    const newColumns = getNewColumnFromColDiff(newCol);
+
+    const insertNewColumn = (
+      changedEntityField: string,
+      colArray: Array<TableColumn | ContainerColumn>
+    ) => {
+      const fieldsArray = changedEntityField.split(FQN_SEPARATOR_CHAR);
+      if (isEmpty(changedEntityField)) {
+        const nonExistingColumns = newColumns.filter((newColumn) =>
+          isUndefined(colArray.find((col) => col.name === newColumn.name))
+        );
+        colArray.unshift(...nonExistingColumns);
+      } else {
+        const parentField = fieldsArray.shift();
+        const arr = colArray.find((col) => col.name === parentField)?.children;
+
+        insertNewColumn(fieldsArray.join(FQN_SEPARATOR_CHAR), arr ?? []);
+      }
+    };
+    insertNewColumn(changedEntity, colList);
+  } catch (err) {
+    // eslint-disable-next-line no-console
+    console.error(err);
+  }
+}
+
+export function getColumnsDiff<A extends TableColumn | ContainerColumn>(
+  columnsDiff: EntityDiffProps,
+  colList: A[] = [],
+  changedEntity = ''
+) {
+  if (columnsDiff.added) {
+    createAddedColumnsDiff(columnsDiff, colList);
+  }
+  if (columnsDiff.deleted) {
+    addDeletedColumnsDiff(columnsDiff, colList, changedEntity);
+  }
+
+  return uniqBy(colList, 'name');
+}
+
+export function getColumnsDataWithVersionChanges<
+  A extends TableColumn | ContainerColumn | DataModelColumn
+>(
+  changeDescription: ChangeDescription,
+  colList?: A[],
+  isContainerEntity?: boolean
+): Array<A> {
+  const columnsDiff = getAllDiffByFieldName(
+    EntityField.COLUMNS,
+    changeDescription
+  );
+
+  const changedFields = getAllChangedEntityNames(columnsDiff);
+
+  let newColumnsList = cloneDeep(colList);
+
+  changedFields?.forEach((changedField) => {
+    const columnDiff = getDiffByFieldName(changedField, changeDescription);
+    const changedEntityName = getChangedEntityName(columnDiff);
+    const changedColName = getChangeColumnNameFromDiffValue(changedEntityName);
+
+    if (isEndsWithField(EntityField.DESCRIPTION, changedEntityName)) {
+      newColumnsList = [
+        ...getEntityDescriptionDiff(columnDiff, changedColName, colList),
+      ];
+    } else if (isEndsWithField(EntityField.TAGS, changedEntityName)) {
+      newColumnsList = [
+        ...getEntityTagDiff(columnDiff, changedColName, colList),
+      ];
+    } else if (isEndsWithField(EntityField.DISPLAYNAME, changedEntityName)) {
+      newColumnsList = [
+        ...getStringEntityDiff(
+          columnDiff,
+          EntityField.DISPLAYNAME,
+          changedColName,
+          colList
+        ),
+      ];
+    } else if (
+      isEndsWithField(EntityField.DATA_TYPE_DISPLAY, changedEntityName)
+    ) {
+      newColumnsList = [
+        ...getStringEntityDiff(
+          columnDiff,
+          EntityField.DATA_TYPE_DISPLAY,
+          changedColName,
+          colList
+        ),
+      ];
+    } else if (!isEndsWithField(EntityField.CONSTRAINT, changedEntityName)) {
+      const changedEntity = changedEntityName
+        ?.split(FQN_SEPARATOR_CHAR)
+        .slice(isContainerEntity ? 2 : 1)
+        .join(FQN_SEPARATOR_CHAR);
+      newColumnsList = [...getColumnsDiff(columnDiff, colList, changedEntity)];
+    }
+  });
+
+  return newColumnsList ?? [];
+}
+
+export const getConstraintChanges = (
+  changeDescription: ChangeDescription,
+  fieldName: EntityField
+) => {
+  const constraintAddedDiff = getAllDiffByFieldName(
+    fieldName,
+    changeDescription
+  ).added;
+  const constraintDeletedDiff = getAllDiffByFieldName(
+    fieldName,
+    changeDescription
+  ).deleted;
+  const constraintUpdatedDiff = getAllDiffByFieldName(
+    fieldName,
+    changeDescription
+  ).updated;
+
+  const addedConstraintDiffs: FieldChange[] = [
+    ...(constraintAddedDiff ?? []),
+    ...(constraintUpdatedDiff ?? []),
+  ];
+  const deletedConstraintDiffs: FieldChange[] = [
+    ...(constraintDeletedDiff ?? []),
+    ...(constraintUpdatedDiff ?? []),
+  ];
+
+  return { addedConstraintDiffs, deletedConstraintDiffs };
+};
+
+export const getMutuallyExclusiveDiffLabel = (value: boolean) => {
+  if (value) {
+    return t('label.yes');
+  } else {
+    return t('label.no');
+  }
+};
+
+export const getMutuallyExclusiveDiff = (
+  changeDescription: ChangeDescription,
+  field: string,
+  fallbackText?: string
+) => {
+  const fieldDiff = getDiffByFieldName(field, changeDescription, true);
+  const oldField = getChangedEntityOldValue(fieldDiff);
+  const newField = getChangedEntityNewValue(fieldDiff);
+
+  const oldDisplayField = getMutuallyExclusiveDiffLabel(oldField);
+  const newDisplayField = getMutuallyExclusiveDiffLabel(newField);
+
+  return getTextDiff(
+    toString(oldDisplayField) ?? '',
+    toString(newDisplayField),
+    toString(fallbackText)
+  );
+};
+
+export const getBasicEntityInfoFromVersionData = (
+  currentVersionData: VersionEntityTypes,
+  entityType: EntityType
+) => ({
+  tier: getTierTags(currentVersionData.tags ?? []),
+  owners: currentVersionData.owners,
+  domains: (currentVersionData as Exclude<VersionEntityTypes, MetadataService>)
+    .domains,
+  breadcrumbLinks: getEntityBreadcrumbs(currentVersionData, entityType),
+  changeDescription:
+    currentVersionData.changeDescription ?? ({} as ChangeDescription),
+  deleted: Boolean(currentVersionData.deleted),
+});
+
+export const getCommonDiffsFromVersionData = (
+  currentVersionData: VersionEntityTypes,
+  changeDescription: ChangeDescription
+) => ({
+  tags: getEntityVersionTags(currentVersionData, changeDescription),
+  displayName: getEntityVersionByField(
+    changeDescription,
+    EntityField.DISPLAYNAME,
+    currentVersionData.displayName
+  ),
+  description: getEntityVersionByField(
+    changeDescription,
+    EntityField.DESCRIPTION,
+    currentVersionData.description
+  ),
+});
+
+export const getChangedEntityStatus = (
+  oldValue?: string,
+  newValue?: string
+) => {
+  if (oldValue && newValue) {
+    return oldValue === newValue
+      ? EntityChangeOperations.NORMAL
+      : EntityChangeOperations.UPDATED;
+  } else if (oldValue && !newValue) {
+    return EntityChangeOperations.DELETED;
+  } else if (!oldValue && newValue) {
+    return EntityChangeOperations.ADDED;
+  }
+
+  return EntityChangeOperations.NORMAL;
+};
+
+export const getParameterValuesDiff = (
+  changeDescription: ChangeDescription,
+  defaultValues?: TestCaseParameterValue[]
+): {
+  name: string;
+  oldValue: string;
+  newValue: string;
+  status: EntityChangeOperations;
+}[] => {
+  const fieldDiff = getDiffByFieldName(
+    EntityField.PARAMETER_VALUES,
+    changeDescription,
+    true
+  );
+
+  const oldValues: TestCaseParameterValue[] =
+    getChangedEntityOldValue(fieldDiff) ?? [];
+  const newValues: TestCaseParameterValue[] =
+    getChangedEntityNewValue(fieldDiff) ?? [];
+
+  // If no diffs exist and we have default values, return them as unchanged
+  if (
+    isEmpty(oldValues) &&
+    isEmpty(newValues) &&
+    defaultValues &&
+    !isEmpty(defaultValues)
+  ) {
+    return defaultValues.map((param) => ({
+      name: String(param.name),
+      oldValue: String(param.value),
+      newValue: String(param.value),
+      status: EntityChangeOperations.NORMAL,
+    }));
+  }
+
+  const result: {
+    name: string;
+    oldValue: string;
+    newValue: string;
+    status: EntityChangeOperations;
+  }[] = [];
+
+  // Find all unique parameter names
+  const allNames = Array.from(
+    new Set([...oldValues.map((p) => p.name), ...newValues.map((p) => p.name)])
+  );
+
+  allNames.forEach((name) => {
+    const oldParam = oldValues.find((p) => p.name === name);
+    const newParam = newValues.find((p) => p.name === name);
+
+    if (oldParam && newParam) {
+      result.push({
+        name: String(name),
+        oldValue: String(oldParam.value),
+        newValue: String(newParam.value),
+        status:
+          oldParam.value === newParam.value
+            ? EntityChangeOperations.NORMAL
+            : EntityChangeOperations.UPDATED,
+      });
+    } else if (!oldParam && newParam) {
+      result.push({
+        name: String(name),
+        oldValue: '',
+        newValue: String(newParam.value),
+        status: EntityChangeOperations.ADDED,
+      });
+    } else if (oldParam && !newParam) {
+      result.push({
+        name: String(name),
+        oldValue: String(oldParam.value),
+        newValue: '',
+        status: EntityChangeOperations.DELETED,
+      });
+    }
+  });
+
+  return result;
+};

--- a/openmetadata-ui/src/main/resources/ui/src/utils/EntityVersionUtilsPure.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/EntityVersionUtilsPure.ts
@@ -11,7 +11,7 @@
  *  limitations under the License.
  */
 
-import { ArrayChange, diffArrays } from 'diff';
+import {type ArrayChange, diffArrays } from 'diff';
 import {
   cloneDeep,
   isEmpty,
@@ -20,24 +20,24 @@ import {
   toString,
   uniqBy,
 } from 'lodash';
-import { ReactNode } from 'react';
+import type { ReactNode } from 'react';
 import { FQN_SEPARATOR_CHAR } from '../constants/char.constants';
 import { EntityField } from '../constants/Feeds.constants';
-import { EntityType, TabSpecificField } from '../enums/entity.enum';
+import { TabSpecificField, type EntityType } from '../enums/entity.enum';
 import { EntityChangeOperations } from '../enums/VersionPage.enum';
-import { Column as ContainerColumn } from '../generated/entity/data/container';
-import { Column as DataModelColumn } from '../generated/entity/data/dashboardDataModel';
-import { Column as TableColumn } from '../generated/entity/data/table';
-import { Field } from '../generated/entity/data/topic';
-import {
+import type { Column as ContainerColumn } from '../generated/entity/data/container';
+import type { Column as DataModelColumn } from '../generated/entity/data/dashboardDataModel';
+import type { Column as TableColumn } from '../generated/entity/data/table';
+import type { Field } from '../generated/entity/data/topic';
+import type {
   ChangeDescription,
   FieldChange,
 } from '../generated/entity/services/databaseService';
-import { MetadataService } from '../generated/entity/services/metadataService';
-import { EntityReference } from '../generated/entity/type';
-import { TestCaseParameterValue } from '../generated/tests/testCase';
-import { TagLabel } from '../generated/type/tagLabel';
-import { EntityDiffProps } from '../interface/EntityVersion.interface';
+import type { MetadataService } from '../generated/entity/services/metadataService';
+import type { EntityReference } from '../generated/entity/type';
+import type { TestCaseParameterValue } from '../generated/tests/testCase';
+import type { TagLabel } from '../generated/type/tagLabel';
+import type { EntityDiffProps } from '../interface/EntityVersion.interface';
 import {
   getAllChangedEntityNames,
   getAllDiffByFieldName,
@@ -55,7 +55,7 @@ import {
   getTextDiff,
 } from './EntityDiffUtils';
 import { getEntityBreadcrumbs, getEntityName } from './EntityUtils';
-import {
+import type {
   AssetsChildForVersionPages,
   TagLabelWithStatus,
   VersionEntityTypes,

--- a/openmetadata-ui/src/main/resources/ui/src/utils/MlModelVersionUtils.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/MlModelVersionUtils.ts
@@ -13,12 +13,12 @@
 
 import { cloneDeep, isEqual } from 'lodash';
 import { EntityField } from '../constants/Feeds.constants';
-import {
+import type {
   ChangeDescription,
   MlFeature,
   Mlmodel,
 } from '../generated/entity/data/mlmodel';
-import { VersionData } from '../pages/EntityVersionPage/EntityVersionPage.component';
+import type { VersionData } from '../pages/EntityVersionPage/EntityVersionPage.component';
 import {
   getAllChangedEntityNames,
   getAllDiffByFieldName,
@@ -27,7 +27,7 @@ import {
   getDiffByFieldName,
 } from './EntityDiffPureUtils';
 import { getTextDiff } from './EntityDiffUtils';
-import { TagLabelWithStatus } from './EntityVersionUtils.interface';
+import type { TagLabelWithStatus } from './EntityVersionUtils.interface';
 import { getTagsDiff, removeDuplicateTags } from './EntityVersionUtilsPure';
 
 const handleFeatureDescriptionChangeDiff = (

--- a/openmetadata-ui/src/main/resources/ui/src/utils/MlModelVersionUtils.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/MlModelVersionUtils.ts
@@ -27,8 +27,8 @@ import {
   getDiffByFieldName,
 } from './EntityDiffPureUtils';
 import { getTextDiff } from './EntityDiffUtils';
-import { getTagsDiff, removeDuplicateTags } from './EntityVersionUtilsPure';
 import { TagLabelWithStatus } from './EntityVersionUtils.interface';
+import { getTagsDiff, removeDuplicateTags } from './EntityVersionUtilsPure';
 
 const handleFeatureDescriptionChangeDiff = (
   colList: Mlmodel['mlFeatures'],

--- a/openmetadata-ui/src/main/resources/ui/src/utils/MlModelVersionUtils.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/MlModelVersionUtils.ts
@@ -25,10 +25,9 @@ import {
   getChangedEntityNewValue,
   getChangedEntityOldValue,
   getDiffByFieldName,
-  getTagsDiff,
-  getTextDiff,
-  removeDuplicateTags,
-} from './EntityVersionUtils';
+} from './EntityDiffPureUtils';
+import { getTextDiff } from './EntityDiffUtils';
+import { getTagsDiff, removeDuplicateTags } from './EntityVersionUtilsPure';
 import { TagLabelWithStatus } from './EntityVersionUtils.interface';
 
 const handleFeatureDescriptionChangeDiff = (

--- a/openmetadata-ui/src/main/resources/ui/src/utils/PipelineVersionUtils.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/PipelineVersionUtils.ts
@@ -24,10 +24,10 @@ import {
   getChangedEntityNewValue,
   getChangedEntityOldValue,
   getDiffByFieldName,
-  getTagsDiff,
-  getTextDiff,
   isEndsWithField,
-} from './EntityVersionUtils';
+} from './EntityDiffPureUtils';
+import { getTextDiff } from './EntityDiffUtils';
+import { getTagsDiff } from './EntityVersionUtilsPure';
 import { TagLabelWithStatus } from './EntityVersionUtils.interface';
 
 const handleTaskDescriptionChangeDiff = (

--- a/openmetadata-ui/src/main/resources/ui/src/utils/PipelineVersionUtils.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/PipelineVersionUtils.ts
@@ -27,8 +27,8 @@ import {
   isEndsWithField,
 } from './EntityDiffPureUtils';
 import { getTextDiff } from './EntityDiffUtils';
-import { getTagsDiff } from './EntityVersionUtilsPure';
 import { TagLabelWithStatus } from './EntityVersionUtils.interface';
+import { getTagsDiff } from './EntityVersionUtilsPure';
 
 const handleTaskDescriptionChangeDiff = (
   tasksDiff: EntityDiffProps,

--- a/openmetadata-ui/src/main/resources/ui/src/utils/PipelineVersionUtils.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/PipelineVersionUtils.ts
@@ -13,10 +13,13 @@
 
 import { cloneDeep, isEqual, uniqBy } from 'lodash';
 import { EntityField } from '../constants/Feeds.constants';
-import { ChangeDescription, Pipeline } from '../generated/entity/data/pipeline';
-import { TagLabel } from '../generated/type/tagLabel';
-import { EntityDiffProps } from '../interface/EntityVersion.interface';
-import { VersionData } from '../pages/EntityVersionPage/EntityVersionPage.component';
+import type {
+  ChangeDescription,
+  Pipeline,
+} from '../generated/entity/data/pipeline';
+import type { TagLabel } from '../generated/type/tagLabel';
+import type { EntityDiffProps } from '../interface/EntityVersion.interface';
+import type { VersionData } from '../pages/EntityVersionPage/EntityVersionPage.component';
 import {
   getAllChangedEntityNames,
   getAllDiffByFieldName,
@@ -27,7 +30,7 @@ import {
   isEndsWithField,
 } from './EntityDiffPureUtils';
 import { getTextDiff } from './EntityDiffUtils';
-import { TagLabelWithStatus } from './EntityVersionUtils.interface';
+import type { TagLabelWithStatus } from './EntityVersionUtils.interface';
 import { getTagsDiff } from './EntityVersionUtilsPure';
 
 const handleTaskDescriptionChangeDiff = (

--- a/openmetadata-ui/src/main/resources/ui/src/utils/SchemaVersionUtils.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/SchemaVersionUtils.ts
@@ -28,12 +28,14 @@ import {
   getChangeColumnNameFromDiffValue,
   getChangedEntityName,
   getDiffByFieldName,
+  isEndsWithField,
+} from './EntityDiffPureUtils';
+import { getTextDiff } from './EntityDiffUtils';
+import {
   getEntityDescriptionDiff,
   getEntityTagDiff,
   getStringEntityDiff,
-  getTextDiff,
-  isEndsWithField,
-} from './EntityVersionUtils';
+} from './EntityVersionUtilsPure';
 
 export function getNewFieldFromSchemaFieldDiff(
   newCol: Array<Field>

--- a/openmetadata-ui/src/main/resources/ui/src/utils/SchemaVersionUtils.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/SchemaVersionUtils.ts
@@ -14,14 +14,14 @@
 import { cloneDeep, isEmpty, isEqual, isUndefined } from 'lodash';
 import { FQN_SEPARATOR_CHAR } from '../constants/char.constants';
 import { EntityField } from '../constants/Feeds.constants';
-import {
+import type {
   ChangeDescription,
   DataTypeTopic,
   Field,
   MessageSchemaObject,
 } from '../generated/entity/data/topic';
-import { APISchema } from '../generated/type/apiSchema';
-import { EntityDiffProps } from '../interface/EntityVersion.interface';
+import type { APISchema } from '../generated/type/apiSchema';
+import type { EntityDiffProps } from '../interface/EntityVersion.interface';
 import {
   getAllChangedEntityNames,
   getAllDiffByFieldName,

--- a/openmetadata-ui/src/main/resources/ui/src/utils/SearchIndexVersionUtils.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/SearchIndexVersionUtils.ts
@@ -30,8 +30,8 @@ import {
   isEndsWithField,
 } from './EntityDiffPureUtils';
 import { getTextDiff } from './EntityDiffUtils';
-import { getTagsDiff } from './EntityVersionUtilsPure';
 import { TagLabelWithStatus } from './EntityVersionUtils.interface';
+import { getTagsDiff } from './EntityVersionUtilsPure';
 
 const handleFieldDescriptionChangeDiff = (
   fieldsDiff: EntityDiffProps,

--- a/openmetadata-ui/src/main/resources/ui/src/utils/SearchIndexVersionUtils.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/SearchIndexVersionUtils.ts
@@ -27,10 +27,10 @@ import {
   getChangedEntityNewValue,
   getChangedEntityOldValue,
   getDiffByFieldName,
-  getTagsDiff,
-  getTextDiff,
   isEndsWithField,
-} from './EntityVersionUtils';
+} from './EntityDiffPureUtils';
+import { getTextDiff } from './EntityDiffUtils';
+import { getTagsDiff } from './EntityVersionUtilsPure';
 import { TagLabelWithStatus } from './EntityVersionUtils.interface';
 
 const handleFieldDescriptionChangeDiff = (

--- a/openmetadata-ui/src/main/resources/ui/src/utils/SearchIndexVersionUtils.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/SearchIndexVersionUtils.ts
@@ -13,13 +13,13 @@
 
 import { cloneDeep, isEqual, uniqBy } from 'lodash';
 import { EntityField } from '../constants/Feeds.constants';
-import {
+import type {
   ChangeDescription,
   SearchIndex,
 } from '../generated/entity/data/searchIndex';
-import { TagLabel } from '../generated/type/tagLabel';
-import { EntityDiffProps } from '../interface/EntityVersion.interface';
-import { VersionData } from '../pages/EntityVersionPage/EntityVersionPage.component';
+import type { TagLabel } from '../generated/type/tagLabel';
+import type { EntityDiffProps } from '../interface/EntityVersion.interface';
+import type { VersionData } from '../pages/EntityVersionPage/EntityVersionPage.component';
 import {
   getAllChangedEntityNames,
   getAllDiffByFieldName,
@@ -30,7 +30,7 @@ import {
   isEndsWithField,
 } from './EntityDiffPureUtils';
 import { getTextDiff } from './EntityDiffUtils';
-import { TagLabelWithStatus } from './EntityVersionUtils.interface';
+import type { TagLabelWithStatus } from './EntityVersionUtils.interface';
 import { getTagsDiff } from './EntityVersionUtilsPure';
 
 const handleFieldDescriptionChangeDiff = (


### PR DESCRIPTION
## Summary
- Split monolithic `EntityVersionUtils.tsx` (~1420 lines) into 4 focused modules:
  - `EntityDiffPureUtils.ts` — 8 pure diff accessor functions (no React dependencies)
  - `EntityDiffUtils.tsx` — 9 JSX diff rendering functions
  - `EntityVersionUtilsPure.ts` — 31 pure version processing functions
  - `EntityVersionClassBase.ts` — lazy-load component registry for version pages
- Slimmed `EntityVersionUtils.tsx` to ~340 lines with re-exports for backward compatibility
- Migrated `EntityVersionPage` to use lazy-loaded components via `EntityVersionClassBase` + `Suspense`
- Updated 6 consumer files to import directly from new modules

Ref: https://github.com/open-metadata/openmetadata-collate/issues/4230

## Test plan
- [ ] Verify version pages render correctly for all entity types (Table, Topic, Dashboard, Pipeline, etc.)
- [ ] Verify version diff highlighting works (added/removed/updated fields)
- [ ] Verify version timeline and summary display correctly
- [ ] Verify lazy-loaded components show loader fallback during chunk loading
- [ ] Run existing unit tests: `yarn test`
- [ ] Run TypeScript type check: `npx tsc --noEmit`

🤖 Generated with [Claude Code](https://claude.com/claude-code)