### PR TITLE
Remove content/column name split for classification

### DIFF
--- a/bootstrap/sql/migrations/native/1.13.0/mysql/postDataMigrationSQLScript.sql
+++ b/bootstrap/sql/migrations/native/1.13.0/mysql/postDataMigrationSQLScript.sql
@@ -123,3 +123,24 @@ WHERE JSON_VALUE(json, '$.classification.name' RETURNING CHAR) = 'PII'
     JSON_EXTRACT(json, '$.autoClassificationEnabled') IS NULL
     OR JSON_EXTRACT(json, '$.autoClassificationEnabled') = false
   );
+
+-- Remove default column_name recognizers from PII tags (no longer used as boosters)
+UPDATE tag
+SET json = JSON_SET(
+    json,
+    '$.recognizers',
+    COALESCE(
+        (
+            SELECT JSON_ARRAYAGG(r)
+            FROM JSON_TABLE(
+                JSON_EXTRACT(json, '$.recognizers'),
+                '$[*]' COLUMNS (r JSON PATH '$')
+            ) AS jt
+            WHERE JSON_VALUE(r, '$.target') != 'column_name'
+        ),
+        JSON_ARRAY()
+    )
+)
+WHERE JSON_VALUE(json, '$.classification.name' RETURNING CHAR) = 'PII'
+  AND JSON_VALUE(json, '$.name' RETURNING CHAR) IN ('NonSensitive', 'Sensitive')
+  AND JSON_SEARCH(json, 'one', 'column_name', NULL, '$.recognizers[*].target') IS NOT NULL;

--- a/bootstrap/sql/migrations/native/1.13.0/mysql/postDataMigrationSQLScript.sql
+++ b/bootstrap/sql/migrations/native/1.13.0/mysql/postDataMigrationSQLScript.sql
@@ -136,7 +136,7 @@ SET json = JSON_SET(
                 JSON_EXTRACT(json, '$.recognizers'),
                 '$[*]' COLUMNS (r JSON PATH '$')
             ) AS jt
-            WHERE JSON_VALUE(r, '$.target') != 'column_name'
+            WHERE JSON_VALUE(r, '$.target') IS NULL OR JSON_VALUE(r, '$.target') != 'column_name'
         ),
         JSON_ARRAY()
     )

--- a/bootstrap/sql/migrations/native/1.13.0/postgres/postDataMigrationSQLScript.sql
+++ b/bootstrap/sql/migrations/native/1.13.0/postgres/postDataMigrationSQLScript.sql
@@ -125,4 +125,25 @@ WHERE json->'classification'->>'name' = 'PII'
     json->>'autoClassificationEnabled' IS NULL
     OR (json->>'autoClassificationEnabled')::boolean = false
   );
-  
+
+-- Remove default column_name recognizers from PII tags (no longer used as boosters)
+UPDATE tag
+SET json = jsonb_set(
+    json::jsonb,
+    '{recognizers}',
+    COALESCE(
+        (
+            SELECT jsonb_agg(r)
+            FROM jsonb_array_elements(json::jsonb->'recognizers') AS r
+            WHERE r->>'target' != 'column_name'
+        ),
+        '[]'::jsonb
+    )
+)::json
+WHERE json->'classification'->>'name' = 'PII'
+  AND json->>'name' IN ('NonSensitive', 'Sensitive')
+  AND EXISTS (
+    SELECT 1
+    FROM jsonb_array_elements(json::jsonb->'recognizers') AS r
+    WHERE r->>'target' = 'column_name'
+  );

--- a/bootstrap/sql/migrations/native/1.13.0/postgres/postDataMigrationSQLScript.sql
+++ b/bootstrap/sql/migrations/native/1.13.0/postgres/postDataMigrationSQLScript.sql
@@ -135,7 +135,7 @@ SET json = jsonb_set(
         (
             SELECT jsonb_agg(r)
             FROM jsonb_array_elements(json::jsonb->'recognizers') AS r
-            WHERE r->>'target' != 'column_name'
+            WHERE r->>'target' IS NULL OR r->>'target' != 'column_name'
         ),
         '[]'::jsonb
     )

--- a/ingestion/src/metadata/pii/algorithms/tag_scoring.py
+++ b/ingestion/src/metadata/pii/algorithms/tag_scoring.py
@@ -58,7 +58,7 @@ class TagScorer:
     def predict_scores(
         self,
         sample_data: Sequence[Any],
-        column_name: Optional[str] = None,  # noqa: UP045
+        run_column_analysis: bool = False,
         _column_data_type: Optional[DataType] = None,  # noqa: UP045
     ) -> List[ScoredTag]:  # noqa: UP006
         str_values = preprocess_values(sample_data)
@@ -68,21 +68,18 @@ class TagScorer:
             len(unique_values) / len(str_values) >= self._relative_cardinality_cutoff
         )
 
-        if not has_valid_content and column_name is None:
+        if not has_valid_content and not run_column_analysis:
             return []
 
         results: List[ScoredTag] = []  # noqa: UP006
         for analyzer in self._analyzers:
             analysis = analyzer.analyze(
                 str_values=str_values if has_valid_content else [],
-                column_name=column_name,
+                run_column_analysis=run_column_analysis,
             )
 
             if analysis.score > self._score_cutoff:
-                recognizer_metadata = self._build_recognizer_metadata(
-                    analysis=analysis,
-                    total_score=analysis.score,
-                )
+                recognizer_metadata = self._build_recognizer_metadata(analysis)
 
                 results.append(
                     ScoredTag(
@@ -98,7 +95,6 @@ class TagScorer:
     def _build_recognizer_metadata(
         self,
         analysis: TagAnalysis,
-        total_score: float,
     ) -> Optional[TagLabelRecognizerMetadata]:  # noqa: UP045
         if not analysis.recognizer_results:
             return None
@@ -147,7 +143,7 @@ class TagScorer:
         return TagLabelRecognizerMetadata(
             recognizerId=recognizer_id,
             recognizerName=recognizer_name,
-            score=min(total_score, 1),
+            score=min(analysis.score, 1),
             target=TARGET_MAP[analysis.target] if analysis.target else None,
             patterns=pattern_matches if pattern_matches else None,
         )
@@ -180,9 +176,8 @@ class ScoreTagsForColumnService:
         )
 
         classifier = TagScorer(tag_analyzers=tag_analyzers)
-        column_name_str = column.fullyQualifiedName.root if column.fullyQualifiedName else None
         return classifier.predict_scores(
             sample_data=data,
-            column_name=column_name_str,
+            run_column_analysis=column.fullyQualifiedName is not None,
             _column_data_type=column.dataType,
         )

--- a/ingestion/src/metadata/pii/algorithms/tag_scoring.py
+++ b/ingestion/src/metadata/pii/algorithms/tag_scoring.py
@@ -45,7 +45,6 @@ class TagScorer:
         self,
         *,
         tag_analyzers: Iterable[TagAnalyzer],
-        column_name_contribution: float = 0.5,
         score_cutoff: float = 0.1,
         relative_cardinality_cutoff: float = 0.01,
     ):
@@ -53,7 +52,6 @@ class TagScorer:
 
         self._analyzers = list(tag_analyzers)
 
-        self._column_name_contribution = column_name_contribution
         self._score_cutoff = score_cutoff
         self._relative_cardinality_cutoff = relative_cardinality_cutoff
 
@@ -65,74 +63,47 @@ class TagScorer:
     ) -> List[ScoredTag]:  # noqa: UP006
         str_values = preprocess_values(sample_data)
 
-        if not str_values:
-            return []
-
-        # Relative cardinality test
         unique_values = set(str_values)
-        if len(unique_values) / len(str_values) < self._relative_cardinality_cutoff:
+        has_valid_content = bool(str_values) and (
+            len(unique_values) / len(str_values) >= self._relative_cardinality_cutoff
+        )
+
+        if not has_valid_content and column_name is None:
             return []
 
         results: List[ScoredTag] = []  # noqa: UP006
         for analyzer in self._analyzers:
-            content_analysis = analyzer.analyze_content(values=str_values)
-            content_score = content_analysis.score
+            analysis = analyzer.analyze(
+                str_values=str_values if has_valid_content else [],
+                column_name=column_name,
+            )
 
-            column_analysis = None
-            column_score = 0.0
-            if column_name is not None:
-                column_analysis = analyzer.analyze_column()
-                column_score = column_analysis.score
-
-                column_score *= max(column_score, self._column_name_contribution)
-
-            total_score = content_score + column_score
-            if total_score > self._score_cutoff:
-                reason = self._build_reason(
-                    content_analysis=content_analysis,
-                    column_analysis=column_analysis,
-                )
-
+            if analysis.score > self._score_cutoff:
                 recognizer_metadata = self._build_recognizer_metadata(
-                    content_analysis=content_analysis,
-                    total_score=total_score,
+                    analysis=analysis,
+                    total_score=analysis.score,
                 )
 
-                scored_tag = ScoredTag(
-                    tag=analyzer.tag,
-                    score=total_score,
-                    reason=reason,
-                    recognizer_metadata=recognizer_metadata,
+                results.append(
+                    ScoredTag(
+                        tag=analyzer.tag,
+                        score=analysis.score,
+                        reason=analysis.explanation or "",
+                        recognizer_metadata=recognizer_metadata,
+                    )
                 )
-
-                results.append(scored_tag)
 
         return results
 
-    def _build_reason(self, content_analysis: TagAnalysis, column_analysis: Optional[TagAnalysis]) -> str:  # noqa: UP045
-        """Build a human-readable reason for why this tag was matched."""
-        reason = f"Content analysis:\n{content_analysis.explanation}\n"
-
-        if column_analysis is not None and column_analysis.explanation is not None:
-            reason += f"Column analysis:\n{column_analysis.explanation}\n"
-
-        return reason
-
     def _build_recognizer_metadata(
         self,
-        content_analysis: TagAnalysis,
+        analysis: TagAnalysis,
         total_score: float,
     ) -> Optional[TagLabelRecognizerMetadata]:  # noqa: UP045
-        """Build recognizer metadata from the primary (highest scoring) analysis."""
-
-        if not content_analysis or not content_analysis.recognizer_results:
+        if not analysis.recognizer_results:
             return None
 
-        results = content_analysis.recognizer_results
-        if not results:
-            return None
-
-        first_result = results[0]
+        first_result = analysis.recognizer_results[0]
         recognition_metadata = cast(Dict[str, str], first_result.recognition_metadata)  # noqa: TC006, UP006
 
         recognizer_name = recognition_metadata.get(
@@ -144,7 +115,7 @@ class TagScorer:
         )
 
         patterns_matched: Set[Tuple[str, str, float]] = set()  # noqa: UP006
-        for result in results:
+        for result in analysis.recognizer_results:
             if result.analysis_explanation and result.analysis_explanation.pattern:
                 patterns_matched.add(
                     (
@@ -160,7 +131,7 @@ class TagScorer:
         ]
 
         recognizer_id = None
-        for recognizer_config in content_analysis.tag.recognizers or []:
+        for recognizer_config in analysis.tag.recognizers or []:
             if isinstance(recognizer_config.recognizerConfig.root, PredefinedRecognizer):
                 name = recognizer_config.recognizerConfig.root.name.value
             else:
@@ -177,7 +148,7 @@ class TagScorer:
             recognizerId=recognizer_id,
             recognizerName=recognizer_name,
             score=min(total_score, 1),
-            target=TARGET_MAP[content_analysis.target] if content_analysis.target else None,
+            target=TARGET_MAP[analysis.target] if analysis.target else None,
             patterns=pattern_matches if pattern_matches else None,
         )
 

--- a/ingestion/src/metadata/pii/tag_analyzer.py
+++ b/ingestion/src/metadata/pii/tag_analyzer.py
@@ -203,39 +203,42 @@ class TagAnalyzer:
                 )
         return results
 
