### PR TITLE
fix: scan all principal claims for email domain during enforcement

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/security/SecurityUtil.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/security/SecurityUtil.java
@@ -376,6 +376,7 @@ public final class SecurityUtil {
           jwtPrincipalClaimsOrder.stream()
               .filter(claims::containsKey)
               .map(c -> getClaimOrObject(claims.get(c)))
+              .filter(v -> !nullOrEmpty(v))
               .map(v -> v.split("@", 2))
               .filter(parts -> parts.length == 2 && !parts[1].isEmpty())
               .map(parts -> parts[1])

--- a/openmetadata-service/src/main/java/org/openmetadata/service/security/SecurityUtil.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/security/SecurityUtil.java
@@ -369,10 +369,18 @@ public final class SecurityUtil {
         throw new AuthenticationException("Invalid JWT token, 'email' claim is not present");
       }
     } else {
-      String jwtClaim = getFirstMatchJwtClaim(jwtPrincipalClaimsOrder, claims);
-      if (jwtClaim.contains("@")) {
-        domain = jwtClaim.split("@")[1];
-      }
+      // Scan all claims in order until one containing '@' is found.
+      // Stops at the first claim that exists in the token (username extraction),
+      // but for domain extraction a bare-username claim (e.g. preferred_username="asmith")
+      // must not shadow a full-email claim (e.g. email="asmith@company.com").
+      domain =
+          jwtPrincipalClaimsOrder.stream()
+              .filter(claims::containsKey)
+              .map(c -> getClaimOrObject(claims.get(c)))
+              .filter(v -> v.contains("@"))
+              .findFirst()
+              .map(v -> v.split("@")[1])
+              .orElse(StringUtils.EMPTY);
     }
 
     // Validate

--- a/openmetadata-service/src/main/java/org/openmetadata/service/security/SecurityUtil.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/security/SecurityUtil.java
@@ -369,17 +369,17 @@ public final class SecurityUtil {
         throw new AuthenticationException("Invalid JWT token, 'email' claim is not present");
       }
     } else {
-      // Scan all claims in order until one containing '@' is found.
-      // Stops at the first claim that exists in the token (username extraction),
-      // but for domain extraction a bare-username claim (e.g. preferred_username="asmith")
-      // must not shadow a full-email claim (e.g. email="asmith@company.com").
+      // Unlike username extraction (stops at first existing claim), domain extraction
+      // must skip bare-username claims (e.g. preferred_username="asmith") and continue
+      // until a full-email claim (e.g. email="asmith@company.com") is found.
       domain =
           jwtPrincipalClaimsOrder.stream()
               .filter(claims::containsKey)
               .map(c -> getClaimOrObject(claims.get(c)))
-              .filter(v -> v.contains("@"))
+              .map(v -> v.split("@", 2))
+              .filter(parts -> parts.length == 2 && !parts[1].isEmpty())
+              .map(parts -> parts[1])
               .findFirst()
-              .map(v -> v.split("@")[1])
               .orElse(StringUtils.EMPTY);
     }
 


### PR DESCRIPTION
## Problem

When `enforcePrincipalDomain` is enabled, domain extraction stops at the first existing claim in `jwtPrincipalClaims`. If that claim holds only a bare username (e.g. `preferred_username = "asmith"` — as OM-issued tokens set it), no domain is extracted and enforcement rejects the token even though a later claim (e.g. `email = "asmith@company.com"`) contains the full email.

This causes `POST /mcp` to return `401 Invalid or expired token` for MCP access tokens when the SSO config has `preferred_username` before `email` in `jwtPrincipalClaims`.

## Fix

In `SecurityUtil.validateDomainEnforcement`, scan all claims in order and use the first one that contains `@`, instead of stopping at the first claim that exists in the token. Username extraction (`findUserNameFromClaims`) is unchanged — it correctly uses the first matching claim regardless of `@`.

No JWT structure changed. No impact on user mapping.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a bug in `SecurityUtil.validateDomainEnforcement` where domain extraction would stop at the first matching claim key in `jwtPrincipalClaimsOrder`, even if that claim held only a bare username (no `@`), causing false-positive 401s for MCP access tokens when `preferred_username` appeared before `email` in the claim order.

- **Domain extraction is now claim-order-aware for `@`**: the new stream scans all matching claims in order and returns the first value that contains `@`, mirroring how username extraction already works.
- **Null safety**: `getClaimOrObject` can return `null` for non-string (e.g., array) claims; the downstream `filter(v -> !nullOrEmpty(v))` step handles this correctly because `nullOrEmpty(null)` returns `true` via short-circuit evaluation (`null == null`), filtering the null before the `.split` call.
- **No-match behavior change**: the old path called `getFirstMatchJwtClaim`, which throws `AuthenticationException(\"none of the following claims are present…\")` if zero claim keys are found; the new path silently sets domain to `\"\"`. When enforcement is enabled, the downstream domain comparison still rejects the token — just with a different error message.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is narrowly scoped to domain extraction under the non-mapping branch and does not alter username lookup, bot handling, or the enforcement checks that follow.

The stream correctly handles null returns from getClaimOrObject (array-typed claims) via nullOrEmpty's short-circuit null guard, and the split('@', 2) plus length/empty filters make the extraction robust. The only behavioral difference from the old path is that missing claims now produce an empty domain rather than a distinct 'claims not present' exception message, which still results in an auth rejection when enforcement is on.

No files require special attention. The single changed file is self-contained and the logic is straightforward.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-service/src/main/java/org/openmetadata/service/security/SecurityUtil.java | Domain enforcement now scans all claims for '@' instead of stopping at the first existing claim; null returns from getClaimOrObject are safely filtered before the split; no test files were added alongside the fix. |

</details>

<sub>Reviews (3): Last reviewed commit: ["gitarbot feedback: filter null claim val..."](https://github.com/open-metadata/openmetadata/commit/834beb38148306d26e1adcc9b76c30634adaeec1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38983519)</sub>

<!-- /greptile_comment -->