### PR TITLE
ci: use playwright-summary as single required check instead of per-shard names

### DIFF
--- a/.github/workflows/playwright-postgresql-e2e-skip.yml
+++ b/.github/workflows/playwright-postgresql-e2e-skip.yml
@@ -32,12 +32,7 @@ on:
       - "openmetadata-ui/src/main/resources/ui/scripts/**"
 
 jobs:
-  playwright-ci-postgresql:
+  playwright-summary:
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        shardIndex: [1, 2, 3, 4, 5, 6]
-        shardTotal: [6]
     steps:
-      - run: 'echo "Step is not required"'
+      - run: echo "Playwright E2E tests not required for this PR"

--- a/.github/workflows/playwright-postgresql-e2e.yml
+++ b/.github/workflows/playwright-postgresql-e2e.yml
@@ -360,8 +360,7 @@ jobs:
           pattern: playwright-results-json-*
           path: results
 
-      - name: Post consolidated PR comment
-        if: ${{ github.event_name == 'pull_request_target' && (github.event.action != 'labeled' || github.event.label.name == 'safe to test') }}
+      - name: Post consolidated PR comment and gate on results
         uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -372,7 +371,6 @@ jobs:
             const runId = '${{ github.run_id }}';
             const repo = context.repo;
             const prNumber = context.payload.pull_request?.number;
-            if (!prNumber) return;
 
             const artifactUrl = `https://github.com/${repo.owner}/${repo.repo}/actions/runs/${runId}`;
             const commentMarker = '<!-- playwright-summary -->';
@@ -424,7 +422,7 @@ jobs:
             }
 
             if (shardResults.length === 0) {
-              console.log('No shard results found');
+              core.setFailed('No Playwright results found — shards may have been cancelled or failed to upload artifacts.');
               return;
             }
 
@@ -506,40 +504,40 @@ jobs:
 
             const body = lines.join('\n');
 
