### PR TITLE
feat(ui-core-components): no-wrap + auto-collapse for Breadcrumbs

### DIFF
--- a/openmetadata-ui-core-components/src/main/resources/ui/src/components/application/breadcrumbs/breadcrumbs.tsx
+++ b/openmetadata-ui-core-components/src/main/resources/ui/src/components/application/breadcrumbs/breadcrumbs.tsx
@@ -14,6 +14,7 @@ import { Dropdown } from '@/components/base/dropdown/dropdown';
 import { cx, sortCx } from '@/utils/cx';
 import { ChevronRight, DotsHorizontal } from '@untitledui/icons';
 import type { FC, HTMLAttributes, Key, ReactNode } from 'react';
+import { useEffect, useLayoutEffect, useRef, useState } from 'react';
 import {
   Breadcrumb as AriaBreadcrumb,
   Breadcrumbs as AriaBreadcrumbs,
@@ -52,9 +53,16 @@ export interface BreadcrumbsProps extends HTMLAttributes<HTMLElement> {
   /**
    * Maximum number of crumbs to render inline. When the list is longer, the
    * middle crumbs collapse into a `…` menu, keeping the first and last crumbs
-   * visible. Omit to always render every crumb.
+   * visible. Omit to always render every crumb. Ignored when `autoCollapse`
+   * is enabled.
    */
   maxItems?: number;
+  /**
+   * Keep the trail on a single line and automatically collapse the middle
+   * crumbs into a `…` menu when the container is too narrow to fit them all.
+   * Overrides `maxItems`.
+   */
+  autoCollapse?: boolean;
   /**
    * Called with the item id when a non-current crumb is activated. When
    * provided, native `href` navigation is suppressed so the callback alone
@@ -170,7 +178,11 @@ const CrumbLabel = ({
   const Icon = item.icon;
 
   return (
-    <span className={cx('tw:flex tw:items-center', sizes[size].gap)}>
+    <span
+      className={cx(
+        'tw:flex tw:items-center tw:whitespace-nowrap',
+        sizes[size].gap
+      )}>
       {Icon && <Icon className={cx('tw:shrink-0', sizes[size].icon)} />}
       {item.label}
     </span>
@@ -220,19 +232,52 @@ export const Breadcrumbs = ({
   divider = 'chevron',
   size = 'sm',
   maxItems,
+  autoCollapse = false,
   className,
   onAction,
   'aria-label': ariaLabel = 'Breadcrumb',
   ...props
 }: BreadcrumbsProps) => {
-  const displayItems = collapseItems(items, maxItems);
-  const padding = type === 'text' ? '' : sizes[size].padding;
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [fittedCount, setFittedCount] = useState(items.length);
 
-  return (
+  const padding = type === 'text' ? '' : sizes[size].padding;
+  const displayItems = collapseItems(
+    items,
+    autoCollapse ? fittedCount : maxItems
+  );
+
+  useLayoutEffect(() => {
+    const el = containerRef.current;
+    if (
+      autoCollapse &&
+      el &&
+      el.scrollWidth > el.clientWidth + 1 &&
+      fittedCount > 2
+    ) {
+      setFittedCount(fittedCount - 1);
+    }
+  }, [autoCollapse, fittedCount, items]);
+
+  useEffect(() => {
+    const el = containerRef.current;
+    if (!autoCollapse || !el) {
+      return undefined;
+    }
+
+    setFittedCount(items.length);
+    const observer = new ResizeObserver(() => setFittedCount(items.length));
+    observer.observe(el);
+
+    return () => observer.disconnect();
+  }, [autoCollapse, items.length]);
+
+  const list = (
     <AriaBreadcrumbs
       aria-label={ariaLabel}
       className={cx(
-        'tw:flex tw:items-center',
+        'tw:flex tw:flex-nowrap tw:items-center',
+        autoCollapse && 'tw:w-max',
         sizes[size].gap,
         sizes[size].text,
         className
@@ -241,7 +286,10 @@ export const Breadcrumbs = ({
       {...props}>
       {(item) => (
         <AriaBreadcrumb
-          className={cx('tw:flex tw:items-center', sizes[size].gap)}>
+          className={cx(
+            'tw:flex tw:shrink-0 tw:items-center',
+            sizes[size].gap
+          )}>
           {({ isCurrent }) => (
             <>
               {isEllipsis(item) ? (
@@ -277,5 +325,13 @@ export const Breadcrumbs = ({
         </AriaBreadcrumb>
       )}
     </AriaBreadcrumbs>
+  );
+
+  return autoCollapse ? (
+    <div className="tw:w-full tw:min-w-0 tw:overflow-hidden" ref={containerRef}>
+      {list}
+    </div>
+  ) : (
+    list
   );
 };

--- a/openmetadata-ui-core-components/src/main/resources/ui/src/components/application/breadcrumbs/breadcrumbs.tsx
+++ b/openmetadata-ui-core-components/src/main/resources/ui/src/components/application/breadcrumbs/breadcrumbs.tsx
@@ -14,7 +14,13 @@ import { Dropdown } from '@/components/base/dropdown/dropdown';
 import { cx, sortCx } from '@/utils/cx';
 import { ChevronRight, DotsHorizontal } from '@untitledui/icons';
 import type { FC, HTMLAttributes, Key, ReactNode } from 'react';
-import { useEffect, useLayoutEffect, useRef, useState } from 'react';
+import {
+  useEffect,
+  useLayoutEffect,
+  useReducer,
+  useRef,
+  useState,
+} from 'react';
 import {
   Breadcrumb as AriaBreadcrumb,
   Breadcrumbs as AriaBreadcrumbs,
@@ -240,6 +246,7 @@ export const Breadcrumbs = ({
 }: BreadcrumbsProps) => {
   const containerRef = useRef<HTMLDivElement>(null);
   const [fittedCount, setFittedCount] = useState(items.length);
+  const [measureKey, requestMeasure] = useReducer((key: number) => key + 1, 0);
 
   const padding = type === 'text' ? '' : sizes[size].padding;
   const displayItems = collapseItems(
@@ -247,27 +254,41 @@ export const Breadcrumbs = ({
     autoCollapse ? fittedCount : maxItems
   );
 
+  // While the trail overflows its container, drop one more crumb into the `…`
+  // menu. Re-runs as `fittedCount` decreases (the convergence loop) and whenever
+  // a re-measure is requested, so it settles once the trail fits (or only the
+  // first + last remain). The `ol` is the measured element — react-aria renders
+  // a 0-width <template> as the wrapper's first child, so the list must be
+  // queried, not read positionally.
   useLayoutEffect(() => {
-    const el = containerRef.current;
+    const list = containerRef.current?.querySelector('ol');
     if (
       autoCollapse &&
-      el &&
-      el.scrollWidth > el.clientWidth + 1 &&
+      list &&
+      list.scrollWidth > list.clientWidth + 1 &&
       fittedCount > 2
     ) {
       setFittedCount(fittedCount - 1);
     }
-  }, [autoCollapse, fittedCount, items]);
+  }, [autoCollapse, fittedCount, items, measureKey]);
 
+  // Reset to the full trail and re-measure on mount, on a container resize, and
+  // once web fonts load (label widths can change after the first layout, which
+  // would otherwise leave a stale measurement). The reset lets the trail
+  // re-expand when there is more room.
   useEffect(() => {
     const el = containerRef.current;
     if (!autoCollapse || !el) {
       return undefined;
     }
 
-    setFittedCount(items.length);
-    const observer = new ResizeObserver(() => setFittedCount(items.length));
+    const remeasure = () => {
+      setFittedCount(items.length);
+      requestMeasure();
+    };
+    const observer = new ResizeObserver(remeasure);
     observer.observe(el);
+    document.fonts?.ready.then(remeasure).catch(() => undefined);
 
     return () => observer.disconnect();
   }, [autoCollapse, items.length]);
@@ -277,7 +298,7 @@ export const Breadcrumbs = ({
       aria-label={ariaLabel}
       className={cx(
         'tw:flex tw:flex-nowrap tw:items-center',
-        autoCollapse && 'tw:w-max',
+        autoCollapse && 'tw:w-full tw:min-w-0 tw:overflow-hidden',
         sizes[size].gap,
         sizes[size].text,
         className

--- a/openmetadata-ui-core-components/src/main/resources/ui/src/stories/Breadcrumbs.stories.tsx
+++ b/openmetadata-ui-core-components/src/main/resources/ui/src/stories/Breadcrumbs.stories.tsx
@@ -77,3 +77,14 @@ export const Sizes: Story = {
     </div>
   ),
 };
+
+export const AutoCollapse: Story = {
+  args: { items: deepItems, autoCollapse: true },
+  render: (args) => (
+    <div
+      className="tw:resize-x tw:overflow-auto tw:rounded-lg tw:border tw:border-secondary tw:p-3"
+      style={{ width: 320 }}>
+      <Breadcrumbs {...args} />
+    </div>
+  ),
+};


### PR DESCRIPTION
### Describe your changes:

Breadcrumb labels were wrapping mid-word and the trail grew tall when space ran out (see the search-result cards in the screenshot). This PR keeps each crumb on a single line (`whitespace-nowrap` labels, `flex-nowrap` non-shrinking crumbs) and adds an **`autoCollapse`** prop: when enabled, a `ResizeObserver` measures the container and progressively collapses the middle crumbs into the existing `…` menu until the trail fits on one line, re-expanding when space allows. `autoCollapse` overrides the static `maxItems`, and the measuring wrapper is only rendered when it is enabled, so the default DOM and behaviour are unchanged. Verified with `yarn type-check`, `yarn build`, ESLint and Prettier.

#
### Type of change:
- [ ] Improvement

#
### High-level design:

The component already supported a static `maxItems` collapse into a `…` dropdown. `autoCollapse` reuses that collapse path but drives the visible-count dynamically: a `ResizeObserver` on a width-constrained wrapper resets to the full list on resize, and a `useLayoutEffect` decrements the fitted count while the content overflows (`scrollWidth > clientWidth`), converging before paint. First and last crumbs always stay visible.

#
### Tests:

#### Use cases covered
- Long labels no longer wrap mid-word; the trail stays on one line.
- In a narrow/resizing container with `autoCollapse`, middle crumbs collapse into the `…` menu and re-expand as space allows; first and last crumbs remain.

#### Unit tests
- [ ] Not applicable — presentational/layout behaviour; covered by build/type-check and a resizable Storybook story.

#### Backend integration tests
- [x] Not applicable (no backend changes).

#### Ingestion integration tests
- [x] Not applicable (no ingestion changes).

#### Playwright (UI) tests
- [x] Not applicable — library component.

#### Manual testing performed
1. `yarn type-check` — passed.
2. `yarn build` (ES + CJS + d.ts) — passed.
3. ESLint `--fix` and Prettier `--check` on changed files — clean.
4. Reviewable via `yarn storybook` → Components/Breadcrumbs → AutoCollapse (drag the container's resize handle).

#
### UI screen recording / screenshots:

Storybook AutoCollapse story added (resizable container). No production screen changed by this library PR.

#
### Checklist:
- [x] I have read the **CONTRIBUTING** document.
- [x] I have commented on my code, particularly in hard-to-understand areas.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds an `autoCollapse` prop to the `Breadcrumbs` component that uses a `ResizeObserver` + `useLayoutEffect` convergence loop to progressively collapse middle crumbs into the existing `…` menu when the container is too narrow to fit them all. It also unconditionally applies `whitespace-nowrap` to all crumb labels and `shrink-0` to all crumb items, preventing mid-word wrapping regardless of the `autoCollapse` flag.

- **`autoCollapse` logic**: A `ResizeObserver` on the outer wrapper resets `fittedCount` to `items.length` on every resize; a `useLayoutEffect` then decrements `fittedCount` one step at a time while `scrollWidth > clientWidth`, converging before paint. First and last crumbs are always preserved (`fittedCount > 2` guard).
- **Global layout fix**: `tw:whitespace-nowrap` on `CrumbLabel` and `tw:shrink-0` on each `AriaBreadcrumb` are applied for all usages, not just `autoCollapse`, stopping mid-word line breaks across the board.
- **Storybook story**: An `AutoCollapse` story with a CSS-resizable container is added to exercise the collapsing behaviour interactively.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge for new autoCollapse usage; the collapse loop and ResizeObserver wiring are sound, but middle crumbs can remain unnecessarily collapsed after navigating to a sibling route with the same number of crumbs.

The convergence loop, ResizeObserver setup, and first/last-crumb preservation all work correctly. The one correctness gap — useEffect depending on items.length rather than the items reference — means that switching between sibling routes with the same crumb depth never resets fittedCount, leaving the trail more collapsed than necessary until the next container resize.

breadcrumbs.tsx — specifically the useEffect dependency array and the remeasure reset logic when items change at equal depth.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-ui-core-components/src/main/resources/ui/src/components/application/breadcrumbs/breadcrumbs.tsx | Adds autoCollapse prop with ResizeObserver + useLayoutEffect convergence loop; also unconditionally applies whitespace-nowrap and shrink-0. Known issue: useEffect depends on items.length instead of items, so same-depth navigation leaves fittedCount stale. |
| openmetadata-ui-core-components/src/main/resources/ui/src/stories/Breadcrumbs.stories.tsx | Adds AutoCollapse story with a resizable container wrapper using deepItems; clean addition with no issues. |

</details>

</details>

<details open><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Render Breadcrumbs
autoCollapse=true] --> B[fittedCount = items.length
measureKey = 0]
    B --> C[useLayoutEffect fires
before paint]
    C --> D{ol.scrollWidth >
ol.clientWidth + 1
AND fittedCount > 2?}
    D -- Yes --> E[setFittedCount fittedCount - 1
Re-render]
    E --> C
    D -- No --> F[Browser paints
collapsed trail]
    F --> G[useEffect fires
after paint]
    G --> H[ResizeObserver.observe el
fonts.ready.then remeasure]
    H --> I{Container
resized or
fonts loaded?}
    I -- Yes --> J[remeasure:
setFittedCount items.length
requestMeasure]
    J --> C
    I -- No --> I
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Render Breadcrumbs
autoCollapse=true] --> B[fittedCount = items.length
measureKey = 0]
    B --> C[useLayoutEffect fires
before paint]
    C --> D{ol.scrollWidth >
ol.clientWidth + 1
AND fittedCount > 2?}
    D -- Yes --> E[setFittedCount fittedCount - 1
Re-render]
    E --> C
    D -- No --> F[Browser paints
collapsed trail]
    F --> G[useEffect fires
after paint]
    G --> H[ResizeObserver.observe el
fonts.ready.then remeasure]
    H --> I{Container
resized or
fonts loaded?}
    I -- Yes --> J[remeasure:
setFittedCount items.length
requestMeasure]
    J --> C
    I -- No --> I
```

</a>
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(ui-core-components): make Breadcrumb..."](https://github.com/open-metadata/openmetadata/commit/e79ff3cb83bd838821dd0df975276d7197c5868c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37907879)</sub>

<!-- /greptile_comment -->