### PR TITLE
fix(policy): allow bare references to approved functions in SpEL conditions

### DIFF
--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/PolicyResourceIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/PolicyResourceIT.java
@@ -240,6 +240,37 @@ public class PolicyResourceIT extends BaseEntityIT<Policy, CreatePolicy> {
     assertEquals("isOwner()", policy.getRules().get(0).getCondition());
   }
 
+  /**
+   * Regression for the Orsted-reported failure (#20262): creating or updating a policy whose rule
+   * condition uses the bare, parenthesis-less form of a boolean function (e.g. {@code !isOwner})
+   * failed with "disallowed SpEL construct: PropertyOrFieldReference ('isOwner')". The bare form is
+   * functionally identical to {@code !isOwner()} — SpEL resolves it to the same getter — and is
+   * documented as valid in RuleEvaluator's @Function examples. Both create and update must succeed.
+   */
+  @Test
+  void test_createAndUpdatePolicyWithBareReferenceCondition(TestNamespace ns) {
+    Rule rule =
+        new Rule()
+            .withName("bareOwnerRule")
+            .withResources(List.of(ALL_RESOURCES))
+            .withOperations(List.of(MetadataOperation.EDIT_ALL))
+            .withEffect(Effect.ALLOW)
+            .withCondition("!isOwner");
+
+    CreatePolicy create =
+        new CreatePolicy()
+            .withName(ns.prefix("bareConditionPolicy"))
+            .withRules(List.of(rule))
+            .withDescription("Policy with a bare-reference condition");
+
+    Policy policy = createEntity(create);
+    assertEquals("!isOwner", policy.getRules().get(0).getCondition());
+
+    policy.getRules().get(0).setCondition("noOwner() || isOwner");
+    Policy updated = patchEntity(policy.getId().toString(), policy);
+    assertEquals("noOwner() || isOwner", updated.getRules().get(0).getCondition());
+  }
+
   @Test
   void test_createPolicyWithDenyEffect(TestNamespace ns) {
     OpenMetadataClient client = SdkClients.adminClient();

--- a/openmetadata-service/src/main/java/org/openmetadata/service/security/policyevaluator/ExpressionValidator.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/security/policyevaluator/ExpressionValidator.java
@@ -41,6 +41,7 @@ import org.springframework.expression.spel.ast.OpLT;
 import org.springframework.expression.spel.ast.OpNE;
 import org.springframework.expression.spel.ast.OpOr;
 import org.springframework.expression.spel.ast.OperatorNot;
+import org.springframework.expression.spel.ast.PropertyOrFieldReference;
 import org.springframework.expression.spel.ast.RealLiteral;
 import org.springframework.expression.spel.ast.StringLiteral;
 import org.springframework.expression.spel.ast.Ternary;
@@ -109,6 +110,11 @@ public final class ExpressionValidator {
           InlineMap.class,
           // Method calls — subject to ALLOWED_FUNCTIONS check below
           MethodReference.class,
+          // Bare references to no-arg boolean functions (e.g. `!isOwner`, `noOwner`) —
+          // SpEL resolves these to the matching @Function getter; subject to the
+          // ALLOWED_FUNCTIONS check below. Compound references (e.g. `System.exit`) parse
+          // as CompoundExpression, which stays disallowed.
+          PropertyOrFieldReference.class,
           // Conditional combinators
           Ternary.class,
           Elvis.class);
@@ -138,7 +144,7 @@ public final class ExpressionValidator {
       return;
     }
     ensureNodeKindAllowed(node);
-    ensureMethodNameAllowed(node);
+    ensureCallableNameAllowed(node);
     for (int i = 0; i < node.getChildCount(); i++) {
       validateNode(node.getChild(i));
     }
@@ -157,12 +163,14 @@ public final class ExpressionValidator {
             + " ternaries, and method calls on approved @Function-annotated methods are allowed.");
   }
 
