### PR TITLE
fix(ui): fix ComboBox popover positioning + add Storybook stories

### DIFF
--- a/openmetadata-ui-core-components/src/main/resources/ui/src/components/base/select/combobox.tsx
+++ b/openmetadata-ui-core-components/src/main/resources/ui/src/components/base/select/combobox.tsx
@@ -196,8 +196,7 @@ export const ComboBox = ({
             <Popover
               className={otherProps.popoverClassName}
               size={size}
-              style={{ width: popoverWidth }}
-              triggerRef={placeholderRef}>
+              style={{ width: popoverWidth }}>
               <AriaListBox
                 className="tw:size-full tw:outline-hidden"
                 items={items}>

--- a/openmetadata-ui-core-components/src/main/resources/ui/src/stories/Combobox.stories.tsx
+++ b/openmetadata-ui-core-components/src/main/resources/ui/src/stories/Combobox.stories.tsx
@@ -1,0 +1,233 @@
+/*
+ *  Copyright 2025 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+import { useState } from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+import { Button } from '../components/base/buttons/button';
+import { Select } from '../components/base/select/select';
+import type { SelectItemType } from '../components/base/select/select';
+import {
+  Dialog,
+  DialogTrigger,
+  Modal,
+  ModalOverlay,
+} from '../components/application/modals/modal';
+
+const { ComboBox, Item: SelectItem } = Select;
+
+const ITEMS: SelectItemType[] = [
+  { id: '1', label: 'Dashboard' },
+  { id: '2', label: 'Tables' },
+  { id: '3', label: 'Topics' },
+  { id: '4', label: 'Pipelines', isDisabled: true },
+  { id: '5', label: 'ML Models' },
+  { id: '6', label: 'Containers' },
+  { id: '7', label: 'Search Indexes' },
+];
+
+const ITEMS_WITH_SUPPORTING_TEXT: SelectItemType[] = [
+  { id: 'p1', label: 'PII', supportingText: 'Personally Identifiable Info' },
+  { id: 'p2', label: 'Sensitive', supportingText: 'Internal use only' },
+  { id: 'p3', label: 'Public', supportingText: 'Publicly available' },
+  { id: 'p4', label: 'Confidential', supportingText: 'Restricted access' },
+  { id: 'p5', label: 'Restricted', supportingText: 'Highly restricted' },
+];
+
+const renderItem = (item: SelectItemType) => (
+  <SelectItem id={item.id} isDisabled={item.isDisabled} key={item.id}>
+    {item.label}
+  </SelectItem>
+);
+
+const meta = {
+  title: 'Components/ComboBox',
+  component: ComboBox,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+} satisfies Meta<typeof ComboBox>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  render: () => (
+    <div style={{ width: 320 }}>
+      <ComboBox items={ITEMS} placeholder="Search assets...">
+        {renderItem}
+      </ComboBox>
+    </div>
+  ),
+};
+
+export const WithLabel: Story = {
+  render: () => (
+    <div style={{ width: 320 }}>
+      <ComboBox
+        items={ITEMS}
+        label="Asset type"
+        placeholder="Search asset types...">
+        {renderItem}
+      </ComboBox>
+    </div>
+  ),
+};
+
+export const WithHint: Story = {
+  render: () => (
+    <div style={{ width: 320 }}>
+      <ComboBox
+        hint="Choose the asset type you want to explore."
+        items={ITEMS}
+        label="Asset type"
+        placeholder="Search asset types...">
+        {renderItem}
+      </ComboBox>
+    </div>
+  ),
+};
+
+export const WithSupportingText: Story = {
+  render: () => (
+    <div style={{ width: 360 }}>
+      <ComboBox
+        items={ITEMS_WITH_SUPPORTING_TEXT}
+        label="Tag"
+        placeholder="Search tags...">
+        {(item) => (
+          <SelectItem
+            id={item.id}
+            key={item.id}
+            supportingText={item.supportingText}>
+            {item.label}
+          </SelectItem>
+        )}
+      </ComboBox>
+    </div>
+  ),
+};
+
+export const Sizes: Story = {
+  render: () => (
+    <div
+      style={{ display: 'flex', flexDirection: 'column', gap: 16, width: 320 }}>
+      <ComboBox items={ITEMS} placeholder="Small (default)" size="sm">
+        {renderItem}
+      </ComboBox>
+      <ComboBox items={ITEMS} placeholder="Medium" size="md">
+        {renderItem}
+      </ComboBox>
+    </div>
+  ),
+};
+
+export const WithoutShortcut: Story = {
+  render: () => (
+    <div style={{ width: 320 }}>
+      <ComboBox
+        items={ITEMS}
+        label="Asset type"
+        placeholder="Search..."
+        shortcut={false}>
+        {renderItem}
+      </ComboBox>
+    </div>
+  ),
+};
+
+export const Disabled: Story = {
+  render: () => (
+    <div style={{ width: 320 }}>
+      <ComboBox
+        isDisabled
+        items={ITEMS}
+        label="Asset type (disabled)"
+        placeholder="Search...">
+        {renderItem}
+      </ComboBox>
+    </div>
+  ),
+};
+
+export const WithInvalidState: Story = {
+  render: () => (
+    <div style={{ width: 320 }}>
+      <ComboBox
+        isInvalid
+        isRequired
+        hint="Please select an asset type."
+        items={ITEMS}
+        label="Asset type"
+        placeholder="Search...">
+        {renderItem}
+      </ComboBox>
+    </div>
+  ),
+};
+
+export const InModal: Story = {
+  name: 'ComboBox inside a Modal',
+  render: () => {
+    const [isOpen, setIsOpen] = useState(false);
+
+    return (
+      <DialogTrigger isOpen={isOpen} onOpenChange={setIsOpen}>
+        <Button color="primary" onPress={() => setIsOpen(true)}>
+          Open modal with ComboBox
+        </Button>
+        <ModalOverlay>
+          <Modal>
+            <Dialog
+              showCloseButton
+              title="Filter assets"
+              onClose={() => setIsOpen(false)}>
+              <Dialog.Content>
+                <p className="tw:text-sm tw:text-secondary">
+                  Use the search below to filter by asset type or tag.
+                </p>
+                <ComboBox
+                  items={ITEMS}
+                  label="Asset type"
+                  placeholder="Search asset types..."
+                  shortcut={false}>
+                  {renderItem}
+                </ComboBox>
+                <ComboBox
+                  items={ITEMS_WITH_SUPPORTING_TEXT}
+                  label="Tag"
+                  placeholder="Search tags...">
+                  {(item) => (
+                    <SelectItem
+                      id={item.id}
+                      key={item.id}
+                      supportingText={item.supportingText}>
+                      {item.label}
+                    </SelectItem>
+                  )}
+                </ComboBox>
+              </Dialog.Content>
+              <Dialog.Footer>
+                <Button color="secondary" onPress={() => setIsOpen(false)}>
+                  Cancel
+                </Button>
+                <Button color="primary" onPress={() => setIsOpen(false)}>
+                  Apply filters
+                </Button>
+              </Dialog.Footer>
+            </Dialog>
+          </Modal>
+        </ModalOverlay>
+      </DialogTrigger>
+    );
+  },
+};


### PR DESCRIPTION
## Summary

- **Bug fix**: Removed `triggerRef={placeholderRef}` from `<Popover>` inside `ComboBox`. `AriaComboBox` manages its own trigger reference via its internal state context; passing an external ref pointing to the wrapper `div` overrode it, causing the popover to anchor at position (0, 0) instead of directly below the input.
- **Stories**: Adds `Combobox.stories.tsx` with 9 stories covering all key variants.

## Stories added

| Story | Coverage |
|---|---|
| `Default` | Bare combobox, no label |
| `WithLabel` | Label above input |
| `WithHint` | Label + hint text |
| `WithSupportingText` | Items with secondary description |
| `Sizes` | `sm` vs `md` side-by-side |
| `WithoutShortcut` | `shortcut={false}` — no ⌘K badge |
| `Disabled` | `isDisabled` state |
| `WithInvalidState` | `isInvalid + isRequired` |
| `InModal` | Two ComboBoxes inside a Dialog/Modal |

## Test plan

- [ ] Open Storybook → Components/ComboBox → verify popover opens beneath the input in all stories
- [ ] Verify `InModal` story: open modal, click a ComboBox, confirm dropdown positions correctly inside the modal overlay

https://github.com/user-attachments/assets/2caa69ff-35e7-45c4-b718-7c7054d78bb8




🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Removes `triggerRef={placeholderRef}` from the `<Popover>` inside `ComboBox` so that `AriaComboBox` can manage its own trigger reference via its internal state context, fixing the (0,0) anchor bug. Adds nine Storybook stories covering the full variant matrix.

- **Bug fix** (`combobox.tsx`): `placeholderRef` (attached to the `ComboBoxValue` `AriaGroup` wrapper) was being forwarded to `Popover.triggerRef`, overriding react-aria-components' internal input-anchor logic and collapsing the popover to position (0,0). Removing the prop restores correct below-input positioning; `placeholderRef` continues to drive the resize observer that supplies `popoverWidth`.
- **Stories** (`Combobox.stories.tsx`): Nine stories — `Default`, `WithLabel`, `WithHint`, `WithSupportingText`, `Sizes`, `WithoutShortcut`, `Disabled`, `WithInvalidState`, and `InModal` — following the same patterns established in `Select.stories.tsx` and `Modal.stories.tsx`.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge. The single-line removal in combobox.tsx restores a well-understood react-aria-components behaviour without touching any public API surface, and the new stories file is additive only.

The fix correctly delegates popover anchor management back to AriaComboBox's internal trigger ref (the actual AriaInput element) rather than overriding it with the outer AriaGroup wrapper ref. The placeholderRef is still wired to the resize observer for popover width — that path is untouched. Stories follow the exact same patterns as the established Modal and Select story files, including the useState-inside-render technique used by Storybook. No existing behaviour is removed or altered beyond what the bug fix intends.

No files require special attention.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-ui-core-components/src/main/resources/ui/src/components/base/select/combobox.tsx | One-line bug fix: removes `triggerRef={placeholderRef}` from `<Popover>` so AriaComboBox manages its own anchor; `placeholderRef` remains in use for the resize observer and popover width calculation. |
| openmetadata-ui-core-components/src/main/resources/ui/src/stories/Combobox.stories.tsx | New stories file with nine well-structured variants; follows established patterns from Select.stories.tsx and Modal.stories.tsx including useState inside render for stateful stories. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant User
    participant ComboBoxValue as ComboBoxValue (AriaGroup)
    participant AriaComboBox
    participant AriaInput
    participant Popover

    Note over ComboBoxValue,Popover: Before fix — triggerRef={placeholderRef}
    User->>AriaInput: Focus / type
    AriaComboBox->>Popover: Open (triggerRef overridden → anchors to AriaGroup wrapper)
    Popover-->>User: Renders at (0, 0) ❌

    Note over ComboBoxValue,Popover: After fix — no triggerRef prop
    User->>AriaInput: Focus / type
    AriaComboBox->>Popover: Open (internal trigger ref → anchors to AriaInput)
    Popover-->>User: Renders below input ✅

    Note over ComboBoxValue: placeholderRef still used by ResizeObserver for popoverWidth
    ComboBoxValue->>AriaComboBox: resize event → setPopoverWidth(rect.width)
    AriaComboBox->>Popover: "style={{ width: popoverWidth }}"
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant User
    participant ComboBoxValue as ComboBoxValue (AriaGroup)
    participant AriaComboBox
    participant AriaInput
    participant Popover

    Note over ComboBoxValue,Popover: Before fix — triggerRef={placeholderRef}
    User->>AriaInput: Focus / type
    AriaComboBox->>Popover: Open (triggerRef overridden → anchors to AriaGroup wrapper)
    Popover-->>User: Renders at (0, 0) ❌

    Note over ComboBoxValue,Popover: After fix — no triggerRef prop
    User->>AriaInput: Focus / type
    AriaComboBox->>Popover: Open (internal trigger ref → anchors to AriaInput)
    Popover-->>User: Renders below input ✅

    Note over ComboBoxValue: placeholderRef still used by ResizeObserver for popoverWidth
    ComboBoxValue->>AriaComboBox: resize event → setPopoverWidth(rect.width)
    AriaComboBox->>Popover: "style={{ width: popoverWidth }}"
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(ui): fix ComboBox popover positionin..."](https://github.com/open-metadata/openmetadata/commit/833487f05aa8aa4087f35ae73bcb93351494d677) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40261614)</sub>

<!-- /greptile_comment -->