### PR TITLE
fix(cache): extend immutable Cache-Control header to /images/ path

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/socket/OpenMetadataAssetServlet.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/socket/OpenMetadataAssetServlet.java
@@ -45,7 +45,6 @@ public class OpenMetadataAssetServlet extends AssetServlet {
       Set.of(
           "js", "css", "map", "json", "txt", "html", "ico", "png", "jpg", "jpeg", "svg", "gif",
           "webp", "woff", "woff2", "ttf", "eot", "otf", "pdf", "md");
-
   // Matches Vite's content-hash filename pattern, e.g. `index-Z3O_FBkA.js`,
   // `MyComponent.component-a1b2c3d4.css`. The hash chunk is base64url and at
   // least 8 chars — long enough to make accidental collisions vanishingly
@@ -54,6 +53,8 @@ public class OpenMetadataAssetServlet extends AssetServlet {
   private static final Pattern HASHED_ASSET =
       Pattern.compile(".*-[A-Za-z0-9_-]{8,}\\.[a-z0-9]+(\\.br|\\.gz)?$");
 
+  private static final String ASSETS_PREFIX = "/assets/";
+  private static final String IMAGES_PREFIX = "/images/";
   private static final String IMMUTABLE_CACHE = "public, max-age=31536000, immutable";
 
   // The HTML shell points at hash-named JS chunks, so it MUST be re-fetched
@@ -217,7 +218,7 @@ public class OpenMetadataAssetServlet extends AssetServlet {
   private void applyCacheControl(HttpServletRequest req, HttpServletResponse resp) {
     String requestUri = req.getRequestURI();
     String pathToCheck = stripBasePath(requestUri);
-    if ((pathToCheck.startsWith("/assets/") || pathToCheck.startsWith("/images/"))
+    if ((pathToCheck.startsWith(ASSETS_PREFIX) || pathToCheck.startsWith(IMAGES_PREFIX))
         && HASHED_ASSET.matcher(pathToCheck).matches()) {
       resp.setHeader("Cache-Control", IMMUTABLE_CACHE);
       return;
@@ -435,8 +436,8 @@ public class OpenMetadataAssetServlet extends AssetServlet {
     }
 
     // Known static resource directories should not be rewritten.
-    if (pathToCheck.startsWith("/assets/")
-        || pathToCheck.startsWith("/images/")
+    if (pathToCheck.startsWith(ASSETS_PREFIX)
+        || pathToCheck.startsWith(IMAGES_PREFIX)
         || pathToCheck.startsWith("/favicons/")) {
       return false;
     }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/socket/OpenMetadataAssetServlet.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/socket/OpenMetadataAssetServlet.java
@@ -198,9 +198,10 @@ public class OpenMetadataAssetServlet extends AssetServlet {
    * Pick a {@code Cache-Control} policy by path shape.
    *
    * <ul>
-   *   <li><b>Hashed assets under {@code /assets/}</b> — names are content-addressed by Vite
-   *       (e.g. {@code index-Z3O_FBkA.js}). The filename changes whenever the body changes, so
-   *       the browser can cache forever and not even ask the server again. Emit
+   *   <li><b>Hashed assets under {@code /assets/} and {@code /images/}</b> — names are
+   *       content-addressed by Vite (e.g. {@code index-Z3O_FBkA.js},
+   *       {@code landing-page-header-bg-DcT5-tmD.svg}). The filename changes whenever the body
+   *       changes, so the browser can cache forever and not even ask the server again. Emit
    *       {@code public, max-age=31536000, immutable}.
    *   <li><b>SPA HTML / fallback routes</b> — the shell that references the hashed asset names.
    *       Must NOT be long-cached, else a fresh deploy lands and clients keep a stale shell
@@ -216,7 +217,8 @@ public class OpenMetadataAssetServlet extends AssetServlet {
   private void applyCacheControl(HttpServletRequest req, HttpServletResponse resp) {
     String requestUri = req.getRequestURI();
     String pathToCheck = stripBasePath(requestUri);
-    if (pathToCheck.startsWith("/assets/") && HASHED_ASSET.matcher(pathToCheck).matches()) {
+    if ((pathToCheck.startsWith("/assets/") || pathToCheck.startsWith("/images/"))
+        && HASHED_ASSET.matcher(pathToCheck).matches()) {
       resp.setHeader("Cache-Control", IMMUTABLE_CACHE);
       return;
     }

--- a/openmetadata-service/src/test/java/org/openmetadata/service/socket/OpenMetadataAssetServletTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/socket/OpenMetadataAssetServletTest.java
@@ -310,6 +310,25 @@ public class OpenMetadataAssetServletTest {
   }
 
   @Test
+  public void testUnhashedImageDoesNotGetImmutableCacheControl() throws Exception {
+    String path = "/images/logo.png";
+    when(request.getRequestURI()).thenReturn(path);
+    when(request.getContextPath()).thenReturn("");
+    when(request.getPathInfo()).thenReturn(path);
+    when(request.getServletPath()).thenReturn("");
+    when(request.getHeader("Accept-Encoding")).thenReturn(null);
+    when(request.getMethod()).thenReturn("GET");
+    when(request.getDateHeader(anyString())).thenReturn(-1L);
+    when(request.getHeader("If-None-Match")).thenReturn(null);
+    when(request.getHeader("If-Modified-Since")).thenReturn(null);
+
+    servlet.doGet(request, response);
+
+    verify(response, never())
+        .setHeader(eq("Cache-Control"), eq("public, max-age=31536000, immutable"));
+  }
+
+  @Test
   public void testUnhashedAssetDoesNotGetImmutableCacheControl() throws Exception {
     // {@code manifest.json} ships under {@code /assets/} without a content hash,
     // so the immutable header would be wrong (a future deploy could change the file

--- a/openmetadata-service/src/test/java/org/openmetadata/service/socket/OpenMetadataAssetServletTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/socket/OpenMetadataAssetServletTest.java
@@ -1,5 +1,6 @@
 package org.openmetadata.service.socket;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.*;
@@ -13,6 +14,7 @@ import java.io.StringWriter;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.MockedStatic;
 import org.mockito.MockitoAnnotations;
@@ -37,6 +39,26 @@ public class OpenMetadataAssetServletTest {
 
     // Initialize servlet with /assets as resource path
     servlet = new OpenMetadataAssetServlet("/", "/assets", "/", "index.html", webConfiguration);
+  }
+
+  private void assertFinalCacheControlHeader(String expectedValue) {
+    ArgumentCaptor<String> cacheControlValues = ArgumentCaptor.forClass(String.class);
+    verify(response, atLeastOnce()).setHeader(eq("Cache-Control"), cacheControlValues.capture());
+
+    List<String> capturedValues = cacheControlValues.getAllValues();
+    assertEquals(expectedValue, capturedValues.get(capturedValues.size() - 1));
+  }
+
+  private void mockStaticAssetRequest(String path) {
+    when(request.getRequestURI()).thenReturn(path);
+    when(request.getContextPath()).thenReturn("");
+    when(request.getPathInfo()).thenReturn(path);
+    when(request.getServletPath()).thenReturn("");
+    when(request.getHeader("Accept-Encoding")).thenReturn(null);
+    when(request.getMethod()).thenReturn("GET");
+    when(request.getDateHeader(anyString())).thenReturn(-1L);
+    when(request.getHeader("If-None-Match")).thenReturn(null);
+    when(request.getHeader("If-Modified-Since")).thenReturn(null);
   }
 
   @Test
@@ -275,57 +297,41 @@ public class OpenMetadataAssetServletTest {
   @Test
   public void testHashedAssetGetsImmutableCacheControl() throws Exception {
     String path = "/assets/index-Z3O_FBkA.js";
-    when(request.getRequestURI()).thenReturn(path);
-    when(request.getContextPath()).thenReturn("");
-    when(request.getPathInfo()).thenReturn(path);
-    when(request.getServletPath()).thenReturn("");
-    when(request.getHeader("Accept-Encoding")).thenReturn(null);
-    when(request.getMethod()).thenReturn("GET");
-    when(request.getDateHeader(anyString())).thenReturn(-1L);
-    when(request.getHeader("If-None-Match")).thenReturn(null);
-    when(request.getHeader("If-Modified-Since")).thenReturn(null);
+    when(webConfiguration.getCacheControl()).thenReturn("no-cache, no-store, must-revalidate");
+    mockStaticAssetRequest(path);
 
     servlet.doGet(request, response);
 
-    // Hashed filenames are content-addressed, so they're safe to cache forever.
-    verify(response).setHeader("Cache-Control", "public, max-age=31536000, immutable");
+    assertFinalCacheControlHeader("public, max-age=31536000, immutable");
   }
 
   @Test
-  public void testHashedImageGetsImmutableCacheControl() throws Exception {
-    String path = "/images/landing-page-header-bg-DcT5-tmD.svg";
-    when(request.getRequestURI()).thenReturn(path);
-    when(request.getContextPath()).thenReturn("");
-    when(request.getPathInfo()).thenReturn(path);
-    when(request.getServletPath()).thenReturn("");
-    when(request.getHeader("Accept-Encoding")).thenReturn(null);
-    when(request.getMethod()).thenReturn("GET");
-    when(request.getDateHeader(anyString())).thenReturn(-1L);
-    when(request.getHeader("If-None-Match")).thenReturn(null);
-    when(request.getHeader("If-Modified-Since")).thenReturn(null);
+  public void testHashedImageAssetsGetImmutableCacheControl() throws Exception {
+    when(webConfiguration.getCacheControl()).thenReturn("no-cache, no-store, must-revalidate");
 
-    servlet.doGet(request, response);
+    for (String path :
+        List.of(
+            "/images/logo-DcT5-tmD.png",
+            "/images/service-icon-kafka-Z3O_FBkA.webp",
+            "/images/landing-page-header-bg-DcT5-tmD.svg")) {
+      mockStaticAssetRequest(path);
 
-    verify(response).setHeader("Cache-Control", "public, max-age=31536000, immutable");
+      servlet.doGet(request, response);
+
+      assertFinalCacheControlHeader("public, max-age=31536000, immutable");
+      clearInvocations(response);
+    }
   }
 
   @Test
   public void testUnhashedImageDoesNotGetImmutableCacheControl() throws Exception {
     String path = "/images/logo.png";
-    when(request.getRequestURI()).thenReturn(path);
-    when(request.getContextPath()).thenReturn("");
-    when(request.getPathInfo()).thenReturn(path);
-    when(request.getServletPath()).thenReturn("");
-    when(request.getHeader("Accept-Encoding")).thenReturn(null);
-    when(request.getMethod()).thenReturn("GET");
-    when(request.getDateHeader(anyString())).thenReturn(-1L);
-    when(request.getHeader("If-None-Match")).thenReturn(null);
-    when(request.getHeader("If-Modified-Since")).thenReturn(null);
+    when(webConfiguration.getCacheControl()).thenReturn("no-cache, no-store, must-revalidate");
+    mockStaticAssetRequest(path);
 
     servlet.doGet(request, response);
 
-    verify(response, never())
-        .setHeader(eq("Cache-Control"), eq("public, max-age=31536000, immutable"));
+    assertFinalCacheControlHeader("no-cache, no-store, must-revalidate");
   }
 
   @Test
@@ -334,20 +340,12 @@ public class OpenMetadataAssetServletTest {
     // so the immutable header would be wrong (a future deploy could change the file
     // body while the URL stays the same).
     String path = "/assets/manifest.json";
-    when(request.getRequestURI()).thenReturn(path);
-    when(request.getContextPath()).thenReturn("");
-    when(request.getPathInfo()).thenReturn(path);
-    when(request.getServletPath()).thenReturn("");
-    when(request.getHeader("Accept-Encoding")).thenReturn(null);
-    when(request.getMethod()).thenReturn("GET");
-    when(request.getDateHeader(anyString())).thenReturn(-1L);
-    when(request.getHeader("If-None-Match")).thenReturn(null);
-    when(request.getHeader("If-Modified-Since")).thenReturn(null);
+    when(webConfiguration.getCacheControl()).thenReturn("no-cache, no-store, must-revalidate");
+    mockStaticAssetRequest(path);
 
     servlet.doGet(request, response);
 
-    verify(response, never())
-        .setHeader(eq("Cache-Control"), eq("public, max-age=31536000, immutable"));
+    assertFinalCacheControlHeader("no-cache, no-store, must-revalidate");
   }
 
   @Test

--- a/openmetadata-service/src/test/java/org/openmetadata/service/socket/OpenMetadataAssetServletTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/socket/OpenMetadataAssetServletTest.java
@@ -292,6 +292,24 @@ public class OpenMetadataAssetServletTest {
   }
 
   @Test
+  public void testHashedImageGetsImmutableCacheControl() throws Exception {
+    String path = "/images/landing-page-header-bg-DcT5-tmD.svg";
+    when(request.getRequestURI()).thenReturn(path);
+    when(request.getContextPath()).thenReturn("");
+    when(request.getPathInfo()).thenReturn(path);
+    when(request.getServletPath()).thenReturn("");
+    when(request.getHeader("Accept-Encoding")).thenReturn(null);
+    when(request.getMethod()).thenReturn("GET");
+    when(request.getDateHeader(anyString())).thenReturn(-1L);
+    when(request.getHeader("If-None-Match")).thenReturn(null);
+    when(request.getHeader("If-Modified-Since")).thenReturn(null);
+
+    servlet.doGet(request, response);
+
+    verify(response).setHeader("Cache-Control", "public, max-age=31536000, immutable");
+  }
+
+  @Test
   public void testUnhashedAssetDoesNotGetImmutableCacheControl() throws Exception {
     // {@code manifest.json} ships under {@code /assets/} without a content hash,
     // so the immutable header would be wrong (a future deploy could change the file


### PR DESCRIPTION
## Summary

- Hashed assets under `/images/` (e.g. `landing-page-header-bg-DcT5-tmD.svg`) were not receiving `public, max-age=31536000, immutable` Cache-Control header — only `/assets/` was checked
- Extends the path prefix condition in `OpenMetadataAssetServlet` to include `/images/`
- Adds regression test `testHashedImageGetsImmutableCacheControl`

## Test plan

- [ ] `testHashedImageGetsImmutableCacheControl` passes
- [ ] Verify `/images/` assets get `immutable` header in network tab after deploy

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a missing `Cache-Control: public, max-age=31536000, immutable` header for hashed static assets served from the `/images/` path, which was previously only applied to `/assets/`. It also extracts the two path prefix literals into named constants and refactors test helpers to avoid duplication.

- **`OpenMetadataAssetServlet.java`**: Introduces `ASSETS_PREFIX` and `IMAGES_PREFIX` constants and widens the `applyCacheControl` guard to OR both prefixes before the regex match; both constants are reused in the existing `isSpaRoute` check.
- **`OpenMetadataAssetServletTest.java`**: Adds `testHashedImageAssetsGetImmutableCacheControl` and `testUnhashedImageDoesNotGetImmutableCacheControl`, and extracts `mockStaticAssetRequest` / `assertFinalCacheControlHeader` helpers to eliminate copy-paste setup across test cases.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is a one-line condition widening with no side-effects outside the Cache-Control header path.

The fix is minimal and isolated: it adds two named constants and ORs a second prefix check before an existing regex guard that already correctly distinguishes hashed from unhashed filenames. The new tests cover both the positive case (multiple hashed image filenames) and the negative case (unhashed filename stays on the fallback policy), and the refactored assertion helper correctly captures the last Cache-Control value set by the two-phase header logic.

No files require special attention.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-service/src/main/java/org/openmetadata/service/socket/OpenMetadataAssetServlet.java | Adds ASSETS_PREFIX / IMAGES_PREFIX constants and extends the immutable Cache-Control condition to cover /images/; logic is minimal and correct. |
| openmetadata-service/src/test/java/org/openmetadata/service/socket/OpenMetadataAssetServletTest.java | Adds positive (hashed images get immutable) and negative (unhashed image does not) tests, plus shared setup/assertion helpers that reduce duplication. |

</details>

</details>

<details open><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[doGet] --> B[setSecurityHeader\nsets Cache-Control from webConfig]
    B --> C[applyCacheControl]
    C --> D{pathToCheck starts with\n/assets/ OR /images/?}
    D -- Yes --> E{HASHED_ASSET\nregex matches?}
    E -- Yes --> F[Set Cache-Control:\npublic, max-age=31536000, immutable]
    E -- No --> G{ends with / or .html,\nor isSpaRoute?}
    D -- No --> G
    G -- Yes --> H[Set Cache-Control:\nno-cache, must-revalidate]
    G -- No --> I[No override — keep\nwebConfig Cache-Control]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[doGet] --> B[setSecurityHeader\nsets Cache-Control from webConfig]
    B --> C[applyCacheControl]
    C --> D{pathToCheck starts with\n/assets/ OR /images/?}
    D -- Yes --> E{HASHED_ASSET\nregex matches?}
    E -- Yes --> F[Set Cache-Control:\npublic, max-age=31536000, immutable]
    E -- No --> G{ends with / or .html,\nor isSpaRoute?}
    D -- No --> G
    G -- Yes --> H[Set Cache-Control:\nno-cache, must-revalidate]
    G -- No --> I[No override — keep\nwebConfig Cache-Control]
```

</a>
</details>

<sub>Reviews (3): Last reviewed commit: ["minor updates"](https://github.com/open-metadata/openmetadata/commit/15c1a8a288091748d9d4f7f7914ccf4964b60a1b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38080576)</sub>

<!-- /greptile_comment -->