### PR TITLE
fix(test): add missing JsonUtils import to SearchIndexUtilsTest (fixes 1.13 build)

### DIFF
--- a/openmetadata-service/src/test/java/org/openmetadata/service/search/SearchIndexUtilsTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/search/SearchIndexUtilsTest.java
@@ -26,6 +26,7 @@ import org.openmetadata.schema.type.EntityReference;
 import org.openmetadata.schema.type.TagLabel;
 import org.openmetadata.schema.type.change.ChangeSource;
 import org.openmetadata.schema.type.change.ChangeSummary;
+import org.openmetadata.schema.utils.JsonUtils;
 import org.openmetadata.service.TypeRegistry;
 
 class SearchIndexUtilsTest {


### PR DESCRIPTION
## Problem
The #29212 backport to 1.13 (#29298) merged with `SearchIndexUtilsTest.java` calling `JsonUtils.pojoToJson(...)` but **no `JsonUtils` import**, breaking test compilation on `1.13`:

```
SearchIndexUtilsTest.java:[457,18] cannot find symbol
  symbol: variable JsonUtils
```

## Cause
1.13's base `SearchIndexUtilsTest` had no pre-existing `JsonUtils` usage, so the import was never present. On `main` the import already existed (used by other tests), so the cherry-pick diff didn't carry it over. Result: the new strip tests reference `JsonUtils` with nothing importing it.

## Fix
One line — add `import org.openmetadata.schema.utils.JsonUtils;` (the same path `SearchIndexUtils.java` uses).

## Verification
Complete local build on the `1.13` head:
- `mvn clean install -pl openmetadata-service -am -DskipTests` → BUILD SUCCESS
- `mvn test -pl openmetadata-service -Dtest=SearchIndexUtilsTest` → **Tests run: 11, Failures: 0, Errors: 0**

Follow-up to #29298.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This is a one-line backport fix that adds the missing `import org.openmetadata.schema.utils.JsonUtils;` to `SearchIndexUtilsTest.java` on the `1.13` branch. The import was already present on `main` (used by other tests), so the cherry-pick diff never carried it over, leaving the new strip tests unresolvable at compile time.

- Adds `import org.openmetadata.schema.utils.JsonUtils;` at line 29, unblocking compilation of `SearchIndexUtilsTest` on `1.13`.
- No logic changes; only a missing import is restored, exactly matching the import path used by `SearchIndexUtils.java` itself.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change adds a single missing import with no logic modifications.

A single missing import is restored to fix a compilation failure introduced by the backport cherry-pick. The import path exactly matches what SearchIndexUtils.java already uses, the PR author verified the full test suite passes locally (11 tests, 0 failures), and there are no logic changes of any kind.

No files require special attention.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-service/src/test/java/org/openmetadata/service/search/SearchIndexUtilsTest.java | Adds the missing `import org.openmetadata.schema.utils.JsonUtils;` that was omitted when the backport was cherry-picked to 1.13, resolving the compilation error. |

</details>

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Build as mvn test
    participant Test as SearchIndexUtilsTest
    participant JsonUtils as org.openmetadata.schema.utils.JsonUtils

    Note over Build,JsonUtils: Before fix (1.13 backport)
    Build->>Test: compile SearchIndexUtilsTest.java
    Test-->>Build: ❌ cannot find symbol: JsonUtils (line 457)

    Note over Build,JsonUtils: After fix
    Build->>Test: compile SearchIndexUtilsTest.java
    Test->>JsonUtils: import resolved ✅
    Build->>Test: "mvn test -Dtest=SearchIndexUtilsTest"
    Test->>JsonUtils: JsonUtils.pojoToJson(...)
    JsonUtils-->>Test: JSON string
    Test-->>Build: Tests run: 11, Failures: 0, Errors: 0 ✅
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Build as mvn test
    participant Test as SearchIndexUtilsTest
    participant JsonUtils as org.openmetadata.schema.utils.JsonUtils

    Note over Build,JsonUtils: Before fix (1.13 backport)
    Build->>Test: compile SearchIndexUtilsTest.java
    Test-->>Build: ❌ cannot find symbol: JsonUtils (line 457)

    Note over Build,JsonUtils: After fix
    Build->>Test: compile SearchIndexUtilsTest.java
    Test->>JsonUtils: import resolved ✅
    Build->>Test: "mvn test -Dtest=SearchIndexUtilsTest"
    Test->>JsonUtils: JsonUtils.pojoToJson(...)
    JsonUtils-->>Test: JSON string
    Test-->>Build: Tests run: 11, Failures: 0, Errors: 0 ✅
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(test): add missing JsonUtils import ..."](https://github.com/open-metadata/openmetadata/commit/4a62cfe1b0cbd90cc878fd074e84eff616ff37ac) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39057300)</sub>

<!-- /greptile_comment -->