### PR TITLE
feat(ui): add DestinationFormItemV2 — AntD-free alert destination form

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/Alerts/DestinationFormItemV2/DestinationFormItemV2.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Alerts/DestinationFormItemV2/DestinationFormItemV2.component.tsx
@@ -1,0 +1,267 @@
+/*
+ *  Copyright 2024 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+import {
+  Button,
+  Card,
+  Divider,
+  Grid,
+  Input,
+  Tooltip,
+  Typography,
+} from '@openmetadata/ui-core-components';
+import { AxiosError } from 'axios';
+import { isEmpty, isNil, isUndefined } from 'lodash';
+import { Fragment, useCallback, useEffect, useMemo, useState } from 'react';
+import {
+  Controller,
+  useFieldArray,
+  useFormContext,
+  useWatch,
+} from 'react-hook-form';
+import { useTranslation } from 'react-i18next';
+
+import {
+  DEFAULT_READ_TIMEOUT,
+  EXTERNAL_CATEGORY_OPTIONS,
+} from '../../../constants/Alerts.constants';
+import type { ModifiedDestination } from '../../../pages/AddObservabilityPage/AddObservabilityPage.interface';
+import { testAlertDestination } from '../../../rest/alertsAPI';
+import { getFormattedDestinations } from '../../../utils/Alerts/AlertsUtilPure';
+import { showErrorToast } from '../../../utils/ToastUtils';
+import { DestinationFormItemV2Props } from './DestinationFormItemV2.interface';
+import DestinationSelectItemV2 from './DestinationSelectItemV2/DestinationSelectItemV2';
+
+function DestinationFormItemV2({
+  isViewMode = false,
+}: Readonly<DestinationFormItemV2Props>) {
+  const { t } = useTranslation();
+  const { control, setError, clearErrors, formState } = useFormContext();
+
+  const { fields, append, remove } = useFieldArray({
+    name: 'destinations',
+    control,
+  });
+
+  const [destinationsWithStatus, setDestinationsWithStatus] =
+    useState<ModifiedDestination[]>();
+  const [isDestinationStatusLoading, setIsDestinationStatusLoading] =
+    useState(false);
+
+  const selectedResources: string[] =
+    useWatch({ name: 'resources', control }) ?? [];
+  const destinations: ModifiedDestination[] =
+    (useWatch({ name: 'destinations', control }) as ModifiedDestination[]) ??
+    [];
+
+  const selectedSource = selectedResources[0];
+
+  useEffect(() => {
+    if (fields.length === 0) {
+      setError('destinations', {
+        type: 'manual',
+        message: t('message.minimum-count-error', {
+          field: t('label.destination'),
+          count: 1,
+        }),
+      });
+    } else {
+      clearErrors('destinations');
+    }
+  }, [fields.length, setError, clearErrors, t]);
+
+  const isExternalDestinationSelected = useMemo(
+    () =>
+      destinations.some((destination) => {
+        const externalDestinationTypes = EXTERNAL_CATEGORY_OPTIONS.map(
+          (o) => o.value
+        );
+
+        return (
+          destination.category === 'External' &&
+          externalDestinationTypes.includes(destination.type ?? '')
+        );
+      }),
+    [destinations]
+  );
+
+  const disableTestDestinationButton = useMemo(
+    () =>
+      isEmpty(selectedSource) ||
+      isNil(selectedSource) ||
+      !isExternalDestinationSelected,
+    [selectedSource, isExternalDestinationSelected]
+  );
+
+  const handleTestDestinationClick = useCallback(async () => {
+    try {
+      setIsDestinationStatusLoading(true);
+      const formattedDestinations = getFormattedDestinations(destinations);
+      if (!isUndefined(formattedDestinations)) {
+        const externalDestinations = formattedDestinations.filter(
+          (d) => d.category === 'External' && !isEmpty(d?.config)
+        );
+        const results = await testAlertDestination({
+          destinations: externalDestinations,
+        });
+        setDestinationsWithStatus(results as ModifiedDestination[]);
+      }
+    } catch (e) {
+      showErrorToast(e as AxiosError);
+    } finally {
+      setIsDestinationStatusLoading(false);
+    }
+  }, [destinations]);
+
+  const destinationListError = (
+    formState.errors.destinations as { message?: string } | undefined
+  )?.message;
+
+  return (
+    <Card variant="default">
+      <Card.Header
+        subtitle={t('message.alerts-destination-description')}
+        title={t('label.destination')}
+      />
+      <Card.Content>
+        <Grid colGap="4" rowGap="4">
+          <Grid.Item span={7}>
+            <Typography as="span" size="text-sm">
+              {`${t('label.connection-timeout')} (${t('label.second-plural')})`}
+            </Typography>
+          </Grid.Item>
+          <Grid.Item span={1}>
+            <Typography as="span" size="text-sm">
+              :
+            </Typography>
+          </Grid.Item>
+          <Grid.Item data-testid="connection-timeout" span={16}>
+            <Controller
+              control={control}
+              name="timeout"
+              render={({ field }) => (
+                <Input
+                  data-testid="connection-timeout-input"
+                  defaultValue="10"
+                  inputDataTestId="connection-timeout-input-field"
+                  placeholder={`${t('label.connection-timeout')} (${t(
+                    'label.second-plural'
+                  )})`}
+                  ref={field.ref}
+                  type="number"
+                  value={field.value !== undefined ? String(field.value) : ''}
+                  onBlur={field.onBlur}
+                  onChange={(val) => field.onChange(val)}
+                />
+              )}
+            />
+          </Grid.Item>
+
+          <Grid.Item span={7}>
+            <Typography as="span" size="text-sm">
+              {`${t('label.read-type', { type: t('label.timeout') })} (${t(
+                'label.second-plural'
+              )})`}
+            </Typography>
+          </Grid.Item>
+          <Grid.Item span={1}>
+            <Typography as="span" size="text-sm">
+              :
+            </Typography>
+          </Grid.Item>
+          <Grid.Item data-testid="read-timeout" span={16}>
+            <Controller
+              control={control}
+              name="readTimeout"
+              render={({ field }) => (
+                <Input
+                  data-testid="read-timeout-input"
+                  defaultValue={String(DEFAULT_READ_TIMEOUT)}
+                  inputDataTestId="read-timeout-input-field"
+                  placeholder={`${t('label.read-type', {
+                    type: t('label.timeout'),
+                  })} (${t('label.second-plural')})`}
+                  ref={field.ref}
+                  type="number"
+                  value={field.value !== undefined ? String(field.value) : ''}
+                  onBlur={field.onBlur}
+                  onChange={(val) => field.onChange(val)}
+                />
+              )}
+            />
+          </Grid.Item>
+
+          <Grid.Item span={24}>
+            <Divider />
+          </Grid.Item>
+
+          <Grid.Item
+            className="tw:flex tw:flex-col tw:gap-4"
+            data-testid="destination-list"
+            span={24}>
+            {fields.map(({ id: fieldId }, index) => (
+              <Fragment key={fieldId}>
+                <DestinationSelectItemV2
+                  destinationsWithStatus={destinationsWithStatus}
+                  id={index}
+                  isDestinationStatusLoading={isDestinationStatusLoading}
+                  isViewMode={isViewMode}
+                  remove={remove}
+                  selectorKey={index}
+                />
+                {index < fields.length - 1 && <Divider />}
+              </Fragment>
+            ))}
+          </Grid.Item>
+
+          {destinationListError && (
+            <Grid.Item span={24}>
+              <Typography as="p" size="text-sm">
+                {destinationListError}
+              </Typography>
+            </Grid.Item>
+          )}
+
+          {!isViewMode && (
+            <Grid.Item span={24}>
+              <div className="tw:flex tw:gap-4">
+                <Button
+                  color="primary"
+                  data-testid="add-destination-button"
+                  isDisabled={isEmpty(selectedSource) || isNil(selectedSource)}
+                  onPress={() => append({})}>
+                  {t('label.add-entity', { entity: t('label.destination') })}
+                </Button>
+                <Tooltip
+                  placement="right"
+                  title={t('message.external-destination-selection')}>
+                  <Button
+                    color="secondary"
+                    data-testid="test-destination-button"
+                    isDisabled={disableTestDestinationButton}
+                    onPress={handleTestDestinationClick}>
+                    {t('label.test-entity', {
+                      entity: t('label.destination-plural'),
+                    })}
+                  </Button>
+                </Tooltip>
+              </div>
+            </Grid.Item>
+          )}
+        </Grid>
+      </Card.Content>
+    </Card>
+  );
+}
+
+export default DestinationFormItemV2;

--- a/openmetadata-ui/src/main/resources/ui/src/components/Alerts/DestinationFormItemV2/DestinationFormItemV2.interface.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Alerts/DestinationFormItemV2/DestinationFormItemV2.interface.ts
@@ -1,0 +1,16 @@
+/*
+ *  Copyright 2024 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+export interface DestinationFormItemV2Props {
+  isViewMode?: boolean;
+}

--- a/openmetadata-ui/src/main/resources/ui/src/components/Alerts/DestinationFormItemV2/DestinationFormItemV2.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Alerts/DestinationFormItemV2/DestinationFormItemV2.test.tsx
@@ -1,0 +1,415 @@
+/*
+ *  Copyright 2024 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from '@testing-library/react';
+import { ReactNode } from 'react';
+import { FormProvider, useForm } from 'react-hook-form';
+import {
+  SubscriptionCategory,
+  SubscriptionType,
+} from '../../../generated/events/eventSubscription';
+import { testAlertDestination } from '../../../rest/alertsAPI';
+import { showErrorToast } from '../../../utils/ToastUtils';
+import DestinationFormItemV2 from './DestinationFormItemV2.component';
+
+jest.mock('../../../rest/alertsAPI', () => ({
+  testAlertDestination: jest.fn(),
+}));
+
+jest.mock('../../../utils/ToastUtils', () => ({
+  showErrorToast: jest.fn(),
+}));
+
+const mockGetFormattedDestinations = jest.fn();
+
+jest.mock('../../../utils/Alerts/AlertsUtilPure', () => ({
+  getFormattedDestinations: (...args: unknown[]) =>
+    mockGetFormattedDestinations(...args),
+}));
+
+jest.mock('./DestinationSelectItemV2/DestinationSelectItemV2', () =>
+  jest
+    .fn()
+    .mockImplementation(
+      ({ id, remove }: { id: number; remove: (i: number) => void }) => (
+        <div data-testid={`destination-select-item-${id}`}>
+          <button
+            data-testid={`remove-destination-${id}`}
+            onClick={() => remove(id)}>
+            Remove
+          </button>
+        </div>
+      )
+    )
+);
+
+jest.mock('@openmetadata/ui-core-components', () => {
+  const CardHeader = ({
+    title,
+    subtitle,
+  }: {
+    title?: ReactNode;
+    subtitle?: ReactNode;
+  }) => (
+    <div>
+      <div>{title}</div>
+      <div>{subtitle}</div>
+    </div>
+  );
+
+  const CardContent = ({ children }: { children?: ReactNode }) => (
+    <div>{children}</div>
+  );
+
+  const Card = ({ children }: { children?: ReactNode }) => (
+    <div data-testid="card">{children}</div>
+  );
+
+  Card.Header = CardHeader;
+  Card.Content = CardContent;
+
+  const GridItem = ({
+    children,
+    'data-testid': tid,
+  }: {
+    children?: ReactNode;
+    'data-testid'?: string;
+  }) => <div data-testid={tid}>{children}</div>;
+
+  const Grid = ({ children }: { children?: ReactNode }) => (
+    <div>{children}</div>
+  );
+
+  Grid.Item = GridItem;
+
+  return {
+    Button: ({
+      onPress,
+      children,
+      isDisabled,
+      'data-testid': tid,
+    }: {
+      onPress?: () => void;
+      children?: ReactNode;
+      isDisabled?: boolean;
+      'data-testid'?: string;
+    }) => (
+      <button data-testid={tid} disabled={isDisabled} onClick={onPress}>
+        {children}
+      </button>
+    ),
+    Card,
+    Divider: () => <hr />,
+    Grid,
+    Input: ({
+      onChange,
+      value,
+      'data-testid': tid,
+      inputDataTestId,
+      defaultValue,
+    }: {
+      onChange?: (val: string) => void;
+      value?: string;
+      'data-testid'?: string;
+      inputDataTestId?: string;
+      defaultValue?: string;
+    }) => (
+      <input
+        data-testid={inputDataTestId ?? tid}
+        defaultValue={defaultValue}
+        value={value ?? ''}
+        onChange={(e) => onChange?.(e.target.value)}
+      />
+    ),
+    Tooltip: ({ children }: { children?: ReactNode }) => <>{children}</>,
+    Typography: ({
+      children,
+      as: Tag = 'span',
+    }: {
+      children?: ReactNode;
+      as?: keyof JSX.IntrinsicElements;
+    }) => <Tag>{children}</Tag>,
+  };
+});
+
+function renderWithForm(
+  ui: React.ReactElement,
+  defaultValues: Record<string, unknown> = {}
+) {
+  function Wrapper({ children }: { children: ReactNode }) {
+    const methods = useForm({ defaultValues });
+
+    return <FormProvider {...methods}>{children}</FormProvider>;
+  }
+
+  return render(ui, { wrapper: Wrapper });
+}
+
+describe('DestinationFormItemV2', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders title, subtitle and add destination button', () => {
+    renderWithForm(<DestinationFormItemV2 />, { resources: ['container'] });
+
+    expect(screen.getByText('label.destination')).toBeInTheDocument();
+    expect(
+      screen.getByText('message.alerts-destination-description')
+    ).toBeInTheDocument();
+    expect(screen.getByTestId('add-destination-button')).toBeInTheDocument();
+  });
+
+  it('renders connection timeout and read timeout inputs', () => {
+    renderWithForm(<DestinationFormItemV2 />, { resources: ['container'] });
+
+    expect(
+      screen.getByTestId('connection-timeout-input-field')
+    ).toBeInTheDocument();
+    expect(screen.getByTestId('read-timeout-input-field')).toBeInTheDocument();
+  });
+
+  it('disables add button when no resource is selected', () => {
+    renderWithForm(<DestinationFormItemV2 />, { resources: [] });
+
+    expect(screen.getByTestId('add-destination-button')).toBeDisabled();
+  });
+
+  it('enables add button when a resource is selected', () => {
+    renderWithForm(<DestinationFormItemV2 />, { resources: ['container'] });
+
+    expect(screen.getByTestId('add-destination-button')).toBeEnabled();
+  });
+
+  it('adds a destination row when add button is clicked', async () => {
+    renderWithForm(<DestinationFormItemV2 />, { resources: ['container'] });
+
+    expect(
+      screen.queryByTestId('destination-select-item-0')
+    ).not.toBeInTheDocument();
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('add-destination-button'));
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId('destination-select-item-0')
+      ).toBeInTheDocument();
+    });
+  });
+
+  it('removes a destination row when remove is called', async () => {
+    renderWithForm(<DestinationFormItemV2 />, { resources: ['container'] });
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('add-destination-button'));
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId('destination-select-item-0')
+      ).toBeInTheDocument();
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('remove-destination-0'));
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.queryByTestId('destination-select-item-0')
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  it('disables test destination button when no external destination is selected', () => {
+    renderWithForm(<DestinationFormItemV2 />, {
+      resources: ['container'],
+      destinations: [
+        {
+          destinationType: SubscriptionCategory.Owners,
+          category: SubscriptionCategory.Owners,
+        },
+      ],
+    });
+
+    expect(screen.getByTestId('test-destination-button')).toBeDisabled();
+  });
+
+  it('enables test destination button when external destination is selected', () => {
+    renderWithForm(<DestinationFormItemV2 />, {
+      resources: ['container'],
+      destinations: [
+        {
+          destinationType: SubscriptionType.Slack,
+          category: SubscriptionCategory.External,
+          type: SubscriptionType.Slack,
+        },
+      ],
+    });
+
+    expect(screen.getByTestId('test-destination-button')).toBeEnabled();
+  });
+
+  it('calls testAlertDestination with formatted external destinations', async () => {
+    const formattedDestinations = [
+      {
+        category: SubscriptionCategory.External,
+        type: SubscriptionType.Slack,
+        config: { endpoint: 'https://slack.example.com' },
+      },
+    ];
+
+    mockGetFormattedDestinations.mockReturnValue(formattedDestinations);
+    (testAlertDestination as jest.Mock).mockResolvedValue([]);
+
+    renderWithForm(<DestinationFormItemV2 />, {
+      resources: ['container'],
+      destinations: [
+        {
+          destinationType: SubscriptionType.Slack,
+          category: SubscriptionCategory.External,
+          type: SubscriptionType.Slack,
+          config: { endpoint: 'https://slack.example.com' },
+        },
+      ],
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('test-destination-button'));
+    });
+
+    await waitFor(() => {
+      expect(testAlertDestination).toHaveBeenCalledWith({
+        destinations: formattedDestinations,
+      });
+    });
+  });
+
+  it('filters out external destinations with empty config before testing', async () => {
+    const formattedDestinations = [
+      {
+        category: SubscriptionCategory.External,
+        type: SubscriptionType.Slack,
+        config: { endpoint: 'https://slack.example.com' },
+      },
+      {
+        category: SubscriptionCategory.External,
+        type: SubscriptionType.Webhook,
+        config: {},
+      },
+    ];
+
+    mockGetFormattedDestinations.mockReturnValue(formattedDestinations);
+    (testAlertDestination as jest.Mock).mockResolvedValue([]);
+
+    renderWithForm(<DestinationFormItemV2 />, {
+      resources: ['container'],
+      destinations: [
+        {
+          category: SubscriptionCategory.External,
+          type: SubscriptionType.Slack,
+        },
+        {
+          category: SubscriptionCategory.External,
+          type: SubscriptionType.Webhook,
+        },
+      ],
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('test-destination-button'));
+    });
+
+    await waitFor(() => {
+      expect(testAlertDestination).toHaveBeenCalledWith({
+        destinations: [formattedDestinations[0]],
+      });
+    });
+  });
+
+  it('does not call API when getFormattedDestinations returns undefined', async () => {
+    mockGetFormattedDestinations.mockReturnValue(undefined);
+
+    renderWithForm(<DestinationFormItemV2 />, {
+      resources: ['container'],
+      destinations: [
+        {
+          category: SubscriptionCategory.External,
+          type: SubscriptionType.Slack,
+        },
+      ],
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('test-destination-button'));
+    });
+
+    await waitFor(() => {
+      expect(mockGetFormattedDestinations).toHaveBeenCalled();
+    });
+
+    expect(testAlertDestination).not.toHaveBeenCalled();
+  });
+
+  it('shows error toast when testAlertDestination fails', async () => {
+    const mockError = new Error('Network error');
+
+    mockGetFormattedDestinations.mockReturnValue([
+      {
+        category: SubscriptionCategory.External,
+        type: SubscriptionType.Slack,
+        config: { endpoint: 'https://slack.example.com' },
+      },
+    ]);
+    (testAlertDestination as jest.Mock).mockRejectedValue(mockError);
+
+    renderWithForm(<DestinationFormItemV2 />, {
+      resources: ['container'],
+      destinations: [
+        {
+          category: SubscriptionCategory.External,
+          type: SubscriptionType.Slack,
+        },
+      ],
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('test-destination-button'));
+    });
+
+    await waitFor(() => {
+      expect(showErrorToast).toHaveBeenCalledWith(mockError);
+    });
+  });
+
+  it('hides add and test buttons in view mode', () => {
+    renderWithForm(<DestinationFormItemV2 isViewMode />, {
+      resources: ['container'],
+    });
+
+    expect(
+      screen.queryByTestId('add-destination-button')
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId('test-destination-button')
+    ).not.toBeInTheDocument();
+  });
+});

--- a/openmetadata-ui/src/main/resources/ui/src/components/Alerts/DestinationFormItemV2/DestinationSelectItemV2/DestinationConfigField/DestinationConfigField.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Alerts/DestinationFormItemV2/DestinationSelectItemV2/DestinationConfigField/DestinationConfigField.tsx
@@ -1,0 +1,377 @@
+/*
+ *  Copyright 2024 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+import {
+  Accordion,
+  AccordionHeader,
+  AccordionItem,
+  AccordionPanel,
+  BadgeWithButton,
+  Grid,
+  Input,
+  PasswordInput,
+  Select,
+} from '@openmetadata/ui-core-components';
+import { isEmpty } from 'lodash';
+import { useCallback, useState } from 'react';
+import { Controller, useFormContext, useWatch } from 'react-hook-form';
+import { useTranslation } from 'react-i18next';
+
+import { ReactComponent as ConfigIcon } from '../../../../../assets/svg/configuration-icon.svg';
+import { DESTINATION_TYPE_BASED_PLACEHOLDERS } from '../../../../../constants/Alerts.constants';
+import { SearchIndex } from '../../../../../enums/search.enum';
+import {
+  SubscriptionCategory,
+  SubscriptionType,
+  Type,
+} from '../../../../../generated/events/eventSubscription';
+import { searchEntity } from '../../../../../utils/Alerts/AlertsUtil';
+import { getTermQuery } from '../../../../../utils/SearchPureUtils';
+import TeamAndUserSelectItemV2 from '../../TeamAndUserSelectItemV2/TeamAndUserSelectItemV2';
+
+interface DestinationConfigFieldProps {
+  type: SubscriptionType | SubscriptionCategory;
+  fieldName: number;
+}
+
+const getUserOptions = async (searchText: string) =>
+  searchEntity({
+    searchText,
+    searchIndex: SearchIndex.USER,
+    queryFilter: getTermQuery({ isBot: 'false' }),
+  });
+
+const getTeamOptions = async (searchText: string) =>
+  searchEntity({ searchText, searchIndex: SearchIndex.TEAM });
+
+function FieldError({ message }: { message?: string }) {
+  if (!message) {
+    return null;
+  }
+
+  return (
+    <p className="tw:mt-1 tw:text-sm tw:text-fg-error-secondary">{message}</p>
+  );
+}
+
+function EmailTagInput({ fieldName }: { fieldName: number }) {
+  const { t } = useTranslation();
+  const { setValue, control } = useFormContext();
+  const [inputValue, setInputValue] = useState('');
+
+  const receivers: string[] =
+    useWatch({
+      name: `destinations.${fieldName}.config.receivers`,
+      control,
+    }) ?? [];
+
+  const addEmail = useCallback(() => {
+    const trimmed = inputValue.trim();
+    if (!trimmed || receivers.includes(trimmed)) {
+      setInputValue('');
+
+      return;
+    }
+    setValue(`destinations.${fieldName}.config.receivers`, [
+      ...receivers,
+      trimmed,
+    ]);
+    setInputValue('');
+  }, [inputValue, receivers, fieldName, setValue]);
+
+  const removeEmail = useCallback(
+    (email: string) => {
+      setValue(
+        `destinations.${fieldName}.config.receivers`,
+        receivers.filter((r) => r !== email)
+      );
+    },
+    [receivers, fieldName, setValue]
+  );
+
+  return (
+    <div className="tw:flex tw:flex-col tw:gap-2">
+      <Input
+        data-testid={`email-input-${fieldName}`}
+        inputDataTestId={`email-input-field-${fieldName}`}
+        placeholder={
+          DESTINATION_TYPE_BASED_PLACEHOLDERS[SubscriptionType.Email] ?? ''
+        }
+        value={inputValue}
+        onChange={(val) => setInputValue(val)}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter') {
+            e.preventDefault();
+            addEmail();
+          }
+        }}
+      />
+      {!isEmpty(receivers) && (
+        <div
+          className="tw:flex tw:flex-wrap tw:gap-1.5"
+          data-testid={`email-tags-${fieldName}`}>
+          {receivers.map((email) => (
+            <BadgeWithButton
+              buttonLabel={t('label.remove')}
+              color="gray"
+              data-testid={`email-tag-${email}`}
+              key={email}
+              type="pill-color"
+              onButtonClick={() => removeEmail(email)}>
+              {email}
+            </BadgeWithButton>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function DestinationConfigField({
+  type,
+  fieldName,
+}: Readonly<DestinationConfigFieldProps>) {
+  const { t } = useTranslation();
+  const { control } = useFormContext();
+
+  const selectedAuthType: string | undefined = useWatch({
+    name: `destinations.${fieldName}.config.authType.type`,
+    control,
+  });
+
+  const isWebhookType =
+    type === SubscriptionType.Slack ||
+    type === SubscriptionType.MSTeams ||
+    type === SubscriptionType.GChat ||
+    type === SubscriptionType.Webhook;
+
+  if (isWebhookType) {
+    return (
+      <>
+        <Grid.Item span={12}>
+          <Controller
+            control={control}
+            name={`destinations.${fieldName}.config.endpoint`}
+            render={({ field, fieldState }) => (
+              <div>
+                <Input
+                  data-testid={`endpoint-input-${fieldName}`}
+                  inputDataTestId={`endpoint-input-field-${fieldName}`}
+                  placeholder={DESTINATION_TYPE_BASED_PLACEHOLDERS[type] ?? ''}
+                  ref={field.ref}
+                  value={field.value ?? ''}
+                  onBlur={() => field.onBlur()}
+                  onChange={(val) => field.onChange(val)}
+                />
+                <FieldError message={fieldState.error?.message} />
+              </div>
+            )}
+            rules={{
+              required: t('message.field-text-is-required', {
+                fieldText: t('label.endpoint-url'),
+              }),
+            }}
+          />
+        </Grid.Item>
+
+        <Grid.Item span={24}>
+          <Accordion>
+            <AccordionItem id={`advanced-config-${fieldName}`}>
+              <AccordionHeader>
+                <span className="tw:flex tw:items-center tw:gap-2">
+                  <ConfigIcon className="tw:size-4" />
+                  {t('label.advanced-configuration')}
+                </span>
+              </AccordionHeader>
+              <AccordionPanel>
+                <Grid colGap="2" rowGap="2">
+                  <Grid.Item span={24}>
+                    <Controller
+                      control={control}
+                      name={`destinations.${fieldName}.config.authType.type`}
+                      render={({ field }) => (
+                        <Select
+                          data-testid={`auth-type-select-${fieldName}`}
+                          label={`${t('label.authentication-type')}:`}
+                          placeholder={t('label.authentication-type')}
+                          selectedKey={field.value ?? null}
+                          onSelectionChange={(key) => field.onChange(key)}>
+                          <Select.Item id={Type.None}>
+                            {t('label.no-authentication')}
+                          </Select.Item>
+                          <Select.Item id={Type.Bearer}>
+                            {t('label.bearer-hmac-signature')}
+                          </Select.Item>
+                          <Select.Item id={Type.Oauth2}>
+                            {t('label.oauth2-client-credential-plural')}
+                          </Select.Item>
+                        </Select>
+                      )}
+                    />
+                  </Grid.Item>
+
+                  {selectedAuthType === Type.Bearer && (
+                    <Grid.Item data-testid="secret-key" span={24}>
+                      <Controller
+                        control={control}
+                        name={`destinations.${fieldName}.config.authType.secretKey`}
+                        render={({ field, fieldState }) => (
+                          <div>
+                            <PasswordInput
+                              data-testid={`secret-key-input-${fieldName}`}
+                              label={`${t('label.secret-key')}:`}
+                              placeholder={t('label.secret-key')}
+                              ref={field.ref}
+                              value={field.value ?? ''}
+                              onBlur={() => field.onBlur()}
+                              onChange={(val) => field.onChange(val)}
+                            />
+                            <FieldError message={fieldState.error?.message} />
+                          </div>
+                        )}
+                        rules={{
+                          required: t('message.field-text-is-required', {
+                            fieldText: t('label.secret-key'),
+                          }),
+                        }}
+                      />
+                    </Grid.Item>
+                  )}
+
+                  {selectedAuthType === Type.Oauth2 && (
+                    <>
+                      <Grid.Item span={24}>
+                        <Controller
+                          control={control}
+                          name={`destinations.${fieldName}.config.authType.tokenUrl`}
+                          render={({ field, fieldState }) => (
+                            <div>
+                              <Input
+                                data-testid={`token-url-input-${fieldName}`}
+                                inputDataTestId={`token-url-input-field-${fieldName}`}
+                                label={`${t('label.token-url')}:`}
+                                placeholder="https://auth.example.com/oauth/token"
+                                ref={field.ref}
+                                value={field.value ?? ''}
+                                onBlur={() => field.onBlur()}
+                                onChange={(val) => field.onChange(val)}
+                              />
+                              <FieldError message={fieldState.error?.message} />
+                            </div>
+                          )}
+                          rules={{
+                            required: t('message.field-text-is-required', {
+                              fieldText: t('label.token-url'),
+                            }),
+                          }}
+                        />
+                      </Grid.Item>
+                      <Grid.Item span={12}>
+                        <Controller
+                          control={control}
+                          name={`destinations.${fieldName}.config.authType.clientId`}
+                          render={({ field, fieldState }) => (
+                            <div>
+                              <PasswordInput
+                                data-testid={`client-id-input-${fieldName}`}
+                                label={`${t('label.client-id')}:`}
+                                placeholder={t('label.client-id')}
+                                ref={field.ref}
+                                value={field.value ?? ''}
+                                onBlur={() => field.onBlur()}
+                                onChange={(val) => field.onChange(val)}
+                              />
+                              <FieldError message={fieldState.error?.message} />
+                            </div>
+                          )}
+                          rules={{
+                            required: t('message.field-text-is-required', {
+                              fieldText: t('label.client-id'),
+                            }),
+                          }}
+                        />
+                      </Grid.Item>
+                      <Grid.Item span={12}>
+                        <Controller
+                          control={control}
+                          name={`destinations.${fieldName}.config.authType.clientSecret`}
+                          render={({ field, fieldState }) => (
+                            <div>
+                              <PasswordInput
+                                data-testid={`client-secret-input-${fieldName}`}
+                                label={`${t('label.client-secret')}:`}
+                                placeholder={t('label.client-secret')}
+                                ref={field.ref}
+                                value={field.value ?? ''}
+                                onBlur={() => field.onBlur()}
+                                onChange={(val) => field.onChange(val)}
+                              />
+                              <FieldError message={fieldState.error?.message} />
+                            </div>
+                          )}
+                          rules={{
+                            required: t('message.field-text-is-required', {
+                              fieldText: t('label.client-secret'),
+                            }),
+                          }}
+                        />
+                      </Grid.Item>
+                    </>
+                  )}
+                </Grid>
+              </AccordionPanel>
+            </AccordionItem>
+          </Accordion>
+        </Grid.Item>
+      </>
+    );
+  }
+
+  if (type === SubscriptionType.Email) {
+    return (
+      <Grid.Item span={24}>
+        <EmailTagInput fieldName={fieldName} />
+      </Grid.Item>
+    );
+  }
+
+  if (type === SubscriptionCategory.Teams) {
+    return (
+      <Grid.Item span={24}>
+        <TeamAndUserSelectItemV2
+          destinationNumber={fieldName}
+          entityType={t('label.team-lowercase')}
+          fieldName={[fieldName, 'config', 'receivers']}
+          onSearch={getTeamOptions}
+        />
+      </Grid.Item>
+    );
+  }
+
+  if (type === SubscriptionCategory.Users) {
+    return (
+      <Grid.Item span={24}>
+        <TeamAndUserSelectItemV2
+          destinationNumber={fieldName}
+          entityType={t('label.user-lowercase')}
+          fieldName={[fieldName, 'config', 'receivers']}
+          onSearch={getUserOptions}
+        />
+      </Grid.Item>
+    );
+  }
+
+  return null;
+}
+
+export default DestinationConfigField;

--- a/openmetadata-ui/src/main/resources/ui/src/components/Alerts/DestinationFormItemV2/DestinationSelectItemV2/DestinationSelectItemV2.interface.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Alerts/DestinationFormItemV2/DestinationSelectItemV2/DestinationSelectItemV2.interface.ts
@@ -1,0 +1,23 @@
+/*
+ *  Copyright 2024 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+import { Destination } from '../../../../generated/events/eventSubscription';
+
+export interface DestinationSelectItemV2Props {
+  selectorKey: number;
+  id: number;
+  remove: (index: number) => void;
+  destinationsWithStatus?: Destination[];
+  isDestinationStatusLoading: boolean;
+  isViewMode?: boolean;
+}

--- a/openmetadata-ui/src/main/resources/ui/src/components/Alerts/DestinationFormItemV2/DestinationSelectItemV2/DestinationSelectItemV2.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Alerts/DestinationFormItemV2/DestinationSelectItemV2/DestinationSelectItemV2.test.tsx
@@ -1,0 +1,456 @@
+/*
+ *  Copyright 2024 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from '@testing-library/react';
+import { ReactNode } from 'react';
+import { FormProvider, useForm } from 'react-hook-form';
+import {
+  Status,
+  SubscriptionCategory,
+  SubscriptionType,
+} from '../../../../generated/events/eventSubscription';
+import DestinationSelectItemV2 from './DestinationSelectItemV2';
+import { DestinationSelectItemV2Props } from './DestinationSelectItemV2.interface';
+
+jest.mock('@openmetadata/ui-core-components', () => {
+  const SelectItem = ({
+    id,
+    children,
+  }: {
+    id: string;
+    children?: ReactNode;
+  }) => <option value={id}>{children}</option>;
+
+  const ComboBox = ({
+    onSelectionChange,
+    selectedKey,
+    items = [],
+    'data-testid': tid,
+  }: {
+    onSelectionChange?: (key: string) => void;
+    selectedKey?: string | null;
+    items?: { id: string; label?: string; isDisabled?: boolean }[];
+    'data-testid'?: string;
+  }) => (
+    <select
+      data-testid={tid}
+      value={selectedKey ?? ''}
+      onChange={(e) => onSelectionChange?.(e.target.value)}>
+      <option value="" />
+      {items.map((item) => (
+        <option disabled={item.isDisabled} key={item.id} value={item.id}>
+          {item.label}
+        </option>
+      ))}
+    </select>
+  );
+
+  const SelectBase = ({
+    onSelectionChange,
+    selectedKey,
+    children,
+    'data-testid': tid,
+    isRequired,
+    placeholder,
+  }: {
+    onSelectionChange?: (key: string) => void;
+    selectedKey?: string | null;
+    children?: ReactNode;
+    'data-testid'?: string;
+    isRequired?: boolean;
+    placeholder?: string;
+  }) => (
+    <select
+      data-testid={tid}
+      required={isRequired}
+      value={selectedKey ?? ''}
+      onChange={(e) => onSelectionChange?.(e.target.value)}>
+      {placeholder && <option value="">{placeholder}</option>}
+      {children}
+    </select>
+  );
+
+  SelectBase.Item = SelectItem;
+  SelectBase.ComboBox = ComboBox;
+
+  const GridItem = ({ children }: { children?: ReactNode }) => (
+    <div>{children}</div>
+  );
+  const Grid = ({ children }: { children?: ReactNode }) => (
+    <div>{children}</div>
+  );
+
+  Grid.Item = GridItem;
+
+  return {
+    Alert: ({ title, variant }: { title: ReactNode; variant?: string }) => (
+      <div data-testid={`alert-${variant}`}>{title}</div>
+    ),
+    Button: ({
+      onPress,
+      children,
+      isDisabled,
+      'data-testid': tid,
+    }: {
+      onPress?: () => void;
+      children?: ReactNode;
+      isDisabled?: boolean;
+      'data-testid'?: string;
+    }) => (
+      <button data-testid={tid} disabled={isDisabled} onClick={onPress}>
+        {children}
+      </button>
+    ),
+    Grid,
+    Input: ({
+      onChange,
+      value,
+      'data-testid': tid,
+      inputDataTestId,
+      label,
+      defaultValue,
+    }: {
+      onChange?: (val: string) => void;
+      value?: string;
+      'data-testid'?: string;
+      inputDataTestId?: string;
+      label?: ReactNode;
+      defaultValue?: string;
+    }) => (
+      <div>
+        {label && <label>{label}</label>}
+        <input
+          data-testid={inputDataTestId ?? tid}
+          defaultValue={defaultValue}
+          value={value ?? ''}
+          onChange={(e) => onChange?.(e.target.value)}
+        />
+      </div>
+    ),
+    Select: SelectBase,
+    Toggle: ({
+      onChange,
+      isSelected,
+      label,
+    }: {
+      onChange?: (checked: boolean) => void;
+      isSelected?: boolean;
+      label?: ReactNode;
+    }) => (
+      <label>
+        <input
+          checked={isSelected ?? false}
+          data-testid="notify-downstream-toggle"
+          type="checkbox"
+          onChange={(e) => onChange?.(e.target.checked)}
+        />
+        {label}
+      </label>
+    ),
+  };
+});
+
+jest.mock('@untitledui/icons', () => ({
+  X: () => <span>X</span>,
+}));
+
+jest.mock('../../../../utils/ObservabilityUtils', () => ({
+  checkIfDestinationIsInternal: jest
+    .fn()
+    .mockImplementation((value: string) =>
+      ['Owners', 'Followers', 'Admins', 'Teams', 'Users'].includes(value)
+    ),
+  getConfigFieldFromDestinationType: jest.fn().mockReturnValue(null),
+  getAlertDestinationCategoryIcons: jest.fn().mockReturnValue(null),
+}));
+
+jest.mock('../../../../utils/Alerts/AlertsUtil', () => ({
+  getDestinationStatusAlertData: jest.fn().mockReturnValue({
+    statusLabel: 'Success',
+    alertClassName: '',
+    alertIcon: null,
+  }),
+}));
+
+jest.mock('../../../../utils/Alerts/AlertsUtilPure', () => ({
+  getSubscriptionTypeOptions: jest.fn().mockReturnValue([
+    { value: 'ActivityFeed', disabled: false },
+    { value: 'Email', disabled: false },
+  ]),
+  normalizeDestinationConfig: jest.fn().mockImplementation((c) => c),
+}));
+
+jest.mock('./DestinationConfigField/DestinationConfigField', () =>
+  jest
+    .fn()
+    .mockImplementation(() => <div data-testid="destination-config-field" />)
+);
+
+const MOCK_PROPS: DestinationSelectItemV2Props = {
+  selectorKey: 0,
+  id: 0,
+  remove: jest.fn(),
+  isDestinationStatusLoading: false,
+};
+
+function renderWithForm(
+  ui: React.ReactElement,
+  defaultValues: Record<string, unknown> = {}
+) {
+  function Wrapper({ children }: { children: ReactNode }) {
+    const methods = useForm({ defaultValues });
+
+    return <FormProvider {...methods}>{children}</FormProvider>;
+  }
+
+  return render(ui, { wrapper: Wrapper });
+}
+
+describe('DestinationSelectItemV2', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders the destination category combobox', () => {
+    renderWithForm(<DestinationSelectItemV2 {...MOCK_PROPS} />);
+
+    expect(
+      screen.getByTestId(`destination-category-select-${MOCK_PROPS.id}`)
+    ).toBeInTheDocument();
+  });
+
+  it('renders remove button and calls remove on click', async () => {
+    renderWithForm(<DestinationSelectItemV2 {...MOCK_PROPS} />);
+
+    const removeBtn = screen.getByTestId(`remove-destination-${MOCK_PROPS.id}`);
+
+    await act(async () => {
+      fireEvent.click(removeBtn);
+    });
+
+    expect(MOCK_PROPS.remove).toHaveBeenCalledWith(MOCK_PROPS.id);
+  });
+
+  it('hides remove button in view mode', () => {
+    renderWithForm(<DestinationSelectItemV2 {...MOCK_PROPS} isViewMode />);
+
+    expect(
+      screen.queryByTestId(`remove-destination-${MOCK_PROPS.id}`)
+    ).not.toBeInTheDocument();
+  });
+
+  it('shows config field when external destination is selected', async () => {
+    renderWithForm(<DestinationSelectItemV2 {...MOCK_PROPS} />, {
+      destinations: [{ destinationType: SubscriptionType.Slack }],
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId('destination-config-field')
+      ).toBeInTheDocument();
+    });
+  });
+
+  it('shows internal type select when internal destination is selected', async () => {
+    renderWithForm(<DestinationSelectItemV2 {...MOCK_PROPS} />, {
+      destinations: [{ destinationType: SubscriptionCategory.Owners }],
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId(`destination-type-select-${MOCK_PROPS.id}`)
+      ).toBeInTheDocument();
+    });
+  });
+
+  it('shows owner-selection warning for Owners with non-Email subscription type', async () => {
+    renderWithForm(<DestinationSelectItemV2 {...MOCK_PROPS} />, {
+      destinations: [
+        {
+          destinationType: SubscriptionCategory.Owners,
+          type: SubscriptionType.ActivityFeed,
+        },
+      ],
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.getByText('message.destination-owner-selection-warning')
+      ).toBeInTheDocument();
+    });
+  });
+
+  it('shows generic selection warning for Owners with Email subscription type', async () => {
+    renderWithForm(<DestinationSelectItemV2 {...MOCK_PROPS} />, {
+      destinations: [
+        {
+          destinationType: SubscriptionCategory.Owners,
+          type: SubscriptionType.Email,
+        },
+      ],
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.getByText('message.destination-selection-warning')
+      ).toBeInTheDocument();
+    });
+  });
+
+  it('shows generic selection warning for non-Owners internal destination', async () => {
+    renderWithForm(<DestinationSelectItemV2 {...MOCK_PROPS} />, {
+      destinations: [
+        {
+          destinationType: SubscriptionCategory.Admins,
+          type: SubscriptionType.Email,
+        },
+      ],
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.getByText('message.destination-selection-warning')
+      ).toBeInTheDocument();
+    });
+  });
+
+  it('shows notify downstream toggle when a destination is selected', async () => {
+    renderWithForm(<DestinationSelectItemV2 {...MOCK_PROPS} />, {
+      destinations: [
+        {
+          destinationType: SubscriptionType.Slack,
+          category: SubscriptionCategory.External,
+        },
+      ],
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('label.notify-downstream')).toBeInTheDocument();
+    });
+  });
+
+  it('shows downstream depth input when notify downstream is enabled', async () => {
+    renderWithForm(<DestinationSelectItemV2 {...MOCK_PROPS} />, {
+      destinations: [
+        {
+          destinationType: SubscriptionType.Slack,
+          notifyDownstream: true,
+        },
+      ],
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId(
+          `destination-downstream-depth-input-${MOCK_PROPS.id}`
+        )
+      ).toBeInTheDocument();
+    });
+  });
+
+  it('hides downstream depth input when notify downstream is disabled', async () => {
+    renderWithForm(<DestinationSelectItemV2 {...MOCK_PROPS} />, {
+      destinations: [
+        {
+          destinationType: SubscriptionType.Slack,
+          notifyDownstream: false,
+        },
+      ],
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.queryByTestId(
+          `destination-downstream-depth-input-${MOCK_PROPS.id}`
+        )
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  it('shows success status alert when destination status matches', async () => {
+    const destinationsWithStatus = [
+      {
+        type: SubscriptionType.Slack,
+        category: SubscriptionCategory.External,
+        config: { endpoint: 'https://hooks.slack.com' },
+        statusDetails: {
+          status: Status.Success,
+          statusCode: 200,
+          reason: 'OK',
+        },
+      },
+    ];
+
+    renderWithForm(
+      <DestinationSelectItemV2
+        {...MOCK_PROPS}
+        destinationsWithStatus={destinationsWithStatus}
+      />,
+      {
+        destinations: [
+          {
+            type: SubscriptionType.Slack,
+            category: SubscriptionCategory.External,
+            config: { endpoint: 'https://hooks.slack.com' },
+          },
+        ],
+      }
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('alert-success')).toBeInTheDocument();
+    });
+  });
+
+  it('shows loading skeleton when destination status is loading', async () => {
+    renderWithForm(
+      <DestinationSelectItemV2 {...MOCK_PROPS} isDestinationStatusLoading />,
+      {
+        destinations: [
+          {
+            destinationType: SubscriptionType.Slack,
+            category: SubscriptionCategory.External,
+          },
+        ],
+      }
+    );
+
+    await waitFor(() => {
+      expect(document.querySelector('.tw\\:animate-pulse')).toBeInTheDocument();
+    });
+  });
+
+  it('shows config field when category is changed via combobox', async () => {
+    renderWithForm(<DestinationSelectItemV2 {...MOCK_PROPS} />);
+
+    const comboBox = screen.getByTestId(
+      `destination-category-select-${MOCK_PROPS.id}`
+    );
+
+    await act(async () => {
+      fireEvent.change(comboBox, { target: { value: SubscriptionType.Slack } });
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId('destination-config-field')
+      ).toBeInTheDocument();
+    });
+  });
+});

--- a/openmetadata-ui/src/main/resources/ui/src/components/Alerts/DestinationFormItemV2/DestinationSelectItemV2/DestinationSelectItemV2.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Alerts/DestinationFormItemV2/DestinationSelectItemV2/DestinationSelectItemV2.tsx
@@ -1,0 +1,359 @@
+/*
+ *  Copyright 2024 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+import type { SelectItemType } from '@openmetadata/ui-core-components';
+import {
+  Alert,
+  Button,
+  Grid,
+  Input,
+  Select,
+  Toggle,
+} from '@openmetadata/ui-core-components';
+import { X } from '@untitledui/icons';
+import { isEmpty, isEqual, isUndefined, omitBy, startCase } from 'lodash';
+import { useCallback, useMemo } from 'react';
+import { Controller, useFormContext, useWatch } from 'react-hook-form';
+import { useTranslation } from 'react-i18next';
+
+import {
+  EXTERNAL_CATEGORY_OPTIONS,
+  INTERNAL_CATEGORY_OPTIONS,
+} from '../../../../constants/Alerts.constants';
+import {
+  SubscriptionCategory,
+  SubscriptionType,
+} from '../../../../generated/events/eventSubscription';
+import { getDestinationStatusAlertData } from '../../../../utils/Alerts/AlertsUtil';
+import {
+  getSubscriptionTypeOptions,
+  normalizeDestinationConfig,
+} from '../../../../utils/Alerts/AlertsUtilPure';
+import {
+  checkIfDestinationIsInternal,
+  getConfigFieldFromDestinationType,
+} from '../../../../utils/ObservabilityUtils';
+import DestinationConfigField from './DestinationConfigField/DestinationConfigField';
+import { DestinationSelectItemV2Props } from './DestinationSelectItemV2.interface';
+
+function buildGroupedOptions(
+  internalLabel: string,
+  externalLabel: string
+): SelectItemType[] {
+  return [
+    { id: 'header-internal', label: internalLabel, isDisabled: true },
+    ...INTERNAL_CATEGORY_OPTIONS.map((o) => ({ id: o.value, label: o.value })),
+    { id: 'header-external', label: externalLabel, isDisabled: true },
+    ...EXTERNAL_CATEGORY_OPTIONS.map((o) => ({ id: o.value, label: o.value })),
+  ];
+}
+
+function DestinationSelectItemV2({
+  selectorKey,
+  id,
+  remove,
+  destinationsWithStatus,
+  isDestinationStatusLoading,
+  isViewMode = false,
+}: Readonly<DestinationSelectItemV2Props>) {
+  const { t } = useTranslation();
+  const { control, setValue } = useFormContext();
+
+  const destinationItem =
+    useWatch({ name: `destinations.${id}`, control }) ?? {};
+
+  const destinationType: string | undefined = destinationItem.destinationType;
+  const subscriptionType: string | undefined = destinationItem.type;
+  const notifyDownstream: boolean = destinationItem.notifyDownstream ?? false;
+
+  const isInternalDestinationSelected = useMemo(
+    () => checkIfDestinationIsInternal(destinationType ?? ''),
+    [destinationType]
+  );
+
+  const groupedOptions = useMemo(
+    () => buildGroupedOptions(t('label.internal'), t('label.external')),
+    [t]
+  );
+
+  const destinationStatusDetails = useMemo(() => {
+    const { type, category, config } = destinationItem;
+    const current = destinationsWithStatus?.find((d) =>
+      isEqual(
+        { type, category, config: omitBy(config, isUndefined) },
+        {
+          type: d.type,
+          category: d.category,
+          config: normalizeDestinationConfig(d.config),
+        }
+      )
+    );
+
+    return current?.statusDetails;
+  }, [destinationItem, destinationsWithStatus]);
+
+  const { statusLabel } = useMemo(
+    () => getDestinationStatusAlertData(destinationStatusDetails?.status),
+    [destinationStatusDetails]
+  );
+
+  const statusAlertVariant =
+    destinationStatusDetails?.status === 'Success' ? 'success' : 'error';
+
+  const handleDestinationTypeSelect = useCallback(
+    (value: string | null) => {
+      if (!value || value.startsWith('header-')) {
+        return;
+      }
+      const isInternal = checkIfDestinationIsInternal(value);
+      setValue(`destinations.${id}`, { destinationType: value });
+      setValue(
+        `destinations.${id}.category`,
+        isInternal ? value : SubscriptionCategory.External
+      );
+
+      if (!isInternal) {
+        setValue(`destinations.${id}.type`, value);
+      }
+
+      const configField = getConfigFieldFromDestinationType(value);
+      if (configField) {
+        setValue(`destinations.${id}.config.${configField}`, true);
+      }
+    },
+    [id, setValue]
+  );
+
+  const handleNotifyDownstreamChange = useCallback(
+    (checked: boolean) => {
+      if (!checked) {
+        setValue(`destinations.${id}.downstreamDepth`, undefined);
+      }
+    },
+    [id, setValue]
+  );
+
+  return (
+    <div
+      className="tw:flex tw:gap-4"
+      data-testid={`destination-${id}`}
+      key={selectorKey}>
+      <div className="tw:min-w-0 tw:flex-1">
+        <Grid colGap="2" rowGap="2">
+          <Grid.Item span={12}>
+            <Select.ComboBox
+              data-testid={`destination-category-select-${id}`}
+              items={groupedOptions}
+              placeholder={t('label.select-field', {
+                field: t('label.destination'),
+              })}
+              selectedKey={destinationType ?? null}
+              onSelectionChange={(key) =>
+                handleDestinationTypeSelect(key as string)
+              }>
+              {(item) => (
+                <Select.Item
+                  className={
+                    item.isDisabled
+                      ? 'tw:cursor-default tw:text-xs tw:font-semibold tw:uppercase tw:tracking-wider tw:text-tertiary'
+                      : undefined
+                  }
+                  id={item.id}
+                  textValue={item.label ?? ''}>
+                  {item.label}
+                </Select.Item>
+              )}
+            </Select.ComboBox>
+          </Grid.Item>
+
+          {destinationType && !isInternalDestinationSelected && (
+            <DestinationConfigField
+              fieldName={id}
+              type={destinationType as SubscriptionType}
+            />
+          )}
+
+          {destinationType && isInternalDestinationSelected && (
+            <>
+              {(destinationType === SubscriptionCategory.Teams ||
+                destinationType === SubscriptionCategory.Users) && (
+                <DestinationConfigField
+                  fieldName={id}
+                  type={destinationType as SubscriptionCategory}
+                />
+              )}
+
+              <Grid.Item span={24}>
+                <Controller
+                  control={control}
+                  name={`destinations.${id}.type`}
+                  render={({ field, fieldState }) => (
+                    <div>
+                      <Select
+                        isRequired
+                        data-testid={`destination-type-select-${id}`}
+                        placeholder={t('label.select-field', {
+                          field: t('label.destination'),
+                        })}
+                        selectedKey={field.value ?? null}
+                        onSelectionChange={(key) => field.onChange(key)}>
+                        {getSubscriptionTypeOptions(destinationType).map(
+                          (option) => (
+                            <Select.Item
+                              id={option.value}
+                              isDisabled={option.disabled}
+                              key={option.value}
+                              textValue={startCase(option.value)}>
+                              {startCase(option.value)}
+                            </Select.Item>
+                          )
+                        )}
+                      </Select>
+                      {fieldState.error?.message && (
+                        <p className="tw:mt-1 tw:text-sm tw:text-fg-error-secondary">
+                          {fieldState.error.message}
+                        </p>
+                      )}
+                    </div>
+                  )}
+                  rules={{
+                    required: t('message.field-text-is-required', {
+                      fieldText: t('label.field'),
+                    }),
+                  }}
+                />
+              </Grid.Item>
+
+              {destinationType && subscriptionType && (
+                <Grid.Item span={24}>
+                  <Alert
+                    closable
+                    title={
+                      destinationType === SubscriptionCategory.Owners &&
+                      subscriptionType !== SubscriptionType.Email
+                        ? t('message.destination-owner-selection-warning', {
+                            subscriptionCategory: destinationType,
+                            subscriptionType,
+                          })
+                        : t('message.destination-selection-warning', {
+                            subscriptionCategory: destinationType,
+                            subscriptionType,
+                          })
+                    }
+                    variant="warning"
+                  />
+                </Grid.Item>
+              )}
+            </>
+          )}
+
+          {!isEmpty(destinationItem) && (
+            <Grid.Item span={24}>
+              <Controller
+                control={control}
+                name={`destinations.${id}.notifyDownstream`}
+                render={({ field }) => (
+                  <Toggle
+                    isSelected={field.value ?? false}
+                    label={t('label.notify-downstream')}
+                    onChange={(checked) => {
+                      field.onChange(checked);
+                      handleNotifyDownstreamChange(checked);
+                    }}
+                  />
+                )}
+              />
+            </Grid.Item>
+          )}
+
+          {notifyDownstream && (
+            <Grid.Item span={24}>
+              <Controller
+                control={control}
+                name={`destinations.${id}.downstreamDepth`}
+                render={({ field, fieldState }) => (
+                  <div>
+                    <Input
+                      data-testid={`destination-downstream-depth-${id}`}
+                      defaultValue="1"
+                      inputDataTestId={`destination-downstream-depth-input-${id}`}
+                      label={t('label.downstream-depth')}
+                      ref={field.ref}
+                      value={
+                        field.value !== undefined ? String(field.value) : ''
+                      }
+                      onBlur={() => field.onBlur()}
+                      onChange={(val) => field.onChange(val)}
+                    />
+                    {fieldState.error?.message && (
+                      <p className="tw:mt-1 tw:text-sm tw:text-fg-error-secondary">
+                        {fieldState.error.message}
+                      </p>
+                    )}
+                  </div>
+                )}
+                rules={{
+                  required: t('message.field-text-is-required', {
+                    fieldText: t('label.downstream-depth'),
+                  }),
+                  validate: (value) => {
+                    const numVal = Number(value);
+
+                    return !isEmpty(String(value)) && numVal <= 0
+                      ? t('message.value-must-be-greater-than', {
+                          field: t('label.downstream-depth'),
+                          minimum: 0,
+                        })
+                      : true;
+                  },
+                }}
+              />
+            </Grid.Item>
+          )}
+
+          {isDestinationStatusLoading &&
+            destinationItem.category === SubscriptionCategory.External && (
+              <Grid.Item span={24}>
+                <div className="tw:h-8 tw:animate-pulse tw:rounded-lg tw:bg-secondary" />
+              </Grid.Item>
+            )}
+
+          {!isDestinationStatusLoading &&
+            !isUndefined(destinationStatusDetails) && (
+              <Grid.Item span={24}>
+                <Alert
+                  closable
+                  title={`${t('label.status')}: ${
+                    destinationStatusDetails?.statusCode
+                  } ${statusLabel} ${destinationStatusDetails?.reason ?? ''}`}
+                  variant={statusAlertVariant}
+                />
+              </Grid.Item>
+            )}
+        </Grid>
+      </div>
+
+      {!isViewMode && (
+        <Button
+          data-icon
+          color="tertiary"
+          data-testid={`remove-destination-${id}`}
+          onPress={() => remove(id)}>
+          <X />
+        </Button>
+      )}
+    </div>
+  );
+}
+
+export default DestinationSelectItemV2;

--- a/openmetadata-ui/src/main/resources/ui/src/components/Alerts/DestinationFormItemV2/TeamAndUserSelectItemV2/TeamAndUserSelectItemV2.interface.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Alerts/DestinationFormItemV2/TeamAndUserSelectItemV2/TeamAndUserSelectItemV2.interface.ts
@@ -1,0 +1,21 @@
+/*
+ *  Copyright 2024 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+import { SelectOption } from '../../../common/AsyncSelectList/AsyncSelectList.interface';
+
+export interface TeamAndUserSelectItemV2Props {
+  entityType: string;
+  onSearch: (value: string) => Promise<SelectOption[]>;
+  fieldName: (string | number)[];
+  destinationNumber: number;
+}

--- a/openmetadata-ui/src/main/resources/ui/src/components/Alerts/DestinationFormItemV2/TeamAndUserSelectItemV2/TeamAndUserSelectItemV2.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Alerts/DestinationFormItemV2/TeamAndUserSelectItemV2/TeamAndUserSelectItemV2.test.tsx
@@ -1,0 +1,288 @@
+/*
+ *  Copyright 2024 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from '@testing-library/react';
+import { ReactNode } from 'react';
+import { FormProvider, useForm } from 'react-hook-form';
+import TeamAndUserSelectItemV2 from './TeamAndUserSelectItemV2';
+import { TeamAndUserSelectItemV2Props } from './TeamAndUserSelectItemV2.interface';
+
+jest.mock('@openmetadata/ui-core-components', () => ({
+  BadgeWithButton: ({
+    children,
+    onButtonClick,
+    'data-testid': tid,
+  }: {
+    children: ReactNode;
+    onButtonClick?: (e: React.MouseEvent) => void;
+    'data-testid'?: string;
+  }) => (
+    <span data-testid={tid}>
+      {children}
+      <button data-testid={`${tid}-remove`} onClick={onButtonClick}>
+        x
+      </button>
+    </span>
+  ),
+  Checkbox: ({
+    isSelected,
+    'data-testid': tid,
+  }: {
+    isSelected?: boolean;
+    'data-testid'?: string;
+  }) => (
+    <input
+      readOnly
+      checked={isSelected ?? false}
+      data-testid={tid}
+      type="checkbox"
+    />
+  ),
+  Input: ({
+    onChange,
+    value,
+    'data-testid': tid,
+    inputDataTestId,
+    placeholder,
+    autoFocus,
+  }: {
+    onChange?: (val: string) => void;
+    value?: string;
+    'data-testid'?: string;
+    inputDataTestId?: string;
+    placeholder?: string;
+    autoFocus?: boolean;
+  }) => (
+    <input
+      autoFocus={autoFocus}
+      data-testid={inputDataTestId ?? tid}
+      placeholder={placeholder}
+      value={value ?? ''}
+      onChange={(e) => onChange?.(e.target.value)}
+    />
+  ),
+}));
+
+const MOCK_OPTIONS = [
+  { label: 'Team Alpha', value: 'team-alpha' },
+  { label: 'Team Beta', value: 'team-beta' },
+];
+
+const MOCK_SEARCHED_OPTIONS = [{ label: 'Team Gamma', value: 'team-gamma' }];
+
+const mockOnSearch = jest
+  .fn()
+  .mockImplementation((text: string) =>
+    Promise.resolve(text ? MOCK_SEARCHED_OPTIONS : MOCK_OPTIONS)
+  );
+
+const MOCK_PROPS: TeamAndUserSelectItemV2Props = {
+  entityType: 'team',
+  onSearch: mockOnSearch,
+  fieldName: [0, 'config', 'receivers'],
+  destinationNumber: 0,
+};
+
+function renderWithForm(
+  ui: React.ReactElement,
+  defaultValues: Record<string, unknown> = {}
+) {
+  function Wrapper({ children }: { children: ReactNode }) {
+    const methods = useForm({ defaultValues });
+
+    return <FormProvider {...methods}>{children}</FormProvider>;
+  }
+
+  return render(ui, { wrapper: Wrapper });
+}
+
+describe('TeamAndUserSelectItemV2', () => {
+  beforeEach(() => {
+    jest.useFakeTimers('modern');
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('renders placeholder when no items are selected', () => {
+    renderWithForm(<TeamAndUserSelectItemV2 {...MOCK_PROPS} />);
+
+    expect(screen.getByTestId('placeholder-text')).toBeInTheDocument();
+  });
+
+  it('opens dropdown on trigger click', async () => {
+    renderWithForm(<TeamAndUserSelectItemV2 {...MOCK_PROPS} />);
+
+    await act(async () => {
+      fireEvent.click(
+        screen.getByTestId(
+          `team-user-select-trigger-${MOCK_PROPS.destinationNumber}`
+        )
+      );
+      jest.advanceTimersByTime(500);
+    });
+
+    expect(
+      screen.getByTestId(
+        `team-user-select-dropdown-${MOCK_PROPS.destinationNumber}`
+      )
+    ).toBeInTheDocument();
+  });
+
+  it('loads and shows initial options when dropdown opens', async () => {
+    renderWithForm(<TeamAndUserSelectItemV2 {...MOCK_PROPS} />);
+
+    await act(async () => {
+      fireEvent.click(
+        screen.getByTestId(
+          `team-user-select-trigger-${MOCK_PROPS.destinationNumber}`
+        )
+      );
+      jest.advanceTimersByTime(500);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('Team Alpha-option-label')).toBeInTheDocument();
+      expect(screen.getByTestId('Team Beta-option-label')).toBeInTheDocument();
+    });
+  });
+
+  it('shows filtered options after typing in search input', async () => {
+    renderWithForm(<TeamAndUserSelectItemV2 {...MOCK_PROPS} />);
+
+    await act(async () => {
+      fireEvent.click(
+        screen.getByTestId(
+          `team-user-select-trigger-${MOCK_PROPS.destinationNumber}`
+        )
+      );
+      jest.advanceTimersByTime(500);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('search-input-field')).toBeInTheDocument();
+    });
+
+    await act(async () => {
+      fireEvent.change(screen.getByTestId('search-input-field'), {
+        target: { value: 'gamma' },
+      });
+      jest.advanceTimersByTime(500);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('Team Gamma-option-label')).toBeInTheDocument();
+    });
+  });
+
+  it('closes dropdown when clicking outside', async () => {
+    renderWithForm(<TeamAndUserSelectItemV2 {...MOCK_PROPS} />);
+
+    await act(async () => {
+      fireEvent.click(
+        screen.getByTestId(
+          `team-user-select-trigger-${MOCK_PROPS.destinationNumber}`
+        )
+      );
+      jest.advanceTimersByTime(500);
+    });
+
+    expect(
+      screen.getByTestId(
+        `team-user-select-dropdown-${MOCK_PROPS.destinationNumber}`
+      )
+    ).toBeInTheDocument();
+
+    await act(async () => {
+      fireEvent.click(document.body);
+    });
+
+    expect(
+      screen.queryByTestId(
+        `team-user-select-dropdown-${MOCK_PROPS.destinationNumber}`
+      )
+    ).not.toBeInTheDocument();
+  });
+
+  it('adds selected option as badge and removes placeholder', async () => {
+    renderWithForm(<TeamAndUserSelectItemV2 {...MOCK_PROPS} />);
+
+    await act(async () => {
+      fireEvent.click(
+        screen.getByTestId(
+          `team-user-select-trigger-${MOCK_PROPS.destinationNumber}`
+        )
+      );
+      jest.advanceTimersByTime(500);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('team-alpha')).toBeInTheDocument();
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('team-alpha'));
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('selected-tag-team-alpha')).toBeInTheDocument();
+      expect(screen.queryByTestId('placeholder-text')).not.toBeInTheDocument();
+    });
+  });
+
+  it('removes badge on X click', async () => {
+    renderWithForm(<TeamAndUserSelectItemV2 {...MOCK_PROPS} />, {
+      destinations: [{ config: { receivers: ['team-alpha'] } }],
+    });
+
+    expect(screen.getByTestId('selected-tag-team-alpha')).toBeInTheDocument();
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('selected-tag-team-alpha-remove'));
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.queryByTestId('selected-tag-team-alpha')
+      ).not.toBeInTheDocument();
+      expect(screen.getByTestId('placeholder-text')).toBeInTheDocument();
+    });
+  });
+
+  it('shows "no data found" message when search returns empty', async () => {
+    mockOnSearch.mockResolvedValueOnce([]);
+
+    renderWithForm(<TeamAndUserSelectItemV2 {...MOCK_PROPS} />);
+
+    await act(async () => {
+      fireEvent.click(
+        screen.getByTestId(
+          `team-user-select-trigger-${MOCK_PROPS.destinationNumber}`
+        )
+      );
+      jest.advanceTimersByTime(500);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('label.no-data-found')).toBeInTheDocument();
+    });
+  });
+});

--- a/openmetadata-ui/src/main/resources/ui/src/components/Alerts/DestinationFormItemV2/TeamAndUserSelectItemV2/TeamAndUserSelectItemV2.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Alerts/DestinationFormItemV2/TeamAndUserSelectItemV2/TeamAndUserSelectItemV2.tsx
@@ -1,0 +1,202 @@
+/*
+ *  Copyright 2024 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+import {
+  BadgeWithButton,
+  Checkbox,
+  Input,
+} from '@openmetadata/ui-core-components';
+import { debounce, isEmpty } from 'lodash';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useFormContext, useWatch } from 'react-hook-form';
+import { useTranslation } from 'react-i18next';
+
+import { SelectOption } from '../../../common/AsyncSelectList/AsyncSelectList.interface';
+import { TeamAndUserSelectItemV2Props } from './TeamAndUserSelectItemV2.interface';
+
+function TeamAndUserSelectItemV2({
+  entityType,
+  onSearch,
+  fieldName,
+  destinationNumber,
+}: Readonly<TeamAndUserSelectItemV2Props>) {
+  const { t } = useTranslation();
+  const { setValue, control } = useFormContext();
+  const dropdownRef = useRef<HTMLDivElement>(null);
+  const triggerRef = useRef<HTMLDivElement>(null);
+  const [isLoadingOptions, setIsLoadingOptions] = useState(false);
+  const [isDropdownOpen, setIsDropdownOpen] = useState(false);
+  const [searchText, setSearchText] = useState('');
+  const [options, setOptions] = useState<SelectOption[]>([]);
+
+  const fieldPath = `destinations.${fieldName.join('.')}`;
+  const selectedOptions: string[] =
+    useWatch({ name: fieldPath, control }) ?? [];
+
+  const handleSearch = useCallback(
+    async (value: string) => {
+      try {
+        setIsLoadingOptions(true);
+        const results = await onSearch(value);
+        setOptions(results);
+      } catch {
+        setOptions([]);
+      } finally {
+        setIsLoadingOptions(false);
+      }
+    },
+    [onSearch]
+  );
+
+  const debouncedSearch = useMemo(
+    () => debounce(handleSearch, 500),
+    [handleSearch]
+  );
+
+  const handleOptionClick = useCallback(
+    (value: string) => {
+      const isSelected = selectedOptions.includes(value);
+      const updated = isSelected
+        ? selectedOptions.filter((o) => o !== value)
+        : [...selectedOptions, value];
+      setValue(fieldPath, updated);
+    },
+    [selectedOptions, fieldPath, setValue]
+  );
+
+  const handleTagClose = useCallback(
+    (value: string) => {
+      setValue(
+        fieldPath,
+        selectedOptions.filter((o) => o !== value)
+      );
+    },
+    [selectedOptions, fieldPath, setValue]
+  );
+
+  const handleTriggerClick = useCallback(() => {
+    setIsDropdownOpen((prev) => !prev);
+  }, []);
+
+  useEffect(() => {
+    debouncedSearch(searchText);
+  }, [searchText, entityType, debouncedSearch]);
+
+  useEffect(() => {
+    const handleOutsideClick = (e: MouseEvent) => {
+      const clickedOutsideDropdown = !dropdownRef.current?.contains(
+        e.target as Node
+      );
+      const clickedInsideTrigger = triggerRef.current?.contains(
+        e.target as Node
+      );
+      if (clickedOutsideDropdown && !clickedInsideTrigger) {
+        setIsDropdownOpen(false);
+        setSearchText('');
+      }
+    };
+    document.addEventListener('click', handleOutsideClick);
+
+    return () => document.removeEventListener('click', handleOutsideClick);
+  }, []);
+
+  return (
+    <div className="tw:relative tw:w-full">
+      <div
+        className={[
+          'tw:flex tw:min-h-9 tw:w-full tw:cursor-pointer tw:flex-wrap tw:items-center',
+          'tw:gap-1.5 tw:rounded-lg tw:bg-primary tw:px-3 tw:py-2',
+          'tw:shadow-xs tw:ring-1 tw:ring-primary tw:ring-inset',
+        ].join(' ')}
+        data-testid={`team-user-select-trigger-${destinationNumber}`}
+        ref={triggerRef}
+        onClick={handleTriggerClick}>
+        {isEmpty(selectedOptions) ? (
+          <span
+            className="tw:text-sm tw:text-placeholder"
+            data-testid="placeholder-text">
+            {t('label.please-select-entity', { entity: entityType })}
+          </span>
+        ) : (
+          selectedOptions.map((option) => (
+            <BadgeWithButton
+              buttonLabel={t('label.remove')}
+              color="gray"
+              data-testid={`selected-tag-${option}`}
+              key={option}
+              type="pill-color"
+              onButtonClick={(e) => {
+                e.stopPropagation();
+                handleTagClose(option);
+              }}>
+              {option}
+            </BadgeWithButton>
+          ))
+        )}
+      </div>
+
+      {isDropdownOpen && (
+        <div
+          className="tw:absolute tw:z-50 tw:mt-1 tw:w-full tw:rounded-xl tw:border tw:border-secondary tw:bg-primary tw:p-2 tw:shadow-lg"
+          data-testid={`team-user-select-dropdown-${destinationNumber}`}
+          ref={dropdownRef}>
+          <Input
+            autoFocus
+            data-testid="search-input"
+            inputDataTestId="search-input-field"
+            placeholder={t('label.search-by-type', { type: entityType })}
+            value={searchText}
+            onChange={(val) => setSearchText(val)}
+          />
+          <div className="tw:mt-2 tw:max-h-48 tw:overflow-y-auto">
+            {isLoadingOptions ? (
+              <div className="tw:space-y-1 tw:p-2">
+                {[1, 2, 3].map((i) => (
+                  <div
+                    className="tw:h-6 tw:animate-pulse tw:rounded tw:bg-secondary"
+                    key={i}
+                  />
+                ))}
+              </div>
+            ) : isEmpty(options) ? (
+              <p className="tw:p-2 tw:text-center tw:text-sm tw:text-tertiary">
+                {t('label.no-data-found')}
+              </p>
+            ) : (
+              options.map(({ label, value }) => (
+                <button
+                  className="tw:flex tw:w-full tw:cursor-pointer tw:items-center tw:gap-2 tw:rounded-md tw:px-2 tw:py-1.5 tw:text-left hover:tw:bg-secondary"
+                  data-testid={value}
+                  key={value}
+                  type="button"
+                  onClick={() => handleOptionClick(value)}>
+                  <Checkbox
+                    data-testid={`${label}-option-checkbox`}
+                    isSelected={selectedOptions.includes(value)}
+                  />
+                  <span
+                    className="tw:truncate tw:text-sm tw:text-primary"
+                    data-testid={`${label}-option-label`}>
+                    {label}
+                  </span>
+                </button>
+              ))
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default TeamAndUserSelectItemV2;


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:

I worked on creating `DestinationFormItemV2`, a fully AntD-free replacement for the existing `DestinationFormItem` component family, because the alerts destination form still depended on Ant Design while the rest of the UI is migrating to `@openmetadata/ui-core-components`.

This PR adds 7 new files — `DestinationFormItemV2`, `DestinationSelectItemV2`, `DestinationConfigField`, and `TeamAndUserSelectItemV2` — built on `react-hook-form` + react-aria-components from `@openmetadata/ui-core-components`, plus 3 test files covering 35 unit tests across all new components.

#
### Type of change:
- [x] New feature

#
### High-level design:

The new component family mirrors the structure of the existing `DestinationFormItem` family but replaces all Ant Design primitives (`Select`, `Input`, `Form`, `Button`, `Switch`, etc.) with their `@openmetadata/ui-core-components` equivalents.

Form state is managed entirely via `react-hook-form` (`useFieldArray`, `useWatch`, `Controller`, `useFormContext`) — no local state for field values. `DestinationConfigField` handles the per-destination-type config fields (Slack endpoint, Email receivers, Teams webhook, etc.) using `Controller`-wrapped `Input`/`PasswordInput`/`Select` components. Validation errors are displayed via standalone `<p>` elements rather than the `errorMessage` prop (which react-aria explicitly omits from `TextFieldProps`/`SelectProps`). The existing `DestinationFormItem` is untouched; `DestinationFormItemV2` is a parallel addition ready to swap in.

#
### Tests:

#### Use cases covered
- Adding and removing destination rows
- Selecting internal vs external destination categories
- Warning messages for Owners/Followers/Admins/Teams/Users destinations
- Notify-downstream toggle and downstream-depth input visibility
- Destination status alert rendering (success/failure/loading)
- Team/user search with debounce: open dropdown, search, select, remove badge
- "No data found" state when search returns empty
- Test-destination button: enabled/disabled state, API call with filtered/formatted destinations, error toast on failure
- View-mode hides add/test/remove controls

#### Unit tests
- [x] I added unit tests for the new/changed logic.
- Files added:
  - `DestinationFormItemV2/DestinationFormItemV2.test.tsx` (13 tests)
  - `DestinationFormItemV2/DestinationSelectItemV2/DestinationSelectItemV2.test.tsx` (14 tests)
  - `DestinationFormItemV2/TeamAndUserSelectItemV2/TeamAndUserSelectItemV2.test.tsx` (8 tests)

#### Backend integration tests
- [x] Not applicable (no backend API changes).

#### Ingestion integration tests
- [x] Not applicable (no ingestion changes).

#### Playwright (UI) tests
- [x] Not applicable (no UI changes to existing flows; new component is not yet wired into pages).

#### Manual testing performed
Not performed — component is not yet wired into any page. Unit tests cover the component behaviour end-to-end.

#
### UI screen recording / screenshots:

Note: It's not actaully used just capture screenshot from temporary usage

<img width="1400" height="900" alt="12_owners_selected" src="https://github.com/user-attachments/assets/4b2f1ab7-e04b-4133-bcc0-4fe13088d9ca" />
<img width="1400" height="900" alt="11_slack_selected" src="https://github.com/user-attachments/assets/412c0ca8-66a2-41f8-969d-00ac35f43a21" />
<img width="1400" height="900" alt="03_destination_row_added" src="https://github.com/user-attachments/assets/5e7b22d0-e203-4266-9fe8-f2594bf6e22c" />
<img width="1400" height="900" alt="02_destination_form_v2_empty" src="https://github.com/user-attachments/assets/6e8659c9-924f-4cc3-bf56-10e1bcf114f3" />


#
### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have added tests (unit / integration / Playwright as applicable) and listed them above.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds `DestinationFormItemV2`, a parallel AntD-free family of alert-destination form components built on `react-hook-form` and `@openmetadata/ui-core-components`, with 35 unit tests covering the full interaction surface.

- **`DestinationFormItemV2`** manages a `useFieldArray` of destination rows, drives the "test destinations" API call with filtered external config, and delegates each row to `DestinationSelectItemV2`.
- **`DestinationSelectItemV2`** handles category/type selection, inline config via `DestinationConfigField`, and the notify-downstream toggle; **`TeamAndUserSelectItemV2`** is a hand-rolled async combobox with debounced search and badge selection for Teams/Users destinations.
- The existing `DestinationFormItem` is untouched; this component is a parallel addition not yet wired into any page.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge as a non-wired parallel addition; the debounce cleanup gap in TeamAndUserSelectItemV2 should be fixed before the component is connected to a page.

The component family is not yet wired into any page, so the identified issues carry no immediate user-facing risk. The missing debounce cancel on unmount is a real defect that will cause stale state updates once the component is rendered in production flows — it should be addressed before the wire-up PR. The other findings (dead `defaultValue` prop, missing email validation, hardcoded placeholder string, raw string comparison for status) are quality concerns that don't block correctness today but will need cleanup before this replaces the legacy form.

TeamAndUserSelectItemV2.tsx (missing debounce cleanup) and DestinationConfigField.tsx (email validation, i18n placeholder) deserve a second look before the component is connected to a page.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-ui/src/main/resources/ui/src/components/Alerts/DestinationFormItemV2/DestinationFormItemV2.component.tsx | Main container component using useFieldArray/useFormContext; logic is solid but `defaultValue` on the controlled timeout inputs is ignored at runtime. |
| openmetadata-ui/src/main/resources/ui/src/components/Alerts/DestinationFormItemV2/DestinationSelectItemV2/DestinationSelectItemV2.tsx | Destination row component; destination type / category / subscription-type wiring is correct; status alert variant uses a raw string `'Success'` instead of the generated `Status` enum. |
| openmetadata-ui/src/main/resources/ui/src/components/Alerts/DestinationFormItemV2/DestinationSelectItemV2/DestinationConfigField/DestinationConfigField.tsx | Per-destination config fields; hardcoded OAuth2 token URL placeholder violates i18n policy, and `EmailTagInput` adds receivers without validating email format. |
| openmetadata-ui/src/main/resources/ui/src/components/Alerts/DestinationFormItemV2/TeamAndUserSelectItemV2/TeamAndUserSelectItemV2.tsx | Custom team/user combobox with debounced search; missing `debouncedSearch.cancel()` cleanup on unmount can cause state updates after the component is gone. |
| openmetadata-ui/src/main/resources/ui/src/components/Alerts/DestinationFormItemV2/DestinationFormItemV2.test.tsx | 13 unit tests covering add/remove rows, button enable/disable logic, API call filtering, and error toast; coverage is thorough for the component's surface area. |
| openmetadata-ui/src/main/resources/ui/src/components/Alerts/DestinationFormItemV2/DestinationSelectItemV2/DestinationSelectItemV2.test.tsx | 14 tests covering internal/external selection, warning messages, downstream toggle, status alerts, and combobox interaction; well-structured. |
| openmetadata-ui/src/main/resources/ui/src/components/Alerts/DestinationFormItemV2/TeamAndUserSelectItemV2/TeamAndUserSelectItemV2.test.tsx | 8 tests covering dropdown open/close, debounced search, option selection, badge removal, and empty state; fake timers used correctly. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[DestinationFormItemV2] -->|useFieldArray 'destinations'| B[DestinationSelectItemV2 × N]
    A -->|testAlertDestination API| C[Test Destinations Button]
    A -->|useWatch 'resources'| D{Source selected?}
    D -->|No| E[Add/Test buttons disabled]
    D -->|Yes| F[Add/Test buttons enabled]

    B -->|Select.ComboBox| G{Destination Type}
    G -->|External: Slack / MSTeams / GChat / Webhook| H[DestinationConfigField — endpoint + auth accordion]
    G -->|External: Email| I[DestinationConfigField — EmailTagInput]
    G -->|Internal: Teams / Users| J[DestinationConfigField → TeamAndUserSelectItemV2]
    G -->|Internal: Owners / Followers / Admins| K[DestinationConfigField — config flag only]
    G -->|Internal: any| L[Subscription Type Select + Warning Alert]

    J -->|debounced onSearch| M[(Search API)]
    M --> N[Checkbox dropdown with BadgeWithButton tags]

    B -->|notifyDownstream Toggle| O{notifyDownstream?}
    O -->|true| P[downstreamDepth Input]
    O -->|false| Q[hidden]

    C -->|getFormattedDestinations + filter empty config| R[testAlertDestination]
    R -->|results| S[destinationsWithStatus → Alert per row]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[DestinationFormItemV2] -->|useFieldArray 'destinations'| B[DestinationSelectItemV2 × N]
    A -->|testAlertDestination API| C[Test Destinations Button]
    A -->|useWatch 'resources'| D{Source selected?}
    D -->|No| E[Add/Test buttons disabled]
    D -->|Yes| F[Add/Test buttons enabled]

    B -->|Select.ComboBox| G{Destination Type}
    G -->|External: Slack / MSTeams / GChat / Webhook| H[DestinationConfigField — endpoint + auth accordion]
    G -->|External: Email| I[DestinationConfigField — EmailTagInput]
    G -->|Internal: Teams / Users| J[DestinationConfigField → TeamAndUserSelectItemV2]
    G -->|Internal: Owners / Followers / Admins| K[DestinationConfigField — config flag only]
    G -->|Internal: any| L[Subscription Type Select + Warning Alert]

    J -->|debounced onSearch| M[(Search API)]
    M --> N[Checkbox dropdown with BadgeWithButton tags]

    B -->|notifyDownstream Toggle| O{notifyDownstream?}
    O -->|true| P[downstreamDepth Input]
    O -->|false| Q[hidden]

    C -->|getFormattedDestinations + filter empty config| R[testAlertDestination]
    R -->|results| S[destinationsWithStatus → Alert per row]
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["test(ui): add unit tests for Destination..."](https://github.com/open-metadata/openmetadata/commit/68a5270b84b8581c812275e5d3bdf40aed145957) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40155729)</sub>

> Greptile also left **5 inline comments** on this PR.

**Context used:**

- Context used - CLAUDE.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=52f0d9d9-cad1-4e7d-b070-de181a0aa5e7))

<!-- /greptile_comment -->