### PR TITLE
test(e2e): fix ContextCenter vote/follow color assertions for new design tokens

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/BulkImport.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/BulkImport.spec.ts
@@ -151,8 +151,8 @@ test.describe('Bulk Import Export', () => {
   });
 
   test('Database service', async ({ page }) => {
-    // 5 minutes to avoid test timeout happening some times in AUTs, since it add all the entities layer
-    test.setTimeout(500_000);
+    // 6 minutes to avoid test timeout happening some times in AUTs, since it add all the entities layer
+    test.setTimeout(600_000);
 
     let customPropertyRecord: Record<string, string> = {};
 

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/BulkImport.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/BulkImport.spec.ts
@@ -768,7 +768,7 @@ test.describe('Bulk Import Export', () => {
   });
 
   test('Table', async ({ page }) => {
-    test.slow(true);
+    test.setTimeout(300_000);
 
     const tableEntity = new TableClass();
 

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/ContextCenterPermission.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/ContextCenterPermission.spec.ts
@@ -593,7 +593,9 @@ test.describe('Context Center Permissions', () => {
         const upvoteRes = await upvoteResPromise;
 
         expect(upvoteRes.status()).toBe(200);
-        await expect(upvoteBtn.locator('svg')).toHaveClass(/fill-blue-500/);
+        await expect(upvoteBtn.locator('svg')).toHaveClass(
+          /fill-utility-blue-500/
+        );
 
         const downvoteResPromise = viewOnlyPage.waitForResponse(
           `/api/v1/contextCenter/pages/${articleEntity.responseData.id}/vote`
@@ -602,7 +604,9 @@ test.describe('Context Center Permissions', () => {
         const downvoteRes = await downvoteResPromise;
 
         expect(downvoteRes.status()).toBe(200);
-        await expect(downvoteBtn.locator('svg')).toHaveClass(/fill-blue-500/);
+        await expect(downvoteBtn.locator('svg')).toHaveClass(
+          /fill-utility-blue-500/
+        );
       });
 
       await test.step('can start a conversation on the article', async () => {
@@ -640,7 +644,7 @@ test.describe('Context Center Permissions', () => {
         const followRes = await followResPromise;
 
         expect(followRes.status()).toBe(200);
-        await expect(followBtn).toHaveClass(/text-brand-600/);
+        await expect(followBtn).toHaveClass(/text-fg-brand-primary/);
 
         const unfollowResPromise = viewOnlyPage.waitForResponse((response) =>
           response
@@ -653,7 +657,7 @@ test.describe('Context Center Permissions', () => {
         const unfollowRes = await unfollowResPromise;
 
         expect(unfollowRes.status()).toBe(200);
-        await expect(followBtn).not.toHaveClass(/text-brand-600/);
+        await expect(followBtn).not.toHaveClass(/text-fg-brand-primary/);
       });
     });
 


### PR DESCRIPTION
### Describe your changes:

I updated the `ContextCenterPermission` Playwright e2e assertions because the article header migrated its active vote/follow indicators to design-token classes — the upvote/downvote SVG now uses `tw:fill-utility-blue-500` (was `fill-blue-500`) and the follow button uses `tw:text-fg-brand-primary` (was `text-brand-600`) — which made the upvote/downvote/follow steps fail.

#
### Type of change:
- [x] Bug fix

#
### High-level design:

N/A — small change.

#
### Tests:

#### Use cases covered
- View-only user can upvote/downvote an article and the active vote color is asserted against the current design-token class.
- View-only user can follow/unfollow an article and the active follow color is asserted correctly.

#### Playwright (UI) tests
- Updated: `openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/ContextCenterPermission.spec.ts`

#### Manual testing performed
Verified the new class names against `ArticleDetailHeader.component.tsx` (active states render `tw:fill-utility-blue-500` and `tw:text-fg-brand-primary`).

#
### UI screen recording / screenshots:

Not applicable.

#
### Checklist:
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests (unit / integration / Playwright as applicable) and listed them above.

----
## Summary by Gitar

- **Test assertions:**
  - Updated `ContextCenterPermission.spec.ts` to use `fill-utility-blue-500` and `text-fg-brand-primary` for vote/follow assertions.
- **Test infrastructure:**
  - Increased `test.setTimeout` in `BulkImport.spec.ts` from `500,000ms` to `600,000ms`.
  - Set an explicit `test.setTimeout(300,000)` for the `Table` test in `BulkImport.spec.ts`.

<sub>This will update automatically on new commits.</sub>

------|----------|
| openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/ContextCenterPermission.spec.ts | Updates vote/follow CSS class assertions from legacy Tailwind classes (`fill-blue-500`, `text-brand-600`) to current design-token classes (`fill-utility-blue-500`, `text-fg-brand-primary`), matching what ArticleDetailHeader.component.tsx actually renders. |
| openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/BulkImport.spec.ts | Increases the `Database service` test timeout from 500 000 ms (5 min) to 600 000 ms (6 min) to reduce flakiness in AUT environments. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Test as Playwright Test
    participant Page as ViewOnly Browser Page
    participant API as OpenMetadata API
    participant DOM as Article Header DOM

    Test->>Page: click upvoteBtn
    Page->>API: "POST /contextCenter/pages/{id}/vote"
    API-->>Page: 200 OK
    Page->>DOM: render SVG with tw:fill-utility-blue-500
    Test->>DOM: toHaveClass(/fill-utility-blue-500/) ✓

    Test->>Page: click downvoteBtn
    Page->>API: "POST /contextCenter/pages/{id}/vote"
    API-->>Page: 200 OK
    Page->>DOM: render SVG with tw:fill-utility-blue-500
    Test->>DOM: toHaveClass(/fill-utility-blue-500/) ✓

    Test->>Page: click followBtn
    Page->>API: "POST /contextCenter/pages/{id}/followers"
    API-->>Page: 200 OK
    Page->>DOM: render followBtn with tw:text-fg-brand-primary
    Test->>DOM: toHaveClass(/text-fg-brand-primary/) ✓

    Test->>Page: click followBtn (unfollow)
    Page->>API: "DELETE /contextCenter/pages/{id}/followers/{userId}"
    API-->>Page: 200 OK
    Page->>DOM: remove tw:text-fg-brand-primary from followBtn
    Test->>DOM: not.toHaveClass(/text-fg-brand-primary/) ✓
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Test as Playwright Test
    participant Page as ViewOnly Browser Page
    participant API as OpenMetadata API
    participant DOM as Article Header DOM

    Test->>Page: click upvoteBtn
    Page->>API: "POST /contextCenter/pages/{id}/vote"
    API-->>Page: 200 OK
    Page->>DOM: render SVG with tw:fill-utility-blue-500
    Test->>DOM: toHaveClass(/fill-utility-blue-500/) ✓

    Test->>Page: click downvoteBtn
    Page->>API: "POST /contextCenter/pages/{id}/vote"
    API-->>Page: 200 OK
    Page->>DOM: render SVG with tw:fill-utility-blue-500
    Test->>DOM: toHaveClass(/fill-utility-blue-500/) ✓

    Test->>Page: click followBtn
    Page->>API: "POST /contextCenter/pages/{id}/followers"
    API-->>Page: 200 OK
    Page->>DOM: render followBtn with tw:text-fg-brand-primary
    Test->>DOM: toHaveClass(/text-fg-brand-primary/) ✓

    Test->>Page: click followBtn (unfollow)
    Page->>API: "DELETE /contextCenter/pages/{id}/followers/{userId}"
    API-->>Page: 200 OK
    Page->>DOM: remove tw:text-fg-brand-primary from followBtn
    Test->>DOM: not.toHaveClass(/text-fg-brand-primary/) ✓
```

</a>
</details>

<sub>Reviews (3): Last reviewed commit: ["increase the timeout"](https://github.com/open-metadata/openmetadata/commit/967de82a7867a0fd3e57d20cc73e25e52c601aaa) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39824545)</sub>

<!-- /greptile_comment -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR updates two Playwright e2e test files to align with recent design-token class name changes in the article header component, and bumps two timeouts in `BulkImport.spec.ts` to reduce flakiness.

- **ContextCenterPermission.spec.ts**: Regex assertions for the active vote state changed from `/fill-blue-500/` → `/fill-utility-blue-500/` and for the follow state from `/text-brand-600/` → `/text-fg-brand-primary/`, matching what `ArticleDetailHeader.component.tsx` now emits (`tw:fill-utility-blue-500`, `tw:text-fg-brand-primary`).
- **BulkImport.spec.ts**: The "Database service" test timeout is raised from 500 s to 600 s, and the "Table" test switches from `test.slow(true)` (which triples the global 60 s → 180 s) to an explicit `test.setTimeout(300_000)` (5 min), giving the table test more headroom than before.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — both files are test-only and the class name updates are verified against the production component source.

The ContextCenterPermission assertions are updated to match the exact token class names found in ArticleDetailHeader.component.tsx. The regex patterns correctly match the tw:-prefixed classes via substring. The BulkImport timeout increases are conservative and strictly raise, not lower, the previous budgets. No production code is changed.

No files require special attention.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/ContextCenterPermission.spec.ts | Updates four regex assertions to match the new design-token class names emitted by ArticleDetailHeader; the patterns correctly match the tw:-prefixed classes via substring regex. |
| openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/BulkImport.spec.ts | Raises the "Database service" test timeout from 500 s to 600 s and replaces test.slow() (180 s) with an explicit 300 s timeout for the "Table" test, increasing both budgets to reduce CI flakiness. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant T as Playwright Test
    participant P as viewOnlyPage (Browser)
    participant API as OpenMetadata API
    participant C as ArticleDetailHeader Component

    T->>P: upvoteBtn.click()
    P->>API: "POST /contextCenter/pages/{id}/vote"
    API-->>P: 200 OK
    P->>C: re-renders SVG with tw:fill-utility-blue-500
    T->>P: expect(upvoteBtn.locator('svg')).toHaveClass(/fill-utility-blue-500/)
    P-->>T: pass

    T->>P: followBtn.click()
    P->>API: "PUT /contextCenter/pages/{id}/followers"
    API-->>P: 200 OK
    P->>C: re-renders button with tw:text-fg-brand-primary
    T->>P: expect(followBtn).toHaveClass(/text-fg-brand-primary/)
    P-->>T: pass
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant T as Playwright Test
    participant P as viewOnlyPage (Browser)
    participant API as OpenMetadata API
    participant C as ArticleDetailHeader Component

    T->>P: upvoteBtn.click()
    P->>API: "POST /contextCenter/pages/{id}/vote"
    API-->>P: 200 OK
    P->>C: re-renders SVG with tw:fill-utility-blue-500
    T->>P: expect(upvoteBtn.locator('svg')).toHaveClass(/fill-utility-blue-500/)
    P-->>T: pass

    T->>P: followBtn.click()
    P->>API: "PUT /contextCenter/pages/{id}/followers"
    API-->>P: 200 OK
    P->>C: re-renders button with tw:text-fg-brand-primary
    T->>P: expect(followBtn).toHaveClass(/text-fg-brand-primary/)
    P-->>T: pass
```

</a>
</details>

<sub>Reviews (4): Last reviewed commit: ["minor fix"](https://github.com/open-metadata/openmetadata/commit/2e3242c25cec7e817dc64ac8b3906081df157ada) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39824545)</sub>

<!-- /greptile_comment -->