### PR TITLE
fix(ui): avoid sample data children column crash

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/Database/SampleDataTable/SampleDataTable.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Database/SampleDataTable/SampleDataTable.component.tsx
@@ -58,6 +58,9 @@ import {
   ROW_LIMIT_OPTIONS,
 } from './SampleDataTable.utils';
 
+const SAMPLE_DATA_CHILDREN_COLUMN_NAME =
+  '__openmetadata_sample_data_children__';
+
 const SampleDataTable: FC<SampleDataProps> = ({
   isTableDeleted,
   tableId,
@@ -337,6 +340,7 @@ const SampleDataTable: FC<SampleDataProps> = ({
       </Space>
 
       <TableComponent
+        childrenColumnName={SAMPLE_DATA_CHILDREN_COLUMN_NAME}
         columns={sampleData?.columns}
         data-testid="sample-data-table"
         dataSource={slicedRows}

--- a/openmetadata-ui/src/main/resources/ui/src/components/Database/SampleDataTable/SampleDataTable.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Database/SampleDataTable/SampleDataTable.test.tsx
@@ -80,6 +80,31 @@ describe('Test SampleDataTable Component', () => {
     expect(table).toBeInTheDocument();
   });
 
+  it('Renders sample data when a column is named children', async () => {
+    (getSampleDataByTableId as jest.Mock).mockImplementationOnce(() =>
+      Promise.resolve({
+        ...MOCK_TABLE,
+        columns: [
+          { ...MOCK_TABLE.columns[0], name: 'id' },
+          { ...MOCK_TABLE.columns[1], name: 'children' },
+          { ...MOCK_TABLE.columns[2], name: 'active' },
+        ],
+        sampleData: {
+          columns: ['id', 'children', 'active'],
+          rows: [['1', false, true]],
+        },
+      })
+    );
+
+    await act(async () => {
+      render(<SampleDataTable {...mockProps} />);
+    });
+
+    expect(screen.getByText('children')).toBeInTheDocument();
+    expect(screen.getByText('false')).toBeInTheDocument();
+    expect(screen.getByText('true')).toBeInTheDocument();
+  });
+
   it('Sample Data menu dropdown should not be present when not have permission', async () => {
     await act(async () => {
       render(


### PR DESCRIPTION
## Description

Fixes #28585.

The Sample Data table can receive user-defined column names, including `children`. Ant Design treats `children` as its default tree-data field, so a scalar sample value under that column can be interpreted as expandable row data and crash the table.

This sets a non-conflicting `childrenColumnName` only for the Sample Data table and adds regression coverage for rendering a sample column named `children`.

## Tests

- `npm_config_cache=/tmp/openmetadata-npm-cache npx --yes prettier@2.8.8 --config './.prettierrc.yaml' --ignore-path './.prettierignore' --check src/components/Database/SampleDataTable/SampleDataTable.component.tsx src/components/Database/SampleDataTable/SampleDataTable.test.tsx`
- `git diff --check`

Not run locally:

- `yarn test src/components/Database/SampleDataTable/SampleDataTable.test.tsx --runInBand`
- `yarn lint:base src/components/Database/SampleDataTable/SampleDataTable.component.tsx src/components/Database/SampleDataTable/SampleDataTable.test.tsx`

The full UI dependency install could not complete on this machine because it exhausted available local disk space.
