### PR TITLE
fix(ingestion): secret serialization crash on plain SecretStr/null secrets

### DIFF
--- a/ingestion/src/metadata/ingestion/models/custom_pydantic.py
+++ b/ingestion/src/metadata/ingestion/models/custom_pydantic.py
@@ -175,24 +175,34 @@ class _CustomSecretStr(SecretStr):
 
         Since the SecretsManagerFactory is a singleton, getting it here
         will pick up the object with all the necessary info already in it.
+
+        A secret stored as ``null`` in the secrets manager resolves to ``None``.
+        We log it and fall back to an empty string so downstream callers that
+        expect a string (e.g. URL building with ``quote_plus``) do not crash.
         """
         # Importing inside function to avoid circular import error
         from metadata.utils.secrets.secrets_manager_factory import (  # pylint: disable=import-outside-toplevel,cyclic-import  # noqa: PLC0415
             SecretsManagerFactory,
         )
 
+        secret_value = self._secret_value
         if (
             not skip_secret_manager
+            and self._secret_value
             and self._secret_value.startswith(SECRET)
             and SecretsManagerFactory().get_secrets_manager()
         ):
             secret_id = self._secret_value.replace(SECRET, "")
             logger.info(f"Getting secret value for {secret_id}")
             try:
-                return SecretsManagerFactory().get_secrets_manager().get_string_value(secret_id)
+                secret_value = SecretsManagerFactory().get_secrets_manager().get_string_value(secret_id)
             except Exception as exc:
                 logger.error(f"Secret value [{secret_id}] not present in the configured secrets manager: {exc}")
-        return self._secret_value
+
+        if secret_value is None:
+            logger.warning("Resolved a null secret value; treating it as an empty string")
+            secret_value = ""
+        return secret_value
 
 
 def handle_secret(value: Any, handler, info: SerializationInfo) -> str:
@@ -206,9 +216,19 @@ def handle_secret(value: Any, handler, info: SerializationInfo) -> str:
         # is not silently turned into a plain secret. Resolution against the
         # secrets manager happens at use-time through a direct get_secret_value()
         # call (e.g. when building a connection).
+        #
+        # A CustomSecretStr field can still hold a plain pydantic SecretStr when
+        # code assigns one directly (e.g. connection builders setting an empty
+        # password). Only _CustomSecretStr accepts skip_secret_manager, so guard
+        # the call to avoid a TypeError on plain SecretStr values.
+        raw_value = (
+            value.get_secret_value(skip_secret_manager=True)
+            if isinstance(value, _CustomSecretStr)
+            else value.get_secret_value()
+        )
         if info.mode == "json":
-            return value.get_secret_value(skip_secret_manager=True)
-        return handler(value.get_secret_value(skip_secret_manager=True))
+            return raw_value
+        return handler(raw_value)
     return str(value)  # use pydantic's logic to mask the secret
 
 

--- a/ingestion/tests/unit/models/test_custom_pydantic.py
+++ b/ingestion/tests/unit/models/test_custom_pydantic.py
@@ -2,8 +2,11 @@ import json
 import uuid
 from typing import List, Optional  # noqa: UP035
 from unittest import TestCase
+from urllib.parse import quote_plus
 
 import pytest
+from pydantic import BaseModel as PydanticBaseModel
+from pydantic import SecretStr
 
 from metadata.generated.schema.api.data.createDashboardDataModel import (
     CreateDashboardDataModelRequest,
@@ -218,6 +221,45 @@ def test_model_dump_json_secrets():
         model.model_validate_json(model.model_dump_json(mask_secrets=False)).root_secret.get_secret_value()
         == "root_password"
     )
+
+
+class _LeakedSecretConnection(BaseModel):
+    password: CustomSecretStr
+
+
+class _LeakedSecretParams(PydanticBaseModel):
+    """Mirrors data-quality runtime-param models: a vanilla pydantic model
+    (no mask-by-default ``model_dump_json``) wrapping a generated connection."""
+
+    conn_config: _LeakedSecretConnection
+
+
+class TestPlainSecretStrInCustomSecretStrField:
+    """Regression test for the data-quality serialization crash.
+
+    Connection builders (snowflake/oracle/impala/hive) assign a plain pydantic
+    ``SecretStr`` to a ``CustomSecretStr``-typed field when auth has no password.
+    Data-quality runtime-param setters then serialize that config through a
+    vanilla ``model_dump_json()``. ``handle_secret`` must not pass
+    ``skip_secret_manager`` to a plain ``SecretStr`` whose base
+    ``get_secret_value`` rejects the kwarg.
+    """
+
+    def test_model_dump_json_does_not_crash_on_plain_secret(self):
+        connection = _LeakedSecretConnection(password=CustomSecretStr("real_password"))
+        connection.password = SecretStr("")
+
+        serialized = json.loads(_LeakedSecretParams(conn_config=connection).model_dump_json())
+
+        assert serialized["conn_config"]["password"] == ""
+
+    def test_python_dump_does_not_crash_on_plain_secret(self):
+        connection = _LeakedSecretConnection(password=CustomSecretStr("real_password"))
+        connection.password = SecretStr("plain_value")
+
+        dumped = _LeakedSecretParams(conn_config=connection).model_dump()
+
+        assert dumped["conn_config"]["password"] == "plain_value"
 
 
 # Additional comprehensive tests for enhanced functionality
@@ -659,10 +701,11 @@ class CustomSecretStrExtendedTest(TestCase):
         assert empty_secret.get_secret_value() == ""
         assert str(empty_secret) == ""
 
-        # Test None secret handling
+        # Test None secret handling: a null secret resolves to an empty string
+        # instead of propagating None (see the get_secret_value null guard).
         try:
             none_secret = CustomSecretStr(None)
-            assert none_secret.get_secret_value() is None
+            assert none_secret.get_secret_value() == ""
         except (TypeError, ValueError, AttributeError):
             # This is acceptable behavior for None values
             pass
@@ -895,6 +938,43 @@ class TestExternalSecretReferenceResolution:
 
         assert serialized["authType"]["password"] == self.EXTERNAL_SECRET_REFERENCE
         assert serialized["authType"]["password"] != RESOLVED_EXTERNAL_SECRET
+
+
+class _NullExternalSecretsManager(SecretsManager):
+    """Test double for a secrets manager holding a secret stored as ``null``."""
+
+    def get_string_value(self, secret_id: str) -> str:
+        return None
+
+
+class TestNullSecretResolution:
+    """Regression test for a secret stored as ``null`` in the secrets manager.
+
+    Resolving it must yield an empty string (with a warning), not ``None``.
+    A ``None`` value crashes downstream string callers such as URL building
+    with ``quote_plus`` (``TypeError: quote_from_bytes() expected bytes``).
+    """
+
+    EXTERNAL_SECRET_REFERENCE = "secret:/external/path/to/db/password"
+
+    @pytest.fixture(autouse=True)
+    def null_secrets_manager(self):
+        Singleton.clear_all()
+        factory = SecretsManagerFactory(SecretsManagerProvider.db, SecretsManagerClientLoader.noop)
+        factory.secrets_manager = _NullExternalSecretsManager()
+        yield
+        Singleton.clear_all()
+
+    def test_null_secret_resolves_to_empty_string(self):
+        resolved = CustomSecretStr(self.EXTERNAL_SECRET_REFERENCE).get_secret_value()
+
+        assert resolved == ""
+        assert isinstance(resolved, str)
+
+    def test_null_secret_is_quote_plus_safe(self):
+        resolved = CustomSecretStr(self.EXTERNAL_SECRET_REFERENCE).get_secret_value()
+
+        assert quote_plus(resolved) == ""
 
 
 class DashboardDataModelTransformationTest(TestCase):


### PR DESCRIPTION
Fixes https://github.com/open-metadata/OpenMetadata/issues/29219

### Describe your changes:

Follow-up to #28625 — fixes the regression it introduced. No separate issue filed.

Two ingestion secret-serialization crashes, both present on `main` and `1.13`. `handle_secret` passed `skip_secret_manager` unconditionally and died on plain `pydantic.SecretStr` values that leak into `CustomSecretStr` fields (e.g. snowflake/oracle/impala/hive connection builders setting an empty password), surfaced by data-quality runtime-param `model_dump_json()` as `_SecretBase.get_secret_value() got an unexpected keyword argument 'skip_secret_manager'`. Separately, `get_secret_value` returned `None` for a secret stored as `null` in the secrets manager, crashing `quote_plus` URL building with `quote_from_bytes() expected bytes`. Now `handle_secret` guards the kwarg with an `isinstance(value, _CustomSecretStr)` check, and `get_secret_value` logs a warning and falls back to an empty string so it always returns a `str`. Both fixes are central in `custom_pydantic.py`, covering every connector rather than per-call-site.

#
### Type of change:
- [x] Bug fix

#
### High-level design:

N/A — small change (2 files, `custom_pydantic.py` + tests).

#
### Tests:

#### Use cases covered
- Data-quality custom-SQL / rule-library test against snowflake key-pair (or oracle/impala/hive empty-password) auth serializes its connection without crashing.
- A `secret:<id>` reference whose stored value is `null` resolves to an empty string instead of propagating `None` into URL building.

#### Unit tests
- [x] Added in `ingestion/tests/unit/models/test_custom_pydantic.py`:
  - `TestPlainSecretStrInCustomSecretStrField` — plain `SecretStr` leaked into a `CustomSecretStr` field, serialized via a vanilla-pydantic outer model (mirrors the DQ runtime-param models).
  - `TestNullSecretResolution` — secrets manager returning `null` resolves to `""` and is `quote_plus`-safe.
  - Updated `test_empty_and_none_secrets` (it asserted the old `is None` behavior).

#### Backend integration tests
- [x] Not applicable (no backend API changes).

#### Ingestion integration tests
- [x] Not applicable (covered by unit tests on the shared serialization helpers).

#### Playwright (UI) tests
- [x] Not applicable (no UI changes).

#### Manual testing performed
Reproduced both crashes against unfixed code (exact reported errors) and confirmed the fixed code passes; full `test_custom_pydantic.py` suite green (41 passed), `ruff format`/`check` clean.

#
### UI screen recording / screenshots:

Not applicable.

#
### Checklist:
- [x] I have read the **CONTRIBUTING** document.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have added tests (unit) and listed them above.
- [x] I have added a test that covers the exact scenario we are fixing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes two regression crashes introduced in #28625, both in the shared `custom_pydantic.py` secret-serialization helpers that affect every connector.

- **`handle_secret` TypeError fix**: adds an `isinstance(value, _CustomSecretStr)` guard before passing `skip_secret_manager=True`, so plain `pydantic.SecretStr` values that leak into `CustomSecretStr` fields (e.g. empty passwords in snowflake/oracle/impala/hive connection builders) no longer raise `TypeError: got an unexpected keyword argument`.
- **Null secret fallback**: `get_secret_value` now assigns the resolved value to a local variable upfront, adds a falsy-guard on `_secret_value` before calling `.startswith` (preventing an `AttributeError` on `None`), and converts a `None` return from the secrets manager to `\"\"` with a warning — stopping the `quote_plus` crash on `None`.
- Both regression paths are covered by new unit-test classes (`TestPlainSecretStrInCustomSecretStrField`, `TestNullSecretResolution`) and the updated `test_empty_and_none_secrets` assertion.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; both fixes are narrowly scoped to the serialization helpers and backed by focused regression tests.

The logic changes are small and well-contained. The only outstanding item is the -> str annotation on _NullExternalSecretsManager.get_string_value in the test, which lies about returning None and will trip static type checkers, but has no runtime impact.

The test file's _NullExternalSecretsManager.get_string_value return-type annotation warrants a quick fix before merge.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| ingestion/src/metadata/ingestion/models/custom_pydantic.py | Two targeted fixes: (1) get_secret_value now guards against _secret_value being None/falsy before calling .startswith, and converts a None return from the secrets manager to empty string with a warning; (2) handle_secret gates skip_secret_manager=True behind an isinstance(_CustomSecretStr) check so plain SecretStr values do not get an unexpected keyword argument. Both changes are minimal and correct. |
| ingestion/tests/unit/models/test_custom_pydantic.py | Adds two new regression test classes covering both crashes; updates the existing test_empty_and_none_secrets assertion to match the new empty-string behavior. Minor: _NullExternalSecretsManager.get_string_value annotates -> str but returns None, which will be flagged by static type checkers. |

</details>

</details>

<details open><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[handle_secret] --> B{mask_secrets?}
    B -- Yes --> C[return str masked]
    B -- No --> D{isinstance _CustomSecretStr?}
    D -- Yes --> E[get_secret_value skip_secret_manager=True]
    D -- No --> F[get_secret_value]
    E --> G[raw_value]
    F --> G
    G --> H{json mode?}
    H -- Yes --> I[return raw_value]
    H -- No --> J[return handler raw_value]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[handle_secret] --> B{mask_secrets?}
    B -- Yes --> C[return str masked]
    B -- No --> D{isinstance _CustomSecretStr?}
    D -- Yes --> E[get_secret_value skip_secret_manager=True]
    D -- No --> F[get_secret_value]
    E --> G[raw_value]
    F --> G
    G --> H{json mode?}
    H -- Yes --> I[return raw_value]
    H -- No --> J[return handler raw_value]
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(ingestion): harden secret serializat..."](https://github.com/open-metadata/openmetadata/commit/2a05b2d22e529c1a65db86a4db9194cbfab3adfe) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38628472)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->