### PR TITLE
Fix/search settings.spec

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/SearchSettings.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/SearchSettings.spec.ts
@@ -316,12 +316,32 @@ test.describe('Search Settings', () => {
       }) => {
         await settingClick(page, GlobalSettingOptions.SEARCH_SETTINGS);
         const tableCard = page.getByTestId(mockEntitySearchSettings.key);
+
+        // Register before navigation so the on-load preview request is captured.
+        const initialPreviewPromise = page.waitForResponse((r) =>
+          r.url().includes('/api/v1/search/preview')
+        );
+
         await tableCard.click();
 
         await expect(page).toHaveURL(
           new RegExp(mockEntitySearchSettings.url + '$')
         );
         await waitForAllLoadersToDisappear(page);
+
+        const initialPreviewResponse = await initialPreviewPromise;
+        expect(initialPreviewResponse.status()).toBe(200);
+
+        const initialNgramBoost =
+          initialPreviewResponse
+            .request()
+            .postDataJSON()
+            ?.searchSettings?.assetTypeConfigurations?.find(
+              (c: { assetType: string }) => c.assetType === 'table'
+            )
+            ?.searchFields?.find(
+              (f: { field: string }) => f.field === 'name.ngram'
+            )?.boost ?? 0;
 
         // Expand the name.ngram field configuration panel.
         const ngramPanel = page.getByTestId(
@@ -341,31 +361,29 @@ test.describe('Search Settings', () => {
         await saveResponse;
         await toastNotification(page, /Search Settings updated successfully/);
 
-        // Re-expand the panel after save — it may have collapsed during re-render.
-        await ngramPanel.click();
-
         // Register the listener BEFORE moving the slider so the response is
         // never missed regardless of how fast the preview fires.
         const revertedPreviewPromise = page.waitForResponse((r) =>
           r.url().includes('/api/v1/search/preview')
         );
 
-        // Revert weight to 1 (the default from mockEntitySearchConfig).
-        await setSliderValue(page, 'field-weight-slider', 1);
+        await setSliderValue(page, 'field-weight-slider', initialNgramBoost);
 
         const revertedPreviewResponse = await revertedPreviewPromise;
         expect(revertedPreviewResponse.status()).toBe(200);
 
-        const revertedBody = revertedPreviewResponse.request().postDataJSON();
         const revertedNgramBoost =
-          revertedBody?.searchSettings?.assetTypeConfigurations
-            ?.find((c: { assetType: string }) => c.assetType === 'table')
+          revertedPreviewResponse
+            .request()
+            .postDataJSON()
+            ?.searchSettings?.assetTypeConfigurations?.find(
+              (c: { assetType: string }) => c.assetType === 'table'
+            )
             ?.searchFields?.find(
               (f: { field: string }) => f.field === 'name.ngram'
             )?.boost ?? 0;
 
-        // Preview must reflect the reverted value, not the saved value of 5.
-        expect(revertedNgramBoost).toBe(1);
+        expect(revertedNgramBoost).toBe(initialNgramBoost);
       });
 
       test('Preview config updates when restore defaults returns empty search fields', async ({

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/SearchSettings.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/SearchSettings.spec.ts
@@ -361,20 +361,13 @@ test.describe('Search Settings', () => {
         await saveResponse;
         await toastNotification(page, /Search Settings updated successfully/);
 
-        // Register the listener BEFORE moving the slider so the response is
-        // never missed regardless of how fast the preview fires.
-        const revertedPreviewPromise = page.waitForResponse((r) =>
-          r.url().includes('/api/v1/search/preview')
-        );
-
-        await setSliderValue(page, 'field-weight-slider', initialNgramBoost);
-
-        const revertedPreviewResponse = await revertedPreviewPromise;
-        expect(revertedPreviewResponse.status()).toBe(200);
-
-        const revertedBody = revertedPreviewResponse.request().postDataJSON();
-        const revertedNgramBoost =
-          revertedPreviewResponse
+        // Scope the predicate to the reverted boost value so a stale post-save
+        // preview response (boost=5) can never satisfy the promise.
+        const revertedPreviewPromise = page.waitForResponse((r) => {
+          if (!r.url().includes('/api/v1/search/preview')) {
+            return false;
+          }
+          const boost = r
             .request()
             .postDataJSON()
             ?.searchSettings?.assetTypeConfigurations?.find(
@@ -382,9 +375,15 @@ test.describe('Search Settings', () => {
             )
             ?.searchFields?.find(
               (f: { field: string }) => f.field === 'name.ngram'
-            )?.boost ?? 0;
+            )?.boost;
 
-        expect(revertedNgramBoost).toBe(initialNgramBoost);
+          return boost === initialNgramBoost;
+        });
+
+        await setSliderValue(page, 'field-weight-slider', initialNgramBoost);
+
+        const revertedPreviewResponse = await revertedPreviewPromise;
+        expect(revertedPreviewResponse.status()).toBe(200);
       });
 
       test('Preview config updates when restore defaults returns empty search fields', async ({

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/SearchSettings.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/SearchSettings.spec.ts
@@ -316,31 +316,12 @@ test.describe('Search Settings', () => {
       }) => {
         await settingClick(page, GlobalSettingOptions.SEARCH_SETTINGS);
         const tableCard = page.getByTestId(mockEntitySearchSettings.key);
-
-        // Register waitForResponse BEFORE the click so the on-load preview
-        // request is captured rather than missed.
-        const initialPreviewPromise = page.waitForResponse((r) =>
-          r.url().includes('/api/v1/search/preview')
-        );
-
         await tableCard.click();
 
         await expect(page).toHaveURL(
           new RegExp(mockEntitySearchSettings.url + '$')
         );
         await waitForAllLoadersToDisappear(page);
-
-        // Capture the initial preview request to read original n-gram boost.
-        const initialPreviewResponse = await initialPreviewPromise;
-        expect(initialPreviewResponse.status()).toBe(200);
-        const initialBody = initialPreviewResponse.request().postDataJSON();
-
-        const initialNgramBoost =
-          initialBody?.searchSettings?.assetTypeConfigurations
-            ?.find((c: { assetType: string }) => c.assetType === 'table')
-            ?.searchFields?.find(
-              (f: { field: string }) => f.field === 'name.ngram'
-            )?.boost ?? 0;
 
         // Expand the name.ngram field configuration panel.
         const ngramPanel = page.getByTestId(
@@ -360,16 +341,22 @@ test.describe('Search Settings', () => {
         await saveResponse;
         await toastNotification(page, /Search Settings updated successfully/);
 
-        // Revert n-gram weight back to its original value.
-        await setSliderValue(page, 'field-weight-slider', initialNgramBoost);
+        // Re-expand the panel after save — it may have collapsed during re-render.
+        await ngramPanel.click();
 
-        // Wait for the preview to re-fetch with the reverted config.
-        const revertedPreviewResponse = await page.waitForResponse((r) =>
+        // Register the listener BEFORE moving the slider so the response is
+        // never missed regardless of how fast the preview fires.
+        const revertedPreviewPromise = page.waitForResponse((r) =>
           r.url().includes('/api/v1/search/preview')
         );
-        expect(revertedPreviewResponse.status()).toBe(200);
-        const revertedBody = revertedPreviewResponse.request().postDataJSON();
 
+        // Revert weight to 1 (the default from mockEntitySearchConfig).
+        await setSliderValue(page, 'field-weight-slider', 1);
+
+        const revertedPreviewResponse = await revertedPreviewPromise;
+        expect(revertedPreviewResponse.status()).toBe(200);
+
+        const revertedBody = revertedPreviewResponse.request().postDataJSON();
         const revertedNgramBoost =
           revertedBody?.searchSettings?.assetTypeConfigurations
             ?.find((c: { assetType: string }) => c.assetType === 'table')
@@ -377,8 +364,8 @@ test.describe('Search Settings', () => {
               (f: { field: string }) => f.field === 'name.ngram'
             )?.boost ?? 0;
 
-        // The reverted preview must use the original n-gram boost value.
-        expect(revertedNgramBoost).toBe(initialNgramBoost);
+        // Preview must reflect the reverted value, not the saved value of 5.
+        expect(revertedNgramBoost).toBe(1);
       });
 
       test('Preview config updates when restore defaults returns empty search fields', async ({


### PR DESCRIPTION
fixes: #27946 

<!--
Short blurb explaining:
- What changes did you make?
- Why did you make them?
-->

Describe your changes: I fixed a bug in the search settings preview where reverting a field weight (e.g. name.ngram from 5 back to 1) or clicking "Restore Defaults" would leave the preview panel frozen on the previous state instead of re-fetching with the updated config.


#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### High-level design:
<!--
REQUIRED for large PRs (new features, refactors, breaking changes, or anything touching >5 files).
Skip for small bug fixes and trivial changes.

Cover:
- Architecture / approach you took and why
- Key components or files added/changed and how they interact
- Alternatives considered and why you rejected them
- Any migration, backward-compatibility, or rollout concerns
- Diagrams or links to design docs / RFCs if available
-->

N/A — small change. <!-- Or fill in the design above -->

#
### Tests:

#### Use cases covered
<!--
List the user-visible scenarios this PR exercises. Example:
- User with Admin role can create a Glossary Term with a parent term
- Ingestion run for Snowflake correctly extracts row counts for partitioned tables
-->

#### Unit tests
<!--
- [ ] I added unit tests for the new/changed logic.
- Files added/updated:
- Coverage on changed classes (run `mvn jacoco:report` for backend, `yarn test:coverage` for UI,
  `make unit_ingestion` for ingestion). Target is 90% line coverage on changed classes.
- Coverage %: <e.g., 92% on EntityRepository.java>
-->

#### Backend integration tests
<!--
- [ ] I added integration tests in `openmetadata-integration-tests/` for new/changed API endpoints.
- [ ] Not applicable (no backend API changes).
- Files added/updated:
-->

#### Ingestion integration tests
<!--
- [ ] I added/updated ingestion integration tests for connector changes.
- [ ] Not applicable (no ingestion changes).
- Files added/updated:
-->

#### Playwright (UI) tests
<!--
- [ ] I added Playwright E2E tests under `openmetadata-ui/.../ui/playwright/` for UI changes.
- [ ] Not applicable (no UI changes).
- Files added/updated:
-->

#### Manual testing performed
<!--
List the manual test steps you performed before requesting review. Example:
1. Started local stack via `./docker/run_local_docker.sh -m ui -d mysql`
2. Logged in as admin, created entity X, verified Y appears in the UI
3. Triggered ingestion for Snowflake source, confirmed lineage edges in the explore page
-->

#
### UI screen recording / screenshots:
<!--
REQUIRED for any PR that changes the UI. Drag-and-drop a short screen recording (.mov / .mp4 / .gif)
demonstrating the change end-to-end, plus before/after screenshots where relevant.
Mark "Not applicable" if there are no UI changes.
-->

Not applicable. <!-- Or attach recording/screenshots above -->

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] My PR title is `Fixes <issue-number>: <short explanation>`
- [x] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.
- [ ] For UI changes: I attached a screen recording and/or screenshots above.
- [ ] I have added tests (unit / integration / Playwright as applicable) and listed them above.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [x] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->


----
## Summary by Gitar

- **Test reliability improvements:**
  - Refactored `SearchSettings.spec.ts` to capture and validate `initialNgramBoost` from API responses.
  - Added request scoping in `revertedPreviewPromise` to prevent test flakiness caused by race conditions between stale and updated preview responses.


<sub>This will update automatically on new commits.</sub>