### PR TITLE
Fix logs viewer bundle suite pagination

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/LogsViewer.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/LogsViewer.spec.ts
@@ -21,7 +21,10 @@ import { TableClass } from '../../support/entity/TableClass';
 import { performAdminLogin } from '../../utils/admin';
 import { redirectToHomePage } from '../../utils/common';
 import { waitForAllLoadersToDisappear } from '../../utils/entity';
-import { waitForFirstPipelineStatusNotQueued } from '../../utils/logsViewer';
+import {
+  navigateToBundleSuiteWithPagination,
+  waitForFirstPipelineStatusNotQueued,
+} from '../../utils/logsViewer';
 import { test } from '../fixtures/pages';
 
 let table: TableClass;
@@ -79,12 +82,7 @@ test.describe(
           bundleSuiteFqn,
           'bundle suite created in beforeAll'
         ).toBeTruthy();
-        const bundleSuiteLink = page
-          .getByTestId('test-suite-table')
-          .locator(`a[href*="${encodeURIComponent(bundleSuiteFqn)}"]`);
-        await expect(bundleSuiteLink).toBeVisible({ timeout: 10000 });
-        await bundleSuiteLink.click();
-        await waitForAllLoadersToDisappear(page);
+        await navigateToBundleSuiteWithPagination(page, bundleSuiteFqn);
       });
 
       await test.step('Open Pipeline tab and click Logs for first pipeline', async () => {

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/logsViewer.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/logsViewer.ts
@@ -18,6 +18,48 @@ import {
 } from '../constant/logsViewer';
 import { waitForAllLoadersToDisappear } from './entity';
 
+export const navigateToBundleSuiteWithPagination = async (
+  page: Page,
+  bundleSuiteFqn: string,
+  maxPages = 15
+) => {
+  const encodedBundleSuiteFqn = encodeURIComponent(bundleSuiteFqn);
+
+  for (let currentPage = 0; currentPage < maxPages; currentPage++) {
+    await waitForAllLoadersToDisappear(page);
+
+    const bundleSuiteLink = page
+      .getByTestId('test-suite-table')
+      .locator(`a[href*="${encodedBundleSuiteFqn}"]`)
+      .first();
+
+    if (await bundleSuiteLink.isVisible()) {
+      await bundleSuiteLink.click();
+      await waitForAllLoadersToDisappear(page);
+
+      return;
+    }
+
+    const nextBtn = page.locator('[data-testid="next"]');
+
+    if (!(await nextBtn.isVisible()) || !(await nextBtn.isEnabled())) {
+      break;
+    }
+
+    const listResponse = page.waitForResponse(
+      (r) =>
+        r.url().includes('/api/v1/dataQuality/testSuites/search/list') &&
+        r.status() === 200
+    );
+    await nextBtn.click();
+    await listResponse;
+  }
+
+  throw new Error(
+    `Bundle suite ${bundleSuiteFqn} was not found after checking ${maxPages} page(s)`
+  );
+};
+
 export async function waitForFirstPipelineStatusNotQueued(page: Page) {
   await expect(async () => {
     await page.reload();


### PR DESCRIPTION
### Describe your changes
- Add a LogsViewer Playwright utility to navigate bundle suite pagination before selecting the created suite.
- Update the LogsViewer spec to use the shared pagination helper instead of checking only the current table page.

Note: Targeted Playwright run reached the spec but local setup failed before the changed flow because triggering the generated pipeline returned HTTP 400.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a flaky test by replacing a single-page bundle suite lookup with a paginated navigation helper that iterates up to 15 table pages before declaring the suite not found.

- **New `navigateToBundleSuiteWithPagination` utility** (`logsViewer.ts`): loops through paginated table results, waits for each page's API response, and clicks the matching bundle suite link when found.
- **`LogsViewer.spec.ts` updated**: replaces the inline single-page `expect(link).toBeVisible()` block with a call to the new helper, removing the hard assumption that the created suite always appears on the first page.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; changes are confined to Playwright test utilities with no production code impact.

The pagination loop introduces a point-in-time `isVisible()` check that could give a false negative before the table finishes rendering, and the `waitForResponse` predicate that only resolves on HTTP 200 will silently hang on any server error. Both are test-reliability concerns rather than correctness blockers, and there is also a TypeScript type mismatch where `string | undefined` is passed to a `string` parameter without narrowing.

Both changed files deserve a second look: `logsViewer.ts` for the `isVisible()` retry gap and the `waitForResponse` error-status handling, and `LogsViewer.spec.ts` for the `bundleSuiteFqn` type narrowing.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-ui/src/main/resources/ui/playwright/utils/logsViewer.ts | Adds `navigateToBundleSuiteWithPagination` that iterates up to 15 table pages searching for a bundle suite link; uses `isVisible()` (point-in-time) and awaits a 200-only `waitForResponse` predicate on each page flip. |
| openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/LogsViewer.spec.ts | Replaces the inline single-page bundle-suite navigation with the new `navigateToBundleSuiteWithPagination` helper; passes a `string | undefined` value where the helper expects `string`. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[navigateToBundleSuiteWithPagination called] --> B[waitForAllLoadersToDisappear]
    B --> C{bundleSuiteLink\nisVisible?}
    C -- Yes --> D[click link]
    D --> E[waitForAllLoadersToDisappear]
    E --> F[return]
    C -- No --> G{nextBtn visible\nand enabled?}
    G -- No --> H[break]
    H --> I[throw Error:\nnot found after N pages]
    G -- Yes --> J[set up waitForResponse\n200 only]
    J --> K[await nextBtn.click]
    K --> L[await listResponse]
    L --> M{currentPage < maxPages?}
    M -- Yes --> B
    M -- No --> I
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[navigateToBundleSuiteWithPagination called] --> B[waitForAllLoadersToDisappear]
    B --> C{bundleSuiteLink\nisVisible?}
    C -- Yes --> D[click link]
    D --> E[waitForAllLoadersToDisappear]
    E --> F[return]
    C -- No --> G{nextBtn visible\nand enabled?}
    G -- No --> H[break]
    H --> I[throw Error:\nnot found after N pages]
    G -- Yes --> J[set up waitForResponse\n200 only]
    J --> K[await nextBtn.click]
    K --> L[await listResponse]
    L --> M{currentPage < maxPages?}
    M -- Yes --> B
    M -- No --> I
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["Fix logs viewer bundle suite pagination"](https://github.com/open-metadata/openmetadata/commit/808ae2f4b02eee8a0d6a72808e7a101767de9c2f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39491275)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->