### PR TITLE
fix(e2e): scope admin domain-isolation assertions by searching first

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DomainIsolation/DomainDropdownIsolation.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DomainIsolation/DomainDropdownIsolation.spec.ts
@@ -16,6 +16,7 @@ import { Domain } from '../../../support/domain/Domain';
 import { UserClass } from '../../../support/user/UserClass';
 import { performAdminLogin } from '../../../utils/admin';
 import { redirectToHomePage } from '../../../utils/common';
+import { searchDomainInDropdownTree } from '../../../utils/domainIsolationUtils';
 
 // Issue #24180 — a user holding the seeded DomainOnlyAccessRole must only see their own
 // domains in the navbar domain dropdown; admins see every domain plus the "All Domains" option.
@@ -151,9 +152,13 @@ test('Admin sees every domain and the All Domains option', async ({
   await openDomainDropdown(adminPage);
 
   await expect(adminPage.getByTestId('all-domains-selector')).toBeVisible();
+
+  await searchDomainInDropdownTree(adminPage, ownedDomainA);
   await expect(
     adminPage.getByTestId(`tag-${ownedDomainA.responseData.fullyQualifiedName}`)
   ).toBeVisible();
+
+  await searchDomainInDropdownTree(adminPage, foreignDomain);
   await expect(
     adminPage.getByTestId(
       `tag-${foreignDomain.responseData.fullyQualifiedName}`

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DomainIsolation/DomainListingIsolation.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DomainIsolation/DomainListingIsolation.spec.ts
@@ -19,6 +19,7 @@ import { redirectToHomePage } from '../../../utils/common';
 import {
   assignDomainOnlyAccess,
   safeDelete,
+  searchDomainInListing,
 } from '../../../utils/domainIsolationUtils';
 import { waitForAllLoadersToDisappear } from '../../../utils/entity';
 import { enableDisableSearchRBAC } from '../../../utils/searchRBAC';
@@ -142,7 +143,10 @@ test.describe('Domain isolation - domain listing page @domain-isolation', () => 
   }) => {
     await openDomainListing(adminPage);
 
+    await searchDomainInListing(adminPage, tenantA);
     await expect(adminPage.getByTestId(tenantA.data.name)).toBeVisible();
+
+    await searchDomainInListing(adminPage, tenantB);
     await expect(adminPage.getByTestId(tenantB.data.name)).toBeVisible();
   });
 });

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/domainIsolationUtils.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/domainIsolationUtils.ts
@@ -10,7 +10,7 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-import { APIRequestContext } from '@playwright/test';
+import { APIRequestContext, Page } from '@playwright/test';
 import { Domain } from '../support/domain/Domain';
 import { UserClass } from '../support/user/UserClass';
 
@@ -85,4 +85,41 @@ export const safeDelete = async (deleteFn: () => Promise<unknown>) => {
   } catch (error) {
     // Best-effort teardown: one failing delete should not block the rest.
   }
+};
+
+const waitForDomainSearch = (page: Page, domain: Domain) =>
+  page.waitForResponse(
+    (response) =>
+      response.url().includes('/api/v1/search/query') &&
+      response.url().includes(encodeURIComponent(domain.data.name))
+  );
+
+// The admin-facing domain views (navbar dropdown tree and the domains listing page) are
+// server-side paginated over every domain, so a freshly created domain can land off the
+// first page in a busy environment. Searching by name scopes the view to the target
+// domain before asserting, keeping the admin isolation specs deterministic.
+export const searchDomainInDropdownTree = async (
+  page: Page,
+  domain: Domain
+) => {
+  const searchResponse = waitForDomainSearch(page, domain);
+  await page
+    .getByTestId('domain-selectable-tree')
+    .getByTestId('searchbar')
+    .fill(domain.data.name);
+  await searchResponse;
+};
+
+// The domains listing search box rewrites the typed term before issuing the request, so the
+// encoded name is not a substring of the URL. Match the domain search request loosely (by
+// index) instead, mirroring the established selectDomain helper.
+export const searchDomainInListing = async (page: Page, domain: Domain) => {
+  const searchResponse = page.waitForResponse(
+    '/api/v1/search/query?q=*&index=domain*'
+  );
+  await page
+    .getByTestId('page-layout-v1')
+    .getByPlaceholder('Search')
+    .fill(domain.data.name);
+  await searchResponse;
 };


### PR DESCRIPTION
## What

The **admin** variants of the DomainIsolation Playwright specs open the unfiltered navbar domain dropdown / domains listing and assert that a freshly created domain is visible. Both views are server-side paginated over *every* domain (the listing fetches only `size=9`), so in a populated environment the target domain lands off the first page and `toBeVisible()` times out:

- `DomainDropdownIsolation › Admin sees every domain and the All Domains option`
- `DomainListingIsolation › admin sees both tenants on the domains listing page`

The RBAC-restricted user tests pass because the seeded `DomainOnlyAccessRole` filters the result set down to the 1–2 assigned domains, which always fit on the first page — only the admin variants see the full, unfiltered list.

## Fix

Add two helpers in `domainIsolationUtils.ts` that filter each view to the target domain **before** asserting, mirroring the existing `assignDomain` / `selectDomain` search patterns:

