### PR TITLE
Fix:Show DAR button based on create permission

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/DataAssets/DataAssetsHeader/DataAssetsHeader.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataAssets/DataAssetsHeader/DataAssetsHeader.component.tsx
@@ -78,7 +78,6 @@ import {
   getEntityFeedLink,
   getEntityName,
   getEntityVoteStatus,
-  hasEditAccess,
 } from '../../../utils/EntityUtils';
 import { getPrioritizedEditPermission } from '../../../utils/PermissionsUtils';
 import { getEntityDetailsPath } from '../../../utils/RouterUtils';
@@ -594,24 +593,12 @@ export const DataAssetsHeader = ({
     permissions.Trigger,
   ]);
 
-  const isOwner = useMemo(
-    () =>
-      Boolean(
-        currentUser &&
-          dataAsset.owners?.length &&
-          hasEditAccess(dataAsset.owners, currentUser)
-      ),
-    [dataAsset.owners, currentUser]
-  );
-
   const requestDataAccessButton = useMemo(() => {
     if (
       !tableClassBase.getShowRequestDataAccess() ||
-      SERVICE_TYPES.includes(entityType) ||
       entityType !== EntityType.TABLE ||
       deleted ||
-      isOwner ||
-      (!canCreateTask && !currentUser?.isAdmin)
+      !canCreateTask
     ) {
       return null;
     }
@@ -637,7 +624,6 @@ export const DataAssetsHeader = ({
   }, [
     entityType,
     deleted,
-    isOwner,
     isDarDisabled,
     isDarAwaitingGrant,
     isDarGranted,

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataAssets/DataAssetsHeader/DataAssetsHeader.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataAssets/DataAssetsHeader/DataAssetsHeader.component.tsx
@@ -628,7 +628,6 @@ export const DataAssetsHeader = ({
     isDarAwaitingGrant,
     isDarGranted,
     canCreateTask,
-    currentUser,
     t,
   ]);
 

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataAssets/DataAssetsHeader/DataAssetsHeader.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataAssets/DataAssetsHeader/DataAssetsHeader.test.tsx
@@ -690,7 +690,7 @@ describe('DataAssetsHeader component', () => {
     expect(button).toBeEnabled();
   });
 
-  it('should not render the request data access button on OSS', () => {
+  it('should not render the request data access button when getShowRequestDataAccess is false', () => {
     render(<DataAssetsHeader {...mockProps} />);
 
     expect(
@@ -740,10 +740,20 @@ describe('DataAssetsHeader component', () => {
       ).not.toBeInTheDocument();
     });
 
-    it('should not render when user is an owner', async () => {
-      const { hasEditAccess } = jest.requireMock('../../../utils/EntityUtils');
-      (hasEditAccess as jest.Mock).mockReturnValue(true);
+    it('should not render on OSS (getShowRequestDataAccess returns false)', () => {
+      const { getShowRequestDataAccess } = jest.requireMock(
+        '../../../utils/TableClassBase'
+      );
+      (getShowRequestDataAccess as jest.Mock).mockReturnValue(false);
 
+      render(<DataAssetsHeader {...tableProps} />);
+
+      expect(
+        screen.queryByTestId('request-data-access-button')
+      ).not.toBeInTheDocument();
+    });
+
+    it('should render for owner with canCreateTask permission', async () => {
       render(
         <DataAssetsHeader
           {...tableProps}
@@ -754,33 +764,21 @@ describe('DataAssetsHeader component', () => {
         />
       );
 
-      expect(
-        screen.queryByTestId('request-data-access-button')
-      ).not.toBeInTheDocument();
-
-      (hasEditAccess as jest.Mock).mockReturnValue(false);
+      await waitFor(() => {
+        expect(
+          screen.getByTestId('request-data-access-button')
+        ).toBeInTheDocument();
+      });
     });
 
-    it('should not render when user belongs to an owner team', async () => {
-      const { useApplicationStore } = jest.requireMock(
-        '../../../hooks/useApplicationStore'
-      );
-      const { hasEditAccess } = jest.requireMock('../../../utils/EntityUtils');
-      (hasEditAccess as jest.Mock).mockReturnValue(true);
-      (useApplicationStore as jest.Mock).mockReturnValue({
-        currentUser: {
-          id: 'user-2',
-          name: 'team.member',
-          teams: [{ id: 'team-1', type: 'team' }],
-        },
-      });
-
+    it('should not render for owner without canCreateTask permission', async () => {
       render(
         <DataAssetsHeader
           {...tableProps}
+          canCreateTask={false}
           dataAsset={{
             ...tableProps.dataAsset,
-            owners: [{ id: 'team-1', type: 'team' }],
+            owners: [{ id: 'user-1', type: 'user' }],
           }}
         />
       );
@@ -788,11 +786,6 @@ describe('DataAssetsHeader component', () => {
       expect(
         screen.queryByTestId('request-data-access-button')
       ).not.toBeInTheDocument();
-
-      (hasEditAccess as jest.Mock).mockReturnValue(false);
-      (useApplicationStore as jest.Mock).mockReturnValue({
-        currentUser: { id: 'user-1', name: 'test.user' },
-      });
     });
 
     it('should render enabled button when no existing DAR task', async () => {
@@ -972,80 +965,15 @@ describe('DataAssetsHeader component', () => {
       ).not.toBeInTheDocument();
     });
 
-    it('should render when user is admin even without canCreateTask permission', async () => {
-      const { useApplicationStore } = jest.requireMock(
-        '../../../hooks/useApplicationStore'
-      );
-
-      (useApplicationStore as jest.Mock).mockReturnValue({
-        currentUser: { id: 'user-1', name: 'test.user', isAdmin: true },
-      });
-
+    it('should not render when admin has no canCreateTask permission', () => {
       render(<DataAssetsHeader {...tableProps} canCreateTask={false} />);
-
-      await waitFor(() => {
-        expect(
-          screen.getByTestId('request-data-access-button')
-        ).toBeInTheDocument();
-      });
-
-      (useApplicationStore as jest.Mock).mockReturnValue({
-        currentUser: { id: 'user-1', name: 'test.user' },
-      });
-    });
-
-    it('should render when user is admin with canCreateTask permission', async () => {
-      const { useApplicationStore } = jest.requireMock(
-        '../../../hooks/useApplicationStore'
-      );
-      (useApplicationStore as jest.Mock).mockReturnValue({
-        currentUser: { id: 'user-1', name: 'test.user', isAdmin: true },
-      });
-
-      render(<DataAssetsHeader {...tableProps} />);
-
-      await waitFor(() => {
-        expect(
-          screen.getByTestId('request-data-access-button')
-        ).toBeInTheDocument();
-      });
-
-      (useApplicationStore as jest.Mock).mockReturnValue({
-        currentUser: { id: 'user-1', name: 'test.user' },
-      });
-    });
-
-    it('should not render when user is admin and is also the owner', async () => {
-      const { useApplicationStore } = jest.requireMock(
-        '../../../hooks/useApplicationStore'
-      );
-      const { hasEditAccess } = jest.requireMock('../../../utils/EntityUtils');
-      (useApplicationStore as jest.Mock).mockReturnValue({
-        currentUser: { id: 'user-1', name: 'test.user', isAdmin: true },
-      });
-      (hasEditAccess as jest.Mock).mockReturnValue(true);
-
-      render(
-        <DataAssetsHeader
-          {...tableProps}
-          dataAsset={{
-            ...tableProps.dataAsset,
-            owners: [{ id: 'user-1', type: 'user' }],
-          }}
-        />
-      );
 
       expect(
         screen.queryByTestId('request-data-access-button')
       ).not.toBeInTheDocument();
-
-      (useApplicationStore as jest.Mock).mockReturnValue({
-        currentUser: { id: 'user-1', name: 'test.user' },
-      });
-      (hasEditAccess as jest.Mock).mockReturnValue(false);
     });
 
-    it('should render for non-admin user with canCreateTask permission who is not owner', async () => {
+    it('should render for non-admin user with canCreateTask permission', async () => {
       render(<DataAssetsHeader {...tableProps} />);
 
       await waitFor(() => {

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataProducts/DataProductsDetailsPage/DataProductsDetailsPage.component.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataProducts/DataProductsDetailsPage/DataProductsDetailsPage.component.test.tsx
@@ -16,7 +16,6 @@ import { usePermissionProvider } from '../../../context/PermissionProvider/Permi
 import { DataProduct } from '../../../generated/entity/domains/dataProduct';
 import { useApplicationStore } from '../../../hooks/useApplicationStore';
 import { useDataAccessRequest } from '../../../hooks/useDataAccessRequest';
-import { hasEditAccess } from '../../../utils/EntityUtils';
 import DataProductsDetailsPage from './DataProductsDetailsPage.component';
 import { DataProductsDetailsPageProps } from './DataProductsDetailsPage.interface';
 
@@ -49,7 +48,6 @@ jest.mock('../../../context/PermissionProvider/PermissionProvider', () => ({
 jest.mock('../../../utils/EntityUtils', () => ({
   getEntityName: jest.fn().mockReturnValue('Test Data Product'),
   getEntityVoteStatus: jest.fn().mockReturnValue('unVoted'),
-  hasEditAccess: jest.fn().mockReturnValue(false),
   getEntityFeedLink: jest.fn().mockReturnValue(''),
 }));
 
@@ -149,7 +147,6 @@ describe('DataProductsDetailsPage — Request Data Access button', () => {
       getEntityPermission: jest.fn().mockResolvedValue({}),
       permissions: { task: { Create: true } },
     });
-    (hasEditAccess as jest.Mock).mockReturnValue(false);
     getDataProductClassBase().getShowRequestDataAccess.mockReturnValue(false);
   });
 
@@ -161,7 +158,7 @@ describe('DataProductsDetailsPage — Request Data Access button', () => {
     ).not.toBeInTheDocument();
   });
 
-  it('renders and is enabled for an admin when the feature flag is on', () => {
+  it('does not render for admin without task-Create permission', () => {
     enableRequestDataAccess();
     (useApplicationStore as unknown as jest.Mock).mockReturnValue({
       currentUser: { id: 'admin-1', name: 'admin', isAdmin: true },
@@ -173,12 +170,24 @@ describe('DataProductsDetailsPage — Request Data Access button', () => {
 
     render(<DataProductsDetailsPage {...defaultProps} />);
 
+    expect(
+      screen.queryByTestId('request-data-access-button')
+    ).not.toBeInTheDocument();
+  });
+
+  it('renders and is enabled for an admin with task-Create permission', () => {
+    enableRequestDataAccess();
+    (useApplicationStore as unknown as jest.Mock).mockReturnValue({
+      currentUser: { id: 'admin-1', name: 'admin', isAdmin: true },
+    });
+
+    render(<DataProductsDetailsPage {...defaultProps} />);
+
     expect(screen.getByTestId('request-data-access-button')).toBeEnabled();
   });
 
-  it('does not render for the entity owner', () => {
+  it('renders for entity owner with task-Create permission', () => {
     enableRequestDataAccess();
-    (hasEditAccess as jest.Mock).mockReturnValue(true);
 
     render(
       <DataProductsDetailsPage
@@ -190,9 +199,7 @@ describe('DataProductsDetailsPage — Request Data Access button', () => {
       />
     );
 
-    expect(
-      screen.queryByTestId('request-data-access-button')
-    ).not.toBeInTheDocument();
+    expect(screen.getByTestId('request-data-access-button')).toBeEnabled();
   });
 
   it('does not render when the user lacks task-Create permission', () => {
@@ -237,7 +244,6 @@ describe('DataProductsDetailsPage — awaiting-grant banner', () => {
       getEntityPermission: jest.fn().mockResolvedValue({}),
       permissions: { task: { Create: true } },
     });
-    (hasEditAccess as jest.Mock).mockReturnValue(false);
     getDataProductClassBase().getShowRequestDataAccess.mockReturnValue(true);
     (useDataAccessRequest as jest.Mock).mockReturnValue({
       isDarDisabled: false,

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataProducts/DataProductsDetailsPage/DataProductsDetailsPage.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataProducts/DataProductsDetailsPage/DataProductsDetailsPage.component.tsx
@@ -383,7 +383,6 @@ const DataProductsDetailsPage = ({
     [dataProduct.votes, currentUser?.id]
   );
 
-
   const handleVoteChange = useCallback(
     async (data: VotingDataProps) => {
       await onUpdateVote?.(data, dataProduct.id);

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataProducts/DataProductsDetailsPage/DataProductsDetailsPage.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataProducts/DataProductsDetailsPage/DataProductsDetailsPage.component.tsx
@@ -91,7 +91,6 @@ import {
   getEntityFeedLink,
   getEntityName,
   getEntityVoteStatus,
-  hasEditAccess,
 } from '../../../utils/EntityUtils';
 import { getEntityVersionByField } from '../../../utils/EntityVersionUtils';
 import { downloadFile } from '../../../utils/Export/ExportUtils';
@@ -384,15 +383,6 @@ const DataProductsDetailsPage = ({
     [dataProduct.votes, currentUser?.id]
   );
 
-  const isOwner = useMemo(
-    () =>
-      Boolean(
-        currentUser &&
-          dataProduct.owners?.length &&
-          hasEditAccess(dataProduct.owners, currentUser)
-      ),
-    [dataProduct.owners, currentUser]
-  );
 
   const handleVoteChange = useCallback(
     async (data: VotingDataProps) => {
@@ -895,8 +885,7 @@ const DataProductsDetailsPage = ({
           <div>
             <div className="tw:flex tw:gap-3 tw:justify-end tw:items-center tw:pb-1">
               {!isVersionsView &&
-                !isOwner &&
-                (canCreateTask || currentUser?.isAdmin) &&
+                canCreateTask &&
                 dataProductClassBase.getShowRequestDataAccess() && (
                   <CoreTooltip
                     isDisabled={!isDarDisabled}


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:

Fixes #28841 

The DAR button should be displayed solely based on whether the user has the Create Request permission.

With permission

https://github.com/user-attachments/assets/2f1ce05c-5418-4739-8333-d786d7b2ec58

Without permission

<img width="1512" height="431" alt="Screenshot 2026-06-09 at 12 30 45 PM" src="https://github.com/user-attachments/assets/bc39bbb1-0527-407a-8d28-9f003b9254ab" />


#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [x] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### High-level design:
<!--
REQUIRED for large PRs (new features, refactors, breaking changes, or anything touching >5 files).
Skip for small bug fixes and trivial changes.

Cover:
- Architecture / approach you took and why
- Key components or files added/changed and how they interact
- Alternatives considered and why you rejected them
- Any migration, backward-compatibility, or rollout concerns
- Diagrams or links to design docs / RFCs if available
-->

N/A — small change. <!-- Or fill in the design above -->

#
### Tests:

#### Use cases covered
<!--
List the user-visible scenarios this PR exercises. Example:
- User with Admin role can create a Glossary Term with a parent term
- Ingestion run for Snowflake correctly extracts row counts for partitioned tables
-->

#### Unit tests
<!--
- [x] I added unit tests for the new/changed logic.
- Files added/updated:
- Coverage on changed classes (run `mvn jacoco:report` for backend, `yarn test:coverage` for UI,
  `make unit_ingestion` for ingestion). Target is 90% line coverage on changed classes.
- Coverage %: <e.g., 92% on EntityRepository.java>
-->

#### Backend integration tests
<!--
- [ ] I added integration tests in `openmetadata-integration-tests/` for new/changed API endpoints.
- [ ] Not applicable (no backend API changes).
- Files added/updated:
-->

#### Ingestion integration tests
<!--
- [ ] I added/updated ingestion integration tests for connector changes.
- [ ] Not applicable (no ingestion changes).
- Files added/updated:
-->

#### Playwright (UI) tests
<!--
- [ ] I added Playwright E2E tests under `openmetadata-ui/.../ui/playwright/` for UI changes.
- [ ] Not applicable (no UI changes).
- Files added/updated:
-->

#### Manual testing performed
<!--
List the manual test steps you performed before requesting review. Example:
1. Started local stack via `./docker/run_local_docker.sh -m ui -d mysql`
2. Logged in as admin, created entity X, verified Y appears in the UI
3. Triggered ingestion for Snowflake source, confirmed lineage edges in the explore page
-->

### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.
- [ ] For UI changes: I attached a screen recording and/or screenshots above.
- [ ] I have added tests (unit / integration / Playwright as applicable) and listed them above.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->
