### PR TITLE
chore(e2e): balance out shard allocation for reduce timing

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/Glossary/GlossaryPagination.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/Glossary/GlossaryPagination.spec.ts
@@ -14,12 +14,13 @@ import test, { expect } from '@playwright/test';
 import { Glossary } from '../../../support/glossary/Glossary';
 import { GlossaryTerm } from '../../../support/glossary/GlossaryTerm';
 import { createNewPage } from '../../../utils/common';
+import { PLAYWRIGHT_BASIC_TEST_TAG_OBJ } from '../../../constant/config';
 
 test.use({
   storageState: 'playwright/.auth/admin.json',
 });
 
-test.describe('Glossary tests', () => {
+test.describe('Glossary tests', PLAYWRIGHT_BASIC_TEST_TAG_OBJ, () => {
   const glossary = new Glossary();
   const glossaryTerms: GlossaryTerm[] = [];
   let parentTerm: GlossaryTerm;

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/Glossary/GlossaryPagination.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/Glossary/GlossaryPagination.spec.ts
@@ -11,10 +11,10 @@
  *  limitations under the License.
  */
 import test, { expect } from '@playwright/test';
+import { PLAYWRIGHT_BASIC_TEST_TAG_OBJ } from '../../../constant/config';
 import { Glossary } from '../../../support/glossary/Glossary';
 import { GlossaryTerm } from '../../../support/glossary/GlossaryTerm';
 import { createNewPage } from '../../../utils/common';
-import { PLAYWRIGHT_BASIC_TEST_TAG_OBJ } from '../../../constant/config';
 
 test.use({
   storageState: 'playwright/.auth/admin.json',

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Flow/LineageSettings.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Flow/LineageSettings.spec.ts
@@ -46,348 +46,358 @@ import {
 } from '../../utils/lineage';
 import { settingClick, sidebarClick } from '../../utils/sidebar';
 import { test } from '../fixtures/pages';
+import { PLAYWRIGHT_BASIC_TEST_TAG_OBJ } from '../../constant/config';
 
-test.describe.serial('Lineage Settings Tests', () => {
-  const table = new TableClass();
-  const topic = new TopicClass();
-  const dashboard = new DashboardClass();
-  const mlModel = new MlModelClass();
-  const searchIndex = new SearchIndexClass();
-  const container = new ContainerClass();
-  const metric = new MetricClass();
-  const pipeline = new PipelineClass();
+test.describe.serial(
+  'Lineage Settings Tests',
+  PLAYWRIGHT_BASIC_TEST_TAG_OBJ,
+  () => {
+    const table = new TableClass();
+    const topic = new TopicClass();
+    const dashboard = new DashboardClass();
+    const mlModel = new MlModelClass();
+    const searchIndex = new SearchIndexClass();
+    const container = new ContainerClass();
+    const metric = new MetricClass();
+    const pipeline = new PipelineClass();
 
-  test.beforeAll('setup lineage settings', async ({ browser }) => {
-    const { apiContext, afterAction } = await performAdminLogin(browser);
+    test.beforeAll('setup lineage settings', async ({ browser }) => {
+      const { apiContext, afterAction } = await performAdminLogin(browser);
 
-    await Promise.all([
-      table.create(apiContext),
-      topic.create(apiContext),
-      dashboard.create(apiContext),
-      mlModel.create(apiContext),
-      searchIndex.create(apiContext),
-      container.create(apiContext),
-      metric.create(apiContext),
-      pipeline.create(apiContext),
-    ]);
-
-    await connectEdgeBetweenNodesViaAPI(
-      apiContext,
-      { id: table.entityResponseData.id, type: 'table' },
-      { id: topic.entityResponseData.id, type: 'topic' }
-    );
-    await connectEdgeBetweenNodesViaAPI(
-      apiContext,
-      { id: topic.entityResponseData.id, type: 'topic' },
-      { id: dashboard.entityResponseData.id, type: 'dashboard' }
-    );
-    await connectEdgeBetweenNodesViaAPI(
-      apiContext,
-      { id: dashboard.entityResponseData.id, type: 'dashboard' },
-      { id: mlModel.entityResponseData.id, type: 'mlmodel' }
-    );
-    await connectEdgeBetweenNodesViaAPI(
-      apiContext,
-      { id: mlModel.entityResponseData.id, type: 'mlmodel' },
-      { id: searchIndex.entityResponseData.id, type: 'searchIndex' }
-    );
-    await connectEdgeBetweenNodesViaAPI(
-      apiContext,
-      { id: searchIndex.entityResponseData.id, type: 'searchIndex' },
-      { id: container.entityResponseData.id, type: 'container' }
-    );
-    await connectEdgeBetweenNodesViaAPI(
-      apiContext,
-      { id: container.entityResponseData.id, type: 'container' },
-      { id: metric.entityResponseData.id, type: 'metric' }
-    );
-    await connectEdgeBetweenNodesViaAPI(
-      apiContext,
-      { id: metric.entityResponseData.id, type: 'metric' },
-      { id: pipeline.entityResponseData.id, type: 'pipeline' }
-    );
-
-    await afterAction();
-  });
-
-  test.afterAll('cleanup', async ({ browser }) => {
-    const { apiContext, afterAction } = await performAdminLogin(browser);
-
-    await Promise.all([
-      table.delete(apiContext),
-      topic.delete(apiContext),
-      dashboard.delete(apiContext),
-      mlModel.delete(apiContext),
-      searchIndex.delete(apiContext),
-      container.delete(apiContext),
-      metric.delete(apiContext),
-      pipeline.delete(apiContext),
-    ]);
-
-    await afterAction();
-  });
-
-  test.beforeEach(async ({ page }) => {
-    await redirectToHomePage(page);
-  });
-
-  test('Verify global lineage config', async ({ page }) => {
-    test.slow(true);
-
-    await test.step('Lineage config should throw error if upstream depth is less than 0', async () => {
-      await settingClick(page, GlobalSettingOptions.LINEAGE_CONFIG);
-
-      await page.getByTestId('field-upstream').fill('-1');
-      await page.getByTestId('field-downstream').fill('-1');
-      await page.getByTestId('save-button').click();
-
-      await expect(
-        page.getByText('Upstream Depth size cannot be less than 0')
-      ).toBeVisible();
-      await expect(
-        page.getByText('Downstream Depth size cannot be less than 0')
-      ).toBeVisible();
-
-      await page.getByTestId('field-upstream').fill('0');
-      await page.getByTestId('field-downstream').fill('0');
-
-      const saveRes = page.waitForResponse('/api/v1/system/settings');
-      await page.getByTestId('save-button').click();
-      await saveRes;
-
-      await toastNotification(page, /Lineage Config updated successfully/);
-    });
-
-    await test.step('Update global lineage config and verify lineage for column layer', async () => {
-      await settingClick(page, GlobalSettingOptions.LINEAGE_CONFIG);
-      await fillLineageConfigForm(page, {
-        upstreamDepth: 1,
-        downstreamDepth: 1,
-        layer: 'Column Level Lineage',
-      });
-
-      await topic.visitEntityPage(page);
-      await visitLineageTab(page);
-      await performZoomOut(page);
-      await verifyNodePresent(page, table);
-      await verifyNodePresent(page, dashboard);
-      const mlModelFqn = get(mlModel, 'entityResponseData.fullyQualifiedName');
-      const mlModelNode = page.locator(
-        `[data-testid="lineage-node-${mlModelFqn}"]`
-      );
-
-      await expect(mlModelNode).not.toBeVisible();
-
-      await verifyColumnLayerActive(page);
-    });
-
-    await test.step('Update global lineage config and verify lineage for entity layer', async () => {
-      await settingClick(page, GlobalSettingOptions.LINEAGE_CONFIG);
-      await fillLineageConfigForm(page, {
-        upstreamDepth: 1,
-        downstreamDepth: 1,
-        layer: 'Entity Lineage',
-      });
-
-      await dashboard.visitEntityPage(page);
-      await visitLineageTab(page);
-      await performZoomOut(page);
-      await verifyNodePresent(page, dashboard);
-      await verifyNodePresent(page, mlModel);
-      await verifyNodePresent(page, topic);
-
-      const tableNode = page.locator(
-        `[data-testid="lineage-node-${get(
-          table,
-          'entityResponseData.fullyQualifiedName'
-        )}"]`
-      );
-
-      const searchIndexNode = page.locator(
-        `[data-testid="lineage-node-${get(
-          searchIndex,
-          'entityResponseData.fullyQualifiedName'
-        )}"]`
-      );
-
-      await expect(tableNode).not.toBeVisible();
-      await expect(searchIndexNode).not.toBeVisible();
-    });
-
-    await test.step('Verify Upstream and Downstream expand collapse buttons', async () => {
-      await redirectToHomePage(page);
-      await dashboard.visitEntityPage(page);
-      await visitLineageTab(page);
-      const closeIcon = page.getByTestId('entity-panel-close-icon');
-      if (await closeIcon.isVisible()) {
-        await closeIcon.click();
-      }
-      await performZoomOut(page);
-      await verifyNodePresent(page, topic);
-      await verifyNodePresent(page, mlModel);
-
-      await verifyExpandHandleHover(page, mlModel, false);
-      await clickOutside(page);
-      await verifyExpandHandleHover(page, topic, true);
-
-      await performExpand(page, mlModel, false, searchIndex);
-      await performExpand(page, searchIndex, false, container);
-      await performExpand(page, container, false, metric);
-      await performExpand(page, topic, true, table);
-
-      await performZoomOut(page);
-
-      await performCollapse(page, mlModel, false, [
-        searchIndex,
-        container,
-        metric,
+      await Promise.all([
+        table.create(apiContext),
+        topic.create(apiContext),
+        dashboard.create(apiContext),
+        mlModel.create(apiContext),
+        searchIndex.create(apiContext),
+        container.create(apiContext),
+        metric.create(apiContext),
+        pipeline.create(apiContext),
       ]);
-      await performZoomOut(page);
-      await performCollapse(page, dashboard, true, [table, topic]);
+
+      await connectEdgeBetweenNodesViaAPI(
+        apiContext,
+        { id: table.entityResponseData.id, type: 'table' },
+        { id: topic.entityResponseData.id, type: 'topic' }
+      );
+      await connectEdgeBetweenNodesViaAPI(
+        apiContext,
+        { id: topic.entityResponseData.id, type: 'topic' },
+        { id: dashboard.entityResponseData.id, type: 'dashboard' }
+      );
+      await connectEdgeBetweenNodesViaAPI(
+        apiContext,
+        { id: dashboard.entityResponseData.id, type: 'dashboard' },
+        { id: mlModel.entityResponseData.id, type: 'mlmodel' }
+      );
+      await connectEdgeBetweenNodesViaAPI(
+        apiContext,
+        { id: mlModel.entityResponseData.id, type: 'mlmodel' },
+        { id: searchIndex.entityResponseData.id, type: 'searchIndex' }
+      );
+      await connectEdgeBetweenNodesViaAPI(
+        apiContext,
+        { id: searchIndex.entityResponseData.id, type: 'searchIndex' },
+        { id: container.entityResponseData.id, type: 'container' }
+      );
+      await connectEdgeBetweenNodesViaAPI(
+        apiContext,
+        { id: container.entityResponseData.id, type: 'container' },
+        { id: metric.entityResponseData.id, type: 'metric' }
+      );
+      await connectEdgeBetweenNodesViaAPI(
+        apiContext,
+        { id: metric.entityResponseData.id, type: 'metric' },
+        { id: pipeline.entityResponseData.id, type: 'pipeline' }
+      );
+
+      await afterAction();
     });
 
-    await test.step('Reset global lineage config and verify lineage', async () => {
-      await settingClick(page, GlobalSettingOptions.LINEAGE_CONFIG);
-      await fillLineageConfigForm(page, {
-        upstreamDepth: 2,
-        downstreamDepth: 2,
-        layer: 'Entity Lineage',
+    test.afterAll('cleanup', async ({ browser }) => {
+      const { apiContext, afterAction } = await performAdminLogin(browser);
+
+      await Promise.all([
+        table.delete(apiContext),
+        topic.delete(apiContext),
+        dashboard.delete(apiContext),
+        mlModel.delete(apiContext),
+        searchIndex.delete(apiContext),
+        container.delete(apiContext),
+        metric.delete(apiContext),
+        pipeline.delete(apiContext),
+      ]);
+
+      await afterAction();
+    });
+
+    test.beforeEach(async ({ page }) => {
+      await redirectToHomePage(page);
+    });
+
+    test('Verify global lineage config', async ({ page }) => {
+      test.slow(true);
+
+      await test.step('Lineage config should throw error if upstream depth is less than 0', async () => {
+        await settingClick(page, GlobalSettingOptions.LINEAGE_CONFIG);
+
+        await page.getByTestId('field-upstream').fill('-1');
+        await page.getByTestId('field-downstream').fill('-1');
+        await page.getByTestId('save-button').click();
+
+        await expect(
+          page.getByText('Upstream Depth size cannot be less than 0')
+        ).toBeVisible();
+        await expect(
+          page.getByText('Downstream Depth size cannot be less than 0')
+        ).toBeVisible();
+
+        await page.getByTestId('field-upstream').fill('0');
+        await page.getByTestId('field-downstream').fill('0');
+
+        const saveRes = page.waitForResponse('/api/v1/system/settings');
+        await page.getByTestId('save-button').click();
+        await saveRes;
+
+        await toastNotification(page, /Lineage Config updated successfully/);
       });
 
-      await dashboard.visitEntityPage(page);
+      await test.step('Update global lineage config and verify lineage for column layer', async () => {
+        await settingClick(page, GlobalSettingOptions.LINEAGE_CONFIG);
+        await fillLineageConfigForm(page, {
+          upstreamDepth: 1,
+          downstreamDepth: 1,
+          layer: 'Column Level Lineage',
+        });
+
+        await topic.visitEntityPage(page);
+        await visitLineageTab(page);
+        await performZoomOut(page);
+        await verifyNodePresent(page, table);
+        await verifyNodePresent(page, dashboard);
+        const mlModelFqn = get(
+          mlModel,
+          'entityResponseData.fullyQualifiedName'
+        );
+        const mlModelNode = page.locator(
+          `[data-testid="lineage-node-${mlModelFqn}"]`
+        );
+
+        await expect(mlModelNode).not.toBeVisible();
+
+        await verifyColumnLayerActive(page);
+      });
+
+      await test.step('Update global lineage config and verify lineage for entity layer', async () => {
+        await settingClick(page, GlobalSettingOptions.LINEAGE_CONFIG);
+        await fillLineageConfigForm(page, {
+          upstreamDepth: 1,
+          downstreamDepth: 1,
+          layer: 'Entity Lineage',
+        });
+
+        await dashboard.visitEntityPage(page);
+        await visitLineageTab(page);
+        await performZoomOut(page);
+        await verifyNodePresent(page, dashboard);
+        await verifyNodePresent(page, mlModel);
+        await verifyNodePresent(page, topic);
+
+        const tableNode = page.locator(
+          `[data-testid="lineage-node-${get(
+            table,
+            'entityResponseData.fullyQualifiedName'
+          )}"]`
+        );
+
+        const searchIndexNode = page.locator(
+          `[data-testid="lineage-node-${get(
+            searchIndex,
+            'entityResponseData.fullyQualifiedName'
+          )}"]`
+        );
+
+        await expect(tableNode).not.toBeVisible();
+        await expect(searchIndexNode).not.toBeVisible();
+      });
+
+      await test.step('Verify Upstream and Downstream expand collapse buttons', async () => {
+        await redirectToHomePage(page);
+        await dashboard.visitEntityPage(page);
+        await visitLineageTab(page);
+        const closeIcon = page.getByTestId('entity-panel-close-icon');
+        if (await closeIcon.isVisible()) {
+          await closeIcon.click();
+        }
+        await performZoomOut(page);
+        await verifyNodePresent(page, topic);
+        await verifyNodePresent(page, mlModel);
+
+        await verifyExpandHandleHover(page, mlModel, false);
+        await clickOutside(page);
+        await verifyExpandHandleHover(page, topic, true);
+
+        await performExpand(page, mlModel, false, searchIndex);
+        await performExpand(page, searchIndex, false, container);
+        await performExpand(page, container, false, metric);
+        await performExpand(page, topic, true, table);
+
+        await performZoomOut(page);
+
+        await performCollapse(page, mlModel, false, [
+          searchIndex,
+          container,
+          metric,
+        ]);
+        await performZoomOut(page);
+        await performCollapse(page, dashboard, true, [table, topic]);
+      });
+
+      await test.step('Reset global lineage config and verify lineage', async () => {
+        await settingClick(page, GlobalSettingOptions.LINEAGE_CONFIG);
+        await fillLineageConfigForm(page, {
+          upstreamDepth: 2,
+          downstreamDepth: 2,
+          layer: 'Entity Lineage',
+        });
+
+        await dashboard.visitEntityPage(page);
+        await visitLineageTab(page);
+        await performZoomOut(page);
+
+        await verifyNodePresent(page, table);
+        await verifyNodePresent(page, dashboard);
+        await verifyNodePresent(page, mlModel);
+        await verifyNodePresent(page, searchIndex);
+        await verifyNodePresent(page, topic);
+      });
+    });
+
+    test('Verify lineage time filter and tab switch reuse loaded graph', async ({
+      page,
+    }) => {
+      await table.visitEntityPage(page);
       await visitLineageTab(page);
-      await performZoomOut(page);
-
       await verifyNodePresent(page, table);
-      await verifyNodePresent(page, dashboard);
-      await verifyNodePresent(page, mlModel);
-      await verifyNodePresent(page, searchIndex);
-      await verifyNodePresent(page, topic);
-    });
-  });
 
-  test('Verify lineage time filter and tab switch reuse loaded graph', async ({
-    page,
-  }) => {
-    await table.visitEntityPage(page);
-    await visitLineageTab(page);
-    await verifyNodePresent(page, table);
+      const lineageTimeFilteredResponse = page.waitForResponse((response) => {
+        const url = new URL(response.url());
 
-    const lineageTimeFilteredResponse = page.waitForResponse((response) => {
-      const url = new URL(response.url());
+        return (
+          url.pathname.endsWith('/api/v1/lineage/getLineage') &&
+          url.searchParams.has('startTime') &&
+          url.searchParams.has('endTime')
+        );
+      });
 
-      return (
-        url.pathname.endsWith('/api/v1/lineage/getLineage') &&
-        url.searchParams.has('startTime') &&
-        url.searchParams.has('endTime')
+      await page.getByTestId('lineage-time-filter').click();
+      await page.getByRole('menuitemradio', { name: 'Last 7 days' }).click();
+
+      const response = await lineageTimeFilteredResponse;
+      const responseUrl = new URL(response.url());
+      const startTime = responseUrl.searchParams.get('startTime');
+      const endTime = responseUrl.searchParams.get('endTime');
+
+      expect(Number(startTime)).toBeLessThan(Number(endTime));
+      await expect(page.getByTestId('lineage-time-filter')).toContainText(
+        'Last 7 days'
       );
+
+      const isLineageFetchRequest = (request: Request) => {
+        const url = new URL(request.url());
+
+        return url.pathname.endsWith('/api/v1/lineage/getLineage');
+      };
+
+      const lineageTabPanel = page.getByRole('tabpanel', { name: 'Lineage' });
+
+      await lineageTabPanel
+        .getByRole('tab', { name: 'Impact Analysis' })
+        .click();
+      await expect(page).toHaveURL(/mode=impact_analysis/);
+      await waitForAllLoadersToDisappear(page);
+
+      const lineageFetchAfterViewSwitch = page
+        .waitForRequest(isLineageFetchRequest, { timeout: 1000 })
+        .then(() => true)
+        .catch(() => false);
+
+      await lineageTabPanel.getByRole('tab', { name: 'Lineage' }).click();
+      await expect(page).not.toHaveURL(/mode=impact_analysis/);
+      expect(await lineageFetchAfterViewSwitch).toBe(false);
     });
 
-    await page.getByTestId('lineage-time-filter').click();
-    await page.getByRole('menuitemradio', { name: 'Last 7 days' }).click();
-
-    const response = await lineageTimeFilteredResponse;
-    const responseUrl = new URL(response.url());
-    const startTime = responseUrl.searchParams.get('startTime');
-    const endTime = responseUrl.searchParams.get('endTime');
-
-    expect(Number(startTime)).toBeLessThan(Number(endTime));
-    await expect(page.getByTestId('lineage-time-filter')).toContainText(
-      'Last 7 days'
-    );
-
-    const isLineageFetchRequest = (request: Request) => {
-      const url = new URL(request.url());
-
-      return url.pathname.endsWith('/api/v1/lineage/getLineage');
-    };
-
-    const lineageTabPanel = page.getByRole('tabpanel', { name: 'Lineage' });
-
-    await lineageTabPanel.getByRole('tab', { name: 'Impact Analysis' }).click();
-    await expect(page).toHaveURL(/mode=impact_analysis/);
-    await waitForAllLoadersToDisappear(page);
-
-    const lineageFetchAfterViewSwitch = page
-      .waitForRequest(isLineageFetchRequest, { timeout: 1000 })
-      .then(() => true)
-      .catch(() => false);
-
-    await lineageTabPanel.getByRole('tab', { name: 'Lineage' }).click();
-    await expect(page).not.toHaveURL(/mode=impact_analysis/);
-    expect(await lineageFetchAfterViewSwitch).toBe(false);
-  });
-
-  test('Verify lineage settings for PipelineViewMode as Edge', async ({
-    page,
-    dataStewardPage,
-  }) => {
-    // Update setting to show pipeline as Edge
-    await redirectToHomePage(page);
-    await sidebarClick(page, SidebarItem.SETTINGS);
-    await page.getByTestId('preferences').click();
-    await page.getByTestId('preferences.lineageConfig').click();
-
-    await page.getByTestId('field-pipeline-view-mode').click();
-
-    await page.getByTitle('Edge').filter({ visible: true }).click();
-    const lineageSettingUpdate = page.waitForResponse(
-      '/api/v1/system/settings'
-    );
-    await page.getByTestId('save-button').click();
-    await lineageSettingUpdate;
-
-    await redirectToHomePage(dataStewardPage);
-
-    await table.visitEntityPage(dataStewardPage);
-    await visitLineageTab(dataStewardPage);
-    await editLineage(dataStewardPage);
-
-    // Select pipeline from Modal
-    await applyPipelineFromModal(dataStewardPage, table, topic, pipeline);
-    await editLineageClick(dataStewardPage);
-    await waitForAllLoadersToDisappear(dataStewardPage);
-    await verifyPipelineDataInDrawer(
+    test('Verify lineage settings for PipelineViewMode as Edge', async ({
+      page,
       dataStewardPage,
-      table,
-      topic,
-      pipeline,
-      true
-    );
+    }) => {
+      // Update setting to show pipeline as Edge
+      await redirectToHomePage(page);
+      await sidebarClick(page, SidebarItem.SETTINGS);
+      await page.getByTestId('preferences').click();
+      await page.getByTestId('preferences.lineageConfig').click();
 
-    await pipeline.visitEntityPage(dataStewardPage);
-    await visitLineageTab(dataStewardPage);
+      await page.getByTestId('field-pipeline-view-mode').click();
 
-    await performZoomOut(dataStewardPage, 5);
+      await page.getByTitle('Edge').filter({ visible: true }).click();
+      const lineageSettingUpdate = page.waitForResponse(
+        '/api/v1/system/settings'
+      );
+      await page.getByTestId('save-button').click();
+      await lineageSettingUpdate;
 
-    // Pipeline should be shown as Edge and not as Node
-    await expect(
-      dataStewardPage.getByTestId(
-        `pipeline-label-${table.entityResponseData.fullyQualifiedName}-${topic.entityResponseData.fullyQualifiedName}`
-      )
-    ).toBeVisible({ timeout: 10000 });
+      await redirectToHomePage(dataStewardPage);
 
-    // update pipeline view mode to Node
-    await page.getByTestId('field-pipeline-view-mode').click();
-    await page.getByTitle('Node').filter({ visible: true }).click();
-    const settingsUpdate = page.waitForResponse('/api/v1/system/settings');
-    await page.getByTestId('save-button').click();
-    await settingsUpdate;
+      await table.visitEntityPage(dataStewardPage);
+      await visitLineageTab(dataStewardPage);
+      await editLineage(dataStewardPage);
 
-    await dataStewardPage.reload();
-    await waitForAllLoadersToDisappear(dataStewardPage);
+      // Select pipeline from Modal
+      await applyPipelineFromModal(dataStewardPage, table, topic, pipeline);
+      await editLineageClick(dataStewardPage);
+      await waitForAllLoadersToDisappear(dataStewardPage);
+      await verifyPipelineDataInDrawer(
+        dataStewardPage,
+        table,
+        topic,
+        pipeline,
+        true
+      );
 
-    // Pipeline should be shown as Node and not as Edge
-    await expect(
-      dataStewardPage.getByTestId(
-        `pipeline-label-${table.entityResponseData.fullyQualifiedName}-${topic.entityResponseData.fullyQualifiedName}`
-      )
-    ).not.toBeVisible();
+      await pipeline.visitEntityPage(dataStewardPage);
+      await visitLineageTab(dataStewardPage);
 
-    await expect(
-      dataStewardPage.getByTestId(
-        `lineage-node-${pipeline.entityResponseData.fullyQualifiedName}`
-      )
-    ).toBeVisible();
-  });
-});
+      await performZoomOut(dataStewardPage, 5);
+
+      // Pipeline should be shown as Edge and not as Node
+      await expect(
+        dataStewardPage.getByTestId(
+          `pipeline-label-${table.entityResponseData.fullyQualifiedName}-${topic.entityResponseData.fullyQualifiedName}`
+        )
+      ).toBeVisible({ timeout: 10000 });
+
+      // update pipeline view mode to Node
+      await page.getByTestId('field-pipeline-view-mode').click();
+      await page.getByTitle('Node').filter({ visible: true }).click();
+      const settingsUpdate = page.waitForResponse('/api/v1/system/settings');
+      await page.getByTestId('save-button').click();
+      await settingsUpdate;
+
+      await dataStewardPage.reload();
+      await waitForAllLoadersToDisappear(dataStewardPage);
+
+      // Pipeline should be shown as Node and not as Edge
+      await expect(
+        dataStewardPage.getByTestId(
+          `pipeline-label-${table.entityResponseData.fullyQualifiedName}-${topic.entityResponseData.fullyQualifiedName}`
+        )
+      ).not.toBeVisible();
+
+      await expect(
+        dataStewardPage.getByTestId(
+          `lineage-node-${pipeline.entityResponseData.fullyQualifiedName}`
+        )
+      ).toBeVisible();
+    });
+  }
+);

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Flow/LineageSettings.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Flow/LineageSettings.spec.ts
@@ -12,6 +12,7 @@
  */
 import { expect, Request } from '@playwright/test';
 import { get } from 'lodash';
+import { PLAYWRIGHT_BASIC_TEST_TAG_OBJ } from '../../constant/config';
 import { GlobalSettingOptions } from '../../constant/settings';
 import { SidebarItem } from '../../constant/sidebar';
 import { ContainerClass } from '../../support/entity/ContainerClass';
@@ -46,7 +47,6 @@ import {
 } from '../../utils/lineage';
 import { settingClick, sidebarClick } from '../../utils/sidebar';
 import { test } from '../fixtures/pages';
-import { PLAYWRIGHT_BASIC_TEST_TAG_OBJ } from '../../constant/config';
 
 test.describe.serial(
   'Lineage Settings Tests',

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/ExploreTree.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/ExploreTree.spec.ts
@@ -12,6 +12,7 @@
  */
 import test, { expect } from '@playwright/test';
 import { get } from 'lodash';
+import { PLAYWRIGHT_BASIC_TEST_TAG_OBJ } from '../../constant/config';
 import { SidebarItem } from '../../constant/sidebar';
 import { EntityTypeEndpoint } from '../../support/entity/Entity.interface';
 import { EntityDataClass } from '../../support/entity/EntityDataClass';
@@ -32,7 +33,6 @@ import {
   verifyDatabaseAndSchemaInExploreTree,
 } from '../../utils/explore';
 import { sidebarClick } from '../../utils/sidebar';
-import { PLAYWRIGHT_BASIC_TEST_TAG_OBJ } from '../../constant/config';
 
 // use the admin user to login
 test.use({

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/ExploreTree.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/ExploreTree.spec.ts
@@ -32,6 +32,7 @@ import {
   verifyDatabaseAndSchemaInExploreTree,
 } from '../../utils/explore';
 import { sidebarClick } from '../../utils/sidebar';
+import { PLAYWRIGHT_BASIC_TEST_TAG_OBJ } from '../../constant/config';
 
 // use the admin user to login
 test.use({
@@ -46,7 +47,7 @@ test.beforeEach(async ({ page }) => {
   await sidebarClick(page, SidebarItem.EXPLORE);
 });
 
-test.describe('Explore Tree scenarios', () => {
+test.describe('Explore Tree scenarios', PLAYWRIGHT_BASIC_TEST_TAG_OBJ, () => {
   let table1: TableClass;
   let table2: TableClass;
 

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/Lineage/DataAssetLineage.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/Lineage/DataAssetLineage.spec.ts
@@ -58,6 +58,7 @@ import {
   visitLineageTab,
 } from '../../../utils/lineage';
 import { test } from '../../fixtures/pages';
+import { PLAYWRIGHT_BASIC_TEST_TAG_OBJ } from '../../../constant/config';
 
 // Contains list of entity supported
 const allEntities = {
@@ -106,7 +107,7 @@ type EntityClassUnion =
   | SpreadsheetClass
   | WorksheetClass;
 
-test.describe('Data asset lineage', () => {
+test.describe('Data asset lineage', PLAYWRIGHT_BASIC_TEST_TAG_OBJ, () => {
   const pipeline = new PipelineClass();
   const entities: EntityClassUnion[] = [];
 

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/Lineage/DataAssetLineage.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/Lineage/DataAssetLineage.spec.ts
@@ -12,6 +12,7 @@
  */
 import { expect } from '@playwright/test';
 import { get, startCase } from 'lodash';
+import { PLAYWRIGHT_BASIC_TEST_TAG_OBJ } from '../../../constant/config';
 import { ApiEndpointClass } from '../../../support/entity/ApiEndpointClass';
 import { ContainerClass } from '../../../support/entity/ContainerClass';
 import { DashboardClass } from '../../../support/entity/DashboardClass';
@@ -58,7 +59,6 @@ import {
   visitLineageTab,
 } from '../../../utils/lineage';
 import { test } from '../../fixtures/pages';
-import { PLAYWRIGHT_BASIC_TEST_TAG_OBJ } from '../../../constant/config';
 
 // Contains list of entity supported
 const allEntities = {

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/Lineage/LineageControls.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/Lineage/LineageControls.spec.ts
@@ -31,6 +31,7 @@ import {
 } from '../../../utils/lineage';
 import { sidebarClick } from '../../../utils/sidebar';
 import { test } from '../../fixtures/pages';
+import { PLAYWRIGHT_BASIC_TEST_TAG_OBJ } from '../../../constant/config';
 
 const table = new TableClass();
 const topic = new TopicClass();
@@ -94,7 +95,7 @@ test.beforeEach(async ({ page }) => {
 // ====================
 // Suite 1: Canvas Control Buttons (4 tests)
 // ====================
-test.describe('Canvas Controls', () => {
+test.describe('Canvas Controls', PLAYWRIGHT_BASIC_TEST_TAG_OBJ, () => {
   test.beforeEach(async ({ page }) => {
     await table.visitEntityPage(page);
     await visitLineageTab(page);
@@ -164,7 +165,7 @@ test.describe('Canvas Controls', () => {
   });
 });
 
-test.describe('Lineage Layers', () => {
+test.describe('Lineage Layers', PLAYWRIGHT_BASIC_TEST_TAG_OBJ, () => {
   test.describe('Data Observability Layer', () => {
     test.beforeEach(async ({ page }) => {
       await table.visitEntityPage(page);

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/Lineage/LineageControls.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/Lineage/LineageControls.spec.ts
@@ -12,6 +12,7 @@
  */
 import { expect } from '@playwright/test';
 import { get } from 'lodash';
+import { PLAYWRIGHT_BASIC_TEST_TAG_OBJ } from '../../../constant/config';
 import { SidebarItem } from '../../../constant/sidebar';
 import { EntityDataClass } from '../../../support/entity/EntityDataClass';
 import { PipelineClass } from '../../../support/entity/PipelineClass';
@@ -31,7 +32,6 @@ import {
 } from '../../../utils/lineage';
 import { sidebarClick } from '../../../utils/sidebar';
 import { test } from '../../fixtures/pages';
-import { PLAYWRIGHT_BASIC_TEST_TAG_OBJ } from '../../../constant/config';
 
 const table = new TableClass();
 const topic = new TopicClass();

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/Lineage/LineageInteraction.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/Lineage/LineageInteraction.spec.ts
@@ -37,8 +37,9 @@ import {
   visitLineageTab,
 } from '../../../utils/lineage';
 import { test } from '../../fixtures/pages';
+import { PLAYWRIGHT_BASIC_TEST_TAG_OBJ } from '../../../constant/config';
 
-test.describe('Lineage Interactions', () => {
+test.describe('Lineage Interactions', PLAYWRIGHT_BASIC_TEST_TAG_OBJ, () => {
   const table1 = new TableClass();
   const table2 = new TableClass();
   const topic = new TopicClass();

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/Lineage/LineageInteraction.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/Lineage/LineageInteraction.spec.ts
@@ -12,6 +12,7 @@
  */
 import { expect } from '@playwright/test';
 import { get } from 'lodash';
+import { PLAYWRIGHT_BASIC_TEST_TAG_OBJ } from '../../../constant/config';
 import { DashboardClass } from '../../../support/entity/DashboardClass';
 import { EntityDataClass } from '../../../support/entity/EntityDataClass';
 import { TableClass } from '../../../support/entity/TableClass';
@@ -37,7 +38,6 @@ import {
   visitLineageTab,
 } from '../../../utils/lineage';
 import { test } from '../../fixtures/pages';
-import { PLAYWRIGHT_BASIC_TEST_TAG_OBJ } from '../../../constant/config';
 
 test.describe('Lineage Interactions', PLAYWRIGHT_BASIC_TEST_TAG_OBJ, () => {
   const table1 = new TableClass();

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/Lineage/LineageNodePagination.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/Lineage/LineageNodePagination.spec.ts
@@ -27,6 +27,7 @@ import {
   visitLineageTab,
 } from '../../../utils/lineage';
 import { test } from '../../fixtures/pages';
+import { PLAYWRIGHT_BASIC_TEST_TAG_OBJ } from '../../../constant/config';
 
 const generateColumnsWithNames = (count: number) => {
   const columns = [];
@@ -45,49 +46,32 @@ const generateColumnsWithNames = (count: number) => {
 
 const table1Columns = generateColumnsWithNames(21);
 const table2Columns = generateColumnsWithNames(22);
-test.describe.serial('Test pagination in column level lineage', () => {
-  const table1 = new TableClass();
-  const table2 = new TableClass();
+test.describe.serial(
+  'Test pagination in column level lineage',
+  PLAYWRIGHT_BASIC_TEST_TAG_OBJ,
+  () => {
+    const table1 = new TableClass();
+    const table2 = new TableClass();
 
-  let table1Fqn: string;
-  let table2Fqn: string;
+    let table1Fqn: string;
+    let table2Fqn: string;
 
-  test.beforeAll(async ({ browser }) => {
-    const { apiContext, afterAction } = await getDefaultAdminAPIContext(
-      browser
-    );
+    test.beforeAll(async ({ browser }) => {
+      const { apiContext, afterAction } = await getDefaultAdminAPIContext(
+        browser
+      );
 
-    table1.entity.columns = table1Columns as Column[];
-    table2.entity.columns = table2Columns as Column[];
+      table1.entity.columns = table1Columns as Column[];
+      table2.entity.columns = table2Columns as Column[];
 
-    const [table1Response, table2Response] = await Promise.all([
-      table1.create(apiContext),
-      table2.create(apiContext),
-    ]);
+      const [table1Response, table2Response] = await Promise.all([
+        table1.create(apiContext),
+        table2.create(apiContext),
+      ]);
 
-    table1Fqn = get(table1Response, 'entity.fullyQualifiedName');
-    table2Fqn = get(table2Response, 'entity.fullyQualifiedName');
+      table1Fqn = get(table1Response, 'entity.fullyQualifiedName');
+      table2Fqn = get(table2Response, 'entity.fullyQualifiedName');
 
-    await connectEdgeBetweenNodesViaAPI(
-      apiContext,
-      {
-        id: table1Response.entity.id,
-        type: 'table',
-      },
-      {
-        id: table2Response.entity.id,
-        type: 'table',
-      }
-    );
-
-    const table1ColumnFqn = table1Response.entity.columns?.map(
-      (col: { fullyQualifiedName: string }) => col.fullyQualifiedName
-    ) as string[];
-    const table2ColumnFqn = table2Response.entity.columns?.map(
-      (col: { fullyQualifiedName: string }) => col.fullyQualifiedName
-    ) as string[];
-
-    await test.step('Add edges between T1-P1 and T2-P1', async () => {
       await connectEdgeBetweenNodesViaAPI(
         apiContext,
         {
@@ -97,479 +81,502 @@ test.describe.serial('Test pagination in column level lineage', () => {
         {
           id: table2Response.entity.id,
           type: 'table',
-        },
-        [
-          {
-            fromColumns: [table1ColumnFqn[0]],
-            toColumn: table2ColumnFqn[0],
-          },
-          {
-            fromColumns: [table1ColumnFqn[1]],
-            toColumn: table2ColumnFqn[1],
-          },
-          {
-            fromColumns: [table1ColumnFqn[2]],
-            toColumn: table2ColumnFqn[2],
-          },
-          {
-            fromColumns: [table1ColumnFqn[0]],
-            toColumn: table2ColumnFqn[15],
-          },
-          {
-            fromColumns: [table1ColumnFqn[1]],
-            toColumn: table2ColumnFqn[16],
-          },
-          {
-            fromColumns: [table1ColumnFqn[3]],
-            toColumn: table2ColumnFqn[17],
-          },
-          {
-            fromColumns: [table1ColumnFqn[4]],
-            toColumn: table2ColumnFqn[17],
-          },
-          {
-            fromColumns: [table1ColumnFqn[15]],
-            toColumn: table2ColumnFqn[15],
-          },
-          {
-            fromColumns: [table1ColumnFqn[16]],
-            toColumn: table2ColumnFqn[16],
-          },
-          {
-            fromColumns: [table1ColumnFqn[18]],
-            toColumn: table2ColumnFqn[17],
-          },
-        ]
-      );
-    });
-
-    await afterAction();
-  });
-
-  test.afterAll(async ({ browser }) => {
-    const { apiContext, afterAction } = await getDefaultAdminAPIContext(
-      browser
-    );
-    await Promise.all([table1.delete(apiContext), table2.delete(apiContext)]);
-    await afterAction();
-  });
-
-  test.beforeEach(async ({ page }) => {
-    await redirectToHomePage(page);
-  });
-
-  test.beforeEach(async ({ page }) => {
-    await table1.visitEntityPage(page);
-    await visitLineageTab(page);
-    await activateColumnLayer(page);
-    await performZoomOut(page);
-    await toggleLineageFilters(page, table1Fqn);
-    await toggleLineageFilters(page, table2Fqn);
-  });
-
-  test('Verify column visibility across pagination pages', async ({ page }) => {
-    test.slow();
-
-    const table1Node = page.locator(
-      `[data-testid="lineage-node-${table1Fqn}"]`
-    );
-    const table2Node = page.locator(
-      `[data-testid="lineage-node-${table2Fqn}"]`
-    );
-
-    const table1NextBtn = table1Node.getByTestId('column-scroll-down');
-    const table2NextBtn = table2Node.getByTestId('column-scroll-down');
-
-    const allColumnTestIds = {
-      table1: table1Columns.map((col) => `column-${table1Fqn}.${col.name}`),
-      table2: table2Columns.map((col) => `column-${table2Fqn}.${col.name}`),
-    };
-
-    const columnTestIds: Record<string, string[]> = {
-      'T1-P1': allColumnTestIds.table1.slice(0, 10),
-      'T1-P2': allColumnTestIds.table1.slice(10, 20),
-      'T1-P3': allColumnTestIds.table1.slice(11, 21),
-      'T2-P1': allColumnTestIds.table2.slice(0, 10),
-      'T2-P2': allColumnTestIds.table2.slice(10, 20),
-      'T2-P3': allColumnTestIds.table2.slice(12, 22),
-    };
-
-    await test.step('Verify T1-P1: C1-C10 visible, C10-C21 hidden', async () => {
-      for (const testId of columnTestIds['T1-P1']) {
-        await expect(page.locator(`[data-testid="${testId}"]`)).toBeVisible();
-      }
-
-      for (const testId of allColumnTestIds.table1) {
-        if (!columnTestIds['T1-P1'].includes(testId)) {
-          await expect(
-            page.locator(`[data-testid="${testId}"]`)
-          ).not.toBeVisible();
         }
-      }
-    });
-
-    await test.step('Verify T2-P1: C1-C10 visible, C10-C22 hidden', async () => {
-      for (const testId of columnTestIds['T2-P1']) {
-        await expect(page.locator(`[data-testid="${testId}"]`)).toBeVisible();
-      }
-
-      for (const testId of allColumnTestIds.table2) {
-        if (!columnTestIds['T2-P1'].includes(testId)) {
-          await expect(
-            page.locator(`[data-testid="${testId}"]`)
-          ).not.toBeVisible();
-        }
-      }
-    });
-
-    await test.step('Navigate to T1-P2 and verify visibility', async () => {
-      if (await table1NextBtn.isVisible()) {
-        await table1NextBtn.click();
-      }
-
-      for (const testId of columnTestIds['T1-P2']) {
-        await expect(page.locator(`[data-testid="${testId}"]`)).toBeVisible();
-      }
-
-      for (const testId of allColumnTestIds.table1) {
-        if (!columnTestIds['T1-P2'].includes(testId)) {
-          await expect(
-            page.locator(`[data-testid="${testId}"]`)
-          ).not.toBeVisible();
-        }
-      }
-    });
-
-    await test.step('Navigate to T2-P2 and verify visibility', async () => {
-      if (await table2NextBtn.isVisible()) {
-        await table2NextBtn.click();
-      }
-
-      for (const testId of columnTestIds['T2-P2']) {
-        await expect(page.locator(`[data-testid="${testId}"]`)).toBeVisible();
-      }
-
-      for (const testId of allColumnTestIds.table2) {
-        if (!columnTestIds['T2-P2'].includes(testId)) {
-          await expect(
-            page.locator(`[data-testid="${testId}"]`)
-          ).not.toBeVisible();
-        }
-      }
-    });
-
-    await test.step('Navigate to T1-P3 and verify visibility', async () => {
-      if (await table1NextBtn.isVisible()) {
-        await table1NextBtn.click();
-      }
-
-      for (const testId of columnTestIds['T1-P3']) {
-        await expect(page.locator(`[data-testid="${testId}"]`)).toBeVisible();
-      }
-
-      for (const testId of allColumnTestIds.table1) {
-        if (!columnTestIds['T1-P3'].includes(testId)) {
-          await expect(
-            page.locator(`[data-testid="${testId}"]`)
-          ).not.toBeVisible();
-        }
-      }
-    });
-
-    await test.step('Navigate to T2-P3 and verify visibility', async () => {
-      if (await table2NextBtn.isVisible()) {
-        await table2NextBtn.click();
-      }
-
-      for (const testId of columnTestIds['T2-P3']) {
-        await expect(page.locator(`[data-testid="${testId}"]`)).toBeVisible();
-      }
-
-      for (const testId of allColumnTestIds.table2) {
-        if (!columnTestIds['T2-P3'].includes(testId)) {
-          await expect(
-            page.locator(`[data-testid="${testId}"]`)
-          ).not.toBeVisible();
-        }
-      }
-    });
-  });
-
-  test('Verify edges when no column is hovered or selected', async ({
-    page,
-  }) => {
-    const table1Node = page.getByTestId(`lineage-node-${table1Fqn}`);
-    const table2Node = page.getByTestId(`lineage-node-${table2Fqn}`);
-
-    const table1NextBtn = table1Node.getByTestId('column-scroll-down');
-    const table2NextBtn = table2Node.getByTestId('column-scroll-down');
-
-    await test.step('Verify T1-P1 and T2-P1: Only (T1,C1)-(T2,C1), (T1,C2)-(T2,C2), (T1,C3)-(T2,C3) edges visible', async () => {
-      const visibleEdges = [
-        `column-edge-${table1Fqn}.${table1Columns[0].name}-${table2Fqn}.${table2Columns[0].name}`,
-        `column-edge-${table1Fqn}.${table1Columns[1].name}-${table2Fqn}.${table2Columns[1].name}`,
-        `column-edge-${table1Fqn}.${table1Columns[2].name}-${table2Fqn}.${table2Columns[2].name}`,
-      ];
-
-      const hiddenEdges = [
-        `column-edge-${table1Fqn}.${table1Columns[0].name}-${table2Fqn}.${table2Columns[15].name}`,
-        `column-edge-${table1Fqn}.${table1Columns[1].name}-${table2Fqn}.${table2Columns[16].name}`,
-        `column-edge-${table1Fqn}.${table1Columns[3].name}-${table2Fqn}.${table2Columns[17].name}`,
-        `column-edge-${table1Fqn}.${table1Columns[4].name}-${table2Fqn}.${table2Columns[17].name}`,
-        `column-edge-${table1Fqn}.${table1Columns[15].name}-${table2Fqn}.${table2Columns[15].name}`,
-        `column-edge-${table1Fqn}.${table1Columns[16].name}-${table2Fqn}.${table2Columns[16].name}`,
-        `column-edge-${table1Fqn}.${table1Columns[18].name}-${table2Fqn}.${table2Columns[17].name}`,
-      ];
-
-      for (const edgeId of visibleEdges) {
-        await expect(page.getByTestId(edgeId)).toBeVisible();
-      }
-
-      for (const edgeId of hiddenEdges) {
-        await expect(page.getByTestId(edgeId)).not.toBeVisible();
-      }
-    });
-
-    await test.step('Navigate to T2-P2 and verify (T1,C1)-(T2,C6), (T1,C2)-(T2,C7), (T1,C4)-(T2,C8), (T1,C5)-(T2,C8) edges visible', async () => {
-      if (await table2NextBtn.isVisible()) {
-        await table2NextBtn.click();
-      }
-
-      const visibleEdges = [
-        `column-edge-${table1Fqn}.${table1Columns[0].name}-${table2Fqn}.${table2Columns[15].name}`,
-        `column-edge-${table1Fqn}.${table1Columns[1].name}-${table2Fqn}.${table2Columns[16].name}`,
-        `column-edge-${table1Fqn}.${table1Columns[3].name}-${table2Fqn}.${table2Columns[17].name}`,
-        `column-edge-${table1Fqn}.${table1Columns[4].name}-${table2Fqn}.${table2Columns[17].name}`,
-      ];
-
-      const hiddenEdges = [
-        `column-edge-${table1Fqn}.${table1Columns[0].name}-${table2Fqn}.${table2Columns[0].name}`,
-        `column-edge-${table1Fqn}.${table1Columns[1].name}-${table2Fqn}.${table2Columns[1].name}`,
-        `column-edge-${table1Fqn}.${table1Columns[2].name}-${table2Fqn}.${table2Columns[2].name}`,
-        `column-edge-${table1Fqn}.${table1Columns[15].name}-${table2Fqn}.${table2Columns[15].name}`,
-        `column-edge-${table1Fqn}.${table1Columns[16].name}-${table2Fqn}.${table2Columns[16].name}`,
-        `column-edge-${table1Fqn}.${table1Columns[18].name}-${table2Fqn}.${table2Columns[17].name}`,
-      ];
-
-      for (const edgeId of visibleEdges) {
-        await expect(page.getByTestId(edgeId)).toBeVisible();
-      }
-
-      for (const edgeId of hiddenEdges) {
-        await expect(page.getByTestId(edgeId)).not.toBeVisible();
-      }
-    });
-
-    await test.step('Navigate to T1-P2 and verify (T1,C6)-(T2,C6), (T1,C7)-(T2,C7), (T1,C9)-(T2,C8) edges visible', async () => {
-      if (await table1NextBtn.isVisible()) {
-        await table1NextBtn.click();
-      }
-
-      const visibleEdges = [
-        `column-edge-${table1Fqn}.${table1Columns[15].name}-${table2Fqn}.${table2Columns[15].name}`,
-        `column-edge-${table1Fqn}.${table1Columns[16].name}-${table2Fqn}.${table2Columns[16].name}`,
-        `column-edge-${table1Fqn}.${table1Columns[18].name}-${table2Fqn}.${table2Columns[17].name}`,
-      ];
-
-      const hiddenEdges = [
-        `column-edge-${table1Fqn}.${table1Columns[0].name}-${table2Fqn}.${table2Columns[0].name}`,
-        `column-edge-${table1Fqn}.${table1Columns[1].name}-${table2Fqn}.${table2Columns[1].name}`,
-        `column-edge-${table1Fqn}.${table1Columns[2].name}-${table2Fqn}.${table2Columns[2].name}`,
-        `column-edge-${table1Fqn}.${table1Columns[0].name}-${table2Fqn}.${table2Columns[15].name}`,
-        `column-edge-${table1Fqn}.${table1Columns[1].name}-${table2Fqn}.${table2Columns[16].name}`,
-        `column-edge-${table1Fqn}.${table1Columns[3].name}-${table2Fqn}.${table2Columns[17].name}`,
-        `column-edge-${table1Fqn}.${table1Columns[4].name}-${table2Fqn}.${table2Columns[17].name}`,
-      ];
-
-      for (const edgeId of visibleEdges) {
-        await expect(page.getByTestId(edgeId)).toBeVisible();
-      }
-
-      for (const edgeId of hiddenEdges) {
-        await expect(page.getByTestId(edgeId)).not.toBeVisible();
-      }
-    });
-  });
-
-  test('Verify columns and edges when a column is hovered', async ({
-    page,
-  }) => {
-    await test.step('Hover on (T1,C1) and verify highlighted columns and edges', async () => {
-      const c1Column = page.getByTestId(
-        `column-${table1Fqn}.${table1Columns[0].name}`
       );
 
-      await c1Column.hover();
+      const table1ColumnFqn = table1Response.entity.columns?.map(
+        (col: { fullyQualifiedName: string }) => col.fullyQualifiedName
+      ) as string[];
+      const table2ColumnFqn = table2Response.entity.columns?.map(
+        (col: { fullyQualifiedName: string }) => col.fullyQualifiedName
+      ) as string[];
 
-      // Verify (T1,C1), (T2,C1) and (T2,C6) are highlighted and visible
-      const t1c1 = page.getByTestId(
-        `column-${table1Fqn}.${table1Columns[0].name}`
-      );
-      const t2c1 = page.getByTestId(
-        `column-${table2Fqn}.${table2Columns[0].name}`
-      );
-      const t2c6 = page.getByTestId(
-        `column-${table2Fqn}.${table2Columns[15].name}`
-      );
+      await test.step('Add edges between T1-P1 and T2-P1', async () => {
+        await connectEdgeBetweenNodesViaAPI(
+          apiContext,
+          {
+            id: table1Response.entity.id,
+            type: 'table',
+          },
+          {
+            id: table2Response.entity.id,
+            type: 'table',
+          },
+          [
+            {
+              fromColumns: [table1ColumnFqn[0]],
+              toColumn: table2ColumnFqn[0],
+            },
+            {
+              fromColumns: [table1ColumnFqn[1]],
+              toColumn: table2ColumnFqn[1],
+            },
+            {
+              fromColumns: [table1ColumnFqn[2]],
+              toColumn: table2ColumnFqn[2],
+            },
+            {
+              fromColumns: [table1ColumnFqn[0]],
+              toColumn: table2ColumnFqn[15],
+            },
+            {
+              fromColumns: [table1ColumnFqn[1]],
+              toColumn: table2ColumnFqn[16],
+            },
+            {
+              fromColumns: [table1ColumnFqn[3]],
+              toColumn: table2ColumnFqn[17],
+            },
+            {
+              fromColumns: [table1ColumnFqn[4]],
+              toColumn: table2ColumnFqn[17],
+            },
+            {
+              fromColumns: [table1ColumnFqn[15]],
+              toColumn: table2ColumnFqn[15],
+            },
+            {
+              fromColumns: [table1ColumnFqn[16]],
+              toColumn: table2ColumnFqn[16],
+            },
+            {
+              fromColumns: [table1ColumnFqn[18]],
+              toColumn: table2ColumnFqn[17],
+            },
+          ]
+        );
+      });
 
-      await expect(t1c1).toBeVisible();
-      await expect(t1c1).toHaveClass(/custom-node-header-column-tracing/);
-
-      await expect(t2c1).toBeVisible();
-      await expect(t2c1).toHaveClass(/custom-node-header-column-tracing/);
-
-      await expect(t2c6).toBeVisible();
-      await expect(t2c6).toHaveClass(/custom-node-header-column-tracing/);
-
-      // Verify edges are visible
-      const edge_t1c1_to_t2c1 = `column-edge-${table1Fqn}.${table1Columns[0].name}-${table2Fqn}.${table2Columns[0].name}`;
-      const edge_t1c1_to_t2c6 = `column-edge-${table1Fqn}.${table1Columns[0].name}-${table2Fqn}.${table2Columns[15].name}`;
-
-      await expect(page.getByTestId(edge_t1c1_to_t2c1)).toBeVisible();
-      await expect(page.getByTestId(edge_t1c1_to_t2c6)).toBeVisible();
-    });
-  });
-
-  test('Verify columns and edges when a column is clicked', async ({
-    page,
-  }) => {
-    test.slow();
-
-    await test.step('Navigate to T1-P2 and T2-P2, click (T2,C6) and verify highlighted columns and edges', async () => {
-      const table1Node = page.getByTestId(`lineage-node-${table1Fqn}`);
-      const table2Node = page.getByTestId(`lineage-node-${table2Fqn}`);
-
-      // Navigate to T1-P2
-      const table1NextBtn = table1Node.getByTestId('column-scroll-down');
-      if (await table1NextBtn.isVisible()) {
-        await table1NextBtn.click();
-      }
-
-      // Navigate to T2-P2
-      const table2NextBtn = table2Node.getByTestId('column-scroll-down');
-      if (await table2NextBtn.isVisible()) {
-        await table2NextBtn.click();
-      }
-
-      // Click on (T2,C6)
-      const t2c6Column = page.getByTestId(
-        `column-${table2Fqn}.${table2Columns[15].name}`
-      );
-      await t2c6Column.click();
-
-      // Verify (T1,C1), (T1,C6) and (T2,C6) are highlighted and visible
-      const t1c1 = page.getByTestId(
-        `column-${table1Fqn}.${table1Columns[0].name}`
-      );
-      const t1c6 = page.getByTestId(
-        `column-${table1Fqn}.${table1Columns[15].name}`
-      );
-      const t2c6 = page.getByTestId(
-        `column-${table2Fqn}.${table2Columns[15].name}`
-      );
-
-      await expect(t1c1).toBeVisible();
-      await expect(t1c1).toHaveClass(/custom-node-header-column-tracing/);
-
-      await expect(t1c6).toBeVisible();
-      await expect(t1c6).toHaveClass(/custom-node-header-column-tracing/);
-
-      await expect(t2c6).toBeVisible();
-      await expect(t2c6).toHaveClass(/custom-node-header-column-tracing/);
-
-      // Verify edges are visible
-      const edge_t1c1_to_t2c6 = `column-edge-${table1Fqn}.${table1Columns[0].name}-${table2Fqn}.${table2Columns[15].name}`;
-      const edge_t1c6_to_t2c6 = `column-edge-${table1Fqn}.${table1Columns[15].name}-${table2Fqn}.${table2Columns[15].name}`;
-
-      await expect(page.getByTestId(edge_t1c1_to_t2c6)).toBeVisible();
-      await expect(page.getByTestId(edge_t1c6_to_t2c6)).toBeVisible();
-    });
-  });
-
-  test('Verify edges for column level lineage between 2 nodes when filter is toggled', async ({
-    page,
-  }) => {
-    await test.step('1. Verify edges visible and hidden for page1 of both the tables', async () => {
-      const visibleEdges = [
-        `column-edge-${table1Fqn}.${table1Columns[0].name}-${table2Fqn}.${table2Columns[0].name}`,
-        `column-edge-${table1Fqn}.${table1Columns[1].name}-${table2Fqn}.${table2Columns[1].name}`,
-        `column-edge-${table1Fqn}.${table1Columns[2].name}-${table2Fqn}.${table2Columns[2].name}`,
-      ];
-
-      const hiddenEdges = [
-        `column-edge-${table1Fqn}.${table1Columns[0].name}-${table2Fqn}.${table2Columns[15].name}`,
-        `column-edge-${table1Fqn}.${table1Columns[1].name}-${table2Fqn}.${table2Columns[16].name}`,
-        `column-edge-${table1Fqn}.${table1Columns[3].name}-${table2Fqn}.${table2Columns[17].name}`,
-      ];
-
-      for (const edgeId of visibleEdges) {
-        await expect(page.getByTestId(edgeId)).toBeVisible();
-      }
-
-      for (const edgeId of hiddenEdges) {
-        await expect(page.getByTestId(edgeId)).not.toBeVisible();
-      }
+      await afterAction();
     });
 
-    await test.step('3. Enable the filter for table1 by clicking filter button', async () => {
+    test.afterAll(async ({ browser }) => {
+      const { apiContext, afterAction } = await getDefaultAdminAPIContext(
+        browser
+      );
+      await Promise.all([table1.delete(apiContext), table2.delete(apiContext)]);
+      await afterAction();
+    });
+
+    test.beforeEach(async ({ page }) => {
+      await redirectToHomePage(page);
+    });
+
+    test.beforeEach(async ({ page }) => {
+      await table1.visitEntityPage(page);
+      await visitLineageTab(page);
+      await activateColumnLayer(page);
+      await performZoomOut(page);
       await toggleLineageFilters(page, table1Fqn);
-    });
-
-    await test.step('4. Verify that only columns with lineage are visible in table1', async () => {
-      const columnsWithLineage = [0, 1, 2, 3, 4, 15, 16, 18];
-      const columnsWithoutLineage = [7, 9, 10];
-
-      for (const index of columnsWithLineage) {
-        await expect(
-          page.getByTestId(`column-${table1Fqn}.${table1Columns[index].name}`)
-        ).toBeVisible();
-      }
-
-      for (const index of columnsWithoutLineage) {
-        await expect(
-          page.getByTestId(`column-${table1Fqn}.${table1Columns[index].name}`)
-        ).not.toBeVisible();
-      }
-    });
-
-    await test.step('5. Enable the filter for table2 by clicking filter button', async () => {
       await toggleLineageFilters(page, table2Fqn);
     });
 
-    await test.step('6. Verify that only columns with lineage are visible in table2', async () => {
-      const columnsWithLineage = [0, 1, 2, 15, 16, 17];
-      const columnsWithoutLineage = [3, 4, 8, 9, 10, 11];
+    test('Verify column visibility across pagination pages', async ({
+      page,
+    }) => {
+      test.slow();
 
-      for (const index of columnsWithLineage) {
-        await expect(
-          page.getByTestId(`column-${table2Fqn}.${table2Columns[index].name}`)
-        ).toBeVisible();
-      }
+      const table1Node = page.locator(
+        `[data-testid="lineage-node-${table1Fqn}"]`
+      );
+      const table2Node = page.locator(
+        `[data-testid="lineage-node-${table2Fqn}"]`
+      );
 
-      for (const index of columnsWithoutLineage) {
-        await expect(
-          page.getByTestId(`column-${table2Fqn}.${table2Columns[index].name}`)
-        ).not.toBeVisible();
-      }
+      const table1NextBtn = table1Node.getByTestId('column-scroll-down');
+      const table2NextBtn = table2Node.getByTestId('column-scroll-down');
+
+      const allColumnTestIds = {
+        table1: table1Columns.map((col) => `column-${table1Fqn}.${col.name}`),
+        table2: table2Columns.map((col) => `column-${table2Fqn}.${col.name}`),
+      };
+
+      const columnTestIds: Record<string, string[]> = {
+        'T1-P1': allColumnTestIds.table1.slice(0, 10),
+        'T1-P2': allColumnTestIds.table1.slice(10, 20),
+        'T1-P3': allColumnTestIds.table1.slice(11, 21),
+        'T2-P1': allColumnTestIds.table2.slice(0, 10),
+        'T2-P2': allColumnTestIds.table2.slice(10, 20),
+        'T2-P3': allColumnTestIds.table2.slice(12, 22),
+      };
+
+      await test.step('Verify T1-P1: C1-C10 visible, C10-C21 hidden', async () => {
+        for (const testId of columnTestIds['T1-P1']) {
+          await expect(page.locator(`[data-testid="${testId}"]`)).toBeVisible();
+        }
+
+        for (const testId of allColumnTestIds.table1) {
+          if (!columnTestIds['T1-P1'].includes(testId)) {
+            await expect(
+              page.locator(`[data-testid="${testId}"]`)
+            ).not.toBeVisible();
+          }
+        }
+      });
+
+      await test.step('Verify T2-P1: C1-C10 visible, C10-C22 hidden', async () => {
+        for (const testId of columnTestIds['T2-P1']) {
+          await expect(page.locator(`[data-testid="${testId}"]`)).toBeVisible();
+        }
+
+        for (const testId of allColumnTestIds.table2) {
+          if (!columnTestIds['T2-P1'].includes(testId)) {
+            await expect(
+              page.locator(`[data-testid="${testId}"]`)
+            ).not.toBeVisible();
+          }
+        }
+      });
+
+      await test.step('Navigate to T1-P2 and verify visibility', async () => {
+        if (await table1NextBtn.isVisible()) {
+          await table1NextBtn.click();
+        }
+
+        for (const testId of columnTestIds['T1-P2']) {
+          await expect(page.locator(`[data-testid="${testId}"]`)).toBeVisible();
+        }
+
+        for (const testId of allColumnTestIds.table1) {
+          if (!columnTestIds['T1-P2'].includes(testId)) {
+            await expect(
+              page.locator(`[data-testid="${testId}"]`)
+            ).not.toBeVisible();
+          }
+        }
+      });
+
+      await test.step('Navigate to T2-P2 and verify visibility', async () => {
+        if (await table2NextBtn.isVisible()) {
+          await table2NextBtn.click();
+        }
+
+        for (const testId of columnTestIds['T2-P2']) {
+          await expect(page.locator(`[data-testid="${testId}"]`)).toBeVisible();
+        }
+
+        for (const testId of allColumnTestIds.table2) {
+          if (!columnTestIds['T2-P2'].includes(testId)) {
+            await expect(
+              page.locator(`[data-testid="${testId}"]`)
+            ).not.toBeVisible();
+          }
+        }
+      });
+
+      await test.step('Navigate to T1-P3 and verify visibility', async () => {
+        if (await table1NextBtn.isVisible()) {
+          await table1NextBtn.click();
+        }
+
+        for (const testId of columnTestIds['T1-P3']) {
+          await expect(page.locator(`[data-testid="${testId}"]`)).toBeVisible();
+        }
+
+        for (const testId of allColumnTestIds.table1) {
+          if (!columnTestIds['T1-P3'].includes(testId)) {
+            await expect(
+              page.locator(`[data-testid="${testId}"]`)
+            ).not.toBeVisible();
+          }
+        }
+      });
+
+      await test.step('Navigate to T2-P3 and verify visibility', async () => {
+        if (await table2NextBtn.isVisible()) {
+          await table2NextBtn.click();
+        }
+
+        for (const testId of columnTestIds['T2-P3']) {
+          await expect(page.locator(`[data-testid="${testId}"]`)).toBeVisible();
+        }
+
+        for (const testId of allColumnTestIds.table2) {
+          if (!columnTestIds['T2-P3'].includes(testId)) {
+            await expect(
+              page.locator(`[data-testid="${testId}"]`)
+            ).not.toBeVisible();
+          }
+        }
+      });
     });
 
-    await test.step('7. Verify new edges are now visible.', async () => {
-      const allVisibleEdges = [
-        `column-edge-${table1Fqn}.${table1Columns[0].name}-${table2Fqn}.${table2Columns[0].name}`,
-        `column-edge-${table1Fqn}.${table1Columns[1].name}-${table2Fqn}.${table2Columns[1].name}`,
-        `column-edge-${table1Fqn}.${table1Columns[2].name}-${table2Fqn}.${table2Columns[2].name}`,
-        `column-edge-${table1Fqn}.${table1Columns[0].name}-${table2Fqn}.${table2Columns[15].name}`,
-        `column-edge-${table1Fqn}.${table1Columns[1].name}-${table2Fqn}.${table2Columns[16].name}`,
-        `column-edge-${table1Fqn}.${table1Columns[3].name}-${table2Fqn}.${table2Columns[17].name}`,
-        `column-edge-${table1Fqn}.${table1Columns[4].name}-${table2Fqn}.${table2Columns[17].name}`,
-        `column-edge-${table1Fqn}.${table1Columns[15].name}-${table2Fqn}.${table2Columns[15].name}`,
-        `column-edge-${table1Fqn}.${table1Columns[16].name}-${table2Fqn}.${table2Columns[16].name}`,
-        `column-edge-${table1Fqn}.${table1Columns[18].name}-${table2Fqn}.${table2Columns[17].name}`,
-      ];
+    test('Verify edges when no column is hovered or selected', async ({
+      page,
+    }) => {
+      const table1Node = page.getByTestId(`lineage-node-${table1Fqn}`);
+      const table2Node = page.getByTestId(`lineage-node-${table2Fqn}`);
 
-      for (const edgeId of allVisibleEdges) {
-        await expect(page.getByTestId(edgeId)).toBeVisible();
-      }
+      const table1NextBtn = table1Node.getByTestId('column-scroll-down');
+      const table2NextBtn = table2Node.getByTestId('column-scroll-down');
+
+      await test.step('Verify T1-P1 and T2-P1: Only (T1,C1)-(T2,C1), (T1,C2)-(T2,C2), (T1,C3)-(T2,C3) edges visible', async () => {
+        const visibleEdges = [
+          `column-edge-${table1Fqn}.${table1Columns[0].name}-${table2Fqn}.${table2Columns[0].name}`,
+          `column-edge-${table1Fqn}.${table1Columns[1].name}-${table2Fqn}.${table2Columns[1].name}`,
+          `column-edge-${table1Fqn}.${table1Columns[2].name}-${table2Fqn}.${table2Columns[2].name}`,
+        ];
+
+        const hiddenEdges = [
+          `column-edge-${table1Fqn}.${table1Columns[0].name}-${table2Fqn}.${table2Columns[15].name}`,
+          `column-edge-${table1Fqn}.${table1Columns[1].name}-${table2Fqn}.${table2Columns[16].name}`,
+          `column-edge-${table1Fqn}.${table1Columns[3].name}-${table2Fqn}.${table2Columns[17].name}`,
+          `column-edge-${table1Fqn}.${table1Columns[4].name}-${table2Fqn}.${table2Columns[17].name}`,
+          `column-edge-${table1Fqn}.${table1Columns[15].name}-${table2Fqn}.${table2Columns[15].name}`,
+          `column-edge-${table1Fqn}.${table1Columns[16].name}-${table2Fqn}.${table2Columns[16].name}`,
+          `column-edge-${table1Fqn}.${table1Columns[18].name}-${table2Fqn}.${table2Columns[17].name}`,
+        ];
+
+        for (const edgeId of visibleEdges) {
+          await expect(page.getByTestId(edgeId)).toBeVisible();
+        }
+
+        for (const edgeId of hiddenEdges) {
+          await expect(page.getByTestId(edgeId)).not.toBeVisible();
+        }
+      });
+
+      await test.step('Navigate to T2-P2 and verify (T1,C1)-(T2,C6), (T1,C2)-(T2,C7), (T1,C4)-(T2,C8), (T1,C5)-(T2,C8) edges visible', async () => {
+        if (await table2NextBtn.isVisible()) {
+          await table2NextBtn.click();
+        }
+
+        const visibleEdges = [
+          `column-edge-${table1Fqn}.${table1Columns[0].name}-${table2Fqn}.${table2Columns[15].name}`,
+          `column-edge-${table1Fqn}.${table1Columns[1].name}-${table2Fqn}.${table2Columns[16].name}`,
+          `column-edge-${table1Fqn}.${table1Columns[3].name}-${table2Fqn}.${table2Columns[17].name}`,
+          `column-edge-${table1Fqn}.${table1Columns[4].name}-${table2Fqn}.${table2Columns[17].name}`,
+        ];
+
+        const hiddenEdges = [
+          `column-edge-${table1Fqn}.${table1Columns[0].name}-${table2Fqn}.${table2Columns[0].name}`,
+          `column-edge-${table1Fqn}.${table1Columns[1].name}-${table2Fqn}.${table2Columns[1].name}`,
+          `column-edge-${table1Fqn}.${table1Columns[2].name}-${table2Fqn}.${table2Columns[2].name}`,
+          `column-edge-${table1Fqn}.${table1Columns[15].name}-${table2Fqn}.${table2Columns[15].name}`,
+          `column-edge-${table1Fqn}.${table1Columns[16].name}-${table2Fqn}.${table2Columns[16].name}`,
+          `column-edge-${table1Fqn}.${table1Columns[18].name}-${table2Fqn}.${table2Columns[17].name}`,
+        ];
+
+        for (const edgeId of visibleEdges) {
+          await expect(page.getByTestId(edgeId)).toBeVisible();
+        }
+
+        for (const edgeId of hiddenEdges) {
+          await expect(page.getByTestId(edgeId)).not.toBeVisible();
+        }
+      });
+
+      await test.step('Navigate to T1-P2 and verify (T1,C6)-(T2,C6), (T1,C7)-(T2,C7), (T1,C9)-(T2,C8) edges visible', async () => {
+        if (await table1NextBtn.isVisible()) {
+          await table1NextBtn.click();
+        }
+
+        const visibleEdges = [
+          `column-edge-${table1Fqn}.${table1Columns[15].name}-${table2Fqn}.${table2Columns[15].name}`,
+          `column-edge-${table1Fqn}.${table1Columns[16].name}-${table2Fqn}.${table2Columns[16].name}`,
+          `column-edge-${table1Fqn}.${table1Columns[18].name}-${table2Fqn}.${table2Columns[17].name}`,
+        ];
+
+        const hiddenEdges = [
+          `column-edge-${table1Fqn}.${table1Columns[0].name}-${table2Fqn}.${table2Columns[0].name}`,
+          `column-edge-${table1Fqn}.${table1Columns[1].name}-${table2Fqn}.${table2Columns[1].name}`,
+          `column-edge-${table1Fqn}.${table1Columns[2].name}-${table2Fqn}.${table2Columns[2].name}`,
+          `column-edge-${table1Fqn}.${table1Columns[0].name}-${table2Fqn}.${table2Columns[15].name}`,
+          `column-edge-${table1Fqn}.${table1Columns[1].name}-${table2Fqn}.${table2Columns[16].name}`,
+          `column-edge-${table1Fqn}.${table1Columns[3].name}-${table2Fqn}.${table2Columns[17].name}`,
+          `column-edge-${table1Fqn}.${table1Columns[4].name}-${table2Fqn}.${table2Columns[17].name}`,
+        ];
+
+        for (const edgeId of visibleEdges) {
+          await expect(page.getByTestId(edgeId)).toBeVisible();
+        }
+
+        for (const edgeId of hiddenEdges) {
+          await expect(page.getByTestId(edgeId)).not.toBeVisible();
+        }
+      });
     });
-  });
-});
+
+    test('Verify columns and edges when a column is hovered', async ({
+      page,
+    }) => {
+      await test.step('Hover on (T1,C1) and verify highlighted columns and edges', async () => {
+        const c1Column = page.getByTestId(
+          `column-${table1Fqn}.${table1Columns[0].name}`
+        );
+
+        await c1Column.hover();
+
+        // Verify (T1,C1), (T2,C1) and (T2,C6) are highlighted and visible
+        const t1c1 = page.getByTestId(
+          `column-${table1Fqn}.${table1Columns[0].name}`
+        );
+        const t2c1 = page.getByTestId(
+          `column-${table2Fqn}.${table2Columns[0].name}`
+        );
+        const t2c6 = page.getByTestId(
+          `column-${table2Fqn}.${table2Columns[15].name}`
+        );
+
+        await expect(t1c1).toBeVisible();
+        await expect(t1c1).toHaveClass(/custom-node-header-column-tracing/);
+
+        await expect(t2c1).toBeVisible();
+        await expect(t2c1).toHaveClass(/custom-node-header-column-tracing/);
+
+        await expect(t2c6).toBeVisible();
+        await expect(t2c6).toHaveClass(/custom-node-header-column-tracing/);
+
+        // Verify edges are visible
+        const edge_t1c1_to_t2c1 = `column-edge-${table1Fqn}.${table1Columns[0].name}-${table2Fqn}.${table2Columns[0].name}`;
+        const edge_t1c1_to_t2c6 = `column-edge-${table1Fqn}.${table1Columns[0].name}-${table2Fqn}.${table2Columns[15].name}`;
+
+        await expect(page.getByTestId(edge_t1c1_to_t2c1)).toBeVisible();
+        await expect(page.getByTestId(edge_t1c1_to_t2c6)).toBeVisible();
+      });
+    });
+
+    test('Verify columns and edges when a column is clicked', async ({
+      page,
+    }) => {
+      test.slow();
+
+      await test.step('Navigate to T1-P2 and T2-P2, click (T2,C6) and verify highlighted columns and edges', async () => {
+        const table1Node = page.getByTestId(`lineage-node-${table1Fqn}`);
+        const table2Node = page.getByTestId(`lineage-node-${table2Fqn}`);
+
+        // Navigate to T1-P2
+        const table1NextBtn = table1Node.getByTestId('column-scroll-down');
+        if (await table1NextBtn.isVisible()) {
+          await table1NextBtn.click();
+        }
+
+        // Navigate to T2-P2
+        const table2NextBtn = table2Node.getByTestId('column-scroll-down');
+        if (await table2NextBtn.isVisible()) {
+          await table2NextBtn.click();
+        }
+
+        // Click on (T2,C6)
+        const t2c6Column = page.getByTestId(
+          `column-${table2Fqn}.${table2Columns[15].name}`
+        );
+        await t2c6Column.click();
+
+        // Verify (T1,C1), (T1,C6) and (T2,C6) are highlighted and visible
+        const t1c1 = page.getByTestId(
+          `column-${table1Fqn}.${table1Columns[0].name}`
+        );
+        const t1c6 = page.getByTestId(
+          `column-${table1Fqn}.${table1Columns[15].name}`
+        );
+        const t2c6 = page.getByTestId(
+          `column-${table2Fqn}.${table2Columns[15].name}`
+        );
+
+        await expect(t1c1).toBeVisible();
+        await expect(t1c1).toHaveClass(/custom-node-header-column-tracing/);
+
+        await expect(t1c6).toBeVisible();
+        await expect(t1c6).toHaveClass(/custom-node-header-column-tracing/);
+
+        await expect(t2c6).toBeVisible();
+        await expect(t2c6).toHaveClass(/custom-node-header-column-tracing/);
+
+        // Verify edges are visible
+        const edge_t1c1_to_t2c6 = `column-edge-${table1Fqn}.${table1Columns[0].name}-${table2Fqn}.${table2Columns[15].name}`;
+        const edge_t1c6_to_t2c6 = `column-edge-${table1Fqn}.${table1Columns[15].name}-${table2Fqn}.${table2Columns[15].name}`;
+
+        await expect(page.getByTestId(edge_t1c1_to_t2c6)).toBeVisible();
+        await expect(page.getByTestId(edge_t1c6_to_t2c6)).toBeVisible();
+      });
+    });
+
+    test('Verify edges for column level lineage between 2 nodes when filter is toggled', async ({
+      page,
+    }) => {
+      await test.step('1. Verify edges visible and hidden for page1 of both the tables', async () => {
+        const visibleEdges = [
+          `column-edge-${table1Fqn}.${table1Columns[0].name}-${table2Fqn}.${table2Columns[0].name}`,
+          `column-edge-${table1Fqn}.${table1Columns[1].name}-${table2Fqn}.${table2Columns[1].name}`,
+          `column-edge-${table1Fqn}.${table1Columns[2].name}-${table2Fqn}.${table2Columns[2].name}`,
+        ];
+
+        const hiddenEdges = [
+          `column-edge-${table1Fqn}.${table1Columns[0].name}-${table2Fqn}.${table2Columns[15].name}`,
+          `column-edge-${table1Fqn}.${table1Columns[1].name}-${table2Fqn}.${table2Columns[16].name}`,
+          `column-edge-${table1Fqn}.${table1Columns[3].name}-${table2Fqn}.${table2Columns[17].name}`,
+        ];
+
+        for (const edgeId of visibleEdges) {
+          await expect(page.getByTestId(edgeId)).toBeVisible();
+        }
+
+        for (const edgeId of hiddenEdges) {
+          await expect(page.getByTestId(edgeId)).not.toBeVisible();
+        }
+      });
+
+      await test.step('3. Enable the filter for table1 by clicking filter button', async () => {
+        await toggleLineageFilters(page, table1Fqn);
+      });
+
+      await test.step('4. Verify that only columns with lineage are visible in table1', async () => {
+        const columnsWithLineage = [0, 1, 2, 3, 4, 15, 16, 18];
+        const columnsWithoutLineage = [7, 9, 10];
+
+        for (const index of columnsWithLineage) {
+          await expect(
+            page.getByTestId(`column-${table1Fqn}.${table1Columns[index].name}`)
+          ).toBeVisible();
+        }
+
+        for (const index of columnsWithoutLineage) {
+          await expect(
+            page.getByTestId(`column-${table1Fqn}.${table1Columns[index].name}`)
+          ).not.toBeVisible();
+        }
+      });
+
+      await test.step('5. Enable the filter for table2 by clicking filter button', async () => {
+        await toggleLineageFilters(page, table2Fqn);
+      });
+
+      await test.step('6. Verify that only columns with lineage are visible in table2', async () => {
+        const columnsWithLineage = [0, 1, 2, 15, 16, 17];
+        const columnsWithoutLineage = [3, 4, 8, 9, 10, 11];
+
+        for (const index of columnsWithLineage) {
+          await expect(
+            page.getByTestId(`column-${table2Fqn}.${table2Columns[index].name}`)
+          ).toBeVisible();
+        }
+
+        for (const index of columnsWithoutLineage) {
+          await expect(
+            page.getByTestId(`column-${table2Fqn}.${table2Columns[index].name}`)
+          ).not.toBeVisible();
+        }
+      });
+
+      await test.step('7. Verify new edges are now visible.', async () => {
+        const allVisibleEdges = [
+          `column-edge-${table1Fqn}.${table1Columns[0].name}-${table2Fqn}.${table2Columns[0].name}`,
+          `column-edge-${table1Fqn}.${table1Columns[1].name}-${table2Fqn}.${table2Columns[1].name}`,
+          `column-edge-${table1Fqn}.${table1Columns[2].name}-${table2Fqn}.${table2Columns[2].name}`,
+          `column-edge-${table1Fqn}.${table1Columns[0].name}-${table2Fqn}.${table2Columns[15].name}`,
+          `column-edge-${table1Fqn}.${table1Columns[1].name}-${table2Fqn}.${table2Columns[16].name}`,
+          `column-edge-${table1Fqn}.${table1Columns[3].name}-${table2Fqn}.${table2Columns[17].name}`,
+          `column-edge-${table1Fqn}.${table1Columns[4].name}-${table2Fqn}.${table2Columns[17].name}`,
+          `column-edge-${table1Fqn}.${table1Columns[15].name}-${table2Fqn}.${table2Columns[15].name}`,
+          `column-edge-${table1Fqn}.${table1Columns[16].name}-${table2Fqn}.${table2Columns[16].name}`,
+          `column-edge-${table1Fqn}.${table1Columns[18].name}-${table2Fqn}.${table2Columns[17].name}`,
+        ];
+
+        for (const edgeId of allVisibleEdges) {
+          await expect(page.getByTestId(edgeId)).toBeVisible();
+        }
+      });
+    });
+  }
+);

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/Lineage/LineageNodePagination.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/Lineage/LineageNodePagination.spec.ts
@@ -13,6 +13,7 @@
 import { expect } from '@playwright/test';
 import { get } from 'lodash';
 import { Column } from '../../../../src/generated/entity/data/table';
+import { PLAYWRIGHT_BASIC_TEST_TAG_OBJ } from '../../../constant/config';
 import { TableClass } from '../../../support/entity/TableClass';
 import {
   getDefaultAdminAPIContext,
@@ -27,7 +28,6 @@ import {
   visitLineageTab,
 } from '../../../utils/lineage';
 import { test } from '../../fixtures/pages';
-import { PLAYWRIGHT_BASIC_TEST_TAG_OBJ } from '../../../constant/config';
 
 const generateColumnsWithNames = (count: number) => {
   const columns = [];

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/Lineage/PlatformLineage.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/Lineage/PlatformLineage.spec.ts
@@ -12,6 +12,7 @@
  */
 import { expect } from '@playwright/test';
 import { get } from 'lodash';
+import { PLAYWRIGHT_BASIC_TEST_TAG_OBJ } from '../../../constant/config';
 import { SidebarItem } from '../../../constant/sidebar';
 import { EntityDataClass } from '../../../support/entity/EntityDataClass';
 import { TableClass } from '../../../support/entity/TableClass';
@@ -28,7 +29,6 @@ import {
 } from '../../../utils/lineage';
 import { sidebarClick } from '../../../utils/sidebar';
 import { test } from '../../fixtures/pages';
-import { PLAYWRIGHT_BASIC_TEST_TAG_OBJ } from '../../../constant/config';
 
 // Create a table with '/' in the name to test encoding functionality
 const tableNameWithSlash = `pw-table-with/slash-${uuid()}`;

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/Lineage/PlatformLineage.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/Lineage/PlatformLineage.spec.ts
@@ -28,6 +28,7 @@ import {
 } from '../../../utils/lineage';
 import { sidebarClick } from '../../../utils/sidebar';
 import { test } from '../../fixtures/pages';
+import { PLAYWRIGHT_BASIC_TEST_TAG_OBJ } from '../../../constant/config';
 
 // Create a table with '/' in the name to test encoding functionality
 const tableNameWithSlash = `pw-table-with/slash-${uuid()}`;
@@ -60,117 +61,131 @@ test.beforeEach(async ({ page }) => {
   await performZoomOut(page);
 });
 
-test('Verify table search with special characters as handled', async ({
-  page,
-}) => {
-  await redirectToHomePage(page);
-  const db = table.databaseResponseData.name;
+test(
+  'Verify table search with special characters as handled',
+  PLAYWRIGHT_BASIC_TEST_TAG_OBJ,
+  async ({ page }) => {
+    await redirectToHomePage(page);
+    const db = table.databaseResponseData.name;
 
-  await sidebarClick(page, SidebarItem.LINEAGE);
+    await sidebarClick(page, SidebarItem.LINEAGE);
 
-  await page.getByTestId('search-entity-select').waitFor();
-  await page.getByTestId('search-entity-select').click();
+    await page.getByTestId('search-entity-select').waitFor();
+    await page.getByTestId('search-entity-select').click();
 
-  await page.fill(
-    '[data-testid="search-entity-select"] .ant-select-selection-search-input',
-    table.entity.name
-  );
+    await page.fill(
+      '[data-testid="search-entity-select"] .ant-select-selection-search-input',
+      table.entity.name
+    );
 
-  await page.waitForRequest(
-    (req) =>
-      req.url().includes('/api/v1/search/query') &&
-      req.url().includes('deleted=false')
-  );
+    await page.waitForRequest(
+      (req) =>
+        req.url().includes('/api/v1/search/query') &&
+        req.url().includes('deleted=false')
+    );
 
-  await page.locator('.ant-select-dropdown').waitFor();
+    await page.locator('.ant-select-dropdown').waitFor();
 
-  const nodeFqn = get(table, 'entityResponseData.fullyQualifiedName');
-  const dbFqn = get(
-    table,
-    'entityResponseData.database.fullyQualifiedName',
-    ''
-  );
-  await page
-    .locator(`[data-testid="node-suggestion-${nodeFqn}"]`)
-    .dispatchEvent('click');
+    const nodeFqn = get(table, 'entityResponseData.fullyQualifiedName');
+    const dbFqn = get(
+      table,
+      'entityResponseData.database.fullyQualifiedName',
+      ''
+    );
+    await page
+      .locator(`[data-testid="node-suggestion-${nodeFqn}"]`)
+      .dispatchEvent('click');
 
-  await page.waitForResponse('/api/v1/lineage/getLineage?*');
+    await page.waitForResponse('/api/v1/lineage/getLineage?*');
 
-  await expect(page.locator('[data-testid="lineage-details"]')).toBeVisible();
+    await expect(page.locator('[data-testid="lineage-details"]')).toBeVisible();
 
-  await expect(
-    page.locator(`[data-testid="lineage-node-${nodeFqn}"]`)
-  ).toBeVisible();
+    await expect(
+      page.locator(`[data-testid="lineage-node-${nodeFqn}"]`)
+    ).toBeVisible();
 
-  await redirectToHomePage(page);
-  await sidebarClick(page, SidebarItem.LINEAGE);
-  await page.getByTestId('search-entity-select').waitFor();
-  await page.click('[data-testid="search-entity-select"]');
+    await redirectToHomePage(page);
+    await sidebarClick(page, SidebarItem.LINEAGE);
+    await page.getByTestId('search-entity-select').waitFor();
+    await page.click('[data-testid="search-entity-select"]');
 
-  await page.fill(
-    '[data-testid="search-entity-select"] .ant-select-selection-search-input',
-    db
-  );
-  await page.getByTestId(`node-suggestion-${dbFqn}`).waitFor();
-  await page.getByTestId(`node-suggestion-${dbFqn}`).dispatchEvent('click');
-  await page.waitForResponse('/api/v1/lineage/getLineage?*');
+    await page.fill(
+      '[data-testid="search-entity-select"] .ant-select-selection-search-input',
+      db
+    );
+    await page.getByTestId(`node-suggestion-${dbFqn}`).waitFor();
+    await page.getByTestId(`node-suggestion-${dbFqn}`).dispatchEvent('click');
+    await page.waitForResponse('/api/v1/lineage/getLineage?*');
 
-  await expect(page.getByTestId('lineage-details')).toBeVisible();
+    await expect(page.getByTestId('lineage-details')).toBeVisible();
 
-  await clickLineageNode(page, dbFqn);
+    await clickLineageNode(page, dbFqn);
 
-  await expect(
-    page.locator('.lineage-entity-panel').getByTestId('entity-header-title')
-  ).toBeVisible();
-});
+    await expect(
+      page.locator('.lineage-entity-panel').getByTestId('entity-header-title')
+    ).toBeVisible();
+  }
+);
 
-test('Verify service platform view', async ({ page }) => {
-  await page.getByTestId('lineage-layer-btn').click();
+test(
+  'Verify service platform view',
+  PLAYWRIGHT_BASIC_TEST_TAG_OBJ,
+  async ({ page }) => {
+    await page.getByTestId('lineage-layer-btn').click();
 
-  const serviceBtn = page.getByTestId('lineage-layer-service-btn');
-  await expect(serviceBtn).toBeVisible();
+    const serviceBtn = page.getByTestId('lineage-layer-service-btn');
+    await expect(serviceBtn).toBeVisible();
 
-  await serviceBtn.click();
-  await page.keyboard.press('Escape');
+    await serviceBtn.click();
+    await page.keyboard.press('Escape');
 
-  await page.getByTestId('lineage-layer-btn').click();
-  await expect(serviceBtn).toHaveClass(/Mui-selected/);
-});
+    await page.getByTestId('lineage-layer-btn').click();
+    await expect(serviceBtn).toHaveClass(/Mui-selected/);
+  }
+);
 
-test('Verify domain platform view', async ({ page }) => {
-  await page.getByTestId('lineage-layer-btn').click();
+test(
+  'Verify domain platform view',
+  PLAYWRIGHT_BASIC_TEST_TAG_OBJ,
+  async ({ page }) => {
+    await page.getByTestId('lineage-layer-btn').click();
 
-  const domainBtn = page.getByTestId('lineage-layer-domain-btn');
-  await expect(domainBtn).toBeVisible();
+    const domainBtn = page.getByTestId('lineage-layer-domain-btn');
+    await expect(domainBtn).toBeVisible();
 
-  await domainBtn.click();
-  await page.keyboard.press('Escape');
+    await domainBtn.click();
+    await page.keyboard.press('Escape');
 
-  await page.getByTestId('lineage-layer-btn').click();
-  await expect(domainBtn).toHaveClass(/Mui-selected/);
+    await page.getByTestId('lineage-layer-btn').click();
+    await expect(domainBtn).toHaveClass(/Mui-selected/);
 
-  await page.keyboard.press('Escape');
+    await page.keyboard.press('Escape');
 
-  await waitForAllLoadersToDisappear(page);
-});
+    await waitForAllLoadersToDisappear(page);
+  }
+);
 
-test('Verify platform view switching', async ({ page }) => {
-  await page.getByTestId('lineage-layer-btn').click();
+test(
+  'Verify platform view switching',
+  PLAYWRIGHT_BASIC_TEST_TAG_OBJ,
+  async ({ page }) => {
+    await page.getByTestId('lineage-layer-btn').click();
 
-  const serviceBtn = page.getByTestId('lineage-layer-service-btn');
-  const domainBtn = page.getByTestId('lineage-layer-domain-btn');
+    const serviceBtn = page.getByTestId('lineage-layer-service-btn');
+    const domainBtn = page.getByTestId('lineage-layer-domain-btn');
 
-  await serviceBtn.click();
-  await page.keyboard.press('Escape');
+    await serviceBtn.click();
+    await page.keyboard.press('Escape');
 
-  await page.getByTestId('lineage-layer-btn').click();
-  await expect(serviceBtn).toHaveClass(/Mui-selected/);
-  await expect(domainBtn).not.toHaveClass(/Mui-selected/);
+    await page.getByTestId('lineage-layer-btn').click();
+    await expect(serviceBtn).toHaveClass(/Mui-selected/);
+    await expect(domainBtn).not.toHaveClass(/Mui-selected/);
 
-  await domainBtn.click();
-  await page.keyboard.press('Escape');
+    await domainBtn.click();
+    await page.keyboard.press('Escape');
 
-  await page.getByTestId('lineage-layer-btn').click();
-  await expect(domainBtn).toHaveClass(/Mui-selected/);
-  await expect(serviceBtn).not.toHaveClass(/Mui-selected/);
-});
+    await page.getByTestId('lineage-layer-btn').click();
+    await expect(domainBtn).toHaveClass(/Mui-selected/);
+    await expect(serviceBtn).not.toHaveClass(/Mui-selected/);
+  }
+);

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/Login.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/Login.spec.ts
@@ -24,6 +24,7 @@ import {
 } from '../../utils/common';
 import { waitForAllLoadersToDisappear } from '../../utils/entity';
 import { updateJWTTokenExpiryTime } from '../../utils/login';
+import { PLAYWRIGHT_BASIC_TEST_TAG_OBJ } from '../../constant/config';
 
 const user = new UserClass();
 const CREDENTIALS = user.data;
@@ -35,205 +36,219 @@ test.describe.configure({
   timeout: 5 * 60 * 1000,
 });
 
-test.describe('Login flow should work properly', () => {
-  test.afterAll('Cleanup', async ({ browser }) => {
-    const { apiContext, afterAction, page } = await performAdminLogin(browser);
-    const response = await page.request.get(
-      `/api/v1/users/name/${user.getUserDisplayName()}`
-    );
+test.describe(
+  'Login flow should work properly',
+  PLAYWRIGHT_BASIC_TEST_TAG_OBJ,
+  () => {
+    test.afterAll('Cleanup', async ({ browser }) => {
+      const { apiContext, afterAction, page } = await performAdminLogin(
+        browser
+      );
+      const response = await page.request.get(
+        `/api/v1/users/name/${user.getUserDisplayName()}`
+      );
 
-    // reset token expiry to 4 hours
-    await updateJWTTokenExpiryTime(apiContext, JWT_EXPIRY_TIME_MAP['4 hours']);
-
-    user.responseData = await response.json();
-    await user.delete(apiContext);
-    await afterAction();
-  });
-
-  test.beforeAll(
-    'Update token timer to be 3 minutes for new token created',
-    async ({ browser }) => {
-      const { apiContext, afterAction } = await performAdminLogin(browser);
-
-      // update expiry for 3 mins
+      // reset token expiry to 4 hours
       await updateJWTTokenExpiryTime(
         apiContext,
-        JWT_EXPIRY_TIME_MAP['2 minutes']
+        JWT_EXPIRY_TIME_MAP['4 hours']
       );
 
+      user.responseData = await response.json();
+      await user.delete(apiContext);
       await afterAction();
-    }
-  );
+    });
 
-  test('Signup and Login with signed up credentials', async ({ page }) => {
-    await page.goto('/');
+    test.beforeAll(
+      'Update token timer to be 3 minutes for new token created',
+      async ({ browser }) => {
+        const { apiContext, afterAction } = await performAdminLogin(browser);
 
-    await expect(page).toHaveURL(`/signin`);
+        // update expiry for 3 mins
+        await updateJWTTokenExpiryTime(
+          apiContext,
+          JWT_EXPIRY_TIME_MAP['2 minutes']
+        );
 
-    // Click on create account button
-    await page.locator('[data-testid="signup"]').click();
-
-    // Enter credentials
-    await page.locator('#firstName').fill(CREDENTIALS.firstName);
-
-    await expect(page.locator('#firstName')).toHaveValue(CREDENTIALS.firstName);
-
-    await page.locator('#lastName').fill(CREDENTIALS.lastName);
-
-    await expect(page.locator('#lastName')).toHaveValue(CREDENTIALS.lastName);
-
-    await page.locator('#email').fill(CREDENTIALS.email);
-
-    await expect(page.locator('#email')).toHaveValue(CREDENTIALS.email);
-
-    await page.locator('#password').fill(CREDENTIALS.password);
-
-    await expect(page.locator('#password')).toHaveAttribute('type', 'password');
-
-    await page.locator('#confirmPassword').fill(CREDENTIALS.password);
-
-    const createUserResponse = page.waitForResponse(`/api/v1/users/signup`);
-    // Click on create account button
-    await page.getByRole('button', { name: 'Create Account' }).click();
-    await createUserResponse;
-
-    await expect(page).toHaveURL(`/signin`);
-
-    // Login with the created user
-    await page.fill('#email', CREDENTIALS.email);
-    await page.fill('#password', CREDENTIALS.password);
-    const loginResponse = page.waitForResponse(`/api/v1/auth/login`);
-    await page.locator('[data-testid="login"]').click();
-    await loginResponse;
-
-    await expect(page).toHaveURL(`/my-data`);
-
-    // Verify user profile
-    await page.locator('[data-testid="dropdown-profile"]').click();
-
-    await expect(page.getByTestId('nav-user-name')).toContainText(
-      `${CREDENTIALS.firstName}${CREDENTIALS.lastName}`
+        await afterAction();
+      }
     );
-  });
 
-  test('Signin using invalid credentials', async ({ page }) => {
-    await page.goto(`/signin`);
-    // Login with invalid email
-    await page.fill('#email', invalidEmail);
-    await page.fill('#password', CREDENTIALS.password);
-    const loginResponse = page.waitForResponse(`/api/v1/auth/login`);
-    await page.locator('[data-testid="login"]').click();
-    await loginResponse;
+    test('Signup and Login with signed up credentials', async ({ page }) => {
+      await page.goto('/');
 
-    await toastNotification(page, LOGIN_ERROR_MESSAGE);
+      await expect(page).toHaveURL(`/signin`);
 
-    // Login with invalid password
-    await page.fill('#email', CREDENTIALS.email);
-    await page.fill('#password', invalidPassword);
-    const loginResponse2 = page.waitForResponse(`/api/v1/auth/login`);
-    await page.locator('[data-testid="login"]').click();
-    await loginResponse2;
+      // Click on create account button
+      await page.locator('[data-testid="signup"]').click();
 
-    await toastNotification(page, LOGIN_ERROR_MESSAGE);
-  });
+      // Enter credentials
+      await page.locator('#firstName').fill(CREDENTIALS.firstName);
 
-  test('Forgot password and login with new password', async ({ page }) => {
-    await page.goto('/');
-    // Click on Forgot button
-    await page.locator('[data-testid="forgot-password"]').click();
-
-    await expect(page).toHaveURL(`/forgot-password`);
-
-    // Enter email
-    await page.locator('#email').fill(CREDENTIALS.email);
-    // Click on Forgot button
-    await page.getByRole('button', { name: 'Send Login Link' }).click();
-    await page.locator('[data-testid="go-back-button"]').click();
-  });
-
-  test('Refresh should work', async ({ page: page1, browser }) => {
-    test.slow();
-
-    const { apiContext, afterAction } = await getDefaultAdminAPIContext(
-      browser
-    );
-    const context = page1.context();
-    const page2 = await context.newPage();
-
-    const testUser = new UserClass();
-    await testUser.create(apiContext);
-    await testUser.setAdminRole(apiContext);
-
-    await test.step('Login and wait for refresh call is made', async () => {
-      // User login
-
-      await testUser.login(page1);
-      await redirectToHomePage(page1);
-      await waitForAllLoadersToDisappear(page1);
-      await redirectToHomePage(page2);
-      await waitForAllLoadersToDisappear(page2);
-      await page2.reload();
-
-      // eslint-disable-next-line playwright/no-wait-for-timeout -- wait for token refresh timer to fire
-      await page1.waitForTimeout(3 * 60 * 1000);
-
-      await page1.bringToFront();
-      await visitOwnProfilePage(page1);
-      await waitForAllLoadersToDisappear(page1);
-      await expect(page1.getByTestId('user-display-name')).toHaveText(
-        testUser.responseData.displayName ?? testUser.responseData.name
+      await expect(page.locator('#firstName')).toHaveValue(
+        CREDENTIALS.firstName
       );
 
-      await page2.bringToFront();
-      await page2.evaluate(() => {
-        document.dispatchEvent(
-          new Event('visibilitychange', { bubbles: true })
+      await page.locator('#lastName').fill(CREDENTIALS.lastName);
+
+      await expect(page.locator('#lastName')).toHaveValue(CREDENTIALS.lastName);
+
+      await page.locator('#email').fill(CREDENTIALS.email);
+
+      await expect(page.locator('#email')).toHaveValue(CREDENTIALS.email);
+
+      await page.locator('#password').fill(CREDENTIALS.password);
+
+      await expect(page.locator('#password')).toHaveAttribute(
+        'type',
+        'password'
+      );
+
+      await page.locator('#confirmPassword').fill(CREDENTIALS.password);
+
+      const createUserResponse = page.waitForResponse(`/api/v1/users/signup`);
+      // Click on create account button
+      await page.getByRole('button', { name: 'Create Account' }).click();
+      await createUserResponse;
+
+      await expect(page).toHaveURL(`/signin`);
+
+      // Login with the created user
+      await page.fill('#email', CREDENTIALS.email);
+      await page.fill('#password', CREDENTIALS.password);
+      const loginResponse = page.waitForResponse(`/api/v1/auth/login`);
+      await page.locator('[data-testid="login"]').click();
+      await loginResponse;
+
+      await expect(page).toHaveURL(`/my-data`);
+
+      // Verify user profile
+      await page.locator('[data-testid="dropdown-profile"]').click();
+
+      await expect(page.getByTestId('nav-user-name')).toContainText(
+        `${CREDENTIALS.firstName}${CREDENTIALS.lastName}`
+      );
+    });
+
+    test('Signin using invalid credentials', async ({ page }) => {
+      await page.goto(`/signin`);
+      // Login with invalid email
+      await page.fill('#email', invalidEmail);
+      await page.fill('#password', CREDENTIALS.password);
+      const loginResponse = page.waitForResponse(`/api/v1/auth/login`);
+      await page.locator('[data-testid="login"]').click();
+      await loginResponse;
+
+      await toastNotification(page, LOGIN_ERROR_MESSAGE);
+
+      // Login with invalid password
+      await page.fill('#email', CREDENTIALS.email);
+      await page.fill('#password', invalidPassword);
+      const loginResponse2 = page.waitForResponse(`/api/v1/auth/login`);
+      await page.locator('[data-testid="login"]').click();
+      await loginResponse2;
+
+      await toastNotification(page, LOGIN_ERROR_MESSAGE);
+    });
+
+    test('Forgot password and login with new password', async ({ page }) => {
+      await page.goto('/');
+      // Click on Forgot button
+      await page.locator('[data-testid="forgot-password"]').click();
+
+      await expect(page).toHaveURL(`/forgot-password`);
+
+      // Enter email
+      await page.locator('#email').fill(CREDENTIALS.email);
+      // Click on Forgot button
+      await page.getByRole('button', { name: 'Send Login Link' }).click();
+      await page.locator('[data-testid="go-back-button"]').click();
+    });
+
+    test('Refresh should work', async ({ page: page1, browser }) => {
+      test.slow();
+
+      const { apiContext, afterAction } = await getDefaultAdminAPIContext(
+        browser
+      );
+      const context = page1.context();
+      const page2 = await context.newPage();
+
+      const testUser = new UserClass();
+      await testUser.create(apiContext);
+      await testUser.setAdminRole(apiContext);
+
+      await test.step('Login and wait for refresh call is made', async () => {
+        // User login
+
+        await testUser.login(page1);
+        await redirectToHomePage(page1);
+        await waitForAllLoadersToDisappear(page1);
+        await redirectToHomePage(page2);
+        await waitForAllLoadersToDisappear(page2);
+        await page2.reload();
+
+        // eslint-disable-next-line playwright/no-wait-for-timeout -- wait for token refresh timer to fire
+        await page1.waitForTimeout(3 * 60 * 1000);
+
+        await page1.bringToFront();
+        await visitOwnProfilePage(page1);
+        await waitForAllLoadersToDisappear(page1);
+        await expect(page1.getByTestId('user-display-name')).toHaveText(
+          testUser.responseData.displayName ?? testUser.responseData.name
         );
+
+        await page2.bringToFront();
+        await page2.evaluate(() => {
+          document.dispatchEvent(
+            new Event('visibilitychange', { bubbles: true })
+          );
+        });
+
+        await visitOwnProfilePage(page2);
+        await waitForAllLoadersToDisappear(page2);
+        await expect(page2.getByTestId('user-display-name')).toHaveText(
+          testUser.responseData.displayName ?? testUser.responseData.name
+        );
+
+        await page1.close();
+        await page2.close();
       });
 
-      await visitOwnProfilePage(page2);
-      await waitForAllLoadersToDisappear(page2);
-      await expect(page2.getByTestId('user-display-name')).toHaveText(
-        testUser.responseData.displayName ?? testUser.responseData.name
-      );
+      await afterAction();
+    });
+
+    test('accessing app with expired token should do auto renew token', async ({
+      browser,
+    }) => {
+      const browserContext = await browser.newContext();
+
+      // Create new page and validate access
+      const page1 = await browserContext.newPage();
+      const page2 = await browserContext.newPage();
+
+      const admin = new AdminClass();
+      await admin.login(page1);
+
+      await redirectToHomePage(page1);
+      await page1.getByTestId('dropdown-profile').click();
+      await clickOutside(page1);
+
+      await expect(page1.getByTestId('nav-user-name')).toContainText(/admin/i);
+
+      // eslint-disable-next-line playwright/no-wait-for-timeout -- wait for token expiry timer (61s * 2 to ensure refresh API completes)
+      await page2.waitForTimeout(2 * 61 * 1000);
+
+      await redirectToHomePage(page2);
+
+      await page2.getByTestId('dropdown-profile').click();
+      await clickOutside(page2);
+
+      await expect(page2.getByTestId('nav-user-name')).toContainText(/admin/i);
 
       await page1.close();
       await page2.close();
+      await browserContext.close();
     });
-
-    await afterAction();
-  });
-
-  test('accessing app with expired token should do auto renew token', async ({
-    browser,
-  }) => {
-    const browserContext = await browser.newContext();
-
-    // Create new page and validate access
-    const page1 = await browserContext.newPage();
-    const page2 = await browserContext.newPage();
-
-    const admin = new AdminClass();
-    await admin.login(page1);
-
-    await redirectToHomePage(page1);
-    await page1.getByTestId('dropdown-profile').click();
-    await clickOutside(page1);
-
-    await expect(page1.getByTestId('nav-user-name')).toContainText(/admin/i);
-
-    // eslint-disable-next-line playwright/no-wait-for-timeout -- wait for token expiry timer (61s * 2 to ensure refresh API completes)
-    await page2.waitForTimeout(2 * 61 * 1000);
-
-    await redirectToHomePage(page2);
-
-    await page2.getByTestId('dropdown-profile').click();
-    await clickOutside(page2);
-
-    await expect(page2.getByTestId('nav-user-name')).toContainText(/admin/i);
-
-    await page1.close();
-    await page2.close();
-    await browserContext.close();
-  });
-});
+  }
+);

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/Login.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/Login.spec.ts
@@ -11,6 +11,7 @@
  *  limitations under the License.
  */
 import { expect, test } from '@playwright/test';
+import { PLAYWRIGHT_BASIC_TEST_TAG_OBJ } from '../../constant/config';
 import { JWT_EXPIRY_TIME_MAP, LOGIN_ERROR_MESSAGE } from '../../constant/login';
 import { AdminClass } from '../../support/user/AdminClass';
 import { UserClass } from '../../support/user/UserClass';
@@ -24,7 +25,6 @@ import {
 } from '../../utils/common';
 import { waitForAllLoadersToDisappear } from '../../utils/entity';
 import { updateJWTTokenExpiryTime } from '../../utils/login';
-import { PLAYWRIGHT_BASIC_TEST_TAG_OBJ } from '../../constant/config';
 
 const user = new UserClass();
 const CREDENTIALS = user.data;

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/LoginConfiguration.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/LoginConfiguration.spec.ts
@@ -11,10 +11,10 @@
  *  limitations under the License.
  */
 import { expect, Page, test } from '@playwright/test';
+import { PLAYWRIGHT_BASIC_TEST_TAG_OBJ } from '../../constant/config';
 import { GlobalSettingOptions } from '../../constant/settings';
 import { redirectToHomePage, toastNotification } from '../../utils/common';
 import { settingClick } from '../../utils/sidebar';
-import { PLAYWRIGHT_BASIC_TEST_TAG_OBJ } from '../../constant/config';
 
 // use the admin user to login
 test.use({ storageState: 'playwright/.auth/admin.json' });

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/LoginConfiguration.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/LoginConfiguration.spec.ts
@@ -14,6 +14,7 @@ import { expect, Page, test } from '@playwright/test';
 import { GlobalSettingOptions } from '../../constant/settings';
 import { redirectToHomePage, toastNotification } from '../../utils/common';
 import { settingClick } from '../../utils/sidebar';
+import { PLAYWRIGHT_BASIC_TEST_TAG_OBJ } from '../../constant/config';
 
 // use the admin user to login
 test.use({ storageState: 'playwright/.auth/admin.json' });
@@ -50,7 +51,7 @@ const expectSavedLoginConfig = async (
   await toastNotification(page, 'Login Configuration updated successfully.');
 };
 
-test.describe('Login configuration', () => {
+test.describe('Login configuration', PLAYWRIGHT_BASIC_TEST_TAG_OBJ, () => {
   test.beforeEach(async ({ page }) => {
     await redirectToHomePage(page);
     await settingClick(page, GlobalSettingOptions.LOGIN_CONFIGURATION);

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/SubDomainPagination.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/SubDomainPagination.spec.ts
@@ -22,6 +22,7 @@ import {
 import { createSubDomain, selectDomain } from '../../utils/domain';
 import { waitForAllLoadersToDisappear } from '../../utils/entity';
 import { sidebarClick } from '../../utils/sidebar';
+import { PLAYWRIGHT_BASIC_TEST_TAG_OBJ } from '../../constant/config';
 
 test.use({ storageState: 'playwright/.auth/admin.json' });
 
@@ -29,7 +30,7 @@ const domain = new Domain();
 const subDomains: SubDomain[] = [];
 const SUBDOMAIN_COUNT = 60;
 
-test.describe('SubDomain Pagination', () => {
+test.describe('SubDomain Pagination', PLAYWRIGHT_BASIC_TEST_TAG_OBJ, () => {
   test.slow(true);
 
   test.beforeAll('Setup domain and subdomains', async ({ browser }) => {

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/SubDomainPagination.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/SubDomainPagination.spec.ts
@@ -11,6 +11,7 @@
  *  limitations under the License.
  */
 import { expect, test } from '@playwright/test';
+import { PLAYWRIGHT_BASIC_TEST_TAG_OBJ } from '../../constant/config';
 import { SidebarItem } from '../../constant/sidebar';
 import { Domain } from '../../support/domain/Domain';
 import { SubDomain } from '../../support/domain/SubDomain';
@@ -22,7 +23,6 @@ import {
 import { createSubDomain, selectDomain } from '../../utils/domain';
 import { waitForAllLoadersToDisappear } from '../../utils/entity';
 import { sidebarClick } from '../../utils/sidebar';
-import { PLAYWRIGHT_BASIC_TEST_TAG_OBJ } from '../../constant/config';
 
 test.use({ storageState: 'playwright/.auth/admin.json' });
 


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:

Fixes #<issue-number>
<!--
Linking an issue is REQUIRED. Replace <issue-number> with the GitHub issue number this PR addresses
(e.g., `Fixes #12345`). GitHub will auto-link it. If no issue exists, please open one first so the
problem and design can be discussed before review.
-->

<!--
Short blurb explaining:
- What changes did you make?
- Why did you make them?
-->

I worked on ... because ...

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### High-level design:
<!--
REQUIRED for large PRs (new features, refactors, breaking changes, or anything touching >5 files).
Skip for small bug fixes and trivial changes.

Cover:
- Architecture / approach you took and why
- Key components or files added/changed and how they interact
- Alternatives considered and why you rejected them
- Any migration, backward-compatibility, or rollout concerns
- Diagrams or links to design docs / RFCs if available
-->

N/A — small change. <!-- Or fill in the design above -->

#
### Tests:

#### Use cases covered
<!--
List the user-visible scenarios this PR exercises. Example:
- User with Admin role can create a Glossary Term with a parent term
- Ingestion run for Snowflake correctly extracts row counts for partitioned tables
-->

#### Unit tests
<!--
- [ ] I added unit tests for the new/changed logic.
- Files added/updated:
- Coverage on changed classes (run `mvn jacoco:report` for backend, `yarn test:coverage` for UI,
  `make unit_ingestion` for ingestion). Target is 90% line coverage on changed classes.
- Coverage %: <e.g., 92% on EntityRepository.java>
-->

#### Backend integration tests
<!--
- [ ] I added integration tests in `openmetadata-integration-tests/` for new/changed API endpoints.
- [ ] Not applicable (no backend API changes).
- Files added/updated:
-->

#### Ingestion integration tests
<!--
- [ ] I added/updated ingestion integration tests for connector changes.
- [ ] Not applicable (no ingestion changes).
- Files added/updated:
-->

#### Playwright (UI) tests
<!--
- [ ] I added Playwright E2E tests under `openmetadata-ui/.../ui/playwright/` for UI changes.
- [ ] Not applicable (no UI changes).
- Files added/updated:
-->

#### Manual testing performed
<!--
List the manual test steps you performed before requesting review. Example:
1. Started local stack via `./docker/run_local_docker.sh -m ui -d mysql`
2. Logged in as admin, created entity X, verified Y appears in the UI
3. Triggered ingestion for Snowflake source, confirmed lineage edges in the explore page
-->

#
### UI screen recording / screenshots:
<!--
REQUIRED for any PR that changes the UI. Drag-and-drop a short screen recording (.mov / .mp4 / .gif)
demonstrating the change end-to-end, plus before/after screenshots where relevant.
Mark "Not applicable" if there are no UI changes.
-->

Not applicable. <!-- Or attach recording/screenshots above -->

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.
- [ ] For UI changes: I attached a screen recording and/or screenshots above.
- [ ] I have added tests (unit / integration / Playwright as applicable) and listed them above.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR rebalances E2E test shard allocation by moving several Playwright test suites from the `chromium` project to the `Basic` project via the `@basic` tag (`PLAYWRIGHT_BASIC_TEST_TAG_OBJ`). The change affects 11 spec files spanning Lineage, Glossary, Login, ExploreTree, and SubDomain tests.

- All 11 spec files receive the `@basic` tag import and the tag is attached to their top-level `test.describe` (or individual `test`) calls.
- `LineageSettings.spec.ts` and `LineageNodePagination.spec.ts` are also reformatted from flat-style to parenthesised callback style to accommodate the tag parameter.
- Three files — `LineageInteraction.spec.ts`, `PlatformLineage.spec.ts`, and `LineageControls.spec.ts` — have `beforeAll` hooks that consume `EntityDataClass.user1/domain1.responseData.id`. Because the `Basic` project only depends on `setup` (not `entity-data-setup`), those fields are `undefined` at runtime, causing API errors that break every test in the affected suites under the `Basic` project.
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge for 8 of 11 files; the three Lineage files (LineageInteraction, PlatformLineage, LineageControls) will have their beforeAll hooks fail when run under the Basic project.

Three spec files patch entities using EntityDataClass.user1/domain1.responseData.id inside their beforeAll hooks, but the Basic project that now runs their @basic-tagged tests only depends on setup, not entity-data-setup. Those IDs are undefined at that point, so every test in the affected suites will fail at setup time in CI.

LineageInteraction.spec.ts, PlatformLineage.spec.ts, and LineageControls.spec.ts — all three have beforeAll hooks that read from EntityDataClass before entity-data-setup has populated it.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/Lineage/LineageInteraction.spec.ts | Added @basic tag to 'Lineage Interactions' describe block, but its beforeAll uses EntityDataClass.user1/domain1.responseData.id which is unpopulated in the Basic project (no entity-data-setup dependency), causing setup to fail. |
| openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/Lineage/PlatformLineage.spec.ts | Added @basic tag to a top-level test(); the file-level beforeAll uses EntityDataClass.domain1.responseData.id which is undefined under the Basic project, breaking setup for any @basic-tagged test in this file. |
| openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/Lineage/LineageControls.spec.ts | Added @basic to 'Canvas Controls' and 'Lineage Layers' describe blocks; file-level beforeAll still accesses EntityDataClass.user1/domain1.responseData.id which is unset in the Basic project (already flagged in a previous review cycle). |
| openmetadata-ui/src/main/resources/ui/playwright/e2e/Flow/LineageSettings.spec.ts | Wrapped entire test.describe.serial in PLAYWRIGHT_BASIC_TEST_TAG_OBJ and reformatted as callback-style describe; no EntityDataClass usage, setup is self-contained. |
| openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/Lineage/LineageNodePagination.spec.ts | Added @basic tag and reformatted test.describe.serial; self-contained setup with no EntityDataClass dependency. |
| openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/Lineage/DataAssetLineage.spec.ts | Added @basic tag to 'Data asset lineage' describe block; no EntityDataClass dependency, safe. |
| openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/ExploreTree.spec.ts | Added @basic to 'Explore Tree scenarios' describe block only; EntityDataClass usage is confined to the separate 'Explore page' describe block which does not carry the @basic tag. |
| openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/Glossary/GlossaryPagination.spec.ts | Added @basic to 'Glossary tests' describe; no EntityDataClass dependency, self-contained setup. |
| openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/Login.spec.ts | Added @basic to 'Login flow should work properly' describe; no EntityDataClass usage, safe. |
| openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/LoginConfiguration.spec.ts | Added @basic tag; tests are fully self-contained with no EntityDataClass dependency. |
| openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/SubDomainPagination.spec.ts | Added @basic tag; no EntityDataClass usage, self-contained test setup. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    setup["setup\n(auth.setup.ts)"]
    eds["entity-data-setup\n(entity-data.setup.ts)"]
    chromium["chromium project\ngrepInvert: @basic\ndeps: setup + entity-data-setup"]
    basic["Basic project\ngrep: @basic\ndeps: setup ONLY"]

    setup --> eds
    setup --> basic
    eds --> chromium

    lc["LineageControls.spec.ts\nbeforeAll → EntityDataClass.user1/domain1.id"]
    li["LineageInteraction.spec.ts\nbeforeAll → EntityDataClass.user1/domain1.id"]
    pl["PlatformLineage.spec.ts\nbeforeAll → EntityDataClass.domain1.id"]

    basic -->|"runs @basic tests"| lc
    basic -->|"runs @basic tests"| li
    basic -->|"runs @basic tests"| pl

    lc -->|"undefined id → API error"| fail["❌ beforeAll fails\nAll tests broken"]
    li -->|"undefined id → API error"| fail
    pl -->|"undefined id → API error"| fail

    eds -.->|"NOT a dependency\nof Basic"| basic
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    setup["setup\n(auth.setup.ts)"]
    eds["entity-data-setup\n(entity-data.setup.ts)"]
    chromium["chromium project\ngrepInvert: @basic\ndeps: setup + entity-data-setup"]
    basic["Basic project\ngrep: @basic\ndeps: setup ONLY"]

    setup --> eds
    setup --> basic
    eds --> chromium

    lc["LineageControls.spec.ts\nbeforeAll → EntityDataClass.user1/domain1.id"]
    li["LineageInteraction.spec.ts\nbeforeAll → EntityDataClass.user1/domain1.id"]
    pl["PlatformLineage.spec.ts\nbeforeAll → EntityDataClass.domain1.id"]

    basic -->|"runs @basic tests"| lc
    basic -->|"runs @basic tests"| li
    basic -->|"runs @basic tests"| pl

    lc -->|"undefined id → API error"| fail["❌ beforeAll fails\nAll tests broken"]
    li -->|"undefined id → API error"| fail
    pl -->|"undefined id → API error"| fail

    eds -.->|"NOT a dependency\nof Basic"| basic
```

</a>
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/Lineage/LineageControls.spec.ts`, line 40-78 ([link](https://github.com/open-metadata/openmetadata/blob/8b2674fd94305a6487e8986bb220e78623244c60/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/Lineage/LineageControls.spec.ts#L40-L78)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **`@basic` tag conflicts with EntityDataClass dependency**

   The `beforeAll` on line 57–70 patches the topic with `EntityDataClass.user1.responseData.id` and `EntityDataClass.domain1.responseData.id`. Those values are populated by `entity-data-setup`, but the `Basic` project only declares `dependencies: ['setup']` — it does not list `entity-data-setup` as a dependency. If `Basic` starts (or runs in a separate shard) before `entity-data-setup` has written `entity-response-data.json`, `loadResponseData()` silently skips, leaving both `responseData` properties as empty objects (`{}`), and the PATCH request will send `id: undefined`. This would cause an API error that fails the shared `beforeAll`, breaking every test in this file when run under the `Basic` project.

2. `openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/Lineage/LineageInteraction.spec.ts`, line 48-79 ([link](https://github.com/open-metadata/openmetadata/blob/9ed369de4ce0342ca01346e24fd90d2730d9b742/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/Lineage/LineageInteraction.spec.ts#L48-L79)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **`EntityDataClass` used in `@basic`-tagged suite without `entity-data-setup` dependency**

   The `beforeAll` inside `test.describe('Lineage Interactions', PLAYWRIGHT_BASIC_TEST_TAG_OBJ, ...)` patches the topic with `EntityDataClass.user1.responseData.id` (line 68) and `EntityDataClass.domain1.responseData.id` (line 76). The `Basic` project that picks up `@basic` tests declares `dependencies: ['setup']` only — it does not list `entity-data-setup`. When `entity-data.setup.ts` has not run, `EntityDataClass.user1.responseData` and `EntityDataClass.domain1.responseData` are both `{} as ResponseDataType`, so `.id` is `undefined`. The PATCH request will therefore send `id: undefined`, causing an API error that breaks the entire `beforeAll` and fails every test in this describe block under `Basic`.

   The same pattern — a `beforeAll` consuming `EntityDataClass` while the file's suites carry `@basic` — also exists in `PlatformLineage.spec.ts` (line 48, patching `domain1.responseData.id`) and was previously noted in `LineageControls.spec.ts`. The fix is either to add `entity-data-setup` to the `Basic` project's `dependencies`, or to fetch the user/domain data fresh via API inside `beforeAll` rather than relying on the pre-populated static class.

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["fix checkstyle"](https://github.com/open-metadata/openmetadata/commit/9ed369de4ce0342ca01346e24fd90d2730d9b742) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40751541)</sub>

<!-- /greptile_comment -->