### PR TITLE
fix(governance): redeploy workflow BPMN on upgrade so moved/renamed approvals resolve

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/migration/mysql/v1131/Migration.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/migration/mysql/v1131/Migration.java
@@ -1,5 +1,6 @@
 package org.openmetadata.service.migration.mysql.v1131;
 
+import static org.openmetadata.service.migration.utils.v1131.MigrationUtil.redeployGovernanceWorkflows;
 import static org.openmetadata.service.migration.utils.v1131.MigrationUtil.repairChildFqns;
 
 import lombok.SneakyThrows;
@@ -16,5 +17,7 @@ public class Migration extends MigrationProcessImpl {
   @SneakyThrows
   public void runDataMigration() {
     repairChildFqns(collectionDAO);
+    initializeWorkflowHandler();
+    redeployGovernanceWorkflows();
   }
 }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/migration/postgres/v1131/Migration.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/migration/postgres/v1131/Migration.java
@@ -1,5 +1,6 @@
 package org.openmetadata.service.migration.postgres.v1131;
 
+import static org.openmetadata.service.migration.utils.v1131.MigrationUtil.redeployGovernanceWorkflows;
 import static org.openmetadata.service.migration.utils.v1131.MigrationUtil.repairChildFqns;
 
 import lombok.SneakyThrows;
@@ -16,5 +17,7 @@ public class Migration extends MigrationProcessImpl {
   @SneakyThrows
   public void runDataMigration() {
     repairChildFqns(collectionDAO);
+    initializeWorkflowHandler();
+    redeployGovernanceWorkflows();
   }
 }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/migration/utils/v1131/MigrationUtil.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/migration/utils/v1131/MigrationUtil.java
