### PR TITLE
fix(playwright): define data observability tab for data product customization

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/constant/customizeDetail.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/constant/customizeDetail.ts
@@ -80,6 +80,7 @@ export enum EntityTabs {
   SUBDOMAINS = 'subdomains',
   CONTRACT = 'contract',
   ER_DIAGRAM = 'erDiagram',
+  DATA_OBSERVABILITY = 'data_observability',
 }
 
 export const TABLE_DEFAULT_TABS = [


### PR DESCRIPTION
## Summary
- define the missing Playwright Data Observability tab enum for 1.13 data product customization
- fixes DataProductPersonaCustomization looking for tab-undefined after PR #28713 cherry-pick

## Testing
- organize-imports-cli playwright/constant/customizeDetail.ts
- eslint --no-error-on-unmatched-pattern --fix playwright/constant/customizeDetail.ts
- prettier --write playwright/constant/customizeDetail.ts
- static verification that DATA_PRODUCT_DEFAULT_TABS references a defined DATA_OBSERVABILITY enum

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Adds the missing `EntityTabs.DATA_OBSERVABILITY = 'data_observability'` entry to the Playwright `EntityTabs` enum in `customizeDetail.ts`, fixing a broken tab reference in `DATA_PRODUCT_DEFAULT_TABS` that was introduced when PR #28713 was cherry-picked to the 1.13 branch without the accompanying enum definition.

- Adds `DATA_OBSERVABILITY = 'data_observability'` to `EntityTabs` — the string value matches the production enum in `src/enums/entity.enum.ts`.
- Resolves `DATA_PRODUCT_DEFAULT_TABS` pointing to an undefined enum member, which would have caused Playwright tests for Data Product persona customization to fail with `tab-undefined`.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is a one-line enum addition with no runtime side effects.

The added enum member exactly mirrors the production value in `src/enums/entity.enum.ts`. The fix is narrowly scoped to restoring a missing constant that `DATA_PRODUCT_DEFAULT_TABS` already referenced, so the Playwright test suite will now resolve the tab correctly instead of producing `tab-undefined`.

No files require special attention.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-ui/src/main/resources/ui/playwright/constant/customizeDetail.ts | Adds missing `DATA_OBSERVABILITY = 'data_observability'` enum member to `EntityTabs`, fixing `DATA_PRODUCT_DEFAULT_TABS` reference that was undefined after the cherry-pick from #28713. The string value matches `src/enums/entity.enum.ts`. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[EntityTabs enum\nin customizeDetail.ts] -->|was missing| B[DATA_OBSERVABILITY]
    B -->|now defined as| C['data_observability']
    D[DATA_PRODUCT_DEFAULT_TABS] -->|references| B
    E[src/enums/entity.enum.ts\nDATA_OBSERVABILITY] -->|matches value| C
    D -->|used by| F[DataProductPersonaCustomization\nPlaywright tests]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[EntityTabs enum\nin customizeDetail.ts] -->|was missing| B[DATA_OBSERVABILITY]
    B -->|now defined as| C['data_observability']
    D[DATA_PRODUCT_DEFAULT_TABS] -->|references| B
    E[src/enums/entity.enum.ts\nDATA_OBSERVABILITY] -->|matches value| C
    D -->|used by| F[DataProductPersonaCustomization\nPlaywright tests]
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(playwright): define data observabili..."](https://github.com/open-metadata/openmetadata/commit/d6c35d1b136bf287e06303629bf3b9de181a13e9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39532569)</sub>

<!-- /greptile_comment -->