### PR TITLE
Fixes #29233: Correct recognizer feedback task type

### DIFF
--- a/bootstrap/sql/migrations/native/2.0.2/mysql/schemaChanges.sql
+++ b/bootstrap/sql/migrations/native/2.0.2/mysql/schemaChanges.sql
@@ -1,0 +1,3 @@
+-- Data migration only.
+-- Java migration seeds default task workflows and rewrites open recognizer feedback
+-- review tasks that were persisted with the DataQualityReview task type.

--- a/bootstrap/sql/migrations/native/2.0.2/postgres/schemaChanges.sql
+++ b/bootstrap/sql/migrations/native/2.0.2/postgres/schemaChanges.sql
@@ -1,0 +1,3 @@
+-- Data migration only.
+-- Java migration seeds default task workflows and rewrites open recognizer feedback
+-- review tasks that were persisted with the DataQualityReview task type.

--- a/ingestion/src/metadata/ingestion/ometa/task_models.py
+++ b/ingestion/src/metadata/ingestion/ometa/task_models.py
@@ -51,6 +51,7 @@ class TaskEntityType(str, Enum):
     IncidentResolution = "IncidentResolution"
     PipelineReview = "PipelineReview"
     DataQualityReview = "DataQualityReview"
+    RecognizerFeedbackApproval = "RecognizerFeedbackApproval"
     CustomTask = "CustomTask"
 
 

