### PR TITLE
fix(ingestion): upgrade sudo to patch CVE-2026-35535

### DIFF
--- a/ingestion/Dockerfile
+++ b/ingestion/Dockerfile
@@ -48,7 +48,7 @@ RUN apt-get -qq update \
   # openssh -> 1:9.2p1-2+deb12u10, rsync -> 3.2.7-1+deb12u5).
   # --only-upgrade is a no-op for packages not present in the base image.
   && apt-get -qq install -y --only-upgrade \
-       libgnutls30 libcap2 libcap2-bin openssh-client rsync \
+       libgnutls30 libcap2 libcap2-bin openssh-client rsync sudo \
   && apt-get -qq purge -y \
        'imagemagick*' 'libmagick*' 'graphicsmagick*' \
   && apt-get -qq autoremove -y --purge \

--- a/ingestion/Dockerfile
+++ b/ingestion/Dockerfile
@@ -49,6 +49,7 @@ RUN apt-get -qq update \
   # --only-upgrade is a no-op for packages not present in the base image.
   && apt-get -qq install -y --only-upgrade \
        libgnutls30 libcap2 libcap2-bin openssh-client rsync sudo \
+       libpam0g libpam-modules libpam-modules-bin libpam-runtime \
   && apt-get -qq purge -y \
        'imagemagick*' 'libmagick*' 'graphicsmagick*' \
   && apt-get -qq autoremove -y --purge \

--- a/ingestion/Dockerfile.ci
+++ b/ingestion/Dockerfile.ci
@@ -49,6 +49,7 @@ RUN dpkg --configure -a \
   # --only-upgrade is a no-op for packages not present in the base image.
   && apt-get -qq install -y --only-upgrade \
        libgnutls30 libcap2 libcap2-bin openssh-client rsync sudo \
+       libpam0g libpam-modules libpam-modules-bin libpam-runtime \
   && apt-get -qq purge -y \
        'imagemagick*' 'libmagick*' 'graphicsmagick*' \
   && apt-get -qq autoremove -y --purge \

--- a/ingestion/Dockerfile.ci
+++ b/ingestion/Dockerfile.ci
@@ -48,7 +48,7 @@ RUN dpkg --configure -a \
   # openssh -> 1:9.2p1-2+deb12u10, rsync -> 3.2.7-1+deb12u5).
   # --only-upgrade is a no-op for packages not present in the base image.
   && apt-get -qq install -y --only-upgrade \
-       libgnutls30 libcap2 libcap2-bin openssh-client rsync \
+       libgnutls30 libcap2 libcap2-bin openssh-client rsync sudo \
   && apt-get -qq purge -y \
        'imagemagick*' 'libmagick*' 'graphicsmagick*' \
   && apt-get -qq autoremove -y --purge \

--- a/ingestion/operators/docker/Dockerfile
+++ b/ingestion/operators/docker/Dockerfile
@@ -46,6 +46,7 @@ RUN dpkg --configure -a \
     # --only-upgrade is a no-op for packages not present in the base image.
     && apt-get -qq install -y --only-upgrade \
          libgnutls30 libcap2 libcap2-bin openssh-client rsync sudo \
