### PR TITLE
Fixes #29439: Table schemaDefinition silently dropped on PUT

### DIFF
--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/TableResourceIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/TableResourceIT.java
@@ -1198,7 +1198,6 @@ public class TableResourceIT extends BaseEntityIT<Table, CreateTable> {
   // TODO: Migrate put_tableJoinsInvalidColumnName_4xx - Requires SDK table joins validation
   // TODO: Migrate put_tableSampleData_200 - Requires SDK sample data support
   // TODO: Migrate put_tableInvalidSampleData_4xx - Requires SDK sample data validation
-  // TODO: Migrate put_schemaDefinition_200 - Requires SDK schema definition support
   // TODO: Migrate put_profileConfig_200 - Requires SDK profiler config support
   // TODO: Migrate put_tableProfile_200 - Requires SDK table profile support
   // TODO: Migrate create_profilerWrongTimestamp - Requires SDK profile timestamp validation
@@ -2009,7 +2008,6 @@ public class TableResourceIT extends BaseEntityIT<Table, CreateTable> {
   void put_schemaDefinition_200(TestNamespace ns) {
     OpenMetadataClient client = SdkClients.adminClient();
 
-    // Create a view table with schema definition
     String query =
         """
         sales_vw
@@ -2021,16 +2019,30 @@ public class TableResourceIT extends BaseEntityIT<Table, CreateTable> {
         """;
 
     CreateTable createRequest = createRequest(ns.prefix("view_table"), ns);
-    createRequest.setTableType(org.openmetadata.schema.type.TableType.View);
+    createRequest.setTableType(TableType.View);
     createRequest.setSchemaDefinition(query);
 
     Table table = createEntity(createRequest);
     assertNotNull(table);
-    assertEquals(org.openmetadata.schema.type.TableType.View, table.getTableType());
+    assertEquals(TableType.View, table.getTableType());
 
-    // Fetch with schemaDefinition field
+    // Verify schemaDefinition persisted on create
     Table fetched = client.tables().get(table.getId().toString(), "schemaDefinition");
     assertEquals(query, fetched.getSchemaDefinition());
+
+    // Verify schemaDefinition is updated via PUT
+    String updatedQuery =
+        """
+        sales_vw
+        create view sales_vw as
+        select * from public.sales;
+        """;
+    createRequest.setSchemaDefinition(updatedQuery);
+    createEntity(createRequest);
+
+    Table fetchedAfterUpdate =
+        client.tables().get(table.getId().toString(), "schemaDefinition");
+    assertEquals(updatedQuery, fetchedAfterUpdate.getSchemaDefinition());
   }
 
   // ===================================================================

--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/TableResourceIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/TableResourceIT.java
@@ -2040,8 +2040,7 @@ public class TableResourceIT extends BaseEntityIT<Table, CreateTable> {
     createRequest.setSchemaDefinition(updatedQuery);
     createEntity(createRequest);
 
-    Table fetchedAfterUpdate =
-        client.tables().get(table.getId().toString(), "schemaDefinition");
+    Table fetchedAfterUpdate = client.tables().get(table.getId().toString(), "schemaDefinition");
     assertEquals(updatedQuery, fetchedAfterUpdate.getSchemaDefinition());
   }
 

--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/TableResourceIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/TableResourceIT.java
@@ -2038,7 +2038,7 @@ public class TableResourceIT extends BaseEntityIT<Table, CreateTable> {
         select * from public.sales;
         """;
     createRequest.setSchemaDefinition(updatedQuery);
-    createEntity(createRequest);
+    client.tables().createOrUpdate(createRequest);
 
     Table fetchedAfterUpdate = client.tables().get(table.getId().toString(), "schemaDefinition");
     assertEquals(updatedQuery, fetchedAfterUpdate.getSchemaDefinition());

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/TableRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/TableRepository.java
@@ -2335,6 +2335,9 @@ public class TableRepository extends EntityRepository<Table> {
       if (updatedTable.getDataModel() == null && origTable.getDataModel() != null) {
         updatedTable.withDataModel(origTable.getDataModel());
       }
+      if (updatedTable.getSchemaDefinition() == null && origTable.getSchemaDefinition() != null) {
+        updatedTable.withSchemaDefinition(origTable.getSchemaDefinition());
+      }
 
       compareAndUpdate(
           "schemaDefinition",

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/TableRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/TableRepository.java
@@ -142,7 +142,7 @@ public class TableRepository extends EntityRepository<Table> {
   public static final String PATCH_FIELDS = "tableConstraints,tablePartition,columns";
   // Table fields that can be updated in a PUT request
   public static final String UPDATE_FIELDS =
-      "tableConstraints,tablePartition,dataModel,sourceUrl,columns";
+      "tableConstraints,tablePartition,dataModel,sourceUrl,columns,schemaDefinition";
 
   public static final String FIELD_RELATION_COLUMN_TYPE = "table.columns.column";
   public static final String FIELD_RELATION_TABLE_TYPE = "table";
@@ -2336,6 +2336,13 @@ public class TableRepository extends EntityRepository<Table> {
         updatedTable.withDataModel(origTable.getDataModel());
       }
 
+      compareAndUpdate(
+          "schemaDefinition",
+          () ->
+              recordChange(
+                  "schemaDefinition",
+                  original.getSchemaDefinition(),
+                  updated.getSchemaDefinition()));
       compareAndUpdate(
           "columns",
           () -> {


### PR DESCRIPTION
### Describe your changes:

Fixes #29439

`schemaDefinition` was absent from `UPDATE_FIELDS` in `TableRepository`, so every PUT request silently dropped the field. It was correctly persisted on initial create (POST) but ignored on all subsequent updates.

This also caused `updateProcessedLineage` to never detect schema changes, since it reads `origTable.getSchemaDefinition()` which was always null because the field was never loaded.

Fix: add `schemaDefinition` to `UPDATE_FIELDS` and add a `compareAndUpdate` call in `entitySpecificUpdate` before the `columns` block.

#
### Type of change:
- [x] Bug fix

#
### High-level design:

N/A — small change.

#
### Tests:

#### Use cases covered
- Table created with a `schemaDefinition`, then updated via PUT with a new
  DDL string — the fetched entity reflects the updated value.

#### Unit tests
- [ ] Not applicable (behavior is covered by the integration test below).

#### Backend integration tests
- [x] Extended `put_schemaDefinition_200` in
  `openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/TableResourceIT.java`
  to cover the PUT update path. The test previously only verified
  persistence on create and had a TODO noting the update path was not covered.

#### Ingestion integration tests
- [x] Not applicable (no ingestion changes).

#### Playwright (UI) tests
- [x] Not applicable (no UI changes).

#### Manual testing performed
Not performed locally (requires a running OpenMetadata stack).

#
### UI screen recording / screenshots:

Not applicable.

#
### Checklist:
- [x] I have read the CONTRIBUTING document.
- [x] My PR title is `Fixes #29439: Table schemaDefinition silently dropped on PUT`
- [x] My PR is linked to a GitHub issue via `Fixes #29439` above.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [x] For JSON Schema changes: not applicable.
- [x] For UI changes: not applicable.
- [x] I have added tests (integration test extended) and listed them above.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes table `schemaDefinition` handling on table updates. The main changes are:

- Adds `schemaDefinition` to table PUT update fields.
- Records `schemaDefinition` changes during table-specific updates.
- Extends the table integration test to cover updating the field through `createOrUpdate`.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge.

- No blocking issues found in the changed code.

</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/TableRepository.java | Adds `schemaDefinition` to table PUT handling and change tracking. |
| openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/TableResourceIT.java | Adds integration coverage for updating a table `schemaDefinition` through the SDK update path. |

</details>

<sub>Reviews (4): Last reviewed commit: ["Fix PUT test: use createOrUpdate instead..."](https://github.com/open-metadata/openmetadata/commit/254de36119a48f70d7d9619713f63c013797efcc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39623939)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Context used - CLAUDE.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=52f0d9d9-cad1-4e7d-b070-de181a0aa5e7))
- Context used - openmetadata-ui-core-components/CLAUDE.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=41754627-b2bf-474b-8082-f37ef1a07013))
- Context used - AGENTS.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=ef262f5f-911f-44f3-8d2d-e9cb1579c8c8))
</details>

<!-- /greptile_comment -->