### PR TITLE
fix(exasol): flush statistics before polling Exasol audit tables in integration tests

### DIFF
--- a/ingestion/tests/integration/sources/database/exasol/test_exasol_queries.py
+++ b/ingestion/tests/integration/sources/database/exasol/test_exasol_queries.py
@@ -60,6 +60,16 @@ def wait_for_system_table(
     )
 
 
+def _enable_auditing(engine: Engine) -> None:
+    """Enable database auditing so the EXA_DBA_AUDIT_* tables are populated.
+
+    A freshly spawned Exasol container ships with AUDITING = OFF, leaving the
+    audit statistics tables empty no matter how long the tests poll them.
+    """
+    with engine.begin() as connection:
+        connection.execute(text("ALTER SYSTEM SET AUDITING = 'ON'"))
+
+
 def _prepare_exasol_objects(engine: Engine) -> None:
     setup_statements = [
         f"CREATE SCHEMA IF NOT EXISTS {SCHEMA_NAME}",
@@ -131,6 +141,7 @@ class TestExasolQueries:
         )
 
         cls.engine = create_engine(f"exa+websocket://sys:exasol@localhost:{DB_PORT}/?SSLCertificate=SSL_VERIFY_NONE")
+        _enable_auditing(cls.engine)
         _prepare_exasol_objects(cls.engine)
 
     @classmethod
@@ -140,7 +151,7 @@ class TestExasolQueries:
 
     def test_connection_test_get_queries(self):
         query = EXASOL_TEST_GET_QUERIES
-        rows = wait_for_system_table(self.engine, query, expected_count=1)
+        rows = wait_for_system_table(self.engine, query, expected_count=1, timeout_seconds=120)
         columns = {column.lower() for column in rows[0]}
 
         assert columns == {
@@ -161,7 +172,7 @@ class TestExasolQueries:
             result_limit=5,
         )
 
