### PR TITLE
fix(ingestion/mysql): default unknown stored-procedure language to SQL instead of None

### DIFF
--- a/ingestion/src/metadata/ingestion/source/database/mysql/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/database/mysql/metadata.py
@@ -38,6 +38,7 @@ from metadata.ingestion.api.steps import InvalidSourceException
 from metadata.ingestion.ometa.ometa_api import OpenMetadata
 from metadata.ingestion.source.database.common_db_source import CommonDbSourceService
 from metadata.ingestion.source.database.mysql.models import (
+    DEFAULT_STORED_PROC_LANGUAGE,
     STORED_PROC_LANGUAGE_MAP,
     STORED_PROC_TYPE_MAP,
     MysqlRoutine,
@@ -110,7 +111,7 @@ class MysqlSource(CommonDbSourceService):
                 name=EntityName(stored_procedure.name),
                 description=(Markdown(stored_procedure.description) if stored_procedure.description else None),
                 storedProcedureCode=StoredProcedureCode(
-                    language=STORED_PROC_LANGUAGE_MAP.get(stored_procedure.language),
+                    language=STORED_PROC_LANGUAGE_MAP.get(stored_procedure.language, DEFAULT_STORED_PROC_LANGUAGE),
                     code=stored_procedure.definition,
                 ),
                 databaseSchema=fqn.build(

--- a/ingestion/src/metadata/ingestion/source/database/mysql/models.py
+++ b/ingestion/src/metadata/ingestion/source/database/mysql/models.py
@@ -25,6 +25,7 @@ DEFAULT_STORED_PROC_LANGUAGE = Language.SQL
 
 STORED_PROC_LANGUAGE_MAP = {
     "SQL": Language.SQL,
+    "EXTERNAL": Language.External,
 }
 
 STORED_PROC_TYPE_MAP = {

--- a/ingestion/src/metadata/ingestion/source/database/mysql/models.py
+++ b/ingestion/src/metadata/ingestion/source/database/mysql/models.py
@@ -21,6 +21,8 @@ from metadata.generated.schema.entity.data.storedProcedure import (
     StoredProcedureType,
 )
 
+DEFAULT_STORED_PROC_LANGUAGE = Language.SQL
+
 STORED_PROC_LANGUAGE_MAP = {
     "SQL": Language.SQL,
 }

--- a/ingestion/src/metadata/ingestion/source/database/mysql/queries.py
+++ b/ingestion/src/metadata/ingestion/source/database/mysql/queries.py
@@ -78,6 +78,7 @@ MYSQL_GET_ROUTINES = """
     ROUTINE_SCHEMA AS schema_name,
     ROUTINE_DEFINITION AS definition,
     ROUTINE_TYPE AS routine_type,
+    ROUTINE_BODY AS language,
     ROUTINE_COMMENT AS description
 FROM information_schema.ROUTINES
 WHERE ROUTINE_TYPE IN ('PROCEDURE', 'FUNCTION')

--- a/ingestion/tests/unit/topology/database/test_mysql.py
+++ b/ingestion/tests/unit/topology/database/test_mysql.py
@@ -17,6 +17,7 @@ from unittest import TestCase
 from unittest.mock import MagicMock, patch
 
 from metadata.generated.schema.entity.data.databaseSchema import DatabaseSchema
+from metadata.generated.schema.entity.data.storedProcedure import Language
 from metadata.generated.schema.entity.services.databaseService import (
     DatabaseConnection,
     DatabaseService,
@@ -122,6 +123,7 @@ class MysqlUnitTest(TestCase):
                     "schema_name": "test_schema",
                     "definition": "BEGIN SELECT 1; END",
                     "routine_type": "PROCEDURE",
+                    "language": "SQL",
                     "description": "Test stored procedure",
                 }
             ),
@@ -131,6 +133,7 @@ class MysqlUnitTest(TestCase):
                     "schema_name": "test_schema",
                     "definition": "BEGIN RETURN 1; END",
                     "routine_type": "FUNCTION",
+                    "language": "SQL",
                     "description": "Test function",
                 }
             ),
@@ -140,6 +143,7 @@ class MysqlUnitTest(TestCase):
                     "schema_name": "test_schema",
                     "definition": "BEGIN RETURN 1; END",
                     "routine_type": "PROCEDURE",
+                    "language": "SQL",
                     "description": "Test exclude",
                 }
             ),
@@ -164,3 +168,23 @@ class MysqlUnitTest(TestCase):
         self.assertIsInstance(stored_procedures[0], MysqlRoutine)
         self.assertEqual(stored_procedures[0].name, "test_procedure")
         self.assertEqual(stored_procedures[0].routine_type, "PROCEDURE")
+
+    def _yield_language(self, language: str) -> Language:
+        routine = MysqlRoutine(
+            routine_name="proc",
+            schema_name="test_schema",
+            definition="BEGIN SELECT 1; END",
+            routine_type="PROCEDURE",
+            language=language,
+        )
+        request = next(self.mysql_source.yield_stored_procedure(routine)).right
+        return request.storedProcedureCode.language
+
+    def test_yield_stored_procedure_maps_db_reported_language(self):
+        """SQL and EXTERNAL routine bodies map to their respective languages"""
+        self.assertEqual(self._yield_language("SQL"), Language.SQL)
+        self.assertEqual(self._yield_language("EXTERNAL"), Language.External)
+
+    def test_yield_stored_procedure_unknown_language_defaults_to_sql(self):
+        """An unmapped routine body falls back to SQL rather than None"""
+        self.assertEqual(self._yield_language("UNKNOWN_LANG"), Language.SQL)


### PR DESCRIPTION
Fix #https://github.com/open-metadata/OpenMetadata/issues/28844
### Description
- When ingesting MySQL stored procedures and functions, the connector mapped
the routine's reported language through `STORED_PROC_LANGUAGE_MAP`, which only
contains a single entry for `"SQL"`. The lookup used `.get()` with no default,
so any other value returned by MySQL resolved to `None`, and the stored
procedure was recorded with no language — silently, with no log message.

- MySQL 8 can report `ROUTINE_BODY = 'EXTERNAL'` or other non-SQL bodies, which
triggered this case.

### Current Behaviour

- `STORED_PROC_LANGUAGE_MAP.get(stored_procedure.language)` returns `None` for
any reported language that is not exactly `"SQL"`, so the routine is ingested
with `language=None`.

### Expected Behaviour

- An unmapped or unexpected language value falls back to `Language.SQL` (MySQL
routines are SQL in practice) rather than `None`.

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [x] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### High-level design:
<!--
REQUIRED for large PRs (new features, refactors, breaking changes, or anything touching >5 files).
Skip for small bug fixes and trivial changes.

Cover:
- Architecture / approach you took and why
- Key components or files added/changed and how they interact
- Alternatives considered and why you rejected them
- Any migration, backward-compatibility, or rollout concerns
- Diagrams or links to design docs / RFCs if available
-->

N/A — small change. <!-- Or fill in the design above -->

#
### Tests:

#### Use cases covered
<!--
List the user-visible scenarios this PR exercises. Example:
- User with Admin role can create a Glossary Term with a parent term
- Ingestion run for Snowflake correctly extracts row counts for partitioned tables
-->

#### Unit tests
<!--
- [ ] I added unit tests for the new/changed logic.
- Files added/updated:
- Coverage on changed classes (run `mvn jacoco:report` for backend, `yarn test:coverage` for UI,
  `make unit_ingestion` for ingestion). Target is 90% line coverage on changed classes.
- Coverage %: <e.g., 92% on EntityRepository.java>
-->

#### Backend integration tests
<!--
- [ ] I added integration tests in `openmetadata-integration-tests/` for new/changed API endpoints.
- [ ] Not applicable (no backend API changes).
- Files added/updated:
-->

#### Ingestion integration tests
<!--
- [ ] I added/updated ingestion integration tests for connector changes.
- [ ] Not applicable (no ingestion changes).
- Files added/updated:
-->

#### Playwright (UI) tests
<!--
- [ ] I added Playwright E2E tests under `openmetadata-ui/.../ui/playwright/` for UI changes.
- [ ] Not applicable (no UI changes).
- Files added/updated:
-->

#### Manual testing performed
<!--
List the manual test steps you performed before requesting review. Example:
1. Started local stack via `./docker/run_local_docker.sh -m ui -d mysql`
2. Logged in as admin, created entity X, verified Y appears in the UI
3. Triggered ingestion for Snowflake source, confirmed lineage edges in the explore page
-->

#
### UI screen recording / screenshots:
<!--
REQUIRED for any PR that changes the UI. Drag-and-drop a short screen recording (.mov / .mp4 / .gif)
demonstrating the change end-to-end, plus before/after screenshots where relevant.
Mark "Not applicable" if there are no UI changes.
-->

Not applicable. <!-- Or attach recording/screenshots above -->

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.
- [ ] For UI changes: I attached a screen recording and/or screenshots above.
- [ ] I have added tests (unit / integration / Playwright as applicable) and listed them above.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->
