### PR TITLE
ci: run downstream Collate build on UI-only OSS PRs

### DIFF
--- a/.github/workflows/maven-build-collate.yml
+++ b/.github/workflows/maven-build-collate.yml
@@ -36,6 +36,9 @@ on:
     types: [opened, synchronize, labeled, ready_for_review]
     paths:
       - "openmetadata-service/**"
+      - "openmetadata-ui/**"
+      - "!openmetadata-ui/src/main/resources/ui/playwright/doc-generator/**"
+      - "!openmetadata-ui/src/main/resources/ui/playwright/docs/**"
       - "openmetadata-spec/src/main/resources/json/schema/**"
       - "openmetadata-integration-tests/**"
       - "openmetadata-mcp/**"

--- a/.github/workflows/maven-build-collate.yml
+++ b/.github/workflows/maven-build-collate.yml
@@ -36,9 +36,12 @@ on:
     types: [opened, synchronize, labeled, ready_for_review]
     paths:
       - "openmetadata-service/**"
-      - "openmetadata-ui/**"
-      - "!openmetadata-ui/src/main/resources/ui/playwright/doc-generator/**"
-      - "!openmetadata-ui/src/main/resources/ui/playwright/docs/**"
+      - "openmetadata-ui/src/main/resources/ui/src/**"
+      - "!openmetadata-ui/src/main/resources/ui/src/test/**"
+      - "!openmetadata-ui/src/main/resources/ui/src/**/*.test.ts"
+      - "!openmetadata-ui/src/main/resources/ui/src/**/*.test.tsx"
+      - "!openmetadata-ui/src/main/resources/ui/src/**/*.spec.ts"
+      - "!openmetadata-ui/src/main/resources/ui/src/**/*.spec.tsx"
       - "openmetadata-spec/src/main/resources/json/schema/**"
       - "openmetadata-integration-tests/**"
       - "openmetadata-mcp/**"
@@ -68,10 +71,10 @@ jobs:
         uses: jesusvasquez333/verify-pr-label-action@v1.4.0
         if: ${{ github.event_name == 'pull_request_target' }}
         with:
-          github-token: '${{ secrets.GITHUB_TOKEN }}'
-          valid-labels: 'safe to test'
-          pull-request-number: '${{ github.event.pull_request.number }}'
-          disable-reviews: true  # To not auto approve changes
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+          valid-labels: "safe to test"
+          pull-request-number: "${{ github.event.pull_request.number }}"
+          disable-reviews: true # To not auto approve changes
 
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/maven-build-collate.yml
+++ b/.github/workflows/maven-build-collate.yml
@@ -40,8 +40,6 @@ on:
       - "!openmetadata-ui/src/main/resources/ui/src/test/**"
       - "!openmetadata-ui/src/main/resources/ui/src/**/*.test.ts"
       - "!openmetadata-ui/src/main/resources/ui/src/**/*.test.tsx"
-      - "!openmetadata-ui/src/main/resources/ui/src/**/*.spec.ts"
-      - "!openmetadata-ui/src/main/resources/ui/src/**/*.spec.tsx"
       - "openmetadata-spec/src/main/resources/json/schema/**"
       - "openmetadata-integration-tests/**"
       - "openmetadata-mcp/**"


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:

<!--
Linking an issue is REQUIRED. Replace <issue-number> with the GitHub issue number this PR addresses
(e.g., `Fixes #12345`). GitHub will auto-link it. If no issue exists, please open one first so the
problem and design can be discussed before review.
-->

<!--
Short blurb explaining:
- What changes did you make?
- Why did you make them?
-->

## What

Add `openmetadata-ui/**` to the `pull_request_target` paths in `maven-build-collate.yml`, so OSS PRs that change only UI files trigger the existing downstream Collate build before merge.

## Why

The downstream "OpenMetadata Collate Test" check (which builds `collate-ui` against the OSS PR via `mvn install -DskipTests`) was wired to `pull_request_target` paths covering only:

- `openmetadata-service/**`
- `openmetadata-spec/.../schema/**`
- `openmetadata-integration-tests/**`
- `openmetadata-mcp/**`

`openmetadata-ui/**` was missing. So an OSS PR that deletes/renames a UI file or export used **only** by Collate (e.g. `searchTagInData` in `TableTags.utils`, or the `EntityNameUtils` file) passed all OSS checks, merged, and then broke Collate's build — discovered late on unrelated Collate PRs, nightly Docker, or release backports.

The post-merge `push` trigger already includes `openmetadata-ui/**`, but that runs after merge — too late. This change moves the same coverage to pre-merge.


#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### High-level design:
<!--
REQUIRED for large PRs (new features, refactors, breaking changes, or anything touching >5 files).
Skip for small bug fixes and trivial changes.

Cover:
- Architecture / approach you took and why
- Key components or files added/changed and how they interact
- Alternatives considered and why you rejected them
- Any migration, backward-compatibility, or rollout concerns
- Diagrams or links to design docs / RFCs if available
-->

N/A — small change. <!-- Or fill in the design above -->

#
### Tests:

