### PR TITLE
fix(glossary): preserve domains through CSV import/export (1.13 cherry-pick of #29481)

### DIFF
--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/GlossaryCsvRelationTypesIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/GlossaryCsvRelationTypesIT.java
@@ -106,8 +106,8 @@ public class GlossaryCsvRelationTypesIT {
 
     String csvContent =
         String.format(
-            "parent,name*,displayName,description,synonyms,relatedTerms,references,tags,reviewers,owner,glossaryStatus,color,iconURL,extension%n"
-                + ",%s_newTerm,New Term,Test description,,synonym:%s,,,,,Draft,,,",
+            "parent,name*,displayName,description,synonyms,relatedTerms,references,tags,reviewers,owner,glossaryStatus,color,iconURL,domains,extension%n"
+                + ",%s_newTerm,New Term,Test description,,synonym:%s,,,,,Draft,,,,",
             ns.prefix(""), existingTerm.getFullyQualifiedName());
 
     String result = importGlossaryCsv(glossary.getName(), csvContent, false);
@@ -130,8 +130,8 @@ public class GlossaryCsvRelationTypesIT {
 
     String csvContent =
         String.format(
-            "parent,name*,displayName,description,synonyms,relatedTerms,references,tags,reviewers,owner,glossaryStatus,color,iconURL,extension%n"
-                + ",%s_legacyTerm,Legacy Term,Test description,,%s,,,,,Draft,,,",
+            "parent,name*,displayName,description,synonyms,relatedTerms,references,tags,reviewers,owner,glossaryStatus,color,iconURL,domains,extension%n"
+                + ",%s_legacyTerm,Legacy Term,Test description,,%s,,,,,Draft,,,,",
             ns.prefix(""), existingTerm.getFullyQualifiedName());
 
     String result = importGlossaryCsv(glossary.getName(), csvContent, false);
@@ -164,8 +164,8 @@ public class GlossaryCsvRelationTypesIT {
     String termName = ns.prefix("") + "_mixedTerm";
     String csvContent =
         String.format(
-            "parent,name*,displayName,description,synonyms,relatedTerms,references,tags,reviewers,owner,glossaryStatus,color,iconURL,extension%n"
-                + ",%s,Mixed Term,Test description,,synonym:%s;%s;broader:%s,,,,,Draft,,,",
+            "parent,name*,displayName,description,synonyms,relatedTerms,references,tags,reviewers,owner,glossaryStatus,color,iconURL,domains,extension%n"
+                + ",%s,Mixed Term,Test description,,synonym:%s;%s;broader:%s,,,,,Draft,,,,",
             termName,
             term1.getFullyQualifiedName(),
             term2.getFullyQualifiedName(),
@@ -194,8 +194,8 @@ public class GlossaryCsvRelationTypesIT {
 
     String csvContent =
         String.format(
-            "parent,name*,displayName,description,synonyms,relatedTerms,references,tags,reviewers,owner,glossaryStatus,color,iconURL,extension%n"
-                + ",%s_invalidRelTerm,Invalid Rel Term,Test description,,invalidtype:%s,,,,,Draft,,,",
+            "parent,name*,displayName,description,synonyms,relatedTerms,references,tags,reviewers,owner,glossaryStatus,color,iconURL,domains,extension%n"
+                + ",%s_invalidRelTerm,Invalid Rel Term,Test description,,invalidtype:%s,,,,,Draft,,,,",
             ns.prefix(""), existingTerm.getFullyQualifiedName());
 
     String result = importGlossaryCsv(glossary.getName(), csvContent, true);
@@ -342,8 +342,8 @@ public class GlossaryCsvRelationTypesIT {
     String newTermName = ns.prefix("") + "_importedTerm";
     String csvContent =
         String.format(
-            "parent,name*,displayName,description,synonyms,relatedTerms,references,tags,reviewers,owner,glossaryStatus,color,iconURL,extension%n"
-                + ",%s,Imported Term,Imported via CSV,,broader:%s,,,,,Draft,,,",
+            "parent,name*,displayName,description,synonyms,relatedTerms,references,tags,reviewers,owner,glossaryStatus,color,iconURL,domains,extension%n"
+                + ",%s,Imported Term,Imported via CSV,,broader:%s,,,,,Draft,,,,",
             newTermName, existingTerm.getFullyQualifiedName());
 
     String result = importGlossaryCsv(glossary.getName(), csvContent, false);
@@ -404,8 +404,8 @@ public class GlossaryCsvRelationTypesIT {
 
     String csvContent =
         String.format(
-            "parent,name*,displayName,description,synonyms,relatedTerms,references,tags,reviewers,owner,glossaryStatus,color,iconURL,extension%n"
-                + ",%s_colonTerm,Colon Term,Test description,,notarelation:%s.subterm,,,,,Draft,,,",
+            "parent,name*,displayName,description,synonyms,relatedTerms,references,tags,reviewers,owner,glossaryStatus,color,iconURL,domains,extension%n"
+                + ",%s_colonTerm,Colon Term,Test description,,notarelation:%s.subterm,,,,,Draft,,,,",
             ns.prefix(""), existingTerm.getFullyQualifiedName());
 
     String result = importGlossaryCsv(glossary.getName(), csvContent, true);

--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/GlossaryResourceIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/GlossaryResourceIT.java
@@ -19,6 +19,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
+import static org.openmetadata.csv.EntityCsv.IMPORT_FAILED;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -61,7 +62,7 @@ public class GlossaryResourceIT extends BaseEntityIT<Glossary, CreateGlossary> {
       org.slf4j.LoggerFactory.getLogger(GlossaryResourceIT.class);
 
   private static final String GLOSSARY_TERM_CSV_HEADER =
-      "parent,name*,displayName,description,synonyms,relatedTerms,references,tags,reviewers,owner,glossaryStatus,color,iconURL,extension\n";
+      "parent,name*,displayName,description,synonyms,relatedTerms,references,tags,reviewers,owner,glossaryStatus,color,iconURL,domains,extension\n";
 
   {
     supportsImportExport = true;
@@ -1105,9 +1106,9 @@ public class GlossaryResourceIT extends BaseEntityIT<Glossary, CreateGlossary> {
    * Helper method to create CSV content for glossary terms import.
    * Returns CSV with header and 3 glossary terms with all required columns.
    *
-   * CSV Format (14 columns):
+   * CSV Format (15 columns):
    * parent,name*,displayName,description,synonyms,relatedTerms,references,tags,
-   * reviewers,owner,glossaryStatus,color,iconURL,extension
+   * reviewers,owner,glossaryStatus,color,iconURL,domains,extension
    *
    * Note: parent column is for PARENT GLOSSARY TERM, not glossary.
    * For top-level terms, leave parent EMPTY.
@@ -1118,24 +1119,24 @@ public class GlossaryResourceIT extends BaseEntityIT<Glossary, CreateGlossary> {
    */
   private String buildGlossaryTermsCsv(String glossaryFqn, TestNamespace ns) {
     StringBuilder csv = new StringBuilder();
-    // CSV header with all 14 columns as expected by GlossaryCsv.addRecord()
+    // CSV header with all 15 columns as expected by GlossaryCsv.addRecord()
     // Note: 'owner' (singular) NOT 'owners', and 'glossaryStatus' NOT 'status'
     csv.append(GLOSSARY_TERM_CSV_HEADER);
 
     // Add 3 top-level glossary terms with EMPTY parent column
     // Columns: parent, name, displayName, description, synonyms, relatedTerms, references,
-    //          tags, reviewers, owner, glossaryStatus, color, iconURL, extension
+    //          tags, reviewers, owner, glossaryStatus, color, iconURL, domains, extension
     csv.append(
         String.format(
-            ",\"%s\",\"Term 1\",\"First test term for bulk import\",,,,,,,,,,\n",
+            ",\"%s\",\"Term 1\",\"First test term for bulk import\",,,,,,,,,,,\n",
             ns.prefix("bulkTerm1")));
     csv.append(
         String.format(
-            ",\"%s\",\"Term 2\",\"Second test term for bulk import\",,,,,,,,,,\n",
+            ",\"%s\",\"Term 2\",\"Second test term for bulk import\",,,,,,,,,,,\n",
             ns.prefix("bulkTerm2")));
     csv.append(
         String.format(
-            ",\"%s\",\"Term 3\",\"Third test term for bulk import\",,,,,,,,,,\n",
+            ",\"%s\",\"Term 3\",\"Third test term for bulk import\",,,,,,,,,,,\n",
             ns.prefix("bulkTerm3")));
 
     return csv.toString();
@@ -1341,7 +1342,7 @@ public class GlossaryResourceIT extends BaseEntityIT<Glossary, CreateGlossary> {
             + ns.prefix("newTerm")
             + ",New Term,Test Term,,\""
             + inReviewTerm.getFullyQualifiedName()
-            + "\",,,,,,,,";
+            + "\",,,,,,,,,";
     log.info("TEST: Attempting CSV import for glossary: {}", glossary.getName());
     String resultCsv = client.glossaries().importCsv(glossary.getName(), csv, false);
 
@@ -1394,7 +1395,7 @@ public class GlossaryResourceIT extends BaseEntityIT<Glossary, CreateGlossary> {
             + ns.prefix("newTermWithApproved")
             + ",New Term With Approved,Test Term,,\""
             + approvedTerm.getFullyQualifiedName()
-            + "\",,,,,,,,";
+            + "\",,,,,,,,,";
 
     String resultCsv = client.glossaries().importCsv(glossary.getName(), csv, false);
 
@@ -1424,6 +1425,100 @@ public class GlossaryResourceIT extends BaseEntityIT<Glossary, CreateGlossary> {
     }
   }
 
+  /**
+   * Regression test: glossary terms must keep their assigned domains through a CSV export/import
+   * round-trip (the UI "bulk edit" flow). Domains were silently dropped because the glossary CSV
+   * had no domains column.
+   */
+  @Test
+  void test_importExportCsv_preservesDomains(TestNamespace ns) {
+    OpenMetadataClient client = SdkClients.adminClient();
+
+    Glossary glossary = createEntity(createMinimalRequest(ns));
+
+    CreateGlossaryTerm createTerm =
+        new CreateGlossaryTerm()
+            .withName(ns.prefix("termWithDomain"))
+            .withGlossary(glossary.getFullyQualifiedName())
+            .withDescription("Term that must keep its domain through CSV import");
+    GlossaryTerm term = client.glossaryTerms().create(createTerm);
+
+    String domainFqn = testDomain().getFullyQualifiedName();
+    term.setDomains(List.of(testDomain().getEntityReference()));
+    client.glossaryTerms().update(term.getId(), term);
+
+    String exportedCsv = client.glossaries().exportCsv(glossary.getName());
+    assertTrue(
+        exportedCsv.contains(domainFqn),
+        "Exported glossary CSV should contain the term's domain. CSV:\n" + exportedCsv);
+
+    String resultCsv = client.glossaries().importCsv(glossary.getName(), exportedCsv, false);
+    assertImportSucceeded(resultCsv);
+
+    GlossaryTerm reimported =
+        client.glossaryTerms().getByName(term.getFullyQualifiedName(), "domains");
+    assertNotNull(reimported.getDomains(), "Domain must be preserved after CSV re-import");
+    assertEquals(1, reimported.getDomains().size());
+    assertEquals(domainFqn, reimported.getDomains().getFirst().getFullyQualifiedName());
+  }
+
+  /**
+   * A term that only <b>inherits</b> its domain from the parent glossary must not have that domain
+   * materialized as a direct domain through a CSV export/import round-trip. Inherited domains are
+   * excluded from the exported domains column, so re-import leaves the term inheriting (not owning)
+   * the domain.
+   */
+  @Test
+  void test_importExportCsv_doesNotMaterializeInheritedDomains(TestNamespace ns) {
+    OpenMetadataClient client = SdkClients.adminClient();
+
+    Glossary glossary = createEntity(createMinimalRequest(ns));
+    String domainFqn = testDomain().getFullyQualifiedName();
+    glossary.setDomains(List.of(testDomain().getEntityReference()));
+    patchEntity(glossary.getId().toString(), glossary);
+
+    CreateGlossaryTerm createTerm =
+        new CreateGlossaryTerm()
+            .withName(ns.prefix("inheritingTerm"))
+            .withGlossary(glossary.getFullyQualifiedName())
+            .withDescription("Term that only inherits the glossary's domain");
+    GlossaryTerm term = client.glossaryTerms().create(createTerm);
+
+    String exportedCsv = client.glossaries().exportCsv(glossary.getName());
+    String termRow =
+        exportedCsv.lines().filter(line -> line.contains(term.getName())).findFirst().orElseThrow();
+    assertFalse(
+        termRow.contains(domainFqn),
+        "Inherited domain must not be written to the exported CSV. Row: " + termRow);
+
+    String resultCsv = client.glossaries().importCsv(glossary.getName(), exportedCsv, false);
+    assertImportSucceeded(resultCsv);
+
+    GlossaryTerm reimported =
+        client.glossaryTerms().getByName(term.getFullyQualifiedName(), "domains");
+    boolean hasDirectDomain =
+        reimported.getDomains() != null
+            && reimported.getDomains().stream()
+                .anyMatch(domain -> !Boolean.TRUE.equals(domain.getInherited()));
+    assertFalse(
+        hasDirectDomain,
+        "Inherited domain must not be materialized as a direct domain after CSV round-trip");
+
+    boolean stillInherits =
+        reimported.getDomains() != null
+            && reimported.getDomains().stream()
+                .anyMatch(
+                    domain ->
+                        domainFqn.equals(domain.getFullyQualifiedName())
+                            && Boolean.TRUE.equals(domain.getInherited()));
+    assertTrue(stillInherits, "Inherited domain must still be present after CSV round-trip");
+  }
+
+  private static void assertImportSucceeded(String resultCsv) {
+    boolean anyRowFailed = resultCsv.lines().anyMatch(line -> line.startsWith(IMPORT_FAILED + ","));
+    assertFalse(anyRowFailed, "CSV import reported a failure row:\n" + resultCsv);
+  }
+
   // ===================================================================
   // CSV IMPORT/EXPORT SUPPORT
   // ===================================================================
@@ -1451,6 +1546,7 @@ public class GlossaryResourceIT extends BaseEntityIT<Glossary, CreateGlossary> {
       csv.append(escapeCSVValue("Approved")).append(","); // glossaryStatus
       csv.append(escapeCSVValue("#FF5733")).append(","); // color
       csv.append(escapeCSVValue("")).append(","); // iconURL
+      csv.append(escapeCSVValue("")).append(","); // domains
       csv.append(escapeCSVValue(formatExtensionForCsv(null))); // extension
       csv.append("\n");
     }
@@ -1462,9 +1558,9 @@ public class GlossaryResourceIT extends BaseEntityIT<Glossary, CreateGlossary> {
     StringBuilder csv = new StringBuilder();
     csv.append(GLOSSARY_TERM_CSV_HEADER);
     // Missing required name field
-    csv.append(",,Term,Description,,,,,,,,,\n");
+    csv.append(",,Term,Description,,,,,,,,,,\n");
     // Invalid glossary status
-    csv.append(",invalid_term,,,,,,,,INVALID_STATUS,,,\n");
+    csv.append(",invalid_term,,,,,,,,INVALID_STATUS,,,,\n");
     return csv.toString();
   }
 
@@ -1487,6 +1583,7 @@ public class GlossaryResourceIT extends BaseEntityIT<Glossary, CreateGlossary> {
         "glossaryStatus",
         "color",
         "iconURL",
+        "domains",
         "extension");
   }
 

--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/GlossaryTermRelationEdgeCasesIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/GlossaryTermRelationEdgeCasesIT.java
@@ -486,8 +486,8 @@ public class GlossaryTermRelationEdgeCasesIT {
 
     String csvContent =
         String.format(
-            "parent,name*,displayName,description,synonyms,relatedTerms,references,tags,reviewers,owner,glossaryStatus,color,iconURL,extension%n"
-                + ",%s_termWithBadRef,Term With Bad Ref,Test description,,synonym:nonExistent.term.fqn,,,,,Draft,,,",
+            "parent,name*,displayName,description,synonyms,relatedTerms,references,tags,reviewers,owner,glossaryStatus,color,iconURL,domains,extension%n"
+                + ",%s_termWithBadRef,Term With Bad Ref,Test description,,synonym:nonExistent.term.fqn,,,,,Draft,,,,",
             ns.prefix(""));
 
     String result = importGlossaryCsv(glossary.getName(), csvContent, true);
@@ -504,8 +504,8 @@ public class GlossaryTermRelationEdgeCasesIT {
 
     String csvContent =
         String.format(
-            "parent,name*,displayName,description,synonyms,relatedTerms,references,tags,reviewers,owner,glossaryStatus,color,iconURL,extension%n"
-                + ",%s_newTerm,New Term,Test description,,invalidType:%s,,,,,Draft,,,",
+            "parent,name*,displayName,description,synonyms,relatedTerms,references,tags,reviewers,owner,glossaryStatus,color,iconURL,domains,extension%n"
+                + ",%s_newTerm,New Term,Test description,,invalidType:%s,,,,,Draft,,,,",
             ns.prefix(""), existingTerm.getFullyQualifiedName());
 
     String result = importGlossaryCsv(glossary.getName(), csvContent, true);

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/GlossaryRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/GlossaryRepository.java
@@ -16,8 +16,10 @@
 
 package org.openmetadata.service.jdbi3;
 
+import static org.openmetadata.common.utils.CommonUtil.listOrEmpty;
 import static org.openmetadata.common.utils.CommonUtil.nullOrEmpty;
 import static org.openmetadata.csv.CsvUtil.FIELD_SEPARATOR;
+import static org.openmetadata.csv.CsvUtil.addDomains;
 import static org.openmetadata.csv.CsvUtil.addEntityReference;
 import static org.openmetadata.csv.CsvUtil.addExtension;
 import static org.openmetadata.csv.CsvUtil.addField;
@@ -241,7 +243,8 @@ public class GlossaryRepository extends EntityRepository<Glossary> {
         (GlossaryTermRepository) Entity.getEntityRepository(GLOSSARY_TERM);
     List<GlossaryTerm> terms =
         repository.listAllForCSV(
-            repository.getFields("owners,reviewers,tags,relatedTerms,synonyms,extension,parent"),
+            repository.getFields(
+                "owners,reviewers,tags,relatedTerms,synonyms,extension,parent,domains"),
             glossary.getFullyQualifiedName());
     terms.sort(Comparator.comparing(EntityInterface::getFullyQualifiedName));
     return new GlossaryCsv(glossary, user).exportCsv(terms, callback);
@@ -316,7 +319,8 @@ public class GlossaryRepository extends EntityRepository<Glossary> {
           .withOwners(getOwners(printer, csvRecord, 9))
           .withEntityStatus(getTermStatus(printer, csvRecord))
           .withStyle(getStyle(csvRecord))
-          .withExtension(getExtension(printer, csvRecord, 13));
+          .withDomains(getDomains(printer, csvRecord, 13))
+          .withExtension(getExtension(printer, csvRecord, 14));
 
       // Validate to catch logical errors for both dry run and actual import
       if (processRecord) {
@@ -531,8 +535,15 @@ public class GlossaryRepository extends EntityRepository<Glossary> {
       addField(recordList, entity.getEntityStatus().value());
       addField(recordList, entity.getStyle() != null ? entity.getStyle().getColor() : null);
       addField(recordList, entity.getStyle() != null ? entity.getStyle().getIconURL() : null);
+      addDomains(recordList, getDirectDomains(entity.getDomains()));
       addExtension(recordList, entity.getExtension());
       addRecord(csvFile, recordList);
+    }
+
+    private static List<EntityReference> getDirectDomains(List<EntityReference> domains) {
+      return listOrEmpty(domains).stream()
+          .filter(domain -> !Boolean.TRUE.equals(domain.getInherited()))
+          .toList();
     }
 
     private String termReferencesToRecord(List<TermReference> list) {

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/GlossaryTermRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/GlossaryTermRepository.java
@@ -2767,7 +2767,8 @@ public class GlossaryTermRepository extends EntityRepository<GlossaryTerm> {
       String name, String user, boolean recursive, CsvExportProgressCallback callback)
       throws IOException {
     Fields fields =
-        getFields("owners,reviewers,tags,relatedTerms,synonyms,references,extension,parent");
+        getFields(
+            "owners,reviewers,tags,relatedTerms,synonyms,references,extension,parent,domains");
     GlossaryTerm glossaryTerm = getByName(null, name, fields);
     GlossaryRepository glossaryRepository =
         (GlossaryRepository) Entity.getEntityRepository(GLOSSARY);

--- a/openmetadata-service/src/main/resources/json/data/glossary/glossaryCsvDocumentation.json
+++ b/openmetadata-service/src/main/resources/json/data/glossary/glossaryCsvDocumentation.json
@@ -117,6 +117,14 @@
       ]
     },
     {
+      "name": "domains",
+      "required": false,
+      "description": "Fully qualified names of the domains the glossary term belongs to, separated by ';'.",
+      "examples": [
+        "Marketing", "Sales;Operations"
+      ]
+    },
+    {
       "name": "extension",
       "required": false,
       "description": "Custom property values added to the glossary term. Each field value (property and its value) is separated by `;` and internal values can be separated by `|`. For `entityReferenceList` type property, pass `type1:fqn1|type2:fqn2`. For single `entityReference` type property, pass `type:fqn`. Similarly, for `enumMultiSelect`, pass values separated by `|`, and for `enumSingleSelect`, pass a single value along with the property name. For `timeInterval` property type, pass the `startTime:endTime` to the property name. If the field value itself contains delimiter values like `,` and `;` or newline they need to be quoted, and the quotation needs to be further escaped. In general, if passing multiple field values separated by `;`, the extension column value needs to be quoted.",

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/CSVImportWithQuotesAndCommas.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/CSVImportWithQuotesAndCommas.spec.ts
@@ -35,10 +35,10 @@ test.use({
   storageState: 'playwright/.auth/admin.json',
 });
 
-const CSV_WITH_QUOTES_AND_COMMAS = `parent,name*,displayName,description,synonyms,relatedTerms,references,tags,reviewers,owner,glossaryStatus,color,iconURL,extension
-,"Term1",TermAnuj,"<p>Contains a timestamp for the most recent ""login"" of this feature user, to be used for PIN expiration.</p>",,,,,,user:admin,Approved,,,
-,"Test1234","Contains a timestamp for the most recent ""login"" of this feature user, to be used for PIN expiration.","<p>Contains a timestamp for the most recent ""login"" of this feature user, to be used for PIN expiration.</p>",,,,,,user:admin,Approved,,,
-,"TermWithComma,AndQuote","Display name with ""quoted"" text, and comma","<p>Description with ""quotes"" and, commas</p>",,,,,,user:admin,Approved,,,`;
+const CSV_WITH_QUOTES_AND_COMMAS = `parent,name*,displayName,description,synonyms,relatedTerms,references,tags,reviewers,owner,glossaryStatus,color,iconURL,domains,extension
+,"Term1",TermAnuj,"<p>Contains a timestamp for the most recent ""login"" of this feature user, to be used for PIN expiration.</p>",,,,,,user:admin,Approved,,,,
+,"Test1234","Contains a timestamp for the most recent ""login"" of this feature user, to be used for PIN expiration.","<p>Contains a timestamp for the most recent ""login"" of this feature user, to be used for PIN expiration.</p>",,,,,,user:admin,Approved,,,,
+,"TermWithComma,AndQuote","Display name with ""quoted"" text, and comma","<p>Description with ""quotes"" and, commas</p>",,,,,,user:admin,Approved,,,,`;
 
 test.describe('CSV Import with Commas and Quotes - All Entity Types', () => {
   let createCsvImportPromise: () => Promise<void>;

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/GlossaryImportExport.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/GlossaryImportExport.spec.ts
@@ -296,10 +296,10 @@ test.describe('Glossary Bulk Import Export', () => {
         await page.click('[data-testid="manage-button"]');
         await page.click('[data-testid="import-button-description"]');
 
-        const initialCsvContent = `parent,name*,displayName,description,synonyms,relatedTerms,references,tags,reviewers,owner,glossaryStatus,color,iconURL,extension
-,name1,name1,<p>name1</p>,,,,,,user:admin,Approved,,,
-,parent,parent,<p>parent</p>,,,,,,user:admin,Approved,,,
-${circularRefGlossary.data.name}.parent,child,child,<p>child</p>,,,,,,user:admin,Approved,,,`;
+        const initialCsvContent = `parent,name*,displayName,description,synonyms,relatedTerms,references,tags,reviewers,owner,glossaryStatus,color,iconURL,domains,extension
+,name1,name1,<p>name1</p>,,,,,,user:admin,Approved,,,,
+,parent,parent,<p>parent</p>,,,,,,user:admin,Approved,,,,
+${circularRefGlossary.data.name}.parent,child,child,<p>child</p>,,,,,,user:admin,Approved,,,,`;
 
         const initialCsvBlob = new Blob([initialCsvContent], {
           type: 'text/csv',
@@ -353,10 +353,10 @@ ${circularRefGlossary.data.name}.parent,child,child,<p>child</p>,,,,,,user:admin
         await page.click('[data-testid="manage-button"]');
         await page.click('[data-testid="import-button-description"]');
 
-        const circularCsvContent = `parent,name*,displayName,description,synonyms,relatedTerms,references,tags,reviewers,owner,glossaryStatus,color,iconURL,extension
-${circularRefGlossary.data.name}.name1,name1,name1,<p>name1</p>,,,,,,user:admin,Approved,,,
-,parent,parent,<p>parent</p>,,,,,,user:admin,Approved,,,
-${circularRefGlossary.data.name}.parent,child,child,<p>child</p>,,,,,,user:admin,Approved,,,`;
+        const circularCsvContent = `parent,name*,displayName,description,synonyms,relatedTerms,references,tags,reviewers,owner,glossaryStatus,color,iconURL,domains,extension
+${circularRefGlossary.data.name}.name1,name1,name1,<p>name1</p>,,,,,,user:admin,Approved,,,,
+,parent,parent,<p>parent</p>,,,,,,user:admin,Approved,,,,
+${circularRefGlossary.data.name}.parent,child,child,<p>child</p>,,,,,,user:admin,Approved,,,,`;
 
         const circularCsvBlob = new Blob([circularCsvContent], {
           type: 'text/csv',
@@ -429,8 +429,8 @@ ${circularRefGlossary.data.name}.parent,child,child,<p>child</p>,,,,,,user:admin
         await page.click('[data-testid="import-button-description"]');
 
         // CSV with missing name (required field)
-        const missingNameCsv = `parent,name*,displayName,description,synonyms,relatedTerms,references,tags,reviewers,owner,glossaryStatus,color,iconURL,extension
-,,,<p>Description without name</p>,,,,,,user:admin,Approved,,,`;
+        const missingNameCsv = `parent,name*,displayName,description,synonyms,relatedTerms,references,tags,reviewers,owner,glossaryStatus,color,iconURL,domains,extension
+,,,<p>Description without name</p>,,,,,,user:admin,Approved,,,,`;
 
         const csvBlob = new Blob([missingNameCsv], { type: 'text/csv' });
         const csvFile = new File([csvBlob], 'missing-name.csv', {
@@ -488,8 +488,8 @@ ${circularRefGlossary.data.name}.parent,child,child,<p>child</p>,,,,,,user:admin
         await page.click('[data-testid="import-button-description"]');
 
         // CSV with reference to non-existent parent
-        const invalidParentCsv = `parent,name*,displayName,description,synonyms,relatedTerms,references,tags,reviewers,owner,glossaryStatus,color,iconURL,extension
-${parentRefGlossary.data.name}.NonExistentParent,childTerm,childTerm,<p>Child with invalid parent</p>,,,,,,user:admin,Approved,,,`;
+        const invalidParentCsv = `parent,name*,displayName,description,synonyms,relatedTerms,references,tags,reviewers,owner,glossaryStatus,color,iconURL,domains,extension
+${parentRefGlossary.data.name}.NonExistentParent,childTerm,childTerm,<p>Child with invalid parent</p>,,,,,,user:admin,Approved,,,,`;
 
         const csvBlob = new Blob([invalidParentCsv], { type: 'text/csv' });
         const csvFile = new File([csvBlob], 'invalid-parent.csv', {
@@ -551,9 +551,9 @@ ${parentRefGlossary.data.name}.NonExistentParent,childTerm,childTerm,<p>Child wi
         await page.click('[data-testid="import-button-description"]');
 
         // CSV with one valid term and one with circular reference
-        const mixedCsv = `parent,name*,displayName,description,synonyms,relatedTerms,references,tags,reviewers,owner,glossaryStatus,color,iconURL,extension
-,validTerm,validTerm,<p>This is a valid term</p>,,,,,,user:admin,Approved,,,
-${partialGlossary.data.name}.selfRef,selfRef,selfRef,<p>Self-referential term</p>,,,,,,user:admin,Approved,,,`;
+        const mixedCsv = `parent,name*,displayName,description,synonyms,relatedTerms,references,tags,reviewers,owner,glossaryStatus,color,iconURL,domains,extension
+,validTerm,validTerm,<p>This is a valid term</p>,,,,,,user:admin,Approved,,,,
+${partialGlossary.data.name}.selfRef,selfRef,selfRef,<p>Self-referential term</p>,,,,,,user:admin,Approved,,,,`;
 
         const csvBlob = new Blob([mixedCsv], { type: 'text/csv' });
         const csvFile = new File([csvBlob], 'mixed-terms.csv', {

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/importUtils.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/importUtils.ts
@@ -498,6 +498,7 @@ export const fillGlossaryRowDetails = async (
   await fillTextInputDetails(page, base64Src);
 
   await moveToNextColumnWithVerification(page);
+  await moveToNextColumnWithVerification(page);
   await page.locator(RDG_ACTIVE_CELL_SELECTOR).click();
 
   if (propertyListName) {


### PR DESCRIPTION
Cherry-pick of #29481 onto **1.13**, with the test-only follow-up #29507 folded in.

## Background

A parallel fix had been pushed directly to 1.13 (commit `18d94f71`); it was reverted (`2bc54c2a6f`) so the reviewed change from main could be backported instead. This PR is that backport.

## What this includes

**From #29481 (merged to main):**
- Add a `domains` column to the glossary CSV (`glossaryCsvDocumentation.json`, parsed/serialized in `GlossaryCsv`, added to the export field lists in `GlossaryRepository` and `GlossaryTermRepository`) so a term's domains survive an import/export round-trip.
- Exclude **inherited** domains from export (`getDirectDomains`) so a round-trip does not materialize an inherited domain as a direct one.
- Regression ITs: `test_importExportCsv_preservesDomains`, `test_importExportCsv_doesNotMaterializeInheritedDomains`; robust import-result assertion; updated CSV fixtures to the 15-column layout.

**From #29507 (test-only, not separately merged):**
- Add `domains` to `GlossaryResourceIT.getAllCsvHeaders()` so the base `test_importCsv_emptyData` header-only import matches the new 15-column header.

## Conflict resolution

Two test fixtures (`GlossaryCsvRelationTypesIT.java`, `GlossaryImportExport.spec.ts`) conflicted only on main-only typed-relations test blocks that don't exist on 1.13 — resolved by keeping the 1.13 side; all domain-related hunks applied cleanly. Verified no stale 14-column headers/rows remain.

## Verification

`mvn spotless:apply` + `openmetadata-service,openmetadata-integration-tests -am install -DskipTests` → BUILD SUCCESS. Prettier clean on both specs.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR cherry-picks the glossary domains CSV fix from main onto the 1.13 branch, adding a `domains` column (position 13, before `extension`) to the glossary term CSV schema so that directly-assigned domains survive an export/import round-trip. Inherited domains are deliberately excluded from the exported column via `getDirectDomains`, preventing a round-trip from materializing an inherited domain as a direct one.

- **Core fix** (`GlossaryRepository`, `GlossaryTermRepository`): `domains` field added to the CSV column set for both glossary-level and term-level export; import parses column 13 as `getDomains` and shifts `getExtension` to column 14.
- **Test coverage** (`GlossaryResourceIT`): two new regression ITs cover the fix and the inherited-domain guard; all existing CSV fixtures across three IT files and two Playwright specs updated to the 15-column layout.
- **UI helper** (`importUtils.ts`): one extra `moveToNextColumnWithVerification` call added so the grid navigator skips the new `domains` column when filling rows interactively.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is a well-scoped additive column insert into a backward-compatible CSV format, all column indices have been verified consistent, and both the inherited-domain guard and the round-trip behavior are covered by new integration tests.

The column index arithmetic is correct end-to-end (getTermStatus at 10, getStyle at 11-12, getDomains at 13, getExtension at 14, matching the export order), getDirectDomains correctly filters the inherited flag before writing, and all existing fixture files have been updated to the 15-column layout. The two new regression ITs directly exercise the fixed code paths. No logic errors or off-by-one issues were found.

No files require special attention.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/GlossaryRepository.java | Adds domains at column index 13 in both import and export; column indices are consistent with getStyle (cols 11-12) and getTermStatus (col 10). |
| openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/GlossaryTermRepository.java | Adds domains to the fields list fetched for term-level CSV export. |
| openmetadata-service/src/main/resources/json/data/glossary/glossaryCsvDocumentation.json | Inserts domains column documentation between iconURL and extension, matching the new column position 13. |
| openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/GlossaryResourceIT.java | Adds domains to the CSV header constant and all fixture rows; adds two regression tests and a helper assertImportSucceeded. |
| openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/GlossaryCsvRelationTypesIT.java | Updates all inline CSV fixtures from 14 to 15 columns. |
| openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/GlossaryTermRelationEdgeCasesIT.java | Same 14 to 15 column update as GlossaryCsvRelationTypesIT. |
| openmetadata-ui/src/main/resources/ui/playwright/utils/importUtils.ts | Adds one extra moveToNextColumnWithVerification call to skip the new domains column. |
| openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/GlossaryImportExport.spec.ts | Updates all CSV fixtures in E2E tests from 14 to 15 columns. |
| openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/CSVImportWithQuotesAndCommas.spec.ts | Updates the embedded CSV fixture to 15 columns. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant UI as UI / Client
    participant GR as GlossaryRepository
    participant GCsv as GlossaryCsv
    participant DB as Database

    Note over UI,DB: Export flow
    UI->>GR: exportCsv(glossaryName)
    GR->>DB: listAllForCSV(fields incl. domains)
    DB-->>GR: List[GlossaryTerm] with domains
    GR->>GCsv: exportCsv(terms)
    loop per term
        GCsv->>GCsv: col13 addDomains(getDirectDomains()) col14 addExtension()
    end
    GCsv-->>UI: CSV with 15-column rows

    Note over UI,DB: Import flow
    UI->>GR: importCsv(glossaryName, csv)
    GR->>GCsv: importCsv(csv)
    loop per row
        GCsv->>GCsv: col13 getDomains() col14 getExtension()
        GCsv->>DB: createEntity(GlossaryTerm with domains)
    end
    GCsv-->>UI: result CSV
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant UI as UI / Client
    participant GR as GlossaryRepository
    participant GCsv as GlossaryCsv
    participant DB as Database

    Note over UI,DB: Export flow
    UI->>GR: exportCsv(glossaryName)
    GR->>DB: listAllForCSV(fields incl. domains)
    DB-->>GR: List[GlossaryTerm] with domains
    GR->>GCsv: exportCsv(terms)
    loop per term
        GCsv->>GCsv: col13 addDomains(getDirectDomains()) col14 addExtension()
    end
    GCsv-->>UI: CSV with 15-column rows

    Note over UI,DB: Import flow
    UI->>GR: importCsv(glossaryName, csv)
    GR->>GCsv: importCsv(csv)
    loop per row
        GCsv->>GCsv: col13 getDomains() col14 getExtension()
        GCsv->>DB: createEntity(GlossaryTerm with domains)
    end
    GCsv-->>UI: result CSV
```

</a>
</details>

<sub>Reviews (2): Last reviewed commit: ["fix glossaryimportexport playwright"](https://github.com/open-metadata/openmetadata/commit/c1907179bb592d12a8efa56861aa99e49e654305) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40022021)</sub>

<!-- /greptile_comment -->