### PR TITLE
Fixes #29467: expose Trigger in ingestionPipeline descriptor and require EditAll to kill

### DIFF
--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/IngestionPipelineOwnerInheritanceIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/IngestionPipelineOwnerInheritanceIT.java
@@ -34,6 +34,8 @@ import org.openmetadata.schema.metadataIngestion.DashboardServiceMetadataPipelin
 import org.openmetadata.schema.metadataIngestion.SourceConfig;
 import org.openmetadata.schema.type.EntityReference;
 import org.openmetadata.schema.type.MetadataOperation;
+import org.openmetadata.schema.type.ResourceDescriptor;
+import org.openmetadata.schema.utils.ResultList;
 import org.openmetadata.sdk.client.OpenMetadataClient;
 import org.openmetadata.sdk.network.HttpMethod;
 
@@ -241,4 +243,157 @@ public class IngestionPipelineOwnerInheritanceIT {
       adminClient.policies().delete(ownerPolicy.getId());
     }
   }
+
+  @Test
+  void test_ingestionPipelineDescriptorExposesTrigger() {
+    OpenMetadataClient adminClient = SdkClients.adminClient();
+    ResourceDescriptorList resources =
+        adminClient
+            .getHttpClient()
+            .execute(HttpMethod.GET, "/v1/policies/resources", null, ResourceDescriptorList.class);
+    ResourceDescriptor descriptor =
+        resources.getData().stream()
+            .filter(rd -> "ingestionPipeline".equals(rd.getName()))
+            .findFirst()
+            .orElseThrow(
+                () -> new AssertionError("ingestionPipeline resource descriptor not found"));
+    assertTrue(
+        descriptor.getOperations().contains(MetadataOperation.TRIGGER),
+        "ingestionPipeline descriptor must expose Trigger so it is grantable scoped to "
+            + "Ingestion Pipeline in the policy editor");
+  }
+
+  @Test
+  void test_killRequiresEditPermission(TestNamespace ns) {
+    OpenMetadataClient adminClient = SdkClients.adminClient();
+    String unique = UUID.randomUUID().toString().substring(0, 8);
+
+    Policy viewPolicy =
+        adminClient
+            .policies()
+            .create(
+                new CreatePolicy()
+                    .withName("ipkillViewPolicy_" + unique)
+                    .withDescription("View-only access to ingestion pipelines")
+                    .withRules(
+                        List.of(
+                            new Rule()
+                                .withName("pipelineViewOnly")
+                                .withEffect(Rule.Effect.ALLOW)
+                                .withOperations(List.of(MetadataOperation.VIEW_ALL))
+                                .withResources(List.of("ingestionPipeline")))));
+    Policy editPolicy =
+        adminClient
+            .policies()
+            .create(
+                new CreatePolicy()
+                    .withName("ipkillEditPolicy_" + unique)
+                    .withDescription("View and edit access to ingestion pipelines")
+                    .withRules(
+                        List.of(
+                            new Rule()
+                                .withName("pipelineViewAndEdit")
+                                .withEffect(Rule.Effect.ALLOW)
+                                .withOperations(
+                                    List.of(MetadataOperation.VIEW_ALL, MetadataOperation.EDIT_ALL))
+                                .withResources(List.of("ingestionPipeline")))));
+
+    try {
+      Role viewRole =
+          adminClient
+              .roles()
+              .create(
+                  new CreateRole()
+                      .withName("ipkillViewRole_" + unique)
+                      .withPolicies(List.of(viewPolicy.getFullyQualifiedName())));
+      Role editRole =
+          adminClient
+              .roles()
+              .create(
+                  new CreateRole()
+                      .withName("ipkillEditRole_" + unique)
+                      .withPolicies(List.of(editPolicy.getFullyQualifiedName())));
+
+      try {
+        String viewerName = "ipkillviewer_" + unique;
+        User viewer =
+            adminClient
+                .users()
+                .create(
+                    new CreateUser()
+                        .withName(viewerName)
+                        .withEmail(viewerName + "@test.openmetadata.org")
+                        .withRoles(List.of(viewRole.getId())));
+        String editorName = "ipkilleditor_" + unique;
+        User editor =
+            adminClient
+                .users()
+                .create(
+                    new CreateUser()
+                        .withName(editorName)
+                        .withEmail(editorName + "@test.openmetadata.org")
+                        .withRoles(List.of(editRole.getId())));
+
+        try {
+          DashboardService service = DashboardServiceTestFactory.createMetabase(ns);
+
+          try {
+            IngestionPipeline pipeline =
+                adminClient
+                    .ingestionPipelines()
+                    .create(
+                        new CreateIngestionPipeline()
+                            .withName(ns.prefix("ipkillPipeline_" + unique))
+                            .withPipelineType(PipelineType.METADATA)
+                            .withService(service.getEntityReference())
+                            .withSourceConfig(
+                                new SourceConfig()
+                                    .withConfig(new DashboardServiceMetadataPipeline()))
+                            .withAirflowConfig(new AirflowConfig().withStartDate(START_DATE)));
+
+            try {
+              OpenMetadataClient viewerClient =
+                  SdkClients.createClient(viewerName, viewerName, new String[] {});
+              OpenMetadataClient editorClient =
+                  SdkClients.createClient(editorName, editorName, new String[] {});
+
+              String killPath = "/v1/services/ingestionPipelines/kill/" + pipeline.getId();
+
+              // A view-only user can read the pipeline but must NOT be able to kill it: kill now
+              // requires EditAll, not the ViewAll the underlying read path enforces.
+              viewerClient.ingestionPipelines().get(pipeline.getId().toString());
+              assertThrows(
+                  Exception.class,
+                  () ->
+                      viewerClient
+                          .getHttpClient()
+                          .execute(HttpMethod.POST, killPath, null, Void.class),
+                  "View-only user must not be able to kill an ingestion pipeline");
+
+              // A user with EditAll (plus ViewAll for the read path) can kill.
+              editorClient.getHttpClient().execute(HttpMethod.POST, killPath, null, Void.class);
+            } finally {
+              adminClient.ingestionPipelines().delete(pipeline.getId().toString());
+            }
+          } finally {
+            adminClient
+                .dashboardServices()
+                .delete(
+                    service.getId().toString(), Map.of("hardDelete", "true", "recursive", "true"));
+          }
+        } finally {
+          adminClient.users().delete(viewer.getId());
+          adminClient.users().delete(editor.getId());
+        }
+      } finally {
+        adminClient.roles().delete(viewRole.getId());
+        adminClient.roles().delete(editRole.getId());
+      }
+    } finally {
+      adminClient.policies().delete(viewPolicy.getId());
+      adminClient.policies().delete(editPolicy.getId());
+    }
+  }
+
+  static class ResourceDescriptorList extends ResultList<ResourceDescriptor> {}
 }

