### PR TITLE
ci: run only changed Playwright specs when PR touches only spec files

### DIFF
--- a/.github/workflows/playwright-postgresql-e2e.yml
+++ b/.github/workflows/playwright-postgresql-e2e.yml
@@ -115,12 +115,12 @@ jobs:
       - name: Get all changed files
         id: all-changes
         if: ${{ github.event_name == 'pull_request_target' }}
-        uses: tj-actions/changed-files@22103cc46bda19c2b464ffe86db46df6922fd323
+        uses: tj-actions/changed-files@9426d40962ed5378910ee2e21d5f8c6fcbf2dd96 # v47.0.6
 
       - name: Get changed runnable spec files
         id: changed-specs
         if: ${{ github.event_name == 'pull_request_target' }}
-        uses: tj-actions/changed-files@22103cc46bda19c2b464ffe86db46df6922fd323
+        uses: tj-actions/changed-files@9426d40962ed5378910ee2e21d5f8c6fcbf2dd96 # v47.0.6
         with:
           path: openmetadata-ui/src/main/resources/ui
           files: |

--- a/.github/workflows/playwright-postgresql-e2e.yml
+++ b/.github/workflows/playwright-postgresql-e2e.yml
@@ -96,8 +96,64 @@ jobs:
           path: openmetadata-dist/target/openmetadata-*.tar.gz
           retention-days: 1
 
+  detect-changes:
+    runs-on: ubuntu-latest
+    if: ${{ !github.event.pull_request.draft && (github.event_name != 'pull_request_target' || github.event.action != 'labeled' || github.event.label.name == 'safe to test') }}
+    outputs:
+      spec_only_mode: ${{ steps.compute.outputs.spec_only_mode }}
+      changed_specs: ${{ steps.compute.outputs.changed_specs }}
+      matrix: ${{ steps.compute.outputs.matrix }}
+    steps:
+      - name: Checkout
+        if: ${{ github.event_name == 'pull_request_target' }}
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
+          filter: blob:none
+
+      - name: Get all changed files
+        id: all-changes
+        if: ${{ github.event_name == 'pull_request_target' }}
+        uses: tj-actions/changed-files@22103cc46bda19c2b464ffe86db46df6922fd323
+
+      - name: Get changed runnable spec files
+        id: changed-specs
+        if: ${{ github.event_name == 'pull_request_target' }}
+        uses: tj-actions/changed-files@22103cc46bda19c2b464ffe86db46df6922fd323
+        with:
+          path: openmetadata-ui/src/main/resources/ui
+          files: |
+            playwright/e2e/**/*.spec.ts
+          files_ignore: |
+            playwright/e2e/**/SystemCertificationTags.spec.ts
+            playwright/e2e/**/IntakeForm.spec.ts
+
+      - name: Compute spec-only mode and matrix
+        id: compute
+        run: |
+          FULL_MATRIX='{"shardIndex":[1,2,3,4,5,6],"shardTotal":[6]}'
+          SPEC_MATRIX='{"shardIndex":[1],"shardTotal":[1]}'
+
+          ALL_FILES="${{ steps.all-changes.outputs.all_changed_files }}"
+          SPEC_FILES="${{ steps.changed-specs.outputs.all_changed_files }}"
+          ALL_COUNT=$(echo "$ALL_FILES" | wc -w)
+          SPEC_COUNT=$(echo "$SPEC_FILES" | wc -w)
+
+          if [ "$SPEC_COUNT" -gt 0 ] && [ "$ALL_COUNT" -eq "$SPEC_COUNT" ]; then
+            echo "spec_only_mode=true" >> "$GITHUB_OUTPUT"
+            echo "changed_specs=$SPEC_FILES" >> "$GITHUB_OUTPUT"
+            echo "matrix=$SPEC_MATRIX" >> "$GITHUB_OUTPUT"
+            echo "Spec-only mode: ${SPEC_COUNT} spec(s) changed"
+          else
+            echo "spec_only_mode=false" >> "$GITHUB_OUTPUT"
+            echo "changed_specs=" >> "$GITHUB_OUTPUT"
+            echo "matrix=$FULL_MATRIX" >> "$GITHUB_OUTPUT"
+            echo "Full suite mode (total=${ALL_COUNT}, runnable-specs=${SPEC_COUNT})"
+          fi
+
   playwright-ci-postgresql:
