### PR TITLE
fix(types): self-heal custom-property registry on cache miss across replicas

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/TypeRegistry.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/TypeRegistry.java
@@ -17,7 +17,10 @@ import static org.openmetadata.common.utils.CommonUtil.listOrEmpty;
 import static org.openmetadata.service.Entity.ADMIN_USER_NAME;
 import static org.openmetadata.service.resources.types.TypeResource.PROPERTIES_FIELD;
 
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
 import com.networknt.schema.Schema;
+import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -45,6 +48,16 @@ public class TypeRegistry {
 
   /** Custom property map (fully qualified customPropertyName) to (jsonSchema) */
   protected static final Map<String, Schema> CUSTOM_PROPERTY_SCHEMAS = new ConcurrentHashMap<>();
+
+  /**
+   * Negative cache of custom-property FQNs that were missing in this process even after a fresh
+   * read from the shared database. In a multi-replica deployment a custom property created on one
+   * replica is not pushed to the in-memory registry of its peers; this lets a peer self-heal by
+   * re-reading the owning type from the database on a cache miss, while the negative entry bounds
+   * how often a genuinely-unknown field re-triggers that database read.
+   */
+  protected static final Cache<String, Boolean> MISSING_CUSTOM_PROPERTIES =
+      Caffeine.newBuilder().maximumSize(10_000).expireAfterWrite(Duration.ofSeconds(60)).build();
 
   private static final TypeRegistry INSTANCE = new TypeRegistry();
 
@@ -108,6 +121,7 @@ public class TypeRegistry {
       String entityType, String propertyName, CustomProperty customProperty) {
     String customPropertyFQN = getCustomPropertyFQN(entityType, propertyName);
     CUSTOM_PROPERTIES.put(customPropertyFQN, customProperty);
+    MISSING_CUSTOM_PROPERTIES.invalidate(customPropertyFQN);
 
     try {
       Schema jsonSchema =
@@ -131,7 +145,42 @@ public class TypeRegistry {
 
   public Schema getSchema(String entityType, String propertyName) {
     String customPropertyFQN = getCustomPropertyFQN(entityType, propertyName);
+    ensureCustomPropertyLoaded(entityType, customPropertyFQN);
     return CUSTOM_PROPERTY_SCHEMAS.get(customPropertyFQN);
+  }
+
+  /**
+   * Self-heals the registry when a custom property is missing locally. Other replicas do not learn
+   * about a custom property created on a peer, so on a miss we re-read the owning type from the
+   * shared database (source of truth) and repopulate the registry. A short-lived negative cache
+   * prevents a genuinely-unknown field from re-reading the database on every request.
+   */
+  private void ensureCustomPropertyLoaded(String entityType, String customPropertyFQN) {
+    boolean present = CUSTOM_PROPERTIES.containsKey(customPropertyFQN);
+    boolean recentlyMissed = MISSING_CUSTOM_PROPERTIES.getIfPresent(customPropertyFQN) != null;
+    if (!present && !recentlyMissed) {
+      refreshTypeFromDb(entityType);
+      if (!CUSTOM_PROPERTIES.containsKey(customPropertyFQN)) {
+        MISSING_CUSTOM_PROPERTIES.put(customPropertyFQN, Boolean.TRUE);
+      }
+    }
+  }
+
+  private void refreshTypeFromDb(String entityType) {
+    TypeRepository repository = Entity.getTypeRepository();
+    if (repository != null) {
+      try {
+        EntityUtil.Fields fields = repository.getFields(PROPERTIES_FIELD);
+        Type type = repository.getByName(null, entityType, fields);
+        addType(type);
+        LOG.info("Refreshed type '{}' from database after custom property cache miss", entityType);
+      } catch (RuntimeException e) {
+        LOG.debug(
+            "Could not refresh type '{}' from database on cache miss: {}",
+            entityType,
+            e.getMessage());
+      }
+    }
   }
 
   public void validateCustomProperties(Type type) {
@@ -163,6 +212,7 @@ public class TypeRegistry {
 
   public static String getCustomPropertyType(String entityType, String propertyName) {
     String fqn = getCustomPropertyFQN(entityType, propertyName);
+    instance().ensureCustomPropertyLoaded(entityType, fqn);
     CustomProperty property = CUSTOM_PROPERTIES.get(fqn);
     if (property == null) {
       throw EntityNotFoundException.byMessage(
@@ -173,6 +223,7 @@ public class TypeRegistry {
 
   public static String getCustomPropertyConfig(String entityType, String propertyName) {
     String fqn = getCustomPropertyFQN(entityType, propertyName);
+    instance().ensureCustomPropertyLoaded(entityType, fqn);
     CustomProperty property = CUSTOM_PROPERTIES.get(fqn);
     if (property != null
         && property.getCustomPropertyConfig() != null

--- a/openmetadata-service/src/test/java/org/openmetadata/service/TypeRegistryTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/TypeRegistryTest.java
@@ -14,28 +14,111 @@
 package org.openmetadata.service;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
+import com.networknt.schema.Schema;
+import java.util.List;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
+import org.openmetadata.schema.entity.Type;
+import org.openmetadata.schema.entity.type.Category;
 import org.openmetadata.schema.entity.type.CustomProperty;
+import org.openmetadata.schema.type.EntityReference;
+import org.openmetadata.service.jdbi3.TypeRepository;
+import org.openmetadata.service.util.EntityUtil;
 
 /**
- * Tests {@link TypeRegistry#getPropertyName(String)}.
+ * Tests {@link TypeRegistry#getPropertyName(String)} and the self-healing custom-property lookup.
  *
  * <p>The OpenMetadata FQN system normalises quotes — a property named {@code "/random/"} (with
  * literal quote characters) and a property named {@code custom.test} (with dots) end up with FQN
  * segments that look the same after normalisation. To return the original name to API consumers,
  * {@code getPropertyName} prefers the registered {@link CustomProperty#getName()} over re-deriving
  * from the FQN. These tests pin that behaviour.
+ *
+ * <p>The remaining tests cover the multi-replica self-heal: a custom property created on a peer
+ * replica is absent from this process's registry, so a cache miss re-reads the owning type from the
+ * shared database, while a negative cache bounds repeated reads for genuinely-unknown fields.
  */
 class TypeRegistryTest {
 
   private static final String ENTITY_TYPE = "table";
   private static final String FQN_PREFIX_TABLE = "table.customProperties";
 
+  private static final String STRING_TYPE = "string";
+
   @AfterEach
   void cleanRegistry() {
     TypeRegistry.CUSTOM_PROPERTIES.clear();
+    TypeRegistry.CUSTOM_PROPERTY_SCHEMAS.clear();
+    TypeRegistry.TYPES.clear();
+    TypeRegistry.MISSING_CUSTOM_PROPERTIES.invalidateAll();
+    Entity.setTypeRepository(null);
+  }
+
+  /**
+   * Simulates the multi-replica desync: a custom property created on a peer replica exists in the
+   * shared database but is absent from this process's registry. A cache miss must self-heal by
+   * re-reading the owning type from the database (the {@link TypeRepository} boundary) instead of
+   * surfacing the property as unknown.
+   */
+  @Test
+  void getSchema_selfHealsFromDatabaseOnCacheMiss() {
+    seedBasePropertyType();
+    String propertyName = "relationships";
+    TypeRepository repository = repositoryReturningTableWith(propertyName);
+
+    String fqn = TypeRegistry.getCustomPropertyFQN(ENTITY_TYPE, propertyName);
+    assertNull(
+        TypeRegistry.CUSTOM_PROPERTY_SCHEMAS.get(fqn),
+        "Precondition: stale replica does not know the custom property");
+
+    Schema schema = TypeRegistry.instance().getSchema(ENTITY_TYPE, propertyName);
+
+    assertNotNull(schema, "Schema should be self-healed from the database on a cache miss");
+    verify(repository).getByName(any(), eq(ENTITY_TYPE), any());
+  }
+
+  @Test
+  void getSchema_negativeCacheBoundsDatabaseReadsForUnknownField() {
+    seedBasePropertyType();
+    TypeRepository repository = repositoryReturningTableWith("somethingElse");
+
+    Schema first = TypeRegistry.instance().getSchema(ENTITY_TYPE, "doesNotExist");
+    Schema second = TypeRegistry.instance().getSchema(ENTITY_TYPE, "doesNotExist");
+
+    assertNull(first);
+    assertNull(second);
+    verify(repository, times(1)).getByName(any(), eq(ENTITY_TYPE), any());
+  }
+
+  private void seedBasePropertyType() {
+    TypeRegistry.TYPES.put(
+        STRING_TYPE, new Type().withName(STRING_TYPE).withSchema("{\"type\":\"string\"}"));
+  }
+
+  private TypeRepository repositoryReturningTableWith(String propertyName) {
+    Type tableType =
+        new Type()
+            .withName(ENTITY_TYPE)
+            .withCategory(Category.Entity)
+            .withCustomProperties(
+                List.of(
+                    new CustomProperty()
+                        .withName(propertyName)
+                        .withPropertyType(new EntityReference().withName(STRING_TYPE))));
+    TypeRepository repository = mock(TypeRepository.class);
+    when(repository.getFields(any())).thenReturn(EntityUtil.Fields.EMPTY_FIELDS);
+    when(repository.getByName(any(), eq(ENTITY_TYPE), any())).thenReturn(tableType);
+    Entity.setTypeRepository(repository);
+    return repository;
   }
 
   @Test


### PR DESCRIPTION
In a multi-replica deployment, a custom property added at runtime is only known to the replica that handled the `PUT /metadata/types/{id}`. The per-process `TypeRegistry` is populated once at startup and updated write-through only on the serving replica, with no cross-node invalidation. Entity `extension` validation reads solely from this in-memory registry, so a peer replica that never learned the new property rejects writes with `400 Unknown custom field <name>` — persistently, behind a non-sticky load balancer at a rate of stale_replicas / total_replicas.

Make the registry self-healing: on a custom-property miss, re-read the owning type from the shared database (the source of truth) and repopulate the registry, then re-check. A bounded Caffeine negative cache (10k entries, 60s TTL) prevents a genuinely-unknown field from re-reading the database on every request. This works in the default CACHE_PROVIDER=none topology where the bug occurs, with no new infrastructure dependency.

Wired into all three entity-type+property resolution points (getSchema, getCustomPropertyType, getCustomPropertyConfig), covering POST/PATCH validation, CSV import, and search indexing.

Refs #25532, discussion #21865

<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:

Fixes #<issue-number>
<!--
Linking an issue is REQUIRED. Replace <issue-number> with the GitHub issue number this PR addresses
(e.g., `Fixes #12345`). GitHub will auto-link it. If no issue exists, please open one first so the
problem and design can be discussed before review.
-->

<!--
Short blurb explaining:
- What changes did you make?
- Why did you make them?
-->

I worked on ... because ...

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### High-level design:
<!--
REQUIRED for large PRs (new features, refactors, breaking changes, or anything touching >5 files).
Skip for small bug fixes and trivial changes.

Cover:
- Architecture / approach you took and why
- Key components or files added/changed and how they interact
- Alternatives considered and why you rejected them
- Any migration, backward-compatibility, or rollout concerns
- Diagrams or links to design docs / RFCs if available
-->

N/A — small change. <!-- Or fill in the design above -->

#
### Tests:

#### Use cases covered
<!--
List the user-visible scenarios this PR exercises. Example:
- User with Admin role can create a Glossary Term with a parent term
- Ingestion run for Snowflake correctly extracts row counts for partitioned tables
-->

#### Unit tests
<!--
- [ ] I added unit tests for the new/changed logic.
- Files added/updated:
- Coverage on changed classes (run `mvn jacoco:report` for backend, `yarn test:coverage` for UI,
  `make unit_ingestion` for ingestion). Target is 90% line coverage on changed classes.
- Coverage %: <e.g., 92% on EntityRepository.java>
-->

#### Backend integration tests
<!--
- [ ] I added integration tests in `openmetadata-integration-tests/` for new/changed API endpoints.
- [ ] Not applicable (no backend API changes).
- Files added/updated:
-->

#### Ingestion integration tests
<!--
- [ ] I added/updated ingestion integration tests for connector changes.
- [ ] Not applicable (no ingestion changes).
- Files added/updated:
-->

#### Playwright (UI) tests
<!--
- [ ] I added Playwright E2E tests under `openmetadata-ui/.../ui/playwright/` for UI changes.
- [ ] Not applicable (no UI changes).
- Files added/updated:
-->

#### Manual testing performed
<!--
List the manual test steps you performed before requesting review. Example:
1. Started local stack via `./docker/run_local_docker.sh -m ui -d mysql`
2. Logged in as admin, created entity X, verified Y appears in the UI
3. Triggered ingestion for Snowflake source, confirmed lineage edges in the explore page
-->

#
### UI screen recording / screenshots:
<!--
REQUIRED for any PR that changes the UI. Drag-and-drop a short screen recording (.mov / .mp4 / .gif)
demonstrating the change end-to-end, plus before/after screenshots where relevant.
Mark "Not applicable" if there are no UI changes.
-->

Not applicable. <!-- Or attach recording/screenshots above -->

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.
- [ ] For UI changes: I attached a screen recording and/or screenshots above.
- [ ] I have added tests (unit / integration / Playwright as applicable) and listed them above.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a multi-replica desync bug in `TypeRegistry` where custom properties created on one replica are unknown to peers, causing persistent `400 Unknown custom field` errors. The fix adds a self-healing DB read on cache miss and a Caffeine negative cache (10k entries, 60s TTL) to bound repeated reads for genuinely-unknown fields.

- `ensureCustomPropertyLoaded` is wired into `getSchema`, `getCustomPropertyType`, and `getCustomPropertyConfig`; on a miss it calls `refreshTypeFromDb` which fetches the owning type from the shared DB and calls `addType` to repopulate all maps.
- `addCustomProperty` now invalidates the negative cache entry on a successful write, so a newly-registered property is immediately available without waiting for the TTL to expire.
- Two unit tests pin the self-heal and negative-cache throttling behaviors, using a Mockito mock of `TypeRepository` and the newly-exposed `Entity.setTypeRepository` seam.
</details>


<details open><summary><h3>Confidence Score: 3/5</h3></summary>

The self-heal mechanism is sound in the happy path but has a latent defect that can silently break it in production.

The `addType` method iterates directly over `type.getCustomProperties()` without null protection. Via the new `refreshTypeFromDb` call, any entity type whose DB record returns a null list causes an NPE that is caught by the catch block and logged only at DEBUG — operators see nothing, the property is wrongly placed in the negative cache, and the self-heal silently fails for 60 seconds. Combined with the blanket DEBUG log level masking all unexpected failures in `refreshTypeFromDb`, diagnosing incidents in production would be difficult.

TypeRegistry.java — specifically `addType` (null-safety) and the catch block in `refreshTypeFromDb` (log level).
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| openmetadata-service/src/main/java/org/openmetadata/service/TypeRegistry.java | Adds self-healing DB refresh and Caffeine negative cache for missing custom properties. `addType` iterates `getCustomProperties()` without null-safety (now a hot-path risk), and the catch block logs unexpected failures at DEBUG only. |
| openmetadata-service/src/test/java/org/openmetadata/service/TypeRegistryTest.java | Adds two targeted unit tests (self-heal on cache miss, negative-cache throttling) for `getSchema`. Missing equivalent coverage for `getCustomPropertyType` and `getCustomPropertyConfig`. |

</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Client
    participant TypeRegistry
    participant NegativeCache as MISSING_CUSTOM_PROPERTIES
    participant PropMap as CUSTOM_PROPERTIES
    participant TypeRepository

    Client->>TypeRegistry: getSchema(entityType, propName)
    TypeRegistry->>PropMap: containsKey(FQN)?
    PropMap-->>TypeRegistry: false (stale replica)
    TypeRegistry->>NegativeCache: getIfPresent(FQN)?
    NegativeCache-->>TypeRegistry: null (not recently missed)
    TypeRegistry->>TypeRepository: getByName(entityType, PROPERTIES_FIELD)
    TypeRepository-->>TypeRegistry: Type (with customProperties)
    TypeRegistry->>PropMap: addType() → put all custom properties
    TypeRegistry->>NegativeCache: invalidate(FQN) for each added prop
    TypeRegistry->>PropMap: containsKey(FQN)?
    alt Property found in DB
        PropMap-->>TypeRegistry: true → return Schema
        TypeRegistry-->>Client: Schema (self-healed)
    else Property not in DB
        PropMap-->>TypeRegistry: false
        TypeRegistry->>NegativeCache: put(FQN, true)
        TypeRegistry-->>Client: null (genuine miss, cached for 60s)
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Client
    participant TypeRegistry
    participant NegativeCache as MISSING_CUSTOM_PROPERTIES
    participant PropMap as CUSTOM_PROPERTIES
    participant TypeRepository

    Client->>TypeRegistry: getSchema(entityType, propName)
    TypeRegistry->>PropMap: containsKey(FQN)?
    PropMap-->>TypeRegistry: false (stale replica)
    TypeRegistry->>NegativeCache: getIfPresent(FQN)?
    NegativeCache-->>TypeRegistry: null (not recently missed)
    TypeRegistry->>TypeRepository: getByName(entityType, PROPERTIES_FIELD)
    TypeRepository-->>TypeRegistry: Type (with customProperties)
    TypeRegistry->>PropMap: addType() → put all custom properties
    TypeRegistry->>NegativeCache: invalidate(FQN) for each added prop
    TypeRegistry->>PropMap: containsKey(FQN)?
    alt Property found in DB
        PropMap-->>TypeRegistry: true → return Schema
        TypeRegistry-->>Client: Schema (self-healed)
    else Property not in DB
        PropMap-->>TypeRegistry: false
        TypeRegistry->>NegativeCache: put(FQN, true)
        TypeRegistry-->>Client: null (genuine miss, cached for 60s)
    end
```

</a>
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `openmetadata-service/src/main/java/org/openmetadata/service/TypeRegistry.java`, line 101-108 ([link](https://github.com/open-metadata/openmetadata/blob/9a2893c5e4947a5abb2feb5edcdc4498e1a42f95/openmetadata-service/src/main/java/org/openmetadata/service/TypeRegistry.java#L101-L108)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **`addType` iterates `customProperties` without null-safety, silently broken via the new hot path**

   `addType` at line 105 calls `type.getCustomProperties()` directly in a for-each loop. When called from `refreshTypeFromDb`, if the entity type exists in the DB but has no custom properties (and the schema-generated POJO returns `null` rather than an empty list), this throws NPE. That NPE is a `RuntimeException`, so it is swallowed by the `catch (RuntimeException e)` in `refreshTypeFromDb` and logged only at `DEBUG` — making the failure completely invisible in production. Note that `TYPES.put(type.getName(), type)` on line 102 executes before the NPE, leaving `TYPES` partially updated while `CUSTOM_PROPERTIES` is not updated. The subsequent `!CUSTOM_PROPERTIES.containsKey(customPropertyFQN)` check in `ensureCustomPropertyLoaded` then places the property into the negative cache for 60 seconds, causing false 400 errors even though the DB query succeeded. Compare with `validateCustomProperties` at line 188, which defensively uses `listOrEmpty(type.getCustomProperties())` — the same guard should be applied in `addType`. This is a pre-existing gap that becomes a live defect because `refreshTypeFromDb` is now on the hot request path.

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["fix(types): self-heal custom-property re..."](https://github.com/open-metadata/openmetadata/commit/9a2893c5e4947a5abb2feb5edcdc4498e1a42f95) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39837419)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->