### PR TITLE
test(it): scope list_databaseServiceWithPipelinesField via domain filter

### DIFF
--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/DatabaseServiceResourceIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/DatabaseServiceResourceIT.java
@@ -339,8 +339,20 @@ public class DatabaseServiceResourceIT
 
   @Test
   void list_databaseServiceWithPipelinesField_populatesPipelines(TestNamespace ns) {
-    DatabaseService service =
-        createEntity(createMinimalRequest(ns).withName(ns.prefix("svc_pipe")));
+    Domain domain =
+        SdkClients.adminClient()
+            .domains()
+            .create(
+                new CreateDomain()
+                    .withName(ns.prefix("svc_pipe_dom"))
+                    .withDescription("Isolates list query for pipelines-field test")
+                    .withDomainType(CreateDomain.DomainType.AGGREGATE));
+
+    CreateDatabaseService createRequest =
+        createMinimalRequest(ns)
+            .withName(ns.prefix("svc_pipe"))
+            .withDomains(List.of(domain.getFullyQualifiedName()));
+    DatabaseService service = createEntity(createRequest);
 
     CreateIngestionPipeline pipelineRequest =
         new CreateIngestionPipeline()
@@ -354,8 +366,7 @@ public class DatabaseServiceResourceIT
     IngestionPipeline pipeline =
         SdkClients.adminClient().ingestionPipelines().create(pipelineRequest);
 
-    ListParams params = new ListParams();
-    params.setLimit(1000);
+    ListParams params = new ListParams().withDomain(domain.getFullyQualifiedName()).withLimit(1000);
     params.setFields("pipelines");
     ListResponse<DatabaseService> response = listEntities(params);
 


### PR DESCRIPTION
## Summary
- `DatabaseServiceResourceIT.list_databaseServiceWithPipelinesField_populatesPipelines` is flaky on `main`. Reproduced in [this CI run](https://github.com/open-metadata/OpenMetadata/actions) where the test fails with `Created service should be present in list response ==> expected: not <null>`.
- Introduced in PR #28675 (perf: one-transaction flush + async indexing write path, read-path fixes), commit `1a2ae45640`, as a regression guard for the `ServiceEntityRepository` fix that added `setFieldsInBulk` so `fields=pipelines` actually populates pipelines on the list endpoint.
- Failure mode: the test created a service then called the global list endpoint with `limit=1000` and filtered the result by id. Under `@Execution(ExecutionMode.CONCURRENT)` this suite creates thousands of `DatabaseService` rows in a single run, so the just-created service can land past page 1 and the assertion fails.

## Fix
Attach a per-test `Domain` (named via `TestNamespace.prefix`) to the service, and pass `domain=<fqn>` on the list endpoint — the only entity-scoping filter `DatabaseServiceResource.list` exposes ([`DatabaseServiceResource.java:131-135`](openmetadata-service/src/main/java/org/openmetadata/service/resources/services/database/DatabaseServiceResource.java#L131-L135)). Both `listAfter` and `listAfterWithOffset` still invoke `setFieldsInBulk(fields, entities)` on the result set, so the bulk-fetch regression PR #28675 guards against remains exercised. Matches the established `BaseServiceIT.test_listWithDomainFilter` idiom in this suite.

## Test plan
- [x] `mvn spotless:apply -pl openmetadata-integration-tests` clean
- [x] `mvn test-compile -pl openmetadata-integration-tests` passes
- [x] `mvn test -pl openmetadata-integration-tests -Dtest='DatabaseServiceResourceIT#list_databaseServiceWithPipelinesField_populatesPipelines'` — **Tests run: 1, Failures: 0, Errors: 0, Skipped: 0** (0.148s)