### PR TITLE
fix(ingestion): parameterize MySQL routines query to avoid SQL string interpolation

### DIFF
--- a/ingestion/src/metadata/ingestion/source/database/mysql/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/database/mysql/metadata.py
@@ -81,7 +81,7 @@ class MysqlSource(CommonDbSourceService):
         if self.source_config.includeStoredProcedures:
             with self.engine.connect() as conn:
                 results = conn.execute(
-                    text(MYSQL_GET_ROUTINES.format(schema_name=self.context.get().database_schema))
+                    text(MYSQL_GET_ROUTINES).bindparams(schema_name=self.context.get().database_schema)
                 ).all()
             for row in results:
                 try:

--- a/ingestion/src/metadata/ingestion/source/database/mysql/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/database/mysql/metadata.py
@@ -81,7 +81,7 @@ class MysqlSource(CommonDbSourceService):
         if self.source_config.includeStoredProcedures:
             with self.engine.connect() as conn:
                 results = conn.execute(
-                    text(MYSQL_GET_ROUTINES).bindparams(schema_name=self.context.get().database_schema)
+                    text(MYSQL_GET_ROUTINES).bindparams(schema_name=self.context.get().database_schema)  # pyright: ignore[reportAttributeAccessIssue]
                 ).all()
             for row in results:
                 try:

--- a/ingestion/src/metadata/ingestion/source/database/mysql/queries.py
+++ b/ingestion/src/metadata/ingestion/source/database/mysql/queries.py
@@ -82,5 +82,5 @@ MYSQL_GET_ROUTINES = """
     ROUTINE_COMMENT AS description
 FROM information_schema.ROUTINES
 WHERE ROUTINE_TYPE IN ('PROCEDURE', 'FUNCTION')
-AND ROUTINE_SCHEMA = '{schema_name}';
+AND ROUTINE_SCHEMA = :schema_name
 """  # noqa: W291

--- a/ingestion/tests/unit/topology/database/test_mysql.py
+++ b/ingestion/tests/unit/topology/database/test_mysql.py
@@ -30,6 +30,7 @@ from metadata.generated.schema.type.entityReference import EntityReference
 from metadata.generated.schema.type.filterPattern import FilterPattern
 from metadata.ingestion.source.database.mysql.metadata import MysqlSource
 from metadata.ingestion.source.database.mysql.models import MysqlRoutine
