### PR TITLE
fix(data-quality): add search to column selection dropdowns in test case form (#28323)

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/apps/bundles/searchIndex/OpenSearchBulkSink.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/apps/bundles/searchIndex/OpenSearchBulkSink.java
@@ -814,8 +814,12 @@ public class OpenSearchBulkSink implements BulkSink {
         return json;
       }
 
+      int expectedDimension =
+          vectorService.getEmbeddingClient() != null
+              ? vectorService.getEmbeddingClient().getDimension()
+              : -1;
       JsonNode cached = existingEmbeddingsById.get(entity.getId().toString());
-      if (canReuseCachedEmbedding(cached)) {
+      if (canReuseCachedEmbedding(cached, expectedDimension)) {
         // Splices chunkIndex/chunkCount/parentId along with embedding — safe because the
         // service-layer pre-filter only admits entries whose state matches (same fingerprint or
         // same updatedAt), and fingerprint covers the body text that determines chunk count.
@@ -844,18 +848,31 @@ public class OpenSearchBulkSink implements BulkSink {
   /**
    * The cached payload from {@code fetchExistingEmbeddings} is pre-filtered by the service layer
    * to entries whose state matches. As defense-in-depth at the splice site we also require the
-   * cached doc to (a) be an object, (b) have a non-empty {@code embedding} array, and (c) have a
-   * textual non-blank {@code fingerprint}. Tree-model access is type-tolerant — a missing or
-   * unexpectedly-typed field returns a safe default rather than throwing — and the fingerprint
-   * check ensures we never splice a vector into the new index without also carrying its
-   * fingerprint, which would silently break future reuse for that entity.
+   * cached doc to (a) be an object, (b) have a non-empty {@code embedding} array, (c) have an
+   * {@code embedding} whose length matches {@code expectedDimension} — the current embedding
+   * client's dimension — and (d) have a textual non-blank {@code fingerprint}.
+   *
+   * <p>The dimension check is essential: the reuse pre-filter keys only on entity content
+   * (fingerprint / {@code updatedAt}), which does not change when the embedding model or dimension
+   * changes. Without this guard, a recreate that switches model/dimension would splice an
+   * old-dimension vector into a staged index built for the new dimension, and the document would be
+   * rejected by the knn field — silently leaving the entity unembedded. When {@code
+   * expectedDimension} is non-positive (no active client) the dimension check is skipped.
+   *
+   * <p>Tree-model access is type-tolerant — a missing or unexpectedly-typed field returns a safe
+   * default rather than throwing — and the fingerprint check ensures we never splice a vector into
+   * the new index without also carrying its fingerprint, which would silently break future reuse
+   * for that entity.
    */
-  private static boolean canReuseCachedEmbedding(JsonNode cached) {
+  private static boolean canReuseCachedEmbedding(JsonNode cached, int expectedDimension) {
     if (cached == null || !cached.isObject()) {
       return false;
     }
     JsonNode embedding = cached.path("embedding");
     if (!embedding.isArray() || embedding.isEmpty()) {
+      return false;
+    }
+    if (expectedDimension > 0 && embedding.size() != expectedDimension) {
       return false;
     }
     JsonNode fingerprint = cached.path("fingerprint");

--- a/openmetadata-service/src/test/java/org/openmetadata/service/apps/bundles/searchIndex/ElasticSearchBulkSinkBehaviorTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/apps/bundles/searchIndex/ElasticSearchBulkSinkBehaviorTest.java
@@ -40,6 +40,7 @@ import org.openmetadata.service.search.SearchRepository;
 import org.openmetadata.service.search.elasticsearch.ElasticSearchClient;
 import org.openmetadata.service.search.indexes.DocBuildContext;
 import org.openmetadata.service.search.indexes.SearchIndex;
+import org.openmetadata.service.search.vector.OpenSearchVectorService;
 
 class ElasticSearchBulkSinkBehaviorTest {
 
@@ -366,6 +367,46 @@ class ElasticSearchBulkSinkBehaviorTest {
           Collections.emptyMap());
 
       assertSame(DocBuildContext.empty(), ContextCapturingIndex.observedContext);
+    }
+  }
+
+  @Test
+  void addEntityNeverTouchesVectorServiceBecauseElasticsearchHasNoEmbeddingPath() throws Exception {
+    // Vector embedding is OpenSearch-only (SearchRepository: "Vector embedding is only supported
+    // with OpenSearch. Elasticsearch support is planned."). The ES sink therefore has no
+    // embedding-reuse path and needs no dimension guard. This test locks that invariant in: if ES
+    // vector support is ever added, the sink will start consulting OpenSearchVectorService and this
+    // test will fail — forcing the author to also add the embedding-dimension reuse guard that
+    // OpenSearchBulkSink#canReuseCachedEmbedding applies.
+    EntityInterface entity = mock(EntityInterface.class);
+    StageStatsTracker tracker = mock(StageStatsTracker.class);
+    UUID entityId = UUID.randomUUID();
+    when(entity.getId()).thenReturn(entityId);
+
+    try (MockedConstruction<ElasticSearchBulkSink.CustomBulkProcessor> ignored =
+            mockConstruction(ElasticSearchBulkSink.CustomBulkProcessor.class);
+        MockedStatic<Entity> entityMock = mockStatic(Entity.class);
+        MockedStatic<OpenSearchVectorService> vectorServiceMock =
+            mockStatic(OpenSearchVectorService.class)) {
+      entityMock.when(Entity::getSearchRepository).thenReturn(searchRepository);
+      entityMock.when(() -> Entity.getEntityTypeFromObject(entity)).thenReturn(ENTITY_TYPE);
+      entityMock
+          .when(() -> Entity.buildSearchIndex(ENTITY_TYPE, entity))
+          .thenReturn(new StubSearchIndex(Map.of("field", "value")));
+
+      ElasticSearchBulkSink sink = new ElasticSearchBulkSink(searchRepository, 10, 2, 1000L);
+      invokePrivate(
+          sink,
+          "addEntity",
+          new Class<?>[] {EntityInterface.class, String.class, StageStatsTracker.class, Map.class},
+          entity,
+          "table_index",
+          tracker,
+          Collections.emptyMap());
+
+      vectorServiceMock.verify(OpenSearchVectorService::getInstance, never());
+      verify(tracker).recordProcess(StatsResult.SUCCESS);
+      assertEquals(1, sink.getProcessStats().getSuccessRecords());
     }
   }
 

--- a/openmetadata-service/src/test/java/org/openmetadata/service/apps/bundles/searchIndex/OpenSearchBulkSinkBehaviorTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/apps/bundles/searchIndex/OpenSearchBulkSinkBehaviorTest.java
@@ -45,6 +45,7 @@ import org.openmetadata.service.search.indexes.DocBuildContext;
 import org.openmetadata.service.search.indexes.SearchIndex;
 import org.openmetadata.service.search.opensearch.OpenSearchClient;
 import org.openmetadata.service.search.vector.OpenSearchVectorService;
+import org.openmetadata.service.search.vector.client.EmbeddingClient;
 
 class OpenSearchBulkSinkBehaviorTest {
 
@@ -611,6 +612,62 @@ class OpenSearchBulkSinkBehaviorTest {
       verify(vectorService).generateEmbeddingFields(entity);
       verify(tracker).recordVector(StatsResult.SUCCESS);
       assertEquals("fp-new", mapper.readTree(result).get("fingerprint").asText());
+    }
+  }
+
+  @Test
+  void enrichWithEmbeddingRecomputesWhenCachedDimensionMismatchesClient() throws Exception {
+    // Reuse is keyed only on entity content (fingerprint / updatedAt), which does NOT change when
+    // the embedding model/dimension changes. A cached vector whose length no longer matches the
+    // active client's dimension must be regenerated — otherwise an old-dimension vector would be
+    // spliced into a staged index built for the new dimension and silently rejected by the knn
+    // field. This is the recreate-after-model-change dimension mismatch.
+    EntityInterface entity = mock(EntityInterface.class);
+    UUID entityId = UUID.randomUUID();
+    when(entity.getId()).thenReturn(entityId);
+
+    StageStatsTracker tracker = mock(StageStatsTracker.class);
+    OpenSearchVectorService vectorService = mock(OpenSearchVectorService.class);
+    EmbeddingClient embeddingClient = mock(EmbeddingClient.class);
+    when(embeddingClient.getDimension()).thenReturn(4);
+    when(vectorService.getEmbeddingClient()).thenReturn(embeddingClient);
+    when(vectorService.generateEmbeddingFields(entity))
+        .thenReturn(Map.of("fingerprint", "fp-new", "embedding", List.of(0.1, 0.2, 0.3, 0.4)));
+
+    ObjectMapper mapper = new ObjectMapper();
+    // Cached embedding has 3 dims; the active client now reports 4 -> must NOT be reused.
+    JsonNode staleDimensionCached =
+        mapper.readTree(
+            "{\"fingerprint\":\"fp-unchanged\",\"embedding\":[0.1,0.2,0.3],\"parentId\":\""
+                + entityId
+                + "\"}");
+    Map<String, JsonNode> existingEmbeddingsById =
+        Map.of(entityId.toString(), staleDimensionCached);
+
+    try (MockedConstruction<OpenSearchBulkSink.CustomBulkProcessor> processorConstruction =
+            mockConstruction(OpenSearchBulkSink.CustomBulkProcessor.class);
+        MockedStatic<OpenSearchVectorService> vectorServiceMock =
+            mockStatic(OpenSearchVectorService.class)) {
+      vectorServiceMock.when(OpenSearchVectorService::getInstance).thenReturn(vectorService);
+
+      OpenSearchBulkSink sink = new OpenSearchBulkSink(searchRepository, 10, 2, 1000L);
+      Method enrich =
+          OpenSearchBulkSink.class.getDeclaredMethod(
+              "enrichWithEmbedding",
+              EntityInterface.class,
+              String.class,
+              Map.class,
+              StageStatsTracker.class);
+      enrich.setAccessible(true);
+
+      String result =
+          (String) enrich.invoke(sink, entity, "{\"name\":\"z\"}", existingEmbeddingsById, tracker);
+
+      verify(vectorService).generateEmbeddingFields(entity);
+      verify(tracker).recordVector(StatsResult.SUCCESS);
+      JsonNode resultNode = mapper.readTree(result);
+      assertEquals("fp-new", resultNode.get("fingerprint").asText());
+      assertEquals(4, resultNode.get("embedding").size());
     }
   }
 


### PR DESCRIPTION
Add `showSearch` to the two column `Select` dropdowns in `ParameterForm`
that previously had no search capability:
- Partition column select (tableRowInsertedCountToBeBetween / columnName)
- Generic column select (data.name === 'column')

Fixes #28303

----
## Summary by Gitar

- **Data quality improvements:**
  - Enabled search in column selection dropdowns within the `ParameterForm` for `Partition` and generic column fields.
  - Fixed data quality data product filter search issues in Playwright tests.
  - Defined data observability tab for data product customization.
- **Feature enhancements:**
  - Implemented logic to regenerate embeddings on dimension change instead of reusing stale vectors.
  - Added support for incremental metadata extraction in Unified Catalog.
- **Bug fixes:**
  - Resolved Kinesis poll inactivity timer reset issues per shard.
  - Fixed link modal usability within focus-trapping drawers.
  - Fixed PNG lineage export download issues and corrected loading spinner behavior.
- **Security updates:**
  - Upgraded `jackson-databind` to version `2.18.8` to address CVE-2026-54512, CVE-2026-54513, and CVE-2026-54514.
- **Test and UI improvements:**
  - Added comprehensive Playwright end-to-end tests, including `My Data` asset card assertions by `displayName` and improved Fivetran integration coverage.


<sub>This will update automatically on new commits.</sub>