### PR TITLE
fix(security): bump jackson-databind 2.18.7 -> 2.18.8 (CVE-2026-5451{2,3,4})

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -73,7 +73,7 @@
     <mockito.version>5.14.2</mockito.version>
     <!-- Upgrading slf4j causes dropwizard issues -->
     <slf4j.version>2.0.4</slf4j.version>
-    <jackson.version>2.18.7</jackson.version>
+    <jackson.version>2.18.8</jackson.version>
     <!-- Single source for the AWS SDK v2 BOM version, consumed by the root BOM
          import below and by openmetadata-service's BOM import. -->
     <awssdk.version>2.41.30</awssdk.version>


### PR DESCRIPTION
## Summary

Bumps `jackson.version` from `2.18.7` to `2.18.8` to patch the jackson-databind copy transitively bundled into the shaded `elasticsearch-deps` jar.

## Snyk verification — new version is vulnerability-free

**jackson-databind 2.18.8 — "No direct vulnerabilities have been found for this package in Snyk's vulnerability database":**

https://security.snyk.io/package/maven/com.fasterxml.jackson.core:jackson-databind/2.18.8

## CVEs closed by this bump (3/3 applicable on 2.18.x line)

| CVE | Severity | CVSS | Description |
|---|---|---|---|
| CVE-2026-54513 | High | 8.1 | `BasicPolymorphicTypeValidator.allowIfSubTypeIsArray()` allowlist bypass via array element type |
| CVE-2026-54512 | High | 8.1 | `PolymorphicTypeValidator` generic parameter allowlist bypass |
| CVE-2026-54514 | Medium | 5.3 | `JDKFromStringDeserializer` eager DNS resolution of `InetSocketAddress` |

The `2.18.x` line is **not affected** by CVE-2026-54516 / 54517 / 54518 per the upstream advisories (those affect `2.21.x` only).

## Remaining open

CVE-2026-54515 affects 2.18.8 and remains open until upstream releases 2.18.9 (backport merged but unreleased — https://github.com/FasterXML/jackson-databind/issues/6041). Only released fix today is Jackson 3.1.4 (`tools.jackson` namespace migration).

## Test plan

- [ ] CI build green
- [ ] Shaded `elasticsearch-deps` jar now bundles `jackson-databind-2.18.8`