### PR TITLE
fix(ci): close remaining label-triggered CI rerun gaps from #28737

### DIFF
--- a/.github/workflows/openmetadata-service-unit-tests.yml
+++ b/.github/workflows/openmetadata-service-unit-tests.yml
@@ -27,7 +27,7 @@ permissions:
 
 concurrency:
   group: openmetadata-service-unit-tests-${{ github.head_ref || github.run_id }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name != 'pull_request' || github.event.action != 'labeled' || github.event.label.name == 'safe to test' }}
 
 jobs:
   # Detect whether relevant paths changed. When no Java service files
@@ -37,7 +37,7 @@ jobs:
   changes:
     name: Detect Changes
     runs-on: ubuntu-latest
-    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
+    if: ${{ (github.event_name != 'pull_request' || !github.event.pull_request.draft) && (github.event_name != 'pull_request' || github.event.action != 'labeled' || github.event.label.name == 'safe to test') }}
     outputs:
       java: ${{ github.event_name == 'workflow_dispatch' && 'true' || steps.filter.outputs.java }}
       k8s_operator: ${{ github.event_name == 'workflow_dispatch' && 'true' || steps.filter.outputs.k8s_operator }}

--- a/.github/workflows/playwright-postgresql-e2e.yml
+++ b/.github/workflows/playwright-postgresql-e2e.yml
@@ -260,7 +260,7 @@ jobs:
           sudo rm -rf ${PWD}/docker-volume
 
   playwright-summary:
-    if: ${{ !cancelled() && github.event_name == 'pull_request_target' }}
+    if: ${{ !cancelled() && github.event_name == 'pull_request_target' && (github.event.action != 'labeled' || github.event.label.name == 'safe to test') }}
     needs: playwright-ci-postgresql
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/playwright-sso-tests.yml
+++ b/.github/workflows/playwright-sso-tests.yml
@@ -225,7 +225,7 @@ jobs:
           sudo rm -rf ${PWD}/docker-volume
 
   sso-summary:
-    if: ${{ !cancelled() && github.event_name == 'pull_request_target' }}
+    if: ${{ !cancelled() && github.event_name == 'pull_request_target' && (github.event.action != 'labeled' || github.event.label.name == 'safe to test') }}
     needs: sso-auth-tests
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/validate-jsons-yamls.yml
+++ b/.github/workflows/validate-jsons-yamls.yml
@@ -28,6 +28,7 @@ permissions:
 jobs:
   validate-json-yaml:
     runs-on: ubuntu-latest
+    if: ${{ github.event_name != 'pull_request_target' || github.event.action != 'labeled' || github.event.label.name == 'safe to test' }}
     permissions:
       pull-requests: write
     steps:


### PR DESCRIPTION
## Problem

#28737 was supposed to stop an unrelated label (e.g. `to release`, `skip-pr-checks`) from cancelling and rerunning PR CI. It gated the gateway job `if` and `cancel-in-progress` on `safe to test`, but **only for the 19 `pull_request_target` workflows** — so adding an unrelated label still triggered work in four cases.

Reproduced on #29034: `skip-pr-checks` was added at `12:25:19Z`; six seconds later most workflows correctly skipped, but inspecting the job-level results shows two still ran:

- **`OpenMetadata Service Unit Tests`** → `Detect Changes` job ran (checkout + paths-filter).
- **`Postgresql PR Playwright E2E Tests`** → `playwright-summary` job ran.

## Root cause (per file)

| Workflow | Gap |
|---|---|
| `openmetadata-service-unit-tests.yml` | Triggers on `pull_request` (not `pull_request_target`), so it was never in #28737's scope. `cancel-in-progress` was **unconditionally `true`** — a label cancels an in-flight unit-test build and restarts it — and the `changes` detect job had no label gate. |
| `validate-jsons-yamls.yml` | Never touched by #28737; its only job had no label gate, so any label reran full validation (when json/yaml paths match). |
| `playwright-postgresql-e2e.yml` → `playwright-summary` | `if: !cancelled() && github.event_name == 'pull_request_target'` is true for `labeled` events. A **skipped `needs:` job does not block a job whose `if` omits `needs.*.result`**, so the summary fired even though `build` correctly skipped. |
| `playwright-sso-tests.yml` → `sso-summary` | Same condition, same leak. |

Already-safe patterns (left untouched): `ui-checkstyle`'s `report` guards on `needs.authorize.result == 'success'`; the `*-status` jobs use `failure() || cancelled()`; `py-combine-coverage` checks `needs.changes.outputs.python`.

## Fix

