### PR TITLE
fix(search): stream search responses + exclude dataModel from Explore to prevent heap OOM on large schemas

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/DataInsightSystemChartRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/DataInsightSystemChartRepository.java
@@ -19,7 +19,6 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
-import org.glassfish.jersey.message.internal.OutboundJaxrsResponse;
 import org.openmetadata.schema.dataInsight.custom.DataInsightCustomChart;
 import org.openmetadata.schema.dataInsight.custom.DataInsightCustomChartResultList;
 import org.openmetadata.schema.entity.app.App;
@@ -36,6 +35,7 @@ import org.openmetadata.schema.utils.ResultList;
 import org.openmetadata.service.Entity;
 import org.openmetadata.service.resources.datainsight.system.DataInsightSystemChartResource;
 import org.openmetadata.service.search.SearchClient;
+import org.openmetadata.service.search.SearchResponseStreamer;
 import org.openmetadata.service.socket.WebSocketManager;
 import org.openmetadata.service.socket.messages.ChartDataStreamMessage;
 import org.openmetadata.service.util.EntityUtil;
@@ -185,8 +185,7 @@ public class DataInsightSystemChartRepository extends EntityRepository<DataInsig
               break;
             }
 
-            String responseBody =
-                (String) ((OutboundJaxrsResponse) response).getContext().getEntity();
+            String responseBody = SearchResponseStreamer.toJsonString(response);
             List<Map> pageStatuses = parseIngestionPipelineResponse(responseBody);
             if (pageStatuses.isEmpty()) {
               break;

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/GlossaryTermRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/GlossaryTermRepository.java
@@ -1346,8 +1346,7 @@ public class GlossaryTermRepository extends EntityRepository<GlossaryTerm> {
               .withDeleted(softDeleted)
               .withSortOrder("desc")
               .withIncludeSourceFields(new ArrayList<>());
-      Response response = searchRepository.search(searchRequest, null);
-      String json = (String) response.getEntity();
+      String json = searchRepository.searchAsString(searchRequest, null);
       Set<EntityReference> fqns = new TreeSet<>(compareEntityReferenceById);
       for (Iterator<JsonNode> it =
               ((ArrayNode) JsonUtils.extractValue(json, "hits", "hits")).elements();

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/DefaultInheritedFieldEntitySearch.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/DefaultInheritedFieldEntitySearch.java
@@ -28,6 +28,7 @@ import jakarta.json.JsonObject;
 import jakarta.json.JsonString;
 import jakarta.json.JsonValue;
 import jakarta.ws.rs.core.Response;
+import java.io.IOException;
 import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -156,9 +157,10 @@ public class DefaultInheritedFieldEntitySearch implements InheritedFieldEntitySe
     }
   }
 
-  private String extractResponseBody(Response response) {
-    Object entity = response.getEntity();
-    return entity != null ? entity.toString() : EMPTY_JSON;
+  private String extractResponseBody(Response response) throws IOException {
+    return response.getEntity() != null
+        ? SearchResponseStreamer.toJsonString(response)
+        : EMPTY_JSON;
   }
 
   private List<EntityReference> extractEntityReferencesFromSearchResponse(JsonNode searchResponse) {

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/SearchRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/SearchRepository.java
@@ -2919,6 +2919,16 @@ public class SearchRepository {
     return searchClient.search(request, subjectContext);
   }
 
+  /**
+   * Runs a search and returns the response body as a JSON String. For internal, bounded callers
+   * that parse the body in-process — the user-facing path streams the response instead (see {@link
+   * SearchResponseStreamer}).
+   */
+  public String searchAsString(SearchRequest request, SubjectContext subjectContext)
+      throws IOException {
+    return SearchResponseStreamer.toJsonString(search(request, subjectContext));
+  }
+
   public int countSearchResults(SearchRequest baseRequest, SubjectContext subjectContext)
       throws IOException {
     SearchRequest countRequest =
@@ -3332,8 +3342,7 @@ public class SearchRepository {
               .withIncludeSourceFields(new ArrayList<>());
 
       // Execute the search and parse the response
-      Response response = search(searchRequest, null);
-      String json = (String) response.getEntity();
+      String json = searchAsString(searchRequest, null);
       Set<EntityReference> fqns = new TreeSet<>(compareEntityReferenceById);
 
       // Extract hits from the response JSON and create entity references

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/SearchResponseStreamer.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/SearchResponseStreamer.java
@@ -15,7 +15,11 @@ package org.openmetadata.service.search;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.StreamingOutput;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+import org.openmetadata.schema.utils.JsonUtils;
 
 /**
  * Streams a search response directly to the HTTP output instead of materializing it into a single
@@ -53,6 +57,27 @@ public final class SearchResponseStreamer {
           output.flush();
         };
     return Response.ok(body, MediaType.APPLICATION_JSON_TYPE).build();
+  }
+
+  /**
+   * Materializes a (possibly streamed) search {@link Response} into a JSON String for internal,
+   * bounded callers that parse the body in-process. Handles both the streaming entity and the
+   * legacy String entity. Intended only for small/targeted internal queries — never the
+   * user-facing path, where streaming exists precisely to avoid this allocation.
+   */
+  public static String toJsonString(Response response) throws IOException {
+    Object entity = response.getEntity();
+    String result;
+    if (entity instanceof String s) {
+      result = s;
+    } else if (entity instanceof StreamingOutput streamingOutput) {
+      ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+      streamingOutput.write(buffer);
+      result = buffer.toString(StandardCharsets.UTF_8);
+    } else {
+      result = JsonUtils.pojoToJson(entity);
+    }
+    return result;
   }
 
   /** Wraps a failure that occurs while streaming the response body. */

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/SearchResponseStreamer.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/SearchResponseStreamer.java
@@ -1,0 +1,64 @@
+/*
+ *  Copyright 2024 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.openmetadata.service.search;
+
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.StreamingOutput;
+import java.io.OutputStream;
+
+/**
+ * Streams a search response directly to the HTTP output instead of materializing it into a single
+ * in-memory String.
+ *
+ * <p>The previous pattern built the entire response as one String before returning it
+ * ({@code searchResponse.toJsonString()} on OpenSearch, {@code serializeSearchResponse(...)} on
+ * ElasticSearch). For a single very large document — e.g. a container carrying a 170MB+ {@code
+ * dataModel} — that String is hundreds of MB allocated in one shot, on top of the already-parsed
+ * response object, and OOMs the node under concurrency. Writing the JSON straight to the response
+ * {@link OutputStream} removes that second full-size copy of the payload.
+ *
+ * <p>The serialization itself is engine-specific (the OpenSearch and ElasticSearch client types are
+ * distinct), so each manager supplies a {@link JsonWriter} that writes its typed response using its
+ * own JSON-P mapper; this helper owns the shared JAX-RS streaming plumbing.
+ */
+public final class SearchResponseStreamer {
+
+  private SearchResponseStreamer() {}
+
+  /** Writes a JSON payload to the supplied output stream. */
+  @FunctionalInterface
+  public interface JsonWriter {
+    void writeTo(OutputStream output) throws Exception;
+  }
+
+  public static Response stream(JsonWriter writer) {
+    StreamingOutput body =
+        output -> {
+          try {
+            writer.writeTo(output);
+          } catch (Exception e) {
+            throw new SearchStreamingException(e);
+          }
+          output.flush();
+        };
+    return Response.ok(body, MediaType.APPLICATION_JSON_TYPE).build();
+  }
+
+  /** Wraps a failure that occurs while streaming the response body. */
+  public static class SearchStreamingException extends RuntimeException {
+    public SearchStreamingException(Throwable cause) {
+      super("Failed to stream search response", cause);
+    }
+  }
+}

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/elasticsearch/ElasticSearchSearchManager.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/elasticsearch/ElasticSearchSearchManager.java
@@ -72,6 +72,7 @@ import org.openmetadata.service.jdbi3.TestCaseResultRepository;
 import org.openmetadata.service.monitoring.RequestLatencyContext;
 import org.openmetadata.service.resources.settings.SettingsCache;
 import org.openmetadata.service.search.SearchManagementClient;
+import org.openmetadata.service.search.SearchResponseStreamer;
 import org.openmetadata.service.search.SearchResultListMapper;
 import org.openmetadata.service.search.SearchSortFilter;
 import org.openmetadata.service.search.SearchSourceBuilderFactory;
@@ -164,8 +165,7 @@ public class ElasticSearchSearchManager implements SearchManagementClient {
         RequestLatencyContext.endSearchOperation(searchTimerSample);
       }
     }
-    String responseJson = serializeSearchResponse(response);
-    return Response.status(OK).entity(responseJson).build();
+    return streamSearchResponse(response);
   }
 
   @Override
@@ -202,8 +202,7 @@ public class ElasticSearchSearchManager implements SearchManagementClient {
         RequestLatencyContext.endSearchOperation(searchTimerSample);
       }
     }
-    String responseJson = serializeSearchResponse(response);
-    return Response.status(OK).entity(responseJson).build();
+    return streamSearchResponse(response);
   }
 
   @Override
@@ -582,9 +581,7 @@ public class ElasticSearchSearchManager implements SearchManagementClient {
           nlqService.cacheQuery(request.getQuery(), transformedQuery);
         }
 
-        return Response.status(Response.Status.OK)
-            .entity(serializeSearchResponse(response))
-            .build();
+        return streamSearchResponse(response);
       } catch (Exception e) {
         LOG.error("Error transforming or executing NLQ query: {}", e.getMessage(), e);
         return fallbackToBasicSearch(request, subjectContext);
@@ -671,9 +668,8 @@ public class ElasticSearchSearchManager implements SearchManagementClient {
         }
       }
 
