### PR TITLE
fix(sse): force UTF-8 decoding to prevent JSON truncation on multibyte chars

### DIFF
--- a/ingestion/src/metadata/ingestion/ometa/sse_client.py
+++ b/ingestion/src/metadata/ingestion/ometa/sse_client.py
@@ -119,8 +119,19 @@ class SSEClient:
                     response.raise_for_status()
                     self.logger.info("Connected to SSE stream")
 
+                    # SSE payloads are UTF-8. ``requests`` defaults a charset-less
+                    # ``text/event-stream`` response to ISO-8859-1, which corrupts
+                    # multi-byte characters (e.g. emoji in model output) and decodes
+                    # UTF-8 continuation bytes such as 0x85 into codepoints that
+                    # ``str.splitlines()`` treats as line breaks. Forcing UTF-8 plus
+                    # splitting only on ``\n`` keeps a single ``data:`` line intact;
+                    # without this an emoji like ``✅`` (bytes e2 9c 85) truncates
+                    # the JSON mid-string, surfacing as ``Unterminated string``.
+                    response.encoding = "utf-8"
+
                     event_buffer = []
-                    for line in response.iter_lines(decode_unicode=True):
+                    for line in response.iter_lines(decode_unicode=True, delimiter="\n"):
+                        line = line.rstrip("\r")
                         if not line:
                             if event_buffer:
                                 parsed_event = self._parse_sse_event(event_buffer)

--- a/ingestion/src/metadata/ingestion/ometa/sse_client.py
+++ b/ingestion/src/metadata/ingestion/ometa/sse_client.py
@@ -130,8 +130,8 @@ class SSEClient:
                     response.encoding = "utf-8"
 
                     event_buffer = []
-                    for line in response.iter_lines(decode_unicode=True, delimiter="\n"):
-                        line = line.rstrip("\r")
+                    for raw_line in response.iter_lines(decode_unicode=True, delimiter="\n"):
+                        line = raw_line.rstrip("\r")
                         if not line:
                             if event_buffer:
                                 parsed_event = self._parse_sse_event(event_buffer)

--- a/ingestion/tests/unit/metadata/ingestion/ometa/test_sse_client.py
+++ b/ingestion/tests/unit/metadata/ingestion/ometa/test_sse_client.py
@@ -35,6 +35,7 @@ class MockSSEResponse:
         self.lines: list[str] = lines
         self.status_code: int = status_code
         self.raise_error: Optional[Exception] = raise_error  # noqa: UP045
+        self.encoding: Optional[str] = None  # noqa: UP045
 
     def raise_for_status(self):
         if self.status_code >= 400:
@@ -42,10 +43,49 @@ class MockSSEResponse:
             err.response = Mock(status_code=self.status_code)
             raise err
 
-    def iter_lines(self, decode_unicode: bool = False) -> Iterator[str]:
+    def iter_lines(self, decode_unicode: bool = False, delimiter: Optional[str] = None) -> Iterator[str]:  # noqa: UP045
         if self.raise_error:
             raise self.raise_error
         yield from self.lines
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> bool:
+        return False
+
+
+class MockByteStreamSSEResponse:
+    """Mock SSE response that reproduces ``requests``' real wire decoding.
+
+    Holds raw UTF-8 bytes plus the charset ``requests`` would derive from the
+    response headers (ISO-8859-1 for a charset-less ``text/event-stream``), and
+    mirrors how ``iter_lines`` decodes and splits: ``str.splitlines()`` when no
+    delimiter is given, ``str.split(delimiter)`` otherwise. This exercises the
+    real bug — UTF-8 multi-byte characters mis-decoded as Latin-1 inject
+    codepoints (e.g. 0x85) that ``splitlines()`` breaks on.
+    """
+
+    def __init__(
+        self,
+        raw: bytes,
+        declared_encoding: str = "ISO-8859-1",
+        status_code: int = 200,
+    ):
+        self.raw: bytes = raw
+        self.encoding: str = declared_encoding
+        self.status_code: int = status_code
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            err = requests.exceptions.HTTPError("HTTP error")
+            err.response = Mock(status_code=self.status_code)
+            raise err
+
+    def iter_lines(self, decode_unicode: bool = False, delimiter: Optional[str] = None) -> Iterator[str]:  # noqa: UP045
+        text = self.raw.decode(self.encoding) if decode_unicode else self.raw
+        lines = text.split(delimiter) if delimiter else text.splitlines()
+        yield from lines
 
     def __enter__(self):
         return self
