### PR TITLE
test(ui): stable key-based testid for asset quick-filter dropdowns

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/constant/common.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/constant/common.ts
@@ -64,14 +64,17 @@ export const COMMON_TIER_TAG = [
   },
 ];
 
-export const ASSET_FILTER_NAMES = [
-  'Entity Type',
-  'Domains',
-  'Owners',
-  'Tag',
-  'Tier',
-  'Service',
-  'Service Type',
+// Stable, locale-independent search keys (EntityFields) for the asset-filter
+// quick-filter dropdowns. Keyed off field.key rather than the translated label
+// so the selectors survive i18n/label changes.
+export const ASSET_FILTER_KEYS = [
+  'entityType',
+  'domains.displayName.keyword',
+  'ownerDisplayName',
+  'tags.tagFQN',
+  'tier.tagFQN',
+  'service.displayName.keyword',
+  'serviceType',
 ];
 
 export const KEY_PROFILE_METRICS = [

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DomainFilterQueryFilter.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DomainFilterQueryFilter.spec.ts
@@ -754,7 +754,7 @@ test.describe('Domain Filter - User Behavior Tests', () => {
     const applyEntityTypeFilter = async (entityType: string) => {
       await page.locator('.filters-row button').first().click();
       await page.getByRole('menuitem', { name: /Entity Type/i }).click();
-      await page.click('[data-testid="search-dropdown-Entity Type"]');
+      await page.click('[data-testid="search-dropdown-entityType"]');
       await page.getByTestId('drop-down-menu').waitFor({
         state: 'visible',
       });

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/assetDrawerQuickFilter.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/assetDrawerQuickFilter.ts
@@ -30,8 +30,8 @@ export interface DrawerQuickFilterContext {
   untieredTable: DrawerAsset;
   topic: DrawerAsset;
   dashboard: DrawerAsset;
-  entityTypeLabel?: string;
-  tierLabel?: string;
+  entityTypeKey?: string;
+  tierKey?: string;
 }
 
 export const toDrawerAsset = (entity: object): DrawerAsset => ({
@@ -44,8 +44,8 @@ const popover = (page: Page): Locator => page.locator(POPOVER);
 const optionByValue = (page: Page, value: string): Locator =>
   popover(page).getByTestId(`${value}-checkbox`);
 
-export const openQuickFilter = async (page: Page, label: string) => {
-  await page.getByTestId(`search-dropdown-${label}`).click();
+export const openQuickFilter = async (page: Page, searchKey: string) => {
+  await page.getByTestId(`search-dropdown-${searchKey}`).click();
   await expect(popover(page)).toBeVisible();
 };
 
@@ -79,9 +79,9 @@ export const expectAssetHidden = async (page: Page, fqn: string) => {
 
 const assertPopoverInteractiveAndFiltersOptions = async (
   page: Page,
-  entityTypeLabel: string
+  entityTypeKey: string
 ) => {
-  await openQuickFilter(page, entityTypeLabel);
+  await openQuickFilter(page, entityTypeKey);
 
   await expect(optionByValue(page, 'table')).toBeVisible();
   await expect(optionByValue(page, 'topic')).toBeVisible();
@@ -100,28 +100,28 @@ const assertPopoverInteractiveAndFiltersOptions = async (
 
 const assertCloseDiscardsSelection = async (
   page: Page,
-  entityTypeLabel: string
+  entityTypeKey: string
 ) => {
-  await openQuickFilter(page, entityTypeLabel);
+  await openQuickFilter(page, entityTypeKey);
   await optionByValue(page, 'dashboard').click();
   await closeQuickFilterPopover(page);
 
   await expect(
-    page.getByTestId(`search-dropdown-${entityTypeLabel}`)
+    page.getByTestId(`search-dropdown-${entityTypeKey}`)
   ).not.toContainText('dashboard');
 };
 
 const assertApplyNarrowsList = async (
   page: Page,
   ctx: DrawerQuickFilterContext,
-  entityTypeLabel: string
+  entityTypeKey: string
 ) => {
-  await openQuickFilter(page, entityTypeLabel);
+  await openQuickFilter(page, entityTypeKey);
   await optionByValue(page, 'table').click();
   await applyQuickFilter(page);
 
   await expect(
-    page.getByTestId(`search-dropdown-${entityTypeLabel}`)
+    page.getByTestId(`search-dropdown-${entityTypeKey}`)
   ).toContainText('table');
 
   await scopeDrawerSearch(page, ctx.topic.name);
@@ -133,9 +133,9 @@ const assertApplyNarrowsList = async (
 const assertCombineFilters = async (
   page: Page,
   ctx: DrawerQuickFilterContext,
-  tierLabel: string
+  tierKey: string
 ) => {
-  await openQuickFilter(page, tierLabel);
+  await openQuickFilter(page, tierKey);
   await popover(page)
     .getByTestId(/tier1-checkbox$/i)
     .click();
@@ -153,25 +153,25 @@ export const runDrawerQuickFilterMatrix = async (
   page: Page,
   ctx: DrawerQuickFilterContext
 ) => {
-  const entityTypeLabel = ctx.entityTypeLabel ?? 'Entity Type';
-  const tierLabel = ctx.tierLabel ?? 'Tier';
+  const entityTypeKey = ctx.entityTypeKey ?? 'entityType';
+  const tierKey = ctx.tierKey ?? 'tier.tagFQN';
 
   await ctx.openDrawer();
 
   await test.step(`[${ctx.surface}] popover is interactive and filters its options`, async () => {
-    await assertPopoverInteractiveAndFiltersOptions(page, entityTypeLabel);
+    await assertPopoverInteractiveAndFiltersOptions(page, entityTypeKey);
   });
 
   await test.step(`[${ctx.surface}] Close discards the staged selection`, async () => {
-    await assertCloseDiscardsSelection(page, entityTypeLabel);
+    await assertCloseDiscardsSelection(page, entityTypeKey);
   });
 
   await test.step(`[${ctx.surface}] selecting + Update narrows the asset list`, async () => {
-    await assertApplyNarrowsList(page, ctx, entityTypeLabel);
+    await assertApplyNarrowsList(page, ctx, entityTypeKey);
   });
 
   await test.step(`[${ctx.surface}] combining filters intersects the results`, async () => {
-    await assertCombineFilters(page, ctx, tierLabel);
+    await assertCombineFilters(page, ctx, tierKey);
   });
 
   await ctx.closeDrawer();

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/glossary.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/glossary.ts
@@ -12,7 +12,7 @@
  */
 import { APIRequestContext, expect, Locator, Page } from '@playwright/test';
 import { get, isUndefined } from 'lodash';
-import { ASSET_FILTER_NAMES } from '../constant/common';
+import { ASSET_FILTER_KEYS } from '../constant/common';
 import { SidebarItem } from '../constant/sidebar';
 import { GLOSSARY_TERM_PATCH_PAYLOAD } from '../constant/version';
 import { PolicyClass } from '../support/access-control/PoliciesClass';
@@ -946,9 +946,9 @@ export const verifyAssetModalFilters = async (
 
   await expect(filterButton).not.toBeVisible();
 
-  for (const filterName of ASSET_FILTER_NAMES) {
+  for (const filterKey of ASSET_FILTER_KEYS) {
     await expect(
-      page.locator(`[data-testid="search-dropdown-${filterName}"]`)
+      page.locator(`[data-testid="search-dropdown-${filterKey}"]`)
     ).toBeVisible();
   }
 
@@ -958,7 +958,7 @@ export const verifyAssetModalFilters = async (
   await testFilterWithSpecificOption(
     page,
     filterWrapper,
-    'Entity Type',
+    'entityType',
     'table',
     'table'
   );
@@ -966,17 +966,21 @@ export const verifyAssetModalFilters = async (
   await testFilterWithSpecificOption(
     page,
     filterWrapper,
-    'Service Type',
+    'serviceType',
     'mysql',
     'mysql'
   );
 
-  await testFilterWithFirstOption(page, filterWrapper, 'Tag');
+  await testFilterWithFirstOption(page, filterWrapper, 'tags.tagFQN');
 
-  await testFilterWithFirstOption(page, filterWrapper, 'Domains');
+  await testFilterWithFirstOption(
+    page,
+    filterWrapper,
+    'domains.displayName.keyword'
+  );
 
-  await testFilterWithFirstOption(page, filterWrapper, 'Tier');
-  await testFilterWithFirstOption(page, filterWrapper, 'Owners');
+  await testFilterWithFirstOption(page, filterWrapper, 'tier.tagFQN');
+  await testFilterWithFirstOption(page, filterWrapper, 'ownerDisplayName');
 };
 
 export const updateNameForGlossaryTerm = async (

--- a/openmetadata-ui/src/main/resources/ui/src/components/Explore/QuickFilterDropdown.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Explore/QuickFilterDropdown.test.tsx
@@ -134,7 +134,7 @@ describe('QuickFilterDropdown', () => {
     const onGetInitialOptions = jest.fn();
     renderDropdown({ onGetInitialOptions });
 
-    fireEvent.click(screen.getByTestId('entityType'));
+    fireEvent.click(screen.getByTestId('search-dropdown-entityType'));
 
     expect(onGetInitialOptions).toHaveBeenCalledWith('entityType');
   });
@@ -143,7 +143,7 @@ describe('QuickFilterDropdown', () => {
     const onChange = jest.fn();
     renderDropdown({ onChange });
 
-    fireEvent.click(screen.getByTestId('entityType'));
+    fireEvent.click(screen.getByTestId('search-dropdown-entityType'));
     fireEvent.click(screen.getByRole('checkbox', { name: 'Table' }));
 
     expect(onChange).not.toHaveBeenCalled();
@@ -160,7 +160,7 @@ describe('QuickFilterDropdown', () => {
     const onChange = jest.fn();
     renderDropdown({ onChange, singleSelect: true });
 
-    fireEvent.click(screen.getByTestId('entityType'));
+    fireEvent.click(screen.getByTestId('search-dropdown-entityType'));
     fireEvent.click(screen.getByRole('checkbox', { name: 'Table' }));
     fireEvent.click(screen.getByRole('checkbox', { name: 'Topic' }));
     fireEvent.click(screen.getByTestId('update-btn'));
@@ -175,7 +175,7 @@ describe('QuickFilterDropdown', () => {
     const onChange = jest.fn();
     renderDropdown({ onChange, hasNullOption: true });
 
-    fireEvent.click(screen.getByTestId('entityType'));
+    fireEvent.click(screen.getByTestId('search-dropdown-entityType'));
     fireEvent.click(screen.getByTestId('no-option-checkbox'));
     fireEvent.click(screen.getByTestId('update-btn'));
 
@@ -192,7 +192,7 @@ describe('QuickFilterDropdown', () => {
     const onSearch = jest.fn();
     renderDropdown({ onSearch });
 
-    fireEvent.click(screen.getByTestId('entityType'));
+    fireEvent.click(screen.getByTestId('search-dropdown-entityType'));
     fireEvent.change(screen.getByTestId('search-input'), {
       target: { value: 'tab' },
     });

--- a/openmetadata-ui/src/main/resources/ui/src/components/Explore/QuickFilterDropdown.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Explore/QuickFilterDropdown.tsx
@@ -151,7 +151,7 @@ const QuickFilterDropdown: FC<QuickFilterDropdownProps> = ({
     <PopoverTrigger isOpen={isOpen} onOpenChange={handleOpenChange}>
       <Button
         color="secondary"
-        data-testid={searchKey}
+        data-testid={`search-dropdown-${searchKey}`}
         iconTrailing={<ChevronDown className="tw:size-4" />}
         size="sm">
         <span data-testid={`search-dropdown-${label}`}>

--- a/openmetadata-ui/src/main/resources/ui/src/components/SearchDropdown/SearchDropdown.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/SearchDropdown/SearchDropdown.tsx
@@ -402,6 +402,7 @@ const SearchDropdown: FC<SearchDropdownProps> = ({
         trigger="hover">
         <Button
           className="quick-filter-dropdown-trigger-btn"
+          data-testid={`search-dropdown-${searchKey}`}
           size={triggerButtonSize}>
           <Space data-testid={`search-dropdown-${label}`} size={4}>
             <Space


### PR DESCRIPTION
## Problem

The Add-Assets drawer and asset-selection modal quick-filter dropdowns expose a testid derived from the **translated** filter label — `data-testid="search-dropdown-${label}"`. The asset-filter E2E specs therefore query selectors like `search-dropdown-Entity Type`.

That makes the selectors **locale-fragile**: when the filter label is translated (or overridden by a downstream consumer) — e.g. `label.entity-type-plural` rendering `Entity types` instead of `Entity Type` — `search-dropdown-Entity Type` no longer exists in the DOM, and the asset-filter specs either hang (drawer: `openQuickFilter`'s `.click()` retries to the test timeout) or fail fast (modal: `toBeVisible`):

- `Domains › Add-Assets drawer quick filter - behaviour matrix`
- `InputOutputPorts › Input/Output port drawer quick filter - behaviour matrix`
- `DataProductAndSubdomains › Add-Assets drawer quick filter - behaviour matrix`
- `Glossary › Verify asset selection modal filters are shown upfront`
- `DomainFilterQueryFilter › Multi-nested domain hierarchy: filters should scope correctly at every level`

## Fix

Expose an additional, **locale-independent** testid `search-dropdown-${searchKey}` (where `searchKey` is the filter's `field.key`, e.g. `entityType`, `serviceType`, `tier.tagFQN`) on both quick-filter dropdown variants, and key the asset-filter specs/helpers off it instead of the translated label.

- **`SearchDropdown.tsx` / `QuickFilterDropdown.tsx`** — add `data-testid="search-dropdown-<searchKey>"` on the trigger button. **Additive**: the existing `search-dropdown-<label>` testid is preserved, so the ~29 other specs that rely on it are unaffected.
- **`assetDrawerQuickFilter.ts`** — key the drawer behaviour matrix off `field.key` (`entityType`, `tier.tagFQN`).
- **`glossary.ts` + `common.ts`** — `ASSET_FILTER_NAMES` → `ASSET_FILTER_KEYS` (field.key values).
- **`DomainFilterQueryFilter.spec.ts`** — query `search-dropdown-entityType`.

## Testing

All 6 affected tests verified **green** locally against a running server (`setup` → `entity-data-setup` → tests):

| Test | Result |
|---|---|
| DomainFilterQueryFilter › Multi-nested domain hierarchy | ✅ |
| DataProductAndSubdomains › Add-Assets drawer quick filter | ✅ |
| Domains › Add-Assets drawer quick filter | ✅ |
| Glossary › asset selection modal filters shown upfront | ✅ |
| InputOutputPorts › Input port drawer quick filter | ✅ |
| InputOutputPorts › Output port drawer quick filter | ✅ |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes locale-fragile E2E test selectors by adding a stable, locale-independent `data-testid="search-dropdown-<searchKey>"` attribute to the trigger buttons of both `SearchDropdown` and `QuickFilterDropdown`, and updating the affected Playwright specs and constants to use the new field-key-based selectors.

- **Additive testid on both components**: `SearchDropdown.tsx` and `QuickFilterDropdown.tsx` each gain `data-testid="search-dropdown-${searchKey}"` on the trigger `<Button>`, while the existing `data-testid="search-dropdown-${label}"` on the inner child element is preserved untouched, so the ~29 unaffected specs continue to work.
- **Playwright helpers migrated**: `assetDrawerQuickFilter.ts` renames `entityTypeLabel`/`tierLabel` params to `entityTypeKey`/`tierKey`; `ASSET_FILTER_NAMES` in `common.ts` is replaced by `ASSET_FILTER_KEYS` (field.key values); `glossary.ts` and `DomainFilterQueryFilter.spec.ts` are updated accordingly.
- **Unit tests updated**: `QuickFilterDropdown.test.tsx` updates all `getByTestId('entityType')` calls to `getByTestId('search-dropdown-entityType')` to match the renamed button attribute.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is purely additive on both UI components and all affected test files are consistently updated.

Both component changes add a new stable search-dropdown-${searchKey} attribute to the trigger button without removing or moving the existing search-dropdown-${label} child attribute, so the ~29 untouched specs continue to work via click-event bubbling. The unit test file is included in the PR and correctly updated. The new field-key constants are well-formed and will work correctly in CSS attribute selectors even with dots in the key strings like tier.tagFQN.

No files require special attention.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-ui/src/main/resources/ui/src/components/Explore/QuickFilterDropdown.tsx | Renames button testid from bare searchKey to search-dropdown-${searchKey}; existing search-dropdown-${label} span testid preserved. |
| openmetadata-ui/src/main/resources/ui/src/components/SearchDropdown/SearchDropdown.tsx | Adds search-dropdown-${searchKey} testid on the trigger button; additive alongside the existing label-based testid on the inner Space element. |
| openmetadata-ui/src/main/resources/ui/src/components/Explore/QuickFilterDropdown.test.tsx | Updates all 5 occurrences of getByTestId('entityType') to getByTestId('search-dropdown-entityType') to match the renamed button attribute. |
| openmetadata-ui/src/main/resources/ui/playwright/utils/assetDrawerQuickFilter.ts | Migrates entityTypeLabel/tierLabel parameters to entityTypeKey/tierKey and updates all internal testid lookups to use field keys. |
| openmetadata-ui/src/main/resources/ui/playwright/constant/common.ts | Replaces ASSET_FILTER_NAMES (translated labels) with ASSET_FILTER_KEYS (stable field keys like entityType, tier.tagFQN). |
| openmetadata-ui/src/main/resources/ui/playwright/utils/glossary.ts | Switches verifyAssetModalFilters to use ASSET_FILTER_KEYS and key-based testids; testFilterWithSpecificOption/testFilterWithFirstOption calls updated accordingly. |
| openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DomainFilterQueryFilter.spec.ts | Single selector updated from search-dropdown-Entity Type to search-dropdown-entityType. |

</details>

</details>

<details open><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[SearchDropdown / QuickFilterDropdown] -->|renders trigger button| B["Button\ndata-testid=search-dropdown-searchKey"]
    B -->|contains child| C["Inner span/Space\ndata-testid=search-dropdown-label\n(preserved unchanged)"]
    B --> D{Tests}
    C --> D
    D -->|New specs use searchKey| E["search-dropdown-entityType\nsearch-dropdown-tier.tagFQN"]
    D -->|Existing specs use label| F["search-dropdown-Entity Type\nclick bubbles up to button"]
    E --> G[Stable across i18n changes]
    F --> H[Backward-compatible]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[SearchDropdown / QuickFilterDropdown] -->|renders trigger button| B["Button\ndata-testid=search-dropdown-searchKey"]
    B -->|contains child| C["Inner span/Space\ndata-testid=search-dropdown-label\n(preserved unchanged)"]
    B --> D{Tests}
    C --> D
    D -->|New specs use searchKey| E["search-dropdown-entityType\nsearch-dropdown-tier.tagFQN"]
    D -->|Existing specs use label| F["search-dropdown-Entity Type\nclick bubbles up to button"]
    E --> G[Stable across i18n changes]
    F --> H[Backward-compatible]
```

</a>
</details>

<sub>Reviews (2): Last reviewed commit: ["Merge branch &#39;main&#39; into fix/asset-quick..."](https://github.com/open-metadata/openmetadata/commit/924fb2acfcbe7bf0e7be906ebe31a5f6e0ed48ca) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39014579)</sub>

<!-- /greptile_comment -->