### PR TITLE
feat(data-insight): typed timeRangeConfig + server-side resolver for DI charts

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/DataInsightSystemChartRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/DataInsightSystemChartRepository.java
@@ -748,6 +748,12 @@ public class DataInsightSystemChartRepository extends EntityRepository<DataInsig
     return searchClient.buildDIChart(chart, startTimestamp, endTimestamp);
   }
 
+  public DataInsightCustomChartResultList getPreviewData(
+      DataInsightCustomChart chart, long startTimestamp, long endTimestamp, boolean live)
+      throws IOException {
+    return searchClient.buildDIChart(chart, startTimestamp, endTimestamp, live);
+  }
+
   public Map<String, DataInsightCustomChartResultList> listChartData(
       String chartNames,
       long startTimestamp,

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/TimeRangeConfigResolver.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/TimeRangeConfigResolver.java
@@ -1,0 +1,85 @@
+/*
+ *  Copyright 2021 Collate
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.openmetadata.service.jdbi3;
+
+import java.time.DayOfWeek;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.time.temporal.ChronoUnit;
+import java.time.temporal.TemporalAdjusters;
+import org.openmetadata.schema.dataInsight.custom.TimeRangeConfig;
+import org.openmetadata.schema.dataInsight.custom.TimeRangeConfig.CalendarUnit;
+
+/**
+ * Resolves a Data Insight chart's {@link TimeRangeConfig} into the concrete
+ * {@code (startMillis, endMillis, live)} window the DI executor consumes, for both chart preview and
+ * scheduled refresh. Boundary math runs in UTC; week boundary is Monday (ISO), quarter is 3 months.
+ */
+public final class TimeRangeConfigResolver {
+
+  private TimeRangeConfigResolver() {}
+
+  /** Resolved window. When {@code live} is true the executor ignores start/end and reads the live index. */
+  public record Resolved(long startMillis, long endMillis, boolean live) {}
+
+  public static Resolved resolve(TimeRangeConfig config, Instant runStart) {
+    return switch (config) {
+      case TimeRangeConfig.LiveSnapshot ignored -> new Resolved(0L, 0L, true);
+      case TimeRangeConfig.RollingWindow window -> new Resolved(
+          minus(window.unit(), runStart.atZone(ZoneOffset.UTC), window.value())
+              .toInstant()
+              .toEpochMilli(),
+          runStart.toEpochMilli(),
+          false);
+      case TimeRangeConfig.CompletedPeriod period -> resolveCompletedPeriod(period, runStart);
+      case TimeRangeConfig.FixedWindow window -> new Resolved(
+          window.startTimestamp(), window.endTimestamp(), false);
+    };
+  }
+
+  private static Resolved resolveCompletedPeriod(
+      TimeRangeConfig.CompletedPeriod period, Instant runStart) {
+    ZonedDateTime startOfCurrent =
+        truncateToBoundary(period.unit(), runStart.atZone(ZoneOffset.UTC));
+    ZonedDateTime startOfPrior = minus(period.unit(), startOfCurrent, period.value());
+    return new Resolved(
+        startOfPrior.toInstant().toEpochMilli(), startOfCurrent.toInstant().toEpochMilli(), false);
+  }
+
+  private static ZonedDateTime minus(CalendarUnit unit, ZonedDateTime from, int value) {
+    return switch (unit) {
+      case day -> from.minusDays(value);
+      case week -> from.minusWeeks(value);
+      case month -> from.minusMonths(value);
+      case quarter -> from.minusMonths(value * 3L);
+      case year -> from.minusYears(value);
+    };
+  }
+
+  private static ZonedDateTime truncateToBoundary(CalendarUnit unit, ZonedDateTime zdt) {
+    return switch (unit) {
+      case day -> zdt.truncatedTo(ChronoUnit.DAYS);
+      case week -> zdt.truncatedTo(ChronoUnit.DAYS)
+          .with(TemporalAdjusters.previousOrSame(DayOfWeek.MONDAY));
+      case month -> zdt.truncatedTo(ChronoUnit.DAYS).withDayOfMonth(1);
+      case quarter -> truncateToQuarter(zdt);
+      case year -> zdt.truncatedTo(ChronoUnit.DAYS).withDayOfYear(1);
+    };
+  }
+
+  private static ZonedDateTime truncateToQuarter(ZonedDateTime zdt) {
+    int quarterStartMonth = ((zdt.getMonthValue() - 1) / 3) * 3 + 1;
+    return zdt.truncatedTo(ChronoUnit.DAYS).withDayOfMonth(1).withMonth(quarterStartMonth);
+  }
+}

--- a/openmetadata-service/src/test/java/org/openmetadata/service/jdbi3/TimeRangeConfigResolverTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/jdbi3/TimeRangeConfigResolverTest.java
@@ -1,0 +1,271 @@
+/*
+ *  Copyright 2021 Collate
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.openmetadata.service.jdbi3;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.openmetadata.schema.dataInsight.custom.TimeRangeConfig;
+import org.openmetadata.schema.dataInsight.custom.TimeRangeConfig.CalendarUnit;
+import org.openmetadata.schema.dataInsight.custom.TimeRangeConfig.CompletedPeriod;
+import org.openmetadata.schema.dataInsight.custom.TimeRangeConfig.FixedWindow;
+import org.openmetadata.schema.dataInsight.custom.TimeRangeConfig.LiveSnapshot;
+import org.openmetadata.schema.dataInsight.custom.TimeRangeConfig.RollingWindow;
+import org.openmetadata.schema.utils.JsonUtils;
+import org.openmetadata.service.jdbi3.TimeRangeConfigResolver.Resolved;
+
+class TimeRangeConfigResolverTest {
+
+  private static long epochMillis(String isoInstant) {
+    return Instant.parse(isoInstant).toEpochMilli();
+  }
+
+  private static Resolved resolve(TimeRangeConfig config, String isoInstant) {
+    return TimeRangeConfigResolver.resolve(config, Instant.parse(isoInstant));
+  }
+
+  // LiveSnapshot returns (0, 0, live=true).
+  @Test
+  void liveSnapshot_resolvesToLiveSentinel() {
+    Resolved r = resolve(new LiveSnapshot(), "2026-05-16T12:00:00Z");
+    assertEquals(0L, r.startMillis());
+    assertEquals(0L, r.endMillis());
+    assertTrue(r.live());
+  }
+
+  // RollingWindow {N, day} returns [runStart - N*86400000, runStart].
+  @Test
+  void rollingWindow_daysFromRunStart() {
+    Instant runStart = Instant.parse("2026-05-16T12:00:00Z");
+    Resolved r = TimeRangeConfigResolver.resolve(new RollingWindow(7, CalendarUnit.day), runStart);
+    assertEquals(runStart.toEpochMilli() - 7L * 86_400_000L, r.startMillis());
+    assertEquals(runStart.toEpochMilli(), r.endMillis());
+    assertFalse(r.live());
+  }
+
+  // RollingWindow with week / month / year — live flag is always false.
+  @Test
+  void rollingWindow_otherUnits_liveFlagAlwaysFalse() {
+    assertFalse(resolve(new RollingWindow(3, CalendarUnit.week), "2026-05-16T12:00:00Z").live());
+    assertFalse(resolve(new RollingWindow(2, CalendarUnit.month), "2026-05-16T12:00:00Z").live());
+    assertFalse(resolve(new RollingWindow(1, CalendarUnit.year), "2026-05-16T12:00:00Z").live());
+  }
+
+  // Year boundary — CompletedPeriod {1, year} on 2026-01-01T00:00:01Z → [2025-01-01, 2026-01-01].
+  @Test
+  void completedPeriod_yearBoundary() {
+    Resolved r = resolve(new CompletedPeriod(1, CalendarUnit.year), "2026-01-01T00:00:01Z");
+    assertEquals(epochMillis("2025-01-01T00:00:00Z"), r.startMillis());
+    assertEquals(epochMillis("2026-01-01T00:00:00Z"), r.endMillis());
+    assertFalse(r.live());
+  }
+
+  // Leap-day boundaries — CompletedPeriod {1, year} from 2024-03-01 and 2024-02-29 both give
+  // [2023-01-01, 2024-01-01]. No off-by-one from the leap day.
+  @Test
+  void completedPeriod_year_leapDayBoundary() {
+    Resolved fromMarch1 =
+        resolve(new CompletedPeriod(1, CalendarUnit.year), "2024-03-01T00:00:00Z");
+    Resolved fromLeapDay =
+        resolve(new CompletedPeriod(1, CalendarUnit.year), "2024-02-29T00:00:00Z");
+
+    assertEquals(epochMillis("2023-01-01T00:00:00Z"), fromMarch1.startMillis());
+    assertEquals(epochMillis("2024-01-01T00:00:00Z"), fromMarch1.endMillis());
+    assertEquals(epochMillis("2023-01-01T00:00:00Z"), fromLeapDay.startMillis());
+    assertEquals(epochMillis("2024-01-01T00:00:00Z"), fromLeapDay.endMillis());
+  }
+
+  // End-of-month rollover — CompletedPeriod {1, month} on 2026-01-31 → [2025-12-01, 2026-01-01].
+  @Test
+  void completedPeriod_month_endOfMonthRollover() {
+    Resolved r = resolve(new CompletedPeriod(1, CalendarUnit.month), "2026-01-31T15:30:00Z");
+    assertEquals(epochMillis("2025-12-01T00:00:00Z"), r.startMillis());
+    assertEquals(epochMillis("2026-01-01T00:00:00Z"), r.endMillis());
+  }
+
+  // Q1-of-year boundary — CompletedPeriod {1, quarter} on 2026-04-01 → Q1; on 2026-03-31 → Q4
+  // prior.
+  @Test
+  void completedPeriod_quarter_q1Boundary() {
+    Resolved fromApril1 =
+        resolve(new CompletedPeriod(1, CalendarUnit.quarter), "2026-04-01T00:00:00Z");
+    assertEquals(epochMillis("2026-01-01T00:00:00Z"), fromApril1.startMillis());
+    assertEquals(epochMillis("2026-04-01T00:00:00Z"), fromApril1.endMillis());
+
+    Resolved fromMarch31 =
+        resolve(new CompletedPeriod(1, CalendarUnit.quarter), "2026-03-31T23:59:59Z");
+    assertEquals(epochMillis("2025-10-01T00:00:00Z"), fromMarch31.startMillis());
+    assertEquals(epochMillis("2026-01-01T00:00:00Z"), fromMarch31.endMillis());
+  }
+
+  // CompletedPeriod {2, quarter} — two completed quarters back from mid-Q3.
+  @Test
+  void completedPeriod_quarter_multipleQuartersBack() {
+    Resolved r = resolve(new CompletedPeriod(2, CalendarUnit.quarter), "2026-07-15T10:00:00Z");
+    assertEquals(epochMillis("2026-01-01T00:00:00Z"), r.startMillis());
+    assertEquals(epochMillis("2026-07-01T00:00:00Z"), r.endMillis());
+  }
+
+  // CompletedPeriod {1, week} — ISO week starts Monday. 2026-05-16 (Sat) → [2026-05-04,
+  // 2026-05-11].
+  @Test
+  void completedPeriod_week_isoMondayStart() {
+    Resolved r = resolve(new CompletedPeriod(1, CalendarUnit.week), "2026-05-16T12:00:00Z");
+    assertEquals(epochMillis("2026-05-04T00:00:00Z"), r.startMillis());
+    assertEquals(epochMillis("2026-05-11T00:00:00Z"), r.endMillis());
+  }
+
+  // FixedWindow returns its input verbatim regardless of runStart.
+  @Test
+  void fixedWindow_identity() {
+    long start = epochMillis("2026-01-01T00:00:00Z");
+    long end = epochMillis("2026-04-01T00:00:00Z");
+    FixedWindow fw = new FixedWindow(start, end);
+
+    Resolved r1 = TimeRangeConfigResolver.resolve(fw, Instant.parse("2026-05-16T12:00:00Z"));
+    Resolved r2 = TimeRangeConfigResolver.resolve(fw, Instant.parse("2030-12-31T23:59:59Z"));
+
+    assertEquals(start, r1.startMillis());
+    assertEquals(end, r1.endMillis());
+    assertFalse(r1.live());
+    assertEquals(start, r2.startMillis());
+    assertEquals(end, r2.endMillis());
+    assertFalse(r2.live());
+  }
+
+  // --- Jackson polymorphic binding: the existingJavaType directive binds the schema reference
+  // directly to this sealed interface, so JsonUtils.convertValue is what Jackson invokes when the
+  // parent entity is read off the wire. These assert the production deserialization contract.
+
+  @Test
+  void deserializes_liveSnapshot() {
+    TimeRangeConfig parsed =
+        JsonUtils.convertValue(Map.of("type", "LiveSnapshot"), TimeRangeConfig.class);
+    assertInstanceOf(LiveSnapshot.class, parsed);
+  }
+
+  @Test
+  void deserializes_rollingWindow_withNumericValueAndStringUnit() {
+    TimeRangeConfig parsed =
+        JsonUtils.convertValue(
+            Map.of("type", "RollingWindow", "value", 7, "unit", "day"), TimeRangeConfig.class);
+    assertInstanceOf(RollingWindow.class, parsed);
+    assertEquals(7, ((RollingWindow) parsed).value());
+    assertEquals(CalendarUnit.day, ((RollingWindow) parsed).unit());
+  }
+
+  @Test
+  void deserializes_completedPeriod_quarter() {
+    TimeRangeConfig parsed =
+        JsonUtils.convertValue(
+            Map.of("type", "CompletedPeriod", "value", 2, "unit", "quarter"),
+            TimeRangeConfig.class);
+    assertInstanceOf(CompletedPeriod.class, parsed);
+    assertEquals(CalendarUnit.quarter, ((CompletedPeriod) parsed).unit());
+  }
+
+  @Test
+  void deserializes_fixedWindow() {
+    TimeRangeConfig parsed =
+        JsonUtils.convertValue(
+            Map.of("type", "FixedWindow", "startTimestamp", 1_000L, "endTimestamp", 2_000L),
+            TimeRangeConfig.class);
+    assertInstanceOf(FixedWindow.class, parsed);
+    assertEquals(1_000L, ((FixedWindow) parsed).startTimestamp());
+    assertEquals(2_000L, ((FixedWindow) parsed).endTimestamp());
+  }
+
+  @Test
+  void deserializes_nonMapInput_throws() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> JsonUtils.convertValue("LiveSnapshot", TimeRangeConfig.class));
+  }
+
+  @Test
+  void deserializes_missingTypeDiscriminator_throws() {
+    HashMap<String, Object> map = new HashMap<>();
+    map.put("value", 7);
+    map.put("unit", "day");
+    assertThrows(
+        IllegalArgumentException.class, () -> JsonUtils.convertValue(map, TimeRangeConfig.class));
+  }
+
+  @Test
+  void deserializes_unknownTypeDiscriminator_throws() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> JsonUtils.convertValue(Map.of("type", "BogusWindow"), TimeRangeConfig.class));
+  }
+
+  @Test
+  void deserializes_rollingWindow_missingValueCaughtByCompactConstructor() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            JsonUtils.convertValue(
+                Map.of("type", "RollingWindow", "unit", "day"), TimeRangeConfig.class));
+  }
+
+  @Test
+  void deserializes_rollingWindow_unknownUnitThrows() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            JsonUtils.convertValue(
+                Map.of("type", "RollingWindow", "value", 1, "unit", "fortnight"),
+                TimeRangeConfig.class));
+  }
+
+  @Test
+  void deserializes_rollingWindow_zeroValueRejectedByCompactConstructor() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            JsonUtils.convertValue(
+                Map.of("type", "RollingWindow", "value", 0, "unit", "day"), TimeRangeConfig.class));
+  }
+
+  @Test
+  void deserializes_completedPeriod_negativeValueRejectedByCompactConstructor() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            JsonUtils.convertValue(
+                Map.of("type", "CompletedPeriod", "value", -1, "unit", "month"),
+                TimeRangeConfig.class));
+  }
+
+  @Test
+  void deserializes_fixedWindow_endNotAfterStartRejectedByCompactConstructor() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            JsonUtils.convertValue(
+                Map.of("type", "FixedWindow", "startTimestamp", 2_000L, "endTimestamp", 1_000L),
+                TimeRangeConfig.class));
+    assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            JsonUtils.convertValue(
+                Map.of("type", "FixedWindow", "startTimestamp", 5_000L, "endTimestamp", 5_000L),
+                TimeRangeConfig.class));
+  }
+}

--- a/openmetadata-spec/src/main/java/org/openmetadata/schema/dataInsight/custom/TimeRangeConfig.java
+++ b/openmetadata-spec/src/main/java/org/openmetadata/schema/dataInsight/custom/TimeRangeConfig.java
@@ -1,0 +1,82 @@
+/*
+ *  Copyright 2021 Collate
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.openmetadata.schema.dataInsight.custom;
+
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+
+/**
+ * A Data Insight chart's time-range intent. Pure data carrier discriminated by the {@code type}
+ * field; resolution into a concrete (startMillis, endMillis, live) window lives in the service layer
+ * (TimeRangeConfigResolver). Record compact constructors enforce the schema invariants so a payload
+ * that bypassed schema validation fails fast at deserialization.
+ */
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "type")
+@JsonSubTypes({
+  @JsonSubTypes.Type(value = TimeRangeConfig.LiveSnapshot.class, name = "LiveSnapshot"),
+  @JsonSubTypes.Type(value = TimeRangeConfig.RollingWindow.class, name = "RollingWindow"),
+  @JsonSubTypes.Type(value = TimeRangeConfig.CompletedPeriod.class, name = "CompletedPeriod"),
+  @JsonSubTypes.Type(value = TimeRangeConfig.FixedWindow.class, name = "FixedWindow"),
+})
+public sealed interface TimeRangeConfig {
+
+  /** Calendar unit for {@link RollingWindow} and {@link CompletedPeriod}. */
+  enum CalendarUnit {
+    day,
+    week,
+    month,
+    quarter,
+    year
+  }
+
+  /** Current state. The resolver yields {@code live=true}; start/end are ignored downstream. */
+  record LiveSnapshot() implements TimeRangeConfig {}
+
+  /** Sliding trailing window that moves on every refresh. Schema constraint: value >= 1. */
+  record RollingWindow(int value, CalendarUnit unit) implements TimeRangeConfig {
+    public RollingWindow {
+      if (value < 1) {
+        throw new IllegalArgumentException("RollingWindow value must be >= 1, got " + value);
+      }
+      if (unit == null) {
+        throw new IllegalArgumentException("RollingWindow unit is required");
+      }
+    }
+  }
+
+  /** Last {@code value} complete calendar periods, aligned to UTC boundaries. Constraint: value >= 1. */
+  record CompletedPeriod(int value, CalendarUnit unit) implements TimeRangeConfig {
+    public CompletedPeriod {
+      if (value < 1) {
+        throw new IllegalArgumentException("CompletedPeriod value must be >= 1, got " + value);
+      }
+      if (unit == null) {
+        throw new IllegalArgumentException("CompletedPeriod unit is required");
+      }
+    }
+  }
+
+  /** Frozen absolute range in epoch milliseconds (UTC). Constraint: endTimestamp > startTimestamp. */
+  record FixedWindow(long startTimestamp, long endTimestamp) implements TimeRangeConfig {
+    public FixedWindow {
+      if (endTimestamp <= startTimestamp) {
+        throw new IllegalArgumentException(
+            "FixedWindow endTimestamp ("
+                + endTimestamp
+                + ") must be greater than startTimestamp ("
+                + startTimestamp
+                + ")");
+      }
+    }
+  }
+}

