### PR TITLE
fix(ui): correct port card/lineage test-ids in InputOutputPorts e2e

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/InputOutputPorts.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/InputOutputPorts.spec.ts
@@ -785,9 +785,15 @@ test.describe('Input Output Ports', () => {
           ''
         );
 
-        await expect(page.getByTestId(table1Name)).toBeVisible();
-        await expect(page.getByTestId(table2Name)).toBeVisible();
-        await expect(page.getByTestId(table3Name)).toBeVisible();
+        await expect(
+          page.getByTestId(`table-data-card_${table1Name}`)
+        ).toBeVisible();
+        await expect(
+          page.getByTestId(`table-data-card_${table2Name}`)
+        ).toBeVisible();
+        await expect(
+          page.getByTestId(`table-data-card_${table3Name}`)
+        ).toBeVisible();
       });
     });
 
@@ -819,10 +825,14 @@ test.describe('Input Output Ports', () => {
         await expect(page.getByTestId('output-ports-list')).toBeVisible();
 
         await expect(
-          page.getByTestId(dashboards[0].entityResponseData.fullyQualifiedName)
+          page.getByTestId(
+            `table-data-card_${dashboards[0].entityResponseData.fullyQualifiedName}`
+          )
         ).toBeVisible();
         await expect(
-          page.getByTestId(dashboards[1].entityResponseData.fullyQualifiedName)
+          page.getByTestId(
+            `table-data-card_${dashboards[1].entityResponseData.fullyQualifiedName}`
+          )
         ).toBeVisible();
       });
     });
@@ -1151,8 +1161,8 @@ test.describe('Input Output Ports', () => {
         const table2Name =
           tables[1].entityResponseData.fullyQualifiedName ?? '';
 
-        await expect(page.getByTestId(table1Name)).toBeVisible();
-        await expect(page.getByTestId(table2Name)).toBeVisible();
+        await expect(page.getByTestId(`port-node-${table1Name}`)).toBeVisible();
+        await expect(page.getByTestId(`port-node-${table2Name}`)).toBeVisible();
       });
 
       await test.step('Verify output port nodes are visible', async () => {
@@ -1160,10 +1170,14 @@ test.describe('Input Output Ports', () => {
           dashboards[0].entityResponseData.fullyQualifiedName ?? '';
 
         const dashboard2Name =
-          dashboards[1].chartsResponseData.fullyQualifiedName;
+          dashboards[1].entityResponseData.fullyQualifiedName ?? '';
 
-        await expect(page.getByTestId(dashboard1Name)).toBeVisible();
-        await expect(page.getByTestId(dashboard2Name)).toBeVisible();
+        await expect(
+          page.getByTestId(`port-node-${dashboard1Name}`)
+        ).toBeVisible();
+        await expect(
+          page.getByTestId(`port-node-${dashboard2Name}`)
+        ).toBeVisible();
       });
     });
 
@@ -1193,7 +1207,7 @@ test.describe('Input Output Ports', () => {
       await test.step('Verify only input port is shown', async () => {
         await expect(page.getByTestId('ports-lineage-view')).toBeVisible();
         const tableName = tables[0].entityResponseData.fullyQualifiedName ?? '';
-        await expect(page.getByTestId(tableName)).toBeVisible();
+        await expect(page.getByTestId(`port-node-${tableName}`)).toBeVisible();
       });
     });
 
@@ -1224,7 +1238,9 @@ test.describe('Input Output Ports', () => {
         await expect(page.getByTestId('ports-lineage-view')).toBeVisible();
         const dashboardName =
           dashboards[0].entityResponseData.fullyQualifiedName ?? '';
-        await expect(page.getByTestId(dashboardName)).toBeVisible();
+        await expect(
+          page.getByTestId(`port-node-${dashboardName}`)
+        ).toBeVisible();
       });
     });
 


### PR DESCRIPTION
### Describe your changes:

Reference: follows up #28892

I fixed the 5 Playwright failures in `InputOutputPorts.spec.ts` that #28892 introduced on `main`. That PR's Explore card redesign rewrote these assertions to query `getByTestId(<fqn>)`, but no element renders a bare-FQN test-id — so the assertions timed out. I switched them to the test-ids the components actually expose (`table-data-card_<fqn>` for `ExploreSearchCard` list cards, `port-node-<fqn>` for lineage `PortNode`), and corrected one output-port assertion that referenced `chartsResponseData` (the chart FQN) instead of `entityResponseData` (the dashboard FQN).

