### PR TITLE
playwright(ui): deflake Teams private-team profile test — drop racy user-refetch wait

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/Teams.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/Teams.spec.ts
@@ -470,17 +470,9 @@ test.describe('Teams Page', () => {
           !response.url().includes('/api/v1/users/name/') &&
           response.request().method() === 'PATCH'
       );
-      const userPromise = page.waitForResponse(
-        (response) =>
-          response.url().includes('/api/v1/users/name/') &&
-          response.url().includes('fields=profile') &&
-          response.request().method() === 'GET'
-      );
       await page.getByTestId('teams-edit-save-btn').click();
       const patchResponse = await patchUserPromise;
       expect(patchResponse.status()).toBe(200);
-      const userResponse = await userPromise;
-      expect(userResponse.status()).toBe(200);
 
       await expect(
         page.getByTestId('profile-teams-edit-popover')


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:

<!--
Linking an issue is REQUIRED. Replace <issue-number> with the GitHub issue number this PR addresses
(e.g., `Fixes #12345`). GitHub will auto-link it. If no issue exists, please open one first so the
problem and design can be discussed before review.
-->

<!--
Short blurb explaining:
- What changes did you make?
- Why did you make them?
-->

## Problem

The Playwright test `Teams Page › Create a new private team and check if its visible to admin in teams selection dropdown on user profile` (`Teams.spec.ts`) hangs ~2.6m and times out on `1.13`.

The trace shows the PATCH `waitForResponse` resolves immediately, but the
second wait — a `GET /api/v1/users/name/{name}?fields=profile` — never
resolves.

## Root cause

The assertion waits for a refetch the app never deterministically makes:

- Saving teams on the profile (`UserProfileTeams` → `UserPage.updateUserDetails`) issues a **PATCH** and updates local React state from the response (including inherited `domains`). No GET refetch — intentional since #25332 ("fix repeated calls for user").
- The `GET .../users/name?fields=profile` the test waits for is the **avatar fetch** in `useUserProfile`, cached per name in the `userProfilePics` store. It fires once at page load, not after save.

The relevant source (`UserPage`, `useUserProfile`, `useApplicationStore`,`UserProfileTeams`, and the test itself) is **identical between `main` and `1.13`** — there's no behavioral divergence. The GET landing inside the wait window after `save` is a cache/mount-timing artifact, so the assertion is inherently racy on both branches; `main` passes only by timing luck.

The strict GET-wait was introduced by #28899 ("fix flaky online users & Teams spec"), which replaced a loose `waitForResponse('/api/v1/users/*')` (that matched the PATCH and resolved instantly) with a wait for a refetch that
doesn't happen.


### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### High-level design:
<!--
REQUIRED for large PRs (new features, refactors, breaking changes, or anything touching >5 files).
Skip for small bug fixes and trivial changes.

Cover:
- Architecture / approach you took and why
- Key components or files added/changed and how they interact
- Alternatives considered and why you rejected them
- Any migration, backward-compatibility, or rollout concerns
- Diagrams or links to design docs / RFCs if available
-->

N/A — small change. <!-- Or fill in the design above -->

#
### Tests:

#### Use cases covered
<!--
List the user-visible scenarios this PR exercises. Example:
- User with Admin role can create a Glossary Term with a parent term
- Ingestion run for Snowflake correctly extracts row counts for partitioned tables
-->

#### Unit tests
<!--
- [ ] I added unit tests for the new/changed logic.
- Files added/updated:
- Coverage on changed classes (run `mvn jacoco:report` for backend, `yarn test:coverage` for UI,
  `make unit_ingestion` for ingestion). Target is 90% line coverage on changed classes.
- Coverage %: <e.g., 92% on EntityRepository.java>
-->

#### Backend integration tests
<!--
- [ ] I added integration tests in `openmetadata-integration-tests/` for new/changed API endpoints.
- [ ] Not applicable (no backend API changes).
- Files added/updated:
-->

#### Ingestion integration tests
<!--
- [ ] I added/updated ingestion integration tests for connector changes.
- [ ] Not applicable (no ingestion changes).
- Files added/updated:
-->

#### Playwright (UI) tests
<!--
- [ ] I added Playwright E2E tests under `openmetadata-ui/.../ui/playwright/` for UI changes.
- [ ] Not applicable (no UI changes).
- Files added/updated:
-->

#### Manual testing performed
<!--
List the manual test steps you performed before requesting review. Example:
1. Started local stack via `./docker/run_local_docker.sh -m ui -d mysql`
2. Logged in as admin, created entity X, verified Y appears in the UI
3. Triggered ingestion for Snowflake source, confirmed lineage edges in the explore page
-->

#
### UI screen recording / screenshots:
<!--
REQUIRED for any PR that changes the UI. Drag-and-drop a short screen recording (.mov / .mp4 / .gif)
demonstrating the change end-to-end, plus before/after screenshots where relevant.
Mark "Not applicable" if there are no UI changes.
-->

Not applicable. <!-- Or attach recording/screenshots above -->

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.
- [ ] For UI changes: I attached a screen recording and/or screenshots above.
- [ ] I have added tests (unit / integration / Playwright as applicable) and listed them above.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR removes a racy `waitForResponse` for a `GET /api/v1/users/name/{name}?fields=profile` call that was causing the private-team profile test to hang and time out. The GET wait was introduced in #28899 but targets a response the app never deterministically fires after a save — the avatar fetch is cached and fires once at page load, not post-PATCH.

- The PATCH `waitForResponse` (which does resolve reliably after save) and both UI assertions are preserved, keeping the test's correctness signal intact.
- The removal aligns with the actual app behavior: `UserPage` updates local React state from the PATCH response directly, with no follow-up GET refetch (intentional since #25332).
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change only removes a wait that was never guaranteed to fire, while keeping the PATCH wait and UI assertions that correctly verify the save succeeded.

The removed lines waited for a GET response that the application intentionally does not issue after a save (the PATCH response updates React state directly). The test still waits for the PATCH to complete and then asserts both the popover dismissal and the team appearing in the profile, giving strong end-to-end coverage without the flaky dependency.

No files require special attention.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/Teams.spec.ts | Removes a non-deterministic GET waitForResponse that caused ~2.6 min hangs; PATCH wait and UI assertions are intact. |

</details>

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Test as Playwright Test
    participant Browser as Browser / App
    participant API as Backend API

    Test->>Browser: page.getByTestId('edit-teams-button').click()
    Browser->>Test: popover visible

    Test->>Browser: click team name in popover
    Test->>Test: set up patchUserPromise (waitForResponse PATCH)
    Test->>Browser: page.getByTestId('teams-edit-save-btn').click()
    Browser->>API: "PATCH /api/v1/users/{id}"
    API-->>Browser: 200 OK (updates local React state)
    Browser-->>Test: patchUserPromise resolves
    Test->>Test: "assert patchResponse.status() === 200"

    Note over Browser: REMOVED: waitForResponse GET /api/v1/users/name/?fields=profile (cached avatar fetch — fires once at page load, not after save)

    Test->>Browser: expect popover NOT visible
    Test->>Browser: click team name in user-profile-teams
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Test as Playwright Test
    participant Browser as Browser / App
    participant API as Backend API

    Test->>Browser: page.getByTestId('edit-teams-button').click()
    Browser->>Test: popover visible

    Test->>Browser: click team name in popover
    Test->>Test: set up patchUserPromise (waitForResponse PATCH)
    Test->>Browser: page.getByTestId('teams-edit-save-btn').click()
    Browser->>API: "PATCH /api/v1/users/{id}"
    API-->>Browser: 200 OK (updates local React state)
    Browser-->>Test: patchUserPromise resolves
    Test->>Test: "assert patchResponse.status() === 200"

    Note over Browser: REMOVED: waitForResponse GET /api/v1/users/name/?fields=profile (cached avatar fetch — fires once at page load, not after save)

    Test->>Browser: expect popover NOT visible
    Test->>Browser: click team name in user-profile-teams
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["playwright(ui): deflake Teams private-te..."](https://github.com/open-metadata/openmetadata/commit/815911dd5595b133c1ac4188fac2dfb6be39eca1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37940762)</sub>

<!-- /greptile_comment -->