### PR TITLE
feat(ci): nightly Storybook Docker build for ui-core-components

### DIFF
--- a/.github/workflows/storybook-nightly.yml
+++ b/.github/workflows/storybook-nightly.yml
@@ -44,6 +44,7 @@ concurrency:
 jobs:
   build-and-push:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
 
     permissions:
       contents: read

--- a/.github/workflows/storybook-nightly.yml
+++ b/.github/workflows/storybook-nightly.yml
@@ -75,11 +75,10 @@ jobs:
         with:
           context: .
           file: docker/storybook/Dockerfile
+          platforms: linux/amd64,linux/arm64
           # On scheduled runs always push; on workflow_dispatch respect the input.
           push: ${{ github.event_name == 'schedule' || inputs.push_image }}
           tags: ${{ steps.prepare.outputs.tags }}
-          cache-from: type=gha,scope=storybook
-          cache-to: type=gha,mode=max,scope=storybook
 
       - name: Print image reference
         run: |

--- a/.github/workflows/storybook-nightly.yml
+++ b/.github/workflows/storybook-nightly.yml
@@ -1,0 +1,94 @@
+#  Copyright 2024 Collate
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  http://www.apache.org/licenses/LICENSE-2.0
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+# Builds openmetadata-ui-core-components Storybook nightly and pushes the image
+# to Docker Hub so the design team can review components without a local dev
+# environment.
+#
+# Required repository secrets (same ones used by other docker-* workflows):
+#   DOCKERHUB_OPENMETADATA_USERNAME
+#   DOCKERHUB_OPENMETADATA_TOKEN
+#
+# Image: openmetadata/storybook-ui:latest
+#         openmetadata/storybook-ui:<short-sha>
+#
+# To pull and run:
+#   docker run -p 6006:6006 openmetadata/storybook-ui:latest
+
+name: Storybook nightly build
+
+on:
+  schedule:
+    # 02:00 UTC every day.
+    - cron: '0 2 * * *'
+  # Allow a one-click manual run from the Actions tab.
+  workflow_dispatch:
+    inputs:
+      push_image:
+        description: "Push the built image to Docker Hub?"
+        type: boolean
+        default: true
+
+concurrency:
+  group: storybook-nightly
+  cancel-in-progress: true
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Get short commit SHA
+        id: sha
+        run: echo "short=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
+
+      - name: Prepare Docker build
+        id: prepare
+        uses: ./.github/actions/prepare-for-docker-build-and-push
+        with:
+          image: openmetadata/storybook-ui
+          tag: value=${{ steps.sha.outputs.short }}
+          push_latest: "true"
+          is_ingestion: "false"
+          dockerhub_username: ${{ secrets.DOCKERHUB_OPENMETADATA_USERNAME }}
+          dockerhub_token: ${{ secrets.DOCKERHUB_OPENMETADATA_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        env:
+          DOCKER_BUILD_NO_SUMMARY: true
+        with:
+          context: .
+          file: docker/storybook/Dockerfile
+          # On scheduled runs always push; on workflow_dispatch respect the input.
+          push: ${{ github.event_name == 'schedule' || inputs.push_image }}
+          tags: ${{ steps.prepare.outputs.tags }}
+          cache-from: type=gha,scope=storybook
+          cache-to: type=gha,mode=max,scope=storybook
+
+      - name: Print image reference
+        run: |
+          echo "### Storybook image published" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+          echo "${{ steps.prepare.outputs.tags }}" >> "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "Run locally:" >> "$GITHUB_STEP_SUMMARY"
+          echo '```bash' >> "$GITHUB_STEP_SUMMARY"
+          echo "docker run -p 6006:6006 openmetadata/storybook-ui:latest" >> "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"

--- a/docker/storybook/Dockerfile
+++ b/docker/storybook/Dockerfile
@@ -13,7 +13,7 @@
 # Build context must be the repo root so both the source tree and this config
 # file are reachable.  The nightly workflow calls:
 #   docker build -f docker/storybook/Dockerfile .
-FROM node:22-alpine AS builder
+FROM node:22.17-alpine AS builder
 
 WORKDIR /app
 
@@ -31,13 +31,16 @@ COPY openmetadata-ui-core-components/src/main/resources/ui/ ./
 RUN yarn build-storybook
 
 # ── Stage 2: serve with Node ─────────────────────────────────────────────────
-FROM node:22-alpine AS server
+FROM node:22.17-alpine AS server
 
 # `serve` is the static file server Storybook recommends; pin the major so the
 # CLI flags stay stable across nightly rebuilds.
 RUN npm install -g serve@14
 
 COPY --from=builder /app/storybook-static /app/storybook-static
+
+# Drop to the built-in unprivileged user — running a public server as root is unnecessary.
+USER node
 
 EXPOSE 6006
 

--- a/docker/storybook/Dockerfile
+++ b/docker/storybook/Dockerfile
@@ -1,0 +1,44 @@
+#  Copyright 2024 Collate
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  http://www.apache.org/licenses/LICENSE-2.0
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+# ── Stage 1: build Storybook static assets ──────────────────────────────────
+# Build context must be the repo root so both the source tree and this config
+# file are reachable.  The nightly workflow calls:
+#   docker build -f docker/storybook/Dockerfile .
+FROM node:22-alpine AS builder
+
+WORKDIR /app
+
+# Copy lockfile + manifest first so the layer is cached when only source changes.
+COPY openmetadata-ui-core-components/src/main/resources/ui/package.json \
+     openmetadata-ui-core-components/src/main/resources/ui/yarn.lock ./
+
+# Install all dependencies (dev deps are required for the Storybook build).
+RUN yarn install --frozen-lockfile --network-timeout 120000
+
+# Copy the rest of the source tree.
+COPY openmetadata-ui-core-components/src/main/resources/ui/ ./
+
+# Produce the static site in storybook-static/.
+RUN yarn build-storybook
+
+# ── Stage 2: serve with Node ─────────────────────────────────────────────────
+FROM node:22-alpine AS server
+
+# `serve` is the static file server Storybook recommends; pin the major so the
+# CLI flags stay stable across nightly rebuilds.
+RUN npm install -g serve@14
+
+COPY --from=builder /app/storybook-static /app/storybook-static
+
+EXPOSE 6006
+
+CMD ["serve", "-s", "/app/storybook-static", "-l", "6006"]

--- a/docker/storybook/Dockerfile.dockerignore
+++ b/docker/storybook/Dockerfile.dockerignore
@@ -1,0 +1,8 @@
+# Scoped ignore file for docker/storybook/Dockerfile (BuildKit reads
+# <dockerfile>.dockerignore relative to the build context root).
+# Keeps host build artifacts from polluting the image and shrinks the context.
+
+**/node_modules
+**/storybook-static
+**/dist
+**/.git

--- a/docker/storybook/Dockerfile.dockerignore
+++ b/docker/storybook/Dockerfile.dockerignore
@@ -1,8 +1,20 @@
-# Scoped ignore file for docker/storybook/Dockerfile (BuildKit reads
-# <dockerfile>.dockerignore relative to the build context root).
-# Keeps host build artifacts from polluting the image and shrinks the context.
+# Allowlist-style ignore for docker/storybook/Dockerfile.
+# Excludes the entire monorepo by default, then re-includes only the files the
+# Dockerfile actually COPYs, keeping the build context to a few MB instead of
+# hundreds of MB.
 
-**/node_modules
-**/storybook-static
-**/dist
-**/.git
+# Exclude everything.
+**
+
+# Re-include the component library source (each parent dir must be listed explicitly).
+!openmetadata-ui-core-components/
+!openmetadata-ui-core-components/src/
+!openmetadata-ui-core-components/src/main/
+!openmetadata-ui-core-components/src/main/resources/
+!openmetadata-ui-core-components/src/main/resources/ui/
+!openmetadata-ui-core-components/src/main/resources/ui/**
+
+# Re-exclude build artifacts that should never enter the image.
+openmetadata-ui-core-components/src/main/resources/ui/node_modules
+openmetadata-ui-core-components/src/main/resources/ui/storybook-static
+openmetadata-ui-core-components/src/main/resources/ui/dist

--- a/docker/storybook/docker-compose.yml
+++ b/docker/storybook/docker-compose.yml
@@ -1,0 +1,12 @@
+# Local smoke-test compose.  Run from the repo root:
+#   docker compose -f docker/storybook/docker-compose.yml up --build
+#
+# Then open http://localhost:6006
+services:
+  storybook:
+    build:
+      context: ../..
+      dockerfile: docker/storybook/Dockerfile
+    ports:
+      - "6006:6006"
+    restart: unless-stopped


### PR DESCRIPTION
### Describe your changes:

I worked on adding Docker-based Storybook hosting for `openmetadata-ui-core-components` because the design team needs a way to review components without setting up a local dev environment.

### Type of change:
- [x] New feature

#
### High-level design:

Three files added:

- **`docker/storybook/Dockerfile`** — Multi-stage build: `node:22-alpine` builder runs `yarn build-storybook` to produce `storybook-static/`; a second `node:22-alpine` stage serves it with `serve@14` on port 6006. No nginx dependency.
- **`docker/storybook/docker-compose.yml`** — Local smoke-test; run `docker compose -f docker/storybook/docker-compose.yml up --build` from the repo root, then open `http://localhost:6006`.
- **`.github/workflows/storybook-nightly.yml`** — Nightly cron (02:00 UTC) + `workflow_dispatch`. Uses the shared `.github/actions/prepare-for-docker-build-and-push` composite action. Pushes two tags to Docker Hub: `openmetadata/storybook-ui:latest` and `openmetadata/storybook-ui:<short-sha>`. GHA layer cache scoped to `storybook` keeps rebuilds fast.

Requires `DOCKERHUB_OPENMETADATA_USERNAME` and `DOCKERHUB_OPENMETADATA_TOKEN` secrets (already present in the repo).

#
### Tests:

#### Use cases covered
- Design team can pull and run `docker run -p 6006:6006 openmetadata/storybook-ui:latest` to browse all components
- Each nightly build is traceable to a specific commit via the short-SHA tag

#### Unit tests
- [ ] Not applicable — CI/Docker infrastructure only, no application logic changed.

#### Backend integration tests
- [x] Not applicable (no backend API changes).

#### Ingestion integration tests
- [x] Not applicable (no ingestion changes).

#### Playwright (UI) tests
- [x] Not applicable (no UI changes).

#### Manual testing performed
1. Verified `yarn build-storybook` succeeds in the `openmetadata-ui-core-components/src/main/resources/ui/` directory.
2. Confirmed Dockerfile build context paths resolve correctly from repo root.
3. Reviewed composite action inputs match the pattern used by existing `docker-openmetadata-server.yml` workflow.

#
### UI screen recording / screenshots:

Not applicable.

#
### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.
- [ ] For UI changes: I attached a screen recording and/or screenshots above.
- [ ] I have added tests (unit / integration / Playwright as applicable) and listed them above.

----
## Summary by Gitar

- **Docker configuration:**
  - Added `.dockerignore` for `docker/storybook/Dockerfile` to optimize build context by excluding build artifacts and `node_modules`.
  - Pinned `node:22-alpine` to `node:22.17-alpine` in `Dockerfile` for improved build stability.

<sub>This will update automatically on new commits.</sub>

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds a nightly CI workflow that builds a Docker image containing the Storybook static site for `openmetadata-ui-core-components` and pushes it to Docker Hub, giving the design team a way to browse components without a local dev environment.

- **Workflow** (`.github/workflows/storybook-nightly.yml`): Runs at 02:00 UTC and on `workflow_dispatch`, builds a multi-arch (`linux/amd64,linux/arm64`) image via the shared composite action, and pushes two tags (`latest` + short SHA) to `openmetadata/storybook-ui`.
- **Dockerfile** (`docker/storybook/Dockerfile`): Two-stage build — `node:22.17-alpine` builds the Storybook static assets; a second `node:22.17-alpine` stage serves them with `serve@14` on port 6006 under the unprivileged `node` user.
- **Build-context scoping** (`docker/storybook/Dockerfile.dockerignore`): Uses the BuildKit companion-ignore-file pattern to allowlist only the UI source directory, preventing the full monorepo from being sent to the daemon.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — all three new files are additive CI/Docker infrastructure with no changes to application code or existing workflows.

The Dockerfile is well-structured with a pinned Node version in both stages, a non-root serve user, and a companion `.dockerignore` that correctly scopes the monorepo build context using BuildKit's per-Dockerfile ignore-file mechanism. The workflow correctly reuses the shared composite action, handles the `workflow_dispatch` push toggle, and uses the expected secrets. No existing behavior is altered.

`.github/workflows/storybook-nightly.yml` — worth a second look on the timeout value for multi-arch QEMU builds and the missing BuildKit cache configuration.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/storybook-nightly.yml | New nightly workflow — correct structure and secret usage, but the `timeout-minutes: 30` may be tight for multi-arch QEMU emulation, and no BuildKit cache is configured despite the PR description claiming GHA layer caching. |
| docker/storybook/Dockerfile | Clean two-stage build; Node version pinned to 22.17-alpine in both stages, unprivileged user applied in serve stage, serve@14 major pinned. |
| docker/storybook/Dockerfile.dockerignore | Allowlist-style ignore correctly scopes the build context to the UI source tree; node_modules, storybook-static, and dist are re-excluded. |
| docker/storybook/docker-compose.yml | Minimal local smoke-test compose file; context correctly points to repo root with the right Dockerfile path. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A([02:00 UTC cron or workflow_dispatch]) --> B[Checkout repo]
    B --> C[Get short SHA]
    C --> D[prepare-for-docker-build-and-push
Setup QEMU and Buildx
Docker Hub login
Generate tags]
    D --> E[docker/build-push-action v6
platforms amd64 and arm64]
    E --> F{push?}
    F -->|schedule OR push_image=true| G[Push to Docker Hub
openmetadata/storybook-ui:latest
openmetadata/storybook-ui:short-sha]
    F -->|push_image=false| H[Build only no push]
    G --> I[Print image ref to Step Summary]
    H --> I
    subgraph Dockerfile
        J[Stage 1 node:22.17-alpine builder
yarn install and yarn build-storybook]
        J --> K[Stage 2 node:22.17-alpine server
serve@14 USER node EXPOSE 6006]
    end
    E -.->|executes| J
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A([02:00 UTC cron or workflow_dispatch]) --> B[Checkout repo]
    B --> C[Get short SHA]
    C --> D[prepare-for-docker-build-and-push
Setup QEMU and Buildx
Docker Hub login
Generate tags]
    D --> E[docker/build-push-action v6
platforms amd64 and arm64]
    E --> F{push?}
    F -->|schedule OR push_image=true| G[Push to Docker Hub
openmetadata/storybook-ui:latest
openmetadata/storybook-ui:short-sha]
    F -->|push_image=false| H[Build only no push]
    G --> I[Print image ref to Step Summary]
    H --> I
    subgraph Dockerfile
        J[Stage 1 node:22.17-alpine builder
yarn install and yarn build-storybook]
        J --> K[Stage 2 node:22.17-alpine server
serve@14 USER node EXPOSE 6006]
    end
    E -.->|executes| J
```

</a>
</details>

<sub>Reviews (3): Last reviewed commit: ["fix(ci): address PR review comments on s..."](https://github.com/open-metadata/openmetadata/commit/ac3b5b10be096889edfdbb18fd3ce9e45abcfc8b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39055776)</sub>

<!-- /greptile_comment -->