-    def analyze_content(self, values: Sequence[str]) -> TagAnalysis:
-        recognizers = self.content_recognizers
-
-        if not recognizers:
-            return self._build_tag_analysis([], 1, recognizer.Target.content)
-
-        context = split_column_name(self._column_name)
-        results = self._analyze_with(values, recognizers, context=context)
-
-        return self._build_tag_analysis(results, len(values), recognizer.Target.content)
-
-    def analyze_column(self) -> TagAnalysis:
-        recognizers = self.column_recognizers
-
-        if not recognizers:
-            return self._build_tag_analysis([], 1, recognizer.Target.column_name)
-
-        results = self._analyze_with(self._column_name, recognizers)
-
-        return self._build_tag_analysis(results, 1, recognizer.Target.column_name)
-
-    def _build_tag_analysis(
+    def analyze(
         self,
-        results: list[RecognizerResult],
-        analysis_count: int,
-        target: recognizer.Target,
+        str_values: Sequence[str],
+        column_name: Optional[str] = None,  # noqa: UP045
     ) -> TagAnalysis:
+        content_results: list[RecognizerResult] = []
+        content_score = 0.0
+        if str_values:
+            content_recognizers = self.content_recognizers
+            if content_recognizers:
+                context = split_column_name(self._column_name)
+                content_results = self._analyze_with(str_values, content_recognizers, context=context)
+                content_score = sum(r.score for r in content_results) / len(str_values)
+
+        column_results: list[RecognizerResult] = []
+        column_score = 0.0
+        if column_name is not None:
+            column_recognizers = self.column_recognizers
+            if column_recognizers:
+                column_results = self._analyze_with(self._column_name, column_recognizers)
+                column_score = sum(r.score for r in column_results)
+
+        all_results = content_results + column_results
+        score = max(content_score, column_score)
+        target = (
+            recognizer.Target.column_name
+            if column_score >= content_score and column_results
+            else recognizer.Target.content
+        )
+
         return TagAnalysis(
             tag=self.tag,
-            score=sum(r.score for r in results) / analysis_count,
-            explanation=explain_recognition_results(results) if results else None,
-            recognizer_results=results,
-            target=target,
+            score=score,
+            explanation=explain_recognition_results(all_results) if all_results else None,
+            recognizer_results=all_results,
+            target=target if all_results else None,
         )
 
     def __repr__(self) -> str:

--- a/ingestion/src/metadata/pii/tag_analyzer.py
+++ b/ingestion/src/metadata/pii/tag_analyzer.py
@@ -228,14 +228,15 @@ class TagAnalyzer:
         column_wins = column_score >= content_score and bool(column_results)
         score = max(content_score, column_score)
         target = recognizer.Target.column_name if column_wins else recognizer.Target.content
+        winning_results = column_results if column_wins else content_results
         all_results = (column_results + content_results) if column_wins else (content_results + column_results)
 
         return TagAnalysis(
             tag=self.tag,
             score=score,
             explanation=explain_recognition_results(all_results) if all_results else None,
-            recognizer_results=all_results,
-            target=target if all_results else None,
+            recognizer_results=winning_results,
+            target=target if winning_results else None,
         )
 
     def __repr__(self) -> str:

--- a/ingestion/src/metadata/pii/tag_analyzer.py
+++ b/ingestion/src/metadata/pii/tag_analyzer.py
@@ -206,7 +206,7 @@ class TagAnalyzer:
     def analyze(
         self,
         str_values: Sequence[str],
-        column_name: Optional[str] = None,  # noqa: UP045
+        run_column_analysis: bool = False,
     ) -> TagAnalysis:
         content_results: list[RecognizerResult] = []
         content_score = 0.0
@@ -219,19 +219,16 @@ class TagAnalyzer:
 
         column_results: list[RecognizerResult] = []
         column_score = 0.0
-        if column_name is not None:
+        if run_column_analysis:
             column_recognizers = self.column_recognizers
             if column_recognizers:
                 column_results = self._analyze_with(self._column_name, column_recognizers)
                 column_score = sum(r.score for r in column_results)
 
-        all_results = content_results + column_results
+        column_wins = column_score >= content_score and bool(column_results)
         score = max(content_score, column_score)
-        target = (
-            recognizer.Target.column_name
-            if column_score >= content_score and column_results
-            else recognizer.Target.content
-        )
+        target = recognizer.Target.column_name if column_wins else recognizer.Target.content
+        all_results = (column_results + content_results) if column_wins else (content_results + column_results)
 
         return TagAnalysis(
             tag=self.tag,

--- a/ingestion/src/metadata/pii/tag_analyzer.py
+++ b/ingestion/src/metadata/pii/tag_analyzer.py
@@ -215,7 +215,7 @@ class TagAnalyzer:
             if content_recognizers:
                 context = split_column_name(self._column_name)
                 content_results = self._analyze_with(str_values, content_recognizers, context=context)
-                content_score = sum(r.score for r in content_results) / len(str_values)
+                content_score = min(sum(r.score for r in content_results) / len(str_values), 1.0)
 
         column_results: list[RecognizerResult] = []
         column_score = 0.0
@@ -223,7 +223,7 @@ class TagAnalyzer:
             column_recognizers = self.column_recognizers
             if column_recognizers:
                 column_results = self._analyze_with(self._column_name, column_recognizers)
-                column_score = sum(r.score for r in column_results)
+                column_score = min(sum(r.score for r in column_results), 1.0)
 
         column_wins = column_score >= content_score and bool(column_results)
         score = max(content_score, column_score)

--- a/ingestion/tests/unit/metadata/pii/test_language_filtering.py
+++ b/ingestion/tests/unit/metadata/pii/test_language_filtering.py
@@ -117,12 +117,7 @@ class TestScoreTagsForColumnServiceLanguage:
 
         with patch("metadata.pii.algorithms.tag_scoring.TagAnalyzer") as mock_tag_analyzer_class:
             mock_analyzer_instance = Mock()
-            mock_analyzer_instance.analyze_content.return_value = TagAnalysis(
-                tag=sample_tag, score=0.5, explanation="test"
-            )
-            mock_analyzer_instance.analyze_column.return_value = TagAnalysis(
-                tag=sample_tag, score=0.3, explanation="test"
-            )
+            mock_analyzer_instance.analyze.return_value = TagAnalysis(tag=sample_tag, score=0.5, explanation="test")
             mock_analyzer_instance.tag = sample_tag
             mock_tag_analyzer_class.return_value = mock_analyzer_instance
 

--- a/ingestion/tests/unit/metadata/pii/test_tag_analyzer_any_language.py
+++ b/ingestion/tests/unit/metadata/pii/test_tag_analyzer_any_language.py
@@ -317,7 +317,7 @@ class TestAnalyzeWithAnyLanguage:
             nlp_engine=mock_nlp_engine,
             language=ClassificationLanguage.any,
         )
-        result = analyzer.analyze(str_values=[], column_name="email_address")
+        result = analyzer.analyze(str_values=[], run_column_analysis=True)
         assert result is not None
 
 

--- a/ingestion/tests/unit/metadata/pii/test_tag_analyzer_any_language.py
+++ b/ingestion/tests/unit/metadata/pii/test_tag_analyzer_any_language.py
@@ -236,7 +236,7 @@ class TestAnalyzeWithAnyLanguage:
 
         analyzer.build_analyzer_with = tracking_build
 
-        result = analyzer.analyze_content(["john@example.com"])  # noqa: F841
+        result = analyzer.analyze(str_values=["john@example.com"])  # noqa: F841
 
         assert len(build_calls) == 1
         _, used_nlp_engine = build_calls[0]
@@ -253,7 +253,7 @@ class TestAnalyzeWithAnyLanguage:
             nlp_engine=mock_nlp_engine,
             language=ClassificationLanguage.any,
         )
-        result = analyzer.analyze_content(["test@example.com", "not-an-email"])
+        result = analyzer.analyze(str_values=["test@example.com", "not-an-email"])
         assert result is not None
         assert result.score >= 0
 
@@ -270,7 +270,7 @@ class TestAnalyzeWithAnyLanguage:
             nlp_engine=mock_nlp_engine,
             language=ClassificationLanguage.any,
         )
-        result = analyzer.analyze_content(["some data"])
+        result = analyzer.analyze(str_values=["some data"])
         assert result.score == 0
         assert result.recognizer_results == []
 
@@ -317,7 +317,7 @@ class TestAnalyzeWithAnyLanguage:
             nlp_engine=mock_nlp_engine,
             language=ClassificationLanguage.any,
         )
-        result = analyzer.analyze_column()
+        result = analyzer.analyze(str_values=[], column_name="email_address")
         assert result is not None
 
 

--- a/ingestion/tests/unit/metadata/pii/test_tag_analyzer_any_language.py
+++ b/ingestion/tests/unit/metadata/pii/test_tag_analyzer_any_language.py
@@ -406,7 +406,7 @@ class TestAnalyzeWithAnyLanguageRecognizerRealPresidia:
         return _make_any_language_tag(pii_classification)
 
     def test_any_language_recognizer_does_not_raise_with_specific_language_agent(self, any_language_email_tag, column):
-        """When agent language is 'en' and recognizer is 'any', analyze_content must
+        """When agent language is 'en' and recognizer is 'any', analyze() must
         not raise ValueError from Presidio's registry."""
         nlp = _make_presidio_nlp_mock()
         analyzer = TagAnalyzer(
@@ -415,7 +415,7 @@ class TestAnalyzeWithAnyLanguageRecognizerRealPresidia:
             nlp_engine=nlp,
             language=ClassificationLanguage.en,
         )
-        result = analyzer.analyze_content(["user@example.com", "not-an-email"])
+        result = analyzer.analyze(str_values=["user@example.com", "not-an-email"])
         assert result is not None
 
     def test_any_language_recognizer_matches_content_with_specific_language_agent(self, any_language_email_tag, column):
@@ -427,7 +427,7 @@ class TestAnalyzeWithAnyLanguageRecognizerRealPresidia:
             nlp_engine=nlp,
             language=ClassificationLanguage.en,
         )
-        result = analyzer.analyze_content(["user@example.com"])
+        result = analyzer.analyze(str_values=["user@example.com"])
         assert result.score > 0
 
     def test_any_language_recognizer_no_match_scores_zero(self, any_language_email_tag, column):
@@ -439,7 +439,7 @@ class TestAnalyzeWithAnyLanguageRecognizerRealPresidia:
             nlp_engine=nlp,
             language=ClassificationLanguage.en,
         )
-        result = analyzer.analyze_content(["no-match-here", "also-not-an-email"])
+        result = analyzer.analyze(str_values=["no-match-here", "also-not-an-email"])
         assert result.score == 0
 
     def test_any_language_recognizer_with_fr_agent_does_not_raise(self, any_language_email_tag, column):
@@ -451,7 +451,7 @@ class TestAnalyzeWithAnyLanguageRecognizerRealPresidia:
             nlp_engine=nlp,
             language=ClassificationLanguage.fr,
         )
-        result = analyzer.analyze_content(["user@example.com", "not-an-email"])
+        result = analyzer.analyze(str_values=["user@example.com", "not-an-email"])
         assert result is not None
 
     def test_any_language_recognizer_matches_content_with_fr_agent(self, any_language_email_tag, column):
@@ -463,7 +463,7 @@ class TestAnalyzeWithAnyLanguageRecognizerRealPresidia:
             nlp_engine=nlp,
             language=ClassificationLanguage.fr,
         )
-        result = analyzer.analyze_content(["user@example.com"])
+        result = analyzer.analyze(str_values=["user@example.com"])
         assert result.score > 0
 
     def test_any_agent_with_any_recognizer_scores_on_match(self, any_language_email_tag, column):
@@ -479,5 +479,5 @@ class TestAnalyzeWithAnyLanguageRecognizerRealPresidia:
             nlp_engine=MagicMock(),
             language=ClassificationLanguage.any,
         )
-        result = analyzer.analyze_content(["user@example.com"])
+        result = analyzer.analyze(str_values=["user@example.com"])
         assert result.score > 0

