### PR TITLE
Fixes #28696: boundary-aware idempotent tag FQN rewrite on rename

### DIFF
--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/ClassificationResourceIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/ClassificationResourceIT.java
@@ -8,7 +8,10 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import java.time.Duration;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 import org.awaitility.Awaitility;
@@ -22,6 +25,7 @@ import org.openmetadata.schema.api.classification.CreateClassification;
 import org.openmetadata.schema.api.classification.CreateTag;
 import org.openmetadata.schema.api.data.CreateTable;
 import org.openmetadata.schema.entity.classification.Classification;
+import org.openmetadata.schema.entity.classification.Tag;
 import org.openmetadata.schema.entity.data.Table;
 import org.openmetadata.schema.type.EntityHistory;
 import org.openmetadata.schema.type.EntityStatus;
@@ -761,6 +765,114 @@ public class ClassificationResourceIT extends BaseEntityIT<Classification, Creat
                   client.tags().get(tag2.getId().toString());
               assertTrue(fetchedTag1.getFullyQualifiedName().startsWith(newName));
               assertTrue(fetchedTag2.getFullyQualifiedName().startsWith(newName));
+            });
+  }
+
+  // ===================================================================
+  // Issue #28696 (classification analogue): renaming a classification so the new
+  // name keeps the old name as a PREFIX must rewrite child tag FQNs on linked
+  // assets correctly AND must NOT corrupt a sibling classification that merely
+  // shares a textual prefix. Classification asset-tag propagation runs through
+  // the shared, now boundary-aware UPDATE_FQN_PREFIX_SCRIPT
+  // (propagateToRelatedEntities, gated on the displayName change a UI rename
+  // sends). Unlike glossary it is single-pass, so the exact rename was already
+  // fine; the sibling assertion is what the boundary fix protects.
+  // ===================================================================
+  @Test
+  void test_renameClassificationPrefixExtension_rewritesChildTagsButNotSibling(TestNamespace ns) {
+    OpenMetadataClient client = SdkClients.adminClient();
+    ObjectMapper mapper = new ObjectMapper();
+    TableResourceIT tableResourceIT = new TableResourceIT();
+
+    // Dot-free classification name; sibling shares the prefix WITHOUT a '.' boundary.
+    String nameA = "clf_" + ns.shortPrefix();
+    Classification a =
+        createEntity(
+            new CreateClassification()
+                .withName(nameA)
+                .withDisplayName("Sensitivity")
+                .withDescription("Classification renamed via prefix extension (#28696)"));
+    Classification sibling =
+        createEntity(
+            new CreateClassification()
+                .withName(nameA + "x")
+                .withDescription("Sibling classification sharing the textual prefix"));
+
+    Tag tagA =
+        client
+            .tags()
+            .create(
+                new CreateTag()
+                    .withName("sensitive")
+                    .withClassification(a.getFullyQualifiedName())
+                    .withDescription("child tag of the renamed classification"));
+    Tag tagSibling =
+        client
+            .tags()
+            .create(
+                new CreateTag()
+                    .withName("foo")
+                    .withClassification(sibling.getFullyQualifiedName())
+                    .withDescription("child tag of the sibling classification"));
+    String tagAFqn = tagA.getFullyQualifiedName();
+    String siblingTagFqn = tagSibling.getFullyQualifiedName();
+
+    Table assetA = createTableWithTag(tableResourceIT, ns, "a", tagAFqn);
+    Table assetSibling = createTableWithTag(tableResourceIT, ns, "s", siblingTagFqn);
+
+    awaitTableTag(client, mapper, assetA.getId().toString(), tagAFqn);
+    awaitTableTag(client, mapper, assetSibling.getId().toString(), siblingTagFqn);
+
+    a.setName(nameA + " Renamed");
+    a.setDisplayName("Sensitivity Renamed");
+    Classification renamed = patchEntity(a.getId().toString(), a);
+    String newNameA = renamed.getFullyQualifiedName();
+    assertNotEquals(nameA, newNameA);
+    assertTrue(newNameA.startsWith(nameA), "rename must extend the name as a prefix: " + newNameA);
+
+    // Child tag FQN on the linked asset follows the renamed classification...
+    awaitTableTag(client, mapper, assetA.getId().toString(), newNameA + ".sensitive");
+    // ...and the prefix-sharing sibling's asset tag is left untouched.
+    awaitTableTag(client, mapper, assetSibling.getId().toString(), siblingTagFqn);
+  }
+
+  private Table createTableWithTag(
+      TableResourceIT tableResourceIT, TestNamespace ns, String suffix, String tagFqn) {
+    Table table =
+        tableResourceIT.createEntity(
+            tableResourceIT.createRequest(ns.shortPrefix("clf_tbl_" + suffix), ns).withTags(null));
+    table.setTags(List.of(new TagLabel().withTagFQN(tagFqn)));
+    return tableResourceIT.patchEntity(table.getId().toString(), table);
+  }
+
+  private void awaitTableTag(
+      OpenMetadataClient client, ObjectMapper mapper, String tableId, String expectedTagFqn) {
+    Awaitility.await("table search doc carries tag " + expectedTagFqn)
+        .atMost(Duration.ofSeconds(60))
+        .pollDelay(Duration.ofMillis(500))
+        .pollInterval(Duration.ofSeconds(1))
+        .ignoreExceptions()
+        .untilAsserted(
+            () -> {
+              String response =
+                  client
+                      .search()
+                      .query("id:" + tableId)
+                      .index("table_search_index")
+                      .size(1)
+                      .execute();
+              JsonNode hits = mapper.readTree(response).path("hits").path("hits");
+              assertTrue(hits.isArray() && !hits.isEmpty(), "table should be indexed");
+              List<String> tagFqns = new ArrayList<>();
+              for (JsonNode tag : hits.get(0).path("_source").path("tags")) {
+                tagFqns.add(tag.path("tagFQN").asText());
+              }
+              assertTrue(
+                  tagFqns.contains(expectedTagFqn),
+                  "Expected tagFQN '"
+                      + expectedTagFqn
+                      + "' on table search doc but found "
+                      + tagFqns);
             });
   }
 }

