### PR TITLE
fix(alerts): observability status triggers no longer fire on thread events

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/events/subscription/AlertUtil.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/events/subscription/AlertUtil.java
@@ -154,6 +154,13 @@ public final class AlertUtil {
 
     // Trigger Specific Settings
     if (event.getEntityType().equals(THREAD)) {
+      // Observability alerts (those with trigger actions) react to a measurable signal the
+      // entity emits (test/pipeline status, …), never to threads/conversations on it. Routing
+      // a thread here would let an EXCLUDE trigger flip and deliver it. Thread events still
+      // reach notification alerts (no actions) — see #28122.
+      if (!nullOrEmpty(config.getActions())) {
+        return false;
+      }
       return shouldTriggerAlertForThread(event, config.getResources().get(0));
     }
 

--- a/openmetadata-service/src/main/java/org/openmetadata/service/events/subscription/AlertsRuleEvaluator.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/events/subscription/AlertsRuleEvaluator.java
@@ -240,8 +240,8 @@ public class AlertsRuleEvaluator {
     }
     if (!changeEvent.getEntityType().equals(TEST_CASE)
         && !changeEvent.getEntityType().equals(TEST_SUITE)) {
-      // in case the entity is not test case return since the filter doesn't apply
-      return true;
+      // Trigger requires a test case result; non-test-case events (incl. THREAD) cannot fire it.
+      return false;
     }
 
     // we need to handle both fields updated and fields added
@@ -324,13 +324,8 @@ public class AlertsRuleEvaluator {
       return false;
     }
     if (!changeEvent.getEntityType().equals(TEST_CASE)) {
-      // in case the entity is not test case return since the filter doesn't apply
-      return true;
-    }
-
-    // Filter does not apply to Thread Change Events
-    if (changeEvent.getEntityType().equals(THREAD)) {
-      return true;
+      // Trigger requires a test case result; non-test-case events (incl. THREAD) cannot fire it.
+      return false;
     }
 
     // we need to handle both fields updated and fields added
@@ -402,13 +397,8 @@ public class AlertsRuleEvaluator {
       return false;
     }
     if (!changeEvent.getEntityType().equals(INGESTION_PIPELINE)) {
-      // in case the entity is not ingestion pipeline return since the filter doesn't apply
-      return true;
-    }
-
-    // Filter does not apply to Thread Change Events
-    if (changeEvent.getEntityType().equals(THREAD)) {
-      return true;
+      // Trigger requires a pipeline status; non-pipeline events (incl. THREAD) cannot fire it.
+      return false;
     }
 
     for (FieldChange fieldChange : changeEvent.getChangeDescription().getFieldsUpdated()) {
@@ -438,13 +428,8 @@ public class AlertsRuleEvaluator {
       return false;
     }
     if (!changeEvent.getEntityType().equals(PIPELINE)) {
-      // in case the entity is not ingestion pipeline return since the filter doesn't apply
-      return true;
-    }
-
-    // Filter does not apply to Thread Change Events
-    if (changeEvent.getEntityType().equals(THREAD)) {
-      return true;
+      // Trigger requires a pipeline status; non-pipeline events (incl. THREAD) cannot fire it.
+      return false;
     }
 
     for (FieldChange fieldChange : changeEvent.getChangeDescription().getFieldsUpdated()) {

--- a/openmetadata-service/src/test/java/org/openmetadata/service/events/subscription/AlertUtilTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/events/subscription/AlertUtilTest.java
@@ -17,9 +17,13 @@ import org.openmetadata.schema.entity.events.ArgumentsInput;
 import org.openmetadata.schema.entity.events.EventFilterRule;
 import org.openmetadata.schema.entity.events.FilteringRules;
 import org.openmetadata.schema.entity.feed.Thread;
+import org.openmetadata.schema.tests.type.TestCaseResult;
+import org.openmetadata.schema.tests.type.TestCaseStatus;
+import org.openmetadata.schema.type.ChangeDescription;
 import org.openmetadata.schema.type.ChangeEvent;
 import org.openmetadata.schema.type.EntityReference;
 import org.openmetadata.schema.type.EventType;
+import org.openmetadata.schema.type.FieldChange;
 import org.openmetadata.schema.type.ThreadType;
 import org.openmetadata.service.Entity;
 import org.openmetadata.service.security.policyevaluator.CompiledRule;
@@ -244,6 +248,48 @@ class AlertUtilTest {
     assertFalse(AlertUtil.shouldTriggerAlert(event, config));
   }
 
+  // ---- observability triggers must not fire on thread events ----------------
+  // A trigger is a positive predicate. shouldTriggerAlert routes a thread about
+  // an entity to that entity's alert (#28122), but a thread carries no test or
+  // pipeline signal, so the trigger must reject it — otherwise a threadUpdated
+  // leaks into a testCase "status = Failed" observability alert.
+
+  @Test
+  void matchTestResult_threadEventAboutTestCase_returnsFalse() {
+    ChangeEvent event = threadUpdatedEvent(testCaseRef());
+    assertFalse(new AlertsRuleEvaluator(event).matchTestResult(List.of("Failed")));
+  }
+
+  @Test
+  void matchPipelineState_threadEvent_returnsFalse() {
+    ChangeEvent event = threadUpdatedEvent(testCaseRef());
+    assertFalse(new AlertsRuleEvaluator(event).matchPipelineState(List.of("Failed")));
+  }
+
+  @Test
+  void matchIngestionPipelineState_threadEvent_returnsFalse() {
+    ChangeEvent event = threadUpdatedEvent(testCaseRef());
+    assertFalse(new AlertsRuleEvaluator(event).matchIngestionPipelineState(List.of("failed")));
+  }
+
+  @Test
+  void matchTestResult_testCaseFailedResult_returnsTrue() {
+    FieldChange resultChange =
+        new FieldChange()
+            .withName("testCaseResult")
+            .withNewValue(new TestCaseResult().withTestCaseStatus(TestCaseStatus.Failed));
+    ChangeEvent event =
+        new ChangeEvent()
+            .withId(UUID.randomUUID())
+            .withEventType(EventType.ENTITY_UPDATED)
+            .withEntityType(Entity.TEST_CASE)
+            .withChangeDescription(
+                new ChangeDescription()
+                    .withFieldsUpdated(List.of(resultChange))
+                    .withFieldsAdded(Collections.emptyList()));
+    assertTrue(new AlertsRuleEvaluator(event).matchTestResult(List.of("Failed")));
+  }
+
   // ---- evaluateAlertConditions: compile-once cache --------------------------
 
   @Test
@@ -299,6 +345,24 @@ class AlertUtilTest {
         .withEventType(eventType)
         .withEntityType(Entity.THREAD)
         .withEntity(thread);
+  }
+
+  private static ChangeEvent threadUpdatedEvent(EntityReference parent) {
+    Thread thread =
+        new Thread()
+            .withId(UUID.randomUUID())
+            .withType(ThreadType.Conversation)
+            .withEntityRef(parent);
+    return new ChangeEvent()
+        .withId(UUID.randomUUID())
+        .withEventType(EventType.THREAD_UPDATED)
+        .withEntityType(Entity.THREAD)
+        .withEntity(thread)
+        .withChangeDescription(new ChangeDescription());
+  }
+
+  private static EntityReference testCaseRef() {
+    return new EntityReference().withId(UUID.randomUUID()).withType(Entity.TEST_CASE);
   }
 
   private static FilteringRules filteringRules(String resource) {

--- a/openmetadata-service/src/test/java/org/openmetadata/service/events/subscription/AlertUtilTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/events/subscription/AlertUtilTest.java
@@ -290,6 +290,88 @@ class AlertUtilTest {
     assertTrue(new AlertsRuleEvaluator(event).matchTestResult(List.of("Failed")));
   }
 
+  // ---- end-to-end (checkIfChangeEventIsAllowed): no regression across --------
+  // INCLUDE/EXCLUDE triggers. A thread event must never reach an observability
+  // alert's trigger: for an EXCLUDE trigger the "abstain" boolean would otherwise
+  // flip and DELIVER the thread. Real results must still behave correctly.
+
+  @Test
+  void allowed_testCase_includeTrigger_thread_notDelivered() {
+    assertFalse(
+        AlertUtil.checkIfChangeEventIsAllowed(
+            threadUpdatedEvent(ref(Entity.TEST_CASE)),
+            observabilityRules(
+                "testCase", ArgumentsInput.Effect.INCLUDE, "matchTestResult({'Failed'})")));
+  }
+
+  @Test
+  void allowed_testCase_excludeTrigger_thread_notDelivered() {
+    assertFalse(
+        AlertUtil.checkIfChangeEventIsAllowed(
+            threadUpdatedEvent(ref(Entity.TEST_CASE)),
+            observabilityRules(
+                "testCase", ArgumentsInput.Effect.EXCLUDE, "matchTestResult({'Failed'})")));
+  }
+
+  @Test
+  void allowed_pipeline_excludeTrigger_thread_notDelivered() {
+    assertFalse(
+        AlertUtil.checkIfChangeEventIsAllowed(
+            threadUpdatedEvent(ref(Entity.PIPELINE)),
+            observabilityRules(
+                "pipeline", ArgumentsInput.Effect.EXCLUDE, "matchPipelineState({'Failed'})")));
+  }
+
+  @Test
+  void allowed_ingestionPipeline_excludeTrigger_thread_notDelivered() {
+    assertFalse(
+        AlertUtil.checkIfChangeEventIsAllowed(
+            threadUpdatedEvent(ref(Entity.INGESTION_PIPELINE)),
+            observabilityRules(
+                "ingestionPipeline",
+                ArgumentsInput.Effect.EXCLUDE,
+                "matchIngestionPipelineState({'failed'})")));
+  }
+
+  @Test
+  void allowed_testCase_includeTrigger_failedResult_delivered() {
+    assertTrue(
+        AlertUtil.checkIfChangeEventIsAllowed(
+            testCaseResultEvent(TestCaseStatus.Failed),
+            observabilityRules(
+                "testCase", ArgumentsInput.Effect.INCLUDE, "matchTestResult({'Failed'})")));
+  }
+
+  @Test
+  void allowed_testCase_includeTrigger_successResult_notDelivered() {
+    assertFalse(
+        AlertUtil.checkIfChangeEventIsAllowed(
+            testCaseResultEvent(TestCaseStatus.Success),
+            observabilityRules(
+                "testCase", ArgumentsInput.Effect.INCLUDE, "matchTestResult({'Failed'})")));
+  }
+
+  @Test
+  void allowed_testCase_excludeTrigger_failedResult_notDelivered() {
+    assertFalse(
+        AlertUtil.checkIfChangeEventIsAllowed(
+            testCaseResultEvent(TestCaseStatus.Failed),
+            observabilityRules(
+                "testCase", ArgumentsInput.Effect.EXCLUDE, "matchTestResult({'Failed'})")));
+  }
+
+  @Test
+  void allowed_notificationThreadOnEntity_stillDelivered() {
+    // #28122 preserved: notification alerts (no trigger actions) still get thread events.
+    FilteringRules notif =
+        new FilteringRules()
+            .withResources(List.of("glossaryTerm"))
+            .withRules(Collections.emptyList())
+            .withActions(Collections.emptyList());
+    assertTrue(
+        AlertUtil.checkIfChangeEventIsAllowed(threadUpdatedEvent(ref("glossaryTerm")), notif));
+  }
+
   // ---- evaluateAlertConditions: compile-once cache --------------------------
 
   @Test
@@ -363,6 +445,39 @@ class AlertUtilTest {
 
   private static EntityReference testCaseRef() {
     return new EntityReference().withId(UUID.randomUUID()).withType(Entity.TEST_CASE);
+  }
+
+  private static EntityReference ref(String type) {
+    return new EntityReference().withId(UUID.randomUUID()).withType(type);
+  }
+
+  private static FilteringRules observabilityRules(
+      String resource, ArgumentsInput.Effect effect, String condition) {
+    EventFilterRule action =
+        new EventFilterRule()
+            .withName("trigger")
+            .withEffect(effect)
+            .withCondition(condition)
+            .withPrefixCondition(ArgumentsInput.PrefixCondition.AND);
+    return new FilteringRules()
+        .withResources(List.of(resource))
+        .withRules(Collections.emptyList())
+        .withActions(List.of(action));
+  }
+
+  private static ChangeEvent testCaseResultEvent(TestCaseStatus status) {
+    FieldChange resultChange =
+        new FieldChange()
+            .withName("testCaseResult")
+            .withNewValue(new TestCaseResult().withTestCaseStatus(status));
+    return new ChangeEvent()
+        .withId(UUID.randomUUID())
+        .withEventType(EventType.ENTITY_UPDATED)
+        .withEntityType(Entity.TEST_CASE)
+        .withChangeDescription(
+            new ChangeDescription()
+                .withFieldsUpdated(List.of(resultChange))
+                .withFieldsAdded(Collections.emptyList()));
   }
 
   private static FilteringRules filteringRules(String resource) {


### PR DESCRIPTION
Fixes #29114

## Problem

A `testCase` **observability** alert whose trigger is *Get Test Case Status Updates = Failed* also fires on `threadUpdated` events — an update to a conversation/incident/task attached to the test case — delivering a notification that contains no test result. Reported on 1.12.10; present on `main`.

## Root cause

`AlertUtil.checkIfChangeEventIsAllowed` runs **scope → filters → trigger**. Since #28122 (`feefc508aa`, first in 1.12.9), `shouldTriggerAlert` routes `THREAD` events to an entity-typed alert by the thread's **parent** entity type — correct for *notification* alerts, but `shouldTriggerAlert` is shared with *observability* alerts. The status triggers then accept the thread because they "abstain → `return true`" for events that aren't their entity type:

```java
if (!entityType.equals(TEST_CASE) && !entityType.equals(TEST_SUITE)) return true; // wrong for a trigger
```

(`matchDataContractStatus` already does the right thing — `return false`.) Only `threadUpdated` leaks: `matchTestResult` returns `false` on a null change description, which `threadCreated`/`postCreated` have, but an update does not.

## Fix (two layers)

1. **Routing guard** (`shouldTriggerAlert`): thread events are not routed to alerts that have **trigger actions** (observability) — those react to a measurable signal the entity emits, never to a thread/conversation on it. Notification alerts (no actions) still receive thread events, so **#28122 is preserved**.
2. **Positive triggers** (defense-in-depth, consistent with `matchDataContractStatus`): `matchTestResult`, `getTestCaseStatusIfInTestSuite`, `matchPipelineState`, `matchIngestionPipelineState` `return false` for events that don't carry their signal (incl. `THREAD`).

Layer 1 is required because the trigger-only change has an **EXCLUDE-effect regression**: with an *exclude* trigger the condition is `(!matchTestResult(...))`, so `!false → true` and the thread would be **delivered**. The routing guard prevents threads from reaching the trigger in any include/exclude/AND/OR combination.

## Tests (`AlertUtilTest`)

- Triggers reject a `threadUpdated` about a test case / pipeline / ingestion pipeline (direct + end-to-end via `checkIfChangeEventIsAllowed`).
- **INCLUDE and EXCLUDE** triggers × `threadUpdated` / real `Failed` / real `Success` → correct delivery decision. (The EXCLUDE+thread cases fail without the routing guard — they pin the regression.)
- Real `Failed` result still fires; `Success` does not.
- Notification alert (no trigger actions) + thread event still delivered (#28122 preserved).

```
AlertUtilTest: Tests run: 37, Failures: 0, Errors: 0
All alert/subscription/event-consumer unit suites: Tests run: 145, Failures: 0
```

## How tested

- `mvn test -pl openmetadata-service` across `AlertUtilTest`, `AlertsRuleEvaluatorTaskMentionsTest`, `AbstractEventConsumerTest`, `ExpressionValidatorTest`, `SubscriptionUtilTest`, `FeedUtilsTest`, `MessageDecoratorTest`, `RichPlatformMessageDecoratorTest` → green.
- Live reproduction on a 1.12.10 stack (before: alert delivered the `threadUpdated`; after: rejected, while a real `Failed` result still fires).

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a bug where observability alerts with status-based triggers (e.g. "test case = Failed") incorrectly fire on `threadUpdated` events — conversation or task updates attached to a test case — delivering a notification with no test result payload. The fix applies two complementary layers: a routing guard in `shouldTriggerAlert` that short-circuits THREAD events for any alert that has trigger actions, and a semantic correction in four trigger evaluator methods to return `false` rather than `true` when the event carries no signal relevant to the trigger.

- **`AlertUtil.shouldTriggerAlert`**: THREAD events are now rejected before any trigger evaluation for observability alerts (non-empty `actions`); notification alerts (empty/null `actions`) are unaffected, preserving the #28122 routing behaviour.
- **`AlertsRuleEvaluator`**: `matchTestResult`, `getTestCaseStatusIfInTestSuite`, `matchIngestionPipelineState`, and `matchPipelineState` now return `false` for non-matching entity types (defense-in-depth; required to prevent EXCLUDE-trigger regression where `!false` would deliver the thread).
- **`AlertUtilTest`**: 13 new tests cover unit-level trigger rejection, INCLUDE/EXCLUDE × THREAD/real-result combinations end-to-end, and the notification-alert backward-compatibility case.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge. The routing guard is narrow and well-scoped, and the trigger-method changes unify semantics consistently with the existing `matchDataContractStatus` pattern. Notification-alert thread delivery is explicitly preserved and test-covered.

Both changed code paths are narrow and targeted. The test suite covers the exact regression scenario (EXCLUDE trigger + thread event) that motivated the two-layer design, as well as real-result INCLUDE/EXCLUDE cases and the backward-compat notification path.

No files require special attention.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-service/src/main/java/org/openmetadata/service/events/subscription/AlertUtil.java | Adds a routing guard in `shouldTriggerAlert`: THREAD events are rejected early for observability alerts (those with non-empty `actions`) before reaching any trigger evaluator. Notification alerts (no actions) still flow to `shouldTriggerAlertForThread`, preserving #28122 behaviour. |
| openmetadata-service/src/main/java/org/openmetadata/service/events/subscription/AlertsRuleEvaluator.java | Four trigger methods changed from `return true` to `return false` for events whose entity type cannot carry the required signal. Consistent with the existing `matchDataContractStatus` pattern. Minor: comment in `matchTestResult` understates the accepted types (TEST_SUITE is also allowed). |
| openmetadata-service/src/test/java/org/openmetadata/service/events/subscription/AlertUtilTest.java | Adds 13 new tests covering unit-level trigger rejection, INCLUDE/EXCLUDE × THREAD/real-result combinations end-to-end, and the #28122 regression guard. |

</details>

</details>

<sub>Reviews (5): Last reviewed commit: ["fix(alerts): reject thread events for ob..."](https://github.com/open-metadata/openmetadata/commit/883dc7546b6621bfb92e713241aa92f384aa5bc2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38090064)</sub>

<!-- /greptile_comment -->