-            // Find existing consolidated comment
-            let existingComment = null;
-            for await (const response of github.paginate.iterator(
-              github.rest.issues.listComments, { ...repo, issue_number: prNumber, per_page: 100 }
-            )) {
-              const found = response.data.find(c =>
-                c.user?.login === 'github-actions[bot]' && c.body?.includes(commentMarker)
-              );
-              if (found) { existingComment = found; break; }
-            }
+            // Post PR comment only for pull_request_target events
+            if (prNumber) {
+              let existingComment = null;
+              for await (const response of github.paginate.iterator(
+                github.rest.issues.listComments, { ...repo, issue_number: prNumber, per_page: 100 }
+              )) {
+                const found = response.data.find(c =>
+                  c.user?.login === 'github-actions[bot]' && c.body?.includes(commentMarker)
+                );
+                if (found) { existingComment = found; break; }
+              }
 
-            // Also clean up any old per-shard comments from previous runs
-            for await (const response of github.paginate.iterator(
-              github.rest.issues.listComments, { ...repo, issue_number: prNumber, per_page: 100 }
-            )) {
-              for (const c of response.data) {
-                if (c.user?.login === 'github-actions[bot]' && /Playwright Shard \d/.test(c.body || '') && !c.body?.includes(commentMarker)) {
-                  await github.rest.issues.deleteComment({ ...repo, comment_id: c.id });
-                  console.log(`Deleted old per-shard comment ${c.id}`);
+              // Also clean up any old per-shard comments from previous runs
+              for await (const response of github.paginate.iterator(
+                github.rest.issues.listComments, { ...repo, issue_number: prNumber, per_page: 100 }
+              )) {
+                for (const c of response.data) {
+                  if (c.user?.login === 'github-actions[bot]' && /Playwright Shard \d/.test(c.body || '') && !c.body?.includes(commentMarker)) {
+                    await github.rest.issues.deleteComment({ ...repo, comment_id: c.id });
+                    console.log(`Deleted old per-shard comment ${c.id}`);
+                  }
                 }
+              }
+
+              if (existingComment) {
+                await github.rest.issues.updateComment({ ...repo, comment_id: existingComment.id, body });
+              } else {
+                await github.rest.issues.createComment({ ...repo, issue_number: prNumber, body });
               }
             }
 
-            if (existingComment) {
-              await github.rest.issues.updateComment({ ...repo, comment_id: existingComment.id, body });
-            } else {
-              await github.rest.issues.createComment({ ...repo, issue_number: prNumber, body });
+            // Gate: fail the step (and therefore the job) when genuine test failures exist.
+            // This is the single source of truth — the same parsed results that drive the
+            // PR comment also determine whether playwright-summary passes or fails.
+            if (totalFailed > 0) {
+              core.setFailed(`${totalFailed} Playwright test(s) failed.`);
             }
-
-      - name: Gate on test results
-        run: |
-          RESULT="${{ needs.playwright-ci-postgresql.result }}"
-          if [ "$RESULT" = "failure" ] || [ "$RESULT" = "cancelled" ]; then
-            echo "Playwright shards did not complete successfully (result: ${RESULT})."
-            exit 1
-          fi
-          echo "Playwright result: ${RESULT}"

--- a/.github/workflows/playwright-postgresql-e2e.yml
+++ b/.github/workflows/playwright-postgresql-e2e.yml
@@ -350,7 +350,7 @@ jobs:
           sudo rm -rf ${PWD}/docker-volume
 
   playwright-summary:
-    if: ${{ !cancelled() && github.event_name == 'pull_request_target' && (github.event.action != 'labeled' || github.event.label.name == 'safe to test') }}
+    if: ${{ !cancelled() && needs.playwright-ci-postgresql.result != 'skipped' }}
     needs: playwright-ci-postgresql
     runs-on: ubuntu-latest
     steps:
@@ -361,6 +361,7 @@ jobs:
           path: results
 
       - name: Post consolidated PR comment
+        if: ${{ github.event_name == 'pull_request_target' && (github.event.action != 'labeled' || github.event.label.name == 'safe to test') }}
         uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -533,3 +534,11 @@ jobs:
             } else {
               await github.rest.issues.createComment({ ...repo, issue_number: prNumber, body });
             }
+
+      - name: Gate on test results
+        run: |
+          if [ "${{ needs.playwright-ci-postgresql.result }}" = "failure" ]; then
+            echo "One or more Playwright shards failed — see the report above."
+            exit 1
+          fi
+          echo "Playwright result: ${{ needs.playwright-ci-postgresql.result }}"

--- a/.github/workflows/playwright-postgresql-e2e.yml
+++ b/.github/workflows/playwright-postgresql-e2e.yml
@@ -537,8 +537,9 @@ jobs:
 
       - name: Gate on test results
         run: |
-          if [ "${{ needs.playwright-ci-postgresql.result }}" = "failure" ]; then
-            echo "One or more Playwright shards failed — see the report above."
+          RESULT="${{ needs.playwright-ci-postgresql.result }}"
+          if [ "$RESULT" = "failure" ] || [ "$RESULT" = "cancelled" ]; then
+            echo "Playwright shards did not complete successfully (result: ${RESULT})."
             exit 1
           fi
-          echo "Playwright result: ${{ needs.playwright-ci-postgresql.result }}"
+          echo "Playwright result: ${RESULT}"

--- a/.github/workflows/playwright-postgresql-e2e.yml
+++ b/.github/workflows/playwright-postgresql-e2e.yml
@@ -210,9 +210,6 @@ jobs:
       - name: Run Playwright tests
         id: run-tests
         working-directory: openmetadata-ui/src/main/resources/ui/
-        env:
-          SPEC_ONLY: ${{ needs.detect-changes.outputs.spec_only_mode }}
-          CHANGED_SPECS: ${{ needs.detect-changes.outputs.changed_specs }}
         run: |
           if [ "$SPEC_ONLY" = "true" ]; then
             echo "🔹 Spec-only mode: running changed specs → ${CHANGED_SPECS}"
@@ -269,6 +266,8 @@ jobs:
           fi
 
         env:
+          SPEC_ONLY: ${{ needs.detect-changes.outputs.spec_only_mode }}
+          CHANGED_SPECS: ${{ needs.detect-changes.outputs.changed_specs }}
           PLAYWRIGHT_IS_OSS: true
           PLAYWRIGHT_SNOWFLAKE_USERNAME: ${{ secrets.TEST_SNOWFLAKE_USERNAME }}
           PLAYWRIGHT_SNOWFLAKE_PASSWORD: ${{ secrets.TEST_SNOWFLAKE_PASSWORD }}


### PR DESCRIPTION
### Describe your changes:

Follow-up to #29331 and #29351.

Branch protection rules hardcode the shard job names `playwright-ci-postgresql (1, 6)` through `(6, 6)`. In spec-only mode (when a PR changes only Playwright spec files), the workflow collapses to a single `(1, 1)` shard — the other five required checks never get reported and the PR stays permanently blocked.

Fix: make `playwright-summary` the single required check.
- `playwright-summary` runs after all shards complete regardless of how many there are (1 in spec-only, 6 in full suite), so the check name is stable
- A new **Gate on test results** step exits 1 if any shard failed, making `playwright-summary` the canonical pass/fail signal
- The PR comment step stays gated on `pull_request_target` — `merge_group` and `workflow_dispatch` runs skip the comment but still gate
- The job-level `if` is changed to `!cancelled() && needs.playwright-ci-postgresql.result != 'skipped'` so draft PRs (where the whole suite is intentionally skipped) don't produce a blocking failure

**Required action after merge**: update branch protection to require `playwright-summary` instead of the six individual shard check names.

### Type of change:
- [x] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation

#
### High-level design:

N/A — small change.

#
### Tests:

#### Use cases covered
- Full suite (6 shards): `playwright-summary` waits for all 6, gates on combined result
- Spec-only (1 shard): `playwright-summary` waits for the single shard, same gate
- Draft PR / build failure: `playwright-ci-postgresql` skipped → `playwright-summary` skipped (not a blocking check)
- `merge_group`: `playwright-summary` runs and gates; PR comment step skipped

#### Manual testing performed
Confirmed the root cause: required checks hardcode shard names with matrix dimensions that change between spec-only and full-suite mode.

#
### UI screen recording / screenshots:

Not applicable.

#
### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.
- [ ] For UI changes: I attached a screen recording and/or screenshots above.
- [ ] I have added tests (unit / integration / Playwright as applicable) and listed them above.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR makes `playwright-summary` the single required branch-protection check instead of the six per-shard job names, fixing spec-only PRs that were permanently blocked because the missing shards were never reported.

- **`playwright-postgresql-e2e-skip.yml`**: Renames the stub job from `playwright-ci-postgresql` (6-shard matrix) to `playwright-summary` (single step), ensuring non-e2e PRs satisfy the new required check name.
- **`playwright-postgresql-e2e.yml`**: Broadens `playwright-summary`'s `if` condition to cover `merge_group`/`workflow_dispatch`, wraps all PR comment logic in a `prNumber` guard so those events skip the comment but still gate, and introduces a `core.setFailed` step that makes `playwright-summary` the canonical pass/fail signal after aggregating shard results.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The approach is sound and the skip-workflow rename correctly aligns both workflows on the playwright-summary check name; the gate in the main workflow correctly fails on test failures and on missing artifacts.

An open thread from a previous review identifies a scenario where some shards are cancelled mid-run (runner eviction / job timeout) while others succeed — playwright-summary would still pass because it only sees the uploaded artifacts and totalFailed from the completed shards, with no visibility into the cancelled ones. That gap remains unaddressed in this diff.

.github/workflows/playwright-postgresql-e2e.yml — specifically the gate logic at the end of the github-script block and the playwright-summary job-level if condition.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/playwright-postgresql-e2e-skip.yml | Renames the job from `playwright-ci-postgresql` (6-shard matrix) to `playwright-summary` (single step, no matrix), so the skip-workflow now satisfies the same required-check name as the real workflow. |
| .github/workflows/playwright-postgresql-e2e.yml | Expands `playwright-summary` to run on all trigger events, wraps PR comment logic in a `prNumber` guard, and adds a `core.setFailed` gate on genuine test failures; the known gap (partially-cancelled shard runs can still yield a false-green) is an existing open thread. |

</details>

</details>

<details open><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    trigger([Trigger: pull_request_target / merge_group / workflow_dispatch]) --> draft{Draft PR?}
    draft -- Yes --> skip_build[build: skipped\ndetect-changes: skipped]
    draft -- No --> build[build: runs]
    build --> detect[detect-changes: runs\nOutputs: matrix 1x1 or 6x1]
    detect --> pci[playwright-ci-postgresql\nmatrix shards run]
    skip_build --> pci_skip[playwright-ci-postgresql: skipped]

    pci -- result != skipped --> summary[playwright-summary]
    pci_skip -- result == skipped --> summary_skip[playwright-summary: skipped\nnot a blocking check]

    summary --> download[Download shard artifacts]
    download --> parse{shardResults.length == 0?}
    parse -- Yes --> fail1[core.setFailed: No results found]
    parse -- No --> aggregate[Aggregate totals]
    aggregate --> prcheck{prNumber set?\npull_request_target}
    prcheck -- Yes --> comment[Post / update PR comment]
    prcheck -- No --> gate
    comment --> gate{totalFailed > 0?}
    gate -- Yes --> fail2[core.setFailed: N tests failed\nplaywright-summary = FAIL]
    gate -- No --> pass[playwright-summary = PASS]

    skip_wf([playwright-postgresql-e2e-skip.yml\nSpec-only / non-UI PRs]) --> summary_pass[playwright-summary: echo + exit 0\nplaywright-summary = PASS]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    trigger([Trigger: pull_request_target / merge_group / workflow_dispatch]) --> draft{Draft PR?}
    draft -- Yes --> skip_build[build: skipped\ndetect-changes: skipped]
    draft -- No --> build[build: runs]
    build --> detect[detect-changes: runs\nOutputs: matrix 1x1 or 6x1]
    detect --> pci[playwright-ci-postgresql\nmatrix shards run]
    skip_build --> pci_skip[playwright-ci-postgresql: skipped]

    pci -- result != skipped --> summary[playwright-summary]
    pci_skip -- result == skipped --> summary_skip[playwright-summary: skipped\nnot a blocking check]

    summary --> download[Download shard artifacts]
    download --> parse{shardResults.length == 0?}
    parse -- Yes --> fail1[core.setFailed: No results found]
    parse -- No --> aggregate[Aggregate totals]
    aggregate --> prcheck{prNumber set?\npull_request_target}
    prcheck -- Yes --> comment[Post / update PR comment]
    prcheck -- No --> gate
    comment --> gate{totalFailed > 0?}
    gate -- Yes --> fail2[core.setFailed: N tests failed\nplaywright-summary = FAIL]
    gate -- No --> pass[playwright-summary = PASS]

    skip_wf([playwright-postgresql-e2e-skip.yml\nSpec-only / non-UI PRs]) --> summary_pass[playwright-summary: echo + exit 0\nplaywright-summary = PASS]
```

</a>
</details>

<sub>Reviews (3): Last reviewed commit: ["ci: update skip workflow to satisfy play..."](https://github.com/open-metadata/openmetadata/commit/35720d3d138a29356c6b28ba7e5bd0aa79598ed9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39270703)</sub>

<!-- /greptile_comment -->