### PR TITLE
fix(openlineage): reset Kinesis poll inactivity timer per shard (1.12.10 backport)

### DIFF
--- a/ingestion/src/metadata/ingestion/source/pipeline/openlineage/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/pipeline/openlineage/metadata.py
@@ -1124,7 +1124,6 @@ class OpenlineageSource(PipelineServiceSource):
             iterator_type = broker.consumerOffsets.value
             pool_timeout = broker.poolTimeout
             session_timeout = broker.sessionTimeout
-            empty_response_time = 0.0
 
             for shard in shards:
                 shard_id = shard["ShardId"]
@@ -1134,6 +1133,9 @@ class OpenlineageSource(PipelineServiceSource):
                     ShardIteratorType=iterator_type,
                 )
                 shard_iterator = iterator_resp["ShardIterator"]
+                # Reset the inactivity timer for each shard; otherwise the timeout
+                # accrued draining the first shard leaves every later shard skipped.
+                empty_response_time = 0.0
 
                 while shard_iterator and empty_response_time <= session_timeout:
                     response = kinesis_client.get_records(

--- a/ingestion/tests/unit/topology/pipeline/test_openlineage.py
+++ b/ingestion/tests/unit/topology/pipeline/test_openlineage.py
@@ -16,6 +16,7 @@ from metadata.generated.schema.entity.services.connections.metadata.openMetadata
 from metadata.generated.schema.entity.services.connections.pipeline.openLineageConnection import (
     ConsumerOffsets,
     ConsumerOffsets1,
+    KinesisBrokerConfig,
     SecurityProtocol,
 )
 from metadata.generated.schema.entity.services.databaseService import (
@@ -2478,6 +2479,51 @@ class OpenLineageUnitTest(unittest.TestCase):
         so a single bad dataset never aborts the whole event."""
         data = {"namespace": "trino://host:8080", "name": "invalidname"}
         self.assertEqual(OpenlineageSource._iter_table_candidates(data), [])
+
+
+class TestKinesisMultiShardPolling:
+    @patch(
+        "metadata.ingestion.source.pipeline.openlineage.metadata.time.sleep",
+        return_value=None,
+    )
+    def test_poll_kinesis_reads_events_from_every_shard(self, _mock_sleep):
+        # Two shards, each with one record then no new data. The empty polls make
+        # each shard exit via the inactivity timeout (NextShardIterator stays set,
+        # as live shards do). Before the per-shard reset fix, the timeout accrued
+        # on shard-0 skipped shard-1 entirely, yielding only one event.
+        raw = json.dumps(FULL_OL_KAFKA_EVENT).encode()
+
+        client = MagicMock()
+        paginator = MagicMock()
+        paginator.paginate.return_value = [{"Shards": [{"ShardId": "shard-0"}, {"ShardId": "shard-1"}]}]
+        client.get_paginator.return_value = paginator
+        client.get_shard_iterator.side_effect = lambda **kw: {"ShardIterator": f"{kw['ShardId']}-start"}
+
+        def get_records(ShardIterator, Limit):  # noqa: N803
+            if ShardIterator.endswith("-start"):
+                shard = ShardIterator[: -len("-start")]
+                return {
+                    "Records": [{"Data": raw}],
+                    "NextShardIterator": f"{shard}-empty",
+                }
+            return {"Records": [], "NextShardIterator": ShardIterator}
+
+        client.get_records.side_effect = get_records
+
+        broker = KinesisBrokerConfig(
+            streamName="stream",
+            awsConfig={"awsRegion": "us-east-2"},
+            consumerOffsets=ConsumerOffsets1.TRIM_HORIZON,
+            poolTimeout=1.0,
+            sessionTimeout=1,
+        )
+
+        source = object.__new__(OpenlineageSource)
+        source.client = client
+
+        events = list(source._poll_kinesis(broker))
+
+        assert len(events) == 2
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Backport of #29276 to **1.12.10**.

## Problem
The OpenLineage Kinesis source (`_poll_kinesis`) only ingests events from the **first shard** of a multi-shard stream; every subsequent shard is skipped (reported on a multi-shard `TRIM_HORIZON` stream).

## Root cause
`empty_response_time` was initialised once **before** the `for shard in shards:` loop. For a live shard, `get_records` always returns a non-null `NextShardIterator`, so the per-shard `while shard_iterator and empty_response_time <= session_timeout` loop only exits once `empty_response_time` exceeds `sessionTimeout`. That value was never reset between shards, so after the first shard drained, shards 2..N had the loop condition already `False` and were skipped — total ingested events == one shard's worth. Deterministic for any >1-shard stream (single-shard streams appeared to work).

## Fix
Reset `empty_response_time = 0.0` at the start of each shard iteration.

## Testing
Added `TestKinesisMultiShardPolling.test_poll_kinesis_reads_events_from_every_shard` — mocks a 2-shard stream (each shard returns one record then empty polls with a live `NextShardIterator`, forcing the timeout exit path) and asserts events from **both** shards are yielded. Verified on the main fix: **2 events with the fix, 1 without**.

Cherry-picked from #29276.