### PR TITLE
Fixes #27482: Advanced Search between operator ignores range bounds for number custom properties (1.13)

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/CustomProperties.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/CustomProperties.spec.ts
@@ -956,6 +956,286 @@ ALL_ENTITIES.forEach(({ key, makeInstance }) => {
           ).toBeVisible();
         });
       });
+
+      // #27482 – Regression: between operator was dropping the upper bound
+      if (key === 'entity_table') {
+        test('Number CP between operator sends gte/lte bounds (Issue #27482)', async ({
+          page,
+        }) => {
+          test.slow();
+          const numberPropertyName = `pwNumberBetweenTest${uuid()}`;
+          const assignedValue = '55.7';
+
+          await test.step('Create number custom property and assign value', async () => {
+            await settingClick(
+              page,
+              entity.entityApiType as SettingOptionsType,
+              true
+            );
+
+            await addCustomPropertiesForEntity({
+              page,
+              propertyName: numberPropertyName,
+              customPropertyData: entity,
+              customType: 'Number',
+            });
+
+            await mainEntity.visitEntityPage(page);
+
+            const customPropertyResponse = page.waitForResponse(
+              '/api/v1/metadata/types/name/table?fields=customProperties'
+            );
+            await page.getByTestId('custom_properties').click();
+            await customPropertyResponse;
+
+            await page.locator('.ant-skeleton-active').waitFor({
+              state: 'detached',
+            });
+
+            await setValueForProperty({
+              page,
+              propertyName: numberPropertyName,
+              value: assignedValue,
+              propertyType: 'number',
+              endpoint: EntityTypeEndpoint.Table,
+            });
+          });
+
+          await test.step('between [50, 60]: query_filter must contain gte:50 and lte:60', async () => {
+            await sidebarClick(page, SidebarItem.EXPLORE);
+            await showAdvancedSearchDialog(page);
+
+            await applyCustomPropertyFilter(
+              page,
+              numberPropertyName,
+              'between',
+              CP_RANGE_VALUES.number,
+              'Table'
+            );
+
+            const searchResponse = page.waitForResponse(
+              '/api/v1/search/query?*index=dataAsset*'
+            );
+            await page.getByTestId('apply-btn').click();
+            const res = await searchResponse;
+
+            const url = res.request().url();
+            const params = new URLSearchParams(url.split('?')[1]);
+            const queryFilter = JSON.parse(params.get('query_filter') ?? '{}');
+            const queryFilterStr = JSON.stringify(queryFilter);
+
+            expect(queryFilterStr).toContain('"gte":50');
+            expect(queryFilterStr).toContain('"lte":60');
+
+            await expect(
+              page.getByTestId(
+                `table-data-card_${responseData.fullyQualifiedName ?? ''}`
+              )
+            ).toBeVisible();
+
+            await clearAdvancedSearchFilters(page);
+          });
+
+          await test.step('not_between [1, 5]: query_filter must contain must_not with gte:1 and lte:5', async () => {
+            await sidebarClick(page, SidebarItem.EXPLORE);
+            await showAdvancedSearchDialog(page);
+
+            await applyCustomPropertyFilter(
+              page,
+              numberPropertyName,
+              'not_between',
+              { start: 1, end: 5 },
+              'Table'
+            );
+
+            const searchResponse = page.waitForResponse(
+              '/api/v1/search/query?*index=dataAsset*'
+            );
+            await page.getByTestId('apply-btn').click();
+            const res = await searchResponse;
+
+            const url = res.request().url();
+            const params = new URLSearchParams(url.split('?')[1]);
+            const queryFilter = JSON.parse(params.get('query_filter') ?? '{}');
+            const queryFilterStr = JSON.stringify(queryFilter);
+
+            expect(queryFilterStr).toContain('"must_not"');
+            expect(queryFilterStr).toContain('"gte":1');
+            expect(queryFilterStr).toContain('"lte":5');
+
+            await clearAdvancedSearchFilters(page);
+          });
+
+          await test.step('between [100, 200]: entity with value 55.7 should NOT be visible', async () => {
+            await sidebarClick(page, SidebarItem.EXPLORE);
+            await showAdvancedSearchDialog(page);
+
+            await applyCustomPropertyFilter(
+              page,
+              numberPropertyName,
+              'between',
+              { start: 100, end: 200 },
+              'Table'
+            );
+
+            const searchResponse = page.waitForResponse(
+              '/api/v1/search/query?*index=dataAsset*'
+            );
+            await page.getByTestId('apply-btn').click();
+            await searchResponse;
+
+            await expect(
+              page.getByTestId(
+                `table-data-card_${responseData.fullyQualifiedName ?? ''}`
+              )
+            ).not.toBeVisible();
+
+            await clearAdvancedSearchFilters(page);
+          });
+
+          await test.step('Cleanup', async () => {
+            await settingClick(
+              page,
+              entity.entityApiType as SettingOptionsType,
+              true
+            );
+            await deleteCreatedProperty(page, numberPropertyName);
+          });
+        });
+
+        test('no duplicate card after update', async ({ page }) => {
+          test.slow();
+
+          const propertyName = `pw.edge.update.${uuid()}`;
+
+          await test.step('Create property', async () => {
+            await settingClick(
+              page,
+              entity.entityApiType as SettingOptionsType,
+              true
+            );
+            await addCustomPropertiesForEntity({
+              page,
+              propertyName,
+              customPropertyData: entity,
+              customType: 'String',
+            });
+          });
+
+          await test.step('Set initial value', async () => {
+            await mainEntity.visitEntityPage(page);
+            await waitForAllLoadersToDisappear(page);
+
+            await setValueForProperty({
+              page,
+              propertyName,
+              value: 'initial value',
+              propertyType: 'string',
+              endpoint: EntityTypeEndpoint.Table,
+            });
+
+            await validateValueForProperty({
+              page,
+              propertyName,
+              value: 'initial value',
+              propertyType: 'string',
+            });
+          });
+
+          await test.step('Update value and verify only one card exists', async () => {
+            await setValueForProperty({
+              page,
+              propertyName,
+              value: 'updated value',
+              propertyType: 'string',
+              endpoint: EntityTypeEndpoint.Table,
+            });
+
+            await validateValueForProperty({
+              page,
+              propertyName,
+              value: 'updated value',
+              propertyType: 'string',
+            });
+
+            await expect(
+              page.getByTestId(`custom-property-${propertyName}-card`)
+            ).toHaveCount(1);
+            await expect(
+              page.getByTestId(`custom-property-"${propertyName}"-card`)
+            ).toHaveCount(0);
+          });
+
+          await test.step('Value persists after reload', async () => {
+            await page.reload();
+            await waitForAllLoadersToDisappear(page);
+
+            await validateValueForProperty({
+              page,
+              propertyName,
+              value: 'updated value',
+              propertyType: 'string',
+            });
+
+            await expect(
+              page.getByTestId(`custom-property-${propertyName}-card`)
+            ).toHaveCount(1);
+            await expect(
+              page.getByTestId(`custom-property-"${propertyName}"-card`)
+            ).toHaveCount(0);
+          });
+
+          await test.step('Updated value is searchable via Advanced Search', async () => {
+            await sidebarClick(page, SidebarItem.EXPLORE);
+
+            await showAdvancedSearchDialog(page);
+
+            const ruleLocator = page.locator('.rule').nth(0);
+
+            await selectOption(
+              page,
+              ruleLocator.locator('.rule--field .ant-select'),
+              'Custom Properties',
+              true
+            );
+
+            await selectOption(
+              page,
+              ruleLocator.locator('.rule--field .ant-select'),
+              'Table',
+              true
+            );
+
+            await selectOption(
+              page,
+              ruleLocator.locator('.rule--field .ant-select'),
+              propertyName,
+              true
+            );
+
+            await selectOption(
+              page,
+              ruleLocator.locator('.rule--operator .ant-select'),
+              CONDITIONS_MUST.equalTo.name
+            );
+
+            await ruleLocator
+              .locator('.rule--widget--TEXT input[type="text"]')
+              .fill('updated value');
+
+            await advanceSearchSaveFilter(page, 'updated value');
+
+            await expect(
+              page.getByTestId(
+                `table-data-card_${
+                  (mainEntity as TableClass).entityResponseData
+                    .fullyQualifiedName
+                }`
+              )
+            ).toBeVisible();
+          });
+        });
+      }
     }
 
     // ── Container-specific extra tests ─────────────────────────────────────

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/customPropertyAdvancedSearchUtils.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/customPropertyAdvancedSearchUtils.ts
@@ -278,63 +278,94 @@ export const setupCustomPropertyAdvancedSearchTest = async (
 ) => {
   const { apiContext, afterAction } = await getApiContext(page);
 
-  // Get the metadata types info required to create custom properties
-  const typesInfo = await apiContext.get(
-    '/api/v1/metadata/types?category=field&limit=20'
-  );
+  try {
+    // Get the metadata types info required to create custom properties
+    const typesInfo = await apiContext.get(
+      '/api/v1/metadata/types?category=field&limit=20'
+    );
 
-  // Get the dashboard metadata types info to add custom properties to it
-  const cpMetadataType = await apiContext.get(
-    '/api/v1/metadata/types/name/dashboard?fields=customProperties'
-  );
+    // Get the dashboard metadata types info to add custom properties to it
+    const cpMetadataType = await apiContext.get(
+      '/api/v1/metadata/types/name/dashboard?fields=customProperties'
+    );
 
-  testData.types = (await typesInfo.json()).data;
-  testData.cpMetadataType = await cpMetadataType.json();
+    testData.types = (await typesInfo.json()).data;
+    testData.cpMetadataType = await cpMetadataType.json();
 
-  // Map and prepare the data required for creating custom properties of different types
-  const cpCreationData = getCustomPropertyCreationData(testData.types);
-  testData.createdCPData = Object.values(cpCreationData);
+    // Map and prepare the data required for creating custom properties of different types
+    const cpCreationData = getCustomPropertyCreationData(testData.types);
+    testData.createdCPData = Object.values(cpCreationData);
 
-  // The API calls need to be sequential as the server replaces some types with others
-  // due to simultaneous requests causing conflicts.
-  for (const type of testData.types) {
-    const typeData = cpCreationData[type.name as keyof typeof cpCreationData];
+    // The API calls need to be sequential as the server replaces some types with others
+    // due to simultaneous requests causing conflicts.
+    for (const type of testData.types) {
+      const typeData = cpCreationData[type.name as keyof typeof cpCreationData];
 
-    if (!isUndefined(typeData)) {
-      await apiContext.put(
-        `/api/v1/metadata/types/${testData.cpMetadataType.id}`,
-        {
-          data: typeData,
-        }
-      );
+      if (!isUndefined(typeData)) {
+        await apiContext.put(
+          `/api/v1/metadata/types/${testData.cpMetadataType.id}`,
+          {
+            data: typeData,
+          }
+        );
+      }
     }
-  }
 
-  // Get the custom property to values mapping to add to the dashboard entity
-  const cpValuesData = getCustomPropertyValues(
-    testData.createdCPData,
-    topic1,
-    topic2
-  );
+    // Get the custom property to values mapping to add to the dashboard entity
+    const cpValuesData = getCustomPropertyValues(
+      testData.createdCPData,
+      topic1,
+      topic2
+    );
 
-  // Update the dashboard entity with the created custom property values
-  await apiContext.patch(
-    `/api/v1/dashboards/${dashboard.entityResponseData.id}`,
-    {
-      data: [
-        {
-          op: 'add',
-          path: '/extension',
-          value: cpValuesData,
+    // Update the dashboard entity with the created custom property values
+    await apiContext.patch(
+      `/api/v1/dashboards/${dashboard.entityResponseData.id}`,
+      {
+        data: [
+          {
+            op: 'add',
+            path: '/extension',
+            value: cpValuesData,
+          },
+        ],
+        headers: {
+          'Content-Type': 'application/json-patch+json',
         },
-      ],
-      headers: {
-        'Content-Type': 'application/json-patch+json',
-      },
-    }
-  );
+      }
+    );
 
-  await afterAction();
+    // Wait for the custom properties to be indexed in Elasticsearch
+    const cpName = Object.keys(cpValuesData)[0];
+    await expect(async () => {
+      const searchParams = new URLSearchParams({
+        q: `fullyQualifiedName:"${dashboard.entityResponseData.fullyQualifiedName}"`,
+        index: 'dashboard_search_index',
+      });
+      const res = await apiContext.get(
+        `/api/v1/search/query?${searchParams.toString()}`
+      );
+      const data = await res.json();
+      expect(data.hits.hits.length).toBeGreaterThanOrEqual(1);
+
+      const hit = data.hits.hits.find(
+        (h: {
+          _source: {
+            fullyQualifiedName?: string;
+            extension?: Record<string, unknown>;
+          };
+        }) =>
+          h._source.fullyQualifiedName ===
+          dashboard.entityResponseData.fullyQualifiedName
+      );
+      expect(hit).toBeDefined();
+      const source = hit._source;
+      expect(source.extension).toBeDefined();
+      expect(source.extension[cpName]).toBeDefined();
+    }).toPass({ timeout: 20000 });
+  } finally {
+    await afterAction();
+  }
 };
 
 export const getOperatorLabel = (operator: string): string => {
@@ -488,9 +519,13 @@ export const verifySearchResults = async (
   const dashboardCardSelector = `table-data-card_${dashboardFQN}`;
 
   if (shouldBeVisible) {
-    await expect(page.getByTestId(dashboardCardSelector)).toBeVisible();
+    await expect(page.getByTestId(dashboardCardSelector)).toBeVisible({
+      timeout: 30000,
+    });
   } else {
-    await expect(page.getByTestId(dashboardCardSelector)).not.toBeVisible();
+    await expect(page.getByTestId(dashboardCardSelector)).not.toBeVisible({
+      timeout: 30000,
+    });
   }
 
   if (filterValue) {

--- a/openmetadata-ui/src/main/resources/ui/src/utils/QueryBuilderElasticsearchFormatUtils.js
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/QueryBuilderElasticsearchFormatUtils.js
@@ -412,7 +412,11 @@ function buildNestedTypedQuery(propertyName, nestedField, value, operator) {
   // Build the value query based on operator
   if (isRangeOperator(operator)) {
     const rangeQuery = {};
-    if (operator === 'between' && Array.isArray(value) && value.length >= 2) {
+    if (
+      (operator === 'between' || operator === 'not_between') &&
+      Array.isArray(value) &&
+      value.length >= 2
+    ) {
       rangeQuery.gte = value[0];
       rangeQuery.lte = value[1];
     } else if (operator === 'less') {
@@ -777,6 +781,16 @@ function buildEsRule(fieldName, value, operator, config, valueSrc) {
     return undefined;
   } // rule is not fully entered
 
+  if (
+    (operator === 'between' || operator === 'not_between') &&
+    (!Array.isArray(value) ||
+      value.length < 2 ||
+      value[0] === undefined ||
+      value[1] === undefined)
+  ) {
+    return undefined;
+  }
+
   // Check if field has custom elasticsearch field mapping or handle extension fields
   let actualFieldName = fieldName;
   let isNestedExtensionField = false;
@@ -818,10 +832,26 @@ function buildEsRule(fieldName, value, operator, config, valueSrc) {
       extensionPropertyName
     );
 
+    // For range operators (between / not_between) the value is a two-element
+    // array [from, to]. Pass the full array so buildExtensionQuery can build
+    // a proper gte/lte range query. This is scoped to numeric types where ES
+    // range queries work correctly. Non-numeric types (e.g. dateTime-cp)
+    // store values as formatted strings where ES range comparison is unreliable.
+    const isBetweenOp = op === 'between';
+    const isNumericOmType =
+      omPropertyType === 'integer' ||
+      omPropertyType === 'number' ||
+      omPropertyType === 'timestamp';
+    const extensionValue = hasValue
+      ? isBetweenOp && isNumericOmType
+        ? value
+        : value[0]
+      : null;
+
     return buildExtensionQuery(
       extensionPropertyName,
       entityType,
-      hasValue ? value[0] : null,
+      extensionValue,
       op,
       not,
       omPropertyType

--- a/openmetadata-ui/src/main/resources/ui/src/utils/QueryBuilderElasticsearchFormatUtils.test.js
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/QueryBuilderElasticsearchFormatUtils.test.js
@@ -1,0 +1,91 @@
+/*
+ *  Copyright 2025 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+import { AntdConfig } from '@react-awesome-query-builder/antd';
+import { elasticSearchFormat } from './QueryBuilderElasticsearchFormatUtils';
+
+// Minimal Immutable-compatible tree stub.
+// elasticSearchFormat only calls .get() on the tree and its properties map.
+const makeTree = (operator, value) => ({
+  get(key) {
+    if (key === 'type') {
+      return 'rule';
+    }
+    if (key === 'properties') {
+      return {
+        get(k) {
+          if (k === 'field') {
+            return 'extension.table.myNumber';
+          }
+          if (k === 'operator') {
+            return operator;
+          }
+          if (k === 'value') {
+            return { toJS: () => value };
+          }
+          if (k === 'valueSrc') {
+            return { get: () => 'value' };
+          }
+
+          return undefined;
+        },
+      };
+    }
+
+    return undefined;
+  },
+});
+
+// Extend AntdConfig with extension field metadata so lookupOmPropertyType
+// resolves the OM type, which is required for the scoped between/not_between fix.
+const configWithNumberType = {
+  ...AntdConfig,
+  fields: {
+    ...AntdConfig.fields,
+    extension: {
+      subfields: {
+        table: {
+          subfields: {
+            myNumber: {
+              __omPropertyType: 'number',
+            },
+          },
+        },
+      },
+    },
+  },
+};
+
+describe('elasticSearchFormat – extension number field range operators (Issue #27482)', () => {
+  it('between: should include both gte and lte bounds in the nested range query', () => {
+    const result = JSON.stringify(
+      elasticSearchFormat(makeTree('between', [5, 20]), configWithNumberType)
+    );
+
+    expect(result).toContain('"gte":5');
+    expect(result).toContain('"lte":20');
+  });
+
+  it('not_between: should wrap gte/lte range in a must_not clause', () => {
+    const result = JSON.stringify(
+      elasticSearchFormat(
+        makeTree('not_between', [10, 50]),
+        configWithNumberType
+      )
+    );
+
+    expect(result).toContain('"must_not"');
+    expect(result).toContain('"gte":10');
+    expect(result).toContain('"lte":50');
+  });
+});


### PR DESCRIPTION
Cherry-pick of #27525 (squash commit 4966428efb) into the 1.13 release branch.

Fixes #27482: Advanced Search `between` operator was ignoring the upper range bound for Numeric Custom Properties.

- Scopes the `between` operator fix to numeric custom properties only
- Strictly types ES search hits (zero-`any` policy)
- Removes unreachable dead code
- Adds E2E + unit coverage (scoped to Table entities)

UI-only change. Clean cherry-pick. Verified with `mvn clean install -DskipTests` (all modules) → BUILD SUCCESS.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This cherry-pick onto 1.13 fixes a bug where the Advanced Search `between` operator for numeric custom properties was only sending the lower bound (`gte`) to Elasticsearch, ignoring the upper bound (`lte`), because `value[0]` was always passed instead of the full `[from, to]` array.

- **Core fix** (`QueryBuilderElasticsearchFormatUtils.js`): when `between`/`not_between` is used on an `integer`, `number`, or `timestamp` custom property, the full two-element value array is now forwarded to `buildExtensionQuery`, allowing `buildNestedTypedQuery` to set both `gte` and `lte` on the ES range query. An early-exit guard is also added to silently drop incomplete range rules.
- **Test coverage**: a new unit test file validates both `between` and `not_between` on a synthetic number field; two new E2E tests (scoped to `entity_table`) verify the query-filter URL contains the correct bounds and that a row with value `55.7` is excluded from the `[100, 200]` range.
- **Test infra improvements** (`customPropertyAdvancedSearchUtils.ts`): setup wrapped in `try/finally` so cleanup always runs, a polling wait added for ES indexing after PATCH, and visibility assertion timeouts bumped to 30 s.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; the change is narrowly scoped to numeric custom-property range queries and ships with both unit and E2E coverage.

The logic fix is correct and well-tested. The one open point is that isBetweenOp only explicitly guards op === 'between', trusting that not_between has already been normalised — a safe assumption today but worth hardening as suggested.

QueryBuilderElasticsearchFormatUtils.js — specifically the isBetweenOp guard near line 840.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-ui/src/main/resources/ui/src/utils/QueryBuilderElasticsearchFormatUtils.js | Core fix: passes the full [from, to] value array for between/not_between on numeric custom properties; adds early-exit guard for incomplete range values. One minor defensive fragility: isBetweenOp only explicitly covers 'between', relying on not_between being normalised via reversedOp. |
| openmetadata-ui/src/main/resources/ui/src/utils/QueryBuilderElasticsearchFormatUtils.test.js | New unit test file covering both between and not_between operators on extension number fields; uses a minimal Immutable tree stub and AntdConfig with injected omPropertyType metadata. Coverage is appropriate and assertions are correct. |
| openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/CustomProperties.spec.ts | Adds two E2E tests scoped to Table entities: (1) validates gte/lte bounds appear in the query_filter URL for between and not_between, and that a [100,200] range correctly excludes a row with value 55.7; (2) edge-case regression for duplicate card after update. Tests are well-structured with explicit cleanup. |
| openmetadata-ui/src/main/resources/ui/playwright/utils/customPropertyAdvancedSearchUtils.ts | Wraps setup logic in try/finally so afterAction() always runs on failure; adds a polling wait for ES indexing after PATCH; bumps visibility assertion timeouts to 30 s. All changes improve flake resilience. |

</details>

</details>

<details open><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["buildEsRule(fieldName, value, operator, config)"] --> B{operator == between / not_between?}
    B -- "incomplete value" --> C["return undefined (early exit guard — NEW)"]
    B -- "complete value [from, to]" --> D{isNestedExtensionField?}
    D -- No --> E["standard ES format path"]
    D -- Yes --> F["normalize op via reversedOp\nnot_between → op='between', not=true"]
    F --> G["isBetweenOp = op === 'between'\nisNumericOmType = integer|number|timestamp"]
    G --> H{isBetweenOp AND isNumericOmType?}
    H -- "Yes (FIXED)" --> I["extensionValue = value  ← full [from, to] array"]
    H -- "No (non-numeric types)" --> J["extensionValue = value[0]  ← unchanged behaviour"]
    I --> K["buildExtensionQuery(..., [from,to], 'between', not=true/false, ...)"]
    J --> K
    K --> L["buildNestedTypedQuery → range: { gte: from, lte: to }"]
    L --> M{not == true?}
    M -- Yes --> N["wrap in must_not"]
    M -- No --> O["return range query"]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["buildEsRule(fieldName, value, operator, config)"] --> B{operator == between / not_between?}
    B -- "incomplete value" --> C["return undefined (early exit guard — NEW)"]
    B -- "complete value [from, to]" --> D{isNestedExtensionField?}
    D -- No --> E["standard ES format path"]
    D -- Yes --> F["normalize op via reversedOp\nnot_between → op='between', not=true"]
    F --> G["isBetweenOp = op === 'between'\nisNumericOmType = integer|number|timestamp"]
    G --> H{isBetweenOp AND isNumericOmType?}
    H -- "Yes (FIXED)" --> I["extensionValue = value  ← full [from, to] array"]
    H -- "No (non-numeric types)" --> J["extensionValue = value[0]  ← unchanged behaviour"]
    I --> K["buildExtensionQuery(..., [from,to], 'between', not=true/false, ...)"]
    J --> K
    K --> L["buildNestedTypedQuery → range: { gte: from, lte: to }"]
    L --> M{not == true?}
    M -- Yes --> N["wrap in must_not"]
    M -- No --> O["return range query"]
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(ui): scope between operator fix to n..."](https://github.com/open-metadata/openmetadata/commit/c8595f61370429789078af0d3855a2ae2b5371a1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39216929)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->