### PR TITLE
fix(search): re-derive glossaryTags/classificationTags/tier on live tag updates (1.12.11 backport)

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/SearchClient.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/SearchClient.java
@@ -84,7 +84,55 @@ public interface SearchClient
       }
       """;
   String SOFT_DELETE_RESTORE_SCRIPT = "ctx._source.put('deleted', '%s')";
-  String REMOVE_TAGS_CHILDREN_SCRIPT = "ctx._source.tags.removeIf(tag -> tag.tagFQN == params.fqn)";
+
+  /**
+   * Painless snippet that re-derives {@code tier} / {@code classificationTags} /
+   * {@code glossaryTags} from the current state of {@code ctx._source.tags}. Append this to every
+   * script that mutates {@code tags[]} so live-indexing updates produce the same separation that
+   * the reindex path ({@code ParseTags}) produces. Without this, a propagation or glossary-rename
+   * script can leave the lifted fields stale or land a Tier.* TagLabel inside {@code tags[]}.
+   *
+   * <p>The shape mirrors {@code ParseTags}: Tier.* is lifted out of {@code tags[]} into
+   * {@code tier}, but its FQN is still included in {@code classificationTags} since it's
+   * sourced from a Classification — {@code ParseTags} iterates the original list to populate
+   * {@code classificationTags}, so the painless equivalent must do the same.
+   *
+   * <p>Important: {@code ctx._source.tier} is only overwritten when a Tier.* entry is actually
+   * found in {@code tags[]}. The reindex path already strips Tier out of {@code tags[]} into the
+   * dedicated {@code tier} field at index time, so docs touched by a tag-mutating painless almost
+   * never carry Tier in {@code tags[]}. Unconditionally assigning {@code tier = null} when no Tier
+   * was seen would wipe the live-indexed dedicated field.
+   */
+  String TAG_RESEPARATION_SCRIPT =
+      """
+      def newTags = new ArrayList();
+      def tier = null;
+      def classTags = new ArrayList();
+      def glossTags = new ArrayList();
+      if (ctx._source.containsKey('tags') && ctx._source.tags != null) {
+        for (def t : ctx._source.tags) {
+          if (t == null || !t.containsKey('tagFQN') || t.tagFQN == null) { continue; }
+          if (t.tagFQN.startsWith('Tier.')) {
+            tier = t;
+          } else {
+            newTags.add(t);
+          }
+          if (t.containsKey('source')) {
+            if (t.source == 'Classification') { classTags.add(t.tagFQN); }
+            else if (t.source == 'Glossary') { glossTags.add(t.tagFQN); }
+          }
+        }
+        ctx._source.tags = newTags;
+        if (tier != null) {
+          ctx._source.tier = tier;
+        }
+        ctx._source.classificationTags = classTags;
+        ctx._source.glossaryTags = glossTags;
+      }
+      """;
+
+  String REMOVE_TAGS_CHILDREN_SCRIPT =
+      "ctx._source.tags.removeIf(tag -> tag.tagFQN == params.fqn);" + TAG_RESEPARATION_SCRIPT;
 
   String REMOVE_DATA_PRODUCTS_CHILDREN_SCRIPT =
       "ctx._source.dataProducts.removeIf(product -> product.fullyQualifiedName == params.fqn)";
@@ -222,7 +270,8 @@ public interface SearchClient
           }
         }
       }
-      """;
+      """
+          + TAG_RESEPARATION_SCRIPT;
 
   String UPDATE_CLASSIFICATION_TAG_FQN_BY_PREFIX_SCRIPT =
       """
@@ -237,7 +286,8 @@ public interface SearchClient
           }
         }
       }
-      """;
+      """
+          + TAG_RESEPARATION_SCRIPT;
 
   String UPDATE_FQN_PREFIX_SCRIPT =
       """
@@ -267,7 +317,8 @@ public interface SearchClient
                       }
                     }
                   }
-                  """;
+                  """
+          + TAG_RESEPARATION_SCRIPT;
 
   String REMOVE_LINEAGE_SCRIPT =
       """
