### PR TITLE
fix(search): enforce ContextMemory shareConfig visibility in search

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/elasticsearch/ElasticSearchSearchManager.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/elasticsearch/ElasticSearchSearchManager.java
@@ -77,9 +77,11 @@ import org.openmetadata.service.search.SearchSortFilter;
 import org.openmetadata.service.search.SearchSourceBuilderFactory;
 import org.openmetadata.service.search.SearchUtils;
 import org.openmetadata.service.search.elasticsearch.queries.ElasticQueryBuilder;
+import org.openmetadata.service.search.elasticsearch.queries.ElasticQueryBuilderFactory;
 import org.openmetadata.service.search.lineage.LineageDomainFilter;
 import org.openmetadata.service.search.nlq.NLQService;
 import org.openmetadata.service.search.queries.OMQueryBuilder;
+import org.openmetadata.service.search.security.ContextMemorySearchVisibility;
 import org.openmetadata.service.search.security.RBACConditionEvaluator;
 import org.openmetadata.service.security.policyevaluator.SubjectContext;
 import org.openmetadata.service.util.FullyQualifiedName;
@@ -94,6 +96,8 @@ public class ElasticSearchSearchManager implements SearchManagementClient {
   private final boolean isClientAvailable;
   private final String clusterAlias;
   private final RBACConditionEvaluator rbacConditionEvaluator;
+  private final ContextMemorySearchVisibility contextMemoryVisibility =
+      new ContextMemorySearchVisibility(new ElasticQueryBuilderFactory());
   private final NLQService nlqService;
   private static final String SORT_FIELD_SCORE = "_score";
   private static final String SORT_TYPE_KEYWORD = "keyword";
@@ -389,6 +393,37 @@ public class ElasticSearchSearchManager implements SearchManagementClient {
         }
       }
     }
+    applyContextMemoryVisibility(subjectContext, requestBuilder);
+  }
+
+  /**
+   * Enforces ContextMemory shareConfig visibility on search results for non-admin subjects. Applied
+   * independently of {@code shouldApplyRbacConditions} because memory visibility is a per-memory
+   * privacy guarantee, not an RBAC policy — disabling RBAC search filtering must not expose private
+   * memories. Non-memory documents are left untouched.
+   */
+  private void applyContextMemoryVisibility(
+      SubjectContext subjectContext, ElasticSearchRequestBuilder requestBuilder) {
+    OMQueryBuilder visibilityBuilder =
+        contextMemoryVisibility.buildVisibilityFilter(subjectContext);
+    if (visibilityBuilder != null) {
+      Query visibilityQuery = ((ElasticQueryBuilder) visibilityBuilder).buildV2();
+      Query existingQuery = requestBuilder.query();
+      if (existingQuery != null) {
+        Query combinedQuery =
+            Query.of(
+                qb ->
+                    qb.bool(
+                        b -> {
+                          b.must(existingQuery);
+                          b.filter(visibilityQuery);
+                          return b;
+                        }));
+        requestBuilder.query(combinedQuery);
+      } else {
+        requestBuilder.query(visibilityQuery);
+      }
+    }
   }
 
   @Override
@@ -646,6 +681,8 @@ public class ElasticSearchSearchManager implements SearchManagementClient {
           }
         }
       }
+
+      applyContextMemoryVisibility(subjectContext, requestBuilder);
 
       // Add aggregations if needed
       ElasticSearchSourceBuilderFactory factory = getSearchBuilderFactory();
@@ -1550,6 +1587,8 @@ public class ElasticSearchSearchManager implements SearchManagementClient {
           }
         }
       }
+
+      applyContextMemoryVisibility(subjectContext, requestBuilder);
 
       // Add aggregations for fallback NLQ search
       addAggregationsToNLQQuery(requestBuilder, request.getIndex());

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/opensearch/OpenSearchSearchManager.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/opensearch/OpenSearchSearchManager.java
@@ -64,7 +64,9 @@ import org.openmetadata.service.search.SearchUtils;
 import org.openmetadata.service.search.lineage.LineageDomainFilter;
 import org.openmetadata.service.search.nlq.NLQService;
 import org.openmetadata.service.search.opensearch.queries.OpenSearchQueryBuilder;
+import org.openmetadata.service.search.opensearch.queries.OpenSearchQueryBuilderFactory;
 import org.openmetadata.service.search.queries.OMQueryBuilder;
+import org.openmetadata.service.search.security.ContextMemorySearchVisibility;
 import org.openmetadata.service.search.security.RBACConditionEvaluator;
 import org.openmetadata.service.security.policyevaluator.SubjectContext;
 import org.openmetadata.service.util.FullyQualifiedName;
