### PR TITLE
fix(ui): preserve saved Persona Navigation ordering on reload (#28738)

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/SettingsNavigationPage.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/SettingsNavigationPage.spec.ts
@@ -422,4 +422,108 @@ test.describe.serial('Settings Navigation Page Tests', () => {
     await page.getByTestId('save-button').click();
     await resetResponse;
   });
+
+  // Issue #28738 follow-up: the rendered sidebar must reflect a cross-group
+  // move once the persona is applied, not just the editor tree.
+  test('should reflect a sub-item moved to another group in the sidebar after applying the persona', async ({
+    page,
+  }) => {
+    test.slow();
+
+    await redirectToHomePage(page);
+    await setUserDefaultPersona(page, persona.responseData.displayName);
+    await navigateToPersonaNavigation(page);
+
+    const treeItems = page.locator('.ant-tree-node-content-wrapper');
+
+    await expect(treeItems.first()).toBeVisible();
+
+    const testLibraryItem = treeItems.getByTitle('label.test-library');
+    const overviewItem = treeItems.getByTitle('label.overview');
+    const dataMarketplaceItem = treeItems.getByTitle(
+      'label.data-marketplace-section'
+    );
+
+    await expect(testLibraryItem).toBeVisible();
+    await expect(overviewItem).toBeVisible();
+
+    // Move Test Library (an Observability child) into the Data Marketplace
+    // group by dropping it just after Overview (between two of its children).
+    // HTML5 drag-and-drop is occasionally dropped by the browser, so retry the
+    // drag until Test Library actually renders below the Data Marketplace header.
+    await expect(async () => {
+      const testLibraryBox = await testLibraryItem.boundingBox();
+      const overviewBox = await overviewItem.boundingBox();
+
+      expect(testLibraryBox).not.toBeNull();
+      expect(overviewBox).not.toBeNull();
+
+      await testLibraryItem.dragTo(overviewItem, {
+        sourcePosition: {
+          x: (testLibraryBox?.width ?? 0) / 2,
+          y: (testLibraryBox?.height ?? 0) / 2,
+        },
+        targetPosition: {
+          x: (overviewBox?.width ?? 0) / 2,
+          y: (overviewBox?.height ?? 0) / 2 + 10,
+        },
+      });
+
+      const testLibraryY = (await testLibraryItem.boundingBox())?.y ?? 0;
+      const dataMarketplaceY =
+        (await dataMarketplaceItem.boundingBox())?.y ?? 0;
+
+      expect(testLibraryY).toBeGreaterThan(dataMarketplaceY);
+    }).toPass({ timeout: 30000 });
+
+    await expect(page.getByTestId('save-button')).toBeEnabled();
+
+    const saveResponse = page.waitForResponse(
+      (response) =>
+        response.url().includes('/api/v1/docStore') &&
+        [200, 201].includes(response.status())
+    );
+    await page.getByTestId('save-button').click();
+    await saveResponse;
+
+    // Apply the persona, then open the Data Marketplace section in the sidebar
+    await redirectToHomePage(page);
+    await page.getByTestId('dropdown-profile').click();
+    await page
+      .locator('[role="menu"].profile-dropdown')
+      .waitFor({ state: 'visible' });
+    await page
+      .getByRole('menuitem', { name: persona.responseData.displayName })
+      .click();
+
+    await page.hover('[data-testid="left-sidebar"]');
+    await page.click('[data-testid="data-marketplace-section"]');
+
+    // The moved item is now rendered under the Data Marketplace section
+    await expect(
+      page.locator('[data-testid="app-bar-item-test-library"]').first()
+    ).toBeVisible();
+
+    await page.click('[data-testid="data-marketplace-section"]');
+
+    // Cleanup: restore the default navigation layout
+    await navigateToPersonaNavigation(page);
+    await page.getByTestId('reset-button').click();
+
+    await expect(page.getByTestId('unsaved-changes-modal-title')).toContainText(
+      'Reset Default Layout'
+    );
+
+    await page.getByTestId('unsaved-changes-modal-save').click();
+
+    await expect(page.getByTestId('save-button')).toBeEnabled();
+
+    const resetResponseAfterMove = page.waitForResponse(
+      (response) =>
+        response.url().includes('/api/v1/docStore') &&
+        [200, 201].includes(response.status())
+    );
+    await page.getByTestId('save-button').click();
+    await resetResponseAfterMove;
+  });
 });

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/SettingsNavigationPage.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/SettingsNavigationPage.spec.ts
@@ -332,4 +332,94 @@ test.describe.serial('Settings Navigation Page Tests', () => {
     await page.getByTestId('save-button').click();
     await restoreResponse;
   });
