### PR TITLE
feat(snowflake): create Query entities + fix probe in ACCESS_HISTORY lineage

### DIFF
--- a/ingestion/src/metadata/ingestion/source/database/snowflake/connection.py
+++ b/ingestion/src/metadata/ingestion/source/database/snowflake/connection.py
@@ -18,7 +18,8 @@ from urllib.parse import quote_plus
 
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import serialization
-from pydantic import BaseModel, SecretStr
+from pydantic import BaseModel
+from sqlalchemy import text
 from sqlalchemy.engine import Engine
 from sqlalchemy.inspection import inspect
 
@@ -123,7 +124,13 @@ def probe_access_history_available(engine: Engine, account_usage_schema: str) ->
     """
     try:
         with engine.connect() as conn:
-            conn.execute(text(SNOWFLAKE_ACCESS_HISTORY_PROBE.format(account_usage=account_usage_schema)))
+            conn.execute(
+                text(
+                    SNOWFLAKE_ACCESS_HISTORY_PROBE.format(
+                        account_usage=account_usage_schema
+                    )
+                )
+            )
     except Exception as exc:
         logger.info(
             f"ACCESS_HISTORY probe failed (will fall back to legacy lineage path): {exc}. "
@@ -150,13 +157,10 @@ class SnowflakeConnection(BaseConnection[SnowflakeConnectionConfig, Engine]):
 
         if connection.username:
             url += f"{quote_plus(connection.username)}"
-            if not connection.password:
-                connection.password = SecretStr("")
-            url += (
-                f":{quote_plus(connection.password.get_secret_value())}"
-                if connection
-                else ""
+            password = (
+                connection.password.get_secret_value() if connection.password else ""
             )
+            url += f":{quote_plus(password)}"
             url += "@"
 
         url += connection.account

--- a/ingestion/src/metadata/ingestion/source/database/snowflake/lineage.py
+++ b/ingestion/src/metadata/ingestion/source/database/snowflake/lineage.py
@@ -24,9 +24,11 @@ from metadata.generated.schema.api.data.createQuery import CreateQueryRequest
 from metadata.generated.schema.api.lineage.addLineage import AddLineageRequest
 from metadata.generated.schema.entity.data.container import Container
 from metadata.generated.schema.entity.data.table import Table
+from metadata.generated.schema.entity.teams.user import User
 from metadata.generated.schema.metadataIngestion.workflow import (
     Source as WorkflowSource,
 )
+from metadata.generated.schema.type.basic import SqlQuery, Timestamp
 from metadata.generated.schema.type.entityLineage import (
     ColumnLineage,
     EntitiesEdge,
@@ -63,6 +65,7 @@ from metadata.ingestion.source.database.stored_procedures_mixin import (
 from metadata.utils import fqn
 from metadata.utils.helpers import get_start_and_end
 from metadata.utils.logger import ingestion_logger
+from metadata.utils.time_utils import datetime_to_timestamp
 
 logger = ingestion_logger()
 
@@ -71,6 +74,10 @@ USE_ACCESS_HISTORY_OPTION_KEY = "useAccessHistory"
 ACCESS_HISTORY_CHUNK_DAYS_OPTION_KEY = "accessHistoryChunkDays"
 
 TABLE_CACHE_MAX_SIZE = 100
+
+QUERY_DEDUP_CACHE_MAX_SIZE = 1000
+
+USER_CACHE_MAX_SIZE = 1000
 
 ACCESS_HISTORY_CHUNK_DAYS = 2
 
@@ -121,6 +128,10 @@ class SnowflakeLineageSource(
         self._access_history_chunk_days = self._pop_access_history_chunk_days(config)
         super().__init__(config, metadata, get_engine=get_engine)
         self._table_cache: LRUCache = LRUCache(maxsize=TABLE_CACHE_MAX_SIZE)
+        self._seen_query_checksums: LRUCache = LRUCache(
+            maxsize=QUERY_DEDUP_CACHE_MAX_SIZE
+        )
+        self._user_cache: LRUCache = LRUCache(maxsize=USER_CACHE_MAX_SIZE)
         if self._use_access_history and self.engine is not None:
             available = probe_access_history_available(
                 self.engine, self.service_connection.accountUsageSchema
@@ -286,11 +297,15 @@ class SnowflakeLineageSource(
             return
         yield from super().yield_query_lineage()
 
-    def _yield_access_history_lineage(self) -> Iterable[Either[AddLineageRequest]]:
+    def _yield_access_history_lineage(
+        self,
+    ) -> Iterable[Either[Union[AddLineageRequest, CreateQueryRequest]]]:  # noqa: UP007
         """
         Stream one row per directed table edge from the combined ACCESS_HISTORY
         SQL — column-pairs are aggregated into a VARIANT array per edge inside
