### PR TITLE
feat(snowflake): forward-port ACCESS_HISTORY lineage + cache fixes to 1.12.11

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -229,6 +229,14 @@ yarn parse-schema              # Parse JSON schemas for frontend (connection and
 - This keeps the codebase modular and prevents generic utilities from becoming cluttered with connector-specific edge cases
 - **Use `model_str()` for Pydantic RootModel to string conversion** — OpenMetadata schema types like `ColumnName`, `EntityName`, `FullyQualifiedEntityName`, and `UUID` are Pydantic `RootModel[str]` subclasses where `str()` returns `"root='value'"` instead of the raw value. Always use `model_str()` from `metadata.ingestion.ometa.utils` instead of manual `hasattr(x, "root")` / `str(x.root)` checks.
 
+### Caching
+- **All caches MUST be bounded.** Never use a bare `dict` / `HashMap` / `Map` as a cache without an explicit size cap — they grow with the input and cause OOMs on large catalogs/ingestions. The only exception is when the user explicitly asks for an unbounded cache for a specific case.
+- Pick a sane default (typically 100–1000 entries depending on entity size); if you're unsure, ask the user.
+- **Python**: use `collections.OrderedDict` with `popitem(last=False)` eviction after insert, `@functools.lru_cache(maxsize=N)`, or `cachetools.LRUCache`. Cache both hits and misses (negative caching) — repeated unresolvable lookups are a common hot path.
+- **Java**: use Caffeine (`Caffeine.newBuilder().maximumSize(N).build()`) or Guava `CacheBuilder.newBuilder().maximumSize(N).build()`. Never a bare `HashMap`.
+- **TypeScript**: use `lru-cache` — never a bare `Map` or plain object.
+- **Before adding a cache, check whether the underlying call is already cached at a lower layer.** Example: `OpenMetadata._search_es_entity` is `@lru_cache(maxsize=512)`, so wrapping `get_entity_from_es` / `es_search_container_by_path` calls in a local dict cache is redundant — drop the local cache and rely on the existing LRU.
+
 ### Testing Philosophy
 - **Test real behavior, not mock wiring** - if a test requires mocking 3+ classes just to verify a method call, it's testing the wrong thing
 - **Prefer integration tests** over heavily-mocked unit tests. This project has full integration test infrastructure (OpenMetadataApplicationTest, Docker containers, real OpenSearch). Use it.

--- a/ingestion/src/metadata/ingestion/source/database/snowflake/connection.py
+++ b/ingestion/src/metadata/ingestion/source/database/snowflake/connection.py
@@ -45,6 +45,7 @@ from metadata.ingestion.connections.test_connections import (
 )
 from metadata.ingestion.ometa.ometa_api import OpenMetadata
 from metadata.ingestion.source.database.snowflake.queries import (
+    SNOWFLAKE_ACCESS_HISTORY_PROBE,
     SNOWFLAKE_GET_DATABASES,
     SNOWFLAKE_TEST_FETCH_TAG,
     SNOWFLAKE_TEST_GET_QUERIES,
@@ -108,6 +109,28 @@ def test_table_query(engine_wrapper: SnowflakeEngineWrapper, statement: str):
         engine=engine_wrapper.engine,
         statement=statement.format(database_name=engine_wrapper.database_name),
     )
+
+
+def probe_access_history_available(engine: Engine, account_usage_schema: str) -> bool:
+    """
+    Check whether the configured Snowflake role can read ACCOUNT_USAGE.ACCESS_HISTORY.
+
+    Required for the ACCESS_HISTORY-based lineage path. Standard Edition accounts
+    or roles without `IMPORTED PRIVILEGES ON DATABASE SNOWFLAKE` will fail this
+    probe and the caller should fall back to the legacy parser path.
+
+    Logs failures at INFO (not WARNING) — Standard Edition is a legitimate state.
+    """
+    try:
+        with engine.connect() as conn:
+            conn.execute(text(SNOWFLAKE_ACCESS_HISTORY_PROBE.format(account_usage=account_usage_schema)))
+    except Exception as exc:
+        logger.info(
+            f"ACCESS_HISTORY probe failed (will fall back to legacy lineage path): {exc}. "
+            f"Ensure the role has IMPORTED PRIVILEGES ON DATABASE SNOWFLAKE and the account is Enterprise+."
+        )
+        return False
+    return True
 
 
 class SnowflakeConnection(BaseConnection[SnowflakeConnectionConfig, Engine]):

--- a/ingestion/src/metadata/ingestion/source/database/snowflake/lineage.py
+++ b/ingestion/src/metadata/ingestion/source/database/snowflake/lineage.py
@@ -12,12 +12,43 @@
 Snowflake lineage module
 """
 
+import json
 import traceback
-from typing import Iterator
+from typing import Any, Iterable, Iterator, List, Optional, Tuple, Union  # noqa: UP035
 
+from cachetools import LRUCache
+from sqlalchemy import text
+
+from metadata.generated.schema.api.data.createQuery import CreateQueryRequest
+from metadata.generated.schema.api.lineage.addLineage import AddLineageRequest
+from metadata.generated.schema.entity.data.container import Container
+from metadata.generated.schema.entity.data.table import Table
+from metadata.generated.schema.metadataIngestion.workflow import (
+    Source as WorkflowSource,
+)
+from metadata.generated.schema.type.entityLineage import (
+    ColumnLineage,
+    EntitiesEdge,
+    LineageDetails,
+)
+from metadata.generated.schema.type.entityLineage import Source as LineageEdgeSource
+from metadata.generated.schema.type.entityReference import EntityReference
 from metadata.generated.schema.type.tableQuery import TableQuery
+from metadata.ingestion.api.models import Either
+from metadata.ingestion.connections.builders import get_connection_options_dict
+from metadata.ingestion.lineage.sql_lineage import get_column_fqn
+from metadata.ingestion.ometa.ometa_api import OpenMetadata
 from metadata.ingestion.source.database.lineage_source import LineageSource
+from metadata.ingestion.source.database.snowflake.connection import (
+    probe_access_history_available,
+)
+from metadata.ingestion.source.database.snowflake.models import (
+    AccessHistoryRow,
+    CopyHistoryRow,
+)
 from metadata.ingestion.source.database.snowflake.queries import (
+    SNOWFLAKE_ACCESS_HISTORY_LINEAGE,
+    SNOWFLAKE_COPY_HISTORY_LINEAGE,
     SNOWFLAKE_GET_STORED_PROCEDURE_QUERIES,
     SNOWFLAKE_SQL_STATEMENT,
 )
@@ -28,10 +59,26 @@ from metadata.ingestion.source.database.snowflake.query_parser import (
 from metadata.ingestion.source.database.stored_procedures_mixin import (
     StoredProcedureLineageMixin,
 )
+from metadata.utils import fqn
 from metadata.utils.helpers import get_start_and_end
 from metadata.utils.logger import ingestion_logger
 
 logger = ingestion_logger()
+
+USE_ACCESS_HISTORY_OPTION_KEY = "useAccessHistory"
+
+TABLE_CACHE_MAX_SIZE = 100
+
+EXTERNAL_STAGE_PREFIXES = ("s3://", "azure://", "gcs://", "https://")
+
+LINEAGE_OBJECT_DOMAINS = {
+    "Table",
+    "View",
+    "Materialized view",
+    "Dynamic table",
+    "External table",
+    "Iceberg table",
+}
 
 
 class SnowflakeLineageSource(
@@ -54,6 +101,58 @@ class SnowflakeLineageSource(
     """
 
     stored_procedure_query = SNOWFLAKE_GET_STORED_PROCEDURE_QUERIES