@@ -415,7 +466,8 @@ public interface SearchClient
 
         Collections.sort(uniqueTags, (o1, o2) -> o1.tagFQN.compareTo(o2.tagFQN));
         ctx._source.tags = uniqueTags;
-        """;
+        """
+          + TAG_RESEPARATION_SCRIPT;
 
   String REMOVE_TEST_SUITE_CHILDREN_SCRIPT =
       "ctx._source.testSuites.removeIf(suite -> suite.id == params.suiteId)";


### PR DESCRIPTION
Fixes #28696 (glossaryTags half, on the 1.12.11 release branch)

## What

Backport of the `TAG_RESEPARATION_SCRIPT` painless snippet (from #28064) to the `1.12.11` release branch, so the **live search-index path produces the same tag separation as a full reindex** (`ParseTags`).

After any script that mutates `tags[]`, the denormalized `glossaryTags[]`, `classificationTags[]`, and `tier` fields are now re-derived in the same update, instead of only being refreshed on the next full reindex.

## Why

`GlossaryRenamePrefixCascade.spec.ts` (already on `1.12.11` via #28789) is red on the nightly build. Renaming a glossary term so the new name keeps the old as a prefix (`clv_x` → `clv_x Renamed`) and asserting the linked asset carries the renamed term in **both** `tags[]` and `glossaryTags[]`:

```
  tagsHasExactTerm:   true   ✓  tags[] rewritten correctly
  noDuplicatedFqn:    true   ✓  no "…Renamed Renamed" double-suffix
  glossaryTagsHasFqn: false  ✗  glossaryTags[] never picked up the renamed FQN
```

The `tags[]` half is already correct on `1.12.11` (via #28725's `UPDATE_TAG_FQN_BY_PREFIX_FRAGMENT`, already backported). The failure is purely the denormalized `glossaryTags[]`, which stays pinned to the **old** FQN after a live rename because nothing re-derives it from the mutated `tags[]`.

### Root cause of the gap

`#28725`'s scripts on `main` end with `+ TAG_RESEPARATION_SCRIPT`, but that constant is **defined in #28064** — a separate PR that was never backported to `1.12.11`. When `#28725` landed on `1.12.11` without `#28064`, the `+ TAG_RESEPARATION_SCRIPT` append was an undefined symbol and got dropped, so the live-update reseparation was lost. `TAG_RESEPARATION_SCRIPT` currently appears **0 times** on `1.12.11` vs **6 times** on `main`.

## What changed

`SearchClient.java` only — add the `TAG_RESEPARATION_SCRIPT` constant and re-apply the `+ TAG_RESEPARATION_SCRIPT` append to the five tag-mutating scripts, matching `origin/main`:

- `REMOVE_TAGS_CHILDREN_SCRIPT`
- `UPDATE_GLOSSARY_TERM_TAG_FQN_BY_PREFIX_SCRIPT`
- `UPDATE_CLASSIFICATION_TAG_FQN_BY_PREFIX_SCRIPT`
- `UPDATE_FQN_PREFIX_SCRIPT`
- `UPDATE_ADDED_DELETE_GLOSSARY_TAGS`

This also fixes the equivalent stale-`classificationTags` bug on classification and generic FQN-prefix renames — the spec only covers glossary, but the same gap affected all five paths.

## Scope note

This is a **minimal, targeted** backport of just the painless reseparation snippet, **not** the full SearchSeparation feature PR #28064 (56 files: `TaggableIndex` refactor, soft-delete promotion, etc.). The snippet is self-contained painless and does not depend on the rest of #28064. The index-time `glossaryTags`/`classificationTags` separation already exists on `1.12.11` (in `ParseTags`).

## Validation

- `mvn -DskipTests -pl openmetadata-service -am install` — compiles clean.
- `TAG_RESEPARATION_SCRIPT` now matches `main` (1 definition + 5 appends).
- Covered by the already-present `GlossaryRenamePrefixCascade.spec.ts` + the 5 `*ResourceIT` tests on `1.12.11`.

Related: #28064 (source of the snippet), #28725 / #28696 (the `tags[]` fix + spec), #28789 (spec on 1.12.11).
