### PR TITLE
Fixes #26554: Validate legacy feed task payloads

### DIFF
--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/FeedResourceIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/FeedResourceIT.java
@@ -44,6 +44,7 @@ import org.openmetadata.schema.type.ReactionType;
 import org.openmetadata.schema.type.TaskStatus;
 import org.openmetadata.schema.type.TaskType;
 import org.openmetadata.schema.type.ThreadType;
+import org.openmetadata.sdk.exceptions.InvalidRequestException;
 import org.openmetadata.sdk.fluent.DatabaseSchemas;
 import org.openmetadata.sdk.fluent.Databases;
 import org.openmetadata.sdk.network.HttpMethod;
@@ -427,6 +428,124 @@ public class FeedResourceIT {
     assertTrue(tasks.getData().size() > 0);
 
     deleteThread(taskThread.getId());
+  }
+
+  @Test
+  void post_requestApprovalTaskForColumn_400AndDoesNotBreakTaskList(TestNamespace ns)
+      throws Exception {
+    Table table = createTestTable(ns);
+    String about =
+        String.format("<#E::table::%s::columns::%s>", table.getFullyQualifiedName(), "id");
+
+    User assigneeUser = SdkClients.adminClient().users().getByName("admin");
+    EntityReference assignee = assigneeUser.getEntityReference();
+
+    CreateTaskDetails approvalDetails =
+        new CreateTaskDetails()
+            .withType(TaskType.RequestApproval)
+            .withAssignees(List.of(assignee))
+            .withOldValue("this is a test suggestion")
+            .withSuggestion("this is a different test suggestion2");
+
+    CreateThread invalidApprovalTask =
+        new CreateThread()
+            .withFrom(ADMIN_USER)
+            .withMessage("this is a test, I am a very good programmer")
+            .withAbout(about)
+            .withType(ThreadType.Task)
+            .withTaskDetails(approvalDetails);
+
+    InvalidRequestException exception =
+        assertThrows(InvalidRequestException.class, () -> createThread(invalidApprovalTask));
+    assertEquals(400, exception.getStatusCode());
+
+    CreateTaskDetails descriptionDetails =
+        new CreateTaskDetails()
+            .withType(TaskType.RequestDescription)
+            .withAssignees(List.of(assignee))
+            .withOldValue("old description")
+            .withSuggestion("new description");
+
+    Thread validTask = null;
+    try {
+      validTask =
+          createThread(
+              new CreateThread()
+                  .withFrom(ADMIN_USER)
+                  .withMessage("Please update description")
+                  .withAbout(about)
+                  .withType(ThreadType.Task)
+                  .withTaskDetails(descriptionDetails));
+
+      ThreadList tasks = listTasks(about);
+      UUID validTaskId = validTask.getId();
+      assertTrue(tasks.getData().stream().anyMatch(thread -> thread.getId().equals(validTaskId)));
+      assertFalse(
+          tasks.getData().stream()
+              .anyMatch(
+                  thread ->
+                      thread.getTask() != null
+                          && thread.getTask().getType() == TaskType.RequestApproval));
+    } finally {
+      if (validTask != null) {
+        deleteThread(validTask.getId());
+      }
+    }
+  }
+
+  @Test
+  void post_tagTaskWithInvalidSuggestionJson_400(TestNamespace ns) throws Exception {
+    Table table = createTestTable(ns);
+    String about = String.format("<#E::table::%s>", table.getFullyQualifiedName());
+
+    User assigneeUser = SdkClients.adminClient().users().getByName("admin");
+    EntityReference assignee = assigneeUser.getEntityReference();
+
+    CreateTaskDetails taskDetails =
+        new CreateTaskDetails()
+            .withType(TaskType.RequestTag)
+            .withAssignees(List.of(assignee))
+            .withOldValue("[]")
+            .withSuggestion("this is a different test suggestion2");
+
+    CreateThread invalidTagTask =
+        new CreateThread()
+            .withFrom(ADMIN_USER)
+            .withMessage("Please update tags")
+            .withAbout(about)
+            .withType(ThreadType.Task)
+            .withTaskDetails(taskDetails);
+
+    InvalidRequestException exception =
+        assertThrows(InvalidRequestException.class, () -> createThread(invalidTagTask));
+    assertEquals(400, exception.getStatusCode());
+  }
+
+  @Test
+  void post_unsupportedLegacyFeedTaskType_400(TestNamespace ns) throws Exception {
+    Table table = createTestTable(ns);
+    String about = String.format("<#E::table::%s>", table.getFullyQualifiedName());
+
+    User assigneeUser = SdkClients.adminClient().users().getByName("admin");
+    EntityReference assignee = assigneeUser.getEntityReference();
+
+    CreateTaskDetails taskDetails =
+        new CreateTaskDetails()
+            .withType(TaskType.Generic)
+            .withAssignees(List.of(assignee))
+            .withSuggestion("{}");
+
+    CreateThread unsupportedTask =
+        new CreateThread()
+            .withFrom(ADMIN_USER)
+            .withMessage("Please process custom task")
+            .withAbout(about)
+            .withType(ThreadType.Task)
+            .withTaskDetails(taskDetails);
+
+    InvalidRequestException exception =
+        assertThrows(InvalidRequestException.class, () -> createThread(unsupportedTask));
+    assertEquals(400, exception.getStatusCode());
   }
 
   @Test
