### PR TITLE
fix(athena): pass catalogId to get_tables so S3 Tables / cross-account catalogs enumerate tables

### DIFF
--- a/ingestion/src/metadata/ingestion/source/database/athena/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/database/athena/metadata.py
@@ -161,7 +161,10 @@ class AthenaSource(ExternalTableLineageMixin, CommonDbSourceService):
             try:
                 results = []
                 paginator = self.glue_client.get_paginator("get_tables")
-                for page in paginator.paginate(DatabaseName=schema_name):
+                paginate_params = {"DatabaseName": schema_name}
+                if self.service_connection.catalogId:
+                    paginate_params["CatalogId"] = self.service_connection.catalogId
+                for page in paginator.paginate(**paginate_params):
                     for table in page.get("TableList", []):
                         params = table.get("Parameters", {})
                         table_type = (

--- a/ingestion/tests/unit/topology/database/test_athena.py
+++ b/ingestion/tests/unit/topology/database/test_athena.py
@@ -14,8 +14,9 @@ Test athena source
 
 import hashlib
 import unittest
+from copy import deepcopy
 from datetime import datetime
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, PropertyMock, patch
 from uuid import UUID
 
 import pytest
@@ -265,6 +266,14 @@ mock_athena_config = {
         }
     },
 }
+
+S3_TABLES_CATALOG_ID = "s3tablescatalog/my-bucket"
+
+
+def _athena_config_with_catalog_id(catalog_id):
+    config = deepcopy(mock_athena_config)
+    config["source"]["serviceConnection"]["config"]["catalogId"] = catalog_id
+    return config
 
 
 class TestAthenaService(unittest.TestCase):
@@ -754,6 +763,83 @@ class TestQueryTableNamesAndTypesIcebergConstant:
         )
 
         assert ICEBERG_TABLE_TYPE == "ICEBERG"
+
+
+def _make_source_with_glue(config, table_list):
+    """Build an AthenaSource from config and attach a Glue client whose
+    get_tables paginator yields a single page with the given TableList."""
+    workflow_config = OpenMetadataWorkflowConfig.model_validate(config)
+    with patch(
+        "metadata.ingestion.source.database.database_service.DatabaseServiceSource.test_connection",
+        return_value=False,
+    ):
+        source = AthenaSource.create(
+            config["source"],
+            workflow_config.workflowConfig.openMetadataServerConfig,
+        )
+    mock_paginator = MagicMock()
+    mock_paginator.paginate.return_value = [{"TableList": table_list}]
+    mock_glue_client = MagicMock()
+    mock_glue_client.get_paginator.return_value = mock_paginator
+    source.glue_client = mock_glue_client
+    return source, mock_paginator
+
+
+class TestQueryTableNamesAndTypesCatalogId:
+    """get_tables enumeration must target the configured catalogId.
+
+    Regression coverage for S3 Tables / cross-account Glue catalogs, where
+    omitting CatalogId queries the default catalog and returns 0 tables.
+    """
+
+    def test_catalog_id_passed_to_paginate_when_configured(self):
+        config = _athena_config_with_catalog_id(S3_TABLES_CATALOG_ID)
+        source, mock_paginator = _make_source_with_glue(config, [{"Name": MOCK_TABLE_NAME, "Parameters": {}}])
+
+        result = source.query_table_names_and_types(MOCK_DATABASE_SCHEMA.name.root)
+
+        assert result == EXPECTED_QUERY_TABLE_NAMES_TYPES
+        mock_paginator.paginate.assert_called_once_with(
+            DatabaseName=MOCK_DATABASE_SCHEMA.name.root,
+            CatalogId=S3_TABLES_CATALOG_ID,
+        )
+
+    def test_catalog_id_omitted_when_not_configured(self):
+        source, mock_paginator = _make_source_with_glue(
+            deepcopy(mock_athena_config), [{"Name": MOCK_TABLE_NAME, "Parameters": {}}]
+        )
+
+        result = source.query_table_names_and_types(MOCK_DATABASE_SCHEMA.name.root)
+
+        assert result == EXPECTED_QUERY_TABLE_NAMES_TYPES
+        mock_paginator.paginate.assert_called_once_with(DatabaseName=MOCK_DATABASE_SCHEMA.name.root)
+        assert "CatalogId" not in mock_paginator.paginate.call_args.kwargs
+
+    def test_empty_table_list_returns_empty_without_inspector_fallback(self):
+        """A successful Glue call with an empty TableList is returned as-is;
+        the inspector fallback only fires on exception or missing Glue client."""
+        config = _athena_config_with_catalog_id(S3_TABLES_CATALOG_ID)
+        source, _ = _make_source_with_glue(config, [])
+        mock_inspector = MagicMock()
+
+        with patch.object(type(source), "inspector", new_callable=PropertyMock, return_value=mock_inspector):
+            result = source.query_table_names_and_types(MOCK_DATABASE_SCHEMA.name.root)
+
+        assert result == []
+        mock_inspector.get_table_names.assert_not_called()
+
+    def test_falls_back_to_inspector_when_glue_call_raises(self):
+        config = _athena_config_with_catalog_id(S3_TABLES_CATALOG_ID)
+        source, mock_paginator = _make_source_with_glue(config, [])
+        mock_paginator.paginate.side_effect = Exception("AccessDenied")
+        mock_inspector = MagicMock()
+        mock_inspector.get_table_names.return_value = [MOCK_TABLE_NAME]
+
+        with patch.object(type(source), "inspector", new_callable=PropertyMock, return_value=mock_inspector):
+            result = source.query_table_names_and_types(MOCK_DATABASE_SCHEMA.name.root)
+
+        assert result == EXPECTED_QUERY_TABLE_NAMES_TYPES
+        mock_inspector.get_table_names.assert_called_once_with(MOCK_DATABASE_SCHEMA.name.root)
 
 
 class TestIncludeCustomPropertiesSchema:


### PR DESCRIPTION
Fixes https://github.com/open-metadata/OpenMetadata/issues/28928
### Description:

- `AthenaSource.query_table_names_and_types` enumerates tables via the Glue
`get_tables` paginator but did not pass `CatalogId`, so it always queried the
caller's **default** Glue Data Catalog. For services configured with a federated
**S3 Tables** catalog (`s3tablescatalog`) or a **cross-account Glue** catalog via
`catalogId`, the default-catalog query matches nothing and Glue returns a
successful response with an empty `TableList` → **0 tables ingested**.

- Because the Glue call succeeds (rather than raising), the existing fallback to
`inspector.get_table_names()` is never reached, so the empty result is treated as
authoritative. With `markDeletedTables` enabled this is destructive — previously
ingested tables get marked deleted.

- Every other Glue/Lake Formation call in this connector already passes `catalogId`
(`get_databases`, `get_table` for columns and partitions); `get_tables` was the
only one missing it. This PR makes it consistent.

### Changes
- Pass `CatalogId` to the `get_tables` paginator when `service_connection.catalogId`
  is set, mirroring the existing `get_databases` block.

```python
paginate_params = {"DatabaseName": schema_name}
if self.service_connection.catalogId:
    paginate_params["CatalogId"] = self.service_connection.catalogId
for page in paginator.paginate(**paginate_params):
    ...
