### PR TITLE
fix(ingestion): detect missing Lake Formation grants in Athena test connection

### DIFF
--- a/ingestion/src/metadata/ingestion/source/database/athena/connection.py
+++ b/ingestion/src/metadata/ingestion/source/database/athena/connection.py
@@ -97,17 +97,19 @@ class AthenaConnection(BaseConnection[AthenaConnectionConfig, Engine]):
         """
         Return the schemas the configured schemaFilterPattern would target,
         mirroring what the ingestion run will actually read. With no pattern
-        configured, every schema in the catalog is returned. The list is capped
-        at MAX_SCHEMAS_TO_PROBE so a catalog with very many databases cannot
-        exhaust the test-connection timeout.
+        configured, every schema in the catalog is returned. Collection stops at
+        MAX_SCHEMAS_TO_PROBE so a catalog with very many databases cannot exhaust
+        the test-connection timeout.
         """
-        all_schemas = inspector.get_schema_names() or []
-        targeted = [
-            schema
-            for schema in all_schemas
-            if not filter_by_schema(self.service_connection.schemaFilterPattern, schema)
-        ]
-        return targeted[:MAX_SCHEMAS_TO_PROBE]
+        schema_filter_pattern = self.service_connection.schemaFilterPattern
+        targeted: List[str] = []  # noqa: UP006
+        for schema in inspector.get_schema_names() or []:
+            if filter_by_schema(schema_filter_pattern, schema):
+                continue
+            targeted.append(schema)
+            if len(targeted) >= MAX_SCHEMAS_TO_PROBE:
+                break
+        return targeted
 
     def test_connection(
         self,
@@ -124,15 +126,22 @@ class AthenaConnection(BaseConnection[AthenaConnectionConfig, Engine]):
         converts the underlying ClientError into an empty list - so an empty
         result is indistinguishable from missing grants. Raising surfaces the
         missing DESCRIBE/SELECT grants instead of passing and then ingesting 0
-        tables.
+        tables. By design this also fails a genuinely empty or view-only catalog
+        (no tables anywhere); the error message calls out that possibility.
         """
         engine = self.client
         catalog_id = self.service_connection.catalogId
         catalog_label = f"catalog '{catalog_id}'" if catalog_id else "the default catalog (AwsDataCatalog)"
+        targeted_schemas_cache: dict = {}
+
+        def get_targeted_schemas() -> List[str]:  # noqa: UP006
+            if "value" not in targeted_schemas_cache:
+                targeted_schemas_cache["value"] = self._get_targeted_schemas(inspect(engine))
+            return targeted_schemas_cache["value"]
 
         def custom_executor_for_table():
+            targeted_schemas = get_targeted_schemas()
             inspector = inspect(engine)
-            targeted_schemas = self._get_targeted_schemas(inspector)
             if not targeted_schemas:
                 raise RuntimeError(
                     f"No schemas were available to read in {catalog_label}. This usually means the "
@@ -147,15 +156,18 @@ class AthenaConnection(BaseConnection[AthenaConnectionConfig, Engine]):
                     f"{len(targeted_schemas)} targeted schema(s) of {catalog_label}. AWS Lake Formation "
                     "returns an empty list (instead of an error) when grants are missing, so ingestion "
                     "would succeed and ingest 0 tables. Grant Lake Formation DESCRIBE/SELECT to the IAM "
-                    "role on the catalog and its databases/tables, then retry."
+                    "role on the catalog and its databases/tables, then retry. If the catalog is "
+                    "genuinely empty (no tables yet), this failure is expected and can be ignored."
                 )
 
         def custom_executor_for_view():
+            targeted_schemas = get_targeted_schemas()
             inspector = inspect(engine)
-            targeted_schemas = self._get_targeted_schemas(inspector)
             # Views are frequently absent and GetViews is non-mandatory, so we
             # probe for visibility but never raise on an empty result.
-            any(inspector.get_view_names(schema) for schema in targeted_schemas)
+            for schema in targeted_schemas:
+                if inspector.get_view_names(schema):
+                    break
 
         test_fn = {
             "CheckAccess": partial(test_connection_engine_step, engine),

--- a/ingestion/src/metadata/ingestion/source/database/athena/connection.py
+++ b/ingestion/src/metadata/ingestion/source/database/athena/connection.py
@@ -14,7 +14,7 @@ Source connection handler
 """
 
 from functools import partial
-from typing import Optional
+from typing import List, Optional  # noqa: UP035
 from urllib.parse import quote_plus
 
 from sqlalchemy.engine import Engine
@@ -44,6 +44,11 @@ from metadata.ingestion.connections.test_connections import (
 from metadata.ingestion.ometa.ometa_api import OpenMetadata
 from metadata.ingestion.source.connections_utils import kill_active_connections
 from metadata.utils.constants import THREE_MIN
+from metadata.utils.filters import filter_by_schema
+
+# Cap how many schemas the test connection probes so a catalog with many
+# databases cannot exhaust the test-connection timeout.
+MAX_SCHEMAS_TO_PROBE = 100
 
 
 class AthenaConnection(BaseConnection[AthenaConnectionConfig, Engine]):
@@ -88,6 +93,22 @@ class AthenaConnection(BaseConnection[AthenaConnectionConfig, Engine]):
             get_connection_args_fn=get_connection_args_common,
         )
 
+    def _get_targeted_schemas(self, inspector: Inspector) -> List[str]:  # noqa: UP006
+        """
+        Return the schemas the configured schemaFilterPattern would target,
+        mirroring what the ingestion run will actually read. With no pattern
+        configured, every schema in the catalog is returned. The list is capped
+        at MAX_SCHEMAS_TO_PROBE so a catalog with very many databases cannot
+        exhaust the test-connection timeout.
+        """
+        all_schemas = inspector.get_schema_names() or []
+        targeted = [
+            schema
+            for schema in all_schemas
+            if not filter_by_schema(self.service_connection.schemaFilterPattern, schema)
+        ]
+        return targeted[:MAX_SCHEMAS_TO_PROBE]
+
     def test_connection(
         self,
         metadata: OpenMetadata,
@@ -96,23 +117,45 @@ class AthenaConnection(BaseConnection[AthenaConnectionConfig, Engine]):
     ) -> TestConnectionResult:
         """
         Test connection. This can be executed either as part
-        of a metadata workflow or during an Automation Workflow
+        of a metadata workflow or during an Automation Workflow.
+
+        GetTables raises when the targeted schemas return zero readable tables
+        anywhere. AWS Lake Formation silently filters results - pyathena even
+        converts the underlying ClientError into an empty list - so an empty
+        result is indistinguishable from missing grants. Raising surfaces the
+        missing DESCRIBE/SELECT grants instead of passing and then ingesting 0
+        tables.
         """
         engine = self.client
-
-        def get_test_schema(inspector: Inspector):
-            all_schemas = inspector.get_schema_names()
-            return all_schemas[0] if all_schemas else None
+        catalog_id = self.service_connection.catalogId
+        catalog_label = f"catalog '{catalog_id}'" if catalog_id else "the default catalog (AwsDataCatalog)"
 
         def custom_executor_for_table():
             inspector = inspect(engine)
-            test_schema = get_test_schema(inspector)
-            return inspector.get_table_names(test_schema) if test_schema else []
+            targeted_schemas = self._get_targeted_schemas(inspector)
+            if not targeted_schemas:
+                raise RuntimeError(
+                    f"No schemas were available to read in {catalog_label}. This usually means the "
+                    "configured schemaFilterPattern matches no databases, or the IAM role is missing "
+                    "AWS Lake Formation DESCRIBE grants. Grant Lake Formation DESCRIBE/SELECT and verify "
+                    "the schema filter pattern."
+                )
+            readable = any(inspector.get_table_names(schema) for schema in targeted_schemas)
+            if not readable:
+                raise RuntimeError(
+                    f"Connected and listed schemas, but no tables were readable in any of the "
+                    f"{len(targeted_schemas)} targeted schema(s) of {catalog_label}. AWS Lake Formation "
+                    "returns an empty list (instead of an error) when grants are missing, so ingestion "
+                    "would succeed and ingest 0 tables. Grant Lake Formation DESCRIBE/SELECT to the IAM "
+                    "role on the catalog and its databases/tables, then retry."
+                )
 
         def custom_executor_for_view():
             inspector = inspect(engine)
-            test_schema = get_test_schema(inspector)
-            return inspector.get_view_names(test_schema) if test_schema else []
+            targeted_schemas = self._get_targeted_schemas(inspector)
+            # Views are frequently absent and GetViews is non-mandatory, so we
+            # probe for visibility but never raise on an empty result.
+            any(inspector.get_view_names(schema) for schema in targeted_schemas)
 
         test_fn = {
             "CheckAccess": partial(test_connection_engine_step, engine),

--- a/ingestion/tests/unit/source/database/athena/test_connection.py
+++ b/ingestion/tests/unit/source/database/athena/test_connection.py
@@ -183,3 +183,18 @@ def test_get_tables_caps_probing_at_max_schemas():
         captured = _run_steps_capturing(conn)
     assert isinstance(captured["GetTables"], Exception)
     assert inspector.get_table_names.call_count <= athena_connection.MAX_SCHEMAS_TO_PROBE
+
+
+def test_targeted_schemas_listed_once_across_table_and_view_steps():
+    conn = AthenaConnection(_config())
+    conn._client = MagicMock()
+    inspector = MagicMock()
+    inspector.get_schema_names.return_value = ["db1"]
+    inspector.get_table_names.return_value = ["t1"]
+    inspector.get_view_names.return_value = []
+    with patch(f"{CONNECTION_MODULE}.inspect", return_value=inspector):
+        _run_steps_capturing(conn)
+    # The memoized table + view executors share a single schema listing on this
+    # inspector (1 call), instead of one each (2). GetSchemas uses its own
+    # inspector via execute_inspector_func and does not touch this mock.
+    assert inspector.get_schema_names.call_count == 1

--- a/ingestion/tests/unit/source/database/athena/test_connection.py
+++ b/ingestion/tests/unit/source/database/athena/test_connection.py
@@ -19,7 +19,9 @@ from metadata.generated.schema.entity.services.connections.database.athenaConnec
     AthenaScheme,
 )
 from metadata.generated.schema.security.credentials.awsCredentials import AWSCredentials
+from metadata.generated.schema.type.filterPattern import FilterPattern
 from metadata.ingestion.connections.connection import BaseConnection
+from metadata.ingestion.source.database.athena import connection as athena_connection
 from metadata.ingestion.source.database.athena.connection import AthenaConnection
 
 CONNECTION_MODULE = "metadata.ingestion.source.database.athena.connection"
@@ -34,6 +36,32 @@ def _config(**kwargs) -> AthenaConnectionConfig:
     }
     base.update(kwargs)
     return AthenaConnectionConfig(**base)
