### PR TITLE
fix(ui): add height: 100% to DeferredWidget to fix widget height on landing page

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/common/DeferredWidget/DeferredWidget.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/DeferredWidget/DeferredWidget.component.tsx
@@ -159,7 +159,10 @@ export const DeferredWidget = ({
       className={className}
       data-testid={dataTestId}
       ref={ref}
-      style={minHeight !== undefined ? { minHeight } : undefined}>
+      style={{
+        height: '100%',
+        ...(minHeight !== undefined ? { minHeight } : {}),
+      }}>
       {shouldRender ? children : placeholder ?? null}
     </div>
   );


### PR DESCRIPTION
## Summary

- Added `height: 100%` to `DeferredWidget`'s wrapper `div`. ReactGridLayout sets grid cell height via absolute positioning; `WidgetWrapper` inside uses `height: 100%` to fill it. The intermediate `DeferredWidget` wrapper only had `minHeight` — no `height` — so `WidgetWrapper`'s `height: 100%` had no parent height to anchor to and collapsed, causing all deferred widgets to render with wrong height.

Issue:
https://github.com/user-attachments/assets/a61f6e31-7e74-49ba-83bc-d1b23275f365
Fix:
https://github.com/user-attachments/assets/7bd0fd49-02e0-4391-9cc5-610580bfe93d


Closes https://github.com/open-metadata/openmetadata-collate/issues/4495

## Root Cause

When a saved persona layout is loaded, `packWidgetsTightly` assigns y-values in multiples of `h` (0, 3, 6, 9, …). The `isBelowFold = widget.y >= 2` threshold in `MyDataPage` correctly identifies row 2+ widgets for deferral. However, `DeferredWidget` was missing `height: 100%` on its wrapper div — so even though the grid cell had explicit height from ReactGridLayout, `WidgetWrapper`'s `height: 100%` inside it collapsed.

## Test plan

- [ ] Navigate to `/my-data` with a saved persona layout — all widget rows should have correct height
- [ ] Navigate to `/customize-page/{persona}/LandingPage` — heights unchanged (still correct)
- [ ] Reload with no saved persona (default layout) — no regression
- [ ] Scroll down — below-fold widgets still defer correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)