@@ -1438,6 +1557,20 @@ public class FeedResourceIT {
   private ThreadList listTasks() throws Exception {
     RequestOptions options =
         RequestOptions.builder().queryParam("type", ThreadType.Task.toString()).build();
+
+    String response =
+        SdkClients.adminClient()
+            .getHttpClient()
+            .executeForString(HttpMethod.GET, "/v1/feed", null, options);
+    return MAPPER.readValue(response, ThreadList.class);
+  }
+
+  private ThreadList listTasks(String entityLink) throws Exception {
+    RequestOptions options =
+        RequestOptions.builder()
+            .queryParam("entityLink", entityLink)
+            .queryParam("type", ThreadType.Task.toString())
+            .build();
 
     String response =
         SdkClients.adminClient()

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/feeds/FeedResource.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/feeds/FeedResource.java
@@ -56,6 +56,7 @@ import org.openmetadata.schema.api.feed.CreateThread;
 import org.openmetadata.schema.api.feed.ResolveTask;
 import org.openmetadata.schema.api.feed.ThreadCount;
 import org.openmetadata.schema.entity.feed.Thread;
+import org.openmetadata.schema.exception.JsonParsingException;
 import org.openmetadata.schema.type.EntityReference;
 import org.openmetadata.schema.type.MetadataOperation;
 import org.openmetadata.schema.type.Post;
@@ -638,7 +639,7 @@ public class FeedResource {
     if (value != null) {
       try {
         JsonUtils.readObjects(value, TagLabel.class);
-      } catch (Exception ex) {
+      } catch (JsonParsingException ex) {
         throw new IllegalArgumentException(
             String.format("Task %s must be valid JSON for tag tasks.", fieldName), ex);
       }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/feeds/FeedResource.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/feeds/FeedResource.java
@@ -59,8 +59,11 @@ import org.openmetadata.schema.entity.feed.Thread;
 import org.openmetadata.schema.type.EntityReference;
 import org.openmetadata.schema.type.MetadataOperation;
 import org.openmetadata.schema.type.Post;
+import org.openmetadata.schema.type.TagLabel;
 import org.openmetadata.schema.type.TaskStatus;
+import org.openmetadata.schema.type.TaskType;
 import org.openmetadata.schema.type.ThreadType;
+import org.openmetadata.schema.utils.JsonUtils;
 import org.openmetadata.schema.utils.ResultList;
 import org.openmetadata.service.Entity;
 import org.openmetadata.service.jdbi3.FeedFilter;
@@ -74,6 +77,7 @@ import org.openmetadata.service.security.policyevaluator.PostResourceContext;
 import org.openmetadata.service.security.policyevaluator.ResourceContextInterface;
 import org.openmetadata.service.security.policyevaluator.SubjectContext;
 import org.openmetadata.service.security.policyevaluator.ThreadResourceContext;
+import org.openmetadata.service.util.EntityUtil;
 import org.openmetadata.service.util.RestUtil;
 import org.openmetadata.service.util.RestUtil.PatchResponse;
 
@@ -416,6 +420,7 @@ public class FeedResource {
       @Context UriInfo uriInfo,
       @Context SecurityContext securityContext,
       @Valid CreateThread create) {
+    validateCreateThread(create);
     Thread thread = mapper.createToEntity(create, securityContext.getUserPrincipal().getName());
     addHref(uriInfo, dao.create(thread));
     return Response.created(thread.getHref())
@@ -582,5 +587,61 @@ public class FeedResource {
           @PathParam("id")
           UUID id) {
     return new ResultList<>(dao.listPosts(id));
+  }
+
+  private void validateCreateThread(CreateThread create) {
+    if (create.getAbout() == null || create.getAbout().isBlank()) {
+      throw new IllegalArgumentException("Thread about is required.");
+    }
+
+    if (create.getTaskDetails() == null) {
+      if (create.getType() == ThreadType.Task) {
+        throw new IllegalArgumentException("Task details are required for task threads.");
+      }
+      return;
+    }
+
+    if (create.getType() != ThreadType.Task) {
+      throw new IllegalArgumentException("Task details are only allowed for task threads.");
+    }
+
+    TaskType taskType = create.getTaskDetails().getType();
+    if (taskType == null) {
+      throw new IllegalArgumentException("Task type is required for task threads.");
+    }
+
+    if (!isSupportedLegacyFeedTask(taskType)) {
+      throw new IllegalArgumentException(
+          String.format("Task type %s is not supported by feed threads.", taskType));
+    }
+
+    if (taskType == TaskType.RequestApproval) {
+      MessageParser.EntityLink entityLink = MessageParser.EntityLink.parse(create.getAbout());
+      if (entityLink.getLinkType() != MessageParser.EntityLink.LinkType.ENTITY) {
+        throw new IllegalArgumentException("RequestApproval tasks must target an entity.");
+      }
+    }
+
+    if (EntityUtil.isTagTask(taskType)) {
+      validateTagTaskValue(create.getTaskDetails().getOldValue(), "oldValue");
+      validateTagTaskValue(create.getTaskDetails().getSuggestion(), "suggestion");
+    }
+  }
+
+  private boolean isSupportedLegacyFeedTask(TaskType taskType) {
+    return EntityUtil.isDescriptionTask(taskType)
+        || EntityUtil.isTagTask(taskType)
+        || EntityUtil.isApprovalTask(taskType);
+  }
+
+  private void validateTagTaskValue(String value, String fieldName) {
+    if (value != null) {
+      try {
+        JsonUtils.readObjects(value, TagLabel.class);
+      } catch (Exception ex) {
+        throw new IllegalArgumentException(
+            String.format("Task %s must be valid JSON for tag tasks.", fieldName), ex);
+      }
+    }
   }
 }


### PR DESCRIPTION
### Describe your changes:

Fixes #26554

Backports legacy `/v1/feed` task validation to `1.12.13` so unsupported task types, column-level `RequestApproval`, and invalid tag-task JSON are rejected before persistence.

#
### Type of change:
- [x] Bug fix

#
### High-level design:
N/A - small bug fix.

#
### Tests:

#### Use cases covered
- Rejects column-level `RequestApproval` feed tasks while preserving valid description tasks and task listing.
- Rejects tag tasks with non-JSON suggestions.
- Rejects unsupported legacy feed task types.

#### Unit tests
- [ ] Not applicable; backend API integration coverage added.

#### Backend integration tests
- [x] Added integration tests in `openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/FeedResourceIT.java`.

#### Ingestion integration tests
- [x] Not applicable.

#### Playwright (UI) tests
- [x] Not applicable.

#### Manual testing performed
- `mvn -pl openmetadata-service,openmetadata-integration-tests spotless:apply`
- `mvn -pl openmetadata-spec -DskipTests install`
- `mvn -pl openmetadata-service,openmetadata-integration-tests -DskipTests test-compile`
- `mvn -pl openmetadata-service -DskipTests install`
- `mvn -pl openmetadata-k8s-operator -DskipTests install`
- `mvn -U -pl openmetadata-integration-tests -Dit.test=FeedResourceIT -DfailIfNoTests=false failsafe:integration-test@parallel-tests failsafe:verify` ran `FeedResourceIT` assertions successfully (50 tests, 0 failures/errors), then Maven exited nonzero during Failsafe verify because the forked JVM hit the branch-local shutdown error `ContextHandler$ScopedContext.clearLayerAttributes()`.

#
### UI screen recording / screenshots:
Not applicable.

#
### Checklist:
- [x] I have read the CONTRIBUTING document.
- [x] My PR title is `Fixes #26554: Validate legacy feed task payloads`.
- [x] My PR is linked to a GitHub issue via `Fixes #26554` above.
- [x] I have added tests and listed them above.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR backports payload validation for the legacy `/v1/feed` task creation endpoint to branch `1.12.13`. The new `validateCreateThread` guard runs before any persistence, rejecting unsupported task types (`Generic`, `RequestTestCaseFailureResolution`), column-level `RequestApproval` requests, and tag tasks whose `oldValue` or `suggestion` is not valid JSON.

- `FeedResource.java`: adds a five-step private validation method wired into `createThread()`, delegating to `MessageParser.EntityLink.parse()` for link-type inspection and `JsonUtils.readObjects()` for tag JSON parsing; all rejections throw `IllegalArgumentException` which the existing `CatalogGenericExceptionMapper` converts to HTTP 400.
- `FeedResourceIT.java`: adds three integration tests (column-level `RequestApproval` → 400, non-JSON tag suggestion → 400, unsupported `Generic` task type → 400) and a `listTasks` helper to verify the thread list is unpolluted after a rejected request.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — validation logic is narrowly scoped to the HTTP create-thread endpoint, internal callers like TestCaseResolutionStatusRepository bypass it via feedRepository.create() and are unaffected, and all exception paths consistently produce HTTP 400 via the existing CatalogGenericExceptionMapper mapping.

The change adds a single private validation method called unconditionally from createThread(); the five guard conditions are independently correct, the EntityLink.parse() call is protected by the preceding blank-about check and only throws IllegalArgumentException itself, and the tag-JSON path catches JsonParsingException before it can surface as a 500. Internal task creation (e.g. incident resolution) writes directly through FeedRepository and is completely unaffected. Three integration tests cover the three new rejection paths with specific status-code assertions.

No files require special attention.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-service/src/main/java/org/openmetadata/service/resources/feeds/FeedResource.java | Adds validateCreateThread() with five-step validation: blank about, task/non-task consistency, TaskType nullity, supported-legacy-type gate, RequestApproval entity-link-type guard, and tag-task JSON validation; all paths throw IllegalArgumentException which maps to HTTP 400. |
| openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/FeedResourceIT.java | Adds three integration tests covering the three new rejection paths (column-level RequestApproval, non-JSON tag suggestion, unsupported task type) and a listTasks helper; test coverage is solid and the assertions are specific. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[POST /v1/feed] --> B{about null/blank?}
    B -- yes --> ERR1[400: about required]
    B -- no --> C{taskDetails null?}
    C -- yes, type=Task --> ERR2[400: task details required]
    C -- yes, type!=Task --> OK1[continue to create]
    C -- no --> D{type != Task?}
    D -- yes --> ERR3[400: task details only for tasks]
    D -- no --> E{taskType null?}
    E -- yes --> ERR4[400: task type required]
    E -- no --> F{isSupportedLegacyFeedTask?}
    F -- no --> ERR5[400: unsupported task type]
    F -- yes --> G{taskType == RequestApproval?}
    G -- yes --> H{linkType == ENTITY?}
    H -- no --> ERR6[400: RequestApproval must target entity]
    H -- yes --> I{isTagTask?}
    G -- no --> I
    I -- yes --> J[validateTagTaskValue oldValue + suggestion]
    J -- invalid JSON --> ERR7[400: must be valid JSON]
    J -- valid --> OK2[dao.create thread]
    I -- no --> OK2
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[POST /v1/feed] --> B{about null/blank?}
    B -- yes --> ERR1[400: about required]
    B -- no --> C{taskDetails null?}
    C -- yes, type=Task --> ERR2[400: task details required]
    C -- yes, type!=Task --> OK1[continue to create]
    C -- no --> D{type != Task?}
    D -- yes --> ERR3[400: task details only for tasks]
    D -- no --> E{taskType null?}
    E -- yes --> ERR4[400: task type required]
    E -- no --> F{isSupportedLegacyFeedTask?}
    F -- no --> ERR5[400: unsupported task type]
    F -- yes --> G{taskType == RequestApproval?}
    G -- yes --> H{linkType == ENTITY?}
    H -- no --> ERR6[400: RequestApproval must target entity]
    H -- yes --> I{isTagTask?}
    G -- no --> I
    I -- yes --> J[validateTagTaskValue oldValue + suggestion]
    J -- invalid JSON --> ERR7[400: must be valid JSON]
    J -- valid --> OK2[dao.create thread]
    I -- no --> OK2
```

</a>
</details>

<sub>Reviews (2): Last reviewed commit: ["Narrow tag-task JSON validation catch to..."](https://github.com/open-metadata/openmetadata/commit/c44514a3defa8dd7765c0f5132b892b9a9b3284a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40562909)</sub>

<!-- /greptile_comment -->