--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/DataProductResourceIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/DataProductResourceIT.java
@@ -10,7 +10,9 @@ import static org.openmetadata.it.bootstrap.SharedEntities.*;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import java.time.Duration;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -3134,5 +3136,78 @@ public class DataProductResourceIT extends BaseEntityIT<DataProduct, CreateDataP
     SdkClients.adminClient()
         .getHttpClient()
         .execute(HttpMethod.PUT, addPath, addRequest, BulkOperationResult.class);
+  }
+
+  // ===================================================================
+  // Issue #28696 (data product analogue): a prefix-extension rename must keep
+  // the linked asset's dataProducts[].fullyQualifiedName pointing at the new
+  // FQN in search. Data products are flat and their reference update uses an
+  // EXACT-match term query + script (==oldFqn -> newFqn), so this path is
+  // idempotent and prefix-safe by construction (no sibling concern, no
+  // double-apply); this confirms it empirically.
+  // ===================================================================
+  @Test
+  void test_renameDataProductPrefixExtension_keepsAssetReference(TestNamespace ns)
+      throws Exception {
+    OpenMetadataClient client = SdkClients.adminClient();
+    ObjectMapper mapper = new ObjectMapper();
+    Domain domain = getOrCreateDomain(ns);
+
+    String dpName = "dp_" + ns.shortPrefix();
+    DataProduct dataProduct =
+        createEntity(
+            new CreateDataProduct()
+                .withName(dpName)
+                .withDisplayName("Revenue")
+                .withDescription("Data product renamed via prefix extension (#28696)")
+                .withDomains(List.of(domain.getFullyQualifiedName())));
+    String oldFqn = dataProduct.getFullyQualifiedName();
+
+    Table asset = createTestTable(ns, "dp_asset", domain);
+    bulkAddAssets(
+        dataProduct.getFullyQualifiedName(),
+        new BulkAssets().withAssets(List.of(asset.getEntityReference())));
+
+    awaitAssetDataProduct(client, mapper, asset.getId().toString(), oldFqn);
+
+    dataProduct.setName(dpName + " Renamed");
+    dataProduct.setDisplayName("Revenue Renamed");
+    DataProduct renamed = patchEntity(dataProduct.getId().toString(), dataProduct);
+    String newFqn = renamed.getFullyQualifiedName();
+    assertNotEquals(oldFqn, newFqn);
+    assertTrue(newFqn.startsWith(oldFqn), "rename must extend the FQN as a prefix: " + newFqn);
+
+    awaitAssetDataProduct(client, mapper, asset.getId().toString(), newFqn);
+  }
+
+  private void awaitAssetDataProduct(
+      OpenMetadataClient client, ObjectMapper mapper, String tableId, String expectedDpFqn) {
+    Awaitility.await("asset " + tableId + " carries data product " + expectedDpFqn + " in search")
+        .atMost(Duration.ofSeconds(60))
+        .pollDelay(Duration.ofMillis(500))
+        .pollInterval(Duration.ofSeconds(1))
+        .ignoreExceptions()
+        .untilAsserted(
+            () -> {
+              String response =
+                  client
+                      .search()
+                      .query("id:" + tableId)
+                      .index("table_search_index")
+                      .size(1)
+                      .execute();
+              JsonNode hits = mapper.readTree(response).path("hits").path("hits");
+              assertTrue(hits.isArray() && !hits.isEmpty(), "table should be indexed");
+              List<String> dpFqns = new ArrayList<>();
+              for (JsonNode dp : hits.get(0).path("_source").path("dataProducts")) {
+                dpFqns.add(dp.path("fullyQualifiedName").asText());
+              }
+              assertTrue(
+                  dpFqns.contains(expectedDpFqn),
+                  "Expected data product FQN '"
+                      + expectedDpFqn
+                      + "' on table search doc but found "
+                      + dpFqns);
+            });
   }
 }

--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/DomainResourceIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/DomainResourceIT.java
@@ -20,26 +20,39 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import java.time.Duration;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.openmetadata.it.factories.DatabaseSchemaTestFactory;
+import org.openmetadata.it.factories.DatabaseServiceTestFactory;
 import org.openmetadata.it.util.SdkClients;
 import org.openmetadata.it.util.TestNamespace;
 import org.openmetadata.schema.api.VoteRequest;
+import org.openmetadata.schema.api.data.CreateTable;
 import org.openmetadata.schema.api.domains.CreateDomain;
 import org.openmetadata.schema.api.domains.CreateDomain.DomainType;
 import org.openmetadata.schema.api.teams.CreateUser;
+import org.openmetadata.schema.entity.data.Database;
+import org.openmetadata.schema.entity.data.DatabaseSchema;
+import org.openmetadata.schema.entity.data.Table;
 import org.openmetadata.schema.entity.domains.Domain;
+import org.openmetadata.schema.entity.services.DatabaseService;
 import org.openmetadata.schema.entity.teams.User;
 import org.openmetadata.schema.type.ChangeEvent;
+import org.openmetadata.schema.type.Column;
+import org.openmetadata.schema.type.ColumnDataType;
 import org.openmetadata.schema.type.EntityHistory;
 import org.openmetadata.schema.type.EntityReference;
 import org.openmetadata.schema.type.Votes;
 import org.openmetadata.sdk.client.OpenMetadataClient;
