### PR TITLE
Fixes #29259: Batch Data Quality dashboard report aggregations to fix the N+1

### DIFF
--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/TestSuiteResourceIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/TestSuiteResourceIT.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -40,18 +41,25 @@ import org.openmetadata.schema.entity.services.ingestionPipelines.PipelineStatus
 import org.openmetadata.schema.entity.services.ingestionPipelines.PipelineType;
 import org.openmetadata.schema.metadataIngestion.SourceConfig;
 import org.openmetadata.schema.metadataIngestion.TestSuitePipeline;
+import org.openmetadata.schema.tests.DataQualityReport;
+import org.openmetadata.schema.tests.DataQualityReportBatchRequest;
+import org.openmetadata.schema.tests.DataQualityReportBatchResponse;
 import org.openmetadata.schema.tests.TestCase;
 import org.openmetadata.schema.tests.TestSuite;
+import org.openmetadata.schema.tests.type.DataQualityReportRequest;
+import org.openmetadata.schema.tests.type.DataQualityReportResult;
 import org.openmetadata.schema.tests.type.TestSummary;
 import org.openmetadata.schema.type.Column;
 import org.openmetadata.schema.type.ColumnDataType;
 import org.openmetadata.schema.type.EntityHistory;
 import org.openmetadata.schema.type.EntityReference;
+import org.openmetadata.schema.utils.JsonUtils;
 import org.openmetadata.sdk.client.OpenMetadataClient;
 import org.openmetadata.sdk.fluent.builders.TestCaseBuilder;
 import org.openmetadata.sdk.models.ListParams;
 import org.openmetadata.sdk.models.ListResponse;
 import org.openmetadata.sdk.network.HttpMethod;
