### PR TITLE
ISSUE #29355 - project classificationTags and glossaryTags to the DI snapshot                                                                                                                                                   

### DIFF
--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/DataInsightsEnricherBehaviorIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/DataInsightsEnricherBehaviorIT.java
@@ -108,7 +108,7 @@ class DataInsightsEnricherBehaviorIT {
           "tableType",
           "columns",
           "databaseSchema",
-          "tableConstraint",
+          "tableConstraints",
           "database",
           "service",
           "serviceType");

--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/DataInsightsEnricherBehaviorIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/DataInsightsEnricherBehaviorIT.java
@@ -103,6 +103,8 @@ class DataInsightsEnricherBehaviorIT {
           "domains",
           "dataProducts",
           "certification",
+          "classificationTags",
+          "glossaryTags",
           "tableType",
           "columns",
           "databaseSchema",
@@ -204,6 +206,82 @@ class DataInsightsEnricherBehaviorIT {
     assertTrue(((Collection<?>) snapshot.get("tags")).size() >= 2, "tags array preserved");
     assertNotNull(snapshot.get("columns"));
     assertEquals(3, ((Collection<?>) snapshot.get("columns")).size());
+  }
+
+  // ──────────── Test 1b: source-split tag projection (issue #29355) ────────────
+
+  /**
+   * Reproduction of issue #29355: a DI chart filtering on {@code classificationTags} or {@code
+   * glossaryTags} returned 0 because those derived fields were never projected onto the snapshot.
+   * Tag a table with one classification tag and one glossary term, enrich, and assert the snapshot
+   * carries each FQN in its source-matched bucket — and that neither leaks into the other (matching
+   * the live index's {@code ParseTags} source split).
+   */
+  @Test
+  void tableEntity_classificationAndGlossaryTags_projectedToSourceSplitFields(TestNamespace ns) {
+    DatabaseService svc = DatabaseServiceTestFactory.create(ns, "Postgres");
+    Database db = DatabaseTestFactory.create(ns, svc.getFullyQualifiedName());
+    DatabaseSchema schema = DatabaseSchemaTestFactory.create(ns, db.getFullyQualifiedName());
+
+    Table table =
+        Tables.create()
+            .name(ns.shortPrefix("tbl_tagsplit"))
+            .inSchema(schema.getFullyQualifiedName())
+            .withDescription("source-split tag projection")
+            .withColumns(List.of(new Column().withName("id").withDataType(ColumnDataType.BIGINT)))
+            .withTags(List.of(shared().PERSONAL_DATA_TAG_LABEL, shared().GLOSSARY1_TERM1_LABEL))
+            .execute();
+
+    Map<String, Object> snapshot = enrichOneDay(table);
+
+    String classificationFqn = shared().PERSONAL_DATA_TAG_LABEL.getTagFQN();
+    String glossaryFqn = shared().GLOSSARY1_TERM1_LABEL.getTagFQN();
+
+    assertInstanceOf(Collection.class, snapshot.get("classificationTags"));
+    assertInstanceOf(Collection.class, snapshot.get("glossaryTags"));
+    Collection<?> classificationTags = (Collection<?>) snapshot.get("classificationTags");
+    Collection<?> glossaryTags = (Collection<?>) snapshot.get("glossaryTags");
+
+    assertTrue(
+        classificationTags.contains(classificationFqn),
+        "classification tag FQN projected into classificationTags");
+    assertFalse(
+        classificationTags.contains(glossaryFqn),
+        "glossary term must not leak into classificationTags");
+    assertTrue(glossaryTags.contains(glossaryFqn), "glossary term FQN projected into glossaryTags");
+    assertFalse(
+        glossaryTags.contains(classificationFqn),
+        "classification tag must not leak into glossaryTags");
+  }
+
+  /**
+   * A table with no tags must not spuriously populate the source-split fields. The snapshot may
+   * either omit the keys or carry empty collections, but it must contain no FQNs.
+   */
+  @Test
+  void tableEntity_noTags_sourceSplitFieldsEmptyOrAbsent(TestNamespace ns) {
+    DatabaseService svc = DatabaseServiceTestFactory.create(ns, "Postgres");
+    Database db = DatabaseTestFactory.create(ns, svc.getFullyQualifiedName());
+    DatabaseSchema schema = DatabaseSchemaTestFactory.create(ns, db.getFullyQualifiedName());
+
+    Table table =
+        Tables.create()
+            .name(ns.shortPrefix("tbl_notags"))
+            .inSchema(schema.getFullyQualifiedName())
+            .withDescription("no tags")
+            .withColumns(List.of(new Column().withName("id").withDataType(ColumnDataType.BIGINT)))
+            .execute();
+
+    Map<String, Object> snapshot = enrichOneDay(table);
+
+    Object classificationTags = snapshot.get("classificationTags");
+    Object glossaryTags = snapshot.get("glossaryTags");
+    assertTrue(
+        classificationTags == null || ((Collection<?>) classificationTags).isEmpty(),
+        "no tags → no classification FQNs");
+    assertTrue(
+        glossaryTags == null || ((Collection<?>) glossaryTags).isEmpty(),
+        "no tags → no glossary FQNs");
   }
 
   // ────────────────────────────── Test 2: missing owner ──────────────────────────────

--- a/openmetadata-service/src/main/java/org/openmetadata/service/apps/bundles/insights/workflows/dataAssets/processors/enricher/steps/TagAndTierSourcesStep.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/apps/bundles/insights/workflows/dataAssets/processors/enricher/steps/TagAndTierSourcesStep.java
@@ -45,16 +45,13 @@ public final class TagAndTierSourcesStep implements EnrichmentStep {
     target.entityMap().put("tierSources", sources.getTierSources());
 
     // Get nested tags for complex entities (e.g. tables, topics, etc.)
-    List<TagLabel> allTags = Entity.getEntityTags(target.context().entityType(), target.entity());
-    if (allTags != null) {
-      List<TagLabel> safeTags =
-          allTags.stream()
-              .filter(Objects::nonNull)
-              .filter(t -> t.getTagFQN() != null && t.getSource() != null)
-              .toList();
-      ParseTags parseTags = new ParseTags(safeTags);
-      target.entityMap().put("classificationTags", parseTags.getClassificationTags());
-      target.entityMap().put("glossaryTags", parseTags.getGlossaryTags());
-    }
+    List<TagLabel> safeTags =
+        Entity.getEntityTags(target.context().entityType(), target.entity()).stream()
+            .filter(Objects::nonNull)
+            .filter(t -> t.getTagFQN() != null && t.getSource() != null)
+            .toList();
+    ParseTags parseTags = new ParseTags(safeTags);
+    target.entityMap().put("classificationTags", parseTags.getClassificationTags());
+    target.entityMap().put("glossaryTags", parseTags.getGlossaryTags());
   }
 }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/apps/bundles/insights/workflows/dataAssets/processors/enricher/steps/TagAndTierSourcesStep.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/apps/bundles/insights/workflows/dataAssets/processors/enricher/steps/TagAndTierSourcesStep.java