@@ -112,13 +112,25 @@ public class MigrationUtil {
    * regenerated definition.
    */
   public static void redeployGovernanceWorkflows() {
-    WorkflowDefinitionRepository repository =
-        (WorkflowDefinitionRepository) Entity.getEntityRepository(Entity.WORKFLOW_DEFINITION);
-    List<WorkflowDefinition> workflows =
-        repository.listAll(EntityUtil.Fields.EMPTY_FIELDS, new ListFilter());
-    WorkflowHandler workflowHandler = WorkflowHandler.getInstance();
     int redeployed = 0;
-    for (WorkflowDefinition workflow : workflows) {
+    int total = 0;
+    try {
+      final WorkflowDefinitionRepository repository =
+          (WorkflowDefinitionRepository) Entity.getEntityRepository(Entity.WORKFLOW_DEFINITION);
+      final List<WorkflowDefinition> workflows =
+          repository.listAll(EntityUtil.Fields.EMPTY_FIELDS, new ListFilter());
+      total = workflows.size();
+      redeployed = redeployEach(WorkflowHandler.getInstance(), workflows);
+    } catch (Exception e) {
+      LOG.warn("[1.13.1] Skipping governance workflow redeploy; continuing", e);
+    }
+    LOG.info("[1.13.1] Redeployed {} of {} governance workflow definition(s)", redeployed, total);
+  }
+
+  private static int redeployEach(
+      final WorkflowHandler workflowHandler, final List<WorkflowDefinition> workflows) {
+    int redeployed = 0;
+    for (final WorkflowDefinition workflow : workflows) {
       try {
         workflowHandler.deploy(new Workflow(workflow));
         redeployed++;
@@ -129,10 +141,7 @@ public class MigrationUtil {
             e);
       }
     }
-    LOG.info(
-        "[1.13.1] Redeployed {} of {} governance workflow definition(s)",
-        redeployed,
-        workflows.size());
+    return redeployed;
   }
 
   public static List<RepairSummary> repairChildFqns(CollectionDAO collectionDAO) {

--- a/openmetadata-service/src/main/java/org/openmetadata/service/migration/utils/v1131/MigrationUtil.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/migration/utils/v1131/MigrationUtil.java
@@ -21,6 +21,7 @@ import org.openmetadata.schema.entity.data.SearchIndex;
 import org.openmetadata.schema.entity.data.Table;
 import org.openmetadata.schema.entity.data.Topic;
 import org.openmetadata.schema.entity.data.Worksheet;
+import org.openmetadata.schema.governance.workflows.WorkflowDefinition;
 import org.openmetadata.schema.type.Column;
 import org.openmetadata.schema.type.Field;
 import org.openmetadata.schema.type.MlFeature;
@@ -29,8 +30,13 @@ import org.openmetadata.schema.type.SearchIndexField;
 import org.openmetadata.schema.type.Task;
 import org.openmetadata.schema.utils.JsonUtils;
 import org.openmetadata.service.Entity;
+import org.openmetadata.service.governance.workflows.Workflow;
+import org.openmetadata.service.governance.workflows.WorkflowHandler;
 import org.openmetadata.service.jdbi3.CollectionDAO;
 import org.openmetadata.service.jdbi3.EntityDAO;
+import org.openmetadata.service.jdbi3.ListFilter;
+import org.openmetadata.service.jdbi3.WorkflowDefinitionRepository;
+import org.openmetadata.service.util.EntityUtil;
 import org.openmetadata.service.util.FullyQualifiedName;
 
 /**
@@ -90,6 +96,44 @@ public class MigrationUtil {
           feature -> null);
 
   private MigrationUtil() {}
+
+  /**
+   * Regenerate and redeploy every governance workflow's BPMN from the current code.
+   *
+   * <p>Seeded workflow definitions are deployed to Flowable only when first created
+   * ({@code initializeEntity} is create-only), so a jar upgrade that changes the generated BPMN —
+   * e.g. adding the {@code global_relatedEntityId} CallActivity InParameter that lets approval nodes
+   * resolve the entity by its immutable id after a move/rename — never reaches already-installed
+   * environments. Their Flowable process definition stays on the old BPMN, so newly started
+   * instances never receive {@code relatedEntityId}, fall back to the now-stale FQN, and throw
+   * {@code EntityNotFoundException} on resolve. Redeploying each definition here makes the deployed
+   * BPMN track the code again. In-flight instances keep their old definition version (Flowable
+   * preserves deployments that still have running instances); only newly started instances use the
+   * regenerated definition.
+   */
+  public static void redeployGovernanceWorkflows() {
+    WorkflowDefinitionRepository repository =
+        (WorkflowDefinitionRepository) Entity.getEntityRepository(Entity.WORKFLOW_DEFINITION);
+    List<WorkflowDefinition> workflows =
+        repository.listAll(EntityUtil.Fields.EMPTY_FIELDS, new ListFilter());
+    WorkflowHandler workflowHandler = WorkflowHandler.getInstance();
+    int redeployed = 0;
+    for (WorkflowDefinition workflow : workflows) {
+      try {
+        workflowHandler.deploy(new Workflow(workflow));
+        redeployed++;
+      } catch (Exception e) {
+        LOG.warn(
+            "[1.13.1] Failed to redeploy workflow definition '{}'; continuing",
+            workflow.getFullyQualifiedName(),
+            e);
+      }
+    }
+    LOG.info(
+        "[1.13.1] Redeployed {} of {} governance workflow definition(s)",
+        redeployed,
+        workflows.size());
+  }
 
   public static List<RepairSummary> repairChildFqns(CollectionDAO collectionDAO) {
     List<RepairSummary> summaries = new ArrayList<>();


### PR DESCRIPTION
Fixes #29091

## What

Adds a `v1131` (1.13.1) data migration that redeploys every governance workflow definition so the BPMN deployed in Flowable is regenerated from the current code.

## Why

Move/rename-safe approval resolution (resolving the related entity by its immutable `relatedEntityId` instead of the mutable FQN) requires a `global_relatedEntityId` CallActivity **InParameter** that is generated in Java (`EventBasedEntityTrigger`) and baked into the workflow's deployed BPMN.

Seeded workflow definitions are deployed to Flowable **only when first created** — `EntityRepository.initializeEntity` is create-only and returns early when the definition already exists, so `postCreate`/`deploy()` never runs on upgrade. Already-installed environments therefore keep the **old** BPMN with no `relatedEntityId` InParameter.

Result on an upgraded environment:
- A newly started approval instance never receives `relatedEntityId` (the old BPMN doesn't propagate it into the sub-process scope).
- `WorkflowVariableHandler.getRelatedEntity` falls back to the FQN path.
- After the term is moved/renamed, that FQN is stale, so resolve throws:

```
org.openmetadata.service.exception.EntityNotFoundException: glossaryTerm instance for <stale FQN> not found
  at WorkflowVariableHandler.getRelatedEntity(...)
  at SetEntityAttributeImpl.execute(...)
```

This is why it reproduces on release/AUT environments (upgraded, stale BPMN) but passes on a fresh local install (BPMN generated from current code on first create).

## What changed

`migration/utils/v1131/MigrationUtil.java`
- New `redeployGovernanceWorkflows()` — lists all `WorkflowDefinition`s and calls `WorkflowHandler.deploy(new Workflow(wd))` for each, regenerating and redeploying the BPMN (now with the `relatedEntityId` InParameter). Setup (repository lookup, listing, handler retrieval) and the per-definition redeploy are both guarded so any failure degrades to a warning and never aborts the upgrade.

`migration/postgres/v1131/Migration.java`, `migration/mysql/v1131/Migration.java`
- After `repairChildFqns`, call `initializeWorkflowHandler()` then `redeployGovernanceWorkflows()`.

## Coverage

- The existing `v11212` migration repairs stale FQN data and backfills `relatedEntityId` on **already-running** instances.
- This `v1131` migration covers **newly started** instances post-upgrade by making the deployed BPMN track the code.

Flowable preserves deployments that still have running instances, so in-flight instances keep their old definition version; only newly started instances pick up the regenerated definition.

## Review fixes

- Guarded the redeploy **setup** (`Entity.getEntityRepository`, `repository.listAll`, `WorkflowHandler.getInstance`) inside the same best-effort try/catch so a governance/Flowable initialization failure warns instead of aborting the v1131 migration after `repairChildFqns` already ran.
- Extracted the per-definition redeploy loop into a `redeployEach` helper and marked locals `final` to satisfy the method-size / immutability conventions.

## Testing

- `mvn spotless:apply` clean.
- Operational fix for an already-upgraded environment is the existing `POST /api/v1/governance/workflowDefinitions/{id}/redeploy` endpoint; this PR automates the same on upgrade.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Extends the existing `v1131` data migration to redeploy every governance `WorkflowDefinition` to Flowable, ensuring the BPMN generated from current Java code (including the `global_relatedEntityId` InParameter) is active for newly started approval instances on already-upgraded environments.

- `MigrationUtil.redeployGovernanceWorkflows()` lists all `WorkflowDefinition`s via the repository, calls `WorkflowHandler.deploy(new Workflow(wd))` for each, and wraps both the per-workflow loop and the outer setup in independent try-catch blocks so a failure on any single definition or on WorkflowHandler initialization does not abort the upgrade.
- Both `mysql/v1131/Migration` and `postgres/v1131/Migration` gain `initializeWorkflowHandler()` + `redeployGovernanceWorkflows()` after the existing `repairChildFqns` call, following the same ordering pattern established in `v11212`.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge; the change is narrowly scoped to a best-effort redeploy step that is fully wrapped in error handling and cannot abort the upgrade or affect running Flowable instances.

The migration follows an established pattern (v11212), the per-workflow and outer exception guards make the redeploy non-blocking, and Flowable's own semantics preserve in-flight instances on their existing definition version. The only finding is that the filter passed to listAll does not exclude soft-deleted definitions, which is unlikely to cause real harm given per-workflow exception handling.

MigrationUtil.java — the ListFilter passed to listAll() should exclude soft-deleted WorkflowDefinitions.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-service/src/main/java/org/openmetadata/service/migration/utils/v1131/MigrationUtil.java | Adds redeployGovernanceWorkflows() that lists all WorkflowDefinitions and calls WorkflowHandler.deploy() for each; per-workflow and outer exceptions are caught and logged; uses new ListFilter() without a NON_DELETED constraint, so soft-deleted definitions are included in the redeploy sweep |
| openmetadata-service/src/main/java/org/openmetadata/service/migration/mysql/v1131/Migration.java | Adds initializeWorkflowHandler() + redeployGovernanceWorkflows() calls after repairChildFqns; follows the same pattern established in v11212 |
| openmetadata-service/src/main/java/org/openmetadata/service/migration/postgres/v1131/Migration.java | Identical to the MySQL migration counterpart; correct symmetry between both database variants |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Runner as MigrationRunner
    participant Mig as v1131/Migration
    participant Util as MigrationUtil
    participant WH as WorkflowHandler
    participant Repo as WorkflowDefinitionRepository
    participant Flowable as Flowable Engine

    Runner->>Mig: runDataMigration()
    Mig->>Util: repairChildFqns(collectionDAO)
    Util-->>Mig: RepairSummary[]
    Mig->>WH: "initialize(config, isMigrationContext=true)"
    WH-->>Mig: WorkflowHandler initialized
    Mig->>Util: redeployGovernanceWorkflows()
    Util->>Repo: listAll(EMPTY_FIELDS, ListFilter)
    Repo-->>Util: "List<WorkflowDefinition>"
    loop for each WorkflowDefinition
        Util->>WH: deploy(new Workflow(wd))
        WH->>Flowable: deleteDeployment (old, no running instances)
        WH->>Flowable: deployNewBPMN (with relatedEntityId InParameter)
        Flowable-->>WH: new ProcessDefinition
        WH-->>Util: ok
    end
    Util-->>Mig: redeployed N of M definitions logged
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Runner as MigrationRunner
    participant Mig as v1131/Migration
    participant Util as MigrationUtil
    participant WH as WorkflowHandler
    participant Repo as WorkflowDefinitionRepository
    participant Flowable as Flowable Engine

    Runner->>Mig: runDataMigration()
    Mig->>Util: repairChildFqns(collectionDAO)
    Util-->>Mig: RepairSummary[]
    Mig->>WH: "initialize(config, isMigrationContext=true)"
    WH-->>Mig: WorkflowHandler initialized
    Mig->>Util: redeployGovernanceWorkflows()
    Util->>Repo: listAll(EMPTY_FIELDS, ListFilter)
    Repo-->>Util: "List<WorkflowDefinition>"
    loop for each WorkflowDefinition
        Util->>WH: deploy(new Workflow(wd))
        WH->>Flowable: deleteDeployment (old, no running instances)
        WH->>Flowable: deployNewBPMN (with relatedEntityId InParameter)
        Flowable-->>WH: new ProcessDefinition
        WH-->>Util: ok
    end
    Util-->>Mig: redeployed N of M definitions logged
```

</a>
</details>

<sub>Reviews (2): Last reviewed commit: ["address review: guard redeploy setup and..."](https://github.com/open-metadata/openmetadata/commit/9b02d7d800a99c91235377c0a099523ed3f066b8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39786958)</sub>

<!-- /greptile_comment -->