+import org.openmetadata.sdk.network.RequestOptions;
 import org.openmetadata.service.resources.dqtests.TestSuiteResource;
 
 /**
@@ -909,8 +917,145 @@ public class TestSuiteResourceIT extends BaseEntityIT<TestSuite, CreateTestSuite
   }
 
   // ===================================================================
+  // DATA QUALITY REPORT BATCH TESTS
+  // ===================================================================
+
+  @Test
+  void test_dataQualityReportBatch_matchesSingleEndpoint(TestNamespace ns) throws Exception {
+    OpenMetadataClient client = SdkClients.adminClient();
+
+    Table table = createTableForBasicTestSuite(ns, "dq_batch_parity");
+    TestSuite testSuite = createBasicTestSuiteForTable(table);
+    List<TestCase> testCases = createTestCases(client, ns, table, 4);
+    recordTestCaseResults(client, testCases, 2, 2);
+
+    String scopedQuery = scopedTestCaseQuery(testSuite.getId());
+    String statusAgg = "bucketName=status:aggType=terms:field=testCaseResult.testCaseStatus";
+    String coverageAgg = "bucketName=entityWithTests:aggType=cardinality:field=originEntityFQN";
+
+    Awaitility.await("test case results indexed for data quality report")
+        .atMost(Duration.ofSeconds(30))
+        .pollInterval(Duration.ofSeconds(2))
+        .ignoreExceptions()
+        .untilAsserted(
+            () ->
+                assertFalse(
+                    getDataQualityReport(scopedQuery, "testCase", statusAgg).getData().isEmpty(),
+                    "Expected status aggregation to return data"));
+
+    DataQualityReportBatchRequest request =
+        new DataQualityReportBatchRequest()
+            .withRequests(
+                List.of(
+                    reportRequest("status", scopedQuery, "testCase", statusAgg),
+                    reportRequest("coverage", scopedQuery, "testCase", coverageAgg)));
+
+    DataQualityReportBatchResponse response = getDataQualityReportBatch(request);
+    Map<String, DataQualityReportResult> byKey = resultsByKey(response);
+
+    assertEquals(2, byKey.size());
+    assertEquals(
+        JsonUtils.pojoToJson(getDataQualityReport(scopedQuery, "testCase", statusAgg)),
+        JsonUtils.pojoToJson(byKey.get("status").getReport()),
+        "Batch status report should match the single endpoint result");
+    assertEquals(
+        JsonUtils.pojoToJson(getDataQualityReport(scopedQuery, "testCase", coverageAgg)),
+        JsonUtils.pojoToJson(byKey.get("coverage").getReport()),
+        "Batch coverage report should match the single endpoint result");
+  }
+
+  @Test
+  void test_dataQualityReportBatch_isolatesPerItemFailures(TestNamespace ns) {
+    Table table = createTableForBasicTestSuite(ns, "dq_batch_isolation");
+    TestSuite testSuite = createBasicTestSuiteForTable(table);
+    String scopedQuery = scopedTestCaseQuery(testSuite.getId());
+    String statusAgg = "bucketName=status:aggType=terms:field=testCaseResult.testCaseStatus";
+
+    DataQualityReportBatchRequest request =
+        new DataQualityReportBatchRequest()
+            .withRequests(
+                List.of(
+                    reportRequest("ok", scopedQuery, "testCase", statusAgg),
+                    reportRequest("bad", scopedQuery, "index_that_does_not_exist", statusAgg)));
+
+    DataQualityReportBatchResponse response = getDataQualityReportBatch(request);
+    Map<String, DataQualityReportResult> byKey = resultsByKey(response);
+
+    assertNotNull(byKey.get("ok").getReport(), "Valid item should return a report");
+    assertNull(byKey.get("bad").getReport(), "Failed item should not return a report");
+    assertNotNull(byKey.get("bad").getError(), "Failed item should carry an error message");
+  }
+
+  @Test
+  void test_dataQualityReportBatch_validation_400(TestNamespace ns) {
+    assertThrows(
+        Exception.class,
+        () ->
+            getDataQualityReportBatch(new DataQualityReportBatchRequest().withRequests(List.of())),
+        "Empty batch should be rejected");
+
+    DataQualityReportBatchRequest missingAggregation =
+        new DataQualityReportBatchRequest()
+            .withRequests(
+                List.of(new DataQualityReportRequest().withKey("k").withIndex("testCase")));
+    assertThrows(
+        Exception.class,
+        () -> getDataQualityReportBatch(missingAggregation),
+        "Batch item without aggregationQuery should be rejected");
+  }
+
+  // ===================================================================
   // HELPER METHODS
   // ===================================================================
+
+  private String scopedTestCaseQuery(UUID testSuiteId) {
+    return """
+        {"query":{"bool":{"must":[{"term":{"testSuite.id":"%s"}},{"term":{"deleted":false}}]}}}"""
+        .formatted(testSuiteId);
+  }
+
+  private DataQualityReportRequest reportRequest(
+      String key, String q, String index, String aggregationQuery) {
+    return new DataQualityReportRequest()
+        .withKey(key)
+        .withQ(q)
+        .withIndex(index)
+        .withAggregationQuery(aggregationQuery);
+  }
+
+  private Map<String, DataQualityReportResult> resultsByKey(
+      DataQualityReportBatchResponse response) {
+    return response.getResults().stream()
+        .collect(Collectors.toMap(DataQualityReportResult::getKey, result -> result));
+  }
+
+  private DataQualityReport getDataQualityReport(String q, String index, String aggregationQuery) {
+    RequestOptions options =
+        RequestOptions.builder()
+            .queryParam("q", q)
+            .queryParam("index", index)
+            .queryParam("aggregationQuery", aggregationQuery)
+            .build();
+    return SdkClients.adminClient()
+        .getHttpClient()
+        .execute(
+            HttpMethod.GET,
+            "/v1/dataQuality/testSuites/dataQualityReport",
+            null,
+            DataQualityReport.class,
+            options);
+  }
+
+  private DataQualityReportBatchResponse getDataQualityReportBatch(
+      DataQualityReportBatchRequest request) {
+    return SdkClients.adminClient()
+        .getHttpClient()
+        .execute(
+            HttpMethod.POST,
+            "/v1/dataQuality/testSuites/dataQualityReport/batch",
+            request,
+            DataQualityReportBatchResponse.class);
+  }
 
   private Table createTableForBasicTestSuite(TestNamespace ns, String suffix) {
     OpenMetadataClient client = SdkClients.adminClient();

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/TestSuiteRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/TestSuiteRepository.java
@@ -95,6 +95,7 @@ public class TestSuiteRepository extends EntityRepository<TestSuite> {
   public static final String SUMMARY_FIELD = "summary";
   private static final String UPDATE_FIELDS = "tests";
   private static final String PATCH_FIELDS = "tests";
+  private static final int MAX_CONCURRENT_REPORT_QUERIES = 10;
 
   private static final String ENTITY_EXECUTION_SUMMARY_FILTER =
       """
@@ -389,7 +390,8 @@ public class TestSuiteRepository extends EntityRepository<TestSuite> {
   private List<DataQualityReportResult> runReportsConcurrently(
       List<DataQualityReportRequest> requests, SubjectContext subjectContext) {
     Queue<DataQualityReportResult> results = new ConcurrentLinkedQueue<>();
-    try (ExecutorService executor = Executors.newVirtualThreadPerTaskExecutor()) {
+    int concurrency = Math.min(requests.size(), MAX_CONCURRENT_REPORT_QUERIES);
+    try (ExecutorService executor = Executors.newFixedThreadPool(concurrency)) {
       for (DataQualityReportRequest item : requests) {
         executor.submit(() -> results.add(runSingleReport(item, subjectContext)));
       }
@@ -411,7 +413,7 @@ public class TestSuiteRepository extends EntityRepository<TestSuite> {
       result.withReport(report);
     } catch (IOException | RuntimeException e) {
       LOG.error("Failed to compute data quality report for key '{}'", item.getKey(), e);
-      result.withError(e.getMessage());
+      result.withError(e.getMessage() != null ? e.getMessage() : e.getClass().getSimpleName());
     }
     return result;
   }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/TestSuiteRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/TestSuiteRepository.java
@@ -33,9 +33,12 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Queue;
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 import org.jdbi.v3.sqlobject.transaction.Transaction;
@@ -45,10 +48,14 @@ import org.openmetadata.schema.entity.services.ingestionPipelines.IngestionPipel
 import org.openmetadata.schema.entity.services.ingestionPipelines.PipelineStatusType;
 import org.openmetadata.schema.entity.services.ingestionPipelines.PipelineType;
 import org.openmetadata.schema.tests.DataQualityReport;
+import org.openmetadata.schema.tests.DataQualityReportBatchRequest;
+import org.openmetadata.schema.tests.DataQualityReportBatchResponse;
 import org.openmetadata.schema.tests.ResultSummary;
 import org.openmetadata.schema.tests.TestCase;
 import org.openmetadata.schema.tests.TestSuite;
 import org.openmetadata.schema.tests.type.ColumnTestSummaryDefinition;
+import org.openmetadata.schema.tests.type.DataQualityReportRequest;
+import org.openmetadata.schema.tests.type.DataQualityReportResult;
 import org.openmetadata.schema.tests.type.TestSummary;
 import org.openmetadata.schema.type.ChangeDescription;
 import org.openmetadata.schema.type.ChangeEvent;
@@ -370,6 +377,43 @@ public class TestSuiteRepository extends EntityRepository<TestSuite> {
     SearchAggregation searchAggregation = SearchIndexUtils.buildAggregationTree(aggQuery);
     return searchRepository.genericAggregation(
         queryWithDomain, index, searchAggregation, subjectContext);
+  }
+
+  public DataQualityReportBatchResponse getDataQualityReportBatch(
+      DataQualityReportBatchRequest request, SubjectContext subjectContext) {
+    List<DataQualityReportResult> results =
+        runReportsConcurrently(request.getRequests(), subjectContext);
+    return new DataQualityReportBatchResponse().withResults(results);
+  }
+
+  private List<DataQualityReportResult> runReportsConcurrently(
+      List<DataQualityReportRequest> requests, SubjectContext subjectContext) {
+    Queue<DataQualityReportResult> results = new ConcurrentLinkedQueue<>();
+    try (ExecutorService executor = Executors.newVirtualThreadPerTaskExecutor()) {
+      for (DataQualityReportRequest item : requests) {
+        executor.submit(() -> results.add(runSingleReport(item, subjectContext)));
+      }
+    }
+    return new ArrayList<>(results);
+  }
+
+  private DataQualityReportResult runSingleReport(
+      DataQualityReportRequest item, SubjectContext subjectContext) {
+    DataQualityReportResult result = new DataQualityReportResult().withKey(item.getKey());
+    try {
+      DataQualityReport report =
+          getDataQualityReport(
+              item.getQ(),
+              item.getAggregationQuery(),
+              item.getIndex(),
+              item.getDomain(),
+              subjectContext);
+      result.withReport(report);
+    } catch (IOException | RuntimeException e) {
+      LOG.error("Failed to compute data quality report for key '{}'", item.getKey(), e);
+      result.withError(e.getMessage());
+    }
+    return result;
   }
 
   private String addDomainFilter(String query, String domain, String index) {

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/dqtests/TestSuiteResource.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/dqtests/TestSuiteResource.java
@@ -42,7 +42,10 @@ import org.openmetadata.schema.EntityInterface;
 import org.openmetadata.schema.api.data.RestoreEntity;
 import org.openmetadata.schema.api.tests.CreateTestSuite;
 import org.openmetadata.schema.tests.DataQualityReport;
+import org.openmetadata.schema.tests.DataQualityReportBatchRequest;
+import org.openmetadata.schema.tests.DataQualityReportBatchResponse;
 import org.openmetadata.schema.tests.TestSuite;
+import org.openmetadata.schema.tests.type.DataQualityReportRequest;
 import org.openmetadata.schema.tests.type.TestSummary;
 import org.openmetadata.schema.type.EntityHistory;
 import org.openmetadata.schema.type.EntityReference;
@@ -88,6 +91,7 @@ public class TestSuiteResource extends EntityResource<TestSuite, TestSuiteReposi
 
   static final String FIELDS = "owners,reviewers,tests,summary";
   static final String SEARCH_FIELDS_EXCLUDE = "table,database,databaseSchema,service";
+  private static final int MAX_DATA_QUALITY_REPORT_BATCH_SIZE = 50;
 
   public TestSuiteResource(Authorizer authorizer, Limits limits) {
     super(Entity.TEST_SUITE, authorizer, limits);
@@ -544,6 +548,58 @@ public class TestSuiteResource extends EntityResource<TestSuite, TestSuiteReposi
     }
     SubjectContext subjectContext = getSubjectContext(securityContext);
     return repository.getDataQualityReport(query, aggregationQuery, index, domain, subjectContext);
+  }
+
+  @POST
+  @Path("/dataQualityReport/batch")
+  @Operation(
+      operationId = "getDataQualityReportBatch",
+      summary = "Run a batch of Data Quality Reports",
+      description =
+          """
+            Run multiple data quality report aggregations in a single request. Each item is executed
+            concurrently on the server and the results are returned keyed by the request `key`. Use
+            this to avoid N+1 round trips when a dashboard needs many aggregations at once. A failure
+            in one item does not fail the batch; that item's result carries an `error` instead of a `report`.
+            """,
+      responses = {
+        @ApiResponse(
+            responseCode = "200",
+            description = "Data Quality Report batch results",
+            content =
+                @Content(
+                    mediaType = "application/json",
+                    schema = @Schema(implementation = DataQualityReportBatchResponse.class)))
+      })
+  public DataQualityReportBatchResponse getDataQualityReportBatch(
+      @Context SecurityContext securityContext, @Valid DataQualityReportBatchRequest request) {
+    List<AuthRequest> authRequests = getAuthRequestsForListOps();
+    authorizer.authorizeRequests(securityContext, authRequests, AuthorizationLogic.ANY);
+    validateDataQualityReportBatch(request);
+    SubjectContext subjectContext = getSubjectContext(securityContext);
+    return repository.getDataQualityReportBatch(request, subjectContext);
+  }
+
+  private void validateDataQualityReportBatch(DataQualityReportBatchRequest request) {
+    List<DataQualityReportRequest> requests = request.getRequests();
+    if (nullOrEmpty(requests)) {
+      throw new IllegalArgumentException("requests must contain at least one item");
+    }
+    if (requests.size() > MAX_DATA_QUALITY_REPORT_BATCH_SIZE) {
+      throw new IllegalArgumentException(
+          String.format(
+              "requests cannot exceed %d items per batch", MAX_DATA_QUALITY_REPORT_BATCH_SIZE));
+    }
+    requests.forEach(this::validateDataQualityReportRequestItem);
+  }
+
+  private void validateDataQualityReportRequestItem(DataQualityReportRequest item) {
+    if (nullOrEmpty(item.getKey())
+        || nullOrEmpty(item.getAggregationQuery())
+        || nullOrEmpty(item.getIndex())) {
+      throw new IllegalArgumentException(
+          "key, aggregationQuery and index are required for each batch item");
+    }
   }
 
   @POST

--- a/openmetadata-spec/src/main/resources/json/schema/tests/dataQualityReportBatchRequest.json
+++ b/openmetadata-spec/src/main/resources/json/schema/tests/dataQualityReportBatchRequest.json
@@ -1,0 +1,50 @@
+{
+  "$id": "https://open-metadata.org/schema/tests/dataQualityReportBatchRequest.json",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "DataQualityReportBatchRequest",
+  "description": "Request to run multiple data quality report aggregations in a single call.",
+  "type": "object",
+  "javaType": "org.openmetadata.schema.tests.DataQualityReportBatchRequest",
+  "definitions": {
+    "dataQualityReportRequest": {
+      "description": "A single data quality report aggregation to execute as part of a batch.",
+      "javaType": "org.openmetadata.schema.tests.type.DataQualityReportRequest",
+      "type": "object",
+      "properties": {
+        "key": {
+          "description": "Client provided key used to correlate this request with its result in the response.",
+          "type": "string"
+        },
+        "q": {
+          "description": "Search query to filter the aggregation results.",
+          "type": "string"
+        },
+        "index": {
+          "description": "Index to perform the aggregation against.",
+          "type": "string"
+        },
+        "aggregationQuery": {
+          "description": "Aggregation query to perform aggregation on the search results.",
+          "type": "string"
+        },
+        "domain": {
+          "description": "Filter by domain fully qualified name.",
+          "type": "string"
+        }
+      },
+      "required": ["key", "index", "aggregationQuery"],
+      "additionalProperties": false
+    }
+  },
+  "properties": {
+    "requests": {
+      "description": "List of data quality report aggregations to execute concurrently.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/dataQualityReportRequest"
+      }
+    }
+  },
+  "required": ["requests"],
+  "additionalProperties": false
+}

--- a/openmetadata-spec/src/main/resources/json/schema/tests/dataQualityReportBatchResponse.json
+++ b/openmetadata-spec/src/main/resources/json/schema/tests/dataQualityReportBatchResponse.json
@@ -1,0 +1,42 @@
+{
+  "$id": "https://open-metadata.org/schema/tests/dataQualityReportBatchResponse.json",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "DataQualityReportBatchResponse",
+  "description": "Response containing the results for a batch of data quality report aggregations.",
+  "type": "object",
+  "javaType": "org.openmetadata.schema.tests.DataQualityReportBatchResponse",
+  "definitions": {
+    "dataQualityReportResult": {
+      "description": "Result for a single data quality report request in a batch.",
+      "javaType": "org.openmetadata.schema.tests.type.DataQualityReportResult",
+      "type": "object",
+      "properties": {
+        "key": {
+          "description": "Key used to correlate this result with its originating request.",
+          "type": "string"
+        },
+        "report": {
+          "description": "Aggregation result. Present when the request succeeded.",
+          "$ref": "dataQualityReport.json"
+        },
+        "error": {
+          "description": "Error message. Present when the request failed.",
+          "type": "string"
+        }
+      },
+      "required": ["key"],
+      "additionalProperties": false
+    }
+  },
+  "properties": {
+    "results": {
+      "description": "Results for each request. Match to requests by key; order is not guaranteed.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/dataQualityReportResult"
+      }
+    }
+  },
+  "required": ["results"],
+  "additionalProperties": false
+}

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DataQuality/CertificationFilter.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DataQuality/CertificationFilter.spec.ts
@@ -17,6 +17,7 @@ import { createNewPage } from '../../../utils/common';
 import {
   captureReports,
   goToDataQualityDashboard,
+  isDashboardReportBatchResponse,
 } from '../../../utils/dataQuality';
 import { waitForAllLoadersToDisappear } from '../../../utils/entity';
 
@@ -111,23 +112,14 @@ test('Certification filter narrows both table- and testCase-index queries via th
     .fill(cert.responseData.fullyQualifiedName);
   await page.getByTestId(cert.responseData.fullyQualifiedName).click();
 
-  const certFqnEncoded = encodeURIComponent(
-    cert.responseData.fullyQualifiedName
-  );
-  const tableReload = page.waitForResponse(
-    (r) =>
-      r.url().includes('/dataQualityReport') &&
-      r.url().includes('index=table') &&
-      r.url().includes(certFqnEncoded)
-  );
-  const testCaseReload = page.waitForResponse(
-    (r) =>
-      r.url().includes('/dataQualityReport') &&
-      r.url().includes('index=testCase') &&
-      r.url().includes(certFqnEncoded)
+  const reportReload = page.waitForResponse((res) =>
+    isDashboardReportBatchResponse(res, cert.responseData.fullyQualifiedName)
   );
   await page.getByTestId('update-btn').click();
-  await Promise.all([tableReload, testCaseReload]);
+  await reportReload;
+  // Wait for every widget (incl. the table-index coverage widget) to finish so
+  // all batched requests are captured before asserting on them.
+  await waitForAllLoadersToDisappear(page);
 
   const reportsWithCertFilter = captured.filter((c) =>
     c.q.includes(cert.responseData.fullyQualifiedName)
@@ -185,9 +177,8 @@ test('TagPage: Certification detail page routes through certification.tagLabel.t
   const certFqn = cert.responseData.fullyQualifiedName;
   const certFqnEncoded = encodeURIComponent(certFqn);
 
-  const reloadFired = page.waitForResponse(
-    (r) =>
-      r.url().includes('/dataQualityReport') && r.url().includes(certFqnEncoded)
+  const reloadFired = page.waitForResponse((res) =>
+    isDashboardReportBatchResponse(res, certFqn)
   );
   await page.goto(`/tag/${certFqnEncoded}/data_observability`);
   await reloadFired;

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DataQuality/DataObservabilityGovernanceTab.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DataQuality/DataObservabilityGovernanceTab.spec.ts
@@ -24,6 +24,7 @@ import {
   DATA_ASSETS_COVERAGE_PIE_CHART_TEST_ID,
   ENTITY_HEALTH_PIE_CHART_TEST_ID,
   goToDataQualityDashboard,
+  isDashboardReportBatchResponse,
   TEST_CASE_STATUS_PIE_CHART_TEST_ID,
 } from '../../../utils/dataQuality';
 import { waitForAllLoadersToDisappear } from '../../../utils/entity';
@@ -49,10 +50,8 @@ const testCaseResult = {
  * API call containing the given filter key.
  */
 const watchDashboardResponse = (page: Page, filterKey: string) =>
