### PR TITLE
fix(ui): modal footer styling and button alignment

### DIFF
--- a/openmetadata-ui-core-components/src/main/resources/ui/src/components/application/modals/modal.tsx
+++ b/openmetadata-ui-core-components/src/main/resources/ui/src/components/application/modals/modal.tsx
@@ -96,10 +96,11 @@ interface DialogFooterProps {
 
 const DialogFooter = ({ children, className }: DialogFooterProps) => (
   <div
-    className={cx('tw:z-10 tw:pt-6 tw:pb-4 tw:sm:pt-8 tw:sm:pb-6', className)}>
-    <div className="tw:w-full tw:border-t tw:border-secondary" />
-    <div className="tw:h-4 tw:w-full tw:sm:h-6" />
-    <div className="tw:flex tw:flex-1 tw:flex-col-reverse tw:gap-3 tw:sm:grid tw:sm:grid-cols-2 tw:sm:px-6 tw:px-4">
+    className={cx(
+      'tw:z-10 tw:mt-6 tw:sm:mt-8 tw:border-t tw:border-secondary',
+      className
+    )}>
+    <div className="tw:flex tw:flex-1 tw:gap-3 tw:sm:px-6 tw:px-4 tw:py-4 tw:justify-end">
       {children}
     </div>
   </div>


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:

Fixes #<issue-number>
<!--
Linking an issue is REQUIRED. Replace <issue-number> with the GitHub issue number this PR addresses
(e.g., `Fixes #12345`). GitHub will auto-link it. If no issue exists, please open one first so the
problem and design can be discussed before review.
-->

https://github.com/user-attachments/assets/1f845856-14a9-4b9b-9bb4-1a286b2efe2f


<!--
Short blurb explaining:
- What changes did you make?
- Why did you make them?
-->

I worked on ... because ...

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### High-level design:
<!--
REQUIRED for large PRs (new features, refactors, breaking changes, or anything touching >5 files).
Skip for small bug fixes and trivial changes.

Cover:
- Architecture / approach you took and why
- Key components or files added/changed and how they interact
- Alternatives considered and why you rejected them
- Any migration, backward-compatibility, or rollout concerns
- Diagrams or links to design docs / RFCs if available
-->

N/A — small change. <!-- Or fill in the design above -->

#
### Tests:

#### Use cases covered
<!--
List the user-visible scenarios this PR exercises. Example:
- User with Admin role can create a Glossary Term with a parent term
- Ingestion run for Snowflake correctly extracts row counts for partitioned tables
-->

#### Unit tests
<!--
- [ ] I added unit tests for the new/changed logic.
- Files added/updated:
- Coverage on changed classes (run `mvn jacoco:report` for backend, `yarn test:coverage` for UI,
  `make unit_ingestion` for ingestion). Target is 90% line coverage on changed classes.
- Coverage %: <e.g., 92% on EntityRepository.java>
-->

#### Backend integration tests
<!--
- [ ] I added integration tests in `openmetadata-integration-tests/` for new/changed API endpoints.
- [ ] Not applicable (no backend API changes).
- Files added/updated:
-->

#### Ingestion integration tests
<!--
- [ ] I added/updated ingestion integration tests for connector changes.
- [ ] Not applicable (no ingestion changes).
- Files added/updated:
-->

#### Playwright (UI) tests
<!--
- [ ] I added Playwright E2E tests under `openmetadata-ui/.../ui/playwright/` for UI changes.
- [ ] Not applicable (no UI changes).
- Files added/updated:
-->

#### Manual testing performed
<!--
List the manual test steps you performed before requesting review. Example:
1. Started local stack via `./docker/run_local_docker.sh -m ui -d mysql`
2. Logged in as admin, created entity X, verified Y appears in the UI
3. Triggered ingestion for Snowflake source, confirmed lineage edges in the explore page
-->

#
### UI screen recording / screenshots:
<!--
REQUIRED for any PR that changes the UI. Drag-and-drop a short screen recording (.mov / .mp4 / .gif)
demonstrating the change end-to-end, plus before/after screenshots where relevant.
Mark "Not applicable" if there are no UI changes.
-->

Not applicable. <!-- Or attach recording/screenshots above -->

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.
- [ ] For UI changes: I attached a screen recording and/or screenshots above.
- [ ] I have added tests (unit / integration / Playwright as applicable) and listed them above.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR simplifies the `DialogFooter` component by collapsing two intermediate structural divs (a border div and a spacer div) directly into the outer wrapper and adjusting padding/margin accordingly.

- The outer wrapper gains `border-t border-secondary`, `mt-6`/`sm:mt-8`, and no longer carries top/bottom padding, with the border previously rendered via a dedicated child div.
- The buttons container switches from a responsive `flex-col-reverse` / `sm:grid sm:grid-cols-2` layout (mobile-stacked, desktop equal-width columns) to a plain `flex justify-end` row on all screen sizes.
- A leftover `flex-1` class remains on the inner buttons div whose parent has no `display: flex`, making it a no-op.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge — the change only touches layout classes in a single component with no logic changes.

The structural simplification is straightforward. The only leftover is a `flex-1` class that has no visual effect since its parent is a block container. The responsive stacking behaviour was intentionally removed; callers of `Dialog.Footer` on small viewports are worth a quick visual check.

The single changed file `modal.tsx` is low risk; callers of `Dialog.Footer` on small viewports deserve a quick visual check given the removed mobile-stacking layout.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-ui-core-components/src/main/resources/ui/src/components/application/modals/modal.tsx | Refactors DialogFooter layout: collapses the border+spacer intermediate divs into the outer wrapper, and replaces the responsive column-reverse/grid layout with a simple flex row justified to the right. A `flex-1` class is left on the inner div whose parent has no `display: flex`, making it a no-op. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    subgraph Before["Before (old layout)"]
        A["outer div\n(pt-6 pb-4 sm:pt-8 sm:pb-6)"]
        A --> B["border div\n(w-full border-t border-secondary)"]
        A --> C["spacer div\n(h-4 sm:h-6)"]
        A --> D["buttons div\n(flex flex-col-reverse gap-3\nsm:grid sm:grid-cols-2 sm:px-6 px-4)"]
        D --> E["Button 1"]
        D --> F["Button 2"]
    end
    subgraph After["After (new layout)"]
        G["outer div\n(mt-6 sm:mt-8 border-t border-secondary)"]
        G --> H["buttons div\n(flex flex-1 gap-3 sm:px-6 px-4 py-4 justify-end)"]
        H --> I["Button 1"]
        H --> J["Button 2"]
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    subgraph Before["Before (old layout)"]
        A["outer div\n(pt-6 pb-4 sm:pt-8 sm:pb-6)"]
        A --> B["border div\n(w-full border-t border-secondary)"]
        A --> C["spacer div\n(h-4 sm:h-6)"]
        A --> D["buttons div\n(flex flex-col-reverse gap-3\nsm:grid sm:grid-cols-2 sm:px-6 px-4)"]
        D --> E["Button 1"]
        D --> F["Button 2"]
    end
    subgraph After["After (new layout)"]
        G["outer div\n(mt-6 sm:mt-8 border-t border-secondary)"]
        G --> H["buttons div\n(flex flex-1 gap-3 sm:px-6 px-4 py-4 justify-end)"]
        H --> I["Button 1"]
        H --> J["Button 2"]
    end
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(ui): modal footer styling and button..."](https://github.com/open-metadata/openmetadata/commit/04cedc6c32aa339bfba034d90546693b3cf9ac1e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40533447)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->