### PR TITLE
fix(governance): validate Flowable pool connections to survive DB failover

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/governance/workflows/WorkflowHandler.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/governance/workflows/WorkflowHandler.java
@@ -77,6 +77,13 @@ public class WorkflowHandler {
   @Getter private static volatile boolean initialized = false;
   private final boolean isMigrationContext;
 
+  private static final String CONNECTION_VALIDATION_QUERY = "SELECT 1";
+
+  // Validate any pooled connection idle longer than this before reuse. Kept below Flowable's
+  // 60s reset-expired-jobs interval so the periodic async-executor threads always re-validate,
+  // while connections in active sub-second use skip the check and pay no overhead.
+  private static final int CONNECTION_PING_NOT_USED_FOR_MILLIS = 30000;
+
   private WorkflowHandler(OpenMetadataApplicationConfig config, boolean isMigrationContext) {
     this.isMigrationContext = isMigrationContext;
     StandaloneProcessEngineConfiguration processEngineConfiguration =
@@ -180,6 +187,7 @@ public class WorkflowHandler {
       processEngineConfiguration.setJdbcPassword(
           currentProcessEngineConfiguration.getJdbcPassword());
       processEngineConfiguration.setJdbcDriver(currentProcessEngineConfiguration.getJdbcDriver());
+      configureConnectionPoolHealthChecks(processEngineConfiguration);
     }
     processEngineConfiguration.setDatabaseType(currentProcessEngineConfiguration.getDatabaseType());
     processEngineConfiguration.setDatabaseSchemaUpdate(
@@ -238,6 +246,25 @@ public class WorkflowHandler {
         .getSqlSessionFactory()
         .getConfiguration()
         .addMapper(SqlMapper.class);
+  }
+
+  /**
+   * Enable connection-pool health checks on the runtime engine's MyBatis pool.
+   *
+   * <p>Unlike the application's HikariCP pool, the Flowable runtime engine builds its own MyBatis
+   * {@code PooledDataSource} from the raw JDBC settings and does not validate pooled connections.
+   * When the database drops a connection out from under the pool — an Aurora/RDS failover, a
+   * maintenance restart, or an idle-connection reaper, all of which surface as {@code
+   * PSQLException: terminating connection due to administrator command} — the async executor's
+   * polling threads (e.g. {@code ResetExpiredJobsRunnable}) keep borrowing the dead connection and
+   * failing until the pool happens to recycle it. Pool ping runs a lightweight validation query on
+   * any connection idle past the threshold and transparently replaces it before handing it out.
+   */
+  private static void configureConnectionPoolHealthChecks(
+      StandaloneProcessEngineConfiguration processEngineConfiguration) {
+    processEngineConfiguration.setJdbcPingEnabled(true);
+    processEngineConfiguration.setJdbcPingQuery(CONNECTION_VALIDATION_QUERY);
+    processEngineConfiguration.setJdbcPingConnectionNotUsedFor(CONNECTION_PING_NOT_USED_FOR_MILLIS);
   }
 
   public static void initialize(OpenMetadataApplicationConfig config) {

--- a/openmetadata-service/src/test/java/org/openmetadata/service/governance/workflows/WorkflowHandlerSchemaUpdateTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/governance/workflows/WorkflowHandlerSchemaUpdateTest.java
@@ -18,11 +18,13 @@ import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockConstruction;
 import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -162,6 +164,59 @@ class WorkflowHandlerSchemaUpdateTest {
       StandaloneProcessEngineConfiguration engineConfig = engineMock.constructed().getLast();
       verify(engineConfig)
           .setDatabaseSchemaUpdate(ProcessEngineConfiguration.DB_SCHEMA_UPDATE_FALSE);
+    }
+  }
+
+  @Test
+  void runtimeModeEnablesConnectionPoolHealthChecks() {
+    try (MockedConstruction<StandaloneProcessEngineConfiguration> engineMock =
+            mockConstruction(
+                StandaloneProcessEngineConfiguration.class,
+                (mock, ctx) ->
+                    when(mock.buildProcessEngine())
+                        .thenThrow(new FlowableWrongDbException("7.2.0.2", "7.1.0.0")));
+        MockedStatic<ProcessEngines> ignored = mockStatic(ProcessEngines.class);
+        MockedStatic<Entity> entityMock = mockStatic(Entity.class);
+        MockedStatic<PipelineServiceClientFactory> pscMock =
+            mockStatic(PipelineServiceClientFactory.class)) {
+
+      setupEntityMock(entityMock);
+      pscMock
+          .when(() -> PipelineServiceClientFactory.createPipelineServiceClient(any()))
+          .thenReturn(null);
+
+      assertThrows(
+          IllegalStateException.class, () -> WorkflowHandler.initialize(buildMockConfig(), false));
+
+      StandaloneProcessEngineConfiguration engineConfig = engineMock.constructed().getLast();
+      verify(engineConfig).setJdbcPingEnabled(true);
+      verify(engineConfig).setJdbcPingQuery("SELECT 1");
+      verify(engineConfig).setJdbcPingConnectionNotUsedFor(30000);
+    }
+  }
+
+  @Test
+  void migrationModeDoesNotEnableConnectionPoolPing() {
+    ProcessEngine mockEngine = mock(ProcessEngine.class, RETURNS_DEEP_STUBS);
+
+    try (MockedConstruction<StandaloneProcessEngineConfiguration> engineMock =
+            mockConstruction(
+                StandaloneProcessEngineConfiguration.class,
+                (mock, ctx) -> when(mock.buildProcessEngine()).thenReturn(mockEngine));
+        MockedStatic<ProcessEngines> ignored = mockStatic(ProcessEngines.class);
+        MockedStatic<Entity> entityMock = mockStatic(Entity.class);
+        MockedStatic<PipelineServiceClientFactory> pscMock =
+            mockStatic(PipelineServiceClientFactory.class)) {
+
+      setupEntityMock(entityMock);
+      pscMock
+          .when(() -> PipelineServiceClientFactory.createPipelineServiceClient(any()))
+          .thenReturn(null);
+
+      WorkflowHandler.initialize(buildMockConfig(), true);
+
+      StandaloneProcessEngineConfiguration engineConfig = engineMock.constructed().getLast();
+      verify(engineConfig, never()).setJdbcPingEnabled(anyBoolean());
     }
   }
 


### PR DESCRIPTION
### Describe your changes:

Fixes #28836

The runtime Flowable governance engine builds its **own** MyBatis `PooledDataSource` from raw JDBC settings, bypassing the application's HikariCP pool, and never validates pooled connections. So when the database drops a connection out from under it — an Aurora/RDS failover, a maintenance restart, or an idle-connection reaper, all of which surface as `PSQLException: FATAL: terminating connection due to administrator command` — the async-executor poll threads (`ResetExpiredJobsRunnable`) keep borrowing the dead connection and failing until the pool happens to recycle it. This change enables MyBatis pool ping (`SELECT 1`) on the runtime engine so any connection idle past 30s is validated and transparently replaced before reuse; the migration path uses `setDataSource()` and is unaffected.

#
### Type of change:
- [x] Bug fix

#
### High-level design:

N/A — small change (one resilience setting on the Flowable runtime engine, plus tests).

#
### Tests:

#### Use cases covered
- Runtime governance engine starts with connection-pool ping enabled (`SELECT 1`, validate-if-idle past 30s) so the async executor self-heals after a DB connection is killed by failover/maintenance instead of repeatedly logging errors.
- Migration-mode engine (which uses `setDataSource()`, not the MyBatis pool) does **not** enable ping.

#### Unit tests
- [x] Added unit tests for the changed logic.
- Files: `WorkflowHandlerSchemaUpdateTest.java` — `runtimeModeEnablesConnectionPoolHealthChecks`, `migrationModeDoesNotEnableConnectionPoolPing`. All 6 tests in the class pass.

#### Backend integration tests
- [x] Not applicable (no API/endpoint changes).

#### Ingestion integration tests
- [x] Not applicable (no ingestion changes).

#### Playwright (UI) tests
- [x] Not applicable (no UI changes).

#### Manual testing performed
A real DB failover was not reproducible in this environment; the unit tests verify the runtime engine is configured with pool ping via the existing `mockConstruction`/`verify` harness. The fix uses Flowable's native MyBatis pool-ping mechanism (`setJdbcPingEnabled`/`setJdbcPingQuery`/`setJdbcPingConnectionNotUsedFor`).

#
### UI screen recording / screenshots:

Not applicable.

#
### Checklist:
- [x] I have read the **CONTRIBUTING** document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>` (uses conventional-commit style, matching recent repo history).
- [x] My PR is linked to a GitHub issue via `Fixes #28836` above.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] For JSON Schema changes: not applicable (no schema changes).
- [x] For UI changes: not applicable (no UI changes).
- [x] I have added tests and listed them above.

- [x] I have added a test that covers the exact scenario we are fixing.
