### PR TITLE
fix(playwright): stop DataProductDomainMigration no-assets test timing out

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/domain.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/domain.ts
@@ -326,11 +326,11 @@ export const selectDataProduct = async (
     );
   }
 
-  const searchBox = page
-    .getByTestId('page-layout-v1')
-    .getByPlaceholder('Search');
+  await page.waitForURL('**/dataProduct');
 
   await waitForAllLoadersToDisappear(page);
+
+  const searchBox = page.getByTestId('data-product-list-search-bar');
   await searchBox.waitFor({ state: 'visible' });
 
   await Promise.all([

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataProduct/DataProductListPage.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataProduct/DataProductListPage.tsx
@@ -178,6 +178,7 @@ const DataProductListPage = () => {
     searchPlaceholder: t('label.search'),
     onSearchChange: dataProductListing.handleSearchChange,
     initialSearchQuery: dataProductListing.urlState.searchQuery,
+    testId: 'data-product-list-search-bar',
   });
 
   const { view, viewToggle } = useViewToggle();


### PR DESCRIPTION
## Problem
`DataProductDomainMigration.spec.ts:219` — *"Data product with no assets can change domain without confirmation"* — was failing **deterministically with a 180s timeout, on both attempts**.

Root cause: `selectDataProduct` located the search box via `page-layout-v1 >> getByPlaceholder('Search')`, and grabbed it **immediately** after `sidebarClick`, before the hover-flyout navigation to `/dataProduct` had completed. On the still-rendered home dashboard that placeholder matched the **global search box**; typing there both (a) fired an `index=dataAsset` search instead of `index=dataProduct`, so `waitForResponse('…index=dataProduct*')` hung until the `test.slow()` timeout, and (b) interfered with the in-flight navigation. The sibling *migrates assets* test passed only because by the time it reached `selectDataProduct` the listing page had already loaded.

## Fix
- **`DataProductListPage`**: give the list page's own search box a stable `data-product-list-search-bar` testid (the `useSearch` atom already wires `testId` onto the input).
- **`selectDataProduct`**: `await page.waitForURL('**/dataProduct')` before searching — this lets the sidebar navigation finish on its own (the helper no longer touches the home page) — then target the list search box by testid instead of the ambiguous placeholder lookup.

## Validation
- `tsc --noEmit`, `eslint`, `prettier --check` clean on the changed files.
- Ran the spec against a local dev server (`:3000`):
  - ✓ `Changing data product domain via API migrates assets to new domain` (22.3s)
  - ✓ `Data product with no assets can change domain without confirmation` (**15.0s** — previously a 180s timeout)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a deterministic 180s test timeout in `DataProductDomainMigration.spec.ts` caused by a race condition where `selectDataProduct` could resolve its search-box selector against the global home-dashboard search instead of the data-product list search, resulting in a `waitForResponse` that never fires.

- **`domain.ts`**: Replaces the ambiguous `page-layout-v1 >> getByPlaceholder('Search')` lookup with `await page.waitForURL('**/dataProduct')` followed by `page.getByTestId('data-product-list-search-bar')`, ensuring the function only interacts with the correct search box after the list page has fully navigated.
- **`DataProductListPage.tsx`**: Adds `testId: 'data-product-list-search-bar'` to the `useSearch` hook options, wiring a stable `data-testid` attribute onto the input that the Playwright helper can now reliably target.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the changes are narrow, targeted, and directly address a confirmed race condition without touching production logic.

Both changed files are small and self-contained. The React component receives a single new testId prop that flows through an existing useSearch hook with no side effects. The Playwright utility swaps an ambiguous, flaky selector for a URL guard plus a stable testid lookup — a strictly more reliable pattern. No production code paths are altered, and the test fix has been validated locally with a confirmed reduction from a 180s hang to a 15s pass.

No files require special attention.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-ui/src/main/resources/ui/playwright/utils/domain.ts | Replaces ambiguous placeholder-based search box selector with a stable testid lookup, and adds a waitForURL guard to ensure the data product list page is loaded before interaction — directly fixing the race-condition timeout. |
| openmetadata-ui/src/main/resources/ui/src/components/DataProduct/DataProductListPage.tsx | Adds testId: 'data-product-list-search-bar' to the useSearch hook options, giving the list page's search input a stable, uniquely-identifiable attribute for Playwright. |

</details>

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Test as Playwright Test
    participant Page as Browser Page
    participant API as OpenMetadata API

    Note over Test,API: Before fix — race condition path
    Test->>Page: sidebar hover → navigate to /dataProduct
    Page-->>Test: (navigation may not have completed)
    Test->>Page: getByPlaceholder('Search') [ambiguous]
    Page-->>Test: resolves to HOME search box
    Test->>Page: fill(dataProduct.name)
    Page->>API: "GET /search?index=dataAsset (wrong!)"
    API-->>Test: "waitForResponse('index=dataProduct') — never fires → 180s timeout"

    Note over Test,API: After fix — deterministic path
    Test->>Page: sidebar hover → navigate to /dataProduct
    Test->>Page: "waitForURL('**/dataProduct')"
    Page-->>Test: URL confirmed ✓
    Test->>Page: waitForAllLoadersToDisappear
    Test->>Page: getByTestId('data-product-list-search-bar')
    Page-->>Test: correct search box ✓
    Test->>Page: fill(dataProduct.name)
    Page->>API: "GET /search?index=dataProduct ✓"
    API-->>Test: response received (~15s total)
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Test as Playwright Test
    participant Page as Browser Page
    participant API as OpenMetadata API

    Note over Test,API: Before fix — race condition path
    Test->>Page: sidebar hover → navigate to /dataProduct
    Page-->>Test: (navigation may not have completed)
    Test->>Page: getByPlaceholder('Search') [ambiguous]
    Page-->>Test: resolves to HOME search box
    Test->>Page: fill(dataProduct.name)
    Page->>API: "GET /search?index=dataAsset (wrong!)"
    API-->>Test: "waitForResponse('index=dataProduct') — never fires → 180s timeout"

    Note over Test,API: After fix — deterministic path
    Test->>Page: sidebar hover → navigate to /dataProduct
    Test->>Page: "waitForURL('**/dataProduct')"
    Page-->>Test: URL confirmed ✓
    Test->>Page: waitForAllLoadersToDisappear
    Test->>Page: getByTestId('data-product-list-search-bar')
    Page-->>Test: correct search box ✓
    Test->>Page: fill(dataProduct.name)
    Page->>API: "GET /search?index=dataProduct ✓"
    API-->>Test: response received (~15s total)
```

</a>
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(playwright): stop DataProductDomainM..."](https://github.com/open-metadata/openmetadata/commit/7daa7b37b6354a86d4f3d8197fea291f5516a227) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38363038)</sub>

<!-- /greptile_comment -->