### PR TITLE
feat(ssis): make databaseConnection optional to support file-only mode

### DIFF
--- a/openmetadata-service/src/main/resources/json/data/testConnections/pipeline/ssis.json
+++ b/openmetadata-service/src/main/resources/json/data/testConnections/pipeline/ssis.json
@@ -5,40 +5,45 @@
     "steps": [
         {
             "name": "CheckAccess",
-            "description":  "Check if the database is reachable to fetch the DAG details.",
-            "errorMessage": "Failed to connect to ssis, please validate the credentials",
-            "shortCircuit": true,
-            "mandatory": true
+            "description": "Check if the database is reachable to fetch the DAG details. Skipped in file-only mode (no databaseConnection configured).",
+            "errorMessage": "Failed to connect to SSIS database. If running in file-only mode, databaseConnection is not required.",
+            "shortCircuit": false,
+            "mandatory": false
         },
         {
             "name": "SSISDBExist",
-            "description":  "Check if the SSISDB database exists and is accessible.",
+            "description": "Check if the SSISDB database exists and is accessible. Skipped in file-only mode (no databaseConnection configured).",
             "errorMessage": "SSISDB database does not exist or is not accessible.",
-            "shortCircuit": true,
-            "mandatory": true
+            "shortCircuit": false,
+            "mandatory": false
         },
         {
             "name": "SSISDBProjectsExist",
-            "description":  "Check if there are any projects present in the SSISDB database.",
+            "description": "Check if there are any projects present in the SSISDB database. Skipped in file-only mode.",
             "errorMessage": "No projects found in SSISDB database.",
-            "shortCircuit": true,
-            "mandatory": true
+            "shortCircuit": false,
+            "mandatory": false
         },
         {
             "name": "SSISDBPackagesExist",
-            "description":  "Check if there are any packages present in the SSISDB database.",
+            "description": "Check if there are any packages present in the SSISDB database. Skipped in file-only mode.",
             "errorMessage": "No packages found in SSISDB database.",
-            "shortCircuit": true,
-            "mandatory": true
+            "shortCircuit": false,
+            "mandatory": false
+        },
+        {
+            "name": "CheckLocalPath",
+            "description": "Check that the local projects path exists and contains at least one .dtsx package file. Only applies when packageConnection is a local path.",
+            "errorMessage": "Local projects path is missing or contains no .dtsx package files.",
+            "shortCircuit": false,
+            "mandatory": false
         },
         {
             "name": "CheckS3Access",
-            "description":  "Check storage access",
+            "description": "Check storage access",
             "errorMessage": "Unable to connect to storage service",
-            "shortCircuit": true,
+            "shortCircuit": false,
             "mandatory": false
         }
-
-
     ]
 }

--- a/openmetadata-spec/src/main/resources/json/schema/entity/services/connections/pipeline/ssisConnection.json
+++ b/openmetadata-spec/src/main/resources/json/schema/entity/services/connections/pipeline/ssisConnection.json
@@ -27,7 +27,7 @@
       },
       "databaseConnection": {
         "title": "Metadata Database Connection",
-        "description": "Underlying database connection",
+        "description": "Optional. Underlying SSISDB connection. When omitted, the connector runs in file-only mode and run history is not extracted.",
         "$ref": "../database/mssqlConnection.json"
       },
       "packageConnection": {
@@ -48,6 +48,6 @@
       }
     },
     "additionalProperties": false,
-    "required": ["databaseConnection", "packageConnection"]
+    "required": ["packageConnection"]
   }
   

