### PR TITLE
fix(ui): show glossary approve/reject buttons for nested terms after Expand All

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/Glossary/GlossaryTermTab/GlossaryTermTab.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Glossary/GlossaryTermTab/GlossaryTermTab.component.tsx
@@ -370,6 +370,7 @@ const GlossaryTermTab = ({ isGlossary, className }: GlossaryTermTabProps) => {
         TabSpecificField.OWNERS,
         TabSpecificField.PARENT,
         TabSpecificField.CHILDREN,
+        TabSpecificField.REVIEWERS,
       ],
     });
     setGlossaryChildTerms(buildTree(data) as ModifiedGlossary[]);


### PR DESCRIPTION
## Problem
Fixes - #29293 
After clicking **Expand All** on the Glossary terms tree, nested terms in **In Review** status no longer show the **Approve / Reject** buttons for their reviewers. The status badge still correctly reads "In Review", but the action buttons are missing, so reviewers cannot approve/reject nested terms from the expanded tree.

This is what causes `GlossaryApprovalAfterMove.spec.ts` to fail on `1.12.12` (the nested child term is only reachable via Expand All):

```
Error: expect(locator).toBeVisible() failed
Locator: getByTestId('...-approve-btn')
```

## Root cause

The buttons render only when `status === 'In Review'` **and** `permission` is true. On this branch `permissionForApproveOrReject` resolves the reviewer permission from `record.reviewers`:

```ts
const isReviewer = record.reviewers?.some((r) => r.id === currentUser?.id);
return { permission: taskThread && isReviewer, ... };
```

The Expand-All fetch (`fetchExpadedTree`) re-fetches the whole tree but only requested `owners, parent, children` — **not `reviewers`**. `entityStatus` is a core field that is always serialized (so the badge keeps showing "In Review"), but `reviewers` is a non-default field that must be requested explicitly. With it missing, `record.reviewers` is `undefined`, `isReviewer` is `false`, and the buttons are hidden.

The first-level paginated fetch already requests `reviewers`, which is why the bug only appears for nested terms after expanding.

## Fix

Add `TabSpecificField.REVIEWERS` to the Expand-All fetch so the reviewer permission check resolves correctly for nested terms.

```diff
       fields: [
         TabSpecificField.OWNERS,
         TabSpecificField.PARENT,
         TabSpecificField.CHILDREN,
+        TabSpecificField.REVIEWERS,
       ],
```

## Testing

- `GlossaryApprovalAfterMove.spec.ts` (both approve and reject cases) now passes.
- Manual: glossary with a reviewer → create a nested child term (In Review) → log in as reviewer → Expand All → Approve/Reject buttons are visible and functional.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Adds `TabSpecificField.REVIEWERS` to the Expand-All tree fetch so that the reviewer permission check resolves correctly for nested glossary terms, restoring Approve/Reject button visibility for reviewers after clicking Expand All.

- The `fetchExpadedTree` call previously fetched only `owners`, `parent`, and `children`; `reviewers` is a non-default field that must be explicitly requested, so it was `undefined` for all nested terms, causing `isReviewer` to be `false` and the action buttons to be hidden.
- The first-level paginated fetch (`getFirstLevelGlossaryTermsPaginated`) already includes `TabSpecificField.REVIEWERS`, making the omission only affect the expanded-tree path — the fix aligns the two code paths.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — a single additive field to an existing API call that restores parity with the first-level fetch.

The change is exactly one line: adding `TabSpecificField.REVIEWERS` to the expanded-tree fetch. It matches what the first-level paginated fetch already requests, introduces no new logic, and directly fixes the missing buttons. No other code paths are affected.

No files require special attention.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-ui/src/main/resources/ui/src/components/Glossary/GlossaryTermTab/GlossaryTermTab.component.tsx | Adds `TabSpecificField.REVIEWERS` to the `fetchExpadedTree` fields list, aligning it with the first-level fetch and fixing missing Approve/Reject buttons for nested terms after Expand All. |

</details>

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant User as Reviewer
    participant UI as GlossaryTermTab
    participant API as getGlossaryTerms API

    User->>UI: Click "Expand All"
    UI->>API: "fetchExpadedTree()<br/>fields: [owners, parent, children, reviewers]"
    API-->>UI: Terms with reviewers populated
    UI->>UI: buildTree(data)
    UI->>UI: "permissionForApproveOrReject:<br/>isReviewer = record.reviewers.some(r => r.id === currentUser.id)"
    UI-->>User: Approve / Reject buttons visible

    Note over UI,API: Before fix: reviewers field was missing from request
    Note over UI,API: record.reviewers was undefined → isReviewer=false → buttons hidden
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant User as Reviewer
    participant UI as GlossaryTermTab
    participant API as getGlossaryTerms API

    User->>UI: Click "Expand All"
    UI->>API: "fetchExpadedTree()<br/>fields: [owners, parent, children, reviewers]"
    API-->>UI: Terms with reviewers populated
    UI->>UI: buildTree(data)
    UI->>UI: "permissionForApproveOrReject:<br/>isReviewer = record.reviewers.some(r => r.id === currentUser.id)"
    UI-->>User: Approve / Reject buttons visible

    Note over UI,API: Before fix: reviewers field was missing from request
    Note over UI,API: record.reviewers was undefined → isReviewer=false → buttons hidden
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(ui): show glossary approve/reject bu..."](https://github.com/open-metadata/openmetadata/commit/051165017a5aacd90491df2274a85a4c0a9dc4ee) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39016389)</sub>

<!-- /greptile_comment -->