### PR TITLE
fix(glossary): cascade glossary rename to child terms in search index

### DIFF
--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/GlossaryResourceIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/GlossaryResourceIT.java
@@ -32,6 +32,7 @@ import org.junit.jupiter.api.parallel.ExecutionMode;
 import org.openmetadata.it.util.SdkClients;
 import org.openmetadata.it.util.TestNamespace;
 import org.openmetadata.schema.api.data.CreateGlossary;
+import org.openmetadata.schema.api.data.CreateGlossaryTerm;
 import org.openmetadata.schema.entity.data.Glossary;
 import org.openmetadata.schema.entity.data.GlossaryTerm;
 import org.openmetadata.schema.type.ApiStatus;
@@ -624,15 +625,15 @@ public class GlossaryResourceIT extends BaseEntityIT<Glossary, CreateGlossary> {
                 .withName(originalName)
                 .withDescription("Glossary used for rename-propagation IT"));
 
-    org.openmetadata.schema.api.data.CreateGlossaryTerm createTerm =
-        new org.openmetadata.schema.api.data.CreateGlossaryTerm()
+    CreateGlossaryTerm createTerm =
+        new CreateGlossaryTerm()
             .withName(ns.prefix("term"))
             .withGlossary(glossary.getFullyQualifiedName())
             .withDescription("term under renamed glossary");
     GlossaryTerm term = client.glossaryTerms().create(createTerm);
 
-    org.openmetadata.schema.api.data.CreateGlossaryTerm createSubTerm =
-        new org.openmetadata.schema.api.data.CreateGlossaryTerm()
+    CreateGlossaryTerm createSubTerm =
+        new CreateGlossaryTerm()
             .withName(ns.prefix("subterm"))
             .withGlossary(glossary.getFullyQualifiedName())
             .withParent(term.getFullyQualifiedName())

--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/GlossaryResourceIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/GlossaryResourceIT.java
@@ -20,8 +20,12 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.time.Duration;
 import java.util.List;
 import java.util.UUID;
+import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
@@ -29,6 +33,7 @@ import org.openmetadata.it.util.SdkClients;
 import org.openmetadata.it.util.TestNamespace;
 import org.openmetadata.schema.api.data.CreateGlossary;
 import org.openmetadata.schema.entity.data.Glossary;
+import org.openmetadata.schema.entity.data.GlossaryTerm;
 import org.openmetadata.schema.type.ApiStatus;
 import org.openmetadata.schema.type.EntityHistory;
 import org.openmetadata.schema.type.EntityReference;
@@ -599,6 +604,123 @@ public class GlossaryResourceIT extends BaseEntityIT<Glossary, CreateGlossary> {
         Exception.class,
         () -> patchEntity(glossary.getId().toString(), glossary),
         "Cannot rename system provider glossary");
