### PR TITLE
fix(glossary): keep approvals valid after move

### DIFF
--- a/bootstrap/sql/migrations/native/1.12.12/mysql/schemaChanges.sql
+++ b/bootstrap/sql/migrations/native/1.12.12/mysql/schemaChanges.sql
@@ -1,0 +1,7 @@
+-- Widen tag_usage.tagFQN (was VARCHAR(256)) toward the fullyQualifiedEntityName contract (max 3072).
+-- Entity names allow up to 256 chars and nested glossary terms concatenate, so a tag FQN routinely
+-- exceeds 256 -- which made applyTag inserts and glossaryTerm moveAsync renames fail with
+-- "value too long". MySQL widens the base column in place (the tagfqn_lower STORED generated column
+-- and the tagFQN(255)-prefix indexes are unaffected). 512 keeps the full-tagFQN
+-- idx_tag_usage_target_source within InnoDB's 3072-byte key limit (768 + 1 + 512*4 = 2817 bytes).
+ALTER TABLE tag_usage MODIFY tagFQN VARCHAR(512) NOT NULL;

--- a/bootstrap/sql/migrations/native/1.12.12/postgres/schemaChanges.sql
+++ b/bootstrap/sql/migrations/native/1.12.12/postgres/schemaChanges.sql
@@ -1,0 +1,16 @@
+-- Widen tag_usage.tagFQN (was VARCHAR(256)) toward the fullyQualifiedEntityName contract (max 3072).
+-- Entity names allow up to 256 chars and nested glossary terms concatenate, so a tag FQN routinely
+-- exceeds 256 -- which made applyTag inserts and glossaryTerm moveAsync renames fail with
+-- "value too long for type character varying(256)". tagFQN feeds the tagfqn_lower generated column,
+-- which Postgres will not let us re-type in place, so drop it (cascading its two text_pattern_ops
+-- indexes), widen tagFQN, then recreate the column and those indexes unchanged. 512 keeps the column
+-- within MySQL InnoDB's 3072-byte key limit for the full-tagFQN idx_tag_usage_target_source index.
+ALTER TABLE tag_usage DROP COLUMN IF EXISTS tagfqn_lower;
+ALTER TABLE tag_usage ALTER COLUMN tagFQN TYPE VARCHAR(512);
+ALTER TABLE tag_usage ADD COLUMN tagfqn_lower text GENERATED ALWAYS AS (lower(tagFQN)) STORED;
+ALTER TABLE tag_usage ALTER COLUMN tagfqn_lower SET STATISTICS 500;
+CREATE INDEX IF NOT EXISTS idx_tag_usage_tagfqn_lower_pattern
+    ON tag_usage (tagfqn_lower text_pattern_ops);
+CREATE INDEX IF NOT EXISTS idx_tag_usage_tagfqn_prefix_covering
+    ON tag_usage (source, tagfqn_lower text_pattern_ops)
+    INCLUDE (targetFQNHash, labelType, state);

