### PR TITLE
Backport ODPS name-guard hardening + domain-detach resilience to 1.13 (#29205)

### DIFF
--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/GlossaryTermMoveApprovalIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/GlossaryTermMoveApprovalIT.java
@@ -343,7 +343,10 @@ public class GlossaryTermMoveApprovalIT {
   }
 
   private List<Thread> listTasks(String entityLink) {
-    return SdkClients.adminClient().feed().listTasks(entityLink, TaskStatus.Open, null).getData()
+    return SdkClients.adminClient()
+        .feed()
+        .listTasks(entityLink, TaskStatus.Open, null)
+        .getData()
         .stream()
         .filter(thread -> thread.getTask() != null)
         .filter(thread -> TaskType.RequestApproval.equals(thread.getTask().getType()))

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/DataProductRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/DataProductRepository.java
@@ -211,7 +211,15 @@ public class DataProductRepository extends EntityRepository<DataProduct> {
     List<EntityReference> updatedDomains = getDomains(original, ALL);
     List<EntityReference> removedDomains = subtractById(originalDomains, updatedDomains);
     if (!removedDomains.isEmpty()) {
+      removeDomainLineageForDetached(dataProductId, removedDomains);
       persistDomainDetachVersion(original, updatedDomains, removedDomains, updatedBy);
+    }
+  }
+
+  private void removeDomainLineageForDetached(
+      UUID dataProductId, List<EntityReference> removedDomains) {
+    for (EntityReference removedDomain : removedDomains) {
+      removeDomainLineage(dataProductId, DATA_PRODUCT, removedDomain);
     }
   }
 
@@ -270,10 +278,22 @@ public class DataProductRepository extends EntityRepository<DataProduct> {
   public void reindexAfterDomainDetach(Set<UUID> dataProductIds) {
     if (searchRepository != null && !nullOrEmpty(dataProductIds)) {
       for (UUID dataProductId : dataProductIds) {
-        DataProduct dataProduct = find(dataProductId, ALL, false);
-        setFieldsInternal(dataProduct, getPutFields());
-        searchRepository.updateEntityIndex(dataProduct);
+        reindexDetachedProduct(dataProductId);
       }
+    }
+  }
+
+  private void reindexDetachedProduct(UUID dataProductId) {
+    try {
+      DataProduct dataProduct = find(dataProductId, ALL, false);
+      setFieldsInternal(dataProduct, getPutFields());
+      searchRepository.updateEntityIndex(dataProduct);
+    } catch (EntityNotFoundException e) {
+      // A retained product can still be hard-deleted elsewhere in the same domain cascade.
+      // This loop runs post-commit, so skip the vanished product and keep reindexing the rest.
+      LOG.debug(
+          "Skipping post-detach reindex for data product {} which no longer exists after the domain delete cascade",
+          dataProductId);
     }
   }
 

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/DataProductODPS.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/DataProductODPS.spec.ts
@@ -11,10 +11,15 @@
  *  limitations under the License.
  */
 import { APIRequestContext, expect, Page } from '@playwright/test';
+import { dump as yamlDump, load as yamlLoad } from 'js-yaml';
 import { DataProduct } from '../../support/domain/DataProduct';
 import { Domain } from '../../support/domain/Domain';
 import { performAdminLogin } from '../../utils/admin';
-import { redirectToHomePage, uuid } from '../../utils/common';
+import {
+  redirectToHomePage,
+  toastNotification,
+  uuid,
+} from '../../utils/common';
 import { test } from '../fixtures/pages';
 
 // ODPS (Open Data Product Specification) export/import and the data-product
@@ -58,6 +63,26 @@ const exportOdpsYaml = async (apiContext: APIRequestContext, id: string) => {
   expect(response.status()).toBe(200);
 
   return response.text();
+};
+
+// Rename only the ODPS product name (product.details.<lang>.name) rather than
+// string-replacing every occurrence of the old name in the exported document.
+// The backend derives the imported entity name by slugifying this single field
+// (ODPSConverter.fromODPS → findExistingByName), so mutating it is enough to
+// give the round-trip a fresh identity — without corrupting another field
+// (productID mirrors the FQN, description, etc.) that happens to echo the name.
+const renameOdpsProduct = (yaml: string, newName: string): string => {
+  const doc = yamlLoad(yaml) as {
+    product?: { details?: Record<string, { name?: string }> };
+  };
+  const details = doc?.product?.details ?? {};
+  Object.values(details).forEach((detail) => {
+    if (detail) {
+      detail.name = newName;
+    }
+  });
+
+  return yamlDump(doc);
 };
 
 const openManageMenu = async (page: Page, itemTestId: string) => {
@@ -166,7 +191,7 @@ test.describe('DataProduct ODPS — REST contract', () => {
     // export → import round-trip preserves the mapped fields, without colliding
     // with the source product.
     const newName = `pw-odps-imported-${uuid()}`;
-    const importYaml = yaml.split(dp.name).join(newName);
+    const importYaml = renameOdpsProduct(yaml, newName);
 
     const imported = await apiContext.post('/api/v1/dataProducts/odps/yaml', {
       headers: YAML_HEADERS,
@@ -384,10 +409,77 @@ test.describe('DataProduct ODPS & metadata — UI', () => {
       page.on('response', listener);
       await page.getByTestId('odps-import-submit').click();
 
-      // The guard short-circuits before any API call: no PUT, modal stays open.
-      await expect(async () => {
-        expect(putFired).toBe(false);
-      }).toPass({ timeout: 3000, intervals: [300] });
+      // Positive signal: the guard raises a name-mismatch toast and returns
+      // before any API call. Waiting for that toast (which only appears when the
+      // guard fires) is the real regression check — if the guard regressed, the
+      // import would proceed and this would time out. By the time the toast is
+      // visible a real PUT would already have fired, so the no-PUT assertion
+      // below is now meaningful rather than passing instantly.
+      await toastNotification(page, /match the current data product/i);
+      expect(putFired).toBe(false);
+      page.off('response', listener);
+      await expect(page.getByTestId('odps-import-modal')).toBeVisible();
+    } finally {
+      await dataProduct.delete(apiContext);
+      await afterAction();
+    }
+  });
+
+  test('name guard blocks a YAML with no readable product name', async ({
+    page,
+    browser,
+  }) => {
+    const { apiContext, afterAction } = await performAdminLogin(browser);
+    const dataProduct = new DataProduct();
+    const cleanName = `pwodpsnoname${uuid()}`;
+    dataProduct.data.name = cleanName;
+    dataProduct.data.displayName = cleanName;
+    dataProduct.data.fullyQualifiedName = cleanName;
+
+    try {
+      await dataProduct.create(apiContext);
+      await dataProduct.visitEntityPage(page);
+      await openManageMenu(page, 'import-odps-button');
+      await page.getByTestId('import-odps-button').click();
+      await expect(page.getByTestId('odps-import-modal')).toBeVisible();
+
+      // A structurally ODPS-ish document whose product.details omits `name`.
+      // The backend would still resolve (and overwrite) some product from the
+      // document, so an unreadable name must block the import rather than
+      // silently bypass the guard.
+      const noNameYaml = [
+        'schema: "https://opendataproducts.org/v4.1/schema/odps.json"',
+        'version: "4.1"',
+        'product:',
+        '  details:',
+        '    en:',
+        '      productID: "some-other-product"',
+        '      visibility: "private"',
+        '      status: "development"',
+        '      type: "dataset"',
+        '      description: "name-guard no-name decoy"',
+      ].join('\n');
+
+      const yamlField = page
+        .getByTestId('odps-yaml-content')
+        .locator('textarea');
+      await yamlField.click();
+      await yamlField.fill(noNameYaml);
+
+      let putFired = false;
+      const listener = (r: import('@playwright/test').Response) => {
+        if (
+          r.url().includes('/dataProducts/odps/yaml') &&
+          r.request().method() === 'PUT'
+        ) {
+          putFired = true;
+        }
+      };
+      page.on('response', listener);
+      await page.getByTestId('odps-import-submit').click();
+
+      await toastNotification(page, /could not read a product name/i);
+      expect(putFired).toBe(false);
       page.off('response', listener);
       await expect(page.getByTestId('odps-import-modal')).toBeVisible();
     } finally {

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/task.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/task.ts
@@ -20,6 +20,13 @@ export const waitForTaskListResponse = (page: Page) =>
     { timeout: 30_000 }
   );
 
+export const waitForTaskResolveResponse = (page: Page) =>
+  page.waitForResponse(
+    (response) =>
+      response.request().method() === 'POST' &&
+      /\/api\/v1\/tasks\/[^/]+\/resolve(?:\?|$)/.test(response.url())
+  );
+
 export type TaskDetails = {
   term: string;
   assignee?: string;

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataProducts/ODPSImportModal/ODPSImportModal.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataProducts/ODPSImportModal/ODPSImportModal.component.tsx
@@ -149,19 +149,26 @@ const ODPSImportModal = ({
       // The backend exports the ODPS `name` from displayName ?? name
       // (ODPSConverter.buildProductDetails), so an exported YAML round-trips
       // with the product's displayName, while a hand-written YAML may use the
-      // internal name. Accept either; only block when it matches neither —
-      // i.e. the YAML targets a different product the backend would overwrite.
+      // internal name. Accept either; block otherwise.
       const expectedNames = [
         existingDataProduct.displayName,
         existingDataProduct.name,
       ].filter(Boolean);
-      if (yamlName && !expectedNames.includes(yamlName)) {
+      const existingName =
+        existingDataProduct.displayName ?? existingDataProduct.name;
+      // A YAML with no readable product.details.<lang>.name can't be verified
+      // against this product, yet the backend would still resolve — and
+      // overwrite — whichever product the document maps to. Treat an
+      // unreadable name as a mismatch rather than letting an undefined result
+      // bypass the guard.
+      if (!yamlName) {
+        showErrorToast(t('message.odps-yaml-name-missing', { existingName }));
+
+        return;
+      }
+      if (!expectedNames.includes(yamlName)) {
         showErrorToast(
-          t('message.odps-yaml-name-mismatch', {
-            yamlName,
-            existingName:
-              existingDataProduct.displayName ?? existingDataProduct.name,
-          })
+          t('message.odps-yaml-name-mismatch', { yamlName, existingName })
         );
 
         return;

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/ar-sa.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/ar-sa.json
@@ -3028,6 +3028,7 @@
         "odps-validation-successful": "ODPS document is valid.",
         "odps-yaml-invalid": "The ODPS YAML document failed validation.",
         "odps-yaml-name-mismatch": "The YAML's name '{{yamlName}}' doesn't match the current data product '{{existingName}}'. Update the YAML or use the data product page for '{{yamlName}}' to avoid overwriting a different product.",
+        "odps-yaml-name-missing": "Could not read a product name from the YAML (product.details.<language>.name). Add a name matching the current data product '{{existingName}}' before importing, to avoid overwriting a different product.",
         "odps-yaml-valid-description": "Valid ODPS v{{version}} document with languages: {{languages}}.",
         "om-description": "متجر مركزي للبيانات الوصفية، للاكتشاف والتعاون والحصول على بياناتك بشكل صحيح.",
         "om-url-configuration-message": "قم بتكوين إعدادات عنوان URL لـ {{brandName}}.",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/de-de.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/de-de.json
@@ -3028,6 +3028,7 @@
         "odps-validation-successful": "ODPS document is valid.",
         "odps-yaml-invalid": "The ODPS YAML document failed validation.",
         "odps-yaml-name-mismatch": "The YAML's name '{{yamlName}}' doesn't match the current data product '{{existingName}}'. Update the YAML or use the data product page for '{{yamlName}}' to avoid overwriting a different product.",
+        "odps-yaml-name-missing": "Could not read a product name from the YAML (product.details.<language>.name). Add a name matching the current data product '{{existingName}}' before importing, to avoid overwriting a different product.",
         "odps-yaml-valid-description": "Valid ODPS v{{version}} document with languages: {{languages}}.",
         "om-description": "Zentraler Metadatenspeicher, um Daten zu entdecken, zusammenzuarbeiten und die Datenqualität zu verbessern.",
         "om-url-configuration-message": "Konfigurieren Sie die {{brandName}}-URL-Einstellungen.",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/en-us.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/en-us.json
@@ -3028,6 +3028,7 @@
     "odps-validation-successful": "ODPS document is valid.",
     "odps-yaml-invalid": "The ODPS YAML document failed validation.",
     "odps-yaml-name-mismatch": "The YAML's name '{{yamlName}}' doesn't match the current data product '{{existingName}}'. Update the YAML or use the data product page for '{{yamlName}}' to avoid overwriting a different product.",
+    "odps-yaml-name-missing": "Could not read a product name from the YAML (product.details.<language>.name). Add a name matching the current data product '{{existingName}}' before importing, to avoid overwriting a different product.",
     "odps-yaml-valid-description": "Valid ODPS v{{version}} document with languages: {{languages}}.",
     "om-description": "Centralized metadata store, to discover, collaborate and get your data right.",
     "om-url-configuration-message": "Configure the {{brandName}} URL Settings.",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/es-es.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/es-es.json
@@ -3028,6 +3028,7 @@
         "odps-validation-successful": "ODPS document is valid.",
         "odps-yaml-invalid": "The ODPS YAML document failed validation.",
         "odps-yaml-name-mismatch": "The YAML's name '{{yamlName}}' doesn't match the current data product '{{existingName}}'. Update the YAML or use the data product page for '{{yamlName}}' to avoid overwriting a different product.",
+        "odps-yaml-name-missing": "Could not read a product name from the YAML (product.details.<language>.name). Add a name matching the current data product '{{existingName}}' before importing, to avoid overwriting a different product.",
         "odps-yaml-valid-description": "Valid ODPS v{{version}} document with languages: {{languages}}.",
         "om-description": "Almacenamiento centralizado de metadatos para descubrir, colaborar y tener los datos correctos.",
         "om-url-configuration-message": "Configura los Ajustes de la URL de {{brandName}}.",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/fr-fr.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/fr-fr.json
@@ -3028,6 +3028,7 @@
         "odps-validation-successful": "ODPS document is valid.",
         "odps-yaml-invalid": "The ODPS YAML document failed validation.",
         "odps-yaml-name-mismatch": "The YAML's name '{{yamlName}}' doesn't match the current data product '{{existingName}}'. Update the YAML or use the data product page for '{{yamlName}}' to avoid overwriting a different product.",
+        "odps-yaml-name-missing": "Could not read a product name from the YAML (product.details.<language>.name). Add a name matching the current data product '{{existingName}}' before importing, to avoid overwriting a different product.",
         "odps-yaml-valid-description": "Valid ODPS v{{version}} document with languages: {{languages}}.",
         "om-description": "Entrepôt centralisé de métadonnées, découvrez, collaborez et assurez-vous que vos données sont correctes",
         "om-url-configuration-message": "Configurez les paramètres d'URL d'{{brandName}}.",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/gl-es.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/gl-es.json
@@ -3028,6 +3028,7 @@
         "odps-validation-successful": "ODPS document is valid.",
         "odps-yaml-invalid": "The ODPS YAML document failed validation.",
         "odps-yaml-name-mismatch": "The YAML's name '{{yamlName}}' doesn't match the current data product '{{existingName}}'. Update the YAML or use the data product page for '{{yamlName}}' to avoid overwriting a different product.",
+        "odps-yaml-name-missing": "Could not read a product name from the YAML (product.details.<language>.name). Add a name matching the current data product '{{existingName}}' before importing, to avoid overwriting a different product.",
         "odps-yaml-valid-description": "Valid ODPS v{{version}} document with languages: {{languages}}.",
         "om-description": "Repositorio centralizado de metadatos, para descubrir, colaborar e xestionar os teus datos.",
         "om-url-configuration-message": "Configure the {{brandName}} URL Settings.",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/he-he.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/he-he.json
@@ -3028,6 +3028,7 @@
         "odps-validation-successful": "ODPS document is valid.",
         "odps-yaml-invalid": "The ODPS YAML document failed validation.",
         "odps-yaml-name-mismatch": "The YAML's name '{{yamlName}}' doesn't match the current data product '{{existingName}}'. Update the YAML or use the data product page for '{{yamlName}}' to avoid overwriting a different product.",
+        "odps-yaml-name-missing": "Could not read a product name from the YAML (product.details.<language>.name). Add a name matching the current data product '{{existingName}}' before importing, to avoid overwriting a different product.",
         "odps-yaml-valid-description": "Valid ODPS v{{version}} document with languages: {{languages}}.",
         "om-description": "אחסון מטה מרכזי, לגלוש, לשתף פעולה ולהבין את הנתונים שלך כראוי.",
         "om-url-configuration-message": "הגדר את הגדרות ה-URL של {{brandName}}.",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/ja-jp.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/ja-jp.json
@@ -3028,6 +3028,7 @@
         "odps-validation-successful": "ODPS document is valid.",
         "odps-yaml-invalid": "The ODPS YAML document failed validation.",
         "odps-yaml-name-mismatch": "The YAML's name '{{yamlName}}' doesn't match the current data product '{{existingName}}'. Update the YAML or use the data product page for '{{yamlName}}' to avoid overwriting a different product.",
+        "odps-yaml-name-missing": "Could not read a product name from the YAML (product.details.<language>.name). Add a name matching the current data product '{{existingName}}' before importing, to avoid overwriting a different product.",
         "odps-yaml-valid-description": "Valid ODPS v{{version}} document with languages: {{languages}}.",
         "om-description": "中央集約型のメタデータストアで、データの発見・連携・管理を実現します。",
         "om-url-configuration-message": "{{brandName}} の URL 設定を構成してください。",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/ko-kr.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/ko-kr.json
@@ -3029,6 +3029,7 @@
         "odps-validation-successful": "ODPS document is valid.",
         "odps-yaml-invalid": "The ODPS YAML document failed validation.",
         "odps-yaml-name-mismatch": "The YAML's name '{{yamlName}}' doesn't match the current data product '{{existingName}}'. Update the YAML or use the data product page for '{{yamlName}}' to avoid overwriting a different product.",
+        "odps-yaml-name-missing": "Could not read a product name from the YAML (product.details.<language>.name). Add a name matching the current data product '{{existingName}}' before importing, to avoid overwriting a different product.",
         "odps-yaml-valid-description": "Valid ODPS v{{version}} document with languages: {{languages}}.",
         "om-description": "데이터를 발견하고, 협업하고, 올바르게 사용하기 위한 중앙 집중식 메타데이터 저장소입니다.",
         "om-url-configuration-message": "사용 가능한 서비스 인사이트 데이터가 없습니다.",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/mr-in.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/mr-in.json
@@ -3028,6 +3028,7 @@
         "odps-validation-successful": "ODPS document is valid.",
         "odps-yaml-invalid": "The ODPS YAML document failed validation.",
         "odps-yaml-name-mismatch": "The YAML's name '{{yamlName}}' doesn't match the current data product '{{existingName}}'. Update the YAML or use the data product page for '{{yamlName}}' to avoid overwriting a different product.",
+        "odps-yaml-name-missing": "Could not read a product name from the YAML (product.details.<language>.name). Add a name matching the current data product '{{existingName}}' before importing, to avoid overwriting a different product.",
         "odps-yaml-valid-description": "Valid ODPS v{{version}} document with languages: {{languages}}.",
         "om-description": "केंद्रीकृत मेटाडेटा स्टोअर, शोधण्यासाठी, सहयोग करण्यासाठी आणि तुमचा डेटा योग्य मिळवण्यासाठी.",
         "om-url-configuration-message": "Configure the {{brandName}} URL Settings.",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/nl-nl.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/nl-nl.json
@@ -3028,6 +3028,7 @@
         "odps-validation-successful": "ODPS document is valid.",
         "odps-yaml-invalid": "The ODPS YAML document failed validation.",
         "odps-yaml-name-mismatch": "The YAML's name '{{yamlName}}' doesn't match the current data product '{{existingName}}'. Update the YAML or use the data product page for '{{yamlName}}' to avoid overwriting a different product.",
+        "odps-yaml-name-missing": "Could not read a product name from the YAML (product.details.<language>.name). Add a name matching the current data product '{{existingName}}' before importing, to avoid overwriting a different product.",
         "odps-yaml-valid-description": "Valid ODPS v{{version}} document with languages: {{languages}}.",
         "om-description": "Gecentraliseerde metadatastore, om data te ontdekken, samen te werken en op orde te brengen.",
         "om-url-configuration-message": "Configureer de {{brandName}} URL-instellingen.",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/pr-pr.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/pr-pr.json
@@ -3030,6 +3030,7 @@
         "odps-validation-successful": "ODPS document is valid.",
         "odps-yaml-invalid": "The ODPS YAML document failed validation.",
         "odps-yaml-name-mismatch": "The YAML's name '{{yamlName}}' doesn't match the current data product '{{existingName}}'. Update the YAML or use the data product page for '{{yamlName}}' to avoid overwriting a different product.",
+        "odps-yaml-name-missing": "Could not read a product name from the YAML (product.details.<language>.name). Add a name matching the current data product '{{existingName}}' before importing, to avoid overwriting a different product.",
         "odps-yaml-valid-description": "Valid ODPS v{{version}} document with languages: {{languages}}.",
         "om-description": "ذخیره متمرکز متادیتا، برای کشف، همکاری و درست کردن داده‌های شما.",
         "om-url-configuration-message": "Configure the {{brandName}} URL Settings.",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/pt-br.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/pt-br.json
@@ -3028,6 +3028,7 @@
         "odps-validation-successful": "ODPS document is valid.",
         "odps-yaml-invalid": "The ODPS YAML document failed validation.",
         "odps-yaml-name-mismatch": "The YAML's name '{{yamlName}}' doesn't match the current data product '{{existingName}}'. Update the YAML or use the data product page for '{{yamlName}}' to avoid overwriting a different product.",
+        "odps-yaml-name-missing": "Could not read a product name from the YAML (product.details.<language>.name). Add a name matching the current data product '{{existingName}}' before importing, to avoid overwriting a different product.",
         "odps-yaml-valid-description": "Valid ODPS v{{version}} document with languages: {{languages}}.",
         "om-description": "Armazenamento centralizado de metadados, para descobrir, colaborar e obter seus dados corretamente.",
         "om-url-configuration-message": "Defina as configurações de URL do {{brandName}}.",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/pt-pt.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/pt-pt.json
@@ -3028,6 +3028,7 @@
         "odps-validation-successful": "ODPS document is valid.",
         "odps-yaml-invalid": "The ODPS YAML document failed validation.",
         "odps-yaml-name-mismatch": "The YAML's name '{{yamlName}}' doesn't match the current data product '{{existingName}}'. Update the YAML or use the data product page for '{{yamlName}}' to avoid overwriting a different product.",
+        "odps-yaml-name-missing": "Could not read a product name from the YAML (product.details.<language>.name). Add a name matching the current data product '{{existingName}}' before importing, to avoid overwriting a different product.",
         "odps-yaml-valid-description": "Valid ODPS v{{version}} document with languages: {{languages}}.",
         "om-description": "Armazenamento centralizado de metadados, para descobrir, colaborar e obter seus dados corretamente.",
         "om-url-configuration-message": "Configure as Definições de URL do {{brandName}}.",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/ru-ru.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/ru-ru.json
@@ -3029,6 +3029,7 @@
         "odps-validation-successful": "ODPS document is valid.",
         "odps-yaml-invalid": "The ODPS YAML document failed validation.",
         "odps-yaml-name-mismatch": "The YAML's name '{{yamlName}}' doesn't match the current data product '{{existingName}}'. Update the YAML or use the data product page for '{{yamlName}}' to avoid overwriting a different product.",
+        "odps-yaml-name-missing": "Could not read a product name from the YAML (product.details.<language>.name). Add a name matching the current data product '{{existingName}}' before importing, to avoid overwriting a different product.",
         "odps-yaml-valid-description": "Valid ODPS v{{version}} document with languages: {{languages}}.",
         "om-description": "Централизованное хранилище метаданных для обнаружения, совместной работы и правильной обработки ваших данных.",
         "om-url-configuration-message": "Настройте параметры URL {{brandName}}.",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/th-th.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/th-th.json
@@ -3029,6 +3029,7 @@
         "odps-validation-successful": "ODPS document is valid.",
         "odps-yaml-invalid": "The ODPS YAML document failed validation.",
         "odps-yaml-name-mismatch": "The YAML's name '{{yamlName}}' doesn't match the current data product '{{existingName}}'. Update the YAML or use the data product page for '{{yamlName}}' to avoid overwriting a different product.",
+        "odps-yaml-name-missing": "Could not read a product name from the YAML (product.details.<language>.name). Add a name matching the current data product '{{existingName}}' before importing, to avoid overwriting a different product.",
         "odps-yaml-valid-description": "Valid ODPS v{{version}} document with languages: {{languages}}.",
         "om-description": "ที่จัดเก็บข้อมูลเมตาที่รวมศูนย์ เพื่อค้นหา, ร่วมมือ และรับข้อมูลที่ถูกต้อง",
         "om-url-configuration-message": "Configure the {{brandName}} URL Settings.",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/tr-tr.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/tr-tr.json
@@ -3028,6 +3028,7 @@
         "odps-validation-successful": "ODPS document is valid.",
         "odps-yaml-invalid": "The ODPS YAML document failed validation.",
         "odps-yaml-name-mismatch": "The YAML's name '{{yamlName}}' doesn't match the current data product '{{existingName}}'. Update the YAML or use the data product page for '{{yamlName}}' to avoid overwriting a different product.",
+        "odps-yaml-name-missing": "Could not read a product name from the YAML (product.details.<language>.name). Add a name matching the current data product '{{existingName}}' before importing, to avoid overwriting a different product.",
         "odps-yaml-valid-description": "Valid ODPS v{{version}} document with languages: {{languages}}.",
         "om-description": "Merkezi metadata deposu, keşfetmek, işbirliği yapmak ve verilerinizi doğru almak için.",
         "om-url-configuration-message": "{{brandName}} URL Ayarlarını yapılandırın.",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/zh-cn.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/zh-cn.json
@@ -3028,6 +3028,7 @@
         "odps-validation-successful": "ODPS document is valid.",
         "odps-yaml-invalid": "The ODPS YAML document failed validation.",
         "odps-yaml-name-mismatch": "The YAML's name '{{yamlName}}' doesn't match the current data product '{{existingName}}'. Update the YAML or use the data product page for '{{yamlName}}' to avoid overwriting a different product.",
+        "odps-yaml-name-missing": "Could not read a product name from the YAML (product.details.<language>.name). Add a name matching the current data product '{{existingName}}' before importing, to avoid overwriting a different product.",
         "odps-yaml-valid-description": "Valid ODPS v{{version}} document with languages: {{languages}}.",
         "om-description": "统一的元数据存储平台, 更好地探索、协作和处理数据",
         "om-url-configuration-message": "配置{{brandName}} URL设置。",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/zh-tw.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/zh-tw.json
@@ -3028,6 +3028,7 @@
         "odps-validation-successful": "ODPS document is valid.",
         "odps-yaml-invalid": "The ODPS YAML document failed validation.",
         "odps-yaml-name-mismatch": "The YAML's name '{{yamlName}}' doesn't match the current data product '{{existingName}}'. Update the YAML or use the data product page for '{{yamlName}}' to avoid overwriting a different product.",
+        "odps-yaml-name-missing": "Could not read a product name from the YAML (product.details.<language>.name). Add a name matching the current data product '{{existingName}}' before importing, to avoid overwriting a different product.",
         "odps-yaml-valid-description": "Valid ODPS v{{version}} document with languages: {{languages}}.",
         "om-description": "集中的元資料儲存庫，用於探索、協作並確保您的資料正確。",
         "om-url-configuration-message": "設定 {{brandName}} URL 設定。",


### PR DESCRIPTION
## What

Backports the remaining delta of **#29205** (_Fix ODPS import/merge + data-product metadata persistence bugs_, originally #27600) into **1.13**.

1.13 already received the ODPS + Custom Intake Forms feature via **#29154**, which landed *before* #29205's follow-up fixes merged to main. As a result, **ODPS import/merge fixes 1–5 and custom intake forms are already in 1.13** (verified: `DataProductResource.java`, `ODPSConverter.java`, the `recordChange` persistence fix, and the js-yaml `extractOdpsProductName` helper are all identical to main). This PR completes the set with the small remaining delta.

## Changes

### ODPS import name guard (UI)
- **`ODPSImportModal.component.tsx`** — treat a YAML whose `product.details.<lang>.name` is unreadable as a **name mismatch** (block + `odps-yaml-name-missing` toast) instead of letting an `undefined` result bypass the guard and silently overwrite a sibling product.
- **`odps-yaml-name-missing`** locale key added to all **19** locale files present in 1.13 (main's 20th locale, `sv-se`, does not exist in 1.13).
- **`DataProductODPS.spec.ts`** — adds the `name guard blocks a YAML with no readable product name` regression test; replaces the fragile `yaml.split(dp.name).join()` in the round-trip test with a js-yaml `renameOdpsProduct` helper; and upgrades the existing mismatch test to a positive toast assertion.

These three files are now **byte-identical to `main`**.

### DataProduct domain hard-delete resilience (backend, `DataProductRepository.java`)
- **`removeDomainLineageForDetached`** — drop stale domain-lineage edges when a product is detached during a domain hard-delete cascade.
- **`reindexDetachedProduct`** — tolerate a product that was hard-deleted elsewhere in the same cascade (`EntityNotFoundException`) instead of aborting the whole post-detach reindex loop. Adapted to 1.13's loop shape (main's `SearchIndexRetryQueue` deferral branch is intentionally **not** backported — that infrastructure isn't in 1.13).

## Why
ODPS / custom intake forms are on the critical path for Domains, Data Products, and Glossary Terms; this hardens the import name guard against silent cross-product overwrites and the domain-detach cascade against partial-failure aborts.

## Testing
- `mvn -pl openmetadata-service compile` — **BUILD SUCCESS**.
- `mvn -pl openmetadata-service spotless:apply` — no changes (already formatted).
- All 19 edited locale files validated as JSON; key placed alphabetically (`mismatch` < `missing` < `valid-description`).
- Playwright `DataProductODPS.spec.ts` (10 tests) requires a running stack — not executed in this environment; the spec is byte-identical to the main version that passes CI.

## Type of change
- [x] Bug fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR backports two targeted hardening fixes to the 1.13 branch: a UI name-guard tightening for ODPS imports and backend resilience for the domain hard-delete cascade. Both changes are already merged to `main` via #29205; this PR adapts the backend portion to 1.13's transaction shape (no `SearchIndexRetryQueue`).

- **ODPS name guard** (`ODPSImportModal.component.tsx` + 19 locale files): A YAML whose `product.details.<lang>.name` is absent or unreadable now raises an explicit `odps-yaml-name-missing` error toast and aborts the import, closing the bypass path where `undefined` would silently pass the previous `yamlName && !expectedNames.includes(yamlName)` check. The Playwright spec adds a direct regression test and upgrades the mismatch test to a positive toast assertion.
- **Domain hard-delete resilience** (`DataProductRepository.java`): `removeDomainLineageForDetached` drops stale lineage edges during detach (before the version write), and `reindexDetachedProduct` catches `EntityNotFoundException` so a concurrently hard-deleted product does not abort the post-detach reindex loop for other products in the cascade.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the changes are narrow defensive fixes with no regressions visible in the diff or surrounding code.

Both changes are additive guards: the UI fix closes a silent bypass path in the import modal; the backend fix adds lineage cleanup before the version write and prevents a single missing product from aborting the reindex loop. The removeDomainLineage call follows the same argument ordering as the two existing call-sites in EntityRepository and DomainRepository. The EntityNotFoundException catch is intentionally narrow and does not suppress other failures. No data migration, schema change, or breaking API change is involved.

No files require special attention. The 19 locale files all carry the identical English fallback string, which is consistent with the rest of this project's i18n approach.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/DataProductRepository.java | Adds removeDomainLineageForDetached to drop stale lineage edges when a domain is hard-deleted, and extracts reindexDetachedProduct to swallow EntityNotFoundException so one vanished product doesn't abort the whole reindex loop. Argument ordering in the removeDomainLineage call matches the existing pattern in EntityRepository and DomainRepository. |
| openmetadata-ui/src/main/resources/ui/src/components/DataProducts/ODPSImportModal/ODPSImportModal.component.tsx | Name guard now treats a YAML with no readable product.details.<lang>.name as a hard block (new odps-yaml-name-missing toast) rather than letting undefined bypass the existing name-mismatch check and silently overwrite a sibling product. |
| openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/DataProductODPS.spec.ts | Adds a regression test for the no-name YAML guard, upgrades the mismatch test to a positive toast assertion, and replaces the fragile yaml.split(dp.name).join() round-trip mutation with the proper renameOdpsProduct js-yaml helper. |
| openmetadata-ui/src/main/resources/ui/playwright/utils/task.ts | Adds waitForTaskResolveResponse helper that intercepts POST requests to /api/v1/tasks/{id}/resolve; not consumed within this diff but consistent with the existing waitForTaskListResponse pattern. |
| openmetadata-ui/src/main/resources/ui/src/locale/languages/en-us.json | Adds odps-yaml-name-missing locale key alphabetically between odps-yaml-name-mismatch and odps-yaml-valid-description; identical English string added to all 19 locale files. |
| openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/GlossaryTermMoveApprovalIT.java | Formatting-only change: reformats a long method-chain call in listTasks to satisfy the Spotless line-length rule; no logic change. |

</details>

</details>

<details open><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[User submits ODPS YAML in modal] --> B{existingDataProduct present?}
    B -- No --> F[Proceed to import API call]
    B -- Yes --> C[extractOdpsProductName]
    C --> D{yamlName readable?}
    D -- No --> E[Toast: odps-yaml-name-missing\nAbort import]
    D -- Yes --> G{yamlName in expectedNames?}
    G -- No --> H[Toast: odps-yaml-name-mismatch\nAbort import]
    G -- Yes --> F

    subgraph Backend - Domain Hard-Delete Cascade
        I[detachFromDeletingDomains] --> J[removeDomainContainment]
        J --> K[removeDomainLineageForDetached\ndrop stale lineage edges]
        K --> L[persistDomainDetachVersion\nbump version + emit event]
        L --> M[reindexAfterDomainDetach loop]
        M --> N{EntityNotFoundException?}
        N -- Yes --> O[LOG.debug skip\ncontinue loop]
        N -- No --> P[updateEntityIndex in search]
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[User submits ODPS YAML in modal] --> B{existingDataProduct present?}
    B -- No --> F[Proceed to import API call]
    B -- Yes --> C[extractOdpsProductName]
    C --> D{yamlName readable?}
    D -- No --> E[Toast: odps-yaml-name-missing\nAbort import]
    D -- Yes --> G{yamlName in expectedNames?}
    G -- No --> H[Toast: odps-yaml-name-mismatch\nAbort import]
    G -- Yes --> F

    subgraph Backend - Domain Hard-Delete Cascade
        I[detachFromDeletingDomains] --> J[removeDomainContainment]
        J --> K[removeDomainLineageForDetached\ndrop stale lineage edges]
        K --> L[persistDomainDetachVersion\nbump version + emit event]
        L --> M[reindexAfterDomainDetach loop]
        M --> N{EntityNotFoundException?}
        N -- Yes --> O[LOG.debug skip\ncontinue loop]
        N -- No --> P[updateEntityIndex in search]
    end
```

</a>
</details>

<sub>Reviews (3): Last reviewed commit: ["test(playwright): add missing waitForTas..."](https://github.com/open-metadata/openmetadata/commit/a8cc4f8b6149ac69428ac71326d36c7ad8330ec5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38926406)</sub>

<!-- /greptile_comment -->