### PR TITLE
Fix: improve docker-compose-rdf.yml and related docker files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -188,6 +188,7 @@ update_dockerfile_version:  ## To update the dockerfiles version
 	@file_paths="docker/docker-compose-ingestion/docker-compose-ingestion.yml \
 		     docker/docker-compose-openmetadata/docker-compose-openmetadata.yml \
 		     docker/docker-compose-quickstart/docker-compose-postgres.yml \
+		     docker/docker-compose-quickstart/docker-compose-rdf.yml \
 		     docker/docker-compose-quickstart/docker-compose.yml"; \
 	echo "Updating docker github action release version to $(RELEASE_VERSION)... "; \
 	for file_path in $$file_paths; do \

--- a/docker/docker-compose-quickstart/Dockerfile.fuseki-alpine
+++ b/docker/docker-compose-quickstart/Dockerfile.fuseki-alpine
@@ -23,7 +23,7 @@ USER fuseki
 WORKDIR ${FUSEKI_HOME}
 
 # Download and install Fuseki
-RUN wget -q https://archive.apache.org/dist/jena/binaries/apache-jena-fuseki-${FUSEKI_VERSION}.tar.gz && \
+RUN wget -q https://repo1.maven.org/maven2/org/apache/jena/apache-jena-fuseki/${FUSEKI_VERSION}/apache-jena-fuseki-${FUSEKI_VERSION}.tar.gz && \
     tar -xzf apache-jena-fuseki-${FUSEKI_VERSION}.tar.gz --strip-components=1 && \
     rm apache-jena-fuseki-${FUSEKI_VERSION}.tar.gz && \
     mkdir -p ${FUSEKI_HOME}/run ${FUSEKI_HOME}/databases

--- a/docker/docker-compose-quickstart/Dockerfile.fuseki-arm64
+++ b/docker/docker-compose-quickstart/Dockerfile.fuseki-arm64
@@ -20,7 +20,7 @@ ENV FUSEKI_HOME=/fuseki
 # Download and install Fuseki
 RUN mkdir -p ${FUSEKI_HOME} && \
     cd /tmp && \
