### PR TITLE
Fix MCP default loading when settings row is missing

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/settings/SettingsCache.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/settings/SettingsCache.java
@@ -47,6 +47,7 @@ import org.openmetadata.api.configuration.ThemeConfiguration;
 import org.openmetadata.api.configuration.UiThemePreference;
 import org.openmetadata.common.utils.CommonUtil;
 import org.openmetadata.schema.api.configuration.LoginConfiguration;
+import org.openmetadata.schema.api.configuration.MCPConfiguration;
 import org.openmetadata.schema.api.lineage.LineageLayer;
 import org.openmetadata.schema.api.lineage.LineageSettings;
 import org.openmetadata.schema.api.search.AssetTypeConfiguration;
@@ -290,14 +291,13 @@ public class SettingsCache {
     Settings storedMcpConfig =
         Entity.getSystemRepository().getConfigWithKey(MCP_CONFIGURATION.toString());
     if (storedMcpConfig == null) {
-      org.openmetadata.schema.api.configuration.MCPConfiguration mcpConfig =
-          applicationConfig.getMcpConfiguration();
-      if (mcpConfig != null) {
-        Settings setting =
-            new Settings().withConfigType(MCP_CONFIGURATION).withConfigValue(mcpConfig);
+      MCPConfiguration mcpConfig = applicationConfig.getMcpConfiguration();
+      Settings setting =
+          new Settings()
+              .withConfigType(MCP_CONFIGURATION)
+              .withConfigValue(mcpConfig != null ? mcpConfig : getDefaultMcpConfiguration());
 
-        Entity.getSystemRepository().createNewSetting(setting);
-      }
+      Entity.getSystemRepository().createNewSetting(setting);
     }
 
     Settings storedScimConfig =
@@ -570,6 +570,11 @@ public class SettingsCache {
         .withTemplates(SmtpSettings.Templates.OPENMETADATA);
   }
 
+  private static MCPConfiguration getDefaultMcpConfiguration() {
+    return JsonUtils.convertValue(
+        new org.openmetadata.service.config.MCPConfiguration(), MCPConfiguration.class);
+  }
+
   @SuppressWarnings("unchecked")
   public static Map<String, Float> getAggregatedSearchFields() {
     try {
@@ -668,6 +673,15 @@ public class SettingsCache {
           LOG.info("Loaded Setting {}", fetchedSettings.getConfigType());
           // When SEARCH_SETTINGS are loaded, invalidate aggregated fields cache
           CACHE.invalidate(SEARCH_SETTINGS_AGGREGATED_FIELDS);
+        }
+        case MCP_CONFIGURATION -> {
+          fetchedSettings = Entity.getSystemRepository().getConfigWithKey(settingsName);
+          if (fetchedSettings == null) {
+            return new Settings()
+                .withConfigType(MCP_CONFIGURATION)
+                .withConfigValue(getDefaultMcpConfiguration());
+          }
+          LOG.info("Loaded Setting {}", fetchedSettings.getConfigType());
         }
         default -> {
           fetchedSettings = Entity.getSystemRepository().getConfigWithKey(settingsName);

--- a/openmetadata-service/src/test/java/org/openmetadata/service/resources/settings/SettingsCacheDefaultCaseTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/resources/settings/SettingsCacheDefaultCaseTest.java
@@ -1,7 +1,7 @@
 package org.openmetadata.service.resources.settings;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.when;
@@ -9,8 +9,10 @@ import static org.mockito.Mockito.when;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;
+import org.openmetadata.schema.api.configuration.MCPConfiguration;
 import org.openmetadata.schema.settings.Settings;
 import org.openmetadata.schema.settings.SettingsType;
+import org.openmetadata.schema.utils.JsonUtils;
 import org.openmetadata.service.Entity;
 import org.openmetadata.service.jdbi3.SystemRepository;
 
@@ -42,7 +44,7 @@ class SettingsCacheDefaultCaseTest {
   }
 
   @Test
-  void testDefaultCaseWithNullResult() {
+  void testDefaultCaseWithNullResult() throws Exception {
     try (MockedStatic<Entity> entityMock = mockStatic(Entity.class)) {
       SystemRepository mockSystemRepo = mock(SystemRepository.class);
       String key = SettingsType.MCP_CONFIGURATION.toString();
@@ -51,7 +53,16 @@ class SettingsCacheDefaultCaseTest {
 
       SettingsCache.CACHE.invalidate(key);
 
-      assertThrows(Exception.class, () -> SettingsCache.CACHE.get(key));
+      Settings result = SettingsCache.CACHE.get(key);
+
+      assertNotNull(result);
+      assertEquals(SettingsType.MCP_CONFIGURATION, result.getConfigType());
+
+      MCPConfiguration mcpConfig =
+          JsonUtils.convertValue(result.getConfigValue(), MCPConfiguration.class);
+      assertNotNull(mcpConfig);
+      assertEquals("openmetadata-mcp-server", mcpConfig.getMcpServerName());
+      assertEquals("/api/v1/mcp", mcpConfig.getPath());
     }
   }
 }


### PR DESCRIPTION
## Summary
- seed a default `mcpConfiguration` settings row when it is missing during initialization
- return a default MCP config from `SettingsCache` instead of allowing a null cache load
- update the MCP settings cache unit test to cover the missing-row path

## Testing
- Not run locally in this environment (`mvn` was not available)

Closes #28960
