### PR TITLE
Fixes #28993: refactor(ingestion): migrate mlmodel/metadata/messaging connectors to BaseConnection

### DIFF
--- a/ingestion/src/metadata/ingestion/source/messaging/kafka/connection.py
+++ b/ingestion/src/metadata/ingestion/source/messaging/kafka/connection.py
@@ -26,7 +26,7 @@ from metadata.generated.schema.entity.automations.workflow import (
     Workflow as AutomationWorkflow,
 )
 from metadata.generated.schema.entity.services.connections.messaging.kafkaConnection import (
-    KafkaConnection,
+    KafkaConnection as KafkaConnectionConfig,
 )
 from metadata.generated.schema.entity.services.connections.messaging.redpandaConnection import (
     RedpandaConnection,
@@ -34,6 +34,7 @@ from metadata.generated.schema.entity.services.connections.messaging.redpandaCon
 from metadata.generated.schema.entity.services.connections.testConnectionResult import (
     TestConnectionResult,
 )
+from metadata.ingestion.connections.connection import BaseConnection
 from metadata.ingestion.connections.test_connections import test_connection_steps
 from metadata.ingestion.ometa.ometa_api import OpenMetadata
 from metadata.utils.constants import THREE_MIN
@@ -65,7 +66,7 @@ class KafkaClient:
         self.consumer_client = consumer_client
 
 
-def get_connection(connection: Union[KafkaConnection, RedpandaConnection]) -> KafkaClient:  # noqa: UP007
+def get_connection(connection: Union[KafkaConnectionConfig, RedpandaConnection]) -> KafkaClient:  # noqa: UP007
     """
     Create connection
     """
@@ -119,7 +120,7 @@ def get_connection(connection: Union[KafkaConnection, RedpandaConnection]) -> Ka
 def test_connection(
     metadata: OpenMetadata,
     client: KafkaClient,
-    service_connection: Union[KafkaConnection, RedpandaConnection],  # noqa: UP007
+    service_connection: Union[KafkaConnectionConfig, RedpandaConnection],  # noqa: UP007
     automation_workflow: Optional[AutomationWorkflow] = None,  # noqa: UP045
     timeout_seconds: Optional[int] = THREE_MIN,  # noqa: UP045
 ) -> TestConnectionResult:
@@ -158,3 +159,22 @@ def test_connection(
         automation_workflow=automation_workflow,
         timeout_seconds=timeout_seconds,
     )
+
+
+class KafkaConnection(BaseConnection[KafkaConnectionConfig, KafkaClient]):
+    def _get_client(self) -> KafkaClient:
+        return get_connection(self.service_connection)
+
+    def test_connection(
+        self,
+        metadata: OpenMetadata,
+        automation_workflow: Optional[AutomationWorkflow] = None,  # noqa: UP045
+        timeout_seconds: Optional[int] = THREE_MIN,  # noqa: UP045
+    ) -> TestConnectionResult:
+        return test_connection(
+            metadata,
+            self.client,
+            self.service_connection,
+            automation_workflow,
+            timeout_seconds,
+        )

--- a/ingestion/src/metadata/ingestion/source/messaging/kafka/service_spec.py
+++ b/ingestion/src/metadata/ingestion/source/messaging/kafka/service_spec.py
@@ -1,4 +1,5 @@
+from metadata.ingestion.source.messaging.kafka.connection import KafkaConnection
 from metadata.ingestion.source.messaging.kafka.metadata import KafkaSource
 from metadata.utils.service_spec import BaseSpec
 
-ServiceSpec = BaseSpec(metadata_source_class=KafkaSource)
+ServiceSpec = BaseSpec(metadata_source_class=KafkaSource, connection_class=KafkaConnection)  # pyright: ignore[reportArgumentType]

--- a/ingestion/src/metadata/ingestion/source/messaging/kinesis/connection.py
+++ b/ingestion/src/metadata/ingestion/source/messaging/kinesis/connection.py
@@ -13,18 +13,19 @@
 Source connection handler
 """
 
-from typing import Optional
+from typing import Any, Optional
 
 from metadata.clients.aws_client import AWSClient
 from metadata.generated.schema.entity.automations.workflow import (
     Workflow as AutomationWorkflow,
 )
 from metadata.generated.schema.entity.services.connections.messaging.kinesisConnection import (
-    KinesisConnection,
+    KinesisConnection as KinesisConnectionConfig,
 )
 from metadata.generated.schema.entity.services.connections.testConnectionResult import (
     TestConnectionResult,
 )
+from metadata.ingestion.connections.connection import BaseConnection
 from metadata.ingestion.connections.test_connections import test_connection_steps
 from metadata.ingestion.ometa.ometa_api import OpenMetadata
 from metadata.utils.constants import THREE_MIN
@@ -33,31 +34,30 @@ from metadata.utils.logger import ingestion_logger
 logger = ingestion_logger()
 
 
-def get_connection(connection: KinesisConnection):
-    """
-    Create connection
-    """
-    return AWSClient(connection.awsConfig).get_kinesis_client()
+class KinesisConnection(BaseConnection[KinesisConnectionConfig, Any]):
+    def _get_client(self) -> Any:
+        connection = self.service_connection
+        return AWSClient(connection.awsConfig).get_kinesis_client()
 
+    def test_connection(
+        self,
+        metadata: OpenMetadata,
+        automation_workflow: Optional[AutomationWorkflow] = None,  # noqa: UP045
+        timeout_seconds: Optional[int] = THREE_MIN,  # noqa: UP045
+    ) -> TestConnectionResult:
+        """
+        Test connection. This can be executed either as part
+        of a metadata workflow or during an Automation Workflow
+        """
+        client = self.client
+        service_connection = self.service_connection
 
-def test_connection(
-    metadata: OpenMetadata,
-    client,
-    service_connection: KinesisConnection,
-    automation_workflow: Optional[AutomationWorkflow] = None,  # noqa: UP045
-    timeout_seconds: Optional[int] = THREE_MIN,  # noqa: UP045
-) -> TestConnectionResult:
-    """
-    Test connection. This can be executed either as part
-    of a metadata workflow or during an Automation Workflow
-    """
+        test_fn = {"GetTopics": client.list_streams}
 
-    test_fn = {"GetTopics": client.list_streams}
-
-    return test_connection_steps(
-        metadata=metadata,
-        test_fn=test_fn,
-        service_type=service_connection.type.value,
-        automation_workflow=automation_workflow,
-        timeout_seconds=timeout_seconds,
-    )
+        return test_connection_steps(
+            metadata=metadata,
+            test_fn=test_fn,
+            service_type=service_connection.type.value,  # pyright: ignore[reportOptionalMemberAccess]
+            automation_workflow=automation_workflow,
+            timeout_seconds=timeout_seconds,
+        )

--- a/ingestion/src/metadata/ingestion/source/messaging/kinesis/service_spec.py
+++ b/ingestion/src/metadata/ingestion/source/messaging/kinesis/service_spec.py
@@ -1,4 +1,5 @@
+from metadata.ingestion.source.messaging.kinesis.connection import KinesisConnection
 from metadata.ingestion.source.messaging.kinesis.metadata import KinesisSource
 from metadata.utils.service_spec import BaseSpec
 
-ServiceSpec = BaseSpec(metadata_source_class=KinesisSource)
+ServiceSpec = BaseSpec(metadata_source_class=KinesisSource, connection_class=KinesisConnection)  # pyright: ignore[reportArgumentType]

--- a/ingestion/src/metadata/ingestion/source/messaging/pubsub/connection.py
+++ b/ingestion/src/metadata/ingestion/source/messaging/pubsub/connection.py
@@ -24,7 +24,7 @@ from metadata.generated.schema.entity.automations.workflow import (
     Workflow as AutomationWorkflow,
 )
 from metadata.generated.schema.entity.services.connections.messaging.pubSubConnection import (
-    PubSubConnection,
+    PubSubConnection as PubSubConnectionConfig,
 )
 from metadata.generated.schema.entity.services.connections.testConnectionResult import (
     TestConnectionResult,
@@ -33,6 +33,7 @@ from metadata.generated.schema.security.credentials.gcpValues import (
     GcpCredentialsValues,
     SingleProjectId,
 )
+from metadata.ingestion.connections.connection import BaseConnection
 from metadata.ingestion.connections.test_connections import test_connection_steps
 from metadata.ingestion.ometa.ometa_api import OpenMetadata
 from metadata.utils.constants import THREE_MIN
@@ -52,7 +53,7 @@ class PubSubClient:
     project_id: str
 
 
-def _get_project_id(connection: PubSubConnection) -> Optional[str]:  # noqa: UP045
+def _get_project_id(connection: PubSubConnectionConfig) -> Optional[str]:  # noqa: UP045
     """
     Get project ID from connection config or from credentials.
     Returns None if project ID cannot be determined.
@@ -82,7 +83,7 @@ def _get_project_id(connection: PubSubConnection) -> Optional[str]:  # noqa: UP0
     return None
 
 
-def get_connection(connection: PubSubConnection) -> PubSubClient:
+def get_connection(connection: PubSubConnectionConfig) -> PubSubClient:
     """
     Create Pub/Sub client connection.
 
@@ -127,44 +128,49 @@ def get_connection(connection: PubSubConnection) -> PubSubClient:
             del os.environ[PUBSUB_EMULATOR_HOST]
 
 
-def test_connection(
-    metadata: OpenMetadata,
-    client: PubSubClient,
-    service_connection: PubSubConnection,
-    automation_workflow: Optional[AutomationWorkflow] = None,  # noqa: UP045
-    timeout_seconds: Optional[int] = THREE_MIN,  # noqa: UP045
-) -> TestConnectionResult:
-    """
-    Test connection. This can be executed either as part
-    of a metadata workflow or during an Automation Workflow
-    """
+class PubSubConnection(BaseConnection[PubSubConnectionConfig, PubSubClient]):
+    def _get_client(self) -> PubSubClient:
+        return get_connection(self.service_connection)
 
-    def list_topics_test():
-        project_path = f"projects/{client.project_id}"
-        try:
-            topics_iter = client.publisher.list_topics(request={"project": project_path})
-            next(iter(topics_iter), None)
-        except GoogleAPIError as err:  # noqa: TRY203
-            raise err  # noqa: TRY201
+    def test_connection(
+        self,
+        metadata: OpenMetadata,
+        automation_workflow: Optional[AutomationWorkflow] = None,  # noqa: UP045
+        timeout_seconds: Optional[int] = THREE_MIN,  # noqa: UP045
+    ) -> TestConnectionResult:
+        """
+        Test connection. This can be executed either as part
+        of a metadata workflow or during an Automation Workflow
+        """
+        client = self.client
+        service_connection = self.service_connection
 
-    def schema_registry_test():
-        if client.schema_client:
+        def list_topics_test():
             project_path = f"projects/{client.project_id}"
             try:
-                schemas_iter = client.schema_client.list_schemas(request={"parent": project_path})
-                next(iter(schemas_iter), None)
+                topics_iter = client.publisher.list_topics(request={"project": project_path})
+                next(iter(topics_iter), None)
             except GoogleAPIError as err:  # noqa: TRY203
                 raise err  # noqa: TRY201
 
-    test_fn = {
-        "GetTopics": list_topics_test,
-        "CheckSchemaRegistry": schema_registry_test,
-    }
+        def schema_registry_test():
+            if client.schema_client:
+                project_path = f"projects/{client.project_id}"
+                try:
+                    schemas_iter = client.schema_client.list_schemas(request={"parent": project_path})
+                    next(iter(schemas_iter), None)
+                except GoogleAPIError as err:  # noqa: TRY203
+                    raise err  # noqa: TRY201
 
-    return test_connection_steps(
-        metadata=metadata,
-        test_fn=test_fn,
-        service_type=service_connection.type.value,
-        automation_workflow=automation_workflow,
-        timeout_seconds=timeout_seconds,
-    )
+        test_fn = {
+            "GetTopics": list_topics_test,
+            "CheckSchemaRegistry": schema_registry_test,
+        }
+
+        return test_connection_steps(
+            metadata=metadata,
+            test_fn=test_fn,
+            service_type=service_connection.type.value,  # pyright: ignore[reportOptionalMemberAccess]
+            automation_workflow=automation_workflow,
+            timeout_seconds=timeout_seconds,
+        )

--- a/ingestion/src/metadata/ingestion/source/messaging/redpanda/connection.py
+++ b/ingestion/src/metadata/ingestion/source/messaging/redpanda/connection.py
@@ -19,11 +19,12 @@ from metadata.generated.schema.entity.automations.workflow import (
     Workflow as AutomationWorkflow,
 )
 from metadata.generated.schema.entity.services.connections.messaging.redpandaConnection import (
-    RedpandaConnection,
+    RedpandaConnection as RedpandaConnectionConfig,
 )
 from metadata.generated.schema.entity.services.connections.testConnectionResult import (
     TestConnectionResult,
 )
+from metadata.ingestion.connections.connection import BaseConnection
 from metadata.ingestion.ometa.ometa_api import OpenMetadata
 from metadata.ingestion.source.messaging.kafka.connection import KafkaClient
 from metadata.ingestion.source.messaging.kafka.connection import (
@@ -38,29 +39,20 @@ from metadata.utils.logger import ingestion_logger
 logger = ingestion_logger()
 
 
-def get_connection(connection: RedpandaConnection) -> KafkaClient:
-    """
-    Create connection
-    """
-    return get_kafka_connection(connection)
+class RedpandaConnection(BaseConnection[RedpandaConnectionConfig, KafkaClient]):
+    def _get_client(self) -> KafkaClient:
+        return get_kafka_connection(self.service_connection)
 
-
-def test_connection(
-    metadata: OpenMetadata,
-    client: KafkaClient,
-    service_connection: RedpandaConnection,
-    automation_workflow: Optional[AutomationWorkflow] = None,  # noqa: UP045
-    timeout_seconds: Optional[int] = THREE_MIN,  # noqa: UP045
-) -> TestConnectionResult:
-    """
-    Test connection. This can be executed either as part
-    of a metadata workflow or during an Automation Workflow
-    """
-
-    return test_kafka_connection(
-        metadata=metadata,
-        client=client,
-        service_connection=service_connection,
-        automation_workflow=automation_workflow,
-        timeout_seconds=timeout_seconds,
-    )
+    def test_connection(
+        self,
+        metadata: OpenMetadata,
+        automation_workflow: Optional[AutomationWorkflow] = None,  # noqa: UP045
+        timeout_seconds: Optional[int] = THREE_MIN,  # noqa: UP045
+    ) -> TestConnectionResult:
+        return test_kafka_connection(
+            metadata=metadata,
+            client=self.client,
+            service_connection=self.service_connection,
+            automation_workflow=automation_workflow,
+            timeout_seconds=timeout_seconds,
+        )

--- a/ingestion/src/metadata/ingestion/source/messaging/redpanda/service_spec.py
+++ b/ingestion/src/metadata/ingestion/source/messaging/redpanda/service_spec.py
@@ -1,4 +1,5 @@
+from metadata.ingestion.source.messaging.redpanda.connection import RedpandaConnection
 from metadata.ingestion.source.messaging.redpanda.metadata import RedpandaSource
 from metadata.utils.service_spec import BaseSpec
 
-ServiceSpec = BaseSpec(metadata_source_class=RedpandaSource)
+ServiceSpec = BaseSpec(metadata_source_class=RedpandaSource, connection_class=RedpandaConnection)  # pyright: ignore[reportArgumentType]

--- a/ingestion/src/metadata/ingestion/source/metadata/alationsink/connection.py
+++ b/ingestion/src/metadata/ingestion/source/metadata/alationsink/connection.py
@@ -19,42 +19,42 @@ from metadata.generated.schema.entity.automations.workflow import (
     Workflow as AutomationWorkflow,
 )
 from metadata.generated.schema.entity.services.connections.metadata.alationSinkConnection import (
-    AlationSinkConnection,
+    AlationSinkConnection as AlationSinkConnectionConfig,
 )
 from metadata.generated.schema.entity.services.connections.testConnectionResult import (
     TestConnectionResult,
 )
+from metadata.ingestion.connections.connection import BaseConnection
 from metadata.ingestion.connections.test_connections import test_connection_steps
 from metadata.ingestion.ometa.ometa_api import OpenMetadata
 from metadata.ingestion.source.metadata.alationsink.client import AlationSinkClient
 from metadata.utils.constants import THREE_MIN
 
 
-def get_connection(connection: AlationSinkConnection) -> AlationSinkClient:
-    """
-    Create connection
-    """
-    return AlationSinkClient(connection)
+class AlationSinkConnection(BaseConnection[AlationSinkConnectionConfig, AlationSinkClient]):
+    def _get_client(self) -> AlationSinkClient:
+        connection = self.service_connection
+        return AlationSinkClient(connection)
 
+    def test_connection(
+        self,
+        metadata: OpenMetadata,
+        automation_workflow: Optional[AutomationWorkflow] = None,  # noqa: UP045
+        timeout_seconds: Optional[int] = THREE_MIN,  # noqa: UP045
+    ) -> TestConnectionResult:
+        """
+        Test connection. This can be executed either as part
+        of a metadata workflow or during an Automation Workflow
+        """
+        client = self.client
+        service_connection = self.service_connection
 
-def test_connection(
-    metadata: OpenMetadata,
-    client: AlationSinkClient,
-    service_connection: AlationSinkConnection,
-    automation_workflow: Optional[AutomationWorkflow] = None,  # noqa: UP045
-    timeout_seconds: Optional[int] = THREE_MIN,  # noqa: UP045
-) -> TestConnectionResult:
-    """
-    Test connection. This can be executed either as part
-    of a metadata workflow or during an Automation Workflow
-    """
+        test_fn = {"CheckAccess": client.list_native_datasources}
 
-    test_fn = {"CheckAccess": client.list_native_datasources}
-
-    return test_connection_steps(
-        metadata=metadata,
-        test_fn=test_fn,
-        service_type=service_connection.type.value,
-        automation_workflow=automation_workflow,
-        timeout_seconds=timeout_seconds,
-    )
+        return test_connection_steps(
+            metadata=metadata,
+            test_fn=test_fn,
+            service_type=service_connection.type.value,  # pyright: ignore[reportOptionalMemberAccess]
+            automation_workflow=automation_workflow,
+            timeout_seconds=timeout_seconds,
+        )

--- a/ingestion/src/metadata/ingestion/source/metadata/alationsink/service_spec.py
+++ b/ingestion/src/metadata/ingestion/source/metadata/alationsink/service_spec.py
@@ -1,4 +1,5 @@
+from metadata.ingestion.source.metadata.alationsink.connection import AlationSinkConnection
 from metadata.ingestion.source.metadata.alationsink.metadata import AlationsinkSource
 from metadata.utils.service_spec import BaseSpec
 
-ServiceSpec = BaseSpec(metadata_source_class=AlationsinkSource)
+ServiceSpec = BaseSpec(metadata_source_class=AlationsinkSource, connection_class=AlationSinkConnection)  # pyright: ignore[reportArgumentType]

--- a/ingestion/src/metadata/ingestion/source/metadata/amundsen/connection.py
+++ b/ingestion/src/metadata/ingestion/source/metadata/amundsen/connection.py
@@ -20,11 +20,12 @@ from metadata.generated.schema.entity.automations.workflow import (
     Workflow as AutomationWorkflow,
 )
 from metadata.generated.schema.entity.services.connections.metadata.amundsenConnection import (
-    AmundsenConnection,
+    AmundsenConnection as AmundsenConnectionConfig,
 )
 from metadata.generated.schema.entity.services.connections.testConnectionResult import (
     TestConnectionResult,
 )
+from metadata.ingestion.connections.connection import BaseConnection
 from metadata.ingestion.connections.test_connections import (
     SourceConnectionException,
     test_connection_steps,
@@ -37,43 +38,42 @@ from metadata.ingestion.source.metadata.amundsen.queries import (
 from metadata.utils.constants import THREE_MIN
 
 
-def get_connection(connection: AmundsenConnection) -> Neo4jHelper:
-    """
-    Create connection
-    """
-    try:
-        neo4j_config = Neo4JConfig(
-            username=connection.username,
-            password=connection.password.get_secret_value(),
-            neo4j_url=str(connection.hostPort),
-            max_connection_life_time=connection.maxConnectionLifeTime,
-            neo4j_encrypted=connection.encrypted,
-            neo4j_validate_ssl=connection.validateSSL,
+class AmundsenConnection(BaseConnection[AmundsenConnectionConfig, Neo4jHelper]):
+    def _get_client(self) -> Neo4jHelper:
+        connection = self.service_connection
+        try:
+            neo4j_config = Neo4JConfig(
+                username=connection.username,
+                password=connection.password.get_secret_value(),
+                neo4j_url=str(connection.hostPort),
+                max_connection_life_time=connection.maxConnectionLifeTime,  # pyright: ignore[reportArgumentType]
+                neo4j_encrypted=connection.encrypted,  # pyright: ignore[reportArgumentType]
+                neo4j_validate_ssl=connection.validateSSL,  # pyright: ignore[reportArgumentType]
+            )
+            return Neo4jHelper(neo4j_config)
+        except Exception as exc:
+            msg = f"Unknown error connecting with {connection}: {exc}."
+            raise SourceConnectionException(msg)  # noqa: B904
+
+    def test_connection(
+        self,
+        metadata: OpenMetadata,
+        automation_workflow: Optional[AutomationWorkflow] = None,  # noqa: UP045
+        timeout_seconds: Optional[int] = THREE_MIN,  # noqa: UP045
+    ) -> TestConnectionResult:
+        """
+        Test connection. This can be executed either as part
+        of a metadata workflow or during an Automation Workflow
+        """
+        client = self.client
+        service_connection = self.service_connection
+
+        test_fn = {"CheckAccess": partial(client.execute_query, query=NEO4J_AMUNDSEN_USER_QUERY)}
+
+        return test_connection_steps(
+            metadata=metadata,
+            test_fn=test_fn,
+            service_type=service_connection.type.value,  # pyright: ignore[reportOptionalMemberAccess]
+            automation_workflow=automation_workflow,
+            timeout_seconds=timeout_seconds,
         )
-        return Neo4jHelper(neo4j_config)
-    except Exception as exc:
-        msg = f"Unknown error connecting with {connection}: {exc}."
-        raise SourceConnectionException(msg)  # noqa: B904
-
-
-def test_connection(
-    metadata: OpenMetadata,
-    client: Neo4jHelper,
-    service_connection: AmundsenConnection,
-    automation_workflow: Optional[AutomationWorkflow] = None,  # noqa: UP045
-    timeout_seconds: Optional[int] = THREE_MIN,  # noqa: UP045
-) -> TestConnectionResult:
-    """
-    Test connection. This can be executed either as part
-    of a metadata workflow or during an Automation Workflow
-    """
-
-    test_fn = {"CheckAccess": partial(client.execute_query, query=NEO4J_AMUNDSEN_USER_QUERY)}
-
-    return test_connection_steps(
-        metadata=metadata,
-        test_fn=test_fn,
-        service_type=service_connection.type.value,
-        automation_workflow=automation_workflow,
-        timeout_seconds=timeout_seconds,
-    )

--- a/ingestion/src/metadata/ingestion/source/metadata/amundsen/service_spec.py
+++ b/ingestion/src/metadata/ingestion/source/metadata/amundsen/service_spec.py
@@ -1,4 +1,5 @@
+from metadata.ingestion.source.metadata.amundsen.connection import AmundsenConnection
 from metadata.ingestion.source.metadata.amundsen.metadata import AmundsenSource
 from metadata.utils.service_spec import BaseSpec
 
-ServiceSpec = BaseSpec(metadata_source_class=AmundsenSource)
+ServiceSpec = BaseSpec(metadata_source_class=AmundsenSource, connection_class=AmundsenConnection)  # pyright: ignore[reportArgumentType]

--- a/ingestion/src/metadata/ingestion/source/metadata/atlas/connection.py
+++ b/ingestion/src/metadata/ingestion/source/metadata/atlas/connection.py
@@ -19,42 +19,42 @@ from metadata.generated.schema.entity.automations.workflow import (
     Workflow as AutomationWorkflow,
 )
 from metadata.generated.schema.entity.services.connections.metadata.atlasConnection import (
-    AtlasConnection,
+    AtlasConnection as AtlasConnectionConfig,
 )
 from metadata.generated.schema.entity.services.connections.testConnectionResult import (
     TestConnectionResult,
 )
+from metadata.ingestion.connections.connection import BaseConnection
 from metadata.ingestion.connections.test_connections import test_connection_steps
 from metadata.ingestion.ometa.ometa_api import OpenMetadata
 from metadata.ingestion.source.metadata.atlas.client import AtlasClient
 from metadata.utils.constants import THREE_MIN
 
 
-def get_connection(connection: AtlasConnection) -> AtlasClient:
-    """
-    Create connection
-    """
-    return AtlasClient(connection)
+class AtlasConnection(BaseConnection[AtlasConnectionConfig, AtlasClient]):
+    def _get_client(self) -> AtlasClient:
+        connection = self.service_connection
+        return AtlasClient(connection)
 
+    def test_connection(
+        self,
+        metadata: OpenMetadata,
+        automation_workflow: Optional[AutomationWorkflow] = None,  # noqa: UP045
+        timeout_seconds: Optional[int] = THREE_MIN,  # noqa: UP045
+    ) -> TestConnectionResult:
+        """
+        Test connection. This can be executed either as part
+        of a metadata workflow or during an Automation Workflow
+        """
+        client = self.client
+        service_connection = self.service_connection
 
-def test_connection(
-    metadata: OpenMetadata,
-    client: AtlasClient,
-    service_connection: AtlasConnection,
-    automation_workflow: Optional[AutomationWorkflow] = None,  # noqa: UP045
-    timeout_seconds: Optional[int] = THREE_MIN,  # noqa: UP045
-) -> TestConnectionResult:
-    """
-    Test connection. This can be executed either as part
-    of a metadata workflow or during an Automation Workflow
-    """
+        test_fn = {"CheckAccess": client.list_entities}
 
-    test_fn = {"CheckAccess": client.list_entities}
-
-    return test_connection_steps(
-        metadata=metadata,
-        test_fn=test_fn,
-        service_type=service_connection.type.value,
-        automation_workflow=automation_workflow,
-        timeout_seconds=timeout_seconds,
-    )
+        return test_connection_steps(
+            metadata=metadata,
+            test_fn=test_fn,
+            service_type=service_connection.type.value,  # pyright: ignore[reportOptionalMemberAccess]
+            automation_workflow=automation_workflow,
+            timeout_seconds=timeout_seconds,
+        )

--- a/ingestion/src/metadata/ingestion/source/metadata/atlas/service_spec.py
+++ b/ingestion/src/metadata/ingestion/source/metadata/atlas/service_spec.py
@@ -1,4 +1,5 @@
+from metadata.ingestion.source.metadata.atlas.connection import AtlasConnection
 from metadata.ingestion.source.metadata.atlas.metadata import AtlasSource
 from metadata.utils.service_spec import BaseSpec
 
-ServiceSpec = BaseSpec(metadata_source_class=AtlasSource)
+ServiceSpec = BaseSpec(metadata_source_class=AtlasSource, connection_class=AtlasConnection)  # pyright: ignore[reportArgumentType]

--- a/ingestion/src/metadata/ingestion/source/mlmodel/mlflow/connection.py
+++ b/ingestion/src/metadata/ingestion/source/mlmodel/mlflow/connection.py
@@ -21,44 +21,44 @@ from metadata.generated.schema.entity.automations.workflow import (
     Workflow as AutomationWorkflow,
 )
 from metadata.generated.schema.entity.services.connections.mlmodel.mlflowConnection import (
-    MlflowConnection,
+    MlflowConnection as MlflowConnectionConfig,
 )
 from metadata.generated.schema.entity.services.connections.testConnectionResult import (
     TestConnectionResult,
 )
+from metadata.ingestion.connections.connection import BaseConnection
 from metadata.ingestion.connections.test_connections import test_connection_steps
 from metadata.ingestion.ometa.ometa_api import OpenMetadata
 from metadata.utils.constants import THREE_MIN
 
 
-def get_connection(connection: MlflowConnection) -> MlflowClient:
-    """
-    Create connection
-    """
-    return MlflowClient(
-        tracking_uri=connection.trackingUri,
-        registry_uri=connection.registryUri,
-    )
+class MlflowConnection(BaseConnection[MlflowConnectionConfig, MlflowClient]):
+    def _get_client(self) -> MlflowClient:
+        connection = self.service_connection
+        return MlflowClient(
+            tracking_uri=connection.trackingUri,
+            registry_uri=connection.registryUri,
+        )
 
+    def test_connection(
+        self,
+        metadata: OpenMetadata,
+        automation_workflow: Optional[AutomationWorkflow] = None,  # noqa: UP045
+        timeout_seconds: Optional[int] = THREE_MIN,  # noqa: UP045
+    ) -> TestConnectionResult:
+        """
+        Test connection. This can be executed either as part
+        of a metadata workflow or during an Automation Workflow
+        """
+        client = self.client
+        service_connection = self.service_connection
 
-def test_connection(
-    metadata: OpenMetadata,
-    client: MlflowClient,
-    service_connection: MlflowConnection,
-    automation_workflow: Optional[AutomationWorkflow] = None,  # noqa: UP045
-    timeout_seconds: Optional[int] = THREE_MIN,  # noqa: UP045
-) -> TestConnectionResult:
-    """
-    Test connection. This can be executed either as part
-    of a metadata workflow or during an Automation Workflow
-    """
+        test_fn = {"GetModels": client.search_registered_models}
 
-    test_fn = {"GetModels": client.search_registered_models}
-
-    return test_connection_steps(
-        metadata=metadata,
-        test_fn=test_fn,
-        service_type=service_connection.type.value,
-        automation_workflow=automation_workflow,
-        timeout_seconds=timeout_seconds,
-    )
+        return test_connection_steps(
+            metadata=metadata,
+            test_fn=test_fn,
+            service_type=service_connection.type.value,  # pyright: ignore[reportOptionalMemberAccess]
+            automation_workflow=automation_workflow,
+            timeout_seconds=timeout_seconds,
+        )

--- a/ingestion/src/metadata/ingestion/source/mlmodel/mlflow/service_spec.py
+++ b/ingestion/src/metadata/ingestion/source/mlmodel/mlflow/service_spec.py
@@ -1,4 +1,5 @@
+from metadata.ingestion.source.mlmodel.mlflow.connection import MlflowConnection
 from metadata.ingestion.source.mlmodel.mlflow.metadata import MlflowSource
 from metadata.utils.service_spec import BaseSpec
 
-ServiceSpec = BaseSpec(metadata_source_class=MlflowSource)
+ServiceSpec = BaseSpec(metadata_source_class=MlflowSource, connection_class=MlflowConnection)  # pyright: ignore[reportArgumentType]

--- a/ingestion/src/metadata/ingestion/source/mlmodel/sagemaker/connection.py
+++ b/ingestion/src/metadata/ingestion/source/mlmodel/sagemaker/connection.py
@@ -13,48 +13,48 @@
 Source connection handler
 """
 
-from typing import Optional
+from typing import Any, Optional
 
 from metadata.clients.aws_client import AWSClient
 from metadata.generated.schema.entity.automations.workflow import (
     Workflow as AutomationWorkflow,
 )
 from metadata.generated.schema.entity.services.connections.mlmodel.sageMakerConnection import (
-    SageMakerConnection,
+    SageMakerConnection as SageMakerConnectionConfig,
 )
 from metadata.generated.schema.entity.services.connections.testConnectionResult import (
     TestConnectionResult,
 )
+from metadata.ingestion.connections.connection import BaseConnection
 from metadata.ingestion.connections.test_connections import test_connection_steps
 from metadata.ingestion.ometa.ometa_api import OpenMetadata
 from metadata.utils.constants import THREE_MIN
 
 
-def get_connection(connection: SageMakerConnection):
-    """
-    Create connection
-    """
-    return AWSClient(connection.awsConfig).get_sagemaker_client()
+class SageMakerConnection(BaseConnection[SageMakerConnectionConfig, Any]):
+    def _get_client(self) -> Any:
+        connection = self.service_connection
+        return AWSClient(connection.awsConfig).get_sagemaker_client()
 
+    def test_connection(
+        self,
+        metadata: OpenMetadata,
+        automation_workflow: Optional[AutomationWorkflow] = None,  # noqa: UP045
+        timeout_seconds: Optional[int] = THREE_MIN,  # noqa: UP045
+    ) -> TestConnectionResult:
+        """
+        Test connection. This can be executed either as part
+        of a metadata workflow or during an Automation Workflow
+        """
+        client = self.client
+        service_connection = self.service_connection
 
-def test_connection(
-    metadata: OpenMetadata,
-    client,
-    service_connection: SageMakerConnection,
-    automation_workflow: Optional[AutomationWorkflow] = None,  # noqa: UP045
-    timeout_seconds: Optional[int] = THREE_MIN,  # noqa: UP045
-) -> TestConnectionResult:
-    """
-    Test connection. This can be executed either as part
-    of a metadata workflow or during an Automation Workflow
-    """
+        test_fn = {"GetModels": client.list_models}
 
-    test_fn = {"GetModels": client.list_models}
-
-    return test_connection_steps(
-        metadata=metadata,
-        test_fn=test_fn,
-        service_type=service_connection.type.value,
-        automation_workflow=automation_workflow,
-        timeout_seconds=timeout_seconds,
-    )
+        return test_connection_steps(
+            metadata=metadata,
+            test_fn=test_fn,
+            service_type=service_connection.type.value,  # pyright: ignore[reportOptionalMemberAccess]
+            automation_workflow=automation_workflow,
+            timeout_seconds=timeout_seconds,
+        )

--- a/ingestion/src/metadata/ingestion/source/mlmodel/sagemaker/service_spec.py
+++ b/ingestion/src/metadata/ingestion/source/mlmodel/sagemaker/service_spec.py
@@ -1,4 +1,5 @@
+from metadata.ingestion.source.mlmodel.sagemaker.connection import SageMakerConnection
 from metadata.ingestion.source.mlmodel.sagemaker.metadata import SagemakerSource
 from metadata.utils.service_spec import BaseSpec
 
-ServiceSpec = BaseSpec(metadata_source_class=SagemakerSource)
+ServiceSpec = BaseSpec(metadata_source_class=SagemakerSource, connection_class=SageMakerConnection)  # pyright: ignore[reportArgumentType]

--- a/ingestion/tests/unit/source/__init__.py
+++ b/ingestion/tests/unit/source/__init__.py
@@ -8,12 +8,3 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-"""
-Pub/Sub service spec
-"""
-
-from metadata.ingestion.source.messaging.pubsub.connection import PubSubConnection
-from metadata.ingestion.source.messaging.pubsub.metadata import PubsubSource
-from metadata.utils.service_spec import BaseSpec
-
-ServiceSpec = BaseSpec(metadata_source_class=PubsubSource, connection_class=PubSubConnection)  # pyright: ignore[reportArgumentType]

--- a/ingestion/tests/unit/source/messaging/kafka/__init__.py
+++ b/ingestion/tests/unit/source/messaging/kafka/__init__.py
@@ -8,12 +8,3 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-"""
-Pub/Sub service spec
-"""
-
-from metadata.ingestion.source.messaging.pubsub.connection import PubSubConnection
-from metadata.ingestion.source.messaging.pubsub.metadata import PubsubSource
-from metadata.utils.service_spec import BaseSpec
-
-ServiceSpec = BaseSpec(metadata_source_class=PubsubSource, connection_class=PubSubConnection)  # pyright: ignore[reportArgumentType]

--- a/ingestion/tests/unit/source/messaging/kafka/test_connection.py
+++ b/ingestion/tests/unit/source/messaging/kafka/test_connection.py
@@ -1,0 +1,40 @@
+#  Copyright 2025 Collate
+#  Licensed under the Collate Community License, Version 1.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  https://github.com/open-metadata/OpenMetadata/blob/main/ingestion/LICENSE
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+"""Unit tests for Kafka connection handling."""
+
+from unittest.mock import MagicMock, patch
+
+from metadata.ingestion.connections.connection import BaseConnection
+from metadata.ingestion.source.messaging.kafka.connection import KafkaConnection
+
+CONNECTION_MODULE = "metadata.ingestion.source.messaging.kafka.connection"
+
+
+def test_kafka_connection_is_base_connection():
+    assert issubclass(KafkaConnection, BaseConnection)
+
+
+def test_get_client_delegates_to_get_connection():
+    with patch(f"{CONNECTION_MODULE}.get_connection") as mock_get:
+        conn = KafkaConnection(MagicMock())
+        client = conn.client
+
+    assert client is mock_get.return_value
+    mock_get.assert_called_once_with(conn.service_connection)
+
+
+def test_test_connection_runs_steps():
+    conn = KafkaConnection(MagicMock())
+    conn._client = MagicMock()
+    with patch(f"{CONNECTION_MODULE}.test_connection_steps") as mock_step:
+        result = conn.test_connection(metadata=MagicMock())
+
+    assert result is mock_step.return_value

--- a/ingestion/tests/unit/source/messaging/kinesis/__init__.py
+++ b/ingestion/tests/unit/source/messaging/kinesis/__init__.py
@@ -8,12 +8,3 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-"""
-Pub/Sub service spec
-"""
-
-from metadata.ingestion.source.messaging.pubsub.connection import PubSubConnection
-from metadata.ingestion.source.messaging.pubsub.metadata import PubsubSource
-from metadata.utils.service_spec import BaseSpec
-
-ServiceSpec = BaseSpec(metadata_source_class=PubsubSource, connection_class=PubSubConnection)  # pyright: ignore[reportArgumentType]

--- a/ingestion/tests/unit/source/messaging/kinesis/test_connection.py
+++ b/ingestion/tests/unit/source/messaging/kinesis/test_connection.py
@@ -1,0 +1,40 @@
+#  Copyright 2025 Collate
+#  Licensed under the Collate Community License, Version 1.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  https://github.com/open-metadata/OpenMetadata/blob/main/ingestion/LICENSE
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+"""Unit tests for Kinesis connection handling."""
+
+from unittest.mock import MagicMock, patch
+
+from metadata.ingestion.connections.connection import BaseConnection
+from metadata.ingestion.source.messaging.kinesis.connection import KinesisConnection
+
+CONNECTION_MODULE = "metadata.ingestion.source.messaging.kinesis.connection"
+
+
+def test_kinesis_connection_is_base_connection():
+    assert issubclass(KinesisConnection, BaseConnection)
+
+
+def test_get_client_builds_aws_client():
+    with patch(f"{CONNECTION_MODULE}.AWSClient") as mock_aws:
+        conn = KinesisConnection(MagicMock())
+        client = conn.client
+
+    assert client is mock_aws.return_value.get_kinesis_client.return_value
+    mock_aws.assert_called_once()
+
+
+def test_test_connection_runs_steps():
+    conn = KinesisConnection(MagicMock())
+    conn._client = MagicMock()
+    with patch(f"{CONNECTION_MODULE}.test_connection_steps") as mock_step:
+        result = conn.test_connection(metadata=MagicMock())
+
+    assert result is mock_step.return_value

--- a/ingestion/tests/unit/source/messaging/pubsub/__init__.py
+++ b/ingestion/tests/unit/source/messaging/pubsub/__init__.py
@@ -8,12 +8,3 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-"""
-Pub/Sub service spec
-"""
-
-from metadata.ingestion.source.messaging.pubsub.connection import PubSubConnection
-from metadata.ingestion.source.messaging.pubsub.metadata import PubsubSource
-from metadata.utils.service_spec import BaseSpec
-
-ServiceSpec = BaseSpec(metadata_source_class=PubsubSource, connection_class=PubSubConnection)  # pyright: ignore[reportArgumentType]

--- a/ingestion/tests/unit/source/messaging/pubsub/test_connection.py
+++ b/ingestion/tests/unit/source/messaging/pubsub/test_connection.py
@@ -1,0 +1,40 @@
+#  Copyright 2025 Collate
+#  Licensed under the Collate Community License, Version 1.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  https://github.com/open-metadata/OpenMetadata/blob/main/ingestion/LICENSE
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+"""Unit tests for Pub/Sub connection handling."""
+
+from unittest.mock import MagicMock, patch
+
+from metadata.ingestion.connections.connection import BaseConnection
+from metadata.ingestion.source.messaging.pubsub.connection import PubSubConnection
+
+CONNECTION_MODULE = "metadata.ingestion.source.messaging.pubsub.connection"
+
+
+def test_pubsub_connection_is_base_connection():
+    assert issubclass(PubSubConnection, BaseConnection)
+
+
+def test_get_client_delegates_to_get_connection():
+    with patch(f"{CONNECTION_MODULE}.get_connection") as mock_get:
+        conn = PubSubConnection(MagicMock())
+        client = conn.client
+
+    assert client is mock_get.return_value
+    mock_get.assert_called_once_with(conn.service_connection)
+
+
+def test_test_connection_runs_steps():
+    conn = PubSubConnection(MagicMock())
+    conn._client = MagicMock()
+    with patch(f"{CONNECTION_MODULE}.test_connection_steps") as mock_step:
+        result = conn.test_connection(metadata=MagicMock())
+
+    assert result is mock_step.return_value

--- a/ingestion/tests/unit/source/messaging/redpanda/__init__.py
+++ b/ingestion/tests/unit/source/messaging/redpanda/__init__.py
@@ -8,12 +8,3 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-"""
-Pub/Sub service spec
-"""
-
-from metadata.ingestion.source.messaging.pubsub.connection import PubSubConnection
-from metadata.ingestion.source.messaging.pubsub.metadata import PubsubSource
-from metadata.utils.service_spec import BaseSpec
-
-ServiceSpec = BaseSpec(metadata_source_class=PubsubSource, connection_class=PubSubConnection)  # pyright: ignore[reportArgumentType]

--- a/ingestion/tests/unit/source/messaging/redpanda/test_connection.py
+++ b/ingestion/tests/unit/source/messaging/redpanda/test_connection.py
@@ -1,0 +1,40 @@
+#  Copyright 2025 Collate
+#  Licensed under the Collate Community License, Version 1.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  https://github.com/open-metadata/OpenMetadata/blob/main/ingestion/LICENSE
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+"""Unit tests for Redpanda connection handling."""
+
+from unittest.mock import MagicMock, patch
+
+from metadata.ingestion.connections.connection import BaseConnection
+from metadata.ingestion.source.messaging.redpanda.connection import RedpandaConnection
+
+CONNECTION_MODULE = "metadata.ingestion.source.messaging.redpanda.connection"
+
+
+def test_redpanda_connection_is_base_connection():
+    assert issubclass(RedpandaConnection, BaseConnection)
+
+
+def test_get_client_delegates_to_kafka():
+    with patch(f"{CONNECTION_MODULE}.get_kafka_connection") as mock_get:
+        conn = RedpandaConnection(MagicMock())
+        client = conn.client
+
+    assert client is mock_get.return_value
+    mock_get.assert_called_once_with(conn.service_connection)
+
+
+def test_test_connection_runs_steps():
+    conn = RedpandaConnection(MagicMock())
+    conn._client = MagicMock()
+    with patch(f"{CONNECTION_MODULE}.test_kafka_connection") as mock_step:
+        result = conn.test_connection(metadata=MagicMock())
+
+    assert result is mock_step.return_value

--- a/ingestion/tests/unit/source/metadata/__init__.py
+++ b/ingestion/tests/unit/source/metadata/__init__.py
@@ -8,12 +8,3 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-"""
-Pub/Sub service spec
-"""
-
-from metadata.ingestion.source.messaging.pubsub.connection import PubSubConnection
-from metadata.ingestion.source.messaging.pubsub.metadata import PubsubSource
-from metadata.utils.service_spec import BaseSpec
-
-ServiceSpec = BaseSpec(metadata_source_class=PubsubSource, connection_class=PubSubConnection)  # pyright: ignore[reportArgumentType]

--- a/ingestion/tests/unit/source/metadata/alationsink/__init__.py
+++ b/ingestion/tests/unit/source/metadata/alationsink/__init__.py
@@ -8,12 +8,3 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-"""
-Pub/Sub service spec
-"""
-
-from metadata.ingestion.source.messaging.pubsub.connection import PubSubConnection
-from metadata.ingestion.source.messaging.pubsub.metadata import PubsubSource
-from metadata.utils.service_spec import BaseSpec
-
-ServiceSpec = BaseSpec(metadata_source_class=PubsubSource, connection_class=PubSubConnection)  # pyright: ignore[reportArgumentType]

--- a/ingestion/tests/unit/source/metadata/alationsink/test_connection.py
+++ b/ingestion/tests/unit/source/metadata/alationsink/test_connection.py
@@ -1,0 +1,40 @@
+#  Copyright 2025 Collate
+#  Licensed under the Collate Community License, Version 1.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  https://github.com/open-metadata/OpenMetadata/blob/main/ingestion/LICENSE
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+"""Unit tests for Alation Sink connection handling."""
+
+from unittest.mock import MagicMock, patch
+
+from metadata.ingestion.connections.connection import BaseConnection
+from metadata.ingestion.source.metadata.alationsink.connection import AlationSinkConnection
+
+CONNECTION_MODULE = "metadata.ingestion.source.metadata.alationsink.connection"
+
+
+def test_alationsink_connection_is_base_connection():
+    assert issubclass(AlationSinkConnection, BaseConnection)
+
+
+def test_get_client_builds_alation_sink_client():
+    with patch(f"{CONNECTION_MODULE}.AlationSinkClient") as mock_builder:
+        conn = AlationSinkConnection(MagicMock())
+        client = conn.client
+
+    assert client is mock_builder.return_value
+    mock_builder.assert_called_once()
+
+
+def test_test_connection_runs_steps():
+    conn = AlationSinkConnection(MagicMock())
+    conn._client = MagicMock()
+    with patch(f"{CONNECTION_MODULE}.test_connection_steps") as mock_step:
+        result = conn.test_connection(metadata=MagicMock())
+
+    assert result is mock_step.return_value

--- a/ingestion/tests/unit/source/metadata/amundsen/__init__.py
+++ b/ingestion/tests/unit/source/metadata/amundsen/__init__.py
@@ -8,12 +8,3 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-"""
-Pub/Sub service spec
-"""
-
-from metadata.ingestion.source.messaging.pubsub.connection import PubSubConnection
-from metadata.ingestion.source.messaging.pubsub.metadata import PubsubSource
-from metadata.utils.service_spec import BaseSpec
-
-ServiceSpec = BaseSpec(metadata_source_class=PubsubSource, connection_class=PubSubConnection)  # pyright: ignore[reportArgumentType]

--- a/ingestion/tests/unit/source/metadata/amundsen/test_connection.py
+++ b/ingestion/tests/unit/source/metadata/amundsen/test_connection.py
@@ -1,0 +1,43 @@
+#  Copyright 2025 Collate
+#  Licensed under the Collate Community License, Version 1.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  https://github.com/open-metadata/OpenMetadata/blob/main/ingestion/LICENSE
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+"""Unit tests for Amundsen connection handling."""
+
+from unittest.mock import MagicMock, patch
+
+from metadata.ingestion.connections.connection import BaseConnection
+from metadata.ingestion.source.metadata.amundsen.connection import AmundsenConnection
+
+CONNECTION_MODULE = "metadata.ingestion.source.metadata.amundsen.connection"
+
+
+def test_amundsen_connection_is_base_connection():
+    assert issubclass(AmundsenConnection, BaseConnection)
+
+
+def test_get_client_builds_neo4j_helper():
+    with (
+        patch(f"{CONNECTION_MODULE}.Neo4JConfig"),
+        patch(f"{CONNECTION_MODULE}.Neo4jHelper") as mock_builder,
+    ):
+        conn = AmundsenConnection(MagicMock())
+        client = conn.client
+
+    assert client is mock_builder.return_value
+    mock_builder.assert_called_once()
+
+
+def test_test_connection_runs_steps():
+    conn = AmundsenConnection(MagicMock())
+    conn._client = MagicMock()
+    with patch(f"{CONNECTION_MODULE}.test_connection_steps") as mock_step:
+        result = conn.test_connection(metadata=MagicMock())
+
+    assert result is mock_step.return_value

--- a/ingestion/tests/unit/source/metadata/atlas/__init__.py
+++ b/ingestion/tests/unit/source/metadata/atlas/__init__.py
@@ -8,12 +8,3 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-"""
-Pub/Sub service spec
-"""
-
-from metadata.ingestion.source.messaging.pubsub.connection import PubSubConnection
-from metadata.ingestion.source.messaging.pubsub.metadata import PubsubSource
-from metadata.utils.service_spec import BaseSpec
-
-ServiceSpec = BaseSpec(metadata_source_class=PubsubSource, connection_class=PubSubConnection)  # pyright: ignore[reportArgumentType]

--- a/ingestion/tests/unit/source/metadata/atlas/test_connection.py
+++ b/ingestion/tests/unit/source/metadata/atlas/test_connection.py
@@ -1,0 +1,40 @@
+#  Copyright 2025 Collate
+#  Licensed under the Collate Community License, Version 1.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  https://github.com/open-metadata/OpenMetadata/blob/main/ingestion/LICENSE
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+"""Unit tests for Atlas connection handling."""
+
+from unittest.mock import MagicMock, patch
+
+from metadata.ingestion.connections.connection import BaseConnection
+from metadata.ingestion.source.metadata.atlas.connection import AtlasConnection
+
+CONNECTION_MODULE = "metadata.ingestion.source.metadata.atlas.connection"
+
+
+def test_atlas_connection_is_base_connection():
+    assert issubclass(AtlasConnection, BaseConnection)
+
+
+def test_get_client_builds_atlas_client():
+    with patch(f"{CONNECTION_MODULE}.AtlasClient") as mock_builder:
+        conn = AtlasConnection(MagicMock())
+        client = conn.client
+
+    assert client is mock_builder.return_value
+    mock_builder.assert_called_once()
+
+
+def test_test_connection_runs_steps():
+    conn = AtlasConnection(MagicMock())
+    conn._client = MagicMock()
+    with patch(f"{CONNECTION_MODULE}.test_connection_steps") as mock_step:
+        result = conn.test_connection(metadata=MagicMock())
+
+    assert result is mock_step.return_value

--- a/ingestion/tests/unit/source/mlmodel/__init__.py
+++ b/ingestion/tests/unit/source/mlmodel/__init__.py
@@ -8,12 +8,3 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-"""
-Pub/Sub service spec
-"""
-
-from metadata.ingestion.source.messaging.pubsub.connection import PubSubConnection
-from metadata.ingestion.source.messaging.pubsub.metadata import PubsubSource
-from metadata.utils.service_spec import BaseSpec
-
-ServiceSpec = BaseSpec(metadata_source_class=PubsubSource, connection_class=PubSubConnection)  # pyright: ignore[reportArgumentType]

--- a/ingestion/tests/unit/source/mlmodel/mlflow/__init__.py
+++ b/ingestion/tests/unit/source/mlmodel/mlflow/__init__.py
@@ -8,12 +8,3 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-"""
-Pub/Sub service spec
-"""
-
-from metadata.ingestion.source.messaging.pubsub.connection import PubSubConnection
-from metadata.ingestion.source.messaging.pubsub.metadata import PubsubSource
-from metadata.utils.service_spec import BaseSpec
-
-ServiceSpec = BaseSpec(metadata_source_class=PubsubSource, connection_class=PubSubConnection)  # pyright: ignore[reportArgumentType]

--- a/ingestion/tests/unit/source/mlmodel/mlflow/test_connection.py
+++ b/ingestion/tests/unit/source/mlmodel/mlflow/test_connection.py
@@ -1,0 +1,40 @@
+#  Copyright 2025 Collate
+#  Licensed under the Collate Community License, Version 1.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  https://github.com/open-metadata/OpenMetadata/blob/main/ingestion/LICENSE
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+"""Unit tests for MLflow connection handling."""
+
+from unittest.mock import MagicMock, patch
+
+from metadata.ingestion.connections.connection import BaseConnection
+from metadata.ingestion.source.mlmodel.mlflow.connection import MlflowConnection
+
+CONNECTION_MODULE = "metadata.ingestion.source.mlmodel.mlflow.connection"
+
+
+def test_mlflow_connection_is_base_connection():
+    assert issubclass(MlflowConnection, BaseConnection)
+
+
+def test_get_client_builds_mlflow_client():
+    with patch(f"{CONNECTION_MODULE}.MlflowClient") as mock_builder:
+        conn = MlflowConnection(MagicMock())
+        client = conn.client
+
+    assert client is mock_builder.return_value
+    mock_builder.assert_called_once()
+
+
+def test_test_connection_runs_steps():
+    conn = MlflowConnection(MagicMock())
+    conn._client = MagicMock()
+    with patch(f"{CONNECTION_MODULE}.test_connection_steps") as mock_step:
+        result = conn.test_connection(metadata=MagicMock())
+
+    assert result is mock_step.return_value

--- a/ingestion/tests/unit/source/mlmodel/sagemaker/__init__.py
+++ b/ingestion/tests/unit/source/mlmodel/sagemaker/__init__.py
@@ -8,12 +8,3 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-"""
-Pub/Sub service spec
-"""
-
-from metadata.ingestion.source.messaging.pubsub.connection import PubSubConnection
-from metadata.ingestion.source.messaging.pubsub.metadata import PubsubSource
-from metadata.utils.service_spec import BaseSpec
-
-ServiceSpec = BaseSpec(metadata_source_class=PubsubSource, connection_class=PubSubConnection)  # pyright: ignore[reportArgumentType]

--- a/ingestion/tests/unit/source/mlmodel/sagemaker/test_connection.py
+++ b/ingestion/tests/unit/source/mlmodel/sagemaker/test_connection.py
@@ -1,0 +1,40 @@
+#  Copyright 2025 Collate
+#  Licensed under the Collate Community License, Version 1.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  https://github.com/open-metadata/OpenMetadata/blob/main/ingestion/LICENSE
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+"""Unit tests for SageMaker connection handling."""
+
+from unittest.mock import MagicMock, patch
+
+from metadata.ingestion.connections.connection import BaseConnection
+from metadata.ingestion.source.mlmodel.sagemaker.connection import SageMakerConnection
+
+CONNECTION_MODULE = "metadata.ingestion.source.mlmodel.sagemaker.connection"
+
+
+def test_sagemaker_connection_is_base_connection():
+    assert issubclass(SageMakerConnection, BaseConnection)
+
+
+def test_get_client_builds_aws_client():
+    with patch(f"{CONNECTION_MODULE}.AWSClient") as mock_aws:
+        conn = SageMakerConnection(MagicMock())
+        client = conn.client
+
+    assert client is mock_aws.return_value.get_sagemaker_client.return_value
+    mock_aws.assert_called_once()
+
+
+def test_test_connection_runs_steps():
+    conn = SageMakerConnection(MagicMock())
+    conn._client = MagicMock()
+    with patch(f"{CONNECTION_MODULE}.test_connection_steps") as mock_step:
+        result = conn.test_connection(metadata=MagicMock())
+
+    assert result is mock_step.return_value


### PR DESCRIPTION
Fixes #28993

## What

Migrates the **mlmodel**, **metadata** and **messaging** connectors onto the `BaseConnection[Config, Client]` pattern, continuing the connector-wide BaseConnection rollout.

| Service | Connector | Client type | get_connection |
|---|---|---|---|
| mlmodel | mlflow | `MlflowClient` | moved into `_get_client` |
| mlmodel | sagemaker | boto3 (`Any`) | moved into `_get_client` |
| metadata | alationsink | `AlationSinkClient` | moved into `_get_client` |
| metadata | amundsen | `Neo4jHelper` | moved into `_get_client` |
| metadata | atlas | `AtlasClient` | moved into `_get_client` |
| messaging | kafka | `KafkaClient` | kept module-level (redpanda imports it) |
| messaging | kinesis | boto3 (`Any`) | moved into `_get_client` |
| messaging | pubsub | `PubSubClient` | kept module-level (unit test imports it) |
| messaging | redpanda | `KafkaClient` | delegates to kafka's `get_kafka_connection` |

## How

- Each connector gains `XConnection(BaseConnection[ConfigType, ClientType])` with `_get_client` and `test_connection`; `connection_class` is wired into each `service_spec.py`.
- The mlmodel/messaging base sources and the metadata sources already build their client and run `test_connection` through the generic resolver (`metadata.ingestion.source.connections`), so the new classes are exercised end-to-end — no source-side changes.
- **kafka/redpanda share code:** redpanda imports kafka's `get_connection`/`test_connection` (aliased) and the `KafkaClient` dataclass, so kafka keeps those module-level and its class delegates to them; redpanda's class delegates to the aliased kafka functions.
- Boto3-backed sagemaker/kinesis type the client as `Any`, matching the merged glue/dynamodb connectors.

## Tests

- Added colocated `tests/unit/source/<type>/<connector>/test_connection.py` for all nine (BaseConnection subclass, client build, test_connection dispatch).
- Existing mlmodel/messaging suites pass unchanged.
- `basedpyright` baseline check clean; `ruff` clean.

No behavior change — pure structural migration.