-    needs: [build]
+    needs: [build, detect-changes]
     runs-on: ubuntu-latest
     if: ${{ !cancelled() && needs.build.result == 'success' }}
     environment: test
@@ -109,9 +165,7 @@ jobs:
       AUTHENTICATION_MAX_ACTIVE_SESSIONS_PER_USER: "10000"
     strategy:
       fail-fast: false
-      matrix:
-        shardIndex: [1, 2, 3, 4, 5, 6]
-        shardTotal: [6]
+      matrix: ${{ fromJSON(needs.detect-changes.outputs.matrix) }}
     steps:
       - name: Free Disk Space (Ubuntu)
         uses: jlumbroso/free-disk-space@main
@@ -156,7 +210,40 @@ jobs:
         id: run-tests
         working-directory: openmetadata-ui/src/main/resources/ui/
         run: |
-          if [ "${{ matrix.shardIndex }}" -eq "1" ]; then
+          SPEC_ONLY="${{ needs.detect-changes.outputs.spec_only_mode }}"
+
+          if [ "$SPEC_ONLY" = "true" ]; then
+            CHANGED_SPECS="${{ needs.detect-changes.outputs.changed_specs }}"
+            echo "🔹 Spec-only mode: running changed specs → ${CHANGED_SPECS}"
+
+            PROJECT_ARGS=""
+
+            # DataAssetRulesEnabled runs standalone; its deps (setup) are resolved automatically
+            if echo "$CHANGED_SPECS" | tr ' ' '\n' | grep -q "DataAssetRulesEnabled\.spec\.ts"; then
+              PROJECT_ARGS="$PROJECT_ARGS --project=DataAssetRulesEnabled"
+            fi
+            # DataAssetRulesDisabled depends on DataAssetRulesEnabled — Playwright resolves this automatically
+            if echo "$CHANGED_SPECS" | tr ' ' '\n' | grep -q "DataAssetRulesDisabled\.spec\.ts"; then
+              PROJECT_ARGS="$PROJECT_ARGS --project=DataAssetRulesDisabled"
+            fi
+            # SearchRBAC depends on the full DataAssetRules chain — Playwright resolves this automatically
+            if echo "$CHANGED_SPECS" | tr ' ' '\n' | grep -q "SearchRBAC\.spec\.ts"; then
+              PROJECT_ARGS="$PROJECT_ARGS --project=SearchRBAC"
+            fi
+            # DomainIsolation uses serial workers and its own testMatch
+            if echo "$CHANGED_SPECS" | tr ' ' '\n' | grep -q "DomainIsolation/"; then
+              PROJECT_ARGS="$PROJECT_ARGS --project=DomainIsolation"
+            fi
+            # Regular chromium specs: anything not in a special-project category
+            if echo "$CHANGED_SPECS" | tr ' ' '\n' | grep -qvE "(DataAssetRulesEnabled\.spec\.ts|DataAssetRulesDisabled\.spec\.ts|SearchRBAC\.spec\.ts|DomainIsolation/)"; then
+              PROJECT_ARGS="$PROJECT_ARGS --project=chromium"
+            fi
+
+            [ -z "$PROJECT_ARGS" ] && PROJECT_ARGS="--project=chromium"
+
+            npx playwright test $PROJECT_ARGS $CHANGED_SPECS
+
+          elif [ "${{ matrix.shardIndex }}" -eq "1" ]; then
             echo "🔹 Running DataAssetRules-only tests on shard 1"
 
             # The testMatch pattern ensures only DataAssetRules*.spec.ts files run

