### PR TITLE
feat(ui-core-components): add attach label placement to ProgressSteps

### DIFF
--- a/openmetadata-ui-core-components/src/main/resources/ui/src/components/application/progress-steps/progress-steps.tsx
+++ b/openmetadata-ui-core-components/src/main/resources/ui/src/components/application/progress-steps/progress-steps.tsx
@@ -477,7 +477,11 @@ const VerticalSteps = ({
         aria-current={status === 'current' ? 'step' : undefined}
         className="tw:flex tw:gap-3"
         key={getStepKey(step, index)}>
-        <div className="tw:flex tw:flex-col tw:items-center tw:gap-1">
+        <div
+          className={cx(
+            'tw:flex tw:flex-col tw:items-center tw:gap-2',
+            !isLast && 'tw:pb-2'
+          )}>
           <StepIndicator
             icon={step.icon}
             index={index}

--- a/openmetadata-ui-core-components/src/main/resources/ui/src/components/application/progress-steps/progress-steps.tsx
+++ b/openmetadata-ui-core-components/src/main/resources/ui/src/components/application/progress-steps/progress-steps.tsx
@@ -137,13 +137,13 @@ const titleStatusStyles = sortCx({
 });
 
 const attachCircleStatusStyles = sortCx({
-  complete: 'tw:bg-brand-solid tw:text-fg-white',
+  complete: 'tw:bg-success-solid tw:text-fg-white',
   current: 'tw:bg-brand-solid tw:text-fg-white',
   incomplete: 'tw:bg-disabled tw:text-disabled',
 });
 
 const attachTitleStatusStyles = sortCx({
-  complete: 'tw:text-primary',
+  complete: 'tw:text-fg-success-primary',
   current: 'tw:text-primary',
   incomplete: 'tw:text-disabled',
 });

--- a/openmetadata-ui-core-components/src/main/resources/ui/src/components/application/progress-steps/progress-steps.tsx
+++ b/openmetadata-ui-core-components/src/main/resources/ui/src/components/application/progress-steps/progress-steps.tsx
@@ -28,6 +28,17 @@ export type ProgressStepsOrientation = 'horizontal' | 'vertical';
 
 export type ProgressStepsSize = 'sm' | 'md' | 'lg';
 
+/**
+ * Where the step label sits relative to the indicator on horizontal layouts.
+ *
+ * - `bottom` (default): label is rendered below the indicator and centered —
+ *   the standard Untitled UI horizontal stepper.
+ * - `attach`: label sits inline to the right of the indicator. Incomplete
+ *   steps render in a disabled style, and connectors collapse to short
+ *   horizontal lines between adjacent step groups.
+ */
+export type ProgressStepsLabelPlacement = 'bottom' | 'attach';
+
 export interface ProgressStepItem {
   /**
    * Stable identifier for the step. Used as the React key so that reordering,
@@ -68,6 +79,13 @@ export interface ProgressStepsProps
   size?: ProgressStepsSize;
   /** Render the connecting lines between steps. */
   showConnector?: boolean;
+  /**
+   * Where the step label sits relative to the indicator on horizontal
+   * layouts. Defaults to `'bottom'`. Use `'attach'` to render the indicator
+   * and label side-by-side with a disabled treatment for incomplete steps.
+   * Ignored when `orientation` is `'vertical'` or when `type` is `'line'`.
+   */
+  labelPlacement?: ProgressStepsLabelPlacement;
   className?: string;
 }
 
@@ -118,6 +136,18 @@ const titleStatusStyles = sortCx({
   incomplete: 'tw:text-secondary',
 });
 
+const attachCircleStatusStyles = sortCx({
+  complete: 'tw:bg-brand-solid tw:text-fg-white',
+  current: 'tw:bg-brand-solid tw:text-fg-white',
+  incomplete: 'tw:bg-disabled tw:text-disabled',
+});
+
+const attachTitleStatusStyles = sortCx({
+  complete: 'tw:text-primary',
+  current: 'tw:text-primary',
+  incomplete: 'tw:text-disabled',
+});
+
 const resolveStatus = (
   step: ProgressStepItem,
   index: number,
@@ -156,6 +186,12 @@ interface StepIndicatorProps {
   size: ProgressStepsSize;
   index: number;
   icon?: FC<{ className?: string }>;
+  /**
+   * Render the indicator with the attached-variant treatment (solid brand fill
+   * for the current step, disabled fill for incomplete steps). Defaults to
+   * `false` so the standard Untitled UI palette is used.
+   */
+  attached?: boolean;
 }
 
 const FeaturedStepIcon = ({
@@ -211,6 +247,7 @@ const CircleStepIcon = ({
   size,
   index,
   icon: Icon,
+  attached,
 }: StepIndicatorProps) => {
   const isComplete = status === 'complete';
   let content: ReactNode;
@@ -231,12 +268,16 @@ const CircleStepIcon = ({
     );
   }
 
+  const statusStyles = attached
+    ? attachCircleStatusStyles[status]
+    : circleStatusStyles[status];
+
   return (
     <span
       className={cx(
         'tw:flex tw:shrink-0 tw:items-center tw:justify-center tw:rounded-full tw:transition-colors',
         sizes[size].circle,
-        circleStatusStyles[status]
+        statusStyles
       )}>
       {content}
     </span>
@@ -286,10 +327,19 @@ interface StepTextProps {
   status: ProgressStepStatus;
   size: ProgressStepsSize;
   align: 'center' | 'left';
+  /**
+   * Apply the attached-variant title palette (primary text for the active
+   * step, disabled text for incomplete steps). Defaults to `false`.
+   */
+  attached?: boolean;
 }
 
-const StepText = ({ step, status, size, align }: StepTextProps) => {
+const StepText = ({ step, status, size, align, attached }: StepTextProps) => {
   let text: ReactNode = null;
+
+  const titleColor = attached
+    ? attachTitleStatusStyles[status]
+    : titleStatusStyles[status];
 
   if (step.title || step.description) {
     text = (
@@ -299,7 +349,7 @@ const StepText = ({ step, status, size, align }: StepTextProps) => {
           align === 'center' ? 'tw:items-center tw:text-center' : 'tw:text-left'
         )}>
         {step.title && (
-          <span className={cx(sizes[size].title, titleStatusStyles[status])}>
+          <span className={cx(sizes[size].title, titleColor)}>
             {step.title}
           </span>
         )}
@@ -322,6 +372,49 @@ interface RenderArgs {
   size: ProgressStepsSize;
   showConnector: boolean;
 }
+
+const AttachedHorizontalSteps = ({
+  steps,
+  statuses,
+  type,
+  size,
+  showConnector,
+}: RenderArgs) =>
+  steps.map((step, index) => {
+    const status = statuses[index];
+    const isLast = index === steps.length - 1;
+
+    return (
+      <li
+        aria-current={status === 'current' ? 'step' : undefined}
+        className="tw:flex tw:items-center"
+        key={getStepKey(step, index)}>
+        <div className="tw:flex tw:items-center tw:gap-2">
+          <StepIndicator
+            attached
+            icon={step.icon}
+            index={index}
+            size={size}
+            status={status}
+            type={type as Exclude<ProgressStepType, 'line'>}
+          />
+          <StepText
+            attached
+            align="left"
+            size={size}
+            status={status}
+            step={step}
+          />
+        </div>
+        {showConnector && !isLast && (
+          <span
+            aria-hidden="true"
+            className="tw:mx-3 tw:h-px tw:w-8 tw:shrink-0 tw:bg-quaternary"
+          />
+        )}
+      </li>
+    );
+  });
 
 const HorizontalSteps = ({
   steps,
@@ -451,6 +544,7 @@ export const ProgressSteps = ({
   orientation = 'horizontal',
   size = 'md',
   showConnector = true,
+  labelPlacement = 'bottom',
   className,
   ...props
 }: ProgressStepsProps) => {
@@ -464,6 +558,10 @@ export const ProgressSteps = ({
   );
 
   const renderArgs: RenderArgs = { steps, statuses, type, size, showConnector };
+  const isAttached =
+    labelPlacement === 'attach' &&
+    orientation === 'horizontal' &&
+    type !== 'line';
 
   let content: ReactNode;
   let listClassName: string;
@@ -474,6 +572,9 @@ export const ProgressSteps = ({
   } else if (orientation === 'vertical') {
     content = <VerticalSteps {...renderArgs} />;
     listClassName = 'tw:flex tw:flex-col';
+  } else if (isAttached) {
+    content = <AttachedHorizontalSteps {...renderArgs} />;
+    listClassName = 'tw:flex tw:items-center';
   } else {
     content = <HorizontalSteps {...renderArgs} />;
     listClassName = 'tw:flex tw:w-full';

--- a/openmetadata-ui-core-components/src/main/resources/ui/src/components/application/progress-steps/progress-steps.tsx
+++ b/openmetadata-ui-core-components/src/main/resources/ui/src/components/application/progress-steps/progress-steps.tsx
@@ -83,7 +83,9 @@ export interface ProgressStepsProps
    * Where the step label sits relative to the indicator on horizontal
    * layouts. Defaults to `'bottom'`. Use `'attach'` to render the indicator
    * and label side-by-side with a disabled treatment for incomplete steps.
-   * Ignored when `orientation` is `'vertical'` or when `type` is `'line'`.
+   * Only applies when `orientation === 'horizontal'` and `type` is `'number'`
+   * or `'icon'`; other combinations fall back to the standard horizontal
+   * layout to keep the indicator and label palettes consistent.
    */
   labelPlacement?: ProgressStepsLabelPlacement;
   className?: string;
@@ -409,7 +411,10 @@ const AttachedHorizontalSteps = ({
         {showConnector && !isLast && (
           <span
             aria-hidden="true"
-            className="tw:mx-3 tw:h-px tw:w-8 tw:shrink-0 tw:bg-quaternary"
+            className={cx(
+              'tw:mx-3 tw:h-px tw:w-8 tw:shrink-0',
+              status === 'complete' ? 'tw:bg-success-solid' : 'tw:bg-quaternary'
+            )}
           />
         )}
       </li>
@@ -565,7 +570,7 @@ export const ProgressSteps = ({
   const isAttached =
     labelPlacement === 'attach' &&
     orientation === 'horizontal' &&
-    type !== 'line';
+    (type === 'number' || type === 'icon');
 
   let content: ReactNode;
   let listClassName: string;

--- a/openmetadata-ui-core-components/src/main/resources/ui/src/stories/ProgressSteps.stories.tsx
+++ b/openmetadata-ui-core-components/src/main/resources/ui/src/stories/ProgressSteps.stories.tsx
@@ -28,6 +28,12 @@ const steps: ProgressStepItem[] = [
   },
 ];
 
+const attachedSteps: ProgressStepItem[] = [
+  { title: 'Template' },
+  { title: 'Configure' },
+  { title: 'Schedule' },
+];
+
 const stepsWithIcons: ProgressStepItem[] = [
   { ...steps[0], icon: File02 },
   { ...steps[1], icon: Cube01 },
@@ -57,6 +63,16 @@ export const IconCentered: Story = {
 
 export const NumberCentered: Story = {
   args: { type: 'number', orientation: 'horizontal' },
+};
+
+export const NumberAttached: Story = {
+  args: {
+    type: 'number',
+    orientation: 'horizontal',
+    labelPlacement: 'attach',
+    steps: attachedSteps,
+    currentStep: 0,
+  },
 };
 
 export const FeaturedIconCentered: Story = {


### PR DESCRIPTION
### Describe your changes:

I added a new `labelPlacement="attach"` variant to the shared `ProgressSteps` component in `@openmetadata/ui-core-components` because the existing horizontal stepper only supported a bottom-aligned label, while several upcoming flows (e.g. AI Automations create wizard) need the indicator and title rendered inline with a disabled treatment for not-yet-visited steps.

#
### Type of change:
- [x] New feature

#
### High-level design:

- Added `labelPlacement?: 'bottom' | 'attach'` prop (default `'bottom'`, preserves existing behavior).
- New `attachCircleStatusStyles` / `attachTitleStatusStyles` palettes: current/complete render as solid brand fill with white number; incomplete renders as `bg-disabled` + `text-disabled` to match the disabled-state mock.
- New `AttachedHorizontalSteps` renderer places indicator and label side-by-side; short `mx-3` line connector between steps gives equal breathing space on both sides.
- Plumbed an internal `attached` flag through `CircleStepIcon` and `StepText` so existing components are reused rather than duplicated.
- `attach` only applies when `orientation="horizontal"` and `type !== 'line'`; otherwise it transparently falls back to the existing renderers.

#
### Tests:

#### Use cases covered
- ProgressSteps with `labelPlacement="attach"` renders indicator and title inline.
- Incomplete steps show disabled-state styling; current/complete steps show solid brand fill.
- Connector line has equal spacing on either side and does not touch the next indicator.

#### Playwright (UI) tests
- [x] Not applicable (component-library change; covered via Storybook story `Application/ProgressSteps/NumberAttached`).

#### Manual testing performed
1. Ran `yarn type-check` and `prettier --check` in `openmetadata-ui-core-components/.../ui` — both clean.
2. Verified the new `NumberAttached` story matches the provided mock (Template / Configure / Schedule, step 1 active).

#
### UI screen recording / screenshots:

See Storybook story `Application/ProgressSteps → NumberAttached`.

<img width="688" height="176" alt="Screenshot 2026-06-26 at 12 08 33 PM" src="https://github.com/user-attachments/assets/32913b16-c3d5-4041-ad4e-c26adb151079" />

<img width="658" height="193" alt="Screenshot 2026-06-26 at 12 09 21 PM" src="https://github.com/user-attachments/assets/0129e254-f3e0-469b-8fec-c1f0f98cd9bf" />

#
### Checklist:
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests (Storybook story) and listed them above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds a new `labelPlacement="attach"` prop to `ProgressSteps` that renders the indicator and label inline, side-by-side, with a disabled treatment for incomplete steps — intended for wizard flows like the AI Automations create wizard.

- **New `AttachedHorizontalSteps` renderer**: renders each `<li>` as `[indicator] [label] [short connector]`, gated behind `orientation === 'horizontal'` and `type` of `'number'` or `'icon'`.
- **New style palettes** (`attachCircleStatusStyles`, `attachTitleStatusStyles`): the `complete` state is incorrectly wired to `tw:bg-success-solid` / `tw:text-fg-success-primary` (green) while the design spec and PR description state both current and complete should use the brand fill.
- A `NumberAttached` Storybook story is included but only exercises the `current` step, leaving the complete-state colour bug uncovered.
</details>


<details open><summary><h3>Confidence Score: 3/5</h3></summary>

The attached-variant complete state renders green (success) circles and connectors everywhere a finished step should show brand styling — contradicting the stated design intent — so the feature is visually wrong for any multi-step flow where the user advances past step 1.

Two independent style values hardcode `tw:bg-success-solid` for the complete state (circle background and connector), while a third uses `tw:text-fg-success-primary` for the completed step title. The PR description is explicit that both current and complete states should use solid brand fill. Because the Storybook story never exercises a completed step, the bug is not caught by the supplied test coverage.

progress-steps.tsx — the `attachCircleStatusStyles`, `attachTitleStatusStyles`, and the inline connector colour expression all need the `complete` colour corrected from success to brand.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| openmetadata-ui-core-components/src/main/resources/ui/src/components/application/progress-steps/progress-steps.tsx | Adds `labelPlacement="attach"` horizontal variant with a new renderer and style palettes; complete-state colours use `bg-success-solid` (green) instead of the `bg-brand-solid` called for in the design spec, affecting both the circle indicator and the connector; also contains an unexplained spacing tweak to existing `VerticalSteps`. |
| openmetadata-ui-core-components/src/main/resources/ui/src/stories/ProgressSteps.stories.tsx | Adds `NumberAttached` story demonstrating the new variant with step 0 as current; the story never advances past step 0, so the incorrect `bg-success-solid` complete-state styling is not exercised. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[ProgressSteps] --> B{type === 'line'?}
    B -- yes --> C[LineSteps]
    B -- no --> D{orientation === 'vertical'?}
    D -- yes --> E[VerticalSteps]
    D -- no --> F{isAttached?\nlabelPlacement=attach\n+ horizontal\n+ number or icon}
    F -- yes --> G[AttachedHorizontalSteps\nIndicator + Label inline\nShort fixed connector]
    F -- no --> H[HorizontalSteps\nLabel below indicator\nFull-width flex connector]

    G --> G1[CircleStepIcon\nattached=true]
    G --> G2[StepText\nattached=true]
    G --> G3[span connector\nbg-success-solid ⚠️\nor bg-quaternary]

    H --> H1[CircleStepIcon\nattached=false]
    H --> H2[StepText\nattached=false]
    H --> H3[StepConnector\nbg-brand-solid\nor bg-quaternary]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[ProgressSteps] --> B{type === 'line'?}
    B -- yes --> C[LineSteps]
    B -- no --> D{orientation === 'vertical'?}
    D -- yes --> E[VerticalSteps]
    D -- no --> F{isAttached?\nlabelPlacement=attach\n+ horizontal\n+ number or icon}
    F -- yes --> G[AttachedHorizontalSteps\nIndicator + Label inline\nShort fixed connector]
    F -- no --> H[HorizontalSteps\nLabel below indicator\nFull-width flex connector]

    G --> G1[CircleStepIcon\nattached=true]
    G --> G2[StepText\nattached=true]
    G --> G3[span connector\nbg-success-solid ⚠️\nor bg-quaternary]

    H --> H1[CircleStepIcon\nattached=false]
    H --> H2[StepText\nattached=false]
    H --> H3[StepConnector\nbg-brand-solid\nor bg-quaternary]
```

</a>
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `openmetadata-ui-core-components/src/main/resources/ui/src/components/application/progress-steps/progress-steps.tsx`, line 357-362 ([link](https://github.com/open-metadata/openmetadata/blob/1a1a70467045c0ac2aa376748c016da8db0c034e/openmetadata-ui-core-components/src/main/resources/ui/src/components/application/progress-steps/progress-steps.tsx#L357-L362)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Description colour ignored in attach variant**

   `StepText` applies `attached`-aware colouring only to the title span. The description span always uses `tw:text-tertiary` regardless of `attached`, so an incomplete step's description will appear in the standard tertiary colour rather than the disabled `tw:text-disabled` colour expected by the attached variant's design.
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (3): Last reviewed commit: ["Merge branch &#39;main&#39; into progress-step-a..."](https://github.com/open-metadata/openmetadata/commit/f4f56c907cdf1db1d59fbe6879478fe2df673b23) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40029436)</sub>

<!-- /greptile_comment -->