+
+
+def _run_steps_capturing(conn) -> dict:
+    """
+    Patch the framework so each test_fn callable is invoked directly and any
+    raised exception is captured. Returns {step_name: raised_exc_or_None}.
+    The executors are nested closures, so they are driven via the public
+    test_connection with inspect() mocked.
+    """
+    captured = {}
+
+    def fake_steps(*, test_fn, **_kwargs):
+        for name, fn in test_fn.items():
+            try:
+                fn()
+                captured[name] = None
+            except Exception as err:
+                captured[name] = err
+        return MagicMock()
+
+    with (
+        patch(f"{CONNECTION_MODULE}.test_connection_steps", side_effect=fake_steps),
+        patch(f"{CONNECTION_MODULE}.kill_active_connections"),
+    ):
+        conn.test_connection(metadata=MagicMock())
+    return captured
 
 
 def test_athena_connection_is_base_connection():
@@ -71,3 +99,87 @@ def test_athena_url_other_staging_dir():
         "?s3_staging_dir=s3%3A%2F%2Fpostgres%2Fintput%2F&work_group=primary"
     )
     assert AthenaConnection.get_connection_url(_config(s3StagingDir="s3://postgres/intput/")) == expected
+
+
+def test_get_tables_raises_when_all_targeted_schemas_empty():
+    conn = AthenaConnection(_config(catalogId="my_catalog"))
+    conn._client = MagicMock()
+    inspector = MagicMock()
+    inspector.get_schema_names.return_value = ["db1", "db2"]
+    inspector.get_table_names.return_value = []
+    with patch(f"{CONNECTION_MODULE}.inspect", return_value=inspector):
+        captured = _run_steps_capturing(conn)
+    assert isinstance(captured["GetTables"], Exception)
+
+
+def test_get_tables_passes_when_a_schema_has_tables():
+    conn = AthenaConnection(_config())
+    conn._client = MagicMock()
+    inspector = MagicMock()
+    inspector.get_schema_names.return_value = ["db1", "db2"]
+    inspector.get_table_names.side_effect = lambda schema: ["t1"] if schema == "db2" else []
+    with patch(f"{CONNECTION_MODULE}.inspect", return_value=inspector):
+        captured = _run_steps_capturing(conn)
+    assert captured["GetTables"] is None
+
+
+def test_get_tables_honors_schema_filter_pattern():
+    conn = AthenaConnection(_config(schemaFilterPattern=FilterPattern(includes=["db2"])))
+    conn._client = MagicMock()
+    inspector = MagicMock()
+    inspector.get_schema_names.return_value = ["db1", "db2"]
+    inspector.get_table_names.side_effect = lambda schema: ["t1"] if schema == "db2" else []
+    with patch(f"{CONNECTION_MODULE}.inspect", return_value=inspector):
+        captured = _run_steps_capturing(conn)
+    assert captured["GetTables"] is None
+    probed = {call.args[0] for call in inspector.get_table_names.call_args_list}
+    assert probed == {"db2"}
+
+
+def test_get_tables_raises_when_filter_matches_nothing():
+    conn = AthenaConnection(_config(catalogId="my_catalog", schemaFilterPattern=FilterPattern(includes=["nope"])))
+    conn._client = MagicMock()
+    inspector = MagicMock()
+    inspector.get_schema_names.return_value = ["db1", "db2"]
+    with patch(f"{CONNECTION_MODULE}.inspect", return_value=inspector):
+        captured = _run_steps_capturing(conn)
+    assert isinstance(captured["GetTables"], Exception)
+    inspector.get_table_names.assert_not_called()
+
+
+def test_get_views_does_not_raise_when_empty():
+    conn = AthenaConnection(_config())
+    conn._client = MagicMock()
+    inspector = MagicMock()
+    inspector.get_schema_names.return_value = ["db1"]
+    inspector.get_table_names.return_value = ["t1"]
+    inspector.get_view_names.return_value = []
+    with patch(f"{CONNECTION_MODULE}.inspect", return_value=inspector):
+        captured = _run_steps_capturing(conn)
+    assert captured["GetViews"] is None
+
+
+def test_get_tables_error_message_is_actionable():
+    conn = AthenaConnection(_config(catalogId="my_catalog"))
+    conn._client = MagicMock()
+    inspector = MagicMock()
+    inspector.get_schema_names.return_value = ["db1"]
+    inspector.get_table_names.return_value = []
+    with patch(f"{CONNECTION_MODULE}.inspect", return_value=inspector):
+        captured = _run_steps_capturing(conn)
+    raised = str(captured["GetTables"])
+    assert "Lake Formation" in raised
+    assert "my_catalog" in raised
+    assert any(keyword in raised.lower() for keyword in ("describe", "select", "grant"))
+
+
+def test_get_tables_caps_probing_at_max_schemas():
+    conn = AthenaConnection(_config(catalogId="my_catalog"))
+    conn._client = MagicMock()
+    inspector = MagicMock()
+    inspector.get_schema_names.return_value = [f"db{i}" for i in range(500)]
+    inspector.get_table_names.return_value = []
+    with patch(f"{CONNECTION_MODULE}.inspect", return_value=inspector):
+        captured = _run_steps_capturing(conn)
+    assert isinstance(captured["GetTables"], Exception)
+    assert inspector.get_table_names.call_count <= athena_connection.MAX_SCHEMAS_TO_PROBE


