### PR TITLE
fix(ingestion): ingest Iceberg/Delta metadata.json with real table co…

### DIFF
--- a/ingestion/src/metadata/readers/dataframe/json.py
+++ b/ingestion/src/metadata/readers/dataframe/json.py
@@ -121,6 +121,14 @@ class JSONDataFrameReader(DataFrameReader):
             yield DataFrame.from_records(batch)
 
     @staticmethod
+    def _is_iceberg_delta_shape(obj: Any) -> bool:
+        return (
+            isinstance(obj, dict)
+            and isinstance(obj.get("schema"), dict)
+            and isinstance(obj["schema"].get("fields"), list)
+        )
+
+    @staticmethod
     def _read_json_object(
         content: bytes,
     ) -> tuple[Generator["DataFrame", Any, None], Optional[str]]:
@@ -133,7 +141,8 @@ class JSONDataFrameReader(DataFrameReader):
             else content
         )
         data = json.loads(content)
-        raw_data = content if isinstance(data, dict) and data.get("$schema") else None
+        is_json_schema = isinstance(data, dict) and data.get("$schema")
+        raw_data = content if (is_json_schema or JSONDataFrameReader._is_iceberg_delta_shape(data)) else None
         data = [data] if isinstance(data, dict) else data
 
         def chunk_generator():
@@ -153,7 +162,11 @@ class JSONDataFrameReader(DataFrameReader):
             return True
         try:
             obj = json.loads(first_line)
-            return isinstance(obj, dict) and not obj.get("$schema")
+            if not isinstance(obj, dict):
+                return False
+            if obj.get("$schema") or JSONDataFrameReader._is_iceberg_delta_shape(obj):  # noqa: SIM103
+                return False
+            return True  # noqa:TRY300
         except json.JSONDecodeError:
             return False
 

--- a/ingestion/tests/unit/utils/test_datalake.py
+++ b/ingestion/tests/unit/utils/test_datalake.py
@@ -849,6 +849,63 @@ class TestIcebergDeltaLakeMetadataParsing(TestCase):
         # This test ensures we don't break existing JSON Schema parsing
         self.assertIsNotNone(columns)
 
+    def test_read_json_object_propagates_raw_data_for_iceberg(self):
+        from metadata.readers.dataframe.json import JSONDataFrameReader
+
+        content = json.dumps(
+            {
+                "format-version": 1,
+                "schema": {"fields": [{"id": 1, "name": "customer_id", "required": False, "type": "string"}]},
+            }
+        )
+        _gen, raw = JSONDataFrameReader._read_json_object(content.encode("utf-8"))
+        self.assertEqual(raw, content)
+
+    def test_read_json_object_returns_none_for_plain_object(self):
+        from metadata.readers.dataframe.json import JSONDataFrameReader
+
+        content = json.dumps({"a": 1, "b": 2})
+        _gen, raw = JSONDataFrameReader._read_json_object(content.encode("utf-8"))
+        self.assertIsNone(raw)
+
+    def test_read_json_object_propagates_raw_data_for_json_schema(self):
+        from metadata.readers.dataframe.json import JSONDataFrameReader
+
+        content = json.dumps({"$schema": "http://json-schema.org/draft-07/schema#", "type": "object"})
+        _gen, raw = JSONDataFrameReader._read_json_object(content.encode("utf-8"))
+        self.assertEqual(raw, content)
+
+    def test_is_json_lines_returns_false_for_minified_iceberg(self):
+        """Single-line (minified) Iceberg metadata.json must NOT be treated as JSON Lines,
+        otherwise it bypasses _read_json_object and raw_data is never set."""
+        import io
+
+        from metadata.readers.dataframe.json import JSONDataFrameReader
+
+        minified = json.dumps(
+            {
+                "format-version": 1,
+                "schema": {"fields": [{"id": 1, "name": "customer_id", "required": False, "type": "string"}]},
+            }
+        )
+        self.assertFalse(JSONDataFrameReader._is_json_lines(io.BytesIO(minified.encode("utf-8"))))
+
+    def test_is_json_lines_returns_false_for_minified_json_schema(self):
+        import io
+
+        from metadata.readers.dataframe.json import JSONDataFrameReader
+
+        minified = json.dumps({"$schema": "http://json-schema.org/draft-07/schema#", "type": "object"})
+        self.assertFalse(JSONDataFrameReader._is_json_lines(io.BytesIO(minified.encode("utf-8"))))
+
+    def test_is_json_lines_returns_true_for_real_jsonl(self):
+        import io
+
+        from metadata.readers.dataframe.json import JSONDataFrameReader
+
+        jsonl = b'{"a": 1, "b": 2}\n{"a": 3, "b": 4}\n'
+        self.assertTrue(JSONDataFrameReader._is_json_lines(io.BytesIO(jsonl)))
+
 
 class TestFetchColTypesWithParsedObjects:
     """fetch_col_types must correctly type object-dtype columns whose values are already


### PR DESCRIPTION
cherry-picking the commit : https://github.com/open-metadata/OpenMetadata/commit/4a6c5ff5624f0ae2888f64d7f20a94fdb98d1e0e
GH issue: https://github.com/open-metadata/OpenMetadata/issues/28423
ref. PR: https://github.com/open-metadata/OpenMetadata/pull/28422
----
## Summary by Gitar

- **Ingestion logic enhancement:**
  - Added `_is_iceberg_delta_shape` to detect Iceberg/Delta metadata structures in `json.py`.
  - Updated `_read_json_object` to propagate raw data for recognized Iceberg/Delta formats.
  - Modified `_is_json_lines` to prevent Iceberg/Delta metadata from being incorrectly treated as JSON Lines.
- **Testing:**
  - Added unit tests in `test_datalake.py` to verify schema detection, raw data propagation, and JSON Lines identification.


<sub>This will update automatically on new commits.</sub>