### PR TITLE
Fix multi-node search inconsistency: preference + deterministic sort tiebreaker

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/search/VectorSearchResource.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/search/VectorSearchResource.java
@@ -17,11 +17,13 @@ import java.util.Collections;
 import lombok.extern.slf4j.Slf4j;
 import org.openmetadata.service.Entity;
 import org.openmetadata.service.resources.Collection;
+import org.openmetadata.service.search.SearchUtils;
 import org.openmetadata.service.search.vector.OpenSearchVectorService;
 import org.openmetadata.service.search.vector.utils.DTOs.VectorSearchRequest;
 import org.openmetadata.service.search.vector.utils.DTOs.VectorSearchResponse;
 import org.openmetadata.service.security.Authorizer;
 import org.openmetadata.service.security.DefaultAuthorizer;
+import org.openmetadata.service.security.policyevaluator.SubjectContext;
 
 @Slf4j
 @Path("/v1/search/vector")
@@ -56,7 +58,7 @@ public class VectorSearchResource {
       })
   public Response vectorSearchPost(
       @Context SecurityContext securityContext, VectorSearchRequest request) {
-    DefaultAuthorizer.getSubjectContext(securityContext);
+    SubjectContext subjectContext = DefaultAuthorizer.getSubjectContext(securityContext);
 
     if (request.query == null || request.query.isBlank()) {
       return Response.status(Response.Status.BAD_REQUEST)
@@ -88,7 +90,8 @@ public class VectorSearchResource {
               effectiveSize,
               effectiveFrom,
               effectiveK,
-              request.threshold);
+              request.threshold,
+              SearchUtils.searchPreferenceFor(subjectContext));
       return Response.ok(response).build();
     } catch (Exception e) {
       LOG.error("Vector search failed: {}", e.getMessage(), e);

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/SearchUtils.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/SearchUtils.java
@@ -12,6 +12,8 @@ import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import jakarta.json.JsonArray;
 import jakarta.json.JsonObject;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.security.KeyStoreException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -71,6 +73,24 @@ public final class SearchUtils {
       preference = subjectContext.user().getName();
     }
     return preference;
+  }
+
+  /**
+   * Append an OpenSearch {@code preference} routing key to a raw {@code _search} endpoint so all of
+   * a user's queries hit the same shard copy. Used by the vector/raw search paths that build the
+   * endpoint URL directly (the request-builder paths set preference on the builder instead).
+   */
+  public static String appendPreferenceParam(String endpoint, String preference) {
+    String result = endpoint;
+    if (!nullOrEmpty(preference)) {
+      String separator = endpoint.contains("?") ? "&" : "?";
+      result =
+          endpoint
+              + separator
+              + "preference="
+              + URLEncoder.encode(preference, StandardCharsets.UTF_8);
+    }
+    return result;
   }
 
   /** Aggregation name for the exact-match sub-agg (user-typed term only). */

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/SearchUtils.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/SearchUtils.java
@@ -60,6 +60,19 @@ public final class SearchUtils {
 
   private SearchUtils() {}
 
+  /**
+   * Stable search routing key so all of a user's queries hit the same shard copy. Without it,
+   * paginated and repeated searches bounce across replicas/shards on a multi-node cluster,
+   * returning reordered or different results for the same query.
+   */
+  public static String searchPreferenceFor(SubjectContext subjectContext) {
+    String preference = null;
+    if (subjectContext != null && subjectContext.user() != null) {
+      preference = subjectContext.user().getName();
+    }
+    return preference;
+  }
+
   /** Aggregation name for the exact-match sub-agg (user-typed term only). */
   public static String exactAggKey(String fieldName) {
     return fieldName + EXACT_AGG_SUFFIX;

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/elasticsearch/ElasticSearchRequestBuilder.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/elasticsearch/ElasticSearchRequestBuilder.java
@@ -31,6 +31,7 @@ public class ElasticSearchRequestBuilder {
   private String timeout;
   private Boolean explain;
   private List<String> searchAfter;
+  private String preference;
 
   public ElasticSearchRequestBuilder() {}
 
@@ -201,6 +202,15 @@ public class ElasticSearchRequestBuilder {
     return this.searchAfter;
   }
 
+  public ElasticSearchRequestBuilder preference(String preference) {
+    this.preference = preference;
+    return this;
+  }
+
+  public String preference() {
+    return this.preference;
+  }
+
   public SearchRequest build(String... indices) {
     return SearchRequest.of(
         s -> {
@@ -259,6 +269,10 @@ public class ElasticSearchRequestBuilder {
               fieldValues.add(es.co.elastic.clients.elasticsearch._types.FieldValue.of(value));
             }
             s.searchAfter(fieldValues);
+          }
+
+          if (preference != null && !preference.isEmpty()) {
+            s.preference(preference);
           }
 
           return s;

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/elasticsearch/ElasticSearchSearchManager.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/elasticsearch/ElasticSearchSearchManager.java
@@ -97,6 +97,8 @@ public class ElasticSearchSearchManager implements SearchManagementClient {
   private final NLQService nlqService;
   private static final String SORT_FIELD_SCORE = "_score";
   private static final String SORT_TYPE_KEYWORD = "keyword";
+  private static final String SORT_FIELD_NAME_KEYWORD = "name.keyword";
+  private static final String SORT_FIELD_ID_KEYWORD = "id.keyword";
   private static final Set<String> FIELDS_TO_REMOVE =
       Set.of(
           "suggest",
@@ -1068,6 +1070,14 @@ public class ElasticSearchSearchManager implements SearchManagementClient {
     }
   }
 
+  private void appendDeterministicTiebreak(
+      ElasticSearchRequestBuilder requestBuilder, String sortField) {
+    if (!sortField.equalsIgnoreCase(SORT_FIELD_NAME_KEYWORD)) {
+      requestBuilder.sort(SORT_FIELD_NAME_KEYWORD, SortOrder.Asc, SORT_TYPE_KEYWORD);
+    }
+    requestBuilder.sort(SORT_FIELD_ID_KEYWORD, SortOrder.Asc, SORT_TYPE_KEYWORD);
+  }
+
   private ElasticSearchRequestBuilder buildSearchRequestBuilder(
       org.openmetadata.schema.search.SearchRequest request,
       SubjectContext subjectContext,
@@ -1091,6 +1101,8 @@ public class ElasticSearchSearchManager implements SearchManagementClient {
             request.getSize(),
             request.getExplain(),
             request.getIncludeAggregations() != null ? request.getIncludeAggregations() : true);
+
+    requestBuilder.preference(SearchUtils.searchPreferenceFor(subjectContext));
 
     LOG.debug(
         "Elasticsearch query for index '{}' with sanitized query '{}': {}",
@@ -1195,29 +1207,30 @@ public class ElasticSearchSearchManager implements SearchManagementClient {
       requestBuilder.query(deletedQuery);
     }
 
-    // Handle sorting
-    if (!nullOrEmpty(request.getSortFieldParam()) && !request.getIsHierarchy()) {
-      String sortField =
-          SearchSourceBuilderFactory.resolveFieldForSortOrAggregation(request.getSortFieldParam());
-      String sortTypeCapitalized =
-          request.getSortOrder().substring(0, 1).toUpperCase()
-              + request.getSortOrder().substring(1).toLowerCase();
-      SortOrder sortOrder = SortOrder.valueOf(sortTypeCapitalized);
+    // Handle sorting — always append a deterministic tiebreaker so equal-ranked docs order
+    // identically across shards/replicas; without it the same query bounces between copies.
+    if (!request.getIsHierarchy()) {
+      if (!nullOrEmpty(request.getSortFieldParam())) {
+        String sortField =
+            SearchSourceBuilderFactory.resolveFieldForSortOrAggregation(
+                request.getSortFieldParam());
+        String sortTypeCapitalized =
+            request.getSortOrder().substring(0, 1).toUpperCase()
+                + request.getSortOrder().substring(1).toLowerCase();
+        SortOrder sortOrder = SortOrder.valueOf(sortTypeCapitalized);
 
-      if (!sortField.equalsIgnoreCase(SORT_FIELD_SCORE)) {
-        boolean isKeywordField =
-            sortField.endsWith(".keyword")
-                || SearchSourceBuilderFactory.KEYWORD_SORT_FIELDS.contains(sortField);
-        requestBuilder.sort(sortField, sortOrder, isKeywordField ? SORT_TYPE_KEYWORD : "integer");
-      } else {
-        requestBuilder.sort(sortField, sortOrder, null);
-      }
-
-      if (sortField.equalsIgnoreCase(SORT_FIELD_SCORE) || isExport) {
-        if (!sortField.equalsIgnoreCase("name.keyword")) {
-          requestBuilder.sort("name.keyword", SortOrder.Asc, SORT_TYPE_KEYWORD);
+        if (!sortField.equalsIgnoreCase(SORT_FIELD_SCORE)) {
+          boolean isKeywordField =
+              sortField.endsWith(".keyword")
+                  || SearchSourceBuilderFactory.KEYWORD_SORT_FIELDS.contains(sortField);
+          requestBuilder.sort(sortField, sortOrder, isKeywordField ? SORT_TYPE_KEYWORD : "integer");
+        } else {
+          requestBuilder.sort(sortField, sortOrder, null);
         }
-        requestBuilder.sort("id.keyword", SortOrder.Asc, SORT_TYPE_KEYWORD);
+        appendDeterministicTiebreak(requestBuilder, sortField);
+      } else {
+        requestBuilder.sort(SORT_FIELD_SCORE, SortOrder.Desc, null);
+        appendDeterministicTiebreak(requestBuilder, SORT_FIELD_SCORE);
       }
     }
 

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/elasticsearch/ElasticSearchSearchManager.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/elasticsearch/ElasticSearchSearchManager.java
@@ -989,7 +989,7 @@ public class ElasticSearchSearchManager implements SearchManagementClient {
       String clusterAlias)
       throws IOException {
     ElasticSearchRequestBuilder requestBuilder =
-        buildSearchRequestBuilder(request, subjectContext, searchSettings, clusterAlias, false);
+        buildSearchRequestBuilder(request, subjectContext, searchSettings, clusterAlias);
 
     LOG.debug("Executing search on index: {}, query: {}", request.getIndex(), request.getQuery());
 
@@ -1031,7 +1031,7 @@ public class ElasticSearchSearchManager implements SearchManagementClient {
     SearchSettings searchSettings =
         SettingsCache.getSetting(SettingsType.SEARCH_SETTINGS, SearchSettings.class);
     ElasticSearchRequestBuilder requestBuilder =
-        buildSearchRequestBuilder(request, subjectContext, searchSettings, clusterAlias, true);
+        buildSearchRequestBuilder(request, subjectContext, searchSettings, clusterAlias);
 
     try {
       SearchRequest searchRequest = requestBuilder.build(request.getIndex());
@@ -1075,15 +1075,16 @@ public class ElasticSearchSearchManager implements SearchManagementClient {
     if (!sortField.equalsIgnoreCase(SORT_FIELD_NAME_KEYWORD)) {
       requestBuilder.sort(SORT_FIELD_NAME_KEYWORD, SortOrder.Asc, SORT_TYPE_KEYWORD);
     }
-    requestBuilder.sort(SORT_FIELD_ID_KEYWORD, SortOrder.Asc, SORT_TYPE_KEYWORD);
+    if (!sortField.equalsIgnoreCase(SORT_FIELD_ID_KEYWORD)) {
+      requestBuilder.sort(SORT_FIELD_ID_KEYWORD, SortOrder.Asc, SORT_TYPE_KEYWORD);
+    }
   }
 
   private ElasticSearchRequestBuilder buildSearchRequestBuilder(
       org.openmetadata.schema.search.SearchRequest request,
       SubjectContext subjectContext,
       SearchSettings searchSettings,
-      String clusterAlias,
-      boolean isExport)
+      String clusterAlias)
       throws IOException {
     if (!isClientAvailable) {
       throw new IOException("Elasticsearch client is not available");
@@ -1209,7 +1210,7 @@ public class ElasticSearchSearchManager implements SearchManagementClient {
 
     // Handle sorting — always append a deterministic tiebreaker so equal-ranked docs order
     // identically across shards/replicas; without it the same query bounces between copies.
-    if (!request.getIsHierarchy()) {
+    if (!Boolean.TRUE.equals(request.getIsHierarchy())) {
       if (!nullOrEmpty(request.getSortFieldParam())) {
         String sortField =
             SearchSourceBuilderFactory.resolveFieldForSortOrAggregation(

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/opensearch/OpenSearchRequestBuilder.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/opensearch/OpenSearchRequestBuilder.java
@@ -33,6 +33,7 @@ public class OpenSearchRequestBuilder {
   private Boolean explain;
   private List<FieldValue> searchAfter;
   private SearchType searchType;
+  private String preference;
 
   public OpenSearchRequestBuilder() {}
 
@@ -218,6 +219,15 @@ public class OpenSearchRequestBuilder {
     return this.searchType;
   }
 
+  public OpenSearchRequestBuilder preference(String preference) {
+    this.preference = preference;
+    return this;
+  }
+
+  public String preference() {
+    return this.preference;
+  }
+
   public SearchRequest build(String... indices) {
     return SearchRequest.of(
         s -> {
@@ -275,6 +285,10 @@ public class OpenSearchRequestBuilder {
 
           if (searchType != null) {
             s.searchType(searchType);
+          }
+
+          if (preference != null && !preference.isEmpty()) {
+            s.preference(preference);
           }
 
           return s;

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/opensearch/OpenSearchSearchManager.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/opensearch/OpenSearchSearchManager.java
@@ -1035,7 +1035,7 @@ public class OpenSearchSearchManager implements SearchManagementClient {
       String clusterAlias)
       throws IOException {
     OpenSearchRequestBuilder requestBuilder =
-        buildSearchRequestBuilder(request, subjectContext, searchSettings, clusterAlias, false);
+        buildSearchRequestBuilder(request, subjectContext, searchSettings, clusterAlias);
 
     LOG.debug("Executing search on index: {}, query: {}", request.getIndex(), request.getQuery());
 
@@ -1072,7 +1072,7 @@ public class OpenSearchSearchManager implements SearchManagementClient {
     SearchSettings searchSettings =
         SettingsCache.getSetting(SettingsType.SEARCH_SETTINGS, SearchSettings.class);
     OpenSearchRequestBuilder requestBuilder =
-        buildSearchRequestBuilder(request, subjectContext, searchSettings, clusterAlias, true);
+        buildSearchRequestBuilder(request, subjectContext, searchSettings, clusterAlias);
 
     try {
       SearchRequest searchRequest = requestBuilder.build(request.getIndex());
@@ -1116,15 +1116,16 @@ public class OpenSearchSearchManager implements SearchManagementClient {
     if (!sortField.equalsIgnoreCase(SORT_FIELD_NAME_KEYWORD)) {
       requestBuilder.sort(SORT_FIELD_NAME_KEYWORD, SortOrder.Asc, SORT_TYPE_KEYWORD);
     }
-    requestBuilder.sort(SORT_FIELD_ID_KEYWORD, SortOrder.Asc, SORT_TYPE_KEYWORD);
+    if (!sortField.equalsIgnoreCase(SORT_FIELD_ID_KEYWORD)) {
+      requestBuilder.sort(SORT_FIELD_ID_KEYWORD, SortOrder.Asc, SORT_TYPE_KEYWORD);
+    }
   }
 
   private OpenSearchRequestBuilder buildSearchRequestBuilder(
       org.openmetadata.schema.search.SearchRequest request,
       SubjectContext subjectContext,
       SearchSettings searchSettings,
-      String clusterAlias,
-      boolean isExport)
+      String clusterAlias)
       throws IOException {
     if (!isClientAvailable) {
       throw new IOException("OpenSearch client is not available");

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/opensearch/OpenSearchSearchManager.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/opensearch/OpenSearchSearchManager.java
@@ -98,6 +98,8 @@ public class OpenSearchSearchManager implements SearchManagementClient {
   private final NLQService nlqService;
   private static final String SORT_FIELD_SCORE = "_score";
   private static final String SORT_TYPE_KEYWORD = "keyword";
+  private static final String SORT_FIELD_NAME_KEYWORD = "name.keyword";
+  private static final String SORT_FIELD_ID_KEYWORD = "id.keyword";
   private static final Set<String> FIELDS_TO_REMOVE =
       Set.of(
           "suggest",
@@ -1109,6 +1111,14 @@ public class OpenSearchSearchManager implements SearchManagementClient {
     }
   }
 
+  private void appendDeterministicTiebreak(
+      OpenSearchRequestBuilder requestBuilder, String sortField) {
+    if (!sortField.equalsIgnoreCase(SORT_FIELD_NAME_KEYWORD)) {
+      requestBuilder.sort(SORT_FIELD_NAME_KEYWORD, SortOrder.Asc, SORT_TYPE_KEYWORD);
+    }
+    requestBuilder.sort(SORT_FIELD_ID_KEYWORD, SortOrder.Asc, SORT_TYPE_KEYWORD);
+  }
+
   private OpenSearchRequestBuilder buildSearchRequestBuilder(
       org.openmetadata.schema.search.SearchRequest request,
       SubjectContext subjectContext,
@@ -1132,6 +1142,8 @@ public class OpenSearchSearchManager implements SearchManagementClient {
             request.getSize(),
             request.getExplain(),
             request.getIncludeAggregations() != null ? request.getIncludeAggregations() : true);
+
+    requestBuilder.preference(SearchUtils.searchPreferenceFor(subjectContext));
 
     LOG.debug(
         "OpenSearch query for index '{}' with sanitized query '{}': {}",
@@ -1238,30 +1250,30 @@ public class OpenSearchSearchManager implements SearchManagementClient {
       requestBuilder.query(deletedQuery);
     }
 
-    // Handle sorting
-    if (!nullOrEmpty(request.getSortFieldParam())
-        && !Boolean.TRUE.equals(request.getIsHierarchy())) {
-      String sortField =
-          SearchSourceBuilderFactory.resolveFieldForSortOrAggregation(request.getSortFieldParam());
-      String sortTypeCapitalized =
-          request.getSortOrder().substring(0, 1).toUpperCase()
-              + request.getSortOrder().substring(1).toLowerCase();
-      SortOrder sortOrder = SortOrder.valueOf(sortTypeCapitalized);
+    // Handle sorting — always append a deterministic tiebreaker so equal-ranked docs order
+    // identically across shards/replicas; without it the same query bounces between copies.
+    if (!Boolean.TRUE.equals(request.getIsHierarchy())) {
+      if (!nullOrEmpty(request.getSortFieldParam())) {
+        String sortField =
+            SearchSourceBuilderFactory.resolveFieldForSortOrAggregation(
+                request.getSortFieldParam());
+        String sortTypeCapitalized =
+            request.getSortOrder().substring(0, 1).toUpperCase()
+                + request.getSortOrder().substring(1).toLowerCase();
+        SortOrder sortOrder = SortOrder.valueOf(sortTypeCapitalized);
 
-      if (!sortField.equalsIgnoreCase(SORT_FIELD_SCORE)) {
-        boolean isKeywordField =
-            sortField.endsWith(".keyword")
-                || SearchSourceBuilderFactory.KEYWORD_SORT_FIELDS.contains(sortField);
-        requestBuilder.sort(sortField, sortOrder, isKeywordField ? SORT_TYPE_KEYWORD : "integer");
-      } else {
-        requestBuilder.sort(sortField, sortOrder, null);
-      }
-
-      if (sortField.equalsIgnoreCase(SORT_FIELD_SCORE) || isExport) {
-        if (!sortField.equalsIgnoreCase("name.keyword")) {
-          requestBuilder.sort("name.keyword", SortOrder.Asc, SORT_TYPE_KEYWORD);
+        if (!sortField.equalsIgnoreCase(SORT_FIELD_SCORE)) {
+          boolean isKeywordField =
+              sortField.endsWith(".keyword")
+                  || SearchSourceBuilderFactory.KEYWORD_SORT_FIELDS.contains(sortField);
+          requestBuilder.sort(sortField, sortOrder, isKeywordField ? SORT_TYPE_KEYWORD : "integer");
+        } else {
+          requestBuilder.sort(sortField, sortOrder, null);
         }
-        requestBuilder.sort("id.keyword", SortOrder.Asc, SORT_TYPE_KEYWORD);
+        appendDeterministicTiebreak(requestBuilder, sortField);
+      } else {
+        requestBuilder.sort(SORT_FIELD_SCORE, SortOrder.Desc, null);
+        appendDeterministicTiebreak(requestBuilder, SORT_FIELD_SCORE);
       }
     }
 

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/vector/OpenSearchVectorService.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/vector/OpenSearchVectorService.java
@@ -17,6 +17,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.openmetadata.schema.EntityInterface;
 import org.openmetadata.service.Entity;
 import org.openmetadata.service.events.lifecycle.EntityLifecycleEventDispatcher;
+import org.openmetadata.service.search.SearchUtils;
 import org.openmetadata.service.search.vector.client.EmbeddingClient;
 import org.openmetadata.service.search.vector.utils.DTOs.VectorSearchResponse;
 import os.org.opensearch.client.json.JsonData;
@@ -188,7 +189,8 @@ public class OpenSearchVectorService implements VectorIndexService {
       int size,
       int from,
       int k,
-      double threshold) {
+      double threshold,
+      String preference) {
     long start = System.currentTimeMillis();
     try {
       float[] queryVector = embeddingClient.embed(query);
@@ -207,8 +209,9 @@ public class OpenSearchVectorService implements VectorIndexService {
         String queryJson =
             VectorSearchQueryBuilder.build(
                 queryVector, overFetchSize, rawOffset, k, filters, threshold);
-        String responseBody =
-            executeGenericRequest("POST", "/" + aliasName + "/_search", queryJson);
+        String endpoint =
+            SearchUtils.appendPreferenceParam("/" + aliasName + "/_search", preference);
+        String responseBody = executeGenericRequest("POST", endpoint, queryJson);
 
         JsonNode root = MAPPER.readTree(responseBody);
         JsonNode hitsNode = root.path("hits").path("hits");

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/vector/VectorIndexService.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/vector/VectorIndexService.java
@@ -13,6 +13,22 @@ public interface VectorIndexService {
 
   void updateEntityEmbedding(EntityInterface entity, String entityIndexName);
 
+  default VectorSearchResponse search(
+      String query,
+      Map<String, List<String>> filters,
+      int size,
+      int from,
+      int k,
+      double threshold) {
+    return search(query, filters, size, from, k, threshold, null);
+  }
+
   VectorSearchResponse search(
-      String query, Map<String, List<String>> filters, int size, int from, int k, double threshold);
+      String query,
+      Map<String, List<String>> filters,
+      int size,
+      int from,
+      int k,
+      double threshold,
+      String preference);
 }


### PR DESCRIPTION
### Describe your changes:

Fixes #<issue-number> <!-- TODO: link the tracking issue -->

On a multi-node OpenSearch/Elasticsearch cluster the same query could return reordered or different results across requests, because reads bounced between shard copies (no `preference` was ever set) and the default relevance sort had no total-order tiebreaker, so equal-scored docs ordered differently per replica. This PR pins each authenticated user's searches to one shard copy via a `preference` routing key (`SearchUtils.searchPreferenceFor`, threaded through `OpenSearch`/`ElasticSearchRequestBuilder` and both search managers) and always appends a deterministic `name.keyword` + `id.keyword` sort tiebreaker on every sort path (including the default and non-`_score` paths, where docs commonly tie). Together these make repeated/paginated searches return stable, identical ordering across replicas.

#
### Type of change:
- [x] Bug fix

#
### High-level design:

No new API surface: `preference` is derived from the request's `SubjectContext` (per-user key) so a session pins to one shard copy without changing endpoints, and the sort change reuses the existing keyword-tiebreaker logic, extending it to the previously-uncovered default/non-`_score` sort paths. Behavior is unchanged on a single-node/single-shard cluster.

#
### Tests:

#### Use cases covered
- Repeated identical search on a multi-node cluster returns the same result set/order (no "bouncing").
- Read-after-write for a given user resolves to the same shard copy.
- Default (`totalVotes`) and relevance (`_score`) sorts produce a stable total order across replicas.

#### Unit tests
- [ ] Not added in this PR — change is in the request-building/sort path; covered by existing search ITs. Multi-node ordering is best validated against a replicated cluster (see manual testing).

#### Backend integration tests
- [x] Not applicable (no new/changed API endpoint; internal request-building only).

#### Manual testing performed
- Compiled `openmetadata-service` and verified `spotless` is clean.
- Recommended cluster check: with `number_of_replicas >= 1`, run the same query repeatedly and paginate during ingestion — ordering stays stable with `preference` set.

#
### UI screen recording / screenshots:

Not applicable.

#
### Checklist:
- [x] I have read the **CONTRIBUTING** document.
- [ ] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [x] I have commented on my code, particularly in hard-to-understand areas.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes search result instability on multi-node OpenSearch/Elasticsearch clusters by (1) deriving a per-user `preference` routing key that pins each user's requests to one shard copy, and (2) always appending a deterministic `name.keyword` + `id.keyword` sort tiebreaker so equal-scored documents order identically across replicas.

- `SearchUtils.searchPreferenceFor` computes a stable routing key from the authenticated user's name; `appendPreferenceParam` URL-encodes it onto raw `_search` endpoints, while the request-builder path sets it on the builder directly.
- The sort-handling block in both `ElasticSearchSearchManager` and `OpenSearchSearchManager` is restructured: the outer guard is now `!Boolean.TRUE.equals(isHierarchy)` (null-safe), an explicit `_score desc` + tiebreaker is added when no `sortFieldParam` is supplied, and `appendDeterministicTiebreak` guards against duplicating the primary sort field.
- `VectorIndexService` gains a backward-compatible default overload so existing callers that don't supply a preference compile without changes.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — all changes are internal request-building logic with no new API surface, and the null-safety regression that existed before this PR is correctly resolved with `!Boolean.TRUE.equals(...)`.

The two mechanical changes — pinning a per-user `preference` key and always appending `name.keyword`/`id.keyword` tiebreakers — are narrow and well-contained. The `appendDeterministicTiebreak` guard logic correctly skips the field that is already the primary sort key. The `VectorIndexService` default overload preserves backward compatibility cleanly. No new error paths, no schema or API changes, and behavior on a single-node cluster is unchanged.

No files require special attention; the most complex logic is in the two search manager files and the `appendDeterministicTiebreak` helper, both of which read correctly.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| openmetadata-service/src/main/java/org/openmetadata/service/search/SearchUtils.java | Adds `searchPreferenceFor` (returns user's display name) and `appendPreferenceParam` (URL-encodes preference onto raw endpoints). Both methods are null-safe and straightforward. |
| openmetadata-service/src/main/java/org/openmetadata/service/search/elasticsearch/ElasticSearchSearchManager.java | Restructures sort handling to always apply deterministic tiebreaker; outer hierarchy guard changed to null-safe `!Boolean.TRUE.equals(...)`; `isExport` dead parameter removed; preference wired in. |
| openmetadata-service/src/main/java/org/openmetadata/service/search/opensearch/OpenSearchSearchManager.java | Mirrors the ElasticSearch manager changes: null-safe hierarchy guard, always-applied tiebreaker via `appendDeterministicTiebreak`, preference set on builder. |
| openmetadata-service/src/main/java/org/openmetadata/service/search/vector/VectorIndexService.java | Adds a default overload without `preference` for backward compatibility, while the new abstract method requires `String preference` — clean interface evolution. |
| openmetadata-service/src/main/java/org/openmetadata/service/search/vector/OpenSearchVectorService.java | Accepts `preference` parameter and routes it through `appendPreferenceParam` to the raw `_search` endpoint URL. |
| openmetadata-service/src/main/java/org/openmetadata/service/resources/search/VectorSearchResource.java | Captures `subjectContext` (previously discarded) and passes `searchPreferenceFor(subjectContext)` to the vector search call. |
| openmetadata-service/src/main/java/org/openmetadata/service/search/elasticsearch/ElasticSearchRequestBuilder.java | Adds `preference` field with fluent setter/getter and wires it into the `SearchRequest` builder with a null/empty guard. |
| openmetadata-service/src/main/java/org/openmetadata/service/search/opensearch/OpenSearchRequestBuilder.java | Same as the ES counterpart — adds `preference` field with fluent API, applied in `build()` only when non-null/non-empty. |

</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Client
    participant SearchResource
    participant SearchManager as OpenSearch/ElasticSearch SearchManager
    participant RequestBuilder as Request Builder
    participant Cluster as ES/OpenSearch Cluster

    Client->>SearchResource: "GET /search?q=..."
    SearchResource->>SearchResource: getSubjectContext(securityContext)
    SearchResource->>SearchManager: search(request, subjectContext)
    SearchManager->>SearchManager: SearchUtils.searchPreferenceFor(subjectContext) → user.getName()
    SearchManager->>RequestBuilder: requestBuilder.preference(userName)
    SearchManager->>RequestBuilder: appendDeterministicTiebreak(sortField)
    RequestBuilder->>Cluster: "SearchRequest{preference=userName, sort=[...tiebreaker]}"
    Note over Cluster: preference pins request to one shard copy per user
    Cluster-->>Client: Stable, deterministic results

    participant VectorResource
    participant VectorService as OpenSearchVectorService
    Client->>VectorResource: POST /search/vector
    VectorResource->>VectorResource: getSubjectContext(securityContext)
    VectorResource->>VectorService: search(..., searchPreferenceFor(ctx))
    VectorService->>VectorService: appendPreferenceParam(endpoint, preference)
    VectorService->>Cluster: "POST /_search?preference=user"
    Cluster-->>Client: Stable results
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Client
    participant SearchResource
    participant SearchManager as OpenSearch/ElasticSearch SearchManager
    participant RequestBuilder as Request Builder
    participant Cluster as ES/OpenSearch Cluster

    Client->>SearchResource: "GET /search?q=..."
    SearchResource->>SearchResource: getSubjectContext(securityContext)
    SearchResource->>SearchManager: search(request, subjectContext)
    SearchManager->>SearchManager: SearchUtils.searchPreferenceFor(subjectContext) → user.getName()
    SearchManager->>RequestBuilder: requestBuilder.preference(userName)
    SearchManager->>RequestBuilder: appendDeterministicTiebreak(sortField)
    RequestBuilder->>Cluster: "SearchRequest{preference=userName, sort=[...tiebreaker]}"
    Note over Cluster: preference pins request to one shard copy per user
    Cluster-->>Client: Stable, deterministic results

    participant VectorResource
    participant VectorService as OpenSearchVectorService
    Client->>VectorResource: POST /search/vector
    VectorResource->>VectorResource: getSubjectContext(securityContext)
    VectorResource->>VectorService: search(..., searchPreferenceFor(ctx))
    VectorService->>VectorService: appendPreferenceParam(endpoint, preference)
    VectorService->>Cluster: "POST /_search?preference=user"
    Cluster-->>Client: Stable results
```

</a>
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `openmetadata-service/src/main/java/org/openmetadata/service/search/elasticsearch/ElasticSearchSearchManager.java`, line 1081-1086 ([link](https://github.com/open-metadata/openmetadata/blob/4d61a4037ac68b948c5b8e905675230e16bcc70c/openmetadata-service/src/main/java/org/openmetadata/service/search/elasticsearch/ElasticSearchSearchManager.java#L1081-L1086)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Unused `isExport` parameter**

   `isExport` was previously used in the `|| isExport` tiebreaker condition that this PR removed. It no longer appears anywhere in the method body, making it a dead parameter. The `OpenSearchSearchManager` counterpart has the same issue (line 1127).
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (4): Last reviewed commit: ["Merge branch &#39;main&#39; into harshach/multin..."](https://github.com/open-metadata/openmetadata/commit/88b772d413e5f37c13b03fb32c51701e293918f0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40007697)</sub>

<!-- /greptile_comment -->