### PR TITLE
Show testSuite field in the CheckCondition to evaluate the presence of Test Suite

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/constants/JSONLogicSearch.constants.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/constants/JSONLogicSearch.constants.ts
@@ -22,6 +22,7 @@ export const TABLE_ENTITY_FIELDS_KEYS: EntityReferenceFields[] = [
   EntityReferenceFields.DATABASE,
   EntityReferenceFields.DATABASE_SCHEMA,
   EntityReferenceFields.TABLE_TYPE,
+  EntityReferenceFields.TEST_SUITE,
 ];
 
 export const COMMON_ENTITY_FIELDS_KEYS: EntityReferenceFields[] = [

--- a/openmetadata-ui/src/main/resources/ui/src/enums/AdvancedSearch.enum.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/enums/AdvancedSearch.enum.ts
@@ -123,4 +123,5 @@ export enum EntityReferenceFields {
   RELATED_TERMS = 'relatedTerms',
   SYNONYMS = 'synonyms',
   ENTITY_STATUS = 'entityStatus',
+  TEST_SUITE = 'testSuite.name',
 }

--- a/openmetadata-ui/src/main/resources/ui/src/utils/JSONLogicSearchClassBase.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/JSONLogicSearchClassBase.ts
@@ -457,13 +457,6 @@ class JSONLogicSearchClassBase {
         type: 'select',
         mainWidgetProps: this.mainWidgetProps,
         operators: ['is_null', 'is_not_null'],
-        fieldSettings: {
-          asyncFetch: advancedSearchClassBase.autocomplete({
-            searchIndex: SearchIndex.TEST_SUITE,
-            entityField: EntityFields.DISPLAY_NAME_KEYWORD,
-          }),
-          useAsyncSearch: true,
-        },
       },
 
       [EntityReferenceFields.REVIEWERS]: {

--- a/openmetadata-ui/src/main/resources/ui/src/utils/JSONLogicSearchClassBase.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/JSONLogicSearchClassBase.ts
@@ -452,6 +452,20 @@ class JSONLogicSearchClassBase {
         },
       },
 
+      [EntityReferenceFields.TEST_SUITE]: {
+        label: t('label.test-suite'),
+        type: 'select',
+        mainWidgetProps: this.mainWidgetProps,
+        operators: [...this.defaultSelectOperators],
+        fieldSettings: {
+          asyncFetch: advancedSearchClassBase.autocomplete({
+            searchIndex: SearchIndex.TEST_SUITE,
+            entityField: EntityFields.DISPLAY_NAME_KEYWORD,
+          }),
+          useAsyncSearch: true,
+        },
+      },
+
       [EntityReferenceFields.REVIEWERS]: {
         label: t('label.reviewer-plural'),
         type: '!group',

--- a/openmetadata-ui/src/main/resources/ui/src/utils/JSONLogicSearchClassBase.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/JSONLogicSearchClassBase.ts
@@ -456,7 +456,7 @@ class JSONLogicSearchClassBase {
         label: t('label.test-suite'),
         type: 'select',
         mainWidgetProps: this.mainWidgetProps,
-        operators: [...this.defaultSelectOperators],
+        operators: ['is_null', 'is_not_null'],
         fieldSettings: {
           asyncFetch: advancedSearchClassBase.autocomplete({
             searchIndex: SearchIndex.TEST_SUITE,


### PR DESCRIPTION

<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:

Fixes https://github.com/open-metadata/openmetadata-collate/issues/4491

<img width="748" height="803" alt="Screenshot 2026-06-10 at 4 22 37 PM" src="https://github.com/user-attachments/assets/ff9f7c5f-c0d6-4ddc-971e-99d819c75fa3" />

----
## Summary by Gitar

- **UI Enhancements:**
  - Added `TEST_SUITE` field to `CheckCondition` to enable filtering by test suite.
  - Registered `TEST_SUITE` in `EntityReferenceFields` and `TABLE_ENTITY_FIELDS_KEYS` to support search integration.

<sub>This will update automatically on new commits.</sub>