-        Snowflake, so client memory stays O(1) regardless of catalog size.
+        Snowflake, so client memory stays O(1) regardless of catalog size. Each
+        edge with representative SQL also yields a CreateQueryRequest so the
+        query surfaces in OpenMetadata, matching the legacy parser path.
         """
         yield from self._yield_combined_access_history()
         yield from self._yield_copy_history_lineage()
@@ -315,13 +330,19 @@ class SnowflakeLineageSource(
             yield window_start, window_end
             window_start = window_end
 
-    def _yield_combined_access_history(self) -> Iterable[Either[AddLineageRequest]]:
+    def _yield_combined_access_history(
+        self,
+    ) -> Iterable[Either[Union[AddLineageRequest, CreateQueryRequest]]]:  # noqa: UP007
         """
         Stream the combined ACCESS_HISTORY query per date window and emit one
-        `AddLineageRequest` per row, accumulating counters across all windows.
+        `AddLineageRequest` per row, plus a `CreateQueryRequest` for each edge's
+        representative SQL (deduped by checksum) so the originating query lands
+        in OpenMetadata just as the legacy parser path does. Counters accumulate
+        across all windows.
         """
         emitted = 0
         emitted_with_sql = 0
+        queries_emitted = 0
         skipped = 0
         for window_start, window_end in self._iter_lineage_date_windows():
             for row in self._fetch_access_history_rows(window_start, window_end):
@@ -330,16 +351,112 @@ class SnowflakeLineageSource(
                     skipped += 1
                     continue
                 emitted += 1
+                yield Either(right=edge)  # pyright: ignore[reportCallIssue]
                 if row.query_text:
                     emitted_with_sql += 1
-                yield Either(right=edge)  # pyright: ignore[reportCallIssue]
+                    query_request = self._build_query_request(row)
+                    if query_request is not None:
+                        queries_emitted += 1
+                        yield Either(
+                            right=query_request
+                        )  # pyright: ignore[reportCallIssue]
         logger.info(
             "ACCESS_HISTORY lineage: emitted %d edges (%d with SQL text), "
-            "skipped %d (unresolvable downstream/upstream tables)",
+            "%d queries created, skipped %d (unresolvable downstream/upstream tables)",
             emitted,
             emitted_with_sql,
+            queries_emitted,
             skipped,
         )
+
+    def _build_query_request(
+        self, row: AccessHistoryRow
+    ) -> Optional[CreateQueryRequest]:  # noqa: UP045
+        """
+        Build a CreateQueryRequest for an edge's representative SQL so the query
+        is registered in OpenMetadata like the legacy parser path does. Deduped
+        within the run by SQL checksum via a bounded LRU — one Query entity per
+        unique statement, mirroring the sink's checksum dedup. `processedLineage`
+        is True because the edge was derived from ACCESS_HISTORY directly, so the
+        legacy parser must not re-process it.
+
+        `queryUsedIn` references the edge's downstream and upstream tables so the
+        backend creates the MENTIONED_IN relationship that the table "Queries" tab
+        reads — without it the Query entity is created but attached to no table and
+        never surfaces in the UI. Both tables are already in `_table_cache` from
+        building the edge, so resolution here is a cache hit.
+        """
+        if not row.query_text:
+            return None
+        checksum = fqn.get_query_checksum(row.query_text)
+        if checksum in self._seen_query_checksums:
+            return None
+        self._seen_query_checksums[checksum] = True
+        query_date = (
+            Timestamp(
+                root=datetime_to_timestamp(row.query_start_time, milliseconds=True)
+            )
+            if row.query_start_time
+            else None
+        )
+        users, used_by = self._resolve_query_user(row.user_name)
+        return CreateQueryRequest(
+            query=SqlQuery(row.query_text),
+            query_type=row.query_type,
+            duration=row.query_duration,
+            queryDate=query_date,
+            users=users,
+            usedBy=used_by,
+            queryUsedIn=self._build_query_used_in(row) or None,
+            processedLineage=True,
+            service=self.config.serviceName,
+        )
+
+    def _build_query_used_in(
+        self, row: AccessHistoryRow
+    ) -> List[EntityReference]:  # noqa: UP006
+        """
+        Resolve the edge's downstream and upstream tables to EntityReferences for
+        the query's `queryUsedIn`, so the query is linked to both tables in OM.
+        Resolution hits `_table_cache` (populated while building the edge), so this
+        adds no extra API calls.
+        """
+        references: List[EntityReference] = []  # noqa: UP006
+        for snowflake_fqn in (row.downstream_table, row.upstream_table):
+            if not snowflake_fqn:
+                continue
+            entity = self._resolve_snowflake_table(snowflake_fqn)
+            if entity is not None:
+                references.append(
+                    EntityReference(id=entity.id.root, type="table")
+                )  # pyright: ignore[reportCallIssue]
+        return references
+
+    def _resolve_query_user(
+        self, username: Optional[str]  # noqa: UP045
+    ) -> Tuple[Optional[List[str]], Optional[List[str]]]:  # noqa: UP006, UP045
+        """
+        Map the Snowflake `USER_NAME` that ran the query to the CreateQueryRequest
+        `(users, usedBy)` pair, mirroring the usage stage's `_get_user_entity`:
+        `users` is the matching OpenMetadata user FQN (when one exists) and
+        `usedBy` is the raw Snowflake username. Both hits and misses are cached
+        in a bounded LRU — the same handful of service accounts run most queries,
+        so this stays a hot path.
+        """
+        if not username:
+            return None, None
+        if username in self._user_cache:
+            return self._user_cache[username]
+        try:
+            user = self.metadata.get_by_name(entity=User, fqn=username)
+        except Exception as exc:
+            logger.debug("Failed to resolve user `%s`: %s", username, exc)
+            user = None
+        resolved = (
+            ([user.fullyQualifiedName.root], [username]) if user else (None, [username])
+        )
+        self._user_cache[username] = resolved
+        return resolved
 
     def _fetch_access_history_rows(
         self, window_start: datetime, window_end: datetime

--- a/ingestion/src/metadata/ingestion/source/database/snowflake/models.py
+++ b/ingestion/src/metadata/ingestion/source/database/snowflake/models.py
@@ -171,7 +171,9 @@ class SnowflakeQueryResult(QueryResult):
 
 class AccessHistoryRow(BaseModel):
     """One row from SNOWFLAKE_ACCESS_HISTORY_LINEAGE — a directed table edge
