### PR TITLE
Consolidate UI checkstyle workflow

### DIFF
--- a/.github/workflows/ui-checkstyle.yml
+++ b/.github/workflows/ui-checkstyle.yml
@@ -71,8 +71,6 @@ jobs:
     permissions:
       contents: read
     outputs:
-      schema_result: ${{ steps.schema_check.outcome }}
-      schema_changed_files: ${{ steps.schema_check.outputs.changed_files }}
       lint_src_result: ${{ steps.lint_src.outcome }}
       lint_src_changed_files: ${{ steps.lint_src.outputs.changed_files }}
       license_result: ${{ steps.license.outcome }}
@@ -106,39 +104,6 @@ jobs:
       - name: Install UI Yarn Packages
         working-directory: ${{ env.UI_WORKING_DIRECTORY }}
         run: yarn install --frozen-lockfile
-
-      - name: Check for JSON schema changes
-        id: schema_detect
-        run: |
-          changed_files=$(git diff --name-only origin/main...HEAD | grep '^openmetadata-spec/src/main/resources/json/schema/' || true)
-          if [ -n "$changed_files" ]; then
-            echo "has_changes=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "has_changes=false" >> "$GITHUB_OUTPUT"
-          fi
-
-      - name: Build and generate TypeScript from schemas
-        if: steps.schema_detect.outputs.has_changes == 'true'
-        run: |
-          changed_files=$(git diff --name-only origin/main...HEAD | grep '^openmetadata-spec/src/main/resources/json/schema/' || true)
-          if [ -n "$changed_files" ]; then
-            ./openmetadata-ui/src/main/resources/ui/json2ts.sh $changed_files
-          fi
-
-      - name: Check for uncommitted TypeScript changes
-        if: steps.schema_detect.outputs.has_changes == 'true'
-        id: schema_check
-        continue-on-error: true
-        run: |
-          if ! git diff --quiet -- openmetadata-ui/src/main/resources/ui/src/generated; then
-            FILES=$(git status --porcelain openmetadata-ui/src/main/resources/ui/src/generated | awk '{print "  - `" $2 "`"}' | head -20)
-            echo "changed_files<<EOF" >> "$GITHUB_OUTPUT"
-            echo "$FILES" >> "$GITHUB_OUTPUT"
-            echo "EOF" >> "$GITHUB_OUTPUT"
-            git checkout -- .
-            git clean -fd
-            exit 1
-          fi
 
       - name: Get changed src files
         id: changed-src-files