--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/IngestionPipelineOwnerInheritanceIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/IngestionPipelineOwnerInheritanceIT.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.time.Instant;
 import java.util.Date;
@@ -37,6 +38,7 @@ import org.openmetadata.schema.type.MetadataOperation;
 import org.openmetadata.schema.type.ResourceDescriptor;
 import org.openmetadata.schema.utils.ResultList;
 import org.openmetadata.sdk.client.OpenMetadataClient;
+import org.openmetadata.sdk.exceptions.ForbiddenException;
 import org.openmetadata.sdk.network.HttpMethod;
 
 /**
@@ -359,19 +361,27 @@ public class IngestionPipelineOwnerInheritanceIT {
 
               String killPath = "/v1/services/ingestionPipelines/kill/" + pipeline.getId();
 
-              // A view-only user can read the pipeline but must NOT be able to kill it: kill now
-              // requires EditAll, not the ViewAll the underlying read path enforces.
+              // A view-only user can read the pipeline but must be forbidden from killing it: kill
+              // now requires EditAll, not the ViewAll the underlying read path enforces.
               viewerClient.ingestionPipelines().get(pipeline.getId().toString());
               assertThrows(
-                  Exception.class,
+                  ForbiddenException.class,
                   () ->
                       viewerClient
                           .getHttpClient()
                           .execute(HttpMethod.POST, killPath, null, Void.class),
-                  "View-only user must not be able to kill an ingestion pipeline");
+                  "View-only user must be forbidden from killing an ingestion pipeline");
 
-              // A user with EditAll (plus ViewAll for the read path) can kill.
-              editorClient.getHttpClient().execute(HttpMethod.POST, killPath, null, Void.class);
+              // A user with EditAll (plus ViewAll for the read path) must pass authorization. The
+              // kill may still fail downstream when the pipeline service client cannot reach the
+              // orchestrator in this environment; only a 403 means the authz gate rejected it.
+              try {
+                editorClient.getHttpClient().execute(HttpMethod.POST, killPath, null, Void.class);
+              } catch (ForbiddenException e) {
+                fail("User with EditAll must be authorized to kill an ingestion pipeline");
+              } catch (Exception ignored) {
+                // Non-authorization failures (e.g. orchestrator unavailable) are irrelevant here.
+              }
             } finally {
               adminClient.ingestionPipelines().delete(pipeline.getId().toString());
             }

--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/IngestionPipelineOwnerInheritanceIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/IngestionPipelineOwnerInheritanceIT.java
@@ -361,8 +361,7 @@ public class IngestionPipelineOwnerInheritanceIT {
 
               String killPath = "/v1/services/ingestionPipelines/kill/" + pipeline.getId();
 
-              // A view-only user can read the pipeline but must be forbidden from killing it: kill
-              // now requires EditAll, not the ViewAll the underlying read path enforces.
+              // Kill now requires EditAll: a view-only user can read but must be forbidden.
               viewerClient.ingestionPipelines().get(pipeline.getId().toString());
               assertThrows(
                   ForbiddenException.class,
@@ -372,15 +371,13 @@ public class IngestionPipelineOwnerInheritanceIT {
                           .execute(HttpMethod.POST, killPath, null, Void.class),
                   "View-only user must be forbidden from killing an ingestion pipeline");
 
-              // A user with EditAll (plus ViewAll for the read path) must pass authorization. The
-              // kill may still fail downstream when the pipeline service client cannot reach the
-              // orchestrator in this environment; only a 403 means the authz gate rejected it.
+              // EditAll user must pass authz; only a 403 fails the test.
               try {
                 editorClient.getHttpClient().execute(HttpMethod.POST, killPath, null, Void.class);
               } catch (ForbiddenException e) {
                 fail("User with EditAll must be authorized to kill an ingestion pipeline");
               } catch (Exception ignored) {
-                // Non-authorization failures (e.g. orchestrator unavailable) are irrelevant here.
+                // Downstream orchestrator failure, not an authz rejection.
               }
             } finally {
               adminClient.ingestionPipelines().delete(pipeline.getId().toString());

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/services/ingestionpipelines/IngestionPipelineResource.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/services/ingestionpipelines/IngestionPipelineResource.java
@@ -181,7 +181,8 @@ public class IngestionPipelineResource
   protected List<MetadataOperation> getEntitySpecificOperations() {
     return listOf(
         MetadataOperation.CREATE_INGESTION_PIPELINE_AUTOMATOR,
-        MetadataOperation.EDIT_INGESTION_PIPELINE_STATUS);
+        MetadataOperation.EDIT_INGESTION_PIPELINE_STATUS,
+        MetadataOperation.TRIGGER);
   }
 
   public static class IngestionPipelineList extends ResultList<IngestionPipeline> {
@@ -806,6 +807,9 @@ public class IngestionPipelineResource
           @PathParam("id")
           UUID id,
       @Context SecurityContext securityContext) {
+    OperationContext operationContext =
+        new OperationContext(entityType, MetadataOperation.EDIT_ALL);
+    authorizer.authorize(securityContext, operationContext, getResourceContextById(id));
     IngestionPipeline ingestionPipeline =
         getInternal(uriInfo, securityContext, id, FIELDS, Include.NON_DELETED);
     decryptOrNullify(securityContext, ingestionPipeline, true);


### PR DESCRIPTION
Fixes #29467

### Describe your changes

Backend half of the ingestion-pipeline permission alignment. Two fixes in `IngestionPipelineResource`:

**1. Expose `Trigger` in the `ingestionPipeline` resource descriptor.** Since #28109 (1.12.9), `POST /services/ingestionPipelines/trigger/{id}` authorizes `ingestionPipeline.Trigger`, but `Trigger` was never added to the resource descriptor — so it could only be granted under **All Resources** (which over-grants, since the same op governs Apps, AI Automations, and Dynamic Agents). `getEntitySpecificOperations()` now includes `MetadataOperation.TRIGGER`, so the policy editor lists it under **Ingestion Pipeline** and admins can grant it scoped.

**2. Require `EditAll` to kill a pipeline.** `POST /services/ingestionPipelines/kill/{id}` ran through the standard read path (`getInternal` → `getViewOperations`), so it only required `ingestionPipeline.ViewAll` — a read-level permission for a disruptive action, and a mismatch with the UI which gates Kill on `EditAll`. `killIngestion` now authorizes `MetadataOperation.EDIT_ALL` up front. This adds the edit gate on top of the pre-existing view read (it does not relax anything); `EditAll` does not subsume view ops, which is why the read path's `ViewAll` is unchanged.

> Note on Deploy: the deploy endpoint's `DEPLOY` operation only feeds `limits.enforceLimits`, never `authorize()` — its real RBAC check is `EditAll` via `createOrUpdate`. So no descriptor change is needed for Deploy and the UI should keep Deploy/Re-deploy on `EditAll`. Only **Run** and **Kill** were misaligned.

### Type of change

- [x] Bug fix

### Tests

Added to `IngestionPipelineOwnerInheritanceIT` (the IT introduced by #28109):

- `test_ingestionPipelineDescriptorExposesTrigger` — `GET /v1/policies/resources` returns the `ingestionPipeline` descriptor with `Trigger` in its operations.
- `test_killRequiresEditPermission` — a `ViewAll`-only user can read a pipeline but is forbidden from killing it (fails without fix 2); a `ViewAll`+`EditAll` user can kill.

`mvn spotless:apply` applied; `openmetadata-service` compiles and `openmetadata-integration-tests` test-compiles clean.

### Related

- Backend authz change that introduced the Run gap: #28109
- Companion UI issue/PR (Run gated on `EditAll` instead of `Trigger`): #29468

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR closes two RBAC gaps in `IngestionPipelineResource`: it adds `MetadataOperation.TRIGGER` to the entity's descriptor so the permission can be granted scoped to Ingestion Pipeline in the policy editor, and it inserts an explicit `EditAll` authorization check at the entry of `killIngestion` to stop view-only users from calling the kill endpoint.

- **Descriptor fix**: `getEntitySpecificOperations()` now returns `TRIGGER` alongside the existing entity-specific ops, making it visible in the policy editor without requiring an over-broad "All Resources" grant.
- **Kill permission fix**: `killIngestion` now calls `authorizer.authorize(…, EDIT_ALL, …)` before `getInternal()`, so a `ViewAll`-only principal receives a 403 rather than reaching the orchestrator client.
- **Tests**: Two new integration tests in `IngestionPipelineOwnerInheritanceIT` — one asserting the descriptor contains `TRIGGER`, one verifying the `ViewAll`/`EditAll` boundary using `ForbiddenException`-aware assertions.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — both changes are minimal additive authorization checks with no risk of relaxing existing access controls.

The backend change is a two-line addition to the descriptor and a three-line guard at the top of killIngestion. Neither path removes or weakens an existing check; the kill endpoint only gains a stricter gate. The integration tests directly exercise both scenarios (view-only to 403, edit to pass) and address the concerns raised in the previous review round.

No files require special attention.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-service/src/main/java/org/openmetadata/service/resources/services/ingestionpipelines/IngestionPipelineResource.java | Two targeted RBAC fixes: adds MetadataOperation.TRIGGER to getEntitySpecificOperations() so it appears in the policy editor, and inserts an explicit EditAll authorize() call at the top of killIngestion() before the existing view-path check. |
| openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/IngestionPipelineOwnerInheritanceIT.java | Adds two integration tests: one verifies the descriptor exposes Trigger, the other verifies view-only users receive 403 on kill while edit users pass. Previous review concerns (overly broad exception type, environment-dependent success) are addressed by using ForbiddenException.class and try/catch pattern. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Client
    participant KillEndpoint as POST /kill/{id}
    participant Authorizer
    participant DB as Entity Store
    participant PSC as PipelineServiceClient

    Client->>KillEndpoint: "POST kill/{id}"
    Note over KillEndpoint: NEW: explicit EditAll check
    KillEndpoint->>Authorizer: authorize(EDIT_ALL, getResourceContextById(id))
    Authorizer-->>KillEndpoint: 403 if not EditAll
    Note over KillEndpoint: Pre-existing: getInternal ViewAll check
    KillEndpoint->>DB: getInternal (fetches + ViewAll auth)
    DB-->>KillEndpoint: IngestionPipeline
    KillEndpoint->>KillEndpoint: decryptOrNullify(pipeline)
    alt "pipelineServiceClient == null"
        KillEndpoint-->>Client: 200 Pipeline Client Disabled
    else
        KillEndpoint->>PSC: killIngestion(pipeline)
        PSC-->>KillEndpoint: PipelineServiceClientResponse
        KillEndpoint-->>Client: response
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Client
    participant KillEndpoint as POST /kill/{id}
    participant Authorizer
    participant DB as Entity Store
    participant PSC as PipelineServiceClient

    Client->>KillEndpoint: "POST kill/{id}"
    Note over KillEndpoint: NEW: explicit EditAll check
    KillEndpoint->>Authorizer: authorize(EDIT_ALL, getResourceContextById(id))
    Authorizer-->>KillEndpoint: 403 if not EditAll
    Note over KillEndpoint: Pre-existing: getInternal ViewAll check
    KillEndpoint->>DB: getInternal (fetches + ViewAll auth)
    DB-->>KillEndpoint: IngestionPipeline
    KillEndpoint->>KillEndpoint: decryptOrNullify(pipeline)
    alt "pipelineServiceClient == null"
        KillEndpoint-->>Client: 200 Pipeline Client Disabled
    else
        KillEndpoint->>PSC: killIngestion(pipeline)
        PSC-->>KillEndpoint: PipelineServiceClientResponse
        KillEndpoint-->>Client: response
    end
```

</a>
</details>

<sub>Reviews (3): Last reviewed commit: ["test(ingestion-pipeline): trim kill-test..."](https://github.com/open-metadata/openmetadata/commit/daf903a141713a85d4c6387061903c861d5988a6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40076478)</sub>

<!-- /greptile_comment -->