+import org.openmetadata.sdk.fluent.Databases;
 import org.openmetadata.sdk.models.ListParams;
 import org.openmetadata.sdk.models.ListResponse;
 import org.openmetadata.sdk.network.HttpMethod;
@@ -1358,5 +1371,123 @@ public class DomainResourceIT extends BaseEntityIT<Domain, CreateDomain> {
             && votes.getUpVoters().stream()
                 .anyMatch(ref -> ref != null && voter.getId().equals(ref.getId()));
     assertFalse(voterInUpVotes, "Soft-deleted voter must not appear in list endpoint votes");
+  }
+
+  // ===================================================================
+  // Issue #28696 (domain analogue): a prefix-extension rename — where the new
+  // name keeps the old name as a prefix (e.g. "sales" -> "sales global") — must
+  // keep every linked asset, subdomain, and the domain doc itself pointing at
+  // the new FQN in search, and must NOT touch a sibling domain that merely
+  // shares a textual prefix ("salesforce"). The domain FQN-prefix scripts are
+  // boundary-aware (equals(oldFqn) || startsWith(oldFqn + '.')), so this is
+  // idempotent and prefix-safe; this locks that contract in (the prior rename
+  // tests only prepended "renamed_", never extending the name as a prefix).
+  // ===================================================================
+  @Test
+  void test_renameDomainPrefixExtension_keepsAssetSubdomainAndSiblingFqnInSearch(TestNamespace ns) {
+    OpenMetadataClient client = SdkClients.adminClient();
+    ObjectMapper mapper = new ObjectMapper();
+
+    // Dot-free names so FQNs stay unquoted and the new FQN literally startsWith the old one.
+    String parentName = "dom_" + ns.shortPrefix();
+    Domain parent =
+        createEntity(
+            new CreateDomain()
+                .withName(parentName)
+                .withDisplayName("Customer Domain")
+                .withDomainType(DomainType.AGGREGATE)
+                .withDescription("Parent domain for prefix-rename search regression (#28696)"));
+    String oldParentFqn = parent.getFullyQualifiedName();
+
+    Domain subdomain =
+        createEntity(
+            new CreateDomain()
+                .withName("sub_" + ns.shortPrefix())
+                .withDomainType(DomainType.SOURCE_ALIGNED)
+                .withParent(oldParentFqn)
+                .withDescription("Subdomain exercising the child-prefix branch"));
+    String subName = subdomain.getName();
+
+    // Sibling shares the parent's textual prefix WITHOUT a '.' boundary; it must never be
+    // rewritten.
+    Domain sibling =
+        createEntity(
+            new CreateDomain()
+                .withName(parentName + "x")
+                .withDomainType(DomainType.AGGREGATE)
+                .withDescription("Sibling domain that only shares a textual prefix"));
+    String siblingFqn = sibling.getFullyQualifiedName();
+
+    Table asset = createTableInDomain(ns, "clv", oldParentFqn);
+    String assetId = asset.getId().toString();
+
+    awaitAssetDomainFqn(client, mapper, assetId, oldParentFqn);
+
+    // Prefix-extension rename + displayName change (UI rename shape).
+    parent.setName(parentName + " renamed");
+    parent.setDisplayName("Customer Domain Renamed");
+    Domain renamed = patchEntity(parent.getId().toString(), parent);
+    String newParentFqn = renamed.getFullyQualifiedName();
+    assertNotEquals(oldParentFqn, newParentFqn);
+    assertTrue(
+        newParentFqn.startsWith(oldParentFqn),
+        "Reproduction requires the new FQN to extend the old FQN as a prefix: " + newParentFqn);
+
+    // Domain doc, subdomain (child prefix), and the asset must all follow to the new FQN...
+    verifyDomainInSearch(newParentFqn, parent.getId().toString());
+    verifyDomainInSearch(newParentFqn + "." + subName, subdomain.getId().toString());
+    awaitAssetDomainFqn(client, mapper, assetId, newParentFqn);
+
+    // ...and the prefix-sharing sibling must stay exactly as it was (no double / no spillover).
+    verifyDomainInSearch(siblingFqn, sibling.getId().toString());
+  }
+
+  private Table createTableInDomain(TestNamespace ns, String suffix, String domainFqn) {
+    OpenMetadataClient client = SdkClients.adminClient();
+    DatabaseService service = DatabaseServiceTestFactory.createPostgres(ns);
+    Database database =
+        Databases.create()
+            .name(ns.shortPrefix("dom_db_" + suffix))
+            .in(service.getFullyQualifiedName())
+            .execute();
+    DatabaseSchema schema = DatabaseSchemaTestFactory.create(ns, database.getFullyQualifiedName());
+    CreateTable createTable =
+        new CreateTable()
+            .withName(ns.shortPrefix("dom_tbl_" + suffix))
+            .withDatabaseSchema(schema.getFullyQualifiedName())
+            .withColumns(List.of(new Column().withName("id").withDataType(ColumnDataType.BIGINT)))
+            .withDomains(List.of(domainFqn));
+    return client.tables().create(createTable);
+  }
+
+  private void awaitAssetDomainFqn(
+      OpenMetadataClient client, ObjectMapper mapper, String tableId, String expectedDomainFqn) {
+    Awaitility.await("asset " + tableId + " carries domain FQN " + expectedDomainFqn + " in search")
+        .atMost(Duration.ofSeconds(60))
+        .pollDelay(Duration.ofMillis(500))
+        .pollInterval(Duration.ofSeconds(1))
+        .ignoreExceptions()
+        .untilAsserted(
+            () -> {
+              String response =
+                  client
+                      .search()
+                      .query("id:" + tableId)
+                      .index("table_search_index")
+                      .size(1)
+                      .execute();
+              JsonNode hits = mapper.readTree(response).path("hits").path("hits");
+              assertTrue(hits.isArray() && !hits.isEmpty(), "table should be indexed");
+              List<String> domainFqns = new ArrayList<>();
+              for (JsonNode domain : hits.get(0).path("_source").path("domains")) {
+                domainFqns.add(domain.path("fullyQualifiedName").asText());
+              }
+              assertTrue(
+                  domainFqns.contains(expectedDomainFqn),
+                  "Expected asset domain FQN '"
+                      + expectedDomainFqn
+                      + "' on table search doc but found "
+                      + domainFqns);
+            });
   }
 }

