### PR TITLE
Fixes #29261: record change events for async and recursive deletes

### DIFF
--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/AuditLogResourceIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/AuditLogResourceIT.java
@@ -1349,6 +1349,114 @@ public class AuditLogResourceIT {
     verifyAuditEntryHasValidUUIDs(hardDeleteEntry, glossaryId);
   }
 
+  // ==================== Delete Change Event Coverage Tests ====================
+  // Verify that DELETE operations always produce change events (and therefore audit log entries),
+  // including the async delete path, and that a recursive delete records a single event for the
+  // deleted entity rather than one event per cascaded child (so deleting a service with 100k
+  // objects writes one audit entry, not 100k).
+
+  @Test
+  void test_auditLog_asyncHardDelete_writesEntityDeleted() throws Exception {
+    OpenMetadataClient client = SdkClients.adminClient();
+
+    String glossaryName =
+        "AuditLogAsyncDeleteTest_" + java.util.UUID.randomUUID().toString().substring(0, 8);
+    Map<String, Object> glossary = createGlossary(client, glossaryName);
+    String glossaryId = glossary.get("id").toString();
+    String glossaryFqn = glossary.get("fullyQualifiedName").toString();
+
+    waitForAuditLogEntry(client, glossaryFqn, "glossary", "entityCreated");
+
+    client
+        .getHttpClient()
+        .executeForString(
+            HttpMethod.DELETE,
+            "/v1/glossaries/async/" + glossaryId + "?hardDelete=true&recursive=true",
+            null,
+            RequestOptions.builder().build());
+
+    Map<String, Object> auditEntry =
+        waitForAuditLogEntry(client, glossaryFqn, "glossary", "entityDeleted");
+    assertNotNull(
+        auditEntry,
+        "async hard delete should produce an entityDeleted audit log for " + glossaryFqn);
+    verifyAuditEntryHasValidUUIDs(auditEntry, glossaryId);
+    assertEquals("entityDeleted", auditEntry.get("eventType"));
+  }
+
+  @Test
+  void test_auditLog_recursiveSoftDelete_doesNotEmitPerChildEvents() throws Exception {
+    OpenMetadataClient client = SdkClients.adminClient();
+
+    String glossaryName =
+        "AuditLogRecursiveSoftTest_" + java.util.UUID.randomUUID().toString().substring(0, 8);
+    Map<String, Object> glossary = createGlossary(client, glossaryName);
+    String glossaryId = glossary.get("id").toString();
+    String glossaryFqn = glossary.get("fullyQualifiedName").toString();
+
+    Map<String, Object> term = createGlossaryTerm(client, glossaryFqn, "child_term");
+    String termFqn = term.get("fullyQualifiedName").toString();
+    waitForAuditLogEntry(client, termFqn, "glossaryTerm", "entityCreated");
+
+    try {
+      client
+          .getHttpClient()
+          .executeForString(
+              HttpMethod.DELETE,
+              "/v1/glossaries/" + glossaryId + "?recursive=true",
+              null,
+              RequestOptions.builder().build());
+
+      waitForAuditLogEntry(client, glossaryFqn, "glossary", "entitySoftDeleted");
+
+      // The consumer processes events in offset order and the root event is written after the
+      // cascaded children, so once the root soft-delete is visible any child event would already
+      // be queryable. The child must NOT have produced its own change event.
+      assertFalse(
+          auditLogEntryExists(client, termFqn, "glossaryTerm", "entitySoftDeleted"),
+          "Cascaded child term must not produce its own entitySoftDeleted change event");
+    } finally {
+      deleteGlossary(client, glossaryId);
+    }
+  }
+
+  @Test
+  void test_auditLog_asyncRecursiveHardDelete_recordsOnlyRootEvent() throws Exception {
+    OpenMetadataClient client = SdkClients.adminClient();
+
+    String glossaryName =
+        "AuditLogAsyncRecursiveTest_" + java.util.UUID.randomUUID().toString().substring(0, 8);
+    Map<String, Object> glossary = createGlossary(client, glossaryName);
+    String glossaryId = glossary.get("id").toString();
+    String glossaryFqn = glossary.get("fullyQualifiedName").toString();
+
+    Map<String, Object> term = createGlossaryTerm(client, glossaryFqn, "child_term");
+    String termFqn = term.get("fullyQualifiedName").toString();
+    waitForAuditLogEntry(client, termFqn, "glossaryTerm", "entityCreated");
+
+    client
+        .getHttpClient()
+        .executeForString(
+            HttpMethod.DELETE,
+            "/v1/glossaries/async/" + glossaryId + "?hardDelete=true&recursive=true",
+            null,
+            RequestOptions.builder().build());
+
+    Map<String, Object> auditEntry =
+        waitForAuditLogEntry(client, glossaryFqn, "glossary", "entityDeleted");
+    assertNotNull(auditEntry, "async recursive hard delete should record the root entityDeleted");
+    assertEquals("entityDeleted", auditEntry.get("eventType"));
+    assertFalse(
+        auditLogEntryExists(client, termFqn, "glossaryTerm", "entityDeleted"),
+        "Cascaded child term must not produce its own entityDeleted change event");
+
+    Object summary = auditEntry.get("summary");
+    assertNotNull(summary, "audit entry should include a summary");
+    assertTrue(
+        summary.toString().toLowerCase(java.util.Locale.ROOT).contains("recursive"),
+        "recursive delete summary should indicate it was recursive, got: " + summary);
+  }
+
   // ==================== Helper Methods for Audit Log Verification ====================
 
   private Map<String, Object> waitForAuditLogEntry(
@@ -1454,6 +1562,49 @@ public class AuditLogResourceIT {
         "entityId should not be empty - indicates UUID binding failure with @BindBean");
     assertEquals(
         expectedEntityId, entityIdStr, "entityId in audit log should match the entity's ID");
+  }
+
+  private Map<String, Object> createGlossary(OpenMetadataClient client, String name)
+      throws Exception {
+    String createJson =
+        String.format(
+            "{\"name\": \"%s\", \"displayName\": \"%s\", \"description\": \"Audit log test glossary\"}",
+            name, name);
+    String response =
+        client
+            .getHttpClient()
+            .executeForString(
+                HttpMethod.POST, "/v1/glossaries", createJson, RequestOptions.builder().build());
+    return MAPPER.readValue(response, new TypeReference<>() {});
+  }
+
+  private Map<String, Object> createGlossaryTerm(
+      OpenMetadataClient client, String glossaryFqn, String name) throws Exception {
+    String createJson =
+        String.format(
+            "{\"name\": \"%s\", \"glossary\": \"%s\", \"description\": \"Audit log test child term\"}",
+            name, glossaryFqn);
+    String response =
+        client
+            .getHttpClient()
+            .executeForString(
+                HttpMethod.POST, "/v1/glossaryTerms", createJson, RequestOptions.builder().build());
+    return MAPPER.readValue(response, new TypeReference<>() {});
+  }
+
+  private boolean auditLogEntryExists(
+      OpenMetadataClient client, String entityFqn, String entityType, String eventType)
+      throws Exception {
+    Map<String, String> params = new HashMap<>();
+    params.put("entityFQN", entityFqn);
+    params.put("entityType", entityType);
+    params.put("eventType", eventType);
+    params.put("limit", "1");
+    String response = executeGet(client, AUDIT_LOGS_PATH, params);
+    Map<String, Object> result = MAPPER.readValue(response, new TypeReference<>() {});
+    java.util.List<Map<String, Object>> data =
+        (java.util.List<Map<String, Object>>) result.get("data");
+    return data != null && !data.isEmpty();
   }
 
   private void deleteGlossary(OpenMetadataClient client, String glossaryId) {

--- a/openmetadata-service/src/main/java/org/openmetadata/service/audit/AuditLogRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/audit/AuditLogRepository.java
@@ -556,14 +556,15 @@ public class AuditLogRepository {
     EventType eventType = changeEvent.getEventType();
     String entityType = changeEvent.getEntityType();
     String entityFqn = changeEvent.getEntityFullyQualifiedName();
+    String recursiveSuffix = Boolean.TRUE.equals(changeEvent.getRecursive()) ? " (recursive)" : "";
 
     switch (eventType) {
       case ENTITY_CREATED:
         return String.format("Created %s: %s", entityType, entityFqn);
       case ENTITY_DELETED:
-        return String.format("Deleted %s: %s", entityType, entityFqn);
+        return String.format("Deleted %s: %s%s", entityType, entityFqn, recursiveSuffix);
       case ENTITY_SOFT_DELETED:
-        return String.format("Soft deleted %s: %s", entityType, entityFqn);
+        return String.format("Soft deleted %s: %s%s", entityType, entityFqn, recursiveSuffix);
       case ENTITY_RESTORED:
         return String.format("Restored %s: %s", entityType, entityFqn);
       case ENTITY_UPDATED:

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/EntityRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/EntityRepository.java
@@ -6435,7 +6435,7 @@ public abstract class EntityRepository<T extends EntityInterface> {
           buildBulkUpdaters(deletedEntities, updatedBy, Operation.PUT, "bulkRestoreUpdaters", null);
       List<EntityUpdater> changed = filterChanged(updaters);
       if (!changed.isEmpty()) {
-        persistBulkUpdaters(changed, ENTITY_RESTORED, updatedBy, "bulkRestore");
+        persistBulkUpdaters(changed, "bulkRestore");
         ListCountCache.invalidate(entityType);
       }
     }
@@ -6635,7 +6635,7 @@ public abstract class EntityRepository<T extends EntityInterface> {
             e -> e.setDeleted(true));
     List<EntityUpdater> changed = filterChanged(updaters);
     if (!changed.isEmpty()) {
-      persistBulkUpdaters(changed, ENTITY_SOFT_DELETED, updatedBy, "bulkSoftDelete");
+      persistBulkUpdaters(changed, "bulkSoftDelete");
       ListCountCache.invalidate(entityType);
     }
   }
@@ -6910,8 +6910,7 @@ public abstract class EntityRepository<T extends EntityInterface> {
    * reflects the previous state. {@code SearchIndexHandler.onEntitiesUpdated} batches the
    * writes via {@code updateEntitiesIndex}, so this is still bulk on the ES side.
    */
-  private void persistBulkUpdaters(
-      List<EntityUpdater> changed, EventType eventType, String userName, String phasePrefix) {
+  private void persistBulkUpdaters(List<EntityUpdater> changed, String phasePrefix) {
     writeBulkVersionHistory(changed, phasePrefix);
     List<T> changedEntities = changed.stream().map(EntityUpdater::getUpdated).toList();
     try (var ignored = phase(phasePrefix + "UpdateMany")) {
@@ -6923,7 +6922,10 @@ public abstract class EntityRepository<T extends EntityInterface> {
     try (var ignored = phase(phasePrefix + "LifecycleDispatch")) {
       EntityLifecycleEventDispatcher.getInstance().onEntitiesUpdated(changedEntities, null, null);
     }
-    writeBulkChangeEvents(changed, eventType, userName, phasePrefix + "ChangeEvents");
+    // Cascade children of a recursive delete/restore intentionally do NOT emit per-entity change
+    // events. A single change event is recorded for the user-targeted root entity (see the delete
+    // and restore paths in EntityResource). This keeps deleting a service with 100k descendants to
+    // one audit-log entry and avoids 100k change_event inserts on the delete hot path.
   }
 
   private void writeBulkVersionHistory(List<EntityUpdater> changed, String phasePrefix) {
@@ -6944,18 +6946,6 @@ public abstract class EntityRepository<T extends EntityInterface> {
             .entityExtensionDAO()
             .insertMany(historyIds, historyExtensions, entityType, historyJsons);
       }
-    }
-  }
-
-  private void writeBulkChangeEvents(
-      List<EntityUpdater> changed, EventType eventType, String userName, String phaseName) {
-    try (var ignored = phase(phaseName)) {
-      List<String> changeEventJsons = new ArrayList<>();
-      for (EntityUpdater u : changed) {
-        buildChangeEventJsonForBulkOperation(u.getUpdated(), eventType, userName)
-            .ifPresent(changeEventJsons::add);
-      }
-      insertChangeEventsBatch(changeEventJsons);
     }
   }
 
@@ -12825,21 +12815,41 @@ public abstract class EntityRepository<T extends EntityInterface> {
     return update(uriInfo, original, updated, updatedBy, null);
   }
 
-  private void createChangeEventForBulkOperation(T entity, EventType eventType, String userName) {
-    Optional<String> changeEventJson =
-        buildChangeEventJsonForBulkOperation(entity, eventType, userName);
-    if (changeEventJson.isEmpty()) {
-      return;
+  /**
+   * Records the change event for an async delete/restore whose HTTP 202 response bypasses the
+   * response filter that records change events for synchronous operations. Without this, async
+   * deletes and restores are invisible to audit logs, alerts, and webhooks. Recursive deletes pass
+   * a single root event here; cascaded descendants are intentionally not recorded individually (see
+   * {@link #persistBulkUpdaters}).
+   */
+  public final void storeChangeEventForAsyncOperation(
+      T entity, EventType eventType, boolean recursive, String userName) {
+    if (entity != null && eventType != null) {
+      buildChangeEventJsonForBulkOperation(entity, eventType, userName, recursive)
+          .ifPresent(this::insertChangeEvent);
     }
+  }
+
+  private void createChangeEventForBulkOperation(T entity, EventType eventType, String userName) {
+    buildChangeEventJsonForBulkOperation(entity, eventType, userName)
+        .ifPresent(this::insertChangeEvent);
+  }
+
+  private void insertChangeEvent(String changeEventJson) {
     try {
-      Entity.getCollectionDAO().changeEventDAO().insert(changeEventJson.get());
+      Entity.getCollectionDAO().changeEventDAO().insert(changeEventJson);
     } catch (Exception e) {
-      LOG.error("Failed to create change event for bulk operation", e);
+      LOG.error("Failed to insert change event", e);
     }
   }
 
   private Optional<String> buildChangeEventJsonForBulkOperation(
       T entity, EventType eventType, String userName) {
+    return buildChangeEventJsonForBulkOperation(entity, eventType, userName, false);
+  }
+
+  private Optional<String> buildChangeEventJsonForBulkOperation(
+      T entity, EventType eventType, String userName, boolean recursive) {
     try {
       if (eventType.equals(ENTITY_NO_CHANGE)) {
         return Optional.empty();
@@ -12852,6 +12862,10 @@ public abstract class EntityRepository<T extends EntityInterface> {
         Object entityObject = changeEvent.getEntity();
         changeEvent = copyChangeEvent(changeEvent);
         changeEvent.setEntity(JsonUtils.pojoToMaskedJson(entityObject));
+      }
+
+      if (recursive) {
+        changeEvent.setRecursive(true);
       }
 
       LOG.debug(

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/EntityResource.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/EntityResource.java
@@ -731,6 +731,8 @@ public abstract class EntityResource<T extends EntityInterface, K extends Entity
                 if (hardDelete) {
                   limits.invalidateCache(entityType);
                 }
+                repository.storeChangeEventForAsyncOperation(
+                    deleteResponse.entity(), deleteResponse.changeType(), recursive, userName);
                 WebsocketNotificationHandler.sendDeleteOperationCompleteNotification(
                     jobId, securityContext, deleteResponse.entity());
               } catch (Exception e) {
@@ -871,6 +873,8 @@ public abstract class EntityResource<T extends EntityInterface, K extends Entity
                   return;
                 }
                 repository.restoreFromSearch(response.getEntity());
+                repository.storeChangeEventForAsyncOperation(
+                    response.getEntity(), response.getChangeType(), false, userName);
                 LOG.info(
                     "[AsyncRestore] Restored {}:{} (jobId={})",
                     Entity.getEntityTypeFromObject(response.getEntity()),

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/apps/AppResource.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/apps/AppResource.java
@@ -1620,6 +1620,8 @@ public class AppResource extends EntityResource<App, AppRepository> {
               limits.invalidateCache(entityType);
             }
 
+            repository.storeChangeEventForAsyncOperation(
+                deleteResponse.entity(), deleteResponse.changeType(), recursive, userName);
             WebsocketNotificationHandler.sendDeleteOperationCompleteNotification(
                 jobId, securityContext, deleteResponse.entity());
           } catch (Exception e) {

--- a/openmetadata-spec/src/main/resources/json/schema/type/changeEvent.json
+++ b/openmetadata-spec/src/main/resources/json/schema/type/changeEvent.json
@@ -61,6 +61,10 @@
       "description": "Change that lead to this version of the entity.",
       "$ref": "../type/entityHistory.json#/definitions/changeDescription"
     },
+    "recursive": {
+      "description": "True when this change event represents a recursive (cascade) delete of the entity together with its children. A single event is recorded for the deleted root entity; cascaded descendants do not produce individual change events.",
+      "type": "boolean"
+    },
     "entity": {
       "description": "For `eventType` `entityCreated`, this field captures JSON coded string of the entity using the schema corresponding to `entityType`."
     }

--- a/openmetadata-ui/src/main/resources/ui/src/generated/events/api/eventSubscriptionDiagnosticInfo.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/events/api/eventSubscriptionDiagnosticInfo.ts
@@ -120,6 +120,12 @@ export interface ChangeEvent {
      */
     previousVersion?: number;
     /**
+     * True when this change event represents a recursive (cascade) delete of the entity
+     * together with its children. A single event is recorded for the deleted root entity;
+     * cascaded descendants do not produce individual change events.
+     */
+    recursive?: boolean;
+    /**
      * Timestamp when the change was made in Unix epoch time milliseconds.
      */
     timestamp: number;

--- a/openmetadata-ui/src/main/resources/ui/src/generated/events/api/typedEvent.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/events/api/typedEvent.ts
@@ -94,6 +94,12 @@ export interface ChangeEvent {
      */
     previousVersion?: number;
     /**
+     * True when this change event represents a recursive (cascade) delete of the entity
+     * together with its children. A single event is recorded for the deleted root entity;
+     * cascaded descendants do not produce individual change events.
+     */
+    recursive?: boolean;
+    /**
      * Timestamp when the change was made in Unix epoch time milliseconds.
      *
      * Time of Failure
@@ -253,6 +259,12 @@ export interface ChangeEventClass {
      * `currentVersion`.
      */
     previousVersion?: number;
+    /**
+     * True when this change event represents a recursive (cascade) delete of the entity
+     * together with its children. A single event is recorded for the deleted root entity;
+     * cascaded descendants do not produce individual change events.
+     */
+    recursive?: boolean;
     /**
      * Timestamp when the change was made in Unix epoch time milliseconds.
      */

--- a/openmetadata-ui/src/main/resources/ui/src/generated/events/failedEvent.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/events/failedEvent.ts
@@ -100,6 +100,12 @@ export interface ChangeEvent {
      */
     previousVersion?: number;
     /**
+     * True when this change event represents a recursive (cascade) delete of the entity
+     * together with its children. A single event is recorded for the deleted root entity;
+     * cascaded descendants do not produce individual change events.
+     */
+    recursive?: boolean;
+    /**
      * Timestamp when the change was made in Unix epoch time milliseconds.
      */
     timestamp: number;

--- a/openmetadata-ui/src/main/resources/ui/src/generated/events/failedEventResponse.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/events/failedEventResponse.ts
@@ -100,6 +100,12 @@ export interface ChangeEvent {
      */
     previousVersion?: number;
     /**
+     * True when this change event represents a recursive (cascade) delete of the entity
+     * together with its children. A single event is recorded for the deleted root entity;
+     * cascaded descendants do not produce individual change events.
+     */
+    recursive?: boolean;
+    /**
      * Timestamp when the change was made in Unix epoch time milliseconds.
      */
     timestamp: number;

--- a/openmetadata-ui/src/main/resources/ui/src/generated/type/changeEvent.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/type/changeEvent.ts
@@ -72,9 +72,9 @@ export interface ChangeEvent {
      */
     previousVersion?: number;
     /**
-     * True when this change event represents a recursive (cascade) delete of the entity together
-     * with its children. A single event is recorded for the deleted root entity; cascaded
-     * descendants do not produce individual change events.
+     * True when this change event represents a recursive (cascade) delete of the entity
+     * together with its children. A single event is recorded for the deleted root entity;
+     * cascaded descendants do not produce individual change events.
      */
     recursive?: boolean;
     /**

--- a/openmetadata-ui/src/main/resources/ui/src/generated/type/changeEvent.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/type/changeEvent.ts
@@ -72,6 +72,12 @@ export interface ChangeEvent {
      */
     previousVersion?: number;
     /**
+     * True when this change event represents a recursive (cascade) delete of the entity together
+     * with its children. A single event is recorded for the deleted root entity; cascaded
+     * descendants do not produce individual change events.
+     */
+    recursive?: boolean;
+    /**
      * Timestamp when the change was made in Unix epoch time milliseconds.
      */
     timestamp: number;


### PR DESCRIPTION
### Describe your changes:

Fixes #29261

Entity deletes performed from the UI never showed up in **Audit Logs** (and were invisible to Alerts/Webhooks): the async delete endpoints return `202` with a job descriptor, so their responses bypass the `ChangeEventHandler` response filter that records change events. Recursive deletes also wrote one change event per cascaded child, so deleting a service with ~100k objects would write ~100k rows. This PR records a single root change event in the async delete/restore paths and stops emitting per-child events for cascade soft-delete/restore, so a recursive delete is audited as exactly one event for the targeted entity (keeping the delete hot path cheap), plus a `recursive` marker shown in the audit summary.

#
### Type of change:
- [x] Bug fix

#
### High-level design:

Change events (which back Audit Logs, Alerts, and Webhooks via the `change_event` table) are normally created only by the synchronous HTTP response filter through the `X-OpenMetadata-Change` header. Two paths bypassed it: (1) the async delete/restore endpoints (`deleteByIdAsync`, `restoreEntityAsync`, `deleteAppAsync`) return `202` with no such header, and (2) cascaded children were the only entities written directly — `bulkHardDeleteSubtree` wrote none while `bulkSoftDeleteSubtree`/`bulkRestoreSubtree` wrote one per child. The fix records a single root event in the async paths via a new `EntityRepository.storeChangeEventForAsyncOperation(...)`, and removes the per-child `writeBulkChangeEvents` call from `persistBulkUpdaters` (search-index, version-history, and cache updates are retained). A new optional `recursive` flag on `ChangeEvent` is set for recursive deletes and rendered as "(recursive)" in the audit summary (the UI shows `summary` directly, so no UI code change is needed). Sync deletes are unchanged (still recorded by the response filter); the `recursive` marker is set on the async path (the UI's delete path) — plumbing it through the sync path is a small optional follow-up.

#
### Tests:

#### Use cases covered
- Deleting a glossary/term/data asset from the UI (async delete) now appears in Audit Logs.
- Recursively deleting a service records one audit entry for the service, not one per cascaded child.
- The audit entry for a recursive delete is labeled "(recursive)".

#### Unit tests
- N/A — the change-event → audit-log flow requires the async consumer + DB, so it is exercised via integration tests.

#### Backend integration tests
- [x] Added in `openmetadata-integration-tests/.../AuditLogResourceIT.java`:
  - `test_auditLog_asyncHardDelete_writesEntityDeleted`
  - `test_auditLog_recursiveSoftDelete_doesNotEmitPerChildEvents`
  - `test_auditLog_asyncRecursiveHardDelete_recordsOnlyRootEvent`

#### Ingestion integration tests
- [x] Not applicable (no ingestion changes).

#### Playwright (UI) tests
- [x] Not applicable (no UI code changes; the recursive marker surfaces through the existing audit-summary rendering).

#### Manual testing performed
- `mvn -pl openmetadata-service compile/test-compile` and `openmetadata-integration-tests` test-compile pass; `mvn spotless:apply` is clean. The new integration tests were not yet executed against a live stack.

#
### UI screen recording / screenshots:

Not applicable — no UI code changes (the "(recursive)" suffix renders through the existing audit-log summary field).

#
### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] My PR title is `Fixes <issue-number>: <short explanation>`
- [x] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] For JSON Schema changes: I updated the migration scripts or explained why it is not needed. (The `recursive` field is an additive, optional property on the `ChangeEvent` JSON payload — no DB schema/migration change is required; existing rows simply read it as absent.)
- [ ] For UI changes: I attached a screen recording and/or screenshots above.
- [x] I have added tests (unit / integration / Playwright as applicable) and listed them above.

<!-- Bug fix -->
- [x] I have added a test that covers the exact scenario we are fixing.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes two audit-log blind spots: async delete/restore endpoints (which return HTTP 202 and bypass the response-filter change-event path) now record a single root change event via `storeChangeEventForAsyncOperation`, and recursive/cascade deletes no longer emit one change event per child entity — instead a single event with an optional `recursive` flag is emitted for the targeted root.

- **Async delete & restore**: `deleteByIdAsync`, `deleteAppAsync`, and `restoreEntityAsync` now call `repository.storeChangeEventForAsyncOperation(...)` after the operation commits, recording the event that previously never reached audit logs, alerts, or webhooks.
- **Cascade change-event suppression**: `persistBulkUpdaters` no longer calls `writeBulkChangeEvents`; per-child events are intentionally dropped so deleting a service with 100k descendants writes exactly one `change_event` row.
- **Schema & types**: An optional `recursive` boolean is added to the `ChangeEvent` JSON schema and auto-generated TypeScript types; existing rows are unaffected (field reads as absent).
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge. The async paths now correctly record a single root change event, and the cascade bulk-updater path no longer floods the change_event table with per-child rows. No existing sync-delete behavior is altered.

All three async paths are handled consistently. The new recursive field is additive and backward-compatible. The integration test cleanup helper has a minor gap that could leave orphaned test entities, but this does not affect production correctness.

The integration test cleanup helper in AuditLogResourceIT.java should include recursive=true on the hard-delete URL so the test DB is left clean after the recursive soft-delete test.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/EntityRepository.java | Adds storeChangeEventForAsyncOperation for async delete/restore; removes per-child writeBulkChangeEvents from persistBulkUpdaters; adds recursive flag to buildChangeEventJsonForBulkOperation. |
| openmetadata-service/src/main/java/org/openmetadata/service/resources/EntityResource.java | Calls storeChangeEventForAsyncOperation after delete and restore in async paths; change event is correctly recorded after the DB operation commits. |
| openmetadata-service/src/main/java/org/openmetadata/service/resources/apps/AppResource.java | Mirrors EntityResource fix for app-specific async delete path; consistent with the general pattern. |
| openmetadata-service/src/main/java/org/openmetadata/service/audit/AuditLogRepository.java | Adds (recursive) suffix to ENTITY_DELETED and ENTITY_SOFT_DELETED summaries when the recursive flag is set. |
| openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/AuditLogResourceIT.java | Three new integration tests cover async hard delete, sync recursive soft delete, and async recursive hard delete. The soft-delete test's finally-block cleanup may silently fail and leave orphaned entities. |
| openmetadata-spec/src/main/resources/json/schema/type/changeEvent.json | Adds optional recursive boolean field to changeEvent JSON schema; additive and backward-compatible. |
| openmetadata-ui/src/main/resources/ui/src/generated/type/changeEvent.ts | Auto-generated TypeScript type updated to include the optional recursive boolean field. |

</details>


</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant UI
    participant EntityResource
    participant Repository
    participant AsyncExecutor
    participant ChangeEventDAO
    participant ResponseFilter

    Note over UI,ResponseFilter: Async Delete Path (fixed)
    UI->>EntityResource: "DELETE /async/{id}?recursive=true"
    EntityResource->>AsyncExecutor: submit task (returns 202)
    EntityResource-->>UI: 202 Accepted (no X-OpenMetadata-Change header)
    Note over ResponseFilter: filter never fires for 202
    AsyncExecutor->>Repository: delete(id, recursive, hardDelete)
    Repository->>Repository: persistBulkUpdaters (NO writeBulkChangeEvents)
    Repository-->>AsyncExecutor: DeleteResponse
    AsyncExecutor->>Repository: "storeChangeEventForAsyncOperation(entity, eventType, recursive=true)"
    Repository->>ChangeEventDAO: "insert single root event (recursive=true)"

    Note over UI,ResponseFilter: Sync Delete Path (unchanged)
    UI->>EntityResource: "DELETE /{id}?recursive=true"
    EntityResource->>Repository: delete(id, recursive, hardDelete)
    Repository->>Repository: persistBulkUpdaters (NO writeBulkChangeEvents)
    Repository-->>EntityResource: DeleteResponse
    EntityResource-->>ResponseFilter: HTTP 200 with X-OpenMetadata-Change header
    ResponseFilter->>ChangeEventDAO: insert root event (recursive flag NOT set on sync path)
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant UI
    participant EntityResource
    participant Repository
    participant AsyncExecutor
    participant ChangeEventDAO
    participant ResponseFilter

    Note over UI,ResponseFilter: Async Delete Path (fixed)
    UI->>EntityResource: "DELETE /async/{id}?recursive=true"
    EntityResource->>AsyncExecutor: submit task (returns 202)
    EntityResource-->>UI: 202 Accepted (no X-OpenMetadata-Change header)
    Note over ResponseFilter: filter never fires for 202
    AsyncExecutor->>Repository: delete(id, recursive, hardDelete)
    Repository->>Repository: persistBulkUpdaters (NO writeBulkChangeEvents)
    Repository-->>AsyncExecutor: DeleteResponse
    AsyncExecutor->>Repository: "storeChangeEventForAsyncOperation(entity, eventType, recursive=true)"
    Repository->>ChangeEventDAO: "insert single root event (recursive=true)"

    Note over UI,ResponseFilter: Sync Delete Path (unchanged)
    UI->>EntityResource: "DELETE /{id}?recursive=true"
    EntityResource->>Repository: delete(id, recursive, hardDelete)
    Repository->>Repository: persistBulkUpdaters (NO writeBulkChangeEvents)
    Repository-->>EntityResource: DeleteResponse
    EntityResource-->>ResponseFilter: HTTP 200 with X-OpenMetadata-Change header
    ResponseFilter->>ChangeEventDAO: insert root event (recursive flag NOT set on sync path)
```

</a>
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/EntityRepository.java`, line 12896-12909 ([link](https://github.com/open-metadata/openmetadata/blob/39220fdb4b2ef00b9045bdc26d42fbdc6a5c3346/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/EntityRepository.java#L12896-L12909)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> `copyChangeEvent` doesn't carry the new `recursive` field across. Right now this is harmless because `setRecursive(true)` is called after any copy, but if someone later reuses `copyChangeEvent` on a `ChangeEvent` that already has `recursive` set (e.g., a future copy-then-re-serialize path), the flag would be silently dropped. Adding `.withRecursive(changeEvent.getRecursive())` keeps the helper a faithful full copy.

   

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["Merge branch &#39;main&#39; into harshach/audit-..."](https://github.com/open-metadata/openmetadata/commit/4e87f2730d90c89905125570d81c127ffc917e60) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38922736)</sub>

<!-- /greptile_comment -->