### PR TITLE
fix(playwright): stop SSORenewal nightly flake from too-short token TTL

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Auth/SSORenewal.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Auth/SSORenewal.spec.ts
@@ -76,6 +76,10 @@ test.describe('SSO Session Renewal', { tag: ['@sso', '@Platform'] }, () => {
       await createButton.click();
       await page.waitForURL('**/my-data', { timeout: 60_000 });
     }
+
+    await expect(page.getByTestId('dropdown-profile')).toBeVisible({
+      timeout: 60_000,
+    });
   };
 
   test.beforeAll(

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/sessionRenewal.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/sessionRenewal.ts
@@ -13,10 +13,7 @@
 import { BrowserContext } from '@playwright/test';
 import { ProviderConfigOverride } from './ssoAuth';
 
-// Short enough to keep test runtime low, long enough to ride out SAML callback
-// latency plus the small clock skew between the server JWT `exp` and the
-// browser's wall clock.
-export const SHORT_ACCESS_TTL_SECONDS = 10;
+export const SHORT_ACCESS_TTL_SECONDS = 30;
 
 // Server-side SAML HttpSession cookie. SamlAuthServletHandler.handleRefresh
 // uses this cookie to resolve the existing server-side session; clearing it


### PR DESCRIPTION
## What

The **SSO Login Nightly** workflow flaked on the `keycloak-azure-saml` job ([run 27929661599](https://github.com/open-metadata/OpenMetadata/actions/runs/27929661599), 2026-06-22): `SSORenewal.spec.ts › should silently refresh the access token after expiry` failed all 3 retries on the very first assertion, `expect(getByTestId('dropdown-profile')).toBeVisible()`.

## Root cause

The renewal suite swaps the server to a short SAML JWT TTL (`SHORT_ACCESS_TTL_SECONDS`) **before** logging in, so the freshly-issued login token already carries that short TTL. At **10s**, on a loaded CI runner the initial app bootstrap outran the window:

- `users/loggedInUser` → 200, then `/permissions?limit=100` → **401** (token expired mid-bootstrap) → `/auth/refresh` → 200.
- The silent refresh succeeded, but the initial `/permissions` bootstrap fetch is **not retried**, so the global loading spinner never resolves and the navbar (`dropdown-profile`) never renders.

The screenshot from every retry is the bare loading spinner on `/my-data`. It's purely timing — the same job passes when bootstrap happens to finish inside 10s (it passed on retry #2 of the re-run).

## Fix

- **Raise `SHORT_ACCESS_TTL_SECONDS` 10 → 30** so the token outlives the initial bootstrap. 30s stays under `EXPIRY_THRESHOLD_MILLES` (60s), so the proactive-renewal timer (`startTokenExpiryTimer`) still computes `timeoutExpiry = 0` and fires immediately — the refresh-on-expiry behavior under test is unchanged. Comfortably fits the `test.slow()` (3× → 180s) timeout.
- **Wait for `dropdown-profile` at the end of `loginViaSaml`** so login is only "done" once the app shell has rendered. This makes any future bootstrap hang fail in `beforeAll` with a clear cause instead of as a confusing mid-test timeout.

## Test plan

Nightly-only suite (runs against the local Keycloak SAML fixture; skipped for Okta/cross-site). Will verify on the next scheduled `SSO Login Nightly` run, or via a manual dispatch of `playwright-sso-login-nightly.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a nightly flake in `SSORenewal.spec.ts` caused by the SAML JWT token expiring during the app's initial bootstrap on loaded CI runners. The fix raises `SHORT_ACCESS_TTL_SECONDS` from 10 to 30 to ensure the token outlives the bootstrap phase, and adds a `dropdown-profile` visibility guard at the end of `loginViaSaml` so the `beforeAll` hook only completes once the app shell is fully rendered.

- **`sessionRenewal.ts`**: `SHORT_ACCESS_TTL_SECONDS` bumped from 10 → 30; the old explanatory comment was removed without a replacement. The new value intentionally stays under the 60 s `EXPIRY_THRESHOLD_MILLES`, preserving the immediate proactive-renewal behavior under test.
- **`SSORenewal.spec.ts`**: `loginViaSaml` now waits for `dropdown-profile` to be visible (60 s timeout) before returning, surfacing any future bootstrap hangs in `beforeAll` with a clear error instead of a mid-test timeout.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — a two-line targeted fix to a nightly-only test helper with no production code changes.

Both changes are confined to the Playwright test layer: one constant bump and one additional assertion in a login helper. The adjusted TTL (30 s) is correctly reasoned against the EXPIRY_THRESHOLD_MILLES boundary, and the new guard improves error attribution. No production paths are touched.

No files require special attention.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-ui/src/main/resources/ui/playwright/utils/sessionRenewal.ts | Raises SHORT_ACCESS_TTL_SECONDS from 10 to 30 and removes the explanatory comment that justified the old value; the old comment is not updated to explain why 30 was chosen. |
| openmetadata-ui/src/main/resources/ui/playwright/e2e/Auth/SSORenewal.spec.ts | Adds a visible-check on dropdown-profile at the end of loginViaSaml so the beforeAll hook only completes once the app shell is rendered, preventing bootstrap-timing failures from surfacing mid-test. |

</details>

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant T as Test (beforeAll)
    participant B as Browser
    participant S as Server (SAML/short TTL)

    T->>S: "applyProviderConfig (tokenValidity=30s)"
    T->>B: loginViaSaml()
    B->>S: POST /signin → SAML callback
    S-->>B: "access token (exp=now+30s)"
    B->>S: "GET /permissions?limit=100 (bootstrap)"
    S-->>B: 200 OK (within 30s window)
    B-->>T: waitForURL(/my-data) ✓
    B-->>T: expect(dropdown-profile).toBeVisible() ✓ [NEW]

    Note over T,S: Test: should silently refresh after expiry
    T->>T: waitForAccessTokenExpiry(30s+2s buffer)
    Note over S: token now expired
    T->>B: click app-bar-item-explore
    B->>S: GET /explore → 401 (expired token)
    S-->>B: 401
    B->>S: POST /auth/refresh
    S-->>B: "200 new access token (exp=now+30s)"
    B->>S: GET /explore (retry with new token)
    S-->>B: 200 OK
    B-->>T: expect(dropdown-profile).toBeVisible() ✓
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant T as Test (beforeAll)
    participant B as Browser
    participant S as Server (SAML/short TTL)

    T->>S: "applyProviderConfig (tokenValidity=30s)"
    T->>B: loginViaSaml()
    B->>S: POST /signin → SAML callback
    S-->>B: "access token (exp=now+30s)"
    B->>S: "GET /permissions?limit=100 (bootstrap)"
    S-->>B: 200 OK (within 30s window)
    B-->>T: waitForURL(/my-data) ✓
    B-->>T: expect(dropdown-profile).toBeVisible() ✓ [NEW]

    Note over T,S: Test: should silently refresh after expiry
    T->>T: waitForAccessTokenExpiry(30s+2s buffer)
    Note over S: token now expired
    T->>B: click app-bar-item-explore
    B->>S: GET /explore → 401 (expired token)
    S-->>B: 401
    B->>S: POST /auth/refresh
    S-->>B: "200 new access token (exp=now+30s)"
    B->>S: GET /explore (retry with new token)
    S-->>B: 200 OK
    B-->>T: expect(dropdown-profile).toBeVisible() ✓
```

</a>
</details>

<sub>Reviews (2): Last reviewed commit: ["Merge branch &#39;main&#39; into sid/fix-sso-ren..."](https://github.com/open-metadata/openmetadata/commit/304328000a100c7177f50241e7ffb1ae9d6ff2f7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38969753)</sub>

<!-- /greptile_comment -->