### PR TITLE
feat(ui-core-components): add Breadcrumbs component

### DIFF
--- a/openmetadata-ui-core-components/src/main/resources/ui/src/components/application/breadcrumbs/breadcrumbs.tsx
+++ b/openmetadata-ui-core-components/src/main/resources/ui/src/components/application/breadcrumbs/breadcrumbs.tsx
@@ -25,6 +25,8 @@ export type BreadcrumbsType = 'text' | 'button-white' | 'button-gray';
 
 export type BreadcrumbsDivider = 'chevron' | 'slash';
 
+export type BreadcrumbsSize = 'xs' | 'sm' | 'md';
+
 export interface BreadcrumbItemType {
   /** Unique identifier for the item. */
   id: Key;
@@ -43,6 +45,8 @@ export interface BreadcrumbsProps {
   type?: BreadcrumbsType;
   /** Separator rendered between crumbs. */
   divider?: BreadcrumbsDivider;
+  /** Size of the crumbs (text, icons and button padding). */
+  size?: BreadcrumbsSize;
   /**
    * Maximum number of crumbs to render inline. When the list is longer, the
    * middle crumbs collapse into a `…` menu, keeping the first and last crumbs
@@ -75,14 +79,37 @@ const styles = sortCx({
     current: 'tw:text-secondary tw:font-medium',
   },
   'button-white': {
-    link: 'tw:rounded-md tw:px-2 tw:py-1 tw:text-quaternary tw:hover:bg-primary_hover tw:hover:text-secondary',
+    link: 'tw:rounded-md tw:text-quaternary tw:hover:bg-primary_hover tw:hover:text-secondary',
     current:
-      'tw:rounded-md tw:bg-primary tw:px-2 tw:py-1 tw:font-medium tw:text-secondary tw:shadow-xs tw:ring-1 tw:ring-primary tw:ring-inset',
+      'tw:rounded-md tw:bg-primary tw:font-medium tw:text-secondary tw:shadow-xs tw:ring-1 tw:ring-primary tw:ring-inset',
   },
   'button-gray': {
-    link: 'tw:rounded-md tw:px-2 tw:py-1 tw:text-quaternary tw:hover:bg-secondary tw:hover:text-secondary',
-    current:
-      'tw:rounded-md tw:bg-secondary tw:px-2 tw:py-1 tw:font-medium tw:text-secondary',
+    link: 'tw:rounded-md tw:text-quaternary tw:hover:bg-secondary tw:hover:text-secondary',
+    current: 'tw:rounded-md tw:bg-secondary tw:font-medium tw:text-secondary',
+  },
+});
+
+const sizes = sortCx({
+  xs: {
+    gap: 'tw:gap-1',
+    text: 'tw:text-xs',
+    icon: 'tw:size-3.5',
+    dots: 'tw:size-4',
+    padding: 'tw:px-1.5 tw:py-0.5',
+  },
+  sm: {
+    gap: 'tw:gap-1.5',
+    text: 'tw:text-sm',
+    icon: 'tw:size-4',
+    dots: 'tw:size-5',
+    padding: 'tw:px-2 tw:py-1',
+  },
+  md: {
+    gap: 'tw:gap-2',
+    text: 'tw:text-sm',
+    icon: 'tw:size-5',
+    dots: 'tw:size-5',
+    padding: 'tw:px-2.5 tw:py-1.5',
   },
 });
 
@@ -111,7 +138,13 @@ const collapseItems = (
   return result;
 };
 
-const Divider = ({ divider }: { divider: BreadcrumbsDivider }) =>
+const Divider = ({
+  divider,
+  size,
+}: {
+  divider: BreadcrumbsDivider;
+  size: BreadcrumbsSize;
+}) =>
   divider === 'slash' ? (
     <span aria-hidden="true" className="tw:px-0.5 tw:text-quaternary">
       /
@@ -119,16 +152,22 @@ const Divider = ({ divider }: { divider: BreadcrumbsDivider }) =>
   ) : (
     <ChevronRight
       aria-hidden="true"
-      className="tw:size-4 tw:shrink-0 tw:text-fg-quaternary"
+      className={cx('tw:shrink-0 tw:text-fg-quaternary', sizes[size].icon)}
     />
   );
 
-const CrumbLabel = ({ item }: { item: BreadcrumbItemType }) => {
+const CrumbLabel = ({
+  item,
+  size,
+}: {
+  item: BreadcrumbItemType;
+  size: BreadcrumbsSize;
+}) => {
   const Icon = item.icon;
 
   return (
-    <span className="tw:flex tw:items-center tw:gap-1.5">
-      {Icon && <Icon className="tw:size-4 tw:shrink-0" />}
+    <span className={cx('tw:flex tw:items-center', sizes[size].gap)}>
+      {Icon && <Icon className={cx('tw:shrink-0', sizes[size].icon)} />}
       {item.label}
     </span>
   );
@@ -137,15 +176,23 @@ const CrumbLabel = ({ item }: { item: BreadcrumbItemType }) => {
 interface EllipsisMenuProps {
   hidden: BreadcrumbItemType[];
   type: BreadcrumbsType;
+  size: BreadcrumbsSize;
+  padding: string;
   onAction?: (id: Key) => void;
 }
 
-const EllipsisMenu = ({ hidden, type, onAction }: EllipsisMenuProps) => (
+const EllipsisMenu = ({
+  hidden,
+  type,
+  size,
+  padding,
+  onAction,
+}: EllipsisMenuProps) => (
   <Dropdown.Root>
     <AriaButton
       aria-label="Show hidden breadcrumbs"
-      className={cx(linkClassName, styles[type].link)}>
-      <DotsHorizontal className="tw:size-5 tw:shrink-0" />
+      className={cx(linkClassName, styles[type].link, padding)}>
+      <DotsHorizontal className={cx('tw:shrink-0', sizes[size].dots)} />
     </AriaButton>
     <Dropdown.Popover>
       <Dropdown.Menu aria-label="Hidden breadcrumbs">
@@ -167,6 +214,7 @@ export const Breadcrumbs = ({
   items,
   type = 'text',
   divider = 'chevron',
+  size = 'sm',
   maxItems,
   className,
   onAction,
@@ -174,38 +222,48 @@ export const Breadcrumbs = ({
 }: BreadcrumbsProps) => {
   const displayItems = collapseItems(items, maxItems);
   const firstId = displayItems[0]?.id;
+  const padding = type === 'text' ? '' : sizes[size].padding;
 
   return (
     <AriaBreadcrumbs
       aria-label={props['aria-label'] ?? 'Breadcrumb'}
-      className={cx('tw:flex tw:items-center tw:gap-1.5 tw:text-sm', className)}
+      className={cx(
+        'tw:flex tw:items-center',
+        sizes[size].gap,
+        sizes[size].text,
+        className
+      )}
       items={displayItems}>
       {(item) => (
-        <AriaBreadcrumb className="tw:flex tw:items-center tw:gap-1.5">
+        <AriaBreadcrumb
+          className={cx('tw:flex tw:items-center', sizes[size].gap)}>
           {({ isCurrent }) => (
             <>
-              {item.id !== firstId && <Divider divider={divider} />}
+              {item.id !== firstId && <Divider divider={divider} size={size} />}
               {isEllipsis(item) ? (
                 <EllipsisMenu
                   hidden={item.hidden}
+                  padding={padding}
+                  size={size}
                   type={type}
                   onAction={onAction}
                 />
               ) : !isCurrent && (item.href || onAction) ? (
                 <AriaLink
-                  className={cx(linkClassName, styles[type].link)}
+                  className={cx(linkClassName, styles[type].link, padding)}
                   href={item.href}
                   onPress={() => onAction?.(item.id)}>
-                  <CrumbLabel item={item} />
+                  <CrumbLabel item={item} size={size} />
                 </AriaLink>
               ) : (
                 <span
                   aria-current={isCurrent ? 'page' : undefined}
                   className={cx(
                     'tw:flex tw:items-center',
+                    padding,
                     isCurrent ? styles[type].current : 'tw:text-quaternary'
                   )}>
-                  <CrumbLabel item={item} />
+                  <CrumbLabel item={item} size={size} />
                 </span>
               )}
             </>

--- a/openmetadata-ui-core-components/src/main/resources/ui/src/components/application/breadcrumbs/breadcrumbs.tsx
+++ b/openmetadata-ui-core-components/src/main/resources/ui/src/components/application/breadcrumbs/breadcrumbs.tsx
@@ -57,7 +57,13 @@ export interface BreadcrumbsProps {
   'aria-label'?: string;
   /** Class name for the root navigation element. */
   className?: string;
-  /** Called with the item id when a non-current crumb is activated. */
+  /**
+   * Called with the item id when a non-current crumb is activated. When
+   * provided, native `href` navigation is suppressed so the callback alone
+   * drives navigation (client-side routing) — this avoids a double navigation
+   * when an item supplies both `href` and `onAction`. Provide `href` without
+   * `onAction` for a plain link.
+   */
   onAction?: (id: Key) => void;
 }
 
@@ -198,7 +204,7 @@ const EllipsisMenu = ({
       <Dropdown.Menu aria-label="Hidden breadcrumbs">
         {hidden.map((item, index) => (
           <Dropdown.Item
-            href={item.href}
+            href={onAction ? undefined : item.href}
             icon={item.icon}
             key={item.id}
             label={toText(item.label, `Item ${index + 1}`)}
@@ -221,7 +227,6 @@ export const Breadcrumbs = ({
   ...props
 }: BreadcrumbsProps) => {
   const displayItems = collapseItems(items, maxItems);
-  const firstId = displayItems[0]?.id;
   const padding = type === 'text' ? '' : sizes[size].padding;
 
   return (
@@ -239,7 +244,6 @@ export const Breadcrumbs = ({
           className={cx('tw:flex tw:items-center', sizes[size].gap)}>
           {({ isCurrent }) => (
             <>
-              {item.id !== firstId && <Divider divider={divider} size={size} />}
               {isEllipsis(item) ? (
                 <EllipsisMenu
                   hidden={item.hidden}
@@ -251,7 +255,7 @@ export const Breadcrumbs = ({
               ) : !isCurrent && (item.href || onAction) ? (
                 <AriaLink
                   className={cx(linkClassName, styles[type].link, padding)}
-                  href={item.href}
+                  href={onAction ? undefined : item.href}
                   onPress={() => onAction?.(item.id)}>
                   <CrumbLabel item={item} size={size} />
                 </AriaLink>
@@ -266,6 +270,7 @@ export const Breadcrumbs = ({
                   <CrumbLabel item={item} size={size} />
                 </span>
               )}
+              {!isCurrent && <Divider divider={divider} size={size} />}
             </>
           )}
         </AriaBreadcrumb>

--- a/openmetadata-ui-core-components/src/main/resources/ui/src/components/application/breadcrumbs/breadcrumbs.tsx
+++ b/openmetadata-ui-core-components/src/main/resources/ui/src/components/application/breadcrumbs/breadcrumbs.tsx
@@ -1,0 +1,137 @@
+/*
+ *  Copyright 2025 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+import { ChevronRight } from '@untitledui/icons';
+import type { FC, Key, ReactNode } from 'react';
+import {
+  Breadcrumb as AriaBreadcrumb,
+  Breadcrumbs as AriaBreadcrumbs,
+  Link as AriaLink,
+} from 'react-aria-components';
+import { cx, sortCx } from '@/utils/cx';
+
+export type BreadcrumbsType = 'text' | 'button-white' | 'button-gray';
+
+export type BreadcrumbsDivider = 'chevron' | 'slash';
+
+export interface BreadcrumbItemType {
+  /** Unique identifier for the item. */
+  id: Key;
+  /** The text shown for the crumb. */
+  label: ReactNode;
+  /** Navigation target. Omit on the current (last) page. */
+  href?: string;
+  /** Optional leading icon, e.g. a home icon on the first crumb. */
+  icon?: FC<{ className?: string }>;
+}
+
+export interface BreadcrumbsProps {
+  /** Ordered list of crumbs; the last item is treated as the current page. */
+  items: BreadcrumbItemType[];
+  /** Visual style of the crumbs. */
+  type?: BreadcrumbsType;
+  /** Separator rendered between crumbs. */
+  divider?: BreadcrumbsDivider;
+  /** Accessible label for the navigation landmark. */
+  'aria-label'?: string;
+  /** Class name for the root navigation element. */
+  className?: string;
+  /** Called with the item id when a non-current crumb is activated. */
+  onAction?: (id: Key) => void;
+}
+
+const styles = sortCx({
+  text: {
+    link: 'tw:text-quaternary tw:hover:text-secondary',
+    current: 'tw:text-secondary tw:font-medium',
+  },
+  'button-white': {
+    link: 'tw:rounded-md tw:px-2 tw:py-1 tw:text-quaternary tw:hover:bg-primary_hover tw:hover:text-secondary',
+    current:
+      'tw:rounded-md tw:bg-primary tw:px-2 tw:py-1 tw:font-medium tw:text-secondary tw:shadow-xs tw:ring-1 tw:ring-primary tw:ring-inset',
+  },
+  'button-gray': {
+    link: 'tw:rounded-md tw:px-2 tw:py-1 tw:text-quaternary tw:hover:bg-secondary tw:hover:text-secondary',
+    current:
+      'tw:rounded-md tw:bg-secondary tw:px-2 tw:py-1 tw:font-medium tw:text-secondary',
+  },
+});
+
+const Divider = ({ divider }: { divider: BreadcrumbsDivider }) =>
+  divider === 'slash' ? (
+    <span aria-hidden="true" className="tw:px-0.5 tw:text-quaternary">
+      /
+    </span>
+  ) : (
+    <ChevronRight
+      aria-hidden="true"
+      className="tw:size-4 tw:shrink-0 tw:text-fg-quaternary"
+    />
+  );
+
+export const Breadcrumbs = ({
+  items,
+  type = 'text',
+  divider = 'chevron',
+  className,
+  onAction,
+  ...props
+}: BreadcrumbsProps) => {
+  const firstId = items[0]?.id;
+
+  return (
+    <AriaBreadcrumbs
+      aria-label={props['aria-label'] ?? 'Breadcrumb'}
+      className={cx('tw:flex tw:items-center tw:gap-1.5 tw:text-sm', className)}
+      items={items}>
+      {(item) => (
+        <AriaBreadcrumb className="tw:flex tw:items-center tw:gap-1.5">
+          {({ isCurrent }) => {
+            const Icon = item.icon;
+            const content = (
+              <span className="tw:flex tw:items-center tw:gap-1.5">
+                {Icon && <Icon className="tw:size-4 tw:shrink-0" />}
+                {item.label}
+              </span>
+            );
+
+            return (
+              <>
+                {item.id !== firstId && <Divider divider={divider} />}
+                {!isCurrent && (item.href || onAction) ? (
+                  <AriaLink
+                    className={cx(
+                      'tw:flex tw:cursor-pointer tw:items-center tw:rounded-md tw:outline-brand tw:transition tw:duration-100 tw:ease-linear tw:focus-visible:outline-2 tw:focus-visible:outline-offset-2',
+                      styles[type].link
+                    )}
+                    href={item.href}
+                    onPress={() => onAction?.(item.id)}>
+                    {content}
+                  </AriaLink>
+                ) : (
+                  <span
+                    aria-current={isCurrent ? 'page' : undefined}
+                    className={cx(
+                      'tw:flex tw:items-center',
+                      isCurrent ? styles[type].current : 'tw:text-quaternary'
+                    )}>
+                    {content}
+                  </span>
+                )}
+              </>
+            );
+          }}
+        </AriaBreadcrumb>
+      )}
+    </AriaBreadcrumbs>
+  );
+};

--- a/openmetadata-ui-core-components/src/main/resources/ui/src/components/application/breadcrumbs/breadcrumbs.tsx
+++ b/openmetadata-ui-core-components/src/main/resources/ui/src/components/application/breadcrumbs/breadcrumbs.tsx
@@ -10,13 +10,15 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-import { ChevronRight } from '@untitledui/icons';
+import { ChevronRight, DotsHorizontal } from '@untitledui/icons';
 import type { FC, Key, ReactNode } from 'react';
 import {
   Breadcrumb as AriaBreadcrumb,
   Breadcrumbs as AriaBreadcrumbs,
+  Button as AriaButton,
   Link as AriaLink,
 } from 'react-aria-components';
+import { Dropdown } from '@/components/base/dropdown/dropdown';
 import { cx, sortCx } from '@/utils/cx';
 
 export type BreadcrumbsType = 'text' | 'button-white' | 'button-gray';
@@ -41,6 +43,12 @@ export interface BreadcrumbsProps {
   type?: BreadcrumbsType;
   /** Separator rendered between crumbs. */
   divider?: BreadcrumbsDivider;
+  /**
+   * Maximum number of crumbs to render inline. When the list is longer, the
+   * middle crumbs collapse into a `…` menu, keeping the first and last crumbs
+   * visible. Omit to always render every crumb.
+   */
+  maxItems?: number;
   /** Accessible label for the navigation landmark. */
   'aria-label'?: string;
   /** Class name for the root navigation element. */
@@ -48,6 +56,18 @@ export interface BreadcrumbsProps {
   /** Called with the item id when a non-current crumb is activated. */
   onAction?: (id: Key) => void;
 }
+
+const ELLIPSIS_ID = '__breadcrumbs_ellipsis__';
+
+interface EllipsisItem {
+  id: typeof ELLIPSIS_ID;
+  hidden: BreadcrumbItemType[];
+}
+
+type DisplayItem = BreadcrumbItemType | EllipsisItem;
+
+const isEllipsis = (item: DisplayItem): item is EllipsisItem =>
+  item.id === ELLIPSIS_ID;
 
 const styles = sortCx({
   text: {
@@ -66,6 +86,31 @@ const styles = sortCx({
   },
 });
 
+const linkClassName =
+  'tw:flex tw:cursor-pointer tw:items-center tw:rounded-md tw:outline-brand tw:transition tw:duration-100 tw:ease-linear tw:focus-visible:outline-2 tw:focus-visible:outline-offset-2';
+
+const toText = (label: ReactNode, fallback: string): string =>
+  typeof label === 'string' || typeof label === 'number'
+    ? String(label)
+    : fallback;
+
+const collapseItems = (
+  items: BreadcrumbItemType[],
+  maxItems?: number
+): DisplayItem[] => {
+  let result: DisplayItem[] = items;
+  if (maxItems && maxItems >= 2 && items.length > maxItems) {
+    const trailingCount = maxItems - 1;
+    result = [
+      items[0],
+      { id: ELLIPSIS_ID, hidden: items.slice(1, items.length - trailingCount) },
+      ...items.slice(items.length - trailingCount),
+    ];
+  }
+
+  return result;
+};
+
 const Divider = ({ divider }: { divider: BreadcrumbsDivider }) =>
   divider === 'slash' ? (
     <span aria-hidden="true" className="tw:px-0.5 tw:text-quaternary">
@@ -78,58 +123,93 @@ const Divider = ({ divider }: { divider: BreadcrumbsDivider }) =>
     />
   );
 
+const CrumbLabel = ({ item }: { item: BreadcrumbItemType }) => {
+  const Icon = item.icon;
+
+  return (
+    <span className="tw:flex tw:items-center tw:gap-1.5">
+      {Icon && <Icon className="tw:size-4 tw:shrink-0" />}
+      {item.label}
+    </span>
+  );
+};
+
+interface EllipsisMenuProps {
+  hidden: BreadcrumbItemType[];
+  type: BreadcrumbsType;
+  onAction?: (id: Key) => void;
+}
+
+const EllipsisMenu = ({ hidden, type, onAction }: EllipsisMenuProps) => (
+  <Dropdown.Root>
+    <AriaButton
+      aria-label="Show hidden breadcrumbs"
+      className={cx(linkClassName, styles[type].link)}>
+      <DotsHorizontal className="tw:size-5 tw:shrink-0" />
+    </AriaButton>
+    <Dropdown.Popover>
+      <Dropdown.Menu aria-label="Hidden breadcrumbs">
+        {hidden.map((item, index) => (
+          <Dropdown.Item
+            href={item.href}
+            icon={item.icon}
+            key={item.id}
+            label={toText(item.label, `Item ${index + 1}`)}
+            onAction={() => onAction?.(item.id)}
+          />
+        ))}
+      </Dropdown.Menu>
+    </Dropdown.Popover>
+  </Dropdown.Root>
+);
+
 export const Breadcrumbs = ({
   items,
   type = 'text',
   divider = 'chevron',
+  maxItems,
   className,
   onAction,
   ...props
 }: BreadcrumbsProps) => {
-  const firstId = items[0]?.id;
+  const displayItems = collapseItems(items, maxItems);
+  const firstId = displayItems[0]?.id;
 
   return (
     <AriaBreadcrumbs
       aria-label={props['aria-label'] ?? 'Breadcrumb'}
       className={cx('tw:flex tw:items-center tw:gap-1.5 tw:text-sm', className)}
-      items={items}>
+      items={displayItems}>
       {(item) => (
         <AriaBreadcrumb className="tw:flex tw:items-center tw:gap-1.5">
-          {({ isCurrent }) => {
-            const Icon = item.icon;
-            const content = (
-              <span className="tw:flex tw:items-center tw:gap-1.5">
-                {Icon && <Icon className="tw:size-4 tw:shrink-0" />}
-                {item.label}
-              </span>
-            );
-
-            return (
-              <>
-                {item.id !== firstId && <Divider divider={divider} />}
-                {!isCurrent && (item.href || onAction) ? (
-                  <AriaLink
-                    className={cx(
-                      'tw:flex tw:cursor-pointer tw:items-center tw:rounded-md tw:outline-brand tw:transition tw:duration-100 tw:ease-linear tw:focus-visible:outline-2 tw:focus-visible:outline-offset-2',
-                      styles[type].link
-                    )}
-                    href={item.href}
-                    onPress={() => onAction?.(item.id)}>
-                    {content}
-                  </AriaLink>
-                ) : (
-                  <span
-                    aria-current={isCurrent ? 'page' : undefined}
-                    className={cx(
-                      'tw:flex tw:items-center',
-                      isCurrent ? styles[type].current : 'tw:text-quaternary'
-                    )}>
-                    {content}
-                  </span>
-                )}
-              </>
-            );
-          }}
+          {({ isCurrent }) => (
+            <>
+              {item.id !== firstId && <Divider divider={divider} />}
+              {isEllipsis(item) ? (
+                <EllipsisMenu
+                  hidden={item.hidden}
+                  type={type}
+                  onAction={onAction}
+                />
+              ) : !isCurrent && (item.href || onAction) ? (
+                <AriaLink
+                  className={cx(linkClassName, styles[type].link)}
+                  href={item.href}
+                  onPress={() => onAction?.(item.id)}>
+                  <CrumbLabel item={item} />
+                </AriaLink>
+              ) : (
+                <span
+                  aria-current={isCurrent ? 'page' : undefined}
+                  className={cx(
+                    'tw:flex tw:items-center',
+                    isCurrent ? styles[type].current : 'tw:text-quaternary'
+                  )}>
+                  <CrumbLabel item={item} />
+                </span>
+              )}
+            </>
+          )}
         </AriaBreadcrumb>
       )}
     </AriaBreadcrumbs>

--- a/openmetadata-ui-core-components/src/main/resources/ui/src/components/index.ts
+++ b/openmetadata-ui-core-components/src/main/resources/ui/src/components/index.ts
@@ -93,6 +93,7 @@ export {
   getField,
 } from './application/form-field/form-field';
 export * from './application/accordion/accordion';
+export * from './application/breadcrumbs/breadcrumbs';
 export * from './application/tree/tree';
 export { MobileNavigationHeader } from './application/app-navigation/base-components/mobile-header';
 export {

--- a/openmetadata-ui-core-components/src/main/resources/ui/src/stories/Breadcrumbs.stories.tsx
+++ b/openmetadata-ui-core-components/src/main/resources/ui/src/stories/Breadcrumbs.stories.tsx
@@ -67,3 +67,13 @@ export const SlashDivider: Story = {
 export const Collapsed: Story = {
   args: { items: deepItems, maxItems: 3 },
 };
+
+export const Sizes: Story = {
+  render: (args) => (
+    <div className="tw:flex tw:flex-col tw:gap-4">
+      <Breadcrumbs {...args} size="xs" />
+      <Breadcrumbs {...args} size="sm" />
+      <Breadcrumbs {...args} size="md" />
+    </div>
+  ),
+};

--- a/openmetadata-ui-core-components/src/main/resources/ui/src/stories/Breadcrumbs.stories.tsx
+++ b/openmetadata-ui-core-components/src/main/resources/ui/src/stories/Breadcrumbs.stories.tsx
@@ -24,6 +24,15 @@ const items: BreadcrumbItemType[] = [
   { id: 'members', label: 'Members' },
 ];
 
+const deepItems: BreadcrumbItemType[] = [
+  { id: 'home', label: 'Home', href: '#', icon: HomeLine },
+  { id: 'workspace', label: 'Workspace', href: '#' },
+  { id: 'projects', label: 'Projects', href: '#' },
+  { id: 'analytics', label: 'Analytics', href: '#' },
+  { id: 'dashboards', label: 'Dashboards', href: '#' },
+  { id: 'overview', label: 'Overview' },
+];
+
 const meta = {
   title: 'Components/Breadcrumbs',
   component: Breadcrumbs,
@@ -53,4 +62,8 @@ export const ButtonGray: Story = {
 
 export const SlashDivider: Story = {
   args: { divider: 'slash' },
+};
+
+export const Collapsed: Story = {
+  args: { items: deepItems, maxItems: 3 },
 };

--- a/openmetadata-ui-core-components/src/main/resources/ui/src/stories/Breadcrumbs.stories.tsx
+++ b/openmetadata-ui-core-components/src/main/resources/ui/src/stories/Breadcrumbs.stories.tsx
@@ -1,0 +1,56 @@
+/*
+ *  Copyright 2025 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+import { HomeLine } from '@untitledui/icons';
+import type { Meta, StoryObj } from '@storybook/react';
+import {
+  Breadcrumbs,
+  type BreadcrumbItemType,
+} from '../components/application/breadcrumbs/breadcrumbs';
+
+const items: BreadcrumbItemType[] = [
+  { id: 'home', label: 'Home', href: '#', icon: HomeLine },
+  { id: 'settings', label: 'Settings', href: '#' },
+  { id: 'team', label: 'Team', href: '#' },
+  { id: 'members', label: 'Members' },
+];
+
+const meta = {
+  title: 'Components/Breadcrumbs',
+  component: Breadcrumbs,
+  parameters: {
+    layout: 'padded',
+  },
+  args: {
+    items,
+  },
+  tags: ['autodocs'],
+} satisfies Meta<typeof Breadcrumbs>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Text: Story = {
+  args: { type: 'text' },
+};
+
+export const ButtonWhite: Story = {
+  args: { type: 'button-white' },
+};
+
+export const ButtonGray: Story = {
+  args: { type: 'button-gray' },
+};
+
+export const SlashDivider: Story = {
+  args: { divider: 'slash' },
+};


### PR DESCRIPTION
### Describe your changes:

I added a **Breadcrumbs** component to `ui-core-components`, styled to match the Untitled UI breadcrumb look but written clean-room on top of `react-aria-components` (`Breadcrumbs` / `Breadcrumb` / `Link`) using our own design tokens — it is **not** derived from any Untitled UI PRO source. It is data-driven via an `items` prop and supports three visual `type`s (`text`, `button-white`, `button-gray`), two `divider`s (`chevron`, `slash`), an optional per-item leading icon, automatic current-page handling (`aria-current="page"` on the last item), and an `onAction` callback for client-side routing. It is purely additive (new files + one export line) with no new dependencies. Verified with `yarn type-check`, `yarn build`, ESLint and Prettier.

https://github.com/user-attachments/assets/32bf8a00-90b1-4e61-a864-fa333ad9b104


#
### Type of change:
- [ ] New feature

#
### High-level design:

Built on the accessible `react-aria-components` breadcrumb primitives (the same foundation the rest of the fork uses), so keyboard/focus/ARIA semantics come for free. Styling is driven by a `sortCx` variant map referencing our semantic tokens (`text-quaternary`, `bg-secondary`, `ring-primary`, etc.), keeping it consistent with Button/Tree and dark-mode aware.

#
### Tests:

#### Use cases covered
- Text, button-white and button-gray breadcrumb styles render with chevron or slash dividers.
- The last item renders as the non-interactive current page; earlier items are links (or fire `onAction`).
- An optional leading icon (e.g. home) renders on a crumb.

#### Unit tests
- [ ] Not applicable — presentational component on react-aria primitives; covered by build/type-check and Storybook stories.

#### Backend integration tests
- [x] Not applicable (no backend changes).

#### Ingestion integration tests
- [x] Not applicable (no ingestion changes).

#### Playwright (UI) tests
- [x] Not applicable — library component not yet wired into a screen.

#### Manual testing performed
1. `yarn type-check` — passed.
2. `yarn build` (ES + CJS + d.ts) — passed; `Breadcrumbs` exported from the package entry.
3. ESLint `--fix` and Prettier `--check` on changed files — clean.
4. Reviewable via `yarn storybook` → Components/Breadcrumbs (Text / ButtonWhite / ButtonGray / SlashDivider).

#
### UI screen recording / screenshots:

Storybook stories included (Text / ButtonWhite / ButtonGray / SlashDivider). No existing screen changed.

#
### Checklist:
- [x] I have read the **CONTRIBUTING** document.
- [x] I have commented on my code, particularly in hard-to-understand areas.