-  page.waitForResponse(
-    (r) =>
-      r.url().includes('/api/v1/dataQuality/testSuites/dataQualityReport') &&
-      r.url().includes(filterKey)
+  page.waitForResponse((res) =>
+    isDashboardReportBatchResponse(res, decodeURIComponent(filterKey))
   );
 
 test.beforeAll('setup', async ({ browser }) => {
@@ -188,7 +187,9 @@ test.describe('Tag detail page — Data Observability tab', () => {
       await page.getByRole('tab', { name: /data observability/i }).click();
       const response = await apiResponse;
       expect(response.ok()).toBeTruthy();
-      expect(response.url()).toContain(filterKey);
+      expect(
+        isDashboardReportBatchResponse(response, decodeURIComponent(filterKey))
+      ).toBeTruthy();
     });
   });
 
@@ -278,12 +279,12 @@ test.describe('GlossaryTerm detail page — Data Observability tab', () => {
   });
 
   test('DQ dashboard API carries glossaryTerms filter', async ({ page }) => {
-    const capturedDqUrls: string[] = [];
-    page.on('response', (r) => {
+    const capturedDqBodies: string[] = [];
+    page.on('request', (req) => {
       if (
-        r.url().includes('/api/v1/dataQuality/testSuites/dataQualityReport')
+        req.url().includes('/dataQuality/testSuites/dataQualityReport/batch')
       ) {
-        capturedDqUrls.push(r.url());
+        capturedDqBodies.push(req.postData() ?? '');
       }
     });
 
@@ -300,12 +301,10 @@ test.describe('GlossaryTerm detail page — Data Observability tab', () => {
 
     await test.step('DQ API carries glossaryTerms as tags filter', async () => {
       await expect
-        .poll(() => capturedDqUrls.length, { timeout: 30000 })
+        .poll(() => capturedDqBodies.length, { timeout: 30000 })
         .toBeGreaterThan(0);
       expect(
-        capturedDqUrls.some((url) =>
-          decodeURIComponent(url).includes('tags.tagFQN')
-        )
+        capturedDqBodies.some((body) => body.includes('tags.tagFQN'))
       ).toBeTruthy();
     });
   });
@@ -420,7 +419,9 @@ test.describe('Domain detail page — Data Observability tab', () => {
     await test.step('DQ API response carries domainFqn filter', async () => {
       const response = await apiResponse;
       expect(response.ok()).toBeTruthy();
-      expect(response.url()).toContain(filterKey);
+      expect(
+        isDashboardReportBatchResponse(response, decodeURIComponent(filterKey))
+      ).toBeTruthy();
     });
   });
 
@@ -531,12 +532,8 @@ test.describe('Standalone DQ Dashboard — regression', () => {
     });
 
     await test.step('applying tag filter returns successful DQ API responses', async () => {
-      const apiResponse = page.waitForResponse(
-        (r) =>
-          r
-            .url()
-            .includes('/api/v1/dataQuality/testSuites/dataQualityReport') &&
-          r.url().includes('tags.tagFQN')
+      const apiResponse = page.waitForResponse((res) =>
+        isDashboardReportBatchResponse(res, 'tags.tagFQN')
       );
       await page.getByTestId('update-btn').click();
       expect((await apiResponse).ok()).toBeTruthy();

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DataQuality/DataQualityDashboard.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DataQuality/DataQualityDashboard.spec.ts
@@ -36,6 +36,7 @@ import {
   DATA_ASSETS_COVERAGE_PIE_CHART_TEST_ID,
   ENTITY_HEALTH_PIE_CHART_TEST_ID,
   goToDataQualityDashboard,
+  isDashboardReportBatchResponse,
   TEST_CASE_STATUS_PIE_CHART_TEST_ID,
   waitForIncidentToBeIndexed,
 } from '../../../utils/dataQuality';
@@ -411,63 +412,11 @@ test.describe(
       await afterAction();
     });
 
-    const waitForDashboardApiResponses = (page: Page, key: string) => {
-      const testCaseStatusResponse = page.waitForResponse(
-        `/api/v1/dataQuality/testSuites/dataQualityReport?q=*${key}*&index=testCase&aggregationQuery=bucketName%3Dstatus%3AaggType%3Dterms%3Afield%3DtestCaseResult.testCaseStatus`
-      );
-      const unhealthyEntityResponse = page.waitForResponse(
-        `/api/v1/dataQuality/testSuites/dataQualityReport?q=*${key}*&index=testCase&aggregationQuery=bucketName%3DentityWithTests%3AaggType%3Dcardinality%3Afield%3DoriginEntityFQN`
-      );
-      const totalCoveredEntityResponse = page.waitForResponse(
-        `/api/v1/dataQuality/testSuites/dataQualityReport?q=*${key}*&index=testCase&aggregationQuery=bucketName%3DentityWithTests%3AaggType%3Dcardinality%3Afield%3DoriginEntityFQN`
-      );
-      const totalTestCaseResponse = page.waitForResponse(
-        `/api/v1/dataQuality/testSuites/dataQualityReport?q=*${key}*&index=testCase&aggregationQuery=bucketName%3Ddimension%3AaggType%3Dterms%3Afield%3DdataQualityDimension%2CbucketName%3Dstatus%3AaggType%3Dterms%3Afield%3DtestCaseResult.testCaseStatus`
-      );
-      const successStatusResponse = page.waitForResponse(
-        `/api/v1/dataQuality/testSuites/dataQualityReport?q=*${key}*&index=testCaseResult&aggregationQuery=bucketName%3DbyDay%3AaggType%3Ddate_histogram%3Afield%3Dtimestamp%26calendar_interval%3Dday%2CbucketName%3DnewIncidents%3AaggType%3Dcardinality%3Afield%3DtestCase.fullyQualifiedName`
-      );
-      const abortedStatusResponse = page.waitForResponse(
-        `/api/v1/dataQuality/testSuites/dataQualityReport?q=*${key}*&index=testCaseResult&aggregationQuery=bucketName%3DbyDay%3AaggType%3Ddate_histogram%3Afield%3Dtimestamp%26calendar_interval%3Dday%2CbucketName%3DnewIncidents%3AaggType%3Dcardinality%3Afield%3DtestCase.fullyQualifiedName`
-      );
-      const failedStatusResponse = page.waitForResponse(
-        `/api/v1/dataQuality/testSuites/dataQualityReport?q=*${key}*&index=testCaseResult&aggregationQuery=bucketName%3DbyDay%3AaggType%3Ddate_histogram%3Afield%3Dtimestamp%26calendar_interval%3Dday%2CbucketName%3DnewIncidents%3AaggType%3Dcardinality%3Afield%3DtestCase.fullyQualifiedName`
-      );
-      const newIncidentResponse = page.waitForResponse(
-        `/api/v1/dataQuality/testSuites/dataQualityReport?q=*${key}*&index=testCaseResolutionStatus&aggregationQuery=bucketName%3DbyDay%3AaggType%3Ddate_histogram%3Afield%3Dtimestamp%26calendar_interval%3Dday%2CbucketName%3DnewIncidents%3AaggType%3Dcardinality%3Afield%3DstateId`
-      );
-      const resolvedIncidentResponse = page.waitForResponse(
-        `/api/v1/dataQuality/testSuites/dataQualityReport?q=*${key}*&index=testCaseResolutionStatus&aggregationQuery=bucketName%3DbyDay%3AaggType%3Ddate_histogram%3Afield%3Dtimestamp%26calendar_interval%3Dday%2CbucketName%3DnewIncidents%3AaggType%3Dcardinality%3Afield%3DstateId`
-      );
-      const timeToResponseMetricResponse = page.waitForResponse(
-        `/api/v1/dataQuality/testSuites/dataQualityReport?*${key}*&aggregationQuery=bucketName%3DbyDay%3AaggType%3Ddate_histogram%3Afield%3Dtimestamp%26calendar_interval%3Dday%2CbucketName%3Dmetrics%3AaggType%3Dnested%3Apath%3Dmetrics%2CbucketName%3DbyName%3AaggType%3Dterms%3Afield%3Dmetrics.name.keyword%2CbucketName%3DavgValue%3AaggType%3Davg%3Afield%3Dmetrics.value`
-      );
-      const timeToResolutionMetricResponse = page.waitForResponse(
-        `/api/v1/dataQuality/testSuites/dataQualityReport?*${key}*&aggregationQuery=bucketName%3DbyDay%3AaggType%3Ddate_histogram%3Afield%3Dtimestamp%26calendar_interval%3Dday%2CbucketName%3Dmetrics%3AaggType%3Dnested%3Apath%3Dmetrics%2CbucketName%3DbyName%3AaggType%3Dterms%3Afield%3Dmetrics.name.keyword%2CbucketName%3DavgValue%3AaggType%3Davg%3Afield%3Dmetrics.value`
-      );
-      const entityWithTestCasesResponse = page.waitForResponse(
-        `/api/v1/dataQuality/testSuites/dataQualityReport?*${key}*&index=testCase&aggregationQuery=bucketName%3DentityWithTests%3AaggType%3Dcardinality%3Afield%3DoriginEntityFQN`
-      );
-      const totalEntityCountResponse = page.waitForResponse(
-        `/api/v1/dataQuality/testSuites/dataQualityReport?*${key}*&index=table&aggregationQuery=bucketName%3Dcount%3AaggType%3Dcardinality%3Afield%3DfullyQualifiedName`
-      );
-
-      return [
-        testCaseStatusResponse,
-        unhealthyEntityResponse,
-        totalCoveredEntityResponse,
-        totalTestCaseResponse,
-        successStatusResponse,
-        abortedStatusResponse,
-        failedStatusResponse,
-        newIncidentResponse,
-        resolvedIncidentResponse,
-        timeToResponseMetricResponse,
-        timeToResolutionMetricResponse,
-        entityWithTestCasesResponse,
-        totalEntityCountResponse,
-      ];
-    };
+    // The dashboard coalesces every widget aggregation into one batched POST
+    // whose body carries the filter `key`. Wait for that single round trip.
+    const waitForDashboardApiResponses = (page: Page, key: string) => [
+      page.waitForResponse((res) => isDashboardReportBatchResponse(res, key)),
+    ];
 
     test('DataQualityDashboardTab', async ({ page }) => {
       test.slow();
@@ -627,7 +576,7 @@ test.describe(
           .click();
         const glossaryTermApiResponse = waitForDashboardApiResponses(
           page,
-          encodeURIComponent(glossaryTerm.responseData.name)
+          glossaryTerm.responseData.name
         );
         await page.getByTestId('update-btn').click();
         for (const apiRes of glossaryTermApiResponse) {
@@ -661,7 +610,7 @@ test.describe(
           .click();
         const dataProductApiResponse = waitForDashboardApiResponses(
           page,
-          encodeURIComponent(dataProduct.data.name)
+          dataProduct.data.name
         );
         await page.getByTestId('update-btn').click();
         for (const apiRes of dataProductApiResponse) {
@@ -719,6 +668,46 @@ test.describe(
           failed: '1',
           aborted: '0',
         });
+      });
+    });
+
+    test('Dashboard batches all report aggregations into one request (no N+1)', async ({
+      page,
+    }) => {
+      const batchBodies: Array<{ requests?: unknown[] }> = [];
+      let individualReportGetCount = 0;
+      page.on('request', (req) => {
+        const url = req.url();
+        if (url.includes('/dataQualityReport/batch')) {
+          const body = req.postData();
+          if (body) {
+            batchBodies.push(JSON.parse(body));
+          }
+        } else if (
+          url.includes('/dataQualityReport') &&
+          req.method() === 'GET'
+        ) {
+          individualReportGetCount += 1;
+        }
+      });
+
+      await test.step('Navigate to Data Quality dashboard', async () => {
+        await goToDataQualityDashboard(page);
+        await waitForAllLoadersToDisappear(page);
+      });
+
+      await test.step('Widgets coalesce into batch POST(s) with no per-widget GET fan-out', () => {
+        // The N+1 is gone: not a single per-widget GET dataQualityReport fired.
+        expect(individualReportGetCount).toBe(0);
+        expect(batchBodies.length).toBeGreaterThan(0);
+
+        // One round trip carries every widget aggregation across the dashboard.
+        const totalAggregations = batchBodies.reduce(
+          (sum, body) => sum + (body.requests?.length ?? 0),
+          0
+        );
+
+        expect(totalAggregations).toBeGreaterThanOrEqual(10);
       });
     });
 

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/dataQuality.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/dataQuality.ts
@@ -29,12 +29,52 @@ export const DATA_ASSETS_COVERAGE_PIE_CHART_TEST_ID =
   'data-assets-coverage-pie-chart';
 
 /**
+ * Matches the batched `dataQualityReport` POST the dashboard now fires instead
+ * of one GET per widget. The per-aggregation filter (`q`, `index`, ...) lives in
+ * the POST body, so pass `bodyToken` (a raw, non-URL-encoded substring) to assert
+ * a specific filter reached the API.
+ */
+export function isDashboardReportBatchResponse(
+  res: Response,
+  bodyToken?: string
+): boolean {
+  const request = res.request();
+  const isBatch =
+    request.url().includes('/dataQuality/testSuites/dataQualityReport/batch') &&
+    request.method() === 'POST';
+  let matches = isBatch && !bodyToken;
+
+  if (isBatch && bodyToken) {
+    const body = request.postData() ?? '';
+    matches = body.includes(bodyToken);
+    if (!matches) {
+      // Dotted FQNs are quoted (e.g. `"x.y"`); their quotes are JSON-escaped in
+      // the raw body, so fall back to matching parsed request field values.
+      try {
+        const parsed = JSON.parse(body) as {
+          requests?: Array<{ q?: string; domain?: string }>;
+        };
+        matches = (parsed.requests ?? []).some(
+          (item) =>
+            (item.q ?? '').includes(bodyToken) ||
+            (item.domain ?? '').includes(bodyToken)
+        );
+      } catch {
+        matches = false;
+      }
+    }
+  }
+
+  return matches;
+}
+
+/**
  * Navigate to the Data Quality dashboard (Dashboard sub-tab under Data Quality).
  */
 export async function goToDataQualityDashboard(page: Page): Promise<void> {
   await redirectToHomePage(page);
-  const dataQualityReportResponse = page.waitForResponse(
-    '/api/v1/dataQuality/testSuites/dataQualityReport?q=*'
+  const dataQualityReportResponse = page.waitForResponse((res) =>
+    isDashboardReportBatchResponse(res)
   );
   await sidebarClick(page, SidebarItem.DATA_QUALITY);
   await page.getByTestId('dashboard').click();
@@ -402,6 +442,24 @@ export function captureReports(page: Page): CapturedReport[] {
     if (!url.includes('/dataQualityReport')) {
       return;
     }
+
+    // The dashboard batches every aggregation into one POST body; flatten each
+    // item back into a CapturedReport so callers keep asserting on q/index.
+    if (url.includes('/dataQualityReport/batch')) {
+      const body = req.postData();
+      if (!body) {
+        return;
+      }
+      const parsed = JSON.parse(body) as {
+        requests?: Array<{ q?: string; index?: string }>;
+      };
+      for (const item of parsed.requests ?? []) {
+        captured.push({ url, q: item.q ?? '', index: item.index ?? '' });
+      }
+
+      return;
+    }
+
     const u = new URL(url);
     captured.push({
       url,
@@ -409,6 +467,7 @@ export function captureReports(page: Page): CapturedReport[] {
       index: u.searchParams.get('index') ?? '',
     });
   });
+
   return captured;
 }
 
@@ -440,10 +499,8 @@ async function applyDashboardTagBasedFilter(
 
   await page.getByTestId(optionFqn).click();
 
-  const reportRes = page.waitForResponse(
-    (res) =>
-      res.url().includes('/dataQualityReport') &&
-      res.url().includes(encodeURIComponent(optionFqn))
+  const reportRes = page.waitForResponse((res) =>
+    isDashboardReportBatchResponse(res, optionFqn)
   );
   await page.getByTestId('update-btn').click();
   await reportRes;

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/dataQuality.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/dataQuality.ts
@@ -450,9 +450,14 @@ export function captureReports(page: Page): CapturedReport[] {
       if (!body) {
         return;
       }
-      const parsed = JSON.parse(body) as {
-        requests?: Array<{ q?: string; index?: string }>;
-      };
+      let parsed: { requests?: Array<{ q?: string; index?: string }> };
+      try {
+        parsed = JSON.parse(body) as {
+          requests?: Array<{ q?: string; index?: string }>;
+        };
+      } catch {
+        return;
+      }
       for (const item of parsed.requests ?? []) {
         captured.push({ url, q: item.q ?? '', index: item.index ?? '' });
       }

--- a/openmetadata-ui/src/main/resources/ui/src/generated/tests/dataQualityReportBatchRequest.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/tests/dataQualityReportBatchRequest.ts
@@ -37,7 +37,7 @@ export interface DataQualityReportRequest {
      */
     index: string;
     /**
-     * Key used to correlate this request with its result in the response.
+     * Client provided key used to correlate this request with its result in the response.
      */
     key: string;
     /**

--- a/openmetadata-ui/src/main/resources/ui/src/generated/tests/dataQualityReportBatchRequest.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/tests/dataQualityReportBatchRequest.ts
@@ -1,0 +1,47 @@
+/*
+ *  Copyright 2026 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+/**
+ * Request to run multiple data quality report aggregations in a single call.
+ */
+export interface DataQualityReportBatchRequest {
+    /**
+     * List of data quality report aggregations to execute concurrently.
+     */
+    requests: DataQualityReportRequest[];
+}
+
+/**
+ * A single data quality report aggregation to execute as part of a batch.
+ */
+export interface DataQualityReportRequest {
+    /**
+     * Aggregation query to perform aggregation on the search results.
+     */
+    aggregationQuery: string;
+    /**
+     * Filter by domain fully qualified name.
+     */
+    domain?: string;
+    /**
+     * Index to perform the aggregation against.
+     */
+    index: string;
+    /**
+     * Key used to correlate this request with its result in the response.
+     */
+    key: string;
+    /**
+     * Search query to filter the aggregation results.
+     */
+    q?: string;
+}

--- a/openmetadata-ui/src/main/resources/ui/src/generated/tests/dataQualityReportBatchResponse.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/tests/dataQualityReportBatchResponse.ts
@@ -1,0 +1,76 @@
+/*
+ *  Copyright 2026 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+/**
+ * Response containing the results for a batch of data quality report aggregations.
+ */
+export interface DataQualityReportBatchResponse {
+    /**
+     * Results for each request. Match to requests by key; order is not guaranteed.
+     */
+    results: DataQualityReportResult[];
+}
+
+/**
+ * Result for a single data quality report request in a batch.
+ */
+export interface DataQualityReportResult {
+    /**
+     * Error message. Present when the request failed.
+     */
+    error?: string;
+    /**
+     * Key used to correlate this result with its originating request.
+     */
+    key: string;
+    /**
+     * Aggregation result. Present when the request succeeded.
+     */
+    report?: DataQualityReport;
+}
+
+/**
+ * Aggregation result. Present when the request succeeded.
+ *
+ * Data Quality report and aggregation model.
+ */
+export interface DataQualityReport {
+    /**
+     * Data for the data quality report.
+     */
+    data: { [key: string]: string }[];
+    /**
+     * Metadata for the data quality report.
+     */
+    metadata: DataQualityReportMetadata;
+}
+
+/**
+ * Metadata for the data quality report.
+ *
+ * Schema to capture data quality reports and aggregation data.
+ */
+export interface DataQualityReportMetadata {
+    /**
+     * Dimensions to capture the data quality report.
+     */
+    dimensions?: string[];
+    /**
+     * Keys to identify the data quality report.
+     */
+    keys?: string[];
+    /**
+     * Metrics to capture the data quality report.
+     */
+    metrics?: string[];
+    [property: string]: any;
+}

--- a/openmetadata-ui/src/main/resources/ui/src/pages/DataQuality/DataQualityProvider.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/DataQuality/DataQualityProvider.tsx
@@ -105,17 +105,17 @@ const DataQualityProvider = ({ children }: { children: React.ReactNode }) => {
 
     setIsTestCaseSummaryLoading(true);
     try {
-      const { data } = await fetchTestCaseSummary(filters);
-      const { data: unhealthyData } = await fetchEntityCoveredWithDQ(
-        filters,
-        true
-      );
-      const { data: totalDQCoverage } = await fetchEntityCoveredWithDQ(
-        filters,
-        false
-      );
-
-      const { data: entityCount } = await fetchTotalEntityCount(filters);
+      const [
+        { data },
+        { data: unhealthyData },
+        { data: totalDQCoverage },
+        { data: entityCount },
+      ] = await Promise.all([
+        fetchTestCaseSummary(filters),
+        fetchEntityCoveredWithDQ(filters, true),
+        fetchEntityCoveredWithDQ(filters, false),
+        fetchTotalEntityCount(filters),
+      ]);
 
       const unhealthy = parseInt(unhealthyData[0].originEntityFQN);
       const total = parseInt(totalDQCoverage[0].originEntityFQN);

--- a/openmetadata-ui/src/main/resources/ui/src/rest/dataQualityDashboardAPI.test.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/rest/dataQualityDashboardAPI.test.ts
@@ -31,9 +31,13 @@ import {
   fetchTestCaseSummaryByNoDimension,
   fetchTotalEntityCount,
 } from './dataQualityDashboardAPI';
-import { getDataQualityReport } from './testAPI';
+import { batchedDataQualityReport } from './dataQualityReportBatcher';
 jest.mock('./testAPI', () => ({
   getDataQualityReport: jest.fn(),
+}));
+
+jest.mock('./dataQualityReportBatcher', () => ({
+  batchedDataQualityReport: jest.fn(),
 }));
 
 jest.mock('../utils/DataQuality/DataQualityPureUtils', () => ({
@@ -62,7 +66,7 @@ describe('dataQualityDashboardAPI', () => {
         filters: { ownerFqn: 'owner1' },
         isTableApi: true,
       });
-      expect(getDataQualityReport).toHaveBeenCalledWith({
+      expect(batchedDataQualityReport).toHaveBeenCalledWith({
         q: JSON.stringify({
           query: {
             bool: {
@@ -96,7 +100,7 @@ describe('dataQualityDashboardAPI', () => {
 
       await fetchTotalEntityCount(filters);
 
-      expect(getDataQualityReport).toHaveBeenCalledWith({
+      expect(batchedDataQualityReport).toHaveBeenCalledWith({
         q: JSON.stringify({
           query: {
             bool: {
@@ -133,7 +137,7 @@ describe('dataQualityDashboardAPI', () => {
 
       await fetchTotalEntityCount(filters);
 
-      expect(getDataQualityReport).toHaveBeenCalledWith({
+      expect(batchedDataQualityReport).toHaveBeenCalledWith({
         q: JSON.stringify({
           query: {
             bool: {
@@ -181,7 +185,7 @@ describe('dataQualityDashboardAPI', () => {
         filters: { ownerFqn: 'owner1', tags: ['tag1'], tier: ['tier1'] },
         isTableApi: true,
       });
-      expect(getDataQualityReport).toHaveBeenCalledWith({
+      expect(batchedDataQualityReport).toHaveBeenCalledWith({
         q: JSON.stringify({
           query: {
             bool: {
@@ -213,7 +217,7 @@ describe('dataQualityDashboardAPI', () => {
     it('should call getDataQualityReport with correct query when no filters are provided', async () => {
       await fetchTotalEntityCount();
 
-      expect(getDataQualityReport).toHaveBeenCalledWith({
+      expect(batchedDataQualityReport).toHaveBeenCalledWith({
         q: JSON.stringify({
           query: {
             bool: {
@@ -422,7 +426,7 @@ describe('dataQualityDashboardAPI', () => {
           filters,
           ...testData.params,
         });
-        expect(getDataQualityReport).toHaveBeenCalledWith({
+        expect(batchedDataQualityReport).toHaveBeenCalledWith({
           q: testCaseData.test1.q,
           index: testData.index,
           aggregationQuery: testData.aggregationQuery,
@@ -441,7 +445,7 @@ describe('dataQualityDashboardAPI', () => {
           filters,
           ...testData.params,
         });
-        expect(getDataQualityReport).toHaveBeenCalledWith({
+        expect(batchedDataQualityReport).toHaveBeenCalledWith({
           q: testCaseData.test2.q,
           index: testData.index,
           aggregationQuery: testData.aggregationQuery,
@@ -460,7 +464,7 @@ describe('dataQualityDashboardAPI', () => {
           filters,
           ...testData.params,
         });
-        expect(getDataQualityReport).toHaveBeenCalledWith({
+        expect(batchedDataQualityReport).toHaveBeenCalledWith({
           q: testCaseData.test3.q,
           index: testData.index,
           aggregationQuery: testData.aggregationQuery,
@@ -482,7 +486,7 @@ describe('dataQualityDashboardAPI', () => {
           ...testData.params,
         });
 
-        expect(getDataQualityReport).toHaveBeenCalledWith({
+        expect(batchedDataQualityReport).toHaveBeenCalledWith({
           q: testCaseData.test4.q,
           index: testData.index,
           aggregationQuery: testData.aggregationQuery,
@@ -492,7 +496,7 @@ describe('dataQualityDashboardAPI', () => {
       it('should call getDataQualityReport with correct query when no filters are provided', async () => {
         await testData.func();
 
-        expect(getDataQualityReport).toHaveBeenCalledWith({
+        expect(batchedDataQualityReport).toHaveBeenCalledWith({
           q: testCaseData.test5.q,
           index: testData.index,
           aggregationQuery: testData.aggregationQuery,
@@ -509,7 +513,7 @@ describe('dataQualityDashboardAPI', () => {
     it('should call getDataQualityReport with no filters', async () => {
       await fetchTestCaseSummaryByNoDimension();
 
-      expect(getDataQualityReport).toHaveBeenCalledWith({
+      expect(batchedDataQualityReport).toHaveBeenCalledWith({
         q: JSON.stringify({
           query: {
             bool: {
@@ -536,7 +540,7 @@ describe('dataQualityDashboardAPI', () => {
       await fetchTestCaseSummaryByNoDimension({ ownerFqn: 'owner1' });
 
       expect(buildMustEsFilterForOwner).toHaveBeenCalledWith('owner1');
-      expect(getDataQualityReport).toHaveBeenCalledWith({
+      expect(batchedDataQualityReport).toHaveBeenCalledWith({
         q: JSON.stringify({
           query: {
             bool: {
@@ -570,7 +574,7 @@ describe('dataQualityDashboardAPI', () => {
       await fetchTestCaseSummaryByNoDimension({ tags: ['tag1', 'tag2'] });
 
       expect(buildMustEsFilterForTags).toHaveBeenCalledWith(['tag1', 'tag2']);
-      expect(getDataQualityReport).toHaveBeenCalledWith({
+      expect(batchedDataQualityReport).toHaveBeenCalledWith({
         q: JSON.stringify({
           query: {
             bool: {
@@ -598,7 +602,7 @@ describe('dataQualityDashboardAPI', () => {
 
       expect(buildMustEsFilterForTier).toHaveBeenCalledWith(['Tier.Tier1']);
       expect(buildMustEsFilterForTags).not.toHaveBeenCalled();
-      expect(getDataQualityReport).toHaveBeenCalledWith({
+      expect(batchedDataQualityReport).toHaveBeenCalledWith({
         q: JSON.stringify({
           query: {
             bool: {
@@ -640,7 +644,7 @@ describe('dataQualityDashboardAPI', () => {
 
       expect(buildMustEsFilterForTags).toHaveBeenCalledWith(['tag1']);
       expect(buildMustEsFilterForTier).toHaveBeenCalledWith(['Tier.Tier1']);
-      expect(getDataQualityReport).toHaveBeenCalledWith({
+      expect(batchedDataQualityReport).toHaveBeenCalledWith({
         q: JSON.stringify({
           query: {
             bool: {
@@ -659,7 +663,7 @@ describe('dataQualityDashboardAPI', () => {
       await fetchTestCaseSummaryByNoDimension({ tags: [] });
 
       expect(buildMustEsFilterForTags).not.toHaveBeenCalled();
-      expect(getDataQualityReport).toHaveBeenCalledWith(
+      expect(batchedDataQualityReport).toHaveBeenCalledWith(
         expect.objectContaining({
           q: JSON.stringify({
             query: {
@@ -677,7 +681,7 @@ describe('dataQualityDashboardAPI', () => {
       await fetchTestCaseSummaryByNoDimension({ tier: [] });
 
       expect(buildMustEsFilterForTier).not.toHaveBeenCalled();
-      expect(getDataQualityReport).toHaveBeenCalledWith(
+      expect(batchedDataQualityReport).toHaveBeenCalledWith(
         expect.objectContaining({
           q: JSON.stringify({
             query: {
@@ -698,7 +702,7 @@ describe('dataQualityDashboardAPI', () => {
 
       await fetchCountOfIncidentStatusTypeByDays(status);
 
-      expect(getDataQualityReport).toHaveBeenCalledWith({
+      expect(batchedDataQualityReport).toHaveBeenCalledWith({
         q: JSON.stringify({
           query: {
             bool: {
@@ -734,7 +738,7 @@ describe('dataQualityDashboardAPI', () => {
       await fetchCountOfIncidentStatusTypeByDays(status, filters);
 
       expect(buildMustEsFilterForOwner).toHaveBeenCalledWith('owner1', true);
-      expect(getDataQualityReport).toHaveBeenCalledWith({
+      expect(batchedDataQualityReport).toHaveBeenCalledWith({
         q: JSON.stringify({
           query: {
             bool: {
@@ -789,7 +793,7 @@ describe('dataQualityDashboardAPI', () => {
 
       expect(buildMustEsFilterForTags).toHaveBeenCalledWith(['tag1'], true);
       expect(buildMustEsFilterForTier).toHaveBeenCalledWith(['tier1'], true);
-      expect(getDataQualityReport).toHaveBeenCalledWith({
+      expect(batchedDataQualityReport).toHaveBeenCalledWith({
         q: JSON.stringify({
           query: {
             bool: {
@@ -848,7 +852,7 @@ describe('dataQualityDashboardAPI', () => {
       expect(buildMustEsFilterForOwner).toHaveBeenCalledWith('owner1', true);
       expect(buildMustEsFilterForTags).toHaveBeenCalledWith(['tag1'], true);
       expect(buildMustEsFilterForTier).toHaveBeenCalledWith(['tier1'], true);
-      expect(getDataQualityReport).toHaveBeenCalledWith({
+      expect(batchedDataQualityReport).toHaveBeenCalledWith({
         q: JSON.stringify({
           query: {
             bool: {
@@ -881,7 +885,7 @@ describe('dataQualityDashboardAPI', () => {
 
       await fetchCountOfIncidentStatusTypeByDays(status, filters);
 
-      expect(getDataQualityReport).toHaveBeenCalledWith({
+      expect(batchedDataQualityReport).toHaveBeenCalledWith({
         q: JSON.stringify({
           query: {
             bool: {
@@ -912,7 +916,7 @@ describe('dataQualityDashboardAPI', () => {
 
       await fetchIncidentTimeMetrics(type);
 
-      expect(getDataQualityReport).toHaveBeenCalledWith({
+      expect(batchedDataQualityReport).toHaveBeenCalledWith({
         q: JSON.stringify({
           query: {
             bool: {
@@ -962,7 +966,7 @@ describe('dataQualityDashboardAPI', () => {
         testCaseData.filters.ownerFqn,
         true
       );
-      expect(getDataQualityReport).toHaveBeenCalledWith({
+      expect(batchedDataQualityReport).toHaveBeenCalledWith({
         q: JSON.stringify({
           query: {
             bool: {
@@ -1031,7 +1035,7 @@ describe('dataQualityDashboardAPI', () => {
 
       expect(buildMustEsFilterForTags).toHaveBeenCalledWith(['tag1'], true);
       expect(buildMustEsFilterForTier).toHaveBeenCalledWith(['tier1'], true);
-      expect(getDataQualityReport).toHaveBeenCalledWith({
+      expect(batchedDataQualityReport).toHaveBeenCalledWith({
         q: JSON.stringify({
           query: {
             bool: {
@@ -1102,7 +1106,7 @@ describe('dataQualityDashboardAPI', () => {
       expect(buildMustEsFilterForOwner).toHaveBeenCalledWith('owner1', true);
       expect(buildMustEsFilterForTags).toHaveBeenCalledWith(['tag1'], true);
       expect(buildMustEsFilterForTier).toHaveBeenCalledWith(['tier1'], true);
-      expect(getDataQualityReport).toHaveBeenCalledWith({
+      expect(batchedDataQualityReport).toHaveBeenCalledWith({
         q: JSON.stringify({
           query: {
             bool: {
@@ -1144,7 +1148,7 @@ describe('dataQualityDashboardAPI', () => {
 
       await fetchIncidentTimeMetrics(type, filters);
 
-      expect(getDataQualityReport).toHaveBeenCalledWith({
+      expect(batchedDataQualityReport).toHaveBeenCalledWith({
         q: JSON.stringify({
           query: {
             bool: {
@@ -1184,7 +1188,7 @@ describe('dataQualityDashboardAPI', () => {
 
       await fetchTestCaseStatusMetricsByDays(status);
 
-      expect(getDataQualityReport).toHaveBeenCalledWith({
+      expect(batchedDataQualityReport).toHaveBeenCalledWith({
         q: JSON.stringify({
           query: {
             bool: {
@@ -1221,7 +1225,7 @@ describe('dataQualityDashboardAPI', () => {
         testCaseData.filters.ownerFqn,
         true
       );
-      expect(getDataQualityReport).toHaveBeenCalledWith({
+      expect(batchedDataQualityReport).toHaveBeenCalledWith({
         q: JSON.stringify({
           query: {
             bool: {
@@ -1276,7 +1280,7 @@ describe('dataQualityDashboardAPI', () => {
 
       expect(buildMustEsFilterForTags).toHaveBeenCalledWith(['tag1'], true);
       expect(buildMustEsFilterForTier).toHaveBeenCalledWith(['tier1'], true);
-      expect(getDataQualityReport).toHaveBeenCalledWith({
+      expect(batchedDataQualityReport).toHaveBeenCalledWith({
         q: JSON.stringify({
           query: {
             bool: {
@@ -1335,7 +1339,7 @@ describe('dataQualityDashboardAPI', () => {
       expect(buildMustEsFilterForOwner).toHaveBeenCalledWith('owner1', true);
       expect(buildMustEsFilterForTags).toHaveBeenCalledWith(['tag1'], true);
       expect(buildMustEsFilterForTier).toHaveBeenCalledWith(['tier1'], true);
-      expect(getDataQualityReport).toHaveBeenCalledWith({
+      expect(batchedDataQualityReport).toHaveBeenCalledWith({
         q: JSON.stringify({
           query: {
             bool: {
@@ -1368,7 +1372,7 @@ describe('dataQualityDashboardAPI', () => {
 
       await fetchTestCaseStatusMetricsByDays(status, filters);
 
-      expect(getDataQualityReport).toHaveBeenCalledWith({
+      expect(batchedDataQualityReport).toHaveBeenCalledWith({
         q: JSON.stringify({
           query: {
             bool: {
@@ -1403,7 +1407,7 @@ describe('dataQualityDashboardAPI', () => {
 
       await fetchTestCaseStatusMetricsByDays(status, filters);
 
-      expect(getDataQualityReport).toHaveBeenCalledWith({
+      expect(batchedDataQualityReport).toHaveBeenCalledWith({
         q: JSON.stringify({
           query: {
             bool: {
@@ -1442,7 +1446,7 @@ describe('dataQualityDashboardAPI', () => {
 
       await fetchTestCaseStatusMetricsByDays(status, filters);
 
-      expect(getDataQualityReport).toHaveBeenCalledWith({
+      expect(batchedDataQualityReport).toHaveBeenCalledWith({
         q: JSON.stringify({
           query: {
             bool: {

--- a/openmetadata-ui/src/main/resources/ui/src/rest/dataQualityDashboardAPI.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/rest/dataQualityDashboardAPI.ts
@@ -22,6 +22,7 @@ import {
   buildMustEsFilterForTags,
   buildMustEsFilterForTier,
 } from '../utils/DataQuality/DataQualityPureUtils';
+import { batchedDataQualityReport } from './dataQualityReportBatcher';
 import { DataQualityReportParamsType, getDataQualityReport } from './testAPI';
 
 export const fetchEntityCoveredWithDQ = (
@@ -30,7 +31,7 @@ export const fetchEntityCoveredWithDQ = (
 ) => {
   const mustFilter = buildDataQualityDashboardFilters({ filters, unhealthy });
 
-  return getDataQualityReport({
+  return batchedDataQualityReport({
     q: JSON.stringify({
       query: {
         bool: {
@@ -52,7 +53,7 @@ export const fetchTotalEntityCount = (
     isTableApi: true,
   });
 
-  return getDataQualityReport({
+  return batchedDataQualityReport({
     q: JSON.stringify({
       query: {
         bool: {
@@ -71,7 +72,7 @@ export const fetchTestCaseSummary = (
 ) => {
   const mustFilter = buildDataQualityDashboardFilters({ filters });
 
-  return getDataQualityReport({
+  return batchedDataQualityReport({
     q: JSON.stringify({
       query: {
         bool: {
@@ -91,7 +92,7 @@ export const fetchTestCaseSummaryByDimension = (
 ) => {
   const mustFilter = buildDataQualityDashboardFilters({ filters });
 
-  return getDataQualityReport({
+  return batchedDataQualityReport({
     q: JSON.stringify({
       query: {
         bool: {
@@ -123,7 +124,7 @@ export const fetchTestCaseSummaryByNoDimension = (
     mustFilter.push(buildMustEsFilterForDataProducts(filters.dataProductFqns));
   }
 
-  return getDataQualityReport({
+  return batchedDataQualityReport({
     q: JSON.stringify({
       query: {
         bool: {
@@ -159,7 +160,7 @@ export const fetchCountOfIncidentStatusTypeByDays = (
     );
   }
 
-  return getDataQualityReport({
+  return batchedDataQualityReport({
     q: JSON.stringify({
       query: {
         bool: {
@@ -205,7 +206,7 @@ export const fetchIncidentTimeMetrics = (
     );
   }
 
-  return getDataQualityReport({
+  return batchedDataQualityReport({
     q: JSON.stringify({
       query: {
         bool: {
@@ -269,7 +270,7 @@ export const fetchTestCaseStatusMetricsByDays = (
     });
   }
 
-  return getDataQualityReport({
+  return batchedDataQualityReport({
     q: JSON.stringify({
       query: {
         bool: {

--- a/openmetadata-ui/src/main/resources/ui/src/rest/dataQualityReportBatcher.test.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/rest/dataQualityReportBatcher.test.ts
@@ -98,4 +98,30 @@ describe('dataQualityReportBatcher', () => {
 
     expect(mockGetDataQualityReportBatch).toHaveBeenCalledTimes(2);
   });
+
+  it('should split a render tick larger than the server cap into multiple POSTs', async () => {
+    mockGetDataQualityReportBatch.mockImplementation((data) =>
+      Promise.resolve({
+        results: data.requests.map((request: { key: string }) => ({
+          key: request.key,
+          report: { data: [], metadata: {} },
+        })),
+      })
+    );
+
+    const pending = Array.from({ length: 51 }, (_, index) =>
+      batchedDataQualityReport({
+        index: 'testCase',
+        aggregationQuery: `agg${index}`,
+      })
+    );
+    await Promise.all(pending);
+
+    expect(mockGetDataQualityReportBatch).toHaveBeenCalledTimes(2);
+    const chunkSizes = mockGetDataQualityReportBatch.mock.calls
+      .map(([data]) => data.requests.length)
+      .sort((a: number, b: number) => b - a);
+
+    expect(chunkSizes).toEqual([50, 1]);
+  });
 });

--- a/openmetadata-ui/src/main/resources/ui/src/rest/dataQualityReportBatcher.test.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/rest/dataQualityReportBatcher.test.ts
@@ -1,0 +1,101 @@
+/*
+ *  Copyright 2026 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+import { batchedDataQualityReport } from './dataQualityReportBatcher';
+import { getDataQualityReportBatch } from './testAPI';
+
+jest.mock('./testAPI', () => ({
+  getDataQualityReportBatch: jest.fn(),
+}));
+
+const mockGetDataQualityReportBatch = getDataQualityReportBatch as jest.Mock;
+
+describe('dataQualityReportBatcher', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should coalesce requests fired in the same tick into a single batch call', async () => {
+    mockGetDataQualityReportBatch.mockResolvedValue({
+      results: [
+        { key: '0', report: { data: [{ a: '1' }], metadata: {} } },
+        { key: '1', report: { data: [{ b: '2' }], metadata: {} } },
+      ],
+    });
+
+    const [first, second] = await Promise.all([
+      batchedDataQualityReport({ index: 'testCase', aggregationQuery: 'agg1' }),
+      batchedDataQualityReport({ index: 'table', aggregationQuery: 'agg2' }),
+    ]);
+
+    expect(mockGetDataQualityReportBatch).toHaveBeenCalledTimes(1);
+    expect(mockGetDataQualityReportBatch).toHaveBeenCalledWith({
+      requests: [
+        { index: 'testCase', aggregationQuery: 'agg1', key: '0' },
+        { index: 'table', aggregationQuery: 'agg2', key: '1' },
+      ],
+    });
+    expect(first).toEqual({ data: [{ a: '1' }], metadata: {} });
+    expect(second).toEqual({ data: [{ b: '2' }], metadata: {} });
+  });
+
+  it('should reject only the failed item and resolve the rest', async () => {
+    mockGetDataQualityReportBatch.mockResolvedValue({
+      results: [
+        { key: '0', report: { data: [], metadata: {} } },
+        { key: '1', error: 'aggregation failed' },
+      ],
+    });
+
+    const ok = batchedDataQualityReport({
+      index: 'testCase',
+      aggregationQuery: 'agg',
+    });
+    const bad = batchedDataQualityReport({
+      index: 'missing',
+      aggregationQuery: 'agg',
+    });
+
+    await expect(ok).resolves.toEqual({ data: [], metadata: {} });
+    await expect(bad).rejects.toThrow('aggregation failed');
+  });
+
+  it('should reject all callers when the batch request itself fails', async () => {
+    mockGetDataQualityReportBatch.mockRejectedValue(new Error('network error'));
+
+    const first = batchedDataQualityReport({
+      index: 'testCase',
+      aggregationQuery: 'agg',
+    });
+    const second = batchedDataQualityReport({
+      index: 'table',
+      aggregationQuery: 'agg',
+    });
+
+    await expect(first).rejects.toThrow('network error');
+    await expect(second).rejects.toThrow('network error');
+  });
+
+  it('should start a new batch for requests fired after the previous flush', async () => {
+    mockGetDataQualityReportBatch.mockResolvedValue({
+      results: [{ key: '0', report: { data: [], metadata: {} } }],
+    });
+
+    await batchedDataQualityReport({
+      index: 'testCase',
+      aggregationQuery: 'a',
+    });
+    await batchedDataQualityReport({ index: 'table', aggregationQuery: 'b' });
+
+    expect(mockGetDataQualityReportBatch).toHaveBeenCalledTimes(2);
+  });
+});

--- a/openmetadata-ui/src/main/resources/ui/src/rest/dataQualityReportBatcher.test.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/rest/dataQualityReportBatcher.test.ts
@@ -118,6 +118,7 @@ describe('dataQualityReportBatcher', () => {
     await Promise.all(pending);
 
     expect(mockGetDataQualityReportBatch).toHaveBeenCalledTimes(2);
+
     const chunkSizes = mockGetDataQualityReportBatch.mock.calls
       .map(([data]) => data.requests.length)
       .sort((a: number, b: number) => b - a);

--- a/openmetadata-ui/src/main/resources/ui/src/rest/dataQualityReportBatcher.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/rest/dataQualityReportBatcher.ts
@@ -1,0 +1,79 @@
+/*
+ *  Copyright 2026 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+import { DataQualityReport } from '../generated/tests/dataQualityReport';
+import { DataQualityReportRequest } from '../generated/tests/dataQualityReportBatchRequest';
+import {
+  DataQualityReportParamsType,
+  getDataQualityReportBatch,
+} from './testAPI';
+
+interface PendingReport {
+  params: DataQualityReportParamsType;
+  resolve: (value: DataQualityReport) => void;
+  reject: (reason?: unknown) => void;
+}
+
+let pendingReports: PendingReport[] = [];
+let isFlushScheduled = false;
+
+const flushReports = async (): Promise<void> => {
+  const batch = pendingReports;
+
+  pendingReports = [];
+  isFlushScheduled = false;
+
+  const requests: DataQualityReportRequest[] = batch.map((pending, index) => ({
+    ...pending.params,
+    key: String(index),
+  }));
+
+  try {
+    const { results } = await getDataQualityReportBatch({ requests });
+    const resultByKey = new Map(
+      results.map((result) => [result.key, result] as const)
+    );
+
+    batch.forEach((pending, index) => {
+      const result = resultByKey.get(String(index));
+
+      if (result?.report) {
+        pending.resolve(result.report);
+      } else {
+        pending.reject(
+          new Error(result?.error ?? 'Data quality report request failed')
+        );
+      }
+    });
+  } catch (error) {
+    batch.forEach((pending) => pending.reject(error));
+  }
+};
+
+/**
+ * Coalesces every data quality report request fired within the same microtask
+ * into a single POST `/dataQualityReport/batch` call. This collapses the data
+ * quality dashboard's N independent report requests into one round trip while
+ * keeping each caller's promise (and error handling) independent.
+ */
+export const batchedDataQualityReport = (
+  params: DataQualityReportParamsType
+): Promise<DataQualityReport> => {
+  return new Promise<DataQualityReport>((resolve, reject) => {
+    pendingReports.push({ params, resolve, reject });
+
+    if (!isFlushScheduled) {
+      isFlushScheduled = true;
+      void Promise.resolve().then(flushReports);
+    }
+  });
+};

--- a/openmetadata-ui/src/main/resources/ui/src/rest/dataQualityReportBatcher.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/rest/dataQualityReportBatcher.ts
@@ -26,13 +26,14 @@ interface PendingReport {
 let pendingReports: PendingReport[] = [];
 let isFlushScheduled = false;
 
-const flushReports = async (): Promise<void> => {
-  const batch = pendingReports;
+// Mirror of the server-side MAX_DATA_QUALITY_REPORT_BATCH_SIZE. A render tick
+// that produces more report requests than this is split across multiple POSTs
+// so the client never trips the server's batch-size cap (which would 400 and
+// reject the whole batch).
+const MAX_BATCH_SIZE = 50;
 
-  pendingReports = [];
-  isFlushScheduled = false;
-
-  const requests: DataQualityReportRequest[] = batch.map((pending, index) => ({
+const flushChunk = async (chunk: PendingReport[]): Promise<void> => {
+  const requests: DataQualityReportRequest[] = chunk.map((pending, index) => ({
     ...pending.params,
     key: String(index),
   }));
@@ -43,7 +44,7 @@ const flushReports = async (): Promise<void> => {
       results.map((result) => [result.key, result] as const)
     );
 
-    batch.forEach((pending, index) => {
+    chunk.forEach((pending, index) => {
       const result = resultByKey.get(String(index));
 
       if (result?.report) {
@@ -55,7 +56,18 @@ const flushReports = async (): Promise<void> => {
       }
     });
   } catch (error) {
-    batch.forEach((pending) => pending.reject(error));
+    chunk.forEach((pending) => pending.reject(error));
+  }
+};
+
+const flushReports = (): void => {
+  const batch = pendingReports;
+
+  pendingReports = [];
+  isFlushScheduled = false;
+
+  for (let start = 0; start < batch.length; start += MAX_BATCH_SIZE) {
+    void flushChunk(batch.slice(start, start + MAX_BATCH_SIZE));
   }
 };
 

--- a/openmetadata-ui/src/main/resources/ui/src/rest/testAPI.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/rest/testAPI.ts
@@ -24,6 +24,8 @@ import { CreateTestCase } from '../generated/api/tests/createTestCase';
 import { CreateTestDefinition } from '../generated/api/tests/createTestDefinition';
 import { CreateTestSuite } from '../generated/api/tests/createTestSuite';
 import { DataQualityReport } from '../generated/tests/dataQualityReport';
+import { DataQualityReportBatchRequest } from '../generated/tests/dataQualityReportBatchRequest';
+import { DataQualityReportBatchResponse } from '../generated/tests/dataQualityReportBatchResponse';
 import {
   TableData,
   TestCase,
@@ -432,6 +434,17 @@ export const getDataQualityReport = async (
     `${testSuiteUrl}/dataQualityReport`,
     { params }
   );
+
+  return response.data;
+};
+
+export const getDataQualityReportBatch = async (
+  data: DataQualityReportBatchRequest
+): Promise<DataQualityReportBatchResponse> => {
+  const response = await APIClient.post<
+    DataQualityReportBatchRequest,
+    AxiosResponse<DataQualityReportBatchResponse>
+  >(`${testSuiteUrl}/dataQualityReport/batch`, data);
 
   return response.data;
 };


### PR DESCRIPTION
### Describe your changes:

Fixes #29259

The Data Quality dashboard issued ~11 sequential `GET /api/v1/dataQuality/testSuites/dataQualityReport` calls on every load (Sentry flagged it as an "N+1 API Call"). I collapsed them into a single round trip via a new batch endpoint plus a transparent client-side coalescing batcher, so auth/RBAC runs once and the aggregations execute concurrently server-side instead of as a browser-side waterfall.

#
### Type of change:
- [x] Improvement

#
### High-level design:
- **Backend** — new `POST /api/v1/dataQuality/testSuites/dataQualityReport/batch` (`TestSuiteResource` → `TestSuiteRepository.getDataQualityReportBatch`) fans the existing `genericAggregation` out over virtual threads with per-item error isolation (one failing aggregation can't blank the dashboard) and a 50-item cap. Request/response are modeled by new JSON schemas `dataQualityReportBatch{Request,Response}` (response is an array of `{key, report?, error?}`). I chose a virtual-thread fan-out over Elasticsearch `_msearch` to reuse the existing per-call path (RBAC, query/agg parsing) with zero ES/OS client changes; `_msearch` is a clean follow-up if we later want a single ES round trip too.
- **Frontend** — a microtask-coalescing batcher (`rest/dataQualityReportBatcher.ts`) collects every report request fired in the same render tick into one `POST /batch`. The 8 dashboard fetchers route through it (the non-dashboard `fetchTestCaseResultByTestSuiteId` stays on the direct GET), and `DataQualityProvider`'s 4 independent summary calls now run via `Promise.all`. Chart widgets are unchanged, so the dashboard renders identically.

#
### Tests:

#### Use cases covered
- DQ dashboard loads with a single batched request instead of ~11 per-widget GETs (no N+1).
- A failing aggregation returns an error for that key while sibling aggregations still succeed.
- Owner / tier / tag / glossary / data-product / certification / domain filters still scope correctly through the batch (dashboard + entity Data Observability tabs).

#### Unit tests
- [x] Jest: added `rest/dataQualityReportBatcher.test.ts` (coalescing, per-item error isolation, full-batch failure, re-batching across ticks); updated `rest/dataQualityDashboardAPI.test.ts` to assert the batched transport. All green locally.

#### Backend integration tests
- [x] Added `TestSuiteResourceIT` cases: batch-vs-single parity, per-item failure isolation, and 400 validation. Verified locally via Testcontainers (app booted in-process): **3/3 pass**.

#### Ingestion integration tests
- [x] Not applicable (no ingestion changes).

#### Playwright (UI) tests
- [x] Migrated the DQ dashboard suite to the batch endpoint (`DataQualityDashboard`, `CertificationFilter`, `DataObservabilityGovernanceTab` specs + `utils/dataQuality`) and added an explicit "no per-widget GET fan-out" assertion. Verified against a rebuilt local stack: **30/30 pass**.

#### Manual testing performed
1. Rebuilt the stack with this code via `./docker/run_local_docker.sh -m ui -d mysql`.
2. Confirmed `POST .../dataQualityReport/batch` is live (401, auth-gated) and the dashboard renders with a single batched request and no per-widget GETs.

#
### UI screen recording / screenshots:
Not applicable — no visible UI change. Batching is transparent; the dashboard renders identically (verified end-to-end via Playwright, 30/30).

#
### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] My PR title is `Fixes <issue-number>: <short explanation>`
- [x] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] For JSON Schema changes: no migration needed — these are new request/response DTOs only (no stored-entity or search-index mapping changes).
- [x] For UI changes: no visible UI change (transparent batching); Playwright covers it.
- [x] I have added tests (unit / integration / Playwright as applicable) and listed them above.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR eliminates the N+1 pattern on the Data Quality dashboard by introducing a batch endpoint (`POST /dataQualityReport/batch`) on the server and a microtask-coalescing batcher on the client, collapsing ~11 per-widget GETs into a single round trip. The implementation is thorough and well-tested across unit, integration, and Playwright layers.

- **Backend**: A new JAX-RS endpoint fans requests concurrently via a short-lived `ExecutorService`, with per-item error isolation so a failing aggregation never blanks the whole dashboard. `IllegalArgumentException` validation correctly maps to HTTP 400 via the existing `CatalogGenericExceptionMapper`.
- **Frontend batcher**: Module-level microtask coalescing correctly assigns positional keys per chunk, handles per-item and whole-batch failures independently, and auto-splits batches that exceed the 50-item server cap into multiple POSTs.
- **DataQualityProvider**: Four sequential summary calls are parallelised with `Promise.all`, which also lets the batcher coalesce them into the same single POST.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the batch endpoint reuses the existing auth/aggregation path correctly, error isolation is complete, and the client batcher is well-covered by tests.

The core logic (concurrent execution, key-based result routing, per-item error capture) is correct on both client and server. Auth reuse and the IllegalArgumentException to 400 mapping are verified by the existing exception mapper. Unit, integration, and Playwright tests are comprehensive. The only finding is a minor efficiency note about thread pool allocation strategy.

openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/TestSuiteRepository.java — the per-request platform thread pool could be swapped for a virtual-thread executor for better efficiency under load.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/TestSuiteRepository.java | Adds getDataQualityReportBatch which fans tasks over a newFixedThreadPool; error isolation and null-safe fallback are correct, but a new platform-thread pool is created and torn down for every batch call. |
| openmetadata-service/src/main/java/org/openmetadata/service/resources/dqtests/TestSuiteResource.java | Adds POST /dataQualityReport/batch with correct auth reuse, 50-item cap, and per-item validation; IllegalArgumentException correctly maps to HTTP 400 via CatalogGenericExceptionMapper. |
| openmetadata-ui/src/main/resources/ui/src/rest/dataQualityReportBatcher.ts | Microtask-coalescing batcher correctly assigns positional keys per chunk, handles per-item and whole-batch failures independently, and splits oversized ticks into multiple POSTs. |
| openmetadata-ui/src/main/resources/ui/src/pages/DataQuality/DataQualityProvider.tsx | Converts 4 sequential summary fetches to Promise.all, which also lets the microtask batcher coalesce them into one batch POST. |
| openmetadata-ui/src/main/resources/ui/src/rest/dataQualityDashboardAPI.ts | All 8 dashboard fetchers migrated from getDataQualityReport to batchedDataQualityReport; getDataQualityReport is still imported but no longer called (pre-existing finding, already flagged in prior review). |
| openmetadata-ui/src/main/resources/ui/playwright/utils/dataQuality.ts | Adds isDashboardReportBatchResponse helper and updates captureReports/applyDashboardTagBasedFilter to handle the new batch endpoint; captureReports now has a guarded JSON.parse for the batch path. |
| openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/TestSuiteResourceIT.java | Adds three integration tests covering batch-vs-single parity, per-item failure isolation, and 400 validation; well-structured with Awaitility for index readiness. |
| openmetadata-ui/src/main/resources/ui/src/rest/dataQualityReportBatcher.test.ts | Comprehensive unit tests covering coalescing, per-item error isolation, full-batch failure, re-batching, and chunk-splitting at the MAX_BATCH_SIZE boundary. |

</details>

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Browser
    participant Batcher as dataQualityReportBatcher
    participant API as POST /dataQualityReport/batch
    participant Repo as TestSuiteRepository
    participant ES as Elasticsearch/OpenSearch

    Note over Browser,Batcher: Same microtask tick (dashboard render)
    Browser->>Batcher: batchedDataQualityReport(req1)
    Browser->>Batcher: batchedDataQualityReport(req2)
    Browser->>Batcher: batchedDataQualityReport(req3..N)
    Note over Batcher: Promise.resolve().then(flushReports)

    Batcher->>API: POST /batch
    API->>Repo: getDataQualityReportBatch(request, subjectContext)
    Note over Repo: ExecutorService fan-out
    par Concurrent aggregations
        Repo->>ES: genericAggregation(req1)
        Repo->>ES: genericAggregation(req2)
        Repo->>ES: genericAggregation(req3..N)
    end
    ES-->>Repo: results
    Repo-->>API: DataQualityReportBatchResponse
    API-->>Batcher: results keyed by position

    Batcher->>Browser: resolve/reject per caller
    Note over Browser: Dashboard renders (single round trip)
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Browser
    participant Batcher as dataQualityReportBatcher
    participant API as POST /dataQualityReport/batch
    participant Repo as TestSuiteRepository
    participant ES as Elasticsearch/OpenSearch

    Note over Browser,Batcher: Same microtask tick (dashboard render)
    Browser->>Batcher: batchedDataQualityReport(req1)
    Browser->>Batcher: batchedDataQualityReport(req2)
    Browser->>Batcher: batchedDataQualityReport(req3..N)
    Note over Batcher: Promise.resolve().then(flushReports)

    Batcher->>API: POST /batch
    API->>Repo: getDataQualityReportBatch(request, subjectContext)
    Note over Repo: ExecutorService fan-out
    par Concurrent aggregations
        Repo->>ES: genericAggregation(req1)
        Repo->>ES: genericAggregation(req2)
        Repo->>ES: genericAggregation(req3..N)
    end
    ES-->>Repo: results
    Repo-->>API: DataQualityReportBatchResponse
    API-->>Batcher: results keyed by position

    Batcher->>Browser: resolve/reject per caller
    Note over Browser: Dashboard renders (single round trip)
```

</a>
</details>

<sub>Reviews (3): Last reviewed commit: ["Fix UI checkstyle: blank line before con..."](https://github.com/open-metadata/openmetadata/commit/621b687ce6928f814a37ea9241fabfa42f44f371) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38836279)</sub>

<!-- /greptile_comment -->