### PR TITLE
fix(ui): relative imports to avoid breaking builds

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/utils/ContextCenterPureUtils.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/ContextCenterPureUtils.ts
@@ -15,12 +15,12 @@ import { AxiosError } from 'axios';
 import cryptoRandomString from 'crypto-random-string-with-promisify-polyfill';
 import { isNull, isUndefined } from 'lodash';
 import { PagingResponse } from 'Models';
-import { ListParams } from 'src/interface/API.interface';
 import { CREATE_PAGE_HASH } from '../constants/constants';
 import { EntityType } from '../enums/entity.enum';
 import type { Asset } from '../generated/attachments/asset';
 import { AssetType } from '../generated/attachments/asset';
 import type { ContextFile } from '../generated/entity/data/contextFile';
+import { ListParams } from '../interface/API.interface';
 import type {
   CreateKnowledgePage,
   QuickLink,

--- a/openmetadata-ui/src/main/resources/ui/src/utils/Lineage/LineageUtils.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/Lineage/LineageUtils.tsx
@@ -16,6 +16,7 @@ import { ChevronRight } from '@untitledui/icons';
 import { ReactComponent as ColumnIcon } from '../../assets/svg/ic-column.svg';
 import { ReactComponent as TableIcon } from '../../assets/svg/ic-table-new.svg';
 import { CondensedBreadcrumb } from '../../components/CondensedBreadcrumb/CondensedBreadcrumb.component';
+import { NodeData } from '../../components/Lineage/Lineage.interface';
 import { EImpactLevel } from '../../components/LineageTable/LineageTable.interface';
 import i18n from '../i18next/LocalUtil';
 

--- a/openmetadata-ui/src/main/resources/ui/tsconfig.json
+++ b/openmetadata-ui/src/main/resources/ui/tsconfig.json
@@ -56,7 +56,6 @@
     "allowUnreachableCode": false,
     "skipLibCheck": true,
     "noImplicitAny": true,
-    "baseUrl": ".",
     "paths": {
       "react-hook-form": ["./node_modules/react-hook-form"]
     }


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:

Fixes #<issue-number>
<!--
Linking an issue is REQUIRED. Replace <issue-number> with the GitHub issue number this PR addresses
(e.g., `Fixes #12345`). GitHub will auto-link it. If no issue exists, please open one first so the
problem and design can be discussed before review.
-->

<!--
Short blurb explaining:
- What changes did you make?
- Why did you make them?
-->

I worked on ... because ...

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### High-level design:
<!--
REQUIRED for large PRs (new features, refactors, breaking changes, or anything touching >5 files).
Skip for small bug fixes and trivial changes.

Cover:
- Architecture / approach you took and why
- Key components or files added/changed and how they interact
- Alternatives considered and why you rejected them
- Any migration, backward-compatibility, or rollout concerns
- Diagrams or links to design docs / RFCs if available
-->

N/A — small change. <!-- Or fill in the design above -->

#
### Tests:

#### Use cases covered
<!--
List the user-visible scenarios this PR exercises. Example:
- User with Admin role can create a Glossary Term with a parent term
- Ingestion run for Snowflake correctly extracts row counts for partitioned tables
-->

#### Unit tests
<!--
- [ ] I added unit tests for the new/changed logic.
- Files added/updated:
- Coverage on changed classes (run `mvn jacoco:report` for backend, `yarn test:coverage` for UI,
  `make unit_ingestion` for ingestion). Target is 90% line coverage on changed classes.
- Coverage %: <e.g., 92% on EntityRepository.java>
-->

#### Backend integration tests
<!--
- [ ] I added integration tests in `openmetadata-integration-tests/` for new/changed API endpoints.
- [ ] Not applicable (no backend API changes).
- Files added/updated:
-->

#### Ingestion integration tests
<!--
- [ ] I added/updated ingestion integration tests for connector changes.
- [ ] Not applicable (no ingestion changes).
- Files added/updated:
-->

#### Playwright (UI) tests
<!--
- [ ] I added Playwright E2E tests under `openmetadata-ui/.../ui/playwright/` for UI changes.
- [ ] Not applicable (no UI changes).
- Files added/updated:
-->

#### Manual testing performed
<!--
List the manual test steps you performed before requesting review. Example:
1. Started local stack via `./docker/run_local_docker.sh -m ui -d mysql`
2. Logged in as admin, created entity X, verified Y appears in the UI
3. Triggered ingestion for Snowflake source, confirmed lineage edges in the explore page
-->

#
### UI screen recording / screenshots:
<!--
REQUIRED for any PR that changes the UI. Drag-and-drop a short screen recording (.mov / .mp4 / .gif)
demonstrating the change end-to-end, plus before/after screenshots where relevant.
Mark "Not applicable" if there are no UI changes.
-->

Not applicable. <!-- Or attach recording/screenshots above -->

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.
- [ ] For UI changes: I attached a screen recording and/or screenshots above.
- [ ] I have added tests (unit / integration / Playwright as applicable) and listed them above.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR eliminates bare `src/`-rooted imports that relied on `baseUrl: "."` in `tsconfig.json`, replacing them with relative paths and removing the `baseUrl` setting itself.

- **`tsconfig.json`**: Drops `baseUrl: "."`, which prevented TypeScript from silently resolving ambiguous bare-module imports using the project root.
- **`ContextCenterPureUtils.ts`**: Converts `import … from 'src/interface/API.interface'` to the equivalent relative path `'../interface/API.interface'`, the only remaining `src/`-rooted import in the codebase.
- **`LineageUtils.tsx`**: Adds the previously-absent `NodeData` relative import, which was already referenced in function signatures on lines 67–68.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is a targeted import hygiene fix with no remaining bare src/-rooted imports anywhere in the codebase.

The removed baseUrl setting had exactly one consumer left in the codebase (the ListParams import in ContextCenterPureUtils.ts), which has been converted to a relative path. NodeData was already used in LineageUtils.tsx but its import was missing, so adding it only resolves a latent issue. No other files were found using src/-rooted bare imports.

No files require special attention.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-ui/src/main/resources/ui/tsconfig.json | Removes baseUrl: "." to stop TypeScript from resolving src/-rooted bare imports; all consumers have been converted to relative imports |
| openmetadata-ui/src/main/resources/ui/src/utils/ContextCenterPureUtils.ts | Converts ListParams import from bare src/-rooted path to a relative path, fixing the build break introduced by the baseUrl removal |
| openmetadata-ui/src/main/resources/ui/src/utils/Lineage/LineageUtils.tsx | Adds the previously-missing NodeData import (relative path) that was needed by function signatures on lines 67-68 |

</details>

</details>

<details open><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["tsconfig.json\n(baseUrl: '.' removed)"] -->|"no longer resolves"| B["bare 'src/...' imports"]
    B -->|"converted to"| C["relative '../...' imports"]
    C --> D["ContextCenterPureUtils.ts\n'../interface/API.interface'"]
    C --> E["LineageUtils.tsx\n'../../components/Lineage/Lineage.interface'"]
    A --> F["Only remaining path alias:\nreact-hook-form → node_modules"]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["tsconfig.json\n(baseUrl: '.' removed)"] -->|"no longer resolves"| B["bare 'src/...' imports"]
    B -->|"converted to"| C["relative '../...' imports"]
    C --> D["ContextCenterPureUtils.ts\n'../interface/API.interface'"]
    C --> E["LineageUtils.tsx\n'../../components/Lineage/Lineage.interface'"]
    A --> F["Only remaining path alias:\nreact-hook-form → node_modules"]
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(ui): relative imports to avoid break..."](https://github.com/open-metadata/openmetadata/commit/c03c032d4ce24bac99234aac99c2df479320f261) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38586626)</sub>

<!-- /greptile_comment -->