### PR TITLE
feat(looker): add LOOKER_UI_BASE env var for View-in-Looker source URLs

### DIFF
--- a/ingestion/src/metadata/ingestion/source/dashboard/looker/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/dashboard/looker/metadata.py
@@ -219,6 +219,22 @@ class LookerSource(DashboardServiceSource):
 
         self._added_lineage: Optional[Dict] = {}  # noqa: UP006, UP045
 
+    @property
+    def _ui_base(self) -> str:
+        """
+        Base URL for human-facing "View in Looker" links.
+
+        ``hostPort`` configures the Looker connection and may be an API
+        endpoint rather than the browser UI host. Reusing it for ``sourceUrl``
+        then produces links that point at the API instead of the Looker UI.
+        Set the ``LOOKER_UI_BASE`` environment variable to the UI base URL to
+        build those links from it; falls back to ``hostPort`` when unset, so
+        behavior is unchanged.
+        """
+        return clean_uri(
+            os.environ.get("LOOKER_UI_BASE") or str(self.service_connection.hostPort)
+        )
+
     @classmethod
     def create(
         cls,
@@ -622,7 +638,7 @@ class LookerSource(DashboardServiceSource):
                     # In Looker, you need to create Explores and Views within a Project
                     project=model.project_name,
                     sourceUrl=SourceUrl(
-                        f"{clean_uri(self.service_connection.hostPort)}/explore/{model.model_name}/{model.name}"
+                        f"{self._ui_base}/explore/{model.model_name}/{model.name}"
                     ),
                 )
                 yield Either(right=explore_datamodel)
@@ -1248,7 +1264,7 @@ class LookerSource(DashboardServiceSource):
             # Dashboards are created from the UI directly. They are not linked to a project
             # like LookML assets, but rather just organised in folders.
             project=self.get_project_name(dashboard_details),
-            sourceUrl=SourceUrl(f"{clean_uri(self.service_connection.hostPort)}/dashboards/{dashboard_details.id}"),
+            sourceUrl=SourceUrl(f"{self._ui_base}/dashboards/{dashboard_details.id}"),
             service=self.context.get().dashboard_service,
             owners=self.get_owner_ref(dashboard_details=dashboard_details),
         )

