### PR TITLE
Fixes #28992: refactor(ingestion): migrate storage/search/drive connectors to BaseConnection

### DIFF
--- a/ingestion/src/metadata/ingestion/source/drive/googledrive/connection.py
+++ b/ingestion/src/metadata/ingestion/source/drive/googledrive/connection.py
@@ -24,11 +24,12 @@ from metadata.generated.schema.entity.automations.workflow import (
     Workflow as AutomationWorkflow,
 )
 from metadata.generated.schema.entity.services.connections.drive.googleDriveConnection import (
-    GoogleDriveConnection,
+    GoogleDriveConnection as GoogleDriveConnectionConfig,
 )
 from metadata.generated.schema.entity.services.connections.testConnectionResult import (
     TestConnectionResult,
 )
+from metadata.ingestion.connections.connection import BaseConnection
 from metadata.ingestion.connections.test_connections import (
     SourceConnectionException,
     test_connection_steps,
@@ -51,7 +52,7 @@ class GoogleDriveClient:
         self.drive_service = drive_service
 
 
-def get_connection(connection: GoogleDriveConnection) -> GoogleDriveClient:
+def get_connection(connection: GoogleDriveConnectionConfig) -> GoogleDriveClient:
     """
     Create connection to Google Drive
     """
@@ -94,103 +95,108 @@ def get_connection(connection: GoogleDriveConnection) -> GoogleDriveClient:
     return GoogleDriveClient(sheets_service, drive_service)
 
 
-def test_connection(
-    metadata: OpenMetadata,
-    client: GoogleDriveClient,
-    service_connection: GoogleDriveConnection,
-    automation_workflow: Optional[AutomationWorkflow] = None,  # noqa: UP045
-    timeout_seconds: Optional[int] = THREE_MIN,  # noqa: UP045
-) -> TestConnectionResult:
-    """
-    Test connection to Google Drive
-    """
-    logger.info("Starting Google Drive test connection")
+class GoogleDriveConnection(BaseConnection[GoogleDriveConnectionConfig, GoogleDriveClient]):
+    def _get_client(self) -> GoogleDriveClient:
+        return get_connection(self.service_connection)
 
-    def check_access():
+    def test_connection(
+        self,
+        metadata: OpenMetadata,
+        automation_workflow: Optional[AutomationWorkflow] = None,  # noqa: UP045
+        timeout_seconds: Optional[int] = THREE_MIN,  # noqa: UP045
+    ) -> TestConnectionResult:
         """
-        Check if we can access Google Drive API
+        Test connection to Google Drive
         """
-        try:
-            # Try to get user info - this will fail if credentials are invalid
-            about = client.drive_service.about().get(fields="user").execute()
-            user_email = about.get("user", {}).get("emailAddress", "Unknown")
-            logger.info(f"Successfully authenticated as: {user_email}")
-        except Exception as exc:
-            logger.debug(f"Access check error traceback: {traceback.format_exc()}")
-            raise SourceConnectionException(f"Failed to access Google Drive API: {exc}")  # noqa: B904
+        client = self.client
+        service_connection = self.service_connection
+        logger.info("Starting Google Drive test connection")
 
-    def get_drive_files():
-        """
-        Test listing drive files
-        """
-        try:
-            logger.info("Testing Google Drive file listing")
-
-            # Query for a small number of files to test access
-            query = "trashed=false"
-
-            results = (
-                client.drive_service.files()
-                .list(
-                    q=query,
-                    pageSize=5,
-                    fields="files(id, name, mimeType)",
-                    supportsAllDrives=True,
-                    includeItemsFromAllDrives=True,
-                )
-                .execute()
-            )
-
-            files = results.get("files", [])
-            logger.info(f"Found {len(files)} files in Drive (sample)")
-
-            # Also test for shared drives
-            logger.info("Testing shared drive access")
+        def check_access():
+            """
+            Check if we can access Google Drive API
+            """
             try:
-                shared_results = client.drive_service.drives().list(pageSize=5, fields="drives(id, name)").execute()
-                shared_drives = shared_results.get("drives", [])
-                logger.info(f"Found {len(shared_drives)} shared drives")
-                for drive in shared_drives:
-                    logger.info(f"Shared drive: {drive.get('name')} (ID: {drive.get('id')})")
-            except Exception as shared_exc:
-                logger.warning(f"Could not access shared drives: {shared_exc}")
+                # Try to get user info - this will fail if credentials are invalid
+                about = client.drive_service.about().get(fields="user").execute()  # pyright: ignore[reportAttributeAccessIssue]
+                user_email = about.get("user", {}).get("emailAddress", "Unknown")
+                logger.info(f"Successfully authenticated as: {user_email}")
+            except Exception as exc:
+                logger.debug(f"Access check error traceback: {traceback.format_exc()}")
+                raise SourceConnectionException(f"Failed to access Google Drive API: {exc}")  # noqa: B904
 
-        except Exception as exc:
-            logger.debug(f"Drive files test error traceback: {traceback.format_exc()}")
-            raise SourceConnectionException(f"Failed to list drive files: {exc}")  # noqa: B904
+        def get_drive_files():
+            """
+            Test listing drive files
+            """
+            try:
+                logger.info("Testing Google Drive file listing")
 
-    def get_spreadsheets(include_sheets: bool = False):
-        """
-        Test listing spreadsheets if Google Sheets is included
-        """
-        if not include_sheets:
-            return
+                # Query for a small number of files to test access
+                query = "trashed=false"
 
-        try:
-            logger.info("Testing Google Sheets spreadsheet listing")
+                results = (
+                    client.drive_service.files()
+                    .list(
+                        q=query,
+                        pageSize=5,
+                        fields="files(id, name, mimeType)",
+                        supportsAllDrives=True,
+                        includeItemsFromAllDrives=True,
+                    )
+                    .execute()
+                )
 
-            # Query for Google Sheets files
-            query = "mimeType='application/vnd.google-apps.spreadsheet' and trashed=false"
+                files = results.get("files", [])
+                logger.info(f"Found {len(files)} files in Drive (sample)")
 
-            results = client.drive_service.files().list(q=query, pageSize=5, fields="files(id, name)").execute()
+                # Also test for shared drives
+                logger.info("Testing shared drive access")
+                try:
+                    shared_results = client.drive_service.drives().list(pageSize=5, fields="drives(id, name)").execute()  # pyright: ignore[reportAttributeAccessIssue]
+                    shared_drives = shared_results.get("drives", [])
+                    logger.info(f"Found {len(shared_drives)} shared drives")
+                    for drive in shared_drives:
+                        logger.info(f"Shared drive: {drive.get('name')} (ID: {drive.get('id')})")
+                except Exception as shared_exc:
+                    logger.warning(f"Could not access shared drives: {shared_exc}")
 
-            files = results.get("files", [])
-            logger.info(f"Found {len(files)} spreadsheets")
+            except Exception as exc:
+                logger.debug(f"Drive files test error traceback: {traceback.format_exc()}")
+                raise SourceConnectionException(f"Failed to list drive files: {exc}")  # noqa: B904
 
-        except Exception as exc:
-            logger.debug(f"Spreadsheet test error traceback: {traceback.format_exc()}")
-            raise SourceConnectionException(f"Failed to list spreadsheets: {exc}")  # noqa: B904
+        def get_spreadsheets(include_sheets: bool = False):
+            """
+            Test listing spreadsheets if Google Sheets is included
+            """
+            if not include_sheets:
+                return
 
-    test_fn = {
-        "CheckAccess": check_access,
-        "GetDriveFiles": get_drive_files,
-        "GetSpreadsheets": partial(get_spreadsheets, include_sheets=service_connection.includeGoogleSheets),
-    }
+            try:
+                logger.info("Testing Google Sheets spreadsheet listing")
 
-    return test_connection_steps(
-        metadata=metadata,
-        test_fn=test_fn,
-        service_type=service_connection.type.value,
-        automation_workflow=automation_workflow,
-        timeout_seconds=timeout_seconds,
-    )
+                # Query for Google Sheets files
+                query = "mimeType='application/vnd.google-apps.spreadsheet' and trashed=false"
+
+                results = client.drive_service.files().list(q=query, pageSize=5, fields="files(id, name)").execute()  # pyright: ignore[reportAttributeAccessIssue]
+
+                files = results.get("files", [])
+                logger.info(f"Found {len(files)} spreadsheets")
+
+            except Exception as exc:
+                logger.debug(f"Spreadsheet test error traceback: {traceback.format_exc()}")
+                raise SourceConnectionException(f"Failed to list spreadsheets: {exc}")  # noqa: B904
+
+        test_fn = {
+            "CheckAccess": check_access,
+            "GetDriveFiles": get_drive_files,
+            "GetSpreadsheets": partial(get_spreadsheets, include_sheets=service_connection.includeGoogleSheets),  # pyright: ignore[reportArgumentType]
+        }
+
+        return test_connection_steps(
+            metadata=metadata,
+            test_fn=test_fn,
+            service_type=service_connection.type.value,  # pyright: ignore[reportOptionalMemberAccess]
+            automation_workflow=automation_workflow,
+            timeout_seconds=timeout_seconds,
+        )

--- a/ingestion/src/metadata/ingestion/source/drive/sftp/connection.py
+++ b/ingestion/src/metadata/ingestion/source/drive/sftp/connection.py
@@ -26,11 +26,14 @@ from metadata.generated.schema.entity.automations.workflow import (
 from metadata.generated.schema.entity.services.connections.drive.sftpConnection import (
     BasicAuth,
     KeyAuth,
-    SftpConnection,
+)
+from metadata.generated.schema.entity.services.connections.drive.sftpConnection import (
+    SftpConnection as SftpConnectionConfig,
 )
 from metadata.generated.schema.entity.services.connections.testConnectionResult import (
     TestConnectionResult,
 )
+from metadata.ingestion.connections.connection import BaseConnection
 from metadata.ingestion.connections.test_connections import (
     SourceConnectionException,
     test_connection_steps,
@@ -60,7 +63,7 @@ class SftpClient:
             logger.warning(f"Error closing SFTP connection: {exc}")
 
 
-def get_connection(connection: SftpConnection) -> SftpClient:
+def get_connection(connection: SftpConnectionConfig) -> SftpClient:
     """
     Create connection to SFTP server
     """
@@ -127,60 +130,65 @@ def _parse_private_key(private_key_str: str, passphrase: Optional[str] = None) -
     return None
 
 
-def test_connection(
-    metadata: OpenMetadata,
-    client: SftpClient,
-    service_connection: SftpConnection,
-    automation_workflow: Optional[AutomationWorkflow] = None,  # noqa: UP045
-    timeout_seconds: Optional[int] = THREE_MIN,  # noqa: UP045
-) -> TestConnectionResult:
-    """
-    Test connection to SFTP server
-    """
-    logger.info("Starting SFTP test connection")
+class SftpConnection(BaseConnection[SftpConnectionConfig, SftpClient]):
+    def _get_client(self) -> SftpClient:
+        return get_connection(self.service_connection)
 
-    def check_access():
+    def test_connection(
+        self,
+        metadata: OpenMetadata,
+        automation_workflow: Optional[AutomationWorkflow] = None,  # noqa: UP045
+        timeout_seconds: Optional[int] = THREE_MIN,  # noqa: UP045
+    ) -> TestConnectionResult:
         """
-        Check if we can access SFTP server
+        Test connection to SFTP server
         """
-        try:
-            client.sftp.stat(".")
-            logger.info("Successfully authenticated to SFTP server")
-        except Exception as exc:
-            logger.debug(f"Access check error traceback: {traceback.format_exc()}")
-            raise SourceConnectionException(f"Failed to access SFTP server: {exc}")  # noqa: B904
+        client = self.client
+        service_connection = self.service_connection
+        logger.info("Starting SFTP test connection")
 
-    def list_directories():
-        """
-        Test listing root directories
-        """
-        try:
-            logger.info("Testing SFTP directory listing")
-            root_dirs = service_connection.rootDirectories or ["/"]
+        def check_access():
+            """
+            Check if we can access SFTP server
+            """
+            try:
+                client.sftp.stat(".")
+                logger.info("Successfully authenticated to SFTP server")
+            except Exception as exc:
+                logger.debug(f"Access check error traceback: {traceback.format_exc()}")
+                raise SourceConnectionException(f"Failed to access SFTP server: {exc}")  # noqa: B904
 
-            for root_dir in root_dirs:
-                try:
-                    entries = client.sftp.listdir(root_dir)
-                    logger.info(f"Found {len(entries)} entries in '{root_dir}'")
-                except Exception as dir_exc:
-                    logger.warning(f"Could not list directory '{root_dir}': {dir_exc}")
-                    raise SourceConnectionException(f"Failed to list directory '{root_dir}': {dir_exc}")  # noqa: B904
+        def list_directories():
+            """
+            Test listing root directories
+            """
+            try:
+                logger.info("Testing SFTP directory listing")
+                root_dirs = service_connection.rootDirectories or ["/"]
 
-        except SourceConnectionException:
-            raise
-        except Exception as exc:
-            logger.debug(f"Directory listing test error traceback: {traceback.format_exc()}")
-            raise SourceConnectionException(f"Failed to list directories: {exc}")  # noqa: B904
+                for root_dir in root_dirs:
+                    try:
+                        entries = client.sftp.listdir(root_dir)
+                        logger.info(f"Found {len(entries)} entries in '{root_dir}'")
+                    except Exception as dir_exc:
+                        logger.warning(f"Could not list directory '{root_dir}': {dir_exc}")
+                        raise SourceConnectionException(f"Failed to list directory '{root_dir}': {dir_exc}")  # noqa: B904
 
-    test_fn = {
-        "CheckAccess": check_access,
-        "ListDirectories": list_directories,
-    }
+            except SourceConnectionException:
+                raise
+            except Exception as exc:
+                logger.debug(f"Directory listing test error traceback: {traceback.format_exc()}")
+                raise SourceConnectionException(f"Failed to list directories: {exc}")  # noqa: B904
 
-    return test_connection_steps(
-        metadata=metadata,
-        test_fn=test_fn,
-        service_type=service_connection.type.value,
-        automation_workflow=automation_workflow,
-        timeout_seconds=timeout_seconds,
-    )
+        test_fn = {
+            "CheckAccess": check_access,
+            "ListDirectories": list_directories,
+        }
+
+        return test_connection_steps(
+            metadata=metadata,
+            test_fn=test_fn,
+            service_type=service_connection.type.value,  # pyright: ignore[reportOptionalMemberAccess]
+            automation_workflow=automation_workflow,
+            timeout_seconds=timeout_seconds,
+        )

--- a/ingestion/src/metadata/ingestion/source/drive/sftp/service_spec.py
+++ b/ingestion/src/metadata/ingestion/source/drive/sftp/service_spec.py
@@ -12,7 +12,8 @@
 SFTP Service Spec
 """
 
+from metadata.ingestion.source.drive.sftp.connection import SftpConnection
 from metadata.ingestion.source.drive.sftp.metadata import SftpSource
 from metadata.utils.service_spec import BaseSpec
 
-ServiceSpec = BaseSpec(metadata_source_class=SftpSource)
+ServiceSpec = BaseSpec(metadata_source_class=SftpSource, connection_class=SftpConnection)  # pyright: ignore[reportArgumentType]

--- a/ingestion/src/metadata/ingestion/source/search/elasticsearch/connection.py
+++ b/ingestion/src/metadata/ingestion/source/search/elasticsearch/connection.py
@@ -39,12 +39,13 @@ from metadata.generated.schema.entity.services.connections.search.elasticSearch.
     BasicAuthentication,
 )
 from metadata.generated.schema.entity.services.connections.search.elasticSearchConnection import (
-    ElasticsearchConnection,
+    ElasticsearchConnection as ElasticsearchConnectionConfig,
 )
 from metadata.generated.schema.entity.services.connections.testConnectionResult import (
     TestConnectionResult,
 )
 from metadata.ingestion.connections.builders import init_empty_connection_arguments
+from metadata.ingestion.connections.connection import BaseConnection
 from metadata.ingestion.connections.test_connections import test_connection_steps
 from metadata.ingestion.ometa.ometa_api import OpenMetadata
 from metadata.utils.constants import THREE_MIN, UTF_8
@@ -136,76 +137,75 @@ def get_ssl_context(ssl_config: SslConfig) -> ssl.SSLContext:
     return ssl._create_unverified_context()  # pylint: disable=protected-access
 
 
-def get_connection(connection: ElasticsearchConnection) -> Elasticsearch:
-    """
-    Create connection
-    """
-    basic_auth = None
-    api_key = None
-    ssl_context = None
-    if isinstance(connection.authType, BasicAuthentication) and connection.authType.username:
-        basic_auth = (
-            connection.authType.username,
-            connection.authType.password.get_secret_value() if connection.authType.password else None,
+class ElasticsearchConnection(BaseConnection[ElasticsearchConnectionConfig, Elasticsearch]):
+    def _get_client(self) -> Elasticsearch:
+        connection = self.service_connection
+        basic_auth = None
+        api_key = None
+        ssl_context = None
+        if isinstance(connection.authType, BasicAuthentication) and connection.authType.username:
+            basic_auth = (
+                connection.authType.username,
+                connection.authType.password.get_secret_value() if connection.authType.password else None,
+            )
+
+        if isinstance(connection.authType, ApiKeyAuthentication):
+            if connection.authType.apiKeyId and connection.authType.apiKey:
+                api_key = (
+                    connection.authType.apiKeyId,
+                    connection.authType.apiKey.get_secret_value(),
+                )
+            elif connection.authType.apiKey:
+                api_key = connection.authType.apiKey.get_secret_value()
+
+        if not connection.connectionArguments:
+            connection.connectionArguments = init_empty_connection_arguments()
+
+        if connection.sslConfig:
+            ssl_context = get_ssl_context(connection.sslConfig)
+
+        return Elasticsearch(
+            str(connection.hostPort),
+            basic_auth=basic_auth,
+            api_key=api_key,
+            ssl_context=ssl_context,
+            **connection.connectionArguments.root,  # pyright: ignore[reportCallIssue]
         )
 
-    if isinstance(connection.authType, ApiKeyAuthentication):
-        if connection.authType.apiKeyId and connection.authType.apiKey:
-            api_key = (
-                connection.authType.apiKeyId,
-                connection.authType.apiKey.get_secret_value(),
-            )
-        elif connection.authType.apiKey:
-            api_key = connection.authType.apiKey.get_secret_value()
+    def test_connection(
+        self,
+        metadata: OpenMetadata,
+        automation_workflow: Optional[AutomationWorkflow] = None,  # noqa: UP045
+        timeout_seconds: Optional[int] = THREE_MIN,  # noqa: UP045
+    ) -> TestConnectionResult:
+        """
+        Test connection. This can be executed either as part
+        of a metadata workflow or during an Automation Workflow
+        """
+        client = self.client
+        service_connection = self.service_connection
 
-    if not connection.connectionArguments:
-        connection.connectionArguments = init_empty_connection_arguments()
+        def test_get_search_indexes():
+            try:
+                result = client.indices.get_alias(expand_wildcards="open")
+                if result is None:
+                    raise ConnectionError("Failed to retrieve search indexes from Elasticsearch")  # noqa: TRY301
+                return result  # noqa: TRY300
+            except Exception as exc:
+                raise ConnectionError(
+                    f"Unable to connect to Elasticsearch or retrieve indexes: {exc}. "
+                    "Please check your Elasticsearch connection configuration and cluster health."
+                ) from exc
 
-    if connection.sslConfig:
-        ssl_context = get_ssl_context(connection.sslConfig)
+        test_fn = {
+            "CheckAccess": client.info,
+            "GetSearchIndexes": test_get_search_indexes,
+        }
 
-    return Elasticsearch(
-        str(connection.hostPort),
-        basic_auth=basic_auth,
-        api_key=api_key,
-        ssl_context=ssl_context,
-        **connection.connectionArguments.root,
-    )
-
-
-def test_connection(
-    metadata: OpenMetadata,
-    client: Elasticsearch,
-    service_connection: ElasticsearchConnection,
-    automation_workflow: Optional[AutomationWorkflow] = None,  # noqa: UP045
-    timeout_seconds: Optional[int] = THREE_MIN,  # noqa: UP045
-) -> TestConnectionResult:
-    """
-    Test connection. This can be executed either as part
-    of a metadata workflow or during an Automation Workflow
-    """
-
-    def test_get_search_indexes():
-        try:
-            result = client.indices.get_alias(expand_wildcards="open")
-            if result is None:
-                raise ConnectionError("Failed to retrieve search indexes from Elasticsearch")  # noqa: TRY301
-            return result  # noqa: TRY300
-        except Exception as exc:
-            raise ConnectionError(
-                f"Unable to connect to Elasticsearch or retrieve indexes: {exc}. "
-                "Please check your Elasticsearch connection configuration and cluster health."
-            ) from exc
-
-    test_fn = {
-        "CheckAccess": client.info,
-        "GetSearchIndexes": test_get_search_indexes,
-    }
-
-    return test_connection_steps(
-        metadata=metadata,
-        test_fn=test_fn,
-        service_type=service_connection.type.value,
-        automation_workflow=automation_workflow,
-        timeout_seconds=timeout_seconds,
-    )
+        return test_connection_steps(
+            metadata=metadata,
+            test_fn=test_fn,
+            service_type=service_connection.type.value,  # pyright: ignore[reportOptionalMemberAccess]
+            automation_workflow=automation_workflow,
+            timeout_seconds=timeout_seconds,
+        )

--- a/ingestion/src/metadata/ingestion/source/search/elasticsearch/service_spec.py
+++ b/ingestion/src/metadata/ingestion/source/search/elasticsearch/service_spec.py
@@ -1,4 +1,5 @@
+from metadata.ingestion.source.search.elasticsearch.connection import ElasticsearchConnection
 from metadata.ingestion.source.search.elasticsearch.metadata import ElasticsearchSource
 from metadata.utils.service_spec import BaseSpec
 
-ServiceSpec = BaseSpec(metadata_source_class=ElasticsearchSource)
+ServiceSpec = BaseSpec(metadata_source_class=ElasticsearchSource, connection_class=ElasticsearchConnection)  # pyright: ignore[reportArgumentType]

--- a/ingestion/src/metadata/ingestion/source/search/opensearch/connection.py
+++ b/ingestion/src/metadata/ingestion/source/search/opensearch/connection.py
@@ -35,7 +35,7 @@ from metadata.generated.schema.entity.services.connections.search.elasticSearch.
     BasicAuthentication,
 )
 from metadata.generated.schema.entity.services.connections.search.openSearchConnection import (
-    OpenSearchConnection,
+    OpenSearchConnection as OpenSearchConnectionConfig,
 )
 from metadata.generated.schema.entity.services.connections.testConnectionResult import (
     TestConnectionResult,
@@ -43,6 +43,7 @@ from metadata.generated.schema.entity.services.connections.testConnectionResult 
 from metadata.generated.schema.security.credentials.awsCredentials import AWSCredentials
 from metadata.generated.schema.security.ssl.verifySSLConfig import VerifySSL
 from metadata.ingestion.connections.builders import init_empty_connection_arguments
+from metadata.ingestion.connections.connection import BaseConnection
 from metadata.ingestion.connections.test_connections import test_connection_steps
 from metadata.ingestion.ometa.ometa_api import OpenMetadata
 from metadata.utils.constants import THREE_MIN, UTF_8
@@ -99,7 +100,7 @@ def _handle_ssl_context_by_path(ssl_config: SslConfig):
     return ca_cert, client_cert, private_key
 
 
-def get_connection(connection: OpenSearchConnection) -> OpenSearch:
+def get_connection(connection: OpenSearchConnectionConfig) -> OpenSearch:
     """
     Create OpenSearch connection supporting Basic and AWS IAM authentication.
     """
@@ -169,30 +170,35 @@ def get_connection(connection: OpenSearchConnection) -> OpenSearch:
     )
 
 
-def test_connection(
-    metadata: OpenMetadata,
-    client: OpenSearch,
-    service_connection: OpenSearchConnection,
-    automation_workflow: Optional[AutomationWorkflow] = None,  # noqa: UP045
-    timeout_seconds: Optional[int] = THREE_MIN,  # noqa: UP045
-) -> TestConnectionResult:
-    """
-    Test connection for OpenSearch. This can be executed either as part
-    of a metadata workflow or during an Automation Workflow.
-    """
+class OpenSearchConnection(BaseConnection[OpenSearchConnectionConfig, OpenSearch]):
+    def _get_client(self) -> OpenSearch:
+        return get_connection(self.service_connection)
 
-    def test_get_search_indexes():
-        client.indices.get_alias(expand_wildcards="open")
+    def test_connection(
+        self,
+        metadata: OpenMetadata,
+        automation_workflow: Optional[AutomationWorkflow] = None,  # noqa: UP045
+        timeout_seconds: Optional[int] = THREE_MIN,  # noqa: UP045
+    ) -> TestConnectionResult:
+        """
+        Test connection for OpenSearch. This can be executed either as part
+        of a metadata workflow or during an Automation Workflow.
+        """
+        client = self.client
+        service_connection = self.service_connection
 
-    test_fn = {
-        "CheckAccess": client.info,
-        "GetSearchIndexes": test_get_search_indexes,
-    }
+        def test_get_search_indexes():
+            client.indices.get_alias(expand_wildcards="open")  # pyright: ignore[reportCallIssue]
 
-    return test_connection_steps(
-        metadata=metadata,
-        test_fn=test_fn,
-        service_type=service_connection.type.value,
-        automation_workflow=automation_workflow,
-        timeout_seconds=timeout_seconds,
-    )
+        test_fn = {
+            "CheckAccess": client.info,
+            "GetSearchIndexes": test_get_search_indexes,
+        }
+
+        return test_connection_steps(
+            metadata=metadata,
+            test_fn=test_fn,
+            service_type=service_connection.type.value,  # pyright: ignore[reportOptionalMemberAccess]
+            automation_workflow=automation_workflow,
+            timeout_seconds=timeout_seconds,
+        )

--- a/ingestion/src/metadata/ingestion/source/search/opensearch/service_spec.py
+++ b/ingestion/src/metadata/ingestion/source/search/opensearch/service_spec.py
@@ -1,4 +1,5 @@
+from metadata.ingestion.source.search.opensearch.connection import OpenSearchConnection
 from metadata.ingestion.source.search.opensearch.metadata import OpensearchSource
 from metadata.utils.service_spec import BaseSpec
 
-ServiceSpec = BaseSpec(metadata_source_class=OpensearchSource)
+ServiceSpec = BaseSpec(metadata_source_class=OpensearchSource, connection_class=OpenSearchConnection)  # pyright: ignore[reportArgumentType]

--- a/ingestion/src/metadata/ingestion/source/storage/gcs/connection.py
+++ b/ingestion/src/metadata/ingestion/source/storage/gcs/connection.py
@@ -21,7 +21,7 @@ from metadata.generated.schema.entity.automations.workflow import (
     Workflow as AutomationWorkflow,
 )
 from metadata.generated.schema.entity.services.connections.storage.gcsConnection import (
-    GcsConnection,
+    GcsConnection as GcsConnectionConfig,
 )
 from metadata.generated.schema.entity.services.connections.testConnectionResult import (
     TestConnectionResult,
@@ -30,6 +30,7 @@ from metadata.generated.schema.security.credentials.gcpValues import (
     GcpCredentialsValues,
     SingleProjectId,
 )
+from metadata.ingestion.connections.connection import BaseConnection
 from metadata.ingestion.connections.test_connections import (
     SourceConnectionException,
     test_connection_steps,
@@ -50,7 +51,7 @@ class GcsObjectStoreClient:
     metrics_client: MetricServiceClient
 
 
-def get_connection(connection: GcsConnection):
+def get_connection(connection: GcsConnectionConfig):
     set_google_credentials(connection.credentials)
     project_ids = None
     if isinstance(connection.credentials.gcpConfig, GcpCredentialsValues):
@@ -79,7 +80,7 @@ class Tester:
     blobs within a bucket.
     """
 
-    def __init__(self, client: GcsObjectStoreClient, connection: GcsConnection):
+    def __init__(self, client: GcsObjectStoreClient, connection: GcsConnectionConfig):
         self.client = client
         self.connection = connection
         self.bucket_tests = []
@@ -157,31 +158,36 @@ class Tester:
             self.client.metrics_client.list_metric_descriptors(name=f"projects/{project_id}")
 
 
-def test_connection(
-    metadata: OpenMetadata,
-    client: GcsObjectStoreClient,
-    service_connection: GcsConnection,
-    automation_workflow: Optional[AutomationWorkflow] = None,  # noqa: UP045
-    timeout_seconds: Optional[int] = THREE_MIN,  # noqa: UP045
-) -> TestConnectionResult:
-    """
-    Test connection. This can be executed either as part
-    of a metadata workflow or during an Automation Workflow
-    """
-    tester = Tester(client, service_connection)
+class GcsConnection(BaseConnection[GcsConnectionConfig, GcsObjectStoreClient]):
+    def _get_client(self) -> GcsObjectStoreClient:
+        return get_connection(self.service_connection)
 
-    test_fn = {
-        "ListBuckets": tester.list_buckets,
-        "GetBucket": tester.get_bucket,
-        "ListBlobs": tester.list_blobs,
-        "GetBlob": tester.get_blob,
-        "GetMetrics": tester.get_metrics,
-    }
+    def test_connection(
+        self,
+        metadata: OpenMetadata,
+        automation_workflow: Optional[AutomationWorkflow] = None,  # noqa: UP045
+        timeout_seconds: Optional[int] = THREE_MIN,  # noqa: UP045
+    ) -> TestConnectionResult:
+        """
+        Test connection. This can be executed either as part
+        of a metadata workflow or during an Automation Workflow
+        """
+        client = self.client
+        service_connection = self.service_connection
+        tester = Tester(client, service_connection)
 
-    return test_connection_steps(
-        metadata=metadata,
-        test_fn=test_fn,
-        service_type=service_connection.type.value,
-        automation_workflow=automation_workflow,
-        timeout_seconds=timeout_seconds,
-    )
+        test_fn = {
+            "ListBuckets": tester.list_buckets,
+            "GetBucket": tester.get_bucket,
+            "ListBlobs": tester.list_blobs,
+            "GetBlob": tester.get_blob,
+            "GetMetrics": tester.get_metrics,
+        }
+
+        return test_connection_steps(
+            metadata=metadata,
+            test_fn=test_fn,
+            service_type=service_connection.type.value,  # pyright: ignore[reportOptionalMemberAccess]
+            automation_workflow=automation_workflow,
+            timeout_seconds=timeout_seconds,
+        )

--- a/ingestion/src/metadata/ingestion/source/storage/gcs/service_spec.py
+++ b/ingestion/src/metadata/ingestion/source/storage/gcs/service_spec.py
@@ -1,5 +1,6 @@
+from metadata.ingestion.source.storage.gcs.connection import GcsConnection
 from metadata.ingestion.source.storage.gcs.metadata import GcsSource
 from metadata.sampler.storage.gcs.sampler import GCSSampler
 from metadata.utils.service_spec import BaseSpec
 
-ServiceSpec = BaseSpec(metadata_source_class=GcsSource, sampler_class=GCSSampler)
+ServiceSpec = BaseSpec(metadata_source_class=GcsSource, sampler_class=GCSSampler, connection_class=GcsConnection)  # pyright: ignore[reportArgumentType]

--- a/ingestion/src/metadata/ingestion/source/storage/s3/connection.py
+++ b/ingestion/src/metadata/ingestion/source/storage/s3/connection.py
@@ -26,11 +26,12 @@ from metadata.generated.schema.entity.automations.workflow import (
     Workflow as AutomationWorkflow,
 )
 from metadata.generated.schema.entity.services.connections.storage.s3Connection import (
-    S3Connection,
+    S3Connection as S3ConnectionConfig,
 )
 from metadata.generated.schema.entity.services.connections.testConnectionResult import (
     TestConnectionResult,
 )
+from metadata.ingestion.connections.connection import BaseConnection
 from metadata.ingestion.connections.test_connections import test_connection_steps
 from metadata.ingestion.ometa.ometa_api import OpenMetadata
 from metadata.utils.constants import THREE_MIN
@@ -43,7 +44,7 @@ class S3ObjectStoreClient:
     session: Any = None
 
 
-def get_connection(connection: S3Connection) -> S3ObjectStoreClient:
+def get_connection(connection: S3ConnectionConfig) -> S3ObjectStoreClient:
     """
     Returns 2 clients - the s3 client and the cloudwatch client needed for total nr of objects and total size
     """
@@ -58,34 +59,39 @@ def get_connection(connection: S3Connection) -> S3ObjectStoreClient:
     )
 
 
-def test_connection(
-    metadata: OpenMetadata,
-    client: S3ObjectStoreClient,
-    service_connection: S3Connection,
-    automation_workflow: Optional[AutomationWorkflow] = None,  # noqa: UP045
-    timeout_seconds: Optional[int] = THREE_MIN,  # noqa: UP045
-) -> TestConnectionResult:
-    """
-    Test connection. This can be executed either as part
-    of a metadata workflow or during an Automation Workflow
-    """
+class S3Connection(BaseConnection[S3ConnectionConfig, S3ObjectStoreClient]):
+    def _get_client(self) -> S3ObjectStoreClient:
+        return get_connection(self.service_connection)
 
-    def test_buckets(connection: S3Connection, client: S3ObjectStoreClient):
-        if connection.bucketNames:
-            for bucket_name in connection.bucketNames:
-                client.s3_client.list_objects(Bucket=bucket_name)
-            return
-        client.s3_client.list_buckets()
+    def test_connection(
+        self,
+        metadata: OpenMetadata,
+        automation_workflow: Optional[AutomationWorkflow] = None,  # noqa: UP045
+        timeout_seconds: Optional[int] = THREE_MIN,  # noqa: UP045
+    ) -> TestConnectionResult:
+        """
+        Test connection. This can be executed either as part
+        of a metadata workflow or during an Automation Workflow
+        """
+        client = self.client
+        service_connection = self.service_connection
 
-    test_fn = {
-        "ListBuckets": partial(test_buckets, client=client, connection=service_connection),
-        "GetMetrics": partial(client.cloudwatch_client.list_metrics, Namespace="AWS/S3"),
-    }
+        def test_buckets(connection: S3ConnectionConfig, client: S3ObjectStoreClient):
+            if connection.bucketNames:
+                for bucket_name in connection.bucketNames:
+                    client.s3_client.list_objects(Bucket=bucket_name)  # pyright: ignore[reportAttributeAccessIssue]
+                return
+            client.s3_client.list_buckets()  # pyright: ignore[reportAttributeAccessIssue]
 
-    return test_connection_steps(
-        metadata=metadata,
-        test_fn=test_fn,
-        service_type=service_connection.type.value,
-        automation_workflow=automation_workflow,
-        timeout_seconds=timeout_seconds,
-    )
+        test_fn = {
+            "ListBuckets": partial(test_buckets, client=client, connection=service_connection),
+            "GetMetrics": partial(client.cloudwatch_client.list_metrics, Namespace="AWS/S3"),  # pyright: ignore[reportAttributeAccessIssue]
+        }
+
+        return test_connection_steps(
+            metadata=metadata,
+            test_fn=test_fn,
+            service_type=service_connection.type.value,  # pyright: ignore[reportOptionalMemberAccess]
+            automation_workflow=automation_workflow,
+            timeout_seconds=timeout_seconds,
+        )

--- a/ingestion/src/metadata/ingestion/source/storage/s3/service_spec.py
+++ b/ingestion/src/metadata/ingestion/source/storage/s3/service_spec.py
@@ -1,5 +1,6 @@
+from metadata.ingestion.source.storage.s3.connection import S3Connection
 from metadata.ingestion.source.storage.s3.metadata import S3Source
 from metadata.sampler.storage.s3.sampler import S3Sampler
 from metadata.utils.service_spec import BaseSpec
 
-ServiceSpec = BaseSpec(metadata_source_class=S3Source, sampler_class=S3Sampler)
+ServiceSpec = BaseSpec(metadata_source_class=S3Source, sampler_class=S3Sampler, connection_class=S3Connection)  # pyright: ignore[reportArgumentType]

--- a/ingestion/tests/unit/source/drive/googledrive/__init__.py
+++ b/ingestion/tests/unit/source/drive/googledrive/__init__.py
@@ -8,16 +8,3 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-
-"""
-Google Drive service specification
-"""
-
-from metadata.ingestion.source.drive.googledrive.connection import GoogleDriveConnection
-from metadata.ingestion.source.drive.googledrive.metadata import GoogleDriveSource
-from metadata.utils.service_spec.service_spec import BaseSpec
-
-ServiceSpec = BaseSpec(
-    metadata_source_class=GoogleDriveSource,
-    connection_class=GoogleDriveConnection,  # pyright: ignore[reportArgumentType]
-)

--- a/ingestion/tests/unit/source/drive/googledrive/test_connection.py
+++ b/ingestion/tests/unit/source/drive/googledrive/test_connection.py
@@ -1,0 +1,40 @@
+#  Copyright 2025 Collate
+#  Licensed under the Collate Community License, Version 1.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  https://github.com/open-metadata/OpenMetadata/blob/main/ingestion/LICENSE
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+"""Unit tests for Google Drive connection handling."""
+
+from unittest.mock import MagicMock, patch
+
+from metadata.ingestion.connections.connection import BaseConnection
+from metadata.ingestion.source.drive.googledrive.connection import GoogleDriveConnection
+
+CONNECTION_MODULE = "metadata.ingestion.source.drive.googledrive.connection"
+
+
+def test_googledrive_connection_is_base_connection():
+    assert issubclass(GoogleDriveConnection, BaseConnection)
+
+
+def test_get_client_delegates_to_get_connection():
+    with patch(f"{CONNECTION_MODULE}.get_connection") as mock_get:
+        conn = GoogleDriveConnection(MagicMock())
+        client = conn.client
+
+    assert client is mock_get.return_value
+    mock_get.assert_called_once_with(conn.service_connection)
+
+
+def test_test_connection_runs_steps():
+    conn = GoogleDriveConnection(MagicMock())
+    conn._client = MagicMock()
+    with patch(f"{CONNECTION_MODULE}.test_connection_steps") as mock_steps:
+        result = conn.test_connection(metadata=MagicMock())
+
+    assert result is mock_steps.return_value

--- a/ingestion/tests/unit/source/drive/sftp/__init__.py
+++ b/ingestion/tests/unit/source/drive/sftp/__init__.py
@@ -8,16 +8,3 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-
-"""
-Google Drive service specification
-"""
-
-from metadata.ingestion.source.drive.googledrive.connection import GoogleDriveConnection
-from metadata.ingestion.source.drive.googledrive.metadata import GoogleDriveSource
-from metadata.utils.service_spec.service_spec import BaseSpec
-
-ServiceSpec = BaseSpec(
-    metadata_source_class=GoogleDriveSource,
-    connection_class=GoogleDriveConnection,  # pyright: ignore[reportArgumentType]
-)

--- a/ingestion/tests/unit/source/drive/sftp/test_connection.py
+++ b/ingestion/tests/unit/source/drive/sftp/test_connection.py
@@ -1,0 +1,40 @@
+#  Copyright 2025 Collate
+#  Licensed under the Collate Community License, Version 1.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  https://github.com/open-metadata/OpenMetadata/blob/main/ingestion/LICENSE
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+"""Unit tests for SFTP connection handling."""
+
+from unittest.mock import MagicMock, patch
+
+from metadata.ingestion.connections.connection import BaseConnection
+from metadata.ingestion.source.drive.sftp.connection import SftpConnection
+
+CONNECTION_MODULE = "metadata.ingestion.source.drive.sftp.connection"
+
+
+def test_sftp_connection_is_base_connection():
+    assert issubclass(SftpConnection, BaseConnection)
+
+
+def test_get_client_delegates_to_get_connection():
+    with patch(f"{CONNECTION_MODULE}.get_connection") as mock_get:
+        conn = SftpConnection(MagicMock())
+        client = conn.client
+
+    assert client is mock_get.return_value
+    mock_get.assert_called_once_with(conn.service_connection)
+
+
+def test_test_connection_runs_steps():
+    conn = SftpConnection(MagicMock())
+    conn._client = MagicMock()
+    with patch(f"{CONNECTION_MODULE}.test_connection_steps") as mock_steps:
+        result = conn.test_connection(metadata=MagicMock())
+
+    assert result is mock_steps.return_value

--- a/ingestion/tests/unit/source/search/elasticsearch/__init__.py
+++ b/ingestion/tests/unit/source/search/elasticsearch/__init__.py
@@ -8,16 +8,3 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-
-"""
-Google Drive service specification
-"""
-
-from metadata.ingestion.source.drive.googledrive.connection import GoogleDriveConnection
-from metadata.ingestion.source.drive.googledrive.metadata import GoogleDriveSource
-from metadata.utils.service_spec.service_spec import BaseSpec
-
-ServiceSpec = BaseSpec(
-    metadata_source_class=GoogleDriveSource,
-    connection_class=GoogleDriveConnection,  # pyright: ignore[reportArgumentType]
-)

--- a/ingestion/tests/unit/source/search/elasticsearch/test_connection.py
+++ b/ingestion/tests/unit/source/search/elasticsearch/test_connection.py
@@ -1,0 +1,45 @@
+#  Copyright 2025 Collate
+#  Licensed under the Collate Community License, Version 1.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  https://github.com/open-metadata/OpenMetadata/blob/main/ingestion/LICENSE
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+"""Unit tests for Elasticsearch connection handling."""
+
+from unittest.mock import MagicMock, patch
+
+from metadata.ingestion.connections.connection import BaseConnection
+from metadata.ingestion.source.search.elasticsearch.connection import (
+    ElasticsearchConnection,
+)
+
+CONNECTION_MODULE = "metadata.ingestion.source.search.elasticsearch.connection"
+
+
+def test_elasticsearch_connection_is_base_connection():
+    assert issubclass(ElasticsearchConnection, BaseConnection)
+
+
+def test_get_client_builds_elasticsearch():
+    config = MagicMock()
+    config.connectionArguments.root = {}
+    config.sslConfig = None
+    with patch(f"{CONNECTION_MODULE}.Elasticsearch") as mock_es:
+        conn = ElasticsearchConnection(config)
+        client = conn.client
+
+    assert client is mock_es.return_value
+    mock_es.assert_called_once()
+
+
+def test_test_connection_runs_steps():
+    conn = ElasticsearchConnection(MagicMock())
+    conn._client = MagicMock()
+    with patch(f"{CONNECTION_MODULE}.test_connection_steps") as mock_steps:
+        result = conn.test_connection(metadata=MagicMock())
+
+    assert result is mock_steps.return_value

--- a/ingestion/tests/unit/source/search/opensearch/__init__.py
+++ b/ingestion/tests/unit/source/search/opensearch/__init__.py
@@ -8,16 +8,3 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-
-"""
-Google Drive service specification
-"""
-
-from metadata.ingestion.source.drive.googledrive.connection import GoogleDriveConnection
-from metadata.ingestion.source.drive.googledrive.metadata import GoogleDriveSource
-from metadata.utils.service_spec.service_spec import BaseSpec
-
-ServiceSpec = BaseSpec(
-    metadata_source_class=GoogleDriveSource,
-    connection_class=GoogleDriveConnection,  # pyright: ignore[reportArgumentType]
-)

--- a/ingestion/tests/unit/source/search/opensearch/test_connection.py
+++ b/ingestion/tests/unit/source/search/opensearch/test_connection.py
@@ -1,0 +1,40 @@
+#  Copyright 2025 Collate
+#  Licensed under the Collate Community License, Version 1.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  https://github.com/open-metadata/OpenMetadata/blob/main/ingestion/LICENSE
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+"""Unit tests for OpenSearch connection handling."""
+
+from unittest.mock import MagicMock, patch
+
+from metadata.ingestion.connections.connection import BaseConnection
+from metadata.ingestion.source.search.opensearch.connection import OpenSearchConnection
+
+CONNECTION_MODULE = "metadata.ingestion.source.search.opensearch.connection"
+
+
+def test_opensearch_connection_is_base_connection():
+    assert issubclass(OpenSearchConnection, BaseConnection)
+
+
+def test_get_client_delegates_to_get_connection():
+    with patch(f"{CONNECTION_MODULE}.get_connection") as mock_get:
+        conn = OpenSearchConnection(MagicMock())
+        client = conn.client
+
+    assert client is mock_get.return_value
+    mock_get.assert_called_once_with(conn.service_connection)
+
+
+def test_test_connection_runs_steps():
+    conn = OpenSearchConnection(MagicMock())
+    conn._client = MagicMock()
+    with patch(f"{CONNECTION_MODULE}.test_connection_steps") as mock_steps:
+        result = conn.test_connection(metadata=MagicMock())
+
+    assert result is mock_steps.return_value

--- a/ingestion/tests/unit/source/storage/gcs/__init__.py
+++ b/ingestion/tests/unit/source/storage/gcs/__init__.py
@@ -8,16 +8,3 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-
-"""
-Google Drive service specification
-"""
-
-from metadata.ingestion.source.drive.googledrive.connection import GoogleDriveConnection
-from metadata.ingestion.source.drive.googledrive.metadata import GoogleDriveSource
-from metadata.utils.service_spec.service_spec import BaseSpec
-
-ServiceSpec = BaseSpec(
-    metadata_source_class=GoogleDriveSource,
-    connection_class=GoogleDriveConnection,  # pyright: ignore[reportArgumentType]
-)

--- a/ingestion/tests/unit/source/storage/gcs/test_connection.py
+++ b/ingestion/tests/unit/source/storage/gcs/test_connection.py
@@ -1,0 +1,40 @@
+#  Copyright 2025 Collate
+#  Licensed under the Collate Community License, Version 1.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  https://github.com/open-metadata/OpenMetadata/blob/main/ingestion/LICENSE
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+"""Unit tests for GCS object store connection handling."""
+
+from unittest.mock import MagicMock, patch
+
+from metadata.ingestion.connections.connection import BaseConnection
+from metadata.ingestion.source.storage.gcs.connection import GcsConnection
+
+CONNECTION_MODULE = "metadata.ingestion.source.storage.gcs.connection"
+
+
+def test_gcs_connection_is_base_connection():
+    assert issubclass(GcsConnection, BaseConnection)
+
+
+def test_get_client_delegates_to_get_connection():
+    with patch(f"{CONNECTION_MODULE}.get_connection") as mock_get:
+        conn = GcsConnection(MagicMock())
+        client = conn.client
+
+    assert client is mock_get.return_value
+    mock_get.assert_called_once_with(conn.service_connection)
+
+
+def test_test_connection_runs_steps():
+    conn = GcsConnection(MagicMock())
+    conn._client = MagicMock()
+    with patch(f"{CONNECTION_MODULE}.test_connection_steps") as mock_steps:
+        result = conn.test_connection(metadata=MagicMock())
+
+    assert result is mock_steps.return_value

--- a/ingestion/tests/unit/source/storage/s3/__init__.py
+++ b/ingestion/tests/unit/source/storage/s3/__init__.py
@@ -8,16 +8,3 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-
-"""
-Google Drive service specification
-"""
-
-from metadata.ingestion.source.drive.googledrive.connection import GoogleDriveConnection
-from metadata.ingestion.source.drive.googledrive.metadata import GoogleDriveSource
-from metadata.utils.service_spec.service_spec import BaseSpec
-
-ServiceSpec = BaseSpec(
-    metadata_source_class=GoogleDriveSource,
-    connection_class=GoogleDriveConnection,  # pyright: ignore[reportArgumentType]
-)

--- a/ingestion/tests/unit/source/storage/s3/test_connection.py
+++ b/ingestion/tests/unit/source/storage/s3/test_connection.py
@@ -1,0 +1,40 @@
+#  Copyright 2025 Collate
+#  Licensed under the Collate Community License, Version 1.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  https://github.com/open-metadata/OpenMetadata/blob/main/ingestion/LICENSE
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+"""Unit tests for S3 object store connection handling."""
+
+from unittest.mock import MagicMock, patch
+
+from metadata.ingestion.connections.connection import BaseConnection
+from metadata.ingestion.source.storage.s3.connection import S3Connection
+
+CONNECTION_MODULE = "metadata.ingestion.source.storage.s3.connection"
+
+
+def test_s3_connection_is_base_connection():
+    assert issubclass(S3Connection, BaseConnection)
+
+
+def test_get_client_delegates_to_get_connection():
+    with patch(f"{CONNECTION_MODULE}.get_connection") as mock_get:
+        conn = S3Connection(MagicMock())
+        client = conn.client
+
+    assert client is mock_get.return_value
+    mock_get.assert_called_once_with(conn.service_connection)
+
+
+def test_test_connection_runs_steps():
+    conn = S3Connection(MagicMock())
+    conn._client = MagicMock()
+    with patch(f"{CONNECTION_MODULE}.test_connection_steps") as mock_steps:
+        result = conn.test_connection(metadata=MagicMock())
+
+    assert result is mock_steps.return_value


### PR DESCRIPTION
Fixes #28992

## What

Migrates the **storage**, **search** and **drive** connectors onto the `BaseConnection[Config, Client]` pattern, continuing the connector-wide BaseConnection rollout (database vertical already complete).

Connectors in this batch:

| Service | Connector | Client type | get_connection |
|---|---|---|---|
| storage | s3 | `S3ObjectStoreClient` | kept module-level (sampler importer) |
| storage | gcs | `GcsObjectStoreClient` | kept module-level (sampler importer) |
| search | elasticsearch | `Elasticsearch` | moved into `_get_client` (no importer) |
| search | opensearch | `OpenSearch` | kept module-level (test importer) |
| drive | sftp | `SftpClient` | kept module-level (metadata importer) |
| drive | googledrive | `GoogleDriveClient` | kept module-level (metadata importer) |

## How

- Each connector gains an `XConnection(BaseConnection[ConfigType, ClientType])` with `_get_client` and `test_connection`.
- `connection_class` is wired into each `service_spec.py`. The storage/search/drive base sources already build their client and run `test_connection` through the generic resolver (`metadata.ingestion.source.connections`), so the new classes are exercised end-to-end — no source-side changes needed.
- Where a production module (samplers, `metadata.py`) imports `get_connection` directly, the function stays module-level and `_get_client` delegates to it; only elasticsearch (no external importer) moves the build inline.
- Module-level dataclasses (`S3ObjectStoreClient`, `GcsObjectStoreClient`), the GCS `Tester`, and SSL helpers are left untouched.

## Tests

- Added colocated `tests/unit/source/<type>/<connector>/test_connection.py` for all six (BaseConnection subclass, client build, test_connection step dispatch).
- Existing storage/search/drive topology suites pass unchanged (385 passed).
- `basedpyright` baseline check clean; `ruff` clean.

No behavior change — pure structural migration.