### PR TITLE
fix(search): cap oversized dataModel column tree at index time (#29212) [1.12.12 backport]

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/SearchIndexUtils.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/SearchIndexUtils.java
@@ -82,15 +82,17 @@ public final class SearchIndexUtils {
   }
 
   /**
-   * Progressively strips lineage fields from a search document JSON to bring it under maxBytes.
+   * Progressively strips oversized fields from a search document JSON to bring it under maxBytes.
    *
-   * <p>Stripping order: lineageSqlQueries first (retains topology), then upstreamLineage.
-   * Returns the (possibly stripped) JSON — caller must re-check size and handle the still-oversized
-   * case.
+   * <p>Stripping order: lineageSqlQueries first (retains topology), then upstreamLineage, then — if
+   * still oversized — the nested column tree (column {@code children} plus the derived {@code
+   * columnNames}/{@code columnNamesFuzzy}) via {@link #stripColumnTreeForSize}. Returns the
+   * (possibly stripped) JSON — caller must re-check size and handle the still-oversized case.
    */
   public static String stripLineageForSize(
       String json, long maxBytes, String docId, String entityType) {
-    if (json.getBytes(StandardCharsets.UTF_8).length <= maxBytes) {
+    int size = json.getBytes(StandardCharsets.UTF_8).length;
+    if (size <= maxBytes) {
       return json;
     }
     TypeReference<Map<String, Object>> mapType = new TypeReference<>() {};
@@ -98,51 +100,72 @@ public final class SearchIndexUtils {
     if (doc.remove("lineageSqlQueries") != null) {
       stripSqlQueryKeysFromEdges(doc);
       json = JsonUtils.pojoToJson(doc);
-      int sizeAfterStrip = json.getBytes(StandardCharsets.UTF_8).length;
+      size = json.getBytes(StandardCharsets.UTF_8).length;
       LOG.warn(
           "Document {} ({}) too large, stripped lineageSqlQueries (size now {} bytes)",
           docId,
           entityType,
-          sizeAfterStrip);
-      if (sizeAfterStrip <= maxBytes) {
+          size);
+      if (size <= maxBytes) {
         return json;
       }
     }
-    doc.remove("upstreamLineage");
-    json = JsonUtils.pojoToJson(doc);
-    LOG.warn(
-        "Document {} ({}) still too large, stripped upstreamLineage (size now {} bytes)",
-        docId,
-        entityType,
-        json.getBytes(StandardCharsets.UTF_8).length);
+    if (doc.remove("upstreamLineage") != null) {
+      json = JsonUtils.pojoToJson(doc);
+      size = json.getBytes(StandardCharsets.UTF_8).length;
+      LOG.warn(
+          "Document {} ({}) still too large, stripped upstreamLineage (size now {} bytes)",
+          docId,
+          entityType,
+          size);
+    }
+    if (size > maxBytes) {
+      stripColumnTreeForSize(doc);
+      json = JsonUtils.pojoToJson(doc);
+      size = json.getBytes(StandardCharsets.UTF_8).length;
+      LOG.warn(
+          "Document {} ({}) still too large, stripped column children, columnNames and columnNamesFuzzy (size now {} bytes)",
+          docId,
+          entityType,
+          size);
+    }
     return json;
   }
 
   public static Map<String, Object> stripDocMapIfOversized(
       Map<String, Object> doc, long maxBytes, String docId, String entityType) {
-    String json = JsonUtils.pojoToJson(doc);
-    if (json.getBytes(StandardCharsets.UTF_8).length <= maxBytes) {
+    int size = JsonUtils.pojoToJson(doc).getBytes(StandardCharsets.UTF_8).length;
+    if (size <= maxBytes) {
       return doc;
     }
     if (doc.remove("lineageSqlQueries") != null) {
       stripSqlQueryKeysFromEdges(doc);
-      json = JsonUtils.pojoToJson(doc);
-      int strippedSize = json.getBytes(StandardCharsets.UTF_8).length;
+      size = JsonUtils.pojoToJson(doc).getBytes(StandardCharsets.UTF_8).length;
       LOG.warn(
           "Live index doc {} ({}) too large, stripped lineageSqlQueries ({} bytes)",
           docId,
           entityType,
-          strippedSize);
-      if (strippedSize <= maxBytes) {
+          size);
+      if (size <= maxBytes) {
         return doc;
       }
     }
     if (doc.remove("upstreamLineage") != null) {
+      size = JsonUtils.pojoToJson(doc).getBytes(StandardCharsets.UTF_8).length;
       LOG.warn(
           "Live index doc {} ({}) still too large, stripped upstreamLineage ({} bytes)",
           docId,
           entityType,
-          JsonUtils.pojoToJson(doc).getBytes(StandardCharsets.UTF_8).length);
+          size);
+    }
+    if (size > maxBytes) {
+      stripColumnTreeForSize(doc);
+      size = JsonUtils.pojoToJson(doc).getBytes(StandardCharsets.UTF_8).length;
+      LOG.warn(
+          "Live index doc {} ({}) still too large, stripped column children, columnNames and columnNamesFuzzy ({} bytes)",
+          docId,
+          entityType,
+          size);
     }
     return doc;
   }
@@ -154,6 +177,36 @@ public final class SearchIndexUtils {
       for (Object edge : edges) {
         if (edge instanceof Map<?, ?> edgeMap) {
           ((Map<String, Object>) edgeMap).remove("sqlQueryKey");
+        }
+      }
+    }
+  }
+
+  /**
+   * Last-resort size reduction for pathological column schemas. Drops the nested column {@code
+   * children} (mapped {@code enabled:false} — stored in _source but never indexed/searchable) and
+   * the flattened {@code columnNames}/{@code columnNamesFuzzy} derived from them. Reached only after
+   * lineage stripping leaves the doc still over the cap — e.g. a container whose columns each carry
+   * tens of thousands of children, where the column tree dwarfs the rest of the document and would
+   * otherwise OOM the serializer on read. Top-level columns are kept, so column search and the
+   * column grid still work; the full schema remains available via the entity API.
+   */
+  @SuppressWarnings("unchecked")
+  static void stripColumnTreeForSize(Map<String, Object> doc) {
+    stripChildrenFromColumns(doc.get("columns"));
+    if (doc.get("dataModel") instanceof Map<?, ?> dataModel) {
+      stripChildrenFromColumns(((Map<String, Object>) dataModel).get("columns"));
+    }
+    doc.remove("columnNames");
+    doc.remove("columnNamesFuzzy");
+  }
+
+  @SuppressWarnings("unchecked")
+  private static void stripChildrenFromColumns(Object columns) {
+    if (columns instanceof List<?> columnList) {
+      for (Object column : columnList) {
+        if (column instanceof Map<?, ?> columnMap) {
+          ((Map<String, Object>) columnMap).remove("children");
         }
       }
     }

--- a/openmetadata-service/src/test/java/org/openmetadata/service/search/SearchIndexUtilsTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/search/SearchIndexUtilsTest.java
@@ -1,0 +1,129 @@
+package org.openmetadata.service.search;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.openmetadata.schema.utils.JsonUtils;
+
+class SearchIndexUtilsTest {
+
+  @Test
+  void stripDocMapIfOversizedDropsColumnTreeWhenStillTooLargeAfterLineage() {
+    Map<String, Object> doc = oversizedContainerDoc();
+    int before = JsonUtils.pojoToJson(doc).getBytes(StandardCharsets.UTF_8).length;
+
+    Map<String, Object> stripped =
+        SearchIndexUtils.stripDocMapIfOversized(doc, 4096, "doc-1", "container");
+
+    int after = JsonUtils.pojoToJson(stripped).getBytes(StandardCharsets.UTF_8).length;
+    assertTrue(after < before, "doc should shrink");
+    assertTrue(after <= 4096, "doc should fit under the cap after the column tree is stripped");
+    assertColumnTreeStripped(stripped, 3);
+  }
+
+  @Test
+  void stripLineageForSizeDropsColumnTreeWhenStillTooLargeAfterLineage() {
+    String json = JsonUtils.pojoToJson(oversizedContainerDoc());
+
+    String stripped = SearchIndexUtils.stripLineageForSize(json, 4096, "doc-2", "container");
+
+    assertTrue(stripped.getBytes(StandardCharsets.UTF_8).length <= 4096);
+    assertFalse(stripped.contains("\"children\""), "nested children stripped from JSON");
+    assertFalse(stripped.contains("columnNamesFuzzy"), "derived columnNamesFuzzy stripped");
+  }
+
+  @Test
+  void stripDocMapIfOversizedLeavesNormalContainerUntouched() {
+    Map<String, Object> doc = new HashMap<>();
+    doc.put("id", UUID.randomUUID().toString());
+    Map<String, Object> dataModel = new HashMap<>();
+    dataModel.put("columns", new ArrayList<>(List.of(columnWithChildren("c1", 2))));
+    doc.put("dataModel", dataModel);
+    doc.put("columnNames", List.of("c1"));
+
+    Map<String, Object> result =
+        SearchIndexUtils.stripDocMapIfOversized(doc, 10 * 1024 * 1024, "doc-3", "container");
+
+    assertColumnsRetainChildren(result);
+    assertTrue(result.containsKey("columnNames"), "normal doc keeps columnNames");
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void stripColumnTreeForSizeAlsoHandlesTopLevelTableColumns() {
+    Map<String, Object> doc = new HashMap<>();
+    doc.put("columns", new ArrayList<>(List.of(columnWithChildren("c1", 3))));
+    doc.put("columnNames", List.of("c1", "c1.a"));
+    doc.put("columnNamesFuzzy", "c1 c1.a");
+
+    SearchIndexUtils.stripColumnTreeForSize(doc);
+
+    List<Map<String, Object>> columns = (List<Map<String, Object>>) doc.get("columns");
+    assertFalse(columns.get(0).containsKey("children"), "table columns lose children too");
+    assertFalse(doc.containsKey("columnNames"));
+    assertFalse(doc.containsKey("columnNamesFuzzy"));
+  }
+
+  @SuppressWarnings("unchecked")
+  private static void assertColumnTreeStripped(Map<String, Object> doc, int expectedTopLevel) {
+    Map<String, Object> dataModel = (Map<String, Object>) doc.get("dataModel");
+    List<Map<String, Object>> columns = (List<Map<String, Object>>) dataModel.get("columns");
+    assertEquals(expectedTopLevel, columns.size(), "top-level columns are kept");
+    for (Map<String, Object> column : columns) {
+      assertFalse(column.containsKey("children"), "nested children are stripped");
+    }
+    assertFalse(doc.containsKey("columnNames"), "derived columnNames is stripped");
+    assertFalse(doc.containsKey("columnNamesFuzzy"), "derived columnNamesFuzzy is stripped");
+  }
+
+  @SuppressWarnings("unchecked")
+  private static void assertColumnsRetainChildren(Map<String, Object> doc) {
+    Map<String, Object> dataModel = (Map<String, Object>) doc.get("dataModel");
+    List<Map<String, Object>> columns = (List<Map<String, Object>>) dataModel.get("columns");
+    assertTrue(columns.get(0).containsKey("children"), "small doc keeps children");
+  }
+
+  private static Map<String, Object> oversizedContainerDoc() {
+    Map<String, Object> doc = new HashMap<>();
+    doc.put("id", UUID.randomUUID().toString());
+    doc.put("name", "huge_container");
+    List<Map<String, Object>> columns = new ArrayList<>();
+    List<String> flattened = new ArrayList<>();
+    for (int c = 0; c < 3; c++) {
+      columns.add(columnWithChildren("col" + c, 2000));
+      for (int i = 0; i < 2000; i++) {
+        flattened.add("col" + c + ".child" + i);
+      }
+    }
+    Map<String, Object> dataModel = new HashMap<>();
+    dataModel.put("columns", columns);
+    doc.put("dataModel", dataModel);
+    doc.put("columnNames", flattened);
+    doc.put("columnNamesFuzzy", String.join(" ", flattened));
+    return doc;
+  }
+
+  private static Map<String, Object> columnWithChildren(String name, int childCount) {
+    Map<String, Object> column = new HashMap<>();
+    column.put("name", name);
+    column.put("dataType", "STRUCT");
+    List<Map<String, Object>> children = new ArrayList<>();
+    for (int i = 0; i < childCount; i++) {
+      Map<String, Object> child = new HashMap<>();
+      child.put("name", "child" + i);
+      child.put("dataType", "VARCHAR");
+      child.put("description", "child column with descriptive text to add bytes " + i);
+      children.add(child);
+    }
+    column.put("children", children);
+    return column;
+  }
+}

--- a/openmetadata-ui/src/main/resources/ui/src/components/AppBar/Suggestions.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/AppBar/Suggestions.tsx
@@ -214,7 +214,8 @@ const Suggestions = ({
       <div
         className="global-search-suggestion-box"
         data-testid="global-search-suggestion-box"
-        role="none">
+        role="none"
+      >
         {[
           { suggestions: tableSuggestions, searchIndex: SearchIndex.TABLE },
           { suggestions: topicSuggestions, searchIndex: SearchIndex.TOPIC },
@@ -314,7 +315,7 @@ const Suggestions = ({
         queryFilter: quickFilter,
         pageSize: PAGE_SIZE_BASE,
         includeDeleted: false,
-        excludeSourceFields: ['columns', 'queries', 'columnNames'],
+        excludeSourceFields: ['columns', 'queries', 'columnNames', 'dataModel'],
       });
 
       setOptions(res.hits.hits as unknown as Option[]);
@@ -371,7 +372,8 @@ const Suggestions = ({
             }
             key={query}
             type="text"
-            onClick={() => onSearchTextUpdate?.(query)}>
+            onClick={() => onSearchTextUpdate?.(query)}
+          >
             {query}
           </Button>
         ))}

--- a/openmetadata-ui/src/main/resources/ui/src/components/ServiceInsights/ServiceInsightsTab.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/ServiceInsights/ServiceInsightsTab.tsx
@@ -78,8 +78,9 @@ const ServiceInsightsTab = ({
   isIngestionPipelineLoading,
   isCollateAIagentsLoading,
 }: ServiceInsightsTabProps) => {
-  const { serviceCategory } =
-    useRequiredParams<{ serviceCategory: ServiceTypes }>();
+  const { serviceCategory } = useRequiredParams<{
+    serviceCategory: ServiceTypes;
+  }>();
   const { socket } = useWebSocketConnector();
   const [chartsResults, setChartsResults] = useState<ChartsResults>();
   const [agentsInfo, setAgentsInfo] = useState<AgentsInfo[]>([]);
@@ -101,6 +102,9 @@ const ServiceInsightsTab = ({
       const response = await searchQuery({
         queryFilter: getServiceNameQueryFilter(serviceName),
         searchIndex: SearchIndex.ALL,
+        // Aggregation-only query: skip the hit payload entirely (no source, zero hits).
+        pageSize: 0,
+        fetchSource: false,
       });
 
       const assets = getAssetsByServiceType(serviceCategory);
@@ -373,7 +377,8 @@ const ServiceInsightsTab = ({
                 )
                   ? 12
                   : 24
-              }>
+              }
+            >
               <Widget
                 chartsData={getChartsDataFromWidgetName(name, chartsResults)}
                 isLoading={isLoading}

--- a/openmetadata-ui/src/main/resources/ui/src/utils/EntitySummaryPanelUtilsV1.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/EntitySummaryPanelUtilsV1.test.tsx
@@ -18,7 +18,7 @@ import {
   screen,
   waitFor,
 } from '@testing-library/react';
-import { EntityType } from '../enums/entity.enum';
+import { EntityType, TabSpecificField } from '../enums/entity.enum';
 import {
   Container,
   DataType as ContainerDataType,
@@ -36,7 +36,9 @@ import {
 import { Topic } from '../generated/entity/data/topic';
 import { DataType } from '../generated/settings/settings';
 import { DataTypeTopic, Field } from '../generated/type/schema';
+import { getContainerByFQN } from '../rest/storageAPI';
 import { getEntityChildDetailsV1 } from './EntitySummaryPanelUtilsV1';
+import { showErrorToast } from './ToastUtils';
 
 jest.mock('react-i18next', () => ({
   useTranslation: jest.fn().mockReturnValue({
@@ -70,6 +72,16 @@ jest.mock('../rest/tableAPI', () => ({
 
 jest.mock('../rest/dataModelsAPI', () => ({
   getDataModelColumnsByFQN: jest.fn(),
+}));
+
+jest.mock('../rest/storageAPI', () => ({
+  getContainerByFQN: jest
+    .fn()
+    .mockResolvedValue({ dataModel: { columns: [] } }),
+}));
+
+jest.mock('./ToastUtils', () => ({
+  showErrorToast: jest.fn(),
 }));
 
 jest.mock('../components/common/FieldCard', () => ({
@@ -1114,8 +1126,12 @@ describe('EntitySummaryPanelUtilsV1 - Nested Search (Topic, Container, SearchInd
 
       render(<div>{result}</div>);
 
-      expect(screen.getByTestId('field-card-top_level_field')).toBeInTheDocument();
-      expect(screen.getByTestId('field-card-parent_record')).toBeInTheDocument();
+      expect(
+        screen.getByTestId('field-card-top_level_field')
+      ).toBeInTheDocument();
+      expect(
+        screen.getByTestId('field-card-parent_record')
+      ).toBeInTheDocument();
     });
 
     it('should find top-level field by name', () => {
@@ -1129,8 +1145,12 @@ describe('EntitySummaryPanelUtilsV1 - Nested Search (Topic, Container, SearchInd
 
       render(<div>{result}</div>);
 
-      expect(screen.getByTestId('field-card-top_level_field')).toBeInTheDocument();
-      expect(screen.queryByTestId('field-card-parent_record')).not.toBeInTheDocument();
+      expect(
+        screen.getByTestId('field-card-top_level_field')
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByTestId('field-card-parent_record')
+      ).not.toBeInTheDocument();
     });
 
     it('should find nested child field when searching by nested name', () => {
@@ -1145,11 +1165,17 @@ describe('EntitySummaryPanelUtilsV1 - Nested Search (Topic, Container, SearchInd
       render(<div>{result}</div>);
 
       // Parent is shown collapsed; child is behind expand button
-      expect(screen.getByTestId('field-card-parent_record')).toBeInTheDocument();
+      expect(
+        screen.getByTestId('field-card-parent_record')
+      ).toBeInTheDocument();
       expect(screen.getByTestId('expand-icon')).toBeInTheDocument();
-      expect(screen.queryByTestId('field-card-top_level_field')).not.toBeInTheDocument();
+      expect(
+        screen.queryByTestId('field-card-top_level_field')
+      ).not.toBeInTheDocument();
       // Child card is not rendered until user expands
-      expect(screen.queryByTestId('field-card-nested_child_field')).not.toBeInTheDocument();
+      expect(
+        screen.queryByTestId('field-card-nested_child_field')
+      ).not.toBeInTheDocument();
     });
 
     it('should find deeply nested field when searching by its name', () => {
@@ -1164,10 +1190,16 @@ describe('EntitySummaryPanelUtilsV1 - Nested Search (Topic, Container, SearchInd
       render(<div>{result}</div>);
 
       // Ancestor parent is shown collapsed; deeply nested child is behind expand
-      expect(screen.getByTestId('field-card-parent_record')).toBeInTheDocument();
+      expect(
+        screen.getByTestId('field-card-parent_record')
+      ).toBeInTheDocument();
       expect(screen.getByTestId('expand-icon')).toBeInTheDocument();
-      expect(screen.queryByTestId('field-card-top_level_field')).not.toBeInTheDocument();
-      expect(screen.queryByTestId('field-card-deeply_nested')).not.toBeInTheDocument();
+      expect(
+        screen.queryByTestId('field-card-top_level_field')
+      ).not.toBeInTheDocument();
+      expect(
+        screen.queryByTestId('field-card-deeply_nested')
+      ).not.toBeInTheDocument();
     });
 
     it('should show no-data when search text matches nothing', () => {
@@ -1198,7 +1230,9 @@ describe('EntitySummaryPanelUtilsV1 - Nested Search (Topic, Container, SearchInd
       render(<div>{result}</div>);
 
       expect(screen.getByTestId('field-card-top_column')).toBeInTheDocument();
-      expect(screen.getByTestId('field-card-struct_column')).toBeInTheDocument();
+      expect(
+        screen.getByTestId('field-card-struct_column')
+      ).toBeInTheDocument();
     });
 
     it('should find top-level column by name', () => {
@@ -1213,7 +1247,9 @@ describe('EntitySummaryPanelUtilsV1 - Nested Search (Topic, Container, SearchInd
       render(<div>{result}</div>);
 
       expect(screen.getByTestId('field-card-top_column')).toBeInTheDocument();
-      expect(screen.queryByTestId('field-card-struct_column')).not.toBeInTheDocument();
+      expect(
+        screen.queryByTestId('field-card-struct_column')
+      ).not.toBeInTheDocument();
     });
 
     it('should find nested child column when searching by nested name', () => {
@@ -1228,10 +1264,16 @@ describe('EntitySummaryPanelUtilsV1 - Nested Search (Topic, Container, SearchInd
       render(<div>{result}</div>);
 
       // Parent is shown collapsed; child is behind expand button
-      expect(screen.getByTestId('field-card-struct_column')).toBeInTheDocument();
+      expect(
+        screen.getByTestId('field-card-struct_column')
+      ).toBeInTheDocument();
       expect(screen.getByTestId('expand-icon')).toBeInTheDocument();
-      expect(screen.queryByTestId('field-card-top_column')).not.toBeInTheDocument();
-      expect(screen.queryByTestId('field-card-nested_column_child')).not.toBeInTheDocument();
+      expect(
+        screen.queryByTestId('field-card-top_column')
+      ).not.toBeInTheDocument();
+      expect(
+        screen.queryByTestId('field-card-nested_column_child')
+      ).not.toBeInTheDocument();
     });
 
     it('should find deeply nested column when searching by its name', () => {
@@ -1246,10 +1288,16 @@ describe('EntitySummaryPanelUtilsV1 - Nested Search (Topic, Container, SearchInd
       render(<div>{result}</div>);
 
       // Ancestor parent is shown collapsed; deeply nested column is behind expand
-      expect(screen.getByTestId('field-card-struct_column')).toBeInTheDocument();
+      expect(
+        screen.getByTestId('field-card-struct_column')
+      ).toBeInTheDocument();
       expect(screen.getByTestId('expand-icon')).toBeInTheDocument();
-      expect(screen.queryByTestId('field-card-top_column')).not.toBeInTheDocument();
-      expect(screen.queryByTestId('field-card-deeply_nested_column')).not.toBeInTheDocument();
+      expect(
+        screen.queryByTestId('field-card-top_column')
+      ).not.toBeInTheDocument();
+      expect(
+        screen.queryByTestId('field-card-deeply_nested_column')
+      ).not.toBeInTheDocument();
     });
 
     it('should show no-data when search text matches nothing', () => {
@@ -1263,9 +1311,7 @@ describe('EntitySummaryPanelUtilsV1 - Nested Search (Topic, Container, SearchInd
 
       render(<div>{result}</div>);
 
-      expect(
-        screen.getByText('message.no-data-available')
-      ).toBeInTheDocument();
+      expect(screen.getByText('message.no-data-available')).toBeInTheDocument();
     });
   });
 
@@ -1282,7 +1328,9 @@ describe('EntitySummaryPanelUtilsV1 - Nested Search (Topic, Container, SearchInd
       render(<div>{result}</div>);
 
       expect(screen.getByTestId('field-card-top_si_field')).toBeInTheDocument();
-      expect(screen.getByTestId('field-card-nested_si_parent')).toBeInTheDocument();
+      expect(
+        screen.getByTestId('field-card-nested_si_parent')
+      ).toBeInTheDocument();
     });
 
     it('should find top-level field by name', () => {
@@ -1297,7 +1345,9 @@ describe('EntitySummaryPanelUtilsV1 - Nested Search (Topic, Container, SearchInd
       render(<div>{result}</div>);
 
       expect(screen.getByTestId('field-card-top_si_field')).toBeInTheDocument();
-      expect(screen.queryByTestId('field-card-nested_si_parent')).not.toBeInTheDocument();
+      expect(
+        screen.queryByTestId('field-card-nested_si_parent')
+      ).not.toBeInTheDocument();
     });
 
     it('should find nested child field when searching by nested name', () => {
@@ -1312,10 +1362,16 @@ describe('EntitySummaryPanelUtilsV1 - Nested Search (Topic, Container, SearchInd
       render(<div>{result}</div>);
 
       // Parent is shown collapsed; child is behind expand button
-      expect(screen.getByTestId('field-card-nested_si_parent')).toBeInTheDocument();
+      expect(
+        screen.getByTestId('field-card-nested_si_parent')
+      ).toBeInTheDocument();
       expect(screen.getByTestId('expand-icon')).toBeInTheDocument();
-      expect(screen.queryByTestId('field-card-top_si_field')).not.toBeInTheDocument();
-      expect(screen.queryByTestId('field-card-nested_si_child')).not.toBeInTheDocument();
+      expect(
+        screen.queryByTestId('field-card-top_si_field')
+      ).not.toBeInTheDocument();
+      expect(
+        screen.queryByTestId('field-card-nested_si_child')
+      ).not.toBeInTheDocument();
     });
 
     it('should find deeply nested field when searching by its name', () => {
@@ -1330,10 +1386,16 @@ describe('EntitySummaryPanelUtilsV1 - Nested Search (Topic, Container, SearchInd
       render(<div>{result}</div>);
 
       // Ancestor parent is shown collapsed; deeply nested field is behind expand
-      expect(screen.getByTestId('field-card-nested_si_parent')).toBeInTheDocument();
+      expect(
+        screen.getByTestId('field-card-nested_si_parent')
+      ).toBeInTheDocument();
       expect(screen.getByTestId('expand-icon')).toBeInTheDocument();
-      expect(screen.queryByTestId('field-card-top_si_field')).not.toBeInTheDocument();
-      expect(screen.queryByTestId('field-card-deeply_nested_si_field')).not.toBeInTheDocument();
+      expect(
+        screen.queryByTestId('field-card-top_si_field')
+      ).not.toBeInTheDocument();
+      expect(
+        screen.queryByTestId('field-card-deeply_nested_si_field')
+      ).not.toBeInTheDocument();
     });
 
     it('should show no-data when search text matches nothing', () => {
@@ -1347,9 +1409,81 @@ describe('EntitySummaryPanelUtilsV1 - Nested Search (Topic, Container, SearchInd
 
       render(<div>{result}</div>);
 
-      expect(
-        screen.getByText('message.no-data-available')
-      ).toBeInTheDocument();
+      expect(screen.getByText('message.no-data-available')).toBeInTheDocument();
+    });
+  });
+
+  describe('ContainerFieldCardsV1 - on-demand dataModel fetch', () => {
+    beforeEach(() => {
+      jest.clearAllMocks();
+    });
+
+    it('fetches dataModel on demand when columns are absent from the search hit', async () => {
+      (getContainerByFQN as jest.Mock).mockResolvedValue({
+        dataModel: {
+          columns: [
+            { name: 'fetched_col', dataType: ContainerDataType.String },
+          ],
+        },
+      });
+      const containerWithoutColumns = {
+        id: 'c1',
+        name: 'no-cols',
+        fullyQualifiedName: 's3.no-cols',
+      } as Container;
+
+      const result = getEntityChildDetailsV1(
+        EntityType.CONTAINER,
+        containerWithoutColumns,
+        undefined,
+        false,
+        ''
+      );
+      render(<div>{result}</div>);
+
+      await waitFor(() => {
+        expect(getContainerByFQN).toHaveBeenCalledWith('s3.no-cols', {
+          fields: TabSpecificField.DATAMODEL,
+        });
+      });
+    });
+
+    it('does not fetch when columns are already inline on the search hit', async () => {
+      const result = getEntityChildDetailsV1(
+        EntityType.CONTAINER,
+        mockContainerWithNestedColumns,
+        undefined,
+        false,
+        ''
+      );
+      render(<div>{result}</div>);
+
+      await waitFor(() => {
+        expect(screen.getByTestId('field-card-top_column')).toBeInTheDocument();
+      });
+      expect(getContainerByFQN).not.toHaveBeenCalled();
+    });
+
+    it('surfaces an error toast when the on-demand fetch fails', async () => {
+      (getContainerByFQN as jest.Mock).mockRejectedValue(new Error('boom'));
+      const containerWithoutColumns = {
+        id: 'c2',
+        name: 'err',
+        fullyQualifiedName: 's3.err',
+      } as Container;
+
+      const result = getEntityChildDetailsV1(
+        EntityType.CONTAINER,
+        containerWithoutColumns,
+        undefined,
+        false,
+        ''
+      );
+      render(<div>{result}</div>);
+
+      await waitFor(() => {
+        expect(showErrorToast).toHaveBeenCalled();
+      });
     });
   });
 });

--- a/openmetadata-ui/src/main/resources/ui/src/utils/EntitySummaryPanelUtilsV1.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/EntitySummaryPanelUtilsV1.tsx
@@ -19,7 +19,8 @@ import {
   Table,
   Typography as AntTypography,
 } from 'antd';
-import { isEmpty } from 'lodash';
+import { AxiosError } from 'axios';
+import { isEmpty, isUndefined } from 'lodash';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { ReactComponent as NestedIcon } from '../assets/svg/nested.svg';
 import { FieldCard } from '../components/common/FieldCard';
@@ -28,7 +29,7 @@ import Loader from '../components/common/Loader/Loader';
 import '../components/Explore/EntitySummaryPanel/entity-summary-panel.less';
 import { SearchedDataProps } from '../components/SearchedData/SearchedData.interface';
 import { PAGE_SIZE_LARGE } from '../constants/constants';
-import { EntityType } from '../enums/entity.enum';
+import { EntityType, TabSpecificField } from '../enums/entity.enum';
 import { APICollection } from '../generated/entity/data/apiCollection';
 import { APIEndpoint } from '../generated/entity/data/apiEndpoint';
 import { Container } from '../generated/entity/data/container';
@@ -46,6 +47,7 @@ import {
   getDataModelColumnsByFQN,
   searchDataModelColumnsByFQN,
 } from '../rest/dataModelsAPI';
+import { getContainerByFQN } from '../rest/storageAPI';
 import {
   getTableColumnsByFQN,
   getTableList,
@@ -54,8 +56,8 @@ import {
 import { GenericNestedField } from './EntitySummaryPanelUtilsV1.interface';
 import { getEntityName } from './EntityUtils';
 import { t } from './i18next/LocalUtil';
-
 import { pruneEmptyChildren } from './TableUtils';
+import { showErrorToast } from './ToastUtils';
 const { Text } = AntTypography;
 
 /**
@@ -104,7 +106,8 @@ const NestedFieldCard: React.FC<NestedFieldCardProps> = ({
         style={{
           paddingLeft: `${level * 24}px`,
           paddingBottom: hasChildren ? '8px' : '0',
-        }}>
+        }}
+      >
         <div className="field-card-no-border">
           <FieldCard
             columnConstraint={column.constraint}
@@ -128,7 +131,8 @@ const NestedFieldCard: React.FC<NestedFieldCardProps> = ({
               data-testid="expand-icon"
               size="small"
               type="link"
-              onClick={() => onToggleExpand(column.fullyQualifiedName ?? '')}>
+              onClick={() => onToggleExpand(column.fullyQualifiedName ?? '')}
+            >
               <Typography color={theme.palette.primary.main} variant="caption">
                 {isExpanded
                   ? t('label.show-less')
@@ -172,72 +176,74 @@ const NestedSchemaFieldCard: React.FC<{
   expandedRowKeys,
   onToggleExpand,
 }) => {
-    const theme = useTheme();
-    const hasChildren = !isEmpty(field.children);
-    const rowKey = field.fullyQualifiedName ?? field.name;
-    const isExpanded = expandedRowKeys.includes(rowKey);
-    const isHighlighted = highlights?.[highlightKey]?.includes(field.name);
-    const childrenCount = field.children?.length ?? 0;
+  const theme = useTheme();
+  const hasChildren = !isEmpty(field.children);
+  const rowKey = field.fullyQualifiedName ?? field.name;
+  const isExpanded = expandedRowKeys.includes(rowKey);
+  const isHighlighted = highlights?.[highlightKey]?.includes(field.name);
+  const childrenCount = field.children?.length ?? 0;
 
-    return (
-      <div>
-        <div
-          className="nested-field-card-wrapper"
-          data-row-key={rowKey}
-          style={{
-            paddingLeft: `${level * 24}px`,
-            paddingBottom: hasChildren ? '8px' : '0',
-          }}>
-          <div className="field-card-no-border">
-            <FieldCard
-              dataType={field.dataType || 'Unknown'}
-              description={field.description}
-              fieldName={getEntityName(field)}
-              glossaryTerms={field.glossaryTerms}
-              isHighlighted={isHighlighted}
-              tags={field.tags}
-            />
-          </div>
-          {hasChildren && (
-            <div className="d-flex align-items-center m-l-md gap-1">
-              {!isExpanded && (
-                <span className="d-flex">
-                  <NestedIcon />
-                </span>
-              )}
-              <Button
-                className="d-flex p-0 h-auto m-b-xs"
-                data-testid="expand-icon"
-                size="small"
-                type="link"
-                onClick={() => onToggleExpand(rowKey)}>
-                <Typography color={theme.palette.primary.main} variant="caption">
-                  {isExpanded
-                    ? t('label.show-less')
-                    : `${t('label.show-nested')} (${childrenCount})`}
-                </Typography>
-              </Button>
-            </div>
-          )}
+  return (
+    <div>
+      <div
+        className="nested-field-card-wrapper"
+        data-row-key={rowKey}
+        style={{
+          paddingLeft: `${level * 24}px`,
+          paddingBottom: hasChildren ? '8px' : '0',
+        }}
+      >
+        <div className="field-card-no-border">
+          <FieldCard
+            dataType={field.dataType || 'Unknown'}
+            description={field.description}
+            fieldName={getEntityName(field)}
+            glossaryTerms={field.glossaryTerms}
+            isHighlighted={isHighlighted}
+            tags={field.tags}
+          />
         </div>
-        {hasChildren && isExpanded && (
-          <div>
-            {field.children?.map((child) => (
-              <NestedSchemaFieldCard
-                expandedRowKeys={expandedRowKeys}
-                field={child}
-                highlightKey={highlightKey}
-                highlights={highlights}
-                key={child.fullyQualifiedName ?? child.name}
-                level={level + 1}
-                onToggleExpand={onToggleExpand}
-              />
-            ))}
+        {hasChildren && (
+          <div className="d-flex align-items-center m-l-md gap-1">
+            {!isExpanded && (
+              <span className="d-flex">
+                <NestedIcon />
+              </span>
+            )}
+            <Button
+              className="d-flex p-0 h-auto m-b-xs"
+              data-testid="expand-icon"
+              size="small"
+              type="link"
+              onClick={() => onToggleExpand(rowKey)}
+            >
+              <Typography color={theme.palette.primary.main} variant="caption">
+                {isExpanded
+                  ? t('label.show-less')
+                  : `${t('label.show-nested')} (${childrenCount})`}
+              </Typography>
+            </Button>
           </div>
         )}
       </div>
-    );
-  };
+      {hasChildren && isExpanded && (
+        <div>
+          {field.children?.map((child) => (
+            <NestedSchemaFieldCard
+              expandedRowKeys={expandedRowKeys}
+              field={child}
+              highlightKey={highlightKey}
+              highlights={highlights}
+              key={child.fullyQualifiedName ?? child.name}
+              level={level + 1}
+              onToggleExpand={onToggleExpand}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+};
 
 // Shared recursive filter that preserves tree structure (used by Topic, Container, SearchIndex)
 const filterNestedFields = (
@@ -392,7 +398,8 @@ const SchemaFieldCardsV1: React.FC<{
         block
         loading={isLoading && currentPage > 1}
         type="link"
-        onClick={handleLoadMore}>
+        onClick={handleLoadMore}
+      >
         {t('label.show-more')}
       </Button>
     );
@@ -525,7 +532,56 @@ const ContainerFieldCardsV1: React.FC<{
   searchText?: string;
 }> = ({ entityInfo, highlights, loading, searchText }) => {
   const [expandedRowKeys, setExpandedRowKeys] = useState<string[]>([]);
-  const columns = entityInfo.dataModel?.columns || [];
+  const [fetchedColumns, setFetchedColumns] = useState<Column[]>();
+
+  const inlineColumns = entityInfo.dataModel?.columns;
+  const containerFqn = entityInfo.fullyQualifiedName;
+  // Start in the loading state when columns must be fetched on demand, so the first render shows the
+  // loader instead of briefly flashing "No data available".
+  const [isColumnsLoading, setIsColumnsLoading] = useState(
+    () => isUndefined(inlineColumns) && Boolean(containerFqn)
+  );
+
+  useEffect(() => {
+    // dataModel is excluded from Explore search payloads because it can be very large, so when it is
+    // absent on the search hit we fetch it on demand from the entity API.
+    if (!isUndefined(inlineColumns) || !containerFqn) {
+      // No on-demand fetch needed (columns already inline, or no FQN). Clear any loading flag left
+      // set by a now-cancelled in-flight fetch so the loader can't get stuck on.
+      setIsColumnsLoading(false);
+
+      return;
+    }
+    // Drop any previously-fetched columns and show the loader so the prior container's schema isn't
+    // shown while the new one loads; the cancelled guard also ignores a stale in-flight result if
+    // the user switches containers again before it resolves.
+    let cancelled = false;
+    setFetchedColumns(undefined);
+    setIsColumnsLoading(true);
+    getContainerByFQN(containerFqn, { fields: TabSpecificField.DATAMODEL })
+      .then((container) => {
+        if (!cancelled) {
+          setFetchedColumns(container.dataModel?.columns ?? []);
+        }
+      })
+      .catch((error) => {
+        if (!cancelled) {
+          setFetchedColumns([]);
+          showErrorToast(error as AxiosError);
+        }
+      })
+      .finally(() => {
+        if (!cancelled) {
+          setIsColumnsLoading(false);
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [containerFqn, inlineColumns]);
+
+  const columns = inlineColumns ?? fetchedColumns ?? [];
 
   const filteredColumns = useMemo(
     () =>
@@ -541,7 +597,7 @@ const ContainerFieldCardsV1: React.FC<{
     );
   }, []);
 
-  if (loading) {
+  if (loading || isColumnsLoading) {
     return (
       <div className="flex-center p-lg">
         <Loader size="default" />
@@ -955,8 +1011,8 @@ const APIEndpointSchemaV1: React.FC<{
             children: nameMatch
               ? field.children
               : filteredChildren.length > 0
-                ? filteredChildren
-                : field.children,
+              ? filteredChildren
+              : field.children,
           });
         }
 

--- a/openmetadata-ui/src/main/resources/ui/src/utils/ExploreUtils.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/ExploreUtils.tsx
@@ -504,14 +504,16 @@ export const generateTabItems = (
       label: (
         <div
           className="d-flex items-center justify-between"
-          data-testid={`${lowerCase(tabDetail.label)}-tab`}>
+          data-testid={`${lowerCase(tabDetail.label)}-tab`}
+        >
           <div className="explore-tab-label">
             <span className="explore-icon d-flex m-r-xs">
               <Icon />
             </span>
             <Typography.Text
               className={tabSearchIndex === searchIndex ? 'text-primary' : ''}
-              ellipsis={{ tooltip: true }}>
+              ellipsis={{ tooltip: true }}
+            >
               {tabDetail.label}
             </Typography.Text>
           </div>
@@ -641,7 +643,12 @@ export const fetchEntityData = async ({
           pageNumber: page,
           pageSize: size,
           includeDeleted: showDeleted,
-          excludeSourceFields: ['columns', 'queries', 'columnNames'],
+          excludeSourceFields: [
+            'columns',
+            'queries',
+            'columnNames',
+            'dataModel',
+          ],
         };
 
         try {
@@ -673,7 +680,7 @@ export const fetchEntityData = async ({
         pageNumber: page,
         pageSize: size,
         includeDeleted: showDeleted,
-        excludeSourceFields: ['columns', 'queries', 'columnNames'],
+        excludeSourceFields: ['columns', 'queries', 'columnNames', 'dataModel'],
       };
 
       try {


### PR DESCRIPTION
Backport of #29212 to **1.12.12**.

## What
Cherry-pick of the merged fix that caps an oversized container `dataModel` search document at index time — strips `dataModel.columns[].children` (and the derived `columnNames`/`columnNamesFuzzy`) when a doc is still over the size cap after lineage stripping, on both the live-index and bulk-reindex paths. Companion UI changes exclude `dataModel` from Explore/suggestion search payloads and lazy-fetch the container schema in the summary panel.

## Cherry-pick / conflict notes
- **`EntitySummaryPanelUtilsV1.tsx`**: same import conflict as the 1.13 backport — kept 1.12.12's `pruneEmptyChildren` from `./TableUtils` and added the new `showErrorToast` import. 1.12.12 already has `getContainerByFQN` (`rest/storageAPI`) and `TabSpecificField.DATAMODEL`, so the lazy-fetch wiring applies unchanged.
- **`SearchIndexUtilsTest.java`**: this test file does not exist on 1.12.12 (added on main by a later, unrelated refactor that also introduced main-only helpers like `normalizeFollowers`). Rather than drag in that whole file, I added a **minimal, focused test** containing only the 4 column-strip tests this PR is about (they exercise `stripDocMapIfOversized` / `stripLineageForSize` / `stripColumnTreeForSize`, all present on 1.12.12).
- **Larger UI diff than #29212:** 1.12.12's `EntitySummaryPanelUtilsV1.tsx` / `.test.tsx` were pre-existing **not** prettier-clean (e.g. the deprecated `}}>` JSX-bracket style). Because CI's UI Checkstyle reformats the whole touched file and fails on any diff, the touched files are brought fully to Prettier style — hence the extra formatting lines. The logical change is the same as #29212.

## Verification
- UI: organize-imports + eslint (0 errors) + prettier `--check` clean on all 5 files.
- Backend: `SearchIndexUtils.java` auto-merged cleanly and is spotless-clean; strip call sites land inside `stripLineageForSize` / `stripDocMapIfOversized`; minimal test is spotless-clean.
- Full backend unit tests + UI jest run in CI. Local runs are blocked by 1.12.12 build infra unrelated to this change (backend: ungenerated schema models for `IntakeForm`/`CollectionDAO`; UI jest: missing generated connection schemas + `vis-data` in this working tree). The identical test code passes on the 1.13 backport (UI jest 34/34).

Original PR: #29212 · sibling backport: #29298 (1.13)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This backport caps oversized container `dataModel` search documents at index time and trims the payload returned to Explore/suggestion UI queries. The backend adds a third stripping stage that removes column `children` and derived `columnNames`/`columnNamesFuzzy` when a document is still over the size cap after lineage stripping; the UI side excludes `dataModel` from search payloads and lazy-fetches the container schema on demand when the summary panel opens.

- **`SearchIndexUtils.java`**: new `stripColumnTreeForSize` stage fires after `lineageSqlQueries` and `upstreamLineage` stripping in both the bulk-reindex (`stripLineageForSize`) and live-index (`stripDocMapIfOversized`) paths; only top-level column `children` keys are removed, leaving top-level columns intact for column search.
- **`EntitySummaryPanelUtilsV1.tsx`**: `ContainerFieldCardsV1` now detects an absent `dataModel` on the search hit and fetches it on demand via `getContainerByFQN`, with a cancellation guard, dedicated loading state, and error toast.
- **`ExploreUtils.tsx` / `Suggestions.tsx`**: `dataModel` added to `excludeSourceFields` in all Explore and suggestion queries; `ServiceInsightsTab` adds `pageSize: 0` / `fetchSource: false` to its aggregation-only count query.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the stripping logic is well-guarded and the UI lazy-fetch pattern handles cancellation and error states correctly.

The backend stripping is additive and reached only after existing lineage stripping still leaves the document oversized; the `size` variable is kept in sync across all branches and no stale-size path exists. The UI change is purely additive: excluding `dataModel` from Explore payloads has no effect on callers that don't use that field, and the summary panel gracefully falls back to a single on-demand API call when the field is absent. The test coverage directly exercises all four new code paths in the Java utility. No regressions in existing behaviour are expected.

No files require special attention. The `EntitySummaryPanelUtilsV1.tsx` lazy-fetch wiring is the most behaviorally significant change but is well-tested and cancellation-safe.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-service/src/main/java/org/openmetadata/service/search/SearchIndexUtils.java | Adds stripColumnTreeForSize as a third-stage reduction step (after lineage stripping) that removes column children and the derived columnNames/columnNamesFuzzy fields; logic is correct and size is kept in sync across all branches |
| openmetadata-service/src/test/java/org/openmetadata/service/search/SearchIndexUtilsTest.java | New focused test file covering all four stripping scenarios (bulk-reindex oversized, live-index oversized, normal-size no-op, and top-level table columns); test helpers and assertions are correct |
| openmetadata-ui/src/main/resources/ui/src/utils/EntitySummaryPanelUtilsV1.tsx | Adds on-demand getContainerByFQN fetch when dataModel is absent from the search hit; cancellation guard, loading state, and error toast are all implemented correctly |
| openmetadata-ui/src/main/resources/ui/src/utils/EntitySummaryPanelUtilsV1.test.tsx | Adds three new tests for the lazy-fetch path (columns absent fetch triggered, columns present no fetch, fetch failure error toast); mocks and assertions are correct alongside formatting-only reformats of existing tests |
| openmetadata-ui/src/main/resources/ui/src/utils/ExploreUtils.tsx | Adds dataModel to excludeSourceFields in both Explore hit-fetch paths so oversized container schemas are never pulled into Explore results; JSX formatting changes only |
| openmetadata-ui/src/main/resources/ui/src/components/AppBar/Suggestions.tsx | Adds dataModel to excludeSourceFields for suggestion queries; JSX attribute-closing brace reformatting only otherwise |
| openmetadata-ui/src/main/resources/ui/src/components/ServiceInsights/ServiceInsightsTab.tsx | Adds pageSize 0 and fetchSource false to the aggregation-only service-count query; correct optimisation since only aggregations.entityType.buckets is consumed from the response |

</details>

</details>

<details open><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Index document] --> B{size <= maxBytes?}
    B -- yes --> Z[Index as-is]
    B -- no --> C{lineageSqlQueries present?}
    C -- yes --> D[Strip lineageSqlQueries + SQL keys from edges]
    D --> E{size <= maxBytes?}
    E -- yes --> Z
    E -- no --> F{upstreamLineage present?}
    C -- no --> F
    F -- yes --> G[Remove upstreamLineage]
    G --> H{size <= maxBytes?}
    F -- no --> H
    H -- yes --> Z
    H -- no --> I[stripColumnTreeForSize]
    I --> J[Log warning and index stripped doc]
    J --> Z
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Index document] --> B{size <= maxBytes?}
    B -- yes --> Z[Index as-is]
    B -- no --> C{lineageSqlQueries present?}
    C -- yes --> D[Strip lineageSqlQueries + SQL keys from edges]
    D --> E{size <= maxBytes?}
    E -- yes --> Z
    E -- no --> F{upstreamLineage present?}
    C -- no --> F
    F -- yes --> G[Remove upstreamLineage]
    G --> H{size <= maxBytes?}
    F -- no --> H
    H -- yes --> Z
    H -- no --> I[stripColumnTreeForSize]
    I --> J[Log warning and index stripped doc]
    J --> Z
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(search): cap oversized dataModel col..."](https://github.com/open-metadata/openmetadata/commit/f292e8bc736be778b510493a05fb0e6cd022b8b9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39028984)</sub>

<!-- /greptile_comment -->