### PR TITLE
Add API polling to wait for archived items before UI verification

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/ContextCenterPermission.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/ContextCenterPermission.spec.ts
@@ -13,9 +13,9 @@
 
 import {
   APIRequestContext,
+  test as base,
   expect,
   Page,
-  test as base,
 } from '@playwright/test';
 import { KnowledgeCenterClass } from '../../support/entity/KnowledgeCenterClass';
 import { UserClass } from '../../support/user/UserClass';
@@ -26,11 +26,13 @@ import {
   createDisposableArchivedDocument,
   loginAsUser,
   MEMORIES_API,
+  navigateToArchive,
   navigateToArticles,
   navigateToDashboard,
   navigateToDocuments,
   navigateToMemories,
   uploadDisposableDocument,
+  waitForDocumentInArchive,
 } from '../../utils/ContextCenterUtil';
 import { waitForAllLoadersToDisappear } from '../../utils/entity';
 
@@ -1422,18 +1424,14 @@ test.describe('Context Center Permissions', () => {
   // ─── Archive Permissions (documents only — article archive is being removed) ──
 
   test.describe('Archive Permissions', () => {
-    const goToArchive = async (page: Page) => {
-      await page.goto('/context-center/archive');
-      await page
-        .getByTestId('context-center-archive-page')
-        .waitFor({ state: 'visible' });
-      await waitForAllLoadersToDisappear(page);
-    };
-
     test('user with view-only permission cannot see restore or delete actions on an archived document', async ({
       viewOnlyPage,
+      browser
     }) => {
-      await goToArchive(viewOnlyPage);
+      const { apiContext, afterAction } = await getDefaultAdminAPIContext(browser);
+      await waitForDocumentInArchive(apiContext, archivedDocumentId);
+      await afterAction();
+      await navigateToArchive(viewOnlyPage);
 
       const row = viewOnlyPage.getByTestId(`archive-row-${archivedDocumentId}`);
       await row.scrollIntoViewIfNeeded();
@@ -1444,8 +1442,12 @@ test.describe('Context Center Permissions', () => {
 
     test('user with createAll permission cannot see restore or delete actions on an archived document', async ({
       createAllPage,
+      browser
     }) => {
-      await goToArchive(createAllPage);
+       const { apiContext, afterAction } = await getDefaultAdminAPIContext(browser);
+      await waitForDocumentInArchive(apiContext, archivedDocumentId);
+      await afterAction();
+      await navigateToArchive(createAllPage);
 
       const row = createAllPage.getByTestId(
         `archive-row-${archivedDocumentId}`
@@ -1460,7 +1462,10 @@ test.describe('Context Center Permissions', () => {
       editAllPage,
       browser,
     }) => {
-      await goToArchive(editAllPage);
+      const { apiContext, afterAction } = await getDefaultAdminAPIContext(browser);
+      await waitForDocumentInArchive(apiContext, archivedDocumentId);
+      await afterAction();
+      await navigateToArchive(editAllPage);
 
       const row = editAllPage.getByTestId(`archive-row-${archivedDocumentId}`);
       await row.scrollIntoViewIfNeeded();
@@ -1474,9 +1479,10 @@ test.describe('Context Center Permissions', () => {
         );
         const { id: disposableArchivedDocId } =
           await createDisposableArchivedDocument(apiContext, 'cc-restore-doc');
+        await waitForDocumentInArchive(apiContext, disposableArchivedDocId);
         await afterAction();
 
-        await goToArchive(editAllPage);
+        await navigateToArchive(editAllPage);
         const disposableRow = editAllPage.getByTestId(
           `archive-row-${disposableArchivedDocId}`
         );
@@ -1507,7 +1513,10 @@ test.describe('Context Center Permissions', () => {
       deleteAllPage,
       browser,
     }) => {
-      await goToArchive(deleteAllPage);
+      const { apiContext, afterAction } = await getDefaultAdminAPIContext(browser);
+      await waitForDocumentInArchive(apiContext, archivedDocumentId);
+      await afterAction();
+      await navigateToArchive(deleteAllPage);
 
       const row = deleteAllPage.getByTestId(
         `archive-row-${archivedDocumentId}`
@@ -1526,9 +1535,11 @@ test.describe('Context Center Permissions', () => {
             apiContext,
             'cc-archive-delete-doc'
           );
+          
+        await waitForDocumentInArchive(apiContext, disposableArchivedDocId);
         await afterAction();
 
-        await goToArchive(deleteAllPage);
+        await navigateToArchive(deleteAllPage);
         const disposableRow = deleteAllPage.getByTestId(
           `archive-row-${disposableArchivedDocId}`
         );
@@ -1552,8 +1563,12 @@ test.describe('Context Center Permissions', () => {
 
     test('user with all permissions can see restore and delete actions on an archived document', async ({
       allPermissionPage,
+      browser
     }) => {
-      await goToArchive(allPermissionPage);
+      const { apiContext, afterAction } = await getDefaultAdminAPIContext(browser);
+      await waitForDocumentInArchive(apiContext, archivedDocumentId);
+      await afterAction();
+      await navigateToArchive(allPermissionPage);
 
       const row = allPermissionPage.getByTestId(
         `archive-row-${archivedDocumentId}`

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/ContextCenterPermission.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/ContextCenterPermission.spec.ts
@@ -13,9 +13,9 @@
 
 import {
   APIRequestContext,
-  test as base,
   expect,
   Page,
+  test as base,
 } from '@playwright/test';
 import { KnowledgeCenterClass } from '../../support/entity/KnowledgeCenterClass';
 import { UserClass } from '../../support/user/UserClass';
@@ -1426,9 +1426,11 @@ test.describe('Context Center Permissions', () => {
   test.describe('Archive Permissions', () => {
     test('user with view-only permission cannot see restore or delete actions on an archived document', async ({
       viewOnlyPage,
-      browser
+      browser,
     }) => {
-      const { apiContext, afterAction } = await getDefaultAdminAPIContext(browser);
+      const { apiContext, afterAction } = await getDefaultAdminAPIContext(
+        browser
+      );
       await waitForDocumentInArchive(apiContext, archivedDocumentId);
       await afterAction();
       await navigateToArchive(viewOnlyPage);
@@ -1442,9 +1444,11 @@ test.describe('Context Center Permissions', () => {
 
     test('user with createAll permission cannot see restore or delete actions on an archived document', async ({
       createAllPage,
-      browser
+      browser,
     }) => {
-       const { apiContext, afterAction } = await getDefaultAdminAPIContext(browser);
+      const { apiContext, afterAction } = await getDefaultAdminAPIContext(
+        browser
+      );
       await waitForDocumentInArchive(apiContext, archivedDocumentId);
       await afterAction();
       await navigateToArchive(createAllPage);
@@ -1462,7 +1466,9 @@ test.describe('Context Center Permissions', () => {
       editAllPage,
       browser,
     }) => {
-      const { apiContext, afterAction } = await getDefaultAdminAPIContext(browser);
+      const { apiContext, afterAction } = await getDefaultAdminAPIContext(
+        browser
+      );
       await waitForDocumentInArchive(apiContext, archivedDocumentId);
       await afterAction();
       await navigateToArchive(editAllPage);
@@ -1513,7 +1519,9 @@ test.describe('Context Center Permissions', () => {
       deleteAllPage,
       browser,
     }) => {
-      const { apiContext, afterAction } = await getDefaultAdminAPIContext(browser);
+      const { apiContext, afterAction } = await getDefaultAdminAPIContext(
+        browser
+      );
       await waitForDocumentInArchive(apiContext, archivedDocumentId);
       await afterAction();
       await navigateToArchive(deleteAllPage);
@@ -1535,7 +1543,7 @@ test.describe('Context Center Permissions', () => {
             apiContext,
             'cc-archive-delete-doc'
           );
-          
+
         await waitForDocumentInArchive(apiContext, disposableArchivedDocId);
         await afterAction();
 
@@ -1563,9 +1571,11 @@ test.describe('Context Center Permissions', () => {
 
     test('user with all permissions can see restore and delete actions on an archived document', async ({
       allPermissionPage,
-      browser
+      browser,
     }) => {
-      const { apiContext, afterAction } = await getDefaultAdminAPIContext(browser);
+      const { apiContext, afterAction } = await getDefaultAdminAPIContext(
+        browser
+      );
       await waitForDocumentInArchive(apiContext, archivedDocumentId);
       await afterAction();
       await navigateToArchive(allPermissionPage);

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/ContextCenterUtil.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/ContextCenterUtil.ts
@@ -65,7 +65,6 @@ export const navigateToArchive = async (page: Page) => {
   await waitForAllLoadersToDisappear(page);
 };
 
-
 export const buildPermissionRule = (
   namePrefix: string,
   resources: string[],
@@ -123,7 +122,6 @@ export const createDisposableArchivedDocument = async (
   return { id, name };
 };
 
-
 export async function waitForDocumentInArchive(
   apiContext: APIRequestContext,
   documentId: string,
@@ -140,17 +138,17 @@ export async function waitForDocumentInArchive(
     expect(response.ok()).toBeTruthy();
 
     const files = await response.json();
-    console.log(response, files)
 
-    const found = files.data.some(
-      (file: { id: string, deleted: boolean}) => file.id === documentId && file.deleted === true
+    const found = (files?.data ?? []).some(
+      (file: { id: string; deleted: boolean }) =>
+        file.id === documentId && file.deleted === true
     );
 
     if (found) {
       return;
     }
 
-    await new Promise(resolve => setTimeout(resolve, interval));
+    await new Promise((resolve) => setTimeout(resolve, interval));
   }
 
   throw new Error(

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/ContextCenterUtil.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/ContextCenterUtil.ts
@@ -10,7 +10,7 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-import { APIRequestContext, Browser, Page } from '@playwright/test';
+import { APIRequestContext, Browser, expect, Page } from '@playwright/test';
 import { PolicyRulesType } from '../support/access-control/PoliciesClass';
 import { UserClass } from '../support/user/UserClass';
 import { uuid } from './common';
@@ -56,6 +56,15 @@ export const navigateToMemories = async (page: Page) => {
     .waitFor({ state: 'visible' });
   await waitForAllLoadersToDisappear(page);
 };
+
+export const navigateToArchive = async (page: Page) => {
+  await page.goto('/context-center/archive');
+  await page
+    .getByTestId('context-center-archive-page')
+    .waitFor({ state: 'visible' });
+  await waitForAllLoadersToDisappear(page);
+};
+
 
 export const buildPermissionRule = (
   namePrefix: string,
@@ -113,3 +122,38 @@ export const createDisposableArchivedDocument = async (
 
   return { id, name };
 };
+
+
+export async function waitForDocumentInArchive(
+  apiContext: APIRequestContext,
+  documentId: string,
+  timeout = 60_000,
+  interval = 2_000
+) {
+  const start = Date.now();
+
+  while (Date.now() - start < timeout) {
+    const response = await apiContext.get(
+      '/api/v1/contextCenter/drive/files?include=deleted&limit=1000'
+    );
+
+    expect(response.ok()).toBeTruthy();
+
+    const files = await response.json();
+    console.log(response, files)
+
+    const found = files.data.some(
+      (file: { id: string, deleted: boolean}) => file.id === documentId && file.deleted === true
+    );
+
+    if (found) {
+      return;
+    }
+
+    await new Promise(resolve => setTimeout(resolve, interval));
+  }
+
+  throw new Error(
+    `Document ${documentId} did not appear in archive API within ${timeout}ms`
+  );
+}


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:

Fixes #<issue-number>
<!--
Linking an issue is REQUIRED. Replace <issue-number> with the GitHub issue number this PR addresses
(e.g., `Fixes #12345`). GitHub will auto-link it. If no issue exists, please open one first so the
problem and design can be discussed before review.
-->

<!--
Short blurb explaining:
- What changes did you make?
- Why did you make them?
-->

I worked on ... because ...

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### High-level design:
<!--
REQUIRED for large PRs (new features, refactors, breaking changes, or anything touching >5 files).
Skip for small bug fixes and trivial changes.

Cover:
- Architecture / approach you took and why
- Key components or files added/changed and how they interact
- Alternatives considered and why you rejected them
- Any migration, backward-compatibility, or rollout concerns
- Diagrams or links to design docs / RFCs if available
-->

N/A — small change. <!-- Or fill in the design above -->

#
### Tests:

#### Use cases covered
<!--
List the user-visible scenarios this PR exercises. Example:
- User with Admin role can create a Glossary Term with a parent term
- Ingestion run for Snowflake correctly extracts row counts for partitioned tables
-->

#### Unit tests
<!--
- [ ] I added unit tests for the new/changed logic.
- Files added/updated:
- Coverage on changed classes (run `mvn jacoco:report` for backend, `yarn test:coverage` for UI,
  `make unit_ingestion` for ingestion). Target is 90% line coverage on changed classes.
- Coverage %: <e.g., 92% on EntityRepository.java>
-->

#### Backend integration tests
<!--
- [ ] I added integration tests in `openmetadata-integration-tests/` for new/changed API endpoints.
- [ ] Not applicable (no backend API changes).
- Files added/updated:
-->

#### Ingestion integration tests
<!--
- [ ] I added/updated ingestion integration tests for connector changes.
- [ ] Not applicable (no ingestion changes).
- Files added/updated:
-->

#### Playwright (UI) tests
<!--
- [ ] I added Playwright E2E tests under `openmetadata-ui/.../ui/playwright/` for UI changes.
- [ ] Not applicable (no UI changes).
- Files added/updated:
-->

#### Manual testing performed
<!--
List the manual test steps you performed before requesting review. Example:
1. Started local stack via `./docker/run_local_docker.sh -m ui -d mysql`
2. Logged in as admin, created entity X, verified Y appears in the UI
3. Triggered ingestion for Snowflake source, confirmed lineage edges in the explore page
-->

#
### UI screen recording / screenshots:
<!--
REQUIRED for any PR that changes the UI. Drag-and-drop a short screen recording (.mov / .mp4 / .gif)
demonstrating the change end-to-end, plus before/after screenshots where relevant.
Mark "Not applicable" if there are no UI changes.
-->

Not applicable. <!-- Or attach recording/screenshots above -->

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.
- [ ] For UI changes: I attached a screen recording and/or screenshots above.
- [ ] I have added tests (unit / integration / Playwright as applicable) and listed them above.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds an API polling utility (`waitForDocumentInArchive`) to wait for soft-deleted documents to appear in the archive API before navigating the UI in Playwright tests, preventing flaky failures caused by eventual consistency. It also extracts the inline `goToArchive` helper into a shared `navigateToArchive` export in `ContextCenterUtil.ts`.

- **`ContextCenterUtil.ts`**: adds `navigateToArchive` (refactored from the spec) and `waitForDocumentInArchive`, a polling loop that retries an admin API call until the target document is seen with `deleted === true`.
- **`ContextCenterPermission.spec.ts`**: each archive-permission test now obtains a short-lived admin `apiContext`, polls until the document is confirmed archived, then disposes the context before the user-scoped `navigateToArchive` call.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The change is safe to merge — it adds defensive polling before UI checks, which strictly reduces flakiness. The test-utility polling function has two open feedback items from prior rounds that have not yet been addressed.

The polling loop in waitForDocumentInArchive still calls expect(response.ok()).toBeTruthy() on every iteration, meaning a single transient 5xx or network blip fails the test outright instead of retrying — the opposite of what a resilience loop is for. That issue was raised in a previous review pass and remains unresolved. The limit=1000 cap (also previously flagged) can silently exclude the target document if the archive grows large enough, causing the poll to time out even when the document is genuinely archived.

openmetadata-ui/src/main/resources/ui/playwright/utils/ContextCenterUtil.ts — the waitForDocumentInArchive function needs the error-handling and pagination concerns addressed before the polling helper is fully reliable.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-ui/src/main/resources/ui/playwright/utils/ContextCenterUtil.ts | Adds navigateToArchive helper and waitForDocumentInArchive polling loop; the polling loop still uses expect(response.ok()).toBeTruthy() (fails fast on transient errors) and a hard-coded limit=1000 (may miss the document if the archive is large) — both flagged in prior review rounds and not yet resolved. |
| openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/ContextCenterPermission.spec.ts | Archive-permission tests correctly inject a short-lived admin API context, call waitForDocumentInArchive, dispose the context before the user-page navigation, and use the new navigateToArchive helper; logic and ordering look correct. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Test as Playwright Test
    participant Admin as Admin APIContext
    participant API as /api/v1/contextCenter/drive/files
    participant UI as User Page (archive)

    Test->>Admin: getDefaultAdminAPIContext(browser)
    loop "Poll until deleted === true or timeout (60 s)"
        Admin->>API: "GET ?include=deleted&limit=1000"
        API-->>Admin: "{ data: [...files] }"
        Admin->>Admin: "files.some(f => f.id === documentId && f.deleted)"
        alt not found yet
            Admin->>Admin: sleep 2 s
        else found
            Admin-->>Test: return
        end
    end
    alt timeout exceeded
        Admin-->>Test: throw Error
    end
    Test->>Admin: afterAction() — dispose context
    Test->>UI: navigateToArchive(userPage)
    UI-->>Test: archive page visible
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Test as Playwright Test
    participant Admin as Admin APIContext
    participant API as /api/v1/contextCenter/drive/files
    participant UI as User Page (archive)

    Test->>Admin: getDefaultAdminAPIContext(browser)
    loop "Poll until deleted === true or timeout (60 s)"
        Admin->>API: "GET ?include=deleted&limit=1000"
        API-->>Admin: "{ data: [...files] }"
        Admin->>Admin: "files.some(f => f.id === documentId && f.deleted)"
        alt not found yet
            Admin->>Admin: sleep 2 s
        else found
            Admin-->>Test: return
        end
    end
    alt timeout exceeded
        Admin-->>Test: throw Error
    end
    Test->>Admin: afterAction() — dispose context
    Test->>UI: navigateToArchive(userPage)
    UI-->>Test: archive page visible
```

</a>
</details>

<sub>Reviews (2): Last reviewed commit: ["lint fix"](https://github.com/open-metadata/openmetadata/commit/7a3f24d6cbc9029d234d665087cad80a4627350f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40055760)</sub>

<!-- /greptile_comment -->