@@ -333,12 +298,6 @@ jobs:
           script: |
             const checks = [
               {
-                name:    'JSON Schema & TypeScript Generation',
-                reason:  'JSON schema changes require TypeScript regeneration.',
-                result:  '${{ needs.checkstyle.outputs.schema_result }}',
-                files:   ${{ toJSON(needs.checkstyle.outputs.schema_changed_files) }} || '',
-              },
-              {
                 name:    'ESLint + Prettier + Organise Imports (src)',
                 reason:  'One or more source files have linting or formatting issues.',
                 result:  '${{ needs.checkstyle.outputs.lint_src_result }}',
@@ -430,7 +389,6 @@ jobs:
         if: always()
         run: |
           if [ "${{ needs.checkstyle.result }}" != 'success' ] || \
-             [ "${{ needs.checkstyle.outputs.schema_result }}" = 'failure' ] || \
              [ "${{ needs.checkstyle.outputs.lint_src_result }}" = 'failure' ] || \
              [ "${{ needs.checkstyle.outputs.license_result }}" = 'failure' ] || \
              [ "${{ needs.checkstyle.outputs.i18n_result }}" = 'failure' ] || \

--- a/.github/workflows/ui-checkstyle.yml
+++ b/.github/workflows/ui-checkstyle.yml
@@ -93,6 +93,10 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version-file: "${{ env.UI_WORKING_DIRECTORY }}/.nvmrc"
+          cache: yarn
+          cache-dependency-path: |
+            ${{ env.UI_WORKING_DIRECTORY }}/yarn.lock
+            ${{ env.CORE_COMPONENTS_WORKING_DIRECTORY }}/yarn.lock
 
       - name: Install Antlr4 CLI
         run: sudo make install_antlr_cli

--- a/.github/workflows/ui-checkstyle.yml
+++ b/.github/workflows/ui-checkstyle.yml
@@ -93,10 +93,6 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version-file: "${{ env.UI_WORKING_DIRECTORY }}/.nvmrc"
-          cache: yarn
-          cache-dependency-path: |
-            ${{ env.UI_WORKING_DIRECTORY }}/yarn.lock
-            ${{ env.CORE_COMPONENTS_WORKING_DIRECTORY }}/yarn.lock
 
       - name: Install Antlr4 CLI
         run: sudo make install_antlr_cli

--- a/.github/workflows/ui-checkstyle.yml
+++ b/.github/workflows/ui-checkstyle.yml
@@ -40,9 +40,6 @@ env:
   CORE_COMPONENTS_WORKING_DIRECTORY: openmetadata-ui-core-components/src/main/resources/ui
 
 jobs:
-  # ──────────────────────────────────────────────────────────────────────────
-  # Job 0: Authorize
-  # ──────────────────────────────────────────────────────────────────────────
   authorize:
     if: |
       github.event_name == 'merge_group' ||
@@ -68,22 +65,26 @@ jobs:
           pull-request-number: "${{ github.event.pull_request.number }}"
           disable-reviews: true
 
-  # ──────────────────────────────────────────────────────────────────────────
-  # Common setup steps reused across all parallel check jobs via a shared
-  # composite-like pattern: each job does its own checkout + yarn install
-  # (fast due to yarn cache from actions/setup-node).
-  # ──────────────────────────────────────────────────────────────────────────
-
-  # ──────────────────────────────────────────────────────────────────────────
-  # Job 1: Lint — ESLint + Prettier + Organise Imports (src)
-  # ──────────────────────────────────────────────────────────────────────────
-  lint-src:
+  checkstyle:
     needs: authorize
     runs-on: ubuntu-latest
     permissions:
       contents: read
     outputs:
-      changed_files: ${{ steps.lint.outputs.changed_files }}
+      schema_result: ${{ steps.schema_check.outcome }}
+      schema_changed_files: ${{ steps.schema_check.outputs.changed_files }}
+      lint_src_result: ${{ steps.lint_src.outcome }}
+      lint_src_changed_files: ${{ steps.lint_src.outputs.changed_files }}
+      license_result: ${{ steps.license.outcome }}
+      license_changed_files: ${{ steps.license.outputs.changed_files }}
+      i18n_result: ${{ steps.i18n.outcome }}
+      i18n_changed_files: ${{ steps.i18n.outputs.changed_files }}
+      app_docs_result: ${{ steps.app_docs.outcome }}
+      app_docs_changed_files: ${{ steps.app_docs.outputs.changed_files }}
+      lint_playwright_result: ${{ steps.lint_playwright.outcome }}
+      lint_playwright_changed_files: ${{ steps.lint_playwright.outputs.changed_files }}
+      lint_core_components_result: ${{ steps.lint_core_components.outcome }}
+      lint_core_components_changed_files: ${{ steps.lint_core_components.outputs.changed_files }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -95,17 +96,52 @@ jobs:
         with:
           node-version-file: "${{ env.UI_WORKING_DIRECTORY }}/.nvmrc"
           cache: yarn
-          cache-dependency-path: "${{ env.UI_WORKING_DIRECTORY }}/yarn.lock"
+          cache-dependency-path: |
+            ${{ env.UI_WORKING_DIRECTORY }}/yarn.lock
+            ${{ env.CORE_COMPONENTS_WORKING_DIRECTORY }}/yarn.lock
 
       - name: Install Antlr4 CLI
         run: sudo make install_antlr_cli
 
-      - name: Install Yarn Packages
+      - name: Install UI Yarn Packages
         working-directory: ${{ env.UI_WORKING_DIRECTORY }}
         run: yarn install --frozen-lockfile
 
+      - name: Check for JSON schema changes
+        id: schema_detect
+        run: |
+          changed_files=$(git diff --name-only origin/main...HEAD | grep '^openmetadata-spec/src/main/resources/json/schema/' || true)
+          if [ -n "$changed_files" ]; then
+            echo "has_changes=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_changes=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Build and generate TypeScript from schemas
+        if: steps.schema_detect.outputs.has_changes == 'true'
+        run: |
+          changed_files=$(git diff --name-only origin/main...HEAD | grep '^openmetadata-spec/src/main/resources/json/schema/' || true)
+          if [ -n "$changed_files" ]; then
+            ./openmetadata-ui/src/main/resources/ui/json2ts.sh $changed_files
+          fi
+
+      - name: Check for uncommitted TypeScript changes
+        if: steps.schema_detect.outputs.has_changes == 'true'
+        id: schema_check
+        continue-on-error: true
+        run: |
+          if ! git diff --quiet -- openmetadata-ui/src/main/resources/ui/src/generated; then
+            FILES=$(git status --porcelain openmetadata-ui/src/main/resources/ui/src/generated | awk '{print "  - `" $2 "`"}' | head -20)
+            echo "changed_files<<EOF" >> "$GITHUB_OUTPUT"
+            echo "$FILES" >> "$GITHUB_OUTPUT"
+            echo "EOF" >> "$GITHUB_OUTPUT"
+            git checkout -- .
+            git clean -fd
+            exit 1
+          fi
+
       - name: Get changed src files
-        id: changed-files
+        id: changed-src-files
         uses: tj-actions/changed-files@22103cc46bda19c2b464ffe86db46df6922fd323
         with:
           path: ${{ env.UI_WORKING_DIRECTORY }}
@@ -114,12 +150,13 @@ jobs:
           files: |
             src/**/*.{ts,tsx,js,jsx,json}
 
-      - name: ESLint + Prettier + Organise Imports
-        id: lint
-        if: steps.changed-files.outputs.any_changed == 'true'
+      - name: ESLint + Prettier + Organise Imports (src)
+        id: lint_src
+        if: steps.changed-src-files.outputs.any_changed == 'true'
+        continue-on-error: true
         working-directory: ${{ env.UI_WORKING_DIRECTORY }}
         env:
-          CHANGED_FILES: ${{ steps.changed-files.outputs.all_changed_files }}
+          CHANGED_FILES: ${{ steps.changed-src-files.outputs.all_changed_files }}
         run: |
           if [ -z "$CHANGED_FILES" ]; then
             echo "No added or modified files to process."
@@ -141,48 +178,19 @@ jobs:
             exit 1
           fi
 
-  # ──────────────────────────────────────────────────────────────────────────
-  # Job 2: Licence Header Check (all changed files)
-  # ──────────────────────────────────────────────────────────────────────────
-  license-header:
-    needs: authorize
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    outputs:
-      changed_files: ${{ steps.license.outputs.changed_files }}
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event_name == 'merge_group' && github.sha || github.event.pull_request.head.sha }}
-          fetch-depth: 0
-          filter: blob:none
-
-      - uses: actions/setup-node@v4
-        with:
-          node-version-file: "${{ env.UI_WORKING_DIRECTORY }}/.nvmrc"
-          cache: yarn
-          cache-dependency-path: "${{ env.UI_WORKING_DIRECTORY }}/yarn.lock"
-
-      - name: Install Antlr4 CLI
-        run: sudo make install_antlr_cli
-
-      - name: Install Yarn Packages
-        working-directory: ${{ env.UI_WORKING_DIRECTORY }}
-        run: yarn install --frozen-lockfile
-
-      - name: Get all changed files
-        id: changed-files
+      - name: Get all changed UI files
+        id: changed-ui-files
         uses: tj-actions/changed-files@22103cc46bda19c2b464ffe86db46df6922fd323
         with:
           path: ${{ env.UI_WORKING_DIRECTORY }}
 
       - name: Licence Header Check
         id: license
-        if: steps.changed-files.outputs.any_changed == 'true'
+        if: steps.changed-ui-files.outputs.any_changed == 'true'
+        continue-on-error: true
         working-directory: ${{ env.UI_WORKING_DIRECTORY }}
         env:
-          CHANGED_FILES_ALL: ${{ steps.changed-files.outputs.all_changed_files }}
+          CHANGED_FILES_ALL: ${{ steps.changed-ui-files.outputs.all_changed_files }}
         run: |
           if [ -z "$CHANGED_FILES_ALL" ]; then
             echo "No added or modified files to process."
@@ -199,75 +207,9 @@ jobs:
             exit 1
           fi
 
-  # ──────────────────────────────────────────────────────────────────────────
-  # Job 3: TypeScript Type Check (src)
-  # ──────────────────────────────────────────────────────────────────────────
-  tsc-src:
-    needs: authorize
-    if: false  # TODO: re-enable once tsc errors are resolved
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event_name == 'merge_group' && github.sha || github.event.pull_request.head.sha }}
-
-      - uses: actions/setup-node@v4
-        with:
-          node-version-file: "${{ env.UI_WORKING_DIRECTORY }}/.nvmrc"
-          cache: yarn
-          cache-dependency-path: "${{ env.UI_WORKING_DIRECTORY }}/yarn.lock"
-
-      - name: Install Antlr4 CLI
-        run: sudo make install_antlr_cli
-
-      - name: Install Yarn Packages
-        working-directory: ${{ env.UI_WORKING_DIRECTORY }}
-        run: yarn install --frozen-lockfile
-
-      - name: TypeScript Type Check (src)
-        id: tsc
-        working-directory: ${{ env.UI_WORKING_DIRECTORY }}
-        run: |
-          if ! yarn tsc:check > /tmp/tsc_output.txt 2>&1; then
-            ERRORS=$(head -50 /tmp/tsc_output.txt | sed 's/`/\`/g')
-            echo "tsc_errors<<EOF" >> "$GITHUB_OUTPUT"
-            echo "$ERRORS" >> "$GITHUB_OUTPUT"
-            echo "EOF" >> "$GITHUB_OUTPUT"
-            exit 1
-          fi
-
-  # ──────────────────────────────────────────────────────────────────────────
-  # Job 4: I18n Sync
-  # ──────────────────────────────────────────────────────────────────────────
-  i18n-sync:
-    needs: authorize
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    outputs:
-      changed_files: ${{ steps.i18n.outputs.changed_files }}
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event_name == 'merge_group' && github.sha || github.event.pull_request.head.sha }}
-
-      - uses: actions/setup-node@v4
-        with:
-          node-version-file: "${{ env.UI_WORKING_DIRECTORY }}/.nvmrc"
-          cache: yarn
-          cache-dependency-path: "${{ env.UI_WORKING_DIRECTORY }}/yarn.lock"
-
-      - name: Install Antlr4 CLI
-        run: sudo make install_antlr_cli
-
-      - name: Install Yarn Packages
-        working-directory: ${{ env.UI_WORKING_DIRECTORY }}
-        run: yarn install --frozen-lockfile
-
       - name: I18n Sync
         id: i18n
