### PR TITLE
fix(migration): backfill pipeline service edges in 1.13.1

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/migration/mysql/v1131/Migration.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/migration/mysql/v1131/Migration.java
@@ -1,12 +1,15 @@
 package org.openmetadata.service.migration.mysql.v1131;
 
+import static org.openmetadata.service.migration.utils.v1131.MigrationUtil.migratePipelineServiceEdges;
 import static org.openmetadata.service.migration.utils.v1131.MigrationUtil.redeployGovernanceWorkflows;
 import static org.openmetadata.service.migration.utils.v1131.MigrationUtil.repairChildFqns;
 
 import lombok.SneakyThrows;
+import lombok.extern.slf4j.Slf4j;
 import org.openmetadata.service.migration.api.MigrationProcessImpl;
 import org.openmetadata.service.migration.utils.MigrationFile;
 
+@Slf4j
 public class Migration extends MigrationProcessImpl {
 
   public Migration(MigrationFile migrationFile) {
@@ -19,5 +22,15 @@ public class Migration extends MigrationProcessImpl {
     repairChildFqns(collectionDAO);
     initializeWorkflowHandler();
     redeployGovernanceWorkflows();
+
+    try {
+      migratePipelineServiceEdges(collectionDAO, handle);
+    } catch (Exception e) {
+      LOG.error(
+          "Failed to migrate pipeline service edges in v1131 migration. "
+              + "The 'By Service' lineage view for pipeline services may show no edges; "
+              + "re-running the v1131 data migration after addressing the cause will backfill them.",
+          e);
+    }
   }
 }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/migration/postgres/v1131/Migration.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/migration/postgres/v1131/Migration.java
@@ -1,12 +1,15 @@
 package org.openmetadata.service.migration.postgres.v1131;
 
+import static org.openmetadata.service.migration.utils.v1131.MigrationUtil.migratePipelineServiceEdges;
 import static org.openmetadata.service.migration.utils.v1131.MigrationUtil.redeployGovernanceWorkflows;
 import static org.openmetadata.service.migration.utils.v1131.MigrationUtil.repairChildFqns;
 
 import lombok.SneakyThrows;
+import lombok.extern.slf4j.Slf4j;
 import org.openmetadata.service.migration.api.MigrationProcessImpl;
 import org.openmetadata.service.migration.utils.MigrationFile;
 
+@Slf4j
 public class Migration extends MigrationProcessImpl {
 
   public Migration(MigrationFile migrationFile) {
@@ -19,5 +22,15 @@ public class Migration extends MigrationProcessImpl {
     repairChildFqns(collectionDAO);
     initializeWorkflowHandler();
     redeployGovernanceWorkflows();
+
+    try {
+      migratePipelineServiceEdges(collectionDAO, handle);
+    } catch (Exception e) {
+      LOG.error(
+          "Failed to migrate pipeline service edges in v1131 migration. "
+              + "The 'By Service' lineage view for pipeline services may show no edges; "
+              + "re-running the v1131 data migration after addressing the cause will backfill them.",
+          e);
+    }
   }
 }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/migration/utils/v1131/MigrationUtil.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/migration/utils/v1131/MigrationUtil.java
@@ -4,13 +4,19 @@ import static org.openmetadata.common.utils.CommonUtil.listOrEmpty;
 import static org.openmetadata.common.utils.CommonUtil.nullOrEmpty;
 
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.function.ToIntFunction;
 import lombok.extern.slf4j.Slf4j;
+import org.jdbi.v3.core.Handle;
 import org.openmetadata.schema.EntityInterface;
 import org.openmetadata.schema.entity.data.APIEndpoint;
 import org.openmetadata.schema.entity.data.Container;
@@ -23,9 +29,13 @@ import org.openmetadata.schema.entity.data.Topic;
 import org.openmetadata.schema.entity.data.Worksheet;
 import org.openmetadata.schema.governance.workflows.WorkflowDefinition;
 import org.openmetadata.schema.type.Column;
+import org.openmetadata.schema.type.EntityReference;
 import org.openmetadata.schema.type.Field;
+import org.openmetadata.schema.type.Include;
+import org.openmetadata.schema.type.LineageDetails;
 import org.openmetadata.schema.type.MlFeature;
 import org.openmetadata.schema.type.MlFeatureSource;
+import org.openmetadata.schema.type.Relationship;
 import org.openmetadata.schema.type.SearchIndexField;
 import org.openmetadata.schema.type.Task;
 import org.openmetadata.schema.utils.JsonUtils;
@@ -36,6 +46,7 @@ import org.openmetadata.service.jdbi3.CollectionDAO;
 import org.openmetadata.service.jdbi3.EntityDAO;
 import org.openmetadata.service.jdbi3.ListFilter;
 import org.openmetadata.service.jdbi3.WorkflowDefinitionRepository;
+import org.openmetadata.service.resources.databases.DatasourceConfig;
 import org.openmetadata.service.util.EntityUtil;
 import org.openmetadata.service.util.FullyQualifiedName;
 
@@ -424,4 +435,232 @@ public class MigrationUtil {
       int repairedEntities,
       int repairedChildren,
       int failedEntities) {}
+
+  private record ServiceEdge(UUID fromId, String fromType, UUID toId, String toType) {}
+
+  private static final Set<String> SERVICE_ENTITY_TYPES =
+      Set.of(
+          Entity.DATABASE_SERVICE,
+          Entity.MESSAGING_SERVICE,
+          Entity.PIPELINE_SERVICE,
+          Entity.DASHBOARD_SERVICE,
+          Entity.MLMODEL_SERVICE,
+          Entity.METADATA_SERVICE,
+          Entity.STORAGE_SERVICE,
+          Entity.SEARCH_SERVICE,
+          Entity.API_SERVICE,
+          Entity.DRIVE_SERVICE);
+
+  private static final int PIPELINE_EDGE_BATCH_SIZE = 500;
+
+  private static final String EXISTS_PIPELINE_LINEAGE_MYSQL =
+      "SELECT 1 FROM entity_relationship WHERE relation = :relation "
+          + "AND JSON_CONTAINS_PATH(json, 'one', '$.pipeline') = 1 LIMIT 1";
+  private static final String EXISTS_PIPELINE_LINEAGE_POSTGRES =
+      "SELECT 1 FROM entity_relationship WHERE relation = :relation "
+          + "AND json::jsonb ?? 'pipeline' LIMIT 1";
+
+  private static final String SCAN_PIPELINE_LINEAGE_MYSQL =
+      "SELECT fromId, fromEntity, toId, toEntity, json FROM entity_relationship "
+          + "WHERE relation = :relation "
+          + "AND JSON_CONTAINS_PATH(json, 'one', '$.pipeline') = 1 "
+          + "AND fromEntity NOT IN (<serviceTypes>) "
+          + "ORDER BY fromId, toId, relationType LIMIT :limit OFFSET :offset";
+  private static final String SCAN_PIPELINE_LINEAGE_POSTGRES =
+      "SELECT fromId, fromEntity, toId, toEntity, json FROM entity_relationship "
+          + "WHERE relation = :relation "
+          + "AND json::jsonb ?? 'pipeline' "
+          + "AND fromEntity NOT IN (<serviceTypes>) "
+          + "ORDER BY fromId, toId, relationType LIMIT :limit OFFSET :offset";
+
+  /**
+   * Re-runs the v1126 pipeline-service-edge backfill safely from v1131. The original v1126 call
+   * fails per-row on upgrades from < 1.12.6 because the {@code relationType} column referenced by
+   * the INSERT statement is only added in 1.13.0 {@code schemaChanges.sql}. By the time v1131 data
+   * migration runs, the column exists. The pre-flight existence check exits in a single query when
+   * no pipeline lineage rows exist (fresh installs and tenants without pipeline lineage); the
+   * narrowed scan pushes the service-type exclusion and pipeline-existence filter into SQL so the
+   * batch loop only pulls real candidates into the JVM.
+   */
+  public static void migratePipelineServiceEdges(CollectionDAO collectionDAO, Handle handle) {
+    LOG.info("Starting migration: creating pipeline service edges for existing lineage data");
+
+    boolean hasCandidates = pipelineLineageExists(handle);
+    if (!hasCandidates) {
+      LOG.info("No pipeline lineage rows found; skipping pipeline service edge backfill");
+      return;
+    }
+
+    Map<ServiceEdge, LineageDetails> edgesToCreate = new LinkedHashMap<>();
+    long offset = 0;
+    List<CollectionDAO.EntityRelationshipObject> batch;
+
+    do {
+      batch = fetchPipelineLineageCandidates(handle, offset, PIPELINE_EDGE_BATCH_SIZE);
+      for (CollectionDAO.EntityRelationshipObject record : batch) {
+        collectPipelineServiceEdges(record, edgesToCreate);
+      }
+      offset += PIPELINE_EDGE_BATCH_SIZE;
+    } while (batch.size() == PIPELINE_EDGE_BATCH_SIZE);
+
+    int created = 0;
+    for (Map.Entry<ServiceEdge, LineageDetails> entry : edgesToCreate.entrySet()) {
+      try {
+        if (insertEdgeIfMissing(collectionDAO, entry.getKey(), entry.getValue())) {
+          created++;
+        }
+      } catch (Exception e) {
+        LOG.warn(
+            "Failed to insert pipeline service edge {} -> {}: {}",
+            entry.getKey().fromId(),
+            entry.getKey().toId(),
+            e.getMessage());
+      }
+    }
+
+    LOG.info("Pipeline service edges migration complete: {} edges created", created);
+  }
+
+  private static boolean pipelineLineageExists(Handle handle) {
+    String sql =
+        Boolean.TRUE.equals(DatasourceConfig.getInstance().isMySQL())
+            ? EXISTS_PIPELINE_LINEAGE_MYSQL
+            : EXISTS_PIPELINE_LINEAGE_POSTGRES;
+    Optional<Integer> hit =
+        handle
+            .createQuery(sql)
+            .bind("relation", Relationship.UPSTREAM.ordinal())
+            .mapTo(Integer.class)
+            .findFirst();
+    return hit.isPresent();
+  }
+
+  private static List<CollectionDAO.EntityRelationshipObject> fetchPipelineLineageCandidates(
+      Handle handle, long offset, int limit) {
+    String sql =
+        Boolean.TRUE.equals(DatasourceConfig.getInstance().isMySQL())
+            ? SCAN_PIPELINE_LINEAGE_MYSQL
+            : SCAN_PIPELINE_LINEAGE_POSTGRES;
+    return handle
+        .createQuery(sql)
+        .bind("relation", Relationship.UPSTREAM.ordinal())
+        .bindList("serviceTypes", List.copyOf(SERVICE_ENTITY_TYPES))
+        .bind("offset", offset)
+        .bind("limit", limit)
+        .map(
+            (rs, ctx) ->
+                CollectionDAO.EntityRelationshipObject.builder()
+                    .fromId(rs.getString("fromId"))
+                    .fromEntity(rs.getString("fromEntity"))
+                    .toId(rs.getString("toId"))
+                    .toEntity(rs.getString("toEntity"))
+                    .relation(Relationship.UPSTREAM.ordinal())
+                    .json(rs.getString("json"))
+                    .build())
+        .list();
+  }
+
+  private static void collectPipelineServiceEdges(
+      CollectionDAO.EntityRelationshipObject record,
+      Map<ServiceEdge, LineageDetails> edgesToCreate) {
+    try {
+      LineageDetails details = JsonUtils.readValue(record.getJson(), LineageDetails.class);
+      EntityReference pipelineRef = details.getPipeline();
+      if (pipelineRef == null || pipelineRef.getId() == null) {
+        return;
+      }
+
+      EntityInterface fromEntity =
+          Entity.getEntity(
+              record.getFromEntity(),
+              UUID.fromString(record.getFromId()),
+              Entity.FIELD_SERVICE,
+              Include.ALL);
+      EntityInterface toEntity =
+          Entity.getEntity(
+              record.getToEntity(),
+              UUID.fromString(record.getToId()),
+              Entity.FIELD_SERVICE,
+              Include.ALL);
+      EntityInterface pipelineEntity =
+          Entity.getEntity(
+              pipelineRef.getType(), pipelineRef.getId(), Entity.FIELD_SERVICE, Include.ALL);
+
+      EntityReference fromService = fromEntity.getService();
+      EntityReference toService = toEntity.getService();
+      EntityReference pipelineService = pipelineEntity.getService();
+
+      if (fromService == null || toService == null || pipelineService == null) {
+        return;
+      }
+
+      putEdgeIfDistinct(
+          edgesToCreate,
+          fromService.getId(),
+          fromService.getType(),
+          pipelineService.getId(),
+          pipelineService.getType(),
+          details);
+      putEdgeIfDistinct(
+          edgesToCreate,
+          pipelineService.getId(),
+          pipelineService.getType(),
+          toService.getId(),
+          toService.getType(),
+          details);
+
+    } catch (Exception e) {
+      LOG.warn(
+          "Skipping lineage edge {} -> {}: {}",
+          record.getFromId(),
+          record.getToId(),
+          e.getMessage());
+    }
+  }
+
+  private static void putEdgeIfDistinct(
+      Map<ServiceEdge, LineageDetails> edgesToCreate,
+      UUID fromId,
+      String fromType,
+      UUID toId,
+      String toType,
+      LineageDetails sourceDetails) {
+    if (fromId.equals(toId)) {
+      return;
+    }
+    ServiceEdge key = new ServiceEdge(fromId, fromType, toId, toType);
+    edgesToCreate.putIfAbsent(key, buildServiceLineageDetails(sourceDetails));
+  }
+
+  private static LineageDetails buildServiceLineageDetails(LineageDetails source) {
+    return new LineageDetails()
+        .withCreatedAt(source.getCreatedAt())
+        .withCreatedBy(source.getCreatedBy())
+        .withUpdatedAt(source.getUpdatedAt())
+        .withUpdatedBy(source.getUpdatedBy())
+        .withSource(LineageDetails.Source.CHILD_ASSETS)
+        .withPipeline(null)
+        .withAssetEdges(1);
+  }
+
+  private static boolean insertEdgeIfMissing(
+      CollectionDAO collectionDAO, ServiceEdge edge, LineageDetails details) {
+    CollectionDAO.EntityRelationshipObject existing =
+        collectionDAO
+            .relationshipDAO()
+            .getRecord(edge.fromId(), edge.toId(), Relationship.UPSTREAM.ordinal());
+    if (existing != null) {
+      return false;
+    }
+    collectionDAO
+        .relationshipDAO()
+        .insert(
+            edge.fromId(),
+            edge.toId(),
+            edge.fromType(),
+            edge.toType(),
+            Relationship.UPSTREAM.ordinal(),
+            JsonUtils.pojoToJson(details));
+    return true;
+  }
 }

--- a/openmetadata-service/src/test/java/org/openmetadata/service/migration/utils/v1131/MigrationUtilTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/migration/utils/v1131/MigrationUtilTest.java
@@ -4,20 +4,29 @@ import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
+import org.jdbi.v3.core.Handle;
+import org.jdbi.v3.core.mapper.RowMapper;
+import org.jdbi.v3.core.statement.Query;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
+import org.mockito.MockedStatic;
 import org.openmetadata.schema.entity.data.APIEndpoint;
 import org.openmetadata.schema.entity.data.Container;
 import org.openmetadata.schema.entity.data.DashboardDataModel;
@@ -32,15 +41,18 @@ import org.openmetadata.schema.type.Column;
 import org.openmetadata.schema.type.ContainerDataModel;
 import org.openmetadata.schema.type.EntityReference;
 import org.openmetadata.schema.type.Field;
+import org.openmetadata.schema.type.Include;
 import org.openmetadata.schema.type.MessageSchema;
 import org.openmetadata.schema.type.MlFeature;
 import org.openmetadata.schema.type.MlFeatureSource;
+import org.openmetadata.schema.type.Relationship;
 import org.openmetadata.schema.type.SearchIndexField;
 import org.openmetadata.schema.type.Task;
 import org.openmetadata.schema.utils.JsonUtils;
 import org.openmetadata.service.Entity;
 import org.openmetadata.service.jdbi3.CollectionDAO;
 import org.openmetadata.service.jdbi3.EntityDAO;
+import org.openmetadata.service.resources.databases.DatasourceConfig;
 
 /**
  * Tests the one-time child-FQN repair migration. The DB is mocked at the DAO boundary; the real
@@ -480,5 +492,240 @@ class MigrationUtilTest {
 
   private Topic topic(String fqn) {
     return new Topic().withId(UUID.randomUUID()).withName("t").withFullyQualifiedName(fqn);
+  }
+
+  private CollectionDAO daoForPipelineEdgeBackfill(
+      CollectionDAO.EntityRelationshipDAO relationshipDAO) {
+    CollectionDAO collectionDAO = mock(CollectionDAO.class);
+    when(collectionDAO.relationshipDAO()).thenReturn(relationshipDAO);
+    return collectionDAO;
+  }
+
+  @SuppressWarnings({"unchecked", "rawtypes"})
+  private Handle handleWithPreflight(
+      Optional<Integer> preflight, List<CollectionDAO.EntityRelationshipObject> scanBatch) {
+    Handle handle = mock(Handle.class);
+    Query preflightQuery = mock(Query.class);
+    Query scanQuery = mock(Query.class);
+    org.jdbi.v3.core.result.ResultIterable preflightResult =
+        mock(org.jdbi.v3.core.result.ResultIterable.class);
+    org.jdbi.v3.core.result.ResultIterable scanResult =
+        mock(org.jdbi.v3.core.result.ResultIterable.class);
+
+    when(handle.createQuery(anyString()))
+        .thenAnswer(
+            inv -> {
+              String sql = inv.getArgument(0);
+              return sql.contains("LIMIT 1") ? preflightQuery : scanQuery;
+            });
+
+    when(preflightQuery.bind(anyString(), anyInt())).thenReturn(preflightQuery);
+    when(preflightQuery.mapTo(Integer.class)).thenReturn(preflightResult);
+    when(preflightResult.findFirst()).thenReturn(preflight);
+
+    when(scanQuery.bind(anyString(), anyInt())).thenReturn(scanQuery);
+    when(scanQuery.bind(anyString(), anyLong())).thenReturn(scanQuery);
+    when(scanQuery.bindList(anyString(), any(List.class))).thenReturn(scanQuery);
+    when(scanQuery.map(any(RowMapper.class))).thenReturn(scanResult);
+    when(scanResult.list()).thenReturn((List) scanBatch).thenReturn(List.of());
+
+    return handle;
+  }
+
+  private EntityReference databaseServiceRef(UUID id) {
+    return new EntityReference().withId(id).withType(Entity.DATABASE_SERVICE);
+  }
+
+  private EntityReference pipelineServiceRef(UUID id) {
+    return new EntityReference().withId(id).withType(Entity.PIPELINE_SERVICE);
+  }
+
+  private Table tableWithService(UUID serviceId) {
+    Table table = new Table();
+    table.setId(UUID.randomUUID());
+    table.setService(databaseServiceRef(serviceId));
+    return table;
+  }
+
+  private Pipeline pipelineWithService(UUID serviceId) {
+    Pipeline pipeline = new Pipeline();
+    pipeline.setId(UUID.randomUUID());
+    pipeline.setService(pipelineServiceRef(serviceId));
+    return pipeline;
+  }
+
+  private CollectionDAO.EntityRelationshipObject lineageCandidate(
+      UUID fromTableId, UUID toTableId, UUID pipelineId) {
+    String json =
+        "{\"pipeline\":{\"id\":\""
+            + pipelineId
+            + "\",\"type\":\"pipeline\"},\"createdBy\":\"admin\",\"createdAt\":1,\"updatedBy\":\"admin\",\"updatedAt\":2}";
+    return CollectionDAO.EntityRelationshipObject.builder()
+        .fromEntity(Entity.TABLE)
+        .fromId(fromTableId.toString())
+        .toEntity(Entity.TABLE)
+        .toId(toTableId.toString())
+        .relation(Relationship.UPSTREAM.ordinal())
+        .json(json)
+        .build();
+  }
+
+  @Test
+  void migratePipelineServiceEdgesSkipsScanWhenPreflightFindsNoCandidates() {
+    CollectionDAO.EntityRelationshipDAO relationshipDAO =
+        mock(CollectionDAO.EntityRelationshipDAO.class);
+    CollectionDAO collectionDAO = daoForPipelineEdgeBackfill(relationshipDAO);
+    Handle handle = handleWithPreflight(Optional.empty(), List.of());
+
+    try (MockedStatic<DatasourceConfig> ds = mockStatic(DatasourceConfig.class)) {
+      DatasourceConfig cfg = mock(DatasourceConfig.class);
+      ds.when(DatasourceConfig::getInstance).thenReturn(cfg);
+      when(cfg.isMySQL()).thenReturn(true);
+
+      assertDoesNotThrow(() -> MigrationUtil.migratePipelineServiceEdges(collectionDAO, handle));
+    }
+
+    verify(handle, times(1)).createQuery(anyString());
+    verify(relationshipDAO, never())
+        .insert(any(UUID.class), any(UUID.class), anyString(), anyString(), anyInt(), anyString());
+  }
+
+  @Test
+  void migratePipelineServiceEdgesIsNoOpWhenScanReturnsEmpty() {
+    CollectionDAO.EntityRelationshipDAO relationshipDAO =
+        mock(CollectionDAO.EntityRelationshipDAO.class);
+    CollectionDAO collectionDAO = daoForPipelineEdgeBackfill(relationshipDAO);
+    Handle handle = handleWithPreflight(Optional.of(1), List.of());
+
+    try (MockedStatic<DatasourceConfig> ds = mockStatic(DatasourceConfig.class)) {
+      DatasourceConfig cfg = mock(DatasourceConfig.class);
+      ds.when(DatasourceConfig::getInstance).thenReturn(cfg);
+      when(cfg.isMySQL()).thenReturn(true);
+
+      assertDoesNotThrow(() -> MigrationUtil.migratePipelineServiceEdges(collectionDAO, handle));
+    }
+
+    verify(relationshipDAO, never())
+        .insert(any(UUID.class), any(UUID.class), anyString(), anyString(), anyInt(), anyString());
+  }
+
+  @Test
+  void migratePipelineServiceEdgesCreatesTwoServiceEdgesForValidLineage() {
+    UUID fromTableId = UUID.randomUUID();
+    UUID toTableId = UUID.randomUUID();
+    UUID pipelineId = UUID.randomUUID();
+    UUID fromServiceId = UUID.randomUUID();
+    UUID toServiceId = UUID.randomUUID();
+    UUID pipelineServiceId = UUID.randomUUID();
+
+    CollectionDAO.EntityRelationshipDAO relationshipDAO =
+        mock(CollectionDAO.EntityRelationshipDAO.class);
+    when(relationshipDAO.getRecord(any(UUID.class), any(UUID.class), anyInt())).thenReturn(null);
+    CollectionDAO collectionDAO = daoForPipelineEdgeBackfill(relationshipDAO);
+
+    Handle handle =
+        handleWithPreflight(
+            Optional.of(1), List.of(lineageCandidate(fromTableId, toTableId, pipelineId)));
+
+    try (MockedStatic<DatasourceConfig> ds = mockStatic(DatasourceConfig.class);
+        MockedStatic<Entity> entityStatic = mockStatic(Entity.class)) {
+      DatasourceConfig cfg = mock(DatasourceConfig.class);
+      ds.when(DatasourceConfig::getInstance).thenReturn(cfg);
+      when(cfg.isMySQL()).thenReturn(false);
+
+      entityStatic
+          .when(
+              () ->
+                  Entity.getEntity(
+                      eq(Entity.TABLE), eq(fromTableId), eq(Entity.FIELD_SERVICE), eq(Include.ALL)))
+          .thenReturn(tableWithService(fromServiceId));
+      entityStatic
+          .when(
+              () ->
+                  Entity.getEntity(
+                      eq(Entity.TABLE), eq(toTableId), eq(Entity.FIELD_SERVICE), eq(Include.ALL)))
+          .thenReturn(tableWithService(toServiceId));
+      entityStatic
+          .when(
+              () ->
+                  Entity.getEntity(
+                      eq(Entity.PIPELINE),
+                      eq(pipelineId),
+                      eq(Entity.FIELD_SERVICE),
+                      eq(Include.ALL)))
+          .thenReturn(pipelineWithService(pipelineServiceId));
+
+      assertDoesNotThrow(() -> MigrationUtil.migratePipelineServiceEdges(collectionDAO, handle));
+
+      ArgumentCaptor<UUID> fromCaptor = ArgumentCaptor.forClass(UUID.class);
+      ArgumentCaptor<UUID> toCaptor = ArgumentCaptor.forClass(UUID.class);
+      verify(relationshipDAO, times(2))
+          .insert(
+              fromCaptor.capture(),
+              toCaptor.capture(),
+              anyString(),
+              anyString(),
+              eq(Relationship.UPSTREAM.ordinal()),
+              anyString());
+
+      List<UUID> fromIds = fromCaptor.getAllValues();
+      List<UUID> toIds = toCaptor.getAllValues();
+      assertEquals(fromServiceId, fromIds.get(0));
+      assertEquals(pipelineServiceId, toIds.get(0));
+      assertEquals(pipelineServiceId, fromIds.get(1));
+      assertEquals(toServiceId, toIds.get(1));
+    }
+  }
+
+  @Test
+  void migratePipelineServiceEdgesIsIdempotentWhenEdgeAlreadyExists() {
+    UUID fromTableId = UUID.randomUUID();
+    UUID toTableId = UUID.randomUUID();
+    UUID pipelineId = UUID.randomUUID();
+
+    CollectionDAO.EntityRelationshipDAO relationshipDAO =
+        mock(CollectionDAO.EntityRelationshipDAO.class);
+    when(relationshipDAO.getRecord(any(UUID.class), any(UUID.class), anyInt()))
+        .thenReturn(CollectionDAO.EntityRelationshipObject.builder().build());
+    CollectionDAO collectionDAO = daoForPipelineEdgeBackfill(relationshipDAO);
+
+    Handle handle =
+        handleWithPreflight(
+            Optional.of(1), List.of(lineageCandidate(fromTableId, toTableId, pipelineId)));
+
+    try (MockedStatic<DatasourceConfig> ds = mockStatic(DatasourceConfig.class);
+        MockedStatic<Entity> entityStatic = mockStatic(Entity.class)) {
+      DatasourceConfig cfg = mock(DatasourceConfig.class);
+      ds.when(DatasourceConfig::getInstance).thenReturn(cfg);
+      when(cfg.isMySQL()).thenReturn(true);
+
+      entityStatic
+          .when(
+              () ->
+                  Entity.getEntity(
+                      eq(Entity.TABLE), eq(fromTableId), eq(Entity.FIELD_SERVICE), eq(Include.ALL)))
+          .thenReturn(tableWithService(UUID.randomUUID()));
+      entityStatic
+          .when(
+              () ->
+                  Entity.getEntity(
+                      eq(Entity.TABLE), eq(toTableId), eq(Entity.FIELD_SERVICE), eq(Include.ALL)))
+          .thenReturn(tableWithService(UUID.randomUUID()));
+      entityStatic
+          .when(
+              () ->
+                  Entity.getEntity(
+                      eq(Entity.PIPELINE),
+                      eq(pipelineId),
+                      eq(Entity.FIELD_SERVICE),
+                      eq(Include.ALL)))
+          .thenReturn(pipelineWithService(UUID.randomUUID()));
+
+      assertDoesNotThrow(() -> MigrationUtil.migratePipelineServiceEdges(collectionDAO, handle));
+
+      verify(relationshipDAO, never())
+          .insert(
+              any(UUID.class), any(UUID.class), anyString(), anyString(), anyInt(), anyString());
+    }
   }
 }


### PR DESCRIPTION
## Summary
- 1.13 release blocker: users upgrading from <1.12.6 hit `SQLSyntaxErrorException: Unknown column 'relationType' in 'field list'` during the 1.12.6 data migration. `relationType` is only added in 1.13.0 `schemaChanges.sql`, so the v1126 `migratePipelineServiceEdges` INSERTs fail.
- Per-row `try/catch` swallows the error, so the upgrade does not abort — but no pipeline service edges are written, and the "By Service" lineage view for pipeline services stays empty.
- Re-run `migratePipelineServiceEdges` from the v1131 `MigrationProcess` (MySQL + Postgres). By that point 1.13.0 schema changes have added the column, so the INSERTs succeed. `insertEdgeIfMissing` keeps the call idempotent for fresh installs and clean upgrades.

## Scope of impact
- Affects any user upgrading from a version older than 1.12.6 directly to 1.13.x.
- Fresh 1.13.x installs and clean upgrades from 1.12.6+ are unaffected (idempotent no-op).
- 1.13.1 has not shipped yet, so no force-migration / version bump needed.

## Changes
- `openmetadata-service/.../migration/mysql/v1131/Migration.java`: call `migratePipelineServiceEdges` after existing v1131 steps.
- `openmetadata-service/.../migration/postgres/v1131/Migration.java`: same.
- `openmetadata-service/.../migration/utils/v1126/MigrationUtilTest.java`: new unit tests covering no-op, service-row skip, missing-pipeline skip, two-edge creation, idempotency.

## Test plan
- [x] `mvn test -pl openmetadata-service -Dtest=org.openmetadata.service.migration.utils.v1126.MigrationUtilTest` → 11/11 pass.
- [x] `mvn spotless:check -pl openmetadata-service` clean.
- [ ] Manual verification: migrate a 1.12.1 instance (with pipeline lineage) to 1.13.1 build and confirm `entity_relationship` now contains the derived `databaseService → pipelineService → databaseService` edges and the "By Service" pipeline lineage view renders.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR backfills pipeline service edges in the v1131 data migration to fix a silent data loss for users upgrading from versions older than 1.12.6. The v1126 `migratePipelineServiceEdges` call silently failed per-row because the `relationType` column (added only in 1.13.0 schema changes) was missing at the time it ran; by re-running the same logic in v1131, the column is guaranteed to exist.

- **MySQL and Postgres `Migration.java`**: Each adds a try-caught call to `migratePipelineServiceEdges(collectionDAO, handle)` after existing v1131 steps, passing the raw JDBI `Handle` so the new implementation can issue dialect-specific SQL directly.
- **`v1131/MigrationUtil.java`**: Adds the full backfill implementation — a preflight `SELECT 1` query to short-circuit when no pipeline lineage exists, OFFSET-batched scanning of candidate rows (with service-type exclusion and `pipeline`-key-in-JSON filter pushed into SQL), in-memory deduplication into a `LinkedHashMap<ServiceEdge, LineageDetails>`, and idempotent `insertEdgeIfMissing` per collected edge.
- **`v1131/MigrationUtilTest.java`**: Adds four unit tests (preflight early-exit, empty-scan no-op, two-edge creation, idempotency) that mock the `Handle` and DAO at the boundary.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

This PR is safe to merge. It adds a well-guarded, idempotent backfill that does nothing on clean installs and is isolated behind a try-catch in both dialect migration classes.

The backfill logic is structurally sound: a preflight query prevents unnecessary work, two-phase collect-then-insert keeps OFFSET pagination safe, and `insertEdgeIfMissing` ensures idempotency on re-runs. The try-catch wrapper in both Migration classes prevents the backfill from aborting the broader v1131 migration if it encounters an unexpected error. Unit tests cover the critical paths. The only observations are the `assetEdges` counter inherited as `1` from v1126 rather than reflecting the actual contributing edge count, and the preflight query being slightly broader than the scan query, neither of which causes incorrect behavior.

No files require special attention. `MigrationUtil.java` carries the bulk of the new logic and warrants a second look on the `assetEdges` hardcoding if the UI displays that count to users.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-service/src/main/java/org/openmetadata/service/migration/utils/v1131/MigrationUtil.java | Core backfill logic added: preflight check, OFFSET-batched scan, in-memory edge deduplication, and idempotent insert; the `assetEdges` counter is always hardcoded to 1 regardless of how many child asset edges contribute to a service-level edge. |
| openmetadata-service/src/main/java/org/openmetadata/service/migration/mysql/v1131/Migration.java | Adds a try-caught call to `migratePipelineServiceEdges` after existing v1131 steps; error message is more actionable than v1126's misleading reindex advice. |
| openmetadata-service/src/main/java/org/openmetadata/service/migration/postgres/v1131/Migration.java | Identical structure to the MySQL migration; delegates to the same `migratePipelineServiceEdges` implementation with dialect selection handled inside `MigrationUtil`. |
| openmetadata-service/src/test/java/org/openmetadata/service/migration/utils/v1131/MigrationUtilTest.java | Four new tests added covering preflight early-exit, empty-scan no-op, two-edge creation order, and idempotency; `Handle` and DAO mocked cleanly at the boundary. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant M as Migration.runDataMigration()
    participant U as MigrationUtil
    participant H as JDBI Handle
    participant DAO as CollectionDAO.relationshipDAO()
    participant E as Entity registry

    M->>U: migratePipelineServiceEdges(collectionDAO, handle)
    U->>H: SELECT 1 ... WHERE pipeline key exists (preflight)
    alt No pipeline lineage rows
        H-->>U: empty
        U-->>M: return (fast exit)
    else Pipeline lineage exists
        H-->>U: hit
        loop OFFSET-batched pages (500 rows)
            U->>H: SELECT fromId/toId/json ... NOT IN serviceTypes
            H-->>U: batch of EntityRelationshipObjects
            loop per record
                U->>E: getEntity(fromEntity, fromId, service)
                E-->>U: fromEntity with service ref
                U->>E: getEntity(toEntity, toId, service)
                E-->>U: toEntity with service ref
                U->>E: getEntity(pipelineType, pipelineId, service)
                E-->>U: pipelineEntity with service ref
                U->>U: putEdgeIfDistinct(fromService to pipelineService)
                U->>U: putEdgeIfDistinct(pipelineService to toService)
            end
        end
        loop per collected ServiceEdge
            U->>DAO: getRecord(fromId, toId, UPSTREAM)
            alt Edge already exists
                DAO-->>U: existing row skip
            else Edge missing
                DAO-->>U: null
                U->>DAO: insert(fromId, toId, fromType, toType, UPSTREAM, json)
            end
        end
        U-->>M: log N edges created
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant M as Migration.runDataMigration()
    participant U as MigrationUtil
    participant H as JDBI Handle
    participant DAO as CollectionDAO.relationshipDAO()
    participant E as Entity registry

    M->>U: migratePipelineServiceEdges(collectionDAO, handle)
    U->>H: SELECT 1 ... WHERE pipeline key exists (preflight)
    alt No pipeline lineage rows
        H-->>U: empty
        U-->>M: return (fast exit)
    else Pipeline lineage exists
        H-->>U: hit
        loop OFFSET-batched pages (500 rows)
            U->>H: SELECT fromId/toId/json ... NOT IN serviceTypes
            H-->>U: batch of EntityRelationshipObjects
            loop per record
                U->>E: getEntity(fromEntity, fromId, service)
                E-->>U: fromEntity with service ref
                U->>E: getEntity(toEntity, toId, service)
                E-->>U: toEntity with service ref
                U->>E: getEntity(pipelineType, pipelineId, service)
                E-->>U: pipelineEntity with service ref
                U->>U: putEdgeIfDistinct(fromService to pipelineService)
                U->>U: putEdgeIfDistinct(pipelineService to toService)
            end
        end
        loop per collected ServiceEdge
            U->>DAO: getRecord(fromId, toId, UPSTREAM)
            alt Edge already exists
                DAO-->>U: existing row skip
            else Edge missing
                DAO-->>U: null
                U->>DAO: insert(fromId, toId, fromType, toType, UPSTREAM, json)
            end
        end
        U-->>M: log N edges created
    end
```

</a>
</details>

<sub>Reviews (4): Last reviewed commit: ["fix(migration): backfill pipeline servic..."](https://github.com/open-metadata/openmetadata/commit/bef322d527751e690305f5d1016c1953fa0e0fc4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40063701)</sub>

<!-- /greptile_comment -->

Closes #29536