### PR TITLE
Fixes #29484: Stop time-series field propagation (1.13 backport)

### DIFF
--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/IncidentPaginationIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/IncidentPaginationIT.java
@@ -2,9 +2,12 @@ package org.openmetadata.it.tests;
 
 import static org.awaitility.Awaitility.await;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
@@ -29,6 +32,7 @@ import org.openmetadata.schema.tests.type.TestCaseResolutionStatus;
 import org.openmetadata.schema.tests.type.TestCaseResolutionStatusTypes;
 import org.openmetadata.schema.type.Column;
 import org.openmetadata.schema.type.ColumnDataType;
+import org.openmetadata.schema.utils.JsonUtils;
 import org.openmetadata.sdk.client.OpenMetadataClient;
 import org.openmetadata.sdk.models.ListParams;
 import org.openmetadata.sdk.models.ListResponse;
@@ -36,6 +40,7 @@ import org.openmetadata.sdk.models.ListResponse;
 @Slf4j
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class IncidentPaginationIT {
+  private static final ObjectMapper MAPPER = new ObjectMapper();
 
   private static final int TEST_DATA_SIZE = 11;
   private static final int PAGE_SIZE = 5;
@@ -259,6 +264,69 @@ public class IncidentPaginationIT {
                   response.getPaging().getTotal(),
                   "Total count must reflect only the filtered group, not all groups");
             });
