### PR TITLE
Fixes #29145: Prevent NPE when query tags are null

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/security/mask/PIIMasker.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/security/mask/PIIMasker.java
@@ -302,7 +302,9 @@ public class PIIMasker {
   }
 
   private static boolean hasPiiSensitiveTag(Query query) {
-    return listOrEmpty(query.getTags()).stream().map(TagLabel::getTagFQN).anyMatch(SENSITIVE_PII_TAG::equals);
+    return listOrEmpty(query.getTags()).stream()
+        .map(TagLabel::getTagFQN)
+        .anyMatch(SENSITIVE_PII_TAG::equals);
   }
 
   private static boolean hasPiiSensitiveTag(Column column) {

--- a/openmetadata-service/src/main/java/org/openmetadata/service/security/mask/PIIMasker.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/security/mask/PIIMasker.java
@@ -302,7 +302,7 @@ public class PIIMasker {
   }
 
   private static boolean hasPiiSensitiveTag(Query query) {
-    return query.getTags() != null && query.getTags().stream().map(TagLabel::getTagFQN).anyMatch(SENSITIVE_PII_TAG::equals);
+    return listOrEmpty(query.getTags()).stream().map(TagLabel::getTagFQN).anyMatch(SENSITIVE_PII_TAG::equals);
   }
 
   private static boolean hasPiiSensitiveTag(Column column) {

--- a/openmetadata-service/src/main/java/org/openmetadata/service/security/mask/PIIMasker.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/security/mask/PIIMasker.java
@@ -302,7 +302,7 @@ public class PIIMasker {
   }
 
   private static boolean hasPiiSensitiveTag(Query query) {
-    return query.getTags().stream().map(TagLabel::getTagFQN).anyMatch(SENSITIVE_PII_TAG::equals);
+    return query.getTags() != null && query.getTags().stream().map(TagLabel::getTagFQN).anyMatch(SENSITIVE_PII_TAG::equals);
   }
 
   private static boolean hasPiiSensitiveTag(Column column) {

--- a/openmetadata-service/src/test/java/org/openmetadata/service/security/mask/PIIMaskerTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/security/mask/PIIMaskerTest.java
@@ -270,25 +270,17 @@ class PIIMaskerTest {
 
     EntityReference owner = entityReference(Entity.USER, "owner");
 
-    Query query =
-            new Query()
-                    .withQuery("select email from customer")
-                    .withOwners(List.of(owner));
+    Query query = new Query().withQuery("select email from customer").withOwners(List.of(owner));
 
     query.setTags(null);
 
-    ResultList<Query> queries =
-            new ResultList<>(new ArrayList<>(List.of(query)));
+    ResultList<Query> queries = new ResultList<>(new ArrayList<>(List.of(query)));
 
-    when(authorizer.authorizePII(securityContext, List.of(owner)))
-            .thenReturn(false);
+    when(authorizer.authorizePII(securityContext, List.of(owner))).thenReturn(false);
 
-    ResultList<Query> result =
-            PIIMasker.getQueries(queries, authorizer, securityContext);
+    ResultList<Query> result = PIIMasker.getQueries(queries, authorizer, securityContext);
 
-    assertEquals(
-            "select email from customer",
-            result.getData().get(0).getQuery());
+    assertEquals("select email from customer", result.getData().get(0).getQuery());
   }
 
   @Test

--- a/openmetadata-service/src/test/java/org/openmetadata/service/security/mask/PIIMaskerTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/security/mask/PIIMaskerTest.java
@@ -264,6 +264,34 @@ class PIIMaskerTest {
   }
 
   @Test
+  void getQueriesHandlesNullTagsForUnauthorizedUsers() {
+    Authorizer authorizer = mock(Authorizer.class);
+    SecurityContext securityContext = mock(SecurityContext.class);
+
+    EntityReference owner = entityReference(Entity.USER, "owner");
+
+    Query query =
+            new Query()
+                    .withQuery("select email from customer")
+                    .withOwners(List.of(owner));
+
+    query.setTags(null);
+
+    ResultList<Query> queries =
+            new ResultList<>(new ArrayList<>(List.of(query)));
+
+    when(authorizer.authorizePII(securityContext, List.of(owner)))
+            .thenReturn(false);
+
+    ResultList<Query> result =
+            PIIMasker.getQueries(queries, authorizer, securityContext);
+
+    assertEquals(
+            "select email from customer",
+            result.getData().get(0).getQuery());
+  }
+
+  @Test
   void getQueriesAndMaskUserLeaveAuthorizedValuesUntouched() {
     Authorizer authorizer = mock(Authorizer.class);
     SecurityContext securityContext = mock(SecurityContext.class);


### PR DESCRIPTION
Describe your changes:

Fixes #29145

This PR fixes a NullPointerException in `PIIMasker` when query tags are not loaded and `query.getTags()` returns `null`.

The issue occurred when non-admin users accessed queries without requesting the `tags` field (for example, `GET /api/v1/queries?fields=queryUsedIn`). The masking logic attempted to call `.stream()` on a null tag list, resulting in a server error.

Changes made:

* Added a null check in `hasPiiSensitiveTag(Query)` before streaming tags.
* Added a regression test covering queries with null tags for unauthorized users.

#

### Type of change:

* [x] Bug fix

#

### High-level design:

N/A — small change.

#

### Tests:

#### Use cases covered

* Unauthorized user accessing queries when `query.getTags()` is `null`
* Existing query masking behavior for authorized and unauthorized users remains unchanged

#### Unit tests

* [x] I added unit tests for the new/changed logic.
* Files added/updated:

  * PIIMaskerTest.java
  * PIIMasker.java

#### Backend integration tests

* [x] Not applicable (no backend API changes).

#### Ingestion integration tests

* [x] Not applicable (no ingestion changes).

#### Playwright (UI) tests

* [x] Not applicable (no UI changes).

#### Manual testing performed

1. Added a regression test with `query.setTags(null)`
2. Verified the test failed with:
   `Cannot invoke "java.util.List.stream()" because query.getTags() is null`
3. Added null handling in `hasPiiSensitiveTag(Query)`
4. Re-ran `PIIMaskerTest`
5. Verified all tests passed (8/8)

#

### UI screen recording / screenshots:

Not applicable.

#

### Checklist:

* [x] I have read the CONTRIBUTING document.
* [x] My PR title is `Fixes #29145: Prevent NPE when query tags are null`
* [x] My PR is linked to a GitHub issue via `Fixes #29145` above.
* [ ] I have commented on my code, particularly in hard-to-understand areas. (Not applicable - small backend bug fix.)
* [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed. (Not applicable - small backend bug fix.)
* [ ] For UI changes: I attached a screen recording and/or screenshots above. (Not applicable - small backend bug fix.)
* [x] I have added tests (unit / integration / Playwright as applicable) and listed them above.
* [x] I have added a test that covers the exact scenario we are fixing.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds a null guard to `hasPiiSensitiveTag(Query)` in `PIIMasker.java`, preventing an NPE when `query.getTags()` returns `null` — a situation that arises when non-admin users access queries without requesting the `tags` field. A regression test is included that exercises the exact failure path.

- **`PIIMasker.java`**: Replaced the direct `.getTags().stream()` call with `listOrEmpty(query.getTags()).stream()`, consistent with the `listOrEmpty` utility already used elsewhere in the class.
- **`PIIMaskerTest.java`**: Added a test that sets `tags` to `null`, simulates an unauthorized user, and asserts no NPE is thrown and the query text passes through correctly.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is a single, well-scoped null guard that matches an existing utility pattern in the class.

The fix replaces one unsafe `.getTags().stream()` call with `listOrEmpty(query.getTags()).stream()`, which is exactly how every other nullable tag list in the class is handled. The regression test directly reproduces the reported failure path. No behavior changes for the happy path.

No files require special attention.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| openmetadata-service/src/main/java/org/openmetadata/service/security/mask/PIIMasker.java | One-line fix replacing direct `.getTags().stream()` with `listOrEmpty(query.getTags()).stream()` to guard against null tags on Query; change is minimal, correct, and consistent with existing codebase patterns. |
| openmetadata-service/src/test/java/org/openmetadata/service/security/mask/PIIMaskerTest.java | Adds a focused regression test covering the null-tags NPE path for unauthorized users; test setup, assertions, and mocking are appropriate. |

</details>


</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `openmetadata-service/src/main/java/org/openmetadata/service/security/mask/PIIMasker.java`, line 312-344 ([link](https://github.com/open-metadata/openmetadata/blob/726d963820d311100f829bee556fbe7f4a5a3975/openmetadata-service/src/main/java/org/openmetadata/service/security/mask/PIIMasker.java#L312-L344)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Same null-tags NPE risk in `Table`, `SearchIndex`, and `Topic` overloads**

   `hasPiiSensitiveTag(Table)` (line 313), `hasPiiSensitiveTag(SearchIndex)` (line 324), and `hasPiiSensitiveTag(Topic)` (line 333) all call `.getTags().stream()` without a null guard. If any API path retrieves those entities without the `tags` field (just as `GET /queries?fields=queryUsedIn` reproduced the original bug), the identical NPE will surface. Notably, `hasPiiSensitiveTag(Container)` already has the null check at line 317, confirming the pattern has been hit before — it just wasn't applied consistently.
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (3): Last reviewed commit: ["Apply spotless formatting"](https://github.com/open-metadata/openmetadata/commit/74fb7830d30b062bcd4c5fb4adad24718dbcb3b7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38813187)</sub>

<!-- /greptile_comment -->