### PR TITLE
fix(search): cap oversized dataModel column tree at index time (#29212) [1.13 backport]

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/SearchIndexUtils.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/SearchIndexUtils.java
@@ -84,15 +84,17 @@ public final class SearchIndexUtils {
   }
 
   /**
-   * Progressively strips lineage fields from a search document JSON to bring it under maxBytes.
+   * Progressively strips oversized fields from a search document JSON to bring it under maxBytes.
    *
-   * <p>Stripping order: lineageSqlQueries first (retains topology), then upstreamLineage.
-   * Returns the (possibly stripped) JSON — caller must re-check size and handle the still-oversized
-   * case.
+   * <p>Stripping order: lineageSqlQueries first (retains topology), then upstreamLineage, then — if
+   * still oversized — the nested column tree (column {@code children} plus the derived {@code
+   * columnNames}/{@code columnNamesFuzzy}) via {@link #stripColumnTreeForSize}. Returns the
+   * (possibly stripped) JSON — caller must re-check size and handle the still-oversized case.
    */
   public static String stripLineageForSize(
       String json, long maxBytes, String docId, String entityType) {
-    if (json.getBytes(StandardCharsets.UTF_8).length <= maxBytes) {
+    int size = json.getBytes(StandardCharsets.UTF_8).length;
+    if (size <= maxBytes) {
       return json;
     }
     TypeReference<Map<String, Object>> mapType = new TypeReference<>() {};
@@ -100,51 +102,72 @@ public final class SearchIndexUtils {
     if (doc.remove("lineageSqlQueries") != null) {
       stripSqlQueryKeysFromEdges(doc);
       json = JsonUtils.pojoToJson(doc);
-      int sizeAfterStrip = json.getBytes(StandardCharsets.UTF_8).length;
+      size = json.getBytes(StandardCharsets.UTF_8).length;
       LOG.warn(
           "Document {} ({}) too large, stripped lineageSqlQueries (size now {} bytes)",
           docId,
           entityType,
-          sizeAfterStrip);
-      if (sizeAfterStrip <= maxBytes) {
+          size);
+      if (size <= maxBytes) {
         return json;
       }
     }
-    doc.remove("upstreamLineage");
-    json = JsonUtils.pojoToJson(doc);
-    LOG.warn(
-        "Document {} ({}) still too large, stripped upstreamLineage (size now {} bytes)",
-        docId,
-        entityType,
-        json.getBytes(StandardCharsets.UTF_8).length);
+    if (doc.remove("upstreamLineage") != null) {
+      json = JsonUtils.pojoToJson(doc);
+      size = json.getBytes(StandardCharsets.UTF_8).length;
+      LOG.warn(
+          "Document {} ({}) still too large, stripped upstreamLineage (size now {} bytes)",
+          docId,
+          entityType,
+          size);
+    }
+    if (size > maxBytes) {
+      stripColumnTreeForSize(doc);
+      json = JsonUtils.pojoToJson(doc);
+      size = json.getBytes(StandardCharsets.UTF_8).length;
+      LOG.warn(
+          "Document {} ({}) still too large, stripped column children, columnNames and columnNamesFuzzy (size now {} bytes)",
+          docId,
+          entityType,
+          size);
+    }
     return json;
   }
 
   public static Map<String, Object> stripDocMapIfOversized(
       Map<String, Object> doc, long maxBytes, String docId, String entityType) {
-    String json = JsonUtils.pojoToJson(doc);
-    if (json.getBytes(StandardCharsets.UTF_8).length <= maxBytes) {
+    int size = JsonUtils.pojoToJson(doc).getBytes(StandardCharsets.UTF_8).length;
+    if (size <= maxBytes) {
       return doc;
     }
     if (doc.remove("lineageSqlQueries") != null) {
       stripSqlQueryKeysFromEdges(doc);
-      json = JsonUtils.pojoToJson(doc);
-      int strippedSize = json.getBytes(StandardCharsets.UTF_8).length;
+      size = JsonUtils.pojoToJson(doc).getBytes(StandardCharsets.UTF_8).length;
       LOG.warn(
           "Live index doc {} ({}) too large, stripped lineageSqlQueries ({} bytes)",
           docId,
           entityType,
-          strippedSize);
-      if (strippedSize <= maxBytes) {
+          size);
+      if (size <= maxBytes) {
         return doc;
       }
     }
     if (doc.remove("upstreamLineage") != null) {
+      size = JsonUtils.pojoToJson(doc).getBytes(StandardCharsets.UTF_8).length;
       LOG.warn(
           "Live index doc {} ({}) still too large, stripped upstreamLineage ({} bytes)",
           docId,
           entityType,
-          JsonUtils.pojoToJson(doc).getBytes(StandardCharsets.UTF_8).length);
+          size);
+    }
+    if (size > maxBytes) {
+      stripColumnTreeForSize(doc);
+      size = JsonUtils.pojoToJson(doc).getBytes(StandardCharsets.UTF_8).length;
+      LOG.warn(
+          "Live index doc {} ({}) still too large, stripped column children, columnNames and columnNamesFuzzy ({} bytes)",
+          docId,
+          entityType,
+          size);
     }
     return doc;
   }
@@ -156,6 +179,36 @@ public final class SearchIndexUtils {
       for (Object edge : edges) {
         if (edge instanceof Map<?, ?> edgeMap) {
           ((Map<String, Object>) edgeMap).remove("sqlQueryKey");
+        }
+      }
+    }
+  }
+
+  /**
+   * Last-resort size reduction for pathological column schemas. Drops the nested column {@code
+   * children} (mapped {@code enabled:false} — stored in _source but never indexed/searchable) and
+   * the flattened {@code columnNames}/{@code columnNamesFuzzy} derived from them. Reached only after
+   * lineage stripping leaves the doc still over the cap — e.g. a container whose columns each carry
+   * tens of thousands of children, where the column tree dwarfs the rest of the document and would
+   * otherwise OOM the serializer on read. Top-level columns are kept, so column search and the
+   * column grid still work; the full schema remains available via the entity API.
+   */
+  @SuppressWarnings("unchecked")
+  static void stripColumnTreeForSize(Map<String, Object> doc) {
+    stripChildrenFromColumns(doc.get("columns"));
+    if (doc.get("dataModel") instanceof Map<?, ?> dataModel) {
+      stripChildrenFromColumns(((Map<String, Object>) dataModel).get("columns"));
+    }
+    doc.remove("columnNames");
+    doc.remove("columnNamesFuzzy");
+  }
+
+  @SuppressWarnings("unchecked")
+  private static void stripChildrenFromColumns(Object columns) {
+    if (columns instanceof List<?> columnList) {
+      for (Object column : columnList) {
+        if (column instanceof Map<?, ?> columnMap) {
+          ((Map<String, Object>) columnMap).remove("children");
         }
       }
     }

--- a/openmetadata-service/src/test/java/org/openmetadata/service/search/SearchIndexUtilsTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/search/SearchIndexUtilsTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.*;
 
 import jakarta.json.Json;
 import jakarta.json.JsonObject;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -448,5 +449,117 @@ class SearchIndexUtilsTest {
   private static void assertContainsWords(String value, String... expectedWords) {
     Set<String> actualWords = Set.of(value.split(" "));
     assertEquals(Set.of(expectedWords), actualWords);
+  }
+
+  @Test
+  void stripDocMapIfOversizedDropsColumnTreeWhenStillTooLargeAfterLineage() {
+    Map<String, Object> doc = oversizedContainerDoc();
+    int before = JsonUtils.pojoToJson(doc).getBytes(StandardCharsets.UTF_8).length;
+
+    Map<String, Object> stripped =
+        SearchIndexUtils.stripDocMapIfOversized(doc, 4096, "doc-1", "container");
+
+    int after = JsonUtils.pojoToJson(stripped).getBytes(StandardCharsets.UTF_8).length;
+    assertTrue(after < before, "doc should shrink");
+    assertTrue(after <= 4096, "doc should fit under the cap after the column tree is stripped");
+    assertColumnTreeStripped(stripped, 3);
+  }
+
+  @Test
+  void stripLineageForSizeDropsColumnTreeWhenStillTooLargeAfterLineage() {
+    String json = JsonUtils.pojoToJson(oversizedContainerDoc());
+
+    String stripped = SearchIndexUtils.stripLineageForSize(json, 4096, "doc-2", "container");
+
+    assertTrue(stripped.getBytes(StandardCharsets.UTF_8).length <= 4096);
+    assertFalse(stripped.contains("\"children\""), "nested children stripped from JSON");
+    assertFalse(stripped.contains("columnNamesFuzzy"), "derived columnNamesFuzzy stripped");
+  }
+
+  @Test
+  void stripDocMapIfOversizedLeavesNormalContainerUntouched() {
+    Map<String, Object> doc = new HashMap<>();
+    doc.put("id", UUID.randomUUID().toString());
+    Map<String, Object> dataModel = new HashMap<>();
+    dataModel.put("columns", new ArrayList<>(List.of(columnWithChildren("c1", 2))));
+    doc.put("dataModel", dataModel);
+    doc.put("columnNames", List.of("c1"));
+
+    Map<String, Object> result =
+        SearchIndexUtils.stripDocMapIfOversized(doc, 10 * 1024 * 1024, "doc-3", "container");
+
+    assertColumnsRetainChildren(result);
+    assertTrue(result.containsKey("columnNames"), "normal doc keeps columnNames");
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void stripColumnTreeForSizeAlsoHandlesTopLevelTableColumns() {
+    Map<String, Object> doc = new HashMap<>();
+    doc.put("columns", new ArrayList<>(List.of(columnWithChildren("c1", 3))));
+    doc.put("columnNames", List.of("c1", "c1.a"));
+    doc.put("columnNamesFuzzy", "c1 c1.a");
+
+    SearchIndexUtils.stripColumnTreeForSize(doc);
+
+    List<Map<String, Object>> columns = (List<Map<String, Object>>) doc.get("columns");
+    assertFalse(columns.get(0).containsKey("children"), "table columns lose children too");
+    assertFalse(doc.containsKey("columnNames"));
+    assertFalse(doc.containsKey("columnNamesFuzzy"));
+  }
+
+  @SuppressWarnings("unchecked")
+  private static void assertColumnTreeStripped(Map<String, Object> doc, int expectedTopLevel) {
+    Map<String, Object> dataModel = (Map<String, Object>) doc.get("dataModel");
+    List<Map<String, Object>> columns = (List<Map<String, Object>>) dataModel.get("columns");
+    assertEquals(expectedTopLevel, columns.size(), "top-level columns are kept");
+    for (Map<String, Object> column : columns) {
+      assertFalse(column.containsKey("children"), "nested children are stripped");
+    }
+    assertFalse(doc.containsKey("columnNames"), "derived columnNames is stripped");
+    assertFalse(doc.containsKey("columnNamesFuzzy"), "derived columnNamesFuzzy is stripped");
+  }
+
+  @SuppressWarnings("unchecked")
+  private static void assertColumnsRetainChildren(Map<String, Object> doc) {
+    Map<String, Object> dataModel = (Map<String, Object>) doc.get("dataModel");
+    List<Map<String, Object>> columns = (List<Map<String, Object>>) dataModel.get("columns");
+    assertTrue(columns.get(0).containsKey("children"), "small doc keeps children");
+  }
+
+  private static Map<String, Object> oversizedContainerDoc() {
+    Map<String, Object> doc = new HashMap<>();
+    doc.put("id", UUID.randomUUID().toString());
+    doc.put("name", "huge_container");
+    List<Map<String, Object>> columns = new ArrayList<>();
+    List<String> flattened = new ArrayList<>();
+    for (int c = 0; c < 3; c++) {
+      columns.add(columnWithChildren("col" + c, 2000));
+      for (int i = 0; i < 2000; i++) {
+        flattened.add("col" + c + ".child" + i);
+      }
+    }
+    Map<String, Object> dataModel = new HashMap<>();
+    dataModel.put("columns", columns);
+    doc.put("dataModel", dataModel);
+    doc.put("columnNames", flattened);
+    doc.put("columnNamesFuzzy", String.join(" ", flattened));
+    return doc;
+  }
+
+  private static Map<String, Object> columnWithChildren(String name, int childCount) {
+    Map<String, Object> column = new HashMap<>();
+    column.put("name", name);
+    column.put("dataType", "STRUCT");
+    List<Map<String, Object>> children = new ArrayList<>();
+    for (int i = 0; i < childCount; i++) {
+      Map<String, Object> child = new HashMap<>();
+      child.put("name", "child" + i);
+      child.put("dataType", "VARCHAR");
+      child.put("description", "child column with descriptive text to add bytes " + i);
+      children.add(child);
+    }
+    column.put("children", children);
+    return column;
   }
 }

--- a/openmetadata-ui/src/main/resources/ui/src/components/AppBar/Suggestions.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/AppBar/Suggestions.tsx
@@ -312,7 +312,7 @@ const Suggestions = ({
         queryFilter: quickFilter,
         pageSize: PAGE_SIZE_BASE,
         includeDeleted: false,
-        excludeSourceFields: ['columns', 'queries', 'columnNames'],
+        excludeSourceFields: ['columns', 'queries', 'columnNames', 'dataModel'],
       });
 
       setOptions(res.hits.hits as unknown as Option[]);

--- a/openmetadata-ui/src/main/resources/ui/src/components/ServiceInsights/ServiceInsightsTab.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/ServiceInsights/ServiceInsightsTab.tsx
@@ -102,6 +102,9 @@ const ServiceInsightsTab = ({
       const response = await searchQuery({
         queryFilter: getServiceNameQueryFilter(serviceName),
         searchIndex: SearchIndex.ALL,
+        // Aggregation-only query: skip the hit payload entirely (no source, zero hits).
+        pageSize: 0,
+        fetchSource: false,
       });
 
       const assets = getAssetsByServiceType(serviceCategory);

--- a/openmetadata-ui/src/main/resources/ui/src/utils/EntitySummaryPanelUtilsV1.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/EntitySummaryPanelUtilsV1.test.tsx
@@ -18,7 +18,7 @@ import {
   screen,
   waitFor,
 } from '@testing-library/react';
-import { EntityType } from '../enums/entity.enum';
+import { EntityType, TabSpecificField } from '../enums/entity.enum';
 import {
   Container,
   DataType as ContainerDataType,
@@ -36,7 +36,9 @@ import {
 import { Topic } from '../generated/entity/data/topic';
 import { DataType } from '../generated/settings/settings';
 import { DataTypeTopic, Field } from '../generated/type/schema';
+import { getContainerByFQN } from '../rest/storageAPI';
 import { getEntityChildDetailsV1 } from './EntitySummaryPanelUtilsV1';
+import { showErrorToast } from './ToastUtils';
 
 jest.mock('react-i18next', () => ({
   useTranslation: jest.fn().mockReturnValue({
@@ -70,6 +72,16 @@ jest.mock('../rest/tableAPI', () => ({
 
 jest.mock('../rest/dataModelsAPI', () => ({
   getDataModelColumnsByFQN: jest.fn(),
+}));
+
+jest.mock('../rest/storageAPI', () => ({
+  getContainerByFQN: jest
+    .fn()
+    .mockResolvedValue({ dataModel: { columns: [] } }),
+}));
+
+jest.mock('./ToastUtils', () => ({
+  showErrorToast: jest.fn(),
 }));
 
 jest.mock('../components/common/FieldCard', () => ({
@@ -1398,6 +1410,80 @@ describe('EntitySummaryPanelUtilsV1 - Nested Search (Topic, Container, SearchInd
       render(<div>{result}</div>);
 
       expect(screen.getByText('message.no-data-available')).toBeInTheDocument();
+    });
+  });
+
+  describe('ContainerFieldCardsV1 - on-demand dataModel fetch', () => {
+    beforeEach(() => {
+      jest.clearAllMocks();
+    });
+
+    it('fetches dataModel on demand when columns are absent from the search hit', async () => {
+      (getContainerByFQN as jest.Mock).mockResolvedValue({
+        dataModel: {
+          columns: [
+            { name: 'fetched_col', dataType: ContainerDataType.String },
+          ],
+        },
+      });
+      const containerWithoutColumns = {
+        id: 'c1',
+        name: 'no-cols',
+        fullyQualifiedName: 's3.no-cols',
+      } as Container;
+
+      const result = getEntityChildDetailsV1(
+        EntityType.CONTAINER,
+        containerWithoutColumns,
+        undefined,
+        false,
+        ''
+      );
+      render(<div>{result}</div>);
+
+      await waitFor(() => {
+        expect(getContainerByFQN).toHaveBeenCalledWith('s3.no-cols', {
+          fields: TabSpecificField.DATAMODEL,
+        });
+      });
+    });
+
+    it('does not fetch when columns are already inline on the search hit', async () => {
+      const result = getEntityChildDetailsV1(
+        EntityType.CONTAINER,
+        mockContainerWithNestedColumns,
+        undefined,
+        false,
+        ''
+      );
+      render(<div>{result}</div>);
+
+      await waitFor(() => {
+        expect(screen.getByTestId('field-card-top_column')).toBeInTheDocument();
+      });
+      expect(getContainerByFQN).not.toHaveBeenCalled();
+    });
+
+    it('surfaces an error toast when the on-demand fetch fails', async () => {
+      (getContainerByFQN as jest.Mock).mockRejectedValue(new Error('boom'));
+      const containerWithoutColumns = {
+        id: 'c2',
+        name: 'err',
+        fullyQualifiedName: 's3.err',
+      } as Container;
+
+      const result = getEntityChildDetailsV1(
+        EntityType.CONTAINER,
+        containerWithoutColumns,
+        undefined,
+        false,
+        ''
+      );
+      render(<div>{result}</div>);
+
+      await waitFor(() => {
+        expect(showErrorToast).toHaveBeenCalled();
+      });
     });
   });
 });

--- a/openmetadata-ui/src/main/resources/ui/src/utils/EntitySummaryPanelUtilsV1.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/EntitySummaryPanelUtilsV1.tsx
@@ -19,7 +19,8 @@ import {
   Table,
   Typography as AntTypography,
 } from 'antd';
-import { isEmpty } from 'lodash';
+import { AxiosError } from 'axios';
+import { isEmpty, isUndefined } from 'lodash';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { ReactComponent as NestedIcon } from '../assets/svg/nested.svg';
 import { FieldCard } from '../components/common/FieldCard';
@@ -28,7 +29,7 @@ import Loader from '../components/common/Loader/Loader';
 import '../components/Explore/EntitySummaryPanel/entity-summary-panel.less';
 import { SearchedDataProps } from '../components/SearchedData/SearchedData.interface';
 import { PAGE_SIZE_LARGE } from '../constants/constants';
-import { EntityType } from '../enums/entity.enum';
+import { EntityType, TabSpecificField } from '../enums/entity.enum';
 import { APICollection } from '../generated/entity/data/apiCollection';
 import { APIEndpoint } from '../generated/entity/data/apiEndpoint';
 import { Container } from '../generated/entity/data/container';
@@ -48,6 +49,7 @@ import {
   getDataModelColumnsByFQN,
   searchDataModelColumnsByFQN,
 } from '../rest/dataModelsAPI';
+import { getContainerByFQN } from '../rest/storageAPI';
 import {
   getTableColumnsByFQN,
   getTableList,
@@ -56,8 +58,8 @@ import {
 import { GenericNestedField } from './EntitySummaryPanelUtilsV1.interface';
 import { getEntityName } from './EntityUtils';
 import { t } from './i18next/LocalUtil';
-
 import { pruneEmptyChildren } from './TableUtils';
+import { showErrorToast } from './ToastUtils';
 const { Text } = AntTypography;
 
 /**
@@ -524,7 +526,56 @@ const ContainerFieldCardsV1: React.FC<{
   searchText?: string;
 }> = ({ entityInfo, highlights, loading, searchText }) => {
   const [expandedRowKeys, setExpandedRowKeys] = useState<string[]>([]);
-  const columns = entityInfo.dataModel?.columns || [];
+  const [fetchedColumns, setFetchedColumns] = useState<Column[]>();
+
+  const inlineColumns = entityInfo.dataModel?.columns;
+  const containerFqn = entityInfo.fullyQualifiedName;
+  // Start in the loading state when columns must be fetched on demand, so the first render shows the
+  // loader instead of briefly flashing "No data available".
+  const [isColumnsLoading, setIsColumnsLoading] = useState(
+    () => isUndefined(inlineColumns) && Boolean(containerFqn)
+  );
+
+  useEffect(() => {
+    // dataModel is excluded from Explore search payloads because it can be very large, so when it is
+    // absent on the search hit we fetch it on demand from the entity API.
+    if (!isUndefined(inlineColumns) || !containerFqn) {
+      // No on-demand fetch needed (columns already inline, or no FQN). Clear any loading flag left
+      // set by a now-cancelled in-flight fetch so the loader can't get stuck on.
+      setIsColumnsLoading(false);
+
+      return;
+    }
+    // Drop any previously-fetched columns and show the loader so the prior container's schema isn't
+    // shown while the new one loads; the cancelled guard also ignores a stale in-flight result if
+    // the user switches containers again before it resolves.
+    let cancelled = false;
+    setFetchedColumns(undefined);
+    setIsColumnsLoading(true);
+    getContainerByFQN(containerFqn, { fields: TabSpecificField.DATAMODEL })
+      .then((container) => {
+        if (!cancelled) {
+          setFetchedColumns(container.dataModel?.columns ?? []);
+        }
+      })
+      .catch((error) => {
+        if (!cancelled) {
+          setFetchedColumns([]);
+          showErrorToast(error as AxiosError);
+        }
+      })
+      .finally(() => {
+        if (!cancelled) {
+          setIsColumnsLoading(false);
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [containerFqn, inlineColumns]);
+
+  const columns = inlineColumns ?? fetchedColumns ?? [];
 
   const filteredColumns = useMemo(
     () =>
@@ -540,7 +591,7 @@ const ContainerFieldCardsV1: React.FC<{
     );
   }, []);
 
-  if (loading) {
+  if (loading || isColumnsLoading) {
     return (
       <div className="flex-center p-lg">
         <Loader size="default" />

--- a/openmetadata-ui/src/main/resources/ui/src/utils/ExploreUtils.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/ExploreUtils.tsx
@@ -657,7 +657,12 @@ export const fetchEntityData = async ({
           pageNumber: page,
           pageSize: size,
           includeDeleted: showDeleted,
-          excludeSourceFields: ['columns', 'queries', 'columnNames'],
+          excludeSourceFields: [
+            'columns',
+            'queries',
+            'columnNames',
+            'dataModel',
+          ],
         };
 
         try {
@@ -689,7 +694,7 @@ export const fetchEntityData = async ({
         pageNumber: page,
         pageSize: size,
         includeDeleted: showDeleted,
-        excludeSourceFields: ['columns', 'queries', 'columnNames'],
+        excludeSourceFields: ['columns', 'queries', 'columnNames', 'dataModel'],
       };
 
       try {


### PR DESCRIPTION
Backport of #29212 to **1.13**.

## What
Cherry-pick of the merged fix that caps an oversized container `dataModel` search document at index time — strips `dataModel.columns[].children` (and the derived `columnNames`/`columnNamesFuzzy`) when a doc is still over the size cap after lineage stripping, on both the live-index and bulk-reindex paths. Companion UI changes exclude `dataModel` from Explore/suggestion search payloads and lazy-fetch the container schema in the summary panel.

## Cherry-pick notes
- One conflict resolved in `EntitySummaryPanelUtilsV1.tsx`: on 1.13 `pruneEmptyChildren` is imported from `./TableUtils` (main moved it to `./TablePureUtils`). Kept 1.13's path and added the new `showErrorToast` import. All other files auto-merged.
- 1.13 already has `getContainerByFQN` (`rest/storageAPI`) and `TabSpecificField.DATAMODEL`, so the lazy-fetch wiring applies unchanged.

## Verification
- UI: organize-imports + eslint (0 errors) + prettier clean; **jest 34/34** on `EntitySummaryPanelUtilsV1.test.tsx`.
- Backend: `SearchIndexUtils.java` auto-merged cleanly and is spotless-clean; the column-strip call sites land inside `stripLineageForSize` and `stripDocMapIfOversized`. Full backend unit tests run in CI (local offline test-compile is blocked by unrelated 1.13 generated-model deps).

Original PR: #29212

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This backport caps oversized container `dataModel` search documents at index time by adding a third stripping stage — removing column `children` and the derived `columnNames`/`columnNamesFuzzy` fields — to both the bulk-reindex (`stripLineageForSize`) and live-index (`stripDocMapIfOversized`) paths. The companion UI changes exclude `dataModel` from Explore and suggestion search payloads and lazily fetch the container schema on demand in the summary panel.

- **Backend (`SearchIndexUtils.java`)**: `stripColumnTreeForSize` is called as a last resort after lineage stripping; it removes `children` from every top-level column in both `columns` and `dataModel.columns`, then drops `columnNames`/`columnNamesFuzzy`. The `size` variable is tracked correctly across all three stages and four new unit tests cover the oversized, normal, table-column, and error paths.
- **Frontend (`EntitySummaryPanelUtilsV1.tsx`)**: `ContainerFieldCardsV1` gains a `useEffect` that fires an on-demand fetch via `getContainerByFQN` when `dataModel` is absent from the search hit, with a `cancelled` flag to discard stale in-flight results on unmount or container switch.
- **Query payloads** (`ExploreUtils.tsx`, `Suggestions.tsx`, `ServiceInsightsTab.tsx`): `dataModel` added to `excludeSourceFields` where appropriate; `ServiceInsightsTab` also adds `pageSize: 0` and `fetchSource: false` for its aggregation-only query.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; both stripping paths are guarded by size re-checks after each stage and the UI lazy-fetch is correctly cancellation-safe.

The three-stage stripping cascade is logically correct and well-tested. The cancelled flag pattern in the React effect correctly discards stale in-flight fetches. The brief render-cycle window where a previous container's columns could appear before isColumnsLoading is set is real but cosmetic. All other changes are straightforward.

EntitySummaryPanelUtilsV1.tsx — stale-columns window on back-to-back container switches; SearchIndexUtils.java — asymmetric early-return pattern between lineageSqlQueries and upstreamLineage stages.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-service/src/main/java/org/openmetadata/service/search/SearchIndexUtils.java | Adds stripColumnTreeForSize as a last-resort step in both bulk-reindex and live-index size-reduction paths; logic is functionally correct with minor asymmetry in early-return behaviour for upstreamLineage vs lineageSqlQueries. |
| openmetadata-service/src/test/java/org/openmetadata/service/search/SearchIndexUtilsTest.java | Four new tests covering oversized container doc stripping, no-op on normal-sized docs, top-level table columns, and the stripColumnTreeForSize helper directly. |
| openmetadata-ui/src/main/resources/ui/src/utils/EntitySummaryPanelUtilsV1.tsx | ContainerFieldCardsV1 gains on-demand dataModel fetch with cancellation guard; brief stale-data window exists when switching between containers that both lack inline columns. |
| openmetadata-ui/src/main/resources/ui/src/utils/EntitySummaryPanelUtilsV1.test.tsx | Three new tests for the on-demand fetch path: happy path, already-inline guard, and error-toast path; mocks are correctly scoped. |
| openmetadata-ui/src/main/resources/ui/src/utils/ExploreUtils.tsx | Adds dataModel to excludeSourceFields in both regular and alternate search paths; correctly aligned with the lazy-fetch approach in ContainerFieldCardsV1. |
| openmetadata-ui/src/main/resources/ui/src/components/AppBar/Suggestions.tsx | Adds dataModel to excludeSourceFields for suggestion search; correct as suggestions only display names/descriptions, not schema details. |
| openmetadata-ui/src/main/resources/ui/src/components/ServiceInsights/ServiceInsightsTab.tsx | Adds pageSize: 0 and fetchSource: false to the aggregation-only asset-count query; fetchSource: false is a valid union member of SearchRequest and the handler only consumes response.aggregations. |

</details>

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Indexer
    participant SIU as SearchIndexUtils
    participant ES as Elasticsearch

    Indexer->>SIU: stripLineageForSize(json, maxBytes)
    alt "doc <= maxBytes"
        SIU-->>Indexer: return unchanged json
    else "doc > maxBytes"
        SIU->>SIU: remove lineageSqlQueries
        alt "now <= maxBytes"
            SIU-->>Indexer: return stripped json
        else "still > maxBytes"
            SIU->>SIU: remove upstreamLineage
            alt "still > maxBytes"
                SIU->>SIU: stripColumnTreeForSize(doc)
            end
            SIU-->>Indexer: return stripped json
        end
    end
    Indexer->>ES: index document

    participant Browser
    participant API as Entity API

    Browser->>ES: Explore search (excludeSourceFields: dataModel)
    ES-->>Browser: search hit (no dataModel)
    Browser->>Browser: ContainerFieldCardsV1 renders
    Browser->>API: getContainerByFQN(fqn, DATAMODEL)
    API-->>Browser: container with dataModel.columns
    Browser->>Browser: render column cards
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Indexer
    participant SIU as SearchIndexUtils
    participant ES as Elasticsearch

    Indexer->>SIU: stripLineageForSize(json, maxBytes)
    alt "doc <= maxBytes"
        SIU-->>Indexer: return unchanged json
    else "doc > maxBytes"
        SIU->>SIU: remove lineageSqlQueries
        alt "now <= maxBytes"
            SIU-->>Indexer: return stripped json
        else "still > maxBytes"
            SIU->>SIU: remove upstreamLineage
            alt "still > maxBytes"
                SIU->>SIU: stripColumnTreeForSize(doc)
            end
            SIU-->>Indexer: return stripped json
        end
    end
    Indexer->>ES: index document

    participant Browser
    participant API as Entity API

    Browser->>ES: Explore search (excludeSourceFields: dataModel)
    ES-->>Browser: search hit (no dataModel)
    Browser->>Browser: ContainerFieldCardsV1 renders
    Browser->>API: getContainerByFQN(fqn, DATAMODEL)
    API-->>Browser: container with dataModel.columns
    Browser->>Browser: render column cards
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(search): cap oversized dataModel col..."](https://github.com/open-metadata/openmetadata/commit/58d95193efe3c639809eefbe6ba8f91c65f0d628) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39025655)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->