-      String responseJson = serializeSearchResponse(response);
       LOG.debug("Direct query search completed successfully");
-      return Response.status(Response.Status.OK).entity(responseJson).build();
+      return streamSearchResponse(response);
     } catch (Exception e) {
       LOG.error("Error executing direct query search: {}", e.getMessage(), e);
       return Response.status(Response.Status.INTERNAL_SERVER_ERROR)
@@ -973,6 +969,16 @@ public class ElasticSearchSearchManager implements SearchManagementClient {
     return stringWriter.toString();
   }
 
+  private Response streamSearchResponse(SearchResponse<JsonData> searchResponse) {
+    JsonpMapper mapper = client._transport().jsonpMapper();
+    return SearchResponseStreamer.stream(
+        output -> {
+          try (JsonGenerator generator = mapper.jsonProvider().createGenerator(output)) {
+            searchResponse.serialize(generator, mapper);
+          }
+        });
+  }
+
   public Response doSearch(
       org.openmetadata.schema.search.SearchRequest request,
       SubjectContext subjectContext,
@@ -998,8 +1004,7 @@ public class ElasticSearchSearchManager implements SearchManagementClient {
       }
 
       if (!Boolean.TRUE.equals(request.getIsHierarchy())) {
-        String responseJson = serializeSearchResponse(searchResponse);
-        return Response.status(OK).entity(responseJson).build();
+        return streamSearchResponse(searchResponse);
       } else {
         List<?> response = buildSearchHierarchy(request, searchResponse, clusterAlias);
         return Response.status(OK).entity(response).build();
@@ -1558,9 +1563,7 @@ public class ElasticSearchSearchManager implements SearchManagementClient {
         }
       }
 
-      return Response.status(Response.Status.OK)
-          .entity(serializeSearchResponse(searchResponse))
-          .build();
+      return streamSearchResponse(searchResponse);
     } catch (Exception e) {
       LOG.error("Error in fallback search: {}", e.getMessage(), e);
       return Response.status(Response.Status.INTERNAL_SERVER_ERROR)

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/elasticsearch/ElasticSearchSearchManager.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/elasticsearch/ElasticSearchSearchManager.java
@@ -36,20 +36,17 @@ import jakarta.json.JsonObject;
 import jakarta.json.JsonReader;
 import jakarta.json.JsonString;
 import jakarta.json.JsonValue;
-import jakarta.json.spi.JsonProvider;
 import jakarta.json.stream.JsonGenerator;
 import jakarta.json.stream.JsonParser;
 import jakarta.ws.rs.core.Response;
 import java.io.IOException;
 import java.io.StringReader;
-import java.io.StringWriter;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
@@ -752,35 +749,32 @@ public class ElasticSearchSearchManager implements SearchManagementClient {
     }
     processedNode.add(fqn);
     SearchResponse<JsonData> searchResponse = performLineageSearchForDQ(fqn, queryFilter, deleted);
-    Optional<List> optionalDocs =
-        JsonUtils.readJsonAtPath(
-            serializeSearchResponse(searchResponse), "$.hits.hits[*]._source", List.class);
+    for (Hit<JsonData> hit : searchResponse.hits().hits()) {
+      if (hit.source() == null) {
+        continue;
+      }
+      Map<String, Object> doc = EsUtils.jsonDataToMap(hit.source());
+      String nodeId = doc.get("id").toString();
+      allNodes.put(nodeId, doc);
+      if (testCaseResultRepository.hasTestCaseFailure(doc.get("fullyQualifiedName").toString())) {
+        nodesWithFailure.add(nodeId);
+      }
 
-    if (optionalDocs.isPresent()) {
-      List<Map<String, Object>> docs = (List<Map<String, Object>>) optionalDocs.get();
-      for (Map<String, Object> doc : docs) {
-        String nodeId = doc.get("id").toString();
-        allNodes.put(nodeId, doc);
-        if (testCaseResultRepository.hasTestCaseFailure(doc.get("fullyQualifiedName").toString())) {
-          nodesWithFailure.add(nodeId);
-        }
-
-        List<EsLineageData> lineageDataList =
-            JsonUtils.readOrConvertValues(doc.get("upstreamLineage"), EsLineageData.class);
-        for (EsLineageData lineage : lineageDataList) {
-          lineage.withToEntity(SearchUtils.getRelationshipRef(doc));
-          String fromEntityId = lineage.getFromEntity().getId().toString();
-          allEdges.computeIfAbsent(fromEntityId, k -> new ArrayList<>()).add(lineage);
-          collectNodesAndEdgesForDQ(
-              lineage.getFromEntity().getFullyQualifiedName(),
-              upstreamDepth - 1,
-              queryFilter,
-              deleted,
-              allEdges,
-              allNodes,
-              nodesWithFailure,
-              processedNode);
-        }
+      List<EsLineageData> lineageDataList =
+          JsonUtils.readOrConvertValues(doc.get("upstreamLineage"), EsLineageData.class);
+      for (EsLineageData lineage : lineageDataList) {
+        lineage.withToEntity(SearchUtils.getRelationshipRef(doc));
+        String fromEntityId = lineage.getFromEntity().getId().toString();
+        allEdges.computeIfAbsent(fromEntityId, k -> new ArrayList<>()).add(lineage);
+        collectNodesAndEdgesForDQ(
+            lineage.getFromEntity().getFullyQualifiedName(),
+            upstreamDepth - 1,
+            queryFilter,
+            deleted,
+            allEdges,
+            allNodes,
+            nodesWithFailure,
+            processedNode);
       }
     }
   }
@@ -949,24 +943,6 @@ public class ElasticSearchSearchManager implements SearchManagementClient {
     AssetTypeConfiguration assetConfig =
         sourceBuilderFactory.findAssetTypeConfig(indexName, searchSettings);
     sourceBuilderFactory.addConfiguredAggregationsV2(requestBuilder, assetConfig);
-  }
-
-  /**
-   * Serializes a SearchResponse to JSON string.
-   *
-   * @param searchResponse the SearchResponse to serialize
-   * @return JSON string representation of the response
-   */
-  private String serializeSearchResponse(SearchResponse<JsonData> searchResponse) {
-    JsonpMapper jsonpMapper = client._transport().jsonpMapper();
-    JsonProvider provider = jsonpMapper.jsonProvider();
-    StringWriter stringWriter = new StringWriter();
-    JsonGenerator generator = provider.createGenerator(stringWriter);
-
-    searchResponse.serialize(generator, jsonpMapper);
-    generator.close();
-
-    return stringWriter.toString();
   }
 
   private Response streamSearchResponse(SearchResponse<JsonData> searchResponse) {

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/opensearch/OpenSearchSearchManager.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/opensearch/OpenSearchSearchManager.java
@@ -33,7 +33,6 @@ import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
@@ -660,9 +659,8 @@ public class OpenSearchSearchManager implements SearchManagementClient {
         }
       }
 
-      String responseJson = response.toJsonString();
       LOG.debug("Direct query search completed successfully");
-      return Response.status(Response.Status.OK).entity(responseJson).build();
+      return streamSearchResponse(response);
     } catch (Exception e) {
       LOG.error("Error executing direct query search: {}", e.getMessage(), e);
       return Response.status(Response.Status.INTERNAL_SERVER_ERROR)
@@ -745,35 +743,32 @@ public class OpenSearchSearchManager implements SearchManagementClient {
     }
     processedNode.add(fqn);
     SearchResponse<JsonData> searchResponse = performLineageSearchForDQ(fqn, queryFilter, deleted);
-    Optional<List> optionalDocs =
-        JsonUtils.readJsonAtPath(
-            searchResponse.toJsonString(), "$.hits.hits[*]._source", List.class);
+    for (Hit<JsonData> hit : searchResponse.hits().hits()) {
+      if (hit.source() == null) {
+        continue;
+      }
+      Map<String, Object> doc = OsUtils.jsonDataToMap(hit.source());
+      String nodeId = doc.get("id").toString();
+      allNodes.put(nodeId, doc);
+      if (testCaseResultRepository.hasTestCaseFailure(doc.get("fullyQualifiedName").toString())) {
+        nodesWithFailure.add(nodeId);
+      }
 
-    if (optionalDocs.isPresent()) {
-      List<Map<String, Object>> docs = (List<Map<String, Object>>) optionalDocs.get();
-      for (Map<String, Object> doc : docs) {
-        String nodeId = doc.get("id").toString();
-        allNodes.put(nodeId, doc);
-        if (testCaseResultRepository.hasTestCaseFailure(doc.get("fullyQualifiedName").toString())) {
-          nodesWithFailure.add(nodeId);
-        }
-
-        List<EsLineageData> lineageDataList =
-            JsonUtils.readOrConvertValues(doc.get("upstreamLineage"), EsLineageData.class);
-        for (EsLineageData lineage : lineageDataList) {
-          lineage.withToEntity(SearchUtils.getRelationshipRef(doc));
-          String fromEntityId = lineage.getFromEntity().getId().toString();
-          allEdges.computeIfAbsent(fromEntityId, k -> new ArrayList<>()).add(lineage);
-          collectNodesAndEdgesForDQ(
-              lineage.getFromEntity().getFullyQualifiedName(),
-              upstreamDepth - 1,
-              queryFilter,
-              deleted,
-              allEdges,
-              allNodes,
-              nodesWithFailure,
-              processedNode);
-        }
+      List<EsLineageData> lineageDataList =
+          JsonUtils.readOrConvertValues(doc.get("upstreamLineage"), EsLineageData.class);
+      for (EsLineageData lineage : lineageDataList) {
+        lineage.withToEntity(SearchUtils.getRelationshipRef(doc));
+        String fromEntityId = lineage.getFromEntity().getId().toString();
+        allEdges.computeIfAbsent(fromEntityId, k -> new ArrayList<>()).add(lineage);
+        collectNodesAndEdgesForDQ(
+            lineage.getFromEntity().getFullyQualifiedName(),
+            upstreamDepth - 1,
+            queryFilter,
+            deleted,
+            allEdges,
+            allNodes,
+            nodesWithFailure,
+            processedNode);
       }
     }
   }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/opensearch/OpenSearchSearchManager.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/opensearch/OpenSearchSearchManager.java
@@ -22,6 +22,7 @@ import jakarta.json.JsonArray;
 import jakarta.json.JsonObject;
 import jakarta.json.JsonReader;
 import jakarta.json.JsonValue;
+import jakarta.json.stream.JsonGenerator;
 import jakarta.json.stream.JsonParser;
 import jakarta.ws.rs.core.Response;
 import java.io.IOException;
@@ -57,6 +58,7 @@ import org.openmetadata.service.jdbi3.TestCaseResultRepository;
 import org.openmetadata.service.monitoring.RequestLatencyContext;
 import org.openmetadata.service.resources.settings.SettingsCache;
 import org.openmetadata.service.search.SearchManagementClient;
+import org.openmetadata.service.search.SearchResponseStreamer;
 import org.openmetadata.service.search.SearchResultListMapper;
 import org.openmetadata.service.search.SearchSortFilter;
 import org.openmetadata.service.search.SearchSourceBuilderFactory;
@@ -185,7 +187,7 @@ public class OpenSearchSearchManager implements SearchManagementClient {
         RequestLatencyContext.endSearchOperation(searchTimerSample);
       }
     }
-    return Response.status(OK).entity(response.toJsonString()).build();
+    return streamSearchResponse(response);
   }
 
   @Override
@@ -226,7 +228,7 @@ public class OpenSearchSearchManager implements SearchManagementClient {
         RequestLatencyContext.endSearchOperation(searchTimerSample);
       }
     }
-    return Response.status(OK).entity(response.toJsonString()).build();
+    return streamSearchResponse(response);
   }
 
   @Override
