### PR TITLE
fix(rdf): tolerate disabled RDF when installing RdfIndexApp default app

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/apps/bundles/rdf/RdfIndexApp.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/apps/bundles/rdf/RdfIndexApp.java
@@ -102,8 +102,14 @@ public class RdfIndexApp extends AbstractNativeApplication {
 
   public RdfIndexApp(CollectionDAO collectionDAO, SearchRepository searchRepository) {
     super(collectionDAO, searchRepository);
-    this.rdfRepository = RdfRepository.getInstance();
-    this.batchProcessor = new RdfBatchProcessor(collectionDAO, rdfRepository);
+    // Use getInstanceOrNull(): this app is a seed/default application installed
+    // on every startup, but RdfRepository is only initialized when RDF is
+    // enabled in configuration (disabled by default). Requiring a live instance
+    // here threw IllegalStateException during default-app install whenever RDF
+    // was off. execute() already fails the job gracefully when RDF is disabled.
+    this.rdfRepository = RdfRepository.getInstanceOrNull();
+    this.batchProcessor =
+        rdfRepository == null ? null : new RdfBatchProcessor(collectionDAO, rdfRepository);
   }
 
   @Override
@@ -131,7 +137,7 @@ public class RdfIndexApp extends AbstractNativeApplication {
       }
     }
 