--- a/ingestion/tests/unit/topology/dashboard/test_looker.py
+++ b/ingestion/tests/unit/topology/dashboard/test_looker.py
@@ -12,6 +12,7 @@
 Test looker source
 """
 
+import os
 import uuid
 from datetime import datetime, timedelta
 from unittest import TestCase
@@ -284,6 +285,44 @@ class LookerUnitTest(TestCase):
                 description="description",
                 charts=[],
                 sourceUrl="https://my-looker.com/dashboards/1",
+                service=self.looker.context.get().dashboard_service,
+                owners=None,
+            )
+
+            self.assertEqual(
+                next(self.looker.yield_dashboard(MOCK_LOOKER_DASHBOARD)).right,
+                create_dashboard_request,
+            )
+
+    def test_ui_base_defaults_to_host_port(self):
+        """
+        Without LOOKER_UI_BASE set, _ui_base falls back to hostPort so the
+        source URLs are unchanged.
+        """
+        with patch.dict(os.environ, {}, clear=True):
+            self.assertEqual(self.looker._ui_base, "https://my-looker.com")
+
+    def test_ui_base_uses_env_var(self):
+        """
+        When LOOKER_UI_BASE is set, _ui_base uses it (trailing slash trimmed)
+        instead of the API hostPort.
+        """
+        with patch.dict(os.environ, {"LOOKER_UI_BASE": "https://ui.example.com/"}):
+            self.assertEqual(self.looker._ui_base, "https://ui.example.com")
+
+    def test_yield_dashboard_uses_ui_base_env(self):
+        """
+        The dashboard sourceUrl is built from LOOKER_UI_BASE when set.
+        """
+        with patch.object(LookerSource, "get_owner_ref", return_value=None), patch.dict(
+            os.environ, {"LOOKER_UI_BASE": "https://ui.example.com"}
+        ):
+            create_dashboard_request = CreateDashboardRequest(
+                name="1",
+                displayName="title1",
+                description="description",
+                charts=[],
+                sourceUrl="https://ui.example.com/dashboards/1",
                 service=self.looker.context.get().dashboard_service,
                 owners=None,
             )


### PR DESCRIPTION
## Describe your changes

`hostPort` on the Looker connection configures how the connector talks to Looker and **may be an API endpoint** rather than the browser UI host. The connector also reuses `hostPort` to build the human-facing `sourceUrl`s (the "View in Looker" links). When `hostPort` is an API URL, those links point at the API instead of the Looker UI, so they don't open as expected in a browser.

This adds an optional `LOOKER_UI_BASE` environment variable:

- New `_ui_base` helper: returns `LOOKER_UI_BASE` when set, otherwise falls back to `hostPort` (existing setups unchanged).
- The dashboard and explore `sourceUrl`s are built from `_ui_base`.

No schema change — it's an env var read by the ingestion process, opt-in.

## Type of change

- [x] Bug fix / improvement (non-breaking)

## How was this patch tested?

Added unit tests in `test_looker.py`:
- `_ui_base` falls back to `hostPort` when the env var is unset.
- `_ui_base` uses `LOOKER_UI_BASE` when set (trailing slash trimmed).
- the dashboard `sourceUrl` is built from `LOOKER_UI_BASE`.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/open-metadata/OpenMetadata/blob/main/CONTRIBUTING.md) document.
- [x] My PR includes tests for the changes.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR introduces `LOOKER_UI_BASE`, an opt-in environment variable that lets users point Looker `sourceUrl` links at the UI host when `hostPort` is configured to an API endpoint. A new `_ui_base` property encapsulates the fallback logic and is applied to the explore and dashboard `sourceUrl` constructions.

- The `_ui_base` property reads `LOOKER_UI_BASE` from the environment, strips trailing slashes via `clean_uri`, and falls back to `hostPort` — keeping existing setups unchanged.
- The fix is applied to the explore (`/explore/...`) and dashboard (`/dashboards/...`) `sourceUrl` sites, but **three other sites** (two LookML-view file links at lines 543 and 768, and a chart merge-result link at line 1626) still call `clean_uri(self.service_connection.hostPort)` directly and will remain broken when `LOOKER_UI_BASE` is set.
</details>


<details open><summary><h3>Confidence Score: 3/5</h3></summary>

The core `_ui_base` logic is sound and backward-compatible, but the fix is only partially applied — three URL construction sites in the same file are unchanged.

When `LOOKER_UI_BASE` is configured, dashboard and explore links will resolve to the UI host, but LookML view file links and chart merge-result links will still use the API `hostPort`, producing inconsistently broken navigation for users who set the variable precisely to fix this class of problem.

`ingestion/src/metadata/ingestion/source/dashboard/looker/metadata.py` lines 543, 768, and 1626 still use `hostPort` for UI links and need the same `_ui_base` substitution.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| ingestion/src/metadata/ingestion/source/dashboard/looker/metadata.py | Adds `_ui_base` property for LOOKER_UI_BASE env var support and applies it to explore and dashboard sourceUrls, but three remaining `sourceUrl` constructions (LookML view files and chart merge results) still use `hostPort` directly. |
| ingestion/tests/unit/topology/dashboard/test_looker.py | Adds three unit tests covering the `_ui_base` fallback, the env-var override with trailing-slash trimming, and the dashboard sourceUrl integration. Tests are well-structured and use `patch.dict` correctly. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Build sourceUrl] --> B{LOOKER_UI_BASE set?}
    B -- Yes --> C[Use LOOKER_UI_BASE\nwith trailing slash trimmed]
    B -- No --> D[Use hostPort\nfallback]
    C --> E[_ui_base]
    D --> E
    E --> F[explore sourceUrl\n/explore/model/name]
    E --> G[dashboard sourceUrl\n/dashboards/id]
    H[hostPort directly] --> I[view sourceUrl\n/projects/p/files/f]
    H --> J[view sourceUrl\n/projects/p/files/f]
    H --> K[chart merge sourceUrl\n/merge?mid=...]
    style H fill:#ffcccc
    style I fill:#ffcccc
    style J fill:#ffcccc
    style K fill:#ffcccc
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Build sourceUrl] --> B{LOOKER_UI_BASE set?}
    B -- Yes --> C[Use LOOKER_UI_BASE\nwith trailing slash trimmed]
    B -- No --> D[Use hostPort\nfallback]
    C --> E[_ui_base]
    D --> E
    E --> F[explore sourceUrl\n/explore/model/name]
    E --> G[dashboard sourceUrl\n/dashboards/id]
    H[hostPort directly] --> I[view sourceUrl\n/projects/p/files/f]
    H --> J[view sourceUrl\n/projects/p/files/f]
    H --> K[chart merge sourceUrl\n/merge?mid=...]
    style H fill:#ffcccc
    style I fill:#ffcccc
    style J fill:#ffcccc
    style K fill:#ffcccc
```

</a>
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `ingestion/src/metadata/ingestion/source/dashboard/looker/metadata.py`, line 543 ([link](https://github.com/open-metadata/openmetadata/blob/64411440c9a4bccc41d69faca41ae7c33f36138e/ingestion/src/metadata/ingestion/source/dashboard/looker/metadata.py#L543)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Incomplete migration to `_ui_base`** — three other source URL constructions still use `clean_uri(self.service_connection.hostPort)` directly (lines 543, 768, and 1626). When a user sets `LOOKER_UI_BASE`, the dashboard and explore links will resolve correctly, but LookML view links (`/projects/{project}/files/{view.source_file}`) and chart merge-result links (`/merge?mid=...`) will still point at the API host. The fix should apply `self._ui_base` at all five URL build sites to keep the behaviour consistent.

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["feat(looker): add LOOKER\_UI\_BASE env var..."](https://github.com/open-metadata/openmetadata/commit/64411440c9a4bccc41d69faca41ae7c33f36138e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39569713)</sub>

<!-- /greptile_comment -->