### PR TITLE
fix(ingestion): dbtcloud pipeline status stale FQN ("Invalid task name") and null timestamp (1.13 backport)

### DIFF
--- a/ingestion/src/metadata/ingestion/source/pipeline/dbtcloud/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/pipeline/dbtcloud/metadata.py
@@ -522,18 +522,16 @@ class DbtcloudSource(PipelineServiceSource):
         """
         try:
 
-            # Use stored FQN from context instead of reconstructing
-            # This ensures exact match with database format, especially for special characters
+            # Build the FQN from the per-pipeline context every time. The cached
+            # ctx.pipeline_fqn is written by yield_pipeline_lineage_details, which
+            # runs *after* this stage, so reusing it here would attach the current
+            # pipeline's task statuses to the previous pipeline's FQN.
             ctx = self.context.get()
-            pipeline_fqn = (
-                ctx.pipeline_fqn
-                if hasattr(ctx, "pipeline_fqn") and ctx.pipeline_fqn
-                else fqn.build(
-                    metadata=self.metadata,
-                    entity_type=Pipeline,
-                    service_name=ctx.pipeline_service,
-                    pipeline_name=ctx.pipeline,
-                )
+            pipeline_fqn = fqn.build(
+                metadata=self.metadata,
+                entity_type=Pipeline,
+                service_name=ctx.pipeline_service,  # pyright: ignore[reportAttributeAccessIssue]
+                pipeline_name=ctx.pipeline,  # pyright: ignore[reportAttributeAccessIssue]
             )
 
             # using cached runs from context instead of making another API call
@@ -546,8 +544,9 @@ class DbtcloudSource(PipelineServiceSource):
                 runs = self.client.get_runs(job_id=pipeline_details.id)
 
             for task in runs or []:
+                task_name = str(task.id)
                 task_status = TaskStatus(
-                    name=str(task.id),
+                    name=task_name,
                     executionStatus=STATUS_MAP.get(task.state, StatusType.Pending),
                     startTime=self._parse_timestamp(task.started_at)
                     if task.started_at
@@ -557,12 +556,22 @@ class DbtcloudSource(PipelineServiceSource):
                     else None,
                 )
 
+                status_timestamp = (
+                    task_status.endTime
+                    if task_status.endTime
+                    else task_status.startTime
+                )
+                if status_timestamp is None:
+                    logger.debug(
+                        f"Skipping pipeline status for task '{task_name}' in pipeline "
+                        f"{pipeline_fqn}: run has no start or finish timestamp"
+                    )
+                    continue
+
                 pipeline_status = PipelineStatus(
                     executionStatus=task_status.executionStatus,
                     taskStatus=[task_status],
-                    timestamp=task_status.endTime
-                    if task_status.endTime
-                    else task_status.startTime,
+                    timestamp=status_timestamp,
                 )
 
                 yield Either(

--- a/ingestion/tests/unit/topology/pipeline/test_dbtcloud.py
+++ b/ingestion/tests/unit/topology/pipeline/test_dbtcloud.py
@@ -903,6 +903,73 @@ class DBTCloudUnitTest(TestCase):
                 # Note: Lineage edges may or may not be generated depending on entity resolution
                 self.assertIsInstance(lineage_details, list)
 
+    def test_yield_pipeline_status_uses_current_pipeline_fqn(self):
+        """
+        Pipeline status must be attached to the FQN of the pipeline currently
+        being processed, built from the per-pipeline context - not the stale
+        ctx.pipeline_fqn left over from the previous pipeline's lineage stage
+        (which would cause the server to reject the run id with "Invalid task
+        name").
+        """
+        current_run = DBTRun(
+            id=111,
+            status=1,
+            state="Success",
+            started_at="2024-05-27 10:42:20.621788+00:00",
+            finished_at="2024-05-28 10:42:52.622408+00:00",
+        )
+
+        ctx = self.dbtcloud.context.get()
+        ctx.__dict__["pipeline"] = "Current job"
+        ctx.__dict__["pipeline_service"] = "dbtcloud_pipeline_test"
+        ctx.__dict__["pipeline_fqn"] = "dbtcloud_pipeline_test.Previous job"
+        ctx.__dict__["current_runs"] = [current_run]
+
+        statuses = list(self.dbtcloud.yield_pipeline_status(EXPECTED_JOB_DETAILS))
+
+        self.assertEqual(len(statuses), 1)
+        self.assertEqual(
+            statuses[0].right.pipeline_fqn, "dbtcloud_pipeline_test.Current job"
+        )
+        self.assertEqual(statuses[0].right.pipeline_status.taskStatus[0].name, "111")
+
+    def test_yield_pipeline_status_skips_runs_without_timestamp(self):
+        """
+        A dbt run that has neither started nor finished has no usable timestamp,
+        and PipelineStatus.timestamp is a required integer - such runs must be
+        skipped instead of raising a pydantic ValidationError.
+        """
+        finished_run = DBTRun(
+            id=111,
+            status=1,
+            state="Success",
+            started_at="2024-05-27 10:42:20.621788+00:00",
+            finished_at="2024-05-28 10:42:52.622408+00:00",
+        )
+        queued_run = DBTRun(
+            id=222,
+            status=0,
+            state="Queued",
+            started_at=None,
+            finished_at=None,
+        )
+
+        ctx = self.dbtcloud.context.get()
+        ctx.__dict__["pipeline"] = "Current job"
+        ctx.__dict__["pipeline_service"] = "dbtcloud_pipeline_test"
+        ctx.__dict__["current_runs"] = [finished_run, queued_run]
+
+        statuses = list(self.dbtcloud.yield_pipeline_status(EXPECTED_JOB_DETAILS))
+
+        self.assertEqual(len(statuses), 1)
+        pipeline_status = statuses[0].right.pipeline_status
+        self.assertEqual(pipeline_status.taskStatus[0].name, "111")
+        self.assertIsNotNone(pipeline_status.timestamp)
+        self.assertEqual(
+            pipeline_status.timestamp.root,
+            pipeline_status.taskStatus[0].endTime.root,
+        )
+
     def test_get_table_pipeline_observability_with_context(self):
         """
         Test pipeline observability extraction using context data (current job)


### PR DESCRIPTION
## Describe your changes

Backport of #29458 to the `1.13` branch.

Fixes the dbt Cloud connector's pipeline-status ingestion, which failed for nearly every pipeline with `APIError: Invalid task name <runId>` (HTTP 400 on `/pipelines/{fqn}/status`), plus a related `PipelineStatus.timestamp` `ValidationError`.

### Root cause — "Invalid task name"
The pipeline node's topology stages run in this order:

```
yield_pipeline            -> sets ctx.pipeline (current pipeline name)
yield_pipeline_status     -> READS  ctx.pipeline_fqn
yield_pipeline_lineage    -> WRITES ctx.pipeline_fqn
```

`ctx.pipeline_fqn` is written only in `yield_pipeline_lineage_details`, which runs **after** `yield_pipeline_status`. So pipeline *N*'s status stage reads the FQN that lineage stored for pipeline *N-1*. The status object — correctly built with pipeline *N*'s own run/task ids — is then PUT to pipeline *N-1*'s FQN, whose task list does not contain those ids → server returns `Invalid task name`.

This presents as intermittent: the first pipeline in a run always succeeds (FQN not yet stored), and the leak only kicks in once lineage has resolved a pipeline entity — typically on re-ingestion against existing pipelines with 2+ jobs.

**Fix:** build the FQN fresh from the per-pipeline context (`ctx.pipeline` / `ctx.pipeline_service`) every time, instead of reusing the stale `ctx.pipeline_fqn`.

### Secondary fix — null timestamp
`PipelineStatus.timestamp` is a required integer, but it was set to `endTime or startTime`. A dbt run with neither `started_at` nor `finished_at` produced `timestamp=None` → `pydantic ValidationError`. Such runs are now skipped.

## Type of change

- [x] Bug fix

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/open-metadata/OpenMetadata/blob/main/CONTRIBUTING.md) document.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [x] I have added unit tests that prove my fix is effective.

