### PR TITLE
Fixed global search suggestion test

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/GlobalSearchSuggestions.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/GlobalSearchSuggestions.spec.ts
@@ -33,7 +33,7 @@ test.describe('Global Search Column Suggestions', () => {
   });
 
   test.beforeEach(async ({ page }) => {
-    await redirectToHomePage(page);
+    await redirectToHomePage(page, true);
   });
 
   test('Navigate to column from column suggestion', async ({ page }) => {

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/GlobalSearchSuggestions.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/GlobalSearchSuggestions.spec.ts
@@ -33,7 +33,8 @@ test.describe('Global Search Column Suggestions', () => {
   });
 
   test.beforeEach(async ({ page }) => {
-    await redirectToHomePage(page, true);
+    await redirectToHomePage(page);
+    await page.waitForLoadState('domcontentloaded');
   });
 
   test('Navigate to column from column suggestion', async ({ page }) => {
@@ -44,9 +45,17 @@ test.describe('Global Search Column Suggestions', () => {
     const searchInput = page.getByTestId('searchBox');
     await searchInput.click();
 
+    // Set up the response waiter before typing so we don't miss it.
+    // Filter to only the request that actually carries the typed query,
+    // because the 400ms debounce can fire an earlier request with an empty string.
+    const suggestionsRes = page.waitForResponse(
+      (response) =>
+        response.url().includes('/api/v1/search/query') &&
+        response.url().includes(encodeURIComponent(columnName))
+    );
+
     await searchInput.fill(columnName);
 
-    const suggestionsRes = page.waitForResponse('/api/v1/search/query?*');
     await suggestionsRes;
 
     const suggestionsContainer = page.locator(


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:

Fixes #<issue-number>
<!--
Linking an issue is REQUIRED. Replace <issue-number> with the GitHub issue number this PR addresses
(e.g., `Fixes #12345`). GitHub will auto-link it. If no issue exists, please open one first so the
problem and design can be discussed before review.
-->

<!--
Short blurb explaining:
- What changes did you make?
- Why did you make them?
-->

I worked on ... because ...

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### High-level design:
<!--
REQUIRED for large PRs (new features, refactors, breaking changes, or anything touching >5 files).
Skip for small bug fixes and trivial changes.

Cover:
- Architecture / approach you took and why
- Key components or files added/changed and how they interact
- Alternatives considered and why you rejected them
- Any migration, backward-compatibility, or rollout concerns
- Diagrams or links to design docs / RFCs if available
-->

N/A — small change. <!-- Or fill in the design above -->

#
### Tests:

#### Use cases covered
<!--
List the user-visible scenarios this PR exercises. Example:
- User with Admin role can create a Glossary Term with a parent term
- Ingestion run for Snowflake correctly extracts row counts for partitioned tables
-->

#### Unit tests
<!--
- [ ] I added unit tests for the new/changed logic.
- Files added/updated:
- Coverage on changed classes (run `mvn jacoco:report` for backend, `yarn test:coverage` for UI,
  `make unit_ingestion` for ingestion). Target is 90% line coverage on changed classes.
- Coverage %: <e.g., 92% on EntityRepository.java>
-->

#### Backend integration tests
<!--
- [ ] I added integration tests in `openmetadata-integration-tests/` for new/changed API endpoints.
- [ ] Not applicable (no backend API changes).
- Files added/updated:
-->

#### Ingestion integration tests
<!--
- [ ] I added/updated ingestion integration tests for connector changes.
- [ ] Not applicable (no ingestion changes).
- Files added/updated:
-->

#### Playwright (UI) tests
<!--
- [ ] I added Playwright E2E tests under `openmetadata-ui/.../ui/playwright/` for UI changes.
- [ ] Not applicable (no UI changes).
- Files added/updated:
-->

#### Manual testing performed
<!--
List the manual test steps you performed before requesting review. Example:
1. Started local stack via `./docker/run_local_docker.sh -m ui -d mysql`
2. Logged in as admin, created entity X, verified Y appears in the UI
3. Triggered ingestion for Snowflake source, confirmed lineage edges in the explore page
-->

#
### UI screen recording / screenshots:
<!--
REQUIRED for any PR that changes the UI. Drag-and-drop a short screen recording (.mov / .mp4 / .gif)
demonstrating the change end-to-end, plus before/after screenshots where relevant.
Mark "Not applicable" if there are no UI changes.
-->

Not applicable. <!-- Or attach recording/screenshots above -->

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.
- [ ] For UI changes: I attached a screen recording and/or screenshots above.
- [ ] I have added tests (unit / integration / Playwright as applicable) and listed them above.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->



----
## Summary by Gitar

- **Test stability improvements:**
  - Added `page.waitForLoadState('domcontentloaded')` in `beforeEach` to ensure page readiness.
  - Moved `page.waitForResponse` before `searchInput.fill` to resolve a race condition where the request could complete before the listener was registered.
  - Updated the response filter to check for the search query, preventing premature resolution due to debounced requests with empty strings.

<sub>This will update automatically on new commits.</sub>

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a race condition in the `GlobalSearchSuggestions` Playwright test where `page.waitForResponse(...)` was registered *after* the `fill` call that triggers the search request, meaning the response could arrive before the listener was attached.

- Moves `page.waitForResponse(...)` to before `searchInput.fill(columnName)`, eliminating the race condition.
- Narrows the response filter from a broad glob (`/api/v1/search/query?*`) to a predicate that checks for the encoded column name in the URL, avoiding false positives from the debounced empty-string request.
- Adds `await page.waitForLoadState('domcontentloaded')` in `beforeEach` after `redirectToHomePage`.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — test-only change that correctly reorders listener registration relative to the triggering action.

The change is confined to a single Playwright spec file. Moving `waitForResponse` before the `fill` call is the correct fix for the documented flakiness, and narrowing the URL predicate to include the encoded column name avoids matching spurious debounce requests. The extra `waitForLoadState('domcontentloaded')` in `beforeEach` is redundant but harmless.

No files require special attention.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/GlobalSearchSuggestions.spec.ts | Fixes a `waitForResponse` race condition by registering the listener before the triggering action and tightens the URL predicate to match only the relevant response. |

</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Test
    participant Playwright
    participant Browser
    participant API

    Note over Test,API: Before fix (race condition)
    Test->>Browser: searchInput.fill(columnName)
    Browser->>API: "GET /api/v1/search/query?q=..."
    API-->>Browser: 200 response
    Test->>Playwright: waitForResponse(...) too late
    Note over Test: hangs until timeout

    Note over Test,API: After fix (correct order)
    Test->>Playwright: waitForResponse(url includes columnName)
    Test->>Browser: searchInput.fill(columnName)
    Browser->>API: "GET /api/v1/search/query?q=columnName"
    API-->>Browser: 200 response
    Playwright-->>Test: response resolved
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Test
    participant Playwright
    participant Browser
    participant API

    Note over Test,API: Before fix (race condition)
    Test->>Browser: searchInput.fill(columnName)
    Browser->>API: "GET /api/v1/search/query?q=..."
    API-->>Browser: 200 response
    Test->>Playwright: waitForResponse(...) too late
    Note over Test: hangs until timeout

    Note over Test,API: After fix (correct order)
    Test->>Playwright: waitForResponse(url includes columnName)
    Test->>Browser: searchInput.fill(columnName)
    Browser->>API: "GET /api/v1/search/query?q=columnName"
    API-->>Browser: 200 response
    Playwright-->>Test: response resolved
```

</a>
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/GlobalSearchSuggestions.spec.ts`, line 49-50 ([link](https://github.com/open-metadata/openmetadata/blob/c4f3cd8ff2ff7fae98c838824fdf203ec4d1dc14/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/GlobalSearchSuggestions.spec.ts#L49-L50)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Race condition: `waitForResponse` registered after the action that triggers it**

   `page.waitForResponse(...)` must be set up *before* the action that fires the request, otherwise the response can arrive before the listener is attached and the `await` will hang until timeout. Here the listener is created after `searchInput.fill(columnName)` already triggers the debounce/search call. Move `const suggestionsRes = page.waitForResponse(...)` to before the `fill` call to avoid this flakiness. (This is a pre-existing issue, not introduced by this PR.)
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["minor fix"](https://github.com/open-metadata/openmetadata/commit/547605240f40adbd77e0ed6f160f0e1d5b844cbe) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40461966)</sub>

<!-- /greptile_comment -->