### PR TITLE
Fixes #28886: recreate all indexes on major/minor version upgrade

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/IndexMappingVersionDAO.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/IndexMappingVersionDAO.java
@@ -38,6 +38,9 @@ public interface IndexMappingVersionDAO {
   @SqlQuery("SELECT mappingHash FROM index_mapping_versions WHERE entityType = :entityType")
   String getMappingHash(@Bind("entityType") String entityType);
 
+  @SqlQuery("SELECT DISTINCT version FROM index_mapping_versions")
+  List<String> getDistinctMappingVersions();
+
   @SqlQuery("SELECT entityType, mappingHash FROM index_mapping_versions")
   @RegisterRowMapper(IndexMappingVersionMapper.class)
   List<IndexMappingVersion> getAllMappingVersions();

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/IndexMappingVersionTracker.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/IndexMappingVersionTracker.java
@@ -10,6 +10,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import lombok.extern.slf4j.Slf4j;
 import org.openmetadata.schema.utils.JsonUtils;
 import org.openmetadata.schema.utils.VersionUtils;
@@ -90,22 +91,38 @@ public class IndexMappingVersionTracker {
   }
 
   public void updateMappingVersions() throws IOException {
-    Map<String, MappingEntry> currentMappings = computeCurrentMappings();
+    persistMappingVersions(computeCurrentMappings());
+  }
+
+  /**
+   * Persists the version/hash only for the entities that were actually reindexed. Stamping every
+   * entity (as the no-arg overload does) would mask entities that still need a reindex when only a
+   * subset was run - on a later major/minor upgrade those skipped entities would wrongly look
+   * up-to-date and never be recreated.
+   */
+  public void updateMappingVersions(Set<String> reindexedEntities) throws IOException {
+    Map<String, MappingEntry> reindexedMappings = new HashMap<>();
+    for (Map.Entry<String, MappingEntry> entry : computeCurrentMappings().entrySet()) {
+      if (reindexedEntities.contains(entry.getKey())) {
+        reindexedMappings.put(entry.getKey(), entry.getValue());
+      }
+    }
+    persistMappingVersions(reindexedMappings);
+  }
+
+  private void persistMappingVersions(Map<String, MappingEntry> mappings) {
     long updatedAt = System.currentTimeMillis();
-
-    for (Map.Entry<String, MappingEntry> entry : currentMappings.entrySet()) {
-      String entityType = entry.getKey();
+    for (Map.Entry<String, MappingEntry> entry : mappings.entrySet()) {
       MappingEntry mappingEntry = entry.getValue();
-
       indexMappingVersionDAO.upsertIndexMappingVersion(
-          entityType,
+          entry.getKey(),
           mappingEntry.hash(),
           JsonUtils.pojoToJson(mappingEntry.json()),
           version,
           updatedAt,
           updatedBy);
     }
-    LOG.info("Updated index mapping versions for {} entities", currentMappings.size());
+    LOG.info("Updated index mapping versions for {} entities", mappings.size());
   }
 
   private Map<String, String> getStoredMappingHashes() {

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/IndexMappingVersionTracker.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/IndexMappingVersionTracker.java
@@ -12,6 +12,7 @@ import java.util.List;
 import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
 import org.openmetadata.schema.utils.JsonUtils;
+import org.openmetadata.schema.utils.VersionUtils;
 import org.openmetadata.search.IndexMapping;
 import org.openmetadata.search.IndexMappingLoader;
 import org.openmetadata.service.exception.IndexMappingHashException;
@@ -55,6 +56,37 @@ public class IndexMappingVersionTracker {
     }
 
     return changedMappings;
+  }
+
+  /**
+   * Returns {@code true} when the indexes were last built at a different major/minor release than
+   * the version currently running. A patch-level bump (e.g. {@code 1.12.8 -> 1.12.9}) returns
+   * {@code false} so smart reindexing only touches changed mappings, whereas a major/minor bump
+   * (e.g. {@code 1.12.8 -> 1.13.0} or {@code 1.12.8 -> 2.0.0}) returns {@code true} so every index
+   * is recreated and fully reindexed. A fresh install with no stored versions returns
+   * {@code false} because every mapping is already reported as changed.
+   */
+  public boolean requiresFullReindexForVersionUpgrade() {
+    String previousVersion = findStoredVersionWithDifferentMajorMinor();
+    boolean requiresFullReindex = previousVersion != null;
+    if (requiresFullReindex) {
+      LOG.info(
+          "Index mapping version change {} -> {} crosses a major/minor release - full reindex required",
+          previousVersion,
+          version);
+    }
+    return requiresFullReindex;
+  }
+
+  private String findStoredVersionWithDifferentMajorMinor() {
+    String currentMajorMinor = VersionUtils.getMajorMinorVersion(version);
+    String mismatchedVersion = null;
+    for (String storedVersion : indexMappingVersionDAO.getDistinctMappingVersions()) {
+      if (!currentMajorMinor.equals(VersionUtils.getMajorMinorVersion(storedVersion))) {
+        mismatchedVersion = storedVersion;
+      }
+    }
+    return mismatchedVersion;
   }
 
   public void updateMappingVersions() throws IOException {

--- a/openmetadata-service/src/main/java/org/openmetadata/service/util/OpenMetadataOperations.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/util/OpenMetadataOperations.java
@@ -79,6 +79,7 @@ import org.openmetadata.schema.system.EventPublisherJob;
 import org.openmetadata.schema.type.EntityReference;
 import org.openmetadata.schema.type.Include;
 import org.openmetadata.schema.utils.JsonUtils;
+import org.openmetadata.schema.utils.VersionUtils;
 import org.openmetadata.sdk.PipelineServiceClientInterface;
 import org.openmetadata.search.IndexMapping;
 import org.openmetadata.search.IndexMappingLoader;
@@ -88,6 +89,7 @@ import org.openmetadata.service.OpenMetadataApplicationConfigHolder;
 import org.openmetadata.service.TypeRegistry;
 import org.openmetadata.service.apps.ApplicationHandler;
 import org.openmetadata.service.apps.bundles.insights.DataInsightsApp;
+import org.openmetadata.service.apps.bundles.searchIndex.SearchIndexEntityTypes;
 import org.openmetadata.service.apps.bundles.searchIndex.SlackWebApiClient;
 import org.openmetadata.service.apps.scheduler.AppScheduler;
 import org.openmetadata.service.clients.pipeline.PipelineServiceClientFactory;
@@ -159,6 +161,10 @@ import picocli.CommandLine.Option;
         "Creates or Migrates Database/Search Indexes. ReIndex the existing data into Elastic Search "
             + "or OpenSearch. Re-Deploys the service pipelines.")
 public class OpenMetadataOperations implements Callable<Integer> {
+
+  private static final String CATALOG_VERSION_RESOURCE = "/catalog/VERSION";
+  private static final String UNKNOWN_VERSION = "unknown";
+  private static final String DEFAULT_VERSION = "1.8.0-SNAPSHOT";
 
   private OpenMetadataApplicationConfig config;
   private Jdbi jdbi;
@@ -1797,70 +1803,18 @@ public class OpenMetadataOperations implements Callable<Integer> {
 
     if (!force) {
       try {
-        String version = System.getProperty("project.version", "1.8.0-SNAPSHOT");
-        versionTracker = new IndexMappingVersionTracker(collectionDAO, version, "system");
+        versionTracker =
+            new IndexMappingVersionTracker(collectionDAO, getCurrentServerVersion(), "system");
+        boolean upgradeRequiresFullReindex = versionTracker.requiresFullReindexForVersionUpgrade();
+        List<String> changedMappings =
+            upgradeRequiresFullReindex ? List.of() : versionTracker.getChangedMappings();
 
-        List<String> changedMappings = versionTracker.getChangedMappings();
-
-        if (changedMappings.isEmpty()) {
-          LOG.info("✅ Smart reindexing: No index mapping changes detected, skipping reindex");
-          shouldReindex = false;
-
-          // Send Slack notification if configured
-          if (slackBotToken != null
-              && !slackBotToken.isEmpty()
-              && slackChannel != null
-              && !slackChannel.isEmpty()) {
-            try {
-              String instanceUrl = getInstanceUrlFromSettings();
-              SlackWebApiClient slackClient =
-                  new SlackWebApiClient(slackBotToken, slackChannel, instanceUrl);
-              slackClient.sendNoChangesNotification();
-            } catch (Exception e) {
-              LOG.warn("Failed to send Slack notification for no changes", e);
-            }
-          }
-        } else {
-          shouldUpdateVersions = true;
-
-          // If 'all' entities were requested, only reindex changed ones
-          if (entities.contains("all")) {
-            entities = new HashSet<>(changedMappings);
-          } else {
-            // If specific entities were requested, check if any have changed mappings
-            Set<String> requestedAndChanged = new HashSet<>(entities);
-            requestedAndChanged.retainAll(changedMappings);
-            if (requestedAndChanged.isEmpty()) {
-              LOG.info(
-                  "✅ Smart reindexing: None of the requested entities have mapping changes, skipping reindex");
-              shouldReindex = false;
-              shouldUpdateVersions = false;
-
-              // Send Slack notification if configured
-              if (slackBotToken != null
-                  && !slackBotToken.isEmpty()
-                  && slackChannel != null
-                  && !slackChannel.isEmpty()) {
-                try {
-                  String instanceUrl = getInstanceUrlFromSettings();
-                  SlackWebApiClient slackClient =
-                      new SlackWebApiClient(slackBotToken, slackChannel, instanceUrl);
-                  slackClient.sendNoChangesNotification();
-                } catch (Exception e) {
-                  LOG.warn("Failed to send Slack notification for no changes", e);
-                }
-              }
-            } else {
-              entities = requestedAndChanged;
-            }
-          }
-
-          // Initialize progress monitor for entities that will be reindexed
-          if (shouldReindex) {
-            progressMonitor = new ReindexingProgressMonitor(entities.stream().sorted().toList());
-            progressMonitor.printInitialSummary();
-          }
-        }
+        SmartReindexPlan plan =
+            planSmartReindex(entities, upgradeRequiresFullReindex, changedMappings);
+        entities = plan.entities();
+        shouldReindex = plan.shouldReindex();
+        shouldUpdateVersions = plan.updateVersions();
+        progressMonitor = reportSmartReindexPlan(plan, slackBotToken, slackChannel);
       } catch (Exception e) {
         LOG.warn("⚠️  Smart reindexing unavailable: {}", e.getMessage());
         LOG.info("🔄 Falling back to standard reindexing for all requested entities");
@@ -1869,13 +1823,7 @@ public class OpenMetadataOperations implements Callable<Integer> {
 
     // Initialize progress monitor for force mode as well to get clean output
     if (progressMonitor == null && force) {
-      progressMonitor = new ReindexingProgressMonitor(entities.stream().sorted().toList());
-      LOG.info("");
-      LOG.info("🔄 Force Reindexing");
-      LOG.info("═".repeat(80));
-      LOG.info("🎯 Entities to reindex: {}", String.join(", ", entities));
-      LOG.info("⏳ Reindexing in progress...");
-      LOG.info("");
+      progressMonitor = startFullReindex("Force Reindexing", entities);
     }
 
     // If no mapping changes were detected, we should not proceed with reindexing
@@ -1933,6 +1881,113 @@ public class OpenMetadataOperations implements Callable<Integer> {
     }
 
     return result;
+  }
+
+  private String getCurrentServerVersion() {
+    String version =
+        VersionUtils.getOpenMetadataServerVersion(CATALOG_VERSION_RESOURCE).getVersion();
+    if (nullOrEmpty(version) || UNKNOWN_VERSION.equals(version)) {
+      version = System.getProperty("project.version", DEFAULT_VERSION);
+    }
+    return version;
+  }
+
+  enum SmartReindexAction {
+    SKIP_NO_MAPPING_CHANGES,
+    SKIP_NO_REQUESTED_CHANGES,
+    REINDEX_CHANGED,
+    REINDEX_ALL_FOR_UPGRADE
+  }
+
+  record SmartReindexPlan(SmartReindexAction action, Set<String> entities, boolean updateVersions) {
+    boolean shouldReindex() {
+      return action == SmartReindexAction.REINDEX_CHANGED
+          || action == SmartReindexAction.REINDEX_ALL_FOR_UPGRADE;
+    }
+  }
+
+  static SmartReindexPlan planSmartReindex(
+      Set<String> requestedEntities,
+      boolean upgradeRequiresFullReindex,
+      List<String> changedMappings) {
+    SmartReindexPlan plan;
+    if (upgradeRequiresFullReindex) {
+      plan =
+          new SmartReindexPlan(SmartReindexAction.REINDEX_ALL_FOR_UPGRADE, requestedEntities, true);
+    } else if (changedMappings.isEmpty()) {
+      plan =
+          new SmartReindexPlan(
+              SmartReindexAction.SKIP_NO_MAPPING_CHANGES, requestedEntities, false);
+    } else {
+      Set<String> resolvedEntities = resolveChangedEntities(requestedEntities, changedMappings);
+      boolean hasEntitiesToReindex = !resolvedEntities.isEmpty();
+      SmartReindexAction action =
+          hasEntitiesToReindex
+              ? SmartReindexAction.REINDEX_CHANGED
+              : SmartReindexAction.SKIP_NO_REQUESTED_CHANGES;
+      plan = new SmartReindexPlan(action, resolvedEntities, hasEntitiesToReindex);
+    }
+    return plan;
+  }
+
+  static Set<String> resolveChangedEntities(
+      Set<String> requestedEntities, List<String> changedMappings) {
+    Set<String> resolvedEntities;
+    if (requestedEntities.contains(SearchIndexEntityTypes.ALL)) {
+      resolvedEntities = new HashSet<>(changedMappings);
+    } else {
+      resolvedEntities = new HashSet<>(requestedEntities);
+      resolvedEntities.retainAll(changedMappings);
+    }
+    return resolvedEntities;
+  }
+
+  private ReindexingProgressMonitor reportSmartReindexPlan(
+      SmartReindexPlan plan, String slackBotToken, String slackChannel) {
+    ReindexingProgressMonitor progressMonitor = null;
+    switch (plan.action()) {
+      case REINDEX_ALL_FOR_UPGRADE -> progressMonitor =
+          startFullReindex("Major/Minor Version Upgrade Reindexing", plan.entities());
+      case REINDEX_CHANGED -> {
+        progressMonitor = new ReindexingProgressMonitor(plan.entities().stream().sorted().toList());
+        progressMonitor.printInitialSummary();
+      }
+      case SKIP_NO_MAPPING_CHANGES -> {
+        LOG.info("✅ Smart reindexing: No index mapping changes detected, skipping reindex");
+        sendNoChangesSlackNotification(slackBotToken, slackChannel);
+      }
+      case SKIP_NO_REQUESTED_CHANGES -> {
+        LOG.info(
+            "✅ Smart reindexing: None of the requested entities have mapping changes, skipping reindex");
+        sendNoChangesSlackNotification(slackBotToken, slackChannel);
+      }
+    }
+    return progressMonitor;
+  }
+
+  private ReindexingProgressMonitor startFullReindex(String title, Set<String> entities) {
+    ReindexingProgressMonitor progressMonitor =
+        new ReindexingProgressMonitor(entities.stream().sorted().toList());
+    LOG.info("");
+    LOG.info("🔄 {}", title);
+    LOG.info("═".repeat(80));
+    LOG.info("🎯 Entities to reindex: {}", String.join(", ", entities));
+    LOG.info("⏳ Reindexing in progress...");
+    LOG.info("");
+    return progressMonitor;
+  }
+
+  private void sendNoChangesSlackNotification(String slackBotToken, String slackChannel) {
+    if (!nullOrEmpty(slackBotToken) && !nullOrEmpty(slackChannel)) {
+      try {
+        String instanceUrl = getInstanceUrlFromSettings();
+        SlackWebApiClient slackClient =
+            new SlackWebApiClient(slackBotToken, slackChannel, instanceUrl);
+        slackClient.sendNoChangesNotification();
+      } catch (Exception e) {
+        LOG.warn("Failed to send Slack notification for no changes", e);
+      }
+    }
   }
 
   @Command(

--- a/openmetadata-service/src/main/java/org/openmetadata/service/util/OpenMetadataOperations.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/util/OpenMetadataOperations.java
@@ -27,6 +27,7 @@ import io.dropwizard.jersey.validation.Validators;
 import jakarta.validation.Validator;
 import java.io.File;
 import java.io.FileWriter;
+import java.io.IOException;
 import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
@@ -1871,7 +1872,7 @@ public class OpenMetadataOperations implements Callable<Integer> {
     // Update mapping versions after successful reindexing
     if (result == 0 && shouldUpdateVersions && versionTracker != null) {
       try {
-        versionTracker.updateMappingVersions();
+        persistReindexedMappingVersions(versionTracker, entities);
         LOG.info(
             "✅ Smart reindexing: Updated mapping versions in database for future change detection");
       } catch (Exception e) {
@@ -1890,6 +1891,15 @@ public class OpenMetadataOperations implements Callable<Integer> {
       version = System.getProperty("project.version", DEFAULT_VERSION);
     }
     return version;
+  }
+
+  private void persistReindexedMappingVersions(
+      IndexMappingVersionTracker versionTracker, Set<String> reindexedEntities) throws IOException {
+    if (reindexedEntities.contains(SearchIndexEntityTypes.ALL)) {
+      versionTracker.updateMappingVersions();
+    } else {
+      versionTracker.updateMappingVersions(reindexedEntities);
+    }
   }
 
   enum SmartReindexAction {

--- a/openmetadata-service/src/test/java/org/openmetadata/schema/utils/VersionUtilsTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/schema/utils/VersionUtilsTest.java
@@ -1,0 +1,38 @@
+package org.openmetadata.schema.utils;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import org.junit.jupiter.api.Test;
+
+class VersionUtilsTest {
+
+  @Test
+  void getMajorMinorVersionExtractsMajorMinorFromFullVersion() {
+    assertEquals("1.12", VersionUtils.getMajorMinorVersion("1.12.8"));
+    assertEquals("1.13", VersionUtils.getMajorMinorVersion("1.13.0"));
+    assertEquals("2.0", VersionUtils.getMajorMinorVersion("2.0.0"));
+  }
+
+  @Test
+  void getMajorMinorVersionIgnoresPatchAndQualifier() {
+    assertEquals("1.13", VersionUtils.getMajorMinorVersion("1.13.5-SNAPSHOT"));
+    assertEquals("1.13", VersionUtils.getMajorMinorVersion("1.13.0-rc1"));
+  }
+
+  @Test
+  void getMajorMinorVersionHandlesFourSegmentVersions() {
+    assertEquals("1.12", VersionUtils.getMajorMinorVersion("1.12.8.4"));
+  }
+
+  @Test
+  void getMajorMinorVersionReturnsInputWhenFewerThanTwoSegments() {
+    assertEquals("1", VersionUtils.getMajorMinorVersion("1"));
+    assertEquals("", VersionUtils.getMajorMinorVersion(""));
+  }
+
+  @Test
+  void getMajorMinorVersionReturnsNullForNull() {
+    assertNull(VersionUtils.getMajorMinorVersion(null));
+  }
+}

--- a/openmetadata-service/src/test/java/org/openmetadata/service/search/IndexMappingVersionTrackerTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/search/IndexMappingVersionTrackerTest.java
@@ -7,6 +7,7 @@ import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -115,6 +116,28 @@ class IndexMappingVersionTrackerTest {
               eq("tester"));
       assertFalse(hashCaptor.getValue().isBlank());
       assertTrue(jsonCaptor.getValue().contains("\"en\""));
+    }
+  }
+
+  @Test
+  void updateMappingVersionsForSubsetPersistsOnlyReindexedEntities() throws IOException {
+    Map<String, IndexMapping> mappings =
+        buildMappingsFromPairs(
+            "table", "/elasticsearch/%s/table_index_mapping.json",
+            "glossaryTerm", "/elasticsearch/%s/glossary_term_index_mapping.json");
+    try (var loaderMock = mockStatic(IndexMappingLoader.class)) {
+      loaderMock.when(IndexMappingLoader::getInstance).thenReturn(indexMappingLoader);
+      when(indexMappingLoader.getIndexMapping()).thenReturn(mappings);
+
+      new IndexMappingVersionTracker(collectionDAO, "1.13.0", "tester")
+          .updateMappingVersions(Set.of("table"));
+
+      verify(indexMappingVersionDAO)
+          .upsertIndexMappingVersion(
+              eq("table"), anyString(), anyString(), eq("1.13.0"), anyLong(), eq("tester"));
+      verify(indexMappingVersionDAO, never())
+          .upsertIndexMappingVersion(
+              eq("glossaryTerm"), anyString(), anyString(), anyString(), anyLong(), anyString());
     }
   }
 

--- a/openmetadata-service/src/test/java/org/openmetadata/service/search/IndexMappingVersionTrackerTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/search/IndexMappingVersionTrackerTest.java
@@ -416,6 +416,90 @@ class IndexMappingVersionTrackerTest {
     }
   }
 
+  // --- Version-upgrade detection tests (smart vs full reindex) ---
+
+  @Test
+  void patchUpgradeDoesNotRequireFullReindex() {
+    when(indexMappingVersionDAO.getDistinctMappingVersions()).thenReturn(List.of("1.12.8"));
+
+    assertFalse(
+        new IndexMappingVersionTracker(collectionDAO, "1.12.9", "tester")
+            .requiresFullReindexForVersionUpgrade());
+  }
+
+  @Test
+  void minorUpgradeRequiresFullReindex() {
+    when(indexMappingVersionDAO.getDistinctMappingVersions()).thenReturn(List.of("1.12.8"));
+
+    assertTrue(
+        new IndexMappingVersionTracker(collectionDAO, "1.13.0", "tester")
+            .requiresFullReindexForVersionUpgrade());
+  }
+
+  @Test
+  void minorUpgradeWithNonZeroPatchRequiresFullReindex() {
+    when(indexMappingVersionDAO.getDistinctMappingVersions()).thenReturn(List.of("1.12.8"));
+
+    assertTrue(
+        new IndexMappingVersionTracker(collectionDAO, "1.13.1", "tester")
+            .requiresFullReindexForVersionUpgrade());
+  }
+
+  @Test
+  void majorUpgradeRequiresFullReindex() {
+    when(indexMappingVersionDAO.getDistinctMappingVersions()).thenReturn(List.of("1.12.8"));
+
+    assertTrue(
+        new IndexMappingVersionTracker(collectionDAO, "2.0.0", "tester")
+            .requiresFullReindexForVersionUpgrade());
+  }
+
+  @Test
+  void sameVersionDoesNotRequireFullReindex() {
+    when(indexMappingVersionDAO.getDistinctMappingVersions()).thenReturn(List.of("1.12.8"));
+
+    assertFalse(
+        new IndexMappingVersionTracker(collectionDAO, "1.12.8", "tester")
+            .requiresFullReindexForVersionUpgrade());
+  }
+
+  @Test
+  void freshInstallWithNoStoredVersionsDoesNotRequireFullReindex() {
+    when(indexMappingVersionDAO.getDistinctMappingVersions()).thenReturn(List.of());
+
+    assertFalse(
+        new IndexMappingVersionTracker(collectionDAO, "1.13.0", "tester")
+            .requiresFullReindexForVersionUpgrade());
+  }
+
+  @Test
+  void snapshotQualifierIsIgnoredForPatchUpgrade() {
+    when(indexMappingVersionDAO.getDistinctMappingVersions()).thenReturn(List.of("1.13.0"));
+
+    assertFalse(
+        new IndexMappingVersionTracker(collectionDAO, "1.13.5-SNAPSHOT", "tester")
+            .requiresFullReindexForVersionUpgrade());
+  }
+
+  @Test
+  void snapshotQualifierStillDetectsMinorUpgrade() {
+    when(indexMappingVersionDAO.getDistinctMappingVersions()).thenReturn(List.of("1.12.0"));
+
+    assertTrue(
+        new IndexMappingVersionTracker(collectionDAO, "1.13.0-SNAPSHOT", "tester")
+            .requiresFullReindexForVersionUpgrade());
+  }
+
+  @Test
+  void anyStoredVersionCrossingMajorMinorTriggersFullReindex() {
+    when(indexMappingVersionDAO.getDistinctMappingVersions())
+        .thenReturn(List.of("1.13.0", "1.12.8"));
+
+    assertTrue(
+        new IndexMappingVersionTracker(collectionDAO, "1.13.0", "tester")
+            .requiresFullReindexForVersionUpgrade());
+  }
+
   private static Set<String> diff(Set<String> expected, Set<String> actual) {
     Set<String> missing = new TreeSet<>(expected);
     missing.removeAll(actual);

--- a/openmetadata-service/src/test/java/org/openmetadata/service/util/OpenMetadataOperationsSmartReindexTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/util/OpenMetadataOperationsSmartReindexTest.java
@@ -1,0 +1,104 @@
+package org.openmetadata.service.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+import org.openmetadata.service.util.OpenMetadataOperations.SmartReindexAction;
+import org.openmetadata.service.util.OpenMetadataOperations.SmartReindexPlan;
+
+class OpenMetadataOperationsSmartReindexTest {
+
+  @Test
+  void upgradeReindexesAllRequestedEntitiesWithoutChangedMappingFilter() {
+    SmartReindexPlan plan = OpenMetadataOperations.planSmartReindex(Set.of("all"), true, List.of());
+
+    assertEquals(SmartReindexAction.REINDEX_ALL_FOR_UPGRADE, plan.action());
+    assertEquals(Set.of("all"), plan.entities());
+    assertTrue(plan.shouldReindex());
+    assertTrue(plan.updateVersions());
+  }
+
+  @Test
+  void upgradeKeepsExplicitlyRequestedEntitiesAndIgnoresHashChanges() {
+    SmartReindexPlan plan =
+        OpenMetadataOperations.planSmartReindex(Set.of("table", "topic"), true, List.of("table"));
+
+    assertEquals(SmartReindexAction.REINDEX_ALL_FOR_UPGRADE, plan.action());
+    assertEquals(Set.of("table", "topic"), plan.entities());
+    assertTrue(plan.shouldReindex());
+    assertTrue(plan.updateVersions());
+  }
+
+  @Test
+  void noUpgradeAndNoMappingChangesSkips() {
+    SmartReindexPlan plan =
+        OpenMetadataOperations.planSmartReindex(Set.of("all"), false, List.of());
+
+    assertEquals(SmartReindexAction.SKIP_NO_MAPPING_CHANGES, plan.action());
+    assertFalse(plan.shouldReindex());
+    assertFalse(plan.updateVersions());
+  }
+
+  @Test
+  void noUpgradeWithAllAndChangedMappingsReindexesOnlyChanged() {
+    SmartReindexPlan plan =
+        OpenMetadataOperations.planSmartReindex(
+            Set.of("all"), false, List.of("table", "glossaryTerm"));
+
+    assertEquals(SmartReindexAction.REINDEX_CHANGED, plan.action());
+    assertEquals(Set.of("table", "glossaryTerm"), plan.entities());
+    assertTrue(plan.shouldReindex());
+    assertTrue(plan.updateVersions());
+  }
+
+  @Test
+  void noUpgradeWithRequestedSubsetReindexesIntersection() {
+    SmartReindexPlan plan =
+        OpenMetadataOperations.planSmartReindex(
+            Set.of("table", "topic"), false, List.of("table", "dashboard"));
+
+    assertEquals(SmartReindexAction.REINDEX_CHANGED, plan.action());
+    assertEquals(Set.of("table"), plan.entities());
+    assertTrue(plan.shouldReindex());
+  }
+
+  @Test
+  void noUpgradeWithRequestedEntitiesNoneChangedSkips() {
+    SmartReindexPlan plan =
+        OpenMetadataOperations.planSmartReindex(Set.of("table"), false, List.of("glossaryTerm"));
+
+    assertEquals(SmartReindexAction.SKIP_NO_REQUESTED_CHANGES, plan.action());
+    assertFalse(plan.shouldReindex());
+    assertFalse(plan.updateVersions());
+  }
+
+  @Test
+  void resolveChangedEntitiesForAllReturnsAllChangedMappings() {
+    Set<String> resolved =
+        OpenMetadataOperations.resolveChangedEntities(
+            Set.of("all"), List.of("table", "topic", "glossaryTerm"));
+
+    assertEquals(Set.of("table", "topic", "glossaryTerm"), resolved);
+  }
+
+  @Test
+  void resolveChangedEntitiesForExplicitRequestReturnsIntersection() {
+    Set<String> resolved =
+        OpenMetadataOperations.resolveChangedEntities(
+            Set.of("table", "topic"), List.of("topic", "dashboard"));
+
+    assertEquals(Set.of("topic"), resolved);
+  }
+
+  @Test
+  void resolveChangedEntitiesForExplicitRequestWithNoOverlapIsEmpty() {
+    Set<String> resolved =
+        OpenMetadataOperations.resolveChangedEntities(Set.of("table"), List.of("dashboard"));
+
+    assertTrue(resolved.isEmpty());
+  }
+}

--- a/openmetadata-spec/src/main/java/org/openmetadata/schema/utils/VersionUtils.java
+++ b/openmetadata-spec/src/main/java/org/openmetadata/schema/utils/VersionUtils.java
@@ -33,4 +33,20 @@ public final class VersionUtils {
   public static String[] getVersionFromString(String input) {
     return input.split(Pattern.quote("."));
   }
+
+  /**
+   * Extracts the {@code MAJOR.MINOR} portion of a version string, ignoring the patch level and any
+   * qualifier such as {@code -SNAPSHOT}. Two versions sharing the same major/minor differ only by a
+   * patch release (e.g. {@code 1.12.8} and {@code 1.12.9} both yield {@code 1.12}).
+   */
+  public static String getMajorMinorVersion(String version) {
+    String majorMinor = version;
+    if (version != null) {
+      String[] parts = getVersionFromString(version);
+      if (parts.length >= 2) {
+        majorMinor = parts[0] + "." + parts[1];
+      }
+    }
+    return majorMinor;
+  }
 }


### PR DESCRIPTION
### Describe your changes:

Fixes #28887

I made the CLI `reindex` smart mode version-aware: a patch upgrade (e.g. `1.12.8 → 1.12.9`) still reindexes only entities whose mapping hash changed, while a major/minor upgrade (e.g. `1.12.8 → 1.13.0 / 1.13.1 / 2.0.0`) recreates and fully reindexes every requested entity. Mapping-hash diffing alone can miss index changes a release introduces beyond the stored mapping JSON, so any major/minor bump should rebuild everything. I also switched the running-version source to the reliable `/catalog/VERSION` resource (the same one `VersionResource` uses) instead of the `project.version` system property, which defaults to a stale value when launched via the ops CLI.

#
### Type of change:
- [x] Improvement

#
### High-level design:

- `VersionUtils.getMajorMinorVersion` extracts `MAJOR.MINOR` (tolerant of qualifiers like `-SNAPSHOT`), reusing the same comparison approach `PipelineServiceClient` already uses for client/server checks.
- `IndexMappingVersionTracker.requiresFullReindexForVersionUpgrade()` compares the previously stored versions (new `IndexMappingVersionDAO.getDistinctMappingVersions()`) against the running version; if any differ at the major/minor level it forces a full reindex. Fresh installs (no stored versions) return `false` because every mapping is already reported as changed.
- The smart-reindex branching in `OpenMetadataOperations` was extracted into a pure, unit-testable `planSmartReindex(...) → SmartReindexPlan` (`SKIP` / `REINDEX_CHANGED` / `REINDEX_ALL_FOR_UPGRADE`), with side effects (logging, Slack, progress monitor) isolated in `reportSmartReindexPlan`.
- `IndexMappingVersionTracker.updateMappingVersions(Set)` persists the version/hash only for the entities actually reindexed (a no-arg overload still stamps all for the `all` path). This prevents a partial `--entities` reindex from masking entities that still need a rebuild — see #28887.
- Backward-compatible and no migration needed: it reuses the existing `index_mapping_versions.version` column. Clusters whose stored version predates meaningful version tracking get one self-healing full reindex, then resume smart patch reindexing.

#
### Tests:

#### Use cases covered
- `reindex` on a patch upgrade reindexes only entities with changed mappings.
- `reindex` on a minor/major upgrade reindexes all requested entities (with index recreation).
- `reindex --entities=table,topic` on an upgrade reindexes exactly those entities, unfiltered by hash.
- No version change and no mapping changes → reindex is skipped.

#### Unit tests
- [x] Added unit tests for the new/changed logic.
- Files: `VersionUtilsTest` (new), `OpenMetadataOperationsSmartReindexTest` (new), `IndexMappingVersionTrackerTest` (extended).
- 34 tests total (5 + 9 + 20), all passing.

#### Backend integration tests
- [x] Not applicable — no API changes; the CLI decision logic is covered by unit tests.

#### Ingestion integration tests
- [x] Not applicable.

#### Playwright (UI) tests
- [x] Not applicable — no UI changes.

#### Manual testing performed
- `mvn -pl openmetadata-spec,openmetadata-service compile` → BUILD SUCCESS
- `mvn -pl openmetadata-spec,openmetadata-service test -Dtest='IndexMappingVersionTrackerTest,OpenMetadataOperationsSmartReindexTest,VersionUtilsTest'` → 34/34 pass
- `mvn -pl openmetadata-spec,openmetadata-service spotless:check` → BUILD SUCCESS

#
### UI screen recording / screenshots:

Not applicable.

#
### Checklist:
- [x] I have read the **CONTRIBUTING** document.
- [x] My PR title is `Fixes <issue-number>: <short explanation>`
- [x] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] For JSON Schema changes: not applicable — no schema change (reuses the existing `index_mapping_versions.version` column).
- [x] For UI changes: not applicable.
- [x] I have added tests (unit) and listed them above.

<!-- Improvement -->
- [x] I have added tests around the new logic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
