### PR TITLE
fix(ingestion): decouple patch_mixin from sampler.entity_adapters on 1.13

### DIFF
--- a/ingestion/src/metadata/ingestion/ometa/mixins/patch_mixin.py
+++ b/ingestion/src/metadata/ingestion/ometa/mixins/patch_mixin.py
@@ -30,6 +30,7 @@ from metadata.generated.schema.entity.automations.workflow import (
     Workflow as AutomationWorkflow,
 )
 from metadata.generated.schema.entity.automations.workflow import WorkflowStatus
+from metadata.generated.schema.entity.data.container import Container
 from metadata.generated.schema.entity.data.table import Column, Table, TableConstraint
 from metadata.generated.schema.entity.services.connections.testConnectionResult import (
     TestConnectionResult,
@@ -55,7 +56,6 @@ from metadata.ingestion.ometa.mixins.patch_mixin_utils import (
 )
 from metadata.ingestion.ometa.utils import model_str
 from metadata.pii.types import ClassifiableEntityType
-from metadata.sampler.entity_adapters import EntityAdapter, adapter_for
 from metadata.utils.deprecation import deprecated
 from metadata.utils.logger import get_log_name, ometa_logger
 
@@ -498,63 +498,92 @@ class OMetaPatchMixin(OMetaPatchMixinBase):
 
     def _prepare_destination_for_column_tags(
         self,
-        entity: ClassifiableEntityType,
         instance: ClassifiableEntityType,
         column_tags: List[ColumnTag],  # noqa: UP006
         operation: PatchOperation,
-        adapter: "EntityAdapter",
     ) -> ClassifiableEntityType | None:
-        columns = adapter.get_columns(instance)
+        patch_info = self._column_tag_patch_info(instance)
+        if patch_info is None:
+            return None
+        _, columns = patch_info
+
         if columns is None:
             logger.warning(
                 "Entity %s has no columns, skipping column tag patch",
-                entity.fullyQualifiedName.root if entity.fullyQualifiedName else type(entity).__name__,
+                instance.fullyQualifiedName.root if instance.fullyQualifiedName else type(instance).__name__,
             )
             return None
-        adapter.set_columns(entity, columns)
-        destination = entity.model_copy(deep=True)
-        dest_columns = adapter.get_columns(destination)
-        if dest_columns is not None:
-            for column_tag in column_tags or []:
-                update_column_tags(dest_columns, column_tag, operation)
+
+        destination = instance.model_copy(deep=True)
+        destination_info = self._column_tag_patch_info(destination)
+        if destination_info is None:
+            return None
+        _, destination_columns = destination_info
+        if destination_columns is None:
+            logger.warning(
+                "Entity %s has no columns, skipping column tag patch",
+                destination.fullyQualifiedName.root if destination.fullyQualifiedName else type(destination).__name__,
+            )
+            return None
+
+        for column_tag in column_tags or []:
+            update_column_tags(destination_columns, column_tag, operation)
         return destination
+
+    def _column_tag_patch_info(
+        self, entity: ClassifiableEntityType
+    ) -> tuple[List[str], Optional[List[Column]]] | None:  # noqa: UP006, UP045
+        if isinstance(entity, Table):
+            return ["tags", "columns"], entity.columns
+        if isinstance(entity, Container):
+            return ["tags", "dataModel"], entity.dataModel.columns if entity.dataModel else None
+
+        logger.warning(
+            "Unsupported entity type for column tag patching: %s",
+            type(entity).__name__,
+        )
+        return None
 
     def patch_column_tags(
         self,
-        entity: ClassifiableEntityType,
-        column_tags: List[ColumnTag],  # noqa: UP006
+        table: Optional[ClassifiableEntityType] = None,  # noqa: UP045
+        column_tags: Optional[List[ColumnTag]] = None,  # noqa: UP006, UP045
         operation: Union[PatchOperation.ADD, PatchOperation.REMOVE] = PatchOperation.ADD,  # noqa: UP007
+        entity: Optional[ClassifiableEntityType] = None,  # noqa: UP045
     ) -> Optional[T]:  # noqa: UP045
         """Given an Entity ID, JSON PATCH the tag of the column
 
         Args
-            entity: Classifiable entity (Table, Container, …) to update
+            table: Classifiable entity (Table, Container, …) to update
             column_tags: List of ColumnTag to add or remove
             operation: Patch Operation to add or remove
+            entity: Backward-compatible alias for table
         Returns
             Updated Entity
         """
 
-        adapter = adapter_for(entity)
-        if adapter is None:
-            logger.warning(
-                "Unsupported entity type for column tag patching: %s",
-                type(entity).__name__,
-            )
+        table = table if table is not None else entity
+        if table is None:
+            logger.warning("No entity provided for column tag patching")
             return None
 
-        entity_type = type(entity)
-        entity_label = entity.fullyQualifiedName.root if entity.fullyQualifiedName else entity_type.__name__
+        patch_info = self._column_tag_patch_info(table)
+        if patch_info is None:
+            return None
+        fields, _ = patch_info
+
+        entity_type = type(table)
+        entity_label = table.fullyQualifiedName.root if table.fullyQualifiedName else entity_type.__name__
         last_error: Optional[APIError] = None  # noqa: UP045
         last_rejected_etag: Optional[str] = None  # noqa: UP045
         for attempt in range(MAX_OPTIMISTIC_LOCK_RETRIES):
             instance = self._fetch_entity_if_exists(
-                entity=entity_type, entity_id=entity.id, fields=adapter.patch_fields
+                entity=entity_type, entity_id=table.id, fields=fields
             )
             if not instance:
                 return None
 
-            destination = self._prepare_destination_for_column_tags(entity, instance, column_tags, operation, adapter)
+            destination = self._prepare_destination_for_column_tags(instance, column_tags, operation)
             if destination is None:
                 return None
 
@@ -574,7 +603,7 @@ class OMetaPatchMixin(OMetaPatchMixinBase):
             try:
                 patched_entity = self.patch(
                     entity=entity_type,
-                    source=entity,
+                    source=instance,
                     destination=destination,
                     if_match=None if falling_back else instance_etag,
                 )
@@ -620,7 +649,7 @@ class OMetaPatchMixin(OMetaPatchMixinBase):
     ) -> Optional[T]:  # noqa: UP045
         """Will be deprecated in 1.3"""
         return self.patch_column_tags(
-            entity=table,
+            table=table,
             column_tags=[ColumnTag(column_fqn=column_fqn, tag_label=tag_label)],
             operation=operation,
         )

