### PR TITLE
Added includePipelineObservability configuration flag

### DIFF
--- a/ingestion/src/metadata/ingestion/source/pipeline/airflow/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/pipeline/airflow/metadata.py
@@ -947,6 +947,12 @@ class AirflowSource(PipelineServiceSource):
         Extract pipeline observability data from cached lineage artifacts.
         Uses context data first (current dag), falls back to cache for historical data.
         """
+
+        # Check if pipeline observability is disabled
+        if not self.source_config.includePipelineObservability:
+            logger.info("Pipeline observability extraction is disabled via configuration")
+            return
+
         try:
             table_pipeline_map: Dict[str, List[PipelineObservability]] = defaultdict(list)  # noqa: UP006
 

--- a/ingestion/src/metadata/ingestion/source/pipeline/dbtcloud/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/pipeline/dbtcloud/metadata.py
@@ -406,6 +406,12 @@ class DbtcloudSource(PipelineServiceSource):
         Extract pipeline observability data from cached lineage artifacts.
         Uses context data first (current job), falls back to cache for historical data.
         """
+
+        # Check if pipeline observability is disabled
+        if not self.source_config.includePipelineObservability:
+            logger.info("Pipeline observability extraction is disabled via configuration")
+            return
+
         try:
             table_pipeline_map: Dict[str, List[PipelineObservability]] = defaultdict(list)  # noqa: UP006
 

--- a/openmetadata-spec/src/main/resources/json/schema/metadataIngestion/pipelineServiceMetadataPipeline.json
+++ b/openmetadata-spec/src/main/resources/json/schema/metadataIngestion/pipelineServiceMetadataPipeline.json
@@ -108,6 +108,12 @@
       "description": "Set the 'Override Metadata' toggle to control whether to override the existing metadata in the OpenMetadata server with the metadata fetched from the source. If the toggle is set to true, the metadata fetched from the source will override the existing metadata in the OpenMetadata server. If the toggle is set to false, the metadata fetched from the source will not override the existing metadata in the OpenMetadata server. This is applicable for fields like description, tags, owner and displayName",
       "type": "boolean",
       "default": false
+    },
+    "includePipelineObservability": {
+      "title": "Include Pipeline Observability",
+      "description": "Optional configuration to turn off pipeline observability extraction.",
+      "type": "boolean",
+      "default": true
     }
   },
   "additionalProperties": false

--- a/openmetadata-ui/src/main/resources/ui/public/locales/en-US/Pipeline/workflows/metadata.md
+++ b/openmetadata-ui/src/main/resources/ui/public/locales/en-US/Pipeline/workflows/metadata.md
@@ -38,6 +38,12 @@ Set the Include Lineage toggle to control whether to include lineage between pip
 $$
 
 $$section
+### Include Pipeline Observability $(id="includePipelineObservability")
+
+Set the Include Pipeline Observability toggle to control whether to extract pipeline observability data (e.g., table-level freshness, volume, quality signals) from pipeline runs as part of metadata ingestion.
+$$
+
+$$section
 ### Enable Debug Logs $(id="enableDebugLog")
 
 Set the `Enable Debug Log` toggle to set the logging level of the process to debug. You can check these logs in the Ingestion tab of the service and dig deeper into any errors you might find.