@@ -850,3 +890,42 @@ def test_parse_sse_event_reassembles_json_split_across_data_lines(sse_client):
 
     data = json.loads(parsed["data"])
     assert data["testCases"][0]["name"] == "customer_id_not_null"
+
+
+def test_stream_preserves_utf8_emoji_in_single_data_line(sse_client):
+    """A ``data:`` line carrying a multi-byte UTF-8 character (e.g. ``✅``) must
+    arrive intact and JSON-parseable.
+
+    Regression: ``requests`` defaults a charset-less ``text/event-stream`` to
+    ISO-8859-1, so ``iter_lines(decode_unicode=True)`` decodes the UTF-8 bytes
+    ``e2 9c 85`` (``✅``) byte-by-byte, producing U+0085 — which
+    ``str.splitlines()`` treats as a line break. The single ``data:`` line was
+    split, its tail (no ``data:`` prefix) dropped, and the JSON truncated
+    mid-string, surfacing as ``json.JSONDecodeError: Unterminated string``.
+    """
+    payload = json.dumps(
+        {
+            "streamId": "stream-emoji",
+            "sequence": 1,
+            "data": {
+                "message": {
+                    "sender": "assistant",
+                    "content": [{"textMessage": {"type": "markdown", "message": "## ✅ Done"}}],
+                }
+            },
+        },
+        ensure_ascii=False,  # server emits raw UTF-8 (e2 9c 85), not \uXXXX escapes
+    )
+    raw = (f"event: message\ndata: {payload}\n\n" 'event: stream-completed\ndata: {"type":"completed"}\n\n').encode(
+        "utf-8"
+    )
+
+    mock_response = MockByteStreamSSEResponse(raw, declared_encoding="ISO-8859-1")
+    mock_session = MockRequestsSession(mock_response)
+
+    with patch("requests.Session", return_value=mock_session):
+        events = list(sse_client.stream("GET", "/chat/stream"))
+
+    message_event = next(event for event in events if event["event"] == "message")
+    data_json = json.loads(message_event["data"])
+    assert data_json["data"]["message"]["content"][0]["textMessage"]["message"] == "## ✅ Done"

--- a/ingestion/tests/unit/metadata/ingestion/ometa/test_sse_client.py
+++ b/ingestion/tests/unit/metadata/ingestion/ometa/test_sse_client.py
@@ -916,9 +916,7 @@ def test_stream_preserves_utf8_emoji_in_single_data_line(sse_client):
         },
         ensure_ascii=False,  # server emits raw UTF-8 (e2 9c 85), not \uXXXX escapes
     )
-    raw = (f"event: message\ndata: {payload}\n\n" 'event: stream-completed\ndata: {"type":"completed"}\n\n').encode(
-        "utf-8"
-    )
+    raw = (f'event: message\ndata: {payload}\n\nevent: stream-completed\ndata: {{"type":"completed"}}\n\n').encode()
 
     mock_response = MockByteStreamSSEResponse(raw, declared_encoding="ISO-8859-1")
     mock_session = MockRequestsSession(mock_response)


### PR DESCRIPTION
Fixes #29531

### What
`SSEClient.stream()` read the event stream with `iter_lines(decode_unicode=True)` and no explicit charset. For a charset-less `text/event-stream`, `requests` defaults to ISO-8859-1, so multi-byte UTF-8 chars in model output (e.g. `✅` = `e2 9c 85`) were decoded byte-by-byte; the resulting U+0085 was then treated as a line break by `str.splitlines()`, splitting a single `data:` line and dropping its tail → truncated JSON → `JSONDecodeError: Unterminated string`.

### Fix
- Set `response.encoding = "utf-8"` before reading the stream.
- Read with `iter_lines(decode_unicode=True, delimiter="\n")` so splitting happens only on `\n` (not `splitlines()`, which also breaks on U+0085/U+2028/U+2029), and `rstrip("\r")` each line to keep `\r\n` framing working.

