### PR TITLE
test(ui): verify glossary and inherited term appear under a domain's assets

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/Domains.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/Domains.spec.ts
@@ -3705,3 +3705,73 @@ test.describe('Domain asset dryRun — add confirmation', () => {
     }
   });
 });
+
+test.describe('Domain assets — glossary and inherited glossary term', () => {
+  test.slow(true);
+
+  let assetDomain: Domain;
+  let assetGlossary: Glossary;
+  let inheritedTerm: GlossaryTerm;
+
+  test.beforeAll(
+    'Setup domain with glossary and inherited term',
+    async ({ browser }) => {
+      const { apiContext, afterAction } = await performAdminLogin(browser);
+
+      assetDomain = new Domain();
+      assetGlossary = new Glossary();
+
+      await assetDomain.create(apiContext);
+      await assetGlossary.create(apiContext);
+
+      await assetGlossary.patch(apiContext, [
+        {
+          op: 'add',
+          path: '/domains/0',
+          value: {
+            id: assetDomain.responseData.id,
+            type: 'domain',
+            name: assetDomain.responseData.name,
+            displayName: assetDomain.responseData.displayName,
+          },
+        },
+      ]);
+
+      inheritedTerm = new GlossaryTerm(assetGlossary);
+      await inheritedTerm.create(apiContext);
+
+      await afterAction();
+    }
+  );
+
+  test.afterAll('Cleanup', async ({ browser }) => {
+    const { apiContext, afterAction } = await performAdminLogin(browser);
+    await inheritedTerm.delete(apiContext);
+    await assetGlossary.delete(apiContext);
+    await assetDomain.delete(apiContext);
+    await afterAction();
+  });
+
+  test.beforeEach('Visit home page', async ({ page }) => {
+    await redirectToHomePage(page);
+  });
+
+  test('Assets tab lists the assigned glossary and its inherited term', async ({
+    page,
+  }) => {
+    await sidebarClick(page, SidebarItem.DOMAIN);
+    await waitForAllLoadersToDisappear(page);
+
+    await goToAssetsTab(page, assetDomain.data);
+
+    const glossaryCard = page.getByTestId(
+      `table-data-card_${assetGlossary.responseData.fullyQualifiedName}`
+    );
+    const inheritedTermCard = page.getByTestId(
+      `table-data-card_${inheritedTerm.responseData.fullyQualifiedName}`
+    );
+
+    await expect(glossaryCard).toBeVisible({ timeout: 30_000 });
+    await expect(inheritedTermCard).toBeVisible({ timeout: 30_000 });
+  });
+});


### PR DESCRIPTION
## What

Adds a Playwright E2E test that locks down domain-asset coverage for glossaries: when a glossary is assigned to a domain, the glossary **and** the glossary terms it contains (which inherit the domain) appear under that domain's **Assets** tab.

This capability already works end to end in product code — the domain-assets search runs over the `all` alias (which includes the `glossary` and `glossary_term` indices) and excludes only data products and table columns, and inherited domains are propagated to terms' search docs. There was no test asserting that a glossary and its inherited term actually surface under their domain; this fills that gap.

## The test

New `test.describe('Domain assets — glossary and inherited glossary term')` block in `Domains.spec.ts`:

- **Setup (`beforeAll`, API):** create a Domain → create a Glossary → PATCH the domain onto the glossary → create a GlossaryTerm in that glossary with no explicit domain (it inherits from the glossary).
- **Body (UI only):** navigate sidebar → Domain → select the domain → Assets tab, then assert both the glossary card and the inherited-term card render (`table-data-card_${fqn}`).
- **Teardown (`afterAll`, API):** delete the term, glossary, and domain.

## Verification

Ran locally against a full stack:

```
✓ [chromium] Domain assets — glossary and inherited glossary term ›
  Assets tab lists the assigned glossary and its inherited term (5.2s)
4 passed (42.5s)
```