--- a/openmetadata-ui/src/main/resources/ui/src/generated/metadataIngestion/pipelineServiceMetadataPipeline.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/metadataIngestion/pipelineServiceMetadataPipeline.ts
@@ -19,6 +19,10 @@ export interface PipelineServiceMetadataPipeline {
      */
     includeLineage?: boolean;
     /**
+     * Optional configuration to turn off pipeline observability extraction.
+     */
+    includePipelineObservability?: boolean;
+    /**
      * Set the 'Include Owners' toggle to control whether to include owners to the ingested
      * entity if the owner email matches with a user stored in the OM server as part of metadata
      * ingestion. If the ingested entity already exists and has an owner, the owner will not be


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:

Added includePipelineObservability configuration flag to allow users to disable pipeline observability extraction during metadata ingestion. 

Pipeline observability has a significant performance impact on Airflow ingestion — it queries DagRun history, processes lineage artifacts, and caches observability data for each pipeline. Disabling it when not needed can substantially reduce ingestion time for large Airflow deployments with many DAGs and runs.

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [ ] Improvement
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation


#### Manual testing performed
<!--
List the manual test steps you performed before requesting review. Example:
1. Started local stack via `./docker/run_local_docker.sh -m ui -d mysql`
2. Logged in as admin, created entity X, verified Y appears in the UI
3. Triggered ingestion for Snowflake source, confirmed lineage edges in the explore page
-->

#
### UI screen recording / screenshots:
<!--
REQUIRED for any PR that changes the UI. Drag-and-drop a short screen recording (.mov / .mp4 / .gif)
demonstrating the change end-to-end, plus before/after screenshots where relevant.
Mark "Not applicable" if there are no UI changes.
-->

Not applicable. <!-- Or attach recording/screenshots above -->

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.
- [ ] For UI changes: I attached a screen recording and/or screenshots above.
- [ ] I have added tests (unit / integration / Playwright as applicable) and listed them above.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds an `includePipelineObservability` boolean flag (default `true`) to `PipelineServiceMetadataPipeline` so users can opt out of pipeline observability extraction during metadata ingestion. The JSON schema, generated TypeScript interface, UI locale documentation, and the Airflow and dbtcloud connector implementations are all updated.

- **JSON schema + TypeScript**: New `includePipelineObservability` property added with `default: true`, keeping backward compatibility for existing configurations.
- **Airflow + dbtcloud connectors**: `get_table_pipeline_observability` returns early when the flag is `false`, skipping the final observability emission step.
- **Limitation**: In the Airflow connector, `yield_pipeline_lineage_details` unconditionally calls `get_pipeline_status` and populates `observability_cache` regardless of the flag — the expensive DagRun history query that the PR description targets is not gated by `includePipelineObservability`.
</details>


<details open><summary><h3>Confidence Score: 3/5</h3></summary>

Safe to merge for correctness — observability output is properly suppressed when the flag is false — but the Airflow connector does not skip the underlying DagRun history query and cache writes, so the advertised performance gain does not materialize under the default lineage-enabled configuration.

The early-return guard in `get_table_pipeline_observability` works correctly for both connectors. However, in the Airflow connector the most expensive operations — `get_pipeline_status` called from `yield_pipeline_lineage_details` and the subsequent `observability_cache` population — still execute unconditionally. Users who enable the flag expecting reduced ingestion time for large Airflow deployments will not see the improvement described in the PR unless lineage is also disabled.

ingestion/src/metadata/ingestion/source/pipeline/airflow/metadata.py — specifically `yield_pipeline_lineage_details` around the `get_pipeline_status` call and `observability_cache` writes.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| ingestion/src/metadata/ingestion/source/pipeline/airflow/metadata.py | Adds early return in `get_table_pipeline_observability` when flag is false, but the expensive `get_pipeline_status` call and cache population inside `yield_pipeline_lineage_details` still run unconditionally. |
| ingestion/src/metadata/ingestion/source/pipeline/dbtcloud/metadata.py | Adds the same early-return guard in `get_table_pipeline_observability`; dbtcloud does not have the same lineage-method cache issue as Airflow. |
| openmetadata-spec/src/main/resources/json/schema/metadataIngestion/pipelineServiceMetadataPipeline.json | Adds `includePipelineObservability` boolean property with `default: true`; consistent with other similar flags in the schema. |
| openmetadata-ui/src/main/resources/ui/public/locales/en-US/Pipeline/workflows/metadata.md | Adds UI documentation section for the new toggle; description is clear and consistent with existing toggle documentation. |
| openmetadata-ui/src/main/resources/ui/src/generated/metadataIngestion/pipelineServiceMetadataPipeline.ts | Generated TypeScript interface updated to include optional `includePipelineObservability?: boolean`; consistent with other optional booleans in the interface. |

</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Topology as TopologyRunner
    participant AirflowSrc as AirflowSource
    participant AirflowDB as Airflow DB

    Topology->>AirflowSrc: yield_pipeline_lineage_details(dag)
    AirflowSrc->>AirflowDB: get_pipeline_status(dag_id)
    Note over AirflowSrc,AirflowDB: Always runs (no flag guard)
    AirflowDB-->>AirflowSrc: dag_runs
    AirflowSrc->>AirflowSrc: populate observability_cache
    Note over AirflowSrc: Always runs (no flag guard)
    AirflowSrc-->>Topology: lineage edges

    Topology->>AirflowSrc: get_table_pipeline_observability(dag)
    alt "includePipelineObservability = false"
        AirflowSrc-->>Topology: return (empty)
        Note over AirflowSrc: Only this step is skipped
    else "includePipelineObservability = true"
        AirflowSrc->>AirflowSrc: read observability_cache
        AirflowSrc-->>Topology: yield table_pipeline_map
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Topology as TopologyRunner
    participant AirflowSrc as AirflowSource
    participant AirflowDB as Airflow DB

    Topology->>AirflowSrc: yield_pipeline_lineage_details(dag)
    AirflowSrc->>AirflowDB: get_pipeline_status(dag_id)
    Note over AirflowSrc,AirflowDB: Always runs (no flag guard)
    AirflowDB-->>AirflowSrc: dag_runs
    AirflowSrc->>AirflowSrc: populate observability_cache
    Note over AirflowSrc: Always runs (no flag guard)
    AirflowSrc-->>Topology: lineage edges

    Topology->>AirflowSrc: get_table_pipeline_observability(dag)
    alt "includePipelineObservability = false"
        AirflowSrc-->>Topology: return (empty)
        Note over AirflowSrc: Only this step is skipped
    else "includePipelineObservability = true"
        AirflowSrc->>AirflowSrc: read observability_cache
        AirflowSrc-->>Topology: yield table_pipeline_map
    end
```

</a>
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `ingestion/src/metadata/ingestion/source/pipeline/airflow/metadata.py`, line 847-914 ([link](https://github.com/open-metadata/openmetadata/blob/5134fba01b829f9b91943d9b3bc8875bfbf4f594/ingestion/src/metadata/ingestion/source/pipeline/airflow/metadata.py#L847-L914)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Cache population still runs when `includePipelineObservability=False`**

   `yield_pipeline_lineage_details` calls `get_pipeline_status` (line 847) and populates `observability_cache` (lines 906–914) unconditionally, even when `includePipelineObservability` is disabled. As a result, the expensive DagRun history query and all cache writes still execute for every DAG — only the final emission step in `get_table_pipeline_observability` is skipped. The performance improvement described in the PR ("queries DagRun history, processes lineage artifacts, and caches observability data") will not be realized when lineage extraction is enabled (the default), which is the typical configuration for large Airflow deployments.

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["Added includePipelineObservability confi..."](https://github.com/open-metadata/openmetadata/commit/5134fba01b829f9b91943d9b3bc8875bfbf4f594) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40794414)</sub>

<!-- /greptile_comment -->