### PR TITLE
FIXES #29431: remove Trino stats for Athena table computer

### DIFF
--- a/ingestion/src/metadata/profiler/orm/functions/table_metric_computer.py
+++ b/ingestion/src/metadata/profiler/orm/functions/table_metric_computer.py
@@ -1177,7 +1177,6 @@ table_metric_computer_factory.register(Dialects.Exasol, ExasolTableMetricCompute
 table_metric_computer_factory.register(Dialects.Teradata, TeradataTableMetricComputer)
 table_metric_computer_factory.register(Dialects.Trino, TrinoTableMetricComputer)
 table_metric_computer_factory.register(Dialects.Presto, TrinoTableMetricComputer)
-table_metric_computer_factory.register(Dialects.Athena, TrinoTableMetricComputer)
 table_metric_computer_factory.register(Dialects.Hive, HiveTableMetricComputer)
 table_metric_computer_factory.register(Dialects.Impala, ImpalaTableMetricComputer)
 table_metric_computer_factory.register(Dialects.Databricks, DatabricksTableMetricComputer)


### PR DESCRIPTION
### Describe your changes:

Fixes #29431

I removed the `Dialects.Athena` registration from `TrinoTableMetricComputer` in
`table_metric_computer.py` because Athena does not support the `SHOW STATS FOR`
statement that this computer relies on.

`TrinoTableMetricComputer.compute()` runs `SHOW STATS FOR "<schema>"."<table>"`
to read the table-level row count. That statement is valid in self-hosted
Trino/Presto, but Athena does not include
`SHOW STATS` in its supported `SHOW` statements. On any table where stats are
not present, Athena rejects the query at parse time with:

```
botocore.errorfactory.InvalidRequestException: An error occurred
(InvalidRequestException) when calling the StartQueryExecution operation:
line 2:6: no viable alternative at input 'SHOW STATS'
```

#
### Type of change:
- [x] Bug fix

#
### High-level design:

N/A — small change (single-line deregistration). The `TableMetricComputerFactory`
already falls back to `BaseTableMetricComputer` (`COUNT(*)`) for any dialect that
is not explicitly registered, so removing the Athena mapping is sufficient.
Trino and Presto remain on the `SHOW STATS` path, where the statement is
supported.

why not an Athena-native metric source?
Athena does expose row counts without a full scan in a few places, but none is a
reliable general replacement for `COUNT(*)`

#
### Tests:

#### Use cases covered
- Profiler run for an Athena table with no precomputed statistics (ANALYZE not
  run) completes successfully and reports `rowCount` via `COUNT(*)`, instead of
  failing with `InvalidRequestException` / `RuntimeError`.
- Trino and Presto profiling continue to use `SHOW STATS FOR` (unchanged).

#### Unit tests
- [x] Verify the factory returns `BaseTableMetricComputer` for `Dialects.Athena`
  (i.e. Athena is no longer mapped to `TrinoTableMetricComputer`).

#### Backend integration tests
- [x] Not applicable (no backend API changes).

#### Ingestion integration tests
- [x] Not applicable for this fix (no behavioral change to Trino/Presto).

#### Playwright (UI) tests
- [x] Not applicable (no UI changes).

#### Manual testing performed
1. Ran the profiler against an Athena table that had never been `ANALYZE`d.
2. Confirmed the run no longer raises `InvalidRequestException`/`RuntimeError`
   and that `rowCount`/`columnCount` are populated via the `COUNT(*)` path.

#
### UI screen recording / screenshots:

Not applicable.

#
### Checklist:
- [x] I have read the **CONTRIBUTING** document.
- [x] My PR title is `Fixes <issue-number>: <short explanation>`
- [x] My PR is linked to a GitHub issue via `Fixes #29431` above.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.
- [ ] For UI changes: I attached a screen recording and/or screenshots above.
- [ ] I have added tests (unit / integration / Playwright as applicable) and listed them above.
- [ ] I have added a test that covers the exact scenario we are fixing.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR removes the `Dialects.Athena` entry from `TrinoTableMetricComputer`'s factory registration, because Athena does not support the `SHOW STATS FOR` statement that computer relies on to retrieve row counts.

- The single-line deletion causes `TableMetricComputerFactory.construct()` to fall back to `BaseTableMetricComputer` (a plain `COUNT(*)` query) for Athena, which is the correct and broadly compatible behavior.
- Trino and Presto remain on the `SHOW STATS FOR` path; no other dialects are affected.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — a one-line removal that correctly routes Athena through the existing fallback path.

The change removes a single factory registration, and the factory already has a well-tested fallback (BaseTableMetricComputer) for unregistered dialects. Trino and Presto are unaffected; Athena moves to COUNT(*), which is compatible. No new logic is introduced and the existing error-handling path remains intact.

No files require special attention.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| ingestion/src/metadata/profiler/orm/functions/table_metric_computer.py | Removes the Athena dialect registration from TrinoTableMetricComputer; factory falls back to BaseTableMetricComputer (COUNT(*)) for Athena, fixing the SHOW STATS parse error. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: remove Trino stats for Athena table..."](https://github.com/open-metadata/openmetadata/commit/c0238603bdd101ee480fdc803147cde4f210122b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39668533)</sub>

<!-- /greptile_comment -->