### PR TITLE
Fixes 29521: owner/user name alert filters now match usernames containing a dot

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/events/subscription/AlertsRuleEvaluator.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/events/subscription/AlertsRuleEvaluator.java
@@ -21,6 +21,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
+import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 import org.openmetadata.schema.EntityInterface;
 import org.openmetadata.schema.Function;
@@ -44,6 +45,7 @@ import org.openmetadata.schema.type.Include;
 import org.openmetadata.schema.type.Post;
 import org.openmetadata.schema.type.StatusType;
 import org.openmetadata.schema.type.TaskComment;
+import org.openmetadata.schema.utils.EntityInterfaceUtil;
 import org.openmetadata.schema.utils.JsonUtils;
 import org.openmetadata.service.Entity;
 import org.openmetadata.service.exception.EntityNotFoundException;
@@ -356,12 +358,11 @@ public class AlertsRuleEvaluator {
       return false;
     }
     String entityUpdatedBy = changeEvent.getUserName();
-    for (String name : updatedByUserList) {
-      if (name.equals(entityUpdatedBy)) {
-        return true;
-      }
-    }
-    return false;
+    Set<String> updaterNames =
+        updatedByUserList.stream()
+            .map(EntityInterfaceUtil::unquoteName)
+            .collect(Collectors.toSet());
+    return updaterNames.contains(entityUpdatedBy);
   }
 
   @Function(
@@ -611,16 +612,18 @@ public class AlertsRuleEvaluator {
 
   private boolean matchesMentionedUserOrTeam(
       List<MessageParser.EntityLink> mentions, List<String> usersOrTeamName) {
+    Set<String> names =
+        usersOrTeamName.stream().map(EntityInterfaceUtil::unquoteName).collect(Collectors.toSet());
     for (MessageParser.EntityLink entityLink : mentions) {
       String fqn = entityLink.getEntityFQN();
       if (USER.equals(entityLink.getEntityType())) {
         User user = Entity.getCollectionDAO().userDAO().findEntityByName(fqn);
-        if (usersOrTeamName.contains(user.getName())) {
+        if (names.contains(user.getName())) {
           return true;
         }
       } else if (TEAM.equals(entityLink.getEntityType())) {
         Team team = Entity.getCollectionDAO().teamDAO().findEntityByName(fqn);
-        if (usersOrTeamName.contains(team.getName())) {
+        if (names.contains(team.getName())) {
           return true;
         }
       }
@@ -688,24 +691,27 @@ public class AlertsRuleEvaluator {
   }
 
   private boolean matchOwners(List<EntityReference> ownerReferences, List<String> ownerNameList) {
+    Set<String> ownerNames =
+        ownerNameList.stream().map(EntityInterfaceUtil::unquoteName).collect(Collectors.toSet());
     for (EntityReference owner : ownerReferences) {
-      if (USER.equals(owner.getType())) {
-        User user = Entity.getEntity(Entity.USER, owner.getId(), "", Include.NON_DELETED);
-        for (String name : ownerNameList) {
-          if (user.getName().equals(name)) {
-            return true;
-          }
-        }
-      } else if (TEAM.equals(owner.getType())) {
-        Team team = Entity.getEntity(Entity.TEAM, owner.getId(), "", Include.NON_DELETED);
-        for (String name : ownerNameList) {
-          if (team.getName().equals(name)) {
-            return true;
-          }
-        }
+      String ownerName = resolveOwnerName(owner);
+      if (ownerName != null && ownerNames.contains(ownerName)) {
+        return true;
       }
     }
     return false;
+  }
+
+  private String resolveOwnerName(EntityReference owner) {
+    String ownerName = null;
+    if (USER.equals(owner.getType())) {
+      User user = Entity.getEntity(Entity.USER, owner.getId(), "", Include.NON_DELETED);
+      ownerName = user.getName();
+    } else if (TEAM.equals(owner.getType())) {
+      Team team = Entity.getEntity(Entity.TEAM, owner.getId(), "", Include.NON_DELETED);
+      ownerName = team.getName();
+    }
+    return ownerName;
   }
 
   @Function(

--- a/openmetadata-service/src/test/java/org/openmetadata/schema/utils/EntityInterfaceUtilTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/schema/utils/EntityInterfaceUtilTest.java
@@ -1,0 +1,50 @@
+/*
+ *  Copyright 2024 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ *  except in compliance with the License. You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software distributed under the License
+ *  is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and limitations under
+ *  the License.
+ */
+package org.openmetadata.schema.utils;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Pins the owner/user alert-filter fix: a username containing a dot is FQN-quoted (e.g. {@code
+ * ram.balaji} -> {@code "ram.balaji"}), and the name-based alert matchers must compare against the
+ * raw name. {@link EntityInterfaceUtil#unquoteName} is the normalization those matchers apply.
+ */
+class EntityInterfaceUtilTest {
+
+  @Test
+  void unquoteName_stripsQuotesFromDottedName() {
+    assertEquals("ram.balaji", EntityInterfaceUtil.unquoteName("\"ram.balaji\""));
+    assertEquals("Data.Engineering", EntityInterfaceUtil.unquoteName("\"Data.Engineering\""));
+  }
+
+  @Test
+  void unquoteName_leavesPlainNameUnchanged() {
+    assertEquals("ram.balaji", EntityInterfaceUtil.unquoteName("ram.balaji"));
+    assertEquals("john", EntityInterfaceUtil.unquoteName("john"));
+  }
+
+  @Test
+  void unquoteName_isInverseOfQuoteName() {
+    for (String name : new String[] {"ram.balaji", "Data.Engineering", "john", "team_a"}) {
+      assertEquals(name, EntityInterfaceUtil.unquoteName(EntityInterfaceUtil.quoteName(name)));
+    }
+  }
+
+  @Test
+  void unquoteName_handlesNullAndEmptyWithoutThrowing() {
+    assertNull(EntityInterfaceUtil.unquoteName(null));
+    assertEquals("", EntityInterfaceUtil.unquoteName(""));
+    assertEquals("\"", EntityInterfaceUtil.unquoteName("\""));
+  }
+}

--- a/openmetadata-spec/src/main/java/org/openmetadata/schema/utils/EntityInterfaceUtil.java
+++ b/openmetadata-spec/src/main/java/org/openmetadata/schema/utils/EntityInterfaceUtil.java
@@ -9,4 +9,12 @@ public final class EntityInterfaceUtil {
     }
     return name;
   }
+
+  /** Inverse of {@link #quoteName(String)}: strips a single enclosing pair of quotes if present. */
+  public static String unquoteName(String name) {
+    if (name != null && name.length() > 1 && name.startsWith("\"") && name.endsWith("\"")) {
+      return name.substring(1, name.length() - 1);
+    }
+    return name;
+  }
 }


### PR DESCRIPTION
Fixes #29521

### Describe your changes

Owner / updated-by / mentioned-user alert filters never matched when a user's or team's **username contains a dot** (e.g. `first.last`).

**Cause:** the UI stores these filters using the entity's `fullyQualifiedName`, which quotes dotted names (`ram.balaji` → `"ram.balaji"`), while the backend matchers compare against the raw `name`. `"ram.balaji"` never equals `ram.balaji`, so the filter silently drops every event.

**Fix:** reconcile the two at the matcher. A new `EntityInterfaceUtil.unquoteName` (inverse of `quoteName`) is applied in `matchOwners`, `matchUpdatedBy`, and `matchesMentionedUserOrTeam` before comparing. The matchers now accept both the quoted and plain forms, so existing saved alerts start matching immediately — no migration, no UI change.

### Type of change
- [x] Bug fix

### Tests
- `EntityInterfaceUtilTest` (new): `unquoteName` strips quotes from dotted names, leaves plain names unchanged, round-trips with `quoteName`, and is null/empty-safe.
- Verified end-to-end on a local stack: an alert filtering on a dotted-name owner (`"ram.balaji"`) now delivers to its webhook; a non-matching-owner control alert does not.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a silent filter mismatch in alert rule evaluation where usernames containing dots (e.g. `ram.balaji`) were never matched because the UI persists filter values as quoted FQNs (`"ram.balaji"`) while the backend matchers compared against raw `name` fields from the DB.

- Adds `EntityInterfaceUtil.unquoteName` (inverse of `quoteName`) and applies it in `matchOwners`, `matchUpdatedBy`, and `matchesMentionedUserOrTeam` to normalise filter tokens before comparison, with no schema or data migration required.
- Refactors `matchOwners` to extract a `resolveOwnerName` helper and pre-build a `Set<String>` of unquoted names, consistent with the patterns used in the other two matchers.
- Covers the new utility with unit tests for dotted names, plain names, round-trip invariants, and null/empty safety.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is narrowly scoped to unquoting filter tokens before string comparison, with no effect on persistence, event routing, or other matcher logic.

The fix is a one-liner normalisation applied consistently across all three affected matchers. `unquoteName` is correctly implemented as the strict inverse of `quoteName` (guards on length, prefix, and suffix), passes through plain names and null without mutation, and is pinned by unit tests covering the round-trip, edge values, and the exact bug scenario.

No files require special attention.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-spec/src/main/java/org/openmetadata/schema/utils/EntityInterfaceUtil.java | Adds `unquoteName` as the inverse of `quoteName`; strips a single enclosing quote pair when present, passes through plain names and null unchanged. |
| openmetadata-service/src/main/java/org/openmetadata/service/events/subscription/AlertsRuleEvaluator.java | Three alert matchers (`matchOwners`, `matchUpdatedBy`, `matchesMentionedUserOrTeam`) now pre-build a Set of unquoted names before comparing against raw entity names resolved from the DB; also extracts `resolveOwnerName` helper. |
| openmetadata-service/src/test/java/org/openmetadata/schema/utils/EntityInterfaceUtilTest.java | New unit tests covering `unquoteName` for dotted names, plain names, round-trip with `quoteName`, and null/empty edge cases. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant UI
    participant AlertsRuleEvaluator
    participant EntityInterfaceUtil
    participant EntityDAO

    UI->>AlertsRuleEvaluator: filter stored as "ram.balaji" (quoted FQN)
    Note over AlertsRuleEvaluator: matchOwners / matchUpdatedBy / matchesMentionedUserOrTeam
    AlertsRuleEvaluator->>EntityInterfaceUtil: unquoteName("ram.balaji")
    EntityInterfaceUtil-->>AlertsRuleEvaluator: ram.balaji (unquoted)
    AlertsRuleEvaluator->>EntityDAO: resolve owner/user from event
    EntityDAO-->>AlertsRuleEvaluator: "user.getName() = ram.balaji"
    AlertsRuleEvaluator->>AlertsRuleEvaluator: ownerNames.contains("ram.balaji") → true
    AlertsRuleEvaluator-->>UI: alert fires ✓
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant UI
    participant AlertsRuleEvaluator
    participant EntityInterfaceUtil
    participant EntityDAO

    UI->>AlertsRuleEvaluator: filter stored as "ram.balaji" (quoted FQN)
    Note over AlertsRuleEvaluator: matchOwners / matchUpdatedBy / matchesMentionedUserOrTeam
    AlertsRuleEvaluator->>EntityInterfaceUtil: unquoteName("ram.balaji")
    EntityInterfaceUtil-->>AlertsRuleEvaluator: ram.balaji (unquoted)
    AlertsRuleEvaluator->>EntityDAO: resolve owner/user from event
    EntityDAO-->>AlertsRuleEvaluator: "user.getName() = ram.balaji"
    AlertsRuleEvaluator->>AlertsRuleEvaluator: ownerNames.contains("ram.balaji") → true
    AlertsRuleEvaluator-->>UI: alert fires ✓
```

</a>
</details>

<sub>Reviews (3): Last reviewed commit: ["fix(alerts): owner/user name filters now..."](https://github.com/open-metadata/openmetadata/commit/1dcd1860794f0cc7d3d21a607ba6c4316f9c3143) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40037986)</sub>

<!-- /greptile_comment -->