### PR TITLE
Fixes #29484: Stop time-series field propagation (1.12.13 backport)

### DIFF
--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/IncidentPaginationIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/IncidentPaginationIT.java
@@ -2,9 +2,12 @@ package org.openmetadata.it.tests;
 
 import static org.awaitility.Awaitility.await;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
@@ -26,12 +29,14 @@ import org.openmetadata.schema.tests.type.TestCaseResolutionStatus;
 import org.openmetadata.schema.tests.type.TestCaseResolutionStatusTypes;
 import org.openmetadata.schema.type.Column;
 import org.openmetadata.schema.type.ColumnDataType;
+import org.openmetadata.schema.utils.JsonUtils;
 import org.openmetadata.sdk.client.OpenMetadataClient;
 import org.openmetadata.sdk.models.ListParams;
 import org.openmetadata.sdk.models.ListResponse;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class IncidentPaginationIT {
+  private static final ObjectMapper MAPPER = new ObjectMapper();
 
   private static final int TEST_DATA_SIZE = 11;
   private static final int PAGE_SIZE = 5;
@@ -200,6 +205,69 @@ public class IncidentPaginationIT {
         1,
         response.getPaging().getTotal(),
         "Total count must reflect only the filtered group, not all groups");
+  }
+
+  @Test
+  public void testTestCasePatchDoesNotPropagateToIncidentSearchSource() throws Exception {
+    SharedEntities shared = SharedEntities.get();
+    TestCase target = testCases.get(1);
+    ListParams params =
+        new ListParams()
+            .withLimit(1)
+            .withOffset(0)
+            .withLatest(true)
+            .addFilter("testCaseFQN", target.getFullyQualifiedName());
+    ListResponse<TestCaseResolutionStatus> initialResponse =
+        client.testCaseResolutionStatuses().searchList(params);
+    assertEquals(1, initialResponse.getData().size(), "Expected initial incident to be searchable");
+
+    TestCaseResolutionStatus incident =
+        JsonUtils.convertValue(initialResponse.getData().get(0), TestCaseResolutionStatus.class);
+    String displayName = "incident propagation " + System.currentTimeMillis();
+    TestCase fetched = client.testCases().get(target.getId().toString(), "owners,domains");
+    fetched.setOwners(List.of(shared.USER1_REF));
+    fetched.setDomains(List.of(shared.DOMAIN.getEntityReference()));
+    fetched.setDisplayName(displayName);
+    client.testCases().update(fetched.getId().toString(), fetched);
+
+    await("Incident search source should not receive parent propagation")
+        .atMost(Duration.ofSeconds(60))
+        .pollDelay(Duration.ofMillis(500))
+        .pollInterval(Duration.ofSeconds(1))
+        .ignoreExceptions()
+        .untilAsserted(
+            () -> {
+              JsonNode testCaseSource =
+                  searchSource("test_case_search_index", target.getId().toString());
+              assertEquals(
+                  displayName,
+                  testCaseSource.path("displayName").asText(),
+                  "Test case search doc should receive its own displayName update");
+
+              JsonNode source = searchIncidentSource(incident.getId().toString());
+              assertFalse(
+                  displayName.equals(source.path("testCase").path("displayName").asText()),
+                  "Incident search source must not receive parent displayName propagation");
+              assertFalse(source.has("owners"), "Incident search source must not contain owners");
+              assertFalse(source.has("domains"), "Incident search source must not contain domains");
+
+              ListResponse<TestCaseResolutionStatus> response =
+                  client.testCaseResolutionStatuses().searchList(params);
+              assertEquals(1, response.getData().size(), "Incident latest search should not fail");
+            });
+  }
+
+  private JsonNode searchIncidentSource(String incidentId) throws Exception {
+    return searchSource("test_case_resolution_status_search_index", incidentId);
+  }
+
+  private JsonNode searchSource(String indexName, String id) throws Exception {
+    String searchResponse = client.search().query("id:" + id).index(indexName).size(1).execute();
+    JsonNode hits = MAPPER.readTree(searchResponse).path("hits").path("hits");
+    assertTrue(
+        hits.isArray() && !hits.isEmpty(),
+        "Document should be present in search index " + indexName);
+    return hits.get(0).path("_source");
   }
 
   private Table createTestTable() throws Exception {

--- a/openmetadata-service/src/main/java/org/openmetadata/service/Entity.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/Entity.java
@@ -662,6 +662,10 @@ public final class Entity {
         || ENTITY_TS_REPOSITORY_MAP.containsKey(entityType);
   }
 
+  public static boolean hasEntityTimeSeriesRepository(@NonNull String entityType) {
+    return ENTITY_TS_REPOSITORY_MAP.containsKey(entityType);
+  }
+
   public static EntityTimeSeriesRepository<? extends EntityTimeSeriesInterface>
       getEntityTimeSeriesRepository(@NonNull String entityType) {
     EntityTimeSeriesRepository<? extends EntityTimeSeriesInterface> entityTimeSeriesRepository =

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/SearchRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/SearchRepository.java
@@ -1023,7 +1023,7 @@ public class SearchRepository {
       IndexMapping indexMapping,
       EntityInterface entity)
       throws IOException {
-    if (changeDescription == null) {
+    if (changeDescription == null || nullOrEmpty(indexMapping.getChildAliases())) {
       return;
     }
 
@@ -1032,21 +1032,29 @@ public class SearchRepository {
       return;
     }
 
-    List<String> childAliases = indexMapping.getChildAliases(clusterAlias);
-    if (nullOrEmpty(childAliases)) {
-      return;
-    }
-
-    // Domain has subdomains (parent.id) and data products (domains.id) - handle separately
     if (entityType.equalsIgnoreCase(Entity.DOMAIN)) {
       propagateToDomainChildren(entityId, indexMapping, updates);
       return;
     }
 
-    // Other entities: resolve parent field name and propagate to children
     String parentFieldName = resolveParentFieldName(entityType, updates);
     Pair<String, String> parentMatch = new ImmutablePair<>(parentFieldName, entityId);
-    searchClient.updateChildren(childAliases, parentMatch, updates);
+    List<String> entityChildren = getNonTimeSeriesChildAliases(indexMapping);
+    if (!nullOrEmpty(entityChildren)) {
+      searchClient.updateChildren(entityChildren, parentMatch, updates);
+    }
+  }
+
+  private List<String> getNonTimeSeriesChildAliases(IndexMapping indexMapping) {
+    List<String> childAliases = indexMapping.getChildAliases();
+    if (nullOrEmpty(childAliases)) {
+      return List.of();
+    }
+    boolean hasClusterAlias = !nullOrEmpty(clusterAlias);
+    return childAliases.stream()
+        .filter(alias -> !Entity.hasEntityTimeSeriesRepository(alias))
+        .map(alias -> hasClusterAlias ? clusterAlias + INDEX_NAME_SEPARATOR + alias : alias)
+        .toList();
   }
 
   private String resolveParentFieldName(

--- a/openmetadata-service/src/test/java/org/openmetadata/service/search/SearchRepositoryPropagationTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/search/SearchRepositoryPropagationTest.java
@@ -1,0 +1,155 @@
+package org.openmetadata.service.search;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.lang.reflect.Field;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import org.apache.commons.lang3.tuple.Pair;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.openmetadata.schema.EntityInterface;
+import org.openmetadata.schema.service.configuration.elasticsearch.ElasticSearchConfiguration;
+import org.openmetadata.schema.type.ChangeDescription;
+import org.openmetadata.schema.type.EntityReference;
+import org.openmetadata.schema.type.FieldChange;
+import org.openmetadata.search.IndexMapping;
+import org.openmetadata.search.IndexMappingLoader;
+import org.openmetadata.service.Entity;
+import org.openmetadata.service.events.lifecycle.EntityLifecycleEventDispatcher;
+import org.openmetadata.service.jdbi3.EntityTimeSeriesRepository;
+
+class SearchRepositoryPropagationTest {
+  private static SearchClient searchClientForConstructor;
+
+  private SearchClient searchClient;
+  private SearchRepository repository;
+
+  @BeforeEach
+  void setUp() {
+    searchClient = mock(SearchClient.class);
+    searchClientForConstructor = searchClient;
+    IndexMappingLoader mappingLoader = mock(IndexMappingLoader.class);
+    when(mappingLoader.getIndexMapping()).thenReturn(Map.<String, IndexMapping>of());
+    EntityLifecycleEventDispatcher dispatcher = mock(EntityLifecycleEventDispatcher.class);
+    try (var loaderMock = mockStatic(IndexMappingLoader.class);
+        var dispatcherMock = mockStatic(EntityLifecycleEventDispatcher.class)) {
+      loaderMock.when(IndexMappingLoader::getInstance).thenReturn(mappingLoader);
+      dispatcherMock.when(EntityLifecycleEventDispatcher::getInstance).thenReturn(dispatcher);
+      repository = new TestSearchRepository();
+    }
+    registerTimeSeriesRepository(Entity.TEST_CASE_RESOLUTION_STATUS);
+    registerTimeSeriesRepository(Entity.TEST_CASE_RESULT);
+  }
+
+  @AfterEach
+  void tearDown() {
+    removeTimeSeriesRepository(Entity.TEST_CASE_RESOLUTION_STATUS);
+    removeTimeSeriesRepository(Entity.TEST_CASE_RESULT);
+    searchClientForConstructor = null;
+  }
+
+  @Test
+  void propagateInheritedFieldsToChildrenSkipsAllTimeSeriesChildren() throws Exception {
+    IndexMapping mapping =
+        IndexMapping.builder()
+            .indexName("test_case_search_index")
+            .alias(Entity.TEST_CASE)
+            .childAliases(List.of(Entity.TEST_CASE_RESOLUTION_STATUS, Entity.TEST_CASE_RESULT))
+            .indexMappingFile("/elasticsearch/%s/test_case_index_mapping.json")
+            .build();
+    EntityInterface testCase = testCase();
+
+    repository.propagateInheritedFieldsToChildren(
+        Entity.TEST_CASE, testCase.getId().toString(), displayNameChange(), mapping, testCase);
+
+    verify(searchClient, never()).updateChildren(anyList(), any(Pair.class), any(Pair.class));
+  }
+
+  @Test
+  void propagateInheritedFieldsToChildrenTargetsOnlyNonTimeSeriesChildren() throws Exception {
+    IndexMapping mapping =
+        IndexMapping.builder()
+            .indexName("test_case_search_index")
+            .alias(Entity.TEST_CASE)
+            .childAliases(
+                List.of(
+                    Entity.TEST_CASE_RESOLUTION_STATUS,
+                    Entity.TABLE_COLUMN,
+                    Entity.TEST_CASE_RESULT))
+            .indexMappingFile("/elasticsearch/%s/test_case_index_mapping.json")
+            .build();
+    EntityInterface testCase = testCase();
+
+    repository.propagateInheritedFieldsToChildren(
+        Entity.TEST_CASE, testCase.getId().toString(), displayNameChange(), mapping, testCase);
+
+    @SuppressWarnings("unchecked")
+    ArgumentCaptor<List<String>> targetsCaptor = ArgumentCaptor.forClass(List.class);
+    verify(searchClient).updateChildren(targetsCaptor.capture(), any(Pair.class), any(Pair.class));
+
+    assertEquals(List.of("cluster_tableColumn"), targetsCaptor.getValue());
+  }
+
+  private EntityInterface testCase() {
+    UUID id = UUID.randomUUID();
+    EntityInterface entity = mock(EntityInterface.class);
+    EntityReference reference = new EntityReference().withId(id).withType(Entity.TEST_CASE);
+    when(entity.getId()).thenReturn(id);
+    when(entity.getEntityReference()).thenReturn(reference);
+    return entity;
+  }
+
+  private ChangeDescription displayNameChange() {
+    return new ChangeDescription()
+        .withFieldsAdded(List.of())
+        .withFieldsUpdated(
+            List.of(
+                new FieldChange()
+                    .withName(Entity.FIELD_DISPLAY_NAME)
+                    .withOldValue("old")
+                    .withNewValue("new")))
+        .withFieldsDeleted(List.of());
+  }
+
+  @SuppressWarnings({"unchecked", "rawtypes"})
+  private void registerTimeSeriesRepository(String entityType) {
+    timeSeriesRepositoryMap().put(entityType, mock(EntityTimeSeriesRepository.class));
+  }
+
+  private void removeTimeSeriesRepository(String entityType) {
+    timeSeriesRepositoryMap().remove(entityType);
+  }
+
+  @SuppressWarnings("unchecked")
+  private Map<String, Object> timeSeriesRepositoryMap() {
+    try {
+      Field field = Entity.class.getDeclaredField("ENTITY_TS_REPOSITORY_MAP");
+      field.setAccessible(true);
+      return (Map<String, Object>) field.get(null);
+    } catch (ReflectiveOperationException e) {
+      throw new IllegalStateException("Unable to access time-series repository map", e);
+    }
+  }
+
+  private static final class TestSearchRepository extends SearchRepository {
+    private TestSearchRepository() {
+      super(new ElasticSearchConfiguration().withClusterAlias("cluster"), 1);
+    }
+
+    @Override
+    public SearchClient buildSearchClient(ElasticSearchConfiguration config) {
+      return searchClientForConstructor;
+    }
+  }
+}

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DataQuality/IncidentManagerAfterOwnerChange.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DataQuality/IncidentManagerAfterOwnerChange.spec.ts
@@ -1,0 +1,207 @@
+/*
+ *  Copyright 2026 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+/**
+ * Regression for issue #29484. Updating a TestCase owner used to propagate
+ * inherited parent fields into time-series incident docs, adding top-level
+ * `owners` to TestCaseResolutionStatus search documents. The next latest
+ * Incident Manager search then failed Jackson deserialization with
+ * "Unrecognized field \"owners\"".
+ */
+
+import test, { expect } from '@playwright/test';
+import { SidebarItem } from '../../../constant/sidebar';
+import { TableClass } from '../../../support/entity/TableClass';
+import { UserClass } from '../../../support/user/UserClass';
+import { createNewPage, redirectToHomePage } from '../../../utils/common';
+import { sidebarClick } from '../../../utils/sidebar';
+
+type IncidentListResponse = {
+  data?: Array<{
+    domains?: unknown;
+    owners?: unknown;
+    testCaseReference?: { fullyQualifiedName?: string };
+  }>;
+};
+
+type TestCaseSearchResponse = {
+  hits?: {
+    hits?: Array<{
+      _source?: {
+        owners?: Array<{ id?: string }>;
+      };
+    }>;
+  };
+};
+
+const INCIDENT_LIST_PATH =
+  '/api/v1/dataQuality/testCases/testCaseIncidentStatus/search/list';
+
+test.use({ storageState: 'playwright/.auth/admin.json' });
+
+test('Incident Manager renders after a test case owner change', async ({
+  browser,
+  page,
+}) => {
+  test.setTimeout(180_000);
+
+  const { apiContext, afterAction } = await createNewPage(browser);
+  const table = new TableClass();
+  const owner = new UserClass();
+
+  try {
+    await table.create(apiContext);
+    const testCase = await table.createTestCase(apiContext);
+    const testCaseFqn = testCase.fullyQualifiedName as string;
+    const testCaseId = testCase.id as string;
+
+    await table.addTestCaseResult(apiContext, testCaseFqn, {
+      result: 'owner propagation regression',
+      testCaseStatus: 'Failed',
+      timestamp: Date.now(),
+    });
+
+    await expect
+      .poll(
+        async () => {
+          const res = await apiContext.get(INCIDENT_LIST_PATH, {
+            params: {
+              latest: 'true',
+              include: 'non-deleted',
+              limit: '15',
+              offset: '0',
+              testCaseFQN: testCaseFqn,
+            },
+          });
+
+          if (res.status() !== 200) {
+            return false;
+          }
+
+          const body = (await res.json()) as IncidentListResponse;
+
+          return (
+            body.data?.some(
+              (incident) =>
+                incident.testCaseReference?.fullyQualifiedName === testCaseFqn
+            ) ?? false
+          );
+        },
+        {
+          message: 'incident status endpoint must index the failed test case',
+          timeout: 120_000,
+          intervals: [1_000, 2_000, 5_000],
+        }
+      )
+      .toBe(true);
+
+    await owner.create(apiContext);
+
+    const patchRes = await apiContext.patch(
+      `/api/v1/dataQuality/testCases/${testCaseId}`,
+      {
+        data: [
+          {
+            op: 'add',
+            path: '/owners',
+            value: [{ id: owner.responseData.id, type: 'user' }],
+          },
+        ],
+        headers: {
+          'Content-Type': 'application/json-patch+json',
+        },
+      }
+    );
+
+    expect(patchRes.status()).toBeLessThan(400);
+
+    await expect
+      .poll(
+        async () => {
+          const res = await apiContext.get(
+            `/api/v1/search/query?q=fullyQualifiedName:%22${encodeURIComponent(
+              testCaseFqn
+            )}%22&index=test_case_search_index`
+          );
+
+          if (res.status() !== 200) {
+            return false;
+          }
+
+          const body = (await res.json()) as TestCaseSearchResponse;
+          const owners = body.hits?.hits?.[0]?._source?.owners ?? [];
+
+          return owners.some(
+            (ownerRef) => ownerRef.id === owner.responseData.id
+          );
+        },
+        {
+          message: 'test case search doc must reflect the patched owner',
+          timeout: 60_000,
+          intervals: [1_000, 2_000, 5_000],
+        }
+      )
+      .toBe(true);
+
+    const exactIncidentListResponse = await apiContext.get(INCIDENT_LIST_PATH, {
+      params: {
+        latest: 'true',
+        include: 'non-deleted',
+        limit: '15',
+        offset: '0',
+      },
+    });
+
+    expect(exactIncidentListResponse.status()).toBe(200);
+    const exactIncidentListBody =
+      (await exactIncidentListResponse.json()) as IncidentListResponse;
+    expect(Array.isArray(exactIncidentListBody.data)).toBe(true);
+
+    const exactIncident = exactIncidentListBody.data?.find(
+      (incident) =>
+        incident.testCaseReference?.fullyQualifiedName === testCaseFqn
+    );
+
+    if (!exactIncident) {
+      throw new Error(
+        'Expected patched test case incident in latest incident response'
+      );
+    }
+
+    expect(exactIncident).not.toHaveProperty('owners');
+    expect(exactIncident).not.toHaveProperty('domains');
+
+    const pageIncidentListResponse = page.waitForResponse(
+      (response) =>
+        response.url().includes(INCIDENT_LIST_PATH) &&
+        response.request().method() === 'GET'
+    );
+
+    await redirectToHomePage(page);
+    await sidebarClick(page, SidebarItem.INCIDENT_MANAGER);
+
+    const response = await pageIncidentListResponse;
+    expect(response.status()).toBe(200);
+
+    const errorToast = page
+      .locator('[data-testid="alert-bar"]')
+      .filter({ hasText: /Unrecognized field|owners/i });
+    await expect(errorToast).toHaveCount(0);
+  } finally {
+    await table.delete(apiContext).catch(() => undefined);
+    if (owner.responseData.id) {
+      await owner.delete(apiContext).catch(() => undefined);
+    }
+    await afterAction();
+  }
+});


### PR DESCRIPTION
Backport of #29485 to 1.12.13.\n\nChanges:\n- Skip registered time-series child aliases during inherited-field propagation on 1.12.13.\n- Add focused service regression coverage for time-series child filtering.\n- Carry over incident search regression coverage from the original PR.\n\nValidation:\n- mvn -pl common,openmetadata-spec,openmetadata-sdk,openmetadata-shaded-deps/elasticsearch-dep,openmetadata-shaded-deps/opensearch-dep -am -DskipTests install\n- mvn -pl openmetadata-service -Dtest=SearchRepositoryPropagationTest test

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This is a backport of #29485 to 1.12.13 that fixes a bug where updating a `TestCase`'s inherited fields (owners, domains, displayName) caused propagation into time-series child search documents (`TestCaseResolutionStatus`, `TestCaseResult`). Because those indices don't accept top-level `owners`/`domains` fields, the next Incident Manager search query would fail with a Jackson \"Unrecognized field\" deserialization error.

- **Core fix** (`SearchRepository.java`): Extracts a `getNonTimeSeriesChildAliases()` helper that filters out any alias backed by a time-series repository before calling `searchClient.updateChildren`, and guards the early-exit with the no-arg `getChildAliases()` check. Domain propagation is unaffected.
- **Entity helper** (`Entity.java`): Adds `hasEntityTimeSeriesRepository(String)` to expose a clean, public predicate over `ENTITY_TS_REPOSITORY_MAP`.
- **Test coverage**: Adds a focused unit test (`SearchRepositoryPropagationTest`), an integration-test scenario (`IncidentPaginationIT`), and a Playwright E2E spec (`IncidentManagerAfterOwnerChange.spec.ts`) that each verify the fix end-to-end.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is narrowly scoped to filtering time-series aliases out of inherited-field propagation, with no impact on domain propagation or other entity paths.

The fix is a focused, well-tested backport. The new getNonTimeSeriesChildAliases helper correctly filters using the already-established ENTITY_TS_REPOSITORY_MAP registry, the early-exit guard change is semantically equivalent to the original, and domain propagation is explicitly unaffected. Three levels of test coverage (unit, integration, E2E) validate the exact regression scenario.

No files require special attention.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-service/src/main/java/org/openmetadata/service/search/SearchRepository.java | Core fix: adds getNonTimeSeriesChildAliases() to filter time-series aliases before propagation; early-exit guard updated to no-arg getChildAliases(). Logic is correct and domain propagation is unaffected. |
| openmetadata-service/src/main/java/org/openmetadata/service/Entity.java | Adds hasEntityTimeSeriesRepository() public helper; minimal, correct change that delegates to ENTITY_TS_REPOSITORY_MAP.containsKey(). |
| openmetadata-service/src/test/java/org/openmetadata/service/search/SearchRepositoryPropagationTest.java | New unit test covering two scenarios: all-time-series children (no updateChildren call) and mixed children (only non-time-series alias with cluster prefix forwarded). Reflection-based setup/teardown correctly scopes state per test. |
| openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/IncidentPaginationIT.java | Adds integration-level regression test verifying that patching a TestCase does not propagate inherited fields into the incident search source; correctly awaits ES indexing before asserting. |
| openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DataQuality/IncidentManagerAfterOwnerChange.spec.ts | New Playwright E2E spec covering the full browser flow: creates table/test case, triggers a failure, patches owner, waits for search index, then navigates to Incident Manager and checks no deserialization error toast appears. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant API as REST API
    participant SR as SearchRepository
    participant E as Entity
    participant SC as SearchClient

    API->>SR: propagateInheritedFieldsToChildren(testCase, ...)
    SR->>SR: getChildAliases() — raw list check (early exit if empty)
    SR->>SR: getInheritedFieldChanges(changeDescription)
    SR->>SR: getNonTimeSeriesChildAliases(indexMapping)
    loop for each childAlias
        SR->>E: hasEntityTimeSeriesRepository(alias)
        E-->>SR: true (e.g. testCaseResolutionStatus) → skip
        E-->>SR: false (e.g. tableColumn) → keep + prepend clusterAlias
    end
    alt Non-time-series children exist
        SR->>SC: updateChildren(filteredAliases, parentMatch, updates)
    else All children are time-series
        SR-->>API: return (no-op)
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant API as REST API
    participant SR as SearchRepository
    participant E as Entity
    participant SC as SearchClient

    API->>SR: propagateInheritedFieldsToChildren(testCase, ...)
    SR->>SR: getChildAliases() — raw list check (early exit if empty)
    SR->>SR: getInheritedFieldChanges(changeDescription)
    SR->>SR: getNonTimeSeriesChildAliases(indexMapping)
    loop for each childAlias
        SR->>E: hasEntityTimeSeriesRepository(alias)
        E-->>SR: true (e.g. testCaseResolutionStatus) → skip
        E-->>SR: false (e.g. tableColumn) → keep + prepend clusterAlias
    end
    alt Non-time-series children exist
        SR->>SC: updateChildren(filteredAliases, parentMatch, updates)
    else All children are time-series
        SR-->>API: return (no-op)
    end
```

</a>
</details>

<sub>Reviews (2): Last reviewed commit: ["Fixes #29484: Stop time-series field pro..."](https://github.com/open-metadata/openmetadata/commit/51d5707ebbf5b03beda17e948b5fabc57ace255e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40004666)</sub>

<!-- /greptile_comment -->