+        continue-on-error: true
         working-directory: ${{ env.UI_WORKING_DIRECTORY }}
         run: |
           yarn i18n
@@ -281,36 +223,9 @@ jobs:
             exit 1
           fi
 
-  # ──────────────────────────────────────────────────────────────────────────
-  # Job 5: generate:app-docs
-  # ──────────────────────────────────────────────────────────────────────────
-  app-docs:
-    needs: authorize
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    outputs:
-      changed_files: ${{ steps.docs.outputs.changed_files }}
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event_name == 'merge_group' && github.sha || github.event.pull_request.head.sha }}
-
-      - uses: actions/setup-node@v4
-        with:
-          node-version-file: "${{ env.UI_WORKING_DIRECTORY }}/.nvmrc"
-          cache: yarn
-          cache-dependency-path: "${{ env.UI_WORKING_DIRECTORY }}/yarn.lock"
-
-      - name: Install Antlr4 CLI
-        run: sudo make install_antlr_cli
-
-      - name: Install Yarn Packages
-        working-directory: ${{ env.UI_WORKING_DIRECTORY }}
-        run: yarn install --frozen-lockfile
-
       - name: generate:app-docs
-        id: docs
+        id: app_docs
+        continue-on-error: true
         working-directory: ${{ env.UI_WORKING_DIRECTORY }}
         run: |
           yarn generate:app-docs
