### PR TITLE
fix(security): trust server /auth/callback in SAML SSO redirect allowlist

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/security/auth/SamlAuthServletHandler.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/security/auth/SamlAuthServletHandler.java
@@ -639,12 +639,12 @@ public class SamlAuthServletHandler implements AuthServeletHandler {
       try {
         URI uri = new URI(acs);
         if (uri.getScheme() != null && uri.getHost() != null) {
-          int port = uri.getPort();
-          String origin = uri.getScheme() + "://" + uri.getHost() + (port == -1 ? "" : ":" + port);
+          URI origin =
+              new URI(uri.getScheme(), null, uri.getHost(), uri.getPort(), null, null, null);
           authCallback = origin + "/auth/callback";
         }
       } catch (URISyntaxException e) {
-        LOG.warn("Could not derive SAML server origin from ACS URL: {}", acs);
+        LOG.warn("Could not derive SAML server origin from ACS URL: {}", acs, e);
       }
     }
     return authCallback;

--- a/openmetadata-service/src/main/java/org/openmetadata/service/security/auth/SamlAuthServletHandler.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/security/auth/SamlAuthServletHandler.java
@@ -13,6 +13,8 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.ws.rs.BadRequestException;
 import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -625,7 +627,27 @@ public class SamlAuthServletHandler implements AuthServeletHandler {
 
   private Set<String> trustedSamlRedirects() {
     return org.openmetadata.service.security.SecurityUtil.trustedRedirects(
-        authConfig.getCallbackUrl(), samlSpCallback());
+        authConfig.getCallbackUrl(), samlSpCallback(), samlAuthCallback());
+  }
+
+  private String samlAuthCallback() {
+    SamlSSOClientConfig samlConfig = authConfig.getSamlConfiguration();
+    String acs =
+        (samlConfig == null || samlConfig.getSp() == null) ? null : samlConfig.getSp().getAcs();
+    String authCallback = null;
+    if (!nullOrEmpty(acs)) {
+      try {
+        URI uri = new URI(acs);
+        if (uri.getScheme() != null && uri.getHost() != null) {
+          int port = uri.getPort();
+          String origin = uri.getScheme() + "://" + uri.getHost() + (port == -1 ? "" : ":" + port);
+          authCallback = origin + "/auth/callback";
+        }
+      } catch (URISyntaxException e) {
+        LOG.warn("Could not derive SAML server origin from ACS URL: {}", acs);
+      }
+    }
+    return authCallback;
   }
 
   private String defaultSamlRedirectUri() {

--- a/openmetadata-service/src/test/java/org/openmetadata/service/security/auth/SamlAuthServletHandlerTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/security/auth/SamlAuthServletHandlerTest.java
@@ -176,6 +176,33 @@ class SamlAuthServletHandlerTest {
   }
 
   @Test
+  void handleLogin_trustsServerAuthCallbackRouteForIpv6Host() {
+    when(serviceProviderConfig.getAcs()).thenReturn("http://[::1]:8585/api/v1/saml/acs");
+    when(request.getParameter("callback")).thenReturn(null);
+    when(request.getParameter("redirectUri")).thenReturn("http://[::1]:8585/auth/callback");
+    when(sessionService.createPendingSession(
+            eq(request),
+            eq(response),
+            eq("saml"),
+            eq("http://[::1]:8585/auth/callback"),
+            any(),
+            any(),
+            any()))
+        .thenReturn(new UserSession());
+
+    try (MockedStatic<SamlSettingsHolder> samlSettingsHolder =
+        mockStatic(SamlSettingsHolder.class)) {
+      samlSettingsHolder.when(SamlSettingsHolder::getSaml2Settings).thenReturn(null);
+
+      handler.handleLogin(request, response);
+    }
+
+    verify(sessionService)
+        .createPendingSession(
+            request, response, "saml", "http://[::1]:8585/auth/callback", null, null, null);
+  }
+
+  @Test
   void handleLogin_trustsSamlSpCallbackWhenTopLevelCallbackUrlUnset() {
     when(authConfig.getCallbackUrl()).thenReturn("");
     when(request.getParameter("callback")).thenReturn("https://saml.example.com/callback");

--- a/openmetadata-service/src/test/java/org/openmetadata/service/security/auth/SamlAuthServletHandlerTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/security/auth/SamlAuthServletHandlerTest.java
@@ -149,6 +149,33 @@ class SamlAuthServletHandlerTest {
   }
 
   @Test
+  void handleLogin_trustsServerAuthCallbackRoute() {
+    when(serviceProviderConfig.getAcs()).thenReturn("https://app.example.com/api/v1/saml/acs");
+    when(request.getParameter("callback")).thenReturn(null);
+    when(request.getParameter("redirectUri")).thenReturn("https://app.example.com/auth/callback");
+    when(sessionService.createPendingSession(
+            eq(request),
+            eq(response),
+            eq("saml"),
+            eq("https://app.example.com/auth/callback"),
+            any(),
+            any(),
+            any()))
+        .thenReturn(new UserSession());
+
+    try (MockedStatic<SamlSettingsHolder> samlSettingsHolder =
+        mockStatic(SamlSettingsHolder.class)) {
+      samlSettingsHolder.when(SamlSettingsHolder::getSaml2Settings).thenReturn(null);
+
+      handler.handleLogin(request, response);
+    }
+
+    verify(sessionService)
+        .createPendingSession(
+            request, response, "saml", "https://app.example.com/auth/callback", null, null, null);
+  }
+
+  @Test
   void handleLogin_trustsSamlSpCallbackWhenTopLevelCallbackUrlUnset() {
     when(authConfig.getCallbackUrl()).thenReturn("");
     when(request.getParameter("callback")).thenReturn("https://saml.example.com/callback");


### PR DESCRIPTION
## What

SAML SSO logins fail with HTTP 400 `{"error":"Redirect URI must exactly match a trusted redirect URI"}` at `/api/v1/auth/login`, because `SamlAuthServletHandler.trustedSamlRedirects()` does not allowlist the `/auth/callback` route that the frontend (`GenericAuthenticator`) sends as `redirectUri`. It trusted only `authConfig.callbackUrl` and the SP `callback`. (The OIDC path already trusts `serverUrl + "/auth/callback"`.)

## Changes

- Derive the server origin from the configured SP ACS URL and add `<origin>/auth/callback` to the SAML trusted redirects, mirroring the OIDC path.
- `/mcp/callback` is intentionally omitted — MCP-over-SAML carries its request id in the SAML `RelayState` and never consults this allowlist.
- Add regression test `handleLogin_trustsServerAuthCallbackRoute`.

