### PR TITLE
test(glossary): fix flaky approval-after-move e2e by gating move on workflow readiness

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/Glossary/GlossaryApprovalAfterMove.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/Glossary/GlossaryApprovalAfterMove.spec.ts
@@ -47,7 +47,8 @@ const queryOpenApprovalTasks = async (
 
 // Returns the latest stage displayName of the GlossaryTermApprovalWorkflow
 // instance anchored to the given term FQN, or null if no instance is found.
-// Used purely for diagnostics when the term fails to reach its expected status.
+// Used both to gate the move on workflow readiness (waitForApprovalWorkflowReady)
+// and as diagnostics when the term fails to reach its expected status.
 const queryApprovalWorkflowStage = async (
   apiContext: APIRequestContext,
   termFqn: string
@@ -116,7 +117,7 @@ const waitForTermStatus = async (
         },
         {
           message: `term ${termId} to reach ${expectedStatus}`,
-          timeout: 240_000,
+          timeout: 120_000,
           intervals: [5_000],
         }
       )

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/Glossary/GlossaryApprovalAfterMove.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/Glossary/GlossaryApprovalAfterMove.spec.ts
@@ -45,27 +45,97 @@ const queryOpenApprovalTasks = async (
   return { count: data.length, taskId: data[0]?.id?.toString() ?? null };
 };
 
-const waitForTermStatus = async (
+// Returns the latest stage displayName of the GlossaryTermApprovalWorkflow
+// instance anchored to the given term FQN, or null if no instance is found.
+// Used purely for diagnostics when the term fails to reach its expected status.
+const queryApprovalWorkflowStage = async (
   apiContext: APIRequestContext,
-  termId: string,
-  expectedStatus: string
+  termFqn: string
+): Promise<string | null> => {
+  const entityLink = encodeURIComponent(`<#E::glossaryTerm::${termFqn}>`);
+  const startTs = Date.now() - 24 * 60 * 60 * 1000;
+  const endTs = Date.now();
+
+  const instances = await apiContext
+    .get(
+      `/api/v1/governance/workflowInstances?entityLink=${entityLink}&startTs=${startTs}&endTs=${endTs}&workflowName=GlossaryTermApprovalWorkflow`
+    )
+    .then((r) => r.json());
+
+  const instanceId = instances?.data?.[0]?.id;
+  if (!instanceId) {
+    return null;
+  }
+
+  const states = await apiContext
+    .get(
+      `/api/v1/governance/workflowInstanceStates/GlossaryTermApprovalWorkflow/${instanceId}?startTs=${startTs}&endTs=${endTs}`
+    )
+    .then((r) => r.json());
+
+  return states?.data?.[0]?.stage?.displayName ?? null;
+};
+const waitForApprovalWorkflowReady = async (
+  apiContext: APIRequestContext,
+  termFqn: string
 ) => {
   await expect
     .poll(
       async () => {
-        const res = await apiContext
-          .get(`/api/v1/glossaryTerms/${termId}?fields=entityStatus`)
-          .then((r) => r.json());
+        const [stage, { count }] = await Promise.all([
+          queryApprovalWorkflowStage(apiContext, termFqn),
+          queryOpenApprovalTasks(apiContext, termFqn),
+        ]);
 
-        return res?.entityStatus;
+        return stage !== null && count === 1;
       },
       {
-        message: `term ${termId} to reach ${expectedStatus}`,
+        message: `approval workflow for ${termFqn} to be parked at the review task before moving`,
         timeout: 120_000,
         intervals: [3_000, 5_000, 10_000],
       }
     )
-    .toBe(expectedStatus);
+    .toBe(true);
+};
+
+const waitForTermStatus = async (
+  apiContext: APIRequestContext,
+  termId: string,
+  termFqn: string,
+  expectedStatus: string
+) => {
+  try {
+    await expect
+      .poll(
+        async () => {
+          const res = await apiContext
+            .get(`/api/v1/glossaryTerms/${termId}?fields=entityStatus`)
+            .then((r) => r.json());
+
+          return res?.entityStatus;
+        },
+        {
+          message: `term ${termId} to reach ${expectedStatus}`,
+          timeout: 240_000,
+          intervals: [5_000],
+        }
+      )
+      .toBe(expectedStatus);
+  } catch (error) {
+    const [stage, { count }] = await Promise.all([
+      queryApprovalWorkflowStage(apiContext, termFqn),
+      queryOpenApprovalTasks(apiContext, termFqn),
+    ]);
+
+    throw new Error(
+      `Term ${termId} never reached "${expectedStatus}". ` +
+        `Last GlossaryTermApprovalWorkflow stage: ${stage ?? 'none found'}; ` +
+        `open approval tasks remaining at ${termFqn}: ${count}. ` +
+        `If the workflow is still at "Review" with 0 open tasks, the approval did not ` +
+        `resume after the move (backend issue), not test slowness.\n` +
+        `Original error: ${(error as Error).message}`
+    );
+  }
 };
 
 const reviewerRef = () => ({
@@ -166,6 +236,10 @@ test.describe(
         });
 
         await test.step('Move Securities Lending under Product and Service', async () => {
+          await waitForApprovalWorkflowReady(
+            adminApiContext,
+            child.responseData.fullyQualifiedName
+          );
           await moveParentUnderContainer(adminApiContext, parent, container);
         });
 
@@ -226,6 +300,7 @@ test.describe(
           await waitForTermStatus(
             adminApiContext,
             child.responseData.id,
+            newChildFqn,
             'Approved'
           );
           const { count } = await queryOpenApprovalTasks(
@@ -273,6 +348,10 @@ test.describe(
         });
 
         await test.step('Move Securities Lending under Product and Service', async () => {
+          await waitForApprovalWorkflowReady(
+            adminApiContext,
+            child.responseData.fullyQualifiedName
+          );
           await moveParentUnderContainer(adminApiContext, parent, container);
         });
 
@@ -333,6 +412,7 @@ test.describe(
           await waitForTermStatus(
             adminApiContext,
             child.responseData.id,
+            newChildFqn,
             'Rejected'
           );
           const { count } = await queryOpenApprovalTasks(


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:

Glossary term approval is driven by an async **Flowable** (`GlossaryTermApprovalWorkflow`) process instance. The approval **task** row and the Flowable **process instance** are committed on separate async paths — so the open task can appear *before* Flowable has parked the instance at its review wait-state.

The test waited only for the task, then immediately issued `moveAsync` (which renames the term's FQN). When the move landed inside that window, the term moved but the in-flight Flowable instance stayed bound to the **old FQN** — "only the term moved, the Flowable instance didn't." The later approve/reject then couldn't drive the orphaned instance, so `entityStatus` never left `In Review` and the test timed out with `Expected "Approved" / Received "In Review"`.

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### High-level design:
<!--
REQUIRED for large PRs (new features, refactors, breaking changes, or anything touching >5 files).
Skip for small bug fixes and trivial changes.

Cover:
- Architecture / approach you took and why
- Key components or files added/changed and how they interact
- Alternatives considered and why you rejected them
- Any migration, backward-compatibility, or rollout concerns
- Diagrams or links to design docs / RFCs if available
-->

N/A — small change. <!-- Or fill in the design above -->

#
### Tests:

#### Use cases covered
<!--
List the user-visible scenarios this PR exercises. Example:
- User with Admin role can create a Glossary Term with a parent term
- Ingestion run for Snowflake correctly extracts row counts for partitioned tables
-->

#### Unit tests
<!--
- [ ] I added unit tests for the new/changed logic.
- Files added/updated:
- Coverage on changed classes (run `mvn jacoco:report` for backend, `yarn test:coverage` for UI,
  `make unit_ingestion` for ingestion). Target is 90% line coverage on changed classes.
- Coverage %: <e.g., 92% on EntityRepository.java>
-->

#### Backend integration tests
<!--
- [ ] I added integration tests in `openmetadata-integration-tests/` for new/changed API endpoints.
- [ ] Not applicable (no backend API changes).
- Files added/updated:
-->

#### Ingestion integration tests
<!--
- [ ] I added/updated ingestion integration tests for connector changes.
- [ ] Not applicable (no ingestion changes).
- Files added/updated:
-->

#### Playwright (UI) tests
<!--
- [ ] I added Playwright E2E tests under `openmetadata-ui/.../ui/playwright/` for UI changes.
- [ ] Not applicable (no UI changes).
- Files added/updated:
-->

#### Manual testing performed
<!--
List the manual test steps you performed before requesting review. Example:
1. Started local stack via `./docker/run_local_docker.sh -m ui -d mysql`
2. Logged in as admin, created entity X, verified Y appears in the UI
3. Triggered ingestion for Snowflake source, confirmed lineage edges in the explore page
-->

#
### UI screen recording / screenshots:
<!--
REQUIRED for any PR that changes the UI. Drag-and-drop a short screen recording (.mov / .mp4 / .gif)
demonstrating the change end-to-end, plus before/after screenshots where relevant.
Mark "Not applicable" if there are no UI changes.
-->

Not applicable. <!-- Or attach recording/screenshots above -->

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.
- [ ] For UI changes: I attached a screen recording and/or screenshots above.
- [ ] I have added tests (unit / integration / Playwright as applicable) and listed them above.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a race-condition flakiness in the glossary approval-after-move E2E tests by inserting a `waitForApprovalWorkflowReady` guard that polls until the Flowable workflow instance is parked at its review wait-state before issuing the async move; it also wraps `waitForTermStatus` in a try/catch that emits structured diagnostics on failure.

- **New `waitForApprovalWorkflowReady` function** polls both the Flowable workflow instance stage (via `/api/v1/governance/workflowInstances`) and the open-task count, requiring both to be ready before `moveAsync` is called; this prevents the FQN move from racing ahead of an in-flight workflow.
- **Enriched `waitForTermStatus`** catches poll timeout and re-throws with a human-readable message distinguishing a \"workflow orphaned after move\" backend failure from mere test slowness.
- **`test.setTimeout` not updated** — the cumulative worst-case polling budget (~420 s) now exceeds the existing 300 s limit, so on a slow CI worker Playwright may abort the test before the new diagnostic error can be thrown.
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge with the caveat that the new polling steps push worst-case execution past the current per-test timeout, which could cause Playwright to abort the test before the new diagnostic error is surfaced.

The race-condition fix is well-reasoned and correctly gates the move on Flowable workflow readiness. The only present defect is that the cumulative polling budget (~420 s) exceeds `test.setTimeout(5 * 60 * 1000)` (300 s), meaning the intentional diagnostic throw in `waitForTermStatus` is unreachable on a slow CI worker — undermining the main observability improvement this PR introduces.

The single changed file `GlossaryApprovalAfterMove.spec.ts` needs its `test.setTimeout` raised to cover the new polling windows.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/Glossary/GlossaryApprovalAfterMove.spec.ts | Adds `waitForApprovalWorkflowReady` to gate the async move on Flowable workflow readiness, and enriches `waitForTermStatus` with diagnostic output on failure; cumulative worst-case polling (≈420 s) exceeds the 300 s `test.setTimeout`. |

</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant T as Test
    participant API as Admin API
    participant FL as Flowable Engine
    participant UI as Reviewer UI

    T->>API: create glossary + terms (child under parent)
    API-->>FL: async — start GlossaryTermApprovalWorkflow
    Note over API,FL: task row committed first,<br/>Flowable process parks asynchronously

    T->>T: verifyTaskCreated (open task visible)

    loop waitForApprovalWorkflowReady (new gate, ≤120 s)
        T->>API: GET workflowInstances (stage ≠ null?)
        T->>API: "GET tasks (count == 1?)"
        API-->>T: both ready → proceed
    end

    T->>API: "PUT /glossaryTerms/{parentId}/moveAsync"
    API-->>API: Flowable instance FQN updated atomically

    loop Wait for FQN update (≤120 s)
        T->>API: "GET glossaryTerms/{childId}?fields=fullyQualifiedName"
        API-->>T: newChildFqn ≠ oldFqn → proceed
    end

    T->>UI: reviewer clicks approve/reject (≤60 s)
    UI->>API: resolve task

    loop waitForTermStatus (≤120 s)
        T->>API: "GET glossaryTerms/{childId}?fields=entityStatus"
        API-->>T: "entityStatus == Approved/Rejected"
        alt on timeout
            T->>API: diagnostic — query workflow stage + open tasks
            T-->>T: throw enriched error
        end
    end

    T->>API: assert 0 open tasks remain
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant T as Test
    participant API as Admin API
    participant FL as Flowable Engine
    participant UI as Reviewer UI

    T->>API: create glossary + terms (child under parent)
    API-->>FL: async — start GlossaryTermApprovalWorkflow
    Note over API,FL: task row committed first,<br/>Flowable process parks asynchronously

    T->>T: verifyTaskCreated (open task visible)

    loop waitForApprovalWorkflowReady (new gate, ≤120 s)
        T->>API: GET workflowInstances (stage ≠ null?)
        T->>API: "GET tasks (count == 1?)"
        API-->>T: both ready → proceed
    end

    T->>API: "PUT /glossaryTerms/{parentId}/moveAsync"
    API-->>API: Flowable instance FQN updated atomically

    loop Wait for FQN update (≤120 s)
        T->>API: "GET glossaryTerms/{childId}?fields=fullyQualifiedName"
        API-->>T: newChildFqn ≠ oldFqn → proceed
    end

    T->>UI: reviewer clicks approve/reject (≤60 s)
    UI->>API: resolve task

    loop waitForTermStatus (≤120 s)
        T->>API: "GET glossaryTerms/{childId}?fields=entityStatus"
        API-->>T: "entityStatus == Approved/Rejected"
        alt on timeout
            T->>API: diagnostic — query workflow stage + open tasks
            T-->>T: throw enriched error
        end
    end

    T->>API: assert 0 open tasks remain
```

</a>
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/Glossary/GlossaryApprovalAfterMove.spec.ts`, line 210 ([link](https://github.com/open-metadata/openmetadata/blob/bce6159d75d9de3d653cbc22a59860e4c55e5eb5/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/Glossary/GlossaryApprovalAfterMove.spec.ts#L210)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Test timeout budget exceeded by added polling steps**

   `test.setTimeout(5 * 60 * 1000)` = 300 s, but the cumulative worst-case polling in the new code now totals well above that: `waitForApprovalWorkflowReady` (120 s) + "Wait for FQN update" (120 s) + reviewer UI step (60 s button timeout) + `waitForTermStatus` (240 s) = 540 s. When the backend is genuinely slow on CI, Playwright will kill the test with a generic runner timeout *before* `waitForTermStatus` throws its enriched diagnostic error — the very thing this PR was designed to surface. Both tests share this limit. Consider raising `test.setTimeout` to at least `10 * 60 * 1000` to keep the intentional catch-and-rethrow reachable in the worst case.
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (3): Last reviewed commit: ["Merge branch &#39;main&#39; into glossary-move-t..."](https://github.com/open-metadata/openmetadata/commit/da861a2d027d33be3e6eba3f670d4aa7995fb4a7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39776472)</sub>

<!-- /greptile_comment -->