@@ -324,38 +239,8 @@ jobs:
             exit 1
           fi
 
-  # ──────────────────────────────────────────────────────────────────────────
-  # Job 6: Playwright — ESLint + Prettier + Organise Imports
-  # ──────────────────────────────────────────────────────────────────────────
-  lint-playwright:
-    needs: authorize
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    outputs:
-      changed_files: ${{ steps.lint.outputs.changed_files }}
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event_name == 'merge_group' && github.sha || github.event.pull_request.head.sha }}
-          fetch-depth: 0
-          filter: blob:none
-
-      - uses: actions/setup-node@v4
-        with:
-          node-version-file: "${{ env.UI_WORKING_DIRECTORY }}/.nvmrc"
-          cache: yarn
-          cache-dependency-path: "${{ env.UI_WORKING_DIRECTORY }}/yarn.lock"
-
-      - name: Install Antlr4 CLI
-        run: sudo make install_antlr_cli
-
-      - name: Install Yarn Packages
-        working-directory: ${{ env.UI_WORKING_DIRECTORY }}
-        run: yarn install --frozen-lockfile
-
       - name: Get changed Playwright files
-        id: changed-files
+        id: changed-playwright-files
         uses: tj-actions/changed-files@22103cc46bda19c2b464ffe86db46df6922fd323
         with:
           path: ${{ env.UI_WORKING_DIRECTORY }}
