### PR TITLE
fix(block-editor): keep link modal usable inside focus-trapping drawers

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/BlockEditor/EditorSlots.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/BlockEditor/EditorSlots.test.tsx
@@ -122,10 +122,9 @@ describe('EditorSlots link handling', () => {
 
     const options = (tippy as jest.Mock).mock.calls[0][1];
 
-    // The popup must mount inside the dialog (not document.body) and paint above
-    // the React Aria overlay so its actions remain clickable.
+    // The popup must mount inside the dialog (not document.body) so its actions
+    // remain clickable inside a focus-trapping overlay.
     expect(options.appendTo()).toBe(dialog);
-    expect(options.zIndex).toBe(100001);
 
     editor.destroy();
     document.body.removeChild(dialog);

--- a/openmetadata-ui/src/main/resources/ui/src/components/BlockEditor/EditorSlots.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/BlockEditor/EditorSlots.test.tsx
@@ -130,4 +130,38 @@ describe('EditorSlots link handling', () => {
     editor.destroy();
     document.body.removeChild(dialog);
   });
+
+  it('falls back to document.body when the editor is inside an antd modal', () => {
+    // antd modals also expose role="dialog" but do not trap focus and would
+    // misposition a nested modal, so the link overlays must stay in body.
+    const dialog = document.createElement('div');
+    dialog.setAttribute('role', 'dialog');
+    dialog.className = 'ant-modal';
+    document.body.appendChild(dialog);
+    const editorElement = document.createElement('div');
+    dialog.appendChild(editorElement);
+
+    const editor = new Editor({
+      element: editorElement,
+      extensions: [StarterKit, LinkExtension],
+      content: '<p><a href="https://example.com">link</a></p>',
+    });
+    const ref = createRef<EditorSlotsRef>();
+
+    render(<EditorSlots editor={editor} menuType="bar" ref={ref} />);
+
+    const anchor = editorElement.querySelector('a') as HTMLElement;
+    act(() => {
+      ref.current?.onMouseDown({
+        target: anchor,
+      } as unknown as Parameters<EditorSlotsRef['onMouseDown']>[0]);
+    });
+
+    const options = (tippy as jest.Mock).mock.calls[0][1];
+
+    expect(options.appendTo()).toBe(document.body);
+
+    editor.destroy();
+    document.body.removeChild(dialog);
+  });
 });