--- a/openmetadata-spec/src/main/resources/json/schema/dataInsight/custom/timeRangeConfig.json
+++ b/openmetadata-spec/src/main/resources/json/schema/dataInsight/custom/timeRangeConfig.json
@@ -1,0 +1,107 @@
+{
+  "$id": "https://open-metadata.org/schema/dataInsight/custom/timeRangeConfig.json",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "TimeRangeConfig",
+  "description": "Structured time-range intent for a Data Insight chart. Resolved into (startMillis, endMillis, live) by the server-side resolver (org.openmetadata.service.jdbi3.TimeRangeConfigResolver) for both chart preview and scheduled refresh. One of four variants discriminated by the `type` field. `existingJavaType` binds every reference to the handwritten sealed interface (with record variants and Jackson @JsonTypeInfo / @JsonSubTypes) instead of generating one, so callers get the typed value directly.",
+  "existingJavaType": "org.openmetadata.schema.dataInsight.custom.TimeRangeConfig",
+  "oneOf": [
+    { "$ref": "#/definitions/liveSnapshot" },
+    { "$ref": "#/definitions/rollingWindow" },
+    { "$ref": "#/definitions/completedPeriod" },
+    { "$ref": "#/definitions/fixedWindow" }
+  ],
+  "definitions": {
+    "timeUnit": {
+      "description": "Calendar unit for rolling and completed time windows. All boundary math is performed in UTC.",
+      "existingJavaType": "org.openmetadata.schema.dataInsight.custom.TimeRangeConfig$CalendarUnit",
+      "type": "string",
+      "enum": ["day", "week", "month", "quarter", "year"]
+    },
+    "liveSnapshot": {
+      "description": "Current state with no historical window. Resolves to (0, runStart, live=true); the executor reads the live data-asset search index rather than the time-series Data Insights index. Use for current-state KPIs and inventories (e.g. 'how many tables right now').",
+      "existingJavaType": "org.openmetadata.schema.dataInsight.custom.TimeRangeConfig$LiveSnapshot",
+      "type": "object",
+      "properties": {
+        "type": {
+          "description": "Discriminator field.",
+          "type": "string",
+          "enum": ["LiveSnapshot"],
+          "default": "LiveSnapshot"
+        }
+      },
+      "required": ["type"],
+      "additionalProperties": false
+    },
+    "rollingWindow": {
+      "description": "Sliding trailing window. Resolves to (runStart - value*unit, runStart, live=false). The window moves on every refresh, so a 'last 7 days' chart updates daily. Use for trends (e.g. 'last 30 days', 'trailing year').",
+      "existingJavaType": "org.openmetadata.schema.dataInsight.custom.TimeRangeConfig$RollingWindow",
+      "type": "object",
+      "properties": {
+        "type": {
+          "description": "Discriminator field.",
+          "type": "string",
+          "enum": ["RollingWindow"],
+          "default": "RollingWindow"
+        },
+        "value": {
+          "description": "Number of units in the trailing window. Must be at least 1.",
+          "type": "integer",
+          "minimum": 1
+        },
+        "unit": {
+          "$ref": "#/definitions/timeUnit"
+        }
+      },
+      "required": ["type", "value", "unit"],
+      "additionalProperties": false
+    },
+    "completedPeriod": {
+      "description": "Last N complete calendar periods, aligned to UTC boundaries. Resolves to (startOf(N units ago, unit), startOf(current unit), live=false). The window snaps to calendar boundaries and only changes when the next boundary crosses. Use for recurring reports (e.g. 'last completed quarter', 'prior year').",
+      "existingJavaType": "org.openmetadata.schema.dataInsight.custom.TimeRangeConfig$CompletedPeriod",
+      "type": "object",
+      "properties": {
+        "type": {
+          "description": "Discriminator field.",
+          "type": "string",
+          "enum": ["CompletedPeriod"],
+          "default": "CompletedPeriod"
+        },
+        "value": {
+          "description": "Number of complete periods to include. Must be at least 1.",
+          "type": "integer",
+          "minimum": 1
+        },
+        "unit": {
+          "$ref": "#/definitions/timeUnit"
+        }
+      },
+      "required": ["type", "value", "unit"],
+      "additionalProperties": false
+    },
+    "fixedWindow": {
+      "description": "Frozen absolute range in epoch milliseconds (UTC). Resolves to (startTimestamp, endTimestamp, live=false) — never changes on refresh. Use for retrospective reports and named periods (e.g. 'Q1 2026', 'Jan-Mar 2025'). startTimestamp must be less than endTimestamp.",
+      "existingJavaType": "org.openmetadata.schema.dataInsight.custom.TimeRangeConfig$FixedWindow",
+      "type": "object",
+      "properties": {
+        "type": {
+          "description": "Discriminator field.",
+          "type": "string",
+          "enum": ["FixedWindow"],
+          "default": "FixedWindow"
+        },
+        "startTimestamp": {
+          "description": "Window start in epoch milliseconds (UTC).",
+          "type": "integer",
+          "format": "int64"
+        },
+        "endTimestamp": {
+          "description": "Window end in epoch milliseconds (UTC).",
+          "type": "integer",
+          "format": "int64"
+        }
+      },
+      "required": ["type", "startTimestamp", "endTimestamp"],
+      "additionalProperties": false
+    }
+  }
+}

