### PR TITLE
fix(ui): show glossary approve/reject buttons for nested terms after Expand All

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/Glossary/GlossaryTermTab/GlossaryTermTab.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Glossary/GlossaryTermTab/GlossaryTermTab.component.tsx
@@ -370,6 +370,7 @@ const GlossaryTermTab = ({ isGlossary, className }: GlossaryTermTabProps) => {
         TabSpecificField.OWNERS,
         TabSpecificField.PARENT,
         TabSpecificField.CHILDREN,
+        TabSpecificField.REVIEWERS,
       ],
     });
     setGlossaryChildTerms(buildTree(data) as ModifiedGlossary[]);


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:

Fixes #29293 

After clicking Expand All on the Glossary terms tree, nested terms in In Review status no longer show the Approve / Reject buttons for their reviewers. The status badge still correctly reads "In Review", but the action buttons are missing, so reviewers cannot approve/reject nested terms from the expanded tree.

<!--
Linking an issue is REQUIRED. Replace <issue-number> with the GitHub issue number this PR addresses
(e.g., `Fixes #12345`). GitHub will auto-link it. If no issue exists, please open one first so the
problem and design can be discussed before review.
-->

<!--
Short blurb explaining:
- What changes did you make?
- Why did you make them?
-->


#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### High-level design:
<!--
REQUIRED for large PRs (new features, refactors, breaking changes, or anything touching >5 files).
Skip for small bug fixes and trivial changes.

Cover:
- Architecture / approach you took and why
- Key components or files added/changed and how they interact
- Alternatives considered and why you rejected them
- Any migration, backward-compatibility, or rollout concerns
- Diagrams or links to design docs / RFCs if available
-->

N/A — small change. <!-- Or fill in the design above -->

#
### Tests:

#### Use cases covered
<!--
List the user-visible scenarios this PR exercises. Example:
- User with Admin role can create a Glossary Term with a parent term
- Ingestion run for Snowflake correctly extracts row counts for partitioned tables
-->

#### Unit tests
<!--
- [ ] I added unit tests for the new/changed logic.
- Files added/updated:
- Coverage on changed classes (run `mvn jacoco:report` for backend, `yarn test:coverage` for UI,
  `make unit_ingestion` for ingestion). Target is 90% line coverage on changed classes.
- Coverage %: <e.g., 92% on EntityRepository.java>
-->

#### Backend integration tests
<!--
- [ ] I added integration tests in `openmetadata-integration-tests/` for new/changed API endpoints.
- [ ] Not applicable (no backend API changes).
- Files added/updated:
-->

#### Ingestion integration tests
<!--
- [ ] I added/updated ingestion integration tests for connector changes.
- [ ] Not applicable (no ingestion changes).
- Files added/updated:
-->

#### Playwright (UI) tests
<!--
- [ ] I added Playwright E2E tests under `openmetadata-ui/.../ui/playwright/` for UI changes.
- [ ] Not applicable (no UI changes).
- Files added/updated:
-->

#### Manual testing performed
<!--
List the manual test steps you performed before requesting review. Example:
1. Started local stack via `./docker/run_local_docker.sh -m ui -d mysql`
2. Logged in as admin, created entity X, verified Y appears in the UI
3. Triggered ingestion for Snowflake source, confirmed lineage edges in the explore page
-->

#
### UI screen recording / screenshots:
<!--
REQUIRED for any PR that changes the UI. Drag-and-drop a short screen recording (.mov / .mp4 / .gif)
demonstrating the change end-to-end, plus before/after screenshots where relevant.
Mark "Not applicable" if there are no UI changes.
-->

Not applicable. <!-- Or attach recording/screenshots above -->

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.
- [ ] For UI changes: I attached a screen recording and/or screenshots above.
- [ ] I have added tests (unit / integration / Playwright as applicable) and listed them above.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a missing field in the `fetchExpadedTree` function, which is called when the user clicks "Expand All" on the Glossary terms tree. The API call was explicitly requesting specific fields (`owners`, `parent`, `children`) but omitting `reviewers`, so nested terms loaded via Expand All had no reviewer data — causing the `permissionForApproveOrReject` check to silently fail and hide the Approve/Reject buttons.

- Adds `TabSpecificField.REVIEWERS` to the `fields` array inside `fetchExpadedTree`, aligning it with the search path (which already included `reviewers`) and restoring the approve/reject buttons for \"In Review\" nested terms after Expand All.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Single-line addition in one file that fills a missing API field; no logic changes, no regressions introduced.

The change adds one entry to an existing fields array to restore data that was always expected there. The root cause is clear (the reviewers field was simply absent from the Expand All API call while the search path already included it), the fix is targeted, and there is no risk of side effects — the field is already used by the column renderer on every other code path.

No files require special attention.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-ui/src/main/resources/ui/src/components/Glossary/GlossaryTermTab/GlossaryTermTab.component.tsx | Adds TabSpecificField.REVIEWERS to the fields list in fetchExpadedTree so that reviewer data is present when rendering approve/reject buttons for nested terms after Expand All. |

</details>

</details>

<details open><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[User clicks Expand All] --> B[fetchExpadedTree called]
    B --> C[getGlossaryTerms API call\nwith fields: owners, parent, children, reviewers]
    C --> D[buildTree called on response]
    D --> E[setGlossaryChildTerms with full tree]
    E --> F[Table renders nested terms]
    F --> G{term.entityStatus === InReview?}
    G -- Yes --> H[permissionForApproveOrReject\nrecord, currentUser, termTaskThreads]
    H --> I{currentUser in\nrecord.reviewers?}
    I -- Yes --> J[Show Approve / Reject buttons]
    I -- No --> K[Show StatusBadge only]
    G -- No --> K
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[User clicks Expand All] --> B[fetchExpadedTree called]
    B --> C[getGlossaryTerms API call\nwith fields: owners, parent, children, reviewers]
    C --> D[buildTree called on response]
    D --> E[setGlossaryChildTerms with full tree]
    E --> F[Table renders nested terms]
    F --> G{term.entityStatus === InReview?}
    G -- Yes --> H[permissionForApproveOrReject\nrecord, currentUser, termTaskThreads]
    H --> I{currentUser in\nrecord.reviewers?}
    I -- Yes --> J[Show Approve / Reject buttons]
    I -- No --> K[Show StatusBadge only]
    G -- No --> K
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(ui): show glossary approve/reject bu..."](https://github.com/open-metadata/openmetadata/commit/b1411c2f26df91f2613ea3acbf220fe5c42aa32e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39018867)</sub>

<!-- /greptile_comment -->