--- a/bootstrap/sql/schema/mysql.sql
+++ b/bootstrap/sql/schema/mysql.sql
@@ -905,7 +905,7 @@ DROP TABLE IF EXISTS `tag_usage`;
 /*!50503 SET character_set_client = utf8mb4 */;
 CREATE TABLE `tag_usage` (
   `source` tinyint NOT NULL,
-  `tagFQN` varchar(256) NOT NULL,
+  `tagFQN` varchar(512) NOT NULL,
   `labelType` tinyint NOT NULL,
   `state` tinyint NOT NULL,
   `tagFQNHash` varchar(768) CHARACTER SET ascii COLLATE ascii_bin DEFAULT NULL,

--- a/bootstrap/sql/schema/postgres.sql
+++ b/bootstrap/sql/schema/postgres.sql
@@ -839,7 +839,7 @@ ALTER TABLE public.tag OWNER TO openmetadata_user;
 
 CREATE TABLE public.tag_usage (
     source smallint NOT NULL,
-    tagfqn character varying(256) NOT NULL,
+    tagfqn character varying(512) NOT NULL,
     labeltype smallint NOT NULL,
     state smallint NOT NULL,
     tagfqnhash character varying(382),

--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/GlossaryTermMoveApprovalIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/GlossaryTermMoveApprovalIT.java
@@ -1,0 +1,449 @@
+/*
+ *  Copyright 2024 Collate
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.openmetadata.it.tests;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.openmetadata.it.bootstrap.SharedEntities;
+import org.openmetadata.it.factories.DatabaseSchemaTestFactory;
+import org.openmetadata.it.factories.DatabaseServiceTestFactory;
+import org.openmetadata.it.util.SdkClients;
+import org.openmetadata.it.util.TestNamespace;
+import org.openmetadata.it.util.TestNamespaceExtension;
+import org.openmetadata.schema.api.data.CreateGlossary;
+import org.openmetadata.schema.api.data.CreateGlossaryTerm;
+import org.openmetadata.schema.api.data.CreateTable;
+import org.openmetadata.schema.api.data.MoveGlossaryTermRequest;
+import org.openmetadata.schema.api.feed.ResolveTask;
+import org.openmetadata.schema.entity.data.DatabaseSchema;
+import org.openmetadata.schema.entity.data.Glossary;
+import org.openmetadata.schema.entity.data.GlossaryTerm;
+import org.openmetadata.schema.entity.feed.Thread;
+import org.openmetadata.schema.entity.services.DatabaseService;
+import org.openmetadata.schema.entity.teams.User;
+import org.openmetadata.schema.type.EntityReference;
+import org.openmetadata.schema.type.EntityStatus;
+import org.openmetadata.schema.type.TagLabel;
+import org.openmetadata.schema.type.TaskStatus;
+import org.openmetadata.schema.type.TaskType;
+import org.openmetadata.sdk.client.OpenMetadataClient;
+import org.openmetadata.sdk.fluent.builders.ColumnBuilder;
+import org.openmetadata.sdk.network.HttpMethod;
+import org.openmetadata.sdk.network.RequestOptions;
+import org.openmetadata.service.Entity;
+
+/**
+ * Reproduces the glossary-approval regression where moving a term (or one of its ancestors) while a
+ * descendant term still has an OPEN approval task breaks the approval workflow.
+ *
+ * <p>Scenario (from the bug report):
+ *
+ * <ol>
+ *   <li>Glossary approval is enabled and {@code Securities Lending.Eligible Securities} is created.
+ *       The leaf term {@code Eligible Securities} gets an open approval task.
+ *   <li>A new parent {@code Product and Service} is created and {@code Securities Lending} is moved
+ *       under it, rewriting the leaf term's FQN via a prefix cascade.
+ *   <li>The still-open approval task for {@code Eligible Securities} is approved.
+ * </ol>
+ *
+ * <p>The Glossary Approval Workflow captures the term as a {@code relatedEntity} EntityLink built
+ * from the FQN at trigger time. The move rewrites the term's FQN (and tag usages, field
+ * relationships and legacy feed-thread {@code about}) but NOT the running workflow instance's
+ * {@code relatedEntity} variable. When the task is approved, the workflow's {@code
+ * SetEntityAttributeImpl} resolves {@code relatedEntity} via {@code Entity.getEntity(entityLink)}
+ * using the stale pre-move FQN and throws {@code "glossaryTerm instance for <oldFqn> not found"},
+ * so the Glossary Approval Workflow instance never reaches {@code FINISHED}.
+ *
+ * <p>The fix records the entity's immutable id ({@code relatedEntityId}) at trigger time and has the
+ * workflow nodes resolve the term by id (with an FQN fallback), so a moved/renamed FQN no longer
+ * breaks resolution.
+ *
+ * <p>These tests assert the post-fix invariant: after approving the moved term's task, the term is
+ * {@code Approved} AND the approval workflow instance completes successfully. Without the fix the
+ * workflow instance fails to advance past the failing {@code SetEntityAttribute} node.
+ */
+@ExtendWith(TestNamespaceExtension.class)
+@Execution(ExecutionMode.CONCURRENT)
+public class GlossaryTermMoveApprovalIT {
+
+  private static final String APPROVAL_WORKFLOW = "GlossaryTermApprovalWorkflow";
+  private static final String WORKFLOW_STATUS_FINISHED = "FINISHED";
+  private static final Set<String> TERMINAL_WORKFLOW_STATUSES =
+      Set.of("FINISHED", "EXCEPTION", "FAILURE");
+  private static final Duration TASK_TIMEOUT = Duration.ofMinutes(3);
+  private static final Duration MOVE_TIMEOUT = Duration.ofMinutes(2);
+  private static final Duration STATUS_TIMEOUT = Duration.ofMinutes(2);
+  private static final Duration POLL_INTERVAL = Duration.ofSeconds(2);
+
+  protected SharedEntities shared() {
+    return SharedEntities.get();
+  }
+
+  protected User reviewer() {
+    return shared().USER1;
+  }
+
+  /**
+   * Documented repro: a leaf term has an open approval task, then its parent is moved under a new
+   * term. Approving the leaf's task must still drive the leaf to Approved and complete the workflow.
+   */
+  // Deterministic regardless of the move's async timing: the workflow resolves the leaf by its
+  // immutable id (relatedEntityId), so approving after the move no longer depends on the FQN being
+  // repointed first.
+  @Test
+  void test_approveApprovalTaskAfterMovingParentTerm_drivesMovedTermToApproved(TestNamespace ns)
+      throws Exception {
+    Glossary glossary = createGlossary(ns);
+
+    GlossaryTerm securitiesLending = createTerm(glossary, null, "securities_lending", false);
+    GlossaryTerm eligibleSecurities =
+        createTerm(glossary, securitiesLending, "eligible_securities", true);
+
+    String preMoveLeafFqn = eligibleSecurities.getFullyQualifiedName();
+    Thread approvalTask = waitForOpenApprovalTask(preMoveLeafFqn);
+
+    GlossaryTerm productAndService = createTerm(glossary, null, "product_and_service", false);
+
+    moveGlossaryTerm(securitiesLending.getId(), reference(productAndService, Entity.GLOSSARY_TERM));
+
+    String movedLeafFqn = waitForTermFqnChange(eligibleSecurities.getId(), preMoveLeafFqn);
+    assertTrue(
+        movedLeafFqn.startsWith(productAndService.getFullyQualifiedName() + "."),
+        "Leaf term should now live under the new parent. fqn=" + movedLeafFqn);
+
+    approveTask(approvalTask);
+
+    waitForTermStatus(eligibleSecurities.getId(), EntityStatus.APPROVED);
+    assertApprovalWorkflowFinished(movedLeafFqn);
+  }
+
+  /**
+   * Variant exercising the move-to-glossary-root path: a deeply nested leaf term has an open
+   * approval task, then an ancestor is moved to the glossary root.
+   */
+  // Deterministic via by-id resolution (see the parent-move test).
+  @Test
+  void test_approveApprovalTaskAfterMovingAncestorToGlossaryRoot_drivesMovedTermToApproved(
+      TestNamespace ns) throws Exception {
+    Glossary glossary = createGlossary(ns);
+
+    GlossaryTerm top = createTerm(glossary, null, "asset_class", false);
+    GlossaryTerm middle = createTerm(glossary, top, "securities_lending", false);
+    GlossaryTerm leaf = createTerm(glossary, middle, "eligible_securities", true);
+
+    String preMoveLeafFqn = leaf.getFullyQualifiedName();
+    Thread approvalTask = waitForOpenApprovalTask(preMoveLeafFqn);
+
+    moveGlossaryTerm(middle.getId(), reference(glossary, Entity.GLOSSARY));
+
+    String movedLeafFqn = waitForTermFqnChange(leaf.getId(), preMoveLeafFqn);
+    assertFalse(
+        movedLeafFqn.startsWith(top.getFullyQualifiedName() + "."),
+        "Leaf term should no longer live under the original ancestor. fqn=" + movedLeafFqn);
+    assertTrue(
+        movedLeafFqn.startsWith(glossary.getFullyQualifiedName() + "." + middle.getName() + "."),
+        "Leaf term should now live under the glossary root parent. fqn=" + movedLeafFqn);
+
+    approveTask(approvalTask);
+
+    waitForTermStatus(leaf.getId(), EntityStatus.APPROVED);
+    assertApprovalWorkflowFinished(movedLeafFqn);
+  }
+
+  /**
+   * Rename path: a leaf term has an open approval task, then its parent is RENAMED (PATCH name),
+   * which cascades the leaf's FQN exactly like a move. Approving the leaf's task must still complete
+   * the workflow — by-id resolution makes this work regardless of the renamed FQN.
+   */
+  @Test
+  void test_approveApprovalTaskAfterRenamingParentTerm_drivesRenamedTermToApproved(TestNamespace ns)
+      throws Exception {
+    Glossary glossary = createGlossary(ns);
+
+    GlossaryTerm parent = createTerm(glossary, null, "securities_lending", false);
+    GlossaryTerm leaf = createTerm(glossary, parent, "eligible_securities", true);
+
+    String preRenameLeafFqn = leaf.getFullyQualifiedName();
+    Thread approvalTask = waitForOpenApprovalTask(preRenameLeafFqn);
+
+    renameTerm(parent.getId(), "securities_lending_renamed");
+
+    String renamedLeafFqn = waitForTermFqnChange(leaf.getId(), preRenameLeafFqn);
+    assertTrue(
+        renamedLeafFqn.contains("securities_lending_renamed"),
+        "Leaf FQN should reflect the renamed parent. fqn=" + renamedLeafFqn);
+
+    approveTask(approvalTask);
+
+    waitForTermStatus(leaf.getId(), EntityStatus.APPROVED);
+    assertApprovalWorkflowFinished(renamedLeafFqn);
+  }
+
+  /**
+   * Atomicity: moving a term under a long-named parent produces an FQN beyond {@code
+   * tag_usage.tagFQN}'s VARCHAR(512), so the move's tag rename fails mid-operation. The move must
+   * roll back fully — the term's FQN must NOT change — rather than leaving the FQN rewritten while
+   * relationships/tag usages are not. (Two 256-char names are needed so the moved FQN exceeds the
+   * widened 512-char column.)
+   */
+  @Test
+  void test_moveOfLongFqnTermIsAtomic_noPartialStateOnFailure(TestNamespace ns) throws Exception {
+    OpenMetadataClient admin = SdkClients.adminClient();
+    Glossary glossary = createGlossary(ns);
+
+    String parentName = ("par_" + "y".repeat(256)).substring(0, 256);
+    String termName = ("lng_" + "x".repeat(256)).substring(0, 256);
+    GlossaryTerm longParent = createTerm(glossary, null, parentName, false);
+    GlossaryTerm longTerm = createTerm(glossary, null, termName, false);
+    String originalFqn = longTerm.getFullyQualifiedName();
+
+    String wouldBeFqn = longParent.getFullyQualifiedName() + "." + longTerm.getName();
+    assertTrue(
+        wouldBeFqn.length() > 512,
+        "Moved FQN must exceed the 512-char tag_usage limit to trigger the mid-move failure: "
+            + wouldBeFqn.length());
+
+    // Tag the term onto a table so the move's tag rename has a row to update. The pre-move FQN fits
+    // in tag_usage.tagFQN(512), but the post-move FQN does not, so the rename overflows on BOTH
+    // engines. (On MySQL a 0-row UPDATE would not overflow, unlike Postgres which coerces the bind
+    // param regardless of matching rows.)
+    tagTermOntoNewTable(ns, longTerm);
+
+    moveGlossaryTerm(longTerm.getId(), reference(longParent, Entity.GLOSSARY_TERM));
+
+    // The async move fails on the oversized tag rename. With the atomicity fix it rolls back, so
+    // the
+    // term's FQN never changes; a partial move would flip it to the new parent's path. Assert the
+    // FQN stays put across a window that comfortably contains the (fast) async move execution.
+    Awaitility.await("long-FQN move must not partially apply")
+        .during(Duration.ofSeconds(6))
+        .atMost(Duration.ofSeconds(25))
+        .pollInterval(Duration.ofMillis(500))
+        .untilAsserted(
+            () ->
+                assertEquals(
+                    originalFqn,
+                    admin.glossaryTerms().get(longTerm.getId().toString()).getFullyQualifiedName(),
+                    "Term FQN changed — the failed move left partial state"));
+  }
+
+  private Glossary createGlossary(TestNamespace ns) {
+    CreateGlossary create =
+        new CreateGlossary()
+            .withName(ns.shortPrefix("tisa"))
+            .withDescription("Glossary for move + approval regression test");
+    return ns.trackRoot(Entity.GLOSSARY, SdkClients.adminClient().glossaries().create(create));
+  }
+
+  /**
+   * Reviewers are attached only to the term that needs an open task. Parent terms have no reviewers
+   * and are auto-approved, so the move does not re-trigger sibling approval workflows and exactly
+   * one open task exists for the leaf term.
+   */
+  private GlossaryTerm createTerm(
+      Glossary glossary, GlossaryTerm parent, String name, boolean withReviewer) {
+    CreateGlossaryTerm create =
+        new CreateGlossaryTerm()
+            .withName(name)
+            .withGlossary(glossary.getFullyQualifiedName())
+            .withDescription("Term created by move + approval regression test");
+    if (parent != null) {
+      create.withParent(parent.getFullyQualifiedName());
+    }
+    if (withReviewer) {
+      create.withReviewers(List.of(reviewer().getEntityReference()));
+    }
+    return SdkClients.adminClient().glossaryTerms().create(create);
+  }
+
+  private EntityReference reference(GlossaryTerm term, String type) {
+    return new EntityReference().withId(term.getId()).withType(type);
+  }
+
+  private EntityReference reference(Glossary glossary, String type) {
+    return new EntityReference().withId(glossary.getId()).withType(type);
+  }
+
+  private void moveGlossaryTerm(UUID termId, EntityReference newParent) {
+    MoveGlossaryTermRequest request = new MoveGlossaryTermRequest().withParent(newParent);
+    try {
+      SdkClients.adminClient()
+          .getHttpClient()
+          .executeForString(HttpMethod.PUT, "/v1/glossaryTerms/" + termId + "/moveAsync", request);
+    } catch (Exception e) {
+      throw new RuntimeException("Failed to submit move for glossary term " + termId, e);
+    }
+  }
+
+  private void renameTerm(UUID termId, String newName) throws Exception {
+    JsonNode patch =
+        new ObjectMapper()
+            .readTree(
+                String.format(
+                    "[{\"op\":\"replace\",\"path\":\"/name\",\"value\":\"%s\"}]", newName));
+    SdkClients.adminClient().glossaryTerms().patch(termId.toString(), patch);
+  }
+
+  private void tagTermOntoNewTable(TestNamespace ns, GlossaryTerm term) {
+    DatabaseService service = DatabaseServiceTestFactory.createPostgres(ns);
+    DatabaseSchema schema = DatabaseSchemaTestFactory.createSimple(ns, service);
+    CreateTable tableRequest = new CreateTable();
+    tableRequest.setName(ns.shortPrefix("atomic_tbl"));
+    tableRequest.setDatabaseSchema(schema.getFullyQualifiedName());
+    tableRequest.setColumns(
+        List.of(ColumnBuilder.of("id", "BIGINT").primaryKey().notNull().build()));
+    tableRequest.setTags(
+        List.of(
+            new TagLabel()
+                .withTagFQN(term.getFullyQualifiedName())
+                .withSource(TagLabel.TagSource.GLOSSARY)
+                .withLabelType(TagLabel.LabelType.MANUAL)));
+    SdkClients.adminClient().tables().create(tableRequest);
+  }
+
+  private Thread waitForOpenApprovalTask(String aboutFqn) {
+    String entityLink = glossaryTermEntityLink(aboutFqn);
+    Awaitility.await("wait for open glossary approval task for " + aboutFqn)
+        .atMost(TASK_TIMEOUT)
+        .pollInterval(POLL_INTERVAL)
+        .ignoreExceptions()
+        .until(() -> !listTasks(entityLink).isEmpty());
+    List<Thread> tasks = listTasks(entityLink);
+    assertFalse(tasks.isEmpty(), "Expected an open approval task for " + aboutFqn);
+    Thread task = tasks.get(0);
+    assertNotNull(task.getTask());
+    assertNotNull(task.getTask().getId());
+    return task;
+  }
+
+  private List<Thread> listTasks(String entityLink) {
+    return SdkClients.adminClient().feed().listTasks(entityLink, TaskStatus.Open, null).getData()
+        .stream()
+        .filter(thread -> thread.getTask() != null)
+        .filter(thread -> TaskType.RequestApproval.equals(thread.getTask().getType()))
+        .toList();
+  }
+
+  private String waitForTermFqnChange(UUID termId, String previousFqn) {
+    Awaitility.await("glossary term " + termId + " FQN should change after move")
+        .atMost(MOVE_TIMEOUT)
+        .pollInterval(POLL_INTERVAL)
+        .ignoreExceptions()
+        .until(() -> !previousFqn.equals(currentFqn(termId)));
+    return currentFqn(termId);
+  }
+
+  private String currentFqn(UUID termId) {
+    return SdkClients.adminClient().glossaryTerms().get(termId.toString()).getFullyQualifiedName();
+  }
+
+  private void approveTask(Thread task) throws Exception {
+    SdkClients.user1Client()
+        .getHttpClient()
+        .executeForString(
+            HttpMethod.PUT,
+            "/v1/feed/tasks/" + task.getTask().getId() + "/resolve",
+            new ResolveTask().withNewValue(EntityStatus.APPROVED.value()),
+            RequestOptions.builder().build());
+  }
+
+  private void waitForTermStatus(UUID termId, EntityStatus expected) {
+    Awaitility.await("glossary term " + termId + " should reach status " + expected)
+        .atMost(STATUS_TIMEOUT)
+        .pollInterval(POLL_INTERVAL)
+        .ignoreExceptions()
+        .untilAsserted(
+            () ->
+                assertEquals(
+                    expected,
+                    SdkClients.adminClient()
+                        .glossaryTerms()
+                        .get(termId.toString())
+                        .getEntityStatus()));
+  }
+
+  /**
+   * The Glossary Approval Workflow instance follows the term across a move/rename: the move repoints
+   * the instance's {@code relatedEntity} to the new FQN (so the history card resolves at the term's
+   * current location), so it is queried by the POST-move FQN. After approval it must complete; the
+   * stale-relatedEntity bug stops it from advancing past the failing SetEntityAttribute node so it
+   * never reaches FINISHED.
+   */
+  private void assertApprovalWorkflowFinished(String currentTermFqn) throws Exception {
+    // Poll until the workflow reaches a TERMINAL status, then assert it is FINISHED. Polling for
+    // any
+    // terminal status (not FINISHED only) surfaces a stale-FQN failure within seconds — EXCEPTION
+    // is
+    // terminal, so a regression fails fast instead of waiting the full timeout for FINISHED.
+    Awaitility.await(
+            "glossary approval workflow for " + currentTermFqn + " should reach a terminal state")
+        .atMost(STATUS_TIMEOUT)
+        .pollInterval(POLL_INTERVAL)
+        .ignoreExceptions()
+        .until(
+            () ->
+                approvalWorkflowStatuses(currentTermFqn).stream()
+                    .anyMatch(TERMINAL_WORKFLOW_STATUSES::contains));
+    List<String> statuses = approvalWorkflowStatuses(currentTermFqn);
+    assertTrue(
+        statuses.contains(WORKFLOW_STATUS_FINISHED),
+        "Approval workflow for "
+            + currentTermFqn
+            + " should reach FINISHED but statuses were "
+            + statuses);
+  }
+
+  private List<String> approvalWorkflowStatuses(String termFqn) throws Exception {
+    long now = System.currentTimeMillis();
+    RequestOptions options =
+        RequestOptions.builder()
+            .queryParam("entityLink", glossaryTermEntityLink(termFqn))
+            .queryParam("workflowDefinitionName", APPROVAL_WORKFLOW)
+            .queryParam("startTs", String.valueOf(now - Duration.ofHours(1).toMillis()))
+            .queryParam("endTs", String.valueOf(now + Duration.ofHours(1).toMillis()))
+            .queryParam("limit", "50")
+            .build();
+    String response =
+        SdkClients.adminClient()
+            .getHttpClient()
+            .executeForString(HttpMethod.GET, "/v1/governance/workflowInstances", null, options);
+    JsonNode data = new ObjectMapper().readTree(response).path("data");
+    List<String> statuses = new ArrayList<>();
+    if (data.isArray()) {
+      for (JsonNode instance : data) {
+        statuses.add(instance.path("status").asText());
+      }
+    }
+    return statuses;
+  }
+
+  private String glossaryTermEntityLink(String termFqn) {
+    return String.format("<#E::%s::%s>", Entity.GLOSSARY_TERM, termFqn);
+  }
+}

--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/GlossaryTermResourceIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/GlossaryTermResourceIT.java
@@ -28,8 +28,10 @@ import org.openmetadata.schema.api.CreateTaskDetails;
 import org.openmetadata.schema.api.data.CreateGlossary;
 import org.openmetadata.schema.api.data.CreateGlossaryTerm;
 import org.openmetadata.schema.api.data.CreateTable;
+import org.openmetadata.schema.api.data.MoveGlossaryTermRequest;
 import org.openmetadata.schema.api.data.TermReference;
 import org.openmetadata.schema.api.feed.CreateThread;
+import org.openmetadata.schema.api.feed.ResolveTask;
 import org.openmetadata.schema.api.teams.CreateUser;
 import org.openmetadata.schema.entity.data.Database;
 import org.openmetadata.schema.entity.data.DatabaseSchema;
@@ -42,8 +44,10 @@ import org.openmetadata.schema.entity.teams.User;
 import org.openmetadata.schema.type.Column;
 import org.openmetadata.schema.type.ColumnDataType;
 import org.openmetadata.schema.type.EntityHistory;
+import org.openmetadata.schema.type.EntityReference;
 import org.openmetadata.schema.type.EntityStatus;
 import org.openmetadata.schema.type.TagLabel;
+import org.openmetadata.schema.type.TaskStatus;
 import org.openmetadata.schema.type.TaskType;
 import org.openmetadata.schema.type.TermRelation;
 import org.openmetadata.schema.type.ThreadType;
@@ -724,6 +728,112 @@ public class GlossaryTermResourceIT extends BaseEntityIT<GlossaryTerm, CreateGlo
     }
   }
 
