### PR TITLE
Fixes #28770: write server audit entries to audit.log (#28771) [1.12.11]

### DIFF
--- a/conf/openmetadata.yaml
+++ b/conf/openmetadata.yaml
@@ -179,11 +179,17 @@ logging:
           archivedFileCount: 7
           timeZone: UTC
           maxFileSize: 50MB
+    org.openmetadata.service.audit.AuditLogRepository:
+      # Audit entries are logged at INFO with the AUDIT marker (see AuditLogger) and routed to
+      # logs/audit.log. Pin the level so audit capture does not depend on the global LOG_LEVEL.
+      level: INFO
   appenders:
     - type: console
       threshold: TRACE
       logFormat: "%level [%d{ISO8601,UTC}] [%t] %logger{5} - %msg%n"
       timeZone: UTC
+      filterFactories:
+        - type: audit-exclude-filter-factory
     - type: file
       layout:
         type: json

--- a/openmetadata-service/src/main/java/org/openmetadata/service/audit/AuditLogRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/audit/AuditLogRepository.java
@@ -17,6 +17,7 @@ import org.openmetadata.schema.type.Include;
 import org.openmetadata.schema.utils.JsonUtils;
 import org.openmetadata.schema.utils.ResultList;
 import org.openmetadata.service.Entity;
+import org.openmetadata.service.events.AuditLogger;
 import org.openmetadata.service.jdbi3.CollectionDAO;
 import org.openmetadata.service.util.AsyncService;
 import org.openmetadata.service.util.FullyQualifiedName;
@@ -40,6 +41,8 @@ public class AuditLogRepository {
 
   private static final Set<String> AGENT_INDICATORS =
       Set.of("agent", "documentation", "classification", "automator");
+
+  private static final AuditLogger AUDIT_LOGGER = AuditLogger.getLogger(AuditLogRepository.class);
 
   private final CollectionDAO.AuditLogDAO auditLogDAO;
 
@@ -107,11 +110,27 @@ public class AuditLogRepository {
           record.getActorType(),
           record.getEntityType(),
           record.getEntityId());
-      auditLogDAO.insert(record);
+      int inserted = auditLogDAO.insert(record);
+      if (inserted > 0) {
+        logAuditTrail(record);
+      }
       LOG.debug("Successfully inserted audit log for change event {}", changeEvent.getId());
     } catch (Exception ex) {
       LOG.warn("Failed to persist audit log for change event {}", changeEvent.getId(), ex);
     }
+  }
+
+  private void logAuditTrail(AuditLogRecord record) {
+    AUDIT_LOGGER.log(
+        "eventType={} user={} actorType={} entityType={} entityFQN={} entityId={} service={} ts={}",
+        record.getEventType(),
+        record.getUserName(),
+        record.getActorType(),
+        record.getEntityType(),
+        record.getEntityFQN(),
+        record.getEntityId(),
+        record.getServiceName(),
+        record.getEventTs());
   }
 
   public static final EventType AUTH_EVENT_LOGIN = EventType.USER_LOGIN;

--- a/openmetadata-service/src/main/java/org/openmetadata/service/events/AuditLogger.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/events/AuditLogger.java
@@ -21,10 +21,10 @@ public final class AuditLogger {
   }
 
   public void log(final String message) {
-    logger.error(AUDIT_MARKER, message);
+    logger.info(AUDIT_MARKER, message);
   }
 
   public void log(final String format, final Object... arguments) {
-    logger.error(AUDIT_MARKER, format, arguments);
+    logger.info(AUDIT_MARKER, format, arguments);
   }
 }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/CollectionDAO.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/CollectionDAO.java
@@ -11035,7 +11035,7 @@ public interface CollectionDAO {
                 + ":actorType, :impersonatedBy, :serviceName, "
                 + ":entityType, :entityId, :entityFQN, :entityFQNHash, :eventJson, :createdAt)",
         connectionType = MYSQL)
