### PR TITLE
test(ui): de-flake glossary status-badge tests (Draft / In Review race)

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/Glossary/GlossaryWorkflow.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/Glossary/GlossaryWorkflow.spec.ts
@@ -149,7 +149,7 @@ test.describe('Term Status Transitions', () => {
     await expect(statusBadge).toHaveText('Approved');
   });
 
-  test('should start term as Draft when glossary has reviewers', async ({
+  test('should not auto-approve term when glossary has reviewers', async ({
     page,
   }) => {
     await sidebarClick(page, SidebarItem.GLOSSARY);

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/Glossary/GlossaryWorkflow.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/Glossary/GlossaryWorkflow.spec.ts
@@ -175,15 +175,13 @@ test.describe('Term Status Transitions', () => {
 
     // Wait for the table to update
 
-    // Check the term shows in the table with Draft status
     const termRow = page.locator(`[data-row-key*="${termName}"]`);
 
     await expect(termRow).toBeVisible();
 
-    // Look for status badge - should be Draft
     const statusBadge = termRow.locator('.status-badge');
 
-    await expect(statusBadge).toHaveText('Draft');
+    await expect(statusBadge).toHaveText(/^(Draft|In Review)$/);
   });
 
   // T-C18: Create term - inherits glossary reviewers

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/Glossary/GlossaryWorkflow.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/Glossary/GlossaryWorkflow.spec.ts
@@ -330,9 +330,12 @@ test('should display correct status badge color and icon', async ({ page }) => {
 
     const statusBadge = termRow.locator('.status-badge');
 
-    await expect(statusBadge).toHaveText('In Review');
-    await expect(statusBadge).toHaveClass(/inReview/);
+    await expect(async () => {
+      await page.reload();
+      await expect(statusBadge).toHaveText('In Review', { timeout: 5000 });
+    }).toPass({ timeout: 30000 });
 
+    await expect(statusBadge).toHaveClass(/inReview/);
     await expect(statusBadge).toBeVisible();
   } finally {
     await glossary.delete(apiContext);


### PR DESCRIPTION
## Problem

Two tests in `GlossaryWorkflow.spec.ts` flake on the same root cause — the async glossary-term approval workflow:

- `:152` (was `should start term as Draft when glossary has reviewers`) — failed in [PR CI](https://github.com/open-metadata/OpenMetadata/actions/runs/27196639168/job/80292120637) (`Expected "Draft", Received "In Review"`).
- `:291 should display correct status badge color and icon` — hard-failed both retries in [nightly](https://github.com/open-metadata/openmetadata-nightly/actions/runs/27240347074) (`Expected "In Review", Received "Draft"`).

Same mechanism, opposite symptom.

## Root cause

When a term is created in a glossary that has reviewers:

1. The backend persists it as `DRAFT` (`GlossaryTermRepository.java:604-607`).
2. The `GlossaryTermApprovalWorkflow` asynchronously transitions it `DRAFT → IN_REVIEW` (~2s, measured locally).
3. The terms table does **one** list fetch right after create and **never re-fetches**, so the badge is frozen at whatever that single fetch caught.

So whichever side of the ~2s transition the post-create fetch lands on decides the badge:

| Test | Asserts | Fails when the fetch beats / loses the workflow |
|---|---|---|
| Draft test (`:152`) | `Draft` | fetch lands **after** transition → badge already `In Review` |
| `:291` | `In Review` | fetch lands **before** transition → badge still `Draft` (never refreshes) |

Confirmed from the nightly trace (single `GET …directChildrenOf` returning `Draft`, then 15s of DOM polling with zero network) and reproduced locally (`:291` failed 5/5; an API probe showed the term flipping to `In Review` at t+2s while the UI stayed `Draft`).

## Fix

- **Draft test (`:152`)** — assert the race-free invariant: reviewers ⇒ the term is not auto-approved, i.e. it's in the review pipeline. `toHaveText(/^(Draft|In Review)$/)`. The row is already present, so no waiting is needed. Renamed `should start term as Draft when glossary has reviewers` → **`should not auto-approve term when glossary has reviewers`** so the title matches the asserted invariant (mirror of the no-reviewers `should start term as Approved` case).
- **`:291`** — its purpose is to verify the `In Review` badge styling, so it must actually reach `In Review`. Because the table never re-fetches, a longer flat timeout can't work (the DOM never updates) — instead reload until the badge reads `In Review`, then assert color/class:
  ```ts
  await expect(async () => {
    await page.reload();
    await expect(statusBadge).toHaveText('In Review', { timeout: 5000 });
  }).toPass({ timeout: 30000 });
  await expect(statusBadge).toHaveClass(/inReview/);
  ```

Both stay UI-driven (no API status shortcuts in the test body).

## Testing

Against a local stack:
- Draft test — 5/5 pass (was flaky in CI).
- `:291` — **5/5 pass with the fix; 5/5 fail without it** (verified the exact CI/nightly error reproduces locally first).
- Full `GlossaryWorkflow.spec.ts` — all 10 tests pass.

> Note: this is a pre-existing flake on `main` (surfaced via unrelated PR #28827 and the nightly run), fixed on its own branch so it's independently mergeable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)