### PR TITLE
Fix test suite tab loading race

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/TestSuite.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/TestSuite.spec.ts
@@ -10,9 +10,10 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-import { expect } from '@playwright/test';
+import { expect, Route } from '@playwright/test';
 import { PLAYWRIGHT_INGESTION_TAG_OBJ } from '../../constant/config';
 import { Domain } from '../../support/domain/Domain';
+import { BundleTestSuiteClass } from '../../support/entity/BundleTestSuiteClass';
 import { EntityTypeEndpoint } from '../../support/entity/Entity.interface';
 import { TableClass } from '../../support/entity/TableClass';
 import { UserClass } from '../../support/user/UserClass';
@@ -50,6 +51,16 @@ const user1 = new UserClass();
 const user2 = new UserClass();
 const domain1 = new Domain();
 const domain2 = new Domain();
+const bundleTestSuite = new BundleTestSuiteClass();
+
+const createDeferred = () => {
+  let resolveDeferred: () => void = () => undefined;
+  const promise = new Promise<void>((resolve) => {
+    resolveDeferred = resolve;
+  });
+
+  return { promise, resolve: resolveDeferred };
+};
 
 test.beforeAll(async ({ browser }) => {
   const { apiContext, afterAction } = await performAdminLogin(browser);
@@ -60,11 +71,81 @@ test.beforeAll(async ({ browser }) => {
   await table.createTestCase(apiContext);
   await domain1.create(apiContext);
   await domain2.create(apiContext);
+  await bundleTestSuite.createBundleTestSuite(apiContext);
   await afterAction();
+});
+
+test.afterAll(async ({ browser }) => {
+  const bundleSuiteName = bundleTestSuite.bundleTestSuiteResponseData?.name;
+
+  if (bundleSuiteName) {
+    const { apiContext, afterAction } = await performAdminLogin(browser);
+    await apiContext.delete(
+      `/api/v1/dataQuality/testSuites/name/${encodeURIComponent(
+        bundleSuiteName
+      )}?hardDelete=true&recursive=true`
+    );
+    await afterAction();
+  }
 });
 
 test.beforeEach(async ({ page }) => {
   await redirectToHomePage(page);
+});
+
+test('Test suite tab switching keeps active bundle suite data after stale table suite response', async ({
+  page,
+}) => {
+  const bundleSuiteName =
+    bundleTestSuite.bundleTestSuiteResponseData?.name ?? '';
+  const tableFqn = table.entityResponseData?.fullyQualifiedName ?? '';
+  const tableSuiteRequestReceived = createDeferred();
+  const tableSuiteResponseRelease = createDeferred();
+  const tableSuiteResponseFulfilled = createDeferred();
+
+  expect(bundleSuiteName).not.toBe('');
+  expect(tableFqn).not.toBe('');
+
+  await page.route(
+    '**/api/v1/dataQuality/testSuites/search/list**',
+    async (route: Route) => {
+      const requestUrl = new URL(route.request().url());
+      const testSuiteType = requestUrl.searchParams.get('testSuiteType');
+
+      if (testSuiteType === 'basic') {
+        tableSuiteRequestReceived.resolve();
+        const tableSuiteResponse = await route.fetch();
+        await tableSuiteResponseRelease.promise;
+
+        await route.fulfill({
+          response: tableSuiteResponse,
+        });
+        tableSuiteResponseFulfilled.resolve();
+
+        return;
+      }
+
+      await route.continue();
+    }
+  );
+
+  await page.goto('/data-quality/test-suites/table-suites');
+  await tableSuiteRequestReceived.promise;
+
+  await expect(page.getByTestId('test-suite-table')).toBeVisible();
+  await expect(page.getByTestId('loader')).toBeVisible();
+
+  await page.getByTestId('bundle-suite-radio-btn').click();
+
+  await expect(page.getByTestId(bundleSuiteName)).toBeVisible();
+
+  tableSuiteResponseRelease.resolve();
+  await tableSuiteResponseFulfilled.promise;
+
+  await expect(page.getByTestId(bundleSuiteName)).toBeVisible();
+  await expect(
+    page.getByTestId('test-suite-table').getByText(tableFqn)
+  ).not.toBeVisible();
 });
 
 test(

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/TestSuite/TestSuiteList/TestSuites.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/TestSuite/TestSuiteList/TestSuites.component.tsx
@@ -19,7 +19,7 @@ import { Col, Form, Row, Select, Space, Typography } from 'antd';
 import { AxiosError } from 'axios';
 import { isEmpty } from 'lodash';
 import QueryString from 'qs';
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { SortDescriptor } from 'react-aria-components';
 import { useTranslation } from 'react-i18next';
 import { Link, useNavigate, useParams } from 'react-router-dom';
@@ -59,6 +59,7 @@ import { getEntityDetailsPath } from '../../../../utils/RouterUtils';
 import { showErrorToast } from '../../../../utils/ToastUtils';
 import ErrorPlaceHolder from '../../../common/ErrorWithPlaceholder/ErrorPlaceHolder';
 import FilterTablePlaceHolder from '../../../common/ErrorWithPlaceholder/FilterTablePlaceHolder';
+import Loader from '../../../common/Loader/Loader';
 import NextPrevious from '../../../common/NextPrevious/NextPrevious';
 import { PagingHandlerParams } from '../../../common/NextPrevious/NextPrevious.interface';
 import { OwnerLabel } from '../../../common/OwnerLabel/OwnerLabel.component';
@@ -116,6 +117,7 @@ export const TestSuites = () => {
   } = usePaging();
 
   const [isLoading, setIsLoading] = useState<boolean>(true);
+  const latestRequestId = useRef(0);
 
   const ownerFilterValue = useMemo(() => {
     return selectedOwner
@@ -155,41 +157,55 @@ export const TestSuites = () => {
     });
   }, [testSuites, sortDescriptor]);
 
-  const fetchTestSuites = async (
-    currentPage = INITIAL_PAGING_VALUE,
-    params?: ListTestSuitePramsBySearch
-  ) => {
-    setIsLoading(true);
-    try {
-      const result = await getListTestSuitesBySearch({
-        ...params,
-        fields: [TabSpecificField.OWNERS, TabSpecificField.SUMMARY],
-        q: searchValue ? `*${searchValue}*` : undefined,
-        owner: ownerFilterValue?.key,
-        offset: (currentPage - 1) * pageSize,
-        includeEmptyTestSuites: subTab !== DataQualitySubTabs.TABLE_SUITES,
-        testSuiteType:
-          subTab === DataQualitySubTabs.TABLE_SUITES
-            ? TestSuiteType.basic
-            : TestSuiteType.logical,
-        sortField: 'lastResultTimestamp',
-        sortType: SORT_ORDER.DESC,
-      });
-      setTestSuites(result.data);
-      handlePagingChange(result.paging);
-    } catch (error) {
-      showErrorToast(error as AxiosError);
-    } finally {
-      setIsLoading(false);
-    }
-  };
+  const fetchTestSuites = useCallback(
+    async (
+      currentPage = INITIAL_PAGING_VALUE,
+      params?: ListTestSuitePramsBySearch
+    ) => {
+      const requestId = latestRequestId.current + 1;
+      latestRequestId.current = requestId;
+
+      setIsLoading(true);
+      try {
+        const result = await getListTestSuitesBySearch({
+          ...params,
+          fields: [TabSpecificField.OWNERS, TabSpecificField.SUMMARY],
+          q: searchValue ? `*${searchValue}*` : undefined,
+          owner: ownerFilterValue?.key,
+          offset: (currentPage - 1) * pageSize,
+          includeEmptyTestSuites: subTab !== DataQualitySubTabs.TABLE_SUITES,
+          testSuiteType:
+            subTab === DataQualitySubTabs.TABLE_SUITES
+              ? TestSuiteType.basic
+              : TestSuiteType.logical,
+          sortField: 'lastResultTimestamp',
+          sortType: SORT_ORDER.DESC,
+        });
+        if (requestId !== latestRequestId.current) {
+          return;
+        }
+
+        setTestSuites(result.data);
+        handlePagingChange(result.paging);
+      } catch (error) {
+        if (requestId === latestRequestId.current) {
+          showErrorToast(error as AxiosError);
+        }
+      } finally {
+        if (requestId === latestRequestId.current) {
+          setIsLoading(false);
+        }
+      }
+    },
+    [searchValue, ownerFilterValue?.key, pageSize, subTab, handlePagingChange]
+  );
 
   const handleTestSuitesPageChange = useCallback(
     ({ currentPage }: PagingHandlerParams) => {
       fetchTestSuites(currentPage, { limit: pageSize });
       handlePageChange(currentPage);
     },
-    [pageSize, handlePageChange]
+    [fetchTestSuites, pageSize, handlePageChange]
   );
 
   const handleSearchParam = (
@@ -315,7 +331,15 @@ export const TestSuites = () => {
     } else {
       setIsLoading(false);
     }
-  }, [testSuitePermission, pageSize, searchValue, owner, subTab, currentPage]);
+  }, [
+    testSuitePermission,
+    pageSize,
+    searchValue,
+    owner,
+    subTab,
+    currentPage,
+    fetchTestSuites,
+  ]);
 
   if (!testSuitePermission?.ViewAll && !testSuitePermission?.ViewBasic) {
     return (
@@ -417,7 +441,15 @@ export const TestSuites = () => {
             </Table.Header>
             <Table.Body
               items={isLoading ? [] : sortedData}
-              renderEmptyState={() => (isLoading ? <></> : noDataPlaceholder)}>
+              renderEmptyState={() =>
+                isLoading ? (
+                  <div className="tw:flex tw:justify-center tw:p-8">
+                    <Loader />
+                  </div>
+                ) : (
+                  noDataPlaceholder
+                )
+              }>
               {(record) => renderRow(record as TestSuite)}
             </Table.Body>
           </Table>

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/TestSuite/TestSuiteList/TestSuites.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/TestSuite/TestSuiteList/TestSuites.test.tsx
@@ -11,8 +11,11 @@
  *  limitations under the License.
  */
 import { act, fireEvent, render, screen } from '@testing-library/react';
-import { MemoryRouter, useNavigate } from 'react-router-dom';
-import { DataQualityPageTabs } from '../../../../pages/DataQuality/DataQualityPage.interface';
+import { MemoryRouter, useNavigate, useParams } from 'react-router-dom';
+import {
+  DataQualityPageTabs,
+  DataQualitySubTabs,
+} from '../../../../pages/DataQuality/DataQualityPage.interface';
 import { getListTestSuitesBySearch } from '../../../../rest/testAPI';
 import observabilityRouterClassBase from '../../../../utils/ObservabilityRouterClassBase';
 import { TestSuites } from './TestSuites.component';
@@ -140,9 +143,13 @@ jest.mock('@openmetadata/ui-core-components', () => {
     dependencies?: unknown[];
   }) => (
     <tbody>
-      {items && items.length > 0
-        ? items.map((item) => children(item))
-        : renderEmptyState?.()}
+      {items && items.length > 0 ? (
+        items.map((item) => children(item))
+      ) : (
+        <tr>
+          <td colSpan={4}>{renderEmptyState?.()}</td>
+        </tr>
+      )}
     </tbody>
   );
 
@@ -257,6 +264,10 @@ jest.mock('../../../common/NextPrevious/NextPrevious', () => {
   return jest.fn().mockImplementation(() => <div>NextPrevious.component</div>);
 });
 
+jest.mock('../../../common/Loader/Loader', () =>
+  jest.fn().mockImplementation(() => <div data-testid="loader">Loader</div>)
+);
+
 jest.mock('../../../../utils/ObservabilityRouterClassBase', () => ({
   __esModule: true,
   default: {
@@ -351,6 +362,10 @@ describe('TestSuites component', () => {
     jest.clearAllMocks();
     testSuitePermission.ViewAll = true;
     mockLocation.search = '';
+    (useParams as jest.Mock).mockReturnValue({
+      tab: 'test-cases',
+      subTab: 'table-suites',
+    });
   });
 
   it('component should render', async () => {
@@ -526,6 +541,77 @@ describe('TestSuites component', () => {
     expect(
       await screen.findByTestId('filter-table-placeholder')
     ).toBeInTheDocument();
+  });
+
+  it('should render loader while test suites are loading', async () => {
+    (getListTestSuitesBySearch as jest.Mock).mockImplementationOnce(
+      () => new Promise(() => undefined)
+    );
+
+    render(<TestSuites />);
+
+    expect(await screen.findByTestId('loader')).toBeInTheDocument();
+    expect(
+      screen.queryByTestId('filter-table-placeholder')
+    ).not.toBeInTheDocument();
+  });
+
+  it('should ignore stale table suite response after switching to bundle suites', async () => {
+    let resolveTableSuites: (value: typeof mockList) => void;
+    let resolveBundleSuites: (value: typeof mockList) => void;
+    const tableSuitesResponse = new Promise<typeof mockList>((resolve) => {
+      resolveTableSuites = resolve;
+    });
+    const bundleSuitesResponse = new Promise<typeof mockList>((resolve) => {
+      resolveBundleSuites = resolve;
+    });
+    const bundleSuiteName = 'bundle.suite';
+
+    (getListTestSuitesBySearch as jest.Mock)
+      .mockImplementationOnce(() => tableSuitesResponse)
+      .mockImplementationOnce(() => bundleSuitesResponse);
+
+    const { rerender } = render(<TestSuites />);
+
+    expect(await screen.findByTestId('loader')).toBeInTheDocument();
+
+    (useParams as jest.Mock).mockReturnValue({
+      tab: DataQualityPageTabs.TEST_CASES,
+      subTab: DataQualitySubTabs.BUNDLE_SUITES,
+    });
+
+    rerender(<TestSuites />);
+
+    await act(async () => {
+      resolveBundleSuites({
+        data: [
+          {
+            id: 'bundle-id',
+            name: bundleSuiteName,
+            fullyQualifiedName: bundleSuiteName,
+            basic: false,
+          },
+        ],
+        paging: {
+          offset: 0,
+          limit: 15,
+          total: 1,
+        },
+      });
+    });
+
+    expect(await screen.findByTestId(bundleSuiteName)).toBeInTheDocument();
+
+    await act(async () => {
+      resolveTableSuites(mockList);
+    });
+
+    expect(screen.getByTestId(bundleSuiteName)).toBeInTheDocument();
+    expect(
+      screen.queryByTestId(
+        'sample_data.ecommerce_db.shopify.dim_address.testSuite'
+      )
+    ).not.toBeInTheDocument();
   });
 
   it('should not render pagination when showPagination is false', async () => {


### PR DESCRIPTION
### Description
- Show a loader while the test suite list request is in flight.
- Ignore stale test suite list responses when switching between table suites and bundle suites.
- Add unit coverage and an existing-spec E2E regression for the tab switching race.

### Tests
- `./node_modules/.bin/jest src/components/DataQuality/TestSuite/TestSuiteList/TestSuites.test.tsx --runInBand`
- UI checkstyle sequence on changed UI and Playwright files
- Targeted Playwright TypeScript check for `Pages/TestSuite.spec.ts`
- `git diff --check`

Fixes open-metadata/openmetadata-collate#4741

https://github.com/user-attachments/assets/bdf95b70-1662-4de8-8b9b-a1b4043297ad

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a race condition in the TestSuites component where switching between table suites and bundle suites could cause a stale API response to overwrite the newly loaded data. The fix uses an incrementing request-ID ref (`latestRequestId`) to discard out-of-order responses, and adds an inline `Loader` to the table body while data is in flight.

- **Race fix**: `fetchTestSuites` now stamps each call with a monotonically incrementing ID and short-circuits state updates in `try`/`catch`/`finally` if the request is no longer current, so a delayed table-suite response can never replace bundle-suite data.
- **UX improvement**: `isLoading` is set to `true` at the start of every fetch, forcing `Table.Body` to render the empty-state slot with a `Loader` spinner rather than stale rows.
- **Test coverage**: A new Jest unit test validates both the loader-visible and stale-response-ignored cases; a new Playwright E2E test intercepts the table-suite network request, holds it open while the user switches tabs, then releases it to confirm no regression.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is a targeted, well-tested fix for a UI race condition with no effect on data persistence or API contracts.

The monotonic request-ID pattern is correct and idiomatic: each fetch captures its own ID before any await, the ref is updated synchronously, and all three outcome branches guard against stale updates. Both unit tests and the E2E test reproduce the exact race sequence from the bug report. No regressions are introduced in unrelated code paths.

No files require special attention.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-ui/src/main/resources/ui/src/components/DataQuality/TestSuite/TestSuiteList/TestSuites.component.tsx | Core race-condition fix: replaces a plain async function with a useCallback that stamps each fetch with a monotonic ID, discards stale responses, and renders a Loader while in-flight. Logic is sound and deps arrays are correctly updated. |
| openmetadata-ui/src/main/resources/ui/src/components/DataQuality/TestSuite/TestSuiteList/TestSuites.test.tsx | Adds two focused unit tests: loader visibility while the API promise is pending, and stale-response suppression after switching tabs. Mock structure updated to render renderEmptyState inside a table cell so the loader renders correctly in JSDOM. |
| openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/TestSuite.spec.ts | New E2E test intercepts the table-suite request with a deferred promise, holds the response while the user switches to bundle suites, then verifies the bundle data survives the late table-suite response. BundleTestSuiteClass is added and properly cleaned up in afterAll. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant U as User
    participant C as TestSuites Component
    participant API as API (getListTestSuitesBySearch)

    Note over C: latestRequestId.current = 0

    U->>C: Navigate to Table Suites tab
    C->>C: "requestId=1, latestRequestId=1, setIsLoading(true)"
    C->>API: "fetch(testSuiteType=basic)"

    Note over API: Response delayed…

    U->>C: Switch to Bundle Suites tab
    C->>C: "requestId=2, latestRequestId=2, setIsLoading(true)"
    C->>API: "fetch(testSuiteType=logical)"

    API-->>C: "Bundle suites response (requestId=2)"
    C->>C: "2 === latestRequestId(2) ✓ setTestSuites(bundleData), setIsLoading(false)"

    API-->>C: "Stale table suites response (requestId=1)"
    C->>C: 1 ≠ latestRequestId(2) → DISCARD (no state update)
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant U as User
    participant C as TestSuites Component
    participant API as API (getListTestSuitesBySearch)

    Note over C: latestRequestId.current = 0

    U->>C: Navigate to Table Suites tab
    C->>C: "requestId=1, latestRequestId=1, setIsLoading(true)"
    C->>API: "fetch(testSuiteType=basic)"

    Note over API: Response delayed…

    U->>C: Switch to Bundle Suites tab
    C->>C: "requestId=2, latestRequestId=2, setIsLoading(true)"
    C->>API: "fetch(testSuiteType=logical)"

    API-->>C: "Bundle suites response (requestId=2)"
    C->>C: "2 === latestRequestId(2) ✓ setTestSuites(bundleData), setIsLoading(false)"

    API-->>C: "Stale table suites response (requestId=1)"
    C->>C: 1 ≠ latestRequestId(2) → DISCARD (no state update)
```

</a>
</details>

<sub>Reviews (4): Last reviewed commit: ["Merge branch &#39;main&#39; into codex/test-suit..."](https://github.com/open-metadata/openmetadata/commit/55cb4cf75750ca4e0c28dc70d614996d17a9533b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40470493)</sub>

<!-- /greptile_comment -->