+
+  // Regression for issue #28738: navigation ordering customisations used to
+  // revert to the default tree order after saving and reopening the page.
+  test('should persist a reordered sub-item after reload', async ({ page }) => {
+    test.slow();
+
+    await redirectToHomePage(page);
+    await setUserDefaultPersona(page, persona.responseData.displayName);
+    await navigateToPersonaNavigation(page);
+
+    const treeItems = page.locator('.ant-tree-node-content-wrapper');
+
+    await expect(treeItems.first()).toBeVisible();
+
+    // Data Quality and Incident Manager are adjacent children of Observability
+    // near the top of the tree, which keeps the drag reliable.
+    const dataQualityItem = treeItems.getByTitle('label.data-quality');
+    const incidentManagerItem = treeItems.getByTitle('label.incident-manager');
+
+    await expect(dataQualityItem).toBeVisible();
+    await expect(incidentManagerItem).toBeVisible();
+
+    const isDataQualityBelowIncidentManager = async () => {
+      const dataQualityBox = await dataQualityItem.boundingBox();
+      const incidentManagerBox = await incidentManagerItem.boundingBox();
+
+      return (dataQualityBox?.y ?? 0) > (incidentManagerBox?.y ?? 0);
+    };
+
+    // Default order renders Data Quality above Incident Manager
+    expect(await isDataQualityBelowIncidentManager()).toBe(false);
+
+    const dataQualityBox = await dataQualityItem.boundingBox();
+    const incidentManagerBox = await incidentManagerItem.boundingBox();
+
+    expect(dataQualityBox).not.toBeNull();
+    expect(incidentManagerBox).not.toBeNull();
+
+    // Drag Data Quality just below Incident Manager to reorder within the group
+    await dataQualityItem.dragTo(incidentManagerItem, {
+      sourcePosition: {
+        x: (dataQualityBox?.width ?? 0) / 2,
+        y: (dataQualityBox?.height ?? 0) / 2,
+      },
+      targetPosition: {
+        x: (incidentManagerBox?.width ?? 0) / 2,
+        y: (incidentManagerBox?.height ?? 0) / 2 + 10,
+      },
+    });
+
+    await expect.poll(isDataQualityBelowIncidentManager).toBe(true);
+    await expect(page.getByTestId('save-button')).toBeEnabled();
+
+    const saveResponse = page.waitForResponse(
+      (response) =>
+        response.url().includes('/api/v1/docStore') &&
+        [200, 201].includes(response.status())
+    );
+    await page.getByTestId('save-button').click();
+    await saveResponse;
+
+    // Reopen the page: the new order must persist, not revert to default
+    await redirectToHomePage(page);
+    await navigateToPersonaNavigation(page);
+
+    await expect(treeItems.first()).toBeVisible();
+    await expect(dataQualityItem).toBeVisible();
+    await expect(incidentManagerItem).toBeVisible();
+
+    await expect.poll(isDataQualityBelowIncidentManager).toBe(true);
+
+    // Cleanup: restore the default navigation layout
+    await page.getByTestId('reset-button').click();
+
+    await expect(page.getByTestId('unsaved-changes-modal-title')).toContainText(
+      'Reset Default Layout'
+    );
+
+    await page.getByTestId('unsaved-changes-modal-save').click();
+
+    await expect(page.getByTestId('save-button')).toBeEnabled();
+
+    const resetResponse = page.waitForResponse(
+      (response) =>
+        response.url().includes('/api/v1/docStore') &&
+        [200, 201].includes(response.status())
+    );
+    await page.getByTestId('save-button').click();
+    await resetResponse;
+  });
 });

--- a/openmetadata-ui/src/main/resources/ui/src/utils/CustomizaNavigation/CustomizeNavigation.test.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/CustomizaNavigation/CustomizeNavigation.test.ts
@@ -365,6 +365,54 @@ describe('CustomizeNavigation Utils', () => {
         'new-feature',
       ]);
     });