@@ -365,11 +250,12 @@ jobs:
             playwright/**/*.{ts,tsx,js,jsx}
 
       - name: ESLint + Prettier + Organise Imports (playwright)
-        id: lint
-        if: steps.changed-files.outputs.any_changed == 'true'
+        id: lint_playwright
+        if: steps.changed-playwright-files.outputs.any_changed == 'true'
+        continue-on-error: true
         working-directory: ${{ env.UI_WORKING_DIRECTORY }}
         env:
-          CHANGED_FILES: ${{ steps.changed-files.outputs.all_changed_files }}
+          CHANGED_FILES: ${{ steps.changed-playwright-files.outputs.all_changed_files }}
         run: |
           if [ -z "$CHANGED_FILES" ]; then
             echo "No added or modified files to process."
@@ -388,91 +274,12 @@ jobs:
             exit 1
           fi
 
-  # ──────────────────────────────────────────────────────────────────────────
-  # Job 7: Playwright — TypeScript Type Check
-  # ──────────────────────────────────────────────────────────────────────────
-  tsc-playwright:
-    needs: authorize
-    if: false  # TODO: re-enable once playwright tsc errors are resolved
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event_name == 'merge_group' && github.sha || github.event.pull_request.head.sha }}
-          fetch-depth: 0
-          filter: blob:none
-
-      - uses: actions/setup-node@v4
-        with:
-          node-version-file: "${{ env.UI_WORKING_DIRECTORY }}/.nvmrc"
-          cache: yarn
-          cache-dependency-path: "${{ env.UI_WORKING_DIRECTORY }}/yarn.lock"
-
-      - name: Install Antlr4 CLI
-        run: sudo make install_antlr_cli
-
-      - name: Install Yarn Packages
-        working-directory: ${{ env.UI_WORKING_DIRECTORY }}
-        run: yarn install --frozen-lockfile
-
-      - name: Get changed Playwright files
-        id: changed-files
-        uses: tj-actions/changed-files@22103cc46bda19c2b464ffe86db46df6922fd323
-        with:
-          path: ${{ env.UI_WORKING_DIRECTORY }}
-          files_ignore: |
-            playwright/test-data/**
-          files: |
-            playwright/**/*.{ts,tsx,js,jsx}
-
-      - name: TypeScript Type Check (playwright)
-        id: tsc
-        working-directory: ${{ env.UI_WORKING_DIRECTORY }}
-        run: |
-          if [ -z "$CHANGED_FILES" ]; then
-            echo "No added or modified files to process."
-            exit 0
-          fi
-          if ! yarn tsc:playwright > /tmp/tsc_output.txt 2>&1; then
-            ERRORS=$(head -50 /tmp/tsc_output.txt | sed 's/`/\`/g')
-            echo "tsc_errors<<EOF" >> "$GITHUB_OUTPUT"
-            echo "$ERRORS" >> "$GITHUB_OUTPUT"
-            echo "EOF" >> "$GITHUB_OUTPUT"
-            exit 1
-          fi
-
-  # ──────────────────────────────────────────────────────────────────────────
-  # Job 8: Core Components — ESLint + Prettier
-  # ──────────────────────────────────────────────────────────────────────────
-  lint-core-components:
-    needs: authorize
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    outputs:
-      changed_files: ${{ steps.lint.outputs.changed_files }}
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event_name == 'merge_group' && github.sha || github.event.pull_request.head.sha }}
-          fetch-depth: 0
-          filter: blob:none
-
-      - uses: actions/setup-node@v4
-        with:
-          node-version-file: "${{ env.CORE_COMPONENTS_WORKING_DIRECTORY }}/.nvmrc"
-          cache: yarn
-          cache-dependency-path: "${{ env.CORE_COMPONENTS_WORKING_DIRECTORY }}/yarn.lock"
-
-      - name: Install Yarn Packages
+      - name: Install Core Components Yarn Packages
         working-directory: ${{ env.CORE_COMPONENTS_WORKING_DIRECTORY }}
         run: yarn install --frozen-lockfile
 