Apply the same label-gate clause used in #28737, each with the event name matching that workflow's trigger:

- **`openmetadata-service-unit-tests.yml`** — `cancel-in-progress` expression-gated on the `pull_request` event + `safe to test`; `changes` job `if` gains the label gate (existing draft check preserved).
- **`validate-jsons-yamls.yml`** — label gate added to `validate-json-yaml`.
- **`playwright-postgresql-e2e.yml`** / **`playwright-sso-tests.yml`** — appended `&& (github.event.action != 'labeled' || github.event.label.name == 'safe to test')` to the summary jobs.

## Behavior after

- `safe to test` → CI runs (cancel-on-new-push still works) — unchanged.
- `to release` / `skip-pr-checks` / any other label → no cancel, no rerun, no summary repost.
- `push` / `merge_group` / `synchronize` / `workflow_dispatch` — unaffected.

All four files validated as parseable YAML.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Closes four remaining label-triggered CI rerun gaps missed by #28737 by applying the `safe to test` label gate to the `pull_request`-triggered unit-test workflow, the JSON/YAML validator, and the two Playwright summary jobs.

- **`openmetadata-service-unit-tests.yml`**: `cancel-in-progress` is now expression-gated so an unrelated label no longer cancels an in-flight test run; the `changes` job gains the same label gate (draft check preserved), and downstream jobs already guard on `needs.changes.outputs.*` so they correctly become no-ops for non-`safe to test` labels.
- **`validate-jsons-yamls.yml`**: Single `validate-json-yaml` job gains the label gate; `merge_group` events short-circuit safely through the `event_name != 'pull_request_target'` clause.
- **`playwright-postgresql-e2e.yml` / `playwright-sso-tests.yml`**: Label gate appended to the `playwright-summary` / `sso-summary` `if` conditions, preventing the summary job from firing when a skipped `needs:` job did not block it under the prior condition.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

All four changes are minimal, surgical, and consistent with the existing label-gate pattern from #28737.

Each fix correctly applies the label-gate guard that matches how other workflows in the repo already handle this case. The cancel-in-progress expression in the unit-test workflow returns true for all non-label events and false only for unrelated labels. Downstream jobs already gate on needs.changes.outputs.* outputs so they silently skip when changes is skipped. The merge_group trigger in validate-jsons-yamls.yml short-circuits through the event_name != pull_request_target clause and remains unaffected.

No files require special attention; all four changes are straightforward one-line additions.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/openmetadata-service-unit-tests.yml | Added label gate to cancel-in-progress and changes job if; downstream jobs already guard on needs.changes.outputs.* so they correctly skip when changes is skipped; status job only fires on failure/cancellation and is unaffected. |
| .github/workflows/validate-jsons-yamls.yml | Label gate added to the single validate-json-yaml job; merge_group events pass the gate correctly because github.event_name != pull_request_target short-circuits to true. |
| .github/workflows/playwright-postgresql-e2e.yml | Label gate appended to playwright-summary if; synchronize/opened/reopened events still pass (action != labeled is true), and safe to test label still passes; workflow_dispatch behavior unchanged. |
| .github/workflows/playwright-sso-tests.yml | Identical label-gate fix applied to sso-summary as in playwright-postgresql-e2e.yml; logic is consistent and correct. |

</details>

</details>

<details open><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Label event fires on PR] --> B{Label is safe to test?}
    B -->|Yes| C[cancel-in-progress = true, all jobs run normally]
    B -->|No| D[cancel-in-progress = false, in-flight run NOT cancelled]
    D --> E[New run starts, all jobs skip]
    E --> F1[openmetadata-service-unit-tests: changes skips]
    E --> F2[validate-jsons-yamls: validate-json-yaml skips]
    E --> F3[playwright-postgresql-e2e: playwright-summary skips]
    E --> F4[playwright-sso-tests: sso-summary skips]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Label event fires on PR] --> B{Label is safe to test?}
    B -->|Yes| C[cancel-in-progress = true, all jobs run normally]
    B -->|No| D[cancel-in-progress = false, in-flight run NOT cancelled]
    D --> E[New run starts, all jobs skip]
    E --> F1[openmetadata-service-unit-tests: changes skips]
    E --> F2[validate-jsons-yamls: validate-json-yaml skips]
    E --> F3[playwright-postgresql-e2e: playwright-summary skips]
    E --> F4[playwright-sso-tests: sso-summary skips]
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(ci): close remaining label-triggered..."](https://github.com/open-metadata/openmetadata/commit/df98f4688dc912fbface9ac23f542f91f89cd212) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37826554)</sub>

<!-- /greptile_comment -->