-    with pre-aggregated column pairs (VARIANT) and a representative query text."""
+    with pre-aggregated column pairs (VARIANT) and the representative query's
+    text, type, duration, start time and executing user (pinned to the latest
+    query on the edge)."""
 
     model_config = ConfigDict(extra="ignore")
 
@@ -179,6 +181,10 @@ class AccessHistoryRow(BaseModel):
     upstream_table: Optional[str] = None  # noqa: UP045
     column_pairs: Optional[Any] = None  # noqa: UP045
     query_text: Optional[str] = None  # noqa: UP045
+    query_type: Optional[str] = None  # noqa: UP045
+    query_duration: Optional[float] = None  # noqa: UP045
+    query_start_time: Optional[datetime] = None  # noqa: UP045
+    user_name: Optional[str] = None  # noqa: UP045
 
 
 class CopyHistoryRow(BaseModel):

--- a/ingestion/src/metadata/ingestion/source/database/snowflake/queries.py
+++ b/ingestion/src/metadata/ingestion/source/database/snowflake/queries.py
@@ -541,9 +541,12 @@ SNOWFLAKE_ACCESS_HISTORY_LINEAGE = textwrap.dedent(
         SELECT
             ah.QUERY_ID,
             ah.QUERY_START_TIME,
+            ah.USER_NAME,
             ah.DIRECT_OBJECTS_ACCESSED,
             ah.OBJECTS_MODIFIED,
-            qh.QUERY_TEXT
+            qh.QUERY_TEXT,
+            qh.QUERY_TYPE,
+            qh.TOTAL_ELAPSED_TIME AS QUERY_DURATION
         FROM {account_usage}.ACCESS_HISTORY ah
         LEFT JOIN {account_usage}.QUERY_HISTORY qh
             ON ah.QUERY_ID = qh.QUERY_ID
@@ -560,7 +563,11 @@ SNOWFLAKE_ACCESS_HISTORY_LINEAGE = textwrap.dedent(
             downstream.value:"objectName"::STRING AS DOWNSTREAM_TABLE,
             downstream.value:"objectDomain"::STRING AS DOWNSTREAM_DOMAIN,
             MAX_BY(ah.QUERY_ID, ah.QUERY_START_TIME) AS QUERY_ID,
-            MAX_BY(ah.QUERY_TEXT, ah.QUERY_START_TIME) AS QUERY_TEXT
+            MAX_BY(ah.QUERY_TEXT, ah.QUERY_START_TIME) AS QUERY_TEXT,
+            MAX_BY(ah.QUERY_TYPE, ah.QUERY_START_TIME) AS QUERY_TYPE,
+            MAX_BY(ah.QUERY_DURATION, ah.QUERY_START_TIME) AS QUERY_DURATION,
+            MAX_BY(ah.USER_NAME, ah.QUERY_START_TIME) AS USER_NAME,
+            MAX(ah.QUERY_START_TIME) AS QUERY_START_TIME
         FROM access_history_filtered ah,
              LATERAL FLATTEN(input => ah.DIRECT_OBJECTS_ACCESSED) upstream,
              LATERAL FLATTEN(input => ah.OBJECTS_MODIFIED) downstream
@@ -605,6 +612,10 @@ SNOWFLAKE_ACCESS_HISTORY_LINEAGE = textwrap.dedent(
         te.DOWNSTREAM_DOMAIN,
         te.QUERY_ID,
         te.QUERY_TEXT,
+        te.QUERY_TYPE,
+        te.QUERY_DURATION,
+        te.QUERY_START_TIME,
+        te.USER_NAME,
         ce.COLUMN_PAIRS
     FROM table_edges te
     LEFT JOIN column_edges_grouped ce

--- a/ingestion/tests/unit/topology/database/test_snowflake_access_history_lineage.py
+++ b/ingestion/tests/unit/topology/database/test_snowflake_access_history_lineage.py
@@ -23,9 +23,11 @@ the flag is on.
 from datetime import datetime, timedelta
 from unittest.mock import MagicMock, patch
 
+from metadata.generated.schema.api.data.createQuery import CreateQueryRequest
 from metadata.generated.schema.api.lineage.addLineage import AddLineageRequest
 from metadata.generated.schema.entity.data.container import Container
 from metadata.generated.schema.entity.data.table import Column, DataType, Table
+from metadata.generated.schema.entity.teams.user import User
 from metadata.generated.schema.type.basic import (
     EntityName,
     FullyQualifiedEntityName,
@@ -34,6 +36,9 @@ from metadata.generated.schema.type.basic import (
 from metadata.generated.schema.type.entityLineage import Source as LineageEdgeSource
 from metadata.generated.schema.type.entityReference import EntityReference
 from metadata.ingestion.source.database.lineage_source import LineageSource
+from metadata.ingestion.source.database.snowflake.connection import (
+    probe_access_history_available,
+)
 from metadata.ingestion.source.database.snowflake.lineage import (
     ACCESS_HISTORY_CHUNK_DAYS,
     ACCESS_HISTORY_CHUNK_DAYS_OPTION_KEY,
@@ -112,6 +117,8 @@ def _make_lineage_source(
     src.start = datetime(2025, 1, 1)
     src.end = datetime(2025, 1, 2)
     src._table_cache = {}
+    src._seen_query_checksums = {}
+    src._user_cache = {}
     src._use_access_history = False
     src._access_history_chunk_days = ACCESS_HISTORY_CHUNK_DAYS
     return src
@@ -247,6 +254,29 @@ def test_combined_lineage_left_joins_query_history_for_text_only():
     assert '"app": "OpenMetadata"' not in rendered
 
 
+def test_combined_lineage_sql_surfaces_query_metadata():
+    """
+    The combined SQL must surface the representative query's type, duration and
+    start time alongside its text so the client can build a CreateQueryRequest.
+    """
+    rendered = SNOWFLAKE_ACCESS_HISTORY_LINEAGE.format(
+        account_usage="SNOWFLAKE.ACCOUNT_USAGE",
+        start_time="2025-01-01",
+        end_time="2025-01-31",
+        filter_condition="",
+    )
+    assert "qh.QUERY_TYPE" in rendered
+    assert "qh.TOTAL_ELAPSED_TIME AS QUERY_DURATION" in rendered
+    assert "ah.USER_NAME" in rendered
+    assert "MAX_BY(ah.QUERY_TYPE, ah.QUERY_START_TIME)" in rendered
+    assert "MAX_BY(ah.QUERY_DURATION, ah.QUERY_START_TIME)" in rendered
+    assert "MAX_BY(ah.USER_NAME, ah.QUERY_START_TIME)" in rendered
+    assert "te.QUERY_TYPE" in rendered
+    assert "te.QUERY_DURATION" in rendered
+    assert "te.QUERY_START_TIME" in rendered
+    assert "te.USER_NAME" in rendered
+
+
 def test_build_filter_condition_clause_empty_when_unset():
     src = _make_lineage_source()
     src.source_config.filterCondition = None
@@ -278,6 +308,31 @@ def test_probe_sql_is_lightweight():
     )
     assert "ACCESS_HISTORY" in rendered
     assert "LIMIT 1" in rendered
+
+
+def test_probe_executes_and_returns_true_on_success():
+    """
+    Run the real probe (not a mock) so a missing import or rendering bug is
+    caught: it must execute the probe SQL and return True when the query
+    succeeds. Regression for the unimported `text(...)` NameError that silently
+    demoted every run to the legacy parser path.
+    """
+    engine = _make_mock_engine({"ACCESS_HISTORY": [_Row(dummy=1)]})
+
+    assert probe_access_history_available(engine, "SNOWFLAKE.ACCOUNT_USAGE") is True
+
+    conn = engine.connect.return_value
+    executed = [str(call.args[0]) for call in conn.execute.call_args_list]
+    assert any("ACCESS_HISTORY" in sql and "LIMIT 1" in sql for sql in executed)
+
+
+def test_probe_returns_false_when_query_raises():
+    """A genuine privilege/edition failure surfaces as a swallowed False."""
+    engine = _make_mock_engine({})
+    conn = engine.connect.return_value
+    conn.execute = MagicMock(side_effect=RuntimeError("insufficient privileges"))
+
+    assert probe_access_history_available(engine, "SNOWFLAKE.ACCOUNT_USAGE") is False
 
 
 # ---------------------------------------------------------------------------
@@ -557,11 +612,220 @@ def test_sql_query_text_attaches_when_present_in_row():
             ],
         },
     )
-    edges = list(src._yield_combined_access_history())
-    assert len(edges) == 1
-    details = edges[0].right.edge.lineageDetails
+    results = list(src._yield_combined_access_history())
+    lineage_requests = [
+        r.right for r in results if isinstance(r.right, AddLineageRequest)
+    ]
+    assert len(lineage_requests) == 1
+    details = lineage_requests[0].edge.lineageDetails
     assert details.sqlQuery is not None
     assert str(details.sqlQuery.root) == representative_sql
+
+
+def test_edge_with_query_text_also_creates_query_entity():
+    """
+    An edge whose row carries representative SQL must also emit a
+    CreateQueryRequest so the query surfaces in OpenMetadata exactly like the
+    legacy parser path. processedLineage stays True so the legacy parser never
+    re-processes an edge already derived from ACCESS_HISTORY.
+    """
+    upstream_entity = _make_table_entity(
+        "11111111-1111-1111-1111-111111111111", "DB", "SCHEMA", "ORDERS"
+    )
+    downstream_entity = _make_table_entity(
+        "22222222-2222-2222-2222-222222222222", "DB", "SCHEMA", "REVENUE"
+    )
+    metadata = MagicMock()
+    metadata.get_by_name = MagicMock(
+        side_effect=lambda entity, fqn: {
+            "test_service.DB.SCHEMA.ORDERS": upstream_entity,
+            "test_service.DB.SCHEMA.REVENUE": downstream_entity,
+        }.get(fqn)
+    )
+    representative_sql = "INSERT INTO REVENUE SELECT * FROM ORDERS"
+    src = _make_lineage_source(
+        metadata=metadata,
+        rows_by_sql={
+            "ACCESS_HISTORY": [
+                _Row(
+                    upstream_table="DB.SCHEMA.ORDERS",
+                    upstream_domain="Table",
+                    downstream_table="DB.SCHEMA.REVENUE",
+                    downstream_domain="Table",
+                    query_id="abc",
+                    query_text=representative_sql,
+                    query_type="INSERT",
+                    query_duration=1234.0,
+                    query_start_time=datetime(2025, 1, 1, 12, 0, 0),
+                    user_name="ETL_USER",
+                    column_pairs=None,
+                ),
+            ],
+        },
+    )
+
+    results = list(src._yield_combined_access_history())
+
+    queries = [r.right for r in results if isinstance(r.right, CreateQueryRequest)]
+    assert len(queries) == 1
+    query = queries[0]
+    assert str(query.query.root) == representative_sql
+    assert query.query_type == "INSERT"
+    assert query.duration == 1234.0
+    assert query.queryDate is not None
+    assert query.processedLineage is True
+    assert str(query.service.root) == "test_service"
+    # USER_NAME flows through to usedBy even when no matching OM user exists.
+    assert [str(u) for u in query.usedBy] == ["ETL_USER"]
+    # queryUsedIn links the query to both edge tables so it shows in their
+    # "Queries" tab (backend MENTIONED_IN relationship).
+    linked_ids = {str(ref.id.root) for ref in query.queryUsedIn.root}
+    assert linked_ids == {
+        "11111111-1111-1111-1111-111111111111",
+        "22222222-2222-2222-2222-222222222222",
+    }
+
+
+def test_query_entity_resolves_executing_user_to_om_user():
+    """
+    When the Snowflake USER_NAME matches an OpenMetadata user, the created
+    Query carries that user's FQN in `users`; the raw name always lands in
+    `usedBy`.
+    """
+    upstream_entity = _make_table_entity(
+        "11111111-1111-1111-1111-111111111111", "DB", "SCHEMA", "ORDERS"
+    )
+    downstream_entity = _make_table_entity(
+        "22222222-2222-2222-2222-222222222222", "DB", "SCHEMA", "REVENUE"
+    )
+    om_user = MagicMock()
+    om_user.fullyQualifiedName = FullyQualifiedEntityName("jdoe")
+
+    def _get_by_name(entity, fqn):
+        if entity is User:
+            return om_user if fqn == "jdoe" else None
+        return {
+            "test_service.DB.SCHEMA.ORDERS": upstream_entity,
+            "test_service.DB.SCHEMA.REVENUE": downstream_entity,
+        }.get(fqn)
+
+    metadata = MagicMock()
+    metadata.get_by_name = MagicMock(side_effect=_get_by_name)
+    src = _make_lineage_source(
+        metadata=metadata,
+        rows_by_sql={
+            "ACCESS_HISTORY": [
+                _Row(
+                    upstream_table="DB.SCHEMA.ORDERS",
+                    upstream_domain="Table",
+                    downstream_table="DB.SCHEMA.REVENUE",
+                    downstream_domain="Table",
+                    query_id="abc",
+                    query_text="INSERT INTO REVENUE SELECT * FROM ORDERS",
+                    user_name="jdoe",
+                    column_pairs=None,
+                ),
+            ],
+        },
+    )
+
+    results = list(src._yield_combined_access_history())
+    query = next(r.right for r in results if isinstance(r.right, CreateQueryRequest))
+    assert [str(u.root) for u in query.users] == ["jdoe"]
+    assert [str(u) for u in query.usedBy] == ["jdoe"]
+
+
+def test_query_entity_deduped_by_checksum_within_run():
+    """The same SQL spanning multiple edges must create a single Query entity."""
+    upstream_entity = _make_table_entity(
+        "11111111-1111-1111-1111-111111111111", "DB", "SCHEMA", "ORDERS"
+    )
+    downstream_a = _make_table_entity(
+        "22222222-2222-2222-2222-222222222222", "DB", "SCHEMA", "REVENUE"
+    )
+    downstream_b = _make_table_entity(
+        "33333333-3333-3333-3333-333333333333", "DB", "SCHEMA", "PROFIT"
+    )
+    metadata = MagicMock()
+    metadata.get_by_name = MagicMock(
+        side_effect=lambda entity, fqn: {
+            "test_service.DB.SCHEMA.ORDERS": upstream_entity,
+            "test_service.DB.SCHEMA.REVENUE": downstream_a,
+            "test_service.DB.SCHEMA.PROFIT": downstream_b,
+        }.get(fqn)
+    )
+    shared_sql = "INSERT INTO REVENUE SELECT * FROM ORDERS"
+    src = _make_lineage_source(
+        metadata=metadata,
+        rows_by_sql={
+            "ACCESS_HISTORY": [
+                _Row(
+                    upstream_table="DB.SCHEMA.ORDERS",
+                    upstream_domain="Table",
+                    downstream_table="DB.SCHEMA.REVENUE",
+                    downstream_domain="Table",
+                    query_id="abc",
+                    query_text=shared_sql,
+                    column_pairs=None,
+                ),
+                _Row(
+                    upstream_table="DB.SCHEMA.ORDERS",
+                    upstream_domain="Table",
+                    downstream_table="DB.SCHEMA.PROFIT",
+                    downstream_domain="Table",
+                    query_id="abc",
+                    query_text=shared_sql,
+                    column_pairs=None,
+                ),
+            ],
+        },
+    )
+
+    results = list(src._yield_combined_access_history())
+
+    lineage_requests = [
+        r.right for r in results if isinstance(r.right, AddLineageRequest)
+    ]
+    queries = [r.right for r in results if isinstance(r.right, CreateQueryRequest)]
+    assert len(lineage_requests) == 2
+    assert len(queries) == 1
+
+
+def test_no_query_entity_when_row_has_no_sql():
+    """An edge with no representative SQL must not emit a CreateQueryRequest."""
+    upstream_entity = _make_table_entity(
+        "11111111-1111-1111-1111-111111111111", "DB", "SCHEMA", "ORDERS"
+    )
+    downstream_entity = _make_table_entity(
+        "22222222-2222-2222-2222-222222222222", "DB", "SCHEMA", "REVENUE"
+    )
+    metadata = MagicMock()
+    metadata.get_by_name = MagicMock(
+        side_effect=lambda entity, fqn: {
+            "test_service.DB.SCHEMA.ORDERS": upstream_entity,
+            "test_service.DB.SCHEMA.REVENUE": downstream_entity,
+        }.get(fqn)
+    )
+    src = _make_lineage_source(
+        metadata=metadata,
+        rows_by_sql={
+            "ACCESS_HISTORY": [
+                _Row(
+                    upstream_table="DB.SCHEMA.ORDERS",
+                    upstream_domain="Table",
+                    downstream_table="DB.SCHEMA.REVENUE",
+                    downstream_domain="Table",
+                    query_id="abc",
+                    column_pairs=None,
+                ),
+            ],
+        },
+    )
+
+    results = list(src._yield_combined_access_history())
+
+    assert all(isinstance(r.right, AddLineageRequest) for r in results)
+    assert not [r for r in results if isinstance(r.right, CreateQueryRequest)]
 
 
 def test_table_edges_skip_when_either_side_unresolvable():


### PR DESCRIPTION
## What

The opt-in Snowflake **ACCESS_HISTORY** lineage path (`connectionOptions.useAccessHistory="true"`) emitted only `AddLineageRequest` edges. The SQL that produced each edge never showed up in OpenMetadata as **Query entities** the way the legacy `QUERY_HISTORY` parser path does. This PR closes that gap and fixes a latent bug that prevented the path from ever turning on.

## Changes

- **Create queries** (`lineage.py`): emit a `CreateQueryRequest` per edge that has representative SQL, deduped within the run by SQL checksum via a bounded LRU. Populates `query_type`, `duration`, `queryDate`, and the executing user.
  - **Who ran it**: `users` (matched OM user FQN) + `usedBy` (raw Snowflake `USER_NAME`) resolved via a bounded cache, mirroring the usage stage's `_get_user_entity`.
  - **Shows in the UI**: `queryUsedIn` references the edge's downstream + upstream tables so the backend creates the `MENTIONED_IN` relationship that the table **"Queries" tab** reads. Without it the Query is created but orphaned and never surfaces. Both tables are already in the edge cache, so this adds no extra API calls.
  - `processedLineage=True` since the edge is derived from ACCESS_HISTORY directly (legacy parser must not re-process it).
- **SQL** (`queries.py`): surface `QUERY_TYPE`, `TOTAL_ELAPSED_TIME`, `QUERY_START_TIME`, and `USER_NAME` alongside `QUERY_TEXT`, pinned to the representative query per edge via `MAX_BY`.
- **Models** (`models.py`): extend `AccessHistoryRow` with the new query-metadata fields.
- **Probe fix** (`connection.py`): import `sqlalchemy.text`. `probe_access_history_available` called `text(...)` without importing it, so the probe raised `NameError` on every run, the broad `except` swallowed it, and **every** workflow was silently demoted to the legacy parser path with a misleading "Enterprise+/IMPORTED PRIVILEGES" message. Existing tests mocked the probe out, so it went unnoticed.

## Testing

`ingestion/tests/unit/topology/database/test_snowflake_access_history_lineage.py` (52 passing) — covers query creation with full metadata, checksum dedup across edges sharing SQL, the no-SQL case, OM-user resolution, `queryUsedIn` linkage, the new SQL columns, and a regression test that executes the **real** probe (would have caught the `NameError`).

Verified end-to-end against a live Snowflake account: ACCESS_HISTORY path engages, 28 Query entities created and attached to their tables.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR closes two gaps in the Snowflake ACCESS_HISTORY lineage path: a `NameError` in `probe_access_history_available` that silently disabled the entire ACCESS_HISTORY path on every run, and the absence of `CreateQueryRequest` emission that meant ACCESS_HISTORY-derived edges never produced Query entities visible in the UI.

- **Probe fix** (`connection.py`): adds the missing `from sqlalchemy import text` import and removes dead-code password logic; the regression test now executes the real probe function rather than mocking it away.
- **Query entity creation** (`lineage.py`): emits a `CreateQueryRequest` per unique SQL checksum, resolves the executing Snowflake user to an OM user FQN, and populates `queryUsedIn` with both edge tables so the backend creates the `MENTIONED_IN` relationship needed for the table "Queries" tab.
- **SQL & model changes** (`queries.py`, `models.py`): surfaces `QUERY_TYPE`, `TOTAL_ELAPSED_TIME`, `QUERY_START_TIME`, and `USER_NAME` from `QUERY_HISTORY` via `MAX_BY` per edge; extends `AccessHistoryRow` with the corresponding optional fields.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge after fixing the duration unit in the SQL — all other changes are correct and well-tested.

The ACCESS_HISTORY SQL pulls TOTAL_ELAPSED_TIME directly from Snowflake without the /1000 conversion that the legacy query path applies (line 440). This means every Query entity created via this path will report a duration in milliseconds while the rest of the system stores seconds, making durations 1000× too large in the UI. Everything else — the probe fix, user resolution, queryUsedIn linkage, checksum dedup, and the new test suite — is solid.

ingestion/src/metadata/ingestion/source/database/snowflake/queries.py — the TOTAL_ELAPSED_TIME line in SNOWFLAKE_ACCESS_HISTORY_LINEAGE needs the /1000 divisor.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| ingestion/src/metadata/ingestion/source/database/snowflake/queries.py | Adds USER_NAME, QUERY_TYPE, and TOTAL_ELAPSED_TIME to SNOWFLAKE_ACCESS_HISTORY_LINEAGE SQL, but omits the /1000 milliseconds-to-seconds conversion present in the legacy query path. |
| ingestion/src/metadata/ingestion/source/database/snowflake/lineage.py | Adds _build_query_request, _build_query_used_in, and _resolve_query_user to emit CreateQueryRequest alongside AddLineageRequest; uses bounded LRU caches for dedup and user resolution; logic is correct and well-structured. |
| ingestion/src/metadata/ingestion/source/database/snowflake/connection.py | Fixes NameError in probe_access_history_available by importing sqlalchemy.text; cleans up dead-code password logic that always evaluated the truthy connection branch anyway. |
| ingestion/src/metadata/ingestion/source/database/snowflake/models.py | Extends AccessHistoryRow with query_type, query_duration, query_start_time, and user_name; all fields are Optional with sensible defaults. |
| ingestion/tests/unit/topology/database/test_snowflake_access_history_lineage.py | Adds thorough tests for query entity creation, checksum dedup, user resolution, queryUsedIn linkage, and a real-probe regression test that would have caught the NameError; all 52 cases are well-scoped. |

</details>

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant W as Workflow
    participant LS as SnowflakeLineageSource
    participant SF as Snowflake (ACCESS_HISTORY)
    participant OM as OpenMetadata API

    W->>LS: yield_query_lineage()
    LS->>SF: probe_access_history_available()
    SF-->>LS: OK (text() now imported)
    LS->>SF: SNOWFLAKE_ACCESS_HISTORY_LINEAGE (per window)
    SF-->>LS: rows (with QUERY_TYPE, QUERY_DURATION, USER_NAME)

    loop per row
        LS->>LS: _build_access_history_edge(row)
        LS-->>W: Either[AddLineageRequest]

        alt row.query_text present and checksum not seen
            LS->>OM: get_by_name(User, username)
            OM-->>LS: user or None
            LS->>LS: _build_query_used_in(row) cache hits
            LS-->>W: Either[CreateQueryRequest]
        end
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant W as Workflow
    participant LS as SnowflakeLineageSource
    participant SF as Snowflake (ACCESS_HISTORY)
    participant OM as OpenMetadata API

    W->>LS: yield_query_lineage()
    LS->>SF: probe_access_history_available()
    SF-->>LS: OK (text() now imported)
    LS->>SF: SNOWFLAKE_ACCESS_HISTORY_LINEAGE (per window)
    SF-->>LS: rows (with QUERY_TYPE, QUERY_DURATION, USER_NAME)

    loop per row
        LS->>LS: _build_access_history_edge(row)
        LS-->>W: Either[AddLineageRequest]

        alt row.query_text present and checksum not seen
            LS->>OM: get_by_name(User, username)
            OM-->>LS: user or None
            LS->>LS: _build_query_used_in(row) cache hits
            LS-->>W: Either[CreateQueryRequest]
        end
    end
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["feat(snowflake): create Query entities +..."](https://github.com/open-metadata/openmetadata/commit/a924450e237a9e319ba17d54f5223a151236a9ab) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38128068)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->