+
+    it('should not duplicate a saved child under a new default top-level group', () => {
+      (leftSidebarClassBase.getSidebarItems as jest.Mock).mockReturnValueOnce([
+        { key: 'home', title: 'Home', icon: 'home-icon', children: [] },
+        {
+          key: 'new-group',
+          title: 'New Group',
+          icon: 'new-group-icon',
+          children: [
+            { key: 'shared-child', title: 'Shared Child', icon: 'shared-icon' },
+            {
+              key: 'brand-new-child',
+              title: 'Brand New Child',
+              icon: 'brand-new-icon',
+            },
+          ],
+        },
+      ]);
+
+      // Shared Child was already moved under Home before New Group was added
+      const savedNav: NavigationItem[] = [
+        {
+          id: 'home',
+          title: 'Home',
+          isHidden: false,
+          pageId: 'home',
+          children: [
+            {
+              id: 'shared-child',
+              title: 'Shared Child',
+              isHidden: false,
+              pageId: 'shared-child',
+            },
+          ],
+        },
+      ];
+
+      const result = getTreeDataForNavigationItems(savedNav);
+      const homeNode = result.find((node) => node.key === 'home');
+      const newGroupNode = result.find((node) => node.key === 'new-group');
+
+      expect(homeNode?.children?.map((child) => child.key)).toEqual([
+        'shared-child',
+      ]);
+      expect(newGroupNode?.children?.map((child) => child.key)).toEqual([
+        'brand-new-child',
+      ]);
+    });
   });
 
   describe('getHiddenKeysFromNavigationItems', () => {

--- a/openmetadata-ui/src/main/resources/ui/src/utils/CustomizaNavigation/CustomizeNavigation.test.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/CustomizaNavigation/CustomizeNavigation.test.ts
@@ -189,6 +189,182 @@ describe('CustomizeNavigation Utils', () => {
       expect(result[2].key).toBe('plugin-item');
       expect((result[2] as { isHidden?: boolean }).isHidden).toBe(true);
     });
+
+    it('should preserve the saved order of top-level items', () => {
+      (leftSidebarClassBase.getSidebarItems as jest.Mock).mockReturnValueOnce([
+        { key: 'home', title: 'Home', icon: 'home-icon' },
+        { key: 'explore', title: 'Explore', icon: 'explore-icon' },
+        { key: 'lineage', title: 'Lineage', icon: 'lineage-icon' },
+      ]);
+
+      const savedNav: NavigationItem[] = [
+        { id: 'lineage', title: 'Lineage', isHidden: false, pageId: 'lineage' },
+        { id: 'home', title: 'Home', isHidden: false, pageId: 'home' },
+        { id: 'explore', title: 'Explore', isHidden: false, pageId: 'explore' },
+      ];
+
+      const result = getTreeDataForNavigationItems(savedNav);
+
+      expect(result.map((item) => item.key)).toEqual([
+        'lineage',
+        'home',
+        'explore',
+      ]);
+    });
+
+    it('should preserve the saved order of children within a group', () => {
+      (leftSidebarClassBase.getSidebarItems as jest.Mock).mockReturnValueOnce([
+        {
+          key: 'home',
+          title: 'Home',
+          icon: 'home-icon',
+          children: [
+            { key: 'a', title: 'A', icon: 'a-icon' },
+            { key: 'b', title: 'B', icon: 'b-icon' },
+            { key: 'c', title: 'C', icon: 'c-icon' },
+          ],
+        },
+      ]);
+
+      const savedNav: NavigationItem[] = [
+        {
+          id: 'home',
+          title: 'Home',
+          isHidden: false,
+          pageId: 'home',
+          children: [
+            { id: 'c', title: 'C', isHidden: false, pageId: 'c' },
+            { id: 'a', title: 'A', isHidden: false, pageId: 'a' },
+            { id: 'b', title: 'B', isHidden: false, pageId: 'b' },
+          ],
+        },
+      ];
+
+      const result = getTreeDataForNavigationItems(savedNav);
+
+      expect(result[0].children?.map((child) => child.key)).toEqual([
+        'c',
+        'a',
+        'b',
+      ]);
+    });
+
+    it('should keep a child moved to another group under its new parent', () => {
+      (leftSidebarClassBase.getSidebarItems as jest.Mock).mockReturnValueOnce([
+        {
+          key: 'observability',
+          title: 'Observability',
+          icon: 'observability-icon',
+          children: [
+            { key: 'data-quality', title: 'Data Quality', icon: 'dq-icon' },
+            {
+              key: 'incident-manager',
+              title: 'Incident Manager',
+              icon: 'im-icon',
+            },
+          ],
+        },
+        {
+          key: 'governance',
+          title: 'Govern',
+          icon: 'govern-icon',
+          children: [
+            { key: 'glossary', title: 'Glossary', icon: 'glossary-icon' },
+          ],
+        },
+      ]);
+
+      const savedNav: NavigationItem[] = [
+        {
+          id: 'observability',
+          title: 'Observability',
+          isHidden: false,
+          pageId: 'observability',
+          children: [
+            {
+              id: 'data-quality',
+              title: 'Data Quality',
+              isHidden: false,
+              pageId: 'data-quality',
+            },
+          ],
+        },
+        {
+          id: 'governance',
+          title: 'Govern',
+          isHidden: false,
+          pageId: 'governance',
+          children: [
+            {
+              id: 'glossary',
+              title: 'Glossary',
+              isHidden: false,
+              pageId: 'glossary',
+            },
+            {
+              id: 'incident-manager',
+              title: 'Incident Manager',
+              isHidden: false,
+              pageId: 'incident-manager',
+            },
+          ],
+        },
+      ];
+
+      const result = getTreeDataForNavigationItems(savedNav);
+
+      expect(result[0].key).toBe('observability');
+      expect(result[0].children?.map((child) => child.key)).toEqual([
+        'data-quality',
+      ]);
+      expect(result[1].key).toBe('governance');
+      expect(result[1].children?.map((child) => child.key)).toEqual([
+        'glossary',
+        'incident-manager',
+      ]);
+    });
+
+    it('should append new default children after the saved children', () => {
+      (leftSidebarClassBase.getSidebarItems as jest.Mock).mockReturnValueOnce([
+        {
+          key: 'home',
+          title: 'Home',
+          icon: 'home-icon',
+          children: [
+            {
+              key: 'new-feature',
+              title: 'New Feature',
+              icon: 'new-feature-icon',
+            },
+            { key: 'dashboard', title: 'Dashboard', icon: 'dashboard-icon' },
+          ],
+        },
+      ]);
+
+      const savedNav: NavigationItem[] = [
+        {
+          id: 'home',
+          title: 'Home',
+          isHidden: false,
+          pageId: 'home',
+          children: [
+            {
+              id: 'dashboard',
+              title: 'Dashboard',
+              isHidden: false,
+              pageId: 'dashboard',
+            },
+          ],
+        },
+      ];
+
+      const result = getTreeDataForNavigationItems(savedNav);
+
+      expect(result[0].children?.map((child) => child.key)).toEqual([
+        'dashboard',
+        'new-feature',
+      ]);
+    });
   });
 
   describe('getHiddenKeysFromNavigationItems', () => {
@@ -459,6 +635,73 @@ describe('CustomizeNavigation Utils', () => {
       const result = getHiddenKeysFromNavigationItems(savedNav);
 
       expect(result).toContain('new-feature');
+    });
+
+    it('should not mark a moved child as hidden when it is visible under its new parent', () => {
+      (leftSidebarClassBase.getSidebarItems as jest.Mock).mockReturnValueOnce([
+        {
+          key: 'observability',
+          title: 'Observability',
+          icon: 'observability-icon',
+          children: [
+            { key: 'data-quality', title: 'Data Quality', icon: 'dq-icon' },
+            {
+              key: 'incident-manager',
+              title: 'Incident Manager',
+              icon: 'im-icon',
+            },
+          ],
+        },
+        {
+          key: 'governance',
+          title: 'Govern',
+          icon: 'govern-icon',
+          children: [
+            { key: 'glossary', title: 'Glossary', icon: 'glossary-icon' },
+          ],
+        },
+      ]);
+
+      const savedNav: NavigationItem[] = [
+        {
+          id: 'observability',
+          title: 'Observability',
+          isHidden: false,
+          pageId: 'observability',
+          children: [
+            {
+              id: 'data-quality',
+              title: 'Data Quality',
+              isHidden: false,
+              pageId: 'data-quality',
+            },
+          ],
+        },
+        {
+          id: 'governance',
+          title: 'Govern',
+          isHidden: false,
+          pageId: 'governance',
+          children: [
+            {
+              id: 'glossary',
+              title: 'Glossary',
+              isHidden: false,
+              pageId: 'glossary',
+            },
+            {
+              id: 'incident-manager',
+              title: 'Incident Manager',
+              isHidden: false,
+              pageId: 'incident-manager',
+            },
+          ],
+        },
+      ];
+
+      const result = getHiddenKeysFromNavigationItems(savedNav);
+
+      expect(result).not.toContain('incident-manager');
     });
   });
 

