### PR TITLE
chore(ui): remove the size from base

### DIFF
--- a/openmetadata-ui-core-components/src/main/resources/ui/src/components/base/card/card.tsx
+++ b/openmetadata-ui-core-components/src/main/resources/ui/src/components/base/card/card.tsx
@@ -195,7 +195,6 @@ const CardBase = forwardRef<HTMLDivElement, CardProps>(
             isClickable && cardStyles.interactive.root,
             isClickable && cardStyles.interactiveVariants[variant].root,
             isSelected && cardStyles.selected.root,
-            sizes[size].padding,
             className
           )}>
           {children}


### PR DESCRIPTION
----
## Summary by Gitar

- **UI Refinement:**
  - Removed the `size` prop from the `Card` component in `card.tsx`.

<sub>This will update automatically on new commits.</sub>

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR removes the size-based padding (`sizes[size].padding`) from the root `CardBase` element in the card component. Padding is still applied to sub-components (`Card.Header`, `Card.Content`, `Card.Footer`) via `CardContext`.

- The `size` prop and `CardContext` remain fully functional — sub-components continue to consume the size value for their own padding.
- Any consumer that wraps content directly in `<Card>` without using `Card.Content`/`Card.Header`/`Card.Footer` will now render with no root-level padding, which is a potentially silent visual change.
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge if all card consumers use sub-components (Card.Header/Content/Footer) for their content; any bare-children usage will silently lose padding.

The change is a single-line removal in one file. Sub-component padding via context is fully preserved. The only risk is consumers using `<Card>` with raw children instead of sub-components, which would lose their padding without any warning.

No files require special attention beyond verifying downstream consumers of `Card` do not use bare children.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| openmetadata-ui-core-components/src/main/resources/ui/src/components/base/card/card.tsx | Removes `sizes[size].padding` from the root CardBase div; padding is now applied only by Card.Header/Content/Footer sub-components via context. Bare-children card usage will lose padding. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["<Card size='md'>"] -->|"provides CardContext { size }"| B[CardContext.Provider]
    B --> C["Root <div>"]
    C -->|"Before: sizes[size].padding applied here"| C1["❌ Removed — no padding on root"]
    B --> D["Card.Header"]
    B --> E["Card.Content"]
    B --> F["Card.Footer"]
    D -->|"reads size from context"| D1["✅ sizes[size].padding applied"]
    E -->|"reads size from context"| E1["✅ sizes[size].padding applied"]
    F -->|"reads size from context"| F1["✅ sizes[size].padding applied"]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["<Card size='md'>"] -->|"provides CardContext { size }"| B[CardContext.Provider]
    B --> C["Root <div>"]
    C -->|"Before: sizes[size].padding applied here"| C1["❌ Removed — no padding on root"]
    B --> D["Card.Header"]
    B --> E["Card.Content"]
    B --> F["Card.Footer"]
    D -->|"reads size from context"| D1["✅ sizes[size].padding applied"]
    E -->|"reads size from context"| E1["✅ sizes[size].padding applied"]
    F -->|"reads size from context"| F1["✅ sizes[size].padding applied"]
```

</a>
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `openmetadata-ui-core-components/src/main/resources/ui/src/components/base/card/card.tsx`, line 191-199 ([link](https://github.com/open-metadata/openmetadata/blob/0281836ed0cf5673318eb619d821692eeaaa3ee3/openmetadata-ui-core-components/src/main/resources/ui/src/components/base/card/card.tsx#L191-L199)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Root card loses padding for bare children usage**

   Removing `sizes[size].padding` from the root `CardBase` element means any consumer that places content directly inside `<Card>` without a `<Card.Content>` wrapper will now render with zero padding. Sub-components (`Card.Header`, `Card.Content`, `Card.Footer`) still apply size-based padding via context, so structured usage is unaffected — but bare-children usage silently changes appearance. If this is intentional and all consumers have been migrated to sub-components, this is fine; otherwise it's a quiet visual regression for any `<Card>{children}</Card>` usage without sub-components.

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["remove the size from base"](https://github.com/open-metadata/openmetadata/commit/0281836ed0cf5673318eb619d821692eeaaa3ee3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40532819)</sub>

<!-- /greptile_comment -->