+from metadata.ingestion.source.database.mysql.queries import MYSQL_GET_ROUTINES
 
 mock_mysql_config = {
     "source": {
@@ -168,6 +169,35 @@ class MysqlUnitTest(TestCase):
         self.assertIsInstance(stored_procedures[0], MysqlRoutine)
         self.assertEqual(stored_procedures[0].name, "test_procedure")
         self.assertEqual(stored_procedures[0].routine_type, "PROCEDURE")
+
+        executed_clause = mock_conn.execute.call_args[0][0]
+        self.assertEqual(
+            executed_clause.compile().params.get("schema_name"),
+            MOCK_DATABASE_SCHEMA.name.root,
+        )
+
+    @patch("metadata.ingestion.source.database.common_db_source.CommonDbSourceService.connection")
+    def test_get_stored_procedures_binds_schema_name(self, connection):
+        """A schema name with a quote is bound, never interpolated into the SQL text"""
+        connection.return_value = True
+        malicious_schema = "my'schema"
+
+        mock_engine = MagicMock()
+        mock_conn = MagicMock()
+        mock_conn.execute.return_value.all.return_value = []
+        mock_engine.connect.return_value.__enter__ = MagicMock(return_value=mock_conn)
+        mock_engine.connect.return_value.__exit__ = MagicMock(return_value=False)
+        self.mysql_source.engine = mock_engine
+
+        self.mysql_source.source_config.includeStoredProcedures = True
+        self.mysql_source.context.get().__dict__["database_schema"] = malicious_schema
+
+        list(self.mysql_source.get_stored_procedures())
+
+        executed_clause = mock_conn.execute.call_args[0][0]
+        self.assertEqual(executed_clause.compile().params.get("schema_name"), malicious_schema)
+        self.assertIn(":schema_name", MYSQL_GET_ROUTINES)
+        self.assertNotIn(malicious_schema, str(executed_clause))
 
     def _yield_language(self, language: str) -> Language:
         routine = MysqlRoutine(


### PR DESCRIPTION
Fixes #28842

#### Issue

- The MySQL connector's stored-procedure/function query (`MYSQL_GET_ROUTINES`) interpolated
the schema name directly into the SQL string via Python `.format()`. Wrapping the result in
`text()` does **not** parameterize it — the value is already baked into the SQL before
SQLAlchemy sees it.

- This change binds `schema_name` as a SQLAlchemy parameter so the value is passed to the
driver separately from the SQL text.

- A schema name containing a single quote would break the query, and string-interpolating
identifiers into SQL is the wrong pattern regardless of trust level. DataHub binds the same
value as a parameter (`WHERE ROUTINE_SCHEMA = %s`). Severity is low (schema names are
trusted and rarely contain quotes), but parameterizing is the correct, robust pattern.







#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [x] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.
- [ ] For UI changes: I attached a screen recording and/or screenshots above.
- [ ] I have added tests (unit / integration / Playwright as applicable) and listed them above.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a SQL string-interpolation issue in the MySQL connector's `get_stored_procedures` method. The schema name was previously baked into the query text via Python's `.format()` before SQLAlchemy ever saw it, meaning wrapping it in `text()` offered no protection. The fix replaces the format placeholder with a `:schema_name` named parameter and uses `.bindparams()` to pass the value separately.

- **`queries.py`**: Replaces `'{schema_name}'` f-string placeholder with `:schema_name` SQLAlchemy named-parameter syntax; also removes the trailing semicolon (safe for single-statement execution via a connection).
- **`metadata.py`**: Swaps `.format(schema_name=...)` for `.bindparams(schema_name=...)` so the value is sent to the driver as a bound parameter rather than being embedded in the SQL text.
- **`test_mysql.py`**: Extends the existing stored-procedure test to assert the schema is bound (not interpolated), and adds a dedicated test using a quote-containing schema name to confirm the value never appears raw in the SQL text.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is a focused, correct fix that eliminates string interpolation from a single SQL query and replaces it with proper parameter binding.

The change is minimal and targeted: one SQL constant and one call site are updated in lockstep, the new approach uses the established SQLAlchemy bindparams() idiom correctly, and the two new test assertions directly verify the fix for both normal and quote-containing schema names.

No files require special attention.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| ingestion/src/metadata/ingestion/source/database/mysql/queries.py | Replaced '{schema_name}' Python format placeholder with :schema_name SQLAlchemy named-parameter; also removed the trailing semicolon (harmless for single-statement execution). |
| ingestion/src/metadata/ingestion/source/database/mysql/metadata.py | Switched from text(MYSQL_GET_ROUTINES.format(...)) to text(MYSQL_GET_ROUTINES).bindparams(schema_name=...), correctly binding the schema as a driver-level parameter. |
| ingestion/tests/unit/topology/database/test_mysql.py | Added two assertion blocks: one extending the existing test to verify the schema is properly bound, and a new dedicated test confirming a quote-containing schema name is never interpolated into the SQL text. |

</details>

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant MS as MysqlSource.get_stored_procedures()
    participant SA as SQLAlchemy text()
    participant DB as MySQL Driver

    Note over MS,DB: Before (string interpolation)
    MS->>SA: "text(MYSQL_GET_ROUTINES.format(schema_name=...))"
    Note right of SA: schema value baked into SQL text
    SA->>DB: "WHERE ROUTINE_SCHEMA = 'my_schema'"

    Note over MS,DB: After (parameterized)
    MS->>SA: "text(MYSQL_GET_ROUTINES).bindparams(schema_name=...)"
    Note right of SA: SQL text stays clean: WHERE ROUTINE_SCHEMA = :schema_name
    SA->>DB: "SQL text + bound param {schema_name: my_schema}"
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant MS as MysqlSource.get_stored_procedures()
    participant SA as SQLAlchemy text()
    participant DB as MySQL Driver

    Note over MS,DB: Before (string interpolation)
    MS->>SA: "text(MYSQL_GET_ROUTINES.format(schema_name=...))"
    Note right of SA: schema value baked into SQL text
    SA->>DB: "WHERE ROUTINE_SCHEMA = 'my_schema'"

    Note over MS,DB: After (parameterized)
    MS->>SA: "text(MYSQL_GET_ROUTINES).bindparams(schema_name=...)"
    Note right of SA: SQL text stays clean: WHERE ROUTINE_SCHEMA = :schema_name
    SA->>DB: "SQL text + bound param {schema_name: my_schema}"
```

</a>
</details>

<sub>Reviews (2): Last reviewed commit: ["static check fix"](https://github.com/open-metadata/openmetadata/commit/7a79984446d3beaf318590aaa4d3ca16e1206fb9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37889709)</sub>

<!-- /greptile_comment -->