### PR TITLE
feat(ui): split EntityBreadcrumbPureUtils into domain-specific files

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/Container/ContainerDataModel/ContainerDataModel.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Container/ContainerDataModel/ContainerDataModel.test.tsx
@@ -109,6 +109,7 @@ jest.mock('../../../utils/TableUtils', () => {
 
   return {
     ...actual,
+    getHighlightedRowClassName: jest.fn().mockReturnValue(''),
     getTableExpandableConfig: jest.fn(),
     getTableColumnConfigSelections: jest
       .fn()

--- a/openmetadata-ui/src/main/resources/ui/src/utils/EntityBreadcrumbPureUtils.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/EntityBreadcrumbPureUtils.ts
@@ -11,24 +11,22 @@
  *  limitations under the License.
  */
 
-import { isUndefined, startCase } from 'lodash';
-import type { TitleLink } from '../components/common/TitleBreadcrumb/TitleBreadcrumb.interface';
+/**
+ * Backward-compatible re-export barrel + getEntityBreadcrumbs dispatcher.
+ *
+ * Implementations split into:
+ *   - EntityDataBreadcrumbUtils.ts    — table, chart, API, container/drive helpers
+ *   - EntityServiceBreadcrumbUtils.ts — service-type breadcrumbs (12 service categories)
+ *   - EntityGovernanceBreadcrumbUtils.ts — glossary, domain, test, KPI, role, bot, etc.
+ *   - EntityLinkUtils.ts              — getEntityLinkFromType
+ */
+
+import { isUndefined } from 'lodash';
 import type { DataAssetsWithoutServiceField } from '../components/DataAssets/DataAssetsHeader/DataAssetsHeader.interface';
-import type { EntityWithServices } from '../components/Explore/ExplorePage.interface';
-import type {
-  SearchedDataProps,
-  SourceType,
-} from '../components/SearchedData/SearchedData.interface';
-import { ROUTES } from '../constants/constants';
-import {
-  GlobalSettingOptions,
-  GlobalSettingsMenuCategory,
-} from '../constants/GlobalSettings.constants';
-import { EntityTabs, EntityType } from '../enums/entity.enum';
+import type { SearchedDataProps } from '../components/SearchedData/SearchedData.interface';
+import { EntityType } from '../enums/entity.enum';
 import { ServiceCategory, ServiceCategoryPlural } from '../enums/service.enum';
 import type { Kpi } from '../generated/dataInsight/kpi/kpi';
-import type { Classification } from '../generated/entity/classification/classification';
-import type { Tag } from '../generated/entity/classification/tag';
 import type { APICollection } from '../generated/entity/data/apiCollection';
 import type { APIEndpoint } from '../generated/entity/data/apiEndpoint';
 import type { Chart } from '../generated/entity/data/chart';
@@ -47,433 +45,83 @@ import type { Topic } from '../generated/entity/data/topic';
 import type { Worksheet } from '../generated/entity/data/worksheet';
 import type { DataProduct } from '../generated/entity/domains/dataProduct';
 import type { Team } from '../generated/entity/teams/team';
-import {
-  AlertType,
-  type EventSubscription,
-} from '../generated/events/eventSubscription';
+import type { EventSubscription } from '../generated/events/eventSubscription';
 import type { TestCase, TestSuite } from '../generated/tests/testCase';
-import type { EntityReference } from '../generated/type/entityUsage';
-import { DataInsightTabs } from '../interface/data-insight.interface';
 import type {
   SearchSourceAlias,
   TableColumnSearchSource,
 } from '../interface/search.interface';
-import { DataQualityPageTabs } from '../pages/DataQuality/DataQualityPage.interface';
-import { getDataInsightPathWithFqn } from './DataInsightUtils';
-import { getEntityName } from './EntityNameUtils';
-import Fqn from './Fqn';
-import i18n from './i18next/LocalUtil';
-import { getKnowledgePagePath } from './KnowledgePageUtils';
 import {
-  getApplicationDetailsPath,
-  getBotsPagePath,
-  getBotsPath,
-  getClassificationTagPath,
-  getDataProductDetailsPath,
-  getDataQualityPagePath,
-  getDomainDetailsPath,
-  getDomainPath,
-  getEntityDetailsPath,
-  getGlossaryPath,
-  getGlossaryTermDetailsPath,
-  getKpiPath,
-  getNotificationAlertDetailsPath,
-  getObservabilityAlertDetailsPath,
-  getPersonaDetailsPath,
-  getPolicyWithFqnPath,
-  getRoleWithFqnPath,
-  getServiceDetailsPath,
-  getSettingPath,
-  getTagsDetailsPath,
-  getTeamsWithFqnPath,
-  getTestCaseDetailPagePath,
-} from './RouterUtils';
-import { getServiceRouteFromServiceType } from './ServiceUtils';
+  getBreadCrumbForAPICollection,
+  getBreadCrumbForAPIEndpoint,
+  getBreadcrumbForChart,
+  getBreadcrumbForEntitiesWithServiceOnly,
+  getBreadcrumbForEntityWithParent,
+  getBreadcrumbForTable,
+} from './EntityDataBreadcrumbUtils';
+import {
+  getBreadcrumbForApplication,
+  getBreadcrumbForBot,
+  getBreadcrumbForClassification,
+  getBreadcrumbForDataProduct,
+  getBreadcrumbForDomain,
+  getBreadcrumbForEventSubscription,
+  getBreadcrumbForGlossaryOrTerm,
+  getBreadcrumbForKnowledgePage,
+  getBreadCrumbForKpi,
+  getBreadcrumbForMetric,
+  getBreadcrumbForPersona,
+  getBreadcrumbForPolicy,
+  getBreadcrumbForRole,
+  getBreadcrumbForTag,
+  getBreadcrumbForTeam,
+  getBreadcrumbForTestCase,
+  getBreadcrumbForTestSuite,
+} from './EntityGovernanceBreadcrumbUtils';
+import { getEntityName } from './EntityNameUtils';
+import {
+  getBreadcrumbForDatabase,
+  getBreadcrumbForDatabaseSchema,
+  getBreadcrumbForDatabaseService,
+  getServiceCategoryBreadcrumb,
+} from './EntityServiceBreadcrumbUtils';
+import { getEntityDetailsPath, getServiceDetailsPath } from './RouterUtils';
 
-const { t } = i18n;
-
-export const getEntityLinkFromType = (
-  fullyQualifiedName: string,
-  entityType: EntityType,
-  entity?: SearchSourceAlias
-) => {
-  switch (entityType) {
-    case EntityType.TABLE:
-    case EntityType.TOPIC:
-    case EntityType.DASHBOARD:
-    case EntityType.CHART:
-    case EntityType.PIPELINE:
-    case EntityType.MLMODEL:
-    case EntityType.CONTAINER:
-    case EntityType.DATABASE:
-    case EntityType.DATABASE_SCHEMA:
-    case EntityType.DASHBOARD_DATA_MODEL:
-    case EntityType.STORED_PROCEDURE:
-    case EntityType.SEARCH_INDEX:
-    case EntityType.API_COLLECTION:
-    case EntityType.API_ENDPOINT:
-    case EntityType.DIRECTORY:
-    case EntityType.FILE:
-    case EntityType.SPREADSHEET:
-    case EntityType.WORKSHEET:
-      return getEntityDetailsPath(entityType, fullyQualifiedName);
-    case EntityType.METRIC:
-      return getEntityDetailsPath(entityType, fullyQualifiedName);
-    case EntityType.DATA_PRODUCT:
-      return getDataProductDetailsPath(fullyQualifiedName);
-    case EntityType.GLOSSARY:
-    case EntityType.GLOSSARY_TERM:
-      return getGlossaryTermDetailsPath(fullyQualifiedName);
-    case EntityType.TAG:
-      return getClassificationTagPath(fullyQualifiedName);
-    case EntityType.CLASSIFICATION:
-      return getTagsDetailsPath(fullyQualifiedName);
-
-    case EntityType.DATABASE_SERVICE:
-      return getServiceDetailsPath(
-        fullyQualifiedName,
-        ServiceCategory.DATABASE_SERVICES
-      );
-    case EntityType.MESSAGING_SERVICE:
-      return getServiceDetailsPath(
-        fullyQualifiedName,
-        ServiceCategory.MESSAGING_SERVICES
-      );
-    case EntityType.DASHBOARD_SERVICE:
-      return getServiceDetailsPath(
-        fullyQualifiedName,
-        ServiceCategory.DASHBOARD_SERVICES
-      );
-    case EntityType.PIPELINE_SERVICE:
-      return getServiceDetailsPath(
-        fullyQualifiedName,
-        ServiceCategory.PIPELINE_SERVICES
-      );
-    case EntityType.MLMODEL_SERVICE:
-      return getServiceDetailsPath(
-        fullyQualifiedName,
-        ServiceCategory.ML_MODEL_SERVICES
-      );
-    case EntityType.STORAGE_SERVICE:
-      return getServiceDetailsPath(
-        fullyQualifiedName,
-        ServiceCategory.STORAGE_SERVICES
-      );
-    case EntityType.SEARCH_SERVICE:
-      return getServiceDetailsPath(
-        fullyQualifiedName,
-        ServiceCategory.SEARCH_SERVICES
-      );
-    case EntityType.METADATA_SERVICE:
-      return getServiceDetailsPath(
-        fullyQualifiedName,
-        ServiceCategory.METADATA_SERVICES
-      );
-    case EntityType.API_SERVICE:
-      return getServiceDetailsPath(
-        fullyQualifiedName,
-        ServiceCategory.API_SERVICES
-      );
-    case EntityType.DRIVE_SERVICE:
-      return getServiceDetailsPath(
-        fullyQualifiedName,
-        ServiceCategory.DRIVE_SERVICES
-      );
-    case EntityType.BOT:
-      return getBotsPath(fullyQualifiedName);
-    case EntityType.TEAM:
-      return getTeamsWithFqnPath(fullyQualifiedName);
-    case EntityType.APPLICATION:
-      return getApplicationDetailsPath(fullyQualifiedName);
-    case EntityType.TEST_CASE:
-      return getTestCaseDetailPagePath(fullyQualifiedName);
-    case EntityType.TEST_SUITE:
-      return getEntityDetailsPath(
-        EntityType.TABLE,
-        fullyQualifiedName,
-        EntityTabs.PROFILER
-      );
-    case EntityType.DOMAIN:
-      return getDomainDetailsPath(fullyQualifiedName);
-    case EntityType.EVENT_SUBSCRIPTION:
-      return (entity as EventSubscription)?.alertType ===
-        AlertType.Observability
-        ? getObservabilityAlertDetailsPath(fullyQualifiedName)
-        : getNotificationAlertDetailsPath(fullyQualifiedName);
-    case EntityType.ROLE:
-      return getRoleWithFqnPath(fullyQualifiedName);
-    case EntityType.POLICY:
-      return getPolicyWithFqnPath(fullyQualifiedName);
-    case EntityType.PERSONA:
-      return getPersonaDetailsPath(fullyQualifiedName);
-    case EntityType.KPI:
-      return getKpiPath(fullyQualifiedName);
-    case EntityType.KNOWLEDGE_PAGE:
-      return getKnowledgePagePath(fullyQualifiedName);
-    default:
-      return '';
-  }
-};
-
-export const getBreadcrumbForTable = (
-  entity: Table,
-  includeCurrent = false
-) => {
-  const { service, database, databaseSchema } = entity;
-
-  return [
-    {
-      name: getEntityName(service),
-      url: service?.name
-        ? getServiceDetailsPath(
-            service?.name,
-            ServiceCategory.DATABASE_SERVICES
-          )
-        : '',
-    },
-    {
-      name: getEntityName(database),
-      url: getEntityDetailsPath(
-        EntityType.DATABASE,
-        database?.fullyQualifiedName ?? ''
-      ),
-    },
-    {
-      name: getEntityName(databaseSchema),
-      url: getEntityDetailsPath(
-        EntityType.DATABASE_SCHEMA,
-        databaseSchema?.fullyQualifiedName ?? ''
-      ),
-    },
-    ...(includeCurrent
-      ? [
-          {
-            name: entity.name,
-            url: getEntityLinkFromType(
-              entity.fullyQualifiedName ?? '',
-              ((entity as SourceType).entityType as EntityType) ??
-                EntityType.TABLE
-            ),
-          },
-        ]
-      : []),
-  ];
-};
-
-export const getBreadcrumbForChart = (entity: Chart) => {
-  const { service } = entity;
-
-  return [
-    {
-      name: getEntityName(service),
-      url: getServiceDetailsPath(
-        service?.name ?? '',
-        ServiceCategoryPlural[
-          service?.type as keyof typeof ServiceCategoryPlural
-        ]
-      ),
-    },
-  ];
-};
-
-export const getBreadCrumbForAPICollection = (entity: APICollection) => {
-  const { service } = entity;
-
-  return [
-    {
-      name: startCase(ServiceCategory.API_SERVICES),
-      url: getSettingPath(
-        GlobalSettingsMenuCategory.SERVICES,
-        getServiceRouteFromServiceType(ServiceCategory.API_SERVICES)
-      ),
-    },
-    {
-      name: getEntityName(service),
-      url: service?.name
-        ? getServiceDetailsPath(
-            service?.name ?? '',
-            ServiceCategoryPlural[
-              service?.type as keyof typeof ServiceCategoryPlural
-            ]
-          )
-        : '',
-    },
-  ];
-};
-
-export const getBreadCrumbForAPIEndpoint = (entity: APIEndpoint) => {
-  const { service, apiCollection } = entity;
-
-  return [
-    {
-      name: startCase(ServiceCategory.API_SERVICES),
-      url: getSettingPath(
-        GlobalSettingsMenuCategory.SERVICES,
-        getServiceRouteFromServiceType(ServiceCategory.API_SERVICES)
-      ),
-    },
-    {
-      name: getEntityName(service),
-      url: service?.name
-        ? getServiceDetailsPath(
-            service?.name ?? '',
-            ServiceCategoryPlural[
-              service?.type as keyof typeof ServiceCategoryPlural
-            ]
-          )
-        : '',
-    },
-    {
-      name: getEntityName(apiCollection),
-      url: getEntityDetailsPath(
-        EntityType.API_COLLECTION,
-        apiCollection?.fullyQualifiedName ?? ''
-      ),
-    },
-  ];
-};
-
-export const getBreadcrumbForEntitiesWithServiceOnly = (
-  entity: EntityWithServices,
-  includeCurrent = false
-) => {
-  const { service } = entity;
-
-  return [
-    {
-      name: getEntityName(service),
-      url: service?.name
-        ? getServiceDetailsPath(
-            service?.name,
-            ServiceCategoryPlural[
-              service?.type as keyof typeof ServiceCategoryPlural
-            ]
-          )
-        : '',
-    },
-    ...(includeCurrent
-      ? [
-          {
-            name: entity.name,
-            url: getEntityLinkFromType(
-              entity.fullyQualifiedName ?? '',
-              (entity as SourceType).entityType as EntityType
-            ),
-          },
-        ]
-      : []),
-  ];
-};
-
-export function getBreadcrumbForEntityWithParent<
-  T extends Container | Directory | File
->(data: {
-  entity: T;
-  entityType: EntityType;
-  includeCurrent?: boolean;
-  parents?: Container[] | EntityReference[];
-}) {
-  const { entity, entityType, includeCurrent = false, parents = [] } = data;
-  const { service } = entity;
-
-  return [
-    {
-      name: getEntityName(service),
-      url: service?.name
-        ? getServiceDetailsPath(
-            service?.name,
-            ServiceCategoryPlural[
-              service?.type as keyof typeof ServiceCategoryPlural
-            ]
-          )
-        : '',
-    },
-    ...(parents.length > 0
-      ? parents.map((parent) => ({
-          name: getEntityName(parent),
-          url: getEntityLinkFromType(
-            parent?.fullyQualifiedName ?? '',
-            entityType
-          ),
-        }))
-      : []),
-    ...(includeCurrent
-      ? [
-          {
-            name: entity.name,
-            url: getEntityLinkFromType(
-              entity.fullyQualifiedName ?? '',
-              (entity as SourceType).entityType as EntityType
-            ),
-          },
-        ]
-      : []),
-  ];
-}
-
-export const getBreadcrumbForTestCase = (entity: TestCase): TitleLink[] => [
-  {
-    name: i18n.t('label.data-quality'),
-    url: `${ROUTES.DATA_QUALITY}/${DataQualityPageTabs.TEST_CASES}`,
-  },
-  {
-    name: entity.name,
-    url: getEntityLinkFromType(
-      entity.fullyQualifiedName ?? '',
-      (entity as SourceType)?.entityType as EntityType
-    ),
-    options: {
-      state: {
-        breadcrumbData: [
-          {
-            name: i18n.t('label.data-quality'),
-            url: `${ROUTES.DATA_QUALITY}/${DataQualityPageTabs.TEST_CASES}`,
-          },
-        ],
-      },
-    },
-  },
-];
-
-export const getBreadcrumbForTestSuite = (entity: TestSuite) => {
-  return entity.basic
-    ? [
-        {
-          name: getEntityName(entity.basicEntityReference),
-          url: getEntityLinkFromType(
-            entity.basicEntityReference?.fullyQualifiedName ?? '',
-            EntityType.TABLE
-          ),
-        },
-        {
-          name: t('label.test-suite'),
-          url: '',
-        },
-      ]
-    : [
-        {
-          name: t('label.test-suite-plural'),
-          url: getDataQualityPagePath(DataQualityPageTabs.TEST_SUITES),
-        },
-        {
-          name: getEntityName(entity),
-          url: '',
-        },
-      ];
-};
-
-export const getBreadCrumbForKpi = (entity: Kpi) => {
-  return [
-    {
-      name: i18n.t('label.kpi-uppercase'),
-      url: getDataInsightPathWithFqn(DataInsightTabs.KPIS),
-    },
-    {
-      name: getEntityName(entity),
-      url: getKpiPath(entity.name),
-    },
-  ];
-};
+// Re-export all for backward compatibility
+export {
+  getBreadCrumbForAPICollection,
+  getBreadCrumbForAPIEndpoint,
+  getBreadcrumbForChart,
+  getBreadcrumbForEntitiesWithServiceOnly,
+  getBreadcrumbForEntityWithParent,
+  getBreadcrumbForTable,
+} from './EntityDataBreadcrumbUtils';
+export {
+  getBreadcrumbForApplication,
+  getBreadcrumbForBot,
+  getBreadcrumbForClassification,
+  getBreadcrumbForDataProduct,
+  getBreadcrumbForDomain,
+  getBreadcrumbForEventSubscription,
+  getBreadcrumbForGlossaryOrTerm,
+  getBreadcrumbForKnowledgePage,
+  getBreadCrumbForKpi,
+  getBreadcrumbForMetric,
+  getBreadcrumbForPersona,
+  getBreadcrumbForPolicy,
+  getBreadcrumbForRole,
+  getBreadcrumbForTag,
+  getBreadcrumbForTeam,
+  getBreadcrumbForTestCase,
+  getBreadcrumbForTestSuite,
+} from './EntityGovernanceBreadcrumbUtils';
+export { getEntityLinkFromType } from './EntityLinkUtils';
+export {
+  getBreadcrumbForDatabase,
+  getBreadcrumbForDatabaseSchema,
+  getBreadcrumbForDatabaseService,
+  getServiceCategoryBreadcrumb,
+} from './EntityServiceBreadcrumbUtils';
 
 export const getEntityBreadcrumbs = (
   entity:
@@ -497,244 +145,57 @@ export const getEntityBreadcrumbs = (
       return getBreadcrumbForTable(entity as Table, includeCurrent);
     case EntityType.GLOSSARY:
     case EntityType.GLOSSARY_TERM:
-      // eslint-disable-next-line no-case-declarations
-      const glossary = (entity as GlossaryTerm).glossary;
-      if (!glossary) {
-        return [];
-      }
-      // eslint-disable-next-line no-case-declarations
-      const fqnList = entity.fullyQualifiedName
-        ? Fqn.split(entity.fullyQualifiedName)
-        : [];
-      // eslint-disable-next-line no-case-declarations
-      const tree = fqnList.slice(1, fqnList.length);
-
-      return [
-        {
-          name: glossary.fullyQualifiedName,
-          url: getGlossaryPath(glossary.fullyQualifiedName),
-        },
-        ...tree.map((fqn, index, source) => ({
-          name: fqn,
-          url: getGlossaryPath(
-            `${glossary.fullyQualifiedName}.${source
-              .slice(0, index + 1)
-              .join('.')}`
-          ),
-        })),
-      ];
+      return getBreadcrumbForGlossaryOrTerm(entity as GlossaryTerm);
     case EntityType.TAG: {
-      return [
-        {
-          name: getEntityName((entity as Tag).classification),
-          url: getTagsDetailsPath(
-            (entity as Tag).classification?.fullyQualifiedName ?? ''
-          ),
-        },
-        {
-          name: entity.name,
-          url: getClassificationTagPath(entity.fullyQualifiedName ?? ''),
-        },
-      ];
+      const tag = entity as unknown as {
+        classification?: {
+          fullyQualifiedName?: string;
+          displayName?: string;
+          name?: string;
+        };
+        name: string;
+        fullyQualifiedName?: string;
+      };
+
+      return getBreadcrumbForTag(
+        getEntityName(tag.classification),
+        tag.classification?.fullyQualifiedName ?? '',
+        tag.name,
+        tag.fullyQualifiedName ?? ''
+      );
     }
-
     case EntityType.CLASSIFICATION:
-      return [
-        {
-          name: getEntityName(entity as Classification),
-          url: '',
-        },
-      ];
-
+      return getBreadcrumbForClassification(getEntityName(entity as never));
     case EntityType.DATABASE:
-      return [
-        {
-          name: startCase(ServiceCategory.DATABASE_SERVICES),
-          url: getSettingPath(
-            GlobalSettingsMenuCategory.SERVICES,
-            getServiceRouteFromServiceType(ServiceCategory.DATABASE_SERVICES)
-          ),
-        },
-        ...getBreadcrumbForEntitiesWithServiceOnly(entity as Database),
-        {
-          name: entity.name,
-          url: getEntityLinkFromType(
-            entity.fullyQualifiedName ?? '',
-            ((entity as SourceType).entityType as EntityType) ??
-              EntityType.DATABASE
-          ),
-        },
-      ];
-
+      return getBreadcrumbForDatabase(entity as Database);
     case EntityType.DATABASE_SCHEMA:
-      return [
-        {
-          name: startCase(ServiceCategory.DATABASE_SERVICES),
-          url: getSettingPath(
-            GlobalSettingsMenuCategory.SERVICES,
-            getServiceRouteFromServiceType(ServiceCategory.DATABASE_SERVICES)
-          ),
-        },
-        {
-          name: getEntityName((entity as DatabaseSchema).service),
-          url: (entity as DatabaseSchema).service?.name
-            ? getServiceDetailsPath(
-                (entity as DatabaseSchema).service?.name ?? '',
-                ServiceCategoryPlural[
-                  (entity as DatabaseSchema).service
-                    ?.type as keyof typeof ServiceCategoryPlural
-                ]
-              )
-            : '',
-        },
-        {
-          name: getEntityName((entity as DatabaseSchema).database),
-          url: getEntityDetailsPath(
-            EntityType.DATABASE,
-            (entity as DatabaseSchema).database?.fullyQualifiedName ?? ''
-          ),
-        },
-        {
-          name: entity.name,
-          url: getEntityLinkFromType(
-            entity.fullyQualifiedName ?? '',
-            ((entity as SourceType).entityType as EntityType) ??
-              EntityType.DATABASE_SCHEMA
-          ),
-        },
-      ];
-
+      return getBreadcrumbForDatabaseSchema(entity as DatabaseSchema);
     case EntityType.DATABASE_SERVICE:
-      return [
-        {
-          name: startCase(ServiceCategory.DATABASE_SERVICES),
-          url: getSettingPath(
-            GlobalSettingsMenuCategory.SERVICES,
-            getServiceRouteFromServiceType(ServiceCategory.DATABASE_SERVICES)
-          ),
-        },
-        ...(includeCurrent
-          ? [
-              {
-                name: entity.name,
-                url: getServiceDetailsPath(
-                  entity?.name,
-                  ServiceCategory.DATABASE_SERVICES
-                ),
-              },
-            ]
-          : []),
-      ];
-
+      return getBreadcrumbForDatabaseService(
+        entity.name,
+        entity.name,
+        includeCurrent
+      );
     case EntityType.DASHBOARD_SERVICE:
-      return [
-        {
-          name: startCase(ServiceCategory.DASHBOARD_SERVICES),
-          url: getSettingPath(
-            GlobalSettingsMenuCategory.SERVICES,
-            getServiceRouteFromServiceType(ServiceCategory.DASHBOARD_SERVICES)
-          ),
-        },
-      ];
-
+      return getServiceCategoryBreadcrumb(ServiceCategory.DASHBOARD_SERVICES);
     case EntityType.MESSAGING_SERVICE:
-      return [
-        {
-          name: startCase(ServiceCategory.MESSAGING_SERVICES),
-          url: getSettingPath(
-            GlobalSettingsMenuCategory.SERVICES,
-            getServiceRouteFromServiceType(ServiceCategory.MESSAGING_SERVICES)
-          ),
-        },
-      ];
-
+      return getServiceCategoryBreadcrumb(ServiceCategory.MESSAGING_SERVICES);
     case EntityType.PIPELINE_SERVICE:
-      return [
-        {
-          name: startCase(ServiceCategory.PIPELINE_SERVICES),
-          url: getSettingPath(
-            GlobalSettingsMenuCategory.SERVICES,
-            getServiceRouteFromServiceType(ServiceCategory.PIPELINE_SERVICES)
-          ),
-        },
-      ];
-
+      return getServiceCategoryBreadcrumb(ServiceCategory.PIPELINE_SERVICES);
     case EntityType.MLMODEL_SERVICE:
-      return [
-        {
-          name: startCase(ServiceCategory.ML_MODEL_SERVICES),
-          url: getSettingPath(
-            GlobalSettingsMenuCategory.SERVICES,
-            getServiceRouteFromServiceType(ServiceCategory.ML_MODEL_SERVICES)
-          ),
-        },
-      ];
-
+      return getServiceCategoryBreadcrumb(ServiceCategory.ML_MODEL_SERVICES);
     case EntityType.METADATA_SERVICE:
-      return [
-        {
-          name: startCase(ServiceCategory.METADATA_SERVICES),
-          url: getSettingPath(
-            GlobalSettingsMenuCategory.SERVICES,
-            getServiceRouteFromServiceType(ServiceCategory.METADATA_SERVICES)
-          ),
-        },
-      ];
-
+      return getServiceCategoryBreadcrumb(ServiceCategory.METADATA_SERVICES);
     case EntityType.STORAGE_SERVICE:
-      return [
-        {
-          name: startCase(ServiceCategory.STORAGE_SERVICES),
-          url: getSettingPath(
-            GlobalSettingsMenuCategory.SERVICES,
-            getServiceRouteFromServiceType(ServiceCategory.STORAGE_SERVICES)
-          ),
-        },
-      ];
-
+      return getServiceCategoryBreadcrumb(ServiceCategory.STORAGE_SERVICES);
     case EntityType.SEARCH_SERVICE:
-      return [
-        {
-          name: startCase(ServiceCategory.SEARCH_SERVICES),
-          url: getSettingPath(
-            GlobalSettingsMenuCategory.SERVICES,
-            getServiceRouteFromServiceType(ServiceCategory.SEARCH_SERVICES)
-          ),
-        },
-      ];
+      return getServiceCategoryBreadcrumb(ServiceCategory.SEARCH_SERVICES);
     case EntityType.API_SERVICE:
-      return [
-        {
-          name: startCase(ServiceCategory.API_SERVICES),
-          url: getSettingPath(
-            GlobalSettingsMenuCategory.SERVICES,
-            getServiceRouteFromServiceType(ServiceCategory.API_SERVICES)
-          ),
-        },
-      ];
-
+      return getServiceCategoryBreadcrumb(ServiceCategory.API_SERVICES);
     case EntityType.SECURITY_SERVICE:
-      return [
-        {
-          name: startCase(ServiceCategory.SECURITY_SERVICES),
-          url: getSettingPath(
-            GlobalSettingsMenuCategory.SERVICES,
-            getServiceRouteFromServiceType(ServiceCategory.SECURITY_SERVICES)
-          ),
-        },
-      ];
-
+      return getServiceCategoryBreadcrumb(ServiceCategory.SECURITY_SERVICES);
     case EntityType.DRIVE_SERVICE:
-      return [
-        {
-          name: startCase(ServiceCategory.DRIVE_SERVICES),
-          url: getSettingPath(
-            GlobalSettingsMenuCategory.SERVICES,
-            getServiceRouteFromServiceType(ServiceCategory.DRIVE_SERVICES)
-          ),
-        },
-      ];
-
+      return getServiceCategoryBreadcrumb(ServiceCategory.DRIVE_SERVICES);
     case EntityType.CONTAINER: {
       const data = entity as Container;
 
@@ -745,7 +206,6 @@ export const getEntityBreadcrumbs = (
         parents: isUndefined(data.parent) ? [] : [data.parent],
       });
     }
-
     case EntityType.DIRECTORY: {
       const data = entity as Directory;
 
@@ -756,7 +216,6 @@ export const getEntityBreadcrumbs = (
         parents: isUndefined(data.parent) ? [] : [data.parent],
       });
     }
-
     case EntityType.FILE: {
       const data = entity as File;
 
@@ -767,7 +226,6 @@ export const getEntityBreadcrumbs = (
         parents: isUndefined(data.directory) ? [] : [data.directory],
       });
     }
-
     case EntityType.SPREADSHEET: {
       const data = entity as Spreadsheet;
 
@@ -778,7 +236,6 @@ export const getEntityBreadcrumbs = (
         parents: isUndefined(data.directory) ? [] : [data.directory],
       });
     }