--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/GlossaryTermResourceIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/GlossaryTermResourceIT.java
@@ -3755,4 +3755,136 @@ public class GlossaryTermResourceIT extends BaseEntityIT<GlossaryTerm, CreateGlo
         .getHttpClient()
         .executeForString(HttpMethod.GET, "/v1/glossaryTerms/byIds", null, opts.build());
   }
+
+  // -------------------------------------------------------------------------
+  // Issue #28696: renaming a glossary term so the new name keeps the original
+  // name as a PREFIX (e.g. "Customer Lifetime Value" -> "Customer Lifetime
+  // Value Renamed") corrupted the glossary tagFQN on every linked asset in the
+  // search index. The term's asset page then showed 0 assets even though the
+  // database relationship stayed intact.
+  //
+  // Root cause: a non-idempotent prefix replace runs twice on the same asset
+  // doc. updateAssetIndexes (in-transaction) rewrites the tag old -> new, then
+  // propagateToRelatedEntities (post-commit, gated on the simultaneous
+  // displayName change a UI rename sends) re-runs replace(oldFqn, newFqn) on
+  // the already-renamed tag, producing "<newFqn> Renamed" because the new FQN
+  // still startsWith the old FQN.
+  // -------------------------------------------------------------------------
+  @Test
+  void test_renameGlossaryTermPrefixExtension_keepsAssetGlossaryTagInSearch(TestNamespace ns) {
+    OpenMetadataClient client = SdkClients.adminClient();
+    ObjectMapper mapper = new ObjectMapper();
+
+    // Short, dot-free names: the FQN must stay unquoted so the new FQN literally
+    // startsWith the old one, and stay well under the tag_usage.tagFQN(256) limit.
+    Glossary glossary =
+        client
+            .glossaries()
+            .create(
+                new CreateGlossary()
+                    .withName(ns.shortPrefix("clv_g"))
+                    .withDescription("Glossary for rename-prefix search regression (#28696)"));
+    GlossaryTerm term =
+        createEntity(
+            new CreateGlossaryTerm()
+                .withName(ns.shortPrefix("clv"))
+                .withDisplayName("Customer Lifetime Value")
+                .withGlossary(glossary.getFullyQualifiedName())
+                .withDescription("Term for rename-prefix search regression (#28696)"));
+    String oldFqn = term.getFullyQualifiedName();
+
+    Table table = createTableTaggedWithTerm(ns, term, "clv_asset");
+    String tableId = table.getId().toString();
+
+    awaitTableGlossaryTag(client, mapper, tableId, oldFqn);
+
+    // UI rename shape: the new name extends the old name as a prefix AND the
+    // displayName changes in the same PATCH (EntityNameModal submits both).
+    GlossaryTerm toRename = client.glossaryTerms().get(term.getId().toString(), "tags");
+    toRename.setName(term.getName() + " Renamed");
+    toRename.setDisplayName("Customer Lifetime Value Renamed");
+    GlossaryTerm renamed = patchEntity(term.getId().toString(), toRename);
+
+    String newFqn = renamed.getFullyQualifiedName();
+    assertNotEquals(oldFqn, newFqn);
+    assertTrue(
+        newFqn.startsWith(oldFqn),
+        "Reproduction requires the new FQN to extend the old FQN as a prefix: " + newFqn);
+
+    // The asset's glossary tag in search must equal the NEW FQN exactly. The
+    // regression produced "<newFqn> Renamed", dropping the asset from the term.
+    awaitTableGlossaryTag(client, mapper, tableId, newFqn);
+
+    // ...and the term's asset listing (search backed) must still surface the table.
+    awaitGlossaryTagAssetSearchable(client, mapper, newFqn, tableId);
+  }
+
+  private void awaitTableGlossaryTag(
+      OpenMetadataClient client, ObjectMapper mapper, String tableId, String expectedGlossaryFqn) {
+    Awaitility.await("table search doc carries glossary tag " + expectedGlossaryFqn)
+        .atMost(Duration.ofSeconds(60))
+        .pollDelay(Duration.ofMillis(500))
+        .pollInterval(Duration.ofSeconds(1))
+        .ignoreExceptions()
+        .untilAsserted(
+            () -> {
+              String response =
+                  client
+                      .search()
+                      .query("id:" + tableId)
+                      .index("table_search_index")
+                      .size(1)
+                      .execute();
+              JsonNode hits = mapper.readTree(response).path("hits").path("hits");
+              assertTrue(hits.isArray() && !hits.isEmpty(), "table should be indexed");
+              List<String> glossaryFqns = new ArrayList<>();
+              for (JsonNode tag : hits.get(0).path("_source").path("tags")) {
+                if ("Glossary".equals(tag.path("source").asText())) {
+                  glossaryFqns.add(tag.path("tagFQN").asText());
+                }
+              }
+              assertTrue(
+                  glossaryFqns.contains(expectedGlossaryFqn),
+                  "Expected glossary tagFQN '"
+                      + expectedGlossaryFqn
+                      + "' on table search doc but found "
+                      + glossaryFqns);
+            });
+  }
+
+  private void awaitGlossaryTagAssetSearchable(
+      OpenMetadataClient client, ObjectMapper mapper, String glossaryFqn, String tableId) {
+    String queryFilter =
+        "{\"query\":{\"bool\":{\"must\":[{\"term\":{\"tags.tagFQN\":\"" + glossaryFqn + "\"}}]}}}";
+    Awaitility.await("asset is searchable by glossary tag " + glossaryFqn)
+        .atMost(Duration.ofSeconds(60))
+        .pollDelay(Duration.ofMillis(500))
+        .pollInterval(Duration.ofSeconds(1))
+        .ignoreExceptions()
+        .untilAsserted(
+            () -> {
+              String response =
+                  client
+                      .search()
+                      .query("*")
+                      .index("table_search_index")
+                      .queryFilter(queryFilter)
+                      .size(50)
+                      .execute();
+              JsonNode hits = mapper.readTree(response).path("hits").path("hits");
+              boolean found = false;
+              for (JsonNode hit : hits) {
+                if (tableId.equals(hit.path("_id").asText())
+                    || tableId.equals(hit.path("_source").path("id").asText())) {
+                  found = true;
+                  break;
+                }
+              }
+              assertTrue(
+                  found,
+                  "Glossary term assets page (search by tags.tagFQN="
+                      + glossaryFqn
+                      + ") must still include the linked table");
+            });
+  }
 }