The inherited term appeared on first navigation — no reindex needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Adds a new Playwright E2E test asserting that a glossary assigned to a domain — and a glossary term that inherits the domain — both surface on the domain's Assets tab. The test follows the existing API-setup / UI-assert / API-teardown pattern used elsewhere in `Domains.spec.ts`.

- **Setup**: creates a `Domain`, a `Glossary`, PATCHes `/domains/0` onto the glossary, then creates a `GlossaryTerm` (no explicit domain, inherits from the glossary); teardown deletes in correct child-first order.
- **Assertion**: navigates via sidebar → Domain → Assets tab and checks `table-data-card_<fqn>` test-ids for both the glossary and the inherited term with a 30 s visibility timeout.
- **Style**: one redundant `waitForAllLoadersToDisappear` call appears between `sidebarClick` and `goToAssetsTab`; `selectDomain` (called inside `goToAssetsTab`) already invokes the same wait as its first step.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Test-only change; no production code is modified and the new describe block is self-contained with proper teardown.

The test correctly creates and cleans up all fixtures in the right order, uses sufficiently generous visibility timeouts, and follows the existing API-setup / UI-assert pattern. The single finding is a style-only redundant wait that has no impact on correctness or stability.

No files require special attention; the change is isolated to a single test block at the bottom of Domains.spec.ts.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/Domains.spec.ts | Adds a new test.describe block that creates a domain, glossary, and glossary term via API in beforeAll, verifies both the glossary card and inherited-term card are visible on the domain's Assets tab, then cleans up in afterAll. Setup, assertions, and teardown order are all correct; one redundant waitForAllLoadersToDisappear call exists before goToAssetsTab. |

</details>

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant BAll as beforeAll (API)
    participant Test as test (UI)
    participant AAll as afterAll (API)
    participant API as OpenMetadata API
    participant Browser as Playwright Browser

    BAll->>API: POST /api/v1/domains → assetDomain
    BAll->>API: POST /api/v1/glossaries → assetGlossary
    BAll->>API: "PATCH /api/v1/glossaries/{id} (add /domains/0)"
    BAll->>API: POST /api/v1/glossaryTerms → inheritedTerm

    Test->>Browser: redirectToHomePage()
    Test->>Browser: sidebarClick(DOMAIN)
    Test->>Browser: goToAssetsTab(assetDomain.data)
    Browser->>API: "GET /api/v1/search/query?q=&index=all*"
    Test->>Browser: expect(glossaryCard).toBeVisible()
    Test->>Browser: expect(inheritedTermCard).toBeVisible()

    AAll->>API: DELETE inheritedTerm
    AAll->>API: DELETE assetGlossary
    AAll->>API: DELETE assetDomain
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant BAll as beforeAll (API)
    participant Test as test (UI)
    participant AAll as afterAll (API)
    participant API as OpenMetadata API
    participant Browser as Playwright Browser

    BAll->>API: POST /api/v1/domains → assetDomain
    BAll->>API: POST /api/v1/glossaries → assetGlossary
    BAll->>API: "PATCH /api/v1/glossaries/{id} (add /domains/0)"
    BAll->>API: POST /api/v1/glossaryTerms → inheritedTerm

    Test->>Browser: redirectToHomePage()
    Test->>Browser: sidebarClick(DOMAIN)
    Test->>Browser: goToAssetsTab(assetDomain.data)
    Browser->>API: "GET /api/v1/search/query?q=&index=all*"
    Test->>Browser: expect(glossaryCard).toBeVisible()
    Test->>Browser: expect(inheritedTermCard).toBeVisible()

    AAll->>API: DELETE inheritedTerm
    AAll->>API: DELETE assetGlossary
    AAll->>API: DELETE assetDomain
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["test(ui): verify glossary and its inheri..."](https://github.com/open-metadata/openmetadata/commit/e4248cb6b064a2e799b1dd2d9e4d4309c6cf65f6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39267533)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->