#### Use cases covered
<!--
List the user-visible scenarios this PR exercises. Example:
- User with Admin role can create a Glossary Term with a parent term
- Ingestion run for Snowflake correctly extracts row counts for partitioned tables
-->

#### Unit tests
<!--
- [ ] I added unit tests for the new/changed logic.
- Files added/updated:
- Coverage on changed classes (run `mvn jacoco:report` for backend, `yarn test:coverage` for UI,
  `make unit_ingestion` for ingestion). Target is 90% line coverage on changed classes.
- Coverage %: <e.g., 92% on EntityRepository.java>
-->

#### Backend integration tests
<!--
- [ ] I added integration tests in `openmetadata-integration-tests/` for new/changed API endpoints.
- [ ] Not applicable (no backend API changes).
- Files added/updated:
-->

#### Ingestion integration tests
<!--
- [ ] I added/updated ingestion integration tests for connector changes.
- [ ] Not applicable (no ingestion changes).
- Files added/updated:
-->

#### Playwright (UI) tests
<!--
- [ ] I added Playwright E2E tests under `openmetadata-ui/.../ui/playwright/` for UI changes.
- [ ] Not applicable (no UI changes).
- Files added/updated:
-->

#### Manual testing performed
<!--
List the manual test steps you performed before requesting review. Example:
1. Started local stack via `./docker/run_local_docker.sh -m ui -d mysql`
2. Logged in as admin, created entity X, verified Y appears in the UI
3. Triggered ingestion for Snowflake source, confirmed lineage edges in the explore page
-->

#
### UI screen recording / screenshots:
<!--
REQUIRED for any PR that changes the UI. Drag-and-drop a short screen recording (.mov / .mp4 / .gif)
demonstrating the change end-to-end, plus before/after screenshots where relevant.
Mark "Not applicable" if there are no UI changes.
-->

Not applicable. <!-- Or attach recording/screenshots above -->

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.
- [ ] For UI changes: I attached a screen recording and/or screenshots above.
- [ ] I have added tests (unit / integration / Playwright as applicable) and listed them above.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR extends the `pull_request_target` path filter in `maven-build-collate.yml` to include UI source files, ensuring that OSS PRs touching only `openmetadata-ui/src/**` trigger the downstream Collate build before merge — closing the gap where UI-breaking changes could pass all OSS checks and only surface after merge on the Collate side.

- Adds `openmetadata-ui/src/main/resources/ui/src/**` to the `pull_request_target` `paths` block, mirroring (in a more targeted form) the broader `openmetadata-ui/**` entry that already existed in the `push` trigger.
- Excludes test files (`src/test/**`, `**/*.test.ts`, `**/*.test.tsx`) from the trigger to avoid running the expensive Collate build for test-only changes.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is a one-file CI path filter addition with no runtime code impact.

The only file changed is a GitHub Actions workflow YAML. The addition of openmetadata-ui/src/main/resources/ui/src/** to pull_request_target paths is straightforward and consistent with the existing push trigger. The test-file negation patterns are correctly placed after the positive pattern and follow GitHub Actions negation semantics. No logic, application code, or secrets handling is touched.

No files require special attention.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/maven-build-collate.yml | Adds openmetadata-ui/src/main/resources/ui/src/** (with test-file exclusions) to the pull_request_target path filter, so UI-only OSS PRs now trigger the downstream Collate build pre-merge; also converts single quotes to double quotes in the label-verification step. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[OSS PR opened or synchronized] --> B{pull_request_target paths filter}
    B -->|openmetadata-service| C[Trigger Collate Build]
    B -->|openmetadata-ui src non-test files - NEW| C
    B -->|openmetadata-spec schema| C
    B -->|openmetadata-integration-tests or mcp| C
    B -->|No matching paths| D[Skip - no Collate build]
    C --> E{PR has safe-to-test label?}
    E -->|Yes| F[Dispatch openmetadata-collate workflow]
    E -->|No| G[Fail - label check blocks run]
    F --> H[Wait for Collate build result]
    H -->|Pass| I[Pre-merge check passes]
    H -->|Fail| J[Merge blocked]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[OSS PR opened or synchronized] --> B{pull_request_target paths filter}
    B -->|openmetadata-service| C[Trigger Collate Build]
    B -->|openmetadata-ui src non-test files - NEW| C
    B -->|openmetadata-spec schema| C
    B -->|openmetadata-integration-tests or mcp| C
    B -->|No matching paths| D[Skip - no Collate build]
    C --> E{PR has safe-to-test label?}
    E -->|Yes| F[Dispatch openmetadata-collate workflow]
    E -->|No| G[Fail - label check blocks run]
    F --> H[Wait for Collate build result]
    H -->|Pass| I[Pre-merge check passes]
    H -->|Fail| J[Merge blocked]
```

</a>
</details>

<sub>Reviews (3): Last reviewed commit: ["remove playwright path"](https://github.com/open-metadata/openmetadata/commit/a9df26e125606ca4e3c1e210e186d3355e4535ec) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39495624)</sub>

<!-- /greptile_comment -->