### PR TITLE
fix(jdbi3): chunk IN-list batch queries to stay under DB parameter limit (#28752)

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/CollectionDAO.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/CollectionDAO.java
@@ -1457,12 +1457,18 @@ public interface CollectionDAO {
             + "WHERE id IN (<ids>) AND extension LIKE :extension "
             + "ORDER BY id, extension")
     @RegisterRowMapper(ExtensionRecordWithIdMapper.class)
-    List<ExtensionRecordWithId> getExtensionsBatch(
+    List<ExtensionRecordWithId> getExtensionsBatchInternal(
         @BindList("ids") List<String> ids,
         @BindConcat(
                 value = "extension",
                 parts = {":extensionPrefix", ".%"})
             String extensionPrefix);
+
+    default List<ExtensionRecordWithId> getExtensionsBatch(
+        List<String> ids, String extensionPrefix) {
+      return EntityDAO.queryInChunks(
+          ids, chunk -> getExtensionsBatchInternal(chunk, extensionPrefix));
+    }
 
     @SqlQuery(
         "SELECT id, extension, json "
@@ -1470,8 +1476,12 @@ public interface CollectionDAO {
             + "WHERE id IN (<ids>) AND extension = :extension "
             + "ORDER BY id, extension")
     @RegisterRowMapper(ExtensionRecordWithIdMapper.class)
-    List<ExtensionRecordWithId> getExtensionBatch(
+    List<ExtensionRecordWithId> getExtensionBatchInternal(
         @BindList("ids") List<String> ids, @Bind("extension") String extension);
+
+    default List<ExtensionRecordWithId> getExtensionBatch(List<String> ids, String extension) {
+      return EntityDAO.queryInChunks(ids, chunk -> getExtensionBatchInternal(chunk, extension));
+    }
 
     @SqlQuery(
         "SELECT id, extension, json, jsonschema "
@@ -1598,7 +1608,11 @@ public interface CollectionDAO {
     void deleteAll(@BindUUID("id") UUID id);
 
     @SqlUpdate("DELETE FROM entity_extension WHERE id IN (<ids>)")
-    void deleteAllBatch(@BindList("ids") List<String> ids);
+    void deleteAllBatchInternal(@BindList("ids") List<String> ids);
+
+    default void deleteAllBatch(List<String> ids) {
+      EntityDAO.updateInChunks(ids, this::deleteAllBatchInternal);
+    }
   }
 
   class EntityVersionPair {
@@ -1696,6 +1710,17 @@ public interface CollectionDAO {
   }
 
   interface EntityRelationshipDAO {
+    /** Map an {@link Include} filter to the trailing {@code deleted} SQL clause. */
+    private static String deletedCondition(Include include) {
+      String condition = "";
+      if (include == null || include == Include.NON_DELETED) {
+        condition = "AND deleted = FALSE";
+      } else if (include == Include.DELETED) {
+        condition = "AND deleted = TRUE";
+      }
+      return condition;
+    }
+
     default void insert(UUID fromId, UUID toId, String fromEntity, String toEntity, int relation) {
       insert(fromId, toId, fromEntity, toEntity, relation, "", null);
     }
@@ -1728,14 +1753,16 @@ public interface CollectionDAO {
         UUID fromId, List<UUID> toIds, String fromEntity, String toEntity, int relation) {
 
       List<String> toIdsAsString = toIds.stream().map(UUID::toString).toList();
-      bulkRemoveTo(fromId, toIdsAsString, fromEntity, toEntity, relation);
+      EntityDAO.updateInChunks(
+          toIdsAsString, chunk -> bulkRemoveTo(fromId, chunk, fromEntity, toEntity, relation));
     }
 
     default void bulkRemoveFromRelationship(
         List<UUID> fromIds, UUID toId, String fromEntity, String toEntity, int relation) {
 
       List<String> fromIdsAsString = fromIds.stream().map(UUID::toString).toList();
-      bulkRemoveFrom(fromIdsAsString, toId, fromEntity, toEntity, relation);
+      EntityDAO.updateInChunks(
+          fromIdsAsString, chunk -> bulkRemoveFrom(chunk, toId, fromEntity, toEntity, relation));
     }
 
     @ConnectionAwareSqlUpdate(
@@ -1851,13 +1878,27 @@ public interface CollectionDAO {
             + "AND toEntity = :toEntity "
             + "AND relation = :relation "
             + "AND toId IN (<toIds>)")
-    void bulkUpdateFromId(
+    void bulkUpdateFromIdInternal(
         @BindUUID("oldFromId") UUID oldFromId,
         @BindUUID("newFromId") UUID newFromId,
         @BindList("toIds") List<String> toIds,
         @Bind("fromEntity") String fromEntity,
         @Bind("toEntity") String toEntity,
         @Bind("relation") int relation);
+
+    default void bulkUpdateFromId(
+        UUID oldFromId,
+        UUID newFromId,
+        List<String> toIds,
+        String fromEntity,
+        String toEntity,
+        int relation) {
+      EntityDAO.updateInChunks(
+          toIds,
+          chunk ->
+              bulkUpdateFromIdInternal(
+                  oldFromId, newFromId, chunk, fromEntity, toEntity, relation));
+    }
 
     //
     // Find to operations
@@ -1919,11 +1960,19 @@ public interface CollectionDAO {
             + "AND toEntity = :toEntityType "
             + "AND deleted = FALSE")
     @UseRowMapper(RelationshipObjectMapper.class)
-    List<EntityRelationshipObject> findToBatch(
+    List<EntityRelationshipObject> findToBatchByFromAndToEntityInternal(
         @BindList("fromIds") List<String> fromIds,
         @Bind("relation") int relation,
         @Bind("fromEntityType") String fromEntityType,
         @Bind("toEntityType") String toEntityType);
+
+    default List<EntityRelationshipObject> findToBatch(
+        List<String> fromIds, int relation, String fromEntityType, String toEntityType) {
+      return EntityDAO.queryInChunks(
+          fromIds,
+          chunk ->
+              findToBatchByFromAndToEntityInternal(chunk, relation, fromEntityType, toEntityType));
+    }
 
     @SqlQuery(
         "SELECT fromId, toId, fromEntity, toEntity, relation, json, jsonSchema "
@@ -1933,10 +1982,16 @@ public interface CollectionDAO {
             + "AND toEntity = :toEntityType "
             + "AND deleted = FALSE")
     @UseRowMapper(RelationshipObjectMapper.class)
-    List<EntityRelationshipObject> findToBatch(
+    List<EntityRelationshipObject> findToBatchByToEntityInternal(
         @BindList("fromIds") List<String> fromIds,
         @Bind("relation") int relation,
         @Bind("toEntityType") String toEntityType);
+
+    default List<EntityRelationshipObject> findToBatch(
+        List<String> fromIds, int relation, String toEntityType) {
+      return EntityDAO.queryInChunks(
+          fromIds, chunk -> findToBatchByToEntityInternal(chunk, relation, toEntityType));
+    }
 
     @SqlQuery(
         "SELECT fromId, toId, fromEntity, toEntity, relation, json, jsonSchema "
@@ -1954,13 +2009,9 @@ public interface CollectionDAO {
 
     default List<EntityRelationshipObject> findToBatch(
         List<String> fromIds, int relation, String toEntityType, Include include) {
-      String condition = "";
-      if (include == null || include == Include.NON_DELETED) {
-        condition = "AND deleted = FALSE";
-      } else if (include == Include.DELETED) {
-        condition = "AND deleted = TRUE";
-      }
-      return findToBatchWithCondition(fromIds, relation, toEntityType, condition);
+      String condition = deletedCondition(include);
+      return EntityDAO.queryInChunks(
+          fromIds, chunk -> findToBatchWithCondition(chunk, relation, toEntityType, condition));
     }
 
     @SqlQuery(
@@ -1985,13 +2036,11 @@ public interface CollectionDAO {
         String toEntityType,
         int relation,
         Include include) {
-      String condition = "";
-      if (include == null || include == Include.NON_DELETED) {
-        condition = "AND deleted = FALSE";
-      } else if (include == Include.DELETED) {
-        condition = "AND deleted = TRUE";
-      }
-      return findToBatchWithCondition(fromIds, relation, fromEntityType, toEntityType, condition);
+      String condition = deletedCondition(include);
+      return EntityDAO.queryInChunks(
+          fromIds,
+          chunk ->
+              findToBatchWithCondition(chunk, relation, fromEntityType, toEntityType, condition));
     }
 
     @SqlQuery(
@@ -2008,13 +2057,9 @@ public interface CollectionDAO {
 
     default List<EntityRelationshipObject> findToBatchAllTypes(
         List<String> fromIds, int relation, Include include) {
-      String condition = "";
-      if (include == null || include == Include.NON_DELETED) {
-        condition = "AND deleted = FALSE";
-      } else if (include == Include.DELETED) {
-        condition = "AND deleted = TRUE";
-      }
-      return findToBatchAllTypesWithCondition(fromIds, relation, condition);
+      String condition = deletedCondition(include);
+      return EntityDAO.queryInChunks(
+          fromIds, chunk -> findToBatchAllTypesWithCondition(chunk, relation, condition));
     }
 
     @SqlQuery(
@@ -2033,13 +2078,10 @@ public interface CollectionDAO {
 
     default List<EntityRelationshipObject> findToBatchWithRelations(
         List<String> fromIds, String fromEntity, List<Integer> relations, Include include) {
-      String condition = "";
-      if (include == null || include == Include.NON_DELETED) {
-        condition = "AND deleted = FALSE";
-      } else if (include == Include.DELETED) {
-        condition = "AND deleted = TRUE";
-      }
-      return findToBatchWithRelationsAndCondition(fromIds, fromEntity, relations, condition);
+      String condition = deletedCondition(include);
+      return EntityDAO.queryInChunks(
+          fromIds,
+          chunk -> findToBatchWithRelationsAndCondition(chunk, fromEntity, relations, condition));
     }
 
     default List<EntityRelationshipObject> findToBatchWithRelations(
@@ -2164,8 +2206,13 @@ public interface CollectionDAO {
             + "AND relation = :relation "
             + "AND deleted = FALSE")
     @UseRowMapper(RelationshipObjectMapper.class)
-    List<EntityRelationshipObject> findFromBatch(
+    List<EntityRelationshipObject> findFromBatchByRelationInternal(
         @BindList("toIds") List<String> toIds, @Bind("relation") int relation);
+
+    default List<EntityRelationshipObject> findFromBatch(List<String> toIds, int relation) {
+      return EntityDAO.queryInChunks(
+          toIds, chunk -> findFromBatchByRelationInternal(chunk, relation));
+    }
 
     @SqlQuery(
         "SELECT fromId, toId, fromEntity, toEntity, relation, json, jsonSchema "
@@ -2181,13 +2228,9 @@ public interface CollectionDAO {
 
     default List<EntityRelationshipObject> findFromBatch(
         List<String> toIds, int relation, Include include) {
-      String condition = "";
-      if (include == null || include == Include.NON_DELETED) {
-        condition = "AND deleted = FALSE";
-      } else if (include == Include.DELETED) {
-        condition = "AND deleted = TRUE";
-      }
-      return findFromBatchWithCondition(toIds, relation, condition);
+      String condition = deletedCondition(include);
+      return EntityDAO.queryInChunks(
+          toIds, chunk -> findFromBatchWithCondition(chunk, relation, condition));
     }
 
     @SqlQuery(
@@ -2206,13 +2249,11 @@ public interface CollectionDAO {
 
     default List<EntityRelationshipObject> findFromBatch(
         List<String> toIds, int relation, String fromEntityType, Include include) {
-      String condition = "";
-      if (include == null || include == Include.NON_DELETED) {
-        condition = "AND deleted = FALSE";
-      } else if (include == Include.DELETED) {
-        condition = "AND deleted = TRUE";
-      }
-      return findFromBatchWithEntityTypeAndCondition(toIds, relation, fromEntityType, condition);
+      String condition = deletedCondition(include);
+      return EntityDAO.queryInChunks(
+          toIds,
+          chunk ->
+              findFromBatchWithEntityTypeAndCondition(chunk, relation, fromEntityType, condition));
     }
 
     @SqlQuery(
@@ -2231,13 +2272,11 @@ public interface CollectionDAO {
 
     default List<EntityRelationshipObject> findFromBatchWithRelations(
         List<String> toIds, String toEntityType, List<Integer> relations, Include include) {
-      String condition = "";
-      if (include == null || include == Include.NON_DELETED) {
-        condition = "AND deleted = FALSE";
-      } else if (include == Include.DELETED) {
-        condition = "AND deleted = TRUE";
-      }
-      return findFromBatchWithRelationsAndCondition(toIds, toEntityType, relations, condition);
+      String condition = deletedCondition(include);
+      return EntityDAO.queryInChunks(
+          toIds,
+          chunk ->
+              findFromBatchWithRelationsAndCondition(chunk, toEntityType, relations, condition));
     }
 
     default List<EntityRelationshipObject> findFromBatchWithRelations(
@@ -2253,10 +2292,16 @@ public interface CollectionDAO {
             + "AND fromEntity = :fromEntityType  "
             + "AND deleted = FALSE")
     @UseRowMapper(RelationshipObjectMapper.class)
-    List<EntityRelationshipObject> findFromBatch(
+    List<EntityRelationshipObject> findFromBatchByFromEntityInternal(
         @BindList("toIds") List<String> toIds,
         @Bind("relation") int relation,
         @Bind("fromEntityType") String fromEntityType);
+
+    default List<EntityRelationshipObject> findFromBatch(
+        List<String> toIds, int relation, String fromEntityType) {
+      return EntityDAO.queryInChunks(
+          toIds, chunk -> findFromBatchByFromEntityInternal(chunk, relation, fromEntityType));
+    }
 
     @SqlQuery(
         "SELECT fromId, toId, fromEntity, toEntity, relation, json, jsonSchema "
@@ -2266,10 +2311,16 @@ public interface CollectionDAO {
             + "AND toEntity = :toEntityType "
             + "AND deleted = FALSE")
     @UseRowMapper(RelationshipObjectMapper.class)
-    List<EntityRelationshipObject> findFromBatch(
+    List<EntityRelationshipObject> findFromBatchByToEntityInternal(
         @BindList("toIds") List<String> toIds,
         @Bind("toEntityType") String toEntityType,
         @Bind("relation") int relation);
+
+    default List<EntityRelationshipObject> findFromBatch(
+        List<String> toIds, String toEntityType, int relation) {
+      return EntityDAO.queryInChunks(
+          toIds, chunk -> findFromBatchByToEntityInternal(chunk, toEntityType, relation));
+    }
 
     @SqlQuery(
         "SELECT fromId, fromEntity, json FROM entity_relationship "
@@ -2297,12 +2348,7 @@ public interface CollectionDAO {
 
     default List<EntityRelationshipObject> findToRelationshipsForEntity(
         UUID entityId, String entityType, List<Integer> relations, Include include) {
-      String condition = "";
-      if (include == null || include == Include.NON_DELETED) {
-        condition = "AND deleted = FALSE";
-      } else if (include == Include.DELETED) {
-        condition = "AND deleted = TRUE";
-      }
+      String condition = deletedCondition(include);
       return findToRelationshipsForEntityWithCondition(entityId, entityType, relations, condition);
     }
 
@@ -2328,12 +2374,7 @@ public interface CollectionDAO {
 
     default List<EntityRelationshipObject> findFromRelationshipsForEntity(
         UUID entityId, String entityType, List<Integer> relations, Include include) {
-      String condition = "";
-      if (include == null || include == Include.NON_DELETED) {
-        condition = "AND deleted = FALSE";
-      } else if (include == Include.DELETED) {
-        condition = "AND deleted = TRUE";
-      }
+      String condition = deletedCondition(include);
       return findFromRelationshipsForEntityWithCondition(
           entityId, entityType, relations, condition);
     }
@@ -2352,11 +2393,20 @@ public interface CollectionDAO {
             + "AND toEntity = :toEntityType "
             + "AND deleted = FALSE")
     @UseRowMapper(RelationshipObjectMapper.class)
-    List<EntityRelationshipObject> findFromBatch(
+    List<EntityRelationshipObject> findFromBatchByFromAndToEntityInternal(
         @BindList("toIds") List<String> toIds,
         @Bind("relation") int relation,
         @Bind("fromEntityType") String fromEntityType,
         @Bind("toEntityType") String toEntityType);
+
+    default List<EntityRelationshipObject> findFromBatch(
+        List<String> toIds, int relation, String fromEntityType, String toEntityType) {
+      return EntityDAO.queryInChunks(
+          toIds,
+          chunk ->
+              findFromBatchByFromAndToEntityInternal(
+                  chunk, relation, fromEntityType, toEntityType));
+    }
 
     @ConnectionAwareSqlQuery(
         value =
@@ -5200,8 +5250,12 @@ public interface CollectionDAO {
             + "WHERE targetFQNHash IN (<targetFQNHashes>) "
             + "ORDER BY targetFQNHash, tagFQN")
     @UseRowMapper(TagLabelWithFQNHashMapper.class)
-    List<TagLabelWithFQNHash> getTagsInternalBatch(
+    List<TagLabelWithFQNHash> getTagsInternalBatchInternal(
         @BindListFQN("targetFQNHashes") List<String> targetFQNHashes);
+
+    default List<TagLabelWithFQNHash> getTagsInternalBatch(List<String> targetFQNHashes) {
+      return EntityDAO.queryInChunks(targetFQNHashes, this::getTagsInternalBatchInternal);
+    }
 
     @SqlQuery(
         "SELECT targetFQNHash, source, tagFQN, labelType, state, reason, appliedAt, appliedBy, metadata "
@@ -5211,10 +5265,17 @@ public interface CollectionDAO {
             + "AND tagFQNHash LIKE :tagFQNHashPrefix "
             + "ORDER BY targetFQNHash, tagFQN")
     @UseRowMapper(TagLabelWithFQNHashMapper.class)
-    List<TagLabelWithFQNHash> getCertTagsInternalBatch(
+    List<TagLabelWithFQNHash> getCertTagsInternalBatchInternal(
         @Bind("source") int source,
         @BindListFQN("targetFQNHashes") List<String> targetFQNHashes,
         @Bind("tagFQNHashPrefix") String tagFQNHashPrefix);
+
+    default List<TagLabelWithFQNHash> getCertTagsInternalBatch(
+        int source, List<String> targetFQNHashes, String tagFQNHashPrefix) {
+      return EntityDAO.queryInChunks(
+          targetFQNHashes,
+          chunk -> getCertTagsInternalBatchInternal(source, chunk, tagFQNHashPrefix));
+    }
 
     /**
      * Batch fetch derived tags for multiple glossary term FQNs. Returns a map from glossary term
@@ -5392,7 +5453,11 @@ public interface CollectionDAO {
         @BindFQN("targetFQNHash") String targetFQNHash);
 
     @SqlUpdate("DELETE FROM tag_usage WHERE targetFQNHash IN (<targetFQNHashes>)")
-    void deleteTagsByTargets(@BindListFQN("targetFQNHashes") List<String> targetFQNs);
+    void deleteTagsByTargetsInternal(@BindListFQN("targetFQNHashes") List<String> targetFQNs);
+
+    default void deleteTagsByTargets(List<String> targetFQNs) {
+      EntityDAO.updateInChunks(targetFQNs, this::deleteTagsByTargetsInternal);
+    }
 
     @SqlUpdate(
         "DELETE FROM tag_usage WHERE source = :source AND tagFQN LIKE :tagFQNPrefix AND targetFQNHash IN (<targetFQNHashes>)")
@@ -6389,7 +6454,11 @@ public interface CollectionDAO {
             + "u1.percentile1, u1.percentile7, u1.percentile30 FROM entity_usage u1 "
             + "INNER JOIN (SELECT id, MAX(usageDate) as maxDate FROM entity_usage WHERE id IN (<ids>) GROUP BY id) u2 "
             + "ON u1.id = u2.id AND u1.usageDate = u2.maxDate")
-    List<UsageDetailsWithId> getLatestUsageBatch(@BindList("ids") List<String> ids);
+    List<UsageDetailsWithId> getLatestUsageBatchInternal(@BindList("ids") List<String> ids);
+
+    default List<UsageDetailsWithId> getLatestUsageBatch(List<String> ids) {
+      return EntityDAO.queryInChunks(ids, this::getLatestUsageBatchInternal);
+    }
 
     @SqlUpdate("DELETE FROM entity_usage WHERE id = :id")
     void delete(@BindUUID("id") UUID id);
@@ -8408,8 +8477,12 @@ public interface CollectionDAO {
             + "FROM data_quality_data_time_series WHERE entityFQNHash IN (<entityFQNHashes>) "
             + "GROUP BY entityFQNHash) t2 "
             + "ON t1.entityFQNHash = t2.entityFQNHash AND t1.timestamp = t2.maxTs")
-    List<LatestRecordWithFQNHash> getLatestRecordBatch(
+    List<LatestRecordWithFQNHash> getLatestRecordBatchInternal(
         @BindListFQN("entityFQNHashes") List<String> entityFQNs);
+
+    default List<LatestRecordWithFQNHash> getLatestRecordBatch(List<String> entityFQNs) {
+      return EntityDAO.queryInChunks(entityFQNs, this::getLatestRecordBatchInternal);
+    }
 
     @SqlUpdate(
         "DELETE FROM data_quality_data_time_series WHERE entityFQNHash = :testCaseFQNHash AND extension = 'testCase.testCaseResult'")
@@ -8777,8 +8850,12 @@ public interface CollectionDAO {
             """,
         connectionType = POSTGRES)
     @UseRowMapper(ResultSummaryRowMapper.class)
-    List<ResultSummaryRow> listResultSummariesForTestSuites(
+    List<ResultSummaryRow> listResultSummariesForTestSuitesInternal(
         @BindList("testSuiteIds") List<String> testSuiteIds);
+
+    default List<ResultSummaryRow> listResultSummariesForTestSuites(List<String> testSuiteIds) {
+      return EntityDAO.queryInChunks(testSuiteIds, this::listResultSummariesForTestSuitesInternal);
+    }
 
     record SuiteMaxTimestamp(String testSuiteId, long maxTimestamp) {}
 

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/EntityDAO.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/EntityDAO.java
@@ -25,6 +25,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import java.util.function.Consumer;
+import java.util.function.Function;
 import lombok.SneakyThrows;
 import org.apache.commons.collections4.CollectionUtils;
 import org.jdbi.v3.core.mapper.RowMapper;
@@ -55,6 +57,63 @@ import org.openmetadata.service.workflows.searchIndex.ReindexingUtil;
 
 public interface EntityDAO<T extends EntityInterface> {
   org.slf4j.Logger LOG = org.slf4j.LoggerFactory.getLogger(EntityDAO.class);
+
+  /**
+   * Maximum number of values expanded into a single SQL IN-list. JDBI's {@code @BindList}
+   * produces one bind parameter per element. OpenMetadata supports MySQL and PostgreSQL —
+   * PostgreSQL's protocol caps each statement at 65535 bind parameters
+   * (the {@code int2}-size {@code numParams} field), and MySQL's {@code max_allowed_packet}
+   * caps total statement size. 30k UUID/hash strings stays comfortably under both: each
+   * UUID is ~36 chars, so an IN-list of this size is ~1MB on the wire (well below the 64MB
+   * MySQL default) and still leaves headroom for Postgres's parameter ceiling. Callers that
+   * may exceed this size must chunk their input lists; helpers in this interface
+   * ({@link #findEntitiesByIds}, {@link #findEntityByNames}, {@link #findReferencesByFqns},
+   * {@link #deleteByIds}) already do. (SQL Server isn't a supported connection type here —
+   * its ~2100 sp_executesql cap would require a separate, much smaller constant if it ever
+   * is.)
+   */
+  int MAX_IN_LIST_CHUNK_SIZE = 30_000;
+
+  /**
+   * Run a SQL IN-list query in {@link #MAX_IN_LIST_CHUNK_SIZE}-sized chunks and concatenate the
+   * results, keeping each statement under the database parameter ceiling. For inputs at or below
+   * the chunk size the list is passed straight through, preserving the single-query behavior (and
+   * the caller's empty-list handling) exactly. When chunking is required the ids are de-duplicated
+   * first (encounter order preserved) so a value split across two chunks is not queried twice and
+   * cannot duplicate result rows — matching the semantics of a single {@code IN (...)}, which
+   * ignores duplicate values.
+   */
+  static <I, R> List<R> queryInChunks(List<I> ids, Function<List<I>, List<R>> query) {
+    List<R> result;
+    if (ids != null && ids.size() > MAX_IN_LIST_CHUNK_SIZE) {
+      List<I> distinctIds = ids.stream().distinct().toList();
+      result = new ArrayList<>(distinctIds.size());
+      for (int i = 0; i < distinctIds.size(); i += MAX_IN_LIST_CHUNK_SIZE) {
+        int end = Math.min(i + MAX_IN_LIST_CHUNK_SIZE, distinctIds.size());
+        result.addAll(query.apply(distinctIds.subList(i, end)));
+      }
+    } else {
+      result = query.apply(ids);
+    }
+    return result;
+  }
+
+  /**
+   * Void counterpart of {@link #queryInChunks} for chunked IN-list updates/deletes. De-duplicates
+   * before chunking for the same reason: a value split across chunks would otherwise issue a
+   * redundant statement, whereas a single {@code WHERE id IN (...)} affects each row once.
+   */
+  static <I> void updateInChunks(List<I> ids, Consumer<List<I>> update) {
+    if (ids != null && ids.size() > MAX_IN_LIST_CHUNK_SIZE) {
+      List<I> distinctIds = ids.stream().distinct().toList();
+      for (int i = 0; i < distinctIds.size(); i += MAX_IN_LIST_CHUNK_SIZE) {
+        int end = Math.min(i + MAX_IN_LIST_CHUNK_SIZE, distinctIds.size());
+        update.accept(distinctIds.subList(i, end));
+      }
+    } else {
+      update.accept(ids);
+    }
+  }
 
   /** Methods that need to be overridden by interfaces extending this */
   String getTableName();

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/EntityTimeSeriesDAO.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/EntityTimeSeriesDAO.java
@@ -502,7 +502,9 @@ public interface EntityTimeSeriesDAO {
       return Map.of();
     }
     List<FQNHashJsonRow> rows =
-        getLatestExtensionBatch(getTimeSeriesTableName(), entityFQNHashes, extension);
+        EntityDAO.queryInChunks(
+            entityFQNHashes,
+            chunk -> getLatestExtensionBatch(getTimeSeriesTableName(), chunk, extension));
     Map<String, String> result = new HashMap<>();
     for (FQNHashJsonRow row : rows) {
       result.put(row.entityFQNHash(), row.json());

--- a/openmetadata-service/src/test/java/org/openmetadata/service/jdbi3/InListChunkingTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/jdbi3/InListChunkingTest.java
@@ -1,0 +1,414 @@
+/*
+ *  Copyright 2024 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.openmetadata.service.jdbi3;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.CALLS_REAL_METHODS;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import org.junit.jupiter.api.Test;
+import org.openmetadata.schema.type.Include;
+import org.openmetadata.service.jdbi3.CollectionDAO.DataQualityDataTimeSeriesDAO;
+import org.openmetadata.service.jdbi3.CollectionDAO.EntityExtensionDAO;
+import org.openmetadata.service.jdbi3.CollectionDAO.EntityRelationshipDAO;
+import org.openmetadata.service.jdbi3.CollectionDAO.EntityRelationshipObject;
+import org.openmetadata.service.jdbi3.CollectionDAO.TagUsageDAO;
+import org.openmetadata.service.jdbi3.CollectionDAO.TestCaseResultTimeSeriesDAO;
+import org.openmetadata.service.jdbi3.CollectionDAO.UsageDAO;
+
+/**
+ * Outcome tests for the IN-list chunking that keeps bulk delete / restore queries under the
+ * database prepared-statement parameter ceiling (PostgreSQL hard-caps at 65,535 bound params).
+ *
+ * <p>These do not verify how many times the delegate is called — they assert the observable
+ * contract of the partition: every chunk stays within {@link EntityDAO#MAX_IN_LIST_CHUNK_SIZE},
+ * the union of chunks equals the input exactly once each (no dropped or duplicated ids), and the
+ * aggregated result equals the concatenation of the per-chunk results.
+ */
+class InListChunkingTest {
+
+  private static final int OVER_LIMIT = EntityDAO.MAX_IN_LIST_CHUNK_SIZE * 2 + 2;
+
+  private static List<String> ids(int count) {
+    return IntStream.range(0, count)
+        .mapToObj(i -> new UUID(0L, i).toString())
+        .collect(Collectors.toList());
+  }
+
+  private static List<UUID> uuids(int count) {
+    return IntStream.range(0, count).mapToObj(i -> new UUID(0L, i)).collect(Collectors.toList());
+  }
+
+  private static void assertChunksWithinLimit(List<List<String>> chunks) {
+    assertTrue(
+        chunks.stream().allMatch(chunk -> chunk.size() <= EntityDAO.MAX_IN_LIST_CHUNK_SIZE),
+        "every chunk must stay within MAX_IN_LIST_CHUNK_SIZE");
+  }
+
+  private static void assertCoversInputExactlyOnce(List<String> input, List<List<String>> chunks) {
+    List<String> flattened = chunks.stream().flatMap(List::stream).collect(Collectors.toList());
+    assertEquals(input, flattened, "union of chunks must equal the input exactly once, in order");
+  }
+
+  @Test
+  void findToBatchAllTypes_chunksOverLimitAndAggregates() {
+    EntityRelationshipDAO dao = mock(EntityRelationshipDAO.class, CALLS_REAL_METHODS);
+    List<List<String>> chunks = new ArrayList<>();
+    when(dao.findToBatchAllTypesWithCondition(anyList(), anyInt(), anyString()))
+        .thenAnswer(
+            invocation -> {
+              List<String> chunk = invocation.getArgument(0);
+              chunks.add(List.copyOf(chunk));
+              return chunk.stream()
+                  .map(id -> EntityRelationshipObject.builder().fromId(id).build())
+                  .collect(Collectors.toList());
+            });
+
+    List<String> input = ids(OVER_LIMIT);
+    List<EntityRelationshipObject> result = dao.findToBatchAllTypes(input, 1, Include.ALL);
+
+    assertChunksWithinLimit(chunks);
+    assertCoversInputExactlyOnce(input, chunks);
+    assertEquals(
+        input,
+        result.stream().map(EntityRelationshipObject::getFromId).collect(Collectors.toList()),
+        "aggregated result must equal the concatenation of per-chunk results");
+  }
+
+  @Test
+  void findFromBatch_chunksOverLimitAndAggregates() {
+    EntityRelationshipDAO dao = mock(EntityRelationshipDAO.class, CALLS_REAL_METHODS);
+    List<List<String>> chunks = new ArrayList<>();
+    when(dao.findFromBatchWithCondition(anyList(), anyInt(), anyString()))
+        .thenAnswer(
+            invocation -> {
+              List<String> chunk = invocation.getArgument(0);
+              chunks.add(List.copyOf(chunk));
+              return chunk.stream()
+                  .map(id -> EntityRelationshipObject.builder().toId(id).build())
+                  .collect(Collectors.toList());
+            });
+
+    List<String> input = ids(OVER_LIMIT);
+    List<EntityRelationshipObject> result = dao.findFromBatch(input, 1, Include.ALL);
+
+    assertChunksWithinLimit(chunks);
+    assertCoversInputExactlyOnce(input, chunks);
+    assertEquals(
+        input, result.stream().map(EntityRelationshipObject::getToId).collect(Collectors.toList()));
+  }
+
+  @Test
+  void deleteAllBatch_chunksOverLimit() {
+    EntityExtensionDAO dao = mock(EntityExtensionDAO.class, CALLS_REAL_METHODS);
+    List<List<String>> chunks = new ArrayList<>();
+    doAnswer(
+            invocation -> {
+              chunks.add(List.copyOf(invocation.getArgument(0)));
+              return null;
+            })
+        .when(dao)
+        .deleteAllBatchInternal(anyList());
+
+    List<String> input = ids(OVER_LIMIT);
+    dao.deleteAllBatch(input);
+
+    assertChunksWithinLimit(chunks);
+    assertCoversInputExactlyOnce(input, chunks);
+  }
+
+  @Test
+  void getTagsInternalBatch_chunksOverLimit() {
+    TagUsageDAO dao = mock(TagUsageDAO.class, CALLS_REAL_METHODS);
+    List<List<String>> chunks = new ArrayList<>();
+    when(dao.getTagsInternalBatchInternal(anyList()))
+        .thenAnswer(
+            invocation -> {
+              chunks.add(List.copyOf(invocation.getArgument(0)));
+              return new ArrayList<>();
+            });
+
+    List<String> input = ids(OVER_LIMIT);
+    dao.getTagsInternalBatch(input);
+
+    assertChunksWithinLimit(chunks);
+    assertCoversInputExactlyOnce(input, chunks);
+  }
+
+  @Test
+  void queryInChunks_deduplicatesIdsSplitAcrossChunks() {
+    EntityRelationshipDAO dao = mock(EntityRelationshipDAO.class, CALLS_REAL_METHODS);
+    List<List<String>> chunks = new ArrayList<>();
+    when(dao.findToBatchAllTypesWithCondition(anyList(), anyInt(), anyString()))
+        .thenAnswer(
+            invocation -> {
+              List<String> chunk = invocation.getArgument(0);
+              chunks.add(List.copyOf(chunk));
+              return chunk.stream()
+                  .map(id -> EntityRelationshipObject.builder().fromId(id).build())
+                  .collect(Collectors.toList());
+            });
+
+    List<String> distinct = ids(OVER_LIMIT);
+    List<String> withDuplicates = new ArrayList<>(distinct);
+    withDuplicates.addAll(distinct.subList(0, 10));
+
+    List<EntityRelationshipObject> result = dao.findToBatchAllTypes(withDuplicates, 1, Include.ALL);
+
+    assertChunksWithinLimit(chunks);
+    assertCoversInputExactlyOnce(distinct, chunks);
+    assertEquals(
+        distinct,
+        result.stream().map(EntityRelationshipObject::getFromId).collect(Collectors.toList()),
+        "duplicate ids split across chunks must not produce duplicate result rows");
+  }
+
+  @Test
+  void updateInChunks_deduplicatesIdsSplitAcrossChunks() {
+    EntityExtensionDAO dao = mock(EntityExtensionDAO.class, CALLS_REAL_METHODS);
+    List<List<String>> chunks = new ArrayList<>();
+    doAnswer(
+            invocation -> {
+              chunks.add(List.copyOf(invocation.getArgument(0)));
+              return null;
+            })
+        .when(dao)
+        .deleteAllBatchInternal(anyList());
+
+    List<String> distinct = ids(OVER_LIMIT);
+    List<String> withDuplicates = new ArrayList<>(distinct);
+    withDuplicates.addAll(distinct.subList(0, 10));
+
+    dao.deleteAllBatch(withDuplicates);
+
+    assertChunksWithinLimit(chunks);
+    assertCoversInputExactlyOnce(distinct, chunks);
+  }
+
+  @Test
+  void queryInChunks_atOrBelowLimitPassesDuplicatesThroughVerbatim() {
+    EntityRelationshipDAO dao = mock(EntityRelationshipDAO.class, CALLS_REAL_METHODS);
+    List<List<String>> chunks = new ArrayList<>();
+    when(dao.findToBatchAllTypesWithCondition(anyList(), anyInt(), anyString()))
+        .thenAnswer(
+            invocation -> {
+              List<String> chunk = invocation.getArgument(0);
+              chunks.add(List.copyOf(chunk));
+              return chunk.stream()
+                  .map(id -> EntityRelationshipObject.builder().fromId(id).build())
+                  .collect(Collectors.toList());
+            });
+
+    List<String> withDuplicates = new ArrayList<>(ids(5));
+    withDuplicates.addAll(ids(5).subList(0, 2));
+
+    List<EntityRelationshipObject> result = dao.findToBatchAllTypes(withDuplicates, 1, Include.ALL);
+
+    assertEquals(1, chunks.size(), "a list within the limit must issue exactly one query");
+    assertCoversInputExactlyOnce(withDuplicates, chunks);
+    assertEquals(
+        withDuplicates,
+        result.stream().map(EntityRelationshipObject::getFromId).collect(Collectors.toList()),
+        "within the limit the list is passed through verbatim — duplicates are NOT stripped here; "
+            + "collapsing them is the database's job via IN(...) set semantics");
+  }
+
+  @Test
+  void updateInChunks_atOrBelowLimitPassesDuplicatesThroughVerbatim() {
+    EntityExtensionDAO dao = mock(EntityExtensionDAO.class, CALLS_REAL_METHODS);
+    List<List<String>> chunks = new ArrayList<>();
+    doAnswer(
+            invocation -> {
+              chunks.add(List.copyOf(invocation.getArgument(0)));
+              return null;
+            })
+        .when(dao)
+        .deleteAllBatchInternal(anyList());
+
+    List<String> withDuplicates = new ArrayList<>(ids(5));
+    withDuplicates.addAll(ids(5).subList(0, 2));
+
+    dao.deleteAllBatch(withDuplicates);
+
+    assertEquals(1, chunks.size(), "a list within the limit must issue exactly one statement");
+    assertCoversInputExactlyOnce(withDuplicates, chunks);
+  }
+
+  @Test
+  void bulkUpdateFromId_chunksOverLimit() {
+    EntityRelationshipDAO dao = mock(EntityRelationshipDAO.class, CALLS_REAL_METHODS);
+    List<List<String>> chunks = new ArrayList<>();
+    doAnswer(
+            invocation -> {
+              chunks.add(List.copyOf(invocation.getArgument(2)));
+              return null;
+            })
+        .when(dao)
+        .bulkUpdateFromIdInternal(any(), any(), anyList(), anyString(), anyString(), anyInt());
+
+    List<String> input = ids(OVER_LIMIT);
+    dao.bulkUpdateFromId(new UUID(0L, 1L), new UUID(0L, 2L), input, "glossary", "glossaryTerm", 10);
+
+    assertChunksWithinLimit(chunks);
+    assertCoversInputExactlyOnce(input, chunks);
+  }
+
+  @Test
+  void deleteTagsByTargets_chunksOverLimit() {
+    TagUsageDAO dao = mock(TagUsageDAO.class, CALLS_REAL_METHODS);
+    List<List<String>> chunks = new ArrayList<>();
+    doAnswer(
+            invocation -> {
+              chunks.add(List.copyOf(invocation.getArgument(0)));
+              return null;
+            })
+        .when(dao)
+        .deleteTagsByTargetsInternal(anyList());
+
+    List<String> input = ids(OVER_LIMIT);
+    dao.deleteTagsByTargets(input);
+
+    assertChunksWithinLimit(chunks);
+    assertCoversInputExactlyOnce(input, chunks);
+  }
+
+  @Test
+  void getLatestExtensionBatch_chunksOverLimitAndAggregates() {
+    EntityTimeSeriesDAO dao = mock(EntityTimeSeriesDAO.class, CALLS_REAL_METHODS);
+    List<List<String>> chunks = new ArrayList<>();
+    when(dao.getLatestExtensionBatch(any(), anyList(), anyString()))
+        .thenAnswer(
+            invocation -> {
+              List<String> chunk = invocation.getArgument(1);
+              chunks.add(List.copyOf(chunk));
+              return chunk.stream()
+                  .map(h -> new EntityTimeSeriesDAO.FQNHashJsonRow(h, "{}"))
+                  .collect(Collectors.toList());
+            });
+
+    List<String> input = ids(OVER_LIMIT);
+    Map<String, String> result = dao.getLatestExtensionBatch(input, "someExtension");
+
+    assertChunksWithinLimit(chunks);
+    assertCoversInputExactlyOnce(input, chunks);
+    assertEquals(
+        input.size(), result.size(), "every distinct hash must appear in the aggregated map");
+  }
+
+  @Test
+  void bulkRemoveToRelationship_chunksOverLimit() {
+    EntityRelationshipDAO dao = mock(EntityRelationshipDAO.class, CALLS_REAL_METHODS);
+    List<List<String>> chunks = new ArrayList<>();
+    doAnswer(
+            invocation -> {
+              chunks.add(List.copyOf(invocation.getArgument(1)));
+              return null;
+            })
+        .when(dao)
+        .bulkRemoveTo(any(), anyList(), anyString(), anyString(), anyInt());
+
+    List<UUID> input = uuids(OVER_LIMIT);
+    dao.bulkRemoveToRelationship(new UUID(1L, 0L), input, "glossary", "glossaryTerm", 10);
+
+    assertChunksWithinLimit(chunks);
+    assertCoversInputExactlyOnce(
+        input.stream().map(UUID::toString).collect(Collectors.toList()), chunks);
+  }
+
+  @Test
+  void bulkRemoveFromRelationship_chunksOverLimit() {
+    EntityRelationshipDAO dao = mock(EntityRelationshipDAO.class, CALLS_REAL_METHODS);
+    List<List<String>> chunks = new ArrayList<>();
+    doAnswer(
+            invocation -> {
+              chunks.add(List.copyOf(invocation.getArgument(0)));
+              return null;
+            })
+        .when(dao)
+        .bulkRemoveFrom(anyList(), any(), anyString(), anyString(), anyInt());
+
+    List<UUID> input = uuids(OVER_LIMIT);
+    dao.bulkRemoveFromRelationship(input, new UUID(1L, 0L), "glossary", "glossaryTerm", 10);
+
+    assertChunksWithinLimit(chunks);
+    assertCoversInputExactlyOnce(
+        input.stream().map(UUID::toString).collect(Collectors.toList()), chunks);
+  }
+
+  @Test
+  void getLatestUsageBatch_chunksOverLimit() {
+    UsageDAO dao = mock(UsageDAO.class, CALLS_REAL_METHODS);
+    List<List<String>> chunks = new ArrayList<>();
+    when(dao.getLatestUsageBatchInternal(anyList()))
+        .thenAnswer(
+            invocation -> {
+              chunks.add(List.copyOf(invocation.getArgument(0)));
+              return new ArrayList<>();
+            });
+
+    List<String> input = ids(OVER_LIMIT);
+    dao.getLatestUsageBatch(input);
+
+    assertChunksWithinLimit(chunks);
+    assertCoversInputExactlyOnce(input, chunks);
+  }
+
+  @Test
+  void getLatestRecordBatch_chunksOverLimit() {
+    DataQualityDataTimeSeriesDAO dao = mock(DataQualityDataTimeSeriesDAO.class, CALLS_REAL_METHODS);
+    List<List<String>> chunks = new ArrayList<>();
+    when(dao.getLatestRecordBatchInternal(anyList()))
+        .thenAnswer(
+            invocation -> {
+              chunks.add(List.copyOf(invocation.getArgument(0)));
+              return new ArrayList<>();
+            });
+
+    List<String> input = ids(OVER_LIMIT);
+    dao.getLatestRecordBatch(input);
+
+    assertChunksWithinLimit(chunks);
+    assertCoversInputExactlyOnce(input, chunks);
+  }
+
+  @Test
+  void listResultSummariesForTestSuites_chunksOverLimit() {
+    TestCaseResultTimeSeriesDAO dao = mock(TestCaseResultTimeSeriesDAO.class, CALLS_REAL_METHODS);
+    List<List<String>> chunks = new ArrayList<>();
+    when(dao.listResultSummariesForTestSuitesInternal(anyList()))
+        .thenAnswer(
+            invocation -> {
+              chunks.add(List.copyOf(invocation.getArgument(0)));
+              return new ArrayList<>();
+            });
+
+    List<String> input = ids(OVER_LIMIT);
+    dao.listResultSummariesForTestSuites(input);
+
+    assertChunksWithinLimit(chunks);
+    assertCoversInputExactlyOnce(input, chunks);
+  }
+}


### PR DESCRIPTION
Cherry-pick of #28752 onto the `1.13` branch.

## What
Bulk subtree delete/restore fans an entire tree level's ids into a single `IN (...)` query. JDBI `@BindList` emits one bind parameter per element, so a level with ~100k entities (e.g. a service with 100k tables) exceeds PostgreSQL's 65,535 parameter ceiling and the operation fails. Adds `EntityDAO.queryInChunks` / `updateInChunks` helpers (chunk at `MAX_IN_LIST_CHUNK_SIZE = 30_000`, pass small lists straight through, dedup before chunking) and routes every `@BindList` batch method through them.

## 1.13 backport adaptation
- Omitted the `findToBatchAllTypes(List<Integer> relations, Include)` chunking hunk and its `findToBatchAllTypesWithRelationsCondition` delegate — that overload originates in temporal lineage (#28426), which is **not** on `1.13`. It has no callers on this branch.
- Retargeted the two `queryInChunks` dedup / pass-through tests that exercised that overload to the existing `int`-relation `findToBatchAllTypes` overload (same `queryInChunks` code path), preserving coverage.

## Verification
- `openmetadata-service` compiles (main + test) under Java 21.
- `InListChunkingTest` — **16/16 pass** (0 failures, 0 errors).
- `mvn spotless:apply` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
