### PR TITLE
fix(block-editor): keep link modal usable inside focus-trapping drawers

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/BlockEditor/EditorSlots.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/BlockEditor/EditorSlots.test.tsx
@@ -1,0 +1,101 @@
+/*
+ *  Copyright 2026 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+import { Editor } from '@tiptap/react';
+import StarterKit from '@tiptap/starter-kit';
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from '@testing-library/react';
+import { createRef } from 'react';
+import { EditorSlotsRef } from './BlockEditor.interface';
+import EditorSlots from './EditorSlots';
+import { LinkExtension } from './Extensions/link';
+
+// The surrounding menus rely on tippy.js / portals and are irrelevant to the
+// link-handling logic under test.
+jest.mock('./BlockMenu/BlockMenu', () => () => null);
+jest.mock('./BubbleMenu/BubbleMenu', () => () => null);
+jest.mock('./TableMenu/TableMenu', () => () => null);
+jest.mock('./LinkPopup/LinkPopup', () => () => null);
+jest.mock('tippy.js', () => ({
+  __esModule: true,
+  default: jest.fn(() => []),
+}));
+
+const createTestEditor = (content: string) =>
+  new Editor({
+    extensions: [StarterKit, LinkExtension],
+    content,
+  });
+
+const fillLinkAndSave = async (href: string) => {
+  await waitFor(() => expect(screen.getByRole('textbox')).toBeInTheDocument());
+  fireEvent.change(screen.getByRole('textbox'), { target: { value: href } });
+  fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+};
+
+describe('EditorSlots link handling', () => {
+  const HREF = 'https://example.com/view';
+
+  it('inserts the href as the link text when no text is selected', async () => {
+    const editor = createTestEditor('<p></p>');
+    const ref = createRef<EditorSlotsRef>();
+
+    render(<EditorSlots editor={editor} menuType="bar" ref={ref} />);
+
+    act(() => {
+      ref.current?.onLinkToggle();
+    });
+
+    await fillLinkAndSave(HREF);
+
+    await waitFor(() => {
+      const html = editor.getHTML();
+
+      expect(html).toContain(`href="${HREF}"`);
+      // No selection -> the href itself becomes the visible, clickable text.
+      expect(html).toMatch(/<a[^>]*>https:\/\/example\.com\/view<\/a>/);
+    });
+
+    editor.destroy();
+  });
+
+  it('wraps the selected text in a link when text is selected', async () => {
+    const editor = createTestEditor('<p>Hello</p>');
+    const ref = createRef<EditorSlotsRef>();
+
+    // Select the word "Hello".
+    editor.commands.setTextSelection({ from: 1, to: 6 });
+
+    render(<EditorSlots editor={editor} menuType="bar" ref={ref} />);
+
+    act(() => {
+      ref.current?.onLinkToggle();
+    });
+
+    await fillLinkAndSave(HREF);
+
+    await waitFor(() => {
+      const html = editor.getHTML();
+
+      expect(html).toContain(`href="${HREF}"`);
+      // The existing selection is preserved as the link text.
+      expect(html).toMatch(/<a[^>]*>Hello<\/a>/);
+    });
+
+    editor.destroy();
+  });
+});

--- a/openmetadata-ui/src/main/resources/ui/src/components/BlockEditor/EditorSlots.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/BlockEditor/EditorSlots.tsx
@@ -50,7 +50,27 @@ const EditorSlots = forwardRef<EditorSlotsRef, EditorSlotsProps>(
       }
 
       if (op === 'add') {
-        editor?.chain().focus().setLink({ href: values.href }).run();
+        const { from, to } = editor.state.selection;
+        const hasSelectedText = from !== to;
+
+        if (hasSelectedText) {
+          // Wrap the selected text in a link.
+          editor.chain().focus().setLink({ href: values.href }).run();
+        } else {
+          // No text selected: insert the href as the link text. setLink on an
+          // empty selection only sets a stored mark and renders nothing, which
+          // makes the link silently "disappear". Inserting the href as linked
+          // text guarantees a visible, clickable link.
+          editor
+            .chain()
+            .focus()
+            .insertContent({
+              type: 'text',
+              text: values.href,
+              marks: [{ type: 'link', attrs: { href: values.href } }],
+            })
+            .run();
+        }
       }
 
       // move cursor at the end
@@ -59,6 +79,14 @@ const EditorSlots = forwardRef<EditorSlotsRef, EditorSlotsProps>(
       // close the modal
       handleLinkToggle();
     };
+
+    // Mount the link modal inside the nearest dialog/drawer (if any) so a
+    // focus-trapping overlay (e.g. React Aria's SlideoutMenu) does not steal
+    // focus from the modal input or dismiss the drawer when the modal opens.
+    // Falls back to document.body when the editor is not inside a dialog.
+    const getLinkModalContainer = (): HTMLElement =>
+      (editor?.view.dom.closest('[role="dialog"]') as HTMLElement) ??
+      document.body;
 
     const handleUnlink = () => {
       if (isNil(editor)) {
@@ -160,6 +188,7 @@ const EditorSlots = forwardRef<EditorSlotsRef, EditorSlotsProps>(
         {isLinkModalOpen && (
           <LinkModal
             data={{ href: editor?.getAttributes('link').href }}
+            getContainer={getLinkModalContainer}
             isOpen={isLinkModalOpen}
             onCancel={handleLinkCancel}
             onSave={(values) =>

--- a/openmetadata-ui/src/main/resources/ui/src/components/BlockEditor/LinkModal/LinkModal.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/BlockEditor/LinkModal/LinkModal.test.tsx
@@ -1,0 +1,97 @@
+/*
+ *  Copyright 2026 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import LinkModal from './LinkModal';
+
+const onSave = jest.fn();
+const onCancel = jest.fn();
+
+const defaultProps = {
+  isOpen: true,
+  data: { href: '' },
+  onSave,
+  onCancel,
+};
+
+describe('LinkModal', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should render the "Add link" title and the link input when href is empty', () => {
+    render(<LinkModal {...defaultProps} />);
+
+    expect(screen.getByText('Add link')).toBeInTheDocument();
+    expect(screen.getByRole('textbox')).toBeInTheDocument();
+  });
+
+  it('should render the "Edit link" title when an href is provided', () => {
+    render(<LinkModal {...defaultProps} data={{ href: 'https://x.com' }} />);
+
+    expect(screen.getByText('Edit link')).toBeInTheDocument();
+  });
+
+  it('should call onSave with the entered href on submit', async () => {
+    render(<LinkModal {...defaultProps} />);
+
+    fireEvent.change(screen.getByRole('textbox'), {
+      target: { value: '{{buildEntityUrl event.entityType entity}}' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+    await waitFor(() =>
+      expect(onSave).toHaveBeenCalledWith({
+        href: '{{buildEntityUrl event.entityType entity}}',
+      })
+    );
+  });
+
+  it('should call onCancel when the cancel button is clicked', () => {
+    render(<LinkModal {...defaultProps} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+
+  // Regression: when the editor lives inside a focus-trapping dialog/drawer
+  // (e.g. React Aria's SlideoutMenu), the modal must portal INTO that dialog so
+  // the dialog's focus scope and useInteractOutside do not steal focus from the
+  // input or dismiss the drawer when the modal opens.
+  it('should mount the modal inside the container returned by getContainer', () => {
+    const host = document.createElement('div');
+    host.setAttribute('data-testid', 'dialog-host');
+    document.body.appendChild(host);
+
+    render(<LinkModal {...defaultProps} getContainer={() => host} />);
+
+    expect(host.querySelector('.block-editor-link-modal')).toBeInTheDocument();
+
+    document.body.removeChild(host);
+  });
+
+  it('should apply a z-index above the React Aria overlay (100000)', () => {
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+
+    render(<LinkModal {...defaultProps} getContainer={() => host} />);
+
+    const elementsWithZIndex = Array.from(
+      host.querySelectorAll<HTMLElement>('*')
+    ).filter((element) => element.style.zIndex === '100001');
+
+    expect(elementsWithZIndex.length).toBeGreaterThan(0);
+
+    document.body.removeChild(host);
+  });
+});

--- a/openmetadata-ui/src/main/resources/ui/src/components/BlockEditor/LinkModal/LinkModal.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/BlockEditor/LinkModal/LinkModal.tsx
@@ -22,9 +22,31 @@ export interface LinkModalProps {
   data: LinkData;
   onSave: (data: LinkData) => void;
   onCancel: () => void;
+  /**
+   * Optional portal container for the modal. When the editor lives inside a
+   * focus-trapping dialog/drawer (e.g. React Aria's SlideoutMenu), the modal
+   * must render *inside* that dialog so the dialog's focus scope and
+   * useInteractOutside do not steal focus from the input or dismiss the drawer
+   * when the modal opens. Falls back to document.body (antd default) otherwise.
+   */
+  getContainer?: () => HTMLElement;
 }
 
