### PR TITLE
Fixes #28970: Migrate mongodb connector to BaseConnection (first non-Engine connector)

### DIFF
--- a/ingestion/src/metadata/ingestion/source/database/mongodb/connection.py
+++ b/ingestion/src/metadata/ingestion/source/database/mongodb/connection.py
@@ -23,72 +23,72 @@ from metadata.generated.schema.entity.automations.workflow import (
     Workflow as AutomationWorkflow,
 )
 from metadata.generated.schema.entity.services.connections.database.mongoDBConnection import (
-    MongoDBConnection,
+    MongoDBConnection as MongoDBConnectionConfig,
 )
 from metadata.generated.schema.entity.services.connections.testConnectionResult import (
     TestConnectionResult,
 )
 from metadata.ingestion.connections.builders import get_connection_url_common
+from metadata.ingestion.connections.connection import BaseConnection
 from metadata.ingestion.connections.test_connections import test_connection_steps
 from metadata.ingestion.ometa.ometa_api import OpenMetadata
 from metadata.utils.constants import THREE_MIN
 
 
-def get_connection(connection: MongoDBConnection):
-    """
-    Create connection
-    """
-    mongo_url = get_connection_url_common(connection)
-    args = {}
+class MongoDBConnection(BaseConnection[MongoDBConnectionConfig, MongoClient]):
+    def _get_client(self) -> MongoClient:
+        connection = self.service_connection
+        mongo_url = get_connection_url_common(connection)
+        args = {}
 
-    # Check for extended timeout configuration in connectionArguments
-    # serverSelectionTimeoutMS, connectTimeoutMS, socketTimeoutMS
-    if connection.connectionOptions and connection.connectionOptions.root:
-        args = connection.connectionOptions.root
+        # Extended timeout configuration in connectionOptions:
+        # serverSelectionTimeoutMS, connectTimeoutMS, socketTimeoutMS
+        if connection.connectionOptions and connection.connectionOptions.root:
+            args = connection.connectionOptions.root
 
-    return MongoClient(mongo_url, **args)
+        return MongoClient(mongo_url, **args)  # pyright: ignore[reportArgumentType]
 
+    def test_connection(
+        self,
+        metadata: OpenMetadata,
+        automation_workflow: Optional[AutomationWorkflow] = None,  # noqa: UP045
+        timeout_seconds: Optional[int] = THREE_MIN,  # noqa: UP045
+    ) -> TestConnectionResult:
+        """
+        Test connection. This can be executed either as part
+        of a metadata workflow or during an Automation Workflow
+        """
+        client = self.client
+        service_connection = self.service_connection
 
-def test_connection(
-    metadata: OpenMetadata,
-    client: MongoClient,
-    service_connection: MongoDBConnection,
-    automation_workflow: Optional[AutomationWorkflow] = None,  # noqa: UP045
-    timeout_seconds: Optional[int] = THREE_MIN,  # noqa: UP045
-) -> TestConnectionResult:
-    """
-    Test connection. This can be executed either as part
-    of a metadata workflow or during an Automation Workflow
-    """
+        class SchemaHolder(BaseModel):
+            database: Optional[str] = None  # noqa: UP045
 
-    class SchemaHolder(BaseModel):
-        database: Optional[str] = None  # noqa: UP045
+        holder = SchemaHolder()
 
-    holder = SchemaHolder()
+        def test_get_databases(client_: MongoClient, holder_: SchemaHolder, database_name: Optional[str] = None):  # noqa: UP045
+            # If database name is provided, use it directly instead of listing all databases
+            if database_name:
+                holder_.database = database_name
+            else:
+                for database in client_.list_database_names():
+                    holder_.database = database
+                    break
 
-    def test_get_databases(client_: MongoClient, holder_: SchemaHolder, database_name: Optional[str] = None):  # noqa: UP045
-        # If database name is provided, use it directly instead of listing all databases
-        if database_name:
-            holder_.database = database_name
-        else:
-            for database in client_.list_database_names():
-                holder_.database = database
-                break
+        def test_get_collections(client_: MongoClient, holder_: SchemaHolder):
+            database = client_.get_database(holder_.database)
+            database.list_collection_names()
 