### Tests
Added two unit tests in `tests/unit/topology/pipeline/test_dbtcloud.py`:
- `test_yield_pipeline_status_uses_current_pipeline_fqn` — asserts the status uses the current pipeline's FQN even when a stale `ctx.pipeline_fqn` is present.
- `test_yield_pipeline_status_skips_runs_without_timestamp` — asserts runs with no usable timestamp are skipped rather than raising.

`tests/unit/topology/pipeline/test_dbtcloud.py`: 35 passed. black 22.3.0 + isort clean.

Closes #29457

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Backport of #29458 to the `1.13` branch that fixes two bugs in the dbt Cloud pipeline status ingestion. The root cause was a topology-stage ordering issue: `yield_pipeline_status` ran before `yield_pipeline_lineage_details` (which wrote `ctx.pipeline_fqn`), so every pipeline's statuses were PUT against the *previous* pipeline's FQN, causing the server to reject them with "Invalid task name". A secondary fix skips runs that lack both `started_at` and `finished_at` to avoid a `pydantic ValidationError` on the required `PipelineStatus.timestamp` field.

- **FQN fix**: `yield_pipeline_status` now always calls `fqn.build()` with the current `ctx.pipeline` / `ctx.pipeline_service` instead of falling back to the stale `ctx.pipeline_fqn` that lineage had not yet written.
- **Null timestamp fix**: runs with no usable timestamp are skipped via a `continue` guarded by `if status_timestamp is None`, preventing Pydantic validation failures.
- **Tests**: two new unit tests directly exercise both failure modes (stale FQN and missing timestamp).
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the changes are narrowly scoped to yield_pipeline_status, both fixes are independently testable, and the two new unit tests cover the exact failure scenarios.

