### PR TITLE
test(glossary): fix empty-CSV import test after adding domains column

### DIFF
--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/GlossaryResourceIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/GlossaryResourceIT.java
@@ -1583,6 +1583,7 @@ public class GlossaryResourceIT extends BaseEntityIT<Glossary, CreateGlossary> {
         "glossaryStatus",
         "color",
         "iconURL",
+        "domains",
         "extension");
   }
 


### PR DESCRIPTION
## Problem

After #29481 added the `domains` column to the glossary CSV, `BaseEntityIT.test_importCsv_emptyData` started failing for glossary.

That test builds a header-only CSV from `GlossaryResourceIT.getAllCsvHeaders()`, but that override still listed the old 14 columns (without `domains`). Since CSV import validates headers with an **exact match**, the header-only CSV was rejected and the test's failed-rows assertion blew up.

## Fix

Add `domains` (before `extension`) to `GlossaryResourceIT.getAllCsvHeaders()` so it matches the updated `GLOSSARY_TERM_CSV_HEADER` constant and the server-side documentation. One-line, test-only.

## Verification

`openmetadata-integration-tests -am install -DskipTests` → BUILD SUCCESS.

Follow-up to #29481.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This one-line test fix adds `"domains"` to the `getAllCsvHeaders()` override in `GlossaryResourceIT` so the header list produced for the empty-CSV import test matches the 15-column `GLOSSARY_TERM_CSV_HEADER` constant and the server-side CSV schema introduced in #29481.

- Adds `"domains"` between `"iconURL"` and `"extension"` in `getAllCsvHeaders()`, aligning it with the `GLOSSARY_TERM_CSV_HEADER` constant (`parent,name*,displayName,…,iconURL,domains,extension`) and the hardcoded headers already used in `GlossaryTermRelationEdgeCasesIT`.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is a single-line addition to a test helper method that restores alignment with the server-side CSV schema.

The fix adds exactly one entry (`domains`) to a test-only list, placing it between `iconURL` and `extension` to match the `GLOSSARY_TERM_CSV_HEADER` constant already defined in the same file and the hardcoded headers used in `GlossaryTermRelationEdgeCasesIT`. There is no production code touched, no logic changed, and the corrected list is verified consistent with all other references to the glossary term CSV columns in the codebase.

No files require special attention.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/GlossaryResourceIT.java | Adds `domains` to `getAllCsvHeaders()` to match the updated 15-column `GLOSSARY_TERM_CSV_HEADER` constant, fixing a broken empty-CSV import test. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Test as test_importCsv_emptyData
    participant IT as GlossaryResourceIT
    participant Base as BaseEntityIT
    participant Server as Glossary CSV Endpoint

    Test->>Base: run test_importCsv_emptyData()
    Base->>IT: getAllCsvHeaders()
    IT-->>Base: "[parent, name*, ..., iconURL, domains, extension]"
    Base->>Base: build header-only CSV string
    Base->>Server: POST /glossaries/csv (header-only CSV)
    Server->>Server: validate headers (exact match)
    Server-->>Base: "failedRows = 0 (headers matched)"
    Base->>Base: "assert failedRows == 0 ✅"
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Test as test_importCsv_emptyData
    participant IT as GlossaryResourceIT
    participant Base as BaseEntityIT
    participant Server as Glossary CSV Endpoint

    Test->>Base: run test_importCsv_emptyData()
    Base->>IT: getAllCsvHeaders()
    IT-->>Base: "[parent, name*, ..., iconURL, domains, extension]"
    Base->>Base: build header-only CSV string
    Base->>Server: POST /glossaries/csv (header-only CSV)
    Server->>Server: validate headers (exact match)
    Server-->>Base: "failedRows = 0 (headers matched)"
    Base->>Base: "assert failedRows == 0 ✅"
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["test(glossary): add domains to getAllCsv..."](https://github.com/open-metadata/openmetadata/commit/dd4abd92464b031f3506dd92b4b25de8d71c2837) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40018315)</sub>

<!-- /greptile_comment -->