### PR TITLE
fix(mcp): set preferred_username to full email in OM-issued JWTs

### DIFF
--- a/openmetadata-mcp/src/main/java/org/openmetadata/mcp/server/transport/OAuthHttpStatelessServerTransportProvider.java
+++ b/openmetadata-mcp/src/main/java/org/openmetadata/mcp/server/transport/OAuthHttpStatelessServerTransportProvider.java
@@ -339,11 +339,25 @@ public class OAuthHttpStatelessServerTransportProvider extends HttpServletStatel
       throws IOException {
     String tokenWithType = request.getHeader("Authorization");
 
+    if (tokenWithType == null) {
+      LOG.warn("MCP request rejected: no Authorization header present");
+      sendAuthErrorWithChallenge(
+          response, "Invalid or expired token", HttpServletResponse.SC_UNAUTHORIZED);
+      return false;
+    }
+
     try {
       validatePrefixedTokenRequest(jwtFilter, tokenWithType);
       return true;
     } catch (Exception e) {
-      LOG.debug("Bearer token authentication failed", e);
+      // WARN so the rejection reason is visible without enabling DEBUG.
+      // Full stack trace at DEBUG for deeper investigation.
+      LOG.warn(
+          "MCP Bearer token rejected — reason: {}. "
+              + "Check jwtPrincipalClaims order (email must precede preferred_username) "
+              + "and enforcePrincipalDomain setting. Enable DEBUG for full trace.",
+          e.getMessage());
+      LOG.debug("MCP Bearer token authentication failed (full trace)", e);
       sendAuthErrorWithChallenge(
           response, "Invalid or expired token", HttpServletResponse.SC_UNAUTHORIZED);
       return false;

--- a/openmetadata-service/src/main/java/org/openmetadata/service/security/jwt/JWTTokenGenerator.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/security/jwt/JWTTokenGenerator.java
@@ -226,7 +226,7 @@ public class JWTTokenGenerator {
               .withClaim(IS_BOT_CLAIM, isBot)
               .withClaim(TOKEN_TYPE, tokenType.value())
               .withClaim(USERNAME, userName)
-              .withClaim(PREFERRED_USERNAME, userName)
+              .withClaim(PREFERRED_USERNAME, !nullOrEmpty(email) ? email : userName)
               .withIssuedAt(new Date(System.currentTimeMillis()))
               .withExpiresAt(expires);
 


### PR DESCRIPTION
## Problem

OM-issued JWTs (MCP access tokens, PATs, service tokens) set `preferred_username` to the bare username (`asmith`). SSO configurations that check `preferred_username` first for domain enforcement fail because there is no `@domain` — identity providers like Azure always set `preferred_username` to the full UPN/email format (`asmith@company.com`).

This mismatch causes `POST /mcp` to return `401 Invalid or expired token` even though the OAuth flow completes successfully.

## Fix

- **`JWTTokenGenerator`**: set `preferred_username` to the full email when available, falling back to bare username. This aligns OM-issued JWTs with the OIDC spec (which defines `preferred_username` as an email-like identifier) and with what Azure/Google/Okta tokens provide. `findUserNameFromClaims` is unaffected — it already splits on `@`.
- **`OAuthHttpStatelessServerTransportProvider`**: log token rejection at WARN with the failure reason, so the cause is visible in production without enabling DEBUG.

## Workaround (no deploy needed)

In SSO settings → JWT Principal Claims, move `email` before `preferred_username`.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a `401 Invalid or expired token` error in MCP flows caused by OM-issued JWTs setting `preferred_username` to a bare username (e.g. `asmith`) while SSO domain-enforcement expects a full UPN/email (e.g. `asmith@company.com`). It also improves MCP auth diagnostics by surfacing token-rejection reasons at WARN level.

- **`JWTTokenGenerator`**: `preferred_username` is now set to the full email when available, falling back to the bare username. This is backward-compatible: `findUserNameFromClaims` already strips the `@domain` portion via `split("@")[0]`, so existing username extraction is unaffected.
- **`OAuthHttpStatelessServerTransportProvider`**: Adds a null-check for a missing Authorization header (previously fell into the catch block via NPE) and promotes token-rejection logging from DEBUG to WARN with the failure reason and a stack trace at DEBUG.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge. The core JWT fix is a one-line, backward-compatible change and the transport layer improvement is defensive.

The preferred_username to email change is well-contained: findUserNameFromClaims already strips the @domain portion so username extraction is unaffected for all callers. The null-check addition in authenticateRequest is a straightforward improvement. The one minor concern is the hardcoded claim-ordering hint baked into the WARN log message, which will mislead operators when unrelated token failures (expired, bad signature, revoked bot token) occur.

No files require special attention. JWTTokenGenerator.java change is minimal and safe; OAuthHttpStatelessServerTransportProvider.java is worth a quick look at the WARN log message wording.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-service/src/main/java/org/openmetadata/service/security/jwt/JWTTokenGenerator.java | One-line fix sets `preferred_username` to the full email when available instead of the bare username; backward-compatible because `findUserNameFromClaims` already strips the `@domain` portion. |
| openmetadata-mcp/src/main/java/org/openmetadata/mcp/server/transport/OAuthHttpStatelessServerTransportProvider.java | Adds an early null-check for the Authorization header and promotes token-rejection logging from DEBUG to WARN; the hardcoded claim-ordering hint in the WARN message is specific to one failure scenario. |

</details>

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(mcp): set preferred\_username to emai..."](https://github.com/open-metadata/openmetadata/commit/73d5acb07fce2c62da207c161c7ee4f80de9ad2e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38982092)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->