#
### Type of change:
- [x] Bug fix

#
### High-level design:

N/A — test-only change, single file.

#
### Tests:

#### Use cases covered
- Input/Output ports list renders an entity card per port
- Ports lineage view renders input/output port nodes (both, input-only, output-only)

#### Playwright (UI) tests
- Updated: `openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/InputOutputPorts.spec.ts`

#### Manual testing performed
Ran the 5 previously-failing tests against a local stack — all pass:
Input/Output ports list displays entity cards; Lineage displays input and output ports; Lineage with only input ports; Lineage with only output ports.

#
### UI screen recording / screenshots:

Not applicable — no production code changed.

#
### Checklist:
- [x] I have read the **CONTRIBUTING** document.
- [x] For UI changes: not applicable (test-only).
- [x] I have added/updated tests and listed them above.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes 5 Playwright test failures in `InputOutputPorts.spec.ts` introduced by PR #28892. The assertions were querying bare FQN test-ids that no rendered element actually exposes; this fix aligns them with the real `data-testid` attributes on the components (`table-data-card_<fqn>` for `ExploreSearchCard` list items and `port-node-<fqn>` for `PortNode` lineage components). A separate bug where `dashboards[1].chartsResponseData.fullyQualifiedName` (chart FQN) was used instead of `dashboards[1].entityResponseData.fullyQualifiedName` (dashboard FQN) in the output-port lineage assertion is also corrected.

- **List-card assertions** updated to use `table-data-card_${fqn}`, matching the `data-testid` in `ExploreSearchCard.tsx`.
- **Lineage port-node assertions** updated to use `port-node-${fqn}`, matching the `data-testid` in `PortNode.component.tsx`.
- **`chartsResponseData` → `entityResponseData` fix** corrects the wrong FQN source for `dashboards[1]` in the lineage output-port check.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — test-only change that corrects selector strings to match the real component test-ids.

All changed assertions are verified against the actual data-testid attributes in ExploreSearchCard.tsx and PortNode.component.tsx. The chartsResponseData to entityResponseData correction aligns the dashboard FQN lookup with every other port assertion in the file. No production code is touched.

No files require special attention.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/InputOutputPorts.spec.ts | Test-only fix: aligns 7 getByTestId assertions with the actual data-testid values emitted by ExploreSearchCard and PortNode, and corrects one assertion that was referencing chartsResponseData instead of entityResponseData for a dashboard port-node. |

</details>

</details>

<details open><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[InputOutputPorts Tests] --> B{View Type}
    B --> C[List View]
    B --> D[Lineage View]
    C --> C1[Assert input-ports-list visible]
    C1 --> C2["Assert table-data-card_fqn via ExploreSearchCard"]
    C --> C3[Assert output-ports-list visible]
    C3 --> C4["Assert table-data-card_fqn via ExploreSearchCard"]
    D --> D1[Assert ports-lineage-view visible]
    D1 --> D2["Assert port-node-fqn via PortNode"]
    D2 --> D3["Input ports use tables entityResponseData"]
    D2 --> D4["Output ports use dashboards entityResponseData fixed from chartsResponseData"]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[InputOutputPorts Tests] --> B{View Type}
    B --> C[List View]
    B --> D[Lineage View]
    C --> C1[Assert input-ports-list visible]
    C1 --> C2["Assert table-data-card_fqn via ExploreSearchCard"]
    C --> C3[Assert output-ports-list visible]
    C3 --> C4["Assert table-data-card_fqn via ExploreSearchCard"]
    D --> D1[Assert ports-lineage-view visible]
    D1 --> D2["Assert port-node-fqn via PortNode"]
    D2 --> D3["Input ports use tables entityResponseData"]
    D2 --> D4["Output ports use dashboards entityResponseData fixed from chartsResponseData"]
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(ui): use correct port card/lineage t..."](https://github.com/open-metadata/openmetadata/commit/ce06b5c4c2c97e4823fb0d9cb5391d558cd63644) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39307176)</sub>

<!-- /greptile_comment -->