### PR TITLE
fix(security): bump spring, micrometer & pin opentelemetry to patch CVEs

### DIFF
--- a/openmetadata-k8s-operator/pom.xml
+++ b/openmetadata-k8s-operator/pom.xml
@@ -67,12 +67,12 @@
         <dependency>
             <groupId>io.micrometer</groupId>
             <artifactId>micrometer-registry-prometheus</artifactId>
-            <version>1.14.5</version>
+            <version>${micrometer.version}</version>
         </dependency>
         <dependency>
             <groupId>io.micrometer</groupId>
             <artifactId>micrometer-core</artifactId>
-            <version>1.14.5</version>
+            <version>${micrometer.version}</version>
         </dependency>
 
         <!-- Cron parsing for CronOMJob scheduling -->

--- a/openmetadata-service/pom.xml
+++ b/openmetadata-service/pom.xml
@@ -318,13 +318,9 @@
         </exclusion>
       </exclusions>
     </dependency>
-    <!-- Pin to match micrometer-registry-prometheus 1.15.x's prometheus-metrics 1.3.10;
-         the inherited Dropwizard BOM otherwise keeps this wrapper (and its -core/-model
-         children) at 1.3.6 while the exposition layer resolves to 1.3.10. -->
     <dependency>
       <groupId>io.prometheus</groupId>
       <artifactId>prometheus-metrics-instrumentation-dropwizard</artifactId>
-      <version>1.3.10</version>
     </dependency>
     <dependency>
       <groupId>io.dropwizard</groupId>

--- a/openmetadata-service/pom.xml
+++ b/openmetadata-service/pom.xml
@@ -514,7 +514,7 @@
     <dependency>
       <groupId>io.micrometer</groupId>
       <artifactId>micrometer-bom</artifactId>
-      <version>1.14.5</version>
+      <version>${micrometer.version}</version>
       <type>pom</type>
       <scope>import</scope>
     </dependency>
@@ -533,20 +533,20 @@
     <dependency>
       <groupId>io.micrometer</groupId>
       <artifactId>micrometer-observation</artifactId>
-      <version>1.14.5</version>
+      <version>${micrometer.version}</version>
     </dependency>
 
     <!-- Micrometer Prometheus -->
     <dependency>
       <groupId>io.micrometer</groupId>
       <artifactId>micrometer-registry-prometheus</artifactId>
-      <version>1.14.5</version>
+      <version>${micrometer.version}</version>
     </dependency>
 
     <dependency>
       <groupId>io.micrometer</groupId>
       <artifactId>micrometer-core</artifactId>
-      <version>1.14.5</version>
+      <version>${micrometer.version}</version>
     </dependency>
 
 

--- a/openmetadata-service/pom.xml
+++ b/openmetadata-service/pom.xml
@@ -318,9 +318,13 @@
         </exclusion>
       </exclusions>
     </dependency>
+    <!-- Pin to match micrometer-registry-prometheus 1.15.x's prometheus-metrics 1.3.10;
+         the inherited Dropwizard BOM otherwise keeps this wrapper (and its -core/-model
+         children) at 1.3.6 while the exposition layer resolves to 1.3.10. -->
     <dependency>
       <groupId>io.prometheus</groupId>
       <artifactId>prometheus-metrics-instrumentation-dropwizard</artifactId>
+      <version>1.3.10</version>
     </dependency>
     <dependency>
       <groupId>io.dropwizard</groupId>
@@ -509,14 +513,6 @@
       <groupId>io.prometheus</groupId>
       <artifactId>simpleclient_dropwizard</artifactId>
       <version>0.16.0</version>
-    </dependency>
-
-    <dependency>
-      <groupId>io.micrometer</groupId>
-      <artifactId>micrometer-bom</artifactId>
-      <version>${micrometer.version}</version>
-      <type>pom</type>
-      <scope>import</scope>
     </dependency>
 
     <!-- Flyway dependencies - only for SQL parsing, not migration management -->

--- a/pom.xml
+++ b/pom.xml
@@ -510,11 +510,14 @@
         <version>${dropwizard.version}</version>
       </dependency>
 
-      <!-- For Prometheus support -->
+      <!-- For Prometheus support. Pinned to match micrometer-registry-prometheus 1.15.x
+           (pulls client_java 1.3.10); leaving this at 1.3.6 splits the prometheus-metrics
+           family so the 1.3.10 exposition layer calls config APIs absent in 1.3.6
+           (NoSuchMethodError at runtime). Drives -core/-config across all modules. -->
       <dependency>
         <groupId>io.prometheus</groupId>
         <artifactId>prometheus-metrics-instrumentation-dropwizard</artifactId>
