### PR TITLE
test(playwright): run MCP Chat AUT describe serially to avoid shared-app race

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/McpChat.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/McpChat.spec.ts
@@ -23,6 +23,14 @@ test.describe(
   'MCP Chat - Sidebar Navigation',
   { tag: ['@Features', '@Platform'] },
   () => {
+    // Run serially in a single worker. These tests share one globally-named
+    // installed app (McpChatApplication) set up in beforeAll and removed in
+    // afterAll. Under the project's `fullyParallel` mode the tests would be
+    // split across workers, so afterAll (hardDelete) could run while a sibling
+    // test in another worker is still asserting the sidebar item — making the
+    // `app-bar-item-mcp-chat` entry disappear and the test fail.
+    test.describe.configure({ mode: 'serial' });
+
     test.beforeAll('Install MCP Chat app', async ({ browser }) => {
       const { apiContext, afterAction } = await performAdminLogin(browser);
 


### PR DESCRIPTION
## Problem

The `MCP Chat - Sidebar Navigation` Playwright spec (`McpChat.spec.ts`, added in #26343) fails **deterministically** in the nightly AUT runs. Two of its three tests fail every night:

- `MCP Chat nav item should appear in sidebar when app is installed` → `expect(getByTestId('app-bar-item-mcp-chat')).toBeVisible()` → **element(s) not found**
- `Clicking MCP Chat sidebar nav should navigate to chat page` → 60s timeout waiting for the same sidebar item

The third test, `Send button should enable when input has text`, **passes** — it reaches the page via a direct `page.goto('/mcp-chat')` and does not depend on the sidebar item.

## Root cause

The describe shares **one globally-named installed app** (`McpChatApplication`): installed in `beforeAll`, hard-deleted in `afterAll`. The project runs with `fullyParallel: true` (`workers: 3`), so:

- The describe's tests are split across workers, and `beforeAll`/`afterAll` run **once per worker**.
- The fast direct-navigation test finishes first (~4.5s); its worker's `afterAll` then `DELETE …?hardDelete=true` removes the shared app.
- The slower sidebar-dependent tests are still running in other workers. Once the app is deleted, `GET /api/v1/apps/installed` no longer returns it, the UI's `ApplicationsProvider` builds no `McpChatPlugin`, and the `app-bar-item-mcp-chat` sidebar entry never renders.

It is deterministic (not flaky) because the direct-navigation test is always the quickest to reach its `afterAll`. The `/mcp-chat` route is registered unconditionally, which is why that test still passes.

## Fix

Force the describe to run serially in a single worker:

```ts
test.describe.configure({ mode: 'serial' });
```

`beforeAll`/`afterAll` then run exactly once and `afterAll` only fires after all three tests complete, so the shared app stays installed for the whole describe. No production code change — test isolation only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Fixes a deterministic nightly AUT failure in the `MCP Chat - Sidebar Navigation` spec by configuring the describe block to run in serial mode, preventing worker-level race conditions around the shared `McpChatApplication` install/teardown lifecycle.

- **Root cause fixed**: Under `fullyParallel: true`, each worker ran its own `beforeAll`/`afterAll` — the fastest test's `afterAll` hard-deleted the app while slower sibling tests were still asserting the sidebar item.
- **Fix**: One line — `test.describe.configure({ mode: 'serial' })` — ensures `beforeAll`/`afterAll` fire exactly once and `afterAll` only runs after all three tests finish. No production code is touched.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — one-line test configuration change with no production code impact.

The change is a single test.describe.configure({ mode: 'serial' }) call that corrects a well-documented, deterministic race condition in the test suite. It does not touch any application code, only test isolation semantics. The comment accurately describes the problem, and the fix is the standard Playwright-recommended approach for describes that share global state through beforeAll/afterAll.

No files require special attention.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/McpChat.spec.ts | Adds test.describe.configure({ mode: 'serial' }) to prevent worker-level race conditions where the fast direct-navigation test's afterAll hard-deleted the shared app while sibling tests were still asserting the sidebar item. |

</details>

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant W1 as Worker 1
    participant W2 as Worker 2
    participant W3 as Worker 3
    participant API as OpenMetadata API

    Note over W1,W3: BEFORE (fullyParallel, no serial mode)

    W1->>API: beforeAll: POST /api/v1/apps (install McpChatApplication)
    W2->>API: beforeAll: POST /api/v1/apps (409 already installed)
    W3->>API: beforeAll: POST /api/v1/apps (409 already installed)

    W3->>W3: Test: Send button enables (page.goto, fast ~4.5s)
    W3->>API: "afterAll: DELETE McpChatApplication?hardDelete=true"

    Note over W1,W2: App deleted — sidebar item disappears
    W1--xW1: FAIL: app-bar-item-mcp-chat not found
    W2--xW2: FAIL: 60s timeout waiting for sidebar item

    Note over W1,W3: AFTER (test.describe.configure serial mode)

    W1->>API: beforeAll: POST /api/v1/apps (runs once)
    W1->>W1: Test 1: MCP Chat nav item appears in sidebar
    W1->>W1: Test 2: Clicking nav navigates to chat page
    W1->>W1: Test 3: Send button enables with text
    W1->>API: "afterAll: DELETE McpChatApplication?hardDelete=true"
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant W1 as Worker 1
    participant W2 as Worker 2
    participant W3 as Worker 3
    participant API as OpenMetadata API

    Note over W1,W3: BEFORE (fullyParallel, no serial mode)

    W1->>API: beforeAll: POST /api/v1/apps (install McpChatApplication)
    W2->>API: beforeAll: POST /api/v1/apps (409 already installed)
    W3->>API: beforeAll: POST /api/v1/apps (409 already installed)

    W3->>W3: Test: Send button enables (page.goto, fast ~4.5s)
    W3->>API: "afterAll: DELETE McpChatApplication?hardDelete=true"

    Note over W1,W2: App deleted — sidebar item disappears
    W1--xW1: FAIL: app-bar-item-mcp-chat not found
    W2--xW2: FAIL: 60s timeout waiting for sidebar item

    Note over W1,W3: AFTER (test.describe.configure serial mode)

    W1->>API: beforeAll: POST /api/v1/apps (runs once)
    W1->>W1: Test 1: MCP Chat nav item appears in sidebar
    W1->>W1: Test 2: Clicking nav navigates to chat page
    W1->>W1: Test 3: Send button enables with text
    W1->>API: "afterAll: DELETE McpChatApplication?hardDelete=true"
```

</a>
</details>

<sub>Reviews (2): Last reviewed commit: ["Merge branch &#39;main&#39; into pmbrull/fix-mcp..."](https://github.com/open-metadata/openmetadata/commit/81dc590c534bcc58f975ae464c1118fc8ac25c69) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38360306)</sub>

<!-- /greptile_comment -->