### PR TITLE
Fixes 29038: emit change events for task lifecycle transitions

### DIFF
--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/ContainerResourceIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/ContainerResourceIT.java
@@ -1979,26 +1979,39 @@ public class ContainerResourceIT extends BaseEntityIT<Container, CreateContainer
                 Relationship.CONTAINS.ordinal());
     assertEquals(1, rowsRemoved, "Setup: should have dropped exactly one CONTAINS row");
 
-    // Despite the missing relationship, /children of intermediate must surface the leaf
-    // because the listing is FQN-driven. This is the correctness payoff of moving off
-    // entity_relationship for hierarchy listings.
-    ContainerResultList page =
-        client
-            .getHttpClient()
-            .execute(
-                HttpMethod.GET,
-                "/v1/containers/name/" + intermediate.getFullyQualifiedName() + "/children",
-                null,
-                ContainerResultList.class);
-    assertNotNull(page);
-    assertNotNull(page.getData());
+    try {
+      // Despite the missing relationship, /children of intermediate must surface the leaf
+      // because the listing is FQN-driven. This is the correctness payoff of moving off
+      // entity_relationship for hierarchy listings.
+      ContainerResultList page =
+          client
+              .getHttpClient()
+              .execute(
+                  HttpMethod.GET,
+                  "/v1/containers/name/" + intermediate.getFullyQualifiedName() + "/children",
+                  null,
+                  ContainerResultList.class);
+      assertNotNull(page);
+      assertNotNull(page.getData());
 
-    Set<UUID> ids =
-        page.getData().stream().map(Container::getId).collect(java.util.stream.Collectors.toSet());
-    assertTrue(
-        ids.contains(leaf.getId()),
-        "Leaf must still appear in /children of its FQN-implied parent even though the "
-            + "(parent, CONTAINS, leaf) row was lost — FQN is the source of truth.");
+      Set<UUID> ids =
+          page.getData().stream()
+              .map(Container::getId)
+              .collect(java.util.stream.Collectors.toSet());
+      assertTrue(
+          ids.contains(leaf.getId()),
+          "Leaf must still appear in /children of its FQN-implied parent even though the "
+              + "(parent, CONTAINS, leaf) row was lost — FQN is the source of truth.");
+    } finally {
+      Entity.getCollectionDAO()
+          .relationshipDAO()
+          .insert(
+              intermediate.getId(),
+              leaf.getId(),
+              "container",
+              "container",
+              Relationship.CONTAINS.ordinal());
+    }
   }
 
   /**

--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/DashboardDataModelResourceIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/DashboardDataModelResourceIT.java
@@ -39,12 +39,14 @@ import org.openmetadata.schema.type.Column;
 import org.openmetadata.schema.type.ColumnDataType;
 import org.openmetadata.schema.type.DataModelType;
 import org.openmetadata.schema.type.EntityHistory;
+import org.openmetadata.schema.type.Relationship;
 import org.openmetadata.schema.type.TagLabel;
 import org.openmetadata.schema.type.api.BulkOperationResult;
 import org.openmetadata.sdk.client.OpenMetadataClient;
 import org.openmetadata.sdk.exceptions.OpenMetadataException;
 import org.openmetadata.sdk.models.ListParams;
 import org.openmetadata.sdk.models.ListResponse;
+import org.openmetadata.service.Entity;
 import org.openmetadata.service.resources.datamodels.DashboardDataModelResource;
 
 /**
@@ -770,6 +772,52 @@ public class DashboardDataModelResourceIT
       assertNotNull(column1.getTags(), "Column tags should be present");
       assertEquals(1, column1.getTags().size());
       assertEquals(columnTagLabel.getTagFQN(), column1.getTags().get(0).getTagFQN());
+    }
+  }
+
+  @Test
+  void test_listEntities_orphanWithMissingServiceRelationship_200(TestNamespace ns) {
+    DashboardService service = DashboardServiceTestFactory.createLooker(ns);
+    CreateDashboardDataModel request =
+        new CreateDashboardDataModel()
+            .withName(ns.prefix("dm_orphan_service"))
+            .withService(service.getFullyQualifiedName())
+            .withDataModelType(DataModelType.LookMlView)
+            .withColumns(List.of(new Column().withName("id").withDataType(ColumnDataType.INT)));
+
+    DashboardDataModel dataModel = createEntity(request);
+    int relation = Relationship.CONTAINS.ordinal();
+    int rowsRemoved =
+        Entity.getCollectionDAO()
+            .relationshipDAO()
+            .delete(
+                service.getId(),
+                Entity.DASHBOARD_SERVICE,
+                dataModel.getId(),
+                Entity.DASHBOARD_DATA_MODEL,
+                relation);
+    assertEquals(1, rowsRemoved, "Setup: should have dropped exactly one CONTAINS row");
+
+    try {
+      ListParams params = new ListParams();
+      params.setLimit(20);
+      params.setService(service.getFullyQualifiedName());
+
+      ListResponse<DashboardDataModel> list = listEntities(params);
+      assertNotNull(list);
+      assertNotNull(list.getData());
+      assertTrue(
+          list.getData().stream().anyMatch(dm -> dm.getId().equals(dataModel.getId())),
+          "Listing should still return the orphaned data model");
+    } finally {
+      Entity.getCollectionDAO()
+          .relationshipDAO()
+          .insert(
+              service.getId(),
+              dataModel.getId(),
+              Entity.DASHBOARD_SERVICE,
+              Entity.DASHBOARD_DATA_MODEL,
+              relation);
     }
   }
 

--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/IngestionPipelineResourceIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/IngestionPipelineResourceIT.java
@@ -50,12 +50,14 @@ import org.openmetadata.schema.metadataIngestion.dbtconfig.DbtS3Config;
 import org.openmetadata.schema.security.credentials.AWSCredentials;
 import org.openmetadata.schema.type.EntityHistory;
 import org.openmetadata.schema.type.ProviderType;
+import org.openmetadata.schema.type.Relationship;
 import org.openmetadata.schema.utils.JsonUtils;
 import org.openmetadata.sdk.client.OpenMetadataClient;
 import org.openmetadata.sdk.exceptions.OpenMetadataException;
 import org.openmetadata.sdk.models.ListParams;
 import org.openmetadata.sdk.models.ListResponse;
 import org.openmetadata.sdk.network.HttpMethod;
+import org.openmetadata.service.Entity;
 import org.openmetadata.service.resources.services.ingestionpipelines.IngestionPipelineResource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -253,6 +255,56 @@ public class IngestionPipelineResourceIT
     IngestionPipeline pipeline = createEntity(request);
     assertNotNull(pipeline);
     assertEquals(PipelineType.METADATA, pipeline.getPipelineType());
+  }
+
+  @Test
+  void test_listEntities_orphanWithMissingServiceRelationship_200(TestNamespace ns) {
+    DatabaseService service = DatabaseServiceTestFactory.createPostgres(ns);
+    DatabaseServiceMetadataPipeline metadataPipeline =
+        new DatabaseServiceMetadataPipeline().withMarkDeletedTables(true).withIncludeViews(true);
+
+    CreateIngestionPipeline request =
+        new CreateIngestionPipeline()
+            .withName(ns.prefix("ingestion_orphan_service"))
+            .withDescription("List should tolerate missing service relationship")
+            .withPipelineType(PipelineType.METADATA)
+            .withService(service.getEntityReference())
+            .withSourceConfig(new SourceConfig().withConfig(metadataPipeline))
+            .withAirflowConfig(new AirflowConfig().withStartDate(START_DATE));
+
+    IngestionPipeline pipeline = createEntity(request);
+    int relation = Relationship.CONTAINS.ordinal();
+    int rowsRemoved =
+        Entity.getCollectionDAO()
+            .relationshipDAO()
+            .delete(
+                service.getId(),
+                Entity.DATABASE_SERVICE,
+                pipeline.getId(),
+                Entity.INGESTION_PIPELINE,
+                relation);
+    assertEquals(1, rowsRemoved, "Setup: should have dropped exactly one CONTAINS row");
+
+    try {
+      ListParams params = new ListParams();
+      params.setLimit(1000);
+
+      ListResponse<IngestionPipeline> list = listEntities(params);
+      assertNotNull(list);
+      assertNotNull(list.getData());
+      assertTrue(
+          list.getData().stream().anyMatch(item -> item.getId().equals(pipeline.getId())),
+          "Listing should still return the orphaned ingestion pipeline");
+    } finally {
+      Entity.getCollectionDAO()
+          .relationshipDAO()
+          .insert(
+              service.getId(),
+              pipeline.getId(),
+              Entity.DATABASE_SERVICE,
+              Entity.INGESTION_PIPELINE,
+              relation);
+    }
   }
 
   @Test

--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/MlModelResourceIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/MlModelResourceIT.java
@@ -25,10 +25,12 @@ import org.openmetadata.schema.type.EntityHistory;
 import org.openmetadata.schema.type.MlFeature;
 import org.openmetadata.schema.type.MlFeatureDataType;
 import org.openmetadata.schema.type.MlHyperParameter;
+import org.openmetadata.schema.type.Relationship;
 import org.openmetadata.schema.type.api.BulkOperationResult;
 import org.openmetadata.sdk.client.OpenMetadataClient;
 import org.openmetadata.sdk.models.ListParams;
 import org.openmetadata.sdk.models.ListResponse;
+import org.openmetadata.service.Entity;
 
 /**
  * Integration tests for MlModel entity operations.
@@ -209,6 +211,42 @@ public class MlModelResourceIT extends BaseEntityIT<MlModel, CreateMlModel> {
     assertNotNull(mlModel);
     assertNotNull(mlModel.getMlFeatures());
     assertEquals(2, mlModel.getMlFeatures().size());
+  }
+
+  @Test
+  void test_listEntities_orphanWithMissingServiceRelationship_200(TestNamespace ns) {
+    MlModelService service = MlModelServiceTestFactory.createMlflow(ns);
+
+    CreateMlModel request = new CreateMlModel();
+    request.setName(ns.prefix("mlmodel_orphan_service"));
+    request.setService(service.getFullyQualifiedName());
+    request.setAlgorithm("Random Forest");
+
+    MlModel mlModel = createEntity(request);
+    int relation = Relationship.CONTAINS.ordinal();
+    int rowsRemoved =
+        Entity.getCollectionDAO()
+            .relationshipDAO()
+            .delete(
+                service.getId(), Entity.MLMODEL_SERVICE, mlModel.getId(), Entity.MLMODEL, relation);
+    assertEquals(1, rowsRemoved, "Setup: should have dropped exactly one CONTAINS row");
+
+    try {
+      ListParams params = new ListParams();
+      params.setLimit(1000);
+
+      ListResponse<MlModel> list = listEntities(params);
+      assertNotNull(list);
+      assertNotNull(list.getData());
+      assertTrue(
+          list.getData().stream().anyMatch(item -> item.getId().equals(mlModel.getId())),
+          "Listing should still return the orphaned ml model");
+    } finally {
+      Entity.getCollectionDAO()
+          .relationshipDAO()
+          .insert(
+              service.getId(), mlModel.getId(), Entity.MLMODEL_SERVICE, Entity.MLMODEL, relation);
+    }
   }
 
   @Test

--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/TaskResourceIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/TaskResourceIT.java
@@ -16,6 +16,7 @@ package org.openmetadata.it.tests;
 import static org.junit.jupiter.api.Assertions.*;
 
 import java.net.URI;
+import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.time.Duration;
@@ -92,6 +93,7 @@ import org.openmetadata.schema.type.DataAccessRequestPayload;
 import org.openmetadata.schema.type.DataAccessType;
 import org.openmetadata.schema.type.EntityHistory;
 import org.openmetadata.schema.type.EntityReference;
+import org.openmetadata.schema.type.EventType;
 import org.openmetadata.schema.type.Field;
 import org.openmetadata.schema.type.FieldDataType;
 import org.openmetadata.schema.type.Include;
@@ -122,6 +124,9 @@ import org.openmetadata.service.jdbi3.TaskRepository;
  */
 @Execution(ExecutionMode.CONCURRENT)
 public class TaskResourceIT extends BaseEntityIT<Task, CreateTask> {
+  private static final HttpClient HTTP_CLIENT = HttpClient.newHttpClient();
+  private static final String CHANGE_HEADER = "X-OpenMetadata-Change";
+  private static final String API_PREFIX = "/api";
 
   private static String entityLink(String entityType, String entityFqn) {
     return String.format("<#E::%s::%s>", entityType, entityFqn);
@@ -3821,7 +3826,7 @@ public class TaskResourceIT extends BaseEntityIT<Task, CreateTask> {
         sendDirectJson("POST", String.format("/v1/tasks/%s/resolve", task.getId()), body);
 
     assertEquals(200, response.statusCode());
-    assertChangeHeader(response, "taskResolved");
+    assertChangeHeader(response, EventType.TASK_RESOLVED.value());
   }
 
   @Test
@@ -3842,7 +3847,7 @@ public class TaskResourceIT extends BaseEntityIT<Task, CreateTask> {
             "");
 
     assertEquals(200, response.statusCode());
-    assertChangeHeader(response, "taskClosed");
+    assertChangeHeader(response, EventType.TASK_CLOSED.value());
   }
 
   @Test
@@ -3880,7 +3885,7 @@ public class TaskResourceIT extends BaseEntityIT<Task, CreateTask> {
         sendDirectJson("PUT", String.format("/v1/tasks/%s/suggestion/apply", task.getId()), "");
 
     assertEquals(200, response.statusCode());
-    assertChangeHeader(response, "taskResolved");
+    assertChangeHeader(response, EventType.TASK_RESOLVED.value());
   }
 
   @Test
@@ -4180,7 +4185,7 @@ public class TaskResourceIT extends BaseEntityIT<Task, CreateTask> {
 
   private static HttpResponse<String> sendDirectJson(String method, String path, String body)
       throws Exception {
-    String url = SdkClients.getServerUrl() + "/api" + path;
+    String url = SdkClients.getServerUrl() + normalizeApiPath(path);
     HttpRequest.Builder builder =
         HttpRequest.newBuilder()
             .uri(URI.create(url))
@@ -4192,13 +4197,19 @@ public class TaskResourceIT extends BaseEntityIT<Task, CreateTask> {
             ? HttpRequest.BodyPublishers.noBody()
             : HttpRequest.BodyPublishers.ofString(body);
     HttpRequest request = builder.method(method, publisher).build();
-    return java.net.http.HttpClient.newHttpClient()
-        .send(request, HttpResponse.BodyHandlers.ofString());
+    return HTTP_CLIENT.send(request, HttpResponse.BodyHandlers.ofString());
   }
 
-  private static void assertChangeHeader(HttpResponse<String> response, String expectedHeaderValue) {
-    assertEquals(
-        expectedHeaderValue, response.headers().firstValue("X-OpenMetadata-Change").orElse(null));
+  private static String normalizeApiPath(String path) {
+    String normalizedPath = path.startsWith("/") ? path : "/" + path;
+    return normalizedPath.startsWith(API_PREFIX + "/")
+        ? normalizedPath
+        : API_PREFIX + normalizedPath;
+  }
+
+  private static void assertChangeHeader(
+      HttpResponse<String> response, String expectedHeaderValue) {
+    assertEquals(expectedHeaderValue, response.headers().firstValue(CHANGE_HEADER).orElse(null));
   }
 
   private void awaitSuggestionTaskDeleted(UUID creatorId, String aboutEntity, UUID taskId) {

--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/TaskResourceIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/TaskResourceIT.java
@@ -126,7 +126,6 @@ import org.openmetadata.service.jdbi3.TaskRepository;
 public class TaskResourceIT extends BaseEntityIT<Task, CreateTask> {
   private static final HttpClient HTTP_CLIENT = HttpClient.newHttpClient();
   private static final String CHANGE_HEADER = "X-OpenMetadata-Change";
-  private static final String API_PREFIX = "/api";
 
   private static String entityLink(String entityType, String entityFqn) {
     return String.format("<#E::%s::%s>", entityType, entityFqn);
@@ -3807,12 +3806,26 @@ public class TaskResourceIT extends BaseEntityIT<Task, CreateTask> {
 
   @Test
   void testResolveTaskEmitsTaskResolvedChangeEventHeader(TestNamespace ns) throws Exception {
+    DatabaseService service = DatabaseServiceTestFactory.createPostgres(ns);
+    DatabaseSchema schema = DatabaseSchemaTestFactory.createSimple(ns, service);
+    Table table = TableTestFactory.createSimple(ns, schema.getFullyQualifiedName());
+    String newDescription = "emit-change-event " + ns.shortPrefix();
+
+    org.openmetadata.schema.type.DescriptionUpdatePayload payload =
+        new org.openmetadata.schema.type.DescriptionUpdatePayload()
+            .withFieldPath("description")
+            .withCurrentDescription(table.getDescription())
+            .withNewDescription(newDescription);
+
     Task task =
         createEntity(
             new CreateTask()
                 .withName(ns.prefix("resolve-emits-event"))
-                .withCategory(TaskCategory.Approval)
-                .withType(TaskEntityType.GlossaryApproval));
+                .withDescription("Resolve endpoint should emit change event")
+                .withCategory(TaskCategory.MetadataUpdate)
+                .withType(TaskEntityType.DescriptionUpdate)
+                .withAbout(entityLink("table", table.getFullyQualifiedName()))
+                .withPayload(payload));
 
     awaitTaskReadyForWorkflowResolution(task.getId());
 
@@ -3820,6 +3833,7 @@ public class TaskResourceIT extends BaseEntityIT<Task, CreateTask> {
         JsonUtils.pojoToJson(
             new ResolveTask()
                 .withResolutionType(TaskResolutionType.Approved)
+                .withNewValue(newDescription)
                 .withComment("emit-change-event"));
 
     HttpResponse<String> response =
@@ -3835,10 +3849,9 @@ public class TaskResourceIT extends BaseEntityIT<Task, CreateTask> {
         createEntity(
             new CreateTask()
                 .withName(ns.prefix("close-emits-event"))
+                .withDescription("Close endpoint should emit change event")
                 .withCategory(TaskCategory.Approval)
                 .withType(TaskEntityType.GlossaryApproval));
-
-    awaitTaskReadyForWorkflowResolution(task.getId());
 
     HttpResponse<String> response =
         sendDirectJson(
@@ -4185,7 +4198,7 @@ public class TaskResourceIT extends BaseEntityIT<Task, CreateTask> {
 
   private static HttpResponse<String> sendDirectJson(String method, String path, String body)
       throws Exception {
-    String url = SdkClients.getServerUrl() + normalizeApiPath(path);
+    String url = SdkClients.getServerUrl() + normalizePath(path);
     HttpRequest.Builder builder =
         HttpRequest.newBuilder()
             .uri(URI.create(url))
@@ -4200,11 +4213,8 @@ public class TaskResourceIT extends BaseEntityIT<Task, CreateTask> {
     return HTTP_CLIENT.send(request, HttpResponse.BodyHandlers.ofString());
   }
 
-  private static String normalizeApiPath(String path) {
-    String normalizedPath = path.startsWith("/") ? path : "/" + path;
-    return normalizedPath.startsWith(API_PREFIX + "/")
-        ? normalizedPath
-        : API_PREFIX + normalizedPath;
+  private static String normalizePath(String path) {
+    return path.startsWith("/") ? path : "/" + path;
   }
 
   private static void assertChangeHeader(

--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/TaskResourceIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/TaskResourceIT.java
@@ -15,6 +15,9 @@ package org.openmetadata.it.tests;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import java.net.URI;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
 import java.time.Duration;
 import java.util.Arrays;
 import java.util.List;
@@ -3798,6 +3801,89 @@ public class TaskResourceIT extends BaseEntityIT<Task, CreateTask> {
       TaskFormSchema originalSchema, String createdSchemaId) {}
 
   @Test
+  void testResolveTaskEmitsTaskResolvedChangeEventHeader(TestNamespace ns) throws Exception {
+    Task task =
+        createEntity(
+            new CreateTask()
+                .withName(ns.prefix("resolve-emits-event"))
+                .withCategory(TaskCategory.Approval)
+                .withType(TaskEntityType.GlossaryApproval));
+
+    awaitTaskReadyForWorkflowResolution(task.getId());
+
+    String body =
+        JsonUtils.pojoToJson(
+            new ResolveTask()
+                .withResolutionType(TaskResolutionType.Approved)
+                .withComment("emit-change-event"));
+
+    HttpResponse<String> response =
+        sendDirectJson("POST", String.format("/v1/tasks/%s/resolve", task.getId()), body);
+
+    assertEquals(200, response.statusCode());
+    assertChangeHeader(response, "taskResolved");
+  }
+
+  @Test
+  void testCloseTaskEmitsTaskClosedChangeEventHeader(TestNamespace ns) throws Exception {
+    Task task =
+        createEntity(
+            new CreateTask()
+                .withName(ns.prefix("close-emits-event"))
+                .withCategory(TaskCategory.Approval)
+                .withType(TaskEntityType.GlossaryApproval));
+
+    awaitTaskReadyForWorkflowResolution(task.getId());
+
+    HttpResponse<String> response =
+        sendDirectJson(
+            "POST",
+            String.format("/v1/tasks/%s/close?comment=emit-change-event", task.getId()),
+            "");
+
+    assertEquals(200, response.statusCode());
+    assertChangeHeader(response, "taskClosed");
+  }
+
+  @Test
+  void testApplySuggestionEmitsTaskResolvedChangeEventHeader(TestNamespace ns) throws Exception {
+    DatabaseService service = DatabaseServiceTestFactory.createPostgres(ns);
+    DatabaseSchema schema = DatabaseSchemaTestFactory.createSimple(ns, service);
+    Table table = TableTestFactory.createSimple(ns, schema.getFullyQualifiedName());
+
+    Map<String, Object> rawSuggestionPayload =
+        Map.of(
+            "suggestionType", "Description",
+            "fieldPath", "description",
+            "suggestedValue", "Suggested description from header assertion",
+            "source", "Agent",
+            "confidence", 85.0);
+
+    Task task =
+        SdkClients.adminClient()
+            .getHttpClient()
+            .execute(
+                HttpMethod.POST,
+                "/v1/tasks",
+                Map.of(
+                    "name", ns.prefix("apply-suggestion-event"),
+                    "description", "Apply suggestion endpoint should emit change event",
+                    "category", TaskCategory.MetadataUpdate.value(),
+                    "type", TaskEntityType.Suggestion.value(),
+                    "about", entityLink("table", table.getFullyQualifiedName()),
+                    "payload", rawSuggestionPayload),
+                Task.class);
+
+    awaitTaskReadyForWorkflowResolution(task.getId());
+
+    HttpResponse<String> response =
+        sendDirectJson("PUT", String.format("/v1/tasks/%s/suggestion/apply", task.getId()), "");
+
+    assertEquals(200, response.statusCode());
+    assertChangeHeader(response, "taskResolved");
+  }
+
+  @Test
   void testApplySuggestionEndpointUsesSuggestionSpecificSchemaResolution(TestNamespace ns) {
     DatabaseService service = DatabaseServiceTestFactory.createPostgres(ns);
     DatabaseSchema schema = DatabaseSchemaTestFactory.createSimple(ns, service);
@@ -4090,6 +4176,29 @@ public class TaskResourceIT extends BaseEntityIT<Task, CreateTask> {
                     .withBotUser(botUser.getName()));
 
     return new BotWithUser(bot, botUser);
+  }
+
+  private static HttpResponse<String> sendDirectJson(String method, String path, String body)
+      throws Exception {
+    String url = SdkClients.getServerUrl() + "/api" + path;
+    HttpRequest.Builder builder =
+        HttpRequest.newBuilder()
+            .uri(URI.create(url))
+            .header("Authorization", "Bearer " + SdkClients.getAdminToken())
+            .header("Content-Type", "application/json")
+            .timeout(Duration.ofSeconds(30));
+    HttpRequest.BodyPublisher publisher =
+        body == null || body.isEmpty()
+            ? HttpRequest.BodyPublishers.noBody()
+            : HttpRequest.BodyPublishers.ofString(body);
+    HttpRequest request = builder.method(method, publisher).build();
+    return java.net.http.HttpClient.newHttpClient()
+        .send(request, HttpResponse.BodyHandlers.ofString());
+  }
+
+  private static void assertChangeHeader(HttpResponse<String> response, String expectedHeaderValue) {
+    assertEquals(
+        expectedHeaderValue, response.headers().firstValue("X-OpenMetadata-Change").orElse(null));
   }
 
   private void awaitSuggestionTaskDeleted(UUID creatorId, String aboutEntity, UUID taskId) {

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/ContainerRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/ContainerRepository.java
@@ -56,6 +56,7 @@ import org.openmetadata.service.cache.AncestorsCache;
 import org.openmetadata.service.cache.CacheBundle;
 import org.openmetadata.service.cache.ChildrenPageCache;
 import org.openmetadata.service.exception.CatalogExceptionMessage;
+import org.openmetadata.service.exception.EntityNotFoundException;
 import org.openmetadata.service.jdbi3.FeedRepository.TaskWorkflow;
 import org.openmetadata.service.jdbi3.FeedRepository.ThreadContext;
 import org.openmetadata.service.monitoring.RequestLatencyContext;
@@ -276,13 +277,26 @@ public class ContainerRepository extends EntityRepository<Container> {
       }
       UUID containerId = UUID.fromString(record.getToId());
       UUID serviceId = UUID.fromString(record.getFromId());
-      EntityReference serviceRef =
-          serviceRefById.computeIfAbsent(
-              serviceId, id -> getEntityReferenceById(STORAGE_SERVICE, id, NON_DELETED));
-      serviceMap.put(containerId, serviceRef);
+      EntityReference serviceRef = serviceRefById.get(serviceId);
+      if (serviceRef == null && !serviceRefById.containsKey(serviceId)) {
+        serviceRef = resolveStorageServiceRef(serviceId);
+        serviceRefById.put(serviceId, serviceRef);
+      }
+      if (serviceRef != null) {
+        serviceMap.put(containerId, serviceRef);
+      }
     }
 
     return serviceMap;
+  }
+
+  private EntityReference resolveStorageServiceRef(UUID serviceId) {
+    try {
+      return getEntityReferenceById(STORAGE_SERVICE, serviceId, NON_DELETED);
+    } catch (EntityNotFoundException e) {
+      LOG.info("Skipping deleted storage service reference {}", serviceId);
+      return null;
+    }
   }
 
   @Override
@@ -358,7 +372,7 @@ public class ContainerRepository extends EntityRepository<Container> {
 
   private void setDefaultFields(Container container) {
     EntityReference parentServiceRef =
-        getFromEntityRef(container.getId(), Relationship.CONTAINS, STORAGE_SERVICE, true);
+        getFromEntityRef(container.getId(), Relationship.CONTAINS, STORAGE_SERVICE, false);
     container.withService(parentServiceRef);
   }
 

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/DashboardDataModelRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/DashboardDataModelRepository.java
@@ -15,6 +15,7 @@ package org.openmetadata.service.jdbi3;
 
 import static org.openmetadata.schema.type.Include.ALL;
 import static org.openmetadata.service.Entity.DASHBOARD_DATA_MODEL;
+import static org.openmetadata.service.Entity.DASHBOARD_SERVICE;
 import static org.openmetadata.service.Entity.FIELD_TAGS;
 import static org.openmetadata.service.Entity.populateEntityFieldTags;
 import static org.openmetadata.service.resources.tags.TagLabelUtil.addDerivedTagsGracefully;
@@ -226,7 +227,9 @@ public class DashboardDataModelRepository extends EntityRepository<DashboardData
   }
 
   private void setDefaultFields(DashboardDataModel dashboardDataModel) {
-    EntityReference service = getContainer(dashboardDataModel.getId());
+    EntityReference service =
+        getFromEntityRef(
+            dashboardDataModel.getId(), Relationship.CONTAINS, DASHBOARD_SERVICE, false);
     dashboardDataModel.withService(service);
   }
 

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/IngestionPipelineRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/IngestionPipelineRepository.java
@@ -130,9 +130,11 @@ public class IngestionPipelineRepository extends EntityRepository<IngestionPipel
   @Override
   public void setFullyQualifiedName(IngestionPipeline ingestionPipeline) {
     if (ingestionPipeline.getService() == null) {
-      // Service might not be set when listing with minimal fields
-      EntityReference service = getContainer(ingestionPipeline.getId());
-      ingestionPipeline.withService(service);
+      ingestionPipeline.withService(
+          getFromEntityRef(ingestionPipeline.getId(), Relationship.CONTAINS, null, false));
+    }
+    if (ingestionPipeline.getService() == null) {
+      return;
     }
     ingestionPipeline.setFullyQualifiedName(
         FullyQualifiedName.add(
@@ -143,7 +145,8 @@ public class IngestionPipelineRepository extends EntityRepository<IngestionPipel
   public void setFields(
       IngestionPipeline ingestionPipeline, Fields fields, RelationIncludes relationIncludes) {
     if (ingestionPipeline.getService() == null) {
-      ingestionPipeline.withService(getContainer(ingestionPipeline.getId()));
+      ingestionPipeline.withService(
+          getFromEntityRef(ingestionPipeline.getId(), Relationship.CONTAINS, null, false));
     }
     ingestionPipeline.setPipelineStatuses(
         fields.contains("pipelineStatuses")
@@ -213,18 +216,10 @@ public class IngestionPipelineRepository extends EntityRepository<IngestionPipel
       if (serviceRef != null) {
         pipeline.withService(serviceRef);
       } else {
-        LOG.warn(
-            "Service not found in batch fetch for pipeline: {} (id: {}). Fetching individually.",
-            pipeline.getName(),
-            pipeline.getId());
-        EntityReference service = getContainer(pipeline.getId());
+        EntityReference service =
+            getFromEntityRef(pipeline.getId(), Relationship.CONTAINS, null, false);
         if (service != null) {
           pipeline.withService(service);
-        } else {
-          LOG.error(
-              "No service found for ingestion pipeline: {} (id: {})",
-              pipeline.getName(),
-              pipeline.getId());
         }
       }
     }
@@ -267,26 +262,7 @@ public class IngestionPipelineRepository extends EntityRepository<IngestionPipel
   }
 
   private Map<UUID, EntityReference> batchFetchServices(List<IngestionPipeline> pipelines) {
-    Map<UUID, EntityReference> serviceMap = new HashMap<>();
-    if (pipelines == null || pipelines.isEmpty()) {
-      return serviceMap;
-    }
-
-    // Single batch query to get all services for all pipelines
-    List<CollectionDAO.EntityRelationshipObject> records =
-        daoCollection
-            .relationshipDAO()
-            .findFromBatch(entityListToStrings(pipelines), Relationship.CONTAINS.ordinal());
-
-    for (CollectionDAO.EntityRelationshipObject record : records) {
-      UUID pipelineId = UUID.fromString(record.getToId());
-      EntityReference serviceRef =
-          Entity.getEntityReferenceById(
-              record.getFromEntity(), UUID.fromString(record.getFromId()), Include.NON_DELETED);
-      serviceMap.put(pipelineId, serviceRef);
-    }
-
-    return serviceMap;
+    return batchFetchContainers(pipelines, null, Include.NON_DELETED);
   }
 
   @Override
@@ -544,17 +520,13 @@ public class IngestionPipelineRepository extends EntityRepository<IngestionPipel
           "Service not set for ingestion pipeline: {} (id: {}). Loading it now.",
           entity.getName(),
           entity.getId());
-      EntityReference service = getContainer(entity.getId());
+      EntityReference service =
+          getFromEntityRef(entity.getId(), Relationship.CONTAINS, null, false);
       if (service != null) {
         entity.withService(service);
         return Entity.getEntity(service, fields, Include.ALL);
-      } else {
-        LOG.error(
-            "No service found for ingestion pipeline: {} (id: {})",
-            entity.getName(),
-            entity.getId());
-        return null;
       }
+      return null;
     }
     return Entity.getEntity(entity.getService(), fields, Include.ALL);
   }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/MlModelRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/MlModelRepository.java
@@ -49,7 +49,6 @@ import org.openmetadata.schema.type.change.ChangeSource;
 import org.openmetadata.schema.utils.JsonUtils;
 import org.openmetadata.service.Entity;
 import org.openmetadata.service.exception.CatalogExceptionMessage;
-import org.openmetadata.service.exception.EntityNotFoundException;
 import org.openmetadata.service.jdbi3.FeedRepository.TaskWorkflow;
 import org.openmetadata.service.jdbi3.FeedRepository.ThreadContext;
 import org.openmetadata.service.resources.feeds.MessageParser.EntityLink;
@@ -97,6 +96,13 @@ public class MlModelRepository extends EntityRepository<MlModel> {
 
   @Override
   public void setFullyQualifiedName(MlModel mlModel) {
+    if (mlModel.getService() == null) {
+      mlModel.setService(
+          getFromEntityRef(mlModel.getId(), Relationship.CONTAINS, Entity.MLMODEL_SERVICE, false));
+    }
+    if (mlModel.getService() == null) {
+      return;
+    }
     mlModel.setFullyQualifiedName(
         FullyQualifiedName.add(mlModel.getService().getFullyQualifiedName(), mlModel.getName()));
     if (!nullOrEmpty(mlModel.getMlFeatures())) {
@@ -106,7 +112,10 @@ public class MlModelRepository extends EntityRepository<MlModel> {
 
   @Override
   public void setFields(MlModel mlModel, Fields fields, RelationIncludes relationIncludes) {
-    mlModel.setService(getContainer(mlModel.getId()));
+    if (mlModel.getService() == null) {
+      mlModel.setService(
+          getFromEntityRef(mlModel.getId(), Relationship.CONTAINS, Entity.MLMODEL_SERVICE, false));
+    }
     mlModel.setDashboard(
         fields.contains("dashboard") ? getDashboard(mlModel) : mlModel.getDashboard());
     if (mlModel.getUsageSummary() == null) {
@@ -186,39 +195,7 @@ public class MlModelRepository extends EntityRepository<MlModel> {
   }
 
   private Map<UUID, EntityReference> batchFetchServices(List<MlModel> mlModels) {
-    Map<UUID, EntityReference> serviceMap = new HashMap<>();
-    if (mlModels == null || mlModels.isEmpty()) {
-      return serviceMap;
-    }
-
-    // Single batch query to get all services for all ML models
-    List<CollectionDAO.EntityRelationshipObject> records =
-        daoCollection
-            .relationshipDAO()
-            .findFromBatch(entityListToStrings(mlModels), Relationship.CONTAINS.ordinal());
-
-    for (CollectionDAO.EntityRelationshipObject record : records) {
-      UUID mlModelId = UUID.fromString(record.getToId());
-      EntityReference serviceRef = resolveServiceRefLeniently(UUID.fromString(record.getFromId()));
-      if (serviceRef != null) {
-        serviceMap.put(mlModelId, serviceRef);
-      }
-    }
-
-    return serviceMap;
-  }
-
-  private EntityReference resolveServiceRefLeniently(UUID serviceId) {
-    EntityReference serviceRef = null;
-    try {
-      serviceRef = Entity.getEntityReferenceById(Entity.MLMODEL_SERVICE, serviceId, NON_DELETED);
-    } catch (EntityNotFoundException e) {
-      // The parent service can be hard-deleted concurrently (e.g. a sibling test's cascade delete)
-      // between the relationship lookup above and this resolution. The ml model row is mid-cascade
-      // and about to be removed, so tolerate the missing service rather than failing the read.
-      LOG.debug("MlModel service {} not found (concurrent delete); skipping", serviceId);
-    }
-    return serviceRef;
+    return batchFetchContainers(mlModels, Entity.MLMODEL_SERVICE, NON_DELETED);
   }
 
   @Override

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/tasks/TaskResource.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/tasks/TaskResource.java
@@ -14,7 +14,10 @@
 package org.openmetadata.service.resources.tasks;
 
 import static org.openmetadata.common.utils.CommonUtil.nullOrEmpty;
+import static org.openmetadata.schema.type.EventType.TASK_CLOSED;
+import static org.openmetadata.schema.type.EventType.TASK_RESOLVED;
 import static org.openmetadata.service.security.DefaultAuthorizer.getSubjectContext;
+import static org.openmetadata.service.util.RestUtil.CHANGE_CUSTOM_HEADER;
 
 import io.swagger.v3.oas.annotations.ExternalDocumentation;
 import io.swagger.v3.oas.annotations.Operation;
@@ -1103,7 +1106,7 @@ public class TaskResource extends EntityResource<Task, TaskRepository> {
             resolvedPayload,
             comment,
             userName);
-    return Response.ok(resolvedTask).build();
+    return Response.ok(resolvedTask).header(CHANGE_CUSTOM_HEADER, TASK_RESOLVED.value()).build();
   }
 
   private ListFilter buildTaskListFilter(
@@ -1276,7 +1279,7 @@ public class TaskResource extends EntityResource<Task, TaskRepository> {
     repository.checkPermissionsForResolveTask(authorizer, task, true, securityContext);
 
     Task closedTask = repository.closeTask(task, userName, comment);
-    return Response.ok(closedTask).build();
+    return Response.ok(closedTask).header(CHANGE_CUSTOM_HEADER, TASK_CLOSED.value()).build();
   }
 
   @DELETE
@@ -1367,7 +1370,7 @@ public class TaskResource extends EntityResource<Task, TaskRepository> {
             null,
             null,
             userName);
-    return Response.ok(resolvedTask).build();
+    return Response.ok(resolvedTask).header(CHANGE_CUSTOM_HEADER, TASK_RESOLVED.value()).build();
   }
 
   // ========================= Bulk Operations Endpoint =========================


### PR DESCRIPTION
### Describe your changes:

Fixes #29038

Set `X-OpenMetadata-Change` on the first-class task lifecycle endpoints so `ChangeEventHandler` emits `taskResolved` / `taskClosed` for resolve, close, and applySuggestion.

Added backend integration assertions for the lifecycle endpoints to verify the expected response header is present on `/resolve`, `/close`, and `/suggestion/apply`.

#
### Type of change:
- [x] Bug fix

#
### High-level design:

N/A - small change.

#
### Tests:

#### Use cases covered
- Resolving a task returns `X-OpenMetadata-Change=taskResolved`
- Closing a task returns `X-OpenMetadata-Change=taskClosed`
- Applying a suggestion returns `X-OpenMetadata-Change=taskResolved`

#### Unit tests
- Not applicable.

#### Backend integration tests
- [x] I added integration tests in `openmetadata-integration-tests/` for the changed task lifecycle endpoints.
- Files updated:
  - `openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/TaskResourceIT.java`

#### Ingestion integration tests
- [x] Not applicable (no ingestion changes).

#### Playwright (UI) tests
- [x] Not applicable (no UI changes).

#### Manual testing performed
1. Ran `git diff --check`.
2. Ran `mvn -pl openmetadata-integration-tests -am -DskipTests test-compile` with JDK 21 on Windows.
3. The Maven compile currently fails in unrelated Elasticsearch/OpenSearch classes under `openmetadata-service/src/main/java/org/openmetadata/service/search/...` before reaching the changed task files, so full local integration verification was deferred to CI.

#
### UI screen recording / screenshots:

Not applicable.

#
### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] My PR title is `Fixes <issue-number>: <short explanation>`
- [x] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.
- [ ] For UI changes: I attached a screen recording and/or screenshots above.
- [x] I have added tests (unit / integration / Playwright as applicable) and listed them above.

- [x] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.

----
## Summary by Gitar

- **Task Lifecycle:**
  - Emit `X-OpenMetadata-Change` headers with `TASK_RESOLVED` or `TASK_CLOSED` values on task transition endpoints.
  - Added backend integration tests to verify header emission for task resolve, close, and suggestion application.
- **Robustness improvements:**
  - Updated `ContainerRepository` and `DashboardDataModelRepository` to tolerate orphaned relationship lookups during entity listing.
  - Added integration tests to verify that entities remain visible even if their parent service relationship is missing in the database.

<sub>This will update automatically on new commits.</sub>

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR emits change events for task lifecycle transitions and improves orphaned-entity listing. The main changes are:

- Adds task-resolved and task-closed response headers to lifecycle endpoints.
- Adds integration coverage for resolve, close, and apply-suggestion headers.
- Makes several repositories tolerate missing parent-service relationships.
- Adds integration coverage for listing orphaned entities.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge.

- The task creation schema permits a GlossaryApproval task without `about`.
- The bodyless requests target endpoints that do not declare request-body parameters.
- No blocking issue remains in the changed lifecycle paths.

</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-service/src/main/java/org/openmetadata/service/resources/tasks/TaskResource.java | Adds change-event headers to successful resolve, close, and apply-suggestion responses. |
| openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/TaskResourceIT.java | Adds direct HTTP assertions for task lifecycle response headers. |
| openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/ContainerRepository.java | Makes storage-service resolution tolerant of missing parent references. |
| openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/DashboardDataModelRepository.java | Uses optional service relationship resolution for orphaned data models. |
| openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/IngestionPipelineRepository.java | Makes service and fully qualified name population tolerate missing relationships. |
| openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/MlModelRepository.java | Makes service and fully qualified name population tolerate missing relationships. |

</details>

<sub>Reviews (3): Last reviewed commit: ["Handle orphaned service relations in lis..."](https://github.com/open-metadata/openmetadata/commit/506568801566e0e70890a5c0e35061a0153481c5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37814135)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Context used - CLAUDE.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=52f0d9d9-cad1-4e7d-b070-de181a0aa5e7))
- Context used - openmetadata-ui-core-components/CLAUDE.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=41754627-b2bf-474b-8082-f37ef1a07013))
- Context used - AGENTS.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=ef262f5f-911f-44f3-8d2d-e9cb1579c8c8))
</details>

<!-- /greptile_comment -->