### PR TITLE
fix(ingestion): use CustomSecretStr for empty connection password

### DIFF
--- a/ingestion/src/metadata/ingestion/source/database/hive/connection.py
+++ b/ingestion/src/metadata/ingestion/source/database/hive/connection.py
@@ -51,7 +51,7 @@ from metadata.ingestion.connections.connection import BaseConnection
 from metadata.ingestion.connections.test_connections import (
     test_connection_db_schema_sources,
 )
-from metadata.ingestion.models.custom_pydantic import CustomSecretStr
+from metadata.ingestion.models.custom_pydantic import _CustomSecretStr
 from metadata.ingestion.ometa.ometa_api import OpenMetadata
 from metadata.ingestion.source.database.hive.custom_hive_connection import (
     CustomHiveConnection,
@@ -78,7 +78,7 @@ class HiveConnection(BaseConnection[HiveConnectionConfig, Engine]):
         if connection.username and connection.auth and connection.auth.value in ("LDAP", "CUSTOM"):
             url += quote_plus(connection.username)
             if not connection.password:
-                connection.password = CustomSecretStr("")  # pyright: ignore[reportAttributeAccessIssue]
+                connection.password = _CustomSecretStr("")
             url += f":{quote_plus(connection.password.get_secret_value())}"  # pyright: ignore[reportOptionalMemberAccess]
             url += "@"
 

--- a/ingestion/src/metadata/ingestion/source/database/hive/connection.py
+++ b/ingestion/src/metadata/ingestion/source/database/hive/connection.py
@@ -19,7 +19,7 @@ from functools import singledispatch
 from typing import Any, Optional
 from urllib.parse import quote_plus
 
-from pydantic import SecretStr, ValidationError
+from pydantic import ValidationError
 from sqlalchemy.engine import Engine
 
 from metadata.generated.schema.entity.automations.workflow import (
@@ -51,6 +51,7 @@ from metadata.ingestion.connections.connection import BaseConnection
 from metadata.ingestion.connections.test_connections import (
     test_connection_db_schema_sources,
 )
+from metadata.ingestion.models.custom_pydantic import CustomSecretStr
 from metadata.ingestion.ometa.ometa_api import OpenMetadata
 from metadata.ingestion.source.database.hive.custom_hive_connection import (
     CustomHiveConnection,
@@ -77,7 +78,7 @@ class HiveConnection(BaseConnection[HiveConnectionConfig, Engine]):
         if connection.username and connection.auth and connection.auth.value in ("LDAP", "CUSTOM"):
             url += quote_plus(connection.username)
             if not connection.password:
-                connection.password = SecretStr("")  # pyright: ignore[reportAttributeAccessIssue]
+                connection.password = CustomSecretStr("")  # pyright: ignore[reportAttributeAccessIssue]
             url += f":{quote_plus(connection.password.get_secret_value())}"  # pyright: ignore[reportOptionalMemberAccess]
             url += "@"
 

--- a/ingestion/src/metadata/ingestion/source/database/impala/connection.py
+++ b/ingestion/src/metadata/ingestion/source/database/impala/connection.py
@@ -37,7 +37,7 @@ from metadata.ingestion.connections.connection import BaseConnection
 from metadata.ingestion.connections.test_connections import (
     test_connection_db_schema_sources,
 )
-from metadata.ingestion.models.custom_pydantic import CustomSecretStr
+from metadata.ingestion.models.custom_pydantic import _CustomSecretStr
 from metadata.ingestion.ometa.ometa_api import OpenMetadata
 from metadata.utils.constants import THREE_MIN
 
@@ -52,7 +52,7 @@ class ImpalaConnection(BaseConnection[ImpalaConnectionConfig, Engine]):
         if connection.username and connection.authMechanism and connection.authMechanism.value in ("LDAP", "CUSTOM"):
             url += quote_plus(connection.username)
             if not connection.password:
-                connection.password = CustomSecretStr("")  # pyright: ignore[reportAttributeAccessIssue]
+                connection.password = _CustomSecretStr("")
             url += f":{quote_plus(connection.password.get_secret_value())}"  # pyright: ignore[reportOptionalMemberAccess]
             url += "@"
 

--- a/ingestion/src/metadata/ingestion/source/database/impala/connection.py
+++ b/ingestion/src/metadata/ingestion/source/database/impala/connection.py
@@ -16,7 +16,6 @@ Source connection handler
 from typing import Any, Optional
 from urllib.parse import quote_plus
 
-from pydantic import SecretStr
 from sqlalchemy.engine import Engine
 
 from metadata.generated.schema.entity.automations.workflow import (
@@ -38,6 +37,7 @@ from metadata.ingestion.connections.connection import BaseConnection
 from metadata.ingestion.connections.test_connections import (
     test_connection_db_schema_sources,
 )
+from metadata.ingestion.models.custom_pydantic import CustomSecretStr
 from metadata.ingestion.ometa.ometa_api import OpenMetadata
 from metadata.utils.constants import THREE_MIN
 
@@ -52,7 +52,7 @@ class ImpalaConnection(BaseConnection[ImpalaConnectionConfig, Engine]):
         if connection.username and connection.authMechanism and connection.authMechanism.value in ("LDAP", "CUSTOM"):
             url += quote_plus(connection.username)
             if not connection.password:
-                connection.password = SecretStr("")  # pyright: ignore[reportAttributeAccessIssue]
+                connection.password = CustomSecretStr("")  # pyright: ignore[reportAttributeAccessIssue]
             url += f":{quote_plus(connection.password.get_secret_value())}"  # pyright: ignore[reportOptionalMemberAccess]
             url += "@"
 

--- a/ingestion/src/metadata/ingestion/source/database/oracle/connection.py
+++ b/ingestion/src/metadata/ingestion/source/database/oracle/connection.py
@@ -21,7 +21,6 @@ from urllib.parse import quote_plus
 
 import oracledb
 from oracledb.exceptions import DatabaseError
-from pydantic import SecretStr
 from sqlalchemy.engine import Engine
 
 from metadata.generated.schema.entity.automations.workflow import (
@@ -46,6 +45,7 @@ from metadata.ingestion.connections.builders import (
 from metadata.ingestion.connections.connection import BaseConnection
 from metadata.ingestion.connections.secrets import connection_with_options_secrets
 from metadata.ingestion.connections.test_connections import test_connection_db_common
+from metadata.ingestion.models.custom_pydantic import CustomSecretStr
 from metadata.ingestion.ometa.ometa_api import OpenMetadata
 from metadata.ingestion.source.database.oracle.queries import (
     CHECK_ACCESS_TO_ALL,
@@ -164,7 +164,7 @@ class OracleConnection(BaseConnection[OracleConnectionConfig, Engine]):
         if connection.username:
             url += f"{quote_plus(connection.username)}"
             if not connection.password:
-                connection.password = SecretStr("")
+                connection.password = CustomSecretStr("")
             url += f":{quote_plus(connection.password.get_secret_value())}"
             url += "@"
 

--- a/ingestion/src/metadata/ingestion/source/database/oracle/connection.py
+++ b/ingestion/src/metadata/ingestion/source/database/oracle/connection.py
@@ -45,7 +45,7 @@ from metadata.ingestion.connections.builders import (
 from metadata.ingestion.connections.connection import BaseConnection
 from metadata.ingestion.connections.secrets import connection_with_options_secrets
 from metadata.ingestion.connections.test_connections import test_connection_db_common
-from metadata.ingestion.models.custom_pydantic import CustomSecretStr
+from metadata.ingestion.models.custom_pydantic import _CustomSecretStr
 from metadata.ingestion.ometa.ometa_api import OpenMetadata
 from metadata.ingestion.source.database.oracle.queries import (
     CHECK_ACCESS_TO_ALL,
@@ -164,7 +164,7 @@ class OracleConnection(BaseConnection[OracleConnectionConfig, Engine]):
         if connection.username:
             url += f"{quote_plus(connection.username)}"
             if not connection.password:
-                connection.password = CustomSecretStr("")
+                connection.password = _CustomSecretStr("")
             url += f":{quote_plus(connection.password.get_secret_value())}"
             url += "@"
 

--- a/ingestion/src/metadata/ingestion/source/database/snowflake/connection.py
+++ b/ingestion/src/metadata/ingestion/source/database/snowflake/connection.py
@@ -19,7 +19,7 @@ from urllib.parse import quote_plus
 
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import serialization
-from pydantic import BaseModel, SecretStr
+from pydantic import BaseModel
 from sqlalchemy import text
 from sqlalchemy.engine import Engine
 from sqlalchemy.inspection import inspect
@@ -45,6 +45,7 @@ from metadata.ingestion.connections.test_connections import (
     test_connection_steps,
     test_query,
 )
+from metadata.ingestion.models.custom_pydantic import CustomSecretStr
 from metadata.ingestion.ometa.ometa_api import OpenMetadata
 from metadata.ingestion.source.database.snowflake.queries import (
     SNOWFLAKE_ACCESS_HISTORY_PROBE,
@@ -155,7 +156,7 @@ class SnowflakeConnection(BaseConnection[SnowflakeConnectionConfig, Engine]):
         if connection.username:
             url += f"{quote_plus(connection.username)}"
             if not connection.password:
-                connection.password = SecretStr("")
+                connection.password = CustomSecretStr("")
             url += f":{quote_plus(connection.password.get_secret_value())}" if connection else ""
             url += "@"
 

--- a/ingestion/src/metadata/ingestion/source/database/snowflake/connection.py
+++ b/ingestion/src/metadata/ingestion/source/database/snowflake/connection.py
@@ -45,7 +45,7 @@ from metadata.ingestion.connections.test_connections import (
     test_connection_steps,
     test_query,
 )
-from metadata.ingestion.models.custom_pydantic import CustomSecretStr
+from metadata.ingestion.models.custom_pydantic import _CustomSecretStr
 from metadata.ingestion.ometa.ometa_api import OpenMetadata
 from metadata.ingestion.source.database.snowflake.queries import (
     SNOWFLAKE_ACCESS_HISTORY_PROBE,
@@ -156,7 +156,7 @@ class SnowflakeConnection(BaseConnection[SnowflakeConnectionConfig, Engine]):
         if connection.username:
             url += f"{quote_plus(connection.username)}"
             if not connection.password:
-                connection.password = CustomSecretStr("")
+                connection.password = _CustomSecretStr("")
             url += f":{quote_plus(connection.password.get_secret_value())}" if connection else ""
             url += "@"
 


### PR DESCRIPTION
### Describe your changes:

Fixes # <!-- TODO: link the GitHub issue for this bug before merge -->

I worked on the Snowflake/Oracle/Impala/Hive connection builders because passwordless auth (e.g. Snowflake key-pair) crashed ingestion at sink time. When `username` is set but no password is provided, `get_connection_url()` replaced the empty password with a plain pydantic `SecretStr`. The `password` field is typed as `CustomSecretStr` and `self.service_connection` is shared with the `CreateService` request, so the sink later failed serializing it with `TypeError: _SecretBase.get_secret_value() got an unexpected keyword argument 'skip_secret_manager'` (`handle_secret()` passes a kwarg only `CustomSecretStr` accepts). The fix assigns `CustomSecretStr("")` instead, across all four affected connectors.

#
### Type of change:
- [x] Bug fix

#
### High-level design:

N/A — small change.

#
### Tests:

#### Use cases covered
- Snowflake metadata ingestion with key-pair auth (username + privateKey, no password) where the service is created by ingestion (fresh CLI/e2e run) no longer crashes serializing `CreateDatabaseServiceRequest`.
- Same empty-password path for Oracle, Impala and Hive connection URL building.

#### Unit tests
- Existing connector unit tests pass: `test_snowflake.py`, `test_oracle.py`, `test_hive.py` (69 passed).

#### Backend integration tests
- [x] Not applicable (no backend API changes).

#### Ingestion integration tests
- [x] Not applicable (no new connector behavior; type-correctness fix).

#### Playwright (UI) tests
- [x] Not applicable (no UI changes).

#### Manual testing performed
1. Reproduced the original `PydanticSerializationError` / `skip_secret_manager` `TypeError` against a key-pair Snowflake config, then confirmed the fix serializes the `CreateDatabaseServiceRequest` successfully through the real `get_connection_url` path.
2. Verified inside the running `openmetadata_ingestion` container (pre-fix image) that the crash reproduces, and that password-based auth and already-existing services are unaffected.

#
### UI screen recording / screenshots:

Not applicable.

#
### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] For JSON Schema changes: I updated the migration scripts or explained why it is not needed. <!-- no schema changes -->
- [x] For UI changes: I attached a screen recording and/or screenshots above. <!-- no UI changes -->
- [ ] I have added tests (unit / integration / Playwright as applicable) and listed them above.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a `TypeError` crash during ingestion sink serialization for passwordless auth scenarios (e.g., Snowflake key-pair) on four database connectors. When `username` is set but `password` is `None`, `get_connection_url()` was previously assigning a plain pydantic `SecretStr("")` to `connection.password`, but the field is annotated as `CustomSecretStr` whose `WrapSerializer` calls `value.get_secret_value(skip_secret_manager=True)` — a kwarg that only `_CustomSecretStr` accepts.

- **Snowflake / Oracle / Impala / Hive connection builders**: replaces `SecretStr("")` with `_CustomSecretStr("")` so that the stored password value carries the right `get_secret_value` signature and serialization no longer crashes.
- **Import cleanup**: removes the now-unused `from pydantic import SecretStr` in all four files and adds the import of `_CustomSecretStr` from `metadata.ingestion.models.custom_pydantic`.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — all four changed files receive an identical, minimal one-line fix that resolves a well-understood crash on the passwordless-auth path without touching any other behavior.

The change is surgically small: each file swaps a single `SecretStr("")` assignment for `_CustomSecretStr("")`, which is exactly the type the field annotation and downstream serializer expect. A search of the rest of the codebase confirmed no other connector stores a bare `SecretStr` back into a model field, so the fix is complete. Password-bearing auth paths are unaffected because the assignment is guarded by `if not connection.password`.

No files require special attention; all four connectors received the same mechanical change.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| ingestion/src/metadata/ingestion/source/database/snowflake/connection.py | Replaces `SecretStr("")` with `_CustomSecretStr("")` for the empty-password case in key-pair auth; removes the now-unused `SecretStr` import. |
| ingestion/src/metadata/ingestion/source/database/oracle/connection.py | Same one-line fix as Snowflake — swaps `SecretStr("")` for `_CustomSecretStr("")` in the username-without-password branch. |
| ingestion/src/metadata/ingestion/source/database/hive/connection.py | Same fix applied to LDAP/CUSTOM auth branch; `SecretStr` import removed, `_CustomSecretStr` added. |
| ingestion/src/metadata/ingestion/source/database/impala/connection.py | Same fix applied to LDAP/CUSTOM auth branch; `SecretStr` import removed, `_CustomSecretStr` added. |

</details>

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Ingestion
    participant Connector as Snowflake/Oracle/Impala/Hive Connection
    participant CustomPydantic as custom_pydantic
    participant Sink

    Ingestion->>Connector: get_connection_url(connection)
    note over Connector: username set, password is None
    Connector->>CustomPydantic: _CustomSecretStr("")
    CustomPydantic-->>Connector: "instance with get_secret_value(skip_secret_manager=)"
    Connector->>Connector: "connection.password = _CustomSecretStr("")"
    Connector-->>Ingestion: url (built successfully)

    Ingestion->>Sink: serialize CreateDatabaseServiceRequest
    Sink->>CustomPydantic: handle_secret(value, handler, info)
    CustomPydantic->>CustomPydantic: "value.get_secret_value(skip_secret_manager=True)"
    note over CustomPydantic: Works — _CustomSecretStr accepts kwarg. Crashed before — SecretStr did not.
    CustomPydantic-->>Sink: empty string
    Sink-->>Ingestion: serialized request (no crash)
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Ingestion
    participant Connector as Snowflake/Oracle/Impala/Hive Connection
    participant CustomPydantic as custom_pydantic
    participant Sink

    Ingestion->>Connector: get_connection_url(connection)
    note over Connector: username set, password is None
    Connector->>CustomPydantic: _CustomSecretStr("")
    CustomPydantic-->>Connector: "instance with get_secret_value(skip_secret_manager=)"
    Connector->>Connector: "connection.password = _CustomSecretStr("")"
    Connector-->>Ingestion: url (built successfully)

    Ingestion->>Sink: serialize CreateDatabaseServiceRequest
    Sink->>CustomPydantic: handle_secret(value, handler, info)
    CustomPydantic->>CustomPydantic: "value.get_secret_value(skip_secret_manager=True)"
    note over CustomPydantic: Works — _CustomSecretStr accepts kwarg. Crashed before — SecretStr did not.
    CustomPydantic-->>Sink: empty string
    Sink-->>Ingestion: serialized request (no crash)
```

</a>
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(ingestion): call \_CustomSecretStr to..."](https://github.com/open-metadata/openmetadata/commit/908b75e96d902b3eed040e0b8bde620a0cb1d606) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38463750)</sub>

<!-- /greptile_comment -->