### PR TITLE
fix(tests): mark drag and drop tests as slow to improve stability

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/TeamsDragAndDrop.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/TeamsDragAndDrop.spec.ts
@@ -158,6 +158,7 @@ test.describe(
       test(`Should drag and drop on ${TEAM_TYPE_BY_NAME[droppableTeamName]} team type`, async ({
         page,
       }) => {
+        test.slow();
         // Nested team will be shown once anything is moved under it
         if (index !== 0) {
           await openDragDropDropdown(page, teams[index - 1]);
@@ -181,6 +182,7 @@ test.describe(
     }
 
     test(`Should drag and drop team on table level`, async ({ page }) => {
+      test.slow();
       // Open department team dropdown as it is moved under it from last test
       await openDragDropDropdown(page, teamNameDepartment);
 


### PR DESCRIPTION
### Describe your changes:

I marked the Teams **drag-and-drop** Playwright tests as `test.slow()` because they were intermittently timing out during nightly runs. Drag-and-drop interactions (open dropdown → drag a team → drop it under another) involve multiple sequential UI actions and animations that take longer to settle than the default Playwright timeout allows, especially under the heavier load of the nightly pipeline. `test.slow()` triples the timeout for these specific tests, giving the drag-and-drop sequence enough time to complete and making the suite reliable without affecting other tests.

#
### Type of change:
- [x] Bug fix (test stability)

#
### High-level design:

N/A — small change. Added `test.slow()` to the two team drag-and-drop test blocks in `TeamsDragAndDrop.spec.ts`.

#
### Tests:

#### Playwright (UI) tests
- Files updated: `openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/TeamsDragAndDrop.spec.ts`
- Change: added `test.slow()` to the two drag-and-drop scenarios so their timeout is tripled.

#### Manual testing performed
1. Ran the `TeamsDragAndDrop` spec locally and confirmed it passes consistently.
2. Verified the tripled timeout resolves the intermittent nightly timeouts on the drag-and-drop steps.

#
### UI screen recording / screenshots:

Not applicable — test-only change, no product code or UI behavior modified.

#
### Checklist:
- [x] I have read the **CONTRIBUTING** document.
- [x] My PR is a test-stability fix.
