### PR TITLE
fix(mcp): echo OAuth state without double-encoding in redirect URI

### DIFF
--- a/openmetadata-mcp/src/main/java/org/openmetadata/mcp/server/auth/util/UriUtils.java
+++ b/openmetadata-mcp/src/main/java/org/openmetadata/mcp/server/auth/util/UriUtils.java
@@ -1,7 +1,6 @@
 package org.openmetadata.mcp.server.auth.util;
 
 import java.net.URI;
-import java.net.URISyntaxException;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.util.Map;
@@ -20,46 +19,45 @@ public class UriUtils {
    * @return The constructed redirect URI.
    */
   public static String constructRedirectUri(String redirectUriBase, Map<String, String> params) {
-    try {
-      URI uri = new URI(redirectUriBase);
+    URI uri = URI.create(redirectUriBase);
 
-      // Get existing query
-      String query = uri.getQuery();
-      StringBuilder queryBuilder = new StringBuilder();
-
-      // Append existing query parameters if any
-      if (query != null && !query.isEmpty()) {
-        queryBuilder.append(query);
-        if (!params.isEmpty()) {
-          queryBuilder.append("&");
-        }
-      }
-
-      // Append new parameters
-      if (!params.isEmpty()) {
-        String newParams =
-            params.entrySet().stream()
-                .filter(entry -> entry.getValue() != null)
-                .map(
-                    entry ->
-                        URLEncoder.encode(entry.getKey(), StandardCharsets.UTF_8)
-                            + "="
-                            + URLEncoder.encode(entry.getValue(), StandardCharsets.UTF_8))
-                .collect(Collectors.joining("&"));
-        queryBuilder.append(newParams);
-      }
-
-      // Create new URI with updated query
-      return new URI(
-              uri.getScheme(),
-              uri.getAuthority(),
-              uri.getPath(),
-              queryBuilder.toString(),
-              uri.getFragment())
-          .toString();
-    } catch (URISyntaxException e) {
-      throw new IllegalArgumentException("Invalid redirect URI: " + redirectUriBase, e);
+    StringBuilder queryBuilder = new StringBuilder();
+    String existingQuery = uri.getRawQuery();
+    if (existingQuery != null && !existingQuery.isEmpty()) {
+      queryBuilder.append(existingQuery);
     }
+
+    String newParams =
+        params.entrySet().stream()
+            .filter(entry -> entry.getValue() != null)
+            .map(
+                entry ->
+                    URLEncoder.encode(entry.getKey(), StandardCharsets.UTF_8)
+                        + "="
+                        + URLEncoder.encode(entry.getValue(), StandardCharsets.UTF_8))
+            .collect(Collectors.joining("&"));
+    if (!newParams.isEmpty()) {
+      if (queryBuilder.length() > 0) {
+        queryBuilder.append("&");
+      }
+      queryBuilder.append(newParams);
+    }
+
+    // Reassemble the URI by string concatenation. The query is already percent-encoded above;
+    // passing it through the multi-argument URI constructor would re-encode the '%' characters
+    // (e.g. a base64 state "a==" -> "a%3D%3D" -> "a%253D%253D"), corrupting opaque values such as
+    // the OAuth state and breaking clients that compare it byte-for-byte (e.g. VS Code loopback).
+    String base = redirectUriBase;
+    int fragmentIdx = base.indexOf('#');
+    if (fragmentIdx >= 0) {
+      base = base.substring(0, fragmentIdx);
+    }
+    int queryIdx = base.indexOf('?');
+    if (queryIdx >= 0) {
+      base = base.substring(0, queryIdx);
+    }
+    String fragment = uri.getRawFragment() != null ? "#" + uri.getRawFragment() : "";
+    return queryBuilder.length() > 0 ? base + "?" + queryBuilder + fragment : base + fragment;
   }
 
   /**

--- a/openmetadata-mcp/src/test/java/org/openmetadata/mcp/server/auth/util/UriUtilsTest.java
+++ b/openmetadata-mcp/src/test/java/org/openmetadata/mcp/server/auth/util/UriUtilsTest.java
@@ -4,6 +4,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.net.URI;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
@@ -42,6 +44,26 @@ class UriUtilsTest {
 
     assertThat(result).doesNotContain("https://other.com?a=1&b=2");
     assertThat(result).contains("redirect=");
+  }
+
+  @Test
+  void testConstructRedirectUri_opaqueStateRoundTripsWithSingleEncoding() {
+    // Regression: a base64 state with '+' and '=' padding must survive byte-for-byte after a
+    // single URL-decode. Previously the encoded query was re-quoted by the multi-arg URI
+    // constructor ("a==" -> "a%3D%3D" -> "a%253D%253D"), breaking clients that compare state
+    // exactly (e.g. VS Code's loopback redirect -> "State does not match").
+    String state = "n+eBY2DPiNEk3xEe7rqmtg==";
+    Map<String, String> params = new LinkedHashMap<>();
+    params.put("code", "abc123");
+    params.put("state", state);
+
+    String result = UriUtils.constructRedirectUri("http://127.0.0.1:33418/", params);
+
+    String returnedState =
+        URLDecoder.decode(
+            result.replaceAll(".*[?&]state=", "").replaceAll("&.*", ""), StandardCharsets.UTF_8);
+    assertThat(returnedState).isEqualTo(state);
+    assertThat(result).doesNotContain("%25");
   }
 
   @Test


### PR DESCRIPTION
Fixes #28951

The MCP OAuth redirect double-encoded the `state` parameter, so clients that compare it byte-for-byte (e.g. VS Code's loopback flow) failed with **"State does not match"** on login. This builds the redirect URL so `state` round-trips unchanged.

Full root-cause analysis, affected/unaffected clients, and repro are in #28951.
