### PR TITLE
Add data consumer createTask and editTask constant

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/constant/permission.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/constant/permission.ts
@@ -91,6 +91,14 @@ export const DATA_CONSUMER_RULES: PolicyRulesType[] = [
     operations: ['Create'],
     effect: 'allow',
   },
+  {
+    name: 'DataConsumerPolicy-TaskRule',
+    description:
+      'Allow authenticated users to file and edit tasks (data access requests, suggestions, etc.) against any entity. Restrict this rule (e.g. with an isOwner condition) to limit who can file or edit tasks on which entities.',
+    resources: ['All'],
+    operations: ['CreateTask', 'EditTask'],
+    effect: 'allow',
+  },
 ];
 
 export const VIEW_ALL_RULE: PolicyRulesType[] = [


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:

Fixes #<issue-number>
<!--
Linking an issue is REQUIRED. Replace <issue-number> with the GitHub issue number this PR addresses
(e.g., `Fixes #12345`). GitHub will auto-link it. If no issue exists, please open one first so the
problem and design can be discussed before review.
-->

<!--
Short blurb explaining:
- What changes did you make?
- Why did you make them?
-->

I worked on ... because ...

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### High-level design:
<!--
REQUIRED for large PRs (new features, refactors, breaking changes, or anything touching >5 files).
Skip for small bug fixes and trivial changes.

Cover:
- Architecture / approach you took and why
- Key components or files added/changed and how they interact
- Alternatives considered and why you rejected them
- Any migration, backward-compatibility, or rollout concerns
- Diagrams or links to design docs / RFCs if available
-->

N/A — small change. <!-- Or fill in the design above -->

#
### Tests:

#### Use cases covered
<!--
List the user-visible scenarios this PR exercises. Example:
- User with Admin role can create a Glossary Term with a parent term
- Ingestion run for Snowflake correctly extracts row counts for partitioned tables
-->

#### Unit tests
<!--
- [ ] I added unit tests for the new/changed logic.
- Files added/updated:
- Coverage on changed classes (run `mvn jacoco:report` for backend, `yarn test:coverage` for UI,
  `make unit_ingestion` for ingestion). Target is 90% line coverage on changed classes.
- Coverage %: <e.g., 92% on EntityRepository.java>
-->

#### Backend integration tests
<!--
- [ ] I added integration tests in `openmetadata-integration-tests/` for new/changed API endpoints.
- [ ] Not applicable (no backend API changes).
- Files added/updated:
-->

#### Ingestion integration tests
<!--
- [ ] I added/updated ingestion integration tests for connector changes.
- [ ] Not applicable (no ingestion changes).
- Files added/updated:
-->

#### Playwright (UI) tests
<!--
- [ ] I added Playwright E2E tests under `openmetadata-ui/.../ui/playwright/` for UI changes.
- [ ] Not applicable (no UI changes).
- Files added/updated:
-->

#### Manual testing performed
<!--
List the manual test steps you performed before requesting review. Example:
1. Started local stack via `./docker/run_local_docker.sh -m ui -d mysql`
2. Logged in as admin, created entity X, verified Y appears in the UI
3. Triggered ingestion for Snowflake source, confirmed lineage edges in the explore page
-->

#
### UI screen recording / screenshots:
<!--
REQUIRED for any PR that changes the UI. Drag-and-drop a short screen recording (.mov / .mp4 / .gif)
demonstrating the change end-to-end, plus before/after screenshots where relevant.
Mark "Not applicable" if there are no UI changes.
-->

Not applicable. <!-- Or attach recording/screenshots above -->

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.
- [ ] For UI changes: I attached a screen recording and/or screenshots above.
- [ ] I have added tests (unit / integration / Playwright as applicable) and listed them above.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->

----
## Summary by Gitar

- **Permission updates:**
  - Added `CreateTask` and `EditTask` operations to `DATA_CONSUMER_RULES` in `permission.ts`.
  - Included a new policy rule `DataConsumerPolicy-TaskRule` allowing task interactions across all entities.

<sub>This will update automatically on new commits.</sub>

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds a new `DataConsumerPolicy-TaskRule` entry to the `DATA_CONSUMER_RULES` constant in the Playwright test fixtures, intended to grant data consumers the ability to file and edit tasks on any entity.

- The new rule specifies operations `['CreateTask', 'EditTask']`, but neither operation exists in the backend `MetadataOperation` enum (valid task operations are `ResolveTask`, `CloseTask`, and `ReassignTask`). Because `updateDefaultDataConsumerPolicy` sends this constant directly to `PATCH /api/v1/policies/:id`, any Playwright test that calls that helper will receive a validation error from the API.
- The new rule on resource `All` with task-related operations partially overlaps with the existing `DataConsumerPolicy-CreateTask-Rule` (resource `task`, operation `Create`), making the intended boundary between the two rules unclear.
</details>


<details open><summary><h3>Confidence Score: 3/5</h3></summary>

The change introduces invalid operation names that will cause API rejection when the Playwright policy-setup helper runs.

The operations CreateTask and EditTask do not exist in the MetadataOperation enum in resourceDescriptor.json. Every Playwright test that calls updateDefaultDataConsumerPolicy will fail at setup because the backend will reject the PATCH request containing these unknown operations. The fix is straightforward — use the correct operation names or adjust the resource/operation combination — but until corrected, the affected tests cannot pass.

openmetadata-ui/src/main/resources/ui/playwright/constant/permission.ts — the new rule's operations must be reconciled with the backend enum before the test fixture can be used.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| openmetadata-ui/src/main/resources/ui/playwright/constant/permission.ts | Adds a new DataConsumerPolicy-TaskRule with operations ['CreateTask', 'EditTask'], but neither operation exists in the backend MetadataOperation enum — API PATCH call will fail; also overlaps with the existing DataConsumerPolicy-CreateTask-Rule. |

</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `openmetadata-ui/src/main/resources/ui/playwright/constant/permission.ts`, line 86-101 ([link](https://github.com/open-metadata/openmetadata/blob/9f2e6ba309ccb6e7da509b7fc34f21dbcd6e5408/openmetadata-ui/src/main/resources/ui/playwright/constant/permission.ts#L86-L101)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **New rule overlaps with the existing `DataConsumerPolicy-CreateTask-Rule`**

   The existing rule at lines 86–92 already covers the concept of "creating tasks" (resource `task`, operation `Create`). The new `DataConsumerPolicy-TaskRule` at lines 93–101 adds a second rule for the same concept with a broader resource scope (`All`) and different operation strings. Having two overlapping rules for task creation in the same constant increases maintenance burden and could cause confusion about which rule is actually effective if both are ever applied together. If the new rule is intentional, the older `DataConsumerPolicy-CreateTask-Rule` entry should be removed or the intent of each rule should be clarified with a comment.

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["Add data consumer createTask and editTas..."](https://github.com/open-metadata/openmetadata/commit/9f2e6ba309ccb6e7da509b7fc34f21dbcd6e5408) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40727280)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->