@@ -592,7 +594,7 @@ public class OpenSearchSearchManager implements SearchManagementClient {
           nlqService.cacheQuery(request.getQuery(), transformedQuery);
         }
 
-        return Response.status(Response.Status.OK).entity(response.toJsonString()).build();
+        return streamSearchResponse(response);
       } catch (Exception e) {
         LOG.error("Error transforming or executing NLQ query: {}", e.getMessage(), e);
         return fallbackToBasicSearch(request, subjectContext);
@@ -1019,6 +1021,16 @@ public class OpenSearchSearchManager implements SearchManagementClient {
     sourceBuilderFactory.addConfiguredAggregationsV2(requestBuilder, assetConfig);
   }
 
+  private Response streamSearchResponse(SearchResponse<JsonData> searchResponse) {
+    JsonpMapper mapper = client._transport().jsonpMapper();
+    return SearchResponseStreamer.stream(
+        output -> {
+          try (JsonGenerator generator = mapper.jsonProvider().createGenerator(output)) {
+            searchResponse.serialize(generator, mapper);
+          }
+        });
+  }
+
   public Response doSearch(
       org.openmetadata.schema.search.SearchRequest request,
       SubjectContext subjectContext,
@@ -1036,7 +1048,7 @@ public class OpenSearchSearchManager implements SearchManagementClient {
       SearchResponse<JsonData> searchResponse = client.search(searchRequest, JsonData.class);
 
       if (!Boolean.TRUE.equals(request.getIsHierarchy())) {
-        return Response.status(OK).entity(searchResponse.toJsonString()).build();
+        return streamSearchResponse(searchResponse);
       } else {
         List<?> response = buildSearchHierarchy(request, searchResponse, clusterAlias);
         return Response.status(OK).entity(response).build();
@@ -1591,7 +1603,7 @@ public class OpenSearchSearchManager implements SearchManagementClient {
         }
       }
 
-      return Response.status(Response.Status.OK).entity(searchResponse.toJsonString()).build();
+      return streamSearchResponse(searchResponse);
     } catch (Exception e) {
       LOG.error("Error in fallback search: {}", e.getMessage(), e);
       return Response.status(Response.Status.INTERNAL_SERVER_ERROR)

--- a/openmetadata-service/src/main/java/org/openmetadata/service/workflows/searchIndex/ReindexingUtil.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/workflows/searchIndex/ReindexingUtil.java
@@ -19,7 +19,6 @@ import static org.openmetadata.service.search.SearchClient.GLOBAL_SEARCH_ALIAS;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import es.co.elastic.clients.elasticsearch.core.bulk.BulkResponseItem;
-import jakarta.ws.rs.core.Response;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -247,8 +246,7 @@ public class ReindexingUtil {
             .withSortOrder("desc")
             .withIncludeSourceFields(new ArrayList<>());
     List<EntityReference> entities = new ArrayList<>();
-    Response response = Entity.getSearchRepository().search(searchRequest, null);
-    String json = (String) response.getEntity();
+    String json = Entity.getSearchRepository().searchAsString(searchRequest, null);
 
     for (Iterator<JsonNode> it =
             ((ArrayNode) JsonUtils.extractValue(json, "hits", "hits")).elements();

--- a/openmetadata-ui/src/main/resources/ui/src/components/AppBar/Suggestions.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/AppBar/Suggestions.tsx
@@ -375,7 +375,7 @@ const Suggestions = ({
         queryFilter: quickFilter,
         pageSize: PAGE_SIZE_BASE,
         includeDeleted: false,
-        excludeSourceFields: ['columns', 'queries', 'columnNames'],
+        excludeSourceFields: ['columns', 'queries', 'columnNames', 'dataModel'],
       });
 
       setOptions(res.hits.hits as unknown as Option[]);

--- a/openmetadata-ui/src/main/resources/ui/src/utils/ExploreUtils.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/ExploreUtils.tsx
@@ -231,7 +231,12 @@ export const fetchEntityData = async ({
           pageNumber: page,
           pageSize: size,
           includeDeleted: showDeleted,
-          excludeSourceFields: ['columns', 'queries', 'columnNames'],
+          excludeSourceFields: [
+            'columns',
+            'queries',
+            'columnNames',
+            'dataModel',
+          ],
         };
 
         try {
@@ -272,7 +277,7 @@ export const fetchEntityData = async ({
         pageNumber: page,
         pageSize: size,
         includeDeleted: showDeleted,
-        excludeSourceFields: ['columns', 'queries', 'columnNames'],
+        excludeSourceFields: ['columns', 'queries', 'columnNames', 'dataModel'],
       };
 
       try {


### PR DESCRIPTION
Fixes #29210

## Problem

A single container/table with a very large `dataModel` (a legitimately wide/nested schema — observed in prod: 17 columns × ~43k children ≈ 736k columns, ~173 MB) produces a ~170 MB+ search document. The search **read** path materialized the entire response into one in-memory String (`OpenSearchSearchManager` → `toJsonString()`, `ElasticSearchSearchManager` → `serializeSearchResponse()`) — a hundreds-of-MB single allocation on top of the already-parsed response — and OOM'd the node under concurrency (`java.lang.OutOfMemoryError: Java heap space` in `SearchResource.search`).

The data is **legitimate** (customer-confirmed), so this is a system-scalability fix, not a data cleanup.

## Changes

**A — stream the response (systemic, both engines)**
- New `SearchResponseStreamer`: serializes the response **straight to the HTTP output stream** via a `StreamingOutput` instead of building an intermediate String — removes the allocation that OOM'd.
- Routed all hit-returning sites through it in both `OpenSearchSearchManager` (5 sites: `doSearch`, `searchByField`, `searchBySourceUrl`, `searchWithNLQ`, fallback) and `ElasticSearchSearchManager` (6 sites). `serializeSearchResponse` kept for the internal JsonPath use.

**B1 — exclude `dataModel` from Explore (payload size)**
- Added `dataModel` to `exclude_source_fields` in Explore listing (`ExploreUtils`) and search suggestions (`Suggestions`) so the heavy field isn't returned in listing payloads. No reindex.

## No feature loss
- Column-name search → uses `columnNamesFuzzy` (separate field), unaffected.
- Column Bulk Operations / Column Grid → reads `dataModel` from `_source` (index unchanged), unaffected.
- Container detail page / Schema tab → reads `dataModel` from the entity API (DB), unaffected.

## Scope / follow-ups
- This stops the server OOM. The typed client still parses the response into an object graph (transport buffers anyway), so it's not a hard O(buffer) bound — Explore payloads are kept small via B1.
- Separate: `ServiceInsightsTab.getDataAssetsCount` issues an aggregation-only query with default `size=10` and no source trimming; should pass `size:0` (not in this PR).

## Verification
⚠️ Could not run a local `mvn` build (local cache lacks the 2.0.0-SNAPSHOT upstream modules); relying on CI for compile + `spotless:check`. UI files were prettier-formatted locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR addresses a production heap OOM caused by a 170 MB+ search document by (A) streaming search responses directly to the HTTP output stream via a new `SearchResponseStreamer` instead of materializing the full response as a single in-memory `String`, and (B) excluding the heavy `dataModel` field from Explore listing and suggestion payloads.

- **Streaming (A)**: `SearchResponseStreamer.stream()` wraps engine-specific JSON serialization in JAX-RS `StreamingOutput`, removing the second full-size allocation. Six call sites in each engine manager are updated, and `collectNodesAndEdgesForDQ` in both managers is refactored from deserialize-to-String + JsonPath to direct typed-hit iteration. Internal callers that parse the body in-process are migrated to `SearchResponseStreamer.toJsonString()` / `searchAsString()`.
- **Payload exclusion (B)**: `dataModel` added to `excludeSourceFields` in `ExploreUtils.fetchEntityData` (two call sites) and `Suggestions`, ensuring the large field is not returned in listing or autocomplete payloads without requiring a reindex.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge for correctness, but the search response cache and its single-flight deduplication are silently broken for all streaming responses.

The streaming change is the right fix for the OOM — entity type of search responses changed from `String` to `StreamingOutput`, but `SearchResource`'s `loadOrCompute` supplier still gates caching on `entity instanceof String s`. Since `StreamingOutput` never satisfies that check, the cache is never written and the single-flight deduplication (described as collapsing 100 concurrent identical queries into one ES call) no longer fires. Under high concurrency with a popular query, all callers now hit the backend independently instead of sharing one outstanding ES call — the same scenario the cache was designed to guard against.

SearchResource.java (not in this diff) needs its `loadOrCompute` supplier updated to handle `StreamingOutput` entities so the cache and single-flight deduplication work with the new streaming response type.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-service/src/main/java/org/openmetadata/service/search/SearchResponseStreamer.java | New utility class that streams search responses via StreamingOutput instead of materializing them as in-memory Strings; also provides `toJsonString` for bounded internal callers. Core design is sound. |
| openmetadata-service/src/main/java/org/openmetadata/service/search/elasticsearch/ElasticSearchSearchManager.java | All six hit-returning paths now use `streamSearchResponse`; `collectNodesAndEdgesForDQ` refactored from JsonPath on serialized String to direct typed-hit iteration. |
| openmetadata-service/src/main/java/org/openmetadata/service/search/opensearch/OpenSearchSearchManager.java | Mirrors ElasticSearch changes: six streaming sites, `collectNodesAndEdgesForDQ` refactored to typed-hit iteration replacing `toJsonString()` + JsonPath. Symmetric and correct. |
| openmetadata-service/src/main/java/org/openmetadata/service/search/SearchRepository.java | Adds `searchAsString` convenience method for bounded internal callers; updates two internal callers from `(String) response.getEntity()` cast to the new helper. |
| openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/DataInsightSystemChartRepository.java | Removes Jersey-internal `OutboundJaxrsResponse` cast in favour of `SearchResponseStreamer.toJsonString()`; search is bounded so materializing is safe. |
| openmetadata-ui/src/main/resources/ui/src/utils/ExploreUtils.tsx | Adds `dataModel` to `excludeSourceFields` at two call sites in `fetchEntityData`; straightforward payload-size reduction for Explore listing. |

</details>

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Client
    participant SearchResource
    participant CachedSearchLayer
    participant SearchRepository
    participant ESManager as ES/OS Manager
    participant ES as Elasticsearch/OpenSearch

    Client->>SearchResource: "GET /search?q=..."
    SearchResource->>CachedSearchLayer: loadOrCompute(request, principal, supplier)
    CachedSearchLayer->>SearchRepository: search(request, subjectContext)
    SearchRepository->>ESManager: search(request)
    ESManager->>ES: HTTP search request
    ES-->>ESManager: "SearchResponse<JsonData>"
    ESManager-->>SearchRepository: Response(StreamingOutput)
    SearchRepository-->>CachedSearchLayer: Response(StreamingOutput)
    Note over CachedSearchLayer: entity instanceof String? false<br/>supplier returns null, cache miss<br/>single-flight dedup broken
    CachedSearchLayer-->>SearchResource: "body=null, capturedResponse=Response(StreamingOutput)"
    SearchResource-->>Client: StreamingOutput written to HTTP stream
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Client
    participant SearchResource
    participant CachedSearchLayer
    participant SearchRepository
    participant ESManager as ES/OS Manager
    participant ES as Elasticsearch/OpenSearch

    Client->>SearchResource: "GET /search?q=..."
    SearchResource->>CachedSearchLayer: loadOrCompute(request, principal, supplier)
    CachedSearchLayer->>SearchRepository: search(request, subjectContext)
    SearchRepository->>ESManager: search(request)
    ESManager->>ES: HTTP search request
    ES-->>ESManager: "SearchResponse<JsonData>"
    ESManager-->>SearchRepository: Response(StreamingOutput)
    SearchRepository-->>CachedSearchLayer: Response(StreamingOutput)
    Note over CachedSearchLayer: entity instanceof String? false<br/>supplier returns null, cache miss<br/>single-flight dedup broken
    CachedSearchLayer-->>SearchResource: "body=null, capturedResponse=Response(StreamingOutput)"
    SearchResource-->>Client: StreamingOutput written to HTTP stream
```

</a>
</details>

<sub>Reviews (3): Last reviewed commit: ["fix(search): keep internal search caller..."](https://github.com/open-metadata/openmetadata/commit/bcbd96d79ec4fad8473e5b493db42f4426782381) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38416946)</sub>

<!-- /greptile_comment -->
