### PR TITLE
fix(sse): concatenate multi-line SSE data fields instead of overwriting

### DIFF
--- a/ingestion/src/metadata/ingestion/ometa/sse_client.py
+++ b/ingestion/src/metadata/ingestion/ometa/sse_client.py
@@ -158,16 +158,24 @@ class SSEClient:
             dict[str, Any]: The parsed event.
         """
         event: dict[str, Any] = {}
+        data_lines: list[str] = []
         for line in event_buffer:
             if line.startswith("event:"):
                 event["event"] = line.split(":", 1)[1].strip()
                 if "complete" in event["event"] or "error" in event["event"]:
                     self.stream_completed = True
             elif line.startswith("data:"):
-                event["data"] = line.split(":", 1)[1].strip()
+                # Per the SSE spec a single event's `data` field may span multiple
+                # `data:` lines that must be concatenated with `\n`. Accumulate them
+                # instead of overwriting: keeping only the last line truncated large
+                # payloads (e.g. the Quality agent's createTestCase blob) mid-string,
+                # surfacing downstream as `json.JSONDecodeError: Unterminated string`.
+                data_lines.append(line.split(":", 1)[1].strip())
             elif line.startswith("id:"):
                 event["id"] = line.split(":", 1)[1].strip()
                 self.last_event_id = event["id"]
+        if data_lines:
+            event["data"] = "\n".join(data_lines)
         return event
 
     def _validate_access_token(self):

--- a/ingestion/tests/unit/metadata/ingestion/ometa/test_sse_client.py
+++ b/ingestion/tests/unit/metadata/ingestion/ometa/test_sse_client.py
@@ -816,3 +816,37 @@ def test_parse_sse_event_with_colon_in_data(sse_client):
 
     assert parsed["event"] == "message"
     assert parsed["data"] == '{"key":"value:with:colons"}'
+
+
+def test_parse_sse_event_concatenates_multiple_data_lines(sse_client):
+    """Multiple ``data:`` lines in one SSE event must be concatenated with newlines
+    (per the SSE spec), not overwritten so only the last survives."""
+    event_buffer = [
+        "event: message",
+        "data: part-one",
+        "data: part-two",
+        "data: part-three",
+    ]
+    parsed = sse_client._parse_sse_event(event_buffer)
+
+    assert parsed["data"] == "part-one\npart-two\npart-three"
+
+
+def test_parse_sse_event_reassembles_json_split_across_data_lines(sse_client):
+    """A JSON payload chunked across multiple ``data:`` lines must be fully reassembled
+    so downstream ``json.loads`` sees complete JSON.
+
+    Regression: large/over-escaped agent payloads (e.g. the Quality agent's
+    ``createTestCase`` blob) arrive split across several ``data:`` lines. Keeping only
+    the last line truncated the JSON mid-string and surfaced downstream as
+    ``json.JSONDecodeError: Unterminated string``.
+    """
+    event_buffer = [
+        "event: message",
+        'data: {"testCases":',
+        'data: [{"name":"customer_id_not_null"}]}',
+    ]
+    parsed = sse_client._parse_sse_event(event_buffer)
+
+    data = json.loads(parsed["data"])
+    assert data["testCases"][0]["name"] == "customer_id_not_null"


### PR DESCRIPTION

fixes https://github.com/open-metadata/openmetadata-collate/issues/4498

## Problem

`SSEClient._parse_sse_event` keeps only the **last** `data:` line of an SSE event:

```python
elif line.startswith("data:"):
    event["data"] = line.split(":", 1)[1].strip()   # overwrites every data: line
```

Per the [SSE spec](https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation) a single event's `data` field may span **multiple** `data:` lines, which must be concatenated with `\n`. Overwriting drops all but the last line, so any payload split across several `data:` lines is truncated mid-string. Downstream consumers then fail with `json.JSONDecodeError: Unterminated string` — observed in the dynamic-agent ingestion app (`metadata.applications.dynamic_agent.app`) when the AI Quality agent emits a large/over-escaped `createTestCase` payload, which aborts the run with 0 tests created.

## Fix

Accumulate all `data:` line values and `"\n".join` them. Single-`data:`-line events are unchanged (a join of one).

## Tests

Two regressions added to `test_sse_client.py`:
- `test_parse_sse_event_concatenates_multiple_data_lines` — multi-`data:` join semantics
- `test_parse_sse_event_reassembles_json_split_across_data_lines` — a JSON payload chunked across `data:` lines is reassembled so `json.loads` succeeds

Verified RED→GREEN on the real `_parse_sse_event`. (The full pytest module couldn't run in my local venv due to pre-existing dependency drift, so I exercised the method via an isolated harness; CI runs the suite normally.)

The bug is identical on `1.12.10`/`1.12.11`/`1.13`; to be cherry-picked to the release branches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
