### PR TITLE
fix(glossary): cascade glossary rename to child terms in search index (#29134) [1.13]

### DIFF
--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/GlossaryResourceIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/GlossaryResourceIT.java
@@ -20,15 +20,21 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.time.Duration;
 import java.util.List;
 import java.util.UUID;
+import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
 import org.openmetadata.it.util.SdkClients;
 import org.openmetadata.it.util.TestNamespace;
 import org.openmetadata.schema.api.data.CreateGlossary;
+import org.openmetadata.schema.api.data.CreateGlossaryTerm;
 import org.openmetadata.schema.entity.data.Glossary;
+import org.openmetadata.schema.entity.data.GlossaryTerm;
 import org.openmetadata.schema.type.ApiStatus;
 import org.openmetadata.schema.type.EntityHistory;
 import org.openmetadata.schema.type.EntityReference;
@@ -599,6 +605,123 @@ public class GlossaryResourceIT extends BaseEntityIT<Glossary, CreateGlossary> {
         Exception.class,
         () -> patchEntity(glossary.getId().toString(), glossary),
         "Cannot rename system provider glossary");
+  }
+
+  /**
+   * Reproduces the bug where renaming a glossary leaves child terms with stale glossary denorm
+   * (glossary.name / glossary.fullyQualifiedName) and stale own fullyQualifiedName in the search
+   * index. The DB rename cascades, but before the inline updateAssetIndexes call was added in
+   * GlossaryRepository.updateName the ES cascade only ran via entityRelationshipReindex — which
+   * has had no caller since PR #19550.
+   */
+  @Test
+  void test_renameGlossaryPropagatesToChildTermSearchIndex(TestNamespace ns) throws Exception {
+    OpenMetadataClient client = SdkClients.adminClient();
+
+    String originalName = ns.prefix("renameProp");
+    Glossary glossary =
+        createEntity(
+            new CreateGlossary()
+                .withName(originalName)
+                .withDescription("Glossary used for rename-propagation IT"));
+
+    CreateGlossaryTerm createTerm =
+        new CreateGlossaryTerm()
+            .withName(ns.prefix("term"))
+            .withGlossary(glossary.getFullyQualifiedName())
+            .withDescription("term under renamed glossary");
+    GlossaryTerm term = client.glossaryTerms().create(createTerm);
+
+    CreateGlossaryTerm createSubTerm =
+        new CreateGlossaryTerm()
+            .withName(ns.prefix("subterm"))
+            .withGlossary(glossary.getFullyQualifiedName())
+            .withParent(term.getFullyQualifiedName())
+            .withDescription("subterm under renamed glossary");
+    GlossaryTerm subTerm = client.glossaryTerms().create(createSubTerm);
+
+    awaitTermIndexed(client, term.getId().toString());
+    awaitTermIndexed(client, subTerm.getId().toString());
+
+    String newName = ns.prefix("renamePropAfter");
+    glossary.setName(newName);
+    Glossary renamed = patchEntity(glossary.getId().toString(), glossary);
+    assertEquals(newName, renamed.getName());
+    assertEquals(newName, renamed.getFullyQualifiedName());
+
+    String expectedTermFqn = newName + "." + term.getName();
+    String expectedSubTermFqn = expectedTermFqn + "." + subTerm.getName();
+
+    Awaitility.await("term ES doc reflects glossary rename")
+        .pollInterval(Duration.ofMillis(500))
+        .atMost(Duration.ofSeconds(60))
+        .ignoreExceptions()
+        .untilAsserted(
+            () -> {
+              JsonNode termDoc = searchTermSourceById(client, term.getId().toString());
+              assertNotNull(termDoc, "child term doc must be present in search index");
+              assertEquals(
+                  expectedTermFqn,
+                  termDoc.path("fullyQualifiedName").asText(""),
+                  "child term fullyQualifiedName must reflect renamed glossary");
+              assertEquals(
+                  newName,
+                  termDoc.path("glossary").path("name").asText(""),
+                  "child term glossary.name denorm must reflect rename");
+              assertEquals(
+                  newName,
+                  termDoc.path("glossary").path("fullyQualifiedName").asText(""),
+                  "child term glossary.fullyQualifiedName denorm must reflect rename");
+
+              JsonNode subDoc = searchTermSourceById(client, subTerm.getId().toString());
+              assertNotNull(subDoc, "grandchild term doc must be present in search index");
+              assertEquals(
+                  expectedSubTermFqn,
+                  subDoc.path("fullyQualifiedName").asText(""),
+                  "grandchild fullyQualifiedName must reflect renamed glossary");
+              assertEquals(
+                  newName,
+                  subDoc.path("glossary").path("name").asText(""),
+                  "grandchild glossary.name denorm must reflect rename");
+              assertEquals(
+                  expectedTermFqn,
+                  subDoc.path("parent").path("fullyQualifiedName").asText(""),
+                  "grandchild parent.fullyQualifiedName must reflect renamed glossary");
+            });
+  }
+
+  private static final ObjectMapper RENAME_PROP_MAPPER = new ObjectMapper();
+  private static final String GLOSSARY_TERM_SEARCH_INDEX = "glossary_term_search_index";
+
+  private JsonNode searchTermSourceById(OpenMetadataClient client, String termId) throws Exception {
+    String filter = "{\"query\":{\"term\":{\"id.keyword\":\"" + termId + "\"}}}";
+    String response =
+        client
+            .search()
+            .query("*")
+            .index(GLOSSARY_TERM_SEARCH_INDEX)
+            .queryFilter(filter)
+            .size(1)
+            .deleted(false)
+            .execute();
+    JsonNode hits = RENAME_PROP_MAPPER.readTree(response).path("hits").path("hits");
+    JsonNode result = null;
+    for (JsonNode hit : hits) {
+      if (termId.equals(hit.path("_source").path("id").asText(""))) {
+        result = hit.path("_source");
+        break;
+      }
+    }
+    return result;
+  }
+
+  private void awaitTermIndexed(OpenMetadataClient client, String termId) {
+    Awaitility.await("glossary term " + termId + " becomes searchable")
+        .pollInterval(Duration.ofMillis(500))
+        .atMost(Duration.ofSeconds(60))
+        .ignoreExceptions()
+        .untilAsserted(
+            () -> assertNotNull(searchTermSourceById(client, termId), "term not yet indexed"));
   }
 
   @Test

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/GlossaryRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/GlossaryRepository.java
@@ -693,6 +693,12 @@ public class GlossaryRepository extends EntityRepository<Glossary> {
           condition ->
               PolicyConditionUpdater.renamePrefixInCondition(
                   condition, oldFqn, newFqn, PolicyConditionUpdater.TAG_FUNCTIONS));