--- a/openmetadata-ui/src/main/resources/ui/src/generated/dataInsight/custom/timeRangeConfig.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/dataInsight/custom/timeRangeConfig.ts
@@ -1,0 +1,82 @@
+/*
+ *  Copyright 2026 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+/**
+ * Structured time-range intent for a Data Insight chart. Resolved into (startMillis,
+ * endMillis, live) by the server-side resolver
+ * (org.openmetadata.service.jdbi3.TimeRangeConfigResolver) for both chart preview and
+ * scheduled refresh. One of four variants discriminated by the `type` field.
+ * `existingJavaType` binds every reference to the handwritten sealed interface (with record
+ * variants and Jackson @JsonTypeInfo / @JsonSubTypes) instead of generating one, so callers
+ * get the typed value directly.
+ *
+ * Current state with no historical window. Resolves to (0, runStart, live=true); the
+ * executor reads the live data-asset search index rather than the time-series Data Insights
+ * index. Use for current-state KPIs and inventories (e.g. 'how many tables right now').
+ *
+ * Sliding trailing window. Resolves to (runStart - value*unit, runStart, live=false). The
+ * window moves on every refresh, so a 'last 7 days' chart updates daily. Use for trends
+ * (e.g. 'last 30 days', 'trailing year').
+ *
+ * Last N complete calendar periods, aligned to UTC boundaries. Resolves to (startOf(N units
+ * ago, unit), startOf(current unit), live=false). The window snaps to calendar boundaries
+ * and only changes when the next boundary crosses. Use for recurring reports (e.g. 'last
+ * completed quarter', 'prior year').
+ *
+ * Frozen absolute range in epoch milliseconds (UTC). Resolves to (startTimestamp,
+ * endTimestamp, live=false) — never changes on refresh. Use for retrospective reports and
+ * named periods (e.g. 'Q1 2026', 'Jan-Mar 2025'). startTimestamp must be less than
+ * endTimestamp.
+ */
+export interface TimeRangeConfig {
+    /**
+     * Discriminator field.
+     */
+    type:  Type;
+    unit?: TimeUnit;
+    /**
+     * Number of units in the trailing window. Must be at least 1.
+     *
+     * Number of complete periods to include. Must be at least 1.
+     */
+    value?: number;
+    /**
+     * Window end in epoch milliseconds (UTC).
+     */
+    endTimestamp?: number;
+    /**
+     * Window start in epoch milliseconds (UTC).
+     */
+    startTimestamp?: number;
+}
+
+/**
+ * Discriminator field.
+ */
+export enum Type {
+    CompletedPeriod = "CompletedPeriod",
+    FixedWindow = "FixedWindow",
+    LiveSnapshot = "LiveSnapshot",
+    RollingWindow = "RollingWindow",
+}
+
+/**
+ * Calendar unit for rolling and completed time windows. All boundary math is performed in
+ * UTC.
+ */
+export enum TimeUnit {
+    Day = "day",
+    Month = "month",
+    Quarter = "quarter",
+    Week = "week",
+    Year = "year",
+}