-    def test_get_collections(client_: MongoClient, holder_: SchemaHolder):
-        database = client_.get_database(holder_.database)
-        database.list_collection_names()
+        test_fn = {
+            "CheckAccess": client.server_info,
+            "GetDatabases": partial(test_get_databases, client, holder, service_connection.databaseSchema),
+            "GetCollections": partial(test_get_collections, client, holder),
+        }
 
-    test_fn = {
-        "CheckAccess": client.server_info,
-        "GetDatabases": partial(test_get_databases, client, holder, service_connection.databaseSchema),
-        "GetCollections": partial(test_get_collections, client, holder),
-    }
-
-    return test_connection_steps(
-        metadata=metadata,
-        test_fn=test_fn,
-        service_type=service_connection.type.value,
-        automation_workflow=automation_workflow,
-        timeout_seconds=timeout_seconds,
-    )
+        return test_connection_steps(
+            metadata=metadata,
+            test_fn=test_fn,
+            service_type=service_connection.type.value,  # pyright: ignore[reportOptionalMemberAccess]
+            automation_workflow=automation_workflow,
+            timeout_seconds=timeout_seconds,
+        )

--- a/ingestion/src/metadata/ingestion/source/database/mongodb/connection.py
+++ b/ingestion/src/metadata/ingestion/source/database/mongodb/connection.py
@@ -46,7 +46,9 @@ class MongoDBConnection(BaseConnection[MongoDBConnectionConfig, MongoClient]):
         if connection.connectionOptions and connection.connectionOptions.root:
             args = connection.connectionOptions.root
 
