### PR TITLE
Fixes #29484: Stop time-series field propagation

### DIFF
--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/IncidentPaginationIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/IncidentPaginationIT.java
@@ -2,9 +2,12 @@ package org.openmetadata.it.tests;
 
 import static org.awaitility.Awaitility.await;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
@@ -40,6 +43,7 @@ import org.slf4j.LoggerFactory;
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class IncidentPaginationIT {
   private static final Logger LOG = LoggerFactory.getLogger(IncidentPaginationIT.class);
+  private static final ObjectMapper MAPPER = new ObjectMapper();
 
   private static final int TEST_DATA_SIZE = 11;
   private static final int PAGE_SIZE = 5;
@@ -299,6 +303,69 @@ public class IncidentPaginationIT {
         0,
         orphanedResponse.getData().size(),
         "Orphaned incident records should be skipped instead of failing the search listing");
+  }
+
+  @Test
+  public void testTestCasePatchDoesNotPropagateToIncidentSearchSource() throws Exception {
+    SharedEntities shared = SharedEntities.get();
+    TestCase target = testCases.get(1);
+    ListParams params =
+        new ListParams()
+            .withLimit(1)
+            .withOffset(0)
+            .withLatest(true)
+            .addFilter("testCaseFQN", target.getFullyQualifiedName());
+    ListResponse<TestCaseResolutionStatus> initialResponse =
+        client.testCaseResolutionStatuses().searchList(params);
+    assertEquals(1, initialResponse.getData().size(), "Expected initial incident to be searchable");
+
+    TestCaseResolutionStatus incident =
+        JsonUtils.convertValue(initialResponse.getData().get(0), TestCaseResolutionStatus.class);
+    String displayName = "incident propagation " + System.currentTimeMillis();
+    TestCase fetched = client.testCases().get(target.getId().toString(), "owners,domains");
+    fetched.setOwners(List.of(shared.USER1_REF));
+    fetched.setDomains(List.of(shared.DOMAIN.getEntityReference()));
+    fetched.setDisplayName(displayName);
+    client.testCases().update(fetched.getId().toString(), fetched);
+
+    await("Incident search source should not receive parent propagation")
+        .atMost(Duration.ofSeconds(60))
+        .pollDelay(Duration.ofMillis(500))
+        .pollInterval(Duration.ofSeconds(1))
+        .ignoreExceptions()
+        .untilAsserted(
+            () -> {
+              JsonNode testCaseSource =
+                  searchSource("test_case_search_index", target.getId().toString());
+              assertEquals(
+                  displayName,
+                  testCaseSource.path("displayName").asText(),
+                  "Test case search doc should receive its own displayName update");
+
+              JsonNode source = searchIncidentSource(incident.getId().toString());
+              assertFalse(
+                  displayName.equals(source.path("testCase").path("displayName").asText()),
+                  "Incident search source must not receive parent displayName propagation");
+              assertFalse(source.has("owners"), "Incident search source must not contain owners");
+              assertFalse(source.has("domains"), "Incident search source must not contain domains");
+
+              ListResponse<TestCaseResolutionStatus> response =
+                  client.testCaseResolutionStatuses().searchList(params);
+              assertEquals(1, response.getData().size(), "Incident latest search should not fail");
+            });
+  }
+
+  private JsonNode searchIncidentSource(String incidentId) throws Exception {
+    return searchSource("test_case_resolution_status_search_index", incidentId);
+  }
+
+  private JsonNode searchSource(String indexName, String id) throws Exception {
+    String searchResponse = client.search().query("id:" + id).index(indexName).size(1).execute();
+    JsonNode hits = MAPPER.readTree(searchResponse).path("hits").path("hits");
+    assertTrue(
+        hits.isArray() && !hits.isEmpty(),
+        "Document should be present in search index " + indexName);
+    return hits.get(0).path("_source");
   }
 
   private Table createTestTable() throws Exception {

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/SearchRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/SearchRepository.java
@@ -79,6 +79,7 @@ import java.util.TreeSet;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Function;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import lombok.Getter;
@@ -1879,8 +1880,7 @@ public class SearchRepository {
       return;
     }
 
-    List<String> childAliases = indexMapping.getChildAliases(clusterAlias);
-    if (nullOrEmpty(childAliases)) {
+    if (nullOrEmpty(indexMapping.getChildAliases())) {
       return;
     }
 
@@ -1900,24 +1900,25 @@ public class SearchRepository {
     String parentFieldName = resolveParentFieldName(entityType, updates);
     Pair<String, String> parentMatch = new ImmutablePair<>(parentFieldName, entityId);
     List<String> entityChildren =
-        childAliases.stream().filter(alias -> !isTimeSeriesAlias(alias)).toList();
+        filterChildAliasesByCapability(
+            indexMapping, capability -> capability == null || !capability.isTimeSeries());
     if (nullOrEmpty(entityChildren)) {
       return;
     }
     searchClient.updateChildren(entityChildren, parentMatch, updates);
   }
 
-  private boolean isTimeSeriesAlias(String alias) {
-    String entityType = stripClusterAlias(alias);
-    EntityIndexCapability capability = EntityIndexCapabilityRegistry.get(entityType);
-    return capability != null && capability.isTimeSeries();
-  }
-
-  private String stripClusterAlias(String alias) {
-    if (!nullOrEmpty(clusterAlias) && alias.startsWith(clusterAlias + INDEX_NAME_SEPARATOR)) {
-      return alias.substring((clusterAlias + INDEX_NAME_SEPARATOR).length());
+  private List<String> filterChildAliasesByCapability(
+      IndexMapping indexMapping, Predicate<EntityIndexCapability> includeCapability) {
+    List<String> childAliases = indexMapping.getChildAliases();
+    if (nullOrEmpty(childAliases)) {
+      return List.of();
     }
-    return alias;
+    boolean hasClusterAlias = !nullOrEmpty(clusterAlias);
+    return childAliases.stream()
+        .filter(alias -> includeCapability.test(EntityIndexCapabilityRegistry.get(alias)))
+        .map(alias -> hasClusterAlias ? clusterAlias + INDEX_NAME_SEPARATOR + alias : alias)
+        .toList();
   }
 
   private String resolveParentFieldName(
@@ -2796,12 +2797,7 @@ public class SearchRepository {
     // Each childAlias is an entity-type name (per indexMapping.json). Use the typed script's
     // capability check so we never apply soft-delete to an index whose schema lacks `deleted`.
     SoftDeleteScript script = new SoftDeleteScript(delete);
-    boolean hasClusterAlias = clusterAlias != null && !clusterAlias.isEmpty();
-    List<String> targets =
-        indexMapping.getChildAliases().stream()
-            .filter(a -> script.compatibleWith(EntityIndexCapabilityRegistry.get(a)))
-            .map(a -> hasClusterAlias ? clusterAlias + IndexMapping.INDEX_NAME_SEPARATOR + a : a)
-            .toList();
+    List<String> targets = filterChildAliasesByCapability(indexMapping, script::compatibleWith);
     if (targets.isEmpty()) {
       return;
     }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/SearchRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/SearchRepository.java
@@ -1901,7 +1901,7 @@ public class SearchRepository {
     Pair<String, String> parentMatch = new ImmutablePair<>(parentFieldName, entityId);
     List<String> entityChildren =
         filterChildAliasesByCapability(
-            indexMapping, capability -> capability != null && !capability.isTimeSeries());
+            indexMapping, capability -> capability == null || !capability.isTimeSeries());
     if (nullOrEmpty(entityChildren)) {
       return;
     }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/SearchRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/SearchRepository.java
@@ -1901,7 +1901,7 @@ public class SearchRepository {
     Pair<String, String> parentMatch = new ImmutablePair<>(parentFieldName, entityId);
     List<String> entityChildren =
         filterChildAliasesByCapability(
-            indexMapping, capability -> capability == null || !capability.isTimeSeries());
+            indexMapping, capability -> capability != null && !capability.isTimeSeries());
     if (nullOrEmpty(entityChildren)) {
       return;
     }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/SearchRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/SearchRepository.java
@@ -1876,36 +1876,24 @@ public class SearchRepository {
       IndexMapping indexMapping,
       EntityInterface entity)
       throws IOException {
-    if (changeDescription == null) {
-      return;
+    if (changeDescription != null && !nullOrEmpty(indexMapping.getChildAliases())) {
+      Pair<String, Map<String, Object>> updates =
+          getInheritedFieldChanges(changeDescription, entity, entityType);
+      if (updates.getKey() != null && !updates.getKey().isEmpty()) {
+        if (entityType.equalsIgnoreCase(Entity.DOMAIN)) {
+          propagateToDomainChildren(entityId, indexMapping, updates);
+        } else {
+          String parentFieldName = resolveParentFieldName(entityType, updates);
+          Pair<String, String> parentMatch = new ImmutablePair<>(parentFieldName, entityId);
+          List<String> entityChildren =
+              filterChildAliasesByCapability(
+                  indexMapping, capability -> capability == null || !capability.isTimeSeries());
+          if (!nullOrEmpty(entityChildren)) {
+            searchClient.updateChildren(entityChildren, parentMatch, updates);
+          }
+        }
+      }
     }
-
-    if (nullOrEmpty(indexMapping.getChildAliases())) {
-      return;
-    }
-
-    Pair<String, Map<String, Object>> updates =
-        getInheritedFieldChanges(changeDescription, entity, entityType);
-    if (updates.getKey() == null || updates.getKey().isEmpty()) {
-      return;
-    }
-
-    // Domain has subdomains (parent.id) and data products (domains.id) - handle separately
-    if (entityType.equalsIgnoreCase(Entity.DOMAIN)) {
-      propagateToDomainChildren(entityId, indexMapping, updates);
-      return;
-    }
-
-    // Other entities: resolve parent field name and propagate to children
-    String parentFieldName = resolveParentFieldName(entityType, updates);
-    Pair<String, String> parentMatch = new ImmutablePair<>(parentFieldName, entityId);
-    List<String> entityChildren =
-        filterChildAliasesByCapability(
-            indexMapping, capability -> capability == null || !capability.isTimeSeries());
-    if (nullOrEmpty(entityChildren)) {
-      return;
-    }
-    searchClient.updateChildren(entityChildren, parentMatch, updates);
   }
 
   private List<String> filterChildAliasesByCapability(

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/SearchRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/SearchRepository.java
@@ -132,6 +132,7 @@ import org.openmetadata.service.events.lifecycle.handlers.SearchIndexHandler;
 import org.openmetadata.service.jdbi3.EntityRepository;
 import org.openmetadata.service.monitoring.RequestLatencyContext;
 import org.openmetadata.service.resources.settings.SettingsCache;
+import org.openmetadata.service.search.capability.EntityIndexCapability;
 import org.openmetadata.service.search.capability.EntityIndexCapabilityRegistry;
 import org.openmetadata.service.search.elasticsearch.ElasticSearchClient;
 import org.openmetadata.service.search.indexes.ColumnSearchIndex;
@@ -1878,14 +1879,14 @@ public class SearchRepository {
       return;
     }
 
-    Pair<String, Map<String, Object>> updates =
-        getInheritedFieldChanges(changeDescription, entity, entityType);
-    if (updates.getKey() == null || updates.getKey().isEmpty()) {
+    List<String> childAliases = indexMapping.getChildAliases(clusterAlias);
+    if (nullOrEmpty(childAliases)) {
       return;
     }
 
-    List<String> childAliases = indexMapping.getChildAliases(clusterAlias);
-    if (nullOrEmpty(childAliases)) {
+    Pair<String, Map<String, Object>> updates =
+        getInheritedFieldChanges(changeDescription, entity, entityType);
+    if (updates.getKey() == null || updates.getKey().isEmpty()) {
       return;
     }
 
@@ -1898,7 +1899,25 @@ public class SearchRepository {
     // Other entities: resolve parent field name and propagate to children
     String parentFieldName = resolveParentFieldName(entityType, updates);
     Pair<String, String> parentMatch = new ImmutablePair<>(parentFieldName, entityId);
-    searchClient.updateChildren(childAliases, parentMatch, updates);
+    List<String> entityChildren =
+        childAliases.stream().filter(alias -> !isTimeSeriesAlias(alias)).toList();
+    if (nullOrEmpty(entityChildren)) {
+      return;
+    }
+    searchClient.updateChildren(entityChildren, parentMatch, updates);
+  }
+
+  private boolean isTimeSeriesAlias(String alias) {
+    String entityType = stripClusterAlias(alias);
+    EntityIndexCapability capability = EntityIndexCapabilityRegistry.get(entityType);
+    return capability != null && capability.isTimeSeries();
+  }
+
+  private String stripClusterAlias(String alias) {
+    if (!nullOrEmpty(clusterAlias) && alias.startsWith(clusterAlias + INDEX_NAME_SEPARATOR)) {
+      return alias.substring((clusterAlias + INDEX_NAME_SEPARATOR).length());
+    }
+    return alias;
   }
 
   private String resolveParentFieldName(

--- a/openmetadata-service/src/test/java/org/openmetadata/service/search/SearchRepositoryBehaviorTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/search/SearchRepositoryBehaviorTest.java
@@ -162,6 +162,7 @@ class SearchRepositoryBehaviorTest {
           Entity.DATABASE_SERVICE,
           Entity.DATABASE,
           Entity.TEST_SUITE,
+          Entity.TEST_CASE,
           Entity.GLOSSARY,
           Entity.CLASSIFICATION,
           Entity.QUERY);
@@ -710,6 +711,85 @@ class SearchRepositoryBehaviorTest {
     verify(searchClient)
         .updateChildren(
             eq(List.of("cluster_data_product_search_index")), any(Pair.class), any(Pair.class));
+  }
+
+  @Test
+  void propagateInheritedFieldsToChildrenSkipsAllChangesForTimeSeriesChildren() throws IOException {
+    IndexMapping timeSeriesOnlyMapping =
+        IndexMapping.builder()
+            .indexName("test_case_search_index")
+            .alias("testCase")
+            .childAliases(List.of(Entity.TEST_CASE_RESOLUTION_STATUS, Entity.TEST_CASE_RESULT))
+            .indexMappingFile("/elasticsearch/%s/test_case_index_mapping.json")
+            .build();
+    EntityInterface testCase = mockEntity(Entity.TEST_CASE, UUID.randomUUID(), "test_case");
+    when(testCase.getOwners())
+        .thenReturn(List.of(new EntityReference().withId(UUID.randomUUID()).withType(Entity.USER)));
+    when(testCase.getDomains())
+        .thenReturn(
+            List.of(new EntityReference().withId(UUID.randomUUID()).withType(Entity.DOMAIN)));
+    ChangeDescription changeDescription =
+        changeDescription(
+            List.of(
+                new FieldChange().withName(Entity.FIELD_OWNERS),
+                new FieldChange().withName(Entity.FIELD_DOMAINS)),
+            List.of(
+                new FieldChange()
+                    .withName(Entity.FIELD_DISPLAY_NAME)
+                    .withOldValue("Old Name")
+                    .withNewValue("New Name")),
+            List.of());
+
+    repository.propagateInheritedFieldsToChildren(
+        Entity.TEST_CASE,
+        testCase.getId().toString(),
+        changeDescription,
+        timeSeriesOnlyMapping,
+        testCase);
+
+    verify(searchClient, never()).updateChildren(any(List.class), any(Pair.class), any(Pair.class));
+  }
+
+  @Test
+  void propagateInheritedFieldsToChildrenOnlyTargetsNonTimeSeriesChildren() throws IOException {
+    EntityInterface testCase = mockEntity(Entity.TEST_CASE, UUID.randomUUID(), "test_case");
+    when(testCase.getOwners())
+        .thenReturn(List.of(new EntityReference().withId(UUID.randomUUID()).withType(Entity.USER)));
+    when(testCase.getDomains())
+        .thenReturn(
+            List.of(new EntityReference().withId(UUID.randomUUID()).withType(Entity.DOMAIN)));
+    ChangeDescription changeDescription =
+        changeDescription(
+            List.of(
+                new FieldChange().withName(Entity.FIELD_OWNERS),
+                new FieldChange().withName(Entity.FIELD_DOMAINS)),
+            List.of(
+                new FieldChange()
+                    .withName(Entity.FIELD_DISPLAY_NAME)
+                    .withOldValue("Old Name")
+                    .withNewValue("New Name")),
+            List.of());
+
+    repository.propagateInheritedFieldsToChildren(
+        Entity.TEST_CASE,
+        testCase.getId().toString(),
+        changeDescription,
+        TEST_CASE_MAPPING,
+        testCase);
+
+    @SuppressWarnings("unchecked")
+    ArgumentCaptor<List<String>> targetsCaptor = ArgumentCaptor.forClass(List.class);
+    @SuppressWarnings("unchecked")
+    ArgumentCaptor<Pair<String, Map<String, Object>>> updatesCaptor =
+        ArgumentCaptor.forClass(Pair.class);
+    verify(searchClient)
+        .updateChildren(targetsCaptor.capture(), any(Pair.class), updatesCaptor.capture());
+
+    assertEquals(List.of("cluster_tableColumn"), targetsCaptor.getValue());
+    String entityChildScript = updatesCaptor.getValue().getLeft();
+    assertTrue(entityChildScript.contains(Entity.FIELD_OWNERS));
+    assertTrue(entityChildScript.contains(Entity.FIELD_DOMAINS));
+    assertTrue(entityChildScript.contains(Entity.FIELD_DISPLAY_NAME));
   }
 
   @Test

--- a/openmetadata-service/src/test/java/org/openmetadata/service/search/SearchRepositoryBehaviorTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/search/SearchRepositoryBehaviorTest.java
@@ -793,6 +793,40 @@ class SearchRepositoryBehaviorTest {
   }
 
   @Test
+  void propagateInheritedFieldsToChildrenSkipsUnregisteredChildAliases() throws IOException {
+    IndexMapping mappingWithUnregisteredChild =
+        IndexMapping.builder()
+            .indexName("test_case_search_index")
+            .alias("testCase")
+            .childAliases(List.of("unregisteredChild", Entity.TABLE_COLUMN))
+            .indexMappingFile("/elasticsearch/%s/test_case_index_mapping.json")
+            .build();
+    EntityInterface testCase = mockEntity(Entity.TEST_CASE, UUID.randomUUID(), "test_case");
+    ChangeDescription changeDescription =
+        changeDescription(
+            List.of(),
+            List.of(
+                new FieldChange()
+                    .withName(Entity.FIELD_DISPLAY_NAME)
+                    .withOldValue("Old Name")
+                    .withNewValue("New Name")),
+            List.of());
+
+    repository.propagateInheritedFieldsToChildren(
+        Entity.TEST_CASE,
+        testCase.getId().toString(),
+        changeDescription,
+        mappingWithUnregisteredChild,
+        testCase);
+
+    @SuppressWarnings("unchecked")
+    ArgumentCaptor<List<String>> targetsCaptor = ArgumentCaptor.forClass(List.class);
+    verify(searchClient).updateChildren(targetsCaptor.capture(), any(Pair.class), any(Pair.class));
+
+    assertEquals(List.of("cluster_tableColumn"), targetsCaptor.getValue());
+  }
+
+  @Test
   void deleteEntityByFqnPrefixUsesEntityIndex() throws IOException {
     EntityInterface entity = mockEntity(Entity.TABLE, UUID.randomUUID(), "orders");
 

--- a/openmetadata-service/src/test/java/org/openmetadata/service/search/SearchRepositoryBehaviorTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/search/SearchRepositoryBehaviorTest.java
@@ -793,7 +793,7 @@ class SearchRepositoryBehaviorTest {
   }
 
   @Test
-  void propagateInheritedFieldsToChildrenSkipsUnregisteredChildAliases() throws IOException {
+  void propagateInheritedFieldsToChildrenIncludesUnregisteredChildAliases() throws IOException {
     IndexMapping mappingWithUnregisteredChild =
         IndexMapping.builder()
             .indexName("test_case_search_index")
@@ -823,7 +823,8 @@ class SearchRepositoryBehaviorTest {
     ArgumentCaptor<List<String>> targetsCaptor = ArgumentCaptor.forClass(List.class);
     verify(searchClient).updateChildren(targetsCaptor.capture(), any(Pair.class), any(Pair.class));
 
-    assertEquals(List.of("cluster_tableColumn"), targetsCaptor.getValue());
+    assertEquals(
+        List.of("cluster_unregisteredChild", "cluster_tableColumn"), targetsCaptor.getValue());
   }
 
   @Test

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DataQuality/IncidentManagerAfterOwnerChange.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DataQuality/IncidentManagerAfterOwnerChange.spec.ts
@@ -27,7 +27,11 @@ import { createNewPage, redirectToHomePage } from '../../../utils/common';
 import { sidebarClick } from '../../../utils/sidebar';
 
 type IncidentListResponse = {
-  data?: Array<{ testCaseReference?: { fullyQualifiedName?: string } }>;
+  data?: Array<{
+    domains?: unknown;
+    owners?: unknown;
+    testCaseReference?: { fullyQualifiedName?: string };
+  }>;
 };
 
 type TestCaseSearchResponse = {
@@ -159,6 +163,23 @@ test('Incident Manager renders after a test case owner change', async ({
     });
 
     expect(exactIncidentListResponse.status()).toBe(200);
+    const exactIncidentListBody =
+      (await exactIncidentListResponse.json()) as IncidentListResponse;
+    expect(Array.isArray(exactIncidentListBody.data)).toBe(true);
+
+    const exactIncident = exactIncidentListBody.data?.find(
+      (incident) =>
+        incident.testCaseReference?.fullyQualifiedName === testCaseFqn
+    );
+
+    if (!exactIncident) {
+      throw new Error(
+        'Expected patched test case incident in latest incident response'
+      );
+    }
+
+    expect(exactIncident).not.toHaveProperty('owners');
+    expect(exactIncident).not.toHaveProperty('domains');
 
     const pageIncidentListResponse = page.waitForResponse(
       (response) =>

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DataQuality/IncidentManagerAfterOwnerChange.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DataQuality/IncidentManagerAfterOwnerChange.spec.ts
@@ -1,0 +1,186 @@
+/*
+ *  Copyright 2026 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+/**
+ * Regression for issue #29484. Updating a TestCase owner used to propagate
+ * inherited parent fields into time-series incident docs, adding top-level
+ * `owners` to TestCaseResolutionStatus search documents. The next latest
+ * Incident Manager search then failed Jackson deserialization with
+ * "Unrecognized field \"owners\"".
+ */
+
+import test, { expect } from '@playwright/test';
+import { SidebarItem } from '../../../constant/sidebar';
+import { TableClass } from '../../../support/entity/TableClass';
+import { UserClass } from '../../../support/user/UserClass';
+import { createNewPage, redirectToHomePage } from '../../../utils/common';
+import { sidebarClick } from '../../../utils/sidebar';
+
+type IncidentListResponse = {
+  data?: Array<{ testCaseReference?: { fullyQualifiedName?: string } }>;
+};
+
+type TestCaseSearchResponse = {
+  hits?: {
+    hits?: Array<{
+      _source?: {
+        owners?: Array<{ id?: string }>;
+      };
+    }>;
+  };
+};
+
+const INCIDENT_LIST_PATH =
+  '/api/v1/dataQuality/testCases/testCaseIncidentStatus/search/list';
+
+test.use({ storageState: 'playwright/.auth/admin.json' });
+
+test('Incident Manager renders after a test case owner change', async ({
+  browser,
+  page,
+}) => {
+  test.setTimeout(180_000);
+
+  const { apiContext, afterAction } = await createNewPage(browser);
+  const table = new TableClass();
+  const owner = new UserClass();
+
+  try {
+    await table.create(apiContext);
+    const testCase = await table.createTestCase(apiContext);
+    const testCaseFqn = testCase.fullyQualifiedName as string;
+    const testCaseId = testCase.id as string;
+
+    await table.addTestCaseResult(apiContext, testCaseFqn, {
+      result: 'owner propagation regression',
+      testCaseStatus: 'Failed',
+      timestamp: Date.now(),
+    });
+
+    await expect
+      .poll(
+        async () => {
+          const res = await apiContext.get(INCIDENT_LIST_PATH, {
+            params: {
+              latest: 'true',
+              include: 'non-deleted',
+              limit: '15',
+              offset: '0',
+              testCaseFQN: testCaseFqn,
+            },
+          });
+
+          if (res.status() !== 200) {
+            return false;
+          }
+
+          const body = (await res.json()) as IncidentListResponse;
+
+          return (
+            body.data?.some(
+              (incident) =>
+                incident.testCaseReference?.fullyQualifiedName === testCaseFqn
+            ) ?? false
+          );
+        },
+        {
+          message: 'incident status endpoint must index the failed test case',
+          timeout: 120_000,
+          intervals: [1_000, 2_000, 5_000],
+        }
+      )
+      .toBe(true);
+
+    await owner.create(apiContext);
+
+    const patchRes = await apiContext.patch(
+      `/api/v1/dataQuality/testCases/${testCaseId}`,
+      {
+        data: [
+          {
+            op: 'add',
+            path: '/owners',
+            value: [{ id: owner.responseData.id, type: 'user' }],
+          },
+        ],
+        headers: {
+          'Content-Type': 'application/json-patch+json',
+        },
+      }
+    );
+
+    expect(patchRes.status()).toBeLessThan(400);
+
+    await expect
+      .poll(
+        async () => {
+          const res = await apiContext.get(
+            `/api/v1/search/query?q=fullyQualifiedName:%22${encodeURIComponent(
+              testCaseFqn
+            )}%22&index=test_case_search_index`
+          );
+
+          if (res.status() !== 200) {
+            return false;
+          }
+
+          const body = (await res.json()) as TestCaseSearchResponse;
+          const owners = body.hits?.hits?.[0]?._source?.owners ?? [];
+
+          return owners.some(
+            (ownerRef) => ownerRef.id === owner.responseData.id
+          );
+        },
+        {
+          message: 'test case search doc must reflect the patched owner',
+          timeout: 60_000,
+          intervals: [1_000, 2_000, 5_000],
+        }
+      )
+      .toBe(true);
+
+    const exactIncidentListResponse = await apiContext.get(INCIDENT_LIST_PATH, {
+      params: {
+        latest: 'true',
+        include: 'non-deleted',
+        limit: '15',
+        offset: '0',
+      },
+    });
+
+    expect(exactIncidentListResponse.status()).toBe(200);
+
+    const pageIncidentListResponse = page.waitForResponse(
+      (response) =>
+        response.url().includes(INCIDENT_LIST_PATH) &&
+        response.request().method() === 'GET'
+    );
+
+    await redirectToHomePage(page);
+    await sidebarClick(page, SidebarItem.INCIDENT_MANAGER);
+
+    const response = await pageIncidentListResponse;
+    expect(response.status()).toBe(200);
+
+    const errorToast = page
+      .locator('[data-testid="alert-bar"]')
+      .filter({ hasText: /Unrecognized field|owners/i });
+    await expect(errorToast).toHaveCount(0);
+  } finally {
+    await table.delete(apiContext).catch(() => undefined);
+    if (owner.responseData.id) {
+      await owner.delete(apiContext).catch(() => undefined);
+    }
+    await afterAction();
+  }
+});


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:

Fixes #29484

This prevents generic inherited-field propagation from writing parent TestCase fields into time-series child indexes such as `testCaseResolutionStatus` and `testCaseResult`, which can pollute strict time-series schemas and break latest incident search deserialization.

#
### Type of change:

- [x] Bug fix

#
### High-level design:

N/A — small change.

#
### Tests:

#### Use cases covered

- Updating a TestCase owner/domain/displayName does not add unsupported top-level fields to incident search documents.
- Latest incident search remains readable after parent TestCase changes.
- Non-time-series child indexes still receive inherited-field propagation.

#### Unit tests

- [x] I added unit tests for the new/changed logic.
- Files added/updated: `SearchRepositoryBehaviorTest.java`
- Coverage %: Not measured.

#### Backend integration tests

- [x] I added integration tests in `openmetadata-integration-tests/` for new/changed API behavior.
- Files added/updated: `IncidentPaginationIT.java`

#### Ingestion integration tests

- [x] Not applicable (no ingestion changes).

#### Playwright (UI) tests

- [x] Not applicable (no UI changes).

#### Manual testing performed

- `mvn -pl openmetadata-service,openmetadata-integration-tests spotless:apply`
- `mvn -pl openmetadata-service '-Dtest=SearchRepositoryBehaviorTest#propagateInheritedFieldsToChildren*' test`
- `git diff --check`
- Attempted `mvn -pl openmetadata-integration-tests -DskipTests test-compile`; blocked by existing unrelated compile errors in `EntityRelationshipCleanupIT`.

#
### UI screen recording / screenshots:

Not applicable.

#
### Checklist:

- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] My PR title is `Fixes <issue-number>: <short explanation>`
- [x] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.
- [ ] For UI changes: I attached a screen recording and/or screenshots above.
- [x] I have added tests (unit / integration / Playwright as applicable) and listed them above.

<!-- Bug fix
- [x] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Prevents `propagateInheritedFieldsToChildren` from writing parent TestCase fields (owners, domains, displayName) into time-series child indexes (`testCaseResolutionStatus`, `testCaseResult`), which was polluting those strict schemas and causing Jackson deserialization failures on the latest-incident search listing.

- **Core fix (`SearchRepository.java`)**: Extracts a `filterChildAliasesByCapability` helper (also reused for the existing soft-delete path) and filters out child aliases registered as time-series before calling `searchClient.updateChildren`, while correctly prepending the cluster alias in the same stream.
- **Unit tests (`SearchRepositoryBehaviorTest.java`)**: Three new `@Test` methods cover the all-time-series case (no `updateChildren` call), the mixed case (only non-time-series aliases receive the update), and the unregistered-alias pass-through case.
- **Integration + E2E tests**: `IncidentPaginationIT` adds a full round-trip assertion that `owners`/`domains` are absent from the `_source` of an incident doc after a TestCase PUT; the Playwright spec navigates to the Incident Manager and verifies no deserialization error toast appears.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge. The change is narrowly scoped to the inherited-field propagation path and the soft-delete alias-filtering path; existing non-time-series children are unaffected, and the domain propagation path is deliberately left untouched since domain children are not time-series indexes.

The fix is correct and well-tested at three levels (unit, integration, E2E). The factored-out `filterChildAliasesByCapability` helper is reused consistently, cluster-alias prepending is preserved, and the predicate `capability == null || !capability.isTimeSeries()` correctly passes unregistered aliases through — matching the documented and tested behaviour. No regressions were introduced in the soft-delete path, which previously had its own equivalent inline stream and now uses the same helper.

No files require special attention.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-service/src/main/java/org/openmetadata/service/search/SearchRepository.java | Core fix: time-series child aliases are now excluded from inherited-field propagation via `filterChildAliasesByCapability`; the same helper replaces the equivalent inline stream in the soft-delete path, keeping both code paths consistent. |
| openmetadata-service/src/test/java/org/openmetadata/service/search/SearchRepositoryBehaviorTest.java | Three targeted unit tests added; TEST_CASE added to the mock entity registry. Tests cover the all-time-series-children case, the mixed-children case, and the unregistered-alias pass-through. `TEST_CASE_MAPPING` correctly includes both time-series and non-time-series child aliases for the mixed test. |
| openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/IncidentPaginationIT.java | New integration test performs a TestCase PUT (setting owners, domains, displayName), waits for the test-case search doc to reflect the change, then asserts the corresponding incident doc's `_source` has neither `owners` nor `domains` fields. Correctly uses `awaitility` with `ignoreExceptions` to handle async indexing. |
| openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DataQuality/IncidentManagerAfterOwnerChange.spec.ts | New Playwright regression spec: creates a table+test case, triggers a failed result, patches the owner, waits for the test-case search doc to reflect the owner, then navigates to Incident Manager and asserts no deserialization-error toast. Correctly sets up `page.waitForResponse` before navigation. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[propagateInheritedFieldsToChildren] --> B{changeDescription != null\nAND childAliases not empty?}
    B -- No --> Z[Return — no-op]
    B -- Yes --> C[getInheritedFieldChanges]
    C --> D{updates script non-empty?}
    D -- No --> Z
    D -- Yes --> E{entityType == DOMAIN?}
    E -- Yes --> F[propagateToDomainChildren\nsubdomains + dataProducts]
    E -- No --> G[resolveParentFieldName]
    G --> H[filterChildAliasesByCapability\ncapability == null OR NOT isTimeSeries]
    H --> I{filtered list non-empty?}
    I -- No --> Z
    I -- Yes --> J[searchClient.updateChildren\nnon-time-series aliases only]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[propagateInheritedFieldsToChildren] --> B{changeDescription != null\nAND childAliases not empty?}
    B -- No --> Z[Return — no-op]
    B -- Yes --> C[getInheritedFieldChanges]
    C --> D{updates script non-empty?}
    D -- No --> Z
    D -- Yes --> E{entityType == DOMAIN?}
    E -- Yes --> F[propagateToDomainChildren\nsubdomains + dataProducts]
    E -- No --> G[resolveParentFieldName]
    G --> H[filterChildAliasesByCapability\ncapability == null OR NOT isTimeSeries]
    H --> I{filtered list non-empty?}
    I -- No --> Z
    I -- Yes --> J[searchClient.updateChildren\nnon-time-series aliases only]
```

</a>
</details>

<sub>Reviews (5): Last reviewed commit: ["Simplify child propagation control flow"](https://github.com/open-metadata/openmetadata/commit/e52eb52db24c9b360bd1612072ceb3b8848c7a57) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39885260)</sub>

<!-- /greptile_comment -->