### PR TITLE
Removed MUI component from color picker

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/Modals/IconColorModal/IconColorModal.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Modals/IconColorModal/IconColorModal.test.tsx
@@ -63,17 +63,19 @@ const mockProps: StyleModalProps = {
 };
 
 jest.mock('../../common/ColorPicker', () => ({
-  MUIColorPicker: jest.fn().mockImplementation(({ label, value, onChange }) => (
-    <div data-testid="color-picker">
-      <label>{label}</label>
-      <input
-        data-testid="color-input"
-        type="text"
-        value={value}
-        onChange={(e) => onChange?.(e.target.value)}
-      />
-    </div>
-  )),
+  ColorSwatchPicker: jest
+    .fn()
+    .mockImplementation(({ label, value, onChange }) => (
+      <div data-testid="color-picker">
+        <label>{label}</label>
+        <input
+          data-testid="color-input"
+          type="text"
+          value={value}
+          onChange={(e) => onChange?.(e.target.value)}
+        />
+      </div>
+    )),
 }));
 
 jest.mock('../../common/IconPicker', () => ({

--- a/openmetadata-ui/src/main/resources/ui/src/components/Modals/IconColorModal/IconColorModal.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Modals/IconColorModal/IconColorModal.tsx
@@ -22,7 +22,7 @@ import { FC, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Style } from '../../../generated/type/schema';
 import { iconTooltipDataRender } from '../../../utils/DomainUtils';
-import { MUIColorPicker } from '../../common/ColorPicker';
+import { ColorSwatchPicker } from '../../common/ColorPicker';
 import { DEFAULT_TAG_ICON, MUIIconPicker } from '../../common/IconPicker';
 import { StyleModalProps } from '../StyleModal/StyleModal.interface';
 
@@ -86,7 +86,7 @@ const IconColorModal: FC<StyleModalProps> = ({
                   name="color"
                   trigger="onChange"
                   valuePropName="value">
-                  <MUIColorPicker label={t('label.color')} />
+                  <ColorSwatchPicker label={t('label.color')} />
                 </Form.Item>
               </div>
             </Form>

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/ColorPicker/ColorSwatchPicker.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/ColorPicker/ColorSwatchPicker.tsx
@@ -11,7 +11,7 @@
  *  limitations under the License.
  */
 
-import { Box, FormControl, FormLabel, useTheme } from '@mui/material';
+import { Box, Label } from '@openmetadata/ui-core-components';
 import { FC } from 'react';
 
 interface ColorPickerProps {
@@ -42,17 +42,9 @@ const defaultColorOptions = [
 // Check icon component following the checkbox-icons pattern
 const CheckIcon: FC = () => (
   <Box
-    sx={{
-      position: 'absolute',
-      top: '50%',
-      left: '50%',
-      transform: 'translate(-50%, -50%)',
-      width: '45%',
-      height: '45%',
-      display: 'flex',
-      alignItems: 'center',
-      justifyContent: 'center',
-    }}>
+    align="center"
+    className="tw:absolute tw:top-1/2 tw:left-1/2 tw:h-[45%] tw:w-[45%] tw:-translate-x-1/2 tw:-translate-y-1/2"
+    justify="center">
     <svg fill="none" height="100%" viewBox="0 0 14 14" width="100%">
       <path
         d="M11.6666 3.5L5.24992 9.91667L2.33325 7"
@@ -65,14 +57,12 @@ const CheckIcon: FC = () => (
   </Box>
 );
 
-const MUIColorPicker: FC<ColorPickerProps> = ({
+const ColorSwatchPicker: FC<ColorPickerProps> = ({
   value,
   onChange,
   colors = defaultColorOptions,
   label,
 }) => {
-  const theme = useTheme();
-
   const handleColorClick = (color: string) => {
     if (onChange) {
       onChange(color);
@@ -80,14 +70,9 @@ const MUIColorPicker: FC<ColorPickerProps> = ({
   };
 
   return (
-    <FormControl component="fieldset">
-      {label && <FormLabel>{label}</FormLabel>}
-      <Box
-        sx={{
-          display: 'flex',
-          flexWrap: 'wrap',
-          gap: '6px',
-        }}>
+    <Box direction="col" gap={2}>
+      {label && <Label>{label}</Label>}
+      <Box className="tw:gap-1.5" direction="row" wrap="wrap">
         {colors.map((color) => {
           const isSelected = value?.toLowerCase() === color.toLowerCase();
 
@@ -95,26 +80,10 @@ const MUIColorPicker: FC<ColorPickerProps> = ({
             <Box
               aria-label={`Select color ${color}`}
               aria-pressed={isSelected}
+              className="tw:relative tw:h-8.5 tw:w-8.5 tw:cursor-pointer tw:rounded tw:focus-visible:outline-2 tw:focus-visible:outline-offset-2 tw:focus-visible:outline-focus-ring"
               key={color}
               role="button"
-              sx={{
-                position: 'relative',
-                width: 34,
-                height: 34,
-                borderRadius: '4px',
-                backgroundColor: color,
-                padding: '2px 3px',
-                cursor: 'pointer',
-                border: '2px solid transparent',
-                transition: 'all 0.2s ease',
-                opacity: 1,
-                '&:focus-visible': {
-                  outline: `2px solid ${
-                    theme.palette.primary?.main || '#1470EF'
-                  }`,
-                  outlineOffset: '2px',
-                },
-              }}
+              style={{ backgroundColor: color }}
               tabIndex={0}
               onClick={() => handleColorClick(color)}
               onKeyDown={(e) => {
@@ -128,8 +97,8 @@ const MUIColorPicker: FC<ColorPickerProps> = ({
           );
         })}
       </Box>
-    </FormControl>
+    </Box>
   );
 };
 
-export default MUIColorPicker;
+export default ColorSwatchPicker;

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/ColorPicker/index.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/ColorPicker/index.ts
@@ -12,4 +12,4 @@
  */
 
 export { default } from './ColorPicker.component';
-export { default as MUIColorPicker } from './MUIColorPicker';
+export { default as ColorSwatchPicker } from './ColorSwatchPicker';

--- a/openmetadata-ui/src/main/resources/ui/src/pages/TagsPage/TagsForm.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/TagsPage/TagsForm.test.tsx
@@ -28,6 +28,10 @@ jest.mock('@openmetadata/ui-core-components', () => {
   GridComponent.Item = GridItem;
 
   return {
+    Box: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+    Label: ({ children }: { children: React.ReactNode }) => (
+      <label>{children}</label>
+    ),
     Tooltip: ({
       children,
       title,

--- a/openmetadata-ui/src/main/resources/ui/src/utils/formUtils.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/formUtils.tsx
@@ -34,7 +34,7 @@ import React, { Fragment, ReactNode } from 'react';
 import AsyncSelectList from '../components/common/AsyncSelectList/AsyncSelectList';
 import { AsyncSelectListProps } from '../components/common/AsyncSelectList/AsyncSelectList.interface';
 import TreeAsyncSelectList from '../components/common/AsyncSelectList/TreeAsyncSelectList';
-import { MUIColorPicker } from '../components/common/ColorPicker';
+import { ColorSwatchPicker } from '../components/common/ColorPicker';
 import ColorPicker from '../components/common/ColorPicker/ColorPicker.component';
 import DomainSelectableList from '../components/common/DomainSelectableList/DomainSelectableList.component';
 import { DomainSelectableListProps } from '../components/common/DomainSelectableList/DomainSelectableList.interface';
@@ -405,7 +405,7 @@ export const getField = (field: FieldProp) => {
     case FieldTypes.COLOR_PICKER_MUI: {
       return (
         <Form.Item {...formProps}>
-          <MUIColorPicker
+          <ColorSwatchPicker
             {...(props as Record<string, unknown>)}
             label={muiLabel as string}
           />


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:

Removed MUI component from color picker


https://github.com/user-attachments/assets/22c4e3ad-fefb-473d-91df-8dd6ceac42a5


#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### High-level design:
<!--
REQUIRED for large PRs (new features, refactors, breaking changes, or anything touching >5 files).
Skip for small bug fixes and trivial changes.

Cover:
- Architecture / approach you took and why
- Key components or files added/changed and how they interact
- Alternatives considered and why you rejected them
- Any migration, backward-compatibility, or rollout concerns
- Diagrams or links to design docs / RFCs if available
-->

N/A — small change. <!-- Or fill in the design above -->

#
### Tests:

#### Use cases covered
<!--
List the user-visible scenarios this PR exercises. Example:
- User with Admin role can create a Glossary Term with a parent term
- Ingestion run for Snowflake correctly extracts row counts for partitioned tables
-->

#### Unit tests
<!--
- [ ] I added unit tests for the new/changed logic.
- Files added/updated:
- Coverage on changed classes (run `mvn jacoco:report` for backend, `yarn test:coverage` for UI,
  `make unit_ingestion` for ingestion). Target is 90% line coverage on changed classes.
- Coverage %: <e.g., 92% on EntityRepository.java>
-->

#### Backend integration tests
<!--
- [ ] I added integration tests in `openmetadata-integration-tests/` for new/changed API endpoints.
- [ ] Not applicable (no backend API changes).
- Files added/updated:
-->

#### Ingestion integration tests
<!--
- [ ] I added/updated ingestion integration tests for connector changes.
- [ ] Not applicable (no ingestion changes).
- Files added/updated:
-->

#### Playwright (UI) tests
<!--
- [ ] I added Playwright E2E tests under `openmetadata-ui/.../ui/playwright/` for UI changes.
- [ ] Not applicable (no UI changes).
- Files added/updated:
-->

#### Manual testing performed
<!--
List the manual test steps you performed before requesting review. Example:
1. Started local stack via `./docker/run_local_docker.sh -m ui -d mysql`
2. Logged in as admin, created entity X, verified Y appears in the UI
3. Triggered ingestion for Snowflake source, confirmed lineage edges in the explore page
-->

#
### UI screen recording / screenshots:
<!--
REQUIRED for any PR that changes the UI. Drag-and-drop a short screen recording (.mov / .mp4 / .gif)
demonstrating the change end-to-end, plus before/after screenshots where relevant.
Mark "Not applicable" if there are no UI changes.
-->

Not applicable. <!-- Or attach recording/screenshots above -->

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.
- [ ] For UI changes: I attached a screen recording and/or screenshots above.
- [ ] I have added tests (unit / integration / Playwright as applicable) and listed them above.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR replaces the MUI-based `MUIColorPicker` component with a new `ColorSwatchPicker` built entirely on `@openmetadata/ui-core-components` and Tailwind CSS classes. All MUI dependencies (`Box`, `FormControl`, `FormLabel`, `useTheme`) and `sx` prop styling are removed from this component.

- **Rename + refactor**: `MUIColorPicker.tsx` → `ColorSwatchPicker.tsx`; all existing consumers in `IconColorModal.tsx` and `formUtils.tsx` updated; `index.ts` re-export updated and all test mocks aligned.
- **Note**: The `FieldTypes.COLOR_PICKER_MUI` enum value in `FormUtils.interface.ts` retains its `_MUI` suffix as a pre-existing identifier — renaming it would require broader enum/consumer updates outside the scope of this change.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is a self-contained component rename and MUI-removal with no logic changes.

All consumers of the old MUIColorPicker (IconColorModal, formUtils) are updated, the re-export in index.ts is consistent, and test mocks are aligned. Decimal Tailwind spacing (tw:h-8.5, tw:w-8.5) is established project convention used across multiple components. No functional behaviour was altered.

No files require special attention.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-ui/src/main/resources/ui/src/components/common/ColorPicker/ColorSwatchPicker.tsx | Core rename: MUI sx-props and hooks removed; replaced with ui-core-components Box/Label and Tailwind classes. Decimal spacing (tw:h-8.5, tw:w-8.5) is consistent with project-wide usage patterns. |
| openmetadata-ui/src/main/resources/ui/src/components/Modals/IconColorModal/IconColorModal.tsx | Import updated from MUIColorPicker to ColorSwatchPicker; no other logic changes. |
| openmetadata-ui/src/main/resources/ui/src/components/common/ColorPicker/index.ts | Re-export updated from MUIColorPicker to ColorSwatchPicker; no remaining stale exports. |
| openmetadata-ui/src/main/resources/ui/src/utils/formUtils.tsx | Import updated; COLOR_PICKER_MUI case now renders ColorSwatchPicker correctly. |
| openmetadata-ui/src/main/resources/ui/src/components/Modals/IconColorModal/IconColorModal.test.tsx | Mock updated from MUIColorPicker to ColorSwatchPicker; all test assertions remain intact. |
| openmetadata-ui/src/main/resources/ui/src/pages/TagsPage/TagsForm.test.tsx | Added minimal Box and Label mocks for the new ui-core-components dependency; existing test assertions are render-only and do not require event forwarding. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[ColorPicker/index.ts] -->|exports| B[ColorSwatchPicker]
    A -->|exports default| C[ColorPicker.component]

    B --> D[IconColorModal.tsx]
    B --> E[formUtils.tsx\nFieldTypes.COLOR_PICKER_MUI case]

    D -->|used in| F[Style Edit Modal\nIcon + Color selection]
    E -->|used in| G[TagsForm\nColor field]

    B --> H["@openmetadata/ui-core-components\nBox, Label"]
    B --> I[Tailwind CSS classes\ntw:relative, tw:h-8.5, tw:w-8.5 …]

    style B fill:#22c55e,color:#fff
    style H fill:#3b82f6,color:#fff
    style I fill:#3b82f6,color:#fff
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[ColorPicker/index.ts] -->|exports| B[ColorSwatchPicker]
    A -->|exports default| C[ColorPicker.component]

    B --> D[IconColorModal.tsx]
    B --> E[formUtils.tsx\nFieldTypes.COLOR_PICKER_MUI case]

    D -->|used in| F[Style Edit Modal\nIcon + Color selection]
    E -->|used in| G[TagsForm\nColor field]

    B --> H["@openmetadata/ui-core-components\nBox, Label"]
    B --> I[Tailwind CSS classes\ntw:relative, tw:h-8.5, tw:w-8.5 …]

    style B fill:#22c55e,color:#fff
    style H fill:#3b82f6,color:#fff
    style I fill:#3b82f6,color:#fff
```

</a>
</details>

<sub>Reviews (3): Last reviewed commit: ["Merge branch &#39;color-picker-refactor&#39; of ..."](https://github.com/open-metadata/openmetadata/commit/29033425075adb83833dbbed04a1255a31774012) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40537924)</sub>

<!-- /greptile_comment -->