### PR TITLE
Addressed context center document page feedbacks

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/ContextCenter/DocumentsView/DocumentsView.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/ContextCenter/DocumentsView/DocumentsView.component.tsx
@@ -26,6 +26,7 @@ import {
   Typography,
 } from '@openmetadata/ui-core-components';
 import {
+  Check,
   ChevronRight,
   Copy06,
   Download01,
@@ -39,7 +40,7 @@ import { useTranslation } from 'react-i18next';
 import { ReactComponent as FolderIcon } from '../../../assets/svg/ic-folder-new.svg';
 import ErrorPlaceHolder from '../../../components/common/ErrorWithPlaceholder/ErrorPlaceHolder';
 import { ERROR_PLACEHOLDER_TYPE } from '../../../enums/common.enum';
-import { moveFileToFolder } from '../../../rest/assetAPI';
+import { moveFileToFolder, moveFileToRoot } from '../../../rest/assetAPI';
 import { formatBytes } from '../../../utils/ContextCenterPureUtils';
 import { getShortRelativeTime } from '../../../utils/date-time/DateTimeUtils';
 import { getEntityName } from '../../../utils/EntityNameUtils';
@@ -60,7 +61,11 @@ import {
    dropdown from the bulk Move button in ListHeader.
 --------------------------------------------------------------- */
 
-const FolderPickerMenu: FC<FolderPickerMenuProps> = ({ folders, onPick }) => {
+const FolderPickerMenu: FC<FolderPickerMenuProps> = ({
+  folders,
+  currentFolderId,
+  onPick,
+}) => {
   const { t } = useTranslation();
 
   if (folders.length === 0) {
@@ -75,15 +80,39 @@ const FolderPickerMenu: FC<FolderPickerMenuProps> = ({ folders, onPick }) => {
     <Dropdown.Menu
       className="tw:max-h-48 tw:overflow-y-auto"
       onAction={(key) => onPick(key as string)}>
-      {folders.map((folder) => (
-        <Dropdown.Item
-          data-testid={`move-to-folder-${folder.id}`}
-          icon={FolderIcon}
-          id={folder.id}
-          key={folder.id}
-          label={folder.name}
-        />
-      ))}
+      {folders.map((folder) => {
+        const isCurrent = folder.id === currentFolderId;
+
+        return (
+          <Dropdown.Item
+            className={isCurrent ? 'tw:bg-secondary' : undefined}
+            data-testid={`move-to-folder-${folder.id}`}
+            id={folder.id}
+            key={folder.id}
+            textValue={folder.name}>
+            {() => (
+              <Box align="center" className="tw:w-full" justify="between">
+                <Box align="center" gap={2}>
+                  <FolderIcon
+                    aria-hidden="true"
+                    className="tw:size-4 tw:shrink-0"
+                  />
+                  <Typography ellipsis size="text-sm">
+                    {folder.name}
+                  </Typography>
+                </Box>
+                {isCurrent && (
+                  <Check
+                    aria-hidden="true"
+                    className="tw:size-4 tw:shrink-0 tw:text-brand-primary tw:ml-2"
+                    strokeWidth={2}
+                  />
+                )}
+              </Box>
+            )}
+          </Dropdown.Item>
+        );
+      })}
     </Dropdown.Menu>
   );
 };
@@ -103,16 +132,16 @@ const FileActions: FC<FileActionsProps> = ({
   const { t } = useTranslation();
   const [isMoving, setIsMoving] = useState(false);
 
-  const availableFolders = useMemo(
-    () => folders.filter((folder) => folder.id !== file.folder?.id),
-    [folders, file]
-  );
-
   const handleMoveToFolder = async (folderId: string) => {
     try {
       setIsMoving(true);
-      await moveFileToFolder(file.id, folderId);
-      onFileMoved?.(file, folderId);
+      if (folderId === file.folder?.id) {
+        await moveFileToRoot(file.id);
+        onFileMoved?.(file, null);
+      } else {
+        await moveFileToFolder(file.id, folderId);
+        onFileMoved?.(file, folderId);
+      }
       showSuccessToast(
         t('message.entity-moved-successfully', { entity: t('label.document') })
       );
@@ -147,7 +176,7 @@ const FileActions: FC<FileActionsProps> = ({
               <Dropdown.Item
                 data-testid="move-btn"
                 icon={Pin02}
-                isDisabled={isMoving || availableFolders.length === 0}>
+                isDisabled={isMoving || folders.length === 0}>
                 {() => (
                   <Box align="center" justify="between">
                     <Typography ellipsis className="tw:grow tw:text-secondary">
@@ -166,7 +195,8 @@ const FileActions: FC<FileActionsProps> = ({
                 offset={-6}
                 placement="right top">
                 <FolderPickerMenu
-                  folders={availableFolders}
+                  currentFolderId={file.folder?.id}
+                  folders={folders}
                   onPick={handleMoveToFolder}
                 />
               </Dropdown.Popover>

--- a/openmetadata-ui/src/main/resources/ui/src/components/ContextCenter/DocumentsView/DocumentsView.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/ContextCenter/DocumentsView/DocumentsView.component.tsx
@@ -85,7 +85,7 @@ const FolderPickerMenu: FC<FolderPickerMenuProps> = ({
 
         return (
           <Dropdown.Item
-            className={isCurrent ? 'tw:bg-secondary' : undefined}
+            className={isCurrent ? 'tw:[&>div]:bg-utility-blue-50' : undefined}
             data-testid={`move-to-folder-${folder.id}`}
             id={folder.id}
             key={folder.id}
@@ -104,7 +104,7 @@ const FolderPickerMenu: FC<FolderPickerMenuProps> = ({
                 {isCurrent && (
                   <Check
                     aria-hidden="true"
-                    className="tw:size-4 tw:shrink-0 tw:text-brand-primary tw:ml-2"
+                    className="tw:size-4 tw:shrink-0 tw:text-fg-brand-primary tw:ml-2"
                     strokeWidth={2}
                   />
                 )}

--- a/openmetadata-ui/src/main/resources/ui/src/components/ContextCenter/DocumentsView/DocumentsView.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/ContextCenter/DocumentsView/DocumentsView.component.tsx
@@ -138,13 +138,20 @@ const FileActions: FC<FileActionsProps> = ({
       if (folderId === file.folder?.id) {
         await moveFileToRoot(file.id);
         onFileMoved?.(file, null);
+        showSuccessToast(
+          t('message.entity-removed-from-folder', {
+            entity: t('label.document'),
+          })
+        );
       } else {
         await moveFileToFolder(file.id, folderId);
         onFileMoved?.(file, folderId);
+        showSuccessToast(
+          t('message.entity-moved-successfully', {
+            entity: t('label.document'),
+          })
+        );
       }
-      showSuccessToast(
-        t('message.entity-moved-successfully', { entity: t('label.document') })
-      );
     } catch (err) {
       showErrorToast(err as AxiosError);
     } finally {

--- a/openmetadata-ui/src/main/resources/ui/src/components/ContextCenter/DocumentsView/DocumentsView.interface.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/components/ContextCenter/DocumentsView/DocumentsView.interface.ts
@@ -28,7 +28,7 @@ export interface DocumentsViewProps {
   selectedIds?: Set<string>;
   onDownload?: (file: ContextFile) => void;
   onDeleteFile?: (file: ContextFile) => void;
-  onFileMoved?: (file: ContextFile, targetFolderId: string) => void;
+  onFileMoved?: (file: ContextFile, targetFolderId: string | null) => void;
   onPreview?: (file: ContextFile | undefined) => void;
   onSelectFile?: (fileId: string) => void;
   onBulkDelete?: () => void;
@@ -49,6 +49,7 @@ export interface DocumentPreviewPanelProps {
 
 export interface FolderPickerMenuProps {
   folders: FolderOption[];
+  currentFolderId?: string;
   onPick: (folderId: string) => void;
 }
 export interface FileActionsProps {
@@ -57,7 +58,7 @@ export interface FileActionsProps {
   file: ContextFile;
   folders?: FolderOption[];
   onDeleteFile?: (file: ContextFile) => void;
-  onFileMoved?: (file: ContextFile, targetFolderId: string) => void;
+  onFileMoved?: (file: ContextFile, targetFolderId: string | null) => void;
 }
 export interface ListHeaderProps {
   canDelete?: boolean;
@@ -80,7 +81,7 @@ export interface FileRowProps {
   isSelected?: boolean;
   onDownload?: (file: ContextFile) => void;
   onDeleteFile?: (file: ContextFile) => void;
-  onFileMoved?: (file: ContextFile, targetFolderId: string) => void;
+  onFileMoved?: (file: ContextFile, targetFolderId: string | null) => void;
   onPreview?: (file: ContextFile) => void;
   onSelectFile?: (fileId: string) => void;
 }

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/ar-sa.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/ar-sa.json
@@ -3083,6 +3083,7 @@
     "entity-owned-by-name": "هذا الكيان مملوك لـ {{entityOwner}}",
     "entity-pattern-validation": "يمكن أن يتضمن {{entity}} مسافات والأحرف الخاصة التالية فقط {{pattern}}",
     "entity-pipeline-information": "<0>يجب ربط كل {{entity}} بسير عمل!</0> لا يحتوي {{type}} هذا على سير عمل بعد. لنقم بإنشاء واحد حتى يمكن ربط {{entity}} وجدولته.",
+    "entity-removed-from-folder": "تم إزالة {{entity}} من المجلد",
     "entity-restored-error": "خطأ أثناء استعادة {{entity}}",
     "entity-restored-success": "تمت استعادة {{entity}} بنجاح",
     "entity-saved-successfully": "تم حفظ {{entity}} بنجاح",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/de-de.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/de-de.json
@@ -3083,6 +3083,7 @@
     "entity-owned-by-name": "Diese Entität gehört {{entityOwner}}.",
     "entity-pattern-validation": "{{entity}} kann Leerzeichen und nur die folgenden Sonderzeichen enthalten: {{pattern}}",
     "entity-pipeline-information": "<0>Jede {{entity}} muss mit einer Pipeline verknüpft sein!</0> Dieser {{type}} hat noch keine Pipeline. Lassen Sie uns eine erstellen, damit Ihre {{entity}} verknüpft und geplant werden kann.",
+    "entity-removed-from-folder": "{{entity}} aus Ordner entfernt",
     "entity-restored-error": "Fehler beim Wiederherstellen von {{entity}}.",
     "entity-restored-success": "{{entity}} erfolgreich wiederhergestellt.",
     "entity-saved-successfully": "{{entity}} erfolgreich gespeichert",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/en-us.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/en-us.json
@@ -3083,6 +3083,7 @@
     "entity-owned-by-name": "This entity is owned by {{entityOwner}}",
     "entity-pattern-validation": "{{entity}} can include spaces and only the following special characters {{pattern}}",
     "entity-pipeline-information": "<0>Every {{entity}} must be linked to a pipeline!</0> This {{type}} doesn't have a pipeline yet. Let's create one so your {{entity}} can be linked and scheduled.",
+    "entity-removed-from-folder": "{{entity}} removed from folder",
     "entity-restored-error": "Error while restoring {{entity}}",
     "entity-restored-success": "{{entity}} restored successfully",
     "entity-saved-successfully": "{{entity}} saved successfully",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/es-es.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/es-es.json
@@ -3083,6 +3083,7 @@
     "entity-owned-by-name": "Esta entidad es propiedad de {{entityOwner}}",
     "entity-pattern-validation": "{{entity}} puede incluir espacios y solo los siguientes caracteres especiales {{pattern}}",
     "entity-pipeline-information": "<0>¡Cada {{entity}} debe estar vinculada a un pipeline!</0> Este {{type}} aún no tiene un pipeline. Vamos a crear uno para que su {{entity}} pueda ser vinculada y programada.",
+    "entity-removed-from-folder": "{{entity}} eliminado de la carpeta",
     "entity-restored-error": "Error al restaurar {{entity}}",
     "entity-restored-success": "{{entity}} restaurado exitosamente",
     "entity-saved-successfully": "{{entity}} guardado exitosamente",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/fr-fr.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/fr-fr.json
@@ -3083,6 +3083,7 @@
     "entity-owned-by-name": "Cette Resource appartient à {{entityOwner}}",
     "entity-pattern-validation": "{{entity}} peut contenir des espaces et seulement les caractères spéciaux suivants {{pattern}}",
     "entity-pipeline-information": "<0>Chaque {{entity}} doit être liée à un pipeline !</0> Ce {{type}} n'a pas encore de pipeline. Créons-en un pour que votre {{entity}} puisse être liée et programmée.",
+    "entity-removed-from-folder": "{{entity}} retiré du dossier",
     "entity-restored-error": "Erreur lors de la restauration de {{entity}}",
     "entity-restored-success": "{{entity}} restauré avec succès",
     "entity-saved-successfully": "{{entity}} sauvegardé avec succès",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/gl-es.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/gl-es.json
@@ -3083,6 +3083,7 @@
     "entity-owned-by-name": "Esta entidade é propiedade de {{entityOwner}}",
     "entity-pattern-validation": "{{entity}} pode incluír espazos e só os seguintes caracteres especiais {{pattern}}",
     "entity-pipeline-information": "<0>Cada {{entity}} debe estar vinculada a unha canalización!</0> Este {{type}} aínda non ten unha canalización. Creamos unha para que a súa {{entity}} poida estar vinculada e programada.",
+    "entity-removed-from-folder": "{{entity}} eliminado do cartafol",
     "entity-restored-error": "Erro ao restaurar {{entity}}",
     "entity-restored-success": "{{entity}} restaurado correctamente",
     "entity-saved-successfully": "{{entity}} gardado correctamente",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/he-he.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/he-he.json
@@ -3083,6 +3083,7 @@
     "entity-owned-by-name": "ישות זו שייכת ל-{{entityOwner}}",
     "entity-pattern-validation": "{{entity}} יכול לכלול רווחים ורק את התווים המיוחדים הבאים {{pattern}}",
     "entity-pipeline-information": "<0>כל {{entity}} חייב להיות מקושר לצינור!</0> ל{{type}} הזה אין עדיין צינור. בואו ניצור אחד כדי שה{{entity}} שלכם יוכל להיות מקושר ומתוכנן.",
+    "entity-removed-from-folder": "{{entity}} הוסר מהתיקייה",
     "entity-restored-error": "שגיאה בעת שחזור {{entity}}",
     "entity-restored-success": "{{entity}} שוחזרה בהצלחה",
     "entity-saved-successfully": "{{entity}} נשמרה בהצלחה",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/ja-jp.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/ja-jp.json
@@ -3083,6 +3083,7 @@
     "entity-owned-by-name": "このエンティティは {{entityOwner}} が所有しています",
     "entity-pattern-validation": "{{entity}} にはスペースと、次の特殊文字 {{pattern}} のみを含めることができます",
     "entity-pipeline-information": "<0>すべての{{entity}}はパイプラインにリンクされる必要があります！</0> この{{type}}にはまだパイプラインがありません。{{entity}}をリンクしてスケジュールできるように作成しましょう。",
+    "entity-removed-from-folder": "{{entity}} をフォルダから削除しました",
     "entity-restored-error": "{{entity}} の復元中にエラーが発生しました",
     "entity-restored-success": "{{entity}} は正常に復元されました",
     "entity-saved-successfully": "{{entity}} は正常に保存されました",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/ko-kr.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/ko-kr.json
@@ -3083,6 +3083,7 @@
     "entity-owned-by-name": "이 엔티티는 {{entityOwner}}이(가) 소유하고 있습니다",
     "entity-pattern-validation": "{{entity}}에는 공백과 다음 특수 문자만 포함될 수 있습니다: {{pattern}}",
     "entity-pipeline-information": "<0>모든 {{entity}}는 파이프라인에 연결되어야 합니다!</0> 이 {{type}}에는 아직 파이프라인이 없습니다. {{entity}}를 연결하고 예약할 수 있도록 하나를 만들어 보겠습니다.",
+    "entity-removed-from-folder": "{{entity}}이(가) 폴더에서 제거되었습니다",
     "entity-restored-error": "{{entity}} 복원 중 오류가 발생했습니다",
     "entity-restored-success": "{{entity}}이(가) 성공적으로 복원되었습니다",
     "entity-saved-successfully": "{{entity}}이(가) 성공적으로 저장되었습니다",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/mr-in.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/mr-in.json
@@ -3083,6 +3083,7 @@
     "entity-owned-by-name": "हा घटक {{entityOwner}} द्वारे मालकीचा आहे",
     "entity-pattern-validation": "{{entity}} मध्ये स्पेस आणि फक्त खालील विशेष वर्णांचा समावेश असू शकतो {{pattern}}",
     "entity-pipeline-information": "<0>प्रत्येक {{entity}} पाइपलाइनशी जोडलेले असावे!</0> या {{type}} कडे अजून पाइपलाइन नाही. आम्ही एक तयार करू या यातील तुमचे {{entity}} जोडले आणि नियोजित केले जाऊ शकते.",
+    "entity-removed-from-folder": "{{entity}} फोल्डरमधून काढले",
     "entity-restored-error": "{{entity}} पुनर्संचयित करताना त्रुटी",
     "entity-restored-success": "{{entity}} यशस्वीरित्या पुनर्संचयित केले",
     "entity-saved-successfully": "{{entity}} यशस्वीरित्या जतन केले",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/nl-nl.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/nl-nl.json
@@ -3083,6 +3083,7 @@
     "entity-owned-by-name": "Dit entiteit is eigendom van {{entityOwner}}",
     "entity-pattern-validation": "{{entity}} kan spaties bevatten en alleen de volgende speciale tekens {{pattern}}",
     "entity-pipeline-information": "<0>Elke {{entity}} moet gekoppeld zijn aan een pipeline!</0> Deze {{type}} heeft nog geen pipeline. Laten we er een maken zodat uw {{entity}} gekoppeld en gepland kan worden.",
+    "entity-removed-from-folder": "{{entity}} uit map verwijderd",
     "entity-restored-error": "Fout bij het herstellen van {{entity}}",
     "entity-restored-success": "{{entity}} succesvol hersteld",
     "entity-saved-successfully": "{{entity}} succesvol opgeslagen",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/pr-pr.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/pr-pr.json
@@ -3083,6 +3083,7 @@
     "entity-owned-by-name": "این موجودیت متعلق به {{entityOwner}} است.",
     "entity-pattern-validation": "{{entity}} می‌تواند شامل فاصله‌ها و تنها کاراکترهای خاص {{pattern}} باشد.",
     "entity-pipeline-information": "<0>¡Cada {{entity}} debe estar vinculada a un pipeline!</0> Este {{type}} aún no tiene un pipeline. Vamos a crear uno para que su {{entity}} pueda estar vinculada y programada.",
+    "entity-removed-from-folder": "{{entity}} از پوشه حذف شد",
     "entity-restored-error": "خطا در هنگام بازیابی {{entity}}",
     "entity-restored-success": "{{entity}} با موفقیت بازیابی شد.",
     "entity-saved-successfully": "{{entity}} با موفقیت ذخیره شد.",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/pt-br.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/pt-br.json
@@ -3083,6 +3083,7 @@
     "entity-owned-by-name": "Esta entidade é propriedade de {{entityOwner}}",
     "entity-pattern-validation": "{{entity}} pode incluir espaços e apenas os seguintes caracteres especiais {{pattern}}",
     "entity-pipeline-information": "<0>Toda {{entity}} deve estar vinculada a um pipeline!</0> Esta {{type}} ainda não tem um pipeline. Vamos criar um para que sua {{entity}} possa ser vinculada e agendada.",
+    "entity-removed-from-folder": "{{entity}} removido da pasta",
     "entity-restored-error": "Erro ao restaurar {{entity}}",
     "entity-restored-success": "{{entity}} restaurado com sucesso",
     "entity-saved-successfully": "{{entity}} salvo com sucesso",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/pt-pt.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/pt-pt.json
@@ -3083,6 +3083,7 @@
     "entity-owned-by-name": "Esta entidade é propriedade de {{entityOwner}}",
     "entity-pattern-validation": "{{entity}} pode incluir espaços e apenas os seguintes caracteres especiais {{pattern}}",
     "entity-pipeline-information": "<0>Todas as {{entity}} devem estar ligadas a um pipeline!</0> Este {{type}} ainda não tem um pipeline. Vamos criar um para que a sua {{entity}} possa ser ligada e agendada.",
+    "entity-removed-from-folder": "{{entity}} removido da pasta",
     "entity-restored-error": "Erro ao restaurar {{entity}}",
     "entity-restored-success": "{{entity}} restaurado com sucesso",
     "entity-saved-successfully": "{{entity}} salvo com sucesso",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/ru-ru.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/ru-ru.json
@@ -3083,6 +3083,7 @@
     "entity-owned-by-name": "Этот объект принадлежит {{entityOwner}}",
     "entity-pattern-validation": "{{entity}} может содержать пробелы и только следующие специальные символы {{pattern}}",
     "entity-pipeline-information": "<0>Каждая {{entity}} должна быть связана с конвейером!</0> У этого {{type}} ещё нет конвейера. Давайте создадим его, чтобы ваша {{entity}} могла быть связана и запланирована.",
+    "entity-removed-from-folder": "Объект «{{entity}}» удалён из папки",
     "entity-restored-error": "Ошибка при восстановлении объекта «{{entity}}»",
     "entity-restored-success": "Объект «{{entity}}» восстановлен",
     "entity-saved-successfully": "Объект «{{entity}}» сохранен",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/sv-se.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/sv-se.json
@@ -3083,6 +3083,7 @@
     "entity-owned-by-name": "Denna entitet ägs av {{entityOwner}}",
     "entity-pattern-validation": "{{entity}} kan innehålla blanksteg och endast följande specialtecken {{pattern}}",
     "entity-pipeline-information": "<0>Varje {{entity}} måste kopplas till en pipeline!</0> Denna {{type}} har ingen pipeline ännu. Låt oss skapa en så att din {{entity}} kan kopplas och schemaläggas.",
+    "entity-removed-from-folder": "{{entity}} togs bort från mappen",
     "entity-restored-error": "Fel vid återställning av {{entity}}",
     "entity-restored-success": "{{entity}} återställdes",
     "entity-saved-successfully": "{{entity}} sparades",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/th-th.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/th-th.json
@@ -3083,6 +3083,7 @@
     "entity-owned-by-name": "เอนทิตีนี้เป็นของ {{entityOwner}}",
     "entity-pattern-validation": "{{entity}} สามารถรวมช่องว่างและตัวอักษรพิเศษต่อไปนี้ได้ {{pattern}}",
     "entity-pipeline-information": "<0>{{entity}} ทุกตัวต้องเชื่อมต่อกับไปป์ไลน์!</0> {{type}} นี้ยังไม่มีไปป์ไลน์ มาสร้างหนึ่งอันเพื่อให้ {{entity}} ของคุณสามารถเชื่อมต่อและจัดตารางเวลาได้",
+    "entity-removed-from-folder": "นำ {{entity}} ออกจากโฟลเดอร์แล้ว",
     "entity-restored-error": "เกิดข้อผิดพลาดขณะกู้คืน {{entity}}",
     "entity-restored-success": "กู้คืน {{entity}} สำเร็จ",
     "entity-saved-successfully": "{{entity}} ถูกบันทึกสำเร็จ",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/tr-tr.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/tr-tr.json
@@ -3083,6 +3083,7 @@
     "entity-owned-by-name": "Bu varlık {{entityOwner}} adlı kullanıcıya aittir",
     "entity-pattern-validation": "{{entity}} boşluk ve yalnızca şu özel karakterleri içerebilir: {{pattern}}",
     "entity-pipeline-information": "<0>Her {{entity}} bir boru hattına bağlı olmalıdır!</0> Bu {{type}} henüz bir boru hattına sahip değil. {{entity}} bağlanıp zamanlanabilmesi için bir tane oluşturalim.",
+    "entity-removed-from-folder": "{{entity}} klasörden kaldırıldı",
     "entity-restored-error": "{{entity}} geri yüklenirken hata oluştu",
     "entity-restored-success": "{{entity}} başarıyla geri yüklendi",
     "entity-saved-successfully": "{{entity}} başarıyla kaydedildi",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/zh-cn.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/zh-cn.json
@@ -3083,6 +3083,7 @@
     "entity-owned-by-name": "此实体归{{entityOwner}}所有",
     "entity-pattern-validation": "{{entity}}可以包含空格和以下特殊字符{{pattern}}",
     "entity-pipeline-information": "<0>每个{{entity}}都必须链接到管道！</0>这个{{type}}还没有管道。让我们创建一个，这样您的{{entity}}就可以被链接和调度了。",
+    "entity-removed-from-folder": "{{entity}}已从文件夹中移除",
     "entity-restored-error": "还原{{entity}}时出现错误",
     "entity-restored-success": "{{entity}}还原成功",
     "entity-saved-successfully": "{{entity}}保存成功",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/zh-tw.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/zh-tw.json
@@ -3083,6 +3083,7 @@
     "entity-owned-by-name": "此實體由 {{entityOwner}} 擁有",
     "entity-pattern-validation": "{{entity}} 可以包含空格和以下特殊字元 {{pattern}}",
     "entity-pipeline-information": "<0>每個 {{entity}} 都必須連結到一個管線！</0> 此 {{type}} 尚未有管線。讓我們建立一個，以便您的 {{entity}} 可以被連結和排程。",
+    "entity-removed-from-folder": "{{entity}} 已從資料夾中移除",
     "entity-restored-error": "還原 {{entity}} 時發生錯誤",
     "entity-restored-success": "{{entity}} 還原成功",
     "entity-saved-successfully": "{{entity}} 儲存成功",

--- a/openmetadata-ui/src/main/resources/ui/src/pages/ContextCenterPage/ContextCenterDocumentsPage/ContextCenterDocumentsPage.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/ContextCenterPage/ContextCenterDocumentsPage/ContextCenterDocumentsPage.tsx
@@ -230,17 +230,19 @@ const ContextCenterDocumentsPage: FC = () => {
   }, [fileToDelete, t]);
 
   const handleFileMoved = useCallback(
-    (file: ContextFile, targetFolderId: string) => {
+    (file: ContextFile, targetFolderId: string | null) => {
       setAllDocuments((prev) =>
         prev.map((d) =>
           d.id === file.id
             ? {
                 ...d,
-                folder: {
-                  ...d.folder,
-                  id: targetFolderId,
-                  type: d.folder?.type ?? 'folder',
-                },
+                folder: targetFolderId
+                  ? {
+                      ...d.folder,
+                      id: targetFolderId,
+                      type: d.folder?.type ?? 'folder',
+                    }
+                  : undefined,
               }
             : d
         )

--- a/openmetadata-ui/src/main/resources/ui/src/rest/assetAPI.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/rest/assetAPI.ts
@@ -145,6 +145,10 @@ export const bulkMoveFilesToFolder = async (
   return response.data;
 };
 
+export const moveFileToRoot = async (driveFileId: string): Promise<void> => {
+  await APIClient.put(`/contextCenter/drive/files/${driveFileId}/move`, {});
+}
+
 export const uploadDriveFile = async (
   file: File,
   folderFqn?: string

--- a/openmetadata-ui/src/main/resources/ui/src/rest/assetAPI.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/rest/assetAPI.ts
@@ -147,7 +147,7 @@ export const bulkMoveFilesToFolder = async (
 
 export const moveFileToRoot = async (driveFileId: string): Promise<void> => {
   await APIClient.put(`/contextCenter/drive/files/${driveFileId}/move`, {});
-}
+};
 
 export const uploadDriveFile = async (
   file: File,


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:

https://github.com/user-attachments/assets/0a24badb-d0ac-48e8-8c50-532cbb0c3b23


Fixes [29590](https://github.com/open-metadata/OpenMetadata/issues/29590)
<!--
Linking an issue is REQUIRED. Replace <issue-number> with the GitHub issue number this PR addresses
(e.g., `Fixes #12345`). GitHub will auto-link it. If no issue exists, please open one first so the
problem and design can be discussed before review.
-->

<!--
Short blurb explaining:
- What changes did you make?
- Why did you make them?
-->

I worked on ... because ...

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### High-level design:
<!--
REQUIRED for large PRs (new features, refactors, breaking changes, or anything touching >5 files).
Skip for small bug fixes and trivial changes.

Cover:
- Architecture / approach you took and why
- Key components or files added/changed and how they interact
- Alternatives considered and why you rejected them
- Any migration, backward-compatibility, or rollout concerns
- Diagrams or links to design docs / RFCs if available
-->

N/A — small change. <!-- Or fill in the design above -->

#
### Tests:

#### Use cases covered
<!--
List the user-visible scenarios this PR exercises. Example:
- User with Admin role can create a Glossary Term with a parent term
- Ingestion run for Snowflake correctly extracts row counts for partitioned tables
-->

#### Unit tests
<!--
- [ ] I added unit tests for the new/changed logic.
- Files added/updated:
- Coverage on changed classes (run `mvn jacoco:report` for backend, `yarn test:coverage` for UI,
  `make unit_ingestion` for ingestion). Target is 90% line coverage on changed classes.
- Coverage %: <e.g., 92% on EntityRepository.java>
-->

#### Backend integration tests
<!--
- [ ] I added integration tests in `openmetadata-integration-tests/` for new/changed API endpoints.
- [ ] Not applicable (no backend API changes).
- Files added/updated:
-->

#### Ingestion integration tests
<!--
- [ ] I added/updated ingestion integration tests for connector changes.
- [ ] Not applicable (no ingestion changes).
- Files added/updated:
-->

#### Playwright (UI) tests
<!--
- [ ] I added Playwright E2E tests under `openmetadata-ui/.../ui/playwright/` for UI changes.
- [ ] Not applicable (no UI changes).
- Files added/updated:
-->

#### Manual testing performed
<!--
List the manual test steps you performed before requesting review. Example:
1. Started local stack via `./docker/run_local_docker.sh -m ui -d mysql`
2. Logged in as admin, created entity X, verified Y appears in the UI
3. Triggered ingestion for Snowflake source, confirmed lineage edges in the explore page
-->

#
### UI screen recording / screenshots:
<!--
REQUIRED for any PR that changes the UI. Drag-and-drop a short screen recording (.mov / .mp4 / .gif)
demonstrating the change end-to-end, plus before/after screenshots where relevant.
Mark "Not applicable" if there are no UI changes.
-->

Not applicable. <!-- Or attach recording/screenshots above -->

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.
- [ ] For UI changes: I attached a screen recording and/or screenshots above.
- [ ] I have added tests (unit / integration / Playwright as applicable) and listed them above.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->

----
## Summary by Gitar

- **Context Center Enhancements:**
  - Added `moveFileToRoot` API method to facilitate moving files out of folders.
  - Updated `FolderPickerMenu` to visually indicate the current folder selection with a `Check` icon.
  - Refactored `handleMoveToFolder` logic to support moving files to the root directory when selected.
  - Updated UI components and state management to support `null` as a target folder ID for root transitions.

<sub>This will update automatically on new commits.</sub>

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds toggle-based "remove from folder" support to the Context Center documents page: clicking a folder that already contains the selected file now removes it from that folder (moves to root) instead of being a no-op. A checkmark is shown next to the current folder in the picker to communicate the toggle state.

- Adds `moveFileToRoot` API that PUTs an empty body to the existing `/contextCenter/drive/files/{id}/move` endpoint, and wires it into `handleMoveToFolder` via an equality check on `folderId === file.folder?.id`.
- Updates `FolderPickerMenu` to render a `Check` icon and a highlighted background for the currently assigned folder, and passes all folders (instead of filtered `availableFolders`) to keep the "Move" button enabled when only the current folder exists.
- Propagates `string | null` through `onFileMoved` / `handleFileMoved` so that a root-move correctly clears the in-memory `folder` field to `undefined`, and adds a new `entity-removed-from-folder` i18n key across all 22 locale files.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the changes are scoped to the Context Center documents UI and add well-contained toggle-remove-from-folder logic with no state mutation issues.

The toggle logic correctly distinguishes between moving to a new folder and removing from the current one using a simple ID comparison, the API call uses an established endpoint with an empty body to signal root placement, and the in-memory state update clears the folder field to undefined (which correctly hides the folder label in the row and removes the file from any active folder-filtered view). Type changes are propagated consistently through all interfaces and callbacks. No regressions are introduced.

No files require special attention.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-ui/src/main/resources/ui/src/components/ContextCenter/DocumentsView/DocumentsView.component.tsx | Core UI changes: adds checkmark visual state to FolderPickerMenu and toggle-move-to-root logic in handleMoveToFolder; logic is sound and edge cases (no folder, only one folder) are correctly handled. |
| openmetadata-ui/src/main/resources/ui/src/rest/assetAPI.ts | Adds moveFileToRoot as a PUT to the shared /move endpoint with an empty body, consistent with the existing moveFileToFolder contract. |
| openmetadata-ui/src/main/resources/ui/src/pages/ContextCenterPage/ContextCenterDocumentsPage/ContextCenterDocumentsPage.tsx | handleFileMoved updated to set folder to undefined on null targetFolderId; folder-filtered view (allDocuments.filter by folder.id) correctly reflects the cleared state after a root-move. |
| openmetadata-ui/src/main/resources/ui/src/components/ContextCenter/DocumentsView/DocumentsView.interface.ts | onFileMoved signatures consistently widened to string | null across DocumentsViewProps, FileActionsProps, and FileRowProps; FolderPickerMenuProps gains optional currentFolderId. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant User
    participant FolderPickerMenu
    participant FileActions
    participant assetAPI
    participant ContextCenterDocumentsPage

    User->>FolderPickerMenu: Opens "Move to folder" submenu
    FolderPickerMenu-->>User: Renders folders with ✓ on current folder

    alt Clicks folder already assigned (✓)
        User->>FileActions: "handleMoveToFolder(folderId == file.folder.id)"
        FileActions->>assetAPI: moveFileToRoot(file.id)
        assetAPI->>assetAPI: "PUT /contextCenter/drive/files/{id}/move  {}"
        assetAPI-->>FileActions: success
        FileActions->>ContextCenterDocumentsPage: onFileMoved(file, null)
        ContextCenterDocumentsPage->>ContextCenterDocumentsPage: setAllDocuments → folder: undefined
        FileActions-->>User: Toast "Document removed from folder"
    else Clicks a different folder
        User->>FileActions: "handleMoveToFolder(folderId != file.folder.id)"
        FileActions->>assetAPI: moveFileToFolder(file.id, folderId)
        assetAPI->>assetAPI: "PUT /contextCenter/drive/files/{id}/move  {folder:{id,type}}"
        assetAPI-->>FileActions: success
        FileActions->>ContextCenterDocumentsPage: onFileMoved(file, folderId)
        ContextCenterDocumentsPage->>ContextCenterDocumentsPage: setAllDocuments → folder.id: folderId
        FileActions-->>User: Toast "Document moved successfully"
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant User
    participant FolderPickerMenu
    participant FileActions
    participant assetAPI
    participant ContextCenterDocumentsPage

    User->>FolderPickerMenu: Opens "Move to folder" submenu
    FolderPickerMenu-->>User: Renders folders with ✓ on current folder

    alt Clicks folder already assigned (✓)
        User->>FileActions: "handleMoveToFolder(folderId == file.folder.id)"
        FileActions->>assetAPI: moveFileToRoot(file.id)
        assetAPI->>assetAPI: "PUT /contextCenter/drive/files/{id}/move  {}"
        assetAPI-->>FileActions: success
        FileActions->>ContextCenterDocumentsPage: onFileMoved(file, null)
        ContextCenterDocumentsPage->>ContextCenterDocumentsPage: setAllDocuments → folder: undefined
        FileActions-->>User: Toast "Document removed from folder"
    else Clicks a different folder
        User->>FileActions: "handleMoveToFolder(folderId != file.folder.id)"
        FileActions->>assetAPI: moveFileToFolder(file.id, folderId)
        assetAPI->>assetAPI: "PUT /contextCenter/drive/files/{id}/move  {folder:{id,type}}"
        assetAPI-->>FileActions: success
        FileActions->>ContextCenterDocumentsPage: onFileMoved(file, folderId)
        ContextCenterDocumentsPage->>ContextCenterDocumentsPage: setAllDocuments → folder.id: folderId
        FileActions-->>User: Toast "Document moved successfully"
    end
```

</a>
</details>

<sub>Reviews (8): Last reviewed commit: ["lint fix"](https://github.com/open-metadata/openmetadata/commit/eeb997e8049fd44425fe3137df4f3e684c12f041) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40597237)</sub>

<!-- /greptile_comment -->