--- a/ingestion/tests/unit/metadata/ingestion/ometa/test_patch_mixin.py
+++ b/ingestion/tests/unit/metadata/ingestion/ometa/test_patch_mixin.py
@@ -1,0 +1,190 @@
+#  Copyright 2026 Collate
+#  Licensed under the Collate Community License, Version 1.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  https://github.com/open-metadata/OpenMetadata/blob/main/ingestion/LICENSE
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+"""
+Unit tests for PATCH helpers in OMetaPatchMixin.
+"""
+
+from unittest.mock import MagicMock
+from uuid import uuid4
+
+from metadata.generated.schema.entity.data.container import (
+    Container,
+    ContainerDataModel,
+)
+from metadata.generated.schema.entity.data.table import (
+    Column,
+    ColumnName,
+    DataType,
+    Table,
+)
+from metadata.generated.schema.type.basic import EntityName, FullyQualifiedEntityName
+from metadata.generated.schema.type.entityReference import EntityReference
+from metadata.generated.schema.type.tagLabel import (
+    LabelType,
+    State,
+    TagFQN,
+    TagLabel,
+    TagSource,
+)
+from metadata.ingestion.models.table_metadata import ColumnTag
+from metadata.ingestion.ometa.mixins.patch_mixin import OMetaPatchMixin
+
+PII_TAG = TagLabel(
+    tagFQN=TagFQN("PII.Sensitive"),
+    labelType=LabelType.Automated,
+    state=State.Suggested.value,
+    source=TagSource.Classification,
+)
+
+
+def _make_mixin() -> OMetaPatchMixin:
+    mixin = OMetaPatchMixin.__new__(OMetaPatchMixin)
+    mixin._fetch_entity_if_exists = MagicMock()
+    mixin.patch = MagicMock()
+    return mixin
+
+
+def _column(column_name: str, column_fqn: str) -> Column:
+    return Column(
+        name=ColumnName(column_name),
+        dataType=DataType.INT,
+        fullyQualifiedName=FullyQualifiedEntityName(column_fqn),
+        tags=[],
+    )
+
+
+def _table() -> Table:
+    table_fqn = "service.database.schema.orders"
+    return Table(
+        id=uuid4(),
+        name=EntityName("orders"),
+        fullyQualifiedName=FullyQualifiedEntityName(table_fqn),
+        columns=[_column("id", f"{table_fqn}.id")],
+    )
+
+
+def _container() -> Container:
+    container_fqn = "storage_service.bucket.orders_csv"
+    return Container(
+        id=uuid4(),
+        name=EntityName("orders_csv"),
+        fullyQualifiedName=FullyQualifiedEntityName(container_fqn),
+        service=EntityReference(id=uuid4(), type="storageService"),
+        dataModel=ContainerDataModel(
+            columns=[_column("id", f"{container_fqn}.id")],
+        ),
+    )
+
+
+def test_patch_column_tags_uses_fetched_table_as_source_and_deep_copied_destination():
+    mixin = _make_mixin()
+    request_table = _table()
+    fetched_table = _table()
+    patched_table = _table()
+    mixin._fetch_entity_if_exists.return_value = fetched_table
+    mixin.patch.return_value = patched_table
+
+    result = mixin.patch_column_tags(
+        table=request_table,
+        column_tags=[
+            ColumnTag(
+                column_fqn=f"{fetched_table.fullyQualifiedName.root}.id",
+                tag_label=PII_TAG,
+            )
+        ],
+    )
+
+    assert result is patched_table
+    mixin._fetch_entity_if_exists.assert_called_once_with(
+        entity=Table,
+        entity_id=request_table.id,
+        fields=["tags", "columns"],
+    )
+    patch_call = mixin.patch.call_args.kwargs
+    assert patch_call["entity"] is Table
+    assert patch_call["source"] is fetched_table
+    assert patch_call["destination"] is not fetched_table
+    assert fetched_table.columns[0].tags == []
+    assert patch_call["destination"].columns[0].tags == [PII_TAG]
+
+
+def test_patch_column_tags_supports_legacy_entity_alias():
+    mixin = _make_mixin()
+    request_table = _table()
+    fetched_table = _table()
+    patched_table = _table()
+    mixin._fetch_entity_if_exists.return_value = fetched_table
+    mixin.patch.return_value = patched_table
+
+    result = mixin.patch_column_tags(
+        entity=request_table,
+        column_tags=[
+            ColumnTag(
+                column_fqn=f"{fetched_table.fullyQualifiedName.root}.id",
+                tag_label=PII_TAG,
+            )
+        ],
+    )
+
+    assert result is patched_table
+    mixin._fetch_entity_if_exists.assert_called_once_with(
+        entity=Table,
+        entity_id=request_table.id,
+        fields=["tags", "columns"],
+    )
+
+
+def test_patch_column_tags_updates_container_data_model_columns():
+    mixin = _make_mixin()
+    request_container = _container()
+    fetched_container = _container()
+    patched_container = _container()
+    mixin._fetch_entity_if_exists.return_value = fetched_container
+    mixin.patch.return_value = patched_container
+
+    result = mixin.patch_column_tags(
+        table=request_container,
+        column_tags=[
+            ColumnTag(
+                column_fqn=f"{fetched_container.fullyQualifiedName.root}.id",
+                tag_label=PII_TAG,
+            )
+        ],
+    )
+
+    assert result is patched_container
+    mixin._fetch_entity_if_exists.assert_called_once_with(
+        entity=Container,
+        entity_id=request_container.id,
+        fields=["tags", "dataModel"],
+    )
+    patch_call = mixin.patch.call_args.kwargs
+    assert patch_call["entity"] is Container
+    assert patch_call["source"] is fetched_container
+    assert patch_call["destination"] is not fetched_container
+    assert fetched_container.dataModel.columns[0].tags == []
+    assert patch_call["destination"].dataModel.columns[0].tags == [PII_TAG]
+
+
+def test_patch_column_tags_skips_when_no_entity_is_provided():
+    mixin = _make_mixin()
+
+    assert mixin.patch_column_tags() is None
+    mixin._fetch_entity_if_exists.assert_not_called()
+    mixin.patch.assert_not_called()
+
+
+def test_patch_column_tags_skips_unsupported_entity_type():
+    mixin = _make_mixin()
+
+    assert mixin.patch_column_tags(table=object(), column_tags=[]) is None
+    mixin._fetch_entity_if_exists.assert_not_called()
+    mixin.patch.assert_not_called()


