### PR TITLE
test(playwright): isolate IntakeForm spec so the suite tolerates global intake-form state

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright.config.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright.config.ts
@@ -204,11 +204,6 @@ export default defineConfig({
       dependencies: ['setup', 'chromium'],
       fullyParallel: false,
     },
-    // IntakeForm tests enable a global, singleton-per-entityType intake form for
-    // dataProduct that gates ALL data product creation while it is active. Running
-    // them in parallel makes any concurrent spec that creates a data product fail
-    // with a 400 (missing intake-form required field). Isolate after chromium so no
-    // other data-product-creating test runs alongside them.
     {
       name: 'IntakeForm',
       testMatch: '**/IntakeForm.spec.ts',

--- a/openmetadata-ui/src/main/resources/ui/playwright.config.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright.config.ts
@@ -112,6 +112,7 @@ export default defineConfig({
         '**/SystemCertificationTags.spec.ts',
         '**/SearchRBAC.spec.ts',
         '**/SSOLogin.spec.ts',
+        '**/IntakeForm.spec.ts',
       ],
     },
     // Only register the h2 project when explicitly opted in. Always-on registration would force
@@ -199,6 +200,18 @@ export default defineConfig({
     {
       name: 'SystemCertificationTags',
       testMatch: '**/SystemCertificationTags.spec.ts',
+      use: { ...devices['Desktop Chrome'] },
+      dependencies: ['setup', 'chromium'],
+      fullyParallel: false,
+    },
+    // IntakeForm tests enable a global, singleton-per-entityType intake form for
+    // dataProduct that gates ALL data product creation while it is active. Running
+    // them in parallel makes any concurrent spec that creates a data product fail
+    // with a 400 (missing intake-form required field). Isolate after chromium so no
+    // other data-product-creating test runs alongside them.
+    {
+      name: 'IntakeForm',
+      testMatch: '**/IntakeForm.spec.ts',
       use: { ...devices['Desktop Chrome'] },
       dependencies: ['setup', 'chromium'],
       fullyParallel: false,


### PR DESCRIPTION
## What this enables

Makes the Playwright E2E suite resilient to the **global, singleton-per-entityType intake form** introduced for `dataProduct`. Any spec that creates a Data Product can now run reliably regardless of what the IntakeForm tests are doing.

## Background

`IntakeFormValidator` enforces org-configured required fields on Data Product creation, but only when an **enabled** `IntakeForm` exists for `dataProduct` (singleton per entity type — global server state). `IntakeForm.spec.ts` seeds such an enabled form with a required **Steward** field during several of its tests.

Because `IntakeForm.spec.ts` ran inside the **`fullyParallel: true` `chromium` project**, that enabled form was live while other specs ran concurrently on other workers. Any spec creating a Data Product in that window failed with:

```
HTTP 400: Missing required field(s) per intake form 'dataProduct': Steward
```

This affects ~30 specs that create Data Products (Domains, DataProducts, DataMarketplace, DataProductPermissions, …).

### Observed failure

Nightly run: `Domains.spec.ts › Domain asset dryRun — add confirmation › preview names affected data products when moving across domains` failed at `DataProduct.create()`. Trace timestamps confirm its window (`02:07:45 → 02:07:55`) overlapped `IntakeForm.spec.ts › pick admin user → DP create succeeds…` (`02:07:18 → 02:07:51`), which had an enabled Steward-required form active. Both retries landed in/just after that window.

## Fix

Exclude `IntakeForm.spec.ts` from the `chromium` project and run it in a dedicated **serial project that depends on `chromium`** — so it executes alone after the parallel suite finishes and never overlaps a data-product-creating spec. This mirrors the existing `SystemCertificationTags` isolation pattern (which isolates another global-state spec the same way). In CI this runs on per-shard isolated backends (the bare `playwright test --shard` in `playwright-mysql-e2e.yml`), so the real, unmocked E2E is preserved.

No product code changes — the intake-form enforcement is working as designed; this is purely test isolation.

## Alternatives considered & rejected

We checked whether a lighter fix exists — one that keeps a real end-to-end test, uses no mocking, and needs no product change. None holds up, because intake-form enforcement is **global and unconditional** (keyed by `entityType` only, applied to every Data Product create):

- **A separate test user** — no effect. The validator looks the form up by `entityType` with no user/owner/domain scoping (`IntakeFormRepository.findEnabledForEntityType`, called from `DataProductRepository.prepare()`).
- **Requiring a "universally present" field instead of a custom property** — not robust. No optional native field is set by every DP-creation path: requiring `dataProductType` would block `utils/domain.ts`, `DataProductAndSubdomains.spec.ts`, `DescriptionVisibility.spec.ts`, and UI-created DPs; requiring `displayName` blocks UI-created DPs (empty is treated as missing). Schema-required fields are universal but the validator deliberately skips them.
- **Route-mocking the intake-form fetch** — would stop exercising the real backend; we want a real E2E.
- **Domain-scoping intake forms (product change)** — the global behavior is an intentional product assumption; also a large change with a destructive `UNIQUE(entityType)` migration.

Backend enforcement is independently and comprehensively covered by the isolated Java IT `IntakeFormResourceIT`; this PR keeps the UI-level E2E and isolates it so it never overlaps concurrent Data Product creation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