-
       - name: Get changed core-components files
-        id: changed-files
+        id: changed-core-components-files
         uses: tj-actions/changed-files@22103cc46bda19c2b464ffe86db46df6922fd323
         with:
           path: ${{ env.CORE_COMPONENTS_WORKING_DIRECTORY }}
@@ -480,11 +287,12 @@ jobs:
             src/**/*.{ts,tsx,js,jsx,json}
 
       - name: ESLint + Prettier (core-components)
-        id: lint
-        if: steps.changed-files.outputs.any_changed == 'true'
+        id: lint_core_components
+        if: steps.changed-core-components-files.outputs.any_changed == 'true'
+        continue-on-error: true
         working-directory: ${{ env.CORE_COMPONENTS_WORKING_DIRECTORY }}
         env:
-          CHANGED_FILES: ${{ steps.changed-files.outputs.all_changed_files }}
+          CHANGED_FILES: ${{ steps.changed-core-components-files.outputs.all_changed_files }}
         run: |
           if [ -z "${CHANGED_FILES// }" ]; then
             echo "No added or modified files to process."
@@ -502,12 +310,9 @@ jobs:
             exit 1
           fi
 
-  # ──────────────────────────────────────────────────────────────────────────
-  # Job 9: Report — Post single consolidated summary comment
-  # ──────────────────────────────────────────────────────────────────────────
   report:
-    needs: [authorize, lint-src, license-header, i18n-sync, app-docs, lint-playwright, lint-core-components]
-    if: ${{ always() && needs.authorize.result == 'success' && github.event_name == 'pull_request_target' }}
+    needs: [authorize, checkstyle]
+    if: ${{ always() && needs.authorize.result == 'success' }}
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
@@ -515,6 +320,7 @@ jobs:
       - name: Find existing summary comment
         uses: peter-evans/find-comment@v3
         id: fc
+        if: ${{ github.event_name == 'pull_request_target' }}
         with:
           issue-number: ${{ github.event.pull_request.number }}
           comment-author: github-actions[bot]
@@ -522,44 +328,51 @@ jobs:
 
       - name: Post or update summary comment
         uses: actions/github-script@v7
