### PR TITLE
fix(test-suite): avoid NPE when listing test suites with unresolved test case references

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/TestSuiteRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/TestSuiteRepository.java
@@ -245,8 +245,8 @@ public class TestSuiteRepository extends EntityRepository<TestSuite> {
 
     return records.stream()
         .filter(r -> TEST_CASE.equals(r.getToEntity()))
+        .filter(rel -> idToRefMap.get(rel.getToId()) != null)
         .map(rel -> Map.entry(UUID.fromString(rel.getFromId()), idToRefMap.get(rel.getToId())))
-        .filter(entry -> entry.getValue() != null)
         .collect(
             Collectors.groupingBy(
                 Map.Entry::getKey, Collectors.mapping(Map.Entry::getValue, Collectors.toList())));


### PR DESCRIPTION
Fixes #29127

## What

`TestSuiteRepository.batchFetchTestCases` can throw a `NullPointerException` while *listing* test suites when a `CONTAINS` relationship points to a test case that no longer resolves (deleted / dangling ref). `Map.entry(k, v)` rejects a null value and throws **before** the existing `.filter(getValue() != null)` runs, so the guard never fires and the entire list request returns HTTP 500.

This is the intermittent failure behind `TestSuiteResourceIT` / `TestCaseResourceIT` list errors seen in integration tests.

## Fix

Drop unresolved references **before** building the map entry:

```java
.filter(rel -> idToRefMap.get(rel.getToId()) != null)
.map(rel -> Map.entry(UUID.fromString(rel.getFromId()), idToRefMap.get(rel.getToId())))
```

## Context

Latent since #21771 (*"Bulk load fields for paginations and indexing"*, 2025-07-07); present in all releases through 1.13 and `main`. Single-line, behaviour-preserving change — unresolved refs were always meant to be skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a `NullPointerException` in `TestSuiteRepository.batchFetchTestCases` that caused HTTP 500 responses when listing test suites containing dangling `CONTAINS` relationship references (i.e., test cases that were deleted after the relationship was recorded). `Map.entry(k, v)` throws NPE on a null value, so the previously placed post-map filter was unreachable.

- **Root cause fix**: the null check is moved from after `map()` to before it, so `Map.entry()` is never called with a null value reference.
- **Scope**: single-line, behaviour-preserving change — unresolved references were always intended to be silently skipped.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is a single-line reorder that only affects the NPE code path, with no behaviour change for well-formed data.

The fix correctly moves the null-guard filter before Map.entry() construction. All well-formed records are unaffected; dangling references were always intended to be silently dropped. The change is minimal, isolated to one private method, and directly addresses the root cause.

No files require special attention.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/TestSuiteRepository.java | Moves null-guard filter before Map.entry() construction to prevent NPE when a CONTAINS relationship points to a non-existent test case; fix is correct and behaviour-preserving. |

</details>

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Client
    participant TestSuiteResource
    participant TestSuiteRepository
    participant RelationshipDAO
    participant EntityRefs as Entity

    Client->>TestSuiteResource: GET /testSuites (list)
    TestSuiteResource->>TestSuiteRepository: batchFetchTestCases(testSuites)
    TestSuiteRepository->>RelationshipDAO: findToBatch(suiteIds, CONTAINS)
    RelationshipDAO-->>TestSuiteRepository: relationship records
    TestSuiteRepository->>EntityRefs: getEntityReferencesByIds(testCaseIds, Include.ALL)
    EntityRefs-->>TestSuiteRepository: resolved refs (dangling refs absent from map)
    Note over TestSuiteRepository: BEFORE: Map.entry(k, null) throws NPE<br/>AFTER: filter null refs before Map.entry()
    TestSuiteRepository-->>TestSuiteResource: suiteId to test cases map
    TestSuiteResource-->>Client: 200 OK
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Client
    participant TestSuiteResource
    participant TestSuiteRepository
    participant RelationshipDAO
    participant EntityRefs as Entity

    Client->>TestSuiteResource: GET /testSuites (list)
    TestSuiteResource->>TestSuiteRepository: batchFetchTestCases(testSuites)
    TestSuiteRepository->>RelationshipDAO: findToBatch(suiteIds, CONTAINS)
    RelationshipDAO-->>TestSuiteRepository: relationship records
    TestSuiteRepository->>EntityRefs: getEntityReferencesByIds(testCaseIds, Include.ALL)
    EntityRefs-->>TestSuiteRepository: resolved refs (dangling refs absent from map)
    Note over TestSuiteRepository: BEFORE: Map.entry(k, null) throws NPE<br/>AFTER: filter null refs before Map.entry()
    TestSuiteRepository-->>TestSuiteResource: suiteId to test cases map
    TestSuiteResource-->>Client: 200 OK
```

</a>
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(test-suite): avoid NPE when listing ..."](https://github.com/open-metadata/openmetadata/commit/a920e95730e3bbdf5497136f48aacaf60412fdbd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38141179)</sub>

<!-- /greptile_comment -->