### PR TITLE
fix(search): never set live refresh_interval to -1 on reindex promotion

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/DefaultRecreateHandler.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/DefaultRecreateHandler.java
@@ -43,6 +43,8 @@ public class DefaultRecreateHandler implements RecreateIndexHandler {
   private static final String TRANSLOG = "translog";
   private static final String DURABILITY = "durability";
   private static final String SYNC_INTERVAL = "sync_interval";
+  private static final String REFRESH_DISABLED = "-1";
+  private static final String DEFAULT_LIVE_REFRESH_INTERVAL = "1s";
 
   private EventPublisherJob jobData;
 
@@ -676,13 +678,33 @@ public class DefaultRecreateHandler implements RecreateIndexHandler {
   }
 
   private static String pickRefreshInterval(IndexSettings live, BulkIndexOverrides bulk) {
+    String refreshInterval = null;
     if (live != null && live.getRefreshInterval() != null) {
-      return live.getRefreshInterval();
+      refreshInterval = live.getRefreshInterval();
+    } else if (bulk != null && bulk.getRefreshInterval() != null) {
+      refreshInterval = DEFAULT_LIVE_REFRESH_INTERVAL; // bulk disabled refresh; restore default
     }
-    if (bulk != null && bulk.getRefreshInterval() != null) {
-      return "1s"; // bulk disabled refresh; restore near-real-time default
+    if (isRefreshDisabled(refreshInterval)) {
+      LOG.warn(
+          "Configured live refresh_interval '{}' disables refresh and would leave the promoted "
+              + "index unsearchable until a manual _refresh. Overriding to '{}' so documents stay "
+              + "searchable after promotion.",
+          refreshInterval,
+          DEFAULT_LIVE_REFRESH_INTERVAL);
+      refreshInterval = DEFAULT_LIVE_REFRESH_INTERVAL;
     }
-    return null;
+    return refreshInterval;
+  }
+
+  /**
+   * A {@code refresh_interval} of {@code -1} disables refresh entirely. That is correct for a
+   * staged index nothing reads from, but as a <em>live</em> serving value it leaves newly indexed
+   * documents invisible to search until a manual {@code _refresh} — the "reindex finishes but the
+   * page is empty" symptom. The live-revert must never apply it, regardless of what the admin
+   * configured on {@code liveIndexSettings} or what fell back from the bulk overrides.
+   */
+  private static boolean isRefreshDisabled(String refreshInterval) {
+    return refreshInterval != null && REFRESH_DISABLED.equals(refreshInterval.trim());
   }
 
   private static Integer pickReplicas(IndexSettings live, BulkIndexOverrides bulk) {

--- a/openmetadata-service/src/test/java/org/openmetadata/service/search/DefaultRecreateHandlerTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/search/DefaultRecreateHandlerTest.java
@@ -1458,6 +1458,24 @@ class DefaultRecreateHandlerTest {
     }
 
     @Test
+    @DisplayName("Live refresh_interval '-1' is never applied as a live value (guard -> 1s)")
+    void liveRefreshDisabledIsOverriddenToDefault() {
+      // Misconfiguration: liveIndexSettings.refreshInterval is "-1" (refresh disabled) — e.g.
+      // copied from the bulk side or a stale saved config. Without the guard the revert would
+      // faithfully re-apply "-1" to the promoted index, leaving it unsearchable until a manual
+      // _refresh (the "reindex finishes but the page is empty" symptom). The revert must override
+      // it back to the near-real-time default.
+      org.openmetadata.schema.system.IndexSettings live =
+          new org.openmetadata.schema.system.IndexSettings().withRefreshInterval("-1");
+      org.openmetadata.schema.system.BulkIndexOverrides bulk =
+          new org.openmetadata.schema.system.BulkIndexOverrides().withRefreshInterval("-1");
+      String json = DefaultRecreateHandler.buildRevertJson(live, bulk);
+      assertNotNull(json);
+      assertTrue(json.contains("\"refresh_interval\":\"1s\""));
+      assertFalse(json.contains("\"refresh_interval\":\"-1\""));
+    }
+
+    @Test
     @DisplayName("Bulk JSON properly escapes admin-supplied string values")
     void bulkSettingsEscapesQuotesInValues() {
       // Hostile / unusual but legal admin input — quote, backslash, newline. Naive string


### PR DESCRIPTION
### Describe your changes:

<!-- TODO(maintainer): link the regression issue — e.g. `Fixes #29xxx` -->

I added a guard in `DefaultRecreateHandler.pickRefreshInterval` so a `refresh_interval` of `-1` (refresh disabled) is never applied as a *live* serving value during reindex promotion, because a misconfigured `liveIndexSettings.refreshInterval=-1` was being re-applied verbatim to the promoted index and left newly indexed documents unsearchable until a manual `_refresh` (the "reindex finishes but the page is empty" symptom). When the resolved live value would be `-1`, it is now overridden to `1s` and a warning is logged so operators can spot the bad config. Both promotion paths — centralized `finalizeReindex` and per-entity `promoteEntityIndex` — funnel through this method, so the guard covers both flows. Added a unit test asserting the revert JSON yields `refresh_interval:"1s"` and never `-1`.

#
### Type of change:

- [x] Bug fix

#
### High-level design:

N/A — small, self-contained change to the reindex live-settings revert.

#
### Tests:

#### Use cases covered
- Reindex promotion where the saved `liveIndexSettings.refreshInterval` is `-1`: the promoted index is left with a near-real-time `1s` refresh instead of a disabled refresh, so create-then-search returns results without a manual `_refresh`.

#### Unit tests
- [x] Added `DefaultRecreateHandlerTest.BuildRevertJsonTests#liveRefreshDisabledIsOverriddenToDefault` — RED without the fix (the old code returned the live `-1`).
- Verified: `mvn -pl openmetadata-service test -Dtest=DefaultRecreateHandlerTest` → 39 tests, 0 failures.

#### Backend integration tests
- [x] Not applicable (no API change; pure internal index-settings logic, covered by unit test).

#### Ingestion integration tests
- [x] Not applicable (no ingestion changes).

#### Playwright (UI) tests
- [x] Not applicable (no UI changes).

#### Manual testing performed
Verified via the unit test above; no local stack run required for this internal logic change.

#
### UI screen recording / screenshots:

Not applicable.

#
### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above. <!-- pending issue number -->
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] For JSON Schema changes: I updated the migration scripts or explained why it is not needed. <!-- no schema change -->
- [x] For UI changes: N/A.
- [x] I have added tests and listed them above.

<!-- Bug fix -->
- [x] I have added a test that covers the exact scenario we are fixing.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This fix guards against a misconfigured `liveIndexSettings.refreshInterval=-1` being re-applied verbatim to a promoted index during reindex, which left newly indexed documents invisible to search until a manual `_refresh`. A new `isRefreshDisabled` helper and a warn+override in `pickRefreshInterval` ensure the live value is always at least `1s`.

- Adds `isRefreshDisabled(String)` helper and overrides any `-1` refresh interval to `\"1s\"` with a warning log, covering both the `finalizeReindex` and `promoteEntityIndex` promotion paths.
- Adds a unit test asserting that `buildRevertJson` with `live.refreshInterval=\"-1\"` emits `\"1s\"`, though the isolated case of `live=\"-1\"` with `bulk=null` is not separately exercised.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; the change is narrowly scoped to the reindex promotion path and the override only fires for the pathological `-1` value.

The production logic is correct and the fix covers both promotion paths. The one gap is that the test exercises both `live` and `bulk` set to `-1` simultaneously, so the simpler misconfiguration of `live=-1` with no active bulk run is not directly pinned by a test — a future refactor could break that branch silently.

The test file would benefit from an additional case covering `live="-1"` with `bulk=null`.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-service/src/main/java/org/openmetadata/service/search/DefaultRecreateHandler.java | Adds a guard in `pickRefreshInterval` that prevents a live `refresh_interval` of `-1` from being applied on index promotion; overrides it to `1s` and logs a warning. Logic refactored from two early-returns to a single `isRefreshDisabled` helper — semantics preserved for all existing paths. |
| openmetadata-service/src/test/java/org/openmetadata/service/search/DefaultRecreateHandlerTest.java | Adds `liveRefreshDisabledIsOverriddenToDefault` test asserting the guard produces `1s` and never `-1`. Test exercises the scenario where both live and bulk carry `-1`, but the pure `live=-1, bulk=null` case (the most direct form of the misconfiguration) is not explicitly covered. |

</details>

</details>

<details open><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[pickRefreshInterval called\nlive, bulk] --> B{live != null\n&& live.refreshInterval != null?}
    B -- Yes --> C[refreshInterval = live.refreshInterval]
    B -- No --> D{bulk != null\n&& bulk.refreshInterval != null?}
    D -- Yes --> E[refreshInterval = '1s'\ndefault live value]
    D -- No --> F[refreshInterval = null]
    C --> G{isRefreshDisabled?\nrefreshInterval.trim == '-1'}
    E --> G
    F --> G
    G -- Yes --> H[LOG.warn\nOverride to '1s']
    H --> I[refreshInterval = '1s']
    G -- No --> J[return refreshInterval as-is]
    I --> J
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[pickRefreshInterval called\nlive, bulk] --> B{live != null\n&& live.refreshInterval != null?}
    B -- Yes --> C[refreshInterval = live.refreshInterval]
    B -- No --> D{bulk != null\n&& bulk.refreshInterval != null?}
    D -- Yes --> E[refreshInterval = '1s'\ndefault live value]
    D -- No --> F[refreshInterval = null]
    C --> G{isRefreshDisabled?\nrefreshInterval.trim == '-1'}
    E --> G
    F --> G
    G -- Yes --> H[LOG.warn\nOverride to '1s']
    H --> I[refreshInterval = '1s']
    G -- No --> J[return refreshInterval as-is]
    I --> J
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(search): never apply refresh\_interva..."](https://github.com/open-metadata/openmetadata/commit/f6221d5eab7e23f9b9d642b2f903c12cb0bc812d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38297346)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->