+        if: ${{ github.event_name == 'pull_request_target' }}
         with:
           script: |
             const checks = [
               {
+                name:    'JSON Schema & TypeScript Generation',
+                reason:  'JSON schema changes require TypeScript regeneration.',
+                result:  '${{ needs.checkstyle.outputs.schema_result }}',
+                files:   ${{ toJSON(needs.checkstyle.outputs.schema_changed_files) }} || '',
+              },
+              {
                 name:    'ESLint + Prettier + Organise Imports (src)',
                 reason:  'One or more source files have linting or formatting issues.',
-                result:  '${{ needs.lint-src.result }}',
-                files:   ${{ toJSON(needs.lint-src.outputs.changed_files) }} || '',
+                result:  '${{ needs.checkstyle.outputs.lint_src_result }}',
+                files:   ${{ toJSON(needs.checkstyle.outputs.lint_src_changed_files) }} || '',
               },
               {
                 name:    'Licence Header',
                 reason:  'One or more files are missing or have an outdated Apache 2.0 licence header.',
-                result:  '${{ needs.license-header.result }}',
-                files:   ${{ toJSON(needs.license-header.outputs.changed_files) }} || '',
+                result:  '${{ needs.checkstyle.outputs.license_result }}',
+                files:   ${{ toJSON(needs.checkstyle.outputs.license_changed_files) }} || '',
               },
               {
                 name:    'I18n Sync',
                 reason:  'Translation locale files are out of sync with `en-us.json`.',
-                result:  '${{ needs.i18n-sync.result }}',
-                files:   ${{ toJSON(needs.i18n-sync.outputs.changed_files) }} || '',
+                result:  '${{ needs.checkstyle.outputs.i18n_result }}',
+                files:   ${{ toJSON(needs.checkstyle.outputs.i18n_changed_files) }} || '',
               },
               {
                 name:    'App Docs',
                 reason:  'Generated application docs are stale and need to be regenerated.',
-                result:  '${{ needs.app-docs.result }}',
-                files:   ${{ toJSON(needs.app-docs.outputs.changed_files) }} || '',
+                result:  '${{ needs.checkstyle.outputs.app_docs_result }}',
+                files:   ${{ toJSON(needs.checkstyle.outputs.app_docs_changed_files) }} || '',
               },
               {
-                name:    'Playwright — ESLint + Prettier + Organise Imports',
+                name:    'Playwright - ESLint + Prettier + Organise Imports',
                 reason:  'One or more Playwright test files have linting or formatting issues.',
-                result:  '${{ needs.lint-playwright.result }}',
-                files:   ${{ toJSON(needs.lint-playwright.outputs.changed_files) }} || '',
+                result:  '${{ needs.checkstyle.outputs.lint_playwright_result }}',
+                files:   ${{ toJSON(needs.checkstyle.outputs.lint_playwright_changed_files) }} || '',
               },
               {
-                name:    'Core Components — ESLint + Prettier',
+                name:    'Core Components - ESLint + Prettier',
                 reason:  'One or more core-component files have linting or formatting issues.',
-                result:  '${{ needs.lint-core-components.result }}',
-                files:   ${{ toJSON(needs.lint-core-components.outputs.changed_files) }} || '',
+                result:  '${{ needs.checkstyle.outputs.lint_core_components_result }}',
+                files:   ${{ toJSON(needs.checkstyle.outputs.lint_core_components_changed_files) }} || '',
               },
             ];
 
@@ -591,7 +404,7 @@ jobs:
               '',
               ...sections.flatMap(s => [s, '']),
               '---',
-              '**Fix locally (fast — only checks files changed in this branch):**',
+              '**Fix locally (fast - only checks files changed in this branch):**',
               '```bash',
               'make ui-checkstyle-changed',
               '```',
@@ -612,3 +425,18 @@ jobs:
                 body,
               });
             }
+
+      - name: Check final results
+        if: always()
+        run: |
+          if [ "${{ needs.checkstyle.result }}" != 'success' ] || \
+             [ "${{ needs.checkstyle.outputs.schema_result }}" = 'failure' ] || \
+             [ "${{ needs.checkstyle.outputs.lint_src_result }}" = 'failure' ] || \
+             [ "${{ needs.checkstyle.outputs.license_result }}" = 'failure' ] || \
+             [ "${{ needs.checkstyle.outputs.i18n_result }}" = 'failure' ] || \
+             [ "${{ needs.checkstyle.outputs.app_docs_result }}" = 'failure' ] || \
+             [ "${{ needs.checkstyle.outputs.lint_playwright_result }}" = 'failure' ] || \
+             [ "${{ needs.checkstyle.outputs.lint_core_components_result }}" = 'failure' ]; then
+            echo "One or more checks failed."
+            exit 1
+          fi


