### PR TITLE
Fix the flaky Roles.spec.ts test

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/Roles.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/Roles.spec.ts
@@ -123,7 +123,7 @@ test.describe('Roles page tests', PLAYWRIGHT_BASIC_TEST_TAG_OBJ, () => {
       ]);
 
       // Wait for loader to disappear after submission
-      await expect(page.locator('[data-testid="loader"]')).not.toBeVisible();
+      await waitForAllLoadersToDisappear(page);
 
       // Verify the role is added successfully
       await expect(page).toHaveURL(`/settings/access/roles/${roleName}`);
@@ -144,7 +144,7 @@ test.describe('Roles page tests', PLAYWRIGHT_BASIC_TEST_TAG_OBJ, () => {
       await policiesTab.click();
 
       // Wait for policies tab content to load
-      await expect(page.locator('[data-testid="loader"]')).not.toBeVisible();
+      await waitForAllLoadersToDisappear(page);
 
       // Verifying the added policies - use proper assertions
       await expect(
@@ -167,7 +167,7 @@ test.describe('Roles page tests', PLAYWRIGHT_BASIC_TEST_TAG_OBJ, () => {
       await teamsTab.click();
 
       // Wait for teams tab content to load
-      await expect(page.locator('[data-testid="loader"]')).not.toBeVisible();
+      await waitForAllLoadersToDisappear(page);
       await expect(page.getByRole('cell', { name: 'No data' })).toBeVisible();
 
       // click on the users tab
@@ -176,12 +176,12 @@ test.describe('Roles page tests', PLAYWRIGHT_BASIC_TEST_TAG_OBJ, () => {
       await usersTab.click();
 
       // Wait for users tab content to load
-      await expect(page.locator('[data-testid="loader"]')).not.toBeVisible();
+      await waitForAllLoadersToDisappear(page);
       await expect(page.getByRole('cell', { name: 'No data' })).toBeVisible();
 
       // Navigate to roles list page to verify the added role
       await settingClick(page, GlobalSettingOptions.ROLES);
-      await expect(page.locator('[data-testid="loader"]')).not.toBeVisible();
+      await waitForAllLoadersToDisappear(page);
 
       const roleLocator = page.locator(
         `[data-testid="role-name"][href="/settings/access/roles/${roleName}"]`
@@ -249,7 +249,7 @@ test.describe('Roles page tests', PLAYWRIGHT_BASIC_TEST_TAG_OBJ, () => {
       await settingClick(page, GlobalSettingOptions.ROLES);
 
       // Wait for roles page to be ready
-      await expect(page.locator('[data-testid="loader"]')).not.toBeVisible();
+      await waitForAllLoadersToDisappear(page);
 
       // Edit description
       const roleLocator = page.locator(
@@ -258,7 +258,7 @@ test.describe('Roles page tests', PLAYWRIGHT_BASIC_TEST_TAG_OBJ, () => {
       await getElementWithPagination(page, roleLocator);
 
       // Wait for role details page to load
-      await expect(page.locator('[data-testid="loader"]')).not.toBeVisible();
+      await waitForAllLoadersToDisappear(page);
 
       const editDescriptionButton = page.locator(
         '[data-testid="edit-description"]'
@@ -286,7 +286,7 @@ test.describe('Roles page tests', PLAYWRIGHT_BASIC_TEST_TAG_OBJ, () => {
       ]);
 
       // Wait for loader to disappear and verify description updated
-      await expect(page.locator('[data-testid="loader"]')).not.toBeVisible();
+      await waitForAllLoadersToDisappear(page);
       await expect(page.locator('[data-testid="inactive-link"]')).toBeVisible();
 
       // Asserting updated description
@@ -329,7 +329,7 @@ test.describe('Roles page tests', PLAYWRIGHT_BASIC_TEST_TAG_OBJ, () => {
       ]);
 
       // Wait for loader and verify header updated
-      await expect(page.locator('[data-testid="loader"]')).not.toBeVisible();
+      await waitForAllLoadersToDisappear(page);
       const headerDisplayName = page.getByTestId('entity-header-display-name');
       await expect(headerDisplayName).toBeVisible();
       await expect(headerDisplayName).toContainText(updatedRoleName);
@@ -339,7 +339,7 @@ test.describe('Roles page tests', PLAYWRIGHT_BASIC_TEST_TAG_OBJ, () => {
       await settingClick(page, GlobalSettingOptions.ROLES);
 
       // Wait for roles page to be ready
-      await expect(page.locator('[data-testid="loader"]')).not.toBeVisible();
+      await waitForAllLoadersToDisappear(page);
 
       const roleLocator = page.locator(
         `[data-testid="role-name"][href="/settings/access/roles/${roleName}"]`
@@ -347,7 +347,7 @@ test.describe('Roles page tests', PLAYWRIGHT_BASIC_TEST_TAG_OBJ, () => {
       await getElementWithPagination(page, roleLocator);
 
       // Wait for role details page to load
-      await expect(page.locator('[data-testid="loader"]')).not.toBeVisible();
+      await waitForAllLoadersToDisappear(page);
 
       // Click add policy button
       const addPolicyButton = page.locator('[data-testid="add-policy"]');
@@ -391,7 +391,7 @@ test.describe('Roles page tests', PLAYWRIGHT_BASIC_TEST_TAG_OBJ, () => {
 
       // Wait for modal to close and UI to update
       await expect(modalContainer).not.toBeVisible();
-      await expect(page.locator('[data-testid="loader"]')).not.toBeVisible();
+      await waitForAllLoadersToDisappear(page);
 
       // Verify policy was added
       await expect(
@@ -406,7 +406,7 @@ test.describe('Roles page tests', PLAYWRIGHT_BASIC_TEST_TAG_OBJ, () => {
       await settingClick(page, GlobalSettingOptions.ROLES);
 
       // Wait for roles page to be ready
-      await expect(page.locator('[data-testid="loader"]')).not.toBeVisible();
+      await waitForAllLoadersToDisappear(page);
 
       const roleLocator = page.locator(
         `[data-testid="role-name"][href="/settings/access/roles/${roleName}"]`
@@ -414,7 +414,7 @@ test.describe('Roles page tests', PLAYWRIGHT_BASIC_TEST_TAG_OBJ, () => {
       await getElementWithPagination(page, roleLocator);
 
       // Wait for role details page to load
-      await expect(page.locator('[data-testid="loader"]')).not.toBeVisible();
+      await waitForAllLoadersToDisappear(page);
 
       // Remove policy
       await removePolicyFromRole(
@@ -424,7 +424,7 @@ test.describe('Roles page tests', PLAYWRIGHT_BASIC_TEST_TAG_OBJ, () => {
       );
 
       // Wait for UI to update after removal
-      await expect(page.locator('[data-testid="loader"]')).not.toBeVisible();
+      await waitForAllLoadersToDisappear(page);
 
       // Validating if the policy is removed successfully
       await expect(
@@ -439,7 +439,7 @@ test.describe('Roles page tests', PLAYWRIGHT_BASIC_TEST_TAG_OBJ, () => {
       await settingClick(page, GlobalSettingOptions.ROLES);
 
       // Wait for roles page to be ready
-      await expect(page.locator('[data-testid="loader"]')).not.toBeVisible();
+      await waitForAllLoadersToDisappear(page);
 
       const roleLocator = page.locator(
         `[data-testid="role-name"][href="/settings/access/roles/${roleName}"]`
@@ -447,7 +447,7 @@ test.describe('Roles page tests', PLAYWRIGHT_BASIC_TEST_TAG_OBJ, () => {
       await getElementWithPagination(page, roleLocator);
 
       // Wait for role details page to load
-      await expect(page.locator('[data-testid="loader"]')).not.toBeVisible();
+      await waitForAllLoadersToDisappear(page);
 
       // Removing second policy from the role
       await removePolicyFromRole(
@@ -457,7 +457,7 @@ test.describe('Roles page tests', PLAYWRIGHT_BASIC_TEST_TAG_OBJ, () => {
       );
 
       // Wait for UI to update after removal
-      await expect(page.locator('[data-testid="loader"]')).not.toBeVisible();
+      await waitForAllLoadersToDisappear(page);
 
       // Validating if the policy is removed successfully
       await expect(
@@ -493,7 +493,7 @@ test.describe('Roles page tests', PLAYWRIGHT_BASIC_TEST_TAG_OBJ, () => {
       await settingClick(page, GlobalSettingOptions.ROLES);
 
       // Wait for roles page to be ready
-      await expect(page.locator('[data-testid="loader"]')).not.toBeVisible();
+      await waitForAllLoadersToDisappear(page);
 
       const roleLocator = page.locator(
         `[data-testid="delete-action-${updatedRoleName}"]`
@@ -525,7 +525,7 @@ test.describe('Roles page tests', PLAYWRIGHT_BASIC_TEST_TAG_OBJ, () => {
       ]);
 
       // Wait for modal to close and UI to update
-      await expect(page.locator('[data-testid="loader"]')).not.toBeVisible();
+      await waitForAllLoadersToDisappear(page);
 
       // Validate deleted role is no longer visible
       await expect(
@@ -590,7 +590,7 @@ test.describe('Roles page tests', PLAYWRIGHT_BASIC_TEST_TAG_OBJ, () => {
     ]);
 
     // Wait for UI to update and verify role is deleted
-    await expect(page.locator('[data-testid="loader"]')).not.toBeVisible();
+    await waitForAllLoadersToDisappear(page);
     await expect(roleLocator).not.toBeVisible();
 
     await role.delete(apiContext);


### PR DESCRIPTION
Fixes #29408

This pull request refactors the way test scripts wait for page loading to complete in the `Roles` page Playwright end-to-end tests. Instead of directly checking for the absence of the loader element, the tests now consistently use the `waitForAllLoadersToDisappear` helper function. This change improves reliability and readability by centralizing the logic for waiting until all loaders are gone, reducing potential flakiness in the tests.

**Test reliability and consistency improvements:**

* Replaced all instances of `await expect(page.locator('[data-testid="loader"]')).not.toBeVisible();` with `await waitForAllLoadersToDisappear(page);` throughout `Roles.spec.ts` to standardize waiting for loaders to disappear after navigation, tab changes, and actions. [[1]](diffhunk://#diff-33f2f5a499a55efd21a1d893b3a4ba89556c81219cc30c2e4c80c6ad42e59e0aL126-R126) [[2]](diffhunk://#diff-33f2f5a499a55efd21a1d893b3a4ba89556c81219cc30c2e4c80c6ad42e59e0aL147-R147) [[3]](diffhunk://#diff-33f2f5a499a55efd21a1d893b3a4ba89556c81219cc30c2e4c80c6ad42e59e0aL170-R170) [[4]](diffhunk://#diff-33f2f5a499a55efd21a1d893b3a4ba89556c81219cc30c2e4c80c6ad42e59e0aL179-R184) [[5]](diffhunk://#diff-33f2f5a499a55efd21a1d893b3a4ba89556c81219cc30c2e4c80c6ad42e59e0aL252-R252) [[6]](diffhunk://#diff-33f2f5a499a55efd21a1d893b3a4ba89556c81219cc30c2e4c80c6ad42e59e0aL261-R261) [[7]](diffhunk://#diff-33f2f5a499a55efd21a1d893b3a4ba89556c81219cc30c2e4c80c6ad42e59e0aL289-R289) [[8]](diffhunk://#diff-33f2f5a499a55efd21a1d893b3a4ba89556c81219cc30c2e4c80c6ad42e59e0aL332-R332) [[9]](diffhunk://#diff-33f2f5a499a55efd21a1d893b3a4ba89556c81219cc30c2e4c80c6ad42e59e0aL342-R350) [[10]](diffhunk://#diff-33f2f5a499a55efd21a1d893b3a4ba89556c81219cc30c2e4c80c6ad42e59e0aL394-R394) [[11]](diffhunk://#diff-33f2f5a499a55efd21a1d893b3a4ba89556c81219cc30c2e4c80c6ad42e59e0aL409-R417) [[12]](diffhunk://#diff-33f2f5a499a55efd21a1d893b3a4ba89556c81219cc30c2e4c80c6ad42e59e0aL427-R427) [[13]](diffhunk://#diff-33f2f5a499a55efd21a1d893b3a4ba89556c81219cc30c2e4c80c6ad42e59e0aL442-R450) [[14]](diffhunk://#diff-33f2f5a499a55efd21a1d893b3a4ba89556c81219cc30c2e4c80c6ad42e59e0aL460-R460) [[15]](diffhunk://#diff-33f2f5a499a55efd21a1d893b3a4ba89556c81219cc30c2e4c80c6ad42e59e0aL496-R496) [[16]](diffhunk://#diff-33f2f5a499a55efd21a1d893b3a4ba89556c81219cc30c2e4c80c6ad42e59e0aL528-R528) [[17]](diffhunk://#diff-33f2f5a499a55efd21a1d893b3a4ba89556c81219cc30c2e4c80c6ad42e59e0aL593-R593)

This makes the tests less brittle and easier to maintain, as any changes to loader behavior only need to be handled in the `waitForAllLoadersToDisappear` helper.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR standardizes loader-waiting logic in `Roles.spec.ts` by replacing inline `expect(page.locator('[data-testid="loader"]')).not.toBeVisible()` checks with the shared `waitForAllLoadersToDisappear` helper across 17 call sites.

- The helper (`utils/entity.ts`) uses `toHaveCount(0)` which waits for all loader elements to be fully removed from the DOM, a stricter and more reliable condition than the previous `not.toBeVisible()` which only checked visibility of the first matched element.
- All remaining `.not.toBeVisible()` calls in the file are intentional — they guard non-loader elements (dropdowns, modals, role links) and are correctly left unchanged.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Pure test refactoring with no production code changes; all loader waits are now delegated to a single well-tested helper.

Every changed line is a direct substitution in test-only code. The replacement helper is already used across 200+ other test files in the repo, the import is correctly wired in Roles.spec.ts, and the remaining .not.toBeVisible() calls in the file are all guarding non-loader elements. No logic was altered, only the mechanism for waiting on loaders was centralized.

No files require special attention.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/Roles.spec.ts | Mechanically replaces 17 inline loader-visibility checks with the centralized waitForAllLoadersToDisappear helper; import is present and all remaining .not.toBeVisible() calls are for non-loader elements. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Test as Roles.spec.ts (test)
    participant Helper as waitForAllLoadersToDisappear
    participant Playwright as Playwright Expect
    participant Page as Browser Page

    Test->>Helper: await waitForAllLoadersToDisappear(page)
    Helper->>Playwright: "expect(loaders).toHaveCount(0, { timeout: 30000 })"
    Playwright->>Page: "poll [data-testid="loader"] count"
    Page-->>Playwright: "count = 0 (all loaders gone from DOM)"
    Playwright-->>Helper: assertion passed
    Helper-->>Test: resolved
    Test->>Test: continue with next assertion
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Test as Roles.spec.ts (test)
    participant Helper as waitForAllLoadersToDisappear
    participant Playwright as Playwright Expect
    participant Page as Browser Page

    Test->>Helper: await waitForAllLoadersToDisappear(page)
    Helper->>Playwright: "expect(loaders).toHaveCount(0, { timeout: 30000 })"
    Playwright->>Page: "poll [data-testid="loader"] count"
    Page-->>Playwright: "count = 0 (all loaders gone from DOM)"
    Playwright-->>Helper: assertion passed
    Helper-->>Test: resolved
    Test->>Test: continue with next assertion
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["Fix the flaky Roles.spec.ts test"](https://github.com/open-metadata/openmetadata/commit/97379a875b62964cd9bc2fc6ced11aa3076dc403) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39534073)</sub>

<!-- /greptile_comment -->