### PR TITLE
Refactor:Move MUI Components from Learning Resource Card to Untitled Core Components

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/Learning/LearningResourceCard/LearningResourceCard.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Learning/LearningResourceCard/LearningResourceCard.component.tsx
@@ -11,45 +11,50 @@
  *  limitations under the License.
  */
 
-import { Box, Link, Popover, Typography, useTheme } from '@mui/material';
+import {
+  Badge,
+  BadgeColors,
+  Box,
+  Button,
+  Popover,
+  PopoverTrigger,
+  Typography,
+} from '@openmetadata/ui-core-components';
+import classNames from 'classnames';
 import { DateTime } from 'luxon';
 import React, { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { ReactComponent as StoryLaneIcon } from '../../../assets/svg/ic_storylane.svg';
 import { ReactComponent as VideoIcon } from '../../../assets/svg/ic_video.svg';
-import { ResourceType } from '../../../constants/Learning.constants';
-import { LEARNING_CATEGORIES } from '../Learning.interface';
+import {
+  CATEGORY_BADGE_COLORS,
+  DESCRIPTION_VIEW_MORE_THRESHOLD,
+  ICON_COLOR_CLASS,
+  MAX_VISIBLE_CATEGORIES_IN_CARD,
+  ResourceType,
+} from '../../../constants/Learning.constants';
+import { LEARNING_CATEGORIES, ResourceCategory } from '../Learning.interface';
 import { LearningResourceCardProps } from './LearningResourceCard.interface';
-
-const MAX_VISIBLE_CATEGORIES_IN_CARD = 2;
-const DESCRIPTION_VIEW_MORE_THRESHOLD = 100;
 
 export const LearningResourceCard: React.FC<LearningResourceCardProps> = ({
   resource,
   onClick,
 }) => {
   const { t } = useTranslation();
-  const theme = useTheme();
-
-  const iconColors = {
-    video: theme.palette.allShades?.blue?.[600],
-    storylane: theme.palette.allShades?.purple?.[600],
-  };
-  const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
+  const [popoverOpen, setPopoverOpen] = useState(false);
 
   const showViewMore =
     resource.description &&
     resource.description.length > DESCRIPTION_VIEW_MORE_THRESHOLD;
 
-  const type = resource.resourceType.toLowerCase();
-  const iconColor =
-    iconColors[type as keyof typeof iconColors] ?? iconColors.video;
-  const iconProps = { height: 24, width: 24, style: { color: iconColor } };
+  const iconColorClass =
+    ICON_COLOR_CLASS[resource.resourceType.toLowerCase()] ??
+    ICON_COLOR_CLASS.video;
   const resourceTypeIcon =
     resource.resourceType === ResourceType.Storylane ? (
-      <StoryLaneIcon {...iconProps} />
+      <StoryLaneIcon className={iconColorClass} height={24} width={24} />
     ) : (
-      <VideoIcon {...iconProps} />
+      <VideoIcon className={iconColorClass} height={24} width={24} />
     );
 
   const formattedDuration = resource.estimatedDuration
@@ -70,326 +75,154 @@ export const LearningResourceCard: React.FC<LearningResourceCardProps> = ({
             resource.categories.length - MAX_VISIBLE_CATEGORIES_IN_CARD,
         };
 
-  const getCategoryColors = (category: string) => {
-    const info =
-      LEARNING_CATEGORIES[category as keyof typeof LEARNING_CATEGORIES];
+  const getCategoryLabel = (category: string) =>
+    LEARNING_CATEGORIES[category as ResourceCategory]?.label ?? category;
 
-    return {
-      bgColor: info?.bgColor ?? '#f8f9fc',
-      borderColor: info?.borderColor ?? '#d5d9eb',
-      color: info?.color ?? '#363f72',
-    };
-  };
+  const getCategoryColor = (category: string): BadgeColors =>
+    CATEGORY_BADGE_COLORS[category as ResourceCategory] ?? 'gray';
 
-  const handleViewMoreClick = (e: React.MouseEvent) => {
-    e.stopPropagation();
+  const handleViewMoreClick = () => {
     onClick?.(resource);
   };
 
-  const handleMoreTagClick = (e: React.MouseEvent) => {
+  const stopPropagation = (e: React.MouseEvent) => {
     e.stopPropagation();
-    setAnchorEl(e.currentTarget as HTMLElement);
-  };
-
-  const handlePopoverClose = () => {
-    setAnchorEl(null);
   };
 
   return (
     <Box
-      bgcolor={theme.palette.allShades?.white}
-      border="1px solid"
-      borderColor={theme.palette.allShades?.blueGray?.[50]}
-      borderRadius={theme.spacing(1.5)}
-      boxShadow={theme.shadows[1]}
+      className={classNames(
+        'tw:w-full tw:min-w-0 tw:p-5 tw:rounded-xl tw:bg-primary tw:border tw:border-secondary tw:shadow-xs tw:transition-all',
+        onClick && 'tw:cursor-pointer tw:hover:shadow-md'
+      )}
       data-clickable={onClick ? 'true' : undefined}
       data-testid={`learning-resource-card-${resource.name}`}
-      sx={{
-        width: '100%',
-        minWidth: 0,
-        padding: theme.spacing(2.5),
-        display: 'flex',
-        flexDirection: 'column',
-        gap: 1.5,
-        transition: 'all 0.2s ease',
-        ...(onClick && {
-          cursor: 'pointer',
-          '&:hover': {
-            boxShadow:
-              '0 4px 6px -2px rgba(10, 13, 18, 0.05), 0 2px 4px -2px rgba(10, 13, 18, 0.05)',
-          },
-        }),
-      }}
+      direction="col"
+      gap={3}
       onClick={() => onClick?.(resource)}>
-      <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1.5 }}>
-        <Box
-          sx={{
-            display: 'flex',
-            alignItems: 'flex-start',
-            gap: 1.5,
-            minWidth: 0,
-            minHeight: 40,
-          }}>
-          <Box sx={{ flexShrink: 0, mt: '2px' }}>{resourceTypeIcon}</Box>
-          <Typography
-            component="span"
-            sx={{
-              flex: 1,
-              minWidth: 0,
-              fontSize: theme.typography.body2.fontSize,
-              lineHeight: theme.typography.body2.lineHeight,
-              color: theme.palette.allShades?.gray?.[900],
-              overflow: 'hidden',
-              textOverflow: 'ellipsis',
-              display: '-webkit-box',
-              WebkitLineClamp: 2,
-              WebkitBoxOrient: 'vertical',
-              fontWeight: 600,
-            }}>
-            {resource.displayName || resource.name}
-          </Typography>
-        </Box>
+      <Box align="start" className="tw:min-w-0 tw:min-h-10" gap={3}>
+        <Box className="tw:shrink-0 tw:mt-0.5">{resourceTypeIcon}</Box>
+        <Typography
+          as="span"
+          className="tw:flex-1 tw:min-w-0 tw:text-primary"
+          ellipsis={{ rows: 2 }}
+          size="text-sm"
+          weight="semibold">
+          {resource.displayName || resource.name}
+        </Typography>
+      </Box>
 
-        <Box
-          sx={{
-            display: 'flex',
-            flexDirection: 'column',
-            minHeight: 56,
-          }}>
-          {resource.description ? (
-            <>
-              <Typography
-                aria-label={resource.description}
-                component="span"
-                data-testid="learning-resource-description"
-                sx={{
-                  fontSize: theme.typography.caption.fontSize,
-                  lineHeight: theme.typography.body2.lineHeight,
-                  color: theme.palette.allShades?.gray?.[600],
-                  overflow: 'hidden',
-                  textOverflow: 'ellipsis',
-                  display: '-webkit-box',
-                  WebkitLineClamp: showViewMore ? 2 : 3,
-                  WebkitBoxOrient: 'vertical',
-                  flex: 1,
-                  minHeight: 0,
-                }}>
-                {resource.description}
-              </Typography>
-              {showViewMore && (
-                <Link
-                  component="button"
-                  sx={{
-                    fontSize: theme.typography.caption.fontSize,
-                    color: theme.palette.allShades?.brand?.[600],
-                    cursor: 'pointer',
-                    flexShrink: 0,
-                    alignSelf: 'flex-start',
-                    '&:hover': { textDecoration: 'underline' },
-                  }}
-                  type="button"
-                  onClick={handleViewMoreClick}>
+      <Box className="tw:min-h-14" direction="col" gap={1}>
+        {resource.description ? (
+          <>
+            <Typography
+              aria-label={resource.description}
+              as="span"
+              className="tw:text-tertiary"
+              data-testid="learning-resource-description"
+              ellipsis={{ rows: showViewMore ? 2 : 3 }}
+              size="text-xs">
+              {resource.description}
+            </Typography>
+            {showViewMore && (
+              <Box inline className="tw:shrink-0" onClick={stopPropagation}>
+                <Button
+                  color="link-color"
+                  size="sm"
+                  onPress={handleViewMoreClick}>
                   {t('label.view-more')}
-                </Link>
+                </Button>
+              </Box>
+            )}
+          </>
+        ) : (
+          <Typography
+            as="span"
+            className="tw:italic tw:text-quaternary"
+            data-testid="learning-resource-description"
+            size="text-sm">
+            {t('label.no-entity-added', {
+              entity: t('label.description-lowercase'),
+            })}
+          </Typography>
+        )}
+      </Box>
+
+      <Box direction="col" gap={3}>
+        <Box
+          align="center"
+          className="tw:min-w-0 tw:gap-1.5 tw:overflow-hidden">
+          {categoryTags.visible.length > 0 ? (
+            <>
+              <Box className="tw:min-w-0 tw:flex-nowrap tw:gap-1.5 tw:overflow-hidden">
+                {categoryTags.visible.map((category) => (
+                  <Badge
+                    color={getCategoryColor(category)}
+                    key={category}
+                    size="sm"
+                    type="pill-color">
+                    {getCategoryLabel(category)}
+                  </Badge>
+                ))}
+              </Box>
+              {categoryTags.remaining > 0 && (
+                <Box inline className="tw:shrink-0" onClick={stopPropagation}>
+                  <PopoverTrigger
+                    isOpen={popoverOpen}
+                    onOpenChange={setPopoverOpen}>
+                    <Button
+                      color="secondary"
+                      data-testid="more-categories"
+                      size="sm">
+                      +{categoryTags.remaining}
+                    </Button>
+                    <Popover
+                      containerClassName="tw:p-3"
+                      placement="bottom left">
+                      <Box className="tw:max-w-[250px] tw:flex-wrap tw:gap-1.5">
+                        {categoryTags.hidden.map((category) => (
+                          <Badge
+                            color={getCategoryColor(category)}
+                            key={category}
+                            size="sm"
+                            type="pill-color">
+                            {getCategoryLabel(category)}
+                          </Badge>
+                        ))}
+                      </Box>
+                    </Popover>
+                  </PopoverTrigger>
+                </Box>
               )}
             </>
           ) : (
             <Typography
-              component="span"
-              data-testid="learning-resource-description"
-              sx={{
-                color: theme.palette.allShades?.gray?.[500],
-                fontFamily: theme.typography.fontFamily,
-                fontSize: theme.typography.body2.fontSize,
-                fontStyle: 'italic',
-                fontWeight: theme.typography.fontWeightRegular,
-                lineHeight: theme.typography.body2.lineHeight,
-              }}>
+              as="span"
+              className="tw:italic tw:text-quaternary"
+              size="text-sm">
               {t('label.no-entity-added', {
-                entity: t('label.description-lowercase'),
+                entity: t('label.category-lowercase'),
               })}
             </Typography>
           )}
         </Box>
 
-        <Box
-          sx={{
-            display: 'flex',
-            flexDirection: 'column',
-            gap: 1.5,
-          }}>
-          <Box
-            sx={{
-              display: 'flex',
-              alignItems: 'center',
-              gap: theme.spacing(0.75),
-              minWidth: 0,
-              overflow: 'hidden',
-            }}>
-            {categoryTags.visible.length > 0 ? (
-              <>
-                <Box
-                  sx={{
-                    display: 'flex',
-                    flexWrap: 'nowrap',
-                    gap: theme.spacing(0.75),
-                    minWidth: 0,
-                    overflow: 'hidden',
-                  }}>
-                  {categoryTags.visible.map((category) => {
-                    const colors = getCategoryColors(category);
-
-                    return (
-                      <Box
-                        component="span"
-                        key={category}
-                        sx={{
-                          flexShrink: 0,
-                          fontSize: theme.typography.caption.fontSize,
-                          lineHeight: theme.typography.body2.lineHeight,
-                          padding: theme.spacing(0.25, 0.75),
-                          borderRadius: theme.spacing(0.75),
-                          fontWeight: theme.typography.fontWeightMedium,
-                          backgroundColor: colors.bgColor,
-                          border: '1px solid',
-                          borderColor: colors.borderColor,
-                          color: colors.color,
-                        }}>
-                        {LEARNING_CATEGORIES[
-                          category as keyof typeof LEARNING_CATEGORIES
-                        ]?.label ?? category}
-                      </Box>
-                    );
-                  })}
-                </Box>
-                {categoryTags.remaining > 0 && (
-                  <>
-                    <Box
-                      component="span"
-                      sx={{
-                        flexShrink: 0,
-                        fontSize: theme.typography.caption.fontSize,
-                        lineHeight: theme.typography.body2.lineHeight,
-                        padding: theme.spacing(0.25, 0.75),
-                        borderRadius: theme.spacing(0.75),
-                        fontWeight: theme.typography.fontWeightMedium,
-                        backgroundColor: theme.palette.allShades?.brand?.[50],
-                        border: 'none',
-                        color: theme.palette.allShades?.brand?.[700],
-                        cursor: 'pointer',
-                        '&:hover': {
-                          backgroundColor:
-                            theme.palette.allShades?.brand?.[100],
-                        },
-                      }}
-                      onClick={handleMoreTagClick}>
-                      +{categoryTags.remaining}
-                    </Box>
-                    <Popover
-                      anchorEl={anchorEl}
-                      anchorOrigin={{ vertical: 'bottom', horizontal: 'left' }}
-                      open={Boolean(anchorEl)}
-                      slotProps={{
-                        root: {
-                          onClick: (e: React.MouseEvent) => e.stopPropagation(),
-                        },
-                      }}
-                      transformOrigin={{ vertical: 'top', horizontal: 'left' }}
-                      onClose={handlePopoverClose}>
-                      <Box
-                        sx={{
-                          display: 'flex',
-                          flexWrap: 'wrap',
-                          gap: 0.5,
-                          maxWidth: 250,
-                          p: 1.5,
-                        }}
-                        onClick={(e) => e.stopPropagation()}>
-                        {categoryTags.hidden.map((category) => {
-                          const colors = getCategoryColors(category);
-
-                          return (
-                            <Box
-                              component="span"
-                              key={category}
-                              sx={{
-                                fontSize: theme.typography.caption.fontSize,
-                                lineHeight: theme.typography.body2.lineHeight,
-                                padding: theme.spacing(0.25, 0.75),
-                                borderRadius: theme.spacing(0.75),
-                                fontWeight: theme.typography.fontWeightMedium,
-                                backgroundColor: colors.bgColor,
-                                border: '1px solid',
-                                borderColor: colors.borderColor,
-                                color: colors.color,
-                              }}>
-                              {LEARNING_CATEGORIES[
-                                category as keyof typeof LEARNING_CATEGORIES
-                              ]?.label ?? category}
-                            </Box>
-                          );
-                        })}
-                      </Box>
-                    </Popover>
-                  </>
-                )}
-              </>
-            ) : (
-              <Typography
-                component="span"
-                sx={{
-                  color: theme.palette.allShades?.gray?.[500],
-                  fontFamily: theme.typography.fontFamily,
-                  fontSize: theme.typography.body2.fontSize,
-                  fontStyle: 'italic',
-                  fontWeight: theme.typography.fontWeightRegular,
-                  lineHeight: theme.typography.body2.lineHeight,
-                }}>
-                {t('label.no-entity-added', {
-                  entity: t('label.category-lowercase'),
-                })}
-              </Typography>
-            )}
-          </Box>
-
-          <Box
-            sx={{
-              display: 'flex',
-              alignItems: 'center',
-              gap: 0.75,
-              flexShrink: 0,
-            }}>
-            {formattedDate && (
-              <Typography
-                component="span"
-                sx={{
-                  fontSize: theme.typography.caption.fontSize,
-                  color: theme.palette.allShades?.gray?.[600],
-                }}>
-                {formattedDate}
-              </Typography>
-            )}
-            {formattedDate && formattedDuration && (
-              <Typography
-                component="span"
-                sx={{
-                  fontSize: theme.typography.caption.fontSize,
-                  color: theme.palette.allShades?.blueGray?.[100],
-                }}>
-                |
-              </Typography>
-            )}
-            {formattedDuration && (
-              <Typography
-                component="span"
-                sx={{
-                  fontSize: theme.typography.caption.fontSize,
-                  color: theme.palette.allShades?.gray?.[600],
-                }}>
-                {formattedDuration}
-              </Typography>
-            )}
-          </Box>
+        <Box align="center" className="tw:shrink-0 tw:gap-1.5">
+          {formattedDate && (
+            <Typography as="span" className="tw:text-tertiary" size="text-xs">
+              {formattedDate}
+            </Typography>
+          )}
+          {formattedDate && formattedDuration && (
+            <Typography as="span" className="tw:text-quaternary" size="text-xs">
+              |
+            </Typography>
+          )}
+          {formattedDuration && (
+            <Typography as="span" className="tw:text-tertiary" size="text-xs">
+              {formattedDuration}
+            </Typography>
+          )}
         </Box>
       </Box>
     </Box>

--- a/openmetadata-ui/src/main/resources/ui/src/constants/Learning.constants.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/constants/Learning.constants.ts
@@ -11,6 +11,7 @@
  *  limitations under the License.
  */
 
+import { BadgeColors } from '@openmetadata/ui-core-components';
 import { ReactNode } from 'react';
 import {
   ResourceCategory,
@@ -25,6 +26,23 @@ export const MAX_VISIBLE_CONTEXTS = 2;
 export const DEFAULT_PAGE_SIZE = 10;
 
 export const MAX_CHAIN_PAGES = 25;
+
+export const MAX_VISIBLE_CATEGORIES_IN_CARD = 2;
+export const DESCRIPTION_VIEW_MORE_THRESHOLD = 100;
+
+export const CATEGORY_BADGE_COLORS: Record<ResourceCategory, BadgeColors> = {
+  Discovery: 'blue',
+  Administration: 'blue-light',
+  DataGovernance: 'indigo',
+  DataQuality: 'orange',
+  Observability: 'orange',
+  AI: 'purple',
+};
+
+export const ICON_COLOR_CLASS: Record<string, string> = {
+  video: 'tw:text-utility-blue-600',
+  storylane: 'tw:text-utility-purple-600',
+};
 
 export const RESOURCE_TYPE_VALUES = [
   ResourceType.Video,


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:

Fixes #29533 
<!--
Linking an issue is REQUIRED. Replace <issue-number> with the GitHub issue number this PR addresses
(e.g., `Fixes #12345`). GitHub will auto-link it. If no issue exists, please open one first so the
problem and design can be discussed before review.
-->

<!--
Short blurb explaining:
- What changes did you make?
- Why did you make them?
-->

I worked on ... because ...

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### High-level design:
<!--
REQUIRED for large PRs (new features, refactors, breaking changes, or anything touching >5 files).
Skip for small bug fixes and trivial changes.

Cover:
- Architecture / approach you took and why
- Key components or files added/changed and how they interact
- Alternatives considered and why you rejected them
- Any migration, backward-compatibility, or rollout concerns
- Diagrams or links to design docs / RFCs if available
-->

N/A — small change. <!-- Or fill in the design above -->

#
### Tests:

#### Use cases covered
<!--
List the user-visible scenarios this PR exercises. Example:
- User with Admin role can create a Glossary Term with a parent term
- Ingestion run for Snowflake correctly extracts row counts for partitioned tables
-->

#### Unit tests
<!--
- [ ] I added unit tests for the new/changed logic.
- Files added/updated:
- Coverage on changed classes (run `mvn jacoco:report` for backend, `yarn test:coverage` for UI,
  `make unit_ingestion` for ingestion). Target is 90% line coverage on changed classes.
- Coverage %: <e.g., 92% on EntityRepository.java>
-->

#### Backend integration tests
<!--
- [ ] I added integration tests in `openmetadata-integration-tests/` for new/changed API endpoints.
- [ ] Not applicable (no backend API changes).
- Files added/updated:
-->

#### Ingestion integration tests
<!--
- [ ] I added/updated ingestion integration tests for connector changes.
- [ ] Not applicable (no ingestion changes).
- Files added/updated:
-->

#### Playwright (UI) tests
<!--
- [ ] I added Playwright E2E tests under `openmetadata-ui/.../ui/playwright/` for UI changes.
- [ ] Not applicable (no UI changes).
- Files added/updated:
-->

#### Manual testing performed
<!--
List the manual test steps you performed before requesting review. Example:
1. Started local stack via `./docker/run_local_docker.sh -m ui -d mysql`
2. Logged in as admin, created entity X, verified Y appears in the UI
3. Triggered ingestion for Snowflake source, confirmed lineage edges in the explore page
-->

#
### UI screen recording / screenshots:
<!--
REQUIRED for any PR that changes the UI. Drag-and-drop a short screen recording (.mov / .mp4 / .gif)
demonstrating the change end-to-end, plus before/after screenshots where relevant.
Mark "Not applicable" if there are no UI changes.
-->

Not applicable. <!-- Or attach recording/screenshots above -->

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.
- [ ] For UI changes: I attached a screen recording and/or screenshots above.
- [ ] I have added tests (unit / integration / Playwright as applicable) and listed them above.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->

----
## Summary by Gitar

- **Component migration:**
  - Migrated `LearningResourceCard` from MUI components to `@openmetadata/ui-core-components`.
  - Replaced custom MUI styles with Tailwind utility classes for improved design consistency.
- **UI enhancements:**
  - Integrated `Badge` and `Popover` components from the core library for resource categorization.
  - Updated `ICON_COLOR_CLASS` and `CATEGORY_BADGE_COLORS` in `Learning.constants.ts` to manage styles centrally.
- **Code cleanup:**
  - Removed legacy `useTheme` and custom CSS-in-JS logic in favor of atomic utility classes.

<sub>This will update automatically on new commits.</sub>

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR refactors `LearningResourceCard` to replace MUI components (`Box`, `Link`, `Popover`, `useTheme`) with equivalents from `@openmetadata/ui-core-components` and Tailwind utility classes, and promotes previously inline-component constants into the shared `Learning.constants.ts`.

- Replaces `useTheme`-driven inline styles with Tailwind `tw:` utility classes and the `Box`/`Typography`/`Badge` components from the core library.
- Moves `MAX_VISIBLE_CATEGORIES_IN_CARD`, `DESCRIPTION_VIEW_MORE_THRESHOLD`, `CATEGORY_BADGE_COLORS`, and `ICON_COLOR_CLASS` from the component file to `Learning.constants.ts`.
- Converts the MUI `Popover` (anchor-element pattern) to a `PopoverTrigger`/`Popover` controlled pair, and replaces the MUI `Link` "View More" with a core `Button` using `onPress`.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Pure UI refactoring with no logic changes; the component renders correctly and event propagation is handled equivalently to the original implementation.

The migration replaces MUI bindings with core-component equivalents on a single, self-contained card component. Click-propagation guards are preserved via stopPropagation wrappers on the View More and +N categories buttons, matching the original behaviour. The constants extraction is additive and does not touch any call sites. No backend API, routing, or data-fetching logic is affected.

No files require special attention.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-ui/src/main/resources/ui/src/components/Learning/LearningResourceCard/LearningResourceCard.component.tsx | Full MUI-to-core-components migration: replaces useTheme/inline styles with Tailwind utility classes, swaps Link/Popover for Button/PopoverTrigger, and moves prop-drilling state into PopoverTrigger's controlled isOpen pattern. Logic is equivalent to the original. |
| openmetadata-ui/src/main/resources/ui/src/constants/Learning.constants.ts | Extracts MAX_VISIBLE_CATEGORIES_IN_CARD, DESCRIPTION_VIEW_MORE_THRESHOLD, CATEGORY_BADGE_COLORS, and ICON_COLOR_CLASS from the component into the shared constants file; adds BadgeColors import for the new color map type. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[User clicks LearningResourceCard] --> B{onClick prop set?}
    B -->|No| C[No action]
    B -->|Yes| D[onClick called with resource]

    E[User clicks '+N categories button'] --> F[Box.onClick stopPropagation]
    F --> G[PopoverTrigger onOpenChange fires]
    G --> H[Popover opens with hidden categories]

    I[User clicks View More button] --> J[Box.onClick stopPropagation]
    J --> K[Button onPress fires]
    K --> L[handleViewMoreClick calls onClick resource]

    M[ICON_COLOR_CLASS lookup] --> N{resourceType}
    N -->|video| O[tw:text-utility-blue-600]
    N -->|storylane| P[tw:text-utility-purple-600]

    Q[getCategoryColor lookup] --> R{CATEGORY_BADGE_COLORS}
    R -->|Discovery| S[blue]
    R -->|Administration| T[blue-light]
    R -->|DataGovernance| U[indigo]
    R -->|DataQuality/Observability| V[orange]
    R -->|AI| W[purple]
    R -->|unknown| X[gray fallback]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[User clicks LearningResourceCard] --> B{onClick prop set?}
    B -->|No| C[No action]
    B -->|Yes| D[onClick called with resource]

    E[User clicks '+N categories button'] --> F[Box.onClick stopPropagation]
    F --> G[PopoverTrigger onOpenChange fires]
    G --> H[Popover opens with hidden categories]

    I[User clicks View More button] --> J[Box.onClick stopPropagation]
    J --> K[Button onPress fires]
    K --> L[handleViewMoreClick calls onClick resource]

    M[ICON_COLOR_CLASS lookup] --> N{resourceType}
    N -->|video| O[tw:text-utility-blue-600]
    N -->|storylane| P[tw:text-utility-purple-600]

    Q[getCategoryColor lookup] --> R{CATEGORY_BADGE_COLORS}
    R -->|Discovery| S[blue]
    R -->|Administration| T[blue-light]
    R -->|DataGovernance| U[indigo]
    R -->|DataQuality/Observability| V[orange]
    R -->|AI| W[purple]
    R -->|unknown| X[gray fallback]
```

</a>
</details>

<sub>Reviews (2): Last reviewed commit: ["Merge branch &#39;main&#39; into issue-29533"](https://github.com/open-metadata/openmetadata/commit/44f6fbe4ebb152f1df4dd03129dce8673dfe0576) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40083863)</sub>

<!-- /greptile_comment -->