### PR TITLE
fix(service): deflake column-search integration tests

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/TestCaseRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/TestCaseRepository.java
@@ -157,7 +157,7 @@ public class TestCaseRepository extends EntityRepository<TestCase> {
         fields.contains(INCIDENTS_FIELD) ? getIncidentId(test) : test.getIncidentId());
   }
 
-  private final ThreadLocal<Map<String, Table>> linkedTablesCache = new ThreadLocal<>();
+  private static final ThreadLocal<Map<String, Table>> linkedTablesCache = new ThreadLocal<>();
 
   @Override
   public void setFieldsInBulk(Fields fields, List<TestCase> testCases) {

--- a/openmetadata-service/src/main/java/org/openmetadata/service/tasks/TaskFormSchemaValidator.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/tasks/TaskFormSchemaValidator.java
@@ -14,6 +14,9 @@
 
 package org.openmetadata.service.tasks;
 
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
 import com.networknt.schema.Error;
 import com.networknt.schema.Schema;
 import java.util.List;
@@ -22,6 +25,9 @@ import org.openmetadata.schema.utils.JsonUtils;
 
 /** Validates persisted task payload schemas and payload instances against those schemas. */
 public final class TaskFormSchemaValidator {
+
+  private static final LoadingCache<String, Schema> SCHEMA_CACHE =
+      CacheBuilder.newBuilder().maximumSize(256).build(CacheLoader.from(JsonUtils::getJsonSchema));
 
   private TaskFormSchemaValidator() {
     /* Utility class */
@@ -56,9 +62,10 @@ public final class TaskFormSchemaValidator {
     }
 
     try {
-      return JsonUtils.getJsonSchema(JsonUtils.pojoToJson(formSchema));
+      return SCHEMA_CACHE.get(JsonUtils.pojoToJson(formSchema));
     } catch (Exception e) {
-      throw new IllegalArgumentException("Invalid task form schema: " + e.getMessage(), e);
+      Throwable cause = e.getCause() != null ? e.getCause() : e;
+      throw new IllegalArgumentException("Invalid task form schema: " + cause.getMessage(), e);
     }
   }
 }

--- a/openmetadata-spec/src/main/java/org/openmetadata/schema/utils/JsonUtils.java
+++ b/openmetadata-spec/src/main/java/org/openmetadata/schema/utils/JsonUtils.java
@@ -518,7 +518,11 @@ public final class JsonUtils {
   }
 
   public static Schema getJsonSchema(String schema) {
-    return schemaFactory.getSchema(schema);
+    // SchemaRegistry compiles schemas against shared dialect/metaschema caches that are not safe
+    // under concurrent compilation; serialize compilation to avoid transient failures.
+    synchronized (schemaFactory) {
+      return schemaFactory.getSchema(schema);
+    }
   }
 
   public static JsonNode valueToTree(Object object) {


### PR DESCRIPTION
### Describe your changes:

Fixes #<ISSUE_NUMBER — please fill in>

Two backend integration tests (`ColumnSearchIndexIT`, `ColumnCustomPropertiesIT`) failed intermittently under concurrent execution due to two unrelated thread-safety bugs, both fixed here. `TestCaseRepository.linkedTablesCache` is now a `static` `ThreadLocal` so it can never be `null` when the request-boundary `clearRepositoryThreadLocals()` reaches a repository that the base `EntityRepository` constructor published to the registry *before* the subclass field initializer ran (a this-escape during construction). `JsonUtils.getJsonSchema` now serializes networknt `SchemaRegistry` compilation, which races on shared dialect/metaschema caches under concurrent compiles and was intermittently leaving custom properties unregistered (surfacing later as "Unknown custom field" during column-extension validation). `TaskFormSchemaValidator` additionally caches compiled form schemas in a bounded Guava `LoadingCache`, so the per-task-write compile path keeps that lock effectively uncontended.

#
### Type of change:
- [x] Bug fix

#
### High-level design:

N/A — small change (3 files, concurrency-only).

#
### Tests:

#### Use cases covered
- Concurrent test-case list/field reads no longer NPE on a repository that is mid-construction when `clearRepositoryThreadLocals()` runs.
- Concurrent custom-property registration across entity types reliably registers JSON schemas (no spurious "Unknown custom field").

#### Backend integration tests
- [x] Covered by the existing `ColumnSearchIndexIT` and `ColumnCustomPropertiesIT` suites — these were the flaky tests this PR deflakes.

#### Manual testing performed
- `mvn spotless:check` passes on both changed modules; offline `compile` of `openmetadata-spec` and `openmetadata-service` succeeds.

#
### UI screen recording / screenshots:

Not applicable — no UI changes.

#
### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] I have commented on my code, particularly in hard-to-understand areas.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes two independent thread-safety bugs that caused `ColumnSearchIndexIT` and `ColumnCustomPropertiesIT` to flake under concurrent execution. All three changed files touch only concurrency mechanics with no logic changes.

- **`TestCaseRepository`**: `linkedTablesCache` promoted from `private final` to `private static final` `ThreadLocal`. The base `EntityRepository` constructor calls `Entity.registerEntity(…, this)` before subclass field initializers run; a concurrent `clearRepositoryThreadLocals()` call could reach `clearParentCache()` on the partially-constructed instance while `linkedTablesCache` is still `null`, triggering an NPE. Making it `static` means the field is class-initialized before any constructor runs.
- **`JsonUtils.getJsonSchema`**: Wrapped `schemaFactory.getSchema(schema)` in `synchronized (schemaFactory)`. networknt's `SchemaRegistry` mutates shared dialect/metaschema caches during compilation, which is unsafe under concurrent calls; serializing on the factory object eliminates the race.
- **`TaskFormSchemaValidator`**: Added a 256-entry Guava `LoadingCache<String, Schema>` so repeated compilations of the same form schema hit the cache rather than re-entering the global `synchronized` block. Exception handling is updated to unwrap Guava's `ExecutionException` wrapper before surfacing the message.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — all three changes are narrowly scoped concurrency fixes with no logic changes, no schema or API surface changes, and no altered behaviour on the happy path.

Each fix addresses a clearly identified race: the static ThreadLocal eliminates the this-escape NPE window, the synchronized block on schemaFactory serializes non-thread-safe SchemaRegistry compilation, and the LoadingCache reduces contention without changing observable outcomes. The existing test suites cover the repaired paths. No new mutable shared state is introduced, and cleanup paths (ThreadLocal.remove in finally blocks) remain intact.

No files require special attention. All changes are self-contained within the three modified files.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/TestCaseRepository.java | Made linkedTablesCache a static final ThreadLocal to prevent NPE when clearRepositoryThreadLocals() is called on a partially-constructed instance published via this-escape in the base EntityRepository constructor. |
| openmetadata-spec/src/main/java/org/openmetadata/schema/utils/JsonUtils.java | Added synchronized(schemaFactory) around schemaFactory.getSchema() to serialize networknt SchemaRegistry compilation, fixing a race on its shared dialect/metaschema caches that caused intermittent "Unknown custom field" failures. |
| openmetadata-service/src/main/java/org/openmetadata/service/tasks/TaskFormSchemaValidator.java | Added a bounded Guava LoadingCache for compiled form schemas to avoid redundant compilations and reduce lock contention on the global schemaFactory lock; exception handling now correctly unwraps Guava's ExecutionException wrapper. |

</details>

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant T1 as Thread 1 (request)
    participant T2 as Thread 2 (cleanup filter)
    participant ECR as Entity Constructor (base)
    participant ECRT as TestCaseRepository (subclass)
    participant ERM as ENTITY_REPOSITORY_MAP
    participant TL as linkedTablesCache (ThreadLocal)

    Note over ECR,ECRT: Before fix — this-escape NPE path
    ECR->>ERM: registerEntity(this) [subclass fields not yet initialized]
    T2->>ERM: clearRepositoryThreadLocals()
    ERM->>ECRT: clearParentCache()
    ECRT->>TL: linkedTablesCache.remove() ← NPE (field is null)

    Note over ECR,ECRT: After fix — static field initialized at class load
    Note over TL: static final ThreadLocal initialized before any constructor
    ECR->>ERM: registerEntity(this)
    T2->>ERM: clearRepositoryThreadLocals()
    ERM->>ECRT: clearParentCache()
    ECRT->>TL: linkedTablesCache.remove() ← safe (static, always initialized)

    Note over T1,TL: Schema compilation race (JsonUtils / TaskFormSchemaValidator)
    T1->>TaskFormSchemaValidator: validatePayload(formSchema, payload)
    TaskFormSchemaValidator->>LoadingCache: get(jsonKey)
    LoadingCache->>JsonUtils: getJsonSchema(jsonKey) [cache miss]
    JsonUtils->>JsonUtils: "synchronized(schemaFactory) { schemaFactory.getSchema(...) }"
    JsonUtils-->>LoadingCache: Schema
    LoadingCache-->>TaskFormSchemaValidator: cached Schema
    TaskFormSchemaValidator->>Schema: validate(payloadNode) [thread-safe read]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant T1 as Thread 1 (request)
    participant T2 as Thread 2 (cleanup filter)
    participant ECR as Entity Constructor (base)
    participant ECRT as TestCaseRepository (subclass)
    participant ERM as ENTITY_REPOSITORY_MAP
    participant TL as linkedTablesCache (ThreadLocal)

    Note over ECR,ECRT: Before fix — this-escape NPE path
    ECR->>ERM: registerEntity(this) [subclass fields not yet initialized]
    T2->>ERM: clearRepositoryThreadLocals()
    ERM->>ECRT: clearParentCache()
    ECRT->>TL: linkedTablesCache.remove() ← NPE (field is null)

    Note over ECR,ECRT: After fix — static field initialized at class load
    Note over TL: static final ThreadLocal initialized before any constructor
    ECR->>ERM: registerEntity(this)
    T2->>ERM: clearRepositoryThreadLocals()
    ERM->>ECRT: clearParentCache()
    ECRT->>TL: linkedTablesCache.remove() ← safe (static, always initialized)

    Note over T1,TL: Schema compilation race (JsonUtils / TaskFormSchemaValidator)
    T1->>TaskFormSchemaValidator: validatePayload(formSchema, payload)
    TaskFormSchemaValidator->>LoadingCache: get(jsonKey)
    LoadingCache->>JsonUtils: getJsonSchema(jsonKey) [cache miss]
    JsonUtils->>JsonUtils: "synchronized(schemaFactory) { schemaFactory.getSchema(...) }"
    JsonUtils-->>LoadingCache: Schema
    LoadingCache-->>TaskFormSchemaValidator: cached Schema
    TaskFormSchemaValidator->>Schema: validate(payloadNode) [thread-safe read]
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(service): deflake column-search inte..."](https://github.com/open-metadata/openmetadata/commit/26c7021996e9b3ea7cc7133ec2b3273e8548129a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38050131)</sub>

<!-- /greptile_comment -->