### PR TITLE
fix(deps): bump netty-bom to 4.1.135.Final for CVE-2026-44249

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -692,7 +692,7 @@
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-bom</artifactId>
-        <version>4.1.133.Final</version>
+        <version>4.1.135.Final</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>


### PR DESCRIPTION
Fixes #28879

## What

Bumps `io.netty:netty-bom` from `4.1.133.Final` to `4.1.135.Final` in the root `pom.xml`.

## Why

**GHSA-3qp7-7mw8-wx86 / CVE-2026-44249** (High, CVSS 8.1) in `io.netty:netty-handler`.

`IpSubnetFilterRule.compareTo()` performs a bitwise AND against `networkAddress` instead of `subnetMask`, allowing **IPv6 subnet access-control rules to be bypassed** by valid public IPs. Affected: `<= 4.1.134.Final`. First patched: **`4.1.135.Final`** (latest on the 4.1.x line).

## Notes

Patch-level bump within the API-stable 4.1.x line — bugfix/security only, no breaking changes. Flagged by the Collate release vuln scan; this fixes the standalone OpenMetadata distribution (OMD MySQL/Postgres images).