### PR TITLE
Backport today's MCP/search/audit fixes to 1.13

### DIFF
--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/mcp/McpToolsValidationIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/mcp/McpToolsValidationIT.java
@@ -4,12 +4,14 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import java.time.Duration;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
+import org.awaitility.Awaitility;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Order;
@@ -38,6 +40,7 @@ public class McpToolsValidationIT extends McpTestBase {
   private static Table testTable;
   private static DatabaseSchema testSchema;
   private static String testGlossaryName;
+  private static String createdTestCaseName;
 
   @BeforeAll
   static void setUp() throws Exception {
@@ -281,7 +284,8 @@ public class McpToolsValidationIT extends McpTestBase {
   @Test
   @Order(12)
   void testCreateTestCase() throws Exception {
-    String testCaseName = "mcp_test_case_" + System.currentTimeMillis();
+    createdTestCaseName = "mcp_test_case_" + System.currentTimeMillis();
+    String testCaseName = createdTestCaseName;
     List<Map<String, String>> parameterValues =
         List.of(
             Map.of("name", "minValue", "value", "0"), Map.of("name", "maxValue", "value", "100"));
@@ -428,6 +432,75 @@ public class McpToolsValidationIT extends McpTestBase {
         McpTestUtils.createSearchMetadataToolCall(deletionTestTableName, 5, Entity.TABLE);
     JsonNode defaultResult = executeToolCall(searchDefault);
     validateNoDeletedEntities(defaultResult);
+  }
+
+  @Test
+  @Order(19)
+  void testSearchTestCasesByEntityType() throws Exception {
+    assertThat(createdTestCaseName).isNotNull();
+
+    Awaitility.await()
+        .atMost(Duration.ofSeconds(30))
+        .pollInterval(Duration.ofSeconds(2))
+        .untilAsserted(
+            () -> {
+              Map<String, Object> toolCall =
+                  McpTestUtils.createSearchMetadataToolCall(
+                      createdTestCaseName, 10, Entity.TEST_CASE);
+              JsonNode result = executeToolCall(toolCall);
+              JsonNode response =
+                  OBJECT_MAPPER.readTree(result.get("content").get(0).get("text").asText());
+
+              JsonNode match = findResultByName(response, createdTestCaseName);
+              assertThat(match)
+                  .withFailMessage(
+                      "Expected test case '%s' in search results: %s",
+                      createdTestCaseName, response.get("results"))
+                  .isNotNull();
+              assertThat(match.get("entityType").asText()).isEqualTo(Entity.TEST_CASE);
+              assertThat(match.has("entityFQN"))
+                  .withFailMessage("Test case search result must include 'entityFQN'")
+                  .isTrue();
+              assertThat(match.get("entityFQN").asText())
+                  .isEqualTo(testTable.getFullyQualifiedName());
+            });
+  }
+
+  @Test
+  @Order(20)
+  void testSearchTestSuitesByEntityType() throws Exception {
+    Awaitility.await()
+        .atMost(Duration.ofSeconds(30))
+        .pollInterval(Duration.ofSeconds(2))
+        .untilAsserted(
+            () -> {
+              Map<String, Object> toolCall =
+                  McpTestUtils.createSearchMetadataToolCall("mcp_val_table", 10, Entity.TEST_SUITE);
+              JsonNode result = executeToolCall(toolCall);
+              JsonNode response =
+                  OBJECT_MAPPER.readTree(result.get("content").get(0).get("text").asText());
+
+              boolean hasSuite = false;
+              for (JsonNode r : response.get("results")) {
+                if (Entity.TEST_SUITE.equals(r.get("entityType").asText())) {
+                  hasSuite = true;
+                }
+              }
+              assertThat(hasSuite)
+                  .withFailMessage(
+                      "Expected at least one testSuite in search results: %s",
+                      response.get("results"))
+                  .isTrue();
+            });
+  }
+
+  private JsonNode findResultByName(JsonNode response, String name) {
+    for (JsonNode r : response.get("results")) {
+      if (name.equals(r.get("name").asText())) {
+        return r;
+      }
+    }
+    return null;
   }
 
   private Map<String, Object> createSearchToolCallWithDeletedParam(

--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/mcp/McpToolsValidationIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/mcp/McpToolsValidationIT.java
@@ -577,15 +577,11 @@ public class McpToolsValidationIT extends McpTestBase {
     String responseText = firstResult.get("text").asText();
 
     JsonNode lineageData = OBJECT_MAPPER.readTree(responseText);
-    assertThat(lineageData.has("entity")).isTrue();
+    assertThat(lineageData.has("root")).isTrue();
+    assertThat(lineageData.get("root").asText()).isEqualTo(expectedEntityFqn);
 
-    JsonNode entity = lineageData.get("entity");
-    assertThat(entity.has("fullyQualifiedName")).isTrue();
-    assertThat(entity.get("fullyQualifiedName").asText()).isEqualTo(expectedEntityFqn);
-
-    assertThat(lineageData.has("nodes")).isTrue();
-    assertThat(lineageData.has("upstreamEdges")).isTrue();
-    assertThat(lineageData.has("downstreamEdges")).isTrue();
+    assertThat(lineageData.has("upstream")).isTrue();
+    assertThat(lineageData.has("downstream")).isTrue();
   }
 
   private void validateDeletedFieldPresence(JsonNode result, boolean expectedDeleted)

--- a/openmetadata-mcp/server.json
+++ b/openmetadata-mcp/server.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.open-metadata/openmetadata-mcp",
+  "title": "OpenMetadata",
+  "description": "Official OpenMetadata MCP: governed context and business semantics for AI assistants and agents.",
+  "version": "1.1.0",
+  "repository": {
+    "url": "https://github.com/open-metadata/OpenMetadata",
+    "source": "github",
+    "subfolder": "openmetadata-mcp"
+  },
+  "websiteUrl": "https://docs.open-metadata.org/how-to-guides/mcp",
+  "remotes": [
+    {
+      "type": "streamable-http",
+      "url": "https://{openmetadata_host}/mcp",
+      "variables": {
+        "openmetadata_host": {
+          "description": "Hostname of your OpenMetadata deployment, including port if non-standard. Examples: 'metadata.example.com' (behind a reverse proxy on 443) or 'metadata.example.com:8585' (direct, default OpenMetadata port). The MCP endpoint is mounted at /mcp and authenticates via OAuth 2.0 with PKCE through your existing OpenMetadata SSO provider or Basic Auth.",
+          "isRequired": true
+        }
+      }
+    }
+  ]
+}

--- a/openmetadata-mcp/src/main/java/org/openmetadata/mcp/AuthEnrichedMcpContextExtractor.java
+++ b/openmetadata-mcp/src/main/java/org/openmetadata/mcp/AuthEnrichedMcpContextExtractor.java
@@ -3,16 +3,129 @@ package org.openmetadata.mcp;
 import io.modelcontextprotocol.common.McpTransportContext;
 import io.modelcontextprotocol.server.McpTransportContextExtractor;
 import jakarta.servlet.http.HttpServletRequest;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
 import java.util.Map;
+import java.util.function.Predicate;
 import org.openmetadata.service.security.JwtFilter;
 
 public class AuthEnrichedMcpContextExtractor
     implements McpTransportContextExtractor<HttpServletRequest> {
   public static final String AUTHORIZATION_HEADER = "Authorization";
 
+  /**
+   * Context key carrying the resolved client name (Claude Desktop / Cursor / VS Code / etc.)
+   * derived from the User-Agent header. Stamped on every {@link
+   * org.openmetadata.schema.entity.app.mcp.McpToolCallUsage} row so the Billing > MCP page can
+   * group by client. Kept as a constant on this class so producer + consumer share the spelling.
+   */
+  public static final String CLIENT_NAME = "Mcp-Client-Name";
+
+  private static final String USER_AGENT_HEADER = "User-Agent";
+
+  /**
+   * Upper bound on the persisted client name. The value comes from a user-controlled
+   * {@code User-Agent} header, so we cap it to prevent oversized strings or junk characters from
+   * leaking into the {@code McpToolCallUsage} rows. Mirrors {@code maxLength} on the
+   * {@code clientName} property in {@code mcpToolCallUsage.json}.
+   */
+  static final int MAX_CLIENT_NAME_LENGTH = 64;
+
+  /**
+   * Ordered list of (predicate, label) pairs used to classify a lower-cased User-Agent into a
+   * human-readable client name. Order matters — VS Code is checked before Claude CLI so a UA
+   * containing both {@code claude} and {@code code} substrings (e.g. a Claude extension hosted in
+   * VS Code) is attributed to the host process rather than the standalone CLI.
+   */
+  private static final List<UaMatcher> UA_MATCHERS =
+      List.of(
+          new UaMatcher(ua -> ua.contains("claude") && ua.contains("desktop"), "Claude Desktop"),
+          new UaMatcher(
+              ua ->
+                  ua.contains("vscode")
+                      || ua.contains("vs code")
+                      || ua.contains("visual studio code"),
+              "VS Code"),
+          new UaMatcher(
+              ua ->
+                  ua.contains("claude-cli")
+                      || ua.contains("claude-code")
+                      || ua.contains("claude cli")
+                      || ua.contains("claude code"),
+              "Claude CLI"),
+          new UaMatcher(ua -> ua.contains("cursor"), "Cursor"),
+          new UaMatcher(ua -> ua.contains("zed"), "Zed"),
+          new UaMatcher(ua -> ua.contains("windsurf"), "Windsurf"));
+
+  /** Pairing of a User-Agent substring predicate with the label shown in the dashboard. */
+  private record UaMatcher(Predicate<String> matches, String label) {}
+
   @Override
   public McpTransportContext extract(HttpServletRequest request) {
     String token = JwtFilter.extractToken(request.getHeader(AUTHORIZATION_HEADER));
-    return McpTransportContext.create(Map.of(AUTHORIZATION_HEADER, token != null ? token : ""));
+    String clientName = resolveClientName(request.getHeader(USER_AGENT_HEADER));
+    Map<String, Object> values = new HashMap<>();
+    values.put(AUTHORIZATION_HEADER, token != null ? token : "");
+    if (clientName != null) {
+      values.put(CLIENT_NAME, clientName);
+    }
+    return McpTransportContext.create(values);
+  }
+
+  /**
+   * Heuristic: classify the {@code User-Agent} into the labels the dashboard uses (Claude Desktop,
+   * Cursor, VS Code, Claude CLI, etc.). MCP clients all set distinctive UAs — the table at
+   * {@link #UA_MATCHERS} covers the common ones explicitly and we fall back to the raw product
+   * token so a new client still surfaces in the breakdown without a code change. The fallback
+   * value (and every label) is sanitised before return so the persisted value is bounded.
+   */
+  static String resolveClientName(String userAgent) {
+    String resolved = null;
+    if (userAgent != null && !userAgent.isBlank()) {
+      String ua = userAgent.toLowerCase(Locale.ROOT);
+      resolved =
+          UA_MATCHERS.stream()
+              .filter(matcher -> matcher.matches().test(ua))
+              .map(UaMatcher::label)
+              .findFirst()
+              .orElseGet(() -> fallbackProductToken(userAgent));
+    }
+    return sanitize(resolved);
+  }
+
+  /**
+   * First product token of the User-Agent (the bit before the first slash or space), capitalised.
+   * Avoids leaking version strings into the dashboard while still surfacing unknown clients with a
+   * human-readable label. Returns {@code null} when no usable token is present.
+   */
+  private static String fallbackProductToken(String userAgent) {
+    String head = userAgent.split("[\\s/]", 2)[0];
+    String result = null;
+    if (!head.isBlank()) {
+      result = head.substring(0, 1).toUpperCase(Locale.ROOT) + head.substring(1);
+    }
+    return result;
+  }
+
+  /**
+   * Trims whitespace, strips ISO control characters, and caps the value to
+   * {@link #MAX_CLIENT_NAME_LENGTH} characters. The User-Agent header is attacker-controlled so
+   * the persisted value must be sanitised before it reaches the database or the dashboard.
+   */
+  private static String sanitize(String value) {
+    String result = null;
+    if (value != null) {
+      StringBuilder sb = new StringBuilder(value.length());
+      value.codePoints().filter(cp -> !Character.isISOControl(cp)).forEach(sb::appendCodePoint);
+      String stripped = sb.toString().trim();
+      if (!stripped.isEmpty()) {
+        result =
+            stripped.length() > MAX_CLIENT_NAME_LENGTH
+                ? stripped.substring(0, MAX_CLIENT_NAME_LENGTH)
+                : stripped;
+      }
+    }
+    return result;
   }
 }

--- a/openmetadata-mcp/src/main/java/org/openmetadata/mcp/McpServer.java
+++ b/openmetadata-mcp/src/main/java/org/openmetadata/mcp/McpServer.java
@@ -250,14 +250,23 @@ public class McpServer implements McpServerProvider {
           CatalogSecurityContext securityContext =
               jwtFilter.getCatalogSecurityContext((String) context.get("Authorization"));
           String userName = securityContext.getUserPrincipal().getName();
-          McpSchema.CallToolResult result = null;
+          String clientName =
+              (String)
+                  context.get(org.openmetadata.mcp.AuthEnrichedMcpContextExtractor.CLIENT_NAME);
+          org.openmetadata.mcp.tools.DefaultToolContext.CallToolOutcome outcome = null;
           try {
             ImpersonationContext.setImpersonatedBy(getMcpBotName());
-            result = toolContext.callTool(authorizer, limits, tool.name(), securityContext, req);
-            return result;
+            outcome =
+                toolContext.callToolWithMetadata(
+                    authorizer, limits, tool.name(), securityContext, req);
+            return outcome.result();
           } finally {
-            boolean success = result != null && !Boolean.TRUE.equals(result.isError());
-            McpUsageRecorder.record(tool.name(), userName, success);
+            boolean success = outcome != null && !Boolean.TRUE.equals(outcome.result().isError());
+            Long latencyMs = outcome != null ? outcome.latencyMs() : null;
+            org.openmetadata.schema.entity.app.mcp.McpToolCallUsage.ErrorCategory category =
+                outcome != null ? outcome.errorCategory() : null;
+            McpUsageRecorder.record(
+                tool.name(), userName, success, latencyMs, category, clientName);
             ImpersonationContext.clear();
           }
         });

--- a/openmetadata-mcp/src/main/java/org/openmetadata/mcp/tools/CreateMetricTool.java
+++ b/openmetadata-mcp/src/main/java/org/openmetadata/mcp/tools/CreateMetricTool.java
@@ -187,6 +187,6 @@ public class CreateMetricTool implements McpTool {
     RestUtil.PutResponse<Metric> response =
         repo.createOrUpdate(null, metric, userName, impersonatedBy);
     McpChangeEventUtil.publishChangeEvent(response.getEntity(), response.getChangeType(), userName);
-    return JsonUtils.getMap(response.getEntity());
+    return McpResponseUtils.compact(response.getEntity(), response.getChangeType());
   }
 }

--- a/openmetadata-mcp/src/main/java/org/openmetadata/mcp/tools/CreateTestCaseTool.java
+++ b/openmetadata-mcp/src/main/java/org/openmetadata/mcp/tools/CreateTestCaseTool.java
@@ -120,6 +120,6 @@ public class CreateTestCaseTool implements McpTool {
         repository.createOrUpdate(null, testCase, updatedBy, impersonatedBy);
     McpChangeEventUtil.publishChangeEvent(
         response.getEntity(), response.getChangeType(), updatedBy);
-    return JsonUtils.getMap(response.getEntity());
+    return McpResponseUtils.compact(response.getEntity(), response.getChangeType());
   }
 }

--- a/openmetadata-mcp/src/main/java/org/openmetadata/mcp/tools/DefaultToolContext.java
+++ b/openmetadata-mcp/src/main/java/org/openmetadata/mcp/tools/DefaultToolContext.java
@@ -4,8 +4,11 @@ import static org.openmetadata.mcp.McpUtils.getToolProperties;
 
 import io.modelcontextprotocol.spec.McpSchema;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
+import java.util.function.Predicate;
 import lombok.extern.slf4j.Slf4j;
+import org.openmetadata.schema.entity.app.mcp.McpToolCallUsage;
 import org.openmetadata.schema.utils.JsonUtils;
 import org.openmetadata.service.limits.Limits;
 import org.openmetadata.service.security.AuthorizationException;
@@ -32,6 +35,22 @@ public class DefaultToolContext {
       String toolName,
       CatalogSecurityContext securityContext,
       McpSchema.CallToolRequest request) {
+    return callToolWithMetadata(authorizer, limits, toolName, securityContext, request).result();
+  }
+
+  /**
+   * Phase 3 entry point. Returns the tool result alongside the metadata the {@link
+   * org.openmetadata.mcp.usage.McpUsageRecorder} needs (latency + error category). Kept as a
+   * separate method so the legacy single-result signature stays available for external callers
+   * that haven't migrated yet.
+   */
+  public CallToolOutcome callToolWithMetadata(
+      Authorizer authorizer,
+      Limits limits,
+      String toolName,
+      CatalogSecurityContext securityContext,
+      McpSchema.CallToolRequest request) {
+    long startNanos = System.nanoTime();
     LOG.info(
         "Catalog Principal: {} is trying to call the tool: {}",
         securityContext.getUserPrincipal().getName(),
@@ -97,47 +116,159 @@ public class DefaultToolContext {
           result = new CreateDataProductTool().execute(authorizer, limits, securityContext, params);
           break;
         default:
-          return McpSchema.CallToolResult.builder()
+          return new CallToolOutcome(
+              McpSchema.CallToolResult.builder()
+                  .content(
+                      List.of(
+                          new McpSchema.TextContent(
+                              JsonUtils.pojoToJson(
+                                  Map.of("error", "Unknown function: " + toolName)))))
+                  .isError(true)
+                  .build(),
+              elapsedMs(startNanos),
+              McpToolCallUsage.ErrorCategory.VALIDATION);
+      }
+
+      return new CallToolOutcome(
+          McpSchema.CallToolResult.builder()
+              .content(List.of(new McpSchema.TextContent(JsonUtils.pojoToJson(result))))
+              .isError(false)
+              .build(),
+          elapsedMs(startNanos),
+          null);
+    } catch (AuthorizationException ex) {
+      LOG.warn("Authorization error: {}", ex.getMessage());
+      return new CallToolOutcome(
+          McpSchema.CallToolResult.builder()
               .content(
                   List.of(
                       new McpSchema.TextContent(
-                          JsonUtils.pojoToJson(Map.of("error", "Unknown function: " + toolName)))))
+                          JsonUtils.pojoToJson(
+                              Map.of(
+                                  "error",
+                                  String.format("Authorization error: %s", ex.getMessage()),
+                                  "statusCode",
+                                  403)))))
               .isError(true)
-              .build();
-      }
-
-      return McpSchema.CallToolResult.builder()
-          .content(List.of(new McpSchema.TextContent(JsonUtils.pojoToJson(result))))
-          .isError(false)
-          .build();
-    } catch (AuthorizationException ex) {
-      LOG.warn("Authorization error: {}", ex.getMessage());
-      return McpSchema.CallToolResult.builder()
-          .content(
-              List.of(
-                  new McpSchema.TextContent(
-                      JsonUtils.pojoToJson(
-                          Map.of(
-                              "error",
-                              String.format("Authorization error: %s", ex.getMessage()),
-                              "statusCode",
-                              403)))))
-          .isError(true)
-          .build();
+              .build(),
+          elapsedMs(startNanos),
+          McpToolCallUsage.ErrorCategory.AUTH);
     } catch (Exception ex) {
       LOG.error("Error executing tool '{}': {}", toolName, ex.getMessage(), ex);
-      return McpSchema.CallToolResult.builder()
-          .content(
-              List.of(
-                  new McpSchema.TextContent(
-                      JsonUtils.pojoToJson(
-                          Map.of(
-                              "error",
-                              String.format("Error executing tool: %s", ex.getMessage()),
-                              "statusCode",
-                              500)))))
-          .isError(true)
-          .build();
+      return new CallToolOutcome(
+          McpSchema.CallToolResult.builder()
+              .content(
+                  List.of(
+                      new McpSchema.TextContent(
+                          JsonUtils.pojoToJson(
+                              Map.of(
+                                  "error",
+                                  String.format("Error executing tool: %s", ex.getMessage()),
+                                  "statusCode",
+                                  500)))))
+              .isError(true)
+              .build(),
+          elapsedMs(startNanos),
+          classifyException(ex));
     }
   }
+
+  /**
+   * Maps an arbitrary exception type to one of the {@link McpToolCallUsage.ErrorCategory} values.
+   * Walks the cause chain because the tool wrappers usually rethrow framework errors wrapped in
+   * a {@link RuntimeException}. Defaults to {@link McpToolCallUsage.ErrorCategory#INTERNAL} when
+   * no specific bucket matches.
+   */
+  static McpToolCallUsage.ErrorCategory classifyException(Throwable t) {
+    McpToolCallUsage.ErrorCategory result = McpToolCallUsage.ErrorCategory.INTERNAL;
+    Throwable cursor = t;
+    while (cursor != null && result == McpToolCallUsage.ErrorCategory.INTERNAL) {
+      McpToolCallUsage.ErrorCategory match = matchCategory(cursor);
+      if (match != null) {
+        result = match;
+      } else {
+        Throwable next = cursor.getCause();
+        cursor = (next == null || next == cursor) ? null : next;
+      }
+    }
+    return result;
+  }
+
+  /**
+   * Pairing of an exception (name, message) predicate with the bucket it should produce. Kept
+   * as a static table so adding a new category (or extending an existing one with a new keyword)
+   * is a one-line change rather than another {@code else if} branch.
+   */
+  private record CategoryMatcher(
+      Predicate<ExceptionMeta> matches, McpToolCallUsage.ErrorCategory category) {}
+
+  /** Lower-cased name + message pair so each matcher inspects both without re-parsing. */
+  private record ExceptionMeta(String name, String message) {}
+
+  /**
+   * Ordered category table. Check order matters: more specific patterns sit before broader ones so
+   * a {@code RateLimitException} doesn't get caught by the generic message-substring rules below
+   * it. {@code AUTH} sits above {@code VALIDATION} because some auth exceptions ({@code
+   * AuthorizationException}) extend {@code IllegalArgumentException}-style hierarchies and would
+   * otherwise be mis-bucketed.
+   */
+  private static final List<CategoryMatcher> CATEGORY_MATCHERS =
+      List.of(
+          new CategoryMatcher(
+              meta -> meta.name().contains("RateLimit") || meta.message().contains("rate limit"),
+              McpToolCallUsage.ErrorCategory.RATE_LIMIT),
+          new CategoryMatcher(
+              meta ->
+                  meta.name().contains("Authorization")
+                      || meta.name().contains("Forbidden")
+                      || meta.name().contains("Unauthorized")
+                      || meta.message().contains("forbidden")
+                      || meta.message().contains("unauthorized")
+                      || meta.message().contains("access denied")
+                      || meta.message().contains("permission denied"),
+              McpToolCallUsage.ErrorCategory.AUTH),
+          new CategoryMatcher(
+              meta ->
+                  meta.name().contains("Validation")
+                      || meta.name().contains("IllegalArgument")
+                      || meta.name().contains("BadRequest")
+                      || meta.message().contains("invalid argument"),
+              McpToolCallUsage.ErrorCategory.VALIDATION),
+          new CategoryMatcher(
+              meta ->
+                  meta.name().contains("Timeout")
+                      || meta.message().contains("timeout")
+                      || meta.message().contains("timed out"),
+              McpToolCallUsage.ErrorCategory.TIMEOUT));
+
+  /**
+   * Returns the category that matches the supplied throwable's name or message, or {@code null}
+   * when no specific bucket applies. Kept separate from {@link #classifyException} so the
+   * cause-chain walk reads as a single linear loop.
+   */
+  private static McpToolCallUsage.ErrorCategory matchCategory(Throwable cursor) {
+    ExceptionMeta meta =
+        new ExceptionMeta(
+            cursor.getClass().getSimpleName(),
+            cursor.getMessage() == null ? "" : cursor.getMessage().toLowerCase(Locale.ROOT));
+    return CATEGORY_MATCHERS.stream()
+        .filter(matcher -> matcher.matches().test(meta))
+        .map(CategoryMatcher::category)
+        .findFirst()
+        .orElse(null);
+  }
+
+  private static long elapsedMs(long startNanos) {
+    return (System.nanoTime() - startNanos) / 1_000_000L;
+  }
+
+  /**
+   * Phase 3 — tuple returned by {@link #callToolWithMetadata} so the MCP server can record the
+   * call with full diagnostic detail without re-classifying the exception or re-measuring the
+   * latency at its level.
+   */
+  public record CallToolOutcome(
+      McpSchema.CallToolResult result,
+      long latencyMs,
+      McpToolCallUsage.ErrorCategory errorCategory) {}
 }

--- a/openmetadata-mcp/src/main/java/org/openmetadata/mcp/tools/DefaultToolContext.java
+++ b/openmetadata-mcp/src/main/java/org/openmetadata/mcp/tools/DefaultToolContext.java
@@ -11,6 +11,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.function.Predicate;
 import lombok.extern.slf4j.Slf4j;
+import org.openmetadata.mcp.util.McpResponseTrim;
 import org.openmetadata.schema.entity.app.mcp.McpToolCallUsage;
 import org.openmetadata.schema.utils.JsonUtils;
 import org.openmetadata.service.limits.Limits;
@@ -26,6 +27,9 @@ public class DefaultToolContext {
   private static final int STATUS_TOO_MANY_REQUESTS = 429;
   private static final int STATUS_INTERNAL_ERROR = 500;
   private static final int STATUS_GATEWAY_TIMEOUT = 504;
+  private static final String OVERSIZED_ADVICE =
+      "Response exceeded the size limit and was withheld. Narrow your request — use a more specific "
+          + "query, request fewer results, or fetch a single entity by its fullyQualifiedName.";
 
   public DefaultToolContext() {}
 
@@ -145,7 +149,7 @@ public class DefaultToolContext {
 
       return new CallToolOutcome(
           McpSchema.CallToolResult.builder()
-              .content(List.of(new McpSchema.TextContent(JsonUtils.pojoToJson(result))))
+              .content(List.of(new McpSchema.TextContent(serializeWithinBudget(result, toolName))))
               .isError(false)
               .build(),
           elapsedMs(startNanos),
@@ -160,7 +164,8 @@ public class DefaultToolContext {
                           JsonUtils.pojoToJson(
                               Map.of(
                                   "error",
-                                  String.format("Authorization error: %s", ex.getMessage()),
+                                  String.format(
+                                      "Authorization error: %s", McpResponseTrim.safeMessage(ex)),
                                   "statusCode",
                                   STATUS_FORBIDDEN)))))
               .isError(true)
@@ -177,7 +182,8 @@ public class DefaultToolContext {
                           JsonUtils.pojoToJson(
                               Map.of(
                                   "error",
-                                  String.format("Error executing tool: %s", ex.getMessage()),
+                                  String.format(
+                                      "Error executing tool: %s", McpResponseTrim.safeMessage(ex)),
                                   "statusCode",
                                   resolveStatusCode(ex))))))
               .isError(true)
@@ -298,6 +304,32 @@ public class DefaultToolContext {
 
   private static long elapsedMs(long startNanos) {
     return (System.nanoTime() - startNanos) / 1_000_000L;
+  }
+
+  /**
+   * Serializes a tool result once and, only when it exceeds {@link
+   * McpResponseTrim#MAX_RESPONSE_CHARS}, replaces it with a generic {@code truncated:true} envelope.
+   * This is the dispatch-level floor that bounds tools without their own per-tool trim ({@code
+   * get_entity_details}, {@code get_test_definitions}) and backstops the rest. The happy path
+   * serializes exactly once; the re-serialization runs only on the rare oversized path.
+   *
+   * <p>Public so the Collate dispatcher ({@code CollateToolContext}), which builds its own success
+   * result for Collate-only tools, applies the same floor instead of re-implementing it.
+   */
+  public static String serializeWithinBudget(Object result, String toolName) {
+    String serialized = JsonUtils.pojoToJson(result);
+    if (serialized.length() > McpResponseTrim.MAX_RESPONSE_CHARS) {
+      LOG.warn(
+          "[MCP] tool '{}' response {} chars exceeds {} budget; returning truncation envelope",
+          toolName,
+          serialized.length(),
+          McpResponseTrim.MAX_RESPONSE_CHARS);
+      Map<String, Object> capped =
+          McpResponseTrim.oversizedEnvelope(
+              serialized.length(), Map.of("tool", toolName), OVERSIZED_ADVICE);
+      serialized = JsonUtils.pojoToJson(capped);
+    }
+    return serialized;
   }
 
   /**

--- a/openmetadata-mcp/src/main/java/org/openmetadata/mcp/tools/DefaultToolContext.java
+++ b/openmetadata-mcp/src/main/java/org/openmetadata/mcp/tools/DefaultToolContext.java
@@ -3,9 +3,12 @@ package org.openmetadata.mcp.tools;
 import static org.openmetadata.mcp.McpUtils.getToolProperties;
 
 import io.modelcontextprotocol.spec.McpSchema;
+import java.util.Collections;
+import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.Predicate;
 import lombok.extern.slf4j.Slf4j;
 import org.openmetadata.schema.entity.app.mcp.McpToolCallUsage;
@@ -17,6 +20,13 @@ import org.openmetadata.service.security.auth.CatalogSecurityContext;
 
 @Slf4j
 public class DefaultToolContext {
+  private static final int STATUS_BAD_REQUEST = 400;
+  private static final int STATUS_FORBIDDEN = 403;
+  private static final int STATUS_NOT_FOUND = 404;
+  private static final int STATUS_TOO_MANY_REQUESTS = 429;
+  private static final int STATUS_INTERNAL_ERROR = 500;
+  private static final int STATUS_GATEWAY_TIMEOUT = 504;
+
   public DefaultToolContext() {}
 
   /**
@@ -122,7 +132,11 @@ public class DefaultToolContext {
                       List.of(
                           new McpSchema.TextContent(
                               JsonUtils.pojoToJson(
-                                  Map.of("error", "Unknown function: " + toolName)))))
+                                  Map.of(
+                                      "error",
+                                      "Unknown function: " + toolName,
+                                      "statusCode",
+                                      STATUS_BAD_REQUEST)))))
                   .isError(true)
                   .build(),
               elapsedMs(startNanos),
@@ -148,7 +162,7 @@ public class DefaultToolContext {
                                   "error",
                                   String.format("Authorization error: %s", ex.getMessage()),
                                   "statusCode",
-                                  403)))))
+                                  STATUS_FORBIDDEN)))))
               .isError(true)
               .build(),
           elapsedMs(startNanos),
@@ -165,7 +179,7 @@ public class DefaultToolContext {
                                   "error",
                                   String.format("Error executing tool: %s", ex.getMessage()),
                                   "statusCode",
-                                  500)))))
+                                  resolveStatusCode(ex))))))
               .isError(true)
               .build(),
           elapsedMs(startNanos),
@@ -179,28 +193,42 @@ public class DefaultToolContext {
    * a {@link RuntimeException}. Defaults to {@link McpToolCallUsage.ErrorCategory#INTERNAL} when
    * no specific bucket matches.
    */
-  static McpToolCallUsage.ErrorCategory classifyException(Throwable t) {
-    McpToolCallUsage.ErrorCategory result = McpToolCallUsage.ErrorCategory.INTERNAL;
+  protected static McpToolCallUsage.ErrorCategory classifyException(Throwable t) {
+    CategoryMatcher matched = matchException(t);
+    return matched != null ? matched.category() : McpToolCallUsage.ErrorCategory.INTERNAL;
+  }
+
+  /**
+   * Resolves the HTTP-style status code returned to the client for a failed tool call. Kept
+   * separate from {@link #classifyException} (which buckets for telemetry) because the wire status
+   * is a distinct concern: a missing entity is a 404 and a bad argument is a 400, even though both
+   * bucket as {@code VALIDATION}. Defaults to 500 when no specific matcher applies.
+   */
+  protected static int resolveStatusCode(Throwable t) {
+    CategoryMatcher matched = matchException(t);
+    return matched != null ? matched.statusCode() : STATUS_INTERNAL_ERROR;
+  }
+
+  private static CategoryMatcher matchException(Throwable t) {
+    CategoryMatcher result = null;
+    // Identity-based visited set bounds the walk: a malformed cause cycle (A.cause=B, B.cause=A)
+    // would otherwise spin forever. seen.add returns false on a revisit, ending the loop.
+    Set<Throwable> seen = Collections.newSetFromMap(new IdentityHashMap<>());
     Throwable cursor = t;
-    while (cursor != null && result == McpToolCallUsage.ErrorCategory.INTERNAL) {
-      McpToolCallUsage.ErrorCategory match = matchCategory(cursor);
-      if (match != null) {
-        result = match;
-      } else {
-        Throwable next = cursor.getCause();
-        cursor = (next == null || next == cursor) ? null : next;
-      }
+    while (cursor != null && result == null && seen.add(cursor)) {
+      result = matchSingle(cursor);
+      cursor = cursor.getCause();
     }
     return result;
   }
 
   /**
-   * Pairing of an exception (name, message) predicate with the bucket it should produce. Kept
-   * as a static table so adding a new category (or extending an existing one with a new keyword)
-   * is a one-line change rather than another {@code else if} branch.
+   * Pairing of an exception (name, message) predicate with the telemetry bucket and HTTP status it
+   * should produce. Kept as a static table so adding a new category (or extending an existing one
+   * with a new keyword) is a one-line change rather than another {@code else if} branch.
    */
   private record CategoryMatcher(
-      Predicate<ExceptionMeta> matches, McpToolCallUsage.ErrorCategory category) {}
+      Predicate<ExceptionMeta> matches, McpToolCallUsage.ErrorCategory category, int statusCode) {}
 
   /** Lower-cased name + message pair so each matcher inspects both without re-parsing. */
   private record ExceptionMeta(String name, String message) {}
@@ -216,7 +244,8 @@ public class DefaultToolContext {
       List.of(
           new CategoryMatcher(
               meta -> meta.name().contains("RateLimit") || meta.message().contains("rate limit"),
-              McpToolCallUsage.ErrorCategory.RATE_LIMIT),
+              McpToolCallUsage.ErrorCategory.RATE_LIMIT,
+              STATUS_TOO_MANY_REQUESTS),
           new CategoryMatcher(
               meta ->
                   meta.name().contains("Authorization")
@@ -226,34 +255,43 @@ public class DefaultToolContext {
                       || meta.message().contains("unauthorized")
                       || meta.message().contains("access denied")
                       || meta.message().contains("permission denied"),
-              McpToolCallUsage.ErrorCategory.AUTH),
+              McpToolCallUsage.ErrorCategory.AUTH,
+              STATUS_FORBIDDEN),
+          // Validation by class name runs before the NotFound message heuristic below, so a
+          // bad-argument exception whose message merely contains "not found" (e.g.
+          // IllegalArgumentException("parameter not found")) stays a 400 rather than a 404.
           new CategoryMatcher(
               meta ->
                   meta.name().contains("Validation")
                       || meta.name().contains("IllegalArgument")
                       || meta.name().contains("BadRequest")
                       || meta.message().contains("invalid argument"),
-              McpToolCallUsage.ErrorCategory.VALIDATION),
+              McpToolCallUsage.ErrorCategory.VALIDATION,
+              STATUS_BAD_REQUEST),
+          new CategoryMatcher(
+              meta -> meta.name().contains("NotFound") || meta.message().contains("not found"),
+              McpToolCallUsage.ErrorCategory.VALIDATION,
+              STATUS_NOT_FOUND),
           new CategoryMatcher(
               meta ->
                   meta.name().contains("Timeout")
                       || meta.message().contains("timeout")
                       || meta.message().contains("timed out"),
-              McpToolCallUsage.ErrorCategory.TIMEOUT));
+              McpToolCallUsage.ErrorCategory.TIMEOUT,
+              STATUS_GATEWAY_TIMEOUT));
 
   /**
-   * Returns the category that matches the supplied throwable's name or message, or {@code null}
-   * when no specific bucket applies. Kept separate from {@link #classifyException} so the
+   * Returns the matcher (category + status) for the supplied throwable's name or message, or
+   * {@code null} when no specific bucket applies. Kept separate from {@link #matchException} so the
    * cause-chain walk reads as a single linear loop.
    */
