### PR TITLE
fix(ui): prevent ontology relations graph from crashing on large glossaries

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/OntologyExplorerRdf.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/OntologyExplorerRdf.spec.ts
@@ -20,6 +20,10 @@ import { redirectToHomePage } from '../../utils/common';
 import { waitForAllLoadersToDisappear } from '../../utils/entity';
 import {
   addTermRelation,
+  buildMalformedRdfGraphJson,
+  buildRdfGraphJson,
+  DANGLING_GRAPH_NODE_ID,
+  readGraphEdges,
   readNodePositions,
   waitForGraphLoaded,
 } from '../../utils/ontologyExplorer';
@@ -28,6 +32,20 @@ const adminUser = new AdminClass();
 const rdfGlossary = new Glossary();
 const rdfTerm1 = new GlossaryTerm(rdfGlossary);
 const rdfTerm2 = new GlossaryTerm(rdfGlossary);
+
+const graphJson = () =>
+  buildRdfGraphJson(
+    rdfGlossary.responseData.id,
+    { id: rdfTerm1.responseData.id, name: rdfTerm1.data.name },
+    { id: rdfTerm2.responseData.id, name: rdfTerm2.data.name }
+  );
+
+const malformedGraphJson = () =>
+  buildMalformedRdfGraphJson(
+    rdfGlossary.responseData.id,
+    { id: rdfTerm1.responseData.id, name: rdfTerm1.data.name },
+    { id: rdfTerm2.responseData.id, name: rdfTerm2.data.name }
+  );
 
 test.beforeAll('Seed test data', async ({ browser }) => {
   const { apiContext, afterAction } = await performAdminLogin(browser);
@@ -50,31 +68,6 @@ test.afterAll('Cleanup test data', async ({ browser }) => {
   await afterAction();
 });
 
-function buildGraphJson() {
-  return {
-    nodes: [
-      {
-        id: rdfTerm1.responseData.id,
-        label: rdfTerm1.data.name,
-        type: 'glossaryTerm',
-        glossaryId: rdfGlossary.responseData.id,
-      },
-      {
-        id: rdfTerm2.responseData.id,
-        label: rdfTerm2.data.name,
-        type: 'glossaryTerm',
-        glossaryId: rdfGlossary.responseData.id,
-      },
-    ],
-    edges: [
-      {
-        from: rdfTerm1.responseData.id,
-        to: rdfTerm2.responseData.id,
-        relationType: 'relatedTo',
-      },
-    ],
-  };
-}
 
 async function navigateToGlossaryRelationsGraph(
   page: Parameters<typeof waitForGraphLoaded>[0]
@@ -235,7 +228,7 @@ test.describe('Ontology Explorer — RDF graph data loading', () => {
     await page.route('**/api/v1/rdf/glossary/graph**', (route) => {
       graphApiCalled = true;
 
-      return route.fulfill({ json: buildGraphJson() });
+      return route.fulfill({ json: graphJson() });
     });
 
     await redirectToHomePage(page);
@@ -278,7 +271,7 @@ test.describe('Ontology Explorer — RDF graph data loading', () => {
     await page.route('**/api/v1/rdf/glossary/graph**', (route) => {
       graphApiCalled = true;
 
-      return route.fulfill({ json: buildGraphJson() });
+      return route.fulfill({ json: graphJson() });
     });
 
     await navigateToGlossaryRelationsGraph(page);
@@ -297,6 +290,68 @@ test.describe('Ontology Explorer — RDF graph data loading', () => {
       positions[rdfTerm2.responseData.id],
       'rdfTerm2 must appear as a node (from RDF graph response)'
     ).toBeDefined();
+
+    await page.close();
+  });
+
+  test('renders without crashing when /rdf/glossary/graph returns duplicate nodes and dangling edges', async ({
+    browser,
+  }) => {
+    const page = await browser.newPage();
+    await adminUser.login(page);
+
+    const pageErrors: string[] = [];
+    page.on('pageerror', (error) => pageErrors.push(error.message));
+
+    await page.route('**/api/v1/rdf/status**', (route) =>
+      route.fulfill({ json: { enabled: true } })
+    );
+    await page.route('**/api/v1/rdf/glossary/graph**', (route) =>
+      route.fulfill({ json: malformedGraphJson() })
+    );
+
+    await navigateToGlossaryRelationsGraph(page);
+
+    // The graph must render — not the fetch-error / render-error empty states.
+    await expect(page.getByTestId('ontology-graph-error')).toHaveCount(0);
+    await expect(page.getByTestId('ontology-graph-render-error')).toHaveCount(
+      0
+    );
+
+    // Both real terms render despite the duplicate node and dangling edge.
+    const positions = await readNodePositions(page);
+    expect(
+      positions[rdfTerm1.responseData.id],
+      'rdfTerm1 must render even though its id was duplicated in the payload'
+    ).toBeDefined();
+    expect(
+      positions[rdfTerm2.responseData.id],
+      'rdfTerm2 must render'
+    ).toBeDefined();
+
+    // The valid edge is drawn; the dangling edge is dropped, not rendered.
+    const edges = await readGraphEdges(page);
+    expect(
+      edges.some(
+        (e) =>
+          e.from === rdfTerm1.responseData.id &&
+          e.to === rdfTerm2.responseData.id
+      ),
+      'the valid term-to-term edge must be rendered'
+    ).toBe(true);
+    expect(
+      edges.some(
+        (e) =>
+          e.from === DANGLING_GRAPH_NODE_ID || e.to === DANGLING_GRAPH_NODE_ID
+      ),
+      'the dangling edge must be dropped, never handed to G6'
+    ).toBe(false);
+
+    expect(
+      pageErrors.filter(
+        (m) => m.includes('Node already exists') || m.includes('Node not found')
+      )
+    ).toEqual([]);
 
     await page.close();
   });

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/OntologyExplorerRdf.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/OntologyExplorerRdf.spec.ts
@@ -68,7 +68,6 @@ test.afterAll('Cleanup test data', async ({ browser }) => {
   await afterAction();
 });
 
-
 async function navigateToGlossaryRelationsGraph(
   page: Parameters<typeof waitForGraphLoaded>[0]
 ) {

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/ontologyExplorer.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/ontologyExplorer.ts
@@ -18,6 +18,13 @@ import { GlossaryTerm } from '../support/glossary/GlossaryTerm';
 import { getAuthContext, getToken, redirectToHomePage } from '../utils/common';
 import { sidebarClick } from '../utils/sidebar';
 
+export interface GraphTermRef {
+  id: string;
+  name: string;
+}
+
+export const DANGLING_GRAPH_NODE_ID = '00000000-0000-0000-0000-000000000000';
+
 export async function applyGlossaryFilter(page: Page, glossaryId: string) {
   await page.getByTestId('search-dropdown-Glossary').click();
   await page.getByTestId(glossaryId).click();
@@ -118,6 +125,38 @@ export async function readGraphEdges(
       (el: HTMLElement) =>
         JSON.parse(el.dataset.edges ?? '[]') as RenderedEdge[]
     );
+}
+
+export function buildRdfGraphJson(
+  glossaryId: string,
+  term1: GraphTermRef,
+  term2: GraphTermRef
+) {
+  return {
+    nodes: [
+      { id: term1.id, label: term1.name, type: 'glossaryTerm', glossaryId },
+      { id: term2.id, label: term2.name, type: 'glossaryTerm', glossaryId },
+    ],
+    edges: [{ from: term1.id, to: term2.id, relationType: 'relatedTo' }],
+  };
+}
+
+export function buildMalformedRdfGraphJson(
+  glossaryId: string,
+  term1: GraphTermRef,
+  term2: GraphTermRef
+) {
+  return {
+    nodes: [
+      { id: term1.id, label: term1.name, type: 'glossaryTerm', glossaryId },
+      { id: term1.id, label: term1.name, type: 'glossaryTerm', glossaryId },
+      { id: term2.id, label: term2.name, type: 'glossaryTerm', glossaryId },
+    ],
+    edges: [
+      { from: term1.id, to: term2.id, relationType: 'relatedTo' },
+      { from: term1.id, to: DANGLING_GRAPH_NODE_ID, relationType: 'relatedTo' },
+    ],
+  };
 }
 
 export async function createApiContext(browser: Browser) {

--- a/openmetadata-ui/src/main/resources/ui/src/components/OntologyExplorer/hooks/useGraphData.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/components/OntologyExplorer/hooks/useGraphData.ts
@@ -913,9 +913,30 @@ export function useGraphDataBuilder({
       });
     }
 
+    // Final safety net before data enters G6. G6 throws synchronously (and
+    // takes down the whole canvas via the ErrorBoundary) on a duplicate node id
+    // ("Node already exists") or an edge whose endpoint is missing ("Node not
+    // found"). Many independent builders/derivations feed this memo, so enforce
+    // both invariants once, here, rather than trusting every upstream path.
+    const seenNodeIds = new Set<string>();
+    const safeNodes = g6Nodes.filter((node) => {
+      const id = String(node.id);
+      if (seenNodeIds.has(id)) {
+        return false;
+      }
+      seenNodeIds.add(id);
+
+      return true;
+    });
+    const safeEdges = g6Edges.filter(
+      (edge) =>
+        seenNodeIds.has(String(edge.source)) &&
+        seenNodeIds.has(String(edge.target))
+    );
+
     return {
-      nodes: g6Nodes,
-      edges: g6Edges,
+      nodes: safeNodes,
+      edges: safeEdges,
       combos: combos.length > 0 ? combos : undefined,
     };
   }, [

--- a/openmetadata-ui/src/main/resources/ui/src/components/OntologyExplorer/utils/graphBuilders.test.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/components/OntologyExplorer/utils/graphBuilders.test.ts
@@ -193,6 +193,75 @@ describe('convertRdfGraphToOntologyGraph', () => {
       'relatedTo',
     ]);
   });
+
+  it('dedupes nodes that share an id', () => {
+    const rdf: GraphData = {
+      nodes: [
+        {
+          id: 'term-1',
+          label: 'Revenue',
+          type: 'glossaryTerm',
+          fullyQualifiedName: 'Finance.Revenue',
+        },
+        {
+          id: 'term-1',
+          label: 'Revenue',
+          type: 'glossaryTerm',
+          fullyQualifiedName: 'Finance.Revenue',
+        },
+        {
+          id: 'term-2',
+          label: 'Cost',
+          type: 'glossaryTerm',
+          fullyQualifiedName: 'Finance.Cost',
+        },
+      ],
+      edges: [],
+    };
+
+    const result = convertRdfGraphToOntologyGraph(rdf, glossaries);
+
+    expect(result.nodes).toHaveLength(2);
+    expect(result.nodes.map((n) => n.id).sort()).toEqual(['term-1', 'term-2']);
+  });
+
+  it('drops edges whose endpoints are not in the node set', () => {
+    const rdf: GraphData = {
+      nodes: [
+        {
+          id: 'term-1',
+          label: 'Revenue',
+          type: 'glossaryTerm',
+          fullyQualifiedName: 'Finance.Revenue',
+        },
+        {
+          id: 'term-2',
+          label: 'Cost',
+          type: 'glossaryTerm',
+          fullyQualifiedName: 'Finance.Cost',
+        },
+      ],
+      edges: [
+        {
+          from: 'term-1',
+          to: 'term-2',
+          label: 'Related To',
+          relationType: 'relatedTo',
+        },
+        {
+          from: 'term-1',
+          to: 'missing-node',
+          label: 'Related To',
+          relationType: 'relatedTo',
+        },
+      ],
+    };
+
+    const result = convertRdfGraphToOntologyGraph(rdf, glossaries);
+
+    expect(result.edges).toHaveLength(1);
+    expect(result.edges[0].to).toBe('term-2');
+  });
 });
 
 describe('buildGraphFromAllTerms', () => {
@@ -283,5 +352,47 @@ describe('buildGraphFromAllTerms', () => {
       distinctRelationTypes.has('partOf') ||
         distinctRelationTypes.has('hasPart')
     ).toBe(true);
+  });
+
+  it('dedupes terms that appear more than once in the input', () => {
+    const term = {
+      id: '11111111-1111-1111-1111-111111111111',
+      name: 'KPI 1',
+      displayName: 'KPI 1',
+      fullyQualifiedName: 'Finance.KPI 1',
+      glossary: { id: 'gloss-finance-id', name: 'Finance', type: 'glossary' },
+    } as GlossaryTerm;
+
+    const result = buildGraphFromAllTerms([term, term], [baseGlossary], tStub);
+
+    expect(result.nodes).toHaveLength(1);
+  });
+
+  it('drops related-term edges whose target term is not in the loaded set', () => {
+    const terms: GlossaryTerm[] = [
+      {
+        id: '11111111-1111-1111-1111-111111111111',
+        name: 'KPI 1',
+        displayName: 'KPI 1',
+        fullyQualifiedName: 'Finance.KPI 1',
+        glossary: { id: 'gloss-finance-id', name: 'Finance', type: 'glossary' },
+        relatedTerms: [
+          {
+            term: {
+              id: '99999999-9999-9999-9999-999999999999',
+              type: 'glossaryTerm',
+              name: 'Missing',
+              fullyQualifiedName: 'Finance.Missing',
+            },
+            relationType: 'relatedTo',
+          },
+        ],
+      } as GlossaryTerm,
+    ];
+
+    const result = buildGraphFromAllTerms(terms, [baseGlossary], tStub);
+
+    expect(result.nodes).toHaveLength(1);
+    expect(result.edges).toHaveLength(0);
   });
 });

--- a/openmetadata-ui/src/main/resources/ui/src/components/OntologyExplorer/utils/graphBuilders.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/components/OntologyExplorer/utils/graphBuilders.ts
@@ -120,7 +120,17 @@ export function convertRdfGraphToOntologyGraph(
     }
   });
 