-    if (!rdfRepository.isEnabled()) {
+    if (rdfRepository == null || !rdfRepository.isEnabled()) {
       LOG.error("RDF Repository is not enabled. Please enable RDF in configuration.");
       updateJobStatus(EventPublisherJob.Status.FAILED);
       jobData.setFailure(

--- a/openmetadata-service/src/test/java/org/openmetadata/service/apps/bundles/rdf/RdfIndexAppDisabledRdfTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/apps/bundles/rdf/RdfIndexAppDisabledRdfTest.java
@@ -1,0 +1,114 @@
+/*
+ *  Copyright 2025 Collate
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.openmetadata.service.apps.bundles.rdf;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.Set;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.openmetadata.schema.entity.app.AppRunRecord;
+import org.openmetadata.schema.system.EventPublisherJob;
+import org.openmetadata.service.jdbi3.CollectionDAO;
+import org.openmetadata.service.rdf.RdfRepository;
+import org.openmetadata.service.search.SearchRepository;
+import org.quartz.JobDataMap;
+import org.quartz.JobDetail;
+import org.quartz.JobExecutionContext;
+
+/**
+ * Verifies RdfIndexApp tolerates RDF being disabled. RDF is disabled by default, so the
+ * RdfRepository singleton is never initialized; the app is still installed as a default/seed
+ * application on every startup. This test uses the real (uninitialized) RdfRepository static rather
+ * than a mock so it reproduces the production crash:
+ * IllegalStateException("RdfRepository not initialized").
+ */
+@DisplayName("RdfIndexApp Tests (RDF disabled)")
+class RdfIndexAppDisabledRdfTest {
+
+  private CollectionDAO collectionDAO;
+  private SearchRepository searchRepository;
+
+  private static class TestableRdfIndexApp extends RdfIndexApp {
+    private final AppRunRecord appRunRecord =
+        new AppRunRecord().withStatus(AppRunRecord.Status.RUNNING);
+
+    TestableRdfIndexApp(CollectionDAO collectionDAO, SearchRepository searchRepository) {
+      super(collectionDAO, searchRepository);
+    }
+
+    @Override
+    protected AppRunRecord getJobRecord(JobExecutionContext jobExecutionContext) {
+      return appRunRecord;
+    }
+
+    @Override
+    protected void pushAppStatusUpdates(
+        JobExecutionContext jobExecutionContext, AppRunRecord appRecord, boolean update) {}
+  }
+
+  @BeforeEach
+  void ensureRdfRepositoryNotInitialized() {
+    RdfRepository.reset();
+    collectionDAO = mock(CollectionDAO.class);
+    searchRepository = mock(SearchRepository.class);
+  }
+
+  @AfterEach
+  void cleanup() {
+    RdfRepository.reset();
+  }
+
+  @Test
+  @DisplayName("Constructor must not throw when RdfRepository is not initialized (RDF disabled)")
+  void testConstructorToleratesUninitializedRdfRepository() {
+    assertNull(RdfRepository.getInstanceOrNull(), "Precondition: RDF must be uninitialized");
+    RdfIndexApp app = assertDoesNotThrow(() -> new RdfIndexApp(collectionDAO, searchRepository));
+    assertNotNull(app);
+  }
+
+  @Test
+  @DisplayName("execute must fail the job gracefully when RDF is disabled")
+  void testExecuteFailsGracefullyWhenRdfDisabled() throws Exception {
+    TestableRdfIndexApp app = new TestableRdfIndexApp(collectionDAO, searchRepository);
+
+    EventPublisherJob jobConfig = new EventPublisherJob();
+    jobConfig.setEntities(Set.of("table"));
+    jobConfig.setStatus(EventPublisherJob.Status.STARTED);
+    setJobData(app, jobConfig);
+
+    JobExecutionContext context = mock(JobExecutionContext.class);
+    JobDetail jobDetail = mock(JobDetail.class);
+    when(context.getJobDetail()).thenReturn(jobDetail);
+    when(jobDetail.getJobDataMap()).thenReturn(new JobDataMap());
+
+    assertDoesNotThrow(() -> app.execute(context));
+
+    assertEquals(EventPublisherJob.Status.FAILED, app.getJobData().getStatus());
+    assertNotNull(app.getJobData().getFailure());
+    assertEquals("RDF Repository is not enabled", app.getJobData().getFailure().getMessage());
+  }
+
+  private void setJobData(RdfIndexApp app, EventPublisherJob jobConfig) throws Exception {
+    var jobDataField = RdfIndexApp.class.getDeclaredField("jobData");
+    jobDataField.setAccessible(true);
+    jobDataField.set(app, jobConfig);
+  }
+}

--- a/openmetadata-service/src/test/java/org/openmetadata/service/apps/bundles/rdf/RdfIndexAppTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/apps/bundles/rdf/RdfIndexAppTest.java
@@ -85,7 +85,7 @@ class RdfIndexAppTest {
   static void setUpClass() {
     mockRdfRepository = mock(RdfRepository.class);
     rdfRepositoryMockedStatic = mockStatic(RdfRepository.class);
-    rdfRepositoryMockedStatic.when(RdfRepository::getInstance).thenReturn(mockRdfRepository);
+    rdfRepositoryMockedStatic.when(RdfRepository::getInstanceOrNull).thenReturn(mockRdfRepository);
   }
 
   @AfterAll


### PR DESCRIPTION
### Describe your changes:

Fixes #<issue-number> <!-- TODO: link the GitHub issue for "RdfRepository not initialized" -->

I made `RdfIndexApp`'s constructor tolerate RDF being disabled, because as a seed/default application it is installed on every startup yet called `RdfRepository.getInstance()`, which throws `IllegalStateException: RdfRepository not initialized` whenever RDF is off (the default). The constructor now uses `RdfRepository.getInstanceOrNull()` and `execute()` null-guards before use, matching the safe pattern already used by `RdfResource`, `PipelineRepository`, and `RdfTagUpdater` — and `execute()` already fails the job gracefully when RDF is disabled. This was non-fatal (the install error is caught) but logged a stack trace on every boot and left the app uninstalled.

#
### Type of change:
- [x] Bug fix

#
### High-level design:

N/A — small change.

#
### Tests:

#### Use cases covered
- Server starts with RDF disabled (the default): `RdfIndexApp` installs without throwing.
- `RdfIndexApp.execute()` with RDF disabled marks the run `FAILED` with "RDF Repository is not enabled" instead of crashing.

#### Unit tests
- [x] Added `RdfIndexAppDisabledRdfTest` — reproduces the crash against the real uninitialized singleton (RED without the fix, GREEN with it).
- Updated `RdfIndexAppTest` static stub (`getInstance` → `getInstanceOrNull`).
- Result: 38/38 pass via `mvn -pl openmetadata-service test -Dtest=RdfIndexAppDisabledRdfTest,RdfIndexAppTest`.

#### Backend integration tests
- [x] Not applicable (no API changes).

#### Ingestion integration tests
- [x] Not applicable.

#### Playwright (UI) tests
- [x] Not applicable (no UI changes).

#### Manual testing performed
Verified RED/GREEN: with `getInstance()` the new tests fail with `IllegalStateException: RdfRepository not initialized`; with `getInstanceOrNull()` all 38 pass.

#
### UI screen recording / screenshots:

Not applicable.

#
### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have added tests (unit) and listed them above.
- [x] I have added a test that covers the exact scenario we are fixing.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Fixes a boot-time `IllegalStateException` in `RdfIndexApp` that fired whenever RDF was disabled (the default): the constructor called `RdfRepository.getInstance()`, which throws when the singleton has not been initialized. The fix swaps that for `getInstanceOrNull()` and null-guards `batchProcessor` creation and the `execute()` enabled-check to match the safe pattern already used elsewhere in the codebase.

- **`RdfIndexApp.java`**: constructor now calls `getInstanceOrNull()` and sets `batchProcessor = null` when RDF is off; `execute()` gets an additional `rdfRepository == null` guard so the job fails with a clean status message rather than crashing.
- **`RdfIndexAppDisabledRdfTest.java`**: new test class that uses the real (uninitialized) singleton to reproduce the crash and verify both constructor safety and graceful `execute()` failure.
- **`RdfIndexAppTest.java`**: static mock stub updated from `getInstance` → `getInstanceOrNull` to match the new call site.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is a minimal two-line constructor fix with a matching guard in execute(), well-covered by new and updated tests.

The fix is surgical: it swaps one static call for a null-safe variant, null-guards batchProcessor at construction, and extends an already-existing enabled check in execute(). All code paths that delegate to batchProcessor are reached only after the execute() null check, so no new NPE surface is introduced. No API surface or data model is touched.

No files require special attention.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-service/src/main/java/org/openmetadata/service/apps/bundles/rdf/RdfIndexApp.java | Constructor swapped to getInstanceOrNull() with null-guarded batchProcessor; execute() extended with rdfRepository == null guard — change is minimal and correct. |
| openmetadata-service/src/test/java/org/openmetadata/service/apps/bundles/rdf/RdfIndexAppDisabledRdfTest.java | New test class reproducing the boot-time crash against the real uninitialized singleton; covers constructor safety and graceful execute() failure path. |
| openmetadata-service/src/test/java/org/openmetadata/service/apps/bundles/rdf/RdfIndexAppTest.java | Static mock stub updated from getInstance to getInstanceOrNull to align with the constructor change; no logic changes. |

</details>

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Server as Server Startup
    participant Installer as DefaultApp Installer
    participant App as RdfIndexApp
    participant Repo as RdfRepository

    Server->>Installer: install default apps
    Installer->>App: new RdfIndexApp(dao, search)
    App->>Repo: getInstanceOrNull()
    Note over Repo: RDF disabled (default)
    Repo-->>App: null
    App->>App: "batchProcessor = null"
    App-->>Installer: App constructed (no throw)

    Note over Server: Later — user triggers execute()
    Server->>App: execute(ctx)
    App->>App: "check rdfRepository == null"
    App->>App: updateJobStatus(FAILED)
    App->>App: setFailure(RDF Repository is not enabled)
    App->>App: sendUpdates(ctx, true)
    App-->>Server: return (graceful exit)
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Server as Server Startup
    participant Installer as DefaultApp Installer
    participant App as RdfIndexApp
    participant Repo as RdfRepository

    Server->>Installer: install default apps
    Installer->>App: new RdfIndexApp(dao, search)
    App->>Repo: getInstanceOrNull()
    Note over Repo: RDF disabled (default)
    Repo-->>App: null
    App->>App: "batchProcessor = null"
    App-->>Installer: App constructed (no throw)

    Note over Server: Later — user triggers execute()
    Server->>App: execute(ctx)
    App->>App: "check rdfRepository == null"
    App->>App: updateJobStatus(FAILED)
    App->>App: setFailure(RDF Repository is not enabled)
    App->>App: sendUpdates(ctx, true)
    App-->>Server: return (graceful exit)
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(rdf): tolerate disabled RDF when ins..."](https://github.com/open-metadata/openmetadata/commit/ba020718ee6d1992d5e451d6b6c66d86a0b52e83) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39324370)</sub>

<!-- /greptile_comment -->