-  private static McpToolCallUsage.ErrorCategory matchCategory(Throwable cursor) {
+  private static CategoryMatcher matchSingle(Throwable cursor) {
     ExceptionMeta meta =
         new ExceptionMeta(
             cursor.getClass().getSimpleName(),
             cursor.getMessage() == null ? "" : cursor.getMessage().toLowerCase(Locale.ROOT));
     return CATEGORY_MATCHERS.stream()
         .filter(matcher -> matcher.matches().test(meta))
-        .map(CategoryMatcher::category)
         .findFirst()
         .orElse(null);
   }

--- a/openmetadata-mcp/src/main/java/org/openmetadata/mcp/tools/GetEntityTool.java
+++ b/openmetadata-mcp/src/main/java/org/openmetadata/mcp/tools/GetEntityTool.java
@@ -2,6 +2,7 @@ package org.openmetadata.mcp.tools;
 
 import static org.openmetadata.schema.type.MetadataOperation.VIEW_ALL;
 
+import com.google.common.annotations.VisibleForTesting;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
@@ -27,6 +28,7 @@ public class GetEntityTool implements McpTool {
           "updatedAt",
           "updatedBy",
           "changeDescription",
+          "incrementalChangeDescription",
           "followers",
           "votes",
           "totalVotes",
@@ -44,6 +46,17 @@ public class GetEntityTool implements McpTool {
           "descriptionSources",
           "columnDescriptionStatus",
           "descriptionStatus");
+
+  private static final String DESCRIPTION_KEY = "description";
+  private static final String COLUMNS_KEY = "columns";
+  private static final String CHILDREN_KEY = "children";
+  private static final String SCHEMA_DEFINITION_KEY = "schemaDefinition";
+  private static final String DATA_MODEL_KEY = "dataModel";
+  private static final String SQL_KEY = "sql";
+  private static final String RAW_SQL_KEY = "rawSql";
+  private static final String COLUMN_DESCRIPTIONS_TRUNCATED_KEY = "columnDescriptionsTruncated";
+  private static final String SCHEMA_DEFINITION_TRUNCATED_KEY = "schemaDefinitionTruncated";
+  private static final String SQL_TRUNCATED_KEY = "sqlTruncated";
 
   @Override
   public Map<String, Object> execute(
@@ -65,17 +78,90 @@ public class GetEntityTool implements McpTool {
   }
 
   /**
-   * Removes verbose fields from entity response to optimize LLM context. Keeps essential fields
-   * while removing metadata that adds little value for LLM understanding.
+   * Removes verbose fields and trims the wide-table multipliers (per-column descriptions, raw
+   * schema/model SQL) so the detail response stays usable on entities with hundreds of columns.
+   * The entity-level description is deliberately left untouched — this is the one tool whose
+   * callers need the full text after search results truncated it. The map tree comes from a fresh
+   * Jackson conversion ({@code JsonUtils.getMap}), so in-place edits never touch the cached entity
+   * POJO.
    */
-  private static Map<String, Object> cleanEntityResponse(Map<String, Object> entityData) {
-    if (entityData == null) {
-      return new HashMap<>();
+  @VisibleForTesting
+  static Map<String, Object> cleanEntityResponse(Map<String, Object> entityData) {
+    Map<String, Object> cleaned = new HashMap<>();
+    if (entityData != null) {
+      cleaned = new HashMap<>(entityData);
+      EXCLUDE_FIELDS.forEach(cleaned::remove);
+      McpResponseTrim.VECTOR_NOISE_FIELDS.forEach(cleaned::remove);
+      trimSchemaDefinition(cleaned);
+      trimDataModelSql(cleaned);
+      if (trimColumnDescriptions(cleaned.get(COLUMNS_KEY))) {
+        cleaned.put(COLUMN_DESCRIPTIONS_TRUNCATED_KEY, Boolean.TRUE);
+      }
     }
-    Map<String, Object> cleaned = new HashMap<>(entityData);
-    EXCLUDE_FIELDS.forEach(cleaned::remove);
-    McpResponseTrim.VECTOR_NOISE_FIELDS.forEach(cleaned::remove);
     return cleaned;
+  }
+
+  /**
+   * Truncates over-length column descriptions, recursing through {@code children} for nested
+   * struct/map columns. Returns whether any description was cut so the caller can surface a single
+   * top-level marker instead of per-column flag noise.
+   */
+  private static boolean trimColumnDescriptions(Object columnsValue) {
+    boolean truncated = false;
+    if (columnsValue instanceof List<?> columns) {
+      for (Object column : columns) {
+        if (column instanceof Map) {
+          truncated |= trimColumn(castMap(column));
+        }
+      }
+    }
+    return truncated;
+  }
+
+  private static boolean trimColumn(Map<String, Object> column) {
+    boolean truncated = false;
+    if (column.get(DESCRIPTION_KEY) instanceof String description
+        && description.length() > McpResponseTrim.TEXT_MAX_LENGTH) {
+      column.put(
+          DESCRIPTION_KEY, McpResponseTrim.truncate(description, McpResponseTrim.TEXT_MAX_LENGTH));
+      truncated = true;
+    }
+    // Non-short-circuit | : children must be trimmed even when this column's description was cut.
+    return truncated | trimColumnDescriptions(column.get(CHILDREN_KEY));
+  }
+
+  private static void trimSchemaDefinition(Map<String, Object> entity) {
+    if (entity.get(SCHEMA_DEFINITION_KEY) instanceof String ddl
+        && ddl.length() > McpResponseTrim.SQL_MAX_LENGTH) {
+      entity.put(
+          SCHEMA_DEFINITION_KEY, McpResponseTrim.truncate(ddl, McpResponseTrim.SQL_MAX_LENGTH));
+      entity.put(SCHEMA_DEFINITION_TRUNCATED_KEY, Boolean.TRUE);
+    }
+  }
+
+  private static void trimDataModelSql(Map<String, Object> entity) {
+    if (entity.get(DATA_MODEL_KEY) instanceof Map) {
+      Map<String, Object> dataModel = castMap(entity.get(DATA_MODEL_KEY));
+      // Non-short-circuit | : both sql and rawSql must be trimmed regardless of the other.
+      boolean truncated = trimSqlField(dataModel, SQL_KEY) | trimSqlField(dataModel, RAW_SQL_KEY);
+      if (truncated) {
+        dataModel.put(SQL_TRUNCATED_KEY, Boolean.TRUE);
+      }
+    }
+  }
+
+  private static boolean trimSqlField(Map<String, Object> dataModel, String key) {
+    boolean truncated = false;
+    if (dataModel.get(key) instanceof String sql && sql.length() > McpResponseTrim.SQL_MAX_LENGTH) {
+      dataModel.put(key, McpResponseTrim.truncate(sql, McpResponseTrim.SQL_MAX_LENGTH));
+      truncated = true;
+    }
+    return truncated;
+  }
+
+  @SuppressWarnings("unchecked")
+  private static Map<String, Object> castMap(Object value) {
+    return (Map<String, Object>) value;
   }
 
   @Override

--- a/openmetadata-mcp/src/main/java/org/openmetadata/mcp/tools/GetEntityTool.java
+++ b/openmetadata-mcp/src/main/java/org/openmetadata/mcp/tools/GetEntityTool.java
@@ -7,6 +7,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
+import org.openmetadata.mcp.util.McpResponseTrim;
 import org.openmetadata.schema.utils.JsonUtils;
 import org.openmetadata.service.Entity;
 import org.openmetadata.service.limits.Limits;
@@ -42,8 +43,7 @@ public class GetEntityTool implements McpTool {
           "tagSources",
           "descriptionSources",
           "columnDescriptionStatus",
-          "descriptionStatus",
-          "embeddings");
+          "descriptionStatus");
 
   @Override
   public Map<String, Object> execute(
@@ -74,6 +74,7 @@ public class GetEntityTool implements McpTool {
     }
     Map<String, Object> cleaned = new HashMap<>(entityData);
     EXCLUDE_FIELDS.forEach(cleaned::remove);
+    McpResponseTrim.VECTOR_NOISE_FIELDS.forEach(cleaned::remove);
     return cleaned;
   }
 

--- a/openmetadata-mcp/src/main/java/org/openmetadata/mcp/tools/GetLineageTool.java
+++ b/openmetadata-mcp/src/main/java/org/openmetadata/mcp/tools/GetLineageTool.java
@@ -13,6 +13,8 @@ import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 import lombok.extern.slf4j.Slf4j;
+import org.openmetadata.mcp.util.McpParams;
+import org.openmetadata.mcp.util.McpResponseTrim;
 import org.openmetadata.schema.type.ColumnLineage;
 import org.openmetadata.schema.type.Edge;
 import org.openmetadata.schema.type.EntityLineage;
@@ -43,13 +45,6 @@ public class GetLineageTool implements McpTool {
   private static final int DEFAULT_DEPTH = 3;
   // Maximum depth to prevent exponential response growth (lineage graphs can explode)
   private static final int MAX_DEPTH = 10;
-  // SQL is the single heaviest field; keep the gist of the transform, cap the size
-  private static final int SQL_MAX_LENGTH = 500;
-  // Free-text markdown (pipeline / edge descriptions) is capped for the same reason as SQL:
-  // a single long pipeline doc string can be shared across many edges and reintroduce bloat
-  private static final int TEXT_MAX_LENGTH = 500;
-  // Final safety net mirroring SearchMetadataTool: even slimmed, a wide graph can blow the limit
-  private static final int MAX_RESPONSE_CHARS = 100_000;
   private static final String RELATIONSHIP_SQL = "sql";
 
   @JsonInclude(JsonInclude.Include.NON_NULL)
@@ -94,9 +89,9 @@ public class GetLineageTool implements McpTool {
         securityContext,
         new OperationContext(entityType, MetadataOperation.VIEW_BASIC),
         new ResourceContext<>(entityType));
-    int upstreamDepth = parseDepthParameter(params.get("upstreamDepth"), DEFAULT_DEPTH);
-    int downstreamDepth = parseDepthParameter(params.get("downstreamDepth"), DEFAULT_DEPTH);
-    boolean includeColumnLineage = parseBooleanParameter(params.get("includeColumnLineage"));
+    int upstreamDepth = clampDepth(McpParams.getInt(params, "upstreamDepth", DEFAULT_DEPTH));
+    int downstreamDepth = clampDepth(McpParams.getInt(params, "downstreamDepth", DEFAULT_DEPTH));
+    boolean includeColumnLineage = McpParams.getBoolean(params, "includeColumnLineage", false);
     LOG.info(
         "Getting lineage for entity type: {}, FQN: {}, upstreamDepth: {}, downstreamDepth: {}, "
             + "includeColumnLineage: {}",
@@ -212,11 +207,7 @@ public class GetLineageTool implements McpTool {
   }
 
   private static String truncateText(String text) {
-    String result = text;
-    if (text != null && text.length() > TEXT_MAX_LENGTH) {
-      result = text.substring(0, TEXT_MAX_LENGTH) + "...";
-    }
-    return result;
+    return McpResponseTrim.truncate(text, McpResponseTrim.TEXT_MAX_LENGTH);
   }
 
   private static String sourceValue(LineageDetails details) {
@@ -227,8 +218,8 @@ public class GetLineageTool implements McpTool {
     String sql = details != null ? details.getSqlQuery() : null;
     SqlText result = new SqlText(null, null);
     if (sql != null) {
-      boolean tooLong = sql.length() > SQL_MAX_LENGTH;
-      String value = tooLong ? sql.substring(0, SQL_MAX_LENGTH) + "..." : sql;
+      boolean tooLong = sql.length() > McpResponseTrim.SQL_MAX_LENGTH;
+      String value = McpResponseTrim.truncate(sql, McpResponseTrim.SQL_MAX_LENGTH);
       result = new SqlText(value, tooLong ? Boolean.TRUE : null);
     }
     return result;
@@ -253,9 +244,9 @@ public class GetLineageTool implements McpTool {
   @VisibleForTesting
   static Map<String, Object> enforceSizeBudget(SlimLineage slim) {
     Map<String, Object> response = JsonUtils.getMap(slim);
-    int responseSize = JsonUtils.pojoToJson(response).length();
+    int responseSize = McpResponseTrim.serializedLength(response);
     Map<String, Object> result = response;
-    if (responseSize > MAX_RESPONSE_CHARS) {
+    if (responseSize > McpResponseTrim.MAX_RESPONSE_CHARS) {
       result = oversizedHint(slim, responseSize);
     }
     return result;
@@ -276,42 +267,17 @@ public class GetLineageTool implements McpTool {
         String.format(
             "Lineage response exceeded %d characters (was %d). Reduce upstreamDepth/downstreamDepth,"
                 + " or keep includeColumnLineage disabled, to get a smaller graph.",
-            MAX_RESPONSE_CHARS, size));
+            McpResponseTrim.MAX_RESPONSE_CHARS, size));
     return hint;
   }
 
-  private static boolean parseBooleanParameter(Object value) {
-    boolean result = false;
-    if (value instanceof Boolean bool) {
-      result = bool;
-    } else if (value instanceof String string) {
-      result = Boolean.parseBoolean(string);
-    }
-    return result;
-  }
-
   /**
-   * Parses depth parameter with default value and enforces maximum limit to prevent excessive
-   * response sizes that could overwhelm LLM context.
+   * Clamps a requested depth into {@code [1, MAX_DEPTH]} to prevent excessive response sizes that
+   * could overwhelm LLM context. Parsing is delegated to {@link McpParams}; the valid range is
+   * specific to this tool, so the clamp stays here.
    */
-  private static int parseDepthParameter(Object depthObj, int defaultValue) {
-    int depth = defaultValue;
-    if (depthObj instanceof Number number) {
-      depth = number.intValue();
-    } else if (depthObj instanceof String string) {
-      depth = parseDepthString(string, defaultValue);
-    }
+  private static int clampDepth(int depth) {
     return Math.min(Math.max(depth, 1), MAX_DEPTH);
-  }
-
-  private static int parseDepthString(String value, int defaultValue) {
-    int depth = defaultValue;
-    try {
-      depth = Integer.parseInt(value);
-    } catch (NumberFormatException e) {
-      depth = defaultValue;
-    }
-    return depth;
   }
 
   @Override

--- a/openmetadata-mcp/src/main/java/org/openmetadata/mcp/tools/GetLineageTool.java
+++ b/openmetadata-mcp/src/main/java/org/openmetadata/mcp/tools/GetLineageTool.java
@@ -2,10 +2,24 @@ package org.openmetadata.mcp.tools;
 
 import static org.openmetadata.common.utils.CommonUtil.nullOrEmpty;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.google.common.annotations.VisibleForTesting;
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
 import lombok.extern.slf4j.Slf4j;
+import org.openmetadata.schema.type.ColumnLineage;
+import org.openmetadata.schema.type.Edge;
+import org.openmetadata.schema.type.EntityLineage;
+import org.openmetadata.schema.type.EntityReference;
+import org.openmetadata.schema.type.LineageDetails;
 import org.openmetadata.schema.type.MetadataOperation;
+import org.openmetadata.schema.type.TempLineageTable;
 import org.openmetadata.schema.utils.JsonUtils;
 import org.openmetadata.service.Entity;
 import org.openmetadata.service.limits.Limits;
@@ -14,6 +28,14 @@ import org.openmetadata.service.security.auth.CatalogSecurityContext;
 import org.openmetadata.service.security.policyevaluator.OperationContext;
 import org.openmetadata.service.security.policyevaluator.ResourceContext;
 
+/**
+ * Returns a compact, LLM-friendly lineage graph. The raw {@link EntityLineage} from the repository
+ * is intentionally verbose (full SQL, column-level mappings, node descriptions) and can reach
+ * hundreds of KB for even a couple of nodes. This tool slims it to identity + relationship info,
+ * folding node details into edge endpoints. Column lineage and full SQL are dropped by default and
+ * only surfaced on request, keeping the default response table-level. All slimming happens here in
+ * the tool — the repository and its UI/RCA callers are untouched.
+ */
 @Slf4j
 public class GetLineageTool implements McpTool {
 
@@ -21,43 +43,251 @@ public class GetLineageTool implements McpTool {
   private static final int DEFAULT_DEPTH = 3;
   // Maximum depth to prevent exponential response growth (lineage graphs can explode)
   private static final int MAX_DEPTH = 10;
+  // SQL is the single heaviest field; keep the gist of the transform, cap the size
+  private static final int SQL_MAX_LENGTH = 500;
+  // Free-text markdown (pipeline / edge descriptions) is capped for the same reason as SQL:
+  // a single long pipeline doc string can be shared across many edges and reintroduce bloat
+  private static final int TEXT_MAX_LENGTH = 500;
+  // Final safety net mirroring SearchMetadataTool: even slimmed, a wide graph can blow the limit
+  private static final int MAX_RESPONSE_CHARS = 100_000;
+  private static final String RELATIONSHIP_SQL = "sql";
+
+  @JsonInclude(JsonInclude.Include.NON_NULL)
+  record SlimEdge(
+      String fromFQN,
+      String toFQN,
+      String fromName,
+      String toName,
+      String fromType,
+      String toType,
+      String relationshipType,
+      String pipelineFQN,
+      String pipelineDescription,
+      String edgeDescription,
+      String source,
+      Integer assetEdges,
+      String sqlQuery,
+      Boolean sqlTruncated,
+      List<TempLineageTable> tempLineageTables,
+      Long updatedAt,
+      String updatedBy,
+      List<ColumnLineage> columnsLineage) {}
+
+  @JsonInclude(JsonInclude.Include.NON_NULL)
+  record SlimLineage(
+      String root,
+      String rootId,
+      String rootType,
+      List<SlimEdge> upstream,
+      List<SlimEdge> downstream) {}
+
+  private record SqlText(String value, Boolean truncated) {}
 
   @Override
   public Map<String, Object> execute(
-      Authorizer authorizer, CatalogSecurityContext securityContext, Map<String, Object> params) {
-    try {
-      if (nullOrEmpty(params)) {
-        throw new IllegalArgumentException("Parameters cannot be null or empty");
-      }
-      String entityType = (String) params.get("entityType");
-      String fqn = (String) params.get("fqn");
+      Authorizer authorizer, CatalogSecurityContext securityContext, Map<String, Object> params)
+      throws IOException {
+    validateParams(params);
+    String entityType = (String) params.get("entityType");
+    String fqn = (String) params.get("fqn");
+    authorizer.authorize(
+        securityContext,
+        new OperationContext(entityType, MetadataOperation.VIEW_BASIC),
+        new ResourceContext<>(entityType));
+    int upstreamDepth = parseDepthParameter(params.get("upstreamDepth"), DEFAULT_DEPTH);
+    int downstreamDepth = parseDepthParameter(params.get("downstreamDepth"), DEFAULT_DEPTH);
+    boolean includeColumnLineage = parseBooleanParameter(params.get("includeColumnLineage"));
+    LOG.info(
+        "Getting lineage for entity type: {}, FQN: {}, upstreamDepth: {}, downstreamDepth: {}, "
+            + "includeColumnLineage: {}",
+        entityType,
+        fqn,
+        upstreamDepth,
+        downstreamDepth,
+        includeColumnLineage);
+    EntityLineage lineage =
+        Entity.getLineageRepository().getByName(entityType, fqn, upstreamDepth, downstreamDepth);
+    return enforceSizeBudget(toSlim(lineage, includeColumnLineage));
+  }
 
-      if (nullOrEmpty(entityType) || nullOrEmpty(fqn)) {
-        throw new IllegalArgumentException("Parameters 'entityType' and 'fqn' are required");
-      }
-
-      authorizer.authorize(
-          securityContext,
-          new OperationContext(entityType, MetadataOperation.VIEW_BASIC),
-          new ResourceContext<>(entityType));
-
-      // Parse and validate upstream depth with default and max limits
-      int upstreamDepth = parseDepthParameter(params.get("upstreamDepth"), DEFAULT_DEPTH);
-      // Parse and validate downstream depth with default and max limits
-      int downstreamDepth = parseDepthParameter(params.get("downstreamDepth"), DEFAULT_DEPTH);
-
-      LOG.info(
-          "Getting lineage for entity type: {}, FQN: {}, upstreamDepth: {}, downstreamDepth: {}",
-          entityType,
-          fqn,
-          upstreamDepth,
-          downstreamDepth);
-
-      return JsonUtils.getMap(
-          Entity.getLineageRepository().getByName(entityType, fqn, upstreamDepth, downstreamDepth));
-    } catch (Exception e) {
-      return Map.of("error", e.getMessage());
+  private static void validateParams(Map<String, Object> params) {
+    if (nullOrEmpty(params)) {
+      throw new IllegalArgumentException("Parameters cannot be null or empty");
     }
+    String entityType = (String) params.get("entityType");
+    String fqn = (String) params.get("fqn");
+    if (nullOrEmpty(entityType) || nullOrEmpty(fqn)) {
+      throw new IllegalArgumentException("Parameters 'entityType' and 'fqn' are required");
+    }
+  }
+
+  @VisibleForTesting
+  static SlimLineage toSlim(EntityLineage lineage, boolean includeColumnLineage) {
+    Map<UUID, EntityReference> nodeIndex = buildNodeIndex(lineage);
+    List<SlimEdge> upstream =
+        slimEdges(lineage.getUpstreamEdges(), nodeIndex, includeColumnLineage);
+    List<SlimEdge> downstream =
+        slimEdges(lineage.getDownstreamEdges(), nodeIndex, includeColumnLineage);
+    EntityReference root = lineage.getEntity();
+    return new SlimLineage(
+        refFqn(root),
+        root != null && root.getId() != null ? root.getId().toString() : null,
+        refType(root),
+        upstream,
+        downstream);
+  }
+
+  private static Map<UUID, EntityReference> buildNodeIndex(EntityLineage lineage) {
+    Map<UUID, EntityReference> index = new HashMap<>();
+    if (lineage.getEntity() != null) {
+      index.put(lineage.getEntity().getId(), lineage.getEntity());
+    }
+    if (!nullOrEmpty(lineage.getNodes())) {
+      lineage.getNodes().forEach(node -> index.put(node.getId(), node));
+    }
+    return index;
+  }
+
+  private static List<SlimEdge> slimEdges(
+      List<Edge> edges, Map<UUID, EntityReference> nodeIndex, boolean includeColumnLineage) {
+    // The repository dedups nodes but not edges: a node reachable via multiple paths has its
+    // upstream/downstream edges re-added on each recursion. Identical slim edges carry no extra
+    // information, so collapse them with a LinkedHashSet (record equality), preserving order.
+    Set<SlimEdge> deduped = new LinkedHashSet<>();
+    if (!nullOrEmpty(edges)) {
+      edges.forEach(edge -> deduped.add(buildSlimEdge(edge, nodeIndex, includeColumnLineage)));
+    }
+    return new ArrayList<>(deduped);
+  }
+
+  private static SlimEdge buildSlimEdge(
+      Edge edge, Map<UUID, EntityReference> nodeIndex, boolean includeColumns) {
+    // computeLineage adds every edge endpoint to nodes (or it is the root), so nodeIndex
+    // resolves both ends. If that invariant ever breaks (a partial/cached graph), the endpoint
+    // fields come back null and identical anonymous edges dedup-collapse — warn instead of
+    // silently emitting a linkless edge.
+    EntityReference from = nodeIndex.get(edge.getFromEntity());
+    EntityReference to = nodeIndex.get(edge.getToEntity());
+    if (from == null || to == null) {
+      LOG.warn(
+          "Lineage edge endpoint missing from node index (from={}, to={}); emitting partial edge",
+          edge.getFromEntity(),
+          edge.getToEntity());
+    }
+    LineageDetails details = edge.getLineageDetails();
+    EntityReference pipeline = details != null ? details.getPipeline() : null;
+    SqlText sql = truncateSqlQuery(details);
+    return new SlimEdge(
+        refFqn(from),
+        refFqn(to),
+        refName(from),
+        refName(to),
+        refType(from),
+        refType(to),
+        relationshipType(pipeline),
+        pipeline != null ? pipeline.getFullyQualifiedName() : null,
+        truncateText(pipeline != null ? pipeline.getDescription() : null),
+        truncateText(details != null ? details.getDescription() : null),
+        sourceValue(details),
+        details != null ? details.getAssetEdges() : null,
+        sql.value(),
+        sql.truncated(),
+        details != null ? details.getTempLineageTables() : null,
+        details != null ? details.getUpdatedAt() : null,
+        details != null ? details.getUpdatedBy() : null,
+        columnsLineageOf(details, includeColumns));
+  }
+
+  private static List<ColumnLineage> columnsLineageOf(
+      LineageDetails details, boolean includeColumns) {
+    List<ColumnLineage> columns = null;
+    if (includeColumns && details != null && !nullOrEmpty(details.getColumnsLineage())) {
+      columns = details.getColumnsLineage();
+    }
+    return columns;
+  }
+
+  private static String relationshipType(EntityReference pipeline) {
+    return pipeline != null ? pipeline.getType() + ":" + pipeline.getName() : RELATIONSHIP_SQL;
+  }
+
+  private static String truncateText(String text) {
+    String result = text;
+    if (text != null && text.length() > TEXT_MAX_LENGTH) {
+      result = text.substring(0, TEXT_MAX_LENGTH) + "...";
+    }
+    return result;
+  }
+
+  private static String sourceValue(LineageDetails details) {
+    return details != null && details.getSource() != null ? details.getSource().value() : null;
+  }
+
+  private static SqlText truncateSqlQuery(LineageDetails details) {
+    String sql = details != null ? details.getSqlQuery() : null;
+    SqlText result = new SqlText(null, null);
+    if (sql != null) {
+      boolean tooLong = sql.length() > SQL_MAX_LENGTH;
+      String value = tooLong ? sql.substring(0, SQL_MAX_LENGTH) + "..." : sql;
+      result = new SqlText(value, tooLong ? Boolean.TRUE : null);
+    }
+    return result;
+  }
+
+  private static String refFqn(EntityReference ref) {
+    return ref != null ? ref.getFullyQualifiedName() : null;
+  }
+
+  private static String refType(EntityReference ref) {
+    return ref != null ? ref.getType() : null;
+  }
+
+  private static String refName(EntityReference ref) {
+    String name = null;
+    if (ref != null) {
+      name = ref.getDisplayName() != null ? ref.getDisplayName() : ref.getName();
+    }
+    return name;
+  }
+
+  @VisibleForTesting
+  static Map<String, Object> enforceSizeBudget(SlimLineage slim) {
+    Map<String, Object> response = JsonUtils.getMap(slim);
+    int responseSize = JsonUtils.pojoToJson(response).length();
+    Map<String, Object> result = response;
+    if (responseSize > MAX_RESPONSE_CHARS) {
+      result = oversizedHint(slim, responseSize);
+    }
+    return result;
+  }
+
+  private static Map<String, Object> oversizedHint(SlimLineage slim, int size) {
+    Map<String, Object> hint = new HashMap<>();
+    hint.put("root", slim.root());
+    hint.put("upstreamCount", slim.upstream().size());
+    hint.put("downstreamCount", slim.downstream().size());
+    hint.put("responseSizeChars", size);
+    // Machine-detectable marker so a programmatic client can tell a capped graph from a complete
+    // one without parsing the message. Stays on the success path — this is a deliberate cap, not an
+    // error the caller can fix by retrying.
+    hint.put("truncated", Boolean.TRUE);
+    hint.put(
+        "message",
+        String.format(
+            "Lineage response exceeded %d characters (was %d). Reduce upstreamDepth/downstreamDepth,"
+                + " or keep includeColumnLineage disabled, to get a smaller graph.",
+            MAX_RESPONSE_CHARS, size));
+    return hint;
+  }
+
+  private static boolean parseBooleanParameter(Object value) {
+    boolean result = false;
+    if (value instanceof Boolean bool) {
+      result = bool;
+    } else if (value instanceof String string) {
+      result = Boolean.parseBoolean(string);
+    }
+    return result;
   }
 
   /**
@@ -65,21 +295,23 @@ public class GetLineageTool implements McpTool {
    * response sizes that could overwhelm LLM context.
    */
   private static int parseDepthParameter(Object depthObj, int defaultValue) {
-    if (depthObj == null) {
-      return Math.min(Math.max(defaultValue, 1), MAX_DEPTH);
-    }
     int depth = defaultValue;
     if (depthObj instanceof Number number) {
       depth = number.intValue();
     } else if (depthObj instanceof String string) {
-      try {
-        depth = Integer.parseInt(string);
-      } catch (NumberFormatException e) {
-        depth = defaultValue;
-      }
+      depth = parseDepthString(string, defaultValue);
     }
-    // Enforce maximum depth to prevent exponential response growth
     return Math.min(Math.max(depth, 1), MAX_DEPTH);
+  }
+
+  private static int parseDepthString(String value, int defaultValue) {
+    int depth = defaultValue;
+    try {
+      depth = Integer.parseInt(value);
+    } catch (NumberFormatException e) {
+      depth = defaultValue;
+    }
+    return depth;
   }
 
   @Override

--- a/openmetadata-mcp/src/main/java/org/openmetadata/mcp/tools/GlossaryTermTool.java
+++ b/openmetadata-mcp/src/main/java/org/openmetadata/mcp/tools/GlossaryTermTool.java
@@ -4,7 +4,6 @@ import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
 import org.openmetadata.schema.entity.data.GlossaryTerm;
 import org.openmetadata.schema.type.MetadataOperation;
-import org.openmetadata.schema.utils.JsonUtils;
 import org.openmetadata.service.Entity;
 import org.openmetadata.service.jdbi3.GlossaryTermRepository;
 import org.openmetadata.service.limits.Limits;
@@ -67,6 +66,6 @@ public class GlossaryTermTool implements McpTool {
     RestUtil.PutResponse<GlossaryTerm> response =
         glossaryTermRepository.createOrUpdate(null, glossaryTerm, userName, impersonatedBy);
     McpChangeEventUtil.publishChangeEvent(response.getEntity(), response.getChangeType(), userName);
-    return JsonUtils.getMap(response.getEntity());
+    return McpResponseUtils.compact(response.getEntity(), response.getChangeType());
   }
 }

--- a/openmetadata-mcp/src/main/java/org/openmetadata/mcp/tools/GlossaryTool.java
+++ b/openmetadata-mcp/src/main/java/org/openmetadata/mcp/tools/GlossaryTool.java
@@ -7,7 +7,6 @@ import org.openmetadata.schema.api.data.CreateGlossary;
 import org.openmetadata.schema.entity.data.Glossary;
 import org.openmetadata.schema.type.EntityReference;
 import org.openmetadata.schema.type.MetadataOperation;
-import org.openmetadata.schema.utils.JsonUtils;
 import org.openmetadata.service.Entity;
 import org.openmetadata.service.jdbi3.GlossaryRepository;
 import org.openmetadata.service.limits.Limits;
@@ -75,7 +74,7 @@ public class GlossaryTool implements McpTool {
     RestUtil.PutResponse<Glossary> response =
         glossaryRepository.createOrUpdate(null, glossary, userName, impersonatedBy);
     McpChangeEventUtil.publishChangeEvent(response.getEntity(), response.getChangeType(), userName);
-    return JsonUtils.convertValue(response.getEntity(), Map.class);
+    return McpResponseUtils.compact(response.getEntity(), response.getChangeType());
   }
 
   public static void setReviewers(CreateGlossary entity, Map<String, Object> params) {

--- a/openmetadata-mcp/src/main/java/org/openmetadata/mcp/tools/RootCauseAnalysisTool.java
+++ b/openmetadata-mcp/src/main/java/org/openmetadata/mcp/tools/RootCauseAnalysisTool.java
@@ -3,10 +3,14 @@ package org.openmetadata.mcp.tools;
 import static org.openmetadata.mcp.tools.SearchMetadataTool.cleanSearchResponseObject;
 import static org.openmetadata.service.search.SearchUtils.isConnectedVia;
 
+import com.google.common.annotations.VisibleForTesting;
 import jakarta.ws.rs.core.Response;
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -30,7 +34,16 @@ import org.openmetadata.service.security.policyevaluator.ResourceContext;
 @Slf4j
 public class RootCauseAnalysisTool implements McpTool {
 
+  private static final int DEFAULT_DEPTH = 3;
   private static final int MAX_DEPTH = 10;
+  // Slimming budgets mirror GetLineageTool so RCA's lineage-derived payload stays within
+  // LLM/MCP context limits. The backend (searchDataQualityLineage / searchLineageWithDirection)
+  // is shared with the UI LineageResource and is never touched — we only transform the
+  // in-memory result before returning it to the MCP client.
+  private static final int SQL_MAX_LENGTH = 500;
+  private static final int TEXT_MAX_LENGTH = 500;
+  private static final int MAX_RESPONSE_CHARS = 100_000;
+  private static final String RELATIONSHIP_SQL = "sql";
 
   @Override
   public Map<String, Object> execute(
@@ -39,12 +52,12 @@ public class RootCauseAnalysisTool implements McpTool {
       Map<String, Object> parameters) {
     String fqn = (String) parameters.get("fqn");
     String entityType = (String) parameters.getOrDefault("entityType", "table");
-    int upstreamDepth =
-        Math.min(Math.max(parseIntParam(parameters.get("upstreamDepth"), 3), 1), MAX_DEPTH);
+    int upstreamDepth = clampDepth(parseIntParam(parameters.get("upstreamDepth"), DEFAULT_DEPTH));
     int downstreamDepth =
-        Math.min(Math.max(parseIntParam(parameters.get("downstreamDepth"), 3), 1), MAX_DEPTH);
+        clampDepth(parseIntParam(parameters.get("downstreamDepth"), DEFAULT_DEPTH));
     String queryFilter = (String) parameters.get("queryFilter");
     boolean includeDeleted = parseBooleanParam(parameters.get("includeDeleted"), false);
+    boolean includeColumns = parseBooleanParam(parameters.get("includeColumnLineage"), false);
 
     if (fqn == null || fqn.trim().isEmpty()) {
       throw new IllegalArgumentException("Parameter 'fqn' is required and cannot be empty");
@@ -55,126 +68,299 @@ public class RootCauseAnalysisTool implements McpTool {
         new OperationContext(entityType, MetadataOperation.VIEW_BASIC),
         new ResourceContext<>(entityType));
 
+    RcaRequest request =
+        new RcaRequest(
+            fqn.trim(),
+            entityType,
+            upstreamDepth,
+            downstreamDepth,
+            queryFilter,
+            includeDeleted,
+            includeColumns);
     try {
-      Map<String, Object> result = new HashMap<>();
-      result.put("fqn", fqn);
-      result.put("upstreamDepth", upstreamDepth);
-      result.put("downstreamDepth", downstreamDepth);
-
-      Response upstreamResponse =
-          Entity.getSearchRepository()
-              .searchDataQualityLineage(fqn.trim(), upstreamDepth, queryFilter, includeDeleted);
-
-      Object upstreamEntity = upstreamResponse.getEntity();
-      Map<String, Object> upstreamAnalysis = new HashMap<>();
-      boolean hasFailures = false;
-      int failureCount = 0;
-
-      if (upstreamEntity instanceof Map) {
-        @SuppressWarnings("unchecked")
-        Map<String, Object> upstreamLineageData = (Map<String, Object>) upstreamEntity;
-
-        Set<?> upstreamEdgesList =
-            upstreamLineageData.get("edges") instanceof Set<?> s ? s : Collections.emptySet();
-        Set<?> upstreamNodesList =
-            upstreamLineageData.get("nodes") instanceof Set<?> s ? s : Collections.emptySet();
-        List<Map<String, Object>> upstreamNodes =
-            upstreamNodesList.stream()
-                .filter(node -> node instanceof Map)
-                .map(node -> cleanSearchResponseObject((Map<String, Object>) node))
-                .toList();
-
-        failureCount = upstreamNodes.size();
-        upstreamAnalysis.put("failingUpstreamNodesCount", failureCount);
-        hasFailures = !upstreamNodes.isEmpty();
-        if (!upstreamNodes.isEmpty()) {
-          upstreamAnalysis.put("failingUpstreamNodes", upstreamNodes);
-          upstreamNodes.forEach(
-              node -> node.put("failingTestCases", addTestCaseResultForTestSuite(node)));
-        }
-
-        upstreamAnalysis.put("failingUpstreamEdgesCount", upstreamEdgesList.size());
-        upstreamAnalysis.put("failingUpstreamEdges", upstreamEdgesList);
-        upstreamAnalysis.put(
-            "description", "Upstream entities that may be causing data quality failures");
-      }
-      result.put("upstreamAnalysis", upstreamAnalysis);
-
-      Map<String, Object> downstreamAnalysis = new HashMap<>();
-      if (hasFailures) {
-        try {
-          SearchLineageRequest downstreamRequest =
-              new SearchLineageRequest()
-                  .withFqn(fqn.trim())
-                  .withDirection(LineageDirection.DOWNSTREAM)
-                  .withUpstreamDepth(0)
-                  .withDownstreamDepth(downstreamDepth)
-                  .withQueryFilter(queryFilter)
-                  .withIsConnectedVia(isConnectedVia(entityType))
-                  .withIncludeDeleted(includeDeleted);
-
-          SearchLineageResult downstreamResult =
-              Entity.getSearchRepository().searchLineageWithDirection(downstreamRequest);
-
-          downstreamAnalysis.put(
-              "description", "Downstream entities that may be impacted by the identified failures");
-
-          if (downstreamResult.getNodes() != null) {
-            downstreamAnalysis.put(
-                "downstreamImpactedNodesCount", downstreamResult.getNodes().size());
-            downstreamAnalysis.put("downstreamNodes", downstreamResult.getNodes());
-          }
-
-          if (downstreamResult.getDownstreamEdges() != null) {
-            downstreamAnalysis.put(
-                "downstreamImpactedEdgesCount", downstreamResult.getDownstreamEdges().size());
-            downstreamAnalysis.put("downstreamEdges", downstreamResult.getDownstreamEdges());
-          }
-
-          LOG.info(
-              "Downstream impact analysis completed for entity: {} with {} downstream depth, found {} nodes and {} edges",
-              fqn,
-              downstreamDepth,
-              downstreamResult.getNodes() != null ? downstreamResult.getNodes().size() : 0,
-              downstreamResult.getDownstreamEdges() != null
-                  ? downstreamResult.getDownstreamEdges().size()
-                  : 0);
-
-        } catch (Exception e) {
-          LOG.warn("Failed to perform downstream impact analysis for entity: {}", fqn, e);
-          downstreamAnalysis.put("error", "Failed to analyze downstream impact: " + e.getMessage());
-        }
-      } else {
-        downstreamAnalysis.put(
-            "reason",
-            "No failures found in upstream analysis, downstream impact analysis not needed");
-      }
-
-      result.put("downstreamAnalysis", downstreamAnalysis);
-
-      result.put("status", hasFailures ? "failed" : "success");
-      result.put(
-          "summary",
-          String.format(
-              "Analyzed upstream causes and downstream impacts for '%s'. Found %d upstream failure(s).",
-              fqn, failureCount));
-
-      LOG.info(
-          "Comprehensive root cause analysis completed for entity: {} - Upstream failures: {}",
-          fqn,
-          hasFailures);
-
-      return result;
-
+      return analyze(request);
     } catch (IOException e) {
       LOG.error("IOException during root cause analysis for entity: {}", fqn, e);
       throw new RuntimeException("Failed to perform root cause analysis: " + e.getMessage(), e);
-
     } catch (Exception e) {
       LOG.error("Unexpected error during root cause analysis for entity: {}", fqn, e);
       throw new RuntimeException(
           "Unexpected error during root cause analysis: " + e.getMessage(), e);
     }
+  }
+
+  /** Bundles the parsed and validated tool arguments for a single root cause analysis run. */
+  private record RcaRequest(
+      String fqn,
+      String entityType,
+      int upstreamDepth,
+      int downstreamDepth,
+      String queryFilter,
+      boolean includeDeleted,
+      boolean includeColumns) {}
+
+  private Map<String, Object> analyze(RcaRequest request) throws IOException {
+    Map<String, Object> result = new HashMap<>();
+    result.put("fqn", request.fqn());
+    result.put("upstreamDepth", request.upstreamDepth());
+    result.put("downstreamDepth", request.downstreamDepth());
+
+    Response upstreamResponse =
+        Entity.getSearchRepository()
+            .searchDataQualityLineage(
+                request.fqn(),
+                request.upstreamDepth(),
+                request.queryFilter(),
+                request.includeDeleted());
+    Map<String, Object> upstreamAnalysis =
+        buildUpstreamAnalysis(upstreamResponse.getEntity(), request.includeColumns());
+    result.put("upstreamAnalysis", upstreamAnalysis);
+
+    int failureCount =
+        ((Number) upstreamAnalysis.getOrDefault("failingUpstreamNodesCount", 0)).intValue();
+    boolean hasFailures = failureCount > 0;
+    result.put(
+        "downstreamAnalysis",
+        hasFailures ? buildDownstreamAnalysis(request) : noFailuresDownstream());
+    result.put("status", hasFailures ? "failed" : "success");
+    result.put(
+        "summary",
+        String.format(
+            "Analyzed upstream causes and downstream impacts for '%s'. Found %d upstream failure(s).",
+            request.fqn(), failureCount));
+    return enforceSizeBudget(result);
+  }
+
+  private Map<String, Object> buildUpstreamAnalysis(Object upstreamEntity, boolean includeColumns) {
+    Map<String, Object> upstreamAnalysis = new HashMap<>();
+    if (!(upstreamEntity instanceof Map)) {
+      return upstreamAnalysis;
+    }
+    Map<String, Object> upstreamLineageData = castMap(upstreamEntity);
+    Set<?> rawEdges = asSet(upstreamLineageData.get("edges"));
+    List<Map<String, Object>> nodes = slimUpstreamNodes(asSet(upstreamLineageData.get("nodes")));
+
+    upstreamAnalysis.put("failingUpstreamNodesCount", nodes.size());
+    if (!nodes.isEmpty()) {
+      nodes.forEach(node -> node.put("failingTestCases", addTestCaseResultForTestSuite(node)));
+      upstreamAnalysis.put("failingUpstreamNodes", nodes);
+    }
+    upstreamAnalysis.put("failingUpstreamEdgesCount", rawEdges.size());
+    upstreamAnalysis.put("failingUpstreamEdges", slimEdges(rawEdges, includeColumns));
+    upstreamAnalysis.put(
+        "description", "Upstream entities that may be causing data quality failures");
+    return upstreamAnalysis;
+  }
+
+  private Map<String, Object> buildDownstreamAnalysis(RcaRequest request) {
+    Map<String, Object> downstreamAnalysis = new HashMap<>();
+    downstreamAnalysis.put(
+        "description", "Downstream entities that may be impacted by the identified failures");
+    try {
+      SearchLineageRequest downstreamRequest =
+          new SearchLineageRequest()
+              .withFqn(request.fqn())
+              .withDirection(LineageDirection.DOWNSTREAM)
+              .withUpstreamDepth(0)
+              .withDownstreamDepth(request.downstreamDepth())
+              .withQueryFilter(request.queryFilter())
+              .withIsConnectedVia(isConnectedVia(request.entityType()))
+              .withIncludeDeleted(request.includeDeleted());
+      SearchLineageResult downstreamResult =
+          Entity.getSearchRepository().searchLineageWithDirection(downstreamRequest);
+      addDownstreamNodes(downstreamAnalysis, downstreamResult);
+      addDownstreamEdges(downstreamAnalysis, downstreamResult, request.includeColumns());
+    } catch (Exception e) {
+      LOG.warn("Failed to perform downstream impact analysis for entity: {}", request.fqn(), e);
+      downstreamAnalysis.put("error", "Failed to analyze downstream impact: " + e.getMessage());
+    }
+    return downstreamAnalysis;
+  }
+
+  private static void addDownstreamNodes(
+      Map<String, Object> downstreamAnalysis, SearchLineageResult result) {
+    if (result.getNodes() != null) {
+      downstreamAnalysis.put("downstreamImpactedNodesCount", result.getNodes().size());
+      downstreamAnalysis.put("downstreamNodes", slimDownstreamNodes(result.getNodes()));
+    }
+  }
+
+  private static void addDownstreamEdges(
+      Map<String, Object> downstreamAnalysis, SearchLineageResult result, boolean includeColumns) {
+    if (result.getDownstreamEdges() != null) {
+      downstreamAnalysis.put("downstreamImpactedEdgesCount", result.getDownstreamEdges().size());
+      downstreamAnalysis.put(
+          "downstreamEdges", slimEdgeMap(result.getDownstreamEdges(), includeColumns));
+    }
+  }
+
+  private static Map<String, Object> noFailuresDownstream() {
+    Map<String, Object> downstreamAnalysis = new HashMap<>();
+    downstreamAnalysis.put(
+        "reason", "No failures found in upstream analysis, downstream impact analysis not needed");
+    return downstreamAnalysis;
+  }
+
+  private static List<Map<String, Object>> slimUpstreamNodes(Set<?> rawNodes) {
+    List<Map<String, Object>> nodes = new ArrayList<>();
+    for (Object node : rawNodes) {
+      if (node instanceof Map) {
+        nodes.add(slimNodeEntity(castMap(node)));
+      }
+    }
+    return nodes;
+  }
+
+  @VisibleForTesting
+  static Map<String, Object> slimDownstreamNodes(Map<String, ?> rawNodes) {
+    Map<String, Object> slim = new LinkedHashMap<>();
+    rawNodes.forEach((id, nodeInfo) -> slim.put(id, slimNodeInformation(nodeInfo)));
+    return slim;
+  }
+
+  private static Map<String, Object> slimNodeInformation(Object nodeInfo) {
+    Map<String, Object> info = JsonUtils.getMap(nodeInfo);
+    Map<String, Object> slim = new LinkedHashMap<>();
+    if (info != null) {
+      Object entity = info.get("entity");
+      if (entity instanceof Map) {
+        slim.put("entity", slimNodeEntity(castMap(entity)));
+      }
+      putIfPresent(slim, "nodeDepth", info.get("nodeDepth"));
+    }
+    return slim;
+  }
+
+  /**
+   * Cleans an entity document the same way upstream nodes are cleaned ({@link
+   * SearchMetadataTool#cleanSearchResponseObject} drops {@code columns}, {@code schemaDefinition},
+   * {@code queries} and other verbose keys) and additionally truncates the markdown description
+   * that the cleaner leaves untouched.
+   */
+  @VisibleForTesting
+  static Map<String, Object> slimNodeEntity(Map<String, Object> node) {
+    Map<String, Object> cleaned = cleanSearchResponseObject(node);
+    truncateDescriptionInPlace(cleaned);
+    return cleaned;
+  }
+
+  @VisibleForTesting
+  static List<Map<String, Object>> slimEdges(Collection<?> rawEdges, boolean includeColumns) {
+    List<Map<String, Object>> edges = new ArrayList<>();
+    for (Object edge : rawEdges) {
+      edges.add(slimEdge(JsonUtils.getMap(edge), includeColumns));
+    }
+    return edges;
+  }
+
+  @VisibleForTesting
+  static Map<String, Object> slimEdgeMap(Map<String, ?> rawEdges, boolean includeColumns) {
+    Map<String, Object> slim = new LinkedHashMap<>();
+    rawEdges.forEach((id, edge) -> slim.put(id, slimEdge(JsonUtils.getMap(edge), includeColumns)));
+    return slim;
+  }
+
+  /**
+   * Reduces a raw {@code EsLineageData} edge to the fields useful for reasoning. Drops {@code
+   * docId}/{@code docUniqueId}/{@code fqnHash}, audit fields and the raw {@code pipeline} blob
+   * (folded into {@code relationshipType}); truncates {@code sqlQuery}; and includes column-level
+   * lineage only when explicitly requested.
+   */
+  @VisibleForTesting
+  static Map<String, Object> slimEdge(Map<String, Object> edge, boolean includeColumns) {
+    Map<String, Object> slim = new LinkedHashMap<>();
+    if (edge != null) {
+      putIfPresent(slim, "fromEntity", slimRef(edge.get("fromEntity")));
+      putIfPresent(slim, "toEntity", slimRef(edge.get("toEntity")));
+      slim.put("relationshipType", relationshipType(edge.get("pipeline")));
+      putIfPresent(slim, "source", edge.get("source"));
+      putIfPresent(slim, "assetEdges", edge.get("assetEdges"));
+      putIfPresent(slim, "tempLineageTables", edge.get("tempLineageTables"));
+      applyDescription(slim, edge.get("description"));
+      applySqlQuery(slim, edge.get("sqlQuery"));
+      // For deduplicated SQL the backend empties sqlQuery and stores a pointer into the parent
+      // doc's lineageSqlQueries map; carry the pointer so shared SQL isn't silently lost.
+      putIfPresent(slim, "sqlQueryKey", edge.get("sqlQueryKey"));
+      if (includeColumns) {
+        putIfPresent(slim, "columns", edge.get("columns"));
+      }
+    }
+    return slim;
+  }
+
+  private static Map<String, Object> slimRef(Object ref) {
+    Map<String, Object> result = null;
+    if (ref instanceof Map) {
+      Map<String, Object> refMap = castMap(ref);
+      result = new LinkedHashMap<>();
+      putIfPresent(result, "id", refMap.get("id"));
+      putIfPresent(result, "fullyQualifiedName", refMap.get("fullyQualifiedName"));
+      putIfPresent(result, "type", refMap.get("type"));
+    }
+    return result;
+  }
+
+  private static String relationshipType(Object pipeline) {
+    String result = RELATIONSHIP_SQL;
+    if (pipeline instanceof Map) {
+      Map<String, Object> pipelineMap = castMap(pipeline);
+      Object type = pipelineMap.get("type");
+      Object name = pipelineMap.get("name");
+      if (type != null && name != null) {
+        result = type + ":" + name;
+      }
+    }
+    return result;
+  }
+
+  private static void applyDescription(Map<String, Object> slim, Object description) {
+    if (description instanceof String text && !text.isEmpty()) {
+      slim.put("description", truncate(text, TEXT_MAX_LENGTH));
+    }
+  }
+
+  private static void applySqlQuery(Map<String, Object> slim, Object sqlQuery) {
+    if (sqlQuery instanceof String sql && !sql.isEmpty()) {
+      slim.put("sqlQuery", truncate(sql, SQL_MAX_LENGTH));
+      if (sql.length() > SQL_MAX_LENGTH) {
+        slim.put("sqlTruncated", Boolean.TRUE);
+      }
+    }
+  }
+
+  private static void truncateDescriptionInPlace(Map<String, Object> map) {
+    Object description = map.get("description");
+    if (description instanceof String text && text.length() > TEXT_MAX_LENGTH) {
+      map.put("description", truncate(text, TEXT_MAX_LENGTH));
+    }
+  }
+
+  private static String truncate(String value, int maxLength) {
+    return value.length() > maxLength ? value.substring(0, maxLength) + "..." : value;
+  }
+
+  @VisibleForTesting
+  static Map<String, Object> enforceSizeBudget(Map<String, Object> result) {
+    Map<String, Object> output = result;
+    if (JsonUtils.pojoToJson(result).length() > MAX_RESPONSE_CHARS) {
+      output = oversizedHint(result);
+    }
+    return output;
+  }
+
+  private static Map<String, Object> oversizedHint(Map<String, Object> result) {
+    Map<String, Object> hint = new LinkedHashMap<>();
+    putIfPresent(hint, "fqn", result.get("fqn"));
+    putIfPresent(hint, "upstreamDepth", result.get("upstreamDepth"));
+    putIfPresent(hint, "downstreamDepth", result.get("downstreamDepth"));
+    putIfPresent(hint, "status", result.get("status"));
+    putIfPresent(hint, "summary", result.get("summary"));
+    hint.put("truncated", Boolean.TRUE);
+    hint.put(
+        "message",
+        "Root cause analysis result exceeds the size budget. Reduce upstreamDepth/downstreamDepth, "
+            + "or leave includeColumnLineage off, to get a smaller response.");
+    return hint;
   }
 
   private Map<String, Object> addTestCaseResultForTestSuite(Map<String, Object> node) {
@@ -212,6 +398,25 @@ public class RootCauseAnalysisTool implements McpTool {
     return testCaseResult;
   }
 
+  private static int clampDepth(int depth) {
+    return Math.min(Math.max(depth, 1), MAX_DEPTH);
+  }
+
+  private static Set<?> asSet(Object value) {
+    return value instanceof Set<?> set ? set : Collections.emptySet();
+  }
+
+  @SuppressWarnings("unchecked")
+  private static Map<String, Object> castMap(Object value) {
+    return (Map<String, Object>) value;
+  }
+
+  private static void putIfPresent(Map<String, Object> map, String key, Object value) {
+    if (value != null) {
+      map.put(key, value);
+    }
+  }
+
   private static int parseIntParam(Object value, int defaultValue) {
     if (value == null) {
       return defaultValue;
@@ -233,11 +438,11 @@ public class RootCauseAnalysisTool implements McpTool {
     if (value == null) {
       return defaultValue;
     }
-    if (value instanceof Boolean b) {
-      return b;
+    if (value instanceof Boolean bool) {
+      return bool;
     }
-    if (value instanceof String s) {
-      return "true".equalsIgnoreCase(s);
+    if (value instanceof String string) {
+      return "true".equalsIgnoreCase(string);
     }
     return defaultValue;
   }

--- a/openmetadata-mcp/src/main/java/org/openmetadata/mcp/tools/RootCauseAnalysisTool.java
+++ b/openmetadata-mcp/src/main/java/org/openmetadata/mcp/tools/RootCauseAnalysisTool.java
@@ -15,6 +15,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import lombok.extern.slf4j.Slf4j;
+import org.openmetadata.mcp.util.McpParams;
+import org.openmetadata.mcp.util.McpResponseTrim;
 import org.openmetadata.schema.api.lineage.LineageDirection;
 import org.openmetadata.schema.api.lineage.SearchLineageRequest;
 import org.openmetadata.schema.api.lineage.SearchLineageResult;
@@ -36,13 +38,10 @@ public class RootCauseAnalysisTool implements McpTool {
 
   private static final int DEFAULT_DEPTH = 3;
   private static final int MAX_DEPTH = 10;
-  // Slimming budgets mirror GetLineageTool so RCA's lineage-derived payload stays within
+  // Slimming budgets come from McpResponseTrim so RCA's lineage-derived payload stays within
   // LLM/MCP context limits. The backend (searchDataQualityLineage / searchLineageWithDirection)
   // is shared with the UI LineageResource and is never touched — we only transform the
   // in-memory result before returning it to the MCP client.
-  private static final int SQL_MAX_LENGTH = 500;
-  private static final int TEXT_MAX_LENGTH = 500;
-  private static final int MAX_RESPONSE_CHARS = 100_000;
   private static final String RELATIONSHIP_SQL = "sql";
 
   @Override
@@ -52,12 +51,12 @@ public class RootCauseAnalysisTool implements McpTool {
       Map<String, Object> parameters) {
     String fqn = (String) parameters.get("fqn");
     String entityType = (String) parameters.getOrDefault("entityType", "table");
-    int upstreamDepth = clampDepth(parseIntParam(parameters.get("upstreamDepth"), DEFAULT_DEPTH));
+    int upstreamDepth = clampDepth(McpParams.getInt(parameters, "upstreamDepth", DEFAULT_DEPTH));
     int downstreamDepth =
-        clampDepth(parseIntParam(parameters.get("downstreamDepth"), DEFAULT_DEPTH));
+        clampDepth(McpParams.getInt(parameters, "downstreamDepth", DEFAULT_DEPTH));
     String queryFilter = (String) parameters.get("queryFilter");
-    boolean includeDeleted = parseBooleanParam(parameters.get("includeDeleted"), false);
-    boolean includeColumns = parseBooleanParam(parameters.get("includeColumnLineage"), false);
+    boolean includeDeleted = McpParams.getBoolean(parameters, "includeDeleted", false);
+    boolean includeColumns = McpParams.getBoolean(parameters, "includeColumnLineage", false);
 
     if (fqn == null || fqn.trim().isEmpty()) {
       throw new IllegalArgumentException("Parameter 'fqn' is required and cannot be empty");
@@ -81,11 +80,12 @@ public class RootCauseAnalysisTool implements McpTool {
       return analyze(request);
     } catch (IOException e) {
       LOG.error("IOException during root cause analysis for entity: {}", fqn, e);
-      throw new RuntimeException("Failed to perform root cause analysis: " + e.getMessage(), e);
+      throw new RuntimeException(
+          "Failed to perform root cause analysis: " + McpResponseTrim.safeMessage(e), e);
     } catch (Exception e) {
       LOG.error("Unexpected error during root cause analysis for entity: {}", fqn, e);
       throw new RuntimeException(
-          "Unexpected error during root cause analysis: " + e.getMessage(), e);
+          "Unexpected error during root cause analysis: " + McpResponseTrim.safeMessage(e), e);
     }
   }
 
@@ -172,7 +172,8 @@ public class RootCauseAnalysisTool implements McpTool {
       addDownstreamEdges(downstreamAnalysis, downstreamResult, request.includeColumns());
     } catch (Exception e) {
       LOG.warn("Failed to perform downstream impact analysis for entity: {}", request.fqn(), e);
-      downstreamAnalysis.put("error", "Failed to analyze downstream impact: " + e.getMessage());
+      downstreamAnalysis.put(
+          "error", "Failed to analyze downstream impact: " + McpResponseTrim.safeMessage(e));
     }
     return downstreamAnalysis;
   }
@@ -315,14 +316,14 @@ public class RootCauseAnalysisTool implements McpTool {
 
   private static void applyDescription(Map<String, Object> slim, Object description) {
     if (description instanceof String text && !text.isEmpty()) {
-      slim.put("description", truncate(text, TEXT_MAX_LENGTH));
+      slim.put("description", McpResponseTrim.truncate(text, McpResponseTrim.TEXT_MAX_LENGTH));
     }
   }
 
   private static void applySqlQuery(Map<String, Object> slim, Object sqlQuery) {
     if (sqlQuery instanceof String sql && !sql.isEmpty()) {
-      slim.put("sqlQuery", truncate(sql, SQL_MAX_LENGTH));
-      if (sql.length() > SQL_MAX_LENGTH) {
+      slim.put("sqlQuery", McpResponseTrim.truncate(sql, McpResponseTrim.SQL_MAX_LENGTH));
+      if (sql.length() > McpResponseTrim.SQL_MAX_LENGTH) {
         slim.put("sqlTruncated", Boolean.TRUE);
       }
     }
@@ -330,19 +331,15 @@ public class RootCauseAnalysisTool implements McpTool {
 
   private static void truncateDescriptionInPlace(Map<String, Object> map) {
     Object description = map.get("description");
-    if (description instanceof String text && text.length() > TEXT_MAX_LENGTH) {
-      map.put("description", truncate(text, TEXT_MAX_LENGTH));
+    if (description instanceof String text && text.length() > McpResponseTrim.TEXT_MAX_LENGTH) {
+      map.put("description", McpResponseTrim.truncate(text, McpResponseTrim.TEXT_MAX_LENGTH));
     }
-  }
-
-  private static String truncate(String value, int maxLength) {
-    return value.length() > maxLength ? value.substring(0, maxLength) + "..." : value;
   }
 
   @VisibleForTesting
   static Map<String, Object> enforceSizeBudget(Map<String, Object> result) {
     Map<String, Object> output = result;
-    if (JsonUtils.pojoToJson(result).length() > MAX_RESPONSE_CHARS) {
+    if (McpResponseTrim.serializedLength(result) > McpResponseTrim.MAX_RESPONSE_CHARS) {
       output = oversizedHint(result);
     }
     return output;
@@ -415,36 +412,6 @@ public class RootCauseAnalysisTool implements McpTool {
     if (value != null) {
       map.put(key, value);
     }
-  }
-
-  private static int parseIntParam(Object value, int defaultValue) {
-    if (value == null) {
-      return defaultValue;
-    }
-    if (value instanceof Number number) {
-      return number.intValue();
-    }
-    if (value instanceof String string) {
-      try {
-        return Integer.parseInt(string);
-      } catch (NumberFormatException e) {
-        return defaultValue;
-      }
-    }
-    return defaultValue;
-  }
-
-  private static boolean parseBooleanParam(Object value, boolean defaultValue) {
-    if (value == null) {
-      return defaultValue;
-    }
-    if (value instanceof Boolean bool) {
-      return bool;
-    }
-    if (value instanceof String string) {
-      return "true".equalsIgnoreCase(string);
-    }
-    return defaultValue;
   }
 
   @Override

--- a/openmetadata-mcp/src/main/java/org/openmetadata/mcp/tools/SearchMetadataTool.java
+++ b/openmetadata-mcp/src/main/java/org/openmetadata/mcp/tools/SearchMetadataTool.java
@@ -14,7 +14,9 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import lombok.extern.slf4j.Slf4j;
+import org.openmetadata.mcp.util.McpResponseTrim;
 import org.openmetadata.schema.search.SearchRequest;
 import org.openmetadata.schema.utils.JsonUtils;
 import org.openmetadata.service.Entity;
@@ -28,9 +30,6 @@ public class SearchMetadataTool implements McpTool {
 
   private static final int DEFAULT_MAX_AGGREGATION_BUCKETS = 10;
   private static final int MAX_ALLOWED_AGGREGATION_BUCKETS = 50;
-  private static final int DESCRIPTION_MAX_LENGTH = 500;
-  private static final int DESCRIPTION_TRUNCATE_LENGTH = 450;
-  private static final int MAX_RESPONSE_CHARS = 100_000;
 
   private static final List<String> ESSENTIAL_FIELDS_ONLY =
       List.of(
@@ -65,47 +64,43 @@ public class SearchMetadataTool implements McpTool {
       List.of("testCaseStatus", "timestamp", "result");
 
   private static final List<String> DETAILED_EXCLUDE_KEYS =
-      List.of(
-          "id",
-          "version",
-          "updatedAt",
-          "updatedBy",
-          "usageSummary",
-          "followers",
-          "votes",
-          "lifeCycle",
-          "sourceHash",
-          "processedLineage",
-          "totalVotes",
-          "fqnParts",
-          "service_suggest",
-          "column_suggest",
-          "schema_suggest",
-          "database_suggest",
-          "upstreamLineage",
-          "entityRelationship",
-          "changeSummary",
-          "fqnHash",
-          "columns",
-          "schemaDefinition",
-          "queries",
-          "sourceUrl",
-          "locationPath",
-          "customMetrics",
-          "tierSources",
-          "tagSources",
-          "descriptionSources",
-          "columnDescriptionStatus",
-          "columnNamesFuzzy",
-          "descriptionStatus",
-          "domains",
-          "embeddings",
-          "embedding",
-          "textToEmbed",
-          "textToLLMContext",
-          "fingerprint",
-          "chunkCount",
-          "chunkIndex");
+      Stream.concat(
+              Stream.of(
+                  "id",
+                  "version",
+                  "updatedAt",
+                  "updatedBy",
+                  "usageSummary",
+                  "followers",
+                  "votes",
+                  "lifeCycle",
+                  "sourceHash",
+                  "processedLineage",
+                  "totalVotes",
+                  "fqnParts",
+                  "service_suggest",
+                  "column_suggest",
+                  "schema_suggest",
+                  "database_suggest",
+                  "upstreamLineage",
+                  "entityRelationship",
+                  "changeSummary",
+                  "fqnHash",
+                  "columns",
+                  "schemaDefinition",
+                  "queries",
+                  "sourceUrl",
+                  "locationPath",
+                  "customMetrics",
+                  "tierSources",
+                  "tagSources",
+                  "descriptionSources",
+                  "columnDescriptionStatus",
+                  "columnNamesFuzzy",
+                  "descriptionStatus",
+                  "domains"),
+              McpResponseTrim.VECTOR_NOISE_FIELDS.stream())
+          .toList();
 
   @Override
   public Map<String, Object> execute(
@@ -371,13 +366,15 @@ public class SearchMetadataTool implements McpTool {
           "[MCP] search_metadata response size: {} chars for query '{}'",
           serialized.length(),
           query);
-      if (serialized.length() > MAX_RESPONSE_CHARS) {
+      if (serialized.length() > McpResponseTrim.MAX_RESPONSE_CHARS) {
         int targetCount =
             Math.min(
                 Math.max(
                     1,
                     (int)
-                        (cleanedResults.size() * (MAX_RESPONSE_CHARS * 0.8) / serialized.length())),
+                        (cleanedResults.size()
+                            * (McpResponseTrim.MAX_RESPONSE_CHARS * 0.8)
+                            / serialized.length())),
                 cleanedResults.size());
         List<Map<String, Object>> trimmed = new ArrayList<>(cleanedResults.subList(0, targetCount));
         LOG.warn(
@@ -394,7 +391,7 @@ public class SearchMetadataTool implements McpTool {
                 "Response exceeded %d characters and was trimmed to %d of %d results. "
                     + "There are many matching assets. Are you looking for something specific? "
                     + "Try narrowing with a service name, schema, or specific name.",
-                MAX_RESPONSE_CHARS, trimmed.size(), totalResults));
+                McpResponseTrim.MAX_RESPONSE_CHARS, trimmed.size(), totalResults));
       }
     } catch (RuntimeException e) {
       LOG.warn("Failed to check response size for query '{}': {}", query, e.getMessage());
@@ -424,11 +421,8 @@ public class SearchMetadataTool implements McpTool {
     addSlimTestCaseResult(source, result);
 
     // Truncate long descriptions to optimize LLM context usage
-    if (result.containsKey("description")) {
-      Object descObj = result.get("description");
-      if (descObj instanceof String description && description.length() > DESCRIPTION_MAX_LENGTH) {
-        result.put("description", description.substring(0, DESCRIPTION_TRUNCATE_LENGTH) + "...");
-      }
+    if (result.get("description") instanceof String description) {
+      result.put("description", McpResponseTrim.truncateDescription(description));
     }
     return result;
   }

--- a/openmetadata-mcp/src/main/java/org/openmetadata/mcp/tools/SearchMetadataTool.java
+++ b/openmetadata-mcp/src/main/java/org/openmetadata/mcp/tools/SearchMetadataTool.java
@@ -31,6 +31,7 @@ public class SearchMetadataTool implements McpTool {
   private static final int MAX_ALLOWED_AGGREGATION_BUCKETS = 50;
   private static final int DESCRIPTION_MAX_LENGTH = 500;
   private static final int DESCRIPTION_TRUNCATE_LENGTH = 450;
+  private static final int MAX_RESPONSE_CHARS = 100_000;
 
   private static final List<String> ESSENTIAL_FIELDS_ONLY =
       List.of(
@@ -332,9 +333,46 @@ public class SearchMetadataTool implements McpTool {
       result.put(
           "message",
           String.format(
-              "Found %d total results, showing first %d. Use pagination or refine your search for more specific results, you can call these 3 times by yourself with pagination , and then only if the user ask for more paginate.",
+              "Found %d total results, showing first %d. "
+                  + "There are many matching assets. Are you looking for something specific? "
+                  + "Try narrowing with a service name, schema name, or more specific search term.",
               totalResults, cleanedResults.size()));
       result.put("hasMore", true);
+    }
+
+    try {
+      String serialized = JsonUtils.pojoToJson(result);
+      LOG.debug(
+          "[MCP] search_metadata response size: {} chars for query '{}'",
+          serialized.length(),
+          query);
+      if (serialized.length() > MAX_RESPONSE_CHARS) {
+        int targetCount =
+            Math.min(
+                Math.max(
+                    1,
+                    (int)
+                        (cleanedResults.size() * (MAX_RESPONSE_CHARS * 0.8) / serialized.length())),
+                cleanedResults.size());
+        List<Map<String, Object>> trimmed = new ArrayList<>(cleanedResults.subList(0, targetCount));
+        LOG.warn(
+            "[MCP] search_metadata response trimmed: {} chars -> {} results (was {})",
+            serialized.length(),
+            trimmed.size(),
+            cleanedResults.size());
+        result.put("results", trimmed);
+        result.put("returnedCount", trimmed.size());
+        result.put("hasMore", true);
+        result.put(
+            "message",
+            String.format(
+                "Response exceeded %d characters and was trimmed to %d of %d results. "
+                    + "There are many matching assets. Are you looking for something specific? "
+                    + "Try narrowing with a service name, schema, or specific name.",
+                MAX_RESPONSE_CHARS, trimmed.size(), totalResults));
+      }
+    } catch (RuntimeException e) {
+      LOG.warn("Failed to check response size for query '{}': {}", query, e.getMessage());
     }
 
     return result;

--- a/openmetadata-mcp/src/main/java/org/openmetadata/mcp/tools/SearchMetadataTool.java
+++ b/openmetadata-mcp/src/main/java/org/openmetadata/mcp/tools/SearchMetadataTool.java
@@ -303,6 +303,9 @@ public class SearchMetadataTool implements McpTool {
         if (source == null) continue;
 
         Map<String, Object> cleanedSource = cleanSearchResult(source, requestedFields);
+        if (hit.containsKey("_score")) {
+          cleanedSource.put("similarityScore", hit.get("_score"));
+        }
         cleanedResults.add(cleanedSource);
       }
     }

--- a/openmetadata-mcp/src/main/java/org/openmetadata/mcp/tools/SearchMetadataTool.java
+++ b/openmetadata-mcp/src/main/java/org/openmetadata/mcp/tools/SearchMetadataTool.java
@@ -49,7 +49,20 @@ public class SearchMetadataTool implements McpTool {
           "tier",
           "tableType",
           "columnNames",
-          "deleted");
+          "deleted",
+          "entityFQN",
+          "originEntityFQN",
+          "testCaseStatus",
+          "testCaseType",
+          "dataQualityDimension",
+          "testPlatforms",
+          "basic",
+          "lastResultTimestamp");
+
+  // Latest-result subset kept in test case search results; the full testCaseResult object
+  // (testResultValue, sample row counts, ...) is available via the 'fields' parameter.
+  private static final List<String> TEST_CASE_RESULT_SLIM_FIELDS =
+      List.of("testCaseStatus", "timestamp", "result");
 
   private static final List<String> DETAILED_EXCLUDE_KEYS =
       List.of(
@@ -408,6 +421,8 @@ public class SearchMetadataTool implements McpTool {
       }
     }
 
+    addSlimTestCaseResult(source, result);
+
     // Truncate long descriptions to optimize LLM context usage
     if (result.containsKey("description")) {
       Object descObj = result.get("description");
@@ -416,6 +431,23 @@ public class SearchMetadataTool implements McpTool {
       }
     }
     return result;
+  }
+
+  private static void addSlimTestCaseResult(
+      Map<String, Object> source, Map<String, Object> result) {
+    if (result.containsKey("testCaseResult")
+        || !(source.get("testCaseResult") instanceof Map<?, ?> testCaseResult)) {
+      return;
+    }
+    Map<String, Object> slim = new HashMap<>();
+    for (String field : TEST_CASE_RESULT_SLIM_FIELDS) {
+      if (testCaseResult.containsKey(field)) {
+        slim.put(field, testCaseResult.get(field));
+      }
+    }
+    if (!slim.isEmpty()) {
+      result.put("testCaseResult", slim);
+    }
   }
 
   public static Map<String, Object> createEmptyResponse() {

--- a/openmetadata-mcp/src/main/java/org/openmetadata/mcp/tools/SearchMetadataTool.java
+++ b/openmetadata-mcp/src/main/java/org/openmetadata/mcp/tools/SearchMetadataTool.java
@@ -1,7 +1,6 @@
 package org.openmetadata.mcp.tools;
 
 import static org.openmetadata.common.utils.CommonUtil.nullOrEmpty;
-import static org.openmetadata.service.search.SearchUtils.mapEntityTypesToIndexNames;
 import static org.openmetadata.service.security.DefaultAuthorizer.getSubjectContext;
 
 import com.fasterxml.jackson.databind.JsonNode;
@@ -100,9 +99,9 @@ public class SearchMetadataTool implements McpTool {
       Authorizer authorizer, CatalogSecurityContext securityContext, Map<String, Object> params)
       throws IOException {
     LOG.info("Executing searchMetadata with params: {}", params);
-    String query = params.containsKey("query") ? (String) params.get("query") : "*";
-    String entityType = params.containsKey("entityType") ? (String) params.get("entityType") : null;
-    String index = entityType == null ? "dataAsset" : mapEntityTypesToIndexNames(entityType);
+    String query = stringParam(params, "query", "*");
+    String entityType = stringParam(params, "entityType", null);
+    String index = resolveIndex(entityType);
 
     int size = 10;
     if (params.containsKey("size")) {
@@ -173,21 +172,25 @@ public class SearchMetadataTool implements McpTool {
     }
 
     List<String> requestedFields = new ArrayList<>();
-    if (params.containsKey("fields")) {
-      String fieldsParam = (String) params.get("fields");
-      if (fieldsParam != null && !fieldsParam.trim().isEmpty()) {
-        requestedFields =
-            List.of(fieldsParam.split(",")).stream()
-                .map(String::trim)
-                .filter(field -> !field.isEmpty())
-                .collect(Collectors.toList());
-      }
+    String fieldsParam = stringParam(params, "fields", null);
+    if (fieldsParam != null && !fieldsParam.trim().isEmpty()) {
+      requestedFields =
+          List.of(fieldsParam.split(",")).stream()
+              .map(String::trim)
+              .filter(field -> !field.isEmpty())
+              .collect(Collectors.toList());
     }
 
     String queryFilter = null;
-    if (params.containsKey("queryFilter")) {
-      queryFilter = (String) params.get("queryFilter");
-      JsonNode queryNode = JsonUtils.getObjectMapper().readTree(queryFilter);
+    Object queryFilterParam = params.get("queryFilter");
+    if (queryFilterParam != null) {
+      // LLM callers occasionally send the filter as a JSON object instead of a string; serialize
+      // non-string input back to JSON rather than failing on a cast.
+      String rawFilter =
+          queryFilterParam instanceof String stringValue
+              ? stringValue
+              : JsonUtils.pojoToJson(queryFilterParam);
+      JsonNode queryNode = JsonUtils.getObjectMapper().readTree(rawFilter);
 
       if (!queryNode.has("query")) {
         ObjectNode queryWrapper = JsonUtils.getObjectMapper().createObjectNode();
@@ -428,6 +431,34 @@ public class SearchMetadataTool implements McpTool {
   public static Map<String, Object> cleanSearchResponseObject(Map<String, Object> object) {
     DETAILED_EXCLUDE_KEYS.forEach(object::remove);
     return object;
+  }
+
+  /**
+   * Reads a parameter as a string without assuming the caller sent a string. LLM callers sometimes
+   * send numbers or other scalars (e.g. {@code "entityType": 123}); {@code toString} keeps the tool
+   * tolerant instead of failing on a class cast.
+   */
+  private static String stringParam(Map<String, Object> params, String key, String defaultValue) {
+    Object value = params.get(key);
+    return value == null ? defaultValue : value.toString();
+  }
+
+  /**
+   * Resolves the search index from the requested entity type using the authoritative index registry
+   * instead of a hand-maintained switch. A registered entity type resolves to its own single-type
+   * index, so results are correctly scoped (fixing #27796, where unlisted types fell back to the
+   * broad dataAsset alias and leaked other types). Null, unregistered, wildcard, or comma-separated
+   * input is not a registry key and falls back to dataAsset, preserving the prior graceful default
+   * rather than erroring or widening the search.
+   */
+  @VisibleForTesting
+  static String resolveIndex(String entityType) {
+    String index = "dataAsset";
+    if (!nullOrEmpty(entityType)
+        && Entity.getSearchRepository().getIndexMapping(entityType) != null) {
+      index = entityType;
+    }
+    return index;
   }
 
   /**

--- a/openmetadata-mcp/src/main/java/org/openmetadata/mcp/tools/SearchMetadataTool.java
+++ b/openmetadata-mcp/src/main/java/org/openmetadata/mcp/tools/SearchMetadataTool.java
@@ -87,7 +87,13 @@ public class SearchMetadataTool implements McpTool {
           "columnNamesFuzzy",
           "descriptionStatus",
           "domains",
-          "embeddings");
+          "embeddings",
+          "embedding",
+          "textToEmbed",
+          "textToLLMContext",
+          "fingerprint",
+          "chunkCount",
+          "chunkIndex");
 
   @Override
   public Map<String, Object> execute(

--- a/openmetadata-mcp/src/main/java/org/openmetadata/mcp/tools/SemanticSearchTool.java
+++ b/openmetadata-mcp/src/main/java/org/openmetadata/mcp/tools/SemanticSearchTool.java
@@ -7,6 +7,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
+import org.openmetadata.mcp.util.McpParams;
+import org.openmetadata.mcp.util.McpResponseTrim;
 import org.openmetadata.schema.utils.JsonUtils;
 import org.openmetadata.service.Entity;
 import org.openmetadata.service.limits.Limits;
@@ -23,8 +25,6 @@ public class SemanticSearchTool implements McpTool {
   private static final int DEFAULT_K = 100;
   private static final int MAX_K = 10_000;
   private static final double DEFAULT_THRESHOLD = 0.0;
-  private static final int DESCRIPTION_MAX_LENGTH = 500;
-  private static final int DESCRIPTION_TRUNCATE_LENGTH = 450;
 
   @Override
   public Map<String, Object> execute(
@@ -47,16 +47,16 @@ public class SemanticSearchTool implements McpTool {
       return errorResponse("Vector search service is not initialized");
     }
 
-    int size = parseIntParam(params, "size", DEFAULT_SIZE);
+    int size = McpParams.getInt(params, "size", DEFAULT_SIZE);
     size = Math.min(Math.max(size, 1), MAX_SIZE);
 
-    int from = parseIntParam(params, "from", 0);
+    int from = McpParams.getInt(params, "from", 0);
     from = Math.max(from, 0);
 
-    int k = parseIntParam(params, "k", DEFAULT_K);
+    int k = McpParams.getInt(params, "k", DEFAULT_K);
     k = Math.min(Math.max(k, 1), MAX_K);
 
-    double threshold = parseDoubleParam(params, "threshold", DEFAULT_THRESHOLD);
+    double threshold = McpParams.getDouble(params, "threshold", DEFAULT_THRESHOLD);
     threshold = Math.min(Math.max(threshold, 0.0), 1.0);
 
     Map<String, List<String>> filters = parseFilters(params);
@@ -67,7 +67,7 @@ public class SemanticSearchTool implements McpTool {
       return buildResponse(query, response, size);
     } catch (Exception e) {
       LOG.error("Semantic search failed: {}", e.getMessage(), e);
-      return errorResponse("Semantic search failed: " + e.getMessage());
+      return errorResponse("Semantic search failed: " + McpResponseTrim.safeMessage(e));
     }
   }
 
@@ -144,11 +144,9 @@ public class SemanticSearchTool implements McpTool {
 
     if (hit.containsKey("description")) {
       Object descObj = hit.get("description");
-      if (descObj instanceof String desc && desc.length() > DESCRIPTION_MAX_LENGTH) {
-        cleaned.put("description", desc.substring(0, DESCRIPTION_TRUNCATE_LENGTH) + "...");
-      } else {
-        cleaned.put("description", descObj);
-      }
+      cleaned.put(
+          "description",
+          descObj instanceof String desc ? McpResponseTrim.truncateDescription(desc) : descObj);
     }
 
     return cleaned;
@@ -198,42 +196,6 @@ public class SemanticSearchTool implements McpTool {
     }
 
     return Collections.emptyMap();
-  }
-
-  private int parseIntParam(Map<String, Object> params, String key, int defaultValue) {
-    if (!params.containsKey(key)) {
-      return defaultValue;
-    }
-    Object val = params.get(key);
-    if (val instanceof Number number) {
-      return number.intValue();
-    }
-    if (val instanceof String string) {
-      try {
-        return Integer.parseInt(string);
-      } catch (NumberFormatException e) {
-        return defaultValue;
-      }
-    }
-    return defaultValue;
-  }
-
-  private double parseDoubleParam(Map<String, Object> params, String key, double defaultValue) {
-    if (!params.containsKey(key)) {
-      return defaultValue;
-    }
-    Object val = params.get(key);
-    if (val instanceof Number number) {
-      return number.doubleValue();
-    }
-    if (val instanceof String string) {
-      try {
-        return Double.parseDouble(string);
-      } catch (NumberFormatException e) {
-        return defaultValue;
-      }
-    }
-    return defaultValue;
   }
 
   private Map<String, Object> errorResponse(String message) {

--- a/openmetadata-mcp/src/main/java/org/openmetadata/mcp/usage/McpUsageRecorder.java
+++ b/openmetadata-mcp/src/main/java/org/openmetadata/mcp/usage/McpUsageRecorder.java
@@ -39,7 +39,27 @@ public final class McpUsageRecorder {
 
   private McpUsageRecorder() {}
 
-  public static void record(String toolName, String userName, boolean success) {
+  /**
+   * Records a tool invocation with the full Phase 3 payload. The legacy 3-arg overload below is
+   * kept so existing call sites and tests compile unchanged. New call sites should call this one
+   * directly with the latency timer reading + error category + client name they already have.
+   *
+   * @param toolName name of the tool that was invoked
+   * @param userName principal name from the security context
+   * @param success true when the tool returned without an error result
+   * @param latencyMs wall-clock duration in milliseconds, or null when timing wasn't captured
+   * @param errorCategory bucket the failure falls into (null on success or when we couldn't
+   *     classify the exception)
+   * @param clientName best-effort name of the calling client (Claude Desktop / Cursor / VS Code /
+   *     CLI), or null when the client didn't identify itself
+   */
+  public static void record(
+      String toolName,
+      String userName,
+      boolean success,
+      Long latencyMs,
+      McpToolCallUsage.ErrorCategory errorCategory,
+      String clientName) {
     try {
       App app = resolveMcpApp();
       if (app == null) {
@@ -55,7 +75,10 @@ public final class McpUsageRecorder {
               .withExtension(AppExtension.ExtensionType.LIMITS)
               .withToolName(toolName)
               .withUserName(userName)
-              .withSuccess(success);
+              .withSuccess(success)
+              .withLatencyMs(latencyMs)
+              .withErrorCategory(errorCategory)
+              .withClientName(clientName);
       getDao().insert(JsonUtils.pojoToJson(usage), AppExtension.ExtensionType.LIMITS.toString());
     } catch (Exception e) {
       LOG.warn(
@@ -65,6 +88,14 @@ public final class McpUsageRecorder {
           success,
           e.getMessage());
     }
+  }
+
+  /**
+   * Backwards-compatible overload. New call sites should use the 6-arg variant so the row gets
+   * the full Phase 3 payload.
+   */
+  public static void record(String toolName, String userName, boolean success) {
+    record(toolName, userName, success, null, null, null);
   }
 
   private static App resolveMcpApp() {

--- a/openmetadata-mcp/src/main/java/org/openmetadata/mcp/util/McpParams.java
+++ b/openmetadata-mcp/src/main/java/org/openmetadata/mcp/util/McpParams.java
@@ -1,0 +1,71 @@
+package org.openmetadata.mcp.util;
+
+import java.util.Map;
+
+/**
+ * Lenient coercion of MCP tool arguments. MCP clients send arguments as an untyped {@code
+ * Map<String, Object>} where a numeric value may arrive as a JSON number <em>or</em> a string, so
+ * every read tool was carrying its own {@code parseIntParam}/{@code parseBooleanParam}/{@code
+ * parseDoubleParam} copy. This centralizes that logic.
+ *
+ * <p>All three readers share the same fall-through contract: a missing key, a present-but-null value
+ * and an unparseable value all yield the supplied default. Range clamping (depth/size bounds) stays
+ * with the caller because the valid range is tool-specific.
+ */
+public final class McpParams {
+
+  private McpParams() {}
+
+  public static int getInt(Map<String, Object> params, String key, int defaultValue) {
+    int result = defaultValue;
+    Object value = params.get(key);
+    if (value instanceof Number number) {
+      result = number.intValue();
+    } else if (value instanceof String string) {
+      result = parseInt(string, defaultValue);
+    }
+    return result;
+  }
+
+  public static double getDouble(Map<String, Object> params, String key, double defaultValue) {
+    double result = defaultValue;
+    Object value = params.get(key);
+    if (value instanceof Number number) {
+      result = number.doubleValue();
+    } else if (value instanceof String string) {
+      result = parseDouble(string, defaultValue);
+    }
+    return result;
+  }
+
+  public static boolean getBoolean(Map<String, Object> params, String key, boolean defaultValue) {
+    boolean result = defaultValue;
+    Object value = params.get(key);
+    if (value instanceof Boolean bool) {
+      result = bool;
+    } else if (value instanceof String string) {
+      result = Boolean.parseBoolean(string);
+    }
+    return result;
+  }
+
+  private static int parseInt(String value, int defaultValue) {
+    int result = defaultValue;
+    try {
+      result = Integer.parseInt(value);
+    } catch (NumberFormatException e) {
+      result = defaultValue;
+    }
+    return result;
+  }
+
+  private static double parseDouble(String value, double defaultValue) {
+    double result = defaultValue;
+    try {
+      result = Double.parseDouble(value);
+    } catch (NumberFormatException e) {
+      result = defaultValue;
+    }
+    return result;
+  }
+}

--- a/openmetadata-mcp/src/main/java/org/openmetadata/mcp/util/McpResponseTrim.java
+++ b/openmetadata-mcp/src/main/java/org/openmetadata/mcp/util/McpResponseTrim.java
@@ -1,0 +1,120 @@
+package org.openmetadata.mcp.util;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import org.openmetadata.schema.utils.JsonUtils;
+
+/**
+ * Shared payload-trimming primitives for MCP tools. The truncation budgets, the response size cap,
+ * the {@code substring(0, n) + "..."} truncate logic and the embedding/vector field list were each
+ * copy-pasted across {@code GetLineageTool}, {@code RootCauseAnalysisTool}, {@code
+ * SearchMetadataTool} and {@code SemanticSearchTool}. Centralizing them here makes a change to any
+ * limit a one-line edit and keeps every tool's trimming behaviour identical.
+ *
+ * <p>This holds primitives only — each tool keeps ownership of <em>what</em> to trim. Tools that can
+ * trim intelligently (drop whole results, emit an actionable depth hint) do so themselves; {@link
+ * #oversizedEnvelope} is only the generic last-resort stub used by the dispatch-level safety net.
+ */
+public final class McpResponseTrim {
+
+  /** SQL is the single heaviest lineage field; keep the gist of the transform, cap the size. */
+  public static final int SQL_MAX_LENGTH = 500;
+
+  /**
+   * Free-text markdown (pipeline / edge descriptions) is capped for the same reason as SQL: a single
+   * long doc string can be shared across many edges and reintroduce bloat.
+   */
+  public static final int TEXT_MAX_LENGTH = 500;
+
+  /** Description length above which the search/semantic tools truncate. */
+  public static final int DESCRIPTION_MAX_LENGTH = 500;
+
+  /**
+   * Where an over-length description is cut. Sits below {@link #DESCRIPTION_MAX_LENGTH} so the result
+   * lands comfortably under the threshold rather than right at it.
+   */
+  public static final int DESCRIPTION_TRUNCATE_LENGTH = 450;
+
+  /** Final safety net: even slimmed, a wide payload can blow the LLM/MCP context limit. */
+  public static final int MAX_RESPONSE_CHARS = 100_000;
+
+  /**
+   * Elasticsearch index-only document fields — the embedding vector and the RAG source/context text
+   * used to build it. Each adds several kB per node and carries no value for an LLM reading the
+   * result, so search/lineage documents drop them before returning.
+   */
+  public static final List<String> VECTOR_NOISE_FIELDS =
+      List.of(
+          "embeddings",
+          "embedding",
+          "textToEmbed",
+          "textToLLMContext",
+          "fingerprint",
+          "chunkCount",
+          "chunkIndex");
+
+  private static final String NO_MESSAGE = "<no message>";
+
+  private McpResponseTrim() {}
+
+  /** Cuts {@code value} to {@code maxLength} characters plus an ellipsis when it is longer. */
+  public static String truncate(String value, int maxLength) {
+    String result = value;
+    if (value != null && value.length() > maxLength) {
+      result = value.substring(0, maxLength) + "...";
+    }
+    return result;
+  }
+
+  /**
+   * Truncates a free-text description using the search/semantic convention: only when it exceeds
+   * {@link #DESCRIPTION_MAX_LENGTH}, cut to {@link #DESCRIPTION_TRUNCATE_LENGTH} so the truncated
+   * result sits below the threshold. Distinct from {@link #truncate(String, int)} (cut-at-max) on
+   * purpose — collapsing the two would change the output of half the tools.
+   */
+  public static String truncateDescription(String value) {
+    String result = value;
+    if (value != null && value.length() > DESCRIPTION_MAX_LENGTH) {
+      result = value.substring(0, DESCRIPTION_TRUNCATE_LENGTH) + "...";
+    }
+    return result;
+  }
+
+  /** Serialized JSON length of a result, used by the size-budget checks. */
+  public static int serializedLength(Object result) {
+    return JsonUtils.pojoToJson(result).length();
+  }
+
+  /**
+   * Generic oversized-response envelope for the dispatch-level safety net (tools without a smarter
+   * per-tool trim). Stays on the success path ({@code truncated:true}) because a deliberate cap is
+   * not a failure the caller can retry. Merges the supplied identity fields so the client can still
+   * tell which call was capped.
+   */
+  public static Map<String, Object> oversizedEnvelope(
+      int sizeChars, Map<String, Object> identity, String advice) {
+    Map<String, Object> envelope = new LinkedHashMap<>();
+    if (identity != null) {
+      envelope.putAll(identity);
+    }
+    envelope.put("truncated", Boolean.TRUE);
+    envelope.put("responseSizeChars", sizeChars);
+    envelope.put("maxResponseChars", MAX_RESPONSE_CHARS);
+    envelope.put("message", advice);
+    return envelope;
+  }
+
+  /**
+   * Returns the throwable's message, or a placeholder when it is null, so a client-facing payload
+   * never renders {@code "... null"}. Use only for the message surfaced to the caller — logging
+   * should keep passing the throwable itself for the stack trace.
+   */
+  public static String safeMessage(Throwable t) {
+    String result = NO_MESSAGE;
+    if (t != null && t.getMessage() != null) {
+      result = t.getMessage();
+    }
+    return result;
+  }
+}

--- a/openmetadata-mcp/src/main/resources/json/data/mcp/tools.json
+++ b/openmetadata-mcp/src/main/resources/json/data/mcp/tools.json
@@ -295,7 +295,7 @@
     },
     {
       "name": "get_entity_lineage",
-      "description": "Get detailed information about lineage (upstream/downstream dependencies) of a specific entity. Use this for root cause (upstream entities) or impact (downstream entities) analysis and explaining dependencies between entities.",
+      "description": "Get a compact lineage graph (upstream/downstream dependencies) of a specific entity. Use this for root cause (upstream entities) or impact (downstream entities) analysis and explaining dependencies between entities. By default the response is table-level and optimized for size: each edge carries the connected assets' names, FQNs, types and relationship info (pipeline or sql), with long SQL truncated. Set includeColumnLineage=true only when the user explicitly asks about column-level lineage.",
       "parameters": {
         "description": "Fqn is the fully qualified name of the entity. Entity type could be table, topic etc.",
         "type": "object",
@@ -317,6 +317,11 @@
             "type": "integer",
             "description": "Number of downstream hops to traverse. Default is 3, maximum is 10 to prevent excessive response size.",
             "default": 3
+          },
+          "includeColumnLineage": {
+            "type": "boolean",
+            "description": "Include column-level lineage mappings on each edge. Defaults to false to keep the response table-level and small. Set to true only when the user explicitly needs column-to-column lineage, as it can significantly increase response size on wide tables.",
+            "default": false
           }
         },
         "required": [

--- a/openmetadata-mcp/src/main/resources/json/data/mcp/tools.json
+++ b/openmetadata-mcp/src/main/resources/json/data/mcp/tools.json
@@ -182,7 +182,7 @@
     },
     {
       "name": "get_entity_details",
-      "description": "Get detailed information about a specific entity by its fully qualified name, including its custom properties (returned under the 'extension' field). IMPORTANT: Use the 'fullyQualifiedName' and 'entityType' values directly from search_metadata or semantic_search results — do not construct the FQN manually. Response is optimized for LLM context by excluding verbose metadata fields.",
+      "description": "Get detailed information about a specific entity by its fully qualified name, including its custom properties (returned under the 'extension' field). IMPORTANT: Use the 'fullyQualifiedName' and 'entityType' values directly from search_metadata or semantic_search results — do not construct the FQN manually. Response is optimized for LLM context: verbose metadata fields are excluded, and per-column descriptions and raw schema/model SQL are truncated at 500 characters (marked with 'columnDescriptionsTruncated' / 'schemaDefinitionTruncated', or 'sqlTruncated' inside 'dataModel', when cut). The entity-level description is always returned in full.",
       "parameters": {
         "description": "Use 'fullyQualifiedName' and 'entityType' from search results directly.",
         "type": "object",

--- a/openmetadata-mcp/src/main/resources/json/data/mcp/tools.json
+++ b/openmetadata-mcp/src/main/resources/json/data/mcp/tools.json
@@ -763,7 +763,7 @@
     },
     {
       "name": "root_cause_analysis",
-      "description": "Performs comprehensive root cause analysis via data quality lineage. First identifies upstream failures that may be causing issues for the specified asset. If failures are found, automatically analyzes downstream impact to show which assets may be affected. Returns both upstream root causes and downstream impact analysis. In the response 'status' indicates whether upstream failures were found. If 'status' is 'failed', the 'upstreamAnalysis' can be used to identify the nodes and edges leading to failures and downstreamAnalysis can tell what all nodes in downstream are impacted. If 'status' is 'success', it means no upstream failures were found, and downstream impact analysis was not performed.",
+      "description": "Performs comprehensive root cause analysis via data quality lineage. First identifies upstream failures that may be causing issues for the specified asset. If failures are found, automatically analyzes downstream impact to show which assets may be affected. Returns both upstream root causes and downstream impact analysis. In the response 'status' indicates whether upstream failures were found. If 'status' is 'failed', the 'upstreamAnalysis' can be used to identify the nodes and edges leading to failures and downstreamAnalysis can tell what all nodes in downstream are impacted. If 'status' is 'success', it means no upstream failures were found, and downstream impact analysis was not performed. Responses are compact and table-level by default: node and edge details are trimmed and SQL queries truncated to keep the payload within LLM context limits. Set 'includeColumnLineage' to true only when column-level lineage is needed.",
       "parameters": {
         "type": "object",
         "properties": {
@@ -788,6 +788,11 @@
           "includeDeleted": {
             "type": "boolean",
             "description": "Whether to include deleted entities in the analysis. Default is false.",
+            "default": false
+          },
+          "includeColumnLineage": {
+            "type": "boolean",
+            "description": "Whether to include column-level lineage on upstream/downstream edges. Default is false (table-level only) to keep the response compact. Set to true only when column-to-column lineage is required.",
             "default": false
           },
           "entityType": {

--- a/openmetadata-mcp/src/main/resources/json/data/mcp/tools.json
+++ b/openmetadata-mcp/src/main/resources/json/data/mcp/tools.json
@@ -2,7 +2,7 @@
   "tools": [
     {
       "name": "search_metadata",
-      "description": "Keyword-based search for data assets in OpenMetadata. Best when you know specific names, owners, tags, tiers, services, or column names. Use this for exact lookups (e.g., 'find table X', 'tables owned by team Y'), filtering by metadata properties, counting assets, and aggregations. Supports pagination and advanced OpenSearch DSL queries. Choose this over semantic_search when the query targets known identifiers or structured attributes. Results include 'fullyQualifiedName' and 'entityType' — pass these directly to get_entity_details for full entity information.",
+      "description": "Keyword-based search for data assets and data quality entities in OpenMetadata. Best when you know specific names, owners, tags, tiers, services, or column names. Use this for exact lookups (e.g., 'find table X', 'tables owned by team Y'), filtering by metadata properties, counting assets, and aggregations. Also searches data quality test cases and test suites when entityType is 'testCase' or 'testSuite' — these are NOT part of the default search scope, so always set entityType explicitly for data quality questions. Supports pagination and advanced OpenSearch DSL queries. Choose this over semantic_search when the query targets known identifiers or structured attributes. Results include 'fullyQualifiedName' and 'entityType' — pass these directly to get_entity_details for full entity information.",
       "parameters": {
         "description": "Use 'query' for keyword search or 'queryFilter' for advanced OpenSearch DSL. Best for exact matches and filtering by metadata properties.",
         "type": "object",
@@ -13,7 +13,7 @@
           },
           "entityType": {
             "type": "string",
-            "description": "Filter by entity type (auto-detected if not specified). Use singular form: table, dashboard, topic, pipeline, database, databaseService, glossary, glossaryTerm, mlmodel, container, chart, metric, user, team, domain, dataProduct."
+            "description": "Filter by entity type (auto-detected if not specified). Use singular form: table, dashboard, topic, pipeline, database, databaseService, glossary, glossaryTerm, mlmodel, container, chart, metric, user, team, domain, dataProduct. Data quality types: testCase (individual data quality tests, includes the tested asset's FQN in 'entityFQN' and latest status in 'testCaseStatus'), testSuite (collections of test cases). Data quality entities are only searched when explicitly set as entityType."
           },
           "queryFilter": {
             "type": "string",
@@ -36,7 +36,7 @@
           },
           "fields": {
             "type": "string",
-            "description": "Comma-separated additional fields to include. Default returns: name, displayName, fullyQualifiedName, description, entityType, service, database, databaseSchema, serviceType, href, tags, owners, tier, tableType, columnNames.\n\nAdditional fields by entity type:\n- Table entities: columns, schemaDefinition, queries, upstreamLineage, entityRelationship\n- Topic entities: messageSchema, partitions, replicationFactor  \n- Dashboard entities: charts, dataModels, project\n- Pipeline entities: tasks, pipelineUrl, scheduleInterval\n- All entities: createdAt, updatedAt, changeDescription, extension, domain, dataProducts, lifeCycle, sourceHash\n\nExample: 'columns,queries' for table column details and sample queries."
+            "description": "Comma-separated additional fields to include. Default returns: name, displayName, fullyQualifiedName, description, entityType, service, database, databaseSchema, serviceType, href, tags, owners, tier, tableType, columnNames.\n\nAdditional fields by entity type:\n- Table entities: columns, schemaDefinition, queries, upstreamLineage, entityRelationship\n- Topic entities: messageSchema, partitions, replicationFactor  \n- Dashboard entities: charts, dataModels, project\n- Pipeline entities: tasks, pipelineUrl, scheduleInterval\n- TestCase entities: testCaseResult (full latest result; a slim status/timestamp/result version is returned by default), testDefinition, testSuite, testSuites, parameterValues, table\n- All entities: createdAt, updatedAt, changeDescription, extension, domain, dataProducts, lifeCycle, sourceHash\n\nExample: 'columns,queries' for table column details and sample queries."
           },
           "includeAggregations": {
             "type": "boolean",
@@ -95,6 +95,26 @@
           {
             "description": "Advanced - Aggregation query for counting",
             "queryFilter": "{\"size\": 0, \"query\": {\"bool\": {\"must\": [{\"term\": {\"entityType\": \"databaseService\"}}, {\"term\": {\"serviceType\": \"BigQuery\"}}]}}, \"aggs\": {\"total_count\": {\"value_count\": {\"field\": \"_id\"}}}}"
+          },
+          {
+            "description": "Data quality - Find test cases by name or description",
+            "query": "column values to be unique",
+            "entityType": "testCase"
+          },
+          {
+            "description": "Data quality - List test suites",
+            "query": "*",
+            "entityType": "testSuite"
+          },
+          {
+            "description": "Data quality - All test cases on a table and its columns (entityFQN is a lowercase keyword field; use lowercase prefix of the table FQN)",
+            "entityType": "testCase",
+            "queryFilter": "{\"bool\": {\"must\": [{\"prefix\": {\"entityFQN\": \"sample_data.ecommerce_db.shopify.dim_address\"}}]}}"
+          },
+          {
+            "description": "Data quality - Failed test cases (testCaseResult.testCaseStatus is a lowercase keyword field)",
+            "entityType": "testCase",
+            "queryFilter": "{\"bool\": {\"must\": [{\"term\": {\"testCaseResult.testCaseStatus\": \"failed\"}}]}}"
           }
         ]
       }
@@ -112,7 +132,7 @@
           },
           "filters": {
             "type": "object",
-            "description": "Optional filters to narrow results. Keys are field names and values are arrays of allowed values. Supported filter fields: 'entityType' (e.g., ['table', 'dashboard']), 'service' (e.g., ['BigQuery', 'Snowflake']), 'tags' (e.g., ['PII.Sensitive']). Example: {\"entityType\": [\"table\"], \"service\": [\"BigQuery\"]}.",
+            "description": "Optional filters to narrow results. Keys are field names and values are arrays of allowed values. Supported filter fields: 'entityType' (e.g., ['table', 'dashboard'], also data quality types ['testCase', 'testSuite']), 'service' (e.g., ['BigQuery', 'Snowflake']), 'tags' (e.g., ['PII.Sensitive']). Example: {\"entityType\": [\"table\"], \"service\": [\"BigQuery\"]}.",
             "additionalProperties": {
               "type": "array",
               "items": {
@@ -169,7 +189,7 @@
         "properties": {
           "entityType": {
             "type": "string",
-            "description": "Type of entity (e.g., table, dashboard, topic, pipeline). Use the 'entityType' value from search results."
+            "description": "Type of entity (e.g., table, dashboard, topic, pipeline, testCase, testSuite). Use the 'entityType' value from search results. For testSuite, the response includes a 'summary' field with total/passed/failed test counts."
           },
           "fqn": {
             "type": "string",

--- a/openmetadata-mcp/src/main/resources/json/data/mcp/tools.json
+++ b/openmetadata-mcp/src/main/resources/json/data/mcp/tools.json
@@ -26,7 +26,7 @@
           },
           "size": {
             "type": "integer",
-            "description": "Number of results to return. Default is 10, we can iteratively page through results by increasing 'from'. Maximum allowed is 50.",
+            "description": "Number of results to return. Default is 10. For broad or generic queries (e.g. 'show all tables'), keep size small (5-10), as results are summaries; use get_entity_details for full entity info. Only increase size when the query is specific enough that results will be narrow and focused. Maximum allowed is 50.",
             "default": 10
           },
           "includeDeleted": {
@@ -73,7 +73,7 @@
           {
             "description": "Simple search with pagination",
             "query": "tables",
-            "size": 20,
+            "size": 10,
             "from": 0
           },
           {

--- a/openmetadata-mcp/src/test/java/org/openmetadata/mcp/AuthEnrichedMcpContextExtractorTest.java
+++ b/openmetadata-mcp/src/test/java/org/openmetadata/mcp/AuthEnrichedMcpContextExtractorTest.java
@@ -1,0 +1,99 @@
+/*
+ *  Copyright 2025 Collate
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.openmetadata.mcp;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit-level coverage for the User-Agent -> client name heuristic. The headers we recognise here
+ * are the ones the Billing > MCP page renders explicitly; an unknown UA still produces a sensible
+ * label so a new client surfaces in the per-user breakdown without an extractor change.
+ */
+class AuthEnrichedMcpContextExtractorTest {
+
+  @Test
+  void recognisesClaudeDesktop() {
+    assertThat(
+            AuthEnrichedMcpContextExtractor.resolveClientName(
+                "Claude-Desktop/1.4.2 (macOS; arm64)"))
+        .isEqualTo("Claude Desktop");
+  }
+
+  @Test
+  void recognisesClaudeCli() {
+    assertThat(AuthEnrichedMcpContextExtractor.resolveClientName("claude-cli/0.9.1"))
+        .isEqualTo("Claude CLI");
+  }
+
+  @Test
+  void recognisesCursor() {
+    assertThat(AuthEnrichedMcpContextExtractor.resolveClientName("Cursor/0.42.3"))
+        .isEqualTo("Cursor");
+  }
+
+  @Test
+  void recognisesVSCode() {
+    assertThat(AuthEnrichedMcpContextExtractor.resolveClientName("Visual Studio Code/1.92.0"))
+        .isEqualTo("VS Code");
+  }
+
+  @Test
+  void vsCodeWithClaudeExtensionDoesNotMisclassifyAsCli() {
+    assertThat(
+            AuthEnrichedMcpContextExtractor.resolveClientName(
+                "Visual Studio Code/1.92.0 claude-ext/1.0"))
+        .isEqualTo("VS Code");
+    assertThat(AuthEnrichedMcpContextExtractor.resolveClientName("vscode-claude-ext/0.1"))
+        .isEqualTo("VS Code");
+  }
+
+  @Test
+  void claudeCodeIsRecognisedAsCli() {
+    assertThat(AuthEnrichedMcpContextExtractor.resolveClientName("claude-code/0.9.1"))
+        .isEqualTo("Claude CLI");
+  }
+
+  @Test
+  void unknownAgentFallsBackToCapitalisedProductToken() {
+    assertThat(AuthEnrichedMcpContextExtractor.resolveClientName("zed/0.150")).isEqualTo("Zed");
+    assertThat(AuthEnrichedMcpContextExtractor.resolveClientName("someTool/2.0 extra/info"))
+        .isEqualTo("SomeTool");
+  }
+
+  @Test
+  void nullAndBlankAgentsReturnNull() {
+    assertThat(AuthEnrichedMcpContextExtractor.resolveClientName(null)).isNull();
+    assertThat(AuthEnrichedMcpContextExtractor.resolveClientName("")).isNull();
+    assertThat(AuthEnrichedMcpContextExtractor.resolveClientName("   ")).isNull();
+  }
+
+  @Test
+  void oversizedFallbackTokenIsCappedToMaxLength() {
+    String huge = "x".repeat(500) + "/1.0";
+
+    String resolved = AuthEnrichedMcpContextExtractor.resolveClientName(huge);
+
+    assertThat(resolved).isNotNull();
+    assertThat(resolved.length()).isLessThanOrEqualTo(64);
+  }
+
+  @Test
+  void controlCharactersAreStrippedFromResolvedClient() {
+    String userAgent = "MyTool\u0001\u0007/1.0";
+
+    assertThat(AuthEnrichedMcpContextExtractor.resolveClientName(userAgent)).isEqualTo("MyTool");
+  }
+}

--- a/openmetadata-mcp/src/test/java/org/openmetadata/mcp/McpImpersonationTest.java
+++ b/openmetadata-mcp/src/test/java/org/openmetadata/mcp/McpImpersonationTest.java
@@ -60,13 +60,16 @@ public class McpImpersonationTest {
     doAnswer(
             invocation -> {
               capturedImpersonation.set(ImpersonationContext.getImpersonatedBy());
-              return McpSchema.CallToolResult.builder()
-                  .content(List.of(new McpSchema.TextContent("{}")))
-                  .isError(false)
-                  .build();
+              return new DefaultToolContext.CallToolOutcome(
+                  McpSchema.CallToolResult.builder()
+                      .content(List.of(new McpSchema.TextContent("{}")))
+                      .isError(false)
+                      .build(),
+                  0L,
+                  null);
             })
         .when(toolContext)
-        .callTool(any(), any(), anyString(), any(), any());
+        .callToolWithMetadata(any(), any(), anyString(), any(), any());
 
     TestMcpServer server = new TestMcpServer(toolContext, jwtFilter, authorizer, limits);
     McpSchema.Tool tool = McpSchema.Tool.builder().name("test_tool").description("desc").build();
@@ -95,12 +98,15 @@ public class McpImpersonationTest {
     when(jwtFilter.getCatalogSecurityContext(anyString())).thenReturn(securityContext);
 
     DefaultToolContext toolContext = mock(DefaultToolContext.class);
-    when(toolContext.callTool(any(), any(), anyString(), any(), any()))
+    when(toolContext.callToolWithMetadata(any(), any(), anyString(), any(), any()))
         .thenReturn(
-            McpSchema.CallToolResult.builder()
-                .content(List.of(new McpSchema.TextContent("{}")))
-                .isError(false)
-                .build());
+            new DefaultToolContext.CallToolOutcome(
+                McpSchema.CallToolResult.builder()
+                    .content(List.of(new McpSchema.TextContent("{}")))
+                    .isError(false)
+                    .build(),
+                0L,
+                null));
 
     TestMcpServer server =
         new TestMcpServer(toolContext, jwtFilter, mock(Authorizer.class), mock(Limits.class));
@@ -130,7 +136,7 @@ public class McpImpersonationTest {
     when(jwtFilter.getCatalogSecurityContext(anyString())).thenReturn(securityContext);
 
     DefaultToolContext toolContext = mock(DefaultToolContext.class);
-    when(toolContext.callTool(any(), any(), eq("error_tool"), any(), any()))
+    when(toolContext.callToolWithMetadata(any(), any(), eq("error_tool"), any(), any()))
         .thenThrow(new RuntimeException("tool failed"));
 
     TestMcpServer server =
@@ -174,13 +180,16 @@ public class McpImpersonationTest {
               } else {
                 secondCall.set(ImpersonationContext.getImpersonatedBy());
               }
-              return McpSchema.CallToolResult.builder()
-                  .content(List.of(new McpSchema.TextContent("{}")))
-                  .isError(false)
-                  .build();
+              return new DefaultToolContext.CallToolOutcome(
+                  McpSchema.CallToolResult.builder()
+                      .content(List.of(new McpSchema.TextContent("{}")))
+                      .isError(false)
+                      .build(),
+                  0L,
+                  null);
             })
         .when(toolContext)
-        .callTool(any(), any(), anyString(), any(), any());
+        .callToolWithMetadata(any(), any(), anyString(), any(), any());
 
     TestMcpServer server =
         new TestMcpServer(toolContext, jwtFilter, mock(Authorizer.class), mock(Limits.class));

--- a/openmetadata-mcp/src/test/java/org/openmetadata/mcp/server/auth/handlers/RegistrationHandlerTest.java
+++ b/openmetadata-mcp/src/test/java/org/openmetadata/mcp/server/auth/handlers/RegistrationHandlerTest.java
@@ -91,6 +91,7 @@ class RegistrationHandlerTest {
     OAuthClientInformation result = handler.handle(metadata).join();
 
     assertThat(result.getTokenEndpointAuthMethod()).isEqualTo("client_secret_post");
+    assertThat(result.getClientSecret()).isNotNull().isNotEmpty();
   }
 
   @Test
@@ -254,6 +255,46 @@ class RegistrationHandlerTest {
 
     assertThat(result.getTokenEndpointAuthMethod()).isEqualTo("none");
     verify(clientRepository).register(any());
+  }
+
+  /**
+   * Regression for PR #28552: a public client (token_endpoint_auth_method=none) MUST NOT be issued a
+   * client secret. Before the fix the secret was generated unconditionally, so the token endpoint
+   * then demanded a secret the public PKCE client (Cursor, ChatGPT) never had, failing with
+   * "Client secret required" (401). Public clients are secured by PKCE, not a secret.
+   */
+  @Test
+  void testPublicClient_none_issuesNoSecret() {
+    OAuthClientMetadata metadata = validMetadata();
+    metadata.setTokenEndpointAuthMethod("none");
+
+    OAuthClientInformation result = handler.handle(metadata).join();
+
+    assertThat(result.getClientSecret()).isNull();
+    assertThat(result.getClientSecretExpiresAt()).isNull();
+    verify(clientRepository).register(any());
+  }
+
+  @Test
+  void testConfidentialClient_clientSecretPost_issuesSecret() {
+    OAuthClientMetadata metadata = validMetadata();
+    metadata.setTokenEndpointAuthMethod("client_secret_post");
+
+    OAuthClientInformation result = handler.handle(metadata).join();
+
+    assertThat(result.getClientSecret()).isNotNull().isNotEmpty();
+    assertThat(result.getClientSecretExpiresAt()).isEqualTo(0L);
+  }
+
+  @Test
+  void testConfidentialClient_clientSecretBasic_issuesSecret() {
+    OAuthClientMetadata metadata = validMetadata();
+    metadata.setTokenEndpointAuthMethod("client_secret_basic");
+
+    OAuthClientInformation result = handler.handle(metadata).join();
+
+    assertThat(result.getClientSecret()).isNotNull().isNotEmpty();
+    assertThat(result.getClientSecretExpiresAt()).isEqualTo(0L);
   }
 
   @Test

--- a/openmetadata-mcp/src/test/java/org/openmetadata/mcp/tools/DefaultToolContextTest.java
+++ b/openmetadata-mcp/src/test/java/org/openmetadata/mcp/tools/DefaultToolContextTest.java
@@ -20,6 +20,7 @@ import io.modelcontextprotocol.spec.McpSchema;
 import java.security.Principal;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
+import org.openmetadata.mcp.util.McpResponseTrim;
 import org.openmetadata.schema.entity.app.mcp.McpToolCallUsage;
 import org.openmetadata.service.limits.Limits;
 import org.openmetadata.service.security.AuthorizationException;
@@ -185,6 +186,29 @@ class DefaultToolContextTest {
   void notFoundStillBucketsAsValidationCategory() {
     assertThat(DefaultToolContext.classifyException(new RuntimeException("Entity not found: x")))
         .isEqualTo(McpToolCallUsage.ErrorCategory.VALIDATION);
+  }
+
+  @Test
+  void serializeWithinBudgetPassesSmallResultThrough() {
+    Map<String, Object> result = Map.of("fqn", "svc.db.orders", "status", "success");
+
+    String serialized = DefaultToolContext.serializeWithinBudget(result, "root_cause_analysis");
+
+    assertThat(serialized).contains("svc.db.orders").doesNotContain("truncated");
+  }
+
+  @Test
+  void serializeWithinBudgetReplacesOversizedResultWithEnvelope() {
+    Map<String, Object> result =
+        Map.of("blob", "z".repeat(McpResponseTrim.MAX_RESPONSE_CHARS + 1), "tool", "ignored");
+
+    String serialized = DefaultToolContext.serializeWithinBudget(result, "get_entity_details");
+
+    assertThat(serialized)
+        .contains("\"truncated\":true")
+        .contains("\"tool\":\"get_entity_details\"")
+        .contains("\"maxResponseChars\":" + McpResponseTrim.MAX_RESPONSE_CHARS)
+        .doesNotContain("zzzz");
   }
 
   private static DefaultToolContext.CallToolOutcome invokeWithToolName(String toolName) {

--- a/openmetadata-mcp/src/test/java/org/openmetadata/mcp/tools/DefaultToolContextTest.java
+++ b/openmetadata-mcp/src/test/java/org/openmetadata/mcp/tools/DefaultToolContextTest.java
@@ -115,6 +115,78 @@ class DefaultToolContextTest {
         .isEqualTo(McpToolCallUsage.ErrorCategory.RATE_LIMIT);
   }
 
+  @Test
+  void resolveStatusCodeMapsNotFoundTo404() {
+    assertThat(
+            DefaultToolContext.resolveStatusCode(new RuntimeException("Entity not found: table x")))
+        .isEqualTo(404);
+  }
+
+  @Test
+  void resolveStatusCodeMapsValidationTo400() {
+    assertThat(DefaultToolContext.resolveStatusCode(new IllegalArgumentException("bad arg")))
+        .isEqualTo(400);
+  }
+
+  @Test
+  void validationExceptionWithNotFoundMessageStaysA400() {
+    assertThat(
+            DefaultToolContext.resolveStatusCode(
+                new IllegalArgumentException("parameter not found")))
+        .isEqualTo(400);
+    assertThat(
+            DefaultToolContext.classifyException(new IllegalArgumentException("field not found")))
+        .isEqualTo(McpToolCallUsage.ErrorCategory.VALIDATION);
+  }
+
+  @Test
+  void resolveStatusCodeMapsAuthTo403() {
+    assertThat(DefaultToolContext.resolveStatusCode(new AuthorizationException("forbidden")))
+        .isEqualTo(403);
+  }
+
+  @Test
+  void resolveStatusCodeMapsRateLimitTo429() {
+    assertThat(DefaultToolContext.resolveStatusCode(new RuntimeException("rate limit exceeded")))
+        .isEqualTo(429);
+  }
+
+  @Test
+  void resolveStatusCodeMapsTimeoutTo504() {
+    assertThat(DefaultToolContext.resolveStatusCode(new RuntimeException("connection timed out")))
+        .isEqualTo(504);
+  }
+
+  @Test
+  void resolveStatusCodeFallsBackTo500() {
+    assertThat(DefaultToolContext.resolveStatusCode(new RuntimeException("kaboom"))).isEqualTo(500);
+  }
+
+  @Test
+  void resolveStatusCodeWalksCauseChain() {
+    RuntimeException root = new RuntimeException("Entity not found: table x");
+    RuntimeException wrapped = new RuntimeException("tool wrapper failed", root);
+
+    assertThat(DefaultToolContext.resolveStatusCode(wrapped)).isEqualTo(404);
+  }
+
+  @Test
+  void resolveStatusCodeTerminatesOnCyclicCauseChain() {
+    RuntimeException a = new RuntimeException("kaboom");
+    RuntimeException b = new RuntimeException("boom", a);
+    a.initCause(b);
+
+    assertThat(DefaultToolContext.resolveStatusCode(a)).isEqualTo(500);
+    assertThat(DefaultToolContext.classifyException(a))
+        .isEqualTo(McpToolCallUsage.ErrorCategory.INTERNAL);
+  }
+
+  @Test
+  void notFoundStillBucketsAsValidationCategory() {
+    assertThat(DefaultToolContext.classifyException(new RuntimeException("Entity not found: x")))
+        .isEqualTo(McpToolCallUsage.ErrorCategory.VALIDATION);
+  }
+
   private static DefaultToolContext.CallToolOutcome invokeWithToolName(String toolName) {
     CatalogSecurityContext securityContext = mock(CatalogSecurityContext.class);
     Principal principal = mock(Principal.class);

--- a/openmetadata-mcp/src/test/java/org/openmetadata/mcp/tools/DefaultToolContextTest.java
+++ b/openmetadata-mcp/src/test/java/org/openmetadata/mcp/tools/DefaultToolContextTest.java
@@ -1,0 +1,131 @@
+/*
+ *  Copyright 2025 Collate
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.openmetadata.mcp.tools;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+import io.modelcontextprotocol.spec.McpSchema;
+import java.security.Principal;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.openmetadata.schema.entity.app.mcp.McpToolCallUsage;
+import org.openmetadata.service.limits.Limits;
+import org.openmetadata.service.security.AuthorizationException;
+import org.openmetadata.service.security.Authorizer;
+import org.openmetadata.service.security.auth.CatalogSecurityContext;
+
+/**
+ * Direct coverage for {@link DefaultToolContext}'s Phase 3 outcome construction. The recorder side
+ * of the pipeline is covered by {@code McpUsageRecorderTest}; this file pins the classification
+ * logic so a change in exception → category mapping is caught at unit-test time rather than
+ * silently warping the dashboard tiles.
+ */
+class DefaultToolContextTest {
+
+  @Test
+  void unknownToolReturnsValidationCategory() {
+    DefaultToolContext.CallToolOutcome outcome = invokeWithToolName("not_a_real_tool");
+
+    assertThat(outcome.result().isError()).isTrue();
+    assertThat(outcome.errorCategory()).isEqualTo(McpToolCallUsage.ErrorCategory.VALIDATION);
+    assertThat(outcome.latencyMs()).isGreaterThanOrEqualTo(0L);
+  }
+
+  @Test
+  void classifyAuthorizationExceptionAsAuth() {
+    assertThat(DefaultToolContext.classifyException(new AuthorizationException("forbidden")))
+        .isEqualTo(McpToolCallUsage.ErrorCategory.AUTH);
+  }
+
+  @Test
+  void classifyWrappedAuthorizationExceptionAsAuth() {
+    RuntimeException wrapped =
+        new RuntimeException("tool failed", new AuthorizationException("forbidden"));
+
+    assertThat(DefaultToolContext.classifyException(wrapped))
+        .isEqualTo(McpToolCallUsage.ErrorCategory.AUTH);
+  }
+
+  @Test
+  void classifyAuthMessagePatternsAsAuth() {
+    assertThat(DefaultToolContext.classifyException(new RuntimeException("Permission denied")))
+        .isEqualTo(McpToolCallUsage.ErrorCategory.AUTH);
+    assertThat(DefaultToolContext.classifyException(new RuntimeException("Unauthorized access")))
+        .isEqualTo(McpToolCallUsage.ErrorCategory.AUTH);
+    assertThat(DefaultToolContext.classifyException(new RuntimeException("Access denied for user")))
+        .isEqualTo(McpToolCallUsage.ErrorCategory.AUTH);
+  }
+
+  @Test
+  void classifyValidationException() {
+    assertThat(DefaultToolContext.classifyException(new IllegalArgumentException("bad arg")))
+        .isEqualTo(McpToolCallUsage.ErrorCategory.VALIDATION);
+    assertThat(DefaultToolContext.classifyException(new RuntimeException("invalid argument: foo")))
+        .isEqualTo(McpToolCallUsage.ErrorCategory.VALIDATION);
+  }
+
+  @Test
+  void classifyTimeoutException() {
+    assertThat(DefaultToolContext.classifyException(new RuntimeException("connection timed out")))
+        .isEqualTo(McpToolCallUsage.ErrorCategory.TIMEOUT);
+    assertThat(DefaultToolContext.classifyException(new RuntimeException("request timeout")))
+        .isEqualTo(McpToolCallUsage.ErrorCategory.TIMEOUT);
+  }
+
+  @Test
+  void classifyRateLimitException() {
+    assertThat(DefaultToolContext.classifyException(new RuntimeException("rate limit exceeded")))
+        .isEqualTo(McpToolCallUsage.ErrorCategory.RATE_LIMIT);
+  }
+
+  @Test
+  void classifyFallsBackToInternalForUnknownException() {
+    assertThat(DefaultToolContext.classifyException(new RuntimeException("kaboom")))
+        .isEqualTo(McpToolCallUsage.ErrorCategory.INTERNAL);
+  }
+
+  @Test
+  void classifyWalksCauseChain() {
+    RuntimeException root = new RuntimeException("connection timed out");
+    RuntimeException wrapped = new RuntimeException("upstream failure", root);
+    RuntimeException outermost = new RuntimeException("tool wrapper failed", wrapped);
+
+    assertThat(DefaultToolContext.classifyException(outermost))
+        .isEqualTo(McpToolCallUsage.ErrorCategory.TIMEOUT);
+  }
+
+  @Test
+  void classifyHandlesNullMessageOnIntermediateCause() {
+    RuntimeException root = new RuntimeException("rate limit hit");
+    RuntimeException middle = new RuntimeException((String) null, root);
+
+    assertThat(DefaultToolContext.classifyException(middle))
+        .isEqualTo(McpToolCallUsage.ErrorCategory.RATE_LIMIT);
+  }
+
+  private static DefaultToolContext.CallToolOutcome invokeWithToolName(String toolName) {
+    CatalogSecurityContext securityContext = mock(CatalogSecurityContext.class);
+    Principal principal = mock(Principal.class);
+    org.mockito.Mockito.when(principal.getName()).thenReturn("alice");
+    org.mockito.Mockito.when(securityContext.getUserPrincipal()).thenReturn(principal);
+
+    McpSchema.CallToolRequest request = mock(McpSchema.CallToolRequest.class);
+    org.mockito.Mockito.when(request.arguments()).thenReturn(Map.of());
+
+    return new DefaultToolContext()
+        .callToolWithMetadata(
+            mock(Authorizer.class), mock(Limits.class), toolName, securityContext, request);
+  }
+}

--- a/openmetadata-mcp/src/test/java/org/openmetadata/mcp/tools/GetEntityToolTest.java
+++ b/openmetadata-mcp/src/test/java/org/openmetadata/mcp/tools/GetEntityToolTest.java
@@ -1,0 +1,176 @@
+/*
+ *  Copyright 2025 Collate
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.openmetadata.mcp.tools;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Pins {@link GetEntityTool#cleanEntityResponse}. The entity-level description must always be
+ * returned in full (this is the detail tool — the one place full text is reachable after search
+ * truncates), while per-column descriptions, schema DDL and dbt SQL — the wide-table multipliers —
+ * are truncated. The {@code extension} field (custom properties, #28594 contract) must survive at
+ * both table and column level.
+ */
+class GetEntityToolTest {
+
+  private static Map<String, Object> column(String name, String description) {
+    Map<String, Object> column = new HashMap<>();
+    column.put("name", name);
+    column.put("dataType", "VARCHAR");
+    if (description != null) {
+      column.put("description", description);
+    }
+    return column;
+  }
+
+  @Test
+  void entityDescriptionIsNeverTruncated() {
+    Map<String, Object> entity = new HashMap<>();
+    String longDescription = "d".repeat(5_000);
+    entity.put("description", longDescription);
+
+    Map<String, Object> cleaned = GetEntityTool.cleanEntityResponse(entity);
+
+    assertThat(cleaned.get("description")).isEqualTo(longDescription);
+    assertThat(cleaned).doesNotContainKey("columnDescriptionsTruncated");
+  }
+
+  @Test
+  void longColumnDescriptionIsTruncatedWithTopLevelFlag() {
+    Map<String, Object> entity = new HashMap<>();
+    List<Map<String, Object>> columns = new ArrayList<>();
+    columns.add(column("a", "x".repeat(900)));
+    columns.add(column("b", "short"));
+    entity.put("columns", columns);
+
+    Map<String, Object> cleaned = GetEntityTool.cleanEntityResponse(entity);
+
+    assertThat((String) columns.get(0).get("description")).hasSize(503).endsWith("...");
+    assertThat(columns.get(1).get("description")).isEqualTo("short");
+    assertThat(cleaned.get("columnDescriptionsTruncated")).isEqualTo(Boolean.TRUE);
+  }
+
+  @Test
+  void shortColumnDescriptionsProduceNoFlag() {
+    Map<String, Object> entity = new HashMap<>();
+    entity.put("columns", List.of(column("a", "short"), column("b", null)));
+
+    Map<String, Object> cleaned = GetEntityTool.cleanEntityResponse(entity);
+
+    assertThat(cleaned).doesNotContainKey("columnDescriptionsTruncated");
+  }
+
+  @Test
+  void nestedChildColumnDescriptionsAreTruncatedRecursively() {
+    Map<String, Object> child = column("inner", "y".repeat(700));
+    Map<String, Object> parent = column("outer", "short");
+    parent.put("children", List.of(child));
+    Map<String, Object> entity = new HashMap<>();
+    entity.put("columns", List.of(parent));
+
+    Map<String, Object> cleaned = GetEntityTool.cleanEntityResponse(entity);
+
+    assertThat((String) child.get("description")).hasSize(503).endsWith("...");
+    assertThat(cleaned.get("columnDescriptionsTruncated")).isEqualTo(Boolean.TRUE);
+  }
+
+  @Test
+  void extensionSurvivesAtTableAndColumnLevel() {
+    Map<String, Object> column = column("a", "short");
+    column.put("extension", Map.of("colProp", "v"));
+    Map<String, Object> entity = new HashMap<>();
+    entity.put("extension", Map.of("tableProp", "v"));
+    entity.put("columns", List.of(column));
+
+    Map<String, Object> cleaned = GetEntityTool.cleanEntityResponse(entity);
+
+    assertThat(cleaned.get("extension")).isEqualTo(Map.of("tableProp", "v"));
+    assertThat(column.get("extension")).isEqualTo(Map.of("colProp", "v"));
+  }
+
+  @Test
+  void noiseAndVectorFieldsAreRemoved() {
+    Map<String, Object> entity = new HashMap<>();
+    entity.put("incrementalChangeDescription", Map.of("fieldsAdded", List.of()));
+    entity.put("changeDescription", Map.of());
+    entity.put("embedding", List.of(0.1, 0.2));
+    entity.put("textToEmbed", "blob");
+    entity.put("name", "orders");
+
+    Map<String, Object> cleaned = GetEntityTool.cleanEntityResponse(entity);
+
+    assertThat(cleaned)
+        .doesNotContainKeys(
+            "incrementalChangeDescription", "changeDescription", "embedding", "textToEmbed")
+        .containsKey("name");
+  }
+
+  @Test
+  void schemaDefinitionIsTruncatedWithFlag() {
+    Map<String, Object> entity = new HashMap<>();
+    entity.put("schemaDefinition", "CREATE TABLE orders (".repeat(60));
+
+    Map<String, Object> cleaned = GetEntityTool.cleanEntityResponse(entity);
+
+    assertThat((String) cleaned.get("schemaDefinition")).hasSize(503).endsWith("...");
+    assertThat(cleaned.get("schemaDefinitionTruncated")).isEqualTo(Boolean.TRUE);
+  }
+
+  @Test
+  void dataModelSqlAndRawSqlAreTruncatedWithFlag() {
+    Map<String, Object> dataModel = new HashMap<>();
+    dataModel.put("sql", "SELECT 1 FROM t ".repeat(60));
+    dataModel.put("rawSql", "SELECT 2 FROM t ".repeat(60));
+    Map<String, Object> entity = new HashMap<>();
+    entity.put("dataModel", dataModel);
+
+    Map<String, Object> cleaned = GetEntityTool.cleanEntityResponse(entity);
+
+    Map<String, Object> cleanedModel = castMap(cleaned.get("dataModel"));
+    assertThat((String) cleanedModel.get("sql")).hasSize(503).endsWith("...");
+    assertThat((String) cleanedModel.get("rawSql")).hasSize(503).endsWith("...");
+    assertThat(cleanedModel.get("sqlTruncated")).isEqualTo(Boolean.TRUE);
+  }
+
+  @Test
+  void shortSchemaAndModelSqlAreUntouched() {
+    Map<String, Object> dataModel = new HashMap<>();
+    dataModel.put("sql", "SELECT 1");
+    Map<String, Object> entity = new HashMap<>();
+    entity.put("schemaDefinition", "CREATE TABLE t (id INT)");
+    entity.put("dataModel", dataModel);
+
+    Map<String, Object> cleaned = GetEntityTool.cleanEntityResponse(entity);
+
+    assertThat(cleaned.get("schemaDefinition")).isEqualTo("CREATE TABLE t (id INT)");
+    assertThat(cleaned).doesNotContainKey("schemaDefinitionTruncated");
+    assertThat(castMap(cleaned.get("dataModel"))).doesNotContainKey("sqlTruncated");
+  }
+
+  @Test
+  void nullEntityYieldsEmptyResponse() {
+    assertThat(GetEntityTool.cleanEntityResponse(null)).isEmpty();
+  }
+
+  @SuppressWarnings("unchecked")
+  private static Map<String, Object> castMap(Object value) {
+    return (Map<String, Object>) value;
+  }
+}

--- a/openmetadata-mcp/src/test/java/org/openmetadata/mcp/tools/GetLineageToolTest.java
+++ b/openmetadata-mcp/src/test/java/org/openmetadata/mcp/tools/GetLineageToolTest.java
@@ -1,0 +1,243 @@
+package org.openmetadata.mcp.tools;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.openmetadata.schema.type.ColumnLineage;
+import org.openmetadata.schema.type.Edge;
+import org.openmetadata.schema.type.EntityLineage;
+import org.openmetadata.schema.type.EntityReference;
+import org.openmetadata.schema.type.LineageDetails;
+import org.openmetadata.schema.type.TempLineageTable;
+
+/**
+ * Unit tests for {@link GetLineageTool} slimming. These exercise the pure transform against
+ * hand-built {@link EntityLineage} fixtures (no DB/repository) and assert that the response is
+ * table-level by default, that heavy fields are trimmed, and that the size-cap safeguard fires.
+ */
+class GetLineageToolTest {
+
+  private static EntityReference ref(String name, String fqn) {
+    return new EntityReference()
+        .withId(UUID.randomUUID())
+        .withType("table")
+        .withName(name)
+        .withFullyQualifiedName(fqn)
+        .withDisplayName(name + " Display")
+        .withDescription("A long markdown description that should never reach the LLM payload.");
+  }
+
+  private static LineageDetails details(String sql, List<ColumnLineage> columns) {
+    return new LineageDetails()
+        .withSqlQuery(sql)
+        .withColumnsLineage(columns)
+        .withSource(LineageDetails.Source.QUERY_LINEAGE)
+        .withTempLineageTables(
+            List.of(new TempLineageTable().withFromEntity("src").withToEntity("staging")))
+        .withUpdatedAt(123L)
+        .withUpdatedBy("bob")
+        .withAssetEdges(2);
+  }
+
+  private static EntityLineage singleUpstreamEdge(String sql, List<ColumnLineage> columns) {
+    EntityReference root = ref("orders", "db.public.orders");
+    EntityReference upstream = ref("raw_orders", "db.raw.raw_orders");
+    Edge edge =
+        new Edge()
+            .withFromEntity(upstream.getId())
+            .withToEntity(root.getId())
+            .withLineageDetails(details(sql, columns));
+    return new EntityLineage()
+        .withEntity(root)
+        .withNodes(List.of(upstream))
+        .withUpstreamEdges(List.of(edge))
+        .withDownstreamEdges(List.of());
+  }
+
+  @SuppressWarnings("unchecked")
+  private static Map<String, Object> firstUpstreamEdge(Map<String, Object> response) {
+    List<Map<String, Object>> upstream = (List<Map<String, Object>>) response.get("upstream");
+    return upstream.getFirst();
+  }
+
+  @Test
+  void slimsToTableLevelByDefault() {
+    EntityLineage lineage = singleUpstreamEdge("SELECT 1", List.of());
+    Map<String, Object> response =
+        GetLineageTool.enforceSizeBudget(GetLineageTool.toSlim(lineage, false));
+
+    assertEquals("db.public.orders", response.get("root"));
+    assertFalse(response.containsKey("nodes"), "standalone nodes array must be folded into edges");
+
+    Map<String, Object> edge = firstUpstreamEdge(response);
+    assertEquals("db.raw.raw_orders", edge.get("fromFQN"));
+    assertEquals("db.public.orders", edge.get("toFQN"));
+    assertEquals("raw_orders Display", edge.get("fromName"));
+    assertEquals("sql", edge.get("relationshipType"));
+    assertEquals("QueryLineage", edge.get("source"));
+    assertTrue(edge.containsKey("tempLineageTables"), "temp-table path must be preserved");
+    assertFalse(edge.containsKey("columnsLineage"), "column lineage must be off by default");
+  }
+
+  @Test
+  void truncatesLongSqlAndMarksIt() {
+    String longSql = "SELECT ".repeat(200);
+    Map<String, Object> response =
+        GetLineageTool.enforceSizeBudget(
+            GetLineageTool.toSlim(singleUpstreamEdge(longSql, List.of()), false));
+    Map<String, Object> edge = firstUpstreamEdge(response);
+
+    String sql = (String) edge.get("sqlQuery");
+    assertTrue(sql.endsWith("..."), "long SQL should be truncated with an ellipsis");
+    assertTrue(sql.length() <= 503, "truncated SQL should respect the cap");
+    assertEquals(Boolean.TRUE, edge.get("sqlTruncated"));
+  }
+
+  @Test
+  void keepsShortSqlWithoutTruncationFlag() {
+    Map<String, Object> response =
+        GetLineageTool.enforceSizeBudget(
+            GetLineageTool.toSlim(singleUpstreamEdge("SELECT 1", List.of()), false));
+    Map<String, Object> edge = firstUpstreamEdge(response);
+
+    assertEquals("SELECT 1", edge.get("sqlQuery"));
+    assertNull(edge.get("sqlTruncated"), "short SQL must not carry a truncation flag");
+  }
+
+  @Test
+  void includesColumnLineageWhenRequested() {
+    ColumnLineage column =
+        new ColumnLineage()
+            .withFromColumns(List.of("db.raw.raw_orders.id"))
+            .withToColumn("db.public.orders.id");
+    Map<String, Object> response =
+        GetLineageTool.enforceSizeBudget(
+            GetLineageTool.toSlim(singleUpstreamEdge("SELECT 1", List.of(column)), true));
+    Map<String, Object> edge = firstUpstreamEdge(response);
+
+    assertTrue(edge.containsKey("columnsLineage"), "column lineage must appear when opted in");
+  }
+
+  @Test
+  void omitsEmptyColumnLineageEvenWhenOptedIn() {
+    Map<String, Object> response =
+        GetLineageTool.enforceSizeBudget(
+            GetLineageTool.toSlim(singleUpstreamEdge("SELECT 1", List.of()), true));
+    Map<String, Object> edge = firstUpstreamEdge(response);
+
+    assertFalse(
+        edge.containsKey("columnsLineage"),
+        "empty column lineage must be omitted to avoid per-edge noise");
+  }
+
+  @Test
+  void defaultSlimResponseIsAFractionOfRawPayload() {
+    String fatSql = "SELECT col_a, col_b, col_c FROM upstream JOIN other USING (id) ".repeat(40);
+    EntityReference root = ref("orders", "db.public.orders");
+    List<Edge> edges = new java.util.ArrayList<>();
+    List<EntityReference> nodes = new java.util.ArrayList<>();
+    for (int i = 0; i < 20; i++) {
+      EntityReference upstream = ref("raw_orders_" + i, "db.raw.raw_orders_" + i);
+      nodes.add(upstream);
+      edges.add(
+          new Edge()
+              .withFromEntity(upstream.getId())
+              .withToEntity(root.getId())
+              .withLineageDetails(details(fatSql, buildHeavyColumns())));
+    }
+    EntityLineage lineage =
+        new EntityLineage()
+            .withEntity(root)
+            .withNodes(nodes)
+            .withUpstreamEdges(edges)
+            .withDownstreamEdges(List.of());
+
+    int rawSize = org.openmetadata.schema.utils.JsonUtils.pojoToJson(lineage).length();
+    int slimSize =
+        org.openmetadata.schema.utils.JsonUtils.pojoToJson(
+                GetLineageTool.enforceSizeBudget(GetLineageTool.toSlim(lineage, false)))
+            .length();
+
+    assertTrue(
+        slimSize < rawSize * 0.15,
+        "default slim payload (" + slimSize + ") should be < 15% of raw (" + rawSize + ")");
+  }
+
+  @Test
+  void collapsesDuplicateEdges() {
+    EntityReference root = ref("orders", "db.public.orders");
+    EntityReference upstream = ref("raw_orders", "db.raw.raw_orders");
+    Edge edge =
+        new Edge()
+            .withFromEntity(upstream.getId())
+            .withToEntity(root.getId())
+            .withLineageDetails(details("SELECT 1", List.of()));
+    EntityLineage lineage =
+        new EntityLineage()
+            .withEntity(root)
+            .withNodes(List.of(upstream))
+            .withUpstreamEdges(List.of(edge, edge, edge))
+            .withDownstreamEdges(List.of());
+
+    @SuppressWarnings("unchecked")
+    List<Map<String, Object>> upstreamEdges =
+        (List<Map<String, Object>>)
+            GetLineageTool.enforceSizeBudget(GetLineageTool.toSlim(lineage, false)).get("upstream");
+
+    assertEquals(1, upstreamEdges.size(), "identical edges must be collapsed to one");
+  }
+
+  @Test
+  void oversizedGraphReturnsHintInsteadOfData() {
+    List<ColumnLineage> heavyColumns = buildHeavyColumns();
+    EntityReference root = ref("orders", "db.public.orders");
+    List<Edge> edges = new java.util.ArrayList<>();
+    List<EntityReference> nodes = new java.util.ArrayList<>();
+    for (int i = 0; i < 40; i++) {
+      EntityReference upstream =
+          ref("raw_orders_" + i, "db.raw.raw_orders_with_a_long_qualified_name_" + i);
+      nodes.add(upstream);
+      edges.add(
+          new Edge()
+              .withFromEntity(upstream.getId())
+              .withToEntity(root.getId())
+              .withLineageDetails(details("SELECT 1", heavyColumns)));
+    }
+    EntityLineage lineage =
+        new EntityLineage()
+            .withEntity(root)
+            .withNodes(nodes)
+            .withUpstreamEdges(edges)
+            .withDownstreamEdges(List.of());
+
+    Map<String, Object> response =
+        GetLineageTool.enforceSizeBudget(GetLineageTool.toSlim(lineage, true));
+
+    assertFalse(
+        response.containsKey("upstream"), "oversized response must not carry the full graph");
+    assertTrue(response.containsKey("message"), "oversized response must carry a guidance message");
+    assertEquals(
+        Boolean.TRUE, response.get("truncated"), "oversized response must be machine-flagged");
+    assertEquals(40, response.get("upstreamCount"));
+  }
+
+  private static List<ColumnLineage> buildHeavyColumns() {
+    List<ColumnLineage> columns = new java.util.ArrayList<>();
+    for (int i = 0; i < 60; i++) {
+      columns.add(
+          new ColumnLineage()
+              .withFromColumns(
+                  List.of(
+                      "db.raw.raw_orders.column_with_a_fairly_long_qualified_name_" + i,
+                      "db.raw.raw_orders.another_long_qualified_column_name_" + i))
+              .withToColumn("db.public.orders.derived_column_with_a_long_name_" + i));
+    }
+    return columns;
+  }
+}

--- a/openmetadata-mcp/src/test/java/org/openmetadata/mcp/tools/RootCauseAnalysisToolTest.java
+++ b/openmetadata-mcp/src/test/java/org/openmetadata/mcp/tools/RootCauseAnalysisToolTest.java
@@ -1,0 +1,244 @@
+/*
+ *  Copyright 2025 Collate
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.openmetadata.mcp.tools;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.openmetadata.schema.api.lineage.EsLineageData;
+import org.openmetadata.schema.utils.JsonUtils;
+
+/**
+ * Pins the in-memory slimming that {@link RootCauseAnalysisTool} applies to the raw {@code
+ * EsLineageData} edges and full ES node documents returned by the data-quality lineage search. The
+ * integration test {@code McpToolsValidationIT#testRootCauseAnalysis} only exercises the
+ * no-failure ({@code status:"success"}) path, so the downstream node/edge slim and the size budget
+ * are covered here against hand-built fixtures.
+ */
+class RootCauseAnalysisToolTest {
+
+  private static Map<String, Object> edgeWithSql(String sql) {
+    Map<String, Object> edge = new HashMap<>();
+    edge.put("fromEntity", refMap("up-id", "svc.db.raw", "table", "raw-hash"));
+    edge.put("toEntity", refMap("down-id", "svc.db.orders", "table", "orders-hash"));
+    edge.put("sqlQuery", sql);
+    edge.put("source", "QueryLineage");
+    edge.put("docId", "doc-1");
+    edge.put("docUniqueId", "doc-unique-1");
+    edge.put("createdBy", "ingestion-bot");
+    edge.put("updatedAt", 1700000000000L);
+    return edge;
+  }
+
+  private static Map<String, Object> refMap(String id, String fqn, String type, String fqnHash) {
+    Map<String, Object> ref = new LinkedHashMap<>();
+    ref.put("id", id);
+    ref.put("fullyQualifiedName", fqn);
+    ref.put("type", type);
+    ref.put("fqnHash", fqnHash);
+    return ref;
+  }
+
+  @Test
+  void slimEdgeTruncatesLongSqlAndFlagsIt() {
+    String longSql = "SELECT * FROM orders WHERE ".repeat(80);
+
+    Map<String, Object> slim = RootCauseAnalysisTool.slimEdge(edgeWithSql(longSql), false);
+
+    String sql = (String) slim.get("sqlQuery");
+    assertThat(sql).hasSize(503).endsWith("...");
+    assertThat(slim.get("sqlTruncated")).isEqualTo(Boolean.TRUE);
+  }
+
+  @Test
+  void slimEdgeKeepsShortSqlWithoutTruncationFlag() {
+    Map<String, Object> slim = RootCauseAnalysisTool.slimEdge(edgeWithSql("SELECT 1"), false);
+
+    assertThat(slim.get("sqlQuery")).isEqualTo("SELECT 1");
+    assertThat(slim).doesNotContainKey("sqlTruncated");
+  }
+
+  @Test
+  void slimEdgeDropsNoiseAndSlimsEndpoints() {
+    Map<String, Object> slim = RootCauseAnalysisTool.slimEdge(edgeWithSql("SELECT 1"), false);
+
+    assertThat(slim)
+        .doesNotContainKeys("docId", "docUniqueId", "createdBy", "updatedAt", "pipeline");
+
+    Map<String, Object> from = asMap(slim.get("fromEntity"));
+    assertThat(from).containsKeys("id", "fullyQualifiedName", "type").doesNotContainKey("fqnHash");
+  }
+
+  @Test
+  void slimEdgeDefaultsRelationshipToSqlAndBuildsFromPipeline() {
+    Map<String, Object> sqlEdge = RootCauseAnalysisTool.slimEdge(edgeWithSql("SELECT 1"), false);
+    assertThat(sqlEdge.get("relationshipType")).isEqualTo("sql");
+
+    Map<String, Object> pipelined = edgeWithSql("SELECT 1");
+    pipelined.put("pipeline", Map.of("type", "pipeline", "name", "daily_etl"));
+    Map<String, Object> slim = RootCauseAnalysisTool.slimEdge(pipelined, false);
+    assertThat(slim.get("relationshipType")).isEqualTo("pipeline:daily_etl");
+  }
+
+  @Test
+  void slimEdgeOmitsColumnsByDefaultAndIncludesWhenRequested() {
+    Map<String, Object> edge = edgeWithSql("SELECT 1");
+    edge.put("columns", List.of(Map.of("fromColumns", List.of("a"), "toColumn", "b")));
+
+    assertThat(RootCauseAnalysisTool.slimEdge(edge, false)).doesNotContainKey("columns");
+    assertThat(RootCauseAnalysisTool.slimEdge(edge, true)).containsKey("columns");
+  }
+
+  @Test
+  void slimNodeEntityRemovesColumnsAndTruncatesDescription() {
+    Map<String, Object> node = new HashMap<>();
+    node.put("name", "orders");
+    node.put("fullyQualifiedName", "svc.db.orders");
+    node.put("entityType", "table");
+    node.put("columns", List.of(Map.of("name", "id"), Map.of("name", "amount")));
+    node.put("schemaDefinition", "CREATE TABLE orders ...");
+    node.put("embedding", List.of(0.1, 0.2, 0.3));
+    node.put("textToEmbed", "concatenated text used to build the vector ...");
+    node.put("textToLLMContext", "rag context blob ...");
+    node.put("fingerprint", "abc123");
+    node.put("chunkCount", 4);
+    node.put("chunkIndex", 0);
+    node.put("description", "x".repeat(900));
+
+    Map<String, Object> slim = RootCauseAnalysisTool.slimNodeEntity(node);
+
+    assertThat(slim)
+        .doesNotContainKeys(
+            "columns",
+            "schemaDefinition",
+            "embedding",
+            "textToEmbed",
+            "textToLLMContext",
+            "fingerprint",
+            "chunkCount",
+            "chunkIndex");
+    assertThat(slim).containsKeys("name", "fullyQualifiedName", "entityType");
+    assertThat((String) slim.get("description")).hasSize(503).endsWith("...");
+  }
+
+  @Test
+  void slimDownstreamNodesPreservesIdKeysAndSlimsEntity() {
+    Map<String, Object> entity = new HashMap<>();
+    entity.put("name", "orders");
+    entity.put("columns", List.of(Map.of("name", "id")));
+    Map<String, Object> nodeInfo = new HashMap<>();
+    nodeInfo.put("entity", entity);
+    nodeInfo.put("nodeDepth", 2);
+
+    Map<String, Object> slim =
+        RootCauseAnalysisTool.slimDownstreamNodes(Map.of("node-id", nodeInfo));
+
+    assertThat(slim).containsOnlyKeys("node-id");
+    Map<String, Object> slimNode = asMap(slim.get("node-id"));
+    assertThat(slimNode.get("nodeDepth")).isEqualTo(2);
+    assertThat(asMap(slimNode.get("entity"))).doesNotContainKey("columns");
+  }
+
+  @Test
+  void slimEdgeMatchesRealEsLineageDataKeysAfterRoundTrip() {
+    Map<String, Object> raw = new HashMap<>();
+    raw.put(
+        "fromEntity",
+        refMap("11111111-1111-1111-1111-111111111111", "svc.db.raw", "table", "raw-hash"));
+    raw.put(
+        "toEntity",
+        refMap("22222222-2222-2222-2222-222222222222", "svc.db.orders", "table", "orders-hash"));
+    raw.put("pipeline", Map.of("type", "pipeline", "name", "daily_etl"));
+    raw.put("sqlQuery", "SELECT * FROM raw ".repeat(60));
+    raw.put("source", "QueryLineage");
+    raw.put("docId", "doc-1");
+    raw.put(
+        "columns", List.of(Map.of("toColumn", "svc.db.orders.id", "fromColumns", List.of("a"))));
+
+    EsLineageData typed = JsonUtils.convertValue(raw, EsLineageData.class);
+    Map<String, Object> edgeMap = JsonUtils.getMap(typed);
+
+    Map<String, Object> slim = RootCauseAnalysisTool.slimEdge(edgeMap, false);
+    assertThat(slim.get("relationshipType")).isEqualTo("pipeline:daily_etl");
+    assertThat((String) slim.get("sqlQuery")).hasSize(503).endsWith("...");
+    assertThat(slim.get("sqlTruncated")).isEqualTo(Boolean.TRUE);
+    assertThat(slim.get("source")).isEqualTo("QueryLineage");
+    assertThat(asMap(slim.get("fromEntity")).get("fullyQualifiedName")).isEqualTo("svc.db.raw");
+    assertThat(slim).doesNotContainKeys("docId", "columns");
+    assertThat(RootCauseAnalysisTool.slimEdge(edgeMap, true)).containsKey("columns");
+  }
+
+  @Test
+  void slimEdgeCarriesSqlQueryKeyForDeduplicatedSql() {
+    Map<String, Object> edge = edgeWithSql("");
+    edge.put("sqlQueryKey", "3");
+
+    Map<String, Object> slim = RootCauseAnalysisTool.slimEdge(edge, false);
+
+    assertThat(slim.get("sqlQueryKey")).isEqualTo("3");
+    assertThat(slim).doesNotContainKey("sqlQuery");
+  }
+
+  @Test
+  void slimEdgeHandlesNullEdgeWithoutThrowing() {
+    assertThat(RootCauseAnalysisTool.slimEdge(null, false)).isEmpty();
+  }
+
+  @Test
+  void slimDownstreamNodesHandlesNullNodeInfoWithoutThrowing() {
+    Map<String, Object> withNull = new LinkedHashMap<>();
+    withNull.put("node-id", null);
+
+    Map<String, Object> slim = RootCauseAnalysisTool.slimDownstreamNodes(withNull);
+
+    assertThat(slim).containsOnlyKeys("node-id");
+    assertThat(asMap(slim.get("node-id"))).isEmpty();
+  }
+
+  @SuppressWarnings("unchecked")
+  private static Map<String, Object> asMap(Object value) {
+    return (Map<String, Object>) value;
+  }
+
+  @Test
+  void enforceSizeBudgetPassesThroughSmallResult() {
+    Map<String, Object> result = new LinkedHashMap<>();
+    result.put("fqn", "svc.db.orders");
+    result.put("status", "success");
+
+    assertThat(RootCauseAnalysisTool.enforceSizeBudget(result)).isSameAs(result);
+  }
+
+  @Test
+  void enforceSizeBudgetReturnsHintWhenOversized() {
+    Map<String, Object> result = new LinkedHashMap<>();
+    result.put("fqn", "svc.db.orders");
+    result.put("status", "failed");
+    result.put("summary", "Found 1 upstream failure(s).");
+    result.put("downstreamAnalysis", Map.of("blob", "z".repeat(200_000)));
+
+    result.put("upstreamDepth", 3);
+    result.put("downstreamDepth", 3);
+    Map<String, Object> output = RootCauseAnalysisTool.enforceSizeBudget(result);
+
+    assertThat(output.get("truncated")).isEqualTo(Boolean.TRUE);
+    assertThat(output)
+        .containsKeys("fqn", "upstreamDepth", "downstreamDepth", "status", "summary", "message");
+    assertThat(output).doesNotContainKey("downstreamAnalysis");
+  }
+}

--- a/openmetadata-mcp/src/test/java/org/openmetadata/mcp/tools/SearchMetadataAggregationTest.java
+++ b/openmetadata-mcp/src/test/java/org/openmetadata/mcp/tools/SearchMetadataAggregationTest.java
@@ -242,4 +242,78 @@ class SearchMetadataAggregationTest {
     hits.put("total", total);
     return hits;
   }
+
+  @Test
+  void testResponseTrimmedWhenExceedingCharLimit() {
+    // 50 results each with 200 columns (~50 chars each) => ~500k chars, well over the 100k cap
+    Map<String, Object> searchResponse = createSearchResponseWithLargeResults(50, 200);
+
+    Map<String, Object> result =
+        SearchMetadataTool.buildEnhancedSearchResponse(
+            searchResponse, "*", 50, Collections.emptyList(), false, 10);
+
+    @SuppressWarnings("unchecked")
+    List<Map<String, Object>> results = (List<Map<String, Object>>) result.get("results");
+    assertTrue(results.size() < 50, "Results should be trimmed below requested 50");
+    assertEquals(true, result.get("hasMore"), "hasMore must be true when trimmed by size cap");
+    assertEquals(results.size(), result.get("returnedCount"));
+    String message = (String) result.get("message");
+    assertTrue(message.contains("trimmed"), "Message should mention trimming");
+  }
+
+  @Test
+  void testResponseNotTrimmedWhenUnderCharLimit() {
+    // 5 results with 2 columns each — well under 100k
+    Map<String, Object> searchResponse = createSearchResponseWithLargeResults(5, 2);
+
+    Map<String, Object> result =
+        SearchMetadataTool.buildEnhancedSearchResponse(
+            searchResponse, "*", 50, Collections.emptyList(), false, 10);
+
+    @SuppressWarnings("unchecked")
+    List<Map<String, Object>> results = (List<Map<String, Object>>) result.get("results");
+    assertEquals(5, results.size(), "Results should not be trimmed when under char limit");
+  }
+
+  @Test
+  void testResponseTrimmedToAtLeastOneResult() {
+    // Single result with enough columns to exceed 100k on its own
+    Map<String, Object> searchResponse = createSearchResponseWithLargeResults(1, 3000);
+
+    Map<String, Object> result =
+        SearchMetadataTool.buildEnhancedSearchResponse(
+            searchResponse, "*", 50, Collections.emptyList(), false, 10);
+
+    @SuppressWarnings("unchecked")
+    List<Map<String, Object>> results = (List<Map<String, Object>>) result.get("results");
+    assertEquals(1, results.size(), "At least one result must always be returned");
+  }
+
+  private Map<String, Object> createSearchResponseWithLargeResults(int count, int columnCount) {
+    Map<String, Object> response = new HashMap<>();
+
+    List<Map<String, Object>> hits = new ArrayList<>();
+    for (int i = 0; i < count; i++) {
+      Map<String, Object> source = new HashMap<>();
+      source.put("name", "table_" + i);
+      source.put("fullyQualifiedName", "service.db.schema.table_" + i);
+      source.put("entityType", "table");
+      List<String> columnNames = new ArrayList<>();
+      for (int c = 0; c < columnCount; c++) {
+        columnNames.add("column_with_long_name_to_increase_payload_size_" + c);
+      }
+      source.put("columnNames", columnNames);
+      Map<String, Object> hit = new HashMap<>();
+      hit.put("_source", source);
+      hits.add(hit);
+    }
+
+    Map<String, Object> total = new HashMap<>();
+    total.put("value", count);
+    Map<String, Object> hitsObj = new HashMap<>();
+    hitsObj.put("hits", hits);
+    hitsObj.put("total", total);
+    response.put("hits", hitsObj);
+    return response;
+  }
 }

--- a/openmetadata-mcp/src/test/java/org/openmetadata/mcp/tools/SearchMetadataToolTest.java
+++ b/openmetadata-mcp/src/test/java/org/openmetadata/mcp/tools/SearchMetadataToolTest.java
@@ -285,6 +285,96 @@ class SearchMetadataToolTest {
     assertFalse(results.get(0).containsKey("similarityScore"));
   }
 
+  @Test
+  void testTestCaseAndTestSuiteResolveToOwnIndexes() {
+    // Regression for collate#4323: test cases/suites are not part of the dataAsset alias, so they
+    // must resolve to their own indexes for data quality search to work.
+    when(searchRepository.getIndexMapping("testCase")).thenReturn(mock(IndexMapping.class));
+    when(searchRepository.getIndexMapping("testSuite")).thenReturn(mock(IndexMapping.class));
+
+    assertEquals("testCase", SearchMetadataTool.resolveIndex("testCase"));
+    assertEquals("testSuite", SearchMetadataTool.resolveIndex("testSuite"));
+  }
+
+  @Test
+  void testCleanSearchResultKeepsTestCaseFields() {
+    Map<String, Object> source = new HashMap<>();
+    source.put("entityType", "testCase");
+    source.put("fullyQualifiedName", "svc.db.schema.users.id.column_values_to_be_unique");
+    source.put("entityFQN", "svc.db.schema.users.id");
+    source.put("originEntityFQN", "svc.db.schema.users");
+    source.put("testCaseStatus", "Failed");
+    source.put("testCaseType", "column");
+    source.put("dataQualityDimension", "Uniqueness");
+    source.put("testPlatforms", List.of("OpenMetadata"));
+
+    Map<String, Object> result = SearchMetadataTool.cleanSearchResult(source, List.of());
+
+    assertEquals("svc.db.schema.users.id", result.get("entityFQN"));
+    assertEquals("svc.db.schema.users", result.get("originEntityFQN"));
+    assertEquals("Failed", result.get("testCaseStatus"));
+    assertEquals("column", result.get("testCaseType"));
+    assertEquals("Uniqueness", result.get("dataQualityDimension"));
+    assertEquals(List.of("OpenMetadata"), result.get("testPlatforms"));
+  }
+
+  @Test
+  void testCleanSearchResultKeepsTestSuiteFields() {
+    Map<String, Object> source = new HashMap<>();
+    source.put("entityType", "testSuite");
+    source.put("fullyQualifiedName", "svc.db.schema.users.testSuite");
+    source.put("basic", true);
+    source.put("lastResultTimestamp", 1768222130752L);
+
+    Map<String, Object> result = SearchMetadataTool.cleanSearchResult(source, List.of());
+
+    assertEquals(true, result.get("basic"));
+    assertEquals(1768222130752L, result.get("lastResultTimestamp"));
+  }
+
+  @Test
+  void testCleanSearchResultSlimsTestCaseResult() {
+    Map<String, Object> testCaseResult = new HashMap<>();
+    testCaseResult.put("testCaseStatus", "Failed");
+    testCaseResult.put("timestamp", 1768222130752L);
+    testCaseResult.put("result", "Found min=1001 vs. expected min=90001");
+    testCaseResult.put("testResultValue", List.of(Map.of("name", "min", "value", "1001")));
+    testCaseResult.put("id", "5c0b4b32-b4ec-4570-b3b9-025d3fdf264b");
+
+    Map<String, Object> source = new HashMap<>();
+    source.put("entityType", "testCase");
+    source.put("testCaseResult", testCaseResult);
+
+    Map<String, Object> result = SearchMetadataTool.cleanSearchResult(source, List.of());
+
+    @SuppressWarnings("unchecked")
+    Map<String, Object> slim = (Map<String, Object>) result.get("testCaseResult");
+    assertNotNull(slim);
+    assertEquals("Failed", slim.get("testCaseStatus"));
+    assertEquals(1768222130752L, slim.get("timestamp"));
+    assertEquals("Found min=1001 vs. expected min=90001", slim.get("result"));
+    assertFalse(slim.containsKey("testResultValue"));
+    assertFalse(slim.containsKey("id"));
+  }
+
+  @Test
+  void testCleanSearchResultReturnsFullTestCaseResultWhenRequested() {
+    Map<String, Object> testCaseResult = new HashMap<>();
+    testCaseResult.put("testCaseStatus", "Failed");
+    testCaseResult.put("testResultValue", List.of(Map.of("name", "min", "value", "1001")));
+
+    Map<String, Object> source = new HashMap<>();
+    source.put("entityType", "testCase");
+    source.put("testCaseResult", testCaseResult);
+
+    Map<String, Object> result =
+        SearchMetadataTool.cleanSearchResult(source, List.of("testCaseResult"));
+
+    @SuppressWarnings("unchecked")
+    Map<String, Object> full = (Map<String, Object>) result.get("testCaseResult");
+    assertEquals(testCaseResult, full);
+  }
+
   private Map<String, Object> buildHit(double score, String fqn) {
     Map<String, Object> source = new HashMap<>();
     source.put("entityType", "table");

--- a/openmetadata-mcp/src/test/java/org/openmetadata/mcp/tools/SearchMetadataToolTest.java
+++ b/openmetadata-mcp/src/test/java/org/openmetadata/mcp/tools/SearchMetadataToolTest.java
@@ -7,6 +7,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import jakarta.ws.rs.core.Response;
@@ -18,9 +19,13 @@ import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.openmetadata.schema.entity.teams.User;
+import org.openmetadata.schema.search.SearchRequest;
+import org.openmetadata.schema.utils.JsonUtils;
+import org.openmetadata.search.IndexMapping;
 import org.openmetadata.service.Entity;
 import org.openmetadata.service.search.SearchRepository;
 import org.openmetadata.service.security.Authorizer;
@@ -124,6 +129,7 @@ class SearchMetadataToolTest {
       params.put("entityType", "dashboard");
       params.put("size", 10);
 
+      when(searchRepository.getIndexMapping("dashboard")).thenReturn(mock(IndexMapping.class));
       when(searchRepository.getIndexOrAliasName("dashboard")).thenReturn("openmetadata_dashboard");
 
       Response mockResponse = mock(Response.class);
@@ -137,6 +143,112 @@ class SearchMetadataToolTest {
       assertEquals(0, result.get("returnedCount"));
       assertNotNull(result.get("results"));
     }
+  }
+
+  @Test
+  void testRegisteredEntityTypeResolvesToOwnIndex() {
+    // Regression for #27796: databaseService is absent from the legacy switch and not part of the
+    // dataAsset alias, so it must resolve to its own index rather than falling back to dataAsset.
+    when(searchRepository.getIndexMapping("databaseService")).thenReturn(mock(IndexMapping.class));
+
+    assertEquals("databaseService", SearchMetadataTool.resolveIndex("databaseService"));
+  }
+
+  @Test
+  void testUnregisteredEntityTypeFallsBackToDataAsset() {
+    when(searchRepository.getIndexMapping("bogusType")).thenReturn(null);
+
+    assertEquals("dataAsset", SearchMetadataTool.resolveIndex("bogusType"));
+  }
+
+  @Test
+  void testWildcardAndCommaInputFallBackToDataAsset() {
+    when(searchRepository.getIndexMapping(any())).thenReturn(null);
+
+    assertEquals("dataAsset", SearchMetadataTool.resolveIndex("*"));
+    assertEquals("dataAsset", SearchMetadataTool.resolveIndex("_all"));
+    assertEquals("dataAsset", SearchMetadataTool.resolveIndex("table,user"));
+  }
+
+  @Test
+  void testNullEntityTypeUsesDataAsset() {
+    assertEquals("dataAsset", SearchMetadataTool.resolveIndex(null));
+    assertEquals("dataAsset", SearchMetadataTool.resolveIndex(""));
+  }
+
+  @Test
+  void testNonStringEntityTypeDoesNotThrow() throws Exception {
+    try (MockedStatic<SubjectCache> subjectCacheMock = mockStatic(SubjectCache.class)) {
+      subjectCacheMock.when(() -> SubjectCache.getUserContext("test-user")).thenReturn(mockUser);
+
+      Map<String, Object> params = new HashMap<>();
+      params.put("query", "test");
+      params.put("entityType", 123);
+
+      when(searchRepository.getIndexMapping("123")).thenReturn(null);
+      when(searchRepository.getIndexOrAliasName("dataAsset")).thenReturn("dataAsset");
+      stubEmptySearch();
+
+      Map<String, Object> result = searchMetadataTool.execute(authorizer, securityContext, params);
+
+      assertNotNull(result);
+      verify(searchRepository).getIndexOrAliasName("dataAsset");
+    }
+  }
+
+  @Test
+  void testQueryFilterAsJsonObjectIsSerialized() throws Exception {
+    try (MockedStatic<SubjectCache> subjectCacheMock = mockStatic(SubjectCache.class)) {
+      subjectCacheMock.when(() -> SubjectCache.getUserContext("test-user")).thenReturn(mockUser);
+
+      Map<String, Object> params = new HashMap<>();
+      params.put("queryFilter", Map.of("query", Map.of("term", Map.of("entityType", "table"))));
+
+      when(searchRepository.getIndexOrAliasName("dataAsset")).thenReturn("dataAsset");
+      Response mockResponse = mock(Response.class);
+      when(mockResponse.getEntity()).thenReturn("{\"hits\":{\"hits\":[],\"total\":{\"value\":0}}}");
+      when(searchRepository.searchWithDirectQuery(any(), any(SubjectContext.class)))
+          .thenReturn(mockResponse);
+
+      Map<String, Object> result = searchMetadataTool.execute(authorizer, securityContext, params);
+
+      assertNotNull(result);
+      ArgumentCaptor<SearchRequest> captor = ArgumentCaptor.forClass(SearchRequest.class);
+      verify(searchRepository).searchWithDirectQuery(captor.capture(), any(SubjectContext.class));
+      assertEquals(
+          "table",
+          JsonUtils.readTree(captor.getValue().getQueryFilter())
+              .at("/query/term/entityType")
+              .asText());
+    }
+  }
+
+  @Test
+  void testSearchRequestTargetsResolvedEntityTypeIndex() throws Exception {
+    try (MockedStatic<SubjectCache> subjectCacheMock = mockStatic(SubjectCache.class)) {
+      subjectCacheMock.when(() -> SubjectCache.getUserContext("test-user")).thenReturn(mockUser);
+
+      Map<String, Object> params = new HashMap<>();
+      params.put("query", "test");
+      params.put("entityType", "chart");
+
+      when(searchRepository.getIndexMapping("chart")).thenReturn(mock(IndexMapping.class));
+      when(searchRepository.getIndexOrAliasName("chart")).thenReturn("chart_search_index");
+      stubEmptySearch();
+
+      searchMetadataTool.execute(authorizer, securityContext, params);
+
+      ArgumentCaptor<SearchRequest> captor = ArgumentCaptor.forClass(SearchRequest.class);
+      verify(searchRepository).search(captor.capture(), any(SubjectContext.class));
+      assertEquals("chart_search_index", captor.getValue().getIndex());
+      assertEquals("test", captor.getValue().getQuery());
+    }
+  }
+
+  private void stubEmptySearch() throws Exception {
+    Response mockResponse = mock(Response.class);
+    when(mockResponse.getEntity()).thenReturn("{\"hits\":{\"hits\":[],\"total\":{\"value\":0}}}");
+    when(searchRepository.search(any(), any(SubjectContext.class))).thenReturn(mockResponse);
   }
 
   @Test

--- a/openmetadata-mcp/src/test/java/org/openmetadata/mcp/tools/SearchMetadataToolTest.java
+++ b/openmetadata-mcp/src/test/java/org/openmetadata/mcp/tools/SearchMetadataToolTest.java
@@ -1,8 +1,10 @@
 package org.openmetadata.mcp.tools;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.when;
@@ -10,6 +12,7 @@ import static org.mockito.Mockito.when;
 import jakarta.ws.rs.core.Response;
 import java.security.Principal;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
@@ -51,8 +54,8 @@ class SearchMetadataToolTest {
     searchRepository = mock(SearchRepository.class);
 
     Principal mockPrincipal = mock(Principal.class);
-    when(mockPrincipal.getName()).thenReturn("test-user");
-    when(securityContext.getUserPrincipal()).thenReturn(mockPrincipal);
+    lenient().when(mockPrincipal.getName()).thenReturn("test-user");
+    lenient().when(securityContext.getUserPrincipal()).thenReturn(mockPrincipal);
 
     mockUser = new User();
     mockUser.setId(UUID.randomUUID());
@@ -134,5 +137,61 @@ class SearchMetadataToolTest {
       assertEquals(0, result.get("returnedCount"));
       assertNotNull(result.get("results"));
     }
+  }
+
+  @Test
+  void testResultsIncludeSimilarityScoreFromScore() {
+    Map<String, Object> searchResponse =
+        searchResponseWith(buildHit(12.5, "db.schema.users"), buildHit(8.0, "db.schema.orders"));
+
+    Map<String, Object> result =
+        SearchMetadataTool.buildEnhancedSearchResponse(
+            searchResponse, "users", 10, List.of(), false, 0);
+
+    @SuppressWarnings("unchecked")
+    List<Map<String, Object>> results = (List<Map<String, Object>>) result.get("results");
+    assertEquals(2, results.size());
+    assertEquals(12.5, results.get(0).get("similarityScore"));
+    assertEquals(8.0, results.get(1).get("similarityScore"));
+  }
+
+  @Test
+  void testResultOmitsSimilarityScoreWhenScoreMissing() {
+    Map<String, Object> hit = new HashMap<>();
+    Map<String, Object> source = new HashMap<>();
+    source.put("entityType", "table");
+    source.put("fullyQualifiedName", "db.schema.users");
+    hit.put("_source", source);
+
+    Map<String, Object> result =
+        SearchMetadataTool.buildEnhancedSearchResponse(
+            searchResponseWith(hit), "users", 10, List.of(), false, 0);
+
+    @SuppressWarnings("unchecked")
+    List<Map<String, Object>> results = (List<Map<String, Object>>) result.get("results");
+    assertEquals(1, results.size());
+    assertFalse(results.get(0).containsKey("similarityScore"));
+  }
+
+  private Map<String, Object> buildHit(double score, String fqn) {
+    Map<String, Object> source = new HashMap<>();
+    source.put("entityType", "table");
+    source.put("fullyQualifiedName", fqn);
+
+    Map<String, Object> hit = new HashMap<>();
+    hit.put("_score", score);
+    hit.put("_source", source);
+    return hit;
+  }
+
+  @SafeVarargs
+  private final Map<String, Object> searchResponseWith(Map<String, Object>... hits) {
+    Map<String, Object> hitsContainer = new HashMap<>();
+    hitsContainer.put("hits", List.of(hits));
+    hitsContainer.put("total", Map.of("value", hits.length));
+
+    Map<String, Object> searchResponse = new HashMap<>();
+    searchResponse.put("hits", hitsContainer);
+    return searchResponse;
   }
 }

--- a/openmetadata-mcp/src/test/java/org/openmetadata/mcp/usage/McpUsageRecorderTest.java
+++ b/openmetadata-mcp/src/test/java/org/openmetadata/mcp/usage/McpUsageRecorderTest.java
@@ -144,6 +144,40 @@ class McpUsageRecorderTest {
     assertThat(decoded.getSuccess()).isFalse();
   }
 
+  @Test
+  void recordCapturesPhase3Metadata() {
+    stubMcpApp(UUID.randomUUID(), McpAppConstants.MCP_APP_NAME);
+
+    McpUsageRecorder.record(
+        "create_glossary",
+        "bob",
+        false,
+        342L,
+        McpToolCallUsage.ErrorCategory.AUTH,
+        "Claude Desktop");
+
+    ArgumentCaptor<String> json = ArgumentCaptor.forClass(String.class);
+    verify(dao).insert(json.capture(), eq("limits"));
+    McpToolCallUsage decoded = JsonUtils.readValue(json.getValue(), McpToolCallUsage.class);
+    assertThat(decoded.getLatencyMs()).isEqualTo(342L);
+    assertThat(decoded.getErrorCategory()).isEqualTo(McpToolCallUsage.ErrorCategory.AUTH);
+    assertThat(decoded.getClientName()).isEqualTo("Claude Desktop");
+  }
+
+  @Test
+  void legacy3ArgOverloadOmitsPhase3Fields() {
+    stubMcpApp(UUID.randomUUID(), McpAppConstants.MCP_APP_NAME);
+
+    McpUsageRecorder.record("search_metadata", "alice", true);
+
+    ArgumentCaptor<String> json = ArgumentCaptor.forClass(String.class);
+    verify(dao).insert(json.capture(), eq("limits"));
+    McpToolCallUsage decoded = JsonUtils.readValue(json.getValue(), McpToolCallUsage.class);
+    assertThat(decoded.getLatencyMs()).isNull();
+    assertThat(decoded.getErrorCategory()).isNull();
+    assertThat(decoded.getClientName()).isNull();
+  }
+
   private void stubMcpApp(UUID appId, String appName) {
     AbstractNativeApplication nativeApp = mock(AbstractNativeApplication.class);
     App app = new App().withId(appId).withName(appName);

--- a/openmetadata-mcp/src/test/java/org/openmetadata/mcp/util/McpParamsTest.java
+++ b/openmetadata-mcp/src/test/java/org/openmetadata/mcp/util/McpParamsTest.java
@@ -1,0 +1,74 @@
+/*
+ *  Copyright 2025 Collate
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.openmetadata.mcp.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Pins the three shared fall-through cases (missing key, present-but-null, unparseable) that the
+ * per-tool {@code parseIntParam}/{@code parseBooleanParam}/{@code parseDoubleParam} copies all
+ * funnelled to the default, so migrating the call sites to {@link McpParams} cannot drift.
+ */
+class McpParamsTest {
+
+  private static Map<String, Object> params(String key, Object value) {
+    Map<String, Object> params = new HashMap<>();
+    params.put(key, value);
+    return params;
+  }
+
+  @Test
+  void getIntAcceptsNumberAndNumericString() {
+    assertThat(McpParams.getInt(params("size", 25), "size", 1)).isEqualTo(25);
+    assertThat(McpParams.getInt(params("size", "30"), "size", 1)).isEqualTo(30);
+  }
+
+  @Test
+  void getIntFallsBackOnMissingNullAndUnparseable() {
+    assertThat(McpParams.getInt(new HashMap<>(), "size", 7)).isEqualTo(7);
+    assertThat(McpParams.getInt(params("size", null), "size", 7)).isEqualTo(7);
+    assertThat(McpParams.getInt(params("size", "abc"), "size", 7)).isEqualTo(7);
+  }
+
+  @Test
+  void getDoubleAcceptsNumberAndNumericString() {
+    assertThat(McpParams.getDouble(params("threshold", 0.5), "threshold", 0.0)).isEqualTo(0.5);
+    assertThat(McpParams.getDouble(params("threshold", "0.25"), "threshold", 0.0)).isEqualTo(0.25);
+  }
+
+  @Test
+  void getDoubleFallsBackOnMissingNullAndUnparseable() {
+    assertThat(McpParams.getDouble(new HashMap<>(), "threshold", 1.0)).isEqualTo(1.0);
+    assertThat(McpParams.getDouble(params("threshold", null), "threshold", 1.0)).isEqualTo(1.0);
+    assertThat(McpParams.getDouble(params("threshold", "x"), "threshold", 1.0)).isEqualTo(1.0);
+  }
+
+  @Test
+  void getBooleanAcceptsBooleanAndString() {
+    assertThat(McpParams.getBoolean(params("flag", true), "flag", false)).isTrue();
+    assertThat(McpParams.getBoolean(params("flag", "true"), "flag", false)).isTrue();
+    assertThat(McpParams.getBoolean(params("flag", "TRUE"), "flag", false)).isTrue();
+    assertThat(McpParams.getBoolean(params("flag", "nonsense"), "flag", false)).isFalse();
+  }
+
+  @Test
+  void getBooleanFallsBackOnMissingAndNull() {
+    assertThat(McpParams.getBoolean(new HashMap<>(), "flag", true)).isTrue();
+    assertThat(McpParams.getBoolean(params("flag", null), "flag", true)).isTrue();
+  }
+}

--- a/openmetadata-mcp/src/test/java/org/openmetadata/mcp/util/McpResponseTrimTest.java
+++ b/openmetadata-mcp/src/test/java/org/openmetadata/mcp/util/McpResponseTrimTest.java
@@ -1,0 +1,94 @@
+/*
+ *  Copyright 2025 Collate
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.openmetadata.mcp.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Pins the shared trimming primitives the MCP tools delegate to. The two truncate conventions are
+ * deliberately different (cut-at-max vs. cut-450-when-over-500); these tests guard against them
+ * being accidentally unified, which would silently change tool output.
+ */
+class McpResponseTrimTest {
+
+  @Test
+  void truncateCutsAtMaxAndAppendsEllipsis() {
+    String value = "a".repeat(600);
+
+    String result = McpResponseTrim.truncate(value, McpResponseTrim.SQL_MAX_LENGTH);
+
+    assertThat(result).hasSize(McpResponseTrim.SQL_MAX_LENGTH + 3).endsWith("...");
+  }
+
+  @Test
+  void truncateLeavesShortAndNullUntouched() {
+    assertThat(McpResponseTrim.truncate("short", McpResponseTrim.SQL_MAX_LENGTH))
+        .isEqualTo("short");
+    assertThat(McpResponseTrim.truncate(null, McpResponseTrim.SQL_MAX_LENGTH)).isNull();
+  }
+
+  @Test
+  void truncateDescriptionCutsTo450OnlyWhenOver500() {
+    String justOver = "b".repeat(501);
+    String atThreshold = "c".repeat(500);
+
+    String truncated = McpResponseTrim.truncateDescription(justOver);
+
+    assertThat(truncated).hasSize(McpResponseTrim.DESCRIPTION_TRUNCATE_LENGTH + 3).endsWith("...");
+    assertThat(McpResponseTrim.truncateDescription(atThreshold)).isEqualTo(atThreshold);
+    assertThat(McpResponseTrim.truncateDescription(null)).isNull();
+  }
+
+  @Test
+  void serializedLengthMatchesJsonSize() {
+    Map<String, Object> result = new LinkedHashMap<>();
+    result.put("a", "x");
+
+    assertThat(McpResponseTrim.serializedLength(result)).isEqualTo("{\"a\":\"x\"}".length());
+  }
+
+  @Test
+  void oversizedEnvelopeMergesIdentityAndFlagsTruncated() {
+    Map<String, Object> identity = new LinkedHashMap<>();
+    identity.put("tool", "get_entity_details");
+
+    Map<String, Object> envelope =
+        McpResponseTrim.oversizedEnvelope(123_456, identity, "Refine your query.");
+
+    assertThat(envelope.get("tool")).isEqualTo("get_entity_details");
+    assertThat(envelope.get("truncated")).isEqualTo(Boolean.TRUE);
+    assertThat(envelope.get("responseSizeChars")).isEqualTo(123_456);
+    assertThat(envelope.get("maxResponseChars")).isEqualTo(McpResponseTrim.MAX_RESPONSE_CHARS);
+    assertThat(envelope.get("message")).isEqualTo("Refine your query.");
+  }
+
+  @Test
+  void oversizedEnvelopeToleratesNullIdentity() {
+    Map<String, Object> envelope = McpResponseTrim.oversizedEnvelope(10, null, "advice");
+
+    assertThat(envelope)
+        .containsKeys("truncated", "responseSizeChars", "maxResponseChars", "message");
+  }
+
+  @Test
+  void safeMessageReplacesNullMessage() {
+    assertThat(McpResponseTrim.safeMessage(new RuntimeException("boom"))).isEqualTo("boom");
+    assertThat(McpResponseTrim.safeMessage(new RuntimeException())).isEqualTo("<no message>");
+    assertThat(McpResponseTrim.safeMessage(null)).isEqualTo("<no message>");
+  }
+}

--- a/openmetadata-service/src/main/java/org/openmetadata/service/events/scheduled/EventSubscriptionScheduler.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/events/scheduled/EventSubscriptionScheduler.java
@@ -23,6 +23,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Properties;
+import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import lombok.Getter;
@@ -666,8 +667,8 @@ public class EventSubscriptionScheduler {
     }
   }
 
-  private static final String AUDIT_LOG_JOB_GROUP = "OMAuditLogJobGroup";
-  private static final String AUDIT_LOG_JOB_ID = "AuditLogConsumerJob";
+  static final String AUDIT_LOG_JOB_GROUP = "OMAuditLogJobGroup";
+  static final String AUDIT_LOG_JOB_ID = "AuditLogConsumerJob";
   private static final int AUDIT_LOG_POLL_INTERVAL_SECONDS = 5;
 
   /**
@@ -676,29 +677,35 @@ public class EventSubscriptionScheduler {
    * in multi-server setups.
    */
   public void scheduleAuditLogConsumer() throws SchedulerException {
+    ensureAuditLogConsumerScheduled(alertsScheduler);
+  }
+
+  /**
+   * (Re)arms the audit log consumer trigger on every startup. With the clustered {@code JobStoreTX}
+   * the job and trigger persist across restarts, so a plain existence check sees the job and skips
+   * rescheduling forever. That strands the consumer whenever the persisted trigger stops firing —
+   * not only in ERROR/BLOCKED/PAUSED states, but also while still reported as WAITING/NORMAL with a
+   * frozen past next-fire-time (an abandoned trigger after an unclean shutdown). We therefore always
+   * replace it with a fresh trigger. The consumer offset lives in {@code change_event_consumers},
+   * not in Quartz, so re-arming loses no progress; {@code replace=true} swaps atomically so
+   * concurrent cluster nodes don't race.
+   */
+  static void ensureAuditLogConsumerScheduled(Scheduler scheduler) throws SchedulerException {
     JobKey jobKey = new JobKey(AUDIT_LOG_JOB_ID, AUDIT_LOG_JOB_GROUP);
-
-    // Check if already scheduled
-    if (alertsScheduler.checkExists(jobKey)) {
-      LOG.info("Audit log consumer job already scheduled");
-      return;
-    }
-
     JobDetail jobDetail =
         JobBuilder.newJob(AuditLogConsumer.class).withIdentity(jobKey).storeDurably().build();
-
-    Trigger trigger =
-        TriggerBuilder.newTrigger()
-            .withIdentity(AUDIT_LOG_JOB_ID, AUDIT_LOG_JOB_GROUP)
-            .withSchedule(
-                SimpleScheduleBuilder.repeatSecondlyForever(AUDIT_LOG_POLL_INTERVAL_SECONDS))
-            .startNow()
-            .build();
-
-    alertsScheduler.scheduleJob(jobDetail, trigger);
+    scheduler.scheduleJob(jobDetail, Set.of(buildAuditLogTrigger()), true);
     LOG.info(
-        "Audit log consumer scheduled with poll interval: {} seconds",
+        "Audit log consumer (re)scheduled with poll interval: {} seconds",
         AUDIT_LOG_POLL_INTERVAL_SECONDS);
+  }
+
+  private static Trigger buildAuditLogTrigger() {
+    return TriggerBuilder.newTrigger()
+        .withIdentity(AUDIT_LOG_JOB_ID, AUDIT_LOG_JOB_GROUP)
+        .withSchedule(SimpleScheduleBuilder.repeatSecondlyForever(AUDIT_LOG_POLL_INTERVAL_SECONDS))
+        .startNow()
+        .build();
   }
 
   public static void shutDown() throws SchedulerException {

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/TestCaseRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/TestCaseRepository.java
@@ -103,6 +103,7 @@ import org.openmetadata.service.resources.feeds.MessageParser;
 import org.openmetadata.service.resources.feeds.MessageParser.EntityLink;
 import org.openmetadata.service.resources.tags.TagLabelUtil;
 import org.openmetadata.service.search.SearchListFilter;
+import org.openmetadata.service.search.vector.TestCaseBodyTextContributor;
 import org.openmetadata.service.security.AuthorizationException;
 import org.openmetadata.service.util.EntityUtil;
 import org.openmetadata.service.util.EntityUtil.Fields;
@@ -134,6 +135,7 @@ public class TestCaseRepository extends EntityRepository<TestCase> {
         PATCH_FIELDS,
         UPDATE_FIELDS);
     supportsSearch = true;
+    TestCaseBodyTextContributor.INSTANCE.register();
     // Add the canonical name for test case results
     // As test case result` does not have its own repository
     EntityTimeSeriesInterface.CANONICAL_ENTITY_NAME_MAP.put(

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/TestSuiteRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/TestSuiteRepository.java
@@ -73,6 +73,7 @@ import org.openmetadata.service.search.SearchIndexUtils;
 import org.openmetadata.service.search.SearchListFilter;
 import org.openmetadata.service.search.SearchSortFilter;
 import org.openmetadata.service.search.indexes.SearchIndex;
+import org.openmetadata.service.search.vector.TestSuiteBodyTextContributor;
 import org.openmetadata.service.security.policyevaluator.SubjectContext;
 import org.openmetadata.service.util.AsyncService;
 import org.openmetadata.service.util.DeleteEntityResponse;
@@ -136,6 +137,7 @@ public class TestSuiteRepository extends EntityRepository<TestSuite> {
         UPDATE_FIELDS);
     quoteFqn = false;
     supportsSearch = true;
+    TestSuiteBodyTextContributor.INSTANCE.register();
     EntityLifecycleEventDispatcher.getInstance()
         .registerHandler(new TestSuitePipelineStatusHandler());
     fieldFetchers.put(SUMMARY_FIELD, this::fetchAndSetTestCaseResultSummary);

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/mcp/McpUsageResource.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/mcp/McpUsageResource.java
@@ -30,15 +30,18 @@ import java.time.Duration;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.ZoneOffset;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Consumer;
-import java.util.function.Function;
 import org.openmetadata.schema.entity.app.App;
 import org.openmetadata.schema.entity.app.AppExtension;
 import org.openmetadata.schema.entity.app.mcp.McpToolCallUsage;
@@ -73,6 +76,13 @@ public class McpUsageResource {
   static final String BOT_SUFFIX_KEBAB = "-bot";
   static final long DEFAULT_WINDOW_DAYS = 30L;
   private static final int PAGE_SIZE = 1000;
+
+  /**
+   * Upper bound on latency samples retained per aggregation bucket (summary and per-tool). Above
+   * this size we switch to reservoir sampling so percentile estimates stay statistically valid
+   * without inflating heap usage when a single tool gets millions of calls in the window.
+   */
+  static final int MAX_LATENCY_SAMPLES = 10_000;
 
   private final Authorizer authorizer;
   private final AppRepository appRepository;
@@ -121,8 +131,9 @@ public class McpUsageResource {
       operationId = "getMcpUsageHistory",
       summary = "Daily MCP usage counts",
       description =
-          "Returns a map of UTC start-of-day (epoch millis) to call count. Empty days are filled"
-              + " with 0 so the series is continuous. Admin access required.")
+          "Returns a map keyed by ISO date string (YYYY-MM-DD, UTC) to an object with 'ok' and"
+              + " 'fail' counters. Empty days are seeded with zeros so the series is continuous."
+              + " Admin access required.")
   public Response getHistory(
       @Context SecurityContext securityContext,
       @QueryParam("startTs") Long startTs,
@@ -141,8 +152,12 @@ public class McpUsageResource {
   @Path("/breakdown/tools")
   @Operation(
       operationId = "getMcpUsageByTool",
-      summary = "Per-tool call counts",
-      description = "Counts MCP requests per tool name in the supplied window. Admin only.")
+      summary = "Per-tool call counts with errors + latency",
+      description =
+          "Returns per-tool aggregates in the form { tool: { calls, errors, latencyP50, "
+              + "latencyP95 } }. Latency fields are present once rows recorded by the Phase 3 "
+              + "DefaultToolContext are in the window; otherwise the fields are omitted. Admin "
+              + "only.")
   public Response getByTool(
       @Context SecurityContext securityContext,
       @QueryParam("startTs") Long startTs,
@@ -154,18 +169,18 @@ public class McpUsageResource {
     if (invalid != null) {
       return invalid;
     }
-    Map<String, Long> counts = groupByCount(from, to, McpToolCallUsage::getToolName, true);
-    return Response.ok(counts).build();
+    return Response.ok(buildToolBreakdown(from, to)).build();
   }
 
   @GET
   @Path("/breakdown/users")
   @Operation(
       operationId = "getMcpUsageByUser",
-      summary = "Per-user call counts",
+      summary = "Per-user call counts with client name",
       description =
-          "Counts MCP requests per principal in the supplied window. Bot principals"
-              + " (suffix 'Bot') are excluded. Admin only.")
+          "Returns per-user aggregates in the form { user: { calls, client } } where client is "
+              + "the most-recent MCP client (Claude Desktop / Cursor / VS Code / CLI) the user "
+              + "connected with. Bot principals (suffix 'Bot') are excluded. Admin only.")
   public Response getByUser(
       @Context SecurityContext securityContext,
       @QueryParam("startTs") Long startTs,
@@ -177,8 +192,7 @@ public class McpUsageResource {
     if (invalid != null) {
       return invalid;
     }
-    Map<String, Long> counts = groupByCount(from, to, McpToolCallUsage::getUserName, false);
-    return Response.ok(counts).build();
+    return Response.ok(buildUserBreakdown(from, to)).build();
   }
 
   @GET
@@ -207,6 +221,8 @@ public class McpUsageResource {
     AtomicLong total = new AtomicLong();
     AtomicLong success = new AtomicLong();
     Set<String> users = new LinkedHashSet<>();
+    LatencySample latencies = new LatencySample();
+    Map<String, Long> errorByCategory = new LinkedHashMap<>();
     forEachRow(
         from,
         to,
@@ -214,9 +230,14 @@ public class McpUsageResource {
           total.incrementAndGet();
           if (Boolean.TRUE.equals(usage.getSuccess())) {
             success.incrementAndGet();
+          } else if (usage.getErrorCategory() != null) {
+            errorByCategory.merge(usage.getErrorCategory().value(), 1L, Long::sum);
           }
           if (usage.getUserName() != null && !isBot(usage.getUserName())) {
             users.add(usage.getUserName());
+          }
+          if (usage.getLatencyMs() != null && usage.getLatencyMs() >= 0) {
+            latencies.add(usage.getLatencyMs());
           }
         });
     Map<String, Object> body = new LinkedHashMap<>();
@@ -226,14 +247,142 @@ public class McpUsageResource {
     body.put("uniqueUsers", users.size());
     body.put("startTs", from);
     body.put("endTs", to);
+    List<Long> latencyValues = latencies.values();
+    if (!latencyValues.isEmpty()) {
+      body.put("avgLatencyMs", average(latencyValues));
+      body.put("p95LatencyMs", percentile(latencyValues, 95));
+    }
+    if (!errorByCategory.isEmpty()) {
+      body.put("errorByCategory", errorByCategory);
+    }
+    // Week-over-week trend: re-aggregate a same-sized window immediately prior. Only emit when
+    // the prior window has data so the UI doesn't display a spurious "+100%".
+    long priorFrom = from - (to - from);
+    if (priorFrom > 0) {
+      AtomicLong priorTotal = new AtomicLong();
+      forEachRow(priorFrom, from, u -> priorTotal.incrementAndGet());
+      if (priorTotal.get() > 0) {
+        double change = ((double) (total.get() - priorTotal.get()) / priorTotal.get()) * 100.0;
+        body.put("wowChangePct", Math.round(change * 10.0) / 10.0);
+      }
+    }
     return body;
   }
 
-  private Map<Long, Long> buildDailyHistory(long from, long to) {
-    Map<Long, Long> daily = new TreeMap<>();
-    seedEmptyDays(daily, from, to);
-    forEachRow(from, to, usage -> daily.merge(startOfDay(usage.getTimestamp()), 1L, Long::sum));
+  /**
+   * Daily ok/fail tallies. Returns a TreeMap keyed by ISO date string (YYYY-MM-DD) — the
+   * redesigned MCP page reads this shape directly to render a stacked bar chart of successful
+   * vs. failed requests. Days with no traffic are seeded with zeros so the chart renders a
+   * continuous series. Rows with a null timestamp are skipped — the schema doesn't require it
+   * so legacy or partial rows would otherwise NPE the {@link #isoDate} call.
+   */
+  private Map<String, Map<String, Long>> buildDailyHistory(long from, long to) {
+    Map<String, Map<String, Long>> daily = new TreeMap<>();
+    seedEmptyOkFailDays(daily, from, to);
+    forEachRow(
+        from,
+        to,
+        usage -> {
+          Long ts = usage.getTimestamp();
+          if (ts == null) {
+            return;
+          }
+          String day = isoDate(ts);
+          Map<String, Long> bucket =
+              daily.computeIfAbsent(
+                  day,
+                  k -> {
+                    Map<String, Long> m = new LinkedHashMap<>();
+                    m.put("ok", 0L);
+                    m.put("fail", 0L);
+                    return m;
+                  });
+          if (Boolean.TRUE.equals(usage.getSuccess())) {
+            bucket.merge("ok", 1L, Long::sum);
+          } else {
+            bucket.merge("fail", 1L, Long::sum);
+          }
+        });
     return daily;
+  }
+
+  private Map<String, Map<String, Object>> buildToolBreakdown(long from, long to) {
+    Map<String, Long> calls = new LinkedHashMap<>();
+    Map<String, Long> errors = new HashMap<>();
+    Map<String, LatencySample> latencies = new HashMap<>();
+    forEachRow(
+        from,
+        to,
+        usage -> {
+          String tool = usage.getToolName();
+          if (tool == null) {
+            return;
+          }
+          calls.merge(tool, 1L, Long::sum);
+          if (!Boolean.TRUE.equals(usage.getSuccess())) {
+            errors.merge(tool, 1L, Long::sum);
+          }
+          if (usage.getLatencyMs() != null && usage.getLatencyMs() >= 0) {
+            latencies.computeIfAbsent(tool, k -> new LatencySample()).add(usage.getLatencyMs());
+          }
+        });
+    Map<String, Map<String, Object>> result = new LinkedHashMap<>();
+    calls.entrySet().stream()
+        .sorted(Map.Entry.<String, Long>comparingByValue().reversed())
+        .forEach(
+            e -> {
+              Map<String, Object> row = new LinkedHashMap<>();
+              row.put("calls", e.getValue());
+              row.put("errors", errors.getOrDefault(e.getKey(), 0L));
+              LatencySample toolLatencies = latencies.get(e.getKey());
+              if (toolLatencies != null && !toolLatencies.isEmpty()) {
+                List<Long> values = toolLatencies.values();
+                row.put("latencyP50", percentile(values, 50));
+                row.put("latencyP95", percentile(values, 95));
+              }
+              result.put(e.getKey(), row);
+            });
+    return result;
+  }
+
+  private Map<String, Map<String, Object>> buildUserBreakdown(long from, long to) {
+    Map<String, Long> calls = new LinkedHashMap<>();
+    Map<String, String> latestClient = new HashMap<>();
+    Map<String, Long> latestClientTs = new HashMap<>();
+    forEachRow(
+        from,
+        to,
+        usage -> {
+          String user = usage.getUserName();
+          if (user == null || isBot(user)) {
+            return;
+          }
+          calls.merge(user, 1L, Long::sum);
+          String client = usage.getClientName();
+          if (client != null && !client.isBlank() && usage.getTimestamp() != null) {
+            // Keep the client name from the user's most-recent call in the window. Rolls forward
+            // naturally if a user switches IDE mid-window.
+            Long previousTs = latestClientTs.get(user);
+            if (previousTs == null || usage.getTimestamp() > previousTs) {
+              latestClient.put(user, client);
+              latestClientTs.put(user, usage.getTimestamp());
+            }
+          }
+        });
+    Map<String, Map<String, Object>> result = new LinkedHashMap<>();
+    calls.entrySet().stream()
+        .sorted(Map.Entry.<String, Long>comparingByValue().reversed())
+        .forEach(
+            e -> {
+              Map<String, Object> row = new LinkedHashMap<>();
+              row.put("calls", e.getValue());
+              String client = latestClient.get(e.getKey());
+              if (client != null) {
+                row.put("client", client);
+              }
+              result.put(e.getKey(), row);
+            });
+    return result;
   }
 
   private Map<String, Object> buildSelf(String userName, long from, long to) {
@@ -257,25 +406,6 @@ public class McpUsageResource {
     body.put("startTs", from);
     body.put("endTs", to);
     return body;
-  }
-
-  private Map<String, Long> groupByCount(
-      long from, long to, Function<McpToolCallUsage, String> classifier, boolean includeBots) {
-    Map<String, Long> counts = new LinkedHashMap<>();
-    forEachRow(
-        from,
-        to,
-        usage -> {
-          String key = classifier.apply(usage);
-          if (key == null) {
-            return;
-          }
-          if (!includeBots && isBot(key)) {
-            return;
-          }
-          counts.merge(key, 1L, Long::sum);
-        });
-    return counts;
   }
 
   /**
@@ -348,6 +478,10 @@ public class McpUsageResource {
         .toEpochMilli();
   }
 
+  static String isoDate(long epochMillis) {
+    return LocalDate.ofInstant(Instant.ofEpochMilli(epochMillis), ZoneOffset.UTC).toString();
+  }
+
   static boolean isBot(String principal) {
     if (principal == null) {
       return false;
@@ -355,12 +489,75 @@ public class McpUsageResource {
     return principal.endsWith(BOT_SUFFIX_PASCAL) || principal.endsWith(BOT_SUFFIX_KEBAB);
   }
 
-  private static void seedEmptyDays(Map<Long, Long> daily, long from, long to) {
+  private static void seedEmptyOkFailDays(
+      Map<String, Map<String, Long>> daily, long from, long to) {
     long cursor = startOfDay(from);
     long lastDay = startOfDay(to - 1);
     while (cursor <= lastDay) {
-      daily.put(cursor, 0L);
+      Map<String, Long> row = new LinkedHashMap<>();
+      row.put("ok", 0L);
+      row.put("fail", 0L);
+      daily.put(isoDate(cursor), row);
       cursor = cursor + Duration.ofDays(1).toMillis();
+    }
+  }
+
+  static double average(List<Long> samples) {
+    if (samples.isEmpty()) {
+      return 0.0;
+    }
+    long sum = 0;
+    for (Long s : samples) {
+      sum += s;
+    }
+    return Math.round((double) sum / samples.size() * 10.0) / 10.0;
+  }
+
+  /**
+   * Nearest-rank percentile over an unsorted list. Sort is local so the caller doesn't have to
+   * pre-order; samples list is bounded by {@link #MAX_LATENCY_SAMPLES} entries, so the O(n log n)
+   * cost is dominated by the surrounding aggregation pass.
+   */
+  static long percentile(List<Long> samples, int p) {
+    if (samples.isEmpty()) {
+      return 0L;
+    }
+    List<Long> sorted = new ArrayList<>(samples);
+    Collections.sort(sorted);
+    int idx =
+        Math.min(sorted.size() - 1, Math.max(0, (int) Math.ceil((p / 100.0) * sorted.size()) - 1));
+    return sorted.get(idx);
+  }
+
+  /**
+   * Bounded latency accumulator that switches to reservoir sampling once it sees more than
+   * {@link #MAX_LATENCY_SAMPLES} entries. Caps heap usage at ~80KB per bucket while keeping
+   * percentile estimates statistically valid even for tools that handle millions of calls in the
+   * aggregation window. Not thread-safe; one instance is owned per aggregation bucket and only
+   * touched on the request thread.
+   */
+  static final class LatencySample {
+    private final List<Long> samples = new ArrayList<>();
+    private long seen = 0L;
+
+    void add(long value) {
+      seen++;
+      if (samples.size() < MAX_LATENCY_SAMPLES) {
+        samples.add(value);
+      } else {
+        long idx = ThreadLocalRandom.current().nextLong(seen);
+        if (idx < MAX_LATENCY_SAMPLES) {
+          samples.set((int) idx, value);
+        }
+      }
+    }
+
+    boolean isEmpty() {
+      return samples.isEmpty();
+    }
+
+    List<Long> values() {
+      return samples;
     }
   }
 }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/vector/TestCaseBodyTextContributor.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/vector/TestCaseBodyTextContributor.java
@@ -1,0 +1,99 @@
+/*
+ *  Copyright 2024 Collate
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.openmetadata.service.search.vector;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.openmetadata.schema.EntityInterface;
+import org.openmetadata.schema.tests.TestCase;
+import org.openmetadata.schema.tests.TestCaseParameterValue;
+import org.openmetadata.schema.tests.type.TestCaseResult;
+import org.openmetadata.schema.type.EntityReference;
+import org.openmetadata.service.Entity;
+import org.openmetadata.service.search.vector.VectorDocBuilder.BodyTextExtractor;
+
+/**
+ * Body text contributor for {@link TestCase}. A test case's semantic payload is spread across its
+ * test definition, the data asset it validates ({@code entityFQN}), its parameter values, and its
+ * latest result — not {@code description}, which is usually empty or formulaic. The default
+ * description-only extractor would feed near-empty text to the embedding model, so this contributor
+ * concatenates the populated fields into a labelled body so the vector represents what the test
+ * actually checks and on which asset. Reads only fields already populated on the entity (no extra
+ * lookups) to stay on the create/update hot path.
+ */
+public final class TestCaseBodyTextContributor implements VectorBodyTextContributor {
+
+  public static final TestCaseBodyTextContributor INSTANCE = new TestCaseBodyTextContributor();
+
+  private TestCaseBodyTextContributor() {}
+
+  @Override
+  public String entityType() {
+    return Entity.TEST_CASE;
+  }
+
+  @Override
+  public BodyTextExtractor extractor() {
+    return TestCaseBodyTextContributor::extractBodyText;
+  }
+
+  static String extractBodyText(EntityInterface entity) {
+    if (!(entity instanceof TestCase testCase)) {
+      return null;
+    }
+    List<String> parts = new ArrayList<>();
+    appendIfPresent(parts, "description", testCase.getDescription());
+    appendRef(parts, "testDefinition", testCase.getTestDefinition());
+    appendIfPresent(parts, "testedAsset", testCase.getEntityFQN());
+    appendParameters(parts, testCase.getParameterValues());
+    appendResult(parts, testCase.getTestCaseResult());
+    return parts.isEmpty() ? "" : String.join("; ", parts);
+  }
+
+  private static void appendRef(List<String> parts, String label, EntityReference ref) {
+    if (ref == null) {
+      return;
+    }
+    String value = ref.getName() != null ? ref.getName() : ref.getFullyQualifiedName();
+    appendIfPresent(parts, label, value);
+  }
+
+  private static void appendParameters(List<String> parts, List<TestCaseParameterValue> values) {
+    if (values == null || values.isEmpty()) {
+      return;
+    }
+    List<String> rendered = new ArrayList<>();
+    for (TestCaseParameterValue value : values) {
+      if (value.getName() != null) {
+        rendered.add(value.getName() + "=" + (value.getValue() == null ? "" : value.getValue()));
+      }
+    }
+    if (!rendered.isEmpty()) {
+      parts.add("parameters: " + String.join(", ", rendered));
+    }
+  }
+
+  private static void appendResult(List<String> parts, TestCaseResult result) {
+    if (result == null || result.getTestCaseStatus() == null) {
+      return;
+    }
+    parts.add("status: " + result.getTestCaseStatus().value());
+  }
+
+  private static void appendIfPresent(List<String> parts, String label, String value) {
+    if (value == null || value.isBlank()) {
+      return;
+    }
+    parts.add(label + ": " + value.strip());
+  }
+}

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/vector/TestSuiteBodyTextContributor.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/vector/TestSuiteBodyTextContributor.java
@@ -1,0 +1,71 @@
+/*
+ *  Copyright 2024 Collate
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.openmetadata.service.search.vector;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.openmetadata.schema.EntityInterface;
+import org.openmetadata.schema.tests.TestSuite;
+import org.openmetadata.schema.type.EntityReference;
+import org.openmetadata.service.Entity;
+import org.openmetadata.service.search.vector.VectorDocBuilder.BodyTextExtractor;
+
+/**
+ * Body text contributor for {@link TestSuite}. A suite's semantic payload is its name/description
+ * plus the data asset it groups tests for (its basic entity reference) — so a query like "test
+ * suites for customer" can match on the linked table name even when the suite description is empty.
+ * Reads only fields already populated on the entity (no extra lookups) to stay on the create/update
+ * hot path.
+ */
+public final class TestSuiteBodyTextContributor implements VectorBodyTextContributor {
+
+  public static final TestSuiteBodyTextContributor INSTANCE = new TestSuiteBodyTextContributor();
+
+  private TestSuiteBodyTextContributor() {}
+
+  @Override
+  public String entityType() {
+    return Entity.TEST_SUITE;
+  }
+
+  @Override
+  public BodyTextExtractor extractor() {
+    return TestSuiteBodyTextContributor::extractBodyText;
+  }
+
+  static String extractBodyText(EntityInterface entity) {
+    if (!(entity instanceof TestSuite testSuite)) {
+      return null;
+    }
+    List<String> parts = new ArrayList<>();
+    appendIfPresent(parts, "description", testSuite.getDescription());
+    appendRef(parts, "testedAsset", testSuite.getBasicEntityReference());
+    return parts.isEmpty() ? "" : String.join("; ", parts);
+  }
+
+  private static void appendRef(List<String> parts, String label, EntityReference ref) {
+    if (ref == null) {
+      return;
+    }
+    String value =
+        ref.getFullyQualifiedName() != null ? ref.getFullyQualifiedName() : ref.getName();
+    appendIfPresent(parts, label, value);
+  }
+
+  private static void appendIfPresent(List<String> parts, String label, String value) {
+    if (value == null || value.isBlank()) {
+      return;
+    }
+    parts.add(label + ": " + value.strip());
+  }
+}

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/vector/utils/AvailableEntityTypes.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/vector/utils/AvailableEntityTypes.java
@@ -29,7 +29,9 @@ public final class AvailableEntityTypes {
           "searchIndex",
           "topic",
           "contextMemory",
-          "container");
+          "container",
+          "testSuite",
+          "testCase");
 
   public static final Set<String> SET =
       LIST.stream().map(s -> s.toLowerCase(Locale.ROOT)).collect(Collectors.toUnmodifiableSet());

--- a/openmetadata-service/src/test/java/org/openmetadata/service/events/scheduled/EventSubscriptionSchedulerTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/events/scheduled/EventSubscriptionSchedulerTest.java
@@ -15,9 +15,25 @@ package org.openmetadata.service.events.scheduled;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Date;
+import java.util.Properties;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.openmetadata.service.audit.AuditLogConsumer;
+import org.quartz.JobBuilder;
+import org.quartz.JobDetail;
+import org.quartz.JobKey;
+import org.quartz.Scheduler;
+import org.quartz.SchedulerException;
+import org.quartz.SimpleScheduleBuilder;
+import org.quartz.Trigger;
+import org.quartz.TriggerBuilder;
+import org.quartz.TriggerKey;
+import org.quartz.impl.StdSchedulerFactory;
 
 class EventSubscriptionSchedulerTest {
 
@@ -45,5 +61,128 @@ class EventSubscriptionSchedulerTest {
     assertNotNull(EventSubscriptionScheduler.ALERT_JOB_GROUP, "ALERT_JOB_GROUP should be defined");
     assertNotNull(
         EventSubscriptionScheduler.ALERT_TRIGGER_GROUP, "ALERT_TRIGGER_GROUP should be defined");
+  }
+
+  @Test
+  @DisplayName("Audit log consumer is scheduled and firing when absent")
+  void testEnsureAuditLogConsumerSchedulesWhenAbsent() throws SchedulerException {
+    Scheduler scheduler = newStandbyScheduler("audit-absent");
+    try {
+      EventSubscriptionScheduler.ensureAuditLogConsumerScheduled(scheduler);
+
+      assertTrue(scheduler.checkExists(auditJobKey()), "Audit log consumer job should exist");
+      assertEquals(
+          Trigger.TriggerState.NORMAL,
+          scheduler.getTriggerState(auditTriggerKey()),
+          "Trigger should be firing");
+    } finally {
+      scheduler.shutdown(true);
+    }
+  }
+
+  @Test
+  @DisplayName("Audit log consumer re-arms an abandoned trigger frozen with a past next-fire-time")
+  void testEnsureAuditLogConsumerReArmsAbandonedTrigger() throws SchedulerException {
+    Scheduler scheduler = newStandbyScheduler("audit-abandoned");
+    try {
+      scheduleStaleAuditTrigger(scheduler);
+      Date staleNextFire = scheduler.getTrigger(auditTriggerKey()).getNextFireTime();
+      assertEquals(
+          Trigger.TriggerState.NORMAL,
+          scheduler.getTriggerState(auditTriggerKey()),
+          "Precondition: an abandoned trigger still reports as NORMAL/WAITING");
+
+      EventSubscriptionScheduler.ensureAuditLogConsumerScheduled(scheduler);
+
+      Date freshNextFire = scheduler.getTrigger(auditTriggerKey()).getNextFireTime();
+      assertTrue(
+          freshNextFire.after(staleNextFire),
+          "A NORMAL-but-frozen trigger must be re-armed with a fresh next-fire-time");
+    } finally {
+      scheduler.shutdown(true);
+    }
+  }
+
+  @Test
+  @DisplayName("Audit log consumer recovers a paused trigger")
+  void testEnsureAuditLogConsumerRecoversPausedTrigger() throws SchedulerException {
+    Scheduler scheduler = newStandbyScheduler("audit-paused");
+    try {
+      EventSubscriptionScheduler.ensureAuditLogConsumerScheduled(scheduler);
+      scheduler.pauseTrigger(auditTriggerKey());
+      assertEquals(
+          Trigger.TriggerState.PAUSED,
+          scheduler.getTriggerState(auditTriggerKey()),
+          "Precondition: trigger is paused");
+
+      EventSubscriptionScheduler.ensureAuditLogConsumerScheduled(scheduler);
+
+      assertEquals(
+          Trigger.TriggerState.NORMAL,
+          scheduler.getTriggerState(auditTriggerKey()),
+          "A paused trigger must be re-armed back to NORMAL");
+    } finally {
+      scheduler.shutdown(true);
+    }
+  }
+
+  @Test
+  @DisplayName("Repeated scheduling keeps a single firing job")
+  void testEnsureAuditLogConsumerIsIdempotent() throws SchedulerException {
+    Scheduler scheduler = newStandbyScheduler("audit-idempotent");
+    try {
+      EventSubscriptionScheduler.ensureAuditLogConsumerScheduled(scheduler);
+      EventSubscriptionScheduler.ensureAuditLogConsumerScheduled(scheduler);
+
+      assertEquals(
+          1,
+          scheduler.getTriggersOfJob(auditJobKey()).size(),
+          "Job should have exactly one trigger after repeated scheduling");
+      assertEquals(
+          Trigger.TriggerState.NORMAL,
+          scheduler.getTriggerState(auditTriggerKey()),
+          "Trigger should remain firing");
+    } finally {
+      scheduler.shutdown(true);
+    }
+  }
+
+  private static void scheduleStaleAuditTrigger(Scheduler scheduler) throws SchedulerException {
+    JobDetail jobDetail =
+        JobBuilder.newJob(AuditLogConsumer.class)
+            .withIdentity(auditJobKey())
+            .storeDurably()
+            .build();
+    Trigger staleTrigger =
+        TriggerBuilder.newTrigger()
+            .withIdentity(auditTriggerKey())
+            .withSchedule(SimpleScheduleBuilder.repeatSecondlyForever(5))
+            .startAt(Date.from(Instant.now().minus(Duration.ofDays(60))))
+            .build();
+    scheduler.scheduleJob(jobDetail, staleTrigger);
+  }
+
+  private static JobKey auditJobKey() {
+    return new JobKey(
+        EventSubscriptionScheduler.AUDIT_LOG_JOB_ID,
+        EventSubscriptionScheduler.AUDIT_LOG_JOB_GROUP);
+  }
+
+  private static TriggerKey auditTriggerKey() {
+    return new TriggerKey(
+        EventSubscriptionScheduler.AUDIT_LOG_JOB_ID,
+        EventSubscriptionScheduler.AUDIT_LOG_JOB_GROUP);
+  }
+
+  private static Scheduler newStandbyScheduler(String instanceName) throws SchedulerException {
+    Properties properties = new Properties();
+    properties.put("org.quartz.scheduler.instanceName", instanceName);
+    properties.put("org.quartz.scheduler.skipUpdateCheck", "true");
+    properties.put("org.quartz.threadPool.class", "org.quartz.simpl.SimpleThreadPool");
+    properties.put("org.quartz.threadPool.threadCount", "1");
+    properties.put("org.quartz.jobStore.class", "org.quartz.simpl.RAMJobStore");
+    StdSchedulerFactory factory = new StdSchedulerFactory();
+    factory.initialize(properties);
+    return factory.getScheduler();
   }
 }

--- a/openmetadata-service/src/test/java/org/openmetadata/service/resources/mcp/McpUsageResourceTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/resources/mcp/McpUsageResourceTest.java
@@ -122,10 +122,12 @@ class McpUsageResourceTest {
     Response toolsResp = resource.getByTool(adminContext, null, null);
 
     long summaryTotal = ((Number) bodyAsMap(summaryResp).get("total")).longValue();
+    Map<String, Map<String, Object>> tools =
+        (Map<String, Map<String, Object>>) toolsResp.getEntity();
     long toolsTotal =
-        ((Map<String, Long>) toolsResp.getEntity())
-            .values().stream().mapToLong(Long::longValue).sum();
+        tools.values().stream().mapToLong(row -> ((Number) row.get("calls")).longValue()).sum();
     assertThat(toolsTotal).isEqualTo(summaryTotal);
+    assertThat(tools.get("search_metadata").get("errors")).isEqualTo(0L);
   }
 
   @Test
@@ -140,10 +142,10 @@ class McpUsageResourceTest {
 
     Response response = resource.getByUser(adminContext, null, null);
 
-    Map<String, Long> body = (Map<String, Long>) response.getEntity();
+    Map<String, Map<String, Object>> body = (Map<String, Map<String, Object>>) response.getEntity();
     assertThat(body).containsOnlyKeys("alice", "robot-overlord");
-    assertThat(body.get("alice")).isEqualTo(1L);
-    assertThat(body.get("robot-overlord")).isEqualTo(1L);
+    assertThat(body.get("alice").get("calls")).isEqualTo(1L);
+    assertThat(body.get("robot-overlord").get("calls")).isEqualTo(1L);
   }
 
   @Test
@@ -159,10 +161,106 @@ class McpUsageResourceTest {
     Response response =
         resource.getHistory(adminContext, twoDaysAgo, today + Duration.ofDays(1).toMillis());
 
-    Map<Long, Long> body = (Map<Long, Long>) response.getEntity();
-    assertThat(body.get(twoDaysAgo)).isEqualTo(1L);
-    assertThat(body.get(yesterday)).isEqualTo(0L);
-    assertThat(body.get(today)).isEqualTo(2L);
+    Map<String, Map<String, Long>> body = (Map<String, Map<String, Long>>) response.getEntity();
+    String todayIso = McpUsageResource.isoDate(today);
+    String yesterdayIso = McpUsageResource.isoDate(yesterday);
+    String twoDaysAgoIso = McpUsageResource.isoDate(twoDaysAgo);
+    assertThat(body.get(twoDaysAgoIso)).containsEntry("ok", 1L).containsEntry("fail", 0L);
+    assertThat(body.get(yesterdayIso)).containsEntry("ok", 0L).containsEntry("fail", 0L);
+    assertThat(body.get(todayIso)).containsEntry("ok", 2L).containsEntry("fail", 0L);
+  }
+
+  @Test
+  void historySplitsOkAndFail() {
+    long today = McpUsageResource.startOfDay(Instant.now().toEpochMilli());
+    stubRows(
+        row("a", "alice", true, today + 1000),
+        row("a", "alice", false, today + 2000),
+        row("a", "alice", false, today + 3000));
+
+    Response response =
+        resource.getHistory(adminContext, today, today + Duration.ofDays(1).toMillis());
+
+    Map<String, Map<String, Long>> body = (Map<String, Map<String, Long>>) response.getEntity();
+    Map<String, Long> bucket = body.get(McpUsageResource.isoDate(today));
+    assertThat(bucket).containsEntry("ok", 1L).containsEntry("fail", 2L);
+  }
+
+  @Test
+  void summaryAggregatesLatencyAndErrorCategory() {
+    long now = Instant.now().toEpochMilli();
+    stubRows(
+        rowWithMetadata("search_metadata", "alice", true, daysAgo(1), 120L, null, "Claude Desktop"),
+        rowWithMetadata("search_metadata", "alice", true, daysAgo(1), 240L, null, "Claude Desktop"),
+        rowWithMetadata(
+            "search_metadata",
+            "bob",
+            false,
+            daysAgo(1),
+            500L,
+            McpToolCallUsage.ErrorCategory.AUTH,
+            "Cursor"),
+        rowWithMetadata(
+            "search_metadata",
+            "bob",
+            false,
+            daysAgo(1),
+            null,
+            McpToolCallUsage.ErrorCategory.AUTH,
+            "Cursor"));
+
+    Response response = resource.getSummary(adminContext, null, null);
+
+    Map<String, Object> body = bodyAsMap(response);
+    assertThat(body.get("total")).isEqualTo(4L);
+    assertThat(body.get("totalSuccess")).isEqualTo(2L);
+    assertThat(body.get("totalFailed")).isEqualTo(2L);
+    // Latencies present on three of four rows; avg = (120+240+500)/3 = 286.7
+    assertThat((Double) body.get("avgLatencyMs"))
+        .isCloseTo(286.7, org.assertj.core.data.Offset.offset(0.1));
+    assertThat(body.get("p95LatencyMs")).isEqualTo(500L);
+    @SuppressWarnings("unchecked")
+    Map<String, Long> errorByCategory = (Map<String, Long>) body.get("errorByCategory");
+    assertThat(errorByCategory).containsEntry("AUTH", 2L);
+    // Suppress unused-variable warning for the explicit timestamp we built the rows around.
+    assertThat(now).isPositive();
+  }
+
+  @Test
+  void byUserCarriesLatestClient() {
+    stubRows(
+        rowWithMetadata("a", "alice", true, daysAgo(2), 100L, null, "Cursor"),
+        rowWithMetadata("a", "alice", true, daysAgo(1), 120L, null, "Claude Desktop"));
+
+    Response response = resource.getByUser(adminContext, null, null);
+
+    Map<String, Map<String, Object>> body = (Map<String, Map<String, Object>>) response.getEntity();
+    assertThat(body.get("alice").get("calls")).isEqualTo(2L);
+    assertThat(body.get("alice").get("client")).isEqualTo("Claude Desktop");
+  }
+
+  @Test
+  void byToolReportsErrorsAndLatencyPercentiles() {
+    stubRows(
+        rowWithMetadata("search_metadata", "alice", true, daysAgo(1), 100L, null, null),
+        rowWithMetadata("search_metadata", "alice", true, daysAgo(1), 200L, null, null),
+        rowWithMetadata("search_metadata", "alice", true, daysAgo(1), 300L, null, null),
+        rowWithMetadata(
+            "search_metadata",
+            "bob",
+            false,
+            daysAgo(1),
+            null,
+            McpToolCallUsage.ErrorCategory.VALIDATION,
+            null));
+
+    Response response = resource.getByTool(adminContext, null, null);
+
+    Map<String, Map<String, Object>> body = (Map<String, Map<String, Object>>) response.getEntity();
+    Map<String, Object> row = body.get("search_metadata");
+    assertThat(row.get("calls")).isEqualTo(4L);
+    assertThat(row.get("errors")).isEqualTo(1L);
+    assertThat(row.get("latencyP95")).isEqualTo(300L);
   }
 
   @Test
@@ -197,6 +295,39 @@ class McpUsageResourceTest {
     Response response = resource.getByTool(adminContext, now, now);
 
     assertThat(response.getStatus()).isEqualTo(400);
+  }
+
+  @Test
+  void historySkipsRowsWithNullTimestamp() {
+    long today = McpUsageResource.startOfDay(Instant.now().toEpochMilli());
+    McpToolCallUsage rowWithoutTs =
+        new McpToolCallUsage()
+            .withAppId(UUID.randomUUID())
+            .withAppName(McpAppConstants.MCP_APP_NAME)
+            .withExtension(AppExtension.ExtensionType.LIMITS)
+            .withToolName("search_metadata")
+            .withUserName("alice")
+            .withSuccess(true);
+    stubRows(rowWithoutTs, row("search_metadata", "alice", true, today + 1000));
+
+    Response response =
+        resource.getHistory(adminContext, today, today + Duration.ofDays(1).toMillis());
+
+    Map<String, Map<String, Long>> body = (Map<String, Map<String, Long>>) response.getEntity();
+    assertThat(body.get(McpUsageResource.isoDate(today)))
+        .containsEntry("ok", 1L)
+        .containsEntry("fail", 0L);
+  }
+
+  @Test
+  void latencySampleBoundsMemoryViaReservoirSampling() {
+    McpUsageResource.LatencySample sample = new McpUsageResource.LatencySample();
+    int feed = McpUsageResource.MAX_LATENCY_SAMPLES * 5;
+    for (int i = 0; i < feed; i++) {
+      sample.add(i);
+    }
+
+    assertThat(sample.values()).hasSize(McpUsageResource.MAX_LATENCY_SAMPLES);
   }
 
   @Test
@@ -257,6 +388,20 @@ class McpUsageResourceTest {
         .withUserName(user)
         .withSuccess(success)
         .withTimestamp(ts);
+  }
+
+  private static McpToolCallUsage rowWithMetadata(
+      String tool,
+      String user,
+      boolean success,
+      long ts,
+      Long latencyMs,
+      McpToolCallUsage.ErrorCategory errorCategory,
+      String clientName) {
+    return row(tool, user, success, ts)
+        .withLatencyMs(latencyMs)
+        .withErrorCategory(errorCategory)
+        .withClientName(clientName);
   }
 
   private static long daysAgo(int days) {

--- a/openmetadata-service/src/test/java/org/openmetadata/service/search/vector/TestEntityBodyTextContributorTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/search/vector/TestEntityBodyTextContributorTest.java
@@ -1,0 +1,83 @@
+/*
+ *  Copyright 2024 Collate
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.openmetadata.service.search.vector;
+
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.openmetadata.schema.tests.TestCase;
+import org.openmetadata.schema.tests.TestCaseParameterValue;
+import org.openmetadata.schema.tests.TestSuite;
+import org.openmetadata.schema.tests.type.TestCaseResult;
+import org.openmetadata.schema.tests.type.TestCaseStatus;
+import org.openmetadata.schema.type.EntityReference;
+import org.openmetadata.service.Entity;
+
+class TestEntityBodyTextContributorTest {
+
+  @Test
+  void testCaseBodyTextIncludesDefinitionAssetParamsAndStatus() {
+    TestCase testCase =
+        new TestCase()
+            .withId(UUID.randomUUID())
+            .withName("customers_email_not_null")
+            .withDescription("Ensure email is populated")
+            .withEntityFQN("snowflake.sales.public.customers")
+            .withTestDefinition(
+                new EntityReference()
+                    .withName("columnValuesToBeNotNull")
+                    .withType(Entity.TEST_DEFINITION))
+            .withParameterValues(
+                List.of(new TestCaseParameterValue().withName("columnName").withValue("email")))
+            .withTestCaseResult(new TestCaseResult().withTestCaseStatus(TestCaseStatus.Failed));
+
+    String body = TestCaseBodyTextContributor.extractBodyText(testCase);
+
+    assertTrue(body.contains("Ensure email is populated"), "description should be present");
+    assertTrue(body.contains("columnValuesToBeNotNull"), "test definition should be present");
+    assertTrue(
+        body.contains("snowflake.sales.public.customers"), "tested asset FQN should be present");
+    assertTrue(body.contains("columnName=email"), "parameter values should be present");
+    assertTrue(body.contains("Failed"), "latest status should be present");
+  }
+
+  @Test
+  void testSuiteBodyTextIncludesDescriptionAndLinkedAsset() {
+    TestSuite testSuite =
+        new TestSuite()
+            .withId(UUID.randomUUID())
+            .withName("customers_suite")
+            .withDescription("Quality checks for customers")
+            .withBasicEntityReference(
+                new EntityReference()
+                    .withName("customers")
+                    .withFullyQualifiedName("snowflake.sales.public.customers")
+                    .withType(Entity.TABLE));
+
+    String body = TestSuiteBodyTextContributor.extractBodyText(testSuite);
+
+    assertTrue(body.contains("Quality checks for customers"), "description should be present");
+    assertTrue(
+        body.contains("snowflake.sales.public.customers"), "linked asset FQN should be present");
+  }
+
+  @Test
+  void extractorsReturnNullForWrongEntityType() {
+    // Wrong-type input must fall back to the default extractor (null signals fallback).
+    assertNull(TestCaseBodyTextContributor.extractBodyText(new TestSuite()));
+    assertNull(TestSuiteBodyTextContributor.extractBodyText(new TestCase()));
+  }
+}

--- a/openmetadata-spec/src/main/resources/elasticsearch/en/test_case_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/en/test_case_index_mapping.json
@@ -1,5 +1,6 @@
 {
   "settings": {
+    "index": {},
     "analysis": {
       "tokenizer": {
         "edge_ngram_tokenizer": {
@@ -74,6 +75,24 @@
   },
   "mappings": {
     "properties": {
+      "fingerprint": {
+        "type": "keyword"
+      },
+      "textToLLMContext": {
+        "type": "text"
+      },
+      "textToEmbed": {
+        "type": "text"
+      },
+      "chunkIndex": {
+        "type": "integer"
+      },
+      "chunkCount": {
+        "type": "integer"
+      },
+      "parentId": {
+        "type": "keyword"
+      },
       "changeDescription": {
         "enabled": false
       },

--- a/openmetadata-spec/src/main/resources/elasticsearch/en/test_suite_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/en/test_suite_index_mapping.json
@@ -1,5 +1,6 @@
 {
   "settings": {
+    "index": {},
     "analysis": {
       "tokenizer": {
         "edge_ngram_tokenizer": {
@@ -72,6 +73,24 @@
   },
   "mappings": {
     "properties": {
+      "fingerprint": {
+        "type": "keyword"
+      },
+      "textToLLMContext": {
+        "type": "text"
+      },
+      "textToEmbed": {
+        "type": "text"
+      },
+      "chunkIndex": {
+        "type": "integer"
+      },
+      "chunkCount": {
+        "type": "integer"
+      },
+      "parentId": {
+        "type": "keyword"
+      },
       "changeDescription": {
         "enabled": false
       },

--- a/openmetadata-spec/src/main/resources/elasticsearch/indexMapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/indexMapping.json
@@ -249,7 +249,7 @@
     "indexName": "test_case_search_index",
     "indexMappingFile": "/elasticsearch/%s/test_case_index_mapping.json",
     "alias": "testCase",
-    "parentAliases": ["testSuite", "all"],
+    "parentAliases": ["testSuite", "all", "dataAssetEmbeddings"],
     "childAliases": ["testCaseResolutionStatus", "testCaseResult"]
   },
   "testCaseResult": {
@@ -263,7 +263,7 @@
     "indexName": "test_suite_search_index",
     "indexMappingFile": "/elasticsearch/%s/test_suite_index_mapping.json",
     "alias": "testSuite",
-    "parentAliases": ["all"],
+    "parentAliases": ["all", "dataAssetEmbeddings"],
     "childAliases": ["testCase", "testCaseResolutionStatus", "testCaseResult"]
   },
   "dataProduct": {

--- a/openmetadata-spec/src/main/resources/elasticsearch/jp/test_case_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/jp/test_case_index_mapping.json
@@ -1,5 +1,6 @@
 {
   "settings": {
+    "index": {},
     "analysis": {
       "normalizer": {
         "lowercase_normalizer": {
@@ -80,6 +81,24 @@
   },
   "mappings": {
     "properties": {
+      "fingerprint": {
+        "type": "keyword"
+      },
+      "textToLLMContext": {
+        "type": "text"
+      },
+      "textToEmbed": {
+        "type": "text"
+      },
+      "chunkIndex": {
+        "type": "integer"
+      },
+      "chunkCount": {
+        "type": "integer"
+      },
+      "parentId": {
+        "type": "keyword"
+      },
       "changeDescription": {
         "enabled": false
       },

--- a/openmetadata-spec/src/main/resources/elasticsearch/jp/test_suite_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/jp/test_suite_index_mapping.json
@@ -1,5 +1,6 @@
 {
   "settings": {
+    "index": {},
     "analysis": {
       "normalizer": {
         "lowercase_normalizer": {
@@ -73,6 +74,24 @@
   },
   "mappings": {
     "properties": {
+      "fingerprint": {
+        "type": "keyword"
+      },
+      "textToLLMContext": {
+        "type": "text"
+      },
+      "textToEmbed": {
+        "type": "text"
+      },
+      "chunkIndex": {
+        "type": "integer"
+      },
+      "chunkCount": {
+        "type": "integer"
+      },
+      "parentId": {
+        "type": "keyword"
+      },
       "changeDescription": {
         "enabled": false
       },

--- a/openmetadata-spec/src/main/resources/elasticsearch/ru/test_case_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/ru/test_case_index_mapping.json
@@ -1,5 +1,6 @@
 {
   "settings": {
+    "index": {},
     "analysis": {
       "tokenizer": {
         "edge_ngram_tokenizer": {
@@ -91,6 +92,24 @@
   },
   "mappings": {
     "properties": {
+      "fingerprint": {
+        "type": "keyword"
+      },
+      "textToLLMContext": {
+        "type": "text"
+      },
+      "textToEmbed": {
+        "type": "text"
+      },
+      "chunkIndex": {
+        "type": "integer"
+      },
+      "chunkCount": {
+        "type": "integer"
+      },
+      "parentId": {
+        "type": "keyword"
+      },
       "changeDescription": {
         "enabled": false
       },

--- a/openmetadata-spec/src/main/resources/elasticsearch/ru/test_suite_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/ru/test_suite_index_mapping.json
@@ -1,5 +1,6 @@
 {
   "settings": {
+    "index": {},
     "analysis": {
       "tokenizer": {
         "edge_ngram_tokenizer": {
@@ -91,6 +92,24 @@
   },
   "mappings": {
     "properties": {
+      "fingerprint": {
+        "type": "keyword"
+      },
+      "textToLLMContext": {
+        "type": "text"
+      },
+      "textToEmbed": {
+        "type": "text"
+      },
+      "chunkIndex": {
+        "type": "integer"
+      },
+      "chunkCount": {
+        "type": "integer"
+      },
+      "parentId": {
+        "type": "keyword"
+      },
       "changeDescription": {
         "enabled": false
       },

--- a/openmetadata-spec/src/main/resources/elasticsearch/zh/test_case_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/zh/test_case_index_mapping.json
@@ -1,5 +1,6 @@
 {
   "settings": {
+    "index": {},
     "analysis": {
       "normalizer": {
         "lowercase_normalizer": {
@@ -70,6 +71,24 @@
   },
   "mappings": {
     "properties": {
+      "fingerprint": {
+        "type": "keyword"
+      },
+      "textToLLMContext": {
+        "type": "text"
+      },
+      "textToEmbed": {
+        "type": "text"
+      },
+      "chunkIndex": {
+        "type": "integer"
+      },
+      "chunkCount": {
+        "type": "integer"
+      },
+      "parentId": {
+        "type": "keyword"
+      },
       "changeDescription": {
         "enabled": false
       },

--- a/openmetadata-spec/src/main/resources/elasticsearch/zh/test_suite_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/zh/test_suite_index_mapping.json
@@ -1,5 +1,6 @@
 {
   "settings": {
+    "index": {},
     "analysis": {
       "normalizer": {
         "lowercase_normalizer": {
@@ -49,6 +50,24 @@
   },
   "mappings": {
     "properties": {
+      "fingerprint": {
+        "type": "keyword"
+      },
+      "textToLLMContext": {
+        "type": "text"
+      },
+      "textToEmbed": {
+        "type": "text"
+      },
+      "chunkIndex": {
+        "type": "integer"
+      },
+      "chunkCount": {
+        "type": "integer"
+      },
+      "parentId": {
+        "type": "keyword"
+      },
       "changeDescription": {
         "enabled": false
       },

--- a/openmetadata-spec/src/main/resources/json/schema/entity/applications/mcp/mcpToolCallUsage.json
+++ b/openmetadata-spec/src/main/resources/json/schema/entity/applications/mcp/mcpToolCallUsage.json
@@ -5,6 +5,20 @@
   "description": "Single MCP tool-call usage record. One row written per tool invocation to the apps_extension_time_series table with extension='limits' (reusing the existing per-app usage extension; rows are isolated by appName='McpApplication'). Used to surface MCP traffic as a product growth metric. Not billed, no enforcement.",
   "type": "object",
   "javaType": "org.openmetadata.schema.entity.app.mcp.McpToolCallUsage",
+  "definitions": {
+    "errorCategory": {
+      "description": "Coarse bucket for failed tool invocations. Drives the 'Failed' tile subtext and the errorByCategory aggregate on the redesigned Billing > MCP page.",
+      "type": "string",
+      "enum": [
+        "AUTH",
+        "RATE_LIMIT",
+        "VALIDATION",
+        "TIMEOUT",
+        "INTERNAL",
+        "OTHER"
+      ]
+    }
+  },
   "properties": {
     "appId": {
       "description": "Unique identifier of the McpApplication.",
@@ -33,6 +47,21 @@
     "success": {
       "description": "True if the tool call returned without an error result.",
       "type": "boolean"
+    },
+    "latencyMs": {
+      "description": "Wall-clock duration of the tool call in milliseconds. Measured around DefaultToolContext.callTool(). Null when timing was not captured (e.g. legacy rows written before Phase 3).",
+      "existingJavaType": "java.lang.Long",
+      "type": "integer",
+      "format": "int64"
+    },
+    "errorCategory": {
+      "description": "Populated only when success=false. Drives the 'Failed' tile subtext and the errorByCategory aggregate on the Billing > MCP page.",
+      "$ref": "#/definitions/errorCategory"
+    },
+    "clientName": {
+      "description": "Best-effort name of the calling MCP client (Claude Desktop / Cursor / VS Code / CLI / claude-cli). Extracted from the User-Agent header by AuthEnrichedMcpContextExtractor. Empty when the client did not identify itself. Bounded to 64 chars because the source header is attacker-controlled.",
+      "type": "string",
+      "maxLength": 64
     }
   },
   "additionalProperties": false,

--- a/openmetadata-ui/src/main/resources/ui/src/generated/entity/applications/mcp/mcpToolCallUsage.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/entity/applications/mcp/mcpToolCallUsage.ts
@@ -24,8 +24,26 @@ export interface MCPToolCallUsage {
     /**
      * Name of the application (McpApplication).
      */
-    appName?:  string;
-    extension: ExtensionType;
+    appName?: string;
+    /**
+     * Best-effort name of the calling MCP client (Claude Desktop / Cursor / VS Code / CLI /
+     * claude-cli). Extracted from the User-Agent header by AuthEnrichedMcpContextExtractor.
+     * Empty when the client did not identify itself. Bounded to 64 chars because the source
+     * header is attacker-controlled.
+     */
+    clientName?: string;
+    /**
+     * Populated only when success=false. Drives the 'Failed' tile subtext and the
+     * errorByCategory aggregate on the Billing > MCP page.
+     */
+    errorCategory?: ErrorCategory;
+    extension:      ExtensionType;
+    /**
+     * Wall-clock duration of the tool call in milliseconds. Measured around
+     * DefaultToolContext.callTool(). Null when timing was not captured (e.g. legacy rows
+     * written before Phase 3).
+     */
+    latencyMs?: number;
     /**
      * True if the tool call returned without an error result.
      */
@@ -42,6 +60,22 @@ export interface MCPToolCallUsage {
      * Principal name from the MCP request's security context.
      */
     userName?: string;
+}
+
+/**
+ * Populated only when success=false. Drives the 'Failed' tile subtext and the
+ * errorByCategory aggregate on the Billing > MCP page.
+ *
+ * Coarse bucket for failed tool invocations. Drives the 'Failed' tile subtext and the
+ * errorByCategory aggregate on the redesigned Billing > MCP page.
+ */
+export enum ErrorCategory {
+    Auth = "AUTH",
+    Internal = "INTERNAL",
+    Other = "OTHER",
+    RateLimit = "RATE_LIMIT",
+    Timeout = "TIMEOUT",
+    Validation = "VALIDATION",
 }
 
 /**


### PR DESCRIPTION
Backports the 16 commits cherry-picked into 1.13.1 today onto 1.13 (protected branch, so via PR).

Includes: #27982, #28352, #28383, #28622, #28618, #28658, #28633, #28632, #28669, #28512, #28698, #28743, #28764, #28758, #28821, #28776.

All applied cleanly (no conflicts). Backend reactor build green on 1.13.1 with identical content.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

----
## Summary by Gitar

- **MCP Tooling & Observability:**
  - Integrated per-call latency tracking, error categorization, and client identification (e.g., Claude/Cursor/VSCode) via `McpUsageResource` and `AuthEnrichedMcpContextExtractor`.
  - Implemented response-size budgeting across tools to prevent LLM context overflow, with automated truncation and fallback envelopes.
- **Search & Vectorization:**
  - Vectorized `testSuite` and `testCase` entities for improved hybrid search; added specific `BodyTextContributor` implementations to optimize semantic payload quality.
  - Added `similarityScore` to `search_metadata` results and improved index resolution to prevent cross-type leakage.
- **Audit Logging:**
  - Improved `EventSubscriptionScheduler` to re-arm audit log consumer triggers on startup, resolving issues where abandoned or stale Quartz triggers would stop consumer processing.
- **Refactoring:**
  - Centralized response-trimming logic and standardized exception-to-status mapping across all MCP tools to ensure consistent error reporting.


<sub>This will update automatically on new commits.</sub>