-const LinkModal: FC<LinkModalProps> = ({ isOpen, data, onSave, onCancel }) => {
+/**
+ * z-index for the link modal when mounted inside a React Aria dialog. Must
+ * exceed React Aria's useOverlayPosition z-index (100000) so the modal and its
+ * mask paint above the dialog content. Keep in sync with the suggestion popup
+ * z-index used by the handlebars extension.
+ */
+const LINK_MODAL_Z_INDEX = 100001;
+
+const LinkModal: FC<LinkModalProps> = ({
+  isOpen,
+  data,
+  onSave,
+  onCancel,
+  getContainer,
+}) => {
   const handleSubmit: FormProps<LinkData>['onFinish'] = (values) => {
     onSave(values);
   };
@@ -32,6 +54,7 @@ const LinkModal: FC<LinkModalProps> = ({ isOpen, data, onSave, onCancel }) => {
   return (
     <Modal
       className="block-editor-link-modal"
+      getContainer={getContainer}
       maskClosable={false}
       okButtonProps={{
         htmlType: 'submit',
@@ -41,6 +64,7 @@ const LinkModal: FC<LinkModalProps> = ({ isOpen, data, onSave, onCancel }) => {
       okText="Save"
       open={isOpen}
       title={data.href ? 'Edit link' : 'Add link'}
+      zIndex={LINK_MODAL_Z_INDEX}
       onCancel={onCancel}>
       <Form
         data-testid="link-form"


### PR DESCRIPTION
## Problem

When the BlockEditor is rendered inside a focus‑trapping dialog/drawer (e.g. a React‑Aria `SlideoutMenu`, used by the notification‑template editor), the rich‑text **link** tool is unusable:

- The link modal is an antd `Modal` portaled to `document.body` — **outside** the dialog's focus scope. The dialog's `FocusScope` (`contain`) and `useInteractOutside` then steal focus from the modal's URL input and can dismiss the drawer, so the modal is **frozen** (can't type / Save / Cancel).
- Adding a link with **no text selected** only sets a TipTap "stored mark" and renders no anchor, so the link silently disappears.

## Fix

1. **Mount the link modal inside the editor's nearest `[role="dialog"]`** (falling back to `document.body`) with a z‑index above React‑Aria's overlay, so it stays inside the dialog's focus scope and remains interactive. This mirrors the existing `getPopupContainer` workaround already used for the handlebars suggestion popup.
2. **Insert the href as the link text when no text is selected**, so adding a link always produces a visible, clickable `<a>` (selected text is still wrapped as before).

## Tests

- `LinkModal.test.tsx` — `getContainer` forwarding, z‑index, save/cancel, title.
- `EditorSlots.test.tsx` — link insertion for both empty and non‑empty selections (verified to fail without the fix).

## Notes

- Pure FE change to a shared BlockEditor; falls back to prior behavior outside dialogs.
- Pulled into Collate via the submodule. Collate tracking issue: open-metadata/openmetadata-collate#4677.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes two bugs in the BlockEditor's link tool when the editor is hosted inside a focus-trapping dialog (e.g. React Aria's `SlideoutMenu`): the link modal is now portaled into the nearest `[role="dialog"]` ancestor so the dialog's `FocusScope` cannot steal focus or dismiss the drawer, and inserting a link on an empty selection now produces a visible `<a>` tag by using the href as the link text instead of a silent stored mark.

- **Container fix** (`EditorSlots.tsx`, `LinkModal.tsx`): `getLinkModalContainer` walks up the DOM at modal-mount time and passes the result as antd's `getContainer`; falls back to `document.body` outside dialogs, mirroring the existing handlebars-suggestion-popup workaround.
- **Empty-selection fix** (`EditorSlots.tsx`): when `from === to`, `insertContent` with an explicit `link` mark is used instead of `setLink`, guaranteeing a clickable anchor node in the document.
- **Tests** (`EditorSlots.test.tsx`, `LinkModal.test.tsx`): two new test files covering both insertion branches and the container/z-index forwarding behaviour.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge — the dialog-scoped portal and empty-selection insertion are correctly implemented and covered by new tests; the only concerns are cosmetic.

The two functional fixes are well-reasoned and verified by tests. The main side-effect worth watching is that `zIndex={100001}` is now applied to every link modal unconditionally — even when the editor is not inside a dialog and the modal portals to `document.body`. This changes the stacking context for all usages, though in practice the link modal is already the topmost UI element and the elevation is unlikely to cause visible regressions. `getLinkModalContainer` is also re-created on every render without `useCallback`, which is harmless today but untidy.

Both new test files are clean. `LinkModal.tsx`'s unconditional z-index and `EditorSlots.tsx`'s un-memoized helper are the spots worth a second look before merging.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-ui/src/main/resources/ui/src/components/BlockEditor/EditorSlots.tsx | Adds `getLinkModalContainer` to portal the link modal into the nearest `[role="dialog"]`, and fixes silent link disappearance on empty selection by inserting the href as linked text. Logic is correct; `getLinkModalContainer` lacks `useCallback`. |
| openmetadata-ui/src/main/resources/ui/src/components/BlockEditor/LinkModal/LinkModal.tsx | Adds optional `getContainer` prop and hardcodes `zIndex={100001}` unconditionally; the z-index elevation applies even when the modal mounts in `document.body`, changing existing layering behavior globally. |
| openmetadata-ui/src/main/resources/ui/src/components/BlockEditor/LinkModal/LinkModal.test.tsx | New test file covering container forwarding, z-index, save, cancel, and title rendering. Well-structured and cleans up its DOM after each test. |
| openmetadata-ui/src/main/resources/ui/src/components/BlockEditor/EditorSlots.test.tsx | New test file covering the two link insertion branches (empty vs. non-empty selection) with a real TipTap editor instance; exercises the exact fix path. |

</details>

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant User
    participant EditorSlots
    participant getLinkModalContainer
    participant LinkModal
    participant AntdModal

    User->>EditorSlots: onLinkToggle()
    EditorSlots->>EditorSlots: setIsLinkModalOpen(true)
    EditorSlots->>getLinkModalContainer: called by antd on modal mount
    getLinkModalContainer->>getLinkModalContainer: "editor.view.dom.closest('[role=dialog]')"
    alt Inside a focus-trapping dialog
        getLinkModalContainer-->>LinkModal: returns dialogElement
        LinkModal->>AntdModal: "getContainer=dialogElement, zIndex=100001"
        Note over AntdModal: Portal renders inside dialog's focus scope
    else No parent dialog
        getLinkModalContainer-->>LinkModal: returns document.body
        LinkModal->>AntdModal: "getContainer=document.body, zIndex=100001"
        Note over AntdModal: Standard portal (z-index elevated unconditionally)
    end
    User->>LinkModal: enters URL, clicks Save
    LinkModal->>EditorSlots: handleLinkSave(values, 'add')
    alt "Text selected (from !== to)"
        EditorSlots->>EditorSlots: "editor.chain().setLink({ href }).run()"
    else No selection
        EditorSlots->>EditorSlots: "editor.chain().insertContent({ text: href, marks:[link] }).run()"
    end
    EditorSlots->>EditorSlots: selectTextblockEnd()
    EditorSlots->>EditorSlots: setIsLinkModalOpen(false)
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant User
    participant EditorSlots
    participant getLinkModalContainer
    participant LinkModal
    participant AntdModal

    User->>EditorSlots: onLinkToggle()
    EditorSlots->>EditorSlots: setIsLinkModalOpen(true)
    EditorSlots->>getLinkModalContainer: called by antd on modal mount
    getLinkModalContainer->>getLinkModalContainer: "editor.view.dom.closest('[role=dialog]')"
    alt Inside a focus-trapping dialog
        getLinkModalContainer-->>LinkModal: returns dialogElement
        LinkModal->>AntdModal: "getContainer=dialogElement, zIndex=100001"
        Note over AntdModal: Portal renders inside dialog's focus scope
    else No parent dialog
        getLinkModalContainer-->>LinkModal: returns document.body
        LinkModal->>AntdModal: "getContainer=document.body, zIndex=100001"
        Note over AntdModal: Standard portal (z-index elevated unconditionally)
    end
    User->>LinkModal: enters URL, clicks Save
    LinkModal->>EditorSlots: handleLinkSave(values, 'add')
    alt "Text selected (from !== to)"
        EditorSlots->>EditorSlots: "editor.chain().setLink({ href }).run()"
    else No selection
        EditorSlots->>EditorSlots: "editor.chain().insertContent({ text: href, marks:[link] }).run()"
    end
    EditorSlots->>EditorSlots: selectTextblockEnd()
    EditorSlots->>EditorSlots: setIsLinkModalOpen(false)
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(block-editor): keep link modal usabl..."](https://github.com/open-metadata/openmetadata/commit/c9611603ef9ce80a73be50a49987c4fb345f5e49) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39331584)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->