### PR TITLE
fix(ingestion): refresh RDS IAM auth token per connection for MySQL

### DIFF
--- a/ingestion/src/metadata/clients/aws_client.py
+++ b/ingestion/src/metadata/clients/aws_client.py
@@ -13,6 +13,7 @@ Module containing AWS Client
 """
 
 import datetime
+import threading
 from enum import Enum
 from functools import partial
 from typing import Any, Callable, Dict, Optional, Type, TypeVar  # noqa: UP035
@@ -296,13 +297,22 @@ class RdsIamAuthTokenManager:
         self.refresh_threshold = refresh_threshold
         self._token: Optional[str] = None  # noqa: UP045
         self._expires_at: Optional[datetime.datetime] = None  # noqa: UP045
+        self._lock = threading.Lock()
 
     def get_token(self) -> str:
-        if self._needs_refresh():
-            self._refresh_token()
-        if self._token is None:
-            raise RuntimeError("Failed to generate RDS IAM authentication token")
-        return self._token
+        """Return a valid token, refreshing if needed.
+
+        The check-and-refresh is serialized: the engine shares one manager across
+        all worker threads (each calls ``engine.connect()`` from the ``do_connect``
+        listener), so without the lock multiple threads could refresh concurrently
+        and observe a token paired with a stale expiry.
+        """
+        with self._lock:
+            if self._needs_refresh():
+                self._refresh_token()
+            if self._token is None:
+                raise RuntimeError("Failed to generate RDS IAM authentication token")
+            return self._token
 
     def _needs_refresh(self) -> bool:
         needs_refresh = True

--- a/ingestion/src/metadata/clients/aws_client.py
+++ b/ingestion/src/metadata/clients/aws_client.py
@@ -16,6 +16,7 @@ import datetime
 from enum import Enum
 from functools import partial
 from typing import Any, Callable, Dict, Optional, Type, TypeVar  # noqa: UP035
+from urllib.parse import parse_qs, urlparse
 
 import boto3
 import botocore.session
@@ -263,3 +264,79 @@ class AWSClient:
 
     def get_mwaa_client(self):
         return self.get_client(AWSServices.MWAA.value)
+
+
+RDS_IAM_TOKEN_DEFAULT_TTL = datetime.timedelta(minutes=15)
+RDS_IAM_TOKEN_REFRESH_THRESHOLD = datetime.timedelta(minutes=5)
+
+
+class RdsIamAuthTokenManager:
+    """
+    Manages the lifecycle of an AWS RDS IAM authentication token.
+
+    RDS IAM tokens are short-lived (~15 minutes) presigned URLs. A long ingestion
+    that opens new pooled connections after the token expires would otherwise
+    authenticate with a stale token and fail. This manager caches the current
+    token, derives its expiry from the presigned URL, and regenerates it shortly
+    before it lapses so every connection receives a valid token.
+    """
+
+    def __init__(
+        self,
+        host: str,
+        port: str,
+        username: str,
+        aws_config: AWSCredentials,
+        refresh_threshold: datetime.timedelta = RDS_IAM_TOKEN_REFRESH_THRESHOLD,
+    ):
+        self.host = host
+        self.port = port
+        self.username = username
+        self.aws_config = aws_config
+        self.refresh_threshold = refresh_threshold
+        self._token: Optional[str] = None  # noqa: UP045
+        self._expires_at: Optional[datetime.datetime] = None  # noqa: UP045
+
+    def get_token(self) -> str:
+        if self._needs_refresh():
+            self._refresh_token()
+        if self._token is None:
+            raise RuntimeError("Failed to generate RDS IAM authentication token")
+        return self._token
+
+    def _needs_refresh(self) -> bool:
+        needs_refresh = True
+        if self._token is not None and self._expires_at is not None:
+            time_left = self._expires_at - datetime.datetime.now(datetime.timezone.utc)
+            needs_refresh = time_left <= self.refresh_threshold
+        return needs_refresh
+
+    def _refresh_token(self) -> None:
+        logger.debug(f"Generating RDS IAM auth token for {self.username}@{self.host}")
+        rds_client = AWSClient(config=self.aws_config).get_rds_client()
+        token = rds_client.generate_db_auth_token(
+            DBHostname=self.host,
+            Port=self.port,
+            DBUsername=self.username,
+            Region=self.aws_config.awsRegion,
+        )
+        self._token = token
+        self._expires_at = self._parse_token_expiry(token)
+
+    def _parse_token_expiry(self, token: str) -> datetime.datetime:
+        """Derive token expiry from the presigned URL's X-Amz-Date / X-Amz-Expires.
+
+        Falls back to a conservative default TTL if the token can't be parsed so a
+        malformed token still triggers periodic refresh rather than never expiring.
+        """
+        now = datetime.datetime.now(datetime.timezone.utc)
+        expires_at = now + RDS_IAM_TOKEN_DEFAULT_TTL
+        try:
+            query_params = parse_qs(urlparse(token).query)
+            amz_date = query_params["X-Amz-Date"][0]
+            amz_expires = int(query_params["X-Amz-Expires"][0])
+            issued_at = datetime.datetime.strptime(amz_date, "%Y%m%dT%H%M%SZ").replace(tzinfo=datetime.timezone.utc)
+            expires_at = issued_at + datetime.timedelta(seconds=amz_expires)
+        except (KeyError, ValueError, IndexError) as exc:
+            logger.warning(f"Could not parse RDS IAM token expiry, using default TTL: {exc}")
+        return expires_at

--- a/ingestion/src/metadata/ingestion/source/database/mysql/connection.py
+++ b/ingestion/src/metadata/ingestion/source/database/mysql/connection.py
@@ -14,7 +14,6 @@ Source connection handler
 """
 
 from typing import Any, Dict, Optional, cast  # noqa: UP035
