### PR TITLE
fix(config): use standard AWS env vars for bedrock llmConfiguration

### DIFF
--- a/conf/openmetadata-h2-test.yaml
+++ b/conf/openmetadata-h2-test.yaml
@@ -590,10 +590,10 @@ elasticsearch:
     bedrock:
       awsConfig:
         enabled: ${BEDROCK_AWS_IAM_AUTH_ENABLED:-false}
-        region: ${AWS_BEDROCK_REGION:-""}
-        accessKeyId: ${AWS_BEDROCK_ACCESS_KEY:-""}
-        secretAccessKey: ${AWS_BEDROCK_SECRET_KEY:-""}
-        sessionToken: ${AWS_BEDROCK_SESSION_TOKEN:-""}
+        region: ${AWS_DEFAULT_REGION:-""}
+        accessKeyId: ${AWS_ACCESS_KEY_ID:-""}
+        secretAccessKey: ${AWS_SECRET_ACCESS_KEY:-""}
+        sessionToken: ${AWS_SESSION_TOKEN:-""}
       modelId: ${AWS_BEDROCK_MODEL_ID:-""}
       embeddingModelId: ${AWS_BEDROCK_EMBED_MODEL_ID:-""}
       embeddingDimension: ${AWS_BEDROCK_EMBEDDING_DIMENSION:-""}

--- a/conf/openmetadata.yaml
+++ b/conf/openmetadata.yaml
@@ -611,10 +611,10 @@ llmConfiguration:
   bedrock:
     awsConfig:
       enabled: ${BEDROCK_AWS_IAM_AUTH_ENABLED:-true}
-      region: ${AWS_BEDROCK_REGION:-""}
-      accessKeyId: ${AWS_BEDROCK_ACCESS_KEY:-""}
-      secretAccessKey: ${AWS_BEDROCK_SECRET_KEY:-""}
-      sessionToken: ${AWS_BEDROCK_SESSION_TOKEN:-""}
+      region: ${AWS_DEFAULT_REGION:-""}
+      accessKeyId: ${AWS_ACCESS_KEY_ID:-""}
+      secretAccessKey: ${AWS_SECRET_ACCESS_KEY:-""}
+      sessionToken: ${AWS_SESSION_TOKEN:-""}
     modelId: ${LLM_BEDROCK_MODEL_ID:-"eu.anthropic.claude-haiku-4-5-20251001-v1:0"}
     maxTokens: ${LLM_BEDROCK_MAX_TOKENS:-4096}
   google:

--- a/docker/development/distributed-test/local/server1.yaml
+++ b/docker/development/distributed-test/local/server1.yaml
@@ -399,10 +399,10 @@ elasticsearch:
     bedrock:
       awsConfig:
         enabled: false
-        region: ${AWS_BEDROCK_REGION:-""}
-        accessKeyId: ${AWS_BEDROCK_ACCESS_KEY:-""}
-        secretAccessKey: ${AWS_BEDROCK_SECRET_KEY:-""}
-        sessionToken: ${AWS_BEDROCK_SESSION_TOKEN:-""}
+        region: ${AWS_DEFAULT_REGION:-""}
+        accessKeyId: ${AWS_ACCESS_KEY_ID:-""}
+        secretAccessKey: ${AWS_SECRET_ACCESS_KEY:-""}
+        sessionToken: ${AWS_SESSION_TOKEN:-""}
       modelId: ${AWS_BEDROCK_MODEL_ID:-""}
       embeddingModelId: ${AWS_BEDROCK_EMBED_MODEL_ID:-""}
       embeddingDimension: ${AWS_BEDROCK_EMBEDDING_DIMENSION:-""}

--- a/docker/development/distributed-test/local/server2.yaml
+++ b/docker/development/distributed-test/local/server2.yaml
@@ -399,10 +399,10 @@ elasticsearch:
     bedrock:
       awsConfig:
         enabled: ${BEDROCK_AWS_IAM_AUTH_ENABLED:-false}
-        region: ${AWS_BEDROCK_REGION:-""}
-        accessKeyId: ${AWS_BEDROCK_ACCESS_KEY:-""}
-        secretAccessKey: ${AWS_BEDROCK_SECRET_KEY:-""}
-        sessionToken: ${AWS_BEDROCK_SESSION_TOKEN:-""}
+        region: ${AWS_DEFAULT_REGION:-""}
+        accessKeyId: ${AWS_ACCESS_KEY_ID:-""}
+        secretAccessKey: ${AWS_SECRET_ACCESS_KEY:-""}
+        sessionToken: ${AWS_SESSION_TOKEN:-""}
       modelId: ${AWS_BEDROCK_MODEL_ID:-""}
       embeddingModelId: ${AWS_BEDROCK_EMBED_MODEL_ID:-""}
       embeddingDimension: ${AWS_BEDROCK_EMBEDDING_DIMENSION:-""}

--- a/docker/development/distributed-test/local/server3.yaml
+++ b/docker/development/distributed-test/local/server3.yaml
@@ -400,10 +400,10 @@ elasticsearch:
     bedrock:
       awsConfig:
         enabled: ${BEDROCK_AWS_IAM_AUTH_ENABLED:-false}
