### PR TITLE
test(ui): harden glossary import/export permission tests

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/Glossary/GlossaryHeader/GlossaryHeader.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Glossary/GlossaryHeader/GlossaryHeader.test.tsx
@@ -181,6 +181,13 @@ jest.mock('../../Customization/GenericProvider/GenericProvider', () => ({
 }));
 
 describe('GlossaryHeader component', () => {
+  beforeEach(() => {
+    mockGlossaryTermPermission.All = true;
+    mockGlossaryTermPermission.EditAll = true;
+    mockContext.type = EntityType.GLOSSARY;
+    mockContext.permissions = DEFAULT_ENTITY_PERMISSION;
+  });
+
   it('should render name of Glossary', () => {
     render(
       <GlossaryHeader
@@ -268,6 +275,9 @@ describe('GlossaryHeader component', () => {
   });
 
   it('should render ChangeParentHierarchy component after clicking dropdown menu item', async () => {
+    mockContext.type = EntityType.GLOSSARY_TERM;
+    mockContext.permissions = { ...DEFAULT_ENTITY_PERMISSION, EditAll: true };
+
     render(
       <GlossaryHeader
         updateVote={mockOnUpdateVote}
@@ -294,6 +304,9 @@ describe('GlossaryHeader component', () => {
   });
 
   it('should not render ChangeParentHierarchy component after onCancel call', async () => {
+    mockContext.type = EntityType.GLOSSARY_TERM;
+    mockContext.permissions = { ...DEFAULT_ENTITY_PERMISSION, EditAll: true };
+
     render(
       <GlossaryHeader
         updateVote={mockOnUpdateVote}
@@ -351,6 +364,28 @@ describe('GlossaryHeader component', () => {
       expect(screen.queryByText('label.export')).toBeInTheDocument();
     });
 
+    it('should show import/export when entity-level All permission is granted via conditional policy', async () => {
+      mockGlossaryTermPermission.All = false;
+      mockGlossaryTermPermission.EditAll = false;
+      mockContext.type = EntityType.GLOSSARY;
+      mockContext.permissions = { ...DEFAULT_ENTITY_PERMISSION, All: true };
+
+      render(
+        <GlossaryHeader
+          updateVote={mockOnUpdateVote}
+          onAddGlossaryTerm={mockOnDelete}
+          onDelete={mockOnDelete}
+        />
+      );
+
+      await act(async () => {
+        fireEvent.click(screen.getByTestId('manage-button'));
+      });
+
+      expect(screen.queryByText('label.import')).toBeInTheDocument();
+      expect(screen.queryByText('label.export')).toBeInTheDocument();
+    });
+
     it('should hide import/export when both globalPermissions and entity-level permissions deny', async () => {
       // Both resource-level and entity-level permissions deny — user is not the
       // owner and no other condition grants access.
@@ -373,6 +408,32 @@ describe('GlossaryHeader component', () => {
       );
 
       expect(screen.queryByTestId('manage-button')).not.toBeInTheDocument();
+    });
+
+    it('should hide import/export when only a non-edit permission is granted at entity level', async () => {
+      mockGlossaryTermPermission.All = false;
+      mockGlossaryTermPermission.EditAll = false;
+      mockContext.type = EntityType.GLOSSARY;
+      mockContext.permissions = {
+        ...DEFAULT_ENTITY_PERMISSION,
+        Delete: true,
+        ViewAll: true,
+      };
+
+      render(
+        <GlossaryHeader
+          updateVote={mockOnUpdateVote}
+          onAddGlossaryTerm={mockOnDelete}
+          onDelete={mockOnDelete}
+        />
+      );
+
+      await act(async () => {
+        fireEvent.click(screen.getByTestId('manage-button'));
+      });
+
+      expect(screen.queryByText('label.import')).not.toBeInTheDocument();
+      expect(screen.queryByText('label.export')).not.toBeInTheDocument();
     });
   });
 });


### PR DESCRIPTION
## What

Follow-up to #27488 (which restored the glossary Import/Export buttons when `EditAll` is granted via a conditional policy such as `isOwner()`). This strengthens the test coverage and isolation around that logic in `GlossaryHeader`.

## Changes

- **Isolate shared mock state** — add a `beforeEach` that resets `mockGlossaryTermPermission` and `mockContext`, so tests no longer depend on state leaking between them in source order.
- **Make the `ChangeParentHierarchy` tests self-contained** — they previously passed only by inheriting leaked `GLOSSARY_TERM` + `EditAll` state from an earlier test; with the reset in place they now set their own context.
- **Cover the entity-level `All` operand** — the `permissions[Operation.All]` branch of `importExportPermissions` was never exercised; the new test fails if that operand is removed, so it genuinely guards it.
- **Guard against over-granting** — confirm a non-edit entity permission (`Delete` / `ViewAll`) does not surface Import/Export, while the manage menu still renders via `Delete`.

## Test

`jest GlossaryHeader.test.tsx` → **11/11 passing**. Also verified the new `All`-path test fails when `permissions[Operation.All]` is removed from the component, confirming it guards the intended branch.