### PR TITLE
fix(ci): PR Metadata Validation never used PROJECTS_TOKEN (auth-hook override)

### DIFF
--- a/.github/workflows/pr-metadata-validation.yml
+++ b/.github/workflows/pr-metadata-validation.yml
@@ -47,7 +47,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check linked issue and Shipping project fields
-        uses: actions/github-script@v7
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         env:
           PROJECTS_TOKEN: ${{ secrets.PROJECTS_TOKEN }}
         with:
@@ -137,11 +137,11 @@ jobs:
                 return { error: 'missing-token' };
               }
               try {
-                const data = await github.graphql(ISSUE_PROJECT_QUERY, {
+                const projectsClient = require('@actions/github').getOctokit(token);
+                const data = await projectsClient.graphql(ISSUE_PROJECT_QUERY, {
                   owner,
                   repo,
                   number: issueNumber,
-                  headers: { authorization: `Bearer ${token}` },
                 });
                 return { items: data.repository.issue.projectItems.nodes };
               } catch (error) {
@@ -177,9 +177,10 @@ jobs:
                   core.warning(`Skipping project validation for #${issueNumber}: ${result.error}`);
                   return [];
                 }
+                core.warning(`Project verification failed for #${issueNumber}: ${result.error}`);
                 const detail = result.error === 'missing-token'
                   ? 'the `PROJECTS_TOKEN` secret (a token with `read:project`) is not configured'
-                  : `the project query failed (${result.error})`;
+                  : 'the project query could not be completed (see the workflow run logs)';
                 return [`Could not verify the **${PROJECT_NAME}** project on issue #${issueNumber}: ${detail}.`];
               }
               const projectItem = (result.items || []).find(


### PR DESCRIPTION
## Problem

The **PR Metadata Validation** check (added in #28724) has **never passed for any PR — 0 of 15 runs** since it merged. Every run fails with *"Linked issue #N is not added to the **Shipping** project"*, even when the issue **is** on the Shipping board with all required fields set.

## Root cause

```js
const data = await github.graphql(ISSUE_PROJECT_QUERY, {
  owner, repo, number: issueNumber,
  headers: { authorization: `Bearer ${token}` },   // silently ignored
});
```

`github` is the github-script Octokit, authenticated with `GITHUB_TOKEN`. Its `@octokit/auth-token` hook **overwrites the `Authorization` header on every request**, so the per-request `Bearer ${PROJECTS_TOKEN}` override is discarded and the query always runs as `GITHUB_TOKEN`. `GITHUB_TOKEN` cannot read org-level Projects v2, so `projectItems` comes back **empty** → the check concludes the issue isn't on the board, for every PR.

Verified out-of-band: the same query run directly with the `PROJECTS_TOKEN` value (`gh api graphql -H "Authorization: Bearer …"`) returns `{"project":{"title":"Shipping"}}`. Only the in-workflow path fails — because of the header override, not the token or the data.

## Fix

Build a dedicated Octokit authenticated with `PROJECTS_TOKEN` (its own auth hook then uses the right token) instead of overriding the header on the `GITHUB_TOKEN` client:

```js
const projectsClient = require('@actions/github').getOctokit(token);
const data = await projectsClient.graphql(ISSUE_PROJECT_QUERY, { owner, repo, number: issueNumber });
```

## Also included (low-risk hardening)

- **Stop reflecting the raw GraphQL `error.message` into the public PR comment** — log it via `core.warning` and post a generic "see the workflow run logs" instead. Removes an information-disclosure paper-cut (the error text could surface token *configuration* state to anyone who can open a PR).
- **Pin `actions/github-script` to a commit SHA** (`60a0d83…` = v7.0.1) — supply-chain hardening on the one action this secret-bearing job trusts.

## Deployment note

Because the trigger is `pull_request_target`, the running workflow is always the one on **`main`** — so this only takes effect once merged. This PR's own metadata check runs the still-broken version from `main`, so it's bypassed with the `skip-pr-checks` label (the workflow's documented maintainer bypass). After merge, re-running any open PR's check will use the fixed version.

Validated by dispatching the fixed workflow (`workflow_dispatch` from this branch) against a PR whose issue is correctly set up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)