### PR TITLE
1.12.11 cherry pick

### DIFF
--- a/ingestion/src/metadata/ingestion/source/database/athena/client.py
+++ b/ingestion/src/metadata/ingestion/source/database/athena/client.py
@@ -36,14 +36,18 @@ class AthenaLakeFormationClient:
         connection: AthenaConnection,
     ):
         self.lake_formation_client = get_lake_formation_client(connection=connection)
+        self.catalog_id = connection.catalogId
 
     def get_database_tags(self, name: str) -> Optional[List[TagItem]]:
         """
         Method to call the API and get the database tags
         """
         try:
+            resource = {"Database": {"Name": name}}
+            if self.catalog_id:
+                resource["Database"]["CatalogId"] = self.catalog_id
             response = self.lake_formation_client.get_resource_lf_tags(
-                Resource={"Database": {"Name": name}}
+                Resource=resource
             )
             lf_tags = LFTags(**response)
             return lf_tags.LFTagOnDatabase
@@ -59,16 +63,21 @@ class AthenaLakeFormationClient:
         Method to call the API and get the table and column tags
         """
         try:
+            table_resource = {
+                "DatabaseName": schema_name,
+                "Name": table_name,
+            }
+            table_with_columns_resource = {
+                "DatabaseName": schema_name,
+                "Name": table_name,
+            }
+            if self.catalog_id:
+                table_resource["CatalogId"] = self.catalog_id
+                table_with_columns_resource["CatalogId"] = self.catalog_id
             response = self.lake_formation_client.get_resource_lf_tags(
                 Resource={
-                    "Table": {
-                        "DatabaseName": schema_name,
-                        "Name": table_name,
-                    },
-                    "TableWithColumns": {
-                        "DatabaseName": schema_name,
-                        "Name": table_name,
-                    },
+                    "Table": table_resource,
+                    "TableWithColumns": table_with_columns_resource,
                 }
             )
             return LFTags(**response)

--- a/ingestion/src/metadata/ingestion/source/database/athena/connection.py
+++ b/ingestion/src/metadata/ingestion/source/database/athena/connection.py
@@ -71,6 +71,8 @@ def get_connection_url(connection: AthenaConnection) -> str:
         url += f"&work_group={connection.workgroup}"
     if aws_session_token:
         url += f"&aws_session_token={quote_plus(aws_session_token)}"
+    if connection.catalogId:
+        url += f"&catalog_name={quote_plus(connection.catalogId)}"
 
     return url
 

--- a/ingestion/src/metadata/ingestion/source/database/athena/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/database/athena/metadata.py
@@ -145,7 +145,10 @@ class AthenaSource(ExternalTableLineageMixin, CommonDbSourceService):
                 self.service_connection.awsConfig
             ).get_glue_client()
             paginator = self.glue_client.get_paginator("get_databases")
-            for page in paginator.paginate():
+            paginate_params = {}
+            if self.service_connection.catalogId:
+                paginate_params["CatalogId"] = self.service_connection.catalogId
+            for page in paginator.paginate(**paginate_params):
                 database_page = DatabasePage(**page)
                 for database in database_page.DatabaseList or []:
                     if database.Description:
@@ -207,6 +210,7 @@ class AthenaSource(ExternalTableLineageMixin, CommonDbSourceService):
             schema=schema_name,
             only_partition_columns=True,
             glue_client=self.glue_client,
+            catalog_id=self.service_connection.catalogId,
         )
         if columns:
             partition_details = TablePartition(
@@ -366,6 +370,7 @@ class AthenaSource(ExternalTableLineageMixin, CommonDbSourceService):
             table_type=table_type,
             db_name=db_name,
             glue_client=self.glue_client,
+            catalog_id=self.service_connection.catalogId,
         )
 
     def get_table_extensions(self, table_name: str, table_type: TableType | None = None) -> dict[str, str] | None:

--- a/ingestion/src/metadata/ingestion/source/database/athena/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/database/athena/metadata.py
@@ -175,7 +175,10 @@ class AthenaSource(ExternalTableLineageMixin, CommonDbSourceService):
             try:
                 results = []
                 paginator = self.glue_client.get_paginator("get_tables")
-                for page in paginator.paginate(DatabaseName=schema_name):
+                paginate_params = {"DatabaseName": schema_name}
+                if self.service_connection.catalogId:
+                    paginate_params["CatalogId"] = self.service_connection.catalogId
+                for page in paginator.paginate(**paginate_params):
                     for table in page.get("TableList", []):
                         params = table.get("Parameters", {})
                         table_type = (

--- a/ingestion/src/metadata/ingestion/source/database/athena/utils.py
+++ b/ingestion/src/metadata/ingestion/source/database/athena/utils.py
@@ -157,11 +157,13 @@ def get_columns(self, connection, table_name, schema=None, **kw):
             raw_connection = self._raw_connection(connection)
             schema = schema if schema else raw_connection.schema_name
 
-            # Use the provided Glue client or create one with default credentials
             glue_client = kw.get("glue_client")
+            catalog_id = kw.get("catalog_id")
 
-            # Get full table metadata from Glue
-            response = glue_client.get_table(DatabaseName=schema, Name=table_name)
+            get_table_params = {"DatabaseName": schema, "Name": table_name}
+            if catalog_id:
+                get_table_params["CatalogId"] = catalog_id
+            response = glue_client.get_table(**get_table_params)
 
             table_info = response["Table"]
 

--- a/ingestion/tests/unit/topology/database/test_athena.py
+++ b/ingestion/tests/unit/topology/database/test_athena.py
@@ -14,8 +14,9 @@ Test athena source
 
 import hashlib
 import unittest
+from copy import deepcopy
 from datetime import datetime
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, PropertyMock, patch
 from uuid import UUID
 
 import pytest
@@ -278,6 +279,14 @@ mock_athena_config = {
         }
     },
 }
+
+S3_TABLES_CATALOG_ID = "s3tablescatalog/my-bucket"
+
+
+def _athena_config_with_catalog_id(catalog_id):
+    config = deepcopy(mock_athena_config)
+    config["source"]["serviceConnection"]["config"]["catalogId"] = catalog_id
+    return config
 
 
 class TestAthenaService(unittest.TestCase):
@@ -757,6 +766,83 @@ class TestQueryTableNamesAndTypesIcebergConstant:
         )
 
         assert ICEBERG_TABLE_TYPE == "ICEBERG"
+
+
+def _make_source_with_glue(config, table_list):
+    """Build an AthenaSource from config and attach a Glue client whose
+    get_tables paginator yields a single page with the given TableList."""
+    workflow_config = OpenMetadataWorkflowConfig.model_validate(config)
+    with patch(
+        "metadata.ingestion.source.database.database_service.DatabaseServiceSource.test_connection",
+        return_value=False,
+    ):
+        source = AthenaSource.create(
+            config["source"],
+            workflow_config.workflowConfig.openMetadataServerConfig,
+        )
+    mock_paginator = MagicMock()
+    mock_paginator.paginate.return_value = [{"TableList": table_list}]
+    mock_glue_client = MagicMock()
+    mock_glue_client.get_paginator.return_value = mock_paginator
+    source.glue_client = mock_glue_client
+    return source, mock_paginator
+
+
+class TestQueryTableNamesAndTypesCatalogId:
+    """get_tables enumeration must target the configured catalogId.
+
+    Regression coverage for S3 Tables / cross-account Glue catalogs, where
+    omitting CatalogId queries the default catalog and returns 0 tables.
+    """
+
+    def test_catalog_id_passed_to_paginate_when_configured(self):
+        config = _athena_config_with_catalog_id(S3_TABLES_CATALOG_ID)
+        source, mock_paginator = _make_source_with_glue(config, [{"Name": MOCK_TABLE_NAME, "Parameters": {}}])
+
+        result = source.query_table_names_and_types(MOCK_DATABASE_SCHEMA.name.root)
+
+        assert result == EXPECTED_QUERY_TABLE_NAMES_TYPES
+        mock_paginator.paginate.assert_called_once_with(
+            DatabaseName=MOCK_DATABASE_SCHEMA.name.root,
+            CatalogId=S3_TABLES_CATALOG_ID,
+        )
+
+    def test_catalog_id_omitted_when_not_configured(self):
+        source, mock_paginator = _make_source_with_glue(
+            deepcopy(mock_athena_config), [{"Name": MOCK_TABLE_NAME, "Parameters": {}}]
+        )
+
+        result = source.query_table_names_and_types(MOCK_DATABASE_SCHEMA.name.root)
+
+        assert result == EXPECTED_QUERY_TABLE_NAMES_TYPES
+        mock_paginator.paginate.assert_called_once_with(DatabaseName=MOCK_DATABASE_SCHEMA.name.root)
+        assert "CatalogId" not in mock_paginator.paginate.call_args.kwargs
+
+    def test_empty_table_list_returns_empty_without_inspector_fallback(self):
+        """A successful Glue call with an empty TableList is returned as-is;
+        the inspector fallback only fires on exception or missing Glue client."""
+        config = _athena_config_with_catalog_id(S3_TABLES_CATALOG_ID)
+        source, _ = _make_source_with_glue(config, [])
+        mock_inspector = MagicMock()
+
+        with patch.object(type(source), "inspector", new_callable=PropertyMock, return_value=mock_inspector):
+            result = source.query_table_names_and_types(MOCK_DATABASE_SCHEMA.name.root)
+
+        assert result == []
+        mock_inspector.get_table_names.assert_not_called()
+
+    def test_falls_back_to_inspector_when_glue_call_raises(self):
+        config = _athena_config_with_catalog_id(S3_TABLES_CATALOG_ID)
+        source, mock_paginator = _make_source_with_glue(config, [])
+        mock_paginator.paginate.side_effect = Exception("AccessDenied")
+        mock_inspector = MagicMock()
+        mock_inspector.get_table_names.return_value = [MOCK_TABLE_NAME]
+
+        with patch.object(type(source), "inspector", new_callable=PropertyMock, return_value=mock_inspector):
+            result = source.query_table_names_and_types(MOCK_DATABASE_SCHEMA.name.root)
+
+        assert result == EXPECTED_QUERY_TABLE_NAMES_TYPES
+        mock_inspector.get_table_names.assert_called_once_with(MOCK_DATABASE_SCHEMA.name.root)
 
 
 class TestIncludeCustomPropertiesSchema:

--- a/openmetadata-spec/src/main/resources/json/schema/entity/services/connections/database/athenaConnection.json
+++ b/openmetadata-spec/src/main/resources/json/schema/entity/services/connections/database/athenaConnection.json
@@ -48,6 +48,11 @@
       "description": "Athena workgroup.",
       "type": "string"
     },
+    "catalogId": {
+      "title": "Catalog ID",
+      "description": "Catalog ID for Athena. For S3 Tables, use the format 's3tablescatalog/<bucket-name>'. For cross-account Glue catalogs, use the AWS account ID. If not provided, defaults to the caller's AWS account.",
+      "type": "string"
+    },
     "databaseName": {
       "title": "Database Name",
       "description": "Optional name to give to the database in OpenMetadata. If left blank, we will use default as the database name.",

--- a/openmetadata-ui/src/main/resources/ui/public/locales/en-US/Database/Athena.md
+++ b/openmetadata-ui/src/main/resources/ui/public/locales/en-US/Database/Athena.md
@@ -172,6 +172,18 @@ You can find more information about <a href="https://docs.aws.amazon.com/athena/
 $$
 
 $$section
+### Catalog ID $(id="catalogId")
+
+The catalog ID for Athena. This is required when ingesting metadata from:
+- **S3 Tables**: Use the format `s3tablescatalog/<bucket-name>` (e.g., `s3tablescatalog/my-table-bucket`)
+- **Cross-account catalogs**: Use the AWS account ID of the account that owns the Glue Data Catalog
+
+If not provided, defaults to the caller's AWS account.
+
+Find more information about <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-tables.html" target="_blank">S3 Tables</a> and <a href="https://docs.aws.amazon.com/glue/latest/dg/cross-account-access.html" target="_blank">Cross-account access in AWS Glue</a>.
+$$
+
+$$section
 ### Database Name $(id="databaseName")
 
 In OpenMetadata, the Database Service hierarchy works as follows:

--- a/openmetadata-ui/src/main/resources/ui/src/generated/api/automations/createWorkflow.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/api/automations/createWorkflow.ts
@@ -767,6 +767,12 @@ export interface ConfigObject {
     usageLocation?: string;
     awsConfig?:     AWSCredentials;
     /**
+     * Catalog ID for Athena. For S3 Tables, use the format 's3tablescatalog/<bucket-name>'. For
+     * cross-account Glue catalogs, use the AWS account ID. If not provided, defaults to the
+     * caller's AWS account.
+     */
+    catalogId?: string;
+    /**
      * Optional name to give to the database in OpenMetadata. If left blank, we will use default
      * as the database name.
      *

--- a/openmetadata-ui/src/main/resources/ui/src/generated/api/services/createDatabaseService.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/api/services/createDatabaseService.ts
@@ -340,6 +340,12 @@ export interface ConfigObject {
     usageLocation?: string;
     awsConfig?:     AWSCredentials;
     /**
+     * Catalog ID for Athena. For S3 Tables, use the format 's3tablescatalog/<bucket-name>'. For
+     * cross-account Glue catalogs, use the AWS account ID. If not provided, defaults to the
+     * caller's AWS account.
+     */
+    catalogId?: string;
+    /**
      * Optional name to give to the database in OpenMetadata. If left blank, we will use default
      * as the database name.
      *

--- a/openmetadata-ui/src/main/resources/ui/src/generated/api/services/ingestionPipelines/createIngestionPipeline.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/api/services/ingestionPipelines/createIngestionPipeline.ts
@@ -3810,6 +3810,12 @@ export interface ConfigObject {
      */
     usageLocation?: string;
     /**
+     * Catalog ID for Athena. For S3 Tables, use the format 's3tablescatalog/<bucket-name>'. For
+     * cross-account Glue catalogs, use the AWS account ID. If not provided, defaults to the
+     * caller's AWS account.
+     */
+    catalogId?: string;
+    /**
      * Optional name to give to the database in OpenMetadata. If left blank, we will use default
      * as the database name.
      *

--- a/openmetadata-ui/src/main/resources/ui/src/generated/entity/automations/testServiceConnection.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/entity/automations/testServiceConnection.ts
@@ -649,6 +649,12 @@ export interface ConfigObject {
     usageLocation?: string;
     awsConfig?:     AWSCredentials;
     /**
+     * Catalog ID for Athena. For S3 Tables, use the format 's3tablescatalog/<bucket-name>'. For
+     * cross-account Glue catalogs, use the AWS account ID. If not provided, defaults to the
+     * caller's AWS account.
+     */
+    catalogId?: string;
+    /**
      * Optional name to give to the database in OpenMetadata. If left blank, we will use default
      * as the database name.
      *

--- a/openmetadata-ui/src/main/resources/ui/src/generated/entity/automations/workflow.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/entity/automations/workflow.ts
@@ -1297,6 +1297,12 @@ export interface ConfigObject {
     usageLocation?: string;
     awsConfig?:     AWSCredentials;
     /**
+     * Catalog ID for Athena. For S3 Tables, use the format 's3tablescatalog/<bucket-name>'. For
+     * cross-account Glue catalogs, use the AWS account ID. If not provided, defaults to the
+     * caller's AWS account.
+     */
+    catalogId?: string;
+    /**
      * Optional name to give to the database in OpenMetadata. If left blank, we will use default
      * as the database name.
      *

--- a/openmetadata-ui/src/main/resources/ui/src/generated/entity/services/connections/database/athenaConnection.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/entity/services/connections/database/athenaConnection.ts
@@ -14,7 +14,13 @@
  * AWS Athena Connection Config
  */
 export interface AthenaConnection {
-    awsConfig:            AWSCredentials;
+    awsConfig: AWSCredentials;
+    /**
+     * Catalog ID for Athena. For S3 Tables, use the format 's3tablescatalog/<bucket-name>'. For
+     * cross-account Glue catalogs, use the AWS account ID. If not provided, defaults to the
+     * caller's AWS account.
+     */
+    catalogId?:           string;
     connectionArguments?: { [key: string]: any };
     connectionOptions?:   { [key: string]: string };
     /**

--- a/openmetadata-ui/src/main/resources/ui/src/generated/entity/services/connections/serviceConnection.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/entity/services/connections/serviceConnection.ts
@@ -1134,6 +1134,12 @@ export interface ConfigObject {
      */
     usageLocation?: string;
     /**
+     * Catalog ID for Athena. For S3 Tables, use the format 's3tablescatalog/<bucket-name>'. For
+     * cross-account Glue catalogs, use the AWS account ID. If not provided, defaults to the
+     * caller's AWS account.
+     */
+    catalogId?: string;
+    /**
      * Optional name to give to the database in OpenMetadata. If left blank, we will use default
      * as the database name.
      *

--- a/openmetadata-ui/src/main/resources/ui/src/generated/entity/services/databaseService.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/entity/services/databaseService.ts
@@ -467,6 +467,12 @@ export interface ConfigObject {
     usageLocation?: string;
     awsConfig?:     AWSCredentials;
     /**
+     * Catalog ID for Athena. For S3 Tables, use the format 's3tablescatalog/<bucket-name>'. For
+     * cross-account Glue catalogs, use the AWS account ID. If not provided, defaults to the
+     * caller's AWS account.
+     */
+    catalogId?: string;
+    /**
      * Optional name to give to the database in OpenMetadata. If left blank, we will use default
      * as the database name.
      *

--- a/openmetadata-ui/src/main/resources/ui/src/generated/entity/services/ingestionPipelines/ingestionPipeline.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/entity/services/ingestionPipelines/ingestionPipeline.ts
@@ -4357,6 +4357,12 @@ export interface ConfigObject {
      */
     usageLocation?: string;
     /**
+     * Catalog ID for Athena. For S3 Tables, use the format 's3tablescatalog/<bucket-name>'. For
+     * cross-account Glue catalogs, use the AWS account ID. If not provided, defaults to the
+     * caller's AWS account.
+     */
+    catalogId?: string;
+    /**
      * Optional name to give to the database in OpenMetadata. If left blank, we will use default
      * as the database name.
      *

--- a/openmetadata-ui/src/main/resources/ui/src/generated/metadataIngestion/testSuitePipeline.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/metadataIngestion/testSuitePipeline.ts
@@ -1178,6 +1178,12 @@ export interface ConfigObject {
      */
     usageLocation?: string;
     /**
+     * Catalog ID for Athena. For S3 Tables, use the format 's3tablescatalog/<bucket-name>'. For
+     * cross-account Glue catalogs, use the AWS account ID. If not provided, defaults to the
+     * caller's AWS account.
+     */
+    catalogId?: string;
+    /**
      * Optional name to give to the database in OpenMetadata. If left blank, we will use default
      * as the database name.
      *

--- a/openmetadata-ui/src/main/resources/ui/src/generated/metadataIngestion/workflow.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/metadataIngestion/workflow.ts
@@ -1223,6 +1223,12 @@ export interface ConfigObject {
      */
     usageLocation?: string;
     /**
+     * Catalog ID for Athena. For S3 Tables, use the format 's3tablescatalog/<bucket-name>'. For
+     * cross-account Glue catalogs, use the AWS account ID. If not provided, defaults to the
+     * caller's AWS account.
+     */
+    catalogId?: string;
+    /**
      * Optional name to give to the database in OpenMetadata. If left blank, we will use default
      * as the database name.
      *


### PR DESCRIPTION
cherry-picking 2 commits to `1.12.11`
1) https://github.com/open-metadata/OpenMetadata/commit/67b01d3
2) https://github.com/open-metadata/OpenMetadata/commit/2abfd6dec9cc8dceb7010630ae86f11203938526

----
## Summary by Gitar

- **Athena Connection enhancements:**
  - Added `catalogId` support to `AthenaConnection` schema and connection string for S3 Tables and cross-account Glue catalogs.
  - Updated `AthenaSource` to inject `catalogId` into Glue API calls (`get_databases`, `get_tables`, `get_table`) and Lake Formation resource lookups.
- **Testing & Documentation:**
  - Added comprehensive regression tests for `catalogId` usage in table enumeration and Glue/Inspector fallbacks.
  - Documented `catalogId` configuration in Athena connector UI locale files.

<sub>This will update automatically on new commits.</sub>