+  }
+
+  @Test
+  public void testTestCasePatchDoesNotPropagateToIncidentSearchSource() throws Exception {
+    SharedEntities shared = SharedEntities.get();
+    TestCase target = testCases.get(1);
+    ListParams params =
+        new ListParams()
+            .withLimit(1)
+            .withOffset(0)
+            .withLatest(true)
+            .addFilter("testCaseFQN", target.getFullyQualifiedName());
+    ListResponse<TestCaseResolutionStatus> initialResponse =
+        client.testCaseResolutionStatuses().searchList(params);
+    assertEquals(1, initialResponse.getData().size(), "Expected initial incident to be searchable");
+
+    TestCaseResolutionStatus incident =
+        JsonUtils.convertValue(initialResponse.getData().get(0), TestCaseResolutionStatus.class);
+    String displayName = "incident propagation " + System.currentTimeMillis();
+    TestCase fetched = client.testCases().get(target.getId().toString(), "owners,domains");
+    fetched.setOwners(List.of(shared.USER1_REF));
+    fetched.setDomains(List.of(shared.DOMAIN.getEntityReference()));
+    fetched.setDisplayName(displayName);
+    client.testCases().update(fetched.getId().toString(), fetched);
+
+    await("Incident search source should not receive parent propagation")
+        .atMost(Duration.ofSeconds(60))
+        .pollDelay(Duration.ofMillis(500))
+        .pollInterval(Duration.ofSeconds(1))
+        .ignoreExceptions()
+        .untilAsserted(
+            () -> {
+              JsonNode testCaseSource =
+                  searchSource("test_case_search_index", target.getId().toString());
+              assertEquals(
+                  displayName,
+                  testCaseSource.path("displayName").asText(),
+                  "Test case search doc should receive its own displayName update");
+
+              JsonNode source = searchIncidentSource(incident.getId().toString());
+              assertFalse(
+                  displayName.equals(source.path("testCase").path("displayName").asText()),
+                  "Incident search source must not receive parent displayName propagation");
+              assertFalse(source.has("owners"), "Incident search source must not contain owners");
+              assertFalse(source.has("domains"), "Incident search source must not contain domains");
+
+              ListResponse<TestCaseResolutionStatus> response =
+                  client.testCaseResolutionStatuses().searchList(params);
+              assertEquals(1, response.getData().size(), "Incident latest search should not fail");
+            });
+  }
+
+  private JsonNode searchIncidentSource(String incidentId) throws Exception {
+    return searchSource("test_case_resolution_status_search_index", incidentId);
+  }
+
+  private JsonNode searchSource(String indexName, String id) throws Exception {
+    String searchResponse = client.search().query("id:" + id).index(indexName).size(1).execute();
+    JsonNode hits = MAPPER.readTree(searchResponse).path("hits").path("hits");
+    assertTrue(
+        hits.isArray() && !hits.isEmpty(),
+        "Document should be present in search index " + indexName);
+    return hits.get(0).path("_source");
   }
 
   private Table createTestTable() throws Exception {

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/SearchRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/SearchRepository.java
@@ -79,6 +79,7 @@ import java.util.TreeSet;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Function;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import lombok.Getter;
@@ -129,6 +130,7 @@ import org.openmetadata.service.events.lifecycle.handlers.SearchIndexHandler;
 import org.openmetadata.service.jdbi3.EntityRepository;
 import org.openmetadata.service.monitoring.RequestLatencyContext;
 import org.openmetadata.service.resources.settings.SettingsCache;
+import org.openmetadata.service.search.capability.EntityIndexCapability;
 import org.openmetadata.service.search.capability.EntityIndexCapabilityRegistry;
 import org.openmetadata.service.search.elasticsearch.ElasticSearchClient;
 import org.openmetadata.service.search.indexes.ColumnSearchIndex;
@@ -1680,31 +1682,37 @@ public class SearchRepository {
       IndexMapping indexMapping,
       EntityInterface entity)
       throws IOException {
-    if (changeDescription == null) {
-      return;
+    if (changeDescription != null && !nullOrEmpty(indexMapping.getChildAliases())) {
+      Pair<String, Map<String, Object>> updates =
+          getInheritedFieldChanges(changeDescription, entity, entityType);
+      if (updates.getKey() != null && !updates.getKey().isEmpty()) {
+        if (entityType.equalsIgnoreCase(Entity.DOMAIN)) {
+          propagateToDomainChildren(entityId, indexMapping, updates);
+        } else {
+          String parentFieldName = resolveParentFieldName(entityType, updates);
+          Pair<String, String> parentMatch = new ImmutablePair<>(parentFieldName, entityId);
+          List<String> entityChildren =
+              filterChildAliasesByCapability(
+                  indexMapping, capability -> capability == null || !capability.isTimeSeries());
+          if (!nullOrEmpty(entityChildren)) {
+            searchClient.updateChildren(entityChildren, parentMatch, updates);
+          }
+        }
+      }
     }
+  }
 
-    Pair<String, Map<String, Object>> updates =
-        getInheritedFieldChanges(changeDescription, entity, entityType);
-    if (updates.getKey() == null || updates.getKey().isEmpty()) {
-      return;
-    }
-
-    List<String> childAliases = indexMapping.getChildAliases(clusterAlias);
+  private List<String> filterChildAliasesByCapability(
+      IndexMapping indexMapping, Predicate<EntityIndexCapability> includeCapability) {
+    List<String> childAliases = indexMapping.getChildAliases();
     if (nullOrEmpty(childAliases)) {
-      return;
+      return List.of();
     }
-
-    // Domain has subdomains (parent.id) and data products (domains.id) - handle separately
-    if (entityType.equalsIgnoreCase(Entity.DOMAIN)) {
-      propagateToDomainChildren(entityId, indexMapping, updates);
-      return;
-    }
-
-    // Other entities: resolve parent field name and propagate to children
-    String parentFieldName = resolveParentFieldName(entityType, updates);
-    Pair<String, String> parentMatch = new ImmutablePair<>(parentFieldName, entityId);
-    searchClient.updateChildren(childAliases, parentMatch, updates);
+    boolean hasClusterAlias = !nullOrEmpty(clusterAlias);
+    return childAliases.stream()
+        .filter(alias -> includeCapability.test(EntityIndexCapabilityRegistry.get(alias)))
+        .map(alias -> hasClusterAlias ? clusterAlias + INDEX_NAME_SEPARATOR + alias : alias)
+        .toList();
   }
 
   private String resolveParentFieldName(
@@ -2574,12 +2582,7 @@ public class SearchRepository {
     // Each childAlias is an entity-type name (per indexMapping.json). Use the typed script's
     // capability check so we never apply soft-delete to an index whose schema lacks `deleted`.
     SoftDeleteScript script = new SoftDeleteScript(delete);
-    boolean hasClusterAlias = clusterAlias != null && !clusterAlias.isEmpty();
-    List<String> targets =
-        indexMapping.getChildAliases().stream()
-            .filter(a -> script.compatibleWith(EntityIndexCapabilityRegistry.get(a)))
-            .map(a -> hasClusterAlias ? clusterAlias + IndexMapping.INDEX_NAME_SEPARATOR + a : a)
-            .toList();
+    List<String> targets = filterChildAliasesByCapability(indexMapping, script::compatibleWith);
     if (targets.isEmpty()) {
       return;
     }

--- a/openmetadata-service/src/test/java/org/openmetadata/service/search/SearchRepositoryBehaviorTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/search/SearchRepositoryBehaviorTest.java
@@ -158,6 +158,7 @@ class SearchRepositoryBehaviorTest {
           Entity.DATABASE_SERVICE,
           Entity.DATABASE,
           Entity.TEST_SUITE,
+          Entity.TEST_CASE,
           Entity.GLOSSARY,
           Entity.CLASSIFICATION,
           Entity.QUERY);
@@ -706,6 +707,120 @@ class SearchRepositoryBehaviorTest {
     verify(searchClient)
         .updateChildren(
             eq(List.of("cluster_data_product_search_index")), any(Pair.class), any(Pair.class));
+  }
+
+  @Test
+  void propagateInheritedFieldsToChildrenSkipsAllChangesForTimeSeriesChildren() throws IOException {
+    IndexMapping timeSeriesOnlyMapping =
+        IndexMapping.builder()
+            .indexName("test_case_search_index")
+            .alias("testCase")
+            .childAliases(List.of(Entity.TEST_CASE_RESOLUTION_STATUS, Entity.TEST_CASE_RESULT))
+            .indexMappingFile("/elasticsearch/%s/test_case_index_mapping.json")
+            .build();
+    EntityInterface testCase = mockEntity(Entity.TEST_CASE, UUID.randomUUID(), "test_case");
+    when(testCase.getOwners())
+        .thenReturn(List.of(new EntityReference().withId(UUID.randomUUID()).withType(Entity.USER)));
+    when(testCase.getDomains())
+        .thenReturn(
+            List.of(new EntityReference().withId(UUID.randomUUID()).withType(Entity.DOMAIN)));
+    ChangeDescription changeDescription =
+        changeDescription(
+            List.of(
+                new FieldChange().withName(Entity.FIELD_OWNERS),
+                new FieldChange().withName(Entity.FIELD_DOMAINS)),
+            List.of(
+                new FieldChange()
+                    .withName(Entity.FIELD_DISPLAY_NAME)
+                    .withOldValue("Old Name")
+                    .withNewValue("New Name")),
+            List.of());
+
+    repository.propagateInheritedFieldsToChildren(
+        Entity.TEST_CASE,
+        testCase.getId().toString(),
+        changeDescription,
+        timeSeriesOnlyMapping,
+        testCase);
+
+    verify(searchClient, never()).updateChildren(any(List.class), any(Pair.class), any(Pair.class));
+  }
+
+  @Test
+  void propagateInheritedFieldsToChildrenOnlyTargetsNonTimeSeriesChildren() throws IOException {
+    EntityInterface testCase = mockEntity(Entity.TEST_CASE, UUID.randomUUID(), "test_case");
+    when(testCase.getOwners())
+        .thenReturn(List.of(new EntityReference().withId(UUID.randomUUID()).withType(Entity.USER)));
+    when(testCase.getDomains())
+        .thenReturn(
+            List.of(new EntityReference().withId(UUID.randomUUID()).withType(Entity.DOMAIN)));
+    ChangeDescription changeDescription =
+        changeDescription(
+            List.of(
+                new FieldChange().withName(Entity.FIELD_OWNERS),
+                new FieldChange().withName(Entity.FIELD_DOMAINS)),
+            List.of(
+                new FieldChange()
+                    .withName(Entity.FIELD_DISPLAY_NAME)
+                    .withOldValue("Old Name")
+                    .withNewValue("New Name")),
+            List.of());
+
+    repository.propagateInheritedFieldsToChildren(
+        Entity.TEST_CASE,
+        testCase.getId().toString(),
+        changeDescription,
+        TEST_CASE_MAPPING,
+        testCase);
+
+    @SuppressWarnings("unchecked")
+    ArgumentCaptor<List<String>> targetsCaptor = ArgumentCaptor.forClass(List.class);
+    @SuppressWarnings("unchecked")
+    ArgumentCaptor<Pair<String, Map<String, Object>>> updatesCaptor =
+        ArgumentCaptor.forClass(Pair.class);
+    verify(searchClient)
+        .updateChildren(targetsCaptor.capture(), any(Pair.class), updatesCaptor.capture());
+
+    assertEquals(List.of("cluster_tableColumn"), targetsCaptor.getValue());
+    String entityChildScript = updatesCaptor.getValue().getLeft();
+    assertTrue(entityChildScript.contains(Entity.FIELD_OWNERS));
+    assertTrue(entityChildScript.contains(Entity.FIELD_DOMAINS));
+    assertTrue(entityChildScript.contains(Entity.FIELD_DISPLAY_NAME));
+  }
+
+  @Test
+  void propagateInheritedFieldsToChildrenIncludesUnregisteredChildAliases() throws IOException {
+    IndexMapping mappingWithUnregisteredChild =
+        IndexMapping.builder()
+            .indexName("test_case_search_index")
+            .alias("testCase")
+            .childAliases(List.of("unregisteredChild", Entity.TABLE_COLUMN))
+            .indexMappingFile("/elasticsearch/%s/test_case_index_mapping.json")
+            .build();
+    EntityInterface testCase = mockEntity(Entity.TEST_CASE, UUID.randomUUID(), "test_case");
+    ChangeDescription changeDescription =
+        changeDescription(
+            List.of(),
+            List.of(
+                new FieldChange()
+                    .withName(Entity.FIELD_DISPLAY_NAME)
+                    .withOldValue("Old Name")
+                    .withNewValue("New Name")),
+            List.of());
+
+    repository.propagateInheritedFieldsToChildren(
+        Entity.TEST_CASE,
+        testCase.getId().toString(),
+        changeDescription,
+        mappingWithUnregisteredChild,
+        testCase);
+
+    @SuppressWarnings("unchecked")
+    ArgumentCaptor<List<String>> targetsCaptor = ArgumentCaptor.forClass(List.class);
+    verify(searchClient).updateChildren(targetsCaptor.capture(), any(Pair.class), any(Pair.class));
+
+    assertEquals(
+        List.of("cluster_unregisteredChild", "cluster_tableColumn"), targetsCaptor.getValue());
   }
 
   @Test

--- a/openmetadata-service/src/test/java/org/openmetadata/service/search/SearchUtilsTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/search/SearchUtilsTest.java
@@ -19,7 +19,6 @@ import jakarta.json.JsonArray;
 import jakarta.json.JsonObject;
 import java.io.StringReader;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DataQuality/IncidentManagerAfterOwnerChange.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DataQuality/IncidentManagerAfterOwnerChange.spec.ts
@@ -1,0 +1,207 @@
+/*
+ *  Copyright 2026 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+/**
+ * Regression for issue #29484. Updating a TestCase owner used to propagate
+ * inherited parent fields into time-series incident docs, adding top-level
+ * `owners` to TestCaseResolutionStatus search documents. The next latest
+ * Incident Manager search then failed Jackson deserialization with
+ * "Unrecognized field \"owners\"".
+ */
+
+import test, { expect } from '@playwright/test';
+import { SidebarItem } from '../../../constant/sidebar';
+import { TableClass } from '../../../support/entity/TableClass';
+import { UserClass } from '../../../support/user/UserClass';
+import { createNewPage, redirectToHomePage } from '../../../utils/common';
+import { sidebarClick } from '../../../utils/sidebar';
+
+type IncidentListResponse = {
+  data?: Array<{
+    domains?: unknown;
+    owners?: unknown;
+    testCaseReference?: { fullyQualifiedName?: string };
+  }>;
+};
+
+type TestCaseSearchResponse = {
+  hits?: {
+    hits?: Array<{
+      _source?: {
+        owners?: Array<{ id?: string }>;
+      };
+    }>;
+  };
+};
+
+const INCIDENT_LIST_PATH =
+  '/api/v1/dataQuality/testCases/testCaseIncidentStatus/search/list';
+
+test.use({ storageState: 'playwright/.auth/admin.json' });
+
+test('Incident Manager renders after a test case owner change', async ({
+  browser,
+  page,
+}) => {
+  test.setTimeout(180_000);
+
+  const { apiContext, afterAction } = await createNewPage(browser);
+  const table = new TableClass();
+  const owner = new UserClass();
+
+  try {
+    await table.create(apiContext);
+    const testCase = await table.createTestCase(apiContext);
+    const testCaseFqn = testCase.fullyQualifiedName as string;
+    const testCaseId = testCase.id as string;
+
+    await table.addTestCaseResult(apiContext, testCaseFqn, {
+      result: 'owner propagation regression',
+      testCaseStatus: 'Failed',
+      timestamp: Date.now(),
+    });
+
+    await expect
+      .poll(
+        async () => {
+          const res = await apiContext.get(INCIDENT_LIST_PATH, {
+            params: {
+              latest: 'true',
+              include: 'non-deleted',
+              limit: '15',
+              offset: '0',
+              testCaseFQN: testCaseFqn,
+            },
+          });
+
+          if (res.status() !== 200) {
+            return false;
+          }
+
+          const body = (await res.json()) as IncidentListResponse;
+
+          return (
+            body.data?.some(
+              (incident) =>
+                incident.testCaseReference?.fullyQualifiedName === testCaseFqn
+            ) ?? false
+          );
+        },
+        {
+          message: 'incident status endpoint must index the failed test case',
+          timeout: 120_000,
+          intervals: [1_000, 2_000, 5_000],
+        }
+      )
+      .toBe(true);
+
+    await owner.create(apiContext);
+
+    const patchRes = await apiContext.patch(
+      `/api/v1/dataQuality/testCases/${testCaseId}`,
+      {
+        data: [
+          {
+            op: 'add',
+            path: '/owners',
+            value: [{ id: owner.responseData.id, type: 'user' }],
+          },
+        ],
+        headers: {
+          'Content-Type': 'application/json-patch+json',
+        },
+      }
+    );
+
+    expect(patchRes.status()).toBeLessThan(400);
+
+    await expect
+      .poll(
+        async () => {
+          const res = await apiContext.get(
+            `/api/v1/search/query?q=fullyQualifiedName:%22${encodeURIComponent(
+              testCaseFqn
+            )}%22&index=test_case_search_index`
+          );
+
+          if (res.status() !== 200) {
+            return false;
+          }
+
+          const body = (await res.json()) as TestCaseSearchResponse;
+          const owners = body.hits?.hits?.[0]?._source?.owners ?? [];
+
+          return owners.some(
+            (ownerRef) => ownerRef.id === owner.responseData.id
+          );
+        },
+        {
+          message: 'test case search doc must reflect the patched owner',
+          timeout: 60_000,
+          intervals: [1_000, 2_000, 5_000],
+        }
+      )
+      .toBe(true);
+
+    const exactIncidentListResponse = await apiContext.get(INCIDENT_LIST_PATH, {
+      params: {
+        latest: 'true',
+        include: 'non-deleted',
+        limit: '15',
+        offset: '0',
+      },
+    });
+
+    expect(exactIncidentListResponse.status()).toBe(200);
+    const exactIncidentListBody =
+      (await exactIncidentListResponse.json()) as IncidentListResponse;
+    expect(Array.isArray(exactIncidentListBody.data)).toBe(true);
+
+    const exactIncident = exactIncidentListBody.data?.find(
+      (incident) =>
+        incident.testCaseReference?.fullyQualifiedName === testCaseFqn
+    );
+
+    if (!exactIncident) {
+      throw new Error(
+        'Expected patched test case incident in latest incident response'
+      );
+    }
+
+    expect(exactIncident).not.toHaveProperty('owners');
+    expect(exactIncident).not.toHaveProperty('domains');
+
+    const pageIncidentListResponse = page.waitForResponse(
+      (response) =>
+        response.url().includes(INCIDENT_LIST_PATH) &&
+        response.request().method() === 'GET'
+    );
+
+    await redirectToHomePage(page);
+    await sidebarClick(page, SidebarItem.INCIDENT_MANAGER);
+
+    const response = await pageIncidentListResponse;
+    expect(response.status()).toBe(200);
+
+    const errorToast = page
+      .locator('[data-testid="alert-bar"]')
+      .filter({ hasText: /Unrecognized field|owners/i });
+    await expect(errorToast).toHaveCount(0);
+  } finally {
+    await table.delete(apiContext).catch(() => undefined);
+    if (owner.responseData.id) {
+      await owner.delete(apiContext).catch(() => undefined);
+    }
+    await afterAction();
+  }
+});


### PR DESCRIPTION
### Describe your changes:

Fixes #29484

Backport of #29485 to the **1.13** release branch. Updating a TestCase's inherited fields (owners/domains/displayName) was propagating into its time-series children (`testCaseResolutionStatus`, `testCaseResult`), adding top-level `owners`/`domains` to incident search docs and then breaking the "latest" Incident Manager search with a Jackson `Unrecognized field "owners"` error. `SearchRepository` now filters child aliases by capability via a shared `filterChildAliasesByCapability` helper so inherited-field propagation skips time-series indices (soft-delete propagation reuses the same helper). Verified with a new unit test (`SearchRepositoryBehaviorTest`), an integration test (`IncidentPaginationIT`), and a Playwright E2E (`IncidentManagerAfterOwnerChange`); `openmetadata-service` and `openmetadata-integration-tests` both compile clean on 1.13.

#
### Type of change:
- [x] Bug fix

#
### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

- [x] I have added a test that covers the exact scenario we are fixing.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a Jackson deserialization failure in the Incident Manager search by preventing inherited-field propagation (owners/domains/displayName) from reaching time-series child indices (`testCaseResolutionStatus`, `testCaseResult`). The root cause was that patching a `TestCase`'s inherited fields triggered `propagateInheritedFieldsToChildren`, which blindly pushed updates to all child aliases including time-series indices that don't define those fields in their schema.

- **`SearchRepository.java`**: Extracts a `filterChildAliasesByCapability` helper that filters child aliases by an `EntityIndexCapability` predicate; the inherited-field propagation now passes `capability == null || !capability.isTimeSeries()` (unregistered aliases pass through, time-series are excluded), and the existing soft-delete propagation is refactored to reuse the same helper.
- **Tests**: Three new unit tests in `SearchRepositoryBehaviorTest` cover time-series-only children (no `updateChildren` call), mixed children (only non-time-series targeted), and unregistered aliases (pass through); an integration test (`IncidentPaginationIT`) and a Playwright E2E (`IncidentManagerAfterOwnerChange.spec.ts`) round out coverage for the end-to-end scenario.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the fix is narrowly scoped, targets only the inherited-field propagation path, and is backed by unit, integration, and E2E tests.

The change introduces a shared filterChildAliasesByCapability helper that is functionally equivalent to the old soft-delete path and correctly gates inherited-field propagation on !isTimeSeries. Both use-sites are covered by tests that verify the exact alias lists passed to searchClient. No existing behavior is altered for non-time-series children.

No files require special attention — all changed files are well-tested and the logic is straightforward.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-service/src/main/java/org/openmetadata/service/search/SearchRepository.java | Core fix: adds filterChildAliasesByCapability helper that excludes time-series indices from inherited-field propagation; soft-delete propagation refactored to reuse the same helper — both paths are logically equivalent to their predecessors. |
| openmetadata-service/src/test/java/org/openmetadata/service/search/SearchRepositoryBehaviorTest.java | Three new unit tests cover time-series-only mapping (no propagation), mixed children (only non-time-series targeted), and unregistered aliases (pass-through) — all critical branches of the new predicate logic. |
| openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/IncidentPaginationIT.java | New integration test patches a TestCase's owner/domain/displayName and asserts that the incident search doc receives no owners/domains fields and that the latest-incident query still returns results. |
| openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DataQuality/IncidentManagerAfterOwnerChange.spec.ts | New E2E test exercises the full browser-visible regression path: creates a failed test case, adds an owner, waits for propagation, and asserts the Incident Manager page loads without an Unrecognized field error toast. |
| openmetadata-service/src/test/java/org/openmetadata/service/search/SearchUtilsTest.java | Trivial cleanup: removes an unused Arrays import. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[TestCase PATCH
ownersDomainsdisplayName] --> B[propagateInheritedFieldsToChildren]
    B --> C{changeDescription != null
 AND childAliases non-empty?}
    C -- No --> Z[No-op]
    C -- Yes --> D[getInheritedFieldChanges]
    D --> E{updates non-empty?}
    E -- No --> Z
    E -- Yes --> F{entityType == DOMAIN?}
    F -- Yes --> G[propagateToDomainChildren
subdomains + data products]
    F -- No --> H[filterChildAliasesByCapability
capability == null OR NOT isTimeSeries]
    H --> I{entityChildren non-empty?}
    I -- No --> Z
    I -- Yes --> J[searchClient.updateChildren
non-time-series children only]

    subgraph Excluded
        K[testCaseResolutionStatus isTimeSeries=true]
        L[testCaseResult isTimeSeries=true]
    end

    subgraph Included
        M[tableColumn isTimeSeries=false]
        N[unregistered alias capability=null]
    end

    H -.->|filtered out| K
    H -.->|filtered out| L
    H -.->|passes through| M
    H -.->|passes through| N
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[TestCase PATCH
ownersDomainsdisplayName] --> B[propagateInheritedFieldsToChildren]
    B --> C{changeDescription != null
 AND childAliases non-empty?}
    C -- No --> Z[No-op]
    C -- Yes --> D[getInheritedFieldChanges]
    D --> E{updates non-empty?}
    E -- No --> Z
    E -- Yes --> F{entityType == DOMAIN?}
    F -- Yes --> G[propagateToDomainChildren
subdomains + data products]
    F -- No --> H[filterChildAliasesByCapability
capability == null OR NOT isTimeSeries]
    H --> I{entityChildren non-empty?}
    I -- No --> Z
    I -- Yes --> J[searchClient.updateChildren
non-time-series children only]

    subgraph Excluded
        K[testCaseResolutionStatus isTimeSeries=true]
        L[testCaseResult isTimeSeries=true]
    end

    subgraph Included
        M[tableColumn isTimeSeries=false]
        N[unregistered alias capability=null]
    end

    H -.->|filtered out| K
    H -.->|filtered out| L
    H -.->|passes through| M
    H -.->|passes through| N
```

</a>
</details>

<sub>Reviews (2): Last reviewed commit: ["chore: remove unused import to satisfy s..."](https://github.com/open-metadata/openmetadata/commit/a07ef18c9859ac330aebbd65b828d70bba86c4b4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40002411)</sub>

<!-- /greptile_comment -->