-  private static void ensureMethodNameAllowed(SpelNode node) {
-    if (!(node instanceof MethodReference methodRef)) {
-      return;
-    }
-    String name = methodRef.getName();
-    if (ALLOWED_FUNCTIONS.contains(name)) {
+  private static void ensureCallableNameAllowed(SpelNode node) {
+    String name =
+        switch (node) {
+          case MethodReference methodRef -> methodRef.getName();
+          case PropertyOrFieldReference propertyRef -> propertyRef.getName();
+          default -> null;
+        };
+    if (name == null || ALLOWED_FUNCTIONS.contains(name)) {
       return;
     }
     throw new IllegalArgumentException(

--- a/openmetadata-service/src/main/java/org/openmetadata/service/security/policyevaluator/ExpressionValidator.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/security/policyevaluator/ExpressionValidator.java
@@ -82,7 +82,19 @@ import org.springframework.expression.spel.standard.SpelExpressionParser;
 @Slf4j
 public final class ExpressionValidator {
 
-  private static final Set<String> ALLOWED_FUNCTIONS = initAllowedFunctions();
+  private static final Set<String> ALLOWED_FUNCTIONS = new HashSet<>();
+
+  /**
+   * Names of no-arg boolean {@code @Function} methods. Only these may appear as a bare {@link
+   * PropertyOrFieldReference} (e.g. {@code !isOwner}); SpEL resolves a bare reference to the
+   * matching no-arg getter, so arg-taking functions such as {@code matchAnyTag} cannot be used
+   * bare and are rejected up front rather than failing later at evaluation time.
+   */
+  private static final Set<String> ALLOWED_BARE_FUNCTIONS = new HashSet<>();
+
+  static {
+    initAllowedFunctions(ALLOWED_FUNCTIONS, ALLOWED_BARE_FUNCTIONS);
+  }
 
   private static final Set<Class<?>> ALLOWED_NODE_CLASSES =
       Set.of(
@@ -164,13 +176,20 @@ public final class ExpressionValidator {
   }
 
   private static void ensureCallableNameAllowed(SpelNode node) {
-    String name =
-        switch (node) {
-          case MethodReference methodRef -> methodRef.getName();
-          case PropertyOrFieldReference propertyRef -> propertyRef.getName();
-          default -> null;
-        };
-    if (name == null || ALLOWED_FUNCTIONS.contains(name)) {
+    String name = null;
+    Set<String> allowed = null;
+    switch (node) {
+      case MethodReference methodRef -> {
+        name = methodRef.getName();
+        allowed = ALLOWED_FUNCTIONS;
+      }
+      case PropertyOrFieldReference propertyRef -> {
+        name = propertyRef.getName();
+        allowed = ALLOWED_BARE_FUNCTIONS;
+      }
+      default -> {}
+    }
+    if (name == null || allowed.contains(name)) {
       return;
     }
     throw new IllegalArgumentException(
@@ -180,8 +199,8 @@ public final class ExpressionValidator {
             + "Only use approved functions with @Function annotations in evaluator classes.");
   }
 
-  private static Set<String> initAllowedFunctions() {
-    Set<String> allowedFunctions = new HashSet<>();
+  private static void initAllowedFunctions(
+      Set<String> allowedFunctions, Set<String> bareFunctions) {
     try {
       // Classes that provide functions for policy expressions
       List<Class<?>> evaluatorClasses = new ArrayList<>();
@@ -189,11 +208,12 @@ public final class ExpressionValidator {
       evaluatorClasses.addAll(getClassesAlertAndCompletion());
 
       for (Class<?> clazz : evaluatorClasses) {
-        scanClassForFunctions(clazz, allowedFunctions);
+        scanClassForFunctions(clazz, allowedFunctions, bareFunctions);
       }
       LOG.info(
-          "Initialized ExpressionValidator with {} allowed functions: {}",
+          "Initialized ExpressionValidator with {} allowed functions ({} usable bare): {}",
           allowedFunctions.size(),
+          bareFunctions.size(),
           allowedFunctions);
     } catch (Exception e) {
       LOG.error("Failed to initialize allowed functions", e);
@@ -226,9 +246,20 @@ public final class ExpressionValidator {
               "matchDataContractStatus",
               "filterByEntityNameDataContractBelongsTo",
               "isBot"));
+      bareFunctions.addAll(
+          Arrays.asList(
+              "noOwner",
+              "isOwner",
+              "isReviewer",
+              "isTaskFiler",
+              "isTaskAssignee",
+              "isTaskReviewer",
+              "hasDomain",
+              "noDomain",
+              "matchTeam",
+              "isBot"));
       LOG.info("Using fallback list of {} allowed functions", allowedFunctions.size());
     }
-    return allowedFunctions;
   }
 
   private static List<Class<?>> getClassesAlertAndCompletion() {
@@ -249,17 +280,27 @@ public final class ExpressionValidator {
     return evaluatorClasses;
   }
 
-  private static void scanClassForFunctions(Class<?> clazz, Set<String> allowedFunctions) {
+  private static void scanClassForFunctions(
+      Class<?> clazz, Set<String> allowedFunctions, Set<String> bareFunctions) {
     try {
       for (Method method : clazz.getDeclaredMethods()) {
         if (method.isAnnotationPresent(Function.class)) {
-          Function annotation = method.getAnnotation(Function.class);
-          allowedFunctions.add(annotation.name());
-          LOG.debug("Added allowed function from {}: {}", clazz.getSimpleName(), annotation.name());
+          String name = method.getAnnotation(Function.class).name();
+          allowedFunctions.add(name);
+          if (isNoArgBoolean(method)) {
+            bareFunctions.add(name);
+          }
+          LOG.debug("Added allowed function from {}: {}", clazz.getSimpleName(), name);
         }
       }
     } catch (Exception e) {
       LOG.warn("Failed to scan functions from class {}", clazz.getName(), e);
     }
+  }
+
+  private static boolean isNoArgBoolean(Method method) {
+    Class<?> returnType = method.getReturnType();
+    return method.getParameterCount() == 0
+        && (returnType == boolean.class || returnType == Boolean.class);
   }
 }

--- a/openmetadata-service/src/test/java/org/openmetadata/service/security/policyevaluator/ExpressionValidatorTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/security/policyevaluator/ExpressionValidatorTest.java
@@ -103,6 +103,28 @@ public class ExpressionValidatorTest {
     }
   }
 
+  /**
+   * Bare references are only meaningful for no-arg boolean functions. An arg-taking function such
+   * as {@code matchAnyTag} used bare would pass the node check but fail at SpEL evaluation (no
+   * such property/getter), so it is rejected up front - even though its parenthesised form is a
+   * valid allowed function.
+   */
+  @Test
+  void bareReferencesToArgTakingFunctionsAreRejected() {
+    String[] argTakingBareReferences = {"matchAnyTag", "matchAllTags", "inAnyTeam", "hasAnyRole"};
+
+    for (String expression : argTakingBareReferences) {
+      assertThrows(
+          IllegalArgumentException.class,
+          () -> ExpressionValidator.validateExpressionSafety(expression),
+          "Bare reference to arg-taking function '" + expression + "' must be rejected");
+    }
+
+    assertDoesNotThrow(
+        () -> ExpressionValidator.validateExpressionSafety("matchAnyTag('PII.Sensitive')"),
+        "The parenthesised call form of the same function must still be allowed");
+  }
+
   @Test
   void combinedBooleanWrappedConditionIsSafe() {
     // Boolean wrappers (()/&&/||/!) only add safe nodes, so combining safe fragments stays safe.

--- a/openmetadata-service/src/test/java/org/openmetadata/service/security/policyevaluator/ExpressionValidatorTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/security/policyevaluator/ExpressionValidatorTest.java
@@ -49,6 +49,60 @@ public class ExpressionValidatorTest {
     }
   }
 
+  /**
+   * Bare references to no-arg boolean functions (e.g. {@code !isOwner}) parse as SpEL {@link
+   * org.springframework.expression.spel.ast.PropertyOrFieldReference} nodes, not method calls.
+   * SpEL resolves them to the matching {@code @Function} getter, so they are functionally
+   * identical to the parenthesised form and are documented as valid in {@code RuleEvaluator}'s
+   * {@code @Function} examples. The AST validator must accept them when the referenced name is
+   * an approved function. Customer-reported regression (Orsted): policies using {@code !isOwner}
+   * failed to save with "disallowed SpEL construct: PropertyOrFieldReference ('isOwner')".
+   */
+  @Test
+  void bareReferencesToApprovedFunctionsAreAllowed() {
+    String[] bareExpressions = {
+      "isOwner",
+      "!isOwner",
+      "noOwner",
+      "!noOwner",
+      "isReviewer",
+      "!isReviewer",
+      "matchTeam",
+      "hasDomain",
+      "noOwner() || isOwner",
+      "!noOwner && isOwner",
+      "!noOwner() && !isOwner"
+    };
+
+    for (String expression : bareExpressions) {
+      assertDoesNotThrow(
+          () -> ExpressionValidator.validateExpressionSafety(expression),
+          "Bare reference to an approved function '" + expression + "' should be allowed");
+    }
+  }
+
+  /**
+   * A bare reference is only safe because the name is gated on {@link
+   * ExpressionValidator#getAllowedFunctions()}. Standalone references to names that are not
+   * approved functions must still be rejected so the relaxation cannot be used to read
+   * arbitrary properties.
+   */
+  @Test
+  void bareReferencesToUnknownNamesAreRejected() {
+    String[] disallowedBareReferences = {"System", "entity", "someObject", "Runtime"};
+
+    for (String expression : disallowedBareReferences) {
+      Exception exception =
+          assertThrows(
+              IllegalArgumentException.class,
+              () -> ExpressionValidator.validateExpressionSafety(expression),
+              "Bare reference to non-function '" + expression + "' must be rejected");
+      assertTrue(
+          exception.getMessage().contains("is not allowed in policy expressions"),
+          "Exception should mention that the reference is not an allowed function");
+    }
+  }
+
   @Test
   void combinedBooleanWrappedConditionIsSafe() {
     // Boolean wrappers (()/&&/||/!) only add safe nodes, so combining safe fragments stays safe.


### PR DESCRIPTION
Fixes #28947

## Problem

Creating or updating **any** policy whose rule condition uses the bare, parenthesis-less form of a boolean function fails with:

```
Expression contains a disallowed SpEL construct: PropertyOrFieldReference ('isOwner').
Only literals, boolean/comparison operators, list/map literals, ternaries, and
method calls on approved @Function-annotated methods are allowed.
```

Reported by a SaaS customer (Orsted, P0). Their roles have policies — created on older releases — whose rules use conditions like `!isOwner`, `noOwner || isOwner`, etc. Adding or deleting a rule re-validates every rule in the policy, so the legacy bare conditions block the whole operation.

## Root cause

`ExpressionValidator` was rewritten in #27987 from a regex denylist to an AST allowlist (`ALLOWED_NODE_CLASSES`, default-deny). SpEL parses `isOwner()` as a `MethodReference` (allowlisted) but parses the bare `isOwner` as a `PropertyOrFieldReference`, which was **not** on the allowlist — so the bare form is rejected.

The bare form is functionally identical to the parenthesised call: SpEL's read-only data binding resolves the property `isOwner` to the no-arg boolean getter `isOwner()`. It is also documented as valid in `RuleEvaluator`'s own `@Function` examples (`"!isOwner"`, `"!noOwner"`), so policies authored on older releases use it.

## Fix

Allow standalone `PropertyOrFieldReference` nodes, **gated on the same `ALLOWED_FUNCTIONS` allowlist** already used for method names (`ensureCallableNameAllowed`). This is generic — it covers every approved `@Function` in bare form (`isOwner`, `noOwner`, `isReviewer`, `matchTeam`, `hasDomain`, …), not just `isOwner`.

## Security — no regression from #27987

Compound references such as `System.exit(0)`, `Runtime.getRuntime().exec(...)`, `entity.getClass()` parse as `CompoundExpression` / `TypeReference` / `ConstructorReference` — none of which are allowlisted — so they remain blocked, and a bare disallowed name (`System`, `entity`) is rejected by the name gate. All existing negative tests still pass; the `!System.exit(0)` regression guard stays green.

## Tests

- **Unit** (`ExpressionValidatorTest`): bare approved references (`!isOwner`, `!noOwner`, `isReviewer`, `noOwner() || isOwner`, …) accepted; bare disallowed names (`System`, `entity`, `someObject`, `Runtime`) rejected. Verified these fail without the production change.
- **Integration** (`PolicyResourceIT`): create **and** update a policy with a bare-reference condition.

`ExpressionValidatorTest`: 34/34 pass. `RuleEvaluatorTest` (runtime evaluation): 21/21 pass. `mvn spotless:apply` clean.