### PR TITLE
ci(pr-metadata): trust authors with private org membership

### DIFF
--- a/.github/workflows/pr-metadata-validation.yml
+++ b/.github/workflows/pr-metadata-validation.yml
@@ -152,11 +152,26 @@ jobs:
               }));
             }
 
-            // Cross-repo links: body-parsed, trusted authors + allowlisted repos only.
-            function crossRepoRefsFromBody(text, association) {
-              if (!TRUSTED_ASSOCIATIONS.has(association)) {
-                return [];
+            // Trust the author for cross-repo refs if their PR association is already a trusted
+            // value, or — since the default GITHUB_TOKEN cannot see *private* org membership and
+            // reports such authors as CONTRIBUTOR — by confirming org membership with the elevated
+            // token. Fork PRs from non-members still resolve to untrusted.
+            async function isTrustedAuthor(pr) {
+              let trusted = TRUSTED_ASSOCIATIONS.has(pr.author_association);
+              const client = elevatedClient();
+              if (!trusted && client && pr.user && pr.user.login) {
+                try {
+                  await client.rest.orgs.checkMembershipForUser({ org: owner, username: pr.user.login });
+                  trusted = true; // 204 => org member (including private membership)
+                } catch (error) {
+                  trusted = false; // 404 => not a member
+                }
               }
+              return trusted;
+            }
+
+            // Cross-repo links: body-parsed, allowlisted repos only (caller gates on author trust).
+            function crossRepoRefsFromBody(text) {
               const refs = [];
               const add = (refOwner, refRepo, number) => {
                 if (refOwner === owner && ALLOWED_CROSS_REPOS.has(refRepo)) {
@@ -303,7 +318,9 @@ jobs:
 
             async function collectIssueProblems(pr) {
               const native = await nativeLinkedRefs(pr.number);
-              const cross = crossRepoRefsFromBody(`${pr.title || ''}\n${pr.body || ''}`, pr.author_association);
+              const cross = (await isTrustedAuthor(pr))
+                ? crossRepoRefsFromBody(`${pr.title || ''}\n${pr.body || ''}`)
+                : [];
               const refs = dedupeRefs([...native, ...cross]);
               if (refs.length === 0) {
                 return [


### PR DESCRIPTION
## Problem
The cross-repo linked-issue path added in #28811 gates on the PR author's `author_association`, requiring `OWNER`/`MEMBER`/`COLLABORATOR`. But the workflow runs with the default `GITHUB_TOKEN`, which **cannot see *private* org membership** — so an org member whose membership is private is reported as `CONTRIBUTOR`. The trust gate then drops their cross-repo refs and the check reports "No GitHub issue is linked," even for legitimate members.

Confirmed via a temporary debug run on PR #28822 (author is a private org member): `author_association=CONTRIBUTOR trusted=false`, so `cross=[]`.

## Fix
Resolve trust through `isTrustedAuthor(pr)`: accept the author if `author_association` is already trusted, otherwise confirm org membership with the **elevated `PROJECTS_TOKEN`** (`orgs.checkMembershipForUser`), which can see private memberships. Non-members (incl. fork-PR authors) still resolve to untrusted — `404` → `false` — so the security posture is unchanged.

`crossRepoRefsFromBody` no longer takes the association (the caller now gates on `isTrustedAuthor`).

## Requirement
For this to resolve private members, `PROJECTS_TOKEN` must be able to read org membership (a PAT with `read:org`, or a GitHub App with org **Members: read**). If it can't, the alternative is for members to make their org membership public.

## Validation
- Workflow YAML parses; embedded `github-script` JS passes `node --check` (async-wrapped).
- Same-repo and standard behavior unchanged; only the cross-repo author-trust resolution is affected.