### PR TITLE
feat(ui): update DataQuality & IncidentManager components for lazy-load utility pattern

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/ActivityFeed/ActivityFeedCardV2/FeedCardBody/TestCaseFeed/TestCaseFeed.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/ActivityFeed/ActivityFeedCardV2/FeedCardBody/TestCaseFeed/TestCaseFeed.tsx
@@ -21,11 +21,9 @@ import {
   EntityTestResultSummaryObject,
   TestCaseStatus,
 } from '../../../../../generated/entity/feed/thread';
-import {
-  formatTestStatusData,
-  getTestCaseResultCount,
-} from '../../../../../utils/FeedUtils';
+import { formatTestStatusData } from '../../../../../utils/FeedUtils';
 import { translateWithNestedKeys } from '../../../../../utils/i18next/LocalUtil';
+import { getTestCaseResultCount } from '../../../../../utils/TestCaseUtils';
 import TestSummaryGraph from '../../../../Database/Profiler/TestSummary/TestSummaryGraph';
 import './test-case-feed.less';
 import { TestCaseFeedProps } from './TestCaseFeed.interface';

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/AddDataQualityTest/EditTestCaseModal.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/AddDataQualityTest/EditTestCaseModal.tsx
@@ -37,14 +37,12 @@ import {
   getTestDefinitionById,
   updateTestCaseById,
 } from '../../../rest/testAPI';
-import { createUpdatedTestCasePatch } from '../../../utils/DataQuality/DataQualityUtils';
+import { createUpdatedTestCasePatch } from '../../../utils/DataQuality/DataQualityPureUtils';
 import { getEntityName } from '../../../utils/EntityNameUtils';
 import { getColumnNameFromEntityLink } from '../../../utils/EntityPureUtils';
-import { getEntityFQN } from '../../../utils/FeedUtils';
-import {
-  generateFormFields,
-  getPopupContainer,
-} from '../../../utils/formUtils';
+import { getEntityFQN } from '../../../utils/FeedUtilsPure';
+import { getPopupContainer } from '../../../utils/formPureUtils';
+import { generateFormFields } from '../../../utils/formUtils';
 import { getNameFromFQN } from '../../../utils/FqnUtils';
 import { isValidJSONString } from '../../../utils/StringUtils';
 import { getTagsWithoutTier, getTierTags } from '../../../utils/TablePureUtils';
@@ -54,7 +52,6 @@ import { EntityAttachmentProvider } from '../../common/EntityDescription/EntityA
 import Loader from '../../common/Loader/Loader';
 import { EditTestCaseModalProps } from './AddDataQualityTest.interface';
 import ParameterForm from './components/ParameterForm';