Both changes are surgical: the FQN is now always built from the current per-pipeline context (eliminating the cross-pipeline leak), and runs without a usable timestamp are skipped before the Pydantic model is constructed. The logic is simple, the exception handler still catches any unexpected failure, and the tests directly reproduce the previously-failing conditions.

No files require special attention.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| ingestion/src/metadata/ingestion/source/pipeline/dbtcloud/metadata.py | Fixes stale-FQN bug by always building pipeline FQN from current context instead of caching; adds null-timestamp guard to skip runs lacking both start and finish times. |
| ingestion/tests/unit/topology/pipeline/test_dbtcloud.py | Adds two targeted unit tests that reproduce the exact failure modes fixed in metadata.py — stale FQN and missing timestamp — both pass cleanly. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Topology
    participant yield_pipeline
    participant yield_pipeline_status
    participant yield_pipeline_lineage_details
    participant Server

    Note over Topology: Pipeline N processing begins

    Topology->>yield_pipeline: process(pipeline_N)
    yield_pipeline-->>Topology: "sets ctx.pipeline = Pipeline N"

    Topology->>yield_pipeline_status: process(pipeline_N)
    Note over yield_pipeline_status: OLD: reads stale ctx.pipeline_fqn
    Note over yield_pipeline_status: NEW: builds FQN fresh from ctx.pipeline + ctx.pipeline_service
    yield_pipeline_status->>yield_pipeline_status: if status_timestamp is None skip run
    yield_pipeline_status-->>Server: "PUT /pipelines/{correct_fqn}/status"

    Topology->>yield_pipeline_lineage_details: process(pipeline_N)
    yield_pipeline_lineage_details-->>Topology: "sets ctx.pipeline_fqn = svc.Pipeline N"
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Topology
    participant yield_pipeline
    participant yield_pipeline_status
    participant yield_pipeline_lineage_details
    participant Server

    Note over Topology: Pipeline N processing begins

    Topology->>yield_pipeline: process(pipeline_N)
    yield_pipeline-->>Topology: "sets ctx.pipeline = Pipeline N"

    Topology->>yield_pipeline_status: process(pipeline_N)
    Note over yield_pipeline_status: OLD: reads stale ctx.pipeline_fqn
    Note over yield_pipeline_status: NEW: builds FQN fresh from ctx.pipeline + ctx.pipeline_service
    yield_pipeline_status->>yield_pipeline_status: if status_timestamp is None skip run
    yield_pipeline_status-->>Server: "PUT /pipelines/{correct_fqn}/status"

    Topology->>yield_pipeline_lineage_details: process(pipeline_N)
    yield_pipeline_lineage_details-->>Topology: "sets ctx.pipeline_fqn = svc.Pipeline N"
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(ingestion): dbtcloud pipeline status..."](https://github.com/open-metadata/openmetadata/commit/93b50cd84c540cbd0b1b26a33bf232ddd6a3eeaa) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40052251)</sub>

<!-- /greptile_comment -->