### PR TITLE
fix(lineage): resolve cross-catalog view lineage via database-wildcard fallback

### DIFF
--- a/ingestion/src/metadata/ingestion/lineage/sql_lineage.py
+++ b/ingestion/src/metadata/ingestion/lineage/sql_lineage.py
@@ -569,6 +569,38 @@ def get_table_entities_from_query(
         if table_entities:
             return table_entities
 
+    # Cross-catalog fallback: the database resolved from the query/context may not
+    # match the database the source table was ingested under. This happens when the
+    # same physical data is exposed through different catalogs across services, so a
+    # view in one catalog references a table that another service ingested under a
+    # different database name. Searching with the view's database never matches the
+    # table under a different database name, so no lineage edge is created even with
+    # crossDatabaseServiceNames configured. Retry with database=None so the FQN search
+    # wildcards the database (`<service>.*.<schema>.<table>`) and resolves the table
+    # across the configured cross-database services. This is scoped to `service_names`,
+    # which only holds the current service plus the explicitly allowed
+    # crossDatabaseServiceNames, so it cannot reach unrelated services.
+    table_entities = search_table_entities(
+        metadata=metadata,
+        service_names=service_names,
+        database=None,
+        database_schema=schema_query if schema_query else database_schema,
+        table=table,
+    )
+    if table_entities:
+        return table_entities
+
+    if schema_fallback:
+        table_entities = search_table_entities(
+            metadata=metadata,
+            service_names=service_names,
+            database=None,
+            database_schema=None,
+            table=table,
+        )
+        if table_entities:
+            return table_entities
+
     return None
 
 


### PR DESCRIPTION
## Describe your changes

Cross-database/cross-catalog **view lineage** does not resolve the source table when the same physical data is exposed through **different catalogs across database services**, so a view in one catalog references a table that another service ingested under a **different database name**.

`get_table_entities_from_query` searches every service (including `crossDatabaseServiceNames`) using the **view's** database name, so a source table ingested under a different database never matches — and **no lineage edge is created**, even with `processCrossDatabaseLineage: true` and `crossDatabaseServiceNames` set. The run logs `Table entity [<schema>.<table>] not found in OpenMetadata` and finishes with 0 records.

### Fix
Add a final **`database=None` fallback** in `get_table_entities_from_query`, after the existing exact and schema fallbacks. With `database=None`, `build_es_fqn_search_string` wildcards the database (`<service>.*.<schema>.<table>`), so the table resolves regardless of which database name it was ingested under.

The fallback is **scoped to `service_names`**, which only contains the current service plus the explicitly-allowed `crossDatabaseServiceNames` — it cannot reach unrelated services, and it only runs as a last resort after exact + schema searches miss.

### Why this is safe
- Runs only after the exact-db and schema-fallback searches return nothing.
- Restricted to the already-configured `service_names` (current + `crossDatabaseServiceNames`).
- Mirrors the existing `schema_fallback` pattern in the same function.

### Related
Addresses the class of "cross-database lineage / table not found across catalogs with different database names" reports: #24311, #24738, #21180, #24075.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)