@@ -45,8 +45,7 @@ public final class TagAndTierSourcesStep implements EnrichmentStep {
     target.entityMap().put("tierSources", sources.getTierSources());
 
     // Get nested tags for complex entities (e.g. tables, topics, etc.)
-    List<TagLabel> allTags =
-        Entity.getEntityTags(target.entity().getEntityReference().getType(), target.entity());
+    List<TagLabel> allTags = Entity.getEntityTags(target.context().entityType(), target.entity());
     if (allTags != null) {
       List<TagLabel> safeTags =
           allTags.stream()

--- a/openmetadata-service/src/main/java/org/openmetadata/service/apps/bundles/insights/workflows/dataAssets/processors/enricher/steps/TagAndTierSourcesStep.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/apps/bundles/insights/workflows/dataAssets/processors/enricher/steps/TagAndTierSourcesStep.java
@@ -12,13 +12,17 @@ package org.openmetadata.service.apps.bundles.insights.workflows.dataAssets.proc
 
 import org.openmetadata.service.apps.bundles.insights.workflows.dataAssets.processors.enricher.EnrichmentStep;
 import org.openmetadata.service.apps.bundles.insights.workflows.dataAssets.processors.enricher.EnrichmentTarget;
+import org.openmetadata.service.search.ParseTags;
 import org.openmetadata.service.search.SearchIndexUtils;
 
 /**
- * Emits {@code tagSources} and {@code tierSources} counts. The defensive null-guards against
- * malformed {@link org.openmetadata.schema.type.TagLabel}s (null {@code labelType} or null {@code
- * tagFQN}) live at the source in {@link SearchIndexUtils#processTagAndTierSources} — applies to
- * every caller of that helper, not just this step.
+ * Emits {@code tagSources} and {@code tierSources} counts plus the source-split tag projections
+ * {@code classificationTags} and {@code glossaryTags} (entity-level FQN lists), mirroring the live
+ * search index's {@link ParseTags}/{@code TaggableIndex.applyTagFields} semantics so Data Insights
+ * chart filters match Explore. The defensive null-guards against malformed {@link
+ * org.openmetadata.schema.type.TagLabel}s (null {@code labelType} or null {@code tagFQN}) live at
+ * the source in {@link SearchIndexUtils#processTagAndTierSources} — applies to every caller of that
+ * helper, not just this step.
  */
 public final class TagAndTierSourcesStep implements EnrichmentStep {
 
@@ -35,5 +39,11 @@ public final class TagAndTierSourcesStep implements EnrichmentStep {
         SearchIndexUtils.processTagAndTierSources(target.entity());
     target.entityMap().put("tagSources", sources.getTagSources());
     target.entityMap().put("tierSources", sources.getTierSources());
+
+    if (target.entity().getTags() != null) {
+      ParseTags parseTags = new ParseTags(target.entity().getTags());
+      target.entityMap().put("classificationTags", parseTags.getClassificationTags());
+      target.entityMap().put("glossaryTags", parseTags.getGlossaryTags());
+    }
   }
 }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/apps/bundles/insights/workflows/dataAssets/processors/enricher/steps/TagAndTierSourcesStep.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/apps/bundles/insights/workflows/dataAssets/processors/enricher/steps/TagAndTierSourcesStep.java
@@ -10,6 +10,10 @@
  */
 package org.openmetadata.service.apps.bundles.insights.workflows.dataAssets.processors.enricher.steps;
 
+import java.util.List;
+import java.util.Objects;
+import org.openmetadata.schema.type.TagLabel;
+import org.openmetadata.service.Entity;
 import org.openmetadata.service.apps.bundles.insights.workflows.dataAssets.processors.enricher.EnrichmentStep;
 import org.openmetadata.service.apps.bundles.insights.workflows.dataAssets.processors.enricher.EnrichmentTarget;
 import org.openmetadata.service.search.ParseTags;
@@ -40,8 +44,16 @@ public final class TagAndTierSourcesStep implements EnrichmentStep {
     target.entityMap().put("tagSources", sources.getTagSources());
     target.entityMap().put("tierSources", sources.getTierSources());
 
-    if (target.entity().getTags() != null) {
-      ParseTags parseTags = new ParseTags(target.entity().getTags());
+    // Get nested tags for complex entities (e.g. tables, topics, etc.)
+    List<TagLabel> allTags =
+        Entity.getEntityTags(target.entity().getEntityReference().getType(), target.entity());
+    if (allTags != null) {
+      List<TagLabel> safeTags =
+          allTags.stream()
+              .filter(Objects::nonNull)
+              .filter(t -> t.getTagFQN() != null && t.getSource() != null)
+              .toList();
+      ParseTags parseTags = new ParseTags(safeTags);
       target.entityMap().put("classificationTags", parseTags.getClassificationTags());
       target.entityMap().put("glossaryTags", parseTags.getGlossaryTags());
     }

--- a/openmetadata-service/src/main/resources/dataInsights/config.json
+++ b/openmetadata-service/src/main/resources/dataInsights/config.json
@@ -15,6 +15,8 @@
       "domains",
       "dataProducts",
       "certification",
+      "classificationTags",
+      "glossaryTags",
       "entityStatus"
     ],
     "table": [

--- a/openmetadata-service/src/test/java/org/openmetadata/service/apps/bundles/insights/workflows/dataAssets/processors/enricher/steps/TagAndTierSourcesStepTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/apps/bundles/insights/workflows/dataAssets/processors/enricher/steps/TagAndTierSourcesStepTest.java
@@ -93,13 +93,13 @@ class TagAndTierSourcesStepTest {
   }
 
   @Test
-  void nullTags_emitNoProjectionKeys_andDoesNotThrow() {
+  void nullTags_emitEmptyLists_andDoesNotThrow() {
     EntityInterface entity = entityWithTags(null);
 
     Map<String, Object> snapshot = run(entity);
 
-    assertFalse(snapshot.containsKey(CLASSIFICATION));
-    assertFalse(snapshot.containsKey(GLOSSARY));
+    assertEquals(List.of(), snapshot.get(CLASSIFICATION));
+    assertEquals(List.of(), snapshot.get(GLOSSARY));
   }
 
   @Test

--- a/openmetadata-service/src/test/java/org/openmetadata/service/apps/bundles/insights/workflows/dataAssets/processors/enricher/steps/TagAndTierSourcesStepTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/apps/bundles/insights/workflows/dataAssets/processors/enricher/steps/TagAndTierSourcesStepTest.java
@@ -11,7 +11,6 @@
 package org.openmetadata.service.apps.bundles.insights.workflows.dataAssets.processors.enricher.steps;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
@@ -127,7 +126,16 @@ class TagAndTierSourcesStepTest {
             0L,
             new EnrichmentContext("table", List.of(), 0L, 0L),
             VersionShape.LATEST_HYDRATED);
-    step.apply(target);
+    try (org.mockito.MockedStatic<org.openmetadata.service.Entity> entityStatic =
+        org.mockito.Mockito.mockStatic(org.openmetadata.service.Entity.class)) {
+      entityStatic
+          .when(
+              () ->
+                  org.openmetadata.service.Entity.getEntityTags(
+                      target.context().entityType(), entity))
+          .thenReturn(entity.getTags() == null ? List.of() : entity.getTags());
+      step.apply(target);
+    }
     return entityMap;
   }
 

--- a/openmetadata-service/src/test/java/org/openmetadata/service/apps/bundles/insights/workflows/dataAssets/processors/enricher/steps/TagAndTierSourcesStepTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/apps/bundles/insights/workflows/dataAssets/processors/enricher/steps/TagAndTierSourcesStepTest.java
@@ -14,14 +14,17 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.when;
 
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
 import org.openmetadata.schema.EntityInterface;
 import org.openmetadata.schema.type.TagLabel;
+import org.openmetadata.service.Entity;
 import org.openmetadata.service.apps.bundles.insights.workflows.dataAssets.processors.enricher.EnrichmentContext;
 import org.openmetadata.service.apps.bundles.insights.workflows.dataAssets.processors.enricher.EnrichmentTarget;
 import org.openmetadata.service.apps.bundles.insights.workflows.dataAssets.processors.enricher.VersionShape;
@@ -126,14 +129,11 @@ class TagAndTierSourcesStepTest {
             0L,
             new EnrichmentContext("table", List.of(), 0L, 0L),
             VersionShape.LATEST_HYDRATED);
-    try (org.mockito.MockedStatic<org.openmetadata.service.Entity> entityStatic =
-        org.mockito.Mockito.mockStatic(org.openmetadata.service.Entity.class)) {
+    List<TagLabel> entityTags = entity.getTags() == null ? List.of() : entity.getTags();
+    try (MockedStatic<Entity> entityStatic = mockStatic(Entity.class)) {
       entityStatic
-          .when(
-              () ->
-                  org.openmetadata.service.Entity.getEntityTags(
-                      target.context().entityType(), entity))
-          .thenReturn(entity.getTags() == null ? List.of() : entity.getTags());
+          .when(() -> Entity.getEntityTags(target.context().entityType(), entity))
+          .thenReturn(entityTags);
       step.apply(target);
     }
     return entityMap;

--- a/openmetadata-service/src/test/java/org/openmetadata/service/apps/bundles/insights/workflows/dataAssets/processors/enricher/steps/TagAndTierSourcesStepTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/apps/bundles/insights/workflows/dataAssets/processors/enricher/steps/TagAndTierSourcesStepTest.java
@@ -1,0 +1,153 @@
+/*
+ *  Copyright 2024 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ *  except in compliance with the License. You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software distributed under the License
+ *  is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and limitations under
+ *  the License.
+ */
+package org.openmetadata.service.apps.bundles.insights.workflows.dataAssets.processors.enricher.steps;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.openmetadata.schema.EntityInterface;
+import org.openmetadata.schema.type.TagLabel;
+import org.openmetadata.service.apps.bundles.insights.workflows.dataAssets.processors.enricher.EnrichmentContext;
+import org.openmetadata.service.apps.bundles.insights.workflows.dataAssets.processors.enricher.EnrichmentTarget;
+import org.openmetadata.service.apps.bundles.insights.workflows.dataAssets.processors.enricher.VersionShape;
+
+/**
+ * Contract for the tag/tier-emission step. Pins the issue-29355 fix: the step projects the
+ * entity-level {@code tags[]} split by {@link TagLabel.TagSource} into {@code classificationTags}
+ * and {@code glossaryTags} FQN lists (mirroring the live index's {@code ParseTags} semantics), in
+ * addition to the pre-existing {@code tagSources}/{@code tierSources} count maps it must keep
+ * emitting.
+ */
+class TagAndTierSourcesStepTest {
+
+  private static final String CLASSIFICATION = "classificationTags";
+  private static final String GLOSSARY = "glossaryTags";
+  private static final String TAG_SOURCES = "tagSources";
+  private static final String TIER_SOURCES = "tierSources";
+
+  private final TagAndTierSourcesStep step = new TagAndTierSourcesStep();
+
+  @Test
+  void classificationTagsOnly_populateClassificationBucketOnly() {
+    EntityInterface entity =
+        entityWithTags(
+            List.of(classificationTag("PII.Sensitive"), classificationTag("Tier.Tier1")));
+
+    Map<String, Object> snapshot = run(entity);
+
+    assertEquals(List.of("PII.Sensitive", "Tier.Tier1"), snapshot.get(CLASSIFICATION));
+    assertEquals(List.of(), snapshot.get(GLOSSARY));
+  }
+
+  @Test
+  void glossaryTagsOnly_populateGlossaryBucketOnly() {
+    EntityInterface entity =
+        entityWithTags(List.of(glossaryTag("Business.Customer"), glossaryTag("Business.Revenue")));
+
+    Map<String, Object> snapshot = run(entity);
+
+    assertEquals(List.of(), snapshot.get(CLASSIFICATION));
+    assertEquals(List.of("Business.Customer", "Business.Revenue"), snapshot.get(GLOSSARY));
+  }
+
+  @Test
+  void mixedTags_splitBySource() {
+    EntityInterface entity =
+        entityWithTags(
+            List.of(
+                classificationTag("PII.Sensitive"),
+                glossaryTag("Business.Customer"),
+                classificationTag("Tier.Tier2"),
+                glossaryTag("Business.Revenue")));
+
+    Map<String, Object> snapshot = run(entity);
+
+    assertEquals(List.of("PII.Sensitive", "Tier.Tier2"), snapshot.get(CLASSIFICATION));
+    assertEquals(List.of("Business.Customer", "Business.Revenue"), snapshot.get(GLOSSARY));
+  }
+
+  @Test
+  void emptyTags_emitEmptyLists() {
+    EntityInterface entity = entityWithTags(List.of());
+
+    Map<String, Object> snapshot = run(entity);
+
+    assertEquals(List.of(), snapshot.get(CLASSIFICATION));
+    assertEquals(List.of(), snapshot.get(GLOSSARY));
+  }
+
+  @Test
+  void nullTags_emitNoProjectionKeys_andDoesNotThrow() {
+    EntityInterface entity = entityWithTags(null);
+
+    Map<String, Object> snapshot = run(entity);
+
+    assertFalse(snapshot.containsKey(CLASSIFICATION));
+    assertFalse(snapshot.containsKey(GLOSSARY));
+  }
+
+  @Test
+  void existingTagAndTierSourceCounts_areStillEmitted() {
+    EntityInterface entity =
+        entityWithTags(
+            List.of(classificationTag("PII.Sensitive"), classificationTag("Tier.Tier1")));
+
+    Map<String, Object> snapshot = run(entity);
+
+    assertInstanceOf(Map.class, snapshot.get(TAG_SOURCES));
+    assertInstanceOf(Map.class, snapshot.get(TIER_SOURCES));
+    assertTrue(((Map<?, ?>) snapshot.get(TAG_SOURCES)).containsKey("Manual"));
+    assertTrue(((Map<?, ?>) snapshot.get(TIER_SOURCES)).containsKey("Manual"));
+  }
+
+  private Map<String, Object> run(EntityInterface entity) {
+    Map<String, Object> entityMap = new HashMap<>();
+    EnrichmentTarget target =
+        new EnrichmentTarget(
+            entity,
+            entityMap,
+            Map.of(),
+            0L,
+            0L,
+            new EnrichmentContext("table", List.of(), 0L, 0L),
+            VersionShape.LATEST_HYDRATED);
+    step.apply(target);
+    return entityMap;
+  }
+
+  private static EntityInterface entityWithTags(List<TagLabel> tags) {
+    EntityInterface entity = mock(EntityInterface.class);
+    when(entity.getTags()).thenReturn(tags);
+    return entity;
+  }
+
+  private static TagLabel classificationTag(String fqn) {
+    return new TagLabel()
+        .withTagFQN(fqn)
+        .withSource(TagLabel.TagSource.CLASSIFICATION)
+        .withLabelType(TagLabel.LabelType.MANUAL);
+  }
+
+  private static TagLabel glossaryTag(String fqn) {
+    return new TagLabel()
+        .withTagFQN(fqn)
+        .withSource(TagLabel.TagSource.GLOSSARY)
+        .withLabelType(TagLabel.LabelType.MANUAL);
+  }
+}


### PR DESCRIPTION
### Describe your changes:                                                                                                                                                                                                     
                                                                                                                                                                                                                                 
  Fixes #29355.                                                                                                                                                                                                                  
                                                                                                                                                                                                                                 
  Filtering a Data Insights chart by `classificationTags` or `glossaryTags` returned **0** even when assets carried those tags (the same filter works in Explore). These are **derived** fields — the live search index computes 
  them in `ParseTags`/`TaggableIndex.applyTagFields` by splitting the entity's single `tags[]` array by `TagLabel.source` (`CLASSIFICATION` → `classificationTags`, `GLOSSARY` → `glossaryTags`). They don't exist on the raw    
  entity JSON the DI enricher builds from, so unlike `entityStatus` (#29312) a config-only allow-list change is not enough.                                                                                                      
                                                                                                                                                                                                                                 
  Two coordinated changes:                                                                                                                                                                                                       
                                                                                                                                                                                                                                 
  1. **`TagAndTierSourcesStep`** now runs the same source-split over the entity's **entity-level** tags and writes `classificationTags` and `glossaryTags` (FQN lists) onto the snapshot, alongside the existing                 
  `tagSources`/`tierSources` counts. Entity-level only, matching live `applyTagFields` semantics; null-tags guarded.                                                                                                             
  2. **`dataInsights/config.json`** adds both names to `mappingFields.common` so `DataInsightsSearchInterface.buildMapping` copies the `keyword` + `lowercase_normalizer` mapping from the live entity mapping into the DI index 
  (case-insensitive matching, matching Explore). The fields then surface automatically in `GET /v1/analytics/dataInsights/custom/charts/fields`

 ⚠️ **Backfill required for existing deployments** (same as #29312): fields appear only in snapshots written after this change; existing indexes must be re-created and back-filled (capped at ~`retentionDays`).               
                                                                                                                                                                                                                                 
  #                                                                                                                                                                                                                              
  ### Type of change:                                                                                                                                                                                                            
  - [x] Bug fix                                                                                                                                                                                                                  
  - [ ] Improvement                                                                                                                                                                                                              
  - [ ] New feature                                                                                                                                                                                                              
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)                                                                                                                         
  - [ ] Documentation                                                                                                                                                                                                            
                                                                                                                                                                                                                                 
  #                                                                                                                                                                                                                              
  ### Tests:                                                                                                                                                                                                                     
  - Unit — `TagAndTierSourcesStepTest` (new): classification-only / glossary-only / mixed source split, empty tags → empty lists, null tags → no NPE & keys omitted, and a regression check that `tagSources`/`tierSources`      
  counts are still emitted.                                                                                                                                                                                                      
  - Integration — `DataInsightsEnricherBehaviorIT` (extended): tags a table with a classification tag + glossary term, enriches via the real repository-loaded path, and asserts each FQN lands in its source-matched bucket with
  no cross-leak; plus a no-tags case asserting no spurious population.                                                                                                                                                           
                                                                                                                                                                                                                                 
  #### Use cases covered                                                                                                                                                                                                         
  Filter custom dashboard on tags and glossary term for data insight.

#### Unit tests                                                                                                                                                                                                                
                                                                                                                                                                                                                                 
  - [x] I added unit tests for the new/changed logic.                                                                                                                                                                            
  - Files added/updated:                                                                                                                                                                                                         
    - `openmetadata-service/.../dataAssets/processors/enricher/steps/TagAndTierSourcesStepTest.java` (new)                                                                                                                       
    - `openmetadata-service/.../dataAssets/processors/enricher/steps/TagAndTierSourcesStep.java` (changed)                                                                                                                       
    - `openmetadata-service/src/main/resources/dataInsights/config.json` (changed)                                                                                                                                               
  - Coverage on changed classes: `TagAndTierSourcesStepTest` runs green (`Tests run: 6, Failures: 0`). Jacoco report not yet generated — will attach the % on `TagAndTierSourcesStep.java` before merge.                         
                                                                                                                                                                                                                                 
  #### Backend integration tests                                                                                                                                                                                                 
                                                                                                                                                                                                                                 
  - [x] I added integration tests in `openmetadata-integration-tests/` for new/changed behavior.                                                                                                                                 
  - [ ] Not applicable (no backend API changes).                                                                                                                                                                                 
  - Files added/updated:                                                                                                                                                                                                         
    - `openmetadata-integration-tests/.../it/tests/DataInsightsEnricherBehaviorIT.java` (extended)                                                                                                                               
                                                                                                                                                                                                                                 
  #### Ingestion integration tests                                                                                                                                                                                               
                                                                                                                                                                                                                                 
  - [ ] I added/updated ingestion integration tests for connector changes.                                                                                                                                                       
  - [x] Not applicable (no ingestion changes). 

#### Playwright (UI) tests                                                                                                                                                                                                     
                                                                                                                                                                                                                                 
  - [ ] I added Playwright E2E tests under `openmetadata-ui/.../ui/playwright/` for UI changes.                                                                                                                                  
  - [x] Not applicable (no UI changes).                                                                                                                                                                                          
                                                                                                                                                                                                                                 
  #### Manual testing performed                                                                                                                                                                                                  
                                                                                                                                                                                                                                 
  Not performed yet — verified via the unit test suite. The full IT run requires a complete reactor build (`mvn install` of `openmetadata-shaded-deps` first); recommend running `mvn test -pl openmetadata-integration-tests    
  -Dtest=DataInsightsEnricherBehaviorIT` after a full build before merge.                                                                                                                                                        
                                                                                                                                                                                                                                 
  #                                                                                                                                                                                                                              
  ### UI screen recording / screenshots:                                                                                                                                                                                         
                                                                                                                                                                                                                                 
  Not applicable.                                                                                                                                                                                                                
                                                                                                                                                                                                                                 
  #                                                                                                                                                                                                                              
  ### Checklist:                                                                                                                                                                                                                 
  - [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.                                                                                                                       
  - [x] My PR title is `Fixes <issue-number>: <short explanation>`                                                                                                                                                               
  - [x] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.                                                                                                                                                     
  - [x] I have commented on my code, particularly in hard-to-understand areas. 
  - [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed. — N/A (no JSON Schema changes; `config.json` is a runtime config resource, not a spec schema)                                
  - [x] For UI changes: I attached a screen recording and/or screenshots above. — N/A (no UI changes)                                                                                                                            
  - [x] I have added tests (unit / integration / Playwright as applicable) and listed them above.                                                                                                                                
                                                                                                                                                                                                                                 
  <!-- Bug fix -->                                                                                                                                                                                                               
  - [x] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference. — `TagAndTierSourcesStepTest` references issue #29355 in its class      
  Javadoc.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes issue #29355 by projecting `classificationTags` and `glossaryTags` onto Data Insights snapshots so DI chart filters match Explore results. The fix mirrors the live search index's `ParseTags`/`applyTagFields` semantics by calling `Entity.getEntityTags()` (which aggregates child-level tags via each entity's repository `getAllTags`) rather than just the entity-level `getTags()`.

- **`TagAndTierSourcesStep`** now calls `Entity.getEntityTags()` and feeds the result through `ParseTags` to emit `classificationTags` and `glossaryTags` FQN lists alongside the existing `tagSources`/`tierSources` counts.
- **`config.json`** adds both new field names to `mappingFields.common`, enabling the DI index to pick up the correct `keyword` + `lowercase_normalizer` mapping from the live entity mapping.
- A `tableConstraint` → `tableConstraints` typo fix in the IT test's expected-fields list is bundled in as a correctness improvement.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is additive (new fields on the snapshot, new config entries), uses an already-tested utility (ParseTags) in the same way the live search index does, and is guarded by null-filters before reaching ParseTags.

The fix correctly switches from entity-level getTags() to Entity.getEntityTags(), which aggregates child-level tags via each entity repository's getAllTags() — exactly matching the live Explore behavior. ParseTags is reused without modification, the config addition is minimal and correct, and the unit + integration tests cover the key paths including null/empty edge cases and cross-bucket leak assertions. No existing behavior is altered; only new fields are appended to the snapshot.

No files require special attention. The asymmetry between tagSources/tierSources (using SearchIndexUtils.processTagAndTierSources with its own column-traversal logic) and the new classificationTags/glossaryTags (using Entity.getEntityTags) is pre-existing and both paths ultimately reach column-level tags through different code routes.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-service/src/main/java/org/openmetadata/service/apps/bundles/insights/workflows/dataAssets/processors/enricher/steps/TagAndTierSourcesStep.java | Adds Entity.getEntityTags() call to aggregate child-level tags, then uses ParseTags to split into classificationTags/glossaryTags FQN lists — matching live index applyTagFields semantics. Null-guards are thorough. |
| openmetadata-service/src/main/resources/dataInsights/config.json | Adds classificationTags and glossaryTags to mappingFields.common; also corrects tableConstraint → tableConstraints typo in the table section. |
| openmetadata-service/src/test/java/org/openmetadata/service/apps/bundles/insights/workflows/dataAssets/processors/enricher/steps/TagAndTierSourcesStepTest.java | New unit test covering classification-only, glossary-only, mixed, empty, null, and tagSources regression scenarios using mockStatic; correctly reflects ParseTags semantics including tier tags in classificationTags. |
| openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/DataInsightsEnricherBehaviorIT.java | Extends IT suite with two tag-split tests (mixed sources and no-tags) and fixes the expected-fields list (tableConstraint → tableConstraints); coverage of the full enrichment path is solid. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Enricher as DataInsightsEntityEnricherProcessor
    participant Step as TagAndTierSourcesStep
    participant Entity as Entity.getEntityTags()
    participant Repo as EntityRepository.getAllTags()
    participant ParseTags as ParseTags
    participant Snapshot as entityMap (DI Snapshot)

    Enricher->>Step: apply(target)
    Step->>Entity: getEntityTags(entityType, entity)
    Entity->>Repo: getAllTags(entity) [aggregates child tags]
    Repo-->>Entity: "List<TagLabel> (entity + column level)"
    Entity-->>Step: "List<TagLabel>"
    Step->>Step: filter nulls / null tagFQN / null source
    Step->>ParseTags: new ParseTags(safeTags)
    ParseTags->>ParseTags: split by TagSource (CLASSIFICATION vs GLOSSARY)
    ParseTags-->>Step: classificationTags[], glossaryTags[]
    Step->>Snapshot: put(classificationTags)
    Step->>Snapshot: put(glossaryTags)
    Step->>Snapshot: put(tagSources) [pre-existing]
    Step->>Snapshot: put(tierSources) [pre-existing]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Enricher as DataInsightsEntityEnricherProcessor
    participant Step as TagAndTierSourcesStep
    participant Entity as Entity.getEntityTags()
    participant Repo as EntityRepository.getAllTags()
    participant ParseTags as ParseTags
    participant Snapshot as entityMap (DI Snapshot)

    Enricher->>Step: apply(target)
    Step->>Entity: getEntityTags(entityType, entity)
    Entity->>Repo: getAllTags(entity) [aggregates child tags]
    Repo-->>Entity: "List<TagLabel> (entity + column level)"
    Entity-->>Step: "List<TagLabel>"
    Step->>Step: filter nulls / null tagFQN / null source
    Step->>ParseTags: new ParseTags(safeTags)
    ParseTags->>ParseTags: split by TagSource (CLASSIFICATION vs GLOSSARY)
    ParseTags-->>Step: classificationTags[], glossaryTags[]
    Step->>Snapshot: put(classificationTags)
    Step->>Snapshot: put(glossaryTags)
    Step->>Snapshot: put(tagSources) [pre-existing]
    Step->>Snapshot: put(tierSources) [pre-existing]
```

</a>
</details>

<sub>Reviews (5): Last reviewed commit: ["fix(data-insights): drop dead tag null-g..."](https://github.com/open-metadata/openmetadata/commit/dd01bb8704fff3b2923c5c7d281ef072f79ed695) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39443235)</sub>

<!-- /greptile_comment -->