### PR TITLE
Fix #28932 upgrade micrometer version to 1.14.16 to remediate cve-202…

### DIFF
--- a/openmetadata-service/pom.xml
+++ b/openmetadata-service/pom.xml
@@ -514,7 +514,7 @@
     <dependency>
       <groupId>io.micrometer</groupId>
       <artifactId>micrometer-bom</artifactId>
-      <version>1.14.16</version>
+      <version>1.16.6</version>
       <type>pom</type>
       <scope>import</scope>
     </dependency>
@@ -533,20 +533,20 @@
     <dependency>
       <groupId>io.micrometer</groupId>
       <artifactId>micrometer-observation</artifactId>
-      <version>1.14.16</version>
+      <version>1.16.6</version>
     </dependency>
 
     <!-- Micrometer Prometheus -->
     <dependency>
       <groupId>io.micrometer</groupId>
       <artifactId>micrometer-registry-prometheus</artifactId>
-      <version>1.14.16</version>
+      <version>1.16.6</version>
     </dependency>
 
     <dependency>
       <groupId>io.micrometer</groupId>
       <artifactId>micrometer-core</artifactId>
-      <version>1.14.16</version>
+      <version>1.16.6</version>
     </dependency>
 
 

--- a/openmetadata-service/pom.xml
+++ b/openmetadata-service/pom.xml
@@ -514,7 +514,7 @@
     <dependency>
       <groupId>io.micrometer</groupId>
       <artifactId>micrometer-bom</artifactId>
-      <version>1.14.5</version>
+      <version>1.14.16</version>
       <type>pom</type>
       <scope>import</scope>
     </dependency>
@@ -533,20 +533,20 @@
     <dependency>
       <groupId>io.micrometer</groupId>
       <artifactId>micrometer-observation</artifactId>
-      <version>1.14.5</version>
+      <version>1.14.16</version>
     </dependency>
 
     <!-- Micrometer Prometheus -->
     <dependency>
       <groupId>io.micrometer</groupId>
       <artifactId>micrometer-registry-prometheus</artifactId>
-      <version>1.14.5</version>
+      <version>1.14.16</version>
     </dependency>
 
     <dependency>
       <groupId>io.micrometer</groupId>
       <artifactId>micrometer-core</artifactId>
-      <version>1.14.5</version>
+      <version>1.14.16</version>
     </dependency>
 
 

--- a/openmetadata-service/src/test/java/org/openmetadata/service/apps/bundles/searchIndex/distributed/PartitionWorkerTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/apps/bundles/searchIndex/distributed/PartitionWorkerTest.java
@@ -45,6 +45,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -72,6 +73,8 @@ import org.openmetadata.service.jdbi3.CollectionDAO;
 import org.openmetadata.service.jdbi3.EntityRepository;
 import org.openmetadata.service.jdbi3.ListFilter;
 import org.openmetadata.service.search.ReindexContext;
+import org.openmetadata.service.search.SearchClient;
+import org.openmetadata.service.search.SearchRepository;
 import org.openmetadata.service.util.RestUtil;
 import org.openmetadata.service.workflows.searchIndex.PaginatedEntitiesSource;
 import org.openmetadata.service.workflows.searchIndex.PaginatedEntityTimeSeriesSource;