--- a/ingestion/tests/unit/metadata/pii/test_tag_processor.py
+++ b/ingestion/tests/unit/metadata/pii/test_tag_processor.py
@@ -351,9 +351,7 @@ class TestTagProcessor:
         processor = TagProcessor(
             config=workflow_config,
             metadata=mock_metadata,
-            classification_manager=classification_manager.extend(
-                (pii_classification, [mixed_tag]),
-            ),
+            classification_manager=FakeClassificationManager((pii_classification, [mixed_tag])),
             score_tags_for_column=score_tags_for_column,
         )
 

--- a/ingestion/tests/unit/metadata/pii/test_tag_scoring.py
+++ b/ingestion/tests/unit/metadata/pii/test_tag_scoring.py
@@ -164,7 +164,6 @@ class TestTagScorer:
         """Create a TagClassifier instance with tag analyzers"""
         return TagScorer(
             tag_analyzers=tag_analyzers,
-            column_name_contribution=0.5,
             score_cutoff=0.1,
             relative_cardinality_cutoff=0.01,
         )
@@ -237,11 +236,9 @@ class TestTagScorer:
 
     def test_score_cutoff_filtering(self, tag_analyzers):
         """Test that scores below cutoff are filtered"""
-        # Create a classifier with high cutoff
         high_cutoff_classifier = TagScorer(
             tag_analyzers=tag_analyzers,
-            column_name_contribution=0.5,
-            score_cutoff=0.95,  # Very high cutoff
+            score_cutoff=0.95,
             relative_cardinality_cutoff=0.01,
         )
 
@@ -251,19 +248,23 @@ class TestTagScorer:
         # With such a high cutoff, weak matches should be filtered
         assert len(scored_tags) == 0 or all(scored_tag.score >= 0.95 for scored_tag in scored_tags)
 
-    def test_column_name_contribution(self, classifier):
-        """Test that column name contributes to score"""
-        email_data = ["user1@domain.com", "user2@domain.org"]
+    def test_column_name_only_classifies_independently(self, email_tag, nlp_engine):
+        """Column name recognizer fires on its own without any sample data."""
+        column = Column(
+            name=ColumnName(root="email_address"),
+            dataType=DataType.STRING,
+            fullyQualifiedName="test.table.email_address",
+        )
+        analyzer = TagAnalyzer(tag=email_tag, column=column, nlp_engine=nlp_engine)
+        scorer = TagScorer(tag_analyzers=[analyzer], score_cutoff=0.1)
 
-        # First without column name match
-        scores_without = classifier.predict_scores(email_data, column_name="random_field")
+        scores = scorer.predict_scores([], column_name="email_address")
 
-        # Then with column name that matches email pattern
-        scores_with = classifier.predict_scores(email_data, column_name="email_address")
-
-        # Email tag should have higher score when column name matches
-        if "PII.EmailTag" in scores_with and "PII.EmailTag" in scores_without:
-            assert scores_with["PII.EmailTag"] >= scores_without["PII.EmailTag"]
+        assert len(scores) == 1
+        assert scores[0] == IsInstance(ScoredTag) & HasAttributes(
+            tag=IsInstance(Tag) & HasAttributes(name=EntityName(root="EmailTag")),
+            score=IsNumeric(gt=0.5),
+        )
 
 
 class TestTagAnalyzer:
@@ -320,7 +321,7 @@ class TestTagAnalyzer:
     def test_analyze_content_with_emails(self, tag_analyzer, email_tag: Tag):
         """Test content analysis with email data"""
         values = ["john@example.com", "jane@test.org", "bob@company.co.uk"]
-        analysis = tag_analyzer.analyze_content(values)
+        analysis = tag_analyzer.analyze(str_values=values)
         assert analysis == IsInstance(TagAnalysis) & HasAttributes(
             score=IsFloat(gt=0.8),
             tag=email_tag,
@@ -334,7 +335,7 @@ class TestTagAnalyzer:
     def test_analyze_content_no_match(self, tag_analyzer, email_tag: Tag):
         """Test content analysis with non-matching data"""
         values = ["random text", "no patterns here", "just words"]
-        analysis = tag_analyzer.analyze_content(values)
+        analysis = tag_analyzer.analyze(str_values=values)
         assert analysis == IsInstance(TagAnalysis) & HasAttributes(
             score=0.0,
             tag=email_tag,
@@ -342,8 +343,7 @@ class TestTagAnalyzer:
         )
 
     def test_analyze_column_name(self, email_tag, nlp_engine):
-        """Test column name analysis"""
-        # Create column with email-related name
+        """Test column name analysis fires independently via the unified analyze() method."""
         column = Column(
             name=ColumnName(root="email_address"),
             displayName="Email Address",
@@ -351,7 +351,6 @@ class TestTagAnalyzer:
             fullyQualifiedName="test.table.email_address",
         )
 
-        # Add column name recognizer to tag
         column_name_pattern = PatternFactory.create(
             name="Email column pattern",
             regex=".*email.*",
@@ -374,7 +373,7 @@ class TestTagAnalyzer:
         email_tag.recognizers.append(column_name_recognizer)
 
         analyzer = TagAnalyzer(tag=email_tag, column=column, nlp_engine=nlp_engine)
-        analysis = analyzer.analyze_column()
+        analysis = analyzer.analyze(str_values=[], column_name="email_address")
         assert analysis == IsInstance(TagAnalysis) & HasAttributes(
             score=IsFloat(gt=0.5),
             tag=email_tag,

--- a/ingestion/tests/unit/metadata/pii/test_tag_scoring.py
+++ b/ingestion/tests/unit/metadata/pii/test_tag_scoring.py
@@ -176,7 +176,7 @@ class TestTagScorer:
             "bob@company.co.uk",
         ]
 
-        scores = classifier.predict_scores(sample_data, column_name="customer_email")
+        scores = classifier.predict_scores(sample_data, run_column_analysis=True)
 
         assert len(scores) == 1
         scored_tag = scores[0]
@@ -195,7 +195,7 @@ class TestTagScorer:
         """Test classification with phone data using TagAnalyzer"""
         sample_data = ["555-123-4567", "555.987.6543", "5551234567"]
 
-        scores = classifier.predict_scores(sample_data, column_name="contact_phone")
+        scores = classifier.predict_scores(sample_data, run_column_analysis=True)
 
         assert len(scores) == 1
         scored_tag = scores[0]
@@ -229,7 +229,7 @@ class TestTagScorer:
             "Email support@company.org or call 555.987.6543",
         ]
 
-        scores = classifier.predict_scores(sample_data, column_name="contact_info")
+        scores = classifier.predict_scores(sample_data, run_column_analysis=True)
 
         # Should detect patterns through tag analyzers
         assert len(scores) > 0
@@ -243,7 +243,7 @@ class TestTagScorer:
         )
 
         sample_data = ["maybe an email@somewhere", "could be phone 123456"]
-        scored_tags = high_cutoff_classifier.predict_scores(sample_data, column_name="data")
+        scored_tags = high_cutoff_classifier.predict_scores(sample_data, run_column_analysis=True)
 
         # With such a high cutoff, weak matches should be filtered
         assert len(scored_tags) == 0 or all(scored_tag.score >= 0.95 for scored_tag in scored_tags)
@@ -258,7 +258,7 @@ class TestTagScorer:
         analyzer = TagAnalyzer(tag=email_tag, column=column, nlp_engine=nlp_engine)
         scorer = TagScorer(tag_analyzers=[analyzer], score_cutoff=0.1)
 
-        scores = scorer.predict_scores([], column_name="email_address")
+        scores = scorer.predict_scores([], run_column_analysis=True)
 
         assert len(scores) == 1
         assert scores[0] == IsInstance(ScoredTag) & HasAttributes(
@@ -373,7 +373,7 @@ class TestTagAnalyzer:
         email_tag.recognizers.append(column_name_recognizer)
 
         analyzer = TagAnalyzer(tag=email_tag, column=column, nlp_engine=nlp_engine)
-        analysis = analyzer.analyze(str_values=[], column_name="email_address")
+        analysis = analyzer.analyze(str_values=[], run_column_analysis=True)
         assert analysis == IsInstance(TagAnalysis) & HasAttributes(
             score=IsFloat(gt=0.5),
             tag=email_tag,

--- a/openmetadata-service/src/main/resources/json/data/tags/piiTagsWithRecognizers.json
+++ b/openmetadata-service/src/main/resources/json/data/tags/piiTagsWithRecognizers.json
@@ -16,7 +16,8 @@
       "name": "None",
       "description": "Non PII",
       "autoClassificationEnabled": false,
-      "autoClassificationPriority": 0
+      "autoClassificationPriority": 0,
+      "recognizers": []
     },
     {
       "name": "NonSensitive",
@@ -104,110 +105,6 @@
           },
           "confidenceThreshold": 0.6,
           "target": "content"
-        },
-        {
-          "displayName": "Date time column name",
-          "name": "date_time",
-          "description": "A regex recognizer for column names",
-          "enabled": true,
-          "isSystemDefault": true,
-          "recognizerConfig": {
-            "type": "pattern",
-            "supportedLanguage": "en",
-            "patterns": [
-              {
-                "name": "date_time_pattern_0",
-                "regex": "^.*(date|time|dob|birthday|dod).*$",
-                "score": 0.6
-              }
-            ],
-            "regexFlags": {
-              "dotAll": true,
-              "multiline": true,
-              "ignoreCase": true
-            },
-            "context": []
-          },
-          "confidenceThreshold": 0.6,
-          "target": "column_name"
-        },
-        {
-          "displayName": "Nrp column name",
-          "name": "nrp",
-          "description": "A regex recognizer for column names",
-          "enabled": true,
-          "isSystemDefault": true,
-          "recognizerConfig": {
-            "type": "pattern",
-            "supportedLanguage": "en",
-            "patterns": [
-              {
-                "name": "nrp_pattern_0",
-                "regex": "^.*(gender|nationality).*$",
-                "score": 0.6
-              }
-            ],
-            "regexFlags": {
-              "dotAll": true,
-              "multiline": true,
-              "ignoreCase": true
-            },
-            "context": []
-          },
-          "confidenceThreshold": 0.6,
-          "target": "column_name"
-        },
-        {
-          "displayName": "Location column name",
-          "name": "location",
-          "description": "A regex recognizer for column names",
-          "enabled": true,
-          "isSystemDefault": true,
-          "recognizerConfig": {
-            "type": "pattern",
-            "supportedLanguage": "en",
-            "patterns": [
-              {
-                "name": "location_pattern_0",
-                "regex": "^.*(address|city|state|county|country|zipcode|zip|postal|zone|borough).*$",
-                "score": 0.6
-              }
-            ],
-            "regexFlags": {
-              "dotAll": true,
-              "multiline": true,
-              "ignoreCase": true
-            },
-            "context": []
-          },
-          "confidenceThreshold": 0.6,
-          "target": "column_name"
-        },
-        {
-          "displayName": "Phone number column name",
-          "name": "phone_number",
-          "description": "A regex recognizer for column names",
-          "enabled": true,
-          "isSystemDefault": true,
-          "recognizerConfig": {
-            "type": "pattern",
-            "supportedLanguage": "en",
-            "patterns": [
-              {
-                "name": "phone_number_pattern_0",
-                "regex": "^.*(phone).*$",
-                "score": 0.6
-              }
-            ],
-            "regexFlags": {
-              "dotAll": true,
-              "multiline": true,
-              "ignoreCase": true
-            },
-            "context": []
-          },
-          "confidenceThreshold": 0.6,
-          "target": "column_name"
         }
       ]
     },
@@ -216,850 +113,669 @@
       "description": "PII which if lost, compromised, or disclosed without authorization, could result in substantial harm, embarrassment, inconvenience, or unfairness to an individual.",
       "autoClassificationEnabled": true,
       "autoClassificationPriority": 100,
