### PR TITLE
fix(tour): eliminate race conditions causing flaky steps and resets

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/AppTour/Tour.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/AppTour/Tour.tsx
@@ -53,6 +53,7 @@ const Tour = ({ steps }: { steps: TourSteps[] }) => {
             showCloseButton
             showNumber
             accentColor={theme.primaryColor ?? ''}
+            closeWithMask={false}
             inViewThreshold={200}
             lastStepNextButton={
               <Button

--- a/openmetadata-ui/src/main/resources/ui/src/components/Database/Profiler/TableProfiler/TableProfilerProvider.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Database/Profiler/TableProfiler/TableProfilerProvider.tsx
@@ -86,7 +86,7 @@ export const TableProfilerProvider = ({
 }: TableProfilerProviderProps) => {
   const { t } = useTranslation();
   const { fqn: datasetFQN } = useFqn();
-  const { isTourOpen } = useTourProvider();
+  const { isTourOpen, tourMockDatasetData } = useTourProvider();
   const testCasePaging = usePaging();
   const { subTab } = useParams<{ subTab: ProfilerTabPath }>();
   // profiler has its own api but sent's the data in Table type
@@ -307,13 +307,12 @@ export const TableProfilerProvider = ({
       setIsProfilerDataLoading(false);
     }
     if (isTourOpen) {
-      import('../../../../constants/mockTourData.constants').then(
-        ({ mockDatasetData }) => {
-          setTableProfiler(mockDatasetData.tableDetails as unknown as Table);
-        }
-      );
+      const mock = tourMockDatasetData as { tableDetails: unknown } | undefined;
+      if (mock?.tableDetails) {
+        setTableProfiler(mock.tableDetails as Table);
+      }
     }
-  }, [datasetFQN, isTourOpen, activeTab]);
+  }, [datasetFQN, isTourOpen, activeTab, tourMockDatasetData]);
 
   useEffect(() => {
     const fetchTest =

--- a/openmetadata-ui/src/main/resources/ui/src/components/Database/SampleDataTable/SampleDataTable.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Database/SampleDataTable/SampleDataTable.component.tsx
@@ -65,7 +65,7 @@ const SampleDataTable: FC<SampleDataProps> = ({
   permissions,
   entityType = EntityType.TABLE,
 }) => {
-  const { isTourPage } = useTourProvider();
+  const { isTourPage, tourMockDatasetData } = useTourProvider();
   const { currentUser, theme } = useApplicationStore();
   const { t } = useTranslation();
   const [sampleData, setSampleData] = useState<SampleData>();
@@ -244,18 +244,19 @@ const SampleDataTable: FC<SampleDataProps> = ({
       setIsLoading(false);
     }
     if (isTourPage) {
-      import('../../../constants/mockTourData.constants').then(
-        ({ mockDatasetData }) => {
-          setSampleData(
-            getSampleDataWithType({
-              columns: mockDatasetData.tableDetails.columns,
-              sampleData: mockDatasetData.sampleData,
-            } as unknown as Table)
-          );
-        }
-      );
+      const mock = tourMockDatasetData as
+        | { tableDetails: { columns: unknown }; sampleData: unknown }
+        | undefined;
+      if (mock) {
+        setSampleData(
+          getSampleDataWithType({
+            columns: mock.tableDetails.columns,
+            sampleData: mock.sampleData,
+          } as unknown as Table)
+        );
+      }
     }
-  }, [tableId]);
+  }, [tableId, tourMockDatasetData]);
 
   if (isLoading) {
     return <Loader />;

--- a/openmetadata-ui/src/main/resources/ui/src/context/LineageProvider/LineageProvider.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/context/LineageProvider/LineageProvider.tsx
@@ -185,7 +185,7 @@ const LineageProvider = ({ children }: LineageProviderProps) => {
   const { t } = useTranslation();
   const { fqn: decodedFqn } = useFqn();
   const location = useCustomLocation();
-  const { isTourOpen, isTourPage } = useTourProvider();
+  const { isTourOpen, isTourPage, tourMockDatasetData } = useTourProvider();
   const { appPreferences } = useApplicationStore();
   const { preferences } = useCurrentUserPreferences();
   const defaultLineageConfig = appPreferences?.lineageConfig as LineageSettings;
@@ -2009,15 +2009,14 @@ const LineageProvider = ({ children }: LineageProviderProps) => {
     if (isTourOpen || isTourPage) {
       setInit(true);
       setLoading(false);
-      import('../../constants/mockTourData.constants').then(
-        ({ mockDatasetData }) => {
-          setEntityLineage(
-            mockDatasetData.entityLineage as unknown as EntityLineageResponse
-          );
-        }
-      );
+      const mock = tourMockDatasetData as
+        | { entityLineage: unknown }
+        | undefined;
+      if (mock?.entityLineage) {
+        setEntityLineage(mock.entityLineage as EntityLineageResponse);
+      }
     }
-  }, [isTourOpen, isTourPage]);
+  }, [isTourOpen, isTourPage, tourMockDatasetData]);
 
   useEffect(() => {
     if (lineageLayer) {

--- a/openmetadata-ui/src/main/resources/ui/src/context/TourProvider/TourProvider.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/context/TourProvider/TourProvider.tsx
@@ -20,10 +20,15 @@ import {
   useMemo,
   useState,
 } from 'react';
+import {
+  ExploreSearchIndex,
+  SearchHitCounts,
+} from '../../components/Explore/ExplorePage.interface';
 import { ROUTES } from '../../constants/constants';
 import { EntityTabs } from '../../enums/entity.enum';
 import { CurrentTourPageType } from '../../enums/tour.enum';
 import useCustomLocation from '../../hooks/useCustomLocation/useCustomLocation';
+import { SearchResponse } from '../../interface/search.interface';
 
 interface Props {
   children: ReactNode;
@@ -35,10 +40,18 @@ export interface TourProviderContextProps {
   currentTourPage: CurrentTourPageType;
   activeTabForTourDatasetPage: EntityTabs;
   tourSearchValue: string;
+  tourMockSearchResults?: SearchResponse<ExploreSearchIndex>;
+  tourMockSearchHitCounts?: SearchHitCounts;
+  tourMockDatasetData?: unknown;
   updateIsTourOpen: (value: boolean) => void;
   updateTourPage: (value: CurrentTourPageType) => void;
   updateActiveTab: (value: EntityTabs) => void;
   updateTourSearch: (value: string) => void;
+  updateTourMockData?: (payload: {
+    searchResults: SearchResponse<ExploreSearchIndex>;
+    searchHitCounts: SearchHitCounts;
+    datasetData: unknown;
+  }) => void;
 }
 
 export const TourContext = createContext({} as TourProviderContextProps);
@@ -56,6 +69,11 @@ const TourProvider: FC<Props> = ({ children }) => {
   const [activeTabForTourDatasetPage, setActiveTabForTourDatasetPage] =
     useState<EntityTabs>(EntityTabs.SCHEMA);
   const [searchValue, setSearchValue] = useState('');
+  const [tourMockSearchResults, setTourMockSearchResults] =
+    useState<SearchResponse<ExploreSearchIndex>>();
+  const [tourMockSearchHitCounts, setTourMockSearchHitCounts] =
+    useState<SearchHitCounts>();
+  const [tourMockDatasetData, setTourMockDatasetData] = useState<unknown>();
 
   useEffect(() => {
     if (isTourPage) {
@@ -82,6 +100,19 @@ const TourProvider: FC<Props> = ({ children }) => {
     []
   );
 
+  const handleUpdateTourMockData = useCallback(
+    (payload: {
+      searchResults: SearchResponse<ExploreSearchIndex>;
+      searchHitCounts: SearchHitCounts;
+      datasetData: unknown;
+    }) => {
+      setTourMockSearchResults(payload.searchResults);
+      setTourMockSearchHitCounts(payload.searchHitCounts);
+      setTourMockDatasetData(payload.datasetData);
+    },
+    []
+  );
+
   return (
     <TourContext.Provider
       value={{
@@ -90,10 +121,14 @@ const TourProvider: FC<Props> = ({ children }) => {
         currentTourPage,
         tourSearchValue: searchValue,
         activeTabForTourDatasetPage,
+        tourMockSearchResults,
+        tourMockSearchHitCounts,
+        tourMockDatasetData,
         updateActiveTab: handleActiveTabChange,
         updateIsTourOpen: handleIsTourOpen,
         updateTourPage: handleTourPageChange,
         updateTourSearch: handleUpdateTourSearch,
+        updateTourMockData: handleUpdateTourMockData,
       }}>
       {children}
     </TourContext.Provider>

--- a/openmetadata-ui/src/main/resources/ui/src/pages/ExplorePage/ExplorePageV1.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/ExplorePage/ExplorePageV1.component.tsx
@@ -58,7 +58,8 @@ const ExplorePageV1: FC<unknown> = () => {
     searchClassBase.getEntityTypeSearchIndexMapping();
   const location = useCustomLocation();
   const navigate = useNavigate();
-  const { isTourOpen } = useTourProvider();
+  const { isTourOpen, tourMockSearchResults, tourMockSearchHitCounts } =
+    useTourProvider();
   const TABS_SEARCH_INDEXES = Object.keys(tabsInfo) as ExploreSearchIndex[];
   const { isNLPActive, isNLPEnabled } = useSearchStore();
   const isNLPRequestEnabled = isNLPEnabled && isNLPActive;
@@ -72,9 +73,6 @@ const ExplorePageV1: FC<unknown> = () => {
   const { searchCriteria } = useApplicationStore();
 
   const [searchResults, setSearchResults] =
-    useState<SearchResponse<ExploreSearchIndex>>();
-
-  const [tourSearchResults, setTourSearchResults] =
     useState<SearchResponse<ExploreSearchIndex>>();
 
   const [showIndexNotFoundAlert, setShowIndexNotFoundAlert] =
@@ -308,19 +306,11 @@ const ExplorePageV1: FC<unknown> = () => {
   const getCached = useExploreCache((s) => s.getCached);
   const setCached = useExploreCache((s) => s.setCached);
 
-  // Effect for handling tour — lazy-load the ~113 KB mock dataset only when the tour is open.
   useEffect(() => {
-    if (isTourOpen) {
-      import('../../constants/mockTourData.constants').then(
-        ({ mockSearchData, MOCK_EXPLORE_PAGE_COUNT }) => {
-          setSearchHitCounts(MOCK_EXPLORE_PAGE_COUNT);
-          setTourSearchResults(
-            mockSearchData as unknown as SearchResponse<ExploreSearchIndex>
-          );
-        }
-      );
+    if (isTourOpen && tourMockSearchHitCounts) {
+      setSearchHitCounts(tourMockSearchHitCounts);
     }
-  }, [isTourOpen]);
+  }, [isTourOpen, tourMockSearchHitCounts]);
 
   // Create a dependency string to trigger fetch only when dependencies actually change. Also
   // doubles as the SWR cache key for {@link useExploreCache}.
@@ -548,7 +538,7 @@ const ExplorePageV1: FC<unknown> = () => {
       loading={isLoading && !isTourOpen}
       quickFilters={advancedSearchQuickFilters}
       searchIndex={searchIndex}
-      searchResults={isTourOpen ? tourSearchResults : searchResults}
+      searchResults={isTourOpen ? tourMockSearchResults : searchResults}
       showDeleted={showDeleted}
       sortOrder={sortOrder}
       sortValue={sortValue}

--- a/openmetadata-ui/src/main/resources/ui/src/pages/TableDetailsPageV1/TableDetailsPageV1.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/TableDetailsPageV1/TableDetailsPageV1.tsx
@@ -108,8 +108,12 @@ import { useTestCaseStore } from '../IncidentManager/IncidentManagerDetailPage/u
 import TableDetailsPageSkeleton from './TableDetailsPageSkeleton.component';
 
 const TableDetailsPageV1: React.FC = () => {
-  const { isTourOpen, activeTabForTourDatasetPage, isTourPage } =
-    useTourProvider();
+  const {
+    isTourOpen,
+    activeTabForTourDatasetPage,
+    isTourPage,
+    tourMockDatasetData,
+  } = useTourProvider();
   const { currentUser } = useApplicationStore();
   const { setDqLineageData } = useTestCaseStore();
   const queryClient = useQueryClient();
@@ -911,15 +915,10 @@ const TableDetailsPageV1: React.FC = () => {
 
   useEffect(() => {
     if (isTourOpen || isTourPage) {
-      // Seed the cache with the tour mock so the rest of the page reads through the same
-      // useQuery slot. The {@link useQuery} hook is {@code enabled: false} in tour mode, so
-      // this manual write is the only thing that populates the slot. The tour mock data is
-      // ~113 KB so we lazy-load it only when actually in tour mode.
-      import('../../constants/mockTourData.constants').then(
-        ({ mockDatasetData }) => {
-          setTableDetails(mockDatasetData.tableDetails as unknown as Table);
-        }
-      );
+      const mock = tourMockDatasetData as { tableDetails: unknown } | undefined;
+      if (mock?.tableDetails) {
+        setTableDetails(mock.tableDetails as Table);
+      }
     } else if (viewBasicPermission) {
       // Don't manually clear the cache to {@code undefined} here — that would flash a Loader
       // on every navigation between tables even when the destination is already cached.
@@ -928,7 +927,13 @@ const TableDetailsPageV1: React.FC = () => {
       fetchTaskCounts();
       fetchActivityCount();
     }
-  }, [tableFqn, isTourOpen, isTourPage, viewBasicPermission]);
+  }, [
+    tableFqn,
+    isTourOpen,
+    isTourPage,
+    viewBasicPermission,
+    tourMockDatasetData,
+  ]);
 
   // P1.2: getTestCaseFailureCount drives the global red-alert badge in the page chrome,
   // so it must run as soon as tableDetails resolves — deferring would mean the user could

--- a/openmetadata-ui/src/main/resources/ui/src/pages/TourPage/TourPage.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/TourPage/TourPage.component.tsx
@@ -119,8 +119,9 @@ const TourPage = () => {
     updateTourSearch('');
   }, [updateTourSearch]);
 
-  // Seed mock data synchronously so tour-aware pages read from provider
-  // instead of racing react-tour's stepWaitTimer with a dynamic import.
+  // Seed mock data on mount so tour-aware pages read it from the provider
+  // instead of each one fetching the chunk via a dynamic import that races
+  // react-tour's stepWaitTimer.
   useEffect(() => {
     updateTourMockData?.({
       searchResults:

--- a/openmetadata-ui/src/main/resources/ui/src/pages/TourPage/TourPage.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/TourPage/TourPage.component.tsx
@@ -14,9 +14,20 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import Tour from '../../components/AppTour/Tour';
+import {
+  ExploreSearchIndex,
+  SearchHitCounts,
+} from '../../components/Explore/ExplorePage.interface';
 import { TOUR_SEARCH_TERM } from '../../constants/constants';
+import {
+  mockDatasetData,
+  mockSearchData,
+  MOCK_EXPLORE_PAGE_COUNT,
+} from '../../constants/mockTourData.constants';
 import { useTourProvider } from '../../context/TourProvider/TourProvider';
+import { EntityTabs } from '../../enums/entity.enum';
 import { CurrentTourPageType } from '../../enums/tour.enum';
+import { SearchResponse } from '../../interface/search.interface';
 import { getTourSteps } from '../../utils/TourUtils';
 import ExplorePageV1Component from '../ExplorePage/ExplorePageV1.component';
 import MyDataPage from '../MyDataPage/MyDataPage.component';
@@ -99,6 +110,7 @@ const TourPage = () => {
     updateActiveTab,
     updateTourPage,
     updateTourSearch,
+    updateTourMockData,
   } = useTourProvider();
   const { t } = useTranslation();
   const [isTourReady, setIsTourReady] = useState(false);
@@ -106,6 +118,24 @@ const TourPage = () => {
   const clearSearchTerm = useCallback(() => {
     updateTourSearch('');
   }, [updateTourSearch]);
+
+  // Seed mock data synchronously so tour-aware pages read from provider
+  // instead of racing react-tour's stepWaitTimer with a dynamic import.
+  useEffect(() => {
+    updateTourMockData?.({
+      searchResults:
+        mockSearchData as unknown as SearchResponse<ExploreSearchIndex>,
+      searchHitCounts: MOCK_EXPLORE_PAGE_COUNT as SearchHitCounts,
+      datasetData: mockDatasetData,
+    });
+  }, [updateTourMockData]);
+
+  // Reset on /tour entry — react-tour's stepIndex resets on remount but
+  // TourProvider state persists across the SPA session; keep them in sync.
+  useEffect(() => {
+    updateTourPage(CurrentTourPageType.MY_DATA_PAGE);
+    updateActiveTab(EntityTabs.SCHEMA);
+  }, [updateTourPage, updateActiveTab]);
 
   useEffect(() => {
     let tourMountFrameId = 0;


### PR DESCRIPTION
Fixes #29043 

## Summary

The product tour at `/tour` was flaky in AUT runs and behaved unpredictably in the browser:

- Step transitions (3→4, 9→10, 10→11) sometimes failed because each tour-aware page (`ExplorePageV1`, `TableDetailsPageV1`, `SampleDataTable`, `TableProfilerProvider`, `LineageProvider`) lazy-imported `mockTourData.constants` on mount. The ~113 KB chunk fetch raced react-tour's `stepWaitTimer` (900 ms); on slow networks the next step's target wasn't in the DOM yet, so the badge never moved.
- An accidental mask click closed the overlay (`closeWithMask` defaults to `true` in `@deuex-solutions/react-tour`).
- Re-entering `/tour` after a prior session left `TourProvider` state on `DATASET_PAGE` / `PROFILER` tab while react-tour's internal `stepIndex` reset to 0 — badge 1 targeted MyData widgets that weren't rendered, looking like a broken reload.

## Changes

- `TourProvider`: expose \`tourMockSearchResults\`, \`tourMockSearchHitCounts\`, \`tourMockDatasetData\` + a single \`updateTourMockData\` setter.
- `TourPage`: static-import \`mockSearchData\`, \`MOCK_EXPLORE_PAGE_COUNT\`, \`mockDatasetData\` and seed the provider on mount. Mock data lives in the lazy \`/tour\` route chunk only — no regression for the regular Explore/Table routes. Also reset \`currentTourPage\` and \`activeTabForTourDatasetPage\` on mount.
- \`ExplorePageV1\`, \`TableDetailsPageV1\`, \`SampleDataTable\`, \`TableProfilerProvider\`, \`LineageProvider\`: drop their \`import('mockTourData.constants').then(...)\` paths and read synchronously from \`TourProvider\`.
- \`AppTour/Tour\`: pass \`closeWithMask={false}\` to react-tour.
