### PR TITLE
fix domain isolation spec failure

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DomainIsolation/DomainDropdownIsolation.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DomainIsolation/DomainDropdownIsolation.spec.ts
@@ -48,7 +48,7 @@ const test = base.extend<{ adminPage: Page; restrictedUserPage: Page }>({
 
 const openDomainDropdown = async (page: Page) => {
   await redirectToHomePage(page);
-  await page.getByTestId('domain-dropdown').click();
+  await page.getByTestId('domain-selector').click();
   await page
     .getByTestId('domain-selectable-tree')
     .waitFor({ state: 'visible' });

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DomainIsolation/DomainLineageIsolation.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DomainIsolation/DomainLineageIsolation.spec.ts
@@ -10,7 +10,7 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-import { test as base, expect, Page } from '@playwright/test';
+import { expect, Page, test as base } from '@playwright/test';
 import { Domain } from '../../../support/domain/Domain';
 import { TableClass } from '../../../support/entity/TableClass';
 import { UserClass } from '../../../support/user/UserClass';

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DomainIsolation/DomainLineageIsolation.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DomainIsolation/DomainLineageIsolation.spec.ts
@@ -10,21 +10,21 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-import { expect, Page, test as base } from '@playwright/test';
+import { test as base, expect, Page } from '@playwright/test';
 import { Domain } from '../../../support/domain/Domain';
 import { TableClass } from '../../../support/entity/TableClass';
 import { UserClass } from '../../../support/user/UserClass';
 import { performAdminLogin } from '../../../utils/admin';
 import {
+  assignDomainOnlyAccess,
+  assignDomainToTable,
+  safeDelete,
+} from '../../../utils/domainIsolationUtils';
+import {
   connectEdgeBetweenNodesViaAPI,
   visitLineageTab,
 } from '../../../utils/lineage';
 import { enableDisableSearchRBAC } from '../../../utils/searchRBAC';
-import {
-  assignDomainOnlyAccess,
-  assignDomainToTable,
-  safeDelete,
-} from './domainIsolationUtils';
 
 // Issue #24180 — lineage search is RBAC-gated by the global `enableAccessControl` setting. With it
 // on, the lineage graph for a user holding the seeded DomainOnlyAccessRole must prune nodes that

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DomainIsolation/DomainListingIsolation.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DomainIsolation/DomainListingIsolation.spec.ts
@@ -10,16 +10,19 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-import { expect, Page, test as base } from '@playwright/test';
+import { test as base, expect, Page } from '@playwright/test';
 import { SidebarItem } from '../../../constant/sidebar';
 import { Domain } from '../../../support/domain/Domain';
 import { UserClass } from '../../../support/user/UserClass';
 import { performAdminLogin } from '../../../utils/admin';
 import { redirectToHomePage } from '../../../utils/common';
+import {
+  assignDomainOnlyAccess,
+  safeDelete,
+} from '../../../utils/domainIsolationUtils';
 import { waitForAllLoadersToDisappear } from '../../../utils/entity';
 import { enableDisableSearchRBAC } from '../../../utils/searchRBAC';
 import { sidebarClick } from '../../../utils/sidebar';
-import { assignDomainOnlyAccess, safeDelete } from './domainIsolationUtils';
 
 // Issue #24180 — the Domains listing page is driven by the `index=domain` search query, which is
 // RBAC-gated by the seeded DomainOnlyAccessRole. A restricted user must only see the domain cards

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DomainIsolation/DomainListingIsolation.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DomainIsolation/DomainListingIsolation.spec.ts
@@ -10,7 +10,7 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-import { test as base, expect, Page } from '@playwright/test';
+import { expect, Page, test as base } from '@playwright/test';
 import { SidebarItem } from '../../../constant/sidebar';
 import { Domain } from '../../../support/domain/Domain';
 import { UserClass } from '../../../support/user/UserClass';

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DomainIsolation/DomainSearchIsolation.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DomainIsolation/DomainSearchIsolation.spec.ts
@@ -10,22 +10,18 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-import { Page, test as base } from '@playwright/test';
+import { expect, Page, test as base } from '@playwright/test';
 import { Domain } from '../../../support/domain/Domain';
 import { TableClass } from '../../../support/entity/TableClass';
 import { UserClass } from '../../../support/user/UserClass';
 import { performAdminLogin } from '../../../utils/admin';
-import { redirectToHomePage } from '../../../utils/common';
+import { getApiContext } from '../../../utils/common';
 import {
   assignDomainOnlyAccess,
   assignDomainToTable,
   safeDelete,
 } from '../../../utils/domainIsolationUtils';
-import {
-  enableDisableSearchRBAC,
-  searchForEntityShouldWork,
-  searchForEntityShouldWorkShowNoResult,
-} from '../../../utils/searchRBAC';
+import { enableDisableSearchRBAC } from '../../../utils/searchRBAC';
 
 // Issue #24180 — with the global `enableAccessControl` search setting on, a user holding the
 // seeded DomainOnlyAccessRole can only discover (via navbar search / explore) assets in their
@@ -76,8 +72,35 @@ const test = base.extend<{
 const fqnOf = (table: TableClass) =>
   table.entityResponseData?.fullyQualifiedName ?? '';
 
-const displayNameOf = (table: TableClass) =>
-  table.entityResponseData?.displayName ?? '';
+/**
+ * Runs the global `/api/v1/search/query` as the logged-in user and returns the serialized hits.
+ * With search RBAC (`enableAccessControl`) on, the backend restricts hits to the user's accessible
+ * domains plus domainless assets — which is exactly the isolation we assert on. We assert at the
+ * search-API layer (through the user's own session) because the redesigned landing page scopes its
+ * search box to the user's active domain, which a restricted user cannot widen to "All Domains".
+ */
+const searchHitsAsUser = async (
+  page: Page,
+  table: TableClass
+): Promise<string> => {
+  const { apiContext, afterAction } = await getApiContext(page);
+
+  try {
+    const response = await apiContext.get('/api/v1/search/query', {
+      params: {
+        q: table.entityResponseData?.name ?? '',
+        index: 'dataAsset',
+        from: 0,
+        size: 50,
+      },
+    });
+    const json = await response.json();
+
+    return JSON.stringify(json?.hits?.hits ?? []);
+  } finally {
+    await afterAction();
+  }
+};
 
 test.describe('Domain isolation - search and explore @domain-isolation', () => {
   test.slow(true);
@@ -142,59 +165,41 @@ test.describe('Domain isolation - search and explore @domain-isolation', () => {
   test('userA finds tenantA and domainless tables but not tenantB', async ({
     userAPage,
   }) => {
-    await redirectToHomePage(userAPage);
-
-    await searchForEntityShouldWork(
-      fqnOf(tableA),
-      displayNameOf(tableA),
-      userAPage
-    );
-    await searchForEntityShouldWork(
-      fqnOf(tableNoDomain),
-      displayNameOf(tableNoDomain),
-      userAPage
-    );
-    await searchForEntityShouldWorkShowNoResult(
-      fqnOf(tableB),
-      displayNameOf(tableB),
-      userAPage
-    );
+    await expect
+      .poll(() => searchHitsAsUser(userAPage, tableA), { timeout: 30_000 })
+      .toContain(fqnOf(tableA));
+    await expect
+      .poll(() => searchHitsAsUser(userAPage, tableNoDomain), {
+        timeout: 30_000,
+      })
+      .toContain(fqnOf(tableNoDomain));
+    await expect
+      .poll(() => searchHitsAsUser(userAPage, tableB), { timeout: 30_000 })
+      .not.toContain(fqnOf(tableB));
   });
 
   test('userB finds tenantB and domainless tables but not tenantA', async ({
     userBPage,
   }) => {
-    await redirectToHomePage(userBPage);
-
-    await searchForEntityShouldWork(
-      fqnOf(tableB),
-      displayNameOf(tableB),
-      userBPage
-    );
-    await searchForEntityShouldWork(
-      fqnOf(tableNoDomain),
-      displayNameOf(tableNoDomain),
-      userBPage
-    );
-    await searchForEntityShouldWorkShowNoResult(
-      fqnOf(tableA),
-      displayNameOf(tableA),
-      userBPage
-    );
+    await expect
+      .poll(() => searchHitsAsUser(userBPage, tableB), { timeout: 30_000 })
+      .toContain(fqnOf(tableB));
+    await expect
+      .poll(() => searchHitsAsUser(userBPage, tableNoDomain), {
+        timeout: 30_000,
+      })
+      .toContain(fqnOf(tableNoDomain));
+    await expect
+      .poll(() => searchHitsAsUser(userBPage, tableA), { timeout: 30_000 })
+      .not.toContain(fqnOf(tableA));
   });
 
   test('admin finds tables from both tenants', async ({ adminPage }) => {
-    await redirectToHomePage(adminPage);
-
-    await searchForEntityShouldWork(
-      fqnOf(tableA),
-      displayNameOf(tableA),
-      adminPage
-    );
-    await searchForEntityShouldWork(
-      fqnOf(tableB),
-      displayNameOf(tableB),
-      adminPage
-    );
+    await expect
+      .poll(() => searchHitsAsUser(adminPage, tableA), { timeout: 30_000 })
+      .toContain(fqnOf(tableA));
+    await expect
+      .poll(() => searchHitsAsUser(adminPage, tableB), { timeout: 30_000 })
+      .toContain(fqnOf(tableB));
   });
 });

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DomainIsolation/DomainSearchIsolation.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DomainIsolation/DomainSearchIsolation.spec.ts
@@ -17,15 +17,15 @@ import { UserClass } from '../../../support/user/UserClass';
 import { performAdminLogin } from '../../../utils/admin';
 import { redirectToHomePage } from '../../../utils/common';
 import {
+  assignDomainOnlyAccess,
+  assignDomainToTable,
+  safeDelete,
+} from '../../../utils/domainIsolationUtils';
+import {
   enableDisableSearchRBAC,
   searchForEntityShouldWork,
   searchForEntityShouldWorkShowNoResult,
 } from '../../../utils/searchRBAC';
-import {
-  assignDomainOnlyAccess,
-  assignDomainToTable,
-  safeDelete,
-} from './domainIsolationUtils';
 
 // Issue #24180 — with the global `enableAccessControl` search setting on, a user holding the
 // seeded DomainOnlyAccessRole can only discover (via navbar search / explore) assets in their

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DomainIsolation/DomainTaskIsolation.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DomainIsolation/DomainTaskIsolation.spec.ts
@@ -10,7 +10,7 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-import { expect, Page, test as base } from '@playwright/test';
+import { test as base, expect, Page } from '@playwright/test';
 import { Domain } from '../../../support/domain/Domain';
 import { TableClass } from '../../../support/entity/TableClass';
 import { UserClass } from '../../../support/user/UserClass';
@@ -20,7 +20,7 @@ import {
   assignDomainOnlyAccess,
   assignDomainToTable,
   safeDelete,
-} from './domainIsolationUtils';
+} from '../../../utils/domainIsolationUtils';
 
 // Issue #24180 — a user holding the seeded DomainOnlyAccessRole must only see tasks about entities
 // in their accessible domains. Task isolation is role-based (EntityUtil.addDomainQueryParam +

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DomainIsolation/DomainTaskIsolation.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DomainIsolation/DomainTaskIsolation.spec.ts
@@ -10,12 +10,12 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-import { test as base, expect, Page } from '@playwright/test';
+import { expect, Page, test as base } from '@playwright/test';
 import { Domain } from '../../../support/domain/Domain';
 import { TableClass } from '../../../support/entity/TableClass';
 import { UserClass } from '../../../support/user/UserClass';
 import { performAdminLogin } from '../../../utils/admin';
-import { redirectToHomePage } from '../../../utils/common';
+import { getApiContext } from '../../../utils/common';
 import {
   assignDomainOnlyAccess,
   assignDomainToTable,
@@ -71,19 +71,29 @@ const fqnOf = (table: TableClass) =>
   table.entityResponseData?.fullyQualifiedName ?? '';
 
 /**
- * Lands on the home page (which renders the "My Tasks" feed widget), captures the `/api/v1/tasks`
- * list response the widget fires, and returns the FQNs referenced by the returned tasks.
+ * Queries the `/api/v1/tasks` list endpoint as the logged-in user, scoped to a single table via the
+ * `aboutEntity` filter. The endpoint applies role-based domain scoping (TaskResource.listInternal),
+ * so a user only gets the task back when the table's domain is accessible to them — which is exactly
+ * the isolation we assert on. Scoping by `aboutEntity` (each table FQN is unique per run) keeps the
+ * assertion immune to other tasks accumulating on the shared server. We drive it through the user's
+ * own session (instead of the home page) because the redesigned landing page no longer renders a
+ * "My Tasks" widget by default.
  */
-const taskAboutFqns = async (page: Page): Promise<string> => {
-  const responsePromise = page.waitForResponse(
-    (response) =>
-      response.url().includes('/api/v1/tasks') &&
-      response.request().method() === 'GET'
-  );
-  await redirectToHomePage(page);
-  const response = await responsePromise;
+const tasksAboutTable = async (
+  page: Page,
+  table: TableClass
+): Promise<string> => {
+  const { apiContext, afterAction } = await getApiContext(page);
 
-  return JSON.stringify(await response.json());
+  try {
+    const response = await apiContext.get('/api/v1/tasks', {
+      params: { aboutEntity: fqnOf(table), fields: 'about', limit: 50 },
+    });
+
+    return JSON.stringify(await response.json());
+  } finally {
+    await afterAction();
+  }
 };
 
 test.describe('Domain isolation - tasks @domain-isolation', () => {
@@ -158,23 +168,21 @@ test.describe('Domain isolation - tasks @domain-isolation', () => {
   });
 
   test('userA sees only their own-domain task', async ({ userAPage }) => {
-    const tasks = await taskAboutFqns(userAPage);
-
-    expect(tasks).toContain(fqnOf(tableA));
-    expect(tasks).not.toContain(fqnOf(tableB));
+    expect(await tasksAboutTable(userAPage, tableA)).toContain(fqnOf(tableA));
+    expect(await tasksAboutTable(userAPage, tableB)).not.toContain(
+      fqnOf(tableB)
+    );
   });
 
   test('userB sees only their own-domain task', async ({ userBPage }) => {
-    const tasks = await taskAboutFqns(userBPage);
-
-    expect(tasks).toContain(fqnOf(tableB));
-    expect(tasks).not.toContain(fqnOf(tableA));
+    expect(await tasksAboutTable(userBPage, tableB)).toContain(fqnOf(tableB));
+    expect(await tasksAboutTable(userBPage, tableA)).not.toContain(
+      fqnOf(tableA)
+    );
   });
 
   test('admin sees tasks from both domains', async ({ adminPage }) => {
-    const tasks = await taskAboutFqns(adminPage);
-
-    expect(tasks).toContain(fqnOf(tableA));
-    expect(tasks).toContain(fqnOf(tableB));
+    expect(await tasksAboutTable(adminPage, tableA)).toContain(fqnOf(tableA));
+    expect(await tasksAboutTable(adminPage, tableB)).toContain(fqnOf(tableB));
   });
 });

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/domainIsolationUtils.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/domainIsolationUtils.ts
@@ -11,8 +11,8 @@
  *  limitations under the License.
  */
 import { APIRequestContext } from '@playwright/test';
-import { Domain } from '../../../support/domain/Domain';
-import { UserClass } from '../../../support/user/UserClass';
+import { Domain } from '../support/domain/Domain';
+import { UserClass } from '../support/user/UserClass';
 
 // Issue #24180 — the seeded DomainOnlyAccessRole isolates a user to their assigned
 // domains (plus sub-domains and domainless entities). These helpers centralise the

--- a/openmetadata-ui/src/main/resources/ui/src/components/MyData/CustomizableComponents/CustomiseLandingPageHeader/CustomiseLandingPageHeader.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/MyData/CustomizableComponents/CustomiseLandingPageHeader/CustomiseLandingPageHeader.tsx
@@ -78,8 +78,12 @@ const CustomiseLandingPageHeader = ({
   const { t } = useTranslation();
   const navigate = useNavigate();
   const { currentUser, applicationConfig } = useApplicationStore();
-  const { activeDomain, activeDomainEntityRef, updateActiveDomain } =
-    useDomainStore();
+  const {
+    activeDomain,
+    activeDomainEntityRef,
+    updateActiveDomain,
+    isDomainRestricted,
+  } = useDomainStore();
   const [showCustomiseHomeModal, setShowCustomiseHomeModal] = useState(false);
   const [isDomainDropdownOpen, setIsDomainDropdownOpen] = useState(false);
   // Internal fallback state — only used when the parent doesn't pass announcements through.
@@ -227,7 +231,6 @@ const CustomiseLandingPageHeader = ({
               <CustomiseSearchBar disabled={!onHomePage} />
               <DomainSelectableList
                 hasPermission
-                showAllDomains
                 disabled={!onHomePage}
                 popoverProps={{
                   open: isDomainDropdownOpen,
@@ -236,6 +239,7 @@ const CustomiseLandingPageHeader = ({
                   },
                 }}
                 selectedDomain={activeDomainEntityRef}
+                showAllDomains={!isDomainRestricted}
                 wrapInButton={false}
                 onCancel={() => setIsDomainDropdownOpen(false)}
                 onUpdate={handleDomainChange}>


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:

Fixes #<issue-number>
<!--
Linking an issue is REQUIRED. Replace <issue-number> with the GitHub issue number this PR addresses
(e.g., `Fixes #12345`). GitHub will auto-link it. If no issue exists, please open one first so the
problem and design can be discussed before review.
-->

<!--
Short blurb explaining:
- What changes did you make?
- Why did you make them?
-->

I worked on ... because ...

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### High-level design:
<!--
REQUIRED for large PRs (new features, refactors, breaking changes, or anything touching >5 files).
Skip for small bug fixes and trivial changes.

Cover:
- Architecture / approach you took and why
- Key components or files added/changed and how they interact
- Alternatives considered and why you rejected them
- Any migration, backward-compatibility, or rollout concerns
- Diagrams or links to design docs / RFCs if available
-->

N/A — small change. <!-- Or fill in the design above -->

#
### Tests:

#### Use cases covered
<!--
List the user-visible scenarios this PR exercises. Example:
- User with Admin role can create a Glossary Term with a parent term
- Ingestion run for Snowflake correctly extracts row counts for partitioned tables
-->

#### Unit tests
<!--
- [ ] I added unit tests for the new/changed logic.
- Files added/updated:
- Coverage on changed classes (run `mvn jacoco:report` for backend, `yarn test:coverage` for UI,
  `make unit_ingestion` for ingestion). Target is 90% line coverage on changed classes.
- Coverage %: <e.g., 92% on EntityRepository.java>
-->

#### Backend integration tests
<!--
- [ ] I added integration tests in `openmetadata-integration-tests/` for new/changed API endpoints.
- [ ] Not applicable (no backend API changes).
- Files added/updated:
-->

#### Ingestion integration tests
<!--
- [ ] I added/updated ingestion integration tests for connector changes.
- [ ] Not applicable (no ingestion changes).
- Files added/updated:
-->

#### Playwright (UI) tests
<!--
- [ ] I added Playwright E2E tests under `openmetadata-ui/.../ui/playwright/` for UI changes.
- [ ] Not applicable (no UI changes).
- Files added/updated:
-->

#### Manual testing performed
<!--
List the manual test steps you performed before requesting review. Example:
1. Started local stack via `./docker/run_local_docker.sh -m ui -d mysql`
2. Logged in as admin, created entity X, verified Y appears in the UI
3. Triggered ingestion for Snowflake source, confirmed lineage edges in the explore page
-->

#
### UI screen recording / screenshots:
<!--
REQUIRED for any PR that changes the UI. Drag-and-drop a short screen recording (.mov / .mp4 / .gif)
demonstrating the change end-to-end, plus before/after screenshots where relevant.
Mark "Not applicable" if there are no UI changes.
-->

Not applicable. <!-- Or attach recording/screenshots above -->

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.
- [ ] For UI changes: I attached a screen recording and/or screenshots above.
- [ ] I have added tests (unit / integration / Playwright as applicable) and listed them above.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->

----
## Summary by Gitar

- **UI enhancements:**
  - Updated `CustomiseLandingPageHeader` to handle domain restriction logic by injecting `isDomainRestricted` from `useDomainStore`.
  - Adjusted `DomainSelectableList` in `CustomiseLandingPageHeader` to dynamically toggle `showAllDomains` based on the user's restriction status.
- **Refactored Playwright specs:**
  - Moved `domainIsolationUtils.ts` to the shared `playwright/utils/` directory to decouple it from specific feature folders.
  - Updated all domain isolation tests to directly query API endpoints (`/api/v1/search/query` and `/api/v1/tasks`) instead of relying on fragile UI navigation to the homepage.
  - Standardized domain dropdown locator in `DomainDropdownIsolation.spec.ts` from `domain-dropdown` to `domain-selector`.

<sub>This will update automatically on new commits.</sub>

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes flaky domain isolation Playwright specs that broke after the landing page redesign removed the "My Tasks" widget and scoped the search bar to the user's active domain, making UI-based test flows unreliable for restricted users.

- **Spec refactor (Search & Task isolation)**: Tests now call the backend APIs directly (`/api/v1/search/query` and `/api/v1/tasks?aboutEntity=…`) via the user's own authenticated session instead of navigating the home page UI. The search tests additionally use `expect.poll` to tolerate search-index lag.
- **Utility file move**: `domainIsolationUtils.ts` is relocated from the feature-specific `DomainIsolation/` folder to the shared `playwright/utils/` directory, making it reusable across spec files with updated relative imports.
- **Component fix**: `CustomiseLandingPageHeader` now reads `isDomainRestricted` from `useDomainStore` and passes `showAllDomains={!isDomainRestricted}` to `DomainSelectableList`, preventing restricted users from seeing domains outside their assignment in the domain picker.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — all changes are targeted fixes for broken spec selectors and fragile UI-dependent test flows, plus a correct domain restriction gate on the landing page header.

The spec changes replace brittle home-page navigation with direct authenticated API calls, which is a straightforward stabilization. The component change correctly reads an existing store value and passes it as a boolean prop — the logic is simple and invertible. No new API surfaces, no data-model changes, no shared infrastructure touched.

No files require special attention.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-ui/src/main/resources/ui/src/components/MyData/CustomizableComponents/CustomiseLandingPageHeader/CustomiseLandingPageHeader.tsx | Reads isDomainRestricted from useDomainStore and passes showAllDomains={!isDomainRestricted} to DomainSelectableList; correctly hides all-domain view for restricted users. |
| openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DomainIsolation/DomainSearchIsolation.spec.ts | Refactored search isolation tests to call /api/v1/search/query directly with expect.poll, decoupling from fragile landing page UI. Logic is correct. |
| openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DomainIsolation/DomainTaskIsolation.spec.ts | Refactored task isolation tests to call /api/v1/tasks?aboutEntity= directly; correctly scopes assertions per table FQN. Logic is sound. |
| openmetadata-ui/src/main/resources/ui/playwright/utils/domainIsolationUtils.ts | Utility file moved from feature folder to shared utils; only relative import paths were updated. No functional changes. |
| openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DomainIsolation/DomainDropdownIsolation.spec.ts | One-line selector fix: domain-dropdown → domain-selector, matching the current data-testid on the component. |

</details>

</details>

<details open><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Domain Isolation Specs] --> B{Test Strategy}
    B -->|Before: UI Navigation| C[redirectToHomePage then intercept network]
    B -->|After: Direct API| D[getApiContext from page session]

    D --> E[Search: GET /api/v1/search/query]
    D --> F[Tasks: GET /api/v1/tasks with aboutEntity filter]

    E --> G[expect.poll with 30s timeout handles index lag]
    F --> H[Direct expect - tasks are not search-indexed]

    G --> I{Backend RBAC applied}
    H --> I

    I -->|Restricted user| J[Returns only own-domain assets]
    I -->|Admin user| K[Returns assets from all domains]

    subgraph ComponentFix
        L[CustomiseLandingPageHeader]
        L --> M{isDomainRestricted from useDomainStore}
        M -->|true| N[showAllDomains equals false]
        M -->|false| O[showAllDomains equals true]
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Domain Isolation Specs] --> B{Test Strategy}
    B -->|Before: UI Navigation| C[redirectToHomePage then intercept network]
    B -->|After: Direct API| D[getApiContext from page session]

    D --> E[Search: GET /api/v1/search/query]
    D --> F[Tasks: GET /api/v1/tasks with aboutEntity filter]

    E --> G[expect.poll with 30s timeout handles index lag]
    F --> H[Direct expect - tasks are not search-indexed]

    G --> I{Backend RBAC applied}
    H --> I

    I -->|Restricted user| J[Returns only own-domain assets]
    I -->|Admin user| K[Returns assets from all domains]

    subgraph ComponentFix
        L[CustomiseLandingPageHeader]
        L --> M{isDomainRestricted from useDomainStore}
        M -->|true| N[showAllDomains equals false]
        M -->|false| O[showAllDomains equals true]
    end
```

</a>
</details>

<sub>Reviews (4): Last reviewed commit: ["Merge remote-tracking branch &#39;origin/fix..."](https://github.com/open-metadata/openmetadata/commit/8f7d80d5b00f5e818597d6d075c3a68d2a6b4494) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39105267)</sub>

<!-- /greptile_comment -->