-      "recognizers":
-        [
-          {
-            "name": "EnglishCreditCardRecognizer",
-            "displayName": "English Credit Card Recognizer",
-            "description": "Recognize common credit card numbers using regex + checksum.",
-            "enabled": true,
-            "isSystemDefault": true,
-            "recognizerConfig": {
-              "type": "predefined",
-              "name": "CreditCardRecognizer",
-              "supportedLanguage": "en",
-              "context":  [
-                "credit",
-                "card",
-                "visa",
-                "mastercard",
-                "cc",
-                "amex",
-                "discover",
-                "jcb",
-                "diners",
-                "maestro",
-                "instapayment",
-                "cc_number",
-                "card_number",
-                "payment_info"
-              ]
-            },
-            "confidenceThreshold": 0.6,
-            "target": "content"
+      "recognizers": [
+        {
+          "name": "EnglishCreditCardRecognizer",
+          "displayName": "English Credit Card Recognizer",
+          "description": "Recognize common credit card numbers using regex + checksum.",
+          "enabled": true,
+          "isSystemDefault": true,
+          "recognizerConfig": {
+            "type": "predefined",
+            "name": "CreditCardRecognizer",
+            "supportedLanguage": "en",
+            "context": [
+              "credit",
+              "card",
+              "visa",
+              "mastercard",
+              "cc",
+              "amex",
+              "discover",
+              "jcb",
+              "diners",
+              "maestro",
+              "instapayment",
+              "cc_number",
+              "card_number",
+              "payment_info"
+            ]
           },
-          {
-            "name": "SpanishCreditCardRecognizer",
-            "displayName": "Spanish Credit Card Recognizer",
-            "description": "Recognize common credit card numbers using regex + checksum.",
-            "enabled": true,
-            "isSystemDefault": true,
-            "recognizerConfig": {
-              "type": "predefined",
-              "name": "CreditCardRecognizer",
-              "supportedLanguage": "es",
-              "context":  [
-                "tarjeta",
-                "credito",
-                "visa",
-                "mastercard",
-                "cc",
-                "amex",
-                "discover",
-                "jcb",
-                "diners",
-                "maestro",
-                "instapayment"
-              ]
-            },
-            "confidenceThreshold": 0.6,
-            "target": "content"
+          "confidenceThreshold": 0.6,
+          "target": "content"
+        },
+        {
+          "name": "SpanishCreditCardRecognizer",
+          "displayName": "Spanish Credit Card Recognizer",
+          "description": "Recognize common credit card numbers using regex + checksum.",
+          "enabled": true,
+          "isSystemDefault": true,
+          "recognizerConfig": {
+            "type": "predefined",
+            "name": "CreditCardRecognizer",
+            "supportedLanguage": "es",
+            "context": [
+              "tarjeta",
+              "credito",
+              "visa",
+              "mastercard",
+              "cc",
+              "amex",
+              "discover",
+              "jcb",
+              "diners",
+              "maestro",
+              "instapayment"
+            ]
           },
-          {
-            "name": "ItalianCreditCardRecognizer",
-            "displayName": "Italian Credit Card Recognizer",
-            "description": "Recognize common credit card numbers using regex + checksum.",
-            "enabled": true,
-            "isSystemDefault": true,
-            "recognizerConfig": {
-              "type": "predefined",
-              "name": "CreditCardRecognizer",
-              "supportedLanguage": "it",
-              "context": [
-                "carta",
-                "credito",
-                "visa",
-                "mastercard",
-                "cc",
-                "amex",
-                "discover",
-                "jcb",
-                "diners",
-                "maestro"
-              ]
-            },
-            "confidenceThreshold": 0.6,
-            "target": "content"
+          "confidenceThreshold": 0.6,
+          "target": "content"
+        },
+        {
+          "name": "ItalianCreditCardRecognizer",
+          "displayName": "Italian Credit Card Recognizer",
+          "description": "Recognize common credit card numbers using regex + checksum.",
+          "enabled": true,
+          "isSystemDefault": true,
+          "recognizerConfig": {
+            "type": "predefined",
+            "name": "CreditCardRecognizer",
+            "supportedLanguage": "it",
+            "context": [
+              "carta",
+              "credito",
+              "visa",
+              "mastercard",
+              "cc",
+              "amex",
+              "discover",
+              "jcb",
+              "diners",
+              "maestro"
+            ]
           },
-          {
-            "name": "PolishCreditCardRecognizer",
-            "displayName": "Polish Credit Card Recognizer",
-            "description": "Recognize common credit card numbers using regex + checksum.",
-            "enabled": true,
-            "isSystemDefault": true,
-            "recognizerConfig": {
-              "type": "predefined",
-              "name": "CreditCardRecognizer",
-              "supportedLanguage": "pl",
-              "context": [
-                "karta",
-                "kredytowa",
-                "visa",
-                "mastercard",
-                "cc",
-                "amex",
-                "discover",
-                "jcb",
-                "diners",
-                "maestro"
-              ]
-            },
-            "confidenceThreshold": 0.6,
-            "target": "content"
+          "confidenceThreshold": 0.6,
+          "target": "content"
+        },
+        {
+          "name": "PolishCreditCardRecognizer",
+          "displayName": "Polish Credit Card Recognizer",
+          "description": "Recognize common credit card numbers using regex + checksum.",
+          "enabled": true,
+          "isSystemDefault": true,
+          "recognizerConfig": {
+            "type": "predefined",
+            "name": "CreditCardRecognizer",
+            "supportedLanguage": "pl",
+            "context": [
+              "karta",
+              "kredytowa",
+              "visa",
+              "mastercard",
+              "cc",
+              "amex",
+              "discover",
+              "jcb",
+              "diners",
+              "maestro"
+            ]
           },
-          {
-            "name": "CvvRecognizer",
-            "displayName": "CVV Recognizer",
-            "description": "Recognize CVV/CVC codes (3-4 digit card verification values).",
-            "enabled": true,
-            "isSystemDefault": true,
-            "recognizerConfig": {
-              "type": "pattern",
-              "patterns": [
-                {
-                  "name": "cvv_pattern",
-                  "regex": "\\b\\d{3,4}\\b",
-                  "score": 0.5
-                }
-              ],
-              "context": [
-                "cvv",
-                "cvc",
-                "security",
-                "code",
-                "verification",
-                "card",
-                "cvv2",
-                "cid",
-                "csc"
-              ],
-              "regexFlags": {
-                "dotAll": true,
-                "multiline": true,
-                "ignoreCase": true
-              },
-              "supportedLanguage": "en"
-            },
-            "confidenceThreshold": 0.6,
-            "target": "content"
-          },
-          {
-            "name": "UsBankRecognizer",
-            "displayName": "Us Bank Recognizer",
-            "description": "Recognizes US bank number using regex.",
-            "enabled": true,
-            "isSystemDefault": true,
-            "recognizerConfig": {
-              "type": "predefined",
-              "name": "UsBankRecognizer",
-              "supportedLanguage": "en",
-              "context": [
-                "check",
-                "account",
-                "acct",
-                "bank",
-                "save",
-                "debit",
-                "bank_account",
-                "bank",
-                "account_number"
-              ]
-            },
-            "confidenceThreshold": 0.6,
-            "target": "content"
-          },
-          {
-            "name": "UsLicenseRecognizer",
-            "displayName": "Us License Recognizer",
-            "description": "Recognizes US driver license using regex.",
-            "enabled": true,
-            "isSystemDefault": true,
-            "recognizerConfig": {
-              "type": "predefined",
-              "name": "UsLicenseRecognizer",
-              "supportedLanguage": "en"
-            },
-            "confidenceThreshold": 0.6,
-            "target": "content"
-          },
-          {
-            "name": "UsItinRecognizer",
-            "displayName": "Us Itin Recognizer",
-            "description": "Recognizes US ITIN (Individual Taxpayer Identification Number) using regex.",
-            "enabled": true,
-            "isSystemDefault": true,
-            "recognizerConfig": {
-              "type": "predefined",
-              "name": "UsItinRecognizer",
-              "supportedLanguage": "en"
-            },
-            "confidenceThreshold": 0.6,
-            "target": "content"
-          },
-          {
-            "name": "UsPassportRecognizer",
-            "displayName": "Us Passport Recognizer",
-            "description": "Recognizes US Passport number using regex.",
-            "enabled": true,
-            "isSystemDefault": true,
-            "recognizerConfig": {
-              "type": "predefined",
-              "name": "UsPassportRecognizer",
-              "supportedLanguage": "en"
-            },
-            "confidenceThreshold": 0.6,
-            "target": "content"
-          },
-          {
-            "name": "UsSsnRecognizer",
-            "displayName": "Us Ssn Recognizer",
-            "description": "Recognize US Social Security Number (SSN) using regex.",
-            "enabled": true,
-            "isSystemDefault": true,
-            "recognizerConfig": {
-              "type": "predefined",
-              "name": "UsSsnRecognizer",
-              "supportedLanguage": "en",
-              "context": [
-                "social",
-                "security",
-                "ssn",
-                "ssns",
-                "ssid",
-                "national_id",
-                "id_number"
-              ]
-            },
-            "confidenceThreshold": 0.6,
-            "target": "content"
-          },
-          {
-            "name": "NhsRecognizer",
-            "displayName": "Nhs Recognizer",
-            "description": "Recognizes NHS number using regex and checksum.",
-            "enabled": true,
-            "isSystemDefault": true,
-            "recognizerConfig": {
-              "type": "predefined",
-              "name": "NhsRecognizer",
-              "supportedLanguage": "en",
-              "context": [
-                "nhs",
-                "national_health_service",
-                "nhs_number"
-              ]
-            },
-            "confidenceThreshold": 0.6,
-            "target": "content"
-          },
-          {
-            "name": "UkNinoRecognizer",
-            "displayName": "Uk Nino Recognizer",
-            "description": "Recognizes UK National Insurance Number using regex.",
-            "enabled": true,
-            "isSystemDefault": true,
-            "recognizerConfig": {
-              "type": "predefined",
-              "name": "UkNinoRecognizer",
-              "supportedLanguage": "en"
-            },
-            "confidenceThreshold": 0.6,
-            "target": "content"
-          },
-          {
-            "name": "SgFinRecognizer",
-            "displayName": "Sg Fin Recognizer",
-            "description": "Recognize SG FIN/NRIC number using regex.",
-            "enabled": true,
-            "isSystemDefault": true,
-            "recognizerConfig": {
-              "type": "predefined",
-              "name": "SgFinRecognizer",
-              "supportedLanguage": "en"
-            },
-            "confidenceThreshold": 0.6,
-            "target": "content"
-          },
-          {
-            "name": "AuAbnRecognizer",
-            "displayName": "Au Abn Recognizer",
-            "description": "Recognizes Australian Business Number (\"ABN\").<br/><br/>The Australian Business Number (ABN) is a unique 11 digit identifier issued to all entities registered in the Australian Business Register (ABR). The 11 digit ABN is structured as a 9 digit identifier<br/><br/>with two leading check digits.<br/><br/>The leading check digits are derived using a modulus 89 calculation.<br/><br/>This recognizer identifies ABN using regex, context words and checksum.<br/><br/>Reference: https://abr.business.gov.au/Help/AbnFormat",
-            "enabled": true,
-            "isSystemDefault": true,
-            "recognizerConfig": {
-              "type": "predefined",
-              "name": "AuAbnRecognizer",
-              "supportedLanguage": "en"
-            },
-            "confidenceThreshold": 0.6,
-            "target": "content"
-          },
-          {
-            "name": "AuAcnRecognizer",
-            "displayName": "Au Acn Recognizer",
-            "description": "Recognizes Australian Company Number (\"ACN\").<br/><br/>The Australian Company Number (ACN) is a nine digit number with the last digit being a check digit calculated using a modified modulus 10 calculation.<br/><br/>This recognizer identifies ACN using regex, context words, and checksum.<br/><br/>Reference: https://asic.gov.au/",
-            "enabled": true,
-            "isSystemDefault": true,
-            "recognizerConfig": {
-              "type": "predefined",
-              "name": "AuAcnRecognizer",
-              "supportedLanguage": "en"
-            },
-            "confidenceThreshold": 0.6,
-            "target": "content"
-          },
-          {
-            "name": "AuTfnRecognizer",
-            "displayName": "Au Tfn Recognizer",
-            "description": "Recognizes Australian Tax File Numbers (\"TFN\").<br/><br/>The tax file number (TFN) is a unique identifier issued by the Australian Taxation Office to each taxpaying entity \\u2014 an individual, company,<br/><br/>superannuation fund, partnership, or trust.<br/><br/>The TFN consists of a nine digit number, usually presented in the format NNN NNN NNN.<br/><br/>TFN includes a check digit for detecting erroneous number based on simple modulo 11.<br/><br/>This recognizer uses regex, context words,<br/><br/>and checksum to identify TFN.<br/><br/>Reference: https://www.ato.gov.au/individuals/tax-file-number/",
-            "enabled": true,
-            "isSystemDefault": true,
-            "recognizerConfig": {
-              "type": "predefined",
-              "name": "AuTfnRecognizer",
-              "supportedLanguage": "en"
-            },
-            "confidenceThreshold": 0.6,
-            "target": "content"
-          },
-          {
-            "name": "AuMedicareRecognizer",
-            "displayName": "Au Medicare Recognizer",
-            "description": "Recognizes Australian Medicare number using regex, context words, and checksum.<br/><br/>Medicare number is a unique identifier issued by Australian Government that enables the cardholder to receive a rebates of medical expenses under Australia's Medicare system.<br/><br/>It uses a modulus 10 checksum scheme to validate the number.<br/><br/>Reference: https://en.wikipedia.org/wiki/Medicare_card_(Australia)",
-            "enabled": true,
-            "isSystemDefault": true,
-            "recognizerConfig": {
-              "type": "predefined",
-              "name": "AuMedicareRecognizer",
-              "supportedLanguage": "en"
-            },
-            "confidenceThreshold": 0.6,
-            "target": "content"
-          },
-          {
-            "name": "InPanRecognizer",
-            "displayName": "In Pan Recognizer",
-            "description": "Recognizes Indian Permanent Account Number (\"PAN\").<br/><br/>The Permanent Account Number (PAN) is a ten digit alpha-numeric code with the last digit being a check digit calculated using a modified modulus 10 calculation.<br/><br/>This recognizer identifies PAN using regex and context words.<br/><br/>Reference: https://en.wikipedia.org/wiki/Permanent_account_number\nhttps://incometaxindia.gov.in/Forms/tps/1.Permanent%20Account%20Number%20(PAN).pdf",
-            "enabled": true,
-            "isSystemDefault": true,
-            "recognizerConfig": {
-              "type": "predefined",
-              "name": "InPanRecognizer",
-              "supportedLanguage": "en"
-            },
-            "confidenceThreshold": 0.6,
-            "target": "content"
-          },
-          {
-            "name": "InAadhaarRecognizer",
-            "displayName": "In Aadhaar Recognizer",
-            "description": "Recognizes Indian UIDAI Person Identification Number (\"AADHAAR\").<br/><br/>Reference: https://en.wikipedia.org/wiki/Aadhaar<br/><br/>A 12 digit unique number that is issued to each individual by Government of India",
-            "enabled": true,
-            "isSystemDefault": true,
-            "recognizerConfig": {
-              "type": "predefined",
-              "name": "InAadhaarRecognizer",
-              "supportedLanguage": "en"
-            },
-            "confidenceThreshold": 0.6,
-            "target": "content"
-          },
-          {
-            "name": "InVehicleRegistrationRecognizer",
-            "displayName": "In Vehicle Registration Recognizer",
-            "description": "Recognizes Indian Vehicle Registration Number issued by RTO.<br/><br/>Reference(s):<br/><br/>https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_India\nhttps://en.wikipedia.org/wiki/Regional_Transport_Office\nhttps://en.wikipedia.org/wiki/List_of_Regional_Transport_Office_districts_in_India<br/><br/>The registration scheme changed over time with multiple formats in play over the years<br/><br/>India has multiple active patterns for registration plates issued to different vehicle categories",
-            "enabled": true,
-            "isSystemDefault": true,
-            "recognizerConfig": {
-              "type": "predefined",
-              "name": "InVehicleRegistrationRecognizer",
-              "supportedLanguage": "en"
-            },
-            "confidenceThreshold": 0.6,
-            "target": "content"
-          },
-          {
-            "name": "InPassportRecognizer",
-            "displayName": "In Passport Recognizer",
-            "description": "Recognizes Indian Passport Number.<br/><br/>Indian Passport Number is a eight digit alphanumeric number.<br/><br/>Reference:<br/><br/>https://www.bajajallianz.com/blog/travel-insurance-articles/where-is-passport-number-in-indian-passport.html",
-            "enabled": true,
-            "isSystemDefault": true,
-            "recognizerConfig": {
-              "type": "predefined",
-              "name": "InPassportRecognizer",
-              "supportedLanguage": "en"
-            },
-            "confidenceThreshold": 0.6,
-            "target": "content"
-          },
-          {
-            "name": "EsNifRecognizer",
-            "displayName": "Es Nif Recognizer",
-            "description": "Recognize NIF number using regex and checksum.",
-            "enabled": true,
-            "isSystemDefault": true,
-            "recognizerConfig": {
-              "type": "predefined",
-              "name": "EsNifRecognizer",
-              "supportedLanguage": "es"
-            },
-            "confidenceThreshold": 0.6,
-            "target": "content"
-          },
-          {
-            "name": "EsNieRecognizer",
-            "displayName": "Es Nie Recognizer",
-            "description": "Recognize NIE number using regex and checksum.<br/><br/>Reference(s):<br/><br/>https://es.wikipedia.org/wiki/N%C3%BAmero_de_identidad_de_extranjero\nhttps://www.interior.gob.es/opencms/ca/servicios-al-ciudadano/tramites-y-gestiones/dni/calculo-del-digito-de-control-del-nif-nie/",
-            "enabled": true,
-            "isSystemDefault": true,
-            "recognizerConfig": {
-              "type": "predefined",
-              "name": "EsNieRecognizer",
-              "supportedLanguage": "es"
-            },
-            "confidenceThreshold": 0.6,
-            "target": "content"
-          },
-          {
-            "name": "ItDriverLicenseRecognizer",
-            "displayName": "It Driver License Recognizer",
-            "description": "Recognizes IT Driver License using regex.",
-            "enabled": true,
-            "isSystemDefault": true,
-            "recognizerConfig": {
-              "type": "predefined",
-              "name": "ItDriverLicenseRecognizer",
-              "supportedLanguage": "it"
-            },
-            "confidenceThreshold": 0.6,
-            "target": "content"
-          },
-          {
-            "name": "ItFiscalCodeRecognizer",
-            "displayName": "It Fiscal Code Recognizer",
-            "description": "Recognizes IT Fiscal Code using regex.",
-            "enabled": true,
-            "isSystemDefault": true,
-            "recognizerConfig": {
-              "type": "predefined",
-              "name": "ItFiscalCodeRecognizer",
-              "supportedLanguage": "it"
-            },
-            "confidenceThreshold": 0.6,
-            "target": "content"
-          },
-          {
-            "name": "ItVatCodeRecognizer",
-            "displayName": "It Vat Code Recognizer",
-            "description": "Recognizes Italian VAT code using regex and checksum.<br/><br/>For more information about italian VAT code:<br/><br/>https://en.wikipedia.org/wiki/VAT_identification_number#:~:text=%5B2%5D)-,Italy,-Partita%20IVA",
-            "enabled": true,
-            "isSystemDefault": true,
-            "recognizerConfig": {
-              "type": "predefined",
-              "name": "ItVatCodeRecognizer",
-              "supportedLanguage": "it"
-            },
-            "confidenceThreshold": 0.6,
-            "target": "content"
-          },
-          {
-            "name": "ItIdentityCardRecognizer",
-            "displayName": "It Identity Card Recognizer",
-            "description": "Recognizes Italian Identity Card number using case-insensitive regex.",
-            "enabled": true,
-            "isSystemDefault": true,
-            "recognizerConfig": {
-              "type": "predefined",
-              "name": "ItIdentityCardRecognizer",
-              "supportedLanguage": "it"
-            },
-            "confidenceThreshold": 0.6,
-            "target": "content"
-          },
-          {
-            "name": "ItPassportRecognizer",
-            "displayName": "It Passport Recognizer",
-            "description": "Recognizes IT Passport number using case-insensitive regex.",
-            "enabled": true,
-            "isSystemDefault": true,
-            "recognizerConfig": {
-              "type": "predefined",
-              "name": "ItPassportRecognizer",
-              "supportedLanguage": "it"
-            },
-            "confidenceThreshold": 0.6,
-            "target": "content"
-          },
-          {
-            "name": "PlPeselRecognizer",
-            "displayName": "Pl Pesel Recognizer",
-            "description": "Recognize PESEL number using regex and checksum.<br/><br/>For more information about PESEL: https://en.wikipedia.org/wiki/PESEL",
-            "enabled": true,
-            "isSystemDefault": true,
-            "recognizerConfig": {
-              "type": "predefined",
-              "name": "PlPeselRecognizer",
-              "supportedLanguage": "pl"
-            },
-            "confidenceThreshold": 0.6,
-            "target": "content"
-          },
-          {
-            "name": "CryptoRecognizer",
-            "displayName": "Crypto Recognizer",
-            "description": "Recognize common crypto account numbers using regex + checksum.",
-            "enabled": true,
-            "isSystemDefault": true,
-            "recognizerConfig": {
-              "type": "predefined",
-              "name": "CryptoRecognizer",
-              "context": [
-                "crypto",
-                "bitcoin",
-                "btc",
-                "ethereum",
-                "eth",
-                "litecoin",
-                "ltc",
-                "wallet",
-                "address"
-              ]
-            },
-            "confidenceThreshold": 0.6,
-            "target": "content"
-          },
-          {
-            "name": "EmailRecognizer",
-            "displayName": "Email Recognizer",
-            "description": "Recognize email addresses using regex.",
-            "enabled": true,
-            "isSystemDefault": true,
-            "recognizerConfig": {
-              "type": "predefined",
-              "name": "EmailRecognizer"
-            },
-            "confidenceThreshold": 0.6,
-            "target": "content"
-          },
-          {
-            "name": "IbanRecognizer",
-            "displayName": "Iban Recognizer",
-            "description": "Recognize IBAN code using regex and checksum.",
-            "enabled": true,
-            "isSystemDefault": true,
-            "recognizerConfig": {
-              "type": "predefined",
-              "name": "IbanRecognizer"
-            },
-            "confidenceThreshold": 0.6,
-            "target": "content"
-          },
-          {
-            "name": "IpRecognizer",
-            "displayName": "Ip Recognizer",
-            "description": "Recognize IP address using regex.",
-            "enabled": true,
-            "isSystemDefault": true,
-            "recognizerConfig": {
-              "type": "predefined",
-              "name": "IpRecognizer"
-            },
-            "confidenceThreshold": 0.6,
-            "target": "content"
-          },
-          {
-            "name": "MedicalLicenseRecognizer",
-            "displayName": "Medical License Recognizer",
-            "description": "Recognize common Medical license numbers using regex + checksum.",
-            "enabled": true,
-            "isSystemDefault": true,
-            "recognizerConfig": {
-              "type": "predefined",
-              "name": "MedicalLicenseRecognizer"
-            },
-            "confidenceThreshold": 0.6,
-            "target": "content"
-          },
-          {
-            "name": "InVoterRecognizer",
-            "displayName": "In Voter Recognizer",
-            "description": "Recognize Indian Voter/Election Id(EPIC).<br/><br/>The Elector's Photo Identity Card or Voter id is a ten digit alpha-numeric code issued by Election Commission of India to adult domiciles who have reached the age of 18<br/><br/>Ref: https://en.wikipedia.org/wiki/Voter_ID_(India)",
-            "enabled": true,
-            "isSystemDefault": true,
-            "recognizerConfig": {
-              "type": "predefined",
-              "name": "InVoterRecognizer"
-            },
-            "confidenceThreshold": 0.6,
-            "target": "content"
-          },
-          {
-            "name": "AbaRoutingRecognizer",
-            "displayName": "ABA Routing Recognizer",
-            "description": "Recognize American Banking Association (ABA) routing number.<br/><br/>Also known as routing transit number (RTN) and used to identify financial institutions and process transactions.",
-            "enabled": true,
-            "isSystemDefault": true,
-            "recognizerConfig": {
-              "type": "predefined",
-              "name": "AbaRoutingRecognizer"
-            },
-            "confidenceThreshold": 0.6,
-            "target": "content"
-          },
-          {
-            "name": "FiPersonalIdentityCodeRecognizer",
-            "displayName": "FI Personal Identity Code Recognizer",
-            "description": "Recognizes and validates Finnish Personal Identity Codes (Henkilötunnus).",
-            "enabled": true,
-            "isSystemDefault": true,
-            "recognizerConfig": {
-              "type": "predefined",
-              "name": "FiPersonalIdentityCodeRecognizer",
-              "supportedLanguage": "fi"
-            },
-            "confidenceThreshold": 0.6,
-            "target": "content"
-          },
-          {
-            "name": "SgUenRecognizer",
-            "displayName": "Singaporean UEN recognizer",
-            "description": "Recognize Singapore UEN (Unique Entity Number) using regex.",
-            "enabled": true,
-            "isSystemDefault": true,
-            "recognizerConfig": {
-              "type": "predefined",
-              "name": "SgUenRecognizer"
-            },
-            "confidenceThreshold": 0.6,
-            "target": "content"
-          },
-          {
-            "name": "SpacyRecognizer",
-            "displayName": "Recognizer using spaCy NLP model",
-            "description": "Recognize PII entities using a spaCy NLP model.",
-            "enabled": true,
-            "isSystemDefault": true,
-            "recognizerConfig": {
-              "type": "predefined",
-              "name": "SpacyRecognizer",
-              "supportedEntities": [
-                "PERSON"
-              ],
-              "context": [
-                "name",
-                "first_name",
-                "last_name",
-                "given_name",
-                "firstName",
-                "lastName",
-                "givenName",
-                "familyName"
-              ]
-            },
-            "confidenceThreshold": 0.6,
-            "target": "content"
-          },
-          {
-            "displayName": "US SSN column name",
-            "name": "us_ssn",
-            "description": "A regex recognizer for column names",
-            "enabled": true,
-            "isSystemDefault": true,
-            "recognizerConfig": {
-              "type": "pattern",
-              "supportedLanguage": "en",
-              "patterns": [
-                {
-                  "name": "us_ssn_pattern_0",
-                  "regex": "^.*(ssn|social).*$",
-                  "score": 0.6
-                }
-              ],
-              "regexFlags": {
-                "dotAll": true,
-                "multiline": true,
-                "ignoreCase": true
-              },
-              "context": []
-            },
-            "confidenceThreshold": 0.6,
-            "target": "column_name"
-          },
-          {
-            "displayName": "Credit card column name",
-            "name": "credit_card",
-            "description": "A regex recognizer for column names",
-            "enabled": true,
-            "isSystemDefault": true,
-            "recognizerConfig": {
-              "type": "pattern",
-              "supportedLanguage": "en",
-              "patterns": [
-                {
-                  "name": "credit_card_pattern_0",
-                  "regex": "^.*(credit).*(card).*$",
-                  "score": 0.6
-                }
-              ],
-              "regexFlags": {
-                "dotAll": true,
-                "multiline": true,
-                "ignoreCase": true
-              },
-              "context": []
-            },
-            "confidenceThreshold": 0.6,
-            "target": "column_name"
-          },
-          {
-            "displayName": "US bank number column name",
-            "name": "us_bank_number",
-            "description": "A regex recognizer for column names",
-            "enabled": true,
-            "isSystemDefault": true,
-            "recognizerConfig": {
-              "type": "pattern",
-              "supportedLanguage": "en",
-              "patterns": [
-                {
-                  "name": "us_bank_number_pattern_0",
-                  "regex": "\\b(account|acct|acc)[_-]?(number|num|no)\\b",
-                  "score": 0.6
-                },
-                {
-                  "name": "us_bank_number_pattern_1",
-                  "regex": "\\bbank[_-]?(account|number|num|no)?\\b",
-                  "score": 0.6
-                }
-              ],
-              "regexFlags": {
-                "dotAll": true,
-                "multiline": true,
-                "ignoreCase": true
+          "confidenceThreshold": 0.6,
+          "target": "content"
+        },
+        {
+          "name": "CvvRecognizer",
+          "displayName": "CVV Recognizer",
+          "description": "Recognize CVV/CVC codes (3-4 digit card verification values).",
+          "enabled": true,
+          "isSystemDefault": true,
+          "recognizerConfig": {
+            "type": "pattern",
+            "patterns": [
+              {
+                "name": "cvv_pattern",
+                "regex": "\\b\\d{3,4}\\b",
+                "score": 0.5
               }
+            ],
+            "context": [
+              "cvv",
+              "cvc",
+              "security",
+              "code",
+              "verification",
+              "card",
+              "cvv2",
+              "cid",
+              "csc"
+            ],
+            "regexFlags": {
+              "dotAll": true,
+              "multiline": true,
+              "ignoreCase": true
             },
-            "confidenceThreshold": 0.6,
-            "target": "column_name"
+            "supportedLanguage": "en"
           },
-          {
-            "displayName": "Iban code column name",
-            "name": "iban_code",
-            "description": "A regex recognizer for column names",
-            "enabled": true,
-            "isSystemDefault": true,
-            "recognizerConfig": {
-              "type": "pattern",
-              "supportedLanguage": "en",
-              "patterns": [
-                {
-                  "name": "iban_code_pattern_0",
-                  "regex": "\b(account|acct|acc)[_-]?(number|num|no)\b",
-                  "score": 0.6
-                },
-                {
-                  "name": "iban_code_pattern_1",
-                  "regex": "\bbank[_-]?(account|number|num|no)?\b",
-                  "score": 0.6
-                },
-                {
-                  "name": "iban_code_pattern_2",
-                  "regex": "\biban(?:[_]?(number|code))?\b",
-                  "score": 0.6
-                },
-                {
-                  "name": "iban_code_pattern_3",
-                  "regex": "\bbank[_]?iban\b",
-                  "score": 0.6
-                },
-                {
-                  "name": "iban_code_pattern_4",
-                  "regex": "\binternational[_]?(account|bank[_]?number)\b",
-                  "score": 0.6
-                }
-              ],
-              "regexFlags": {
-                "dotAll": true,
-                "multiline": true,
-                "ignoreCase": true
-              },
-              "context": []
-            },
-            "confidenceThreshold": 0.6,
-            "target": "column_name"
+          "confidenceThreshold": 0.6,
+          "target": "content"
+        },
+        {
+          "name": "UsBankRecognizer",
+          "displayName": "Us Bank Recognizer",
+          "description": "Recognizes US bank number using regex.",
+          "enabled": true,
+          "isSystemDefault": true,
+          "recognizerConfig": {
+            "type": "predefined",
+            "name": "UsBankRecognizer",
+            "supportedLanguage": "en",
+            "context": [
+              "check",
+              "account",
+              "acct",
+              "bank",
+              "save",
+              "debit",
+              "bank_account",
+              "bank",
+              "account_number"
+            ]
           },
-          {
-            "displayName": "Email address column name",
-            "name": "email_address",
-            "description": "A regex recognizer for column names",
-            "enabled": true,
-            "isSystemDefault": true,
-            "recognizerConfig": {
-              "type": "pattern",
-              "supportedLanguage": "en",
-              "patterns": [
-                {
-                  "name": "email_address_pattern_0",
-                  "regex": "^(email|e-mail|mail)(.*address)?$",
-                  "score": 0.6
-                }
-              ],
-              "regexFlags": {
-                "dotAll": true,
-                "multiline": true,
-                "ignoreCase": true
-              },
-              "context": []
-            },
-            "confidenceThreshold": 0.6,
-            "target": "column_name"
+          "confidenceThreshold": 0.6,
+          "target": "content"
+        },
+        {
+          "name": "UsLicenseRecognizer",
+          "displayName": "Us License Recognizer",
+          "description": "Recognizes US driver license using regex.",
+          "enabled": true,
+          "isSystemDefault": true,
+          "recognizerConfig": {
+            "type": "predefined",
+            "name": "UsLicenseRecognizer",
+            "supportedLanguage": "en"
           },
-          {
-            "displayName": "Person column name",
-            "name": "person",
-            "description": "A regex recognizer for column names",
-            "enabled": true,
-            "isSystemDefault": true,
-            "recognizerConfig": {
-              "type": "pattern",
-              "supportedLanguage": "en",
-              "patterns": [
-                {
-                  "name": "person_pattern_0",
-                  "regex": "^.*(user|client|person|first|last|maiden|nick).*(name).*$",
-                  "score": 0.6
-                }
-              ],
-              "regexFlags": {
-                "dotAll": true,
-                "multiline": true,
-                "ignoreCase": true
-              },
-              "context": []
-            },
-            "confidenceThreshold": 0.6,
-            "target": "column_name"
-          }
-        ]
+          "confidenceThreshold": 0.6,
+          "target": "content"
+        },
+        {
+          "name": "UsItinRecognizer",
+          "displayName": "Us Itin Recognizer",
+          "description": "Recognizes US ITIN (Individual Taxpayer Identification Number) using regex.",
+          "enabled": true,
+          "isSystemDefault": true,
+          "recognizerConfig": {
+            "type": "predefined",
+            "name": "UsItinRecognizer",
+            "supportedLanguage": "en"
+          },
+          "confidenceThreshold": 0.6,
+          "target": "content"
+        },
+        {
+          "name": "UsPassportRecognizer",
+          "displayName": "Us Passport Recognizer",
+          "description": "Recognizes US Passport number using regex.",
+          "enabled": true,
+          "isSystemDefault": true,
+          "recognizerConfig": {
+            "type": "predefined",
+            "name": "UsPassportRecognizer",
+            "supportedLanguage": "en"
+          },
+          "confidenceThreshold": 0.6,
+          "target": "content"
+        },
+        {
+          "name": "UsSsnRecognizer",
+          "displayName": "Us Ssn Recognizer",
+          "description": "Recognize US Social Security Number (SSN) using regex.",
+          "enabled": true,
+          "isSystemDefault": true,
+          "recognizerConfig": {
+            "type": "predefined",
+            "name": "UsSsnRecognizer",
+            "supportedLanguage": "en",
+            "context": [
+              "social",
+              "security",
+              "ssn",
+              "ssns",
+              "ssid",
+              "national_id",
+              "id_number"
+            ]
+          },
+          "confidenceThreshold": 0.6,
+          "target": "content"
+        },
+        {
+          "name": "NhsRecognizer",
+          "displayName": "Nhs Recognizer",
+          "description": "Recognizes NHS number using regex and checksum.",
+          "enabled": true,
+          "isSystemDefault": true,
+          "recognizerConfig": {
+            "type": "predefined",
+            "name": "NhsRecognizer",
+            "supportedLanguage": "en",
+            "context": [
+              "nhs",
+              "national_health_service",
+              "nhs_number"
+            ]
+          },
+          "confidenceThreshold": 0.6,
+          "target": "content"
+        },
+        {
+          "name": "UkNinoRecognizer",
+          "displayName": "Uk Nino Recognizer",
+          "description": "Recognizes UK National Insurance Number using regex.",
+          "enabled": true,
+          "isSystemDefault": true,
+          "recognizerConfig": {
+            "type": "predefined",
+            "name": "UkNinoRecognizer",
+            "supportedLanguage": "en"
+          },
+          "confidenceThreshold": 0.6,
+          "target": "content"
+        },
+        {
+          "name": "SgFinRecognizer",
+          "displayName": "Sg Fin Recognizer",
+          "description": "Recognize SG FIN/NRIC number using regex.",
+          "enabled": true,
+          "isSystemDefault": true,
+          "recognizerConfig": {
+            "type": "predefined",
+            "name": "SgFinRecognizer",
+            "supportedLanguage": "en"
+          },
+          "confidenceThreshold": 0.6,
+          "target": "content"
+        },
+        {
+          "name": "AuAbnRecognizer",
+          "displayName": "Au Abn Recognizer",
+          "description": "Recognizes Australian Business Number (\"ABN\").<br/><br/>The Australian Business Number (ABN) is a unique 11 digit identifier issued to all entities registered in the Australian Business Register (ABR). The 11 digit ABN is structured as a 9 digit identifier<br/><br/>with two leading check digits.<br/><br/>The leading check digits are derived using a modulus 89 calculation.<br/><br/>This recognizer identifies ABN using regex, context words and checksum.<br/><br/>Reference: https://abr.business.gov.au/Help/AbnFormat",
+          "enabled": true,
+          "isSystemDefault": true,
+          "recognizerConfig": {
+            "type": "predefined",
+            "name": "AuAbnRecognizer",
+            "supportedLanguage": "en"
+          },
+          "confidenceThreshold": 0.6,
+          "target": "content"
+        },
+        {
+          "name": "AuAcnRecognizer",
+          "displayName": "Au Acn Recognizer",
+          "description": "Recognizes Australian Company Number (\"ACN\").<br/><br/>The Australian Company Number (ACN) is a nine digit number with the last digit being a check digit calculated using a modified modulus 10 calculation.<br/><br/>This recognizer identifies ACN using regex, context words, and checksum.<br/><br/>Reference: https://asic.gov.au/",
+          "enabled": true,
+          "isSystemDefault": true,
+          "recognizerConfig": {
+            "type": "predefined",
+            "name": "AuAcnRecognizer",
+            "supportedLanguage": "en"
+          },
+          "confidenceThreshold": 0.6,
+          "target": "content"
+        },
+        {
+          "name": "AuTfnRecognizer",
+          "displayName": "Au Tfn Recognizer",
+          "description": "Recognizes Australian Tax File Numbers (\"TFN\").<br/><br/>The tax file number (TFN) is a unique identifier issued by the Australian Taxation Office to each taxpaying entity \\u2014 an individual, company,<br/><br/>superannuation fund, partnership, or trust.<br/><br/>The TFN consists of a nine digit number, usually presented in the format NNN NNN NNN.<br/><br/>TFN includes a check digit for detecting erroneous number based on simple modulo 11.<br/><br/>This recognizer uses regex, context words,<br/><br/>and checksum to identify TFN.<br/><br/>Reference: https://www.ato.gov.au/individuals/tax-file-number/",
+          "enabled": true,
+          "isSystemDefault": true,
+          "recognizerConfig": {
+            "type": "predefined",
+            "name": "AuTfnRecognizer",
+            "supportedLanguage": "en"
+          },
+          "confidenceThreshold": 0.6,
+          "target": "content"
+        },
+        {
+          "name": "AuMedicareRecognizer",
+          "displayName": "Au Medicare Recognizer",
+          "description": "Recognizes Australian Medicare number using regex, context words, and checksum.<br/><br/>Medicare number is a unique identifier issued by Australian Government that enables the cardholder to receive a rebates of medical expenses under Australia's Medicare system.<br/><br/>It uses a modulus 10 checksum scheme to validate the number.<br/><br/>Reference: https://en.wikipedia.org/wiki/Medicare_card_(Australia)",
+          "enabled": true,
+          "isSystemDefault": true,
+          "recognizerConfig": {
+            "type": "predefined",
+            "name": "AuMedicareRecognizer",
+            "supportedLanguage": "en"
+          },
+          "confidenceThreshold": 0.6,
+          "target": "content"
+        },
+        {
+          "name": "InPanRecognizer",
+          "displayName": "In Pan Recognizer",
+          "description": "Recognizes Indian Permanent Account Number (\"PAN\").<br/><br/>The Permanent Account Number (PAN) is a ten digit alpha-numeric code with the last digit being a check digit calculated using a modified modulus 10 calculation.<br/><br/>This recognizer identifies PAN using regex and context words.<br/><br/>Reference: https://en.wikipedia.org/wiki/Permanent_account_number\nhttps://incometaxindia.gov.in/Forms/tps/1.Permanent%20Account%20Number%20(PAN).pdf",
+          "enabled": true,
+          "isSystemDefault": true,
+          "recognizerConfig": {
+            "type": "predefined",
+            "name": "InPanRecognizer",
+            "supportedLanguage": "en"
+          },
+          "confidenceThreshold": 0.6,
+          "target": "content"
+        },
+        {
+          "name": "InAadhaarRecognizer",
+          "displayName": "In Aadhaar Recognizer",
+          "description": "Recognizes Indian UIDAI Person Identification Number (\"AADHAAR\").<br/><br/>Reference: https://en.wikipedia.org/wiki/Aadhaar<br/><br/>A 12 digit unique number that is issued to each individual by Government of India",
+          "enabled": true,
+          "isSystemDefault": true,
+          "recognizerConfig": {
+            "type": "predefined",
+            "name": "InAadhaarRecognizer",
+            "supportedLanguage": "en"
+          },
+          "confidenceThreshold": 0.6,
+          "target": "content"
+        },
+        {
+          "name": "InVehicleRegistrationRecognizer",
+          "displayName": "In Vehicle Registration Recognizer",
+          "description": "Recognizes Indian Vehicle Registration Number issued by RTO.<br/><br/>Reference(s):<br/><br/>https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_India\nhttps://en.wikipedia.org/wiki/Regional_Transport_Office\nhttps://en.wikipedia.org/wiki/List_of_Regional_Transport_Office_districts_in_India<br/><br/>The registration scheme changed over time with multiple formats in play over the years<br/><br/>India has multiple active patterns for registration plates issued to different vehicle categories",
+          "enabled": true,
+          "isSystemDefault": true,
+          "recognizerConfig": {
+            "type": "predefined",
+            "name": "InVehicleRegistrationRecognizer",
+            "supportedLanguage": "en"
+          },
+          "confidenceThreshold": 0.6,
+          "target": "content"
+        },
+        {
+          "name": "InPassportRecognizer",
+          "displayName": "In Passport Recognizer",
+          "description": "Recognizes Indian Passport Number.<br/><br/>Indian Passport Number is a eight digit alphanumeric number.<br/><br/>Reference:<br/><br/>https://www.bajajallianz.com/blog/travel-insurance-articles/where-is-passport-number-in-indian-passport.html",
+          "enabled": true,
+          "isSystemDefault": true,
+          "recognizerConfig": {
+            "type": "predefined",
+            "name": "InPassportRecognizer",
+            "supportedLanguage": "en"
+          },
+          "confidenceThreshold": 0.6,
+          "target": "content"
+        },
+        {
+          "name": "EsNifRecognizer",
+          "displayName": "Es Nif Recognizer",
+          "description": "Recognize NIF number using regex and checksum.",
+          "enabled": true,
+          "isSystemDefault": true,
+          "recognizerConfig": {
+            "type": "predefined",
+            "name": "EsNifRecognizer",
+            "supportedLanguage": "es"
+          },
+          "confidenceThreshold": 0.6,
+          "target": "content"
+        },
+        {
+          "name": "EsNieRecognizer",
+          "displayName": "Es Nie Recognizer",
+          "description": "Recognize NIE number using regex and checksum.<br/><br/>Reference(s):<br/><br/>https://es.wikipedia.org/wiki/N%C3%BAmero_de_identidad_de_extranjero\nhttps://www.interior.gob.es/opencms/ca/servicios-al-ciudadano/tramites-y-gestiones/dni/calculo-del-digito-de-control-del-nif-nie/",
+          "enabled": true,
+          "isSystemDefault": true,
+          "recognizerConfig": {
+            "type": "predefined",
+            "name": "EsNieRecognizer",
+            "supportedLanguage": "es"
+          },
+          "confidenceThreshold": 0.6,
+          "target": "content"
+        },
+        {
+          "name": "ItDriverLicenseRecognizer",
+          "displayName": "It Driver License Recognizer",
+          "description": "Recognizes IT Driver License using regex.",
+          "enabled": true,
+          "isSystemDefault": true,
+          "recognizerConfig": {
+            "type": "predefined",
+            "name": "ItDriverLicenseRecognizer",
+            "supportedLanguage": "it"
+          },
+          "confidenceThreshold": 0.6,
+          "target": "content"
+        },
+        {
+          "name": "ItFiscalCodeRecognizer",
+          "displayName": "It Fiscal Code Recognizer",
+          "description": "Recognizes IT Fiscal Code using regex.",
+          "enabled": true,
+          "isSystemDefault": true,
+          "recognizerConfig": {
+            "type": "predefined",
+            "name": "ItFiscalCodeRecognizer",
+            "supportedLanguage": "it"
+          },
+          "confidenceThreshold": 0.6,
+          "target": "content"
+        },
+        {
+          "name": "ItVatCodeRecognizer",
+          "displayName": "It Vat Code Recognizer",
+          "description": "Recognizes Italian VAT code using regex and checksum.<br/><br/>For more information about italian VAT code:<br/><br/>https://en.wikipedia.org/wiki/VAT_identification_number#:~:text=%5B2%5D)-,Italy,-Partita%20IVA",
+          "enabled": true,
+          "isSystemDefault": true,
+          "recognizerConfig": {
+            "type": "predefined",
+            "name": "ItVatCodeRecognizer",
+            "supportedLanguage": "it"
+          },
+          "confidenceThreshold": 0.6,
+          "target": "content"
+        },
+        {
+          "name": "ItIdentityCardRecognizer",
+          "displayName": "It Identity Card Recognizer",
+          "description": "Recognizes Italian Identity Card number using case-insensitive regex.",
+          "enabled": true,
+          "isSystemDefault": true,
+          "recognizerConfig": {
+            "type": "predefined",
+            "name": "ItIdentityCardRecognizer",
+            "supportedLanguage": "it"
+          },
+          "confidenceThreshold": 0.6,
+          "target": "content"
+        },
+        {
+          "name": "ItPassportRecognizer",
+          "displayName": "It Passport Recognizer",
+          "description": "Recognizes IT Passport number using case-insensitive regex.",
+          "enabled": true,
+          "isSystemDefault": true,
+          "recognizerConfig": {
+            "type": "predefined",
+            "name": "ItPassportRecognizer",
+            "supportedLanguage": "it"
+          },
+          "confidenceThreshold": 0.6,
+          "target": "content"
+        },
+        {
+          "name": "PlPeselRecognizer",
+          "displayName": "Pl Pesel Recognizer",
+          "description": "Recognize PESEL number using regex and checksum.<br/><br/>For more information about PESEL: https://en.wikipedia.org/wiki/PESEL",
+          "enabled": true,
+          "isSystemDefault": true,
+          "recognizerConfig": {
+            "type": "predefined",
+            "name": "PlPeselRecognizer",
+            "supportedLanguage": "pl"
+          },
+          "confidenceThreshold": 0.6,
+          "target": "content"
+        },
+        {
+          "name": "CryptoRecognizer",
+          "displayName": "Crypto Recognizer",
+          "description": "Recognize common crypto account numbers using regex + checksum.",
+          "enabled": true,
+          "isSystemDefault": true,
+          "recognizerConfig": {
+            "type": "predefined",
+            "name": "CryptoRecognizer",
+            "context": [
+              "crypto",
+              "bitcoin",
+              "btc",
+              "ethereum",
+              "eth",
+              "litecoin",
+              "ltc",
+              "wallet",
+              "address"
+            ]
+          },
+          "confidenceThreshold": 0.6,
+          "target": "content"
+        },
+        {
+          "name": "EmailRecognizer",
+          "displayName": "Email Recognizer",
+          "description": "Recognize email addresses using regex.",
+          "enabled": true,
+          "isSystemDefault": true,
+          "recognizerConfig": {
+            "type": "predefined",
+            "name": "EmailRecognizer"
+          },
+          "confidenceThreshold": 0.6,
+          "target": "content"
+        },
+        {
+          "name": "IbanRecognizer",
+          "displayName": "Iban Recognizer",
+          "description": "Recognize IBAN code using regex and checksum.",
+          "enabled": true,
+          "isSystemDefault": true,
+          "recognizerConfig": {
+            "type": "predefined",
+            "name": "IbanRecognizer"
+          },
+          "confidenceThreshold": 0.6,
+          "target": "content"
+        },
+        {
+          "name": "IpRecognizer",
+          "displayName": "Ip Recognizer",
+          "description": "Recognize IP address using regex.",
+          "enabled": true,
+          "isSystemDefault": true,
+          "recognizerConfig": {
+            "type": "predefined",
+            "name": "IpRecognizer"
+          },
+          "confidenceThreshold": 0.6,
+          "target": "content"
+        },
+        {
+          "name": "MedicalLicenseRecognizer",
+          "displayName": "Medical License Recognizer",
+          "description": "Recognize common Medical license numbers using regex + checksum.",
+          "enabled": true,
+          "isSystemDefault": true,
+          "recognizerConfig": {
+            "type": "predefined",
+            "name": "MedicalLicenseRecognizer"
+          },
+          "confidenceThreshold": 0.6,
+          "target": "content"
+        },
+        {
+          "name": "InVoterRecognizer",
+          "displayName": "In Voter Recognizer",
+          "description": "Recognize Indian Voter/Election Id(EPIC).<br/><br/>The Elector's Photo Identity Card or Voter id is a ten digit alpha-numeric code issued by Election Commission of India to adult domiciles who have reached the age of 18<br/><br/>Ref: https://en.wikipedia.org/wiki/Voter_ID_(India)",
+          "enabled": true,
+          "isSystemDefault": true,
+          "recognizerConfig": {
+            "type": "predefined",
+            "name": "InVoterRecognizer"
+          },
+          "confidenceThreshold": 0.6,
+          "target": "content"
+        },
+        {
+          "name": "AbaRoutingRecognizer",
+          "displayName": "ABA Routing Recognizer",
+          "description": "Recognize American Banking Association (ABA) routing number.<br/><br/>Also known as routing transit number (RTN) and used to identify financial institutions and process transactions.",
+          "enabled": true,
+          "isSystemDefault": true,
+          "recognizerConfig": {
+            "type": "predefined",
+            "name": "AbaRoutingRecognizer"
+          },
+          "confidenceThreshold": 0.6,
+          "target": "content"
+        },
+        {
+          "name": "FiPersonalIdentityCodeRecognizer",
+          "displayName": "FI Personal Identity Code Recognizer",
+          "description": "Recognizes and validates Finnish Personal Identity Codes (Henkil\u00f6tunnus).",
+          "enabled": true,
+          "isSystemDefault": true,
+          "recognizerConfig": {
+            "type": "predefined",
+            "name": "FiPersonalIdentityCodeRecognizer",
+            "supportedLanguage": "fi"
+          },
+          "confidenceThreshold": 0.6,
+          "target": "content"
+        },
+        {
+          "name": "SgUenRecognizer",
+          "displayName": "Singaporean UEN recognizer",
+          "description": "Recognize Singapore UEN (Unique Entity Number) using regex.",
+          "enabled": true,
+          "isSystemDefault": true,
+          "recognizerConfig": {
+            "type": "predefined",
+            "name": "SgUenRecognizer"
+          },
+          "confidenceThreshold": 0.6,
+          "target": "content"
+        },
+        {
+          "name": "SpacyRecognizer",
+          "displayName": "Recognizer using spaCy NLP model",
+          "description": "Recognize PII entities using a spaCy NLP model.",
+          "enabled": true,
+          "isSystemDefault": true,
+          "recognizerConfig": {
+            "type": "predefined",
+            "name": "SpacyRecognizer",
+            "supportedEntities": [
+              "PERSON"
+            ],
+            "context": [
+              "name",
+              "first_name",
+              "last_name",
+              "given_name",
+              "firstName",
+              "lastName",
+              "givenName",
+              "familyName"
+            ]
+          },
+          "confidenceThreshold": 0.6,
+          "target": "content"
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
### Describe your changes:

Fixes #29202 

This PR removes the content/column name split when using recognizers to remove the boosting quality of column name recognizers and have them contribute in equal terms to the content recognizers.

#
### Type of change:
- [X] Improvement

#
### High-level design:

`tag_analyzer.py` — Replaced `analyze_content`, `analyze_column`, `_build_tag_analysis` with a single `analyze(str_values, column_name)` method. It runs both paths internally, computes independent scores (avg-over-N for content, direct sum for column name), and returns one `TagAnalysis` with `score = max(content_score, column_score)`. target reflects whichever path produced the winning score.

`tag_scoring.py` — Removed `_column_name_contribution`, `_build_reason`, and the boosting formula. `predict_scores` now gates content analysis behind has_valid_content but lets column analysis run independently. Early exit only when both paths are unavailable. `_build_recognizer_metadata` now takes the unified TagAnalysis and works correctly whether the winning result came from content or column_name recognizers.

`piiTagsWithRecognizers.json` — Removed all 10 column_name recognizers from Sensitive and NonSensitive.

MySQL + Postgres migrations — Added statements to strip column_name recognizer entries from existing PII tag records using `JSON_TABLE / jsonb_array_elements` array filtering.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR refactors the PII classification algorithm to remove the "boosting" behavior where column name recognizers amplified content scores, replacing it with a unified `analyze()` method that independently scores both paths and takes `max(content_score, column_score)` as the final result. The default `column_name` recognizers are removed from `piiTagsWithRecognizers.json` and database migrations clean up existing records.

- **`tag_analyzer.py`**: Replaces `analyze_content()` + `analyze_column()` + `_build_tag_analysis()` with a single `analyze(str_values, run_column_analysis)` method; content and column scores are computed independently, the winning path's `RecognizerResult` list populates `recognizer_results`, while `explanation` is built from the combined results of both paths.
- **`tag_scoring.py`**: Removes the additive boosting formula; introduces `has_valid_content` to gate content analysis while allowing column analysis to run independently on low-cardinality columns; the `column_name: Optional[str]` ambiguity is resolved by replacing it with a clean `run_column_analysis: bool`.
- **Migrations (MySQL + Postgres)**: Strip `column_name`-targeted recognizer entries from existing `NonSensitive`/`Sensitive` PII tag records, correctly preserving entries whose `target` field is NULL.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the scoring refactor is well-scoped, all three previously flagged concerns (NULL-safe SQL migrations, boolean gate clarity, and recognizer metadata correctness) are correctly addressed in the implementation.

The unified analyze() method correctly handles all edge cases: content-only, column-only, and dual-path scenarios. The SQL migrations use IS NULL OR guards that keep recognizers without an explicit target field. The winning-path results are correctly isolated in recognizer_results, while the explanation uses the combined set for completeness. No correctness regressions identified.

No files require special attention. The migrations and scoring logic are consistent with the stated design goals.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| ingestion/src/metadata/pii/tag_analyzer.py | Replaces three separate methods with a unified analyze() method; correctly gates content/column paths, computes independent scores (avg-over-N for content, direct sum for column), caps both at 1.0, and returns the winning path's results in recognizer_results while combining both in explanation. |
| ingestion/src/metadata/pii/algorithms/tag_scoring.py | Removes additive boosting formula and column_name_contribution parameter; introduces has_valid_content to independently gate content analysis while allowing column analysis on low-cardinality columns; replaces ambiguous Optional[str] column_name with clear run_column_analysis bool. |
| bootstrap/sql/migrations/native/1.13.0/mysql/postDataMigrationSQLScript.sql | Adds UPDATE to strip column_name-targeted recognizers from NonSensitive/Sensitive PII tags; correctly handles recognizers with no explicit target field via IS NULL OR check, scoped to only rows that actually contain a column_name entry. |
| bootstrap/sql/migrations/native/1.13.0/postgres/postDataMigrationSQLScript.sql | Equivalent Postgres migration using jsonb_array_elements and jsonb_agg; same NULL-safe filter as MySQL; fixes a missing newline at end of file from the previous version. |
| openmetadata-service/src/main/resources/json/data/tags/piiTagsWithRecognizers.json | Removes all 10 default column_name recognizers from NonSensitive and Sensitive tags; adds empty recognizers array to None tag for schema completeness. |
| ingestion/tests/unit/metadata/pii/test_tag_scoring.py | Updates tests to new API; adds test_column_name_only_classifies_independently which correctly uses the email_tag fixture (which includes a column_name recognizer) to verify column-only classification fires without sample data. |
| ingestion/tests/unit/metadata/pii/test_tag_analyzer_any_language.py | Migrates all test call sites from analyze_content/analyze_column to the unified analyze() API; no behavioral changes to test assertions. |
| ingestion/tests/unit/metadata/pii/test_tag_processor.py | Minor fix replacing classification_manager.extend() call with direct FakeClassificationManager construction; unrelated to the core scoring change. |
| ingestion/tests/unit/metadata/pii/test_language_filtering.py | Updates mock setup from analyze_content/analyze_column return values to the unified analyze() return value. |

</details>

</details>

<details open><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[predict_scores] --> B[preprocess_values]
    B --> C{non-empty AND cardinality OK?}
    C -- Yes --> D[has_valid_content = true]
    C -- No --> E[has_valid_content = false]
    D --> F{run_column_analysis?}
    E --> F
    F -- both false --> G[return empty list]
    F -- at least one true --> H[analyzer.analyze]
    H --> I{str_values non-empty?}
    I -- Yes --> J[content analysis: sum scores divided by N, capped at 1.0]
    I -- No --> K[content_score = 0.0]
    J --> L{run_column_analysis?}
    K --> L
    L -- Yes --> M[column analysis: sum scores, capped at 1.0]
    L -- No --> N[column_score = 0.0]
    M --> O{column_score >= content_score AND column has results?}
    N --> O
    O -- Yes --> P[score = column_score, target = column_name]
    O -- No --> Q[score = content_score, target = content]
    P --> R[TagAnalysis returned]
    Q --> R
    R --> S{score > score_cutoff?}
    S -- Yes --> T[build ScoredTag from winning results]
    S -- No --> U[skip tag]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[predict_scores] --> B[preprocess_values]
    B --> C{non-empty AND cardinality OK?}
    C -- Yes --> D[has_valid_content = true]
    C -- No --> E[has_valid_content = false]
    D --> F{run_column_analysis?}
    E --> F
    F -- both false --> G[return empty list]
    F -- at least one true --> H[analyzer.analyze]
    H --> I{str_values non-empty?}
    I -- Yes --> J[content analysis: sum scores divided by N, capped at 1.0]
    I -- No --> K[content_score = 0.0]
    J --> L{run_column_analysis?}
    K --> L
    L -- Yes --> M[column analysis: sum scores, capped at 1.0]
    L -- No --> N[column_score = 0.0]
    M --> O{column_score >= content_score AND column has results?}
    N --> O
    O -- Yes --> P[score = column_score, target = column_name]
    O -- No --> Q[score = content_score, target = content]
    P --> R[TagAnalysis returned]
    Q --> R
    R --> S{score > score_cutoff?}
    S -- Yes --> T[build ScoredTag from winning results]
    S -- No --> U[skip tag]
```

</a>
</details>

<sub>Reviews (7): Last reviewed commit: ["fix(pii): cap content and column scores ..."](https://github.com/open-metadata/openmetadata/commit/4ece8cdc9641d895b7d9750af41460fab67c4a9a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38526873)</sub>

<!-- /greptile_comment -->