-from urllib.parse import quote_plus
 
 from sqlalchemy.engine import Engine
 from sqlalchemy.event import listen
@@ -106,20 +105,31 @@ class MySQLConnection(BaseConnection[MySQLConnectionConfig, Engine]):
             username=connection.username,
             aws_config=auth_type.awsConfig,
         )
-        scheme = connection.scheme.value if connection.scheme else "mysql+pymysql"
-        base_url = f"{scheme}://{quote_plus(connection.username)}@{connection.hostPort}"
         engine = create_generic_db_connection(
             connection=connection,
-            get_connection_url_fn=lambda _: base_url,
+            get_connection_url_fn=self._build_iam_url,
             get_connection_args_fn=get_connection_args_common,
         )
 
         def inject_iam_token(_dialect, _conn_rec, _cargs, cparams: Dict[str, Any]):  # noqa: UP006
             cparams["password"] = token_manager.get_token()
-            cparams["ssl"] = cparams.get("ssl") or {"ssl": True}
+            # PyMySQL requires SSL for RDS IAM auth; preserve any explicit SSL config.
+            if "ssl" not in cparams:
+                cparams["ssl"] = {}
 
         listen(engine, "do_connect", inject_iam_token)
         return engine
+
+    @staticmethod
+    def _build_iam_url(connection: MySQLConnectionConfig) -> str:
+        """Build the connection URL exactly like ``get_connection_url_common`` but
+        without a password/token: the ``do_connect`` listener injects a fresh RDS
+        IAM token per connection. Reusing the common helper with the IAM auth
+        neutralized keeps databaseSchema and connectionOptions handling in sync.
+        """
+        url_connection = connection.model_copy()
+        url_connection.authType = BasicAuth(password="")  # type: ignore
+        return get_connection_url_common(url_connection)
 
     def _get_cloudsql_engine(self, connection: MySQLConnectionConfig) -> Engine:
         try:

--- a/ingestion/src/metadata/ingestion/source/database/mysql/connection.py
+++ b/ingestion/src/metadata/ingestion/source/database/mysql/connection.py
@@ -113,9 +113,12 @@ class MySQLConnection(BaseConnection[MySQLConnectionConfig, Engine]):
 
         def inject_iam_token(_dialect, _conn_rec, _cargs, cparams: Dict[str, Any]):  # noqa: UP006
             cparams["password"] = token_manager.get_token()
-            # PyMySQL requires SSL for RDS IAM auth; preserve any explicit SSL config.
+            # RDS IAM auth requires TLS. A truthy ssl dict makes PyMySQL treat SSL
+            # as required (an empty dict only yields PREFERRED, which can silently
+            # fall back to plaintext). check_hostname also verifies the RDS cert.
+            # Any explicitly provided ssl config is preserved.
             if "ssl" not in cparams:
-                cparams["ssl"] = {}
+                cparams["ssl"] = {"check_hostname": True}
 
         listen(engine, "do_connect", inject_iam_token)
         return engine

--- a/ingestion/src/metadata/ingestion/source/database/mysql/connection.py
+++ b/ingestion/src/metadata/ingestion/source/database/mysql/connection.py
@@ -14,6 +14,7 @@ Source connection handler
 """
 
 from typing import Any, Dict, Optional, cast  # noqa: UP035
+from urllib.parse import quote_plus
 
 from sqlalchemy.engine import Engine
 from sqlalchemy.event import listen
@@ -106,7 +107,7 @@ class MySQLConnection(BaseConnection[MySQLConnectionConfig, Engine]):
             aws_config=auth_type.awsConfig,
         )
         scheme = connection.scheme.value if connection.scheme else "mysql+pymysql"
-        base_url = f"{scheme}://{connection.username}@{connection.hostPort}"
+        base_url = f"{scheme}://{quote_plus(connection.username)}@{connection.hostPort}"
         engine = create_generic_db_connection(
             connection=connection,
             get_connection_url_fn=lambda _: base_url,

--- a/ingestion/src/metadata/ingestion/source/database/mysql/connection.py
+++ b/ingestion/src/metadata/ingestion/source/database/mysql/connection.py
@@ -13,10 +13,12 @@
 Source connection handler
 """
 