- `searchDomainInDropdownTree` — types into the navbar tree `searchbar`; matches the search request by encoded name.
- `searchDomainInListing` — types into the listing `page-layout-v1` Search box; matches the request loosely by `index=domain`, since that box rewrites the typed query term.

The RBAC-restricted user tests are intentionally **left unchanged** so their `toHaveCount(0)` isolation assertions are not masked by a search filter.

## Test plan

Ran against a local Collate stack (`DomainIsolation` project) — both previously failed/timed out, now pass:

```
✓ DomainDropdownIsolation › Admin sees every domain and the All Domains option (2.3s)
✓ DomainListingIsolation  › admin sees both tenants on the domains listing page (2.7s)
```

```bash
cd openmetadata-ui/src/main/resources/ui
PLAYWRIGHT_TEST_BASE_URL=http://localhost:8585 npx playwright test \
  DomainDropdownIsolation.spec.ts DomainListingIsolation.spec.ts --project=DomainIsolation
```

## Note (separate finding, not addressed here)

In an isolated local run, `DomainDropdownIsolation › Restricted user sees only their own domains` failed because the restricted user saw the `all-domains-selector`. That test passes in CI but appears to depend on global search-RBAC state the dropdown spec doesn't set up itself (unlike the listing spec, which calls `enableDisableSearchRBAC(true)`). Left out of this PR — happy to follow up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes two flaky admin-side Playwright specs (`DomainDropdownIsolation` and `DomainListingIsolation`) that fail in populated environments because both views are server-side paginated and newly created domains can land beyond the first page. The fix adds two search helpers that filter each view to the target domain before asserting visibility, mirroring existing patterns in the codebase.

- `searchDomainInDropdownTree` types into the navbar tree searchbar and waits for the scoped API response (matched by encoded domain name); `searchDomainInListing` types into the listing Search box and waits for any `index=domain` response (necessary because the listing box rewrites the query term before sending the request).
- Both helpers correctly register the `waitForResponse` listener before issuing the `fill` action, resolving the ordering concern raised in a previous review; RBAC-restricted user tests are intentionally left unsearched so their `toHaveCount(0)` isolation assertions are not masked.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge; the changes are confined to E2E test helpers and fix deterministic flake with no risk to production code.

Both new helpers follow the established waitForResponse-before-fill convention correctly, the glob URL pattern in searchDomainInListing is justified by the server rewriting the query term, and RBAC-restricted user assertions are deliberately left unmodified to preserve isolation semantics.

No files require special attention.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-ui/src/main/resources/ui/playwright/utils/domainIsolationUtils.ts | Adds two new exported helpers (`searchDomainInDropdownTree`, `searchDomainInListing`) plus a private `waitForDomainSearch`; `waitForResponse` is correctly registered before the triggering `fill` action in both helpers, fixing the ordering concern raised in a prior review. |
| openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DomainIsolation/DomainDropdownIsolation.spec.ts | Admin test now calls `searchDomainInDropdownTree` before each domain assertion, scoping the dropdown tree to one domain at a time; the `all-domains-selector` visibility check is correctly kept before any search is issued. |
| openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DomainIsolation/DomainListingIsolation.spec.ts | Admin test now calls `searchDomainInListing` before each domain card assertion; RBAC-restricted user tests are intentionally left unchanged so their `toHaveCount(0)` isolation assertions are not masked by a search filter. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Test as Admin Test
    participant PW as Playwright Page
    participant UI as Browser UI
    participant API as Search API

    Note over Test,API: searchDomainInDropdownTree
    Test->>PW: waitForResponse(url includes encodedName)
    Test->>UI: fill(searchbar, domain.name)
    UI->>API: "GET /api/v1/search/query?...&q=encodedName"
    API-->>PW: response
    PW-->>Test: searchResponse resolves
    Test->>UI: expect(tag-fqn).toBeVisible()

    Note over Test,API: searchDomainInListing
    Test->>PW: "waitForResponse(glob q=*&index=domain*)"
    Test->>UI: fill(Search box, domain.name)
    UI->>API: "GET /api/v1/search/query?q=rewrittenTerm&index=domain..."
    API-->>PW: response
    PW-->>Test: searchResponse resolves
    Test->>UI: "expect(testId=domain.name).toBeVisible()"
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Test as Admin Test
    participant PW as Playwright Page
    participant UI as Browser UI
    participant API as Search API

    Note over Test,API: searchDomainInDropdownTree
    Test->>PW: waitForResponse(url includes encodedName)
    Test->>UI: fill(searchbar, domain.name)
    UI->>API: "GET /api/v1/search/query?...&q=encodedName"
    API-->>PW: response
    PW-->>Test: searchResponse resolves
    Test->>UI: expect(tag-fqn).toBeVisible()

    Note over Test,API: searchDomainInListing
    Test->>PW: "waitForResponse(glob q=*&index=domain*)"
    Test->>UI: fill(Search box, domain.name)
    UI->>API: "GET /api/v1/search/query?q=rewrittenTerm&index=domain..."
    API-->>PW: response
    PW-->>Test: searchResponse resolves
    Test->>UI: "expect(testId=domain.name).toBeVisible()"
```

</a>
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(e2e): scope admin domain-isolation a..."](https://github.com/open-metadata/openmetadata/commit/ab20cef7cfaff37acc3bcb5e39131057126ca957) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39762227)</sub>

<!-- /greptile_comment -->