### PR TITLE
test(glossary): mark Glossary Terms column-selection spec as slow to fix 60s timeout flake

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/Glossary.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/Glossary.spec.ts
@@ -1523,6 +1523,7 @@ test.describe('Glossary tests', () => {
   test('Column selection and visibility for Glossary Terms table', async ({
     browser,
   }) => {
+    test.slow(true);
     const { page, afterAction, apiContext } = await performAdminLogin(browser);
     const glossary1 = new Glossary();
     const glossaryTerm1 = new GlossaryTerm(glossary1);


### PR DESCRIPTION
## What

Adds `test.slow(true)` to the Playwright test **`Glossary tests › Column selection and visibility for Glossary Terms table`** (`playwright/e2e/Pages/Glossary.spec.ts`), tripling its per-test timeout from the default 60s to 180s.

## Why

This test intermittently times out at exactly 60s in the nightly upgrade runs:

- [openmetadata-nightly run 28412262801](https://github.com/open-metadata/openmetadata-nightly/actions/runs/28412262801) — Automated Upgrade Tests (MySQL, Pre Release), shard (4, 4)
- Also seen adjacent in [run 28412268689](https://github.com/open-metadata/openmetadata-nightly/actions/runs/28412268689) (Postgres)

In the merged report, **both attempts** of this test are `timedOut` at 60.0s. The trace shows the test hangs on its final assertion `expect(getByTestId('glossary-terms-table')).toBeVisible()` (the first line of `verifyAllColumns`), immediately after the last `page.reload()` in the "Hide All columns" step. All glossary/search APIs return 200 and there is no JS exception — the glossary page is simply still rendering its loading state past the 60s budget on a heavily-populated upgrade instance (the test runs four column-toggle + `page.reload()` cycles).

The other tests in this same `describe` block already use `test.slow(true)`; this one was missing it.

## Scope

- One-line change, scoped to this single test. No config change.
- This is test-hardening to stop the flaky timeout. The underlying cause (the glossary page blocking its initial render on a sequential, full-list pagination scan to locate the active glossary by FQN) is tracked separately for a product-side follow-up.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds `test.slow(true)` to a single Playwright test (`Column selection and visibility for Glossary Terms table`) that was intermittently timing out at exactly 60s in nightly upgrade runs, bringing it in line with the 17 other tests in the same file that already carry this annotation.

- The one-line addition triples the test's timeout budget from 60s to 180s, matching the established pattern in `Glossary.spec.ts`.
- No production code, configuration, or test logic is modified — this is a targeted flake-suppression patch.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — a single, well-precedented annotation with no logic changes.

The change adds one call to test.slow(true) inside a test body, identical in form and placement to 17 other tests already present in the file. It widens a timeout for a test that was reproducibly timing out in CI, with no modifications to test logic, production code, or configuration.

No files require special attention.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/Glossary.spec.ts | Adds test.slow(true) to the 'Column selection and visibility for Glossary Terms table' test, tripling its timeout from 60s to 180s; consistent with the same annotation already applied to 17 other tests in this file. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["Test: Column selection and visibility"] --> B["test.slow(true) annotation"]
    B -->|"Before PR - default timeout"| C["60s budget - intermittent timeout in nightly runs"]
    B -->|"After PR - slow = 3x"| D["180s budget - sufficient for upgrade instances"]
    D --> E["4x column-toggle + page.reload cycles"]
    E --> F["expect glossary-terms-table toBeVisible"]
    F --> G["Test PASS"]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["Test: Column selection and visibility"] --> B["test.slow(true) annotation"]
    B -->|"Before PR - default timeout"| C["60s budget - intermittent timeout in nightly runs"]
    B -->|"After PR - slow = 3x"| D["180s budget - sufficient for upgrade instances"]
    D --> E["4x column-toggle + page.reload cycles"]
    E --> F["expect glossary-terms-table toBeVisible"]
    F --> G["Test PASS"]
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["test(glossary): mark Glossary Terms colu..."](https://github.com/open-metadata/openmetadata/commit/c4cf3d5fb8fedb9b0c7b4b9cb856ebe74ab68c88) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40754339)</sub>

<!-- /greptile_comment -->