+  }
+
+  /**
+   * Reproduces the bug where renaming a glossary leaves child terms with stale glossary denorm
+   * (glossary.name / glossary.fullyQualifiedName) and stale own fullyQualifiedName in the search
+   * index. The DB rename cascades, but before the inline updateAssetIndexes call was added in
+   * GlossaryRepository.updateName the ES cascade only ran via entityRelationshipReindex — which
+   * has had no caller since PR #19550.
+   */
+  @Test
+  void test_renameGlossaryPropagatesToChildTermSearchIndex(TestNamespace ns) throws Exception {
+    OpenMetadataClient client = SdkClients.adminClient();
+
+    String originalName = ns.prefix("renameProp");
+    Glossary glossary =
+        createEntity(
+            new CreateGlossary()
+                .withName(originalName)
+                .withDescription("Glossary used for rename-propagation IT"));
+
+    org.openmetadata.schema.api.data.CreateGlossaryTerm createTerm =
+        new org.openmetadata.schema.api.data.CreateGlossaryTerm()
+            .withName(ns.prefix("term"))
+            .withGlossary(glossary.getFullyQualifiedName())
+            .withDescription("term under renamed glossary");
+    GlossaryTerm term = client.glossaryTerms().create(createTerm);
+
+    org.openmetadata.schema.api.data.CreateGlossaryTerm createSubTerm =
+        new org.openmetadata.schema.api.data.CreateGlossaryTerm()
+            .withName(ns.prefix("subterm"))
+            .withGlossary(glossary.getFullyQualifiedName())
+            .withParent(term.getFullyQualifiedName())
+            .withDescription("subterm under renamed glossary");
+    GlossaryTerm subTerm = client.glossaryTerms().create(createSubTerm);
+
+    awaitTermIndexed(client, term.getId().toString());
+    awaitTermIndexed(client, subTerm.getId().toString());
+
+    String newName = ns.prefix("renamePropAfter");
+    glossary.setName(newName);
+    Glossary renamed = patchEntity(glossary.getId().toString(), glossary);
+    assertEquals(newName, renamed.getName());
+    assertEquals(newName, renamed.getFullyQualifiedName());
+
+    String expectedTermFqn = newName + "." + term.getName();
+    String expectedSubTermFqn = expectedTermFqn + "." + subTerm.getName();
+
+    Awaitility.await("term ES doc reflects glossary rename")
+        .pollInterval(Duration.ofMillis(500))
+        .atMost(Duration.ofSeconds(60))
+        .ignoreExceptions()
+        .untilAsserted(
+            () -> {
+              JsonNode termDoc = searchTermSourceById(client, term.getId().toString());
+              assertNotNull(termDoc, "child term doc must be present in search index");
+              assertEquals(
+                  expectedTermFqn,
+                  termDoc.path("fullyQualifiedName").asText(""),
+                  "child term fullyQualifiedName must reflect renamed glossary");
+              assertEquals(
+                  newName,
+                  termDoc.path("glossary").path("name").asText(""),
+                  "child term glossary.name denorm must reflect rename");
+              assertEquals(
+                  newName,
+                  termDoc.path("glossary").path("fullyQualifiedName").asText(""),
+                  "child term glossary.fullyQualifiedName denorm must reflect rename");
+
+              JsonNode subDoc = searchTermSourceById(client, subTerm.getId().toString());
+              assertNotNull(subDoc, "grandchild term doc must be present in search index");
+              assertEquals(
+                  expectedSubTermFqn,
+                  subDoc.path("fullyQualifiedName").asText(""),
+                  "grandchild fullyQualifiedName must reflect renamed glossary");
+              assertEquals(
+                  newName,
+                  subDoc.path("glossary").path("name").asText(""),
+                  "grandchild glossary.name denorm must reflect rename");
+              assertEquals(
+                  expectedTermFqn,
+                  subDoc.path("parent").path("fullyQualifiedName").asText(""),
+                  "grandchild parent.fullyQualifiedName must reflect renamed glossary");
+            });
+  }
+
+  private static final ObjectMapper RENAME_PROP_MAPPER = new ObjectMapper();
+  private static final String GLOSSARY_TERM_SEARCH_INDEX = "glossary_term_search_index";
+
+  private JsonNode searchTermSourceById(OpenMetadataClient client, String termId) throws Exception {
+    String filter = "{\"query\":{\"term\":{\"id.keyword\":\"" + termId + "\"}}}";
+    String response =
+        client
+            .search()
+            .query("*")
+            .index(GLOSSARY_TERM_SEARCH_INDEX)
+            .queryFilter(filter)
+            .size(1)
+            .deleted(false)
+            .execute();
+    JsonNode hits = RENAME_PROP_MAPPER.readTree(response).path("hits").path("hits");
+    JsonNode result = null;
+    for (JsonNode hit : hits) {
+      if (termId.equals(hit.path("_source").path("id").asText(""))) {
+        result = hit.path("_source");
+        break;
+      }
+    }
+    return result;
+  }
+
+  private void awaitTermIndexed(OpenMetadataClient client, String termId) {
+    Awaitility.await("glossary term " + termId + " becomes searchable")
+        .pollInterval(Duration.ofMillis(500))
+        .atMost(Duration.ofSeconds(60))
+        .ignoreExceptions()
+        .untilAsserted(
+            () -> assertNotNull(searchTermSourceById(client, termId), "term not yet indexed"));
   }
 
   @Test

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/GlossaryRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/GlossaryRepository.java
@@ -706,6 +706,12 @@ public class GlossaryRepository extends EntityRepository<Glossary> {
               PolicyConditionUpdater.renamePrefixInCondition(
                   condition, oldFqn, newFqn, PolicyConditionUpdater.TAG_FUNCTIONS));
 
+      // Cascade rename into the search index — child term FQNs and the embedded glossary denorm
+      // (glossary.name / glossary.fullyQualifiedName) must reflect the new name. This used to be
+      // driven by entityRelationshipReindex, which has no caller since PR #19550, so the call has
+      // to happen inline here (mirroring Domain / Classification / GlossaryTerm renames).
+      updateAssetIndexes(original, updated);
+
       finishInvalidateCacheForRenameCascade(Entity.GLOSSARY_TERM, renamedTerms);
     }
 


### PR DESCRIPTION
Fixes #29135

## Summary

Renaming a glossary updated the DB but left every child glossary term's search-index doc with the **old** glossary name in its denormalized `glossary.name` / `glossary.fullyQualifiedName` and an **old** `fullyQualifiedName` on the term itself. The DB-side cascade worked; only Elasticsearch was stale.

## Root cause