--- a/openmetadata-ui/src/main/resources/ui/src/components/BlockEditor/EditorSlots.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/BlockEditor/EditorSlots.test.tsx
@@ -1,0 +1,101 @@
+/*
+ *  Copyright 2026 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from '@testing-library/react';
+import { Editor } from '@tiptap/react';
+import StarterKit from '@tiptap/starter-kit';
+import { createRef } from 'react';
+import { EditorSlotsRef } from './BlockEditor.interface';
+import EditorSlots from './EditorSlots';
+import { LinkExtension } from './Extensions/link';
+
+// The surrounding menus rely on tippy.js / portals and are irrelevant to the
+// link-handling logic under test.
+jest.mock('./BlockMenu/BlockMenu', () => () => null);
+jest.mock('./BubbleMenu/BubbleMenu', () => () => null);
+jest.mock('./TableMenu/TableMenu', () => () => null);
+jest.mock('./LinkPopup/LinkPopup', () => () => null);
+jest.mock('tippy.js', () => ({
+  __esModule: true,
+  default: jest.fn(() => []),
+}));
+
+const createTestEditor = (content: string) =>
+  new Editor({
+    extensions: [StarterKit, LinkExtension],
+    content,
+  });
+
+const fillLinkAndSave = async (href: string) => {
+  await waitFor(() => expect(screen.getByRole('textbox')).toBeInTheDocument());
+  fireEvent.change(screen.getByRole('textbox'), { target: { value: href } });
+  fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+};
+
+describe('EditorSlots link handling', () => {
+  const HREF = 'https://example.com/view';
+
+  it('inserts the href as the link text when no text is selected', async () => {
+    const editor = createTestEditor('<p></p>');
+    const ref = createRef<EditorSlotsRef>();
+
+    render(<EditorSlots editor={editor} menuType="bar" ref={ref} />);
+
+    act(() => {
+      ref.current?.onLinkToggle();
+    });
+
+    await fillLinkAndSave(HREF);
+
+    await waitFor(() => {
+      const html = editor.getHTML();
+
+      expect(html).toContain(`href="${HREF}"`);
+      // No selection -> the href itself becomes the visible, clickable text.
+      expect(html).toMatch(/<a[^>]*>https:\/\/example\.com\/view<\/a>/);
+    });
+
+    editor.destroy();
+  });
+
+  it('wraps the selected text in a link when text is selected', async () => {
+    const editor = createTestEditor('<p>Hello</p>');
+    const ref = createRef<EditorSlotsRef>();
+
+    // Select the word "Hello".
+    editor.commands.setTextSelection({ from: 1, to: 6 });
+
+    render(<EditorSlots editor={editor} menuType="bar" ref={ref} />);
+
+    act(() => {
+      ref.current?.onLinkToggle();
+    });
+
+    await fillLinkAndSave(HREF);
+
+    await waitFor(() => {
+      const html = editor.getHTML();
+
+      expect(html).toContain(`href="${HREF}"`);
+      // The existing selection is preserved as the link text.
+      expect(html).toMatch(/<a[^>]*>Hello<\/a>/);
+    });
+
+    editor.destroy();
+  });
+});

--- a/openmetadata-ui/src/main/resources/ui/src/components/BlockEditor/EditorSlots.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/BlockEditor/EditorSlots.test.tsx
@@ -24,8 +24,6 @@ import { EditorSlotsRef } from './BlockEditor.interface';
 import EditorSlots from './EditorSlots';
 import { LinkExtension } from './Extensions/link';
 
-// The surrounding menus rely on tippy.js / portals and are irrelevant to the
-// link-handling logic under test.
 jest.mock('./BlockMenu/BlockMenu', () => () => null);
 jest.mock('./BubbleMenu/BubbleMenu', () => () => null);
 jest.mock('./TableMenu/TableMenu', () => () => null);
@@ -66,7 +64,6 @@ describe('EditorSlots link handling', () => {
       const html = editor.getHTML();
 
       expect(html).toContain(`href="${HREF}"`);
-      // No selection -> the href itself becomes the visible, clickable text.
       expect(html).toMatch(/<a[^>]*>https:\/\/example\.com\/view<\/a>/);
     });
 
@@ -77,7 +74,6 @@ describe('EditorSlots link handling', () => {
     const editor = createTestEditor('<p>Hello</p>');
     const ref = createRef<EditorSlotsRef>();
 
-    // Select the word "Hello".
     editor.commands.setTextSelection({ from: 1, to: 6 });
 
     render(<EditorSlots editor={editor} menuType="bar" ref={ref} />);
@@ -92,7 +88,6 @@ describe('EditorSlots link handling', () => {
       const html = editor.getHTML();
 
       expect(html).toContain(`href="${HREF}"`);
-      // The existing selection is preserved as the link text.
       expect(html).toMatch(/<a[^>]*>Hello<\/a>/);
     });
 

--- a/openmetadata-ui/src/main/resources/ui/src/components/BlockEditor/EditorSlots.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/BlockEditor/EditorSlots.test.tsx
@@ -20,6 +20,7 @@ import {
 import { Editor } from '@tiptap/react';
 import StarterKit from '@tiptap/starter-kit';
 import { createRef } from 'react';
+import tippy from 'tippy.js';
 import { EditorSlotsRef } from './BlockEditor.interface';
 import EditorSlots from './EditorSlots';
 import { LinkExtension } from './Extensions/link';
@@ -92,5 +93,41 @@ describe('EditorSlots link handling', () => {
     });
 
     editor.destroy();
+  });
+
+  it('mounts the link popup inside the editor dialog with an elevated z-index', () => {
+    const dialog = document.createElement('div');
+    dialog.setAttribute('role', 'dialog');
+    document.body.appendChild(dialog);
+    const editorElement = document.createElement('div');
+    dialog.appendChild(editorElement);
+
+    const editor = new Editor({
+      element: editorElement,
+      extensions: [StarterKit, LinkExtension],
+      content: '<p><a href="https://example.com">link</a></p>',
+    });
+    const ref = createRef<EditorSlotsRef>();
+
+    render(<EditorSlots editor={editor} menuType="bar" ref={ref} />);
+
+    const anchor = editorElement.querySelector('a') as HTMLElement;
+    act(() => {
+      ref.current?.onMouseDown({
+        target: anchor,
+      } as unknown as Parameters<EditorSlotsRef['onMouseDown']>[0]);
+    });
+
+    expect(tippy).toHaveBeenCalled();
+
+    const options = (tippy as jest.Mock).mock.calls[0][1];
+
+    // The popup must mount inside the dialog (not document.body) and paint above
+    // the React Aria overlay so its actions remain clickable.
+    expect(options.appendTo()).toBe(dialog);
+    expect(options.zIndex).toBe(100001);
+
+    editor.destroy();
+    document.body.removeChild(dialog);
   });
 });

--- a/openmetadata-ui/src/main/resources/ui/src/components/BlockEditor/EditorSlots.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/BlockEditor/EditorSlots.tsx
@@ -14,7 +14,6 @@ import { ReactRenderer, type Editor } from '@tiptap/react';
 import { isEmpty, isNil } from 'lodash';
 import { forwardRef, useImperativeHandle, useState } from 'react';
 import tippy, { Instance, Props } from 'tippy.js';
-import { LINK_OVERLAY_Z_INDEX } from '../../constants/BlockEditor.constants';
 import { EditorSlotsProps, EditorSlotsRef } from './BlockEditor.interface';
 import BlockMenu from './BlockMenu/BlockMenu';
 import BubbleMenu from './BubbleMenu/BubbleMenu';
@@ -160,7 +159,6 @@ const EditorSlots = forwardRef<EditorSlotsRef, EditorSlotsProps>(
           trigger: 'manual',
           placement: 'top',
           hideOnClick: true,
-          zIndex: LINK_OVERLAY_Z_INDEX,
         });
         hasPopup = !isEmpty(popup);
       } else {

--- a/openmetadata-ui/src/main/resources/ui/src/components/BlockEditor/EditorSlots.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/BlockEditor/EditorSlots.tsx
@@ -78,12 +78,18 @@ const EditorSlots = forwardRef<EditorSlotsRef, EditorSlotsProps>(
       handleLinkToggle();
     };
 
-    // Mount the link modal and link popup inside the editor's dialog (if any)
-    // so a focus-trapping overlay does not steal focus or swallow their clicks.
-    // Falls back to document.body.
-    const getDialogContainer = (): HTMLElement =>
-      (editor?.view.dom.closest('[role="dialog"]') as HTMLElement) ??
-      document.body;
+    // Mount the link modal and popup inside the editor's nearest focus-trapping
+    // dialog (e.g. React Aria's SlideoutMenu) so it does not steal focus or
+    // swallow their clicks. antd modals/drawers don't trap focus from a
+    // body-portalled modal, and their transforms would misposition it, so fall
+    // back to document.body for those (and when not inside a dialog at all).
+    const getDialogContainer = (): HTMLElement => {
+      const dialog = editor?.view.dom.closest('[role="dialog"]');
+
+      return dialog && !dialog.closest('.ant-modal, .ant-drawer')
+        ? (dialog as HTMLElement)
+        : document.body;
+    };
 
     const handleUnlink = () => {
       if (isNil(editor)) {

--- a/openmetadata-ui/src/main/resources/ui/src/components/BlockEditor/EditorSlots.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/BlockEditor/EditorSlots.tsx
@@ -21,6 +21,10 @@ import LinkModal, { LinkData } from './LinkModal/LinkModal';
 import LinkPopup from './LinkPopup/LinkPopup';
 import TableMenu from './TableMenu/TableMenu';
 
+// Must exceed React Aria's overlay z-index (100000) so the link popup paints
+// above the dialog content when mounted inside a focus-trapping dialog.
+const LINK_POPUP_Z_INDEX = 100001;
+
 const EditorSlots = forwardRef<EditorSlotsRef, EditorSlotsProps>(
   ({ editor, menuType }, ref) => {
     const [isLinkModalOpen, setIsLinkModalOpen] = useState<boolean>(false);
@@ -54,13 +58,10 @@ const EditorSlots = forwardRef<EditorSlotsRef, EditorSlotsProps>(
         const hasSelectedText = from !== to;
 
         if (hasSelectedText) {
-          // Wrap the selected text in a link.
           editor.chain().focus().setLink({ href: values.href }).run();
         } else {
-          // No text selected: insert the href as the link text. setLink on an
-          // empty selection only sets a stored mark and renders nothing, which
-          // makes the link silently "disappear". Inserting the href as linked
-          // text guarantees a visible, clickable link.
+          // setLink on an empty selection only sets a stored mark and renders
+          // nothing, so insert the href as the link text to get a visible link.
           editor
             .chain()
             .focus()
@@ -80,11 +81,10 @@ const EditorSlots = forwardRef<EditorSlotsRef, EditorSlotsProps>(
       handleLinkToggle();
     };
 
-    // Mount the link modal inside the nearest dialog/drawer (if any) so a
-    // focus-trapping overlay (e.g. React Aria's SlideoutMenu) does not steal
-    // focus from the modal input or dismiss the drawer when the modal opens.
-    // Falls back to document.body when the editor is not inside a dialog.
-    const getLinkModalContainer = (): HTMLElement =>
+    // Mount the link modal and link popup inside the editor's dialog (if any)
+    // so a focus-trapping overlay does not steal focus or swallow their clicks.
+    // Falls back to document.body.
+    const getDialogContainer = (): HTMLElement =>
       (editor?.view.dom.closest('[role="dialog"]') as HTMLElement) ??
       document.body;
 
@@ -150,13 +150,14 @@ const EditorSlots = forwardRef<EditorSlotsRef, EditorSlotsProps>(
 
         popup = tippy('body', {
           getReferenceClientRect: () => target.getBoundingClientRect(),
-          appendTo: () => document.body,
+          appendTo: () => getDialogContainer(),
           content: component.element,
           showOnCreate: true,
           interactive: true,
           trigger: 'manual',
           placement: 'top',
           hideOnClick: true,
+          zIndex: LINK_POPUP_Z_INDEX,
         });
         hasPopup = !isEmpty(popup);
       } else {
@@ -188,7 +189,7 @@ const EditorSlots = forwardRef<EditorSlotsRef, EditorSlotsProps>(
         {isLinkModalOpen && (
           <LinkModal
             data={{ href: editor?.getAttributes('link').href }}
-            getContainer={getLinkModalContainer}
+            getContainer={getDialogContainer}
             isOpen={isLinkModalOpen}
             onCancel={handleLinkCancel}
             onSave={(values) =>

--- a/openmetadata-ui/src/main/resources/ui/src/components/BlockEditor/EditorSlots.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/BlockEditor/EditorSlots.tsx
@@ -14,16 +14,13 @@ import { ReactRenderer, type Editor } from '@tiptap/react';
 import { isEmpty, isNil } from 'lodash';
 import { forwardRef, useImperativeHandle, useState } from 'react';
 import tippy, { Instance, Props } from 'tippy.js';
+import { LINK_OVERLAY_Z_INDEX } from '../../constants/BlockEditor.constants';
 import { EditorSlotsProps, EditorSlotsRef } from './BlockEditor.interface';
 import BlockMenu from './BlockMenu/BlockMenu';
 import BubbleMenu from './BubbleMenu/BubbleMenu';
 import LinkModal, { LinkData } from './LinkModal/LinkModal';
 import LinkPopup from './LinkPopup/LinkPopup';
 import TableMenu from './TableMenu/TableMenu';
-
-// Must exceed React Aria's overlay z-index (100000) so the link popup paints
-// above the dialog content when mounted inside a focus-trapping dialog.
-const LINK_POPUP_Z_INDEX = 100001;
 
 const EditorSlots = forwardRef<EditorSlotsRef, EditorSlotsProps>(
   ({ editor, menuType }, ref) => {
@@ -157,7 +154,7 @@ const EditorSlots = forwardRef<EditorSlotsRef, EditorSlotsProps>(
           trigger: 'manual',
           placement: 'top',
           hideOnClick: true,
-          zIndex: LINK_POPUP_Z_INDEX,
+          zIndex: LINK_OVERLAY_Z_INDEX,
         });
         hasPopup = !isEmpty(popup);
       } else {

--- a/openmetadata-ui/src/main/resources/ui/src/components/BlockEditor/EditorSlots.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/BlockEditor/EditorSlots.tsx
@@ -50,7 +50,27 @@ const EditorSlots = forwardRef<EditorSlotsRef, EditorSlotsProps>(
       }
 
       if (op === 'add') {
-        editor?.chain().focus().setLink({ href: values.href }).run();
+        const { from, to } = editor.state.selection;
+        const hasSelectedText = from !== to;
+
+        if (hasSelectedText) {
+          // Wrap the selected text in a link.
+          editor.chain().focus().setLink({ href: values.href }).run();
+        } else {
+          // No text selected: insert the href as the link text. setLink on an
+          // empty selection only sets a stored mark and renders nothing, which
+          // makes the link silently "disappear". Inserting the href as linked
+          // text guarantees a visible, clickable link.
+          editor
+            .chain()
+            .focus()
+            .insertContent({
+              type: 'text',
+              text: values.href,
+              marks: [{ type: 'link', attrs: { href: values.href } }],
+            })
+            .run();
+        }
       }
 
       // move cursor at the end
@@ -59,6 +79,14 @@ const EditorSlots = forwardRef<EditorSlotsRef, EditorSlotsProps>(
       // close the modal
       handleLinkToggle();
     };
+
+    // Mount the link modal inside the nearest dialog/drawer (if any) so a
+    // focus-trapping overlay (e.g. React Aria's SlideoutMenu) does not steal
+    // focus from the modal input or dismiss the drawer when the modal opens.
+    // Falls back to document.body when the editor is not inside a dialog.
+    const getLinkModalContainer = (): HTMLElement =>
+      (editor?.view.dom.closest('[role="dialog"]') as HTMLElement) ??
+      document.body;
 
     const handleUnlink = () => {
       if (isNil(editor)) {
@@ -160,6 +188,7 @@ const EditorSlots = forwardRef<EditorSlotsRef, EditorSlotsProps>(
         {isLinkModalOpen && (
           <LinkModal
             data={{ href: editor?.getAttributes('link').href }}
+            getContainer={getLinkModalContainer}
             isOpen={isLinkModalOpen}
             onCancel={handleLinkCancel}
             onSave={(values) =>

--- a/openmetadata-ui/src/main/resources/ui/src/components/BlockEditor/LinkModal/LinkModal.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/BlockEditor/LinkModal/LinkModal.test.tsx
@@ -1,0 +1,97 @@
+/*
+ *  Copyright 2026 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import LinkModal from './LinkModal';
+
+const onSave = jest.fn();
+const onCancel = jest.fn();
+
+const defaultProps = {
+  isOpen: true,
+  data: { href: '' },
+  onSave,
+  onCancel,
+};
+
+describe('LinkModal', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should render the "Add link" title and the link input when href is empty', () => {
+    render(<LinkModal {...defaultProps} />);
+
+    expect(screen.getByText('Add link')).toBeInTheDocument();
+    expect(screen.getByRole('textbox')).toBeInTheDocument();
+  });
+
+  it('should render the "Edit link" title when an href is provided', () => {
+    render(<LinkModal {...defaultProps} data={{ href: 'https://x.com' }} />);
+
+    expect(screen.getByText('Edit link')).toBeInTheDocument();
+  });
+
+  it('should call onSave with the entered href on submit', async () => {
+    render(<LinkModal {...defaultProps} />);
+
+    fireEvent.change(screen.getByRole('textbox'), {
+      target: { value: '{{buildEntityUrl event.entityType entity}}' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+    await waitFor(() =>
+      expect(onSave).toHaveBeenCalledWith({
+        href: '{{buildEntityUrl event.entityType entity}}',
+      })
+    );
+  });
+
+  it('should call onCancel when the cancel button is clicked', () => {
+    render(<LinkModal {...defaultProps} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+
+  // Regression: when the editor lives inside a focus-trapping dialog/drawer
+  // (e.g. React Aria's SlideoutMenu), the modal must portal INTO that dialog so
+  // the dialog's focus scope and useInteractOutside do not steal focus from the
+  // input or dismiss the drawer when the modal opens.
+  it('should mount the modal inside the container returned by getContainer', () => {
+    const host = document.createElement('div');
+    host.setAttribute('data-testid', 'dialog-host');
+    document.body.appendChild(host);
+
+    render(<LinkModal {...defaultProps} getContainer={() => host} />);
+
+    expect(host.querySelector('.block-editor-link-modal')).toBeInTheDocument();
+
+    document.body.removeChild(host);
+  });
+
+  it('should apply a z-index above the React Aria overlay (100000)', () => {
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+
+    render(<LinkModal {...defaultProps} getContainer={() => host} />);
+
+    const elementsWithZIndex = Array.from(
+      host.querySelectorAll<HTMLElement>('*')
+    ).filter((element) => element.style.zIndex === '100001');
+
+    expect(elementsWithZIndex.length).toBeGreaterThan(0);
+
+    document.body.removeChild(host);
+  });
+});

--- a/openmetadata-ui/src/main/resources/ui/src/components/BlockEditor/LinkModal/LinkModal.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/BlockEditor/LinkModal/LinkModal.test.tsx
@@ -64,10 +64,6 @@ describe('LinkModal', () => {
     expect(onCancel).toHaveBeenCalledTimes(1);
   });
 
-  // Regression: when the editor lives inside a focus-trapping dialog/drawer
-  // (e.g. React Aria's SlideoutMenu), the modal must portal INTO that dialog so
-  // the dialog's focus scope and useInteractOutside do not steal focus from the
-  // input or dismiss the drawer when the modal opens.
   it('should mount the modal inside the container returned by getContainer', () => {
     const host = document.createElement('div');
     host.setAttribute('data-testid', 'dialog-host');
@@ -95,9 +91,6 @@ describe('LinkModal', () => {
     document.body.removeChild(host);
   });
 
-  // The elevated z-index is only needed to paint above React Aria's overlay. It
-  // must not be applied when the modal falls back to document.body, otherwise it
-  // would render above unrelated portals (notifications, messages, etc.).
   it('should not elevate the z-index when no dialog container is provided', () => {
     render(<LinkModal {...defaultProps} />);
 

--- a/openmetadata-ui/src/main/resources/ui/src/components/BlockEditor/LinkModal/LinkModal.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/BlockEditor/LinkModal/LinkModal.test.tsx
@@ -75,39 +75,4 @@ describe('LinkModal', () => {
 
     document.body.removeChild(host);
   });
-
-  it('should apply a z-index above the React Aria overlay (100000) when mounted inside a dialog container', () => {
-    const host = document.createElement('div');
-    document.body.appendChild(host);
-
-    render(<LinkModal {...defaultProps} getContainer={() => host} />);
-
-    const elementsWithZIndex = Array.from(
-      host.querySelectorAll<HTMLElement>('*')
-    ).filter((element) => element.style.zIndex === '100001');
-
-    expect(elementsWithZIndex.length).toBeGreaterThan(0);
-
-    document.body.removeChild(host);
-  });
-
-  it('should not elevate the z-index when no dialog container is provided', () => {
-    render(<LinkModal {...defaultProps} />);
-
-    const elementsWithElevatedZIndex = Array.from(
-      document.body.querySelectorAll<HTMLElement>('*')
-    ).filter((element) => element.style.zIndex === '100001');
-
-    expect(elementsWithElevatedZIndex).toHaveLength(0);
-  });
-
-  it('should not elevate the z-index when getContainer resolves to document.body', () => {
-    render(<LinkModal {...defaultProps} getContainer={() => document.body} />);
-
-    const elementsWithElevatedZIndex = Array.from(
-      document.body.querySelectorAll<HTMLElement>('*')
-    ).filter((element) => element.style.zIndex === '100001');
-
-    expect(elementsWithElevatedZIndex).toHaveLength(0);
-  });
 });

--- a/openmetadata-ui/src/main/resources/ui/src/components/BlockEditor/LinkModal/LinkModal.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/BlockEditor/LinkModal/LinkModal.test.tsx
@@ -80,7 +80,7 @@ describe('LinkModal', () => {
     document.body.removeChild(host);
   });
 
-  it('should apply a z-index above the React Aria overlay (100000)', () => {
+  it('should apply a z-index above the React Aria overlay (100000) when mounted inside a dialog container', () => {
     const host = document.createElement('div');
     document.body.appendChild(host);
 
@@ -93,5 +93,28 @@ describe('LinkModal', () => {
     expect(elementsWithZIndex.length).toBeGreaterThan(0);
 
     document.body.removeChild(host);
+  });
+
+  // The elevated z-index is only needed to paint above React Aria's overlay. It
+  // must not be applied when the modal falls back to document.body, otherwise it
+  // would render above unrelated portals (notifications, messages, etc.).
+  it('should not elevate the z-index when no dialog container is provided', () => {
+    render(<LinkModal {...defaultProps} />);
+
+    const elementsWithElevatedZIndex = Array.from(
+      document.body.querySelectorAll<HTMLElement>('*')
+    ).filter((element) => element.style.zIndex === '100001');
+
+    expect(elementsWithElevatedZIndex).toHaveLength(0);
+  });
+
+  it('should not elevate the z-index when getContainer resolves to document.body', () => {
+    render(<LinkModal {...defaultProps} getContainer={() => document.body} />);
+
+    const elementsWithElevatedZIndex = Array.from(
+      document.body.querySelectorAll<HTMLElement>('*')
+    ).filter((element) => element.style.zIndex === '100001');
+
+    expect(elementsWithElevatedZIndex).toHaveLength(0);
   });
 });

--- a/openmetadata-ui/src/main/resources/ui/src/components/BlockEditor/LinkModal/LinkModal.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/BlockEditor/LinkModal/LinkModal.tsx
@@ -12,6 +12,7 @@
  */
 import { Form, FormProps, Input, Modal } from 'antd';
 import { FC } from 'react';
