### PR TITLE
Fixes #28719: derive reindex promotion aliases from IndexMapping

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/DefaultRecreateHandler.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/DefaultRecreateHandler.java
@@ -87,10 +87,10 @@ public class DefaultRecreateHandler implements RecreateIndexHandler {
     String entityType = context.getEntityType();
     String canonicalIndex = context.getCanonicalIndex();
     String stagedIndex = context.getStagedIndex();
-    Set<String> aliasesFromMapping = context.getExistingAliases();
 
     SearchRepository searchRepository = Entity.getSearchRepository();
     SearchClient searchClient = searchRepository.getSearchClient();
+    IndexMapping indexMapping = searchRepository.getIndexMapping(entityType);
 
     if (canonicalIndex == null || stagedIndex == null) {
       LOG.error(
@@ -144,15 +144,14 @@ public class DefaultRecreateHandler implements RecreateIndexHandler {
       //                         is strictly worse than the writes going back to the canonical
       //                         alias target. Operators need to retry the reindex either way.
       try {
-        // The alias set was derived from indexMapping.json at recreate time via
-        // getAliasesFromMapping; finalize just attaches that captured set. Nothing is read from the
-        // live cluster, so the set is deterministic and matches the distributed promotion path.
-        Set<String> aliasesToAttach = new HashSet<>();
-        if (aliasesFromMapping != null) {
-          aliasesFromMapping.stream()
-              .filter(alias -> alias != null && !alias.isBlank())
-              .forEach(aliasesToAttach::add);
-        }
+        // Re-derive aliases from indexMapping.json rather than trusting
+        // context.getExistingAliases(). A participant server rebuilds the context
+        // from only the staged-index mapping (ReindexContext.fromStagedIndexMapping),
+        // leaving its alias set empty; trusting it would abort promotion and drop the
+        // parent aliases (all/table/dataAsset). Deriving from the mapping matches
+        // promoteEntityIndex.
+        Set<String> aliasesToAttach =
+            getAliasesFromMapping(indexMapping, searchRepository.getClusterAlias());
 
         if (aliasesToAttach.isEmpty()) {
           abortPromotionWithoutAliases(entityType, stagedIndex);

--- a/openmetadata-service/src/test/java/org/openmetadata/service/search/DefaultRecreateHandlerTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/search/DefaultRecreateHandlerTest.java
@@ -587,6 +587,15 @@ class DefaultRecreateHandlerTest {
 
       SearchRepository repo = mock(SearchRepository.class);
       when(repo.getSearchClient()).thenReturn(client);
+      when(repo.getClusterAlias()).thenReturn("");
+      when(repo.getIndexMapping("table"))
+          .thenReturn(
+              IndexMapping.builder()
+                  .indexName("table_search_index")
+                  .alias("table")
+                  .parentAliases(List.of("all"))
+                  .childAliases(List.of())
+                  .build());
 
       ReindexingMetrics metrics = mock(ReindexingMetrics.class);
       try (MockedStatic<Entity> entityMock = mockStatic(Entity.class);
@@ -600,9 +609,6 @@ class DefaultRecreateHandlerTest {
                 .canonicalIndex("table_search_index")
                 .activeIndex("table_search_index")
                 .stagedIndex("table_search_index_rebuild_new")
-                .existingAliases(new HashSet<>(List.of("legacyAlias", "table", "all", "", " ")))
-                .canonicalAliases("table")
-                .parentAliases(new HashSet<>(List.of("all", "", " ")))
                 .build();
 
         new DefaultRecreateHandler().finalizeReindex(context, false);
@@ -611,8 +617,8 @@ class DefaultRecreateHandlerTest {
       assertTrue(aliasState.deletedIndices.contains("table_search_index"));
       assertTrue(aliasState.deletedIndices.contains("table_search_index_rebuild_old"));
       Set<String> stagedAliases = aliasState.indexAliases.get("table_search_index_rebuild_new");
-      assertTrue(stagedAliases.contains("legacyAlias"));
       assertTrue(stagedAliases.contains("table"));
+      assertTrue(stagedAliases.contains("table_search_index"));
       assertTrue(stagedAliases.contains("all"));
       verify(metrics).recordPromotionSuccess("table");
     }
@@ -637,8 +643,6 @@ class DefaultRecreateHandlerTest {
                 .entityType("table")
                 .canonicalIndex("table_search_index")
                 .stagedIndex("table_search_index_rebuild_new")
-                .existingAliases(new HashSet<>())
-                .parentAliases(new HashSet<>())
                 .build();
 
         new DefaultRecreateHandler().finalizeReindex(context, false);
@@ -659,6 +663,15 @@ class DefaultRecreateHandlerTest {
 
       SearchRepository repo = mock(SearchRepository.class);
       when(repo.getSearchClient()).thenReturn(client);
+      when(repo.getClusterAlias()).thenReturn("");
+      when(repo.getIndexMapping("table"))
+          .thenReturn(
+              IndexMapping.builder()
+                  .indexName("table_search_index")
+                  .alias("table")
+                  .parentAliases(List.of("all"))
+                  .childAliases(List.of())
+                  .build());
 
       try (MockedStatic<Entity> entityMock = mockStatic(Entity.class)) {
         entityMock.when(Entity::getSearchRepository).thenReturn(repo);
@@ -668,9 +681,6 @@ class DefaultRecreateHandlerTest {
                 .entityType("table")
                 .canonicalIndex("table_search_index")
                 .stagedIndex("table_search_index_rebuild_new")
-                .existingAliases(new HashSet<>(Set.of("table")))
-                .canonicalAliases("table")
-                .parentAliases(new HashSet<>(Set.of("all")))
                 .build();
 
         new DefaultRecreateHandler().finalizeReindex(context, true);
@@ -692,6 +702,8 @@ class DefaultRecreateHandlerTest {
       SearchClient client = aliasState.toMock();
       SearchRepository repo = mock(SearchRepository.class);
       when(repo.getSearchClient()).thenReturn(client);
+      when(repo.getClusterAlias()).thenReturn("");
+      when(repo.getIndexMapping("table")).thenReturn(null);
 
       try (MockedStatic<Entity> entityMock = mockStatic(Entity.class)) {
         entityMock.when(Entity::getSearchRepository).thenReturn(repo);
@@ -701,9 +713,6 @@ class DefaultRecreateHandlerTest {
                 .entityType("table")
                 .canonicalIndex("table_search_index")
                 .stagedIndex("table_search_index_rebuild_new")
-                .existingAliases(new HashSet<>(List.of("", " ")))
-                .canonicalAliases("")
-                .parentAliases(new HashSet<>(List.of(" ")))
                 .build();
 
         new DefaultRecreateHandler().finalizeReindex(context, true);
@@ -730,6 +739,15 @@ class DefaultRecreateHandlerTest {
       SearchClient client = aliasState.toMock();
       SearchRepository repo = mock(SearchRepository.class);
       when(repo.getSearchClient()).thenReturn(client);
+      when(repo.getClusterAlias()).thenReturn("");
+      when(repo.getIndexMapping("table"))
+          .thenReturn(
+              IndexMapping.builder()
+                  .indexName("table_search_index")
+                  .alias("table")
+                  .parentAliases(List.of("all"))
+                  .childAliases(List.of())
+                  .build());
 
       try (MockedStatic<Entity> entityMock = mockStatic(Entity.class)) {
         entityMock.when(Entity::getSearchRepository).thenReturn(repo);
@@ -740,9 +758,6 @@ class DefaultRecreateHandlerTest {
                 .canonicalIndex("table_search_index")
                 .activeIndex("table_search_index")
                 .stagedIndex("table_search_index_rebuild_new")
-                .existingAliases(new HashSet<>(Set.of("table", "table_search_index", "all")))
-                .canonicalAliases("table")
-                .parentAliases(new HashSet<>(Set.of("all")))
                 .build();
 
         new DefaultRecreateHandler().finalizeReindex(context, true);
@@ -768,6 +783,15 @@ class DefaultRecreateHandlerTest {
 
       SearchRepository repo = mock(SearchRepository.class);
       when(repo.getSearchClient()).thenReturn(client);
+      when(repo.getClusterAlias()).thenReturn("");
+      when(repo.getIndexMapping("table"))
+          .thenReturn(
+              IndexMapping.builder()
+                  .indexName("table_search_index")
+                  .alias("table")
+                  .parentAliases(List.of("all"))
+                  .childAliases(List.of())
+                  .build());
 
       try (MockedStatic<Entity> entityMock = mockStatic(Entity.class)) {
         entityMock.when(Entity::getSearchRepository).thenReturn(repo);
@@ -778,9 +802,6 @@ class DefaultRecreateHandlerTest {
                 .canonicalIndex("table_search_index")
                 .activeIndex("table_search_index")
                 .stagedIndex("table_search_index_rebuild_new")
-                .existingAliases(new HashSet<>(Set.of("table", "table_search_index", "all")))
-                .canonicalAliases("table")
-                .parentAliases(new HashSet<>(Set.of("all")))
                 .build();
 
         new DefaultRecreateHandler().finalizeReindex(context, true);
@@ -801,6 +822,10 @@ class DefaultRecreateHandlerTest {
 
       SearchRepository repo = mock(SearchRepository.class);
       when(repo.getSearchClient()).thenReturn(client);
+      when(repo.getClusterAlias()).thenReturn("");
+      when(repo.getIndexMapping("table"))
+          .thenReturn(
+              IndexMapping.builder().indexName("table_search_index").alias("table").build());
 
       ReindexingMetrics metrics = mock(ReindexingMetrics.class);
       try (MockedStatic<Entity> entityMock = mockStatic(Entity.class);
@@ -813,8 +838,6 @@ class DefaultRecreateHandlerTest {
                 .entityType("table")
                 .canonicalIndex("table_search_index")
                 .stagedIndex("table_search_index_rebuild_new")
-                .existingAliases(new HashSet<>(Set.of("table")))
-                .parentAliases(new HashSet<>())
                 .build();
 
         new DefaultRecreateHandler().finalizeReindex(context, true);
@@ -845,6 +868,15 @@ class DefaultRecreateHandlerTest {
       SearchClient client = aliasState.toMock();
       SearchRepository repo = mock(SearchRepository.class);
       when(repo.getSearchClient()).thenReturn(client);
+      when(repo.getClusterAlias()).thenReturn("");
+      when(repo.getIndexMapping("table"))
+          .thenReturn(
+              IndexMapping.builder()
+                  .indexName("table_search_index")
+                  .alias("table")
+                  .parentAliases(List.of("all"))
+                  .childAliases(List.of())
+                  .build());
 
       try (MockedStatic<Entity> entityMock = mockStatic(Entity.class)) {
         entityMock.when(Entity::getSearchRepository).thenReturn(repo);
@@ -855,9 +887,6 @@ class DefaultRecreateHandlerTest {
                 .canonicalIndex("table_search_index")
                 .activeIndex("table_search_index_rebuild_old")
                 .stagedIndex("table_search_index_rebuild_new")
-                .existingAliases(new HashSet<>(Set.of("table_search_index", "table", "all")))
-                .canonicalAliases("table")
-                .parentAliases(new HashSet<>(Set.of("all")))
                 .build();
 
         new DefaultRecreateHandler().finalizeReindex(context, true);
@@ -877,6 +906,72 @@ class DefaultRecreateHandlerTest {
       assertTrue(
           stagedAliases.contains("all"),
           () -> "Parent alias must end up on staged after promotion; got " + stagedAliases);
+    }
+
+    @Test
+    @DisplayName(
+        "Should attach parent aliases from the mapping when the context carries none "
+            + "(participant-reconstructed context)")
+    void testFinalizeReindexDerivesAliasesFromMappingWhenContextHasNoAliases() {
+      // Regression for the distributed-reindex alias-loss bug: a participant server reconstructs
+      // the
+      // ReindexContext from only the job's staged-index mapping (ReindexContext
+      // .fromStagedIndexMapping), so existingAliases/parentAliases are empty. finalizeReindex must
+      // still attach the column index's parent aliases (all/table/dataAsset) by re-deriving them
+      // from indexMapping.json — otherwise the promoted column index drops out of the
+      // dataAsset/global-search alias. Before the fix, finalize trusted
+      // context.getExistingAliases()
+      // (empty here) and aborted promotion without attaching any alias.
+      AliasState aliasState = new AliasState();
+      aliasState.put(
+          "column_search_index_rebuild_old",
+          new HashSet<>(Set.of("tableColumn", "column_search_index", "all", "table", "dataAsset")));
+      aliasState.put("column_search_index_rebuild_new", new HashSet<>());
+
+      SearchClient client = aliasState.toMock();
+      SearchRepository repo = mock(SearchRepository.class);
+      when(repo.getSearchClient()).thenReturn(client);
+      when(repo.getClusterAlias()).thenReturn("");
+      when(repo.getIndexMapping("tableColumn"))
+          .thenReturn(
+              IndexMapping.builder()
+                  .indexName("column_search_index")
+                  .alias("tableColumn")
+                  .parentAliases(List.of("all", "table", "dataAsset"))
+                  .childAliases(List.of())
+                  .build());
+
+      try (MockedStatic<Entity> entityMock = mockStatic(Entity.class)) {
+        entityMock.when(Entity::getSearchRepository).thenReturn(repo);
+
+        EntityReindexContext context =
+            EntityReindexContext.builder()
+                .entityType("tableColumn")
+                .canonicalIndex("column_search_index")
+                .stagedIndex("column_search_index_rebuild_new")
+                .existingAliases(new HashSet<>())
+                .parentAliases(new HashSet<>())
+                .build();
+
+        new DefaultRecreateHandler().finalizeReindex(context, true);
+      }
+
+      Set<String> stagedAliases = aliasState.indexAliases.get("column_search_index_rebuild_new");
+      assertTrue(stagedAliases.contains("tableColumn"));
+      assertTrue(stagedAliases.contains("column_search_index"));
+      assertTrue(
+          stagedAliases.contains("all"),
+          () -> "parent alias 'all' must be derived from the mapping; got " + stagedAliases);
+      assertTrue(
+          stagedAliases.contains("table"),
+          () -> "parent alias 'table' must be derived from the mapping; got " + stagedAliases);
+      assertTrue(
+          stagedAliases.contains("dataAsset"),
+          () ->
+              "parent alias 'dataAsset' must be derived from the mapping — this is the regression; "
+                  + "got "
+                  + stagedAliases);
+      assertTrue(aliasState.deletedIndices.contains("column_search_index_rebuild_old"));
     }
   }
 


### PR DESCRIPTION
### Describe your changes:

Fixes #28719

I made `DefaultRecreateHandler.finalizeReindex` re-derive the alias set from the entity's `IndexMapping` (via `getAliasesFromMapping`) instead of trusting `context.getExistingAliases()`, because that context's alias set is empty when reconstructed on a participant server via `ReindexContext.fromStagedIndexMapping` — which made distributed promotion abort without attaching any alias and silently drop the parent aliases (`all`/`table`/`dataAsset`), most visibly removing `tableColumn`/`column_search_index` from the `dataAsset`/global-search alias. This makes `finalizeReindex` deterministic and consistent with `promoteEntityIndex`, which already derived aliases from the mapping.

#
### Type of change:
- [x] Bug fix

#
### High-level design:

N/A — small, single-method change.

#
### Tests:

#### Use cases covered
- A distributed reindex promoted via a participant-reconstructed context (empty `existingAliases`) still attaches the entity's parent aliases (`all`/`table`/`dataAsset`) derived from `indexMapping.json`.
- Single-node reindex promotion is unchanged (the context was already seeded from the same mapping helper).

#### Unit tests
- [x] Updated `DefaultRecreateHandlerTest` so all `finalizeReindex` tests source aliases from a mocked `IndexMapping`.
- Added regression test `testFinalizeReindexDerivesAliasesFromMappingWhenContextHasNoAliases` — confirmed it FAILS without the fix (empty context aliases → no alias swap) and passes with it.
- All affected suites pass: `DefaultRecreateHandlerTest`, `DistributedSearchIndexExecutorTest`, `DistributedReindexFinalizerTest`, `DistributedIndexingStrategyTest`, `SearchRepositoryBehaviorTest` finalize case.

#### Backend integration tests
- [x] Not applicable (no API surface change; promotion path covered by unit tests).

#### Ingestion integration tests
- [x] Not applicable (no ingestion changes).

#### Playwright (UI) tests
- [x] Not applicable (no UI changes).

#### Manual testing performed
Verified via the unit suites above, including reverting the fix to prove the regression test fails without it. `mvn spotless:check -pl openmetadata-service` is clean.

#
### UI screen recording / screenshots:

Not applicable.

#
### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] My PR title is `Fixes <issue-number>: <short explanation>`
- [x] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have added tests (unit / integration / Playwright as applicable) and listed them above.
- [x] I have added a test that covers the exact scenario we are fixing (regression test references #28719).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
