### PR TITLE
feat(ui): extract database/schema/table tab utils and config utils

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/utils/CronExpressionUtils.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/CronExpressionUtils.ts
@@ -1,0 +1,303 @@
+/*
+ *  Copyright 2025 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+import { isUndefined, toNumber, toString } from 'lodash';
+
+import { RuleObject } from 'rc-field-form/es/interface';
+import {
+  Combination,
+  StateValue,
+  WorkflowExtraConfig,
+} from '../components/Settings/Services/AddIngestion/Steps/ScheduleInterval.interface';
+import {
+  CRON_COMBINATIONS,
+  DAY_OF_MONTH_PATTERN,
+  DAY_OF_WEEK_PATTERN,
+  DEFAULT_SCHEDULE_CRON_DAILY,
+  DEFAULT_SCHEDULE_CRON_HOURLY,
+  DEFAULT_SCHEDULE_CRON_MONTHLY,
+  DEFAULT_SCHEDULE_CRON_WEEKLY,
+  HOUR_PATTERN,
+  MINUTE_PATTERN,
+  MONTH_PATTERN,
+} from '../constants/Schedular.constants';
+import i18n from './i18next/LocalUtil';
+
+export const getScheduleOptionsFromSchedules = (
+  scheduleOptions: string[]
+): string[] => {
+  return scheduleOptions.map((scheduleOption) => {
+    switch (scheduleOption) {
+      case 'run_once':
+        return '';
+      case 'hourly':
+        return 'hour';
+      case 'daily':
+        return 'day';
+      case 'weekly':
+        return 'week';
+      case 'monthly':
+        return 'month';
+    }
+
+    return '';
+  });
+};
+
+export const getRange = (n: number) => {
+  return [...Array(n).keys()];
+};
+
+export const getRangeOptions = (n: number) => {
+  return getRange(n).map((v) => {
+    return {
+      label: `0${v}`.slice(-2),
+      value: toString(v),
+    };
+  });
+};
+
+export const getMinuteOptions = () => {
+  return getRangeOptions(60);
+};
+
+export const getHourOptions = () => {
+  return getRangeOptions(24);
+};
+
+export const getMinuteCron = (value: Partial<StateValue>) => {
+  return `*/${value.min} * * * *`;
+};
+
+export const getHourCron = (value: Partial<StateValue>) => {
+  return `${value.min} * * * *`;
+};
+
+export const getDayCron = (value: Partial<StateValue>) => {
+  return `${value.min} ${value.hour} * * *`;
+};
+
+export const getWeekCron = (value: Partial<StateValue>) => {
+  return `${value.min} ${value.hour} * * ${value.dow}`;
+};
+
+export const getMonthCron = (value: Partial<StateValue>) => {
+  return `${value.min} ${value.hour} ${value.dom} * ${value.dow}`;
+};
+
+export const getCron = (state: StateValue) => {
+  const { selectedPeriod, cron } = state;
+
+  switch (selectedPeriod) {
+    case 'hour':
+      return getHourCron(state);
+    case 'day':
+      return getDayCron(state);
+    case 'week':
+      return getWeekCron(state);
+    case 'month':
+      return getMonthCron(state);
+    default:
+      return cron;
+  }
+};
+
+const getCronType = (cronStr: string) => {
+  for (const c in CRON_COMBINATIONS) {
+    if (CRON_COMBINATIONS[c as keyof Combination].test(cronStr)) {
+      return c;
+    }
+  }
+
+  return 'custom';
+};
+
+export const getStateValue = (value?: string, defaultValue?: string) => {
+  const a = value?.split(' ');
+  const d = a ?? defaultValue?.split(' ') ?? [];
+
+  const min = d[0];
+  const hour = d[1];
+  const dom = d[2];
+  const dow = d[4];
+
+  const cronType = getCronType(value ?? defaultValue ?? '');
+
+  const stateVal: StateValue = {
+    selectedPeriod: cronType,
+    cron: value,
+    min,
+    hour,
+    dow,
+    dom,
+  };
+
+  return stateVal;
+};
+
+export const getCronDefaultValue = (appName: string) => {
+  const value = {
+    min: '0',
+    hour: '0',
+  };
+
+  let initialValue = getDayCron(value);
+
+  if (appName === 'DataInsightsReportApplication') {
+    initialValue = getWeekCron({ ...value, dow: '0' });
+  }
+
+  return initialValue;
+};
+
+export const getDefaultScheduleValue = ({
+  defaultSchedule,
+  includePeriodOptions,
+  allowNoSchedule = false,
+}: {
+  defaultSchedule?: string;
+  includePeriodOptions?: string[];
+  allowNoSchedule?: boolean;
+}) => {
+  if (isUndefined(includePeriodOptions)) {
+    return allowNoSchedule
+      ? defaultSchedule
+      : defaultSchedule || DEFAULT_SCHEDULE_CRON_DAILY;
+  }
+
+  if (allowNoSchedule && isUndefined(defaultSchedule)) {
+    return defaultSchedule;
+  }
+
+  return getDefaultScheduleFromPeriod(includePeriodOptions);
+};
+
+export const getDefaultScheduleFromPeriod = (
+  includePeriodOptions: string[]
+) => {
+  if (includePeriodOptions.includes('day')) {
+    return DEFAULT_SCHEDULE_CRON_DAILY;
+  } else if (includePeriodOptions.includes('week')) {
+    return DEFAULT_SCHEDULE_CRON_WEEKLY;
+  } else if (includePeriodOptions.includes('month')) {
+    return DEFAULT_SCHEDULE_CRON_MONTHLY;
+  } else if (includePeriodOptions.includes('hour')) {
+    return DEFAULT_SCHEDULE_CRON_HOURLY;
+  }
+
+  return DEFAULT_SCHEDULE_CRON_DAILY;
+};
+
+export const getUpdatedStateFromFormState = <T>(
+  currentState: StateValue,
+  formValues: StateValue & WorkflowExtraConfig & T
+) => {
+  try {
+    const newState = { ...currentState, ...formValues };
+    let { min, hour, dow, dom } = newState;
+
+    min = isNaN(toNumber(min)) ? '0' : min;
+    hour = isNaN(toNumber(hour)) ? '0' : hour;
+    const cronValue = newState.cron?.split(' ');
+
+    switch (newState.selectedPeriod) {
+      case 'week':
+        dow = isNaN(toNumber(dow)) ? '1' : dow;
+        dom = '*';
+
+        break;
+      case 'month':
+        dom = isNaN(toNumber(dom)) ? '1' : dom;
+        dow = '*';
+
+        break;
+      case 'custom':
+        min = cronValue?.[0] ?? '0';
+        hour = cronValue?.[1] ?? '0';
+        dom = cronValue?.[2] ?? '*';
+        dow = cronValue?.[4] ?? '*';
+
+        break;
+    }
+
+    return {
+      ...newState,
+      min,
+      hour,
+      dow,
+      dom,
+    };
+  } catch {
+    return { ...currentState, ...formValues };
+  }
+};
+
+export const cronValidator = async (_: RuleObject, value: string) => {
+  const trimmedValue = value.trim();
+
+  if (!trimmedValue) {
+    return;
+  }
+
+  const cronParts = trimmedValue.split(' ');
+
+  if (cronParts.length !== 5) {
+    return Promise.reject(
+      new Error(i18n.t('message.cron-invalid-field-count'))
+    );
+  }
+
+  const [minute, hour, dayOfMonth, month, dayOfWeek] = cronParts;
+
+  if (!MINUTE_PATTERN.test(minute)) {
+    return Promise.reject(
+      new Error(i18n.t('message.cron-invalid-minute-field'))
+    );
+  }
+  if (!HOUR_PATTERN.test(hour)) {
+    return Promise.reject(new Error(i18n.t('message.cron-invalid-hour-field')));
+  }
+  if (!DAY_OF_MONTH_PATTERN.test(dayOfMonth)) {
+    return Promise.reject(
+      new Error(i18n.t('message.cron-invalid-day-of-month-field'))
+    );
+  }
+  if (!MONTH_PATTERN.test(month)) {
+    return Promise.reject(
+      new Error(i18n.t('message.cron-invalid-month-field'))
+    );
+  }
+  if (!DAY_OF_WEEK_PATTERN.test(dayOfWeek)) {
+    return Promise.reject(
+      new Error(i18n.t('message.cron-invalid-day-of-week-field'))
+    );
+  }
+
+  try {
+    const cronstrue = (await import('cronstrue/i18n')).default;
+    const description = cronstrue.toString(trimmedValue);
+
+    const isFrequencyInMinutes = /Every \d* *minute/.test(description);
+    const isFrequencyInSeconds = /Every \d* *second/.test(description);
+
+    if (isFrequencyInMinutes || isFrequencyInSeconds) {
+      return Promise.reject(
+        new Error(i18n.t('message.cron-less-than-hour-message'))
+      );
+    }
+
+    return Promise.resolve();
+  } catch {
+    return Promise.reject(new Error(i18n.t('message.cron-invalid-expression')));
+  }
+};

--- a/openmetadata-ui/src/main/resources/ui/src/utils/CronExpressionUtils.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/CronExpressionUtils.ts
@@ -13,8 +13,8 @@
 
 import { isUndefined, toNumber, toString } from 'lodash';
 
-import { RuleObject } from 'rc-field-form/es/interface';
-import {
+import type { RuleObject } from 'rc-field-form/es/interface';
+import type {
   Combination,
   StateValue,
   WorkflowExtraConfig,

--- a/openmetadata-ui/src/main/resources/ui/src/utils/Database/Database.util.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/Database/Database.util.tsx
@@ -10,36 +10,17 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-import { get, toLower } from 'lodash';
-import { NavigateFunction } from 'react-router-dom';
-import { ReactComponent as ExportIcon } from '../../assets/svg/ic-export.svg';
-import { ReactComponent as ImportIcon } from '../../assets/svg/ic-import.svg';
-import { ActivityFeedTab } from '../../components/ActivityFeed/ActivityFeedTab/ActivityFeedTab.component';
-import { ActivityFeedLayoutType } from '../../components/ActivityFeed/ActivityFeedTab/ActivityFeedTab.interface';
-import { CustomPropertyTable } from '../../components/common/CustomPropertyTable/CustomPropertyTable';
-import { ManageButtonItemLabel } from '../../components/common/ManageButtonContentItem/ManageButtonContentItem.component';
-import TabsLabel from '../../components/common/TabsLabel/TabsLabel.component';
-import { TabProps } from '../../components/common/TabsLabel/TabsLabel.interface';
-import { GenericTab } from '../../components/Customization/GenericTab/GenericTab';
-import { CommonWidgets } from '../../components/DataAssets/CommonWidgets/CommonWidgets';
-import { DatabaseSchemaTable } from '../../components/Database/DatabaseSchema/DatabaseSchemaTable/DatabaseSchemaTable';
-import { ContractTab } from '../../components/DataContract/ContractTab/ContractTab';
-import { useEntityExportModalProvider } from '../../components/Entity/EntityExportModalProvider/EntityExportModalProvider.component';
-import { ExportTypes } from '../../constants/Export.constants';
-import { OperationPermission } from '../../context/PermissionProvider/PermissionProvider.interface';
-import { DetailPageWidgetKeys } from '../../enums/CustomizeDetailPage.enum';
-import {
-  EntityTabs,
-  EntityType,
-  TabSpecificField,
-} from '../../enums/entity.enum';
-import { PageType } from '../../generated/system/ui/page';
-import LimitWrapper from '../../hoc/LimitWrapper';
-import { WidgetConfig } from '../../pages/CustomizablePage/CustomizablePage.interface';
-import { exportDatabaseDetailsInCSV } from '../../rest/databaseAPI';
-import { getEntityImportPath } from '../EntityUtils';
-import { t } from '../i18next/LocalUtil';
-import { DatabaseDetailPageTabProps } from './DatabaseClassBase';
+/**
+ * Backward-compatible re-export barrel.
+ *
+ * Implementations have been split into focused modules:
+ *   - DatabaseDropdownOptions.tsx — ExtraDatabaseDropdownOptions
+ *   - DatabaseTabsUtils.tsx       — getDatabasePageBaseTabs, getDatabaseWidgetsFromKey
+ *
+ * Import directly from those modules for new code.
+ */
+import { toLower } from 'lodash';
+import { TabSpecificField } from '../../enums/entity.enum';
 
 export const getQueryFilterForDatabase = (
   serviceType: string,
@@ -66,159 +47,8 @@ export const getQueryFilterForDatabase = (
 
 export const DatabaseFields = `${TabSpecificField.TAGS}, ${TabSpecificField.OWNERS}, ${TabSpecificField.DOMAINS},${TabSpecificField.DATA_PRODUCTS}`;
 
-export const getDatabasePageBaseTabs = ({
-  activeTab,
-  database,
-  viewCustomPropertiesPermission,
-  schemaInstanceCount,
-  feedCount,
-  handleFeedCount,
-  getEntityFeedCount,
-  editCustomAttributePermission,
-  getDetailsByFQN,
-  labelMap,
-}: DatabaseDetailPageTabProps): TabProps[] => {
-  return [
-    {
-      label: (
-        <TabsLabel
-          count={schemaInstanceCount}
-          id={EntityTabs.SCHEMAS}
-          isActive={activeTab === EntityTabs.SCHEMAS}
-          name={labelMap?.[EntityTabs.SCHEMAS] ?? t('label.database-schema')}
-        />
-      ),
-      key: EntityTabs.SCHEMAS,
-      children: <GenericTab type={PageType.Database} />,
-    },
-    {
-      label: (
-        <TabsLabel
-          count={feedCount.totalCount}
-          id={EntityTabs.ACTIVITY_FEED}
-          isActive={activeTab === EntityTabs.ACTIVITY_FEED}
-          name={
-            labelMap?.[EntityTabs.ACTIVITY_FEED] ??
-            t('label.activity-feed-and-task-plural')
-          }
-        />
-      ),
-      key: EntityTabs.ACTIVITY_FEED,
-      children: (
-        <ActivityFeedTab
-          refetchFeed
-          entityFeedTotalCount={feedCount.totalCount}
-          entityType={EntityType.DATABASE}
-          feedCount={feedCount}
-          layoutType={ActivityFeedLayoutType.THREE_PANEL}
-          onFeedUpdate={getEntityFeedCount}
-          onUpdateEntityDetails={getDetailsByFQN}
-          onUpdateFeedCount={handleFeedCount}
-        />
-      ),
-    },
-    {
-      label: (
-        <TabsLabel
-          id={EntityTabs.CONTRACT}
-          name={get(labelMap, EntityTabs.CONTRACT, t('label.contract'))}
-        />
-      ),
-      key: EntityTabs.CONTRACT,
-      children: <ContractTab />,
-    },
-    {
-      label: (
-        <TabsLabel
-          id={EntityTabs.CUSTOM_PROPERTIES}
-          name={
-            labelMap?.[EntityTabs.CUSTOM_PROPERTIES] ??
-            t('label.custom-property-plural')
-          }
-        />
-      ),
-      key: EntityTabs.CUSTOM_PROPERTIES,
-      children: database && (
-        <CustomPropertyTable<EntityType.DATABASE>
-          entityType={EntityType.DATABASE}
-          hasEditAccess={editCustomAttributePermission}
-          hasPermission={viewCustomPropertiesPermission}
-          isVersionView={false}
-        />
-      ),
-    },
-  ];
-};
-
-export const getDatabaseWidgetsFromKey = (widgetConfig: WidgetConfig) => {
-  if (widgetConfig.i.startsWith(DetailPageWidgetKeys.DATABASE_SCHEMA)) {
-    return <DatabaseSchemaTable />;
-  }
-
-  return (
-    <CommonWidgets
-      entityType={EntityType.DATABASE}
-      widgetConfig={widgetConfig}
-    />
-  );
-};
-
-export const ExtraDatabaseDropdownOptions = (
-  fqn: string,
-  permission: OperationPermission,
-  deleted: boolean,
-  navigate: NavigateFunction
-) => {
-  const { showModal } = useEntityExportModalProvider();
-
-  const { ViewAll, EditAll } = permission;
-
-  return [
-    ...(EditAll && !deleted
-      ? [
-          {
-            label: (
-              <LimitWrapper resource="database">
-                <ManageButtonItemLabel
-                  description={t('message.import-entity-help', {
-                    entity: t('label.database'),
-                  })}
-                  icon={ImportIcon}
-                  id="import-button"
-                  name={t('label.import')}
-                  onClick={() =>
-                    navigate(getEntityImportPath(EntityType.DATABASE, fqn))
-                  }
-                />
-              </LimitWrapper>
-            ),
-            key: 'import-button',
-          },
-        ]
-      : []),
-    ...(ViewAll && !deleted
-      ? [
-          {
-            label: (
-              <ManageButtonItemLabel
-                description={t('message.export-entity-help', {
-                  entity: t('label.database'),
-                })}
-                icon={ExportIcon}
-                id="export-button"
-                name={t('label.export')}
-                onClick={() =>
-                  showModal({
-                    name: fqn,
-                    onExport: exportDatabaseDetailsInCSV,
-                    exportTypes: [ExportTypes.CSV],
-                  })
-                }
-              />
-            ),
-            key: 'export-button',
-          },
-        ]
-      : []),
-  ];
-};
+export { ExtraDatabaseDropdownOptions } from './DatabaseDropdownOptions';
+export {
+  getDatabasePageBaseTabs,
+  getDatabaseWidgetsFromKey,
+} from './DatabaseTabsUtils';

--- a/openmetadata-ui/src/main/resources/ui/src/utils/Database/DatabaseDropdownOptions.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/Database/DatabaseDropdownOptions.tsx
@@ -1,0 +1,84 @@
+/*
+ *  Copyright 2025 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+import { NavigateFunction } from 'react-router-dom';
+import { ReactComponent as ExportIcon } from '../../assets/svg/ic-export.svg';
+import { ReactComponent as ImportIcon } from '../../assets/svg/ic-import.svg';
+import { ManageButtonItemLabel } from '../../components/common/ManageButtonContentItem/ManageButtonContentItem.component';
+import { useEntityExportModalProvider } from '../../components/Entity/EntityExportModalProvider/EntityExportModalProvider.component';
+import { ExportTypes } from '../../constants/Export.constants';
+import { OperationPermission } from '../../context/PermissionProvider/PermissionProvider.interface';
+import { EntityType } from '../../enums/entity.enum';
+import LimitWrapper from '../../hoc/LimitWrapper';
+import { exportDatabaseDetailsInCSV } from '../../rest/databaseAPI';
+import { getEntityImportPath } from '../EntityUtils';
+import { t } from '../i18next/LocalUtil';
+
+export const ExtraDatabaseDropdownOptions = (
+  fqn: string,
+  permission: OperationPermission,
+  deleted: boolean,
+  navigate: NavigateFunction
+) => {
+  const { showModal } = useEntityExportModalProvider();
+
+  const { ViewAll, EditAll } = permission;
+
+  return [
+    ...(EditAll && !deleted
+      ? [
+          {
+            label: (
+              <LimitWrapper resource="database">
+                <ManageButtonItemLabel
+                  description={t('message.import-entity-help', {
+                    entity: t('label.database'),
+                  })}
+                  icon={ImportIcon}
+                  id="import-button"
+                  name={t('label.import')}
+                  onClick={() =>
+                    navigate(getEntityImportPath(EntityType.DATABASE, fqn))
+                  }
+                />
+              </LimitWrapper>
+            ),
+            key: 'import-button',
+          },
+        ]
+      : []),
+    ...(ViewAll && !deleted
+      ? [
+          {
+            label: (
+              <ManageButtonItemLabel
+                description={t('message.export-entity-help', {
+                  entity: t('label.database'),
+                })}
+                icon={ExportIcon}
+                id="export-button"
+                name={t('label.export')}
+                onClick={() =>
+                  showModal({
+                    name: fqn,
+                    onExport: exportDatabaseDetailsInCSV,
+                    exportTypes: [ExportTypes.CSV],
+                  })
+                }
+              />
+            ),
+            key: 'export-button',
+          },
+        ]
+      : []),
+  ];
+};

--- a/openmetadata-ui/src/main/resources/ui/src/utils/Database/DatabaseDropdownOptions.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/Database/DatabaseDropdownOptions.tsx
@@ -10,13 +10,13 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-import { NavigateFunction } from 'react-router-dom';
+import type { NavigateFunction } from 'react-router-dom';
 import { ReactComponent as ExportIcon } from '../../assets/svg/ic-export.svg';
 import { ReactComponent as ImportIcon } from '../../assets/svg/ic-import.svg';
 import { ManageButtonItemLabel } from '../../components/common/ManageButtonContentItem/ManageButtonContentItem.component';
 import { useEntityExportModalProvider } from '../../components/Entity/EntityExportModalProvider/EntityExportModalProvider.component';
 import { ExportTypes } from '../../constants/Export.constants';
-import { OperationPermission } from '../../context/PermissionProvider/PermissionProvider.interface';
+import type { OperationPermission } from '../../context/PermissionProvider/PermissionProvider.interface';
 import { EntityType } from '../../enums/entity.enum';
 import LimitWrapper from '../../hoc/LimitWrapper';
 import { exportDatabaseDetailsInCSV } from '../../rest/databaseAPI';

--- a/openmetadata-ui/src/main/resources/ui/src/utils/Database/DatabaseTabsUtils.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/Database/DatabaseTabsUtils.tsx
@@ -1,0 +1,161 @@
+/*
+ *  Copyright 2025 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+import { get } from 'lodash';
+import { lazy } from 'react';
+import { ActivityFeedLayoutType } from '../../components/ActivityFeed/ActivityFeedTab/ActivityFeedTab.interface';
+import withSuspenseFallback from '../../components/AppRouter/withSuspenseFallback';
+import type {
+  CustomPropertyProps,
+  ExtentionEntitiesKeys,
+} from '../../components/common/CustomPropertyTable/CustomPropertyTable.interface';
+import TabsLabel from '../../components/common/TabsLabel/TabsLabel.component';
+import { TabProps } from '../../components/common/TabsLabel/TabsLabel.interface';
+import { GenericTab } from '../../components/Customization/GenericTab/GenericTab';
+import { CommonWidgets } from '../../components/DataAssets/CommonWidgets/CommonWidgets';
+import { DetailPageWidgetKeys } from '../../enums/CustomizeDetailPage.enum';
+import { EntityTabs, EntityType } from '../../enums/entity.enum';
+import { PageType } from '../../generated/system/ui/page';
+import { WidgetConfig } from '../../pages/CustomizablePage/CustomizablePage.interface';
+import { t } from '../i18next/LocalUtil';
+import { DatabaseDetailPageTabProps } from './DatabaseClassBase';
+
+const CustomPropertyTable = withSuspenseFallback(
+  lazy(() =>
+    import(
+      '../../components/common/CustomPropertyTable/CustomPropertyTable'
+    ).then((module) => ({ default: module.CustomPropertyTable }))
+  )
+) as <T extends ExtentionEntitiesKeys>(
+  props: CustomPropertyProps<T>
+) => JSX.Element;
+
+const ActivityFeedTab = withSuspenseFallback(
+  lazy(() =>
+    import(
+      '../../components/ActivityFeed/ActivityFeedTab/ActivityFeedTab.component'
+    ).then((module) => ({ default: module.ActivityFeedTab }))
+  )
+);
+
+const ContractTab = withSuspenseFallback(
+  lazy(() =>
+    import('../../components/DataContract/ContractTab/ContractTab').then(
+      (module) => ({ default: module.ContractTab })
+    )
+  )
+);
+
+const DatabaseSchemaTable = withSuspenseFallback(
+  lazy(() =>
+    import(
+      '../../components/Database/DatabaseSchema/DatabaseSchemaTable/DatabaseSchemaTable'
+    ).then((module) => ({ default: module.DatabaseSchemaTable }))
+  )
+);
+
+export const getDatabasePageBaseTabs = ({
+  activeTab,
+  database,
+  viewCustomPropertiesPermission,
+  schemaInstanceCount,
+  feedCount,
+  handleFeedCount,
+  getEntityFeedCount,
+  editCustomAttributePermission,
+  getDetailsByFQN,
+  labelMap,
+}: DatabaseDetailPageTabProps): TabProps[] => {
+  return [
+    {
+      label: (
+        <TabsLabel
+          count={schemaInstanceCount}
+          id={EntityTabs.SCHEMAS}
+          isActive={activeTab === EntityTabs.SCHEMAS}
+          name={labelMap?.[EntityTabs.SCHEMAS] ?? t('label.database-schema')}
+        />
+      ),
+      key: EntityTabs.SCHEMAS,
+      children: <GenericTab type={PageType.Database} />,
+    },
+    {
+      label: (
+        <TabsLabel
+          count={feedCount.totalCount}
+          id={EntityTabs.ACTIVITY_FEED}
+          isActive={activeTab === EntityTabs.ACTIVITY_FEED}
+          name={
+            labelMap?.[EntityTabs.ACTIVITY_FEED] ??
+            t('label.activity-feed-and-task-plural')
+          }
+        />
+      ),
+      key: EntityTabs.ACTIVITY_FEED,
+      children: (
+        <ActivityFeedTab
+          refetchFeed
+          entityFeedTotalCount={feedCount.totalCount}
+          entityType={EntityType.DATABASE}
+          feedCount={feedCount}
+          layoutType={ActivityFeedLayoutType.THREE_PANEL}
+          onFeedUpdate={getEntityFeedCount}
+          onUpdateEntityDetails={getDetailsByFQN}
+          onUpdateFeedCount={handleFeedCount}
+        />
+      ),
+    },
+    {
+      label: (
+        <TabsLabel
+          id={EntityTabs.CONTRACT}
+          name={get(labelMap, EntityTabs.CONTRACT, t('label.contract'))}
+        />
+      ),
+      key: EntityTabs.CONTRACT,
+      children: <ContractTab />,
+    },
+    {
+      label: (
+        <TabsLabel
+          id={EntityTabs.CUSTOM_PROPERTIES}
+          name={
+            labelMap?.[EntityTabs.CUSTOM_PROPERTIES] ??
+            t('label.custom-property-plural')
+          }
+        />
+      ),
+      key: EntityTabs.CUSTOM_PROPERTIES,
+      children: database && (
+        <CustomPropertyTable<EntityType.DATABASE>
+          entityType={EntityType.DATABASE}
+          hasEditAccess={editCustomAttributePermission}
+          hasPermission={viewCustomPropertiesPermission}
+          isVersionView={false}
+        />
+      ),
+    },
+  ];
+};
+
+export const getDatabaseWidgetsFromKey = (widgetConfig: WidgetConfig) => {
+  if (widgetConfig.i.startsWith(DetailPageWidgetKeys.DATABASE_SCHEMA)) {
+    return <DatabaseSchemaTable />;
+  }
+
+  return (
+    <CommonWidgets
+      entityType={EntityType.DATABASE}
+      widgetConfig={widgetConfig}
+    />
+  );
+};

--- a/openmetadata-ui/src/main/resources/ui/src/utils/Database/DatabaseTabsUtils.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/Database/DatabaseTabsUtils.tsx
@@ -12,22 +12,22 @@
  */
 import { get } from 'lodash';
 import { lazy } from 'react';
-import { ActivityFeedLayoutType } from '../../components/ActivityFeed/ActivityFeedTab/ActivityFeedTab.interface';
+import type { ActivityFeedLayoutType } from '../../components/ActivityFeed/ActivityFeedTab/ActivityFeedTab.interface';
 import withSuspenseFallback from '../../components/AppRouter/withSuspenseFallback';
 import type {
   CustomPropertyProps,
   ExtentionEntitiesKeys,
 } from '../../components/common/CustomPropertyTable/CustomPropertyTable.interface';
 import TabsLabel from '../../components/common/TabsLabel/TabsLabel.component';
-import { TabProps } from '../../components/common/TabsLabel/TabsLabel.interface';
+import type { TabProps } from '../../components/common/TabsLabel/TabsLabel.interface';
 import { GenericTab } from '../../components/Customization/GenericTab/GenericTab';
 import { CommonWidgets } from '../../components/DataAssets/CommonWidgets/CommonWidgets';
 import { DetailPageWidgetKeys } from '../../enums/CustomizeDetailPage.enum';
 import { EntityTabs, EntityType } from '../../enums/entity.enum';
 import { PageType } from '../../generated/system/ui/page';
-import { WidgetConfig } from '../../pages/CustomizablePage/CustomizablePage.interface';
+import type { WidgetConfig } from '../../pages/CustomizablePage/CustomizablePage.interface';
 import { t } from '../i18next/LocalUtil';
-import { DatabaseDetailPageTabProps } from './DatabaseClassBase';
+import type { DatabaseDetailPageTabProps } from './DatabaseClassBase';
 
 const CustomPropertyTable = withSuspenseFallback(
   lazy(() =>

--- a/openmetadata-ui/src/main/resources/ui/src/utils/Database/DatabaseTabsUtils.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/Database/DatabaseTabsUtils.tsx
@@ -12,7 +12,7 @@
  */
 import { get } from 'lodash';
 import { lazy } from 'react';
-import type { ActivityFeedLayoutType } from '../../components/ActivityFeed/ActivityFeedTab/ActivityFeedTab.interface';
+import { ActivityFeedLayoutType } from '../../components/ActivityFeed/ActivityFeedTab/ActivityFeedTab.interface';
 import withSuspenseFallback from '../../components/AppRouter/withSuspenseFallback';
 import type {
   CustomPropertyProps,

--- a/openmetadata-ui/src/main/resources/ui/src/utils/DatabaseSchemaDetailsUtils.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/DatabaseSchemaDetailsUtils.tsx
@@ -11,210 +11,25 @@
  *  limitations under the License.
  */
 
-import { get } from 'lodash';
-import { NavigateFunction } from 'react-router-dom';
-import { ReactComponent as ExportIcon } from '../assets/svg/ic-export.svg';
-import { ReactComponent as ImportIcon } from '../assets/svg/ic-import.svg';
-import { ActivityFeedTab } from '../components/ActivityFeed/ActivityFeedTab/ActivityFeedTab.component';
-import { ActivityFeedLayoutType } from '../components/ActivityFeed/ActivityFeedTab/ActivityFeedTab.interface';
-import { CustomPropertyTable } from '../components/common/CustomPropertyTable/CustomPropertyTable';
-import { ManageButtonItemLabel } from '../components/common/ManageButtonContentItem/ManageButtonContentItem.component';
-import TabsLabel from '../components/common/TabsLabel/TabsLabel.component';
-import { TabProps } from '../components/common/TabsLabel/TabsLabel.interface';
-import { GenericTab } from '../components/Customization/GenericTab/GenericTab';
-import { CommonWidgets } from '../components/DataAssets/CommonWidgets/CommonWidgets';
-import { ContractTab } from '../components/DataContract/ContractTab/ContractTab';
-import { useEntityExportModalProvider } from '../components/Entity/EntityExportModalProvider/EntityExportModalProvider.component';
-import { ExportTypes } from '../constants/Export.constants';
-import { OperationPermission } from '../context/PermissionProvider/PermissionProvider.interface';
-import { DetailPageWidgetKeys } from '../enums/CustomizeDetailPage.enum';
-import { EntityTabs, EntityType, TabSpecificField } from '../enums/entity.enum';
-import { PageType } from '../generated/system/ui/page';
-import LimitWrapper from '../hoc/LimitWrapper';
-import { WidgetConfig } from '../pages/CustomizablePage/CustomizablePage.interface';
-import SchemaTablesTab from '../pages/DatabaseSchemaPage/SchemaTablesTab';
-import StoredProcedureTab from '../pages/StoredProcedure/StoredProcedureTab';
-import { exportDatabaseSchemaDetailsInCSV } from '../rest/databaseAPI';
-import { DatabaseSchemaPageTabProps } from './DatabaseSchemaClassBase';
-import { getEntityImportPath } from './EntityUtils';
-import { t } from './i18next/LocalUtil';
+/**
+ * Backward-compatible re-export barrel.
+ *
+ * Implementations have been split into focused modules:
+ *   - DatabaseSchemaDropdownOptions.tsx — ExtraDatabaseSchemaDropdownOptions
+ *   - DatabaseSchemaTabsUtils.tsx       — getDataBaseSchemaPageBaseTabs, getDatabaseSchemaWidgetsFromKey
+ *
+ * Import directly from those modules for new code.
+ */
+import { TabSpecificField } from '../enums/entity.enum';
 import { getTermQuery } from './SearchUtils';
 
 export const defaultFields = `${TabSpecificField.TAGS},${TabSpecificField.OWNERS},${TabSpecificField.USAGE_SUMMARY},${TabSpecificField.DOMAINS},${TabSpecificField.DATA_PRODUCTS}`;
 
-export const getDataBaseSchemaPageBaseTabs = ({
-  feedCount,
-  activeTab,
-  editCustomAttributePermission,
-  viewCustomPropertiesPermission,
-  storedProcedureCount,
-  getEntityFeedCount,
-  fetchDatabaseSchemaDetails,
-  handleFeedCount,
-  tableCount,
-  labelMap,
-}: DatabaseSchemaPageTabProps): TabProps[] => {
-  return [
-    {
-      label: (
-        <TabsLabel
-          count={tableCount}
-          id={EntityTabs.TABLE}
-          isActive={activeTab === EntityTabs.TABLE}
-          name={labelMap[EntityTabs.TABLE] || t('label.table-plural')}
-        />
-      ),
-      key: EntityTabs.TABLE,
-      children: <GenericTab type={PageType.DatabaseSchema} />,
-    },
-    {
-      label: (
-        <TabsLabel
-          count={storedProcedureCount}
-          id={EntityTabs.STORED_PROCEDURE}
-          isActive={activeTab === EntityTabs.STORED_PROCEDURE}
-          name={
-            labelMap[EntityTabs.STORED_PROCEDURE] ||
-            t('label.stored-procedure-plural')
-          }
-        />
-      ),
-      key: EntityTabs.STORED_PROCEDURE,
-      children: <StoredProcedureTab />,
-    },
-    {
-      label: (
-        <TabsLabel
-          count={feedCount.totalCount}
-          id={EntityTabs.ACTIVITY_FEED}
-          isActive={activeTab === EntityTabs.ACTIVITY_FEED}
-          name={
-            labelMap[EntityTabs.ACTIVITY_FEED] ||
-            t('label.activity-feed-and-task-plural')
-          }
-        />
-      ),
-      key: EntityTabs.ACTIVITY_FEED,
-      children: (
-        <ActivityFeedTab
-          refetchFeed
-          entityFeedTotalCount={feedCount.totalCount}
-          entityType={EntityType.DATABASE_SCHEMA}
-          feedCount={feedCount}
-          layoutType={ActivityFeedLayoutType.THREE_PANEL}
-          onFeedUpdate={getEntityFeedCount}
-          onUpdateEntityDetails={fetchDatabaseSchemaDetails}
-          onUpdateFeedCount={handleFeedCount}
-        />
-      ),
-    },
-    {
-      label: (
-        <TabsLabel
-          id={EntityTabs.CONTRACT}
-          name={get(labelMap, EntityTabs.CONTRACT, t('label.contract'))}
-        />
-      ),
-      key: EntityTabs.CONTRACT,
-      children: <ContractTab />,
-    },
-    {
-      label: (
-        <TabsLabel
-          id={EntityTabs.CUSTOM_PROPERTIES}
-          name={
-            labelMap[EntityTabs.CUSTOM_PROPERTIES] ||
-            t('label.custom-property-plural')
-          }
-        />
-      ),
-      key: EntityTabs.CUSTOM_PROPERTIES,
-      children: (
-        <CustomPropertyTable<EntityType.DATABASE_SCHEMA>
-          className=""
-          entityType={EntityType.DATABASE_SCHEMA}
-          hasEditAccess={editCustomAttributePermission}
-          hasPermission={viewCustomPropertiesPermission}
-          isVersionView={false}
-        />
-      ),
-    },
-  ];
-};
-
-export const ExtraDatabaseSchemaDropdownOptions = (
-  fqn: string,
-  permission: OperationPermission,
-  deleted: boolean,
-  navigate: NavigateFunction
-) => {
-  const { showModal } = useEntityExportModalProvider();
-
-  const { ViewAll, EditAll } = permission;
-
-  return [
-    ...(EditAll && !deleted
-      ? [
-          {
-            label: (
-              <LimitWrapper resource="databaseSchema">
-                <ManageButtonItemLabel
-                  description={t('message.import-entity-help', {
-                    entity: t('label.database-schema'),
-                  })}
-                  icon={ImportIcon}
-                  id="import-button"
-                  name={t('label.import')}
-                  onClick={() =>
-                    navigate(
-                      getEntityImportPath(EntityType.DATABASE_SCHEMA, fqn)
-                    )
-                  }
-                />
-              </LimitWrapper>
-            ),
-            key: 'import-button',
-          },
-        ]
-      : []),
-    ...(ViewAll && !deleted
-      ? [
-          {
-            label: (
-              <ManageButtonItemLabel
-                description={t('message.export-entity-help', {
-                  entity: t('label.database-schema'),
-                })}
-                icon={ExportIcon}
-                id="export-button"
-                name={t('label.export')}
-                onClick={() =>
-                  showModal({
-                    name: fqn,
-                    onExport: exportDatabaseSchemaDetailsInCSV,
-                    exportTypes: [ExportTypes.CSV],
-                  })
-                }
-              />
-            ),
-            key: 'export-button',
-          },
-        ]
-      : []),
-  ];
-};
-export const getDatabaseSchemaWidgetsFromKey = (widgetConfig: WidgetConfig) => {
-  if (widgetConfig.i.startsWith(DetailPageWidgetKeys.TABLES)) {
-    return <SchemaTablesTab />;
-  }
-
-  return (
-    <CommonWidgets
-      entityType={EntityType.DATABASE_SCHEMA}
-      widgetConfig={widgetConfig}
-    />
-  );
-};
+export { ExtraDatabaseSchemaDropdownOptions } from './DatabaseSchemaDropdownOptions';
+export {
+  getDataBaseSchemaPageBaseTabs,
+  getDatabaseSchemaWidgetsFromKey,
+} from './DatabaseSchemaTabsUtils';
 
 export function buildSchemaQueryFilter(
   field: string,

--- a/openmetadata-ui/src/main/resources/ui/src/utils/DatabaseSchemaDropdownOptions.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/DatabaseSchemaDropdownOptions.tsx
@@ -1,0 +1,86 @@
+/*
+ *  Copyright 2025 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+import { NavigateFunction } from 'react-router-dom';
+import { ReactComponent as ExportIcon } from '../assets/svg/ic-export.svg';
+import { ReactComponent as ImportIcon } from '../assets/svg/ic-import.svg';
+import { ManageButtonItemLabel } from '../components/common/ManageButtonContentItem/ManageButtonContentItem.component';
+import { useEntityExportModalProvider } from '../components/Entity/EntityExportModalProvider/EntityExportModalProvider.component';
+import { ExportTypes } from '../constants/Export.constants';
+import { OperationPermission } from '../context/PermissionProvider/PermissionProvider.interface';
+import { EntityType } from '../enums/entity.enum';
+import LimitWrapper from '../hoc/LimitWrapper';
+import { exportDatabaseSchemaDetailsInCSV } from '../rest/databaseAPI';
+import { getEntityImportPath } from './EntityUtils';
+import { t } from './i18next/LocalUtil';
+
+export const ExtraDatabaseSchemaDropdownOptions = (
+  fqn: string,
+  permission: OperationPermission,
+  deleted: boolean,
+  navigate: NavigateFunction
+) => {
+  const { showModal } = useEntityExportModalProvider();
+
+  const { ViewAll, EditAll } = permission;
+
+  return [
+    ...(EditAll && !deleted
+      ? [
+          {
+            label: (
+              <LimitWrapper resource="databaseSchema">
+                <ManageButtonItemLabel
+                  description={t('message.import-entity-help', {
+                    entity: t('label.database-schema'),
+                  })}
+                  icon={ImportIcon}
+                  id="import-button"
+                  name={t('label.import')}
+                  onClick={() =>
+                    navigate(
+                      getEntityImportPath(EntityType.DATABASE_SCHEMA, fqn)
+                    )
+                  }
+                />
+              </LimitWrapper>
+            ),
+            key: 'import-button',
+          },
+        ]
+      : []),
+    ...(ViewAll && !deleted
+      ? [
+          {
+            label: (
+              <ManageButtonItemLabel
+                description={t('message.export-entity-help', {
+                  entity: t('label.database-schema'),
+                })}
+                icon={ExportIcon}
+                id="export-button"
+                name={t('label.export')}
+                onClick={() =>
+                  showModal({
+                    name: fqn,
+                    onExport: exportDatabaseSchemaDetailsInCSV,
+                    exportTypes: [ExportTypes.CSV],
+                  })
+                }
+              />
+            ),
+            key: 'export-button',
+          },
+        ]
+      : []),
+  ];
+};

--- a/openmetadata-ui/src/main/resources/ui/src/utils/DatabaseSchemaDropdownOptions.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/DatabaseSchemaDropdownOptions.tsx
@@ -10,13 +10,13 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-import { NavigateFunction } from 'react-router-dom';
+import type { NavigateFunction } from 'react-router-dom';
 import { ReactComponent as ExportIcon } from '../assets/svg/ic-export.svg';
 import { ReactComponent as ImportIcon } from '../assets/svg/ic-import.svg';
 import { ManageButtonItemLabel } from '../components/common/ManageButtonContentItem/ManageButtonContentItem.component';
 import { useEntityExportModalProvider } from '../components/Entity/EntityExportModalProvider/EntityExportModalProvider.component';
 import { ExportTypes } from '../constants/Export.constants';
-import { OperationPermission } from '../context/PermissionProvider/PermissionProvider.interface';
+import type { OperationPermission } from '../context/PermissionProvider/PermissionProvider.interface';
 import { EntityType } from '../enums/entity.enum';
 import LimitWrapper from '../hoc/LimitWrapper';
 import { exportDatabaseSchemaDetailsInCSV } from '../rest/databaseAPI';

--- a/openmetadata-ui/src/main/resources/ui/src/utils/DatabaseSchemaTabsUtils.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/DatabaseSchemaTabsUtils.tsx
@@ -12,7 +12,7 @@
  */
 import { get } from 'lodash';
 import { lazy } from 'react';
-import type { ActivityFeedLayoutType } from '../components/ActivityFeed/ActivityFeedTab/ActivityFeedTab.interface';
+import { ActivityFeedLayoutType } from '../components/ActivityFeed/ActivityFeedTab/ActivityFeedTab.interface';
 import withSuspenseFallback from '../components/AppRouter/withSuspenseFallback';
 import type {
   CustomPropertyProps,

--- a/openmetadata-ui/src/main/resources/ui/src/utils/DatabaseSchemaTabsUtils.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/DatabaseSchemaTabsUtils.tsx
@@ -1,0 +1,177 @@
+/*
+ *  Copyright 2025 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+import { get } from 'lodash';
+import { lazy } from 'react';
+import { ActivityFeedLayoutType } from '../components/ActivityFeed/ActivityFeedTab/ActivityFeedTab.interface';
+import withSuspenseFallback from '../components/AppRouter/withSuspenseFallback';
+import type {
+  CustomPropertyProps,
+  ExtentionEntitiesKeys,
+} from '../components/common/CustomPropertyTable/CustomPropertyTable.interface';
+import TabsLabel from '../components/common/TabsLabel/TabsLabel.component';
+import { TabProps } from '../components/common/TabsLabel/TabsLabel.interface';
+import { GenericTab } from '../components/Customization/GenericTab/GenericTab';
+import { CommonWidgets } from '../components/DataAssets/CommonWidgets/CommonWidgets';
+import { DetailPageWidgetKeys } from '../enums/CustomizeDetailPage.enum';
+import { EntityTabs, EntityType } from '../enums/entity.enum';
+import { PageType } from '../generated/system/ui/page';
+import { WidgetConfig } from '../pages/CustomizablePage/CustomizablePage.interface';
+import { DatabaseSchemaPageTabProps } from './DatabaseSchemaClassBase';
+import { t } from './i18next/LocalUtil';
+
+const CustomPropertyTable = withSuspenseFallback(
+  lazy(() =>
+    import(
+      '../components/common/CustomPropertyTable/CustomPropertyTable'
+    ).then((module) => ({ default: module.CustomPropertyTable }))
+  )
+) as <T extends ExtentionEntitiesKeys>(
+  props: CustomPropertyProps<T>
+) => JSX.Element;
+
+const ActivityFeedTab = withSuspenseFallback(
+  lazy(() =>
+    import(
+      '../components/ActivityFeed/ActivityFeedTab/ActivityFeedTab.component'
+    ).then((module) => ({ default: module.ActivityFeedTab }))
+  )
+);
+
+const ContractTab = withSuspenseFallback(
+  lazy(() =>
+    import('../components/DataContract/ContractTab/ContractTab').then(
+      (module) => ({ default: module.ContractTab })
+    )
+  )
+);
+
+const SchemaTablesTab = withSuspenseFallback(
+  lazy(() => import('../pages/DatabaseSchemaPage/SchemaTablesTab'))
+);
+
+const StoredProcedureTab = withSuspenseFallback(
+  lazy(() => import('../pages/StoredProcedure/StoredProcedureTab'))
+);
+
+export const getDataBaseSchemaPageBaseTabs = ({
+  feedCount,
+  activeTab,
+  editCustomAttributePermission,
+  viewCustomPropertiesPermission,
+  storedProcedureCount,
+  getEntityFeedCount,
+  fetchDatabaseSchemaDetails,
+  handleFeedCount,
+  tableCount,
+  labelMap,
+}: DatabaseSchemaPageTabProps): TabProps[] => {
+  return [
+    {
+      label: (
+        <TabsLabel
+          count={tableCount}
+          id={EntityTabs.TABLE}
+          isActive={activeTab === EntityTabs.TABLE}
+          name={labelMap[EntityTabs.TABLE] || t('label.table-plural')}
+        />
+      ),
+      key: EntityTabs.TABLE,
+      children: <GenericTab type={PageType.DatabaseSchema} />,
+    },
+    {
+      label: (
+        <TabsLabel
+          count={storedProcedureCount}
+          id={EntityTabs.STORED_PROCEDURE}
+          isActive={activeTab === EntityTabs.STORED_PROCEDURE}
+          name={
+            labelMap[EntityTabs.STORED_PROCEDURE] ||
+            t('label.stored-procedure-plural')
+          }
+        />
+      ),
+      key: EntityTabs.STORED_PROCEDURE,
+      children: <StoredProcedureTab />,
+    },
+    {
+      label: (
+        <TabsLabel
+          count={feedCount.totalCount}
+          id={EntityTabs.ACTIVITY_FEED}
+          isActive={activeTab === EntityTabs.ACTIVITY_FEED}
+          name={
+            labelMap[EntityTabs.ACTIVITY_FEED] ||
+            t('label.activity-feed-and-task-plural')
+          }
+        />
+      ),
+      key: EntityTabs.ACTIVITY_FEED,
+      children: (
+        <ActivityFeedTab
+          refetchFeed
+          entityFeedTotalCount={feedCount.totalCount}
+          entityType={EntityType.DATABASE_SCHEMA}
+          feedCount={feedCount}
+          layoutType={ActivityFeedLayoutType.THREE_PANEL}
+          onFeedUpdate={getEntityFeedCount}
+          onUpdateEntityDetails={fetchDatabaseSchemaDetails}
+          onUpdateFeedCount={handleFeedCount}
+        />
+      ),
+    },
+    {
+      label: (
+        <TabsLabel
+          id={EntityTabs.CONTRACT}
+          name={get(labelMap, EntityTabs.CONTRACT, t('label.contract'))}
+        />
+      ),
+      key: EntityTabs.CONTRACT,
+      children: <ContractTab />,
+    },
+    {
+      label: (
+        <TabsLabel
+          id={EntityTabs.CUSTOM_PROPERTIES}
+          name={
+            labelMap[EntityTabs.CUSTOM_PROPERTIES] ||
+            t('label.custom-property-plural')
+          }
+        />
+      ),
+      key: EntityTabs.CUSTOM_PROPERTIES,
+      children: (
+        <CustomPropertyTable<EntityType.DATABASE_SCHEMA>
+          className=""
+          entityType={EntityType.DATABASE_SCHEMA}
+          hasEditAccess={editCustomAttributePermission}
+          hasPermission={viewCustomPropertiesPermission}
+          isVersionView={false}
+        />
+      ),
+    },
+  ];
+};
+
+export const getDatabaseSchemaWidgetsFromKey = (widgetConfig: WidgetConfig) => {
+  if (widgetConfig.i.startsWith(DetailPageWidgetKeys.TABLES)) {
+    return <SchemaTablesTab />;
+  }
+
+  return (
+    <CommonWidgets
+      entityType={EntityType.DATABASE_SCHEMA}
+      widgetConfig={widgetConfig}
+    />
+  );
+};

--- a/openmetadata-ui/src/main/resources/ui/src/utils/DatabaseSchemaTabsUtils.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/DatabaseSchemaTabsUtils.tsx
@@ -31,9 +31,9 @@ import { t } from './i18next/LocalUtil';
 
 const CustomPropertyTable = withSuspenseFallback(
   lazy(() =>
-    import(
-      '../components/common/CustomPropertyTable/CustomPropertyTable'
-    ).then((module) => ({ default: module.CustomPropertyTable }))
+    import('../components/common/CustomPropertyTable/CustomPropertyTable').then(
+      (module) => ({ default: module.CustomPropertyTable })
+    )
   )
 ) as <T extends ExtentionEntitiesKeys>(
   props: CustomPropertyProps<T>

--- a/openmetadata-ui/src/main/resources/ui/src/utils/DatabaseSchemaTabsUtils.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/DatabaseSchemaTabsUtils.tsx
@@ -12,21 +12,21 @@
  */
 import { get } from 'lodash';
 import { lazy } from 'react';
-import { ActivityFeedLayoutType } from '../components/ActivityFeed/ActivityFeedTab/ActivityFeedTab.interface';
+import type { ActivityFeedLayoutType } from '../components/ActivityFeed/ActivityFeedTab/ActivityFeedTab.interface';
 import withSuspenseFallback from '../components/AppRouter/withSuspenseFallback';
 import type {
   CustomPropertyProps,
   ExtentionEntitiesKeys,
 } from '../components/common/CustomPropertyTable/CustomPropertyTable.interface';
 import TabsLabel from '../components/common/TabsLabel/TabsLabel.component';
-import { TabProps } from '../components/common/TabsLabel/TabsLabel.interface';
+import type { TabProps } from '../components/common/TabsLabel/TabsLabel.interface';
 import { GenericTab } from '../components/Customization/GenericTab/GenericTab';
 import { CommonWidgets } from '../components/DataAssets/CommonWidgets/CommonWidgets';
 import { DetailPageWidgetKeys } from '../enums/CustomizeDetailPage.enum';
 import { EntityTabs, EntityType } from '../enums/entity.enum';
 import { PageType } from '../generated/system/ui/page';
-import { WidgetConfig } from '../pages/CustomizablePage/CustomizablePage.interface';
-import { DatabaseSchemaPageTabProps } from './DatabaseSchemaClassBase';
+import type { WidgetConfig } from '../pages/CustomizablePage/CustomizablePage.interface';
+import type { DatabaseSchemaPageTabProps } from './DatabaseSchemaClassBase';
 import { t } from './i18next/LocalUtil';
 
 const CustomPropertyTable = withSuspenseFallback(

--- a/openmetadata-ui/src/main/resources/ui/src/utils/DomainFilterUtils.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/DomainFilterUtils.ts
@@ -1,0 +1,277 @@
+/*
+ *  Copyright 2025 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+import { EntityType } from '../enums/entity.enum';
+import { Domain } from '../generated/entity/domains/domain';
+import { EntityReference } from '../generated/entity/type';
+import {
+  QueryFieldInterface,
+  QueryFilterInterface,
+} from '../pages/ExplorePage/ExplorePage.interface';
+import { getEntityReferenceFromEntity } from './EntityUtils';
+
+export const getQueryFilterToIncludeDomain = (
+  domainFqn: string,
+  dataProductFqn: string
+) => ({
+  query: {
+    bool: {
+      must: [
+        {
+          term: {
+            'domains.fullyQualifiedName': domainFqn,
+          },
+        },
+        {
+          bool: {
+            must_not: [
+              {
+                term: {
+                  'dataProducts.fullyQualifiedName': dataProductFqn,
+                },
+              },
+            ],
+          },
+        },
+        {
+          bool: {
+            must_not: [
+              {
+                terms: {
+                  entityType: [
+                    EntityType.DATA_PRODUCT,
+                    EntityType.TEST_SUITE,
+                    EntityType.QUERY,
+                    EntityType.TEST_CASE,
+                    EntityType.TABLE_COLUMN,
+                  ],
+                },
+              },
+            ],
+          },
+        },
+      ],
+    },
+  },
+});
+
+export const getQueryFilterToExcludeDomainTerms = (
+  fqn: string,
+  parentFqn?: string
+): QueryFilterInterface => {
+  const mustTerm: QueryFieldInterface[] = parentFqn
+    ? [
+        {
+          term: {
+            'domains.fullyQualifiedName': parentFqn,
+          },
+        },
+      ]
+    : [];
+
+  return {
+    query: {
+      bool: {
+        must: mustTerm.concat([
+          {
+            bool: {
+              must_not: [
+                {
+                  term: {
+                    'domains.fullyQualifiedName': fqn,
+                  },
+                },
+              ],
+            },
+          },
+          {
+            bool: {
+              must_not: [
+                {
+                  terms: {
+                    entityType: [EntityType.TABLE_COLUMN],
+                  },
+                },
+              ],
+            },
+          },
+        ]),
+      },
+    },
+  };
+};
+
+/**
+ * Returns an Elasticsearch query filter for fetching assets belonging to a domain,
+ * excluding DataProduct entities. Use this for general domain asset listings.
+ * @param domainFqn - The fully qualified name of the domain
+ */
+export const getQueryFilterForDomain = (domainFqn: string) => {
+  if (!domainFqn) {
+    return { query: { match_none: {} } };
+  }
+
+  return {
+    query: {
+      bool: {
+        must: [
+          {
+            bool: {
+              should: [
+                {
+                  term: {
+                    'domains.fullyQualifiedName': domainFqn,
+                  },
+                },
+                {
+                  prefix: {
+                    'domains.fullyQualifiedName': `${domainFqn}.`,
+                  },
+                },
+              ],
+            },
+          },
+        ],
+        must_not: [
+          {
+            terms: {
+              entityType: [EntityType.DATA_PRODUCT, EntityType.TABLE_COLUMN],
+            },
+          },
+        ],
+      },
+    },
+  };
+};
+
+/**
+ * Returns an Elasticsearch query filter for fetching DataProduct entities within a domain.
+ * Unlike getQueryFilterForDomain, this does not exclude any entity types.
+ * @param domainFqn - The fully qualified name of the domain
+ */
+export const getQueryFilterForDataProducts = (domainFqn: string) => {
+  if (!domainFqn) {
+    return { query: { match_none: {} } };
+  }
+
+  return {
+    query: {
+      bool: {
+        must: [
+          {
+            bool: {
+              should: [
+                {
+                  term: {
+                    'domains.fullyQualifiedName': domainFqn,
+                  },
+                },
+                {
+                  prefix: {
+                    'domains.fullyQualifiedName': `${domainFqn}.`,
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
+    },
+  };
+};
+
+/**
+ * Recursively checks if a domain exists in the hierarchy
+ * @param domain The domain to search in
+ * @param searchDomain The domain to search for
+ * @returns boolean indicating if the domain exists
+ */
+export const isDomainExist = (
+  domain: Domain,
+  searchDomainFqn: string
+): boolean => {
+  if (domain.fullyQualifiedName === searchDomainFqn) {
+    return true;
+  }
+
+  if (domain.children?.length) {
+    return domain.children.some((child) =>
+      isDomainExist(child as unknown as Domain, searchDomainFqn)
+    );
+  }
+
+  return false;
+};
+
+export const initializeDomainEntityRef = (
+  domains: EntityReference[],
+  activeDomainKey: string
+) => {
+  const domain = domains.find((item) => {
+    return item.fullyQualifiedName === activeDomainKey;
+  });
+  if (domain) {
+    return getEntityReferenceFromEntity(domain, EntityType.DOMAIN);
+  }
+
+  return undefined;
+};
+
+export const domainBuildESQuery = (
+  filters: Record<string, string[]>,
+  baseFilter?: string
+): Record<string, unknown> => {
+  let query = baseFilter ? JSON.parse(baseFilter) : null;
+
+  if (!query) {
+    query = {
+      query: {
+        bool: {
+          must: [],
+        },
+      },
+    };
+  }
+
+  if (!query.query) {
+    query.query = { bool: { must: [] } };
+  }
+  if (!query.query.bool) {
+    query.query.bool = { must: [] };
+  }
+  if (!query.query.bool.must) {
+    query.query.bool.must = [];
+  }
+
+  for (const [filterKey, values] of Object.entries(filters)) {
+    if (!values || values.length === 0) {
+      continue;
+    }
+
+    if (values.length === 1) {
+      query.query.bool.must.push({
+        term: {
+          [filterKey]: values[0],
+        },
+      });
+    } else {
+      query.query.bool.must.push({
+        terms: {
+          [filterKey]: values,
+        },
+      });
+    }
+  }
+
+  return query;
+};

--- a/openmetadata-ui/src/main/resources/ui/src/utils/DomainFilterUtils.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/DomainFilterUtils.ts
@@ -12,9 +12,9 @@
  */
 
 import { EntityType } from '../enums/entity.enum';
-import { Domain } from '../generated/entity/domains/domain';
-import { EntityReference } from '../generated/entity/type';
-import {
+import type { Domain } from '../generated/entity/domains/domain';
+import type { EntityReference } from '../generated/entity/type';
+import type {
   QueryFieldInterface,
   QueryFilterInterface,
 } from '../pages/ExplorePage/ExplorePage.interface';

--- a/openmetadata-ui/src/main/resources/ui/src/utils/DomainUtils.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/DomainUtils.tsx
@@ -136,7 +136,6 @@ export const renderDomainLink = (
   );
 };
 
-
 export const convertDomainsToTreeOptions = (
   options: EntityReference[] | Domain[] = [],
   level = 0,
@@ -194,7 +193,6 @@ export const convertDomainsToTreeOptions = (
 
   return treeData;
 };
-
 
 export const getDomainDetailTabs = ({
   domain,
@@ -425,4 +423,3 @@ export const getDomainIcon = (iconURL?: string) => {
   // Otherwise return the default domain icon
   return <DomainIcon className="domain-default-icon" />;
 };
-

--- a/openmetadata-ui/src/main/resources/ui/src/utils/DomainUtils.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/DomainUtils.tsx
@@ -43,12 +43,17 @@ import { Operation } from '../generated/entity/policies/policy';
 import { EntityReference } from '../generated/entity/type';
 import { PageType } from '../generated/system/ui/page';
 import { WidgetConfig } from '../pages/CustomizablePage/CustomizablePage.interface';
-import {
-  QueryFieldInterface,
-  QueryFilterInterface,
-} from '../pages/ExplorePage/ExplorePage.interface';
 import { DomainDetailPageTabProps } from './Domain/DomainClassBase';
-import { getEntityName, getEntityReferenceFromEntity } from './EntityUtils';
+import {
+  domainBuildESQuery,
+  getQueryFilterForDataProducts,
+  getQueryFilterForDomain,
+  getQueryFilterToExcludeDomainTerms,
+  getQueryFilterToIncludeDomain,
+  initializeDomainEntityRef,
+  isDomainExist,
+} from './DomainFilterUtils';
+import { getEntityName } from './EntityUtils';
 import { t } from './i18next/LocalUtil';
 import { renderIcon } from './IconUtils';
 import {
@@ -57,174 +62,14 @@ import {
 } from './PermissionsUtils';
 import { getDomainPath } from './RouterUtils';
 
-export const getQueryFilterToIncludeDomain = (
-  domainFqn: string,
-  dataProductFqn: string
-) => ({
-  query: {
-    bool: {
-      must: [
-        {
-          term: {
-            'domains.fullyQualifiedName': domainFqn,
-          },
-        },
-        {
-          bool: {
-            must_not: [
-              {
-                term: {
-                  'dataProducts.fullyQualifiedName': dataProductFqn,
-                },
-              },
-            ],
-          },
-        },
-        {
-          bool: {
-            must_not: [
-              {
-                terms: {
-                  entityType: [
-                    EntityType.DATA_PRODUCT,
-                    EntityType.TEST_SUITE,
-                    EntityType.QUERY,
-                    EntityType.TEST_CASE,
-                    EntityType.TABLE_COLUMN,
-                  ],
-                },
-              },
-            ],
-          },
-        },
-      ],
-    },
-  },
-});
-
-export const getQueryFilterToExcludeDomainTerms = (
-  fqn: string,
-  parentFqn?: string
-): QueryFilterInterface => {
-  const mustTerm: QueryFieldInterface[] = parentFqn
-    ? [
-        {
-          term: {
-            'domains.fullyQualifiedName': parentFqn,
-          },
-        },
-      ]
-    : [];
-
-  return {
-    query: {
-      bool: {
-        must: mustTerm.concat([
-          {
-            bool: {
-              must_not: [
-                {
-                  term: {
-                    'domains.fullyQualifiedName': fqn,
-                  },
-                },
-              ],
-            },
-          },
-          {
-            bool: {
-              must_not: [
-                {
-                  terms: {
-                    entityType: [EntityType.TABLE_COLUMN],
-                  },
-                },
-              ],
-            },
-          },
-        ]),
-      },
-    },
-  };
-};
-
-/**
- * Returns an Elasticsearch query filter for fetching assets belonging to a domain,
- * excluding DataProduct entities. Use this for general domain asset listings.
- * @param domainFqn - The fully qualified name of the domain
- */
-export const getQueryFilterForDomain = (domainFqn: string) => {
-  if (!domainFqn) {
-    return { query: { match_none: {} } };
-  }
-
-  return {
-    query: {
-      bool: {
-        must: [
-          {
-            bool: {
-              should: [
-                {
-                  term: {
-                    'domains.fullyQualifiedName': domainFqn,
-                  },
-                },
-                {
-                  prefix: {
-                    'domains.fullyQualifiedName': `${domainFqn}.`,
-                  },
-                },
-              ],
-            },
-          },
-        ],
-        must_not: [
-          {
-            terms: {
-              entityType: [EntityType.DATA_PRODUCT, EntityType.TABLE_COLUMN],
-            },
-          },
-        ],
-      },
-    },
-  };
-};
-
-/**
- * Returns an Elasticsearch query filter for fetching DataProduct entities within a domain.
- * Unlike getQueryFilterForDomain, this does not exclude any entity types.
- * @param domainFqn - The fully qualified name of the domain
- */
-export const getQueryFilterForDataProducts = (domainFqn: string) => {
-  if (!domainFqn) {
-    return { query: { match_none: {} } };
-  }
-
-  return {
-    query: {
-      bool: {
-        must: [
-          {
-            bool: {
-              should: [
-                {
-                  term: {
-                    'domains.fullyQualifiedName': domainFqn,
-                  },
-                },
-                {
-                  prefix: {
-                    'domains.fullyQualifiedName': `${domainFqn}.`,
-                  },
-                },
-              ],
-            },
-          },
-        ],
-      },
-    },
-  };
+export {
+  domainBuildESQuery,
+  getQueryFilterForDataProducts,
+  getQueryFilterForDomain,
+  getQueryFilterToExcludeDomainTerms,
+  getQueryFilterToIncludeDomain,
+  initializeDomainEntityRef,
+  isDomainExist,
 };
 
 // Domain type description which will be shown in tooltip
@@ -291,19 +136,6 @@ export const renderDomainLink = (
   );
 };
 
-export const initializeDomainEntityRef = (
-  domains: EntityReference[],
-  activeDomainKey: string
-) => {
-  const domain = domains.find((item) => {
-    return item.fullyQualifiedName === activeDomainKey;
-  });
-  if (domain) {
-    return getEntityReferenceFromEntity(domain, EntityType.DOMAIN);
-  }
-
-  return undefined;
-};
 
 export const convertDomainsToTreeOptions = (
   options: EntityReference[] | Domain[] = [],
@@ -363,28 +195,6 @@ export const convertDomainsToTreeOptions = (
   return treeData;
 };
 
-/**
- * Recursively checks if a domain exists in the hierarchy
- * @param domain The domain to search in
- * @param searchDomain The domain to search for
- * @returns boolean indicating if the domain exists
- */
-export const isDomainExist = (
-  domain: Domain,
-  searchDomainFqn: string
-): boolean => {
-  if (domain.fullyQualifiedName === searchDomainFqn) {
-    return true;
-  }
-
-  if (domain.children?.length) {
-    return domain.children.some((child) =>
-      isDomainExist(child as unknown as Domain, searchDomainFqn)
-    );
-  }
-
-  return false;
-};
 
 export const getDomainDetailTabs = ({
   domain,
@@ -616,51 +426,3 @@ export const getDomainIcon = (iconURL?: string) => {
   return <DomainIcon className="domain-default-icon" />;
 };
 
-export const domainBuildESQuery = (
-  filters: Record<string, string[]>,
-  baseFilter?: string
-): Record<string, unknown> => {
-  let query = baseFilter ? JSON.parse(baseFilter) : null;
-
-  if (!query) {
-    query = {
-      query: {
-        bool: {
-          must: [],
-        },
-      },
-    };
-  }
-
-  if (!query.query) {
-    query.query = { bool: { must: [] } };
-  }
-  if (!query.query.bool) {
-    query.query.bool = { must: [] };
-  }
-  if (!query.query.bool.must) {
-    query.query.bool.must = [];
-  }
-
-  for (const [filterKey, values] of Object.entries(filters)) {
-    if (!values || values.length === 0) {
-      continue;
-    }
-
-    if (values.length === 1) {
-      query.query.bool.must.push({
-        term: {
-          [filterKey]: values[0],
-        },
-      });
-    } else {
-      query.query.bool.must.push({
-        terms: {
-          [filterKey]: values,
-        },
-      });
-    }
-  }
-
-  return query;
-};

--- a/openmetadata-ui/src/main/resources/ui/src/utils/IngestionConfigUtils.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/IngestionConfigUtils.ts
@@ -43,7 +43,7 @@ import {
   getSettingPath,
   getSettingsPathWithFqn,
 } from './RouterUtils';
-import { getDayCron } from './SchedularUtils';
+import { getDayCron } from './CronExpressionUtils';
 import { getFilteredSchema } from './ServiceConnectionUtils';
 import serviceUtilClassBase from './ServiceUtilClassBase';
 import {

--- a/openmetadata-ui/src/main/resources/ui/src/utils/IngestionConfigUtils.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/IngestionConfigUtils.ts
@@ -12,7 +12,7 @@
  */
 
 import { isEmpty, isUndefined, startCase, uniq } from 'lodash';
-import { ServicesUpdateRequest, ServiceTypes } from 'Models';
+import type { ServicesUpdateRequest, ServiceTypes } from 'Models';
 import {
   GlobalSettingOptions,
   GlobalSettingsMenuCategory,
@@ -28,14 +28,14 @@ import { EntityTabs } from '../enums/entity.enum';
 import { ServiceAgentSubTabs, ServiceCategory } from '../enums/service.enum';
 import { ServiceConnectionFilterPatternFields } from '../enums/ServiceConnection.enum';
 import { PipelineType } from '../generated/api/services/ingestionPipelines/createIngestionPipeline';
-import { HiveMetastoreConnectionDetails as Connection } from '../generated/entity/services/databaseService';
+import type { HiveMetastoreConnectionDetails as Connection } from '../generated/entity/services/databaseService';
 import {
-  IngestionPipeline,
   PipelineState,
-  StepSummary,
+  type IngestionPipeline,
+  type StepSummary,
 } from '../generated/entity/services/ingestionPipelines/ingestionPipeline';
-import { SearchSourceAlias } from '../interface/search.interface';
-import { DataObj, ServicesType } from '../interface/service.interface';
+import type { SearchSourceAlias } from '../interface/search.interface';
+import type { DataObj, ServicesType } from '../interface/service.interface';
 import { getDayCron } from './CronExpressionUtils';
 import i18n from './i18next/LocalUtil';
 import { getSchemaByWorkflowType } from './IngestionWorkflowUtils';

--- a/openmetadata-ui/src/main/resources/ui/src/utils/IngestionConfigUtils.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/IngestionConfigUtils.ts
@@ -36,6 +36,7 @@ import {
 } from '../generated/entity/services/ingestionPipelines/ingestionPipeline';
 import { SearchSourceAlias } from '../interface/search.interface';
 import { DataObj, ServicesType } from '../interface/service.interface';
+import { getDayCron } from './CronExpressionUtils';
 import i18n from './i18next/LocalUtil';
 import { getSchemaByWorkflowType } from './IngestionWorkflowUtils';
 import {
@@ -43,13 +44,12 @@ import {
   getSettingPath,
   getSettingsPathWithFqn,
 } from './RouterUtils';
-import { getDayCron } from './CronExpressionUtils';
 import { getFilteredSchema } from './ServiceConnectionUtils';
-import serviceUtilClassBase from './ServiceUtilClassBase';
 import {
   getReadableCountString,
   getServiceRouteFromServiceType,
 } from './ServicePureUtils';
+import serviceUtilClassBase from './ServiceUtilClassBase';
 
 export const getIngestionHeadingName = (
   ingestionType: string,
@@ -261,9 +261,7 @@ export const getDefaultFilterPropertyValues = ({
 }) => {
   if (isEditMode) {
     return getFilteredSchema(
-      ingestionData?.sourceConfig.config as
-        | Record<string, unknown>
-        | undefined,
+      ingestionData?.sourceConfig.config as Record<string, unknown> | undefined,
       false
     );
   } else {

--- a/openmetadata-ui/src/main/resources/ui/src/utils/IngestionConfigUtils.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/IngestionConfigUtils.ts
@@ -1,0 +1,321 @@
+/*
+ *  Copyright 2025 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+import { isEmpty, isUndefined, startCase, uniq } from 'lodash';
+import { ServicesUpdateRequest, ServiceTypes } from 'Models';
+import {
+  GlobalSettingOptions,
+  GlobalSettingsMenuCategory,
+} from '../constants/GlobalSettings.constants';
+import {
+  INGESTION_ACTION_TYPE,
+  PIPELINE_TYPE_LOCALIZATION,
+} from '../constants/Ingestions.constant';
+import { SERVICE_FILTER_PATTERN_FIELDS } from '../constants/ServiceConnection.constants';
+import { SERVICE_INGESTION_PIPELINE_TYPES } from '../constants/Services.constant';
+import { ELASTIC_SEARCH_RE_INDEX_PAGE_TABS } from '../enums/ElasticSearch.enum';
+import { EntityTabs } from '../enums/entity.enum';
+import { ServiceAgentSubTabs, ServiceCategory } from '../enums/service.enum';
+import { ServiceConnectionFilterPatternFields } from '../enums/ServiceConnection.enum';
+import { PipelineType } from '../generated/api/services/ingestionPipelines/createIngestionPipeline';
+import { HiveMetastoreConnectionDetails as Connection } from '../generated/entity/services/databaseService';
+import {
+  IngestionPipeline,
+  PipelineState,
+  StepSummary,
+} from '../generated/entity/services/ingestionPipelines/ingestionPipeline';
+import { SearchSourceAlias } from '../interface/search.interface';
+import { DataObj, ServicesType } from '../interface/service.interface';
+import i18n from './i18next/LocalUtil';
+import { getSchemaByWorkflowType } from './IngestionWorkflowUtils';
+import {
+  getServiceDetailsPath,
+  getSettingPath,
+  getSettingsPathWithFqn,
+} from './RouterUtils';
+import { getDayCron } from './SchedularUtils';
+import { getFilteredSchema } from './ServiceConnectionUtils';
+import serviceUtilClassBase from './ServiceUtilClassBase';
+import {
+  getReadableCountString,
+  getServiceRouteFromServiceType,
+} from './ServicePureUtils';
+
+export const getIngestionHeadingName = (
+  ingestionType: string,
+  type: string
+) => {
+  const ingestionName = i18n.t(
+    `label.${
+      PIPELINE_TYPE_LOCALIZATION[
+        ingestionType as keyof typeof PIPELINE_TYPE_LOCALIZATION
+      ]
+    }`
+  );
+
+  return type === INGESTION_ACTION_TYPE.ADD
+    ? i18n.t('label.add-workflow-agent', {
+        workflow: ingestionName,
+      })
+    : i18n.t('label.edit-workflow-agent', {
+        workflow: ingestionName,
+      });
+};
+
+export const getSettingsPathFromPipelineType = (pipelineType: string) => {
+  switch (pipelineType) {
+    case PipelineType.DataInsight: {
+      return getSettingPath(
+        GlobalSettingsMenuCategory.PREFERENCES,
+        GlobalSettingOptions.DATA_INSIGHT
+      );
+    }
+    case PipelineType.ElasticSearchReindex:
+    default: {
+      return getSettingsPathWithFqn(
+        GlobalSettingsMenuCategory.PREFERENCES,
+        GlobalSettingOptions.SEARCH,
+        ELASTIC_SEARCH_RE_INDEX_PAGE_TABS.SCHEDULE
+      );
+    }
+  }
+};
+
+export const getBreadCrumbsArray = (
+  isSettingsPipeline: boolean,
+  ingestionType: string,
+  serviceCategory: string,
+  serviceFQN: string,
+  type: string,
+  serviceData?: DataObj
+) => {
+  const breadCrumbsArray = [];
+
+  if (isSettingsPipeline) {
+    breadCrumbsArray.push({
+      name: startCase(ingestionType),
+      url: getSettingsPathFromPipelineType(ingestionType),
+      activeTitle: true,
+    });
+  } else {
+    breadCrumbsArray.push(
+      ...[
+        {
+          name: startCase(serviceCategory),
+          url: getSettingPath(
+            GlobalSettingsMenuCategory.SERVICES,
+            getServiceRouteFromServiceType(serviceCategory as ServiceTypes)
+          ),
+        },
+        {
+          name: serviceData?.name || '',
+          url: getServiceDetailsPath(
+            serviceFQN,
+            serviceCategory,
+            EntityTabs.AGENTS,
+            ServiceAgentSubTabs.METADATA
+          ),
+          imgSrc: serviceUtilClassBase.getServiceTypeLogo(
+            serviceData as SearchSourceAlias
+          ),
+          activeTitle: true,
+        },
+      ]
+    );
+  }
+
+  breadCrumbsArray.push({
+    name: getIngestionHeadingName(ingestionType, type),
+    url: '',
+    activeTitle: true,
+  });
+
+  return breadCrumbsArray;
+};
+
+export const getSupportedPipelineTypes = (
+  serviceDetails: ServicesType,
+  serviceCategory?: ServiceCategory
+) => {
+  const pipelineType: PipelineType[] = [];
+  const config = serviceDetails?.connection?.config as Connection;
+
+  if (isUndefined(config)) {
+    return [PipelineType.Metadata];
+  }
+
+  const pipelineMapping: { [key: string]: PipelineType[] } = {
+    supportsMetadataExtraction: [PipelineType.Metadata],
+    supportsUsageExtraction: [PipelineType.Usage],
+    supportsLineageExtraction: [PipelineType.Lineage],
+    supportsViewLineageExtraction: [PipelineType.Lineage],
+    supportsProfiler: [PipelineType.Profiler, PipelineType.AutoClassification],
+    supportsDBTExtraction: [PipelineType.Dbt],
+    supportsDataInsightExtraction: [PipelineType.DataInsight],
+    supportsElasticSearchReindexingExtraction: [
+      PipelineType.ElasticSearchReindex,
+    ],
+  };
+
+  Object.keys(pipelineMapping).forEach((key) => {
+    if (config[key as keyof Connection]) {
+      let types = pipelineMapping[key];
+
+      if (
+        key === 'supportsProfiler' &&
+        serviceCategory === ServiceCategory.STORAGE_SERVICES
+      ) {
+        types = [PipelineType.AutoClassification];
+      }
+
+      pipelineType.push(...types);
+    }
+  });
+
+  return uniq(pipelineType);
+};
+
+export const getIngestionTypes = (
+  supportedPipelineTypes: PipelineType[],
+  ingestionList: IngestionPipeline[],
+  pipelineType?: PipelineType
+) => {
+  const pipelineTypeArray = isUndefined(pipelineType)
+    ? supportedPipelineTypes
+    : [pipelineType];
+
+  return pipelineTypeArray.reduce((prev, curr) => {
+    if (
+      // Prevent adding multiple usage pipeline
+      curr === PipelineType.Usage &&
+      ingestionList.find((d) => d.pipelineType === curr)
+    ) {
+      return prev;
+    } else {
+      return [...prev, curr];
+    }
+  }, [] as PipelineType[]);
+};
+
+export const getDefaultIngestionSchedule = ({
+  isEditMode = false,
+  scheduleInterval,
+  defaultSchedule,
+}: {
+  isEditMode?: boolean;
+  scheduleInterval?: string;
+  defaultSchedule?: string;
+}) => {
+  if (isEditMode) {
+    return scheduleInterval;
+  }
+
+  if (!isEmpty(scheduleInterval)) {
+    return scheduleInterval;
+  }
+
+  return (
+    defaultSchedule ??
+    getDayCron({
+      min: '0',
+      hour: '0',
+    })
+  );
+};
+
+export const getDefaultFilterPropertyFieldsFromSchema = (
+  pipelineType: PipelineType,
+  serviceCategory: ServiceCategory
+) => {
+  const pipelineSchema = getSchemaByWorkflowType(pipelineType, serviceCategory);
+
+  return Object.keys(pipelineSchema.properties ?? {}).filter((key) =>
+    SERVICE_FILTER_PATTERN_FIELDS.includes(
+      key as ServiceConnectionFilterPatternFields
+    )
+  );
+};
+
+export const getDefaultFilterPropertyValues = ({
+  pipelineType,
+  serviceCategory,
+  isEditMode,
+  ingestionData,
+  serviceData,
+}: {
+  pipelineType: PipelineType;
+  serviceCategory: ServiceCategory;
+  isEditMode: boolean;
+  ingestionData?: IngestionPipeline;
+  serviceData?: ServicesUpdateRequest;
+}) => {
+  if (isEditMode) {
+    return getFilteredSchema(
+      ingestionData?.sourceConfig.config as
+        | Record<string, unknown>
+        | undefined,
+      false
+    );
+  } else {
+    const filterPropertiesInSchema = getDefaultFilterPropertyFieldsFromSchema(
+      pipelineType,
+      serviceCategory
+    );
+
+    const filterValues = getFilteredSchema(
+      serviceData?.connection?.config,
+      false
+    );
+
+    return Object.entries(filterValues).reduce((acc, [key, value]) => {
+      if (filterPropertiesInSchema.includes(key)) {
+        acc[key] = value;
+      }
+
+      return acc;
+    }, {} as Record<string, unknown>);
+  }
+};
+
+export const getTypeAndStatusMenuItems = () => {
+  const typeMenuItems = SERVICE_INGESTION_PIPELINE_TYPES.map((type) => ({
+    label: startCase(type),
+    key: type,
+    ['data-testid']: `type-menu-item-${type}`,
+  }));
+  const statusMenuItems = Object.values(PipelineState).map((status) => ({
+    label: startCase(status),
+    key: status,
+    ['data-testid']: `status-menu-item-${status}`,
+  }));
+
+  return { typeMenuItems, statusMenuItems };
+};
+
+export const getIngestionStatusCountData = (summary?: StepSummary) => [
+  {
+    label: i18n.t('label.success'),
+    value: getReadableCountString(summary?.records ?? 0, 1),
+    type: 'success',
+  },
+  {
+    label: i18n.t('label.failed'),
+    value: getReadableCountString(summary?.errors ?? 0, 1),
+    type: 'failed',
+  },
+  {
+    label: i18n.t('label.warning'),
+    value: getReadableCountString(summary?.warnings ?? 0, 1),
+    type: 'warning',
+  },
+];

--- a/openmetadata-ui/src/main/resources/ui/src/utils/IngestionUtils.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/IngestionUtils.tsx
@@ -12,8 +12,6 @@
  */
 
 import { Typography } from 'antd';
-import { isEmpty, isUndefined, startCase, uniq } from 'lodash';
-import { ServicesUpdateRequest, ServiceTypes } from 'Models';
 import ErrorPlaceHolder from '../components/common/ErrorWithPlaceholder/ErrorPlaceHolder';
 import {
   DATA_INSIGHTS_PIPELINE_DOCS,
@@ -21,204 +19,39 @@ import {
   INGESTION_FRAMEWORK_DEPLOYMENT_DOCS,
   WORKFLOWS_METADATA_DOCS,
 } from '../constants/docs.constants';
-import {
-  GlobalSettingOptions,
-  GlobalSettingsMenuCategory,
-} from '../constants/GlobalSettings.constants';
-import {
-  INGESTION_ACTION_TYPE,
-  PIPELINE_TYPE_LOCALIZATION,
-} from '../constants/Ingestions.constant';
-import { SERVICE_FILTER_PATTERN_FIELDS } from '../constants/ServiceConnection.constants';
-import { SERVICE_INGESTION_PIPELINE_TYPES } from '../constants/Services.constant';
+import { PIPELINE_TYPE_LOCALIZATION } from '../constants/Ingestions.constant';
 import { ERROR_PLACEHOLDER_TYPE } from '../enums/common.enum';
-import { ELASTIC_SEARCH_RE_INDEX_PAGE_TABS } from '../enums/ElasticSearch.enum';
-import { EntityTabs } from '../enums/entity.enum';
 import { FormSubmitType } from '../enums/form.enum';
-import { ServiceAgentSubTabs, ServiceCategory } from '../enums/service.enum';
-import { ServiceConnectionFilterPatternFields } from '../enums/ServiceConnection.enum';
 import { PipelineType } from '../generated/api/services/ingestionPipelines/createIngestionPipeline';
 import { UIThemePreference } from '../generated/configuration/uiThemePreference';
-import { HiveMetastoreConnectionDetails as Connection } from '../generated/entity/services/databaseService';
-import {
-  IngestionPipeline,
-  PipelineState,
-  StepSummary,
-} from '../generated/entity/services/ingestionPipelines/ingestionPipeline';
-import { SearchSourceAlias } from '../interface/search.interface';
-import { DataObj, ServicesType } from '../interface/service.interface';
 import i18n, { Transi18next } from './i18next/LocalUtil';
-import { getSchemaByWorkflowType } from './IngestionWorkflowUtils';
 import {
-  getServiceDetailsPath,
-  getSettingPath,
-  getSettingsPathWithFqn,
-} from './RouterUtils';
-import { getDayCron } from './SchedularUtils';
-import { getFilteredSchema } from './ServiceConnectionUtils';
-import serviceUtilClassBase from './ServiceUtilClassBase';
-import {
-  getReadableCountString,
-  getServiceRouteFromServiceType,
-} from './ServiceUtils';
+  getBreadCrumbsArray,
+  getDefaultFilterPropertyFieldsFromSchema,
+  getDefaultFilterPropertyValues,
+  getDefaultIngestionSchedule,
+  getIngestionHeadingName,
+  getIngestionStatusCountData,
+  getIngestionTypes,
+  getSettingsPathFromPipelineType,
+  getSupportedPipelineTypes,
+  getTypeAndStatusMenuItems,
+} from './IngestionConfigUtils';
+
+export {
+  getBreadCrumbsArray,
+  getDefaultFilterPropertyFieldsFromSchema,
+  getDefaultFilterPropertyValues,
+  getDefaultIngestionSchedule,
+  getIngestionHeadingName,
+  getIngestionStatusCountData,
+  getIngestionTypes,
+  getSettingsPathFromPipelineType,
+  getSupportedPipelineTypes,
+  getTypeAndStatusMenuItems,
+};
 
 const { t } = i18n;
-
-export const getIngestionHeadingName = (
-  ingestionType: string,
-  type: string
-) => {
-  const ingestionName = t(
-    `label.${
-      PIPELINE_TYPE_LOCALIZATION[
-        ingestionType as keyof typeof PIPELINE_TYPE_LOCALIZATION
-      ]
-    }`
-  );
-
-  return type === INGESTION_ACTION_TYPE.ADD
-    ? t('label.add-workflow-agent', {
-        workflow: ingestionName,
-      })
-    : t('label.edit-workflow-agent', {
-        workflow: ingestionName,
-      });
-};
-
-export const getSettingsPathFromPipelineType = (pipelineType: string) => {
-  switch (pipelineType) {
-    case PipelineType.DataInsight: {
-      return getSettingPath(
-        GlobalSettingsMenuCategory.PREFERENCES,
-        GlobalSettingOptions.DATA_INSIGHT
-      );
-    }
-    case PipelineType.ElasticSearchReindex:
-    default: {
-      return getSettingsPathWithFqn(
-        GlobalSettingsMenuCategory.PREFERENCES,
-        GlobalSettingOptions.SEARCH,
-        ELASTIC_SEARCH_RE_INDEX_PAGE_TABS.SCHEDULE
-      );
-    }
-  }
-};
-
-export const getBreadCrumbsArray = (
-  isSettingsPipeline: boolean,
-  ingestionType: string,
-  serviceCategory: string,
-  serviceFQN: string,
-  type: string,
-  serviceData?: DataObj
-) => {
-  const breadCrumbsArray = [];
-
-  if (isSettingsPipeline) {
-    breadCrumbsArray.push({
-      name: startCase(ingestionType),
-      url: getSettingsPathFromPipelineType(ingestionType),
-      activeTitle: true,
-    });
-  } else {
-    breadCrumbsArray.push(
-      ...[
-        {
-          name: startCase(serviceCategory),
-          url: getSettingPath(
-            GlobalSettingsMenuCategory.SERVICES,
-            getServiceRouteFromServiceType(serviceCategory as ServiceTypes)
-          ),
-        },
-        {
-          name: serviceData?.name || '',
-          url: getServiceDetailsPath(
-            serviceFQN,
-            serviceCategory,
-            EntityTabs.AGENTS,
-            ServiceAgentSubTabs.METADATA
-          ),
-          imgSrc: serviceUtilClassBase.getServiceTypeLogo(
-            serviceData as SearchSourceAlias
-          ),
-          activeTitle: true,
-        },
-      ]
-    );
-  }
-
-  breadCrumbsArray.push({
-    name: getIngestionHeadingName(ingestionType, type),
-    url: '',
-    activeTitle: true,
-  });
-
-  return breadCrumbsArray;
-};
-
-export const getSupportedPipelineTypes = (
-  serviceDetails: ServicesType,
-  serviceCategory?: ServiceCategory
-) => {
-  const pipelineType: PipelineType[] = [];
-  const config = serviceDetails?.connection?.config as Connection;
-
-  if (isUndefined(config)) {
-    return [PipelineType.Metadata];
-  }
-
-  const pipelineMapping: { [key: string]: PipelineType[] } = {
-    supportsMetadataExtraction: [PipelineType.Metadata],
-    supportsUsageExtraction: [PipelineType.Usage],
-    supportsLineageExtraction: [PipelineType.Lineage],
-    supportsViewLineageExtraction: [PipelineType.Lineage],
-    supportsProfiler: [PipelineType.Profiler, PipelineType.AutoClassification],
-    supportsDBTExtraction: [PipelineType.Dbt],
-    supportsDataInsightExtraction: [PipelineType.DataInsight],
-    supportsElasticSearchReindexingExtraction: [
-      PipelineType.ElasticSearchReindex,
-    ],
-  };
-
-  Object.keys(pipelineMapping).forEach((key) => {
-    if (config[key as keyof Connection]) {
-      let types = pipelineMapping[key];
-
-      if (
-        key === 'supportsProfiler' &&
-        serviceCategory === ServiceCategory.STORAGE_SERVICES
-      ) {
-        types = [PipelineType.AutoClassification];
-      }
-
-      pipelineType.push(...types);
-    }
-  });
-
-  return uniq(pipelineType);
-};
-
-export const getIngestionTypes = (
-  supportedPipelineTypes: PipelineType[],
-  ingestionList: IngestionPipeline[],
-  pipelineType?: PipelineType
-) => {
-  const pipelineTypeArray = isUndefined(pipelineType)
-    ? supportedPipelineTypes
-    : [pipelineType];
-
-  return pipelineTypeArray.reduce((prev, curr) => {
-    if (
-      // Prevent adding multiple usage pipeline
-      curr === PipelineType.Usage &&
-      ingestionList.find((d) => d.pipelineType === curr)
-    ) {
-      return prev;
-    } else {
-      return [...prev, curr];
-    }
-  }, [] as PipelineType[]);
-};
 
 const getPipelineExtraInfo = (
   isPlatFormDisabled: boolean,
@@ -368,118 +201,3 @@ export const getSuccessMessage = (
   );
 };
 
-export const getDefaultIngestionSchedule = ({
-  isEditMode = false,
-  scheduleInterval,
-  defaultSchedule,
-}: {
-  isEditMode?: boolean;
-  scheduleInterval?: string;
-  defaultSchedule?: string;
-}) => {
-  // If it is edit mode, then return the schedule interval from the ingestion data
-  if (isEditMode) {
-    return scheduleInterval;
-  }
-
-  // If it is not edit mode and schedule interval is not empty, then return the schedule interval
-  if (!isEmpty(scheduleInterval)) {
-    return scheduleInterval;
-  }
-
-  // If it is not edit mode, then return the default schedule
-  return (
-    defaultSchedule ??
-    getDayCron({
-      min: '0',
-      hour: '0',
-    })
-  );
-};
-
-export const getDefaultFilterPropertyFieldsFromSchema = (
-  pipelineType: PipelineType,
-  serviceCategory: ServiceCategory
-) => {
-  const pipelineSchema = getSchemaByWorkflowType(pipelineType, serviceCategory);
-
-  return Object.keys(pipelineSchema.properties ?? {}).filter((key) =>
-    SERVICE_FILTER_PATTERN_FIELDS.includes(
-      key as ServiceConnectionFilterPatternFields
-    )
-  );
-};
-
-export const getDefaultFilterPropertyValues = ({
-  pipelineType,
-  serviceCategory,
-  isEditMode,
-  ingestionData,
-  serviceData,
-}: {
-  pipelineType: PipelineType;
-  serviceCategory: ServiceCategory;
-  isEditMode: boolean;
-  ingestionData?: IngestionPipeline;
-  serviceData?: ServicesUpdateRequest;
-}) => {
-  // If it is edit mode, then return the filter property values from the ingestion data
-  if (isEditMode) {
-    return getFilteredSchema(ingestionData?.sourceConfig.config, false);
-  } else {
-    // Get the default filter property fields from the schema
-    const filterPropertiesInSchema = getDefaultFilterPropertyFieldsFromSchema(
-      pipelineType,
-      serviceCategory
-    );
-
-    // Get the default filter values from the service data
-    const filterValues = getFilteredSchema(
-      serviceData?.connection?.config,
-      false
-    );
-
-    // Return the default filter property values from the service data only if
-    // the property is present in the ingestion schema
-    return Object.entries(filterValues).reduce((acc, [key, value]) => {
-      if (filterPropertiesInSchema.includes(key)) {
-        acc[key] = value;
-      }
-
-      return acc;
-    }, {} as Record<string, unknown>);
-  }
-};
-
-export const getTypeAndStatusMenuItems = () => {
-  const typeMenuItems = SERVICE_INGESTION_PIPELINE_TYPES.map((type) => ({
-    label: startCase(type),
-    key: type,
-    ['data-testid']: `type-menu-item-${type}`,
-  }));
-  const statusMenuItems = Object.values(PipelineState).map((status) => ({
-    label: startCase(status),
-    key: status,
-    ['data-testid']: `status-menu-item-${status}`,
-  }));
-
-  return { typeMenuItems, statusMenuItems };
-};
-
-export const getIngestionStatusCountData = (summary?: StepSummary) => [
-  {
-    label: t('label.success'),
-    value: getReadableCountString(summary?.records ?? 0, 1),
-    type: 'success',
-  },
-  {
-    label: t('label.failed'),
-    value: getReadableCountString(summary?.errors ?? 0, 1),
-    type: 'failed',
-  },
-  {
-    label: t('label.warning'),
-    value: getReadableCountString(summary?.warnings ?? 0, 1),
-    type: 'warning',
-  },
-];

--- a/openmetadata-ui/src/main/resources/ui/src/utils/IngestionUtils.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/IngestionUtils.tsx
@@ -200,4 +200,3 @@ export const getSuccessMessage = (
     </Typography.Text>
   );
 };
-

--- a/openmetadata-ui/src/main/resources/ui/src/utils/SchedularUtils.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/SchedularUtils.tsx
@@ -15,7 +15,6 @@ import { Select } from 'antd';
 import { CronOption } from '../components/Settings/Services/AddIngestion/Steps/ScheduleInterval.interface';
 import { CronTypes } from '../enums/Schedular.enum';
 import { FieldTypes, FormItemLayout } from '../interface/FormUtils.interface';
-import i18n from './i18next/LocalUtil';
 import {
   cronValidator,
   getCron,
@@ -35,6 +34,7 @@ import {
   getUpdatedStateFromFormState,
   getWeekCron,
 } from './CronExpressionUtils';
+import i18n from './i18next/LocalUtil';
 
 export {
   cronValidator,

--- a/openmetadata-ui/src/main/resources/ui/src/utils/SchedularUtils.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/SchedularUtils.tsx
@@ -12,156 +12,48 @@
  */
 
 import { Select } from 'antd';
-import { isUndefined, toNumber, toString } from 'lodash';
-
-import { RuleObject } from 'rc-field-form/es/interface';
-import {
-  Combination,
-  CronOption,
-  StateValue,
-  WorkflowExtraConfig,
-} from '../components/Settings/Services/AddIngestion/Steps/ScheduleInterval.interface';
-import {
-  CRON_COMBINATIONS,
-  DAY_OF_MONTH_PATTERN,
-  DAY_OF_WEEK_PATTERN,
-  DEFAULT_SCHEDULE_CRON_DAILY,
-  DEFAULT_SCHEDULE_CRON_HOURLY,
-  DEFAULT_SCHEDULE_CRON_MONTHLY,
-  DEFAULT_SCHEDULE_CRON_WEEKLY,
-  HOUR_PATTERN,
-  MINUTE_PATTERN,
-  MONTH_PATTERN,
-} from '../constants/Schedular.constants';
+import { CronOption } from '../components/Settings/Services/AddIngestion/Steps/ScheduleInterval.interface';
 import { CronTypes } from '../enums/Schedular.enum';
 import { FieldTypes, FormItemLayout } from '../interface/FormUtils.interface';
 import i18n from './i18next/LocalUtil';
+import {
+  cronValidator,
+  getCron,
+  getCronDefaultValue,
+  getDayCron,
+  getDefaultScheduleFromPeriod,
+  getDefaultScheduleValue,
+  getHourCron,
+  getHourOptions,
+  getMinuteCron,
+  getMinuteOptions,
+  getMonthCron,
+  getRange,
+  getRangeOptions,
+  getScheduleOptionsFromSchedules,
+  getStateValue,
+  getUpdatedStateFromFormState,
+  getWeekCron,
+} from './CronExpressionUtils';
 
-export const getScheduleOptionsFromSchedules = (
-  scheduleOptions: string[]
-): string[] => {
-  return scheduleOptions.map((scheduleOption) => {
-    switch (scheduleOption) {
-      case 'run_once':
-        return '';
-      case 'hourly':
-        return 'hour';
-      case 'daily':
-        return 'day';
-      case 'weekly':
-        return 'week';
-      case 'monthly':
-        return 'month';
-    }
-
-    return '';
-  });
-};
-
-export const getRange = (n: number) => {
-  return [...Array(n).keys()];
-};
-
-export const getRangeOptions = (n: number) => {
-  return getRange(n).map((v) => {
-    return {
-      label: `0${v}`.slice(-2),
-      value: toString(v),
-    };
-  });
-};
-
-export const getMinuteOptions = () => {
-  return getRangeOptions(60);
-};
-
-export const getHourOptions = () => {
-  return getRangeOptions(24);
-};
-
-export const getMinuteCron = (value: Partial<StateValue>) => {
-  return `*/${value.min} * * * *`;
-};
-
-export const getHourCron = (value: Partial<StateValue>) => {
-  return `${value.min} * * * *`;
-};
-
-export const getDayCron = (value: Partial<StateValue>) => {
-  return `${value.min} ${value.hour} * * *`;
-};
-
-export const getWeekCron = (value: Partial<StateValue>) => {
-  return `${value.min} ${value.hour} * * ${value.dow}`;
-};
-
-export const getMonthCron = (value: Partial<StateValue>) => {
-  return `${value.min} ${value.hour} ${value.dom} * ${value.dow}`;
-};
-
-export const getCron = (state: StateValue) => {
-  const { selectedPeriod, cron } = state;
-
-  switch (selectedPeriod) {
-    case 'hour':
-      return getHourCron(state);
-    case 'day':
-      return getDayCron(state);
-    case 'week':
-      return getWeekCron(state);
-    case 'month':
-      return getMonthCron(state);
-    default:
-      return cron;
-  }
-};
-
-const getCronType = (cronStr: string) => {
-  for (const c in CRON_COMBINATIONS) {
-    if (CRON_COMBINATIONS[c as keyof Combination].test(cronStr)) {
-      return c;
-    }
-  }
-
-  return 'custom';
-};
-
-export const getStateValue = (value?: string, defaultValue?: string) => {
-  const a = value?.split(' ');
-  const d = a ?? defaultValue?.split(' ') ?? [];
-
-  const min = d[0];
-  const hour = d[1];
-  const dom = d[2];
-  const dow = d[4];
-
-  const cronType = getCronType(value ?? defaultValue ?? '');
-
-  const stateVal: StateValue = {
-    selectedPeriod: cronType,
-    cron: value,
-    min,
-    hour,
-    dow,
-    dom,
-  };
-
-  return stateVal;
-};
-
-export const getCronDefaultValue = (appName: string) => {
-  const value = {
-    min: '0',
-    hour: '0',
-  };
-
-  let initialValue = getDayCron(value);
-
-  if (appName === 'DataInsightsReportApplication') {
-    initialValue = getWeekCron({ ...value, dow: '0' });
-  }
-
-  return initialValue;
+export {
+  cronValidator,
+  getCron,
+  getCronDefaultValue,
+  getDayCron,
+  getDefaultScheduleFromPeriod,
+  getDefaultScheduleValue,
+  getHourCron,
+  getHourOptions,
+  getMinuteCron,
+  getMinuteOptions,
+  getMonthCron,
+  getRange,
+  getRangeOptions,
+  getScheduleOptionsFromSchedules,
+  getStateValue,
+  getUpdatedStateFromFormState,
+  getWeekCron,
 };
 
 const getOptionComponent = () => {
@@ -191,171 +83,6 @@ export const getHourMinuteSelect = ({
     }
   />
 );
-
-export const getDefaultScheduleValue = ({
-  defaultSchedule,
-  includePeriodOptions,
-  allowNoSchedule = false,
-}: {
-  defaultSchedule?: string;
-  includePeriodOptions?: string[];
-  allowNoSchedule?: boolean;
-}) => {
-  if (isUndefined(includePeriodOptions)) {
-    return allowNoSchedule
-      ? defaultSchedule
-      : defaultSchedule || DEFAULT_SCHEDULE_CRON_DAILY;
-  }
-
-  // In case of include periodOptions are present
-  // but the default schedule is undefined and allowNoSchedule is true
-  // return the default schedule
-  if (allowNoSchedule && isUndefined(defaultSchedule)) {
-    return defaultSchedule;
-  }
-
-  return getDefaultScheduleFromPeriod(includePeriodOptions);
-};
-
-export const getDefaultScheduleFromPeriod = (
-  includePeriodOptions: string[]
-) => {
-  // By order, return the default schedule as day, week, month and hour as a last resort
-  // if none of the previous options are included
-  if (includePeriodOptions.includes('day')) {
-    return DEFAULT_SCHEDULE_CRON_DAILY;
-  } else if (includePeriodOptions.includes('week')) {
-    return DEFAULT_SCHEDULE_CRON_WEEKLY;
-  } else if (includePeriodOptions.includes('month')) {
-    return DEFAULT_SCHEDULE_CRON_MONTHLY;
-  } else if (includePeriodOptions.includes('hour')) {
-    return DEFAULT_SCHEDULE_CRON_HOURLY;
-  }
-
-  // return the fallback schedule as daily
-  return DEFAULT_SCHEDULE_CRON_DAILY;
-};
-
-// Function to update return updated state from form values
-export const getUpdatedStateFromFormState = <T,>(
-  currentState: StateValue,
-  formValues: StateValue & WorkflowExtraConfig & T
-) => {
-  try {
-    const newState = { ...currentState, ...formValues };
-    let { min, hour, dow, dom } = newState;
-
-    // min, hour values in a state should be a string
-    // which can be parsed to number to be a valid values for the
-    // respective cron select fields.
-    min = isNaN(toNumber(min)) ? '0' : min;
-    hour = isNaN(toNumber(hour)) ? '0' : hour;
-    const cronValue = newState.cron?.split(' ');
-
-    switch (newState.selectedPeriod) {
-      case 'week':
-        // For selected period week, dow should be a valid value i.e. a number string
-        // and the dom should be '*'
-        dow = isNaN(toNumber(dow)) ? '1' : dow;
-        dom = '*';
-
-        break;
-      case 'month':
-        // For selected period month, dom should be a valid value i.e. a number string
-        // and the dow should be '*'
-        dom = isNaN(toNumber(dom)) ? '1' : dom;
-        dow = '*';
-
-        break;
-      case 'custom':
-        // For selected period custom, change the min, hour, dom and dow values
-        // to the values parsed from the cron string
-        min = cronValue?.[0] ?? '0';
-        hour = cronValue?.[1] ?? '0';
-        dom = cronValue?.[2] ?? '*';
-        dow = cronValue?.[4] ?? '*';
-
-        break;
-    }
-
-    return {
-      ...newState,
-      min,
-      hour,
-      dow,
-      dom,
-    };
-  } catch {
-    return { ...currentState, ...formValues };
-  }
-};
-
-export const cronValidator = async (_: RuleObject, value: string) => {
-  const trimmedValue = value.trim();
-
-  // to avoid multiple validation errors
-  if (!trimmedValue) {
-    return;
-  }
-
-  const cronParts = trimmedValue.split(' ');
-
-  // Check if the cron expression has exactly 5 fields (standard Unix cron)
-
-  if (cronParts.length !== 5) {
-    return Promise.reject(
-      new Error(i18n.t('message.cron-invalid-field-count'))
-    );
-  }
-
-  // Validate that each field follows standard Unix cron format
-  const [minute, hour, dayOfMonth, month, dayOfWeek] = cronParts;
-
-  if (!MINUTE_PATTERN.test(minute)) {
-    return Promise.reject(
-      new Error(i18n.t('message.cron-invalid-minute-field'))
-    );
-  }
-  if (!HOUR_PATTERN.test(hour)) {
-    return Promise.reject(new Error(i18n.t('message.cron-invalid-hour-field')));
-  }
-  if (!DAY_OF_MONTH_PATTERN.test(dayOfMonth)) {
-    return Promise.reject(
-      new Error(i18n.t('message.cron-invalid-day-of-month-field'))
-    );
-  }
-  if (!MONTH_PATTERN.test(month)) {
-    return Promise.reject(
-      new Error(i18n.t('message.cron-invalid-month-field'))
-    );
-  }
-  if (!DAY_OF_WEEK_PATTERN.test(dayOfWeek)) {
-    return Promise.reject(
-      new Error(i18n.t('message.cron-invalid-day-of-week-field'))
-    );
-  }
-
-  try {
-    const cronstrue = (await import('cronstrue/i18n')).default;
-    // Check if cron is valid and get the description
-    const description = cronstrue.toString(trimmedValue);
-
-    // Check if cron has a frequency of less than an hour
-    const isFrequencyInMinutes = /Every \d* *minute/.test(description);
-    const isFrequencyInSeconds = /Every \d* *second/.test(description);
-
-    if (isFrequencyInMinutes || isFrequencyInSeconds) {
-      return Promise.reject(
-        new Error(i18n.t('message.cron-less-than-hour-message'))
-      );
-    }
-
-    return Promise.resolve();
-  } catch {
-    // If cronstrue fails to parse, it's an invalid cron expression
-    return Promise.reject(new Error(i18n.t('message.cron-invalid-expression')));
-  }
-};
 
 export const getRaiseOnErrorFormField = (
   onFocus?: (fieldName: string) => void

--- a/openmetadata-ui/src/main/resources/ui/src/utils/TableDropdownOptions.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/TableDropdownOptions.tsx
@@ -11,13 +11,13 @@
  *  limitations under the License.
  */
 
-import { NavigateFunction } from 'react-router-dom';
+import type { NavigateFunction } from 'react-router-dom';
 import { ReactComponent as ExportIcon } from '../assets/svg/ic-export.svg';
 import { ReactComponent as ImportIcon } from '../assets/svg/ic-import.svg';
 import { ManageButtonItemLabel } from '../components/common/ManageButtonContentItem/ManageButtonContentItem.component';
 import { useEntityExportModalProvider } from '../components/Entity/EntityExportModalProvider/EntityExportModalProvider.component';
 import { ExportTypes } from '../constants/Export.constants';
-import { OperationPermission } from '../context/PermissionProvider/PermissionProvider.interface';
+import type { OperationPermission } from '../context/PermissionProvider/PermissionProvider.interface';
 import { EntityType } from '../enums/entity.enum';
 import LimitWrapper from '../hoc/LimitWrapper';
 import { exportTableDetailsInCSV } from '../rest/tableAPI';

--- a/openmetadata-ui/src/main/resources/ui/src/utils/TableDropdownOptions.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/TableDropdownOptions.tsx
@@ -1,0 +1,84 @@
+/*
+ *  Copyright 2025 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+import { NavigateFunction } from 'react-router-dom';
+import { ReactComponent as ExportIcon } from '../assets/svg/ic-export.svg';
+import { ReactComponent as ImportIcon } from '../assets/svg/ic-import.svg';
+import { ManageButtonItemLabel } from '../components/common/ManageButtonContentItem/ManageButtonContentItem.component';
+import { useEntityExportModalProvider } from '../components/Entity/EntityExportModalProvider/EntityExportModalProvider.component';
+import { ExportTypes } from '../constants/Export.constants';
+import { OperationPermission } from '../context/PermissionProvider/PermissionProvider.interface';
+import { EntityType } from '../enums/entity.enum';
+import LimitWrapper from '../hoc/LimitWrapper';
+import { exportTableDetailsInCSV } from '../rest/tableAPI';
+import { getEntityImportPath } from './EntityUtils';
+import { t } from './i18next/LocalUtil';
+
+export const ExtraTableDropdownOptions = (
+  fqn: string,
+  permission: OperationPermission,
+  deleted: boolean,
+  navigate: NavigateFunction
+) => {
+  const { showModal } = useEntityExportModalProvider();
+  const { ViewAll, EditAll } = permission;
+
+  return [
+    ...(EditAll && !deleted
+      ? [
+          {
+            label: (
+              <LimitWrapper resource="table">
+                <ManageButtonItemLabel
+                  description={t('message.import-entity-help', {
+                    entity: t('label.table'),
+                  })}
+                  icon={ImportIcon}
+                  id="import-button"
+                  name={t('label.import')}
+                  onClick={() =>
+                    navigate(getEntityImportPath(EntityType.TABLE, fqn))
+                  }
+                />
+              </LimitWrapper>
+            ),
+            key: 'import-button',
+          },
+        ]
+      : []),
+    ...(ViewAll && !deleted
+      ? [
+          {
+            label: (
+              <ManageButtonItemLabel
+                description={t('message.export-entity-help', {
+                  entity: t('label.table'),
+                })}
+                icon={ExportIcon}
+                id="export-button"
+                name={t('label.export')}
+                onClick={() =>
+                  showModal({
+                    name: fqn,
+                    onExport: exportTableDetailsInCSV,
+                    exportTypes: [ExportTypes.CSV],
+                  })
+                }
+              />
+            ),
+            key: 'export-button',
+          },
+        ]
+      : []),
+  ];
+};

--- a/openmetadata-ui/src/main/resources/ui/src/utils/TableTabsUtils.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/TableTabsUtils.tsx
@@ -14,8 +14,7 @@
 import { Divider, Space, Typography } from 'antd';
 import { get, isUndefined } from 'lodash';
 import { lazy, Suspense } from 'react';
-import { ActivityFeedTab } from '../components/ActivityFeed/ActivityFeedTab/ActivityFeedTab.component';
-import { ActivityFeedLayoutType } from '../components/ActivityFeed/ActivityFeedTab/ActivityFeedTab.interface';
+import type { ActivityFeedLayoutType } from '../components/ActivityFeed/ActivityFeedTab/ActivityFeedTab.interface';
 import withSuspenseFallback from '../components/AppRouter/withSuspenseFallback';
 import type {
   CustomPropertyProps,
@@ -25,21 +24,29 @@ import ErrorPlaceHolder from '../components/common/ErrorWithPlaceholder/ErrorPla
 import Loader from '../components/common/Loader/Loader';
 import QueryViewer from '../components/common/QueryViewer/QueryViewer.component';
 import TabsLabel from '../components/common/TabsLabel/TabsLabel.component';
-import { TabProps } from '../components/common/TabsLabel/TabsLabel.interface';
+import type { TabProps } from '../components/common/TabsLabel/TabsLabel.interface';
 import { GenericTab } from '../components/Customization/GenericTab/GenericTab';
 import { CommonWidgets } from '../components/DataAssets/CommonWidgets/CommonWidgets';
-import { SourceType } from '../components/SearchedData/SearchedData.interface';
+import type { SourceType } from '../components/SearchedData/SearchedData.interface';
 import { NO_DATA_PLACEHOLDER } from '../constants/constants';
 import { ERROR_PLACEHOLDER_TYPE } from '../enums/common.enum';
 import { DetailPageWidgetKeys } from '../enums/CustomizeDetailPage.enum';
 import { EntityTabs, EntityType } from '../enums/entity.enum';
 import { PageType } from '../generated/system/ui/uiCustomization';
 import { useApplicationStore } from '../hooks/useApplicationStore';
-import { WidgetConfig } from '../pages/CustomizablePage/CustomizablePage.interface';
+import type { WidgetConfig } from '../pages/CustomizablePage/CustomizablePage.interface';
 import { FrequentlyJoinedTables } from '../pages/TableDetailsPageV1/FrequentlyJoinedTables/FrequentlyJoinedTables.component';
 import { PartitionedKeys } from '../pages/TableDetailsPageV1/PartitionedKeys/PartitionedKeys.component';
 import { t } from './i18next/LocalUtil';
-import { TableDetailPageTabProps } from './TableClassBase';
+import type { TableDetailPageTabProps } from './TableClassBase';
+
+const ActivityFeedTab = withSuspenseFallback(
+  lazy(() =>
+    import(
+      '../components/ActivityFeed/ActivityFeedTab/ActivityFeedTab.component'
+    ).then((module) => ({ default: module.ActivityFeedTab }))
+  )
+);
 
 const CustomPropertyTable = withSuspenseFallback(
   lazy(() =>

--- a/openmetadata-ui/src/main/resources/ui/src/utils/TableTabsUtils.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/TableTabsUtils.tsx
@@ -43,9 +43,9 @@ import { TableDetailPageTabProps } from './TableClassBase';
 
 const CustomPropertyTable = withSuspenseFallback(
   lazy(() =>
-    import(
-      '../components/common/CustomPropertyTable/CustomPropertyTable'
-    ).then((module) => ({ default: module.CustomPropertyTable }))
+    import('../components/common/CustomPropertyTable/CustomPropertyTable').then(
+      (module) => ({ default: module.CustomPropertyTable })
+    )
   )
 ) as <T extends ExtentionEntitiesKeys>(
   props: CustomPropertyProps<T>

--- a/openmetadata-ui/src/main/resources/ui/src/utils/TableTabsUtils.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/TableTabsUtils.tsx
@@ -14,7 +14,7 @@
 import { Divider, Space, Typography } from 'antd';
 import { get, isUndefined } from 'lodash';
 import { lazy, Suspense } from 'react';
-import type { ActivityFeedLayoutType } from '../components/ActivityFeed/ActivityFeedTab/ActivityFeedTab.interface';
+import { ActivityFeedLayoutType } from '../components/ActivityFeed/ActivityFeedTab/ActivityFeedTab.interface';
 import withSuspenseFallback from '../components/AppRouter/withSuspenseFallback';
 import type {
   CustomPropertyProps,

--- a/openmetadata-ui/src/main/resources/ui/src/utils/TableTabsUtils.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/TableTabsUtils.tsx
@@ -1,0 +1,427 @@
+/*
+ *  Copyright 2025 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+import { Divider, Space, Typography } from 'antd';
+import { get, isUndefined } from 'lodash';
+import { lazy, Suspense } from 'react';
+import { ActivityFeedTab } from '../components/ActivityFeed/ActivityFeedTab/ActivityFeedTab.component';
+import { ActivityFeedLayoutType } from '../components/ActivityFeed/ActivityFeedTab/ActivityFeedTab.interface';
+import withSuspenseFallback from '../components/AppRouter/withSuspenseFallback';
+import type {
+  CustomPropertyProps,
+  ExtentionEntitiesKeys,
+} from '../components/common/CustomPropertyTable/CustomPropertyTable.interface';
+import ErrorPlaceHolder from '../components/common/ErrorWithPlaceholder/ErrorPlaceHolder';
+import Loader from '../components/common/Loader/Loader';
+import QueryViewer from '../components/common/QueryViewer/QueryViewer.component';
+import TabsLabel from '../components/common/TabsLabel/TabsLabel.component';
+import { TabProps } from '../components/common/TabsLabel/TabsLabel.interface';
+import { GenericTab } from '../components/Customization/GenericTab/GenericTab';
+import { CommonWidgets } from '../components/DataAssets/CommonWidgets/CommonWidgets';
+import { SourceType } from '../components/SearchedData/SearchedData.interface';
+import { NO_DATA_PLACEHOLDER } from '../constants/constants';
+import { ERROR_PLACEHOLDER_TYPE } from '../enums/common.enum';
+import { DetailPageWidgetKeys } from '../enums/CustomizeDetailPage.enum';
+import { EntityTabs, EntityType } from '../enums/entity.enum';
+import { PageType } from '../generated/system/ui/uiCustomization';
+import { useApplicationStore } from '../hooks/useApplicationStore';
+import { WidgetConfig } from '../pages/CustomizablePage/CustomizablePage.interface';
+import { FrequentlyJoinedTables } from '../pages/TableDetailsPageV1/FrequentlyJoinedTables/FrequentlyJoinedTables.component';
+import { PartitionedKeys } from '../pages/TableDetailsPageV1/PartitionedKeys/PartitionedKeys.component';
+import { t } from './i18next/LocalUtil';
+import { TableDetailPageTabProps } from './TableClassBase';
+
+const CustomPropertyTable = withSuspenseFallback(
+  lazy(() =>
+    import(
+      '../components/common/CustomPropertyTable/CustomPropertyTable'
+    ).then((module) => ({ default: module.CustomPropertyTable }))
+  )
+) as <T extends ExtentionEntitiesKeys>(
+  props: CustomPropertyProps<T>
+) => JSX.Element;
+
+const SchemaTable = withSuspenseFallback(
+  lazy(() => import('../components/Database/SchemaTable/SchemaTable.component'))
+);
+
+const SampleDataTableComponent = withSuspenseFallback(
+  lazy(
+    () =>
+      import('../components/Database/SampleDataTable/SampleDataTable.component')
+  )
+);
+
+const TableQueries = withSuspenseFallback(
+  lazy(() => import('../components/Database/TableQueries/TableQueries'))
+);
+
+const ContractTab = withSuspenseFallback(
+  lazy(() =>
+    import('../components/DataContract/ContractTab/ContractTab').then(
+      (module) => ({ default: module.ContractTab })
+    )
+  )
+);
+
+const DataObservabilityTab = withSuspenseFallback(
+  lazy(
+    () =>
+      import(
+        '../components/Database/Profiler/DataObservability/DataObservabilityTab'
+      )
+  )
+);
+
+const EntityLineageTab = withSuspenseFallback(
+  lazy(() =>
+    import('../components/Lineage/EntityLineageTab/EntityLineageTab').then(
+      (module) => ({ default: module.EntityLineageTab })
+    )
+  )
+);
+
+const TableConstraints = withSuspenseFallback(
+  lazy(
+    () =>
+      import('../pages/TableDetailsPageV1/TableConstraints/TableConstraints')
+  )
+);
+
+const KnowledgeGraph = withSuspenseFallback(
+  lazy(() => import('../components/KnowledgeGraph/KnowledgeGraph'))
+);
+
+export const getTableDetailPageBaseTabs = ({
+  queryCount,
+  isTourOpen,
+  tablePermissions,
+  activeTab,
+  deleted,
+  tableDetails,
+  feedCount,
+  getEntityFeedCount,
+  handleFeedCount,
+  viewCustomPropertiesPermission,
+  editCustomAttributePermission,
+  viewSampleDataPermission,
+  viewQueriesPermission,
+  editLineagePermission,
+  fetchTableDetails,
+  isViewTableType,
+  labelMap,
+}: TableDetailPageTabProps): TabProps[] => {
+  return [
+    {
+      label: (
+        <TabsLabel
+          count={tableDetails?.columns.length}
+          id={EntityTabs.SCHEMA}
+          isActive={activeTab === EntityTabs.SCHEMA}
+          name={get(labelMap, EntityTabs.SCHEMA, t('label.column-plural'))}
+        />
+      ),
+      key: EntityTabs.SCHEMA,
+      children: <GenericTab type={PageType.Table} />,
+    },
+    {
+      label: (
+        <TabsLabel
+          count={feedCount.totalCount}
+          id={EntityTabs.ACTIVITY_FEED}
+          isActive={activeTab === EntityTabs.ACTIVITY_FEED}
+          name={get(
+            labelMap,
+            EntityTabs.ACTIVITY_FEED,
+            t('label.activity-feed-and-task-plural')
+          )}
+        />
+      ),
+      key: EntityTabs.ACTIVITY_FEED,
+      children: (
+        <ActivityFeedTab
+          refetchFeed
+          columns={tableDetails?.columns}
+          entityFeedTotalCount={feedCount.totalCount}
+          entityType={EntityType.TABLE}
+          feedCount={feedCount}
+          layoutType={ActivityFeedLayoutType.THREE_PANEL}
+          owners={tableDetails?.owners}
+          onFeedUpdate={getEntityFeedCount}
+          onUpdateEntityDetails={fetchTableDetails}
+          onUpdateFeedCount={handleFeedCount}
+        />
+      ),
+    },
+    {
+      label: (
+        <TabsLabel
+          id={EntityTabs.SAMPLE_DATA}
+          name={get(labelMap, EntityTabs.SAMPLE_DATA, t('label.sample-data'))}
+        />
+      ),
+
+      key: EntityTabs.SAMPLE_DATA,
+      children:
+        !isTourOpen && !viewSampleDataPermission ? (
+          <ErrorPlaceHolder
+            className="border-none"
+            permissionValue={t('label.view-entity', {
+              entity: t('label.sample-data'),
+            })}
+            type={ERROR_PLACEHOLDER_TYPE.PERMISSION}
+          />
+        ) : (
+          <SampleDataTableComponent
+            isTableDeleted={deleted}
+            owners={tableDetails?.owners ?? []}
+            permissions={tablePermissions}
+            tableId={tableDetails?.id ?? ''}
+          />
+        ),
+    },
+    {
+      label: (
+        <TabsLabel
+          count={queryCount}
+          id={EntityTabs.TABLE_QUERIES}
+          isActive={activeTab === EntityTabs.TABLE_QUERIES}
+          name={get(
+            labelMap,
+            EntityTabs.TABLE_QUERIES,
+            t('label.query-plural')
+          )}
+        />
+      ),
+      key: EntityTabs.TABLE_QUERIES,
+      children: viewQueriesPermission ? (
+        <TableQueries
+          isTableDeleted={deleted}
+          tableId={tableDetails?.id ?? ''}
+        />
+      ) : (
+        <ErrorPlaceHolder
+          className="border-none"
+          permissionValue={t('label.view-entity', {
+            entity: t('label.query-plural'),
+          })}
+          type={ERROR_PLACEHOLDER_TYPE.PERMISSION}
+        />
+      ),
+    },
+    {
+      label: (
+        <TabsLabel
+          id={EntityTabs.PROFILER}
+          name={get(
+            labelMap,
+            EntityTabs.PROFILER,
+            t('label.data-observability')
+          )}
+        />
+      ),
+      key: EntityTabs.PROFILER,
+      children: (
+        <DataObservabilityTab
+          permissions={tablePermissions}
+          table={tableDetails}
+        />
+      ),
+    },
+    {
+      label: (
+        <TabsLabel
+          id={EntityTabs.LINEAGE}
+          name={get(labelMap, EntityTabs.LINEAGE, t('label.lineage'))}
+        />
+      ),
+      key: EntityTabs.LINEAGE,
+      children: (
+        <Suspense fallback={<Loader />}>
+          <EntityLineageTab
+            deleted={Boolean(deleted)}
+            entity={tableDetails as SourceType}
+            entityType={EntityType.TABLE}
+            hasEditAccess={editLineagePermission}
+          />
+        </Suspense>
+      ),
+    },
+    {
+      label: (
+        <TabsLabel
+          isBeta
+          id={EntityTabs.KNOWLEDGE_GRAPH}
+          name={get(
+            labelMap,
+            EntityTabs.KNOWLEDGE_GRAPH,
+            t('label.knowledge-graph')
+          )}
+        />
+      ),
+      key: EntityTabs.KNOWLEDGE_GRAPH,
+      children: (
+        <Suspense fallback={<Loader />}>
+          <KnowledgeGraph
+            depth={1}
+            entity={
+              tableDetails
+                ? {
+                    ...tableDetails,
+                    type: EntityType.TABLE,
+                  }
+                : undefined
+            }
+            entityType={EntityType.TABLE}
+          />
+        </Suspense>
+      ),
+      isHidden: !useApplicationStore.getState().rdfEnabled,
+    },
+    {
+      label: (
+        <TabsLabel
+          id={EntityTabs.DBT}
+          name={get(labelMap, EntityTabs.DBT, t('label.dbt-lowercase'))}
+        />
+      ),
+      isHidden: !(
+        tableDetails?.dataModel?.sql ||
+        tableDetails?.dataModel?.rawSql ||
+        tableDetails?.dataModel?.path ||
+        tableDetails?.dataModel?.dbtSourceProject
+      ),
+      key: EntityTabs.DBT,
+      children: (
+        <QueryViewer
+          isActive={activeTab === EntityTabs.DBT}
+          sqlQuery={
+            get(tableDetails, 'dataModel.sql', '') ??
+            get(tableDetails, 'dataModel.rawSql', '')
+          }
+          title={
+            <Space className="p-y-xss" size="small">
+              <div>
+                <Typography.Text className="text-grey-muted">
+                  {`${t('label.dbt-source-project')}: `}
+                </Typography.Text>
+                <Typography.Text data-testid="dbt-source-project-id">
+                  {tableDetails?.dataModel?.dbtSourceProject ??
+                    NO_DATA_PLACEHOLDER}
+                </Typography.Text>
+              </div>
+
+              <Divider
+                className="self-center vertical-divider"
+                type="vertical"
+              />
+
+              <div>
+                <Typography.Text className="text-grey-muted">
+                  {`${t('label.path')}: `}
+                </Typography.Text>
+                <Typography.Text>
+                  {tableDetails?.dataModel?.path}
+                </Typography.Text>
+              </div>
+            </Space>
+          }
+        />
+      ),
+    },
+    {
+      label: (
+        <TabsLabel
+          id={
+            isViewTableType
+              ? EntityTabs.VIEW_DEFINITION
+              : EntityTabs.SCHEMA_DEFINITION
+          }
+          name={get(
+            labelMap,
+            EntityTabs.VIEW_DEFINITION,
+            isViewTableType
+              ? t('label.view-definition')
+              : t('label.schema-definition')
+          )}
+        />
+      ),
+      isHidden: isUndefined(tableDetails?.schemaDefinition),
+      key: EntityTabs.VIEW_DEFINITION,
+      children: (
+        <QueryViewer
+          isActive={[
+            EntityTabs.VIEW_DEFINITION,
+            EntityTabs.SCHEMA_DEFINITION,
+          ].includes(activeTab)}
+          sqlQuery={tableDetails?.schemaDefinition ?? ''}
+        />
+      ),
+    },
+    {
+      label: (
+        <TabsLabel
+          id={EntityTabs.CONTRACT}
+          name={get(labelMap, EntityTabs.CONTRACT, t('label.contract'))}
+        />
+      ),
+      key: EntityTabs.CONTRACT,
+      children: <ContractTab />,
+    },
+    {
+      label: (
+        <TabsLabel
+          id={EntityTabs.CUSTOM_PROPERTIES}
+          name={get(
+            labelMap,
+            EntityTabs.CUSTOM_PROPERTIES,
+            t('label.custom-property-plural')
+          )}
+        />
+      ),
+      key: EntityTabs.CUSTOM_PROPERTIES,
+      children: (
+        <CustomPropertyTable<EntityType.TABLE>
+          entityType={EntityType.TABLE}
+          hasEditAccess={editCustomAttributePermission}
+          hasPermission={viewCustomPropertiesPermission}
+        />
+      ),
+    },
+  ];
+};
+
+export const getTableWidgetFromKey = (
+  widgetConfig: WidgetConfig
+): JSX.Element | null => {
+  if (widgetConfig.i.startsWith(DetailPageWidgetKeys.TABLE_SCHEMA)) {
+    return <SchemaTable />;
+  } else if (
+    widgetConfig.i.startsWith(DetailPageWidgetKeys.TABLE_CONSTRAINTS)
+  ) {
+    return <TableConstraints />;
+  } else if (
+    widgetConfig.i.startsWith(DetailPageWidgetKeys.FREQUENTLY_JOINED_TABLES)
+  ) {
+    return <FrequentlyJoinedTables />;
+  } else if (widgetConfig.i.startsWith(DetailPageWidgetKeys.PARTITIONED_KEYS)) {
+    return <PartitionedKeys />;
+  } else {
+    return (
+      <CommonWidgets
+        entityType={EntityType.TABLE}
+        widgetConfig={widgetConfig}
+      />
+    );
+  }
+};

--- a/openmetadata-ui/src/main/resources/ui/src/utils/TableUtils.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/TableUtils.tsx
@@ -127,6 +127,7 @@ import searchClassBase from './SearchClassBase';
 import serviceUtilClassBase from './ServiceUtilClassBase';
 
 // Re-exports from TablePureUtils (backward compat)
+export { ExtraTableDropdownOptions } from './TableDropdownOptions';
 export {
   buildColumnBreadcrumbPath,
   createTableConstraintObject,
@@ -172,8 +173,6 @@ export {
   updateFieldExtension,
   updateFieldTags,
 } from './TablePureUtils';
-
-export { ExtraTableDropdownOptions } from './TableDropdownOptions';
 export {
   getTableDetailPageBaseTabs,
   getTableWidgetFromKey,
@@ -589,4 +588,3 @@ export const tableConstraintRendererBasedOnType = (
     </div>
   );
 };
-

--- a/openmetadata-ui/src/main/resources/ui/src/utils/TableUtils.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/TableUtils.tsx
@@ -12,13 +12,11 @@
  */
 
 import Icon, { SearchOutlined } from '@ant-design/icons';
-import { Divider, Space, Tooltip, Typography } from 'antd';
+import { Space, Tooltip, Typography } from 'antd';
 import { ExpandableConfig } from 'antd/lib/table/interface';
 import classNames from 'classnames';
-import { get, isUndefined, uniqBy } from 'lodash';
-import { Fragment, lazy, Suspense, type CSSProperties } from 'react';
-import type { NavigateFunction } from 'react-router-dom';
-import { ReactComponent as ImportIcon } from '..//assets/svg/ic-import.svg';
+import { uniqBy } from 'lodash';
+import { Fragment, type CSSProperties } from 'react';
 import { ReactComponent as AlertIcon } from '../assets/svg/alert.svg';
 import { ReactComponent as AnnouncementIcon } from '../assets/svg/announcements-black.svg';
 import { ReactComponent as ApplicationIcon } from '../assets/svg/application.svg';
@@ -78,7 +76,6 @@ import { ReactComponent as DatabaseIcon } from '../assets/svg/ic-database.svg';
 import { ReactComponent as DirectoryIcon } from '../assets/svg/ic-directory.svg';
 import { ReactComponent as DomainIcon } from '../assets/svg/ic-domain.svg';
 import { ReactComponent as DriveServiceIcon } from '../assets/svg/ic-drive-service.svg';
-import { ReactComponent as ExportIcon } from '../assets/svg/ic-export.svg';
 import { ReactComponent as FileIcon } from '../assets/svg/ic-file.svg';
 import { ReactComponent as KnowledgePageIcon } from '../assets/svg/ic-knowledge-page.svg';
 import { ReactComponent as MlModelIcon } from '../assets/svg/ic-ml-model.svg';
@@ -114,28 +111,9 @@ import { ReactComponent as ServicesIcon } from '../assets/svg/services.svg';
 import { ReactComponent as TagIcon } from '../assets/svg/tag.svg';
 import { ReactComponent as TaskIcon } from '../assets/svg/task-ic.svg';
 import { ReactComponent as UserIcon } from '../assets/svg/user.svg';
-import { ActivityFeedTab } from '../components/ActivityFeed/ActivityFeedTab/ActivityFeedTab.component';
-import { ActivityFeedLayoutType } from '../components/ActivityFeed/ActivityFeedTab/ActivityFeedTab.interface';
-import withSuspenseFallback from '../components/AppRouter/withSuspenseFallback';
-import { CustomPropertyTable } from '../components/common/CustomPropertyTable/CustomPropertyTable';
-import ErrorPlaceHolder from '../components/common/ErrorWithPlaceholder/ErrorPlaceHolder';
-import Loader from '../components/common/Loader/Loader';
-import { ManageButtonItemLabel } from '../components/common/ManageButtonContentItem/ManageButtonContentItem.component';
-import QueryViewer from '../components/common/QueryViewer/QueryViewer.component';
-import TabsLabel from '../components/common/TabsLabel/TabsLabel.component';
-import type { TabProps } from '../components/common/TabsLabel/TabsLabel.interface';
-import { GenericTab } from '../components/Customization/GenericTab/GenericTab';
-import { CommonWidgets } from '../components/DataAssets/CommonWidgets/CommonWidgets';
-import SchemaTable from '../components/Database/SchemaTable/SchemaTable.component';
-import { useEntityExportModalProvider } from '../components/Entity/EntityExportModalProvider/EntityExportModalProvider.component';
-import type { SourceType } from '../components/SearchedData/SearchedData.interface';
 import { NON_SERVICE_TYPE_ASSETS } from '../constants/Assets.constants';
-import { DE_ACTIVE_COLOR, NO_DATA_PLACEHOLDER } from '../constants/constants';
-import { ExportTypes } from '../constants/Export.constants';
-import type { OperationPermission } from '../context/PermissionProvider/PermissionProvider.interface';
-import { ERROR_PLACEHOLDER_TYPE } from '../enums/common.enum';
-import { DetailPageWidgetKeys } from '../enums/CustomizeDetailPage.enum';
-import { EntityTabs, EntityType } from '../enums/entity.enum';
+import { DE_ACTIVE_COLOR } from '../constants/constants';
+import { EntityType } from '../enums/entity.enum';
 import { SearchIndex } from '../enums/search.enum';
 import { ConstraintTypes } from '../enums/table.enum';
 import {
@@ -143,19 +121,10 @@ import {
   DataType,
   TableConstraint,
 } from '../generated/entity/data/table';
-import { PageType } from '../generated/system/ui/uiCustomization';
-import LimitWrapper from '../hoc/LimitWrapper';
-import { useApplicationStore } from '../hooks/useApplicationStore';
-import type { WidgetConfig } from '../pages/CustomizablePage/CustomizablePage.interface';
-import { FrequentlyJoinedTables } from '../pages/TableDetailsPageV1/FrequentlyJoinedTables/FrequentlyJoinedTables.component';
-import { PartitionedKeys } from '../pages/TableDetailsPageV1/PartitionedKeys/PartitionedKeys.component';
 import ConstraintIcon from '../pages/TableDetailsPageV1/TableConstraints/ConstraintIcon';
-import { exportTableDetailsInCSV } from '../rest/tableAPI';
-import { getEntityImportPath } from './EntityUtils';
 import { t } from './i18next/LocalUtil';
 import searchClassBase from './SearchClassBase';
 import serviceUtilClassBase from './ServiceUtilClassBase';
-import type { TableDetailPageTabProps } from './TableClassBase';
 
 // Re-exports from TablePureUtils (backward compat)
 export {
@@ -204,52 +173,11 @@ export {
   updateFieldTags,
 } from './TablePureUtils';
 
-const SampleDataTableComponent = withSuspenseFallback(
-  lazy(
-    () =>
-      import('../components/Database/SampleDataTable/SampleDataTable.component')
-  )
-);
-
-const TableQueries = withSuspenseFallback(
-  lazy(() => import('../components/Database/TableQueries/TableQueries'))
-);
-
-const ContractTab = withSuspenseFallback(
-  lazy(() =>
-    import('../components/DataContract/ContractTab/ContractTab').then(
-      (module) => ({ default: module.ContractTab })
-    )
-  )
-);
-
-const DataObservabilityTab = withSuspenseFallback(
-  lazy(
-    () =>
-      import(
-        '../components/Database/Profiler/DataObservability/DataObservabilityTab'
-      )
-  )
-);
-
-const EntityLineageTab = withSuspenseFallback(
-  lazy(() =>
-    import('../components/Lineage/EntityLineageTab/EntityLineageTab').then(
-      (module) => ({ default: module.EntityLineageTab })
-    )
-  )
-);
-
-const TableConstraints = withSuspenseFallback(
-  lazy(
-    () =>
-      import('../pages/TableDetailsPageV1/TableConstraints/TableConstraints')
-  )
-);
-
-const KnowledgeGraph = withSuspenseFallback(
-  lazy(() => import('../components/KnowledgeGraph/KnowledgeGraph'))
-);
+export { ExtraTableDropdownOptions } from './TableDropdownOptions';
+export {
+  getTableDetailPageBaseTabs,
+  getTableWidgetFromKey,
+} from './TableTabsUtils';
 
 export const getConstraintIcon = ({
   constraint = '',
@@ -624,305 +552,6 @@ export const prepareConstraintIcon = ({
   );
 };
 
-export const getTableDetailPageBaseTabs = ({
-  queryCount,
-  isTourOpen,
-  tablePermissions,
-  activeTab,
-  deleted,
-  tableDetails,
-  feedCount,
-  getEntityFeedCount,
-  handleFeedCount,
-  viewCustomPropertiesPermission,
-  editCustomAttributePermission,
-  viewSampleDataPermission,
-  viewQueriesPermission,
-  editLineagePermission,
-  fetchTableDetails,
-  isViewTableType,
-  labelMap,
-}: TableDetailPageTabProps): TabProps[] => {
-  return [
-    {
-      label: (
-        <TabsLabel
-          count={tableDetails?.columns.length}
-          id={EntityTabs.SCHEMA}
-          isActive={activeTab === EntityTabs.SCHEMA}
-          name={get(labelMap, EntityTabs.SCHEMA, t('label.column-plural'))}
-        />
-      ),
-      key: EntityTabs.SCHEMA,
-      children: <GenericTab type={PageType.Table} />,
-    },
-    {
-      label: (
-        <TabsLabel
-          count={feedCount.totalCount}
-          id={EntityTabs.ACTIVITY_FEED}
-          isActive={activeTab === EntityTabs.ACTIVITY_FEED}
-          name={get(
-            labelMap,
-            EntityTabs.ACTIVITY_FEED,
-            t('label.activity-feed-and-task-plural')
-          )}
-        />
-      ),
-      key: EntityTabs.ACTIVITY_FEED,
-      children: (
-        <ActivityFeedTab
-          refetchFeed
-          columns={tableDetails?.columns}
-          entityFeedTotalCount={feedCount.totalCount}
-          entityType={EntityType.TABLE}
-          feedCount={feedCount}
-          layoutType={ActivityFeedLayoutType.THREE_PANEL}
-          owners={tableDetails?.owners}
-          onFeedUpdate={getEntityFeedCount}
-          onUpdateEntityDetails={fetchTableDetails}
-          onUpdateFeedCount={handleFeedCount}
-        />
-      ),
-    },
-    {
-      label: (
-        <TabsLabel
-          id={EntityTabs.SAMPLE_DATA}
-          name={get(labelMap, EntityTabs.SAMPLE_DATA, t('label.sample-data'))}
-        />
-      ),
-
-      key: EntityTabs.SAMPLE_DATA,
-      children:
-        !isTourOpen && !viewSampleDataPermission ? (
-          <ErrorPlaceHolder
-            className="border-none"
-            permissionValue={t('label.view-entity', {
-              entity: t('label.sample-data'),
-            })}
-            type={ERROR_PLACEHOLDER_TYPE.PERMISSION}
-          />
-        ) : (
-          <SampleDataTableComponent
-            isTableDeleted={deleted}
-            owners={tableDetails?.owners ?? []}
-            permissions={tablePermissions}
-            tableId={tableDetails?.id ?? ''}
-          />
-        ),
-    },
-    {
-      label: (
-        <TabsLabel
-          count={queryCount}
-          id={EntityTabs.TABLE_QUERIES}
-          isActive={activeTab === EntityTabs.TABLE_QUERIES}
-          name={get(
-            labelMap,
-            EntityTabs.TABLE_QUERIES,
-            t('label.query-plural')
-          )}
-        />
-      ),
-      key: EntityTabs.TABLE_QUERIES,
-      children: viewQueriesPermission ? (
-        <TableQueries
-          isTableDeleted={deleted}
-          tableId={tableDetails?.id ?? ''}
-        />
-      ) : (
-        <ErrorPlaceHolder
-          className="border-none"
-          permissionValue={t('label.view-entity', {
-            entity: t('label.query-plural'),
-          })}
-          type={ERROR_PLACEHOLDER_TYPE.PERMISSION}
-        />
-      ),
-    },
-    {
-      label: (
-        <TabsLabel
-          id={EntityTabs.PROFILER}
-          name={get(
-            labelMap,
-            EntityTabs.PROFILER,
-            t('label.data-observability')
-          )}
-        />
-      ),
-      key: EntityTabs.PROFILER,
-      children: (
-        <DataObservabilityTab
-          permissions={tablePermissions}
-          table={tableDetails}
-        />
-      ),
-    },
-    {
-      label: (
-        <TabsLabel
-          id={EntityTabs.LINEAGE}
-          name={get(labelMap, EntityTabs.LINEAGE, t('label.lineage'))}
-        />
-      ),
-      key: EntityTabs.LINEAGE,
-      children: (
-        <Suspense fallback={<Loader />}>
-          <EntityLineageTab
-            deleted={Boolean(deleted)}
-            entity={tableDetails as SourceType}
-            entityType={EntityType.TABLE}
-            hasEditAccess={editLineagePermission}
-          />
-        </Suspense>
-      ),
-    },
-    {
-      label: (
-        <TabsLabel
-          isBeta
-          id={EntityTabs.KNOWLEDGE_GRAPH}
-          name={get(
-            labelMap,
-            EntityTabs.KNOWLEDGE_GRAPH,
-            t('label.knowledge-graph')
-          )}
-        />
-      ),
-      key: EntityTabs.KNOWLEDGE_GRAPH,
-      children: (
-        <Suspense fallback={<Loader />}>
-          <KnowledgeGraph
-            depth={1}
-            entity={
-              tableDetails
-                ? {
-                    ...tableDetails,
-                    type: EntityType.TABLE,
-                  }
-                : undefined
-            }
-            entityType={EntityType.TABLE}
-          />
-        </Suspense>
-      ),
-      isHidden: !useApplicationStore.getState().rdfEnabled,
-    },
-    {
-      label: (
-        <TabsLabel
-          id={EntityTabs.DBT}
-          name={get(labelMap, EntityTabs.DBT, t('label.dbt-lowercase'))}
-        />
-      ),
-      isHidden: !(
-        tableDetails?.dataModel?.sql ||
-        tableDetails?.dataModel?.rawSql ||
-        tableDetails?.dataModel?.path ||
-        tableDetails?.dataModel?.dbtSourceProject
-      ),
-      key: EntityTabs.DBT,
-      children: (
-        <QueryViewer
-          isActive={activeTab === EntityTabs.DBT}
-          sqlQuery={
-            get(tableDetails, 'dataModel.sql', '') ??
-            get(tableDetails, 'dataModel.rawSql', '')
-          }
-          title={
-            <Space className="p-y-xss" size="small">
-              <div>
-                <Typography.Text className="text-grey-muted">
-                  {`${t('label.dbt-source-project')}: `}
-                </Typography.Text>
-                <Typography.Text data-testid="dbt-source-project-id">
-                  {tableDetails?.dataModel?.dbtSourceProject ??
-                    NO_DATA_PLACEHOLDER}
-                </Typography.Text>
-              </div>
-
-              <Divider
-                className="self-center vertical-divider"
-                type="vertical"
-              />
-
-              <div>
-                <Typography.Text className="text-grey-muted">
-                  {`${t('label.path')}: `}
-                </Typography.Text>
-                <Typography.Text>
-                  {tableDetails?.dataModel?.path}
-                </Typography.Text>
-              </div>
-            </Space>
-          }
-        />
-      ),
-    },
-    {
-      label: (
-        <TabsLabel
-          id={
-            isViewTableType
-              ? EntityTabs.VIEW_DEFINITION
-              : EntityTabs.SCHEMA_DEFINITION
-          }
-          name={get(
-            labelMap,
-            EntityTabs.VIEW_DEFINITION,
-            isViewTableType
-              ? t('label.view-definition')
-              : t('label.schema-definition')
-          )}
-        />
-      ),
-      isHidden: isUndefined(tableDetails?.schemaDefinition),
-      key: EntityTabs.VIEW_DEFINITION,
-      children: (
-        <QueryViewer
-          isActive={[
-            EntityTabs.VIEW_DEFINITION,
-            EntityTabs.SCHEMA_DEFINITION,
-          ].includes(activeTab)}
-          sqlQuery={tableDetails?.schemaDefinition ?? ''}
-        />
-      ),
-    },
-    {
-      label: (
-        <TabsLabel
-          id={EntityTabs.CONTRACT}
-          name={get(labelMap, EntityTabs.CONTRACT, t('label.contract'))}
-        />
-      ),
-      key: EntityTabs.CONTRACT,
-      children: <ContractTab />,
-    },
-    {
-      label: (
-        <TabsLabel
-          id={EntityTabs.CUSTOM_PROPERTIES}
-          name={get(
-            labelMap,
-            EntityTabs.CUSTOM_PROPERTIES,
-            t('label.custom-property-plural')
-          )}
-        />
-      ),
-      key: EntityTabs.CUSTOM_PROPERTIES,
-      children: (
-        <CustomPropertyTable<EntityType.TABLE>
-          entityType={EntityType.TABLE}
-          hasEditAccess={editCustomAttributePermission}
-          hasPermission={viewCustomPropertiesPermission}
-        />
-      ),
-    },
-  ];
-};
-
 export const tableConstraintRendererBasedOnType = (
   constraintType: ConstraintType,
   columns?: string[]
@@ -961,85 +590,3 @@ export const tableConstraintRendererBasedOnType = (
   );
 };
 
-export const ExtraTableDropdownOptions = (
-  fqn: string,
-  permission: OperationPermission,
-  deleted: boolean,
-  navigate: NavigateFunction
-) => {
-  const { showModal } = useEntityExportModalProvider();
-  const { ViewAll, EditAll } = permission;
-
-  return [
-    ...(EditAll && !deleted
-      ? [
-          {
-            label: (
-              <LimitWrapper resource="table">
-                <ManageButtonItemLabel
-                  description={t('message.import-entity-help', {
-                    entity: t('label.table'),
-                  })}
-                  icon={ImportIcon}
-                  id="import-button"
-                  name={t('label.import')}
-                  onClick={() =>
-                    navigate(getEntityImportPath(EntityType.TABLE, fqn))
-                  }
-                />
-              </LimitWrapper>
-            ),
-            key: 'import-button',
-          },
-        ]
-      : []),
-    ...(ViewAll && !deleted
-      ? [
-          {
-            label: (
-              <ManageButtonItemLabel
-                description={t('message.export-entity-help', {
-                  entity: t('label.table'),
-                })}
-                icon={ExportIcon}
-                id="export-button"
-                name={t('label.export')}
-                onClick={() =>
-                  showModal({
-                    name: fqn,
-                    onExport: exportTableDetailsInCSV,
-                    exportTypes: [ExportTypes.CSV],
-                  })
-                }
-              />
-            ),
-            key: 'export-button',
-          },
-        ]
-      : []),
-  ];
-};
-export const getTableWidgetFromKey = (
-  widgetConfig: WidgetConfig
-): JSX.Element | null => {
-  if (widgetConfig.i.startsWith(DetailPageWidgetKeys.TABLE_SCHEMA)) {
-    return <SchemaTable />;
-  } else if (
-    widgetConfig.i.startsWith(DetailPageWidgetKeys.TABLE_CONSTRAINTS)
-  ) {
-    return <TableConstraints />;
-  } else if (
-    widgetConfig.i.startsWith(DetailPageWidgetKeys.FREQUENTLY_JOINED_TABLES)
-  ) {
-    return <FrequentlyJoinedTables />;
-  } else if (widgetConfig.i.startsWith(DetailPageWidgetKeys.PARTITIONED_KEYS)) {
-    return <PartitionedKeys />;
-  } else {
-    return (
-      <CommonWidgets
-        entityType={EntityType.TABLE}
-        widgetConfig={widgetConfig}
-      />
-    );
-  }
-};


### PR DESCRIPTION
## Summary

Extract tab definitions, dropdown option builders, and configuration utilities from large source files into focused dedicated modules. All original files re-export every moved symbol for backward compatibility.

### New files

| New File | Extracted From | What it contains |
|---|---|---|
| `Database/DatabaseDropdownOptions.tsx` | `Database/Database.util.tsx` | Database dropdown option builders |
| `Database/DatabaseTabsUtils.tsx` | `Database/Database.util.tsx` | Database page tab definitions |
| `DatabaseSchemaDropdownOptions.tsx` | `DatabaseSchemaDetailsUtils.tsx` | Schema dropdown option builders |
| `DatabaseSchemaTabsUtils.tsx` | `DatabaseSchemaDetailsUtils.tsx` | Schema page tab definitions |
| `TableDropdownOptions.tsx` | `TableUtils.tsx` | Table dropdown option builders |
| `TableTabsUtils.tsx` | `TableUtils.tsx` | Table page tab definitions |
| `IngestionConfigUtils.ts` | `IngestionUtils.tsx` | Pure ingestion configuration utils |
| `CronExpressionUtils.ts` | `SchedularUtils.tsx` | Cron schedule/expression pure utils |
| `DomainFilterUtils.ts` | `DomainUtils.tsx` | Domain filter query builders |

### Guidelines followed
- Pure utils (`.ts`): no React imports, no JSX, no API calls
- Tab/dropdown utils (`.tsx`): JSX allowed, but structured as focused modules
- All original files re-export moved symbols for backward compat
- `import type` used for all type-only imports

## Test plan
- [ ] `npx tsc --noEmit` passes (no new errors in changed files)
- [ ] UI checkstyle passes
- [ ] Existing tests continue to pass

🤖 Generated with [Claude Code](https://claude.ai/claude-code)