@@ -95,6 +97,8 @@ public class OpenSearchSearchManager implements SearchManagementClient {
   private final boolean isClientAvailable;
   private final String clusterAlias;
   private final RBACConditionEvaluator rbacConditionEvaluator;
+  private final ContextMemorySearchVisibility contextMemoryVisibility =
+      new ContextMemorySearchVisibility(new OpenSearchQueryBuilderFactory());
   private final NLQService nlqService;
   private static final String SORT_FIELD_SCORE = "_score";
   private static final String SORT_TYPE_KEYWORD = "keyword";
@@ -404,6 +408,8 @@ public class OpenSearchSearchManager implements SearchManagementClient {
       }
     }
 
+    applyContextMemoryVisibility(subjectContext, requestBuilder);
+
     return doListWithOffset(limit, offset, index, searchSortFilter, requestBuilder);
   }
 
@@ -630,6 +636,7 @@ public class OpenSearchSearchManager implements SearchManagementClient {
 
       // Apply RBAC constraints with caching
       applyRbacQueryWithCaching(subjectContext, requestBuilder);
+      applyContextMemoryVisibility(subjectContext, requestBuilder);
 
       // Add aggregations if needed
       OpenSearchSourceBuilderFactory factory = getSearchBuilderFactory();
@@ -861,6 +868,36 @@ public class OpenSearchSearchManager implements SearchManagementClient {
     } finally {
       if (searchTimerSample != null) {
         RequestLatencyContext.endSearchOperation(searchTimerSample);
+      }
+    }
+  }
+
+  /**
+   * Enforces ContextMemory shareConfig visibility on search results for non-admin subjects. Applied
+   * independently of {@code shouldApplyRbacConditions} because memory visibility is a per-memory
+   * privacy guarantee, not an RBAC policy — disabling RBAC search filtering must not expose private
+   * memories. Non-memory documents are left untouched.
+   */
+  private void applyContextMemoryVisibility(
+      SubjectContext subjectContext, OpenSearchRequestBuilder requestBuilder) {
+    OMQueryBuilder visibilityBuilder =
+        contextMemoryVisibility.buildVisibilityFilter(subjectContext);
+    if (visibilityBuilder != null) {
+      Query visibilityQuery = ((OpenSearchQueryBuilder) visibilityBuilder).buildV2();
+      Query existingQuery = requestBuilder.query();
+      if (existingQuery != null) {
+        Query combinedQuery =
+            Query.of(
+                qb ->
+                    qb.bool(
+                        b -> {
+                          b.must(existingQuery);
+                          b.filter(visibilityQuery);
+                          return b;
+                        }));
+        requestBuilder.query(combinedQuery);
+      } else {
+        requestBuilder.query(visibilityQuery);
       }
     }
   }