-
     case EntityType.WORKSHEET: {
       const data = entity as Worksheet;
 
@@ -789,232 +246,106 @@ export const getEntityBreadcrumbs = (
         parents: isUndefined(data.spreadsheet) ? [] : [data.spreadsheet],
       });
     }
-
     case EntityType.DOMAIN:
-      return [
-        {
-          name: i18n.t('label.domain-plural'),
-          url: getDomainPath(),
-        },
-      ];
-
-    case EntityType.DATA_PRODUCT: {
-      const data = entity as DataProduct;
-      if (!data.domains?.length) {
-        return [];
-      }
-
-      return [
-        {
-          name: getEntityName(data.domains[0]),
-          url: getDomainPath(data.domains[0].fullyQualifiedName),
-        },
-      ];
-    }
-
-    case EntityType.TEST_CASE: {
+      return getBreadcrumbForDomain();
+    case EntityType.DATA_PRODUCT:
+      return getBreadcrumbForDataProduct(entity as DataProduct);
+    case EntityType.TEST_CASE:
       return getBreadcrumbForTestCase(entity as TestCase);
-    }
-    case EntityType.EVENT_SUBSCRIPTION: {
-      return [
-        {
-          name: startCase(EntityType.ALERT),
-          url:
-            (entity as EventSubscription).alertType === AlertType.Observability
-              ? ROUTES.OBSERVABILITY_ALERTS
-              : ROUTES.NOTIFICATION_ALERT_LIST,
-        },
-        {
-          name: entity.name,
-          url: getEntityLinkFromType(
-            entity.fullyQualifiedName ?? '',
-            (entity as SourceType).entityType as EntityType,
-            entity as SearchSourceAlias
-          ),
-        },
-      ];
-    }
-
-    case EntityType.TEST_SUITE: {
+    case EntityType.EVENT_SUBSCRIPTION:
+      return getBreadcrumbForEventSubscription(
+        entity as EventSubscription,
+        entity.fullyQualifiedName ?? '',
+        entity as SearchSourceAlias
+      );
+    case EntityType.TEST_SUITE:
       return getBreadcrumbForTestSuite(entity as TestSuite);
-    }
-
-    case EntityType.BOT: {
-      return [
-        {
-          name: startCase(EntityType.BOT),
-          url: getBotsPagePath(),
-        },
-        {
-          name: entity.name,
-          url: getBotsPath(entity.fullyQualifiedName ?? ''),
-        },
-      ];
-    }
-
-    case EntityType.TEAM: {
-      return [
-        {
-          name: getEntityName((entity as Team).parents?.[0]),
-          url: getTeamsWithFqnPath(
-            (entity as Team).parents?.[0].fullyQualifiedName ?? ''
-          ),
-        },
-        {
-          name: getEntityName(entity),
-          url: getTeamsWithFqnPath(entity.fullyQualifiedName ?? ''),
-        },
-      ];
-    }
-
-    case EntityType.APPLICATION: {
-      return [
-        {
-          name: i18n.t('label.application-plural'),
-          url: getSettingPath(GlobalSettingsMenuCategory.APPLICATIONS),
-        },
-        {
-          name: getEntityName(entity),
-          url: getApplicationDetailsPath(entity.fullyQualifiedName ?? ''),
-        },
-      ];
-    }
-
-    case EntityType.PERSONA: {
-      return [
-        {
-          name: i18n.t('label.persona-plural'),
-          url: getSettingPath(
-            GlobalSettingsMenuCategory.MEMBERS,
-            GlobalSettingOptions.PERSONA
-          ),
-        },
-        {
-          name: getEntityName(entity),
-          url: getPersonaDetailsPath(entity.fullyQualifiedName ?? ''),
-        },
-      ];
-    }
-
-    case EntityType.ROLE: {
-      return [
-        {
-          name: i18n.t('label.role-plural'),
-          url: getSettingPath(
-            GlobalSettingsMenuCategory.ACCESS,
-            GlobalSettingOptions.ROLES
-          ),
-        },
-        {
-          name: getEntityName(entity),
-          url: getRoleWithFqnPath(entity.fullyQualifiedName ?? ''),
-        },
-      ];
-    }
-
-    case EntityType.POLICY: {
-      return [
-        {
-          name: i18n.t('label.policy-plural'),
-          url: getSettingPath(
-            GlobalSettingsMenuCategory.ACCESS,
-            GlobalSettingOptions.POLICIES
-          ),
-        },
-        {
-          name: getEntityName(entity),
-          url: getPolicyWithFqnPath(entity.fullyQualifiedName ?? ''),
-        },
-      ];
-    }
-
+    case EntityType.BOT:
+      return getBreadcrumbForBot(entity.name, entity.fullyQualifiedName ?? '');
+    case EntityType.TEAM:
+      return getBreadcrumbForTeam(entity as Team);
+    case EntityType.APPLICATION:
+      return getBreadcrumbForApplication(
+        getEntityName(entity as never),
+        entity.fullyQualifiedName ?? ''
+      );
+    case EntityType.PERSONA:
+      return getBreadcrumbForPersona(
+        getEntityName(entity as never),
+        entity.fullyQualifiedName ?? ''
+      );
+    case EntityType.ROLE:
+      return getBreadcrumbForRole(
+        getEntityName(entity as never),
+        entity.fullyQualifiedName ?? ''
+      );
+    case EntityType.POLICY:
+      return getBreadcrumbForPolicy(
+        getEntityName(entity as never),
+        entity.fullyQualifiedName ?? ''
+      );
     case EntityType.API_COLLECTION:
       return getBreadCrumbForAPICollection(entity as APICollection);
