### PR TITLE
fix(ui): include data product filter in data quality params

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/utils/DataQuality/DataQualityUtils.test.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/DataQuality/DataQualityUtils.test.ts
@@ -51,6 +51,7 @@ jest.mock('../../constants/profiler.constant', () => ({
     tier: 'tier',
     tags: 'tags',
     service: 'serviceName',
+    dataProduct: 'dataProductFqn',
   },
   DEFAULT_SELECTED_RANGE: {
     key: 'last7Days',
@@ -101,8 +102,9 @@ describe('DataQualityUtils', () => {
         startTimestamp: 1234567890,
         entityLink: 'table1',
         testPlatforms: [TestPlatform.Dbt],
+        dataProductFqn: 'domain.dataProduct',
       } as ListTestCaseParamsBySearch;
-      const filters = ['lastRunRange', 'tableFqn'];
+      const filters = ['lastRunRange', 'tableFqn', 'dataProductFqn'];
 
       const result = buildTestCaseParams(params, filters);
 
@@ -110,6 +112,7 @@ describe('DataQualityUtils', () => {
         endTimestamp: 1234567890,
         startTimestamp: 1234567890,
         entityLink: 'table1',
+        dataProductFqn: 'domain.dataProduct',
       });
     });
   });
@@ -249,6 +252,7 @@ describe('DataQualityUtils', () => {
       tier: 'Tier.Tier1',
       serviceName: 'sample_data',
       tableFqn: 'sample_data.ecommerce_db.shopify.fact_sale',
+      dataProductFqn: 'domain.dataProduct',
     } as unknown as TestCaseSearchParams;
 
     it('should correctly process values and selectedFilter', () => {
@@ -262,6 +266,7 @@ describe('DataQualityUtils', () => {
         'tier',
         'serviceName',
         'tableFqn',
+        'dataProductFqn',
       ];
 
       const expected = {
@@ -274,6 +279,7 @@ describe('DataQualityUtils', () => {
         tags: ['PII.None'],
         tier: 'Tier.Tier1',
         serviceName: 'sample_data',
+        dataProductFqn: 'domain.dataProduct',
       };
 
       const result = getTestCaseFiltersValue(

--- a/openmetadata-ui/src/main/resources/ui/src/utils/DataQuality/DataQualityUtils.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/DataQuality/DataQualityUtils.tsx
@@ -100,6 +100,7 @@ export const buildTestCaseParams = (
     ...filterParams('tier', TEST_CASE_FILTERS.tier),
     ...filterParams('serviceName', TEST_CASE_FILTERS.service),
     ...filterParams('dataQualityDimension', TEST_CASE_FILTERS.dimension),
+    ...filterParams('dataProductFqn', TEST_CASE_FILTERS.dataProduct),
   };
 };
 


### PR DESCRIPTION
### Description
- Preserve dataProductFqn when building Data Quality test case search params.
- Add unit coverage for the Data Products filter in DataQualityUtils.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes `buildTestCaseParams` to include `dataProductFqn` when the Data Products filter is active, preventing it from being silently dropped when constructing search API calls. A matching test mock entry and two updated test cases provide direct coverage of the new mapping.

- **`DataQualityUtils.tsx`**: Adds `...filterParams('dataProductFqn', TEST_CASE_FILTERS.dataProduct)` alongside the other per-filter mappings, completing the contract between `TestCaseSearchParams` and the search API params type.
- **`DataQualityUtils.test.ts`**: Extends the `TEST_CASE_FILTERS` mock with `dataProduct: 'dataProductFqn'` and updates `buildTestCaseParams` / `getTestCaseFiltersValue` tests to assert the field is correctly propagated.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is a single-line addition to a well-understood filter mapping function with targeted test coverage.

The fix is minimal and isolated: one new filterParams call in buildTestCaseParams that follows the exact same pattern as the nine already-present mappings. The dataProductFqn field already exists in ListTestCaseParamsBySearch and TEST_CASE_FILTERS.dataProduct was already defined in the constants file, so no contract changes were needed. Tests correctly mirror the real constant mock and assert end-to-end propagation through getTestCaseFiltersValue.

No files require special attention.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-ui/src/main/resources/ui/src/utils/DataQuality/DataQualityUtils.tsx | Adds the missing `dataProductFqn` → `TEST_CASE_FILTERS.dataProduct` mapping in `buildTestCaseParams`, completing the set of supported filter params. |
| openmetadata-ui/src/main/resources/ui/src/utils/DataQuality/DataQualityUtils.test.ts | Extends the TEST_CASE_FILTERS mock and updates two test cases to cover the new dataProductFqn filter path; coverage is correct and targeted. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[TestCases.component\nfetchTestCases] --> B[getTestCaseFiltersValue\nparams, selectedFilter]
    B --> C[omit lastRunRange / tableFqn / searchValue]
    C --> D[buildTestCaseParams\napiParams, selectedFilter]
    D --> E{filters includes\nfilterKey?}
    E -- yes --> F[include param in result]
    E -- no --> G[skip param]
    F --> H[endTimestamp / startTimestamp]
    F --> I[entityLink / testPlatforms\ntestCaseType / testCaseStatus\ntags / tier / serviceName\ndataQualityDimension]
    F --> J[dataProductFqn - new in this PR]
    H & I & J --> K[API call: getListTestCaseBySearch]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[TestCases.component\nfetchTestCases] --> B[getTestCaseFiltersValue\nparams, selectedFilter]
    B --> C[omit lastRunRange / tableFqn / searchValue]
    C --> D[buildTestCaseParams\napiParams, selectedFilter]
    D --> E{filters includes\nfilterKey?}
    E -- yes --> F[include param in result]
    E -- no --> G[skip param]
    F --> H[endTimestamp / startTimestamp]
    F --> I[entityLink / testPlatforms\ntestCaseType / testCaseStatus\ntags / tier / serviceName\ndataQualityDimension]
    F --> J[dataProductFqn - new in this PR]
    H & I & J --> K[API call: getListTestCaseBySearch]
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(ui): include data product filter in ..."](https://github.com/open-metadata/openmetadata/commit/6877698cd65d36f9210aa5578ef09d3341324d02) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39766673)</sub>

<!-- /greptile_comment -->