### PR DESCRIPTION
## What

Adds a typed `timeRangeConfig` to Data Insight custom charts and a single server-side resolver that turns it into a concrete `(start, end, live)` window.

- **`dataInsight/custom/timeRangeConfig.json`** + handwritten `org.openmetadata.schema.dataInsight.custom.TimeRangeConfig`: a sealed, `type`-discriminated union with four variants — `LiveSnapshot`, `RollingWindow{value,unit}`, `CompletedPeriod{value,unit}`, `FixedWindow{startTimestamp,endTimestamp}` (unit ∈ day/week/month/quarter/year). Pure data carrier with Jackson polymorphic binding; record compact constructors enforce the invariants.
- **`TimeRangeConfigResolver`** (`openmetadata-service`): resolves a `TimeRangeConfig` against a run-start instant into `(startMillis, endMillis, live)`. All boundary math is UTC; week boundary is Monday (ISO), quarter is 3 months. `LiveSnapshot` resolves to the live index.
- **`DataInsightSystemChartRepository.getPreviewData(chart, start, end, live)`**: a live-aware overload that routes through the existing `buildDIChart(chart, start, end, live)` so a resolved window can read either the historical Data Insights index or the live snapshot index.

## Why

Data Insight chart time windows were expressed only as raw `start`/`end` query params, with the calendar math (rolling/completed/quarter/week boundaries, live detection) living downstream and duplicated across consumers. This makes the time-range *intent* a first-class, typed concept with one resolver, so previews and scheduled refreshes compute identical windows and richer window types (rolling, completed-period, live) are available to any DI chart consumer.

The resolver and type are additive — existing `start`/`end` paths are untouched.

## Testing

`TimeRangeConfigResolverTest` (22 cases): all four variants, UTC quarter/week/month/year boundaries, leap-day and end-of-month rollover, `LiveSnapshot` live flag, `FixedWindow` identity, plus the Jackson polymorphic deserialization contract (discriminator handling + compact-constructor invariants).