-    wget -q https://archive.apache.org/dist/jena/binaries/apache-jena-fuseki-${FUSEKI_VERSION}.tar.gz && \
+    wget -q https://repo1.maven.org/maven2/org/apache/jena/apache-jena-fuseki/${FUSEKI_VERSION}/apache-jena-fuseki-${FUSEKI_VERSION}.tar.gz && \
     tar -xzf apache-jena-fuseki-${FUSEKI_VERSION}.tar.gz && \
     mv apache-jena-fuseki-${FUSEKI_VERSION}/* ${FUSEKI_HOME}/ && \
     rm -rf apache-jena-fuseki-${FUSEKI_VERSION}.tar.gz apache-jena-fuseki-${FUSEKI_VERSION}

--- a/docker/docker-compose-quickstart/Dockerfile.fuseki-multiarch
+++ b/docker/docker-compose-quickstart/Dockerfile.fuseki-multiarch
@@ -16,7 +16,7 @@ ENV FUSEKI_BASE=/fuseki
 
 # Download and install Fuseki
 WORKDIR /tmp
-RUN wget -q https://archive.apache.org/dist/jena/binaries/apache-jena-fuseki-${FUSEKI_VERSION}.tar.gz && \
+RUN wget -q https://repo1.maven.org/maven2/org/apache/jena/apache-jena-fuseki/${FUSEKI_VERSION}/apache-jena-fuseki-${FUSEKI_VERSION}.tar.gz && \
     tar -xzf apache-jena-fuseki-${FUSEKI_VERSION}.tar.gz && \
     mv apache-jena-fuseki-${FUSEKI_VERSION}/* ${FUSEKI_HOME}/ && \
     rm -rf /tmp/*

--- a/docker/docker-compose-quickstart/Dockerfile.fuseki-simple
+++ b/docker/docker-compose-quickstart/Dockerfile.fuseki-simple
@@ -6,7 +6,7 @@ RUN apk add --no-cache wget tar
 ENV FUSEKI_VERSION=5.6.0
 WORKDIR /tmp
 
-RUN wget -q https://archive.apache.org/dist/jena/binaries/apache-jena-fuseki-${FUSEKI_VERSION}.tar.gz && \
+RUN wget -q https://repo1.maven.org/maven2/org/apache/jena/apache-jena-fuseki/${FUSEKI_VERSION}/apache-jena-fuseki-${FUSEKI_VERSION}.tar.gz && \
     tar -xzf apache-jena-fuseki-${FUSEKI_VERSION}.tar.gz && \
     mv apache-jena-fuseki-${FUSEKI_VERSION} /fuseki-dist
 

--- a/docker/docker-compose-quickstart/Dockerfile.fuseki-working
+++ b/docker/docker-compose-quickstart/Dockerfile.fuseki-working
@@ -13,7 +13,7 @@ RUN mkdir -p ${FUSEKI_HOME}
 WORKDIR ${FUSEKI_HOME}
 
 # Download Fuseki using ADD (doesn't require wget)
-ADD https://archive.apache.org/dist/jena/binaries/apache-jena-fuseki-${FUSEKI_VERSION}.tar.gz /tmp/fuseki.tar.gz
+ADD https://repo1.maven.org/maven2/org/apache/jena/apache-jena-fuseki/${FUSEKI_VERSION}/apache-jena-fuseki-${FUSEKI_VERSION}.tar.gz /tmp/fuseki.tar.gz
 
 # Extract Fuseki
 RUN tar -xzf /tmp/fuseki.tar.gz --strip-components=1 -C ${FUSEKI_HOME} && \

--- a/docker/docker-compose-quickstart/docker-compose-rdf.yml
+++ b/docker/docker-compose-quickstart/docker-compose-rdf.yml
@@ -26,7 +26,7 @@ volumes:
 services:
   mysql:
     container_name: openmetadata_mysql
-    image: docker.getcollate.io/openmetadata/db:1.8.0-SNAPSHOT
+    image: docker.getcollate.io/openmetadata/db:1.12.0-SNAPSHOT
     command: "--sort_buffer_size=10M"
     restart: always
     environment:
@@ -111,7 +111,7 @@ services:
 
   execute-migrate-all:
     container_name: execute_migrate_all
-    image: docker.getcollate.io/openmetadata/server:1.8.0-SNAPSHOT
+    image: docker.getcollate.io/openmetadata/server:1.12.0-SNAPSHOT
     command: "./bootstrap/openmetadata-ops.sh migrate"
     environment:
       OPENMETADATA_CLUSTER_NAME: ${OPENMETADATA_CLUSTER_NAME:-openmetadata}
@@ -285,7 +285,7 @@ services:
   openmetadata-server:
     container_name: openmetadata_server
     restart: always
-    image: docker.getcollate.io/openmetadata/server:1.8.0-SNAPSHOT
+    image: docker.getcollate.io/openmetadata/server:1.12.0-SNAPSHOT
     environment:
       OPENMETADATA_CLUSTER_NAME: ${OPENMETADATA_CLUSTER_NAME:-openmetadata}
       SERVER_PORT: ${SERVER_PORT:-8585}
@@ -463,7 +463,7 @@ services:
     build:
       context: ../
       dockerfile: docker/development/Dockerfile
-    image: docker.getcollate.io/openmetadata/ingestion:1.8.0-SNAPSHOT
+    image: docker.getcollate.io/openmetadata/ingestion:1.12.0-SNAPSHOT
     depends_on:
       elasticsearch:
         condition: service_healthy

--- a/docker/rdf-store/Dockerfile
+++ b/docker/rdf-store/Dockerfile
@@ -25,7 +25,7 @@ RUN apt-get update && apt-get install -y \
     && rm -rf /var/lib/apt/lists/*
 
 # Download and install Fuseki
-RUN wget -q https://archive.apache.org/dist/jena/binaries/apache-jena-fuseki-${FUSEKI_VERSION}.tar.gz \
+RUN wget -q https://repo1.maven.org/maven2/org/apache/jena/apache-jena-fuseki/${FUSEKI_VERSION}/apache-jena-fuseki-${FUSEKI_VERSION}.tar.gz \
     && tar -xzf apache-jena-fuseki-${FUSEKI_VERSION}.tar.gz \
     && mv apache-jena-fuseki-${FUSEKI_VERSION} ${FUSEKI_HOME} \
     && rm apache-jena-fuseki-${FUSEKI_VERSION}.tar.gz


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:

Fixes (None)
<!--
Linking an issue is REQUIRED. Replace <issue-number> with the GitHub issue number this PR addresses
(e.g., `Fixes #12345`). GitHub will auto-link it. If no issue exists, please open one first so the
problem and design can be discussed before review.
-->

<!--
Short blurb explaining:
- What changes did you make?
- Why did you make them?
-->

Replace the Fuseki tarball download source from `archive.apache.org` to Maven
Central (`repo1.maven.org`) in all Fuseki Dockerfiles, because
`archive.apache.org` is extremely slow (~100 KB/s) whereas Maven Central
delivers the same artifact at ~3 MB/s (~30x faster).

Files changed:
- `docker/rdf-store/Dockerfile`
- `docker/docker-compose-quickstart/Dockerfile.fuseki-working`
- `docker/docker-compose-quickstart/Dockerfile.fuseki-arm64`
- `docker/docker-compose-quickstart/Dockerfile.fuseki-simple`
- `docker/docker-compose-quickstart/Dockerfile.fuseki-alpine`
- `docker/docker-compose-quickstart/Dockerfile.fuseki-multiarch`

Also fixes a version mismatch in `docker-compose-rdf.yml`: the file had
hardcoded `1.8.0-SNAPSHOT` image tags while all other compose files in the
same directory used `1.12.0-SNAPSHOT`. The root cause was that
`docker-compose-rdf.yml` was missing from the `update_dockerfile_version`
target in `Makefile`, so it was skipped during release version bumps. The
file has been added to the target so future releases will update it
consistently.

Additional files changed:
- `Makefile` — added `docker/docker-compose-quickstart/docker-compose-rdf.yml` to `update_dockerfile_version`
- `docker/docker-compose-quickstart/docker-compose-rdf.yml` — updated image tags from `1.8.0-SNAPSHOT` to `1.12.0-SNAPSHOT`

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Improvement

#
### High-level design:
<!--
REQUIRED for large PRs (new features, refactors, breaking changes, or anything touching >5 files).
Skip for small bug fixes and trivial changes.

Cover:
- Architecture / approach you took and why
- Key components or files added/changed and how they interact
- Alternatives considered and why you rejected them
- Any migration, backward-compatibility, or rollout concerns
- Diagrams or links to design docs / RFCs if available
-->

N/A — small change. <!-- Or fill in the design above -->

#
### Tests:

#### Use cases covered
<!--
List the user-visible scenarios this PR exercises. Example:
- User with Admin role can create a Glossary Term with a parent term
- Ingestion run for Snowflake correctly extracts row counts for partitioned tables
-->

Docker image for `docker/rdf-store/` builds successfully using the new URL.

#### Unit tests
Not applicable (no core changes).

#### Backend integration tests
- [x] Not applicable (no backend API changes).

#### Ingestion integration tests
- [x] Not applicable (no ingestion changes).

#### Playwright (UI) tests
- [x] Not applicable (no UI changes).

#### Manual testing performed
<!--
List the manual test steps you performed before requesting review. Example:
1. Started local stack via `./docker/run_local_docker.sh -m ui -d mysql`
2. Logged in as admin, created entity X, verified Y appears in the UI
3. Triggered ingestion for Snowflake source, confirmed lineage edges in the explore page
-->

The SHA-512 digest of the file served by Maven Central was computed and
compared against the official checksum published at `archive.apache.org`:

```sh
# Official checksum (archive.apache.org/dist/jena/binaries/apache-jena-fuseki-5.6.0.tar.gz.sha512)
53dfe13cdd5f6387a0c62917e275fde2cd2e2f2052bfe7515384934f24915228b8512a2dd2b50b7060cc300c976254349d991fcea239484cae48e0a59d67cd54

# Computed from Maven Central download
$ curl -sL https://repo1.maven.org/maven2/org/apache/jena/apache-jena-fuseki/5.6.0/apache-jena-fuseki-5.6.0.tar.gz | shasum -a 512
53dfe13cdd5f6387a0c62917e275fde2cd2e2f2052bfe7515384934f24915228b8512a2dd2b50b7060cc300c976254349d991fcea239484cae48e0a59d67cd54
```

The digests match exactly — the Maven Central artifact is identical to the
official Apache release.

Also, docker build is verified:
1. Built `docker/rdf-store/Dockerfile` with `docker build -t openmetadata-rdf-store:test docker/rdf-store/`.
2. Build completed successfully; the Fuseki tarball download step finished in ~15 seconds.

#
### UI screen recording / screenshots:
<!--
REQUIRED for any PR that changes the UI. Drag-and-drop a short screen recording (.mov / .mp4 / .gif)
demonstrating the change end-to-end, plus before/after screenshots where relevant.
Mark "Not applicable" if there are no UI changes.
-->

Not applicable. <!-- Or attach recording/screenshots above -->

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.
- [ ] For UI changes: I attached a screen recording and/or screenshots above.
- [ ] I have added tests (unit / integration / Playwright as applicable) and listed them above.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR updates the RDF Docker setup and Fuseki image builds. The main changes are:

- Fuseki tarball downloads now use Maven Central.
- RDF quickstart OpenMetadata image tags are aligned with the current snapshot version.
- The RDF compose file is included in the release version update target.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge.

- No blocking issues found in the changed code.

</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| Makefile | Adds the RDF quickstart compose file to the existing Docker image tag update target. |
| docker/docker-compose-quickstart/docker-compose-rdf.yml | Updates RDF quickstart OpenMetadata service image tags to the current snapshot version. |
| docker/rdf-store/Dockerfile | Changes the Fuseki tarball source to Maven Central while keeping the install flow unchanged. |
| docker/docker-compose-quickstart/Dockerfile.fuseki-alpine | Changes the Fuseki tarball source to Maven Central. |
| docker/docker-compose-quickstart/Dockerfile.fuseki-arm64 | Changes the Fuseki tarball source to Maven Central. |
| docker/docker-compose-quickstart/Dockerfile.fuseki-multiarch | Changes the Fuseki tarball source to Maven Central. |
| docker/docker-compose-quickstart/Dockerfile.fuseki-simple | Changes the Fuseki tarball source to Maven Central. |
| docker/docker-compose-quickstart/Dockerfile.fuseki-working | Changes the Docker ADD source for the Fuseki tarball to Maven Central. |

</details>

<sub>Reviews (2): Last reviewed commit: ["fix update\_dockerfile\_version to update ..."](https://github.com/open-metadata/openmetadata/commit/7ac0ed1f2a7d6e12a727326c0ab706cdd7d3ebce) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37905210)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Context used - CLAUDE.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=52f0d9d9-cad1-4e7d-b070-de181a0aa5e7))
- Context used - openmetadata-ui-core-components/CLAUDE.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=41754627-b2bf-474b-8082-f37ef1a07013))
- Context used - AGENTS.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=ef262f5f-911f-44f3-8d2d-e9cb1579c8c8))
</details>

<!-- /greptile_comment -->