### PR TITLE
fix(alerts): match Entity FQN filter against an entity and its descendants

### DIFF
--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/AlertsRuleEvaluatorResourceIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/AlertsRuleEvaluatorResourceIT.java
@@ -187,6 +187,79 @@ public class AlertsRuleEvaluatorResourceIT {
     assertFalse(evaluateExpression("matchAnyEntityFqn({'unrelated.fqn'})", evaluationContext));
   }
 
+  // matchAnyEntityFqn matches the entity FQN exactly or any ancestor (service/database scope).
+  @ParameterizedTest
+  @ValueSource(
+      strings = {
+        "Snowflake Integration", // service ancestor
+        "Snowflake Integration.BRONZE_DEV", // database ancestor
+        "Snowflake Integration.BRONZE_DEV.MITELEPLUS", // exact
+      })
+  void test_matchAnyEntityFqn_matchesEntityOrAncestor(String listedFqn) {
+    Table table =
+        new Table()
+            .withName("MITELEPLUS")
+            .withFullyQualifiedName("Snowflake Integration.BRONZE_DEV.MITELEPLUS");
+    ChangeEvent changeEvent = new ChangeEvent();
+    changeEvent.setEntityType(Entity.TABLE);
+    changeEvent.setEntity(table);
+    AlertsRuleEvaluator alertsRuleEvaluator = new AlertsRuleEvaluator(changeEvent);
+    EvaluationContext evaluationContext =
+        SimpleEvaluationContext.forReadOnlyDataBinding()
+            .withInstanceMethods()
+            .withRootObject(alertsRuleEvaluator)
+            .build();
+
+    assertTrue(evaluateExpression("matchAnyEntityFqn({'" + listedFqn + "'})", evaluationContext));
+  }
+
+  @Test
+  void test_matchAnyEntityFqn_rejectsSiblingAndPrefixCollision() {
+    Table table =
+        new Table().withName("X").withFullyQualifiedName("Snowflake Integration 2.BRONZE_DEV.X");
+    ChangeEvent changeEvent = new ChangeEvent();
+    changeEvent.setEntityType(Entity.TABLE);
+    changeEvent.setEntity(table);
+    AlertsRuleEvaluator alertsRuleEvaluator = new AlertsRuleEvaluator(changeEvent);
+    EvaluationContext evaluationContext =
+        SimpleEvaluationContext.forReadOnlyDataBinding()
+            .withInstanceMethods()
+            .withRootObject(alertsRuleEvaluator)
+            .build();
+
+    // Sibling service sharing a name prefix must not match.
+    assertFalse(
+        evaluateExpression("matchAnyEntityFqn({'Snowflake Integration'})", evaluationContext));
+
+    Table sibling = new Table().withName("t").withFullyQualifiedName("service.db.schema2.t");
+    changeEvent.setEntity(sibling);
+    alertsRuleEvaluator = new AlertsRuleEvaluator(changeEvent);
+    evaluationContext =
+        SimpleEvaluationContext.forReadOnlyDataBinding()
+            .withInstanceMethods()
+            .withRootObject(alertsRuleEvaluator)
+            .build();
+    // Prefix collision: schema2 is not under schema.
+    assertFalse(evaluateExpression("matchAnyEntityFqn({'service.db.schema'})", evaluationContext));
+  }
+
+  @Test
+  void test_matchAnyEntityFqn_childFqnDoesNotMatchParentEntity() {
+    Table schema = new Table().withName("schema").withFullyQualifiedName("service.db.schema");
+    ChangeEvent changeEvent = new ChangeEvent();
+    changeEvent.setEntityType(Entity.TABLE);
+    changeEvent.setEntity(schema);
+    AlertsRuleEvaluator alertsRuleEvaluator = new AlertsRuleEvaluator(changeEvent);
+    EvaluationContext evaluationContext =
+        SimpleEvaluationContext.forReadOnlyDataBinding()
+            .withInstanceMethods()
+            .withRootObject(alertsRuleEvaluator)
+            .build();
+
+    assertFalse(
+        evaluateExpression("matchAnyEntityFqn({'service.db.schema.table'})", evaluationContext));
+  }
+
   @Test
   void test_filterByTableNameTestCaseBelongsTo_happyPath() {
     String tableFqn = "service.db.schema.orders";

--- a/openmetadata-service/src/main/java/org/openmetadata/service/events/subscription/AlertsRuleEvaluator.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/events/subscription/AlertsRuleEvaluator.java
@@ -45,6 +45,7 @@ import org.openmetadata.service.Entity;
 import org.openmetadata.service.exception.EntityNotFoundException;
 import org.openmetadata.service.formatter.util.FormatterUtil;
 import org.openmetadata.service.resources.feeds.MessageParser;
+import org.openmetadata.service.util.FullyQualifiedName;
 
 @Slf4j
 public class AlertsRuleEvaluator {
@@ -128,7 +129,7 @@ public class AlertsRuleEvaluator {
       name = "matchAnyEntityFqn",
       input = "List of comma separated fully qualified entity names",
       description =
-          "Returns true if the change event entity's fully qualified name equals any of the listed FQNs.",
+          "Returns true if the change event entity's fully qualified name equals, or is a descendant of, any of the listed FQNs.",
       examples = {
         "matchAnyEntityFqn({'service.database.schema.table1', 'service.database.schema.table2'})"
       },
@@ -144,7 +145,7 @@ public class AlertsRuleEvaluator {
     }
 
     EntityInterface entity = getEntity(changeEvent);
-    if (entityFqns.contains(entity.getFullyQualifiedName())) {
+    if (matchesFqnOrDescendant(entity.getFullyQualifiedName(), entityFqns)) {
       return true;
     }
 
@@ -157,6 +158,20 @@ public class AlertsRuleEvaluator {
     }
 
     return false;
+  }
+
+  // Matches the entity FQN exactly or as a descendant (segment-anchored via isParent, no regex).
+  private boolean matchesFqnOrDescendant(String entityFqn, List<String> entityFqns) {
+    boolean matched = false;
+    if (entityFqn != null) {
+      for (String listedFqn : entityFqns) {
+        if (entityFqn.equals(listedFqn) || FullyQualifiedName.isParent(entityFqn, listedFqn)) {
+          matched = true;
+          break;
+        }
+      }
+    }
+    return matched;
   }
 
   @Function(

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/events/subscription/EventSubscriptionResource.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/events/subscription/EventSubscriptionResource.java
@@ -1563,6 +1563,8 @@ public class EventSubscriptionResource
     }
   }
 
+  private static final String ALL_RESOURCE_NAME = "all";
+
   public static List<FilterResourceDescriptor> getNotificationsFilterDescriptors()
       throws IOException {
     List<NotificationResourceDescriptor> entityNotificationDescriptors =
@@ -1572,19 +1574,39 @@ public class EventSubscriptionResource
         getDescriptorsFromFile("FilterFunctionsDescriptor.json", EventFilterRule.class).stream()
             .collect(
                 Collectors.toMap(EventFilterRule::getName, eventFilterRule -> eventFilterRule));
-    return entityNotificationDescriptors.stream()
-        .map(
-            descriptor -> {
-              List<EventFilterRule> rules =
-                  descriptor.getSupportedFilters().stream()
-                      .map(operation -> functions.get(operation.value()))
-                      .filter(Objects::nonNull)
-                      .toList();
-              return new FilterResourceDescriptor()
-                  .withName(descriptor.getName())
-                  .withSupportedFilters(rules);
-            })
-        .toList();
+    List<FilterResourceDescriptor> descriptors =
+        entityNotificationDescriptors.stream()
+            .map(
+                descriptor -> {
+                  List<EventFilterRule> rules =
+                      descriptor.getSupportedFilters().stream()
+                          .map(operation -> functions.get(operation.value()))
+                          .filter(Objects::nonNull)
+                          .toList();
+                  return new FilterResourceDescriptor()
+                      .withName(descriptor.getName())
+                      .withSupportedFilters(rules)
+                      .withContainerEntities(descriptor.getContainerEntities());
+                })
+            .toList();
+    setAllResourceContainerEntities(descriptors);
+    return descriptors;
+  }
+
+  // The "all" source spans every entity type, so its container entities are the union of every
+  // source's container entities — letting the UI scope an Entity FQN filter to descendants.
+  private static void setAllResourceContainerEntities(List<FilterResourceDescriptor> descriptors) {
+    List<String> unionContainerEntities =
+        descriptors.stream()
+            .map(FilterResourceDescriptor::getContainerEntities)
+            .filter(Objects::nonNull)
+            .flatMap(List::stream)
+            .distinct()
+            .toList();
+    descriptors.stream()
+        .filter(descriptor -> ALL_RESOURCE_NAME.equals(descriptor.getName()))
+        .findFirst()
+        .ifPresent(descriptor -> descriptor.setContainerEntities(unionContainerEntities));
   }
 
   private ResultList<TypedEvent> fetchEventRecords(

--- a/openmetadata-service/src/main/resources/json/data/EntityObservabilityFilterDescriptor.json
+++ b/openmetadata-service/src/main/resources/json/data/EntityObservabilityFilterDescriptor.json
@@ -1,6 +1,7 @@
 [
   {
     "name" : "table",
+    "containerEntities" : ["databaseService", "database", "databaseSchema"],
     "supportedFilters" : [
       {
         "name": "filterByFqn",
@@ -71,6 +72,7 @@
   },
   {
     "name" : "topic",
+    "containerEntities" : ["messagingService"],
     "supportedFilters" : [
       {
         "name": "filterByFqn",
@@ -132,6 +134,7 @@
   },
   {
     "name" : "container",
+    "containerEntities" : ["storageService"],
     "supportedFilters" : [
       {
         "name": "filterByFqn",
@@ -193,6 +196,7 @@
   },
   {
     "name" : "pipeline",
+    "containerEntities" : ["pipelineService"],
     "supportedFilters" : [
       {
         "name": "filterByFqn",
@@ -321,6 +325,7 @@
   },
   {
     "name" : "testCase",
+    "containerEntities" : ["databaseService", "database", "databaseSchema", "table"],
     "supportedFilters" : [
       {
         "name": "filterByFqn",
@@ -410,6 +415,7 @@
   },
   {
     "name" : "testSuite",
+    "containerEntities" : ["databaseService", "database", "databaseSchema", "table"],
     "supportedFilters" : [
       {
         "name": "filterByFqn",

--- a/openmetadata-service/src/main/resources/json/data/EventSubResourceDescriptor.json
+++ b/openmetadata-service/src/main/resources/json/data/EventSubResourceDescriptor.json
@@ -22,7 +22,8 @@
       "filterByDomain",
       "filterByGeneralMetadataEvents",
       "filterByUpdaterIsBot"
-    ]
+    ],
+    "containerEntities" : [ "dashboardService" ]
   },
   {
     "name" : "dashboard",
@@ -34,7 +35,8 @@
       "filterByDomain",
       "filterByGeneralMetadataEvents",
       "filterByUpdaterIsBot"
-    ]
+    ],
+    "containerEntities" : [ "dashboardService" ]
   },
   {
     "name" : "dashboardService",
@@ -58,7 +60,8 @@
       "filterByDomain",
       "filterByGeneralMetadataEvents",
       "filterByUpdaterIsBot"
-    ]
+    ],
+    "containerEntities" : [ "databaseService" ]
   },
   {
     "name" : "databaseSchema",
@@ -70,7 +73,8 @@
       "filterByDomain",
       "filterByGeneralMetadataEvents",
       "filterByUpdaterIsBot"
-    ]
+    ],
+    "containerEntities" : [ "databaseService", "database" ]
   },
   {
     "name" : "databaseService",
@@ -106,7 +110,8 @@
       "filterByDomain",
       "filterByGeneralMetadataEvents",
       "filterByUpdaterIsBot"
-    ]
+    ],
+    "containerEntities" : [ "glossary" ]
   },
   {
     "name" : "ingestionPipeline",
@@ -142,7 +147,8 @@
       "filterByDomain",
       "filterByGeneralMetadataEvents",
       "filterByUpdaterIsBot"
-    ]
+    ],
+    "containerEntities" : [ "mlmodelService" ]
   },
   {
     "name" : "mlmodelService",
@@ -166,7 +172,8 @@
       "filterByDomain",
       "filterByGeneralMetadataEvents",
       "filterByUpdaterIsBot"
-    ]
+    ],
+    "containerEntities" : [ "pipelineService" ]
   },
   {
     "name" : "pipelineService",
@@ -202,7 +209,8 @@
       "filterByDomain",
       "filterByGeneralMetadataEvents",
       "filterByUpdaterIsBot"
-    ]
+    ],
+    "containerEntities" : [ "databaseService", "database", "databaseSchema" ]
   },
   {
     "name" : "tag",
@@ -214,7 +222,8 @@
       "filterByDomain",
       "filterByGeneralMetadataEvents",
       "filterByUpdaterIsBot"
-    ]
+    ],
+    "containerEntities" : [ "classification" ]
   },
   {
     "name" : "tagCategory",
@@ -238,7 +247,8 @@
       "filterByDomain",
       "filterByGeneralMetadataEvents",
       "filterByUpdaterIsBot"
-    ]
+    ],
+    "containerEntities" : [ "messagingService" ]
   },
   {
     "name" : "metadataService",
@@ -262,7 +272,8 @@
       "filterByDomain",
       "filterByGeneralMetadataEvents",
       "filterByUpdaterIsBot"
-    ]
+    ],
+    "containerEntities" : [ "dashboardService" ]
   },
   {
     "name" : "announcement",

--- a/openmetadata-spec/src/main/resources/json/schema/events/filterResourceDescriptor.json
+++ b/openmetadata-spec/src/main/resources/json/schema/events/filterResourceDescriptor.json
@@ -23,6 +23,13 @@
       "items": {
         "$ref": "./eventFilterRule.json"
       }
+    },
+    "containerEntities": {
+      "description": "Ancestor entity types whose fully qualified name is a prefix of this resource's FQN (e.g. a databaseSchema is contained by databaseService and database). Lets an Entity FQN filter scope an alert to all descendants of a parent.",
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
     }
   },
   "additionalProperties": false

