### PR TITLE
fix(ui): use Untitled-UI dropdowns for Add Assets drawer quick-filters

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/DataProductAndSubdomains.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/DataProductAndSubdomains.spec.ts
@@ -16,8 +16,14 @@ import { SidebarItem } from '../../constant/sidebar';
 import { DataProduct } from '../../support/domain/DataProduct';
 import { Domain } from '../../support/domain/Domain';
 import { SubDomain } from '../../support/domain/SubDomain';
+import { DashboardClass } from '../../support/entity/DashboardClass';
 import { TableClass } from '../../support/entity/TableClass';
+import { TopicClass } from '../../support/entity/TopicClass';
 import { UserClass } from '../../support/user/UserClass';
+import {
+  runDrawerQuickFilterMatrix,
+  toDrawerAsset,
+} from '../../utils/assetDrawerQuickFilter';
 import {
   getApiContext,
   redirectToHomePage,
@@ -39,6 +45,91 @@ test.describe('Data Product Comprehensive Tests', () => {
 
   test.beforeEach(async ({ page }) => {
     await redirectToHomePage(page);
+  });
+
+  test('Add-Assets drawer quick filter - behaviour matrix', async ({
+    page,
+  }) => {
+    test.setTimeout(180_000);
+    const { afterAction, apiContext } = await getApiContext(page);
+    const domain = new Domain();
+    const dataProduct = new DataProduct([domain]);
+    const tieredTable = new TableClass();
+    const plainTable = new TableClass();
+    const filterTopic = new TopicClass();
+    const filterDashboard = new DashboardClass();
+
+    try {
+      await test.step('Create data product and varied assets', async () => {
+        await domain.create(apiContext);
+        await dataProduct.create(apiContext);
+
+        const domainPatch = {
+          op: 'add' as const,
+          path: '/domains/0',
+          value: { id: domain.responseData.id, type: 'domain' },
+        };
+
+        await tieredTable.create(apiContext);
+        await tieredTable.patch({
+          apiContext,
+          patchData: [
+            {
+              op: 'add',
+              path: '/tags/0',
+              value: {
+                tagFQN: 'Tier.Tier1',
+                source: 'Classification',
+                labelType: 'Manual',
+              },
+            },
+            domainPatch,
+          ],
+        });
+        await plainTable.create(apiContext);
+        await plainTable.patch({ apiContext, patchData: [domainPatch] });
+        await filterTopic.create(apiContext);
+        await filterTopic.patch({ apiContext, patchData: [domainPatch] });
+        await filterDashboard.create(apiContext);
+        await filterDashboard.patch({ apiContext, patchData: [domainPatch] });
+      });
+
+      await test.step('Open the data product assets tab', async () => {
+        await sidebarClick(page, SidebarItem.DATA_PRODUCT);
+        await selectDataProduct(page, dataProduct.data);
+        await page.getByTestId('assets').click();
+        await waitForAllLoadersToDisappear(page);
+      });
+
+      await runDrawerQuickFilterMatrix(page, {
+        surface: 'data product',
+        openDrawer: async () => {
+          await page.getByTestId('data-product-details-add-button').click();
+          await page
+            .getByTestId('asset-selection-modal')
+            .waitFor({ state: 'visible' });
+          await waitForAllLoadersToDisappear(page);
+        },
+        closeDrawer: async () => {
+          await page.getByTestId('cancel-btn').click();
+          await page
+            .getByTestId('asset-selection-modal')
+            .waitFor({ state: 'hidden' });
+        },
+        table: toDrawerAsset(tieredTable),
+        untieredTable: toDrawerAsset(plainTable),
+        topic: toDrawerAsset(filterTopic),
+        dashboard: toDrawerAsset(filterDashboard),
+      });
+    } finally {
+      await tieredTable.delete(apiContext);
+      await plainTable.delete(apiContext);
+      await filterTopic.delete(apiContext);
+      await filterDashboard.delete(apiContext);
+      await dataProduct.delete(apiContext);
+      await domain.delete(apiContext);
+      await afterAction();
+    }
   });
 
   test('Create data product via UI with description', async ({ page }) => {

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/Domains.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/Domains.spec.ts
@@ -19,12 +19,14 @@ import { RolesClass } from '../../support/access-control/RolesClass';
 import { DataProduct } from '../../support/domain/DataProduct';
 import { Domain } from '../../support/domain/Domain';
 import { SubDomain } from '../../support/domain/SubDomain';
+import { DashboardClass } from '../../support/entity/DashboardClass';
 import {
   EntityTypeEndpoint,
   ENTITY_PATH,
 } from '../../support/entity/Entity.interface';
 import { EntityDataClass } from '../../support/entity/EntityDataClass';
 import { TableClass } from '../../support/entity/TableClass';
+import { TopicClass } from '../../support/entity/TopicClass';
 import { Glossary } from '../../support/glossary/Glossary';
 import { GlossaryTerm } from '../../support/glossary/GlossaryTerm';
 import { ClassificationClass } from '../../support/tag/ClassificationClass';
@@ -32,6 +34,10 @@ import { TagClass } from '../../support/tag/TagClass';
 import { TeamClass } from '../../support/team/TeamClass';
 import { UserClass } from '../../support/user/UserClass';
 import { performAdminLogin } from '../../utils/admin';
+import {
+  runDrawerQuickFilterMatrix,
+  toDrawerAsset,
+} from '../../utils/assetDrawerQuickFilter';
 import {
   clickOutside,
   descriptionBox,
@@ -51,6 +57,7 @@ import {
   createDomain,
   createSubDomain,
   fillDomainForm,
+  goToAssetsTab,
   navigateToSubDomain,
   removeAssetsFromDataProduct,
   renameDomain,
@@ -240,6 +247,79 @@ test.describe('Domains', () => {
     });
 
     await assetCleanup();
+  });
+
+  test('Add-Assets drawer quick filter - behaviour matrix', async ({
+    page,
+  }) => {
+    test.setTimeout(180_000);
+    const { afterAction, apiContext } = await getApiContext(page);
+    const filterDomain = new Domain();
+    const tieredTable = new TableClass();
+    const plainTable = new TableClass();
+    const filterTopic = new TopicClass();
+    const filterDashboard = new DashboardClass();
+
+    try {
+      await test.step('Create domain and varied assets', async () => {
+        await filterDomain.create(apiContext);
+        await tieredTable.create(apiContext);
+        await tieredTable.patch({
+          apiContext,
+          patchData: [
+            {
+              op: 'add',
+              path: '/tags/0',
+              value: {
+                tagFQN: 'Tier.Tier1',
+                source: 'Classification',
+                labelType: 'Manual',
+              },
+            },
+          ],
+        });
+        await plainTable.create(apiContext);
+        await filterTopic.create(apiContext);
+        await filterDashboard.create(apiContext);
+      });
+
+      await test.step('Open the domain assets tab', async () => {
+        await redirectToHomePage(page);
+        await sidebarClick(page, SidebarItem.DOMAIN);
+        await goToAssetsTab(page, filterDomain.data);
+      });
+
+      await runDrawerQuickFilterMatrix(page, {
+        surface: 'domain',
+        openDrawer: async () => {
+          await page.getByTestId('domain-details-add-button').click();
+          await page
+            .getByRole('menuitem', { name: 'Assets', exact: true })
+            .click();
+          await page
+            .getByTestId('asset-selection-modal')
+            .waitFor({ state: 'visible' });
+          await waitForAllLoadersToDisappear(page);
+        },
+        closeDrawer: async () => {
+          await page.getByTestId('cancel-btn').click();
+          await page
+            .getByTestId('asset-selection-modal')
+            .waitFor({ state: 'hidden' });
+        },
+        table: toDrawerAsset(tieredTable),
+        untieredTable: toDrawerAsset(plainTable),
+        topic: toDrawerAsset(filterTopic),
+        dashboard: toDrawerAsset(filterDashboard),
+      });
+    } finally {
+      await tieredTable.delete(apiContext);
+      await plainTable.delete(apiContext);
+      await filterTopic.delete(apiContext);
+      await filterDashboard.delete(apiContext);
+      await filterDomain.delete(apiContext);
+      await afterAction();
+    }
   });
 
   test('Create DataProducts and add remove assets', async ({ page }) => {

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/InputOutputPorts.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/InputOutputPorts.spec.ts
@@ -662,6 +662,21 @@ test.describe('Input Output Ports', () => {
           page.getByTestId('search-dropdown-Entity Type')
         ).toBeVisible();
 
+        // The quick-filter popover must stay interactive inside the react-aria
+        // drawer. Regression guard for the inert document.body-portal bug: a
+        // popup rendered outside the dialog subtree becomes inert and cannot be
+        // typed into. Filling the search box proves the popover is live.
+        await page.getByTestId('search-dropdown-Entity Type').click();
+        const filterPopover = page.getByTestId('drop-down-menu');
+        await expect(filterPopover).toBeVisible();
+
+        const filterSearch = filterPopover.getByRole('textbox');
+        await filterSearch.fill('table');
+        await expect(filterSearch).toHaveValue('table');
+
+        await page.getByTestId('close-btn').click();
+        await expect(filterPopover).toBeHidden();
+
         await page.getByTestId('cancel-btn').click();
       });
 

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/InputOutputPorts.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/InputOutputPorts.spec.ts
@@ -14,12 +14,13 @@
 import base, { expect, Page } from '@playwright/test';
 import { get } from 'lodash';
 import { SidebarItem } from '../../constant/sidebar';
-import { AssetReference, DataProduct } from '../../support/domain/DataProduct';
+import { DataProduct } from '../../support/domain/DataProduct';
 import { Domain } from '../../support/domain/Domain';
 import { DashboardClass } from '../../support/entity/DashboardClass';
 import { TableClass } from '../../support/entity/TableClass';
 import { TopicClass } from '../../support/entity/TopicClass';
 import { performAdminLogin } from '../../utils/admin';
+import { runDrawerQuickFilterMatrix } from '../../utils/assetDrawerQuickFilter';
 import {
   getApiContext,
   redirectToHomePage,
@@ -34,19 +35,13 @@ import {
   verifyPortCounts,
 } from '../../utils/domain';
 import { waitForAllLoadersToDisappear } from '../../utils/entity';
+import {
+  buildPortDrawerContext,
+  cleanupDrawerFilterAssets,
+  createAssetRef,
+  seedDrawerFilterAssets,
+} from '../../utils/inputOutputPorts';
 import { sidebarClick } from '../../utils/sidebar';
-
-const createAssetRef = (
-  entity: TableClass | TopicClass | DashboardClass,
-  type: string
-): AssetReference => ({
-  id: entity.entityResponseData.id,
-  type,
-  name: entity.entityResponseData.name,
-  displayName: entity.entityResponseData.displayName,
-  fullyQualifiedName: entity.entityResponseData.fullyQualifiedName,
-  description: entity.entityResponseData.description,
-});
 
 const domain = new Domain();
 
@@ -634,65 +629,60 @@ test.describe('Input Output Ports', () => {
       });
     });
 
-    test('Port drawers show Entity Type quick filter', async ({ page }) => {
-      const dataProduct = new DataProduct([domain]);
+    test('Input port drawer quick filter - behaviour matrix', async ({
+      page,
+    }) => {
+      test.setTimeout(180_000);
+      const { apiContext } = await getApiContext(page);
+      const seeded = await seedDrawerFilterAssets(apiContext, domain, false);
 
-      await test.step('Create data product with assets', async () => {
-        const { apiContext } = await getApiContext(page);
-        await dataProduct.create(apiContext);
-        await dataProduct.addAssets(apiContext, [
-          createAssetRef(tables[0], 'table'),
-        ]);
-      });
-
-      await test.step('Navigate to ports tab', async () => {
-        await sidebarClick(page, SidebarItem.DATA_PRODUCT);
-        await selectDataProduct(page, dataProduct.data);
-        await navigateToPortsTab(page);
-      });
-
-      await test.step('Verify Entity Type filter in input port drawer', async () => {
-        await page.getByTestId('add-input-port-button').click();
-        await page.getByTestId('asset-selection-modal').waitFor({
-          state: 'visible',
+      try {
+        await test.step('Navigate to ports tab', async () => {
+          await sidebarClick(page, SidebarItem.DATA_PRODUCT);
+          await selectDataProduct(page, seeded.dataProduct.data);
+          await navigateToPortsTab(page);
         });
-        await waitForAllLoadersToDisappear(page);
 
-        await expect(
-          page.getByTestId('search-dropdown-Entity Type')
-        ).toBeVisible();
+        await runDrawerQuickFilterMatrix(
+          page,
+          buildPortDrawerContext(
+            page,
+            'input port',
+            'add-input-port-button',
+            seeded
+          )
+        );
+      } finally {
+        await cleanupDrawerFilterAssets(apiContext, seeded);
+      }
+    });
 
-        // The quick-filter popover must stay interactive inside the react-aria
-        // drawer. Regression guard for the inert document.body-portal bug: a
-        // popup rendered outside the dialog subtree becomes inert and cannot be
-        // typed into. Filling the search box proves the popover is live.
-        await page.getByTestId('search-dropdown-Entity Type').click();
-        const filterPopover = page.getByTestId('drop-down-menu');
-        await expect(filterPopover).toBeVisible();
+    test('Output port drawer quick filter - behaviour matrix', async ({
+      page,
+    }) => {
+      test.setTimeout(180_000);
+      const { apiContext } = await getApiContext(page);
+      const seeded = await seedDrawerFilterAssets(apiContext, domain, true);
 
-        const filterSearch = filterPopover.getByRole('textbox');
-        await filterSearch.fill('table');
-        await expect(filterSearch).toHaveValue('table');
-
-        await page.getByTestId('close-btn').click();
-        await expect(filterPopover).toBeHidden();
-
-        await page.getByTestId('cancel-btn').click();
-      });
-
-      await test.step('Verify Entity Type filter in output port drawer', async () => {
-        await page.getByTestId('add-output-port-button').click();
-        await page.getByTestId('asset-selection-modal').waitFor({
-          state: 'visible',
+      try {
+        await test.step('Navigate to ports tab', async () => {
+          await sidebarClick(page, SidebarItem.DATA_PRODUCT);
+          await selectDataProduct(page, seeded.dataProduct.data);
+          await navigateToPortsTab(page);
         });
-        await waitForAllLoadersToDisappear(page);
 
-        await expect(
-          page.getByTestId('search-dropdown-Entity Type')
-        ).toBeVisible();
-
-        await page.getByTestId('cancel-btn').click();
-      });
+        await runDrawerQuickFilterMatrix(
+          page,
+          buildPortDrawerContext(
+            page,
+            'output port',
+            'add-output-port-button',
+            seeded
+          )
+        );
+      } finally {
+        await cleanupDrawerFilterAssets(apiContext, seeded);
+      }
     });
 
     test('Output port drawer only shows data product assets', async ({

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/assetDrawerQuickFilter.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/assetDrawerQuickFilter.ts
@@ -1,0 +1,178 @@
+/*
+ *  Copyright 2025 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+import { expect, Locator, Page, test } from '@playwright/test';
+import { get } from 'lodash';
+import { waitForAllLoadersToDisappear } from './entity';
+
+const DRAWER = '[data-testid="asset-selection-modal"]';
+const POPOVER = '[data-testid="drop-down-menu"]';
+
+export interface DrawerAsset {
+  name: string;
+  fqn: string;
+}
+
+export interface DrawerQuickFilterContext {
+  surface: string;
+  openDrawer: () => Promise<void>;
+  closeDrawer: () => Promise<void>;
+  table: DrawerAsset;
+  untieredTable: DrawerAsset;
+  topic: DrawerAsset;
+  dashboard: DrawerAsset;
+  entityTypeLabel?: string;
+  tierLabel?: string;
+}
+
+export const toDrawerAsset = (entity: object): DrawerAsset => ({
+  name: get(entity, 'entityResponseData.name', ''),
+  fqn: get(entity, 'entityResponseData.fullyQualifiedName', ''),
+});
+
+const popover = (page: Page): Locator => page.locator(POPOVER);
+
+const optionByValue = (page: Page, value: string): Locator =>
+  popover(page).getByTestId(`${value}-checkbox`);
+
+export const openQuickFilter = async (page: Page, label: string) => {
+  await page.getByTestId(`search-dropdown-${label}`).click();
+  await expect(popover(page)).toBeVisible();
+};
+
+export const applyQuickFilter = async (page: Page) => {
+  await page.getByTestId('update-btn').click();
+  await expect(popover(page)).toBeHidden();
+  await waitForAllLoadersToDisappear(page);
+};
+
+export const closeQuickFilterPopover = async (page: Page) => {
+  await page.getByTestId('close-btn').click();
+  await expect(popover(page)).toBeHidden();
+};
+
+export const scopeDrawerSearch = async (page: Page, text: string) => {
+  await page.locator(DRAWER).getByTestId('searchbar').fill(text);
+  await waitForAllLoadersToDisappear(page);
+};
+
+export const expectAssetVisible = async (page: Page, fqn: string) => {
+  await expect(
+    page.locator(DRAWER).locator(`[data-testid="table-data-card_${fqn}"]`)
+  ).toBeVisible();
+};
+
+export const expectAssetHidden = async (page: Page, fqn: string) => {
+  await expect(
+    page.locator(DRAWER).locator(`[data-testid="table-data-card_${fqn}"]`)
+  ).toBeHidden();
+};
+
+const assertPopoverInteractiveAndFiltersOptions = async (
+  page: Page,
+  entityTypeLabel: string
+) => {
+  await openQuickFilter(page, entityTypeLabel);
+
+  await expect(optionByValue(page, 'table')).toBeVisible();
+  await expect(optionByValue(page, 'topic')).toBeVisible();
+
+  const searchBox = popover(page).getByRole('textbox');
+  await searchBox.fill('table');
+  await expect(searchBox).toHaveValue('table');
+  await expect(optionByValue(page, 'table')).toBeVisible();
+  await expect(optionByValue(page, 'topic')).toBeHidden();
+
+  await searchBox.fill('a-non-existent-option-value');
+  await expect(popover(page)).toContainText(/no data available/i);
+
+  await closeQuickFilterPopover(page);
+};
+
+const assertCloseDiscardsSelection = async (
+  page: Page,
+  entityTypeLabel: string
+) => {
+  await openQuickFilter(page, entityTypeLabel);
+  await optionByValue(page, 'dashboard').click();
+  await closeQuickFilterPopover(page);
+
+  await expect(
+    page.getByTestId(`search-dropdown-${entityTypeLabel}`)
+  ).not.toContainText('dashboard');
+};
+
+const assertApplyNarrowsList = async (
+  page: Page,
+  ctx: DrawerQuickFilterContext,
+  entityTypeLabel: string
+) => {
+  await openQuickFilter(page, entityTypeLabel);
+  await optionByValue(page, 'table').click();
+  await applyQuickFilter(page);
+
+  await expect(
+    page.getByTestId(`search-dropdown-${entityTypeLabel}`)
+  ).toContainText('table');
+
+  await scopeDrawerSearch(page, ctx.topic.name);
+  await expectAssetHidden(page, ctx.topic.fqn);
+  await scopeDrawerSearch(page, ctx.table.name);
+  await expectAssetVisible(page, ctx.table.fqn);
+};
+
+const assertCombineFilters = async (
+  page: Page,
+  ctx: DrawerQuickFilterContext,
+  tierLabel: string
+) => {
+  await openQuickFilter(page, tierLabel);
+  await popover(page)
+    .getByTestId(/tier1-checkbox$/i)
+    .click();
+  await applyQuickFilter(page);
+
+  await scopeDrawerSearch(page, ctx.table.name);
+  await expectAssetVisible(page, ctx.table.fqn);
+  await scopeDrawerSearch(page, ctx.untieredTable.name);
+  await expectAssetHidden(page, ctx.untieredTable.fqn);
+  await scopeDrawerSearch(page, ctx.topic.name);
+  await expectAssetHidden(page, ctx.topic.fqn);
+};
+
+export const runDrawerQuickFilterMatrix = async (
+  page: Page,
+  ctx: DrawerQuickFilterContext
+) => {
+  const entityTypeLabel = ctx.entityTypeLabel ?? 'Entity Type';
+  const tierLabel = ctx.tierLabel ?? 'Tier';
+
+  await ctx.openDrawer();
+
+  await test.step(`[${ctx.surface}] popover is interactive and filters its options`, async () => {
+    await assertPopoverInteractiveAndFiltersOptions(page, entityTypeLabel);
+  });
+
+  await test.step(`[${ctx.surface}] Close discards the staged selection`, async () => {
+    await assertCloseDiscardsSelection(page, entityTypeLabel);
+  });
+
+  await test.step(`[${ctx.surface}] selecting + Update narrows the asset list`, async () => {
+    await assertApplyNarrowsList(page, ctx, entityTypeLabel);
+  });
+
+  await test.step(`[${ctx.surface}] combining filters intersects the results`, async () => {
+    await assertCombineFilters(page, ctx, tierLabel);
+  });
+
+  await ctx.closeDrawer();
+};

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/inputOutputPorts.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/inputOutputPorts.ts
@@ -1,0 +1,136 @@
+/*
+ *  Copyright 2025 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+import { APIRequestContext, Page } from '@playwright/test';
+import { AssetReference, DataProduct } from '../support/domain/DataProduct';
+import { Domain } from '../support/domain/Domain';
+import { DashboardClass } from '../support/entity/DashboardClass';
+import { TableClass } from '../support/entity/TableClass';
+import { TopicClass } from '../support/entity/TopicClass';
+import {
+  DrawerQuickFilterContext,
+  toDrawerAsset,
+} from './assetDrawerQuickFilter';
+import { waitForAllLoadersToDisappear } from './entity';
+
+type PortAssetType = 'table' | 'topic' | 'dashboard';
+
+export interface SeededFilterAssets {
+  dataProduct: DataProduct;
+  tieredTable: TableClass;
+  plainTable: TableClass;
+  filterTopic: TopicClass;
+  filterDashboard: DashboardClass;
+}
+
+export const createAssetRef = (
+  entity: TableClass | TopicClass | DashboardClass,
+  type: PortAssetType
+): AssetReference => ({
+  id: entity.entityResponseData.id,
+  type,
+  name: entity.entityResponseData.name,
+  displayName: entity.entityResponseData.displayName,
+  fullyQualifiedName: entity.entityResponseData.fullyQualifiedName,
+  description: entity.entityResponseData.description,
+});
+
+export const seedDrawerFilterAssets = async (
+  apiContext: APIRequestContext,
+  domain: Domain,
+  addToDataProduct: boolean
+): Promise<SeededFilterAssets> => {
+  const dataProduct = new DataProduct([domain]);
+  const tieredTable = new TableClass();
+  const plainTable = new TableClass();
+  const filterTopic = new TopicClass();
+  const filterDashboard = new DashboardClass();
+
+  await dataProduct.create(apiContext);
+
+  const domainPatch = {
+    op: 'add' as const,
+    path: '/domains/0',
+    value: { id: domain.responseData.id, type: 'domain' },
+  };
+
+  await tieredTable.create(apiContext);
+  await tieredTable.patch({
+    apiContext,
+    patchData: [
+      {
+        op: 'add',
+        path: '/tags/0',
+        value: {
+          tagFQN: 'Tier.Tier1',
+          source: 'Classification',
+          labelType: 'Manual',
+        },
+      },
+      domainPatch,
+    ],
+  });
+  await plainTable.create(apiContext);
+  await plainTable.patch({ apiContext, patchData: [domainPatch] });
+  await filterTopic.create(apiContext);
+  await filterTopic.patch({ apiContext, patchData: [domainPatch] });
+  await filterDashboard.create(apiContext);
+  await filterDashboard.patch({ apiContext, patchData: [domainPatch] });
+
+  if (addToDataProduct) {
+    await dataProduct.addAssets(apiContext, [
+      createAssetRef(tieredTable, 'table'),
+      createAssetRef(plainTable, 'table'),
+      createAssetRef(filterTopic, 'topic'),
+      createAssetRef(filterDashboard, 'dashboard'),
+    ]);
+  }
+
+  return { dataProduct, tieredTable, plainTable, filterTopic, filterDashboard };
+};
+
+export const cleanupDrawerFilterAssets = async (
+  apiContext: APIRequestContext,
+  seeded: SeededFilterAssets
+) => {
+  await seeded.dataProduct.delete(apiContext);
+  await seeded.tieredTable.delete(apiContext);
+  await seeded.plainTable.delete(apiContext);
+  await seeded.filterTopic.delete(apiContext);
+  await seeded.filterDashboard.delete(apiContext);
+};
+
+export const buildPortDrawerContext = (
+  page: Page,
+  surface: string,
+  addButtonTestId: string,
+  seeded: SeededFilterAssets
+): DrawerQuickFilterContext => ({
+  surface,
+  openDrawer: async () => {
+    await page.getByTestId(addButtonTestId).click();
+    await page
+      .getByTestId('asset-selection-modal')
+      .waitFor({ state: 'visible' });
+    await waitForAllLoadersToDisappear(page);
+  },
+  closeDrawer: async () => {
+    await page.getByTestId('cancel-btn').click();
+    await page
+      .getByTestId('asset-selection-modal')
+      .waitFor({ state: 'hidden' });
+  },
+  table: toDrawerAsset(seeded.tieredTable),
+  untieredTable: toDrawerAsset(seeded.plainTable),
+  topic: toDrawerAsset(seeded.filterTopic),
+  dashboard: toDrawerAsset(seeded.filterDashboard),
+});

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataAssets/AssetsSelectionModal/useAssetSelectionContent.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataAssets/AssetsSelectionModal/useAssetSelectionContent.tsx
@@ -717,6 +717,7 @@ export const useAssetSelectionContent = ({
           fields={filters}
           index={SearchIndex.ALL}
           showDeleted={false}
+          untitledDropdown={variant === 'drawer'}
           onFieldValueSelect={handleQuickFiltersValueSelect}
         />
         {quickFilterQuery && (

--- a/openmetadata-ui/src/main/resources/ui/src/components/Explore/ExploreQuickFilters.interface.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Explore/ExploreQuickFilters.interface.ts
@@ -31,4 +31,5 @@ export interface ExploreQuickFiltersProps {
   showSelectedCounts?: boolean; // flag to show counts instead of labels for selected filters
   optionPageSize?: number;
   additionalActions?: ReactNode;
+  untitledDropdown?: boolean;
 }

--- a/openmetadata-ui/src/main/resources/ui/src/components/Explore/ExploreQuickFilters.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Explore/ExploreQuickFilters.tsx
@@ -202,7 +202,7 @@ const ExploreQuickFilters: FC<ExploreQuickFiltersProps> = ({
   };
 
   return (
-    <Space wrap className="explore-quick-filters-container" size={[8, 0]}>
+    <Space wrap className="explore-quick-filters-container" size={[8, 8]}>
       {fields.map((field) => {
         const hasNullOption = fieldsWithNullValues.includes(
           field.key as EntityFields

--- a/openmetadata-ui/src/main/resources/ui/src/components/Explore/ExploreQuickFilters.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Explore/ExploreQuickFilters.tsx
@@ -34,6 +34,7 @@ import { SearchDropdownOption } from '../SearchDropdown/SearchDropdown.interface
 import { useAdvanceSearch } from './AdvanceSearchProvider/AdvanceSearchProvider.component';
 import { ExploreSearchIndex } from './ExplorePage.interface';
 import { ExploreQuickFiltersProps } from './ExploreQuickFilters.interface';
+import QuickFilterDropdown from './QuickFilterDropdown';
 const ExploreQuickFilters: FC<ExploreQuickFiltersProps> = ({
   fields,
   index,
@@ -45,6 +46,7 @@ const ExploreQuickFilters: FC<ExploreQuickFiltersProps> = ({
   showSelectedCounts = false,
   optionPageSize,
   additionalActions,
+  untitledDropdown = false,
 }) => {
   const location = useCustomLocation();
   const [options, setOptions] = useState<SearchDropdownOption[]>();
@@ -207,7 +209,31 @@ const ExploreQuickFilters: FC<ExploreQuickFiltersProps> = ({
         );
         const dropdownOptions = field.options ?? options ?? [];
 
-        return (
+        return untitledDropdown ? (
+          <QuickFilterDropdown
+            hasNullOption={hasNullOption}
+            hideCounts={field.hideCounts ?? false}
+            hideSearchBar={field.hideSearchBar ?? false}
+            independent={independent}
+            isSuggestionsLoading={isOptionsLoading}
+            key={field.key}
+            label={translateWithNestedKeys(field.label, field.labelKeyOptions)}
+            options={dropdownOptions}
+            searchKey={field.key}
+            selectedKeys={field.value ?? []}
+            showSelectedCounts={showSelectedCounts}
+            singleSelect={field.singleSelect}
+            onChange={(updatedValues) =>
+              onFieldValueSelect({ ...field, value: updatedValues })
+            }
+            onGetInitialOptions={(key) =>
+              getInitialOptions(key, field.searchIndex, field.searchKey)
+            }
+            onSearch={(value, key) =>
+              getFilterOptions(value, key, field.searchIndex, field.searchKey)
+            }
+          />
+        ) : (
           <SearchDropdown
             highlight
             dropdownClassName={field.dropdownClassName}

--- a/openmetadata-ui/src/main/resources/ui/src/components/Explore/QuickFilterDropdown.interface.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Explore/QuickFilterDropdown.interface.ts
@@ -1,0 +1,30 @@
+/*
+ *  Copyright 2025 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+import { SearchDropdownOption } from '../SearchDropdown/SearchDropdown.interface';
+
+export interface QuickFilterDropdownProps {
+  label: string;
+  searchKey: string;
+  options: SearchDropdownOption[];
+  selectedKeys: SearchDropdownOption[];
+  isSuggestionsLoading?: boolean;
+  hideCounts?: boolean;
+  hideSearchBar?: boolean;
+  hasNullOption?: boolean;
+  singleSelect?: boolean;
+  showSelectedCounts?: boolean;
+  independent?: boolean;
+  onChange: (values: SearchDropdownOption[], searchKey: string) => void;
+  onSearch: (value: string, searchKey: string) => void;
+  onGetInitialOptions?: (searchKey: string) => void;
+}

--- a/openmetadata-ui/src/main/resources/ui/src/components/Explore/QuickFilterDropdown.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Explore/QuickFilterDropdown.test.tsx
@@ -1,0 +1,206 @@
+/*
+ *  Copyright 2025 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+import { fireEvent, render, screen } from '@testing-library/react';
+import { Children, cloneElement, isValidElement, ReactElement } from 'react';
+import QuickFilterDropdown from './QuickFilterDropdown';
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+jest.mock('../../constants/AdvancedSearch.constants', () => ({
+  NULL_OPTION_KEY: 'null_option_key',
+}));
+
+jest.mock('../../utils/AdvancedSearchPureUtils', () => ({
+  getSelectedOptionLabelString: (options: { label: string }[]) =>
+    (options ?? []).map((option) => option.label).join(', '),
+}));
+
+jest.mock('../common/Loader/Loader', () => ({
+  __esModule: true,
+  default: () => <div data-testid="loader" />,
+}));
+
+jest.mock('@openmetadata/ui-core-components', () => ({
+  Button: ({
+    children,
+    onPress,
+    'data-testid': testId,
+  }: {
+    children: React.ReactNode;
+    onPress?: () => void;
+    'data-testid'?: string;
+  }) => (
+    <button data-testid={testId} type="button" onClick={onPress}>
+      {children}
+    </button>
+  ),
+  Checkbox: ({
+    isSelected,
+    onChange,
+    label,
+    'data-testid': testId,
+  }: {
+    isSelected?: boolean;
+    onChange: (checked: boolean) => void;
+    label: React.ReactNode;
+    'data-testid'?: string;
+  }) => (
+    <label data-testid={testId}>
+      <input
+        checked={Boolean(isSelected)}
+        type="checkbox"
+        onChange={(event) => onChange(event.target.checked)}
+      />
+      {label}
+    </label>
+  ),
+  Input: ({
+    value,
+    onChange,
+    placeholder,
+  }: {
+    value: string;
+    onChange: (value: string) => void;
+    placeholder?: string;
+  }) => (
+    <input
+      data-testid="search-input"
+      placeholder={placeholder}
+      value={value}
+      onChange={(event) => onChange(event.target.value)}
+    />
+  ),
+  Popover: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  PopoverTrigger: ({
+    isOpen,
+    onOpenChange,
+    children,
+  }: {
+    isOpen: boolean;
+    onOpenChange: (open: boolean) => void;
+    children: React.ReactNode;
+  }) => {
+    const [trigger, popover] = Children.toArray(children);
+
+    return (
+      <div>
+        {isValidElement(trigger) &&
+          cloneElement(trigger as ReactElement, {
+            onPress: () => onOpenChange(!isOpen),
+          })}
+        {isOpen ? popover : null}
+      </div>
+    );
+  },
+}));
+
+const OPTIONS = [
+  { key: 'table', label: 'Table', count: 5 },
+  { key: 'topic', label: 'Topic', count: 3 },
+];
+
+const renderDropdown = (
+  props: Partial<React.ComponentProps<typeof QuickFilterDropdown>> = {}
+) =>
+  render(
+    <QuickFilterDropdown
+      label="Entity Type"
+      options={OPTIONS}
+      searchKey="entityType"
+      selectedKeys={[]}
+      onChange={jest.fn()}
+      onGetInitialOptions={jest.fn()}
+      onSearch={jest.fn()}
+      {...props}
+    />
+  );
+
+describe('QuickFilterDropdown', () => {
+  it('should fetch initial options when the dropdown is opened', () => {
+    const onGetInitialOptions = jest.fn();
+    renderDropdown({ onGetInitialOptions });
+
+    fireEvent.click(screen.getByTestId('entityType'));
+
+    expect(onGetInitialOptions).toHaveBeenCalledWith('entityType');
+  });
+
+  it('should emit the selected option only after Update is clicked', () => {
+    const onChange = jest.fn();
+    renderDropdown({ onChange });
+
+    fireEvent.click(screen.getByTestId('entityType'));
+    fireEvent.click(screen.getByRole('checkbox', { name: 'Table' }));
+
+    expect(onChange).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByTestId('update-btn'));
+
+    expect(onChange).toHaveBeenCalledWith(
+      [{ key: 'table', label: 'Table', count: 5 }],
+      'entityType'
+    );
+  });
+
+  it('should keep a single value in single-select mode', () => {
+    const onChange = jest.fn();
+    renderDropdown({ onChange, singleSelect: true });
+
+    fireEvent.click(screen.getByTestId('entityType'));
+    fireEvent.click(screen.getByRole('checkbox', { name: 'Table' }));
+    fireEvent.click(screen.getByRole('checkbox', { name: 'Topic' }));
+    fireEvent.click(screen.getByTestId('update-btn'));
+
+    expect(onChange).toHaveBeenCalledWith(
+      [{ key: 'topic', label: 'Topic', count: 3 }],
+      'entityType'
+    );
+  });
+
+  it('should emit the null option when it is selected', () => {
+    const onChange = jest.fn();
+    renderDropdown({ onChange, hasNullOption: true });
+
+    fireEvent.click(screen.getByTestId('entityType'));
+    fireEvent.click(screen.getByTestId('no-option-checkbox'));
+    fireEvent.click(screen.getByTestId('update-btn'));
+
+    expect(onChange).toHaveBeenCalledWith(
+      expect.arrayContaining([
+        expect.objectContaining({ key: 'null_option_key' }),
+      ]),
+      'entityType'
+    );
+  });
+
+  it('should debounce search input and call onSearch', () => {
+    jest.useFakeTimers();
+    const onSearch = jest.fn();
+    renderDropdown({ onSearch });
+
+    fireEvent.click(screen.getByTestId('entityType'));
+    fireEvent.change(screen.getByTestId('search-input'), {
+      target: { value: 'tab' },
+    });
+
+    jest.advanceTimersByTime(500);
+
+    expect(onSearch).toHaveBeenCalledWith('tab', 'entityType');
+
+    jest.useRealTimers();
+  });
+});

--- a/openmetadata-ui/src/main/resources/ui/src/components/Explore/QuickFilterDropdown.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Explore/QuickFilterDropdown.tsx
@@ -1,0 +1,256 @@
+/*
+ *  Copyright 2025 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+import {
+  Button,
+  Checkbox,
+  Input,
+  Popover,
+  PopoverTrigger,
+} from '@openmetadata/ui-core-components';
+import { ChevronDown } from '@untitledui/icons';
+import { debounce, isUndefined } from 'lodash';
+import { FC, useEffect, useMemo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { NULL_OPTION_KEY } from '../../constants/AdvancedSearch.constants';
+import { getSelectedOptionLabelString } from '../../utils/AdvancedSearchPureUtils';
+import Loader from '../common/Loader/Loader';
+import { SearchDropdownOption } from '../SearchDropdown/SearchDropdown.interface';
+import { QuickFilterDropdownProps } from './QuickFilterDropdown.interface';
+
+/**
+ * Untitled-UI (react-aria) variant of {@link SearchDropdown}. Its popover renders
+ * in the react-aria top layer, so it stays interactive inside a SlideoutMenu
+ * drawer where an Ant Design popup (portaled to document.body) would become inert.
+ */
+const QuickFilterDropdown: FC<QuickFilterDropdownProps> = ({
+  label,
+  searchKey,
+  options,
+  selectedKeys,
+  isSuggestionsLoading = false,
+  hideCounts = false,
+  hideSearchBar = false,
+  hasNullOption = false,
+  singleSelect = false,
+  showSelectedCounts = false,
+  independent = false,
+  onChange,
+  onSearch,
+  onGetInitialOptions,
+}) => {
+  const { t } = useTranslation();
+  const [isOpen, setIsOpen] = useState(false);
+  const [searchText, setSearchText] = useState('');
+  const [selectedOptions, setSelectedOptions] = useState<
+    SearchDropdownOption[]
+  >([]);
+  const [nullOptionSelected, setNullOptionSelected] = useState(false);
+
+  const nullLabelText = t('label.no-entity', { entity: label });
+  const searchPlaceholder = `${t('label.search-entity', { entity: label })}...`;
+
+  const debouncedOnSearch = useMemo(
+    () => debounce((value: string) => onSearch(value, searchKey), 500),
+    [onSearch, searchKey]
+  );
+
+  useEffect(() => {
+    setNullOptionSelected(
+      selectedKeys.some((item) => item.key === NULL_OPTION_KEY)
+    );
+    setSelectedOptions(
+      selectedKeys.filter((item) => item.key !== NULL_OPTION_KEY)
+    );
+  }, [selectedKeys, isOpen]);
+
+  const displayedOptions = useMemo(() => {
+    const selected = independent
+      ? selectedOptions
+      : options.filter((option) =>
+          selectedOptions.some((selected) => selected.key === option.key)
+        );
+    const unselected = options.filter(
+      (option) =>
+        !selectedOptions.some((selected) => selected.key === option.key)
+    );
+
+    return [...selected, ...unselected];
+  }, [options, selectedOptions, independent]);
+
+  const isOptionSelected = (option: SearchDropdownOption) =>
+    selectedOptions.some((selected) => selected.key === option.key);
+
+  const showClearAllBtn = !singleSelect && selectedOptions.length > 1;
+
+  const selectedLabel = showSelectedCounts
+    ? `(${selectedKeys.length})`
+    : getSelectedOptionLabelString(selectedKeys);
+
+  const handleOpenChange = (open: boolean) => {
+    setIsOpen(open);
+    if (open) {
+      onGetInitialOptions?.(searchKey);
+      setSearchText('');
+    }
+  };
+
+  const handleSearchChange = (value: string) => {
+    setSearchText(value);
+    debouncedOnSearch(value);
+  };
+
+  const handleOptionToggle = (option: SearchDropdownOption) => {
+    if (singleSelect) {
+      const isAlreadySelected = isOptionSelected(option);
+      setSelectedOptions(isAlreadySelected ? [] : [option]);
+      if (!isAlreadySelected) {
+        setNullOptionSelected(false);
+      }
+    } else {
+      setSelectedOptions((previous) =>
+        previous.some((selected) => selected.key === option.key)
+          ? previous.filter((selected) => selected.key !== option.key)
+          : [...previous, option]
+      );
+    }
+  };
+
+  const handleNullOptionChange = (checked: boolean) => {
+    setNullOptionSelected(checked);
+    if (singleSelect && checked) {
+      setSelectedOptions([]);
+    }
+  };
+
+  const handleClear = () => {
+    setSelectedOptions([]);
+  };
+
+  const handleApply = () => {
+    const values = nullOptionSelected
+      ? [
+          { key: NULL_OPTION_KEY, label: nullLabelText },
+          ...(singleSelect ? [] : selectedOptions),
+        ]
+      : selectedOptions;
+    onChange(values, searchKey);
+    setIsOpen(false);
+  };
+
+  return (
+    <PopoverTrigger isOpen={isOpen} onOpenChange={handleOpenChange}>
+      <Button
+        color="secondary"
+        data-testid={searchKey}
+        iconTrailing={<ChevronDown className="tw:size-4" />}
+        size="sm">
+        <span data-testid={`search-dropdown-${label}`}>
+          {label}
+          {selectedKeys.length > 0 && (
+            <span className="tw:text-brand-secondary">{`: ${selectedLabel}`}</span>
+          )}
+        </span>
+      </Button>
+      <Popover className="tw:w-72" placement="bottom left">
+        <div className="tw:flex tw:flex-col" data-testid="drop-down-menu">
+          {!hideSearchBar && (
+            <div className="tw:p-2">
+              <Input
+                autoFocus
+                aria-label={searchPlaceholder}
+                placeholder={searchPlaceholder}
+                value={searchText}
+                onChange={handleSearchChange}
+              />
+            </div>
+          )}
+
+          {hasNullOption && (
+            <div className="tw:flex tw:items-center tw:px-3 tw:py-2">
+              <Checkbox
+                data-testid={
+                  singleSelect ? 'no-option-radio' : 'no-option-checkbox'
+                }
+                isSelected={nullOptionSelected}
+                label={nullLabelText}
+                onChange={handleNullOptionChange}
+              />
+            </div>
+          )}
+
+          <div className="tw:max-h-64 tw:overflow-auto tw:px-1.5 tw:py-1">
+            {isSuggestionsLoading ? (
+              <div className="tw:flex tw:justify-center tw:py-3">
+                <Loader size="small" />
+              </div>
+            ) : displayedOptions.length > 0 ? (
+              displayedOptions.map((option) => (
+                <div
+                  className="tw:flex tw:items-center tw:justify-between tw:gap-2 tw:rounded-md tw:px-2 tw:py-1.5 tw:hover:bg-primary_hover"
+                  key={option.key}>
+                  <Checkbox
+                    data-testid={`${option.label}-checkbox`}
+                    isSelected={isOptionSelected(option)}
+                    label={option.label}
+                    onChange={() => handleOptionToggle(option)}
+                  />
+                  {!hideCounts && !isUndefined(option.count) && (
+                    <span className="tw:text-xs tw:text-tertiary">
+                      {option.count}
+                    </span>
+                  )}
+                </div>
+              ))
+            ) : (
+              <div className="tw:px-2 tw:py-3 tw:text-center tw:text-sm tw:text-tertiary">
+                {t('message.no-data-available')}
+              </div>
+            )}
+          </div>
+
+          <div className="tw:flex tw:items-center tw:justify-between tw:gap-2 tw:border-t tw:border-secondary tw:p-2">
+            {showClearAllBtn ? (
+              <Button
+                color="link-color"
+                data-testid="clear-button"
+                size="sm"
+                onPress={handleClear}>
+                {t('label.clear-entity', { entity: t('label.all') })}
+              </Button>
+            ) : (
+              <span />
+            )}
+            <div className="tw:flex tw:gap-2">
+              <Button
+                color="secondary"
+                data-testid="close-btn"
+                size="sm"
+                onPress={() => setIsOpen(false)}>
+                {t('label.close')}
+              </Button>
+              <Button
+                color="primary"
+                data-testid="update-btn"
+                size="sm"
+                onPress={handleApply}>
+                {t('label.update')}
+              </Button>
+            </div>
+          </div>
+        </div>
+      </Popover>
+    </PopoverTrigger>
+  );
+};
+
+export default QuickFilterDropdown;


### PR DESCRIPTION
### Describe your changes:

The **Domains / Data Products → Add Assets** drawer quick-filters (Entity Type, Owners, Tag, Tier, Service) are now fully interactive.

<img width="646" height="163" alt="Screenshot 2026-06-18 at 7 29 31 PM" src="https://github.com/user-attachments/assets/df783c10-5947-439c-9537-17fb0243aee1" />
<img width="659" height="455" alt="Screenshot 2026-06-18 at 7 29 45 PM" src="https://github.com/user-attachments/assets/51b4e3c0-c6d5-4bbf-a2af-ece6c5163802" />

**Why:** The Add Assets drawer is an Untitled-UI `SlideoutMenu` (react-aria `Modal`/`Dialog`). The quick filters used the Ant Design `SearchDropdown`, whose popup portals to `document.body` — *outside* the dialog subtree, where react-aria's `inert` attribute makes it non-interactive (clicks fall through to the content behind and the popup closes). `z-index` cannot override `inert`; the popup must live inside the dialog's layer.

**What:** Add a new **`QuickFilterDropdown`** built on the Untitled-UI `PopoverTrigger`/`Popover` (react-aria), whose popover renders in the dialog's own top layer — so it stays interactive with **no AntD-over-drawer workaround** (no `getPopupContainer`, no `ConfigProvider`). It reproduces the current filter UX: compact button trigger, an in-popover **search box**, a checkbox option list with **counts**, single/multi-select, a null-option row, and Clear/Apply (selection staged until Apply). `ExploreQuickFilters` renders it behind an `untitledDropdown` flag that **only the Add Assets drawer passes** (`variant === 'drawer'`); the Add Assets **modal** variant, the **Explore page**, the **Glossary** asset tab and **Lineage** controls keep the existing AntD `SearchDropdown` — zero change to those surfaces.

It reuses the existing data plumbing unchanged (`ExploreQuickFilterField`, option fetching, `getQuickFilterQuery`), so behavior matches today's filters.

> Supersedes #29161 (same goal, this is the agreed final approach). No tracked GitHub issue — internal handoff; happy to open one if required.

#
### Type of change:
- [x] Bug fix

#
### High-level design:

Small, additive, drawer-scoped. One new consumer-app component composed from `@openmetadata/ui-core-components` primitives (`PopoverTrigger`, `Popover`, `Button`, `Input`, `Checkbox`) — **no core-component changes**. `ExploreQuickFilters` gains an optional `untitledDropdown` prop (defaults to `false`), so the 4 other call sites are untouched. react-aria nested `Popover` inside the `SlideoutMenu` dialog renders in the shared top layer — that's what keeps it interactive.

Rejected approaches (per review): routing the AntD popup into the dialog via `getPopupContainer` / a `ConfigProvider` drawer provider (keeps an AntD overlay in the Untitled drawer); the field-style `MultiSelect`/`Autocomplete` (wrong UX); enhancing the core `Dropdown` primitive (touches a shared core component).

#
### Tests:

#### Use cases covered
- Add Assets drawer (Domain / Data Product / Input-Output Ports): each quick filter opens, the search box filters options, multi/single/null select works with counts, Apply/Clear — fully interactive (the inert bug is gone because no AntD popup is rendered).
- Modal variant (Glossary/Tags) and the Explore page behave exactly as before.

#### Unit tests
- [x] `QuickFilterDropdown.test.tsx` — fetch-on-open, stage-then-Apply emits the selected value, single-select keeps one value, null-option emits the null key, debounced search calls `onSearch`.

#### Backend / Ingestion integration tests
- [x] Not applicable.

#### Playwright (UI) tests
- [x] Added a shared, reusable **drawer quick-filter behaviour matrix** (`playwright/utils/assetDrawerQuickFilter.ts`) that, in a single drawer session, asserts: the popover is interactive and its search box filters options, **Close discards** the staged selection, **selecting + Update narrows** the asset list, and **combining filters** (Entity Type + Tier) intersects the results.
- [x] The matrix runs across every drawer surface: `Domains.spec.ts` (domain Add Assets), `DataProductAndSubdomains.spec.ts` (data-product Add Assets), and `InputOutputPorts.spec.ts` (input **and** output port drawers). Seeding/cleanup and the port-drawer context live in `playwright/utils/inputOutputPorts.ts`.
- [x] This replaces the previous visibility-only check in `InputOutputPorts.spec.ts` with a full interactivity regression guard for the `document.body`-portal inert bug.

#### Manual testing performed
- `tsc --noEmit` on the changed files — clean. UI checkstyle (organize-imports → eslint → prettier, plus license headers on the new playwright utils) — clean. Jest (40 tests across the new + existing Explore filter suites) — pass.

#
### UI screen recording / screenshots:

Screenshots of the interactive Add Assets drawer filters (trigger + open popover with search and counts) are attached at the top of this description.

#
### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR is linked to a GitHub issue (no tracked issue — see note above).
- [x] I have added tests (unit + Playwright) and listed them above.
- [x] For UI changes: I attached screenshots above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

----
## Summary by Gitar

- **Logic fix:**
  - Updated `handleClear` in `QuickFilterDropdown` to correctly reset `nullOptionSelected` in addition to clearing `selectedOptions`.
- **Component robustness:**
  - Added `key` to `QuickFilterDropdown` rendering in `ExploreQuickFilters` to ensure proper React lifecycle management during filter state changes.
- **UI refinement:**
  - Adjusted `Space` gap in `ExploreQuickFilters` from `[8, 0]` to `[8, 8]` to provide better vertical spacing for the new dropdown variant.

<sub>This will update automatically on new commits.</sub>

--|----------|
| openmetadata-ui/src/main/resources/ui/src/components/Explore/QuickFilterDropdown.tsx | New react-aria popover dropdown component; two pre-flagged bugs remain unaddressed: `handleClear` does not reset `nullOptionSelected`, and `debouncedOnSearch` is never cancelled when deps change. |
| openmetadata-ui/src/main/resources/ui/src/components/Explore/ExploreQuickFilters.tsx | Adds `untitledDropdown` flag branching; `field.value ?? []` creates an unstable reference causing `QuickFilterDropdown`'s effect to fire on every loading re-render; row-gap change is applied globally rather than scoped to the new variant. |
| openmetadata-ui/src/main/resources/ui/src/components/Explore/QuickFilterDropdown.test.tsx | Good unit coverage for open-on-fetch, stage-then-apply, single-select, null-option, and debounced search; the `handleClear` + `nullOptionSelected` bug is not exercised by any test case. |
| openmetadata-ui/src/main/resources/ui/src/components/DataAssets/AssetsSelectionModal/useAssetSelectionContent.tsx | Single-line change passing `untitledDropdown={variant === 'drawer'}`; correct and minimal. |
| openmetadata-ui/src/main/resources/ui/playwright/utils/assetDrawerQuickFilter.ts | New shared Playwright helper; covers open/search/apply/close/combine-filter scenarios; relies on `${option.label}-checkbox` testid format matching lowercase entity type labels from the API. |
| openmetadata-ui/src/main/resources/ui/playwright/utils/inputOutputPorts.ts | Cleanly extracts `createAssetRef`, seed/cleanup helpers, and `buildPortDrawerContext` from the spec file; domain lifecycle is correctly left to the caller. |

</details>

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant User
    participant QuickFilterDropdown
    participant ExploreQuickFilters
    participant API

    User->>QuickFilterDropdown: clicks trigger button
    QuickFilterDropdown->>ExploreQuickFilters: onGetInitialOptions(searchKey)
    ExploreQuickFilters->>API: getAggregationOptions(...)
    Note over ExploreQuickFilters: setIsOptionsLoading(true) re-render<br/>selectedKeys = new [] each time<br/>⚠️ useEffect fires → selectedOptions reset
    API-->>ExploreQuickFilters: aggregation buckets
    Note over ExploreQuickFilters: setOptions(result) re-render<br/>⚠️ useEffect fires again → selectedOptions reset
    User->>QuickFilterDropdown: checks options (staged internally)
    User->>QuickFilterDropdown: clicks Update
    QuickFilterDropdown->>ExploreQuickFilters: onChange(selectedValues, searchKey)
    ExploreQuickFilters->>ExploreQuickFilters: onFieldValueSelect updates field.value
    Note over QuickFilterDropdown: setIsOpen(false)<br/>useEffect syncs to new selectedKeys ✓
    User->>QuickFilterDropdown: clicks Close (no Apply)
    Note over QuickFilterDropdown: setIsOpen(false)<br/>useEffect resets staged state to selectedKeys ✓
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant User
    participant QuickFilterDropdown
    participant ExploreQuickFilters
    participant API

    User->>QuickFilterDropdown: clicks trigger button
    QuickFilterDropdown->>ExploreQuickFilters: onGetInitialOptions(searchKey)
    ExploreQuickFilters->>API: getAggregationOptions(...)
    Note over ExploreQuickFilters: setIsOptionsLoading(true) re-render<br/>selectedKeys = new [] each time<br/>⚠️ useEffect fires → selectedOptions reset
    API-->>ExploreQuickFilters: aggregation buckets
    Note over ExploreQuickFilters: setOptions(result) re-render<br/>⚠️ useEffect fires again → selectedOptions reset
    User->>QuickFilterDropdown: checks options (staged internally)
    User->>QuickFilterDropdown: clicks Update
    QuickFilterDropdown->>ExploreQuickFilters: onChange(selectedValues, searchKey)
    ExploreQuickFilters->>ExploreQuickFilters: onFieldValueSelect updates field.value
    Note over QuickFilterDropdown: setIsOpen(false)<br/>useEffect syncs to new selectedKeys ✓
    User->>QuickFilterDropdown: clicks Close (no Apply)
    Note over QuickFilterDropdown: setIsOpen(false)<br/>useEffect resets staged state to selectedKeys ✓
```

</a>
</details>

<sub>Reviews (2): Last reviewed commit: ["test(ui): E2E coverage for Add-Assets dr..."](https://github.com/open-metadata/openmetadata/commit/5b48157c104a2e2cb43abfbcc147c02be79ca615) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38358787)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR introduces `QuickFilterDropdown`, a react-aria `PopoverTrigger`/`Popover`-based replacement for the AntD `SearchDropdown` in the Add Assets drawer, fixing a non-interactive popover bug caused by react-aria's `inert` attribute on `document.body`-portaled overlays. The change is additive and flag-gated behind an `untitledDropdown` prop so all existing surfaces (Explore page, Glossary, Lineage) remain unchanged.

- **New component** (`QuickFilterDropdown.tsx`): reproduces the full filter UX (search box, checkbox list with counts, staged selection, Clear All / Update, null-option row) using Untitled-UI primitives so the popover renders in the react-aria top layer inside the drawer.
- **Flag-gated activation** (`ExploreQuickFilters.tsx` + `useAssetSelectionContent.tsx`): `untitledDropdown={variant === 'drawer'}` is the sole new call-site; existing call-sites pass no flag and render the unchanged AntD `SearchDropdown`.
- **Test coverage**: unit tests for the new component (`QuickFilterDropdown.test.tsx`) and a shared Playwright behaviour matrix (`assetDrawerQuickFilter.ts`) exercised across Domains, Data Products, and Input/Output Port drawer surfaces.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge for the drawer surfaces; three known issues flagged in earlier review threads remain unaddressed in the current code but do not affect the primary save flow or existing surfaces.

The core fix — replacing the AntD popup with a react-aria popover so filters work inside the SlideoutMenu — is correct and well-scoped. The three open issues (handleClear not resetting nullOptionSelected, debounced search not cancelling on prop change, unstable selectedKeys reference wiping staged selections during options load) affect filter UX quality but none cause data corruption or break the primary save flow. All existing surfaces are untouched by the flag-gate.

QuickFilterDropdown.tsx warrants a follow-up pass for the three issues noted in prior review threads before this component is reused beyond the Add Assets drawer.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-ui/src/main/resources/ui/src/components/Explore/QuickFilterDropdown.tsx | New react-aria popover dropdown. Three known bugs (flagged in prior review threads): handleClear omits nullOptionSelected reset, debouncedOnSearch is never cancelled when onSearch/searchKey change, and field.value ?? [] creates an unstable selectedKeys reference in the parent that fires the sync useEffect during the loading sequence. |
| openmetadata-ui/src/main/resources/ui/src/components/Explore/ExploreQuickFilters.tsx | Adds untitledDropdown flag and key prop; Space gap changed from [8,0] to [8,8] globally (affects all surfaces, not just the drawer variant). Inline arrow function props for onChange/onSearch/onGetInitialOptions recreate on every render, feeding the debounce-cancel issue in the child. |
| openmetadata-ui/src/main/resources/ui/src/components/Explore/QuickFilterDropdown.test.tsx | Good unit coverage for open-on-fetch, stage-then-apply, single-select, null-option, and debounced search; the handleClear + nullOptionSelected bug is not exercised by any test case. |
| openmetadata-ui/src/main/resources/ui/src/components/DataAssets/AssetsSelectionModal/useAssetSelectionContent.tsx | Single-line change passing untitledDropdown={variant === 'drawer'}; correct and minimal. |
| openmetadata-ui/src/main/resources/ui/playwright/utils/assetDrawerQuickFilter.ts | New shared Playwright helper covering open/search/apply/close/combine-filter scenarios. The ${option.label}-checkbox testid strategy relies on entity type labels from the aggregation API being lowercase; this matches ES bucket-key conventions and is consistent with the component's data-testid attribute. |
| openmetadata-ui/src/main/resources/ui/playwright/utils/inputOutputPorts.ts | Clean extraction of createAssetRef, seed/cleanup helpers, and buildPortDrawerContext; domain lifecycle correctly delegated to the caller. |

</details>

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant User
    participant QFDropdown as QuickFilterDropdown
    participant EQF as ExploreQuickFilters
    participant API

    User->>QFDropdown: clicks trigger
    QFDropdown->>EQF: onGetInitialOptions(searchKey)
    EQF->>EQF: setIsOptionsLoading(true), setOptions([])
    EQF->>API: getAggregationOptions(...)
    API-->>EQF: aggregation buckets
    EQF->>EQF: setOptions(result), setIsOptionsLoading(false)
    EQF-->>QFDropdown: "isSuggestionsLoading=false, options=[...]"
    User->>QFDropdown: checks one or more options (staged)
    User->>QFDropdown: clicks Update
    QFDropdown->>EQF: onChange(selectedValues, searchKey)
    EQF->>EQF: onFieldValueSelect → updates field.value
    QFDropdown->>QFDropdown: setIsOpen(false)
    Note over QFDropdown: useEffect([selectedKeys, isOpen]) syncs staged state to new selectedKeys ✓
    User->>QFDropdown: clicks Close (without Update)
    QFDropdown->>QFDropdown: setIsOpen(false)
    Note over QFDropdown: useEffect fires → resets staged selections to current selectedKeys (discard) ✓
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant User
    participant QFDropdown as QuickFilterDropdown
    participant EQF as ExploreQuickFilters
    participant API

    User->>QFDropdown: clicks trigger
    QFDropdown->>EQF: onGetInitialOptions(searchKey)
    EQF->>EQF: setIsOptionsLoading(true), setOptions([])
    EQF->>API: getAggregationOptions(...)
    API-->>EQF: aggregation buckets
    EQF->>EQF: setOptions(result), setIsOptionsLoading(false)
    EQF-->>QFDropdown: "isSuggestionsLoading=false, options=[...]"
    User->>QFDropdown: checks one or more options (staged)
    User->>QFDropdown: clicks Update
    QFDropdown->>EQF: onChange(selectedValues, searchKey)
    EQF->>EQF: onFieldValueSelect → updates field.value
    QFDropdown->>QFDropdown: setIsOpen(false)
    Note over QFDropdown: useEffect([selectedKeys, isOpen]) syncs staged state to new selectedKeys ✓
    User->>QFDropdown: clicks Close (without Update)
    QFDropdown->>QFDropdown: setIsOpen(false)
    Note over QFDropdown: useEffect fires → resets staged selections to current selectedKeys (discard) ✓
```

</a>
</details>

<sub>Reviews (3): Last reviewed commit: ["Merge branch &#39;main&#39; into sid/untitled-qu..."](https://github.com/open-metadata/openmetadata/commit/1fba8e7318ebb18468bb382ef9c3cb5d2a248dc0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38358787)</sub>

<!-- /greptile_comment -->