### PR TITLE
fix(security): bump ws to 8.21.0 to address CVE-2026-48779

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/package.json
+++ b/openmetadata-ui/src/main/resources/ui/package.json
@@ -276,7 +276,7 @@
     "prosemirror-state": "1.4.1",
     "prosemirror-transform": "1.7.0",
     "prosemirror-view": "1.28.2",
-    "ws": "8.20.1",
+    "ws": "8.21.0",
     "axios": "1.16.1",
     "micromatch": "4.0.8",
     "minimatch": "3.1.5",

--- a/openmetadata-ui/src/main/resources/ui/yarn.lock
+++ b/openmetadata-ui/src/main/resources/ui/yarn.lock
@@ -13582,10 +13582,10 @@ write-file-atomic@^4.0.2:
     imurmurhash "^0.1.4"
     signal-exit "^3.0.7"
 
-ws@8.20.1, ws@^8.11.0, ws@~8.18.3:
-  version "8.20.1"
-  resolved "https://registry.yarnpkg.com/ws/-/ws-8.20.1.tgz#91a9ae2b312ccf98e0a85ec499b48cef45ab0ddb"
-  integrity sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==
+ws@8.21.0, ws@^8.11.0, ws@~8.18.3:
+  version "8.21.0"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-8.21.0.tgz#012e413fc07429945121b0c153158c4343086951"
+  integrity sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==
 
 wsl-utils@^0.3.0:
   version "0.3.1"


### PR DESCRIPTION
Fixes #29121

## What

Bumps the pinned `ws` resolution from `8.20.1` → `8.21.0` in `openmetadata-ui`, patching **CVE-2026-48779** — *Asymmetric Resource Consumption (Amplification)*, High severity (CVSS 7.5, DoS) — flagged by the [Security Scan (Snyk) on `main`](https://github.com/open-metadata/OpenMetadata/actions/runs/27518211326).

## Changes

- `openmetadata-ui/src/main/resources/ui/package.json` — `resolutions.ws` `8.20.1` → `8.21.0`
- `openmetadata-ui/src/main/resources/ui/yarn.lock` — regenerated `ws` entry (`8.21.0`)

## Validation

`yarn install` regenerates exactly this `ws@8.21.0` lockfile entry (resolved URL + integrity verified against the registry). `ws` is the single resolved copy via the `resolutions` pin, so this one bump covers every transitive consumer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Patches CVE-2026-48779 (memory-exhaustion DoS in `ws`) by bumping the Yarn resolution pin from `8.20.1` to `8.21.0`. The single consolidated `ws` entry in the lockfile covers all three in-range semver patterns, so every transitive consumer is covered by this one change.

- **`package.json`**: `resolutions.ws` bumped from `8.20.1` → `8.21.0`.
- **`yarn.lock`**: `ws` entry updated with new resolved URL and verified sha512 integrity hash; all three semver aliases (`8.21.0`, `^8.11.0`, `~8.18.3`) continue to resolve to the single patched version.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — a minimal, targeted version bump of a single transitive dependency to close a known DoS vulnerability.

The change touches exactly two files: one line in `package.json` and the corresponding lockfile entry. The `ws` resolution pin consolidates all semver ranges into a single resolved copy, and the lockfile confirms that ws@8.21.0, ws@^8.11.0, and ws@~8.18.3 all resolve to the patched version. No application logic is modified.

No files require special attention.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-ui/src/main/resources/ui/package.json | Single-line resolutions bump: ws 8.20.1 → 8.21.0 to patch CVE-2026-48779 (memory-exhaustion DoS) |
| openmetadata-ui/src/main/resources/ui/yarn.lock | Lockfile updated for ws@8.21.0 — resolved URL and sha512 integrity hash regenerated; single consolidated entry covers all three semver ranges (ws@8.21.0, ws@^8.11.0, ws@~8.18.3) |

</details>

</details>

<details open><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["package.json resolutions.ws = 8.21.0"] --> B["yarn install"]
    B --> C["yarn.lock ws@8.21.0 consolidated entry"]
    C --> D1["ws@8.21.0"]
    C --> D2["ws@^8.11.0"]
    C --> D3["ws@~8.18.3"]
    D1 & D2 & D3 --> E["Single patched ws 8.21.0 - CVE-2026-48779 fixed"]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["package.json resolutions.ws = 8.21.0"] --> B["yarn install"]
    B --> C["yarn.lock ws@8.21.0 consolidated entry"]
    C --> D1["ws@8.21.0"]
    C --> D2["ws@^8.11.0"]
    C --> D3["ws@~8.18.3"]
    D1 & D2 & D3 --> E["Single patched ws 8.21.0 - CVE-2026-48779 fixed"]
```

</a>
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(security): bump ws to 8.21.0 to addr..."](https://github.com/open-metadata/openmetadata/commit/aa2b4ee036b76f1dbabe0ae748775eb4cc98987e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38116739)</sub>

<!-- /greptile_comment -->