### PR TITLE
test(ui): remove flaky search-response waits from Explore Browse spec

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/ExploreBrowse.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/ExploreBrowse.spec.ts
@@ -225,13 +225,9 @@ test.describe(
       await expandServiceInExploreTree(page, table.serviceResponseData.name);
 
       await test.step('Selecting a service in the tree adds browse chips', async () => {
-        const browseRes = page.waitForResponse(
-          '/api/v1/search/query?*index=dataAsset*'
-        );
         await page
           .getByTestId(`explore-tree-title-${table.serviceResponseData.name}`)
           .click();
-        await browseRes;
         await waitForAllLoadersToDisappear(page);
 
         await expect(page.getByTestId('browse-chip-serviceType')).toBeVisible();
@@ -260,15 +256,12 @@ test.describe(
       await test.step('Selecting a database service type narrows the browse tree directionally', async () => {
         await expandTreeNode(page, 'Databases');
 
-        const browseRes = page.waitForResponse(
-          '/api/v1/search/query?*index=dataAsset*'
-        );
         await page
           .getByTestId(
             `explore-tree-title-${table.service.serviceType.toLowerCase()}`
           )
           .click();
-        await browseRes;
+
         await waitForAllLoadersToDisappear(page);
 
         await expect(page.getByTestId('browse-chip-serviceType')).toBeVisible();


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:

<!--
Linking an issue is REQUIRED. Replace <issue-number> with the GitHub issue number this PR addresses
(e.g., `Fixes #12345`). GitHub will auto-link it. If no issue exists, please open one first so the
problem and design can be discussed before review.
-->

<!--
Short blurb explaining:
- What changes did you make?
- Why did you make them?
-->
## Description

The Explore Browse Playwright spec wrapped tree-node clicks in `page.waitForResponse('/api/v1/search/query?*index=dataAsset*')`. A single tree click fires more than one `dataAsset` search (count + presence aggregations) and the response can resolve before/around the listener attaching, so the explicit wait was a race — it either matched the wrong request or resolved early, making the assertions that follow flaky.

## Changes

- Drop the `waitForResponse('/api/v1/search/query?*index=dataAsset*')` waits around the service and service-type tree clicks in `ExploreBrowse.spec.ts`.
- Rely on the existing `waitForAllLoadersToDisappear(page)` + the web-first `expect(...).toBeVisible()` assertions on the resulting browse chips, which already gate on the settled UI state.

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### High-level design:
<!--
REQUIRED for large PRs (new features, refactors, breaking changes, or anything touching >5 files).
Skip for small bug fixes and trivial changes.

Cover:
- Architecture / approach you took and why
- Key components or files added/changed and how they interact
- Alternatives considered and why you rejected them
- Any migration, backward-compatibility, or rollout concerns
- Diagrams or links to design docs / RFCs if available
-->

N/A — small change. <!-- Or fill in the design above -->

#
### Tests:

#### Use cases covered
<!--
List the user-visible scenarios this PR exercises. Example:
- User with Admin role can create a Glossary Term with a parent term
- Ingestion run for Snowflake correctly extracts row counts for partitioned tables
-->

#### Unit tests
<!--
- [ ] I added unit tests for the new/changed logic.
- Files added/updated:
- Coverage on changed classes (run `mvn jacoco:report` for backend, `yarn test:coverage` for UI,
  `make unit_ingestion` for ingestion). Target is 90% line coverage on changed classes.
- Coverage %: <e.g., 92% on EntityRepository.java>
-->

#### Backend integration tests
<!--
- [ ] I added integration tests in `openmetadata-integration-tests/` for new/changed API endpoints.
- [ ] Not applicable (no backend API changes).
- Files added/updated:
-->

#### Ingestion integration tests
<!--
- [ ] I added/updated ingestion integration tests for connector changes.
- [ ] Not applicable (no ingestion changes).
- Files added/updated:
-->

#### Playwright (UI) tests
<!--
- [ ] I added Playwright E2E tests under `openmetadata-ui/.../ui/playwright/` for UI changes.
- [ ] Not applicable (no UI changes).
- Files added/updated:
-->

#### Manual testing performed
<!--
List the manual test steps you performed before requesting review. Example:
1. Started local stack via `./docker/run_local_docker.sh -m ui -d mysql`
2. Logged in as admin, created entity X, verified Y appears in the UI
3. Triggered ingestion for Snowflake source, confirmed lineage edges in the explore page
-->

#
### UI screen recording / screenshots:
<!--
REQUIRED for any PR that changes the UI. Drag-and-drop a short screen recording (.mov / .mp4 / .gif)
demonstrating the change end-to-end, plus before/after screenshots where relevant.
Mark "Not applicable" if there are no UI changes.
-->

Not applicable. <!-- Or attach recording/screenshots above -->

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.
- [ ] For UI changes: I attached a screen recording and/or screenshots above.
- [ ] I have added tests (unit / integration / Playwright as applicable) and listed them above.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR removes two `waitForResponse` calls from Playwright E2E tests in `ExploreBrowse.spec.ts` that were guarding tree-node click interactions but whose resolved values were never inspected. Both removals follow the same pattern: the response promise was awaited purely as a synchronization point, with the actual assertions already handled by `waitForAllLoadersToDisappear` + Playwright auto-wait on `toBeVisible()`.

- In \"browsing the tree stacks removable QUERY chips\", the `waitForResponse` guard before clicking the service node in the explore tree is dropped; synchronization is now left to `waitForAllLoadersToDisappear` and the downstream `toBeVisible()` assertion.
- In \"service type drill-down disables unrelated roots\", the same pattern is removed before clicking the service-type node under Databases.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge — this is a small Playwright test change that removes network-response guards whose resolved values were never used.

The two `waitForResponse` calls that were removed were pure synchronization points: neither resolved value was ever inspected (no status check, no body read). The downstream `waitForAllLoadersToDisappear` call and Playwright's built-in auto-wait on `toBeVisible()` (up to 5 s) provide equivalent synchronization. In fact, the original code could time-out if a cached click didn't re-trigger a network request, making the removed pattern a potential source of flakiness rather than a fix. The governance tests that still use `waitForResponse` do so correctly because they inspect `response.status()`. The consistency between the two groups is intentional and correct.

No files require special attention — only one Playwright spec file was changed, and the remaining test logic is intact.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/ExploreBrowse.spec.ts | Removes two unused `waitForResponse` guards around tree-node clicks; the response promises were awaited but never inspected. Synchronization is now delegated to `waitForAllLoadersToDisappear` + Playwright auto-wait on subsequent assertions, which is sufficient but removes an explicit network-level synchronization point. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant T as Test
    participant PW as Playwright
    participant UI as Browser/UI
    participant API as /api/v1/search/query

    Note over T,API: BEFORE (removed)
    T->>PW: waitForResponse(dataAsset)
    T->>UI: click(service tree node)
    UI->>API: "GET search/query?index=dataAsset"
    API-->>UI: 200 results
    PW-->>T: browseRes resolved
    T->>PW: waitForAllLoadersToDisappear
    T->>PW: expect(browse-chip-serviceType).toBeVisible()

    Note over T,API: AFTER (current)
    T->>UI: click(service tree node)
    UI->>API: "GET search/query?index=dataAsset"
    API-->>UI: 200 results
    T->>PW: waitForAllLoadersToDisappear
    T->>PW: expect(browse-chip-serviceType).toBeVisible() [auto-waits up to 5s]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant T as Test
    participant PW as Playwright
    participant UI as Browser/UI
    participant API as /api/v1/search/query

    Note over T,API: BEFORE (removed)
    T->>PW: waitForResponse(dataAsset)
    T->>UI: click(service tree node)
    UI->>API: "GET search/query?index=dataAsset"
    API-->>UI: 200 results
    PW-->>T: browseRes resolved
    T->>PW: waitForAllLoadersToDisappear
    T->>PW: expect(browse-chip-serviceType).toBeVisible()

    Note over T,API: AFTER (current)
    T->>UI: click(service tree node)
    UI->>API: "GET search/query?index=dataAsset"
    API-->>UI: 200 results
    T->>PW: waitForAllLoadersToDisappear
    T->>PW: expect(browse-chip-serviceType).toBeVisible() [auto-waits up to 5s]
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["remove unwanted race conditons"](https://github.com/open-metadata/openmetadata/commit/e7f4a7adfe3164092dc12bea53ec6bc8ea1b32f4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40513792)</sub>

<!-- /greptile_comment -->