--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/TagResourceIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/TagResourceIT.java
@@ -2046,4 +2046,90 @@ public class TagResourceIT extends BaseEntityIT<Tag, CreateTag> {
     return refreshed.getTags() != null
         && refreshed.getTags().stream().anyMatch(t -> tagFqn.equals(t.getTagFQN()));
   }
+
+  // ===================================================================
+  // Issue #28696 (tag analogue): renaming a tag so the new name keeps the old
+  // name as a PREFIX must rewrite that tag's FQN on linked assets and must NOT
+  // corrupt a sibling tag under the same classification that merely shares the
+  // textual prefix. Tag asset propagation runs through the shared, now
+  // boundary-aware UPDATE_FQN_PREFIX_SCRIPT (propagateToRelatedEntities, gated
+  // on the displayName change a UI rename sends) — single-pass, so the exact
+  // rename was already fine; the sibling assertion is what the boundary fix
+  // protects.
+  // ===================================================================
+  @Test
+  void test_renameTagPrefixExtension_rewritesAssetTagButNotSibling(TestNamespace ns) {
+    OpenMetadataClient client = SdkClients.adminClient();
+    ObjectMapper mapper = new ObjectMapper();
+
+    Classification classification = createClassification(ns);
+    Tag tag =
+        client
+            .tags()
+            .create(
+                new CreateTag()
+                    .withName("ptag")
+                    .withClassification(classification.getFullyQualifiedName())
+                    .withDescription("tag renamed via prefix extension (#28696)"));
+    Tag sibling =
+        client
+            .tags()
+            .create(
+                new CreateTag()
+                    .withName("ptagx")
+                    .withClassification(classification.getFullyQualifiedName())
+                    .withDescription("sibling tag sharing the textual prefix"));
+    String oldTagFqn = tag.getFullyQualifiedName();
+    String siblingFqn = sibling.getFullyQualifiedName();
+
+    Table asset = createTableTaggedWith(ns, tag, "p");
+    Table assetSibling = createTableTaggedWith(ns, sibling, "px");
+
+    awaitTableTag(client, mapper, asset.getId().toString(), oldTagFqn);
+    awaitTableTag(client, mapper, assetSibling.getId().toString(), siblingFqn);
+
+    tag.setName("ptag renamed");
+    tag.setDisplayName("Renamed Tag");
+    Tag renamed = patchEntity(tag.getId().toString(), tag);
+    String newTagFqn = renamed.getFullyQualifiedName();
+    assertTrue(
+        !oldTagFqn.equals(newTagFqn) && newTagFqn.startsWith(oldTagFqn),
+        "rename must extend the FQN as a prefix: " + newTagFqn);
+
+    // The renamed tag's FQN follows on the linked asset...
+    awaitTableTag(client, mapper, asset.getId().toString(), newTagFqn);
+    // ...and the prefix-sharing sibling tag is left untouched.
+    awaitTableTag(client, mapper, assetSibling.getId().toString(), siblingFqn);
+  }
+
+  private void awaitTableTag(
+      OpenMetadataClient client, ObjectMapper mapper, String tableId, String expectedTagFqn) {
+    Awaitility.await("table search doc carries tag " + expectedTagFqn)
+        .atMost(Duration.ofSeconds(60))
+        .pollDelay(Duration.ofMillis(500))
+        .pollInterval(Duration.ofSeconds(1))
+        .ignoreExceptions()
+        .untilAsserted(
+            () -> {
+              String response =
+                  client
+                      .search()
+                      .query("id:" + tableId)
+                      .index("table_search_index")
+                      .size(1)
+                      .execute();
+              JsonNode hits = mapper.readTree(response).path("hits").path("hits");
+              assertTrue(hits.isArray() && !hits.isEmpty(), "table should be indexed");
+              List<String> tagFqns = new ArrayList<>();
+              for (JsonNode tag : hits.get(0).path("_source").path("tags")) {
+                tagFqns.add(tag.path("tagFQN").asText());
+              }
+              assertTrue(
+                  tagFqns.contains(expectedTagFqn),
+                  "Expected tagFQN '"
+                      + expectedTagFqn
+                      + "' on table search doc but found "
+                      + tagFqns);
+            });
+  }
 }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/SearchClient.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/SearchClient.java