### Tests
Added `test_stream_preserves_utf8_emoji_in_single_data_line` plus a byte-level mock (`MockByteStreamSSEResponse`) that reproduces real `requests` decode/split behavior. The test fails on the pre-fix code with the exact production error and passes with the fix. Full `test_sse_client.py` suite (34 tests) green.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Fixes a UTF-8 decoding bug in `SSEClient.stream()` where `requests` defaulted to ISO-8859-1 for charset-less `text/event-stream` responses, causing multi-byte characters (e.g. emoji) to be mis-decoded and then split by `str.splitlines()`, truncating JSON payloads with a `JSONDecodeError: Unterminated string`.

- **`sse_client.py`**: Sets `response.encoding = "utf-8"` before reading the stream, and switches `iter_lines` to use `delimiter="\n"` (so splitting happens only on literal newlines, not Unicode line-break codepoints like U+0085), with a `rstrip("\r")` to retain CRLF compatibility.
- **`test_sse_client.py`**: Adds `MockByteStreamSSEResponse` — a byte-level mock that faithfully reproduces `requests`' real decode/split behavior — and a regression test that fails on the pre-fix code with the exact production error and passes with the fix.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is a minimal, targeted fix to SSE stream decoding with no side effects on unrelated paths.

The fix is two lines of production code with a clear causal chain from the bug report to the change. The encoding override and 
-only split are standard, well-understood requests idioms. The new regression test reproduces the exact failure mode byte-for-byte and is now green. Existing 34-test suite remains unaffected.

No files require special attention.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| ingestion/src/metadata/ingestion/ometa/sse_client.py | Forces UTF-8 decoding and uses explicit `\n` delimiter in `iter_lines` to prevent mis-decoding of multi-byte characters; also strips `\r` per-line for CRLF compatibility. Change is minimal, targeted, and correct. |
| ingestion/tests/unit/metadata/ingestion/ometa/test_sse_client.py | Adds `MockByteStreamSSEResponse` that accurately simulates real `requests` byte-level decode/split behavior, and a regression test that reproduces the exact production `JSONDecodeError` before the fix. Existing mock updated to accept the new `delimiter` and `encoding` parameters. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Server as SSE Server
    participant Req as requests.Session
    participant SSE as SSEClient.stream()
    participant Parser as _parse_sse_event()

    Server->>Req: "text/event-stream (charset-less, UTF-8 bytes)"
    Note over Req: "Before fix: defaults to ISO-8859-1. After fix: response.encoding forced to utf-8"
    Req->>SSE: response object

    loop "For each raw_line from iter_lines(delimiter=chr(10))"
        SSE->>SSE: "line = raw_line.rstrip(chr(13))"
        alt "line is empty"
            SSE->>Parser: "_parse_sse_event(event_buffer)"
            Parser-->>SSE: "parsed event dict"
            SSE-->>SSE: "yield event and clear buffer"
        else "line has content and is not a comment"
            SSE->>SSE: "event_buffer.append(line)"
        end
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Server as SSE Server
    participant Req as requests.Session
    participant SSE as SSEClient.stream()
    participant Parser as _parse_sse_event()

    Server->>Req: "text/event-stream (charset-less, UTF-8 bytes)"
    Note over Req: "Before fix: defaults to ISO-8859-1. After fix: response.encoding forced to utf-8"
    Req->>SSE: response object

    loop "For each raw_line from iter_lines(delimiter=chr(10))"
        SSE->>SSE: "line = raw_line.rstrip(chr(13))"
        alt "line is empty"
            SSE->>Parser: "_parse_sse_event(event_buffer)"
            Parser-->>SSE: "parsed event dict"
            SSE-->>SSE: "yield event and clear buffer"
        else "line has content and is not a comment"
            SSE->>SSE: "event_buffer.append(line)"
        end
    end
```

</a>
</details>

<sub>Reviews (2): Last reviewed commit: ["style: apply ruff format/lint to sse\_cli..."](https://github.com/open-metadata/openmetadata/commit/46b6a9fd654fc24b86b53af725c751dbc9bd7cc4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40077705)</sub>

<!-- /greptile_comment -->