### PR TITLE
fix(ui-core): toast z-index, max-width, and alignment

### DIFF
--- a/openmetadata-ui-core-components/src/main/resources/ui/src/components/application/toast/toast-provider.tsx
+++ b/openmetadata-ui-core-components/src/main/resources/ui/src/components/application/toast/toast-provider.tsx
@@ -68,7 +68,7 @@ export const ToastProvider = ({
   return (
     <ToastRegion
       className={cx(
-        'tw:fixed tw:z-200 tw:flex tw:flex-col tw:gap-2 tw:outline-none',
+        'tw:fixed tw:z-[1000] tw:flex tw:flex-col tw:gap-2 tw:outline-none',
         classes.region
       )}
       queue={toastQueue}>

--- a/openmetadata-ui-core-components/src/main/resources/ui/src/components/application/toast/toast.tsx
+++ b/openmetadata-ui-core-components/src/main/resources/ui/src/components/application/toast/toast.tsx
@@ -74,7 +74,7 @@ export const Toast = ({ toast }: ToastProps) => {
   return (
     <AriaToast
       className={cx(
-        'tw:inline-flex tw:items-center tw:gap-2.5',
+        'tw:inline-flex tw:items-start tw:gap-2.5 tw:max-w-[600px]',
         'tw:rounded-[10px] tw:bg-primary-solid tw:px-4 tw:py-2.75',
         'tw:text-sm tw:font-medium tw:text-fg-white',
         'tw:shadow-2xl tw:outline-none',
@@ -82,13 +82,13 @@ export const Toast = ({ toast }: ToastProps) => {
       )}
       data-testid="alert-bar"
       toast={toast}>
-      <span className="tw:flex tw:shrink-0" data-testid="alert-icon">
+      <span className="tw:mt-0.5 tw:flex tw:shrink-0" data-testid="alert-icon">
         <Icon
           aria-hidden="true"
           className={cx('tw:size-4', config.iconClass)}
         />
       </span>
-      <span data-testid="alert-message">
+      <span className="tw:flex-1" data-testid="alert-message">
         {typeof messageOrNode === 'string'
           ? messageOrNode
           : (messageOrNode as ReactNode)}
@@ -96,7 +96,7 @@ export const Toast = ({ toast }: ToastProps) => {
       {showClose && state && (
         <Button
           aria-label="Close"
-          className="tw:-mr-1 tw:ml-1 tw:flex tw:cursor-pointer tw:items-center tw:justify-center tw:rounded-md tw:p-0.5 tw:text-fg-white/60 tw:outline-none tw:transition tw:hover:bg-white/10 tw:hover:text-fg-white"
+          className="tw:-mr-1 tw:mt-0.5 tw:ml-1 tw:flex tw:shrink-0 tw:cursor-pointer tw:items-center tw:justify-center tw:rounded-md tw:p-0.5 tw:text-fg-white/60 tw:outline-none tw:transition tw:hover:bg-white/10 tw:hover:text-fg-white"
           data-testid="alert-icon-close"
           slot="close"
           onPress={() => state.close(toast.key)}>

--- a/openmetadata-ui-core-components/src/main/resources/ui/src/stories/Toast.stories.tsx
+++ b/openmetadata-ui-core-components/src/main/resources/ui/src/stories/Toast.stories.tsx
@@ -98,6 +98,22 @@ export const Info: Story = {
   },
 };
 
+// ─── Long message (wrapping) ───────────────────────────────────────────────────
+
+export const LongMessage: Story = {
+  args: { position: 'bottom-center' },
+  render: (args) => {
+    useEffect(() => {
+      toast.error(
+        'Failed to save changes to the data source. The connection timed out after multiple retries because the upstream service did not respond within the configured threshold. Please verify your network settings and try again.',
+        { timeout: 0 }
+      );
+    }, []);
+
+    return <ToastProvider {...args} />;
+  },
+};
+
 // ─── Stacking ─────────────────────────────────────────────────────────────────
 
 export const Stacked: Story = {


### PR DESCRIPTION
## Summary

Toast styling fixes in `@openmetadata/ui-core-components`:

- **z-index**: region raised from `z-200` to `z-[1000]` so toasts sit above other overlays.
- **max-width**: toast capped at `600px`; long messages now wrap instead of growing unbounded.
- **alignment**: icon, message, and close button top-align (`items-start`) so multi-line toasts read correctly; icon/close get a `mt-0.5` nudge to center on the first text line.
- **close button**: message grows (`flex-1`) so the close button is always right-aligned, regardless of message length.
- **storybook**: added a `LongMessage` story exercising the wrapping + alignment case.

## Before / After

Long error toast now wraps at 600px with the icon aligned to the first line and the close button pinned right; short toasts keep the close button right-aligned too.

<img width="788" height="550" alt="Screenshot 2026-06-30 at 5 44 17 PM" src="https://github.com/user-attachments/assets/de806455-94f0-4531-ae03-62a65cc2c456" />


🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR applies targeted styling fixes to the `@openmetadata/ui-core-components` toast component so that long messages render correctly — capped at 600 px with wrapping text, top-aligned icon and close button, and a raised z-index so toasts sit above other overlays.

- **`toast-provider.tsx`**: z-index changed from `z-200` to `z-[1000]` on the fixed toast region, ensuring toasts are not hidden behind dialogs or drawer overlays.
- **`toast.tsx`**: Container switches to `items-start` with `max-w-[600px]`; message span gains `flex-1` so the close button is always right-aligned; icon and close button receive `mt-0.5` and `shrink-0` to align with the first text line.
- **`Toast.stories.tsx`**: New `LongMessage` story demonstrates the wrapping and alignment behaviour.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — changes are scoped entirely to Tailwind class strings with no logic or data-flow impact.

All three files contain only CSS utility class adjustments and a Storybook story addition. The z-index bump, max-width cap, flex alignment tweaks, and new story are self-contained and follow the patterns already established in the component. There are no logic changes, state mutations, or API calls involved.

No files require special attention.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-ui-core-components/src/main/resources/ui/src/components/application/toast/toast-provider.tsx | Single-line change raising the toast region z-index from `z-200` to `z-[1000]` so toasts render above other overlays. |
| openmetadata-ui-core-components/src/main/resources/ui/src/components/application/toast/toast.tsx | Toast layout updated to top-align icon/message/close (`items-start`), cap width at 600px, let the message grow (`flex-1`), and add `shrink-0` + `mt-0.5` nudges to icon and close button. |
| openmetadata-ui-core-components/src/main/resources/ui/src/stories/Toast.stories.tsx | Added a `LongMessage` story with a multi-line error toast exercising wrapping and alignment fixes; follows the same pattern as all other stories in the file. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Toast triggered] --> B[ToastRegion\nz-index: 1000\nfixed position]
    B --> C[AriaToast\ninline-flex, items-start\nmax-w-600px]
    C --> D[Icon span\nshrink-0, mt-0.5]
    C --> E[Message span\nflex-1 — grows to fill\navailable width]
    C --> F{showClose?}
    F -- yes --> G[Close Button\nshrink-0, mt-0.5\nalways right-aligned]
    F -- no --> H[No close button]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Toast triggered] --> B[ToastRegion\nz-index: 1000\nfixed position]
    B --> C[AriaToast\ninline-flex, items-start\nmax-w-600px]
    C --> D[Icon span\nshrink-0, mt-0.5]
    C --> E[Message span\nflex-1 — grows to fill\navailable width]
    C --> F{showClose?}
    F -- yes --> G[Close Button\nshrink-0, mt-0.5\nalways right-aligned]
    F -- no --> H[No close button]
```

</a>
</details>

<sub>Reviews (2): Last reviewed commit: ["Merge branch &#39;main&#39; into update-storyboo..."](https://github.com/open-metadata/openmetadata/commit/e926769911112520eb5b7d220eea98441f411d67) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40794554)</sub>

<!-- /greptile_comment -->