### PR TITLE
fix(alerts): dedup successful change events to prevent Postgres ON CONFLICT abort

### DIFF
--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/EventSubscriptionBatchUpsertIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/EventSubscriptionBatchUpsertIT.java
@@ -1,0 +1,86 @@
+/*
+ *  Copyright 2025 Collate
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.openmetadata.it.tests;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.openmetadata.service.Entity;
+import org.openmetadata.service.jdbi3.CollectionDAO.EventSubscriptionDAO;
+
+/**
+ * Regression test for {@code EventSubscriptionDAO.batchUpsertSuccessfulChangeEvents}.
+ *
+ * <p>When an alert fans an event out to multiple destination types, the same
+ * {@code (change_event_id, event_subscription_id)} pair was added to the batch more than once. With
+ * the Postgres JDBC driver's {@code reWriteBatchedInserts=true}, the batch collapses into a single
+ * multi-row {@code INSERT ... ON CONFLICT (...) DO UPDATE}, and Postgres aborts the whole statement
+ * with "ON CONFLICT DO UPDATE command cannot affect row a second time" — so no success records were
+ * persisted. This guard must run under a Postgres profile to exercise that path; on MySQL it still
+ * verifies the dedup invariant.
+ */
+@Execution(ExecutionMode.CONCURRENT)
+public class EventSubscriptionBatchUpsertIT {
+
+  private static EventSubscriptionDAO dao() {
+    return Entity.getCollectionDAO().eventSubscriptionDAO();
+  }
+
+  private static String json(String changeEventId) {
+    return "{\"id\":\"" + changeEventId + "\"}";
+  }
+
+  @Test
+  void duplicateKeysInBatchDoNotFailAndCollapseToOneRow() {
+    String subscriptionId = UUID.randomUUID().toString();
+    String changeEventId = UUID.randomUUID().toString();
+    long timestamp = System.currentTimeMillis();
+    try {
+      assertDoesNotThrow(
+          () ->
+              dao()
+                  .batchUpsertSuccessfulChangeEvents(
+                      List.of(changeEventId, changeEventId),
+                      List.of(subscriptionId, subscriptionId),
+                      List.of(json(changeEventId), json(changeEventId)),
+                      List.of(timestamp, timestamp)));
+      assertEquals(1L, dao().getSuccessfulRecordCount(subscriptionId));
+    } finally {
+      dao().deleteSuccessfulChangeEventBySubscriptionId(subscriptionId);
+    }
+  }
+
+  @Test
+  void mixedBatchKeepsOneRowPerDistinctKey() {
+    String subscriptionId = UUID.randomUUID().toString();
+    String changeEventA = UUID.randomUUID().toString();
+    String changeEventB = UUID.randomUUID().toString();
+    long timestamp = System.currentTimeMillis();
+    try {
+      dao()
+          .batchUpsertSuccessfulChangeEvents(
+              List.of(changeEventA, changeEventB, changeEventA),
+              List.of(subscriptionId, subscriptionId, subscriptionId),
+              List.of(json(changeEventA), json(changeEventB), json(changeEventA)),
+              List.of(timestamp, timestamp, timestamp));
+      assertEquals(2L, dao().getSuccessfulRecordCount(subscriptionId));
+    } finally {
+      dao().deleteSuccessfulChangeEventBySubscriptionId(subscriptionId);
+    }
+  }
+}

--- a/openmetadata-service/src/main/java/org/openmetadata/service/apps/bundles/changeEvent/AbstractEventConsumer.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/apps/bundles/changeEvent/AbstractEventConsumer.java
@@ -170,16 +170,6 @@ public abstract class AbstractEventConsumer
             source.toString());
   }
 
