### PR TITLE
fix(tests): stabilise flaky SettingsNavigationPage and LineageFilters Playwright tests

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/SettingsNavigationPage.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/SettingsNavigationPage.spec.ts
@@ -364,25 +364,27 @@ test.describe.serial('Settings Navigation Page Tests', () => {
     // Default order renders Data Quality above Incident Manager
     expect(await isDataQualityBelowIncidentManager()).toBe(false);
 
-    const dataQualityBox = await dataQualityItem.boundingBox();
-    const incidentManagerBox = await incidentManagerItem.boundingBox();
+    // Drag Data Quality just below Incident Manager, retrying until the tree reorders
+    await expect(async () => {
+      const dataQualityBox = await dataQualityItem.boundingBox();
+      const incidentManagerBox = await incidentManagerItem.boundingBox();
 
-    expect(dataQualityBox).not.toBeNull();
-    expect(incidentManagerBox).not.toBeNull();
+      expect(dataQualityBox).not.toBeNull();
+      expect(incidentManagerBox).not.toBeNull();
 
-    // Drag Data Quality just below Incident Manager to reorder within the group
-    await dataQualityItem.dragTo(incidentManagerItem, {
-      sourcePosition: {
-        x: (dataQualityBox?.width ?? 0) / 2,
-        y: (dataQualityBox?.height ?? 0) / 2,
-      },
-      targetPosition: {
-        x: (incidentManagerBox?.width ?? 0) / 2,
-        y: (incidentManagerBox?.height ?? 0) / 2 + 10,
-      },
-    });
+      await dataQualityItem.dragTo(incidentManagerItem, {
+        sourcePosition: {
+          x: (dataQualityBox?.width ?? 0) / 2,
+          y: (dataQualityBox?.height ?? 0) / 2,
+        },
+        targetPosition: {
+          x: (incidentManagerBox?.width ?? 0) / 2,
+          y: (incidentManagerBox?.height ?? 0) / 2 + 10,
+        },
+      });
 
-    await expect.poll(isDataQualityBelowIncidentManager).toBe(true);
+      expect(await isDataQualityBelowIncidentManager()).toBe(true);
+    }).toPass({ timeout: 30_000 });
     await expect(page.getByTestId('save-button')).toBeEnabled();
 
     const saveResponse = page.waitForResponse(

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/Lineage/LineageFilters.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/Lineage/LineageFilters.spec.ts
@@ -978,7 +978,7 @@ test.describe('Lineage Filters', () => {
     });
 
     test('verify upstream count for all the entities', async ({ page }) => {
-      test.slow();
+      test.setTimeout(360_000);
 
       // Verify Dashboard is visible in Impact Analysis for Upstream
       await page.getByRole('button', { name: 'Upstream' }).click();


### PR DESCRIPTION
### Describe your changes:

I worked on stabilising two flaky Playwright tests that consistently failed in nightly CI runs.

**SettingsNavigationPage** (`should persist a reordered sub-item after reload`): The single `dragTo` on the Ant Design tree is unreliable — the tree doesn't always reorder on the first attempt. Wrapped the drag + position-check in `expect(async () => { ... }).toPass({ timeout: 30_000 })` so it retries until the tree reorders, matching the pattern already used in the adjacent `should reflect a sub-item moved to another group` test. Bounding boxes are now re-fetched inside the loop so stale coordinates from a partial drag don't block subsequent retries.

**LineageFilters** (`verify upstream count for all the entities`): The test uses `test.slow()` (3× → 180 s), but the loop visits 14 entities each requiring multiple page navigations (~14 × 13 s ≈ 182 s+), consistently exceeding the budget. Playwright closes the browser at timeout, surfacing as `locator.click: Target page, context or browser has been closed`. Replaced `test.slow()` with `test.setTimeout(360_000)` (6 min) to give the loop sufficient headroom.

#
### Type of change:
- [x] Bug fix

#
### High-level design:

N/A — small change.

#
### Tests:

#### Use cases covered
- `SettingsNavigationPage` — drag-and-drop reorder now retries until the Ant Design tree reflects the new order, preventing single-attempt flakiness
- `LineageFilters` — upstream count verification now has a 6-minute timeout, matching the actual wall time needed to iterate 14 entity types

#### Unit tests
- [ ] Not applicable (test-only change, no production logic changed).

#### Backend integration tests
- [x] Not applicable (no backend API changes).

#### Ingestion integration tests
- [x] Not applicable (no ingestion changes).

#### Playwright (UI) tests
- [x] Modified existing Playwright E2E tests under `openmetadata-ui/.../ui/playwright/`
- Files updated:
  - `playwright/e2e/Features/SettingsNavigationPage.spec.ts`
  - `playwright/e2e/Pages/Lineage/LineageFilters.spec.ts`

#### Manual testing performed
Verified root causes against the CI trace from https://github.com/open-metadata/openmetadata-nightly/actions/runs/28341638087 — both failures were reproducible from the logs and the fixes address the confirmed root causes.

#
### UI screen recording / screenshots:

Not applicable.

#
### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.
- [ ] For UI changes: I attached a screen recording and/or screenshots above.
- [x] I have added tests (unit / integration / Playwright as applicable) and listed them above.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR stabilises two flaky Playwright E2E tests by addressing their confirmed root causes: a non-retrying drag-and-drop in the settings tree, and a timeout budget that was too tight for a 14-entity loop.

- **SettingsNavigationPage** (`should persist a reordered sub-item after reload`): The single `dragTo` call is now wrapped in `expect(async () => { … }).toPass({ timeout: 30_000 })`, re-fetching bounding boxes on each attempt so stale coordinates from a partial drag don't block retries. This matches the pattern already used in the adjacent `should reflect a sub-item moved to another group` test.
- **LineageFilters** (`verify upstream count for all the entities`): `test.slow()` (3 × 60 s = 180 s) is replaced with `test.setTimeout(360_000)` (6 min), giving the 14-entity iteration loop enough headroom instead of consistently racing past the 180 s wall.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Both changes are minimal, test-only, and target confirmed root causes from CI traces — safe to merge.

The drag retry is correctly scoped inside toPass with re-fetched coordinates, and the explicit 6-minute timeout matches the measured wall time for the entity loop. No production code is touched and the approach follows patterns already established in the test suite.

No files require special attention.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/SettingsNavigationPage.spec.ts | Wraps the flaky single-attempt dragTo in expect().toPass({ timeout: 30_000 }), re-fetching bounding boxes on each retry to avoid stale coordinates; correct and matches the established pattern in this file |
| openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/Lineage/LineageFilters.spec.ts | Replaces test.slow() (180 s cap) with test.setTimeout(360_000) (6 min) to give the 14-entity loop sufficient headroom; straightforward and well-targeted fix |

</details>

<details open><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Start drag-and-drop reorder] --> B[Fetch bounding boxes\nfor dataQuality + incidentManager]
    B --> C{Boxes non-null?}
    C -- No --> E[throw → toPass retries]
    C -- Yes --> D[dragTo incidentManager\nwith re-fetched coordinates]
    D --> F{isDataQualityBelowIncidentManager?}
    F -- false, throw --> G[toPass retries\nup to 30 s]
    G --> B
    F -- true, pass --> H[toPass exits]
    H --> I[Check save-button enabled]
    I --> J[Click save, await API response]
    J --> K[Reload page, verify order persists]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Start drag-and-drop reorder] --> B[Fetch bounding boxes\nfor dataQuality + incidentManager]
    B --> C{Boxes non-null?}
    C -- No --> E[throw → toPass retries]
    C -- Yes --> D[dragTo incidentManager\nwith re-fetched coordinates]
    D --> F{isDataQualityBelowIncidentManager?}
    F -- false, throw --> G[toPass retries\nup to 30 s]
    G --> B
    F -- true, pass --> H[toPass exits]
    H --> I[Check save-button enabled]
    I --> J[Click save, await API response]
    J --> K[Reload page, verify order persists]
```

</a>
</details>

<sub>Reviews (2): Last reviewed commit: ["Merge branch &#39;main&#39; into fix-flaky-setti..."](https://github.com/open-metadata/openmetadata/commit/94a99a3f72eefe1eca4d9e1094a042c5099caf88) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40456794)</sub>

<!-- /greptile_comment -->