-        rows = wait_for_system_table(self.engine, query, expected_count=5)
+        rows = wait_for_system_table(self.engine, query, expected_count=5, timeout_seconds=120)
         columns = {column.lower() for column in rows[0]}
 
         assert columns == {

--- a/ingestion/tests/integration/sources/database/exasol/test_exasol_queries.py
+++ b/ingestion/tests/integration/sources/database/exasol/test_exasol_queries.py
@@ -45,7 +45,8 @@ def wait_for_system_table(
     last_rows: list[dict[str, object]] = []
 
     while monotonic() < deadline:
-        with engine.connect() as connection:
+        with engine.begin() as connection:
+            connection.execute(text("FLUSH STATISTICS"))
             rows = connection.execute(text(query), params or {}).mappings().all()
 
         last_rows = list(rows)
@@ -58,16 +59,6 @@ def wait_for_system_table(
         f"Timed out after {timeout_seconds}s waiting for {expected_count} rows. "
         f"Last observed row count: {len(last_rows)}"
     )
-
-
-def _enable_auditing(engine: Engine) -> None:
-    """Enable database auditing so the EXA_DBA_AUDIT_* tables are populated.
-
-    A freshly spawned Exasol container ships with AUDITING = OFF, leaving the
-    audit statistics tables empty no matter how long the tests poll them.
-    """
-    with engine.begin() as connection:
-        connection.execute(text("ALTER SYSTEM SET AUDITING = 'ON'"))
 
 
 def _prepare_exasol_objects(engine: Engine) -> None:
@@ -141,7 +132,6 @@ class TestExasolQueries:
         )
 
         cls.engine = create_engine(f"exa+websocket://sys:exasol@localhost:{DB_PORT}/?SSLCertificate=SSL_VERIFY_NONE")
-        _enable_auditing(cls.engine)
         _prepare_exasol_objects(cls.engine)
 
     @classmethod


### PR DESCRIPTION
### Issue
- Fixes #29289 
- Fixes the flaky/failing `TestExasolQueries` integration test, which timed out
polling Exasol's audit statistics tables with `Last observed row count: 0`.

- `test_connection_test_get_queries` and `test_sql_statement_query` read from
`EXA_STATISTICS.EXA_DBA_AUDIT_SQL` / `EXA_DBA_AUDIT_SESSIONS`. Auditing is
enabled by default on Exasol, so the rows *are* captured — but Exasol writes
audit data into the statistical system tables **asynchronously**. On a freshly
spawned container the setup DDL had run, yet the rows hadn't been flushed into
the `EXA_STATISTICS.*` tables within the 60s poll window, so the queries
returned 0 rows and the test timed out.

### Changes

- Run `FLUSH STATISTICS` before each poll in `wait_for_system_table`. This is
  Exasol's documented mechanism to update the statistical tables on demand,
  forcing the audit rows to be visible immediately instead of waiting for the
  periodic async flush.
- Bump the poll timeout from 60s → 120s on the two audit-table tests as
  headroom for slow/loaded CI runners.

No production code changes — test-only fix.

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### High-level design:
<!--
REQUIRED for large PRs (new features, refactors, breaking changes, or anything touching >5 files).
Skip for small bug fixes and trivial changes.

Cover:
- Architecture / approach you took and why
- Key components or files added/changed and how they interact
- Alternatives considered and why you rejected them
- Any migration, backward-compatibility, or rollout concerns
- Diagrams or links to design docs / RFCs if available
-->

N/A — small change. <!-- Or fill in the design above -->

#
### Tests:

#### Use cases covered
<!--
List the user-visible scenarios this PR exercises. Example:
- User with Admin role can create a Glossary Term with a parent term
- Ingestion run for Snowflake correctly extracts row counts for partitioned tables
-->

#### Unit tests
<!--
- [ ] I added unit tests for the new/changed logic.
- Files added/updated:
- Coverage on changed classes (run `mvn jacoco:report` for backend, `yarn test:coverage` for UI,
  `make unit_ingestion` for ingestion). Target is 90% line coverage on changed classes.
- Coverage %: <e.g., 92% on EntityRepository.java>
-->

#### Backend integration tests
<!--
- [ ] I added integration tests in `openmetadata-integration-tests/` for new/changed API endpoints.
- [ ] Not applicable (no backend API changes).
- Files added/updated:
-->

#### Ingestion integration tests
<!--
- [ ] I added/updated ingestion integration tests for connector changes.
- [ ] Not applicable (no ingestion changes).
- Files added/updated:
-->

#### Playwright (UI) tests
<!--
- [ ] I added Playwright E2E tests under `openmetadata-ui/.../ui/playwright/` for UI changes.
- [ ] Not applicable (no UI changes).
- Files added/updated:
-->

#### Manual testing performed
<!--
List the manual test steps you performed before requesting review. Example:
1. Started local stack via `./docker/run_local_docker.sh -m ui -d mysql`
2. Logged in as admin, created entity X, verified Y appears in the UI
3. Triggered ingestion for Snowflake source, confirmed lineage edges in the explore page
-->

#
### UI screen recording / screenshots:
<!--
REQUIRED for any PR that changes the UI. Drag-and-drop a short screen recording (.mov / .mp4 / .gif)
demonstrating the change end-to-end, plus before/after screenshots where relevant.
Mark "Not applicable" if there are no UI changes.
-->

Not applicable. <!-- Or attach recording/screenshots above -->

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.
- [ ] For UI changes: I attached a screen recording and/or screenshots above.
- [ ] I have added tests (unit / integration / Playwright as applicable) and listed them above.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes flaky Exasol integration tests by flushing statistics before polling system tables and extending wait timeouts. The single changed file is an integration test for Exasol query auditing.

- Switches `engine.connect()` to `engine.begin()` in `wait_for_system_table` and adds a `FLUSH STATISTICS` call before each poll, ensuring Exasol's internal audit log is materialized in the system tables before the query is executed.
- Extends `timeout_seconds` from the default 60 s to 120 s for `test_connection_test_get_queries` and `test_sql_statement_query`, giving the database more time to surface the expected rows.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — changes are limited to an integration test helper and do not touch production code paths.

The change is confined to a single test file. Switching to `engine.begin()` and issuing `FLUSH STATISTICS` inside the same transaction is the correct way to force Exasol's audit log to materialise before querying it. Extending the polling timeout adds resilience without introducing any correctness risk.

No files require special attention.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| ingestion/tests/integration/sources/database/exasol/test_exasol_queries.py | Adds FLUSH STATISTICS inside a proper transaction before each poll in wait_for_system_table, and extends timeouts to 120 s for two test methods; changes are minimal and correct. |

</details>

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Test as Test Method
    participant WFS as wait_for_system_table()
    participant EXA as Exasol DB

    Test->>WFS: "call(engine, query, expected_count, timeout_seconds=120)"
    loop Every 5 s until deadline
        WFS->>EXA: BEGIN transaction
        WFS->>EXA: FLUSH STATISTICS
        WFS->>EXA: SELECT … FROM system table
        EXA-->>WFS: rows
        WFS->>EXA: COMMIT
        alt "rows >= expected_count"
            WFS-->>Test: return rows
        else
            WFS->>WFS: sleep(5)
        end
    end
    WFS-->>Test: AssertionError (timeout)
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Test as Test Method
    participant WFS as wait_for_system_table()
    participant EXA as Exasol DB

    Test->>WFS: "call(engine, query, expected_count, timeout_seconds=120)"
    loop Every 5 s until deadline
        WFS->>EXA: BEGIN transaction
        WFS->>EXA: FLUSH STATISTICS
        WFS->>EXA: SELECT … FROM system table
        EXA-->>WFS: rows
        WFS->>EXA: COMMIT
        alt "rows >= expected_count"
            WFS-->>Test: return rows
        else
            WFS->>WFS: sleep(5)
        end
    end
    WFS-->>Test: AssertionError (timeout)
```

</a>
</details>

<sub>Reviews (2): Last reviewed commit: ["fix: flush stats change"](https://github.com/open-metadata/openmetadata/commit/d834be8069bcf4da4e746584096db7cc316ea610) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38981955)</sub>

<!-- /greptile_comment -->