### PR TITLE
Fixed global serach suggestion flakiness

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/GlobalSearchSuggestions.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/GlobalSearchSuggestions.spec.ts
@@ -38,6 +38,8 @@ test.describe('Global Search Column Suggestions', () => {
   });
 
   test('Navigate to column from column suggestion', async ({ page }) => {
+    await page.getByTestId('KnowledgePanel.ActivityFeed').waitFor({ state: 'visible' });
+    await waitForAllLoadersToDisappear(page);
     const column = table.entityResponseData?.columns?.[0];
     const columnName = column?.name;
     const columnSelector = `[data-testid="${table.service.name}-${columnName}"]`;

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/GlobalSearchSuggestions.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/GlobalSearchSuggestions.spec.ts
@@ -38,7 +38,9 @@ test.describe('Global Search Column Suggestions', () => {
   });
 
   test('Navigate to column from column suggestion', async ({ page }) => {
-    await page.getByTestId('KnowledgePanel.ActivityFeed').waitFor({ state: 'visible' });
+    await page
+      .getByTestId('KnowledgePanel.ActivityFeed')
+      .waitFor({ state: 'visible' });
     await waitForAllLoadersToDisappear(page);
     const column = table.entityResponseData?.columns?.[0];
     const columnName = column?.name;


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:
<img width="1403" height="390" alt="Screenshot 2026-06-30 at 3 55 01 PM" src="https://github.com/user-attachments/assets/a11d8424-1372-406d-975b-849d2fe2b4a6" />

Fixes #<issue-number>
<!--
Linking an issue is REQUIRED. Replace <issue-number> with the GitHub issue number this PR addresses
(e.g., `Fixes #12345`). GitHub will auto-link it. If no issue exists, please open one first so the
problem and design can be discussed before review.
-->

<!--
Short blurb explaining:
- What changes did you make?
- Why did you make them?
-->

I worked on ... because ...

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### High-level design:
<!--
REQUIRED for large PRs (new features, refactors, breaking changes, or anything touching >5 files).
Skip for small bug fixes and trivial changes.

Cover:
- Architecture / approach you took and why
- Key components or files added/changed and how they interact
- Alternatives considered and why you rejected them
- Any migration, backward-compatibility, or rollout concerns
- Diagrams or links to design docs / RFCs if available
-->

N/A — small change. <!-- Or fill in the design above -->

#
### Tests:

#### Use cases covered
<!--
List the user-visible scenarios this PR exercises. Example:
- User with Admin role can create a Glossary Term with a parent term
- Ingestion run for Snowflake correctly extracts row counts for partitioned tables
-->

#### Unit tests
<!--
- [ ] I added unit tests for the new/changed logic.
- Files added/updated:
- Coverage on changed classes (run `mvn jacoco:report` for backend, `yarn test:coverage` for UI,
  `make unit_ingestion` for ingestion). Target is 90% line coverage on changed classes.
- Coverage %: <e.g., 92% on EntityRepository.java>
-->

#### Backend integration tests
<!--
- [ ] I added integration tests in `openmetadata-integration-tests/` for new/changed API endpoints.
- [ ] Not applicable (no backend API changes).
- Files added/updated:
-->

#### Ingestion integration tests
<!--
- [ ] I added/updated ingestion integration tests for connector changes.
- [ ] Not applicable (no ingestion changes).
- Files added/updated:
-->

#### Playwright (UI) tests
<!--
- [ ] I added Playwright E2E tests under `openmetadata-ui/.../ui/playwright/` for UI changes.
- [ ] Not applicable (no UI changes).
- Files added/updated:
-->

#### Manual testing performed
<!--
List the manual test steps you performed before requesting review. Example:
1. Started local stack via `./docker/run_local_docker.sh -m ui -d mysql`
2. Logged in as admin, created entity X, verified Y appears in the UI
3. Triggered ingestion for Snowflake source, confirmed lineage edges in the explore page
-->

#
### UI screen recording / screenshots:
<!--
REQUIRED for any PR that changes the UI. Drag-and-drop a short screen recording (.mov / .mp4 / .gif)
demonstrating the change end-to-end, plus before/after screenshots where relevant.
Mark "Not applicable" if there are no UI changes.
-->

Not applicable. <!-- Or attach recording/screenshots above -->

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.
- [ ] For UI changes: I attached a screen recording and/or screenshots above.
- [ ] I have added tests (unit / integration / Playwright as applicable) and listed them above.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes flakiness in the `GlobalSearchSuggestions` Playwright test by adding an explicit wait for the `KnowledgePanel.ActivityFeed` element to become visible before interacting with the search box, followed by a call to `waitForAllLoadersToDisappear`.

- The `beforeEach` hook navigates to the home page via `redirectToHomePage`, which already waits for DOM load and calls `waitForAllLoadersToDisappear` internally. The new waits inside the test body address a race condition where the `ActivityFeed` panel may still be loading/rendering after those earlier checks pass, causing the search box interaction to fire too early.
- Only the single Playwright test file is modified — no production code is changed.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Only a Playwright test file is modified — no production code is touched, so there is no risk of runtime regression.

The change adds two targeted wait steps to an existing E2E test, addressing a real race condition where the home page's ActivityFeed panel could still be loading when the search box interaction fired. The fix is minimal, well-scoped, and aligns with how waits are used throughout the rest of the test suite.

No files require special attention.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/GlobalSearchSuggestions.spec.ts | Adds two wait steps at the start of the test to ensure the KnowledgePanel.ActivityFeed is visible and all loaders have cleared before interacting with the search box, fixing flakiness caused by premature interaction with the UI. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Test as Playwright Test
    participant Page as Browser Page
    participant API as OpenMetadata API

    Note over Test,Page: beforeEach
    Test->>Page: redirectToHomePage()
    Page->>Page: goto('/')
    Page->>Page: "waitForURL('**/my-data')"
    Page->>Page: waitForAllLoadersToDisappear() [inside redirectToHomePage]
    Page->>Page: waitForLoadState('domcontentloaded')

    Note over Test,Page: test body (NEW waits)
    Test->>Page: waitFor KnowledgePanel.ActivityFeed visible
    Page-->>Test: ActivityFeed visible
    Test->>Page: waitForAllLoadersToDisappear()
    Page-->>Test: no loaders

    Note over Test,Page: search interaction
    Test->>Page: searchInput.click()
    Test->>Page: searchInput.fill(columnName)
    Page->>API: "GET /api/v1/search/query?q=columnName"
    API-->>Page: suggestions response
    Test->>Page: columnSuggestion.click()
    Page->>API: "GET /api/v1/tables/name/*/columns*"
    API-->>Page: column list
    Test->>Page: assert entity-link visible
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Test as Playwright Test
    participant Page as Browser Page
    participant API as OpenMetadata API

    Note over Test,Page: beforeEach
    Test->>Page: redirectToHomePage()
    Page->>Page: goto('/')
    Page->>Page: "waitForURL('**/my-data')"
    Page->>Page: waitForAllLoadersToDisappear() [inside redirectToHomePage]
    Page->>Page: waitForLoadState('domcontentloaded')

    Note over Test,Page: test body (NEW waits)
    Test->>Page: waitFor KnowledgePanel.ActivityFeed visible
    Page-->>Test: ActivityFeed visible
    Test->>Page: waitForAllLoadersToDisappear()
    Page-->>Test: no loaders

    Note over Test,Page: search interaction
    Test->>Page: searchInput.click()
    Test->>Page: searchInput.fill(columnName)
    Page->>API: "GET /api/v1/search/query?q=columnName"
    API-->>Page: suggestions response
    Test->>Page: columnSuggestion.click()
    Page->>API: "GET /api/v1/tables/name/*/columns*"
    API-->>Page: column list
    Test->>Page: assert entity-link visible
```

</a>
</details>

<sub>Reviews (2): Last reviewed commit: ["lint fix"](https://github.com/open-metadata/openmetadata/commit/255b72b621d46e7723fb69d14ac6b4bdcf49c13b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40777685)</sub>

<!-- /greptile_comment -->