### PR TITLE
fix: normalize legacy recognizer feedback review payloads

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/TaskRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/TaskRepository.java
@@ -24,6 +24,9 @@ import static org.openmetadata.service.governance.workflows.Workflow.UPDATED_BY_
 import static org.openmetadata.service.governance.workflows.WorkflowVariableHandler.getNamespacedVariableName;
 import static org.openmetadata.service.governance.workflows.elements.TriggerFactory.getTriggerWorkflowId;
 
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import jakarta.json.JsonPatch;
 import jakarta.ws.rs.core.SecurityContext;
 import jakarta.ws.rs.core.UriInfo;
@@ -273,6 +276,7 @@ public class TaskRepository extends EntityRepository<Task> {
 
   @Override
   public void setFields(Task task, Fields fields, RelationIncludes relationIncludes) {
+    normalizeDataQualityReviewPayload(task);
     task.setAssignees(fields.contains(FIELD_ASSIGNEES) ? getAssignees(task) : task.getAssignees());
     task.setReviewers(
         fields.contains(FIELD_REVIEWERS) ? getTaskReviewers(task) : task.getReviewers());
@@ -282,6 +286,46 @@ public class TaskRepository extends EntityRepository<Task> {
     task.setComments(fields.contains(FIELD_COMMENTS) ? getComments(task) : task.getComments());
     task.setCreatedBy(
         fields.contains(FIELD_CREATED_BY) ? getTaskCreatedBy(task) : task.getCreatedBy());
+  }
+
+  private void normalizeDataQualityReviewPayload(Task task) {
+    if (task == null || task.getType() != TaskEntityType.DataQualityReview) {
+      return;
+    }
+
+    Object payload = task.getPayload();
+    if (payload == null) {
+      return;
+    }
+
+    JsonNode payloadNode = JsonUtils.valueToTree(payload);
+    if (!payloadNode.isObject()) {
+      return;
+    }
+
+    ObjectNode normalizedPayload = ((ObjectNode) payloadNode).deepCopy();
+    boolean updated = false;
+
+    if (!normalizedPayload.has("feedback")
+        && normalizedPayload.has("data")
+        && !normalizedPayload.get("data").isNull()) {
+      normalizedPayload.set("feedback", normalizedPayload.get("data"));
+      updated = true;
+    }
+
+    JsonNode metadataNode = normalizedPayload.get("metadata");
+    if (!normalizedPayload.has("recognizer")
+        && metadataNode != null
+        && metadataNode.has("recognizer")
+        && !metadataNode.get("recognizer").isNull()) {
+      normalizedPayload.set("recognizer", metadataNode.get("recognizer"));
+      updated = true;
+    }
+
+    if (updated) {
+      task.setPayload(
+          JsonUtils.convertValue(normalizedPayload, new TypeReference<Map<String, Object>>() {}));
+    }
   }
 
   @Override

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/TaskRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/TaskRepository.java
@@ -24,7 +24,6 @@ import static org.openmetadata.service.governance.workflows.Workflow.UPDATED_BY_
 import static org.openmetadata.service.governance.workflows.WorkflowVariableHandler.getNamespacedVariableName;
 import static org.openmetadata.service.governance.workflows.elements.TriggerFactory.getTriggerWorkflowId;
 
-import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import jakarta.json.JsonPatch;
@@ -78,6 +77,7 @@ import org.openmetadata.service.security.policyevaluator.TestCaseResourceContext
 import org.openmetadata.service.tasks.TaskFieldValidator;
 import org.openmetadata.service.tasks.TaskFormExecutionResolver;
 import org.openmetadata.service.tasks.TaskIdGenerator;
+import org.openmetadata.service.tasks.RecognizerFeedbackTaskPayloadKeys;
 import org.openmetadata.service.tasks.TaskWorkflowHandler;
 import org.openmetadata.service.tasks.TaskWorkflowLifecycleResolver;
 import org.openmetadata.service.util.EntityUtil;
@@ -303,28 +303,31 @@ public class TaskRepository extends EntityRepository<Task> {
       return;
     }
 
-    ObjectNode normalizedPayload = ((ObjectNode) payloadNode).deepCopy();
+    ObjectNode normalizedPayload = (ObjectNode) payloadNode;
     boolean updated = false;
 
-    if (!normalizedPayload.has("feedback")
-        && normalizedPayload.has("data")
-        && !normalizedPayload.get("data").isNull()) {
-      normalizedPayload.set("feedback", normalizedPayload.get("data"));
+    if (!normalizedPayload.has(RecognizerFeedbackTaskPayloadKeys.FEEDBACK)
+        && normalizedPayload.has(RecognizerFeedbackTaskPayloadKeys.LEGACY_DATA)
+        && !normalizedPayload.get(RecognizerFeedbackTaskPayloadKeys.LEGACY_DATA).isNull()) {
+      normalizedPayload.set(
+          RecognizerFeedbackTaskPayloadKeys.FEEDBACK,
+          normalizedPayload.get(RecognizerFeedbackTaskPayloadKeys.LEGACY_DATA));
       updated = true;
     }
 
-    JsonNode metadataNode = normalizedPayload.get("metadata");
-    if (!normalizedPayload.has("recognizer")
+    JsonNode metadataNode = normalizedPayload.get(RecognizerFeedbackTaskPayloadKeys.METADATA);
+    if (!normalizedPayload.has(RecognizerFeedbackTaskPayloadKeys.RECOGNIZER)
         && metadataNode != null
-        && metadataNode.has("recognizer")
-        && !metadataNode.get("recognizer").isNull()) {
-      normalizedPayload.set("recognizer", metadataNode.get("recognizer"));
+        && metadataNode.has(RecognizerFeedbackTaskPayloadKeys.RECOGNIZER)
+        && !metadataNode.get(RecognizerFeedbackTaskPayloadKeys.RECOGNIZER).isNull()) {
+      normalizedPayload.set(
+          RecognizerFeedbackTaskPayloadKeys.RECOGNIZER,
+          metadataNode.get(RecognizerFeedbackTaskPayloadKeys.RECOGNIZER));
       updated = true;
     }
 
     if (updated) {
-      task.setPayload(
-          JsonUtils.convertValue(normalizedPayload, new TypeReference<Map<String, Object>>() {}));
+      task.setPayload(JsonUtils.convertValue(normalizedPayload, Map.class));
     }
   }
 

--- a/openmetadata-service/src/main/java/org/openmetadata/service/migration/utils/v200/MigrationUtil.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/migration/utils/v200/MigrationUtil.java
@@ -36,6 +36,7 @@ import org.openmetadata.service.jdbi3.PolicyRepository;
 import org.openmetadata.service.jdbi3.RoleRepository;
 import org.openmetadata.service.jdbi3.locator.ConnectionType;
 import org.openmetadata.service.resources.feeds.MessageParser;
+import org.openmetadata.service.tasks.RecognizerFeedbackTaskPayloadKeys;
 import org.openmetadata.service.util.EntityUtil;
 import org.openmetadata.service.util.FullyQualifiedName;
 
@@ -838,18 +839,26 @@ public class MigrationUtil {
       }
       case "RecognizerFeedbackApproval" -> {
         ObjectNode payload = JsonUtils.getObjectNode();
-        if (taskDetails.has("feedback") && !taskDetails.get("feedback").isNull()) {
-          payload.set("feedback", taskDetails.get("feedback"));
+        if (taskDetails.has(RecognizerFeedbackTaskPayloadKeys.FEEDBACK)
+            && !taskDetails.get(RecognizerFeedbackTaskPayloadKeys.FEEDBACK).isNull()) {
+          payload.set(
+              RecognizerFeedbackTaskPayloadKeys.FEEDBACK,
+              taskDetails.get(RecognizerFeedbackTaskPayloadKeys.FEEDBACK));
         }
-        if (taskDetails.has("recognizer") && !taskDetails.get("recognizer").isNull()) {
-          payload.set("recognizer", taskDetails.get("recognizer"));
+        if (taskDetails.has(RecognizerFeedbackTaskPayloadKeys.RECOGNIZER)
+            && !taskDetails.get(RecognizerFeedbackTaskPayloadKeys.RECOGNIZER).isNull()) {
+          payload.set(
+              RecognizerFeedbackTaskPayloadKeys.RECOGNIZER,
+              taskDetails.get(RecognizerFeedbackTaskPayloadKeys.RECOGNIZER));
         }
         yield payload;
       }
       case "Generic" -> {
         ObjectNode payload = JsonUtils.getObjectNode();
         if (taskDetails.has("suggestion") && !taskDetails.get("suggestion").isNull()) {
-          payload.put("data", taskDetails.get("suggestion").asText());
+          payload.put(
+              RecognizerFeedbackTaskPayloadKeys.LEGACY_DATA,
+              taskDetails.get("suggestion").asText());
         }
         yield payload;
       }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/migration/utils/v200/MigrationUtil.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/migration/utils/v200/MigrationUtil.java
@@ -839,12 +839,10 @@ public class MigrationUtil {
       case "RecognizerFeedbackApproval" -> {
         ObjectNode payload = JsonUtils.getObjectNode();
         if (taskDetails.has("feedback") && !taskDetails.get("feedback").isNull()) {
-          payload.set("data", taskDetails.get("feedback"));
+          payload.set("feedback", taskDetails.get("feedback"));
         }
         if (taskDetails.has("recognizer") && !taskDetails.get("recognizer").isNull()) {
-          ObjectNode metadata = JsonUtils.getObjectNode();
-          metadata.set("recognizer", taskDetails.get("recognizer"));
-          payload.set("metadata", metadata);
+          payload.set("recognizer", taskDetails.get("recognizer"));
         }
         yield payload;
       }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/migration/utils/v200/MigrationUtil.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/migration/utils/v200/MigrationUtil.java
@@ -47,6 +47,7 @@ public class MigrationUtil {
   private static final String DATA_CONSUMER_POLICY = "DataConsumerPolicy";
   private static final String TASK_AUTHOR_POLICY = "TaskAuthorPolicy";
   private static final String CREATE_TASK_RULE_NAME = "DataConsumerPolicy-CreateTask-Rule";
+  private static final String GENERIC_DATA_KEY = "data";
 
   /**
    * Per-migration cache of {@code (entityType, entityId) -> resolved domains}. Many migrated tasks
@@ -856,9 +857,7 @@ public class MigrationUtil {
       case "Generic" -> {
         ObjectNode payload = JsonUtils.getObjectNode();
         if (taskDetails.has("suggestion") && !taskDetails.get("suggestion").isNull()) {
-          payload.put(
-              RecognizerFeedbackTaskPayloadKeys.LEGACY_DATA,
-              taskDetails.get("suggestion").asText());
+          payload.put(GENERIC_DATA_KEY, taskDetails.get("suggestion").asText());
         }
         yield payload;
       }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/tasks/RecognizerFeedbackTaskPayloadKeys.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/tasks/RecognizerFeedbackTaskPayloadKeys.java
@@ -1,0 +1,25 @@
+/*
+ *  Copyright 2026 Collate
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.openmetadata.service.tasks;
+
+public final class RecognizerFeedbackTaskPayloadKeys {
+
+  public static final String FEEDBACK = "feedback";
+  public static final String LEGACY_DATA = "data";
+  public static final String RECOGNIZER = "recognizer";
+  public static final String METADATA = "metadata";
+
+  private RecognizerFeedbackTaskPayloadKeys() {}
+}

--- a/openmetadata-service/src/main/java/org/openmetadata/service/tasks/TaskFormExecutionResolver.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/tasks/TaskFormExecutionResolver.java
@@ -14,6 +14,7 @@
 
 package org.openmetadata.service.tasks;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import java.util.List;
 import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
@@ -345,7 +346,12 @@ public final class TaskFormExecutionResolver {
   }
 
   private static boolean hasFeedbackPayload(Task task) {
-    return task.getPayload() != null && JsonUtils.valueToTree(task.getPayload()).has("feedback");
+    if (task.getPayload() == null) {
+      return false;
+    }
+
+    JsonNode payload = JsonUtils.valueToTree(task.getPayload());
+    return payload.has("feedback") || payload.has("data");
   }
 
   private static String stringValue(Object value) {

--- a/openmetadata-service/src/main/java/org/openmetadata/service/tasks/TaskFormExecutionResolver.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/tasks/TaskFormExecutionResolver.java
@@ -22,6 +22,7 @@ import org.openmetadata.schema.entity.feed.TaskFormSchema;
 import org.openmetadata.schema.entity.tasks.Task;
 import org.openmetadata.schema.type.MetadataOperation;
 import org.openmetadata.schema.type.TaskCategory;
+import org.openmetadata.schema.type.TaskEntityType;
 import org.openmetadata.schema.utils.JsonUtils;
 import org.openmetadata.service.Entity;
 import org.openmetadata.service.jdbi3.TaskFormSchemaRepository;
@@ -351,7 +352,12 @@ public final class TaskFormExecutionResolver {
     }
 
     JsonNode payload = JsonUtils.valueToTree(task.getPayload());
-    return payload.has("feedback") || payload.has("data");
+    if (payload.has(RecognizerFeedbackTaskPayloadKeys.FEEDBACK)) {
+      return true;
+    }
+
+    return task.getType() == TaskEntityType.DataQualityReview
+        && payload.has(RecognizerFeedbackTaskPayloadKeys.LEGACY_DATA);
   }
 
   private static String stringValue(Object value) {

--- a/openmetadata-service/src/test/java/org/openmetadata/service/jdbi3/TaskRepositoryTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/jdbi3/TaskRepositoryTest.java
@@ -1,0 +1,133 @@
+/*
+ *  Copyright 2026 Collate
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.openmetadata.service.jdbi3;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.openmetadata.schema.entity.tasks.Task;
+import org.openmetadata.schema.type.TaskEntityType;
+import org.openmetadata.schema.utils.JsonUtils;
+import org.openmetadata.service.Entity;
+import org.openmetadata.service.jobs.JobDAO;
+import org.openmetadata.service.search.SearchRepository;
+import org.openmetadata.service.tasks.RecognizerFeedbackTaskPayloadKeys;
+import org.openmetadata.service.util.EntityUtil.Fields;
+import org.openmetadata.service.util.EntityUtil.RelationIncludes;
+
+class TaskRepositoryTest {
+
+  @Test
+  void setFieldsNormalizesLegacyRecognizerFeedbackPayload() {
+    try (MockedStatic<Entity> entityMock = mockStatic(Entity.class)) {
+      TaskRepository repository = createRepository(entityMock);
+      Task task =
+          new Task()
+              .withId(UUID.randomUUID())
+              .withType(TaskEntityType.DataQualityReview)
+              .withPayload(
+                  Map.of(
+                      RecognizerFeedbackTaskPayloadKeys.LEGACY_DATA,
+                      Map.of("feedbackType", "FalsePositive"),
+                      RecognizerFeedbackTaskPayloadKeys.METADATA,
+                      Map.of(RecognizerFeedbackTaskPayloadKeys.RECOGNIZER, Map.of("id", "pii"))));
+
+      repository.setFields(task, Fields.EMPTY_FIELDS, RelationIncludes.fromInclude(null));
+
+      JsonNode payload = JsonUtils.valueToTree(task.getPayload());
+      assertTrue(payload.has(RecognizerFeedbackTaskPayloadKeys.FEEDBACK));
+      assertTrue(payload.has(RecognizerFeedbackTaskPayloadKeys.RECOGNIZER));
+      assertEquals(
+          "FalsePositive",
+          payload.get(RecognizerFeedbackTaskPayloadKeys.FEEDBACK).get("feedbackType").asText());
+      assertEquals(
+          "pii",
+          payload.get(RecognizerFeedbackTaskPayloadKeys.RECOGNIZER).get("id").asText());
+    }
+  }
+
+  @Test
+  void setFieldsLeavesNonObjectPayloadUnchanged() {
+    try (MockedStatic<Entity> entityMock = mockStatic(Entity.class)) {
+      TaskRepository repository = createRepository(entityMock);
+      Task task =
+          new Task().withId(UUID.randomUUID()).withType(TaskEntityType.DataQualityReview).withPayload("legacy");
+
+      repository.setFields(task, Fields.EMPTY_FIELDS, RelationIncludes.fromInclude(null));
+
+      assertEquals("legacy", task.getPayload());
+    }
+  }
+
+  @Test
+  void setFieldsLeavesNonDataQualityReviewPayloadUnchanged() {
+    try (MockedStatic<Entity> entityMock = mockStatic(Entity.class)) {
+      TaskRepository repository = createRepository(entityMock);
+      Task task =
+          new Task()
+              .withId(UUID.randomUUID())
+              .withType(TaskEntityType.PipelineReview)
+              .withPayload(
+                  Map.of(
+                      RecognizerFeedbackTaskPayloadKeys.LEGACY_DATA,
+                      Map.of("feedbackType", "FalsePositive"),
+                      RecognizerFeedbackTaskPayloadKeys.METADATA,
+                      Map.of(RecognizerFeedbackTaskPayloadKeys.RECOGNIZER, Map.of("id", "pii"))));
+
+      repository.setFields(task, Fields.EMPTY_FIELDS, RelationIncludes.fromInclude(null));
+
+      JsonNode payload = JsonUtils.valueToTree(task.getPayload());
+      assertTrue(payload.has(RecognizerFeedbackTaskPayloadKeys.LEGACY_DATA));
+      assertFalse(payload.has(RecognizerFeedbackTaskPayloadKeys.FEEDBACK));
+      assertFalse(payload.has(RecognizerFeedbackTaskPayloadKeys.RECOGNIZER));
+    }
+  }
+
+  private TaskRepository createRepository(MockedStatic<Entity> entityMock) {
+    CollectionDAO dao = mock(CollectionDAO.class);
+    CollectionDAO.TaskDAO taskDAO = mock(CollectionDAO.TaskDAO.class);
+    when(dao.taskDAO()).thenReturn(taskDAO);
+    entityMock.when(Entity::getCollectionDAO).thenReturn(dao);
+    entityMock.when(Entity::getJobDAO).thenReturn(mock(JobDAO.class));
+    entityMock.when(Entity::getSearchRepository).thenReturn(mock(SearchRepository.class));
+    entityMock
+        .when(() -> Entity.getEntityFields(Task.class))
+        .thenReturn(
+            new HashSet<>(
+                Arrays.asList(
+                    TaskRepository.FIELD_ASSIGNEES,
+                    TaskRepository.FIELD_REVIEWERS,
+                    TaskRepository.FIELD_WATCHERS,
+                    TaskRepository.FIELD_ABOUT,
+                    TaskRepository.FIELD_COMMENTS,
+                    TaskRepository.FIELD_RESOLUTION,
+                    TaskRepository.FIELD_CREATED_BY,
+                    TaskRepository.FIELD_PAYLOAD,
+                    Entity.FIELD_DOMAINS)));
+
+    return new TaskRepository();
+  }
+}

--- a/openmetadata-service/src/test/java/org/openmetadata/service/migration/utils/v200/MigrationUtilTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/migration/utils/v200/MigrationUtilTest.java
@@ -353,6 +353,37 @@ class MigrationUtilTest {
   }
 
   @Test
+  void buildThreadTaskPayloadMapsRecognizerFeedbackPayloadToModernKeys() throws Exception {
+    JsonNode taskDetails =
+        JsonUtilsHolder.readTree(
+            """
+            {
+              "feedback": {
+                "feedbackType": "FalsePositive"
+              },
+              "recognizer": {
+                "id": "pii-recognizer"
+              }
+            }
+            """);
+
+    ObjectNode payload =
+        (ObjectNode)
+            invokePrivateStatic(
+                "buildThreadTaskPayload",
+                new Class[] {String.class, JsonNode.class, MessageParser.EntityLink.class},
+                "RecognizerFeedbackApproval",
+                taskDetails,
+                null);
+
+    assertNotNull(payload);
+    assertEquals("FalsePositive", payload.get("feedback").get("feedbackType").asText());
+    assertEquals("pii-recognizer", payload.get("recognizer").get("id").asText());
+    assertNull(payload.get("data"));
+    assertNull(payload.get("metadata"));
+  }
+
+  @Test
   void buildActivityEventFromLegacyThreadMapsDescriptionUpdate() throws Exception {
     UUID threadId = UUID.randomUUID();
     UUID entityId = UUID.randomUUID();

--- a/openmetadata-service/src/test/java/org/openmetadata/service/tasks/TaskFormExecutionResolverTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/tasks/TaskFormExecutionResolverTest.java
@@ -274,6 +274,39 @@ class TaskFormExecutionResolverTest {
   }
 
   @Test
+  void resolveTreatsLegacyReviewFeedbackPayloadAsFeedbackApproval() {
+    Task task =
+        new Task()
+            .withId(UUID.randomUUID())
+            .withType(TaskEntityType.DataQualityReview)
+            .withCategory(TaskCategory.Review)
+            .withPayload(
+                Map.of(
+                    "data",
+                    Map.of("feedbackType", "FalsePositive"),
+                    "metadata",
+                    Map.of("recognizer", "PII")));
+    TaskFormSchemaRepository repository = mock(TaskFormSchemaRepository.class);
+
+    try (MockedStatic<Entity> entityMock = Mockito.mockStatic(Entity.class)) {
+      entityMock
+          .when(() -> Entity.getEntityRepository(Entity.TASK_FORM_SCHEMA))
+          .thenReturn(repository);
+      when(repository.resolve(
+              TaskEntityType.DataQualityReview.value(),
+              TaskCategory.Review.value(),
+              task.getPayload()))
+          .thenReturn(Optional.empty());
+
+      TaskExecutionBinding binding = TaskFormExecutionResolver.resolve(task);
+
+      assertEquals(HandlerType.FEEDBACK_APPROVAL, binding.handlerType());
+      assertEquals(MetadataOperation.EDIT_ALL, binding.permissionOperation());
+      assertNull(binding.fieldPathField());
+    }
+  }
+
+  @Test
   void resolveDisambiguatesSuggestionSchemasUsingPayloadType() {
     Task task =
         new Task()

--- a/openmetadata-service/src/test/java/org/openmetadata/service/tasks/TaskFormExecutionResolverTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/tasks/TaskFormExecutionResolverTest.java
@@ -307,6 +307,31 @@ class TaskFormExecutionResolverTest {
   }
 
   @Test
+  void resolveDoesNotTreatPipelineReviewDataPayloadAsFeedbackApproval() {
+    Task task =
+        new Task()
+            .withId(UUID.randomUUID())
+            .withType(TaskEntityType.PipelineReview)
+            .withCategory(TaskCategory.Review)
+            .withPayload(Map.of("data", Map.of("status", "pending")));
+    TaskFormSchemaRepository repository = mock(TaskFormSchemaRepository.class);
+
+    try (MockedStatic<Entity> entityMock = Mockito.mockStatic(Entity.class)) {
+      entityMock
+          .when(() -> Entity.getEntityRepository(Entity.TASK_FORM_SCHEMA))
+          .thenReturn(repository);
+      when(repository.resolve(
+              TaskEntityType.PipelineReview.value(), TaskCategory.Review.value(), task.getPayload()))
+          .thenReturn(Optional.empty());
+
+      TaskExecutionBinding binding = TaskFormExecutionResolver.resolve(task);
+
+      assertEquals(HandlerType.CUSTOM, binding.handlerType());
+      assertNull(binding.permissionOperation());
+    }
+  }
+
+  @Test
   void resolveDisambiguatesSuggestionSchemasUsingPayloadType() {
     Task task =
         new Task()


### PR DESCRIPTION
### Describe your changes:

Related to #29233

While investigating #29233, I found current integration tests already expect recognizer feedback review tasks to be exposed as `DataQualityReview`, so this PR does not change the public task type.

Instead, it fixes the legacy payload path that still writes and reads recognizer feedback review tasks using `data` and `metadata.recognizer`. Current resolver and UI paths expect `feedback` and `recognizer`.

This change:
- normalizes legacy `DataQualityReview` payloads on read in `TaskRepository`
- treats legacy `data` payloads as feedback approval tasks in `TaskFormExecutionResolver`
- updates the `v200` migration path to emit modern payload keys
- adds regression tests for the resolver and migration behavior

#
### Type of change:
- [x] Bug fix

#
### High-level design:
N/A - small change.

#
### Tests:

#### Use cases covered
- Legacy recognizer feedback review tasks migrated through `v200` continue to resolve as feedback approval tasks.
- New `v200` migrations emit `feedback` and `recognizer` payload keys expected by current task code.

#### Unit tests
- [x] I added unit tests for the new and changed logic.
- Files updated:
  - `openmetadata-service/src/test/java/org/openmetadata/service/tasks/TaskFormExecutionResolverTest.java`
  - `openmetadata-service/src/test/java/org/openmetadata/service/migration/utils/v200/MigrationUtilTest.java`
- Coverage %: not measured locally.

#### Backend integration tests
- [x] Not applicable for this draft fix. Existing `TagRecognizerFeedbackIT` already asserts the current `DataQualityReview` task type expectations.

#### Ingestion integration tests
- [x] Not applicable.

#### Playwright (UI) tests
- [x] Not applicable.

#### Manual testing performed
- Ran `mvn --% -pl openmetadata-service -am -DskipITs -Dtest=TaskFormExecutionResolverTest,MigrationUtilTest -Dsurefire.failIfNoSpecifiedTests=false test`
- The build did not reach the touched tests because current `main` failed in unrelated search and elasticsearch compile paths under `openmetadata-service`.

#
### UI screen recording / screenshots:
Not applicable.

#
### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.
- [ ] For UI changes: I attached a screen recording and/or screenshots above.
- [x] I have added tests (unit / integration / Playwright as applicable) and listed them above.
- [x] I have added a test that covers the exact scenario we are fixing.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a payload key mismatch for legacy `RecognizerFeedbackApproval` tasks that were written using `data`/`metadata.recognizer` keys but are now expected to use `feedback`/`recognizer` by the resolver and UI.

- **Read-side normalization** (`TaskRepository.normalizeDataQualityReviewPayload`): on every `setFields` call for a `DataQualityReview` task, legacy `data` is copied to `feedback` and `metadata.recognizer` is promoted to top-level `recognizer`. The old keys are kept (additive, not replaced).
- **Migration fix** (`MigrationUtil.buildThreadTaskPayload`): the `RecognizerFeedbackApproval` case now emits `feedback`/`recognizer` directly instead of the old `data`/`metadata.recognizer` shape.
- **Resolver fallback** (`TaskFormExecutionResolver.hasFeedbackPayload`): for `DataQualityReview` tasks that bypass `setFields`, the legacy `data` key is also accepted as a feedback payload indicator.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge — the normalization logic is additive and guarded by type checks, so it cannot affect non-DataQualityReview tasks. The migration fix correctly emits modern keys for new migrations.

The read-side normalization copies legacy keys to modern keys but leaves the old `data` and `metadata` keys intact. The serialized payload returned to API clients will contain both old and new keys simultaneously; documenting this intent or adding a strict-replace test would improve long-term clarity.

openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/TaskRepository.java — the intent of leaving legacy keys in the normalized payload should be made explicit.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-service/src/main/java/org/openmetadata/service/tasks/RecognizerFeedbackTaskPayloadKeys.java | New utility class centralizing payload key constants; clean, no issues. |
| openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/TaskRepository.java | Adds read-side normalization for legacy DataQualityReview payloads; normalization is additive (old keys are not removed), leaving mixed-format payloads on the wire after normalization. |
| openmetadata-service/src/main/java/org/openmetadata/service/migration/utils/v200/MigrationUtil.java | Fixes RecognizerFeedbackApproval migration to emit modern feedback/recognizer keys directly; introduces a local GENERIC_DATA_KEY that duplicates RecognizerFeedbackTaskPayloadKeys.LEGACY_DATA. |
| openmetadata-service/src/main/java/org/openmetadata/service/tasks/TaskFormExecutionResolver.java | Adds legacy data-key fallback in hasFeedbackPayload scoped to DataQualityReview tasks; logic is correct and well-guarded. |
| openmetadata-service/src/test/java/org/openmetadata/service/jdbi3/TaskRepositoryTest.java | New unit tests cover normalization, non-object payload guard, and wrong-task-type guard; missing assertion for whether legacy keys are preserved or removed after normalization. |
| openmetadata-service/src/test/java/org/openmetadata/service/migration/utils/v200/MigrationUtilTest.java | New regression test confirms modern keys are emitted and legacy keys are absent in the migration output; correct and thorough. |
| openmetadata-service/src/test/java/org/openmetadata/service/tasks/TaskFormExecutionResolverTest.java | Two new resolver tests verify legacy DataQualityReview payload maps to FEEDBACK_APPROVAL and non-DataQualityReview data payload maps to CUSTOM; covers both the positive and negative cases cleanly. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Task loaded from DB] --> B{Type == DataQualityReview?}
    B -- No --> C[setFields: skip normalization]
    B -- Yes --> D{payload has 'feedback'?}
    D -- Yes --> E[No normalization needed]
    D -- No --> F{payload has 'data'?}
    F -- No --> G[No normalization needed]
    F -- Yes --> H[Copy 'data' to 'feedback' / Promote 'metadata.recognizer' to 'recognizer' / Legacy keys remain]
    H --> I[task.setPayload updated in-memory]
    I --> J[TaskFormExecutionResolver.hasFeedbackPayload]
    E --> J
    C --> J
    J -- feedback key found --> K[FEEDBACK_APPROVAL handler]
    J -- data key + DataQualityReview --> K
    J -- neither --> L[CUSTOM handler]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Task loaded from DB] --> B{Type == DataQualityReview?}
    B -- No --> C[setFields: skip normalization]
    B -- Yes --> D{payload has 'feedback'?}
    D -- Yes --> E[No normalization needed]
    D -- No --> F{payload has 'data'?}
    F -- No --> G[No normalization needed]
    F -- Yes --> H[Copy 'data' to 'feedback' / Promote 'metadata.recognizer' to 'recognizer' / Legacy keys remain]
    H --> I[task.setPayload updated in-memory]
    I --> J[TaskFormExecutionResolver.hasFeedbackPayload]
    E --> J
    C --> J
    J -- feedback key found --> K[FEEDBACK_APPROVAL handler]
    J -- data key + DataQualityReview --> K
    J -- neither --> L[CUSTOM handler]
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix generic payload key"](https://github.com/open-metadata/openmetadata/commit/58dc4bebaf16cbb21eafb3f2998d05ab2cc89ed5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39510758)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->