### PR TITLE
fix(test): align OIDC self-signup tests with UserUtil.getUser (#29189) [1.13]

### DIFF
--- a/openmetadata-service/src/test/java/org/openmetadata/service/security/AuthenticationCodeFlowHandlerTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/security/AuthenticationCodeFlowHandlerTest.java
@@ -13,6 +13,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.verify;
@@ -72,6 +73,7 @@ import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.openmetadata.schema.api.security.AuthenticationConfiguration;
 import org.openmetadata.schema.api.security.AuthorizerConfiguration;
+import org.openmetadata.schema.api.teams.CreateUser;
 import org.openmetadata.schema.auth.JWTAuthMechanism;
 import org.openmetadata.schema.entity.teams.User;
 import org.openmetadata.schema.security.client.OidcClientConfig;
@@ -1141,7 +1143,7 @@ class AuthenticationCodeFlowHandlerTest {
           .thenThrow(EntityNotFoundException.byName("new-user"));
       User draftUser = new User();
       userUtil
-          .when(() -> UserUtil.user("new-user", "example.com", "new-user"))
+          .when(() -> UserUtil.getUser(eq("new-user"), any(CreateUser.class)))
           .thenReturn(draftUser);
       userUtil.when(() -> UserUtil.assignTeamsFromClaim(draftUser, List.of())).thenReturn(false);
       User persistedUser = new User();
@@ -1260,7 +1262,7 @@ class AuthenticationCodeFlowHandlerTest {
           .thenThrow(EntityNotFoundException.byName("gmail-user"));
       User draftUser = new User();
       userUtil
-          .when(() -> UserUtil.user("gmail-user", "gmail.com", "gmail-user"))
+          .when(() -> UserUtil.getUser(eq("gmail-user"), any(CreateUser.class)))
           .thenReturn(draftUser);
       userUtil.when(() -> UserUtil.assignTeamsFromClaim(draftUser, List.of())).thenReturn(false);
       User persistedUser = new User();
@@ -1334,7 +1336,7 @@ class AuthenticationCodeFlowHandlerTest {
           .thenThrow(EntityNotFoundException.byName("gmail-user"));
       User draftUser = new User();
       userUtil
-          .when(() -> UserUtil.user("gmail-user", "gmail.com", "gmail-user"))
+          .when(() -> UserUtil.getUser(eq("gmail-user"), any(CreateUser.class)))
           .thenReturn(draftUser);
       userUtil.when(() -> UserUtil.assignTeamsFromClaim(draftUser, List.of())).thenReturn(false);
       User persistedUser = new User();
@@ -1484,8 +1486,15 @@ class AuthenticationCodeFlowHandlerTest {
   void getOrCreateOidcUser_selfSignup_rejectsDisallowedEmailDomain() throws Exception {
     AuthenticationCodeFlowHandler handler = createSelfSignupHandler(Set.of("allowed.com"));
 
+    // Domain rejection throws before any user is created, so stub only the lookup that gets us into
+    // the self-signup branch — stubbing user creation here would be flagged as UnnecessaryStubbing.
     try (MockedStatic<Entity> mockedEntity = mockStatic(Entity.class)) {
-      stubUserNotFoundAndEchoCreate(mockedEntity);
+      mockedEntity
+          .when(
+              () ->
+                  Entity.getEntityByName(
+                      eq(Entity.USER), anyString(), anyString(), any(Include.class)))
+          .thenThrow(new EntityNotFoundException("user not found"));
 
       AuthenticationException thrown =
           assertThrows(
@@ -1505,7 +1514,9 @@ class AuthenticationCodeFlowHandlerTest {
     AuthorizerConfiguration authzConfig = mock(AuthorizerConfiguration.class);
     when(authzConfig.getAdminPrincipals()).thenReturn(Set.of());
     when(authzConfig.getAllowedEmailRegistrationDomains()).thenReturn(allowedDomains);
-    when(authzConfig.getDefaultOAuthRole()).thenReturn(null);
+    // Role assignment runs only after a user passes domain validation; rejection-path tests never
+    // reach it, so keep this lenient to avoid UnnecessaryStubbing.
+    lenient().when(authzConfig.getDefaultOAuthRole()).thenReturn(null);
 
     AuthenticationCodeFlowHandler handler = newHandler();
     setField(handler, "authenticationConfiguration", authConfig);


### PR DESCRIPTION
## Problem

Four `AuthenticationCodeFlowHandlerTest.getOrCreateOidcUser*` tests fail on the `1.13` base (deterministically, in isolation) — unrelated to any feature PR:

- #29189 changed the OIDC/SAML self-signup path from `UserUtil.user(name, domain, name)` to `UserUtil.getUser(name, CreateUser)` (to persist the mapped email claim), but three tests still mocked the old `UserUtil.user(...)`. The unmocked `UserUtil.getUser` returned `null`, so production's `.withIsAdmin(...)` chain threw `NullPointerException`.
- `getOrCreateOidcUser_selfSignup_rejectsDisallowedEmailDomain` failed with `UnnecessaryStubbing` (strict mocks): the domain-rejection path throws before any user is created, so the shared `stubUserNotFoundAndEchoCreate` helper's user-creation stubs and `getDefaultOAuthRole` were never exercised.

## Fix (test-only)

- Mock `UserUtil.getUser(name, any(CreateUser.class))` to match the #29189 production code.
- In the rejection test, stub only the user lookup that enters the self-signup branch; make `getDefaultOAuthRole` lenient (it's used by the success-path tests, not the rejection path).

No production code changes. `AuthenticationCodeFlowHandlerTest`: **50/50 pass**.

## Not included (separate pre-existing 1.13 base failures)

These also fail on the 1.13 base and need their owners — they are not addressed here:
- `SearchRepositoryBehaviorTest.propagateCertificationTagsCascadesToTableChildren*` (×2): 1.13's `cascadeCertificationToChildren` resolves no child aliases in the test setup (`indexMapping.getChildAliases(clusterAlias)` empty) — a search/certification-cascade test/code divergence vs main.
- `SecurityConfigurationManagerTest.testConfigGettersReturnNullWhenNotInitialized`: flaky (passes in isolation; order/global-state dependent).
- `py-tests` Static Checks: `basedpyright --baselinemode=discard` surfaces **2136** pre-existing baselined type errors across `ingestion/` — a baseline/tooling issue, not a code fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This test-only PR backports a test alignment fix to the `1.13` branch: after PR #29189 changed the OIDC self-signup path to call `UserUtil.getUser(name, CreateUser)` instead of the old `UserUtil.user(name, domain, name)`, four tests in `AuthenticationCodeFlowHandlerTest` were still mocking the removed signature, causing NPEs or `UnnecessaryStubbing` failures.

- Three self-signup success-path tests updated their `MockedStatic<UserUtil>` stubs from `UserUtil.user(...)` to `UserUtil.getUser(eq(name), any(CreateUser.class))`, matching the production call at `AuthenticationCodeFlowHandler.java:943`.
- The domain-rejection test (`getOrCreateOidcUser_selfSignup_rejectsDisallowedEmailDomain`) now stubs only the user-lookup that enters the self-signup branch; user-creation stubs are removed (they were never exercised on the rejection path), and `getDefaultOAuthRole` is made `lenient()` to prevent false `UnnecessaryStubbing` failures from the shared `createSelfSignupHandler` helper.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — all changes are confined to test stubs with no production code modified.

The mocks now exactly mirror what the production method actually calls (`UserUtil.getUser(name, CreateUser)`), confirmed by reading `AuthenticationCodeFlowHandler.java:943`. The domain-rejection test correctly stubs only the lookup used before the domain check fires. No production logic, interfaces, or data paths are touched.

No files require special attention.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-service/src/test/java/org/openmetadata/service/security/AuthenticationCodeFlowHandlerTest.java | Test-only fix: three mocks updated from the removed `UserUtil.user(...)` to the current `UserUtil.getUser(name, CreateUser)`, and the domain-rejection test narrowed to avoid UnnecessaryStubbing; all changes correctly mirror the production code. |

</details>

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Test as Test
    participant Handler as AuthenticationCodeFlowHandler
    participant Entity as Entity (mocked)
    participant UserUtil as UserUtil (mocked)

    Test->>Handler: getOrCreateOidcUser(name, email, claims)
    Handler->>Entity: getEntityByName(USER, name, ...) → EntityNotFoundException
    alt self-signup enabled AND domain allowed
        Handler->>UserUtil: "getUser(name, CreateUser{name,email,isBot=false})"
        UserUtil-->>Handler: draftUser
        Handler->>Handler: draftUser.withIsAdmin(...).withIsEmailVerified(true)
        Handler->>UserUtil: addOrUpdateUser(draftUser)
        UserUtil-->>Handler: persistedUser
        Handler-->>Test: persistedUser
    else domain disallowed
        Handler-->>Test: throws AuthenticationException
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Test as Test
    participant Handler as AuthenticationCodeFlowHandler
    participant Entity as Entity (mocked)
    participant UserUtil as UserUtil (mocked)

    Test->>Handler: getOrCreateOidcUser(name, email, claims)
    Handler->>Entity: getEntityByName(USER, name, ...) → EntityNotFoundException
    alt self-signup enabled AND domain allowed
        Handler->>UserUtil: "getUser(name, CreateUser{name,email,isBot=false})"
        UserUtil-->>Handler: draftUser
        Handler->>Handler: draftUser.withIsAdmin(...).withIsEmailVerified(true)
        Handler->>UserUtil: addOrUpdateUser(draftUser)
        UserUtil-->>Handler: persistedUser
        Handler-->>Test: persistedUser
    else domain disallowed
        Handler-->>Test: throws AuthenticationException
    end
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(test): align OIDC self-signup tests ..."](https://github.com/open-metadata/openmetadata/commit/3789b625fef2019aee24fbcd90524068e7c1115b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39188389)</sub>

<!-- /greptile_comment -->