### PR TITLE
fix: show Request Data Access button for Admin users

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/DataAssets/DataAssetsHeader/DataAssetsHeader.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataAssets/DataAssetsHeader/DataAssetsHeader.component.tsx
@@ -611,7 +611,7 @@ export const DataAssetsHeader = ({
       entityType !== EntityType.TABLE ||
       deleted ||
       isOwner ||
-      !canCreateTask
+      (!canCreateTask && !currentUser?.isAdmin)
     ) {
       return null;
     }
@@ -642,6 +642,7 @@ export const DataAssetsHeader = ({
     isDarAwaitingGrant,
     isDarGranted,
     canCreateTask,
+    currentUser,
     t,
   ]);
 

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataAssets/DataAssetsHeader/DataAssetsHeader.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataAssets/DataAssetsHeader/DataAssetsHeader.component.tsx
@@ -611,7 +611,6 @@ export const DataAssetsHeader = ({
       entityType !== EntityType.TABLE ||
       deleted ||
       isOwner ||
-      currentUser?.isAdmin ||
       !canCreateTask
     ) {
       return null;

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataAssets/DataAssetsHeader/DataAssetsHeader.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataAssets/DataAssetsHeader/DataAssetsHeader.test.tsx
@@ -992,7 +992,7 @@ describe('DataAssetsHeader component', () => {
       });
     });
 
-    it('should not render when user is admin even with canCreateTask permission', async () => {
+    it('should render when user is admin with canCreateTask permission', async () => {
       const { useApplicationStore } = jest.requireMock(
         '../../../hooks/useApplicationStore'
       );
@@ -1004,8 +1004,8 @@ describe('DataAssetsHeader component', () => {
 
       await waitFor(() => {
         expect(
-          screen.queryByTestId('request-data-access-button')
-        ).not.toBeInTheDocument();
+          screen.getByTestId('request-data-access-button')
+        ).toBeInTheDocument();
       });
 
       (useApplicationStore as jest.Mock).mockReturnValue({

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataAssets/DataAssetsHeader/DataAssetsHeader.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataAssets/DataAssetsHeader/DataAssetsHeader.test.tsx
@@ -972,7 +972,7 @@ describe('DataAssetsHeader component', () => {
       ).not.toBeInTheDocument();
     });
 
-    it('should not render when user is admin but has no canCreateTask permission', async () => {
+    it('should render when user is admin even without canCreateTask permission', async () => {
       const { useApplicationStore } = jest.requireMock(
         '../../../hooks/useApplicationStore'
       );
@@ -983,9 +983,11 @@ describe('DataAssetsHeader component', () => {
 
       render(<DataAssetsHeader {...tableProps} canCreateTask={false} />);
 
-      expect(
-        screen.queryByTestId('request-data-access-button')
-      ).not.toBeInTheDocument();
+      await waitFor(() => {
+        expect(
+          screen.getByTestId('request-data-access-button')
+        ).toBeInTheDocument();
+      });
 
       (useApplicationStore as jest.Mock).mockReturnValue({
         currentUser: { id: 'user-1', name: 'test.user' },
@@ -1017,9 +1019,11 @@ describe('DataAssetsHeader component', () => {
       const { useApplicationStore } = jest.requireMock(
         '../../../hooks/useApplicationStore'
       );
+      const { hasEditAccess } = jest.requireMock('../../../utils/EntityUtils');
       (useApplicationStore as jest.Mock).mockReturnValue({
         currentUser: { id: 'user-1', name: 'test.user', isAdmin: true },
       });
+      (hasEditAccess as jest.Mock).mockReturnValue(true);
 
       render(
         <DataAssetsHeader
@@ -1038,6 +1042,7 @@ describe('DataAssetsHeader component', () => {
       (useApplicationStore as jest.Mock).mockReturnValue({
         currentUser: { id: 'user-1', name: 'test.user' },
       });
+      (hasEditAccess as jest.Mock).mockReturnValue(false);
     });
 
     it('should render for non-admin user with canCreateTask permission who is not owner', async () => {

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataProducts/DataProductsDetailsPage/DataProductsDetailsPage.component.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataProducts/DataProductsDetailsPage/DataProductsDetailsPage.component.test.tsx
@@ -97,12 +97,10 @@ jest.mock('../../../hooks/useCustomPages', () => ({
     .mockReturnValue({ customizedPage: null, isLoading: false }),
 }));
 jest.mock('../../../hooks/useMarketplaceStore', () => ({
-  useMarketplaceStore: jest
-    .fn()
-    .mockReturnValue({
-      isMarketplace: false,
-      dataProductBasePath: '/data-product',
-    }),
+  useMarketplaceStore: jest.fn().mockReturnValue({
+    isMarketplace: false,
+    dataProductBasePath: '/data-product',
+  }),
 }));
 jest.mock('../../../rest/dataProductAPI', () => ({
   getDataProductPortsView: jest.fn().mockResolvedValue({ data: [] }),

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataProducts/DataProductsDetailsPage/DataProductsDetailsPage.component.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataProducts/DataProductsDetailsPage/DataProductsDetailsPage.component.test.tsx
@@ -166,6 +166,10 @@ describe('DataProductsDetailsPage — Request Data Access button', () => {
     (useApplicationStore as unknown as jest.Mock).mockReturnValue({
       currentUser: { id: 'admin-1', name: 'admin', isAdmin: true },
     });
+    (usePermissionProvider as jest.Mock).mockReturnValue({
+      getEntityPermission: jest.fn().mockResolvedValue({}),
+      permissions: { task: { Create: false } },
+    });
 
     render(<DataProductsDetailsPage {...defaultProps} />);
 

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataProducts/DataProductsDetailsPage/DataProductsDetailsPage.component.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataProducts/DataProductsDetailsPage/DataProductsDetailsPage.component.test.tsx
@@ -163,7 +163,7 @@ describe('DataProductsDetailsPage — Request Data Access button', () => {
     ).not.toBeInTheDocument();
   });
 
-  it('does not render for an admin even when the feature flag is on', () => {
+  it('renders and is enabled for an admin when the feature flag is on', () => {
     enableRequestDataAccess();
     (useApplicationStore as unknown as jest.Mock).mockReturnValue({
       currentUser: { id: 'admin-1', name: 'admin', isAdmin: true },
@@ -171,9 +171,7 @@ describe('DataProductsDetailsPage — Request Data Access button', () => {
 
     render(<DataProductsDetailsPage {...defaultProps} />);
 
-    expect(
-      screen.queryByTestId('request-data-access-button')
-    ).not.toBeInTheDocument();
+    expect(screen.getByTestId('request-data-access-button')).toBeEnabled();
   });
 
   it('does not render for the entity owner', () => {

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataProducts/DataProductsDetailsPage/DataProductsDetailsPage.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataProducts/DataProductsDetailsPage/DataProductsDetailsPage.component.tsx
@@ -896,7 +896,6 @@ const DataProductsDetailsPage = ({
             <div className="tw:flex tw:gap-3 tw:justify-end tw:items-center tw:pb-1">
               {!isVersionsView &&
                 !isOwner &&
-                !currentUser?.isAdmin &&
                 canCreateTask &&
                 dataProductClassBase.getShowRequestDataAccess() && (
                   <CoreTooltip

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataProducts/DataProductsDetailsPage/DataProductsDetailsPage.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataProducts/DataProductsDetailsPage/DataProductsDetailsPage.component.tsx
@@ -896,7 +896,7 @@ const DataProductsDetailsPage = ({
             <div className="tw:flex tw:gap-3 tw:justify-end tw:items-center tw:pb-1">
               {!isVersionsView &&
                 !isOwner &&
-                canCreateTask &&
+                (canCreateTask || currentUser?.isAdmin) &&
                 dataProductClassBase.getShowRequestDataAccess() && (
                   <CoreTooltip
                     isDisabled={!isDarDisabled}


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:

Fixes #28788
<!--
Linking an issue is REQUIRED. Replace <issue-number> with the GitHub issue number this PR addresses
(e.g., `Fixes #12345`). GitHub will auto-link it. If no issue exists, please open one first so the
problem and design can be discussed before review.
-->

Updates the visibility logic for the Request Data Access button to ensure it is displayed for Admin users

<img width="1512" height="775" alt="Screenshot 2026-06-08 at 11 49 03 AM" src="https://github.com/user-attachments/assets/85a2790d-efcf-4717-8b21-43c4df636ea2" />


#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [x] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### High-level design:
<!--
REQUIRED for large PRs (new features, refactors, breaking changes, or anything touching >5 files).
Skip for small bug fixes and trivial changes.

Cover:
- Architecture / approach you took and why
- Key components or files added/changed and how they interact
- Alternatives considered and why you rejected them
- Any migration, backward-compatibility, or rollout concerns
- Diagrams or links to design docs / RFCs if available
-->

N/A — small change. <!-- Or fill in the design above -->

#
### Tests:

#### Use cases covered
<!--
List the user-visible scenarios this PR exercises. Example:
- User with Admin role can create a Glossary Term with a parent term
- Ingestion run for Snowflake correctly extracts row counts for partitioned tables
-->

#### Unit tests
<!--
- [x] I added unit tests for the new/changed logic.
- Files added/updated:
- Coverage on changed classes (run `mvn jacoco:report` for backend, `yarn test:coverage` for UI,
  `make unit_ingestion` for ingestion). Target is 90% line coverage on changed classes.
- Coverage %: <e.g., 92% on EntityRepository.java>
-->

#### Backend integration tests
<!--
- [ ] I added integration tests in `openmetadata-integration-tests/` for new/changed API endpoints.
- [ ] Not applicable (no backend API changes).
- Files added/updated:
-->


#### Manual testing performed
<!--
List the manual test steps you performed before requesting review. Example:
1. Started local stack via `./docker/run_local_docker.sh -m ui -d mysql`
2. Logged in as admin, created entity X, verified Y appears in the UI
3. Triggered ingestion for Snowflake source, confirmed lineage edges in the explore page
-->

#
### UI screen recording / screenshots:
<!--
REQUIRED for any PR that changes the UI. Drag-and-drop a short screen recording (.mov / .mp4 / .gif)
demonstrating the change end-to-end, plus before/after screenshots where relevant.
Mark "Not applicable" if there are no UI changes.
-->

Not applicable. <!-- Or attach recording/screenshots above -->

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.
- [ ] For UI changes: I attached a screen recording and/or screenshots above.
- [ ] I have added tests (unit / integration / Playwright as applicable) and listed them above.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->


<!-- Improvement
- [x] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->
