### PR TITLE
fix: bypass domain enforcement for OM-internally-issued tokens (#29433) [1.13 backport]

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/security/JwtFilter.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/security/JwtFilter.java
@@ -65,6 +65,7 @@ import org.openmetadata.service.monitoring.RequestLatencyContext;
 import org.openmetadata.service.security.auth.BotTokenCache;
 import org.openmetadata.service.security.auth.CatalogSecurityContext;
 import org.openmetadata.service.security.auth.UserTokenCache;
+import org.openmetadata.service.security.jwt.JWTTokenGenerator;
 import org.openmetadata.service.security.saml.JwtTokenCacheManager;
 
 @Slf4j
@@ -163,9 +164,10 @@ public class JwtFilter implements ContainerRequestFilter {
     ImpersonationContext.clear();
     try {
       String tokenFromHeader = extractToken(requestContext.getHeaders());
-      LOG.debug("Token from header:{}", tokenFromHeader);
-
-      Map<String, Claim> claims = validateJwtAndGetClaims(tokenFromHeader);
+      LOG.debug("Authorization header present: {}", !nullOrEmpty(tokenFromHeader));
+      DecodedJWT decodedJwt = decodeAndVerify(tokenFromHeader);
+      String tokenKeyId = decodedJwt.getKeyId();
+      Map<String, Claim> claims = extractClaims(decodedJwt);
       String userName =
           findUserNameFromClaims(jwtPrincipalClaimsMapping, jwtPrincipalClaims, claims);
       String email =
@@ -184,7 +186,7 @@ public class JwtFilter implements ContainerRequestFilter {
         userName = impersonateUser;
       }
 
-      checkValidationsForToken(claims, tokenFromHeader, userName, impersonatedBy);
+      checkValidationsForToken(claims, tokenFromHeader, tokenKeyId, userName, impersonatedBy);
 
       CatalogPrincipal catalogPrincipal = new CatalogPrincipal(userName, email);
       String scheme = requestContext.getUriInfo().getRequestUri().getScheme();
@@ -211,17 +213,40 @@ public class JwtFilter implements ContainerRequestFilter {
 
   public void checkValidationsForToken(
       Map<String, Claim> claims, String tokenFromHeader, String userName, String impersonatedBy) {
+    String tokenKeyId = null;
+    try {
+      tokenKeyId = JWT.decode(tokenFromHeader).getKeyId();
+    } catch (JWTDecodeException e) {
+      LOG.debug("Unable to read key id from token during OpenMetadata issuer check", e);
+    }
+    checkValidationsForToken(claims, tokenFromHeader, tokenKeyId, userName, impersonatedBy);
+  }
+
+  private void checkValidationsForToken(
+      Map<String, Claim> claims,
+      String tokenFromHeader,
+      String tokenKeyId,
+      String userName,
+      String impersonatedBy) {
     // the case where OMD generated the Token for the Client in case OM generated Token
     validateTokenIsNotUsedAfterLogout(tokenFromHeader);
 
-    // Validate Domain
-    validateDomainEnforcement(
-        jwtPrincipalClaimsMapping,
-        jwtPrincipalClaims,
-        claims,
-        principalDomain,
-        allowedDomains,
-        enforcePrincipalDomain);
+    // OM-issued tokens (PATs, session tokens, user tokens) set preferred_username to the bare
+    // username without an @domain suffix, which causes getFirstMatchJwtClaim-based domain
+    // extraction to return an empty domain and fail enforcement. Since OM owns the user identity
+    // these tokens are trusted and domain enforcement is skipped — consistent with how bot tokens
+    // are already handled (validateDomainEnforcement returns early for isBot=true tokens).
+    // The isInternallyIssuedToken check is guarded by enforcePrincipalDomain to avoid the
+    // singleton lookup on deployments where enforcement is disabled.
+    if (enforcePrincipalDomain && !isInternallyIssuedToken(claims, tokenKeyId)) {
+      validateDomainEnforcement(
+          jwtPrincipalClaimsMapping,
+          jwtPrincipalClaims,
+          claims,
+          principalDomain,
+          allowedDomains,
+          enforcePrincipalDomain);
+    }
 
     // Validate Bot token matches what was created in OM
     // Skip validation for impersonation tokens - they are generated dynamically and not stored in
@@ -232,6 +257,12 @@ public class JwtFilter implements ContainerRequestFilter {
 
     // validate personal access token
     validatePersonalAccessToken(claims, tokenFromHeader, userName);
+  }
+
+  private boolean isInternallyIssuedToken(Map<String, Claim> claims, String tokenKeyId) {
+    JWTTokenGenerator tokenGenerator = JWTTokenGenerator.getInstance();
+    return SecurityUtil.isOpenMetadataIssuedToken(
+        claims, tokenKeyId, tokenGenerator.getIssuer(), tokenGenerator.getKid());
   }
 
   private Set<String> getUserRolesFromClaims(Map<String, Claim> claims, boolean isBot) {
@@ -248,7 +279,11 @@ public class JwtFilter implements ContainerRequestFilter {
 
   @SneakyThrows
   public Map<String, Claim> validateJwtAndGetClaims(String token) {
-    // Decode JWT Token
+    return extractClaims(decodeAndVerify(token));
+  }
+
+  @SneakyThrows
+  private DecodedJWT decodeAndVerify(String token) {
     DecodedJWT jwt;
     try {
       jwt = JWT.decode(token);
@@ -256,14 +291,11 @@ public class JwtFilter implements ContainerRequestFilter {
       throw AuthenticationException.getInvalidTokenException("Invalid token.");
     }
 
-    // Check if expired
-    // If expiresAt is set to null, treat it as never expiring token
     if (jwt.getExpiresAt() != null
         && jwt.getExpiresAt().before(Calendar.getInstance(TimeZone.getTimeZone("UTC")).getTime())) {
       throw AuthenticationException.getExpiredTokenException();
     }
 
-    // Validate JWT with public key
     Jwk jwk = jwkProvider.get(jwt.getKeyId());
     Algorithm algorithm = createAlgorithmFromJwk(tokenValidationAlgorithm, jwk);
     try {
@@ -273,9 +305,12 @@ public class JwtFilter implements ContainerRequestFilter {
           "Invalid token. Token verification failed. Public key mismatch.", runtimeException);
     }
 
+    return jwt;
+  }
+
+  private static Map<String, Claim> extractClaims(DecodedJWT jwt) {
     Map<String, Claim> claims = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
     claims.putAll(jwt.getClaims());
-
     return claims;
   }
 

--- a/openmetadata-service/src/main/java/org/openmetadata/service/security/SecurityUtil.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/security/SecurityUtil.java
@@ -46,6 +46,7 @@ import org.openmetadata.service.security.auth.CatalogSecurityContext;
 @Slf4j
 public final class SecurityUtil {
   public static final String DEFAULT_PRINCIPAL_DOMAIN = "openmetadata.org";
+  public static final String ISSUER_CLAIM = "iss";
 
   private SecurityUtil() {}
 
@@ -389,5 +390,27 @@ public final class SecurityUtil {
   public static boolean isBotW(Map<String, ?> claims) {
     Claim isBotClaim = (Claim) claims.get("isBot");
     return isBotClaim != null && Boolean.TRUE.equals(isBotClaim.asBoolean());
+  }
+
+  /**
+   * Returns true only when the token was provably minted by OpenMetadata itself. A token qualifies
+   * when its key id matches OpenMetadata's own signing key id and its issuer matches OpenMetadata's
+   * configured issuer. The key id is the trust anchor: the signature has already been verified
+   * against the public key served for that key id, so a matching key id proves OpenMetadata's
+   * private key produced the signature - an external identity provider cannot forge it. The issuer
+   * check is defense in depth against a key id collision in a multi-source JWK provider.
+   */
+  public static boolean isOpenMetadataIssuedToken(
+      Map<String, Claim> claims,
+      String tokenKeyId,
+      String openMetadataIssuer,
+      String openMetadataKeyId) {
+    boolean issuedByOpenMetadata = false;
+    if (!nullOrEmpty(openMetadataIssuer) && !nullOrEmpty(openMetadataKeyId)) {
+      boolean keyIdMatches = openMetadataKeyId.equals(tokenKeyId);
+      boolean issuerMatches = openMetadataIssuer.equals(getClaimOrObject(claims.get(ISSUER_CLAIM)));
+      issuedByOpenMetadata = keyIdMatches && issuerMatches;
+    }
+    return issuedByOpenMetadata;
   }
 }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/security/jwt/JWTTokenGenerator.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/security/jwt/JWTTokenGenerator.java
@@ -61,8 +61,8 @@ public class JWTTokenGenerator {
   private static final JWTTokenGenerator INSTANCE = new JWTTokenGenerator();
   private RSAPrivateKey privateKey;
   @Getter private RSAPublicKey publicKey;
-  private String issuer;
-  private String kid;
+  @Getter private String issuer;
+  @Getter private String kid;
   private AuthenticationConfiguration.TokenValidationAlgorithm tokenValidationAlgorithm;
 
   private JWTTokenGenerator() {

--- a/openmetadata-service/src/test/java/org/openmetadata/service/security/JwtFilterTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/security/JwtFilterTest.java
@@ -46,7 +46,9 @@ import java.util.Map;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
+import org.mockito.MockedStatic;
 import org.openmetadata.schema.auth.ServiceTokenType;
+import org.openmetadata.service.security.jwt.JWTTokenGenerator;
 
 class JwtFilterTest {
 
@@ -54,7 +56,11 @@ class JwtFilterTest {
   private static JwkProvider jwkProvider;
 
   private static Algorithm algorithm;
+  private static RSAPublicKey publicKey;
   private static UriInfo mockRequestURIInfo;
+
+  private static final String OM_ISSUER = "open-metadata.org";
+  private static final String OM_KEY_ID = "om-signing-key";
 
   @BeforeAll
   static void before() throws Exception {
@@ -62,8 +68,8 @@ class JwtFilterTest {
     KeyPairGenerator keyPairGenerator = KeyPairGenerator.getInstance("RSA");
     keyPairGenerator.initialize(2048);
     KeyPair keyPair = keyPairGenerator.generateKeyPair();
-    algorithm =
-        Algorithm.RSA256((RSAPublicKey) keyPair.getPublic(), (RSAPrivateKey) keyPair.getPrivate());
+    publicKey = (RSAPublicKey) keyPair.getPublic();
+    algorithm = Algorithm.RSA256(publicKey, (RSAPrivateKey) keyPair.getPrivate());
 
     // Mock a JwkProvider that has a single JWK containing the public key from the algorithm above
     // This is used to verify the JWT
@@ -251,6 +257,101 @@ class JwtFilterTest {
     Exception exception =
         assertThrows(AuthenticationException.class, () -> jwtFilter.filter(context));
     assertTrue(exception.getMessage().toLowerCase(Locale.ROOT).contains("personal access token"));
+  }
+
+  @Test
+  void openMetadataIssuedTokenBypassesDomainEnforcement() throws Exception {
+    JwtFilter enforcingFilter = newEnforcingFilterForKeyId(OM_KEY_ID);
+    String jwt =
+        JWT.create()
+            .withKeyId(OM_KEY_ID)
+            .withIssuer(OM_ISSUER)
+            .withExpiresAt(Date.from(Instant.now().plus(1, ChronoUnit.DAYS)))
+            .withClaim("sub", "asmith")
+            .withClaim("email", "asmith@intermedia.com")
+            .withClaim(TOKEN_TYPE, ServiceTokenType.OM_USER.value())
+            .sign(algorithm);
+    ContainerRequestContext context = createRequestContextWithJwt(jwt);
+
+    try (MockedStatic<JWTTokenGenerator> generator =
+        org.mockito.Mockito.mockStatic(
+            JWTTokenGenerator.class, org.mockito.Mockito.CALLS_REAL_METHODS)) {
+      JWTTokenGenerator instance = mock(JWTTokenGenerator.class);
+      when(instance.getIssuer()).thenReturn(OM_ISSUER);
+      when(instance.getKid()).thenReturn(OM_KEY_ID);
+      generator.when(JWTTokenGenerator::getInstance).thenReturn(instance);
+
+      enforcingFilter.filter(context);
+    }
+
+    verify(context, times(1))
+        .setSecurityContext(org.mockito.ArgumentMatchers.any(SecurityContext.class));
+  }
+
+  @Test
+  void externalTokenStillEnforcedWhenServerHasNoSigningIdentity() throws Exception {
+    JwtFilter enforcingFilter = newEnforcingFilterForKeyId(OM_KEY_ID);
+    String jwt =
+        JWT.create()
+            .withKeyId(OM_KEY_ID)
+            .withIssuer(OM_ISSUER)
+            .withExpiresAt(Date.from(Instant.now().plus(1, ChronoUnit.DAYS)))
+            .withClaim("email", "asmith@intermedia.com")
+            .sign(algorithm);
+    ContainerRequestContext context = createRequestContextWithJwt(jwt);
+
+    try (MockedStatic<JWTTokenGenerator> generator =
+        org.mockito.Mockito.mockStatic(
+            JWTTokenGenerator.class, org.mockito.Mockito.CALLS_REAL_METHODS)) {
+      JWTTokenGenerator instance = mock(JWTTokenGenerator.class);
+      when(instance.getIssuer()).thenReturn(null);
+      when(instance.getKid()).thenReturn(null);
+      generator.when(JWTTokenGenerator::getInstance).thenReturn(instance);
+
+      Exception exception =
+          assertThrows(AuthenticationException.class, () -> enforcingFilter.filter(context));
+      assertTrue(
+          exception
+              .getMessage()
+              .toLowerCase(Locale.ROOT)
+              .contains("email does not match the principal domain"));
+    }
+  }
+
+  @Test
+  void spoofedOpenMetadataKeyIdWithoutMatchingSignatureIsRejected() throws Exception {
+    KeyPairGenerator keyPairGenerator = KeyPairGenerator.getInstance("RSA");
+    keyPairGenerator.initialize(2048);
+    KeyPair attackerKeyPair = keyPairGenerator.generateKeyPair();
+    Algorithm attackerAlgorithm =
+        Algorithm.RSA256(
+            (RSAPublicKey) attackerKeyPair.getPublic(),
+            (RSAPrivateKey) attackerKeyPair.getPrivate());
+
+    String jwt =
+        JWT.create()
+            .withKeyId(OM_KEY_ID)
+            .withIssuer(OM_ISSUER)
+            .withExpiresAt(Date.from(Instant.now().plus(1, ChronoUnit.DAYS)))
+            .withClaim("sub", "asmith")
+            .withClaim("email", "asmith@intermedia.com")
+            .withClaim(TOKEN_TYPE, ServiceTokenType.OM_USER.value())
+            .sign(attackerAlgorithm);
+    JwtFilter enforcingFilter = newEnforcingFilterForKeyId(OM_KEY_ID);
+    ContainerRequestContext context = createRequestContextWithJwt(jwt);
+
+    Exception exception =
+        assertThrows(AuthenticationException.class, () -> enforcingFilter.filter(context));
+    assertTrue(
+        exception.getMessage().toLowerCase(Locale.ROOT).contains("token verification failed"));
+  }
+
+  private static JwtFilter newEnforcingFilterForKeyId(String keyId) throws Exception {
+    Jwk jwk = mock(Jwk.class);
+    when(jwk.getPublicKey()).thenReturn(publicKey);
+    JwkProvider keyIdAwareProvider = mock(JwkProvider.class);
+    when(keyIdAwareProvider.get(keyId)).thenReturn(jwk);
+    return new JwtFilter(keyIdAwareProvider, List.of("sub", "email"), OM_ISSUER, true);
   }
 
   /**

--- a/openmetadata-service/src/test/java/org/openmetadata/service/security/SecurityUtilTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/security/SecurityUtilTest.java
@@ -442,6 +442,39 @@ class SecurityUtilTest {
   }
 
   @Test
+  void testIsOpenMetadataIssuedTokenRequiresMatchingIssuerAndKeyId() {
+    Map<String, Claim> claims = Map.of(SecurityUtil.ISSUER_CLAIM, stringClaim("open-metadata.org"));
+
+    assertTrue(
+        SecurityUtil.isOpenMetadataIssuedToken(claims, "om-key", "open-metadata.org", "om-key"));
+
+    assertFalse(
+        SecurityUtil.isOpenMetadataIssuedToken(
+            claims, "attacker-key", "open-metadata.org", "om-key"));
+
+    assertFalse(
+        SecurityUtil.isOpenMetadataIssuedToken(
+            Map.of(SecurityUtil.ISSUER_CLAIM, stringClaim("evil.com")),
+            "om-key",
+            "open-metadata.org",
+            "om-key"));
+
+    assertFalse(
+        SecurityUtil.isOpenMetadataIssuedToken(Map.of(), "om-key", "open-metadata.org", "om-key"));
+  }
+
+  @Test
+  void testIsOpenMetadataIssuedTokenFalseWhenServerHasNoSigningIdentity() {
+    Map<String, Claim> spoofed =
+        Map.of(SecurityUtil.ISSUER_CLAIM, stringClaim("open-metadata.org"));
+
+    assertFalse(SecurityUtil.isOpenMetadataIssuedToken(spoofed, "om-key", null, "om-key"));
+    assertFalse(
+        SecurityUtil.isOpenMetadataIssuedToken(spoofed, "om-key", "open-metadata.org", null));
+    assertFalse(SecurityUtil.isOpenMetadataIssuedToken(spoofed, "om-key", "", ""));
+  }
+
+  @Test
   void testWriteJsonResponseSetsBodyHeadersAndStatus() throws IOException {
     HttpServletResponse response = mock(HttpServletResponse.class);
     RecordingServletOutputStream outputStream = new RecordingServletOutputStream();


### PR DESCRIPTION
Cherry-pick of a0c306bd30 (#29433) onto 1.13.

Resolved merge conflicts: dropped `validateRedirectUri` redirect helpers and session/cached-token tests (from #26314 Session Management, not in 1.13); added `JWTTokenGenerator` imports 1.13 lacked. Functional changes identical to original.

Verified: spotless clean, compiles, 54/54 tests pass (42 SecurityUtilTest + 12 JwtFilterTest).

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This backport (cherry-pick of #29433 onto 1.13) fixes a bug where OM-internally-issued tokens (PATs, session tokens, user tokens) were incorrectly rejected by domain enforcement because they embed bare usernames without an `@domain` suffix, causing the domain extraction logic to produce an empty string and fail enforcement. The fix gates `validateDomainEnforcement` behind `isInternallyIssuedToken`, which checks that both the token's key ID and `iss` claim match OM's configured signing identity — the same trust guarantee that already existed for bot tokens.

- **`SecurityUtil.isOpenMetadataIssuedToken`** — new static helper that returns `true` only when both the token's key ID and issuer claim match OM's own signing key and issuer; returns `false` safely when either value is unconfigured (null/empty), preserving domain enforcement on deployments where OM signing is not set up.
- **`JwtFilter`** — refactors `validateJwtAndGetClaims` into `decodeAndVerify` + `extractClaims`, extracts `tokenKeyId` upfront from the verified JWT, and adds an `isInternallyIssuedToken` guard around the domain-enforcement call; adds a backward-compatible public 4-arg overload of `checkValidationsForToken` that re-decodes the raw token string to obtain the key ID for callers (e.g. `SocketAddressFilter`) that don't have the pre-decoded value.
- **`JWTTokenGenerator`** — adds `@Getter` to `issuer` and `kid` fields; three new integration tests in `JwtFilterTest` cover the bypass path, enforcement when the server has no signing identity, and rejection of a spoofed key ID with a non-matching signature.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; the bypass only activates after cryptographic signature verification, and the safe-fail null guards ensure domain enforcement is preserved when OM's signing identity is unconfigured.

The trust chain is solid — the key ID and issuer used for the bypass check both come from the same already-signature-verified DecodedJWT, so an external token cannot spoof its way past enforcement. The one subtle point is the public 4-arg checkValidationsForToken overload, which re-decodes the raw token string without signature verification to recover the key ID for backward-compatible callers like SocketAddressFilter. All current callers pass the same pre-verified token string, so there is no present defect, but the method carries an implicit contract that is not documented and could trap a future caller.

The public checkValidationsForToken(Map, String, String, String) overload in JwtFilter.java deserves a second look — it re-decodes the raw JWT string without signature verification, relying on callers to ensure tokenFromHeader and claims always correspond to the same pre-verified token.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-service/src/main/java/org/openmetadata/service/security/JwtFilter.java | Refactors validateJwtAndGetClaims into decodeAndVerify + extractClaims, extracts key ID upfront, and gates domain enforcement on isInternallyIssuedToken. Core logic is sound; the public 4-arg overload re-decodes the token string without signature verification (safe today, implicit contract for future callers). |
| openmetadata-service/src/main/java/org/openmetadata/service/security/SecurityUtil.java | Adds isOpenMetadataIssuedToken static helper with safe-fail null guards (returns false when issuer or kid is unconfigured). Logic is correct: requires both key ID match and issuer claim match, safe against spoofed key IDs since signature is verified before this point. |
| openmetadata-service/src/main/java/org/openmetadata/service/security/jwt/JWTTokenGenerator.java | Minimal change: adds @Getter to issuer and kid fields to expose them for the new bypass check. No logic changes. |
| openmetadata-service/src/test/java/org/openmetadata/service/security/JwtFilterTest.java | Adds three new tests covering: OM-issued token bypass, enforcement when server has no signing identity (null issuer/kid), and spoofed key ID without matching signature. Tests correctly mock JWTTokenGenerator singleton via MockedStatic. |
| openmetadata-service/src/test/java/org/openmetadata/service/security/SecurityUtilTest.java | Adds unit tests for isOpenMetadataIssuedToken covering all combinations of matching/mismatching issuer and key ID, including null/empty server identity. Comprehensive coverage. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Client
    participant JwtFilter
    participant JWTTokenGenerator
    participant SecurityUtil
    participant validateDomainEnforcement

    Client->>JwtFilter: HTTP request (Authorization: Bearer token)
    JwtFilter->>JwtFilter: extractToken()
    JwtFilter->>JwtFilter: decodeAndVerify(token) — decode, check expiry, verify signature
    JwtFilter->>JwtFilter: extractClaims(decodedJwt) → claims
    JwtFilter->>JwtFilter: "tokenKeyId = decodedJwt.getKeyId()"
    JwtFilter->>JwtFilter: checkValidationsForToken(claims, token, tokenKeyId, ...)
    JwtFilter->>JwtFilter: validateTokenIsNotUsedAfterLogout(token)
    alt "enforcePrincipalDomain == true"
        JwtFilter->>JWTTokenGenerator: getInstance().getIssuer() / getKid()
        JWTTokenGenerator-->>JwtFilter: omIssuer, omKid
        JwtFilter->>SecurityUtil: isOpenMetadataIssuedToken(claims, tokenKeyId, omIssuer, omKid)
        SecurityUtil-->>JwtFilter: true (OM-issued) or false (external IdP)
        alt "isInternallyIssuedToken == false"
            JwtFilter->>validateDomainEnforcement: validateDomainEnforcement(...)
            validateDomainEnforcement-->>JwtFilter: OK or AuthenticationException
        else "isInternallyIssuedToken == true"
            JwtFilter->>JwtFilter: skip domain enforcement
        end
    end
    JwtFilter->>JwtFilter: validateBotToken / validatePersonalAccessToken
    JwtFilter-->>Client: set SecurityContext or throw AuthenticationException
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Client
    participant JwtFilter
    participant JWTTokenGenerator
    participant SecurityUtil
    participant validateDomainEnforcement

    Client->>JwtFilter: HTTP request (Authorization: Bearer token)
    JwtFilter->>JwtFilter: extractToken()
    JwtFilter->>JwtFilter: decodeAndVerify(token) — decode, check expiry, verify signature
    JwtFilter->>JwtFilter: extractClaims(decodedJwt) → claims
    JwtFilter->>JwtFilter: "tokenKeyId = decodedJwt.getKeyId()"
    JwtFilter->>JwtFilter: checkValidationsForToken(claims, token, tokenKeyId, ...)
    JwtFilter->>JwtFilter: validateTokenIsNotUsedAfterLogout(token)
    alt "enforcePrincipalDomain == true"
        JwtFilter->>JWTTokenGenerator: getInstance().getIssuer() / getKid()
        JWTTokenGenerator-->>JwtFilter: omIssuer, omKid
        JwtFilter->>SecurityUtil: isOpenMetadataIssuedToken(claims, tokenKeyId, omIssuer, omKid)
        SecurityUtil-->>JwtFilter: true (OM-issued) or false (external IdP)
        alt "isInternallyIssuedToken == false"
            JwtFilter->>validateDomainEnforcement: validateDomainEnforcement(...)
            validateDomainEnforcement-->>JwtFilter: OK or AuthenticationException
        else "isInternallyIssuedToken == true"
            JwtFilter->>JwtFilter: skip domain enforcement
        end
    end
    JwtFilter->>JwtFilter: validateBotToken / validatePersonalAccessToken
    JwtFilter-->>Client: set SecurityContext or throw AuthenticationException
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: bypass domain enforcement for OM-in..."](https://github.com/open-metadata/openmetadata/commit/946e756b0e68b00dae19c1c9c45e514137379bba) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40387770)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->