### PR TITLE
playwright: Fix DQ data product filter search

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DataQuality/DataQualityDashboard.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DataQuality/DataQualityDashboard.spec.ts
@@ -1043,13 +1043,13 @@ test.describe(
 
       await test.step('Select data product and verify API carries dataProductFqn', async () => {
         const dataProductInput = page.locator('#dataProductFqn');
-        await dataProductInput.click();
         const dataProductOptionsRes = page.waitForResponse(
           (r) =>
             r.url().includes('/api/v1/search/query') &&
             r.url().includes('index=dataProduct') &&
             r.url().includes(dataProductName)
         );
+        await dataProductInput.click();
         await dataProductInput.fill(dataProductName);
         await dataProductOptionsRes;
 

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DataQuality/DataQualityDashboard.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DataQuality/DataQualityDashboard.spec.ts
@@ -1021,6 +1021,7 @@ test.describe(
     test('Test Cases list filter — Data Product', async ({ page }) => {
       const dataProductDisplayName =
         dataProduct.responseData.displayName ?? dataProduct.data.displayName;
+      const dataProductName = dataProduct.data.name;
 
       await test.step('Navigate to DQ Test Cases tab', async () => {
         await page.goto('/data-quality/test-cases');
@@ -1041,7 +1042,17 @@ test.describe(
       });
 
       await test.step('Select data product and verify API carries dataProductFqn', async () => {
-        await page.click('#dataProductFqn');
+        const dataProductInput = page.locator('#dataProductFqn');
+        await dataProductInput.click();
+        const dataProductOptionsRes = page.waitForResponse(
+          (r) =>
+            r.url().includes('/api/v1/search/query') &&
+            r.url().includes('index=dataProduct') &&
+            r.url().includes(dataProductName)
+        );
+        await dataProductInput.fill(dataProductName);
+        await dataProductOptionsRes;
+
         const filterApiRes = page.waitForResponse(
           (r) =>
             r.url().includes('/api/v1/dataQuality/testCases/search/list') &&


### PR DESCRIPTION
### Describe your changes
- Fill the Data Product advanced filter search input before selecting an option.
- Wait for the filtered data product search response before clicking the option.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a flaky Playwright test for the Data Quality dashboard's data product filter. Previously the test clicked the `#dataProductFqn` input without typing a query, leaving the full (unfiltered) options list open and making subsequent option selection unreliable.

- Fills the input with `dataProductName` before awaiting the filtered `/api/v1/search/query` response, so the dropdown only contains the target item when the selection click is made.
- `waitForResponse` is correctly registered before `dataProductInput.click()` / `fill()`, following the standard Playwright race-free listener-first pattern.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — a one-step Playwright test fix with no production code changes.

The change is isolated to a single E2E test step: it adds an input fill and a properly-ordered waitForResponse guard before selecting a dropdown option. The listener is registered before the triggering actions, so no race condition is introduced. No production code, no schema changes, and no shared test utilities are touched.

No files require special attention.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DataQuality/DataQualityDashboard.spec.ts | Fills the data product search input with `dataProductName` before awaiting filtered search response, preventing flaky option selection; `waitForResponse` is correctly registered before the triggering actions. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Test as Playwright Test
    participant Browser as Browser/Page
    participant API as Search API

    Test->>Browser: page.waitForResponse(predicate w/ dataProductName) [registered]
    Test->>Browser: dataProductInput.click()
    Browser->>API: "GET /api/v1/search/query?index=dataProduct (empty query)"
    API-->>Browser: response (no match — predicate not triggered)
    Test->>Browser: dataProductInput.fill(dataProductName)
    Browser->>API: "GET /api/v1/search/query?index=dataProduct&q=dataProductName"
    API-->>Browser: filtered response
    Browser-->>Test: dataProductOptionsRes resolves
    Test->>Browser: waitForResponse(dataProductFqn in URL) [registered]
    Test->>Browser: click option (dataProductDisplayName)
    Browser->>API: "GET /api/v1/dataQuality/testCases/search/list?...&dataProductFqn=..."
    API-->>Browser: filtered test cases response
    Browser-->>Test: filterApiRes resolves
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Test as Playwright Test
    participant Browser as Browser/Page
    participant API as Search API

    Test->>Browser: page.waitForResponse(predicate w/ dataProductName) [registered]
    Test->>Browser: dataProductInput.click()
    Browser->>API: "GET /api/v1/search/query?index=dataProduct (empty query)"
    API-->>Browser: response (no match — predicate not triggered)
    Test->>Browser: dataProductInput.fill(dataProductName)
    Browser->>API: "GET /api/v1/search/query?index=dataProduct&q=dataProductName"
    API-->>Browser: filtered response
    Browser-->>Test: dataProductOptionsRes resolves
    Test->>Browser: waitForResponse(dataProductFqn in URL) [registered]
    Test->>Browser: click option (dataProductDisplayName)
    Browser->>API: "GET /api/v1/dataQuality/testCases/search/list?...&dataProductFqn=..."
    API-->>Browser: filtered test cases response
    Browser-->>Test: filterApiRes resolves
```

</a>
</details>

<sub>Reviews (2): Last reviewed commit: ["Fix DQ data product response wait order"](https://github.com/open-metadata/openmetadata/commit/b2eee795856db4c6e1823ddfc2cecdc2a625a7b4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39498924)</sub>

<!-- /greptile_comment -->