-        <version>1.3.6</version>
+        <version>1.3.10</version>
       </dependency>
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -110,7 +110,7 @@
     <httpasyncclient.version>4.1.5</httpasyncclient.version>
     <openapiswagger.version>2.2.25</openapiswagger.version>
     <httpclient.version>4.5.14</httpclient.version>
-    <spring.version>6.2.18</spring.version>
+    <spring.version>6.2.19</spring.version>
     <log4j.version>2.25.4</log4j.version>
     <org.junit.jupiter.version>5.11.4</org.junit.jupiter.version>
     <org.junit.platform.version>1.11.4</org.junit.platform.version>
@@ -138,6 +138,7 @@
     <sonar.dynamicAnalysis>reuseReports</sonar.dynamicAnalysis>
     <testng.version>7.6.1</testng.version>
     <dropwizard-micrometer.version>3.0.0</dropwizard-micrometer.version>
+    <micrometer.version>1.15.12</micrometer.version>
     <json-schema-validator.version>2.0.1</json-schema-validator.version>
     <java-jwt.version>4.4.0</java-jwt.version>
     <jwks-rsa.version>0.22.1</jwks-rsa.version>
@@ -196,6 +197,16 @@
         <groupId>io.projectreactor.netty</groupId>
         <artifactId>reactor-netty-http</artifactId>
         <version>1.2.16</version>
+      </dependency>
+      <!-- CVE-2026-45292: opentelemetry-api 1.37.0 (transitive of
+           co.elastic.clients:elasticsearch-java, shaded into elasticsearch-deps)
+           is vulnerable; import the BOM to pin -api and -context to the fix. -->
+      <dependency>
+        <groupId>io.opentelemetry</groupId>
+        <artifactId>opentelemetry-bom</artifactId>
+        <version>1.62.0</version>
+        <type>pom</type>
+        <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>org.eclipse.angus</groupId>


### PR DESCRIPTION
## What

Backend dependency bumps to clear 3 high-severity CVEs flagged by the server dependency scan. **Java/Maven only** — the `ws` (npm) finding from the same scan is being handed to the UI team separately.

| CVE | Library | Change |
|---|---|---|
| CVE-2026-41850 / CVE-2026-41851 | `spring-expression`, `spring-core` (+ `spring-beans`) | `6.2.18 → 6.2.19` |
| CVE-2026-40984 | `micrometer-core` (+ `-bom`, `-observation`, `-registry-prometheus`) | `1.14.5 → 1.15.12` |
| CVE-2026-45292 | `opentelemetry-api` / `-context` (transitive via shaded `elasticsearch-java`) | pin `opentelemetry-bom 1.62.0` |

## How

- **Spring** — single `spring.version` property drives `spring-core` (managed), `spring-expression` and `spring-beans` (direct in `openmetadata-service`).
- **Micrometer** — replaced 4 hard-coded `1.14.5` literals with a new `micrometer.version` property (one source of truth).
- **OpenTelemetry** — `opentelemetry-api` is a pure transitive of `co.elastic.clients:elasticsearch-java` shaded into `elasticsearch-deps`; it appears in no pom, so it's pinned via a `dependencyManagement` BOM import in the existing "Security: Force newer versions" block.

## Verification

- `mvn clean install -DskipTests` over `openmetadata-service` + full dependency chain (incl. both shaded-deps modules) → **BUILD SUCCESS**.
- `mvn dependency:tree` confirms the new versions resolve: spring `6.2.19`, micrometer `1.15.12`, opentelemetry-api/context `1.62.0`.

## Follow-up (UI team)

`ws@8.20.1` (CVE-2026-48779, fixed in 8.21.0) — bump the `resolutions` pin in `openmetadata-ui/.../package.json` + regen lockfile. `openmetadata-ui-core-components` also resolves `ws@8.19.0` (same range).

## Review updates (commit 8fe4149a4a)

- **Copilot** — removed the inert `micrometer-bom` import (it sat in `<dependencies>` with `scope=import`, managing nothing). Explicit `${micrometer.version}` versions drive resolution.
- **greptile** — confirmed there is no 1.14.x fix (line stops at 1.14.14, EOL 2025-12-31), so `1.15.12` is the lowest published fix. The 1.15.x bump split the Prometheus client_java family (`-exposition-formats` 1.3.10 vs `-core`/`-model` 1.3.6); pinned `prometheus-metrics-instrumentation-dropwizard` to `1.3.10` so the family resolves uniformly. Full build green; tree shows uniform `1.3.10`.

