### PR TITLE
fix(security): bump handlebars to 4.5.2 (CVE-2026-55760 path traversal)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -115,7 +115,7 @@
     <org.junit.jupiter.version>5.11.4</org.junit.jupiter.version>
     <org.junit.platform.version>1.11.4</org.junit.platform.version>
     <dropwizard-health.version>5.0.0</dropwizard-health.version>
-    <handlebars.version>4.5.0</handlebars.version>
+    <handlebars.version>4.5.2</handlebars.version>
     <fernet.version>1.5.0</fernet.version>
     <antlr.version>4.13.2</antlr.version>
     <!-- Apache Jena RDF client libraries. Pinned project-wide so


### PR DESCRIPTION
Fixes #29222

## What

Bumps `com.github.jknack:handlebars` from **4.5.0** to **4.5.2** (`handlebars.version` in the root `pom.xml`).

## Why

`handlebars` < 4.5.2 is affected by **CVE-2026-55760** / **GHSA-r4gv-qr8j-p3pg** — a High-severity (CVSS 7.5) path-traversal (CWE-22). When a user-controlled value is used as a *template name* in `Handlebars.compile(name)` with a `FileTemplateLoader` / `ClasspathResourceLoader`, an attacker can read arbitrary files. Fixed in 4.5.2. The finding was surfaced by container image scanning of the published server image.

### Reachability note

This codebase is **not exploitable** by the CVE as-shipped: handlebars is only ever used via `Handlebars#compileInline(String)` on in-memory template strings (`HandlebarsNotificationTemplateProcessor`), with a default `Handlebars` instance (`HandlebarsProvider` — no `FileTemplateLoader`/`ClasspathResourceLoader` configured). No template *name* is ever derived from user input. This bump clears the scanner finding and removes the vulnerable jar regardless.

## Compatibility — no breaking change

4.5.2 is a patch release within the 4.5.x line. Verified against the API this repo actually uses:

- **No classes added or removed** between 4.5.0 and 4.5.2.
- **Public API byte-identical** (`javap` diff) for all 7 types referenced here: `Handlebars`, `Handlebars.SafeString`, `EscapingStrategy`, `Helper`, `Options`, `Template`, `HandlebarsException`.
- **Runtime smoke test** mirroring our usage (`EscapingStrategy.HTML_ENTITY` + `registerHelper(...)` + `compileInline(...).apply(Map)` + `SafeString` + `HandlebarsException` on malformed input) passes against 4.5.2 with identical output.
- The only behavior change in 4.5.2 restricts `ClasspathResourceLoader` root/suffix configurations — **not used** in this codebase.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR bumps `com.github.jknack:handlebars` from 4.5.0 to 4.5.2 via the `handlebars.version` property in the root `pom.xml`, clearing a High-severity (CVSS 7.5) path-traversal CVE (CVE-2026-55760 / GHSA-r4gv-qr8j-p3pg) surfaced by container image scanning.

- **Single property change** in `pom.xml` (`handlebars.version` 4.5.0 → 4.5.2); version is inherited by `openmetadata-service/pom.xml` with no override, so the fix propagates correctly.
- **4.5.2 is a patch release** that only restricts `ClasspathResourceLoader`/`FileTemplateLoader` root/suffix paths — this codebase uses `compileInline` with a default `Handlebars` instance and no file-based loader, so there is no behavioral impact.
- The CVE is confirmed as a real advisory (published 2026-06-16); bumping regardless is correct hygiene even though the codebase is not directly exploitable as-shipped.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — a minimal one-line dependency bump with no API changes and a confirmed patch-release compatibility guarantee.

The change touches exactly one property in the root pom.xml. The target version (4.5.2) is a patch release whose only behavioral delta restricts file-based loader configuration paths that this codebase never uses. The CVE advisory is confirmed, the version is available on Maven Central, and the openmetadata-service module inherits the version without an override, so the fix propagates correctly throughout the build.

No files require special attention.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| pom.xml | Single-line version bump of `handlebars.version` from 4.5.0 to 4.5.2 to address CVE-2026-55760 path-traversal vulnerability; no structural changes. |

</details>

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Scanner as Container Scanner
    participant POM as pom.xml
    participant Service as openmetadata-service
    participant HB as handlebars 4.5.2

    Scanner->>POM: Flags CVE-2026-55760 in handlebars 4.5.0
    POM->>POM: handlebars.version 4.5.0 → 4.5.2
    Service->>POM: Inherits handlebars.version (no override)
    Service->>HB: Resolves com.github.jknack:handlebars:4.5.2
    HB-->>Service: compileInline(String) — unchanged API
    Scanner->>HB: No CVE finding (path traversal fix applied)
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Scanner as Container Scanner
    participant POM as pom.xml
    participant Service as openmetadata-service
    participant HB as handlebars 4.5.2

    Scanner->>POM: Flags CVE-2026-55760 in handlebars 4.5.0
    POM->>POM: handlebars.version 4.5.0 → 4.5.2
    Service->>POM: Inherits handlebars.version (no override)
    Service->>HB: Resolves com.github.jknack:handlebars:4.5.2
    HB-->>Service: compileInline(String) — unchanged API
    Scanner->>HB: No CVE finding (path traversal fix applied)
```

</a>
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(security): bump handlebars to 4.5.2 ..."](https://github.com/open-metadata/openmetadata/commit/e22281ebf82f3ec96049517364b045c5a10eb5d5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38640406)</sub>

<!-- /greptile_comment -->