### PR TITLE
Fixes #28949: Migrate db2 connector to BaseConnection

### DIFF
--- a/ingestion/src/metadata/ingestion/source/database/db2/connection.py
+++ b/ingestion/src/metadata/ingestion/source/database/db2/connection.py
@@ -15,8 +15,9 @@ Source connection handler
 
 import importlib
 import sys
+from abc import ABC
 from pathlib import Path
-from typing import Any, Dict, Optional  # noqa: UP035
+from typing import Any, Optional
 from urllib.parse import quote_plus
 
 from sqlalchemy.engine import Engine
@@ -25,7 +26,9 @@ from metadata.generated.schema.entity.automations.workflow import (
     Workflow as AutomationWorkflow,
 )
 from metadata.generated.schema.entity.services.connections.database.db2Connection import (
-    Db2Connection,
+    Db2Connection as Db2ConnectionConfig,
+)
+from metadata.generated.schema.entity.services.connections.database.db2Connection import (
     Db2Scheme,
 )
 from metadata.generated.schema.entity.services.connections.testConnectionResult import (
@@ -37,6 +40,8 @@ from metadata.ingestion.connections.builders import (
     get_connection_url_common,
     get_password_secret,
 )
+from metadata.ingestion.connections.connection import BaseConnection
+from metadata.ingestion.connections.strategies import ClientStrategy
 from metadata.ingestion.connections.test_connections import test_connection_db_common
 from metadata.ingestion.ometa.ometa_api import OpenMetadata
 from metadata.ingestion.source.database.db2.utils import (
@@ -50,119 +55,122 @@ from metadata.utils.ssl_manager import check_ssl_and_init
 logger = ingestion_logger()
 
 
-def _get_ibmi_connection_url(connection: Db2Connection) -> str:
-    """
-    Build connection URL for ibmi scheme.
-
-    sqlalchemy-ibmi validates URL options strictly and does NOT support:
-    - Port in the URL (host:port format) — causes validation error
-    - SSL parameters like SECURITY=SSL — SSL is negotiated via port (9471)
-
-    Port is passed separately via connect_args.
-    """
-    hostname = connection.hostPort.split(":")[0]
-
-    url = f"{connection.scheme.value}://"
-    if connection.username:
-        url += f"{quote_plus(connection.username)}"
-        password = get_password_secret(connection)
-        url += f":{quote_plus(password.get_secret_value())}"
-        url += "@"
-    url += hostname
-    if connection.database:
-        url += f"/{connection.database}"
-    return url
+class Db2Strategy(ClientStrategy[Db2ConnectionConfig, Engine], ABC):
+    """Builds the DB2 engine for one scheme."""
 
 
-def _get_ibmi_connection_args(connection: Db2Connection) -> Dict[str, Any]:  # noqa: UP006
-    """
-    Build connection args for ibmi scheme.
+class Db2StandardStrategy(Db2Strategy):
+    """db2+ibm_db scheme: standard URL with SSL negotiated via connection params."""
 
-    Port must be passed via connect_args since sqlalchemy-ibmi
-    rejects it in the URL.
-    """
-    args = get_connection_args_common(connection)
-    host_port = connection.hostPort
-    if ":" in host_port:
-        port_str = host_port.split(":")[1]
-        try:
-            args["port"] = int(port_str)
-        except ValueError:
-            raise ValueError(f"Invalid port in hostPort '{host_port}'. Expected format: 'hostname:port'")  # noqa: B904
-    return args
-
-
-def get_connection(connection: Db2Connection) -> Engine:
-    """
-    Create connection
-    """
-    # Install ibm_db with specific version
-    clidriver_version = connection.clidriverVersion
-
-    if clidriver_version:
-        clidriver_version = check_clidriver_version(clidriver_version)
-        if clidriver_version:
-            install_clidriver(clidriver_version.value)
-            # Invalidate cached clidriver module so the next import
-            # picks up the freshly installed path
-            sys.modules.pop("clidriver", None)
-
-    # prepare license
-    # pylint: disable=import-outside-toplevel
-    if connection.license and connection.licenseFileName:
-        import clidriver  # noqa: PLC0415
-
-        if clidriver_version:
-            importlib.reload(clidriver)
-
-        license_dir = Path(clidriver.__path__[0], "license")
-        license_dir.mkdir(parents=True, exist_ok=True)
-
-        with open(  # noqa: PTH123
-            license_dir / connection.licenseFileName,
-            "w",
-            encoding=UTF_8,
-        ) as file:
-            file.write(connection.license.encode(UTF_8).decode("unicode-escape"))
-
-    is_ibmi = connection.scheme == Db2Scheme.ibmi
-
-    # SSL setup only for db2+ibm_db scheme.
-    # ibmi scheme negotiates SSL via port (9471), not connection params.
-    if not is_ibmi:
+    def build(self) -> Engine:
+        connection = self._connection
         ssl_manager = check_ssl_and_init(connection)
         if ssl_manager:
             connection = ssl_manager.setup_ssl(connection)
-
-    if is_ibmi:
         return create_generic_db_connection(
             connection=connection,
-            get_connection_url_fn=_get_ibmi_connection_url,
-            get_connection_args_fn=_get_ibmi_connection_args,
+            get_connection_url_fn=get_connection_url_common,
+            get_connection_args_fn=get_connection_args_common,
         )
 
-    return create_generic_db_connection(
-        connection=connection,
-        get_connection_url_fn=get_connection_url_common,
-        get_connection_args_fn=get_connection_args_common,
-    )
+
+class Db2IbmiStrategy(Db2Strategy):
+    """ibmi scheme: sqlalchemy-ibmi rejects the port in the URL, so the host is
+    passed without it and the port goes through connect_args; SSL is negotiated
+    by the port (9471) rather than connection parameters."""
+
+    def build(self) -> Engine:
+        return create_generic_db_connection(
+            connection=self._connection,
+            get_connection_url_fn=self.get_connection_url,
+            get_connection_args_fn=self.get_connection_args,
+        )
+
+    @staticmethod
+    def get_connection_url(connection: Db2ConnectionConfig) -> str:
+        scheme = connection.scheme.value if connection.scheme else Db2Scheme.ibmi.value
+        hostname = connection.hostPort.split(":")[0]
+        url = f"{scheme}://"
+        if connection.username:
+            url += f"{quote_plus(connection.username)}"
+            password = get_password_secret(connection)
+            url += f":{quote_plus(password.get_secret_value())}"
+            url += "@"
+        url += hostname
+        if connection.database:
+            url += f"/{connection.database}"
+        return url
+
+    @staticmethod
+    def get_connection_args(connection: Db2ConnectionConfig) -> dict[str, Any]:
+        args = get_connection_args_common(connection)
+        host_port = connection.hostPort
+        if ":" in host_port:
+            port_str = host_port.split(":")[1]
+            try:
+                args["port"] = int(port_str)
+            except ValueError:
+                raise ValueError(  # noqa: B904
+                    f"Invalid port in hostPort '{host_port}'. Expected format: 'hostname:port'"
+                )
+        return args
 
 
-def test_connection(
-    metadata: OpenMetadata,
-    engine: Engine,
-    service_connection: Db2Connection,
-    automation_workflow: Optional[AutomationWorkflow] = None,  # noqa: UP045
-    timeout_seconds: Optional[int] = THREE_MIN,  # noqa: UP045
-) -> TestConnectionResult:
-    """
-    Test connection. This can be executed either as part
-    of a metadata workflow or during an Automation Workflow
-    """
-    return test_connection_db_common(
-        metadata=metadata,
-        engine=engine,
-        service_connection=service_connection,
-        automation_workflow=automation_workflow,
-        timeout_seconds=timeout_seconds,
-    )
+class Db2Connection(BaseConnection[Db2ConnectionConfig, Engine]):
+    def _get_client(self) -> Engine:
+        connection = self.service_connection
+        self._prepare_driver(connection)
+        match connection.scheme:
+            case Db2Scheme.ibmi:
+                strategy: Db2Strategy = Db2IbmiStrategy(connection)
+            case _:
+                strategy = Db2StandardStrategy(connection)
+        return strategy.build()
+
+    @staticmethod
+    def _prepare_driver(connection: Db2ConnectionConfig) -> None:
+        """Install the pinned clidriver (if requested) and stage the license file."""
+        clidriver_version = connection.clidriverVersion
+        if clidriver_version:
+            clidriver_version = check_clidriver_version(clidriver_version)
+            if clidriver_version:
+                install_clidriver(clidriver_version.value)
+                # Invalidate cached clidriver module so the next import
+                # picks up the freshly installed path
+                sys.modules.pop("clidriver", None)
+
+        if connection.license and connection.licenseFileName:
+            # pylint: disable=import-outside-toplevel
+            # clidriver is installed at runtime by install_clidriver above
+            import clidriver  # noqa: PLC0415 # pyright: ignore[reportMissingImports]
+
+            if clidriver_version:
+                importlib.reload(clidriver)
+
+            license_dir = Path(clidriver.__path__[0], "license")
+            license_dir.mkdir(parents=True, exist_ok=True)
+
+            with open(  # noqa: PTH123
+                license_dir / connection.licenseFileName,
+                "w",
+                encoding=UTF_8,
+            ) as file:
+                file.write(connection.license.encode(UTF_8).decode("unicode-escape"))
+
+    def test_connection(
+        self,
+        metadata: OpenMetadata,
+        automation_workflow: Optional[AutomationWorkflow] = None,  # noqa: UP045
+        timeout_seconds: Optional[int] = THREE_MIN,  # noqa: UP045
+    ) -> TestConnectionResult:
+        """
+        Test connection. This can be executed either as part
+        of a metadata workflow or during an Automation Workflow
+        """
+        return test_connection_db_common(
+            metadata=metadata,
+            engine=self.client,
+            service_connection=self.service_connection,
+            automation_workflow=automation_workflow,
+            timeout_seconds=timeout_seconds,
+        )

--- a/ingestion/src/metadata/ingestion/source/database/db2/service_spec.py
+++ b/ingestion/src/metadata/ingestion/source/database/db2/service_spec.py
@@ -1,3 +1,4 @@
+from metadata.ingestion.source.database.db2.connection import Db2Connection
 from metadata.ingestion.source.database.db2.lineage import Db2LineageSource
 from metadata.ingestion.source.database.db2.metadata import Db2Source
 from metadata.profiler.interface.sqlalchemy.db2.profiler_interface import (
@@ -9,4 +10,5 @@ ServiceSpec = DefaultDatabaseSpec(
     metadata_source_class=Db2Source,
     profiler_class=DB2ProfilerInterface,
     lineage_source_class=Db2LineageSource,
+    connection_class=Db2Connection,  # pyright: ignore[reportArgumentType]
 )

--- a/ingestion/tests/unit/source/database/db2/test_connection.py
+++ b/ingestion/tests/unit/source/database/db2/test_connection.py
@@ -1,0 +1,92 @@
+#  Copyright 2025 Collate
+#  Licensed under the Collate Community License, Version 1.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  https://github.com/open-metadata/OpenMetadata/blob/main/ingestion/LICENSE
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+"""Unit tests for DB2 connection handling."""
+
+from unittest.mock import patch
+
+import pytest
+
+from metadata.generated.schema.entity.services.connections.database.db2Connection import (
+    Db2Connection as Db2ConnectionConfig,
+)
+from metadata.generated.schema.entity.services.connections.database.db2Connection import (
+    Db2Scheme,
+)
+from metadata.ingestion.connections.connection import BaseConnection
+from metadata.ingestion.source.database.db2.connection import (
+    Db2Connection,
+    Db2IbmiStrategy,
+)
+
+CONNECTION_MODULE = "metadata.ingestion.source.database.db2.connection"
+
+
+def _ibmi_config() -> Db2ConnectionConfig:
+    return Db2ConnectionConfig(
+        scheme=Db2Scheme.ibmi,
+        username="openmetadata_user",
+        password="openmetadata_password",
+        hostPort="myhost:8471",
+        database="MYDB",
+    )
+
+
+def _db2_config() -> Db2ConnectionConfig:
+    return Db2ConnectionConfig(
+        scheme=Db2Scheme.db2_ibm_db,
+        username="openmetadata_user",
+        password="openmetadata_password",
+        hostPort="localhost:50000",
+        database="testdb",
+    )
+
+
+def test_db2_connection_is_base_connection():
+    assert issubclass(Db2Connection, BaseConnection)
+
+
+def test_ibmi_url_drops_the_port():
+    config = _ibmi_config()
+    assert (
+        Db2IbmiStrategy(config).get_connection_url(config)
+        == "ibmi://openmetadata_user:openmetadata_password@myhost/MYDB"
+    )
+
+
+def test_ibmi_args_pass_the_port_via_connect_args():
+    config = _ibmi_config()
+    assert Db2IbmiStrategy(config).get_connection_args(config)["port"] == 8471
+
+
+def test_ibmi_args_reject_a_non_numeric_port():
+    config = _ibmi_config()
+    config.hostPort = "myhost:not-a-port"
+    with pytest.raises(ValueError, match="Invalid port"):
+        Db2IbmiStrategy(config).get_connection_args(config)
+
+
+def test_get_client_dispatches_ibmi_scheme_to_ibmi_strategy():
+    config = _ibmi_config()
+    with patch(f"{CONNECTION_MODULE}.create_generic_db_connection") as mock_connection:
+        _ = Db2Connection(config).client
+    url_fn = mock_connection.call_args.kwargs["get_connection_url_fn"]
+    assert url_fn.__name__ == "get_connection_url"
+    assert url_fn(config) == "ibmi://openmetadata_user:openmetadata_password@myhost/MYDB"
+
+
+def test_get_client_dispatches_db2_scheme_to_standard_strategy():
+    config = _db2_config()
+    with (
+        patch(f"{CONNECTION_MODULE}.create_generic_db_connection") as mock_connection,
+        patch(f"{CONNECTION_MODULE}.check_ssl_and_init", return_value=None),
+    ):
+        _ = Db2Connection(config).client
+    assert mock_connection.call_args.kwargs["get_connection_url_fn"].__name__ == "get_connection_url_common"


### PR DESCRIPTION
Fixes #28949

## What
Migrates the **db2** connector onto `BaseConnection` (foundations in #28854).

## Why a strategy
db2 has two schemes that build the engine differently:
- **`db2+ibm_db`** — standard URL, SSL negotiated via connection params (`check_ssl_and_init`).
- **`ibmi`** — `sqlalchemy-ibmi` rejects the port in the URL, so the host is passed without it and the port goes through `connect_args`; SSL is negotiated by the port (9471) instead.

## How
Each scheme is a `ClientStrategy` (`Db2StandardStrategy` / `Db2IbmiStrategy`) selected via `match/case` in `_get_client`. The shared preamble — pinned `clidriver` install + license-file staging — runs **once** before dispatch. Behavior is preserved verbatim (ibmi port handling, db2-only SSL).

## Tests
Colocated unit tests cover both schemes' URL/args and the dispatch; ruff + basedpyright (no new errors) + the existing 20-test db2 topology suite (unchanged — it already patches the generic `common_db_source.get_connection`). The shared `test_db2_url`/`test_db2_conn_arguments` use `get_connection_url_common`/`get_connection_args_common` and are unaffected.

A live db2 e2e isn't feasible locally (IBM Db2 server is amd64-only/licensed/multi-GB + needs the runtime `clidriver`).