### PR TITLE
Fixes #28718: prevent lost-update race in PolicyConditionUpdater

### DIFF
--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/PolicyResourceIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/PolicyResourceIT.java
@@ -23,6 +23,11 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
@@ -840,6 +845,90 @@ public class PolicyResourceIT extends BaseEntityIT<Policy, CreatePolicy> {
     Policy fetched = getEntity(policyId);
     String updatedCondition = fetched.getRules().get(0).getCondition();
     assertEquals("matchAnyTag('" + newFqn + "')", updatedCondition);
+  }
+
+  /**
+   * Regression for the lost-update race in PolicyConditionUpdater (issue #28718): two tags
+   * referenced by the same policy rule are renamed at the same moment. Both rewrites must survive —
+   * a blind full-row write would let one rename clobber the other. Repeated to raise the odds of
+   * hitting the race; with the optimistic compare-and-swap retry it passes deterministically.
+   */
+  @Test
+  void test_concurrentTagRenamesBothUpdatePolicyCondition(TestNamespace ns) throws Exception {
+    OpenMetadataClient client = SdkClients.adminClient();
+
+    for (int iteration = 0; iteration < 3; iteration++) {
+      Tag tagA = createTagInNewClassification(client, ns, "ConcurrentA" + iteration);
+      Tag tagB = createTagInNewClassification(client, ns, "ConcurrentB" + iteration);
+
+      Rule rule =
+          new Rule()
+              .withName("concurrentRenameRule")
+              .withResources(List.of(ALL_RESOURCES))
+              .withOperations(List.of(MetadataOperation.VIEW_ALL))
+              .withEffect(Effect.ALLOW)
+              .withCondition(
+                  "matchAnyTag('"
+                      + tagA.getFullyQualifiedName()
+                      + "', '"
+                      + tagB.getFullyQualifiedName()
+                      + "')");
+
+      Policy policy =
+          createEntity(
+              new CreatePolicy()
+                  .withName(ns.prefix("concurrentRenamePolicy" + iteration))
+                  .withRules(List.of(rule))
+                  .withDescription("Policy referencing two tags renamed concurrently"));
+
+      List<String> newFqns = renameTagsConcurrently(client, tagA, tagB);
+
+      String condition = getEntity(policy.getId().toString()).getRules().get(0).getCondition();
+      assertTrue(
+          condition.contains(newFqns.get(0)),
+          "Rename of tag A was lost from policy condition: " + condition);
+      assertTrue(
+          condition.contains(newFqns.get(1)),
+          "Rename of tag B was lost from policy condition: " + condition);
+    }
+  }
+
+  private Tag createTagInNewClassification(
+      OpenMetadataClient client, TestNamespace ns, String tagName) {
+    Classification classification =
+        client
+            .classifications()
+            .create(
+                new CreateClassification()
+                    .withName(ns.prefix(tagName + "Classification"))
+                    .withDescription("Classification for concurrent rename test"));
+    return client
+        .tags()
+        .create(
+            new CreateTag()
+                .withName(tagName)
+                .withClassification(classification.getFullyQualifiedName())
+                .withDescription("Tag renamed concurrently"));
+  }
+
+  private List<String> renameTagsConcurrently(OpenMetadataClient client, Tag tagA, Tag tagB)
+      throws Exception {
+    CyclicBarrier barrier = new CyclicBarrier(2);
+    ExecutorService executor = Executors.newFixedThreadPool(2);
+    try {
+      Future<String> renameA = executor.submit(() -> renameTag(client, barrier, tagA));
+      Future<String> renameB = executor.submit(() -> renameTag(client, barrier, tagB));
+      return List.of(renameA.get(60, TimeUnit.SECONDS), renameB.get(60, TimeUnit.SECONDS));
+    } finally {
+      executor.shutdownNow();
+    }
+  }
+
+  private String renameTag(OpenMetadataClient client, CyclicBarrier barrier, Tag tag)
+      throws Exception {
+    tag.setName(tag.getName() + "Renamed");
+    barrier.await(30, TimeUnit.SECONDS);
+    return client.tags().update(tag.getId().toString(), tag).getFullyQualifiedName();
   }
 
   @Test

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/EntityDAO.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/EntityDAO.java
@@ -456,6 +456,10 @@ public interface EntityDAO<T extends EntityInterface> {
   String findById(
       @Define("table") String table, @BindUUID("id") UUID id, @Define("cond") String cond);
 
+  @SqlQuery("SELECT json FROM <table> WHERE id = :id <cond> FOR UPDATE")
+  String findByIdForUpdate(
+      @Define("table") String table, @BindUUID("id") UUID id, @Define("cond") String cond);
+
   @SqlQuery("SELECT id, json FROM <table> WHERE id IN (<ids>) <cond>")
   @RegisterRowMapper(EntityIdJsonPairMapper.class)
   List<EntityIdJsonPair> findByIds(
@@ -803,8 +807,14 @@ public interface EntityDAO<T extends EntityInterface> {
     return include == Include.DELETED ? " AND deleted = TRUE" : "";
   }
 
-  default String findJsonById(UUID id, Include include) {
-    return findById(getTableName(), id, getCondition(include));
+  /**
+   * Fetch the raw json for a row while taking a {@code FOR UPDATE} row lock. Background rewrites use
+   * this so that, inside an enclosing transaction, the re-read sees the latest committed row (a
+   * plain consistent read would return the transaction's stale snapshot under MySQL REPEATABLE
+   * READ) and concurrent writers on the same row are serialized.
+   */
+  default String findJsonByIdForUpdate(UUID id, Include include) {
+    return findByIdForUpdate(getTableName(), id, getCondition(include));
   }
 
   default T findEntityById(UUID id, Include include) {

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/EntityDAO.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/EntityDAO.java
@@ -171,6 +171,30 @@ public interface EntityDAO<T extends EntityInterface> {
       @Bind("version") String version);
 
   /**
+   * Optimistic content-based compare-and-swap. Rewrites the row only when its stored json still
+   * equals {@code expectedJson} (the snapshot last read). Returns the number of rows updated (0
+   * when another writer changed the row in the meantime, 1 on success). Lets background rewrites
+   * detect lost-update races without bumping the entity version or writing version history.
+   */
+  @ConnectionAwareSqlUpdate(
+      value =
+          "UPDATE <table> SET json = :json, <nameHashColumn> = :nameHashColumnValue "
+              + "WHERE id = :id AND json = CAST(:expectedJson AS JSON)",
+      connectionType = MYSQL)
+  @ConnectionAwareSqlUpdate(
+      value =
+          "UPDATE <table> SET json = (:json :: jsonb), <nameHashColumn> = :nameHashColumnValue "
+              + "WHERE id = :id AND json = (:expectedJson :: jsonb)",
+      connectionType = POSTGRES)
+  int updateIfMatches(
+      @Define("table") String table,
+      @Define("nameHashColumn") String nameHashColumn,
+      @BindFQN("nameHashColumnValue") String nameHashColumnValue,
+      @Bind("id") String id,
+      @Bind("json") String json,
+      @Bind("expectedJson") String expectedJson);
+
+  /**
    * List (id, fullyQualifiedName) pairs for all rows whose FQN hash begins with {@code
    * oldPrefixHash}. Used by rename cascade flows to enumerate which children need cache
    * invalidation before an {@link #updateFqn} bulk rewrite.
@@ -758,6 +782,16 @@ public interface EntityDAO<T extends EntityInterface> {
         JsonUtils.pojoToJson(entity));
   }
 
+  default int updateIfMatches(EntityInterface entity, String expectedJson) {
+    return updateIfMatches(
+        getTableName(),
+        getNameHashColumn(),
+        entity.getFullyQualifiedName(),
+        entity.getId().toString(),
+        JsonUtils.pojoToJson(entity),
+        expectedJson);
+  }
+
   default String getCondition(Include include) {
     if (!supportsSoftDelete()) {
       return "";
@@ -767,6 +801,10 @@ public interface EntityDAO<T extends EntityInterface> {
       return "AND deleted = FALSE";
     }
     return include == Include.DELETED ? " AND deleted = TRUE" : "";
+  }
+
+  default String findJsonById(UUID id, Include include) {
+    return findById(getTableName(), id, getCondition(include));
   }
 
   default T findEntityById(UUID id, Include include) {

--- a/openmetadata-service/src/main/java/org/openmetadata/service/security/policyevaluator/PolicyConditionUpdater.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/security/policyevaluator/PolicyConditionUpdater.java
@@ -183,10 +183,14 @@ public final class PolicyConditionUpdater {
   }
 
   /**
-   * Re-read the policy's current row, re-apply the rewriter to that fresh copy, and persist it with
-   * a content-based compare-and-swap. On a lost-update conflict (another writer changed the row),
-   * retry up to {@link #MAX_REWRITE_RETRIES} times. Avoids the EntityUpdater path so automated
-   * rewrites neither bump the version nor create version history.
+   * Re-read the policy's current row with a {@code FOR UPDATE} lock, re-apply the rewriter to that
+   * fresh copy, and persist it with a content-based compare-and-swap. The locking read is essential:
+   * this runs inside the enclosing rename/delete transaction, so under MySQL's default REPEATABLE
+   * READ a plain re-read would return the transaction's stale snapshot and the CAS could never
+   * converge. {@code FOR UPDATE} returns the latest committed row and serializes conflicting
+   * writers. On a lost-update conflict it retries up to {@link #MAX_REWRITE_RETRIES} times. Avoids
+   * the EntityUpdater path so automated rewrites neither bump the version nor create version
+   * history.
    */
   private static boolean rewriteSinglePolicy(
       EntityRepository<Policy> policyRepo, UUID policyId, UnaryOperator<String> conditionRewriter) {
@@ -196,7 +200,7 @@ public final class PolicyConditionUpdater {
     int attempt = 0;
     while (attempt < MAX_REWRITE_RETRIES && retryable && !changed) {
       attempt++;
-      String currentJson = dao.findJsonById(policyId, Include.NON_DELETED);
+      String currentJson = dao.findJsonByIdForUpdate(policyId, Include.NON_DELETED);
       Policy policy = currentJson == null ? null : JsonUtils.readValue(currentJson, Policy.class);
       if (policy == null || !rewritePolicyConditions(policy, conditionRewriter)) {
         retryable = false;

--- a/openmetadata-service/src/main/java/org/openmetadata/service/security/policyevaluator/PolicyConditionUpdater.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/security/policyevaluator/PolicyConditionUpdater.java
@@ -16,6 +16,7 @@ package org.openmetadata.service.security.policyevaluator;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
+import java.util.UUID;
 import java.util.function.UnaryOperator;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -23,8 +24,10 @@ import lombok.extern.slf4j.Slf4j;
 import org.openmetadata.schema.entity.policies.Policy;
 import org.openmetadata.schema.entity.policies.accessControl.Rule;
 import org.openmetadata.schema.type.Include;
+import org.openmetadata.schema.utils.JsonUtils;
 import org.openmetadata.schema.utils.ResultList;
 import org.openmetadata.service.Entity;
+import org.openmetadata.service.jdbi3.EntityDAO;
 import org.openmetadata.service.jdbi3.EntityRepository;
 import org.openmetadata.service.jdbi3.ListFilter;
 import org.openmetadata.service.util.EntityUtil.Fields;
@@ -42,6 +45,9 @@ public final class PolicyConditionUpdater {
   public static final Set<String> TEAM_FUNCTIONS = Set.of("inAnyTeam");
 
   private static final Pattern SINGLE_QUOTED_ARG = Pattern.compile("'([^']*)'");
+
+  private static final int MAX_REWRITE_RETRIES = 5;
+  private static final int POLICY_PAGE_SIZE = 1000;
 
   private PolicyConditionUpdater() {}
 
@@ -121,37 +127,105 @@ public final class PolicyConditionUpdater {
 
   /**
    * Find all non-deleted policies, apply conditionRewriter to each rule's condition, and persist
-   * any changes.
+   * any changes. Each changed policy is written with an optimistic content-based compare-and-swap
+   * (re-read, re-apply, retry on conflict) so concurrent tag/glossary renames touching overlapping
+   * policies cannot clobber each other's rewrites.
    */
   public static void updateAllPolicyConditions(UnaryOperator<String> conditionRewriter) {
     try {
       @SuppressWarnings("unchecked")
       EntityRepository<Policy> policyRepo =
           (EntityRepository<Policy>) Entity.getEntityRepository(Entity.POLICY);
-      ListFilter filter = new ListFilter(Include.NON_DELETED);
-      ResultList<Policy> policies =
-          policyRepo.listAfter(null, Fields.EMPTY_FIELDS, filter, 10000, null);
-
-      boolean anyChanged = false;
-      for (Policy policy : policies.getData()) {
-        if (rewritePolicyConditions(policy, conditionRewriter)) {
-          // Direct DAO update to avoid creating version history entries for automated rewrites.
-          policyRepo.getDao().update(policy);
-          // DAO.update skips EntityUpdater.invalidateCachesAfterStore, so the cached policy
-          // still has the pre-rewrite condition embedded. Drop every cache variant for this
-          // policy so the next read rebuilds from the freshly-updated row.
-          EntityRepository.invalidateCacheForEntity(
-              Entity.POLICY, policy.getId(), policy.getFullyQualifiedName());
-          anyChanged = true;
-          LOG.info("Updated policy conditions for '{}'", policy.getFullyQualifiedName());
-        }
-      }
+      boolean anyChanged = rewriteMatchingPolicies(policyRepo, conditionRewriter);
       if (anyChanged) {
         SubjectCache.invalidateAll();
       }
     } catch (Exception e) {
       LOG.error("Failed to update policy conditions", e);
     }
+  }
+
+  /**
+   * Page through every non-deleted policy (no fixed cap) and rewrite each one whose conditions
+   * reference the renamed/deleted entity.
+   */
+  private static boolean rewriteMatchingPolicies(
+      EntityRepository<Policy> policyRepo, UnaryOperator<String> conditionRewriter) {
+    ListFilter filter = new ListFilter(Include.NON_DELETED);
+    boolean anyChanged = false;
+    String after = null;
+    do {
+      ResultList<Policy> page =
+          policyRepo.listAfter(null, Fields.EMPTY_FIELDS, filter, POLICY_PAGE_SIZE, after);
+      for (Policy policy : page.getData()) {
+        if (conditionsWouldChange(policy, conditionRewriter)
+            && rewriteSinglePolicy(policyRepo, policy.getId(), conditionRewriter)) {
+          anyChanged = true;
+        }
+      }
+      after = page.getPaging() == null ? null : page.getPaging().getAfter();
+    } while (after != null);
+    return anyChanged;
+  }
+
+  /** Cheap, non-mutating pre-check: would the rewriter change any of this policy's conditions? */
+  private static boolean conditionsWouldChange(
+      Policy policy, UnaryOperator<String> conditionRewriter) {
+    boolean wouldChange = false;
+    for (Rule rule : policy.getRules()) {
+      String condition = rule.getCondition();
+      if (condition != null && !condition.equals(conditionRewriter.apply(condition))) {
+        wouldChange = true;
+        break;
+      }
+    }
+    return wouldChange;
+  }
+
+  /**
+   * Re-read the policy's current row, re-apply the rewriter to that fresh copy, and persist it with
+   * a content-based compare-and-swap. On a lost-update conflict (another writer changed the row),
+   * retry up to {@link #MAX_REWRITE_RETRIES} times. Avoids the EntityUpdater path so automated
+   * rewrites neither bump the version nor create version history.
+   */
+  private static boolean rewriteSinglePolicy(
+      EntityRepository<Policy> policyRepo, UUID policyId, UnaryOperator<String> conditionRewriter) {
+    EntityDAO<Policy> dao = policyRepo.getDao();
+    boolean changed = false;
+    boolean retryable = true;
+    int attempt = 0;
+    while (attempt < MAX_REWRITE_RETRIES && retryable && !changed) {
+      attempt++;
+      String currentJson = dao.findJsonById(policyId, Include.NON_DELETED);
+      Policy policy = currentJson == null ? null : JsonUtils.readValue(currentJson, Policy.class);
+      if (policy == null || !rewritePolicyConditions(policy, conditionRewriter)) {
+        retryable = false;
+      } else {
+        changed = casWritePolicy(dao, policy, currentJson);
+      }
+    }
+    if (retryable && !changed) {
+      LOG.warn(
+          "Gave up rewriting conditions for policy {} after {} attempts due to concurrent modifications",
+          policyId,
+          MAX_REWRITE_RETRIES);
+    }
+    return changed;
+  }
+
+  /**
+   * Persist the rewritten policy only if its stored row still matches {@code expectedJson}. On
+   * success, drop every cache variant for the policy so the next read rebuilds from the fresh row
+   * (the DAO write skips EntityUpdater's cache invalidation).
+   */
+  private static boolean casWritePolicy(EntityDAO<Policy> dao, Policy policy, String expectedJson) {
+    boolean written = dao.updateIfMatches(policy, expectedJson) == 1;
+    if (written) {
+      EntityRepository.invalidateCacheForEntity(
+          Entity.POLICY, policy.getId(), policy.getFullyQualifiedName());
+      LOG.info("Updated policy conditions for '{}'", policy.getFullyQualifiedName());
+    }
+    return written;
   }
 
   private static boolean rewritePolicyConditions(


### PR DESCRIPTION
### Describe your changes:

Fixes #28718

I reworked `PolicyConditionUpdater.updateAllPolicyConditions` because concurrent tag/glossary renames touching overlapping policy rows could clobber each other's condition rewrites — each changed policy was written with a blind full-row update and no conflict check (classic lost-update). The blind `getDao().update(policy)` is replaced with an optimistic **content-based compare-and-swap** (new `EntityDAO.updateIfMatches`, which writes only if the stored JSON still equals the snapshot last read) plus a bounded retry that re-reads with a **`FOR UPDATE` lock** and re-applies the rewriter. I chose content-CAS over the existing version-CAS so the automated rewrite keeps its silent semantics (no version bump, no version-history entry). I also paginated the policy scan to drop the silent 10000-policy cap.

#
### Type of change:
- [x] Bug fix

#
### High-level design:

`EntityDAO.updateIfMatches(...)` adds `AND json = CAST(:expectedJson AS JSON)` (MySQL) / `AND json = (:expectedJson :: jsonb)` (Postgres) to the row update, returning rows-updated (0 = a concurrent writer won → retry). `rewriteSinglePolicy` re-reads the row via `findByIdForUpdate` (`SELECT json ... FOR UPDATE`), re-applies the rewriter, and CAS-writes; on conflict it re-reads and retries up to 5×. **The locking read is essential:** this runs inside the enclosing rename/delete `@Transaction`, so under MySQL's default REPEATABLE READ a non-locking re-read returns the transaction's stale snapshot and the retry could never converge (the second rename would be silently dropped) — `FOR UPDATE` returns the latest committed row and serializes conflicting writers. Version-CAS (`updateWithVersion`) was rejected because it only detects conflicts when each write bumps the version, which would break the deliberate silent-rewrite behavior and desync version history.

#
### Tests:

#### Use cases covered
- Two tags referenced by the same policy rule are renamed concurrently — both FQN rewrites survive in the policy condition.
- Instances with >10000 policies are fully scanned (no silent tail truncation).

#### Unit tests
- Existing `PolicyConditionUpdaterTest` (41 tests) still green; the pure rewrite helpers are unchanged.

#### Backend integration tests
- [x] Added `PolicyResourceIT.test_concurrentTagRenamesBothUpdatePolicyCondition` (barrier-aligned concurrent renames, repeated, asserts both rewrites persist). Runs against MySQL in CI.

#### Ingestion integration tests
- [x] Not applicable (no ingestion changes).

#### Playwright (UI) tests
- [x] Not applicable (no UI changes).

#### Manual testing performed
Reproduced the race on real MySQL 8.3 with two `pymysql` connections in REPEATABLE READ transactions (the same isolation as production), each holding a snapshot of the policy row:
1. Connection A CAS-writes rename #1 and commits.
2. Connection B's CAS for rename #2 correctly returns 0 rows (conflict detected).
3. With a **plain** re-read, B keeps reading its stale snapshot, exhausts all 5 retries, and rename #2 is **lost** — `matchAnyTag(A2, B)`.
4. With the **`FOR UPDATE`** re-read, B reads the latest committed row, re-applies, and succeeds in 1 attempt — both survive: `matchAnyTag(A2, B2)`.

Same harness, only the re-read strategy differs, confirming both the bug and the fix.

#
### UI screen recording / screenshots:

Not applicable.

#
### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] My PR title is `Fixes <issue-number>: <short explanation>`
- [x] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have added tests (unit / integration / Playwright as applicable) and listed them above.
- [x] I have added a test that covers the exact scenario we are fixing (`test_concurrentTagRenamesBothUpdatePolicyCondition`, see #28718).
