### PR TITLE
test: add waitForTaskResolveResponse helper to task utils

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/task.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/task.ts
@@ -84,6 +84,9 @@ export const createDescriptionTask = async (
   await toastNotification(page, /Task created successfully./);
 };
 
+export const waitForTaskResolveResponse = (page: Page) =>
+  page.waitForResponse('/api/v1/feed/tasks/*/resolve', { timeout: 30_000 });
+
 export const createTagTask = async (
   page: Page,
   value: TaskDetails,


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:

Fixes #<issue-number>
<!--
Linking an issue is REQUIRED. Replace <issue-number> with the GitHub issue number this PR addresses
(e.g., `Fixes #12345`). GitHub will auto-link it. If no issue exists, please open one first so the
problem and design can be discussed before review.
-->

<!--
Short blurb explaining:
- What changes did you make?
- Why did you make them?
-->

I worked on ... because ...

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### High-level design:
<!--
REQUIRED for large PRs (new features, refactors, breaking changes, or anything touching >5 files).
Skip for small bug fixes and trivial changes.

Cover:
- Architecture / approach you took and why
- Key components or files added/changed and how they interact
- Alternatives considered and why you rejected them
- Any migration, backward-compatibility, or rollout concerns
- Diagrams or links to design docs / RFCs if available
-->

N/A — small change. <!-- Or fill in the design above -->

#
### Tests:

#### Use cases covered
<!--
List the user-visible scenarios this PR exercises. Example:
- User with Admin role can create a Glossary Term with a parent term
- Ingestion run for Snowflake correctly extracts row counts for partitioned tables
-->

#### Unit tests
<!--
- [ ] I added unit tests for the new/changed logic.
- Files added/updated:
- Coverage on changed classes (run `mvn jacoco:report` for backend, `yarn test:coverage` for UI,
  `make unit_ingestion` for ingestion). Target is 90% line coverage on changed classes.
- Coverage %: <e.g., 92% on EntityRepository.java>
-->

#### Backend integration tests
<!--
- [ ] I added integration tests in `openmetadata-integration-tests/` for new/changed API endpoints.
- [ ] Not applicable (no backend API changes).
- Files added/updated:
-->

#### Ingestion integration tests
<!--
- [ ] I added/updated ingestion integration tests for connector changes.
- [ ] Not applicable (no ingestion changes).
- Files added/updated:
-->

#### Playwright (UI) tests
<!--
- [ ] I added Playwright E2E tests under `openmetadata-ui/.../ui/playwright/` for UI changes.
- [ ] Not applicable (no UI changes).
- Files added/updated:
-->

#### Manual testing performed
<!--
List the manual test steps you performed before requesting review. Example:
1. Started local stack via `./docker/run_local_docker.sh -m ui -d mysql`
2. Logged in as admin, created entity X, verified Y appears in the UI
3. Triggered ingestion for Snowflake source, confirmed lineage edges in the explore page
-->

#
### UI screen recording / screenshots:
<!--
REQUIRED for any PR that changes the UI. Drag-and-drop a short screen recording (.mov / .mp4 / .gif)
demonstrating the change end-to-end, plus before/after screenshots where relevant.
Mark "Not applicable" if there are no UI changes.
-->

Not applicable. <!-- Or attach recording/screenshots above -->

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.
- [ ] For UI changes: I attached a screen recording and/or screenshots above.
- [ ] I have added tests (unit / integration / Playwright as applicable) and listed them above.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Adds a single exported Playwright helper, `waitForTaskResolveResponse`, that waits for the `/api/v1/feed/tasks/*/resolve` endpoint using a glob URL pattern with a 30-second timeout, consistent in shape with the existing `waitForTaskListResponse` utility.

- The helper is a straight addition with no changes to existing functions; it follows the same two-liner arrow-function style used elsewhere in the file.
- Unlike `waitForTaskListResponse`, the new function uses a glob string rather than a predicate, which means no HTTP method filtering; a predicate would align it more closely with existing patterns and allow optional status assertions.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge — the change is a small additive helper with no impact on production code.

The addition is isolated to a single Playwright test utility file, touches no existing functions, and introduces no logic that could break tests or production behaviour. The only gap is that the glob-string matcher doesn't filter by HTTP method or check the response status code, which can cause a test to silently accept a failed resolve response, but this only affects test robustness rather than correctness.

No files require special attention.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-ui/src/main/resources/ui/playwright/utils/task.ts | Adds `waitForTaskResolveResponse` helper that waits for the `/api/v1/feed/tasks/*/resolve` API response using a glob URL pattern and 30s timeout; no HTTP method filter is applied, unlike the existing `waitForTaskListResponse`. |

</details>

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Test as Playwright Test
    participant Helper as waitForTaskResolveResponse
    participant Browser as Browser / Page
    participant API as /api/v1/feed/tasks/:id/resolve

    Test->>Helper: call waitForTaskResolveResponse(page)
    Helper->>Browser: "page.waitForResponse(glob, {timeout: 30_000})"
    Note over Browser: returns Promise (not yet resolved)
    Test->>Browser: trigger resolve action (e.g. click button)
    Browser->>API: PUT/POST request
    API-->>Browser: response
    Browser-->>Helper: response matched by glob
    Helper-->>Test: resolves with Response
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Test as Playwright Test
    participant Helper as waitForTaskResolveResponse
    participant Browser as Browser / Page
    participant API as /api/v1/feed/tasks/:id/resolve

    Test->>Helper: call waitForTaskResolveResponse(page)
    Helper->>Browser: "page.waitForResponse(glob, {timeout: 30_000})"
    Note over Browser: returns Promise (not yet resolved)
    Test->>Browser: trigger resolve action (e.g. click button)
    Browser->>API: PUT/POST request
    API-->>Browser: response
    Browser-->>Helper: response matched by glob
    Helper-->>Test: resolves with Response
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["test: add waitForTaskResolveResponse hel..."](https://github.com/open-metadata/openmetadata/commit/4e05008abdbffe57e3b43f7e147d4ae5430b4e08) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38975562)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->