+  @Test
+  void test_approveGlossaryTermAfterMove(TestNamespace ns) throws Exception {
+    OpenMetadataClient client = SdkClients.adminClient();
+    String suffix = UUID.randomUUID().toString().replace("-", "").substring(0, 8);
+    CreateGlossary glossaryRequest =
+        new CreateGlossary()
+            .withName("gm_" + suffix)
+            .withDescription("Glossary to validate approval after ancestor term move")
+            .withReviewers(List.of(testUser1().getEntityReference()));
+    Glossary glossary = client.glossaries().create(glossaryRequest);
+    GlossaryTerm newParent = null;
+    GlossaryTerm sourceParent = null;
+    GlossaryTerm term = null;
+
+    try {
+      newParent =
+          client
+              .glossaryTerms()
+              .create(
+                  new CreateGlossaryTerm()
+                      .withName("np_" + suffix)
+                      .withGlossary(glossary.getFullyQualifiedName())
+                      .withDescription("New parent for moved approval term ancestor"));
+      sourceParent =
+          client
+              .glossaryTerms()
+              .create(
+                  new CreateGlossaryTerm()
+                      .withName("sp_" + suffix)
+                      .withGlossary(glossary.getFullyQualifiedName())
+                      .withDescription("Parent that moves while child approval is open"));
+      term =
+          client
+              .glossaryTerms()
+              .create(
+                  new CreateGlossaryTerm()
+                      .withName("c_" + suffix)
+                      .withGlossary(glossary.getFullyQualifiedName())
+                      .withParent(sourceParent.getFullyQualifiedName())
+                      .withDescription("Term that should remain approvable after ancestor move"));
+      assertEquals(EntityStatus.DRAFT, term.getEntityStatus());
+
+      UUID termId = term.getId();
+      String oldEntityLink = getGlossaryTermEntityLink(term);
+      Thread approvalTask = awaitApprovalTask(client, oldEntityLink);
+      int approvalTaskId = approvalTask.getTask().getId();
+      UUID workflowInstanceId = awaitWorkflowInstance(client, oldEntityLink);
+
+      moveGlossaryTerm(client, sourceParent.getId(), newParent.getEntityReference());
+      String movedFqn =
+          newParent.getFullyQualifiedName() + "." + sourceParent.getName() + "." + term.getName();
+      Awaitility.await("wait for glossary term move to finish")
+          .atMost(Duration.ofSeconds(60))
+          .pollInterval(Duration.ofSeconds(2))
+          .untilAsserted(
+              () ->
+                  assertEquals(
+                      movedFqn,
+                      client.glossaryTerms().get(termId.toString()).getFullyQualifiedName()));
+
+      String movedEntityLink = String.format("<#E::glossaryTerm::%s>", movedFqn);
+      Awaitility.await("wait for approval task to follow moved glossary term")
+          .atMost(Duration.ofSeconds(60))
+          .pollInterval(Duration.ofSeconds(2))
+          .untilAsserted(
+              () ->
+                  assertFalse(
+                      client
+                          .feed()
+                          .listTasks(movedEntityLink, TaskStatus.Open, null)
+                          .getData()
+                          .isEmpty(),
+                      "Expected approval task on moved glossary term link"));
+      UUID movedWorkflowInstanceId = awaitWorkflowInstance(client, movedEntityLink);
+      assertEquals(
+          workflowInstanceId,
+          movedWorkflowInstanceId,
+          "Expected workflow instance card to follow moved glossary term link");
+      awaitWorkflowInstanceStates(client, movedWorkflowInstanceId);
+
+      resolveApprovalTask(SdkClients.user1Client(), approvalTaskId, EntityStatus.APPROVED.value());
+
+      Awaitility.await("wait for moved glossary term approval")
+          .atMost(Duration.ofSeconds(60))
+          .pollInterval(Duration.ofSeconds(2))
+          .untilAsserted(
+              () ->
+                  assertEquals(
+                      EntityStatus.APPROVED,
+                      client.glossaryTerms().get(termId.toString()).getEntityStatus()));
+    } finally {
+      if (term != null) {
+        hardDeleteEntity(term.getId().toString());
+      }
+      if (sourceParent != null) {
+        hardDeleteEntity(sourceParent.getId().toString());
+      }
+      if (newParent != null) {
+        hardDeleteEntity(newParent.getId().toString());
+      }
+      client
+          .glossaries()
+          .delete(glossary.getId().toString(), java.util.Map.of("hardDelete", "true"));
+    }
+  }
+
   private List<String> getOpenGlossaryTaskEntityNames(String glossaryFqn) throws Exception {
     RequestOptions options =
         RequestOptions.builder()
@@ -745,6 +855,107 @@ public class GlossaryTermResourceIT extends BaseEntityIT<GlossaryTerm, CreateGlo
       }
     }
     return entityNames;
+  }
+
+  private Thread awaitApprovalTask(OpenMetadataClient client, String entityLink) {
+    return Awaitility.await("wait for glossary approval task")
+        .atMost(Duration.ofSeconds(60))
+        .pollInterval(Duration.ofSeconds(2))
+        .until(
+            () ->
+                client.feed().listTasks(entityLink, TaskStatus.Open, null).getData().stream()
+                    .filter(
+                        thread ->
+                            thread.getTask() != null
+                                && TaskType.RequestApproval.equals(thread.getTask().getType()))
+                    .findFirst()
+                    .orElse(null),
+            java.util.Objects::nonNull);
+  }
+
+  private UUID awaitWorkflowInstance(OpenMetadataClient client, String entityLink) {
+    return Awaitility.await("wait for workflow instance on glossary term")
+        .atMost(Duration.ofSeconds(60))
+        .pollInterval(Duration.ofSeconds(2))
+        .until(() -> getFirstWorkflowInstanceId(client, entityLink), java.util.Objects::nonNull);
+  }
+
+  private UUID getFirstWorkflowInstanceId(OpenMetadataClient client, String entityLink)
+      throws Exception {
+    RequestOptions options =
+        RequestOptions.builder()
+            .queryParam("entityLink", entityLink)
+            .queryParam("workflowDefinitionName", "GlossaryTermApprovalWorkflow")
+            .queryParam("startTs", "0")
+            .queryParam("endTs", String.valueOf(System.currentTimeMillis()))
+            .build();
+
+    String response =
+        client
+            .getHttpClient()
+            .executeForString(HttpMethod.GET, "/v1/governance/workflowInstances", null, options);
+    JsonNode data = new ObjectMapper().readTree(response).path("data");
+    if (!data.isArray() || data.isEmpty()) {
+      return null;
+    }
+    return UUID.fromString(data.get(0).path("id").asText());
+  }
+
+  private void awaitWorkflowInstanceStates(OpenMetadataClient client, UUID workflowInstanceId) {
+    Awaitility.await("wait for workflow instance states")
+        .atMost(Duration.ofSeconds(60))
+        .pollInterval(Duration.ofSeconds(2))
+        .untilAsserted(
+            () ->
+                assertFalse(
+                    getWorkflowInstanceStates(client, workflowInstanceId).isEmpty(),
+                    "Expected workflow instance states for workflow history card"));
+  }
+
+  private JsonNode getWorkflowInstanceStates(OpenMetadataClient client, UUID workflowInstanceId)
+      throws Exception {
+    RequestOptions options =
+        RequestOptions.builder()
+            .queryParam("startTs", "0")
+            .queryParam("endTs", String.valueOf(System.currentTimeMillis()))
+            .build();
+
+    String response =
+        client
+            .getHttpClient()
+            .executeForString(
+                HttpMethod.GET,
+                "/v1/governance/workflowInstanceStates/GlossaryTermApprovalWorkflow/"
+                    + workflowInstanceId,
+                null,
+                options);
+    return new ObjectMapper().readTree(response).path("data");
+  }
+
+  private void moveGlossaryTerm(OpenMetadataClient client, UUID termId, EntityReference newParent)
+      throws Exception {
+    client
+        .getHttpClient()
+        .executeForString(
+            HttpMethod.PUT,
+            "/v1/glossaryTerms/" + termId + "/moveAsync",
+            new MoveGlossaryTermRequest().withParent(newParent),
+            RequestOptions.builder().build());
+  }
+
+  private void resolveApprovalTask(OpenMetadataClient client, int taskId, String newValue)
+      throws Exception {
+    client
+        .getHttpClient()
+        .executeForString(
+            HttpMethod.PUT,
+            "/v1/feed/tasks/" + taskId + "/resolve",
+            new ResolveTask().withNewValue(newValue),
+            RequestOptions.builder().build());
+  }
+
+  private String getGlossaryTermEntityLink(GlossaryTerm term) {
+    return String.format("<#E::glossaryTerm::%s>", term.getFullyQualifiedName());
   }
 
   @Test

