### PR TITLE
Fixes #29086: Re-add --recreate-indexes flag to reindex CLI for backward compatibility

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/util/OpenMetadataOperations.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/util/OpenMetadataOperations.java
@@ -1357,7 +1357,7 @@ public class OpenMetadataOperations implements Callable<Integer> {
       @Option(
               names = {"--recreate-indexes"},
               defaultValue = "true",
-              description = "Flag to determine if indexes should be recreated.")
+              description = "Deprecated only here for backward compatibilty, won't have any effect.")
           boolean recreateIndexes,
       @Option(
               names = {"--force"},

--- a/openmetadata-service/src/main/java/org/openmetadata/service/util/OpenMetadataOperations.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/util/OpenMetadataOperations.java
@@ -1357,7 +1357,8 @@ public class OpenMetadataOperations implements Callable<Integer> {
       @Option(
               names = {"--recreate-indexes"},
               defaultValue = "true",
-              description = "Deprecated only here for backward compatibilty, won't have any effect.")
+              description =
+                  "Deprecated only here for backward compatibilty, won't have any effect.")
           boolean recreateIndexes,
       @Option(
               names = {"--force"},

--- a/openmetadata-service/src/main/java/org/openmetadata/service/util/OpenMetadataOperations.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/util/OpenMetadataOperations.java
@@ -1355,6 +1355,11 @@ public class OpenMetadataOperations implements Callable<Integer> {
                   "Enable automatic performance tuning based on cluster capabilities and database entity count. When enabled, overrides manual parameter settings.")
           boolean autoTune,
       @Option(
+              names = {"--recreate-indexes"},
+              defaultValue = "true",
+              description = "Flag to determine if indexes should be recreated.")
+          boolean recreateIndexes,
+      @Option(
               names = {"--force"},
               defaultValue = "false",
               description = "Force reindexing even if no index mapping changes are detected.")


### PR DESCRIPTION
## Describe your changes

Re-adds the `--recreate-indexes` option to the `reindex` command in `OpenMetadataOperations`.

PR #28402 dropped this option because the search reindex always runs in recreate mode, making the flag functionally dead in the reindex path. However, picocli rejects unknown options (the `reindex` command does not enable `unmatchedArgumentsAllowed`), so existing scripts and scheduled jobs that still pass `--recreate-indexes` started failing with an "Unknown option" error before any reindexing could begin.

This change brings the option back as an **accepted-but-unused** parameter (default `true`):

- Reindex behavior is unchanged — it still always recreates the indexes.
- The flag's value is intentionally not threaded into `executeSearchReindexApp`; it exists purely so existing CLI invocations keep working.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How was this tested

- `mvn spotless:check -pl openmetadata-service` passes.
- `openmetadata-ops.sh reindex --recreate-indexes=true` is accepted again instead of erroring on an unknown option; reindex runs and recreates as before.

Fixes #29086

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Re-adds `--recreate-indexes` to the `reindex` CLI subcommand as an accepted-but-unused option (default `true`) so that existing scripts passing the flag no longer fail with picocli's "Unknown option" error, while leaving reindex behavior unchanged.

- The option is declared with a deprecation notice in its description and is intentionally never forwarded to `executeSearchReindexApp`; reindexing always recreates indexes regardless of the flag's value.
- The change is minimal and isolated to a single parameter declaration; no logic paths are altered.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The change is a no-op backward-compatibility shim — it only registers a previously-removed CLI flag so existing invocations no longer error out; no reindex logic is altered.

A single parameter annotation is added with no downstream wiring. The flag's value is never read by any business logic, so there is no risk of changed behavior.

No files require special attention.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-service/src/main/java/org/openmetadata/service/util/OpenMetadataOperations.java | Re-adds `--recreate-indexes` as an accepted-but-unused boolean option (default `true`) in the `reindex` subcommand to restore backward compatibility for existing CLI scripts. |

</details>

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Script as CLI Script
    participant Picocli as Picocli Parser
    participant Reindex as reindex command
    participant App as executeSearchReindexApp

    Script->>Picocli: "reindex --recreate-indexes=true ..."
    Note over Picocli: Previously: Unknown option error
    Note over Picocli: Now: Option accepted
    Picocli->>Reindex: "recreateIndexes=true (parsed, not forwarded)"
    Reindex->>App: executeSearchReindexApp(params...)
    Note over App: Always recreates indexes regardless of flag
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Script as CLI Script
    participant Picocli as Picocli Parser
    participant Reindex as reindex command
    participant App as executeSearchReindexApp

    Script->>Picocli: "reindex --recreate-indexes=true ..."
    Note over Picocli: Previously: Unknown option error
    Note over Picocli: Now: Option accepted
    Picocli->>Reindex: "recreateIndexes=true (parsed, not forwarded)"
    Reindex->>App: executeSearchReindexApp(params...)
    Note over App: Always recreates indexes regardless of flag
```

</a>
</details>

<sub>Reviews (3): Last reviewed commit: ["Fix Check Style"](https://github.com/open-metadata/openmetadata/commit/146d127f4741125673d733c642aced76b2c9e36b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37967575)</sub>

<!-- /greptile_comment -->