- **Copilot (k8s-operator)** — `openmetadata-k8s-operator` independently hard-pinned `micrometer-core`/`-registry-prometheus` to 1.14.5 (same CVE). Bumped both to `${micrometer.version}` (commit 4bf86d0255) so CVE-2026-40984 is cleared on **all paths**. Operator resolves micrometer 1.15.12 + prometheus-metrics uniform 1.3.10; builds; 66 operator unit tests pass.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR bumps Spring (`6.2.18→6.2.19`), Micrometer (`1.14.5→1.15.12`), and pins the OpenTelemetry BOM (`1.62.0`) to address three high-severity CVEs flagged by the server dependency scan. A concurrent Prometheus client_java family split introduced by the Micrometer minor-version jump is also resolved.

- **Spring / Micrometer / OTel**: Three discrete CVE fixes — a patch-level Spring bump, a minor-version Micrometer bump (1.14.x EOL means no patch-only path exists), and a BOM pin to force `opentelemetry-api`/`-context` away from the vulnerable `1.37.0` that `elasticsearch-java 9.2.4` transitively pulls.
- **Micrometer property extraction**: Hard-coded `1.14.5` literals across `pom.xml`, `openmetadata-service/pom.xml`, and `openmetadata-k8s-operator/pom.xml` are replaced with a single `micrometer.version` property in the root POM.
- **Prometheus family pin**: `prometheus-metrics-instrumentation-dropwizard` is bumped to `1.3.10` in root `dependencyManagement` to align the entire client_java family with what `micrometer-registry-prometheus 1.15.x` pulls, preventing a `NoSuchMethodError` at the `/prometheus` scrape endpoint at runtime.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — targeted version bumps with no structural changes, all three CVEs addressed, and the Prometheus client_java family split that a naive Micrometer bump would have introduced is also resolved.

All changes are pure version bumps in POM files. Spring and Micrometer are controlled through single properties in the root POM, preventing accidental partial updates. The OTel BOM is correctly placed in root dependencyManagement and inherits correctly to elasticsearch-dep via openmetadata-shaded-deps. The Prometheus family pin eliminates the runtime NoSuchMethodError risk at the /prometheus endpoint.

No files require special attention — all three changed POM files are straightforward version property updates.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| pom.xml | Root POM: Spring property bumped to 6.2.19, micrometer.version property added at 1.15.12, opentelemetry-bom 1.62.0 BOM import added to dependencyManagement, prometheus-metrics-instrumentation-dropwizard pinned to 1.3.10. All placements are correct. |
| openmetadata-service/pom.xml | Removed inert micrometer-bom BOM import (had scope=import inside dependencies, not dependencyManagement, so it was managing nothing); replaced three hard-coded 1.14.5 literals with ${micrometer.version}. |
| openmetadata-k8s-operator/pom.xml | Two hard-coded 1.14.5 Micrometer version literals replaced with ${micrometer.version} property; property itself is inherited from root POM. |

</details>

</details>

<details open><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[CVE-2026-41850 / CVE-2026-41851
spring-expression / spring-core] -->|spring.version
6.2.18 → 6.2.19| B[spring-core
spring-expression
spring-beans]
    C[CVE-2026-40984
micrometer-core] -->|micrometer.version
1.14.5 → 1.15.12| D[micrometer-core
micrometer-observation
micrometer-registry-prometheus]
    D -->|pulls client_java 1.3.10
family split risk| E{Prometheus family
consistency check}
    E -->|pin instrumentation-dropwizard
1.3.6 → 1.3.10 in root DM| F[prometheus-metrics family
uniform at 1.3.10]
    G[CVE-2026-45292
opentelemetry-api 1.37.0
via elasticsearch-java 9.2.4] -->|opentelemetry-bom 1.62.0
BOM import in root DM| H[opentelemetry-api
opentelemetry-context
pinned to 1.62.0]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[CVE-2026-41850 / CVE-2026-41851
spring-expression / spring-core] -->|spring.version
6.2.18 → 6.2.19| B[spring-core
spring-expression
spring-beans]
    C[CVE-2026-40984
micrometer-core] -->|micrometer.version
1.14.5 → 1.15.12| D[micrometer-core
micrometer-observation
micrometer-registry-prometheus]
    D -->|pulls client_java 1.3.10
family split risk| E{Prometheus family
consistency check}
    E -->|pin instrumentation-dropwizard
1.3.6 → 1.3.10 in root DM| F[prometheus-metrics family
uniform at 1.3.10]
    G[CVE-2026-45292
opentelemetry-api 1.37.0
via elasticsearch-java 9.2.4] -->|opentelemetry-bom 1.62.0
BOM import in root DM| H[opentelemetry-api
opentelemetry-context
pinned to 1.62.0]
```

</a>
</details>

<sub>Reviews (4): Last reviewed commit: ["fix(security): clear CVE-2026-40984 in k..."](https://github.com/open-metadata/openmetadata/commit/4bf86d0255556dad743497426913af56ab98708f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38081143)</sub>

<!-- /greptile_comment -->