### PR TITLE
Fix NullPointerException in MeteredPipelineServiceClient.respondWithMetering when decorated client returns null

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/clients/pipeline/MeteredPipelineServiceClient.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/clients/pipeline/MeteredPipelineServiceClient.java
@@ -1,16 +1,32 @@
 package org.openmetadata.service.clients.pipeline;
 
-import static org.openmetadata.service.util.MicrometerBundleUtil.recordMetrics;
-
+import io.micrometer.core.instrument.Metrics;
+import jakarta.ws.rs.core.Response;
+import java.net.URL;
+import java.util.List;
+import java.util.Map;
 import java.util.function.Supplier;
-import javax.ws.rs.core.Response;
-import lombok.extern.slf4j.Slf4j;
+import org.openmetadata.schema.ServiceEntityInterface;
+import org.openmetadata.schema.entity.app.App;
+import org.openmetadata.schema.entity.app.AppMarketPlaceDefinition;
+import org.openmetadata.schema.entity.automations.Workflow;
+import org.openmetadata.schema.entity.services.ingestionPipelines.IngestionPipeline;
 import org.openmetadata.schema.entity.services.ingestionPipelines.PipelineServiceClientResponse;
-import org.openmetadata.schema.entity.services.ingestionPipelines.PipelineServiceClientStatus;
+import org.openmetadata.schema.entity.services.ingestionPipelines.PipelineStatus;
 import org.openmetadata.sdk.PipelineServiceClientInterface;
+import org.openmetadata.sdk.exception.PipelineServiceClientException;
 
-@Slf4j
 public class MeteredPipelineServiceClient implements PipelineServiceClientInterface {
+  private final String DEPLOY = "deploy";
+  private final String RUN = "run";
+  private final String DELETE = "delete";
+  private final String TOGGLE = "toggle";
+  private final String KILL = "kill";
+  private final String GET_LOGS = "get_logs";
+  private final String GET_STATUS = "get_status";
+  private final String RUN_AUTOMATIONS_WORKFLOW = "run_automations_workflow";
+  private final String RUN_APPLICATION_FLOW = "run_application_flow";
+  private final String VALIDATE_APP_REGISTRATION = "validate_app_registration";
 
   private final PipelineServiceClientInterface decoratedClient;
 
@@ -18,101 +34,185 @@ public class MeteredPipelineServiceClient implements PipelineServiceClientInterf
     this.decoratedClient = decoratedClient;
   }
 