-        return MongoClient(mongo_url, **args)  # pyright: ignore[reportArgumentType]
+        client = MongoClient(mongo_url, **args)  # pyright: ignore[reportArgumentType]
+        self._on_close(client.close)
+        return client
 
     def test_connection(
         self,

--- a/ingestion/src/metadata/ingestion/source/database/mongodb/service_spec.py
+++ b/ingestion/src/metadata/ingestion/source/database/mongodb/service_spec.py
@@ -1,3 +1,4 @@
+from metadata.ingestion.source.database.mongodb.connection import MongoDBConnection
 from metadata.ingestion.source.database.mongodb.metadata import MongodbSource
 from metadata.profiler.interface.nosql.profiler_interface import NoSQLProfilerInterface
 from metadata.sampler.nosql.sampler import NoSQLSampler
@@ -7,4 +8,5 @@ ServiceSpec = DefaultDatabaseSpec(
     metadata_source_class=MongodbSource,
     profiler_class=NoSQLProfilerInterface,
     sampler_class=NoSQLSampler,
+    connection_class=MongoDBConnection,  # pyright: ignore[reportArgumentType]
 )

--- a/ingestion/tests/unit/source/database/mongodb/test_connection.py
+++ b/ingestion/tests/unit/source/database/mongodb/test_connection.py
@@ -1,0 +1,60 @@
+#  Copyright 2025 Collate
+#  Licensed under the Collate Community License, Version 1.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  https://github.com/open-metadata/OpenMetadata/blob/main/ingestion/LICENSE
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+"""Unit tests for the MongoDB BaseConnection wiring.
+
+MongoDB is the first non-Engine connector: its client is a ``pymongo.MongoClient``
+rather than a SQLAlchemy ``Engine``, so ``BaseConnection``'s client type is
+``MongoClient`` and ``test_connection`` drives pymongo calls directly.
+"""
+
+from unittest.mock import patch
+
+from metadata.generated.schema.entity.services.connections.database.mongoDBConnection import (
+    MongoDBConnection as MongoDBConnectionConfig,
+)
+from metadata.generated.schema.entity.services.connections.database.mongoDBConnection import (
+    MongoDBScheme,
+)
+from metadata.ingestion.connections.connection import BaseConnection
+from metadata.ingestion.source.database.mongodb.connection import MongoDBConnection
+
+CONNECTION_MODULE = "metadata.ingestion.source.database.mongodb.connection"
+
+
+def _config(**kwargs) -> MongoDBConnectionConfig:
+    base = {
+        "scheme": MongoDBScheme.mongodb,
+        "username": "user",
+        "password": "pass",
+        "hostPort": "localhost:27017",
+    }
+    base.update(kwargs)
+    return MongoDBConnectionConfig(**base)
+
+
+def test_mongodb_connection_is_base_connection():
+    assert issubclass(MongoDBConnection, BaseConnection)
+
+
+def test_get_client_builds_a_mongo_client_from_the_url():
+    with patch(f"{CONNECTION_MODULE}.MongoClient") as mock_mongo:
+        client = MongoDBConnection(_config()).client
+    args, kwargs = mock_mongo.call_args
+    assert args[0].startswith("mongodb://")
+    assert kwargs == {}
+    assert client is mock_mongo.return_value
+
+
+def test_get_client_passes_connection_options_as_kwargs():
+    config = _config(connectionOptions={"serverSelectionTimeoutMS": "5000"})
+    with patch(f"{CONNECTION_MODULE}.MongoClient") as mock_mongo:
+        _ = MongoDBConnection(config).client
+    assert mock_mongo.call_args.kwargs["serverSelectionTimeoutMS"] == "5000"

--- a/ingestion/tests/unit/source/database/mongodb/test_connection.py
+++ b/ingestion/tests/unit/source/database/mongodb/test_connection.py
@@ -58,3 +58,11 @@ def test_get_client_passes_connection_options_as_kwargs():
     with patch(f"{CONNECTION_MODULE}.MongoClient") as mock_mongo:
         _ = MongoDBConnection(config).client
     assert mock_mongo.call_args.kwargs["serverSelectionTimeoutMS"] == "5000"
+
+
+def test_close_releases_the_mongo_client_pool():
+    with patch(f"{CONNECTION_MODULE}.MongoClient") as mock_mongo:
+        connection = MongoDBConnection(_config())
+        _ = connection.client
+        connection.close()
+    mock_mongo.return_value.close.assert_called_once_with()


### PR DESCRIPTION
Fixes #28970

## What
Migrates **mongodb** onto `BaseConnection` — the **first non-`Engine` connector**, and a spike to de-risk the remaining NoSQL/SDK tier.

## Why it matters
Every connector migrated so far returned a SQLAlchemy `Engine`. mongodb's client is a `pymongo.MongoClient`, so this is the first `BaseConnection[S, C]` where `C` is not `Engine`. The spike confirms the pattern needs **zero framework changes**:
- the generic resolver's client path is type-agnostic — `_get_connection_fn_from_service_spec` returns `connection_class(conn).client`, which yields the `MongoClient`;
- `_get_test_fn_from_service_spec` returns the **bound** `test_connection` method, and `test_connection_common` invokes it as `test_connection_fn(metadata)` (the 1-arg `BaseConnection.test_connection` signature), falling back to the legacy 3-arg form via `except TypeError`;
- `CommonNoSQLSource` already builds its client through the same resolver (`self.connection_obj = get_connection(...)`), so the source needs no change.

## How
`_get_client` builds the `MongoClient` (URL + `connectionOptions` kwargs); `test_connection` becomes a method driving the pymongo checks (`server_info`, `list_database_names`, `list_collection_names`) via `self.client`. Logic preserved verbatim; service spec wires `connection_class`.

## Tests
Colocated unit tests assert the client is a `MongoClient` built from the URL and that `connectionOptions` pass through as kwargs; the existing `test_mongodb.py` topology suite is unchanged (it patches the source-level `test_connection`, not the connection module). Verified end-to-end that the resolver returns a `MongoClient` (not an Engine) and resolves the bound `test_connection`. ruff + basedpyright clean (no new errors).

This unblocks the remaining non-`Engine` connectors (cassandra, couchbase, dynamodb, salesforce, deltalake, glue, …) to follow the same recipe.