@@ -1141,6 +1178,7 @@ public class OpenSearchSearchManager implements SearchManagementClient {
 
     // Apply RBAC query with caching
     applyRbacQueryWithCaching(subjectContext, requestBuilder);
+    applyContextMemoryVisibility(subjectContext, requestBuilder);
 
     // Apply query filter
     if (!nullOrEmpty(request.getQueryFilter()) && !request.getQueryFilter().equals("{}")) {
@@ -1583,6 +1621,7 @@ public class OpenSearchSearchManager implements SearchManagementClient {
 
       // Apply RBAC constraints using applyRbacQueryWithCaching
       applyRbacQueryWithCaching(subjectContext, requestBuilder);
+      applyContextMemoryVisibility(subjectContext, requestBuilder);
 
       // Add aggregations for fallback NLQ search
       addAggregationsToNLQQuery(requestBuilder, request.getIndex());

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/security/ContextMemorySearchVisibility.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/security/ContextMemorySearchVisibility.java
@@ -1,0 +1,116 @@
+/*
+ *  Copyright 2024 Collate
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.openmetadata.service.search.security;
+
+import static org.openmetadata.common.utils.CommonUtil.listOrEmpty;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.openmetadata.schema.entity.context.MemoryVisibility;
+import org.openmetadata.schema.entity.teams.User;
+import org.openmetadata.schema.type.EntityReference;
+import org.openmetadata.service.Entity;
+import org.openmetadata.service.search.queries.OMQueryBuilder;
+import org.openmetadata.service.search.queries.QueryBuilderFactory;
+import org.openmetadata.service.security.policyevaluator.SubjectContext;
+
+/**
+ * Builds a search-time filter that hides {@link
+ * org.openmetadata.schema.entity.context.ContextMemory} documents a subject is not allowed to see,
+ * while leaving every other entity type untouched. The filter is ANDed into global search and
+ * search-backed listings so they enforce the same per-memory {@code shareConfig} privacy as the
+ * REST read endpoints (see {@link
+ * org.openmetadata.service.resources.context.ContextMemoryVisibility#isVisibleToUser}).
+ *
+ * <p>Memory visibility is driven by the per-memory shareConfig, not by the OSS RBAC/policy model,
+ * so it is applied for every non-admin subject regardless of the RBAC access-control toggle.
+ * Disabling RBAC search filtering must never expose another user's private memories.
+ *
+ * <p>The produced query is engine-agnostic via {@link QueryBuilderFactory}, so the same builder
+ * serves both Elasticsearch and OpenSearch. Each OR-group is a bool with only {@code should}
+ * clauses so the engine default {@code minimum_should_match = 1} applies (the {@link OMQueryBuilder}
+ * abstraction exposes no way to set it explicitly).
+ */
+public class ContextMemorySearchVisibility {
+
+  static final String FIELD_ENTITY_TYPE = "entityType";
+  static final String FIELD_VISIBILITY = "visibility";
+  static final String FIELD_OWNERS = "owners";
+  static final String FIELD_OWNERS_ID = "owners.id";
+  static final String FIELD_SHARED_WITH_IDS = "sharedWithIds";
+
+  private final QueryBuilderFactory queryBuilderFactory;
+
+  public ContextMemorySearchVisibility(QueryBuilderFactory queryBuilderFactory) {
+    this.queryBuilderFactory = queryBuilderFactory;
+  }
+
+  /**
+   * Returns a filter constraining context memory documents to those visible to the subject, or
+   * {@code null} when no restriction is needed (admins, or a missing/unidentifiable subject). The
+   * filter is safe to AND into any search: non-memory documents always pass.
+   */
+  public OMQueryBuilder buildVisibilityFilter(SubjectContext subjectContext) {
+    OMQueryBuilder filter = null;
+    if (isVisibilityEnforced(subjectContext)) {
+      filter = buildFilter(subjectContext.user());
+    }
+    return filter;
+  }
+
+  private boolean isVisibilityEnforced(SubjectContext subjectContext) {
+    return subjectContext != null
+        && !subjectContext.isAdmin()
+        && subjectContext.user() != null
+        && subjectContext.user().getId() != null;
+  }
+
+  private OMQueryBuilder buildFilter(User user) {
+    OMQueryBuilder nonMemory =
+        queryBuilderFactory
+            .boolQuery()
+            .mustNot(
+                List.of(queryBuilderFactory.termQuery(FIELD_ENTITY_TYPE, Entity.CONTEXT_MEMORY)));
+    OMQueryBuilder memoryVisible =
+        queryBuilderFactory
+            .boolQuery()
+            .must(
+                List.of(
+                    queryBuilderFactory.termQuery(FIELD_ENTITY_TYPE, Entity.CONTEXT_MEMORY),
+                    buildVisibleToUserClause(user)));
+    return queryBuilderFactory.boolQuery().should(List.of(nonMemory, memoryVisible));
+  }
+
+  private OMQueryBuilder buildVisibleToUserClause(User user) {
+    List<OMQueryBuilder> clauses = new ArrayList<>();
+    clauses.add(queryBuilderFactory.termQuery(FIELD_VISIBILITY, MemoryVisibility.ENTITY.value()));
+    clauses.add(
+        queryBuilderFactory.nestedQuery(
+            FIELD_OWNERS, queryBuilderFactory.termQuery(FIELD_OWNERS_ID, user.getId().toString())));
+    clauses.add(queryBuilderFactory.termsQuery(FIELD_SHARED_WITH_IDS, sharedPrincipalIds(user)));
+    return queryBuilderFactory.boolQuery().should(clauses);
+  }
+
+  private List<String> sharedPrincipalIds(User user) {
+    List<String> principalIds = new ArrayList<>();
+    principalIds.add(user.getId().toString());
+    for (EntityReference team : listOrEmpty(user.getTeams())) {
+      principalIds.add(team.getId().toString());
+    }
+    for (EntityReference domain : listOrEmpty(user.getDomains())) {
+      principalIds.add(domain.getId().toString());
+    }
+    return principalIds;
+  }
+}

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/security/ContextMemorySearchVisibility.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/security/ContextMemorySearchVisibility.java
@@ -98,8 +98,24 @@ public class ContextMemorySearchVisibility {
     clauses.add(
         queryBuilderFactory.nestedQuery(
             FIELD_OWNERS, queryBuilderFactory.termQuery(FIELD_OWNERS_ID, user.getId().toString())));
-    clauses.add(queryBuilderFactory.termsQuery(FIELD_SHARED_WITH_IDS, sharedPrincipalIds(user)));
+    clauses.add(sharedWithSubjectClause(user));
     return queryBuilderFactory.boolQuery().should(clauses);
+  }
+
+  /**
+   * Matches a memory shared with the subject (directly or via a team/domain) — but only when its
+   * visibility is actually {@code Shared}. Gating on visibility mirrors {@link
+   * org.openmetadata.service.resources.context.ContextMemoryVisibility#isInSharedWithList}, which is
+   * consulted only for {@code SHARED}, so a stale {@code sharedWithIds} left on a memory later flipped
+   * to {@code Private} cannot leak it to those principals through search.
+   */
+  private OMQueryBuilder sharedWithSubjectClause(User user) {
+    return queryBuilderFactory
+        .boolQuery()
+        .must(
+            List.of(
+                queryBuilderFactory.termQuery(FIELD_VISIBILITY, MemoryVisibility.SHARED.value()),
+                queryBuilderFactory.termsQuery(FIELD_SHARED_WITH_IDS, sharedPrincipalIds(user))));
   }
 
   private List<String> sharedPrincipalIds(User user) {

--- a/openmetadata-service/src/test/java/org/openmetadata/service/search/security/ContextMemorySearchVisibilityTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/search/security/ContextMemorySearchVisibilityTest.java
@@ -113,8 +113,29 @@ class ContextMemorySearchVisibilityTest {
         "owners see their own (including Private) memories");
     assertFieldExists(
         json,
+        "$.bool.should[1].bool.must[1].bool.should[?(@.bool.must[?(@.terms['sharedWithIds'])])]",
+        "Shared memories are matched via sharedWithIds (gated by visibility=Shared)");
+  }
+
+  @Test
+  void sharedWithIdsBranchIsGatedByVisibilityShared() {
+    // ContextMemoryVisibility.isInSharedWithList is consulted ONLY when visibility==Shared, so the
+    // sharedWithIds match must be ANDed with visibility=Shared. A bare sharedWithIds clause would
+    // leak a memory later flipped to Private but still carrying a stale sharedWithIds list.
+    DocumentContext json = JsonPath.parse(buildElasticJson(nonAdminSubject()));
+
+    assertFieldExists(
+        json,
+        "$.bool.should[1].bool.must[1].bool.should[?(@.bool.must[?(@.term['visibility'].value=='Shared')])]",
+        "the sharedWithIds match sits in a bool.must alongside visibility=Shared");
+    assertFieldExists(
+        json,
+        "$.bool.should[1].bool.must[1].bool.should[?(@.bool.must[?(@.terms['sharedWithIds'])])]",
+        "that same gated branch carries the sharedWithIds terms");
+    assertFieldDoesNotExist(
+        json,
         "$.bool.should[1].bool.must[1].bool.should[?(@.terms['sharedWithIds'])]",
-        "Shared memories are matched via sharedWithIds");
+        "sharedWithIds must never appear as an ungated (bare) should clause");
   }
 
   @Test

--- a/openmetadata-service/src/test/java/org/openmetadata/service/search/security/ContextMemorySearchVisibilityTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/search/security/ContextMemorySearchVisibilityTest.java
@@ -1,0 +1,186 @@
+/*
+ *  Copyright 2024 Collate
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.openmetadata.service.search.security;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.openmetadata.service.util.TestUtils.assertFieldDoesNotExist;
+import static org.openmetadata.service.util.TestUtils.assertFieldExists;
+
+import com.jayway.jsonpath.DocumentContext;
+import com.jayway.jsonpath.JsonPath;
+import es.co.elastic.clients.elasticsearch._types.query_dsl.Query;
+import es.co.elastic.clients.json.jackson.JacksonJsonpMapper;
+import jakarta.json.stream.JsonGenerator;
+import java.io.StringWriter;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.openmetadata.schema.entity.teams.User;
+import org.openmetadata.schema.type.EntityReference;
+import org.openmetadata.service.Entity;
+import org.openmetadata.service.search.elasticsearch.queries.ElasticQueryBuilder;
+import org.openmetadata.service.search.elasticsearch.queries.ElasticQueryBuilderFactory;
+import org.openmetadata.service.search.opensearch.queries.OpenSearchQueryBuilder;
+import org.openmetadata.service.search.opensearch.queries.OpenSearchQueryBuilderFactory;
+import org.openmetadata.service.search.queries.OMQueryBuilder;
+import org.openmetadata.service.security.policyevaluator.SubjectContext;
+
+@Execution(ExecutionMode.CONCURRENT)
+class ContextMemorySearchVisibilityTest {
+
+  private static final JacksonJsonpMapper JACKSON_JSONP_MAPPER = new JacksonJsonpMapper();
+
+  private static final UUID USER_ID = UUID.randomUUID();
+  private static final UUID TEAM_ID = UUID.randomUUID();
+  private static final UUID DOMAIN_ID = UUID.randomUUID();
+
+  private SubjectContext nonAdminSubject() {
+    User user =
+        new User()
+            .withId(USER_ID)
+            .withName("alice")
+            .withIsAdmin(false)
+            .withTeams(List.of(ref(TEAM_ID, Entity.TEAM, "analytics")))
+            .withDomains(List.of(ref(DOMAIN_ID, Entity.DOMAIN, "finance")));
+    return new SubjectContext(user, null);
+  }
+
+  private EntityReference ref(UUID id, String type, String name) {
+    return new EntityReference().withId(id).withType(type).withName(name);
+  }
+
+  private String buildElasticJson(SubjectContext subjectContext) {
+    OMQueryBuilder filter =
+        new ContextMemorySearchVisibility(new ElasticQueryBuilderFactory())
+            .buildVisibilityFilter(subjectContext);
+    return serializeElasticQuery(((ElasticQueryBuilder) filter).build());
+  }
+
+  private String serializeElasticQuery(Query query) {
+    StringWriter writer = new StringWriter();
+    JsonGenerator generator = JACKSON_JSONP_MAPPER.jsonProvider().createGenerator(writer);
+    query.serialize(generator, JACKSON_JSONP_MAPPER);
+    generator.close();
+    return writer.toString();
+  }
+
+  @Test
+  void nonAdminSubjectLeavesNonMemoryDocumentsUntouched() {
+    DocumentContext json = JsonPath.parse(buildElasticJson(nonAdminSubject()));
+
+    assertFieldExists(
+        json,
+        "$.bool.should[0].bool.must_not[?(@.term['entityType'].value=='"
+            + Entity.CONTEXT_MEMORY
+            + "')]",
+        "non-memory documents pass through via a must_not entityType branch");
+  }
+
+  @Test
+  void nonAdminSubjectRestrictsMemoryDocumentsToVisibleOnes() {
+    DocumentContext json = JsonPath.parse(buildElasticJson(nonAdminSubject()));
+
+    assertFieldExists(
+        json,
+        "$.bool.should[1].bool.must[?(@.term['entityType'].value=='"
+            + Entity.CONTEXT_MEMORY
+            + "')]",
+        "the memory branch is scoped to contextMemory documents");
+    assertFieldExists(
+        json,
+        "$.bool.should[1].bool.must[1].bool.should[?(@.term['visibility'].value=='Entity')]",
+        "Entity-visibility memories are visible to everyone");
+    assertFieldExists(
+        json,
+        "$.bool.should[1].bool.must[1].bool.should[?(@.nested.query.term['owners.id'].value=='"
+            + USER_ID
+            + "')]",
+        "owners see their own (including Private) memories");
+    assertFieldExists(
+        json,
+        "$.bool.should[1].bool.must[1].bool.should[?(@.terms['sharedWithIds'])]",
+        "Shared memories are matched via sharedWithIds");
+  }
+
+  @Test
+  void sharedPrincipalIdsIncludeUserTeamsAndDomains() {
+    String json = buildElasticJson(nonAdminSubject());
+
+    assertTrue(json.contains(USER_ID.toString()), "sharedWithIds must include the user id");
+    assertTrue(json.contains(TEAM_ID.toString()), "sharedWithIds must include the user's team id");
+    assertTrue(
+        json.contains(DOMAIN_ID.toString()), "sharedWithIds must include the user's domain id");
+  }
+
+  @Test
+  void outerClauseUsesShouldOnlySoMinimumShouldMatchDefaultsToOne() {
+    // The filter excludes invisible memories only because the outer bool is should-only, which
+    // makes the engine default minimum_should_match=1. A stray must/filter sibling would flip that
+    // default to 0 and turn the whole filter into a silent no-op (fail-open). Guard against it.
+    DocumentContext json = JsonPath.parse(buildElasticJson(nonAdminSubject()));
+
+    assertFieldExists(json, "$.bool.should", "the outer access clause must be should-based");
+    assertFieldDoesNotExist(
+        json, "$.bool.must", "a must sibling would drop minimum_should_match to 0 (fail-open)");
+    assertFieldDoesNotExist(
+        json, "$.bool.filter", "a filter sibling would drop minimum_should_match to 0 (fail-open)");
+  }
+
+  @Test
+  void privateMemoriesAreNotMatchedByVisibilityValue() {
+    String json = buildElasticJson(nonAdminSubject());
+
+    assertFalse(
+        json.contains("Private"),
+        "Private memories are reachable only via ownership, never a bare visibility match");
+  }
+
+  @Test
+  void adminSubjectGetsNoVisibilityFilter() {
+    User admin = new User().withId(USER_ID).withName("root").withIsAdmin(true);
+    OMQueryBuilder filter =
+        new ContextMemorySearchVisibility(new ElasticQueryBuilderFactory())
+            .buildVisibilityFilter(new SubjectContext(admin, null));
+
+    assertNull(filter, "Admins bypass memory visibility, mirroring ContextMemoryVisibility");
+  }
+
+  @Test
+  void nullSubjectGetsNoVisibilityFilter() {
+    OMQueryBuilder filter =
+        new ContextMemorySearchVisibility(new ElasticQueryBuilderFactory())
+            .buildVisibilityFilter(null);
+
+    assertNull(filter, "A missing subject must not silently expose memories");
+  }
+
+  @Test
+  void openSearchBuilderProducesEquivalentFilter() {
+    OMQueryBuilder filter =
+        new ContextMemorySearchVisibility(new OpenSearchQueryBuilderFactory())
+            .buildVisibilityFilter(nonAdminSubject());
+    String json = ((OpenSearchQueryBuilder) filter).build().toJsonString();
+
+    assertTrue(json.contains("entityType"), "OpenSearch filter guards on entityType");
+    assertTrue(json.contains(Entity.CONTEXT_MEMORY), "OpenSearch filter targets contextMemory");
+    assertTrue(json.contains("\"visibility\""), "OpenSearch filter matches the visibility field");
+    assertTrue(json.contains("owners.id"), "OpenSearch filter matches owners.id");
+    assertTrue(json.contains("sharedWithIds"), "OpenSearch filter matches sharedWithIds");
+    assertTrue(json.contains(USER_ID.toString()), "OpenSearch filter binds the user id");
+  }
+}


### PR DESCRIPTION
### Describe your changes:

`ContextMemory` enforces its per-memory `shareConfig` visibility (Private = owner-only, Entity = everyone, Shared = listed principals; admins bypass) **only** on the REST `/v1/contextCenter/memories` read endpoints. Global search (`/search/query` on the `all` alias) and the search-backed listing/NLQ paths applied only domain + RBAC filters, neither of which understands `shareConfig`, so any user could see other users' Private/Shared memory `title`/`question`/`answer` in search results. This PR adds `ContextMemorySearchVisibility` — an engine-agnostic search filter that mirrors `ContextMemoryVisibility` — and ANDs it into the Elasticsearch and OpenSearch query paths for every non-admin subject, deliberately independent of the RBAC access-control toggle so disabling RBAC can never expose private memories. The filter is `entityType`-guarded so non-memory documents are untouched, and the index still stores every memory so owners can always find their own.

Fixes [29490](https://github.com/open-metadata/OpenMetadata/issues/29490)

#
### Type of change:
- [x] Bug fix

#
### High-level design:

`ContextMemorySearchVisibility` builds a per-subject `OMQueryBuilder` using the same `QueryBuilderFactory` abstraction `RBACConditionEvaluator` uses, so one builder serves both engines: `should[ NOT(entityType=contextMemory) , (entityType=contextMemory AND should[ visibility=Entity, nested owners.id=me, sharedWithIds ∋ {me + teams + domains} ]) ]`. It is applied wherever RBAC is applied — `ElasticSearchSearchManager` (folded into `applyRbacCondition`, plus the inline direct-query and NLQ-fallback paths) and `OpenSearchSearchManager` (the inline `listWithOffset` path plus after each `applyRbacQueryWithCaching` call) — gated only on `!isAdmin`. Correctness rests on each OR-group being a should-only bool (engine default `minimum_should_match=1`, the same default `RBACConditionEvaluator` already relies on); a unit test pins that invariant so a stray `must`/`filter` can't silently turn the filter into a fail-open no-op. No DB migration or schema change (visibility data was already indexed); reindex already covers `contextMemory`. The AI/RAG vector-retrieval path (`VectorSearchResource` → `OpenSearchVectorService`) is a deliberate follow-up — it ignores the subject today and needs subject plumbing plus an acting-principal decision.

#
### Tests:

#### Use cases covered
- A non-admin's global search excludes other users' Private memories, keeps their own (incl. Private) and Entity-visibility memories, and shows Shared memories only to the listed user/team/domain principals.
- Non-memory documents (tables, dashboards, etc.) are unaffected by the filter.
- Admins and missing/unidentifiable subjects get no filter.

#### Unit tests
- [x] Added `ContextMemorySearchVisibilityTest` (8 tests, Elasticsearch + OpenSearch): `entityType` guard, the three visibility clauses, `sharedWithIds` = {user, teams, domains}, admin/null → no filter, and the should-only `minimum_should_match=1` invariant.

#### Backend integration tests
- [ ] Not applicable — no new/changed API endpoint (this is a search query-filter change). A live-engine end-to-end search IT is a planned follow-up.

#### Ingestion integration tests
- [x] Not applicable (no ingestion changes).

#### Playwright (UI) tests
- [x] Not applicable (no UI changes).

#### Manual testing performed
- `mvn -pl openmetadata-service test -Dtest=ContextMemorySearchVisibilityTest` → 8/8 green; `mvn spotless:apply` clean.

#
### UI screen recording / screenshots:

Not applicable.

#
### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] For JSON Schema changes: I updated the migration scripts or explained why it is not needed. _(No schema changes.)_
- [x] For UI changes: I attached a screen recording and/or screenshots above. _(No UI changes.)_
- [x] I have added tests (unit / integration / Playwright as applicable) and listed them above.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR introduces `ContextMemorySearchVisibility`, a new engine-agnostic filter that ANDs per-memory `shareConfig` visibility (Private = owner-only, Entity = everyone, Shared = listed principals with a `visibility=Shared` guard to prevent stale-list leaks) into search query paths for non-admin subjects, independent of the RBAC toggle.

- The filter is correctly wired into the main listing, direct-query, and NLQ-fallback paths for both Elasticsearch and OpenSearch, and the `sharedWithIds` branch is properly gated by `visibility=Shared` (addressing a prior review concern).
- The `searchWithNLQ` **success path** in both engines (when the NLQ service returns a transformed query) executes `client.search` without applying either RBAC or the new visibility filter — private ContextMemory documents remain reachable via NLQ search, which is the scenario this PR specifically targets.
- The AI/RAG vector-retrieval path is acknowledged as a deliberate follow-up.
</details>


<details open><summary><h3>Confidence Score: 3/5</h3></summary>

Not safe to merge as-is — the NLQ success path in both engines executes without the visibility filter, which is the primary attack vector this PR aims to close.

The filter implementation and wiring are correct for listing, direct-query, and fallback paths, but both ElasticSearchSearchManager.searchWithNLQ and OpenSearchSearchManager.searchWithNLQ execute the engine query directly when the NLQ service returns a transformed query, skipping both RBAC and the new visibility filter. A non-admin user with NLQ access can retrieve private ContextMemory documents owned by others — the exact exposure the PR describes fixing.

ElasticSearchSearchManager.java and OpenSearchSearchManager.java — specifically the searchWithNLQ success branch in each file (the block between requestBuilder.query(nlqQuery) and client.search).
</details>


<details open><summary><h3>Security Review</h3></summary>

- **Missing visibility filter on NLQ success path (ES + OS):** `ElasticSearchSearchManager.searchWithNLQ` and `OpenSearchSearchManager.searchWithNLQ` both skip `applyContextMemoryVisibility` (and RBAC) when the NLQ service successfully transforms a query. A non-admin user can retrieve private ContextMemory documents owned by other users via the NLQ search endpoint whenever the NLQ service is configured and returns results.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| openmetadata-service/src/main/java/org/openmetadata/service/search/security/ContextMemorySearchVisibility.java | New filter class that correctly enforces ContextMemory shareConfig visibility (Entity/owner-nested/Shared-gated) using engine-agnostic QueryBuilderFactory; the sharedWithIds branch is properly gated by visibility=Shared, addressing the stale-list leak from the prior thread. |
| openmetadata-service/src/main/java/org/openmetadata/service/search/elasticsearch/ElasticSearchSearchManager.java | Correctly adds applyContextMemoryVisibility to applyRbacCondition, searchWithDirectQuery, and fallbackToBasicSearch, but the searchWithNLQ success path (when transformedQuery is non-null) executes without RBAC or the visibility filter, leaving private memories exposed via NLQ. |
| openmetadata-service/src/main/java/org/openmetadata/service/search/opensearch/OpenSearchSearchManager.java | Correctly adds applyContextMemoryVisibility after each applyRbacQueryWithCaching call and in listWithOffset, but searchWithNLQ success path has the same gap as ElasticSearch — neither RBAC nor the visibility filter is applied before client.search. |
| openmetadata-service/src/test/java/org/openmetadata/service/search/security/ContextMemorySearchVisibilityTest.java | Comprehensive unit tests covering entityType guard, three visibility clauses, sharedWithIds gating by visibility=Shared, principal ID composition, the should-only minimum_should_match invariant, admin/null bypass, and OpenSearch equivalence; does not cover the NLQ integration paths. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Search Request] --> B{Search Path}
    B --> C[listWithOffset]
    B --> D[searchWithDirectQuery]
    B --> E[searchWithNLQ]
    B --> F[main search / buildSearchRequestBuilder]
    C --> C1[applyRbacCondition] --> C2[applyContextMemoryVisibility ✅] --> C3[Execute]
    D --> D1[inline RBAC] --> D2[applyContextMemoryVisibility ✅] --> D3[Execute]
    E --> E1{NLQ transform}
    E1 -->|success| E2[Execute query - NO RBAC - NO visibility filter ❌]
    E1 -->|failure/null| E3[fallbackToBasicSearch]
    E3 --> E4[inline RBAC] --> E5[applyContextMemoryVisibility ✅] --> E6[Execute]
    F --> F1[applyRbacQueryWithCaching] --> F2[applyContextMemoryVisibility ✅] --> F3[Execute]
    style E2 fill:#ff6b6b,color:#fff
    style C2 fill:#51cf66,color:#fff
    style D2 fill:#51cf66,color:#fff
    style E5 fill:#51cf66,color:#fff
    style F2 fill:#51cf66,color:#fff
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Search Request] --> B{Search Path}
    B --> C[listWithOffset]
    B --> D[searchWithDirectQuery]
    B --> E[searchWithNLQ]
    B --> F[main search / buildSearchRequestBuilder]
    C --> C1[applyRbacCondition] --> C2[applyContextMemoryVisibility ✅] --> C3[Execute]
    D --> D1[inline RBAC] --> D2[applyContextMemoryVisibility ✅] --> D3[Execute]
    E --> E1{NLQ transform}
    E1 -->|success| E2[Execute query - NO RBAC - NO visibility filter ❌]
    E1 -->|failure/null| E3[fallbackToBasicSearch]
    E3 --> E4[inline RBAC] --> E5[applyContextMemoryVisibility ✅] --> E6[Execute]
    F --> F1[applyRbacQueryWithCaching] --> F2[applyContextMemoryVisibility ✅] --> F3[Execute]
    style E2 fill:#ff6b6b,color:#fff
    style C2 fill:#51cf66,color:#fff
    style D2 fill:#51cf66,color:#fff
    style E5 fill:#51cf66,color:#fff
    style F2 fill:#51cf66,color:#fff
```

</a>
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `openmetadata-service/src/main/java/org/openmetadata/service/search/elasticsearch/ElasticSearchSearchManager.java`, line 573-623 ([link](https://github.com/open-metadata/openmetadata/blob/b0efa965fe8e2b43cdab6a4a109c21f362b3bb14/openmetadata-service/src/main/java/org/openmetadata/service/search/elasticsearch/ElasticSearchSearchManager.java#L573-L623)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> <a href="#"><img alt="security" src="https://greptile-static-assets.s3.amazonaws.com/badges/Security.svg?v=2" align="top"></a> **NLQ success path bypasses context-memory visibility filter**

   When the NLQ service is configured and `transformNaturalLanguageQuery` returns a non-null result, the query is executed directly (lines 595–612) without going through either RBAC or `applyContextMemoryVisibility`. Only the `fallbackToBasicSearch` path has the filter applied. A non-admin user can issue an NLQ query, receive a transformed ES query, and get back private ContextMemory documents belonging to other users — the exact leak this PR is meant to close. The fix is to call `applyContextMemoryVisibility(subjectContext, requestBuilder)` (and RBAC, which is also absent here) before `client.search(...)` in the success branch. The same gap exists in the OpenSearch `searchWithNLQ` success path for the same reason.


2. `openmetadata-service/src/main/java/org/openmetadata/service/search/opensearch/OpenSearchSearchManager.java`, line 558-602 ([link](https://github.com/open-metadata/openmetadata/blob/b0efa965fe8e2b43cdab6a4a109c21f362b3bb14/openmetadata-service/src/main/java/org/openmetadata/service/search/opensearch/OpenSearchSearchManager.java#L558-L602)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> <a href="#"><img alt="security" src="https://greptile-static-assets.s3.amazonaws.com/badges/Security.svg?v=2" align="top"></a> **NLQ success path bypasses context-memory visibility filter (OpenSearch)**

   Same gap as the Elasticsearch counterpart: when `nlqService.transformNaturalLanguageQuery` returns a non-null result, the code sets the query, adds aggregations, and calls `client.search` without calling `applyRbacQueryWithCaching` or `applyContextMemoryVisibility`. Only the `fallbackToBasicSearch` paths carry the filter. `applyRbacQueryWithCaching(subjectContext, requestBuilder)` and `applyContextMemoryVisibility(subjectContext, requestBuilder)` should both be called after `requestBuilder.query(nlqQuery)` and before `client.search(...)`.

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["fix(search): gate ContextMemory sharedWi..."](https://github.com/open-metadata/openmetadata/commit/b0efa965fe8e2b43cdab6a4a109c21f362b3bb14) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39454102)</sub>

<!-- /greptile_comment -->