--- a/openmetadata-service/src/main/java/org/openmetadata/service/governance/workflows/Workflow.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/governance/workflows/Workflow.java
@@ -11,6 +11,7 @@ import org.openmetadata.service.governance.workflows.flowable.TriggerWorkflow;
 public class Workflow {
   public static final String INGESTION_PIPELINE_ID_VARIABLE = "ingestionPipelineId";
   public static final String RELATED_ENTITY_VARIABLE = "relatedEntity";
+  public static final String RELATED_ENTITY_ID_VARIABLE = "relatedEntityId";
   public static final String ENTITY_LIST_VARIABLE = "entityList";
   public static final String BATCH_SINK_PROCESSED_VARIABLE = "batchSinkProcessed";
   public static final String TRIGGERING_OBJECT_ID_VARIABLE = "triggeringObjectId";

--- a/openmetadata-service/src/main/java/org/openmetadata/service/governance/workflows/WorkflowEventConsumer.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/governance/workflows/WorkflowEventConsumer.java
@@ -3,6 +3,7 @@ package org.openmetadata.service.governance.workflows;
 import static org.openmetadata.schema.entity.events.SubscriptionDestination.SubscriptionType.GOVERNANCE_WORKFLOW_CHANGE_EVENT;
 import static org.openmetadata.service.governance.workflows.Workflow.GLOBAL_NAMESPACE;
 import static org.openmetadata.service.governance.workflows.Workflow.RECOGNIZER_FEEDBACK;
+import static org.openmetadata.service.governance.workflows.Workflow.RELATED_ENTITY_ID_VARIABLE;
 import static org.openmetadata.service.governance.workflows.Workflow.RELATED_ENTITY_VARIABLE;
 import static org.openmetadata.service.governance.workflows.Workflow.TRIGGERING_OBJECT_ID_VARIABLE;
 import static org.openmetadata.service.governance.workflows.Workflow.UPDATED_BY_VARIABLE;
@@ -233,6 +234,10 @@ public class WorkflowEventConsumer implements Destination<ChangeEvent> {
           getNamespacedVariableName(GLOBAL_NAMESPACE, RELATED_ENTITY_VARIABLE),
           entityLink.getLinkString());
 
+      variables.put(
+          getNamespacedVariableName(GLOBAL_NAMESPACE, RELATED_ENTITY_ID_VARIABLE),
+          entityReference.getId().toString());
+
       // Set the updatedBy variable from the change event userName
       if (event.getUserName() != null) {
         variables.put(
@@ -260,6 +265,10 @@ public class WorkflowEventConsumer implements Destination<ChangeEvent> {
     variables.put(
         getNamespacedVariableName(GLOBAL_NAMESPACE, RELATED_ENTITY_VARIABLE),
         entityLink.getLinkString());
+
+    variables.put(
+        getNamespacedVariableName(GLOBAL_NAMESPACE, RELATED_ENTITY_ID_VARIABLE),
+        entityReference.getId().toString());
 
     variables.put(
         getNamespacedVariableName(GLOBAL_NAMESPACE, TRIGGERING_OBJECT_ID_VARIABLE),

--- a/openmetadata-service/src/main/java/org/openmetadata/service/governance/workflows/WorkflowHandler.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/governance/workflows/WorkflowHandler.java
@@ -10,6 +10,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
@@ -1176,6 +1177,21 @@ public class WorkflowHandler {
   public void updateBusinessKey(String processInstanceId, UUID workflowInstanceBusinessKey) {
     RuntimeService runtimeService = processEngine.getRuntimeService();
     runtimeService.updateBusinessKey(processInstanceId, workflowInstanceBusinessKey.toString());
+  }
+
+  public Map<String, Map<String, Object>> getRunningInstanceVariables() {
+    RuntimeService runtimeService = processEngine.getRuntimeService();
+    List<ProcessInstance> instances =
+        runtimeService.createProcessInstanceQuery().includeProcessVariables().list();
+    Map<String, Map<String, Object>> instanceVariables = new LinkedHashMap<>();
+    for (ProcessInstance instance : instances) {
+      instanceVariables.put(instance.getId(), instance.getProcessVariables());
+    }
+    return instanceVariables;
+  }
+
+  public void setProcessInstanceVariable(String instanceId, String variableName, Object value) {
+    processEngine.getRuntimeService().setVariable(instanceId, variableName, value);
   }
 
   public boolean hasProcessInstanceFinished(String processInstanceId) {

--- a/openmetadata-service/src/main/java/org/openmetadata/service/governance/workflows/WorkflowVariableHandler.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/governance/workflows/WorkflowVariableHandler.java
@@ -1,13 +1,20 @@
 package org.openmetadata.service.governance.workflows;
 
+import static org.openmetadata.common.utils.CommonUtil.nullOrEmpty;
 import static org.openmetadata.service.governance.workflows.Workflow.FAILURE_VARIABLE;
 import static org.openmetadata.service.governance.workflows.Workflow.GLOBAL_NAMESPACE;
+import static org.openmetadata.service.governance.workflows.Workflow.RELATED_ENTITY_ID_VARIABLE;
 
 import java.util.Optional;
+import java.util.UUID;
 import lombok.extern.slf4j.Slf4j;
 import org.flowable.engine.delegate.DelegateExecution;
 import org.flowable.task.service.delegate.DelegateTask;
 import org.flowable.variable.api.delegate.VariableScope;
+import org.openmetadata.schema.EntityInterface;
+import org.openmetadata.schema.type.Include;
+import org.openmetadata.service.Entity;
+import org.openmetadata.service.resources.feeds.MessageParser;
 
 @Slf4j
 public class WorkflowVariableHandler {
@@ -70,6 +77,17 @@ public class WorkflowVariableHandler {
 
   public void setGlobalVariable(String varName, Object varValue) {
     setNamespacedVariable(GLOBAL_NAMESPACE, varName, varValue);
+  }
+
+  public EntityInterface getRelatedEntity(
+      MessageParser.EntityLink entityLink, String fields, Include include) {
+    Object idValue = getNamespacedVariable(GLOBAL_NAMESPACE, RELATED_ENTITY_ID_VARIABLE);
+    String relatedEntityId = idValue != null ? idValue.toString() : null;
+    if (nullOrEmpty(relatedEntityId)) {
+      return Entity.getEntity(entityLink, fields, include);
+    }
+    return Entity.getEntity(
+        entityLink.getEntityType(), UUID.fromString(relatedEntityId), fields, include);
   }
 
   private String getNodeNamespace() {

--- a/openmetadata-service/src/main/java/org/openmetadata/service/governance/workflows/elements/nodes/automatedTask/impl/CheckEntityAttributesImpl.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/governance/workflows/elements/nodes/automatedTask/impl/CheckEntityAttributesImpl.java
@@ -16,7 +16,6 @@ import org.flowable.engine.delegate.JavaDelegate;
 import org.openmetadata.schema.EntityInterface;
 import org.openmetadata.schema.type.Include;
 import org.openmetadata.schema.utils.JsonUtils;
-import org.openmetadata.service.Entity;
 import org.openmetadata.service.governance.workflows.WorkflowVariableHandler;
 import org.openmetadata.service.resources.feeds.MessageParser;
 import org.openmetadata.service.rules.RuleEngine;
@@ -38,7 +37,7 @@ public class CheckEntityAttributesImpl implements JavaDelegate {
               (String)
                   varHandler.getNamespacedVariable(
                       inputNamespaceMap.get(RELATED_ENTITY_VARIABLE), RELATED_ENTITY_VARIABLE));
-      varHandler.setNodeVariable(RESULT_VARIABLE, checkAttributes(entityLink, rules));
+      varHandler.setNodeVariable(RESULT_VARIABLE, checkAttributes(varHandler, entityLink, rules));
     } catch (Exception exc) {
       LOG.error(
           "[{}] Failure: ", getProcessDefinitionKeyFromId(execution.getProcessDefinitionId()), exc);
@@ -47,8 +46,9 @@ public class CheckEntityAttributesImpl implements JavaDelegate {
     }
   }
 
-  private Boolean checkAttributes(MessageParser.EntityLink entityLink, String rules) {
-    EntityInterface entity = Entity.getEntity(entityLink, "*", Include.ALL);
+  private Boolean checkAttributes(
+      WorkflowVariableHandler varHandler, MessageParser.EntityLink entityLink, String rules) {
+    EntityInterface entity = varHandler.getRelatedEntity(entityLink, "*", Include.ALL);
 
     boolean result;
     try {

--- a/openmetadata-service/src/main/java/org/openmetadata/service/governance/workflows/elements/nodes/automatedTask/impl/RollbackEntityImpl.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/governance/workflows/elements/nodes/automatedTask/impl/RollbackEntityImpl.java
@@ -61,7 +61,7 @@ public class RollbackEntityImpl implements JavaDelegate {
         updatedBy = "governance-bot";
       }
 
-      EntityInterface currentEntity = Entity.getEntity(entityLink, "", Include.ALL);
+      EntityInterface currentEntity = varHandler.getRelatedEntity(entityLink, "", Include.ALL);
 
       String entityType = currentEntity.getEntityReference().getType();
       UUID entityId = currentEntity.getId();

--- a/openmetadata-service/src/main/java/org/openmetadata/service/governance/workflows/elements/nodes/automatedTask/impl/SetEntityAttributeImpl.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/governance/workflows/elements/nodes/automatedTask/impl/SetEntityAttributeImpl.java
@@ -17,7 +17,6 @@ import org.flowable.engine.delegate.JavaDelegate;
 import org.openmetadata.schema.EntityInterface;
 import org.openmetadata.schema.type.Include;
 import org.openmetadata.schema.utils.JsonUtils;
-import org.openmetadata.service.Entity;
 import org.openmetadata.service.governance.workflows.WorkflowVariableHandler;
 import org.openmetadata.service.resources.feeds.MessageParser;
 import org.openmetadata.service.util.EntityFieldUtils;
@@ -42,7 +41,7 @@ public class SetEntityAttributeImpl implements JavaDelegate {
       MessageParser.EntityLink entityLink = MessageParser.EntityLink.parse(relatedEntityValue);
 
       String entityType = entityLink.getEntityType();
-      EntityInterface entity = Entity.getEntity(entityLink, "*", Include.ALL);
+      EntityInterface entity = varHandler.getRelatedEntity(entityLink, "*", Include.ALL);
 
       String fieldName = fieldNameExpr != null ? (String) fieldNameExpr.getValue(execution) : "";
 

--- a/openmetadata-service/src/main/java/org/openmetadata/service/governance/workflows/elements/triggers/EventBasedEntityTrigger.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/governance/workflows/elements/triggers/EventBasedEntityTrigger.java
@@ -2,6 +2,7 @@ package org.openmetadata.service.governance.workflows.elements.triggers;
 
 import static org.openmetadata.service.governance.workflows.Workflow.EXCEPTION_VARIABLE;
 import static org.openmetadata.service.governance.workflows.Workflow.GLOBAL_NAMESPACE;
+import static org.openmetadata.service.governance.workflows.Workflow.RELATED_ENTITY_ID_VARIABLE;
 import static org.openmetadata.service.governance.workflows.Workflow.RELATED_ENTITY_VARIABLE;
 import static org.openmetadata.service.governance.workflows.Workflow.WORKFLOW_RUNTIME_EXCEPTION;
 import static org.openmetadata.service.governance.workflows.Workflow.getFlowableElementId;
@@ -178,6 +179,13 @@ public class EventBasedEntityTrigger implements TriggerInterface {
     relatedEntityParam.setTarget(
         getNamespacedVariableName(GLOBAL_NAMESPACE, RELATED_ENTITY_VARIABLE));
     inputParameters.add(relatedEntityParam);
+
+    IOParameter relatedEntityIdParam = new IOParameter();
+    relatedEntityIdParam.setSource(
+        getNamespacedVariableName(GLOBAL_NAMESPACE, RELATED_ENTITY_ID_VARIABLE));
+    relatedEntityIdParam.setTarget(
+        getNamespacedVariableName(GLOBAL_NAMESPACE, RELATED_ENTITY_ID_VARIABLE));
+    inputParameters.add(relatedEntityIdParam);
 
     // Dynamically add any additional outputs declared in trigger - Eg updatedBy in
     // GlossaryTermApprovalWorkflow

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/CollectionDAO.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/CollectionDAO.java
@@ -9833,6 +9833,26 @@ public interface CollectionDAO {
     default String getTimeSeriesTableName() {
       return "workflow_instance_time_series";
     }
+
+    @ConnectionAwareSqlUpdate(
+        value =
+            "UPDATE workflow_instance_time_series "
+                + "SET json = JSON_SET(json, '$.variables.global_relatedEntity', "
+                + "REPLACE(JSON_UNQUOTE(JSON_EXTRACT(json, '$.variables.global_relatedEntity')), :oldStem, :newStem)) "
+                + "WHERE entityLink = :oldLink OR entityLink LIKE :oldChildPrefix ESCAPE '!'",
+        connectionType = MYSQL)
+    @ConnectionAwareSqlUpdate(
+        value =
+            "UPDATE workflow_instance_time_series "
+                + "SET json = jsonb_set(json, '{variables,global_relatedEntity}', "
+                + "to_jsonb(REPLACE(json->'variables'->>'global_relatedEntity', :oldStem, :newStem))) "
+                + "WHERE entityLink = :oldLink OR entityLink LIKE :oldChildPrefix ESCAPE '!'",
+        connectionType = POSTGRES)
+    int repointRelatedEntitySubtree(
+        @Bind("oldLink") String oldLink,
+        @Bind("oldChildPrefix") String oldChildPrefix,
+        @Bind("oldStem") String oldStem,
+        @Bind("newStem") String newStem);
   }
 
   interface WorkflowInstanceStateTimeSeriesDAO extends EntityTimeSeriesDAO {

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/EntityRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/EntityRepository.java
@@ -241,6 +241,7 @@ import org.openmetadata.service.jdbi3.FeedRepository.ThreadContext;
 import org.openmetadata.service.jobs.JobDAO;
 import org.openmetadata.service.lock.HierarchicalLockManager;
 import org.openmetadata.service.rdf.RdfUpdater;
+import org.openmetadata.service.resources.feeds.MessageParser;
 import org.openmetadata.service.resources.settings.SettingsCache;
 import org.openmetadata.service.resources.tags.TagLabelUtil;
 import org.openmetadata.service.resources.teams.RoleResource;
@@ -2136,6 +2137,27 @@ public abstract class EntityRepository<T extends EntityInterface> {
     String startHash = fqnPrefixHash + ".00000000000000000000000000000000";
     String endHash = fqnPrefixHash + ".ffffffffffffffffffffffffffffffff";
     return dao.listAll(startHash, endHash, filter);
+  }
+
+  protected void repointWorkflowInstancesForFqnChange(
+      String entityType, String oldFqn, String newFqn) {
+    String oldLink = new MessageParser.EntityLink(entityType, oldFqn).getLinkString();
+    String newLink = new MessageParser.EntityLink(entityType, newFqn).getLinkString();
+    String oldStem = oldLink.substring(0, oldLink.length() - 1);
+    String newStem = newLink.substring(0, newLink.length() - 1);
+    String oldChildPrefix = escapeLikePattern(oldStem + Entity.SEPARATOR) + "%";
+    int instances =
+        daoCollection
+            .workflowInstanceTimeSeriesDAO()
+            .repointRelatedEntitySubtree(oldLink, oldChildPrefix, oldStem, newStem);
+    if (instances > 0) {
+      LOG.info(
+          "[fqn-change] repointed workflow instances {} -> {} rows={}", oldFqn, newFqn, instances);
+    }
+  }
+
+  private static String escapeLikePattern(String value) {
+    return value.replace("!", "!!").replace("%", "!%").replace("_", "!_");
   }
 
   public ResultList<T> listAfter(

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/GlossaryRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/GlossaryRepository.java
@@ -622,6 +622,7 @@ public class GlossaryRepository extends EntityRepository<Glossary> {
       newAbout = new MessageParser.EntityLink(GLOSSARY_TERM, child.getFullyQualifiedName());
       daoCollection.feedDAO().updateByEntityId(newAbout.getLinkString(), child.getId().toString());
     }
+    repointWorkflowInstancesForFqnChange(GLOSSARY_TERM, oldFqn, newFqn);
   }
 
   private List<GlossaryTerm> getAllTerms(Glossary glossary) {

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/GlossaryTermRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/GlossaryTermRepository.java
@@ -1734,13 +1734,19 @@ public class GlossaryTermRepository extends EntityRepository<GlossaryTerm> {
     EntityLink newAbout = new EntityLink(GLOSSARY_TERM, newFqn);
     daoCollection.feedDAO().updateByEntityId(newAbout.getLinkString(), updated.getId().toString());
 
-    List<EntityReference> childTerms =
-        findTo(updated.getId(), GLOSSARY_TERM, Relationship.CONTAINS, GLOSSARY_TERM);
-
-    for (EntityReference child : childTerms) {
-      newAbout = new EntityLink(entityType, child.getFullyQualifiedName());
+    for (GlossaryTerm child : getNestedTerms(updated)) {
+      String childNewFqn = child.getFullyQualifiedName();
+      if (!childNewFqn.startsWith(newFqn + ".")) {
+        LOG.warn(
+            "Skipping workflow link update for unexpected glossary child FQN {} under {}",
+            childNewFqn,
+            newFqn);
+        continue;
+      }
+      newAbout = new EntityLink(entityType, childNewFqn);
       daoCollection.feedDAO().updateByEntityId(newAbout.getLinkString(), child.getId().toString());
     }
+    repointWorkflowInstancesForFqnChange(GLOSSARY_TERM, oldFqn, newFqn);
   }
 
   private List<GlossaryTerm> getNestedTerms(GlossaryTerm glossaryTerm) {
@@ -2049,16 +2055,21 @@ public class GlossaryTermRepository extends EntityRepository<GlossaryTerm> {
       updated.setMutuallyExclusive(original.getMutuallyExclusive());
     }
 
-    /**
-     * Move a glossary term to a new parent or glossary. Only parent or glossary can be changed.
-     */
-    @Transaction
+    /** Move a glossary term to a new parent or glossary. Only parent or glossary can be changed. */
     public void moveAndStore() {
-      changeDescription = new ChangeDescription().withPreviousVersion(original.getVersion());
-      // Now updated from previous/original to updated one
-      validateParent();
-      updateParent(original, updated); // Only update parent/glossary and FQN/relationships
-      storeUpdate();
+      DeadlockRetry.execute(
+          () -> {
+            Entity.getJdbi()
+                .useTransaction(
+                    handle -> {
+                      changeDescription =
+                          new ChangeDescription().withPreviousVersion(original.getVersion());
+                      validateParent();
+                      updateParent(original, updated);
+                      storeUpdate();
+                    });
+            return null;
+          });
       postUpdate(original, updated);
     }
 

--- a/openmetadata-service/src/main/java/org/openmetadata/service/migration/mysql/v11212/Migration.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/migration/mysql/v11212/Migration.java
@@ -1,0 +1,20 @@
+package org.openmetadata.service.migration.mysql.v11212;
+
+import lombok.SneakyThrows;
+import org.openmetadata.service.migration.api.MigrationProcessImpl;
+import org.openmetadata.service.migration.utils.MigrationFile;
+import org.openmetadata.service.migration.utils.v11212.MigrationUtil;
+
+public class Migration extends MigrationProcessImpl {
+
+  public Migration(MigrationFile migrationFile) {
+    super(migrationFile);
+  }
+
+  @Override
+  @SneakyThrows
+  public void runDataMigration() {
+    initializeWorkflowHandler();
+    MigrationUtil.repairStaleGlossaryApprovalFqns(handle, false);
+  }
+}

--- a/openmetadata-service/src/main/java/org/openmetadata/service/migration/postgres/v11212/Migration.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/migration/postgres/v11212/Migration.java
@@ -1,0 +1,20 @@
+package org.openmetadata.service.migration.postgres.v11212;
+
+import lombok.SneakyThrows;
+import org.openmetadata.service.migration.api.MigrationProcessImpl;
+import org.openmetadata.service.migration.utils.MigrationFile;
+import org.openmetadata.service.migration.utils.v11212.MigrationUtil;
+
+public class Migration extends MigrationProcessImpl {
+
+  public Migration(MigrationFile migrationFile) {
+    super(migrationFile);
+  }
+
+  @Override
+  @SneakyThrows
+  public void runDataMigration() {
+    initializeWorkflowHandler();
+    MigrationUtil.repairStaleGlossaryApprovalFqns(handle, true);
+  }
+}

--- a/openmetadata-service/src/main/java/org/openmetadata/service/migration/utils/v11212/MigrationUtil.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/migration/utils/v11212/MigrationUtil.java
@@ -1,0 +1,288 @@
+package org.openmetadata.service.migration.utils.v11212;
+
+import static org.openmetadata.common.utils.CommonUtil.nullOrEmpty;
+import static org.openmetadata.service.governance.workflows.Workflow.GLOBAL_NAMESPACE;
+import static org.openmetadata.service.governance.workflows.Workflow.RELATED_ENTITY_ID_VARIABLE;
+import static org.openmetadata.service.governance.workflows.Workflow.RELATED_ENTITY_VARIABLE;
+import static org.openmetadata.service.governance.workflows.WorkflowVariableHandler.getNamespacedVariableName;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import lombok.extern.slf4j.Slf4j;
+import org.jdbi.v3.core.Handle;
+import org.jdbi.v3.core.statement.PreparedBatch;
+import org.openmetadata.schema.EntityInterface;
+import org.openmetadata.schema.type.EntityReference;
+import org.openmetadata.schema.type.Include;
+import org.openmetadata.service.Entity;
+import org.openmetadata.service.governance.workflows.WorkflowHandler;
+import org.openmetadata.service.resources.feeds.MessageParser.EntityLink;
+
+/**
+ * One-time repair for glossary-term {@code RequestApproval} tasks stranded by a move/rename on
+ * 1.12.x / 1.13, where the move never updated the stale FQN references (that code only exists on
+ * main, so it can't be backpatched).
+ *
+ * <p>Self-contained by design: it only touches tables/APIs that exist on those branches
+ * ({@code thread_entity}, {@code workflow_instance_time_series}, the Flowable runtime), so it
+ * backports cleanly. The stable anchor is {@code thread_entity.json.entityRef.id} (the term's
+ * immutable id): resolve the term's current FQN by id, then rewrite every stale reference to it —
+ *
+ * <ul>
+ *   <li>{@code thread_entity.json.about} — the task points at the term's new location.
+ *   <li>{@code workflow_instance_time_series.variables.global_relatedEntity} — the
+ *       workflow-history API (queried by the new FQN) finds the instance again.
+ *   <li>the running Flowable instance's {@code global_relatedEntity} variable — approving the
+ *       still-open task now resolves the term, so the workflow finishes instead of throwing
+ *       {@code EntityNotFoundException}.
+ *   <li>the running Flowable instance's {@code global_relatedEntityId} variable — old instances
+ *       that are still current during migration keep resolving by immutable id after any future
+ *       move.
+ * </ul>
+ */
+@Slf4j
+public final class MigrationUtil {
+  private MigrationUtil() {}
+
+  private static final String GLOSSARY_TERM_TYPE = "glossaryTerm";
+  private static final String REQUEST_APPROVAL_TASK = "RequestApproval";
+  private static final String RELATED_ENTITY_KEY =
+      getNamespacedVariableName(GLOBAL_NAMESPACE, RELATED_ENTITY_VARIABLE);
+  private static final String RELATED_ENTITY_ID_KEY =
+      getNamespacedVariableName(GLOBAL_NAMESPACE, RELATED_ENTITY_ID_VARIABLE);
+
+  public static void repairStaleGlossaryApprovalFqns(Handle handle, boolean isPostgres) {
+    if (!tableExists(handle, isPostgres, "thread_entity")) {
+      LOG.info(
+          "[1.12.12] thread_entity not present (DB already migrated past 2.0.0 to the Task system); "
+              + "skipping glossary approval FQN repair");
+      return;
+    }
+    Map<String, String> staleToCurrentLink = collectStaleApprovalLinks(handle, isPostgres);
+    int threadRows = 0;
+    int repointed = 0;
+    if (staleToCurrentLink.isEmpty()) {
+      LOG.info("[1.12.12] No stale glossary RequestApproval tasks to repair");
+    } else {
+      String varPath = "variables." + RELATED_ENTITY_KEY;
+      threadRows = batchRewrite(handle, isPostgres, "thread_entity", "about", staleToCurrentLink);
+      batchRewrite(
+          handle, isPostgres, "workflow_instance_time_series", varPath, staleToCurrentLink);
+      repointed = repointRunningInstances(staleToCurrentLink);
+    }
+    int idBackfilled = backfillMissingRelatedEntityIds();
+    if (staleToCurrentLink.isEmpty()) {
+      LOG.info(
+          "[1.12.12] Backfilled relatedEntityId on {} running workflow instance(s)", idBackfilled);
+      return;
+    }
+    LOG.info(
+        "[1.12.12] Repaired {} stale glossary RequestApproval task(s) ({} thread row(s)); repointed {} running instance(s); backfilled relatedEntityId on {} running instance(s)",
+        staleToCurrentLink.size(),
+        threadRows,
+        repointed,
+        idBackfilled);
+  }
+
+  /**
+   * {@code staleAboutLink -> currentAboutLink} for every open glossary {@code RequestApproval} task
+   * whose stored {@code about} FQN no longer matches the term's current FQN (resolved by the stable
+   * {@code entityId}). Unresolvable/hard-deleted terms are skipped.
+   */
+  private static Map<String, String> collectStaleApprovalLinks(Handle handle, boolean isPostgres) {
+    Map<String, String> result = new LinkedHashMap<>();
+    for (Map<String, Object> row : queryApprovalThreads(handle, isPostgres)) {
+      addStaleLinkIfMoved(result, asString(row.get("entityid")), asString(row.get("about")));
+    }
+    return result;
+  }
+
+  private static void addStaleLinkIfMoved(
+      Map<String, String> result, String entityId, String oldLink) {
+    if (nullOrEmpty(entityId) || nullOrEmpty(oldLink)) {
+      return;
+    }
+    try {
+      EntityInterface term =
+          Entity.getEntity(GLOSSARY_TERM_TYPE, UUID.fromString(entityId), "", Include.NON_DELETED);
+      String newLink =
+          new EntityLink(GLOSSARY_TERM_TYPE, term.getFullyQualifiedName()).getLinkString();
+      if (!oldLink.equals(newLink)) {
+        result.put(oldLink, newLink);
+      }
+    } catch (Exception e) {
+      LOG.warn(
+          "[1.12.12] Could not resolve term {} for approval-task repair; skipping", entityId, e);
+    }
+  }
+
+  /**
+   * Every glossary {@code RequestApproval} task thread — open AND closed. Closed/successful runs
+   * (terms approved then moved) have no running Flowable instance and no open task, but their closed
+   * thread still carries the stable {@code entityRef.id} (the thread JSON has no top-level
+   * {@code entityId}), so they are discovered and their stale time-series rows get repaired for the
+   * workflow history card.
+   */
+  private static List<Map<String, Object>> queryApprovalThreads(Handle handle, boolean isPostgres) {
+    String sql =
+        isPostgres
+            ? "SELECT json->'entityRef'->>'id' AS entityid, json->>'about' AS about "
+                + "FROM thread_entity "
+                + "WHERE json->>'type' = 'Task' AND json->'task'->>'type' = :taskType "
+                + "AND json->>'about' LIKE :glossaryPrefix"
+            : "SELECT JSON_UNQUOTE(JSON_EXTRACT(json,'$.entityRef.id')) AS entityid, "
+                + "JSON_UNQUOTE(JSON_EXTRACT(json,'$.about')) AS about FROM thread_entity "
+                + "WHERE JSON_UNQUOTE(JSON_EXTRACT(json,'$.type')) = 'Task' "
+                + "AND JSON_UNQUOTE(JSON_EXTRACT(json,'$.task.type')) = :taskType "
+                + "AND JSON_UNQUOTE(JSON_EXTRACT(json,'$.about')) LIKE :glossaryPrefix";
+    return handle
+        .createQuery(sql)
+        .bind("taskType", REQUEST_APPROVAL_TASK)
+        .bind("glossaryPrefix", "<#E::" + GLOSSARY_TERM_TYPE + "::%")
+        .mapToMap()
+        .list();
+  }
+
+  /**
+   * Batch-rewrite the dot-pathed JSON string field {@code oldLink -> newLink} for every stale link
+   * in a single prepared batch (one round-trip), instead of a statement per link. {@code dotPath} is
+   * e.g. {@code about} or {@code variables.global_relatedEntity}. Connection-aware
+   * ({@code jsonb_set} vs {@code JSON_SET}); the path is a fixed constant (no user input), so it is
+   * safe to inline. Best-effort: a batch failure on one table is logged and does not abort the
+   * others or the upgrade. Returns the total number of rows updated.
+   */
+  private static int batchRewrite(
+      Handle handle, boolean isPostgres, String table, String dotPath, Map<String, String> links) {
+    String sql = buildRewriteSql(isPostgres, table, dotPath);
+    int updated = 0;
+    try {
+      PreparedBatch batch = handle.prepareBatch(sql);
+      links.forEach(
+          (oldLink, newLink) -> batch.bind("newLink", newLink).bind("oldLink", oldLink).add());
+      for (int count : batch.execute()) {
+        updated += count;
+      }
+    } catch (Exception e) {
+      LOG.warn("[1.12.12] Batch repair failed for {}; continuing", table, e);
+    }
+    return updated;
+  }
+
+  private static String buildRewriteSql(boolean isPostgres, String table, String dotPath) {
+    String pgPath = "{" + dotPath.replace('.', ',') + "}";
+    return isPostgres
+        ? "UPDATE "
+            + table
+            + " SET json = jsonb_set(json, '"
+            + pgPath
+            + "', to_jsonb(:newLink::text)) WHERE json #>> '"
+            + pgPath
+            + "' = :oldLink"
+        : "UPDATE "
+            + table
+            + " SET json = JSON_SET(json, '$."
+            + dotPath
+            + "', :newLink) WHERE JSON_UNQUOTE(JSON_EXTRACT(json, '$."
+            + dotPath
+            + "')) = :oldLink";
+  }
+
+  /**
+   * Repoint the {@code relatedEntity} variable on running Flowable instances whose value is one of
+   * the stale links. One-time and race-free — no concurrent approvals run during the migration.
+   */
+  private static int repointRunningInstances(Map<String, String> staleToCurrentLink) {
+    WorkflowHandler workflowHandler = WorkflowHandler.getInstance();
+    int repointed = 0;
+    for (Map.Entry<String, Map<String, Object>> instance :
+        workflowHandler.getRunningInstanceVariables().entrySet()) {
+      Object current = instance.getValue().get(RELATED_ENTITY_KEY);
+      if (current instanceof String link && staleToCurrentLink.containsKey(link)) {
+        if (setProcessInstanceVariable(
+            workflowHandler, instance.getKey(), RELATED_ENTITY_KEY, staleToCurrentLink.get(link))) {
+          repointed++;
+        }
+      }
+    }
+    return repointed;
+  }
+
+  /**
+   * Backfill immutable ids for old running workflow instances that still have only
+   * {@code global_relatedEntity}. This protects instances that were current at upgrade time but get
+   * moved later: workflow nodes can then resolve by id instead of falling back to the mutable FQN.
+   */
+  private static int backfillMissingRelatedEntityIds() {
+    WorkflowHandler workflowHandler = WorkflowHandler.getInstance();
+    int backfilled = 0;
+    for (Map.Entry<String, Map<String, Object>> instance :
+        workflowHandler.getRunningInstanceVariables().entrySet()) {
+      Map<String, Object> variables = instance.getValue();
+      if (variables.get(RELATED_ENTITY_ID_KEY) != null) {
+        continue;
+      }
+      Object current = variables.get(RELATED_ENTITY_KEY);
+      if (current instanceof String link) {
+        UUID entityId = resolveEntityId(link);
+        if (entityId != null) {
+          if (setProcessInstanceVariable(
+              workflowHandler, instance.getKey(), RELATED_ENTITY_ID_KEY, entityId.toString())) {
+            backfilled++;
+          }
+        }
+      }
+    }
+    return backfilled;
+  }
+
+  private static boolean setProcessInstanceVariable(
+      WorkflowHandler workflowHandler, String instanceId, String variableName, Object value) {
+    try {
+      workflowHandler.setProcessInstanceVariable(instanceId, variableName, value);
+      return true;
+    } catch (Exception e) {
+      LOG.warn(
+          "[1.12.12] Could not set {} on running workflow instance {}; skipping",
+          variableName,
+          instanceId,
+          e);
+      return false;
+    }
+  }
+
+  private static UUID resolveEntityId(String entityLink) {
+    try {
+      EntityLink parsed = EntityLink.parse(entityLink);
+      EntityReference reference =
+          Entity.getEntityReferenceByName(
+              parsed.getEntityType(), parsed.getEntityFQN(), Include.NON_DELETED);
+      return reference.getId();
+    } catch (Exception e) {
+      LOG.warn(
+          "[1.12.12] Could not resolve relatedEntity {} for id backfill; skipping", entityLink, e);
+      return null;
+    }
+  }
+
+  /**
+   * Whether {@code tableName} exists in the current schema. Used to no-op this repair on databases
+   * already migrated past 2.0.0 (where {@code thread_entity} has been moved to the Task system),
+   * while still running it on the target 1.12.x upgrade where the table is present.
+   */
+  private static boolean tableExists(Handle handle, boolean isPostgres, String tableName) {
+    String schemaFn = isPostgres ? "current_schema()" : "DATABASE()";
+    String sql =
+        "SELECT COUNT(*) FROM information_schema.tables "
+            + "WHERE table_schema = "
+            + schemaFn
+            + " AND table_name = :tableName";
+    Integer count = handle.createQuery(sql).bind("tableName", tableName).mapTo(Integer.class).one();
+    return count != null && count > 0;
+  }
+
+  private static String asString(Object value) {
+    return value == null ? null : value.toString();
+  }
+}

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/Glossary/GlossaryApprovalAfterMove.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/Glossary/GlossaryApprovalAfterMove.spec.ts
@@ -1,0 +1,360 @@
+/*
+ *  Copyright 2025 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+import test, { expect, type APIRequestContext } from '@playwright/test';
+import { SidebarItem } from '../../../constant/sidebar';
+import { Glossary } from '../../../support/glossary/Glossary';
+import { GlossaryTerm } from '../../../support/glossary/GlossaryTerm';
+import { UserClass } from '../../../support/user/UserClass';
+import { performAdminLogin } from '../../../utils/admin';
+import { redirectToHomePage, toastNotification } from '../../../utils/common';
+import {
+  performExpandAll,
+  selectActiveGlossary,
+  verifyTaskCreated,
+} from '../../../utils/glossary';
+import { sidebarClick } from '../../../utils/sidebar';
+import { waitForTaskResolveResponse } from '../../../utils/task';
+import { performUserLogin } from '../../../utils/user';
+
+const reviewerUser = new UserClass();
+
+const queryOpenApprovalTasks = async (
+  apiContext: APIRequestContext,
+  termFqn: string
+): Promise<{ count: number; taskId: string | null }> => {
+  const entityLink = `<#E::glossaryTerm::${termFqn}>`;
+  const res = await apiContext
+    .get(
+      `/api/v1/feed?entityLink=${encodeURIComponent(
+        entityLink
+      )}&type=Task&taskStatus=Open&limit=100`
+    )
+    .then((r) => r.json());
+  const data: { task?: { id?: string | number } }[] = res?.data ?? [];
+
+  return { count: data.length, taskId: data[0]?.task?.id?.toString() ?? null };
+};
+
+const waitForTermStatus = async (
+  apiContext: APIRequestContext,
+  termId: string,
+  expectedStatus: string
+) => {
+  await expect
+    .poll(
+      async () => {
+        const res = await apiContext
+          .get(`/api/v1/glossaryTerms/${termId}?fields=entityStatus`)
+          .then((r) => r.json());
+
+        return res?.entityStatus;
+      },
+      {
+        message: `term ${termId} to reach ${expectedStatus}`,
+        timeout: 120_000,
+        intervals: [3_000, 5_000, 10_000],
+      }
+    )
+    .toBe(expectedStatus);
+};
+
+const reviewerRef = () => ({
+  id: reviewerUser.responseData.id,
+  type: 'user' as const,
+  displayName: reviewerUser.responseData.displayName,
+  fullyQualifiedName: reviewerUser.responseData.fullyQualifiedName,
+  name: reviewerUser.responseData.name,
+});
+
+const setupGlossaryWithPendingApproval = async (
+  adminApiContext: APIRequestContext
+) => {
+  const glossary = new Glossary();
+  const parent = new GlossaryTerm(glossary); // Securities Lending
+  const child = new GlossaryTerm(glossary); // Eligible Securities — has the open task
+  const container = new GlossaryTerm(glossary); // Product and Service — move target
+
+  await glossary.create(adminApiContext);
+  await glossary.patch(adminApiContext, [
+    { op: 'add', path: '/reviewers/0', value: reviewerRef() },
+  ]);
+  await parent.create(adminApiContext);
+  child.data.parent = parent.responseData.fullyQualifiedName;
+  await child.create(adminApiContext);
+  await container.create(adminApiContext);
+
+  return { glossary, parent, child, container };
+};
+
+const moveParentUnderContainer = async (
+  adminApiContext: APIRequestContext,
+  parent: GlossaryTerm,
+  container: GlossaryTerm
+) => {
+  const res = await adminApiContext.put(
+    `/api/v1/glossaryTerms/${parent.responseData.id}/moveAsync`,
+    {
+      data: {
+        parent: {
+          id: container.responseData.id,
+          type: 'glossaryTerm',
+          name: container.responseData.name,
+          fullyQualifiedName: container.responseData.fullyQualifiedName,
+        },
+      },
+    }
+  );
+  expect(res.ok()).toBeTruthy();
+};
+
+test.beforeAll(async ({ browser }) => {
+  const { apiContext, afterAction } = await performAdminLogin(browser);
+  await reviewerUser.create(apiContext);
+  await reviewerUser.setDataStewardRole(apiContext);
+  await afterAction();
+});
+
+test.afterAll(async ({ browser }) => {
+  const { apiContext, afterAction } = await performAdminLogin(browser);
+  await reviewerUser.delete(apiContext);
+  await afterAction();
+});
+
+test.describe(
+  'Glossary - Approval After Move',
+  { tag: ['@Features', '@Governance'] },
+  () => {
+    test('approving an open task succeeds after the parent term is moved under a sibling', async ({
+      browser,
+    }) => {
+      test.slow(true);
+
+      const { apiContext: adminApiContext, afterAction: adminAfterAction } =
+        await performAdminLogin(browser);
+      const { page: reviewerPage, afterAction: reviewerAfterAction } =
+        await performUserLogin(browser, reviewerUser);
+
+      let originalTaskId: string | null = null;
+      let newChildFqn = '';
+
+      const { glossary, parent, child, container } =
+        await setupGlossaryWithPendingApproval(adminApiContext);
+
+      try {
+        await test.step('Verify exactly one open approval task exists for Eligible Securities', async () => {
+          await verifyTaskCreated(
+            reviewerPage,
+            glossary.responseData.fullyQualifiedName,
+            child.data.name
+          );
+          const { count, taskId } = await queryOpenApprovalTasks(
+            adminApiContext,
+            child.responseData.fullyQualifiedName
+          );
+          expect(count).toBe(1);
+          originalTaskId = taskId;
+        });
+
+        await test.step('Move Securities Lending under Product and Service', async () => {
+          await moveParentUnderContainer(adminApiContext, parent, container);
+        });
+
+        await test.step('Wait for task accessible at new FQN: count=1, same task ID (no duplicate or replacement)', async () => {
+          await expect
+            .poll(
+              async () => {
+                const res = await adminApiContext
+                  .get(
+                    `/api/v1/glossaryTerms/${child.responseData.id}?fields=fullyQualifiedName`
+                  )
+                  .then((r) => r.json());
+                newChildFqn = res.fullyQualifiedName;
+
+                return newChildFqn;
+              },
+              {
+                message: 'child FQN to update after async move',
+                timeout: 120_000,
+                intervals: [3_000, 5_000, 10_000],
+              }
+            )
+            .not.toBe(child.responseData.fullyQualifiedName);
+
+          await verifyTaskCreated(
+            reviewerPage,
+            glossary.responseData.fullyQualifiedName,
+            child.data.name
+          );
+
+          const { count: countNew, taskId: taskIdNew } =
+            await queryOpenApprovalTasks(adminApiContext, newChildFqn);
+          expect(countNew).toBe(1);
+          expect(taskIdNew).toBe(originalTaskId);
+        });
+
+        await test.step('Reviewer: expand tree and approve Eligible Securities', async () => {
+          await redirectToHomePage(reviewerPage);
+          await sidebarClick(reviewerPage, SidebarItem.GLOSSARY);
+          await selectActiveGlossary(
+            reviewerPage,
+            glossary.responseData.displayName
+          );
+          await performExpandAll(reviewerPage);
+
+          const approveButton = reviewerPage.getByTestId(
+            `${child.data.name}-approve-btn`
+          );
+          await expect(approveButton).toBeVisible({ timeout: 60_000 });
+
+          const taskResolve = waitForTaskResolveResponse(reviewerPage);
+          await approveButton.click();
+          await taskResolve;
+
+          await toastNotification(
+            reviewerPage,
+            /Task resolved successfully|Vote recorded/
+          );
+        });
+
+        await test.step('Verify Approved status and zero remaining open tasks', async () => {
+          await waitForTermStatus(
+            adminApiContext,
+            child.responseData.id,
+            'Approved'
+          );
+          const { count } = await queryOpenApprovalTasks(
+            adminApiContext,
+            newChildFqn
+          );
+          expect(count).toBe(0);
+        });
+      } finally {
+        await glossary.delete(adminApiContext);
+        await adminAfterAction();
+        await reviewerAfterAction();
+      }
+    });
+
+    test('rejecting an open task succeeds after the parent term is moved under a sibling', async ({
+      browser,
+    }) => {
+      test.slow(true);
+
+      const { apiContext: adminApiContext, afterAction: adminAfterAction } =
+        await performAdminLogin(browser);
+      const { page: reviewerPage, afterAction: reviewerAfterAction } =
+        await performUserLogin(browser, reviewerUser);
+
+      let originalTaskId: string | null = null;
+      let newChildFqn = '';
+
+      const { glossary, parent, child, container } =
+        await setupGlossaryWithPendingApproval(adminApiContext);
+
+      try {
+        await test.step('Verify exactly one open approval task exists for Eligible Securities', async () => {
+          await verifyTaskCreated(
+            reviewerPage,
+            glossary.responseData.fullyQualifiedName,
+            child.data.name
+          );
+          const { count, taskId } = await queryOpenApprovalTasks(
+            adminApiContext,
+            child.responseData.fullyQualifiedName
+          );
+          expect(count).toBe(1);
+          originalTaskId = taskId;
+        });
+
+        await test.step('Move Securities Lending under Product and Service', async () => {
+          await moveParentUnderContainer(adminApiContext, parent, container);
+        });
+
+        await test.step('Wait for task accessible at new FQN: count=1, same task ID (no duplicate or replacement)', async () => {
+          await expect
+            .poll(
+              async () => {
+                const res = await adminApiContext
+                  .get(
+                    `/api/v1/glossaryTerms/${child.responseData.id}?fields=fullyQualifiedName`
+                  )
+                  .then((r) => r.json());
+                newChildFqn = res.fullyQualifiedName;
+
+                return newChildFqn;
+              },
+              {
+                message: 'child FQN to update after async move',
+                timeout: 120_000,
+                intervals: [3_000, 5_000, 10_000],
+              }
+            )
+            .not.toBe(child.responseData.fullyQualifiedName);
+
+          await verifyTaskCreated(
+            reviewerPage,
+            glossary.responseData.fullyQualifiedName,
+            child.data.name
+          );
+
+          const { count: countNew, taskId: taskIdNew } =
+            await queryOpenApprovalTasks(adminApiContext, newChildFqn);
+          expect(countNew).toBe(1);
+          expect(taskIdNew).toBe(originalTaskId);
+        });
+
+        await test.step('Reviewer: expand tree and reject Eligible Securities', async () => {
+          await redirectToHomePage(reviewerPage);
+          await sidebarClick(reviewerPage, SidebarItem.GLOSSARY);
+          await selectActiveGlossary(
+            reviewerPage,
+            glossary.responseData.displayName
+          );
+          await performExpandAll(reviewerPage);
+
+          const rejectButton = reviewerPage.getByTestId(
+            `${child.data.name}-reject-btn`
+          );
+          await expect(rejectButton).toBeVisible({ timeout: 60_000 });
+
+          const taskResolve = waitForTaskResolveResponse(reviewerPage);
+          await rejectButton.click();
+          await taskResolve;
+
+          await toastNotification(
+            reviewerPage,
+            /Task resolved successfully|Vote recorded/
+          );
+        });
+
+        await test.step('Verify term reaches Rejected status and zero remaining open tasks', async () => {
+          await waitForTermStatus(
+            adminApiContext,
+            child.responseData.id,
+            'Rejected'
+          );
+          const { count } = await queryOpenApprovalTasks(
+            adminApiContext,
+            newChildFqn
+          );
+          expect(count).toBe(0);
+        });
+      } finally {
+        await glossary.delete(adminApiContext);
+        await adminAfterAction();
+        await reviewerAfterAction();
+      }
+    });
+  }
+);


### PR DESCRIPTION
## Summary
- Backport immutable relatedEntityId workflow resolution so approval workflows can resolve moved or renamed glossary terms by id.
- Update 1.13 feed task about links and workflow instance cards when glossary terms or glossary names move/rename, including nested children.
- Add the same 1.12.12 SQL and Java migration files on the 1.13 branch so upgrades through 1.13 still execute the 1.12.12 repair.
- Update fresh-install MySQL/Postgres schema for tag_usage tagFQN width.
- Add backend regression coverage and Playwright coverage for approval tasks after glossary moves.

## Tests
- mvn -pl openmetadata-service,openmetadata-integration-tests spotless:apply -DspotlessFiles=<changed Java files>
- mvn -pl openmetadata-service -DskipTests compile
- mvn -pl openmetadata-integration-tests -Dtest=GlossaryTermResourceIT#test_approveGlossaryTermAfterMove test
- mvn -pl openmetadata-integration-tests -Dtest=GlossaryTermMoveApprovalIT test
- git diff --check
- npx organize-imports-cli@0.10.0 openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/Glossary/GlossaryApprovalAfterMove.spec.ts
- npx prettier@2.8.8 --write openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/Glossary/GlossaryApprovalAfterMove.spec.ts

## Notes
- The 1.13 branch stores approval tasks as feed threads, so the task migration/update path is the thread_entity/feed about rewrite plus field relationship rename, not the older task_entity/aboutFqnHash path from main.
- UI ESLint could not be run locally because the repo dependency install is blocked on Node v24.8.0: @windmillcode/quill-emoji requires Node 18.x, 20.x, or 22.x. A direct npx eslint attempt also failed because the flat config requires local packages such as @eslint/js.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR backports immutable `relatedEntityId`-based workflow resolution to the 1.13 branch so that approval workflows survive glossary term moves/renames. It adds `global_relatedEntityId` as a new workflow variable set at trigger time, threads it through `EventBasedEntityTrigger` and the three automated-task impls, and wires `repointWorkflowInstancesForFqnChange` into both `GlossaryRepository` and `GlossaryTermRepository` to keep `workflow_instance_time_series` in sync at move time.

- **Migration (`v11212`)**: one-time SQL repair of stale `thread_entity.about` and `workflow_instance_time_series.variables.global_relatedEntity` links, plus a Flowable runtime backfill of `global_relatedEntityId` on still-running instances.
- **Schema fix**: widened `tag_usage.tagFQN` from `VARCHAR(256)` to `VARCHAR(512)` in both dialects, with matching Postgres generated-column recreation.
- **`moveAndStore` refactor**: replaced `@Transaction` annotation with explicit `DeadlockRetry.execute` + `Entity.getJdbi().useTransaction()`, moving `postUpdate` outside the transaction boundary (correct for event-publishing semantics).
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The fix is structurally correct and well-tested; the small gap in the migration (DB snapshot rows for pre-existing workflow instances not receiving global_relatedEntityId) does not break workflow execution because getRelatedEntity() falls back to the FQN, which the migration already repairs.

All workflow-execution paths are correctly guarded: new instances always carry the immutable UUID, running pre-existing instances get the UUID backfilled in the Flowable runtime, and the DB snapshot global_relatedEntity FQN is repaired so the FQN fallback also works. The entityLink generated-column design is correctly understood and exploited by repointRelatedEntitySubtree. Integration tests cover the full approval-after-move flow.

MigrationUtil.java — the backfill writes global_relatedEntityId only to the Flowable runtime, not to the workflow_instance_time_series JSON blob; worth a follow-up if any history-card reader starts keying off that field without a FQN fallback.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-service/src/main/java/org/openmetadata/service/migration/utils/v11212/MigrationUtil.java | New one-time repair utility: rewrites stale FQN references in thread_entity and workflow_instance_time_series, then backfills global_relatedEntityId on running Flowable instances. The DB snapshot for pre-existing migrated instances does not receive global_relatedEntityId (only the Flowable runtime gets it), but FQN fallback makes this non-blocking. |
| openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/CollectionDAO.java | Adds repointRelatedEntitySubtree to WorkflowInstanceTimeSeriesDAO. Uses REPLACE on global_relatedEntity and a LIKE-prefix WHERE clause. Because entityLink is a GENERATED column derived from json.variables.global_relatedEntity, updating the JSON field automatically propagates to the indexed column—no separate update needed. |
| openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/EntityRepository.java | Adds repointWorkflowInstancesForFqnChange helper that computes the correct oldStem/newStem/oldChildPrefix from an FQN change and delegates to repointRelatedEntitySubtree, covering the term itself and all descendants in one SQL batch. |
| openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/GlossaryTermRepository.java | updateFeedAboutLinks now iterates all nested terms (recursive) instead of direct children only, and adds a call to repointWorkflowInstancesForFqnChange. moveAndStore drops @Transaction in favour of explicit DeadlockRetry + useTransaction, correctly moving postUpdate outside the transaction boundary. |
| openmetadata-service/src/main/java/org/openmetadata/service/governance/workflows/WorkflowHandler.java | Adds getRunningInstanceVariables() and setProcessInstanceVariable() — previously flagged as dead code, now actively used by MigrationUtil for runtime backfill. |
| openmetadata-service/src/main/java/org/openmetadata/service/governance/workflows/WorkflowVariableHandler.java | Adds getRelatedEntity() which resolves by immutable UUID (global_relatedEntityId) when available, falling back to FQN-based EntityLink lookup — core of the fix. |
| openmetadata-service/src/main/java/org/openmetadata/service/governance/workflows/WorkflowEventConsumer.java | Now writes global_relatedEntityId (entity UUID) alongside global_relatedEntity (FQN link) in both trigger paths, ensuring all newly started workflow instances carry the immutable ID. |
| bootstrap/sql/migrations/native/1.12.12/postgres/schemaChanges.sql | Correctly drops the generated tagfqn_lower column (which blocks in-place ALTER in Postgres), widens tagFQN to VARCHAR(512), and recreates the generated column with its two covering indexes. |
| openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/GlossaryTermMoveApprovalIT.java | New integration test that reproduces the approval-after-ancestor-move regression end-to-end; waits for FQN rewrite, task re-link, workflow instance re-link, and final APPROVED status. |
| openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/Glossary/GlossaryApprovalAfterMove.spec.ts | Playwright E2E spec covering the full browser-level flow: create term with approval, move parent, approve via UI, assert Approved status. |

</details>

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Client
    participant GlossaryTermRepo
    participant FeedDAO
    participant WorkflowInstanceTSDAO
    participant FlowableRuntime
    participant WorkflowVariableHandler

    Client->>GlossaryTermRepo: moveGlossaryTerm(term, newParent)
    GlossaryTermRepo->>GlossaryTermRepo: "DeadlockRetry { useTransaction { updateParent + storeUpdate } }"
    GlossaryTermRepo->>FeedDAO: updateByEntityId(newAbout, termId) [for term + nested children]
    GlossaryTermRepo->>WorkflowInstanceTSDAO: repointRelatedEntitySubtree(oldLink, oldChildPrefix, oldStem, newStem)
    WorkflowInstanceTSDAO-->>GlossaryTermRepo: rows updated (entityLink generated col auto-updates)
    GlossaryTermRepo->>GlossaryTermRepo: postUpdate(original, updated) [outside TX]

    Note over FlowableRuntime: At trigger time (pre-move)
    FlowableRuntime->>FlowableRuntime: "set global_relatedEntity = FQN link"
    FlowableRuntime->>FlowableRuntime: "set global_relatedEntityId = UUID [NEW]"

    Note over WorkflowVariableHandler: At approval time (post-move)
    WorkflowVariableHandler->>FlowableRuntime: read global_relatedEntityId
    alt relatedEntityId present
        WorkflowVariableHandler->>WorkflowVariableHandler: Entity.getEntity(type, UUID) resolves by immutable ID
    else fallback
        WorkflowVariableHandler->>WorkflowVariableHandler: Entity.getEntity(entityLink) FQN lookup
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Client
    participant GlossaryTermRepo
    participant FeedDAO
    participant WorkflowInstanceTSDAO
    participant FlowableRuntime
    participant WorkflowVariableHandler

    Client->>GlossaryTermRepo: moveGlossaryTerm(term, newParent)
    GlossaryTermRepo->>GlossaryTermRepo: "DeadlockRetry { useTransaction { updateParent + storeUpdate } }"
    GlossaryTermRepo->>FeedDAO: updateByEntityId(newAbout, termId) [for term + nested children]
    GlossaryTermRepo->>WorkflowInstanceTSDAO: repointRelatedEntitySubtree(oldLink, oldChildPrefix, oldStem, newStem)
    WorkflowInstanceTSDAO-->>GlossaryTermRepo: rows updated (entityLink generated col auto-updates)
    GlossaryTermRepo->>GlossaryTermRepo: postUpdate(original, updated) [outside TX]

    Note over FlowableRuntime: At trigger time (pre-move)
    FlowableRuntime->>FlowableRuntime: "set global_relatedEntity = FQN link"
    FlowableRuntime->>FlowableRuntime: "set global_relatedEntityId = UUID [NEW]"

    Note over WorkflowVariableHandler: At approval time (post-move)
    WorkflowVariableHandler->>FlowableRuntime: read global_relatedEntityId
    alt relatedEntityId present
        WorkflowVariableHandler->>WorkflowVariableHandler: Entity.getEntity(type, UUID) resolves by immutable ID
    else fallback
        WorkflowVariableHandler->>WorkflowVariableHandler: Entity.getEntity(entityLink) FQN lookup
    end
```

</a>
</details>

<sub>Reviews (4): Last reviewed commit: ["fix(glossary): keep approvals valid afte..."](https://github.com/open-metadata/openmetadata/commit/b0dd7a9d0170d93d279b459754c49e9d976d8a68) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38617255)</sub>

<!-- /greptile_comment -->