-
     case EntityType.API_ENDPOINT:
       return getBreadCrumbForAPIEndpoint(entity as APIEndpoint);
-
-    case EntityType.METRIC: {
-      return [
-        {
-          name: t('label.metric-plural'),
-          url: ROUTES.METRICS,
-        },
-        {
-          name: entity.name,
-          url: '',
-        },
-      ];
-    }
-
+    case EntityType.METRIC:
+      return getBreadcrumbForMetric(entity.name);
     case EntityType.KPI:
       return getBreadCrumbForKpi(entity as Kpi);
-
     case EntityType.KNOWLEDGE_PAGE:
-      return [
-        {
-          name: i18n.t('label.knowledge-center'),
-          url: ROUTES.KNOWLEDGE_CENTER,
-        },
-        {
-          name: getEntityName(entity),
-          url: '',
-          activeTitle: Boolean(includeCurrent),
-        },
-      ];
-
+      return getBreadcrumbForKnowledgePage(
+        getEntityName(entity as never),
+        includeCurrent
+      );
     case EntityType.TABLE_COLUMN: {
       const columnData = entity as TableColumnSearchSource;
-      const service = columnData.service;
-      const database = columnData.database;
-      const databaseSchema = columnData.databaseSchema;
-      const table = columnData.table;
 
       return [
-        ...(service
+        ...(columnData.service
           ? [
               {
-                name: getEntityName(service),
-                url: service?.name
+                name: getEntityName(columnData.service),
+                url: columnData.service?.name
                   ? getServiceDetailsPath(
-                      service?.name,
+                      columnData.service?.name,
                       ServiceCategoryPlural[
-                        service?.type as keyof typeof ServiceCategoryPlural
+                        columnData.service
+                          ?.type as keyof typeof ServiceCategoryPlural
                       ]
                     )
                   : '',
               },
             ]
           : []),
-        ...(database
+        ...(columnData.database
           ? [
               {
-                name: getEntityName(database),
+                name: getEntityName(columnData.database),
                 url: getEntityDetailsPath(
                   EntityType.DATABASE,
-                  database?.fullyQualifiedName ?? ''
+                  columnData.database?.fullyQualifiedName ?? ''
                 ),
               },
             ]
           : []),
-        ...(databaseSchema
+        ...(columnData.databaseSchema
           ? [
               {
-                name: getEntityName(databaseSchema),
+                name: getEntityName(columnData.databaseSchema),
                 url: getEntityDetailsPath(
                   EntityType.DATABASE_SCHEMA,
-                  databaseSchema?.fullyQualifiedName ?? ''
+                  columnData.databaseSchema?.fullyQualifiedName ?? ''
                 ),
               },
             ]
           : []),
-        ...(table
+        ...(columnData.table
           ? [
               {
-                name: getEntityName(table),
+                name: getEntityName(columnData.table),
                 url: getEntityDetailsPath(
                   EntityType.TABLE,
-                  table?.fullyQualifiedName ?? ''
+                  columnData.table?.fullyQualifiedName ?? ''
                 ),
               },
             ]
@@ -1029,7 +360,6 @@ export const getEntityBreadcrumbs = (
           : []),
       ];
     }
-
     case EntityType.TOPIC:
     case EntityType.DASHBOARD:
     case EntityType.PIPELINE:

--- a/openmetadata-ui/src/main/resources/ui/src/utils/EntityBreadcrumbPureUtils.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/EntityBreadcrumbPureUtils.ts
@@ -165,7 +165,9 @@ export const getEntityBreadcrumbs = (
       );
     }
     case EntityType.CLASSIFICATION:
-      return getBreadcrumbForClassification(getEntityName(entity as never));
+      return getBreadcrumbForClassification(
+        getEntityName(entity as { name?: string; displayName?: string })
+      );
     case EntityType.DATABASE:
       return getBreadcrumbForDatabase(entity as Database);
     case EntityType.DATABASE_SCHEMA:
@@ -266,22 +268,22 @@ export const getEntityBreadcrumbs = (
       return getBreadcrumbForTeam(entity as Team);
     case EntityType.APPLICATION:
       return getBreadcrumbForApplication(
-        getEntityName(entity as never),
+        getEntityName(entity as { name?: string; displayName?: string }),
         entity.fullyQualifiedName ?? ''
       );
     case EntityType.PERSONA:
       return getBreadcrumbForPersona(
-        getEntityName(entity as never),
+        getEntityName(entity as { name?: string; displayName?: string }),
         entity.fullyQualifiedName ?? ''
       );
     case EntityType.ROLE:
       return getBreadcrumbForRole(
-        getEntityName(entity as never),
+        getEntityName(entity as { name?: string; displayName?: string }),
         entity.fullyQualifiedName ?? ''
       );
     case EntityType.POLICY:
       return getBreadcrumbForPolicy(
-        getEntityName(entity as never),
+        getEntityName(entity as { name?: string; displayName?: string }),
         entity.fullyQualifiedName ?? ''
       );
     case EntityType.API_COLLECTION:
@@ -294,7 +296,7 @@ export const getEntityBreadcrumbs = (
       return getBreadCrumbForKpi(entity as Kpi);
     case EntityType.KNOWLEDGE_PAGE:
       return getBreadcrumbForKnowledgePage(
-        getEntityName(entity as never),
+        getEntityName(entity as { name?: string; displayName?: string }),
         includeCurrent
       );
     case EntityType.TABLE_COLUMN: {

--- a/openmetadata-ui/src/main/resources/ui/src/utils/EntityBreadcrumbUtils.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/EntityBreadcrumbUtils.tsx
@@ -11,16 +11,39 @@
  *  limitations under the License.
  */
 
+// Re-export all for backward compatibility
+export { getEntityBreadcrumbs } from './EntityBreadcrumbPureUtils';
 export {
   getBreadCrumbForAPICollection,
   getBreadCrumbForAPIEndpoint,
   getBreadcrumbForChart,
   getBreadcrumbForEntitiesWithServiceOnly,
   getBreadcrumbForEntityWithParent,
-  getBreadCrumbForKpi,
   getBreadcrumbForTable,
+} from './EntityDataBreadcrumbUtils';
+export {
+  getBreadcrumbForApplication,
+  getBreadcrumbForBot,
+  getBreadcrumbForClassification,
+  getBreadcrumbForDataProduct,
+  getBreadcrumbForDomain,
+  getBreadcrumbForEventSubscription,
+  getBreadcrumbForGlossaryOrTerm,
+  getBreadcrumbForKnowledgePage,
+  getBreadCrumbForKpi,
+  getBreadcrumbForMetric,
+  getBreadcrumbForPersona,
+  getBreadcrumbForPolicy,
+  getBreadcrumbForRole,
+  getBreadcrumbForTag,
+  getBreadcrumbForTeam,
   getBreadcrumbForTestCase,
   getBreadcrumbForTestSuite,
-  getEntityBreadcrumbs,
-  getEntityLinkFromType,
-} from './EntityBreadcrumbPureUtils';
+} from './EntityGovernanceBreadcrumbUtils';
+export { getEntityLinkFromType } from './EntityLinkUtils';
+export {
+  getBreadcrumbForDatabase,
+  getBreadcrumbForDatabaseSchema,
+  getBreadcrumbForDatabaseService,
+  getServiceCategoryBreadcrumb,
+} from './EntityServiceBreadcrumbUtils';

--- a/openmetadata-ui/src/main/resources/ui/src/utils/EntityDataBreadcrumbUtils.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/EntityDataBreadcrumbUtils.ts
@@ -1,0 +1,231 @@
+/*
+ *  Copyright 2025 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+import { startCase } from 'lodash';
+import type { EntityWithServices } from '../components/Explore/ExplorePage.interface';
+import type { SourceType } from '../components/SearchedData/SearchedData.interface';
+import { GlobalSettingsMenuCategory } from '../constants/GlobalSettings.constants';
+import { EntityType } from '../enums/entity.enum';
+import { ServiceCategory, ServiceCategoryPlural } from '../enums/service.enum';
+import type { APICollection } from '../generated/entity/data/apiCollection';
+import type { APIEndpoint } from '../generated/entity/data/apiEndpoint';
+import type { Chart } from '../generated/entity/data/chart';
+import type { Container } from '../generated/entity/data/container';
+import type { Directory } from '../generated/entity/data/directory';
+import type { File } from '../generated/entity/data/file';
+import type { Table } from '../generated/entity/data/table';
+import type { EntityReference } from '../generated/type/entityUsage';
+import { getEntityLinkFromType } from './EntityLinkUtils';
+import { getEntityName } from './EntityNameUtils';
+import {
+  getEntityDetailsPath,
+  getServiceDetailsPath,
+  getSettingPath,
+} from './RouterUtils';
+import { getServiceRouteFromServiceType } from './ServicePureUtils';
+
+export const getBreadcrumbForTable = (
+  entity: Table,
+  includeCurrent = false
+) => {
+  const { service, database, databaseSchema } = entity;
+
+  return [
+    {
+      name: getEntityName(service),
+      url: service?.name
+        ? getServiceDetailsPath(
+            service?.name,
+            ServiceCategory.DATABASE_SERVICES
+          )
+        : '',
+    },
+    {
+      name: getEntityName(database),
+      url: getEntityDetailsPath(
+        EntityType.DATABASE,
+        database?.fullyQualifiedName ?? ''
+      ),
+    },
+    {
+      name: getEntityName(databaseSchema),
+      url: getEntityDetailsPath(
+        EntityType.DATABASE_SCHEMA,
+        databaseSchema?.fullyQualifiedName ?? ''
+      ),
+    },
+    ...(includeCurrent
+      ? [
+          {
+            name: entity.name,
+            url: getEntityLinkFromType(
+              entity.fullyQualifiedName ?? '',
+              ((entity as SourceType).entityType as EntityType) ??
+                EntityType.TABLE
+            ),
+          },
+        ]
+      : []),
+  ];
+};
+
+export const getBreadcrumbForChart = (entity: Chart) => {
+  const { service } = entity;
+
+  return [
+    {
+      name: getEntityName(service),
+      url: getServiceDetailsPath(
+        service?.name ?? '',
+        ServiceCategoryPlural[
+          service?.type as keyof typeof ServiceCategoryPlural
+        ]
+      ),
+    },
+  ];
+};
+
+export const getBreadCrumbForAPICollection = (entity: APICollection) => {
+  const { service } = entity;
+
+  return [
+    {
+      name: startCase(ServiceCategory.API_SERVICES),
+      url: getSettingPath(
+        GlobalSettingsMenuCategory.SERVICES,
+        getServiceRouteFromServiceType(ServiceCategory.API_SERVICES)
+      ),
+    },
+    {
+      name: getEntityName(service),
+      url: service?.name
+        ? getServiceDetailsPath(
+            service?.name ?? '',
+            ServiceCategoryPlural[
+              service?.type as keyof typeof ServiceCategoryPlural
+            ]
+          )
+        : '',
+    },
+  ];
+};
+
+export const getBreadCrumbForAPIEndpoint = (entity: APIEndpoint) => {
+  const { service, apiCollection } = entity;
+
+  return [
+    {
+      name: startCase(ServiceCategory.API_SERVICES),
+      url: getSettingPath(
+        GlobalSettingsMenuCategory.SERVICES,
+        getServiceRouteFromServiceType(ServiceCategory.API_SERVICES)
+      ),
+    },
+    {
+      name: getEntityName(service),
+      url: service?.name
+        ? getServiceDetailsPath(
+            service?.name ?? '',
+            ServiceCategoryPlural[
+              service?.type as keyof typeof ServiceCategoryPlural
+            ]
+          )
+        : '',
+    },
+    {
+      name: getEntityName(apiCollection),
+      url: getEntityDetailsPath(
+        EntityType.API_COLLECTION,
+        apiCollection?.fullyQualifiedName ?? ''
+      ),
+    },
+  ];
+};
+
+export const getBreadcrumbForEntitiesWithServiceOnly = (
+  entity: EntityWithServices,
+  includeCurrent = false
+) => {
+  const { service } = entity;
+
+  return [
+    {
+      name: getEntityName(service),
+      url: service?.name
+        ? getServiceDetailsPath(
+            service?.name,
+            ServiceCategoryPlural[
+              service?.type as keyof typeof ServiceCategoryPlural
+            ]
+          )
+        : '',
+    },
+    ...(includeCurrent
+      ? [
+          {
+            name: entity.name,
+            url: getEntityLinkFromType(
+              entity.fullyQualifiedName ?? '',
+              (entity as SourceType).entityType as EntityType
+            ),
+          },
+        ]
+      : []),
+  ];
+};
+
+export function getBreadcrumbForEntityWithParent<
+  T extends Container | Directory | File
+>(data: {
+  entity: T;
+  entityType: EntityType;
+  includeCurrent?: boolean;
+  parents?: Container[] | EntityReference[];
+}) {
+  const { entity, entityType, includeCurrent = false, parents = [] } = data;
+  const { service } = entity;
+
+  return [
+    {
+      name: getEntityName(service),
+      url: service?.name
+        ? getServiceDetailsPath(
+            service?.name,
+            ServiceCategoryPlural[
+              service?.type as keyof typeof ServiceCategoryPlural
+            ]
+          )
+        : '',
+    },
+    ...(parents.length > 0
+      ? parents.map((parent) => ({
+          name: getEntityName(parent),
+          url: getEntityLinkFromType(
+            parent?.fullyQualifiedName ?? '',
+            entityType
+          ),
+        }))
+      : []),
+    ...(includeCurrent
+      ? [
+          {
+            name: entity.name,
+            url: getEntityLinkFromType(
+              entity.fullyQualifiedName ?? '',
+              (entity as SourceType).entityType as EntityType
+            ),
+          },
+        ]
+      : []),
+  ];
+}

--- a/openmetadata-ui/src/main/resources/ui/src/utils/EntityGovernanceBreadcrumbUtils.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/EntityGovernanceBreadcrumbUtils.ts
@@ -1,0 +1,312 @@
+/*
+ *  Copyright 2025 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+import { startCase } from 'lodash';
+import type { TitleLink } from '../components/common/TitleBreadcrumb/TitleBreadcrumb.interface';
+import type { SourceType } from '../components/SearchedData/SearchedData.interface';
+import { ROUTES } from '../constants/constants';
+import {
+  GlobalSettingOptions,
+  GlobalSettingsMenuCategory,
+} from '../constants/GlobalSettings.constants';
+import { EntityType } from '../enums/entity.enum';
+import type { Kpi } from '../generated/dataInsight/kpi/kpi';
+import type { GlossaryTerm } from '../generated/entity/data/glossaryTerm';
+import type { DataProduct } from '../generated/entity/domains/dataProduct';
+import type { Team } from '../generated/entity/teams/team';
+import {
+  AlertType,
+  type EventSubscription,
+} from '../generated/events/eventSubscription';
+import type { TestCase, TestSuite } from '../generated/tests/testCase';
+import { DataInsightTabs } from '../interface/data-insight.interface';
+import type { SearchSourceAlias } from '../interface/search.interface';
+import { DataQualityPageTabs } from '../pages/DataQuality/DataQualityPage.interface';
+import { getDataInsightPathWithFqn } from './DataInsightUtils';
+import { getEntityLinkFromType } from './EntityLinkUtils';
+import { getEntityName } from './EntityNameUtils';
+import Fqn from './Fqn';
+import i18n from './i18next/LocalUtil';
+import {
+  getApplicationDetailsPath,
+  getBotsPagePath,
+  getBotsPath,
+  getClassificationTagPath,
+  getDataQualityPagePath,
+  getDomainPath,
+  getGlossaryPath,
+  getKpiPath,
+  getPersonaDetailsPath,
+  getPolicyWithFqnPath,
+  getRoleWithFqnPath,
+  getSettingPath,
+  getTagsDetailsPath,
+  getTeamsWithFqnPath,
+} from './RouterUtils';
+
+export const getBreadcrumbForGlossaryOrTerm = (entity: GlossaryTerm) => {
+  const glossary = entity.glossary;
+  if (!glossary) {
+    return [];
+  }
+  const fqnList = entity.fullyQualifiedName
+    ? Fqn.split(entity.fullyQualifiedName)
+    : [];
+  const tree = fqnList.slice(1, fqnList.length);
+
+  return [
+    {
+      name: glossary.fullyQualifiedName,
+      url: getGlossaryPath(glossary.fullyQualifiedName),
+    },
+    ...tree.map((fqn, index, source) => ({
+      name: fqn,
+      url: getGlossaryPath(
+        `${glossary.fullyQualifiedName}.${source.slice(0, index + 1).join('.')}`
+      ),
+    })),
+  ];
+};
+
+export const getBreadcrumbForTestCase = (entity: TestCase): TitleLink[] => [
+  {
+    name: i18n.t('label.data-quality'),
+    url: `${ROUTES.DATA_QUALITY}/${DataQualityPageTabs.TEST_CASES}`,
+  },
+  {
+    name: entity.name,
+    url: getEntityLinkFromType(
+      entity.fullyQualifiedName ?? '',
+      (entity as SourceType)?.entityType as EntityType
+    ),
+    options: {
+      state: {
+        breadcrumbData: [
+          {
+            name: i18n.t('label.data-quality'),
+            url: `${ROUTES.DATA_QUALITY}/${DataQualityPageTabs.TEST_CASES}`,
+          },
+        ],
+      },
+    },
+  },
+];
+
+export const getBreadcrumbForTestSuite = (entity: TestSuite) => {
+  const { t } = i18n;
+
+  return entity.basic
+    ? [
+        {
+          name: getEntityName(entity.basicEntityReference),
+          url: getEntityLinkFromType(
+            entity.basicEntityReference?.fullyQualifiedName ?? '',
+            EntityType.TABLE
+          ),
+        },
+        {
+          name: t('label.test-suite'),
+          url: '',
+        },
+      ]
+    : [
+        {
+          name: t('label.test-suite-plural'),
+          url: getDataQualityPagePath(DataQualityPageTabs.TEST_SUITES),
+        },
+        {
+          name: getEntityName(entity),
+          url: '',
+        },
+      ];
+};
+
+export const getBreadCrumbForKpi = (entity: Kpi) => [
+  {
+    name: i18n.t('label.kpi-uppercase'),
+    url: getDataInsightPathWithFqn(DataInsightTabs.KPIS),
+  },
+  {
+    name: getEntityName(entity),
+    url: getKpiPath(entity.name),
+  },
+];
+
+export const getBreadcrumbForDomain = () => [
+  {
+    name: i18n.t('label.domain-plural'),
+    url: getDomainPath(),
+  },
+];
+
+export const getBreadcrumbForDataProduct = (entity: DataProduct) => {
+  if (!entity.domains?.length) {
+    return [];
+  }
+
+  return [
+    {
+      name: getEntityName(entity.domains[0]),
+      url: getDomainPath(entity.domains[0].fullyQualifiedName),
+    },
+  ];
+};
+
+export const getBreadcrumbForEventSubscription = (
+  entity: EventSubscription,
+  entityFqn: string,
+  entitySourceType: SearchSourceAlias
+) => [
+  {
+    name: startCase(EntityType.ALERT),
+    url:
+      entity.alertType === AlertType.Observability
+        ? ROUTES.OBSERVABILITY_ALERTS
+        : ROUTES.NOTIFICATION_ALERT_LIST,
+  },
+  {
+    name: entity.name,
+    url: getEntityLinkFromType(
+      entityFqn,
+      (entitySourceType as SourceType).entityType as EntityType,
+      entitySourceType
+    ),
+  },
+];
+
+export const getBreadcrumbForBot = (entityName: string, fqn: string) => [
+  {
+    name: startCase(EntityType.BOT),
+    url: getBotsPagePath(),
+  },
+  {
+    name: entityName,
+    url: getBotsPath(fqn),
+  },
+];
+
+export const getBreadcrumbForTeam = (entity: Team) => [
+  {
+    name: getEntityName(entity.parents?.[0]),
+    url: getTeamsWithFqnPath(entity.parents?.[0]?.fullyQualifiedName ?? ''),
+  },
+  {
+    name: getEntityName(entity),
+    url: getTeamsWithFqnPath(entity.fullyQualifiedName ?? ''),
+  },
+];
+
+export const getBreadcrumbForApplication = (
+  entityName: string,
+  fqn: string
+) => [
+  {
+    name: i18n.t('label.application-plural'),
+    url: getSettingPath(GlobalSettingsMenuCategory.APPLICATIONS),
+  },
+  {
+    name: entityName,
+    url: getApplicationDetailsPath(fqn),
+  },
+];
+
+export const getBreadcrumbForPersona = (entityName: string, fqn: string) => [
+  {
+    name: i18n.t('label.persona-plural'),
+    url: getSettingPath(
+      GlobalSettingsMenuCategory.MEMBERS,
+      GlobalSettingOptions.PERSONA
+    ),
+  },
+  {
+    name: entityName,
+    url: getPersonaDetailsPath(fqn),
+  },
+];
+
+export const getBreadcrumbForRole = (entityName: string, fqn: string) => [
+  {
+    name: i18n.t('label.role-plural'),
+    url: getSettingPath(
+      GlobalSettingsMenuCategory.ACCESS,
+      GlobalSettingOptions.ROLES
+    ),
+  },
+  {
+    name: entityName,
+    url: getRoleWithFqnPath(fqn),
+  },
+];
+
+export const getBreadcrumbForPolicy = (entityName: string, fqn: string) => [
+  {
+    name: i18n.t('label.policy-plural'),
+    url: getSettingPath(
+      GlobalSettingsMenuCategory.ACCESS,
+      GlobalSettingOptions.POLICIES
+    ),
+  },
+  {
+    name: entityName,
+    url: getPolicyWithFqnPath(fqn),
+  },
+];
+
+export const getBreadcrumbForTag = (
+  classificationName: string,
+  classificationFqn: string,
+  entityName: string,
+  entityFqn: string
+) => [
+  {
+    name: classificationName,
+    url: getTagsDetailsPath(classificationFqn),
+  },
+  {
+    name: entityName,
+    url: getClassificationTagPath(entityFqn),
+  },
+];
+
+export const getBreadcrumbForClassification = (entityName: string) => [
+  {
+    name: entityName,
+    url: '',
+  },
+];
+
+export const getBreadcrumbForMetric = (entityName: string) => [
+  {
+    name: i18n.t('label.metric-plural'),
+    url: ROUTES.METRICS,
+  },
+  {
+    name: entityName,
+    url: '',
+  },
+];
+
+export const getBreadcrumbForKnowledgePage = (
+  entityName: string,
+  includeCurrent: boolean
+) => [
+  {
+    name: i18n.t('label.knowledge-center'),
+    url: ROUTES.KNOWLEDGE_CENTER,
+  },
+  {
+    name: entityName,
+    url: '',
+    activeTitle: Boolean(includeCurrent),
+  },
+];

--- a/openmetadata-ui/src/main/resources/ui/src/utils/EntityLinkUtils.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/EntityLinkUtils.ts
@@ -1,0 +1,163 @@
+/*
+ *  Copyright 2025 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+import { EntityTabs, EntityType } from '../enums/entity.enum';
+import { ServiceCategory } from '../enums/service.enum';
+import {
+  AlertType,
+  type EventSubscription,
+} from '../generated/events/eventSubscription';
+import type { SearchSourceAlias } from '../interface/search.interface';
+import { getKnowledgePagePath } from './KnowledgePageUtils';
+import {
+  getApplicationDetailsPath,
+  getBotsPath,
+  getClassificationTagPath,
+  getDataProductDetailsPath,
+  getDomainDetailsPath,
+  getEntityDetailsPath,
+  getGlossaryTermDetailsPath,
+  getKpiPath,
+  getNotificationAlertDetailsPath,
+  getObservabilityAlertDetailsPath,
+  getPersonaDetailsPath,
+  getPolicyWithFqnPath,
+  getRoleWithFqnPath,
+  getServiceDetailsPath,
+  getTagsDetailsPath,
+  getTeamsWithFqnPath,
+  getTestCaseDetailPagePath,
+} from './RouterUtils';
+
+export const getEntityLinkFromType = (
+  fullyQualifiedName: string,
+  entityType: EntityType,
+  entity?: SearchSourceAlias
+) => {
+  switch (entityType) {
+    case EntityType.TABLE:
+    case EntityType.TOPIC:
+    case EntityType.DASHBOARD:
+    case EntityType.CHART:
+    case EntityType.PIPELINE:
+    case EntityType.MLMODEL:
+    case EntityType.CONTAINER:
+    case EntityType.DATABASE:
+    case EntityType.DATABASE_SCHEMA:
+    case EntityType.DASHBOARD_DATA_MODEL:
+    case EntityType.STORED_PROCEDURE:
+    case EntityType.SEARCH_INDEX:
+    case EntityType.API_COLLECTION:
+    case EntityType.API_ENDPOINT:
+    case EntityType.DIRECTORY:
+    case EntityType.FILE:
+    case EntityType.SPREADSHEET:
+    case EntityType.WORKSHEET:
+      return getEntityDetailsPath(entityType, fullyQualifiedName);
+    case EntityType.METRIC:
+      return getEntityDetailsPath(entityType, fullyQualifiedName);
+    case EntityType.DATA_PRODUCT:
+      return getDataProductDetailsPath(fullyQualifiedName);
+    case EntityType.GLOSSARY:
+    case EntityType.GLOSSARY_TERM:
+      return getGlossaryTermDetailsPath(fullyQualifiedName);
+    case EntityType.TAG:
+      return getClassificationTagPath(fullyQualifiedName);
+    case EntityType.CLASSIFICATION:
+      return getTagsDetailsPath(fullyQualifiedName);
+
+    case EntityType.DATABASE_SERVICE:
+      return getServiceDetailsPath(
+        fullyQualifiedName,
+        ServiceCategory.DATABASE_SERVICES
+      );
+    case EntityType.MESSAGING_SERVICE:
+      return getServiceDetailsPath(
+        fullyQualifiedName,
+        ServiceCategory.MESSAGING_SERVICES
+      );
+    case EntityType.DASHBOARD_SERVICE:
+      return getServiceDetailsPath(
+        fullyQualifiedName,
+        ServiceCategory.DASHBOARD_SERVICES
+      );
+    case EntityType.PIPELINE_SERVICE:
+      return getServiceDetailsPath(
+        fullyQualifiedName,
+        ServiceCategory.PIPELINE_SERVICES
+      );
+    case EntityType.MLMODEL_SERVICE:
+      return getServiceDetailsPath(
+        fullyQualifiedName,
+        ServiceCategory.ML_MODEL_SERVICES
+      );
+    case EntityType.STORAGE_SERVICE:
+      return getServiceDetailsPath(
+        fullyQualifiedName,
+        ServiceCategory.STORAGE_SERVICES
+      );
+    case EntityType.SEARCH_SERVICE:
+      return getServiceDetailsPath(
+        fullyQualifiedName,
+        ServiceCategory.SEARCH_SERVICES
+      );
+    case EntityType.METADATA_SERVICE:
+      return getServiceDetailsPath(
+        fullyQualifiedName,
+        ServiceCategory.METADATA_SERVICES
+      );
+    case EntityType.API_SERVICE:
+      return getServiceDetailsPath(
+        fullyQualifiedName,
+        ServiceCategory.API_SERVICES
+      );
+    case EntityType.DRIVE_SERVICE:
+      return getServiceDetailsPath(
+        fullyQualifiedName,
+        ServiceCategory.DRIVE_SERVICES
+      );
+    case EntityType.BOT:
+      return getBotsPath(fullyQualifiedName);
+    case EntityType.TEAM:
+      return getTeamsWithFqnPath(fullyQualifiedName);
+    case EntityType.APPLICATION:
+      return getApplicationDetailsPath(fullyQualifiedName);
+    case EntityType.TEST_CASE:
+      return getTestCaseDetailPagePath(fullyQualifiedName);
+    case EntityType.TEST_SUITE:
+      return getEntityDetailsPath(
+        EntityType.TABLE,
+        fullyQualifiedName,
+        EntityTabs.PROFILER
+      );
+    case EntityType.DOMAIN:
+      return getDomainDetailsPath(fullyQualifiedName);
+    case EntityType.EVENT_SUBSCRIPTION:
+      return (entity as EventSubscription)?.alertType ===
+        AlertType.Observability
+        ? getObservabilityAlertDetailsPath(fullyQualifiedName)
+        : getNotificationAlertDetailsPath(fullyQualifiedName);
+    case EntityType.ROLE:
+      return getRoleWithFqnPath(fullyQualifiedName);
+    case EntityType.POLICY:
+      return getPolicyWithFqnPath(fullyQualifiedName);
+    case EntityType.PERSONA:
+      return getPersonaDetailsPath(fullyQualifiedName);
+    case EntityType.KPI:
+      return getKpiPath(fullyQualifiedName);
+    case EntityType.KNOWLEDGE_PAGE:
+      return getKnowledgePagePath(fullyQualifiedName);
+    default:
+      return '';
+  }
+};

--- a/openmetadata-ui/src/main/resources/ui/src/utils/EntityServiceBreadcrumbUtils.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/EntityServiceBreadcrumbUtils.ts
@@ -1,0 +1,100 @@
+/*
+ *  Copyright 2025 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+import { startCase } from 'lodash';
+import type { SourceType } from '../components/SearchedData/SearchedData.interface';
+import { GlobalSettingsMenuCategory } from '../constants/GlobalSettings.constants';
+import { EntityType } from '../enums/entity.enum';
+import { ServiceCategory, ServiceCategoryPlural } from '../enums/service.enum';
+import type { Database } from '../generated/entity/data/database';
+import type { DatabaseSchema } from '../generated/entity/data/databaseSchema';
+import { getBreadcrumbForEntitiesWithServiceOnly } from './EntityDataBreadcrumbUtils';
+import { getEntityLinkFromType } from './EntityLinkUtils';
+import { getEntityName } from './EntityNameUtils';
+import {
+  getEntityDetailsPath,
+  getServiceDetailsPath,
+  getSettingPath,
+} from './RouterUtils';
+import { getServiceRouteFromServiceType } from './ServicePureUtils';
+
+export const getServiceCategoryBreadcrumb = (
+  serviceCategory: ServiceCategory
+) => [
+  {
+    name: startCase(serviceCategory),
+    url: getSettingPath(
+      GlobalSettingsMenuCategory.SERVICES,
+      getServiceRouteFromServiceType(serviceCategory)
+    ),
+  },
+];
+
+export const getBreadcrumbForDatabaseService = (
+  entityName: string,
+  fqn: string,
+  includeCurrent: boolean
+) => {
+  const items = getServiceCategoryBreadcrumb(ServiceCategory.DATABASE_SERVICES);
+
+  if (includeCurrent) {
+    items.push({
+      name: entityName,
+      url: getServiceDetailsPath(fqn, ServiceCategory.DATABASE_SERVICES),
+    });
+  }
+
+  return items;
+};
+
+export const getBreadcrumbForDatabase = (entity: Database) => [
+  ...getServiceCategoryBreadcrumb(ServiceCategory.DATABASE_SERVICES),
+  ...getBreadcrumbForEntitiesWithServiceOnly(entity),
+  {
+    name: entity.name,
+    url: getEntityLinkFromType(
+      entity.fullyQualifiedName ?? '',
+      ((entity as SourceType).entityType as EntityType) ?? EntityType.DATABASE
+    ),
+  },
+];
+
+export const getBreadcrumbForDatabaseSchema = (entity: DatabaseSchema) => [
+  ...getServiceCategoryBreadcrumb(ServiceCategory.DATABASE_SERVICES),
+  {
+    name: getEntityName(entity.service),
+    url: entity.service?.name
+      ? getServiceDetailsPath(
+          entity.service?.name ?? '',
+          ServiceCategoryPlural[
+            entity.service?.type as keyof typeof ServiceCategoryPlural
+          ]
+        )
+      : '',
+  },
+  {
+    name: getEntityName(entity.database),
+    url: getEntityDetailsPath(
+      EntityType.DATABASE,
+      entity.database?.fullyQualifiedName ?? ''
+    ),
+  },
+  {
+    name: entity.name,
+    url: getEntityLinkFromType(
+      entity.fullyQualifiedName ?? '',
+      ((entity as unknown as SourceType).entityType as EntityType) ??
+        EntityType.DATABASE_SCHEMA
+    ),
+  },
+];

--- a/openmetadata-ui/src/main/resources/ui/src/utils/EntityUtils.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/EntityUtils.test.tsx
@@ -50,7 +50,7 @@ import {
   getServiceDetailsPath,
   getSettingPath,
 } from './RouterUtils';
-import { getServiceRouteFromServiceType } from './ServiceUtils';
+import { getServiceRouteFromServiceType } from './ServicePureUtils';
 
 jest.mock('../constants/constants', () => ({
   DEFAULT_DOMAIN_VALUE: 'All Domains',
@@ -66,7 +66,7 @@ jest.mock('./RouterUtils', () => ({
   getEntityDetailsPath: jest.fn(),
 }));
 
-jest.mock('./ServiceUtils', () => ({
+jest.mock('./ServicePureUtils', () => ({
   getServiceRouteFromServiceType: jest.fn(),
 }));
 


### PR DESCRIPTION
## Summary
- Extract 1046-line `EntityBreadcrumbPureUtils.ts` into 4 focused files: `EntityLinkUtils.ts`, `EntityDataBreadcrumbUtils.ts`, `EntityGovernanceBreadcrumbUtils.ts`, `EntityServiceBreadcrumbUtils.ts`
- `EntityBreadcrumbPureUtils.ts` becomes a re-export facade keeping `getEntityBreadcrumbs` dispatcher
- `EntityBreadcrumbUtils.tsx` re-exports all symbols for full backward compatibility — no consumer changes needed

## Test plan
- [ ] TypeScript compiles with no new errors (`npx tsc --noEmit`)
- [ ] All breadcrumb-related pages render correctly (entity detail pages, search results)
- [ ] No import resolution errors in dev server

🤖 Generated with [Claude Code](https://claude.com/claude-code)