### PR TITLE
fix(ingestion): mssql BigInteger identity reflection on SQLAlchemy 2.0

### DIFF
--- a/ingestion/src/metadata/ingestion/source/database/mssql/utils.py
+++ b/ingestion/src/metadata/ingestion/source/database/mssql/utils.py
@@ -34,7 +34,6 @@ from sqlalchemy.dialects.mssql.base import (
 from sqlalchemy.engine import Engine, reflection
 from sqlalchemy.sql import func
 from sqlalchemy.types import NVARCHAR
-from sqlalchemy.util import compat
 
 from metadata.ingestion.source.database.mssql.queries import (
     GET_DB_CONFIGS,
@@ -92,9 +91,24 @@ def db_plus_owner(fn):
     return update_wrapper(wrap, fn)
 
 
+def get_identity_values(coltype, identity_start, identity_increment):
+    """Build the reflected identity dict for an MSSQL column.
+
+    seed_value / increment_value come back from MSSQL as Decimal (or None).
+    Integer and BigInteger identities are normalised to ``int``; other numeric
+    identity types keep their original value. BigInteger previously used
+    ``sqlalchemy.util.compat.long_type``, which was removed in SQLAlchemy 2.0.
+    """
+    if identity_start is None or identity_increment is None:
+        return {}
+    if isinstance(coltype, (sqltypes.BigInteger, sqltypes.Integer)):
+        return {"start": int(identity_start), "increment": int(identity_increment)}
+    return {"start": identity_start, "increment": identity_increment}
+
+
 @reflection.cache
 @db_plus_owner
-def get_columns(self, connection, tablename, dbname, owner, schema, **kw):  # pylint: disable=unused-argument, too-many-locals, disable=too-many-branches, too-many-statements  # noqa: C901
+def get_columns(self, connection, tablename, dbname, owner, schema, **kw):  # pylint: disable=unused-argument, too-many-locals, disable=too-many-branches, too-many-statements
     """
     This function overrides to add support for column comments
     """
@@ -282,24 +296,7 @@ def get_columns(self, connection, tablename, dbname, owner, schema, **kw):  # py
             }
 
         if is_identity is not None:
-            # identity_start and identity_increment are Decimal or None
-            if identity_start is None or identity_increment is None:
-                cdict["identity"] = {}
-            else:
-                if isinstance(coltype, sqltypes.BigInteger):
-                    start = compat.long_type(identity_start)
-                    increment = compat.long_type(identity_increment)
-                elif isinstance(coltype, sqltypes.Integer):
-                    start = int(identity_start)
-                    increment = int(identity_increment)
-                else:
-                    start = identity_start
-                    increment = identity_increment
-
-                cdict["identity"] = {
-                    "start": start,
-                    "increment": increment,
-                }
+            cdict["identity"] = get_identity_values(coltype, identity_start, identity_increment)
 
         cols.append(cdict)
     return cols

--- a/ingestion/tests/unit/topology/database/test_mssql.py
+++ b/ingestion/tests/unit/topology/database/test_mssql.py
@@ -13,10 +13,11 @@ Test Mssql using the topology
 """
 
 import types
+from decimal import Decimal
 from unittest import TestCase
 from unittest.mock import MagicMock, patch
 
-from sqlalchemy.types import INTEGER, VARCHAR
+from sqlalchemy.types import INTEGER, VARCHAR, BigInteger, Integer, Numeric
 
 import metadata.ingestion.source.database.mssql.utils as mssql_dialet
 from metadata.generated.schema.api.data.createDatabase import CreateDatabaseRequest
@@ -491,3 +492,36 @@ class TestUpdateMssqlIschemaNames:
         result = self.mssql._get_encrypted_procedures("test_db", "dbo")
 
         assert result == set()
+
+
+class MssqlIdentityColumnTest(TestCase):
+    """Regression tests for identity column reflection.
+
+    BigInteger identity columns previously crashed with
+    ``module 'sqlalchemy.util.compat' has no attribute 'long_type'`` on
+    SQLAlchemy 2.0, dropping every column of the affected table.
+    """
+
+    def test_bigint_identity_returns_int_values(self):
+        result = mssql_dialet.get_identity_values(BigInteger(), Decimal("1"), Decimal("1"))
+
+        assert result == {"start": 1, "increment": 1}
+        assert isinstance(result["start"], int)
+        assert isinstance(result["increment"], int)
+
+    def test_int_identity_returns_int_values(self):
+        result = mssql_dialet.get_identity_values(Integer(), Decimal("5"), Decimal("2"))
+
+        assert result == {"start": 5, "increment": 2}
+        assert isinstance(result["start"], int)
+        assert isinstance(result["increment"], int)
+
+    def test_non_integer_identity_keeps_original_values(self):
+        start, increment = Decimal("1.0"), Decimal("1.0")
+        result = mssql_dialet.get_identity_values(Numeric(), start, increment)
+
+        assert result == {"start": start, "increment": increment}
+
+    def test_missing_seed_returns_empty_dict(self):
+        assert mssql_dialet.get_identity_values(BigInteger(), None, Decimal("1")) == {}
+        assert mssql_dialet.get_identity_values(BigInteger(), Decimal("1"), None) == {}


### PR DESCRIPTION
## Problem

Issue: https://github.com/open-metadata/OpenMetadata/issues/29190

MSSQL metadata ingestion fails to reflect columns for any table that has a `BIGINT IDENTITY` column. Every such table is logged with:

```
WARNING - Unexpected exception getting columns for table [<table>] (schema: '<schema>', db: '<db>'):
module 'sqlalchemy.util.compat' has no attribute 'long_type'
```

and is ingested with **0 columns**. Test-connection passes (it only lists table names), so the failure only surfaces during the full crawl.

## Root cause

In `mssql/utils.py`, the column-reflection override cast the identity seed/increment of `BigInteger` columns with `sqlalchemy.util.compat.long_type`. That symbol was removed in **SQLAlchemy 2.0** (Python 3 has no `long`), so the call raises `AttributeError`. The per-table handler in `sql_column_handler.py` catches the exception and sets `columns = []`, silently dropping the table's columns. `INT IDENTITY` columns are unaffected because that branch already used `int()`.

## Fix

- Remove the `from sqlalchemy.util import compat` import.
- Extract the identity conversion into a small, testable `get_identity_values()` helper and use `int()` for both `Integer` and `BigInteger` (on Python 3 `long_type` *was* `int`). Non-integer numeric identity types keep their original value; a missing seed/increment still yields `{}`.

This is forward-compatible with SQLAlchemy 2.0 and preserves the previous behavior on 1.4.

## Testing

Added `MssqlIdentityColumnTest` in `tests/unit/topology/database/test_mssql.py` covering `BigInteger`, `Integer`, non-integer numeric, and missing-seed cases. Verified end-to-end against a live SQL Server: a `BIGINT IDENTITY` table that previously ingested with 0 columns now ingests all columns, with no warning.

## Reproduction

```sql
CREATE TABLE dbo.big_identity (id BIGINT IDENTITY(1,1) PRIMARY KEY, name NVARCHAR(50));
```
Run a metadata ingestion on SQLAlchemy 2.0 — before this change the table ingests with no columns and emits the `long_type` warning.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a `BigInteger IDENTITY` column reflection failure in MSSQL ingestion on SQLAlchemy 2.0, where `sqlalchemy.util.compat.long_type` was removed and caused every table with a `BIGINT IDENTITY` column to be ingested with 0 columns.

- Removes the `compat` import and extracts a standalone `get_identity_values()` helper that converts identity seed/increment to `int` for both `Integer` and `BigInteger` types (on Python 3, `long_type` was simply `int`), while preserving the original value for other numeric types and returning `{}` for missing seed/increment.
- Adds a `MssqlIdentityColumnTest` unit test class covering `BigInteger`, `Integer`, non-integer `Numeric`, and missing-seed cases, providing direct regression coverage of the previously crashing code path.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is a minimal, targeted removal of a removed SQLAlchemy 2.0 symbol with no behaviour change for any existing code path.

The fix removes exactly one broken dependency (compat.long_type) and replaces a 17-line inline block with a well-tested helper whose output is identical for every branch. The helper's logic is straightforward: BigInteger IS-A Integer in SQLAlchemy, so both correctly reach the int() path; the None guard and the non-integer fallback are both exercised by the new tests. No other callers of the removed import exist, and the extraction also reduces cyclomatic complexity in get_columns, making the noqa C901 suppressor correctly removable.

No files require special attention.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| ingestion/src/metadata/ingestion/source/database/mssql/utils.py | Removes the broken sqlalchemy.util.compat import and extracts identity value conversion into a clean, tested helper; behavior is preserved exactly for all column type branches. |
| ingestion/tests/unit/topology/database/test_mssql.py | Adds MssqlIdentityColumnTest with four targeted regression cases covering BigInteger, Integer, non-integer Numeric, and missing seed/increment — directly exercising the previously crashing code path. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Ingestion as Ingestion Engine
    participant GetColumns as get_columns()
    participant GetIdentity as get_identity_values()
    participant SQLAlchemy as SQLAlchemy / SQL Server

    Ingestion->>GetColumns: reflect columns(tablename)
    GetColumns->>SQLAlchemy: query identity_columns
    SQLAlchemy-->>GetColumns: identity_start (Decimal), identity_increment (Decimal), coltype
    GetColumns->>GetIdentity: get_identity_values(coltype, identity_start, identity_increment)
    alt BigInteger or Integer
        GetIdentity-->>GetColumns: "{"start": int(...), "increment": int(...)}"
    else Other Numeric
        GetIdentity-->>GetColumns: "{"start": Decimal, "increment": Decimal}"
    else None seed/increment
        GetIdentity-->>GetColumns: "{}"
    end
    GetColumns-->>Ingestion: cdict["identity"] populated correctly
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Ingestion as Ingestion Engine
    participant GetColumns as get_columns()
    participant GetIdentity as get_identity_values()
    participant SQLAlchemy as SQLAlchemy / SQL Server

    Ingestion->>GetColumns: reflect columns(tablename)
    GetColumns->>SQLAlchemy: query identity_columns
    SQLAlchemy-->>GetColumns: identity_start (Decimal), identity_increment (Decimal), coltype
    GetColumns->>GetIdentity: get_identity_values(coltype, identity_start, identity_increment)
    alt BigInteger or Integer
        GetIdentity-->>GetColumns: "{"start": int(...), "increment": int(...)}"
    else Other Numeric
        GetIdentity-->>GetColumns: "{"start": Decimal, "increment": Decimal}"
    else None seed/increment
        GetIdentity-->>GetColumns: "{}"
    end
    GetColumns-->>Ingestion: cdict["identity"] populated correctly
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(ingestion): mssql BigInteger identit..."](https://github.com/open-metadata/openmetadata/commit/fb4704cb035d425f86473c36681a2bdf21b4d547) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40928671)</sub>

<!-- /greptile_comment -->