@@ -240,15 +240,34 @@ public interface SearchClient
       }
       """;
 
+  // FQN-boundary aware, idempotent rewrite of a single tagFQN. A bare
+  // startsWith + replace is NOT idempotent when the new FQN keeps the old one
+  // as a prefix (rename "a" -> "a b"): the glossary rename fires this twice
+  // (in-transaction updateAssetIndexes, then the post-commit propagation pass)
+  // and the second pass turns "a b" into "a b b", dropping the asset from the
+  // term (issue #28696). Matching only an exact FQN or a real "oldFQN." child
+  // boundary makes the second pass a no-op and never touches a sibling that
+  // merely shares a textual prefix (e.g. "a" must not rewrite "ab").
+  String UPDATE_TAG_FQN_BY_PREFIX_FRAGMENT =
+      """
+            String currentFQN = ctx._source.tags[i].tagFQN;
+            if (currentFQN != null && currentFQN.equals(params.oldParentFQN)) {
+              ctx._source.tags[i].tagFQN = params.newParentFQN;
+            } else if (currentFQN != null && currentFQN.startsWith(params.oldParentFQN + '.')) {
+              ctx._source.tags[i].tagFQN = params.newParentFQN + currentFQN.substring(params.oldParentFQN.length());
+            }
+      """;
+
   String UPDATE_GLOSSARY_TERM_TAG_FQN_BY_PREFIX_SCRIPT =
       """
       if (ctx._source.containsKey('tags')) {
         for (int i = 0; i < ctx._source.tags.size(); i++) {
           if (ctx._source.tags[i].containsKey('tagFQN') &&
               ctx._source.tags[i].containsKey('source') &&
-              ctx._source.tags[i].source == 'Glossary' &&
-              ctx._source.tags[i].tagFQN.startsWith(params.oldParentFQN)) {
-            ctx._source.tags[i].tagFQN = ctx._source.tags[i].tagFQN.replace(params.oldParentFQN, params.newParentFQN);
+              ctx._source.tags[i].source == 'Glossary') {
+      """
+          + UPDATE_TAG_FQN_BY_PREFIX_FRAGMENT
+          + """
           }
         }
       }
@@ -261,9 +280,10 @@ public interface SearchClient
         for (int i = 0; i < ctx._source.tags.size(); i++) {
           if (ctx._source.tags[i].containsKey('tagFQN') &&
               ctx._source.tags[i].containsKey('source') &&
-              ctx._source.tags[i].source == 'Classification' &&
-              ctx._source.tags[i].tagFQN.startsWith(params.oldParentFQN)) {
-            ctx._source.tags[i].tagFQN = ctx._source.tags[i].tagFQN.replace(params.oldParentFQN, params.newParentFQN);
+              ctx._source.tags[i].source == 'Classification') {
+      """
+          + UPDATE_TAG_FQN_BY_PREFIX_FRAGMENT
+          + """
           }
         }
       }
