### PR TITLE
test: stabilize data-asset dropdown options to stop re-render race

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/WorkflowDefinitions/WorkflowBuilder/forms/DataAssetFormSection.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/WorkflowDefinitions/WorkflowBuilder/forms/DataAssetFormSection.tsx
@@ -13,7 +13,7 @@
 
 import { Autocomplete, SelectItemType } from '@openmetadata/ui-core-components';
 import { upperFirst } from 'lodash';
-import React, { useEffect, useMemo, useRef } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useListData } from 'react-stately';
 import { ALL_DATA_ASSETS_OPTION_VALUE } from '../../../../constants/WorkflowBuilder.constants';
@@ -47,10 +47,13 @@ export const DataAssetFormSection: React.FC<DataAssetFormSectionProps> = ({
       : dataAssets;
   }, [dataAssets, availableDataAssets]);
 
-  const resolveLabel = (option: string) =>
-    option === ALL_DATA_ASSETS_OPTION_VALUE
-      ? t('label.all')
-      : upperFirst(option);
+  const resolveLabel = useCallback(
+    (option: string) =>
+      option === ALL_DATA_ASSETS_OPTION_VALUE
+        ? t('label.all')
+        : upperFirst(option),
+    [t]
+  );
 
   const isAllDataAssetsSelected = dataAssetSelectDisplayValue.includes(
     ALL_DATA_ASSETS_OPTION_VALUE
@@ -77,11 +80,16 @@ export const DataAssetFormSection: React.FC<DataAssetFormSectionProps> = ({
     }
   }, [dataAssetSelectDisplayValue]);
 