### PR DESCRIPTION
## Problem

The 1.13 nightly crashes on **every** `metadata` command at import time:

```
ModuleNotFoundError: No module named 'metadata.sampler.entity_adapters'
  ...
  File ".../metadata/ingestion/ometa/mixins/patch_mixin.py", line 58
    from metadata.sampler.entity_adapters import EntityAdapter, adapter_for
```

`patch_mixin` is imported at the root of the package
(`metadata/__init__.py` → `profiler.metrics.registry` → `ometa_api` → `patch_mixin`),
so the missing module takes down the whole CLI, not just patching.

## Root cause

The 1.13 cherry-pick of **#28837** ("persist nested column changes on optimistic-locking PATCH")
added the `metadata.sampler.entity_adapters` import to `patch_mixin.py`.
That module was **not** created by #28837 — it came from a separate, earlier PR (**#27716**,
"introduce ClassifiableEntityAdapter…") that was never ported to 1.13. Incomplete transitive
dependency in the cherry-pick.

## Fix

Inline the `Table`/`Container` column handling directly in `patch_mixin` and drop the
`sampler.entity_adapters` import entirely.

Back-porting the full #27716 adapter refactor was rejected: it drags in the `processor.py`
rewrite plus `sampler_config`/`config_utils`, which re-introduce a `sampler` → `profiler`
import cycle right at the package root. Inlining the two entity types keeps the
optimistic-locking column-tag patch behavior with zero sampler coupling.