-  @Override
-  public PipelineServiceClientResponse getServiceStatus() {
-    return respondWithMetering(decoratedClient::getServiceStatus);
+  /** Get the underlying decorated client. Used for testing to check the actual client type. */
+  @com.google.common.annotations.VisibleForTesting
+  public PipelineServiceClientInterface getDecoratedClient() {
+    return decoratedClient;
+  }
+
+  private <T> T executeWithMetering(String name, Supplier<T> operation) {
+    try {
+      T result = operation.get();
+      Metrics.counter("pipeline_client_request_status", "operation", name, "status", "200")
+          .increment();
+      return result;
+    } catch (PipelineServiceClientException e) {
+      Metrics.counter(
+              "pipeline_client_request_status",
+              "operation",
+              name,
+              "status",
+              Integer.toString(e.getResponse().getStatus()))
+          .increment();
+      throw e;
+    } catch (Exception e) {
+      Metrics.counter("pipeline_client_request_status", "operation", name, "status", "unknown")
+          .increment();
+      throw e;
+    }
+  }
+
+  private PipelineServiceClientResponse respondWithMetering(
+      String name, Supplier<PipelineServiceClientResponse> operation) {
+    try {
+      PipelineServiceClientResponse result = operation.get();
+      if (result == null) {
+        result = new PipelineServiceClientResponse().withCode(200);
+      }
+      Metrics.counter(
+              "pipeline_client_request_status",
+              "operation",
+              name,
+              "status",
+              Integer.toString(result.getCode()))
+          .increment();
+      return result;
+    } catch (PipelineServiceClientException e) {
+      Metrics.counter(
+              "pipeline_client_request_status",
+              "operation",
+              name,
+              "status",
+              Integer.toString(e.getResponse().getStatus()))
+          .increment();
+      throw e;
+    } catch (Exception e) {
+      Metrics.counter("pipeline_client_request_status", "operation", name, "status", "unknown")
+          .increment();
+      throw e;
+    }
   }
 
   @Override
-  public PipelineServiceClientResponse runAutomationFlow(String clusterName) {
-    return respondWithMetering(() -> decoratedClient.runAutomationFlow(clusterName));
+  public PipelineServiceClientResponse deployPipeline(
+      IngestionPipeline ingestionPipeline, ServiceEntityInterface service) {
+    return this.respondWithMetering(
+        DEPLOY, () -> this.decoratedClient.deployPipeline(ingestionPipeline, service));
   }
 
   @Override
-  public Response getLastOperatorLogs(String ingestionPipelineFQN, String taskId) {
-    return decoratedClient.getLastOperatorLogs(ingestionPipelineFQN, taskId);
+  public PipelineServiceClientResponse runPipeline(
+      IngestionPipeline ingestionPipeline, ServiceEntityInterface service) {
+    return this.respondWithMetering(
+        RUN, () -> this.decoratedClient.runPipeline(ingestionPipeline, service));
   }
 
   @Override
-  public Response getLogs(String pipelineName, String pipelineType, Long start, Long end) {
-    return decoratedClient.getLogs(pipelineName, pipelineType, start, end);
+  public PipelineServiceClientResponse runPipeline(
+      IngestionPipeline ingestionPipeline,
+      ServiceEntityInterface service,
+      Map<String, Object> config) {
+    return this.respondWithMetering(
+        RUN, () -> this.decoratedClient.runPipeline(ingestionPipeline, service, config));
   }
 
   @Override
-  public Response uploadLogs(String pipelineName, String pipelineType) {
-    return decoratedClient.uploadLogs(pipelineName, pipelineType);
+  public PipelineServiceClientResponse deletePipeline(IngestionPipeline ingestionPipeline) {
+    return this.respondWithMetering(
+        DELETE, () -> this.decoratedClient.deletePipeline(ingestionPipeline));
   }
 
   @Override
-  public Response deleteLogs(String pipelineName) {
-    return decoratedClient.deleteLogs(pipelineName);
+  public List<PipelineStatus> getQueuedPipelineStatusInternal(IngestionPipeline ingestionPipeline) {
+    return this.decoratedClient.getQueuedPipelineStatusInternal(ingestionPipeline);
+  }
+
+  public PipelineServiceClientResponse toggleIngestion(IngestionPipeline ingestionPipeline) {
+    return this.respondWithMetering(
+        TOGGLE, () -> this.decoratedClient.toggleIngestion(ingestionPipeline));
   }
 
   @Override
-  public void updateServiceEndpoint() {
-    decoratedClient.updateServiceEndpoint();
+  public Map<String, String> getLastIngestionLogs(
+      IngestionPipeline ingestionPipeline, String after) {
+    return executeWithMetering(
+        GET_LOGS, () -> this.decoratedClient.getLastIngestionLogs(ingestionPipeline, after));
   }
 
   @Override
-  public String getHostIp() {
+  public Map<String, String> getIngestionLogs(
+      IngestionPipeline ingestionPipeline, String after, String runId) {
+    return executeWithMetering(
+        GET_LOGS, () -> this.decoratedClient.getIngestionLogs(ingestionPipeline, after, runId));
+  }
+
+  public PipelineServiceClientResponse killIngestion(IngestionPipeline ingestionPipeline) {
+    return this.respondWithMetering(
+        KILL, () -> this.decoratedClient.killIngestion(ingestionPipeline));
+  }
+
+  @Override
+  public PipelineServiceClientResponse killIngestionRun(
+      IngestionPipeline ingestionPipeline, String runId) {
+    return this.respondWithMetering(
+        KILL, () -> this.decoratedClient.killIngestionRun(ingestionPipeline, runId));
+  }
+
+  @Override
+  public String getPlatform() {
+    return this.decoratedClient.getPlatform();
+  }
+
+  @Override
+  public URL validateServiceURL(String serviceURL) {
+    return decoratedClient.validateServiceURL(serviceURL);
+  }
+
+  @Override
+  public String getBasicAuthenticationHeader(String username, String password) {
+    return decoratedClient.getBasicAuthenticationHeader(username, password);
+  }
+
+  @Override
+  public Boolean validServerClientVersions(String clientVersion, String serverVersion) {
+    return decoratedClient.validServerClientVersions(clientVersion, serverVersion);
+  }
+
+  @Override
+  public Response getHostIp() {
     return decoratedClient.getHostIp();
   }
 
   @Override
-  public void validateHostIp() {
-    decoratedClient.validateHostIp();
+  public String getServiceStatusBackoff() {
+    return executeWithMetering(GET_STATUS, decoratedClient::getServiceStatusBackoff);
   }
 
   @Override
-  public boolean isPipelineServiceClientReady() {
-    return decoratedClient.isPipelineServiceClientReady();
+  public PipelineServiceClientResponse getServiceStatus() {
+    return this.respondWithMetering(GET_STATUS, this.decoratedClient::getServiceStatus);
   }
 
   @Override
-  public void deployPipeline(String pipelineName, PipelineServiceClientResponse response) {
-    decoratedClient.deployPipeline(pipelineName, response);
+  public List<PipelineStatus> getQueuedPipelineStatus(IngestionPipeline ingestionPipeline) {
+    return this.decoratedClient.getQueuedPipelineStatus(ingestionPipeline);
   }
 
   @Override
-  public void runPipeline(String pipelineName, String pipelineType, Long start, Long end) {
-    decoratedClient.runPipeline(pipelineName, pipelineType, start, end);
+  public PipelineServiceClientResponse runAutomationsWorkflow(Workflow workflow) {
+    return this.respondWithMetering(
+        RUN_AUTOMATIONS_WORKFLOW, () -> this.decoratedClient.runAutomationsWorkflow(workflow));
   }
 
   @Override
-  public void stopPipeline(String pipelineName) {
-    decoratedClient.stopPipeline(pipelineName);
+  public PipelineServiceClientResponse runApplicationFlow(App application) {
+    return this.respondWithMetering(
+        RUN_APPLICATION_FLOW, () -> this.decoratedClient.runApplicationFlow(application));
   }
 
   @Override
-  public void deletePipeline(String pipelineName) {
-    decoratedClient.deletePipeline(pipelineName);
-  }
-
-  @Override
-  public PipelineServiceClientResponse getAutomationFlowStatus() {
-    return decoratedClient.getAutomationFlowStatus();
-  }
-
-  private PipelineServiceClientResponse respondWithMetering(
-      Supplier<PipelineServiceClientResponse> responseSupplier) {
-    PipelineServiceClientResponse result = responseSupplier.get();
-    if (result == null) {
-      return new PipelineServiceClientResponse()
-          .withCode(200)
-          .withTimestamp(System.currentTimeMillis());
-    }
-    long elapsedTime = System.currentTimeMillis() - result.getTimestamp();
-    long statusCode = result.getCode();
-    String requestType = extractRequestType();
-    recordMetrics(requestType, statusCode, elapsedTime);
-    return result;
-  }
-
-  private String extractRequestType() {
-    StackTraceElement[] stackTrace = Thread.currentThread().getStackTrace();
-    if (stackTrace.length > 2) {
-      return stackTrace[2].getMethodName();
-    }
-    return "unknown";
+  public PipelineServiceClientResponse validateAppRegistration(AppMarketPlaceDefinition app) {
+    return this.respondWithMetering(
+        VALIDATE_APP_REGISTRATION, () -> this.decoratedClient.validateAppRegistration(app));
   }
 }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/clients/pipeline/MeteredPipelineServiceClient.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/clients/pipeline/MeteredPipelineServiceClient.java
@@ -1,32 +1,16 @@
 package org.openmetadata.service.clients.pipeline;
 
-import io.micrometer.core.instrument.Metrics;
-import jakarta.ws.rs.core.Response;
-import java.net.URL;
-import java.util.List;
-import java.util.Map;
-import java.util.function.Supplier;
-import org.openmetadata.schema.ServiceEntityInterface;
-import org.openmetadata.schema.entity.app.App;
-import org.openmetadata.schema.entity.app.AppMarketPlaceDefinition;
-import org.openmetadata.schema.entity.automations.Workflow;
-import org.openmetadata.schema.entity.services.ingestionPipelines.IngestionPipeline;
-import org.openmetadata.schema.entity.services.ingestionPipelines.PipelineServiceClientResponse;
-import org.openmetadata.schema.entity.services.ingestionPipelines.PipelineStatus;
-import org.openmetadata.sdk.PipelineServiceClientInterface;
-import org.openmetadata.sdk.exception.PipelineServiceClientException;
+import static org.openmetadata.service.util.MicrometerBundleUtil.recordMetrics;
 
+import java.util.function.Supplier;
+import javax.ws.rs.core.Response;
+import lombok.extern.slf4j.Slf4j;
+import org.openmetadata.schema.entity.services.ingestionPipelines.PipelineServiceClientResponse;
+import org.openmetadata.schema.entity.services.ingestionPipelines.PipelineServiceClientStatus;
+import org.openmetadata.sdk.PipelineServiceClientInterface;
+
+@Slf4j
 public class MeteredPipelineServiceClient implements PipelineServiceClientInterface {
-  private final String DEPLOY = "deploy";
-  private final String RUN = "run";
-  private final String DELETE = "delete";
-  private final String TOGGLE = "toggle";
-  private final String KILL = "kill";
-  private final String GET_LOGS = "get_logs";
-  private final String GET_STATUS = "get_status";
-  private final String RUN_AUTOMATIONS_WORKFLOW = "run_automations_workflow";
-  private final String RUN_APPLICATION_FLOW = "run_application_flow";
-  private final String VALIDATE_APP_REGISTRATION = "validate_app_registration";
 
   private final PipelineServiceClientInterface decoratedClient;
 
@@ -34,182 +18,101 @@ public class MeteredPipelineServiceClient implements PipelineServiceClientInterf
     this.decoratedClient = decoratedClient;
   }
 
-  /** Get the underlying decorated client. Used for testing to check the actual client type. */
-  @com.google.common.annotations.VisibleForTesting
-  public PipelineServiceClientInterface getDecoratedClient() {
-    return decoratedClient;
-  }
-
-  private <T> T executeWithMetering(String name, Supplier<T> operation) {
-    try {
-      T result = operation.get();
-      Metrics.counter("pipeline_client_request_status", "operation", name, "status", "200")
-          .increment();
-      return result;
-    } catch (PipelineServiceClientException e) {
-      Metrics.counter(
-              "pipeline_client_request_status",
-              "operation",
-              name,
-              "status",
-              Integer.toString(e.getResponse().getStatus()))
-          .increment();
-      throw e;
-    } catch (Exception e) {
-      Metrics.counter("pipeline_client_request_status", "operation", name, "status", "unknown")
-          .increment();
-      throw e;
-    }
-  }
-
-  private PipelineServiceClientResponse respondWithMetering(
-      String name, Supplier<PipelineServiceClientResponse> operation) {
-    try {
-      PipelineServiceClientResponse result = operation.get();
-      Metrics.counter(
-              "pipeline_client_request_status",
-              "operation",
-              name,
-              "status",
-              Integer.toString(result.getCode()))
-          .increment();
-      return result;
-    } catch (PipelineServiceClientException e) {
-      Metrics.counter(
-              "pipeline_client_request_status",
-              "operation",
-              name,
-              "status",
-              Integer.toString(e.getResponse().getStatus()))
-          .increment();
-      throw e;
-    } catch (Exception e) {
-      Metrics.counter("pipeline_client_request_status", "operation", name, "status", "unknown")
-          .increment();
-      throw e;
-    }
+  @Override
+  public PipelineServiceClientResponse getServiceStatus() {
+    return respondWithMetering(decoratedClient::getServiceStatus);
   }
 
   @Override
-  public PipelineServiceClientResponse deployPipeline(
-      IngestionPipeline ingestionPipeline, ServiceEntityInterface service) {
-    return this.respondWithMetering(
-        DEPLOY, () -> this.decoratedClient.deployPipeline(ingestionPipeline, service));
+  public PipelineServiceClientResponse runAutomationFlow(String clusterName) {
+    return respondWithMetering(() -> decoratedClient.runAutomationFlow(clusterName));
   }
 
   @Override
-  public PipelineServiceClientResponse runPipeline(
-      IngestionPipeline ingestionPipeline, ServiceEntityInterface service) {
-    return this.respondWithMetering(
-        RUN, () -> this.decoratedClient.runPipeline(ingestionPipeline, service));
+  public Response getLastOperatorLogs(String ingestionPipelineFQN, String taskId) {
+    return decoratedClient.getLastOperatorLogs(ingestionPipelineFQN, taskId);
   }
 
   @Override
-  public PipelineServiceClientResponse runPipeline(
-      IngestionPipeline ingestionPipeline,
-      ServiceEntityInterface service,
-      Map<String, Object> config) {
-    return this.respondWithMetering(
-        RUN, () -> this.decoratedClient.runPipeline(ingestionPipeline, service, config));
+  public Response getLogs(String pipelineName, String pipelineType, Long start, Long end) {
+    return decoratedClient.getLogs(pipelineName, pipelineType, start, end);
   }
 
   @Override
-  public PipelineServiceClientResponse deletePipeline(IngestionPipeline ingestionPipeline) {
-    return this.respondWithMetering(
-        DELETE, () -> this.decoratedClient.deletePipeline(ingestionPipeline));
+  public Response uploadLogs(String pipelineName, String pipelineType) {
+    return decoratedClient.uploadLogs(pipelineName, pipelineType);
   }
 
   @Override
-  public List<PipelineStatus> getQueuedPipelineStatusInternal(IngestionPipeline ingestionPipeline) {
-    return this.decoratedClient.getQueuedPipelineStatusInternal(ingestionPipeline);
-  }
-
-  public PipelineServiceClientResponse toggleIngestion(IngestionPipeline ingestionPipeline) {
-    return this.respondWithMetering(
-        TOGGLE, () -> this.decoratedClient.toggleIngestion(ingestionPipeline));
+  public Response deleteLogs(String pipelineName) {
+    return decoratedClient.deleteLogs(pipelineName);
   }
 
   @Override
-  public Map<String, String> getLastIngestionLogs(
-      IngestionPipeline ingestionPipeline, String after) {
-    return executeWithMetering(
-        GET_LOGS, () -> this.decoratedClient.getLastIngestionLogs(ingestionPipeline, after));
+  public void updateServiceEndpoint() {
+    decoratedClient.updateServiceEndpoint();
   }
 
   @Override
-  public Map<String, String> getIngestionLogs(
-      IngestionPipeline ingestionPipeline, String after, String runId) {
-    return executeWithMetering(
-        GET_LOGS, () -> this.decoratedClient.getIngestionLogs(ingestionPipeline, after, runId));
-  }
-
-  public PipelineServiceClientResponse killIngestion(IngestionPipeline ingestionPipeline) {
-    return this.respondWithMetering(
-        KILL, () -> this.decoratedClient.killIngestion(ingestionPipeline));
-  }
-
-  @Override
-  public PipelineServiceClientResponse killIngestionRun(
-      IngestionPipeline ingestionPipeline, String runId) {
-    return this.respondWithMetering(
-        KILL, () -> this.decoratedClient.killIngestionRun(ingestionPipeline, runId));
-  }
-
-  @Override
-  public String getPlatform() {
-    return this.decoratedClient.getPlatform();
-  }
-
-  @Override
-  public URL validateServiceURL(String serviceURL) {
-    return decoratedClient.validateServiceURL(serviceURL);
-  }
-
-  @Override
-  public String getBasicAuthenticationHeader(String username, String password) {
-    return decoratedClient.getBasicAuthenticationHeader(username, password);
-  }
-
-  @Override
-  public Boolean validServerClientVersions(String clientVersion, String serverVersion) {
-    return decoratedClient.validServerClientVersions(clientVersion, serverVersion);
-  }
-
-  @Override
-  public Response getHostIp() {
+  public String getHostIp() {
     return decoratedClient.getHostIp();
   }
 
   @Override
-  public String getServiceStatusBackoff() {
-    return executeWithMetering(GET_STATUS, decoratedClient::getServiceStatusBackoff);
+  public void validateHostIp() {
+    decoratedClient.validateHostIp();
   }
 
   @Override
-  public PipelineServiceClientResponse getServiceStatus() {
-    return this.respondWithMetering(GET_STATUS, this.decoratedClient::getServiceStatus);
+  public boolean isPipelineServiceClientReady() {
+    return decoratedClient.isPipelineServiceClientReady();
   }
 
   @Override
-  public List<PipelineStatus> getQueuedPipelineStatus(IngestionPipeline ingestionPipeline) {
-    return this.decoratedClient.getQueuedPipelineStatus(ingestionPipeline);
+  public void deployPipeline(String pipelineName, PipelineServiceClientResponse response) {
+    decoratedClient.deployPipeline(pipelineName, response);
   }
 
   @Override
-  public PipelineServiceClientResponse runAutomationsWorkflow(Workflow workflow) {
-    return this.respondWithMetering(
-        RUN_AUTOMATIONS_WORKFLOW, () -> this.decoratedClient.runAutomationsWorkflow(workflow));
+  public void runPipeline(String pipelineName, String pipelineType, Long start, Long end) {
+    decoratedClient.runPipeline(pipelineName, pipelineType, start, end);
   }
 
   @Override
-  public PipelineServiceClientResponse runApplicationFlow(App application) {
-    return this.respondWithMetering(
-        RUN_APPLICATION_FLOW, () -> this.decoratedClient.runApplicationFlow(application));
+  public void stopPipeline(String pipelineName) {
+    decoratedClient.stopPipeline(pipelineName);
   }
 
   @Override
-  public PipelineServiceClientResponse validateAppRegistration(AppMarketPlaceDefinition app) {
-    return this.respondWithMetering(
-        VALIDATE_APP_REGISTRATION, () -> this.decoratedClient.validateAppRegistration(app));
+  public void deletePipeline(String pipelineName) {
+    decoratedClient.deletePipeline(pipelineName);
+  }
+
+  @Override
+  public PipelineServiceClientResponse getAutomationFlowStatus() {
+    return decoratedClient.getAutomationFlowStatus();
+  }
+
+  private PipelineServiceClientResponse respondWithMetering(
+      Supplier<PipelineServiceClientResponse> responseSupplier) {
+    PipelineServiceClientResponse result = responseSupplier.get();
+    if (result == null) {
+      return new PipelineServiceClientResponse()
+          .withCode(200)
+          .withTimestamp(System.currentTimeMillis());
+    }
+    long elapsedTime = System.currentTimeMillis() - result.getTimestamp();
+    long statusCode = result.getCode();
+    String requestType = extractRequestType();
+    recordMetrics(requestType, statusCode, elapsedTime);
+    return result;
+  }
+
+  private String extractRequestType() {
+    StackTraceElement[] stackTrace = Thread.currentThread().getStackTrace();
+    if (stackTrace.length > 2) {
+      return stackTrace[2].getMethodName();
+    }
+    return "unknown";
   }
 }


### PR DESCRIPTION
Fixes #28959.

Fix NullPointerException in MeteredPipelineServiceClient.respondWithMetering when decorated client returns null. When PIPELINE_SERVICE_CLIENT_CLASS_NAME is set to NoopClient, getServiceStatus() returns null. MeteredPipelineServiceClient.respondWithMetering() does not null-check the result before calling result.getCode(), causing a NullPointerException on every UI poll to GET /api/v1/services/ingestionPipelines/status. Adding a null guard that returns a default 200 OK response resolves the issue.

I checked the changed Java file with the available static check.

----
## Summary by Gitar

- **Bug Fixes:**
  - Added null guard in `respondWithMetering` to return `200 OK` when `decoratedClient` returns `null`.
- **Refactor:**
  - Simplified `MeteredPipelineServiceClient` by removing manual operation constants and streamlining metering logic.
  - Replaced explicit `Metrics` counter usage with `MicrometerBundleUtil.recordMetrics` and dynamic stack trace analysis for request type identification.

<sub>This will update automatically on new commits.</sub>

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a `NullPointerException` that occurred on every UI poll to `GET /api/v1/services/ingestionPipelines/status` when `PIPELINE_SERVICE_CLIENT_CLASS_NAME` is set to `NoopClient`, because `NoopClient.getServiceStatusInternal()` returns `null` and `respondWithMetering` called `result.getCode()` without a null check.

- Adds a null guard in `respondWithMetering` that substitutes a default `200 OK` `PipelineServiceClientResponse` whenever the decorated client returns `null`; the guard is applied at the metering wrapper level, so it also covers `runAutomationsWorkflow`, `runApplicationFlow`, and `validateAppRegistration` — all of which return `null` in `NoopClient`.
- The fabricated fallback response uses only `.withCode(200)` without populating `platform` or `version`, differing from the `buildHealthyStatus` pattern used elsewhere in the base class.
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The change is a safe, targeted bug fix that eliminates a recurring NPE when running in NoopClient mode; no existing logic is removed or restructured.

The fix correctly stops the NPE crash on every UI status poll. The null guard is slightly broader than the stated scope — it also intercepts null returns from `runAutomationsWorkflow`, `runApplicationFlow`, and `validateAppRegistration` on NoopClient, converting them to silent 200 OKs rather than fixing them at the source. The synthesized response also omits the `platform` field that the rest of the codebase populates via `buildHealthyStatus`. Neither issue is likely to cause a visible regression today, but they represent a small drift from the established response-construction patterns.

openmetadata-service/src/main/java/org/openmetadata/service/clients/pipeline/MeteredPipelineServiceClient.java — the null guard and its fabricated response deserve a second look.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| openmetadata-service/src/main/java/org/openmetadata/service/clients/pipeline/MeteredPipelineServiceClient.java | Adds a null guard in `respondWithMetering` to prevent NPE when the decorated client (e.g., NoopClient) returns null; the guard is broader than necessary, also affecting `runAutomationsWorkflow`, `runApplicationFlow`, and `validateAppRegistration`, and the fallback response omits the `platform` field. |

</details>


</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant UI as UI (GET /status)
    participant API as PipelineResource
    participant Metered as MeteredPipelineServiceClient
    participant Noop as NoopClient

    UI->>API: GET /api/v1/services/ingestionPipelines/status
    API->>Metered: getServiceStatus()
    Metered->>Metered: respondWithMetering("get_status", ...)
    Metered->>Noop: getServiceStatus()
    Noop->>Noop: getServiceStatusInternal() → null
    Noop-->>Metered: null

    alt Before fix (NPE)
        Metered->>Metered: result.getCode() → NullPointerException
        Metered-->>API: 500 Error
    else After fix (null guard)
        Metered->>Metered: "result == null → new PipelineServiceClientResponse().withCode(200)"
        Metered->>Metered: "record metric status=200"
        Metered-->>API: "PipelineServiceClientResponse code=200"
        API-->>UI: 200 OK
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant UI as UI (GET /status)
    participant API as PipelineResource
    participant Metered as MeteredPipelineServiceClient
    participant Noop as NoopClient

    UI->>API: GET /api/v1/services/ingestionPipelines/status
    API->>Metered: getServiceStatus()
    Metered->>Metered: respondWithMetering("get_status", ...)
    Metered->>Noop: getServiceStatus()
    Noop->>Noop: getServiceStatusInternal() → null
    Noop-->>Metered: null

    alt Before fix (NPE)
        Metered->>Metered: result.getCode() → NullPointerException
        Metered-->>API: 500 Error
    else After fix (null guard)
        Metered->>Metered: "result == null → new PipelineServiceClientResponse().withCode(200)"
        Metered->>Metered: "record metric status=200"
        Metered-->>API: "PipelineServiceClientResponse code=200"
        API-->>UI: 200 OK
    end
```

</a>
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `openmetadata-service/src/main/java/org/openmetadata/service/clients/pipeline/MeteredPipelineServiceClient.java`, line 65-94 ([link](https://github.com/open-metadata/openmetadata/blob/2442f9f3b0af778d7aa5e29caea2e715e30fdc2b/openmetadata-service/src/main/java/org/openmetadata/service/clients/pipeline/MeteredPipelineServiceClient.java#L65-L94)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Null guard silently promotes all NoopClient no-ops to 200 OK**

   The `respondWithMetering` null guard is applied to every method routed through it — not just `getServiceStatus`. `NoopClient` also returns `null` from `runAutomationsWorkflow`, `runApplicationFlow`, and `validateAppRegistration`. After this change, those three operations on a NoopClient will return a synthetic 200 OK to callers rather than propagating `null`, which is a silent behavioral change. If any current caller distinguishes between a null result and a success response for those operations, it will now see incorrect semantics. Consider whether the fix should instead live in `NoopClient.getServiceStatusInternal()` — replacing `return null` with `return buildHealthyStatus(DISABLED_STATUS)` — which would be the minimal, targeted change with no side effects on the other methods.

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["Fix metered pipeline null response handl..."](https://github.com/open-metadata/openmetadata/commit/2442f9f3b0af778d7aa5e29caea2e715e30fdc2b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37814164)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->