### PR TITLE
chore(test): fix pre-requisites for lineage spec

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright.config.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright.config.ts
@@ -68,7 +68,10 @@ export default defineConfig({
     ],
     ['blob'],
     ['json', { outputFile: './playwright/output/results.json' }],
-    ['@flakiness/playwright', { flakinessProject: 'OpenMetadata/OpenMetadata' }],
+    [
+      '@flakiness/playwright',
+      { flakinessProject: 'OpenMetadata/OpenMetadata' },
+    ],
   ],
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
@@ -191,7 +194,7 @@ export default defineConfig({
       name: 'Basic',
       grep: [/@basic/],
       use: { ...devices['Desktop Chrome'] },
-      dependencies: ['setup'],
+      dependencies: ['setup', 'entity-data-setup'],
       fullyParallel: true,
     },
     {


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:

Fixes #<issue-number>
<!--
Linking an issue is REQUIRED. Replace <issue-number> with the GitHub issue number this PR addresses
(e.g., `Fixes #12345`). GitHub will auto-link it. If no issue exists, please open one first so the
problem and design can be discussed before review.
-->

<!--
Short blurb explaining:
- What changes did you make?
- Why did you make them?
-->

I worked on ... because ...

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### High-level design:
<!--
REQUIRED for large PRs (new features, refactors, breaking changes, or anything touching >5 files).
Skip for small bug fixes and trivial changes.

Cover:
- Architecture / approach you took and why
- Key components or files added/changed and how they interact
- Alternatives considered and why you rejected them
- Any migration, backward-compatibility, or rollout concerns
- Diagrams or links to design docs / RFCs if available
-->

N/A — small change. <!-- Or fill in the design above -->

#
### Tests:

#### Use cases covered
<!--
List the user-visible scenarios this PR exercises. Example:
- User with Admin role can create a Glossary Term with a parent term
- Ingestion run for Snowflake correctly extracts row counts for partitioned tables
-->

#### Unit tests
<!--
- [ ] I added unit tests for the new/changed logic.
- Files added/updated:
- Coverage on changed classes (run `mvn jacoco:report` for backend, `yarn test:coverage` for UI,
  `make unit_ingestion` for ingestion). Target is 90% line coverage on changed classes.
- Coverage %: <e.g., 92% on EntityRepository.java>
-->

#### Backend integration tests
<!--
- [ ] I added integration tests in `openmetadata-integration-tests/` for new/changed API endpoints.
- [ ] Not applicable (no backend API changes).
- Files added/updated:
-->

#### Ingestion integration tests
<!--
- [ ] I added/updated ingestion integration tests for connector changes.
- [ ] Not applicable (no ingestion changes).
- Files added/updated:
-->

#### Playwright (UI) tests
<!--
- [ ] I added Playwright E2E tests under `openmetadata-ui/.../ui/playwright/` for UI changes.
- [ ] Not applicable (no UI changes).
- Files added/updated:
-->

#### Manual testing performed
<!--
List the manual test steps you performed before requesting review. Example:
1. Started local stack via `./docker/run_local_docker.sh -m ui -d mysql`
2. Logged in as admin, created entity X, verified Y appears in the UI
3. Triggered ingestion for Snowflake source, confirmed lineage edges in the explore page
-->

#
### UI screen recording / screenshots:
<!--
REQUIRED for any PR that changes the UI. Drag-and-drop a short screen recording (.mov / .mp4 / .gif)
demonstrating the change end-to-end, plus before/after screenshots where relevant.
Mark "Not applicable" if there are no UI changes.
-->

Not applicable. <!-- Or attach recording/screenshots above -->

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.
- [ ] For UI changes: I attached a screen recording and/or screenshots above.
- [ ] I have added tests (unit / integration / Playwright as applicable) and listed them above.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->

----
## Summary by Gitar

- **Test Infrastructure:**
  - Updated `playwright.config.ts` to include `entity-data-setup` as a dependency for the `Basic` test suite.
  - Adjusted formatting for the `@flakiness/playwright` reporter configuration.

<sub>This will update automatically on new commits.</sub>

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a missing prerequisite for the `Basic` Playwright test project by adding `entity-data-setup` to its `dependencies` array, so that lineage specs tagged `@basic` have the required entity data seeded before they run. It also reformats the `@flakiness/playwright` reporter entry into multi-line style for consistency.

- The `Basic` project previously only depended on `['setup']` (auth only), which skipped the entity-data seeding step that lineage specs rely on.
- The new `dependencies: ['setup', 'entity-data-setup']` aligns `Basic` with the `chromium`, `Knowledge Graph`, and `Data Insight` projects that share the same pattern.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The core dependency fix is correct, but the `Basic` project lacks a teardown reference that could cause data-race failures in parallel CI runs.

Adding `entity-data-setup` to `Basic` is the right fix for the missing prerequisite. The concern is that `Basic` has no `teardown` configured, while `chromium`'s `entity-data-teardown` can fire while `Basic` is still running under CI's 3-worker parallelism. Every other project that depends on `entity-data-setup` and runs alongside `chromium` (`Knowledge Graph`, `Data Insight`) has its own teardown wired to `entity-data-teardown`, which signals Playwright to hold the teardown until all dependents are done. Without that on `Basic`, lineage tests could intermittently fail in CI when `chromium` finishes first and tears down the shared entity data mid-run.

openmetadata-ui/src/main/resources/ui/playwright.config.ts — specifically the `Basic` project definition missing a `teardown` entry.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-ui/src/main/resources/ui/playwright.config.ts | Adds `entity-data-setup` to the `Basic` project's dependencies and reformats the `@flakiness/playwright` reporter entry; teardown timing with the shared `entity-data-teardown` is worth watching. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    setup["setup\n(auth.setup.ts)"]
    entity_setup["entity-data-setup\n(entity-data.setup.ts)"]
    chromium["chromium\n(grepInvert: @basic, @data-insight, @knowledge-graph)"]
    basic["Basic\n(grep: @basic)\n✅ now depends on entity-data-setup"]
    kg["Knowledge Graph\n(grep: @knowledge-graph)"]
    di_app["data-insight-application"]
    di["Data Insight\n(grep: @data-insight)"]
    teardown["entity-data-teardown"]

    setup --> entity_setup
    entity_setup --> chromium
    entity_setup --> basic
    entity_setup --> kg
    entity_setup --> di_app
    di_app --> di

    chromium -->|teardown| teardown
    kg -->|teardown| teardown
    di -->|teardown| teardown

    basic -.->|"⚠️ no teardown wired"| teardown
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    setup["setup\n(auth.setup.ts)"]
    entity_setup["entity-data-setup\n(entity-data.setup.ts)"]
    chromium["chromium\n(grepInvert: @basic, @data-insight, @knowledge-graph)"]
    basic["Basic\n(grep: @basic)\n✅ now depends on entity-data-setup"]
    kg["Knowledge Graph\n(grep: @knowledge-graph)"]
    di_app["data-insight-application"]
    di["Data Insight\n(grep: @data-insight)"]
    teardown["entity-data-teardown"]

    setup --> entity_setup
    entity_setup --> chromium
    entity_setup --> basic
    entity_setup --> kg
    entity_setup --> di_app
    di_app --> di

    chromium -->|teardown| teardown
    kg -->|teardown| teardown
    di -->|teardown| teardown

    basic -.->|"⚠️ no teardown wired"| teardown
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["chore(test): fix pre-requisites for line..."](https://github.com/open-metadata/openmetadata/commit/dfa89dd35bbddaade47e1607a5e6fd6f2212b195) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40823941)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->