+
+    def __init__(
+        self,
+        config: WorkflowSource,
+        metadata: OpenMetadata,
+        get_engine: bool = True,
+    ):
+        # Pop the OM-specific flag from connectionOptions BEFORE the parent
+        # creates the SQLAlchemy engine — the Snowflake URL builder copies
+        # every connectionOptions entry into the URL query string, so the
+        # driver would otherwise receive an unknown `useAccessHistory` param.
+        self._use_access_history = self._pop_access_history_flag(config)
+        super().__init__(config, metadata, get_engine=get_engine)
+        self._table_cache: LRUCache = LRUCache(maxsize=TABLE_CACHE_MAX_SIZE)
+        if self._use_access_history and self.engine is not None:
+            available = probe_access_history_available(self.engine, self.service_connection.accountUsageSchema)
+            if not available:
+                logger.warning(
+                    "useAccessHistory was set in connectionOptions but the ACCESS_HISTORY probe failed; "
+                    "falling back to legacy QUERY_HISTORY parser path."
+                )
+                self._use_access_history = False
+            else:
+                logger.info("ACCESS_HISTORY-based lineage path enabled via connectionOptions.useAccessHistory.")
+
+    @staticmethod
+    def _pop_access_history_flag(config: WorkflowSource) -> bool:
+        """
+        Read and remove the OM-specific `useAccessHistory` key from
+        connectionOptions on the workflow config. Called before the parent
+        init so the popped key never reaches the Snowflake driver URL.
+        """
+        service_connection = config.serviceConnection.root.config  # pyright: ignore[reportOptionalMemberAccess]
+        options = get_connection_options_dict(service_connection)
+        if not options:
+            return False
+        raw = options.pop(USE_ACCESS_HISTORY_OPTION_KEY, None)
+        if raw is None:
+            return False
+        return str(raw).strip().lower() == "true"
+
+    def _build_filter_condition_clause(self) -> str:
+        """
+        Render `sourceConfig.filterCondition` as an extra `AND (...)` predicate
+        scoped to the access_history_filtered CTE. Unqualified column names
+        resolve against `qh` (QUERY_HISTORY) — e.g. `query_type = 'COPY'`,
+        `user_name = 'etl_user'`, `query_text ILIKE '%my_pipeline%'`.
+        """
+        condition = getattr(self.source_config, "filterCondition", None)
+        if not condition:
+            return ""
+        return f"AND ({condition})"
 
     def get_stored_procedure_sql_statement(self) -> str:
         """
@@ -93,28 +192,331 @@ class SnowflakeLineageSource(
                             limit=batch_size,
                         )
                     )
-                for row in rows:
-                    query_dict = dict(row)
-                    query_dict.update({k.lower(): v for k, v in query_dict.items()})
-                    row_count += 1
-                    try:
-                        yield TableQuery(
-                            dialect=self.dialect.value,
-                            query=query_dict["query_text"],
-                            databaseName=self.get_database_name(query_dict),
-                            serviceName=self.config.serviceName,
-                            databaseSchema=self.get_schema_name(query_dict),
-                        )
-                    except Exception as exc:
-                        logger.debug(traceback.format_exc())
-                        logger.warning(
-                            f"Error processing query_dict {query_dict}: {exc}"
-                        )
+                    for row in rows:
+                        query_dict = row._asdict()
+                        query_dict.update({k.lower(): v for k, v in query_dict.items()})
+                        row_count += 1
+                        try:
+                            yield TableQuery(
+                                dialect=self.dialect.value,
+                                query=query_dict["query_text"],
+                                databaseName=self.get_database_name(query_dict),
+                                serviceName=self.config.serviceName,
+                                databaseSchema=self.get_schema_name(query_dict),
+                            )
+                        except Exception as exc:
+                            logger.debug(traceback.format_exc())
+                            logger.warning("Error processing query_dict %s: %s", query_dict, exc)
                 total_fetched += row_count
                 if row_count < batch_size:
                     break
                 offset += batch_size
                 logger.info(
-                    f"Fetching next page with offset {offset} (fetched {total_fetched}/{max_results}) "
-                    f"for lineage queries"
+                    "Fetching next page with offset %d (fetched %d/%d) for lineage queries",
+                    offset,
+                    total_fetched,
+                    max_results,
                 )
+
+    def yield_query_lineage(
+        self,
+    ) -> Iterable[Either[Union[AddLineageRequest, CreateQueryRequest]]]:  # noqa: UP007
+        """
+        Dispatch lineage extraction to either the ACCESS_HISTORY path (gated by
+        `useAccessHistory` in connectionOptions) or the legacy QUERY_HISTORY +
+        client-side parser path.
+        """
+        if self._use_access_history:
+            logger.info("Processing Query Lineage via ACCESS_HISTORY")
+            yield from self._yield_access_history_lineage()  # pyright: ignore[reportReturnType]
+            return
+        yield from super().yield_query_lineage()
+
+    def _yield_access_history_lineage(self) -> Iterable[Either[AddLineageRequest]]:
+        """
+        Stream one row per directed table edge from the combined ACCESS_HISTORY
+        SQL — column-pairs are aggregated into a VARIANT array per edge inside
+        Snowflake, so client memory stays O(1) regardless of catalog size.
+        """
+        yield from self._yield_combined_access_history()
+        yield from self._yield_copy_history_lineage()
+
+    def _yield_combined_access_history(self) -> Iterable[Either[AddLineageRequest]]:
+        """
+        Run the single combined ACCESS_HISTORY query and emit one
+        `AddLineageRequest` per row. Uses `stream_results=True` so the
+        snowflake-sqlalchemy cursor streams rather than buffering.
+        """
+        sql_statement = SNOWFLAKE_ACCESS_HISTORY_LINEAGE.format(
+            account_usage=self.service_connection.accountUsageSchema,
+            start_time=self.start,
+            end_time=self.end,
+            filter_condition=self._build_filter_condition_clause(),
+        )
+        emitted = 0
+        emitted_with_sql = 0
+        skipped = 0
+        try:
+            for engine in self.get_engine():
+                if engine is None:
+                    continue
+                with engine.connect() as conn:
+                    logger.debug("Executing combined ACCESS_HISTORY lineage query: %s", sql_statement)
+                    rows = conn.execution_options(stream_results=True, max_row_buffer=1000).execute(text(sql_statement))
+                    for raw_row in rows:
+                        row = AccessHistoryRow(**self._row_to_lower_dict(raw_row))
+                        edge = self._build_access_history_edge(row)
+                        if edge is None:
+                            skipped += 1
+                            continue
+                        emitted += 1
+                        if row.query_text:
+                            emitted_with_sql += 1
+                        yield Either(right=edge)  # pyright: ignore[reportCallIssue]
+        except Exception as exc:
+            logger.warning("Failed to extract lineage from ACCESS_HISTORY: %s", exc)
+            logger.debug(traceback.format_exc())
+        logger.info(
+            "ACCESS_HISTORY lineage: emitted %d edges (%d with SQL text), "
+            "skipped %d (unresolvable downstream/upstream tables)",
+            emitted,
+            emitted_with_sql,
+            skipped,
+        )
+
+    def _build_access_history_edge(self, row: AccessHistoryRow) -> Optional[AddLineageRequest]:  # noqa: UP045
+        """
+        Resolve both sides of a table edge to OM Table entities and build the
+        AddLineageRequest, attaching column lineage parsed from the row's
+        VARIANT `COLUMN_PAIRS` array (already aggregated server-side).
+        """
+        if not (row.downstream_table and row.upstream_table):
+            return None
+
+        downstream_entity = self._resolve_snowflake_table(row.downstream_table)
+        upstream_entity = self._resolve_snowflake_table(row.upstream_table)
+        if downstream_entity is None or upstream_entity is None:
+            return None
+
+        column_pairs = self._parse_column_pairs(row.column_pairs)
+        columns_lineage = self._build_columns_lineage(downstream_entity, upstream_entity, column_pairs)
+
+        lineage_details = LineageDetails(  # pyright: ignore[reportCallIssue]
+            source=LineageEdgeSource.QueryLineage,
+            sqlQuery=row.query_text or None,
+            columnsLineage=columns_lineage or None,
+        )
+
+        return AddLineageRequest(
+            edge=EntitiesEdge(
+                fromEntity=EntityReference(id=upstream_entity.id.root, type="table"),  # pyright: ignore[reportCallIssue]
+                toEntity=EntityReference(id=downstream_entity.id.root, type="table"),  # pyright: ignore[reportCallIssue]
+                lineageDetails=lineage_details,
+            )
+        )
+
+    @staticmethod
+    def _parse_column_pairs(raw: object) -> List[Tuple[str, str]]:  # noqa: UP006
+        """
+        Decode the `COLUMN_PAIRS` VARIANT returned by the combined SQL into
+        a list of (downstream_column, upstream_column) tuples. The snowflake
+        driver can hand back either a parsed list or a JSON string depending
+        on cursor configuration, so handle both.
+        """
+        if not raw:
+            return []
+        if isinstance(raw, str):
+            try:
+                raw = json.loads(raw)
+            except (ValueError, TypeError):
+                return []
+        if not isinstance(raw, list):
+            return []
+        pairs: List[Tuple[str, str]] = []  # noqa: UP006
+        for item in raw:
+            if not isinstance(item, dict):
+                continue
+            d_col = item.get("d") or item.get("D")
+            u_col = item.get("u") or item.get("U")
+            if d_col and u_col:
+                pairs.append((d_col, u_col))
+        return pairs
+
+    @staticmethod
+    def _build_columns_lineage(
+        downstream_entity: Table,
+        upstream_entity: Table,
+        column_pairs: List[Tuple[str, str]],  # noqa: UP006
+    ) -> List[ColumnLineage]:  # noqa: UP006
+        """
+        Convert raw (downstream_col, upstream_col) pairs into ColumnLineage objects
+        with fully qualified column names. Drops pairs where either column does
+        not exist on its parent table entity.
+        """
+        result: List[ColumnLineage] = []  # noqa: UP006
+        for d_col, u_col in column_pairs:
+            d_fqn = get_column_fqn(downstream_entity, d_col)
+            u_fqn = get_column_fqn(upstream_entity, u_col)
+            if d_fqn and u_fqn:
+                result.append(ColumnLineage(fromColumns=[u_fqn], toColumn=d_fqn))  # pyright: ignore[reportCallIssue]
+        return result
+
+    def _yield_copy_history_lineage(self) -> Iterable[Either[AddLineageRequest]]:
+        """
+        Read ACCOUNT_USAGE.COPY_HISTORY for stage→table lineage. Resolve the
+        downstream Table and the upstream Container (by stage location URL).
+        Skip internal Snowflake stages silently (they don't map to OM Containers).
+        """
+        sql_statement = SNOWFLAKE_COPY_HISTORY_LINEAGE.format(
+            account_usage=self.service_connection.accountUsageSchema,
+            start_time=self.start,
+            end_time=self.end,
+        )
+        emitted = 0
+        skipped_internal = 0
+        skipped_unresolved = 0
+        try:
+            for engine in self.get_engine():
+                if engine is None:
+                    continue
+                with engine.connect() as conn:
+                    logger.debug("Executing COPY_HISTORY lineage query: %s", sql_statement)
+                    rows = conn.execute(text(sql_statement))
+                    for raw_row in rows:
+                        row = CopyHistoryRow(**self._row_to_lower_dict(raw_row))
+                        if not self._is_external_stage(row.stage_location or ""):
+                            skipped_internal += 1
+                            continue
+                        edge = self._build_copy_edge(row)
+                        if edge is None:
+                            skipped_unresolved += 1
+                            continue
+                        emitted += 1
+                        yield Either(right=edge)  # pyright: ignore[reportCallIssue]
+        except Exception as exc:
+            logger.warning("Failed to extract COPY_HISTORY lineage: %s", exc)
+            logger.debug(traceback.format_exc())
+        logger.info(
+            "COPY_HISTORY lineage: emitted %d edges, skipped %d internal stages, skipped %d unresolved external stages",
+            emitted,
+            skipped_internal,
+            skipped_unresolved,
+        )
+
+    def _build_copy_edge(self, row: CopyHistoryRow) -> Optional[AddLineageRequest]:  # noqa: UP045
+        """
+        Resolve the downstream table and upstream container, then build the
+        Container → Table lineage request. Returns None if either side is
+        unresolvable in OM (e.g., storage service not ingested).
+        """
+        if not (row.downstream_database and row.downstream_schema and row.downstream_table and row.stage_location):
+            return None
+
+        downstream_fqn = fqn._build(
+            self.config.serviceName, row.downstream_database, row.downstream_schema, row.downstream_table
+        )
+        downstream_entity = self._get_table_by_fqn(downstream_fqn)
+        if downstream_entity is None:
+            return None
+
+        container_entity = self._resolve_container_by_path(row.stage_location)
+        if container_entity is None:
+            logger.info(
+                "COPY edge unresolved: no Container ingested for stage `%s` (downstream table `%s` skipped)",
+                row.stage_location,
+                downstream_fqn,
+            )
+            return None
+
+        return AddLineageRequest(
+            edge=EntitiesEdge(
+                fromEntity=EntityReference(id=container_entity.id.root, type="container"),  # pyright: ignore[reportCallIssue]
+                toEntity=EntityReference(id=downstream_entity.id.root, type="table"),  # pyright: ignore[reportCallIssue]
+                lineageDetails=LineageDetails(source=LineageEdgeSource.QueryLineage),  # pyright: ignore[reportCallIssue]
+            )
+        )
+
+    def _resolve_snowflake_table(self, snowflake_fqn: str) -> Optional[Table]:  # noqa: UP045
+        """
+        Parse a Snowflake-style `DB.SCHEMA.TABLE` FQN into OM-style and resolve
+        to a Table entity. Caches both hits and misses for the run.
+        """
+        parts = self._split_snowflake_fqn(snowflake_fqn)
+        if parts is None:
+            return None
+        db, schema, table = parts
+        om_fqn = fqn._build(self.config.serviceName, db, schema, table)
+        return self._get_table_by_fqn(om_fqn)
+
+    def _get_table_by_fqn(self, om_fqn: str) -> Optional[Table]:  # noqa: UP045
+        if om_fqn in self._table_cache:
+            return self._table_cache[om_fqn]
+        try:
+            entity = self.metadata.get_by_name(entity=Table, fqn=om_fqn)
+        except Exception as exc:
+            logger.debug("Failed to resolve Table `%s`: %s", om_fqn, exc)
+            entity = None
+        self._table_cache[om_fqn] = entity
+        return entity
+
+    def _resolve_container_by_path(self, stage_location: str) -> Optional[Container]:  # noqa: UP045
+        try:
+            results = self.metadata.es_search_container_by_path(full_path=stage_location) or []
+            return results[0] if results else None
+        except Exception as exc:
+            logger.debug("Failed to resolve Container for path `%s`: %s", stage_location, exc)
+            return None
+
+    @staticmethod
+    def _split_snowflake_fqn(snowflake_fqn: str) -> Optional[Tuple[str, str, str]]:  # noqa: UP006, UP045
+        """
+        Split a Snowflake `DB.SCHEMA.TABLE` FQN into its three parts.
+        Handles quoted identifiers (`"My DB"."My.Schema"."Table"`) by
+        splitting on unquoted dots and stripping surrounding quotes per part.
+        Snowflake escapes embedded `"` inside a quoted identifier as `""`;
+        we unescape that to a single `"`.
+        Returns None for malformed inputs and logs at DEBUG.
+        """
+        if not snowflake_fqn:
+            return None
+        parts: list = []
+        current: list = []
+        inside_quotes = False
+        for ch in snowflake_fqn:
+            if ch == '"':
+                inside_quotes = not inside_quotes
+                current.append(ch)
+            elif ch == "." and not inside_quotes:
+                parts.append("".join(current))
+                current = []
+            else:
+                current.append(ch)
+        parts.append("".join(current))
+        if len(parts) != 3:
+            logger.debug("Skipping FQN with unexpected part count: %s", snowflake_fqn)
+            return None
+        normalized = [p[1:-1].replace('""', '"') if p.startswith('"') and p.endswith('"') else p for p in parts]
+        if not all(normalized):
+            logger.debug("Skipping FQN with empty part: %s", snowflake_fqn)
+            return None
+        return normalized[0], normalized[1], normalized[2]
+
+    @staticmethod
+    def _is_external_stage(stage_location: str) -> bool:
+        """
+        External stage URLs start with a cloud storage scheme. Internal Snowflake
+        stages (`@~/`, `@%table/`, `@db.schema.stage/`) don't map to OM Containers.
+        """
+        if not stage_location:
+            return False
+        return stage_location.lower().startswith(EXTERNAL_STAGE_PREFIXES)
+
+    @staticmethod
+    def _row_to_lower_dict(row: Any) -> dict:
+        """
+        Snowflake returns uppercase column names; normalize to a lower-cased
+        dict so the Pydantic row models can resolve fields uniformly. Accepts
+        anything row-like: a SQLAlchemy `Row` (has `_asdict`) or a plain dict.
+        """
+        raw = row._asdict() if hasattr(row, "_asdict") else dict(row)
+        return {k.lower(): v for k, v in raw.items()}

--- a/ingestion/src/metadata/ingestion/source/database/snowflake/lineage.py
+++ b/ingestion/src/metadata/ingestion/source/database/snowflake/lineage.py
@@ -14,6 +14,7 @@ Snowflake lineage module
 
 import json
 import traceback
+from datetime import datetime, timedelta
 from typing import Any, Iterable, Iterator, List, Optional, Tuple, Union  # noqa: UP035
 
 from cachetools import LRUCache
@@ -69,6 +70,8 @@ USE_ACCESS_HISTORY_OPTION_KEY = "useAccessHistory"
 
 TABLE_CACHE_MAX_SIZE = 100
 
+ACCESS_HISTORY_CHUNK_DAYS = 2
+
 EXTERNAL_STAGE_PREFIXES = ("s3://", "azure://", "gcs://", "https://")
 
 LINEAGE_OBJECT_DOMAINS = {
@@ -116,7 +119,9 @@ class SnowflakeLineageSource(
         super().__init__(config, metadata, get_engine=get_engine)
         self._table_cache: LRUCache = LRUCache(maxsize=TABLE_CACHE_MAX_SIZE)
         if self._use_access_history and self.engine is not None:
-            available = probe_access_history_available(self.engine, self.service_connection.accountUsageSchema)
+            available = probe_access_history_available(
+                self.engine, self.service_connection.accountUsageSchema
+            )
             if not available:
                 logger.warning(
                     "useAccessHistory was set in connectionOptions but the ACCESS_HISTORY probe failed; "
@@ -124,7 +129,9 @@ class SnowflakeLineageSource(
                 )
                 self._use_access_history = False
             else:
-                logger.info("ACCESS_HISTORY-based lineage path enabled via connectionOptions.useAccessHistory.")
+                logger.info(
+                    "ACCESS_HISTORY-based lineage path enabled via connectionOptions.useAccessHistory."
+                )
 
     @staticmethod
     def _pop_access_history_flag(config: WorkflowSource) -> bool:
@@ -133,7 +140,9 @@ class SnowflakeLineageSource(
         connectionOptions on the workflow config. Called before the parent
         init so the popped key never reaches the Snowflake driver URL.
         """
-        service_connection = config.serviceConnection.root.config  # pyright: ignore[reportOptionalMemberAccess]
+        service_connection = (
+            config.serviceConnection.root.config
+        )  # pyright: ignore[reportOptionalMemberAccess]
         options = get_connection_options_dict(service_connection)
         if not options:
             return False
@@ -144,15 +153,17 @@ class SnowflakeLineageSource(
 
     def _build_filter_condition_clause(self) -> str:
         """
-        Render `sourceConfig.filterCondition` as an extra `AND (...)` predicate
-        scoped to the access_history_filtered CTE. Unqualified column names
-        resolve against `qh` (QUERY_HISTORY) — e.g. `query_type = 'COPY'`,
-        `user_name = 'etl_user'`, `query_text ILIKE '%my_pipeline%'`.
+        Render `sourceConfig.filterCondition` as a trailing `WHERE (...)` on the
+        final edge result, so it scopes lineage by the edge's tables rather than
+        by QUERY_HISTORY. Unqualified column names resolve against the edge
+        columns `UPSTREAM_TABLE` / `DOWNSTREAM_TABLE` (Snowflake `DB.SCHEMA.TABLE`
+        FQNs) — e.g. `DOWNSTREAM_TABLE LIKE 'MYDB.%'`,
+        `UPSTREAM_TABLE ILIKE 'MYDB.MYSCHEMA.%'`.
         """
         condition = getattr(self.source_config, "filterCondition", None)
         if not condition:
             return ""
-        return f"AND ({condition})"
+        return f"WHERE ({condition})"
 
     def get_stored_procedure_sql_statement(self) -> str:
         """
@@ -206,7 +217,9 @@ class SnowflakeLineageSource(
                             )
                         except Exception as exc:
                             logger.debug(traceback.format_exc())
-                            logger.warning("Error processing query_dict %s: %s", query_dict, exc)
+                            logger.warning(
+                                "Error processing query_dict %s: %s", query_dict, exc
+                            )
                 total_fetched += row_count
                 if row_count < batch_size:
                     break
@@ -241,41 +254,42 @@ class SnowflakeLineageSource(
         yield from self._yield_combined_access_history()
         yield from self._yield_copy_history_lineage()
 
+    def _iter_lineage_date_windows(
+        self,
+    ) -> Iterable[Tuple[datetime, datetime]]:  # noqa: UP006
+        """
+        Split the configured [start, end] window into ACCESS_HISTORY_CHUNK_DAYS
+        chunks. A single query over a large window (e.g. queryLogDuration=180)
+        builds a FLATTEN-heavy plan that Snowflake cancels on a client/server
+        timeout; per-chunk queries keep each scan bounded and let one slow
+        window fail without aborting the run.
+        """
+        window_start = self.start
+        while window_start < self.end:
+            window_end = min(
+                window_start + timedelta(days=ACCESS_HISTORY_CHUNK_DAYS), self.end
+            )
+            yield window_start, window_end
+            window_start = window_end
+
     def _yield_combined_access_history(self) -> Iterable[Either[AddLineageRequest]]:
         """
-        Run the single combined ACCESS_HISTORY query and emit one
-        `AddLineageRequest` per row. Uses `stream_results=True` so the
-        snowflake-sqlalchemy cursor streams rather than buffering.
+        Stream the combined ACCESS_HISTORY query per date window and emit one
+        `AddLineageRequest` per row, accumulating counters across all windows.
         """
-        sql_statement = SNOWFLAKE_ACCESS_HISTORY_LINEAGE.format(
-            account_usage=self.service_connection.accountUsageSchema,
-            start_time=self.start,
-            end_time=self.end,
-            filter_condition=self._build_filter_condition_clause(),
-        )
         emitted = 0
         emitted_with_sql = 0
         skipped = 0
-        try:
-            for engine in self.get_engine():
-                if engine is None:
+        for window_start, window_end in self._iter_lineage_date_windows():
+            for row in self._fetch_access_history_rows(window_start, window_end):
+                edge = self._build_access_history_edge(row)
+                if edge is None:
+                    skipped += 1
                     continue
-                with engine.connect() as conn:
-                    logger.debug("Executing combined ACCESS_HISTORY lineage query: %s", sql_statement)
-                    rows = conn.execution_options(stream_results=True, max_row_buffer=1000).execute(text(sql_statement))
-                    for raw_row in rows:
-                        row = AccessHistoryRow(**self._row_to_lower_dict(raw_row))
-                        edge = self._build_access_history_edge(row)
-                        if edge is None:
-                            skipped += 1
-                            continue
-                        emitted += 1
-                        if row.query_text:
-                            emitted_with_sql += 1
-                        yield Either(right=edge)  # pyright: ignore[reportCallIssue]
-        except Exception as exc:
-            logger.warning("Failed to extract lineage from ACCESS_HISTORY: %s", exc)
-            logger.debug(traceback.format_exc())
+                emitted += 1
+                if row.query_text:
+                    emitted_with_sql += 1
+                yield Either(right=edge)  # pyright: ignore[reportCallIssue]
         logger.info(
             "ACCESS_HISTORY lineage: emitted %d edges (%d with SQL text), "
             "skipped %d (unresolvable downstream/upstream tables)",
@@ -284,7 +298,67 @@ class SnowflakeLineageSource(
             skipped,
         )
 
-    def _build_access_history_edge(self, row: AccessHistoryRow) -> Optional[AddLineageRequest]:  # noqa: UP045
+    def _fetch_access_history_rows(
+        self, window_start: datetime, window_end: datetime
+    ) -> Iterable[AccessHistoryRow]:
+        """
+        Run the combined ACCESS_HISTORY query for a single [window_start,
+        window_end) window and yield parsed rows. Uses `stream_results=True`
+        so the snowflake-sqlalchemy cursor streams rather than buffering.
+        A failure on one window is logged and swallowed so the remaining
+        windows still run; a single malformed row is skipped so the rest of
+        the window still yields.
+        """
+        sql_statement = SNOWFLAKE_ACCESS_HISTORY_LINEAGE.format(
+            account_usage=self.service_connection.accountUsageSchema,
+            start_time=window_start,
+            end_time=window_end,
+            filter_condition=self._build_filter_condition_clause(),
+        )
+        try:
+            for engine in self.get_engine():
+                if engine is None:
+                    continue
+                with engine.connect() as conn:
+                    logger.debug(
+                        "Executing ACCESS_HISTORY lineage query for %s - %s",
+                        window_start,
+                        window_end,
+                    )
+                    rows = conn.execution_options(
+                        stream_results=True, max_row_buffer=1000
+                    ).execute(text(sql_statement))
+                    for raw_row in rows:
+                        parsed = self._parse_access_history_row(raw_row)
+                        if parsed is not None:
+                            yield parsed
+        except Exception as exc:
+            logger.warning(
+                "Failed to extract lineage from ACCESS_HISTORY for window %s - %s: %s",
+                window_start,
+                window_end,
+                exc,
+            )
+            logger.debug(traceback.format_exc())
+
+    def _parse_access_history_row(
+        self, raw_row: Any
+    ) -> Optional[AccessHistoryRow]:  # noqa: UP045
+        """
+        Parse one cursor row into an `AccessHistoryRow`. A single malformed row
+        is logged and skipped (returns None) so it doesn't abort the rest of
+        the window's results.
+        """
+        try:
+            return AccessHistoryRow(**self._row_to_lower_dict(raw_row))
+        except Exception as exc:
+            logger.warning("Skipping malformed ACCESS_HISTORY row: %s", exc)
+            logger.debug(traceback.format_exc())
+            return None
+
+    def _build_access_history_edge(
+        self, row: AccessHistoryRow
+    ) -> Optional[AddLineageRequest]:  # noqa: UP045
         """
         Resolve both sides of a table edge to OM Table entities and build the
         AddLineageRequest, attaching column lineage parsed from the row's
@@ -296,10 +370,20 @@ class SnowflakeLineageSource(
         downstream_entity = self._resolve_snowflake_table(row.downstream_table)
         upstream_entity = self._resolve_snowflake_table(row.upstream_table)
         if downstream_entity is None or upstream_entity is None:
+            logger.debug(
+                "Skipping ACCESS_HISTORY edge: table not found in OpenMetadata "
+                "(upstream=`%s` found=%s, downstream=`%s` found=%s)",
+                row.upstream_table,
+                upstream_entity is not None,
+                row.downstream_table,
+                downstream_entity is not None,
+            )
             return None
 
         column_pairs = self._parse_column_pairs(row.column_pairs)
-        columns_lineage = self._build_columns_lineage(downstream_entity, upstream_entity, column_pairs)
+        columns_lineage = self._build_columns_lineage(
+            downstream_entity, upstream_entity, column_pairs
+        )
 
         lineage_details = LineageDetails(  # pyright: ignore[reportCallIssue]
             source=LineageEdgeSource.QueryLineage,
@@ -309,8 +393,12 @@ class SnowflakeLineageSource(
 
         return AddLineageRequest(
             edge=EntitiesEdge(
-                fromEntity=EntityReference(id=upstream_entity.id.root, type="table"),  # pyright: ignore[reportCallIssue]
-                toEntity=EntityReference(id=downstream_entity.id.root, type="table"),  # pyright: ignore[reportCallIssue]
+                fromEntity=EntityReference(
+                    id=upstream_entity.id.root, type="table"
+                ),  # pyright: ignore[reportCallIssue]
+                toEntity=EntityReference(
+                    id=downstream_entity.id.root, type="table"
+                ),  # pyright: ignore[reportCallIssue]
                 lineageDetails=lineage_details,
             )
         )
@@ -358,7 +446,9 @@ class SnowflakeLineageSource(
             d_fqn = get_column_fqn(downstream_entity, d_col)
             u_fqn = get_column_fqn(upstream_entity, u_col)
             if d_fqn and u_fqn:
-                result.append(ColumnLineage(fromColumns=[u_fqn], toColumn=d_fqn))  # pyright: ignore[reportCallIssue]
+                result.append(
+                    ColumnLineage(fromColumns=[u_fqn], toColumn=d_fqn)
+                )  # pyright: ignore[reportCallIssue]
         return result
 
     def _yield_copy_history_lineage(self) -> Iterable[Either[AddLineageRequest]]:
@@ -380,7 +470,9 @@ class SnowflakeLineageSource(
                 if engine is None:
                     continue
                 with engine.connect() as conn:
-                    logger.debug("Executing COPY_HISTORY lineage query: %s", sql_statement)
+                    logger.debug(
+                        "Executing COPY_HISTORY lineage query: %s", sql_statement
+                    )
                     rows = conn.execute(text(sql_statement))
                     for raw_row in rows:
                         row = CopyHistoryRow(**self._row_to_lower_dict(raw_row))
@@ -403,17 +495,27 @@ class SnowflakeLineageSource(
             skipped_unresolved,
         )
 
-    def _build_copy_edge(self, row: CopyHistoryRow) -> Optional[AddLineageRequest]:  # noqa: UP045
+    def _build_copy_edge(
+        self, row: CopyHistoryRow
+    ) -> Optional[AddLineageRequest]:  # noqa: UP045
         """
         Resolve the downstream table and upstream container, then build the
         Container → Table lineage request. Returns None if either side is
         unresolvable in OM (e.g., storage service not ingested).
         """
-        if not (row.downstream_database and row.downstream_schema and row.downstream_table and row.stage_location):
+        if not (
+            row.downstream_database
+            and row.downstream_schema
+            and row.downstream_table
+            and row.stage_location
+        ):
             return None
 
         downstream_fqn = fqn._build(
-            self.config.serviceName, row.downstream_database, row.downstream_schema, row.downstream_table
+            self.config.serviceName,
+            row.downstream_database,
+            row.downstream_schema,
+            row.downstream_table,
         )
         downstream_entity = self._get_table_by_fqn(downstream_fqn)
         if downstream_entity is None:
@@ -430,13 +532,21 @@ class SnowflakeLineageSource(
 
         return AddLineageRequest(
             edge=EntitiesEdge(
-                fromEntity=EntityReference(id=container_entity.id.root, type="container"),  # pyright: ignore[reportCallIssue]
-                toEntity=EntityReference(id=downstream_entity.id.root, type="table"),  # pyright: ignore[reportCallIssue]
-                lineageDetails=LineageDetails(source=LineageEdgeSource.QueryLineage),  # pyright: ignore[reportCallIssue]
+                fromEntity=EntityReference(
+                    id=container_entity.id.root, type="container"
+                ),  # pyright: ignore[reportCallIssue]
+                toEntity=EntityReference(
+                    id=downstream_entity.id.root, type="table"
+                ),  # pyright: ignore[reportCallIssue]
+                lineageDetails=LineageDetails(
+                    source=LineageEdgeSource.QueryLineage
+                ),  # pyright: ignore[reportCallIssue]
             )
         )
 
-    def _resolve_snowflake_table(self, snowflake_fqn: str) -> Optional[Table]:  # noqa: UP045
+    def _resolve_snowflake_table(
+        self, snowflake_fqn: str
+    ) -> Optional[Table]:  # noqa: UP045
         """
         Parse a Snowflake-style `DB.SCHEMA.TABLE` FQN into OM-style and resolve
         to a Table entity. Caches both hits and misses for the run.
@@ -459,16 +569,25 @@ class SnowflakeLineageSource(
         self._table_cache[om_fqn] = entity
         return entity
 
-    def _resolve_container_by_path(self, stage_location: str) -> Optional[Container]:  # noqa: UP045
+    def _resolve_container_by_path(
+        self, stage_location: str
+    ) -> Optional[Container]:  # noqa: UP045
         try:
-            results = self.metadata.es_search_container_by_path(full_path=stage_location) or []
+            results = (
+                self.metadata.es_search_container_by_path(full_path=stage_location)
+                or []
+            )
             return results[0] if results else None
         except Exception as exc:
-            logger.debug("Failed to resolve Container for path `%s`: %s", stage_location, exc)
+            logger.debug(
+                "Failed to resolve Container for path `%s`: %s", stage_location, exc
+            )
             return None
 
     @staticmethod
-    def _split_snowflake_fqn(snowflake_fqn: str) -> Optional[Tuple[str, str, str]]:  # noqa: UP006, UP045
+    def _split_snowflake_fqn(
+        snowflake_fqn: str,
+    ) -> Optional[Tuple[str, str, str]]:  # noqa: UP006, UP045
         """
         Split a Snowflake `DB.SCHEMA.TABLE` FQN into its three parts.
         Handles quoted identifiers (`"My DB"."My.Schema"."Table"`) by
@@ -495,7 +614,10 @@ class SnowflakeLineageSource(
         if len(parts) != 3:
             logger.debug("Skipping FQN with unexpected part count: %s", snowflake_fqn)
             return None
-        normalized = [p[1:-1].replace('""', '"') if p.startswith('"') and p.endswith('"') else p for p in parts]
+        normalized = [
+            p[1:-1].replace('""', '"') if p.startswith('"') and p.endswith('"') else p
+            for p in parts
+        ]
         if not all(normalized):
             logger.debug("Skipping FQN with empty part: %s", snowflake_fqn)
             return None

--- a/ingestion/src/metadata/ingestion/source/database/snowflake/lineage.py
+++ b/ingestion/src/metadata/ingestion/source/database/snowflake/lineage.py
@@ -68,6 +68,8 @@ logger = ingestion_logger()
 
 USE_ACCESS_HISTORY_OPTION_KEY = "useAccessHistory"
 
+ACCESS_HISTORY_CHUNK_DAYS_OPTION_KEY = "accessHistoryChunkDays"
+
 TABLE_CACHE_MAX_SIZE = 100
 
 ACCESS_HISTORY_CHUNK_DAYS = 2
@@ -116,6 +118,7 @@ class SnowflakeLineageSource(
         # every connectionOptions entry into the URL query string, so the
         # driver would otherwise receive an unknown `useAccessHistory` param.
         self._use_access_history = self._pop_access_history_flag(config)
+        self._access_history_chunk_days = self._pop_access_history_chunk_days(config)
         super().__init__(config, metadata, get_engine=get_engine)
         self._table_cache: LRUCache = LRUCache(maxsize=TABLE_CACHE_MAX_SIZE)
         if self._use_access_history and self.engine is not None:
@@ -150,6 +153,44 @@ class SnowflakeLineageSource(
         if raw is None:
             return False
         return str(raw).strip().lower() == "true"
+
+    @staticmethod
+    def _pop_access_history_chunk_days(config: WorkflowSource) -> int:
+        """
+        Read and remove the OM-specific `accessHistoryChunkDays` key from
+        connectionOptions, mirroring `_pop_access_history_flag` so the popped
+        key never reaches the Snowflake driver URL. Controls the size of the
+        date windows the [start, end] lineage span is split into. Falls back to
+        ACCESS_HISTORY_CHUNK_DAYS when unset or invalid (non-int / non-positive).
+        """
+        service_connection = (
+            config.serviceConnection.root.config
+        )  # pyright: ignore[reportOptionalMemberAccess]
+        options = get_connection_options_dict(service_connection)
+        if not options:
+            return ACCESS_HISTORY_CHUNK_DAYS
+        raw = options.pop(ACCESS_HISTORY_CHUNK_DAYS_OPTION_KEY, None)
+        if raw is None:
+            return ACCESS_HISTORY_CHUNK_DAYS
+        try:
+            chunk_days = int(str(raw).strip())
+        except (ValueError, TypeError):
+            logger.warning(
+                "Invalid %s=%r in connectionOptions; falling back to %d days.",
+                ACCESS_HISTORY_CHUNK_DAYS_OPTION_KEY,
+                raw,
+                ACCESS_HISTORY_CHUNK_DAYS,
+            )
+            return ACCESS_HISTORY_CHUNK_DAYS
+        if chunk_days <= 0:
+            logger.warning(
+                "%s must be a positive integer (got %d); falling back to %d days.",
+                ACCESS_HISTORY_CHUNK_DAYS_OPTION_KEY,
+                chunk_days,
+                ACCESS_HISTORY_CHUNK_DAYS,
+            )
+            return ACCESS_HISTORY_CHUNK_DAYS
+        return chunk_days
 
     def _build_filter_condition_clause(self) -> str:
         """
@@ -258,16 +299,18 @@ class SnowflakeLineageSource(
         self,
     ) -> Iterable[Tuple[datetime, datetime]]:  # noqa: UP006
         """
-        Split the configured [start, end] window into ACCESS_HISTORY_CHUNK_DAYS
-        chunks. A single query over a large window (e.g. queryLogDuration=180)
-        builds a FLATTEN-heavy plan that Snowflake cancels on a client/server
-        timeout; per-chunk queries keep each scan bounded and let one slow
-        window fail without aborting the run.
+        Split the configured [start, end] window into
+        `accessHistoryChunkDays`-sized chunks (default ACCESS_HISTORY_CHUNK_DAYS).
+        A single query over a large window (e.g. queryLogDuration=180) builds a
+        FLATTEN-heavy plan that Snowflake cancels on a client/server timeout;
+        per-chunk queries keep each scan bounded and let one slow window fail
+        without aborting the run.
         """
         window_start = self.start
         while window_start < self.end:
             window_end = min(
-                window_start + timedelta(days=ACCESS_HISTORY_CHUNK_DAYS), self.end
+                window_start + timedelta(days=self._access_history_chunk_days),
+                self.end,
             )
             yield window_start, window_end
             window_start = window_end

--- a/ingestion/src/metadata/ingestion/source/database/snowflake/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/database/snowflake/metadata.py
@@ -1066,9 +1066,18 @@ class SnowflakeSource(
                 pass
 
         try:
-            columns = inspector.get_columns(
-                table_name, schema_name, table_type=table_type, db_name=db_name
-            )
+            # Do NOT forward `table_type` here. SQLAlchemy's @reflection.cache
+            # decorator on the underlying get_columns / _get_schema_columns
+            # builds its cache key from **kw, so a varying `table_type`
+            # (Regular for base tables, View for views) produces distinct
+            # cache keys for the SAME schema. For a huge schema (e.g. ~13k
+            # wide tables), the table→view transition then cache-misses on
+            # _get_schema_columns and re-materializes the whole schema's
+            # column metadata (~1.6 GB) — which is what OOM-killed the pod
+            # in the COM_US_IMDNA_ADL.AWB_INTERM incident. The Snowflake
+            # dialect's get_columns ignores `table_type`; the Stage/Stream
+            # branches above already consumed it.
+            columns = inspector.get_columns(table_name, schema_name, db_name=db_name)
         except sa_exc.NoSuchTableError:
             logger.warning(
                 f"Table [{table_name}] (schema: '{schema_name}', db: '{db_name}') not found."

--- a/ingestion/src/metadata/ingestion/source/database/snowflake/models.py
+++ b/ingestion/src/metadata/ingestion/source/database/snowflake/models.py
@@ -13,10 +13,10 @@ Snowflake models
 """
 import urllib
 from datetime import datetime
-from typing import List, Optional
+from typing import Any, List, Optional  # noqa: UP035
 
-from pydantic import BaseModel, Field, TypeAdapter, field_validator
-from requests.utils import quote
+from pydantic import BaseModel, ConfigDict, Field, TypeAdapter, field_validator
+from requests.utils import quote  # pyright: ignore[reportPrivateImportUsage]
 from sqlalchemy import text
 from sqlalchemy.orm import Session
 
@@ -167,6 +167,29 @@ class SnowflakeQueryResult(QueryResult):
     rows_inserted: Optional[int] = None
     rows_updated: Optional[int] = None
     rows_deleted: Optional[int] = None
+
+
+class AccessHistoryRow(BaseModel):
+    """One row from SNOWFLAKE_ACCESS_HISTORY_LINEAGE — a directed table edge
+    with pre-aggregated column pairs (VARIANT) and a representative query text."""
+
+    model_config = ConfigDict(extra="ignore")
+
+    downstream_table: Optional[str] = None  # noqa: UP045
+    upstream_table: Optional[str] = None  # noqa: UP045
+    column_pairs: Optional[Any] = None  # noqa: UP045
+    query_text: Optional[str] = None  # noqa: UP045
+
+
+class CopyHistoryRow(BaseModel):
+    """One row from SNOWFLAKE_COPY_HISTORY_LINEAGE — a stage→table load event."""
+
+    model_config = ConfigDict(extra="ignore")
+
+    downstream_database: Optional[str] = None  # noqa: UP045
+    downstream_schema: Optional[str] = None  # noqa: UP045
+    downstream_table: Optional[str] = None  # noqa: UP045
+    stage_location: Optional[str] = None  # noqa: UP045
 
 
 class SnowflakeDynamicTableRefreshEntry(BaseModel):

--- a/ingestion/src/metadata/ingestion/source/database/snowflake/queries.py
+++ b/ingestion/src/metadata/ingestion/source/database/snowflake/queries.py
@@ -530,3 +530,105 @@ SNOWFLAKE_DYNAMIC_TABLE_REFRESH_HISTORY_QUERY = """
         AND name ILIKE '%{tablename}%'
         AND refresh_start_time >= DATEADD('DAY', -1, CURRENT_TIMESTAMP);
 """
+
+SNOWFLAKE_ACCESS_HISTORY_PROBE = """
+SELECT 1 FROM {account_usage}.ACCESS_HISTORY LIMIT 1
+"""
+
+SNOWFLAKE_ACCESS_HISTORY_LINEAGE = textwrap.dedent(
+    """
+    WITH access_history_filtered AS (
+        SELECT
+            ah.QUERY_ID,
+            ah.QUERY_START_TIME,
+            ah.DIRECT_OBJECTS_ACCESSED,
+            ah.OBJECTS_MODIFIED,
+            qh.QUERY_TEXT
+        FROM {account_usage}.ACCESS_HISTORY ah
+        JOIN {account_usage}.QUERY_HISTORY qh
+            ON ah.QUERY_ID = qh.QUERY_ID
+        WHERE ah.QUERY_START_TIME
+            BETWEEN to_timestamp_ltz('{start_time}') AND to_timestamp_ltz('{end_time}')
+            AND qh.EXECUTION_STATUS = 'SUCCESS'
+            AND qh.QUERY_TEXT NOT LIKE '/* {{"app": "OpenMetadata", %%}} */%%'
+            AND qh.QUERY_TEXT NOT LIKE '/* {{"app": "dbt", %%}} */%%'
+            {filter_condition}
+    ),
+    table_edges AS (
+        SELECT
+            upstream.value:"objectName"::STRING AS UPSTREAM_TABLE,
+            upstream.value:"objectDomain"::STRING AS UPSTREAM_DOMAIN,
+            downstream.value:"objectName"::STRING AS DOWNSTREAM_TABLE,
+            downstream.value:"objectDomain"::STRING AS DOWNSTREAM_DOMAIN,
+            MAX_BY(ah.QUERY_ID, ah.QUERY_START_TIME) AS QUERY_ID,
+            MAX_BY(ah.QUERY_TEXT, ah.QUERY_START_TIME) AS QUERY_TEXT
+        FROM access_history_filtered ah,
+             LATERAL FLATTEN(input => ah.DIRECT_OBJECTS_ACCESSED) upstream,
+             LATERAL FLATTEN(input => ah.OBJECTS_MODIFIED) downstream
+        WHERE upstream.value:"objectDomain"::STRING IN
+                ('Table', 'View', 'Materialized view', 'Dynamic table', 'External table', 'Iceberg table')
+          AND downstream.value:"objectDomain"::STRING IN
+                ('Table', 'View', 'Materialized view', 'Dynamic table', 'External table', 'Iceberg table')
+          AND upstream.value:"objectName"::STRING IS NOT NULL
+          AND downstream.value:"objectName"::STRING IS NOT NULL
+          AND upstream.value:"objectName"::STRING != downstream.value:"objectName"::STRING
+        GROUP BY
+            upstream.value:"objectName"::STRING,
+            upstream.value:"objectDomain"::STRING,
+            downstream.value:"objectName"::STRING,
+            downstream.value:"objectDomain"::STRING
+    ),
+    column_edges_grouped AS (
+        SELECT
+            downstream.value:"objectName"::STRING AS DOWNSTREAM_TABLE,
+            direct_source.value:"objectName"::STRING AS UPSTREAM_TABLE,
+            ARRAY_AGG(DISTINCT OBJECT_CONSTRUCT(
+                'd', downstream_col.value:"columnName"::STRING,
+                'u', direct_source.value:"columnName"::STRING
+            )) AS COLUMN_PAIRS
+        FROM access_history_filtered ah,
+             LATERAL FLATTEN(input => ah.OBJECTS_MODIFIED) downstream,
+             LATERAL FLATTEN(input => downstream.value:"columns", outer => true) downstream_col,
+             LATERAL FLATTEN(input => downstream_col.value:"directSources", outer => true) direct_source
+        WHERE direct_source.value:"objectName"::STRING IS NOT NULL
+          AND direct_source.value:"columnName"::STRING IS NOT NULL
+          AND downstream.value:"objectName"::STRING IS NOT NULL
+          AND downstream_col.value:"columnName"::STRING IS NOT NULL
+          AND direct_source.value:"objectName"::STRING != downstream.value:"objectName"::STRING
+        GROUP BY
+            downstream.value:"objectName"::STRING,
+            direct_source.value:"objectName"::STRING
+    )
+    SELECT
+        te.UPSTREAM_TABLE,
+        te.UPSTREAM_DOMAIN,
+        te.DOWNSTREAM_TABLE,
+        te.DOWNSTREAM_DOMAIN,
+        te.QUERY_ID,
+        te.QUERY_TEXT,
+        ce.COLUMN_PAIRS
+    FROM table_edges te
+    LEFT JOIN column_edges_grouped ce
+        ON te.UPSTREAM_TABLE = ce.UPSTREAM_TABLE
+        AND te.DOWNSTREAM_TABLE = ce.DOWNSTREAM_TABLE
+    """
+)
+
+SNOWFLAKE_COPY_HISTORY_LINEAGE = textwrap.dedent(
+    """
+    SELECT
+        TABLE_CATALOG_NAME AS DOWNSTREAM_DATABASE,
+        TABLE_SCHEMA_NAME AS DOWNSTREAM_SCHEMA,
+        TABLE_NAME AS DOWNSTREAM_TABLE,
+        STAGE_LOCATION,
+        MAX(LAST_LOAD_TIME) AS LAST_LOAD_TIME,
+        COUNT(*) AS LOAD_COUNT
+    FROM {account_usage}.COPY_HISTORY
+    WHERE LAST_LOAD_TIME
+        BETWEEN to_timestamp_ltz('{start_time}') AND to_timestamp_ltz('{end_time}')
+        AND STATUS = 'Loaded'
+        AND STAGE_LOCATION IS NOT NULL
+        AND TABLE_NAME IS NOT NULL
+    GROUP BY DOWNSTREAM_DATABASE, DOWNSTREAM_SCHEMA, DOWNSTREAM_TABLE, STAGE_LOCATION
+    """
+)

--- a/ingestion/src/metadata/ingestion/source/database/snowflake/queries.py
+++ b/ingestion/src/metadata/ingestion/source/database/snowflake/queries.py
@@ -545,14 +545,13 @@ SNOWFLAKE_ACCESS_HISTORY_LINEAGE = textwrap.dedent(
             ah.OBJECTS_MODIFIED,
             qh.QUERY_TEXT
         FROM {account_usage}.ACCESS_HISTORY ah
-        JOIN {account_usage}.QUERY_HISTORY qh
+        LEFT JOIN {account_usage}.QUERY_HISTORY qh
             ON ah.QUERY_ID = qh.QUERY_ID
+            AND qh.START_TIME
+                BETWEEN to_timestamp_ltz('{start_time}') AND to_timestamp_ltz('{end_time}')
+            AND qh.EXECUTION_STATUS = 'SUCCESS'
         WHERE ah.QUERY_START_TIME
             BETWEEN to_timestamp_ltz('{start_time}') AND to_timestamp_ltz('{end_time}')
-            AND qh.EXECUTION_STATUS = 'SUCCESS'
-            AND qh.QUERY_TEXT NOT LIKE '/* {{"app": "OpenMetadata", %%}} */%%'
-            AND qh.QUERY_TEXT NOT LIKE '/* {{"app": "dbt", %%}} */%%'
-            {filter_condition}
     ),
     table_edges AS (
         SELECT
@@ -611,6 +610,7 @@ SNOWFLAKE_ACCESS_HISTORY_LINEAGE = textwrap.dedent(
     LEFT JOIN column_edges_grouped ce
         ON te.UPSTREAM_TABLE = ce.UPSTREAM_TABLE
         AND te.DOWNSTREAM_TABLE = ce.DOWNSTREAM_TABLE
+    {filter_condition}
     """
 )
 

--- a/ingestion/src/metadata/ingestion/source/database/snowflake/utils.py
+++ b/ingestion/src/metadata/ingestion/source/database/snowflake/utils.py
@@ -12,7 +12,9 @@
 """
 Module to define overridden dialect methods
 """
-import operator
+import operator  # noqa: I001
+import os
+from collections import OrderedDict
 from functools import reduce
 from typing import Dict, Optional
 
@@ -62,6 +64,37 @@ logger = ingestion_logger()
 dialect = SnowflakeDialect()
 Query = str
 QueryMap = Dict[str, Query]
+
+
+# How many schemas' column dicts we keep in the get_schema_columns cache
+# per Inspector. Inspectors are per-thread in OpenMetadata's setup
+# (common_db_source.py:721), so this is effectively a per-thread bound:
+# the schema each thread is currently processing, plus 1 buffer slot for
+# the just-finished schema. That bound is N+1 in the "1 thread" case and
+# in general gives each thread its own current+previous slots, so no
+# thread's actively-used schema can be evicted by another thread cycling
+# through small schemas.
+#
+# Without this bound info_cache only clears between databases
+# (_release_engine in common_db_source.py:171), so multi-schema runs
+# accumulate every schema's column metadata in RAM -- ~1.6 GB per
+# pathologically wide schema, OOM-killing 4 GB pods on databases like
+# COM_US_IMDNA_ADL.
+_DEFAULT_SCHEMA_COLUMNS_CACHE_SIZE = 2
+try:
+    SCHEMA_COLUMNS_CACHE_SIZE = max(
+        1,
+        int(
+            os.environ.get(
+                "OM_SNOWFLAKE_SCHEMA_COLUMNS_CACHE_SIZE",
+                _DEFAULT_SCHEMA_COLUMNS_CACHE_SIZE,
+            )
+        ),
+    )
+except ValueError:
+    SCHEMA_COLUMNS_CACHE_SIZE = _DEFAULT_SCHEMA_COLUMNS_CACHE_SIZE
+
+_SCHEMA_COLUMNS_LRU_KEY = "_om_snowflake_schema_columns_lru"
 
 
 TABLE_QUERY_MAPS = {
@@ -401,11 +434,76 @@ def normalize_names(self, name):  # pylint: disable=unused-argument
     return name
 
 
+def _store_schema_columns_in_lru(info_cache, schema, value) -> None:
+    """Add ``value`` (the schema columns dict, or ``None`` for the 90030
+    fallback) to the bounded LRU and evict the oldest entry if the cache
+    exceeds SCHEMA_COLUMNS_CACHE_SIZE. When an entry is evicted, drop the
+    per-table ``get_columns`` cache entries for that schema too so the
+    column data is actually freed."""
+    if info_cache is None:
+        return
+    lru: OrderedDict = info_cache.setdefault(_SCHEMA_COLUMNS_LRU_KEY, OrderedDict())
+    lru[schema] = value
+    lru.move_to_end(schema)
+    while len(lru) > SCHEMA_COLUMNS_CACHE_SIZE:
+        evicted_schema, _ = lru.popitem(last=False)
+        _evict_per_table_column_entries(info_cache, evicted_schema)
+
+
+def _evict_per_table_column_entries(info_cache: dict, schema: str) -> None:
+    """Remove per-table get_columns @reflection.cache entries for ``schema``.
+
+    Each per-table cache entry holds the list returned by
+    ``schema_columns[table_name]`` -- the SAME list object that lives inside
+    the schema-wide dict. So dropping the schema-wide dict from our LRU is
+    not enough on its own: the column data is still pinned via per-table
+    entries until they are removed too.
+
+    @reflection.cache key layout is
+    ``(fn_name, server_version_info, default_schema_name, args, kw_items, exclude)``
+    where ``args`` is the positional-arg tuple after ``(self, connection)``.
+    For ``get_columns(table_name, schema)`` that is ``(table_name, schema)``.
+    The check is defensive so a SQLAlchemy version that changes the layout
+    just leaves entries in place rather than crashing.
+    """
+    to_drop = []
+    for key in info_cache:
+        if not isinstance(key, tuple) or len(key) < 4 or key[0] != "get_columns":
+            continue
+        args = key[3]
+        if isinstance(args, tuple) and len(args) >= 2 and args[1] == schema:
+            to_drop.append(key)
+    for key in to_drop:
+        info_cache.pop(key, None)
+
+
 # pylint: disable=too-many-locals,protected-access
-@reflection.cache
 def get_schema_columns(self, connection, schema, **kw):
-    """Get all columns in the schema, if we hit 'Information schema query returned too much data' problem return
-    None, as it is cacheable and is an unexpected return type for this function"""
+    """Get all columns in the schema.
+
+    Returns ``None`` if Snowflake refuses the bulk information_schema query
+    with errno 90030 ("Information schema query returned too much data") --
+    callers (``get_columns`` below) treat that as a signal to fall back to
+    per-table reflection.
+
+    Caching: this function is NOT decorated with ``@reflection.cache``. The
+    stock decorator would keep every schema's column dict in info_cache for
+    the entire database run (info_cache is only cleared between databases
+    in common_db_source.py:171), and a single pathologically wide schema
+    can be ~1.6 GB. Instead we keep a bounded LRU of size
+    SCHEMA_COLUMNS_CACHE_SIZE under a private key on info_cache, which is
+    already per-thread via _inspector_map. When we evict a schema from the
+    LRU we also drop the per-table ``get_columns`` entries for it so the
+    column data is actually freed (otherwise it stays pinned via per-table
+    cache references).
+    """
+    info_cache = kw.get("info_cache")
+    if info_cache is not None:
+        lru: OrderedDict = info_cache.setdefault(_SCHEMA_COLUMNS_LRU_KEY, OrderedDict())
+        if schema in lru:
+            lru.move_to_end(schema)
+            return lru[schema]
+
     ans = {}
     current_database, _ = self._current_database_schema(connection, **kw)
     full_schema_name = _denormalize_quote_join(current_database, fqn.quote_name(schema))
@@ -422,8 +520,12 @@ def get_schema_columns(self, connection, schema, **kw):
 
     except sa_exc.ProgrammingError as p_err:
         if p_err.orig.errno == 90030:
-            # This means that there are too many tables in the schema, we need to go more granular
-            return None  # None triggers _get_table_columns while staying cacheable
+            # Too many tables in the schema for the bulk query; signal the
+            # per-table fallback in get_columns by returning None. Cache the
+            # None so subsequent tables in the same schema don't re-run the
+            # bulk query just to hit 90030 again.
+            _store_schema_columns_in_lru(info_cache, schema, None)
+            return None
         raise
     for (
         table_name,
@@ -505,6 +607,8 @@ def get_schema_columns(self, connection, schema, **kw):
                 "start": identity_start,
                 "increment": identity_increment,
             }
+
+    _store_schema_columns_in_lru(info_cache, schema, ans)
     return ans
 
 

--- a/ingestion/tests/unit/topology/database/test_snowflake_access_history_lineage.py
+++ b/ingestion/tests/unit/topology/database/test_snowflake_access_history_lineage.py
@@ -1,0 +1,729 @@
+#  Copyright 2025 Collate
+#  Licensed under the Collate Community License, Version 1.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  https://github.com/open-metadata/OpenMetadata/blob/main/ingestion/LICENSE
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+"""
+Unit tests for the Snowflake ACCESS_HISTORY lineage path.
+
+The path is selected via `connectionOptions.useAccessHistory = "true"` and is
+gated by a runtime probe against `ACCOUNT_USAGE.ACCESS_HISTORY`. These tests
+cover SQL rendering, connectionOptions parsing, probe behavior, table-edge
+and column-edge yielding, COPY_HISTORY stage→container resolution, and the
+critical regression that the client-side SQL parser is never invoked when
+the flag is on.
+"""
+
+from unittest.mock import MagicMock, patch
+
+from metadata.generated.schema.api.lineage.addLineage import AddLineageRequest
+from metadata.generated.schema.entity.data.container import Container
+from metadata.generated.schema.entity.data.table import Column, DataType, Table
+from metadata.generated.schema.type.basic import EntityName, FullyQualifiedEntityName, Uuid
+from metadata.generated.schema.type.entityLineage import Source as LineageEdgeSource
+from metadata.generated.schema.type.entityReference import EntityReference
+from metadata.ingestion.source.database.lineage_source import LineageSource
+from metadata.ingestion.source.database.snowflake.lineage import (
+    USE_ACCESS_HISTORY_OPTION_KEY,
+    SnowflakeLineageSource,
+)
+from metadata.ingestion.source.database.snowflake.queries import (
+    SNOWFLAKE_ACCESS_HISTORY_LINEAGE,
+    SNOWFLAKE_ACCESS_HISTORY_PROBE,
+    SNOWFLAKE_COPY_HISTORY_LINEAGE,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_table_entity(table_uuid: str, db: str, schema: str, table: str, columns=None) -> Table:
+    """Build a minimal Table entity for column-lineage resolution tests."""
+    table_fqn = f"test_service.{db}.{schema}.{table}"
+    cols = [
+        Column(
+            name=c,
+            dataType=DataType.STRING,
+            fullyQualifiedName=FullyQualifiedEntityName(f"{table_fqn}.{c}"),
+        )
+        for c in (columns or [])
+    ]
+    return Table(
+        id=Uuid(table_uuid),
+        name=EntityName(table),
+        fullyQualifiedName=FullyQualifiedEntityName(table_fqn),
+        columns=cols,
+    )
+
+
+def _make_container_entity(container_uuid: str, full_path: str) -> Container:
+    return Container(
+        id=Uuid(container_uuid),
+        name=EntityName("stage_bucket"),
+        fullyQualifiedName=FullyQualifiedEntityName(f"storage_service.{full_path}"),
+        fullPath=full_path,
+        service=EntityReference(
+            id=Uuid("99999999-9999-9999-9999-999999999999"),
+            type="storageService",
+        ),
+    )
+
+
+def _make_lineage_source(
+    metadata=None,
+    connection_options=None,
+    rows_by_sql=None,
+    service_name="test_service",
+    account_usage="SNOWFLAKE.ACCOUNT_USAGE",
+) -> SnowflakeLineageSource:
+    """
+    Instantiate SnowflakeLineageSource bypassing the heavy parent __init__.
+
+    Tests inject `connectionOptions` (popped value semantics), the metadata
+    client, and a `rows_by_sql` dict that maps a substring of the rendered
+    SQL to the list of mock rows the connection should return.
+    """
+    src = SnowflakeLineageSource.__new__(SnowflakeLineageSource)
+    src.metadata = metadata or MagicMock()
+    src.config = MagicMock()
+    src.config.serviceName = service_name
+    src.service_connection = MagicMock()
+    src.service_connection.accountUsageSchema = account_usage
+    src.service_connection.connectionOptions = MagicMock()
+    src.service_connection.connectionOptions.root = dict(connection_options or {})
+    src.source_config = MagicMock()
+    src.engine = _make_mock_engine(rows_by_sql or {})
+    src.start = "2025-01-01 00:00:00"
+    src.end = "2025-01-02 00:00:00"
+    src._table_cache = {}
+    src._use_access_history = False
+    return src
+
+
+def _make_mock_engine(rows_by_sql):
+    """
+    Build a SQLAlchemy-engine-like mock whose `engine.connect()` context
+    manager returns a connection whose `execute(...)` returns mock rows
+    keyed by which SQL constant was rendered (matched by substring).
+    """
+
+    def _rows_for(sql_str: str):
+        for marker, rows in rows_by_sql.items():
+            if marker in sql_str:
+                return iter(rows)
+        return iter([])
+
+    conn = MagicMock()
+    conn.execute = MagicMock(side_effect=lambda statement: _rows_for(str(statement)))
+    # execution_options(...).execute(...) needs to route through the same matcher.
+    conn.execution_options = MagicMock(return_value=conn)
+    conn.__enter__ = MagicMock(return_value=conn)
+    conn.__exit__ = MagicMock(return_value=False)
+
+    engine = MagicMock()
+    engine.connect = MagicMock(return_value=conn)
+    return engine
+
+
+class _Row(dict):
+    """A row mock that satisfies SQLAlchemy's row interface for our reader."""
+
+    def _asdict(self):
+        return dict(self)
+
+
+# ---------------------------------------------------------------------------
+# SQL rendering
+# ---------------------------------------------------------------------------
+
+
+def test_combined_lineage_sql_streams_one_row_per_edge():
+    """
+    The combined SQL must (a) dedupe table edges with MAX_BY, (b) aggregate
+    column pairs into a per-edge VARIANT array via ARRAY_AGG, and (c) LEFT
+    JOIN them so one row = one edge with column pairs attached.
+    """
+    rendered = SNOWFLAKE_ACCESS_HISTORY_LINEAGE.format(
+        account_usage="SNOWFLAKE.ACCOUNT_USAGE",
+        start_time="2025-01-01",
+        end_time="2025-01-31",
+        filter_condition="",
+    )
+    # Server-side dedup for table edges (both QUERY_ID and QUERY_TEXT pinned to the same row)
+    assert "MAX_BY(ah.QUERY_ID, ah.QUERY_START_TIME)" in rendered
+    assert "MAX_BY(ah.QUERY_TEXT, ah.QUERY_START_TIME)" in rendered
+    # Column pairs aggregated server-side — no client map needed
+    assert "ARRAY_AGG(DISTINCT OBJECT_CONSTRUCT(" in rendered
+    assert "COLUMN_PAIRS" in rendered
+    # Both flatten paths preserved
+    assert "DIRECT_OBJECTS_ACCESSED" in rendered
+    assert "directSources" in rendered
+    # LEFT JOIN binds column array to its table edge
+    assert "LEFT JOIN column_edges_grouped" in rendered
+    # QUERY_TEXT now flows from the single inner JOIN inside access_history_filtered,
+    # not a second LEFT JOIN to QUERY_HISTORY — drop the qh_repr indirection.
+    assert "te.QUERY_TEXT" in rendered
+    assert "qh_repr" not in rendered
+    # No per-downstream array caps
+    assert "ARRAY_SLICE" not in rendered
+
+
+def test_combined_sql_injects_filter_condition_when_provided():
+    """User's sourceConfig.filterCondition must be injected into the source CTE."""
+    rendered = SNOWFLAKE_ACCESS_HISTORY_LINEAGE.format(
+        account_usage="SNOWFLAKE.ACCOUNT_USAGE",
+        start_time="2025-01-01",
+        end_time="2025-01-31",
+        filter_condition="AND (qh.QUERY_TYPE = 'CREATE_TABLE_AS_SELECT')",
+    )
+    # Predicate lands inside the access_history_filtered CTE before flatten/aggregation
+    assert "AND (qh.QUERY_TYPE = 'CREATE_TABLE_AS_SELECT')" in rendered
+    cte_section, _, _ = rendered.partition("table_edges AS")
+    assert "AND (qh.QUERY_TYPE = 'CREATE_TABLE_AS_SELECT')" in cte_section
+
+
+def test_build_filter_condition_clause_empty_when_unset():
+    src = _make_lineage_source()
+    src.source_config.filterCondition = None
+    assert src._build_filter_condition_clause() == ""
+
+
+def test_build_filter_condition_clause_wraps_user_predicate():
+    src = _make_lineage_source()
+    src.source_config.filterCondition = "qh.USER_NAME = 'etl_user'"
+    assert src._build_filter_condition_clause() == "AND (qh.USER_NAME = 'etl_user')"
+
+
+def test_copy_history_sql_filters_loaded_status():
+    rendered = SNOWFLAKE_COPY_HISTORY_LINEAGE.format(
+        account_usage="SNOWFLAKE.ACCOUNT_USAGE",
+        start_time="2025-01-01",
+        end_time="2025-01-31",
+    )
+    assert "COPY_HISTORY" in rendered
+    assert "STATUS = 'Loaded'" in rendered
+    assert "STAGE_LOCATION" in rendered
+
+
+def test_probe_sql_is_lightweight():
+    rendered = SNOWFLAKE_ACCESS_HISTORY_PROBE.format(account_usage="SNOWFLAKE.ACCOUNT_USAGE")
+    assert "ACCESS_HISTORY" in rendered
+    assert "LIMIT 1" in rendered
+
+
+# ---------------------------------------------------------------------------
+# connectionOptions parsing
+# ---------------------------------------------------------------------------
+
+
+def _make_fake_workflow_config(options: dict) -> MagicMock:
+    """Build a config that mirrors `config.serviceConnection.root.config.connectionOptions.root`."""
+    fake = MagicMock()
+    fake.serviceConnection.root.config.connectionOptions = MagicMock()
+    fake.serviceConnection.root.config.connectionOptions.root = options
+    return fake
+
+
+def test_use_access_history_flag_default_off():
+    config = _make_fake_workflow_config({})
+    assert SnowflakeLineageSource._pop_access_history_flag(config) is False
+
+
+def test_use_access_history_flag_parses_true():
+    config = _make_fake_workflow_config({USE_ACCESS_HISTORY_OPTION_KEY: "true"})
+    assert SnowflakeLineageSource._pop_access_history_flag(config) is True
+
+
+def test_use_access_history_flag_parses_case_insensitive():
+    config = _make_fake_workflow_config({USE_ACCESS_HISTORY_OPTION_KEY: "TRUE"})
+    assert SnowflakeLineageSource._pop_access_history_flag(config) is True
+
+
+def test_use_access_history_flag_ignores_unrelated_options():
+    config = _make_fake_workflow_config({"otherOpt": "value"})
+    assert SnowflakeLineageSource._pop_access_history_flag(config) is False
+
+
+def test_use_access_history_key_is_popped_from_options():
+    """The OM-specific key must be removed so the Snowflake driver never sees it."""
+    options = {USE_ACCESS_HISTORY_OPTION_KEY: "true", "OTHER": "keep"}
+    config = _make_fake_workflow_config(options)
+    SnowflakeLineageSource._pop_access_history_flag(config)
+    assert USE_ACCESS_HISTORY_OPTION_KEY not in options
+    assert "OTHER" in options
+
+
+def test_pop_runs_before_super_init():
+    """Regression test: the flag must be removed from connectionOptions before
+    the parent init builds the Snowflake URL, otherwise the driver receives
+    an unknown `useAccessHistory` param."""
+    options = {USE_ACCESS_HISTORY_OPTION_KEY: "true"}
+    config = _make_fake_workflow_config(options)
+    captured = {}
+
+    def fake_super_init(self, cfg, meta, get_engine=True):
+        captured["options_at_super_init"] = dict(cfg.serviceConnection.root.config.connectionOptions.root)
+        self.service_connection = MagicMock()
+        self.engine = None
+
+    with (
+        patch(
+            "metadata.ingestion.source.database.snowflake.lineage.SnowflakeQueryParserSource.__init__",
+            fake_super_init,
+        ),
+        patch(
+            "metadata.ingestion.source.database.snowflake.lineage.probe_access_history_available",
+            return_value=False,
+        ),
+    ):
+        src = SnowflakeLineageSource.__new__(SnowflakeLineageSource)
+        SnowflakeLineageSource.__init__(src, config, MagicMock(), get_engine=False)
+
+    assert USE_ACCESS_HISTORY_OPTION_KEY not in captured["options_at_super_init"]
+
+
+# ---------------------------------------------------------------------------
+# Probe demote behavior
+# ---------------------------------------------------------------------------
+
+
+def test_probe_failure_falls_back_to_legacy():
+    """A failing probe must flip _use_access_history to False even if the flag was set."""
+    config = _make_fake_workflow_config({USE_ACCESS_HISTORY_OPTION_KEY: "true"})
+
+    def fake_super_init(self, cfg, meta, get_engine=True):
+        self.service_connection = MagicMock()
+        self.service_connection.accountUsageSchema = "SNOWFLAKE.ACCOUNT_USAGE"
+        self.engine = MagicMock()
+
+    with (
+        patch(
+            "metadata.ingestion.source.database.snowflake.lineage.SnowflakeQueryParserSource.__init__",
+            fake_super_init,
+        ),
+        patch(
+            "metadata.ingestion.source.database.snowflake.lineage.probe_access_history_available",
+            return_value=False,
+        ),
+    ):
+        src = SnowflakeLineageSource.__new__(SnowflakeLineageSource)
+        SnowflakeLineageSource.__init__(src, config, MagicMock())
+
+    assert src._use_access_history is False
+
+
+# ---------------------------------------------------------------------------
+# Table edge yielding
+# ---------------------------------------------------------------------------
+
+
+def test_table_edges_resolve_and_emit_lineage_requests():
+    upstream_entity = _make_table_entity("11111111-1111-1111-1111-111111111111", "DB", "SCHEMA", "ORDERS")
+    downstream_entity = _make_table_entity("22222222-2222-2222-2222-222222222222", "DB", "SCHEMA", "REVENUE")
+    metadata = MagicMock()
+
+    def _get_by_name(entity, fqn):
+        if fqn == "test_service.DB.SCHEMA.ORDERS":
+            return upstream_entity
+        if fqn == "test_service.DB.SCHEMA.REVENUE":
+            return downstream_entity
+        return None
+
+    metadata.get_by_name = MagicMock(side_effect=_get_by_name)
+
+    src = _make_lineage_source(
+        metadata=metadata,
+        rows_by_sql={
+            "ACCESS_HISTORY": [
+                _Row(
+                    upstream_table="DB.SCHEMA.ORDERS",
+                    upstream_domain="Table",
+                    downstream_table="DB.SCHEMA.REVENUE",
+                    downstream_domain="Table",
+                    query_id="abc",
+                    column_pairs=None,
+                ),
+            ],
+        },
+    )
+
+    edges = list(src._yield_combined_access_history())
+    assert len(edges) == 1
+    request = edges[0].right
+    assert isinstance(request, AddLineageRequest)
+    assert str(request.edge.fromEntity.id.root) == "11111111-1111-1111-1111-111111111111"
+    assert str(request.edge.toEntity.id.root) == "22222222-2222-2222-2222-222222222222"
+    assert request.edge.lineageDetails.source == LineageEdgeSource.QueryLineage
+    assert request.edge.lineageDetails.columnsLineage is None
+    # Row had no query_text → sqlQuery stays unset
+    assert request.edge.lineageDetails.sqlQuery is None
+
+
+def test_sql_query_text_attaches_when_present_in_row():
+    """The representative QUERY_TEXT from QUERY_HISTORY should land on LineageDetails.sqlQuery."""
+    upstream_entity = _make_table_entity("11111111-1111-1111-1111-111111111111", "DB", "SCHEMA", "ORDERS")
+    downstream_entity = _make_table_entity("22222222-2222-2222-2222-222222222222", "DB", "SCHEMA", "REVENUE")
+    metadata = MagicMock()
+    metadata.get_by_name = MagicMock(
+        side_effect=lambda entity, fqn: {
+            "test_service.DB.SCHEMA.ORDERS": upstream_entity,
+            "test_service.DB.SCHEMA.REVENUE": downstream_entity,
+        }.get(fqn)
+    )
+    representative_sql = "INSERT INTO REVENUE (total_amount) SELECT amount FROM ORDERS WHERE active = true"
+    src = _make_lineage_source(
+        metadata=metadata,
+        rows_by_sql={
+            "ACCESS_HISTORY": [
+                _Row(
+                    upstream_table="DB.SCHEMA.ORDERS",
+                    upstream_domain="Table",
+                    downstream_table="DB.SCHEMA.REVENUE",
+                    downstream_domain="Table",
+                    query_id="abc",
+                    query_text=representative_sql,
+                    column_pairs=None,
+                ),
+            ],
+        },
+    )
+    edges = list(src._yield_combined_access_history())
+    assert len(edges) == 1
+    details = edges[0].right.edge.lineageDetails
+    assert details.sqlQuery is not None
+    assert str(details.sqlQuery.root) == representative_sql
+
+
+def test_table_edges_skip_when_either_side_unresolvable():
+    metadata = MagicMock()
+    metadata.get_by_name = MagicMock(return_value=None)
+    src = _make_lineage_source(
+        metadata=metadata,
+        rows_by_sql={
+            "ACCESS_HISTORY": [
+                _Row(
+                    upstream_table="DB.SCHEMA.ORDERS",
+                    upstream_domain="Table",
+                    downstream_table="DB.SCHEMA.REVENUE",
+                    downstream_domain="Table",
+                    query_id="abc",
+                    column_pairs=None,
+                ),
+            ],
+        },
+    )
+    edges = list(src._yield_combined_access_history())
+    assert edges == []
+
+
+def test_split_snowflake_fqn_handles_three_part_name():
+    assert SnowflakeLineageSource._split_snowflake_fqn("DB.SCHEMA.TABLE") == ("DB", "SCHEMA", "TABLE")
+
+
+def test_split_snowflake_fqn_rejects_malformed():
+    assert SnowflakeLineageSource._split_snowflake_fqn(None) is None
+    assert SnowflakeLineageSource._split_snowflake_fqn("") is None
+    assert SnowflakeLineageSource._split_snowflake_fqn("DB.SCHEMA") is None
+    assert SnowflakeLineageSource._split_snowflake_fqn("DB.SCHEMA.TABLE.EXTRA") is None
+
+
+def test_split_snowflake_fqn_strips_quoted_identifiers():
+    assert SnowflakeLineageSource._split_snowflake_fqn('"DB"."SCHEMA"."TABLE"') == (
+        "DB",
+        "SCHEMA",
+        "TABLE",
+    )
+    assert SnowflakeLineageSource._split_snowflake_fqn('"My DB".PUBLIC."My Table"') == (
+        "My DB",
+        "PUBLIC",
+        "My Table",
+    )
+
+
+def test_split_snowflake_fqn_handles_embedded_dots_in_quoted_parts():
+    assert SnowflakeLineageSource._split_snowflake_fqn('"My.DB"."My.Schema"."My.Table"') == (
+        "My.DB",
+        "My.Schema",
+        "My.Table",
+    )
+
+
+def test_split_snowflake_fqn_unescapes_doubled_quotes():
+    assert SnowflakeLineageSource._split_snowflake_fqn('DB.SCHEMA."weird""name"') == (
+        "DB",
+        "SCHEMA",
+        'weird"name',
+    )
+
+
+def test_split_snowflake_fqn_logs_debug_for_skips():
+    from unittest.mock import patch
+
+    with patch("metadata.ingestion.source.database.snowflake.lineage.logger") as mock_logger:
+        assert SnowflakeLineageSource._split_snowflake_fqn("DB.SCHEMA") is None
+        debug_messages = [call.args[0] for call in mock_logger.debug.call_args_list]
+        assert any("unexpected part count" in msg for msg in debug_messages)
+
+
+# ---------------------------------------------------------------------------
+# Column lineage attachment
+# ---------------------------------------------------------------------------
+
+
+def test_column_lineage_attaches_to_table_edge():
+    """Column pairs arrive pre-aggregated in the row's VARIANT column."""
+    upstream_entity = _make_table_entity(
+        "11111111-1111-1111-1111-111111111111", "DB", "SCHEMA", "ORDERS", columns=["AMOUNT", "ID"]
+    )
+    downstream_entity = _make_table_entity(
+        "22222222-2222-2222-2222-222222222222", "DB", "SCHEMA", "REVENUE", columns=["TOTAL_AMOUNT", "ID"]
+    )
+    metadata = MagicMock()
+
+    def _get_by_name(entity, fqn):
+        return {
+            "test_service.DB.SCHEMA.ORDERS": upstream_entity,
+            "test_service.DB.SCHEMA.REVENUE": downstream_entity,
+        }.get(fqn)
+
+    metadata.get_by_name = MagicMock(side_effect=_get_by_name)
+
+    src = _make_lineage_source(
+        metadata=metadata,
+        rows_by_sql={
+            "ACCESS_HISTORY": [
+                _Row(
+                    upstream_table="DB.SCHEMA.ORDERS",
+                    upstream_domain="Table",
+                    downstream_table="DB.SCHEMA.REVENUE",
+                    downstream_domain="Table",
+                    query_id="abc",
+                    column_pairs=[{"d": "TOTAL_AMOUNT", "u": "AMOUNT"}],
+                ),
+            ],
+        },
+    )
+
+    edges = list(src._yield_combined_access_history())
+    assert len(edges) == 1
+    details = edges[0].right.edge.lineageDetails
+    assert details.columnsLineage is not None
+    assert len(details.columnsLineage) == 1
+    cl = details.columnsLineage[0]
+    # ColumnLineage shape matches today's parser output (sql_lineage.py:614).
+    assert str(cl.toColumn.root) == "test_service.DB.SCHEMA.REVENUE.TOTAL_AMOUNT"
+    assert [str(c.root) for c in cl.fromColumns] == ["test_service.DB.SCHEMA.ORDERS.AMOUNT"]
+
+
+def test_column_lineage_attaches_multiple_column_pairs():
+    """Multiple column pairs from the same edge should all attach."""
+    upstream_entity = _make_table_entity(
+        "11111111-1111-1111-1111-111111111111", "DB", "SCHEMA", "ORDERS", columns=["AMOUNT", "ID"]
+    )
+    downstream_entity = _make_table_entity(
+        "22222222-2222-2222-2222-222222222222", "DB", "SCHEMA", "REVENUE", columns=["TOTAL_AMOUNT", "ID"]
+    )
+    metadata = MagicMock()
+    metadata.get_by_name = MagicMock(
+        side_effect=lambda entity, fqn: {
+            "test_service.DB.SCHEMA.ORDERS": upstream_entity,
+            "test_service.DB.SCHEMA.REVENUE": downstream_entity,
+        }.get(fqn)
+    )
+
+    src = _make_lineage_source(
+        metadata=metadata,
+        rows_by_sql={
+            "ACCESS_HISTORY": [
+                _Row(
+                    upstream_table="DB.SCHEMA.ORDERS",
+                    upstream_domain="Table",
+                    downstream_table="DB.SCHEMA.REVENUE",
+                    downstream_domain="Table",
+                    query_id="abc",
+                    column_pairs=[
+                        {"d": "TOTAL_AMOUNT", "u": "AMOUNT"},
+                        {"d": "ID", "u": "ID"},
+                    ],
+                ),
+            ],
+        },
+    )
+    edges = list(src._yield_combined_access_history())
+    assert len(edges) == 1
+    cls = edges[0].right.edge.lineageDetails.columnsLineage
+    assert len(cls) == 2
+
+
+# ---------------------------------------------------------------------------
+# _parse_column_pairs — VARIANT decoding robustness
+# ---------------------------------------------------------------------------
+
+
+def test_parse_column_pairs_accepts_python_list():
+    assert SnowflakeLineageSource._parse_column_pairs([{"d": "x", "u": "y"}]) == [("x", "y")]
+
+
+def test_parse_column_pairs_accepts_json_string():
+    """snowflake-sqlalchemy can return VARIANTs as JSON strings depending on cursor config."""
+    assert SnowflakeLineageSource._parse_column_pairs('[{"d": "x", "u": "y"}]') == [("x", "y")]
+
+
+def test_parse_column_pairs_handles_none_and_empty():
+    assert SnowflakeLineageSource._parse_column_pairs(None) == []
+    assert SnowflakeLineageSource._parse_column_pairs([]) == []
+    assert SnowflakeLineageSource._parse_column_pairs("") == []
+
+
+def test_parse_column_pairs_handles_malformed():
+    """Unparseable JSON or non-list inputs degrade silently — never raise."""
+    assert SnowflakeLineageSource._parse_column_pairs("not json") == []
+    assert SnowflakeLineageSource._parse_column_pairs({"not": "a list"}) == []
+    assert SnowflakeLineageSource._parse_column_pairs([{"d": "x"}]) == []  # missing 'u'
+    assert SnowflakeLineageSource._parse_column_pairs([{"u": "y"}]) == []  # missing 'd'
+
+
+# ---------------------------------------------------------------------------
+# COPY_HISTORY → Container resolution
+# ---------------------------------------------------------------------------
+
+
+def test_copy_edge_emitted_when_container_resolves():
+    downstream_entity = _make_table_entity("33333333-3333-3333-3333-333333333333", "DB", "SCHEMA", "STAGE_TBL")
+    container_entity = _make_container_entity("44444444-4444-4444-4444-444444444444", "s3://my-bucket/path/")
+    metadata = MagicMock()
+    metadata.get_by_name = MagicMock(return_value=downstream_entity)
+    metadata.es_search_container_by_path = MagicMock(return_value=[container_entity])
+
+    src = _make_lineage_source(
+        metadata=metadata,
+        rows_by_sql={
+            "COPY_HISTORY": [
+                _Row(
+                    downstream_database="DB",
+                    downstream_schema="SCHEMA",
+                    downstream_table="STAGE_TBL",
+                    stage_location="s3://my-bucket/path/",
+                    last_load_time="2025-01-15",
+                    load_count=5,
+                ),
+            ],
+        },
+    )
+    edges = list(src._yield_copy_history_lineage())
+    assert len(edges) == 1
+    request = edges[0].right
+    assert request.edge.fromEntity.type == "container"
+    assert str(request.edge.fromEntity.id.root) == "44444444-4444-4444-4444-444444444444"
+    assert str(request.edge.toEntity.id.root) == "33333333-3333-3333-3333-333333333333"
+
+
+def test_copy_edge_skipped_when_container_not_ingested():
+    downstream_entity = _make_table_entity("33333333-3333-3333-3333-333333333333", "DB", "SCHEMA", "STAGE_TBL")
+    metadata = MagicMock()
+    metadata.get_by_name = MagicMock(return_value=downstream_entity)
+    metadata.es_search_container_by_path = MagicMock(return_value=[])
+
+    src = _make_lineage_source(
+        metadata=metadata,
+        rows_by_sql={
+            "COPY_HISTORY": [
+                _Row(
+                    downstream_database="DB",
+                    downstream_schema="SCHEMA",
+                    downstream_table="STAGE_TBL",
+                    stage_location="s3://my-bucket/path/",
+                    last_load_time="2025-01-15",
+                    load_count=5,
+                ),
+            ],
+        },
+    )
+    edges = list(src._yield_copy_history_lineage())
+    assert edges == []
+
+
+def test_copy_edge_skips_internal_stage_silently():
+    metadata = MagicMock()
+    metadata.es_search_container_by_path = MagicMock()  # should never be called
+    src = _make_lineage_source(
+        metadata=metadata,
+        rows_by_sql={
+            "COPY_HISTORY": [
+                _Row(
+                    downstream_database="DB",
+                    downstream_schema="SCHEMA",
+                    downstream_table="STAGE_TBL",
+                    stage_location="@MY_DB.MY_SCHEMA.INT_STAGE/path/",
+                    last_load_time="2025-01-15",
+                    load_count=5,
+                ),
+                _Row(
+                    downstream_database="DB",
+                    downstream_schema="SCHEMA",
+                    downstream_table="STAGE_TBL",
+                    stage_location="@~/userstage/",
+                    last_load_time="2025-01-15",
+                    load_count=5,
+                ),
+            ],
+        },
+    )
+    edges = list(src._yield_copy_history_lineage())
+    assert edges == []
+    metadata.es_search_container_by_path.assert_not_called()
+
+
+def test_is_external_stage_classifier():
+    assert SnowflakeLineageSource._is_external_stage("s3://bucket/path/") is True
+    assert SnowflakeLineageSource._is_external_stage("S3://bucket/path/") is True
+    assert SnowflakeLineageSource._is_external_stage("azure://account.blob.core.windows.net/c/path/") is True
+    assert SnowflakeLineageSource._is_external_stage("gcs://bucket/path/") is True
+    assert SnowflakeLineageSource._is_external_stage("@~/path") is False
+    assert SnowflakeLineageSource._is_external_stage("@%mytable/") is False
+    assert SnowflakeLineageSource._is_external_stage("@DB.SCHEMA.STAGE/") is False
+    assert SnowflakeLineageSource._is_external_stage("") is False
+    assert SnowflakeLineageSource._is_external_stage(None) is False
+
+
+# ---------------------------------------------------------------------------
+# Parser bypass regression — the load-bearing safety net
+# ---------------------------------------------------------------------------
+
+
+def test_access_history_path_does_not_call_legacy_parser():
+    """
+    When _use_access_history is True, yield_query_lineage must NOT descend into
+    the legacy parser chain (get_lineage_by_query / query_lineage_processor).
+    Patch those to raise; the test passes iff they are never called.
+    """
+    metadata = MagicMock()
+    metadata.get_by_name = MagicMock(return_value=None)
+    metadata.es_search_container_by_path = MagicMock(return_value=[])
+
+    src = _make_lineage_source(metadata=metadata, rows_by_sql={})
+    src._use_access_history = True
+
+    with patch(
+        "metadata.ingestion.lineage.sql_lineage.get_lineage_by_query",
+        side_effect=AssertionError("legacy parser must not be called on the ACCESS_HISTORY path"),
+    ):
+        # Consume the generator; we don't care about output, only that no exception fires.
+        list(src.yield_query_lineage())
+
+
+def test_access_history_flag_off_falls_through_to_super():
+    """When the flag is off, yield_query_lineage delegates to super() (LineageSource)."""
+    src = _make_lineage_source(rows_by_sql={})
+    src._use_access_history = False
+
+    with patch.object(LineageSource, "yield_query_lineage", return_value=iter([])) as mocked:
+        list(src.yield_query_lineage())
+        mocked.assert_called_once()

--- a/ingestion/tests/unit/topology/database/test_snowflake_access_history_lineage.py
+++ b/ingestion/tests/unit/topology/database/test_snowflake_access_history_lineage.py
@@ -20,16 +20,22 @@ critical regression that the client-side SQL parser is never invoked when
 the flag is on.
 """
 
+from datetime import datetime, timedelta
 from unittest.mock import MagicMock, patch
 
 from metadata.generated.schema.api.lineage.addLineage import AddLineageRequest
 from metadata.generated.schema.entity.data.container import Container
 from metadata.generated.schema.entity.data.table import Column, DataType, Table
-from metadata.generated.schema.type.basic import EntityName, FullyQualifiedEntityName, Uuid
+from metadata.generated.schema.type.basic import (
+    EntityName,
+    FullyQualifiedEntityName,
+    Uuid,
+)
 from metadata.generated.schema.type.entityLineage import Source as LineageEdgeSource
 from metadata.generated.schema.type.entityReference import EntityReference
 from metadata.ingestion.source.database.lineage_source import LineageSource
 from metadata.ingestion.source.database.snowflake.lineage import (
+    ACCESS_HISTORY_CHUNK_DAYS,
     USE_ACCESS_HISTORY_OPTION_KEY,
     SnowflakeLineageSource,
 )
@@ -44,7 +50,9 @@ from metadata.ingestion.source.database.snowflake.queries import (
 # ---------------------------------------------------------------------------
 
 
-def _make_table_entity(table_uuid: str, db: str, schema: str, table: str, columns=None) -> Table:
+def _make_table_entity(
+    table_uuid: str, db: str, schema: str, table: str, columns=None
+) -> Table:
     """Build a minimal Table entity for column-lineage resolution tests."""
     table_fqn = f"test_service.{db}.{schema}.{table}"
     cols = [
@@ -100,8 +108,8 @@ def _make_lineage_source(
     src.service_connection.connectionOptions.root = dict(connection_options or {})
     src.source_config = MagicMock()
     src.engine = _make_mock_engine(rows_by_sql or {})
-    src.start = "2025-01-01 00:00:00"
-    src.end = "2025-01-02 00:00:00"
+    src.start = datetime(2025, 1, 1)
+    src.end = datetime(2025, 1, 2)
     src._table_cache = {}
     src._use_access_history = False
     return src
@@ -175,18 +183,66 @@ def test_combined_lineage_sql_streams_one_row_per_edge():
     assert "ARRAY_SLICE" not in rendered
 
 
-def test_combined_sql_injects_filter_condition_when_provided():
-    """User's sourceConfig.filterCondition must be injected into the source CTE."""
+def test_combined_sql_injects_filter_condition_at_final_select():
+    """
+    sourceConfig.filterCondition scopes the final edge result by table FQN
+    (database/schema), so it must land on the outer SELECT — after the source
+    CTE, not inside it.
+    """
+    predicate = "WHERE (DOWNSTREAM_TABLE LIKE 'MYDB.%')"
     rendered = SNOWFLAKE_ACCESS_HISTORY_LINEAGE.format(
         account_usage="SNOWFLAKE.ACCOUNT_USAGE",
         start_time="2025-01-01",
         end_time="2025-01-31",
-        filter_condition="AND (qh.QUERY_TYPE = 'CREATE_TABLE_AS_SELECT')",
+        filter_condition=predicate,
     )
-    # Predicate lands inside the access_history_filtered CTE before flatten/aggregation
-    assert "AND (qh.QUERY_TYPE = 'CREATE_TABLE_AS_SELECT')" in rendered
+    cte_section = rendered.partition("table_edges AS")[0]
+    assert "DOWNSTREAM_TABLE LIKE 'MYDB.%'" not in cte_section
+    after_final_from = rendered.partition("FROM table_edges te")[2]
+    assert predicate in after_final_from
+
+
+def test_combined_lineage_sql_prunes_query_history_by_date():
+    """
+    The QUERY_HISTORY side of the join must also be date-bounded so Snowflake can
+    prune its micro-partitions instead of scanning the full table to satisfy the
+    QUERY_ID join.
+    """
+    rendered = SNOWFLAKE_ACCESS_HISTORY_LINEAGE.format(
+        account_usage="SNOWFLAKE.ACCOUNT_USAGE",
+        start_time="2025-01-01",
+        end_time="2025-01-31",
+        filter_condition="",
+    )
     cte_section, _, _ = rendered.partition("table_edges AS")
-    assert "AND (qh.QUERY_TYPE = 'CREATE_TABLE_AS_SELECT')" in cte_section
+    assert "qh.START_TIME" in cte_section
+    assert "ah.QUERY_START_TIME" in cte_section
+
+
+def test_combined_lineage_left_joins_query_history_for_text_only():
+    """
+    ACCESS_HISTORY is the authoritative lineage source; QUERY_HISTORY only
+    enriches with query text. Every qh predicate (time prune + success) lives in
+    the LEFT JOIN ON clause, so an absent/failed/boundary qh row yields null text
+    but never drops the edge — no post-join WHERE guard needed. The
+    dbt/OpenMetadata noise filters are dropped — ACCESS_HISTORY only surfaces
+    queries that actually modified objects.
+    """
+    rendered = SNOWFLAKE_ACCESS_HISTORY_LINEAGE.format(
+        account_usage="SNOWFLAKE.ACCOUNT_USAGE",
+        start_time="2025-01-01",
+        end_time="2025-01-31",
+        filter_condition="",
+    )
+    assert "LEFT JOIN SNOWFLAKE.ACCOUNT_USAGE.QUERY_HISTORY" in rendered
+    on_clause, _, where_clause = rendered.partition("table_edges AS")[0].partition(
+        "WHERE ah.QUERY_START_TIME"
+    )
+    assert "qh.EXECUTION_STATUS = 'SUCCESS'" in on_clause
+    assert "qh.EXECUTION_STATUS" not in where_clause
+    assert "qh.QUERY_ID IS NULL" not in rendered
+    assert '"app": "dbt"' not in rendered
+    assert '"app": "OpenMetadata"' not in rendered
 
 
 def test_build_filter_condition_clause_empty_when_unset():
@@ -197,8 +253,10 @@ def test_build_filter_condition_clause_empty_when_unset():
 
 def test_build_filter_condition_clause_wraps_user_predicate():
     src = _make_lineage_source()
-    src.source_config.filterCondition = "qh.USER_NAME = 'etl_user'"
-    assert src._build_filter_condition_clause() == "AND (qh.USER_NAME = 'etl_user')"
+    src.source_config.filterCondition = "DOWNSTREAM_TABLE LIKE 'MYDB.%'"
+    assert (
+        src._build_filter_condition_clause() == "WHERE (DOWNSTREAM_TABLE LIKE 'MYDB.%')"
+    )
 
 
 def test_copy_history_sql_filters_loaded_status():
@@ -213,7 +271,9 @@ def test_copy_history_sql_filters_loaded_status():
 
 
 def test_probe_sql_is_lightweight():
-    rendered = SNOWFLAKE_ACCESS_HISTORY_PROBE.format(account_usage="SNOWFLAKE.ACCOUNT_USAGE")
+    rendered = SNOWFLAKE_ACCESS_HISTORY_PROBE.format(
+        account_usage="SNOWFLAKE.ACCOUNT_USAGE"
+    )
     assert "ACCESS_HISTORY" in rendered
     assert "LIMIT 1" in rendered
 
@@ -269,7 +329,9 @@ def test_pop_runs_before_super_init():
     captured = {}
 
     def fake_super_init(self, cfg, meta, get_engine=True):
-        captured["options_at_super_init"] = dict(cfg.serviceConnection.root.config.connectionOptions.root)
+        captured["options_at_super_init"] = dict(
+            cfg.serviceConnection.root.config.connectionOptions.root
+        )
         self.service_connection = MagicMock()
         self.engine = None
 
@@ -325,8 +387,12 @@ def test_probe_failure_falls_back_to_legacy():
 
 
 def test_table_edges_resolve_and_emit_lineage_requests():
-    upstream_entity = _make_table_entity("11111111-1111-1111-1111-111111111111", "DB", "SCHEMA", "ORDERS")
-    downstream_entity = _make_table_entity("22222222-2222-2222-2222-222222222222", "DB", "SCHEMA", "REVENUE")
+    upstream_entity = _make_table_entity(
+        "11111111-1111-1111-1111-111111111111", "DB", "SCHEMA", "ORDERS"
+    )
+    downstream_entity = _make_table_entity(
+        "22222222-2222-2222-2222-222222222222", "DB", "SCHEMA", "REVENUE"
+    )
     metadata = MagicMock()
 
     def _get_by_name(entity, fqn):
@@ -358,7 +424,9 @@ def test_table_edges_resolve_and_emit_lineage_requests():
     assert len(edges) == 1
     request = edges[0].right
     assert isinstance(request, AddLineageRequest)
-    assert str(request.edge.fromEntity.id.root) == "11111111-1111-1111-1111-111111111111"
+    assert (
+        str(request.edge.fromEntity.id.root) == "11111111-1111-1111-1111-111111111111"
+    )
     assert str(request.edge.toEntity.id.root) == "22222222-2222-2222-2222-222222222222"
     assert request.edge.lineageDetails.source == LineageEdgeSource.QueryLineage
     assert request.edge.lineageDetails.columnsLineage is None
@@ -368,8 +436,12 @@ def test_table_edges_resolve_and_emit_lineage_requests():
 
 def test_sql_query_text_attaches_when_present_in_row():
     """The representative QUERY_TEXT from QUERY_HISTORY should land on LineageDetails.sqlQuery."""
-    upstream_entity = _make_table_entity("11111111-1111-1111-1111-111111111111", "DB", "SCHEMA", "ORDERS")
-    downstream_entity = _make_table_entity("22222222-2222-2222-2222-222222222222", "DB", "SCHEMA", "REVENUE")
+    upstream_entity = _make_table_entity(
+        "11111111-1111-1111-1111-111111111111", "DB", "SCHEMA", "ORDERS"
+    )
+    downstream_entity = _make_table_entity(
+        "22222222-2222-2222-2222-222222222222", "DB", "SCHEMA", "REVENUE"
+    )
     metadata = MagicMock()
     metadata.get_by_name = MagicMock(
         side_effect=lambda entity, fqn: {
@@ -419,12 +491,163 @@ def test_table_edges_skip_when_either_side_unresolvable():
             ],
         },
     )
+    with patch(
+        "metadata.ingestion.source.database.snowflake.lineage.logger"
+    ) as mock_logger:
+        edges = list(src._yield_combined_access_history())
+        assert edges == []
+        debug_messages = [str(call.args) for call in mock_logger.debug.call_args_list]
+        assert any("table not found in OpenMetadata" in msg for msg in debug_messages)
+        assert any("DB.SCHEMA.ORDERS" in msg for msg in debug_messages)
+        assert any("DB.SCHEMA.REVENUE" in msg for msg in debug_messages)
+
+
+def test_access_history_chunks_window_into_slices():
+    """A multi-day window is split into one combined query per ACCESS_HISTORY_CHUNK_DAYS slice."""
+    upstream_entity = _make_table_entity(
+        "11111111-1111-1111-1111-111111111111", "DB", "SCHEMA", "ORDERS"
+    )
+    downstream_entity = _make_table_entity(
+        "22222222-2222-2222-2222-222222222222", "DB", "SCHEMA", "REVENUE"
+    )
+    metadata = MagicMock()
+    metadata.get_by_name = MagicMock(
+        side_effect=lambda entity, fqn: {
+            "test_service.DB.SCHEMA.ORDERS": upstream_entity,
+            "test_service.DB.SCHEMA.REVENUE": downstream_entity,
+        }.get(fqn)
+    )
+    src = _make_lineage_source(
+        metadata=metadata,
+        rows_by_sql={
+            "ACCESS_HISTORY": [
+                _Row(
+                    upstream_table="DB.SCHEMA.ORDERS",
+                    upstream_domain="Table",
+                    downstream_table="DB.SCHEMA.REVENUE",
+                    downstream_domain="Table",
+                    query_id="abc",
+                    column_pairs=None,
+                ),
+            ],
+        },
+    )
+    chunk = timedelta(days=ACCESS_HISTORY_CHUNK_DAYS)
+    src.start = datetime(2025, 1, 1)
+    src.end = src.start + chunk * 3
+
     edges = list(src._yield_combined_access_history())
-    assert edges == []
+
+    assert len(edges) == 3
+    conn = src.engine.connect.return_value
+    executed = [str(call.args[0]) for call in conn.execute.call_args_list]
+    assert len(executed) == 3
+    for slice_index in range(3):
+        window_start = src.start + chunk * slice_index
+        window_end = src.start + chunk * (slice_index + 1)
+        assert any(
+            str(window_start) in sql and str(window_end) in sql for sql in executed
+        )
+
+
+def test_access_history_window_failure_does_not_abort_run():
+    """A failure on one date window must not stop the remaining windows."""
+    upstream_entity = _make_table_entity(
+        "11111111-1111-1111-1111-111111111111", "DB", "SCHEMA", "ORDERS"
+    )
+    downstream_entity = _make_table_entity(
+        "22222222-2222-2222-2222-222222222222", "DB", "SCHEMA", "REVENUE"
+    )
+    metadata = MagicMock()
+    metadata.get_by_name = MagicMock(
+        side_effect=lambda entity, fqn: {
+            "test_service.DB.SCHEMA.ORDERS": upstream_entity,
+            "test_service.DB.SCHEMA.REVENUE": downstream_entity,
+        }.get(fqn)
+    )
+    src = _make_lineage_source(
+        metadata=metadata,
+        rows_by_sql={
+            "ACCESS_HISTORY": [
+                _Row(
+                    upstream_table="DB.SCHEMA.ORDERS",
+                    upstream_domain="Table",
+                    downstream_table="DB.SCHEMA.REVENUE",
+                    downstream_domain="Table",
+                    query_id="abc",
+                    column_pairs=None,
+                ),
+            ],
+        },
+    )
+    src.start = datetime(2025, 1, 1)
+    src.end = src.start + timedelta(days=ACCESS_HISTORY_CHUNK_DAYS) * 2
+
+    conn = src.engine.connect.return_value
+    healthy_side_effect = conn.execute.side_effect
+    call_state = {"count": 0}
+
+    def _flaky_execute(statement):
+        call_state["count"] += 1
+        if call_state["count"] == 1:
+            raise RuntimeError("simulated snowflake timeout")
+        return healthy_side_effect(statement)
+
+    conn.execute.side_effect = _flaky_execute
+
+    edges = list(src._yield_combined_access_history())
+
+    assert call_state["count"] == 2
+    assert len(edges) == 1
+
+
+def test_access_history_skips_malformed_row_and_keeps_rest():
+    """A single unparseable row must be skipped without dropping the rest of the window."""
+    upstream_entity = _make_table_entity(
+        "11111111-1111-1111-1111-111111111111", "DB", "SCHEMA", "ORDERS"
+    )
+    downstream_entity = _make_table_entity(
+        "22222222-2222-2222-2222-222222222222", "DB", "SCHEMA", "REVENUE"
+    )
+    metadata = MagicMock()
+    metadata.get_by_name = MagicMock(
+        side_effect=lambda entity, fqn: {
+            "test_service.DB.SCHEMA.ORDERS": upstream_entity,
+            "test_service.DB.SCHEMA.REVENUE": downstream_entity,
+        }.get(fqn)
+    )
+    src = _make_lineage_source(
+        metadata=metadata,
+        rows_by_sql={
+            "ACCESS_HISTORY": [
+                _Row({1: "boom"}),  # non-string key fails lower-casing → row skipped
+                _Row(
+                    upstream_table="DB.SCHEMA.ORDERS",
+                    upstream_domain="Table",
+                    downstream_table="DB.SCHEMA.REVENUE",
+                    downstream_domain="Table",
+                    query_id="abc",
+                    column_pairs=None,
+                ),
+            ],
+        },
+    )
+
+    edges = list(src._yield_combined_access_history())
+
+    assert len(edges) == 1
+    assert (
+        str(edges[0].right.edge.toEntity.id.root)
+        == "22222222-2222-2222-2222-222222222222"
+    )
 
 
 def test_split_snowflake_fqn_handles_three_part_name():
-    assert SnowflakeLineageSource._split_snowflake_fqn("DB.SCHEMA.TABLE") == ("DB", "SCHEMA", "TABLE")
+    assert SnowflakeLineageSource._split_snowflake_fqn("DB.SCHEMA.TABLE") == (
+        "DB",
+        "SCHEMA",
+        "TABLE",
+    )
 
 
 def test_split_snowflake_fqn_rejects_malformed():
@@ -448,7 +671,9 @@ def test_split_snowflake_fqn_strips_quoted_identifiers():
 
 
 def test_split_snowflake_fqn_handles_embedded_dots_in_quoted_parts():
-    assert SnowflakeLineageSource._split_snowflake_fqn('"My.DB"."My.Schema"."My.Table"') == (
+    assert SnowflakeLineageSource._split_snowflake_fqn(
+        '"My.DB"."My.Schema"."My.Table"'
+    ) == (
         "My.DB",
         "My.Schema",
         "My.Table",
@@ -466,7 +691,9 @@ def test_split_snowflake_fqn_unescapes_doubled_quotes():
 def test_split_snowflake_fqn_logs_debug_for_skips():
     from unittest.mock import patch
 
-    with patch("metadata.ingestion.source.database.snowflake.lineage.logger") as mock_logger:
+    with patch(
+        "metadata.ingestion.source.database.snowflake.lineage.logger"
+    ) as mock_logger:
         assert SnowflakeLineageSource._split_snowflake_fqn("DB.SCHEMA") is None
         debug_messages = [call.args[0] for call in mock_logger.debug.call_args_list]
         assert any("unexpected part count" in msg for msg in debug_messages)
@@ -480,10 +707,18 @@ def test_split_snowflake_fqn_logs_debug_for_skips():
 def test_column_lineage_attaches_to_table_edge():
     """Column pairs arrive pre-aggregated in the row's VARIANT column."""
     upstream_entity = _make_table_entity(
-        "11111111-1111-1111-1111-111111111111", "DB", "SCHEMA", "ORDERS", columns=["AMOUNT", "ID"]
+        "11111111-1111-1111-1111-111111111111",
+        "DB",
+        "SCHEMA",
+        "ORDERS",
+        columns=["AMOUNT", "ID"],
     )
     downstream_entity = _make_table_entity(
-        "22222222-2222-2222-2222-222222222222", "DB", "SCHEMA", "REVENUE", columns=["TOTAL_AMOUNT", "ID"]
+        "22222222-2222-2222-2222-222222222222",
+        "DB",
+        "SCHEMA",
+        "REVENUE",
+        columns=["TOTAL_AMOUNT", "ID"],
     )
     metadata = MagicMock()
 
@@ -519,16 +754,26 @@ def test_column_lineage_attaches_to_table_edge():
     cl = details.columnsLineage[0]
     # ColumnLineage shape matches today's parser output (sql_lineage.py:614).
     assert str(cl.toColumn.root) == "test_service.DB.SCHEMA.REVENUE.TOTAL_AMOUNT"
-    assert [str(c.root) for c in cl.fromColumns] == ["test_service.DB.SCHEMA.ORDERS.AMOUNT"]
+    assert [str(c.root) for c in cl.fromColumns] == [
+        "test_service.DB.SCHEMA.ORDERS.AMOUNT"
+    ]
 
 
 def test_column_lineage_attaches_multiple_column_pairs():
     """Multiple column pairs from the same edge should all attach."""
     upstream_entity = _make_table_entity(
-        "11111111-1111-1111-1111-111111111111", "DB", "SCHEMA", "ORDERS", columns=["AMOUNT", "ID"]
+        "11111111-1111-1111-1111-111111111111",
+        "DB",
+        "SCHEMA",
+        "ORDERS",
+        columns=["AMOUNT", "ID"],
     )
     downstream_entity = _make_table_entity(
-        "22222222-2222-2222-2222-222222222222", "DB", "SCHEMA", "REVENUE", columns=["TOTAL_AMOUNT", "ID"]
+        "22222222-2222-2222-2222-222222222222",
+        "DB",
+        "SCHEMA",
+        "REVENUE",
+        columns=["TOTAL_AMOUNT", "ID"],
     )
     metadata = MagicMock()
     metadata.get_by_name = MagicMock(
@@ -568,12 +813,16 @@ def test_column_lineage_attaches_multiple_column_pairs():
 
 
 def test_parse_column_pairs_accepts_python_list():
-    assert SnowflakeLineageSource._parse_column_pairs([{"d": "x", "u": "y"}]) == [("x", "y")]
+    assert SnowflakeLineageSource._parse_column_pairs([{"d": "x", "u": "y"}]) == [
+        ("x", "y")
+    ]
 
 
 def test_parse_column_pairs_accepts_json_string():
     """snowflake-sqlalchemy can return VARIANTs as JSON strings depending on cursor config."""
-    assert SnowflakeLineageSource._parse_column_pairs('[{"d": "x", "u": "y"}]') == [("x", "y")]
+    assert SnowflakeLineageSource._parse_column_pairs('[{"d": "x", "u": "y"}]') == [
+        ("x", "y")
+    ]
 
 
 def test_parse_column_pairs_handles_none_and_empty():
@@ -596,8 +845,12 @@ def test_parse_column_pairs_handles_malformed():
 
 
 def test_copy_edge_emitted_when_container_resolves():
-    downstream_entity = _make_table_entity("33333333-3333-3333-3333-333333333333", "DB", "SCHEMA", "STAGE_TBL")
-    container_entity = _make_container_entity("44444444-4444-4444-4444-444444444444", "s3://my-bucket/path/")
+    downstream_entity = _make_table_entity(
+        "33333333-3333-3333-3333-333333333333", "DB", "SCHEMA", "STAGE_TBL"
+    )
+    container_entity = _make_container_entity(
+        "44444444-4444-4444-4444-444444444444", "s3://my-bucket/path/"
+    )
     metadata = MagicMock()
     metadata.get_by_name = MagicMock(return_value=downstream_entity)
     metadata.es_search_container_by_path = MagicMock(return_value=[container_entity])
@@ -621,12 +874,16 @@ def test_copy_edge_emitted_when_container_resolves():
     assert len(edges) == 1
     request = edges[0].right
     assert request.edge.fromEntity.type == "container"
-    assert str(request.edge.fromEntity.id.root) == "44444444-4444-4444-4444-444444444444"
+    assert (
+        str(request.edge.fromEntity.id.root) == "44444444-4444-4444-4444-444444444444"
+    )
     assert str(request.edge.toEntity.id.root) == "33333333-3333-3333-3333-333333333333"
 
 
 def test_copy_edge_skipped_when_container_not_ingested():
-    downstream_entity = _make_table_entity("33333333-3333-3333-3333-333333333333", "DB", "SCHEMA", "STAGE_TBL")
+    downstream_entity = _make_table_entity(
+        "33333333-3333-3333-3333-333333333333", "DB", "SCHEMA", "STAGE_TBL"
+    )
     metadata = MagicMock()
     metadata.get_by_name = MagicMock(return_value=downstream_entity)
     metadata.es_search_container_by_path = MagicMock(return_value=[])
@@ -684,7 +941,12 @@ def test_copy_edge_skips_internal_stage_silently():
 def test_is_external_stage_classifier():
     assert SnowflakeLineageSource._is_external_stage("s3://bucket/path/") is True
     assert SnowflakeLineageSource._is_external_stage("S3://bucket/path/") is True
-    assert SnowflakeLineageSource._is_external_stage("azure://account.blob.core.windows.net/c/path/") is True
+    assert (
+        SnowflakeLineageSource._is_external_stage(
+            "azure://account.blob.core.windows.net/c/path/"
+        )
+        is True
+    )
     assert SnowflakeLineageSource._is_external_stage("gcs://bucket/path/") is True
     assert SnowflakeLineageSource._is_external_stage("@~/path") is False
     assert SnowflakeLineageSource._is_external_stage("@%mytable/") is False
@@ -713,7 +975,9 @@ def test_access_history_path_does_not_call_legacy_parser():
 
     with patch(
         "metadata.ingestion.lineage.sql_lineage.get_lineage_by_query",
-        side_effect=AssertionError("legacy parser must not be called on the ACCESS_HISTORY path"),
+        side_effect=AssertionError(
+            "legacy parser must not be called on the ACCESS_HISTORY path"
+        ),
     ):
         # Consume the generator; we don't care about output, only that no exception fires.
         list(src.yield_query_lineage())
@@ -724,6 +988,8 @@ def test_access_history_flag_off_falls_through_to_super():
     src = _make_lineage_source(rows_by_sql={})
     src._use_access_history = False
 
-    with patch.object(LineageSource, "yield_query_lineage", return_value=iter([])) as mocked:
+    with patch.object(
+        LineageSource, "yield_query_lineage", return_value=iter([])
+    ) as mocked:
         list(src.yield_query_lineage())
         mocked.assert_called_once()

--- a/ingestion/tests/unit/topology/database/test_snowflake_access_history_lineage.py
+++ b/ingestion/tests/unit/topology/database/test_snowflake_access_history_lineage.py
@@ -36,6 +36,7 @@ from metadata.generated.schema.type.entityReference import EntityReference
 from metadata.ingestion.source.database.lineage_source import LineageSource
 from metadata.ingestion.source.database.snowflake.lineage import (
     ACCESS_HISTORY_CHUNK_DAYS,
+    ACCESS_HISTORY_CHUNK_DAYS_OPTION_KEY,
     USE_ACCESS_HISTORY_OPTION_KEY,
     SnowflakeLineageSource,
 )
@@ -112,6 +113,7 @@ def _make_lineage_source(
     src.end = datetime(2025, 1, 2)
     src._table_cache = {}
     src._use_access_history = False
+    src._access_history_chunk_days = ACCESS_HISTORY_CHUNK_DAYS
     return src
 
 
@@ -349,6 +351,95 @@ def test_pop_runs_before_super_init():
         SnowflakeLineageSource.__init__(src, config, MagicMock(), get_engine=False)
 
     assert USE_ACCESS_HISTORY_OPTION_KEY not in captured["options_at_super_init"]
+
+
+def test_chunk_days_default_when_unset():
+    config = _make_fake_workflow_config({})
+    assert (
+        SnowflakeLineageSource._pop_access_history_chunk_days(config)
+        == ACCESS_HISTORY_CHUNK_DAYS
+    )
+
+
+def test_chunk_days_parses_positive_int():
+    config = _make_fake_workflow_config({ACCESS_HISTORY_CHUNK_DAYS_OPTION_KEY: "7"})
+    assert SnowflakeLineageSource._pop_access_history_chunk_days(config) == 7
+
+
+def test_chunk_days_invalid_value_falls_back_to_default():
+    config = _make_fake_workflow_config(
+        {ACCESS_HISTORY_CHUNK_DAYS_OPTION_KEY: "not-a-number"}
+    )
+    assert (
+        SnowflakeLineageSource._pop_access_history_chunk_days(config)
+        == ACCESS_HISTORY_CHUNK_DAYS
+    )
+
+
+def test_chunk_days_non_positive_falls_back_to_default():
+    config = _make_fake_workflow_config({ACCESS_HISTORY_CHUNK_DAYS_OPTION_KEY: "0"})
+    assert (
+        SnowflakeLineageSource._pop_access_history_chunk_days(config)
+        == ACCESS_HISTORY_CHUNK_DAYS
+    )
+
+
+def test_chunk_days_key_is_popped_from_options():
+    """The OM-specific key must be removed so the Snowflake driver never sees it."""
+    options = {ACCESS_HISTORY_CHUNK_DAYS_OPTION_KEY: "5", "OTHER": "keep"}
+    config = _make_fake_workflow_config(options)
+    SnowflakeLineageSource._pop_access_history_chunk_days(config)
+    assert ACCESS_HISTORY_CHUNK_DAYS_OPTION_KEY not in options
+    assert "OTHER" in options
+
+
+def test_configured_chunk_days_drives_window_slicing():
+    """A custom accessHistoryChunkDays controls the size of each lineage window."""
+    upstream_entity = _make_table_entity(
+        "11111111-1111-1111-1111-111111111111", "DB", "SCHEMA", "ORDERS"
+    )
+    downstream_entity = _make_table_entity(
+        "22222222-2222-2222-2222-222222222222", "DB", "SCHEMA", "REVENUE"
+    )
+    metadata = MagicMock()
+    metadata.get_by_name = MagicMock(
+        side_effect=lambda entity, fqn: {
+            "test_service.DB.SCHEMA.ORDERS": upstream_entity,
+            "test_service.DB.SCHEMA.REVENUE": downstream_entity,
+        }.get(fqn)
+    )
+    src = _make_lineage_source(
+        metadata=metadata,
+        rows_by_sql={
+            "ACCESS_HISTORY": [
+                _Row(
+                    upstream_table="DB.SCHEMA.ORDERS",
+                    upstream_domain="Table",
+                    downstream_table="DB.SCHEMA.REVENUE",
+                    downstream_domain="Table",
+                    query_id="abc",
+                    column_pairs=None,
+                ),
+            ],
+        },
+    )
+    src._access_history_chunk_days = 5
+    chunk = timedelta(days=5)
+    src.start = datetime(2025, 1, 1)
+    src.end = src.start + chunk * 3
+
+    edges = list(src._yield_combined_access_history())
+
+    assert len(edges) == 3
+    conn = src.engine.connect.return_value
+    executed = [str(call.args[0]) for call in conn.execute.call_args_list]
+    assert len(executed) == 3
+    for slice_index in range(3):
+        window_start = src.start + chunk * slice_index
+        window_end = src.start + chunk * (slice_index + 1)
+        assert any(
+            str(window_start) in sql and str(window_end) in sql for sql in executed
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/ingestion/tests/unit/topology/database/test_snowflake_schema_columns_lru.py
+++ b/ingestion/tests/unit/topology/database/test_snowflake_schema_columns_lru.py
@@ -1,0 +1,224 @@
+#  Copyright 2025 Collate
+#  Licensed under the Collate Community License, Version 1.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  https://github.com/open-metadata/OpenMetadata/blob/main/ingestion/LICENSE
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+"""
+Tests for the bounded LRU on Snowflake's ``get_schema_columns``.
+
+Background: ``info_cache`` is only cleared between databases (see
+``common_db_source.py:_release_engine``), so the stock ``@reflection.cache``
+on ``get_schema_columns`` accumulated every schema's column metadata in
+RAM for the entire database run -- ~1.6 GB per pathologically wide schema,
+OOM-killing 4 GB pods. The replacement is a per-Inspector bounded LRU
+(``SCHEMA_COLUMNS_CACHE_SIZE``) stored under a private key on
+``info_cache`` so it inherits the per-thread isolation that
+``_inspector_map`` already provides.
+"""
+
+from unittest.mock import Mock, patch
+
+import pytest
+from snowflake.sqlalchemy.snowdialect import SnowflakeDialect
+
+from metadata.ingestion.source.database.snowflake import utils as snowflake_utils
+from metadata.ingestion.source.database.snowflake.utils import (
+    _SCHEMA_COLUMNS_LRU_KEY,
+    get_schema_columns,
+)
+
+# A single-row mock result; the exact content doesn't matter for these
+# tests -- we only care about cache structure and execute() call counts.
+_MOCK_COL_ROW = ("T1", "ID", "NUMBER", None, 10, 0, "NO", None, "NO", None, None, None, 1)
+
+
+def _make_dialect():
+    dialect = SnowflakeDialect()
+    dialect.normalize_name = lambda x: x
+    dialect.denormalize_name = lambda x: x
+    return dialect
+
+
+def _make_connection_returning_rows(rows=(_MOCK_COL_ROW,)):
+    """Return a Mock connection whose ``execute`` returns a fresh
+    iterable on each call -- we want every miss to actually iterate the
+    rows, so the iterator must not be exhausted across calls."""
+    connection = Mock()
+
+    def execute_side_effect(*args, **kwargs):
+        result = Mock()
+        result.__iter__ = Mock(return_value=iter(list(rows)))
+        return result
+
+    connection.execute = Mock(side_effect=execute_side_effect)
+    return connection
+
+
+def _call(dialect, connection, schema, info_cache):
+    with (
+        patch.object(dialect, "_current_database_schema", return_value=("DB", schema)),
+        patch.object(dialect, "_get_schema_primary_keys", return_value={}),
+    ):
+        return get_schema_columns(dialect, connection, schema, info_cache=info_cache)
+
+
+def test_same_schema_returns_cached_dict_without_rerunning_query():
+    """Two calls for the same schema -> bulk SCHEMA_COLUMNS query runs once."""
+    dialect = _make_dialect()
+    connection = _make_connection_returning_rows()
+    info_cache = {}
+
+    first = _call(dialect, connection, "S1", info_cache)
+    second = _call(dialect, connection, "S1", info_cache)
+
+    assert first is second
+    assert connection.execute.call_count == 1
+
+
+def test_lru_evicts_oldest_entry_when_over_size(monkeypatch):
+    """With cache size 2, adding a 3rd schema drops the oldest."""
+    monkeypatch.setattr(snowflake_utils, "SCHEMA_COLUMNS_CACHE_SIZE", 2)
+    dialect = _make_dialect()
+    connection = _make_connection_returning_rows()
+    info_cache = {}
+
+    _call(dialect, connection, "S1", info_cache)
+    _call(dialect, connection, "S2", info_cache)
+    _call(dialect, connection, "S3", info_cache)
+
+    lru = info_cache[_SCHEMA_COLUMNS_LRU_KEY]
+    assert list(lru.keys()) == ["S2", "S3"]
+    assert "S1" not in lru
+
+
+def test_lru_recency_protects_long_running_schema(monkeypatch):
+    """The user's "long-running schema" concern: re-querying an active
+    schema marks it most-recently-used, so cycling other (small)
+    schemas does NOT evict it."""
+    monkeypatch.setattr(snowflake_utils, "SCHEMA_COLUMNS_CACHE_SIZE", 2)
+    dialect = _make_dialect()
+    connection = _make_connection_returning_rows()
+    info_cache = {}
+
+    _call(dialect, connection, "A", info_cache)  # cache: [A]
+    _call(dialect, connection, "B", info_cache)  # cache: [A, B]
+    _call(dialect, connection, "A", info_cache)  # cache: [B, A] -- A re-touched
+    _call(dialect, connection, "C", info_cache)  # cache: [A, C] -- B evicted
+
+    lru = info_cache[_SCHEMA_COLUMNS_LRU_KEY]
+    assert "A" in lru, "actively-queried schema must not be evicted"
+    assert "C" in lru
+    assert "B" not in lru
+
+
+def test_eviction_drops_per_table_get_columns_entries(monkeypatch):
+    """When a schema is evicted from the LRU, the per-table
+    ``get_columns`` reflection cache entries for it are also cleared.
+    Without this, the per-table entries pin the column lists and memory
+    is not actually freed."""
+    monkeypatch.setattr(snowflake_utils, "SCHEMA_COLUMNS_CACHE_SIZE", 1)
+    dialect = _make_dialect()
+    connection = _make_connection_returning_rows()
+    info_cache = {}
+
+    # Seed per-table @reflection.cache entries for two schemas. Key layout
+    # mirrors what SQLAlchemy's @reflection.cache produces:
+    # (fn_name, server_version_info, default_schema_name, args, kw_items, exclude)
+    info_cache[("get_columns", None, None, ("T_a", "S1"), (), None)] = "list-T_a"
+    info_cache[("get_columns", None, None, ("T_b", "S1"), (), None)] = "list-T_b"
+    info_cache[("get_columns", None, None, ("U_a", "S2"), (), None)] = "list-U_a"
+
+    _call(dialect, connection, "S1", info_cache)  # LRU: [S1]
+    _call(dialect, connection, "S2", info_cache)  # LRU: [S2], S1 evicted
+
+    s1_entries = [
+        k
+        for k in info_cache
+        if isinstance(k, tuple) and k and k[0] == "get_columns" and isinstance(k[3], tuple) and k[3][1] == "S1"
+    ]
+    s2_entries = [
+        k
+        for k in info_cache
+        if isinstance(k, tuple) and k and k[0] == "get_columns" and isinstance(k[3], tuple) and k[3][1] == "S2"
+    ]
+    assert s1_entries == [], f"S1 per-table entries still in info_cache after eviction: {s1_entries}"
+    assert s2_entries, "S2 per-table entries should remain"
+
+
+def test_no_info_cache_falls_through_to_uncached_compute():
+    """If the caller did not pass an info_cache (rare, but supported
+    by SQLAlchemy's reflection plumbing), the function should still
+    return a result -- without caching anywhere."""
+    dialect = _make_dialect()
+    connection = _make_connection_returning_rows()
+
+    with (
+        patch.object(dialect, "_current_database_schema", return_value=("DB", "S1")),
+        patch.object(dialect, "_get_schema_primary_keys", return_value={}),
+    ):
+        result1 = get_schema_columns(dialect, connection, "S1")
+        result2 = get_schema_columns(dialect, connection, "S1")
+
+    # Both calls returned a populated dict; no caching means the query
+    # ran each time (this is the documented behaviour of
+    # @reflection.cache when info_cache is absent).
+    assert result1 is not None
+    assert result2 is not None
+    assert connection.execute.call_count == 2
+
+
+def test_none_result_from_90030_is_cached():
+    """The 90030 ("Information schema query returned too much data")
+    fallback returns None to trigger per-table reflection in
+    ``get_columns``. The None must be cached so subsequent tables in
+    the same schema don't re-run the bulk query just to hit 90030."""
+    dialect = _make_dialect()
+
+    class _FakeOrigError(Exception):
+        errno = 90030
+
+    err = __import__("sqlalchemy").exc.ProgrammingError(statement="", params=None, orig=_FakeOrigError())
+
+    connection = Mock()
+    connection.execute = Mock(side_effect=err)
+    info_cache = {}
+
+    with (
+        patch.object(dialect, "_current_database_schema", return_value=("DB", "S")),
+        patch.object(dialect, "_get_schema_primary_keys", return_value={}),
+    ):
+        first = get_schema_columns(dialect, connection, "S", info_cache=info_cache)
+        second = get_schema_columns(dialect, connection, "S", info_cache=info_cache)
+
+    assert first is None
+    assert second is None
+    # First call hit 90030 once; second call must short-circuit via the LRU
+    # (no second execute, no second 90030).
+    assert connection.execute.call_count == 1
+    assert info_cache[_SCHEMA_COLUMNS_LRU_KEY]["S"] is None
+
+
+def test_env_var_overrides_cache_size(monkeypatch):
+    """Operators can tune the cache size via OM_SNOWFLAKE_SCHEMA_COLUMNS_CACHE_SIZE.
+    The value is read at module import, so this exercises the parsing branch
+    by reloading the module."""
+    import importlib
+
+    monkeypatch.setenv("OM_SNOWFLAKE_SCHEMA_COLUMNS_CACHE_SIZE", "5")
+    reloaded = importlib.reload(snowflake_utils)
+    try:
+        assert reloaded.SCHEMA_COLUMNS_CACHE_SIZE == 5
+    finally:
+        # Reset to default for the rest of the test session
+        monkeypatch.delenv("OM_SNOWFLAKE_SCHEMA_COLUMNS_CACHE_SIZE")
+        importlib.reload(snowflake_utils)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/ingestion/tests/unit/topology/database/test_snowflake_table_type_cache_pollution.py
+++ b/ingestion/tests/unit/topology/database/test_snowflake_table_type_cache_pollution.py
@@ -1,0 +1,107 @@
+#  Copyright 2025 Collate
+#  Licensed under the Collate Community License, Version 1.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  https://github.com/open-metadata/OpenMetadata/blob/main/ingestion/LICENSE
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+"""
+Regression test for the Snowflake column-reflection cache-key pollution.
+
+SnowflakeSource._get_columns_internal used to forward ``table_type`` to
+``inspector.get_columns(...)``. SQLAlchemy's ``@reflection.cache`` decorator
+on the underlying dialect ``get_columns`` and ``_get_schema_columns``
+includes ``**kw`` in its cache key, so a varying ``table_type`` (Regular for
+base tables, View for views) produces distinct cache keys for the SAME
+schema. On the table -> view transition this cache-misses on
+``_get_schema_columns`` and re-materializes the whole schema's column
+metadata (~1.6 GB for ~13k wide tables) -- the exact mechanism behind the
+``COM_US_IMDNA_ADL.AWB_INTERM`` pod OOM (kernel SIGKILL at the 4 GB cgroup
+limit, no traceback).
+
+These tests pin the fix: ``_get_columns_internal`` must not forward
+``table_type`` into ``inspector.get_columns(...)``. ``table_type`` is still
+read by the early-return branches above (Stage / Stream) before that call.
+"""
+
+from unittest.mock import Mock
+
+from metadata.generated.schema.entity.data.table import TableType
+from metadata.ingestion.source.database.snowflake.metadata import SnowflakeSource
+
+
+def _call(inspector, table_type, table_name="T1"):
+    """Drive SnowflakeSource._get_columns_internal as an unbound method --
+    for Regular / View the code path only touches ``inspector`` and the
+    module-level logger, so a bare Mock for ``self`` is sufficient."""
+    SnowflakeSource._get_columns_internal(
+        Mock(),
+        schema_name="AWB_INTERM",
+        table_name=table_name,
+        db_name="COM_US_IMDNA_ADL",
+        inspector=inspector,
+        table_type=table_type,
+    )
+
+
+def test_table_type_is_not_forwarded_for_base_tables():
+    inspector = Mock()
+    inspector.get_columns.return_value = []
+
+    _call(inspector, TableType.Regular, table_name="T1")
+
+    assert inspector.get_columns.call_count == 1
+    kwargs = inspector.get_columns.call_args_list[0].kwargs
+    assert "table_type" not in kwargs, (
+        f"table_type forwarded to inspector.get_columns ({kwargs}); this "
+        "pollutes SQLAlchemy's @reflection.cache key and reintroduces the "
+        "AWB_INTERM-style OOM at the table->view transition."
+    )
+    # db_name is still passed (Databricks reads kw['db_name']; for Snowflake
+    # it's constant per database run so it does not vary the cache key)
+    assert kwargs == {"db_name": "COM_US_IMDNA_ADL"}
+
+
+def test_table_type_is_not_forwarded_for_views():
+    inspector = Mock()
+    inspector.get_columns.return_value = []
+
+    _call(inspector, TableType.View, table_name="V1")
+
+    kwargs = inspector.get_columns.call_args_list[0].kwargs
+    assert "table_type" not in kwargs
+    assert kwargs == {"db_name": "COM_US_IMDNA_ADL"}
+
+
+def test_table_then_view_call_signatures_are_identical():
+    """The smoking-gun assertion: at the table -> view transition the kwargs
+    passed to inspector.get_columns must be identical so SQLAlchemy's
+    @reflection.cache key on the downstream _get_schema_columns is stable."""
+    inspector = Mock()
+    inspector.get_columns.return_value = []
+
+    _call(inspector, TableType.Regular, table_name="T1")
+    _call(inspector, TableType.View, table_name="V1")
+
+    assert inspector.get_columns.call_count == 2
+    table_kwargs = inspector.get_columns.call_args_list[0].kwargs
+    view_kwargs = inspector.get_columns.call_args_list[1].kwargs
+    assert table_kwargs == view_kwargs, (
+        f"kwargs differ between table call {table_kwargs} and view call "
+        f"{view_kwargs}; this re-introduces the cache-miss that caused the "
+        "AWB_INTERM 1.6 GB schema column re-materialization."
+    )
+
+
+def test_stage_short_circuit_still_works():
+    """The Stage early-return path must still fire (it does not call
+    inspector.get_columns at all -- Stages have no columns in Snowflake)."""
+    inspector = Mock()
+
+    _call(inspector, TableType.Stage, table_name="STG")
+
+    assert inspector.get_columns.call_count == 0


### PR DESCRIPTION
## What

Forward-ports the Snowflake **ACCESS_HISTORY lineage** work (and the related schema-column cache fix) from `1.12.8` into `1.12.11`. This work landed in `1.12.8` and `main` but was never forward-ported to the `1.12.9`/`1.12.10`/`1.12.11` release branches, so `1.12.11` is currently missing all of it.

Cherry-picked (oldest→newest, provenance recorded via `git cherry-pick -x`):

| Commit | PR | Summary |
|---|---|---|
| `b0ebfca4bdb` | #28149 | `feat(snowflake): opt-in ACCESS_HISTORY lineage path` |
| `ad8f1aabf29` | #28136 | `fix(snowflake): bound schema column reflection cache and stop table_type cache pollution` |
| `d79e6790f06` | #28332 | `fix(ingestion): chunk Snowflake ACCESS_HISTORY lineage to avoid timeouts` |
| `6227a5b5f1e` | — | `feat(snowflake): make ACCESS_HISTORY lineage chunk size configurable` |

## Why

- The opt-in ACCESS_HISTORY-based lineage path (with per-day chunking + configurable chunk size) is absent from `1.12.11`.
- The `get_schema_columns` cache bounding / `table_type` cache-key fix (#28136) that prevents the ~1.6 GB-per-wide-schema OOM is also absent.

## Notes

- **Excluded** the `client.py` changes from the 1.12.8 socket-cap batch (#28131): `1.12.11` already has a newer resilient-transport client (`post_best_effort`, per-call timeouts/retries). The Snowflake socket-cap itself is already present in `1.12.11`.
- All four commits cherry-picked cleanly (no conflicts).

## Testing

- Ported test files (`test_snowflake_access_history_lineage.py`, `test_snowflake_schema_columns_lru.py`, `test_snowflake_table_type_cache_pollution.py`) → **56/56 pass**.
- Full local Snowflake unit suite → **83 pass, 1 fail**. The single failure (`test_snowflake.py::test_schema_tag_inheritance`) is a **pre-existing upstream bug** (`NameError: mock_parent_get_schema_tag_labels` used but never defined); it is byte-identical and fails the same way on `1.12.8`, `1.12.10`, and `1.12.11`, and is untouched by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
