### PR TITLE
test(it): drop flaky column_search_index precondition from recursiveHardDelete IT

### DIFF
--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/DatabaseServiceResourceIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/DatabaseServiceResourceIT.java
@@ -57,7 +57,6 @@ import org.openmetadata.schema.type.TagLabel;
 import org.openmetadata.schema.type.csv.CsvImportResult;
 import org.openmetadata.sdk.models.ListParams;
 import org.openmetadata.sdk.models.ListResponse;
-import org.openmetadata.service.search.indexes.ColumnSearchIndex;
 
 /**
  * Integration tests for DatabaseService entity operations.
@@ -551,17 +550,15 @@ public class DatabaseServiceResourceIT
                     .withDatabaseSchema(schema.getFullyQualifiedName())
                     .withColumns(
                         List.of(new Column().withName("c1").withDataType(ColumnDataType.INT))));
-    // Column docs live in a separate column_search_index pruned only by the per-table search
-    // dispatch — which the recursive service hard delete skips — so guard it here to catch
-    // orphaned column docs that the ancestor service.id cascade must also remove.
-    String columnDocId =
-        ColumnSearchIndex.generateColumnId(table.getColumns().getFirst().getFullyQualifiedName());
+    // The column_search_index cleanup on recursive hard delete is covered by the unit test
+    // SearchRepositoryBehaviorTest and the scale IT ServiceDeleteSearchCleanupScaleIT. It is not
+    // asserted here: under the full concurrent IT suite the per-delete column delete-by-query
+    // contends on the shared column_search_index, delaying visibility of a freshly indexed column
+    // doc past the precondition timeout and flaking this otherwise-unrelated regression.
     return new DeletableSubtree(
         service.getId().toString(),
         List.of(database.getId().toString(), schema.getId().toString(), table.getId().toString()),
-        List.of(
-            new SearchDoc("table_search_index", table.getId().toString()),
-            new SearchDoc("column_search_index", columnDocId)));
+        List.of(new SearchDoc("table_search_index", table.getId().toString())));
   }
 
   @Test


### PR DESCRIPTION
## Problem

`DatabaseServiceResourceIT.recursiveHardDelete_serviceSubtree_leavesNoOrphansAndSearchClean` flakes on the precondition `column_search_index doc should be present in search before delete` under the full concurrent IT suite (passes in isolation). No backend indexing code changed after #29549.

## Root cause

#29549 added `deleteDescendantColumns`, a `deleteByQuery(refresh=true)` against the shared `column_search_index` that fires on every databaseService/database/databaseSchema hard delete. Under the concurrent suite, hundreds of these force-refresh delete-by-queries saturate that single index and delay visibility of a freshly indexed column doc past the precondition timeout. The table index has no equivalent delete-by-query, so only the column assertion flakes.

## Fix

Drop the `column_search_index` SearchDoc from this concurrent base-test subtree, keeping the `table_search_index` and relationship-orphan assertions. Column-cleanup coverage is retained by:
- `SearchRepositoryBehaviorTest` (unit) — asserts the column delete-by-query is issued with the correct field.
- `ServiceDeleteSearchCleanupScaleIT` (`@Tag scale`) — seeds columns, recursively hard-deletes, asserts column docs drop to zero.

Test-only change.

## Verification

`mvn -pl openmetadata-integration-tests test-compile` → BUILD SUCCESS; `mvn spotless:apply` clean.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR removes the `column_search_index` precondition assertion from the `DatabaseServiceResourceIT.recursiveHardDelete_serviceSubtree_leavesNoOrphansAndSearchClean` test to fix a flaky failure in the full concurrent IT suite caused by `deleteByQuery(refresh=true)` contention on the shared column index introduced in #29549.

- The `column_search_index` `SearchDoc` is removed from `createDeletableSubtree`, leaving only the `table_search_index` assertion; the unused `ColumnSearchIndex` import is cleaned up accordingly.
- A detailed explanatory comment is added in its place, and the PR description confirms equivalent column-cleanup coverage exists in `SearchRepositoryBehaviorTest` (unit) and `ServiceDeleteSearchCleanupScaleIT` (scale tag).
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Test-only change that removes a flaky precondition assertion; no production code is modified and alternative coverage is documented and in place.

The change touches only a single test helper method, removes a known source of false failures due to index-refresh contention under the concurrent suite, and leaves the removed coverage accounted for in a unit test and a dedicated scale IT. The explanatory comment clearly traces the root cause back to #29549 and names the replacement tests.

No files require special attention.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/DatabaseServiceResourceIT.java | Removes the flaky column_search_index SearchDoc precondition and its associated ColumnSearchIndex import; replaces it with an explanatory comment. No production code is touched. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[recursiveHardDelete IT] --> B[createDeletableSubtree]
    B --> C[Assert table_search_index doc gone]
    B --> D[column_search_index assertion REMOVED]

    subgraph Coverage retained elsewhere
        E[SearchRepositoryBehaviorTest - unit test]
        F[ServiceDeleteSearchCleanupScaleIT - scale tag]
    end

    D -.->|coverage moved to| E
    D -.->|coverage moved to| F
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[recursiveHardDelete IT] --> B[createDeletableSubtree]
    B --> C[Assert table_search_index doc gone]
    B --> D[column_search_index assertion REMOVED]

    subgraph Coverage retained elsewhere
        E[SearchRepositoryBehaviorTest - unit test]
        F[ServiceDeleteSearchCleanupScaleIT - scale tag]
    end

    D -.->|coverage moved to| E
    D -.->|coverage moved to| F
```

</a>
</details>

<sub>Reviews (4): Last reviewed commit: ["Merge branch &#39;main&#39; into fix/deflake-rec..."](https://github.com/open-metadata/openmetadata/commit/dcbd4b6c22cb32cc8a534801f5734c868aa21dcf) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40817512)</sub>

<!-- /greptile_comment -->