### PR TITLE
fix(ui): modal footer styling and button alignment

### DIFF
--- a/openmetadata-ui-core-components/src/main/resources/ui/src/components/application/modals/modal.tsx
+++ b/openmetadata-ui-core-components/src/main/resources/ui/src/components/application/modals/modal.tsx
@@ -96,10 +96,11 @@ interface DialogFooterProps {
 
 const DialogFooter = ({ children, className }: DialogFooterProps) => (
   <div
-    className={cx('tw:z-10 tw:pt-6 tw:pb-4 tw:sm:pt-8 tw:sm:pb-6', className)}>
-    <div className="tw:w-full tw:border-t tw:border-secondary" />
-    <div className="tw:h-4 tw:w-full tw:sm:h-6" />
-    <div className="tw:flex tw:flex-1 tw:flex-col-reverse tw:gap-3 tw:sm:grid tw:sm:grid-cols-2 tw:sm:px-6 tw:px-4">
+    className={cx(
+      'tw:z-10 tw:mt-6 tw:sm:mt-8 tw:border-t tw:border-secondary',
+      className
+    )}>
+    <div className="tw:flex tw:flex-1 tw:gap-3 tw:sm:px-6 tw:px-4 tw:py-4 tw:justify-end">
       {children}
     </div>
   </div>


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:

Fixes #<issue-number>

1. Unwanted gap between footer and buttons 
2. Fix button styling from occupying full width to required one

<!--
Linking an issue is REQUIRED. Replace <issue-number> with the GitHub issue number this PR addresses
(e.g., `Fixes #12345`). GitHub will auto-link it. If no issue exists, please open one first so the
problem and design can be discussed before review.
-->

https://github.com/user-attachments/assets/1d330044-8441-4b6d-925c-b55db8c93666


<!--
Short blurb explaining:
- What changes did you make?
- Why did you make them?
-->

I worked on ... because ...

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### High-level design:
<!--
REQUIRED for large PRs (new features, refactors, breaking changes, or anything touching >5 files).
Skip for small bug fixes and trivial changes.

Cover:
- Architecture / approach you took and why
- Key components or files added/changed and how they interact
- Alternatives considered and why you rejected them
- Any migration, backward-compatibility, or rollout concerns
- Diagrams or links to design docs / RFCs if available
-->

N/A — small change. <!-- Or fill in the design above -->

#
### Tests:

#### Use cases covered
<!--
List the user-visible scenarios this PR exercises. Example:
- User with Admin role can create a Glossary Term with a parent term
- Ingestion run for Snowflake correctly extracts row counts for partitioned tables
-->

#### Unit tests
<!--
- [ ] I added unit tests for the new/changed logic.
- Files added/updated:
- Coverage on changed classes (run `mvn jacoco:report` for backend, `yarn test:coverage` for UI,
  `make unit_ingestion` for ingestion). Target is 90% line coverage on changed classes.
- Coverage %: <e.g., 92% on EntityRepository.java>
-->

#### Backend integration tests
<!--
- [ ] I added integration tests in `openmetadata-integration-tests/` for new/changed API endpoints.
- [ ] Not applicable (no backend API changes).
- Files added/updated:
-->

#### Ingestion integration tests
<!--
- [ ] I added/updated ingestion integration tests for connector changes.
- [ ] Not applicable (no ingestion changes).
- Files added/updated:
-->

#### Playwright (UI) tests
<!--
- [ ] I added Playwright E2E tests under `openmetadata-ui/.../ui/playwright/` for UI changes.
- [ ] Not applicable (no UI changes).
- Files added/updated:
-->

#### Manual testing performed
<!--
List the manual test steps you performed before requesting review. Example:
1. Started local stack via `./docker/run_local_docker.sh -m ui -d mysql`
3. Logged in as admin, created entity X, verified Y appears in the UI
4. Triggered ingestion for Snowflake source, confirmed lineage edges in the explore page
-->

#
### UI screen recording / screenshots:
<!--
REQUIRED for any PR that changes the UI. Drag-and-drop a short screen recording (.mov / .mp4 / .gif)
demonstrating the change end-to-end, plus before/after screenshots where relevant.
Mark "Not applicable" if there are no UI changes.
-->

Not applicable. <!-- Or attach recording/screenshots above -->

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.
- [ ] For UI changes: I attached a screen recording and/or screenshots above.
- [ ] I have added tests (unit / integration / Playwright as applicable) and listed them above.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR refactors the `DialogFooter` component in `modal.tsx` to fix two visual issues: an unwanted gap between the footer border and buttons, and buttons incorrectly stretching to full width.

- Simplifies the footer from three nested divs (outer padding, separate border element, spacer) to two divs (outer with `mt-6`/`border-t`, inner with `py-4`/`justify-end`), eliminating the spacer-driven gap.
- Removes the `sm:grid sm:grid-cols-2` layout (which caused full-width buttons) and the mobile `flex-col-reverse` stack in favour of a plain `flex justify-end` row so buttons size to their content and align right.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

This is a small, self-contained CSS layout change with no logic, data, or API surface touched.

The change removes three divs and replaces them with two, consolidating the border onto the outer container and switching from a grid/column-reverse layout to a plain flex row. The resulting structure is simpler, the spacing math is equivalent, and no component API or prop contract was changed. Mobile button stacking via flex-col-reverse is intentionally removed as part of the fix.

No files require special attention.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-ui-core-components/src/main/resources/ui/src/components/application/modals/modal.tsx | DialogFooter simplified from three divs to two; border moved to outer container, spacing corrected, and button layout switched from grid/column-reverse to a right-aligned flex row. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    subgraph Before["Before"]
        A["outer div\n[z-10, pt-6, pb-4, sm:pt-8, sm:pb-6]"]
        B["border div\n[w-full, border-t, border-secondary]"]
        C["spacer div\n[h-4, sm:h-6]"]
        D["button row div\n[flex, flex-col-reverse, sm:grid, sm:grid-cols-2]"]
        A --> B
        A --> C
        A --> D
    end

    subgraph After["After"]
        E["outer div\n[z-10, mt-6, sm:mt-8, border-t, border-secondary]"]
        F["button row div\n[flex, justify-end, py-4, px-4, sm:px-6]"]
        E --> F
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    subgraph Before["Before"]
        A["outer div\n[z-10, pt-6, pb-4, sm:pt-8, sm:pb-6]"]
        B["border div\n[w-full, border-t, border-secondary]"]
        C["spacer div\n[h-4, sm:h-6]"]
        D["button row div\n[flex, flex-col-reverse, sm:grid, sm:grid-cols-2]"]
        A --> B
        A --> C
        A --> D
    end

    subgraph After["After"]
        E["outer div\n[z-10, mt-6, sm:mt-8, border-t, border-secondary]"]
        F["button row div\n[flex, justify-end, py-4, px-4, sm:px-6]"]
        E --> F
    end
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(ui): modal footer styling and button..."](https://github.com/open-metadata/openmetadata/commit/04cedc6c32aa339bfba034d90546693b3cf9ac1e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40483369)</sub>

<!-- /greptile_comment -->