@@ -88,16 +91,27 @@ class PartitionWorkerTest {
   @Mock private ReindexingConfiguration reindexingConfiguration;
 
   private PartitionWorker worker;
+  private SearchRepository previousSearchRepository;
 
   private static final int BATCH_SIZE = 100;
   private static final String TEST_SERVER_ID = "test-server-1";
 
   @BeforeEach
   void setUp() {
+    previousSearchRepository = Entity.getSearchRepository();
+    SearchRepository searchRepository = mock(SearchRepository.class);
+    when(searchRepository.getSearchClient()).thenReturn(mock(SearchClient.class));
+    Entity.setSearchRepository(searchRepository);
+
     when(stagedIndexContext.getStagedIndex(any()))
         .thenAnswer(
             invocation -> Optional.of(invocation.getArgument(0, String.class) + "_staging"));
     worker = new PartitionWorker(coordinator, bulkSink, BATCH_SIZE, stagedIndexContext);
+  }
+
+  @AfterEach
+  void tearDown() {
+    Entity.setSearchRepository(previousSearchRepository);
   }
 
   @Test

--- a/pom.xml
+++ b/pom.xml
@@ -503,7 +503,7 @@
       <dependency>
         <groupId>io.prometheus</groupId>
         <artifactId>prometheus-metrics-instrumentation-dropwizard</artifactId>
-        <version>1.3.6</version>
+        <version>1.6.1</version>
       </dependency>
 
 


### PR DESCRIPTION
…6-40984

<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Upgrade micrometer version to remediate CVE-2026-40984

Fixes #28932 
<!--
Linking an issue is REQUIRED. Replace <issue-number> with the GitHub issue number this PR addresses
(e.g., `Fixes #12345`). GitHub will auto-link it. If no issue exists, please open one first so the
problem and design can be discussed before review.
-->

<!--
Short blurb explaining:
- What changes did you make?
- Why did you make them?
-->

I worked on it because my company requires this remediation in order to adopt OpenMetaData

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [x] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### High-level design:
<!--
REQUIRED for large PRs (new features, refactors, breaking changes, or anything touching >5 files).
Skip for small bug fixes and trivial changes.

Cover:
- Architecture / approach you took and why
- Key components or files added/changed and how they interact
- Alternatives considered and why you rejected them
- Any migration, backward-compatibility, or rollout concerns
- Diagrams or links to design docs / RFCs if available
-->

N/A — small change. <!-- Or fill in the design above -->

#
### Tests:

#### Use cases covered
<!--
List the user-visible scenarios this PR exercises. Example:
- User with Admin role can create a Glossary Term with a parent term
- Ingestion run for Snowflake correctly extracts row counts for partitioned tables
-->

#### Unit tests
<!--
- [ ] I added unit tests for the new/changed logic.
- Files added/updated:
- Coverage on changed classes (run `mvn jacoco:report` for backend, `yarn test:coverage` for UI,
  `make unit_ingestion` for ingestion). Target is 90% line coverage on changed classes.
- Coverage %: <e.g., 92% on EntityRepository.java>
-->

#### Backend integration tests
<!--
- [ ] I added integration tests in `openmetadata-integration-tests/` for new/changed API endpoints.
- [ ] Not applicable (no backend API changes).
- Files added/updated:
-->

#### Ingestion integration tests
<!--
- [ ] I added/updated ingestion integration tests for connector changes.
- [ ] Not applicable (no ingestion changes).
- Files added/updated:
-->

#### Playwright (UI) tests
<!--
- [ ] I added Playwright E2E tests under `openmetadata-ui/.../ui/playwright/` for UI changes.
- [ ] Not applicable (no UI changes).
- Files added/updated:
-->

#### Manual testing performed
<!--
List the manual test steps you performed before requesting review. Example:
1. Started local stack via `./docker/run_local_docker.sh -m ui -d mysql`
2. Logged in as admin, created entity X, verified Y appears in the UI
3. Triggered ingestion for Snowflake source, confirmed lineage edges in the explore page
-->

#
### UI screen recording / screenshots:
<!--
REQUIRED for any PR that changes the UI. Drag-and-drop a short screen recording (.mov / .mp4 / .gif)
demonstrating the change end-to-end, plus before/after screenshots where relevant.
Mark "Not applicable" if there are no UI changes.
-->

Not applicable. <!-- Or attach recording/screenshots above -->

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] My PR title is `Fixes 28932: upgrade micrometer version to 1.14.16 to remediate cve-2026-40984`
- [x] My PR is linked to a GitHub issue via `Fixes #28932` above.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.
- [x] For UI changes: I attached a screen recording and/or screenshots above.
- [x] I have added tests (unit / integration / Playwright as applicable) and listed them above.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->

----
## Summary by Gitar

- **Dependency upgrades:**
  - Upgraded Micrometer to `1.16.6` across the project to remediate `CVE-2026-40984`.
  - Updated `prometheus-metrics-instrumentation-dropwizard` to `1.6.1` in the root `pom.xml`.
