### PR TITLE
fix(test): restore dropped JsonUtils import in SearchIndexUtilsTest (1.13)

### DIFF
--- a/openmetadata-service/src/test/java/org/openmetadata/service/search/SearchIndexUtilsTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/search/SearchIndexUtilsTest.java
@@ -26,6 +26,7 @@ import org.openmetadata.schema.type.EntityReference;
 import org.openmetadata.schema.type.TagLabel;
 import org.openmetadata.schema.type.change.ChangeSource;
 import org.openmetadata.schema.type.change.ChangeSummary;
+import org.openmetadata.schema.utils.JsonUtils;
 import org.openmetadata.service.TypeRegistry;
 
 class SearchIndexUtilsTest {


### PR DESCRIPTION
## Problem

The 1.13 branch `testCompile` is broken:

```
SearchIndexUtilsTest.java:[457,18] cannot find symbol
  symbol:   variable JsonUtils
SearchIndexUtilsTest.java:[462,17] cannot find symbol
SearchIndexUtilsTest.java:[470,19] cannot find symbol
```

## Root cause

Commit `391b126` (PR #29298, the 1.13 backport of #29212 "cap oversized dataModel column tree at index time") added `JsonUtils.pojoToJson(...)` calls to `SearchIndexUtilsTest` at lines 457/462/470, but the cherry-pick **dropped the `import org.openmetadata.schema.utils.JsonUtils;`** line. The compiler reports `symbol: variable JsonUtils` — an unresolved identifier, i.e. a missing import (not a wrong-package error).

On 1.13, `JsonUtils` lives at `org.openmetadata.schema.utils.JsonUtils`; the production `SearchIndexUtils.java` imports it correctly — only the test lost it in the merge.

## Fix

Re-add the single missing import (placed in google-java-format order, `schema.*` before `service.*`). This is the only error CI reported, so it fully restores the build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR restores a single missing import in `SearchIndexUtilsTest.java` that was dropped during the cherry-pick of PR #29298 onto the 1.13 branch, causing a `testCompile` failure.

- Adds `import org.openmetadata.schema.utils.JsonUtils;` back to the test file, placed in correct google-java-format order between `schema.type.*` and `service.*` imports.
- The import is required by three `JsonUtils.pojoToJson(...)` call sites introduced in the backport at lines 457/462/470.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Single-line import restoration in a test file; does not touch production code and directly unbreaks the 1.13 branch build.

The change is a one-line import addition to a test file, addressing an exact compiler error caused by a missed line during cherry-pick. Import placement is correct per google-java-format ordering, and the import matches the package used in production code on the same branch.

No files require special attention.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-service/src/test/java/org/openmetadata/service/search/SearchIndexUtilsTest.java | Adds the missing `org.openmetadata.schema.utils.JsonUtils` import that was dropped during the 1.13 cherry-pick; restores testCompile with no other changes. |

</details>

</details>

<details open><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["PR #29212 (main)\ncap oversized dataModel column tree"] -->|backport| B["PR #29298 (1.13)\ncherry-pick"]
    B -->|"cherry-pick dropped\nJsonUtils import"| C["SearchIndexUtilsTest.java\nmissing import ❌"]
    C -->|"testCompile failure\n(symbol: variable JsonUtils)"| D["CI broken on 1.13"]
    E["PR #29318 (this PR)\nre-add import"] -->|fixes| C
    E --> F["SearchIndexUtilsTest.java\nimport restored ✅"]
    F --> G["CI passes on 1.13"]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["PR #29212 (main)\ncap oversized dataModel column tree"] -->|backport| B["PR #29298 (1.13)\ncherry-pick"]
    B -->|"cherry-pick dropped\nJsonUtils import"| C["SearchIndexUtilsTest.java\nmissing import ❌"]
    C -->|"testCompile failure\n(symbol: variable JsonUtils)"| D["CI broken on 1.13"]
    E["PR #29318 (this PR)\nre-add import"] -->|fixes| C
    E --> F["SearchIndexUtilsTest.java\nimport restored ✅"]
    F --> G["CI passes on 1.13"]
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(test): restore dropped JsonUtils imp..."](https://github.com/open-metadata/openmetadata/commit/15b7e76b5a127f92ce4f9dd29a7167e41cdb8af9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39058035)</sub>

<!-- /greptile_comment -->