--- a/openmetadata-ui/src/main/resources/ui/src/utils/CustomizaNavigation/CustomizeNavigation.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/CustomizaNavigation/CustomizeNavigation.ts
@@ -132,36 +132,87 @@ const convertSidebarItemToTreeNode = (
   })),
 });
 
-const mapSidebarItemWithNavigation = (
-  sidebarItem: LeftSidebarItem,
-  navigationMap: Map<string, NavigationItem>
-): TreeDataNode & { isHidden?: boolean } => {
-  const navItem = navigationMap.get(sidebarItem.key);
+const collectNavigationKeys = (
+  navigationItems: NavigationItem[]
+): Set<string> => {
+  const keys = new Set<string>();
 
-  if (!navItem) {
-    return {
-      title: sidebarItem.title,
-      key: sidebarItem.key,
-      icon: sidebarItem.icon as TreeDataNode['icon'],
-      isHidden: true,
-    };
+  navigationItems.forEach((item) => {
+    keys.add(item.id);
+    item.children?.forEach((child) => keys.add(child.id));
+  });
+
+  return keys;
+};
+
+const convertNavigationChildToTreeNode = (
+  navChild: NavigationItem,
+  sidebarMap: Map<string, LeftSidebarItem>
+): TreeDataNode | null => {
+  const sidebarChild = sidebarMap.get(navChild.id);
+
+  return sidebarChild
+    ? {
+        title: navChild.title,
+        key: navChild.id,
+        icon: sidebarChild.icon as TreeDataNode['icon'],
+      }
+    : null;
+};
+
+const buildChildrenForSavedItem = (
+  navItem: NavigationItem,
+  sidebarItem: LeftSidebarItem | undefined,
+  sidebarMap: Map<string, LeftSidebarItem>,
+  savedKeys: Set<string>
+): TreeDataNode[] | undefined => {
+  const defaultChildren = sidebarItem?.children ?? [];
+
+  if (isEmpty(navItem.children) && isEmpty(defaultChildren)) {
+    return undefined;
   }
+
+  const savedChildNodes = (navItem.children ?? [])
+    .map((child) => convertNavigationChildToTreeNode(child, sidebarMap))
+    .filter((node): node is TreeDataNode => node !== null);
+
+  const newDefaultChildNodes = defaultChildren
+    .filter((child) => !savedKeys.has(child.key))
+    .map((child) => ({
+      title: child.title,
+      key: child.key,
+      icon: child.icon as TreeDataNode['icon'],
+    }));
+
+  return [...savedChildNodes, ...newDefaultChildNodes];
+};
+
+const buildTreeNodeFromSavedItem = (
+  navItem: NavigationItem,
+  sidebarMap: Map<string, LeftSidebarItem>,
+  savedKeys: Set<string>
+): TreeDataNode => {
+  const sidebarItem = sidebarMap.get(navItem.id);
 
   return {
     title: navItem.title,
     key: navItem.id,
-    icon: sidebarItem.icon as TreeDataNode['icon'],
-    children: sidebarItem.children?.map((child) => {
-      const navChild = navigationMap.get(child.key);
-
-      return {
-        title: navChild?.title ?? child.title,
-        key: navChild?.id ?? child.key,
-        icon: child.icon as TreeDataNode['icon'],
-      };
-    }),
+    icon: sidebarItem?.icon as TreeDataNode['icon'],
+    children: buildChildrenForSavedItem(
+      navItem,
+      sidebarItem,
+      sidebarMap,
+      savedKeys
+    ),
   };
 };
+
+const convertNewDefaultItemToTreeNode = (
+  sidebarItem: LeftSidebarItem
+): TreeDataNode & { isHidden?: boolean } => ({
+  ...convertSidebarItemToTreeNode(sidebarItem),
+  isHidden: true,
+});
 
 export const getTreeDataForNavigationItems = (
   navigationItems: NavigationItem[] | null,
@@ -173,41 +224,36 @@ export const getTreeDataForNavigationItems = (
     return sidebarItemsWithPlugins.map(convertSidebarItemToTreeNode);
   }
 
-  const navigationMap = createNavigationMap(navigationItems);
+  const sidebarMap = createSidebarMap(sidebarItemsWithPlugins);
+  const savedKeys = collectNavigationKeys(navigationItems);
 
-  return sidebarItemsWithPlugins.map((sidebarItem) =>
-    mapSidebarItemWithNavigation(sidebarItem, navigationMap)
-  );
-};
-
-const collectHiddenKeys = (
-  item: LeftSidebarItem,
-  navigationMap: Map<string, NavigationItem> | null
-): string[] => {
-  const keys: string[] = [];
-  const navItem = navigationMap?.get(item.key);
-
-  if (navigationMap && (!navItem || navItem.isHidden)) {
-    keys.push(item.key);
-
-    return keys;
-  }
-
-  if (navItem && item.children) {
-    const savedChildMap = new Map(
-      navItem.children?.map((c) => [c.id, c]) ?? []
+  const savedNodes = navigationItems
+    .filter((navItem) => sidebarMap.has(navItem.id))
+    .map((navItem) =>
+      buildTreeNodeFromSavedItem(navItem, sidebarMap, savedKeys)
     );
 
-    item.children.forEach((child) => {
-      const navChild = savedChildMap.get(child.key);
+  const newDefaultNodes = sidebarItemsWithPlugins
+    .filter((sidebarItem) => !savedKeys.has(sidebarItem.key))
+    .map(convertNewDefaultItemToTreeNode);
 
-      if (!navChild || navChild.isHidden) {
-        keys.push(child.key);
-      }
-    });
-  }
+  return [...savedNodes, ...newDefaultNodes];
+};
+
+const collectSidebarKeys = (sidebarItem: LeftSidebarItem): string[] => {
+  const keys = [sidebarItem.key];
+  sidebarItem.children?.forEach((child) => keys.push(child.key));
 
   return keys;
+};
+
+const isNavigationItemHidden = (
+  key: string,
+  navigationMap: Map<string, NavigationItem>
+): boolean => {
+  const navItem = navigationMap.get(key);
+
+  return !navItem || Boolean(navItem.isHidden);
 };
 
 export const getHiddenKeysFromNavigationItems = (
@@ -215,14 +261,16 @@ export const getHiddenKeysFromNavigationItems = (
   plugins?: AppPlugin[]
 ): string[] => {
   const sidebarItemsWithPlugins = getSidebarItemsWithPlugins(plugins);
-  const navigationMap =
-    navigationItems && !isEmpty(navigationItems)
-      ? createNavigationMap(navigationItems)
-      : null;
 
-  return sidebarItemsWithPlugins.flatMap((item) =>
-    collectHiddenKeys(item, navigationMap)
-  );
+  if (!navigationItems || isEmpty(navigationItems)) {
+    return [];
+  }
+
+  const navigationMap = createNavigationMap(navigationItems);
+
+  return sidebarItemsWithPlugins
+    .flatMap(collectSidebarKeys)
+    .filter((key) => isNavigationItemHidden(key, navigationMap));
 };
 
 const enhanceNavigationItem = (

--- a/openmetadata-ui/src/main/resources/ui/src/utils/CustomizaNavigation/CustomizeNavigation.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/CustomizaNavigation/CustomizeNavigation.ts
@@ -119,17 +119,29 @@ const createNavigationMap = (
   return map;
 };
 
+const convertSidebarChildToTreeNode = (
+  child: LeftSidebarItem
+): TreeDataNode => ({
+  title: child.title,
+  key: child.key,
+  icon: child.icon as TreeDataNode['icon'],
+});
+
+const collectNewDefaultChildNodes = (
+  defaultChildren: LeftSidebarItem[],
+  savedKeys: Set<string>
+): TreeDataNode[] =>
+  defaultChildren
+    .filter((child) => !savedKeys.has(child.key))
+    .map(convertSidebarChildToTreeNode);
+
 const convertSidebarItemToTreeNode = (
   sidebarItem: LeftSidebarItem
 ): TreeDataNode => ({
   title: sidebarItem.title,
   key: sidebarItem.key,
   icon: sidebarItem.icon as TreeDataNode['icon'],
-  children: sidebarItem.children?.map((child) => ({
-    title: child.title,
-    key: child.key,
-    icon: child.icon as TreeDataNode['icon'],
-  })),
+  children: sidebarItem.children?.map(convertSidebarChildToTreeNode),
 });
 
 const collectNavigationKeys = (
@@ -176,13 +188,10 @@ const buildChildrenForSavedItem = (
     .map((child) => convertNavigationChildToTreeNode(child, sidebarMap))
     .filter((node): node is TreeDataNode => node !== null);
 
-  const newDefaultChildNodes = defaultChildren
-    .filter((child) => !savedKeys.has(child.key))
-    .map((child) => ({
-      title: child.title,
-      key: child.key,
-      icon: child.icon as TreeDataNode['icon'],
-    }));
+  const newDefaultChildNodes = collectNewDefaultChildNodes(
+    defaultChildren,
+    savedKeys
+  );
 
   return [...savedChildNodes, ...newDefaultChildNodes];
 };
@@ -208,9 +217,15 @@ const buildTreeNodeFromSavedItem = (
 };
 
 const convertNewDefaultItemToTreeNode = (
-  sidebarItem: LeftSidebarItem
+  sidebarItem: LeftSidebarItem,
+  savedKeys: Set<string>
 ): TreeDataNode & { isHidden?: boolean } => ({
-  ...convertSidebarItemToTreeNode(sidebarItem),
+  title: sidebarItem.title,
+  key: sidebarItem.key,
+  icon: sidebarItem.icon as TreeDataNode['icon'],
+  children: sidebarItem.children
+    ? collectNewDefaultChildNodes(sidebarItem.children, savedKeys)
+    : undefined,
   isHidden: true,
 });
 
@@ -235,7 +250,9 @@ export const getTreeDataForNavigationItems = (
 
   const newDefaultNodes = sidebarItemsWithPlugins
     .filter((sidebarItem) => !savedKeys.has(sidebarItem.key))
-    .map(convertNewDefaultItemToTreeNode);
+    .map((sidebarItem) =>
+      convertNewDefaultItemToTreeNode(sidebarItem, savedKeys)
+    );
 
   return [...savedNodes, ...newDefaultNodes];
 };


### PR DESCRIPTION
## Problem

Fixes #28738. In **Settings → Persona → Navigation**, moving a sub-item to another group (or any reorder) looked correct until you saved and reopened the page — the item snapped back to its original position.

## Root cause

The **save** path was correct (`getNavigationItems` persists the exact reordered tree). The bug was in the **re-hydration** path in `utils/CustomizaNavigation/CustomizeNavigation.ts`. Two functions rebuilt the editor state from the **default** sidebar structure and borrowed only titles/visibility from the saved navigation, discarding the saved order and parent placement:

- `getTreeDataForNavigationItems` iterated the default sidebar and built each parent's children from the *default* children, so a moved/reordered child was re-emitted in its default position.
- `getHiddenKeysFromNavigationItems` judged each child against its *default* parent's saved children, so a child moved to another group was wrongly marked hidden.

The runtime sidebar (`filterHiddenNavigationItems`) already built from saved data, so only the editor was affected.

## Fix

Drive both functions from the **saved navigation**:

- Preserve saved order/structure, look up icons from the default sidebar, and merge defaults in only for genuinely **new** items (which remain hidden by default).
- Decide hidden state via a **global** lookup, so a moved child is judged by its actual saved state rather than its old default parent.

https://github.com/user-attachments/assets/9851885c-9a87-4fb1-9b16-a1c91a51e5d4


## Testing

- **Unit** (`CustomizeNavigation.test.ts`): added tests for top-level reordering, child reordering within a group, cross-group child moves, and new-item merging. All fail on the old code and pass on the fix; the 40 existing tests still pass.
- **E2E** (`SettingsNavigationPage.spec.ts`): added a regression that reorders a sub-item, saves, reopens the page, and asserts the order persists. Verified it **fails against the old build** (reproduces the revert) and **passes against this fix**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a post-save revert bug in the Persona Navigation editor where the re-hydration functions (`getTreeDataForNavigationItems` and `getHiddenKeysFromNavigationItems`) were rebuilding editor state from the *default* sidebar structure, discarding the saved order and cross-group placements.

- **`getTreeDataForNavigationItems`** is rewritten to iterate the *saved* navigation items first (preserving order and parent placement), look up icons from a flat sidebar map, and append only genuinely new default items/children (those absent from a global `savedKeys` set) as hidden at the end.
- **`getHiddenKeysFromNavigationItems`** now builds a flat map of all saved items across all groups and checks each default sidebar key against it globally, so a child moved to another group is correctly seen as visible rather than implicitly hidden.
- Unit tests cover top-level reordering, child reordering, cross-group moves, new-item merging, and hidden-key correctness; two E2E regression tests cover save-and-reload persistence and sidebar reflection after persona apply.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the changes are confined to two utility functions and their tests, the fix is logically sound, and all edge cases are covered by the new unit tests.

The re-hydration logic correctly drives from saved navigation data, uses a global key set to prevent child duplication, and the flat navigation map makes hidden-state lookups order-independent. The unit tests exercise all four meaningful scenarios and fail on the old code.

The E2E spec uses `.ant-tree-node-content-wrapper` (an internal AntD class) as the primary tree item locator in both new tests, and the cross-group test wraps a `dragTo` inside `toPass`, which re-issues the drag on each retry.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-ui/src/main/resources/ui/src/utils/CustomizaNavigation/CustomizeNavigation.ts | Core bug fix: re-hydration of editor state now drives from saved navigation order instead of default sidebar, using a global key set to prevent duplication and a flat navigation map for cross-group hidden-state lookups. |
| openmetadata-ui/src/main/resources/ui/src/utils/CustomizaNavigation/CustomizeNavigation.test.ts | Adds five targeted unit tests: top-level ordering, child ordering within a group, cross-group child moves, new-item merging, and the hidden-key correctness for moved children. |
| openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/SettingsNavigationPage.spec.ts | Two new E2E regression tests: one for same-group reorder persistence and one for cross-group move visibility in the live sidebar. The cross-group test wraps a dragTo inside toPass, which can accumulate multiple drags before the assertion fires. |

</details>

</details>

<details open><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[getTreeDataForNavigationItems] --> B{navigationItems null/empty?}
    B -- Yes --> C[Map default sidebar to TreeDataNode]
    B -- No --> D[Build sidebarMap from defaults
Build savedKeys from ALL saved items]
    D --> E[savedNodes: filter saved items
still in sidebarMap
buildTreeNodeFromSavedItem]
    E --> F[buildChildrenForSavedItem
saved children first
then new defaults not in savedKeys]
    D --> G[newDefaultNodes: default items
not in savedKeys
convertNewDefaultItemToTreeNode
isHidden=true]
    E --> H[savedNodes + newDefaultNodes]
    G --> H
    I[getHiddenKeysFromNavigationItems] --> J{navigationItems null/empty?}
    J -- Yes --> K[return empty array]
    J -- No --> L[createNavigationMap
flat map of ALL saved items]
    L --> M[collectSidebarKeys from defaults]
    M --> N[filter keys where isNavigationItemHidden
no entry OR isHidden=true]
    N --> O[hidden keys list]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[getTreeDataForNavigationItems] --> B{navigationItems null/empty?}
    B -- Yes --> C[Map default sidebar to TreeDataNode]
    B -- No --> D[Build sidebarMap from defaults
Build savedKeys from ALL saved items]
    D --> E[savedNodes: filter saved items
still in sidebarMap
buildTreeNodeFromSavedItem]
    E --> F[buildChildrenForSavedItem
saved children first
then new defaults not in savedKeys]
    D --> G[newDefaultNodes: default items
not in savedKeys
convertNewDefaultItemToTreeNode
isHidden=true]
    E --> H[savedNodes + newDefaultNodes]
    G --> H
    I[getHiddenKeysFromNavigationItems] --> J{navigationItems null/empty?}
    J -- Yes --> K[return empty array]
    J -- No --> L[createNavigationMap
flat map of ALL saved items]
    L --> M[collectSidebarKeys from defaults]
    M --> N[filter keys where isNavigationItemHidden
no entry OR isHidden=true]
    N --> O[hidden keys list]
```

</a>
</details>

<sub>Reviews (3): Last reviewed commit: ["test(ui): verify sidebar reflects a cros..."](https://github.com/open-metadata/openmetadata/commit/22a080bb81c770bbf891e48c24943007fa4b77ad) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39260182)</sub>

<!-- /greptile_comment -->