-from typing import Optional
+from typing import Any, Dict, Optional, cast  # noqa: UP035
 
 from sqlalchemy.engine import Engine
+from sqlalchemy.event import listen
 
+from metadata.clients.aws_client import RdsIamAuthTokenManager
 from metadata.generated.schema.entity.automations.workflow import (
     Workflow as AutomationWorkflow,
 )
@@ -28,6 +30,9 @@ from metadata.generated.schema.entity.services.connections.database.common.basic
 )
 from metadata.generated.schema.entity.services.connections.database.common.gcpCloudSqlConfig import (
     GcpCloudsqlConfigurationSource,
+)
+from metadata.generated.schema.entity.services.connections.database.common.iamAuthConfig import (
+    IamAuthConfigurationSource,
 )
 from metadata.generated.schema.entity.services.connections.database.mysqlConnection import (
     MysqlConnection as MySQLConnectionConfig,
@@ -72,11 +77,48 @@ class MySQLConnection(BaseConnection[MySQLConnectionConfig, Engine]):
         if isinstance(connection.authType, GcpCloudsqlConfigurationSource):
             return self._get_cloudsql_engine(connection)
 
+        if isinstance(connection.authType, IamAuthConfigurationSource):
+            return self._get_iam_engine(connection)
+
         return create_generic_db_connection(
             connection=connection,
             get_connection_url_fn=get_connection_url_common,
             get_connection_args_fn=get_connection_args_common,
         )
+
+    def _get_iam_engine(self, connection: MySQLConnectionConfig) -> Engine:
+        """Build an engine that refreshes the RDS IAM token per connection.
+
+        RDS IAM tokens expire after ~15 minutes. Rather than baking a single token
+        into the connection URL (which would go stale for connections opened later
+        in a long ingestion), a ``do_connect`` listener injects a freshly minted
+        token on every new connection.
+        """
+        auth_type = cast("IamAuthConfigurationSource", connection.authType)
+        if auth_type.awsConfig is None:
+            raise ValueError("awsConfig is required for MySQL RDS IAM authentication")
+
+        host, port = connection.hostPort.split(":")
+        token_manager = RdsIamAuthTokenManager(
+            host=host,
+            port=port,
+            username=connection.username,
+            aws_config=auth_type.awsConfig,
+        )
+        scheme = connection.scheme.value if connection.scheme else "mysql+pymysql"
+        base_url = f"{scheme}://{connection.username}@{connection.hostPort}"
+        engine = create_generic_db_connection(
+            connection=connection,
+            get_connection_url_fn=lambda _: base_url,
+            get_connection_args_fn=get_connection_args_common,
+        )
+
+        def inject_iam_token(_dialect, _conn_rec, _cargs, cparams: Dict[str, Any]):  # noqa: UP006
+            cparams["password"] = token_manager.get_token()
+            cparams["ssl"] = cparams.get("ssl") or {"ssl": True}
+
+        listen(engine, "do_connect", inject_iam_token)
+        return engine
 
     def _get_cloudsql_engine(self, connection: MySQLConnectionConfig) -> Engine:
         try:

--- a/ingestion/tests/unit/connections/test_iam_token_refresh.py
+++ b/ingestion/tests/unit/connections/test_iam_token_refresh.py
@@ -1,0 +1,127 @@
+#  Copyright 2025 Collate
+#  Licensed under the Collate Community License, Version 1.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  https://github.com/open-metadata/OpenMetadata/blob/main/ingestion/LICENSE
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+"""
+Characterization tests for the SHARED RDS IAM auth path in ``builders.py``.
+
+RDS IAM auth tokens expire after ~15 minutes. ``get_connection_url_common`` mints
+the token once and bakes it into the connection URL string, so a single engine
+reuses one frozen token for every pooled connection and cannot refresh it.
+
+The MySQL connector now works around this at the connector level (it builds the
+engine without a token in the URL and attaches a ``do_connect`` listener that
+injects a fresh token per connection) — see
+``tests/unit/source/database/test_mysql_iam.py``.
+
+These tests pin the behaviour of the SHARED helper, which is still token-frozen
+and is the remaining gap for the other RDS connectors that go through it
+(Postgres, Redshift, Greenplum, Timescale). They are expected to FAIL — and
+should be flipped to assert refreshed behaviour — once the shared path is fixed
+too. ``test_iam_token_is_used_for_authentication`` is the invariant that holds
+either way.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from metadata.generated.schema.entity.services.connections.database.common.iamAuthConfig import (
+    IamAuthConfigurationSource,
+)
+from metadata.generated.schema.entity.services.connections.database.mysqlConnection import (
+    MysqlConnection,
+)
+from metadata.generated.schema.security.credentials.awsCredentials import (
+    AWSCredentials,
+)
+from metadata.ingestion.connections import builders
+
+IAM_TOKEN = "iam-token-v1"
+HOST = "myrds.abc.us-east-1.rds.amazonaws.com"
+PORT = "3306"
+USERNAME = "iam_user"
+REGION = "us-east-1"
+
+
+def _iam_connection() -> MysqlConnection:
+    return MysqlConnection(
+        username=USERNAME,
+        hostPort=f"{HOST}:{PORT}",
+        authType=IamAuthConfigurationSource(awsConfig=AWSCredentials(awsRegion=REGION)),
+    )
+
+
+@pytest.fixture
+def mock_rds_token():
+    """Patch AWSClient so generate_db_auth_token returns a fixed token and is counted."""
+    with patch.object(builders, "AWSClient") as mock_aws_client:
+        rds_client = MagicMock()
+        rds_client.generate_db_auth_token.return_value = IAM_TOKEN
+        mock_aws_client.return_value.get_rds_client.return_value = rds_client
+        yield rds_client
+
+
+class TestRdsIamTokenRefresh:
+    def test_iam_token_is_used_for_authentication(self, mock_rds_token):
+        """Invariant: the generated IAM token authenticates the connection.
+
+        Holds before and after the B1 fix.
+        """
+        url = builders.get_connection_url_common(_iam_connection())
+
+        assert IAM_TOKEN in url
+        assert mock_rds_token.generate_db_auth_token.call_args.kwargs == {
+            "DBHostname": HOST,
+            "Port": PORT,
+            "DBUsername": USERNAME,
+            "Region": REGION,
+        }
+
+    def test_iam_token_is_generated_once_and_frozen_in_url(self, mock_rds_token):
+        """Documents the remaining shared-path gap: token baked into the URL string.
+
+        ``get_connection_url_common`` embeds the token in the URL, so every engine
+        built from it reuses that single token for its whole lifetime — it is never
+        refreshed and goes stale after the ~15 min RDS IAM token TTL. The MySQL
+        connector bypasses this path; the connectors that still rely on it do not.
+
+        EXPECTED TO FAIL once the shared path is fixed to mint a token per
+        connection rather than embedding it in the URL.
+        """
+        conn = _iam_connection()
+
+        first_url = builders.get_connection_url_common(conn)
+        second_url = builders.get_connection_url_common(conn)
+
+        assert IAM_TOKEN in first_url, "token is embedded directly in the URL (the bug)"
+        assert first_url == second_url, "same frozen token is reused, never refreshed"
+
+    def test_no_do_connect_listener_is_registered_for_iam(self, mock_rds_token):
+        """Documents the shared-path gap: no per-connection token injection hook.
+
+        The shared ``create_generic_db_connection`` does not attach a ``do_connect``
+        listener for IAM, so an engine built purely through it cannot refresh the
+        baked-in token once it expires. (The MySQL connector adds this listener
+        itself; see test_mysql_iam.py.)
+
+        EXPECTED TO FAIL once the shared path grows its own IAM listener.
+        """
+        with patch.object(builders, "listen") as mock_listen:
+            builders.create_generic_db_connection(
+                connection=_iam_connection(),
+                get_connection_url_fn=builders.get_connection_url_common,
+                get_connection_args_fn=builders.get_connection_args_common,
+            )
+
+        do_connect_registrations = [call for call in mock_listen.call_args_list if "do_connect" in call.args]
+        assert not do_connect_registrations, (
+            "no do_connect listener is wired for IAM today — this is the gap B1 "
+            "describes; once fixed, invert this assertion"
+        )

--- a/ingestion/tests/unit/source/database/test_mysql_iam.py
+++ b/ingestion/tests/unit/source/database/test_mysql_iam.py
@@ -164,7 +164,32 @@ class TestMySQLIamEngine:
         cparams = {}
         listener(None, None, None, cparams)
         assert "ssl" in cparams
-        assert cparams["ssl"] == {}
+        # Must be truthy so PyMySQL treats TLS as required (not PREFERRED).
+        assert cparams["ssl"]
+
+    @patch.object(connection_module, "RdsIamAuthTokenManager")
+    @patch.object(connection_module, "listen")
+    @patch.object(connection_module, "create_generic_db_connection")
+    def test_injected_ssl_makes_pymysql_require_tls(self, mock_create, mock_listen, mock_token_manager):
+        """Assert real PyMySQL behavior: the injected ssl value enables required TLS.
+
+        An empty dict only yields PREFERRED mode (_ssl_required=False), which can
+        fall back to plaintext; the injected value must produce _ssl_required=True.
+        """
+        import pymysql
+
+        mock_token_manager.return_value.get_token.return_value = "FRESH_TOKEN"
+        mysql_conn = _make_mysql_connection(_iam_connection())
+        mysql_conn._get_iam_engine(mysql_conn.service_connection)
+        listener = mock_listen.call_args.args[2]
+
+        cparams = {}
+        listener(None, None, None, cparams)
+
+        with patch.object(pymysql.connections.Connection, "connect", lambda self: None):
+            conn = pymysql.connections.Connection(host="h", user="u", ssl=cparams["ssl"])
+        assert conn.ssl is True
+        assert conn._ssl_required is True
 
     @patch.object(connection_module, "RdsIamAuthTokenManager")
     @patch.object(connection_module, "listen")

--- a/ingestion/tests/unit/source/database/test_mysql_iam.py
+++ b/ingestion/tests/unit/source/database/test_mysql_iam.py
@@ -18,6 +18,9 @@ later in a long ingestion still authenticate successfully.
 """
 
 import datetime
+import threading
+import time
+from concurrent.futures import ThreadPoolExecutor
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -76,6 +79,24 @@ class TestMySQLIamEngine:
         url = url_fn(mysql_conn.service_connection)
         assert "FRESH_TOKEN" not in url
         assert url == f"mysql+pymysql://{USERNAME}@{HOST}:{PORT}"
+
+    @patch.object(connection_module, "RdsIamAuthTokenManager")
+    @patch.object(connection_module, "listen")
+    @patch.object(connection_module, "create_generic_db_connection")
+    def test_username_is_url_encoded(self, mock_create, mock_listen, mock_token_manager):
+        connection = MysqlConnection(
+            username="iam@user/db",
+            hostPort=f"{HOST}:{PORT}",
+            authType=IamAuthConfigurationSource(awsConfig=AWSCredentials(awsRegion=REGION)),
+        )
+        mysql_conn = _make_mysql_connection(connection)
+
+        mysql_conn._get_iam_engine(connection)
+
+        url_fn = mock_create.call_args.kwargs["get_connection_url_fn"]
+        url = url_fn(connection)
+        assert "iam%40user%2Fdb" in url
+        assert "iam@user/db@" not in url
 
     @patch.object(connection_module, "RdsIamAuthTokenManager")
     @patch.object(connection_module, "listen")
@@ -215,3 +236,32 @@ class TestRdsIamAuthTokenManager:
         manager.get_token()
 
         assert manager._expires_at is not None
+
+    def test_concurrent_get_token_refreshes_only_once(self, mock_rds):
+        """Many threads hitting a cold manager must trigger a single refresh.
+
+        Each worker thread calls engine.connect() -> the shared do_connect listener
+        -> the shared manager's get_token(). Without locking, threads racing on a
+        cold/expired token each call generate_db_auth_token. A slow token generator
+        widens the race window so the assertion is meaningful.
+        """
+        now = datetime.datetime.now(datetime.timezone.utc)
+
+        def slow_generate(**_kwargs):
+            time.sleep(0.05)
+            return _presigned_token(now)
+
+        mock_rds.generate_db_auth_token.side_effect = slow_generate
+        manager = self._manager()
+
+        barrier = threading.Barrier(10)
+
+        def call():
+            barrier.wait()
+            return manager.get_token()
+
+        with ThreadPoolExecutor(max_workers=10) as executor:
+            tokens = [future.result() for future in [executor.submit(call) for _ in range(10)]]
+
+        assert mock_rds.generate_db_auth_token.call_count == 1
+        assert all(token == _presigned_token(now) for token in tokens)

--- a/ingestion/tests/unit/source/database/test_mysql_iam.py
+++ b/ingestion/tests/unit/source/database/test_mysql_iam.py
@@ -78,7 +78,8 @@ class TestMySQLIamEngine:
         url_fn = mock_create.call_args.kwargs["get_connection_url_fn"]
         url = url_fn(mysql_conn.service_connection)
         assert "FRESH_TOKEN" not in url
-        assert url == f"mysql+pymysql://{USERNAME}@{HOST}:{PORT}"
+        assert "Action=connect" not in url
+        assert url.startswith(f"mysql+pymysql://{USERNAME}:@{HOST}:{PORT}")
 
     @patch.object(connection_module, "RdsIamAuthTokenManager")
     @patch.object(connection_module, "listen")
@@ -97,6 +98,27 @@ class TestMySQLIamEngine:
         url = url_fn(connection)
         assert "iam%40user%2Fdb" in url
         assert "iam@user/db@" not in url
+
+    @patch.object(connection_module, "RdsIamAuthTokenManager")
+    @patch.object(connection_module, "listen")
+    @patch.object(connection_module, "create_generic_db_connection")
+    def test_url_preserves_database_schema_and_options(self, mock_create, mock_listen, mock_token_manager):
+        connection = MysqlConnection(
+            username=USERNAME,
+            hostPort=f"{HOST}:{PORT}",
+            databaseSchema="analytics",
+            connectionOptions={"charset": "utf8mb4"},
+            authType=IamAuthConfigurationSource(awsConfig=AWSCredentials(awsRegion=REGION)),
+        )
+        mysql_conn = _make_mysql_connection(connection)
+
+        mysql_conn._get_iam_engine(connection)
+
+        url_fn = mock_create.call_args.kwargs["get_connection_url_fn"]
+        url = url_fn(connection)
+        assert "/analytics" in url
+        assert "charset=utf8mb4" in url
+        assert "Action=connect" not in url
 
     @patch.object(connection_module, "RdsIamAuthTokenManager")
     @patch.object(connection_module, "listen")
@@ -141,7 +163,8 @@ class TestMySQLIamEngine:
 
         cparams = {}
         listener(None, None, None, cparams)
-        assert cparams["ssl"]
+        assert "ssl" in cparams
+        assert cparams["ssl"] == {}
 
     @patch.object(connection_module, "RdsIamAuthTokenManager")
     @patch.object(connection_module, "listen")
@@ -153,10 +176,25 @@ class TestMySQLIamEngine:
         mysql_conn._get_iam_engine(mysql_conn.service_connection)
         listener = mock_listen.call_args.args[2]
 
-        existing_ssl = {"ca": "/path/to/ca.pem"}
+        existing_ssl = {"ssl_ca": "/path/to/ca.pem"}
         cparams = {"ssl": existing_ssl}
         listener(None, None, None, cparams)
         assert cparams["ssl"] == existing_ssl
+
+    @patch.object(connection_module, "RdsIamAuthTokenManager")
+    @patch.object(connection_module, "listen")
+    @patch.object(connection_module, "create_generic_db_connection")
+    def test_listener_does_not_overwrite_explicit_empty_ssl(self, mock_create, mock_listen, mock_token_manager):
+        mock_token_manager.return_value.get_token.return_value = "FRESH_TOKEN"
+        mysql_conn = _make_mysql_connection(_iam_connection())
+
+        mysql_conn._get_iam_engine(mysql_conn.service_connection)
+        listener = mock_listen.call_args.args[2]
+
+        sentinel_ssl = {}
+        cparams = {"ssl": sentinel_ssl}
+        listener(None, None, None, cparams)
+        assert cparams["ssl"] is sentinel_ssl
 
     @patch.object(connection_module, "RdsIamAuthTokenManager")
     @patch.object(connection_module, "listen")

--- a/ingestion/tests/unit/source/database/test_mysql_iam.py
+++ b/ingestion/tests/unit/source/database/test_mysql_iam.py
@@ -1,0 +1,217 @@
+#  Copyright 2025 Collate
+#  Licensed under the Collate Community License, Version 1.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  https://github.com/open-metadata/OpenMetadata/blob/main/ingestion/LICENSE
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+"""
+Tests for MySQL RDS IAM authentication (finding B1 fix).
+
+RDS IAM tokens expire after ~15 minutes. The MySQL connector must inject a fresh
+token on every new connection (via a SQLAlchemy ``do_connect`` listener) instead
+of baking a single token into the connection URL, so that connections opened
+later in a long ingestion still authenticate successfully.
+"""
+
+import datetime
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import metadata.ingestion.source.database.mysql.connection as connection_module
+from metadata.clients.aws_client import RdsIamAuthTokenManager
+from metadata.generated.schema.entity.services.connections.database.common.iamAuthConfig import (
+    IamAuthConfigurationSource,
+)
+from metadata.generated.schema.entity.services.connections.database.mysqlConnection import (
+    MysqlConnection,
+)
+from metadata.generated.schema.security.credentials.awsCredentials import (
+    AWSCredentials,
+)
+from metadata.ingestion.source.database.mysql.connection import MySQLConnection
+
+HOST = "myrds.abc.us-east-2.rds.amazonaws.com"
+PORT = "3306"
+USERNAME = "iam_user"
+REGION = "us-east-2"
+
+
+def _iam_connection() -> MysqlConnection:
+    return MysqlConnection(
+        username=USERNAME,
+        hostPort=f"{HOST}:{PORT}",
+        authType=IamAuthConfigurationSource(awsConfig=AWSCredentials(awsRegion=REGION)),
+    )
+
+
+def _make_mysql_connection(connection: MysqlConnection) -> MySQLConnection:
+    mysql_conn = MySQLConnection.__new__(MySQLConnection)
+    mysql_conn.service_connection = connection
+    return mysql_conn
+
+
+def _presigned_token(issued_at: datetime.datetime, expires_seconds: int = 900) -> str:
+    amz_date = issued_at.strftime("%Y%m%dT%H%M%SZ")
+    return f"{HOST}:{PORT}/?Action=connect&DBUser={USERNAME}&X-Amz-Date={amz_date}&X-Amz-Expires={expires_seconds}"
+
+
+class TestMySQLIamEngine:
+    """The connector wires a per-connection token-refresh listener for IAM auth."""
+
+    @patch.object(connection_module, "RdsIamAuthTokenManager")
+    @patch.object(connection_module, "listen")
+    @patch.object(connection_module, "create_generic_db_connection")
+    def test_iam_token_is_not_baked_into_url(self, mock_create, mock_listen, mock_token_manager):
+        mock_token_manager.return_value.get_token.return_value = "FRESH_TOKEN"
+        mysql_conn = _make_mysql_connection(_iam_connection())
+
+        mysql_conn._get_iam_engine(mysql_conn.service_connection)
+
+        url_fn = mock_create.call_args.kwargs["get_connection_url_fn"]
+        url = url_fn(mysql_conn.service_connection)
+        assert "FRESH_TOKEN" not in url
+        assert url == f"mysql+pymysql://{USERNAME}@{HOST}:{PORT}"
+
+    @patch.object(connection_module, "RdsIamAuthTokenManager")
+    @patch.object(connection_module, "listen")
+    @patch.object(connection_module, "create_generic_db_connection")
+    def test_do_connect_listener_is_registered(self, mock_create, mock_listen, mock_token_manager):
+        mock_token_manager.return_value.get_token.return_value = "FRESH_TOKEN"
+        mysql_conn = _make_mysql_connection(_iam_connection())
+
+        mysql_conn._get_iam_engine(mysql_conn.service_connection)
+
+        event_name = mock_listen.call_args.args[1]
+        assert event_name == "do_connect"
+
+    @patch.object(connection_module, "RdsIamAuthTokenManager")
+    @patch.object(connection_module, "listen")
+    @patch.object(connection_module, "create_generic_db_connection")
+    def test_listener_injects_fresh_token_per_connection(self, mock_create, mock_listen, mock_token_manager):
+        mock_token_manager.return_value.get_token.return_value = "FRESH_TOKEN"
+        mysql_conn = _make_mysql_connection(_iam_connection())
+
+        mysql_conn._get_iam_engine(mysql_conn.service_connection)
+        listener = mock_listen.call_args.args[2]
+
+        first_cparams = {}
+        listener(None, None, None, first_cparams)
+        second_cparams = {}
+        listener(None, None, None, second_cparams)
+
+        assert first_cparams["password"] == "FRESH_TOKEN"
+        assert second_cparams["password"] == "FRESH_TOKEN"
+        assert mock_token_manager.return_value.get_token.call_count == 2
+
+    @patch.object(connection_module, "RdsIamAuthTokenManager")
+    @patch.object(connection_module, "listen")
+    @patch.object(connection_module, "create_generic_db_connection")
+    def test_listener_enables_ssl_required_by_pymysql_for_iam(self, mock_create, mock_listen, mock_token_manager):
+        mock_token_manager.return_value.get_token.return_value = "FRESH_TOKEN"
+        mysql_conn = _make_mysql_connection(_iam_connection())
+
+        mysql_conn._get_iam_engine(mysql_conn.service_connection)
+        listener = mock_listen.call_args.args[2]
+
+        cparams = {}
+        listener(None, None, None, cparams)
+        assert cparams["ssl"]
+
+    @patch.object(connection_module, "RdsIamAuthTokenManager")
+    @patch.object(connection_module, "listen")
+    @patch.object(connection_module, "create_generic_db_connection")
+    def test_listener_preserves_existing_ssl_config(self, mock_create, mock_listen, mock_token_manager):
+        mock_token_manager.return_value.get_token.return_value = "FRESH_TOKEN"
+        mysql_conn = _make_mysql_connection(_iam_connection())
+
+        mysql_conn._get_iam_engine(mysql_conn.service_connection)
+        listener = mock_listen.call_args.args[2]
+
+        existing_ssl = {"ca": "/path/to/ca.pem"}
+        cparams = {"ssl": existing_ssl}
+        listener(None, None, None, cparams)
+        assert cparams["ssl"] == existing_ssl
+
+    @patch.object(connection_module, "RdsIamAuthTokenManager")
+    @patch.object(connection_module, "listen")
+    @patch.object(connection_module, "create_generic_db_connection")
+    def test_token_manager_built_with_split_host_and_port(self, mock_create, mock_listen, mock_token_manager):
+        mysql_conn = _make_mysql_connection(_iam_connection())
+
+        mysql_conn._get_iam_engine(mysql_conn.service_connection)
+
+        assert mock_token_manager.call_args.kwargs["host"] == HOST
+        assert mock_token_manager.call_args.kwargs["port"] == PORT
+        assert mock_token_manager.call_args.kwargs["username"] == USERNAME
+
+
+class TestRdsIamAuthTokenManager:
+    """The token manager caches a token and refreshes it before expiry."""
+
+    @pytest.fixture
+    def mock_rds(self):
+        with patch("metadata.clients.aws_client.AWSClient") as mock_aws_client:
+            rds_client = MagicMock()
+            mock_aws_client.return_value.get_rds_client.return_value = rds_client
+            yield rds_client
+
+    def _manager(self) -> RdsIamAuthTokenManager:
+        return RdsIamAuthTokenManager(
+            host=HOST,
+            port=PORT,
+            username=USERNAME,
+            aws_config=AWSCredentials(awsRegion=REGION),
+        )
+
+    def test_first_call_generates_token(self, mock_rds):
+        now = datetime.datetime.now(datetime.timezone.utc)
+        mock_rds.generate_db_auth_token.return_value = _presigned_token(now)
+
+        token = self._manager().get_token()
+
+        assert token == _presigned_token(now)
+        assert mock_rds.generate_db_auth_token.call_count == 1
+
+    def test_token_cached_within_ttl(self, mock_rds):
+        now = datetime.datetime.now(datetime.timezone.utc)
+        mock_rds.generate_db_auth_token.return_value = _presigned_token(now)
+
+        manager = self._manager()
+        manager.get_token()
+        manager.get_token()
+
+        assert mock_rds.generate_db_auth_token.call_count == 1
+
+    def test_token_refreshed_after_expiry(self, mock_rds):
+        now = datetime.datetime.now(datetime.timezone.utc)
+        mock_rds.generate_db_auth_token.return_value = _presigned_token(now)
+
+        manager = self._manager()
+        manager.get_token()
+        manager._expires_at = now - datetime.timedelta(seconds=1)
+        manager.get_token()
+
+        assert mock_rds.generate_db_auth_token.call_count == 2
+
+    def test_expiry_parsed_from_presigned_url(self, mock_rds):
+        now = datetime.datetime.now(datetime.timezone.utc)
+        mock_rds.generate_db_auth_token.return_value = _presigned_token(now, expires_seconds=900)
+
+        manager = self._manager()
+        manager.get_token()
+
+        seconds_until_expiry = (manager._expires_at - now).total_seconds()
+        assert 890 <= seconds_until_expiry <= 910
+
+    def test_malformed_token_falls_back_to_default_ttl(self, mock_rds):
+        mock_rds.generate_db_auth_token.return_value = "not-a-presigned-url"
+
+        manager = self._manager()
+        manager.get_token()
+
+        assert manager._expires_at is not None


### PR DESCRIPTION
## Problem
Fix: https://github.com/open-metadata/OpenMetadata/issues/28686
- MySQL ingestion against AWS RDS using **IAM authentication** fails partway
through long runs with `Access denied`.

- The IAM auth token is generated **once**, at engine-build time, and baked into
the SQLAlchemy connection URL (`get_password_secret` → `get_connection_url_common`
in `builders.py`). RDS IAM tokens **expire after ~15 minutes**, and the token is
never refreshed for the lifetime of the engine. Because the engine is created with
`max_overflow=-1` (unlimited overflow connections) and ingestion is multi-threaded,
any new pooled connection opened after the token expires — large schemas, the
profiler, reconnects — authenticates with a stale credential and dies mid-run.

- The failure is time-dependent and intermittent: a small/single-connection run can
reuse one still-valid connection and pass, which masks the bug; a large catalog
reliably hits it.

## Fix

- **`clients/aws_client.py`** — add `RdsIamAuthTokenManager`: generates the RDS IAM
  token, derives expiry from the presigned-URL params (`X-Amz-Date` / `X-Amz-Expires`),
  caches it, and regenerates shortly before expiry. Falls back to a conservative TTL
  if the token can't be parsed so it still refreshes rather than living forever.
- **`source/database/mysql/connection.py`** — route `IamAuthConfigurationSource` to a
  new `_get_iam_engine` that:
  - builds the engine with **no token in the URL** (`scheme://user@host:port`), and
  - attaches a SQLAlchemy `do_connect` event listener that injects a **fresh token on
    every connection** and enables SSL (PyMySQL requires SSL for RDS IAM), preserving
    any existing SSL config.

This keeps the connector-specific wiring in the MySQL connection handler while the
reusable token manager lives with `AWSClient`.

## Scope / follow-up

Scoped to **MySQL**. The shared `builders.py` IAM path remains token-frozen for the
other RDS connectors that go through it (**Postgres, Redshift, Greenplum, Timescale**).
`tests/unit/connections/test_iam_token_refresh.py` documents that remaining gap and is
set up to flip to green once the shared path adopts `RdsIamAuthTokenManager`.

## Tests

- `tests/unit/source/database/test_mysql_iam.py` (new):
  - **Connector**: token not baked into the URL, `do_connect` listener registered,
    **fresh token minted per connection**, SSL enabled, existing SSL preserved,
    host/port split correctly.
  - **Token manager**: first call generates, cached within TTL, **refreshed after
    expiry**, expiry parsed from the presigned URL, malformed-token fallback.
- `tests/unit/connections/test_iam_token_refresh.py` (new): characterizes the shared
  `builders.py` IAM path as the remaining gap for the non-MySQL RDS connectors.