### PR DESCRIPTION
Fixes #29160 

## Problem

The Athena connector's **Test Connection** reported all four steps green —
CheckAccess, GetSchemas, GetTables, GetViews — even when the IAM role was
missing the AWS Lake Formation `DESCRIBE`/`SELECT` grants needed to read the
target tables. The metadata run then "succeeded" but ingested **0 tables**,
giving users no signal that anything was wrong.

### Why it passed

- The test steps only checked that the AWS call *didn't raise*. AWS Lake
  Formation **silently filters** results — when grants are missing it returns
  an **empty list instead of an error**. pyathena reinforces this: its
  `list_table_metadata`/`_get_schemas` even convert some `ClientError`s into
  `[]`. So `inspector.get_table_names(schema)` came back empty, the step was
  marked passed, and nothing raised.
- The old executor probed only the **first** schema returned (`all_schemas[0]`),
  not the schemas the configured `schemaFilterPattern` actually targets.

### Catalog vs. schema

`catalogId` is the AWS **data catalog** (the level *above* schemas), injected
into the connection URL as `&catalog_name=<catalogId>`. pyathena scopes
`list_databases`/`list_table_metadata` to it, so `get_schema_names()` already
returns the databases *within* the configured catalog and `get_table_names()`
is already catalog-scoped. A single Athena service maps to a single catalog
(Athena doesn't override `get_database_names`), so detecting "zero readable
tables across the targeted schemas" via the inspector is a faithful proxy for
the same condition that makes ingestion yield 0 tables.

## Fix

- **`GetTables`** now selects the schemas `schemaFilterPattern` would target
  (reusing `filter_by_schema`, capped at `MAX_SCHEMAS_TO_PROBE = 100` so a
  catalog with many databases can't exhaust the 3-minute timeout) and **raises**
  when no tables are readable in any of them — with a message naming the catalog
  and pointing the user at Lake Formation `DESCRIBE`/`SELECT` grants. It passes
  as soon as **any one** targeted schema is readable.
- **`GetViews`** uses the same schema selection but **never raises** on empty
  (views are legitimately often absent; the step is non-mandatory).
- The Athena test-connection definition's `GetTables` `errorMessage` now mentions
  Lake Formation so the user-visible one-liner is actionable.


#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [x] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### High-level design:
<!--
REQUIRED for large PRs (new features, refactors, breaking changes, or anything touching >5 files).
Skip for small bug fixes and trivial changes.

Cover:
- Architecture / approach you took and why
- Key components or files added/changed and how they interact
- Alternatives considered and why you rejected them
- Any migration, backward-compatibility, or rollout concerns
- Diagrams or links to design docs / RFCs if available
-->

N/A — small change. <!-- Or fill in the design above -->

#
### Tests:

#### Use cases covered
<!--
List the user-visible scenarios this PR exercises. Example:
- User with Admin role can create a Glossary Term with a parent term
- Ingestion run for Snowflake correctly extracts row counts for partitioned tables
-->

#### Unit tests
<!--
- [ ] I added unit tests for the new/changed logic.
- Files added/updated:
- Coverage on changed classes (run `mvn jacoco:report` for backend, `yarn test:coverage` for UI,
  `make unit_ingestion` for ingestion). Target is 90% line coverage on changed classes.
- Coverage %: <e.g., 92% on EntityRepository.java>
-->

#### Backend integration tests
<!--
- [ ] I added integration tests in `openmetadata-integration-tests/` for new/changed API endpoints.
- [ ] Not applicable (no backend API changes).
- Files added/updated:
-->

#### Ingestion integration tests
<!--
- [ ] I added/updated ingestion integration tests for connector changes.
- [ ] Not applicable (no ingestion changes).
- Files added/updated:
-->

#### Playwright (UI) tests
<!--
- [ ] I added Playwright E2E tests under `openmetadata-ui/.../ui/playwright/` for UI changes.
- [ ] Not applicable (no UI changes).
- Files added/updated:
-->

#### Manual testing performed
<!--
List the manual test steps you performed before requesting review. Example:
1. Started local stack via `./docker/run_local_docker.sh -m ui -d mysql`
2. Logged in as admin, created entity X, verified Y appears in the UI
3. Triggered ingestion for Snowflake source, confirmed lineage edges in the explore page
-->

#
### UI screen recording / screenshots:
<!--
REQUIRED for any PR that changes the UI. Drag-and-drop a short screen recording (.mov / .mp4 / .gif)
demonstrating the change end-to-end, plus before/after screenshots where relevant.
Mark "Not applicable" if there are no UI changes.
-->

Not applicable. <!-- Or attach recording/screenshots above -->

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.
- [ ] For UI changes: I attached a screen recording and/or screenshots above.
- [ ] I have added tests (unit / integration / Playwright as applicable) and listed them above.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a silent false-positive in the Athena connector's Test Connection flow: AWS Lake Formation returns empty lists (not errors) when grants are missing, so the old executor reported all steps green while ingestion would produce 0 tables. The fix makes `GetTables` inspect the schemas the configured `schemaFilterPattern` actually targets and raise a descriptive `RuntimeError` when no tables are readable across all of them.

- `_get_targeted_schemas()` mirrors the ingestion-time schema filter and caps probing at `MAX_SCHEMAS_TO_PROBE = 100` to avoid exhausting the 3-minute timeout on wide catalogs.
- `custom_executor_for_table` short-circuits as soon as any one targeted schema has at least one readable table; `custom_executor_for_view` is probe-only and never raises, because views are legitimately absent.
- Eight new unit tests cover the raise/pass/filter/cap/memoisation behaviours introduced by the fix.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is scoped entirely to the Athena test-connection path and does not touch ingestion runtime, schema listing logic, or any shared utilities.

The implementation correctly mirrors the ingestion-time schema filter, handles the Lake Formation silent-empty-list behaviour, caps probing to avoid timeouts, and memoises schema listing across the two executor steps. All new code paths are covered by targeted unit tests that verify both the raise and the pass conditions. No existing tests are broken and no shared code was modified.

No files require special attention.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| ingestion/src/metadata/ingestion/source/database/athena/connection.py | Adds _get_targeted_schemas(), rewrites custom_executor_for_table to raise on zero-readable-tables, and updates custom_executor_for_view to probe-only. Logic is correct; minor ordering nit with inspect() before the guard is cosmetic only. |
| ingestion/tests/unit/source/database/athena/test_connection.py | Adds eight focused unit tests covering empty schema list, partial reads, filter pattern, cap at MAX_SCHEMAS_TO_PROBE, and memoisation. Test helper _run_steps_capturing correctly intercepts the framework without coupling to its internals. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant TC as test_connection()
    participant GS as get_targeted_schemas() [memoised]
    participant Insp as SQLAlchemy Inspector
    participant LF as AWS Lake Formation (via pyathena)

    TC->>GS: get_targeted_schemas()
    GS->>Insp: get_schema_names()
    Insp->>LF: list_databases (catalog-scoped)
    LF-->>Insp: ["db1", "db2", ...]
    Insp-->>GS: schema list
    GS->>GS: filter_by_schema + cap at MAX_SCHEMAS_TO_PROBE
    GS-->>TC: targeted_schemas (cached)

    note over TC: GetTables step
    TC->>Insp: get_table_names(schema) for each targeted schema
    Insp->>LF: list_table_metadata (catalog-scoped)
    alt Lake Formation grants missing
        LF-->>Insp: [] (silently filtered)
        Insp-->>TC: []
        TC-->>TC: raise RuntimeError (Lake Formation DESCRIBE/SELECT missing)
    else Grants present
        LF-->>Insp: ["t1", "t2"]
        Insp-->>TC: ["t1", "t2"]
        TC-->>TC: "any() == True → pass"
    end

    note over TC: GetViews step (non-mandatory, never raises)
    TC->>GS: get_targeted_schemas() [cache hit, no new call]
    GS-->>TC: targeted_schemas
    TC->>Insp: get_view_names(schema) for each targeted schema
    Insp-->>TC: views or []
    TC-->>TC: break on first non-empty, or finish quietly
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant TC as test_connection()
    participant GS as get_targeted_schemas() [memoised]
    participant Insp as SQLAlchemy Inspector
    participant LF as AWS Lake Formation (via pyathena)

    TC->>GS: get_targeted_schemas()
    GS->>Insp: get_schema_names()
    Insp->>LF: list_databases (catalog-scoped)
    LF-->>Insp: ["db1", "db2", ...]
    Insp-->>GS: schema list
    GS->>GS: filter_by_schema + cap at MAX_SCHEMAS_TO_PROBE
    GS-->>TC: targeted_schemas (cached)

    note over TC: GetTables step
    TC->>Insp: get_table_names(schema) for each targeted schema
    Insp->>LF: list_table_metadata (catalog-scoped)
    alt Lake Formation grants missing
        LF-->>Insp: [] (silently filtered)
        Insp-->>TC: []
        TC-->>TC: raise RuntimeError (Lake Formation DESCRIBE/SELECT missing)
    else Grants present
        LF-->>Insp: ["t1", "t2"]
        Insp-->>TC: ["t1", "t2"]
        TC-->>TC: "any() == True → pass"
    end

    note over TC: GetViews step (non-mandatory, never raises)
    TC->>GS: get_targeted_schemas() [cache hit, no new call]
    GS-->>TC: targeted_schemas
    TC->>Insp: get_view_names(schema) for each targeted schema
    Insp-->>TC: views or []
    TC-->>TC: break on first non-empty, or finish quietly
```

</a>
</details>

<sub>Reviews (2): Last reviewed commit: ["refactor(ingestion): address review feed..."](https://github.com/open-metadata/openmetadata/commit/be547bb558cd47e3813c8435b33a060ddb06ec25) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40025725)</sub>

<!-- /greptile_comment -->