### PR TITLE
fix(ui): resolve QuickFilterDropdown import on 1.13

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/Explore/QuickFilterDropdown.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Explore/QuickFilterDropdown.test.tsx
@@ -22,7 +22,7 @@ jest.mock('../../constants/AdvancedSearch.constants', () => ({
   NULL_OPTION_KEY: 'null_option_key',
 }));
 
-jest.mock('../../utils/AdvancedSearchPureUtils', () => ({
+jest.mock('../../utils/AdvancedSearchUtils', () => ({
   getSelectedOptionLabelString: (options: { label: string }[]) =>
     (options ?? []).map((option) => option.label).join(', '),
 }));

--- a/openmetadata-ui/src/main/resources/ui/src/components/Explore/QuickFilterDropdown.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Explore/QuickFilterDropdown.tsx
@@ -22,7 +22,7 @@ import { debounce, isUndefined } from 'lodash';
 import { FC, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { NULL_OPTION_KEY } from '../../constants/AdvancedSearch.constants';
-import { getSelectedOptionLabelString } from '../../utils/AdvancedSearchPureUtils';
+import { getSelectedOptionLabelString } from '../../utils/AdvancedSearchUtils';
 import Loader from '../common/Loader/Loader';
 import { SearchDropdownOption } from '../SearchDropdown/SearchDropdown.interface';
 import { QuickFilterDropdownProps } from './QuickFilterDropdown.interface';


### PR DESCRIPTION
## What

Re-points the `getSelectedOptionLabelString` import in `QuickFilterDropdown.tsx` (and its test mock) from `../../utils/AdvancedSearchPureUtils` → `../../utils/AdvancedSearchUtils`, **on the 1.13 line only**.

## Why

The Collate 1.13 build fails with:

```
Could not resolve "../../utils/AdvancedSearchPureUtils" from
  .../src/components/Explore/QuickFilterDropdown.tsx
```

`QuickFilterDropdown` was cherry-picked into 1.13 (#29168) carrying an import of `AdvancedSearchPureUtils` — a module that only exists on `main`, created by the un-backported refactor #28704 (*"extract form/search etc pure utils"*). On 1.13 that split never happened, so `getSelectedOptionLabelString` still lives in `AdvancedSearchUtils.tsx` (where `DataQualityDashboard` and `SearchDropdown` already import it from on 1.13).

Rather than back-port the large #28704 refactor (18 files, ~±3000 lines), this adapts the cherry-pick to the 1.13 codebase by pointing at the module that actually exists there.

## Scope

- 1.13-only. `main` already has `AdvancedSearchPureUtils` and is unaffected.
- 2 files, 2 lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a build breakage on the 1.13 branch where `QuickFilterDropdown.tsx` (cherry-picked from main in #29168) imported `getSelectedOptionLabelString` from `AdvancedSearchPureUtils` — a module introduced on main by #28704 that was never back-ported to 1.13. The fix re-points both the production import and the Jest mock to `AdvancedSearchUtils`, which exports the function on 1.13 (confirmed at line 242).

- **`QuickFilterDropdown.tsx`**: import path corrected from `../../utils/AdvancedSearchPureUtils` → `../../utils/AdvancedSearchUtils`; no logic changes.
- **`QuickFilterDropdown.test.tsx`**: `jest.mock` target updated to match the new import path, keeping the mock in sync with the module being tested.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — two-line import path fix that unblocks the 1.13 build with no logic changes.

Both changed lines are pure import redirects; getSelectedOptionLabelString is confirmed to exist and be exported from AdvancedSearchUtils on 1.13, and AdvancedSearchPureUtils is confirmed absent. The test mock is updated consistently, so the test suite will resolve correctly as well.

No files require special attention.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-ui/src/main/resources/ui/src/components/Explore/QuickFilterDropdown.tsx | Redirects getSelectedOptionLabelString import from the non-existent AdvancedSearchPureUtils to AdvancedSearchUtils, which exports the function on 1.13. |
| openmetadata-ui/src/main/resources/ui/src/components/Explore/QuickFilterDropdown.test.tsx | Updates the Jest mock to match the corrected import path, keeping the test aligned with the production module resolution. |

</details>

</details>

<details open><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[QuickFilterDropdown.tsx] -->|"imports getSelectedOptionLabelString"| B{1.13 branch?}
    B -->|"Before (broken)"| C["AdvancedSearchPureUtils ❌\n(only exists on main)"]
    B -->|"After (fixed)"| D["AdvancedSearchUtils ✅\n(exists on 1.13, line 242)"]
    E[QuickFilterDropdown.test.tsx] -->|"jest.mock"| F{1.13 branch?}
    F -->|"Before (broken)"| G["AdvancedSearchPureUtils ❌"]
    F -->|"After (fixed)"| H["AdvancedSearchUtils ✅"]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[QuickFilterDropdown.tsx] -->|"imports getSelectedOptionLabelString"| B{1.13 branch?}
    B -->|"Before (broken)"| C["AdvancedSearchPureUtils ❌\n(only exists on main)"]
    B -->|"After (fixed)"| D["AdvancedSearchUtils ✅\n(exists on 1.13, line 242)"]
    E[QuickFilterDropdown.test.tsx] -->|"jest.mock"| F{1.13 branch?}
    F -->|"Before (broken)"| G["AdvancedSearchPureUtils ❌"]
    F -->|"After (fixed)"| H["AdvancedSearchUtils ✅"]
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(ui): resolve QuickFilterDropdown imp..."](https://github.com/open-metadata/openmetadata/commit/73a559e00af4cfd78d70d8bd5c84aa82884592fa) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38590402)</sub>

<!-- /greptile_comment -->