-
 const EditTestCaseModal: React.FC<EditTestCaseModalProps> = ({
   visible,
   testCase,

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/AddDataQualityTest/TestSuiteIngestion.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/AddDataQualityTest/TestSuiteIngestion.tsx
@@ -40,11 +40,11 @@ import {
   deployIngestionPipelineById,
   updateIngestionPipeline,
 } from '../../../rest/ingestionPipelineAPI';
+import { getScheduleOptionsFromSchedules } from '../../../utils/CronExpressionUtils';
 import { getEntityName } from '../../../utils/EntityNameUtils';
 import { getNameFromFQN } from '../../../utils/FqnUtils';
 import { Transi18next } from '../../../utils/i18next/LocalUtil';
-import { getScheduleOptionsFromSchedules } from '../../../utils/SchedularUtils';
-import { getIngestionName } from '../../../utils/ServiceUtils';
+import { getIngestionName } from '../../../utils/ServicePureUtils';
 import {
   generateUUID,
   replaceAllSpacialCharWith_,

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/AddDataQualityTest/components/EditTestCaseModalV1.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/AddDataQualityTest/components/EditTestCaseModalV1.tsx
@@ -57,15 +57,15 @@ import {
   getTestDefinitionById,
   updateTestCaseById,
 } from '../../../../rest/testAPI';
-import { createUpdatedTestCasePatch } from '../../../../utils/DataQuality/DataQualityUtils';
+import { createUpdatedTestCasePatch } from '../../../../utils/DataQuality/DataQualityPureUtils';
 import { getEntityName } from '../../../../utils/EntityNameUtils';
 import { getColumnNameFromEntityLink } from '../../../../utils/EntityPureUtils';
-import { getEntityFQN } from '../../../../utils/FeedUtils';
+import { getEntityFQN } from '../../../../utils/FeedUtilsPure';
 import {
   createScrollToErrorHandler,
-  generateFormFields,
   getPopupContainer,
-} from '../../../../utils/formUtils';
+} from '../../../../utils/formPureUtils';
+import { generateFormFields } from '../../../../utils/formUtils';
 import { getNameFromFQN } from '../../../../utils/FqnUtils';
 import { isValidJSONString } from '../../../../utils/StringUtils';
 import {
@@ -80,7 +80,6 @@ import Loader from '../../../common/Loader/Loader';
 import ServiceDocPanel from '../../../common/ServiceDocPanel/ServiceDocPanel';
 import { EditTestCaseModalProps } from './EditTestCaseModal.interface';
 import ParameterForm from './ParameterForm';
-
 // =============================================
 // MAIN COMPONENT
 // =============================================

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/AddDataQualityTest/components/ParameterForm.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/AddDataQualityTest/components/ParameterForm.tsx
@@ -55,7 +55,7 @@ import {
 } from '../../../../interface/search.interface';
 import { searchQuery } from '../../../../rest/searchAPI';
 import { getEntityName } from '../../../../utils/EntityNameUtils';
-import { getPopupContainer } from '../../../../utils/formUtils';
+import { getPopupContainer } from '../../../../utils/formPureUtils';
 import {
   getSelectedColumnsSet,
   validateEquals,
@@ -66,7 +66,6 @@ import {
 import withSuspenseFallback from '../../../AppRouter/withSuspenseFallback';
 import '../../../Database/Profiler/TableProfiler/table-profiler.less';
 import { ParameterFormProps } from '../AddDataQualityTest.interface';
-
 const CodeEditor = withSuspenseFallback(
   lazy(() => import('../../../Database/SchemaEditor/CodeEditor'))
 );

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/AddDataQualityTest/components/TestCaseFormV1.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/AddDataQualityTest/components/TestCaseFormV1.tsx
@@ -96,20 +96,20 @@ import {
   getListTestCaseBySearch,
   getListTestDefinitions,
 } from '../../../../rest/testAPI';
+import { getScheduleOptionsFromSchedules } from '../../../../utils/CronExpressionUtils';
 import {
   convertSearchSourceToTable,
   getServiceTypeForTestDefinition,
-} from '../../../../utils/DataQuality/DataQualityUtils';
+} from '../../../../utils/DataQuality/DataQualityPureUtils';
 import { getEntityName } from '../../../../utils/EntityNameUtils';
 import { filterSelectOptions } from '../../../../utils/FilterQueryUtils';
 import {
   createScrollToErrorHandler,
-  generateFormFields,
   getPopupContainer,
-} from '../../../../utils/formUtils';
+} from '../../../../utils/formPureUtils';
+import { generateFormFields } from '../../../../utils/formUtils';
 import { Transi18next } from '../../../../utils/i18next/LocalUtil';
-import { getScheduleOptionsFromSchedules } from '../../../../utils/SchedularUtils';
-import { getIngestionName } from '../../../../utils/ServiceUtils';
+import { getIngestionName } from '../../../../utils/ServicePureUtils';
 import {
   escapeESReservedCharacters,
   generateUUID,
@@ -133,7 +133,6 @@ import {
   TestLevel,
 } from './TestCaseFormV1.interface';
 import './TestCaseFormV1.less';
-
 // =============================================
 // MAIN COMPONENT
 // =============================================

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/AddTestCaseList/AddTestCaseList.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/AddTestCaseList/AddTestCaseList.component.tsx
@@ -54,10 +54,10 @@ import {
   getColumnNameFromColumnFilterKey,
   getSelectedOptionsFromKeys,
   parseColumnAggregateBuckets,
-} from '../../../utils/DataQuality/DataQualityUtils';
+} from '../../../utils/DataQuality/DataQualityPureUtils';
 import { getEntityName } from '../../../utils/EntityNameUtils';
 import { getColumnNameFromEntityLink } from '../../../utils/EntityPureUtils';
-import { getEntityFQN } from '../../../utils/FeedUtils';
+import { getEntityFQN } from '../../../utils/FeedUtilsPure';
 import { getNameFromFQN } from '../../../utils/FqnUtils';
 import { getEntityDetailsPath } from '../../../utils/RouterUtils';
 import { replacePlus } from '../../../utils/StringUtils';

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/AddToBundleSuiteModal/AddToBundleSuiteModal.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/AddToBundleSuiteModal/AddToBundleSuiteModal.component.tsx
@@ -32,11 +32,10 @@ import {
   getListTestSuitesBySearch,
 } from '../../../rest/testAPI';
 import { getEntityName } from '../../../utils/EntityNameUtils';
-import { getPopupContainer } from '../../../utils/formUtils';
+import { getPopupContainer } from '../../../utils/formPureUtils';
 import observabilityRouterClassBase from '../../../utils/ObservabilityRouterClassBase';
 import { showErrorToast, showSuccessToast } from '../../../utils/ToastUtils';
 import { AddToBundleSuiteModalProps } from './AddToBundleSuiteModal.interface';
-
 const AddToBundleSuiteModal: React.FC<AddToBundleSuiteModalProps> = ({
   open,
   selectedTestCases,

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/BundleSuiteForm/BundleSuiteForm.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/BundleSuiteForm/BundleSuiteForm.tsx
@@ -54,14 +54,12 @@ import {
   addTestCasesToLogicalTestSuiteBulk,
   createTestSuites,
 } from '../../../rest/testAPI';
+import { getScheduleOptionsFromSchedules } from '../../../utils/CronExpressionUtils';
 import { getEntityName } from '../../../utils/EntityNameUtils';
-import {
-  createScrollToErrorHandler,
-  generateFormFields,
-} from '../../../utils/formUtils';
+import { createScrollToErrorHandler } from '../../../utils/formPureUtils';
+import { generateFormFields } from '../../../utils/formUtils';
 import { getNameFromFQN } from '../../../utils/FqnUtils';
-import { getScheduleOptionsFromSchedules } from '../../../utils/SchedularUtils';
-import { getIngestionName } from '../../../utils/ServiceUtils';
+import { getIngestionName } from '../../../utils/ServicePureUtils';
 import {
   generateUUID,
   replaceAllSpacialCharWith_,
@@ -76,7 +74,6 @@ import {
   BundleSuiteFormData,
   BundleSuiteFormProps,
 } from './BundleSuiteForm.interface';
-
 // =============================================
 // MAIN COMPONENT
 // =============================================

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/ChartWidgets/EntityHealthStatusPieChartWidget/EntityHealthStatusPieChartWidget.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/ChartWidgets/EntityHealthStatusPieChartWidget/EntityHealthStatusPieChartWidget.component.tsx
@@ -18,16 +18,13 @@ import { ReactComponent as HealthCheckIcon } from '../../../../assets/svg/ic-gre
 import { GREEN_3, RED_3 } from '../../../../constants/Color.constants';
 import { INITIAL_ENTITY_HEALTH_MATRIX } from '../../../../constants/profiler.constant';
 import { fetchEntityCoveredWithDQ } from '../../../../rest/dataQualityDashboardAPI';
-import {
-  getPieChartLabel,
-  getTestCaseTabPath,
-} from '../../../../utils/DataQuality/DataQualityUtils';
+import { getTestCaseTabPath } from '../../../../utils/DataQuality/DataQualityPureUtils';
+import { getPieChartLabel } from '../../../../utils/DataQuality/DataQualityUtils';
 import type { CustomPieChartData } from '../../../Visualisations/Chart/Chart.interface';
 import CustomPieChart from '../../../Visualisations/Chart/CustomPieChart.component';
 import { PieChartWidgetCommonProps } from '../../DataQuality.interface';
 import '../chart-widgets.less';
 import { BINARY_STATUS_PIE_SEGMENT_ORDER } from '../ChartWidgets.constants';
-
 const EntityHealthStatusPieChartWidget = ({
   className = '',
   chartFilter,

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/ChartWidgets/EntityHealthStatusPieChartWidget/EntityHealthStatusPieChartWidget.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/ChartWidgets/EntityHealthStatusPieChartWidget/EntityHealthStatusPieChartWidget.test.tsx
@@ -34,6 +34,9 @@ jest.mock('../../../../rest/dataQualityDashboardAPI', () => ({
 
 jest.mock('../../../../utils/DataQuality/DataQualityUtils', () => ({
   getPieChartLabel: jest.fn().mockReturnValue(<div>Test Label</div>),
+}));
+
+jest.mock('../../../../utils/DataQuality/DataQualityPureUtils', () => ({
   getTestCaseTabPath: jest.fn((status: TestCaseStatus) => ({
     pathname: '/data-quality/test-cases',
     search: `testCaseStatus=${status}`,
@@ -108,7 +111,7 @@ describe('EntityHealthStatusPieChartWidget', () => {
 
   it('should pass onSegmentClick to CustomPieChart and navigate on segment click', async () => {
     const { getTestCaseTabPath } = jest.requireMock(
-      '../../../../utils/DataQuality/DataQualityUtils'
+      '../../../../utils/DataQuality/DataQualityPureUtils'
     ) as { getTestCaseTabPath: jest.Mock };
     const mockNavigate = (
       jest.requireMock('react-router-dom') as {

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/ChartWidgets/StatusByDimensionCardWidget/StatusByDimensionCardWidget.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/ChartWidgets/StatusByDimensionCardWidget/StatusByDimensionCardWidget.component.tsx
@@ -25,12 +25,11 @@ import {
 import {
   getDimensionIcon,
   transformToTestCaseStatusByDimension,
-} from '../../../../utils/DataQuality/DataQualityUtils';
+} from '../../../../utils/DataQuality/DataQualityPureUtils';
 import observabilityRouterClassBase from '../../../../utils/ObservabilityRouterClassBase';
 import { PieChartWidgetCommonProps } from '../../DataQuality.interface';
 import StatusByDimensionWidget from '../StatusCardWidget/StatusCardWidget.component';
 import './status-by-dimension-card-widget.less';
-
 const StatusByDimensionCardWidget = ({
   chartFilter,
 }: PieChartWidgetCommonProps) => {

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/ChartWidgets/TestCaseStatusPieChartWidget/TestCaseStatusPieChartWidget.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/ChartWidgets/TestCaseStatusPieChartWidget/TestCaseStatusPieChartWidget.component.tsx
@@ -23,16 +23,15 @@ import {
 import { INITIAL_TEST_SUMMARY } from '../../../../constants/TestSuite.constant';
 import { fetchTestCaseSummary } from '../../../../rest/dataQualityDashboardAPI';
 import {
-  getPieChartLabel,
   getTestCaseTabPath,
   transformToTestCaseStatusObject,
-} from '../../../../utils/DataQuality/DataQualityUtils';
+} from '../../../../utils/DataQuality/DataQualityPureUtils';
+import { getPieChartLabel } from '../../../../utils/DataQuality/DataQualityUtils';
 import type { CustomPieChartData } from '../../../Visualisations/Chart/Chart.interface';
 import CustomPieChart from '../../../Visualisations/Chart/CustomPieChart.component';
 import { PieChartWidgetCommonProps } from '../../DataQuality.interface';
 import '../chart-widgets.less';
 import { TEST_CASE_STATUS_PIE_SEGMENT_ORDER } from '../ChartWidgets.constants';
-
 const TestCaseStatusPieChartWidget = ({
   className = '',
   chartFilter,

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/ChartWidgets/TestCaseStatusPieChartWidget/TestCaseStatusPieChartWidget.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/ChartWidgets/TestCaseStatusPieChartWidget/TestCaseStatusPieChartWidget.test.tsx
@@ -37,6 +37,9 @@ jest.mock('../../../../utils/DataQuality/DataQualityUtils', () => ({
     total: 8,
   }),
   getPieChartLabel: jest.fn().mockReturnValue(<div>Test Label</div>),
+}));
+
+jest.mock('../../../../utils/DataQuality/DataQualityPureUtils', () => ({
   getTestCaseTabPath: jest.fn((status: TestCaseStatus) => ({
     pathname: '/data-quality/test-cases',
     search: `testCaseStatus=${status}`,
@@ -136,7 +139,7 @@ describe('TestCaseStatusPieChartWidget', () => {
 
   it('should pass onSegmentClick to CustomPieChart and navigate on segment click', async () => {
     const { getTestCaseTabPath } = jest.requireMock(
-      '../../../../utils/DataQuality/DataQualityUtils'
+      '../../../../utils/DataQuality/DataQualityPureUtils'
     ) as { getTestCaseTabPath: jest.Mock };
     const mockNavigate = (
       jest.requireMock('react-router-dom') as {

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/DataQualityDashboard/DataQualityDashboard.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/DataQualityDashboard/DataQualityDashboard.component.tsx
@@ -46,7 +46,7 @@ import { TestCaseResolutionStatusTypes } from '../../../generated/tests/testCase
 import { EntityReference } from '../../../generated/type/entityReference';
 import { DataQualityPageTabs } from '../../../pages/DataQuality/DataQualityPage.interface';
 import { searchQuery } from '../../../rest/searchAPI';
-import { getSelectedOptionLabelString } from '../../../utils/AdvancedSearchUtils';
+import { getSelectedOptionLabelString } from '../../../utils/AdvancedSearchPureUtils';
 import {
   formatDate,
   getCurrentMillis,
@@ -66,7 +66,6 @@ import TestCaseStatusPieChartWidget from '../ChartWidgets/TestCaseStatusPieChart
 import { IncidentTimeMetricsType } from '../DataQuality.interface';
 import './data-quality-dashboard.style.less';
 import { DqDashboardChartFilters } from './DataQualityDashboard.interface';
-
 const DataQualityDashboard = ({
   initialFilters,
   hideFilterBar = false,

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/IncidentManager/DimensionalityTab/DimensionalityTab.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/IncidentManager/DimensionalityTab/DimensionalityTab.tsx
@@ -30,7 +30,7 @@ import {
   getEndOfDayInMillis,
   getStartOfDayInMillis,
 } from '../../../../utils/date-time/DateTimeUtils';
-import { getEntityFQN } from '../../../../utils/FeedUtils';
+import { getEntityFQN } from '../../../../utils/FeedUtilsPure';
 import {
   getEntityDetailsPath,
   getTestCaseDimensionsDetailPagePath,
@@ -44,7 +44,6 @@ import { StatusType } from '../../../common/StatusBadge/StatusBadge.interface';
 import { ProfilerTabPath } from '../../../Database/Profiler/ProfilerDashboard/profilerDashboard.interface';
 import DimensionalityHeatmap from './DimensionalityHeatmap/DimensionalityHeatmap.component';
 import { DimensionResultWithTimestamp } from './DimensionalityHeatmap/DimensionalityHeatmap.interface';
-
 const DimensionalityTab = () => {
   const { t } = useTranslation();
   const { dimensionKey } = useRequiredParams<{ dimensionKey?: string }>();

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/IncidentManager/IncidentManagerPageHeader/IncidentManagerPageHeader.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/IncidentManager/IncidentManagerPageHeader/IncidentManagerPageHeader.component.tsx
@@ -41,8 +41,8 @@ import {
 } from '../../../../rest/incidentManagerAPI';
 import { getEntityName } from '../../../../utils/EntityNameUtils';
 import { getColumnNameFromEntityLink } from '../../../../utils/EntityPureUtils';
-import { getCommonExtraInfoForVersionDetails } from '../../../../utils/EntityVersionUtils';
-import { getEntityFQN } from '../../../../utils/FeedUtils';
+import { getCommonExtraInfoForVersionDetails } from '../../../../utils/EntityVersionUtilsPure';
+import { getEntityFQN } from '../../../../utils/FeedUtilsPure';
 import { getNameFromFQN } from '../../../../utils/FqnUtils';
 import { getPrioritizedEditPermission } from '../../../../utils/PermissionsUtils';
 import { getEntityDetailsPath } from '../../../../utils/RouterUtils';
@@ -57,7 +57,6 @@ import Severity from '../Severity/Severity.component';
 import TestCaseIncidentManagerStatus from '../TestCaseStatus/TestCaseIncidentManagerStatus.component';
 import './incident-manager.less';
 import { IncidentManagerPageHeaderProps } from './IncidentManagerPageHeader.interface';
-
 const IncidentManagerPageHeader = ({
   onOwnerUpdate,
   fetchTaskCount,

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/IncidentManager/SqlQueryTab/SqlQueryTab.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/IncidentManager/SqlQueryTab/SqlQueryTab.component.tsx
@@ -23,15 +23,14 @@ import { useTestCaseStore } from '../../../../pages/IncidentManager/IncidentMana
 import {
   getChangedEntityNewValue,
   getChangedEntityOldValue,
-  getChangedEntityStatus,
   getDiffByFieldName,
-  getDiffDisplayValue,
-} from '../../../../utils/EntityVersionUtils';
+} from '../../../../utils/EntityDiffPureUtils';
+import { getDiffDisplayValue } from '../../../../utils/EntityDiffUtils';
+import { getChangedEntityStatus } from '../../../../utils/EntityVersionUtilsPure';
 import Loader from '../../../common/Loader/Loader';
 import QueryViewer from '../../../common/QueryViewer/QueryViewer.component';
 import '../TestCaseResultTab/test-case-result-tab.style.less';
 import AddSqlQueryFormModal from './AddSqlQueryFormModal/AddSqlQueryFormModal.component';
-
 const SqlQueryTab = () => {
   const { testCase, isLoading } = useTestCaseStore();
   const { version } = useParams<{ version: string }>();

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/IncidentManager/TestCaseIncidentTab/TestCaseIncidentTab.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/IncidentManager/TestCaseIncidentTab/TestCaseIncidentTab.component.tsx
@@ -32,10 +32,11 @@ import { useTestCaseStore } from '../../../../pages/IncidentManager/IncidentMana
 import { getTaskCounts, Task } from '../../../../rest/tasksAPI';
 import TaskListV1 from '../../../ActivityFeed/ActivityFeedList/TaskListV1.component';
 import { useActivityFeedProvider } from '../../../ActivityFeed/ActivityFeedProvider/ActivityFeedProvider';
-import { TaskFilter } from '../../../ActivityFeed/ActivityFeedTab/ActivityFeedTab.interface';
 import withSuspenseFallback from '../../../AppRouter/withSuspenseFallback';
 import Loader from '../../../common/Loader/Loader';
 import './test-case-incident-tab.style.less';
+
+type TaskFilter = 'open' | 'close';
 
 const TaskTabNew = withSuspenseFallback(
   lazy(() =>

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/IncidentManager/TestCaseResultTab/TestCaseResultTab.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/IncidentManager/TestCaseResultTab/TestCaseResultTab.component.tsx
@@ -44,17 +44,19 @@ import {
 } from '../../../../rest/testAPI';
 import {
   getComputeRowCountDiffDisplay,
-  getEntityVersionByField,
-  getEntityVersionTags,
   getParameterValueDiffDisplay,
 } from '../../../../utils/EntityVersionUtils';
 import { VersionEntityTypes } from '../../../../utils/EntityVersionUtils.interface';
+import {
+  getEntityVersionByField,
+  getEntityVersionTags,
+} from '../../../../utils/EntityVersionUtilsPure';
 import { getPrioritizedEditPermission } from '../../../../utils/PermissionsUtils';
 import {
   getTagsWithoutTier,
   getTierTags,
 } from '../../../../utils/TablePureUtils';
-import { createTagObject } from '../../../../utils/TagsUtils';
+import { createTagObject } from '../../../../utils/TagsPureUtils';
 import { showErrorToast, showSuccessToast } from '../../../../utils/ToastUtils';
 import withSuspenseFallback from '../../../AppRouter/withSuspenseFallback';
 import DescriptionV1 from '../../../common/EntityDescription/DescriptionV1';
@@ -66,7 +68,6 @@ import EditTestCaseModal from '../../AddDataQualityTest/EditTestCaseModal';
 import '../incident-manager.style.less';
 import './test-case-result-tab.style.less';
 import testCaseResultTabClassBase from './TestCaseResultTabClassBase';
-
 const SchemaEditor = withSuspenseFallback(
   lazy(() => import('../../../Database/SchemaEditor/SchemaEditor'))
 );

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/TestCases/TestCases.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/TestCases/TestCases.component.tsx
@@ -65,9 +65,9 @@ import {
   getListTestCaseBySearch,
   ListTestCaseParamsBySearch,
 } from '../../../rest/testAPI';
-import { getTestCaseFiltersValue } from '../../../utils/DataQuality/DataQualityUtils';
+import { getTestCaseFiltersValue } from '../../../utils/DataQuality/DataQualityPureUtils';
 import { getEntityName } from '../../../utils/EntityNameUtils';
-import { getPopupContainer } from '../../../utils/formUtils';
+import { getPopupContainer } from '../../../utils/formPureUtils';
 import observabilityRouterClassBase from '../../../utils/ObservabilityRouterClassBase';
 import {
   checkPermission,

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/TestSuite/TestSuiteList/TestSuites.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/TestSuite/TestSuiteList/TestSuites.component.tsx
@@ -52,7 +52,7 @@ import {
   ListTestSuitePramsBySearch,
 } from '../../../../rest/testAPI';
 import { getEntityName } from '../../../../utils/EntityNameUtils';
-import { getPopupContainer } from '../../../../utils/formUtils';
+import { getPopupContainer } from '../../../../utils/formPureUtils';
 import observabilityRouterClassBase from '../../../../utils/ObservabilityRouterClassBase';
 import { getPrioritizedViewPermission } from '../../../../utils/PermissionsUtils';
 import { getEntityDetailsPath } from '../../../../utils/RouterUtils';

--- a/openmetadata-ui/src/main/resources/ui/src/components/Database/ColumnDetailPanel/ColumnDetailPanel.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Database/ColumnDetailPanel/ColumnDetailPanel.component.tsx
@@ -35,7 +35,7 @@ import { TagLabel, TagSource } from '../../../generated/type/tagLabel';
 import { getTypeByFQN } from '../../../rest/metadataTypeAPI';
 import { getColumnByFQN, updateTableColumn } from '../../../rest/tableAPI';
 import { listTestCases } from '../../../rest/testAPI';
-import { calculateTestCaseStatusCounts } from '../../../utils/DataQuality/DataQualityUtils';
+import { calculateTestCaseStatusCounts } from '../../../utils/DataQuality/DataQualityPureUtils';
 import EntityLink from '../../../utils/EntityLink';
 import { getEntityName } from '../../../utils/EntityNameUtils';
 import { toEntityData } from '../../../utils/EntitySummaryPanelUtils';

--- a/openmetadata-ui/src/main/resources/ui/src/components/Database/Profiler/TableProfiler/TableProfiler.interface.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Database/Profiler/TableProfiler/TableProfiler.interface.ts
@@ -24,7 +24,7 @@ import {
 import { TestCase } from '../../../../generated/tests/testCase';
 import { UsePagingInterface } from '../../../../hooks/paging/usePaging';
 import { ListTestCaseParamsBySearch } from '../../../../rest/testAPI';
-import { TestCaseCountByStatus } from '../../../../utils/DataQuality/DataQualityUtils';
+import { TestCaseCountByStatus } from '../../../../utils/DataQuality/DataQualityPureUtils';
 import { TestLevel } from '../../../DataQuality/AddDataQualityTest/components/TestCaseFormV1.interface';
 
 export interface TableProfilerProps {

--- a/openmetadata-ui/src/main/resources/ui/src/components/Database/Profiler/TableProfiler/TableProfilerProvider.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Database/Profiler/TableProfiler/TableProfilerProvider.tsx
@@ -50,7 +50,7 @@ import {
 import {
   aggregateTestResultsByEntity,
   TestCaseCountByStatus,
-} from '../../../../utils/DataQuality/DataQualityUtils';
+} from '../../../../utils/DataQuality/DataQualityPureUtils';
 import { formatNumberWithComma } from '../../../../utils/NumberUtils';
 import { bytesToSize } from '../../../../utils/StringUtils';
 import { generateEntityLink } from '../../../../utils/TablePureUtils';

--- a/openmetadata-ui/src/main/resources/ui/src/components/TestLibrary/TestDefinitionForm/TestDefinitionForm.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/TestLibrary/TestDefinitionForm/TestDefinitionForm.component.tsx
@@ -44,13 +44,12 @@ import {
   patchTestDefinition,
 } from '../../../rest/testAPI';
 import { handleSearchFilterOption } from '../../../utils/FilterQueryUtils';
-import { createScrollToErrorHandler } from '../../../utils/formUtils';
+import { createScrollToErrorHandler } from '../../../utils/formPureUtils';
 import { isExternalTestDefinition } from '../../../utils/TestDefinitionUtils';
 import { showSuccessToast } from '../../../utils/ToastUtils';
 import AlertBar from '../../AlertBar/AlertBar';
 import withSuspenseFallback from '../../AppRouter/withSuspenseFallback';
 import FormItemLabel from '../../common/Form/FormItemLabel';
-
 const CodeEditor = withSuspenseFallback(
   lazy(() => import('../../Database/SchemaEditor/CodeEditor'))
 );

--- a/openmetadata-ui/src/main/resources/ui/src/components/TestLibrary/TestDefinitionForm/TestDefinitionForm.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/TestLibrary/TestDefinitionForm/TestDefinitionForm.test.tsx
@@ -110,6 +110,7 @@ describe('TestDefinitionForm Component', () => {
     jest.clearAllMocks();
     (createTestDefinition as jest.Mock).mockResolvedValue({});
     (patchTestDefinition as jest.Mock).mockResolvedValue({});
+    window.HTMLElement.prototype.scrollIntoView = jest.fn();
   });
 
   describe('Rendering', () => {

--- a/openmetadata-ui/src/main/resources/ui/src/pages/DataQuality/DataQualityProvider.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/DataQuality/DataQualityProvider.tsx
@@ -25,7 +25,7 @@ import {
   fetchTestCaseSummary,
   fetchTotalEntityCount,
 } from '../../rest/dataQualityDashboardAPI';
-import { transformToTestCaseStatusObject } from '../../utils/DataQuality/DataQualityUtils';
+import { transformToTestCaseStatusObject } from '../../utils/DataQuality/DataQualityPureUtils';
 import { getPrioritizedViewPermission } from '../../utils/PermissionsUtils';
 import { showErrorToast } from '../../utils/ToastUtils';
 import { useRequiredParams } from '../../utils/useRequiredParams';

--- a/openmetadata-ui/src/main/resources/ui/src/pages/IncidentManager/IncidentManagerDetailPage/IncidentManagerDetailPage.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/IncidentManager/IncidentManagerDetailPage/IncidentManagerDetailPage.tsx
@@ -63,11 +63,11 @@ import {
   updateTestCaseById,
 } from '../../../rest/testAPI';
 import { getEntityName } from '../../../utils/EntityNameUtils';
-import { getEntityVersionByField } from '../../../utils/EntityVersionUtils';
+import { getEntityVersionByField } from '../../../utils/EntityVersionUtilsPure';
 import {
   fetchEntityTaskCountsInto,
   getFeedCounts,
-} from '../../../utils/FeedUtils';
+} from '../../../utils/FeedUtilsPure';
 import observabilityRouterClassBase from '../../../utils/ObservabilityRouterClassBase';
 import { showErrorToast } from '../../../utils/ToastUtils';
 import { useRequiredParams } from '../../../utils/useRequiredParams';
@@ -75,7 +75,6 @@ import { TestCasePageTabs } from '../IncidentManager.interface';
 import './incident-manager-details.less';
 import testCaseClassBase from './TestCaseClassBase';
 import { useTestCaseStore } from './useTestCase.store';
-
 const IncidentManagerDetailPage = ({
   isVersionPage = false,
 }: {

--- a/openmetadata-ui/src/main/resources/ui/src/pages/IncidentManager/IncidentManagerDetailPage/TestCaseClassBase.test.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/IncidentManager/IncidentManagerDetailPage/TestCaseClassBase.test.ts
@@ -16,7 +16,7 @@ import TestCaseIncidentTab from '../../../components/DataQuality/IncidentManager
 import TestCaseResultTab from '../../../components/DataQuality/IncidentManager/TestCaseResultTab/TestCaseResultTab.component';
 import { CreateTestCase } from '../../../generated/api/tests/createTestCase';
 import { TestDefinition } from '../../../generated/tests/testDefinition';
-import { createTestCaseParameters } from '../../../utils/DataQuality/DataQualityUtils';
+import { createTestCaseParameters } from '../../../utils/DataQuality/DataQualityPureUtils';
 import i18n from '../../../utils/i18next/LocalUtil';
 import { TestCasePageTabs } from '../IncidentManager.interface';
 import { TestCaseClassBase, TestCaseTabType } from './TestCaseClassBase';

--- a/openmetadata-ui/src/main/resources/ui/src/pages/IncidentManager/IncidentManagerDetailPage/TestCaseClassBase.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/IncidentManager/IncidentManagerDetailPage/TestCaseClassBase.ts
@@ -19,7 +19,7 @@ import { TabSpecificField } from '../../../enums/entity.enum';
 import { CreateTestCase } from '../../../generated/api/tests/createTestCase';
 import { TestDefinition } from '../../../generated/tests/testDefinition';
 import { FieldProp } from '../../../interface/FormUtils.interface';
-import { createTestCaseParameters } from '../../../utils/DataQuality/DataQualityUtils';
+import { createTestCaseParameters } from '../../../utils/DataQuality/DataQualityPureUtils';
 import i18n from '../../../utils/i18next/LocalUtil';
 import { TestCasePageTabs } from '../IncidentManager.interface';
 

--- a/openmetadata-ui/src/main/resources/ui/src/rest/dataQualityDashboardAPI.test.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/rest/dataQualityDashboardAPI.test.ts
@@ -20,7 +20,7 @@ import {
   buildMustEsFilterForOwner,
   buildMustEsFilterForTags,
   buildMustEsFilterForTier,
-} from '../utils/DataQuality/DataQualityUtils';
+} from '../utils/DataQuality/DataQualityPureUtils';
 import {
   fetchCountOfIncidentStatusTypeByDays,
   fetchEntityCoveredWithDQ,
@@ -32,16 +32,16 @@ import {
   fetchTotalEntityCount,
 } from './dataQualityDashboardAPI';
 import { getDataQualityReport } from './testAPI';
-
 jest.mock('./testAPI', () => ({
   getDataQualityReport: jest.fn(),
 }));
 
-jest.mock('../utils/DataQuality/DataQualityUtils', () => ({
+jest.mock('../utils/DataQuality/DataQualityPureUtils', () => ({
   buildMustEsFilterForOwner: jest.fn(),
   buildMustEsFilterForTags: jest.fn(),
   buildMustEsFilterForTier: jest.fn(),
   buildDataQualityDashboardFilters: jest.fn().mockReturnValue([]),
+  buildMustEsFilterForDataProducts: jest.fn(),
 }));
 
 describe('dataQualityDashboardAPI', () => {

--- a/openmetadata-ui/src/main/resources/ui/src/rest/dataQualityDashboardAPI.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/rest/dataQualityDashboardAPI.ts
@@ -21,7 +21,7 @@ import {
   buildMustEsFilterForOwner,
   buildMustEsFilterForTags,
   buildMustEsFilterForTier,
-} from '../utils/DataQuality/DataQualityUtils';
+} from '../utils/DataQuality/DataQualityPureUtils';
 import { DataQualityReportParamsType, getDataQualityReport } from './testAPI';
 
 export const fetchEntityCoveredWithDQ = (

--- a/openmetadata-ui/src/main/resources/ui/src/utils/DataQuality/CustomDQTooltip.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/DataQuality/CustomDQTooltip.component.tsx
@@ -13,7 +13,7 @@
 import { startCase, uniqBy } from 'lodash';
 import { Surface } from 'recharts';
 import { DataInsightChartTooltipProps } from '../../interface/data-insight.interface';
-import { getEntryFormattedValue } from '../DataInsightUtils';
+import { getEntryFormattedValue } from '../DataInsightPureUtils';
 import { formatDate } from '../date-time/DateTimeUtils';
 
 export const CustomDQTooltip = (props: DataInsightChartTooltipProps) => {

--- a/openmetadata-ui/src/main/resources/ui/src/utils/DataQuality/DataQualityPureUtils.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/DataQuality/DataQualityPureUtils.ts
@@ -59,7 +59,7 @@ import {
 import type { ListTestCaseParamsBySearch } from '../../rest/testAPI';
 import EntityLink from '../EntityLink';
 import { getColumnNameFromEntityLink } from '../EntityPureUtils';
-import { getEntityFQN } from '../FeedUtils';
+import { getEntityFQN } from '../FeedUtilsPure';
 import { getDataQualityPagePath } from '../RouterUtils';
 import { generateEntityLink, getTierTags } from '../TablePureUtils';
 

--- a/openmetadata-ui/src/main/resources/ui/src/utils/DataQuality/DataQualityUtils.test.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/DataQuality/DataQualityUtils.test.ts
@@ -47,8 +47,7 @@ import {
   getTestCaseFiltersValue,
   parseColumnAggregateBuckets,
   transformToTestCaseStatusObject,
-} from './DataQualityUtils';
-
+} from './DataQualityPureUtils';
 jest.mock('../../constants/profiler.constant', () => ({
   TEST_CASE_FILTERS: {
     table: 'tableFqn',
@@ -864,11 +863,11 @@ describe('DataQualityUtils', () => {
 
       expect(getColumnFilterOptions(items)).toEqual([
         {
-          key: `${mockColumnCase1.entityLink ?? ''}::col1`,
+          key: 'service.db.schema.tableA::col1',
           label: 'col1',
         },
         {
-          key: `${mockColumnCase2.entityLink ?? ''}::col2`,
+          key: 'service.db.schema.tableB::col2',
           label: 'col2',
         },
       ]);
@@ -948,15 +947,16 @@ describe('DataQualityUtils', () => {
     });
 
     it('filters by table when filterTables is non-empty', () => {
-      const tableKey = mockTableCase.entityLink ?? '';
+      const tableKey = 'service.db.schema.tableA';
 
       expect(filterTestCasesByTableAndColumn(items, [tableKey], [])).toEqual([
         mockTableCase,
+        mockColumnCase1,
       ]);
     });
 
     it('filters by column when filterColumns is non-empty', () => {
-      const columnKey = `${mockColumnCase1.entityLink ?? ''}::col1`;
+      const columnKey = 'service.db.schema.tableA::col1';
 
       expect(filterTestCasesByTableAndColumn(items, [], [columnKey])).toEqual([
         mockColumnCase1,
@@ -964,7 +964,7 @@ describe('DataQualityUtils', () => {
     });
 
     it('excludes table-only test cases when filtering by column', () => {
-      const columnKey = `${mockColumnCase1.entityLink ?? ''}::col1`;
+      const columnKey = 'service.db.schema.tableA::col1';
 
       expect(
         filterTestCasesByTableAndColumn(items, [], [columnKey])
@@ -972,8 +972,8 @@ describe('DataQualityUtils', () => {
     });
 
     it('applies both table and column filters when both provided', () => {
-      const tableKey = mockColumnCase1.entityLink ?? '';
-      const columnKey = `${mockColumnCase1.entityLink ?? ''}::col1`;
+      const tableKey = 'service.db.schema.tableA';
+      const columnKey = 'service.db.schema.tableA::col1';
 
       expect(
         filterTestCasesByTableAndColumn(items, [tableKey], [columnKey])

--- a/openmetadata-ui/src/main/resources/ui/src/utils/DataQuality/DataQualityUtils.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/DataQuality/DataQualityUtils.tsx
@@ -62,36 +62,3 @@ export const getPieChartLabel = (label: string, value = 0) => {
     </>
   );
 };
-
-// Re-exports from DataQualityPureUtils (backward compat)
-export {
-  aggregateTestResultsByEntity,
-  buildDataQualityDashboardFilters,
-  buildMustEsFilterForDataProducts,
-  buildMustEsFilterForOwner,
-  buildMustEsFilterForTags,
-  buildMustEsFilterForTier,
-  buildTestCaseParams,
-  calculateTestCaseStatusCounts,
-  COLUMN_AGGREGATE_FIELD,
-  convertSearchSourceToTable,
-  createTestCaseParameters,
-  createUpdatedTestCasePatch,
-  filterTestCasesByTableAndColumn,
-  getColumnFilterEntityLink,
-  getColumnFilterOptions,
-  getColumnNameFromColumnFilterKey,
-  getDimensionIcon,
-  getEntityLinkForColumnFilter,
-  getSelectedOptionsFromKeys,
-  getServiceTypeForTestDefinition,
-  getTestCaseFiltersValue,
-  getTestCaseTabPath,
-  parseColumnAggregateBuckets,
-  transformToTestCaseStatusByDimension,
-  transformToTestCaseStatusObject,
-} from './DataQualityPureUtils';
-export type {
-  CreateUpdatedTestCasePatchArgs,
-  TestCaseCountByStatus,
-} from './DataQualityPureUtils';

--- a/openmetadata-ui/src/main/resources/ui/src/utils/FeedUtils.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/FeedUtils.tsx
@@ -14,7 +14,6 @@
 import { RightOutlined } from '@ant-design/icons';
 import Icon from '@ant-design/icons/lib/components/Icon';
 import { Typography } from 'antd';
-import { lowerCase } from 'lodash';
 import type { ReactNode } from 'react';
 import ReactDOM from 'react-dom';
 import { ReactComponent as AddIcon } from '../assets/svg/added-icon.svg';
@@ -25,11 +24,7 @@ import { EntityType } from '../enums/entity.enum';
 import { SearchIndex } from '../enums/search.enum';
 import { OwnerType } from '../enums/user.enum';
 import { ActivityEventType } from '../generated/entity/activity/activityEvent';
-import {
-  CardStyle,
-  FieldOperation,
-  TestCaseStatus,
-} from '../generated/entity/feed/thread';
+import { CardStyle, FieldOperation } from '../generated/entity/feed/thread';
 import type { User } from '../generated/entity/teams/user';
 import { searchQuery } from '../rest/searchAPI';
 import { getRandomColor } from './ColorUtils';
@@ -251,21 +246,6 @@ export const getFieldOperationIcon = (fieldOperation?: FieldOperation) => {
     )
   );
 };
-
-export const getTestCaseResultCount = (
-  count: number,
-  status: TestCaseStatus
-) => (
-  <div
-    className={`test-result-container ${lowerCase(status)}`}
-    data-testid={`test-${status}`}>
-    <Typography.Text
-      className="font-medium text-md"
-      data-testid={`test-${status}-value`}>
-      {count}
-    </Typography.Text>
-  </div>
-);
 
 const getActionLabelFromCardStyle = (
   cardStyle?: CardStyle,

--- a/openmetadata-ui/src/main/resources/ui/src/utils/TestCaseUtils.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/TestCaseUtils.tsx
@@ -15,7 +15,6 @@ import { Typography } from 'antd';
 import { ItemType } from 'antd/lib/menu/hooks/useItems';
 import { lowerCase } from 'lodash';
 import { NavigateFunction } from 'react-router-dom';
-import { TestCaseStatus } from '../generated/entity/feed/thread';
 import { ReactComponent as IconEdit } from '../assets/svg/edit-new.svg';
 import { ReactComponent as ExportIcon } from '../assets/svg/ic-export.svg';
 import { ReactComponent as ImportIcon } from '../assets/svg/ic-import.svg';
@@ -23,6 +22,7 @@ import { ManageButtonItemLabel } from '../components/common/ManageButtonContentI
 import { ExportData } from '../components/Entity/EntityExportModalProvider/EntityExportModalProvider.interface';
 import { ExportTypes } from '../constants/Export.constants';
 import { EntityType } from '../enums/entity.enum';
+import { TestCaseStatus } from '../generated/entity/feed/thread';
 import LimitWrapper from '../hoc/LimitWrapper';
 import { exportTestCasesInCSV } from '../rest/testAPI';
 import { getEntityBulkEditPath, getEntityImportPath } from './EntityPureUtils';

--- a/openmetadata-ui/src/main/resources/ui/src/utils/TestCaseUtils.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/TestCaseUtils.tsx
@@ -11,8 +11,11 @@
  *  limitations under the License.
  */
 
+import { Typography } from 'antd';
 import { ItemType } from 'antd/lib/menu/hooks/useItems';
+import { lowerCase } from 'lodash';
 import { NavigateFunction } from 'react-router-dom';
+import { TestCaseStatus } from '../generated/entity/feed/thread';
 import { ReactComponent as IconEdit } from '../assets/svg/edit-new.svg';
 import { ReactComponent as ExportIcon } from '../assets/svg/ic-export.svg';
 import { ReactComponent as ImportIcon } from '../assets/svg/ic-import.svg';
@@ -24,6 +27,21 @@ import LimitWrapper from '../hoc/LimitWrapper';
 import { exportTestCasesInCSV } from '../rest/testAPI';
 import { getEntityBulkEditPath, getEntityImportPath } from './EntityPureUtils';
 import { t } from './i18next/LocalUtil';
+
+export const getTestCaseResultCount = (
+  count: number,
+  status: TestCaseStatus
+) => (
+  <div
+    className={`test-result-container ${lowerCase(status)}`}
+    data-testid={`test-${status}`}>
+    <Typography.Text
+      className="font-medium text-md"
+      data-testid={`test-${status}-value`}>
+      {count}
+    </Typography.Text>
+  </div>
+);
 
 interface TestCasePermission {
   ViewAll: boolean;


### PR DESCRIPTION
## Summary
- Updates DataQuality and IncidentManager components to import from extracted pure utility modules
- Updates DataQualityUtils, TestCaseUtils imports
- Updates dataQualityDashboardAPI for consistent utility usage

Ref: open-metadata/openmetadata-collate#4230

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR completes the migration of DataQuality and IncidentManager components to the lazy-load pure-utility pattern by removing the backward-compatibility re-export block from `DataQualityUtils.tsx` and updating all consumers to import directly from `DataQualityPureUtils`. It also moves `getTestCaseResultCount` from `FeedUtils` to `TestCaseUtils` and switches several other imports to their `*Pure` counterparts.

- Removes ~30 re-exports from `DataQualityUtils.tsx`; all 39 affected files now import directly from `DataQualityPureUtils`, `FeedUtilsPure`, `EntityVersionUtilsPure`, `TagsPureUtils`, and related pure modules.
- Relocates `getTestCaseResultCount` from `FeedUtils` to `TestCaseUtils` and updates both consumers (`TestCaseFeed` and the removed export site).
- Fixes test expectations in `DataQualityUtils.test.ts` to use real FQN strings instead of raw entity-link strings, reflecting the actual behavior of the un-mocked `FeedUtilsPure.getEntityFQN`.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — all previously broken consumer imports have been updated in this PR and the overall refactoring is mechanically consistent across 39 files.

The change is a pure import-path migration with no logic alterations. Every file that previously relied on the removed re-exports from DataQualityUtils has been updated to import directly from DataQualityPureUtils, and the test updates correctly reflect the real behavior of the now-unmocked FeedUtilsPure.getEntityFQN.

DataQualityUtils.test.ts carries an orphaned jest.mock for FeedUtils that should be swapped to FeedUtilsPure, but it does not affect test correctness.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| openmetadata-ui/src/main/resources/ui/src/utils/DataQuality/DataQualityUtils.tsx | Removes the backward-compat re-export block; only the JSX-dependent getPieChartLabel and its imports remain. |
| openmetadata-ui/src/main/resources/ui/src/utils/DataQuality/DataQualityPureUtils.ts | Switches the getEntityFQN import from FeedUtils to FeedUtilsPure to keep pure-utility dependencies within the pure-utils module boundary. |
| openmetadata-ui/src/main/resources/ui/src/utils/DataQuality/DataQualityUtils.test.ts | Redirects imports to DataQualityPureUtils, replaces entity-link-string filter keys with FQN strings, and expands filterTestCasesByTableAndColumn expectations; the FeedUtils mock is orphaned and should point to FeedUtilsPure. |
| openmetadata-ui/src/main/resources/ui/src/utils/FeedUtils.tsx | Removes getTestCaseResultCount (moved to TestCaseUtils) and the now-unused TestCaseStatus/lowerCase imports. |
| openmetadata-ui/src/main/resources/ui/src/utils/TestCaseUtils.tsx | Receives getTestCaseResultCount extracted from FeedUtils, along with its TestCaseStatus and lowerCase dependencies. |
| openmetadata-ui/src/main/resources/ui/src/pages/IncidentManager/IncidentManagerDetailPage/TestCaseClassBase.ts | Updates createTestCaseParameters import from DataQualityUtils to DataQualityPureUtils. |
| openmetadata-ui/src/main/resources/ui/src/components/Database/Profiler/TableProfiler/TableProfilerProvider.tsx | Updates aggregateTestResultsByEntity and TestCaseCountByStatus imports from DataQualityUtils to DataQualityPureUtils. |
| openmetadata-ui/src/main/resources/ui/src/rest/dataQualityDashboardAPI.ts | Redirects filter-builder imports from DataQualityUtils to DataQualityPureUtils. |
| openmetadata-ui/src/main/resources/ui/src/rest/dataQualityDashboardAPI.test.ts | Updates the jest.mock path from DataQualityUtils to DataQualityPureUtils and adds the missing buildMustEsFilterForDataProducts mock entry. |

</details>


</details>


<details open><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Components / Pages\nDataQuality & IncidentManager] -->|previously via re-export| B[DataQualityUtils.tsx\nJSX utilities only]
    A -->|now direct| C[DataQualityPureUtils.ts\npure logic: filters, params, counts]
    C -->|getEntityFQN| D[FeedUtilsPure.ts]

    E[TestCaseFeed.tsx] -->|getTestCaseResultCount| F[TestCaseUtils.tsx\nnew home]
    G[FeedUtils.tsx\ngetTestCaseResultCount removed] -.->|moved to| F

    H[dataQualityDashboardAPI.ts] -->|filter builders| C
    I[TableProfilerProvider.tsx] -->|aggregateTestResultsByEntity| C
    J[TestCaseClassBase.ts] -->|createTestCaseParameters| C
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Components / Pages\nDataQuality & IncidentManager] -->|previously via re-export| B[DataQualityUtils.tsx\nJSX utilities only]
    A -->|now direct| C[DataQualityPureUtils.ts\npure logic: filters, params, counts]
    C -->|getEntityFQN| D[FeedUtilsPure.ts]

    E[TestCaseFeed.tsx] -->|getTestCaseResultCount| F[TestCaseUtils.tsx\nnew home]
    G[FeedUtils.tsx\ngetTestCaseResultCount removed] -.->|moved to| F

    H[dataQualityDashboardAPI.ts] -->|filter builders| C
    I[TableProfilerProvider.tsx] -->|aggregateTestResultsByEntity| C
    J[TestCaseClassBase.ts] -->|createTestCaseParameters| C
```

</a>
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `openmetadata-ui/src/main/resources/ui/src/utils/DataQuality/DataQualityUtils.tsx`, line 1-64 ([link](https://github.com/open-metadata/openmetadata/blob/f3698be13aa71b959313984f409a002d399acead/openmetadata-ui/src/main/resources/ui/src/utils/DataQuality/DataQualityUtils.tsx#L1-L64)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Missed consumers of removed re-exports will break the build**

   The backward-compat re-export block (`createTestCaseParameters`, `aggregateTestResultsByEntity`, `TestCaseCountByStatus`, `calculateTestCaseStatusCounts`, etc.) was removed from this file, but at least five files that were not part of this PR still import those names from `DataQualityUtils` and will fail to compile:

   - `TestCaseClassBase.ts` (+ its test file) — `createTestCaseParameters`
   - `TableProfilerProvider.tsx` — `aggregateTestResultsByEntity`, `TestCaseCountByStatus`
   - `TableProfiler.interface.ts` — `TestCaseCountByStatus`
   - `ColumnDetailPanel.component.tsx` — `calculateTestCaseStatusCounts`

   Each of those sites needs to be updated to import from `DataQualityPureUtils` before this PR can merge without breaking the build.

2. `openmetadata-ui/src/main/resources/ui/src/utils/DataQuality/DataQualityUtils.test.ts`, line 83-85 ([link](https://github.com/open-metadata/openmetadata/blob/f3698be13aa71b959313984f409a002d399acead/openmetadata-ui/src/main/resources/ui/src/utils/DataQuality/DataQualityUtils.test.ts#L83-L85)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> The mock for `FeedUtils` is now orphaned — `DataQualityPureUtils` switched its `getEntityFQN` import to `FeedUtilsPure`, so this mock no longer intercepts anything and should be removed or replaced with a matching mock for `FeedUtilsPure`.

   

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (3): Last reviewed commit: ["fix checkstyle, tests and build"](https://github.com/open-metadata/openmetadata/commit/882e39742e311e646b0c9faceb1e38c4f70ecb05) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37841890)</sub>

<!-- /greptile_comment -->