-    void insert(@BindBean AuditLogRecord record);
+    int insert(@BindBean AuditLogRecord record);
 
     @SqlQuery(
         "SELECT id, change_event_id, event_ts, event_type, user_name, "

--- a/openmetadata-service/src/test/java/org/openmetadata/service/audit/AuditLogRepositoryTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/audit/AuditLogRepositoryTest.java
@@ -1,0 +1,111 @@
+/*
+ *  Copyright 2021 Collate
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.openmetadata.service.audit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.openmetadata.schema.type.ChangeEvent;
+import org.openmetadata.schema.type.EventType;
+import org.openmetadata.service.Entity;
+import org.openmetadata.service.jdbi3.CollectionDAO;
+import org.slf4j.LoggerFactory;
+import org.slf4j.Marker;
+
+/**
+ * Verifies that {@link AuditLogRepository#write(ChangeEvent)} re-emits each persisted audit entry
+ * through the AUDIT-marked logger so the dedicated {@code audit.log} appender is fed, that the file
+ * emission is gated on an actual DB insert (so the publisher + consumer dual-write path and
+ * multi-server replays do not produce duplicate lines).
+ */
+class AuditLogRepositoryTest {
+
+  private static final String AUDIT_MARKER_NAME = "AUDIT";
+  private static final String BOT_USER = "ingestion-bot";
+
+  private CollectionDAO.AuditLogDAO auditLogDAO;
+  private AuditLogRepository repository;
+  private Logger auditLogger;
+  private ListAppender<ILoggingEvent> appender;
+
+  @BeforeEach
+  void setUp() {
+    CollectionDAO collectionDAO = mock(CollectionDAO.class);
+    auditLogDAO = mock(CollectionDAO.AuditLogDAO.class);
+    when(collectionDAO.auditLogDAO()).thenReturn(auditLogDAO);
+    repository = new AuditLogRepository(collectionDAO);
+
+    auditLogger = (Logger) LoggerFactory.getLogger(AuditLogRepository.class);
+    appender = new ListAppender<>();
+    appender.start();
+    auditLogger.addAppender(appender);
+  }
+
+  @AfterEach
+  void tearDown() {
+    auditLogger.detachAppender(appender);
+  }
+
+  @Test
+  void writeEmitsAuditMarkerWhenRowInserted() {
+    when(auditLogDAO.insert(any())).thenReturn(1);
+
+    repository.write(changeEvent());
+
+    List<ILoggingEvent> auditEvents = auditEvents();
+    assertEquals(1, auditEvents.size());
+    String message = auditEvents.getFirst().getFormattedMessage();
+    assertTrue(message.contains("user=" + BOT_USER), message);
+    assertTrue(message.contains("eventType=" + EventType.ENTITY_CREATED.value()), message);
+  }
+
+  @Test
+  void writeSkipsAuditMarkerWhenRowDeduplicated() {
+    when(auditLogDAO.insert(any())).thenReturn(0);
+
+    repository.write(changeEvent());
+
+    assertEquals(0, auditEvents().size());
+  }
+
+  private List<ILoggingEvent> auditEvents() {
+    return appender.list.stream().filter(this::hasAuditMarker).toList();
+  }
+
+  private boolean hasAuditMarker(ILoggingEvent event) {
+    Marker marker = event.getMarker();
+    return marker != null && AUDIT_MARKER_NAME.equals(marker.getName());
+  }
+
+  private ChangeEvent changeEvent() {
+    return new ChangeEvent()
+        .withId(UUID.randomUUID())
+        .withEventType(EventType.ENTITY_CREATED)
+        .withEntityType(Entity.TABLE)
+        .withEntityId(UUID.randomUUID())
+        .withUserName(BOT_USER)
+        .withTimestamp(System.currentTimeMillis());
+  }
+}


### PR DESCRIPTION
Backport of #28771 to the `1.12.11` release branch.

### Original fix (#28770 / #28771)
Audit-to-file logging silently broke in #23733: gutting `AuditEventHandler` removed the only emitter of the `AUDIT` log marker, so the `audit.log` appender created the file but never wrote to it.

This re-emits each audit entry through the `AUDIT`-marked logger from `AuditLogRepository.write()`, gated on a successful (non-duplicate) DB insert so the publisher+consumer dual-write path does not double-log. Emits a compact one-line summary at INFO. Hardens `conf/openmetadata.yaml`: pins the audit logger to INFO so capture is independent of `LOG_LEVEL`, and excludes audit lines from the console appender so they land only in `audit.log`.

### Cherry-pick adjustments for 1.12.11
- **Dropped the lineage test** — `1.12.11` does not have the `EventType.ENTITY_LINEAGE_ADDED/UPDATED/DELETED` values (that feature is only on `main`), so `writePersistsLineageChangeEvents` (and its now-unused imports) was removed. No `ENTITY_LINEAGE` enum values were added. The two audit-marker tests (`writeEmitsAuditMarkerWhenRowInserted`, `writeSkipsAuditMarkerWhenRowDeduplicated`) are retained and use `ENTITY_CREATED`, which is in `1.12.11`'s `SUPPORTED_EVENT_TYPES`.
- **`conf/openmetadata.yaml`** — `1.12.11`'s console appender uses `logFormat:` (not the `layout:` block on `main`), so its structure was preserved and only the intended `filterFactories: audit-exclude-filter-factory` was added. The audit-logger `level: INFO` pin applied unchanged.

The three production files (`AuditLogRepository`, `AuditLogger`, `CollectionDAO`) match the original commit exactly.

### Verification
- `mvn -pl openmetadata-service test-compile` → BUILD SUCCESS
- `mvn -pl openmetadata-service spotless:check` → BUILD SUCCESS
- `AuditLogRepositoryTest` → Tests run: 2, Failures: 0, Errors: 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)