- **Test infrastructure:**
  - Added `SearchRepository` mock configuration and cleanup logic to `PartitionWorkerTest` to ensure test isolation.

<sub>This will update automatically on new commits.</sub>

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR remediates CVE-2026-40984 (Micrometer HTTP server instrumentation DoS) by upgrading micrometer dependencies and also bumps the Prometheus Dropwizard bridge alongside a test isolation fix in `PartitionWorkerTest`.

- **Micrometer version bump** (`openmetadata-service/pom.xml`): four micrometer artifacts (`micrometer-bom`, `micrometer-observation`, `micrometer-registry-prometheus`, `micrometer-core`) are upgraded from 1.14.5 to 1.16.6. The PR title states the target is 1.14.16, creating an ambiguity about whether the intended fix is a same-branch patch or a cross-branch jump.
- **Prometheus Dropwizard bridge bump** (`pom.xml`): `prometheus-metrics-instrumentation-dropwizard` jumps from 1.3.6 to 1.6.1; this artifact is unrelated to the CVE advisory and the upgrade appears to be bundled incidentally.
- **Test isolation fix** (`PartitionWorkerTest.java`): adds `@BeforeEach`/`@AfterEach` hooks to save and restore the global `SearchRepository`, preventing test state leakage.
</details>

<details open><summary><h3>Confidence Score: 3/5</h3></summary>

The CVE is remediated, but the version actually applied (1.16.6) does not match the version stated in the PR title (1.14.16), and the jump spans two minor versions beyond where the project was; this needs confirmation before merging.

The core question — whether the code intentionally targets 1.16.6 or whether 1.14.16 was meant — is unresolved. If 1.16.6 is correct, the micrometer 1.15 and 1.16 release notes need to be reviewed for breaking changes against this codebase. The bundled prometheus bump (1.3.6 → 1.6.1) adds further unverified surface area. Together these make the PR riskier than a simple patch-level CVE fix would be.

openmetadata-service/pom.xml — the micrometer version applied differs from the PR title; pom.xml — the prometheus version bump needs justification.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-service/pom.xml | Micrometer dependencies bumped from 1.14.5 to 1.16.6 (four artifacts). The version in the code (1.16.6) does not match the PR title (1.14.16); either title or code has an error. The jump spans two minor versions from the previously used 1.14.x line. |
| pom.xml | prometheus-metrics-instrumentation-dropwizard bumped from 1.3.6 to 1.6.1 — a large independent jump not required by the CVE advisory, bundled alongside the micrometer upgrade. |
| openmetadata-service/src/test/java/org/openmetadata/service/apps/bundles/searchIndex/distributed/PartitionWorkerTest.java | Adds proper test isolation: saves/restores the global SearchRepository in @BeforeEach/@AfterEach and sets up a mock SearchClient. This is a clean improvement in test hygiene. |

</details>

</details>

<details open><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["Project was on micrometer 1.14.5"] --> B{"CVE-2026-40984\nremediation path?"}
    B -->|"Same branch fix\n(PR title)"| C["Upgrade to 1.14.16\n(minimal change)"]
    B -->|"Cross-branch fix\n(actual code)"| D["Upgrade to 1.16.6\n(two minor versions ahead)"]
    C --> E["✅ CVE fixed\nLow regression risk"]
    D --> F["✅ CVE fixed\nHigher regression risk\n(1.14→1.15→1.16 API changes)"]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["Project was on micrometer 1.14.5"] --> B{"CVE-2026-40984\nremediation path?"}
    B -->|"Same branch fix\n(PR title)"| C["Upgrade to 1.14.16\n(minimal change)"]
    B -->|"Cross-branch fix\n(actual code)"| D["Upgrade to 1.16.6\n(two minor versions ahead)"]
    C --> E["✅ CVE fixed\nLow regression risk"]
    D --> F["✅ CVE fixed\nHigher regression risk\n(1.14→1.15→1.16 API changes)"]
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["#28932 upgrade micrometer to 1.16.6 as 1..."](https://github.com/open-metadata/openmetadata/commit/838300ae478962dd1487d3edb8deb169d9a6bf91) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37814156)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->