--- a/openmetadata-ui/src/main/resources/ui/src/generated/api/automations/createWorkflow.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/api/automations/createWorkflow.ts
@@ -1975,6 +1975,9 @@ export interface ConfigObject {
     pipelineFilterPattern?: FilterPattern;
     /**
      * Underlying database connection
+     *
+     * Optional. Underlying SSISDB connection. When omitted, the connector runs in file-only
+     * mode and run history is not extracted.
      */
     databaseConnection?: DatabaseConnectionClass;
     /**
@@ -4202,6 +4205,9 @@ export interface PurpleGCPCredentials {
  * Underlying database connection
  *
  * Mssql Database Connection Config
+ *
+ * Optional. Underlying SSISDB connection. When omitted, the connector runs in file-only
+ * mode and run history is not extracted.
  */
 export interface DatabaseConnectionClass {
     connectionArguments?: { [key: string]: any };

--- a/openmetadata-ui/src/main/resources/ui/src/generated/api/services/createPipelineService.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/api/services/createPipelineService.ts
@@ -161,6 +161,9 @@ export interface ConfigObject {
     type?: PipelineServiceType;
     /**
      * Underlying database connection
+     *
+     * Optional. Underlying SSISDB connection. When omitted, the connector runs in file-only
+     * mode and run history is not extracted.
      */
     databaseConnection?: DatabaseConnectionClass;
     /**
@@ -1259,6 +1262,9 @@ export enum Type {
  * Underlying database connection
  *
  * Mssql Database Connection Config
+ *
+ * Optional. Underlying SSISDB connection. When omitted, the connector runs in file-only
+ * mode and run history is not extracted.
  */
 export interface DatabaseConnectionClass {
     connectionArguments?: { [key: string]: any };

--- a/openmetadata-ui/src/main/resources/ui/src/generated/api/services/ingestionPipelines/createIngestionPipeline.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/api/services/ingestionPipelines/createIngestionPipeline.ts
@@ -5143,6 +5143,9 @@ export interface ConfigObject {
     pipelineFilterPattern?: FilterPattern;
     /**
      * Underlying database connection
+     *
+     * Optional. Underlying SSISDB connection. When omitted, the connector runs in file-only
+     * mode and run history is not extracted.
      */
     databaseConnection?: DatabaseConnectionClass;
     /**
@@ -6865,6 +6868,9 @@ export interface PurpleGCPCredentials {
  * Underlying database connection
  *
  * Mssql Database Connection Config
+ *
+ * Optional. Underlying SSISDB connection. When omitted, the connector runs in file-only
+ * mode and run history is not extracted.
  */
 export interface DatabaseConnectionClass {
     connectionArguments?: { [key: string]: any };

--- a/openmetadata-ui/src/main/resources/ui/src/generated/entity/automations/testServiceConnection.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/entity/automations/testServiceConnection.ts
@@ -1857,6 +1857,9 @@ export interface ConfigObject {
     pipelineFilterPattern?: FilterPattern;
     /**
      * Underlying database connection
+     *
+     * Optional. Underlying SSISDB connection. When omitted, the connector runs in file-only
+     * mode and run history is not extracted.
      */
     databaseConnection?: DatabaseConnectionClass;
     /**
@@ -4084,6 +4087,9 @@ export interface PurpleGCPCredentials {
  * Underlying database connection
  *
  * Mssql Database Connection Config
+ *
+ * Optional. Underlying SSISDB connection. When omitted, the connector runs in file-only
+ * mode and run history is not extracted.
  */
 export interface DatabaseConnectionClass {
     connectionArguments?: { [key: string]: any };

--- a/openmetadata-ui/src/main/resources/ui/src/generated/entity/automations/workflow.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/entity/automations/workflow.ts
@@ -2528,6 +2528,9 @@ export interface ConfigObject {
     pipelineFilterPattern?: FilterPattern;
     /**
      * Underlying database connection
+     *
+     * Optional. Underlying SSISDB connection. When omitted, the connector runs in file-only
+     * mode and run history is not extracted.
      */
     databaseConnection?: DatabaseConnectionClass;
     /**
@@ -4592,6 +4595,9 @@ export interface PurpleGCPCredentials {
  * Underlying database connection
  *
  * Mssql Database Connection Config
+ *
+ * Optional. Underlying SSISDB connection. When omitted, the connector runs in file-only
+ * mode and run history is not extracted.
  */
 export interface DatabaseConnectionClass {
     connectionArguments?: { [key: string]: any };

--- a/openmetadata-ui/src/main/resources/ui/src/generated/entity/services/connections/pipeline/ssisConnection.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/entity/services/connections/pipeline/ssisConnection.ts
@@ -15,9 +15,10 @@
  */
 export interface SsisConnection {
     /**
-     * Underlying database connection
+     * Optional. Underlying SSISDB connection. When omitted, the connector runs in file-only
+     * mode and run history is not extracted.
      */
-    databaseConnection: MssqlConnection;
+    databaseConnection?: MssqlConnection;
     /**
      * Underlying storage connection
      */
@@ -30,7 +31,8 @@ export interface SsisConnection {
 }
 
 /**
- * Underlying database connection
+ * Optional. Underlying SSISDB connection. When omitted, the connector runs in file-only
+ * mode and run history is not extracted.
  *
  * Mssql Database Connection Config
  */

--- a/openmetadata-ui/src/main/resources/ui/src/generated/entity/services/connections/serviceConnection.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/entity/services/connections/serviceConnection.ts
@@ -2037,6 +2037,9 @@ export interface ConfigObject {
     pipelineFilterPattern?: FilterPattern;
     /**
      * Underlying database connection
+     *
+     * Optional. Underlying SSISDB connection. When omitted, the connector runs in file-only
+     * mode and run history is not extracted.
      */
     databaseConnection?: DatabaseConnectionClass;
     /**
@@ -4113,6 +4116,9 @@ export interface PurpleGCPCredentials {
  * Underlying database connection
  *
  * Mssql Database Connection Config
+ *
+ * Optional. Underlying SSISDB connection. When omitted, the connector runs in file-only
+ * mode and run history is not extracted.
  */
 export interface DatabaseConnectionClass {
     connectionArguments?: { [key: string]: any };

--- a/openmetadata-ui/src/main/resources/ui/src/generated/entity/services/ingestionPipelines/ingestionPipeline.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/entity/services/ingestionPipelines/ingestionPipeline.ts
@@ -5675,6 +5675,9 @@ export interface ConfigObject {
     pipelineFilterPattern?: FilterPattern;
     /**
      * Underlying database connection
+     *
+     * Optional. Underlying SSISDB connection. When omitted, the connector runs in file-only
+     * mode and run history is not extracted.
      */
     databaseConnection?: DatabaseConnectionClass;
     /**
@@ -7378,6 +7381,9 @@ export interface PurpleGCPCredentials {
  * Underlying database connection
  *
  * Mssql Database Connection Config
+ *
+ * Optional. Underlying SSISDB connection. When omitted, the connector runs in file-only
+ * mode and run history is not extracted.
  */
 export interface DatabaseConnectionClass {
     connectionArguments?: { [key: string]: any };

--- a/openmetadata-ui/src/main/resources/ui/src/generated/entity/services/pipelineService.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/entity/services/pipelineService.ts
@@ -283,6 +283,9 @@ export interface ConfigObject {
     type?: PipelineServiceType;
     /**
      * Underlying database connection
+     *
+     * Optional. Underlying SSISDB connection. When omitted, the connector runs in file-only
+     * mode and run history is not extracted.
      */
     databaseConnection?: DatabaseConnectionClass;
     /**
@@ -1381,6 +1384,9 @@ export enum Type {
  * Underlying database connection
  *
  * Mssql Database Connection Config
+ *
+ * Optional. Underlying SSISDB connection. When omitted, the connector runs in file-only
+ * mode and run history is not extracted.
  */
 export interface DatabaseConnectionClass {
     connectionArguments?: { [key: string]: any };

--- a/openmetadata-ui/src/main/resources/ui/src/generated/metadataIngestion/testSuitePipeline.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/metadataIngestion/testSuitePipeline.ts
@@ -2135,6 +2135,9 @@ export interface ConfigObject {
     pipelineFilterPattern?: FilterPattern;
     /**
      * Underlying database connection
+     *
+     * Optional. Underlying SSISDB connection. When omitted, the connector runs in file-only
+     * mode and run history is not extracted.
      */
     databaseConnection?: DatabaseConnectionClass;
     /**
@@ -4211,6 +4214,9 @@ export interface PurpleGCPCredentials {
  * Underlying database connection
  *
  * Mssql Database Connection Config
+ *
+ * Optional. Underlying SSISDB connection. When omitted, the connector runs in file-only
+ * mode and run history is not extracted.
  */
 export interface DatabaseConnectionClass {
     connectionArguments?: { [key: string]: any };

--- a/openmetadata-ui/src/main/resources/ui/src/generated/metadataIngestion/workflow.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/metadataIngestion/workflow.ts
@@ -2126,6 +2126,9 @@ export interface ConfigObject {
     pipelineFilterPattern?: FilterPattern;
     /**
      * Underlying database connection
+     *
+     * Optional. Underlying SSISDB connection. When omitted, the connector runs in file-only
+     * mode and run history is not extracted.
      */
     databaseConnection?: DatabaseConnectionClass;
     /**
@@ -4230,6 +4233,9 @@ export interface PurpleGCPCredentials {
  * Underlying database connection
  *
  * Mssql Database Connection Config
+ *
+ * Optional. Underlying SSISDB connection. When omitted, the connector runs in file-only
+ * mode and run history is not extracted.
  */
 export interface DatabaseConnectionClass {
     connectionArguments?: { [key: string]: any };


### PR DESCRIPTION
The SSIS connector previously required databaseConnection (SSISDB) in all configurations. This change makes it optional, enabling a file-only mode where the connector extracts pipeline metadata directly from .dtsx package files without needing an SSISDB database connection.

Schema change ([ssisConnection.json](vscode-webview://09c2u5q77snrporqgcseinnqc1kq0cc1dp2nv7eqth1v1cggig3l/openmetadata-spec/src/main/resources/json/schema/entity/services/connections/pipeline/ssisConnection.json)):

Removed databaseConnection from the required array — only packageConnection is now required
Clarified the databaseConnection description: when omitted, the connector runs in file-only mode and run history is not extracted
Test connection steps ([ssis.json](vscode-webview://09c2u5q77snrporqgcseinnqc1kq0cc1dp2nv7eqth1v1cggig3l/openmetadata-service/src/main/resources/json/data/testConnections/pipeline/ssis.json)):

All SSISDB-dependent steps (CheckAccess, SSISDBExist, SSISDBProjectsExist, SSISDBPackagesExist) are now mandatory: false and shortCircuit: false — they are skipped gracefully in file-only mode
Added a new CheckLocalPath step that validates the local .dtsx package path exists and contains at least one package file
Updated all step descriptions to mention file-only mode behavior