@@ -292,8 +312,9 @@ public interface SearchClient
                   if (ctx._source.containsKey('tags')) {
                     for (int i = 0; i < ctx._source.tags.size(); i++) {
                       if (ctx._source.tags[i].containsKey('tagFQN')) {
-                        String tagFQN = ctx._source.tags[i].tagFQN;
-                        ctx._source.tags[i].tagFQN = tagFQN.replace(params.oldParentFQN, params.newParentFQN);
+                  """
+          + UPDATE_TAG_FQN_BY_PREFIX_FRAGMENT
+          + """
                       }
                     }
                   }

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/SearchSeparation/DomainRenamePrefixCascade.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/SearchSeparation/DomainRenamePrefixCascade.spec.ts
@@ -1,0 +1,161 @@
+/*
+ *  Copyright 2026 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+/**
+ * Domain analogue of {@code GlossaryRenamePrefixCascade.spec.ts} (issue #28696).
+ * A prefix-extension rename — new name keeps the old name as a prefix
+ * (e.g. "sales" -> "sales global") — must keep every linked asset's
+ * {@code domains[].fullyQualifiedName} pointing at the new FQN in search, with
+ * no double-suffixed FQN.
+ *
+ * <p>The domain FQN-prefix scripts are already boundary-aware
+ * (`fqn.equals(oldFqn) || fqn.startsWith(oldFqn + '.')`), so domains never had
+ * the glossary double-apply; this spec locks that contract in from the UI/API
+ * surface. The domain name is kept dot-free so its FQN is unquoted and the new
+ * FQN literally startsWith the old one.
+ */
+
+import test, { expect } from '@playwright/test';
+import { Domain } from '../../../support/domain/Domain';
+import { TableClass } from '../../../support/entity/TableClass';
+import { createNewPage, uuid } from '../../../utils/common';
+
+test.use({ storageState: 'playwright/.auth/admin.json' });
+
+test('domain prefix rename keeps linked asset domain reference consistent', async ({
+  browser,
+}) => {
+  test.setTimeout(180_000);
+  const { apiContext, afterAction } = await createNewPage(browser);
+
+  const table = new TableClass();
+  const id = uuid();
+  // Dot-free name so the FQN is unquoted and the new FQN startsWith the old one.
+  const domain = new Domain({
+    name: `pw_dom_${id}`,
+    displayName: `PW Domain ${id}`,
+    description: 'prefix-rename domain search regression (#28696)',
+    domainType: 'Aggregate',
+    fullyQualifiedName: `pw_dom_${id}`,
+  });
+
+  try {
+    await domain.create(apiContext);
+    await table.create(apiContext);
+
+    const originalDomainFqn = domain.responseData.fullyQualifiedName as string;
+    const tableFqn = table.entityResponseData.fullyQualifiedName as string;
+
+    await table.patch({
+      apiContext,
+      patchData: [
+        {
+          op: 'add',
+          path: '/domains/0',
+          value: {
+            id: domain.responseData.id,
+            type: 'domain',
+            name: domain.responseData.name,
+            fullyQualifiedName: originalDomainFqn,
+          },
+        },
+      ],
+    });
+
+    await assertAssetDomain({
+      apiContext,
+      tableFqn,
+      expectedDomainFqn: originalDomainFqn,
+      label: 'pre-rename',
+    });
+
+    await domain.patch({
+      apiContext,
+      patchData: [
+        {
+          op: 'replace',
+          path: '/name',
+          value: `${domain.responseData.name} Renamed`,
+        },
+        {
+          op: 'replace',
+          path: '/displayName',
+          value: 'Customer Domain Renamed',
+        },
+      ],
+    });
+
+    const newDomainFqn = domain.responseData.fullyQualifiedName as string;
+    expect(newDomainFqn).not.toBe(originalDomainFqn);
+    expect(newDomainFqn.startsWith(originalDomainFqn)).toBe(true);
+
+    await assertAssetDomain({
+      apiContext,
+      tableFqn,
+      expectedDomainFqn: newDomainFqn,
+      label: 'post-prefix-rename',
+    });
+  } finally {
+    await table.delete(apiContext);
+    await domain.delete(apiContext);
+    await afterAction();
+  }
+});
+
+async function assertAssetDomain(opts: {
+  apiContext: import('@playwright/test').APIRequestContext;
+  tableFqn: string;
+  expectedDomainFqn: string;
+  label: string;
+}): Promise<void> {
+  const { apiContext, tableFqn, expectedDomainFqn, label } = opts;
+
+  await expect
+    .poll(
+      async () => {
+        const res = await apiContext.get(
+          `/api/v1/search/query?q=fullyQualifiedName:%22${encodeURIComponent(
+            tableFqn
+          )}%22&index=table_search_index`
+        );
+        if (res.status() !== 200) {
+          return undefined;
+        }
+        const body = await res.json();
+        const source = body?.hits?.hits?.[0]?._source;
+        if (!source) {
+          return undefined;
+        }
+
+        const domainFqns = (source.domains ?? []).map(
+          (d: { fullyQualifiedName?: string }) => d.fullyQualifiedName
+        );
+
+        return {
+          hasExactDomain: domainFqns.includes(expectedDomainFqn),
+          noDuplicatedFqn: !domainFqns.some(
+            (fqn: string) =>
+              fqn !== expectedDomainFqn && fqn.startsWith(expectedDomainFqn)
+          ),
+        };
+      },
+      {
+        message: `${label}: the linked asset must carry domain FQN "${expectedDomainFqn}" with no double-suffixed FQN`,
+        timeout: 60_000,
+      }
+    )
+    .toEqual({
+      hasExactDomain: true,
+      noDuplicatedFqn: true,
+    });
+}

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/SearchSeparation/GlossaryRenamePrefixCascade.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/SearchSeparation/GlossaryRenamePrefixCascade.spec.ts
@@ -1,0 +1,172 @@
+/*
+ *  Copyright 2026 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+/**
+ * Reproduces issue #28696: renaming a glossary term so the new name keeps the
+ * original name as a PREFIX (e.g. "Customer Lifetime Value" -> "Customer
+ * Lifetime Value Renamed") corrupted the glossary {@code tagFQN} on every
+ * linked asset in the search index, so the term's asset page showed 0 assets
+ * even though the database relationship stayed intact.
+ *
+ * <p>Two conditions are required and both differ from
+ * {@code GlossaryRenameCascade.spec.ts}:
+ * <ul>
+ *   <li>The term name must NOT contain a dot, so the FQN is unquoted and the
+ *   new FQN literally startsWith the old FQN (a quoted name breaks the raw
+ *   prefix and the bug does not trigger).</li>
+ *   <li>The rename must change name AND displayName in the same PATCH — exactly
+ *   what the UI rename modal submits — because the redundant post-commit
+ *   propagation pass that double-applies the prefix replace is gated on a
+ *   propagated field (displayName) changing.</li>
+ * </ul>
+ *
+ * <p>Before the fix the asset's {@code tags[].tagFQN} becomes
+ * "&lt;newFqn&gt; Renamed" and {@code glossaryTags[]} loses the term entirely.
+ */
+
+import test, { expect } from '@playwright/test';
+import { TableClass } from '../../../support/entity/TableClass';
+import { Glossary } from '../../../support/glossary/Glossary';
+import { GlossaryTerm } from '../../../support/glossary/GlossaryTerm';
+import { createNewPage, uuid } from '../../../utils/common';
+
+test.use({ storageState: 'playwright/.auth/admin.json' });
+
+test('glossary-term prefix rename keeps linked asset glossary tag consistent', async ({
+  browser,
+}) => {
+  // Create + tag + dual-field rename + ES poll comfortably exceeds the default.
+  test.setTimeout(180_000);
+  const { apiContext, afterAction } = await createNewPage(browser);
+
+  const table = new TableClass();
+  const glossary = new Glossary();
+  // Dot-free name so the FQN is unquoted and the new FQN startsWith the old one.
+  const glossaryTerm = new GlossaryTerm(glossary, undefined, `clv_${uuid()}`);
+
+  try {
+    await glossary.create(apiContext);
+    await glossaryTerm.create(apiContext);
+    await table.create(apiContext);
+
+    const originalTermFqn = glossaryTerm.responseData
+      .fullyQualifiedName as string;
+    const tableFqn = table.entityResponseData.fullyQualifiedName as string;
+
+    await table.patch({
+      apiContext,
+      patchData: [
+        {
+          op: 'add',
+          path: '/tags/0',
+          value: {
+            tagFQN: originalTermFqn,
+            labelType: 'Manual',
+            state: 'Confirmed',
+            source: 'Glossary',
+          },
+        },
+      ],
+    });
+
+    await assertAssetGlossaryTag({
+      apiContext,
+      tableFqn,
+      expectedTermFqn: originalTermFqn,
+      label: 'pre-rename',
+    });
+
+    // UI rename shape: extend the name as a prefix AND change displayName in the
+    // same PATCH (EntityNameModal always submits both fields).
+    await glossaryTerm.patch(apiContext, [
+      {
+        op: 'replace',
+        path: '/name',
+        value: `${glossaryTerm.responseData.name} Renamed`,
+      },
+      {
+        op: 'replace',
+        path: '/displayName',
+        value: 'Customer Lifetime Value Renamed',
+      },
+    ]);
+
+    const newTermFqn = glossaryTerm.responseData.fullyQualifiedName as string;
+    expect(newTermFqn).not.toBe(originalTermFqn);
+    expect(newTermFqn.startsWith(originalTermFqn)).toBe(true);
+
+    await assertAssetGlossaryTag({
+      apiContext,
+      tableFqn,
+      expectedTermFqn: newTermFqn,
+      label: 'post-prefix-rename',
+    });
+  } finally {
+    await table.delete(apiContext);
+    await glossaryTerm.delete(apiContext);
+    await glossary.delete(apiContext);
+    await afterAction();
+  }
+});
+
+async function assertAssetGlossaryTag(opts: {
+  apiContext: import('@playwright/test').APIRequestContext;
+  tableFqn: string;
+  expectedTermFqn: string;
+  label: string;
+}): Promise<void> {
+  const { apiContext, tableFqn, expectedTermFqn, label } = opts;
+
+  await expect
+    .poll(
+      async () => {
+        const res = await apiContext.get(
+          `/api/v1/search/query?q=fullyQualifiedName:%22${encodeURIComponent(
+            tableFqn
+          )}%22&index=table_search_index`
+        );
+        if (res.status() !== 200) {
+          return undefined;
+        }
+        const body = await res.json();
+        const source = body?.hits?.hits?.[0]?._source;
+        if (!source) {
+          return undefined;
+        }
+
+        const glossaryTagFqns = (source.tags ?? [])
+          .filter((t: { source?: string }) => t.source === 'Glossary')
+          .map((t: { tagFQN?: string }) => t.tagFQN);
+
+        return {
+          tagsHasExactTerm: glossaryTagFqns.includes(expectedTermFqn),
+          glossaryTagsHasFqn: (source.glossaryTags ?? []).includes(
+            expectedTermFqn
+          ),
+          noDuplicatedFqn: !glossaryTagFqns.some(
+            (fqn: string) =>
+              fqn !== expectedTermFqn && fqn.startsWith(expectedTermFqn)
+          ),
+        };
+      },
+      {
+        message: `${label}: the linked asset must carry the glossary term FQN "${expectedTermFqn}" in both tags[] and glossaryTags[], with no double-suffixed FQN`,
+        timeout: 60_000,
+      }
+    )
+    .toEqual({
+      tagsHasExactTerm: true,
+      glossaryTagsHasFqn: true,
+      noDuplicatedFqn: true,
+    });
+}