The ES cascade for a glossary rename used to be driven by `entityRelationshipReindex(original, updated)` invoked from `EntityRepository.patch(...)`. That call site was removed in [#19550](https://github.com/open-metadata/OpenMetadata/pull/19550) (Feb 2025) and was never restored, leaving `entityRelationshipReindex` without any caller.

Every other rename-supporting repository already performs the ES rewrite **inline** inside its `updateName`:

| Repo | Inline ES cascade in `updateName`? |
|---|---|
| `DomainRepository.updateName` | ✅ `updateSearchIndexes(...)` |
| `ClassificationRepository.updateName` | ✅ `updateAssetIndexes(...)` |
| `GlossaryTermRepository.updateName` / `updateParent` | ✅ `updateAssetIndexes(...)` |
| `ContainerRepository` rename | ✅ `updateAssetIndexes(...)` |
| **`GlossaryRepository.updateName`** | **❌ only via the dead `entityRelationshipReindex` hook** |

So glossary-level rename has been silently leaving stale child term docs in the search index since #19550.

## Fix

Mirror the inline pattern from the sister repos: call `updateAssetIndexes(original, updated)` directly at the end of `GlossaryUpdater.updateName`, after the DB FQN rewrite and policy condition updates. No new code path — just reusing the existing private method that was already there but unreachable.

## Test plan

- [x] Added `test_renameGlossaryPropagatesToChildTermSearchIndex` in `GlossaryResourceIT`. Creates a glossary with a child term and grandchild subterm, renames the glossary, and asserts on the ES docs of both child terms that `fullyQualifiedName`, `glossary.name`, `glossary.fullyQualifiedName`, and `parent.fullyQualifiedName` all reflect the new glossary name.
- [x] Verified RED on `main` (test times out waiting for the stale FQN to converge — the bug reproduces deterministically).
- [x] Verified GREEN after the fix.
- [x] `GlossaryResourceIT`: 95 tests, 0 failures, 0 errors (5 skipped).
- [x] `GlossaryTermResourceIT`: 107 tests, 0 failures, 0 errors (1 skipped).

## Reproduction (manual)

1. Create glossary `G` with term `T` and subterm `T.TT`.
2. Rename `G` → `G_renamed`.
3. Search `glossary_term_search_index` for `T` and `T.TT`.
4. **Before this fix:** docs still show `glossary.name: "G"`, `fullyQualifiedName: "G.T"`, etc.
5. **After this fix:** docs show `glossary.name: "G_renamed"`, `fullyQualifiedName: "G_renamed.T"`, etc.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a long-standing bug where renaming a glossary correctly updated the database but left every child term's Elasticsearch document with stale `fullyQualifiedName`, `glossary.name`, and `glossary.fullyQualifiedName` fields. The root cause was the removal of the `entityRelationshipReindex` call site in PR #19550, which was the only driver of the ES cascade for glossary renames.

- **Core fix** (`GlossaryRepository.java`): adds a single `updateAssetIndexes(original, updated)` call at the end of `GlossaryUpdater.updateName`, mirroring the inline ES-cascade pattern already used by `DomainRepository`, `ClassificationRepository`, and `GlossaryTermRepository`.
- **Integration test** (`GlossaryResourceIT.java`): adds `test_renameGlossaryPropagatesToChildTermSearchIndex`, which creates a two-level term hierarchy, renames the glossary, and polls ES (Awaitility, 60 s) until all denormalized fields converge on both the child and grandchild term documents.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is a minimal one-line addition that reuses a well-tested private method already called by sibling repositories for the same rename-cascade scenario.

The fix is surgical: one `updateAssetIndexes` call added at the correct point in the rename flow, after the DB rewrite and before the cache-invalidation pass. The method is private, already exercised by Classification and Domain renames, and the integration test deterministically reproduces the original bug and verifies convergence. No new code paths are introduced.

The integration test in `GlossaryResourceIT.java` is missing a `glossary.fullyQualifiedName` assertion on the grandchild term document, which is a minor coverage gap but does not affect merge safety.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/GlossaryRepository.java | Adds a single inline `updateAssetIndexes(original, updated)` call at the end of `GlossaryUpdater.updateName`, mirroring the pattern already used by Domain/Classification/GlossaryTerm repos; a note exists about the dormant `entityRelationshipReindex` override that also calls `updateAssetIndexes` and could cause double-reindex if given a future caller. |
| openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/GlossaryResourceIT.java | Adds an integration test that creates a glossary with a child term and grandchild, renames the glossary, and polls ES until denorm fields converge; test is well-structured but omits a `glossary.fullyQualifiedName` assertion on the grandchild document. |

</details>


</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/GlossaryRepository.java`, line 221-226 ([link](https://github.com/open-metadata/openmetadata/blob/8f5ae85abb3ea555a263b11777681aa2f5c66fb8/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/GlossaryRepository.java#L221-L226)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Dormant double-reindex path still present**

   `entityRelationshipReindex` (lines 221-226) calls `updateAssetIndexes` unconditionally when the FQN changes. Now that `updateName` also calls `updateAssetIndexes` inline, any future code that restores a caller for `entityRelationshipReindex` will trigger a second full reindex of all child terms for every glossary rename — doubling the ES write load and potentially racing with the first pass. Consider removing the `updateAssetIndexes` call from `entityRelationshipReindex` (or the entire override) so the canonical path is only the one added by this PR.

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["test: import CreateGlossaryTerm instead ..."](https://github.com/open-metadata/openmetadata/commit/c68ecad495ff952d768318a580b9b8db2beec4e6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38183743)</sub>

<!-- /greptile_comment -->