### PR TITLE
fix(glossary): preserve domains through CSV import/export

### DIFF
--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/GlossaryCsvRelationTypesIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/GlossaryCsvRelationTypesIT.java
@@ -118,8 +118,8 @@ public class GlossaryCsvRelationTypesIT {
 
     String csvContent =
         String.format(
-            "parent,name*,displayName,description,synonyms,relatedTerms,references,tags,reviewers,owner,glossaryStatus,color,iconURL,extension%n"
-                + ",%s_newTerm,New Term,Test description,,synonym:%s,,,,,Draft,,,",
+            "parent,name*,displayName,description,synonyms,relatedTerms,references,tags,reviewers,owner,glossaryStatus,color,iconURL,domains,extension%n"
+                + ",%s_newTerm,New Term,Test description,,synonym:%s,,,,,Draft,,,,",
             ns.prefix(""), existingTerm.getFullyQualifiedName());
 
     String result = importGlossaryCsv(glossary.getName(), csvContent, false);
@@ -142,8 +142,8 @@ public class GlossaryCsvRelationTypesIT {
 
     String csvContent =
         String.format(
-            "parent,name*,displayName,description,synonyms,relatedTerms,references,tags,reviewers,owner,glossaryStatus,color,iconURL,extension%n"
-                + ",%s_legacyTerm,Legacy Term,Test description,,%s,,,,,Draft,,,",
+            "parent,name*,displayName,description,synonyms,relatedTerms,references,tags,reviewers,owner,glossaryStatus,color,iconURL,domains,extension%n"
+                + ",%s_legacyTerm,Legacy Term,Test description,,%s,,,,,Draft,,,,",
             ns.prefix(""), existingTerm.getFullyQualifiedName());
 
     String result = importGlossaryCsv(glossary.getName(), csvContent, false);
@@ -176,8 +176,8 @@ public class GlossaryCsvRelationTypesIT {
     String termName = ns.prefix("") + "_mixedTerm";
     String csvContent =
         String.format(
-            "parent,name*,displayName,description,synonyms,relatedTerms,references,tags,reviewers,owner,glossaryStatus,color,iconURL,extension%n"
-                + ",%s,Mixed Term,Test description,,synonym:%s;%s;broader:%s,,,,,Draft,,,",
+            "parent,name*,displayName,description,synonyms,relatedTerms,references,tags,reviewers,owner,glossaryStatus,color,iconURL,domains,extension%n"
+                + ",%s,Mixed Term,Test description,,synonym:%s;%s;broader:%s,,,,,Draft,,,,",
             termName,
             term1.getFullyQualifiedName(),
             term2.getFullyQualifiedName(),
@@ -206,8 +206,8 @@ public class GlossaryCsvRelationTypesIT {
 
     String csvContent =
         String.format(
-            "parent,name*,displayName,description,synonyms,relatedTerms,references,tags,reviewers,owner,glossaryStatus,color,iconURL,extension%n"
-                + ",%s_invalidRelTerm,Invalid Rel Term,Test description,,invalidtype:%s,,,,,Draft,,,",
+            "parent,name*,displayName,description,synonyms,relatedTerms,references,tags,reviewers,owner,glossaryStatus,color,iconURL,domains,extension%n"
+                + ",%s_invalidRelTerm,Invalid Rel Term,Test description,,invalidtype:%s,,,,,Draft,,,,",
             ns.prefix(""), existingTerm.getFullyQualifiedName());
 
     String result = importGlossaryCsv(glossary.getName(), csvContent, true);
@@ -354,8 +354,8 @@ public class GlossaryCsvRelationTypesIT {
     String newTermName = ns.prefix("") + "_importedTerm";
     String csvContent =
         String.format(
-            "parent,name*,displayName,description,synonyms,relatedTerms,references,tags,reviewers,owner,glossaryStatus,color,iconURL,extension%n"
-                + ",%s,Imported Term,Imported via CSV,,broader:%s,,,,,Draft,,,",
+            "parent,name*,displayName,description,synonyms,relatedTerms,references,tags,reviewers,owner,glossaryStatus,color,iconURL,domains,extension%n"
+                + ",%s,Imported Term,Imported via CSV,,broader:%s,,,,,Draft,,,,",
             newTermName, existingTerm.getFullyQualifiedName());
 
     String result = importGlossaryCsv(glossary.getName(), csvContent, false);
@@ -416,8 +416,8 @@ public class GlossaryCsvRelationTypesIT {
 
     String csvContent =
         String.format(
-            "parent,name*,displayName,description,synonyms,relatedTerms,references,tags,reviewers,owner,glossaryStatus,color,iconURL,extension%n"
-                + ",%s_colonTerm,Colon Term,Test description,,notarelation:%s.subterm,,,,,Draft,,,",
+            "parent,name*,displayName,description,synonyms,relatedTerms,references,tags,reviewers,owner,glossaryStatus,color,iconURL,domains,extension%n"
+                + ",%s_colonTerm,Colon Term,Test description,,notarelation:%s.subterm,,,,,Draft,,,,",
             ns.prefix(""), existingTerm.getFullyQualifiedName());
 
     String result = importGlossaryCsv(glossary.getName(), csvContent, true);
@@ -444,8 +444,8 @@ public class GlossaryCsvRelationTypesIT {
     String newTermName = ns.prefix("") + "_mixed";
     String csvContent =
         String.format(
-            "parent,name*,displayName,description,synonyms,relatedTerms,references,tags,reviewers,owner,glossaryStatus,color,iconURL,extension%n"
-                + ",%s,Mixed,Mixed term,,synonym:%s;%s;narrower:%s,,,,,Draft,,,",
+            "parent,name*,displayName,description,synonyms,relatedTerms,references,tags,reviewers,owner,glossaryStatus,color,iconURL,domains,extension%n"
+                + ",%s,Mixed,Mixed term,,synonym:%s;%s;narrower:%s,,,,,Draft,,,,",
             newTermName,
             t1.getFullyQualifiedName(),
             t2.getFullyQualifiedName(),
@@ -576,8 +576,8 @@ public class GlossaryCsvRelationTypesIT {
       String newName = ns.prefix("") + "_imported";
       String csvImport =
           String.format(
-              "parent,name*,displayName,description,synonyms,relatedTerms,references,tags,reviewers,owner,glossaryStatus,color,iconURL,extension%n"
-                  + ",%s,Imported,via custom type,,%s:%s,,,,,Draft,,,",
+              "parent,name*,displayName,description,synonyms,relatedTerms,references,tags,reviewers,owner,glossaryStatus,color,iconURL,domains,extension%n"
+                  + ",%s,Imported,via custom type,,%s:%s,,,,,Draft,,,,",
               newName, customType, effect.getFullyQualifiedName());
       String result = importGlossaryCsv(glossary.getName(), csvImport, false);
       assertNotNull(result);

--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/GlossaryResourceIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/GlossaryResourceIT.java
@@ -1469,6 +1469,57 @@ public class GlossaryResourceIT extends BaseEntityIT<Glossary, CreateGlossary> {
     assertEquals(domainFqn, reimported.getDomains().getFirst().getFullyQualifiedName());
   }
 
+  /**
+   * A term that only <b>inherits</b> its domain from the parent glossary must not have that domain
+   * materialized as a direct domain through a CSV export/import round-trip. Inherited domains are
+   * excluded from the exported domains column, so re-import leaves the term inheriting (not owning)
+   * the domain.
+   */
+  @Test
+  void test_importExportCsv_doesNotMaterializeInheritedDomains(TestNamespace ns) {
+    OpenMetadataClient client = SdkClients.adminClient();
+
+    Glossary glossary = createEntity(createMinimalRequest(ns));
+    String domainFqn = testDomain().getFullyQualifiedName();
+    EntityReference domainRef =
+        new EntityReference()
+            .withId(testDomain().getId())
+            .withType("domain")
+            .withName(testDomain().getName())
+            .withFullyQualifiedName(domainFqn);
+    glossary.setDomains(List.of(domainRef));
+    patchEntity(glossary.getId().toString(), glossary);
+
+    CreateGlossaryTerm createTerm =
+        new CreateGlossaryTerm()
+            .withName(ns.prefix("inheritingTerm"))
+            .withGlossary(glossary.getFullyQualifiedName())
+            .withDescription("Term that only inherits the glossary's domain");
+    GlossaryTerm term = client.glossaryTerms().create(createTerm);
+
+    String exportedCsv = client.glossaries().exportCsv(glossary.getName());
+    String termRow =
+        exportedCsv.lines().filter(line -> line.contains(term.getName())).findFirst().orElseThrow();
+    assertFalse(
+        termRow.contains(domainFqn),
+        "Inherited domain must not be written to the exported CSV. Row: " + termRow);
+
+    String resultCsv = client.glossaries().importCsv(glossary.getName(), exportedCsv, false);
+    assertFalse(
+        resultCsv.contains("failure"),
+        "Re-importing the exported CSV should succeed. Result: " + resultCsv);
+
+    GlossaryTerm reimported =
+        client.glossaryTerms().getByName(term.getFullyQualifiedName(), "domains");
+    boolean hasDirectDomain =
+        reimported.getDomains() != null
+            && reimported.getDomains().stream()
+                .anyMatch(domain -> !Boolean.TRUE.equals(domain.getInherited()));
+    assertFalse(
+        hasDirectDomain,
+        "Inherited domain must not be materialized as a direct domain after CSV round-trip");
+  }
+
   // ===================================================================
   // CSV IMPORT/EXPORT SUPPORT
   // ===================================================================

--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/GlossaryResourceIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/GlossaryResourceIT.java
@@ -19,6 +19,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
+import static org.openmetadata.csv.EntityCsv.IMPORT_FAILED;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -1118,13 +1119,13 @@ public class GlossaryResourceIT extends BaseEntityIT<Glossary, CreateGlossary> {
    */
   private String buildGlossaryTermsCsv(String glossaryFqn, TestNamespace ns) {
     StringBuilder csv = new StringBuilder();
-    // CSV header with all 14 columns as expected by GlossaryCsv.addRecord()
+    // CSV header with all 15 columns as expected by GlossaryCsv.addRecord()
     // Note: 'owner' (singular) NOT 'owners', and 'glossaryStatus' NOT 'status'
     csv.append(GLOSSARY_TERM_CSV_HEADER);
 
     // Add 3 top-level glossary terms with EMPTY parent column
     // Columns: parent, name, displayName, description, synonyms, relatedTerms, references,
-    //          tags, reviewers, owner, glossaryStatus, color, iconURL, extension
+    //          tags, reviewers, owner, glossaryStatus, color, iconURL, domains, extension
     csv.append(
         String.format(
             ",\"%s\",\"Term 1\",\"First test term for bulk import\",,,,,,,,,,,\n",
@@ -1443,13 +1444,7 @@ public class GlossaryResourceIT extends BaseEntityIT<Glossary, CreateGlossary> {
     GlossaryTerm term = client.glossaryTerms().create(createTerm);
 
     String domainFqn = testDomain().getFullyQualifiedName();
-    EntityReference domainRef =
-        new EntityReference()
-            .withId(testDomain().getId())
-            .withType("domain")
-            .withName(testDomain().getName())
-            .withFullyQualifiedName(domainFqn);
-    term.setDomains(List.of(domainRef));
+    term.setDomains(List.of(testDomain().getEntityReference()));
     client.glossaryTerms().update(term.getId(), term);
 
     String exportedCsv = client.glossaries().exportCsv(glossary.getName());
@@ -1458,9 +1453,7 @@ public class GlossaryResourceIT extends BaseEntityIT<Glossary, CreateGlossary> {
         "Exported glossary CSV should contain the term's domain. CSV:\n" + exportedCsv);
 
     String resultCsv = client.glossaries().importCsv(glossary.getName(), exportedCsv, false);
-    assertFalse(
-        resultCsv.contains("failure"),
-        "Re-importing the exported CSV should succeed. Result: " + resultCsv);
+    assertImportSucceeded(resultCsv);
 
     GlossaryTerm reimported =
         client.glossaryTerms().getByName(term.getFullyQualifiedName(), "domains");
@@ -1481,13 +1474,7 @@ public class GlossaryResourceIT extends BaseEntityIT<Glossary, CreateGlossary> {
 
     Glossary glossary = createEntity(createMinimalRequest(ns));
     String domainFqn = testDomain().getFullyQualifiedName();
-    EntityReference domainRef =
-        new EntityReference()
-            .withId(testDomain().getId())
-            .withType("domain")
-            .withName(testDomain().getName())
-            .withFullyQualifiedName(domainFqn);
-    glossary.setDomains(List.of(domainRef));
+    glossary.setDomains(List.of(testDomain().getEntityReference()));
     patchEntity(glossary.getId().toString(), glossary);
 
     CreateGlossaryTerm createTerm =
@@ -1505,9 +1492,7 @@ public class GlossaryResourceIT extends BaseEntityIT<Glossary, CreateGlossary> {
         "Inherited domain must not be written to the exported CSV. Row: " + termRow);
 
     String resultCsv = client.glossaries().importCsv(glossary.getName(), exportedCsv, false);
-    assertFalse(
-        resultCsv.contains("failure"),
-        "Re-importing the exported CSV should succeed. Result: " + resultCsv);
+    assertImportSucceeded(resultCsv);
 
     GlossaryTerm reimported =
         client.glossaryTerms().getByName(term.getFullyQualifiedName(), "domains");
@@ -1527,6 +1512,11 @@ public class GlossaryResourceIT extends BaseEntityIT<Glossary, CreateGlossary> {
                         domainFqn.equals(domain.getFullyQualifiedName())
                             && Boolean.TRUE.equals(domain.getInherited()));
     assertTrue(stillInherits, "Inherited domain must still be present after CSV round-trip");
+  }
+
+  private static void assertImportSucceeded(String resultCsv) {
+    boolean anyRowFailed = resultCsv.lines().anyMatch(line -> line.startsWith(IMPORT_FAILED + ","));
+    assertFalse(anyRowFailed, "CSV import reported a failure row:\n" + resultCsv);
   }
 
   // ===================================================================

--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/GlossaryResourceIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/GlossaryResourceIT.java
@@ -1518,6 +1518,15 @@ public class GlossaryResourceIT extends BaseEntityIT<Glossary, CreateGlossary> {
     assertFalse(
         hasDirectDomain,
         "Inherited domain must not be materialized as a direct domain after CSV round-trip");
+
+    boolean stillInherits =
+        reimported.getDomains() != null
+            && reimported.getDomains().stream()
+                .anyMatch(
+                    domain ->
+                        domainFqn.equals(domain.getFullyQualifiedName())
+                            && Boolean.TRUE.equals(domain.getInherited()));
+    assertTrue(stillInherits, "Inherited domain must still be present after CSV round-trip");
   }
 
   // ===================================================================

--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/GlossaryResourceIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/GlossaryResourceIT.java
@@ -61,7 +61,7 @@ public class GlossaryResourceIT extends BaseEntityIT<Glossary, CreateGlossary> {
       org.slf4j.LoggerFactory.getLogger(GlossaryResourceIT.class);
 
   private static final String GLOSSARY_TERM_CSV_HEADER =
-      "parent,name*,displayName,description,synonyms,relatedTerms,references,tags,reviewers,owner,glossaryStatus,color,iconURL,extension\n";
+      "parent,name*,displayName,description,synonyms,relatedTerms,references,tags,reviewers,owner,glossaryStatus,color,iconURL,domains,extension\n";
 
   {
     supportsImportExport = true;
@@ -1105,9 +1105,9 @@ public class GlossaryResourceIT extends BaseEntityIT<Glossary, CreateGlossary> {
    * Helper method to create CSV content for glossary terms import.
    * Returns CSV with header and 3 glossary terms with all required columns.
    *
-   * CSV Format (14 columns):
+   * CSV Format (15 columns):
    * parent,name*,displayName,description,synonyms,relatedTerms,references,tags,
-   * reviewers,owner,glossaryStatus,color,iconURL,extension
+   * reviewers,owner,glossaryStatus,color,iconURL,domains,extension
    *
    * Note: parent column is for PARENT GLOSSARY TERM, not glossary.
    * For top-level terms, leave parent EMPTY.
@@ -1127,15 +1127,15 @@ public class GlossaryResourceIT extends BaseEntityIT<Glossary, CreateGlossary> {
     //          tags, reviewers, owner, glossaryStatus, color, iconURL, extension
     csv.append(
         String.format(
-            ",\"%s\",\"Term 1\",\"First test term for bulk import\",,,,,,,,,,\n",
+            ",\"%s\",\"Term 1\",\"First test term for bulk import\",,,,,,,,,,,\n",
             ns.prefix("bulkTerm1")));
     csv.append(
         String.format(
-            ",\"%s\",\"Term 2\",\"Second test term for bulk import\",,,,,,,,,,\n",
+            ",\"%s\",\"Term 2\",\"Second test term for bulk import\",,,,,,,,,,,\n",
             ns.prefix("bulkTerm2")));
     csv.append(
         String.format(
-            ",\"%s\",\"Term 3\",\"Third test term for bulk import\",,,,,,,,,,\n",
+            ",\"%s\",\"Term 3\",\"Third test term for bulk import\",,,,,,,,,,,\n",
             ns.prefix("bulkTerm3")));
 
     return csv.toString();
@@ -1341,7 +1341,7 @@ public class GlossaryResourceIT extends BaseEntityIT<Glossary, CreateGlossary> {
             + ns.prefix("newTerm")
             + ",New Term,Test Term,,\""
             + inReviewTerm.getFullyQualifiedName()
-            + "\",,,,,,,,";
+            + "\",,,,,,,,,";
     log.info("TEST: Attempting CSV import for glossary: {}", glossary.getName());
     String resultCsv = client.glossaries().importCsv(glossary.getName(), csv, false);
 
@@ -1394,7 +1394,7 @@ public class GlossaryResourceIT extends BaseEntityIT<Glossary, CreateGlossary> {
             + ns.prefix("newTermWithApproved")
             + ",New Term With Approved,Test Term,,\""
             + approvedTerm.getFullyQualifiedName()
-            + "\",,,,,,,,";
+            + "\",,,,,,,,,";
 
     String resultCsv = client.glossaries().importCsv(glossary.getName(), csv, false);
 
@@ -1424,6 +1424,51 @@ public class GlossaryResourceIT extends BaseEntityIT<Glossary, CreateGlossary> {
     }
   }
 
+  /**
+   * Regression test: glossary terms must keep their assigned domains through a CSV export/import
+   * round-trip (the UI "bulk edit" flow). Domains were silently dropped because the glossary CSV
+   * had no domains column.
+   */
+  @Test
+  void test_importExportCsv_preservesDomains(TestNamespace ns) {
+    OpenMetadataClient client = SdkClients.adminClient();
+
+    Glossary glossary = createEntity(createMinimalRequest(ns));
+
+    CreateGlossaryTerm createTerm =
+        new CreateGlossaryTerm()
+            .withName(ns.prefix("termWithDomain"))
+            .withGlossary(glossary.getFullyQualifiedName())
+            .withDescription("Term that must keep its domain through CSV import");
+    GlossaryTerm term = client.glossaryTerms().create(createTerm);
+
+    String domainFqn = testDomain().getFullyQualifiedName();
+    EntityReference domainRef =
+        new EntityReference()
+            .withId(testDomain().getId())
+            .withType("domain")
+            .withName(testDomain().getName())
+            .withFullyQualifiedName(domainFqn);
+    term.setDomains(List.of(domainRef));
+    client.glossaryTerms().update(term.getId(), term);
+
+    String exportedCsv = client.glossaries().exportCsv(glossary.getName());
+    assertTrue(
+        exportedCsv.contains(domainFqn),
+        "Exported glossary CSV should contain the term's domain. CSV:\n" + exportedCsv);
+
+    String resultCsv = client.glossaries().importCsv(glossary.getName(), exportedCsv, false);
+    assertFalse(
+        resultCsv.contains("failure"),
+        "Re-importing the exported CSV should succeed. Result: " + resultCsv);
+
+    GlossaryTerm reimported =
+        client.glossaryTerms().getByName(term.getFullyQualifiedName(), "domains");
+    assertNotNull(reimported.getDomains(), "Domain must be preserved after CSV re-import");
+    assertEquals(1, reimported.getDomains().size());
+    assertEquals(domainFqn, reimported.getDomains().getFirst().getFullyQualifiedName());
+  }
+
   // ===================================================================
   // CSV IMPORT/EXPORT SUPPORT
   // ===================================================================
@@ -1451,6 +1496,7 @@ public class GlossaryResourceIT extends BaseEntityIT<Glossary, CreateGlossary> {
       csv.append(escapeCSVValue("Approved")).append(","); // glossaryStatus
       csv.append(escapeCSVValue("#FF5733")).append(","); // color
       csv.append(escapeCSVValue("")).append(","); // iconURL
+      csv.append(escapeCSVValue("")).append(","); // domains
       csv.append(escapeCSVValue(formatExtensionForCsv(null))); // extension
       csv.append("\n");
     }
@@ -1462,9 +1508,9 @@ public class GlossaryResourceIT extends BaseEntityIT<Glossary, CreateGlossary> {
     StringBuilder csv = new StringBuilder();
     csv.append(GLOSSARY_TERM_CSV_HEADER);
     // Missing required name field
-    csv.append(",,Term,Description,,,,,,,,,\n");
+    csv.append(",,Term,Description,,,,,,,,,,\n");
     // Invalid glossary status
-    csv.append(",invalid_term,,,,,,,,INVALID_STATUS,,,\n");
+    csv.append(",invalid_term,,,,,,,,INVALID_STATUS,,,,\n");
     return csv.toString();
   }
 

--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/GlossaryTermRelationEdgeCasesIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/GlossaryTermRelationEdgeCasesIT.java
@@ -486,8 +486,8 @@ public class GlossaryTermRelationEdgeCasesIT {
 
     String csvContent =
         String.format(
-            "parent,name*,displayName,description,synonyms,relatedTerms,references,tags,reviewers,owner,glossaryStatus,color,iconURL,extension%n"
-                + ",%s_termWithBadRef,Term With Bad Ref,Test description,,synonym:nonExistent.term.fqn,,,,,Draft,,,",
+            "parent,name*,displayName,description,synonyms,relatedTerms,references,tags,reviewers,owner,glossaryStatus,color,iconURL,domains,extension%n"
+                + ",%s_termWithBadRef,Term With Bad Ref,Test description,,synonym:nonExistent.term.fqn,,,,,Draft,,,,",
             ns.prefix(""));
 
     String result = importGlossaryCsv(glossary.getName(), csvContent, true);
@@ -504,8 +504,8 @@ public class GlossaryTermRelationEdgeCasesIT {
 
     String csvContent =
         String.format(
-            "parent,name*,displayName,description,synonyms,relatedTerms,references,tags,reviewers,owner,glossaryStatus,color,iconURL,extension%n"
-                + ",%s_newTerm,New Term,Test description,,invalidType:%s,,,,,Draft,,,",
+            "parent,name*,displayName,description,synonyms,relatedTerms,references,tags,reviewers,owner,glossaryStatus,color,iconURL,domains,extension%n"
+                + ",%s_newTerm,New Term,Test description,,invalidType:%s,,,,,Draft,,,,",
             ns.prefix(""), existingTerm.getFullyQualifiedName());
 
     String result = importGlossaryCsv(glossary.getName(), csvContent, true);

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/GlossaryRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/GlossaryRepository.java
@@ -16,6 +16,7 @@
 
 package org.openmetadata.service.jdbi3;
 
+import static org.openmetadata.common.utils.CommonUtil.listOrEmpty;
 import static org.openmetadata.common.utils.CommonUtil.nullOrEmpty;
 import static org.openmetadata.csv.CsvUtil.FIELD_SEPARATOR;
 import static org.openmetadata.csv.CsvUtil.addDomains;
@@ -535,9 +536,15 @@ public class GlossaryRepository extends EntityRepository<Glossary> {
       addField(recordList, entity.getEntityStatus().value());
       addField(recordList, entity.getStyle() != null ? entity.getStyle().getColor() : null);
       addField(recordList, entity.getStyle() != null ? entity.getStyle().getIconURL() : null);
-      addDomains(recordList, entity.getDomains());
+      addDomains(recordList, getDirectDomains(entity.getDomains()));
       addExtension(recordList, entity.getExtension());
       addRecord(csvFile, recordList);
+    }
+
+    private static List<EntityReference> getDirectDomains(List<EntityReference> domains) {
+      return listOrEmpty(domains).stream()
+          .filter(domain -> !Boolean.TRUE.equals(domain.getInherited()))
+          .toList();
     }
 
     private String termReferencesToRecord(List<TermReference> list) {

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/GlossaryRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/GlossaryRepository.java
@@ -18,6 +18,7 @@ package org.openmetadata.service.jdbi3;
 
 import static org.openmetadata.common.utils.CommonUtil.nullOrEmpty;
 import static org.openmetadata.csv.CsvUtil.FIELD_SEPARATOR;
+import static org.openmetadata.csv.CsvUtil.addDomains;
 import static org.openmetadata.csv.CsvUtil.addEntityReference;
 import static org.openmetadata.csv.CsvUtil.addExtension;
 import static org.openmetadata.csv.CsvUtil.addField;
@@ -242,7 +243,8 @@ public class GlossaryRepository extends EntityRepository<Glossary> {
         (GlossaryTermRepository) Entity.getEntityRepository(GLOSSARY_TERM);
     List<GlossaryTerm> terms =
         repository.listAllForCSV(
-            repository.getFields("owners,reviewers,tags,relatedTerms,synonyms,extension,parent"),
+            repository.getFields(
+                "owners,reviewers,tags,relatedTerms,synonyms,extension,parent,domains"),
             glossary.getFullyQualifiedName());
     terms.sort(Comparator.comparing(EntityInterface::getFullyQualifiedName));
     return new GlossaryCsv(glossary, user).exportCsv(terms, callback);
@@ -317,7 +319,8 @@ public class GlossaryRepository extends EntityRepository<Glossary> {
           .withOwners(getOwners(printer, csvRecord, 9))
           .withEntityStatus(getTermStatus(printer, csvRecord))
           .withStyle(getStyle(csvRecord))
-          .withExtension(getExtension(printer, csvRecord, 13));
+          .withDomains(getDomains(printer, csvRecord, 13))
+          .withExtension(getExtension(printer, csvRecord, 14));
 
       // Validate to catch logical errors for both dry run and actual import
       if (processRecord) {
@@ -532,6 +535,7 @@ public class GlossaryRepository extends EntityRepository<Glossary> {
       addField(recordList, entity.getEntityStatus().value());
       addField(recordList, entity.getStyle() != null ? entity.getStyle().getColor() : null);
       addField(recordList, entity.getStyle() != null ? entity.getStyle().getIconURL() : null);
+      addDomains(recordList, entity.getDomains());
       addExtension(recordList, entity.getExtension());
       addRecord(csvFile, recordList);
     }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/GlossaryTermRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/GlossaryTermRepository.java
@@ -2832,7 +2832,8 @@ public class GlossaryTermRepository extends EntityRepository<GlossaryTerm> {
       String name, String user, boolean recursive, CsvExportProgressCallback callback)
       throws IOException {
     Fields fields =
-        getFields("owners,reviewers,tags,relatedTerms,synonyms,references,extension,parent");
+        getFields(
+            "owners,reviewers,tags,relatedTerms,synonyms,references,extension,parent,domains");
     GlossaryTerm glossaryTerm = getByName(null, name, fields);
     GlossaryRepository glossaryRepository =
         (GlossaryRepository) Entity.getEntityRepository(GLOSSARY);

--- a/openmetadata-service/src/main/resources/json/data/glossary/glossaryCsvDocumentation.json
+++ b/openmetadata-service/src/main/resources/json/data/glossary/glossaryCsvDocumentation.json
@@ -119,6 +119,14 @@
       ]
     },
     {
+      "name": "domains",
+      "required": false,
+      "description": "Domains to which the glossary term belongs to, separated by ';'.",
+      "examples": [
+        "Marketing", "Sales;Operations"
+      ]
+    },
+    {
       "name": "extension",
       "required": false,
       "description": "Custom property values added to the glossary term. Each field value (property and its value) is separated by `;` and internal values can be separated by `|`. For `entityReferenceList` type property, pass `type1:fqn1|type2:fqn2`. For single `entityReference` type property, pass `type:fqn`. Similarly, for `enumMultiSelect`, pass values separated by `|`, and for `enumSingleSelect`, pass a single value along with the property name. For `timeInterval` property type, pass the `startTime:endTime` to the property name. If the field value itself contains delimiter values like `,` and `;` or newline they need to be quoted, and the quotation needs to be further escaped. In general, if passing multiple field values separated by `;`, the extension column value needs to be quoted.",

--- a/openmetadata-service/src/main/resources/json/data/glossary/glossaryCsvDocumentation.json
+++ b/openmetadata-service/src/main/resources/json/data/glossary/glossaryCsvDocumentation.json
@@ -121,7 +121,7 @@
     {
       "name": "domains",
       "required": false,
-      "description": "Domains to which the glossary term belongs to, separated by ';'.",
+      "description": "Fully qualified names of the domains the glossary term belongs to, separated by ';'.",
       "examples": [
         "Marketing", "Sales;Operations"
       ]

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/CSVImportWithQuotesAndCommas.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/CSVImportWithQuotesAndCommas.spec.ts
@@ -66,10 +66,10 @@ test.use({
   storageState: 'playwright/.auth/admin.json',
 });
 
-const CSV_WITH_QUOTES_AND_COMMAS = `parent,name*,displayName,description,synonyms,relatedTerms,references,tags,reviewers,owner,glossaryStatus,color,iconURL,extension
-,"Term1",TermAnuj,"<p>Contains a timestamp for the most recent ""login"" of this feature user, to be used for PIN expiration.</p>",,,,,,user:admin,Approved,,,
-,"Test1234","Contains a timestamp for the most recent ""login"" of this feature user, to be used for PIN expiration.","<p>Contains a timestamp for the most recent ""login"" of this feature user, to be used for PIN expiration.</p>",,,,,,user:admin,Approved,,,
-,"TermWithComma,AndQuote","Display name with ""quoted"" text, and comma","<p>Description with ""quotes"" and, commas</p>",,,,,,user:admin,Approved,,,`;
+const CSV_WITH_QUOTES_AND_COMMAS = `parent,name*,displayName,description,synonyms,relatedTerms,references,tags,reviewers,owner,glossaryStatus,color,iconURL,domains,extension
+,"Term1",TermAnuj,"<p>Contains a timestamp for the most recent ""login"" of this feature user, to be used for PIN expiration.</p>",,,,,,user:admin,Approved,,,,
+,"Test1234","Contains a timestamp for the most recent ""login"" of this feature user, to be used for PIN expiration.","<p>Contains a timestamp for the most recent ""login"" of this feature user, to be used for PIN expiration.</p>",,,,,,user:admin,Approved,,,,
+,"TermWithComma,AndQuote","Display name with ""quoted"" text, and comma","<p>Description with ""quotes"" and, commas</p>",,,,,,user:admin,Approved,,,,`;
 
 test.describe('CSV Import with Commas and Quotes - All Entity Types', () => {
   let createCsvImportPromise: () => Promise<void>;

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/GlossaryImportExport.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/GlossaryImportExport.spec.ts
@@ -297,10 +297,10 @@ test.describe('Glossary Bulk Import Export', () => {
         await page.click('[data-testid="manage-button"]');
         await page.click('[data-testid="import-button-description"]');
 
-        const initialCsvContent = `parent,name*,displayName,description,synonyms,relatedTerms,references,tags,reviewers,owner,glossaryStatus,color,iconURL,extension
-,name1,name1,<p>name1</p>,,,,,,user:admin,Approved,,,
-,parent,parent,<p>parent</p>,,,,,,user:admin,Approved,,,
-${circularRefGlossary.data.name}.parent,child,child,<p>child</p>,,,,,,user:admin,Approved,,,`;
+        const initialCsvContent = `parent,name*,displayName,description,synonyms,relatedTerms,references,tags,reviewers,owner,glossaryStatus,color,iconURL,domains,extension
+,name1,name1,<p>name1</p>,,,,,,user:admin,Approved,,,,
+,parent,parent,<p>parent</p>,,,,,,user:admin,Approved,,,,
+${circularRefGlossary.data.name}.parent,child,child,<p>child</p>,,,,,,user:admin,Approved,,,,`;
 
         const initialCsvBlob = new Blob([initialCsvContent], {
           type: 'text/csv',
@@ -350,10 +350,10 @@ ${circularRefGlossary.data.name}.parent,child,child,<p>child</p>,,,,,,user:admin
         await page.click('[data-testid="manage-button"]');
         await page.click('[data-testid="import-button-description"]');
 
-        const circularCsvContent = `parent,name*,displayName,description,synonyms,relatedTerms,references,tags,reviewers,owner,glossaryStatus,color,iconURL,extension
-${circularRefGlossary.data.name}.name1,name1,name1,<p>name1</p>,,,,,,user:admin,Approved,,,
-,parent,parent,<p>parent</p>,,,,,,user:admin,Approved,,,
-${circularRefGlossary.data.name}.parent,child,child,<p>child</p>,,,,,,user:admin,Approved,,,`;
+        const circularCsvContent = `parent,name*,displayName,description,synonyms,relatedTerms,references,tags,reviewers,owner,glossaryStatus,color,iconURL,domains,extension
+${circularRefGlossary.data.name}.name1,name1,name1,<p>name1</p>,,,,,,user:admin,Approved,,,,
+,parent,parent,<p>parent</p>,,,,,,user:admin,Approved,,,,
+${circularRefGlossary.data.name}.parent,child,child,<p>child</p>,,,,,,user:admin,Approved,,,,`;
 
         const circularCsvBlob = new Blob([circularCsvContent], {
           type: 'text/csv',
@@ -422,8 +422,8 @@ ${circularRefGlossary.data.name}.parent,child,child,<p>child</p>,,,,,,user:admin
         await page.click('[data-testid="import-button-description"]');
 
         // CSV with missing name (required field)
-        const missingNameCsv = `parent,name*,displayName,description,synonyms,relatedTerms,references,tags,reviewers,owner,glossaryStatus,color,iconURL,extension
-,,,<p>Description without name</p>,,,,,,user:admin,Approved,,,`;
+        const missingNameCsv = `parent,name*,displayName,description,synonyms,relatedTerms,references,tags,reviewers,owner,glossaryStatus,color,iconURL,domains,extension
+,,,<p>Description without name</p>,,,,,,user:admin,Approved,,,,`;
 
         const csvBlob = new Blob([missingNameCsv], { type: 'text/csv' });
         const csvFile = new File([csvBlob], 'missing-name.csv', {
@@ -477,8 +477,8 @@ ${circularRefGlossary.data.name}.parent,child,child,<p>child</p>,,,,,,user:admin
         await page.click('[data-testid="import-button-description"]');
 
         // CSV with reference to non-existent parent
-        const invalidParentCsv = `parent,name*,displayName,description,synonyms,relatedTerms,references,tags,reviewers,owner,glossaryStatus,color,iconURL,extension
-${parentRefGlossary.data.name}.NonExistentParent,childTerm,childTerm,<p>Child with invalid parent</p>,,,,,,user:admin,Approved,,,`;
+        const invalidParentCsv = `parent,name*,displayName,description,synonyms,relatedTerms,references,tags,reviewers,owner,glossaryStatus,color,iconURL,domains,extension
+${parentRefGlossary.data.name}.NonExistentParent,childTerm,childTerm,<p>Child with invalid parent</p>,,,,,,user:admin,Approved,,,,`;
 
         const csvBlob = new Blob([invalidParentCsv], { type: 'text/csv' });
         const csvFile = new File([csvBlob], 'invalid-parent.csv', {
@@ -536,9 +536,9 @@ ${parentRefGlossary.data.name}.NonExistentParent,childTerm,childTerm,<p>Child wi
         await page.click('[data-testid="import-button-description"]');
 
         // CSV with one valid term and one with circular reference
-        const mixedCsv = `parent,name*,displayName,description,synonyms,relatedTerms,references,tags,reviewers,owner,glossaryStatus,color,iconURL,extension
-,validTerm,validTerm,<p>This is a valid term</p>,,,,,,user:admin,Approved,,,
-${partialGlossary.data.name}.selfRef,selfRef,selfRef,<p>Self-referential term</p>,,,,,,user:admin,Approved,,,`;
+        const mixedCsv = `parent,name*,displayName,description,synonyms,relatedTerms,references,tags,reviewers,owner,glossaryStatus,color,iconURL,domains,extension
+,validTerm,validTerm,<p>This is a valid term</p>,,,,,,user:admin,Approved,,,,
+${partialGlossary.data.name}.selfRef,selfRef,selfRef,<p>Self-referential term</p>,,,,,,user:admin,Approved,,,,`;
 
         const csvBlob = new Blob([mixedCsv], { type: 'text/csv' });
         const csvFile = new File([csvBlob], 'mixed-terms.csv', {
@@ -748,11 +748,11 @@ ${partialGlossary.data.name}.selfRef,selfRef,selfRef,<p>Self-referential term</p
         await page.click('[data-testid="import-button-description"]');
 
         const csvContent =
-          `parent,name*,displayName,description,synonyms,relatedTerms,references,tags,reviewers,owner,glossaryStatus,color,iconURL,extension\n` +
+          `parent,name*,displayName,description,synonyms,relatedTerms,references,tags,reviewers,owner,glossaryStatus,color,iconURL,domains,extension\n` +
           `,${importedTermName},${importedTermName},Imported,,` +
           `synonym:${target1.responseData.fullyQualifiedName};` +
           `${target2.responseData.fullyQualifiedName};` +
-          `narrower:${target3.responseData.fullyQualifiedName},,,,user:admin,Approved,,,`;
+          `narrower:${target3.responseData.fullyQualifiedName},,,,user:admin,Approved,,,,`;
 
         await page.locator('[type="file"]').waitFor({ state: 'attached' });
         await page.setInputFiles('[type="file"]', {
@@ -884,9 +884,9 @@ ${partialGlossary.data.name}.selfRef,selfRef,selfRef,<p>Self-referential term</p
 
         const newTermName = `TR_invalid_${uuid()}`;
         const csvContent =
-          `parent,name*,displayName,description,synonyms,relatedTerms,references,tags,reviewers,owner,glossaryStatus,color,iconURL,extension\n` +
+          `parent,name*,displayName,description,synonyms,relatedTerms,references,tags,reviewers,owner,glossaryStatus,color,iconURL,domains,extension\n` +
           `,${newTermName},${newTermName},Invalid,,` +
-          `notarealtype:${target.responseData.fullyQualifiedName},,,,user:admin,Approved,,,`;
+          `notarealtype:${target.responseData.fullyQualifiedName},,,,user:admin,Approved,,,,`;
 
         await page.locator('[type="file"]').waitFor({ state: 'attached' });
         await page.setInputFiles('[type="file"]', {


### PR DESCRIPTION
Fixes #29483.

## Problem

Glossary terms **lose their assigned domains** when a CSV import is performed (the UI "bulk edit" flow).

Validated example: a term with a domain, after a CSV import round-trip, comes back with no domain.

## Root cause

The glossary CSV had **no `domains` column**:

1. **Export** never serialized a term's domains — and the term loaded for export didn't even hydrate `domains` (it was missing from the `getFields(...)` lists in both `GlossaryRepository.exportToCsv` and `GlossaryTermRepository.exportToCsv`).
2. **Import** built the `GlossaryTerm` with `domains = null`, and the bulk-import persistence path wrote that null back — wiping the existing assignment.

Every other domain-bearing entity (Database, DatabaseSchema, Directory, …) already exposes a `domains` column in its CSV; glossary was the gap.

## Fix

Add a `domains` column to the glossary CSV, placed immediately before `extension` (matching the established convention across the other entities):

- `glossaryCsvDocumentation.json` — new `domains` header
- `GlossaryCsv` import — parse with `getDomains(printer, csvRecord, 13)`
- `GlossaryCsv` export — write with `addDomains(...)`
- Add `domains` to the export field lists in **both** `GlossaryRepository.exportToCsv` (whole glossary) and `GlossaryTermRepository.exportToCsv` (term subtree) so the column is hydrated before serialization. Both share `GlossaryCsv.addRecord`, so the column appears in both export flows.

### Inherited domains are excluded from export

Glossary terms inherit their domain from the parent glossary/term (the ref is marked `inherited=true`). Writing those inherited refs into the CSV would **re-materialize them as direct domains** on re-import — the term would stop tracking the parent. Export filters to **direct (non-inherited)** domains only (`getDirectDomains`), so an inherited-only domain is left out of the row and re-import keeps the term inheriting rather than owning the domain.

## Tests

- **`GlossaryResourceIT#test_importExportCsv_preservesDomains`** — assigns a domain to a term, exports the glossary CSV, asserts the domain FQN is present, re-imports, and asserts the domain is still set. Genuine RED→GREEN.
- **`GlossaryResourceIT#test_importExportCsv_doesNotMaterializeInheritedDomains`** — a term that only inherits the glossary's domain: asserts the exported row omits the domain and that, after re-import, the domain is not materialized as a direct domain.
- Updated existing IT and Playwright CSV fixtures (`GlossaryCsvRelationTypesIT`, `GlossaryTermRelationEdgeCasesIT`, `GlossaryImportExport.spec.ts`, `CSVImportWithQuotesAndCommas.spec.ts`) for the new column.

Ran `mvn spotless:apply` and the UI checkstyle (organize-imports + eslint + prettier) on the changed files. Verified the `openmetadata-service` + `openmetadata-integration-tests` build compiles (BUILD SUCCESS).

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes glossary terms losing their assigned domains during a CSV import/export round-trip by adding a `domains` column (at index 13, before `extension`) to the glossary CSV format, matching the convention already used by all other domain-bearing entities.

- **Export**: `domains` is now hydrated via `getFields(..., domains)` in both `GlossaryRepository` and `GlossaryTermRepository`, then serialized with `addDomains(getDirectDomains(...))` — inherited domains are filtered out so re-import does not materialize them as direct assignments.
- **Import**: `getDomains(printer, csvRecord, 13)` parses the new column; `getExtension` index is bumped from 13 to 14; the `GlossaryCsv` documentation JSON is updated accordingly.
- **Tests**: Two new integration tests (`test_importExportCsv_preservesDomains`, `test_importExportCsv_doesNotMaterializeInheritedDomains`) provide genuine RED→GREEN coverage; all existing IT and Playwright CSV fixtures are updated to the 15-column format.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is a well-scoped additive column to an existing CSV format, is backward-compatible (empty field for terms with no direct domain), and is fully covered by new integration tests and updated Playwright fixtures.

The column-index arithmetic is consistent across both import and export paths, the inherited-domain filter correctly uses Boolean.TRUE.equals to guard against null, and all existing test fixtures are updated to the new 15-column schema. No existing behavior is changed for terms that have no domains.

No files require special attention. The core logic in GlossaryRepository.java is small, localized, and mirrors the pattern used by every other domain-bearing entity's CSV handler.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/GlossaryRepository.java | Core fix: adds domains field to field-fetch lists for export, inserts getDomains at index 13 for import, bumps getExtension to index 14, adds addDomains to addRecord, and introduces getDirectDomains helper to filter inherited refs. |
| openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/GlossaryTermRepository.java | Adds 'domains' to the field list for term-subtree export so the field is hydrated before GlossaryCsv.addRecord serializes it. |
| openmetadata-service/src/main/resources/json/data/glossary/glossaryCsvDocumentation.json | Adds the new 'domains' column descriptor (required=false) before the existing 'extension' entry, matching the established ordering convention. |
| openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/GlossaryResourceIT.java | Adds two new regression tests (preservesDomains, doesNotMaterializeInheritedDomains) and an assertImportSucceeded helper; updates GLOSSARY_TERM_CSV_HEADER and all existing CSV fixtures to the 15-column format. |
| openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/GlossaryCsvRelationTypesIT.java | All CSV header strings and data rows updated to include the new domains column; no logic changes. |
| openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/GlossaryTermRelationEdgeCasesIT.java | CSV fixtures updated to 15-column format; no logic changes. |
| openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/GlossaryImportExport.spec.ts | All inline CSV literals in Playwright specs updated to 15-column format with an empty domains field. |
| openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/CSVImportWithQuotesAndCommas.spec.ts | CSV_WITH_QUOTES_AND_COMMAS constant updated to 15-column format; no logic changes. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant UI as UI / Client
    participant GR as GlossaryRepository
    participant GTR as GlossaryTermRepository
    participant GCsv as GlossaryCsv
    participant CU as CsvUtil

    Note over UI,CU: Export Flow
    UI->>GR: exportToCsv(glossaryName)
    GR->>GTR: listAllForCSV(fields incl. domains)
    GTR-->>GR: List of GlossaryTerm with domains hydrated
    GR->>GCsv: exportCsv(terms, callback)
    loop per term
        GCsv->>GCsv: getDirectDomains - filters inherited refs
        GCsv->>CU: addDomains(recordList, directDomains)
        CU-->>GCsv: FQNs joined by semicolon at col 13
    end
    GCsv-->>UI: CSV with domains column at index 13

    Note over UI,CU: Import Flow
    UI->>GR: importFromCsv(glossaryName, csvContent)
    GR->>GCsv: importCsv(csvContent)
    loop per CSV row
        GCsv->>CU: getDomains(printer, csvRecord, 13)
        CU-->>GCsv: List of EntityReference
        GCsv->>CU: getExtension(printer, csvRecord, 14)
        CU-->>GCsv: extension object
        GCsv->>GR: createEntity(term with domains)
    end
    GCsv-->>UI: result CSV with success or failure rows
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant UI as UI / Client
    participant GR as GlossaryRepository
    participant GTR as GlossaryTermRepository
    participant GCsv as GlossaryCsv
    participant CU as CsvUtil

    Note over UI,CU: Export Flow
    UI->>GR: exportToCsv(glossaryName)
    GR->>GTR: listAllForCSV(fields incl. domains)
    GTR-->>GR: List of GlossaryTerm with domains hydrated
    GR->>GCsv: exportCsv(terms, callback)
    loop per term
        GCsv->>GCsv: getDirectDomains - filters inherited refs
        GCsv->>CU: addDomains(recordList, directDomains)
        CU-->>GCsv: FQNs joined by semicolon at col 13
    end
    GCsv-->>UI: CSV with domains column at index 13

    Note over UI,CU: Import Flow
    UI->>GR: importFromCsv(glossaryName, csvContent)
    GR->>GCsv: importCsv(csvContent)
    loop per CSV row
        GCsv->>CU: getDomains(printer, csvRecord, 13)
        CU-->>GCsv: List of EntityReference
        GCsv->>CU: getExtension(printer, csvRecord, 14)
        CU-->>GCsv: extension object
        GCsv->>GR: createEntity(term with domains)
    end
    GCsv-->>UI: result CSV with success or failure rows
```

</a>
</details>

<sub>Reviews (3): Last reviewed commit: ["test(glossary): address PR review feedba..."](https://github.com/open-metadata/openmetadata/commit/1a5f425d9e6005f8d10a46383b12f917abf889e6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39848254)</sub>

<!-- /greptile_comment -->