- `patch_mixin.py`: inline `(patch_fields, columns)` resolution via `isinstance(Table/Container)`
- `test_patch_mixin.py`: unit coverage for the column-tag patch paths

## Test plan

- [x] `python -m py_compile patch_mixin.py test_patch_mixin.py`
- [x] No remaining `entity_adapters` references in `ingestion/src`
- [ ] Re-run the 1.13 nightly — import chain resolves

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a boot-time crash on the 1.13 branch where every `metadata` CLI command failed with `ModuleNotFoundError: No module named 'metadata.sampler.entity_adapters'` because an incomplete cherry-pick added that import to `patch_mixin.py` without porting the module it depended on.

- **`patch_mixin.py`**: Removes the `sampler.entity_adapters` import and inlines the `Table`/`Container` column-resolution logic directly via `isinstance` checks; also corrects the `self.patch` call to use `source=instance` (the fresh server copy) rather than the caller-supplied entity.
- **`test_patch_mixin.py`**: New unit tests covering the Table path, Container path, legacy `entity` alias, no-entity guard, and unsupported-type guard.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; fixes a hard crash with a focused, well-tested inline change and no new cross-module dependencies.

The removal of the broken import resolves the boot-time crash cleanly. The source=instance correction is a genuine improvement over the old mutate-then-copy pattern. The only rough edge is the redundant dead-code guards inside _prepare_destination_for_column_tags, which have no runtime impact but slightly obscure the logic.

The redundant post-model_copy checks in patch_mixin.py are the only item worth a second look.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| ingestion/src/metadata/ingestion/ometa/mixins/patch_mixin.py | Removes broken sampler import, inlines Table/Container dispatch via isinstance, and fixes source=instance in patch call; minor redundant dead-code checks in _prepare_destination_for_column_tags. |
| ingestion/tests/unit/metadata/ingestion/ometa/test_patch_mixin.py | New unit tests covering all primary and edge-case paths for patch_column_tags; well-structured and thorough. |

</details>

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Caller
    participant patch_column_tags
    participant _column_tag_patch_info
    participant _prepare_destination
    participant _fetch_entity_if_exists
    participant patch

    Caller->>patch_column_tags: table / entity (alias)
    patch_column_tags->>_column_tag_patch_info: table → fields
    Note over _column_tag_patch_info: isinstance(Table) → ["tags","columns"]<br/>isinstance(Container) → ["tags","dataModel"]<br/>else → None (unsupported)
    loop MAX_OPTIMISTIC_LOCK_RETRIES
        patch_column_tags->>_fetch_entity_if_exists: entity_type, id, fields
        _fetch_entity_if_exists-->>patch_column_tags: instance (fresh)
        patch_column_tags->>_prepare_destination: instance, column_tags, operation
        _prepare_destination->>_column_tag_patch_info: instance → columns ref
        _prepare_destination-->>patch_column_tags: destination (deep copy + updated tags)
        patch_column_tags->>patch: "source=instance, destination=destination, if_match=etag"
        alt 412 Precondition Failed
            patch-->>patch_column_tags: APIError (retry)
        else success
            patch-->>patch_column_tags: patched_entity
            patch_column_tags-->>Caller: patched_entity
        end
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Caller
    participant patch_column_tags
    participant _column_tag_patch_info
    participant _prepare_destination
    participant _fetch_entity_if_exists
    participant patch

    Caller->>patch_column_tags: table / entity (alias)
    patch_column_tags->>_column_tag_patch_info: table → fields
    Note over _column_tag_patch_info: isinstance(Table) → ["tags","columns"]<br/>isinstance(Container) → ["tags","dataModel"]<br/>else → None (unsupported)
    loop MAX_OPTIMISTIC_LOCK_RETRIES
        patch_column_tags->>_fetch_entity_if_exists: entity_type, id, fields
        _fetch_entity_if_exists-->>patch_column_tags: instance (fresh)
        patch_column_tags->>_prepare_destination: instance, column_tags, operation
        _prepare_destination->>_column_tag_patch_info: instance → columns ref
        _prepare_destination-->>patch_column_tags: destination (deep copy + updated tags)
        patch_column_tags->>patch: "source=instance, destination=destination, if_match=etag"
        alt 412 Precondition Failed
            patch-->>patch_column_tags: APIError (retry)
        else success
            patch-->>patch_column_tags: patched_entity
            patch_column_tags-->>Caller: patched_entity
        end
    end
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(ingestion): decouple patch\_mixin fro..."](https://github.com/open-metadata/openmetadata/commit/b03f99ed0e4e8605d416827464724e9926847217) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38452005)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->