+import { LINK_OVERLAY_Z_INDEX } from '../../../constants/BlockEditor.constants';
 
 export interface LinkData {
   href: string;
@@ -29,10 +30,6 @@ export interface LinkModalProps {
   getContainer?: () => HTMLElement;
 }
 
-// Must exceed React Aria's overlay z-index (100000) so the modal paints above
-// the dialog content.
-const LINK_MODAL_Z_INDEX = 100001;
-
 const LinkModal: FC<LinkModalProps> = ({
   isOpen,
   data,
@@ -48,7 +45,7 @@ const LinkModal: FC<LinkModalProps> = ({
   // default avoids painting above unrelated portals.
   const container = getContainer?.();
   const zIndex =
-    container && container !== document.body ? LINK_MODAL_Z_INDEX : undefined;
+    container && container !== document.body ? LINK_OVERLAY_Z_INDEX : undefined;
 
   return (
     <Modal

--- a/openmetadata-ui/src/main/resources/ui/src/components/BlockEditor/LinkModal/LinkModal.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/BlockEditor/LinkModal/LinkModal.tsx
@@ -22,9 +22,31 @@ export interface LinkModalProps {
   data: LinkData;
   onSave: (data: LinkData) => void;
   onCancel: () => void;
+  /**
+   * Optional portal container for the modal. When the editor lives inside a
+   * focus-trapping dialog/drawer (e.g. React Aria's SlideoutMenu), the modal
+   * must render *inside* that dialog so the dialog's focus scope and
+   * useInteractOutside do not steal focus from the input or dismiss the drawer
+   * when the modal opens. Falls back to document.body (antd default) otherwise.
+   */
+  getContainer?: () => HTMLElement;
 }
 
-const LinkModal: FC<LinkModalProps> = ({ isOpen, data, onSave, onCancel }) => {
+/**
+ * z-index for the link modal when mounted inside a React Aria dialog. Must
+ * exceed React Aria's useOverlayPosition z-index (100000) so the modal and its
+ * mask paint above the dialog content. Keep in sync with the suggestion popup
+ * z-index used by the handlebars extension.
+ */
+const LINK_MODAL_Z_INDEX = 100001;
+
+const LinkModal: FC<LinkModalProps> = ({
+  isOpen,
+  data,
+  onSave,
+  onCancel,
+  getContainer,
+}) => {
   const handleSubmit: FormProps<LinkData>['onFinish'] = (values) => {
     onSave(values);
   };
@@ -32,6 +54,7 @@ const LinkModal: FC<LinkModalProps> = ({ isOpen, data, onSave, onCancel }) => {
   return (
     <Modal
       className="block-editor-link-modal"
+      getContainer={getContainer}
       maskClosable={false}
       okButtonProps={{
         htmlType: 'submit',
@@ -41,6 +64,7 @@ const LinkModal: FC<LinkModalProps> = ({ isOpen, data, onSave, onCancel }) => {
       okText="Save"
       open={isOpen}
       title={data.href ? 'Edit link' : 'Add link'}
+      zIndex={LINK_MODAL_Z_INDEX}
       onCancel={onCancel}>
       <Form
         data-testid="link-form"

--- a/openmetadata-ui/src/main/resources/ui/src/components/BlockEditor/LinkModal/LinkModal.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/BlockEditor/LinkModal/LinkModal.tsx
@@ -51,6 +51,14 @@ const LinkModal: FC<LinkModalProps> = ({
     onSave(values);
   };
 
+  // Only elevate the z-index when the modal is actually mounted inside a
+  // focus-trapping dialog (getContainer resolves to a non-body element). In
+  // every other context the antd default is used so the modal does not paint
+  // above unrelated portals (e.g. notifications/messages).
+  const container = getContainer?.();
+  const zIndex =
+    container && container !== document.body ? LINK_MODAL_Z_INDEX : undefined;
+
   return (
     <Modal
       className="block-editor-link-modal"
@@ -64,7 +72,7 @@ const LinkModal: FC<LinkModalProps> = ({
       okText="Save"
       open={isOpen}
       title={data.href ? 'Edit link' : 'Add link'}
-      zIndex={LINK_MODAL_Z_INDEX}
+      zIndex={zIndex}
       onCancel={onCancel}>
       <Form
         data-testid="link-form"

--- a/openmetadata-ui/src/main/resources/ui/src/components/BlockEditor/LinkModal/LinkModal.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/BlockEditor/LinkModal/LinkModal.tsx
@@ -23,21 +23,14 @@ export interface LinkModalProps {
   onSave: (data: LinkData) => void;
   onCancel: () => void;
   /**
-   * Optional portal container for the modal. When the editor lives inside a
-   * focus-trapping dialog/drawer (e.g. React Aria's SlideoutMenu), the modal
-   * must render *inside* that dialog so the dialog's focus scope and
-   * useInteractOutside do not steal focus from the input or dismiss the drawer
-   * when the modal opens. Falls back to document.body (antd default) otherwise.
+   * Portal container for the modal. Lets it mount inside a focus-trapping
+   * dialog so the dialog does not steal focus from the input.
    */
   getContainer?: () => HTMLElement;
 }
 
-/**
- * z-index for the link modal when mounted inside a React Aria dialog. Must
- * exceed React Aria's useOverlayPosition z-index (100000) so the modal and its
- * mask paint above the dialog content. Keep in sync with the suggestion popup
- * z-index used by the handlebars extension.
- */
+// Must exceed React Aria's overlay z-index (100000) so the modal paints above
+// the dialog content.
 const LINK_MODAL_Z_INDEX = 100001;
 
 const LinkModal: FC<LinkModalProps> = ({
@@ -51,10 +44,8 @@ const LinkModal: FC<LinkModalProps> = ({
     onSave(values);
   };
 
-  // Only elevate the z-index when the modal is actually mounted inside a
-  // focus-trapping dialog (getContainer resolves to a non-body element). In
-  // every other context the antd default is used so the modal does not paint
-  // above unrelated portals (e.g. notifications/messages).
+  // Only elevate the z-index when mounted inside a dialog; otherwise the antd
+  // default avoids painting above unrelated portals.
   const container = getContainer?.();
   const zIndex =
     container && container !== document.body ? LINK_MODAL_Z_INDEX : undefined;

--- a/openmetadata-ui/src/main/resources/ui/src/components/BlockEditor/LinkModal/LinkModal.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/BlockEditor/LinkModal/LinkModal.tsx
@@ -12,7 +12,6 @@
  */
 import { Form, FormProps, Input, Modal } from 'antd';
 import { FC } from 'react';
-import { LINK_OVERLAY_Z_INDEX } from '../../../constants/BlockEditor.constants';
 
 export interface LinkData {
   href: string;
@@ -41,12 +40,6 @@ const LinkModal: FC<LinkModalProps> = ({
     onSave(values);
   };
 
-  // Only elevate the z-index when mounted inside a dialog; otherwise the antd
-  // default avoids painting above unrelated portals.
-  const container = getContainer?.();
-  const zIndex =
-    container && container !== document.body ? LINK_OVERLAY_Z_INDEX : undefined;
-
   return (
     <Modal
       className="block-editor-link-modal"
@@ -60,7 +53,6 @@ const LinkModal: FC<LinkModalProps> = ({
       okText="Save"
       open={isOpen}
       title={data.href ? 'Edit link' : 'Add link'}
-      zIndex={zIndex}
       onCancel={onCancel}>
       <Form
         data-testid="link-form"

--- a/openmetadata-ui/src/main/resources/ui/src/components/BlockEditor/LinkPopup/LinkPopup.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/BlockEditor/LinkPopup/LinkPopup.test.tsx
@@ -1,0 +1,62 @@
+/*
+ *  Copyright 2026 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+import { fireEvent, render, screen } from '@testing-library/react';
+import LinkPopup from './LinkPopup';
+
+const handleLinkToggle = jest.fn();
+const handleUnlink = jest.fn();
+
+const defaultProps = {
+  href: 'https://example.com',
+  handleLinkToggle,
+  handleUnlink,
+};
+
+describe('LinkPopup', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should render the edit, open, and unlink actions', () => {
+    render(<LinkPopup {...defaultProps} />);
+
+    expect(screen.getByTestId('link-popup-edit')).toBeInTheDocument();
+    expect(screen.getByTestId('link-popup-open')).toBeInTheDocument();
+    expect(screen.getByTestId('link-popup-unlink')).toBeInTheDocument();
+  });
+
+  it('should point the open action at the href in a new tab', () => {
+    render(<LinkPopup {...defaultProps} />);
+
+    const open = screen.getByTestId('link-popup-open');
+
+    expect(open).toHaveAttribute('href', 'https://example.com');
+    expect(open).toHaveAttribute('target', '_blank');
+  });
+
+  it('should call handleLinkToggle when edit is clicked', () => {
+    render(<LinkPopup {...defaultProps} />);
+
+    fireEvent.click(screen.getByTestId('link-popup-edit'));
+
+    expect(handleLinkToggle).toHaveBeenCalledTimes(1);
+  });
+
+  it('should call handleUnlink when unlink is clicked', () => {
+    render(<LinkPopup {...defaultProps} />);
+
+    fireEvent.click(screen.getByTestId('link-popup-unlink'));
+
+    expect(handleUnlink).toHaveBeenCalledTimes(1);
+  });
+});

--- a/openmetadata-ui/src/main/resources/ui/src/components/BlockEditor/LinkPopup/LinkPopup.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/BlockEditor/LinkPopup/LinkPopup.tsx
@@ -34,12 +34,14 @@ const LinkPopup: FC<LinkPopupProps> = ({
     <Space className="link-popup">
       <Button
         className="p-0"
+        data-testid="link-popup-edit"
         icon={<EditIcon width={iconSize} />}
         type="text"
         onClick={handleLinkToggle}
       />
       <Button
         className="p-0"
+        data-testid="link-popup-open"
         href={href}
         icon={<ExternalLinkIcon width={iconSize + 2} />}
         target="_blank"
@@ -47,6 +49,7 @@ const LinkPopup: FC<LinkPopupProps> = ({
       />
       <Button
         className="p-0"
+        data-testid="link-popup-unlink"
         icon={<UnlinkIcon width={iconSize} />}
         type="text"
         onClick={handleUnlink}

--- a/openmetadata-ui/src/main/resources/ui/src/constants/BlockEditor.constants.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/constants/BlockEditor.constants.ts
@@ -77,3 +77,8 @@ export const LINK_PASTE_REGEX =
 export const UPLOADED_ASSETS_URL = '/api/v1/attachments/';
 
 export const TEXT_TYPES = ['text/plain', 'text/rtf'];
+
+// z-index for the link modal/popup when the editor lives inside a
+// focus-trapping dialog. Must exceed React Aria's overlay z-index (100000) so
+// they paint above the dialog content.
+export const LINK_OVERLAY_Z_INDEX = 100001;

--- a/openmetadata-ui/src/main/resources/ui/src/constants/BlockEditor.constants.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/constants/BlockEditor.constants.ts
@@ -77,8 +77,3 @@ export const LINK_PASTE_REGEX =
 export const UPLOADED_ASSETS_URL = '/api/v1/attachments/';
 
 export const TEXT_TYPES = ['text/plain', 'text/rtf'];
-
-// z-index for the link modal/popup when the editor lives inside a
-// focus-trapping dialog. Must exceed React Aria's overlay z-index (100000) so
-// they paint above the dialog content.
-export const LINK_OVERLAY_Z_INDEX = 100001;

--- a/openmetadata-ui/src/main/resources/ui/src/utils/BlockEditorExtensionsClassBase.test.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/BlockEditorExtensionsClassBase.test.ts
@@ -12,6 +12,7 @@
  */
 
 import { Extensions } from '@tiptap/react';
+import { LinkExtension } from '../components/BlockEditor/Extensions/link';
 import blockEditorExtensionsClassBase, {
   BlockEditorExtensionsClassBase,
 } from './BlockEditorExtensionsClassBase';
@@ -222,6 +223,18 @@ describe('BlockEditorExtensionsClassBase', () => {
       );
 
       expect(link).toBeDefined();
+    });
+
+    it('should configure links to open on click only in read-only previews', () => {
+      (
+        extensionsClass as unknown as {
+          getCoreExtensions: () => Extensions;
+        }
+      ).getCoreExtensions();
+
+      expect(LinkExtension.configure).toHaveBeenCalledWith(
+        expect.objectContaining({ openOnClick: 'whenNotEditable' })
+      );
     });
 
     it('should include slash command extension', () => {

--- a/openmetadata-ui/src/main/resources/ui/src/utils/BlockEditorExtensionsClassBase.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/BlockEditorExtensionsClassBase.ts
@@ -104,7 +104,10 @@ export class BlockEditorExtensionsClassBase {
       }),
       LinkExtension.configure({
         autolink: false,
-        openOnClick: true,
+        // Open links on click only in read-only previews. While editing, a
+        // click should surface the link popup (edit/open/unlink) instead of
+        // navigating away.
+        openOnClick: 'whenNotEditable',
         linkOnPaste: true,
         HTMLAttributes: {
           rel: 'noopener noreferrer nofollow',


### PR DESCRIPTION
Closes #29376


https://github.com/user-attachments/assets/475bca27-1f22-465d-a510-1451b4fbde55



## Problem

When the BlockEditor is rendered inside a focus‑trapping dialog/drawer (e.g. a React‑Aria `SlideoutMenu`, used by the notification‑template editor), the rich‑text **link** tool is unusable:

- The link modal is an antd `Modal` portaled to `document.body` — **outside** the dialog's focus scope. The dialog's `FocusScope` (`contain`) and `useInteractOutside` then steal focus from the modal's URL input and can dismiss the drawer, so the modal is **frozen** (can't type / Save / Cancel).
- Adding a link with **no text selected** only sets a TipTap "stored mark" and renders no anchor, so the link silently disappears.

## Fix

1. **Mount the link modal inside the editor's nearest `[role="dialog"]`** (falling back to `document.body`) with a z‑index above the overlay, so it stays inside the dialog's focus scope and remains interactive. Mirrors the existing `getPopupContainer` workaround already used for the handlebars suggestion popup.
2. **Insert the href as the link text when no text is selected**, so adding a link always produces a visible, clickable `<a>` (selected text is still wrapped as before).

## Tests

- `LinkModal.test.tsx` — `getContainer` forwarding, z‑index, save/cancel, title.
- `EditorSlots.test.tsx` — link insertion for both empty and non‑empty selections (verified to fail without the fix).

## Notes

- Pure FE change to a shared BlockEditor; falls back to prior behavior outside dialogs.
- Pulled into Collate via the submodule. Collate tracking issue: open-metadata/openmetadata-collate#4677.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes the BlockEditor's link tool being unusable when rendered inside a focus-trapping dialog (e.g., a React Aria `SlideoutMenu`). The solution mounts the link modal and tippy popup inside the editor's nearest `[role="dialog"]` ancestor — skipping antd's own modals/drawers, which don't trap focus — and falls back to `document.body` otherwise. It also fixes a silent data-loss bug where adding a link with no text selected would only set a stored mark without rendering any visible `<a>` element; the href is now inserted as the link text in that case.

- `EditorSlots.tsx`: adds `getDialogContainer()` which walks up from `editor.view.dom` to find the correct portal target, passes it to both the tippy `appendTo` and `LinkModal.getContainer`, and branches `handleLinkSave` for empty vs non-empty selections.
- `LinkModal.tsx` / `BlockEditorExtensionsClassBase.ts`: threads the optional `getContainer` prop into antd `Modal` and changes `openOnClick` from `true` to `'whenNotEditable'` so TipTap only auto-navigates in read-only mode.
- Three new test files cover container routing, link insertion scenarios, and popup button behavior.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is purely frontend, confined to the BlockEditor component, and falls back to existing behavior when not inside a focus-trapping dialog.

The container-resolution logic is well-guarded: it uses optional chaining on the editor reference, explicitly filters out antd's own modal/drawer to avoid transform-positioning issues, and always returns document.body as a fallback. The empty-selection insertion path inserts visible content with a proper link mark rather than the silent no-op it replaces. The openOnClick change to 'whenNotEditable' aligns with the existing handleLinkPopup guard that skips popup creation in non-editable mode. All three changed behaviors are covered by new unit tests.

No files require special attention.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-ui/src/main/resources/ui/src/components/BlockEditor/EditorSlots.tsx | Core fix: adds getDialogContainer helper that resolves the correct portal target (nearest non-antd dialog vs document.body), passes it to both the tippy popup appendTo and LinkModal getContainer, and handles empty-selection link insertion by injecting the URL as visible link text. |
| openmetadata-ui/src/main/resources/ui/src/components/BlockEditor/LinkModal/LinkModal.tsx | Adds optional getContainer prop threaded into antd Modal so the portal target is controlled by the caller. |
| openmetadata-ui/src/main/resources/ui/src/utils/BlockEditorExtensionsClassBase.ts | Changes openOnClick from true to 'whenNotEditable' so TipTap only auto-navigates links in read-only mode, preserving the link-popup UX while editing. |
| openmetadata-ui/src/main/resources/ui/src/components/BlockEditor/LinkPopup/LinkPopup.tsx | Adds data-testid attributes to the edit/open/unlink buttons to support the new test coverage. |
| openmetadata-ui/src/main/resources/ui/src/components/BlockEditor/EditorSlots.test.tsx | New test file covering empty-selection insertion, selected-text wrapping, dialog container routing, and antd modal fallback. |
| openmetadata-ui/src/main/resources/ui/src/components/BlockEditor/LinkModal/LinkModal.test.tsx | New test file verifying title rendering, save/cancel callbacks, and portal mounting inside a custom container. |
| openmetadata-ui/src/main/resources/ui/src/components/BlockEditor/LinkPopup/LinkPopup.test.tsx | New test file verifying edit/open/unlink actions render correctly and invoke their handlers. |
| openmetadata-ui/src/main/resources/ui/src/utils/BlockEditorExtensionsClassBase.test.ts | Extends existing test to assert openOnClick is configured as 'whenNotEditable'. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[User clicks Add Link / clicks existing link] --> B{editor.isEditable?}
    B -- No --> Z[TipTap openOnClick: whenNotEditable\nnavigates to href]
    B -- Yes --> C[handleLinkPopup / onLinkToggle]

    C --> D[getDialogContainer]
    D --> E{editor.view.dom\nclosest role=dialog?}
    E -- No dialog found --> F[portal = document.body]
    E -- Dialog found --> G{dialog.closest\n.ant-modal or .ant-drawer?}
    G -- Yes antd container --> F
    G -- No React Aria or other --> H[portal = dialog element]

    F --> I[Mount tippy popup / LinkModal\nin document.body]
    H --> J[Mount tippy popup / LinkModal\ninside dialog stays in focus scope]

    J --> K{User saves href}
    I --> K
    K --> L{from !== to?\ntext selected?}
    L -- Yes --> M[chain.focus.setLink wrap selection]
    L -- No --> N[chain.focus.insertContent\nhref as link text with link mark]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[User clicks Add Link / clicks existing link] --> B{editor.isEditable?}
    B -- No --> Z[TipTap openOnClick: whenNotEditable\nnavigates to href]
    B -- Yes --> C[handleLinkPopup / onLinkToggle]

    C --> D[getDialogContainer]
    D --> E{editor.view.dom\nclosest role=dialog?}
    E -- No dialog found --> F[portal = document.body]
    E -- Dialog found --> G{dialog.closest\n.ant-modal or .ant-drawer?}
    G -- Yes antd container --> F
    G -- No React Aria or other --> H[portal = dialog element]

    F --> I[Mount tippy popup / LinkModal\nin document.body]
    H --> J[Mount tippy popup / LinkModal\ninside dialog stays in focus scope]

    J --> K{User saves href}
    I --> K
    K --> L{from !== to?\ntext selected?}
    L -- Yes --> M[chain.focus.setLink wrap selection]
    L -- No --> N[chain.focus.insertContent\nhref as link text with link mark]
```

</a>
</details>

<sub>Reviews (8): Last reviewed commit: ["refactor(block-editor): rely on default ..."](https://github.com/open-metadata/openmetadata/commit/2ef7c081351259aa06d47a21f3940d51c64aec28) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39333535)</sub>

<!-- /greptile_comment -->