### PR DESCRIPTION
### Describe your changes:

Fixes #28696

Renaming a glossary term, classification, or tag so the new name keeps the old name as a prefix (e.g. `Customer Lifetime Value` → `Customer Lifetime Value Renamed`) corrupted `tags[].tagFQN` on every linked asset in the search index — the non-idempotent painless prefix-replace, run by two propagation passes, double-applied it (`… Renamed Renamed`) and rewrote prefix-colliding siblings — so the entity's asset page showed 0 assets while the DB relationship stayed intact. The fix makes the painless tag rewrite FQN-boundary aware and idempotent via a shared `UPDATE_TAG_FQN_BY_PREFIX_FRAGMENT` (exact match, or a real `oldFqn.` child boundary, else no-op), applied to the glossary, classification, and generic FQN-prefix scripts; the domain and data-product paths were already boundary/exact-match safe. It adds prefix-extension rename reproduction tests (red against the old bare scripts, green after) for glossary, classification, tag, domain, and data product, plus Playwright specs for glossary and domain rename cascades.

#
### Type of change:
- [x] Bug fix

#
### High-level design:

N/A — one painless tag-rewrite fragment made boundary-aware/idempotent; the rest is test coverage.

#
### Tests:

#### Use cases covered
- Renaming a glossary term / classification / tag to `<name> Renamed` keeps all linked assets visible (asset `tagFQN` follows to the new FQN, no `… Renamed Renamed` double-apply).
- A prefix-colliding sibling (e.g. `clf_Xx` when `clf_X` is renamed) is never rewritten.
- Renaming a domain (incl. a subdomain) and a data product keeps linked-asset references correct in search.

#### Backend integration tests
- [x] Added integration tests in `openmetadata-integration-tests/`.
- Files: `GlossaryTermResourceIT`, `ClassificationResourceIT`, `TagResourceIT`, `DomainResourceIT`, `DataProductResourceIT` — each a `test_rename…PrefixExtension…` case, verified red→green on Postgres + OpenSearch via testcontainers.

#### Playwright (UI) tests
- [x] Added `Features/SearchSeparation/GlossaryRenamePrefixCascade.spec.ts` and `DomainRenamePrefixCascade.spec.ts`.

#### Manual testing performed
- Ran all five rename ITs against a clean-built service jar: all green. Confirmed the classification/tag cases go red against the pre-fix bare scripts (sibling-collision + double-apply teeth), and that the deployed jar must be `clean`-built to pick up painless-constant edits.

#
### UI screen recording / screenshots:

Not applicable — search-index/backend fix; the Playwright specs exercise it via the API.

#
### Checklist:
- [x] I have read the **CONTRIBUTING** document.
- [x] My PR title is `Fixes <issue-number>: <short explanation>`
- [x] My PR is linked to a GitHub issue via `Fixes #28696` above.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have added tests (unit / integration / Playwright as applicable) and listed them above.
- [x] I have added a test that covers the exact scenario we are fixing (issue number referenced in the tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