+         libpam0g libpam-modules libpam-modules-bin libpam-runtime \
     && rm -rf /var/lib/apt/lists/*
 
 # Add updated postgres/redshift dependencies based on libq

--- a/ingestion/operators/docker/Dockerfile
+++ b/ingestion/operators/docker/Dockerfile
@@ -45,7 +45,7 @@ RUN dpkg --configure -a \
     # openssh -> 1:9.2p1-2+deb12u10, rsync -> 3.2.7-1+deb12u5).
     # --only-upgrade is a no-op for packages not present in the base image.
     && apt-get -qq install -y --only-upgrade \
-         libgnutls30 libcap2 libcap2-bin openssh-client rsync \
+         libgnutls30 libcap2 libcap2-bin openssh-client rsync sudo \
     && rm -rf /var/lib/apt/lists/*
 
 # Add updated postgres/redshift dependencies based on libq

--- a/ingestion/operators/docker/Dockerfile.ci
+++ b/ingestion/operators/docker/Dockerfile.ci
@@ -46,6 +46,7 @@ RUN apt-get -qq update \
     # --only-upgrade is a no-op for packages not present in the base image.
     && apt-get -qq install -y --only-upgrade \
          libgnutls30 libcap2 libcap2-bin openssh-client rsync sudo \
+         libpam0g libpam-modules libpam-modules-bin libpam-runtime \
     && rm -rf /var/lib/apt/lists/*
 
 # Add updated postgres/redshift dependencies based on libq

--- a/ingestion/operators/docker/Dockerfile.ci
+++ b/ingestion/operators/docker/Dockerfile.ci
@@ -45,7 +45,7 @@ RUN apt-get -qq update \
     # openssh -> 1:9.2p1-2+deb12u10, rsync -> 3.2.7-1+deb12u5).
     # --only-upgrade is a no-op for packages not present in the base image.
     && apt-get -qq install -y --only-upgrade \
-         libgnutls30 libcap2 libcap2-bin openssh-client rsync \
+         libgnutls30 libcap2 libcap2-bin openssh-client rsync sudo \
     && rm -rf /var/lib/apt/lists/*
 
 # Add updated postgres/redshift dependencies based on libq


### PR DESCRIPTION
Fix #29346 
## Summary

- Adds `sudo` to the existing `apt-get install -y --only-upgrade` list in all four ingestion Dockerfiles so the airflow-based image pulls the patched sudo `1.9.13p3-1+deb12u4` from `bookworm-security`.
- Closes the Snyk finding for **CVE-2026-35535** (sudo — Privilege Dropping/Lowering Errors, high) reported on the `openmetadata-ingestion` image.
- The `python:3.10-bookworm`-based variants (`ingestion/operators/docker/Dockerfile{,.ci}`) don't ship sudo; the addition is a documented no-op there, kept for symmetry with the other security-fix entries already in the same list.

## Why this minimal change

- `sudo` is a **transitive** dependency from `apache/airflow:3.2.1-python3.10`; we do not declare it ourselves.
- Plain `apt-get install` doesn't upgrade unrelated installed packages, so without an explicit `--only-upgrade sudo` the build keeps the vulnerable `+deb12u3`.
- This follows the same pattern already used for `libgnutls30`, `libcap2`, `openssh-client`, and `rsync` in the same `RUN` block.

## Test plan

- [ ] CI builds both ingestion images successfully.
- [ ] After image build: `docker run --rm <ingestion-image> dpkg -l sudo | tail -1` shows `1.9.13p3-1+deb12u4` (or newer).
- [ ] Re-run Snyk container scan against the rebuilt `openmetadata-ingestion` image and confirm `sudo` CVE-2026-35535 no longer appears.



----
## Summary by Gitar

- **Security patches:**
  - Added `libpam0g`, `libpam-modules`, `libpam-modules-bin`, and `libpam-runtime` to the security upgrade list in all ingestion Dockerfiles to force-upgrade PAM packages.

<sub>This will update automatically on new commits.</sub>

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR patches CVE-2026-35535 (`sudo` privilege-dropping vulnerability) by adding `sudo` to the `--only-upgrade` security-fix block already present in all four ingestion Dockerfiles, following the established pattern for `libgnutls30`, `libcap2`, `openssh-client`, and `rsync`.

- `sudo` is added to the `apt-get install -y --only-upgrade` list in all four Dockerfiles; for the `python:3.10-bookworm`-based operator images this is intentionally a no-op since `sudo` isn't shipped by that base image.
- Four PAM packages (`libpam0g`, `libpam-modules`, `libpam-modules-bin`, `libpam-runtime`) are also added to the upgrade list across all Dockerfiles — this is not mentioned in the PR description and lacks CVE/version documentation in the comment block that tracks every other upgraded package.
- The version comment that documents the patched target for each package is not updated to include `sudo` or the PAM packages, breaking the inline audit trail established for this block.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — all changes use --only-upgrade, which cannot downgrade or newly install packages, so the blast radius is strictly bounded to upgrading packages already present in the base image.

The change is a minimal, additive security patch using a well-understood Dockerfile idiom. The --only-upgrade flag guarantees no regressions for packages not already present, and the sudo fix directly closes a reported CVE. The undocumented PAM additions are the only notable gap — they are safe operationally but should be justified in the comment block for auditability.

All four Dockerfiles share the same documentation gap in the version comment block; no single file is more risky than the others.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| ingestion/Dockerfile | Adds sudo + 4 PAM packages to --only-upgrade list; sudo targets CVE-2026-35535 but PAM packages lack CVE/version documentation in the comment block |
| ingestion/Dockerfile.ci | Mirrors ingestion/Dockerfile change — sudo + PAM packages added to --only-upgrade; same documentation gap in the version comment |
| ingestion/operators/docker/Dockerfile | Same change as ingestion/Dockerfile applied to operator image; python:3.10-bookworm base doesn't ship sudo so this is a no-op for sudo (as documented), but PAM upgrade rationale still undocumented |
| ingestion/operators/docker/Dockerfile.ci | CI variant of operator Dockerfile; identical change pattern, same documentation gap for PAM packages |

</details>


</details>


<details open><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Docker base image\napache/airflow:3.2.1-python3.10\nor python:3.10-bookworm] --> B[apt-get update]
    B --> C[apt-get install --only-upgrade\nlibgnutls30 libcap2 libcap2-bin\nopenssh-client rsync sudo\nlibpam0g libpam-modules\nlibpam-modules-bin libpam-runtime]
    C --> D{Package present\nin base image?}
    D -- Yes --> E[Upgrade to bookworm-security version]
    D -- No --> F[No-op — package not installed]
    E --> G[CVE-2026-35535 patched\nsudo 1.9.13p3-1+deb12u4]
    F --> H[airflow image: sudo upgraded\noperator image: sudo is a no-op]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Docker base image\napache/airflow:3.2.1-python3.10\nor python:3.10-bookworm] --> B[apt-get update]
    B --> C[apt-get install --only-upgrade\nlibgnutls30 libcap2 libcap2-bin\nopenssh-client rsync sudo\nlibpam0g libpam-modules\nlibpam-modules-bin libpam-runtime]
    C --> D{Package present\nin base image?}
    D -- Yes --> E[Upgrade to bookworm-security version]
    D -- No --> F[No-op — package not installed]
    E --> G[CVE-2026-35535 patched\nsudo 1.9.13p3-1+deb12u4]
    F --> H[airflow image: sudo upgraded\noperator image: sudo is a no-op]
```

</a>
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `ingestion/Dockerfile`, line 47-48 ([link](https://github.com/open-metadata/openmetadata/blob/5afce9b8dbbfee3a3cc54c4925dcd4f1d42f1635/ingestion/Dockerfile#L47-L48)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> The existing comment pattern documents the pinned target version for each security-upgraded package, but `sudo`'s target version is missing. This breaks the documentation pattern established for all other entries in the same block.

   

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!


2. `ingestion/Dockerfile.ci`, line 47-48 ([link](https://github.com/open-metadata/openmetadata/blob/5afce9b8dbbfee3a3cc54c4925dcd4f1d42f1635/ingestion/Dockerfile.ci#L47-L48)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> Same documentation gap as `ingestion/Dockerfile` — the pinned target version for `sudo` (`1.9.13p3-1+deb12u4`) is absent from the comment that documents all other upgraded packages.

   

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!


3. `ingestion/operators/docker/Dockerfile`, line 44-45 ([link](https://github.com/open-metadata/openmetadata/blob/5afce9b8dbbfee3a3cc54c4925dcd4f1d42f1635/ingestion/operators/docker/Dockerfile#L44-L45)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> Same documentation gap — `sudo`'s target version is missing from the comment that tracks the patched version for every other package in this block. This same pattern applies to `ingestion/operators/docker/Dockerfile.ci` as well.

   

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["fix(security): also force-upgrade PAM in..."](https://github.com/open-metadata/openmetadata/commit/59b8de597ccf2fca82c08f5f06cf99e2ec25ae95) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39241919)</sub>

<!-- /greptile_comment -->