### PR TITLE
Fixes #28996: refactor(ingestion): migrate pipeline connectors (batch A) to BaseConnection

### DIFF
--- a/ingestion/src/metadata/ingestion/source/pipeline/airbyte/connection.py
+++ b/ingestion/src/metadata/ingestion/source/pipeline/airbyte/connection.py
@@ -22,11 +22,12 @@ from metadata.generated.schema.entity.services.connections.pipeline.airbyte.oaut
     Oauth20ClientCredentialsAuthentication,
 )
 from metadata.generated.schema.entity.services.connections.pipeline.airbyteConnection import (
-    AirbyteConnection,
+    AirbyteConnection as AirbyteConnectionConfig,
 )
 from metadata.generated.schema.entity.services.connections.testConnectionResult import (
     TestConnectionResult,
 )
+from metadata.ingestion.connections.connection import BaseConnection
 from metadata.ingestion.connections.test_connections import test_connection_steps
 from metadata.ingestion.ometa.ometa_api import OpenMetadata
 from metadata.ingestion.source.pipeline.airbyte.client import (
@@ -37,7 +38,7 @@ from metadata.utils.constants import THREE_MIN
 
 
 def get_connection(
-    connection: AirbyteConnection,
+    connection: AirbyteConnectionConfig,
 ) -> Union[AirbyteClient, AirbyteCloudClient]:  # noqa: UP007
     """
     Create connection - returns appropriate client based on auth type.
@@ -48,24 +49,29 @@ def get_connection(
     return AirbyteClient(connection)
 
 
-def test_connection(
-    metadata: OpenMetadata,
-    client: Union[AirbyteClient, AirbyteCloudClient],  # noqa: UP007
-    service_connection: AirbyteConnection,
-    automation_workflow: Optional[AutomationWorkflow] = None,  # noqa: UP045
-    timeout_seconds: Optional[int] = THREE_MIN,  # noqa: UP045
-) -> TestConnectionResult:
-    """
-    Test connection. This can be executed either as part
-    of a metadata workflow or during an Automation Workflow
-    """
+class AirbyteConnection(BaseConnection[AirbyteConnectionConfig, AirbyteClient | AirbyteCloudClient]):
+    def _get_client(self) -> AirbyteClient | AirbyteCloudClient:
+        return get_connection(self.service_connection)
 
-    test_fn = {"GetPipelines": client.list_workspaces}
+    def test_connection(
+        self,
+        metadata: OpenMetadata,
+        automation_workflow: Optional[AutomationWorkflow] = None,  # noqa: UP045
+        timeout_seconds: Optional[int] = THREE_MIN,  # noqa: UP045
+    ) -> TestConnectionResult:
+        """
+        Test connection. This can be executed either as part
+        of a metadata workflow or during an Automation Workflow
+        """
+        client = self.client
+        service_connection = self.service_connection
 
-    return test_connection_steps(
-        metadata=metadata,
-        test_fn=test_fn,
-        service_type=service_connection.type.value,
-        automation_workflow=automation_workflow,
-        timeout_seconds=timeout_seconds,
-    )
+        test_fn = {"GetPipelines": client.list_workspaces}
+
+        return test_connection_steps(
+            metadata=metadata,
+            test_fn=test_fn,
+            service_type=service_connection.type.value,  # pyright: ignore[reportOptionalMemberAccess]
+            automation_workflow=automation_workflow,
+            timeout_seconds=timeout_seconds,
+        )

--- a/ingestion/src/metadata/ingestion/source/pipeline/airbyte/service_spec.py
+++ b/ingestion/src/metadata/ingestion/source/pipeline/airbyte/service_spec.py
@@ -1,4 +1,5 @@
+from metadata.ingestion.source.pipeline.airbyte.connection import AirbyteConnection
 from metadata.ingestion.source.pipeline.airbyte.metadata import AirbyteSource
 from metadata.utils.service_spec import BaseSpec
 
-ServiceSpec = BaseSpec(metadata_source_class=AirbyteSource)
+ServiceSpec = BaseSpec(metadata_source_class=AirbyteSource, connection_class=AirbyteConnection)  # pyright: ignore[reportArgumentType]

--- a/ingestion/src/metadata/ingestion/source/pipeline/airflow/connection.py
+++ b/ingestion/src/metadata/ingestion/source/pipeline/airflow/connection.py
@@ -39,7 +39,7 @@ from metadata.generated.schema.entity.services.connections.database.sqliteConnec
     SQLiteConnection as SQLiteConnectionConfig,
 )
 from metadata.generated.schema.entity.services.connections.pipeline.airflowConnection import (
-    AirflowConnection,
+    AirflowConnection as AirflowConnectionConfig,
 )
 from metadata.generated.schema.entity.services.connections.pipeline.backendConnection import (
     BackendConnection,
@@ -47,6 +47,7 @@ from metadata.generated.schema.entity.services.connections.pipeline.backendConne
 from metadata.generated.schema.entity.services.connections.testConnectionResult import (
     TestConnectionResult,
 )
+from metadata.ingestion.connections.connection import BaseConnection
 from metadata.ingestion.connections.query_logger import attach_query_tracker
 from metadata.ingestion.connections.test_connections import (
     SourceConnectionException,
@@ -188,7 +189,7 @@ def _(airflow_connection: SQLiteConnectionConfig) -> Engine:
     return SQLiteConnection(airflow_connection)._get_client()
 
 
-def get_connection(connection: AirflowConnection):
+def get_connection(connection: AirflowConnectionConfig):
     """
     Create connection
     """
@@ -254,7 +255,7 @@ def _test_task_detail_access(session) -> Optional[Any]:  # noqa: UP045
         raise AirflowTaskDetailsAccessError(f"Task details access error : {e}") from e
 
 
-def _decorated_check_access(client, host, auth_config, verify: bool) -> Any:
+def _decorated_check_access(client, host, auth_config, verify: bool) -> Any:  # pyright: ignore[reportMissingParameterType]
     """
     Call client.get_version(); on failure, attempt a managed-flavor-specific
     diagnostic and raise SourceConnectionException with a combined message
@@ -279,7 +280,7 @@ def _decorated_check_access(client, host, auth_config, verify: bool) -> Any:
 def _test_api_connection(
     metadata: OpenMetadata,
     client,
-    service_connection: AirflowConnection,
+    service_connection: AirflowConnectionConfig,
     automation_workflow: Optional[AutomationWorkflow] = None,  # noqa: UP045
     timeout_seconds: Optional[int] = THREE_MIN,  # noqa: UP045
 ) -> TestConnectionResult:
@@ -305,7 +306,7 @@ def _test_api_connection(
 def test_connection(
     metadata: OpenMetadata,
     connection_obj,
-    service_connection: AirflowConnection,
+    service_connection: AirflowConnectionConfig,
     automation_workflow: Optional[AutomationWorkflow] = None,  # noqa: UP045
     timeout_seconds: Optional[int] = THREE_MIN,  # noqa: UP045
 ) -> TestConnectionResult:
@@ -350,3 +351,22 @@ def test_connection(
         automation_workflow=automation_workflow,
         timeout_seconds=timeout_seconds,
     )
+
+
+class AirflowConnection(BaseConnection[AirflowConnectionConfig, Any]):
+    def _get_client(self) -> Any:
+        return get_connection(self.service_connection)
+
+    def test_connection(
+        self,
+        metadata: OpenMetadata,
+        automation_workflow: Optional[AutomationWorkflow] = None,  # noqa: UP045
+        timeout_seconds: Optional[int] = THREE_MIN,  # noqa: UP045
+    ) -> TestConnectionResult:
+        return test_connection(
+            metadata,
+            self.client,
+            self.service_connection,
+            automation_workflow,
+            timeout_seconds,
+        )

--- a/ingestion/src/metadata/ingestion/source/pipeline/airflow/service_spec.py
+++ b/ingestion/src/metadata/ingestion/source/pipeline/airflow/service_spec.py
@@ -1,4 +1,5 @@
+from metadata.ingestion.source.pipeline.airflow.connection import AirflowConnection
 from metadata.ingestion.source.pipeline.airflow.metadata import AirflowSource
 from metadata.utils.service_spec import BaseSpec
 
-ServiceSpec = BaseSpec(metadata_source_class=AirflowSource)
+ServiceSpec = BaseSpec(metadata_source_class=AirflowSource, connection_class=AirflowConnection)  # pyright: ignore[reportArgumentType]

--- a/ingestion/src/metadata/ingestion/source/pipeline/dagster/connection.py
+++ b/ingestion/src/metadata/ingestion/source/pipeline/dagster/connection.py
@@ -19,11 +19,12 @@ from metadata.generated.schema.entity.automations.workflow import (
     Workflow as AutomationWorkflow,
 )
 from metadata.generated.schema.entity.services.connections.pipeline.dagsterConnection import (
-    DagsterConnection,
+    DagsterConnection as DagsterConnectionConfig,
 )
 from metadata.generated.schema.entity.services.connections.testConnectionResult import (
     TestConnectionResult,
 )
+from metadata.ingestion.connections.connection import BaseConnection
 from metadata.ingestion.connections.test_connections import test_connection_steps
 from metadata.ingestion.ometa.ometa_api import OpenMetadata
 from metadata.ingestion.source.pipeline.dagster.client import DagsterClient
@@ -31,34 +32,33 @@ from metadata.ingestion.source.pipeline.dagster.queries import TEST_QUERY_GRAPHQ
 from metadata.utils.constants import THREE_MIN
 
 
-def get_connection(connection: DagsterConnection) -> DagsterClient:
-    """
-    Create connection
-    """
-    return DagsterClient(connection)
+class DagsterConnection(BaseConnection[DagsterConnectionConfig, DagsterClient]):
+    def _get_client(self) -> DagsterClient:
+        connection = self.service_connection
+        return DagsterClient(connection)
 
+    def test_connection(
+        self,
+        metadata: OpenMetadata,
+        automation_workflow: Optional[AutomationWorkflow] = None,  # noqa: UP045
+        timeout_seconds: Optional[int] = THREE_MIN,  # noqa: UP045
+    ) -> TestConnectionResult:
+        """
+        Test connection. This can be executed either as part
+        of a metadata workflow or during an Automation Workflow
+        """
+        client = self.client
+        service_connection = self.service_connection
 
-def test_connection(
-    metadata: OpenMetadata,
-    client: DagsterClient,
-    service_connection: DagsterConnection,
-    automation_workflow: Optional[AutomationWorkflow] = None,  # noqa: UP045
-    timeout_seconds: Optional[int] = THREE_MIN,  # noqa: UP045
-) -> TestConnectionResult:
-    """
-    Test connection. This can be executed either as part
-    of a metadata workflow or during an Automation Workflow
-    """
+        def custom_executor_for_pipeline():
+            client.client._execute(TEST_QUERY_GRAPHQL)  # pylint: disable=protected-access
 
-    def custom_executor_for_pipeline():
-        client.client._execute(TEST_QUERY_GRAPHQL)  # pylint: disable=protected-access
+        test_fn = {"GetPipelines": custom_executor_for_pipeline}
 
-    test_fn = {"GetPipelines": custom_executor_for_pipeline}
-
-    return test_connection_steps(
-        metadata=metadata,
-        test_fn=test_fn,
-        service_type=service_connection.type.value,
-        automation_workflow=automation_workflow,
-        timeout_seconds=timeout_seconds,
-    )
+        return test_connection_steps(
+            metadata=metadata,
+            test_fn=test_fn,
+            service_type=service_connection.type.value,  # pyright: ignore[reportOptionalMemberAccess]
+            automation_workflow=automation_workflow,
+            timeout_seconds=timeout_seconds,
+        )

--- a/ingestion/src/metadata/ingestion/source/pipeline/dagster/service_spec.py
+++ b/ingestion/src/metadata/ingestion/source/pipeline/dagster/service_spec.py
@@ -1,4 +1,5 @@
+from metadata.ingestion.source.pipeline.dagster.connection import DagsterConnection
 from metadata.ingestion.source.pipeline.dagster.metadata import DagsterSource
 from metadata.utils.service_spec import BaseSpec
 
-ServiceSpec = BaseSpec(metadata_source_class=DagsterSource)
+ServiceSpec = BaseSpec(metadata_source_class=DagsterSource, connection_class=DagsterConnection)  # pyright: ignore[reportArgumentType]

--- a/ingestion/src/metadata/ingestion/source/pipeline/databrickspipeline/connection.py
+++ b/ingestion/src/metadata/ingestion/source/pipeline/databrickspipeline/connection.py
@@ -19,7 +19,7 @@ from metadata.generated.schema.entity.automations.workflow import (
     Workflow as AutomationWorkflow,
 )
 from metadata.generated.schema.entity.services.connections.pipeline.databricksPipelineConnection import (
-    DatabricksPipelineConnection,
+    DatabricksPipelineConnection as DatabricksPipelineConnectionConfig,
 )
 from metadata.generated.schema.entity.services.connections.testConnectionResult import (
     TestConnectionResult,
@@ -29,6 +29,7 @@ from metadata.ingestion.connections.builders import (
     get_connection_args_common,
     init_empty_connection_arguments,
 )
+from metadata.ingestion.connections.connection import BaseConnection
 from metadata.ingestion.connections.test_connections import test_connection_steps
 from metadata.ingestion.ometa.ometa_api import OpenMetadata
 from metadata.ingestion.source.database.databricks.client import DatabricksClient
@@ -40,12 +41,12 @@ from metadata.utils.constants import THREE_MIN
 suppress_user_agent_entry_deprecation_log()
 
 
-def get_connection_url(connection: DatabricksPipelineConnection) -> str:
+def get_connection_url(connection: DatabricksPipelineConnectionConfig) -> str:
     url = f"databricks://token:{connection.token.get_secret_value()}@{connection.hostPort}"
     return url  # noqa: RET504
 
 
-def get_connection(connection: DatabricksPipelineConnection) -> DatabricksClient:
+def get_connection(connection: DatabricksPipelineConnectionConfig) -> DatabricksClient:
     """
     Create connection
     """
@@ -64,27 +65,32 @@ def get_connection(connection: DatabricksPipelineConnection) -> DatabricksClient
     return DatabricksClient(connection, engine)
 
 
-def test_connection(
-    metadata: OpenMetadata,
-    client: DatabricksClient,
-    service_connection: DatabricksPipelineConnection,
-    automation_workflow: Optional[AutomationWorkflow] = None,  # noqa: UP045
-    timeout_seconds: Optional[int] = THREE_MIN,  # noqa: UP045
-) -> TestConnectionResult:
-    """
-    Test connection. This can be executed either as part
-    of a metadata workflow or during an Automation Workflow
-    """
+class DatabricksPipelineConnection(BaseConnection[DatabricksPipelineConnectionConfig, DatabricksClient]):
+    def _get_client(self) -> DatabricksClient:
+        return get_connection(self.service_connection)
 
-    test_fn = {
-        "GetPipelines": client.list_jobs_test_connection,
-        "GetLineage": client.test_lineage_query,
-    }
+    def test_connection(
+        self,
+        metadata: OpenMetadata,
+        automation_workflow: Optional[AutomationWorkflow] = None,  # noqa: UP045
+        timeout_seconds: Optional[int] = THREE_MIN,  # noqa: UP045
+    ) -> TestConnectionResult:
+        """
+        Test connection. This can be executed either as part
+        of a metadata workflow or during an Automation Workflow
+        """
+        client = self.client
+        service_connection = self.service_connection
 
-    return test_connection_steps(
-        metadata=metadata,
-        test_fn=test_fn,
-        service_type=service_connection.type.value,
-        automation_workflow=automation_workflow,
-        timeout_seconds=timeout_seconds,
-    )
+        test_fn = {
+            "GetPipelines": client.list_jobs_test_connection,
+            "GetLineage": client.test_lineage_query,
+        }
+
+        return test_connection_steps(
+            metadata=metadata,
+            test_fn=test_fn,
+            service_type=service_connection.type.value,  # pyright: ignore[reportOptionalMemberAccess]
+            automation_workflow=automation_workflow,
+            timeout_seconds=timeout_seconds,
+        )

--- a/ingestion/src/metadata/ingestion/source/pipeline/databrickspipeline/service_spec.py
+++ b/ingestion/src/metadata/ingestion/source/pipeline/databrickspipeline/service_spec.py
@@ -1,6 +1,7 @@
+from metadata.ingestion.source.pipeline.databrickspipeline.connection import DatabricksPipelineConnection
 from metadata.ingestion.source.pipeline.databrickspipeline.metadata import (
     DatabrickspipelineSource,
 )
 from metadata.utils.service_spec import BaseSpec
 
-ServiceSpec = BaseSpec(metadata_source_class=DatabrickspipelineSource)
+ServiceSpec = BaseSpec(metadata_source_class=DatabrickspipelineSource, connection_class=DatabricksPipelineConnection)  # pyright: ignore[reportArgumentType]

--- a/ingestion/src/metadata/ingestion/source/pipeline/dbtcloud/connection.py
+++ b/ingestion/src/metadata/ingestion/source/pipeline/dbtcloud/connection.py
@@ -20,45 +20,45 @@ from metadata.generated.schema.entity.automations.workflow import (
     Workflow as AutomationWorkflow,
 )
 from metadata.generated.schema.entity.services.connections.pipeline.dbtCloudConnection import (
-    DBTCloudConnection,
+    DBTCloudConnection as DBTCloudConnectionConfig,
 )
 from metadata.generated.schema.entity.services.connections.testConnectionResult import (
     TestConnectionResult,
 )
+from metadata.ingestion.connections.connection import BaseConnection
 from metadata.ingestion.connections.test_connections import test_connection_steps
 from metadata.ingestion.ometa.ometa_api import OpenMetadata
 from metadata.ingestion.source.pipeline.dbtcloud.client import DBTCloudClient
 from metadata.utils.constants import THREE_MIN
 
 
-def get_connection(connection: DBTCloudConnection) -> DBTCloudClient:
-    """
-    Create connection
-    """
-    return DBTCloudClient(connection)
+class DBTCloudConnection(BaseConnection[DBTCloudConnectionConfig, DBTCloudClient]):
+    def _get_client(self) -> DBTCloudClient:
+        connection = self.service_connection
+        return DBTCloudClient(connection)
 
+    def test_connection(
+        self,
+        metadata: OpenMetadata,
+        automation_workflow: Optional[AutomationWorkflow] = None,  # noqa: UP045
+        timeout_seconds: Optional[int] = THREE_MIN,  # noqa: UP045
+    ) -> TestConnectionResult:
+        """
+        Test connection. This can be executed either as part
+        of a metadata workflow or during an Automation Workflow
+        """
+        client = self.client
+        service_connection = self.service_connection
 
-def test_connection(
-    metadata: OpenMetadata,
-    client: DBTCloudClient,
-    service_connection: DBTCloudConnection,
-    automation_workflow: Optional[AutomationWorkflow] = None,  # noqa: UP045
-    timeout_seconds: Optional[int] = THREE_MIN,  # noqa: UP045
-) -> TestConnectionResult:
-    """
-    Test connection. This can be executed either as part
-    of a metadata workflow or during an Automation Workflow
-    """
+        test_fn = {
+            "GetJobs": client.test_get_jobs,
+            "GetRuns": partial(client.test_get_runs),
+        }
 
-    test_fn = {
-        "GetJobs": client.test_get_jobs,
-        "GetRuns": partial(client.test_get_runs),
-    }
-
-    return test_connection_steps(
-        metadata=metadata,
-        test_fn=test_fn,
-        service_type=service_connection.type.value,
-        automation_workflow=automation_workflow,
-        timeout_seconds=timeout_seconds,
-    )
+        return test_connection_steps(
+            metadata=metadata,
+            test_fn=test_fn,
+            service_type=service_connection.type.value,  # pyright: ignore[reportOptionalMemberAccess]
+            automation_workflow=automation_workflow,
+            timeout_seconds=timeout_seconds,
+        )

--- a/ingestion/src/metadata/ingestion/source/pipeline/dbtcloud/service_spec.py
+++ b/ingestion/src/metadata/ingestion/source/pipeline/dbtcloud/service_spec.py
@@ -1,4 +1,5 @@
+from metadata.ingestion.source.pipeline.dbtcloud.connection import DBTCloudConnection
 from metadata.ingestion.source.pipeline.dbtcloud.metadata import DbtcloudSource
 from metadata.utils.service_spec import BaseSpec
 
-ServiceSpec = BaseSpec(metadata_source_class=DbtcloudSource)
+ServiceSpec = BaseSpec(metadata_source_class=DbtcloudSource, connection_class=DBTCloudConnection)  # pyright: ignore[reportArgumentType]

--- a/ingestion/src/metadata/ingestion/source/pipeline/domopipeline/connection.py
+++ b/ingestion/src/metadata/ingestion/source/pipeline/domopipeline/connection.py
@@ -15,18 +15,17 @@ Source connection handler
 
 from typing import Optional
 
-from pydomo import Domo
-
 from metadata.clients.domo_client import DomoClient
 from metadata.generated.schema.entity.automations.workflow import (
     Workflow as AutomationWorkflow,
 )
 from metadata.generated.schema.entity.services.connections.pipeline.domoPipelineConnection import (
-    DomoPipelineConnection,
+    DomoPipelineConnection as DomoPipelineConnectionConfig,
 )
 from metadata.generated.schema.entity.services.connections.testConnectionResult import (
     TestConnectionResult,
 )
+from metadata.ingestion.connections.connection import BaseConnection
 from metadata.ingestion.connections.test_connections import (
     SourceConnectionException,
     test_connection_steps,
@@ -35,39 +34,38 @@ from metadata.ingestion.ometa.ometa_api import OpenMetadata
 from metadata.utils.constants import THREE_MIN
 
 
-def get_connection(connection: DomoPipelineConnection) -> Domo:
-    """
-    Create connection
-    """
-    try:
-        return DomoClient(connection)
-    except Exception as exc:
-        msg = f"Unknown error connecting with {connection}: {exc}."
-        raise SourceConnectionException(msg)  # noqa: B904
+class DomoPipelineConnection(BaseConnection[DomoPipelineConnectionConfig, DomoClient]):
+    def _get_client(self) -> DomoClient:
+        connection = self.service_connection
+        try:
+            return DomoClient(connection)
+        except Exception as exc:
+            msg = f"Unknown error connecting with {connection}: {exc}."
+            raise SourceConnectionException(msg)  # noqa: B904
 
+    def test_connection(
+        self,
+        metadata: OpenMetadata,
+        automation_workflow: Optional[AutomationWorkflow] = None,  # noqa: UP045
+        timeout_seconds: Optional[int] = THREE_MIN,  # noqa: UP045
+    ) -> TestConnectionResult:
+        """
+        Test connection. This can be executed either as part
+        of a metadata workflow or during an Automation Workflow
+        """
+        connection = self.client
+        service_connection = self.service_connection
 
-def test_connection(
-    metadata: OpenMetadata,
-    connection: Domo,
-    service_connection: DomoPipelineConnection,
-    automation_workflow: Optional[AutomationWorkflow] = None,  # noqa: UP045
-    timeout_seconds: Optional[int] = THREE_MIN,  # noqa: UP045
-) -> TestConnectionResult:
-    """
-    Test connection. This can be executed either as part
-    of a metadata workflow or during an Automation Workflow
-    """
+        def custom_executor():
+            result = connection.get_pipelines()
+            return list(result)  # pyright: ignore[reportArgumentType]
 
-    def custom_executor():
-        result = connection.get_pipelines()
-        return list(result)
+        test_fn = {"GetPipelines": custom_executor}
 
-    test_fn = {"GetPipelines": custom_executor}
-
-    return test_connection_steps(
-        metadata=metadata,
-        test_fn=test_fn,
-        service_type=service_connection.type.value,
-        automation_workflow=automation_workflow,
-        timeout_seconds=timeout_seconds,
-    )
+        return test_connection_steps(
+            metadata=metadata,
+            test_fn=test_fn,
+            service_type=service_connection.type.value,  # pyright: ignore[reportOptionalMemberAccess]
+            automation_workflow=automation_workflow,
+            timeout_seconds=timeout_seconds,
+        )

--- a/ingestion/src/metadata/ingestion/source/pipeline/domopipeline/service_spec.py
+++ b/ingestion/src/metadata/ingestion/source/pipeline/domopipeline/service_spec.py
@@ -1,4 +1,5 @@
+from metadata.ingestion.source.pipeline.domopipeline.connection import DomoPipelineConnection
 from metadata.ingestion.source.pipeline.domopipeline.metadata import DomopipelineSource
 from metadata.utils.service_spec import BaseSpec
 
-ServiceSpec = BaseSpec(metadata_source_class=DomopipelineSource)
+ServiceSpec = BaseSpec(metadata_source_class=DomopipelineSource, connection_class=DomoPipelineConnection)  # pyright: ignore[reportArgumentType]

--- a/ingestion/src/metadata/ingestion/source/pipeline/fivetran/connection.py
+++ b/ingestion/src/metadata/ingestion/source/pipeline/fivetran/connection.py
@@ -19,42 +19,48 @@ from metadata.generated.schema.entity.automations.workflow import (
     Workflow as AutomationWorkflow,
 )
 from metadata.generated.schema.entity.services.connections.pipeline.fivetranConnection import (
-    FivetranConnection,
+    FivetranConnection as FivetranConnectionConfig,
 )
 from metadata.generated.schema.entity.services.connections.testConnectionResult import (
     TestConnectionResult,
 )
+from metadata.ingestion.connections.connection import BaseConnection
 from metadata.ingestion.connections.test_connections import test_connection_steps
 from metadata.ingestion.ometa.ometa_api import OpenMetadata
 from metadata.ingestion.source.pipeline.fivetran.client import FivetranClient
 from metadata.utils.constants import THREE_MIN
 
 
-def get_connection(connection: FivetranConnection) -> FivetranClient:
+def get_connection(connection: FivetranConnectionConfig) -> FivetranClient:
     """
     Create connection
     """
     return FivetranClient(connection)
 
 
-def test_connection(
-    metadata: OpenMetadata,
-    client: FivetranClient,
-    service_connection: FivetranConnection,
-    automation_workflow: Optional[AutomationWorkflow] = None,  # noqa: UP045
-    timeout_seconds: Optional[int] = THREE_MIN,  # noqa: UP045
-) -> TestConnectionResult:
-    """
-    Test connection. This can be executed either as part
-    of a metadata workflow or during an Automation Workflow
-    """
+class FivetranConnection(BaseConnection[FivetranConnectionConfig, FivetranClient]):
+    def _get_client(self) -> FivetranClient:
+        return get_connection(self.service_connection)
 
-    test_fn = {"GetPipelines": lambda: list(client.list_groups())}
+    def test_connection(
+        self,
+        metadata: OpenMetadata,
+        automation_workflow: Optional[AutomationWorkflow] = None,  # noqa: UP045
+        timeout_seconds: Optional[int] = THREE_MIN,  # noqa: UP045
+    ) -> TestConnectionResult:
+        """
+        Test connection. This can be executed either as part
+        of a metadata workflow or during an Automation Workflow
+        """
+        client = self.client
+        service_connection = self.service_connection
 
-    return test_connection_steps(
-        metadata=metadata,
-        test_fn=test_fn,
-        service_type=service_connection.type.value,
-        automation_workflow=automation_workflow,
-        timeout_seconds=timeout_seconds,
-    )
+        test_fn = {"GetPipelines": lambda: list(client.list_groups())}
+
+        return test_connection_steps(
+            metadata=metadata,
+            test_fn=test_fn,
+            service_type=service_connection.type.value,  # pyright: ignore[reportOptionalMemberAccess]
+            automation_workflow=automation_workflow,
+            timeout_seconds=timeout_seconds,
+        )

--- a/ingestion/tests/unit/airflow/test_airflow_metadata.py
+++ b/ingestion/tests/unit/airflow/test_airflow_metadata.py
@@ -17,6 +17,7 @@ connect to Airflow 2.x databases (which have execution_date column).
 """
 
 from datetime import datetime, timezone
+from types import SimpleNamespace
 from unittest.mock import MagicMock, PropertyMock, patch
 from uuid import uuid4
 
@@ -333,13 +334,19 @@ class TestYieldPipelineStatus:
         return AirflowSource.__new__(AirflowSource)
 
     def _make_dag_run(self, logical_date, start_date):
-        dag_run = MagicMock(spec=DagRun)
-        dag_run.run_id = "manual__2024-01-01"
-        dag_run.dag_id = "test_dag"
-        dag_run.state = "success"
-        dag_run.logical_date = logical_date
-        dag_run.start_date = start_date
-        return dag_run
+        # A SimpleNamespace carries exactly the attributes yield_pipeline_status
+        # reads. MagicMock(spec=DagRun) would force SQLAlchemy to configure the
+        # whole shared mapper registry (via DagRun's association proxies) just to
+        # build the mock; if any unrelated test on the same xdist worker has left
+        # a mapper in a failed state, that configuration raises and this test
+        # fails for reasons that have nothing to do with what it verifies.
+        return SimpleNamespace(
+            run_id="manual__2024-01-01",
+            dag_id="test_dag",
+            state="success",
+            logical_date=logical_date,
+            start_date=start_date,
+        )
 
     @patch(
         "metadata.ingestion.source.pipeline.airflow.metadata.AirflowSource.__init__",

--- a/ingestion/tests/unit/source/__init__.py
+++ b/ingestion/tests/unit/source/__init__.py
@@ -8,8 +8,3 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-from metadata.ingestion.source.pipeline.fivetran.connection import FivetranConnection
-from metadata.ingestion.source.pipeline.fivetran.metadata import FivetranSource
-from metadata.utils.service_spec import BaseSpec
-
-ServiceSpec = BaseSpec(metadata_source_class=FivetranSource, connection_class=FivetranConnection)  # pyright: ignore[reportArgumentType]

--- a/ingestion/tests/unit/source/pipeline/__init__.py
+++ b/ingestion/tests/unit/source/pipeline/__init__.py
@@ -8,8 +8,3 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-from metadata.ingestion.source.pipeline.fivetran.connection import FivetranConnection
-from metadata.ingestion.source.pipeline.fivetran.metadata import FivetranSource
-from metadata.utils.service_spec import BaseSpec
-
-ServiceSpec = BaseSpec(metadata_source_class=FivetranSource, connection_class=FivetranConnection)  # pyright: ignore[reportArgumentType]

--- a/ingestion/tests/unit/source/pipeline/airbyte/__init__.py
+++ b/ingestion/tests/unit/source/pipeline/airbyte/__init__.py
@@ -8,8 +8,3 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-from metadata.ingestion.source.pipeline.fivetran.connection import FivetranConnection
-from metadata.ingestion.source.pipeline.fivetran.metadata import FivetranSource
-from metadata.utils.service_spec import BaseSpec
-
-ServiceSpec = BaseSpec(metadata_source_class=FivetranSource, connection_class=FivetranConnection)  # pyright: ignore[reportArgumentType]

--- a/ingestion/tests/unit/source/pipeline/airbyte/test_connection.py
+++ b/ingestion/tests/unit/source/pipeline/airbyte/test_connection.py
@@ -1,0 +1,40 @@
+#  Copyright 2025 Collate
+#  Licensed under the Collate Community License, Version 1.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  https://github.com/open-metadata/OpenMetadata/blob/main/ingestion/LICENSE
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+"""Unit tests for Airbyte connection handling."""
+
+from unittest.mock import MagicMock, patch
+
+from metadata.ingestion.connections.connection import BaseConnection
+from metadata.ingestion.source.pipeline.airbyte.connection import AirbyteConnection
+
+CONNECTION_MODULE = "metadata.ingestion.source.pipeline.airbyte.connection"
+
+
+def test_airbyte_connection_is_base_connection():
+    assert issubclass(AirbyteConnection, BaseConnection)
+
+
+def test_get_client_delegates_to_get_connection():
+    with patch(f"{CONNECTION_MODULE}.get_connection") as mock_get:
+        conn = AirbyteConnection(MagicMock())
+        client = conn.client
+
+    assert client is mock_get.return_value
+    mock_get.assert_called_once_with(conn.service_connection)
+
+
+def test_test_connection_runs_steps():
+    conn = AirbyteConnection(MagicMock())
+    conn._client = MagicMock()
+    with patch(f"{CONNECTION_MODULE}.test_connection_steps") as mock_step:
+        result = conn.test_connection(metadata=MagicMock())
+
+    assert result is mock_step.return_value

--- a/ingestion/tests/unit/source/pipeline/airflow/__init__.py
+++ b/ingestion/tests/unit/source/pipeline/airflow/__init__.py
@@ -8,8 +8,3 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-from metadata.ingestion.source.pipeline.fivetran.connection import FivetranConnection
-from metadata.ingestion.source.pipeline.fivetran.metadata import FivetranSource
-from metadata.utils.service_spec import BaseSpec
-
-ServiceSpec = BaseSpec(metadata_source_class=FivetranSource, connection_class=FivetranConnection)  # pyright: ignore[reportArgumentType]

--- a/ingestion/tests/unit/source/pipeline/airflow/test_connection.py
+++ b/ingestion/tests/unit/source/pipeline/airflow/test_connection.py
@@ -1,0 +1,40 @@
+#  Copyright 2025 Collate
+#  Licensed under the Collate Community License, Version 1.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  https://github.com/open-metadata/OpenMetadata/blob/main/ingestion/LICENSE
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+"""Unit tests for Airflow connection handling."""
+
+from unittest.mock import MagicMock, patch
+
+from metadata.ingestion.connections.connection import BaseConnection
+from metadata.ingestion.source.pipeline.airflow.connection import AirflowConnection
+
+CONNECTION_MODULE = "metadata.ingestion.source.pipeline.airflow.connection"
+
+
+def test_airflow_connection_is_base_connection():
+    assert issubclass(AirflowConnection, BaseConnection)
+
+
+def test_get_client_delegates_to_get_connection():
+    with patch(f"{CONNECTION_MODULE}.get_connection") as mock_get:
+        conn = AirflowConnection(MagicMock())
+        client = conn.client
+
+    assert client is mock_get.return_value
+    mock_get.assert_called_once_with(conn.service_connection)
+
+
+def test_test_connection_runs_steps():
+    conn = AirflowConnection(MagicMock())
+    conn._client = MagicMock()
+    with patch(f"{CONNECTION_MODULE}.test_connection") as mock_step:
+        result = conn.test_connection(metadata=MagicMock())
+
+    assert result is mock_step.return_value

--- a/ingestion/tests/unit/source/pipeline/dagster/__init__.py
+++ b/ingestion/tests/unit/source/pipeline/dagster/__init__.py
@@ -8,8 +8,3 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-from metadata.ingestion.source.pipeline.fivetran.connection import FivetranConnection
-from metadata.ingestion.source.pipeline.fivetran.metadata import FivetranSource
-from metadata.utils.service_spec import BaseSpec
-
-ServiceSpec = BaseSpec(metadata_source_class=FivetranSource, connection_class=FivetranConnection)  # pyright: ignore[reportArgumentType]

--- a/ingestion/tests/unit/source/pipeline/dagster/test_connection.py
+++ b/ingestion/tests/unit/source/pipeline/dagster/test_connection.py
@@ -1,0 +1,40 @@
+#  Copyright 2025 Collate
+#  Licensed under the Collate Community License, Version 1.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  https://github.com/open-metadata/OpenMetadata/blob/main/ingestion/LICENSE
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+"""Unit tests for Dagster connection handling."""
+
+from unittest.mock import MagicMock, patch
+
+from metadata.ingestion.connections.connection import BaseConnection
+from metadata.ingestion.source.pipeline.dagster.connection import DagsterConnection
+
+CONNECTION_MODULE = "metadata.ingestion.source.pipeline.dagster.connection"
+
+
+def test_dagster_connection_is_base_connection():
+    assert issubclass(DagsterConnection, BaseConnection)
+
+
+def test_get_client_builds_the_client():
+    with patch(f"{CONNECTION_MODULE}.DagsterClient") as mock_builder:
+        conn = DagsterConnection(MagicMock())
+        client = conn.client
+
+    assert client is mock_builder.return_value
+    mock_builder.assert_called_once()
+
+
+def test_test_connection_runs_steps():
+    conn = DagsterConnection(MagicMock())
+    conn._client = MagicMock()
+    with patch(f"{CONNECTION_MODULE}.test_connection_steps") as mock_step:
+        result = conn.test_connection(metadata=MagicMock())
+
+    assert result is mock_step.return_value

--- a/ingestion/tests/unit/source/pipeline/databrickspipeline/__init__.py
+++ b/ingestion/tests/unit/source/pipeline/databrickspipeline/__init__.py
@@ -8,8 +8,3 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-from metadata.ingestion.source.pipeline.fivetran.connection import FivetranConnection
-from metadata.ingestion.source.pipeline.fivetran.metadata import FivetranSource
-from metadata.utils.service_spec import BaseSpec
-
-ServiceSpec = BaseSpec(metadata_source_class=FivetranSource, connection_class=FivetranConnection)  # pyright: ignore[reportArgumentType]

--- a/ingestion/tests/unit/source/pipeline/databrickspipeline/test_connection.py
+++ b/ingestion/tests/unit/source/pipeline/databrickspipeline/test_connection.py
@@ -1,0 +1,40 @@
+#  Copyright 2025 Collate
+#  Licensed under the Collate Community License, Version 1.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  https://github.com/open-metadata/OpenMetadata/blob/main/ingestion/LICENSE
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+"""Unit tests for Databricks Pipeline connection handling."""
+
+from unittest.mock import MagicMock, patch
+
+from metadata.ingestion.connections.connection import BaseConnection
+from metadata.ingestion.source.pipeline.databrickspipeline.connection import DatabricksPipelineConnection
+
+CONNECTION_MODULE = "metadata.ingestion.source.pipeline.databrickspipeline.connection"
+
+
+def test_databrickspipeline_connection_is_base_connection():
+    assert issubclass(DatabricksPipelineConnection, BaseConnection)
+
+
+def test_get_client_delegates_to_get_connection():
+    with patch(f"{CONNECTION_MODULE}.get_connection") as mock_get:
+        conn = DatabricksPipelineConnection(MagicMock())
+        client = conn.client
+
+    assert client is mock_get.return_value
+    mock_get.assert_called_once_with(conn.service_connection)
+
+
+def test_test_connection_runs_steps():
+    conn = DatabricksPipelineConnection(MagicMock())
+    conn._client = MagicMock()
+    with patch(f"{CONNECTION_MODULE}.test_connection_steps") as mock_step:
+        result = conn.test_connection(metadata=MagicMock())
+
+    assert result is mock_step.return_value

--- a/ingestion/tests/unit/source/pipeline/dbtcloud/__init__.py
+++ b/ingestion/tests/unit/source/pipeline/dbtcloud/__init__.py
@@ -8,8 +8,3 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-from metadata.ingestion.source.pipeline.fivetran.connection import FivetranConnection
-from metadata.ingestion.source.pipeline.fivetran.metadata import FivetranSource
-from metadata.utils.service_spec import BaseSpec
-
-ServiceSpec = BaseSpec(metadata_source_class=FivetranSource, connection_class=FivetranConnection)  # pyright: ignore[reportArgumentType]

--- a/ingestion/tests/unit/source/pipeline/dbtcloud/test_connection.py
+++ b/ingestion/tests/unit/source/pipeline/dbtcloud/test_connection.py
@@ -1,0 +1,40 @@
+#  Copyright 2025 Collate
+#  Licensed under the Collate Community License, Version 1.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  https://github.com/open-metadata/OpenMetadata/blob/main/ingestion/LICENSE
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+"""Unit tests for dbt Cloud connection handling."""
+
+from unittest.mock import MagicMock, patch
+
+from metadata.ingestion.connections.connection import BaseConnection
+from metadata.ingestion.source.pipeline.dbtcloud.connection import DBTCloudConnection
+
+CONNECTION_MODULE = "metadata.ingestion.source.pipeline.dbtcloud.connection"
+
+
+def test_dbtcloud_connection_is_base_connection():
+    assert issubclass(DBTCloudConnection, BaseConnection)
+
+
+def test_get_client_builds_the_client():
+    with patch(f"{CONNECTION_MODULE}.DBTCloudClient") as mock_builder:
+        conn = DBTCloudConnection(MagicMock())
+        client = conn.client
+
+    assert client is mock_builder.return_value
+    mock_builder.assert_called_once()
+
+
+def test_test_connection_runs_steps():
+    conn = DBTCloudConnection(MagicMock())
+    conn._client = MagicMock()
+    with patch(f"{CONNECTION_MODULE}.test_connection_steps") as mock_step:
+        result = conn.test_connection(metadata=MagicMock())
+
+    assert result is mock_step.return_value

--- a/ingestion/tests/unit/source/pipeline/domopipeline/__init__.py
+++ b/ingestion/tests/unit/source/pipeline/domopipeline/__init__.py
@@ -8,8 +8,3 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-from metadata.ingestion.source.pipeline.fivetran.connection import FivetranConnection
-from metadata.ingestion.source.pipeline.fivetran.metadata import FivetranSource
-from metadata.utils.service_spec import BaseSpec
-
-ServiceSpec = BaseSpec(metadata_source_class=FivetranSource, connection_class=FivetranConnection)  # pyright: ignore[reportArgumentType]

--- a/ingestion/tests/unit/source/pipeline/domopipeline/test_connection.py
+++ b/ingestion/tests/unit/source/pipeline/domopipeline/test_connection.py
@@ -1,0 +1,40 @@
+#  Copyright 2025 Collate
+#  Licensed under the Collate Community License, Version 1.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  https://github.com/open-metadata/OpenMetadata/blob/main/ingestion/LICENSE
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+"""Unit tests for Domo Pipeline connection handling."""
+
+from unittest.mock import MagicMock, patch
+
+from metadata.ingestion.connections.connection import BaseConnection
+from metadata.ingestion.source.pipeline.domopipeline.connection import DomoPipelineConnection
+
+CONNECTION_MODULE = "metadata.ingestion.source.pipeline.domopipeline.connection"
+
+
+def test_domopipeline_connection_is_base_connection():
+    assert issubclass(DomoPipelineConnection, BaseConnection)
+
+
+def test_get_client_builds_the_client():
+    with patch(f"{CONNECTION_MODULE}.DomoClient") as mock_builder:
+        conn = DomoPipelineConnection(MagicMock())
+        client = conn.client
+
+    assert client is mock_builder.return_value
+    mock_builder.assert_called_once()
+
+
+def test_test_connection_runs_steps():
+    conn = DomoPipelineConnection(MagicMock())
+    conn._client = MagicMock()
+    with patch(f"{CONNECTION_MODULE}.test_connection_steps") as mock_step:
+        result = conn.test_connection(metadata=MagicMock())
+
+    assert result is mock_step.return_value

--- a/ingestion/tests/unit/source/pipeline/fivetran/__init__.py
+++ b/ingestion/tests/unit/source/pipeline/fivetran/__init__.py
@@ -8,8 +8,3 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-from metadata.ingestion.source.pipeline.fivetran.connection import FivetranConnection
-from metadata.ingestion.source.pipeline.fivetran.metadata import FivetranSource
-from metadata.utils.service_spec import BaseSpec
-
-ServiceSpec = BaseSpec(metadata_source_class=FivetranSource, connection_class=FivetranConnection)  # pyright: ignore[reportArgumentType]

--- a/ingestion/tests/unit/source/pipeline/fivetran/test_connection.py
+++ b/ingestion/tests/unit/source/pipeline/fivetran/test_connection.py
@@ -1,0 +1,40 @@
+#  Copyright 2025 Collate
+#  Licensed under the Collate Community License, Version 1.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  https://github.com/open-metadata/OpenMetadata/blob/main/ingestion/LICENSE
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+"""Unit tests for Fivetran connection handling."""
+
+from unittest.mock import MagicMock, patch
+
+from metadata.ingestion.connections.connection import BaseConnection
+from metadata.ingestion.source.pipeline.fivetran.connection import FivetranConnection
+
+CONNECTION_MODULE = "metadata.ingestion.source.pipeline.fivetran.connection"
+
+
+def test_fivetran_connection_is_base_connection():
+    assert issubclass(FivetranConnection, BaseConnection)
+
+
+def test_get_client_delegates_to_get_connection():
+    with patch(f"{CONNECTION_MODULE}.get_connection") as mock_get:
+        conn = FivetranConnection(MagicMock())
+        client = conn.client
+
+    assert client is mock_get.return_value
+    mock_get.assert_called_once_with(conn.service_connection)
+
+
+def test_test_connection_runs_steps():
+    conn = FivetranConnection(MagicMock())
+    conn._client = MagicMock()
+    with patch(f"{CONNECTION_MODULE}.test_connection_steps") as mock_step:
+        result = conn.test_connection(metadata=MagicMock())
+
+    assert result is mock_step.return_value


### PR DESCRIPTION
Fixes #28996

## What

Migrates the first batch of **pipeline** connectors onto `BaseConnection[Config, Client]`.

| Connector | Client type | get_connection |
|---|---|---|
| airbyte | `AirbyteClient \| AirbyteCloudClient` | kept module-level (tests patch it) |
| airflow | `Any` (Engine or REST client) | kept module-level (tests import it; singledispatch backend builders) |
| dagster | `DagsterClient` | moved into `_get_client` |
| databrickspipeline | `DatabricksClient` | kept module-level (tests import it) |
| dbtcloud | `DBTCloudClient` | moved into `_get_client` |
| domopipeline | `DomoClient` | moved into `_get_client` |
| fivetran | `FivetranClient` | kept module-level (tests patch it) |

## How

- Each connector gains `XConnection(BaseConnection[...])` with `_get_client` + `test_connection`; `connection_class` wired into each `service_spec.py`. The pipeline base source already resolves client + test_connection through `metadata.ingestion.source.connections`, so no source-side changes.
- **airflow** is the special case: its `@singledispatch` `_get_connection` dispatches to the migrated DB connectors (mysql/postgres/sqlite) for the metadata DB and its unit tests import `get_connection`/`test_connection`, so those stay module-level and the class delegates. Client type is `Any` because `get_connection` returns either a SQLAlchemy `Engine` or the REST `AirflowApiClient`.
- Where existing tests **patch** `<conn>.connection.get_connection` (airbyte, fivetran) or **import** it (databrickspipeline, airflow), it stays module-level and the class delegates — so no test churn.
- **domopipeline** is now correctly typed `DomoClient` (the original `-> Domo` from `pydomo` was wrong — `DomoClient` is what's actually built and what exposes `get_pipelines`), which clears two long-baselined pyright errors.

## Tests

- Colocated `tests/unit/source/pipeline/<connector>/test_connection.py` for all seven (21 tests).
- All existing pipeline topology + importer suites pass (834).
- `basedpyright` baseline check clean; `ruff` clean.

## Note — bundled test-isolation fix

This branch also includes the one-commit fix from #28995 (`test(airflow): isolate yield_pipeline_status tests from SQLAlchemy registry pollution`). Because this PR modifies `airflow/connection.py`, it shifts the `pytest -n auto` test distribution; the `SimpleNamespace` change keeps `TestYieldPipelineStatus` from flaking on a poisoned shared SQLAlchemy mapper registry. The change is identical to #28995, so it merges cleanly whichever lands first.