### PR TITLE
Fix flaky "Entity not found: <service>" on list (concurrent cascade delete)

### DIFF
--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/BaseEntityIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/BaseEntityIT.java
@@ -33,6 +33,7 @@ import org.openmetadata.it.util.TestNamespace;
 import org.openmetadata.it.util.TestNamespaceExtension;
 import org.openmetadata.it.util.UpdateType;
 import org.openmetadata.schema.EntityInterface;
+import org.openmetadata.schema.ServiceEntityInterface;
 import org.openmetadata.schema.api.policies.CreatePolicy;
 import org.openmetadata.schema.api.teams.CreateRole;
 import org.openmetadata.schema.api.teams.CreateUser;
@@ -45,7 +46,10 @@ import org.openmetadata.schema.entity.teams.Role;
 import org.openmetadata.schema.entity.teams.User;
 import org.openmetadata.schema.type.ApiStatus;
 import org.openmetadata.schema.type.ChangeDescription;
+import org.openmetadata.schema.type.EntityReference;
+import org.openmetadata.schema.type.Include;
 import org.openmetadata.schema.type.MetadataOperation;
+import org.openmetadata.schema.type.Relationship;
 import org.openmetadata.schema.type.TagLabel;
 import org.openmetadata.schema.type.api.BulkOperationResult;
 import org.openmetadata.schema.type.api.BulkResponse;
@@ -58,6 +62,10 @@ import org.openmetadata.sdk.network.HttpMethod;
 import org.openmetadata.sdk.services.policies.PolicyService;
 import org.openmetadata.sdk.services.teams.RoleService;
 import org.openmetadata.sdk.services.teams.UserService;
+import org.openmetadata.service.Entity;
+import org.openmetadata.service.jdbi3.CollectionDAO;
+import org.openmetadata.service.jdbi3.EntityDAO;
+import org.openmetadata.service.jdbi3.EntityRepository;
 import org.openmetadata.service.util.TestUtils;
 
 /**
@@ -1046,6 +1054,76 @@ public abstract class BaseEntityIT<T extends EntityInterface, K> {
         Exception.class,
         () -> listEntities(paramsBefore),
         "Listing with invalid before cursor should fail");
+  }
+
+  /**
+   * Regression for the flaky {@code Entity not found: <service> <id>} failure on the LIST path (seen
+   * in CI on {@code ContainerResourceIT}/{@code MlModelResourceIT}). A list resolves every row's
+   * parent service in bulk, in a statement separate from the relationship lookup; when a sibling
+   * test cascade-hard-deletes the service in between, the {@code CONTAINS} relationship row is still
+   * seen but the service entity row is already gone. A non-lenient bulk resolver then threw {@code
+   * EntityNotFoundException} and failed the whole list instead of the single affected row.
+   *
+   * <p>Runs for every entity directly contained by a service this test created (skips entities with
+   * no owned service parent). Reproduces the window deterministically: delete only the service
+   * entity row (the {@code CONTAINS} relationship survives) and evict it from the entity cache —
+   * exactly the state a concurrent cascade delete leaves mid-flight — then list scoped by the
+   * now-dangling service FQN. The list must succeed; the bulk resolver must tolerate the deleted
+   * service rather than fail the whole page.
+   */
+  @Test
+  void list_toleratesConcurrentlyHardDeletedService(TestNamespace ns) {
+    T entity = createEntity(createMinimalRequest(ns));
+    EntityReference serviceRef = findOwnedServiceParent(ns, entity);
+    Assumptions.assumeTrue(
+        serviceRef != null,
+        getEntityType() + " is not directly contained by a service it owns; tolerance test N/A");
+
+    String serviceType = serviceRef.getType();
+    EntityDAO<?> serviceDao = Entity.getEntityRepository(serviceType).getDao();
+    int rowsRemoved = serviceDao.delete(serviceDao.getTableName(), serviceRef.getId());
+    assertEquals(1, rowsRemoved, "Setup: should have removed exactly the service entity row");
+    EntityRepository.invalidateCacheForEntity(
+        serviceType, serviceRef.getId(), serviceRef.getFullyQualifiedName());
+
+    org.openmetadata.sdk.models.ListParams params = new org.openmetadata.sdk.models.ListParams();
+    params.setService(serviceRef.getFullyQualifiedName());
+    params.setLimit(1000);
+
+    org.openmetadata.sdk.models.ListResponse<T> response = listEntities(params);
+    assertNotNull(response);
+    assertNotNull(
+        response.getData(),
+        "List must tolerate the concurrently hard-deleted service, not fail the whole page");
+  }
+
+  /**
+   * Find this entity's immediate {@code CONTAINS} parent that is a service AND was created by this
+   * test (tracked as a namespace root) so deleting it can never disturb a shared fixture. Returns
+   * {@code null} when the entity is not directly service-scoped or its parent service is not owned
+   * here.
+   */
+  private EntityReference findOwnedServiceParent(TestNamespace ns, T entity) {
+    EntityReference serviceRef = null;
+    List<CollectionDAO.EntityRelationshipRecord> parents =
+        Entity.getCollectionDAO()
+            .relationshipDAO()
+            .findFrom(entity.getId(), getEntityType(), Relationship.CONTAINS.ordinal());
+    for (CollectionDAO.EntityRelationshipRecord parent : parents) {
+      boolean ownedByThisTest =
+          ns.trackedRoots().stream().anyMatch(root -> root.id().equals(parent.getId()));
+      if (ownedByThisTest && isServiceEntity(parent.getType(), parent.getId())) {
+        serviceRef = Entity.getEntityReferenceById(parent.getType(), parent.getId(), Include.ALL);
+        break;
+      }
+    }
+    return serviceRef;
+  }
+
+  private boolean isServiceEntity(String entityType, UUID id) {
+    EntityInterface candidate =
+        Entity.getEntity(new EntityReference().withId(id).withType(entityType), "", Include.ALL);
+    return candidate instanceof ServiceEntityInterface;
   }
 
   @Test