--- a/.github/workflows/playwright-postgresql-e2e.yml
+++ b/.github/workflows/playwright-postgresql-e2e.yml
@@ -131,12 +131,13 @@ jobs:
 
       - name: Compute spec-only mode and matrix
         id: compute
+        env:
+          ALL_FILES: ${{ steps.all-changes.outputs.all_changed_files }}
+          SPEC_FILES: ${{ steps.changed-specs.outputs.all_changed_files }}
         run: |
           FULL_MATRIX='{"shardIndex":[1,2,3,4,5,6],"shardTotal":[6]}'
           SPEC_MATRIX='{"shardIndex":[1],"shardTotal":[1]}'
 
-          ALL_FILES="${{ steps.all-changes.outputs.all_changed_files }}"
-          SPEC_FILES="${{ steps.changed-specs.outputs.all_changed_files }}"
           ALL_COUNT=$(echo "$ALL_FILES" | wc -w)
           SPEC_COUNT=$(echo "$SPEC_FILES" | wc -w)
 
@@ -155,7 +156,7 @@ jobs:
   playwright-ci-postgresql:
     needs: [build, detect-changes]
     runs-on: ubuntu-latest
-    if: ${{ !cancelled() && needs.build.result == 'success' }}
+    if: ${{ !cancelled() && needs.build.result == 'success' && needs.detect-changes.result == 'success' }}
     environment: test
     env:
       # Playwright logs the admin user in many times (performAdminLogin per test, parallel
@@ -209,11 +210,11 @@ jobs:
       - name: Run Playwright tests
         id: run-tests
         working-directory: openmetadata-ui/src/main/resources/ui/
+        env:
+          SPEC_ONLY: ${{ needs.detect-changes.outputs.spec_only_mode }}
+          CHANGED_SPECS: ${{ needs.detect-changes.outputs.changed_specs }}
         run: |
-          SPEC_ONLY="${{ needs.detect-changes.outputs.spec_only_mode }}"
-
           if [ "$SPEC_ONLY" = "true" ]; then
-            CHANGED_SPECS="${{ needs.detect-changes.outputs.changed_specs }}"
             echo "🔹 Spec-only mode: running changed specs → ${CHANGED_SPECS}"
 
             PROJECT_ARGS=""
@@ -234,12 +235,14 @@ jobs:
             if echo "$CHANGED_SPECS" | tr ' ' '\n' | grep -q "DomainIsolation/"; then
               PROJECT_ARGS="$PROJECT_ARGS --project=DomainIsolation"
             fi
-            # Regular chromium specs: anything not in a special-project category
+            # Regular chromium specs: anything not in a special-project category.
+            # Also add Basic because chromium has grepInvert:[@basic], so @basic-tagged tests
+            # in the changed files would be silently skipped without it.
             if echo "$CHANGED_SPECS" | tr ' ' '\n' | grep -qvE "(DataAssetRulesEnabled\.spec\.ts|DataAssetRulesDisabled\.spec\.ts|SearchRBAC\.spec\.ts|DomainIsolation/)"; then
-              PROJECT_ARGS="$PROJECT_ARGS --project=chromium"
+              PROJECT_ARGS="$PROJECT_ARGS --project=chromium --project=Basic"
             fi
 
-            [ -z "$PROJECT_ARGS" ] && PROJECT_ARGS="--project=chromium"
+            [ -z "$PROJECT_ARGS" ] && PROJECT_ARGS="--project=chromium --project=Basic"
 
             npx playwright test $PROJECT_ARGS $CHANGED_SPECS
 


### PR DESCRIPTION
### Describe your changes:

