### PR TITLE
Fix SocketAddressFilter NPE on WebSocket handshake without query string

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/socket/SocketAddressFilter.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/socket/SocketAddressFilter.java
@@ -51,7 +51,9 @@ public class SocketAddressFilter implements Filter {
       throws IOException {
     try {
       HttpServletRequest httpServletRequest = (HttpServletRequest) request;
-      Map<String, String> query = ParseQS.decode(httpServletRequest.getQueryString());
+      String queryString = httpServletRequest.getQueryString();
+      Map<String, String> query =
+          queryString != null && !queryString.isBlank() ? ParseQS.decode(queryString) : Map.of();
 
       HeaderRequestWrapper requestWrapper = new HeaderRequestWrapper(httpServletRequest);
       requestWrapper.addHeader("RemoteAddress", httpServletRequest.getRemoteAddr());

--- a/openmetadata-service/src/test/java/org/openmetadata/service/socket/SocketAddressFilterTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/socket/SocketAddressFilterTest.java
@@ -1,0 +1,35 @@
+package org.openmetadata.service.socket;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class SocketAddressFilterTest {
+
+  @Mock private HttpServletRequest request;
+  @Mock private HttpServletResponse response;
+  @Mock private FilterChain chain;
+
+  @Test
+  void handshakeWithoutQueryStringDoesNotFail() throws Exception {
+    SocketAddressFilter filter = new SocketAddressFilter();
+    when(request.getQueryString()).thenReturn(null);
+    when(request.getRemoteAddr()).thenReturn("127.0.0.1");
+
+    filter.doFilter(request, response, chain);
+
+    verify(chain).doFilter(any(), eq(response));
+    verify(response, never()).getWriter();
+  }
+}


### PR DESCRIPTION
## Problem

Production Sentry (release **1.13.0**, `release-1-13-dev`) is logging a recurring error — Sentry issue **COLLATE-BACKEND-4S**:

```
[SAFilter] Failed in filtering request: Cannot invoke "String.split(String)" because "qs" is null
```

A WebSocket handshake that reaches `SocketAddressFilter` **without any query string** makes `HttpServletRequest.getQueryString()` return `null`. The filter passed that straight into `ParseQS.decode(...)`, whose very first action is `qs.split("&")` → `NullPointerException` (`qs` is the parameter name inside `io.socket.engineio.server.utils.ParseQS.decode`). The NPE is swallowed by the `catch` block (the `LOG.error` on line 68 is what Sentry captures) and the handshake fails with a 500.

## Fix

Guard the null/blank query string and fall back to an empty parameter map before calling `ParseQS.decode`:

```java
String queryString = httpServletRequest.getQueryString();
Map<String, String> query =
    queryString != null && !queryString.isBlank() ? ParseQS.decode(queryString) : Map.of();
```

`main` already carries an equivalent guard, but only incidentally as part of the large session-management PR #26314 (not backportable as-is). This is the minimal, self-contained backport for the **1.13** release line (the bug is live on `1.13`, `1.13.0`, `1.13.1`, and `hotfix/1.13`).

## Test

Adds `SocketAddressFilterTest.handshakeWithoutQueryStringDoesNotFail`, a focused regression test. Verified locally:

- **RED** (without the guard): the test reproduces the exact production error —
  `[SAFilter] Failed in filtering request: Cannot invoke "String.split(String)" because "qs" is null` — and fails.
- **GREEN** (with the guard): `Tests run: 1, Failures: 0, Errors: 0` / `BUILD SUCCESS`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Fixes a production NPE in `SocketAddressFilter` where a WebSocket handshake arriving without a query string caused `ParseQS.decode(null)` to throw, failing the handshake with a 500. The guard is correct and matches the equivalent fix already present on `main`.

- **`SocketAddressFilter.java`**: Introduces a `null`/blank check on `getQueryString()` before calling `ParseQS.decode()`, falling back to `Map.of()` — a safe, immutable empty map.
- **`SocketAddressFilterTest.java`**: New regression test verifies the filter completes successfully and invokes the `FilterChain` when `getQueryString()` returns `null`; the blank-string (`\"\"`) branch added by `isBlank()` is not covered by the test.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; the change is a one-line guard that directly resolves a confirmed production crash without touching any other logic.

The fix is minimal and correct — guarding against a null/blank query string before calling ParseQS.decode(). The test file is new and covers the main null-query-string scenario well, but the isBlank() branch (empty string) has no corresponding test case.

SocketAddressFilterTest.java — the blank query-string branch of the guard condition is not tested.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-service/src/main/java/org/openmetadata/service/socket/SocketAddressFilter.java | Adds null/blank guard before ParseQS.decode(); correct minimal fix for the production NPE |
| openmetadata-service/src/test/java/org/openmetadata/service/socket/SocketAddressFilterTest.java | New regression test covers null query-string path; blank string branch (isBlank guard) has no test case |

</details>

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Client
    participant SocketAddressFilter
    participant ParseQS
    participant FilterChain

    Client->>SocketAddressFilter: WebSocket handshake (no query string)
    SocketAddressFilter->>SocketAddressFilter: getQueryString() → null
    Note over SocketAddressFilter: BEFORE fix: passes null to ParseQS.decode()<br/>→ NPE → 500 error
    Note over SocketAddressFilter: AFTER fix: null check → Map.of()
    SocketAddressFilter->>FilterChain: doFilter(requestWrapper, response)
    FilterChain-->>Client: 101 Switching Protocols
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Client
    participant SocketAddressFilter
    participant ParseQS
    participant FilterChain

    Client->>SocketAddressFilter: WebSocket handshake (no query string)
    SocketAddressFilter->>SocketAddressFilter: getQueryString() → null
    Note over SocketAddressFilter: BEFORE fix: passes null to ParseQS.decode()<br/>→ NPE → 500 error
    Note over SocketAddressFilter: AFTER fix: null check → Map.of()
    SocketAddressFilter->>FilterChain: doFilter(requestWrapper, response)
    FilterChain-->>Client: 101 Switching Protocols
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["Fix SocketAddressFilter NPE on WebSocket..."](https://github.com/open-metadata/openmetadata/commit/68d696b2ddf987db3521c18505e71488131fd0ca) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38940644)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->