### PR TITLE
Fixes #29007: refactor(ingestion): migrate api/rest connector to BaseConnection

### DIFF
--- a/ingestion/src/metadata/ingestion/source/api/rest/connection.py
+++ b/ingestion/src/metadata/ingestion/source/api/rest/connection.py
@@ -31,11 +31,12 @@ from metadata.generated.schema.entity.services.connections.api.openAPISchemaURL 
     OpenAPISchemaURL,
 )
 from metadata.generated.schema.entity.services.connections.api.restConnection import (
-    RestConnection,
+    RestConnection as RestConnectionConfig,
 )
 from metadata.generated.schema.entity.services.connections.testConnectionResult import (
     TestConnectionResult,
 )
+from metadata.ingestion.connections.connection import BaseConnection
 from metadata.ingestion.connections.test_connections import test_connection_steps
 from metadata.ingestion.ometa.ometa_api import OpenMetadata
 from metadata.ingestion.source.api.rest.parser import (
@@ -61,7 +62,7 @@ class InvalidOpenAPISchemaError(Exception):
     """
 
 
-def get_connection(connection: RestConnection) -> Union[Response, Dict]:  # noqa: UP006, UP007
+def get_connection(connection: RestConnectionConfig) -> Union[Response, Dict]:  # noqa: UP006, UP007
     """
     Create connection.
     If openAPISchemaURL is provided, fetches the schema via HTTP.
@@ -90,50 +91,55 @@ def get_connection(connection: RestConnection) -> Union[Response, Dict]:  # noqa
     raise ValueError(f"Unsupported openAPISchemaConnection type: {type(schema_conn)}")
 
 
-def test_connection(
-    metadata: OpenMetadata,
-    client: Union[Response, Dict],  # noqa: UP006, UP007
-    service_connection: RestConnection,
-    automation_workflow: Optional[AutomationWorkflow] = None,  # noqa: UP045
-    timeout_seconds: Optional[int] = THREE_MIN,  # noqa: UP045
-) -> TestConnectionResult:
-    """
-    Test connection. This can be executed either as part
-    of a metadata workflow or during an Automation Workflow
-    """
-    is_local_file = isinstance(client, dict)
+class RestConnection(BaseConnection[RestConnectionConfig, Response | dict]):
+    def _get_client(self) -> Response | dict:
+        return get_connection(self.service_connection)
 
-    def custom_url_exec():
-        if is_local_file:
-            return []
-        if client.status_code == 200:
-            return []
-        raise SchemaURLError(
-            "Failed to connect to the JSON schema url. "
-            "Please check the url and credentials. "
-            f"Status Code was: {client.status_code}"
-        )
+    def test_connection(
+        self,
+        metadata: OpenMetadata,
+        automation_workflow: Optional[AutomationWorkflow] = None,  # noqa: UP045
+        timeout_seconds: Optional[int] = THREE_MIN,  # noqa: UP045
+    ) -> TestConnectionResult:
+        """
+        Test connection. This can be executed either as part
+        of a metadata workflow or during an Automation Workflow
+        """
+        client = self.client
+        service_connection = self.service_connection
+        is_local_file = isinstance(client, dict)
 
-    def custom_schema_exec():
-        try:
-            schema = client if is_local_file else parse_openapi_schema(client)
-            if validate_openapi_schema(schema):
+        def custom_url_exec():
+            if is_local_file:
                 return []
+            if client.status_code == 200:  # pyright: ignore[reportAttributeAccessIssue]
+                return []
+            raise SchemaURLError(
+                "Failed to connect to the JSON schema url. "
+                "Please check the url and credentials. "
+                f"Status Code was: {client.status_code}"  # pyright: ignore[reportAttributeAccessIssue]
+            )
 
-            raise InvalidOpenAPISchemaError("Provided schema is not valid OpenAPI specification")  # noqa: TRY301
-        except OpenAPIParseError as e:
-            raise InvalidOpenAPISchemaError(f"Failed to parse OpenAPI schema: {e}")  # noqa: B904
-        except InvalidOpenAPISchemaError:
-            raise
-        except Exception as e:
-            raise InvalidOpenAPISchemaError(f"Error validating OpenAPI schema: {e}")  # noqa: B904
+        def custom_schema_exec():
+            try:
+                schema = client if is_local_file else parse_openapi_schema(client)  # pyright: ignore[reportArgumentType]
+                if validate_openapi_schema(schema):  # pyright: ignore[reportArgumentType]
+                    return []
 
-    test_fn = {"CheckURL": custom_url_exec, "CheckSchema": custom_schema_exec}
+                raise InvalidOpenAPISchemaError("Provided schema is not valid OpenAPI specification")  # noqa: TRY301
+            except OpenAPIParseError as e:
+                raise InvalidOpenAPISchemaError(f"Failed to parse OpenAPI schema: {e}")  # noqa: B904
+            except InvalidOpenAPISchemaError:
+                raise
+            except Exception as e:
+                raise InvalidOpenAPISchemaError(f"Error validating OpenAPI schema: {e}")  # noqa: B904
 
-    return test_connection_steps(
-        metadata=metadata,
-        test_fn=test_fn,
-        service_type=service_connection.type.value,
-        automation_workflow=automation_workflow,
-        timeout_seconds=timeout_seconds,
-    )
+        test_fn = {"CheckURL": custom_url_exec, "CheckSchema": custom_schema_exec}
+
+        return test_connection_steps(
+            metadata=metadata,
+            test_fn=test_fn,
+            service_type=service_connection.type.value,  # pyright: ignore[reportOptionalMemberAccess]
+            automation_workflow=automation_workflow,
+            timeout_seconds=timeout_seconds,
+        )

--- a/ingestion/src/metadata/ingestion/source/api/rest/service_spec.py
+++ b/ingestion/src/metadata/ingestion/source/api/rest/service_spec.py
@@ -1,4 +1,5 @@
+from metadata.ingestion.source.api.rest.connection import RestConnection
 from metadata.ingestion.source.api.rest.metadata import RestSource
 from metadata.utils.service_spec import BaseSpec
 
-ServiceSpec = BaseSpec(metadata_source_class=RestSource)
+ServiceSpec = BaseSpec(metadata_source_class=RestSource, connection_class=RestConnection)  # pyright: ignore[reportArgumentType]

--- a/ingestion/tests/unit/airflow/test_airflow_metadata.py
+++ b/ingestion/tests/unit/airflow/test_airflow_metadata.py
@@ -17,6 +17,7 @@ connect to Airflow 2.x databases (which have execution_date column).
 """
 
 from datetime import datetime, timezone
+from types import SimpleNamespace
 from unittest.mock import MagicMock, PropertyMock, patch
 from uuid import uuid4
 
@@ -333,13 +334,19 @@ class TestYieldPipelineStatus:
         return AirflowSource.__new__(AirflowSource)
 
     def _make_dag_run(self, logical_date, start_date):
-        dag_run = MagicMock(spec=DagRun)
-        dag_run.run_id = "manual__2024-01-01"
-        dag_run.dag_id = "test_dag"
-        dag_run.state = "success"
-        dag_run.logical_date = logical_date
-        dag_run.start_date = start_date
-        return dag_run
+        # A SimpleNamespace carries exactly the attributes yield_pipeline_status
+        # reads. MagicMock(spec=DagRun) would force SQLAlchemy to configure the
+        # whole shared mapper registry (via DagRun's association proxies) just to
+        # build the mock; if any unrelated test on the same xdist worker has left
+        # a mapper in a failed state, that configuration raises and this test
+        # fails for reasons that have nothing to do with what it verifies.
+        return SimpleNamespace(
+            run_id="manual__2024-01-01",
+            dag_id="test_dag",
+            state="success",
+            logical_date=logical_date,
+            start_date=start_date,
+        )
 
     @patch(
         "metadata.ingestion.source.pipeline.airflow.metadata.AirflowSource.__init__",

--- a/ingestion/tests/unit/source/__init__.py
+++ b/ingestion/tests/unit/source/__init__.py
@@ -1,0 +1,10 @@
+#  Copyright 2025 Collate
+#  Licensed under the Collate Community License, Version 1.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  https://github.com/open-metadata/OpenMetadata/blob/main/ingestion/LICENSE
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.

--- a/ingestion/tests/unit/source/api/__init__.py
+++ b/ingestion/tests/unit/source/api/__init__.py
@@ -1,0 +1,10 @@
+#  Copyright 2025 Collate
+#  Licensed under the Collate Community License, Version 1.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  https://github.com/open-metadata/OpenMetadata/blob/main/ingestion/LICENSE
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.

--- a/ingestion/tests/unit/source/api/rest/__init__.py
+++ b/ingestion/tests/unit/source/api/rest/__init__.py
@@ -1,0 +1,10 @@
+#  Copyright 2025 Collate
+#  Licensed under the Collate Community License, Version 1.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  https://github.com/open-metadata/OpenMetadata/blob/main/ingestion/LICENSE
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.

--- a/ingestion/tests/unit/source/api/rest/test_connection.py
+++ b/ingestion/tests/unit/source/api/rest/test_connection.py
@@ -1,0 +1,40 @@
+#  Copyright 2025 Collate
+#  Licensed under the Collate Community License, Version 1.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  https://github.com/open-metadata/OpenMetadata/blob/main/ingestion/LICENSE
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+"""Unit tests for REST API connection handling."""
+
+from unittest.mock import MagicMock, patch
+
+from metadata.ingestion.connections.connection import BaseConnection
+from metadata.ingestion.source.api.rest.connection import RestConnection
+
+CONNECTION_MODULE = "metadata.ingestion.source.api.rest.connection"
+
+
+def test_rest_connection_is_base_connection():
+    assert issubclass(RestConnection, BaseConnection)
+
+
+def test_get_client_delegates_to_get_connection():
+    with patch(f"{CONNECTION_MODULE}.get_connection") as mock_get:
+        conn = RestConnection(MagicMock())
+        client = conn.client
+
+    assert client is mock_get.return_value
+    mock_get.assert_called_once_with(conn.service_connection)
+
+
+def test_test_connection_runs_steps():
+    conn = RestConnection(MagicMock())
+    conn._client = MagicMock()
+    with patch(f"{CONNECTION_MODULE}.test_connection_steps") as mock_step:
+        result = conn.test_connection(metadata=MagicMock())
+
+    assert result is mock_step.return_value


### PR DESCRIPTION
Fixes #29007

## What

Migrates the **api/rest** (OpenAPI) connector onto `BaseConnection[Config, Client]` — the last deferred standard case in the rollout.

## The unusual bit (and why it still fits)

Unlike every other connector, rest's `get_connection` doesn't return a stateful client — it returns the **fetched OpenAPI schema itself**:

```python
def get_connection(connection: RestConnection) -> Union[Response, Dict]:
    if isinstance(schema_conn, OpenAPISchemaURL):      return requests.get(...)            # Response
    if isinstance(schema_conn, OpenAPISchemaFilePath): return parse_..._from_file(...)     # dict
    if isinstance(schema_conn, OpenAPISchemaS3):       return parse_..._from_s3(...)        # dict
```

`BaseConnection[S, C]` is generic over `C`, so `Response | Dict` is a perfectly valid client type — `test_connection` and `rest/metadata.py` already branch on `isinstance(client, dict)`. No framework change is needed.

## How

- `RestConnection(BaseConnection[RestConnectionConfig, Response | Dict])` with `_get_client` + `test_connection`; `connection_class` wired into the spec.
- The api base source (`api_service.py`) already resolves the connection and runs `test_connection` through `metadata.ingestion.source.connections`, so no source-side changes.
- `get_connection` stays module-level (a unit test imports it); the class delegates.

## Tests

- Colocated `tests/unit/source/api/rest/test_connection.py` (3 tests).
- Existing `test_rest.py` passes (66).
- `basedpyright` baseline check clean; `ruff` clean.

## Note — bundled test-isolation fix

Includes the one-commit fix from #28995 (airflow registry-pollution test isolation), identical content, merges cleanly whichever lands first.