+
+      // Cascade rename into the search index — child term FQNs and the embedded glossary denorm
+      // (glossary.name / glossary.fullyQualifiedName) must reflect the new name. This used to be
+      // driven by entityRelationshipReindex, which has no caller since PR #19550, so the call has
+      // to happen inline here (mirroring Domain / Classification / GlossaryTerm renames).
+      updateAssetIndexes(original, updated);
     }
 
     public void invalidateGlossary(UUID classificationId) {


### PR DESCRIPTION
Cherry-pick of #29134 into the 1.13 release branch.

Conflict: 1.13 lacks the rename-cascade cache invalidation plumbing introduced on `main` (`invalidateCacheForRenameCascade` / `renamedTerms` / `finishInvalidateCacheForRenameCascade`). Resolved by dropping the `finishInvalidateCacheForRenameCascade` line and keeping only the new `updateAssetIndexes(original, updated)` call — that is the actual fix.

## Verification

- `mvn install -pl openmetadata-service -am -DskipTests` clean
- `mvn -pl openmetadata-integration-tests test-compile` clean
- `GlossaryResourceIT#test_renameGlossaryPropagatesToChildTermSearchIndex` → 1 / 0 / 0 (14.26 s)

Original PR: #29134
Issue: #29135

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Cherry-pick of #29134 onto the 1.13 branch — fixes a bug where renaming a glossary left all child terms with stale `fullyQualifiedName` and denormalized `glossary.*` fields in Elasticsearch because `entityRelationshipReindex` (the previous cascade driver) has had no caller since PR #19550.

- **`GlossaryRepository.java`**: adds a single `updateAssetIndexes(original, updated)` call at the end of `GlossaryUpdater.updateName()`, mirroring the pattern already used in `ClassificationRepository` and `GlossaryTermRepository`. The cherry-pick conflict was resolved by omitting the `finishInvalidateCacheForRenameCascade` helper (absent on 1.13) while keeping the core search-index fix.
- **`GlossaryResourceIT.java`**: new IT that creates a glossary with a child term and a grandchild term, renames the glossary, and asserts via Awaitility that the ES docs for both terms reflect the updated FQN and embedded `glossary.*` / `parent.*` references.
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; the change is a one-line addition that closes a long-standing search-index staleness bug on glossary rename, backed by a new integration test that passes.

The fix is minimal and well-understood: a single `updateAssetIndexes` call added at the end of the rename path, matching the pattern already used in Classification and GlossaryTerm repositories. The existing `entityRelationshipReindex` override (lines 221-227) contains a duplicate call to `updateAssetIndexes` that would fire if that method ever gains a caller again — today it is dead code so there is no runtime impact, but the redundancy is worth noting. The integration test covers child and grandchild term propagation across FQN, `glossary.*`, and `parent.*` fields.

The `entityRelationshipReindex` override in `GlossaryRepository.java` (lines 221-227) also calls `updateAssetIndexes` on rename and is worth revisiting if that hook is ever re-wired.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/GlossaryRepository.java | Adds an inline `updateAssetIndexes(original, updated)` call at the end of `GlossaryUpdater.updateName()` to cascade glossary renames into the Elasticsearch index. The fix mirrors the pattern already used in Classification and GlossaryTerm renames. A latent double-reindex is possible if `entityRelationshipReindex` is re-enabled later (lines 221-227 also call `updateAssetIndexes` on rename), but it is harmless and idempotent today. |
| openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/GlossaryResourceIT.java | New integration test `test_renameGlossaryPropagatesToChildTermSearchIndex` verifies that both child-term and grandchild-term ES documents are updated after a glossary rename. Uses Awaitility with a 60-second budget, waits for initial indexing before the rename, and asserts FQN, `glossary.name`, `glossary.fullyQualifiedName`, and `parent.fullyQualifiedName` fields. Well-structured with no issues. |

</details>


</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Client
    participant GlossaryResource
    participant GlossaryUpdater
    participant DB
    participant ES

    Client->>GlossaryResource: "PATCH /glossaries/{id} (rename)"
    GlossaryResource->>GlossaryUpdater: entitySpecificUpdate()
    GlossaryUpdater->>GlossaryUpdater: updateName(updated)
    GlossaryUpdater->>DB: glossaryTermDAO.updateFqn(oldFqn, newFqn)
    GlossaryUpdater->>DB: tagUsageDAO.updateTagPrefix(oldFqn, newFqn)
    GlossaryUpdater->>DB: invalidateCacheForRenameCascade(GLOSSARY_TERM, oldFqn)
    GlossaryUpdater->>GlossaryUpdater: updateAssetIndexes(original, updated) NEW
    GlossaryUpdater->>DB: getAllTerms(updated)
    GlossaryUpdater->>ES: getEntitiesContainingFQNFromES(original.fqn)
    loop each child term
        GlossaryUpdater->>ES: searchRepository.updateEntity(child)
        GlossaryUpdater->>ES: reindexAcrossIndices(tags.tagFQN, child)
    end
    GlossaryUpdater->>ES: updateEntityIndex(original)
    GlossaryUpdater->>ES: reindexAcrossIndices(fullyQualifiedName, original)
    GlossaryUpdater->>ES: reindexAcrossIndices(glossary.name, original)
    GlossaryResource-->>Client: 200 OK
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Client
    participant GlossaryResource
    participant GlossaryUpdater
    participant DB
    participant ES

    Client->>GlossaryResource: "PATCH /glossaries/{id} (rename)"
    GlossaryResource->>GlossaryUpdater: entitySpecificUpdate()
    GlossaryUpdater->>GlossaryUpdater: updateName(updated)
    GlossaryUpdater->>DB: glossaryTermDAO.updateFqn(oldFqn, newFqn)
    GlossaryUpdater->>DB: tagUsageDAO.updateTagPrefix(oldFqn, newFqn)
    GlossaryUpdater->>DB: invalidateCacheForRenameCascade(GLOSSARY_TERM, oldFqn)
    GlossaryUpdater->>GlossaryUpdater: updateAssetIndexes(original, updated) NEW
    GlossaryUpdater->>DB: getAllTerms(updated)
    GlossaryUpdater->>ES: getEntitiesContainingFQNFromES(original.fqn)
    loop each child term
        GlossaryUpdater->>ES: searchRepository.updateEntity(child)
        GlossaryUpdater->>ES: reindexAcrossIndices(tags.tagFQN, child)
    end
    GlossaryUpdater->>ES: updateEntityIndex(original)
    GlossaryUpdater->>ES: reindexAcrossIndices(fullyQualifiedName, original)
    GlossaryUpdater->>ES: reindexAcrossIndices(glossary.name, original)
    GlossaryResource-->>Client: 200 OK
```

</a>
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/GlossaryRepository.java`, line 221-227 ([link](https://github.com/open-metadata/openmetadata/blob/387e52c389d05310022bd7e6948801789ca92ae6/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/GlossaryRepository.java#L221-L227)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Latent double reindex if `entityRelationshipReindex` is ever re-wired**

   `entityRelationshipReindex` already calls `updateAssetIndexes(original, updated)` on a rename (lines 223-226). Now that `updateName` also calls it inline (line 701), a future caller of `entityRelationshipReindex` on the rename path would trigger the full ES cascade twice. Today this is harmless — the method is reportedly dead since PR #19550 — but the duplication could surprise the next developer who adds a caller. A comment here noting that `updateName` already handles the ES cascade would prevent confusion.

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["fix(glossary): cascade glossary rename t..."](https://github.com/open-metadata/openmetadata/commit/387e52c389d05310022bd7e6948801789ca92ae6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38332528)</sub>

<!-- /greptile_comment -->