-  const nodes: OntologyNode[] = rdfData.nodes.map((node) => {
+  // Dedupe by id: the paginated RDF graph endpoint can return the same node on
+  // more than one page (and serializes a node once per relationship it appears
+  // in), so a node id may repeat. G6 throws "Node already exists" when handed a
+  // duplicate id, so keep only the first occurrence — mirrors the edge dedupe
+  // below.
+  const nodesById = new Map<string, OntologyNode>();
+  rdfData.nodes.forEach((node) => {
+    if (nodesById.has(node.id)) {
+      return;
+    }
+
     // Prefer the explicit glossaryId from the RDF endpoint — it survives
     // glossary rename / display-name drift better than the FQN-prefix
     // heuristic. Fall back to looking up the glossary by `group` (display
@@ -152,7 +162,7 @@ export function convertRdfGraphToOntologyGraph(
       }
     }
 
-    return {
+    nodesById.set(node.id, {
       id: node.id,
       label: nodeLabel,
       type: node.type || 'glossaryTerm',
@@ -160,11 +170,20 @@ export function convertRdfGraphToOntologyGraph(
       description: node.description,
       glossaryId,
       group: node.group,
-    };
+    });
   });
+  const nodes: OntologyNode[] = Array.from(nodesById.values());
 
   const edgeMap = new Map<string, OntologyEdge>();
   rdfData.edges.forEach((edge) => {
+    // Drop dangling edges: the RDF graph endpoint can reference nodes that
+    // aren't in this node set (cross-glossary relations, or endpoints not
+    // returned by pagination). G6 throws "Node not found" when an edge points
+    // at a missing node, so keep only edges whose endpoints both exist —
+    // mirrors the validEdges filter in buildGraphFromAllTerms.
+    if (!nodesById.has(edge.from) || !nodesById.has(edge.to)) {
+      return;
+    }
     const relationType = edge.relationType || 'relatedTo';
     const edgeKey = `${[edge.from, edge.to].sort().join('-')}|${relationType}`;
     if (!edgeMap.has(edgeKey)) {


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:

Fixes the "Error while fetching Graph" message that appeared on the Relations Graph tab of certain glossaries, even when all data loaded correctly. The graph now renders reliably regardless of glossary size or how the underlying graph data is shaped.

## Problem
Opening the Relations Graph for some glossaries showed an error state instead of the graph. The confusing part: the network calls all returned valid data. The issue was reproducible on a large glossary (~835 terms) and never happened on smaller ones, which made it look intermittent.

## Root cause

The relations graph is drawn by a graph rendering library that enforces two
strict rules:

1. Every term shown must be unique — the same term cannot appear twice.
2. Every relationship must connect two terms that are actually present.

When the graph is built from the RDF source, the data for a large glossary is fetched in multiple pages, and a term can be described more than once (once per relationship it takes part in). This produced two problems the library could not accept:
- the same term appearing twice, and
- relationships pointing to terms that were not in the returned set
  (for example, cross-glossary links or terms that landed on another page).

Either one causes the library to throw and stop drawing the whole graph, which the screen reported as the generic "Error while fetching Graph". The graph is built in a single pass, so one bad entry takes down the entire view rather than just hiding one item. Smaller glossaries fit in a single page with no repeats, so they never hit this — which is why it looked like only one glossary was affected.

Importantly, the database-backed path already cleaned its data (removing duplicates and invalid relationships), so it was never affected. Only the RDF path was missing that cleanup. That asymmetry was the bug.


<img width="1355" height="674" alt="Screenshot 2026-06-22 at 11 25 09 AM" src="https://github.com/user-attachments/assets/4c975175-2e43-4b72-9b1b-4382e92a48ed" />

<img width="1512" height="725" alt="Screenshot 2026-06-22 at 11 32 10 AM" src="https://github.com/user-attachments/assets/c8db62cc-c059-4ca7-8e80-a75f2129b35a" />

Fixes #29272 
<!--
Linking an issue is REQUIRED. Replace <issue-number> with the GitHub issue number this PR addresses
(e.g., `Fixes #12345`). GitHub will auto-link it. If no issue exists, please open one first so the
problem and design can be discussed before review.
-->

<!--
Short blurb explaining:
- What changes did you make?
- Why did you make them?
-->


#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### High-level design:
<!--
REQUIRED for large PRs (new features, refactors, breaking changes, or anything touching >5 files).
Skip for small bug fixes and trivial changes.

Cover:
- Architecture / approach you took and why
- Key components or files added/changed and how they interact
- Alternatives considered and why you rejected them
- Any migration, backward-compatibility, or rollout concerns
- Diagrams or links to design docs / RFCs if available
-->

N/A — small change. <!-- Or fill in the design above -->

#
### Tests:

#### Use cases covered
<!--
List the user-visible scenarios this PR exercises. Example:
- User with Admin role can create a Glossary Term with a parent term
- Ingestion run for Snowflake correctly extracts row counts for partitioned tables
-->

#### Unit tests

- [x] I added unit tests for the new/changed logic.
- Files added/updated:
- Coverage on changed classes (run `mvn jacoco:report` for backend, `yarn test:coverage` for UI,
  `make unit_ingestion` for ingestion). Target is 90% line coverage on changed classes.
- Coverage %: <e.g., 92% on EntityRepository.java>


#### Backend integration tests
<!--
- [ ] I added integration tests in `openmetadata-integration-tests/` for new/changed API endpoints.
- [ ] Not applicable (no backend API changes).
- Files added/updated:
-->

#### Ingestion integration tests
<!--
- [ ] I added/updated ingestion integration tests for connector changes.
- [ ] Not applicable (no ingestion changes).
- Files added/updated:
-->

#### Playwright (UI) tests

- [x] I added Playwright E2E tests under `openmetadata-ui/.../ui/playwright/` for UI changes.
- [ ] Not applicable (no UI changes).
- Files added/updated:


#### Manual testing performed
<!--
List the manual test steps you performed before requesting review. Example:
1. Started local stack via `./docker/run_local_docker.sh -m ui -d mysql`
2. Logged in as admin, created entity X, verified Y appears in the UI
3. Triggered ingestion for Snowflake source, confirmed lineage edges in the explore page
-->

#
### UI screen recording / screenshots:
<!--
REQUIRED for any PR that changes the UI. Drag-and-drop a short screen recording (.mov / .mp4 / .gif)
demonstrating the change end-to-end, plus before/after screenshots where relevant.
Mark "Not applicable" if there are no UI changes.
-->

Not applicable. <!-- Or attach recording/screenshots above -->

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.
- [ ] For UI changes: I attached a screen recording and/or screenshots above.
- [ ] I have added tests (unit / integration / Playwright as applicable) and listed them above.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->


- [x] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.


<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a crash in the Relations Graph for large glossaries where the RDF paginated endpoint could return duplicate node IDs and edges pointing to nodes absent from the current page. Either condition caused G6 to throw synchronously and take down the whole canvas.

- **`graphBuilders.ts`**: `convertRdfGraphToOntologyGraph` now builds nodes into a `Map` (first-occurrence wins, deduplicating naturally) and filters edges before insertion to drop any whose `from`/`to` IDs are not in that Map — mirroring the existing `validEdges` guard in `buildGraphFromAllTerms`.
- **`useGraphData.ts`**: A final safety net is added at the memo's return point that re-deduplicates `g6Nodes` and removes any `g6Edges` whose `source`/`target` don't appear in the safe node set, guarding every upstream builder path in one place.
- **Tests**: Four new unit tests cover both invariants for both builders, and a new Playwright E2E test intercepts the API with a malformed payload and asserts no error state, both valid nodes render, and the dangling edge is never handed to G6.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is narrowly scoped to the RDF graph builder and a final-pass safety net in the G6 data memo, with no effect on the database-backed path.

Both the RDF-specific builder and the shared memo-level safety net correctly implement duplicate-node elimination and dangling-edge filtering. The logic is straightforward (Map first-occurrence dedup + membership check), unit tests cover all four new invariants, and an E2E Playwright test exercises the exact crash scenario end-to-end. No pre-existing behavior is altered for the database path.

No files require special attention.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-ui/src/main/resources/ui/src/components/OntologyExplorer/utils/graphBuilders.ts | Core fix: converts node list processing from a simple map() to a nodesById Map that deduplicates on first-occurrence, then adds a dangling-edge guard that drops any edge whose from/to IDs are absent from that Map. Logic is correct and mirrors the already-existing validEdges filter in buildGraphFromAllTerms. |
| openmetadata-ui/src/main/resources/ui/src/components/OntologyExplorer/hooks/useGraphData.ts | Adds a final safety net just before the memo return: deduplicates g6Nodes and filters g6Edges to only those whose source/target are in the deduplicated set. Correctly uses G6's source/target field names (not OntologyEdge's from/to). Catches any builder path not yet covered by the graphBuilders.ts fix. |
| openmetadata-ui/src/main/resources/ui/src/components/OntologyExplorer/utils/graphBuilders.test.ts | Adds four new unit tests: two for convertRdfGraphToOntologyGraph (duplicate node dedup, dangling-edge drop) and two for buildGraphFromAllTerms (duplicate term dedup, missing-target edge drop). All scenarios match the exact G6 error conditions described in the PR. |
| openmetadata-ui/src/main/resources/ui/playwright/utils/ontologyExplorer.ts | Extracts the formerly inline buildGraphJson into reusable buildRdfGraphJson and adds buildMalformedRdfGraphJson (with a duplicate node and a dangling edge to DANGLING_GRAPH_NODE_ID), plus the exported constant. Clean refactoring with no regressions. |
| openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/OntologyExplorerRdf.spec.ts | Adds an E2E test that intercepts the RDF graph API with a malformed payload, then asserts no error state appears, both valid nodes render, the valid edge is drawn, and the dangling edge is never passed to G6. Comprehensive end-to-end coverage of the bug scenario. |

</details>

</details>

<details open><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[RDF API response\nraw nodes + edges] --> B[convertRdfGraphToOntologyGraph]
    B --> C{node.id already\nin nodesById?}
    C -- yes --> D[skip duplicate]
    C -- no --> E[nodesById.set]
    E --> F{edge.from AND\nedge.to in nodesById?}
    F -- no --> G[drop dangling edge]
    F -- yes --> H[keep edge in edgeMap]
    H --> I[OntologyGraphData\nclean nodes + edges]
    I --> J[useGraphData memo\ng6Nodes + g6Edges built]
    J --> K[Safety net:\ndedupe g6Nodes\nfilter g6Edges by source+target]
    K --> L[G6 render\nno crash]
    D --> F
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[RDF API response\nraw nodes + edges] --> B[convertRdfGraphToOntologyGraph]
    B --> C{node.id already\nin nodesById?}
    C -- yes --> D[skip duplicate]
    C -- no --> E[nodesById.set]
    E --> F{edge.from AND\nedge.to in nodesById?}
    F -- no --> G[drop dangling edge]
    F -- yes --> H[keep edge in edgeMap]
    H --> I[OntologyGraphData\nclean nodes + edges]
    I --> J[useGraphData memo\ng6Nodes + g6Edges built]
    J --> K[Safety net:\ndedupe g6Nodes\nfilter g6Edges by source+target]
    K --> L[G6 render\nno crash]
    D --> F
```

</a>
</details>

<sub>Reviews (2): Last reviewed commit: ["Merge branch &#39;main&#39; into fix-duplicate-n..."](https://github.com/open-metadata/openmetadata/commit/44e994110c9e5ce5fa682d2265bc4633c54e9931) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38972972)</sub>

<!-- /greptile_comment -->