### PR TITLE
Fix the ServiceIngestion and Entity spec AUT failiures

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/entity.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/entity.ts
@@ -82,15 +82,15 @@ export const visitEntityPage = async (data: {
   );
 
   // Adding a failsafe for the operation below to avoid a tooltip overlap issue.
-  // A tooltip over the option can cause Playwright click failures:
-  // 1) Hover over the option to move the mouse away from the tooltip trigger element.
-  // 2) If the tooltip is still present, force-click the option.
-  await page.getByTestId(dataTestId).getByTestId('data-name').hover();
-  await page
-    .getByTestId(dataTestId)
-    .getByTestId('data-name')
-    // eslint-disable-next-line playwright/no-force-option
-    .click({ force: true });
+  // A tooltip over the option can cause Playwright click failures
+  // move the mouse away from the option first to get rid of the tooltip.
+  await page.locator('body').hover({
+    position: {
+      x: 0,
+      y: 0,
+    },
+  });
+  await page.getByTestId(dataTestId).getByTestId('data-name').click();
   await waitForAllLoadersToDisappear(page);
   await page.getByTestId('searchBox').clear();
 };
@@ -2040,25 +2040,30 @@ export const softDeleteEntity = async (
   await page.reload();
   await waitForAllLoadersToDisappear(page);
   // Retry mechanism for checking deleted badge
-  let deletedBadge = page.locator('[data-testid="deleted-badge"]');
-  let attempts = 0;
-  const maxAttempts = 5;
+  await expect
+    .poll(
+      async () => {
+        const isVisible = await page
+          .locator('[data-testid="deleted-badge"]')
+          .isVisible();
+        if (isVisible) {
+          return true;
+        }
 
-  while (attempts < maxAttempts) {
-    const isVisible = await deletedBadge.isVisible();
-    if (isVisible) {
-      break;
-    }
+        await page.reload({ waitUntil: 'domcontentloaded' });
 
-    attempts++;
-    if (attempts < maxAttempts) {
-      await page.reload();
-      await waitForAllLoadersToDisappear(page);
-      deletedBadge = page.locator('[data-testid="deleted-badge"]');
-    }
-  }
+        return false;
+      },
+      {
+        timeout: 120000,
+        intervals: [15000, 10000, 5000],
+      }
+    )
+    .toBeTruthy();
 
-  await expect(deletedBadge).toHaveText('Deleted');
+  await expect(page.locator('[data-testid="deleted-badge"]')).toHaveText(
+    'Deleted'
+  );
 
   await deletedEntityCommonChecks({
     page,

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/entity.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/entity.ts
@@ -2043,20 +2043,22 @@ export const softDeleteEntity = async (
   await expect
     .poll(
       async () => {
-        const isVisible = await page
+        const isVisibleBeforeReload = await page
           .locator('[data-testid="deleted-badge"]')
           .isVisible();
-        if (isVisible) {
+        if (isVisibleBeforeReload) {
           return true;
         }
 
         await page.reload({ waitUntil: 'domcontentloaded' });
+        await waitForAllLoadersToDisappear(page);
 
-        return false;
+        return await page.locator('[data-testid="deleted-badge"]').isVisible();
       },
       {
+        message: 'Waiting for deleted badge to be visible after soft delete',
         timeout: 120000,
-        intervals: [15000, 10000, 5000],
+        intervals: [5000, 10000, 15000],
       }
     )
     .toBeTruthy();


### PR DESCRIPTION
Fixes #29175

This pull request improves the reliability and readability of Playwright utility functions for entity interactions by refining how UI elements are interacted with and how retry logic is handled. The changes focus on making UI automation less prone to failures caused by tooltips and improving the robustness of the soft deletion verification process.

**UI interaction reliability improvements:**

* In `visitEntityPage`, replaced the previous workaround for tooltip overlap (hovering and force-clicking) with a more reliable approach: moving the mouse to the top-left of the page to dismiss tooltips before performing a standard click on the entity name. This reduces flaky test failures due to tooltip interference.

**Robust retry logic for deletion checks:**

* In `softDeleteEntity`, refactored the manual retry loop for checking the "deleted" badge into Playwright's `expect.poll` with configurable intervals and timeout. This makes the check more robust, readable, and easier to maintain.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR addresses flaky Playwright test failures in `ServiceIngestion` and entity spec tests by refining two utility functions in `entity.ts`. The tooltip-dismissal strategy in `visitEntityPage` is simplified (replacing hover + force-click with a mouse-to-origin move and a standard click), and the deleted-badge polling loop in `softDeleteEntity` is migrated to Playwright's idiomatic `expect.poll` API.

- **`visitEntityPage`**: Drops `force: true` and the prior hover workaround; instead moves the mouse to `body` position `(0, 0)` before the click, which is a more reliable way to dismiss transient tooltips without bypassing Playwright's overlap detection.
- **`softDeleteEntity`**: Replaces a manual `while` loop (≤ 5 reload attempts, no timeout) with `expect.poll` (120 s timeout, ascending retry intervals of 5 s → 10 s → 15 s), giving the check a clear timeout, a descriptive failure message, and making it easier to maintain.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge; changes are scoped to Playwright test utilities with no production code path affected.

Both changes are self-contained improvements to test utility helpers. The `visitEntityPage` tooltip fix removes a linting suppression and the unreliable force-click. The `softDeleteEntity` migration to `expect.poll` is a strict improvement in clarity and robustness over the raw while loop, with the same eventual correctness guarantees. No application logic is touched.

No files require special attention.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-ui/src/main/resources/ui/playwright/utils/entity.ts | Two targeted changes: tooltip-dismissal strategy in `visitEntityPage` simplified to mouse-origin hover + standard click (removes `force: true`); `softDeleteEntity` manual retry loop replaced with `expect.poll`. One minor concern: the internal reload uses `waitUntil: 'domcontentloaded'` which resolves before the SPA is fully hydrated, though `waitForAllLoadersToDisappear` partially mitigates this. |

</details>

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Test
    participant Page
    participant Server

    Note over Test,Server: softDeleteEntity flow

    Test->>Page: click confirm-button
    Server-->>Test: deleteResponse (API 200)
    Test->>Page: toastNotification check
    Test->>Page: reload() + waitForAllLoadersToDisappear()

    loop expect.poll (timeout: 120s, intervals: 5s→10s→15s)
        Test->>Page: isVisible('[deleted-badge]')?
        alt Badge already visible
            Page-->>Test: true → poll resolves
        else Badge not visible
            Test->>Page: "reload({ waitUntil: 'domcontentloaded' })"
            Test->>Page: waitForAllLoadersToDisappear()
            Test->>Page: isVisible('[deleted-badge]')?
            Page-->>Test: true / false
        end
    end

    Test->>Page: expect toHaveText('Deleted')
    Test->>Page: deletedEntityCommonChecks (deleted: true)
    Test->>Page: restoreEntity()
    Test->>Page: reload() + waitForAllLoadersToDisappear()
    Test->>Page: deletedEntityCommonChecks (deleted: false)
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Test
    participant Page
    participant Server

    Note over Test,Server: softDeleteEntity flow

    Test->>Page: click confirm-button
    Server-->>Test: deleteResponse (API 200)
    Test->>Page: toastNotification check
    Test->>Page: reload() + waitForAllLoadersToDisappear()

    loop expect.poll (timeout: 120s, intervals: 5s→10s→15s)
        Test->>Page: isVisible('[deleted-badge]')?
        alt Badge already visible
            Page-->>Test: true → poll resolves
        else Badge not visible
            Test->>Page: "reload({ waitUntil: 'domcontentloaded' })"
            Test->>Page: waitForAllLoadersToDisappear()
            Test->>Page: isVisible('[deleted-badge]')?
            Page-->>Test: true / false
        end
    end

    Test->>Page: expect toHaveText('Deleted')
    Test->>Page: deletedEntityCommonChecks (deleted: true)
    Test->>Page: restoreEntity()
    Test->>Page: reload() + waitForAllLoadersToDisappear()
    Test->>Page: deletedEntityCommonChecks (deleted: false)
```

</a>
</details>

<sub>Reviews (2): Last reviewed commit: ["Worked on comments"](https://github.com/open-metadata/openmetadata/commit/8f8281ab88d4526d28bd8b3bd0a9cb9dd20528dd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38373885)</sub>

<!-- /greptile_comment -->