-        region: ${AWS_BEDROCK_REGION:-""}
-        accessKeyId: ${AWS_BEDROCK_ACCESS_KEY:-""}
-        secretAccessKey: ${AWS_BEDROCK_SECRET_KEY:-""}
-        sessionToken: ${AWS_BEDROCK_SESSION_TOKEN:-""}
+        region: ${AWS_DEFAULT_REGION:-""}
+        accessKeyId: ${AWS_ACCESS_KEY_ID:-""}
+        secretAccessKey: ${AWS_SECRET_ACCESS_KEY:-""}
+        sessionToken: ${AWS_SESSION_TOKEN:-""}
       modelId: ${AWS_BEDROCK_MODEL_ID:-""}
       embeddingModelId: ${AWS_BEDROCK_EMBED_MODEL_ID:-""}
       embeddingDimension: ${AWS_BEDROCK_EMBEDDING_DIMENSION:-""}

--- a/docs/company-context-knowledge-pills.md
+++ b/docs/company-context-knowledge-pills.md
@@ -479,8 +479,8 @@ llmConfiguration:
     maxTokens:     ${LLM_OPENAI_MAX_TOKENS:-4096}
   bedrock:
     awsConfig:
-      awsRegion:       ${AWS_BEDROCK_REGION:-""}
-      # IAM or static keys via AWS_BEDROCK_ACCESS_KEY / _SECRET_KEY / _SESSION_TOKEN
+      awsRegion:       ${AWS_DEFAULT_REGION:-""}
+      # IAM or static keys via AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY / AWS_SESSION_TOKEN
     modelId:   ${LLM_BEDROCK_MODEL_ID:-"eu.anthropic.claude-haiku-4-5-20251001-v1:0"}
     maxTokens: ${LLM_BEDROCK_MAX_TOKENS:-4096}
   google:


### PR DESCRIPTION
## What

`llmConfiguration.bedrock.awsConfig` used **bedrock-specific** env var names that diverged from the standard AWS env vars used everywhere else in the config — including the elasticsearch `aws` block right above it (which reads `AWS_DEFAULT_REGION` / `AWS_ACCESS_KEY_ID` / …) — and from the AWS SDK default credential chain. That forces operators to set non-standard vars and breaks deployments that already export the standard AWS variables.

Revert to the standard names:

| was | now |
|---|---|
| `AWS_BEDROCK_REGION` | `AWS_DEFAULT_REGION` |
| `AWS_BEDROCK_ACCESS_KEY` | `AWS_ACCESS_KEY_ID` |
| `AWS_BEDROCK_SECRET_KEY` | `AWS_SECRET_ACCESS_KEY` |
| `AWS_BEDROCK_SESSION_TOKEN` | `AWS_SESSION_TOKEN` |

`enabled` (`BEDROCK_AWS_IAM_AUTH_ENABLED`) and `modelId` (`LLM_BEDROCK_MODEL_ID`) are left as-is — not AWS-standard names.

## Files
- `conf/openmetadata.yaml`
- `conf/openmetadata-h2-test.yaml`
- `docker/development/distributed-test/local/server{1,2,3}.yaml`
- `docs/company-context-knowledge-pills.md`

## Companion
Same change in openmetadata-collate: open-metadata/openmetadata-collate#4583.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes the Bedrock `awsConfig` blocks across all server and test YAML configs to use the standard AWS SDK environment variable names (`AWS_DEFAULT_REGION`, `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_SESSION_TOKEN`) instead of the non-standard `AWS_BEDROCK_*` variants, aligning Bedrock with every other AWS integration in the same files.

- All six changed files receive the identical four-line substitution; the change is mechanical and consistently applied.
- The `docs/company-context-knowledge-pills.md` snippet updates the env var references in the comment but retains a stale `awsRegion:` key name that diverges from the `region:` key used in the real configs (see inline comment).
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge; changes are purely config env-var renames applied consistently across all affected files, with no logic changes.

All six files receive the same four-line substitution replacing non-standard Bedrock-specific var names with standard AWS SDK names. The change is mechanical, consistent, and aligns Bedrock with how every other AWS block in these same configs already works. The only minor gap is a stale key name in the docs snippet (awsRegion vs region).

docs/company-context-knowledge-pills.md — the knowledge-pill snippet uses `awsRegion:` while the real configs use `region:`; worth fixing while the file is open.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| conf/openmetadata.yaml | Renames bedrock awsConfig env vars under llmConfiguration to standard AWS names (AWS_DEFAULT_REGION, AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_SESSION_TOKEN). |
| conf/openmetadata-h2-test.yaml | Same env var rename applied to the elasticsearch bedrock awsConfig block in the H2 test config. |
| docker/development/distributed-test/local/server1.yaml | Identical env var substitution update; server1 already hard-codes `enabled: false` for IAM auth (pre-existing, unrelated). |
| docker/development/distributed-test/local/server2.yaml | Same env var rename applied consistently to the elasticsearch bedrock awsConfig block. |
| docker/development/distributed-test/local/server3.yaml | Same env var rename applied consistently to the elasticsearch bedrock awsConfig block. |
| docs/company-context-knowledge-pills.md | Docs snippet env var references updated, but the YAML key shown as `awsRegion` still diverges from the actual `region` key used in all the real config files. |

</details>

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(config): use standard AWS env vars f..."](https://github.com/open-metadata/openmetadata/commit/d9babee60fe9597ec1d55312c52ec0fc9631e194) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38335186)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->