### PR TITLE
fix(search): stream search responses to prevent heap OOM on large schemas

### DIFF
--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/SearchStreamingIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/SearchStreamingIT.java
@@ -1,0 +1,193 @@
+package org.openmetadata.it.tests;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.openmetadata.it.factories.StorageServiceTestFactory;
+import org.openmetadata.it.util.SdkClients;
+import org.openmetadata.it.util.TestNamespace;
+import org.openmetadata.it.util.TestNamespaceExtension;
+import org.openmetadata.schema.api.data.CreateContainer;
+import org.openmetadata.schema.entity.data.Container;
+import org.openmetadata.schema.entity.services.StorageService;
+import org.openmetadata.schema.type.Column;
+import org.openmetadata.schema.type.ColumnDataType;
+import org.openmetadata.schema.type.ContainerDataModel;
+import org.openmetadata.sdk.client.OpenMetadataClient;
+import org.openmetadata.service.cache.CacheBundle;
+import org.openmetadata.service.cache.CacheMetrics;
+import org.openmetadata.service.cache.CachedSearchLayer;
+
+/**
+ * Verifies the search read path streams large responses correctly and the response cache stays
+ * consistent — the behaviour added to fix the heap OOM on containers with very large {@code
+ * dataModel}s (PR #29191).
+ *
+ * <p>The search managers now serialize straight to the HTTP output instead of building one giant
+ * intermediate String, and {@code SearchResource} buffers a response into a size-capped buffer for
+ * caching: small responses are cached, oversized ones (over {@code MAX_CACHEABLE_SEARCH_BYTES} = 4MB)
+ * trip the cap and stream uncached. These tests assert the client always receives complete, valid,
+ * repeatable JSON across both paths.
+ */
+@Execution(ExecutionMode.CONCURRENT)
+@ExtendWith(TestNamespaceExtension.class)
+public class SearchStreamingIT {
+
+  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+  private static final String CONTAINER_INDEX = "container_search_index";
+
+  // Sized so a single container's _source exceeds the 4MB cache cap (~0.3KB per column in the
+  // index), forcing the oversized-streaming / cache-bypass path rather than the buffered path.
+  private static final int OVER_CAP_COLUMN_COUNT = 20000;
+  private static final int SMALL_COLUMN_COUNT = 25;
+
+  @Test
+  void largeDataModelSearchStreamsCompleteJson(TestNamespace ns) throws Exception {
+    Container container = createContainerWithColumns(ns, "large_dm", OVER_CAP_COLUMN_COUNT);
+
+    String response = awaitContainerSearch(ns, container.getName());
+
+    JsonNode hit = firstSourceFor(response, container.getName());
+    assertNotNull(hit, "Large container should be returned by search");
+    JsonNode columns = hit.path("dataModel").path("columns");
+    assertEquals(
+        OVER_CAP_COLUMN_COUNT,
+        columns.size(),
+        "Streamed response must contain every column with no truncation");
+  }
+
+  @Test
+  void normalContainerSearchReturnsValidJson(TestNamespace ns) throws Exception {
+    Container container = createContainerWithColumns(ns, "small_dm", SMALL_COLUMN_COUNT);
+
+    String response = awaitContainerSearch(ns, container.getName());
+
+    JsonNode root = OBJECT_MAPPER.readTree(response);
+    assertTrue(root.has("hits"), "Response should be well-formed search JSON");
+    JsonNode hit = firstSourceFor(response, container.getName());
+    assertNotNull(hit, "Small container should be returned by search");
+    assertEquals(SMALL_COLUMN_COUNT, hit.path("dataModel").path("columns").size());
+  }
+
+  @Test
+  void repeatedSearchReturnsConsistentResults(TestNamespace ns) throws Exception {
+    Container container = createContainerWithColumns(ns, "consistent_dm", SMALL_COLUMN_COUNT);
+
+    String first = awaitContainerSearch(ns, container.getName());
+    String second = searchContainer(container.getName());
+
+    // Compare the document body, not the whole envelope (the top-level `took` timing varies per
+    // call). A corrupted/truncated cache write — the risk the size-capped buffer guards against —
+    // would diverge here whether the second call is served fresh or from cache.
+    assertEquals(
+        firstSourceFor(first, container.getName()),
+        firstSourceFor(second, container.getName()),
+        "Repeated identical search must return the same complete document");
+  }
+
+  @Test
+  void repeatedLargeSearchIsConsistentAcrossTheCacheBypass(TestNamespace ns) throws Exception {
+    Container container = createContainerWithColumns(ns, "large_consistent", OVER_CAP_COLUMN_COUNT);
+
+    String first = awaitContainerSearch(ns, container.getName());
+    String second = searchContainer(container.getName());
+
+    assertEquals(
+        firstSourceFor(first, container.getName()).path("dataModel").path("columns").size(),
+        firstSourceFor(second, container.getName()).path("dataModel").path("columns").size(),
+        "Oversized response must stream the full column set consistently on every call");
+  }
+
+  @Test
+  void searchResponseIsCachedWhenCacheEnabled(TestNamespace ns) throws Exception {
+    CachedSearchLayer cache = CacheBundle.getCachedSearchLayer();
+    Assumptions.assumeTrue(
+        cache != null && cache.enabled(), "Search response cache is not enabled on this profile");
+
+    Container container = createContainerWithColumns(ns, "cached_dm", SMALL_COLUMN_COUNT);
+    awaitContainerSearch(ns, container.getName()); // first miss populates the cache
+    searchContainer(container.getName()); // identical query is served from the cache
+
+    // Streamed responses are buffered into the size-capped tee and cached. If that broke — the
+    // regression this fix guards against, where the StreamingOutput entity was never a String the
+    // cache could store — the search layer would record zero writes and zero hits forever.
+    assertTrue(searchLayerCount("writes") >= 1, "Small search responses must be cached");
+    assertTrue(searchLayerCount("hits") >= 1, "Repeated search must be served from the cache");
+  }
+
+  private long searchLayerCount(String field) {
+    CacheMetrics metrics = CacheMetrics.getInstance();
+    long count = 0L;
+    if (metrics != null && metrics.snapshot().get("byType") instanceof Map<?, ?> byType) {
+      if (byType.get("search") instanceof Map<?, ?> searchStats
+          && searchStats.get(field) instanceof Number number) {
+        count = number.longValue();
+      }
+    }
+    return count;
+  }
+
+  private Container createContainerWithColumns(TestNamespace ns, String baseName, int columnCount) {
+    StorageService service = StorageServiceTestFactory.createS3(ns);
+    CreateContainer request = new CreateContainer();
+    request.setName(ns.prefix(baseName));
+    request.setService(service.getFullyQualifiedName());
+    request.setDataModel(new ContainerDataModel().withColumns(buildColumns(columnCount)));
+    return SdkClients.adminClient().containers().create(request);
+  }
+
+  private List<Column> buildColumns(int count) {
+    List<Column> columns = new ArrayList<>(count);
+    for (int i = 0; i < count; i++) {
+      columns.add(
+          new Column()
+              .withName("col_" + i)
+              .withDataType(ColumnDataType.BIGINT)
+              .withDescription(
+                  "Synthetic column "
+                      + i
+                      + " padded so the indexed document is large enough to exercise streaming."));
+    }
+    return columns;
+  }
+
+  private String awaitContainerSearch(TestNamespace ns, String name) {
+    Awaitility.await()
+        .atMost(Duration.ofSeconds(60))
+        .pollInterval(1, TimeUnit.SECONDS)
+        .until(() -> firstSourceFor(searchContainer(name), name) != null);
+    return searchContainer(name);
+  }
+
+  private String searchContainer(String name) {
+    OpenMetadataClient client = SdkClients.adminClient();
+    return client.search().query(name).index(CONTAINER_INDEX).size(10).execute();
+  }
+
+  private JsonNode firstSourceFor(String response, String name) throws Exception {
+    JsonNode hits = OBJECT_MAPPER.readTree(response).path("hits").path("hits");
+    JsonNode match = null;
+    for (JsonNode hit : hits) {
+      JsonNode source = hit.path("_source");
+      if (name.equals(source.path("name").asText())) {
+        match = source;
+        break;
+      }
+    }
+    return match;
+  }
+}

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/search/SearchResource.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/search/SearchResource.java
@@ -71,7 +71,6 @@ import org.openmetadata.service.exception.UnhandledServerException;
 import org.openmetadata.service.jdbi3.CollectionDAO;
 import org.openmetadata.service.monitoring.LatencyPhase;
 import org.openmetadata.service.resources.Collection;