--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/TagRecognizerFeedbackIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/TagRecognizerFeedbackIT.java
@@ -225,7 +225,7 @@ public class TagRecognizerFeedbackIT {
         Map.of(
             "limit", "100",
             "status", TaskEntityStatus.Open.value(),
-            "type", TaskEntityType.DataQualityReview.value());
+            "type", TaskEntityType.RecognizerFeedbackApproval.value());
 
     try {
       Awaitility.await(String.format("Wait for Task entity to be created for Tag: '%s'", tagFQN))
@@ -274,7 +274,7 @@ public class TagRecognizerFeedbackIT {
   }
 
   private boolean isRecognizerFeedbackTaskForTag(Task task, String tagFQN) {
-    if (task == null || task.getType() != TaskEntityType.DataQualityReview) {
+    if (task == null || task.getType() != TaskEntityType.RecognizerFeedbackApproval) {
       return false;
     }
     RecognizerFeedback feedback = getTaskPayloadFeedback(task);
@@ -366,10 +366,34 @@ public class TagRecognizerFeedbackIT {
     Task task = waitForRecognizerFeedbackTask(tag.getFullyQualifiedName());
 
     assertNotNull(task, "Task should be created for tag with reviewer");
-    assertEquals(TaskEntityType.DataQualityReview, task.getType());
+    assertEquals(TaskEntityType.RecognizerFeedbackApproval, task.getType());
     RecognizerFeedback payloadFeedback = getTaskPayloadFeedback(task);
     assertNotNull(payloadFeedback, "Task payload should contain feedback details");
     assertEquals(feedback.getEntityLink(), payloadFeedback.getEntityLink());
+
+    ListResponse<Task> taskApiResponse =
+        SdkClients.adminClient()
+            .tasks()
+            .listWithFilters(
+                Map.of(
+                    "statusGroup",
+                    "open",
+                    "aboutEntity",
+                    tag.getFullyQualifiedName(),
+                    "fields",
+                    "assignees,createdBy,about,comments,payload",
+                    "limit",
+                    "100"));
+    Task listedTask =
+        taskApiResponse.getData().stream()
+            .filter(apiTask -> task.getId().equals(apiTask.getId()))
+            .findFirst()
+            .orElseThrow(
+                () ->
+                    new AssertionError(
+                        "Task API should return recognizer feedback task for tag "
+                            + tag.getFullyQualifiedName()));
+    assertEquals(TaskEntityType.RecognizerFeedbackApproval, listedTask.getType());
   }
 
   @RetryingTest(3)

--- a/openmetadata-service/src/main/java/org/openmetadata/service/governance/workflows/elements/nodes/userTask/CreateRecognizerFeedbackApprovalTask.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/governance/workflows/elements/nodes/userTask/CreateRecognizerFeedbackApprovalTask.java
@@ -87,7 +87,7 @@ public class CreateRecognizerFeedbackApprovalTask implements NodeInterface {
     FieldExtension taskTypeExpr =
         new FieldExtensionBuilder()
             .fieldName("taskTypeExpr")
-            .fieldValue(TaskEntityType.DataQualityReview.value())
+            .fieldValue(TaskEntityType.RecognizerFeedbackApproval.value())
             .build();
 
     FieldExtension taskCategoryExpr =

--- a/openmetadata-service/src/main/java/org/openmetadata/service/governance/workflows/elements/nodes/userTask/CreateTask.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/governance/workflows/elements/nodes/userTask/CreateTask.java
@@ -987,7 +987,9 @@ public class CreateTask implements TaskListener {
       TaskEntityType taskType,
       Map<String, String> inputNamespaceMap,
       WorkflowVariableHandler varHandler) {
-    if (taskType != TaskEntityType.DataQualityReview || inputNamespaceMap == null) {
+    if ((taskType != TaskEntityType.RecognizerFeedbackApproval
+            && taskType != TaskEntityType.DataQualityReview)
+        || inputNamespaceMap == null) {
       return null;
     }
 

--- a/openmetadata-service/src/main/java/org/openmetadata/service/migration/mysql/v202/Migration.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/migration/mysql/v202/Migration.java
@@ -1,0 +1,20 @@
+package org.openmetadata.service.migration.mysql.v202;
+
+import lombok.SneakyThrows;
+import org.openmetadata.service.migration.api.MigrationProcessImpl;
+import org.openmetadata.service.migration.utils.MigrationFile;
+import org.openmetadata.service.migration.utils.v201.MigrationUtil;
+
+public class Migration extends MigrationProcessImpl {
+
+  public Migration(MigrationFile migrationFile) {
+    super(migrationFile);
+  }
+
+  @Override
+  @SneakyThrows
+  public void runDataMigration() {
+    initializeWorkflowHandler();
+    new MigrationUtil(handle).runRecognizerFeedbackTaskTypeMigration();
+  }
+}

--- a/openmetadata-service/src/main/java/org/openmetadata/service/migration/postgres/v202/Migration.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/migration/postgres/v202/Migration.java
@@ -1,0 +1,20 @@
+package org.openmetadata.service.migration.postgres.v202;
+
+import lombok.SneakyThrows;
+import org.openmetadata.service.migration.api.MigrationProcessImpl;
+import org.openmetadata.service.migration.utils.MigrationFile;
+import org.openmetadata.service.migration.utils.v201.MigrationUtil;
+
+public class Migration extends MigrationProcessImpl {
+
+  public Migration(MigrationFile migrationFile) {
+    super(migrationFile);
+  }
+
+  @Override
+  @SneakyThrows
+  public void runDataMigration() {
+    initializeWorkflowHandler();
+    new MigrationUtil(handle).runRecognizerFeedbackTaskTypeMigration();
+  }
+}

--- a/openmetadata-service/src/main/java/org/openmetadata/service/migration/utils/v200/MigrationUtil.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/migration/utils/v200/MigrationUtil.java
@@ -744,7 +744,7 @@ public class MigrationUtil {
           ? "GlossaryApproval"
           : "RequestApproval";
       case "RequestTestCaseFailureResolution" -> "TestCaseResolution";
-      case "RecognizerFeedbackApproval" -> "DataQualityReview";
+      case "RecognizerFeedbackApproval" -> "RecognizerFeedbackApproval";
       default -> "CustomTask";
     };
   }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/migration/utils/v201/MigrationUtil.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/migration/utils/v201/MigrationUtil.java
@@ -26,6 +26,7 @@ import org.openmetadata.schema.governance.workflows.elements.WorkflowNodeDefinit
 import org.openmetadata.schema.type.EntityReference;
 import org.openmetadata.schema.type.Include;
 import org.openmetadata.schema.type.Post;
+import org.openmetadata.schema.type.RecognizerFeedback;
 import org.openmetadata.schema.type.TaskCategory;
 import org.openmetadata.schema.type.TaskComment;
 import org.openmetadata.schema.type.TaskDetails;
@@ -55,6 +56,7 @@ public class MigrationUtil {
   private static final String USER_APPROVAL_TASK_SUBTYPE = "userApprovalTask";
   private static final String RECOGNIZER_APPROVAL_TASK_SUBTYPE =
       "createRecognizerFeedbackApprovalTask";
+  private static final String FEEDBACK_PAYLOAD_KEY = "feedback";
   private static final int BATCH_SIZE = 200;
 
   private static final String NOTIFICATION_ALERT_TYPE = "Notification";
@@ -85,17 +87,29 @@ public class MigrationUtil {
     int seededDefaults = ensureDefaultTaskWorkflows();
     int redeployedWorkflows = redeployUserApprovalWorkflows();
     MigrationStats stats = migrateLegacyThreadTasks();
+    int rewrittenRecognizerFeedbackTasks = rewriteRecognizerFeedbackDataQualityReviewTasks();
     int backfilledOpenTasks = backfillOpenTasksToWorkflowInstances();
 
     LOG.info(
-        "Completed task workflow cutover migration. seededDefaults={}, workflowsRedeployed={}, migrated={}, alreadyMigrated={}, skipped={}, failures={}, backfilledOpenTasks={}",
+        "Completed task workflow cutover migration. seededDefaults={}, workflowsRedeployed={}, migrated={}, alreadyMigrated={}, skipped={}, failures={}, rewrittenRecognizerFeedbackTasks={}, backfilledOpenTasks={}",
         seededDefaults,
         redeployedWorkflows,
         stats.migrated,
         stats.alreadyMigrated,
         stats.skipped,
         stats.failed,
+        rewrittenRecognizerFeedbackTasks,
         backfilledOpenTasks);
+  }
+
+  public void runRecognizerFeedbackTaskTypeMigration() {
+    int seededDefaults = ensureDefaultTaskWorkflows();
+    int rewrittenRecognizerFeedbackTasks = rewriteRecognizerFeedbackDataQualityReviewTasks();
+
+    LOG.info(
+        "Completed recognizer feedback task type migration. seededDefaults={}, rewrittenRecognizerFeedbackTasks={}",
+        seededDefaults,
+        rewrittenRecognizerFeedbackTasks);
   }
 
   private int ensureDefaultTaskWorkflows() {
@@ -207,7 +221,7 @@ public class MigrationUtil {
       ListFilter filter = new ListFilter(Include.NON_DELETED);
       filter.addQueryParam("taskStatusGroup", "open");
       List<Task> openTasks =
-          taskRepository.listAll(taskRepository.getFields("about,payload"), filter);
+          listOrEmpty(taskRepository.listAll(taskRepository.getFields("about,payload"), filter));
       for (Task task : openTasks) {
         if (task.getWorkflowInstanceId() != null || task.getAbout() == null) {
           continue;
@@ -252,6 +266,54 @@ public class MigrationUtil {
       LOG.error("Failed to backfill open tasks to workflow instances", e);
     }
     return backfilled;
+  }
+
+  private int rewriteRecognizerFeedbackDataQualityReviewTasks() {
+    int rewritten = 0;
+    try {
+      ListFilter filter = new ListFilter(Include.NON_DELETED);
+      filter.addQueryParam("taskStatusGroup", "open");
+      filter.addQueryParam("taskType", TaskEntityType.DataQualityReview.value());
+
+      List<Task> openDataQualityReviewTasks =
+          listOrEmpty(taskRepository.listAll(taskRepository.getFields("about,payload"), filter));
+      for (Task task : openDataQualityReviewTasks) {
+        if (task.getId() == null || !isRecognizerFeedbackDataQualityReviewTask(task)) {
+          continue;
+        }
+
+        task.setType(TaskEntityType.RecognizerFeedbackApproval);
+        task.setCategory(TaskCategory.Review);
+        collectionDAO.taskDAO().updateTask(task.getId().toString(), JsonUtils.pojoToJson(task));
+        rewritten++;
+      }
+    } catch (Exception e) {
+      LOG.error("Failed to rewrite recognizer feedback review task types", e);
+    }
+    return rewritten;
+  }
+
+  private boolean isRecognizerFeedbackDataQualityReviewTask(Task task) {
+    if (task == null || task.getType() != TaskEntityType.DataQualityReview) {
+      return false;
+    }
+
+    try {
+      Map<String, Object> payload = JsonUtils.readOrConvertValue(task.getPayload(), Map.class);
+      if (payload == null || !payload.containsKey(FEEDBACK_PAYLOAD_KEY)) {
+        return false;
+      }
+
+      RecognizerFeedback feedback =
+          JsonUtils.convertValue(payload.get(FEEDBACK_PAYLOAD_KEY), RecognizerFeedback.class);
+      return feedback != null
+          && !nullOrEmpty(feedback.getTagFQN())
+          && !nullOrEmpty(feedback.getEntityLink());
+    } catch (Exception e) {
+      LOG.debug(
+          "Unable to inspect task '{}' payload for recognizer feedback keys", task.getId(), e);
+      return false;
+    }
   }
 
   private List<String> listTaskThreadWithOffset(String tableName, int limit, int offset) {

--- a/openmetadata-service/src/main/java/org/openmetadata/service/migration/utils/v201/MigrationUtil.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/migration/utils/v201/MigrationUtil.java
@@ -356,7 +356,7 @@ public class MigrationUtil {
       case RequestApproval -> new TypeAndCategory(
           TaskEntityType.GlossaryApproval, TaskCategory.Approval);
       case RecognizerFeedbackApproval -> new TypeAndCategory(
-          TaskEntityType.DataQualityReview, TaskCategory.Review);
+          TaskEntityType.RecognizerFeedbackApproval, TaskCategory.Review);
       case RequestDescription, UpdateDescription -> new TypeAndCategory(
           TaskEntityType.DescriptionUpdate, TaskCategory.MetadataUpdate);
       case RequestTag, UpdateTag -> new TypeAndCategory(

--- a/openmetadata-service/src/main/java/org/openmetadata/service/migration/utils/v201/MigrationUtil.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/migration/utils/v201/MigrationUtil.java
@@ -278,17 +278,27 @@ public class MigrationUtil {
       List<Task> openDataQualityReviewTasks =
           listOrEmpty(taskRepository.listAll(taskRepository.getFields("about,payload"), filter));
       for (Task task : openDataQualityReviewTasks) {
-        if (task.getId() == null || !isRecognizerFeedbackDataQualityReviewTask(task)) {
+        if (task == null
+            || task.getId() == null
+            || !isRecognizerFeedbackDataQualityReviewTask(task)) {
           continue;
         }
 
-        task.setType(TaskEntityType.RecognizerFeedbackApproval);
-        task.setCategory(TaskCategory.Review);
-        collectionDAO.taskDAO().updateTask(task.getId().toString(), JsonUtils.pojoToJson(task));
-        rewritten++;
+        TaskEntityType previousType = task.getType();
+        TaskCategory previousCategory = task.getCategory();
+        try {
+          task.setType(TaskEntityType.RecognizerFeedbackApproval);
+          task.setCategory(TaskCategory.Review);
+          collectionDAO.taskDAO().updateTask(task.getId().toString(), JsonUtils.pojoToJson(task));
+          rewritten++;
+        } catch (Exception e) {
+          task.setType(previousType);
+          task.setCategory(previousCategory);
+          LOG.error("Failed to rewrite recognizer feedback task '{}'", task.getId(), e);
+        }
       }
     } catch (Exception e) {
-      LOG.error("Failed to rewrite recognizer feedback review task types", e);
+      LOG.error("Failed to list recognizer feedback review tasks for type rewrite", e);
     }
     return rewritten;
   }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/tasks/TaskWorkflowHandler.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/tasks/TaskWorkflowHandler.java
@@ -1194,7 +1194,9 @@ public class TaskWorkflowHandler {
       return defaultTransitionId;
     }
 
-    if (task != null && TaskEntityType.DataQualityReview == task.getType()) {
+    if (task != null
+        && (TaskEntityType.RecognizerFeedbackApproval == task.getType()
+            || TaskEntityType.DataQualityReview == task.getType())) {
       return isPositiveResolution(resolutionType) ? "true" : "false";
     }
 

--- a/openmetadata-service/src/main/java/org/openmetadata/service/tasks/TaskWorkflowLifecycleResolver.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/tasks/TaskWorkflowLifecycleResolver.java
@@ -208,7 +208,8 @@ public final class TaskWorkflowLifecycleResolver {
       case TestCaseResolution -> "TestCaseResolutionTaskWorkflow";
       case IncidentResolution -> "IncidentResolutionTaskWorkflow";
       case PipelineReview -> "PipelineReviewTaskWorkflow";
-      case DataQualityReview -> "RecognizerFeedbackReviewWorkflow";
+      case DataQualityReview -> "DataQualityReviewTaskWorkflow";
+      case RecognizerFeedbackApproval -> "RecognizerFeedbackReviewWorkflow";
       case CustomTask -> "CustomTaskWorkflow";
       default -> "CustomTaskWorkflow";
     };
@@ -233,7 +234,8 @@ public final class TaskWorkflowLifecycleResolver {
       case "TestCaseResolutionTaskWorkflow" -> TaskEntityType.TestCaseResolution;
       case "IncidentResolutionTaskWorkflow" -> TaskEntityType.IncidentResolution;
       case "PipelineReviewTaskWorkflow" -> TaskEntityType.PipelineReview;
-      case "RecognizerFeedbackReviewWorkflow" -> TaskEntityType.DataQualityReview;
+      case "DataQualityReviewTaskWorkflow" -> TaskEntityType.DataQualityReview;
+      case "RecognizerFeedbackReviewWorkflow" -> TaskEntityType.RecognizerFeedbackApproval;
       case "GenericReviewTaskWorkflow" -> TaskEntityType.RequestApproval;
       case "GenericIncidentTaskWorkflow" -> TaskEntityType.IncidentResolution;
       case "CustomTaskWorkflow" -> TaskEntityType.CustomTask;
@@ -257,7 +259,7 @@ public final class TaskWorkflowLifecycleResolver {
       case GlossaryApproval, RequestApproval -> TaskCategory.Approval;
       case DataAccessRequest -> TaskCategory.DataAccess;
       case IncidentResolution, TestCaseResolution -> TaskCategory.Incident;
-      case DataQualityReview, PipelineReview -> TaskCategory.Review;
+      case DataQualityReview, PipelineReview, RecognizerFeedbackApproval -> TaskCategory.Review;
       case CustomTask -> TaskCategory.Custom;
     };
   }
@@ -275,6 +277,7 @@ public final class TaskWorkflowLifecycleResolver {
         "TestCaseResolutionTaskWorkflow",
         "IncidentResolutionTaskWorkflow",
         "PipelineReviewTaskWorkflow",
+        "DataQualityReviewTaskWorkflow",
         "RecognizerFeedbackReviewWorkflow",
         "CustomTaskWorkflow",
         // Keep legacy generic defaults seedable during cutover so older bindings remain valid.
@@ -574,7 +577,7 @@ public final class TaskWorkflowLifecycleResolver {
                       "recommendation", stringProperty(),
                       "attachments", Map.of("type", "array", "items", objectProperty()))))
           : null;
-      case DataQualityReview -> taskCategory == TaskCategory.Review
+      case DataQualityReview, RecognizerFeedbackApproval -> taskCategory == TaskCategory.Review
           ? defaultSchema(
               taskType,
               taskCategory,

--- a/openmetadata-service/src/main/resources/json/data/governance/workflows/DataQualityReviewTaskWorkflow.json
+++ b/openmetadata-service/src/main/resources/json/data/governance/workflows/DataQualityReviewTaskWorkflow.json
@@ -1,0 +1,92 @@
+{
+  "name": "DataQualityReviewTaskWorkflow",
+  "fullyQualifiedName": "DataQualityReviewTaskWorkflow",
+  "displayName": "Data Quality Review Task Workflow",
+  "description": "Default workflow-driven lifecycle for data quality review tasks.",
+  "config": {
+    "storeStageStatus": true
+  },
+  "trigger": {
+    "type": "noOp",
+    "config": {},
+    "output": ["relatedEntity", "updatedBy"]
+  },
+  "nodes": [
+    {
+      "type": "startEvent",
+      "subType": "startEvent",
+      "name": "TaskStart",
+      "displayName": "Task Start"
+    },
+    {
+      "type": "userTask",
+      "subType": "userApprovalTask",
+      "name": "TaskReview",
+      "displayName": "Review Task",
+      "config": {
+        "assignees": {
+          "addReviewers": true,
+          "addOwners": false,
+          "candidates": []
+        },
+        "approvalThreshold": 1,
+        "rejectionThreshold": 1,
+        "stageId": "review",
+        "stageDisplayName": "Review",
+        "taskStatus": "Open",
+        "assigneeStrategy": "reviewers-and-assignees",
+        "transitionMetadata": [
+          {
+            "id": "approve",
+            "label": "Approve",
+            "targetStageId": "approved",
+            "targetTaskStatus": "Approved",
+            "resolutionType": "Approved",
+            "formRef": "approve",
+            "requiresComment": false
+          },
+          {
+            "id": "reject",
+            "label": "Reject",
+            "targetStageId": "rejected",
+            "targetTaskStatus": "Rejected",
+            "resolutionType": "Rejected",
+            "formRef": "reject",
+            "requiresComment": true
+          }
+        ]
+      },
+      "inputNamespaceMap": {
+        "relatedEntity": "global"
+      }
+    },
+    {
+      "type": "endEvent",
+      "subType": "endEvent",
+      "name": "ApprovedEnd",
+      "displayName": "Approved"
+    },
+    {
+      "type": "endEvent",
+      "subType": "endEvent",
+      "name": "RejectedEnd",
+      "displayName": "Rejected"
+    }
+  ],
+  "edges": [
+    {
+      "from": "TaskStart",
+      "to": "TaskReview"
+    },
+    {
+      "from": "TaskReview",
+      "to": "ApprovedEnd",
+      "condition": "approve"
+    },
+    {
+      "from": "TaskReview",
+      "to": "RejectedEnd",
+      "condition": "reject"
+    }
+  ]
+}

--- a/openmetadata-service/src/test/java/org/openmetadata/service/migration/utils/v201/MigrationUtilTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/migration/utils/v201/MigrationUtilTest.java
@@ -18,6 +18,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.contains;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.mock;
@@ -31,6 +32,7 @@ import java.sql.Connection;
 import java.sql.DatabaseMetaData;
 import java.sql.ResultSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
@@ -42,7 +44,9 @@ import org.openmetadata.schema.entity.tasks.Task;
 import org.openmetadata.schema.governance.workflows.WorkflowDefinition;
 import org.openmetadata.schema.governance.workflows.elements.WorkflowNodeDefinitionInterface;
 import org.openmetadata.schema.type.EntityReference;
+import org.openmetadata.schema.type.Include;
 import org.openmetadata.schema.type.TaskCategory;
+import org.openmetadata.schema.type.TaskEntityStatus;
 import org.openmetadata.schema.type.TaskEntityType;
 import org.openmetadata.service.Entity;
 import org.openmetadata.service.governance.workflows.WorkflowHandler;
@@ -56,6 +60,7 @@ class MigrationUtilTest {
   private Connection connection;
   private DatabaseMetaData metadata;
   private CollectionDAO collectionDAO;
+  private CollectionDAO.TaskDAO taskDAO;
   private TaskRepository taskRepository;
   private TaskFormSchemaRepository taskFormSchemaRepository;
   private WorkflowDefinitionRepository workflowDefinitionRepository;
@@ -67,12 +72,14 @@ class MigrationUtilTest {
     connection = mock(Connection.class);
     metadata = mock(DatabaseMetaData.class);
     collectionDAO = mock(CollectionDAO.class);
+    taskDAO = mock(CollectionDAO.TaskDAO.class);
     taskRepository = mock(TaskRepository.class);
     taskFormSchemaRepository = mock(TaskFormSchemaRepository.class);
     workflowDefinitionRepository = mock(WorkflowDefinitionRepository.class);
     workflowHandler = mock(WorkflowHandler.class);
 
     when(handle.attach(CollectionDAO.class)).thenReturn(collectionDAO);
+    when(collectionDAO.taskDAO()).thenReturn(taskDAO);
     when(handle.getConnection()).thenReturn(connection);
     when(connection.getMetaData()).thenReturn(metadata);
     when(workflowDefinitionRepository.listAll(any(), any())).thenReturn(List.of());
@@ -133,12 +140,19 @@ class MigrationUtilTest {
         new WorkflowDefinition().withName("DescriptionUpdateTaskWorkflow");
     WorkflowDefinition incidentWorkflow =
         new WorkflowDefinition().withName("IncidentResolutionTaskWorkflow");
+    WorkflowDefinition dataQualityWorkflow =
+        new WorkflowDefinition().withName("DataQualityReviewTaskWorkflow");
     WorkflowDefinition recognizerWorkflow =
         new WorkflowDefinition().withName("RecognizerFeedbackReviewWorkflow");
     WorkflowDefinition unrelatedWorkflow = new WorkflowDefinition().withName("SomeOtherWorkflow");
     when(workflowDefinitionRepository.getEntitiesFromSeedData())
         .thenReturn(
-            List.of(descriptionWorkflow, incidentWorkflow, recognizerWorkflow, unrelatedWorkflow));
+            List.of(
+                descriptionWorkflow,
+                incidentWorkflow,
+                dataQualityWorkflow,
+                recognizerWorkflow,
+                unrelatedWorkflow));
 
     MigrationUtil migrationUtil = newMigrationUtil();
 
@@ -146,6 +160,7 @@ class MigrationUtilTest {
 
     verify(workflowDefinitionRepository).createOrUpdate(null, descriptionWorkflow, "admin");
     verify(workflowDefinitionRepository).createOrUpdate(null, incidentWorkflow, "admin");
+    verify(workflowDefinitionRepository).createOrUpdate(null, dataQualityWorkflow, "admin");
     verify(workflowDefinitionRepository).createOrUpdate(null, recognizerWorkflow, "admin");
     verify(workflowDefinitionRepository, never()).createOrUpdate(null, unrelatedWorkflow, "admin");
   }
@@ -174,8 +189,7 @@ class MigrationUtilTest {
 
     when(taskRepository.listAll(any(), any())).thenReturn(List.of(openTask));
     when(workflowDefinitionRepository.findByNameOrNull(
-            eq("DescriptionUpdateTaskWorkflow"),
-            eq(org.openmetadata.schema.type.Include.NON_DELETED)))
+            eq("DescriptionUpdateTaskWorkflow"), eq(Include.NON_DELETED)))
         .thenReturn(workflowDefinition);
     try (MockedStatic<Entity> entityMock = mockStatic(Entity.class);
         MockedStatic<WorkflowHandler> workflowMock = mockStatic(WorkflowHandler.class)) {
@@ -194,6 +208,83 @@ class MigrationUtilTest {
       verify(workflowHandler)
           .triggerByKey(eq("DescriptionUpdateTaskWorkflowTrigger"), eq(taskId.toString()), any());
     }
+  }
+
+  @Test
+  void runTaskWorkflowCutoverMigrationRewritesRecognizerFeedbackTasksBeforeBackfill()
+      throws Exception {
+    stubTables(Set.of());
+    UUID taskId = UUID.randomUUID();
+    Task openTask =
+        new Task()
+            .withId(taskId)
+            .withName("recognizer-feedback")
+            .withType(TaskEntityType.DataQualityReview)
+            .withCategory(TaskCategory.Review)
+            .withStatus(TaskEntityStatus.Open)
+            .withAbout(new EntityReference().withType("tag").withFullyQualifiedName("PII.Email"))
+            .withUpdatedBy("alice")
+            .withPayload(
+                Map.of(
+                    "feedback",
+                    Map.of(
+                        "tagFQN",
+                        "PII.Email",
+                        "entityLink",
+                        "<#E::table::sample_data.ecommerce_db.shopify.raw_product_catalog::tags>")));
+
+    WorkflowDefinition workflowDefinition =
+        new WorkflowDefinition()
+            .withId(UUID.randomUUID())
+            .withName("RecognizerFeedbackReviewWorkflow")
+            .withFullyQualifiedName("RecognizerFeedbackReviewWorkflow");
+
+    when(taskRepository.listAll(any(), any())).thenReturn(List.of(openTask));
+    when(workflowDefinitionRepository.findByNameOrNull(
+            eq("RecognizerFeedbackReviewWorkflow"), eq(Include.NON_DELETED)))
+        .thenReturn(workflowDefinition);
+
+    try (MockedStatic<Entity> entityMock = mockStatic(Entity.class);
+        MockedStatic<WorkflowHandler> workflowMock = mockStatic(WorkflowHandler.class)) {
+      entityMock.when(() -> Entity.getEntityRepository(Entity.TASK)).thenReturn(taskRepository);
+      entityMock
+          .when(() -> Entity.getEntityRepository(Entity.TASK_FORM_SCHEMA))
+          .thenReturn(taskFormSchemaRepository);
+      entityMock
+          .when(() -> Entity.getEntityRepository(Entity.WORKFLOW_DEFINITION))
+          .thenReturn(workflowDefinitionRepository);
+      workflowMock.when(WorkflowHandler::getInstance).thenReturn(workflowHandler);
+
+      MigrationUtil migrationUtil = new MigrationUtil(handle);
+      migrationUtil.runTaskWorkflowCutoverMigration();
+
+      assertEquals(TaskEntityType.RecognizerFeedbackApproval, openTask.getType());
+      verify(taskDAO)
+          .updateTask(eq(taskId.toString()), contains("\"type\":\"RecognizerFeedbackApproval\""));
+      verify(workflowHandler)
+          .triggerByKey(
+              eq("RecognizerFeedbackReviewWorkflowTrigger"), eq(taskId.toString()), any());
+    }
+  }
+
+  @Test
+  void runRecognizerFeedbackTaskTypeMigrationSeedsDataQualityWorkflow() throws Exception {
+    WorkflowDefinition dataQualityWorkflow =
+        new WorkflowDefinition().withName("DataQualityReviewTaskWorkflow");
+    WorkflowDefinition recognizerWorkflow =
+        new WorkflowDefinition().withName("RecognizerFeedbackReviewWorkflow");
+    WorkflowDefinition unrelatedWorkflow = new WorkflowDefinition().withName("SomeOtherWorkflow");
+    when(workflowDefinitionRepository.getEntitiesFromSeedData())
+        .thenReturn(List.of(dataQualityWorkflow, recognizerWorkflow, unrelatedWorkflow));
+    when(taskRepository.listAll(any(), any())).thenReturn(List.of());
+
+    MigrationUtil migrationUtil = newMigrationUtil();
+
+    migrationUtil.runRecognizerFeedbackTaskTypeMigration();
+
+    verify(workflowDefinitionRepository).createOrUpdate(null, dataQualityWorkflow, "admin");
+    verify(workflowDefinitionRepository).createOrUpdate(null, recognizerWorkflow, "admin");
+    verify(workflowDefinitionRepository, never()).createOrUpdate(null, unrelatedWorkflow, "admin");
   }
 
   private MigrationUtil newMigrationUtil() {

--- a/openmetadata-service/src/test/java/org/openmetadata/service/migration/utils/v201/MigrationUtilTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/migration/utils/v201/MigrationUtilTest.java
@@ -21,6 +21,7 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.contains;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.never;
@@ -215,23 +216,7 @@ class MigrationUtilTest {
       throws Exception {
     stubTables(Set.of());
     UUID taskId = UUID.randomUUID();
-    Task openTask =
-        new Task()
-            .withId(taskId)
-            .withName("recognizer-feedback")
-            .withType(TaskEntityType.DataQualityReview)
-            .withCategory(TaskCategory.Review)
-            .withStatus(TaskEntityStatus.Open)
-            .withAbout(new EntityReference().withType("tag").withFullyQualifiedName("PII.Email"))
-            .withUpdatedBy("alice")
-            .withPayload(
-                Map.of(
-                    "feedback",
-                    Map.of(
-                        "tagFQN",
-                        "PII.Email",
-                        "entityLink",
-                        "<#E::table::sample_data.ecommerce_db.shopify.raw_product_catalog::tags>")));
+    Task openTask = recognizerFeedbackDataQualityTask(taskId, "PII.Email");
 
     WorkflowDefinition workflowDefinition =
         new WorkflowDefinition()
@@ -265,6 +250,33 @@ class MigrationUtilTest {
           .triggerByKey(
               eq("RecognizerFeedbackReviewWorkflowTrigger"), eq(taskId.toString()), any());
     }
+  }
+
+  @Test
+  void runRecognizerFeedbackTaskTypeMigrationContinuesAfterSingleRewriteFailure() throws Exception {
+    UUID failingTaskId = UUID.randomUUID();
+    UUID rewrittenTaskId = UUID.randomUUID();
+    Task failingTask = recognizerFeedbackDataQualityTask(failingTaskId, "PII.Email");
+    Task rewrittenTask = recognizerFeedbackDataQualityTask(rewrittenTaskId, "PII.Phone");
+
+    when(workflowDefinitionRepository.getEntitiesFromSeedData()).thenReturn(List.of());
+    when(taskRepository.listAll(any(), any())).thenReturn(List.of(failingTask, rewrittenTask));
+    doThrow(new RuntimeException("update failed"))
+        .when(taskDAO)
+        .updateTask(eq(failingTaskId.toString()), anyString());
+
+    MigrationUtil migrationUtil = newMigrationUtil();
+
+    migrationUtil.runRecognizerFeedbackTaskTypeMigration();
+
+    assertEquals(TaskEntityType.DataQualityReview, failingTask.getType());
+    assertEquals(TaskEntityType.RecognizerFeedbackApproval, rewrittenTask.getType());
+    verify(taskDAO)
+        .updateTask(
+            eq(failingTaskId.toString()), contains("\"type\":\"RecognizerFeedbackApproval\""));
+    verify(taskDAO)
+        .updateTask(
+            eq(rewrittenTaskId.toString()), contains("\"type\":\"RecognizerFeedbackApproval\""));
   }
 
   @Test
@@ -308,6 +320,25 @@ class MigrationUtilTest {
     method.setAccessible(true);
 
     return (String) method.invoke(migrationUtil);
+  }
+
+  private Task recognizerFeedbackDataQualityTask(UUID taskId, String tagFqn) {
+    return new Task()
+        .withId(taskId)
+        .withName("recognizer-feedback")
+        .withType(TaskEntityType.DataQualityReview)
+        .withCategory(TaskCategory.Review)
+        .withStatus(TaskEntityStatus.Open)
+        .withAbout(new EntityReference().withType("tag").withFullyQualifiedName(tagFqn))
+        .withUpdatedBy("alice")
+        .withPayload(
+            Map.of(
+                "feedback",
+                Map.of(
+                    "tagFQN",
+                    tagFqn,
+                    "entityLink",
+                    "<#E::table::sample_data.ecommerce_db.shopify.raw_product_catalog::tags>")));
   }
 
   private void stubTables(Set<String> tables) throws Exception {

--- a/openmetadata-service/src/test/java/org/openmetadata/service/tasks/TaskWorkflowLifecycleResolverTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/tasks/TaskWorkflowLifecycleResolverTest.java
@@ -229,9 +229,13 @@ class TaskWorkflowLifecycleResolverTest {
         TaskWorkflowLifecycleResolver.defaultWorkflowDefinitionRef(
             TaskEntityType.IncidentResolution));
     assertEquals(
-        "RecognizerFeedbackReviewWorkflow",
+        "DataQualityReviewTaskWorkflow",
         TaskWorkflowLifecycleResolver.defaultWorkflowDefinitionRef(
             TaskEntityType.DataQualityReview));
+    assertEquals(
+        "RecognizerFeedbackReviewWorkflow",
+        TaskWorkflowLifecycleResolver.defaultWorkflowDefinitionRef(
+            TaskEntityType.RecognizerFeedbackApproval));
     assertEquals(
         "CustomTaskWorkflow",
         TaskWorkflowLifecycleResolver.defaultWorkflowDefinitionRef(TaskEntityType.CustomTask));
@@ -255,6 +259,18 @@ class TaskWorkflowLifecycleResolverTest {
         TaskCategory.Approval,
         TaskWorkflowLifecycleResolver.defaultTaskCategoryForWorkflowDefinitionRef(
             "GlossaryApprovalTaskWorkflow"));
+    assertEquals(
+        TaskEntityType.RecognizerFeedbackApproval,
+        TaskWorkflowLifecycleResolver.defaultTaskTypeForWorkflowDefinitionRef(
+            "RecognizerFeedbackReviewWorkflow"));
+    assertEquals(
+        TaskEntityType.DataQualityReview,
+        TaskWorkflowLifecycleResolver.defaultTaskTypeForWorkflowDefinitionRef(
+            "DataQualityReviewTaskWorkflow"));
+    assertEquals(
+        TaskCategory.Review,
+        TaskWorkflowLifecycleResolver.defaultTaskCategoryForWorkflowDefinitionRef(
+            "RecognizerFeedbackReviewWorkflow"));
     assertEquals(
         TaskEntityType.CustomTask,
         TaskWorkflowLifecycleResolver.defaultTaskTypeForWorkflowDefinitionRef("UnknownWorkflow"));

--- a/openmetadata-spec/src/main/resources/json/schema/entity/tasks/task.json
+++ b/openmetadata-spec/src/main/resources/json/schema/entity/tasks/task.json
@@ -46,6 +46,7 @@
         "IncidentResolution",
         "PipelineReview",
         "DataQualityReview",
+        "RecognizerFeedbackApproval",
         "CustomTask"
       ],
       "javaEnums": [
@@ -62,6 +63,7 @@
         {"name": "IncidentResolution"},
         {"name": "PipelineReview"},
         {"name": "DataQualityReview"},
+        {"name": "RecognizerFeedbackApproval"},
         {"name": "CustomTask"}
       ]
     },

--- a/openmetadata-ui/src/main/resources/ui/src/constants/Task.constant.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/constants/Task.constant.ts
@@ -40,5 +40,7 @@ export const TASK_ENTITY_TYPES: Record<TaskEntityType, string> = {
   [TaskEntityType.IncidentResolution]: 'message.incident-resolution-message',
   [TaskEntityType.PipelineReview]: 'message.pipeline-review-message',
   [TaskEntityType.DataQualityReview]: 'message.data-quality-review-message',
+  [TaskEntityType.RecognizerFeedbackApproval]:
+    'message.recognizer-feedback-approval-message',
   [TaskEntityType.CustomTask]: 'message.custom-task-message',
 };

--- a/openmetadata-ui/src/main/resources/ui/src/generated/api/tasks/createTask.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/api/tasks/createTask.ts
@@ -354,6 +354,7 @@ export enum TaskType {
     IncidentResolution = "IncidentResolution",
     OwnershipUpdate = "OwnershipUpdate",
     PipelineReview = "PipelineReview",
+    RecognizerFeedbackApproval = "RecognizerFeedbackApproval",
     RequestApproval = "RequestApproval",
     Suggestion = "Suggestion",
     TagUpdate = "TagUpdate",

--- a/openmetadata-ui/src/main/resources/ui/src/generated/entity/tasks/task.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/entity/tasks/task.ts
@@ -730,6 +730,7 @@ export enum TaskType {
     IncidentResolution = "IncidentResolution",
     OwnershipUpdate = "OwnershipUpdate",
     PipelineReview = "PipelineReview",
+    RecognizerFeedbackApproval = "RecognizerFeedbackApproval",
     RequestApproval = "RequestApproval",
     Suggestion = "Suggestion",
     TagUpdate = "TagUpdate",

--- a/openmetadata-ui/src/main/resources/ui/src/utils/TasksUtils.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/TasksUtils.ts
@@ -1039,7 +1039,8 @@ export const isRecognizerFeedbackTask = (task: TaskEntity) => {
 
   return (
     hasFeedbackPayload &&
-    (task.type === TaskEntityType.DataQualityReview ||
+    (task.type === TaskEntityType.RecognizerFeedbackApproval ||
+      task.type === TaskEntityType.DataQualityReview ||
       taskType === 'RecognizerFeedbackApproval')
   );
 };

--- a/openmetadata-ui/src/main/resources/ui/src/utils/TasksUtils.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/TasksUtils.ts
@@ -1031,7 +1031,6 @@ export const isTagsTaskType = (taskType: TaskEntityType) =>
   [TaskEntityType.TagUpdate].includes(taskType);
 
 export const isRecognizerFeedbackTask = (task: TaskEntity) => {
-  const taskType = task.type as unknown as string;
   const hasFeedbackPayload =
     Boolean(task.payload) &&
     typeof task.payload === 'object' &&
@@ -1040,8 +1039,7 @@ export const isRecognizerFeedbackTask = (task: TaskEntity) => {
   return (
     hasFeedbackPayload &&
     (task.type === TaskEntityType.RecognizerFeedbackApproval ||
-      task.type === TaskEntityType.DataQualityReview ||
-      taskType === 'RecognizerFeedbackApproval')
+      task.type === TaskEntityType.DataQualityReview)
   );
 };
 


### PR DESCRIPTION
### Describe your changes:

Fixes #29233

I worked on returning auto-classified tag review tasks as `RecognizerFeedbackApproval` because the recognizer feedback workflow was hardcoding `DataQualityReview`. This also adds a dedicated `DataQualityReviewTaskWorkflow` seed so data-quality reviews keep their own workflow/template instead of sharing the recognizer-specific event workflow, while preserving compatibility for existing recognizer tasks stored as `DataQualityReview`.

#
### Type of change:
- [x] Bug fix

#
### High-level design:

The recognizer feedback workflow now creates `RecognizerFeedbackApproval` tasks and maps only that task type to `RecognizerFeedbackReviewWorkflow`. `DataQualityReview` now resolves to a separate `DataQualityReviewTaskWorkflow` with the standard review lifecycle.

#
### Tests:

#### Use cases covered
- Task API returns `RecognizerFeedbackApproval` for auto-classified tag review tasks filtered by `statusGroup=open` and `aboutEntity`.
- `DataQualityReview` and `RecognizerFeedbackApproval` resolve to separate default workflow definitions.

#### Unit tests
- [x] I added unit tests for the new/changed logic.
- Files updated: `TaskWorkflowLifecycleResolverTest.java`
- Coverage %: Not measured.

#### Backend integration tests
- [x] I added integration tests in `openmetadata-integration-tests/` for new/changed API endpoints.
- Files updated: `TagRecognizerFeedbackIT.java`

#### Ingestion integration tests
- [x] Not applicable (no connector behavior changes).

#### Playwright (UI) tests
- [x] Not applicable (no visible UI workflow changes).

#### Manual testing performed
1. `mvn spotless:apply`
2. UI checkstyle sequence on touched UI files: organize imports, ESLint fix, Prettier
3. `ruff check ingestion/src/metadata/ingestion/ometa/task_models.py --config ingestion/pyproject.toml`
4. `ruff format --check ingestion/src/metadata/ingestion/ometa/task_models.py --config ingestion/pyproject.toml`
5. `mvn -pl openmetadata-service -am -Dtest=TaskWorkflowLifecycleResolverTest -Dsurefire.failIfNoSpecifiedTests=false package`
6. `mvn -pl openmetadata-integration-tests -am -DskipTests package`
7. `mvn -pl openmetadata-integration-tests -am -Dtest=NoUnitTests -Dsurefire.failIfNoSpecifiedTests=false -Dit.test=TagRecognizerFeedbackIT#test_recognizerFeedback_withDirectReviewer_createsTask -Dfailsafe.failIfNoSpecifiedTests=false verify`

#
### UI screen recording / screenshots:

Not applicable.

#
### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] My PR title is `Fixes <issue-number>: <short explanation>`
- [x] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [x] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.
- [x] For UI changes: no visible UI change; screenshots are not applicable.
- [x] I have added tests (unit / integration / Playwright as applicable) and listed them above.

<!-- Bug fix -->
- [x] I have added a test that covers the exact scenario we are fixing.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a bug where the recognizer feedback workflow was hardcoding `DataQualityReview` as the task type instead of `RecognizerFeedbackApproval`, and separates data quality review tasks into their own `DataQualityReviewTaskWorkflow` so the two task families no longer share workflow state.

- **Core type fix**: `CreateRecognizerFeedbackApprovalTask` now emits `RecognizerFeedbackApproval`, and `TaskWorkflowLifecycleResolver` maps each type to its own dedicated workflow (`DataQualityReviewTaskWorkflow` vs `RecognizerFeedbackReviewWorkflow`).
- **Data migration**: v201 `runTaskWorkflowCutoverMigration` now rewrites open `DataQualityReview` recognizer-feedback tasks *before* backfilling workflow instances, so the correct workflow trigger is used; a new v202 migration handles the same rewrite for instances already on 2.0.1.
- **Backward compat**: `TaskWorkflowHandler` and the TypeScript `isRecognizerFeedbackTask` utility both retain a `DataQualityReview` fallback for tasks that were persisted under the old type before migration runs.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is a targeted bug fix with a well-ordered data migration and backward-compatible fallbacks.

All changed code paths have corresponding unit and integration tests. The migration correctly rewrites tasks before backfilling workflow instances so no task ends up bound to the wrong workflow. The `TaskWorkflowHandler` and UI utility retain `DataQualityReview` fallbacks for any tasks that reach those code paths before migration runs, preventing regressions for tasks already in flight.

No files require special attention.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| openmetadata-service/src/main/java/org/openmetadata/service/governance/workflows/elements/nodes/userTask/CreateRecognizerFeedbackApprovalTask.java | Core bug fix: changes the hardcoded `DataQualityReview` task type expression to `RecognizerFeedbackApproval`. |
| openmetadata-service/src/main/java/org/openmetadata/service/tasks/TaskWorkflowLifecycleResolver.java | Correctly splits the resolver: `DataQualityReview` → `DataQualityReviewTaskWorkflow`, `RecognizerFeedbackApproval` → `RecognizerFeedbackReviewWorkflow`; also adds `RecognizerFeedbackApproval` to the `Review` category arm and the default workflow refs set. |
| openmetadata-service/src/main/java/org/openmetadata/service/migration/utils/v201/MigrationUtil.java | Adds `rewriteRecognizerFeedbackDataQualityReviewTasks()` (run before `backfillOpenTasksToWorkflowInstances` so the type is correct when backfilling) and exposes `runRecognizerFeedbackTaskTypeMigration()` for the v202 standalone migration path. |
| openmetadata-service/src/main/resources/json/data/governance/workflows/DataQualityReviewTaskWorkflow.json | New seed workflow for data quality review tasks; uses standard `userApprovalTask` subType with approve/reject transitions, correctly decoupled from the recognizer feedback workflow. |
| openmetadata-service/src/main/java/org/openmetadata/service/migration/mysql/v202/Migration.java | New MySQL v202 migration stub that seeds `DataQualityReviewTaskWorkflow` and rewrites open recognizer feedback tasks from `DataQualityReview` to `RecognizerFeedbackApproval`. |
| openmetadata-service/src/main/java/org/openmetadata/service/migration/postgres/v202/Migration.java | Postgres counterpart of the v202 migration, identical in logic to the MySQL version. |
| openmetadata-service/src/main/java/org/openmetadata/service/tasks/TaskWorkflowHandler.java | Adds `RecognizerFeedbackApproval` alongside `DataQualityReview` in the transition-ID branch for backward compatibility with tasks stored under the old type. |
| openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/TagRecognizerFeedbackIT.java | Updates integration test assertions from `DataQualityReview` to `RecognizerFeedbackApproval` and adds an end-to-end check that the task list API returns the correct type when filtered by `statusGroup=open` and `aboutEntity`. |

</details>


</details>


<details open><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[RecognizerFeedbackWorkflow trigger] --> B[CreateRecognizerFeedbackApprovalTask]
    B -->|taskType = RecognizerFeedbackApproval| C[Task persisted in DB]

    C --> D{TaskWorkflowLifecycleResolver}
    D -->|RecognizerFeedbackApproval| E[RecognizerFeedbackReviewWorkflow]
    D -->|DataQualityReview| F[DataQualityReviewTaskWorkflow new]

    G[v201 migration] --> H[migrateLegacyThreadTasks]
    H --> I[rewriteRecognizerFeedbackDQReviewTasks]
    I --> J[backfillOpenTasksToWorkflowInstances]
    J -->|type now RecognizerFeedbackApproval| E

    K[v202 migration new] --> L[ensureDefaultTaskWorkflows]
    L --> M[seeds DataQualityReviewTaskWorkflow]
    K --> N[rewriteRecognizerFeedbackDQReviewTasks]
    N -->|covers installs already on 2.0.1| C
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[RecognizerFeedbackWorkflow trigger] --> B[CreateRecognizerFeedbackApprovalTask]
    B -->|taskType = RecognizerFeedbackApproval| C[Task persisted in DB]

    C --> D{TaskWorkflowLifecycleResolver}
    D -->|RecognizerFeedbackApproval| E[RecognizerFeedbackReviewWorkflow]
    D -->|DataQualityReview| F[DataQualityReviewTaskWorkflow new]

    G[v201 migration] --> H[migrateLegacyThreadTasks]
    H --> I[rewriteRecognizerFeedbackDQReviewTasks]
    I --> J[backfillOpenTasksToWorkflowInstances]
    J -->|type now RecognizerFeedbackApproval| E

    K[v202 migration new] --> L[ensureDefaultTaskWorkflows]
    L --> M[seeds DataQualityReviewTaskWorkflow]
    K --> N[rewriteRecognizerFeedbackDQReviewTasks]
    N -->|covers installs already on 2.0.1| C
```

</a>
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `openmetadata-service/src/main/java/org/openmetadata/service/tasks/TaskWorkflowLifecycleResolver.java`, line 580-586 ([link](https://github.com/open-metadata/openmetadata/blob/1fe43306d3a923e8ce538af2b0436559ebfa52f4/openmetadata-service/src/main/java/org/openmetadata/service/tasks/TaskWorkflowLifecycleResolver.java#L580-L586)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> Shared schema branch for `DataQualityReview` and `RecognizerFeedbackApproval`. Both types now resolve to `namedObjectSchema("comment")`, but they map to different workflow definition refs (`DataQualityReviewTaskWorkflow` vs `RecognizerFeedbackReviewWorkflow`). Since `defaultSchema` embeds `defaultWorkflowDefinitionRef(taskType)` as the `workflowDefinitionRef` field, the resolved schema for each type will correctly carry its own workflow ref — just worth noting that any future divergence between the two schemas will require splitting this case arm.

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (3): Last reviewed commit: ["Make recognizer feedback task rewrite re..."](https://github.com/open-metadata/openmetadata/commit/93c8a4ab69c007a6dc7046bc9254ad34881e14f7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38715974)</sub>

<!-- /greptile_comment -->