### PR DESCRIPTION
### Describe your changes:

Fixes #N/A

Consolidates UI Checkstyle into a single shared `checkstyle` job so setup runs once while preserving authorization, safe-to-test gating, consolidated PR reporting, and final failure behavior. Keeps checks for source linting, license headers, i18n, app docs, Playwright, and core components.

#
### Type of change:
- [x] Improvement

#
### High-level design:
The workflow now follows the collate pattern with `authorize`, one `checkstyle` job, and one `report` job. Individual check steps use `continue-on-error` so the report can summarize all failures before the final gate fails the workflow. TypeScript type generation stays in the separate `typescript-type-generation.yml` workflow.

#
### Tests:

#### Use cases covered
- UI checkstyle workflow runs shared setup once and reports failures from individual checks.
- PR comments remain consolidated for UI checkstyle failures.

#### Unit tests
- [ ] Not applicable; GitHub Actions workflow-only change.

#### Backend integration tests
- [x] Not applicable (no backend API changes).

#### Ingestion integration tests
- [x] Not applicable (no ingestion changes).

#### Playwright (UI) tests
- [x] Not applicable (no UI changes).

#### Manual testing performed
1. Parsed `.github/workflows/ui-checkstyle.yml` with Ruby YAML parser.
2. Ran `git diff --check -- .github/workflows/ui-checkstyle.yml`.

#
### UI screen recording / screenshots:
Not applicable.

#
### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.
- [ ] For UI changes: I attached a screen recording and/or screenshots above.
- [ ] I have added tests (unit / integration / Playwright as applicable) and listed them above.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR consolidates the six previously parallel UI checkstyle jobs (`lint-src`, `license-header`, `i18n-sync`, `app-docs`, `lint-playwright`, `lint-core-components`) into a single sequential `checkstyle` job, saving CI setup overhead while preserving all individual check results via `step.outcome` outputs and a dedicated `report` job.

- **Single setup, sequential checks:** Checkout, `setup-node`, Antlr4, and `yarn install` now run once; each check step uses `continue-on-error: true` so all steps execute and failures are surfaced together in the PR comment and `Check final results` gate.
- **Merge-group gating improved:** The `report` job's `if` condition no longer excludes `merge_group` events, meaning the `Check final results` step now gates queue merges — a gap that existed in the old workflow where `report` was entirely skipped on `merge_group`.
- **Old required-check names are gone:** `lint-src`, `license-header`, `i18n-sync`, `app-docs`, `lint-playwright`, and `lint-core-components` no longer exist as job names; any branch protection rules referencing them must be updated to `checkstyle` and/or `report` before this lands.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge once branch protection rules are updated to reference the new `checkstyle` and `report` job names — merging without that update will either silently drop the required checks or block all PRs.

The workflow consolidation is logically sound: `step.outcome` correctly captures per-check results through `continue-on-error`, each mutating step fully resets the workspace with `git checkout -- . && git clean -fd` before the next step runs, and the `report` job now properly gates `merge_group` events. The one blocking operational concern is that the six old job names used as required status checks disappear; if branch protection rules aren't updated before this ships, the checks either stop being enforced or start blocking all merges.

.github/workflows/ui-checkstyle.yml — confirm the repository's branch protection rules are updated to require `checkstyle` and/or `report` before merging.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/ui-checkstyle.yml | Consolidates 6 parallel checkstyle jobs into one sequential `checkstyle` job; uses `step.outcome` + `continue-on-error` for per-check reporting; removes the `merge_group` guard on `report` so merges are now properly gated. Old job names (`lint-src`, `license-header`, etc.) no longer exist and branch protection rules referencing them must be updated before this ships. |

</details>

</details>

<sub>Reviews (2): Last reviewed commit: ["ci: restore yarn cache for UI checkstyle..."](https://github.com/open-metadata/openmetadata/commit/494c7d1c2f00ab4021f495198fc72953af20d25b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38660223)</sub>

<!-- /greptile_comment -->