### PR TITLE
Load the learning drawer chunk without a page-loader flash

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/AppRouter/withSuspenseFallback.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/AppRouter/withSuspenseFallback.tsx
@@ -11,20 +11,22 @@
  *  limitations under the License.
  */
 
-import { ComponentType, forwardRef, Suspense } from 'react';
+import { ComponentType, forwardRef, ReactNode, Suspense } from 'react';
 import Loader from '../common/Loader/Loader';
 
+const DEFAULT_FALLBACK = (
+  <div className="ant-layout-content flex-center">
+    <Loader />
+  </div>
+);
+
 export function withSuspenseFallback<T extends object>(
-  Component: ComponentType<T>
+  Component: ComponentType<T>,
+  fallback: ReactNode = DEFAULT_FALLBACK
 ) {
   return forwardRef<unknown, T>(function DefaultFallback(props, ref) {
     return (
-      <Suspense
-        fallback={
-          <div className="ant-layout-content flex-center">
-            <Loader />
-          </div>
-        }>
+      <Suspense fallback={fallback}>
         <Component {...(props as T)} ref={ref} />
       </Suspense>
     );

--- a/openmetadata-ui/src/main/resources/ui/src/components/Learning/LearningIcon/LearningIcon.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Learning/LearningIcon/LearningIcon.component.tsx
@@ -26,7 +26,8 @@ const LearningDrawer = withSuspenseFallback(
     import('../LearningDrawer/LearningDrawer.component').then((m) => ({
       default: m.LearningDrawer,
     }))
-  )
+  ),
+  null
 );
 
 export const LearningIcon: React.FC<LearningIconProps> = ({


### PR DESCRIPTION
## What

`LearningIcon` always mounts the lazy-loaded `LearningDrawer` (it's rendered unconditionally, just toggled via `open={drawerOpen}`). Because it's `lazy()` wrapped in `withSuspenseFallback`, the Suspense fallback — a centered, page-sized `<Loader />` (`ant-layout-content flex-center`) — rendered **inline next to the icon** while the drawer's JS chunk downloaded on mount, before the user ever interacted with it.

This makes the loader behavior reusable/opt-out instead of forcing every lazy consumer to show the page loader during chunk load:

- **`withSuspenseFallback`** now takes an optional second `fallback` argument (`ReactNode`), defaulting to the existing `<Loader />`. All current callers are unchanged.
- **`LearningIcon`** passes `null`, so the chunk loads silently on mount. By the time the user clicks, the drawer opens instantly.


## Testing

- [x] Verify no loader flashes inline beside the learning icon on page load
- [ ] Verify the drawer opens/closes with its animation intact
- [x] Verify clicking a resource still opens the player modal

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR eliminates an unwanted full-page loader flash that appeared next to the learning icon on mount, caused by `LearningDrawer`'s lazy chunk resolving while wrapped in a Suspense boundary that defaulted to the page-sized `<Loader />`.

- **`withSuspenseFallback`** is made more flexible: the fallback UI is extracted to a module-level constant `DEFAULT_FALLBACK` and an optional second argument (`fallback: ReactNode`) is added, keeping all existing callers unchanged.
- **`LearningIcon`** passes `null` as the fallback so the drawer chunk loads silently on mount; by the time the user clicks, the drawer is ready and opens immediately without a Suspense flash.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — both files receive minimal, targeted changes with no behavioral risk to existing consumers.

The change to `withSuspenseFallback` is purely additive: the new `fallback` parameter defaults to the existing behavior, so every current call site is unaffected. Passing `null` to React's `Suspense.fallback` is a valid `ReactNode` and renders nothing, which is exactly the desired outcome. The drawer's always-mounted pattern and its animation/modal interaction are unchanged.

No files require special attention.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-ui/src/main/resources/ui/src/components/AppRouter/withSuspenseFallback.tsx | Backward-compatible extension: extracts the default Loader JSX into a module-level constant and adds an optional `fallback: ReactNode` parameter; all existing call sites are unaffected. |
| openmetadata-ui/src/main/resources/ui/src/components/Learning/LearningIcon/LearningIcon.component.tsx | Passes `null` as the Suspense fallback when wrapping `LearningDrawer`, suppressing the loader flash during chunk download on mount. |

</details>

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Browser
    participant LearningIcon
    participant Suspense
    participant DrawerChunk as LearningDrawer (lazy chunk)

    Note over Browser,DrawerChunk: Before this PR
    Browser->>LearningIcon: mount
    LearningIcon->>Suspense: "render (fallback = page Loader)"
    Suspense-->>Browser: render full-page Loader ❌
    DrawerChunk-->>Suspense: chunk loaded
    Suspense-->>Browser: render LearningDrawer (hidden)

    Note over Browser,DrawerChunk: After this PR
    Browser->>LearningIcon: mount
    LearningIcon->>Suspense: "render (fallback = null)"
    Suspense-->>Browser: render nothing during load ✅
    DrawerChunk-->>Suspense: chunk loaded
    Suspense-->>Browser: render LearningDrawer (hidden, ready)
    Browser->>LearningIcon: user clicks icon
    LearningIcon->>DrawerChunk: "open=true (instant, chunk already loaded)"
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Browser
    participant LearningIcon
    participant Suspense
    participant DrawerChunk as LearningDrawer (lazy chunk)

    Note over Browser,DrawerChunk: Before this PR
    Browser->>LearningIcon: mount
    LearningIcon->>Suspense: "render (fallback = page Loader)"
    Suspense-->>Browser: render full-page Loader ❌
    DrawerChunk-->>Suspense: chunk loaded
    Suspense-->>Browser: render LearningDrawer (hidden)

    Note over Browser,DrawerChunk: After this PR
    Browser->>LearningIcon: mount
    LearningIcon->>Suspense: "render (fallback = null)"
    Suspense-->>Browser: render nothing during load ✅
    DrawerChunk-->>Suspense: chunk loaded
    Suspense-->>Browser: render LearningDrawer (hidden, ready)
    Browser->>LearningIcon: user clicks icon
    LearningIcon->>DrawerChunk: "open=true (instant, chunk already loaded)"
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["Load learning drawer chunk without a pag..."](https://github.com/open-metadata/openmetadata/commit/43be75eea14d49905f5255181f19d632c7970a58) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38983280)</sub>

<!-- /greptile_comment -->