### PR TITLE
test(playwright): add waitForTaskResolveResponse helper to task utils

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/task.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/task.ts
@@ -21,7 +21,7 @@ export const waitForTaskListResponse = (page: Page) =>
   );
 
 export const waitForTaskResolveResponse = (page: Page) =>
-  page.waitForResponse('/api/v1/feed/tasks/*/resolve');
+  page.waitForResponse('/api/v1/feed/tasks/*/resolve', { timeout: 30_000 });
 
 export type TaskDetails = {
   term: string;

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/task.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/task.ts
@@ -21,11 +21,7 @@ export const waitForTaskListResponse = (page: Page) =>
   );
 
 export const waitForTaskResolveResponse = (page: Page) =>
-  page.waitForResponse(
-    (response) =>
-      response.request().method() === 'POST' &&
-      /\/api\/v1\/tasks\/[^/]+\/resolve(?:\?|$)/.test(response.url())
-  );
+  page.waitForResponse('/api/v1/feed/tasks/*/resolve', { timeout: 30_000 });
 
 export type TaskDetails = {
   term: string;

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/task.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/task.ts
@@ -20,6 +20,9 @@ export const waitForTaskListResponse = (page: Page) =>
     { timeout: 30_000 }
   );
 
+export const waitForTaskResolveResponse = (page: Page) =>
+  page.waitForResponse('/api/v1/feed/tasks/*/resolve');
+
 export type TaskDetails = {
   term: string;
   assignee?: string;


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:

Fixes #29264 

GlossaryApprovalAfterMove.spec.ts imports waitForTaskResolveResponse from utils/task, but the helper only exists on main (which uses the rewritten /api/v1/tasks API) and was never present on 1.13. This caused the test to fail at runtime


<img width="895" height="579" alt="Screenshot 2026-06-22 at 10 46 01 AM" src="https://github.com/user-attachments/assets/9b96702a-5297-412d-a7bb-bd150ccc99b4" />


### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### High-level design:
<!--
REQUIRED for large PRs (new features, refactors, breaking changes, or anything touching >5 files).
Skip for small bug fixes and trivial changes.

Cover:
- Architecture / approach you took and why
- Key components or files added/changed and how they interact
- Alternatives considered and why you rejected them
- Any migration, backward-compatibility, or rollout concerns
- Diagrams or links to design docs / RFCs if available
-->

N/A — small change. <!-- Or fill in the design above -->

#
### Tests:

#### Use cases covered
<!--
List the user-visible scenarios this PR exercises. Example:
- User with Admin role can create a Glossary Term with a parent term
- Ingestion run for Snowflake correctly extracts row counts for partitioned tables
-->

#### Unit tests
<!--
- [ ] I added unit tests for the new/changed logic.
- Files added/updated:
- Coverage on changed classes (run `mvn jacoco:report` for backend, `yarn test:coverage` for UI,
  `make unit_ingestion` for ingestion). Target is 90% line coverage on changed classes.
- Coverage %: <e.g., 92% on EntityRepository.java>
-->

#### Backend integration tests
<!--
- [ ] I added integration tests in `openmetadata-integration-tests/` for new/changed API endpoints.
- [ ] Not applicable (no backend API changes).
- Files added/updated:
-->

#### Ingestion integration tests
<!--
- [ ] I added/updated ingestion integration tests for connector changes.
- [ ] Not applicable (no ingestion changes).
- Files added/updated:
-->

#### Playwright (UI) tests
<!--
- [ ] I added Playwright E2E tests under `openmetadata-ui/.../ui/playwright/` for UI changes.
- [ ] Not applicable (no UI changes).
- Files added/updated:
-->

#### Manual testing performed
<!--
List the manual test steps you performed before requesting review. Example:
1. Started local stack via `./docker/run_local_docker.sh -m ui -d mysql`
2. Logged in as admin, created entity X, verified Y appears in the UI
3. Triggered ingestion for Snowflake source, confirmed lineage edges in the explore page
-->

#
### UI screen recording / screenshots:
<!--
REQUIRED for any PR that changes the UI. Drag-and-drop a short screen recording (.mov / .mp4 / .gif)
demonstrating the change end-to-end, plus before/after screenshots where relevant.
Mark "Not applicable" if there are no UI changes.
-->

Not applicable. <!-- Or attach recording/screenshots above -->

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.
- [ ] For UI changes: I attached a screen recording and/or screenshots above.
- [ ] I have added tests (unit / integration / Playwright as applicable) and listed them above.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Backports the `waitForTaskResolveResponse` helper to the 1.13 branch, fixing a runtime import failure in `GlossaryApprovalAfterMove.spec.ts`. The helper was previously only present on `main` and targeted the newer `/api/v1/tasks/{id}/resolve` API; the 1.13 version points at the correct `/api/v1/feed/tasks/*/resolve` endpoint.

- Adds `waitForTaskResolveResponse` to `task.ts` on the 1.13 branch using Playwright's glob URL matching instead of the predicate-based form used on `main`.
- Includes `{ timeout: 30_000 }` to keep the helper consistent with the existing `waitForTaskListResponse` sibling.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is a minimal one-liner backport that adds a previously missing test helper using the correct 1.13 API endpoint.

The change is isolated to a single test utility function and corrects a real import-time failure. The endpoint glob and timeout are appropriate for the 1.13 API surface. No production code is touched.

No files require special attention.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-ui/src/main/resources/ui/playwright/utils/task.ts | Replaces the main-branch `/api/v1/tasks/{id}/resolve` predicate with a 1.13-compatible glob pattern targeting `/api/v1/feed/tasks/*/resolve`; adds the missing `timeout: 30_000` to match the sibling helper's style. |

</details>

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Test as Playwright Test
    participant Helper as waitForTaskResolveResponse
    participant App as OpenMetadata UI
    participant API as /api/v1/feed/tasks/{id}/resolve

    Test->>Helper: call waitForTaskResolveResponse(page)
    Helper->>Helper: "page.waitForResponse(glob, {timeout:30_000})"
    Test->>App: trigger resolve action (button click)
    App->>API: POST /api/v1/feed/tasks/123/resolve
    API-->>App: 200 OK
    App-->>Helper: response intercepted (glob match)
    Helper-->>Test: promise resolves
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Test as Playwright Test
    participant Helper as waitForTaskResolveResponse
    participant App as OpenMetadata UI
    participant API as /api/v1/feed/tasks/{id}/resolve

    Test->>Helper: call waitForTaskResolveResponse(page)
    Helper->>Helper: "page.waitForResponse(glob, {timeout:30_000})"
    Test->>App: trigger resolve action (button click)
    App->>API: POST /api/v1/feed/tasks/123/resolve
    API-->>App: 200 OK
    App-->>Helper: response intercepted (glob match)
    Helper-->>Test: promise resolves
```

</a>
</details>

<sub>Reviews (3): Last reviewed commit: ["nit"](https://github.com/open-metadata/openmetadata/commit/46250b0eab8eae7b0c90e9ca4b0f92a2beac046d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38962938)</sub>

<!-- /greptile_comment -->