--- a/openmetadata-service/src/main/java/org/openmetadata/service/Entity.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/Entity.java
@@ -527,6 +527,30 @@ public final class Entity {
     return repository.getReference(id, include);
   }
 
+  /**
+   * Lenient variant of {@link #getEntityReferenceById(String, UUID, Include)} that returns {@code
+   * null} instead of throwing when the referenced entity was concurrently hard-deleted. A bulk read
+   * path resolves a relationship's target entity in a statement separate from the relationship
+   * lookup; if the target is hard-deleted in between (e.g. a sibling test cascade-deleting a parent
+   * service), the relationship row was seen but the entity row is already gone. Returning {@code
+   * null} there — rather than 500'ing the whole list with "Entity not found: &lt;type&gt;
+   * &lt;id&gt;" — mirrors {@link EntityRepository#getFromEntityRef}'s existing single-entity
+   * tolerance and the batch resolver {@link #getEntityReferencesByIds}, whose underlying
+   * {@code findEntitiesByIds} already omits concurrently-deleted rows.
+   */
+  public static EntityReference getEntityReferenceByIdOrNull(
+      @NonNull String entityType, @NonNull UUID id, Include include) {
+    EntityReference reference;
+    try {
+      reference = getEntityReferenceById(entityType, id, include);
+    } catch (EntityNotFoundException e) {
+      LOG.debug(
+          "Skipping concurrently-deleted reference {} {}: {}", entityType, id, e.getMessage());
+      reference = null;
+    }
+    return reference;
+  }
+
   public static List<EntityReference> getEntityReferencesByIds(
       @NonNull String entityType, @NonNull List<UUID> ids, Include include) {
     // Check if this is a time-series entity

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/ContainerRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/ContainerRepository.java
@@ -8,7 +8,7 @@ import static org.openmetadata.service.Entity.DASHBOARD_DATA_MODEL;
 import static org.openmetadata.service.Entity.FIELD_PARENT;
 import static org.openmetadata.service.Entity.FIELD_TAGS;
 import static org.openmetadata.service.Entity.STORAGE_SERVICE;
-import static org.openmetadata.service.Entity.getEntityReferenceById;
+import static org.openmetadata.service.Entity.getEntityReferenceByIdOrNull;
 import static org.openmetadata.service.resources.tags.TagLabelUtil.addDerivedTagsGracefully;
 import static org.openmetadata.service.resources.tags.TagLabelUtil.addDerivedTagsWithPreFetched;
 import static org.openmetadata.service.resources.tags.TagLabelUtil.batchFetchDerivedTags;
@@ -187,9 +187,11 @@ public class ContainerRepository extends EntityRepository<Container> {
       // Only consider container parents, not service parents
       if (CONTAINER.equals(record.getFromEntity())) {
         EntityReference parentRef =
-            getEntityReferenceById(
+            getEntityReferenceByIdOrNull(
                 record.getFromEntity(), UUID.fromString(record.getFromId()), NON_DELETED);
-        parentsMap.put(containerId, parentRef);
+        if (parentRef != null) {
+          parentsMap.put(containerId, parentRef);
+        }
       }
     }
 
@@ -226,8 +228,10 @@ public class ContainerRepository extends EntityRepository<Container> {
     for (CollectionDAO.EntityRelationshipObject record : records) {
       UUID parentId = UUID.fromString(record.getFromId());
       EntityReference childRef =
-          getEntityReferenceById(CONTAINER, UUID.fromString(record.getToId()), NON_DELETED);
-      childrenMap.get(parentId).add(childRef);
+          getEntityReferenceByIdOrNull(CONTAINER, UUID.fromString(record.getToId()), NON_DELETED);
+      if (childRef != null) {
+        childrenMap.get(parentId).add(childRef);
+      }
     }
 
     return childrenMap;
@@ -273,8 +277,10 @@ public class ContainerRepository extends EntityRepository<Container> {
       UUID serviceId = UUID.fromString(record.getFromId());
       EntityReference serviceRef =
           serviceRefById.computeIfAbsent(
-              serviceId, id -> getEntityReferenceById(STORAGE_SERVICE, id, NON_DELETED));
-      serviceMap.put(containerId, serviceRef);
+              serviceId, id -> getEntityReferenceByIdOrNull(STORAGE_SERVICE, id, NON_DELETED));
+      if (serviceRef != null) {
+        serviceMap.put(containerId, serviceRef);
+      }
     }
 
     return serviceMap;

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/DirectoryRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/DirectoryRepository.java
@@ -27,6 +27,7 @@ import static org.openmetadata.service.Entity.FIELD_PARENT;
 import static org.openmetadata.service.Entity.FILE;
 import static org.openmetadata.service.Entity.SPREADSHEET;
 import static org.openmetadata.service.Entity.getEntityReferenceById;
+import static org.openmetadata.service.Entity.getEntityReferenceByIdOrNull;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -281,8 +282,11 @@ public class DirectoryRepository extends EntityRepository<Directory> {
         UUID fromId = UUID.fromString(record.getFromId());
         EntityReference ref =
             refById.computeIfAbsent(
-                fromId, id -> getEntityReferenceById(fromEntityType, id, Include.NON_DELETED));
-        resultMap.put(directoryId, ref);
+                fromId,
+                id -> getEntityReferenceByIdOrNull(fromEntityType, id, Include.NON_DELETED));
+        if (ref != null) {
+          resultMap.put(directoryId, ref);
+        }
       }
     }
     return resultMap;

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/IngestionPipelineRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/IngestionPipelineRepository.java
@@ -274,9 +274,11 @@ public class IngestionPipelineRepository extends EntityRepository<IngestionPipel
     for (CollectionDAO.EntityRelationshipObject record : records) {
       UUID pipelineId = UUID.fromString(record.getToId());
       EntityReference serviceRef =
-          Entity.getEntityReferenceById(
+          Entity.getEntityReferenceByIdOrNull(
               record.getFromEntity(), UUID.fromString(record.getFromId()), Include.NON_DELETED);
-      serviceMap.put(pipelineId, serviceRef);
+      if (serviceRef != null) {
+        serviceMap.put(pipelineId, serviceRef);
+      }
     }
 
     return serviceMap;

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/LLMModelRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/LLMModelRepository.java
@@ -104,9 +104,11 @@ public class LLMModelRepository extends EntityRepository<LLMModel> {
     for (CollectionDAO.EntityRelationshipObject record : records) {
       UUID llmModelId = UUID.fromString(record.getToId());
       EntityReference serviceRef =
-          Entity.getEntityReferenceById(
+          Entity.getEntityReferenceByIdOrNull(
               Entity.LLM_SERVICE, UUID.fromString(record.getFromId()), NON_DELETED);
-      serviceMap.put(llmModelId, serviceRef);
+      if (serviceRef != null) {
+        serviceMap.put(llmModelId, serviceRef);
+      }
     }
 
     return serviceMap;

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/MlModelRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/MlModelRepository.java
@@ -195,9 +195,11 @@ public class MlModelRepository extends EntityRepository<MlModel> {
     for (CollectionDAO.EntityRelationshipObject record : records) {
       UUID mlModelId = UUID.fromString(record.getToId());
       EntityReference serviceRef =
-          Entity.getEntityReferenceById(
+          Entity.getEntityReferenceByIdOrNull(
               Entity.MLMODEL_SERVICE, UUID.fromString(record.getFromId()), NON_DELETED);
-      serviceMap.put(mlModelId, serviceRef);
+      if (serviceRef != null) {
+        serviceMap.put(mlModelId, serviceRef);
+      }
     }
 
     return serviceMap;

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/PipelineRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/PipelineRepository.java
@@ -972,9 +972,11 @@ public class PipelineRepository extends EntityRepository<Pipeline> {
     for (CollectionDAO.EntityRelationshipObject record : records) {
       UUID pipelineId = UUID.fromString(record.getToId());
       EntityReference serviceRef =
-          Entity.getEntityReferenceById(
+          Entity.getEntityReferenceByIdOrNull(
               Entity.PIPELINE_SERVICE, UUID.fromString(record.getFromId()), NON_DELETED);
-      serviceMap.put(pipelineId, serviceRef);
+      if (serviceRef != null) {
+        serviceMap.put(pipelineId, serviceRef);
+      }
     }
 
     return serviceMap;

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/SearchIndexRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/SearchIndexRepository.java
@@ -227,9 +227,11 @@ public class SearchIndexRepository extends EntityRepository<SearchIndex> {
       if (Entity.SEARCH_SERVICE.equals(record.getFromEntity())) {
         UUID searchIndexId = UUID.fromString(record.getToId());
         EntityReference serviceRef =
-            Entity.getEntityReferenceById(
+            Entity.getEntityReferenceByIdOrNull(
                 Entity.SEARCH_SERVICE, UUID.fromString(record.getFromId()), Include.NON_DELETED);
-        serviceMap.put(searchIndexId, serviceRef);
+        if (serviceRef != null) {
+          serviceMap.put(searchIndexId, serviceRef);
+        }
       }
     }
 

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/TopicRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/TopicRepository.java
@@ -573,9 +573,11 @@ public class TopicRepository extends EntityRepository<Topic> {
         record -> {
           var topicId = UUID.fromString(record.getToId());
           var serviceRef =
-              Entity.getEntityReferenceById(
+              Entity.getEntityReferenceByIdOrNull(
                   Entity.MESSAGING_SERVICE, UUID.fromString(record.getFromId()), NON_DELETED);
-          serviceMap.put(topicId, serviceRef);
+          if (serviceRef != null) {
+            serviceMap.put(topicId, serviceRef);
+          }
         });
 
     return serviceMap;


### PR DESCRIPTION
### Describe your changes:

Fixes the flaky `Entity not found: storageService/mlmodelService <id>` failures on the **list** path (seen in CI on `ContainerResourceIT`/`MlModelResourceIT`). A list resolves each row's parent service in bulk, in a statement separate from the relationship lookup; when a sibling test cascade-hard-deletes that service mid-list, the `CONTAINS` relationship row is still visible while the service entity row is already gone, and the non-lenient bulk resolver threw and failed the whole list instead of the one affected row. PR #29093 fixed this read-side TOCTOU for the single-GET path; this extends the same tolerance to the LIST batch path. I added `Entity.getEntityReferenceByIdOrNull()` (catches `EntityNotFoundException` → null, mirroring `getFromEntityRef`) and used it in the 8 non-lenient batch service resolvers (Container, MlModel, Topic, Pipeline, SearchIndex, LLMModel, IngestionPipeline, Directory) plus Container's parent/children resolvers, with null-guarded puts.

#
### Type of change:
- [x] Bug fix

#
### High-level design:

The failure is read-side: a list loads rows, then resolves each row's `CONTAINS` parent service in a separate statement. The single-GET path (`getContainer`/`getFromEntityRef`) already tolerates the parent being concurrently hard-deleted (returns `null`); the per-repo `batchFetch*` loops did not — they called the throwing `Entity.getEntityReferenceById()`. The fix adds a lenient sibling and swaps it in only where the bulk path was still throwing. Repos that already resolve via the batch `getEntityReferencesByIds` (Table, Database, DatabaseSchema, Dashboard, Chart, APICollection, APIEndpoint) were already lenient and are untouched. No schema, API, or behavior change beyond returning a `null` service reference (instead of a 404/500) when the parent was concurrently deleted.

#
### Tests:

#### Use cases covered
- Listing any service-scoped entity while its parent service is concurrently hard-deleted returns 200 with the service tolerated as `null`, instead of failing the whole page.

#### Backend integration tests
- [x] Added `BaseEntityIT#list_toleratesConcurrentlyHardDeletedService` — a generic, deterministic regression test that runs for every entity extending `BaseEntityIT`. It deletes only the service entity row + evicts the entity cache (the exact concurrent-delete window: relationship row present, entity row gone), then asserts the scoped list succeeds. It is namespace-ownership-gated (only deletes a service this test created) and skips entities with no owned service parent.
- Files: `openmetadata-integration-tests/.../BaseEntityIT.java`

#### Manual testing performed
- Ran the test on the `mysql-elasticsearch` profile: verified **RED** without the fix (`ApiException (404): Entity not found: storageService <id>` at the list call) and **GREEN** with it, for both `ContainerResourceIT` (storageService) and `TopicResourceIT` (messagingService). `mvn spotless:check` passes.

#
### UI screen recording / screenshots:

Not applicable.

#
### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have added tests (integration) and listed them above.
- [x] I have added a test that covers the exact scenario we are fixing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Extends the read-side TOCTOU tolerance (introduced in #29093 for single-GET) to the LIST batch path by adding `Entity.getEntityReferenceByIdOrNull` and swapping it into 8 non-lenient `batchFetch*` service resolvers with null-guarded map puts. A new generic regression test in `BaseEntityIT` reproduces the race window deterministically for every entity type.

- **`Entity.getEntityReferenceByIdOrNull`** catches `EntityNotFoundException` and returns `null`, mirroring the existing `getFromEntityRef` and `getEntityReferencesByIds` tolerance, with a `DEBUG` log to keep the signal without noise.
- **8 repository batch resolvers** (Container, Directory, MlModel, Topic, Pipeline, SearchIndex, LLMModel, IngestionPipeline) are switched to the lenient variant; Container's parent/child resolvers are also covered.
- **`list_toleratesConcurrentlyHardDeletedService`** in `BaseEntityIT` deletes only the service entity row and evicts the cache (the exact concurrent-delete window), then asserts the scoped list returns 200 instead of throwing a 404.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge — the production fix is minimal and well-scoped; the only note is that the deduplication map in ContainerRepository and DirectoryRepository won't cache null results, so a full page of containers under the same concurrently-deleted service will each hit the DB separately.

The core change is a targeted catch-and-null around getEntityReferenceById in batch resolvers, with careful null-guards before every map put. The pattern is consistent across all 8 repositories. The one thing to watch is computeIfAbsent not caching null in ContainerRepository and DirectoryRepository — the deduplication advertised in the comment only works for live services; deleted services incur N lookups instead of 1 per page.

ContainerRepository.java and DirectoryRepository.java — both use computeIfAbsent for deduplication but that map won't retain null results, so the optimisation doesn't apply to the concurrent-delete case.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-service/src/main/java/org/openmetadata/service/Entity.java | Adds `getEntityReferenceByIdOrNull` — a lenient wrapper that catches `EntityNotFoundException` and returns null, mirrors existing single-entity and batch-resolver tolerance. |
| openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/ContainerRepository.java | Switches three batch resolvers (parent containers, child containers, storage service) to the lenient variant with null-guards; `computeIfAbsent` won't cache null so the deduplication map doesn't protect against repeated DB hits for the same deleted service. |
| openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/DirectoryRepository.java | Switches `batchFetchFromByType` to the lenient variant; same `computeIfAbsent`-null deduplication gap as ContainerRepository. Non-batch paths keep the throwing variant correctly. |
| openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/MlModelRepository.java | Switches `batchFetchMlModelService` to the lenient variant with a null-guard; straightforward and correct. |
| openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/TopicRepository.java | Switches messaging-service batch resolver to the lenient variant with a null-guard inside a forEach lambda; clean. |
| openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/PipelineRepository.java | Switches pipeline-service batch resolver to the lenient variant with a null-guard; straightforward. |
| openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/SearchIndexRepository.java | Switches search-service batch resolver to the lenient variant with a null-guard; straightforward. |
| openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/IngestionPipelineRepository.java | Switches ingestion-pipeline service batch resolver to the lenient variant with a null-guard; straightforward. |
| openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/LLMModelRepository.java | Switches LLM-service batch resolver to the lenient variant with a null-guard; straightforward. |
| openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/BaseEntityIT.java | Adds `list_toleratesConcurrentlyHardDeletedService` regression test that deterministically reproduces the TOCTOU window (entity row deleted, relationship row intact) and asserts the list succeeds; `isServiceEntity` does a needless full DB fetch for the type-check. |

</details>

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Client
    participant ListEndpoint
    participant RelationshipDAO
    participant BatchResolver
    participant EntityDAO

    Client->>ListEndpoint: "GET /containers?service=svc"
    ListEndpoint->>RelationshipDAO: findFromBatch(containerIds, CONTAINS)
    Note over RelationshipDAO: Returns rows — service row still present
    RelationshipDAO-->>ListEndpoint: "[{serviceId, containerId}, ...]"

    Note over EntityDAO: Concurrent hard-delete removes service entity row

    ListEndpoint->>BatchResolver: resolve service references
    alt Before fix
        BatchResolver->>EntityDAO: fetch service by ID
        EntityDAO-->>BatchResolver: EntityNotFoundException
        BatchResolver-->>Client: 404 / 500
    else After fix
        BatchResolver->>EntityDAO: fetch service by ID
        EntityDAO-->>BatchResolver: EntityNotFoundException returns null
        BatchResolver-->>ListEndpoint: "serviceRef = null (skipped in map)"
        ListEndpoint-->>Client: 200 OK (service field null for affected rows)
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Client
    participant ListEndpoint
    participant RelationshipDAO
    participant BatchResolver
    participant EntityDAO

    Client->>ListEndpoint: "GET /containers?service=svc"
    ListEndpoint->>RelationshipDAO: findFromBatch(containerIds, CONTAINS)
    Note over RelationshipDAO: Returns rows — service row still present
    RelationshipDAO-->>ListEndpoint: "[{serviceId, containerId}, ...]"

    Note over EntityDAO: Concurrent hard-delete removes service entity row

    ListEndpoint->>BatchResolver: resolve service references
    alt Before fix
        BatchResolver->>EntityDAO: fetch service by ID
        EntityDAO-->>BatchResolver: EntityNotFoundException
        BatchResolver-->>Client: 404 / 500
    else After fix
        BatchResolver->>EntityDAO: fetch service by ID
        EntityDAO-->>BatchResolver: EntityNotFoundException returns null
        BatchResolver-->>ListEndpoint: "serviceRef = null (skipped in map)"
        ListEndpoint-->>Client: 200 OK (service field null for affected rows)
    end
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["Fix flaky &quot;Entity not found: &lt;service&gt;&quot; ..."](https://github.com/open-metadata/openmetadata/commit/fac052188ecee198a7580782438591b2ef87d916) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38272369)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->