### PR TITLE
fix(cache): close L1 stale-after-write race exposed by Redis CI variant

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/EntityRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/EntityRepository.java
@@ -2314,11 +2314,15 @@ public abstract class EntityRepository<T extends EntityInterface> {
     // Hot path — L1 Guava first, NotFoundCache only on L1 miss. Same shape as find(UUID,…).
     try {
       Pair<String, String> cacheKey = cacheNameKey(entityType, fqn);
+      // Canonical FQN for marker lookups: cacheNameKey lowercases USER FQNs so a mixed-case
+      // delete (writer keys the marker off the canonical form) is observable from a mixed-case
+      // read here. Using the raw `fqn` would miss markers across case variants.
+      String canonicalFqn = cacheKey.getRight();
       String cachedJson = CACHE_WITH_NAME.getIfPresent(cacheKey);
       if (cachedJson == null) {
         if (include == NON_DELETED
             && notFoundCache != null
-            && notFoundCache.isMarkedNotFoundByName(entityType, fqn)) {
+            && notFoundCache.isMarkedNotFoundByName(entityType, canonicalFqn)) {
           throw new EntityNotFoundException(entityNotFound(entityType, fqn));
         }
         try (var ignored = phase("cacheGet")) {
@@ -2327,7 +2331,7 @@ public abstract class EntityRepository<T extends EntityInterface> {
       } else if (include == NON_DELETED
           && notFoundCache != null
           && readEpochByName(cacheKey) != 0L
-          && notFoundCache.isMarkedNotFoundByName(entityType, fqn)) {
+          && notFoundCache.isMarkedNotFoundByName(entityType, canonicalFqn)) {
         // L1 hit but marker is set — racing loader poisoned L1 after the delete's invalidate.
         // See find(UUID,…) for the full rationale; mirror it here so by-name reads honor the
         // post-commit marker even when the L1 entry is from a pre-delete read race. Gated on

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/EntityRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/EntityRepository.java
@@ -142,7 +142,9 @@ import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executors;
 import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
@@ -343,6 +345,147 @@ public abstract class EntityRepository<T extends EntityInterface> {
       buildEntityIdCache(
           CacheConfiguration.DEFAULT_ENTITY_CACHE_MAX_SIZE_BYTES,
           CacheConfiguration.DEFAULT_ENTITY_CACHE_TTL_SECONDS);
+
+  /**
+   * Per-entity write-epoch counters. Each writer that invalidates L1 also bumps the entity's
+   * epoch; each loader records the epoch at load start and re-reads it at load end. A mismatch
+   * means a writer ran during the load, and the loader throws {@link LoaderRaceException} so
+   * Guava skips caching its stale return value (Guava's {@link LoadingCache} otherwise puts a
+   * returning loader's value into L1 even if {@code invalidate()} was called during the load —
+   * documented behavior, and the root mechanism of the stale-after-update flakes the
+   * postgres-elasticsearch-redis CI variant catches). Bounded Guava caches so memory stays
+   * proportional to the L1 cache rather than to total entity count over time; eviction is
+   * tolerable because an evicted-then-re-fetched epoch only widens the race window for the next
+   * load, not for any load already in-flight against the prior epoch slot.
+   */
+  private static final Cache<Pair<String, UUID>, AtomicLong> WRITE_EPOCH_BY_ID =
+      CacheBuilder.newBuilder().maximumSize(200_000).expireAfterAccess(5, TimeUnit.MINUTES).build();
+
+  private static final Cache<Pair<String, String>, AtomicLong> WRITE_EPOCH_BY_NAME =
+      CacheBuilder.newBuilder().maximumSize(200_000).expireAfterAccess(5, TimeUnit.MINUTES).build();
+
+  private static long readEpochById(Pair<String, UUID> key) {
+    AtomicLong epoch = WRITE_EPOCH_BY_ID.getIfPresent(key);
+    return epoch == null ? 0L : epoch.get();
+  }
+
+  private static long readEpochByName(Pair<String, String> key) {
+    AtomicLong epoch = WRITE_EPOCH_BY_NAME.getIfPresent(key);
+    return epoch == null ? 0L : epoch.get();
+  }
+
+  private static void bumpWriteEpoch(String entityType, UUID id, String fqn) {
+    if (id != null) {
+      try {
+        WRITE_EPOCH_BY_ID
+            .get(new ImmutablePair<>(entityType, id), AtomicLong::new)
+            .incrementAndGet();
+      } catch (ExecutionException e) {
+        // AtomicLong::new cannot throw; the loader signature requires the catch.
+      }
+    }
+    if (fqn != null) {
+      try {
+        WRITE_EPOCH_BY_NAME.get(cacheNameKey(entityType, fqn), AtomicLong::new).incrementAndGet();
+      } catch (ExecutionException e) {
+        // AtomicLong::new cannot throw.
+      }
+    }
+  }
+
+  /**
+   * Thrown by a cache loader that detected a concurrent write during its load. Guava swallows
+   * normal exceptions from loaders into {@link UncheckedExecutionException}; {@code find()} /
+   * {@code findByName()} catch this specific cause and re-read through the explicit-bypass path
+   * instead of returning the stale loaded value. This is internal to the cache layer — never
+   * propagated to API callers.
+   */
+  static final class LoaderRaceException extends RuntimeException {
+    LoaderRaceException(String message) {
+      super(message);
+    }
+  }
+
+  /**
+   * Daemon-thread scheduler for deferred L1 re-invalidations. Backstops the rare nanosecond race
+   * window between a cache loader's end-of-load epoch check passing and Guava's internal put
+   * landing: a writer that bumps the epoch + invalidates L1 inside that window can have its
+   * inline invalidate beaten by the loader's put, leaving L1 poisoned. The deferred invalidate
+   * runs after every loader could plausibly have finished, wiping any such poison. Two threads
+   * are sufficient — the tasks are pure local map evictions, no I/O. Daemon threads so the JVM
+   * shuts down cleanly without an explicit close; production lifecycle owners (Dropwizard
+   * managed objects) can call {@link #shutdownL1RepairExecutor} during graceful shutdown if
+   * they want to wait for in-flight repairs.
+   */
+  private static final ScheduledExecutorService L1_REPAIR_EXECUTOR =
+      Executors.newScheduledThreadPool(
+          2,
+          r -> {
+            Thread t = new Thread(r, "entity-cache-l1-repair");
+            t.setDaemon(true);
+            return t;
+          });
+
+  private static final long L1_REPAIR_DELAY_MS = 500L;
+
+  /**
+   * Schedule a deferred L1 eviction for {@code (entityType, id, fqn, originalFqn)} {@value
+   * #L1_REPAIR_DELAY_MS}ms after the writer's inline invalidate. Closes the loader-vs-writer
+   * race: a loader whose end-of-load epoch check passed (so {@link #bumpWriteEpoch} hadn't run
+   * yet at check time) but whose Guava-internal put has not yet landed will land its stale value
+   * AFTER the writer's inline invalidate. The delay is comfortably longer than any plausible
+   * loader execution (L2 + DB + JSON parse, all sub-100ms in practice), so by the time this task
+   * fires the racing loader's put has either already happened (caught here) or never will (the
+   * loader threw on its epoch check). Idempotent — repeated calls for the same key just do
+   * repeat no-op invalidates.
+   */
+  private static void scheduleL1Repair(String entityType, UUID id, String fqn, String originalFqn) {
+    if (entityType == null || L1_REPAIR_EXECUTOR.isShutdown()) {
+      return;
+    }
+    try {
+      L1_REPAIR_EXECUTOR.schedule(
+          () -> {
+            try {
+              if (id != null) {
+                CACHE_WITH_ID.invalidate(new ImmutablePair<>(entityType, id));
+              }
+              if (fqn != null) {
+                CACHE_WITH_NAME.invalidate(cacheNameKey(entityType, fqn));
+              }
+              if (originalFqn != null && !originalFqn.equals(fqn)) {
+                CACHE_WITH_NAME.invalidate(cacheNameKey(entityType, originalFqn));
+              }
+            } catch (Exception e) {
+              LOG.debug(
+                  "Deferred L1 repair failed for type={} id={} fqn={}", entityType, id, fqn, e);
+            }
+          },
+          L1_REPAIR_DELAY_MS,
+          TimeUnit.MILLISECONDS);
+    } catch (Exception e) {
+      // Pool rejection (shutdown race, queue overflow) is non-fatal — Fix B epoch check still
+      // catches the common case and the L1 TTL is the ultimate backstop.
+      LOG.debug("Failed to schedule L1 repair type={} id={}", entityType, id, e);
+    }
+  }
+
+  /**
+   * Graceful shutdown hook for the L1 repair executor. Optional — daemon threads will be killed
+   * on JVM exit anyway. Call from a Dropwizard {@code Managed.stop()} if you want to drain
+   * in-flight repair tasks before shutdown.
+   */
+  public static void shutdownL1RepairExecutor() {
+    L1_REPAIR_EXECUTOR.shutdown();
+    try {
+      if (!L1_REPAIR_EXECUTOR.awaitTermination(2, TimeUnit.SECONDS)) {
+        L1_REPAIR_EXECUTOR.shutdownNow();
+      }
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      L1_REPAIR_EXECUTOR.shutdownNow();
+    }
+  }
 
   /**
    * Canonical {@link #CACHE_WITH_NAME} key. User FQNs are lowercased at the DB layer
@@ -1513,6 +1656,22 @@ public abstract class EntityRepository<T extends EntityInterface> {
         try (var ignored = phase("cacheGet")) {
           cachedJson = CACHE_WITH_ID.get(cacheKey);
         }
+      } else if (include == NON_DELETED
+          && notFoundCache != null
+          && notFoundCache.isMarkedNotFoundById(entityType, id)) {
+        // L1 hit, but the negative-cache marker says this entity is deleted. The marker is
+        // set post-commit by the delete path; if we reach here it means a concurrent
+        // EntityLoaderWithId race poisoned L1 with the pre-delete state AFTER the writer's
+        // invalidate ran (Guava's LoadingCache puts the loader's return value into L1 even if
+        // invalidate() was called during the load — documented behavior). Without this check
+        // the stale L1 entry shadows the marker until the L1 TTL expires (default 30 s), and
+        // the writer's two invalidate passes are insufficient under load (see the comment in
+        // {@link #delete}'s post-commit invalidate block). Evict the poison and surface the
+        // deletion. Costs one Redis GET per NON_DELETED read on the L1-hit path; the earlier
+        // unconditional shape was reverted for that cost but the correctness gap it accepted
+        // now reliably fails the postgres-elasticsearch-redis CI variant.
+        CACHE_WITH_ID.invalidate(cacheKey);
+        throw new EntityNotFoundException(entityNotFound(entityType, id));
       }
       T entity;
       try (var ignored = phase("cacheCopy")) {
@@ -1543,6 +1702,11 @@ public abstract class EntityRepository<T extends EntityInterface> {
       // the caller. We only populate the negative cache on EntityNotFoundException; other
       // causes are rethrown unchanged.
       Throwable cause = e.getCause();
+      if (cause instanceof LoaderRaceException) {
+        // The loader detected a concurrent write and refused to cache its stale value. Re-read
+        // through the explicit-bypass path so the response reflects the freshly-committed state.
+        return find(id, include, false);
+      }
       if (cause instanceof EntityNotFoundException notFound) {
         if (include == NON_DELETED && notFoundCache != null) {
           notFoundCache.markNotFoundById(entityType, id);
@@ -2132,6 +2296,14 @@ public abstract class EntityRepository<T extends EntityInterface> {
         try (var ignored = phase("cacheGet")) {
           cachedJson = CACHE_WITH_NAME.get(cacheKey);
         }
+      } else if (include == NON_DELETED
+          && notFoundCache != null
+          && notFoundCache.isMarkedNotFoundByName(entityType, fqn)) {
+        // L1 hit but marker is set — racing loader poisoned L1 after the delete's invalidate.
+        // See find(UUID,…) for the full rationale; mirror it here so by-name reads honor the
+        // post-commit marker even when the L1 entry is from a pre-delete read race.
+        CACHE_WITH_NAME.invalidate(cacheKey);
+        throw new EntityNotFoundException(entityNotFound(entityType, fqn));
       }
       T entity;
       try (var ignored = phase("cacheCopy")) {
@@ -2147,6 +2319,10 @@ public abstract class EntityRepository<T extends EntityInterface> {
       // failures (DB timeout, deserialization error) must not poison the cache for 30s and
       // must not be masked as 404s — same reasoning as the find(UUID, …) path above.
       Throwable cause = e.getCause();
+      if (cause instanceof LoaderRaceException) {
+        // Loader saw a concurrent write — re-read through the explicit-bypass path.
+        return findByName(fqn, include, false);
+      }
       if (cause instanceof EntityNotFoundException notFound) {
         if (include == NON_DELETED && notFoundCache != null) {
           notFoundCache.markNotFoundByName(entityType, fqn);
@@ -3128,9 +3304,14 @@ public abstract class EntityRepository<T extends EntityInterface> {
     if (entityType == null || id == null) {
       return;
     }
+    // Bump the per-entity write-epoch so a concurrent cache loader's end-of-load check observes
+    // the increment and refuses to poison L1 with the pre-write state.
+    bumpWriteEpoch(entityType, id, fqn);
     // Guava L1 always cleared inline — it is a local map eviction, not a network round trip, and
     // the rare uncached read path may have populated it even for UNCACHED_ENTITY_TYPES.
     CACHE_WITH_ID.invalidate(new ImmutablePair<>(entityType, id));
+    // Backstop the nanosecond race window where a loader's put can land after this invalidate.
+    scheduleL1Repair(entityType, id, fqn, null);
     if (fqn != null) {
       CACHE_WITH_NAME.invalidate(cacheNameKey(entityType, fqn));
     }
@@ -4611,9 +4792,15 @@ public abstract class EntityRepository<T extends EntityInterface> {
   }
 
   void invalidate(T entity) {
+    // Bump the write-epoch first so any in-flight cache loader's end-of-load check sees the
+    // new value and refuses to populate L1 with the pre-write state.
+    bumpWriteEpoch(entityType, entity.getId(), entity.getFullyQualifiedName());
     CACHE_WITH_ID.invalidate(new ImmutablePair<>(entityType, entity.getId()));
     CACHE_WITH_NAME.invalidate(cacheNameKey(entityType, entity.getFullyQualifiedName()));
     RequestEntityCache.invalidate(entityType, entity.getId(), entity.getFullyQualifiedName());
+
+    // Backstop the nanosecond race between this inline invalidate and a Guava loader's put.
+    scheduleL1Repair(entityType, entity.getId(), entity.getFullyQualifiedName(), null);
 
     // Also invalidate Redis cache
     invalidateCache(entity);
@@ -9849,6 +10036,14 @@ public abstract class EntityRepository<T extends EntityInterface> {
       UUID id = updated.getId();
       String fqn = updated.getFullyQualifiedName();
 
+      // Bump the write-epoch BEFORE invalidating so any in-flight loader sees the new epoch
+      // when it does its end-of-load check. Pair with the loader-side race guard in
+      // EntityLoaderWithId / EntityLoaderWithName. Cheap (per-entity AtomicLong increment).
+      bumpWriteEpoch(entityType, id, fqn);
+      if (originalFqn != null && !originalFqn.equals(fqn)) {
+        bumpWriteEpoch(entityType, null, originalFqn);
+      }
+
       // Evict the Guava L1 so future reads reload from Redis/DB.
       CACHE_WITH_ID.invalidate(new ImmutablePair<>(entityType, id));
       CACHE_WITH_NAME.invalidate(cacheNameKey(entityType, fqn));
@@ -9896,6 +10091,12 @@ public abstract class EntityRepository<T extends EntityInterface> {
       // so the next GET on this instance can't race an in-flight async repopulate.
       EntityRepository.this.writeThroughCache(updated, true);
       RequestEntityCache.invalidate(entityType, id, fqn);
+
+      // Backstop: schedule a deferred L1 re-eviction after the inline invalidate completes.
+      // Closes the nanosecond race where a loader's end-of-load epoch check passes (so Fix B
+      // doesn't catch it) and its Guava-internal put lands AFTER our inline invalidate above.
+      // The deferred task wipes any such poison once every plausible loader has finished.
+      scheduleL1Repair(entityType, id, fqn, originalFqn);
 
       var pubsub = CacheBundle.getCacheInvalidationPubSub();
       if (pubsub != null) {
@@ -10230,6 +10431,20 @@ public abstract class EntityRepository<T extends EntityInterface> {
   static class EntityLoaderWithName extends CacheLoader<Pair<String, String>, String> {
     @Override
     public @NonNull String load(@NotNull Pair<String, String> fqnPair) {
+      // Race guard: capture the write-epoch BEFORE we start loading and re-check after we have
+      // the json. If a writer ran between these two reads, our loaded value reflects the pre-write
+      // state and must NOT be cached — throw {@link LoaderRaceException} so Guava skips the put,
+      // and {@code findByName()} retries through the explicit-bypass path.
+      long startEpoch = readEpochByName(fqnPair);
+      String json = loadInternal(fqnPair);
+      if (readEpochByName(fqnPair) != startEpoch) {
+        throw new LoaderRaceException("Concurrent write during loadByName: " + fqnPair);
+      }
+      return json;
+    }
+
+    @NonNull
+    private String loadInternal(@NotNull Pair<String, String> fqnPair) {
       String entityType = fqnPair.getLeft();
       String fqn = fqnPair.getRight();
       EntityRepository<? extends EntityInterface> repository =
@@ -10320,6 +10535,17 @@ public abstract class EntityRepository<T extends EntityInterface> {
   static class EntityLoaderWithId extends CacheLoader<Pair<String, UUID>, String> {
     @Override
     public @NonNull String load(@NotNull Pair<String, UUID> idPair) {
+      // See EntityLoaderWithName.load for the race-guard rationale.
+      long startEpoch = readEpochById(idPair);
+      String json = loadInternal(idPair);
+      if (readEpochById(idPair) != startEpoch) {
+        throw new LoaderRaceException("Concurrent write during loadById: " + idPair);
+      }
+      return json;
+    }
+
+    @NonNull
+    private String loadInternal(@NotNull Pair<String, UUID> idPair) {
       String entityType = idPair.getLeft();
       UUID id = idPair.getRight();
       EntityRepository<? extends EntityInterface> repository =

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/EntityRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/EntityRepository.java
@@ -349,18 +349,9 @@ public abstract class EntityRepository<T extends EntityInterface> {
           CacheConfiguration.DEFAULT_ENTITY_CACHE_MAX_SIZE_BYTES,
           CacheConfiguration.DEFAULT_ENTITY_CACHE_TTL_SECONDS);
 
-  /**
-   * Per-entity write-epoch counters. Each writer that invalidates L1 also bumps the entity's
-   * epoch; each loader records the epoch at load start and re-reads it at load end. A mismatch
-   * means a writer ran during the load, and the loader throws {@link LoaderRaceException} so
-   * Guava skips caching its stale return value (Guava's {@link LoadingCache} otherwise puts a
-   * returning loader's value into L1 even if {@code invalidate()} was called during the load —
-   * documented behavior, and the root mechanism of the stale-after-update flakes the
-   * postgres-elasticsearch-redis CI variant catches). Bounded Guava caches so memory stays
-   * proportional to the L1 cache rather than to total entity count over time; eviction is
-   * tolerable because an evicted-then-re-fetched epoch only widens the race window for the next
-   * load, not for any load already in-flight against the prior epoch slot.
-   */
+  // Per-entity write-epoch counters. Writers increment; loaders capture at start and re-check
+  // at end. Mismatch means a write raced the load — loader throws LoaderRaceException so Guava
+  // skips caching its stale return value. Bounded so memory tracks the L1 working set.
   private static final Cache<Pair<String, UUID>, AtomicLong> WRITE_EPOCH_BY_ID =
       CacheBuilder.newBuilder().maximumSize(200_000).expireAfterAccess(5, TimeUnit.MINUTES).build();
 
@@ -384,17 +375,13 @@ public abstract class EntityRepository<T extends EntityInterface> {
             .get(new ImmutablePair<>(entityType, id), AtomicLong::new)
             .incrementAndGet();
       } catch (ExecutionException e) {
-        // AtomicLong::new cannot throw; signature-mandated catch. Log so a future runtime
-        // surprise (e.g. interrupted thread during get()) isn't silently swallowed.
         LOG.debug("Unexpected epoch-bump failure for type={} id={}", entityType, id, e);
       }
     }
     if (fqn != null) {
-      // quoteFqn entity repositories (Glossary, Team, User, Classification, etc.) quote the FQN
-      // before the loader records its epoch (`fqn = quoteFqn ? quoteName(fqn) : fqn;` at the top
-      // of findByName). Writers pass the entity's stored FQN which may not be in the same form,
-      // so bump both raw and quoted variants — the loader's read will match one of them. Bumping
-      // a no-op variant is harmless (~50ns AtomicLong increment).
+      // findByName quotes the input fqn for quoteFqn entities (Glossary, Team, User, ...) before
+      // the loader records its epoch; writers pass the stored fqn which may differ. Bump both
+      // forms so the loader's read matches one.
       bumpNameEpoch(cacheNameKey(entityType, fqn), entityType, fqn);
       String quoted = quoteName(fqn);
       if (!quoted.equals(fqn)) {
@@ -411,36 +398,19 @@ public abstract class EntityRepository<T extends EntityInterface> {
     }
   }
 
-  /**
-   * Thrown by a cache loader that detected a concurrent write during its load. Guava swallows
-   * normal exceptions from loaders into {@link UncheckedExecutionException}; {@code find()} /
-   * {@code findByName()} catch this specific cause and re-read through the explicit-bypass path
-   * instead of returning the stale loaded value. This is internal to the cache layer — never
-   * propagated to API callers.
-   */
   static final class LoaderRaceException extends RuntimeException {
     LoaderRaceException(String message) {
       super(message);
     }
   }
 
-  /**
-   * Daemon-thread scheduler for deferred L1 re-invalidations. Backstops the rare nanosecond race
-   * window between a cache loader's end-of-load epoch check passing and Guava's internal put
-   * landing: a writer that bumps the epoch + invalidates L1 inside that window can have its
-   * inline invalidate beaten by the loader's put, leaving L1 poisoned. The deferred invalidate
-   * runs after every loader could plausibly have finished, wiping any such poison. Two threads
-   * are sufficient — the tasks are pure local map evictions, no I/O. Daemon threads so the JVM
-   * shuts down cleanly without an explicit close; production lifecycle owners (Dropwizard
-   * managed objects) can call {@link #shutdownL1RepairExecutor} during graceful shutdown if
-   * they want to wait for in-flight repairs.
-   */
+  // Deferred L1 re-eviction. Backstops the nanosecond race where a loader's put lands after the
+  // writer's inline invalidate. Daemon threads.
   private static final ScheduledExecutorService L1_REPAIR_EXECUTOR =
       Executors.newScheduledThreadPool(
           2,
           r -> {
-            // FQN java.lang.Thread because org.openmetadata.schema.entity.feed.Thread is also
-            // imported elsewhere in this file and the simple name resolves to it.
+            // FQN: org.openmetadata.schema.entity.feed.Thread shadows the simple name here.
             java.lang.Thread t = new java.lang.Thread(r, "entity-cache-l1-repair");
             t.setDaemon(true);
             return t;
@@ -448,19 +418,18 @@ public abstract class EntityRepository<T extends EntityInterface> {
 
   private static final long L1_REPAIR_DELAY_MS = 500L;
 
-  /**
-   * Schedule a deferred L1 eviction for {@code (entityType, id, fqn, originalFqn)} {@value
-   * #L1_REPAIR_DELAY_MS}ms after the writer's inline invalidate. Closes the loader-vs-writer
-   * race: a loader whose end-of-load epoch check passed (so {@link #bumpWriteEpoch} hadn't run
-   * yet at check time) but whose Guava-internal put has not yet landed will land its stale value
-   * AFTER the writer's inline invalidate. The delay is comfortably longer than any plausible
-   * loader execution (L2 + DB + JSON parse, all sub-100ms in practice), so by the time this task
-   * fires the racing loader's put has either already happened (caught here) or never will (the
-   * loader threw on its epoch check). Idempotent — repeated calls for the same key just do
-   * repeat no-op invalidates.
-   */
+  // Coalescing guard. Without this, bulk writes can enqueue thousands of pending repair tasks
+  // per key (one per write). One pending task per key is sufficient to evict any racing loader's
+  // put — repeated bumps within the delay window collapse to a single eviction.
+  private static final java.util.Set<Object> PENDING_L1_REPAIRS =
+      java.util.concurrent.ConcurrentHashMap.newKeySet();
+
   private static void scheduleL1Repair(String entityType, UUID id, String fqn, String originalFqn) {
     if (entityType == null || L1_REPAIR_EXECUTOR.isShutdown()) {
+      return;
+    }
+    Object coalesceKey = id != null ? new ImmutablePair<>(entityType, id) : entityType + "|" + fqn;
+    if (!PENDING_L1_REPAIRS.add(coalesceKey)) {
       return;
     }
     try {
@@ -477,28 +446,21 @@ public abstract class EntityRepository<T extends EntityInterface> {
                 CACHE_WITH_NAME.invalidate(cacheNameKey(entityType, originalFqn));
               }
             } catch (RuntimeException e) {
-              // Guava L1 invalidate is pure local-map work and shouldn't throw, but defensively
-              // catch RuntimeException so a freak event-loop exception doesn't kill the daemon
-              // thread (the executor would survive — ScheduledThreadPoolExecutor logs and keeps
-              // going — but the next-scheduled task would still benefit from us not propagating).
               LOG.debug(
                   "Deferred L1 repair failed for type={} id={} fqn={}", entityType, id, fqn, e);
+            } finally {
+              PENDING_L1_REPAIRS.remove(coalesceKey);
             }
           },
           L1_REPAIR_DELAY_MS,
           TimeUnit.MILLISECONDS);
     } catch (RejectedExecutionException e) {
-      // Pool rejection (shutdown race, queue overflow) is non-fatal — Fix B epoch check still
-      // catches the common case and the L1 TTL is the ultimate backstop.
+      // Submission rejected — clear the coalescing marker so the next write can re-schedule.
+      PENDING_L1_REPAIRS.remove(coalesceKey);
       LOG.debug("Failed to schedule L1 repair type={} id={}", entityType, id, e);
     }
   }
 
-  /**
-   * Graceful shutdown hook for the L1 repair executor. Optional — daemon threads will be killed
-   * on JVM exit anyway. Call from a Dropwizard {@code Managed.stop()} if you want to drain
-   * in-flight repair tasks before shutdown.
-   */
   public static void shutdownL1RepairExecutor() {
     L1_REPAIR_EXECUTOR.shutdown();
     try {
@@ -1684,20 +1646,8 @@ public abstract class EntityRepository<T extends EntityInterface> {
           && notFoundCache != null
           && readEpochById(cacheKey) != 0L
           && notFoundCache.isMarkedNotFoundById(entityType, id)) {
-        // L1 hit, but the negative-cache marker says this entity is deleted. The marker is
-        // set post-commit by the delete path; if we reach here it means a concurrent
-        // EntityLoaderWithId race poisoned L1 with the pre-delete state AFTER the writer's
-        // invalidate ran (Guava's LoadingCache puts the loader's return value into L1 even if
-        // invalidate() was called during the load — documented behavior). Without this check
-        // the stale L1 entry shadows the marker until the L1 TTL expires (default 30 s), and
-        // the writer's two invalidate passes are insufficient under load (see the comment in
-        // {@link #delete}'s post-commit invalidate block).
-        //
-        // Gated on a non-zero write-epoch so the common, uncontended case keeps the zero-Redis
-        // L1 fast path. {@link #bumpWriteEpoch} (called by every writer) is what makes the
-        // epoch non-zero, so the gate only opens for keys a writer has ever touched — exactly
-        // the population where the race can occur. The earlier unconditional shape was
-        // reverted precisely because it paid a Redis GET on EVERY L1 hit.
+        // Stale L1 from a racing loader after a delete — marker says gone, evict and 404.
+        // Epoch gate skips the Redis GET on keys no writer has touched.
         CACHE_WITH_ID.invalidate(cacheKey);
         throw new EntityNotFoundException(entityNotFound(entityType, id));
       }
@@ -1731,8 +1681,6 @@ public abstract class EntityRepository<T extends EntityInterface> {
       // causes are rethrown unchanged.
       Throwable cause = e.getCause();
       if (cause instanceof LoaderRaceException) {
-        // The loader detected a concurrent write and refused to cache its stale value. Re-read
-        // through the explicit-bypass path so the response reflects the freshly-committed state.
         return find(id, include, false);
       }
       if (cause instanceof EntityNotFoundException notFound) {
@@ -2288,9 +2236,10 @@ public abstract class EntityRepository<T extends EntityInterface> {
     if (!fromCache) {
       // Explicit cache bypass — checking the negative cache before the DB still saves the
       // DB hit on a known-missing entity. (Same reasoning as find(UUID, …).)
+      String bypassCanonicalFqn = cacheNameKey(entityType, fqn).getRight();
       if (include == NON_DELETED
           && notFoundCache != null
-          && notFoundCache.isMarkedNotFoundByName(entityType, fqn)) {
+          && notFoundCache.isMarkedNotFoundByName(entityType, bypassCanonicalFqn)) {
         throw new EntityNotFoundException(entityNotFound(entityType, fqn));
       }
       CACHE_WITH_NAME.invalidate(cacheNameKey(entityType, fqn));
@@ -2300,7 +2249,7 @@ public abstract class EntityRepository<T extends EntityInterface> {
       }
       if (entity == null) {
         if (include == NON_DELETED && notFoundCache != null) {
-          notFoundCache.markNotFoundByName(entityType, fqn);
+          notFoundCache.markNotFoundByName(entityType, bypassCanonicalFqn);
         }
         throw new EntityNotFoundException(entityNotFound(entityType, fqn));
       }
@@ -2314,9 +2263,8 @@ public abstract class EntityRepository<T extends EntityInterface> {
     // Hot path — L1 Guava first, NotFoundCache only on L1 miss. Same shape as find(UUID,…).
     try {
       Pair<String, String> cacheKey = cacheNameKey(entityType, fqn);
-      // Canonical FQN for marker lookups: cacheNameKey lowercases USER FQNs so a mixed-case
-      // delete (writer keys the marker off the canonical form) is observable from a mixed-case
-      // read here. Using the raw `fqn` would miss markers across case variants.
+      // cacheNameKey lowercases USER FQNs; use the canonical form on both marker reads and
+      // writes so mixed-case lookups observe markers set by canonical-form writes.
       String canonicalFqn = cacheKey.getRight();
       String cachedJson = CACHE_WITH_NAME.getIfPresent(cacheKey);
       if (cachedJson == null) {
@@ -2332,10 +2280,7 @@ public abstract class EntityRepository<T extends EntityInterface> {
           && notFoundCache != null
           && readEpochByName(cacheKey) != 0L
           && notFoundCache.isMarkedNotFoundByName(entityType, canonicalFqn)) {
-        // L1 hit but marker is set — racing loader poisoned L1 after the delete's invalidate.
-        // See find(UUID,…) for the full rationale; mirror it here so by-name reads honor the
-        // post-commit marker even when the L1 entry is from a pre-delete read race. Gated on
-        // non-zero write-epoch so uncontended reads keep the zero-Redis fast path.
+        // Stale L1 from a racing loader after a delete — marker says gone, evict and 404.
         CACHE_WITH_NAME.invalidate(cacheKey);
         throw new EntityNotFoundException(entityNotFound(entityType, fqn));
       }
@@ -2349,17 +2294,13 @@ public abstract class EntityRepository<T extends EntityInterface> {
       }
       return entity;
     } catch (ExecutionException | UncheckedExecutionException e) {
-      // Only negative-cache when the cause is genuinely "entity doesn't exist". Transient
-      // failures (DB timeout, deserialization error) must not poison the cache for 30s and
-      // must not be masked as 404s — same reasoning as the find(UUID, …) path above.
       Throwable cause = e.getCause();
       if (cause instanceof LoaderRaceException) {
-        // Loader saw a concurrent write — re-read through the explicit-bypass path.
         return findByName(fqn, include, false);
       }
       if (cause instanceof EntityNotFoundException notFound) {
         if (include == NON_DELETED && notFoundCache != null) {
-          notFoundCache.markNotFoundByName(entityType, fqn);
+          notFoundCache.markNotFoundByName(entityType, cacheNameKey(entityType, fqn).getRight());
         }
         throw notFound;
       }
@@ -3338,13 +3279,9 @@ public abstract class EntityRepository<T extends EntityInterface> {
     if (entityType == null || id == null) {
       return;
     }
-    // Bump the per-entity write-epoch so a concurrent cache loader's end-of-load check observes
-    // the increment and refuses to poison L1 with the pre-write state.
     bumpWriteEpoch(entityType, id, fqn);
-    // Guava L1 always cleared inline — it is a local map eviction, not a network round trip, and
-    // the rare uncached read path may have populated it even for UNCACHED_ENTITY_TYPES.
+    // Guava L1 always cleared inline — local map eviction, not a network round trip.
     CACHE_WITH_ID.invalidate(new ImmutablePair<>(entityType, id));
-    // Backstop the nanosecond race window where a loader's put can land after this invalidate.
     scheduleL1Repair(entityType, id, fqn, null);
     if (fqn != null) {
       CACHE_WITH_NAME.invalidate(cacheNameKey(entityType, fqn));
@@ -4826,17 +4763,11 @@ public abstract class EntityRepository<T extends EntityInterface> {
   }
 
   void invalidate(T entity) {
-    // Bump the write-epoch first so any in-flight cache loader's end-of-load check sees the
-    // new value and refuses to populate L1 with the pre-write state.
     bumpWriteEpoch(entityType, entity.getId(), entity.getFullyQualifiedName());
     CACHE_WITH_ID.invalidate(new ImmutablePair<>(entityType, entity.getId()));
     CACHE_WITH_NAME.invalidate(cacheNameKey(entityType, entity.getFullyQualifiedName()));
     RequestEntityCache.invalidate(entityType, entity.getId(), entity.getFullyQualifiedName());
-
-    // Backstop the nanosecond race between this inline invalidate and a Guava loader's put.
     scheduleL1Repair(entityType, entity.getId(), entity.getFullyQualifiedName(), null);
-
-    // Also invalidate Redis cache
     invalidateCache(entity);
   }
 
@@ -10126,10 +10057,6 @@ public abstract class EntityRepository<T extends EntityInterface> {
       EntityRepository.this.writeThroughCache(updated, true);
       RequestEntityCache.invalidate(entityType, id, fqn);
 
-      // Backstop: schedule a deferred L1 re-eviction after the inline invalidate completes.
-      // Closes the nanosecond race where a loader's end-of-load epoch check passes (so Fix B
-      // doesn't catch it) and its Guava-internal put lands AFTER our inline invalidate above.
-      // The deferred task wipes any such poison once every plausible loader has finished.
       scheduleL1Repair(entityType, id, fqn, originalFqn);
 
       var pubsub = CacheBundle.getCacheInvalidationPubSub();
@@ -10465,10 +10392,8 @@ public abstract class EntityRepository<T extends EntityInterface> {
   static class EntityLoaderWithName extends CacheLoader<Pair<String, String>, String> {
     @Override
     public @NonNull String load(@NotNull Pair<String, String> fqnPair) {
-      // Race guard: capture the write-epoch BEFORE we start loading and re-check after we have
-      // the json. If a writer ran between these two reads, our loaded value reflects the pre-write
-      // state and must NOT be cached — throw {@link LoaderRaceException} so Guava skips the put,
-      // and {@code findByName()} retries through the explicit-bypass path.
+      // Race guard — epoch mismatch means a writer ran during the load; throw so Guava skips
+      // caching the now-stale value and find() re-reads via the bypass path.
       long startEpoch = readEpochByName(fqnPair);
       String json = loadInternal(fqnPair);
       if (readEpochByName(fqnPair) != startEpoch) {

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/EntityRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/EntityRepository.java
@@ -94,6 +94,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
@@ -144,10 +145,12 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executors;
 import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.BiConsumer;
 import java.util.function.BiPredicate;
 import java.util.function.Consumer;
@@ -381,15 +384,30 @@ public abstract class EntityRepository<T extends EntityInterface> {
             .get(new ImmutablePair<>(entityType, id), AtomicLong::new)
             .incrementAndGet();
       } catch (ExecutionException e) {
-        // AtomicLong::new cannot throw; the loader signature requires the catch.
+        // AtomicLong::new cannot throw; signature-mandated catch. Log so a future runtime
+        // surprise (e.g. interrupted thread during get()) isn't silently swallowed.
+        LOG.debug("Unexpected epoch-bump failure for type={} id={}", entityType, id, e);
       }
     }
     if (fqn != null) {
-      try {
-        WRITE_EPOCH_BY_NAME.get(cacheNameKey(entityType, fqn), AtomicLong::new).incrementAndGet();
-      } catch (ExecutionException e) {
-        // AtomicLong::new cannot throw.
+      // quoteFqn entity repositories (Glossary, Team, User, Classification, etc.) quote the FQN
+      // before the loader records its epoch (`fqn = quoteFqn ? quoteName(fqn) : fqn;` at the top
+      // of findByName). Writers pass the entity's stored FQN which may not be in the same form,
+      // so bump both raw and quoted variants — the loader's read will match one of them. Bumping
+      // a no-op variant is harmless (~50ns AtomicLong increment).
+      bumpNameEpoch(cacheNameKey(entityType, fqn), entityType, fqn);
+      String quoted = quoteName(fqn);
+      if (!quoted.equals(fqn)) {
+        bumpNameEpoch(cacheNameKey(entityType, quoted), entityType, quoted);
       }
+    }
+  }
+
+  private static void bumpNameEpoch(Pair<String, String> key, String entityType, String fqn) {
+    try {
+      WRITE_EPOCH_BY_NAME.get(key, AtomicLong::new).incrementAndGet();
+    } catch (ExecutionException e) {
+      LOG.debug("Unexpected epoch-bump failure for type={} fqn={}", entityType, fqn, e);
     }
   }
 
@@ -421,7 +439,9 @@ public abstract class EntityRepository<T extends EntityInterface> {
       Executors.newScheduledThreadPool(
           2,
           r -> {
-            Thread t = new Thread(r, "entity-cache-l1-repair");
+            // FQN java.lang.Thread because org.openmetadata.schema.entity.feed.Thread is also
+            // imported elsewhere in this file and the simple name resolves to it.
+            java.lang.Thread t = new java.lang.Thread(r, "entity-cache-l1-repair");
             t.setDaemon(true);
             return t;
           });
@@ -456,14 +476,18 @@ public abstract class EntityRepository<T extends EntityInterface> {
               if (originalFqn != null && !originalFqn.equals(fqn)) {
                 CACHE_WITH_NAME.invalidate(cacheNameKey(entityType, originalFqn));
               }
-            } catch (Exception e) {
+            } catch (RuntimeException e) {
+              // Guava L1 invalidate is pure local-map work and shouldn't throw, but defensively
+              // catch RuntimeException so a freak event-loop exception doesn't kill the daemon
+              // thread (the executor would survive — ScheduledThreadPoolExecutor logs and keeps
+              // going — but the next-scheduled task would still benefit from us not propagating).
               LOG.debug(
                   "Deferred L1 repair failed for type={} id={} fqn={}", entityType, id, fqn, e);
             }
           },
           L1_REPAIR_DELAY_MS,
           TimeUnit.MILLISECONDS);
-    } catch (Exception e) {
+    } catch (RejectedExecutionException e) {
       // Pool rejection (shutdown race, queue overflow) is non-fatal — Fix B epoch check still
       // catches the common case and the L1 TTL is the ultimate backstop.
       LOG.debug("Failed to schedule L1 repair type={} id={}", entityType, id, e);
@@ -482,7 +506,7 @@ public abstract class EntityRepository<T extends EntityInterface> {
         L1_REPAIR_EXECUTOR.shutdownNow();
       }
     } catch (InterruptedException e) {
-      Thread.currentThread().interrupt();
+      java.lang.Thread.currentThread().interrupt();
       L1_REPAIR_EXECUTOR.shutdownNow();
     }
   }
@@ -1658,6 +1682,7 @@ public abstract class EntityRepository<T extends EntityInterface> {
         }
       } else if (include == NON_DELETED
           && notFoundCache != null
+          && readEpochById(cacheKey) != 0L
           && notFoundCache.isMarkedNotFoundById(entityType, id)) {
         // L1 hit, but the negative-cache marker says this entity is deleted. The marker is
         // set post-commit by the delete path; if we reach here it means a concurrent
@@ -1666,10 +1691,13 @@ public abstract class EntityRepository<T extends EntityInterface> {
         // invalidate() was called during the load — documented behavior). Without this check
         // the stale L1 entry shadows the marker until the L1 TTL expires (default 30 s), and
         // the writer's two invalidate passes are insufficient under load (see the comment in
-        // {@link #delete}'s post-commit invalidate block). Evict the poison and surface the
-        // deletion. Costs one Redis GET per NON_DELETED read on the L1-hit path; the earlier
-        // unconditional shape was reverted for that cost but the correctness gap it accepted
-        // now reliably fails the postgres-elasticsearch-redis CI variant.
+        // {@link #delete}'s post-commit invalidate block).
+        //
+        // Gated on a non-zero write-epoch so the common, uncontended case keeps the zero-Redis
+        // L1 fast path. {@link #bumpWriteEpoch} (called by every writer) is what makes the
+        // epoch non-zero, so the gate only opens for keys a writer has ever touched — exactly
+        // the population where the race can occur. The earlier unconditional shape was
+        // reverted precisely because it paid a Redis GET on EVERY L1 hit.
         CACHE_WITH_ID.invalidate(cacheKey);
         throw new EntityNotFoundException(entityNotFound(entityType, id));
       }
@@ -2298,10 +2326,12 @@ public abstract class EntityRepository<T extends EntityInterface> {
         }
       } else if (include == NON_DELETED
           && notFoundCache != null
+          && readEpochByName(cacheKey) != 0L
           && notFoundCache.isMarkedNotFoundByName(entityType, fqn)) {
         // L1 hit but marker is set — racing loader poisoned L1 after the delete's invalidate.
         // See find(UUID,…) for the full rationale; mirror it here so by-name reads honor the
-        // post-commit marker even when the L1 entry is from a pre-delete read race.
+        // post-commit marker even when the L1 entry is from a pre-delete read race. Gated on
+        // non-zero write-epoch so uncontended reads keep the zero-Redis fast path.
         CACHE_WITH_NAME.invalidate(cacheKey);
         throw new EntityNotFoundException(entityNotFound(entityType, fqn));
       }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/EntityRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/EntityRepository.java
@@ -428,13 +428,19 @@ public abstract class EntityRepository<T extends EntityInterface> {
     if (entityType == null || L1_REPAIR_EXECUTOR.isShutdown()) {
       return;
     }
-    Object coalesceKey = id != null ? new ImmutablePair<>(entityType, id) : entityType + "|" + fqn;
+    // Include fqn so a rename within the delay window gets its own task instead of being
+    // coalesced into a prior task that only knows the old fqn.
+    Object coalesceKey =
+        List.of(entityType, id == null ? "" : id.toString(), fqn == null ? "" : fqn);
     if (!PENDING_L1_REPAIRS.add(coalesceKey)) {
       return;
     }
     try {
       L1_REPAIR_EXECUTOR.schedule(
           () -> {
+            // Clear at task start so a writer arriving during the invalidates re-schedules its
+            // own task and gets the full delay-window backstop.
+            PENDING_L1_REPAIRS.remove(coalesceKey);
             try {
               if (id != null) {
                 CACHE_WITH_ID.invalidate(new ImmutablePair<>(entityType, id));
@@ -448,14 +454,11 @@ public abstract class EntityRepository<T extends EntityInterface> {
             } catch (RuntimeException e) {
               LOG.debug(
                   "Deferred L1 repair failed for type={} id={} fqn={}", entityType, id, fqn, e);
-            } finally {
-              PENDING_L1_REPAIRS.remove(coalesceKey);
             }
           },
           L1_REPAIR_DELAY_MS,
           TimeUnit.MILLISECONDS);
     } catch (RejectedExecutionException e) {
-      // Submission rejected — clear the coalescing marker so the next write can re-schedule.
       PENDING_L1_REPAIRS.remove(coalesceKey);
       LOG.debug("Failed to schedule L1 repair type={} id={}", entityType, id, e);
     }


### PR DESCRIPTION
Fixes #28912

## Summary

Fixes the L1 cache stale-after-write race that the `postgres-elasticsearch-redis` integration test job has been catching across unrelated PRs since early June.

Across 4 CI runs traced (June 9 + June 10), 6 distinct test failures all share one root cause: a Guava `LoadingCache` loader in flight when a writer's `invalidate()` runs **still puts its pre-write value into L1** after the load completes — documented Guava behavior. Subsequent reads on the same pod then serve stale data until L1 TTL.

## Why now

The L1 race is older than #28675 — the team has known about it and partially patched it:
- #28197 (May 16) added `NotFoundCache` marker for the delete-side. The comment at `EntityRepository.java:4578-4582` admits the seal isn't complete: *"A stale L1 entry that survives the two invalidate passes is NOT caught by this marker… the second invalidate makes that case rare in practice."*
- #28100 (May 21) closed a rename-cascade variant of the same family.

What widened the window enough to tip CI 1–2 tests per run:
- #28012 (May 13) added the `postgres-elasticsearch-redis` CI variant that exercises more concurrent read paths (cache invalidation pubsub, async lifecycle, governance workflow consumer).
- #28675 (June 5) introduced `OrderedLaneExecutor` for per-entity async search indexing AND moved `invalidateCachesAfterStore` out of the `@Transaction` boundary.

## What this PR changes

Three layered defenses, all in `EntityRepository.java`. No public API changes, no schema changes, no new dependencies.

### 1. `NotFoundCache` check on L1 hit
`find(UUID)` and `findByName(String)` now consult `NotFoundCache` on L1 hit (not just L1 miss). If the entity is marked deleted but L1 still has a poisoned value from a racing loader, evict and throw `EntityNotFoundException`.

**Gated on `readEpochById/ByName != 0L`** so the common, uncontended case keeps the zero-Redis L1 fast path. The marker is only consulted for keys a writer has ever touched — exactly the population where the race can occur.

### 2. Per-entity write-epoch counter in loaders
Bounded Guava caches of `AtomicLong` per `(entityType, id)` and `(entityType, fqn)`. Writers (`invalidateCachesAfterStore`, `invalidate(T)`, `invalidateCacheForEntity`) bump the epoch BEFORE invalidating L1. Loaders capture the epoch at start, re-check at end, throw `LoaderRaceException` on mismatch — Guava skips caching on throw. `find()` / `findByName()` catch the wrapped cause and re-read via the explicit-bypass path.

**FQN bumps are written under both the raw and `quoteName`d forms.** Repositories with `quoteFqn = true` (Glossary, Team, User, Classification, etc.) quote the input FQN before the loader records its epoch; bumping only the raw form would leave the loader looking at a different key. Both bumps are idempotent — the alternate form is a no-op when no loader recorded it.

### 3. Deferred async L1 re-invalidate
Daemon-thread `ScheduledExecutorService` (2 threads, named `entity-cache-l1-repair`) re-invalidates the key 500ms after every writer's inline invalidate. Catches any loader whose end-of-load epoch check passed but whose Guava-internal put landed AFTER the writer's inline invalidate — the residual nanosecond window from defense 2.

## Failure variants covered

| Failure | Family | Caught by |
|---|---|---|
| `MlModelResourceIT.test_entityStatus` | Update-side | 2 + 3 |
| `GlossaryResourceIT.test_entityStatus` | Update-side | 2 + 3 (relies on the dual quoteFqn bump) |
| `MetadataServiceResourceIT.post_delete_entityWithOwner_200` | Delete-side | 1 + 3 |
| `ContextFileIT.testHardDeleteFileIsAsync` | Delete-side | 1 + 3 |
| `DriveFileUploadIT.testUploadPdfToMinIO` | Update-side (async status) | 2 + 3 |
| `RdfGlossaryGraphIT.scopedResponseCarriesGlossaryNameAndIdPerNode` | Likely same family (not traced end-to-end) | 1 + 3 if delete-flavor, 2 + 3 if update-flavor |

## Cost

- Memory: bounded epoch caches (~13 MB worst case at 200k entries × 2 caches × ~32 bytes each).
- Per loader call: one extra Guava `getIfPresent` (sub-µs).
- Per writer: one `AtomicLong.incrementAndGet`, one schedule (~1 µs).
- Per L1-hit `NON_DELETED` read on a key a writer has ever touched: one `NotFoundCache` Redis GET. Uncontended L1 hits keep the zero-Redis fast path.
- Two daemon threads on a tiny queue.

## Review-cycle notes

First push (`b859d412ef`) failed CI build because the local incremental compile cached over two missing imports (`com.google.common.cache.Cache`, `java.util.concurrent.atomic.AtomicLong`) that a clean build catches. Second push (`513b074a35`) adds those plus addresses three legitimate findings from the bot reviewer:

1. Performance gate on the L1-hit `NotFoundCache` check (Fix 1 above).
2. Empty-catch / `catch (Exception)` cleanup — narrowed to `RejectedExecutionException` / `RuntimeException` and added debug logs.
3. `quoteFqn` epoch-key mismatch fix (Fix 2 above).

`mvn clean compile` runs clean locally now; spotless clean.

## Test plan

- [x] CI: `integration-tests-postgres-elasticsearch-redis` passes 3 runs in a row
- [x] CI: `integration-tests-mysql-elasticsearch` stays green (verifies no regression on non-Redis variant)
- [x] CI: `integration-tests-postgres-opensearch` stays green
- [x] Spotless / Java checkstyle clean
- [x] Build + unit tests green

## Honest residual risk

A loader that takes longer than 500ms to complete (e.g., a DB call near the JDBI timeout) could land its put after the deferred re-invalidate. The next read would serve stale until L1 TTL (default 30s). Probability: rare DB stalls only. If that becomes the dominant flake source post-merge, the right next step is replacing `LoadingCache` with Caffeine `AsyncCache` + atomic compute — a bigger refactor that should be a separate PR.

## Asks

- Cache-write-path owners (#28675 / #28197 authors): please weigh in on the trade-off of restoring the `NotFoundCache`-on-L1-hit check (now gated, see Fix 1) and on the epoch counter approach vs. a full `LoadingCache` replacement.
- Until this lands, the `postgres-elasticsearch-redis` job is a shared CI flake on `main` blocking unrelated PRs.
