### PR TITLE
fix(ci): build projects Octokit via github.constructor (require fails with no checkout)

### DIFF
--- a/.github/workflows/pr-metadata-validation.yml
+++ b/.github/workflows/pr-metadata-validation.yml
@@ -137,7 +137,7 @@ jobs:
                 return { error: 'missing-token' };
               }
               try {
-                const projectsClient = require('@actions/github').getOctokit(token);
+                const projectsClient = new github.constructor({ auth: token });
                 const data = await projectsClient.graphql(ISSUE_PROJECT_QUERY, {
                   owner,
                   repo,


### PR DESCRIPTION
Follow-up to #28728. That PR fixed the auth-hook override, but built the client with `require('@actions/github').getOctokit(token)` — and github-script's sandboxed `require` **cannot resolve action node_modules when there is no checkout**. It throws `Cannot find module '@actions/github'`, so project verification now fails for every PR with *"the project query could not be completed."*

## Fix

Instantiate the already-loaded Octokit class with the token — no module resolution needed:

```js
const projectsClient = new github.constructor({ auth: token });
const data = await projectsClient.graphql(ISSUE_PROJECT_QUERY, { owner, repo, number: issueNumber });
```

`github` is an instance of `@actions/github`'s Octokit; `github.constructor` is that class. Constructing it with `{ auth: token }` authenticates as `PROJECTS_TOKEN` (via the standard `@octokit/auth-token` strategy) and inherits the `api.github.com` baseUrl — without the `GITHUB_TOKEN` auth hook that clobbered the header in the original code.

Verified by dispatching this branch's workflow against a PR whose linked issue is correctly set up on the Shipping board — the check passes.

Bypassed with `skip-pr-checks` (the workflow's own gate is still broken on `main` until this merges).

🤖 Generated with [Claude Code](https://claude.com/claude-code)