I added a `detect-changes` job to `.github/workflows/playwright-postgresql-e2e.yml` to reduce CI time when a PR only modifies Playwright spec files. Instead of always running the full 6-shard suite, the workflow now detects spec-only PRs and collapses execution to a single shard that runs only the changed specs with the appropriate Playwright projects (routing DataAssetRules, DomainIsolation, SearchRBAC, and regular chromium specs to their correct projects automatically via Playwright's dependency resolution). Full-suite behaviour is preserved for merge_group, workflow_dispatch, non-spec changes, and specs with cross-project dependencies (SystemCertificationTags, IntakeForm).

### Type of change:
- [ ] Bug fix
- [x] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### High-level design:

**`detect-changes` job** (runs in parallel with `build`, completes in ~10s):
- Uses `tj-actions/changed-files@22103cc46bda19c2b464ffe86db46df6922fd323` (same pinned SHA as `ui-checkstyle.yml`) — two steps: one for all changed files (total count), one filtered to isolatable spec files only
- Spec-only mode activates when `SPEC_COUNT > 0 && ALL_COUNT == SPEC_COUNT`; excludes `SystemCertificationTags.spec.ts` and `IntakeForm.spec.ts` (they require the full `chromium` project to run first)
- Outputs a dynamic `matrix` JSON: either `{shardIndex:[1],shardTotal:[1]}` (spec-only) or `{shardIndex:[1,2,3,4,5,6],shardTotal:[6]}` (full), consumed via `fromJSON`

**`playwright-ci-postgresql` job** changes:
- `strategy.matrix` is now `fromJSON(needs.detect-changes.outputs.matrix)` — 1 runner vs 6 for spec-only PRs
- Test step gains a new `SPEC_ONLY` branch that picks `--project=` flags based on which spec files changed; Playwright's built-in `dependencies` config handles prerequisite projects (setup, entity-data-setup, DataAssetRules chain) automatically

#
### Tests:

#### Use cases covered
- PR with only regular `playwright/e2e/**/*.spec.ts` changes → 1 shard, only changed files run with `--project=chromium`
- PR with only `DataAssetRulesEnabled/Disabled` or `SearchRBAC` spec changes → 1 shard, correct project chain selected
- PR with mixed spec + source changes → full 6-shard suite unchanged
- PR with `SystemCertificationTags.spec.ts` or `IntakeForm.spec.ts` changes → full 6-shard suite (complex cross-project deps)
- `merge_group` / `workflow_dispatch` → full 6-shard suite always

#### Unit tests
- [ ] Not applicable (CI workflow change only).

#### Backend integration tests
- [ ] Not applicable (no backend API changes).

#### Ingestion integration tests
- [ ] Not applicable (no ingestion changes).

#### Playwright (UI) tests
- [ ] Not applicable (this PR improves how Playwright tests are triggered, not the tests themselves).

#### Manual testing performed
Reviewed the workflow YAML and Playwright config (`playwright.config.ts`) to verify project dependency chains are correctly handled by Playwright's native `dependencies` field.

#
### UI screen recording / screenshots:

Not applicable.

#
### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.
- [ ] For UI changes: I attached a screen recording and/or screenshots above.
- [ ] I have added tests (unit / integration / Playwright as applicable) and listed them above.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds a `detect-changes` job to `.github/workflows/playwright-postgresql-e2e.yml` that collapses the 6-shard Playwright suite to a single shard running only the changed spec files when a PR touches only spec files, preserving full-suite behavior for `merge_group`, `workflow_dispatch`, and non-spec changes.

- **`detect-changes` job**: compares all-changed-files count against isolatable spec count; emits a dynamic `matrix` JSON (1 shard vs 6) and the list of changed specs consumed downstream.
- **Spec-only execution path**: routes changed specs to the correct Playwright project (`DataAssetRulesEnabled`, `DataAssetRulesDisabled`, `SearchRBAC`, `DomainIsolation`, or `chromium`+`Basic`) by grepping filenames; `SystemCertificationTags` and `IntakeForm` are excluded from spec-only mode because they depend on the full `chromium` run.
- **Guard restored**: `playwright-ci-postgresql` now requires `detect-changes.result == 'success'` in its `if` condition, preventing the job from running with a null matrix if the upstream job fails.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge for the common case; one edge case in the spec-only path leaves SSO spec files unexecuted.

The optimization logic correctly handles the main spec categories and falls back to the full 6-shard suite for merge_group, workflow_dispatch, and mixed changes. The gap is specific: SSOLogin.spec.ts and SSORenewal.spec.ts (under Auth/) are picked up by the changed-specs filter but not matched by any special-project branch, so they land on --project=chromium which excludes **/Auth/** via testIgnore — the tests execute 0 times and CI passes. Merging with this gap means a future PR that touches only SSO specs will get a green check without actually running them.

.github/workflows/playwright-postgresql-e2e.yml — specifically the files_ignore list in the changed-specs step and the project-selection logic in the Run Playwright tests step.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/playwright-postgresql-e2e.yml | Adds detect-changes job for spec-only CI optimization; SSO spec files under Auth/ not excluded from the filter and not handled in spec-only project selection, causing those tests to silently not run. |

</details>

</details>

<details open><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[PR event / merge_group / workflow_dispatch] --> B{detect-changes job}
    B -->|pull_request_target| C[tj-actions/changed-files all files]
    B -->|pull_request_target| D[tj-actions/changed-files spec files only exclude SystemCertificationTags exclude IntakeForm]
    C --> E[compute step ALL_COUNT vs SPEC_COUNT]
    D --> E
    B -->|merge_group / workflow_dispatch| E2[compute step both counts = 0]
    E -->|SPEC_COUNT > 0 AND ALL_COUNT == SPEC_COUNT| F[spec_only_mode=true matrix: 1 shard]
    E -->|otherwise| G[spec_only_mode=false matrix: 6 shards]
    E2 --> G
    F --> H[playwright-ci-postgresql 1 runner]
    G --> I[playwright-ci-postgresql 6 runners]
    H --> J{Project selection by filename grep}
    J -->|DataAssetRulesEnabled| K[--project=DataAssetRulesEnabled]
    J -->|DataAssetRulesDisabled| L[--project=DataAssetRulesDisabled]
    J -->|SearchRBAC| M[--project=SearchRBAC]
    J -->|DomainIsolation/| N[--project=DomainIsolation]
    J -->|other specs| O[--project=chromium --project=Basic]
    J -->|Auth/ specs e.g. SSOLogin| O
    O -->|chromium testIgnore Auth/**| P[0 tests run - silent skip]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[PR event / merge_group / workflow_dispatch] --> B{detect-changes job}
    B -->|pull_request_target| C[tj-actions/changed-files all files]
    B -->|pull_request_target| D[tj-actions/changed-files spec files only exclude SystemCertificationTags exclude IntakeForm]
    C --> E[compute step ALL_COUNT vs SPEC_COUNT]
    D --> E
    B -->|merge_group / workflow_dispatch| E2[compute step both counts = 0]
    E -->|SPEC_COUNT > 0 AND ALL_COUNT == SPEC_COUNT| F[spec_only_mode=true matrix: 1 shard]
    E -->|otherwise| G[spec_only_mode=false matrix: 6 shards]
    E2 --> G
    F --> H[playwright-ci-postgresql 1 runner]
    G --> I[playwright-ci-postgresql 6 runners]
    H --> J{Project selection by filename grep}
    J -->|DataAssetRulesEnabled| K[--project=DataAssetRulesEnabled]
    J -->|DataAssetRulesDisabled| L[--project=DataAssetRulesDisabled]
    J -->|SearchRBAC| M[--project=SearchRBAC]
    J -->|DomainIsolation/| N[--project=DomainIsolation]
    J -->|other specs| O[--project=chromium --project=Basic]
    J -->|Auth/ specs e.g. SSOLogin| O
    O -->|chromium testIgnore Auth/**| P[0 tests run - silent skip]
```

</a>
</details>

<sub>Reviews (3): Last reviewed commit: ["ci: bump tj-actions/changed-files to v47..."](https://github.com/open-metadata/openmetadata/commit/c5341694fa5056d16629c2743581acbdfce19064) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39210220)</sub>

<!-- /greptile_comment -->