### PR TITLE
chore(styles): remove unused Poppins font

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/package.json
+++ b/openmetadata-ui/src/main/resources/ui/package.json
@@ -66,7 +66,6 @@
     "@emotion/react": "^11.14.0",
     "@emotion/styled": "^11.14.1",
     "@fontsource-variable/inter": "^5.2.8",
-    "@fontsource/poppins": "^5.0.0",
     "@fontsource/source-code-pro": "^5.0.0",
     "@github/g-emoji-element": "^1.1.5",
     "@internationalized/date": "^3.11.0",

--- a/openmetadata-ui/src/main/resources/ui/src/styles/index.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/styles/index.ts
@@ -11,10 +11,6 @@
  *  limitations under the License.
  */
 
-import '@fontsource/poppins'; // Font 400
-import '@fontsource/poppins/300.css'; // Font 300
-import '@fontsource/poppins/500.css'; // Font 500
-import '@fontsource/poppins/600.css'; // Font 600
 import '@fontsource/source-code-pro'; // Font 400
 
 // Variable Inter aliased under the "Inter" family name. Loads one woff2 per

--- a/openmetadata-ui/src/main/resources/ui/yarn.lock
+++ b/openmetadata-ui/src/main/resources/ui/yarn.lock
@@ -1785,11 +1785,6 @@
   resolved "https://registry.yarnpkg.com/@fontsource-variable/inter/-/inter-5.2.8.tgz#29b11476f5149f6a443b4df6516e26002d87941a"
   integrity sha512-kOfP2D+ykbcX/P3IFnokOhVRNoTozo5/JxhAIVYLpea/UBmCQ/YWPBfWIDuBImXX/15KH+eKh4xpEUyS2sQQGQ==
 
-"@fontsource/poppins@^5.0.0":
-  version "5.2.7"
-  resolved "https://registry.yarnpkg.com/@fontsource/poppins/-/poppins-5.2.7.tgz#bad145a8a625340873faff1f95b254f032e0d588"
-  integrity sha512-6uQyPmseo4FgI97WIhA4yWRlNaoLk4vSDK/PyRwdqqZb5zAEuc+Kunt8JTMcsHYUEGYBtN15SNkMajMdqUSUmg==
-
 "@fontsource/source-code-pro@^5.0.0":
   version "5.2.7"
   resolved "https://registry.yarnpkg.com/@fontsource/source-code-pro/-/source-code-pro-5.2.7.tgz#ab5cd5882e21cdc38076e12939ddf01424139f61"


### PR DESCRIPTION
## Summary
- Removes 4 `@fontsource/poppins` weight imports from `styles/index.ts` (Poppins is no longer the UI font family)
- Removes `@fontsource/poppins` dependency from `package.json`
- `yarn.lock` updated automatically

## Test Plan
- [ ] Verify app loads with no visual regressions (Inter is the active font via `inter-variable.css`)
- [ ] Confirm no `Poppins` references remain in the codebase

🤖 Generated with [Claude Code](https://claude.com/claude-code)