### PR TITLE
Fixes #27548: set updatedAt/updatedBy on OpenLineage auto-created entities

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/openlineage/OpenLineageEntityResolver.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/openlineage/OpenLineageEntityResolver.java
@@ -494,6 +494,9 @@ public class OpenLineageEntityResolver {
         newTable.setOwners(owners);
       }
 
+      newTable.setUpdatedBy(updatedBy);
+      newTable.setUpdatedAt(System.currentTimeMillis());
+
       Table created = tableRepository.create(null, newTable);
       LOG.info("Created table from OpenLineage event: {}", created.getFullyQualifiedName());
 
@@ -669,6 +672,9 @@ public class OpenLineageEntityResolver {
       newPipeline.setFullyQualifiedName(buildPipelineFqn(pipelineName));
       newPipeline.setService(serviceRef);
       newPipeline.setDescription("Pipeline created from OpenLineage event");
+
+      newPipeline.setUpdatedBy(updatedBy);
+      newPipeline.setUpdatedAt(System.currentTimeMillis());
 
       Pipeline created = pipelineRepository.create(null, newPipeline);
       LOG.info("Created pipeline from OpenLineage event: {}", created.getFullyQualifiedName());


### PR DESCRIPTION
Fixes #27548

I worked on OpenLineageEntityResolver because when OpenMetadata receives 
an OpenLineage event for a pipeline or table that doesn't exist yet, the 
code tries to auto-create that entity. The methods that do this 
(createTableInternal and createPipeline) take an updatedBy parameter, 
but they never actually set it on the entity object before saving it. 
They also never set updatedAt at all.

On PostgreSQL, updatedAt and updatedBy are required (NOT NULL) columns 
that get their value from the entity's JSON. Since the code never set 
those two fields, the database insert failed silently — the API still 
returned a 200 OK, but the entity was never actually saved. On MySQL 
this constraint isn't enforced the same way, so the same bug doesn't 
surface there.

The fix is two lines added in each method, right before the entity is 
saved:

  newTable.setUpdatedBy(updatedBy);
  newTable.setUpdatedAt(System.currentTimeMillis());

(and the same two lines for newPipeline in createPipeline()).

This is the same pattern already used elsewhere in the codebase, in 
EntityRepository.initializeEntity(), so I'm not introducing a new way 
of doing this — just applying the existing pattern to a place that 
was missing it.

#
### Type of change:
- [x] Bug fix

#
### High-level design:

N/A — small change, 6 lines added across two methods in one file.

#
### Tests:

#### Use cases covered
- Tables and Pipelines auto-created from OpenLineage events now get 
  updatedAt and updatedBy set, so they save correctly on PostgreSQL.

#### Unit tests
- [ ] I added unit tests for the new/changed logic.
- I did not add a new test. The existing OpenLineageEntityResolverTest 
  uses Mockito mocks for the repository, so it wouldn't catch this kind 
  of database-constraint issue anyway. I'm relying on this matching an 
  already-tested pattern elsewhere in the codebase.

#### Backend integration tests
- [x] Not applicable (no backend API changes).

#### Ingestion integration tests
- [x] Not applicable (no ingestion changes).

#### Playwright (UI) tests
- [x] Not applicable (no UI changes).

#### Manual testing performed
I did not run this against a live PostgreSQL instance. The fix mirrors 
the exact same setUpdatedBy/setUpdatedAt calls already used in 
EntityRepository.initializeEntity() elsewhere in the codebase.

#
### UI screen recording / screenshots:

Not applicable.

#
### Checklist:
- [x] I have read the CONTRIBUTING document.
- [x] My PR title is `Fixes #27548: set updatedAt/updatedBy on OpenLineage auto-created entities`
- [x] My PR is linked to a GitHub issue via `Fixes #27548` above.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.
- [ ] For UI changes: I attached a screen recording and/or screenshots above.
- [ ] I have added tests (unit / integration / Playwright as applicable) and listed them above.

#### Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a silent insert failure on PostgreSQL where auto-created `Table` and `Pipeline` entities were missing the required `updatedBy` and `updatedAt` fields before being persisted via `EntityRepository.create()`. Two lines are added to each of the two auto-creation methods, mirroring the pattern already established in `EntityRepository.initializeEntity()`.

- `createTableInternal`: adds `newTable.setUpdatedBy(updatedBy)` and `newTable.setUpdatedAt(System.currentTimeMillis())` before `tableRepository.create()`.
- `createPipeline`: adds the same two calls on `newPipeline` before `pipelineRepository.create()`.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

This change is safe to merge — it adds two missing field assignments in each of two entity-creation methods, directly preventing a NOT NULL constraint failure on PostgreSQL.

The fix is minimal, targeted, and mirrors the identical pattern used by EntityRepository.initializeEntity(). Both createTableInternal and createPipeline are now consistent with each other and with the rest of the codebase. No other entity-creation paths in this file are missing the same calls.

No files require special attention.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-service/src/main/java/org/openmetadata/service/openlineage/OpenLineageEntityResolver.java | Adds missing setUpdatedBy/setUpdatedAt calls before entity creation in createTableInternal and createPipeline, matching the pattern in EntityRepository.initializeEntity(). Both methods are now consistent. |

</details>

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant OL as OpenLineage Event
    participant Resolver as OpenLineageEntityResolver
    participant Repo as EntityRepository
    participant DB as PostgreSQL

    OL->>Resolver: Incoming event (pipeline/table not found)
    Resolver->>Resolver: createTableInternal() / createPipeline()
    Note over Resolver: Before fix: updatedBy/updatedAt not set<br/>After fix: setUpdatedBy(updatedBy)<br/>         setUpdatedAt(System.currentTimeMillis())
    Resolver->>Repo: repository.create(null, entity)
    Repo->>DB: INSERT entity JSON (with updatedBy + updatedAt)
    DB-->>Repo: success (NOT NULL constraint satisfied)
    Repo-->>Resolver: created entity reference
    Resolver-->>OL: EntityReference returned
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant OL as OpenLineage Event
    participant Resolver as OpenLineageEntityResolver
    participant Repo as EntityRepository
    participant DB as PostgreSQL

    OL->>Resolver: Incoming event (pipeline/table not found)
    Resolver->>Resolver: createTableInternal() / createPipeline()
    Note over Resolver: Before fix: updatedBy/updatedAt not set<br/>After fix: setUpdatedBy(updatedBy)<br/>         setUpdatedAt(System.currentTimeMillis())
    Resolver->>Repo: repository.create(null, entity)
    Repo->>DB: INSERT entity JSON (with updatedBy + updatedAt)
    DB-->>Repo: success (NOT NULL constraint satisfied)
    Repo-->>Resolver: created entity reference
    Resolver-->>OL: EntityReference returned
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: set updatedAt/updatedBy on OpenLine..."](https://github.com/open-metadata/openmetadata/commit/4ee5a4b1687ceda1f1ee4703d895d653670789f2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38577628)</sub>

<!-- /greptile_comment -->