### PR TITLE
Fixes #28916: Migrate SAP HANA connector to BaseConnection with per-mode strategies

### DIFF
--- a/ingestion/src/metadata/ingestion/source/database/saphana/connection.py
+++ b/ingestion/src/metadata/ingestion/source/database/saphana/connection.py
@@ -12,8 +12,10 @@
 Source connection handler
 """
 
+from abc import ABC, abstractmethod
+from collections.abc import Callable
 from functools import partial
-from typing import Callable, Dict, Optional  # noqa: UP035
+from typing import Optional
 from urllib.parse import quote_plus
 
 from sqlalchemy import inspect
@@ -29,7 +31,11 @@ from metadata.generated.schema.entity.services.connections.database.sapHana.sapH
     SapHanaSQLConnection,
 )
 from metadata.generated.schema.entity.services.connections.database.sapHanaConnection import (
-    SapHanaConnection,
+    SapHanaConnection as SapHanaConnectionConfig,
+)
+from metadata.generated.schema.entity.services.connections.database.sapHanaConnection import (
+    SapHanaScheme,
+    SapHanaType,
 )
 from metadata.generated.schema.entity.services.connections.testConnectionResult import (
     TestConnectionResult,
@@ -39,6 +45,8 @@ from metadata.ingestion.connections.builders import (
     get_connection_args_common,
     get_connection_options_dict,
 )
+from metadata.ingestion.connections.connection import BaseConnection
+from metadata.ingestion.connections.strategies import ClientStrategy
 from metadata.ingestion.connections.test_connections import (
     execute_inspector_func,
     test_connection_engine_step,
@@ -48,126 +56,107 @@ from metadata.ingestion.ometa.ometa_api import OpenMetadata
 from metadata.utils.constants import THREE_MIN
 
 
-def get_database_connection_url(connection: SapHanaConnection) -> str:
-    """
-    Build the SQLConnection URL for the database connection
-    """
+class SapHanaStrategy(ClientStrategy[SapHanaConnectionConfig, Engine], ABC):
+    """Builds the SAP HANA engine for one connection mode."""
 
-    conn = connection.connection
+    @property
+    def _scheme(self) -> str:
+        scheme = self._connection.scheme
+        return scheme.value if scheme else SapHanaScheme.hana.value
 
-    if not isinstance(conn, SapHanaSQLConnection):
-        raise ValueError("Database Connection requires the SQL connection details")  # noqa: TRY004
+    @abstractmethod
+    def get_url(self) -> str:
+        """Return the SQLAlchemy URL for this connection mode."""
 
-    url = (
-        f"{connection.scheme.value}://"
-        f"{quote_plus(conn.username)}:"
-        f"{quote_plus(conn.password.get_secret_value())}@"
-        f"{conn.hostPort}"
-    )
-
-    if hasattr(connection, "database"):
-        url += f"/{connection.database}" if connection.database else ""
-
-    options = get_connection_options_dict(connection)
-    if options:
-        if hasattr(conn, "database") and not conn.database:
-            url += "/"
-        params = "&".join(f"{key}={quote_plus(value)}" for (key, value) in options.items() if value)
-        url = f"{url}?{params}"
-    return url
-
-
-def get_hdb_connection_url(connection: SapHanaConnection) -> str:
-    """
-    Build the SQLConnection URL for the database connection
-    """
-
-    if not isinstance(connection.connection, SapHanaHDBConnection):
-        raise ValueError("Database Connection requires the SQL connection details")  # noqa: TRY004
-
-    return f"{connection.scheme.value}://userkey={connection.connection.userKey}"
-
-
-def get_connection(connection: SapHanaConnection) -> Engine:
-    """
-    Create connection
-    """
-
-    if isinstance(connection.connection, SapHanaSQLConnection):
+    def build(self) -> Engine:
         return create_generic_db_connection(
-            connection=connection,
-            get_connection_url_fn=get_database_connection_url,
+            connection=self._connection,
+            get_connection_url_fn=lambda _connection: self.get_url(),
             get_connection_args_fn=get_connection_args_common,
         )
 
-    if isinstance(connection.connection, SapHanaHDBConnection):
-        return create_generic_db_connection(
-            connection=connection,
-            get_connection_url_fn=get_hdb_connection_url,
-            get_connection_args_fn=get_connection_args_common,
+
+class SapHanaSQLStrategy(SapHanaStrategy):
+    """Direct host/port connection with username and password."""
+
+    def __init__(self, connection: SapHanaConnectionConfig, sql: SapHanaSQLConnection) -> None:
+        super().__init__(connection)
+        self._sql = sql
+
+    def get_url(self) -> str:
+        url = (
+            f"{self._scheme}://"
+            f"{quote_plus(self._sql.username)}:"
+            f"{quote_plus(self._sql.password.get_secret_value())}@"
+            f"{self._sql.hostPort}"
+        )
+        if self._sql.database:
+            url += f"/{self._sql.database}"
+        options = get_connection_options_dict(self._connection)
+        if options:
+            if not self._sql.database:
+                url += "/"
+            params = "&".join(f"{key}={quote_plus(value)}" for (key, value) in options.items() if value)
+            url = f"{url}?{params}"
+        return url
+
+
+class SapHanaHDBStrategy(SapHanaStrategy):
+    """Connection through a stored secure user store (HDB) key."""
+
+    def __init__(self, connection: SapHanaConnectionConfig, hdb: SapHanaHDBConnection) -> None:
+        super().__init__(connection)
+        self._hdb = hdb
+
+    def get_url(self) -> str:
+        return f"{self._scheme}://userkey={self._hdb.userKey}"
+
+
+class SapHanaConnection(BaseConnection[SapHanaConnectionConfig, Engine]):
+    def _get_client(self) -> Engine:
+        match self.service_connection.connection:
+            case SapHanaSQLConnection() as sql:
+                strategy: SapHanaStrategy = SapHanaSQLStrategy(self.service_connection, sql)
+            case SapHanaHDBConnection() as hdb:
+                strategy = SapHanaHDBStrategy(self.service_connection, hdb)
+        return strategy.build()
+
+    def test_connection(
+        self,
+        metadata: OpenMetadata,
+        automation_workflow: Optional[AutomationWorkflow] = None,  # noqa: UP045
+        timeout_seconds: Optional[int] = THREE_MIN,  # noqa: UP045
+    ) -> TestConnectionResult:
+        """
+        Test connection. This can be executed either as part
+        of a metadata workflow or during an Automation Workflow
+        """
+        service_type = self.service_connection.type
+        return test_connection_steps(
+            metadata=metadata,
+            test_fn=self._build_test_functions(),
+            service_type=service_type.value if service_type else SapHanaType.SapHana.value,
+            automation_workflow=automation_workflow,
+            timeout_seconds=timeout_seconds,
         )
 
-    raise ValueError("Unrecognized SAP Hana connection type!")
+    def _build_test_functions(self) -> dict[str, Callable]:
+        engine = self.client
 
+        def list_from_schema(inspector_fn_str: str) -> None:
+            inspector = inspect(engine)
+            inspector_fn = getattr(inspector, inspector_fn_str)
+            database_schema = getattr(self.service_connection.connection, "databaseSchema", None)
+            if database_schema:
+                inspector_fn(database_schema)
+            else:
+                for schema in inspector.get_schema_names() or []:
+                    inspector_fn(schema)
+                    break
 
-def _build_test_fn_dict(engine: Engine, service_connection: SapHanaConnection) -> Dict[str, Callable]:  # noqa: UP006
-    """
-    Build the test connection steps dict
-    """
-
-    def custom_executor(engine_: Engine, inspector_fn_str: str):
-        """
-        Check if we can list tables or views from a given schema
-        or a random one
-        """
-
-        inspector = inspect(engine_)
-        inspector_fn = getattr(inspector, inspector_fn_str)
-
-        # HDB connection won't have a databaseSchema
-        if getattr(service_connection.connection, "databaseSchema"):  # noqa: B009
-            inspector_fn(service_connection.connection.databaseSchema)
-        else:
-            schema_name = inspector.get_schema_names() or []
-            for schema in schema_name:
-                inspector_fn(schema)
-                break
-
-    if isinstance(service_connection.connection, SapHanaSQLConnection):
         return {
             "CheckAccess": partial(test_connection_engine_step, engine),
             "GetSchemas": partial(execute_inspector_func, engine, "get_schema_names"),
-            "GetTables": partial(custom_executor, engine, "get_table_names"),
-            "GetViews": partial(custom_executor, engine, "get_view_names"),
+            "GetTables": partial(list_from_schema, "get_table_names"),
+            "GetViews": partial(list_from_schema, "get_view_names"),
         }
-
-    if isinstance(service_connection.connection, SapHanaHDBConnection):
-        return {
-            "CheckAccess": partial(test_connection_engine_step, engine),
-            "GetSchemas": partial(execute_inspector_func, engine, "get_schema_names"),
-            "GetTables": partial(custom_executor, engine, "get_table_names"),
-            "GetViews": partial(custom_executor, engine, "get_view_names"),
-        }
-
-    raise ValueError(f"Unknown connection type for {service_connection.connection}")
-
-
-def test_connection(
-    metadata: OpenMetadata,
-    engine: Engine,
-    service_connection: SapHanaConnection,
-    automation_workflow: Optional[AutomationWorkflow] = None,  # noqa: UP045
-    timeout_seconds: Optional[int] = THREE_MIN,  # noqa: UP045
-) -> TestConnectionResult:
-    """
-    Test connection. This can be executed either as part
-    of a metadata workflow or during an Automation Workflow
-    """
-
-    return test_connection_steps(
-        metadata=metadata,
-        test_fn=_build_test_fn_dict(engine, service_connection),
-        service_type=service_connection.type.value,
-        automation_workflow=automation_workflow,
-        timeout_seconds=timeout_seconds,
-    )

--- a/ingestion/src/metadata/ingestion/source/database/saphana/connection.py
+++ b/ingestion/src/metadata/ingestion/source/database/saphana/connection.py
@@ -20,6 +20,7 @@ from urllib.parse import quote_plus
 
 from sqlalchemy import inspect
 from sqlalchemy.engine import Engine
+from typing_extensions import assert_never
 
 from metadata.generated.schema.entity.automations.workflow import (
     Workflow as AutomationWorkflow,
@@ -119,6 +120,8 @@ class SapHanaConnection(BaseConnection[SapHanaConnectionConfig, Engine]):
                 strategy: SapHanaStrategy = SapHanaSQLStrategy(self.service_connection, sql)
             case SapHanaHDBConnection() as hdb:
                 strategy = SapHanaHDBStrategy(self.service_connection, hdb)
+            case _:
+                assert_never(self.service_connection.connection)
         return strategy.build()
 
     def test_connection(

--- a/ingestion/src/metadata/ingestion/source/database/saphana/service_spec.py
+++ b/ingestion/src/metadata/ingestion/source/database/saphana/service_spec.py
@@ -1,5 +1,10 @@
+from metadata.ingestion.source.database.saphana.connection import SapHanaConnection
 from metadata.ingestion.source.database.saphana.lineage import SaphanaLineageSource
 from metadata.ingestion.source.database.saphana.metadata import SaphanaSource
 from metadata.utils.service_spec.default import DefaultDatabaseSpec
 
-ServiceSpec = DefaultDatabaseSpec(metadata_source_class=SaphanaSource, lineage_source_class=SaphanaLineageSource)
+ServiceSpec = DefaultDatabaseSpec(
+    metadata_source_class=SaphanaSource,  # pyright: ignore[reportArgumentType]
+    lineage_source_class=SaphanaLineageSource,  # pyright: ignore[reportArgumentType]
+    connection_class=SapHanaConnection,  # pyright: ignore[reportArgumentType]
+)

--- a/ingestion/tests/unit/source/database/saphana/test_connection.py
+++ b/ingestion/tests/unit/source/database/saphana/test_connection.py
@@ -1,0 +1,124 @@
+#  Copyright 2025 Collate
+#  Licensed under the Collate Community License, Version 1.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  https://github.com/open-metadata/OpenMetadata/blob/main/ingestion/LICENSE
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+"""Unit tests for SAP HANA connection handling.
+
+The SAP HANA dialect is an optional extra absent from the unit-test
+environment, so URL parity is asserted via each connection-mode strategy
+rather than by instantiating an engine.
+"""
+
+from unittest.mock import patch
+
+from metadata.generated.schema.entity.services.connections.database.sapHana.sapHanaHDBConnection import (
+    SapHanaHDBConnection,
+)
+from metadata.generated.schema.entity.services.connections.database.sapHana.sapHanaSQLConnection import (
+    SapHanaSQLConnection,
+)
+from metadata.generated.schema.entity.services.connections.database.sapHanaConnection import (
+    SapHanaConnection as SapHanaConnectionConfig,
+)
+from metadata.generated.schema.entity.services.connections.database.sapHanaConnection import (
+    SapHanaScheme,
+)
+from metadata.ingestion.connections.connection import BaseConnection
+from metadata.ingestion.source.database.saphana.connection import (
+    SapHanaConnection,
+    SapHanaHDBStrategy,
+    SapHanaSQLStrategy,
+)
+
+CONNECTION_MODULE = "metadata.ingestion.source.database.saphana.connection"
+
+
+def _sql_config(**sql_kwargs) -> SapHanaConnectionConfig:
+    return SapHanaConnectionConfig(
+        scheme=SapHanaScheme.hana,
+        connection=SapHanaSQLConnection(
+            username="openmetadata_user",
+            password="openmetadata_password",
+            hostPort="localhost:39041",
+            **sql_kwargs,
+        ),
+    )
+
+
+def _hdb_config() -> SapHanaConnectionConfig:
+    return SapHanaConnectionConfig(
+        scheme=SapHanaScheme.hana,
+        connection=SapHanaHDBConnection(userKey="USER1UserKey"),
+    )
+
+
+def test_saphana_connection_is_base_connection():
+    assert issubclass(SapHanaConnection, BaseConnection)
+
+
+def test_sql_url_includes_database():
+    config = _sql_config(database="HXE")
+    url = SapHanaSQLStrategy(config, config.connection).get_url()
+    assert url == "hana://openmetadata_user:openmetadata_password@localhost:39041/HXE"
+
+
+def test_sql_url_appends_options_with_database():
+    config = SapHanaConnectionConfig(
+        scheme=SapHanaScheme.hana,
+        connection=SapHanaSQLConnection(
+            username="openmetadata_user",
+            password="openmetadata_password",
+            hostPort="localhost:39041",
+            database="HXE",
+        ),
+        connectionOptions={"encrypt": "true"},
+    )
+    url = SapHanaSQLStrategy(config, config.connection).get_url()
+    assert url == "hana://openmetadata_user:openmetadata_password@localhost:39041/HXE?encrypt=true"
+
+
+def test_sql_url_without_database():
+    config = _sql_config()
+    url = SapHanaSQLStrategy(config, config.connection).get_url()
+    assert url == "hana://openmetadata_user:openmetadata_password@localhost:39041"
+
+
+def test_hdb_url_uses_user_key():
+    config = _hdb_config()
+    url = SapHanaHDBStrategy(config, config.connection).get_url()
+    assert url == "hana://userkey=USER1UserKey"
+
+
+def test_get_client_selects_sql_strategy():
+    config = _sql_config(database="HXE")
+    with patch(f"{CONNECTION_MODULE}.create_generic_db_connection") as mock_connection:
+        _ = SapHanaConnection(config).client
+    url_fn = mock_connection.call_args.kwargs["get_connection_url_fn"]
+    assert url_fn(config) == "hana://openmetadata_user:openmetadata_password@localhost:39041/HXE"
+
+
+def test_get_client_selects_hdb_strategy():
+    config = _hdb_config()
+    with patch(f"{CONNECTION_MODULE}.create_generic_db_connection") as mock_connection:
+        _ = SapHanaConnection(config).client
+    url_fn = mock_connection.call_args.kwargs["get_connection_url_fn"]
+    assert url_fn(config) == "hana://userkey=USER1UserKey"
+
+
+@patch(f"{CONNECTION_MODULE}.inspect")
+@patch(f"{CONNECTION_MODULE}.create_generic_db_connection")
+def test_hdb_test_functions_tolerate_missing_database_schema(_mock_connection, mock_inspect):
+    mock_inspect.return_value.get_schema_names.return_value = []
+    connection = SapHanaConnection(_hdb_config())
+
+    test_functions = connection._build_test_functions()
+    test_functions["GetTables"]()
+    test_functions["GetViews"]()
+
+    mock_inspect.return_value.get_schema_names.assert_called()


### PR DESCRIPTION
Fixes #28916

## What

Migrates the SAP HANA connector onto `BaseConnection`, and cleans up its connection handling using the `ClientStrategy` pattern.

## Why a strategy here

SAP HANA's `connection` is a discriminated union of two distinct mechanisms:

| Mode | Type | URL |
|------|------|-----|
| SQL | `SapHanaSQLConnection` | `hana://user:pass@host:port/db?opts` |
| HDB | `SapHanaHDBConnection` | `hana://userkey=<stored-key>` (secure user store) |

The old code branched on `isinstance` in **three** places — engine build, the test-function dict (whose two arms returned *identical* dicts), and each URL builder's guard — to express a single 2-way decision.

## How

- One `ClientStrategy` per mode (`SapHanaSQLStrategy` / `SapHanaHDBStrategy`), selected **once** via `match/case` in `_get_client`. The `case` arms narrow the union, so the URL builders need no `isinstance` guards; the test-function dict is built once.
- `connection_class` wired into the service spec.

## Two latent bugs fixed (surfaced by reading the builders against the models)

1. **The SQL DSN never included the database.** It checked `hasattr(connection, "database")` on the **outer** `SapHanaConnection` (which has no `database` field) instead of the **inner** `SapHanaSQLConnection`. So the database was silently dropped from every SQL connection URL.
2. **HDB crashed the test-connection step.** The executor called `getattr(connection, "databaseSchema")` with no default; HDB connections have only `userKey`, so this raised `AttributeError` — despite a comment right above acknowledging HDB has no `databaseSchema`. Now uses a `None` default and falls back to iterating schemas.

## Tests

Colocated unit tests under `tests/unit/source/database/saphana/` cover both URL modes, the `match/case` dispatch (SQL vs HDB), and both fixes — including a regression test that exercises the HDB test-function path that previously raised. (The SAP HANA dialect isn't in the unit-test env, so URLs are asserted via the strategies rather than a live engine; a real HANA server isn't feasible to stand up locally for an e2e.)