### PR TITLE
fix: remove duplicate env key that caused 0-job Playwright workflow failures

### DIFF
--- a/.github/workflows/playwright-postgresql-e2e.yml
+++ b/.github/workflows/playwright-postgresql-e2e.yml
@@ -210,9 +210,6 @@ jobs:
       - name: Run Playwright tests
         id: run-tests
         working-directory: openmetadata-ui/src/main/resources/ui/
-        env:
-          SPEC_ONLY: ${{ needs.detect-changes.outputs.spec_only_mode }}
-          CHANGED_SPECS: ${{ needs.detect-changes.outputs.changed_specs }}
         run: |
           if [ "$SPEC_ONLY" = "true" ]; then
             echo "🔹 Spec-only mode: running changed specs → ${CHANGED_SPECS}"
@@ -269,6 +266,8 @@ jobs:
           fi
 
         env:
+          SPEC_ONLY: ${{ needs.detect-changes.outputs.spec_only_mode }}
+          CHANGED_SPECS: ${{ needs.detect-changes.outputs.changed_specs }}
           PLAYWRIGHT_IS_OSS: true
           PLAYWRIGHT_SNOWFLAKE_USERNAME: ${{ secrets.TEST_SNOWFLAKE_USERNAME }}
           PLAYWRIGHT_SNOWFLAKE_PASSWORD: ${{ secrets.TEST_SNOWFLAKE_PASSWORD }}


### PR DESCRIPTION
### Describe your changes:

Fixes a bug introduced in #29331.

The `Run Playwright tests` step ended up with two `env:` keys in the same YAML mapping — a new block added for `SPEC_ONLY`/`CHANGED_SPECS` before `run:`, and the original secrets block after `run:`. Duplicate keys in a YAML mapping are invalid; GitHub Actions rejected the entire workflow at parse time, producing 0-job failures on every `merge_group` and `pull_request_target` run of the workflow.

Fix: move `SPEC_ONLY` and `CHANGED_SPECS` into the single existing `env:` block alongside the secrets.

### Type of change:
- [x] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### High-level design:

N/A — small change.

#
### Tests:

#### Use cases covered
- `merge_group` and `pull_request_target` runs of `playwright-postgresql-e2e.yml` now produce jobs instead of failing immediately with 0 jobs

#### Unit tests
- [ ] Not applicable (CI workflow fix only).

#### Backend integration tests
- [ ] Not applicable.

#### Ingestion integration tests
- [ ] Not applicable.

#### Playwright (UI) tests
- [ ] Not applicable.

#### Manual testing performed
Confirmed root cause by comparing job counts: pre-#29331 runs had 8 jobs; post-#29331 runs had 0 jobs. Duplicate `env:` key in YAML mapping identified as cause.

#
### UI screen recording / screenshots:

Not applicable.

#
### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.
- [ ] For UI changes: I attached a screen recording and/or screenshots above.
- [ ] I have added tests (unit / integration / Playwright as applicable) and listed them above.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a YAML parsing error introduced in #29331 where the `Run Playwright tests` step had two `env:` keys in the same mapping — one before `run:` (with `SPEC_ONLY`/`CHANGED_SPECS`) and one after (with all the secrets). Duplicate keys in a YAML mapping are invalid, causing GitHub Actions to reject the entire workflow at parse time and produce 0-job failures. The fix moves `SPEC_ONLY` and `CHANGED_SPECS` into the single `env:` block alongside the secrets.

- Removes the orphaned `env:` block placed before `run:` and consolidates its two variables (`SPEC_ONLY`, `CHANGED_SPECS`) into the existing `env:` block after `run:`, yielding a valid single-`env:` step.
- No logic changes; the environment variables are identical — only their YAML position is corrected.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is a one-step consolidation of two `env:` blocks into one with no behavioral difference.

The fix moves two environment variables from an invalid duplicate `env:` block into the correct single `env:` block. All variables end up with the same values, the shell script logic is unchanged, and the only effect is restoring valid YAML so the workflow can be parsed and run by GitHub Actions.

No files require special attention.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/playwright-postgresql-e2e.yml | Removes duplicate `env:` key before `run:` and merges `SPEC_ONLY`/`CHANGED_SPECS` into the single `env:` block that follows `run:`, fixing YAML parse errors that caused 0-job workflow runs. |

</details>

</details>

<details open><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Run Playwright tests step] --> B{Duplicate env keys?}
    B -->|Before fix - 2 env blocks| C[GitHub Actions YAML parse error]
    C --> D[0 jobs triggered]
    B -->|After fix - 1 env block| E[SPEC_ONLY + CHANGED_SPECS + secrets merged]
    E --> F[Workflow parses correctly]
    F --> G[8 jobs triggered normally]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Run Playwright tests step] --> B{Duplicate env keys?}
    B -->|Before fix - 2 env blocks| C[GitHub Actions YAML parse error]
    C --> D[0 jobs triggered]
    B -->|After fix - 1 env block| E[SPEC_ONLY + CHANGED_SPECS + secrets merged]
    E --> F[Workflow parses correctly]
    F --> G[8 jobs triggered normally]
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: remove duplicate env key that cause..."](https://github.com/open-metadata/openmetadata/commit/67e716f117c3cab44d53ef7acd124ed5732c95bb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39253912)</sub>

<!-- /greptile_comment -->