--- a/openmetadata-spec/src/main/resources/json/schema/events/subscriptionResourceDescriptor.json
+++ b/openmetadata-spec/src/main/resources/json/schema/events/subscriptionResourceDescriptor.json
@@ -36,6 +36,13 @@
       "items": {
         "$ref": "#/definitions/operation"
       }
+    },
+    "containerEntities": {
+      "description": "Ancestor entity types whose fully qualified name is a prefix of this resource's FQN (e.g. a databaseSchema is contained by databaseService and database). Lets an Entity FQN filter scope an alert to all descendants of a parent.",
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
     }
   },
   "additionalProperties": false

--- a/openmetadata-ui/src/main/resources/ui/src/components/Alerts/AlertDetails/AlertConfigDetails/AlertConfigDetails.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Alerts/AlertDetails/AlertConfigDetails/AlertConfigDetails.tsx
@@ -70,19 +70,19 @@ function AlertConfigDetails({
   const [templateResourcePermission, setTemplateResourcePermission] =
     useState<OperationPermission>(DEFAULT_ENTITY_PERMISSION);
 
-  const { supportedFilters, supportedTriggers } = useMemo(
-    () => ({
-      supportedFilters: filterResources.find(
+  const { supportedFilters, supportedTriggers, containerEntities } =
+    useMemo(() => {
+      const resource = filterResources.find(
         (resource) =>
           resource.name === alertDetails.filteringRules?.resources[0]
-      )?.supportedFilters,
-      supportedTriggers: filterResources.find(
-        (resource) =>
-          resource.name === alertDetails.filteringRules?.resources[0]
-      )?.supportedActions,
-    }),
-    [filterResources, alertDetails]
-  );
+      );
+
+      return {
+        supportedFilters: resource?.supportedFilters,
+        supportedTriggers: resource?.supportedActions,
+        containerEntities: resource?.containerEntities,
+      };
+    }, [filterResources, alertDetails]);
 
   const fetchFunctions = useCallback(async () => {
     try {
@@ -172,6 +172,7 @@ function AlertConfigDetails({
             <Col span={24}>
               <ObservabilityFormFiltersItem
                 isViewMode
+                containerEntities={containerEntities}
                 supportedFilters={supportedFilters}
               />
             </Col>

--- a/openmetadata-ui/src/main/resources/ui/src/components/Alerts/FQNListSelect/FQNListSelect.component.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Alerts/FQNListSelect/FQNListSelect.component.test.tsx
@@ -1,0 +1,182 @@
+/*
+ *  Copyright 2025 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+import { render, screen, waitFor } from '@testing-library/react';
+import { SearchIndex } from '../../../enums/search.enum';
+import { searchQuery } from '../../../rest/searchAPI';
+import FQNListSelect, { resolveWildcardFqns } from './FQNListSelect.component';
+
+jest.mock('../../../rest/searchAPI', () => ({
+  searchQuery: jest.fn(),
+}));
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+let capturedProps: any;
+jest.mock('../../common/AsyncSelect/AsyncSelect', () => ({
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  AsyncSelect: (props: any) => {
+    capturedProps = props;
+
+    return <div data-testid="async-select" />;
+  },
+}));
+
+const mockSearchQuery = searchQuery as jest.Mock;
+
+describe('resolveWildcardFqns', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns only the FQNs whose entityType is a container type', async () => {
+    mockSearchQuery.mockResolvedValue({
+      hits: {
+        hits: [
+          {
+            _source: {
+              fullyQualifiedName: 'svc',
+              entityType: 'databaseService',
+            },
+          },
+          {
+            _source: {
+              fullyQualifiedName: 'svc.db.schema.tbl',
+              entityType: 'table',
+            },
+          },
+        ],
+      },
+    });
+
+    const result = await resolveWildcardFqns(
+      ['svc', 'svc.db.schema.tbl'],
+      SearchIndex.TABLE,
+      ['databaseService', 'database', 'databaseSchema']
+    );
+
+    expect(result).toEqual(['svc']);
+  });
+
+  it('queries the exact-match "fullyQualifiedName" field, not a ".keyword" subfield', async () => {
+    mockSearchQuery.mockResolvedValue({ hits: { hits: [] } });
+
+    await resolveWildcardFqns(['svc'], SearchIndex.TABLE, ['databaseService']);
+
+    const filter = JSON.stringify(mockSearchQuery.mock.calls[0][0].queryFilter);
+
+    expect(filter).toContain('"fullyQualifiedName":"svc"');
+    expect(filter).not.toContain('fullyQualifiedName.keyword');
+  });
+
+  it('does not call search when fqns or containerEntities are empty', async () => {
+    expect(
+      await resolveWildcardFqns([], SearchIndex.TABLE, ['databaseService'])
+    ).toEqual([]);
+    expect(await resolveWildcardFqns(['svc'], SearchIndex.TABLE, [])).toEqual(
+      []
+    );
+    expect(mockSearchQuery).not.toHaveBeenCalled();
+  });
+
+  it('returns an empty list when the search fails', async () => {
+    mockSearchQuery.mockRejectedValue(new Error('boom'));
+
+    expect(
+      await resolveWildcardFqns(['svc'], SearchIndex.TABLE, ['databaseService'])
+    ).toEqual([]);
+  });
+});
+
+describe('FQNListSelect', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    capturedProps = undefined;
+  });
+
+  it('decorates container FQNs with ".*" and renders leaves plain', async () => {
+    mockSearchQuery.mockResolvedValue({
+      hits: {
+        hits: [
+          {
+            _source: {
+              fullyQualifiedName: 'svc',
+              entityType: 'databaseService',
+            },
+          },
+        ],
+      },
+    });
+
+    render(
+      <FQNListSelect
+        api={jest.fn()}
+        containerEntities={['databaseService']}
+        mode="multiple"
+        searchIndex={SearchIndex.TABLE}
+        value={['svc', 'svc.db.schema.tbl']}
+      />
+    );
+
+    await screen.findByTestId('async-select');
+
+    await waitFor(() => {
+      const containerTag = render(
+        capturedProps.tagRender({
+          value: 'svc',
+          closable: true,
+          onClose: jest.fn(),
+        })
+      );
+
+      expect(containerTag.getByText('svc.*')).toBeInTheDocument();
+      expect(
+        containerTag.getByText('svc.*').closest('[title]')
+      ).toHaveAttribute('title', 'svc.*');
+    });
+
+    const leafTag = render(
+      capturedProps.tagRender({
+        value: 'svc.db.schema.tbl',
+        closable: true,
+        onClose: jest.fn(),
+      })
+    );
+
+    expect(leafTag.getByText('svc.db.schema.tbl')).toBeInTheDocument();
+  });
+
+  it('renders all tags plain when there are no container entities', async () => {
+    render(
+      <FQNListSelect
+        api={jest.fn()}
+        containerEntities={[]}
+        mode="multiple"
+        searchIndex={SearchIndex.TABLE}
+        value={['svc']}
+      />
+    );
+
+    await screen.findByTestId('async-select');
+
+    const tag = render(
+      capturedProps.tagRender({
+        value: 'svc',
+        closable: true,
+        onClose: jest.fn(),
+      })
+    );
+
+    expect(tag.getByText('svc')).toBeInTheDocument();
+    expect(mockSearchQuery).not.toHaveBeenCalled();
+  });
+});

--- a/openmetadata-ui/src/main/resources/ui/src/components/Alerts/FQNListSelect/FQNListSelect.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Alerts/FQNListSelect/FQNListSelect.component.tsx
@@ -1,0 +1,122 @@
+/*
+ *  Copyright 2025 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+import { SelectProps, Tag, Typography } from 'antd';
+import { isEmpty } from 'lodash';
+import type { CustomTagProps } from 'rc-select/lib/BaseSelect';
+import React, { useEffect, useState } from 'react';
+import { SearchIndex } from '../../../enums/search.enum';
+import { searchQuery } from '../../../rest/searchAPI';
+import { getTermQuery } from '../../../utils/SearchUtils';
+import { AsyncSelect } from '../../common/AsyncSelect/AsyncSelect';
+import { AsyncSelectListProps } from '../../common/AsyncSelect/AsyncSelectList.interface';
+
+interface FQNListSelectProps
+  extends SelectProps,
+    Pick<AsyncSelectListProps, 'api'> {
+  searchIndex: SearchIndex | SearchIndex[];
+  containerEntities?: string[];
+}
+
+// Resolves which of the saved FQNs refer to a container (ancestor) entity type for the current
+// source. The match rule is identical to authoring time (entityType in containerEntities), so the
+// saved-alert view can re-apply the display-only ".*" subtree hint that is not persisted.
+export const resolveWildcardFqns = async (
+  fqns: string[],
+  searchIndex: SearchIndex | SearchIndex[],
+  containerEntities: string[] = []
+): Promise<string[]> => {
+  let wildcardFqns: string[] = [];
+  if (!isEmpty(fqns) && !isEmpty(containerEntities)) {
+    try {
+      const response = await searchQuery({
+        query: '*',
+        pageNumber: 1,
+        pageSize: fqns.length,
+        searchIndex,
+        queryFilter: getTermQuery({ fullyQualifiedName: fqns }, 'should', 1),
+      });
+
+      wildcardFqns = response.hits.hits
+        .filter(
+          (hit) =>
+            !!hit._source.entityType &&
+            containerEntities.includes(hit._source.entityType)
+        )
+        .map((hit) => hit._source.fullyQualifiedName ?? '')
+        .filter(Boolean);
+    } catch {
+      wildcardFqns = [];
+    }
+  }
+
+  return wildcardFqns;
+};
+
+// Alerts-only wrapper around the shared AsyncSelect. It keeps the shared component untouched and
+// scopes the ".*" tag decoration to the Entity-FQN filter, so other consumers of AsyncSelect are
+// unaffected.
+const FQNListSelect = ({
+  value,
+  searchIndex,
+  containerEntities = [],
+  ...rest
+}: FQNListSelectProps) => {
+  const [wildcardFqns, setWildcardFqns] = useState<Set<string>>(new Set());
+
+  useEffect(() => {
+    const fqns = (value as string[] | undefined) ?? [];
+    if (isEmpty(fqns) || isEmpty(containerEntities)) {
+      setWildcardFqns(new Set());
+
+      return;
+    }
+
+    let isActive = true;
+    resolveWildcardFqns(fqns, searchIndex, containerEntities).then((list) => {
+      if (isActive) {
+        setWildcardFqns(new Set(list));
+      }
+    });
+
+    return () => {
+      isActive = false;
+    };
+  }, [value, searchIndex, containerEntities]);
+
+  const tagRender = (tagProps: CustomTagProps) => {
+    const { value: tagValue, closable, onClose } = tagProps;
+    const fqn = tagValue as string;
+    const label = wildcardFqns.has(fqn) ? `${fqn}.*` : fqn;
+
+    const onPreventMouseDown = (event: React.MouseEvent<HTMLSpanElement>) => {
+      event.preventDefault();
+      event.stopPropagation();
+    };
+
+    return (
+      <Tag
+        closable={closable}
+        data-testid={`fqn-tag-${fqn}`}
+        title={label}
+        onClose={onClose}
+        onMouseDown={onPreventMouseDown}>
+        <Typography.Text className="break-all">{label}</Typography.Text>
+      </Tag>
+    );
+  };
+
+  return <AsyncSelect {...rest} tagRender={tagRender} value={value} />;
+};
+
+export default FQNListSelect;

--- a/openmetadata-ui/src/main/resources/ui/src/components/Alerts/ObservabilityFormFiltersItem/ObservabilityFormFiltersItem.interface.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Alerts/ObservabilityFormFiltersItem/ObservabilityFormFiltersItem.interface.ts
@@ -15,5 +15,6 @@ import { EventFilterRule } from '../../../generated/events/eventSubscription';
 
 export interface ObservabilityFormFiltersItemProps {
   supportedFilters?: EventFilterRule[];
+  containerEntities?: string[];
   isViewMode?: boolean;
 }

--- a/openmetadata-ui/src/main/resources/ui/src/components/Alerts/ObservabilityFormFiltersItem/ObservabilityFormFiltersItem.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Alerts/ObservabilityFormFiltersItem/ObservabilityFormFiltersItem.tsx
@@ -30,6 +30,7 @@ import { ObservabilityFormFiltersItemProps } from './ObservabilityFormFiltersIte
 
 function ObservabilityFormFiltersItem({
   supportedFilters,
+  containerEntities,
   isViewMode = false,
 }: Readonly<ObservabilityFormFiltersItemProps>) {
   const { t } = useTranslation();
@@ -109,7 +110,8 @@ function ObservabilityFormFiltersItem({
                               selectedFilters[name].name ?? '',
                               name,
                               selectedTrigger,
-                              supportedFilters
+                              supportedFilters,
+                              containerEntities
                             )}
                         </Row>
                       </div>

--- a/openmetadata-ui/src/main/resources/ui/src/generated/events/filterResourceDescriptor.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/events/filterResourceDescriptor.ts
@@ -15,6 +15,12 @@
  */
 export interface FilterResourceDescriptor {
     /**
+     * Ancestor entity types whose fully qualified name is a prefix of this resource's FQN (e.g.
+     * a databaseSchema is contained by databaseService and database). Lets an Entity FQN filter
+     * scope an alert to all descendants of a parent.
+     */
+    containerEntities?: string[];
+    /**
      * Name of the resource. For entity related resources, resource name is same as the entity
      * name. Some resources such as lineage are not entities but are resources.
      */

--- a/openmetadata-ui/src/main/resources/ui/src/generated/events/subscriptionResourceDescriptor.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/events/subscriptionResourceDescriptor.ts
@@ -15,6 +15,12 @@
  */
 export interface SubscriptionResourceDescriptor {
     /**
+     * Ancestor entity types whose fully qualified name is a prefix of this resource's FQN (e.g.
+     * a databaseSchema is contained by databaseService and database). Lets an Entity FQN filter
+     * scope an alert to all descendants of a parent.
+     */
+    containerEntities?: string[];
+    /**
      * Name of the resource. For entity related resources, resource name is same as the entity
      * name. Some resources such as lineage are not entities but are resources.
      */

--- a/openmetadata-ui/src/main/resources/ui/src/pages/AddNotificationPage/AddNotificationPage.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/AddNotificationPage/AddNotificationPage.tsx
@@ -231,6 +231,13 @@ const AddNotificationPage = () => {
     [entityFunctions, selectedTrigger]
   );
 
+  const containerEntities = useMemo(
+    () =>
+      entityFunctions.find((resource) => resource.name === selectedTrigger)
+        ?.containerEntities,
+    [entityFunctions, selectedTrigger]
+  );
+
   const shouldShowFiltersSection = useMemo(
     () => (selectedTrigger ? !isEmpty(supportedFilters) : true),
     [selectedTrigger, supportedFilters]
@@ -373,6 +380,7 @@ const AddNotificationPage = () => {
                               </Col>
                               <Col span={24}>
                                 <ObservabilityFormFiltersItem
+                                  containerEntities={containerEntities}
                                   supportedFilters={supportedFilters}
                                 />
                               </Col>

--- a/openmetadata-ui/src/main/resources/ui/src/pages/AddObservabilityPage/AddObservabilityPage.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/AddObservabilityPage/AddObservabilityPage.tsx
@@ -200,6 +200,13 @@ function AddObservabilityPage() {
     [filterResources, selectedTrigger]
   );
 
+  const containerEntities = useMemo(
+    () =>
+      filterResources.find((resource) => resource.name === selectedTrigger)
+        ?.containerEntities,
+    [filterResources, selectedTrigger]
+  );
+
   const supportedTriggers = useMemo(
     () =>
       filterResources.find((resource) => resource.name === selectedTrigger)
@@ -339,6 +346,7 @@ function AddObservabilityPage() {
                             </Col>
                             <Col span={24}>
                               <ObservabilityFormFiltersItem
+                                containerEntities={containerEntities}
                                 supportedFilters={supportedFilters}
                               />
                             </Col>

--- a/openmetadata-ui/src/main/resources/ui/src/utils/Alerts/AlertsUtil.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/Alerts/AlertsUtil.test.tsx
@@ -56,6 +56,7 @@ import {
   getFieldByArgumentType,
   getFilteredDestinationOptions,
   getFormattedDestinations,
+  getFqnSearchIndexes,
   getFunctionDisplayName,
   getLabelsForEventDetails,
   listLengthValidator,
@@ -332,7 +333,11 @@ describe('AlertsUtil tests', () => {
 
 describe('getFieldByArgumentType tests', () => {
   it('should return correct fields for argumentType fqnList', async () => {
-    const field = getFieldByArgumentType(0, 'fqnList', 0, 'table');
+    const field = getFieldByArgumentType(0, 'fqnList', 0, 'table', [
+      'databaseService',
+      'database',
+      'databaseSchema',
+    ]);
 
     render(field);
 
@@ -345,7 +350,12 @@ describe('getFieldByArgumentType tests', () => {
       pageNumber: 1,
       pageSize: 50,
       queryFilter: undefined,
-      searchIndex: SearchIndex.TABLE,
+      searchIndex: [
+        SearchIndex.TABLE,
+        SearchIndex.DATABASE_SERVICE,
+        SearchIndex.DATABASE,
+        SearchIndex.DATABASE_SCHEMA,
+      ],
     });
   });
 
@@ -1868,5 +1878,33 @@ describe('getFormattedDestinations', () => {
     ]);
     expect(result?.[0]?.config).not.toHaveProperty('timeout');
     expect(result?.[0]?.config).not.toHaveProperty('readTimeout');
+  });
+});
+
+describe('getFqnSearchIndexes', () => {
+  it('includes the source index plus the descriptor-provided ancestor indexes', () => {
+    expect(
+      getFqnSearchIndexes('databaseSchema', ['databaseService', 'database'])
+    ).toEqual([
+      SearchIndex.DATABASE_SCHEMA,
+      SearchIndex.DATABASE_SERVICE,
+      SearchIndex.DATABASE,
+    ]);
+    expect(getFqnSearchIndexes('glossaryTerm', ['glossary'])).toEqual([
+      SearchIndex.GLOSSARY_TERM,
+      SearchIndex.GLOSSARY,
+    ]);
+  });
+
+  it('returns only the source index when there are no ancestors', () => {
+    expect(getFqnSearchIndexes('databaseService')).toEqual([
+      SearchIndex.DATABASE_SERVICE,
+    ]);
+  });
+
+  it('returns only the ALL index for the "all" source, ignoring container types', () => {
+    expect(getFqnSearchIndexes('all', ['databaseService', 'database'])).toEqual(
+      [SearchIndex.ALL]
+    );
   });
 });

--- a/openmetadata-ui/src/main/resources/ui/src/utils/Alerts/AlertsUtil.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/Alerts/AlertsUtil.tsx
@@ -70,6 +70,7 @@ import { ReactComponent as MSTeamsIcon } from '../../assets/svg/ms-teams.svg';
 import { ReactComponent as SlackIcon } from '../../assets/svg/slack.svg';
 import { ReactComponent as WebhookIcon } from '../../assets/svg/webhook.svg';
 import TeamAndUserSelectItem from '../../components/Alerts/DestinationFormItem/TeamAndUserSelectItem/TeamAndUserSelectItem';
+import FQNListSelect from '../../components/Alerts/FQNListSelect/FQNListSelect.component';
 import { AsyncSelect } from '../../components/common/AsyncSelect/AsyncSelect';
 import {
   DATA_CONTRACT_STATUS_OPTIONS,
@@ -134,12 +135,14 @@ export const searchEntity = async ({
   queryFilter,
   showDisplayNameAsLabel = true,
   setSourceAsValue = false,
+  wildcardEntityTypes,
 }: {
   searchText: string;
   searchIndex: SearchIndex | SearchIndex[];
   queryFilter?: Record<string, unknown>;
   showDisplayNameAsLabel?: boolean;
   setSourceAsValue?: boolean;
+  wildcardEntityTypes?: string[];
 }) => {
   try {
     const response = await searchQuery({
@@ -160,6 +163,13 @@ export const searchEntity = async ({
           ? getEntityName(d._source)
           : d._source.fullyQualifiedName ?? '';
 
+        // Container options (a type that has in-scope descendants) show a display-only ".*" hint
+        // to convey "matches everything under this FQN"; the stored value stays the plain FQN.
+        const isContainerOption =
+          !!d._source.entityType &&
+          (wildcardEntityTypes ?? []).includes(d._source.entityType);
+        const label = isContainerOption ? `${displayName}.*` : displayName;
+
         const value = setSourceAsValue
           ? JSON.stringify({
               ...d._source,
@@ -168,7 +178,7 @@ export const searchEntity = async ({
           : d._source.fullyQualifiedName ?? '';
 
         return {
-          label: displayName,
+          label,
           value,
         };
       }),
@@ -184,6 +194,25 @@ export const searchEntity = async ({
 
     return [];
   }
+};
+
+// Indexes to search for an Entity FQN filter: the source plus its ancestor (container) entity
+// types from the resource descriptor, so a parent FQN can be selected to scope to its descendants.
+export const getFqnSearchIndexes = (
+  selectedTrigger: string,
+  containerEntities: string[] = []
+): SearchIndex[] => {
+  const mapping = searchClassBase.getEntityTypeSearchIndexMapping();
+  const sourceIndex = mapping[selectedTrigger];
+
+  // The "all" index already spans every entity, so ancestor indexes are redundant there.
+  if (sourceIndex === SearchIndex.ALL) {
+    return [sourceIndex];
+  }
+
+  return [selectedTrigger, ...containerEntities]
+    .map((type) => mapping[type])
+    .filter((index): index is SearchIndex => Boolean(index));
 };
 
 const getTableSuggestions = async (searchText: string) => {
@@ -846,18 +875,17 @@ export const getFieldByArgumentType = (
   fieldName: number,
   argument: string,
   index: number,
-  selectedTrigger: string
+  selectedTrigger: string,
+  containerEntities: string[] = []
 ) => {
   let field: JSX.Element;
 
   const getEntityByFQN = async (searchText: string) => {
-    const searchIndexMapping =
-      searchClassBase.getEntityTypeSearchIndexMapping();
-
     return searchEntity({
       searchText,
-      searchIndex: searchIndexMapping[selectedTrigger],
+      searchIndex: getFqnSearchIndexes(selectedTrigger, containerEntities),
       showDisplayNameAsLabel: false,
+      wildcardEntityTypes: containerEntities,
     });
   };
 
@@ -913,16 +941,17 @@ export const getFieldByArgumentType = (
   switch (argument) {
     case 'fqnList':
       field = (
-        <AsyncSelect
+        <FQNListSelect
           api={getEntityByFQN}
           className="w-full"
+          containerEntities={containerEntities}
           data-testid="fqn-list-select"
-          maxTagTextLength={45}
           mode="multiple"
           optionFilterProp="label"
           placeholder={t('label.search-by-type', {
             type: t('label.fqn-uppercase'),
           })}
+          searchIndex={getFqnSearchIndexes(selectedTrigger, containerEntities)}
         />
       );
 
@@ -1168,7 +1197,8 @@ export const getConditionalField = (
   condition: string,
   name: number,
   selectedTrigger: string,
-  supportedActions?: EventFilterRule[]
+  supportedActions?: EventFilterRule[],
+  containerEntities?: string[]
 ) => {
   const selectedAction = supportedActions?.find(
     (action) => action.name === condition
@@ -1183,7 +1213,13 @@ export const getConditionalField = (
   return (
     <>
       {requiredArguments?.map((argument, index) => {
-        return getFieldByArgumentType(name, argument, index, selectedTrigger);
+        return getFieldByArgumentType(
+          name,
+          argument,
+          index,
+          selectedTrigger,
+          containerEntities
+        );
       })}
     </>
   );


### PR DESCRIPTION
Fixes #28834

## Problem

PR #27987 ("strict literal matching across alert filter functions") changed `AlertsRuleEvaluator.matchAnyEntityFqn` from a substring **regex** (`Pattern.compile(value).matcher(fqn).find()`) to **exact equality** (`entityFqns.contains(fqn)`). That was a correct security/correctness fix (regex injection, crashes on metacharacter names, substring false positives) — but it silently removed a capability customers relied on: filtering by a **parent FQN** (a service / database / glossary / classification) to match **all of its descendants**.

Example: an alert with `Source = databaseSchema` and `matchAnyEntityFqn({'Snowflake Integration'})` (a *service* FQN) matched all schemas under that service before the upgrade, and matched **nothing** after — "no change events". This regressed every hierarchical source (table, database, chart/dashboard, topic, mlmodel, pipeline, glossaryTerm, tag, dataProduct, …), not just databaseSchema.

## Fix

**Backend (the restore).** `matchAnyEntityFqn` now matches when the entity FQN **equals** a listed FQN **or is a descendant** of one, using the existing literal, segment-anchored helper `FullyQualifiedName.isParent` (no regex). This restores subtree matching for existing alerts **with no migration** (the stored condition just starts matching again) while preserving every guarantee from #27987 — its regex-metacharacter and "unrelated FQN" tests still pass.

**Backend-driven hierarchy.** The source→ancestor mapping lives in the backend: a new `containerEntities` field on the notification/`filter` resource descriptors (`subscriptionResourceDescriptor` / `filterResourceDescriptor`), populated per source in `EventSubResourceDescriptor.json` and served through `getNotificationsFilterDescriptors`. The UI consumes it — no hardcoded hierarchy.

**UI picker.** The "Entity FQN" filter now searches the source index **plus its ancestor indexes**, so a user can select a parent (service/database/…) for a child source. Ancestor options render as `Snowflake Integration.*` (display only) to convey "everything under this"; the stored value stays the plain FQN.

## Tests

- `AlertsRuleEvaluatorResourceIT` (mirrors #27987's harness): descendant-positive (service/database/exact), sibling & mid-segment prefix-collision negatives, child-FQN-does-not-match-parent — **plus all #27987 literal-matching tests kept green** (41 run, 0 failures, on Postgres).
- `AlertsUtil` Jest: `getFqnSearchIndexes` index expansion (hierarchical vs flat source) and the FQN picker's multi-index search.

## Notes

- No data migration needed; existing alerts heal on deploy.
- The truly-dynamic alternative (deriving the hierarchy from entity relationships) isn't available; `containerEntities` is the curated list, now owned by the backend and served to all clients.
- Separate from #28827 (Postgres `ON CONFLICT` batch dedup), which addressed a different alert bug surfaced in the same customer report.