### PR TITLE
Fixed the colors for context center

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/ContextCenter/ArchiveView/ArchiveView.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/ContextCenter/ArchiveView/ArchiveView.component.tsx
@@ -64,12 +64,16 @@ const ArchiveRow: FC<ArchiveRowProps> = ({ item, onDelete, onRestore }) => {
       <div
         className={classNames(
           'tw:flex tw:h-8 tw:w-8 tw:shrink-0 tw:items-center tw:justify-center tw:rounded-lg',
-          item.type === 'article' ? 'tw:bg-brand-50' : 'tw:bg-purple-50'
+          item.type === 'article'
+            ? 'tw:bg-utility-brand-50'
+            : 'tw:bg-utility-purple-50'
         )}>
         <Icon
           className={classNames(
             'tw:size-4',
-            item.type === 'article' ? 'tw:text-brand-700' : 'tw:text-purple-500'
+            item.type === 'article'
+              ? 'tw:text-utility-brand-700'
+              : 'tw:text-utility-purple-500'
           )}
         />
       </div>
@@ -78,7 +82,7 @@ const ArchiveRow: FC<ArchiveRowProps> = ({ item, onDelete, onRestore }) => {
         <Typography className="tw:truncate" size="text-sm" weight="medium">
           {item.name}
         </Typography>
-        <Typography className="tw:text-gray-500" size="text-xs">
+        <Typography className="tw:text-quaternary" size="text-xs">
           {item.updatedBy && (
             <>
               {t('label.archived-by', { name: item.updatedBy })}

--- a/openmetadata-ui/src/main/resources/ui/src/components/ContextCenter/ArticleDetailHeader/ArticleDetailHeader.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/ContextCenter/ArticleDetailHeader/ArticleDetailHeader.component.tsx
@@ -347,9 +347,9 @@ const ArticleDetailHeader: FC<ArticleDetailHeaderProps> = ({
         {/* Row 1: title + meta + actions */}
         <div className="tw:flex tw:items-center tw:justify-between tw:mb-6">
           <div className="tw:flex tw:gap-4 tw:items-stretch tw:w-full tw:max-w-[60%] tw:pr-3">
-            <div className="h:full tw:w-auto tw:shrink-0 tw:bg-gray-100 tw:rounded-xl tw:flex tw:items-center tw:p-2">
+            <div className="h:full tw:w-auto tw:shrink-0 tw:bg-tertiary tw:rounded-xl tw:flex tw:items-center tw:p-2">
               <File06
-                className="tw:text-gray-500"
+                className="tw:text-utility-gray-500"
                 height={40}
                 strokeWidth={1.2}
                 style={{ verticalAlign: 'middle', flexShrink: 0 }}
@@ -380,7 +380,9 @@ const ArticleDetailHeader: FC<ArticleDetailHeaderProps> = ({
                   </Tooltip>
                   <Typography
                     className={
-                      firstDomain ? 'tw:text-primary-900' : 'tw:text-gray-400'
+                      firstDomain
+                        ? 'tw:text-primary'
+                        : 'tw:text-utility-gray-400'
                     }
                     data-testid="domain-link"
                     size="text-sm"
@@ -390,7 +392,7 @@ const ArticleDetailHeader: FC<ArticleDetailHeaderProps> = ({
                       : t('label.no-entity', { entity: t('label.domain') })}
                   </Typography>
                   {extraDomains.length > 0 && (
-                    <span className="tw:inline-flex tw:items-center tw:rounded-full tw:bg-gray-100 tw:px-1.5 tw:py-0.5 tw:text-xs tw:font-medium tw:text-tertiary">
+                    <span className="tw:inline-flex tw:items-center tw:rounded-full tw:bg-tertiary tw:px-1.5 tw:py-0.5 tw:text-xs tw:font-medium tw:text-tertiary">
                       +{extraDomains.length}
                     </span>
                   )}
@@ -415,7 +417,7 @@ const ArticleDetailHeader: FC<ArticleDetailHeaderProps> = ({
                 </div>
 
                 {/* Dot separator */}
-                <Dot className="tw:text-gray-400" size="xs" />
+                <Dot className="tw:text-fg-quaternary" size="xs" />
 
                 {/* Owners */}
                 <div className="tw:flex tw:items-center tw:gap-1.5">
@@ -440,7 +442,7 @@ const ArticleDetailHeader: FC<ArticleDetailHeaderProps> = ({
                     </div>
                   ) : (
                     <Typography
-                      className="tw:text-gray-400"
+                      className="tw:text-utility-gray-400"
                       size="text-sm"
                       weight="regular">
                       {t('label.no-entity', { entity: t('label.owner') })}
@@ -473,7 +475,7 @@ const ArticleDetailHeader: FC<ArticleDetailHeaderProps> = ({
                 {/* Editors */}
                 {editors.length > 0 && (
                   <>
-                    <Dot className="tw:text-gray-400" size="xs" />
+                    <Dot className="tw:text-fg-quaternary" size="xs" />
                     <div className="tw:flex tw:items-center tw:gap-1.5">
                       <Tooltip title={t('label.editor')}>
                         <TooltipTrigger className="tw:leading-0">
@@ -530,7 +532,7 @@ const ArticleDetailHeader: FC<ArticleDetailHeaderProps> = ({
                 <ButtonUtility
                   className={
                     voteStatus === QueryVoteType.votedUp
-                      ? 'tw:text-brand-600'
+                      ? 'tw:text-fg-brand-primary'
                       : undefined
                   }
                   color="secondary"
@@ -540,7 +542,7 @@ const ArticleDetailHeader: FC<ArticleDetailHeaderProps> = ({
                     <ThumbsUp
                       className={
                         voteStatus === QueryVoteType.votedUp
-                          ? 'tw:fill-blue-500 tw:stroke-white'
+                          ? 'tw:fill-utility-blue-500 tw:stroke-white'
                           : 'tw:fill-none'
                       }
                       height={18}
@@ -558,7 +560,7 @@ const ArticleDetailHeader: FC<ArticleDetailHeaderProps> = ({
                 <ButtonUtility
                   className={
                     voteStatus === QueryVoteType.votedDown
-                      ? 'tw:text-brand-600'
+                      ? 'tw:text-fg-brand-primary'
                       : undefined
                   }
                   color="secondary"
@@ -568,7 +570,7 @@ const ArticleDetailHeader: FC<ArticleDetailHeaderProps> = ({
                     <ThumbsDown
                       className={
                         voteStatus === QueryVoteType.votedDown
-                          ? 'tw:fill-blue-500 tw:stroke-white'
+                          ? 'tw:fill-utility-blue-500 tw:stroke-white'
                           : 'tw:fill-none'
                       }
                       height={18}
@@ -595,7 +597,9 @@ const ArticleDetailHeader: FC<ArticleDetailHeaderProps> = ({
               title={isFollowing ? t('label.un-follow') : t('label.follow')}>
               <TooltipTrigger>
                 <ButtonUtility
-                  className={isFollowing ? 'tw:text-brand-600' : undefined}
+                  className={
+                    isFollowing ? 'tw:text-fg-brand-primary' : undefined
+                  }
                   color="secondary"
                   data-testid="follow-btn"
                   disabled={isFollowLoading || knowledgePage?.deleted}
@@ -650,11 +654,11 @@ const ArticleDetailHeader: FC<ArticleDetailHeaderProps> = ({
                       <div className="tw:flex tw:items-center tw:gap-2">
                         <Trash01
                           aria-hidden="true"
-                          className="tw:size-4 tw:shrink-0 tw:stroke-[2.25px] tw:text-error-600"
+                          className="tw:size-4 tw:shrink-0 tw:stroke-[2.25px] tw:text-error-primary"
                         />
                         <Typography
                           ellipsis
-                          className="tw:grow tw:text-error-600"
+                          className="tw:grow tw:text-error-primary"
                           size="text-sm"
                           weight="medium">
                           {t('label.delete')}

--- a/openmetadata-ui/src/main/resources/ui/src/components/ContextCenter/ArticleDetailHeader/ArticleDetailHeader.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/ContextCenter/ArticleDetailHeader/ArticleDetailHeader.component.tsx
@@ -349,7 +349,7 @@ const ArticleDetailHeader: FC<ArticleDetailHeaderProps> = ({
           <div className="tw:flex tw:gap-4 tw:items-stretch tw:w-full tw:max-w-[60%] tw:pr-3">
             <div className="h:full tw:w-auto tw:shrink-0 tw:bg-tertiary tw:rounded-xl tw:flex tw:items-center tw:p-2">
               <File06
-                className="tw:text-utility-gray-500"
+                className="tw:text-quaternary"
                 height={40}
                 strokeWidth={1.2}
                 style={{ verticalAlign: 'middle', flexShrink: 0 }}

--- a/openmetadata-ui/src/main/resources/ui/src/components/ContextCenter/ArticleVersionHeader/ArticleVersionHeader.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/ContextCenter/ArticleVersionHeader/ArticleVersionHeader.component.tsx
@@ -79,7 +79,7 @@ const ArticleVersionHeader: FC<ArticleVersionHeaderProps> = ({
         <div className="tw:flex tw:gap-4 tw:items-center">
           <div className="tw:w-auto tw:shrink-0 tw:bg-tertiary tw:rounded-xl tw:flex tw:items-center tw:p-2">
             <File06
-              className="tw:text-utility-gray-500"
+              className="tw:text-quaternary"
               height={40}
               strokeWidth={1.2}
               style={{ verticalAlign: 'middle', flexShrink: 0 }}

--- a/openmetadata-ui/src/main/resources/ui/src/components/ContextCenter/ArticleVersionHeader/ArticleVersionHeader.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/ContextCenter/ArticleVersionHeader/ArticleVersionHeader.component.tsx
@@ -77,9 +77,9 @@ const ArticleVersionHeader: FC<ArticleVersionHeaderProps> = ({
       <Card className="tw:mb-0 tw:p-6" style={cardStyle}>
         {breadcrumbInsideCard && <div className="tw:mb-4">{breadcrumbEl}</div>}
         <div className="tw:flex tw:gap-4 tw:items-center">
-          <div className="tw:w-auto tw:shrink-0 tw:bg-gray-100 tw:rounded-xl tw:flex tw:items-center tw:p-2">
+          <div className="tw:w-auto tw:shrink-0 tw:bg-tertiary tw:rounded-xl tw:flex tw:items-center tw:p-2">
             <File06
-              className="tw:text-gray-500"
+              className="tw:text-utility-gray-500"
               height={40}
               strokeWidth={1.2}
               style={{ verticalAlign: 'middle', flexShrink: 0 }}

--- a/openmetadata-ui/src/main/resources/ui/src/components/ContextCenter/ContextKnowledgePillarCard/ContextKnowledgePillarCard.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/ContextCenter/ContextKnowledgePillarCard/ContextKnowledgePillarCard.component.tsx
@@ -132,7 +132,7 @@ const ContextKnowledgePillarCard: FC<ContextKnowledgePillarCardProps> = ({
 
   return (
     <Card
-      className="tw:cursor-pointer tw:p-5 tw:flex tw:flex-col tw:justify-between tw:transition-[border-color,transform] tw:duration-150 tw:hover:border-blue-200 tw:hover:-translate-y-px"
+      className="tw:cursor-pointer tw:p-5 tw:flex tw:flex-col tw:justify-between tw:transition-[border-color,transform] tw:duration-150 tw:hover:border-utility-blue-200 tw:hover:-translate-y-px"
       data-testid={dataTestId}
       onClick={onClick}>
       <div>

--- a/openmetadata-ui/src/main/resources/ui/src/components/ContextCenter/CreateFolderModal/CreateFolderModal.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/ContextCenter/CreateFolderModal/CreateFolderModal.component.tsx
@@ -79,7 +79,7 @@ const CreateFolderModal: FC<CreateFolderModalProps> = ({
           <Dialog.Content className="tw:flex tw:flex-col tw:gap-4 tw:pb-6">
             <div className="tw:bg-brand-primary tw:p-2 tw:mb-2 tw:w-max tw:leading-0 tw:rounded-xl">
               <FolderPlus
-                className="tw:text-brand-700"
+                className="tw:text-fg-brand-primary"
                 height={32}
                 width={32}
               />

--- a/openmetadata-ui/src/main/resources/ui/src/components/ContextCenter/CreateMemoryModal/CreateMemoryModal.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/ContextCenter/CreateMemoryModal/CreateMemoryModal.component.tsx
@@ -116,7 +116,7 @@ const LinkedAssetCard: FC<{
       <div className="tw:shrink-0">
         {searchClassBase.getEntityIcon(
           asset.reference?.type ?? '',
-          'tw:w-8 tw:h-8 tw:text-utility-gray-500'
+          'tw:w-8 tw:h-8 tw:text-quaternary'
         )}
       </div>
       <div className="tw:flex tw:flex-1 tw:justify-between tw:items-center tw:min-w-0">
@@ -544,7 +544,7 @@ const CreateMemoryModal: FC<CreateMemoryModalProps> = ({
                       memoryToEdit?.updatedBy) && (
                       <div className="tw:flex tw:items-center tw:gap-1">
                         <Typography
-                          className="tw:text-utility-gray-500"
+                          className="tw:text-quaternary"
                           size="text-xs">
                           {t('label.created-by')}
                         </Typography>
@@ -558,7 +558,7 @@ const CreateMemoryModal: FC<CreateMemoryModalProps> = ({
                           &middot;
                         </span>
                         <Typography
-                          className="tw:text-utility-gray-500"
+                          className="tw:text-quaternary"
                           size="text-xs">
                           {formatDate(memoryToEdit.updatedAt)}
                         </Typography>
@@ -572,7 +572,7 @@ const CreateMemoryModal: FC<CreateMemoryModalProps> = ({
                           strokeWidth={2}
                         />
                         <Typography
-                          className="tw:text-utility-gray-500"
+                          className="tw:text-quaternary"
                           size="text-xs">
                           {t('label.extracted-from')}
                         </Typography>
@@ -773,7 +773,7 @@ const CreateMemoryModal: FC<CreateMemoryModalProps> = ({
                       <div className="tw:flex tw:items-start tw:gap-3 tw:px-4 tw:py-3">
                         <div className="tw:basis-[30%] tw:shrink-0">
                           <Typography
-                            className="tw:text-utility-gray-500 tw:w-28 tw:shrink-0"
+                            className="tw:text-quaternary tw:w-28 tw:shrink-0"
                             size="text-sm">
                             {t('label.visibility')}
                           </Typography>
@@ -825,7 +825,7 @@ const CreateMemoryModal: FC<CreateMemoryModalProps> = ({
                               </Badge>
                               {visibilityOption && (
                                 <Typography
-                                  className="tw:text-utility-gray-500"
+                                  className="tw:text-quaternary"
                                   size="text-xs">
                                   {t(visibilityOption.descriptionKey)}
                                 </Typography>
@@ -847,7 +847,7 @@ const CreateMemoryModal: FC<CreateMemoryModalProps> = ({
                         <div className="tw:flex tw:items-center tw:gap-3">
                           <div className="tw:basis-[30%]">
                             <Typography
-                              className="tw:text-utility-gray-500 tw:w-28 tw:shrink-0"
+                              className="tw:text-quaternary tw:w-28 tw:shrink-0"
                               size="text-sm">
                               {t('label.tag-plural')}
                             </Typography>
@@ -940,7 +940,7 @@ const CreateMemoryModal: FC<CreateMemoryModalProps> = ({
                         <div className="tw:flex tw:items-center tw:gap-3 tw:px-4 tw:py-3">
                           <div className="tw:basis-[30%]">
                             <Typography
-                              className="tw:text-utility-gray-500 tw:w-28 tw:shrink-0"
+                              className="tw:text-quaternary tw:w-28 tw:shrink-0"
                               size="text-sm">
                               {t('label.updated')}
                             </Typography>

--- a/openmetadata-ui/src/main/resources/ui/src/components/ContextCenter/CreateMemoryModal/CreateMemoryModal.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/ContextCenter/CreateMemoryModal/CreateMemoryModal.component.tsx
@@ -116,7 +116,7 @@ const LinkedAssetCard: FC<{
       <div className="tw:shrink-0">
         {searchClassBase.getEntityIcon(
           asset.reference?.type ?? '',
-          'tw:w-8 tw:h-8 tw:text-gray-500'
+          'tw:w-8 tw:h-8 tw:text-utility-gray-500'
         )}
       </div>
       <div className="tw:flex tw:flex-1 tw:justify-between tw:items-center tw:min-w-0">
@@ -124,7 +124,10 @@ const LinkedAssetCard: FC<{
           <Typography ellipsis size="text-sm" weight="medium">
             {displayName}
           </Typography>
-          <Typography ellipsis className="tw:text-gray-400" size="text-xs">
+          <Typography
+            ellipsis
+            className="tw:text-utility-gray-400"
+            size="text-xs">
             {asset.reference?.fullyQualifiedName ?? ''}
           </Typography>
         </div>
@@ -155,8 +158,8 @@ const EmptyLinkedAssets: FC = () => {
   const { t } = useTranslation();
 
   return (
-    <div className="tw:p-3 tw:border-dashed tw:border tw:rounded-lg tw:border-gray-300 tw:flex tw:justify-center tw:items-center">
-      <Typography className="tw:text-gray-400" size="text-sm">
+    <div className="tw:p-3 tw:border-dashed tw:border tw:rounded-lg tw:border-primary tw:flex tw:justify-center tw:items-center">
+      <Typography className="tw:text-utility-gray-400" size="text-sm">
         {t('label.not-linked-to-any-data-asset')}
       </Typography>
     </div>
@@ -473,7 +476,7 @@ const CreateMemoryModal: FC<CreateMemoryModalProps> = ({
   const renderMemoryContent = () => {
     if (isViewOnly) {
       return (
-        <div className="prose tw:p-3 tw:rounded-lg tw:border tw:border-gray-200 tw:bg-gray-50 tw:h-36 tw:overflow-y-auto tw:resize-y">
+        <div className="prose tw:p-3 tw:rounded-lg tw:border tw:border-secondary tw:bg-secondary tw:h-36 tw:overflow-y-auto tw:resize-y">
           <ReactMarkdown components={getCustomMarkdownComponents()}>
             {preprocessMarkdownText(memory)}
           </ReactMarkdown>
@@ -493,13 +496,13 @@ const CreateMemoryModal: FC<CreateMemoryModalProps> = ({
     }
 
     return (
-      <div className="prose tw:p-3 tw:rounded-lg tw:border tw:border-gray-200 tw:bg-gray-100 tw:text-secondary tw:h-36 tw:overflow-y-auto tw:resize-y">
+      <div className="prose tw:p-3 tw:rounded-lg tw:border tw:border-secondary tw:bg-tertiary tw:text-secondary tw:h-36 tw:overflow-y-auto tw:resize-y">
         {memory.trim() ? (
           <ReactMarkdown components={getCustomMarkdownComponents()}>
             {preprocessMarkdownText(memory)}
           </ReactMarkdown>
         ) : (
-          <Typography className="tw:text-gray-400" size="text-sm">
+          <Typography className="tw:text-utility-gray-400" size="text-sm">
             {t('message.nothing-to-preview')}
           </Typography>
         )}
@@ -524,9 +527,9 @@ const CreateMemoryModal: FC<CreateMemoryModalProps> = ({
                 }>
                 {/* Sticky header */}
                 <div className="tw:flex tw:items-center tw:gap-3 tw:pt-5 tw:pb-4 tw:shrink-0 tw:px-6">
-                  <div className="tw:flex tw:items-center tw:justify-center tw:w-10 tw:h-10 tw:rounded-lg tw:bg-blue-50 tw:border tw:border-indigo-100 tw:shrink-0">
+                  <div className="tw:flex tw:items-center tw:justify-center tw:w-10 tw:h-10 tw:rounded-lg tw:bg-utility-brand-50 tw:border tw:border-utility-indigo-100 tw:shrink-0">
                     <Lightbulb03
-                      className="tw:text-brand-700"
+                      className="tw:text-utility-brand-700"
                       size={20}
                       strokeWidth={1.5}
                     />
@@ -540,7 +543,9 @@ const CreateMemoryModal: FC<CreateMemoryModalProps> = ({
                     {(memoryToEdit?.owners?.[0]?.name ??
                       memoryToEdit?.updatedBy) && (
                       <div className="tw:flex tw:items-center tw:gap-1">
-                        <Typography className="tw:text-gray-500" size="text-xs">
+                        <Typography
+                          className="tw:text-utility-gray-500"
+                          size="text-xs">
                           {t('label.created-by')}
                         </Typography>
                         <UserPopOverCard
@@ -549,10 +554,12 @@ const CreateMemoryModal: FC<CreateMemoryModalProps> = ({
                           profileWidth={16}
                           userName={memoryToEdit?.owners?.[0]?.name || ''}
                         />
-                        <span className="tw:text-gray-400 tw:leading-none tw:select-none tw:text-xl">
+                        <span className="tw:text-utility-gray-400 tw:leading-none tw:select-none tw:text-xl">
                           &middot;
                         </span>
-                        <Typography className="tw:text-gray-500" size="text-xs">
+                        <Typography
+                          className="tw:text-utility-gray-500"
+                          size="text-xs">
                           {formatDate(memoryToEdit.updatedAt)}
                         </Typography>
                       </div>
@@ -560,15 +567,17 @@ const CreateMemoryModal: FC<CreateMemoryModalProps> = ({
                     {memorySource && memorySourceLink && (
                       <div className="tw:flex tw:items-center tw:gap-1">
                         <FileLock02
-                          className="tw:shrink-0 tw:text-gray-400"
+                          className="tw:shrink-0 tw:text-utility-gray-400"
                           size={12}
                           strokeWidth={2}
                         />
-                        <Typography className="tw:text-gray-500" size="text-xs">
+                        <Typography
+                          className="tw:text-utility-gray-500"
+                          size="text-xs">
                           {t('label.extracted-from')}
                         </Typography>
                         <Link
-                          className="tw:text-xs tw:font-medium tw:text-brand-600 tw:hover:underline tw:truncate"
+                          className="tw:text-xs tw:font-medium tw:text-brand-secondary tw:hover:underline tw:truncate"
                           data-testid="memory-source-file-link"
                           to={memorySourceLink}>
                           {getEntityName(memorySource)}
@@ -652,7 +661,7 @@ const CreateMemoryModal: FC<CreateMemoryModalProps> = ({
                           title={t('message.what-should-ask-collate-remember')}>
                           <TooltipTrigger className="tw:leading-0">
                             <InfoCircle
-                              className="tw:text-gray-400 tw:cursor-pointer"
+                              className="tw:text-utility-gray-400 tw:cursor-pointer"
                               size={14}
                               strokeWidth={2}
                             />
@@ -759,12 +768,12 @@ const CreateMemoryModal: FC<CreateMemoryModalProps> = ({
                       weight="semibold">
                       {t('label.metadata')}
                     </Typography>
-                    <Card className="tw:flex tw:flex-col tw:divide-y tw:divide-gray-100 tw:mt-2">
+                    <Card className="tw:flex tw:flex-col tw:divide-y tw:divide-tertiary tw:mt-2">
                       {/* Visibility row */}
                       <div className="tw:flex tw:items-start tw:gap-3 tw:px-4 tw:py-3">
                         <div className="tw:basis-[30%] tw:shrink-0">
                           <Typography
-                            className="tw:text-gray-500 tw:w-28 tw:shrink-0"
+                            className="tw:text-utility-gray-500 tw:w-28 tw:shrink-0"
                             size="text-sm">
                             {t('label.visibility')}
                           </Typography>
@@ -816,7 +825,7 @@ const CreateMemoryModal: FC<CreateMemoryModalProps> = ({
                               </Badge>
                               {visibilityOption && (
                                 <Typography
-                                  className="tw:text-gray-500"
+                                  className="tw:text-utility-gray-500"
                                   size="text-xs">
                                   {t(visibilityOption.descriptionKey)}
                                 </Typography>
@@ -838,7 +847,7 @@ const CreateMemoryModal: FC<CreateMemoryModalProps> = ({
                         <div className="tw:flex tw:items-center tw:gap-3">
                           <div className="tw:basis-[30%]">
                             <Typography
-                              className="tw:text-gray-500 tw:w-28 tw:shrink-0"
+                              className="tw:text-utility-gray-500 tw:w-28 tw:shrink-0"
                               size="text-sm">
                               {t('label.tag-plural')}
                             </Typography>
@@ -931,7 +940,7 @@ const CreateMemoryModal: FC<CreateMemoryModalProps> = ({
                         <div className="tw:flex tw:items-center tw:gap-3 tw:px-4 tw:py-3">
                           <div className="tw:basis-[30%]">
                             <Typography
-                              className="tw:text-gray-500 tw:w-28 tw:shrink-0"
+                              className="tw:text-utility-gray-500 tw:w-28 tw:shrink-0"
                               size="text-sm">
                               {t('label.updated')}
                             </Typography>
@@ -952,7 +961,7 @@ const CreateMemoryModal: FC<CreateMemoryModalProps> = ({
                               key={key}>
                               <div className="tw:basis-[30%]">
                                 <Typography
-                                  className="tw:text-gray-500 tw:w-28 tw:shrink-0"
+                                  className="tw:text-quaternary tw:w-28 tw:shrink-0"
                                   size="text-sm">
                                   {label}
                                 </Typography>
@@ -967,8 +976,8 @@ const CreateMemoryModal: FC<CreateMemoryModalProps> = ({
                   )}
                 </div>
 
-                {/* Footer */}
-                <div className="tw:flex tw:items-center tw:justify-between tw:gap-3 tw:py-4 tw:border-t tw:border-gray-100 tw:shrink-0 tw:px-6">
+                {/* Sticky footer */}
+                <div className="tw:flex tw:items-center tw:justify-between tw:gap-3 tw:py-4 tw:border-t tw:border-tertiary tw:shrink-0 tw:px-6">
                   <div>
                     {(isEditMode || (isViewOnly && canDelete)) && (
                       <Button

--- a/openmetadata-ui/src/main/resources/ui/src/components/ContextCenter/DocumentsView/DocumentFolderView.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/ContextCenter/DocumentsView/DocumentFolderView.component.tsx
@@ -176,7 +176,7 @@ const DocumentFolderView = ({
                             handleFolderItemSelect(folder.id);
                           }}>
                           <FolderIcon
-                            className="tw:shrink-0 tw:text-utility-gray-500"
+                            className="tw:shrink-0 tw:text-quaternary"
                             height={16}
                             width={16}
                           />

--- a/openmetadata-ui/src/main/resources/ui/src/components/ContextCenter/DocumentsView/DocumentFolderView.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/ContextCenter/DocumentsView/DocumentFolderView.component.tsx
@@ -117,7 +117,7 @@ const DocumentFolderView = ({
                 {t('label.folder')}
               </Typography>
               <Typography
-                className="tw:text-gray-500 tw:flex tw:items-center tw:gap-2"
+                className="tw:text-quaternary tw:flex tw:items-center tw:gap-2"
                 size="text-xs">
                 <span>
                   {folders.length} {t('label.folder-plural')}
@@ -161,7 +161,9 @@ const DocumentFolderView = ({
 
                 return (
                   <Tree.Item
-                    className={isSelected ? 'tw:bg-blue-50 tw:rounded-lg' : ''}
+                    className={
+                      isSelected ? 'tw:bg-utility-blue-50 tw:rounded-lg' : ''
+                    }
                     id={folder.id}
                     key={folder.id}
                     textValue={folder.displayName ?? folder.name}>
@@ -174,7 +176,7 @@ const DocumentFolderView = ({
                             handleFolderItemSelect(folder.id);
                           }}>
                           <FolderIcon
-                            className="tw:shrink-0 tw:text-gray-500"
+                            className="tw:shrink-0 tw:text-utility-gray-500"
                             height={16}
                             width={16}
                           />

--- a/openmetadata-ui/src/main/resources/ui/src/components/ContextCenter/DocumentsView/DocumentPreviewPanel.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/ContextCenter/DocumentsView/DocumentPreviewPanel.component.tsx
@@ -33,7 +33,7 @@ import {
 
 const MetaRow: FC<MetaRowProps> = ({ label, value }) => (
   <Box align="center" className="tw:py-1.5" justify="between">
-    <Typography className="tw:text-gray-500" size="text-sm">
+    <Typography className="tw:text-quaternary" size="text-sm">
       {label}
     </Typography>
     <Typography className="tw:text-primary" size="text-sm" weight="medium">
@@ -70,7 +70,7 @@ const DocumentPreviewPanel: FC<DocumentPreviewPanelProps> = ({
         <Card className="tw:p-4 tw:shrink-0">
           <Box align="center" className="tw:mb-3" justify="between">
             <Typography
-              className="tw:text-gray-500 tw:uppercase"
+              className="tw:text-quaternary tw:uppercase"
               size="text-xs"
               weight="semibold">
               {t('label.detail-plural')}
@@ -90,7 +90,7 @@ const DocumentPreviewPanel: FC<DocumentPreviewPanelProps> = ({
             </Box>
           </Box>
           <Box align="center" className="tw:py-1.5" justify="between">
-            <Typography className="tw:text-gray-500" size="text-sm">
+            <Typography className="tw:text-quaternary" size="text-sm">
               {t('label.status')}
             </Typography>
             <DocumentStatusBadge
@@ -114,11 +114,11 @@ const DocumentPreviewPanel: FC<DocumentPreviewPanelProps> = ({
           )}
           {file.processingError && (
             <Box className="tw:py-1.5" direction="col" gap={1}>
-              <Typography className="tw:text-gray-500" size="text-sm">
+              <Typography className="tw:text-quaternary" size="text-sm">
                 {t('label.error')}
               </Typography>
               <Typography
-                className="tw:text-error-600 tw:break-words"
+                className="tw:text-error-primary tw:break-words"
                 data-testid="processing-error"
                 size="text-sm">
                 {file.processingError}

--- a/openmetadata-ui/src/main/resources/ui/src/components/ContextCenter/DocumentsView/DocumentsView.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/ContextCenter/DocumentsView/DocumentsView.component.tsx
@@ -65,7 +65,7 @@ const FolderPickerMenu: FC<FolderPickerMenuProps> = ({ folders, onPick }) => {
 
   if (folders.length === 0) {
     return (
-      <Typography as="p" className="tw:px-3 tw:py-2 tw:text-gray-400">
+      <Typography as="p" className="tw:px-3 tw:py-2 tw:text-utility-gray-400">
         {t('label.no-entity', { entity: t('label.folder-plural') })}
       </Typography>
     );
@@ -171,11 +171,11 @@ const FileActions: FC<FileActionsProps> = ({
               <Box align="center" gap={2}>
                 <Trash01
                   aria-hidden="true"
-                  className="tw:size-4 tw:shrink-0 tw:stroke-[2.25px] tw:text-error-600"
+                  className="tw:size-4 tw:shrink-0 tw:stroke-[2.25px] tw:text-error-primary"
                 />
                 <Typography
                   ellipsis
-                  className="tw:grow tw:text-error-600"
+                  className="tw:grow tw:text-error-primary"
                   size="text-sm"
                   weight="medium">
                   {t('label.delete')}
@@ -243,10 +243,10 @@ const ListHeader: FC<ListHeaderProps> = ({
     return (
       <Box
         align="center"
-        className="tw:px-4 tw:h-12 tw:shrink-0 tw:border-b tw:border-blue-100 tw:bg-blue-50"
+        className="tw:px-4 tw:h-12 tw:shrink-0 tw:border-b tw:border-utility-blue-100 tw:bg-utility-blue-50"
         gap={2}>
         <Typography
-          className="tw:text-blue-700"
+          className="tw:text-utility-blue-700"
           size="text-sm"
           weight="semibold">
           {selectedCount} {t('label.selected-lowercase')}
@@ -307,11 +307,17 @@ const ListHeader: FC<ListHeaderProps> = ({
     <Box
       align="center"
       className="tw:px-4 tw:h-12 tw:shrink-0 tw:border-b tw:border-secondary tw:bg-primary">
-      <Typography className="tw:text-gray-500" size="text-xs" weight="semibold">
+      <Typography
+        className="tw:text-quaternary"
+        size="text-xs"
+        weight="semibold">
         {count} {t('label.file-plural').toLowerCase()}
       </Typography>
       <span className="tw:flex-1" />
-      <Typography className="tw:text-gray-500" size="text-xs" weight="semibold">
+      <Typography
+        className="tw:text-quaternary"
+        size="text-xs"
+        weight="semibold">
         {t('label.sorted-by-recently-uploaded')}
       </Typography>
     </Box>
@@ -356,7 +362,9 @@ const FileRow: FC<FileRowProps> = ({
     <Box
       align="center"
       className={`tw:relative tw:px-4 tw:py-3 tw:border-b tw:border-secondary tw:cursor-pointer tw:transition-colors tw:duration-100 ${
-        isActive ? 'tw:bg-blue-50' : 'tw:bg-primary hover:tw:bg-gray-25'
+        isActive
+          ? 'tw:bg-utility-blue-50'
+          : 'tw:bg-primary hover:tw:bg-secondary_subtle'
       }`}
       data-testid={`document-row-${file.id}`}
       gap={4}
@@ -399,16 +407,16 @@ const FileRow: FC<FileRowProps> = ({
         </Box>
         <Box align="center" gap={2}>
           <Typography
-            className="tw:text-gray-500"
+            className="tw:text-quaternary"
             data-testid="document-size"
             size="text-xs">
             {formattedFileSize}
           </Typography>
           {Boolean(file.memoryCount) && (
             <>
-              <Dot className="tw:text-gray-500" size="micro" />
+              <Dot className="tw:text-quaternary" size="micro" />
               <Typography
-                className="tw:text-gray-500"
+                className="tw:text-quaternary"
                 data-testid="document-memory-count"
                 size="text-xs">
                 {file.memoryCount} {t('label.memory-plural').toLowerCase()}
@@ -417,9 +425,9 @@ const FileRow: FC<FileRowProps> = ({
           )}
           {file.updatedBy && (
             <>
-              <Dot className="tw:text-gray-500" size="micro" />
+              <Dot className="tw:text-quaternary" size="micro" />
               <Typography
-                className="tw:text-gray-500"
+                className="tw:text-quaternary"
                 data-testid="document-updated-by"
                 size="text-xs">
                 {file.updatedBy}
@@ -428,9 +436,9 @@ const FileRow: FC<FileRowProps> = ({
           )}
           {file.updatedAt && (
             <>
-              <Dot className="tw:text-gray-500" size="micro" />
+              <Dot className="tw:text-quaternary" size="micro" />
               <Typography
-                className="tw:text-gray-500"
+                className="tw:text-quaternary"
                 data-testid="document-updated-at"
                 size="text-xs">
                 {relativeTime}
@@ -439,9 +447,9 @@ const FileRow: FC<FileRowProps> = ({
           )}
           {folderName && (
             <>
-              <Dot className="tw:text-gray-500" size="micro" />
+              <Dot className="tw:text-quaternary" size="micro" />
               <Typography
-                className="tw:text-gray-500"
+                className="tw:text-quaternary"
                 data-testid="document-folder-name"
                 size="text-xs">
                 {folderName}
@@ -462,7 +470,7 @@ const FileRow: FC<FileRowProps> = ({
               data-testid="download-btn"
               icon={
                 <Download01
-                  className="tw:text-gray-500"
+                  className="tw:text-quaternary"
                   height={16}
                   width={16}
                 />

--- a/openmetadata-ui/src/main/resources/ui/src/components/ContextCenter/ExtractedMemoriesCard/ExtractedMemoriesCard.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/ContextCenter/ExtractedMemoriesCard/ExtractedMemoriesCard.component.tsx
@@ -87,7 +87,7 @@ const ExtractedMemoriesCard: FC<ExtractedMemoriesCardProps> = ({
     <Card className="tw:p-4 tw:shrink-0" data-testid="extracted-memories-card">
       <div className="tw:mb-3">
         <Typography
-          className="tw:text-gray-500 tw:uppercase"
+          className="tw:text-quaternary tw:uppercase"
           size="text-xs"
           weight="semibold">
           {t('label.memory-plural')}
@@ -100,14 +100,14 @@ const ExtractedMemoriesCard: FC<ExtractedMemoriesCardProps> = ({
           <Skeleton height="14px" variant="rounded" width="60%" />
         </Box>
       ) : memories.length === 0 ? (
-        <Typography className="tw:text-gray-400" size="text-sm">
+        <Typography className="tw:text-utility-gray-400" size="text-sm">
           {t('label.no-entity', { entity: t('label.memory-plural') })}
         </Typography>
       ) : (
         <Box direction="col">
           {memories.map((memory) => (
             <Box
-              className="tw:py-1.5 tw:-mx-2 tw:px-2 tw:rounded-md tw:cursor-pointer hover:tw:bg-gray-50"
+              className="tw:py-1.5 tw:-mx-2 tw:px-2 tw:rounded-md tw:cursor-pointer hover:tw:bg-secondary"
               data-testid={`extracted-memory-${memory.id}`}
               direction="col"
               key={memory.id}
@@ -121,7 +121,7 @@ const ExtractedMemoriesCard: FC<ExtractedMemoriesCardProps> = ({
               }}>
               <Typography
                 ellipsis
-                className="tw:text-gray-900"
+                className="tw:text-primary"
                 size="text-sm"
                 weight="medium">
                 {memory.title ?? getEntityName(memory)}
@@ -129,7 +129,7 @@ const ExtractedMemoriesCard: FC<ExtractedMemoriesCardProps> = ({
               {memory.question && (
                 <Typography
                   ellipsis
-                  className="tw:text-gray-500"
+                  className="tw:text-utility-gray-400"
                   size="text-xs">
                   {memory.question}
                 </Typography>

--- a/openmetadata-ui/src/main/resources/ui/src/components/ContextCenter/ExtractedMemoriesCard/ExtractedMemoriesCard.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/ContextCenter/ExtractedMemoriesCard/ExtractedMemoriesCard.component.tsx
@@ -129,7 +129,7 @@ const ExtractedMemoriesCard: FC<ExtractedMemoriesCardProps> = ({
               {memory.question && (
                 <Typography
                   ellipsis
-                  className="tw:text-utility-gray-400"
+                  className="tw:text-quaternary"
                   size="text-xs">
                   {memory.question}
                 </Typography>

--- a/openmetadata-ui/src/main/resources/ui/src/components/ContextCenter/MemoriesView/MemoriesView.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/ContextCenter/MemoriesView/MemoriesView.component.tsx
@@ -59,11 +59,11 @@ const MemoryActions: FC<MemoryActionsProps> = ({ memory, onDeleteMemory }) => {
             <Box align="center" gap={2}>
               <Trash01
                 aria-hidden="true"
-                className="tw:size-4 tw:shrink-0 tw:stroke-[2.25px] tw:text-error-600"
+                className="tw:size-4 tw:shrink-0 tw:stroke-[2.25px] tw:text-error-primary"
               />
               <Typography
                 ellipsis
-                className="tw:grow tw:text-error-600"
+                className="tw:grow tw:text-error-primary"
                 size="text-sm"
                 weight="medium">
                 {t('label.delete')}
@@ -90,7 +90,7 @@ const PinButton: FC<PinButtonProps> = ({ pinned, animKey, onClick }) => {
       <TooltipTrigger>
         <ButtonUtility
           className={classNames('tw:transition-colors tw:duration-150', {
-            'tw:bg-blue-50 tw:text-brand-600': pinned,
+            'tw:bg-utility-blue-50 tw:text-fg-brand-primary': pinned,
           })}
           color="tertiary"
           icon={
@@ -173,7 +173,7 @@ const MemoryRow: FC<MemoryRowProps> = ({
         pinned
           ? {
               background:
-                'linear-gradient(180deg, color-mix(in srgb, var(--tw-color-brand-50) 80%, transparent) 0%, transparent 60%)',
+                'linear-gradient(180deg, color-mix(in srgb, var(--tw-color-utility-brand-50) 80%, transparent) 0%, transparent 60%)',
             }
           : undefined
       }
@@ -181,13 +181,13 @@ const MemoryRow: FC<MemoryRowProps> = ({
       {pinned && (
         <Box
           align="start"
-          className="tw:pointer-events-none tw:absolute tw:top-0 tw:right-0 tw:text-brand-600"
+          className="tw:pointer-events-none tw:absolute tw:top-0 tw:right-0 tw:text-fg-brand-primary"
           justify="end"
           style={{
             width: 28,
             height: 28,
             background:
-              'linear-gradient(225deg, color-mix(in srgb, var(--tw-color-brand-100) 80%, transparent) 0%, transparent 70%)',
+              'linear-gradient(225deg, color-mix(in srgb, var(--tw-color-utility-brand-100) 80%, transparent) 0%, transparent 70%)',
             borderBottomLeftRadius: 12,
             padding: '5px 7px 0 0',
           }}>
@@ -220,10 +220,10 @@ const MemoryRow: FC<MemoryRowProps> = ({
             )}
             {memory.updatedAt !== undefined && (
               <>
-                <span className="tw:text-gray-400 tw:leading-none tw:select-none tw:text-xs">
+                <span className="tw:text-utility-gray-400 tw:leading-none tw:select-none tw:text-xs">
                   &middot;
                 </span>
-                <Typography className="tw:text-gray-500" size="text-xs">
+                <Typography className="tw:text-quaternary" size="text-xs">
                   {getShortRelativeTime(memory.updatedAt)}
                 </Typography>
               </>
@@ -270,9 +270,13 @@ const MemoryRow: FC<MemoryRowProps> = ({
           {(memory.usageCount !== undefined ||
             memory.lastUsedAt !== undefined) && (
             <Box align="center" className="tw:mt-1" gap={1}>
-              <Clock className="tw:text-gray-500" size={12} strokeWidth={1.5} />
+              <Clock
+                className="tw:text-utility-gray-500"
+                size={12}
+                strokeWidth={1.5}
+              />
               <Typography
-                className="tw:text-gray-500 tw:whitespace-nowrap"
+                className="tw:text-quaternary tw:whitespace-nowrap"
                 size="text-xs">
                 {memory.usageCount === undefined
                   ? ''
@@ -358,7 +362,7 @@ const MemoriesView: FC<MemoriesViewProps> = ({
             entity: t('label.memory-plural'),
           })}
         </Typography>
-        <Typography className="tw:text-gray-500" size="text-sm">
+        <Typography className="tw:text-quaternary" size="text-sm">
           {t('message.try-a-different-filter-or-search')}
         </Typography>
       </Box>

--- a/openmetadata-ui/src/main/resources/ui/src/components/KnowledgeCenter/KnowledgeCard/KnowledgeCard.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/KnowledgeCenter/KnowledgeCard/KnowledgeCard.tsx
@@ -290,7 +290,7 @@ const KnowledgeCard: FC<KnowledgeCardProps> = ({
               ellipsis
               className={
                 firstDomain
-                  ? 'tw:text-utility-gray-500'
+                  ? 'tw:text-quaternary'
                   : 'tw:text-utility-gray-400'
               }
               data-testid="domain-name"

--- a/openmetadata-ui/src/main/resources/ui/src/components/KnowledgeCenter/KnowledgeCard/KnowledgeCard.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/KnowledgeCenter/KnowledgeCard/KnowledgeCard.tsx
@@ -213,7 +213,7 @@ const KnowledgeCard: FC<KnowledgeCardProps> = ({
 
   return (
     <Card
-      className="tw:flex tw:flex-col tw:cursor-pointer tw:transition-[border-color,transform] tw:duration-150 tw:hover:border-blue-200 tw:hover:-translate-y-px"
+      className="tw:flex tw:flex-col tw:cursor-pointer tw:transition-[border-color,transform] tw:duration-150 tw:hover:border-utility-blue-200 tw:hover:-translate-y-px"
       data-testid={`knowledge-card-${displayName || name}`}>
       <Link
         className="tw:flex tw:flex-col tw:gap-2.5 tw:px-5 tw:py-4.5"
@@ -234,7 +234,7 @@ const KnowledgeCard: FC<KnowledgeCardProps> = ({
             {isQuickLink && !readonly && quickLinkActions}
           </Box>
           <Typography
-            className="tw:text-gray-500"
+            className="tw:text-quaternary"
             data-testid="updated-at"
             size="text-xs">
             {t('label.last-edited-time', {
@@ -253,7 +253,7 @@ const KnowledgeCard: FC<KnowledgeCardProps> = ({
           </Typography>
         ) : (
           <Typography
-            className="tw:text-gray-400"
+            className="tw:text-utility-gray-400"
             data-testid="no-description"
             size="text-sm">
             {t('label.no-description')}
@@ -276,7 +276,7 @@ const KnowledgeCard: FC<KnowledgeCardProps> = ({
             />
           ) : (
             <Typography
-              className="tw:text-gray-400"
+              className="tw:text-utility-gray-400"
               data-testid="owner-name"
               size="text-xs"
               weight="medium">
@@ -284,11 +284,15 @@ const KnowledgeCard: FC<KnowledgeCardProps> = ({
             </Typography>
           )}
 
-          <Dot className="tw:text-gray-400" size="micro" />
+          <Dot className="tw:text-fg-quaternary" size="micro" />
           <div className="tw:max-w-40">
             <Typography
               ellipsis
-              className={firstDomain ? 'tw:text-gray-500' : 'tw:text-gray-400'}
+              className={
+                firstDomain
+                  ? 'tw:text-utility-gray-500'
+                  : 'tw:text-utility-gray-400'
+              }
               data-testid="domain-name"
               size="text-xs">
               {firstDomain?.displayName ??

--- a/openmetadata-ui/src/main/resources/ui/src/components/KnowledgeCenter/KnowledgeCard/KnowledgeCard.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/KnowledgeCenter/KnowledgeCard/KnowledgeCard.tsx
@@ -289,9 +289,7 @@ const KnowledgeCard: FC<KnowledgeCardProps> = ({
             <Typography
               ellipsis
               className={
-                firstDomain
-                  ? 'tw:text-quaternary'
-                  : 'tw:text-utility-gray-400'
+                firstDomain ? 'tw:text-quaternary' : 'tw:text-utility-gray-400'
               }
               data-testid="domain-name"
               size="text-xs">

--- a/openmetadata-ui/src/main/resources/ui/src/components/KnowledgeCenter/KnowledgePagesHierarchy/KnowledgePagesHierarchy.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/KnowledgeCenter/KnowledgePagesHierarchy/KnowledgePagesHierarchy.tsx
@@ -564,7 +564,7 @@ const KnowledgePagesHierarchy = forwardRef<
                   )}>
                   <Box align="center" className="tw:min-w-0 tw:flex-1" gap={2}>
                     <File06
-                      className="tw:shrink-0 tw:text-gray-500"
+                      className="tw:shrink-0 tw:text-utility-gray-500"
                       data-testid="page-icon"
                       height={13}
                       width={13}
@@ -682,14 +682,14 @@ const KnowledgePagesHierarchy = forwardRef<
         <Box align="center" className="tw:px-1.5 tw:pb-5" justify="between">
           <Box align="center" gap={3}>
             <div className="tw:p-3 tw:rounded-lg tw:bg-gray-blue-50 tw:leading-0">
-              <File06 className="tw:text-gray-600" size={20} />
+              <File06 className="tw:text-fg-tertiary" size={20} />
             </div>
             <div>
               <Typography size="text-md" weight="medium">
                 {t('label.article-plural')}
               </Typography>
               <Typography
-                className="tw:text-gray-500 tw:flex tw:items-center tw:gap-2"
+                className="tw:text-quaternary tw:flex tw:items-center tw:gap-2"
                 size="text-xs">
                 {paginationState.paging.total ?? 0} {t('label.article-plural')}
               </Typography>
@@ -718,7 +718,7 @@ const KnowledgePagesHierarchy = forwardRef<
           <div className="tw:px-1.5">
             {Array.from({ length: 8 }, (_, i) => (
               <div
-                className="tw:h-5 tw:mb-2 tw:rounded tw:bg-gray-100 tw:animate-pulse"
+                className="tw:h-5 tw:mb-2 tw:rounded tw:bg-tertiary tw:animate-pulse"
                 key={`skeleton-${i}`}
                 style={{ width: `${60 + (i % 3) * 15}%` }}
               />

--- a/openmetadata-ui/src/main/resources/ui/src/pages/ContextCenterPage/ContextCenterArchivePage/ContextCenterArchivePage.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/ContextCenterPage/ContextCenterArchivePage/ContextCenterArchivePage.tsx
@@ -248,8 +248,8 @@ const ContextCenterArchivePage: FC = () => {
                   {...tab}
                   className={({ isSelected }) =>
                     isSelected
-                      ? 'tw:rounded-md tw:border tw:border-brand-100 tw:bg-brand-50 tw:px-3 tw:py-1.5 tw:text-sm tw:font-semibold tw:text-brand-700 tw:cursor-pointer'
-                      : 'tw:rounded-md tw:border tw:border-gray-300 tw:bg-primary tw:px-3 tw:py-1.5 tw:text-sm tw:font-semibold tw:text-quaternary tw:cursor-pointer'
+                      ? 'tw:rounded-md tw:border tw:border-utility-brand-100 tw:bg-utility-brand-50 tw:px-3 tw:py-1.5 tw:text-sm tw:font-semibold tw:text-utility-brand-700 tw:cursor-pointer'
+                      : 'tw:rounded-md tw:border tw:border-primary tw:bg-primary tw:px-3 tw:py-1.5 tw:text-sm tw:font-semibold tw:text-quaternary tw:cursor-pointer'
                   }
                 />
               )}

--- a/openmetadata-ui/src/main/resources/ui/src/pages/ContextCenterPage/ContextCenterMemoriesPage/ContextCenterMemoriesPage.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/ContextCenterPage/ContextCenterMemoriesPage/ContextCenterMemoriesPage.tsx
@@ -596,7 +596,7 @@ const ContextCenterMemoriesPage: FC = () => {
                         <div className="tw:shrink-0">
                           {searchClassBase.getEntityIcon(
                             opt.type,
-                            'tw:w-6 tw:h-6 tw:text-utility-gray-500'
+                            'tw:w-6 tw:h-6 tw:text-quaternary'
                           )}
                         </div>
                         <Box

--- a/openmetadata-ui/src/main/resources/ui/src/pages/ContextCenterPage/ContextCenterMemoriesPage/ContextCenterMemoriesPage.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/ContextCenterPage/ContextCenterMemoriesPage/ContextCenterMemoriesPage.tsx
@@ -75,7 +75,7 @@ const FILTER_BUTTON_BASE_CLS =
   ' tw:ease-linear hover:tw:ring-brand tw:outline-hidden tw:whitespace-nowrap';
 
 const FILTER_BUTTON_CLS = `${FILTER_BUTTON_BASE_CLS} tw:bg-primary tw:ring-primary`;
-const FILTER_BUTTON_ACTIVE_CLS = `${FILTER_BUTTON_BASE_CLS} tw:bg-brand-50 tw:ring-brand-100`;
+const FILTER_BUTTON_ACTIVE_CLS = `${FILTER_BUTTON_BASE_CLS} tw:bg-utility-brand-50 tw:ring-utility-brand-100`;
 
 const ContextCenterMemoriesPage: FC = () => {
   const { t } = useTranslation();
@@ -474,7 +474,7 @@ const ContextCenterMemoriesPage: FC = () => {
               className={classNames(
                 'tw:group tw:relative tw:p-4 tw:flex tw:flex-col tw:gap-1',
                 'tw:cursor-pointer tw:transition-all tw:duration-150 tw:ease-out tw:hover:-translate-y-px',
-                { 'tw:bg-blue-50 tw:border-blue-200': isActive }
+                { 'tw:bg-utility-blue-50 tw:border-utility-blue-200': isActive }
               )}
               key={filterKey}
               onClick={() => handleFilterChange(filterKey)}>
@@ -542,9 +542,9 @@ const ContextCenterMemoriesPage: FC = () => {
                   classNames(
                     'tw:rounded-full tw:border tw:px-3 tw:py-1.5 tw:text-sm tw:font-semibold tw:cursor-pointer',
                     {
-                      'tw:border-brand-100 tw:bg-brand-50 tw:text-brand-700':
+                      'tw:border-utility-brand-100 tw:bg-utility-brand-50 tw:text-utility-brand-700':
                         isSelected,
-                      'tw:border-gray-300 tw:bg-primary tw:text-secondary':
+                      'tw:border-primary tw:bg-primary tw:text-secondary':
                         !isSelected,
                     }
                   )
@@ -562,7 +562,9 @@ const ContextCenterMemoriesPage: FC = () => {
               }>
               <Typography
                 className={
-                  selectedAsset ? 'tw:text-brand-700' : 'tw:text-secondary'
+                  selectedAsset
+                    ? 'tw:text-utility-brand-700'
+                    : 'tw:text-secondary'
                 }
                 weight="medium">
                 {assetOptions.find((o) => o.id === selectedAsset)?.label ??
@@ -594,7 +596,7 @@ const ContextCenterMemoriesPage: FC = () => {
                         <div className="tw:shrink-0">
                           {searchClassBase.getEntityIcon(
                             opt.type,
-                            'tw:w-6 tw:h-6 tw:text-gray-500'
+                            'tw:w-6 tw:h-6 tw:text-utility-gray-500'
                           )}
                         </div>
                         <Box
@@ -604,14 +606,14 @@ const ContextCenterMemoriesPage: FC = () => {
                           <div className="tw:max-w-55">
                             <Typography
                               ellipsis
-                              className="tw:truncate tw:text-gray-800"
+                              className="tw:truncate tw:text-utility-gray-800"
                               size="text-sm"
                               weight="medium">
                               {opt.displayName}
                             </Typography>
                             <Typography
                               ellipsis
-                              className="tw:text-gray-400 tw:truncate"
+                              className="tw:text-utility-gray-400 tw:truncate"
                               size="text-xs">
                               {opt.id}
                             </Typography>
@@ -641,7 +643,9 @@ const ContextCenterMemoriesPage: FC = () => {
               }>
               <Typography
                 className={
-                  selectedAuthor ? 'tw:text-brand-700' : 'tw:text-secondary'
+                  selectedAuthor
+                    ? 'tw:text-utility-brand-700'
+                    : 'tw:text-secondary'
                 }
                 weight="medium">
                 {authorOptions.find((o) => o.id === selectedAuthor)?.label ??


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:

Fixes #<issue-number>
<!--
Linking an issue is REQUIRED. Replace <issue-number> with the GitHub issue number this PR addresses
(e.g., `Fixes #12345`). GitHub will auto-link it. If no issue exists, please open one first so the
problem and design can be discussed before review.
-->

<!--
Short blurb explaining:
- What changes did you make?
- Why did you make them?
-->

I worked on ... because ...

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### High-level design:
<!--
REQUIRED for large PRs (new features, refactors, breaking changes, or anything touching >5 files).
Skip for small bug fixes and trivial changes.

Cover:
- Architecture / approach you took and why
- Key components or files added/changed and how they interact
- Alternatives considered and why you rejected them
- Any migration, backward-compatibility, or rollout concerns
- Diagrams or links to design docs / RFCs if available
-->

N/A — small change. <!-- Or fill in the design above -->

#
### Tests:

#### Use cases covered
<!--
List the user-visible scenarios this PR exercises. Example:
- User with Admin role can create a Glossary Term with a parent term
- Ingestion run for Snowflake correctly extracts row counts for partitioned tables
-->

#### Unit tests
<!--
- [ ] I added unit tests for the new/changed logic.
- Files added/updated:
- Coverage on changed classes (run `mvn jacoco:report` for backend, `yarn test:coverage` for UI,
  `make unit_ingestion` for ingestion). Target is 90% line coverage on changed classes.
- Coverage %: <e.g., 92% on EntityRepository.java>
-->

#### Backend integration tests
<!--
- [ ] I added integration tests in `openmetadata-integration-tests/` for new/changed API endpoints.
- [ ] Not applicable (no backend API changes).
- Files added/updated:
-->

#### Ingestion integration tests
<!--
- [ ] I added/updated ingestion integration tests for connector changes.
- [ ] Not applicable (no ingestion changes).
- Files added/updated:
-->

#### Playwright (UI) tests
<!--
- [ ] I added Playwright E2E tests under `openmetadata-ui/.../ui/playwright/` for UI changes.
- [ ] Not applicable (no UI changes).
- Files added/updated:
-->

#### Manual testing performed
<!--
List the manual test steps you performed before requesting review. Example:
1. Started local stack via `./docker/run_local_docker.sh -m ui -d mysql`
2. Logged in as admin, created entity X, verified Y appears in the UI
3. Triggered ingestion for Snowflake source, confirmed lineage edges in the explore page
-->

#
### UI screen recording / screenshots:
<!--
REQUIRED for any PR that changes the UI. Drag-and-drop a short screen recording (.mov / .mp4 / .gif)
demonstrating the change end-to-end, plus before/after screenshots where relevant.
Mark "Not applicable" if there are no UI changes.
-->

Not applicable. <!-- Or attach recording/screenshots above -->

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.
- [ ] For UI changes: I attached a screen recording and/or screenshots above.
- [ ] I have added tests (unit / integration / Playwright as applicable) and listed them above.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR migrates hardcoded Tailwind palette color classes (e.g. `tw:bg-gray-100`, `tw:text-gray-500`, `tw:bg-blue-50`, `tw:text-error-600`) across 15 ContextCenter and KnowledgeCenter components to semantic design tokens (`tw:bg-tertiary`, `tw:text-quaternary`, `tw:bg-utility-blue-50`, `tw:text-error-primary`) for dark-mode compatibility.

- **Color token migration** across all ContextCenter views (Archive, Documents, Memories, Articles) and KnowledgeCenter cards/hierarchy, replacing raw palette references with semantic and utility tokens.
- **Two instances of inconsistent mapping**: `tw:text-gray-500` is mapped to `tw:text-utility-gray-500` (a raw palette token) for the `Clock` icon in `MemoriesView` and the `File06` icon in `KnowledgePagesHierarchy`, while every other `gray-500` element in the PR is mapped to the semantic `tw:text-quaternary`. These two icons will not auto-adapt in dark mode like their sibling elements.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — pure color token substitution with no logic changes.

Every change is a class name swap with no logic, state, or API surface touched. The two icon tokens that use tw:text-utility-gray-500 instead of tw:text-quaternary are a visual consistency nit with no functional impact.

MemoriesView.component.tsx (Clock icon token) and KnowledgePagesHierarchy.tsx (File06 icon token) have the minor mapping inconsistency, but neither affects runtime behaviour.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-ui/src/main/resources/ui/src/components/ContextCenter/ArchiveView/ArchiveView.component.tsx | Migrates brand/purple background and icon colors to utility tokens; replaces text-gray-500 with semantic text-quaternary — consistent with the rest of the PR. |
| openmetadata-ui/src/main/resources/ui/src/components/ContextCenter/ArticleDetailHeader/ArticleDetailHeader.component.tsx | Replaces multiple hardcoded gray, brand, blue, and error colors with semantic/utility tokens throughout the article header. |
| openmetadata-ui/src/main/resources/ui/src/components/ContextCenter/MemoriesView/MemoriesView.component.tsx | Mostly consistent migration, but Clock icon at line 274 uses text-utility-gray-500 while the adjacent Typography uses text-quaternary. |
| openmetadata-ui/src/main/resources/ui/src/components/KnowledgeCenter/KnowledgePagesHierarchy/KnowledgePagesHierarchy.tsx | Article count text and skeleton loader migrated cleanly; File06 icon at line 567 uses text-utility-gray-500 rather than text-quaternary, inconsistent with the rest of the PR. |
| openmetadata-ui/src/main/resources/ui/src/components/ContextCenter/CreateMemoryModal/CreateMemoryModal.component.tsx | Comprehensive token migration across linked-asset card, empty state, memory preview, metadata rows, and sticky footer — all consistent. |
| openmetadata-ui/src/main/resources/ui/src/components/ContextCenter/DocumentsView/DocumentsView.component.tsx | Large consistent migration for file rows, list headers, selection banner, and actions. |

</details>

<sub>Reviews (5): Last reviewed commit: ["lint fix"](https://github.com/open-metadata/openmetadata/commit/a592fe1f2e5e0d9180b2072b0248e553dc9a13fb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38470675)</sub>

<!-- /greptile_comment -->