-  const allItems: SelectItemType[] = dataAssetOptionsIncludingAll.map((v) => ({
-    id: v,
-    isDisabled: isAllDataAssetsSelected && v !== ALL_DATA_ASSETS_OPTION_VALUE,
-    label: resolveLabel(v),
-  }));
+  const allItems: SelectItemType[] = useMemo(
+    () =>
+      dataAssetOptionsIncludingAll.map((v) => ({
+        id: v,
+        isDisabled:
+          isAllDataAssetsSelected && v !== ALL_DATA_ASSETS_OPTION_VALUE,
+        label: resolveLabel(v),
+      })),
+    [dataAssetOptionsIncludingAll, isAllDataAssetsSelected, resolveLabel]
+  );
 
   const handleItemInserted = (key: React.Key) => {
     const id = String(key);


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:


<!--
Linking an issue is REQUIRED. Replace <issue-number> with the GitHub issue number this PR addresses
(e.g., `Fixes #12345`). GitHub will auto-link it. If no issue exists, please open one first so the
problem and design can be discussed before review.
-->

<!--
Short blurb explaining:
- What changes did you make?
- Why did you make them?
-->

The data-asset dropdown in the workflow builder's start node was rebuilding its full list of options on every render. The dropdown library treats a new options list as a brand-new set and tears down and recreates each option in
the DOM. Because this section re-renders whenever the selected items change (and as the surrounding workflow editor updates), the options were being destroyed and recreated repeatedly while the menu was open.

This made selecting an option unreliable: a click could land just as the option was being replaced, so it either did nothing or failed. It also showed up as a flaky end-to-end test that timed out trying to click the "All" option ("element was detached from the DOM, retrying").

The options list (and its label helper) are now computed once and reused until their inputs actually change, so options stay stable while the menu is open. This matches how the other derived values in the same component are
already handled.


#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### High-level design:
<!--
REQUIRED for large PRs (new features, refactors, breaking changes, or anything touching >5 files).
Skip for small bug fixes and trivial changes.

Cover:
- Architecture / approach you took and why
- Key components or files added/changed and how they interact
- Alternatives considered and why you rejected them
- Any migration, backward-compatibility, or rollout concerns
- Diagrams or links to design docs / RFCs if available
-->

N/A — small change. <!-- Or fill in the design above -->

#
### Tests:

#### Use cases covered
<!--
List the user-visible scenarios this PR exercises. Example:
- User with Admin role can create a Glossary Term with a parent term
- Ingestion run for Snowflake correctly extracts row counts for partitioned tables
-->

#### Unit tests
<!--
- [ ] I added unit tests for the new/changed logic.
- Files added/updated:
- Coverage on changed classes (run `mvn jacoco:report` for backend, `yarn test:coverage` for UI,
  `make unit_ingestion` for ingestion). Target is 90% line coverage on changed classes.
- Coverage %: <e.g., 92% on EntityRepository.java>
-->

#### Backend integration tests
<!--
- [ ] I added integration tests in `openmetadata-integration-tests/` for new/changed API endpoints.
- [ ] Not applicable (no backend API changes).
- Files added/updated:
-->

#### Ingestion integration tests
<!--
- [ ] I added/updated ingestion integration tests for connector changes.
- [ ] Not applicable (no ingestion changes).
- Files added/updated:
-->

#### Playwright (UI) tests
<!--
- [ ] I added Playwright E2E tests under `openmetadata-ui/.../ui/playwright/` for UI changes.
- [ ] Not applicable (no UI changes).
- Files added/updated:
-->

#### Manual testing performed
<!--
List the manual test steps you performed before requesting review. Example:
1. Started local stack via `./docker/run_local_docker.sh -m ui -d mysql`
2. Logged in as admin, created entity X, verified Y appears in the UI
3. Triggered ingestion for Snowflake source, confirmed lineage edges in the explore page
-->

#
### UI screen recording / screenshots:
<!--
REQUIRED for any PR that changes the UI. Drag-and-drop a short screen recording (.mov / .mp4 / .gif)
demonstrating the change end-to-end, plus before/after screenshots where relevant.
Mark "Not applicable" if there are no UI changes.
-->

Not applicable. <!-- Or attach recording/screenshots above -->

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.
- [ ] For UI changes: I attached a screen recording and/or screenshots above.
- [ ] I have added tests (unit / integration / Playwright as applicable) and listed them above.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a flaky E2E test caused by the data-asset dropdown's options list being rebuilt on every render, causing React Aria/Stately to unmount and remount DOM nodes mid-click. Wrapping `resolveLabel` in `useCallback` and `allItems` in `useMemo` makes the options reference-stable so the dropdown doesn't tear down while it is open.

- `resolveLabel` is wrapped in `useCallback([t])` so it produces the same reference across renders when the translation function hasn't changed.
- `allItems` is wrapped in `useMemo([dataAssetOptionsIncludingAll, isAllDataAssetsSelected, resolveLabel])`, preventing the dropdown library from seeing a new options array — and thus skipping DOM teardown — on every render cycle.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — change is a targeted memoisation fix with no logic alterations.

The only change is wrapping two existing derivations in useCallback/useMemo with correct dependency arrays. No logic is altered, no data flows change, and the fix directly addresses the documented race condition. The sole remaining nit (toItem not yet wrapped) is purely a linting concern with no runtime impact.

No files require special attention.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| openmetadata-ui/src/main/resources/ui/src/components/WorkflowDefinitions/WorkflowBuilder/forms/DataAssetFormSection.tsx | Stabilises dropdown options list via useMemo and wraps resolveLabel in useCallback; the helper toItem remains an inline function and is still absent from the useEffect dep array (P2 style note). |

</details>


</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `openmetadata-ui/src/main/resources/ui/src/components/WorkflowDefinitions/WorkflowBuilder/forms/DataAssetFormSection.tsx`, line 62-66 ([link](https://github.com/open-metadata/openmetadata/blob/37f70e94f0e25cbe057ffd966c1a0b9c80703102/openmetadata-ui/src/main/resources/ui/src/components/WorkflowDefinitions/WorkflowBuilder/forms/DataAssetFormSection.tsx#L62-L66)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> The `toItem` helper is recreated on every render and is called inside the `useEffect` at line 78, yet it is absent from that effect's dependency array. While the missing-dep doesn't cause incorrect behaviour today (because `resolveLabel` is now stable), it would trip an `eslint-plugin-react-hooks` `exhaustive-deps` warning and leaves the pattern inconsistent with the stabilisation goal of this PR. Wrapping it in `useCallback` aligns it with `resolveLabel`.
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (3): Last reviewed commit: ["Merge branch &#39;main&#39; into data-asset-all-..."](https://github.com/open-metadata/openmetadata/commit/0a5e62fa36213bd7bf146b18420a7a045ce33b21) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38981855)</sub>

<!-- /greptile_comment -->