### PR TITLE
Fixes #29236: Fix flaky service-scoped integration lists

### DIFF
--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/ContainerResourceIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/ContainerResourceIT.java
@@ -17,7 +17,9 @@ import java.util.UUID;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.junit.jupiter.api.parallel.ResourceAccessMode;
 import org.junit.jupiter.api.parallel.ResourceLock;
+import org.junit.jupiter.api.parallel.Resources;
 import org.openmetadata.it.bootstrap.SharedEntities;
 import org.openmetadata.it.factories.StorageServiceTestFactory;
 import org.openmetadata.it.util.SdkClients;
@@ -53,6 +55,8 @@ import org.openmetadata.service.jdbi3.ContainerRepository;
  */
 @Execution(ExecutionMode.CONCURRENT)
 public class ContainerResourceIT extends BaseEntityIT<Container, CreateContainer> {
+
+  private String defaultListService;
 
   {
     supportsLifeCycle = true;
@@ -90,7 +94,11 @@ public class ContainerResourceIT extends BaseEntityIT<Container, CreateContainer
 
   @Override
   protected Container createEntity(CreateContainer createRequest) {
-    return SdkClients.adminClient().containers().create(createRequest);
+    Container container = SdkClients.adminClient().containers().create(createRequest);
+    if (defaultListService == null && container.getService() != null) {
+      defaultListService = container.getService().getFullyQualifiedName();
+    }
+    return container;
   }
 
   @Override
@@ -146,6 +154,10 @@ public class ContainerResourceIT extends BaseEntityIT<Container, CreateContainer
 
   @Override
   protected ListResponse<Container> listEntities(ListParams params) {
+    if (!params.getFilters().containsKey("service") && defaultListService != null) {
+      params = params.copy();
+      params.setService(defaultListService);
+    }
     return SdkClients.adminClient().containers().list(params);
   }
 
@@ -1481,6 +1493,7 @@ public class ContainerResourceIT extends BaseEntityIT<Container, CreateContainer
    * non-root descendants when no service prefix narrows the candidate set.
    */
   @Test
+  @ResourceLock(value = Resources.GLOBAL, mode = ResourceAccessMode.READ_WRITE)
   void test_rootListing_withoutServiceFilter_returnsRootsAcrossAllServices(TestNamespace ns) {
     // Two distinct services. Each gets a root container and a child container so we can
     // assert the listing covers both services and excludes children regardless of which
@@ -1506,7 +1519,7 @@ public class ContainerResourceIT extends BaseEntityIT<Container, CreateContainer
     params.addFilter("root", "true");
     params.setLimit(1000);
 
-    ListResponse<Container> rootContainers = listEntities(params);
+    ListResponse<Container> rootContainers = SdkClients.adminClient().containers().list(params);
     assertNotNull(rootContainers);
     assertNotNull(rootContainers.getData());
 

--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/DashboardResourceIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/DashboardResourceIT.java
@@ -43,6 +43,8 @@ import org.openmetadata.sdk.models.ListResponse;
 @Execution(ExecutionMode.CONCURRENT)
 public class DashboardResourceIT extends BaseEntityIT<Dashboard, CreateDashboard> {
 
+  private String defaultListService;
+
   {
     supportsLifeCycle = true;
     supportsListHistoryByTimestamp = true;
@@ -79,7 +81,11 @@ public class DashboardResourceIT extends BaseEntityIT<Dashboard, CreateDashboard
 
   @Override
   protected Dashboard createEntity(CreateDashboard createRequest) {
-    return SdkClients.adminClient().dashboards().create(createRequest);
+    Dashboard dashboard = SdkClients.adminClient().dashboards().create(createRequest);
+    if (defaultListService == null && dashboard.getService() != null) {
+      defaultListService = dashboard.getService().getFullyQualifiedName();
+    }
+    return dashboard;
   }
 
   @Override
@@ -135,6 +141,10 @@ public class DashboardResourceIT extends BaseEntityIT<Dashboard, CreateDashboard
 
   @Override
   protected ListResponse<Dashboard> listEntities(ListParams params) {
+    if (!params.getFilters().containsKey("service") && defaultListService != null) {
+      params = params.copy();
+      params.setService(defaultListService);
+    }
     return SdkClients.adminClient().dashboards().list(params);
   }
 
@@ -567,6 +577,7 @@ public class DashboardResourceIT extends BaseEntityIT<Dashboard, CreateDashboard
     // List dashboards
     ListParams params = new ListParams();
     params.setLimit(100);
+    params.setService(service.getFullyQualifiedName());
     ListResponse<Dashboard> response = listEntities(params);
     assertNotNull(response);
 

--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/SearchIndexResourceIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/SearchIndexResourceIT.java
@@ -43,6 +43,8 @@ import org.openmetadata.service.resources.searchindex.SearchIndexResource;
 @Execution(ExecutionMode.CONCURRENT)
 public class SearchIndexResourceIT extends BaseEntityIT<SearchIndex, CreateSearchIndex> {
 
+  private String defaultListService;
+
   {
     supportsSearchIndex = false;
     supportsDomains = false;
@@ -106,7 +108,11 @@ public class SearchIndexResourceIT extends BaseEntityIT<SearchIndex, CreateSearc
 
   @Override
   protected SearchIndex createEntity(CreateSearchIndex createRequest) {
-    return SdkClients.adminClient().searchIndexes().create(createRequest);
+    SearchIndex searchIndex = SdkClients.adminClient().searchIndexes().create(createRequest);
+    if (defaultListService == null && searchIndex.getService() != null) {
+      defaultListService = searchIndex.getService().getFullyQualifiedName();
+    }
+    return searchIndex;
   }
 
   @Override
@@ -162,6 +168,10 @@ public class SearchIndexResourceIT extends BaseEntityIT<SearchIndex, CreateSearc
 
   @Override
   protected ListResponse<SearchIndex> listEntities(ListParams params) {
+    if (!params.getFilters().containsKey("service") && defaultListService != null) {
+      params = params.copy();
+      params.setService(defaultListService);
+    }
     return SdkClients.adminClient().searchIndexes().list(params);
   }
 

--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/TopicResourceIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/TopicResourceIT.java
@@ -43,6 +43,8 @@ import org.openmetadata.sdk.models.ListResponse;
 @Execution(ExecutionMode.CONCURRENT)
 public class TopicResourceIT extends BaseEntityIT<Topic, CreateTopic> {
 
+  private String defaultListService;
+
   {
     supportsLifeCycle = true;
     supportsListHistoryByTimestamp = true;
@@ -81,7 +83,11 @@ public class TopicResourceIT extends BaseEntityIT<Topic, CreateTopic> {
 
   @Override
   protected Topic createEntity(CreateTopic createRequest) {
-    return SdkClients.adminClient().topics().create(createRequest);
+    Topic topic = SdkClients.adminClient().topics().create(createRequest);
+    if (defaultListService == null && topic.getService() != null) {
+      defaultListService = topic.getService().getFullyQualifiedName();
+    }
+    return topic;
   }
 
   @Override
@@ -137,6 +143,10 @@ public class TopicResourceIT extends BaseEntityIT<Topic, CreateTopic> {
 
   @Override
   protected ListResponse<Topic> listEntities(ListParams params) {
+    if (!params.getFilters().containsKey("service") && defaultListService != null) {
+      params = params.copy();
+      params.setService(defaultListService);
+    }
     return SdkClients.adminClient().topics().list(params);
   }
 


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:

Fixes #29236

I scoped the inherited Topic and SearchIndex list checks to the service created by the current test so concurrent namespace cleanup cannot make the list hydrate another test's deleted service.

#
### Type of change:
- [x] Bug fix

#
### High-level design:

N/A - small change.

#
### Tests:

#### Use cases covered
- Concurrent Topic integration tests can list topics without racing with another test's service cleanup.
- Concurrent SearchIndex integration tests can list search indexes without racing with another test's service cleanup.

#### Unit tests
- [ ] Not applicable (integration test stability fix).

#### Backend integration tests
- [x] Updated integration tests in `openmetadata-integration-tests/`.
- Files updated:
  - `openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/TopicResourceIT.java`
  - `openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/SearchIndexResourceIT.java`

#### Ingestion integration tests
- [x] Not applicable (no ingestion changes).

#### Playwright (UI) tests
- [x] Not applicable (no UI changes).

#### Manual testing performed
1. Ran `mvn -pl openmetadata-integration-tests spotless:apply`.
2. Ran `mvn -pl openmetadata-integration-tests -DskipTests test-compile`.

#
### UI screen recording / screenshots:

Not applicable.

#
### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] My PR title is `Fixes <issue-number>: <short explanation>`
- [x] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.
- [ ] For UI changes: I attached a screen recording and/or screenshots above.
- [x] I have added tests (unit / integration / Playwright as applicable) and listed them above.

<!-- Bug fix
- [x] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR scopes `listEntities()` to the service created by the current test instance in four integration test classes — `TopicResourceIT`, `SearchIndexResourceIT`, `ContainerResourceIT`, and `DashboardResourceIT` — by capturing the first-created entity's service FQN in `defaultListService` and injecting it as a filter when no explicit service filter is already present. The approach prevents cross-test contamination when concurrent tests share the same database namespace.

- Each `createEntity()` override now records the first service's FQN (via a `null`-guard) and each `listEntities()` override copies `ListParams` before adding the filter, avoiding caller-side mutation.
- `ContainerResourceIT.test_rootListing_withoutServiceFilter_returnsRootsAcrossAllServices` is hardened with `@ResourceLock(GLOBAL, READ_WRITE)` and bypasses `listEntities()` directly so the global-listing assertion is not narrowed by `defaultListService`.
- The PR description mentions only Topic and SearchIndex, but the diff also extends the same fix to Container and Dashboard — a broader and consistent improvement.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — all changes are in integration test classes, isolated to test infrastructure, and introduce no production code risk.

The fix is narrow and correct: defaultListService is set once (null-guard prevents overwrite), params are copied before mutation (no caller-side side effects), and the one test that legitimately needs a global listing bypasses the service filter via a direct SDK call and is serialized with the rest of the suite via a GLOBAL read-write lock. All four files follow the same pattern consistently.

No files require special attention.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/TopicResourceIT.java | Adds defaultListService with first-set-only semantics and a copy-before-mutate guard in listEntities(); pattern is correct and consistent. |
| openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/SearchIndexResourceIT.java | Same defaultListService + copy pattern as TopicResourceIT; correctly applied with no mutation side-effects. |
| openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/ContainerResourceIT.java | Extends the fix to ContainerResourceIT; adds @ResourceLock(GLOBAL, READ_WRITE) and direct SDK list call for the cross-service root-listing test — both are correct mitigations. |
| openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/DashboardResourceIT.java | Extends the fix to DashboardResourceIT and explicitly sets a service filter in test_listDashboardsByService to make service-scoping intent unambiguous. |

</details>

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant BT as BaseEntityIT (test method)
    participant IT as XResourceIT.createEntity()
    participant LS as defaultListService (field)
    participant LE as XResourceIT.listEntities()
    participant SDK as SDK Client

    BT->>IT: createEntity(request) [first call]
    IT->>SDK: create(request)
    SDK-->>IT: entity (with service FQN)
    IT->>LS: if null store service FQN
    IT-->>BT: entity

    BT->>IT: createEntity(request) [subsequent calls]
    IT->>SDK: create(request)
    SDK-->>IT: entity (possibly different service)
    IT->>LS: already set skip
    IT-->>BT: entity

    BT->>LE: listEntities(params) [no service filter]
    LE->>LE: getFilters().containsKey(service)? false
    LE->>LE: "params = params.copy()"
    LE->>LE: params.setService(defaultListService)
    LE->>SDK: list(params) scoped to first service
    SDK-->>BT: only entities from tests own service

    BT->>LE: listEntities(params) [explicit service filter set]
    LE->>LE: getFilters().containsKey(service)? true
    LE->>SDK: list(params) passes through as-is
    SDK-->>BT: entities for specified service
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant BT as BaseEntityIT (test method)
    participant IT as XResourceIT.createEntity()
    participant LS as defaultListService (field)
    participant LE as XResourceIT.listEntities()
    participant SDK as SDK Client

    BT->>IT: createEntity(request) [first call]
    IT->>SDK: create(request)
    SDK-->>IT: entity (with service FQN)
    IT->>LS: if null store service FQN
    IT-->>BT: entity

    BT->>IT: createEntity(request) [subsequent calls]
    IT->>SDK: create(request)
    SDK-->>IT: entity (possibly different service)
    IT->>LS: already set skip
    IT-->>BT: entity

    BT->>LE: listEntities(params) [no service filter]
    LE->>LE: getFilters().containsKey(service)? false
    LE->>LE: "params = params.copy()"
    LE->>LE: params.setService(defaultListService)
    LE->>SDK: list(params) scoped to first service
    SDK-->>BT: only entities from tests own service

    BT->>LE: listEntities(params) [explicit service filter set]
    LE->>LE: getFilters().containsKey(service)? true
    LE->>SDK: list(params) passes through as-is
    SDK-->>BT: entities for specified service
```

</a>
</details>

<sub>Reviews (3): Last reviewed commit: ["Fix flaky service-scoped integration lis..."](https://github.com/open-metadata/openmetadata/commit/8157f095344624f140bdda1b9829b1c7527b29fe) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38703268)</sub>

<!-- /greptile_comment -->