### PR TITLE
fix(ui): render each entity-header breadcrumb crumb exactly once

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/EntityHeaderBreadcrumb.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/EntityHeaderBreadcrumb.spec.ts
@@ -1,0 +1,118 @@
+/*
+ *  Copyright 2026 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+import { Page, test as base } from '@playwright/test';
+import { PLAYWRIGHT_BASIC_TEST_TAG_OBJ } from '../../constant/config';
+import { ApiCollectionClass } from '../../support/entity/ApiCollectionClass';
+import { ApiEndpointClass } from '../../support/entity/ApiEndpointClass';
+import { ChartClass } from '../../support/entity/ChartClass';
+import { ContainerClass } from '../../support/entity/ContainerClass';
+import { DashboardClass } from '../../support/entity/DashboardClass';
+import { DashboardDataModelClass } from '../../support/entity/DashboardDataModelClass';
+import { DatabaseClass } from '../../support/entity/DatabaseClass';
+import { DatabaseSchemaClass } from '../../support/entity/DatabaseSchemaClass';
+import { DirectoryClass } from '../../support/entity/DirectoryClass';
+import { FileClass } from '../../support/entity/FileClass';
+import { MetricClass } from '../../support/entity/MetricClass';
+import { MlModelClass } from '../../support/entity/MlModelClass';
+import { PipelineClass } from '../../support/entity/PipelineClass';
+import { SearchIndexClass } from '../../support/entity/SearchIndexClass';
+import { SpreadsheetClass } from '../../support/entity/SpreadsheetClass';
+import { StoredProcedureClass } from '../../support/entity/StoredProcedureClass';
+import { TableClass } from '../../support/entity/TableClass';
+import { TopicClass } from '../../support/entity/TopicClass';
+import { WorksheetClass } from '../../support/entity/WorksheetClass';
+import { UserClass } from '../../support/user/UserClass';
+import { performAdminLogin } from '../../utils/admin';
+import { redirectToHomePage } from '../../utils/common';
+import { expectBreadcrumbCrumbsUnique } from '../../utils/headerBreadcrumbUtils';
+
+const entities = {
+  Database: DatabaseClass,
+  'Database Schema': DatabaseSchemaClass,
+  Metric: MetricClass,
+  Table: TableClass,
+  'Stored Procedure': StoredProcedureClass,
+  Dashboard: DashboardClass,
+  Pipeline: PipelineClass,
+  Topic: TopicClass,
+  'Ml Model': MlModelClass,
+  Container: ContainerClass,
+  'Search Index': SearchIndexClass,
+  'Dashboard Data Model': DashboardDataModelClass,
+  Chart: ChartClass,
+  'Api Collection': ApiCollectionClass,
+  'Api Endpoint': ApiEndpointClass,
+  Directory: DirectoryClass,
+  File: FileClass,
+  Spreadsheet: SpreadsheetClass,
+  Worksheet: WorksheetClass,
+} as const;
+
+const adminUser = new UserClass();
+
+const test = base.extend<{ page: Page }>({
+  page: async ({ browser }, use) => {
+    const adminPage = await browser.newPage();
+    await adminUser.login(adminPage);
+    await use(adminPage);
+    await adminPage.close();
+  },
+});
+
+test.beforeAll('Setup admin', async ({ browser }) => {
+  const { apiContext, afterAction } = await performAdminLogin(browser);
+  await adminUser.create(apiContext);
+  await adminUser.setAdminRole(apiContext);
+  await afterAction();
+});
+
+test.afterAll('Cleanup admin', async ({ browser }) => {
+  const { apiContext, afterAction } = await performAdminLogin(browser);
+  await adminUser.delete(apiContext);
+  await afterAction();
+});
+
+Object.entries(entities).forEach(([label, EntityClass]) => {
+  const entity = new EntityClass();
+
+  test.describe(
+    `Entity header breadcrumb - ${label}`,
+    PLAYWRIGHT_BASIC_TEST_TAG_OBJ,
+    () => {
+      test.slow(true);
+
+      test.beforeAll('Create entity', async ({ browser }) => {
+        const { apiContext, afterAction } = await performAdminLogin(browser);
+        await entity.create(apiContext);
+        await afterAction();
+      });
+
+      test.afterAll('Delete entity', async ({ browser }) => {
+        const { apiContext, afterAction } = await performAdminLogin(browser);
+        await entity.delete(apiContext);
+        await afterAction();
+      });
+
+      test.beforeEach('Visit entity page', async ({ page }) => {
+        await redirectToHomePage(page);
+        await entity.visitEntityPage(page);
+      });
+
+      test('should render every breadcrumb crumb exactly once', async ({
+        page,
+      }) => {
+        await expectBreadcrumbCrumbsUnique(page);
+      });
+    }
+  );
+});

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/headerBreadcrumbUtils.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/headerBreadcrumbUtils.ts
@@ -1,0 +1,26 @@
+/*
+ *  Copyright 2026 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+import { expect, Page } from '@playwright/test';
+
+export const expectBreadcrumbCrumbsUnique = async (page: Page) => {
+  const breadcrumb = page.getByTestId('breadcrumb');
+
+  await expect(breadcrumb).toBeVisible();
+
+  const crumbLabels = (await breadcrumb.getByRole('listitem').allInnerTexts())
+    .map((label) => label.trim())
+    .filter((label) => label.length > 0);
+
+  expect(crumbLabels.length).toBeGreaterThan(0);
+  expect(new Set(crumbLabels).size).toBe(crumbLabels.length);
+};

--- a/openmetadata-ui/src/main/resources/ui/src/utils/DataAssetsHeader.breadcrumb.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/DataAssetsHeader.breadcrumb.test.tsx
@@ -1,0 +1,328 @@
+/*
+ *  Copyright 2026 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+import { DataAssetsHeaderProps } from '../components/DataAssets/DataAssetsHeader/DataAssetsHeader.interface';
+import { EntityType } from '../enums/entity.enum';
+import { Database } from '../generated/entity/data/database';
+import { DatabaseSchema } from '../generated/entity/data/databaseSchema';
+import { getDataAssetsHeaderInfo } from './DataAssetsHeader.utils';
+import { getBreadcrumbForMetric } from './EntityGovernanceBreadcrumbUtils';
+import { getEntityName } from './EntityNameUtils';
+import {
+  getBreadcrumbForDatabase,
+  getBreadcrumbForDatabaseSchema,
+} from './EntityServiceBreadcrumbUtils';
+
+const buildService = (type: string) => ({
+  id: 'svc-id',
+  name: 'svc',
+  type,
+  fullyQualifiedName: 'svc',
+});
+
+const databaseRef = { id: 'db-id', name: 'db', fullyQualifiedName: 'svc.db' };
+const schemaRef = {
+  id: 'schema-id',
+  name: 'schema',
+  fullyQualifiedName: 'svc.db.schema',
+};
+const apiCollectionRef = {
+  id: 'coll-id',
+  name: 'coll',
+  fullyQualifiedName: 'svc.coll',
+};
+
+const HEADER_ENTITY_CASES: Array<{
+  entityType: DataAssetsHeaderProps['entityType'];
+  entity: Record<string, unknown>;
+}> = [
+  {
+    entityType: EntityType.TABLE,
+    entity: {
+      name: 'tbl',
+      fullyQualifiedName: 'svc.db.schema.tbl',
+      service: buildService('databaseService'),
+      database: databaseRef,
+      databaseSchema: schemaRef,
+    },
+  },
+  {
+    entityType: EntityType.STORED_PROCEDURE,
+    entity: {
+      name: 'sp',
+      fullyQualifiedName: 'svc.db.schema.sp',
+      service: buildService('databaseService'),
+      database: databaseRef,
+      databaseSchema: schemaRef,
+    },
+  },
+  {
+    entityType: EntityType.DATABASE,
+    entity: {
+      name: 'db',
+      fullyQualifiedName: 'svc.db',
+      service: buildService('databaseService'),
+    },
+  },
+  {
+    entityType: EntityType.DATABASE_SCHEMA,
+    entity: {
+      name: 'schema',
+      fullyQualifiedName: 'svc.db.schema',
+      service: buildService('databaseService'),
+      database: databaseRef,
+    },
+  },
+  {
+    entityType: EntityType.DATABASE_SERVICE,
+    entity: { name: 'svc', fullyQualifiedName: 'svc' },
+  },
+  {
+    entityType: EntityType.METRIC,
+    entity: { name: 'metric1', fullyQualifiedName: 'metric1' },
+  },
+  {
+    entityType: EntityType.CHART,
+    entity: {
+      name: 'chart1',
+      fullyQualifiedName: 'svc.chart1',
+      service: buildService('dashboardService'),
+    },
+  },
+  {
+    entityType: EntityType.TOPIC,
+    entity: {
+      name: 'topic1',
+      fullyQualifiedName: 'svc.topic1',
+      service: buildService('messagingService'),
+    },
+  },
+  {
+    entityType: EntityType.DASHBOARD,
+    entity: {
+      name: 'dashboard1',
+      fullyQualifiedName: 'svc.dashboard1',
+      service: buildService('dashboardService'),
+    },
+  },
+  {
+    entityType: EntityType.PIPELINE,
+    entity: {
+      name: 'pipeline1',
+      fullyQualifiedName: 'svc.pipeline1',
+      service: buildService('pipelineService'),
+    },
+  },
+  {
+    entityType: EntityType.MLMODEL,
+    entity: {
+      name: 'mlmodel1',
+      fullyQualifiedName: 'svc.mlmodel1',
+      service: buildService('mlmodelService'),
+    },
+  },
+  {
+    entityType: EntityType.DASHBOARD_DATA_MODEL,
+    entity: {
+      name: 'datamodel1',
+      fullyQualifiedName: 'svc.datamodel1',
+      service: buildService('dashboardService'),
+    },
+  },
+  {
+    entityType: EntityType.SEARCH_INDEX,
+    entity: {
+      name: 'searchindex1',
+      fullyQualifiedName: 'svc.searchindex1',
+      service: buildService('searchService'),
+    },
+  },
+  {
+    entityType: EntityType.CONTAINER,
+    entity: {
+      name: 'container1',
+      fullyQualifiedName: 'svc.container1',
+      service: buildService('storageService'),
+    },
+  },
+  {
+    entityType: EntityType.DIRECTORY,
+    entity: {
+      name: 'directory1',
+      fullyQualifiedName: 'svc.directory1',
+      service: buildService('driveService'),
+    },
+  },
+  {
+    entityType: EntityType.FILE,
+    entity: {
+      name: 'file1',
+      fullyQualifiedName: 'svc.file1',
+      service: buildService('driveService'),
+    },
+  },
+  {
+    entityType: EntityType.SPREADSHEET,
+    entity: {
+      name: 'spreadsheet1',
+      fullyQualifiedName: 'svc.spreadsheet1',
+      service: buildService('driveService'),
+    },
+  },
+  {
+    entityType: EntityType.WORKSHEET,
+    entity: {
+      name: 'worksheet1',
+      fullyQualifiedName: 'svc.worksheet1',
+      service: buildService('driveService'),
+    },
+  },
+  {
+    entityType: EntityType.API_COLLECTION,
+    entity: {
+      name: 'collection1',
+      fullyQualifiedName: 'svc.collection1',
+      service: buildService('apiService'),
+    },
+  },
+  {
+    entityType: EntityType.API_ENDPOINT,
+    entity: {
+      name: 'endpoint1',
+      fullyQualifiedName: 'svc.coll.endpoint1',
+      service: buildService('apiService'),
+      apiCollection: apiCollectionRef,
+    },
+  },
+  {
+    entityType: EntityType.API_SERVICE,
+    entity: { name: 'svc', fullyQualifiedName: 'svc' },
+  },
+  {
+    entityType: EntityType.DASHBOARD_SERVICE,
+    entity: { name: 'svc', fullyQualifiedName: 'svc' },
+  },
+  {
+    entityType: EntityType.MESSAGING_SERVICE,
+    entity: { name: 'svc', fullyQualifiedName: 'svc' },
+  },
+  {
+    entityType: EntityType.PIPELINE_SERVICE,
+    entity: { name: 'svc', fullyQualifiedName: 'svc' },
+  },
+  {
+    entityType: EntityType.MLMODEL_SERVICE,
+    entity: { name: 'svc', fullyQualifiedName: 'svc' },
+  },
+  {
+    entityType: EntityType.METADATA_SERVICE,
+    entity: { name: 'svc', fullyQualifiedName: 'svc' },
+  },
+  {
+    entityType: EntityType.STORAGE_SERVICE,
+    entity: { name: 'svc', fullyQualifiedName: 'svc' },
+  },
+  {
+    entityType: EntityType.SEARCH_SERVICE,
+    entity: { name: 'svc', fullyQualifiedName: 'svc' },
+  },
+  {
+    entityType: EntityType.SECURITY_SERVICE,
+    entity: { name: 'svc', fullyQualifiedName: 'svc' },
+  },
+  {
+    entityType: EntityType.DRIVE_SERVICE,
+    entity: { name: 'svc', fullyQualifiedName: 'svc' },
+  },
+];
+
+describe('breadcrumb builders gate the current entity behind includeCurrent', () => {
+  const service = {
+    id: 'svc-id',
+    name: 'svc',
+    type: 'databaseService',
+    fullyQualifiedName: 'svc',
+  };
+  const database = {
+    id: 'db-id',
+    name: 'db',
+    fullyQualifiedName: 'svc.db',
+    service,
+  } as unknown as Database;
+  const databaseSchema = {
+    id: 'schema-id',
+    name: 'schema',
+    fullyQualifiedName: 'svc.db.schema',
+    service,
+    database: { id: 'db-id', name: 'db', fullyQualifiedName: 'svc.db' },
+  } as unknown as DatabaseSchema;
+
+  it('should exclude the current database by default', () => {
+    const crumbs = getBreadcrumbForDatabase(database);
+
+    expect(crumbs.some((crumb) => crumb.name === 'db')).toBe(false);
+  });
+
+  it('should append the current database when includeCurrent is true', () => {
+    const crumbs = getBreadcrumbForDatabase(database, true);
+
+    expect(crumbs[crumbs.length - 1].name).toBe('db');
+  });
+
+  it('should exclude the current schema by default', () => {
+    const crumbs = getBreadcrumbForDatabaseSchema(databaseSchema);
+
+    expect(crumbs.some((crumb) => crumb.name === 'schema')).toBe(false);
+  });
+
+  it('should append the current schema when includeCurrent is true', () => {
+    const crumbs = getBreadcrumbForDatabaseSchema(databaseSchema, true);
+
+    expect(crumbs[crumbs.length - 1].name).toBe('schema');
+  });
+
+  it('should exclude the current metric by default', () => {
+    const crumbs = getBreadcrumbForMetric('metric1');
+
+    expect(crumbs.some((crumb) => crumb.name === 'metric1')).toBe(false);
+  });
+
+  it('should append the current metric when includeCurrent is true', () => {
+    const crumbs = getBreadcrumbForMetric('metric1', true);
+
+    expect(crumbs[crumbs.length - 1].name).toBe('metric1');
+  });
+});
+
+describe('DataAssetsHeader breadcrumbs - builders are ancestor-only for every entity', () => {
+  it.each(HEADER_ENTITY_CASES)(
+    'should not include the current entity in breadcrumbs for $entityType',
+    ({ entityType, entity }) => {
+      const dataAsset = entity as unknown as DataAssetsHeaderProps['dataAsset'];
+      const entityName = getEntityName(dataAsset);
+      const { breadcrumbs } = getDataAssetsHeaderInfo(
+        entityType,
+        dataAsset,
+        entityName,
+        []
+      );
+
+      const currentEntityNames = new Set([entityName, entity.name as string]);
+      const currentEntityCrumbs = breadcrumbs.filter((crumb) =>
+        currentEntityNames.has(crumb.name)
+      );
+
+      expect(currentEntityCrumbs).toHaveLength(0);
+    }
+  );
+});

--- a/openmetadata-ui/src/main/resources/ui/src/utils/DataAssetsHeader.utils.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/DataAssetsHeader.utils.tsx
@@ -464,8 +464,7 @@ export const getDataAssetsHeaderInfo = (
 
       returnData.breadcrumbs = getEntityBreadcrumbs(
         databaseSchemaDetails,
-        EntityType.DATABASE_SCHEMA,
-        true
+        EntityType.DATABASE_SCHEMA
       );
 
       break;

--- a/openmetadata-ui/src/main/resources/ui/src/utils/EntityBreadcrumbPureUtils.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/EntityBreadcrumbPureUtils.test.tsx
@@ -47,7 +47,7 @@ describe('EntityBreadcrumbPureUtils unit tests', () => {
       jest.clearAllMocks();
     });
 
-    it('should return breadcrumbs for EntityType.DATABASE', () => {
+    it('should return ancestor-only breadcrumbs for EntityType.DATABASE', () => {
       (getServiceRouteFromServiceType as jest.Mock).mockReturnValue(mockUrl);
       (getSettingPath as jest.Mock).mockReturnValue(mockSettingUrl);
       (getServiceDetailsPath as jest.Mock).mockReturnValue(
@@ -66,10 +66,6 @@ describe('EntityBreadcrumbPureUtils unit tests', () => {
           url: mockSettingUrl,
         },
         { name: 'mysql_sample', url: '/service/databaseServices/mysql_sample' },
-        {
-          name: 'default',
-          url: '/database/default',
-        },
       ]);
 
       expect(getServiceRouteFromServiceType).toHaveBeenCalledWith(
@@ -77,7 +73,23 @@ describe('EntityBreadcrumbPureUtils unit tests', () => {
       );
     });
 
-    it('should return breadcrumbs for EntityType.DATABASE_SCHEMA', () => {
+    it('should append the current entity for EntityType.DATABASE when includeCurrent is true', () => {
+      (getServiceRouteFromServiceType as jest.Mock).mockReturnValue(mockUrl);
+      (getSettingPath as jest.Mock).mockReturnValue(mockSettingUrl);
+      (getServiceDetailsPath as jest.Mock).mockReturnValue(
+        '/service/databaseServices/mysql_sample'
+      );
+
+      const result = getEntityBreadcrumbs(
+        mockEntityForDatabase,
+        EntityType.DATABASE,
+        true
+      );
+
+      expect(result[result.length - 1].name).toBe('default');
+    });
+
+    it('should return ancestor-only breadcrumbs for EntityType.DATABASE_SCHEMA', () => {
       (getSettingPath as jest.Mock).mockReturnValue(mockSettingUrl);
       (getServiceDetailsPath as jest.Mock).mockReturnValue(mockServiceUrl);
       (getEntityDetailsPath as jest.Mock).mockReturnValue(mockDatabaseUrl);
@@ -100,10 +112,6 @@ describe('EntityBreadcrumbPureUtils unit tests', () => {
           name: 'ecommerce_db',
           url: mockDatabaseUrl,
         },
-        {
-          name: 'shopify',
-          url: '/entity/MockDatabase',
-        },
       ]);
 
       expect(getServiceDetailsPath).toHaveBeenCalledWith(
@@ -114,6 +122,20 @@ describe('EntityBreadcrumbPureUtils unit tests', () => {
         EntityType.DATABASE,
         'sample_data.ecommerce_db'
       );
+    });
+
+    it('should append the current entity for EntityType.DATABASE_SCHEMA when includeCurrent is true', () => {
+      (getSettingPath as jest.Mock).mockReturnValue(mockSettingUrl);
+      (getServiceDetailsPath as jest.Mock).mockReturnValue(mockServiceUrl);
+      (getEntityDetailsPath as jest.Mock).mockReturnValue(mockDatabaseUrl);
+
+      const result = getEntityBreadcrumbs(
+        mockEntityForDatabaseSchema,
+        EntityType.DATABASE_SCHEMA,
+        true
+      );
+
+      expect(result[result.length - 1].name).toBe('shopify');
     });
   });
 });

--- a/openmetadata-ui/src/main/resources/ui/src/utils/EntityBreadcrumbPureUtils.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/EntityBreadcrumbPureUtils.ts
@@ -123,9 +123,12 @@ export const getEntityBreadcrumbs = (
         getEntityName(entity as { name?: string; displayName?: string })
       );
     case EntityType.DATABASE:
-      return getBreadcrumbForDatabase(entity as Database);
+      return getBreadcrumbForDatabase(entity as Database, includeCurrent);
     case EntityType.DATABASE_SCHEMA:
-      return getBreadcrumbForDatabaseSchema(entity as DatabaseSchema);
+      return getBreadcrumbForDatabaseSchema(
+        entity as DatabaseSchema,
+        includeCurrent
+      );
     case EntityType.DATABASE_SERVICE:
       return getBreadcrumbForDatabaseService(
         entity.name,
@@ -245,7 +248,7 @@ export const getEntityBreadcrumbs = (
     case EntityType.API_ENDPOINT:
       return getBreadCrumbForAPIEndpoint(entity as APIEndpoint);
     case EntityType.METRIC:
-      return getBreadcrumbForMetric(entity.name);
+      return getBreadcrumbForMetric(entity.name, includeCurrent);
     case EntityType.KPI:
       return getBreadCrumbForKpi(entity as Kpi);
     case EntityType.KNOWLEDGE_PAGE:

--- a/openmetadata-ui/src/main/resources/ui/src/utils/EntityGovernanceBreadcrumbUtils.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/EntityGovernanceBreadcrumbUtils.ts
@@ -285,15 +285,22 @@ export const getBreadcrumbForClassification = (entityName: string) => [
   },
 ];
 
-export const getBreadcrumbForMetric = (entityName: string) => [
+export const getBreadcrumbForMetric = (
+  entityName: string,
+  includeCurrent = false
+) => [
   {
     name: i18n.t('label.metric-plural'),
     url: ROUTES.METRICS,
   },
-  {
-    name: entityName,
-    url: '',
-  },
+  ...(includeCurrent
+    ? [
+        {
+          name: entityName,
+          url: '',
+        },
+      ]
+    : []),
 ];
 
 export const getBreadcrumbForKnowledgePage = (

--- a/openmetadata-ui/src/main/resources/ui/src/utils/EntityServiceBreadcrumbUtils.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/EntityServiceBreadcrumbUtils.ts
@@ -57,19 +57,30 @@ export const getBreadcrumbForDatabaseService = (
   return items;
 };
 
-export const getBreadcrumbForDatabase = (entity: Database) => [
+export const getBreadcrumbForDatabase = (
+  entity: Database,
+  includeCurrent = false
+) => [
   ...getServiceCategoryBreadcrumb(ServiceCategory.DATABASE_SERVICES),
   ...getBreadcrumbForEntitiesWithServiceOnly(entity),
-  {
-    name: entity.name,
-    url: getEntityLinkFromType(
-      entity.fullyQualifiedName ?? '',
-      ((entity as SourceType).entityType as EntityType) ?? EntityType.DATABASE
-    ),
-  },
+  ...(includeCurrent
+    ? [
+        {
+          name: entity.name,
+          url: getEntityLinkFromType(
+            entity.fullyQualifiedName ?? '',
+            ((entity as SourceType).entityType as EntityType) ??
+              EntityType.DATABASE
+          ),
+        },
+      ]
+    : []),
 ];
 
-export const getBreadcrumbForDatabaseSchema = (entity: DatabaseSchema) => [
+export const getBreadcrumbForDatabaseSchema = (
+  entity: DatabaseSchema,
+  includeCurrent = false
+) => [
   ...getServiceCategoryBreadcrumb(ServiceCategory.DATABASE_SERVICES),
   {
     name: getEntityName(entity.service),
@@ -89,12 +100,16 @@ export const getBreadcrumbForDatabaseSchema = (entity: DatabaseSchema) => [
       entity.database?.fullyQualifiedName ?? ''
     ),
   },
-  {
-    name: entity.name,
-    url: getEntityLinkFromType(
-      entity.fullyQualifiedName ?? '',
-      ((entity as unknown as SourceType).entityType as EntityType) ??
-        EntityType.DATABASE_SCHEMA
-    ),
-  },
+  ...(includeCurrent
+    ? [
+        {
+          name: entity.name,
+          url: getEntityLinkFromType(
+            entity.fullyQualifiedName ?? '',
+            ((entity as unknown as SourceType).entityType as EntityType) ??
+              EntityType.DATABASE_SCHEMA
+          ),
+        },
+      ]
+    : []),
 ];


### PR DESCRIPTION
## What

The 2.0 entity page header now shows a single, clean breadcrumb trail for every entity, with the current entity rendered exactly once.

## Why

The redesigned header (#28538) appends the current entity as the trailing breadcrumb crumb. Most breadcrumb builders return only the ancestor path, but `getBreadcrumbForDatabase`, `getBreadcrumbForDatabaseSchema`, and `getBreadcrumbForMetric` already appended the current entity themselves — so for those three it rendered twice (e.g. `Database Services › service › db › db`).

## How

- Gate the current-entity crumb in those three builders behind `includeCurrent` (default `false`), matching every other builder, and forward the flag through `getEntityBreadcrumbs`.
- The header then renders the ancestor trail and appends the current entity itself — so **every entity type uses one uniform path**: ancestor-only builder + header append. No special-casing, no de-dupe helper.
- Consumers that want the current entity in the breadcrumb (`ExploreSearchCard`, bulk Import) already pass `includeCurrent: true` and are unchanged. The component reverts to the original `main` append, so its net diff is zero — the entire fix lives in the breadcrumb builders.

## Scope / safety

Only the database / database-schema / metric breadcrumbs change; every other entity type's breadcrumb is byte-identical. The only consumers affected are those that pass `includeCurrent: false` for these three types — entity version pages, the activity feed, the deprecated `TableDataCardV2`, and hashtag suggestions — which simply drop a redundant trailing crumb (each renders the entity name separately, so it's a consistency improvement). No consumer relies on the breadcrumb's last crumb being the current entity (the only `.slice(0, -1)` caller, `ExploreSearchCard`, passes `true`).

## Tests

- **`DataAssetsHeader.breadcrumb.test.tsx`** — asserts `getDataAssetsHeaderInfo(...).breadcrumbs` is ancestor-only for **every** entity type the header renders (30 types, incl. all services), plus `includeCurrent` unit tests for the three builders. Verified RED→GREEN: forcing a builder to include the current entity fails the relevant case.
- **`EntityBreadcrumbPureUtils.test.tsx`** — updated to the new ancestor-only default + added `includeCurrent: true` cases.
- **`EntityHeaderBreadcrumb.spec.ts`** (Playwright) + **`headerBreadcrumbUtils.ts`** — iterate **all 19 data-entity detail pages** and assert every breadcrumb crumb renders exactly once. All 19 pass against a live stack.
- Full regression run of every suite touching the changed utils/consumers (ExploreSearchCard, KnowledgeGraph, EntityImport, SearchClassBase, version utils, header) — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a double-rendering of the current entity in the entity-page header breadcrumb for `Database`, `DatabaseSchema`, and `Metric` entity types. The header already appends the current entity as the trailing crumb, but those three builders unconditionally appended it themselves, causing a duplicate like `Database Services › service › db › db`.

- Gates the current-entity crumb in `getBreadcrumbForDatabase`, `getBreadcrumbForDatabaseSchema`, and `getBreadcrumbForMetric` behind an `includeCurrent` parameter (default `false`), matching every other builder.
- Threads `includeCurrent` through `getEntityBreadcrumbs` so the flag propagates correctly; removes the previously-ignored `true` argument from the `DATABASE_SCHEMA` call in `DataAssetsHeader.utils.tsx`.
- Adds unit tests for all 30 entity types the header renders and E2E Playwright tests that visit each of 19 entity detail pages and assert every breadcrumb crumb renders exactly once.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is surgical, touching only three breadcrumb builders, all behind a defaulted-off flag that keeps every existing caller's behavior identical.

The fix is minimal and well-scoped: three builder functions each gain an opt-in `includeCurrent` parameter with a `false` default, so all callers that don't pass the flag are unaffected. The only consumer that explicitly passed `true` to trigger the now-corrected `DATABASE_SCHEMA` path was doing so to a parameter that wasn't being forwarded anyway, so removing it is a no-op for that path. The accompanying unit tests cover all 30 entity types the header renders and directly verify the before/after behavior for the three changed builders; the new Playwright spec validates uniqueness end-to-end against all 19 entity detail pages.

No files require special attention.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-ui/src/main/resources/ui/src/utils/EntityServiceBreadcrumbUtils.ts | Adds `includeCurrent = false` parameter to `getBreadcrumbForDatabase` and `getBreadcrumbForDatabaseSchema`, gating the trailing self-crumb behind the flag. Logic is correct and backward-compatible. |
| openmetadata-ui/src/main/resources/ui/src/utils/EntityGovernanceBreadcrumbUtils.ts | Adds `includeCurrent = false` parameter to `getBreadcrumbForMetric`, matching the same pattern used for the other two builders. Correct and minimal. |
| openmetadata-ui/src/main/resources/ui/src/utils/EntityBreadcrumbPureUtils.ts | Threads `includeCurrent` through to the three affected builders in `getEntityBreadcrumbs`. All other entity-type branches are unchanged. |
| openmetadata-ui/src/main/resources/ui/src/utils/DataAssetsHeader.utils.tsx | Removes the previously-ignored `true` third argument from the `DATABASE_SCHEMA` call to `getEntityBreadcrumbs`. The `DATABASE` and `METRIC` header calls already omitted the flag. One-line change, correct. |
| openmetadata-ui/src/main/resources/ui/src/utils/DataAssetsHeader.breadcrumb.test.tsx | New test file: exercises all 30 entity types the header renders and verifies each builder returns ancestor-only breadcrumbs by default, plus `includeCurrent: true` unit tests for the three fixed builders. Solid coverage. |
| openmetadata-ui/src/main/resources/ui/src/utils/EntityBreadcrumbPureUtils.test.tsx | Updated existing tests to reflect the ancestor-only default and added `includeCurrent: true` verification for `DATABASE` and `DATABASE_SCHEMA`. Accurate and well-structured. |
| openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/EntityHeaderBreadcrumb.spec.ts | New Playwright spec that iterates all 19 data-entity types and asserts every breadcrumb crumb renders exactly once. Test structure is clean; setup/teardown correctly creates and deletes entities per describe block. |
| openmetadata-ui/src/main/resources/ui/playwright/utils/headerBreadcrumbUtils.ts | New Playwright utility that locates the breadcrumb container, collects all listitem text labels, and asserts uniqueness. Simple and correct. |

</details>

</details>

<details open><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[DataAssetsHeader calls getDataAssetsHeaderInfo] --> B{EntityType?}
    B -->|DATABASE| C[getEntityBreadcrumbs\nentity, DATABASE]
    B -->|DATABASE_SCHEMA| D[getEntityBreadcrumbs\nentity, DATABASE_SCHEMA]
    B -->|METRIC| E[getEntityBreadcrumbs\nentity, METRIC]
    B -->|Other types| F[getEntityBreadcrumbs\nentity, type]

    C --> G[getBreadcrumbForDatabase\nentity, includeCurrent=false]
    D --> H[getBreadcrumbForDatabaseSchema\nentity, includeCurrent=false]
    E --> I[getBreadcrumbForMetric\nentity.name, includeCurrent=false]
    F --> J[Other builder\nancestor-only]

    G --> K[ServiceCategory + Service crumbs only]
    H --> L[ServiceCategory + Service + DB crumbs only]
    I --> M[Metrics page crumb only]
    J --> N[Ancestor crumbs only]

    K --> O[Header appends current entity]
    L --> O
    M --> O
    N --> O

    O --> P[Final breadcrumb: ancestors + current entity exactly once]

    style P fill:#22c55e,color:#fff
    style K fill:#3b82f6,color:#fff
    style L fill:#3b82f6,color:#fff
    style M fill:#3b82f6,color:#fff
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[DataAssetsHeader calls getDataAssetsHeaderInfo] --> B{EntityType?}
    B -->|DATABASE| C[getEntityBreadcrumbs\nentity, DATABASE]
    B -->|DATABASE_SCHEMA| D[getEntityBreadcrumbs\nentity, DATABASE_SCHEMA]
    B -->|METRIC| E[getEntityBreadcrumbs\nentity, METRIC]
    B -->|Other types| F[getEntityBreadcrumbs\nentity, type]

    C --> G[getBreadcrumbForDatabase\nentity, includeCurrent=false]
    D --> H[getBreadcrumbForDatabaseSchema\nentity, includeCurrent=false]
    E --> I[getBreadcrumbForMetric\nentity.name, includeCurrent=false]
    F --> J[Other builder\nancestor-only]

    G --> K[ServiceCategory + Service crumbs only]
    H --> L[ServiceCategory + Service + DB crumbs only]
    I --> M[Metrics page crumb only]
    J --> N[Ancestor crumbs only]

    K --> O[Header appends current entity]
    L --> O
    M --> O
    N --> O

    O --> P[Final breadcrumb: ancestors + current entity exactly once]

    style P fill:#22c55e,color:#fff
    style K fill:#3b82f6,color:#fff
    style L fill:#3b82f6,color:#fff
    style M fill:#3b82f6,color:#fff
```

</a>
</details>

<sub>Reviews (3): Last reviewed commit: ["fix(ui): render each entity-header bread..."](https://github.com/open-metadata/openmetadata/commit/ea244beacb3e0ab47c212160a88887abfa218055) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38623252)</sub>

<!-- /greptile_comment -->