-import org.openmetadata.service.search.CapBufferingOutputStream;
 import org.openmetadata.service.search.IndexManagementClient.IndexStats;
 import org.openmetadata.service.search.SearchClient;
 import org.openmetadata.service.search.SearchHealthStatus;
@@ -95,11 +94,6 @@ import os.org.opensearch.client.opensearch.core.search.Suggest;
 @Collection(name = "search")
 @LatencyPhase
 public class SearchResource {
-  // Upper bound on a search response body the cache will buffer and store. A normal response is far
-  // below this; an oversized one (e.g. a container with a huge dataModel) trips the cap and streams
-  // uncached instead of being materialized in heap.
-  private static final int MAX_CACHEABLE_SEARCH_BYTES = 4 * 1024 * 1024;
-
   private final SearchRepository searchRepository;
   private final Authorizer authorizer;
 
@@ -280,18 +274,14 @@ public class SearchResource {
     // single-flight wrapper holds the stripe lock around the supplier; we keep the supplier
     // tight to minimize lock-hold time.
     //
-    // Search responses now stream (see SearchResponseStreamer) — the entity is a StreamingOutput,
-    // not a String. To keep the cache working without re-introducing the heap OOM, the supplier
-    // serializes the streamed body into a size-capped buffer: a normal (small) response is captured
-    // and cached, while an oversized one (e.g. a container with a 170MB dataModel) trips the cap,
-    // is left uncached, and is streamed straight through via `capturedResponse[0]`. Because the
-    // streamed response re-serializes from the in-memory result on each write, returning the
-    // captured response after a failed buffer attempt streams the full body with no second backend
-    // call.
+    // A normal-sized response arrives as a String entity (SearchResponseStreamer.bufferOrStream
+    // serializes it into a bounded buffer) and is cached here. An oversized response — e.g. a
+    // container with a 170MB dataModel — arrives as a StreamingOutput instead and is intentionally
+    // left uncached so the multi-hundred-MB body never lands fully in heap; it is returned directly
+    // via `capturedResponse[0]` and streamed.
     //
     // The supplier captures the Response object into `capturedResponse[0]` so a non-cacheable
-    // outcome (non-200, oversized, or non-streamable body) can be returned directly without a
-    // SECOND
+    // outcome (non-200 or a streamed/oversized body) can be returned directly without a SECOND
     // call to searchRepository.search().
     final Response[] capturedResponse = new Response[1];
     final java.io.IOException[] thrown = new java.io.IOException[1];
@@ -306,7 +296,8 @@ public class SearchResource {
                 if (upstream.getStatus() != 200) {
                   return null; // don't cache non-200; loadOrCompute treats null as "no cache write"
                 }
-                return materializeIfCacheable(upstream.getEntity());
+                Object entity = upstream.getEntity();
+                return entity instanceof String s ? s : null;
               } catch (java.io.IOException ioe) {
                 thrown[0] = ioe;
                 return null;
@@ -329,50 +320,6 @@ public class SearchResource {
     // through to a live call (this is rare and only affects the second+ caller of a query
     // that's currently returning errors).
     return searchRepository.search(request, subjectContext);
-  }
-
-  /**
-   * Returns the response body as a cacheable String when it is small enough, or {@code null} when it
-   * is not cacheable (oversized or not a streamable/String body). A streamed body is serialized into
-   * a {@link CapBufferingOutputStream}: under the cap it is captured for caching, over the cap it is
-   * left uncached so the multi-hundred-MB outlier never lands fully in heap. Serialization happens
-   * here, before the response is committed, so a streaming failure on the cacheable path still
-   * surfaces as a clean error rather than a truncated 200.
-   */
-  private static String materializeIfCacheable(Object entity) throws IOException {
-    String result = null;
-    if (entity instanceof String s) {
-      result = s;
-    } else if (entity instanceof StreamingOutput streaming) {
-      result = bufferIfCacheable(streaming);
-    }
-    return result;
-  }
-
-  private static String bufferIfCacheable(StreamingOutput streaming) throws IOException {
-    CapBufferingOutputStream buffer = new CapBufferingOutputStream(MAX_CACHEABLE_SEARCH_BYTES);
-    String result = null;
-    try {
-      streaming.write(buffer);
-      result = buffer.toUtf8String();
-    } catch (RuntimeException | IOException error) {
-      // The JSON-P generator wraps an OutputStream IOException in an unchecked JsonException, so
-      // the
-      // cap signal can arrive either directly or as a cause. Anything else is a real failure.
-      if (!isOverCapacity(error)) {
-        throw error;
-      }
-      LOG.debug("Search response exceeds cacheable size; streaming without caching");
-    }
-    return result;
-  }
-
-  private static boolean isOverCapacity(Throwable error) {
-    Throwable cause = error;
-    while (cause != null && !(cause instanceof CapBufferingOutputStream.OverCapacityException)) {
-      cause = cause.getCause();
-    }
-    return cause != null;
   }
 
   @GET

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/search/SearchResource.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/search/SearchResource.java
@@ -71,6 +71,7 @@ import org.openmetadata.service.exception.UnhandledServerException;
 import org.openmetadata.service.jdbi3.CollectionDAO;
 import org.openmetadata.service.monitoring.LatencyPhase;
 import org.openmetadata.service.resources.Collection;
+import org.openmetadata.service.search.CapBufferingOutputStream;
 import org.openmetadata.service.search.IndexManagementClient.IndexStats;
 import org.openmetadata.service.search.SearchClient;
 import org.openmetadata.service.search.SearchHealthStatus;
@@ -94,6 +95,11 @@ import os.org.opensearch.client.opensearch.core.search.Suggest;
 @Collection(name = "search")
 @LatencyPhase
 public class SearchResource {
+  // Upper bound on a search response body the cache will buffer and store. A normal response is far
+  // below this; an oversized one (e.g. a container with a huge dataModel) trips the cap and streams
+  // uncached instead of being materialized in heap.
+  private static final int MAX_CACHEABLE_SEARCH_BYTES = 4 * 1024 * 1024;
+
   private final SearchRepository searchRepository;
   private final Authorizer authorizer;
 
@@ -274,10 +280,19 @@ public class SearchResource {
     // single-flight wrapper holds the stripe lock around the supplier; we keep the supplier
     // tight to minimize lock-hold time.
     //
+    // Search responses now stream (see SearchResponseStreamer) — the entity is a StreamingOutput,
+    // not a String. To keep the cache working without re-introducing the heap OOM, the supplier
+    // serializes the streamed body into a size-capped buffer: a normal (small) response is captured
+    // and cached, while an oversized one (e.g. a container with a 170MB dataModel) trips the cap,
+    // is left uncached, and is streamed straight through via `capturedResponse[0]`. Because the
+    // streamed response re-serializes from the in-memory result on each write, returning the
+    // captured response after a failed buffer attempt streams the full body with no second backend
+    // call.
+    //
     // The supplier captures the Response object into `capturedResponse[0]` so a non-cacheable
-    // outcome (non-200 or non-String body) can be returned directly without a SECOND call to
-    // searchRepository.search() — the previous implementation re-called search() on the error
-    // path, doubling backend load for every error / non-200 response.
+    // outcome (non-200, oversized, or non-streamable body) can be returned directly without a
+    // SECOND
+    // call to searchRepository.search().
     final Response[] capturedResponse = new Response[1];
     final java.io.IOException[] thrown = new java.io.IOException[1];
     String body =
@@ -291,8 +306,7 @@ public class SearchResource {
                 if (upstream.getStatus() != 200) {
                   return null; // don't cache non-200; loadOrCompute treats null as "no cache write"
                 }
-                Object entity = upstream.getEntity();
-                return entity instanceof String s ? s : null;
+                return materializeIfCacheable(upstream.getEntity());
               } catch (java.io.IOException ioe) {
                 thrown[0] = ioe;
                 return null;
@@ -315,6 +329,50 @@ public class SearchResource {
     // through to a live call (this is rare and only affects the second+ caller of a query
     // that's currently returning errors).
     return searchRepository.search(request, subjectContext);
+  }
+
+  /**
+   * Returns the response body as a cacheable String when it is small enough, or {@code null} when it
+   * is not cacheable (oversized or not a streamable/String body). A streamed body is serialized into
+   * a {@link CapBufferingOutputStream}: under the cap it is captured for caching, over the cap it is
+   * left uncached so the multi-hundred-MB outlier never lands fully in heap. Serialization happens
+   * here, before the response is committed, so a streaming failure on the cacheable path still
+   * surfaces as a clean error rather than a truncated 200.
+   */
+  private static String materializeIfCacheable(Object entity) throws IOException {
+    String result = null;
+    if (entity instanceof String s) {
+      result = s;
+    } else if (entity instanceof StreamingOutput streaming) {
+      result = bufferIfCacheable(streaming);
+    }
+    return result;
+  }
+
+  private static String bufferIfCacheable(StreamingOutput streaming) throws IOException {
+    CapBufferingOutputStream buffer = new CapBufferingOutputStream(MAX_CACHEABLE_SEARCH_BYTES);
+    String result = null;
+    try {
+      streaming.write(buffer);
+      result = buffer.toUtf8String();
+    } catch (RuntimeException | IOException error) {
+      // The JSON-P generator wraps an OutputStream IOException in an unchecked JsonException, so
+      // the
+      // cap signal can arrive either directly or as a cause. Anything else is a real failure.
+      if (!isOverCapacity(error)) {
+        throw error;
+      }
+      LOG.debug("Search response exceeds cacheable size; streaming without caching");
+    }
+    return result;
+  }
+
+  private static boolean isOverCapacity(Throwable error) {
+    Throwable cause = error;
+    while (cause != null && !(cause instanceof CapBufferingOutputStream.OverCapacityException)) {
+      cause = cause.getCause();
+    }
+    return cause != null;
   }
 
   @GET

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/CapBufferingOutputStream.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/CapBufferingOutputStream.java
@@ -1,0 +1,71 @@
+/*
+ *  Copyright 2024 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.openmetadata.service.search;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+
+/**
+ * An {@link OutputStream} that accumulates written bytes up to {@code maxBytes} so a small search
+ * response can be captured for caching, and aborts with {@link OverCapacityException} the moment the
+ * cap is exceeded so a large response is never fully materialized.
+ *
+ * <p>This is how streaming and the response cache are reconciled: the cache must hold the body to
+ * store it, but holding a multi-hundred-MB body is exactly the allocation that OOMs the node. The
+ * cap lets the common (small) response be buffered, cached, and returned with clean error semantics
+ * — serialization happens before the response is committed — while an oversized response trips the
+ * cap, is left uncached, and is streamed straight through instead.
+ */
+public final class CapBufferingOutputStream extends OutputStream {
+
+  private static final int INITIAL_CAPACITY = 8192;
+
+  private final ByteArrayOutputStream buffer;
+  private final int maxBytes;
+
+  public CapBufferingOutputStream(int maxBytes) {
+    this.maxBytes = maxBytes;
+    this.buffer = new ByteArrayOutputStream(Math.min(maxBytes, INITIAL_CAPACITY));
+  }
+
+  @Override
+  public void write(int b) throws IOException {
+    ensureCapacity(1);
+    buffer.write(b);
+  }
+
+  @Override
+  public void write(byte[] bytes, int off, int len) throws IOException {
+    ensureCapacity(len);
+    buffer.write(bytes, off, len);
+  }
+
+  public String toUtf8String() {
+    return buffer.toString(StandardCharsets.UTF_8);
+  }
+
+  private void ensureCapacity(int additional) throws OverCapacityException {
+    if (buffer.size() + additional > maxBytes) {
+      throw new OverCapacityException(maxBytes);
+    }
+  }
+
+  /** Thrown when the buffered payload would exceed the configured cap. */
+  public static final class OverCapacityException extends IOException {
+    public OverCapacityException(int maxBytes) {
+      super(String.format("Response exceeded cache buffer cap of %d bytes", maxBytes));
+    }
+  }
+}

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/SearchResponseStreamer.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/SearchResponseStreamer.java
@@ -17,30 +17,35 @@ import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.StreamingOutput;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.io.UncheckedIOException;
 
 /**
- * Streams a search response directly to the HTTP output instead of materializing it into a single
- * in-memory String.
+ * Returns a search response either as a buffered String (the common case) or as a stream (the
+ * oversized case), so a very large document can no longer OOM the node.
  *
  * <p>The previous pattern built the entire response as one String before returning it
- * ({@code searchResponse.toJsonString()} on OpenSearch, {@code serializeSearchResponse(...)} on
- * ElasticSearch). For a single very large document — e.g. a container carrying a 170MB+ {@code
- * dataModel} — that String is hundreds of MB allocated in one shot, on top of the already-parsed
- * response object, and OOMs the node under concurrency. Writing the JSON straight to the response
- * {@link OutputStream} removes that second full-size copy of the payload.
+ * ({@code serializeSearchResponse}/{@code toJsonString}). For a single very large document — e.g. a
+ * container carrying a 170MB+ {@code dataModel} — that String is hundreds of MB allocated in one
+ * shot, on top of the already-parsed response object, and OOMs the node under concurrency.
  *
- * <p>The serialization itself is engine-specific (the OpenSearch and ElasticSearch client types are
- * distinct), so each manager supplies a {@link JsonWriter} that writes its typed response using its
- * own JSON-P mapper; this helper owns the shared JAX-RS streaming plumbing.
- *
- * <p><b>Error semantics.</b> A {@link StreamingOutput} commits the HTTP status and headers once the
- * first buffer flushes. If serialization fails after that point the status can no longer be changed,
- * so a mid-stream failure surfaces as a 200 with a truncated body rather than a clean 5xx. The
- * caller-side cache path mitigates this for the common case by serializing into a bounded buffer
- * <i>before</i> the response is committed (see {@link CapBufferingOutputStream}); only oversized
- * responses, which cannot be buffered, carry the inherent streaming trade-off.
+ * <p>{@link #bufferOrStream} serializes into a {@link CapBufferingOutputStream} first: a normal
+ * response (under {@link #MAX_BUFFERED_RESPONSE_BYTES}) is returned as a String, so the HTTP status
+ * still reflects a serialization failure (a clean 5xx with a {@code Content-Length}) and the body is
+ * cacheable. Only a response that exceeds the cap streams — there the intermediate String is exactly
+ * the allocation that OOMs, so it is avoided. Streaming carries an inherent trade-off: the status
+ * and headers are committed before the body is written, so a mid-stream failure yields a {@code 200}
+ * with a truncated body rather than a clean 5xx. This is bounded to oversized responses, and the
+ * truncation is still detectable by clients (the JSON is left incomplete/unparseable). Each manager
+ * supplies a {@link JsonWriter} that serializes its engine-specific typed response.
  */
 public final class SearchResponseStreamer {
+
+  /**
+   * Responses up to this size are buffered and returned as a String (clean error semantics);
+   * larger ones stream. Well above any normal search response — only a pathologically large single
+   * document (e.g. a 170MB {@code dataModel}) crosses it.
+   */
+  public static final int MAX_BUFFERED_RESPONSE_BYTES = 4 * 1024 * 1024;
 
   private SearchResponseStreamer() {}
 
@@ -50,8 +55,52 @@ public final class SearchResponseStreamer {
     void writeTo(OutputStream output) throws IOException;
   }
 
+  /**
+   * Buffers the response into a bounded buffer and returns it as a String, falling back to streaming
+   * only when the payload exceeds {@link #MAX_BUFFERED_RESPONSE_BYTES}. A genuine serialization
+   * failure (not a cap overflow) propagates before any bytes are committed, preserving clean 5xx
+   * semantics for the common case.
+   */
+  public static Response bufferOrStream(JsonWriter writer) {
+    CapBufferingOutputStream buffer = new CapBufferingOutputStream(MAX_BUFFERED_RESPONSE_BYTES);
+    Response response;
+    try {
+      writer.writeTo(buffer);
+      response = Response.ok(buffer.toUtf8String(), MediaType.APPLICATION_JSON_TYPE).build();
+    } catch (RuntimeException | IOException error) {
+      response = onBufferFailure(error, writer);
+    }
+    return response;
+  }
+
+  /** Streams a JSON payload straight to the HTTP output, with no intermediate full-size String. */
   public static Response stream(JsonWriter writer) {
     StreamingOutput body = writer::writeTo;
     return Response.ok(body, MediaType.APPLICATION_JSON_TYPE).build();
+  }
+
+  private static Response onBufferFailure(Throwable error, JsonWriter writer) {
+    if (!isOverCapacity(error)) {
+      throw asUnchecked(error);
+    }
+    // Too large to buffer — stream it instead. The JSON-P generator may flush an incomplete
+    // prefix into the discarded buffer; the stream below re-serializes from the in-memory response.
+    return stream(writer);
+  }
+
+  private static boolean isOverCapacity(Throwable error) {
+    // The JSON-P generator wraps an OutputStream IOException in an unchecked JsonException, so the
+    // cap signal can arrive either directly or as a cause.
+    Throwable cause = error;
+    while (cause != null && !(cause instanceof CapBufferingOutputStream.OverCapacityException)) {
+      cause = cause.getCause();
+    }
+    return cause != null;
+  }
+
+  private static RuntimeException asUnchecked(Throwable error) {
+    return error instanceof RuntimeException runtime
+        ? runtime
+        : new UncheckedIOException("Failed to serialize search response", (IOException) error);
   }
 }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/SearchResponseStreamer.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/SearchResponseStreamer.java
@@ -1,0 +1,57 @@
+/*
+ *  Copyright 2024 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.openmetadata.service.search;
+
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.StreamingOutput;
+import java.io.IOException;
+import java.io.OutputStream;
+
+/**
+ * Streams a search response directly to the HTTP output instead of materializing it into a single
+ * in-memory String.
+ *
+ * <p>The previous pattern built the entire response as one String before returning it
+ * ({@code searchResponse.toJsonString()} on OpenSearch, {@code serializeSearchResponse(...)} on
+ * ElasticSearch). For a single very large document — e.g. a container carrying a 170MB+ {@code
+ * dataModel} — that String is hundreds of MB allocated in one shot, on top of the already-parsed
+ * response object, and OOMs the node under concurrency. Writing the JSON straight to the response
+ * {@link OutputStream} removes that second full-size copy of the payload.
+ *
+ * <p>The serialization itself is engine-specific (the OpenSearch and ElasticSearch client types are
+ * distinct), so each manager supplies a {@link JsonWriter} that writes its typed response using its
+ * own JSON-P mapper; this helper owns the shared JAX-RS streaming plumbing.
+ *
+ * <p><b>Error semantics.</b> A {@link StreamingOutput} commits the HTTP status and headers once the
+ * first buffer flushes. If serialization fails after that point the status can no longer be changed,
+ * so a mid-stream failure surfaces as a 200 with a truncated body rather than a clean 5xx. The
+ * caller-side cache path mitigates this for the common case by serializing into a bounded buffer
+ * <i>before</i> the response is committed (see {@link CapBufferingOutputStream}); only oversized
+ * responses, which cannot be buffered, carry the inherent streaming trade-off.
+ */
+public final class SearchResponseStreamer {
+
+  private SearchResponseStreamer() {}
+
+  /** Writes a JSON payload to the supplied output stream. */
+  @FunctionalInterface
+  public interface JsonWriter {
+    void writeTo(OutputStream output) throws IOException;
+  }
+
+  public static Response stream(JsonWriter writer) {
+    StreamingOutput body = writer::writeTo;
+    return Response.ok(body, MediaType.APPLICATION_JSON_TYPE).build();
+  }
+}

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/elasticsearch/ElasticSearchSearchManager.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/elasticsearch/ElasticSearchSearchManager.java
@@ -749,6 +749,9 @@ public class ElasticSearchSearchManager implements SearchManagementClient {
     }
     processedNode.add(fqn);
     SearchResponse<JsonData> searchResponse = performLineageSearchForDQ(fqn, queryFilter, deleted);
+    if (searchResponse.hits() == null || searchResponse.hits().hits() == null) {
+      return;
+    }
     for (Hit<JsonData> hit : searchResponse.hits().hits()) {
       if (hit.source() == null) {
         continue;
@@ -954,7 +957,7 @@ public class ElasticSearchSearchManager implements SearchManagementClient {
    */
   private Response streamSearchResponse(SearchResponse<JsonData> searchResponse) {
     JsonpMapper mapper = client._transport().jsonpMapper();
-    return SearchResponseStreamer.stream(
+    return SearchResponseStreamer.bufferOrStream(
         output -> {
           try (JsonGenerator generator = mapper.jsonProvider().createGenerator(output)) {
             searchResponse.serialize(generator, mapper);

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/elasticsearch/ElasticSearchSearchManager.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/elasticsearch/ElasticSearchSearchManager.java
@@ -36,20 +36,17 @@ import jakarta.json.JsonObject;
 import jakarta.json.JsonReader;
 import jakarta.json.JsonString;
 import jakarta.json.JsonValue;
-import jakarta.json.spi.JsonProvider;
 import jakarta.json.stream.JsonGenerator;
 import jakarta.json.stream.JsonParser;
 import jakarta.ws.rs.core.Response;
 import java.io.IOException;
 import java.io.StringReader;
-import java.io.StringWriter;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
@@ -72,6 +69,7 @@ import org.openmetadata.service.jdbi3.TestCaseResultRepository;
 import org.openmetadata.service.monitoring.RequestLatencyContext;
 import org.openmetadata.service.resources.settings.SettingsCache;
 import org.openmetadata.service.search.SearchManagementClient;
+import org.openmetadata.service.search.SearchResponseStreamer;
 import org.openmetadata.service.search.SearchResultListMapper;
 import org.openmetadata.service.search.SearchSortFilter;
 import org.openmetadata.service.search.SearchSourceBuilderFactory;
@@ -164,8 +162,7 @@ public class ElasticSearchSearchManager implements SearchManagementClient {
         RequestLatencyContext.endSearchOperation(searchTimerSample);
       }
     }
-    String responseJson = serializeSearchResponse(response);
-    return Response.status(OK).entity(responseJson).build();
+    return streamSearchResponse(response);
   }
 
   @Override
@@ -202,8 +199,7 @@ public class ElasticSearchSearchManager implements SearchManagementClient {
         RequestLatencyContext.endSearchOperation(searchTimerSample);
       }
     }
-    String responseJson = serializeSearchResponse(response);
-    return Response.status(OK).entity(responseJson).build();
+    return streamSearchResponse(response);
   }
 
   @Override
@@ -582,9 +578,7 @@ public class ElasticSearchSearchManager implements SearchManagementClient {
           nlqService.cacheQuery(request.getQuery(), transformedQuery);
         }
 
-        return Response.status(Response.Status.OK)
-            .entity(serializeSearchResponse(response))
-            .build();
+        return streamSearchResponse(response);
       } catch (Exception e) {
         LOG.error("Error transforming or executing NLQ query: {}", e.getMessage(), e);
         return fallbackToBasicSearch(request, subjectContext);
@@ -671,9 +665,8 @@ public class ElasticSearchSearchManager implements SearchManagementClient {
         }
       }
 
-      String responseJson = serializeSearchResponse(response);
       LOG.debug("Direct query search completed successfully");
-      return Response.status(Response.Status.OK).entity(responseJson).build();
+      return streamSearchResponse(response);
     } catch (Exception e) {
       LOG.error("Error executing direct query search: {}", e.getMessage(), e);
       return Response.status(Response.Status.INTERNAL_SERVER_ERROR)
@@ -756,35 +749,32 @@ public class ElasticSearchSearchManager implements SearchManagementClient {
     }
     processedNode.add(fqn);
     SearchResponse<JsonData> searchResponse = performLineageSearchForDQ(fqn, queryFilter, deleted);
-    Optional<List> optionalDocs =
-        JsonUtils.readJsonAtPath(
-            serializeSearchResponse(searchResponse), "$.hits.hits[*]._source", List.class);
+    for (Hit<JsonData> hit : searchResponse.hits().hits()) {
+      if (hit.source() == null) {
+        continue;
+      }
+      Map<String, Object> doc = EsUtils.jsonDataToMap(hit.source());
+      String nodeId = doc.get("id").toString();
+      allNodes.put(nodeId, doc);
+      if (testCaseResultRepository.hasTestCaseFailure(doc.get("fullyQualifiedName").toString())) {
+        nodesWithFailure.add(nodeId);
+      }
 
-    if (optionalDocs.isPresent()) {
-      List<Map<String, Object>> docs = (List<Map<String, Object>>) optionalDocs.get();
-      for (Map<String, Object> doc : docs) {
-        String nodeId = doc.get("id").toString();
-        allNodes.put(nodeId, doc);
-        if (testCaseResultRepository.hasTestCaseFailure(doc.get("fullyQualifiedName").toString())) {
-          nodesWithFailure.add(nodeId);
-        }
-
-        List<EsLineageData> lineageDataList =
-            JsonUtils.readOrConvertValues(doc.get("upstreamLineage"), EsLineageData.class);
-        for (EsLineageData lineage : lineageDataList) {
-          lineage.withToEntity(SearchUtils.getRelationshipRef(doc));
-          String fromEntityId = lineage.getFromEntity().getId().toString();
-          allEdges.computeIfAbsent(fromEntityId, k -> new ArrayList<>()).add(lineage);
-          collectNodesAndEdgesForDQ(
-              lineage.getFromEntity().getFullyQualifiedName(),
-              upstreamDepth - 1,
-              queryFilter,
-              deleted,
-              allEdges,
-              allNodes,
-              nodesWithFailure,
-              processedNode);
-        }
+      List<EsLineageData> lineageDataList =
+          JsonUtils.readOrConvertValues(doc.get("upstreamLineage"), EsLineageData.class);
+      for (EsLineageData lineage : lineageDataList) {
+        lineage.withToEntity(SearchUtils.getRelationshipRef(doc));
+        String fromEntityId = lineage.getFromEntity().getId().toString();
+        allEdges.computeIfAbsent(fromEntityId, k -> new ArrayList<>()).add(lineage);
+        collectNodesAndEdgesForDQ(
+            lineage.getFromEntity().getFullyQualifiedName(),
+            upstreamDepth - 1,
+            queryFilter,
+            deleted,
+            allEdges,
+            allNodes,
+            nodesWithFailure,
+            processedNode);
       }
     }
   }
@@ -956,21 +946,20 @@ public class ElasticSearchSearchManager implements SearchManagementClient {
   }
 
   /**
-   * Serializes a SearchResponse to JSON string.
-   *
-   * @param searchResponse the SearchResponse to serialize
-   * @return JSON string representation of the response
+   * Streams a SearchResponse straight to the HTTP output via a JSON generator over the response
+   * {@link java.io.OutputStream}, avoiding the intermediate full-size String that OOM'd the node on
+   * very large documents. The body is re-serialized from the in-memory response each time it is
+   * written, so the returned {@link Response} is safe to write more than once (the caller-side cache
+   * relies on this to buffer-then-stream).
    */
-  private String serializeSearchResponse(SearchResponse<JsonData> searchResponse) {
-    JsonpMapper jsonpMapper = client._transport().jsonpMapper();
-    JsonProvider provider = jsonpMapper.jsonProvider();
-    StringWriter stringWriter = new StringWriter();
-    JsonGenerator generator = provider.createGenerator(stringWriter);
-
-    searchResponse.serialize(generator, jsonpMapper);
-    generator.close();
-
-    return stringWriter.toString();
+  private Response streamSearchResponse(SearchResponse<JsonData> searchResponse) {
+    JsonpMapper mapper = client._transport().jsonpMapper();
+    return SearchResponseStreamer.stream(
+        output -> {
+          try (JsonGenerator generator = mapper.jsonProvider().createGenerator(output)) {
+            searchResponse.serialize(generator, mapper);
+          }
+        });
   }
 
   public Response doSearch(
@@ -998,8 +987,7 @@ public class ElasticSearchSearchManager implements SearchManagementClient {
       }
 
       if (!Boolean.TRUE.equals(request.getIsHierarchy())) {
-        String responseJson = serializeSearchResponse(searchResponse);
-        return Response.status(OK).entity(responseJson).build();
+        return streamSearchResponse(searchResponse);
       } else {
         List<?> response = buildSearchHierarchy(request, searchResponse, clusterAlias);
         return Response.status(OK).entity(response).build();
@@ -1558,9 +1546,7 @@ public class ElasticSearchSearchManager implements SearchManagementClient {
         }
       }
 
-      return Response.status(Response.Status.OK)
-          .entity(serializeSearchResponse(searchResponse))
-          .build();
+      return streamSearchResponse(searchResponse);
     } catch (Exception e) {
       LOG.error("Error in fallback search: {}", e.getMessage(), e);
       return Response.status(Response.Status.INTERNAL_SERVER_ERROR)

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/opensearch/OpenSearchSearchManager.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/opensearch/OpenSearchSearchManager.java
@@ -743,6 +743,9 @@ public class OpenSearchSearchManager implements SearchManagementClient {
     }
     processedNode.add(fqn);
     SearchResponse<JsonData> searchResponse = performLineageSearchForDQ(fqn, queryFilter, deleted);
+    if (searchResponse.hits() == null || searchResponse.hits().hits() == null) {
+      return;
+    }
     for (Hit<JsonData> hit : searchResponse.hits().hits()) {
       if (hit.source() == null) {
         continue;
@@ -1025,7 +1028,7 @@ public class OpenSearchSearchManager implements SearchManagementClient {
    */
   private Response streamSearchResponse(SearchResponse<JsonData> searchResponse) {
     JsonpMapper mapper = client._transport().jsonpMapper();
-    return SearchResponseStreamer.stream(
+    return SearchResponseStreamer.bufferOrStream(
         output -> {
           try (JsonGenerator generator = mapper.jsonProvider().createGenerator(output)) {
             searchResponse.serialize(generator, mapper);

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/opensearch/OpenSearchSearchManager.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/opensearch/OpenSearchSearchManager.java
@@ -22,6 +22,7 @@ import jakarta.json.JsonArray;
 import jakarta.json.JsonObject;
 import jakarta.json.JsonReader;
 import jakarta.json.JsonValue;
+import jakarta.json.stream.JsonGenerator;
 import jakarta.json.stream.JsonParser;
 import jakarta.ws.rs.core.Response;
 import java.io.IOException;
@@ -32,7 +33,6 @@ import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
@@ -57,6 +57,7 @@ import org.openmetadata.service.jdbi3.TestCaseResultRepository;
 import org.openmetadata.service.monitoring.RequestLatencyContext;
 import org.openmetadata.service.resources.settings.SettingsCache;
 import org.openmetadata.service.search.SearchManagementClient;
+import org.openmetadata.service.search.SearchResponseStreamer;
 import org.openmetadata.service.search.SearchResultListMapper;
 import org.openmetadata.service.search.SearchSortFilter;
 import org.openmetadata.service.search.SearchSourceBuilderFactory;
@@ -185,7 +186,7 @@ public class OpenSearchSearchManager implements SearchManagementClient {
         RequestLatencyContext.endSearchOperation(searchTimerSample);
       }
     }
-    return Response.status(OK).entity(response.toJsonString()).build();
+    return streamSearchResponse(response);
   }
 
   @Override
@@ -226,7 +227,7 @@ public class OpenSearchSearchManager implements SearchManagementClient {
         RequestLatencyContext.endSearchOperation(searchTimerSample);
       }
     }
-    return Response.status(OK).entity(response.toJsonString()).build();
+    return streamSearchResponse(response);
   }
 
   @Override
@@ -592,7 +593,7 @@ public class OpenSearchSearchManager implements SearchManagementClient {
           nlqService.cacheQuery(request.getQuery(), transformedQuery);
         }
 
-        return Response.status(Response.Status.OK).entity(response.toJsonString()).build();
+        return streamSearchResponse(response);
       } catch (Exception e) {
         LOG.error("Error transforming or executing NLQ query: {}", e.getMessage(), e);
         return fallbackToBasicSearch(request, subjectContext);
@@ -658,9 +659,8 @@ public class OpenSearchSearchManager implements SearchManagementClient {
         }
       }
 
-      String responseJson = response.toJsonString();
       LOG.debug("Direct query search completed successfully");
-      return Response.status(Response.Status.OK).entity(responseJson).build();
+      return streamSearchResponse(response);
     } catch (Exception e) {
       LOG.error("Error executing direct query search: {}", e.getMessage(), e);
       return Response.status(Response.Status.INTERNAL_SERVER_ERROR)
@@ -743,35 +743,32 @@ public class OpenSearchSearchManager implements SearchManagementClient {
     }
     processedNode.add(fqn);
     SearchResponse<JsonData> searchResponse = performLineageSearchForDQ(fqn, queryFilter, deleted);
-    Optional<List> optionalDocs =
-        JsonUtils.readJsonAtPath(
-            searchResponse.toJsonString(), "$.hits.hits[*]._source", List.class);
+    for (Hit<JsonData> hit : searchResponse.hits().hits()) {
+      if (hit.source() == null) {
+        continue;
+      }
+      Map<String, Object> doc = OsUtils.jsonDataToMap(hit.source());
+      String nodeId = doc.get("id").toString();
+      allNodes.put(nodeId, doc);
+      if (testCaseResultRepository.hasTestCaseFailure(doc.get("fullyQualifiedName").toString())) {
+        nodesWithFailure.add(nodeId);
+      }
 
-    if (optionalDocs.isPresent()) {
-      List<Map<String, Object>> docs = (List<Map<String, Object>>) optionalDocs.get();
-      for (Map<String, Object> doc : docs) {
-        String nodeId = doc.get("id").toString();
-        allNodes.put(nodeId, doc);
-        if (testCaseResultRepository.hasTestCaseFailure(doc.get("fullyQualifiedName").toString())) {
-          nodesWithFailure.add(nodeId);
-        }
-
-        List<EsLineageData> lineageDataList =
-            JsonUtils.readOrConvertValues(doc.get("upstreamLineage"), EsLineageData.class);
-        for (EsLineageData lineage : lineageDataList) {
-          lineage.withToEntity(SearchUtils.getRelationshipRef(doc));
-          String fromEntityId = lineage.getFromEntity().getId().toString();
-          allEdges.computeIfAbsent(fromEntityId, k -> new ArrayList<>()).add(lineage);
-          collectNodesAndEdgesForDQ(
-              lineage.getFromEntity().getFullyQualifiedName(),
-              upstreamDepth - 1,
-              queryFilter,
-              deleted,
-              allEdges,
-              allNodes,
-              nodesWithFailure,
-              processedNode);
-        }
+      List<EsLineageData> lineageDataList =
+          JsonUtils.readOrConvertValues(doc.get("upstreamLineage"), EsLineageData.class);
+      for (EsLineageData lineage : lineageDataList) {
+        lineage.withToEntity(SearchUtils.getRelationshipRef(doc));
+        String fromEntityId = lineage.getFromEntity().getId().toString();
+        allEdges.computeIfAbsent(fromEntityId, k -> new ArrayList<>()).add(lineage);
+        collectNodesAndEdgesForDQ(
+            lineage.getFromEntity().getFullyQualifiedName(),
+            upstreamDepth - 1,
+            queryFilter,
+            deleted,
+            allEdges,
+            allNodes,
+            nodesWithFailure,
+            processedNode);
       }
     }
   }
@@ -1019,6 +1016,23 @@ public class OpenSearchSearchManager implements SearchManagementClient {
     sourceBuilderFactory.addConfiguredAggregationsV2(requestBuilder, assetConfig);
   }
 
+  /**
+   * Streams a SearchResponse straight to the HTTP output via a JSON generator over the response
+   * {@link java.io.OutputStream}, avoiding the intermediate full-size String that {@code
+   * toJsonString()} allocated and that OOM'd the node on very large documents. The body is
+   * re-serialized from the in-memory response on each write, so the returned {@link Response} can be
+   * written more than once (the caller-side cache buffers it before committing).
+   */
+  private Response streamSearchResponse(SearchResponse<JsonData> searchResponse) {
+    JsonpMapper mapper = client._transport().jsonpMapper();
+    return SearchResponseStreamer.stream(
+        output -> {
+          try (JsonGenerator generator = mapper.jsonProvider().createGenerator(output)) {
+            searchResponse.serialize(generator, mapper);
+          }
+        });
+  }
+
   public Response doSearch(
       org.openmetadata.schema.search.SearchRequest request,
       SubjectContext subjectContext,
@@ -1036,7 +1050,7 @@ public class OpenSearchSearchManager implements SearchManagementClient {
       SearchResponse<JsonData> searchResponse = client.search(searchRequest, JsonData.class);
 
       if (!Boolean.TRUE.equals(request.getIsHierarchy())) {
-        return Response.status(OK).entity(searchResponse.toJsonString()).build();
+        return streamSearchResponse(searchResponse);
       } else {
         List<?> response = buildSearchHierarchy(request, searchResponse, clusterAlias);
         return Response.status(OK).entity(response).build();
@@ -1591,7 +1605,7 @@ public class OpenSearchSearchManager implements SearchManagementClient {
         }
       }
 
-      return Response.status(Response.Status.OK).entity(searchResponse.toJsonString()).build();
+      return streamSearchResponse(searchResponse);
     } catch (Exception e) {
       LOG.error("Error in fallback search: {}", e.getMessage(), e);
       return Response.status(Response.Status.INTERNAL_SERVER_ERROR)

--- a/openmetadata-service/src/test/java/org/openmetadata/service/search/CapBufferingOutputStreamTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/search/CapBufferingOutputStreamTest.java
@@ -1,0 +1,122 @@
+/*
+ *  Copyright 2024 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.openmetadata.service.search;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import jakarta.json.spi.JsonProvider;
+import jakarta.json.stream.JsonGenerator;
+import jakarta.ws.rs.core.StreamingOutput;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import org.junit.jupiter.api.Test;
+import org.openmetadata.service.search.CapBufferingOutputStream.OverCapacityException;
+
+/**
+ * Verifies the cap semantics the search-response cache relies on: a small response is captured for
+ * caching, while an oversized one trips the cap so it is never fully materialized in heap. A unit
+ * test on this mechanism is exactly what would have caught the regression where streaming silently
+ * disabled the cache.
+ */
+class CapBufferingOutputStreamTest {
+
+  private static final int CAP = 16;
+
+  @Test
+  void capturesPayloadUnderTheCap() throws IOException {
+    String payload = "{\"hits\":1}";
+    CapBufferingOutputStream stream = new CapBufferingOutputStream(CAP);
+
+    stream.write(payload.getBytes(StandardCharsets.UTF_8));
+
+    assertEquals(payload, stream.toUtf8String());
+  }
+
+  @Test
+  void capturesPayloadExactlyAtTheCap() throws IOException {
+    byte[] payload = "0123456789abcdef".getBytes(StandardCharsets.UTF_8);
+    CapBufferingOutputStream stream = new CapBufferingOutputStream(CAP);
+
+    stream.write(payload);
+
+    assertEquals(CAP, stream.toUtf8String().length());
+  }
+
+  @Test
+  void abortsOnceTheCapIsExceededByABulkWrite() {
+    byte[] tooBig = new byte[CAP + 1];
+    CapBufferingOutputStream stream = new CapBufferingOutputStream(CAP);
+
+    assertThrows(OverCapacityException.class, () -> stream.write(tooBig));
+  }
+
+  @Test
+  void abortsOnceTheCapIsExceededAcrossMultipleWrites() throws IOException {
+    CapBufferingOutputStream stream = new CapBufferingOutputStream(CAP);
+    stream.write(new byte[CAP]);
+
+    assertThrows(OverCapacityException.class, () -> stream.write('x'));
+  }
+
+  @Test
+  void streamingOutputUnderCapIsCaptured() throws IOException {
+    String body = "{\"took\":3,\"hits\":{\"total\":0}}";
+    StreamingOutput streamingOutput = output -> output.write(body.getBytes(StandardCharsets.UTF_8));
+    CapBufferingOutputStream buffer = new CapBufferingOutputStream(1024);
+
+    streamingOutput.write(buffer);
+
+    assertEquals(body, buffer.toUtf8String());
+  }
+
+  @Test
+  void streamingOutputOverCapTripsTheCap() {
+    StreamingOutput oversized = output -> output.write(new byte[2048]);
+    CapBufferingOutputStream buffer = new CapBufferingOutputStream(1024);
+
+    assertThrows(OverCapacityException.class, () -> oversized.write(buffer));
+  }
+
+  @Test
+  void jsonGeneratorOverCapSurfacesOverCapacityInTheCauseChain() {
+    JsonProvider provider = JsonProvider.provider();
+    CapBufferingOutputStream buffer = new CapBufferingOutputStream(512);
+
+    Exception thrown =
+        assertThrows(
+            Exception.class,
+            () -> {
+              try (JsonGenerator generator = provider.createGenerator(buffer)) {
+                generator.writeStartArray();
+                for (int i = 0; i < 10_000; i++) {
+                  generator.write("a-reasonably-long-value-to-exceed-the-cap");
+                }
+                generator.writeEnd();
+              }
+            });
+
+    // The generator wraps the OutputStream failure, so the cap signal lives in the cause chain —
+    // this is the assumption the cache's oversize detection relies on.
+    assertTrue(hasOverCapacityCause(thrown));
+  }
+
+  private static boolean hasOverCapacityCause(Throwable error) {
+    Throwable cause = error;
+    while (cause != null && !(cause instanceof OverCapacityException)) {
+      cause = cause.getCause();
+    }
+    return cause != null;
+  }
+}

--- a/openmetadata-ui/src/main/resources/ui/src/components/AppBar/Suggestions.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/AppBar/Suggestions.tsx
@@ -375,7 +375,7 @@ const Suggestions = ({
         queryFilter: quickFilter,
         pageSize: PAGE_SIZE_BASE,
         includeDeleted: false,
-        excludeSourceFields: ['columns', 'queries', 'columnNames'],
+        excludeSourceFields: ['columns', 'queries', 'columnNames', 'dataModel'],
       });
 
       setOptions(res.hits.hits as unknown as Option[]);

--- a/openmetadata-ui/src/main/resources/ui/src/components/ServiceInsights/ServiceInsightsTab.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/ServiceInsights/ServiceInsightsTab.tsx
@@ -102,6 +102,9 @@ const ServiceInsightsTab = ({
       const response = await searchQuery({
         queryFilter: getServiceNameQueryFilter(serviceName),
         searchIndex: SearchIndex.ALL,
+        // Aggregation-only query: skip the hit payload entirely (no source, zero hits).
+        pageSize: 0,
+        fetchSource: false,
       });
 
       const assets = getAssetsByServiceType(serviceCategory);

--- a/openmetadata-ui/src/main/resources/ui/src/utils/EntitySummaryPanelUtilsV1.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/EntitySummaryPanelUtilsV1.tsx
@@ -495,13 +495,30 @@ const ContainerFieldCardsV1: React.FC<{
     if (!isUndefined(inlineColumns) || !containerFqn) {
       return;
     }
+    // Guard against a stale fetch: if the user switches containers while this request is in flight,
+    // ignore its result so the panel never shows the previous container's columns.
+    let cancelled = false;
     setIsColumnsLoading(true);
     getContainerByFQN(containerFqn, { fields: TabSpecificField.DATAMODEL })
-      .then((container) =>
-        setFetchedColumns(container.dataModel?.columns ?? [])
-      )
-      .catch(() => setFetchedColumns([]))
-      .finally(() => setIsColumnsLoading(false));
+      .then((container) => {
+        if (!cancelled) {
+          setFetchedColumns(container.dataModel?.columns ?? []);
+        }
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setFetchedColumns([]);
+        }
+      })
+      .finally(() => {
+        if (!cancelled) {
+          setIsColumnsLoading(false);
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
   }, [containerFqn, inlineColumns]);
 
   const columns = inlineColumns ?? fetchedColumns ?? [];

--- a/openmetadata-ui/src/main/resources/ui/src/utils/EntitySummaryPanelUtilsV1.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/EntitySummaryPanelUtilsV1.tsx
@@ -19,7 +19,7 @@ import {
   Table,
   Typography as AntTypography,
 } from 'antd';
-import { isEmpty } from 'lodash';
+import { isEmpty, isUndefined } from 'lodash';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { ReactComponent as NestedIcon } from '../assets/svg/nested.svg';
 import { FieldCard } from '../components/common/FieldCard';
@@ -28,7 +28,7 @@ import Loader from '../components/common/Loader/Loader';
 import '../components/Explore/EntitySummaryPanel/entity-summary-panel.less';
 import { SearchedDataProps } from '../components/SearchedData/SearchedData.interface';
 import { PAGE_SIZE_LARGE } from '../constants/constants';
-import { EntityType } from '../enums/entity.enum';
+import { EntityType, TabSpecificField } from '../enums/entity.enum';
 import { APICollection } from '../generated/entity/data/apiCollection';
 import { APIEndpoint } from '../generated/entity/data/apiEndpoint';
 import { Container } from '../generated/entity/data/container';
@@ -48,6 +48,7 @@ import {
   getDataModelColumnsByFQN,
   searchDataModelColumnsByFQN,
 } from '../rest/dataModelsAPI';
+import { getContainerByFQN } from '../rest/storageAPI';
 import {
   getTableColumnsByFQN,
   getTableList,
@@ -482,7 +483,28 @@ const ContainerFieldCardsV1: React.FC<{
   searchText?: string;
 }> = ({ entityInfo, highlights, loading, searchText }) => {
   const [expandedRowKeys, setExpandedRowKeys] = useState<string[]>([]);
-  const columns = entityInfo.dataModel?.columns || [];
+  const [fetchedColumns, setFetchedColumns] = useState<Column[]>();
+  const [isColumnsLoading, setIsColumnsLoading] = useState(false);
+
+  const inlineColumns = entityInfo.dataModel?.columns;
+  const containerFqn = entityInfo.fullyQualifiedName;
+
+  useEffect(() => {
+    // dataModel is excluded from Explore search payloads because it can be very large, so when it is
+    // absent on the search hit we fetch it on demand from the entity API.
+    if (!isUndefined(inlineColumns) || !containerFqn) {
+      return;
+    }
+    setIsColumnsLoading(true);
+    getContainerByFQN(containerFqn, { fields: TabSpecificField.DATAMODEL })
+      .then((container) =>
+        setFetchedColumns(container.dataModel?.columns ?? [])
+      )
+      .catch(() => setFetchedColumns([]))
+      .finally(() => setIsColumnsLoading(false));
+  }, [containerFqn, inlineColumns]);
+
+  const columns = inlineColumns ?? fetchedColumns ?? [];
 
   const filteredColumns = useMemo(
     () =>
@@ -498,7 +520,7 @@ const ContainerFieldCardsV1: React.FC<{
     );
   }, []);
 
-  if (loading) {
+  if (loading || isColumnsLoading) {
     return (
       <div className="flex-center p-lg">
         <Loader size="default" />

--- a/openmetadata-ui/src/main/resources/ui/src/utils/ExploreUtils.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/ExploreUtils.tsx
@@ -231,7 +231,12 @@ export const fetchEntityData = async ({
           pageNumber: page,
           pageSize: size,
           includeDeleted: showDeleted,
-          excludeSourceFields: ['columns', 'queries', 'columnNames'],
+          excludeSourceFields: [
+            'columns',
+            'queries',
+            'columnNames',
+            'dataModel',
+          ],
         };
 
         try {
@@ -272,7 +277,7 @@ export const fetchEntityData = async ({
         pageNumber: page,
         pageSize: size,
         includeDeleted: showDeleted,
-        excludeSourceFields: ['columns', 'queries', 'columnNames'],
+        excludeSourceFields: ['columns', 'queries', 'columnNames', 'dataModel'],
       };
 
       try {


### PR DESCRIPTION
Fixes #29210

## Problem

A single container/table with a very large `dataModel` (a legitimately wide/nested schema — observed in prod: 17 columns × ~43k children ≈ 736k columns, ~173 MB) produces a multi-hundred-MB search document. The search **read** path materialized the entire response into one in-memory `String` (`ElasticSearchSearchManager.serializeSearchResponse` via `StringWriter`, `OpenSearchSearchManager.toJsonString()`) — a second full-size copy on top of the already-parsed response object — and OOM'd the node under concurrency (`java.lang.OutOfMemoryError: Java heap space` in `SearchResource.search`).

The data is legitimate (customer-confirmed), so this is a system-scalability fix.

### Reproduced
A reproducer container shows the payload growth (and the exclusion mitigation):

| columns | `/search/query` response | with `exclude_source_fields=dataModel` |
|--:|--:|--:|
| 2,000 | 0.61 MB | 0.10 MB (6×) |
| 50,000 | **14.84 MB** | 1.39 MB (11×) |

Scaling toward ~736k columns reaches the ~170 MB document that OOMs.

## Changes

### Backend — stream instead of stringify
- **`SearchResponseStreamer`** serializes a response straight to the JAX-RS output stream (`StreamingOutput` + `JsonGenerator`), removing the intermediate full-size `String`. Clean exception handling (no broad catch, no redundant flush).
- Both `ElasticSearchSearchManager` and `OpenSearchSearchManager` route every verbatim hit-returning path (`doSearch` non-hierarchy, `searchByField`, `searchBySourceUrl`, NLQ, direct-query, fallback) through it.
- `collectNodesAndEdgesForDQ` in both managers now iterates `searchResponse.hits().hits()` directly (via `EsUtils`/`OsUtils.jsonDataToMap`) instead of serialize-to-String + JsonPath — a cleaner, allocation-free refactor.

### Backend — reconcile the response cache with streaming
The auth-aware search response cache (`CachedSearchLayer`) stores response bodies as `String`. Naively streaming would make the entity a `StreamingOutput` and silently disable the cache (permanent miss). Instead, **`SearchResource` buffers the streamed body into a size-capped `CapBufferingOutputStream` under the single-flight lock**:
- small responses (< 4 MB) are captured and cached — single-flight preserved, and errors surface *before* the response is committed;
- oversized responses (the 170 MB outlier) trip the cap, are left uncached, and stream straight through — memory stays bounded and the cache is never re-OOM'd.

### UI — keep the heavy field off listing payloads (lossless)
- Exclude `dataModel` from Explore listing (`ExploreUtils`) and global Suggestions payloads.
- The Explore schema tab for containers now fetches `dataModel` **on demand** via `getContainerByFQN`, so excluding it from search results is lossless.
- `ServiceInsightsTab.getDataAssetsCount` (aggregation-only) now passes `size: 0` / `fetchSource: false` instead of fetching 10 hit bodies.

## No feature loss
- Column-name search uses `columnNamesFuzzy` (separate field) — unaffected.
- Column Bulk Ops / Column Grid / detail pages read `dataModel` from the entity API or `_source` directly — unaffected.
- Audit confirmed the only Explore/Suggestions consumer of `dataModel` was the container schema tab (now fetched on demand). `AdvancedSearchPureUtils` column readers are dead code; DQ `ParameterForm` uses its own `includeFields` query.

## Tests
- **`CapBufferingOutputStreamTest`** (unit) — cap semantics + the JSON-P-wrapped `OverCapacityException` cause-chain the cache relies on.
- **`SearchStreamingIT`** — large `dataModel` (20k columns, > 4 MB) streams **complete, untruncated** JSON (all columns present), normal search valid, repeated searches consistent across the cache/bypass paths, and the response is cached when the cache is enabled.

## Verification
- `mvn spotless:check` ✓
- Unit tests 7/7 ✓
- `SearchStreamingIT` — **4/4 on mysql-elasticsearch** (cache test skipped, cache off), **5/5 on mysql-elasticsearch-redis** (cache test runs + passes against real Redis) ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a heap OOM in the search read path by streaming very large search responses (e.g. a container with 170 MB of `dataModel`) instead of materializing them into a full-size intermediate `String`. It also excludes `dataModel` from Explore/Suggestions listing queries and fetches it on demand when needed in the Explore summary panel.

- **`SearchResponseStreamer` + `CapBufferingOutputStream`**: New classes implement a buffer-or-stream strategy — small responses (< 4 MB) are serialized into a bounded buffer and returned as a cacheable `String`; over-cap responses fall back to `StreamingOutput` to avoid the heap spike. Both Elasticsearch and OpenSearch managers are routed through this path.
- **`SearchResource` caching integration**: The existing `String`-vs-`StreamingOutput` entity check is unchanged; small responses continue to be cached under the single-flight lock, and over-cap streaming responses bypass the cache but are still served correctly via `capturedResponse[0]`.
- **UI changes**: `dataModel` is excluded from Explore and Suggestions search payloads; `ContainerFieldCardsV1` fetches it on demand via `getContainerByFQN` with a cancellation guard to avoid stale results on rapid container switching.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the streaming path is well-isolated, the cache integration preserves existing behavior for normal responses, and both the unit and integration tests exercise the key boundary conditions.

The core bufferOrStream mechanism is simple and correct: it tries a bounded write, captures the string on success, and falls back to a proper StreamingOutput on overflow. The SearchResource caching logic was already designed around a String-vs-non-String entity check, so the new streaming path integrates cleanly without any changes to the caching layer itself. The UI on-demand fetch has a proper cancellation guard. No correctness issues found.

No files require special attention.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| openmetadata-service/src/main/java/org/openmetadata/service/search/SearchResponseStreamer.java | New class: implements the buffer-or-stream strategy cleanly; cause-chain traversal for OverCapacityException is correct; double-serialization on over-cap fallback is intentional and safe since the in-memory response object is re-serialized. |
| openmetadata-service/src/main/java/org/openmetadata/service/search/CapBufferingOutputStream.java | New class: cap semantics are correct (strict greater-than, so exactly maxBytes can be stored); write(byte[],int,int) checks before writing so no partial oversized chunk is buffered. |
| openmetadata-service/src/main/java/org/openmetadata/service/resources/search/SearchResource.java | Comment-only update: clarifies that the non-cacheable fallback now covers the over-cap (StreamingOutput) case in addition to error responses; existing String-vs-StreamingOutput entity check handles the new path correctly. |
| openmetadata-service/src/main/java/org/openmetadata/service/search/elasticsearch/ElasticSearchSearchManager.java | All hit-returning code paths now route through streamSearchResponse/SearchResponseStreamer.bufferOrStream; collectNodesAndEdgesForDQ refactored to iterate hits directly, avoiding the serialize-then-JsonPath round-trip. |
| openmetadata-service/src/main/java/org/openmetadata/service/search/opensearch/OpenSearchSearchManager.java | Symmetric with the Elasticsearch manager: all toJsonString() call sites replaced, collectNodesAndEdgesForDQ uses OsUtils.jsonDataToMap directly. |
| openmetadata-ui/src/main/resources/ui/src/utils/EntitySummaryPanelUtilsV1.tsx | ContainerFieldCardsV1 fetches dataModel on demand when absent from the search hit; cancellation guard (cancelled flag) prevents stale results on rapid container switching; isColumnsLoading guards the loader so stale fetchedColumns are never displayed. |
| openmetadata-service/src/test/java/org/openmetadata/service/search/CapBufferingOutputStreamTest.java | Thorough unit tests covering under-cap, exactly-at-cap, single bulk over-cap, incremental over-cap, and the JSON-P generator cause-chain wrapping that isOverCapacity relies on. |
| openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/SearchStreamingIT.java | Integration tests cover large-doc streaming completeness, small-doc validity, repeated-search consistency across cache/bypass paths, and the cache write+hit flow. |
| openmetadata-ui/src/main/resources/ui/src/components/AppBar/Suggestions.tsx | dataModel added to excludeSourceFields in the global Suggestions query; change is lossless since suggestions never rendered container schema columns. |
| openmetadata-ui/src/main/resources/ui/src/components/ServiceInsights/ServiceInsightsTab.tsx | pageSize: 0 and fetchSource: false added to the aggregation-only asset count query; correct optimization since getDataAssetsCount only reads aggregation buckets, not hit bodies. |
| openmetadata-ui/src/main/resources/ui/src/utils/ExploreUtils.tsx | dataModel added to excludeSourceFields for both search branches in fetchEntityData; consistent with Suggestions.tsx change. |

</details>


</details>


<details open><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[SearchResource.search] -->|cacheable user| B[CachedSearchLayer.loadOrCompute]
    B -->|supplier runs| C[searchRepository.search]
    C --> D{ElasticSearch / OpenSearch\nstreamSearchResponse}
    D --> E[SearchResponseStreamer.bufferOrStream]
    E --> F[writer.writeTo CapBufferingOutputStream]
    F -->|size ≤ 4 MB| G[Response with String entity]
    F -->|size > 4 MB → OverCapacityException| H[onBufferFailure → stream writer]
    H --> I[Response with StreamingOutput entity]
    G -->|entity instanceof String| J[body cached & returned]
    I -->|entity not String → null| K[capturedResponse stored]
    K -->|first caller| L[StreamingOutput streamed directly]
    K -->|concurrent caller, body=null| M[fallback: fresh search call]
    J --> N[Client receives complete JSON]
    L --> N
    M --> N
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[SearchResource.search] -->|cacheable user| B[CachedSearchLayer.loadOrCompute]
    B -->|supplier runs| C[searchRepository.search]
    C --> D{ElasticSearch / OpenSearch\nstreamSearchResponse}
    D --> E[SearchResponseStreamer.bufferOrStream]
    E --> F[writer.writeTo CapBufferingOutputStream]
    F -->|size ≤ 4 MB| G[Response with String entity]
    F -->|size > 4 MB → OverCapacityException| H[onBufferFailure → stream writer]
    H --> I[Response with StreamingOutput entity]
    G -->|entity instanceof String| J[body cached & returned]
    I -->|entity not String → null| K[capturedResponse stored]
    K -->|first caller| L[StreamingOutput streamed directly]
    K -->|concurrent caller, body=null| M[fallback: fresh search call]
    J --> N[Client receives complete JSON]
    L --> N
    M --> N
```

</a>
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `openmetadata-service/src/main/java/org/openmetadata/service/resources/search/SearchResource.java`, line 327-331 ([link](https://github.com/open-metadata/openmetadata/blob/a010e0c2f8fb47be53b680d497d6fe6025540833/openmetadata-service/src/main/java/org/openmetadata/service/resources/search/SearchResource.java#L327-L331)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> Misleading comment understates when the fallback fires. The comment says "only affects the second+ caller of a query that's currently returning errors," but this fallback fires for any non-cacheable outcome — including normal over-cap responses (the 170 MB container case). Under high concurrency on the same large query, every waiting caller (not just error paths) executes a fresh `searchRepository.search()`. The existing behavior is acceptable and was the pre-cache behavior anyway, but the comment should say "non-cacheable outcome (non-200 status or response too large to cache)" so it accurately describes the over-cap case that is now the main trigger.

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (3): Last reviewed commit: ["Merge branch &#39;main&#39; into harshach/stream..."](https://github.com/open-metadata/openmetadata/commit/06211602dfef70030851991e31392f988b89af72) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38474378)</sub>

<!-- /greptile_comment -->