-  private void recordSuccessfulChangeEvent(UUID eventSubscriptionId, ChangeEvent event) {
-    Entity.getCollectionDAO()
-        .eventSubscriptionDAO()
-        .upsertSuccessfulChangeEvent(
-            event.getId().toString(),
-            eventSubscriptionId.toString(),
-            JsonUtils.pojoToJson(event),
-            System.currentTimeMillis());
-  }
-
   private EventSubscriptionOffset loadInitialOffset(JobExecutionContext context) {
     Object offsetValue = jobDetail.getJobDataMap().get(ALERT_OFFSET_KEY);
     if (offsetValue != null) {
@@ -229,57 +219,61 @@ public abstract class AbstractEventConsumer
 
   @Override
   public void publishEvents(Map<ChangeEvent, Set<UUID>> events) {
-    if (events.isEmpty()) {
-      return;
-    }
-
-    // Filter events based on subscription configuration (entity type, conditions, etc.)
-    Map<ChangeEvent, Set<UUID>> filteredEvents = getFilteredEvents(eventSubscription, events);
-    RecipientResolver resolver = new RecipientResolver();
-
-    for (var eventWithReceivers : filteredEvents.entrySet()) {
-      ChangeEvent event = eventWithReceivers.getKey();
-      Set<UUID> destinationIds = eventWithReceivers.getValue();
-
-      // Group destinations by type to enable cross-destination recipient deduplication
-      Map<SubscriptionType, List<Destination<ChangeEvent>>> destinationsByType =
-          groupDestinationsByType(destinationIds);
-
-      for (var entry : destinationsByType.entrySet()) {
-        List<Destination<ChangeEvent>> destinations = entry.getValue();
-        Destination<ChangeEvent> publisher = destinations.getFirst();
-
-        // Resolve recipients from all destinations of this type for deduplication
-        Set<Recipient> recipients = Set.of();
-        if (publisher.requiresRecipients()) {
-          List<SubscriptionDestination> subDestinations =
-              destinations.stream().map(Destination::getSubscriptionDestination).toList();
-          recipients = resolver.resolveRecipients(event, subDestinations);
-        }
-
-        // Send via primary destination only, with deduplicated recipients (one send per type)
-        boolean status = true;
-        if (!publisher.requiresRecipients() || !recipients.isEmpty()) {
-          try {
-            publisher.sendMessage(event, recipients);
-          } catch (EventPublisherException e) {
-            LOG.error("Failed to send alert: {}", e.getMessage());
-            handleFailedEvent(e, true);
-            status = false;
-          }
-        }
-
-        if (status) {
-          // Collect successful events instead of writing immediately
-          // Batch write happens in commit() to reduce connection pool contention
-          // Note: Empty recipients is treated as successful (no-op send)
-          successfulEvents.add(eventWithReceivers.getKey());
-          alertMetrics.withSuccessEvents(alertMetrics.getSuccessEvents() + 1);
-        } else {
-          alertMetrics.withFailedEvents(alertMetrics.getFailedEvents() + 1);
-        }
+    if (!events.isEmpty()) {
+      // Filter events based on subscription configuration (entity type, conditions, etc.)
+      Map<ChangeEvent, Set<UUID>> filteredEvents = getFilteredEvents(eventSubscription, events);
+      RecipientResolver resolver = new RecipientResolver();
+      for (var eventWithReceivers : filteredEvents.entrySet()) {
+        publishEvent(eventWithReceivers.getKey(), eventWithReceivers.getValue(), resolver);
       }
     }
+  }
+
+  private void publishEvent(
+      ChangeEvent event, Set<UUID> destinationIds, RecipientResolver resolver) {
+    // Group destinations by type to enable cross-destination recipient deduplication
+    Map<SubscriptionType, List<Destination<ChangeEvent>>> destinationsByType =
+        groupDestinationsByType(destinationIds);
+    boolean delivered = false;
+    for (var entry : destinationsByType.entrySet()) {
+      if (sendToDestinationType(event, entry.getValue(), resolver)) {
+        delivered = true;
+        alertMetrics.withSuccessEvents(alertMetrics.getSuccessEvents() + 1);
+      } else {
+        alertMetrics.withFailedEvents(alertMetrics.getFailedEvents() + 1);
+      }
+    }
+    // Record each delivered event once. successful_sent_change_events is keyed by
+    // (change_event_id, event_subscription_id) with no destination dimension, so recording per
+    // destination type produces duplicate batch rows that break Postgres ON CONFLICT.
+    if (delivered) {
+      successfulEvents.add(event);
+    }
+  }
+
+  private boolean sendToDestinationType(
+      ChangeEvent event, List<Destination<ChangeEvent>> destinations, RecipientResolver resolver) {
+    Destination<ChangeEvent> publisher = destinations.getFirst();
+    // Resolve recipients from all destinations of this type for deduplication
+    Set<Recipient> recipients = Set.of();
+    if (publisher.requiresRecipients()) {
+      List<SubscriptionDestination> subDestinations =
+          destinations.stream().map(Destination::getSubscriptionDestination).toList();
+      recipients = resolver.resolveRecipients(event, subDestinations);
+    }
+    // Send via primary destination only, with deduplicated recipients (one send per type).
+    // Empty recipients is treated as successful (no-op send).
+    boolean status = true;
+    if (!publisher.requiresRecipients() || !recipients.isEmpty()) {
+      try {
+        publisher.sendMessage(event, recipients);
+      } catch (EventPublisherException e) {
+        LOG.error("Failed to send alert: {}", e.getMessage());
+        handleFailedEvent(e, true);
+        status = false;
+      }
+    }
+    return status;
   }
 
   private Map<SubscriptionType, List<Destination<ChangeEvent>>> groupDestinationsByType(

--- a/openmetadata-service/src/main/java/org/openmetadata/service/apps/bundles/changeEvent/AbstractEventConsumer.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/apps/bundles/changeEvent/AbstractEventConsumer.java
@@ -219,37 +219,47 @@ public abstract class AbstractEventConsumer
 
   @Override
   public void publishEvents(Map<ChangeEvent, Set<UUID>> events) {
-    if (!events.isEmpty()) {
-      // Filter events based on subscription configuration (entity type, conditions, etc.)
-      Map<ChangeEvent, Set<UUID>> filteredEvents = getFilteredEvents(eventSubscription, events);
-      RecipientResolver resolver = new RecipientResolver();
-      for (var eventWithReceivers : filteredEvents.entrySet()) {
-        publishEvent(eventWithReceivers.getKey(), eventWithReceivers.getValue(), resolver);
-      }
+    if (events.isEmpty()) {
+      return;
     }
+    Map<ChangeEvent, Set<UUID>> filteredEvents = getFilteredEvents(eventSubscription, events);
+    RecipientResolver resolver = new RecipientResolver();
+    int successDeliveries = 0;
+    int failedDeliveries = 0;
+    for (Map.Entry<ChangeEvent, Set<UUID>> eventWithReceivers : filteredEvents.entrySet()) {
+      EventDeliveryResult result =
+          publishEvent(eventWithReceivers.getKey(), eventWithReceivers.getValue(), resolver);
+      // Record once per (event, subscription): the table has no destination dimension, so
+      // recording per type would duplicate rows and break Postgres ON CONFLICT.
+      if (result.delivered()) {
+        successfulEvents.add(eventWithReceivers.getKey());
+      }
+      successDeliveries += result.successCount();
+      failedDeliveries += result.failedCount();
+    }
+    alertMetrics.withSuccessEvents(alertMetrics.getSuccessEvents() + successDeliveries);
+    alertMetrics.withFailedEvents(alertMetrics.getFailedEvents() + failedDeliveries);
   }
 
-  private void publishEvent(
+  private EventDeliveryResult publishEvent(
       ChangeEvent event, Set<UUID> destinationIds, RecipientResolver resolver) {
     // Group destinations by type to enable cross-destination recipient deduplication
     Map<SubscriptionType, List<Destination<ChangeEvent>>> destinationsByType =
         groupDestinationsByType(destinationIds);
-    boolean delivered = false;
-    for (var entry : destinationsByType.entrySet()) {
+    int successCount = 0;
+    int failedCount = 0;
+    for (Map.Entry<SubscriptionType, List<Destination<ChangeEvent>>> entry :
+        destinationsByType.entrySet()) {
       if (sendToDestinationType(event, entry.getValue(), resolver)) {
-        delivered = true;
-        alertMetrics.withSuccessEvents(alertMetrics.getSuccessEvents() + 1);
+        successCount++;
       } else {
-        alertMetrics.withFailedEvents(alertMetrics.getFailedEvents() + 1);
+        failedCount++;
       }
     }
-    // Record each delivered event once. successful_sent_change_events is keyed by
-    // (change_event_id, event_subscription_id) with no destination dimension, so recording per
-    // destination type produces duplicate batch rows that break Postgres ON CONFLICT.
-    if (delivered) {
-      successfulEvents.add(event);
-    }
+    return new EventDeliveryResult(successCount > 0, successCount, failedCount);
   }
+
+  private record EventDeliveryResult(boolean delivered, int successCount, int failedCount) {}
 
   private boolean sendToDestinationType(
       ChangeEvent event, List<Destination<ChangeEvent>> destinations, RecipientResolver resolver) {

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/CollectionDAO.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/CollectionDAO.java
@@ -5333,27 +5333,47 @@ public interface CollectionDAO {
         @Bind("json") String json,
         @Bind("source") String source);
 
-    @ConnectionAwareSqlUpdate(
-        value =
-            "INSERT INTO successful_sent_change_events (change_event_id, event_subscription_id, json, timestamp) "
-                + "VALUES (:change_event_id, :event_subscription_id, :json, :timestamp) "
-                + "ON DUPLICATE KEY UPDATE json = :json, timestamp = :timestamp",
-        connectionType = MYSQL)
-    @ConnectionAwareSqlUpdate(
-        value =
-            "INSERT INTO successful_sent_change_events (change_event_id, event_subscription_id, json, timestamp) "
-                + "VALUES (:change_event_id, :event_subscription_id, CAST(:json AS jsonb), :timestamp) "
-                + "ON CONFLICT (change_event_id, event_subscription_id) "
-                + "DO UPDATE SET json = EXCLUDED.json, timestamp = EXCLUDED.timestamp",
-        connectionType = POSTGRES)
-    void upsertSuccessfulChangeEvent(
-        @Bind("change_event_id") String changeEventId,
-        @Bind("event_subscription_id") String eventSubscriptionId,
-        @Bind("json") String json,
-        @Bind("timestamp") long timestamp);
-
     // Batch insert for successful events - reduces connection pool contention
-    // from N connections to 1 when processing multiple events
+    // from N connections to 1 when processing multiple events.
+    // Deduplicates by (change_event_id, event_subscription_id) first: the primary key has no
+    // destination dimension, and Postgres rejects a rewritten multi-row INSERT whose own rows
+    // conflict on the arbiter key ("ON CONFLICT DO UPDATE command cannot affect row a second
+    // time").
+    default void batchUpsertSuccessfulChangeEvents(
+        List<String> changeEventIds,
+        List<String> eventSubscriptionIds,
+        List<String> jsonList,
+        List<Long> timestamps) {
+      List<Integer> keep = distinctLastIndexes(changeEventIds, eventSubscriptionIds);
+      if (keep.size() == changeEventIds.size()) {
+        batchUpsertSuccessfulChangeEventsInternal(
+            changeEventIds, eventSubscriptionIds, jsonList, timestamps);
+      } else {
+        batchUpsertSuccessfulChangeEventsInternal(
+            pickByIndex(changeEventIds, keep),
+            pickByIndex(eventSubscriptionIds, keep),
+            pickByIndex(jsonList, keep),
+            pickByIndex(timestamps, keep));
+      }
+    }
+
+    static List<Integer> distinctLastIndexes(
+        List<String> changeEventIds, List<String> eventSubscriptionIds) {
+      LinkedHashMap<String, Integer> lastIndexByKey = new LinkedHashMap<>();
+      for (int i = 0; i < changeEventIds.size(); i++) {
+        lastIndexByKey.put(changeEventIds.get(i) + "|" + eventSubscriptionIds.get(i), i);
+      }
+      return new ArrayList<>(lastIndexByKey.values());
+    }
+
+    static <T> List<T> pickByIndex(List<T> source, List<Integer> indexes) {
+      List<T> result = new ArrayList<>(indexes.size());
+      for (int index : indexes) {
+        result.add(source.get(index));
+      }
+      return result;
+    }
+
     @Transaction
     @ConnectionAwareSqlBatch(
         value =
@@ -5368,7 +5388,7 @@ public interface CollectionDAO {
                 + "ON CONFLICT (change_event_id, event_subscription_id) "
                 + "DO UPDATE SET json = EXCLUDED.json, timestamp = EXCLUDED.timestamp",
         connectionType = POSTGRES)
-    void batchUpsertSuccessfulChangeEvents(
+    void batchUpsertSuccessfulChangeEventsInternal(
         @Bind("change_event_id") List<String> changeEventIds,
         @Bind("event_subscription_id") List<String> eventSubscriptionIds,
         @Bind("json") List<String> jsonList,

--- a/openmetadata-service/src/test/java/org/openmetadata/service/apps/bundles/changeEvent/AbstractEventConsumerTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/apps/bundles/changeEvent/AbstractEventConsumerTest.java
@@ -16,16 +16,22 @@ package org.openmetadata.service.apps.bundles.changeEvent;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
+import java.lang.reflect.Field;
 import java.util.*;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
+import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.openmetadata.schema.entity.events.AlertMetrics;
 import org.openmetadata.schema.entity.events.EventSubscription;
+import org.openmetadata.schema.entity.events.SubscriptionDestination;
+import org.openmetadata.schema.entity.events.SubscriptionDestination.SubscriptionType;
 import org.openmetadata.schema.type.ChangeEvent;
 import org.openmetadata.schema.utils.ResultList;
 import org.openmetadata.service.events.errors.EventPublisherException;
+import org.openmetadata.service.events.subscription.AlertUtil;
 import org.openmetadata.service.util.DIContainer;
 import org.quartz.JobDataMap;
 import org.quartz.JobDetail;
@@ -334,6 +340,84 @@ class AbstractEventConsumerTest {
         1,
         testEventConsumer.getCollectedSuccessfulEvents().size(),
         "Only successful events should be collected");
+  }
+
+  @Test
+  void testEventRecordedOncePerSubscriptionAcrossDestinationTypes() throws Exception {
+    RealPublishConsumer consumer = new RealPublishConsumer(dependencies);
+    consumer.eventSubscription = eventSubscription;
+
+    UUID webhookId = UUID.randomUUID();
+    UUID emailId = UUID.randomUUID();
+    Map<UUID, Destination<ChangeEvent>> destinations = new HashMap<>();
+    destinations.put(webhookId, mockDestination(SubscriptionType.WEBHOOK));
+    destinations.put(emailId, mockDestination(SubscriptionType.EMAIL));
+    consumer.destinationMap = destinations;
+    setField(
+        consumer,
+        "alertMetrics",
+        new AlertMetrics().withTotalEvents(0).withFailedEvents(0).withSuccessEvents(0));
+
+    ChangeEvent event = createMockChangeEvent();
+    Map<ChangeEvent, Set<UUID>> events = Map.of(event, Set.of(webhookId, emailId));
+
+    try (MockedStatic<AlertUtil> alertUtil = mockStatic(AlertUtil.class)) {
+      alertUtil.when(() -> AlertUtil.getFilteredEvents(any(), any())).thenReturn(events);
+      consumer.publishEvents(events);
+    }
+
+    List<?> recorded = (List<?>) getField(consumer, "successfulEvents");
+    assertEquals(
+        1,
+        recorded.size(),
+        "Event delivered to two destination types must be recorded once: "
+            + "successful_sent_change_events is keyed by (change_event_id, event_subscription_id)");
+    assertSame(event, recorded.getFirst());
+
+    AlertMetrics metrics = (AlertMetrics) getField(consumer, "alertMetrics");
+    assertEquals(
+        2,
+        metrics.getSuccessEvents(),
+        "Per-destination-type success metric is intentionally preserved");
+  }
+
+  @SuppressWarnings("unchecked")
+  private Destination<ChangeEvent> mockDestination(SubscriptionType type) {
+    Destination<ChangeEvent> destination = mock(Destination.class);
+    SubscriptionDestination subscriptionDestination = mock(SubscriptionDestination.class);
+    lenient().when(subscriptionDestination.getType()).thenReturn(type);
+    lenient().when(destination.getEnabled()).thenReturn(true);
+    lenient().when(destination.getSubscriptionDestination()).thenReturn(subscriptionDestination);
+    lenient().when(destination.requiresRecipients()).thenReturn(false);
+    return destination;
+  }
+
+  private static void setField(Object target, String name, Object value) throws Exception {
+    Field field = AbstractEventConsumer.class.getDeclaredField(name);
+    field.setAccessible(true);
+    field.set(target, value);
+  }
+
+  private static Object getField(Object target, String name) throws Exception {
+    Field field = AbstractEventConsumer.class.getDeclaredField(name);
+    field.setAccessible(true);
+    return field.get(target);
+  }
+
+  static class RealPublishConsumer extends AbstractEventConsumer {
+    RealPublishConsumer(DIContainer dependencies) {
+      super(dependencies);
+    }
+
+    @Override
+    public boolean sendAlert(UUID receiverId, ChangeEvent event) {
+      return true;
+    }
+
+    @Override
+    public boolean getEnabled() {
+      return true;
+    }
   }
 
   private ChangeEvent createMockChangeEvent() {

--- a/openmetadata-service/src/test/java/org/openmetadata/service/apps/bundles/changeEvent/AbstractEventConsumerTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/apps/bundles/changeEvent/AbstractEventConsumerTest.java
@@ -21,7 +21,9 @@ import java.util.*;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
+import org.mockito.MockedConstruction;
 import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.openmetadata.schema.entity.events.AlertMetrics;
@@ -32,6 +34,9 @@ import org.openmetadata.schema.type.ChangeEvent;
 import org.openmetadata.schema.utils.ResultList;
 import org.openmetadata.service.events.errors.EventPublisherException;
 import org.openmetadata.service.events.subscription.AlertUtil;
+import org.openmetadata.service.notifications.recipients.RecipientResolver;
+import org.openmetadata.service.notifications.recipients.context.EmailRecipient;
+import org.openmetadata.service.notifications.recipients.context.Recipient;
 import org.openmetadata.service.util.DIContainer;
 import org.quartz.JobDataMap;
 import org.quartz.JobDetail;
@@ -381,15 +386,190 @@ class AbstractEventConsumerTest {
         "Per-destination-type success metric is intentionally preserved");
   }
 
+  // #25312: same-type destinations get one send via the primary, recipients unioned across them.
+  @Test
   @SuppressWarnings("unchecked")
+  void testRecipientsUnionedAndSentOncePerSameTypeDestinations() throws Exception {
+    RealPublishConsumer consumer = newRealConsumerWithMetrics();
+
+    Destination<ChangeEvent> emailA = mockDestination(SubscriptionType.EMAIL, true);
+    Destination<ChangeEvent> emailB = mockDestination(SubscriptionType.EMAIL, true);
+    SubscriptionDestination subA = emailA.getSubscriptionDestination();
+    SubscriptionDestination subB = emailB.getSubscriptionDestination();
+    UUID idA = UUID.randomUUID();
+    UUID idB = UUID.randomUUID();
+    Map<UUID, Destination<ChangeEvent>> destinations = new HashMap<>();
+    destinations.put(idA, emailA);
+    destinations.put(idB, emailB);
+    consumer.destinationMap = destinations;
+
+    ChangeEvent event = createMockChangeEvent();
+    Map<ChangeEvent, Set<UUID>> events = Map.of(event, Set.of(idA, idB));
+
+    Recipient r1 = new EmailRecipient("a@example.com");
+    Recipient r2 = new EmailRecipient("b@example.com");
+    Set<Recipient> union = Set.of(r1, r2);
+
+    List<Set<Recipient>> sent = new ArrayList<>();
+    // Only the primary is sent to (Set order picks which), so record both and assert the total.
+    lenient()
+        .doAnswer(
+            inv -> {
+              sent.add(inv.getArgument(1));
+              return null;
+            })
+        .when(emailA)
+        .sendMessage(any(), any());
+    lenient()
+        .doAnswer(
+            inv -> {
+              sent.add(inv.getArgument(1));
+              return null;
+            })
+        .when(emailB)
+        .sendMessage(any(), any());
+
+    try (MockedStatic<AlertUtil> alertUtil = mockStatic(AlertUtil.class);
+        MockedConstruction<RecipientResolver> resolverCtor =
+            mockConstruction(
+                RecipientResolver.class,
+                (mock, ctx) -> when(mock.resolveRecipients(any(), anyList())).thenReturn(union))) {
+      alertUtil.when(() -> AlertUtil.getFilteredEvents(any(), any())).thenReturn(events);
+
+      consumer.publishEvents(events);
+
+      assertEquals(1, sent.size(), "One send per SubscriptionType, via the primary destination");
+      assertEquals(union, sent.getFirst(), "Recipients unioned across same-type destinations");
+
+      RecipientResolver resolver = resolverCtor.constructed().getFirst();
+      ArgumentCaptor<List<SubscriptionDestination>> captor = ArgumentCaptor.forClass(List.class);
+      verify(resolver).resolveRecipients(eq(event), captor.capture());
+      assertEquals(2, captor.getValue().size());
+      assertTrue(
+          captor.getValue().containsAll(List.of(subA, subB)),
+          "Resolver receives every same-type destination so recipients dedup across them");
+    }
+
+    assertEquals(
+        1,
+        ((List<?>) getField(consumer, "successfulEvents")).size(),
+        "Event recorded once for the (event, subscription)");
+  }
+
+  // #25312: empty recipients (destination requires them, none resolved) is a successful no-op send.
+  @Test
+  void testEmptyRecipientsIsNoOpSuccessAndRecorded() throws Exception {
+    RealPublishConsumer consumer = newRealConsumerWithMetrics();
+    Destination<ChangeEvent> email = mockDestination(SubscriptionType.EMAIL, true);
+    UUID id = UUID.randomUUID();
+    consumer.destinationMap = Map.of(id, email);
+
+    ChangeEvent event = createMockChangeEvent();
+    Map<ChangeEvent, Set<UUID>> events = Map.of(event, Set.of(id));
+
+    try (MockedStatic<AlertUtil> alertUtil = mockStatic(AlertUtil.class);
+        MockedConstruction<RecipientResolver> resolverCtor =
+            mockConstruction(
+                RecipientResolver.class,
+                (mock, ctx) ->
+                    when(mock.resolveRecipients(any(), anyList())).thenReturn(Set.of()))) {
+      alertUtil.when(() -> AlertUtil.getFilteredEvents(any(), any())).thenReturn(events);
+      consumer.publishEvents(events);
+    }
+
+    verify(email, never()).sendMessage(any(), any());
+    assertEquals(
+        1,
+        ((List<?>) getField(consumer, "successfulEvents")).size(),
+        "Empty recipients is a no-op success and still recorded");
+    assertEquals(1, ((AlertMetrics) getField(consumer, "alertMetrics")).getSuccessEvents());
+  }
+
+  // #25312: destinations that don't require recipients always send.
+  @Test
+  void testRequiresRecipientsFalseSendsWithoutResolving() throws Exception {
+    RealPublishConsumer consumer = newRealConsumerWithMetrics();
+    Destination<ChangeEvent> destination = mockDestination(SubscriptionType.WEBHOOK, false);
+    UUID id = UUID.randomUUID();
+    consumer.destinationMap = Map.of(id, destination);
+
+    ChangeEvent event = createMockChangeEvent();
+    Map<ChangeEvent, Set<UUID>> events = Map.of(event, Set.of(id));
+
+    try (MockedStatic<AlertUtil> alertUtil = mockStatic(AlertUtil.class);
+        MockedConstruction<RecipientResolver> resolverCtor =
+            mockConstruction(RecipientResolver.class)) {
+      alertUtil.when(() -> AlertUtil.getFilteredEvents(any(), any())).thenReturn(events);
+      consumer.publishEvents(events);
+
+      RecipientResolver resolver = resolverCtor.constructed().getFirst();
+      verify(resolver, never()).resolveRecipients(any(), any());
+    }
+
+    verify(destination).sendMessage(eq(event), eq(Set.of()));
+    assertEquals(1, ((List<?>) getField(consumer, "successfulEvents")).size());
+  }
+
+  // #28827: delivered-on-one-type/failed-on-another is recorded once; failing type still reported.
+  @Test
+  void testMixedDeliveryRecordsOnceAndReportsTypeFailure() throws Exception {
+    RealPublishConsumer consumer = newRealConsumerWithMetrics();
+    Destination<ChangeEvent> ok = mockDestination(SubscriptionType.WEBHOOK, false);
+    Destination<ChangeEvent> failing = mockDestination(SubscriptionType.EMAIL, false);
+    doThrow(mock(EventPublisherException.class)).when(failing).sendMessage(any(), any());
+
+    UUID okId = UUID.randomUUID();
+    UUID failId = UUID.randomUUID();
+    Map<UUID, Destination<ChangeEvent>> destinations = new HashMap<>();
+    destinations.put(okId, ok);
+    destinations.put(failId, failing);
+    consumer.destinationMap = destinations;
+
+    ChangeEvent event = createMockChangeEvent();
+    Map<ChangeEvent, Set<UUID>> events = Map.of(event, Set.of(okId, failId));
+
+    try (MockedStatic<AlertUtil> alertUtil = mockStatic(AlertUtil.class);
+        MockedConstruction<RecipientResolver> resolverCtor =
+            mockConstruction(RecipientResolver.class)) {
+      alertUtil.when(() -> AlertUtil.getFilteredEvents(any(), any())).thenReturn(events);
+      consumer.publishEvents(events);
+    }
+
+    assertEquals(
+        1,
+        ((List<?>) getField(consumer, "successfulEvents")).size(),
+        "Delivered to at least one type, so recorded exactly once");
+    AlertMetrics metrics = (AlertMetrics) getField(consumer, "alertMetrics");
+    assertEquals(1, metrics.getSuccessEvents());
+    assertEquals(1, metrics.getFailedEvents());
+    assertEquals(
+        1, consumer.capturedFailures.size(), "handleFailedEvent invoked for the failing type");
+  }
+
   private Destination<ChangeEvent> mockDestination(SubscriptionType type) {
+    return mockDestination(type, false);
+  }
+
+  @SuppressWarnings("unchecked")
+  private Destination<ChangeEvent> mockDestination(
+      SubscriptionType type, boolean requiresRecipients) {
     Destination<ChangeEvent> destination = mock(Destination.class);
     SubscriptionDestination subscriptionDestination = mock(SubscriptionDestination.class);
     lenient().when(subscriptionDestination.getType()).thenReturn(type);
     lenient().when(destination.getEnabled()).thenReturn(true);
     lenient().when(destination.getSubscriptionDestination()).thenReturn(subscriptionDestination);
-    lenient().when(destination.requiresRecipients()).thenReturn(false);
+    lenient().when(destination.requiresRecipients()).thenReturn(requiresRecipients);
     return destination;
+  }
+
+  private RealPublishConsumer newRealConsumerWithMetrics() throws Exception {
+    RealPublishConsumer consumer = new RealPublishConsumer(dependencies);
+    consumer.eventSubscription = eventSubscription;
+    setField(
+        consumer,
+        "alertMetrics",
+        new AlertMetrics().withTotalEvents(0).withFailedEvents(0).withSuccessEvents(0));
+    return consumer;
   }
 
   private static void setField(Object target, String name, Object value) throws Exception {
@@ -405,6 +585,8 @@ class AbstractEventConsumerTest {
   }
 
   static class RealPublishConsumer extends AbstractEventConsumer {
+    final List<EventPublisherException> capturedFailures = new ArrayList<>();
+
     RealPublishConsumer(DIContainer dependencies) {
       super(dependencies);
     }
@@ -417,6 +599,12 @@ class AbstractEventConsumerTest {
     @Override
     public boolean getEnabled() {
       return true;
+    }
+
+    @Override
+    public void handleFailedEvent(EventPublisherException ex, boolean errorOnSub) {
+      // Capture instead of writing via the DAO, so the real publishEvents runs without one.
+      capturedFailures.add(ex);
     }
   }
 

--- a/openmetadata-service/src/test/java/org/openmetadata/service/jdbi3/EventSubscriptionDaoDedupTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/jdbi3/EventSubscriptionDaoDedupTest.java
@@ -1,0 +1,62 @@
+/*
+ *  Copyright 2021 Collate
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.openmetadata.service.jdbi3;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.openmetadata.service.jdbi3.CollectionDAO.EventSubscriptionDAO;
+
+class EventSubscriptionDaoDedupTest {
+
+  @Test
+  void distinctLastIndexesCollapsesDuplicateKeysKeepingLast() {
+    List<String> changeEventIds = List.of("event-a", "event-a");
+    List<String> subscriptionIds = List.of("sub-1", "sub-1");
+
+    List<Integer> kept = EventSubscriptionDAO.distinctLastIndexes(changeEventIds, subscriptionIds);
+
+    assertEquals(List.of(1), kept, "duplicate (change_event_id, subscription_id) keeps last index");
+  }
+
+  @Test
+  void distinctLastIndexesKeepsAllWhenNoDuplicates() {
+    List<String> changeEventIds = List.of("event-a", "event-b", "event-a");
+    List<String> subscriptionIds = List.of("sub-1", "sub-1", "sub-2");
+
+    List<Integer> kept = EventSubscriptionDAO.distinctLastIndexes(changeEventIds, subscriptionIds);
+
+    assertEquals(List.of(0, 1, 2), kept, "distinct composite keys are all kept, in order");
+  }
+
+  @Test
+  void distinctLastIndexesIsDrivenByCompositeKeyNotChangeEventAlone() {
+    List<String> changeEventIds = List.of("event-a", "event-a");
+    List<String> subscriptionIds = List.of("sub-1", "sub-2");
+
+    List<Integer> kept = EventSubscriptionDAO.distinctLastIndexes(changeEventIds, subscriptionIds);
+
+    assertEquals(
+        List.of(0, 1), kept, "same change event for different subscriptions is not a duplicate");
+  }
+
+  @Test
+  void pickByIndexSelectsRequestedElements() {
+    List<String> source = List.of("a", "b", "c");
+
+    assertEquals(List.of("a", "c"), EventSubscriptionDAO.pickByIndex(source, List.of(0, 2)));
+    assertEquals(List.of("b"), EventSubscriptionDAO.pickByIndex(source, List.of(1)));
+  }
+}


### PR DESCRIPTION
Fixes #28828

## Problem

On PostgreSQL, alerts that fan an event out to **two or more destination types** intermittently fail to record sent events, with:

```
org.postgresql.util.PSQLException: ERROR: ON CONFLICT DO UPDATE command cannot affect row a second time
  /* EventSubscriptionDAO.batchUpsertSuccessfulChangeEvents */
```

The whole batch aborts, so **no rows** land in `successful_sent_change_events`. `commit()` swallows the error and advances the offset, so the alert's "Recent Events" tab shows nothing even though destinations were notified. MySQL is unaffected (`ON DUPLICATE KEY UPDATE` tolerates intra-statement duplicate keys; Postgres `ON CONFLICT` does not).

## Root cause

`successful_sent_change_events` is keyed `(change_event_id, event_subscription_id)` — no destination dimension. But `AbstractEventConsumer.publishEvents()` added the same `ChangeEvent` to the batch **once per destination type**. With the Postgres driver's `reWriteBatchedInserts=true`, the JDBI batch collapses into one multi-row `INSERT ... ON CONFLICT DO UPDATE`, and Postgres rejects a statement whose own rows conflict on the arbiter key.

## Fix

- **Source (primary):** `publishEvents` now records each event **once** per subscription (if delivered to ≥1 destination), instead of once per type. Per-type send / recipient-dedup behaviour and per-type success/failure metrics are unchanged.
- **DAO (defensive invariant):** `batchUpsertSuccessfulChangeEvents` deduplicates by `(change_event_id, event_subscription_id)` before the batch and delegates to `…Internal`, so the method honours the uniqueness its own `ON CONFLICT` SQL declares — protecting any future caller.
- **Cleanup:** removed the now-dead single-row writer `recordSuccessfulChangeEvent` and its orphaned DAO method `upsertSuccessfulChangeEvent` (no callers since the batch refactor in #25250).

## Refactor + safety (no #25312 regression)

While here, the delivery hot path was tidied — **behaviour-identical**:

- `publishEvent` now returns a small `EventDeliveryResult(delivered, successCount, failedCount)`; the success-record and metric deltas are applied **once** in `publishEvents` instead of being mutated deep inside the per-destination-type loop. Same sends, same metric totals, same recorded rows — just clearer, with no hidden field mutation.
- Early-return guard for the empty-batch case (one fewer nesting level).

That path also carries the recipient-dedup fix from #25312 (issue #24691): **one send per `SubscriptionType`** via the primary destination, recipients **unioned/deduped across all same-type destinations**, empty recipients = no-op success, `requiresRecipients()` guard. That orchestration was previously **not** exercised by unit tests (the test double overrode `publishEvents`), so this PR adds consumer-level characterization tests that drive the **real** `publishEvents` and lock those invariants — the refactor (and any future change) can't silently regress #25312.

## Tests

- **`EventSubscriptionBatchUpsertIT`** (new) — Postgres regression: a batch with duplicate keys must not throw and must collapse to one row. Verified **RED** against unfixed code (reproduces the exact `ON CONFLICT` error) and **GREEN** with the fix, on a real `postgres:15` container.
- **`AbstractEventConsumerTest`** — now drives the **real** `publishEvents` (no longer overridden):
  - **#25312:** two same-type destinations → exactly **one** `sendMessage` on the primary, with recipients unioned across both subscription destinations; empty recipients = no-op success; `requiresRecipients()==false` always sends; mixed success/failure across types → recorded once + `handleFailedEvent` invoked + per-type metrics.
  - **#28827:** event matched to multiple destination types → recorded **once**; per-type `successEvents` metric preserved.
- **`EventSubscriptionDaoDedupTest`** (new) — dedup-helper semantics: collapse duplicate composite keys keeping last, keep all distinct keys, key on the full composite (not change-event alone), `pickByIndex` projection.
- Existing `RecipientResolver` / `AlertPublisher` tests still green.
- **End-to-end** (deployed instance, webhook sniffer): delivery works; same-endpoint dedup → **1** POST; distinct endpoints → **2** POSTs; multi-type alert → one POST per type and recorded once; failure path (dead endpoint) → `failedEvents` metric increments, offset still advances, no crash, no `ON CONFLICT`.
