### PR TITLE
fix(ui): use Untitled-UI dropdowns for Add Assets drawer quick-filters

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/DataAssets/AssetsSelectionModal/useAssetSelectionContent.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataAssets/AssetsSelectionModal/useAssetSelectionContent.tsx
@@ -717,6 +717,7 @@ export const useAssetSelectionContent = ({
           fields={filters}
           index={SearchIndex.ALL}
           showDeleted={false}
+          untitledDropdown={variant === 'drawer'}
           onFieldValueSelect={handleQuickFiltersValueSelect}
         />
         {quickFilterQuery && (

--- a/openmetadata-ui/src/main/resources/ui/src/components/Explore/ExploreQuickFilters.interface.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Explore/ExploreQuickFilters.interface.ts
@@ -31,4 +31,5 @@ export interface ExploreQuickFiltersProps {
   showSelectedCounts?: boolean; // flag to show counts instead of labels for selected filters
   optionPageSize?: number;
   additionalActions?: ReactNode;
+  untitledDropdown?: boolean;
 }

--- a/openmetadata-ui/src/main/resources/ui/src/components/Explore/ExploreQuickFilters.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Explore/ExploreQuickFilters.tsx
@@ -34,6 +34,7 @@ import { SearchDropdownOption } from '../SearchDropdown/SearchDropdown.interface
 import { useAdvanceSearch } from './AdvanceSearchProvider/AdvanceSearchProvider.component';
 import { ExploreSearchIndex } from './ExplorePage.interface';
 import { ExploreQuickFiltersProps } from './ExploreQuickFilters.interface';
+import QuickFilterDropdown from './QuickFilterDropdown';
 const ExploreQuickFilters: FC<ExploreQuickFiltersProps> = ({
   fields,
   index,
@@ -45,6 +46,7 @@ const ExploreQuickFilters: FC<ExploreQuickFiltersProps> = ({
   showSelectedCounts = false,
   optionPageSize,
   additionalActions,
+  untitledDropdown = false,
 }) => {
   const location = useCustomLocation();
   const [options, setOptions] = useState<SearchDropdownOption[]>();
@@ -207,7 +209,24 @@ const ExploreQuickFilters: FC<ExploreQuickFiltersProps> = ({
         );
         const dropdownOptions = field.options ?? options ?? [];
 
-        return (
+        return untitledDropdown ? (
+          <QuickFilterDropdown
+            hideCounts={field.hideCounts ?? false}
+            key={field.key}
+            label={translateWithNestedKeys(field.label, field.labelKeyOptions)}
+            options={dropdownOptions}
+            searchKey={field.key}
+            selectedKeys={field.value ?? []}
+            showSelectedCounts={showSelectedCounts}
+            singleSelect={field.singleSelect}
+            onChange={(updatedValues) =>
+              onFieldValueSelect({ ...field, value: updatedValues })
+            }
+            onGetInitialOptions={(key) =>
+              getInitialOptions(key, field.searchIndex, field.searchKey)
+            }
+          />
+        ) : (
           <SearchDropdown
             highlight
             dropdownClassName={field.dropdownClassName}

--- a/openmetadata-ui/src/main/resources/ui/src/components/Explore/QuickFilterDropdown.interface.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Explore/QuickFilterDropdown.interface.ts
@@ -1,0 +1,25 @@
+/*
+ *  Copyright 2025 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+import { SearchDropdownOption } from '../SearchDropdown/SearchDropdown.interface';
+
+export interface QuickFilterDropdownProps {
+  label: string;
+  searchKey: string;
+  options: SearchDropdownOption[];
+  selectedKeys: SearchDropdownOption[];
+  hideCounts?: boolean;
+  singleSelect?: boolean;
+  showSelectedCounts?: boolean;
+  onChange: (values: SearchDropdownOption[], searchKey: string) => void;
+  onGetInitialOptions?: (searchKey: string) => void;
+}

--- a/openmetadata-ui/src/main/resources/ui/src/components/Explore/QuickFilterDropdown.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Explore/QuickFilterDropdown.tsx
@@ -1,0 +1,94 @@
+/*
+ *  Copyright 2025 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+import { Button, Dropdown } from '@openmetadata/ui-core-components';
+import { ChevronDown } from '@untitledui/icons';
+import { isUndefined } from 'lodash';
+import { FC, useMemo } from 'react';
+import { getSelectedOptionLabelString } from '../../utils/AdvancedSearchPureUtils';
+import { QuickFilterDropdownProps } from './QuickFilterDropdown.interface';
+
+/**
+ * Untitled-UI (react-aria) variant of {@link SearchDropdown}, built on the
+ * core `Dropdown` primitive. Its popover renders in the react-aria top layer,
+ * so it stays interactive inside a SlideoutMenu drawer where an Ant Design
+ * popup (portaled to document.body) would become inert.
+ */
+const QuickFilterDropdown: FC<QuickFilterDropdownProps> = ({
+  label,
+  searchKey,
+  options,
+  selectedKeys,
+  hideCounts = false,
+  singleSelect = false,
+  showSelectedCounts = false,
+  onChange,
+  onGetInitialOptions,
+}) => {
+  const selectedIds = useMemo(
+    () => new Set(selectedKeys.map((option) => option.key)),
+    [selectedKeys]
+  );
+
+  const selectedLabel = showSelectedCounts
+    ? `(${selectedKeys.length})`
+    : getSelectedOptionLabelString(selectedKeys);
+
+  return (
+    <Dropdown.Root
+      onOpenChange={(open) => open && onGetInitialOptions?.(searchKey)}>
+      <Button
+        color="secondary"
+        data-testid={searchKey}
+        iconTrailing={<ChevronDown className="tw:size-4" />}
+        size="sm">
+        <span data-testid={`search-dropdown-${label}`}>
+          {label}
+          {selectedKeys.length > 0 && (
+            <span className="tw:text-brand-secondary">{`: ${selectedLabel}`}</span>
+          )}
+        </span>
+      </Button>
+      <Dropdown.Popover>
+        <Dropdown.Menu
+          aria-label={label}
+          disallowEmptySelection={false}
+          selectedKeys={selectedIds}
+          selectionMode={singleSelect ? 'single' : 'multiple'}
+          onSelectionChange={(keys) =>
+            onChange(
+              options.filter(
+                (option) => keys === 'all' || keys.has(option.key)
+              ),
+              searchKey
+            )
+          }>
+          {options.map((option) => (
+            <Dropdown.Item
+              showCheckbox
+              addon={
+                hideCounts || isUndefined(option.count)
+                  ? undefined
+                  : String(option.count)
+              }
+              id={option.key}
+              key={option.key}>
+              {option.label}
+            </Dropdown.Item>
+          ))}
+        </Dropdown.Menu>
+      </Dropdown.Popover>
+    </Dropdown.Root>
+  );
+};
+
+export default QuickFilterDropdown;


### PR DESCRIPTION
### Describe your changes:

The **Domains / Data Products → Add Assets** drawer quick-filters (Entity Type, Owners, Tag, Tier, Service) are now interactive.

**Why:** The Add Assets drawer is an Untitled-UI `SlideoutMenu` (react-aria `Modal`/`Dialog`). The quick filters used the Ant Design `SearchDropdown`, whose popup portals to `document.body` — *outside* the dialog subtree, where react-aria's `inert` attribute makes it non-interactive (clicks fall through and the popup closes). `z-index` can't override `inert`.

**What:** Add a small **`QuickFilterDropdown`** built on the core **`Dropdown`** (react-aria) primitive from `@openmetadata/ui-core-components`. Its popover renders in the dialog's own top layer, so it stays interactive — no AntD-over-drawer workaround (`getPopupContainer`/`ConfigProvider`). `ExploreQuickFilters` renders it behind an `untitledDropdown` flag that **only the Add Assets drawer passes** (`variant === 'drawer'`); the Add Assets **modal** variant, the **Explore page**, the **Glossary** asset tab and **Lineage** controls keep the existing AntD `SearchDropdown` — zero change to those surfaces.

The library primitive provides the popover, the checkable items (`showCheckbox`), the counts (`addon`) and selection, so the component is ~30 lines. Per-filter in-popover *search* was intentionally left out to keep it minimal (a search box fights react-aria's menu typeahead, and the drawer already has its own asset searchbar); selection applies on click.

> Note: no tracked GitHub issue — internal handoff. Happy to open one if required.

#
### Type of change:
- [x] Bug fix

#
### High-level design:

Minimal, additive, drawer-scoped. One new consumer-app component composed from the core `Dropdown` primitive (no core-component changes). `ExploreQuickFilters` gains an optional `untitledDropdown` prop (defaults to `false`), so the 4 other call sites are untouched. Rejected (per review): routing the AntD popup into the dialog via `getPopupContainer` / a `ConfigProvider` drawer provider — keeps an AntD overlay inside the Untitled drawer.

#
### Tests:

#### Use cases covered
- Add Assets drawer (Domain / Data Product / Input-Output Ports): each quick filter opens, selects (multi/single) with counts, fully interactive — the inert bug is gone because no AntD popup is rendered.
- Modal variant (Glossary/Tags) and the Explore page behave exactly as before.

#### Unit tests
- [x] Existing `ExploreQuickFilters.test.tsx` / `SearchDropdown.test.tsx` Jest suites pass unchanged (the kept AntD paths). No new unit test in this minimal pass — the component is a thin wrapper over the library `Dropdown`.

#### Backend / Ingestion integration tests
- [x] Not applicable.

#### Playwright (UI) tests
- The existing `InputOutputPorts.spec.ts` *"Port drawers show Entity Type quick filter"* test still covers the drawer trigger. A follow-up can extend it to open the popover and select an option (interactivity guard) — happy to add if wanted.

#### Manual testing performed
- `tsc --noEmit` on the changed files — clean. UI checkstyle (organize-imports → eslint → prettier) — clean.

#
### UI screen recording / screenshots:

⚠️ **To be attached** — short recording of the Add Assets drawer filters opening and selecting.

#
### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR is linked to a GitHub issue (no tracked issue — see note above).
- [ ] For UI changes: I attached a screen recording and/or screenshots above (pending).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes the non-interactive quick-filters in the Add Assets drawer by replacing the AntD `SearchDropdown` (whose popup portals to `document.body`, outside react-aria's `inert`-protected dialog subtree) with a new `QuickFilterDropdown` built on the core react-aria `Dropdown` primitive whose popover stays in the top layer and remains interactive.

- `QuickFilterDropdown` is a ~80-line component wrapping `Dropdown.Root/Popover/Menu/Item`; it follows the existing `Dropdown.Root + Button` trigger pattern already used in `OwnerReveal`, `OwnerTeamList`, and others.
- An `untitledDropdown` flag (default `false`) on `ExploreQuickFilters` gates the new path exclusively to the drawer `variant`; all four other call sites (Explore page, Glossary, Lineage, modal variant) keep the existing AntD `SearchDropdown` unchanged.
- Selections apply immediately on click rather than behind an "Update" button; this is an intentional simplification noted in the PR description.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is purely additive and drawer-scoped; all existing call sites are untouched.

The new `QuickFilterDropdown` follows the established `Dropdown.Root + Button` trigger pattern already proven across multiple components in the codebase. The `untitledDropdown` flag defaults to `false`, leaving every existing consumer (Explore, Glossary, Lineage, modal) on the unmodified AntD `SearchDropdown` path. No shared state, prop contracts, or API calls are changed.

No files require special attention.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-ui/src/main/resources/ui/src/components/Explore/QuickFilterDropdown.tsx | New react-aria Dropdown-based filter component; follows the established Dropdown.Root pattern; selections apply immediately on click rather than via an Update button (intentional); defensive `keys === 'all'` guard is correct. |
| openmetadata-ui/src/main/resources/ui/src/components/Explore/ExploreQuickFilters.tsx | Adds `untitledDropdown` flag (default `false`) gating the new component; existing AntD SearchDropdown path is fully unchanged; `hasNullOption` feature is omitted for the untitled path, consistent with the drawer call site not passing `fieldsWithNullValues`. |
| openmetadata-ui/src/main/resources/ui/src/components/DataAssets/AssetsSelectionModal/useAssetSelectionContent.tsx | Passes `untitledDropdown={variant === 'drawer'}` to `ExploreQuickFilters`; correctly scopes the new component to the drawer variant only. |
| openmetadata-ui/src/main/resources/ui/src/components/Explore/QuickFilterDropdown.interface.ts | Minimal interface; `onChange` carries a redundant `searchKey` second parameter (callers have it in closure), but this is a minor style point with no runtime impact. |
| openmetadata-ui/src/main/resources/ui/src/components/Explore/ExploreQuickFilters.interface.ts | Adds optional `untitledDropdown?: boolean` prop; clean additive change. |

</details>

</details>

<details open><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["ExploreQuickFilters\n(fields.map)"] --> B{untitledDropdown?}
    B -- "true\n(drawer variant)" --> C["QuickFilterDropdown\n(Dropdown.Root / react-aria)"]
    B -- "false\n(default)" --> D["SearchDropdown\n(Ant Design)"]
    C --> E["Dropdown.Popover\n→ react-aria top layer\n(stays interactive in SlideoutMenu)"]
    D --> F["AntD popup\n→ document.body\n(blocked by react-aria inert)"]
    G["useAssetSelectionContent\nvariant === 'drawer'"] -->|"untitledDropdown=true"| A
    H["ExplorePage / Glossary\n/ Lineage / Modal"] -->|"untitledDropdown=false (default)"| A
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["ExploreQuickFilters\n(fields.map)"] --> B{untitledDropdown?}
    B -- "true\n(drawer variant)" --> C["QuickFilterDropdown\n(Dropdown.Root / react-aria)"]
    B -- "false\n(default)" --> D["SearchDropdown\n(Ant Design)"]
    C --> E["Dropdown.Popover\n→ react-aria top layer\n(stays interactive in SlideoutMenu)"]
    D --> F["AntD popup\n→ document.body\n(blocked by react-aria inert)"]
    G["useAssetSelectionContent\nvariant === 'drawer'"] -->|"untitledDropdown=true"| A
    H["ExplorePage / Glossary\n/ Lineage / Modal"] -->|"untitledDropdown=false (default)"| A
```

</a>
</details>

<sub>Reviews (4): Last reviewed commit: ["fix(ui): use Untitled-UI dropdowns for A..."](https://github.com/open-metadata/openmetadata/commit/ce7b87d202e8b6533e9f46800afad20ddfe4c00e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38334260)</sub>

<!-- /greptile_comment -->