### PR TITLE
chore(test): balance shards 1 to pull more tests

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DataQuality/TableTestCasePagination.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DataQuality/TableTestCasePagination.spec.ts
@@ -11,6 +11,7 @@
  *  limitations under the License.
  */
 import { expect } from '@playwright/test';
+import { PLAYWRIGHT_BASIC_TEST_TAG_OBJ } from '../../../constant/config';
 import { TableClass } from '../../../support/entity/TableClass';
 import { performAdminLogin } from '../../../utils/admin';
 import { redirectToHomePage } from '../../../utils/common';
@@ -27,7 +28,7 @@ const table = new TableClass();
 
 test.describe(
   'Table Data Quality tab pagination',
-  { tag: ['@Features', '@Observability'] },
+  { tag: ['@Features', '@Observability', PLAYWRIGHT_BASIC_TEST_TAG_OBJ.tag] },
   () => {
     test.beforeAll(
       'Create a table with test cases beyond the page size',

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Flow/PlatformLineage.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Flow/PlatformLineage.spec.ts
@@ -10,67 +10,75 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
+import { PLAYWRIGHT_BASIC_TEST_TAG_OBJ } from '../../constant/config';
 import { SidebarItem } from '../../constant/sidebar';
 import { redirectToHomePage } from '../../utils/common';
 import { verifyExportLineagePNG } from '../../utils/lineage';
 import { sidebarClick } from '../../utils/sidebar';
 import { test } from '../fixtures/pages';
 
-test('Verify Platform Lineage View', async ({ page }) => {
-  // Need to add more time for AUT and not for PR checks
-  test.slow(!process.env.PLAYWRIGHT_IS_OSS);
+test(
+  'Verify Platform Lineage View',
+  PLAYWRIGHT_BASIC_TEST_TAG_OBJ,
+  async ({ page }) => {
+    // Need to add more time for AUT and not for PR checks
+    test.slow(!process.env.PLAYWRIGHT_IS_OSS);
 
-  // Limit MAX_NODES to get PNG export in time
-  const MAX_NODES = 200;
+    // Limit MAX_NODES to get PNG export in time
+    const MAX_NODES = 200;
 
-  await page.route('**/api/v1/lineage/getPlatformLineage**', async (route) => {
-    const response = await route.fetch();
-    const data = await response.json();
-    const filteredData = {
-      ...data,
-      nodes: data.nodes
-        ? Object.fromEntries(Object.entries(data.nodes).slice(0, MAX_NODES))
-        : data.nodes,
-    };
+    await page.route(
+      '**/api/v1/lineage/getPlatformLineage**',
+      async (route) => {
+        const response = await route.fetch();
+        const data = await response.json();
+        const filteredData = {
+          ...data,
+          nodes: data.nodes
+            ? Object.fromEntries(Object.entries(data.nodes).slice(0, MAX_NODES))
+            : data.nodes,
+        };
 
-    // Use Playwright's { response, json } shortcut so headers stay valid
-    // after the body change. The shortcut auto-strips Content-Encoding
-    // (no longer gzip after our modification) and re-computes Content-
-    // Length. Passing headers: response.headers() verbatim — which the
-    // previous version did — keeps a stale Content-Encoding: gzip and
-    // wrong Content-Length, both of which silently break body parsing.
-    await route.fulfill({
-      response,
-      json: filteredData,
-    });
-  });
+        // Use Playwright's { response, json } shortcut so headers stay valid
+        // after the body change. The shortcut auto-strips Content-Encoding
+        // (no longer gzip after our modification) and re-computes Content-
+        // Length. Passing headers: response.headers() verbatim — which the
+        // previous version did — keeps a stale Content-Encoding: gzip and
+        // wrong Content-Length, both of which silently break body parsing.
+        await route.fulfill({
+          response,
+          json: filteredData,
+        });
+      }
+    );
 
-  await redirectToHomePage(page);
-  const lineageRes = page.waitForResponse(
-    '/api/v1/lineage/getPlatformLineage?view=service*'
-  );
-  await sidebarClick(page, SidebarItem.LINEAGE);
-  await lineageRes;
+    await redirectToHomePage(page);
+    const lineageRes = page.waitForResponse(
+      '/api/v1/lineage/getPlatformLineage?view=service*'
+    );
+    await sidebarClick(page, SidebarItem.LINEAGE);
+    await lineageRes;
 
-  // Verify PNG export
-  await verifyExportLineagePNG(page, true);
+    // Verify PNG export
+    await verifyExportLineagePNG(page, true);
 
-  await page.getByTestId('lineage-layer-btn').click();
+    await page.getByTestId('lineage-layer-btn').click();
 
-  await page
-    .locator('[data-testid="lineage-layer-domain-btn"]:not(.MUI-selected)')
-    .waitFor();
+    await page
+      .locator('[data-testid="lineage-layer-domain-btn"]:not(.MUI-selected)')
+      .waitFor();
 
-  const domainRes = page.waitForResponse(
-    '/api/v1/lineage/getPlatformLineage?view=domain*'
-  );
-  await page.getByTestId('lineage-layer-domain-btn').click();
-  await domainRes;
+    const domainRes = page.waitForResponse(
+      '/api/v1/lineage/getPlatformLineage?view=domain*'
+    );
+    await page.getByTestId('lineage-layer-domain-btn').click();
+    await domainRes;
 
-  await page.getByTestId('lineage-layer-btn').click();
-  const dataProductRes = page.waitForResponse(
-    '/api/v1/lineage/getPlatformLineage?view=dataProduct*'
-  );
-  await page.getByTestId('lineage-layer-data-product-btn').click();
-  await dataProductRes;
-});
+    await page.getByTestId('lineage-layer-btn').click();
+    const dataProductRes = page.waitForResponse(
+      '/api/v1/lineage/getPlatformLineage?view=dataProduct*'
+    );
+    await page.getByTestId('lineage-layer-data-product-btn').click();
+    await dataProductRes;
+  }
+);

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Flow/ServiceDocPanel.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Flow/ServiceDocPanel.spec.ts
@@ -12,6 +12,7 @@
  */
 
 import { expect, Page, test } from '@playwright/test';
+import { PLAYWRIGHT_BASIC_TEST_TAG_OBJ } from '../../constant/config';
 import { redirectToHomePage } from '../../utils/common';
 import {
   copyAndGetClipboardText,
@@ -38,7 +39,7 @@ const goToMysqlConnectionStep = async (page: Page, serviceName: string) => {
   await advanceToServiceConnectionStep(page);
 };
 
-test.describe('ServiceDocPanel', () => {
+test.describe('ServiceDocPanel', PLAYWRIGHT_BASIC_TEST_TAG_OBJ, () => {
   test.beforeEach(async ({ page }) => {
     await redirectToHomePage(page);
   });

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Flow/UsersPagination.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Flow/UsersPagination.spec.ts
@@ -11,6 +11,7 @@
  *  limitations under the License.
  */
 import { expect, test } from '@playwright/test';
+import { PLAYWRIGHT_BASIC_TEST_TAG_OBJ } from '../../constant/config';
 import { GlobalSettingOptions } from '../../constant/settings';
 import { UserClass } from '../../support/user/UserClass';
 import { createNewPage, redirectToHomePage } from '../../utils/common';
@@ -60,30 +61,34 @@ test.describe('Soft Delete User Pagination', () => {
     await afterAction();
   });
 
-  test('Testing user API calls and pagination', async ({ page }) => {
-    const expectedUrl =
-      '**/api/v1/users?isBot=false&fields=profile%2Cteams%2Croles&limit=*&isAdmin=false&include=deleted';
+  test(
+    'Testing user API calls and pagination',
+    PLAYWRIGHT_BASIC_TEST_TAG_OBJ,
+    async ({ page }) => {
+      const expectedUrl =
+        '**/api/v1/users?isBot=false&fields=profile%2Cteams%2Croles&limit=*&isAdmin=false&include=deleted';
 
-    const deletedUserResponsePromise = page.waitForResponse(expectedUrl);
+      const deletedUserResponsePromise = page.waitForResponse(expectedUrl);
 
-    await page.click('[data-testid="show-deleted"]');
+      await page.click('[data-testid="show-deleted"]');
 
-    const response = await deletedUserResponsePromise;
+      const response = await deletedUserResponsePromise;
 
-    expect(response.ok()).toBeTruthy();
+      expect(response.ok()).toBeTruthy();
 
-    const nextButton = page.locator('[data-testid="next"]');
-    const expectedUrlPattern =
-      /\/api\/v1\/users\?isBot=false&fields=profile%2Cteams%2Croles&limit=.*&isAdmin=false&include=deleted(&after=.*)?/;
+      const nextButton = page.locator('[data-testid="next"]');
+      const expectedUrlPattern =
+        /\/api\/v1\/users\?isBot=false&fields=profile%2Cteams%2Croles&limit=.*&isAdmin=false&include=deleted(&after=.*)?/;
 
-    const paginatedResponsePromise = page.waitForResponse((response) => {
-      const url = response.url();
+      const paginatedResponsePromise = page.waitForResponse((response) => {
+        const url = response.url();
 
-      return expectedUrlPattern.test(url);
-    });
-    await nextButton.click();
-    const paginatedResponse = await paginatedResponsePromise;
+        return expectedUrlPattern.test(url);
+      });
+      await nextButton.click();
+      const paginatedResponse = await paginatedResponsePromise;
 
-    expect(paginatedResponse.ok()).toBeTruthy();
-  });
+      expect(paginatedResponse.ok()).toBeTruthy();
+    }
+  );
 });

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/DataMarketplace.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/DataMarketplace.spec.ts
@@ -11,6 +11,7 @@
  *  limitations under the License.
  */
 import { expect } from '@playwright/test';
+import { PLAYWRIGHT_BASIC_TEST_TAG_OBJ } from '../../constant/config';
 import { DataProduct } from '../../support/domain/DataProduct';
 import { Domain } from '../../support/domain/Domain';
 import { performAdminLogin } from '../../utils/admin';
@@ -39,7 +40,7 @@ const uiCreatedDomainName = `PW-mp-domain-${uuid()}`;
 
 test.describe(
   'Data Marketplace - Core',
-  { tag: ['@Pages', '@Discovery'] },
+  { tag: ['@Pages', '@Discovery', PLAYWRIGHT_BASIC_TEST_TAG_OBJ.tag] },
   () => {
     test.beforeAll('Setup entities', async ({ browser }) => {
       const { apiContext, afterAction } = await performAdminLogin(browser);

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/DataMarketplaceAnnouncements.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/DataMarketplaceAnnouncements.spec.ts
@@ -11,6 +11,7 @@
  *  limitations under the License.
  */
 import { expect } from '@playwright/test';
+import { PLAYWRIGHT_BASIC_TEST_TAG_OBJ } from '../../constant/config';
 import { DataProduct } from '../../support/domain/DataProduct';
 import { Domain } from '../../support/domain/Domain';
 import { performAdminLogin } from '../../utils/admin';
@@ -29,7 +30,7 @@ let dpAnnouncementId: string;
 
 test.describe(
   'Data Marketplace - Announcements',
-  { tag: ['@Pages', '@Discovery'] },
+  { tag: ['@Pages', '@Discovery', PLAYWRIGHT_BASIC_TEST_TAG_OBJ.tag] },
   () => {
     test.beforeAll('Setup entities and announcements', async ({ browser }) => {
       const { apiContext, afterAction } = await performAdminLogin(browser);

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/DataMarketplacePermissions.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/DataMarketplacePermissions.spec.ts
@@ -11,6 +11,7 @@
  *  limitations under the License.
  */
 import base, { expect, Page } from '@playwright/test';
+import { PLAYWRIGHT_BASIC_TEST_TAG_OBJ } from '../../constant/config';
 import { DataProduct } from '../../support/domain/DataProduct';
 import { Domain } from '../../support/domain/Domain';
 import { UserClass } from '../../support/user/UserClass';
@@ -47,7 +48,7 @@ const test = base.extend<{
 
 test.describe(
   'Data Marketplace - Permissions',
-  { tag: ['@Pages', '@Discovery'] },
+  { tag: ['@Pages', '@Discovery', PLAYWRIGHT_BASIC_TEST_TAG_OBJ.tag] },
   () => {
     test.beforeAll('Setup entities', async ({ browser }) => {
       const { apiContext, afterAction } = await performAdminLogin(browser);

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/DescriptionVisibility.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/DescriptionVisibility.spec.ts
@@ -12,6 +12,7 @@
  */
 
 import { expect } from '@playwright/test';
+import { PLAYWRIGHT_BASIC_TEST_TAG_OBJ } from '../../constant/config';
 import {
   LONG_DESCRIPTION,
   LONG_DESCRIPTION_END_TEXT,
@@ -45,433 +46,438 @@ import { navigateToPersonaWithPagination } from '../../utils/persona';
 import { settingClick, sidebarClick } from '../../utils/sidebar';
 import { test } from '../fixtures/pages';
 
-test.describe('Long Description Visibility', () => {
-  test.slow(true);
+test.describe(
+  'Long Description Visibility',
+  PLAYWRIGHT_BASIC_TEST_TAG_OBJ,
+  () => {
+    test.slow(true);
 
-  let domain: Domain;
-  let dataProductData: DataProduct['data'];
-  let glossary: Glossary;
-  let glossaryTerm: GlossaryTerm;
-  let persona: PersonaClass;
-  let adminUser: AdminClass;
-  let regularUser: UserClass;
-  let table: TableClass;
+    let domain: Domain;
+    let dataProductData: DataProduct['data'];
+    let glossary: Glossary;
+    let glossaryTerm: GlossaryTerm;
+    let persona: PersonaClass;
+    let adminUser: AdminClass;
+    let regularUser: UserClass;
+    let table: TableClass;
 
-  test.beforeAll(
-    'Setup entities with long descriptions',
-    async ({ browser }) => {
-      const adminPage = await browser.newPage({
-        storageState: 'playwright/.auth/admin.json',
-      });
-      await adminPage.goto('/');
-      const { apiContext, afterAction } = await getApiContext(adminPage);
+    test.beforeAll(
+      'Setup entities with long descriptions',
+      async ({ browser }) => {
+        const adminPage = await browser.newPage({
+          storageState: 'playwright/.auth/admin.json',
+        });
+        await adminPage.goto('/');
+        const { apiContext, afterAction } = await getApiContext(adminPage);
 
-      const id = uuid();
+        const id = uuid();
 
-      // Domain
-      domain = new Domain({
-        name: `PW_Domain_LongDesc_${id}`,
-        displayName: `PW Domain LongDesc ${id}`,
-        description: LONG_DESCRIPTION,
-        domainType: 'Aggregate',
-        fullyQualifiedName: `PW_Domain_LongDesc_${id}`,
-      });
-      await domain.create(apiContext);
-
-      // Data Product
-      const dpName = `PW_DataProduct_LongDesc_${id}`;
-      const dpResponse = await apiContext.post('/api/v1/dataProducts', {
-        data: {
-          name: dpName,
-          displayName: `PW Data Product LongDesc ${id}`,
+        // Domain
+        domain = new Domain({
+          name: `PW_Domain_LongDesc_${id}`,
+          displayName: `PW Domain LongDesc ${id}`,
           description: LONG_DESCRIPTION,
-          domains: [domain.responseData.fullyQualifiedName],
-        },
-      });
+          domainType: 'Aggregate',
+          fullyQualifiedName: `PW_Domain_LongDesc_${id}`,
+        });
+        await domain.create(apiContext);
 
-      if (!dpResponse.ok()) {
-        throw new Error(
-          `Failed to create data product: ${dpResponse.status()} ${await dpResponse.text()}`
+        // Data Product
+        const dpName = `PW_DataProduct_LongDesc_${id}`;
+        const dpResponse = await apiContext.post('/api/v1/dataProducts', {
+          data: {
+            name: dpName,
+            displayName: `PW Data Product LongDesc ${id}`,
+            description: LONG_DESCRIPTION,
+            domains: [domain.responseData.fullyQualifiedName],
+          },
+        });
+
+        if (!dpResponse.ok()) {
+          throw new Error(
+            `Failed to create data product: ${dpResponse.status()} ${await dpResponse.text()}`
+          );
+        }
+
+        dataProductData = await dpResponse.json();
+
+        // Glossary
+        glossary = new Glossary(`PW_Glossary_LongDesc_${id}`);
+        glossary.data.description = LONG_DESCRIPTION;
+        await glossary.create(apiContext);
+
+        // Glossary Term
+        glossaryTerm = new GlossaryTerm(
+          glossary,
+          undefined,
+          `PW_GlossaryTerm_LongDesc_${id}`
         );
+        glossaryTerm.data.description = LONG_DESCRIPTION;
+        await glossaryTerm.create(apiContext);
+
+        // Persona + Table for customized detail page test
+        persona = new PersonaClass();
+        await persona.create(apiContext);
+
+        adminUser = new AdminClass();
+        await adminUser.create(apiContext);
+        await adminUser.setAdminRole(apiContext);
+
+        regularUser = new UserClass();
+        await regularUser.create(apiContext);
+        await regularUser.setAdminRole(apiContext);
+
+        await regularUser.patch({
+          apiContext,
+          patchData: [
+            {
+              op: 'add',
+              path: '/personas/0',
+              value: {
+                id: persona.responseData.id,
+                name: persona.responseData.name,
+                displayName: persona.responseData.displayName,
+                fullyQualifiedName: persona.responseData.fullyQualifiedName,
+                type: 'persona',
+              },
+            },
+            {
+              op: 'add',
+              path: '/defaultPersona',
+              value: {
+                id: persona.responseData.id,
+                name: persona.responseData.name,
+                displayName: persona.responseData.displayName,
+                fullyQualifiedName: persona.responseData.fullyQualifiedName,
+                type: 'persona',
+              },
+            },
+          ],
+        });
+
+        table = new TableClass();
+        table.entity.description = LONG_DESCRIPTION;
+        await table.create(apiContext);
+
+        await afterAction();
+        await adminPage.close();
       }
-
-      dataProductData = await dpResponse.json();
-
-      // Glossary
-      glossary = new Glossary(`PW_Glossary_LongDesc_${id}`);
-      glossary.data.description = LONG_DESCRIPTION;
-      await glossary.create(apiContext);
-
-      // Glossary Term
-      glossaryTerm = new GlossaryTerm(
-        glossary,
-        undefined,
-        `PW_GlossaryTerm_LongDesc_${id}`
-      );
-      glossaryTerm.data.description = LONG_DESCRIPTION;
-      await glossaryTerm.create(apiContext);
-
-      // Persona + Table for customized detail page test
-      persona = new PersonaClass();
-      await persona.create(apiContext);
-
-      adminUser = new AdminClass();
-      await adminUser.create(apiContext);
-      await adminUser.setAdminRole(apiContext);
-
-      regularUser = new UserClass();
-      await regularUser.create(apiContext);
-      await regularUser.setAdminRole(apiContext);
-
-      await regularUser.patch({
-        apiContext,
-        patchData: [
-          {
-            op: 'add',
-            path: '/personas/0',
-            value: {
-              id: persona.responseData.id,
-              name: persona.responseData.name,
-              displayName: persona.responseData.displayName,
-              fullyQualifiedName: persona.responseData.fullyQualifiedName,
-              type: 'persona',
-            },
-          },
-          {
-            op: 'add',
-            path: '/defaultPersona',
-            value: {
-              id: persona.responseData.id,
-              name: persona.responseData.name,
-              displayName: persona.responseData.displayName,
-              fullyQualifiedName: persona.responseData.fullyQualifiedName,
-              type: 'persona',
-            },
-          },
-        ],
-      });
-
-      table = new TableClass();
-      table.entity.description = LONG_DESCRIPTION;
-      await table.create(apiContext);
-
-      await afterAction();
-      await adminPage.close();
-    }
-  );
-
-  test.afterAll('Cleanup', async ({ browser }) => {
-    const { apiContext, afterAction } = await performAdminLogin(browser);
-    await persona.delete(apiContext);
-    await adminUser.delete(apiContext);
-    await regularUser.delete(apiContext);
-    await table.delete(apiContext);
-    await afterAction();
-  });
-
-  // ── Domain ──
-
-  test('Domain long description is scrollable and end of text is visible after scroll', async ({
-    page,
-  }) => {
-    await redirectToHomePage(page);
-    await sidebarClick(page, SidebarItem.DOMAIN);
-    await selectDomain(page, domain.responseData);
-
-    const descContainer = page.getByTestId('asset-description-container');
-    await expect(descContainer).toBeVisible();
-    await expect(page.getByTestId('viewer-container')).toBeVisible();
-
-    await expect(page.getByTestId('read-more-button')).not.toBeVisible();
-
-    await verifyDescriptionRequiresScroll(descContainer, page);
-  });
-
-  test('Domain description card collapse hides content and expand restores scrollability', async ({
-    page,
-  }) => {
-    await redirectToHomePage(page);
-    await sidebarClick(page, SidebarItem.DOMAIN);
-    await selectDomain(page, domain.responseData);
-
-    const descContainer = page.getByTestId('asset-description-container');
-    await expect(descContainer).toBeVisible();
-    await expect(descContainer).toHaveClass(/\bexpanded\b/);
-
-    await descContainer.getByTestId('expand-collapse-icon').click();
-    await expect(descContainer).not.toHaveClass(/\bexpanded\b/);
-
-    await descContainer.getByTestId('expand-collapse-icon').click();
-    await expect(descContainer).toHaveClass(/\bexpanded\b/);
-
-    await verifyDescriptionRequiresScroll(descContainer, page);
-  });
-
-  // ── Data Product ──
-
-  test('Data Product truncates long description and end of text is not visible before expand', async ({
-    page,
-  }) => {
-    await redirectToHomePage(page);
-    await sidebarClick(page, SidebarItem.DATA_PRODUCT);
-    await selectDataProduct(page, dataProductData);
-
-    const descContainer = page.getByTestId('asset-description-container');
-    await expect(descContainer).toBeVisible();
-
-    await expect(descContainer.getByTestId('read-more-button')).toBeVisible();
-
-    await expect(
-      descContainer.getByText(LONG_DESCRIPTION_END_TEXT)
-    ).not.toBeVisible();
-  });
-
-  test('Data Product long description is scrollable and end of text is visible after expanding', async ({
-    page,
-  }) => {
-    await redirectToHomePage(page);
-    await sidebarClick(page, SidebarItem.DATA_PRODUCT);
-    await selectDataProduct(page, dataProductData);
-
-    const descContainer = page.getByTestId('asset-description-container');
-    await expect(descContainer).toBeVisible();
-
-    await descContainer.getByTestId('read-more-button').click();
-
-    await verifyEndOfDescriptionReachable(descContainer, page);
-
-    await expect(descContainer.getByTestId('read-less-button')).toBeVisible();
-
-    await descContainer.getByTestId('read-less-button').click();
-    await expect(
-      descContainer.getByText(LONG_DESCRIPTION_END_TEXT)
-    ).not.toBeVisible();
-    await expect(descContainer.getByTestId('read-more-button')).toBeVisible();
-  });
-
-  test('Data Product description card collapse hides content and expand restores it', async ({
-    page,
-  }) => {
-    await redirectToHomePage(page);
-    await sidebarClick(page, SidebarItem.DATA_PRODUCT);
-    await selectDataProduct(page, dataProductData);
-
-    const descContainer = page.getByTestId('asset-description-container');
-    await expect(descContainer).toBeVisible();
-    await expect(descContainer).toHaveClass(/\bexpanded\b/);
-
-    await descContainer.getByTestId('expand-collapse-icon').click();
-    await expect(descContainer).not.toHaveClass(/\bexpanded\b/);
-
-    await descContainer.getByTestId('expand-collapse-icon').click();
-    await expect(descContainer).toHaveClass(/\bexpanded\b/);
-  });
-
-  // ── Glossary ──
-
-  test('Glossary truncates long description and end of text is not visible before expand', async ({
-    page,
-  }) => {
-    await visitGlossaryPage(page, glossary.responseData.displayName);
-
-    const descContainer = page.getByTestId('asset-description-container');
-    await expect(descContainer).toBeVisible();
-
-    await expect(descContainer.getByTestId('read-more-button')).toBeVisible();
-
-    await expect(
-      descContainer.getByText(LONG_DESCRIPTION_END_TEXT)
-    ).not.toBeVisible();
-  });
-
-  test('Glossary long description is visible after expanding', async ({
-    page,
-  }) => {
-    await visitGlossaryPage(page, glossary.responseData.displayName);
-
-    const descContainer = page.getByTestId('asset-description-container');
-    await expect(descContainer).toBeVisible();
-
-    await descContainer.getByTestId('read-more-button').click();
-
-    await verifyEndOfDescriptionReachable(descContainer, page);
-
-    await expect(descContainer.getByTestId('read-less-button')).toBeVisible();
-
-    await descContainer.getByTestId('read-less-button').click();
-    await expect(
-      descContainer.getByText(LONG_DESCRIPTION_END_TEXT)
-    ).not.toBeVisible();
-    await expect(descContainer.getByTestId('read-more-button')).toBeVisible();
-  });
-
-  test('Glossary description card collapse hides content and expand restores it', async ({
-    page,
-  }) => {
-    await visitGlossaryPage(page, glossary.responseData.displayName);
-
-    const descContainer = page.getByTestId('asset-description-container');
-    await expect(descContainer).toBeVisible();
-    await expect(descContainer).toHaveClass(/\bexpanded\b/);
-
-    await descContainer.getByTestId('expand-collapse-icon').click();
-    await expect(descContainer).not.toHaveClass(/\bexpanded\b/);
-
-    await descContainer.getByTestId('expand-collapse-icon').click();
-    await expect(descContainer).toHaveClass(/\bexpanded\b/);
-  });
-
-  // ── Glossary Term ──
-
-  test('Glossary Term truncates long description and end of text is not visible before expand', async ({
-    page,
-  }) => {
-    await glossaryTerm.visitPage(page);
-
-    const descContainer = page.getByTestId('asset-description-container');
-    await expect(descContainer).toBeVisible();
-
-    await expect(descContainer.getByTestId('read-more-button')).toBeVisible();
-
-    await expect(
-      descContainer.getByText(LONG_DESCRIPTION_END_TEXT)
-    ).not.toBeVisible();
-  });
-
-  test('Glossary Term long description is visible after expanding', async ({
-    page,
-  }) => {
-    await glossaryTerm.visitPage(page);
-
-    const descContainer = page.getByTestId('asset-description-container');
-    await expect(descContainer).toBeVisible();
-
-    await descContainer.getByTestId('read-more-button').click();
-
-    await verifyEndOfDescriptionReachable(descContainer, page);
-
-    await expect(descContainer.getByTestId('read-less-button')).toBeVisible();
-
-    await descContainer.getByTestId('read-less-button').click();
-    await expect(
-      descContainer.getByText(LONG_DESCRIPTION_END_TEXT)
-    ).not.toBeVisible();
-    await expect(descContainer.getByTestId('read-more-button')).toBeVisible();
-  });
-
-  test('Glossary Term description card collapse hides content and expand restores it', async ({
-    page,
-  }) => {
-    await glossaryTerm.visitPage(page);
-
-    const descContainer = page.getByTestId('asset-description-container');
-    await expect(descContainer).toBeVisible();
-    await expect(descContainer).toHaveClass(/\bexpanded\b/);
-
-    await descContainer.getByTestId('expand-collapse-icon').click();
-    await expect(descContainer).not.toHaveClass(/\bexpanded\b/);
-
-    await descContainer.getByTestId('expand-collapse-icon').click();
-    await expect(descContainer).toHaveClass(/\bexpanded\b/);
-  });
-
-  // ── Customized Table Detail Page ──
-
-  test('Customized Table detail page Description widget shows long description', async ({
-    browser,
-  }) => {
-    // Admin: Customize Table detail page for persona
-    const adminPage = await browser.newPage();
-    await adminUser.login(adminPage);
-    await redirectToHomePage(adminPage);
-
-    const personaListResponse = adminPage.waitForResponse('/api/v1/personas?*');
-    await settingClick(adminPage, GlobalSettingOptions.PERSONA);
-    await personaListResponse;
-    await navigateToPersonaWithPagination(adminPage, persona.data.name, true);
-    await adminPage.getByRole('tab', { name: 'Customize UI' }).click();
-
-    await adminPage.getByText('Data Assets').click();
-    await adminPage.getByText('Table', { exact: true }).click();
-    await waitForAllLoadersToDisappear(adminPage);
-
-    // Add custom tab
-    await adminPage.getByRole('button', { name: 'Add tab' }).click();
-    await expect(adminPage.getByRole('dialog')).toBeVisible();
-    await adminPage.getByTestId('add-tab-input').fill('Description Tab');
-
-    const addButton = adminPage
-      .getByRole('dialog')
-      .getByRole('button', { name: 'Add' });
-    await adminPage.locator('.ant-modal').waitFor({ state: 'visible' });
-    await expect(addButton).toBeEnabled();
-    await addButton.click();
-
-    await expect(adminPage.getByTestId('tab-Description Tab')).toBeVisible();
-
-    // Wait for dialog to close
-    await adminPage.getByRole('dialog').waitFor({ state: 'hidden' });
-    await adminPage.locator('.ant-modal-wrap').waitFor({ state: 'detached' });
-
-    // Add Description widget to custom tab
-    const addWidgetButton = adminPage
-      .getByTestId('ExtraWidget.EmptyWidgetPlaceholder')
-      .getByTestId('add-widget-button');
-    await addWidgetButton.waitFor({ state: 'visible' });
-    await expect(addWidgetButton).toBeEnabled();
-    await addWidgetButton.click();
-    await adminPage
-      .getByTestId('widget-info-tabs')
-      .waitFor({ state: 'visible' });
-
-    await adminPage
-      .getByTestId('add-widget-modal')
-      .getByTestId('Description-widget')
-      .click();
-    await adminPage
-      .getByTestId('add-widget-modal')
-      .getByTestId('add-widget-button')
-      .click();
-
-    await adminPage
-      .getByTestId('widget-info-tabs')
-      .waitFor({ state: 'hidden' });
-
-    // Save customization
-    await adminPage.getByTestId('save-button').click();
-    await toastNotification(
-      adminPage,
-      /^Page layout (created|updated) successfully\.$/
     );
-    await adminPage.close();
 
-    // User: Validate long description in custom tab
-    const userPage = await browser.newPage();
-    await regularUser.login(userPage);
-    await redirectToHomePage(userPage);
-
-    await table.visitEntityPage(userPage);
-    await waitForAllLoadersToDisappear(userPage);
-
-    await expect(
-      userPage.getByRole('tab', { name: 'Description Tab' })
-    ).toBeVisible();
-    await userPage.getByRole('tab', { name: 'Description Tab' }).click();
-
-    const descriptionWidget = userPage
-      .getByTestId(/KnowledgePanel.Description-/)
-      .locator('visible=true');
-    await expect(descriptionWidget).toBeVisible();
-
-    // Widget truncates long content behind a "more" button
-    const moreButton = descriptionWidget.getByRole('button', {
-      name: 'more',
+    test.afterAll('Cleanup', async ({ browser }) => {
+      const { apiContext, afterAction } = await performAdminLogin(browser);
+      await persona.delete(apiContext);
+      await adminUser.delete(apiContext);
+      await regularUser.delete(apiContext);
+      await table.delete(apiContext);
+      await afterAction();
     });
-    await expect(moreButton).toBeVisible();
-    await moreButton.click();
 
-    await verifyEndOfDescriptionReachable(descriptionWidget, userPage);
+    // ── Domain ──
 
-    await userPage.close();
-  });
-});
+    test('Domain long description is scrollable and end of text is visible after scroll', async ({
+      page,
+    }) => {
+      await redirectToHomePage(page);
+      await sidebarClick(page, SidebarItem.DOMAIN);
+      await selectDomain(page, domain.responseData);
+
+      const descContainer = page.getByTestId('asset-description-container');
+      await expect(descContainer).toBeVisible();
+      await expect(page.getByTestId('viewer-container')).toBeVisible();
+
+      await expect(page.getByTestId('read-more-button')).not.toBeVisible();
+
+      await verifyDescriptionRequiresScroll(descContainer, page);
+    });
+
+    test('Domain description card collapse hides content and expand restores scrollability', async ({
+      page,
+    }) => {
+      await redirectToHomePage(page);
+      await sidebarClick(page, SidebarItem.DOMAIN);
+      await selectDomain(page, domain.responseData);
+
+      const descContainer = page.getByTestId('asset-description-container');
+      await expect(descContainer).toBeVisible();
+      await expect(descContainer).toHaveClass(/\bexpanded\b/);
+
+      await descContainer.getByTestId('expand-collapse-icon').click();
+      await expect(descContainer).not.toHaveClass(/\bexpanded\b/);
+
+      await descContainer.getByTestId('expand-collapse-icon').click();
+      await expect(descContainer).toHaveClass(/\bexpanded\b/);
+
+      await verifyDescriptionRequiresScroll(descContainer, page);
+    });
+
+    // ── Data Product ──
+
+    test('Data Product truncates long description and end of text is not visible before expand', async ({
+      page,
+    }) => {
+      await redirectToHomePage(page);
+      await sidebarClick(page, SidebarItem.DATA_PRODUCT);
+      await selectDataProduct(page, dataProductData);
+
+      const descContainer = page.getByTestId('asset-description-container');
+      await expect(descContainer).toBeVisible();
+
+      await expect(descContainer.getByTestId('read-more-button')).toBeVisible();
+
+      await expect(
+        descContainer.getByText(LONG_DESCRIPTION_END_TEXT)
+      ).not.toBeVisible();
+    });
+
+    test('Data Product long description is scrollable and end of text is visible after expanding', async ({
+      page,
+    }) => {
+      await redirectToHomePage(page);
+      await sidebarClick(page, SidebarItem.DATA_PRODUCT);
+      await selectDataProduct(page, dataProductData);
+
+      const descContainer = page.getByTestId('asset-description-container');
+      await expect(descContainer).toBeVisible();
+
+      await descContainer.getByTestId('read-more-button').click();
+
+      await verifyEndOfDescriptionReachable(descContainer, page);
+
+      await expect(descContainer.getByTestId('read-less-button')).toBeVisible();
+
+      await descContainer.getByTestId('read-less-button').click();
+      await expect(
+        descContainer.getByText(LONG_DESCRIPTION_END_TEXT)
+      ).not.toBeVisible();
+      await expect(descContainer.getByTestId('read-more-button')).toBeVisible();
+    });
+
+    test('Data Product description card collapse hides content and expand restores it', async ({
+      page,
+    }) => {
+      await redirectToHomePage(page);
+      await sidebarClick(page, SidebarItem.DATA_PRODUCT);
+      await selectDataProduct(page, dataProductData);
+
+      const descContainer = page.getByTestId('asset-description-container');
+      await expect(descContainer).toBeVisible();
+      await expect(descContainer).toHaveClass(/\bexpanded\b/);
+
+      await descContainer.getByTestId('expand-collapse-icon').click();
+      await expect(descContainer).not.toHaveClass(/\bexpanded\b/);
+
+      await descContainer.getByTestId('expand-collapse-icon').click();
+      await expect(descContainer).toHaveClass(/\bexpanded\b/);
+    });
+
+    // ── Glossary ──
+
+    test('Glossary truncates long description and end of text is not visible before expand', async ({
+      page,
+    }) => {
+      await visitGlossaryPage(page, glossary.responseData.displayName);
+
+      const descContainer = page.getByTestId('asset-description-container');
+      await expect(descContainer).toBeVisible();
+
+      await expect(descContainer.getByTestId('read-more-button')).toBeVisible();
+
+      await expect(
+        descContainer.getByText(LONG_DESCRIPTION_END_TEXT)
+      ).not.toBeVisible();
+    });
+
+    test('Glossary long description is visible after expanding', async ({
+      page,
+    }) => {
+      await visitGlossaryPage(page, glossary.responseData.displayName);
+
+      const descContainer = page.getByTestId('asset-description-container');
+      await expect(descContainer).toBeVisible();
+
+      await descContainer.getByTestId('read-more-button').click();
+
+      await verifyEndOfDescriptionReachable(descContainer, page);
+
+      await expect(descContainer.getByTestId('read-less-button')).toBeVisible();
+
+      await descContainer.getByTestId('read-less-button').click();
+      await expect(
+        descContainer.getByText(LONG_DESCRIPTION_END_TEXT)
+      ).not.toBeVisible();
+      await expect(descContainer.getByTestId('read-more-button')).toBeVisible();
+    });
+
+    test('Glossary description card collapse hides content and expand restores it', async ({
+      page,
+    }) => {
+      await visitGlossaryPage(page, glossary.responseData.displayName);
+
+      const descContainer = page.getByTestId('asset-description-container');
+      await expect(descContainer).toBeVisible();
+      await expect(descContainer).toHaveClass(/\bexpanded\b/);
+
+      await descContainer.getByTestId('expand-collapse-icon').click();
+      await expect(descContainer).not.toHaveClass(/\bexpanded\b/);
+
+      await descContainer.getByTestId('expand-collapse-icon').click();
+      await expect(descContainer).toHaveClass(/\bexpanded\b/);
+    });
+
+    // ── Glossary Term ──
+
+    test('Glossary Term truncates long description and end of text is not visible before expand', async ({
+      page,
+    }) => {
+      await glossaryTerm.visitPage(page);
+
+      const descContainer = page.getByTestId('asset-description-container');
+      await expect(descContainer).toBeVisible();
+
+      await expect(descContainer.getByTestId('read-more-button')).toBeVisible();
+
+      await expect(
+        descContainer.getByText(LONG_DESCRIPTION_END_TEXT)
+      ).not.toBeVisible();
+    });
+
+    test('Glossary Term long description is visible after expanding', async ({
+      page,
+    }) => {
+      await glossaryTerm.visitPage(page);
+
+      const descContainer = page.getByTestId('asset-description-container');
+      await expect(descContainer).toBeVisible();
+
+      await descContainer.getByTestId('read-more-button').click();
+
+      await verifyEndOfDescriptionReachable(descContainer, page);
+
+      await expect(descContainer.getByTestId('read-less-button')).toBeVisible();
+
+      await descContainer.getByTestId('read-less-button').click();
+      await expect(
+        descContainer.getByText(LONG_DESCRIPTION_END_TEXT)
+      ).not.toBeVisible();
+      await expect(descContainer.getByTestId('read-more-button')).toBeVisible();
+    });
+
+    test('Glossary Term description card collapse hides content and expand restores it', async ({
+      page,
+    }) => {
+      await glossaryTerm.visitPage(page);
+
+      const descContainer = page.getByTestId('asset-description-container');
+      await expect(descContainer).toBeVisible();
+      await expect(descContainer).toHaveClass(/\bexpanded\b/);
+
+      await descContainer.getByTestId('expand-collapse-icon').click();
+      await expect(descContainer).not.toHaveClass(/\bexpanded\b/);
+
+      await descContainer.getByTestId('expand-collapse-icon').click();
+      await expect(descContainer).toHaveClass(/\bexpanded\b/);
+    });
+
+    // ── Customized Table Detail Page ──
+
+    test('Customized Table detail page Description widget shows long description', async ({
+      browser,
+    }) => {
+      // Admin: Customize Table detail page for persona
+      const adminPage = await browser.newPage();
+      await adminUser.login(adminPage);
+      await redirectToHomePage(adminPage);
+
+      const personaListResponse =
+        adminPage.waitForResponse('/api/v1/personas?*');
+      await settingClick(adminPage, GlobalSettingOptions.PERSONA);
+      await personaListResponse;
+      await navigateToPersonaWithPagination(adminPage, persona.data.name, true);
+      await adminPage.getByRole('tab', { name: 'Customize UI' }).click();
+
+      await adminPage.getByText('Data Assets').click();
+      await adminPage.getByText('Table', { exact: true }).click();
+      await waitForAllLoadersToDisappear(adminPage);
+
+      // Add custom tab
+      await adminPage.getByRole('button', { name: 'Add tab' }).click();
+      await expect(adminPage.getByRole('dialog')).toBeVisible();
+      await adminPage.getByTestId('add-tab-input').fill('Description Tab');
+
+      const addButton = adminPage
+        .getByRole('dialog')
+        .getByRole('button', { name: 'Add' });
+      await adminPage.locator('.ant-modal').waitFor({ state: 'visible' });
+      await expect(addButton).toBeEnabled();
+      await addButton.click();
+
+      await expect(adminPage.getByTestId('tab-Description Tab')).toBeVisible();
+
+      // Wait for dialog to close
+      await adminPage.getByRole('dialog').waitFor({ state: 'hidden' });
+      await adminPage.locator('.ant-modal-wrap').waitFor({ state: 'detached' });
+
+      // Add Description widget to custom tab
+      const addWidgetButton = adminPage
+        .getByTestId('ExtraWidget.EmptyWidgetPlaceholder')
+        .getByTestId('add-widget-button');
+      await addWidgetButton.waitFor({ state: 'visible' });
+      await expect(addWidgetButton).toBeEnabled();
+      await addWidgetButton.click();
+      await adminPage
+        .getByTestId('widget-info-tabs')
+        .waitFor({ state: 'visible' });
+
+      await adminPage
+        .getByTestId('add-widget-modal')
+        .getByTestId('Description-widget')
+        .click();
+      await adminPage
+        .getByTestId('add-widget-modal')
+        .getByTestId('add-widget-button')
+        .click();
+
+      await adminPage
+        .getByTestId('widget-info-tabs')
+        .waitFor({ state: 'hidden' });
+
+      // Save customization
+      await adminPage.getByTestId('save-button').click();
+      await toastNotification(
+        adminPage,
+        /^Page layout (created|updated) successfully\.$/
+      );
+      await adminPage.close();
+
+      // User: Validate long description in custom tab
+      const userPage = await browser.newPage();
+      await regularUser.login(userPage);
+      await redirectToHomePage(userPage);
+
+      await table.visitEntityPage(userPage);
+      await waitForAllLoadersToDisappear(userPage);
+
+      await expect(
+        userPage.getByRole('tab', { name: 'Description Tab' })
+      ).toBeVisible();
+      await userPage.getByRole('tab', { name: 'Description Tab' }).click();
+
+      const descriptionWidget = userPage
+        .getByTestId(/KnowledgePanel.Description-/)
+        .locator('visible=true');
+      await expect(descriptionWidget).toBeVisible();
+
+      // Widget truncates long content behind a "more" button
+      const moreButton = descriptionWidget.getByRole('button', {
+        name: 'more',
+      });
+      await expect(moreButton).toBeVisible();
+      await moreButton.click();
+
+      await verifyEndOfDescriptionReachable(descriptionWidget, userPage);
+
+      await userPage.close();
+    });
+  }
+);

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/Lineage/LineageRightPanel.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/Lineage/LineageRightPanel.spec.ts
@@ -12,6 +12,7 @@
  */
 import { expect } from '@playwright/test';
 import { get } from 'lodash';
+import { PLAYWRIGHT_BASIC_TEST_TAG_OBJ } from '../../../constant/config';
 import { SidebarItem } from '../../../constant/sidebar';
 import { ApiEndpointClass } from '../../../support/entity/ApiEndpointClass';
 import { ChartClass } from '../../../support/entity/ChartClass';
@@ -39,71 +40,76 @@ import { clickLineageNode, visitLineageTab } from '../../../utils/lineage';
 import { sidebarClick } from '../../../utils/sidebar';
 import { test } from '../../fixtures/pages';
 
-test.describe('Verify custom properties tab visibility logic for supported entity types lineage', () => {
-  const supportedEntities = [
-    { entity: new TableClass(), type: 'table' },
-    { entity: new TopicClass(), type: 'topic' },
-    { entity: new DashboardClass(), type: 'dashboard' },
-    { entity: new PipelineClass(), type: 'pipeline' },
-    { entity: new MlModelClass(), type: 'mlmodel' },
-    { entity: new ContainerClass(), type: 'container' },
-    { entity: new SearchIndexClass(), type: 'searchIndex' },
-    { entity: new ApiEndpointClass(), type: 'apiEndpoint' },
-    { entity: new MetricClass(), type: 'metric' },
-    { entity: new ChartClass(), type: 'chart' },
-  ];
+test.describe(
+  'Verify custom properties tab visibility logic for supported entity types lineage',
+  PLAYWRIGHT_BASIC_TEST_TAG_OBJ,
+  () => {
+    const supportedEntities = [
+      { entity: new TableClass(), type: 'table' },
+      { entity: new TopicClass(), type: 'topic' },
+      { entity: new DashboardClass(), type: 'dashboard' },
+      { entity: new PipelineClass(), type: 'pipeline' },
+      { entity: new MlModelClass(), type: 'mlmodel' },
+      { entity: new ContainerClass(), type: 'container' },
+      { entity: new SearchIndexClass(), type: 'searchIndex' },
+      { entity: new ApiEndpointClass(), type: 'apiEndpoint' },
+      { entity: new MetricClass(), type: 'metric' },
+      { entity: new ChartClass(), type: 'chart' },
+    ];
 
-  test.beforeAll(async ({ browser }) => {
-    const { apiContext, afterAction } = await getDefaultAdminAPIContext(
-      browser
-    );
-
-    const createEntityArray: Promise<unknown>[] = [];
-
-    supportedEntities.forEach(({ entity }) => {
-      createEntityArray.push(entity.create(apiContext));
-    });
-
-    await Promise.all(createEntityArray);
-
-    await afterAction();
-  });
-
-  test.beforeEach(async ({ page }) => {
-    await redirectToHomePage(page);
-  });
-
-  for (const { entity, type } of supportedEntities) {
-    test(`Verify custom properties tab IS visible for supported type: ${type}`, async ({
-      page,
-    }) => {
-      const searchTerm =
-        entity.entityResponseData?.['fullyQualifiedName'] || entity.entity.name;
-
-      await entity.visitEntityPage(page, searchTerm);
-      await visitLineageTab(page);
-
-      const nodeFqn = entity.entityResponseData?.['fullyQualifiedName'] ?? '';
-
-      await clickLineageNode(page, nodeFqn);
-
-      const lineagePanel = page.getByTestId('lineage-entity-panel');
-      await expect(lineagePanel).toBeVisible();
-      await waitForAllLoadersToDisappear(page);
-
-      const customPropertiesTab = lineagePanel.getByTestId(
-        'custom-properties-tab'
+    test.beforeAll(async ({ browser }) => {
+      const { apiContext, afterAction } = await getDefaultAdminAPIContext(
+        browser
       );
-      await expect(customPropertiesTab).toBeVisible();
 
-      const closeButton = lineagePanel.getByTestId('drawer-close-icon');
-      if (await closeButton.isVisible()) {
-        await closeButton.click();
-        await expect(lineagePanel).not.toBeVisible();
-      }
+      const createEntityArray: Promise<unknown>[] = [];
+
+      supportedEntities.forEach(({ entity }) => {
+        createEntityArray.push(entity.create(apiContext));
+      });
+
+      await Promise.all(createEntityArray);
+
+      await afterAction();
     });
+
+    test.beforeEach(async ({ page }) => {
+      await redirectToHomePage(page);
+    });
+
+    for (const { entity, type } of supportedEntities) {
+      test(`Verify custom properties tab IS visible for supported type: ${type}`, async ({
+        page,
+      }) => {
+        const searchTerm =
+          entity.entityResponseData?.['fullyQualifiedName'] ||
+          entity.entity.name;
+
+        await entity.visitEntityPage(page, searchTerm);
+        await visitLineageTab(page);
+
+        const nodeFqn = entity.entityResponseData?.['fullyQualifiedName'] ?? '';
+
+        await clickLineageNode(page, nodeFqn);
+
+        const lineagePanel = page.getByTestId('lineage-entity-panel');
+        await expect(lineagePanel).toBeVisible();
+        await waitForAllLoadersToDisappear(page);
+
+        const customPropertiesTab = lineagePanel.getByTestId(
+          'custom-properties-tab'
+        );
+        await expect(customPropertiesTab).toBeVisible();
+
+        const closeButton = lineagePanel.getByTestId('drawer-close-icon');
+        if (await closeButton.isVisible()) {
+          await closeButton.click();
+          await expect(lineagePanel).not.toBeVisible();
+        }
+      });
+    }
   }
-});
+);
 
 test.describe('Verify custom properties tab is NOT visible for unsupported entity types in platform lineage', () => {
   const unsupportedServices = [


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:

Fixes #<issue-number>
<!--
Linking an issue is REQUIRED. Replace <issue-number> with the GitHub issue number this PR addresses
(e.g., `Fixes #12345`). GitHub will auto-link it. If no issue exists, please open one first so the
problem and design can be discussed before review.
-->

<!--
Short blurb explaining:
- What changes did you make?
- Why did you make them?
-->

I worked on ... because ...

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### High-level design:
<!--
REQUIRED for large PRs (new features, refactors, breaking changes, or anything touching >5 files).
Skip for small bug fixes and trivial changes.

Cover:
- Architecture / approach you took and why
- Key components or files added/changed and how they interact
- Alternatives considered and why you rejected them
- Any migration, backward-compatibility, or rollout concerns
- Diagrams or links to design docs / RFCs if available
-->

N/A — small change. <!-- Or fill in the design above -->

#
### Tests:

#### Use cases covered
<!--
List the user-visible scenarios this PR exercises. Example:
- User with Admin role can create a Glossary Term with a parent term
- Ingestion run for Snowflake correctly extracts row counts for partitioned tables
-->

#### Unit tests
<!--
- [ ] I added unit tests for the new/changed logic.
- Files added/updated:
- Coverage on changed classes (run `mvn jacoco:report` for backend, `yarn test:coverage` for UI,
  `make unit_ingestion` for ingestion). Target is 90% line coverage on changed classes.
- Coverage %: <e.g., 92% on EntityRepository.java>
-->

#### Backend integration tests
<!--
- [ ] I added integration tests in `openmetadata-integration-tests/` for new/changed API endpoints.
- [ ] Not applicable (no backend API changes).
- Files added/updated:
-->

#### Ingestion integration tests
<!--
- [ ] I added/updated ingestion integration tests for connector changes.
- [ ] Not applicable (no ingestion changes).
- Files added/updated:
-->

#### Playwright (UI) tests
<!--
- [ ] I added Playwright E2E tests under `openmetadata-ui/.../ui/playwright/` for UI changes.
- [ ] Not applicable (no UI changes).
- Files added/updated:
-->

#### Manual testing performed
<!--
List the manual test steps you performed before requesting review. Example:
1. Started local stack via `./docker/run_local_docker.sh -m ui -d mysql`
2. Logged in as admin, created entity X, verified Y appears in the UI
3. Triggered ingestion for Snowflake source, confirmed lineage edges in the explore page
-->

#
### UI screen recording / screenshots:
<!--
REQUIRED for any PR that changes the UI. Drag-and-drop a short screen recording (.mov / .mp4 / .gif)
demonstrating the change end-to-end, plus before/after screenshots where relevant.
Mark "Not applicable" if there are no UI changes.
-->

Not applicable. <!-- Or attach recording/screenshots above -->

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.
- [ ] For UI changes: I attached a screen recording and/or screenshots above.
- [ ] I have added tests (unit / integration / Playwright as applicable) and listed them above.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->

----
## Summary by Gitar

- **Test infrastructure:**
  - Integrated `PLAYWRIGHT_BASIC_TEST_TAG_OBJ` across various E2E test suites to enable flexible test sharding.
  - Applied new tags to core test suites including `DescriptionVisibility`, `LineageRightPanel`, `PlatformLineage`, `UsersPagination`, and `DataMarketplace` tests.

<sub>This will update automatically on new commits.</sub>

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds the `@basic` tag (via `PLAYWRIGHT_BASIC_TEST_TAG_OBJ`) to nine Playwright E2E test spec files so that these tests can be included when the CI shard that filters on `@basic` runs, helping to balance test distribution across shards.

- The tag is applied consistently: as a direct `test.describe` / `test` option object when no prior tags exist, and as an appended string (`PLAYWRIGHT_BASIC_TEST_TAG_OBJ.tag`) inside existing tag arrays where other domain tags are already present.
- No test logic, assertions, or setup/teardown code was changed — only the `@basic` annotation was added.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

All changes are confined to Playwright test annotation metadata; no production code, application logic, or test assertions are modified.

Every changed file only gains an import and a tag argument. The two tagging patterns used (passing the full object vs. appending `.tag` to an existing array) are both correct for Playwright's API. No test assertions, setup hooks, or teardown logic were altered, making accidental breakage extremely unlikely.

No files require special attention.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DataQuality/TableTestCasePagination.spec.ts | Added @basic tag to the existing @Features/@Observability tag array for the Data Quality pagination describe block. |
| openmetadata-ui/src/main/resources/ui/playwright/e2e/Flow/PlatformLineage.spec.ts | Restructured the lone test() call to accept PLAYWRIGHT_BASIC_TEST_TAG_OBJ as the options argument; logic unchanged. |
| openmetadata-ui/src/main/resources/ui/playwright/e2e/Flow/ServiceDocPanel.spec.ts | Added PLAYWRIGHT_BASIC_TEST_TAG_OBJ as the second argument to test.describe; no functional change. |
| openmetadata-ui/src/main/resources/ui/playwright/e2e/Flow/UsersPagination.spec.ts | Added @basic tag to the inner test() call for pagination; the outer describe remains untagged, which is intentional. |
| openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/DataMarketplace.spec.ts | Added @basic tag to the @Pages/@Discovery tag array for the Data Marketplace Core describe block. |
| openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/DataMarketplaceAnnouncements.spec.ts | Added @basic tag to the @Pages/@Discovery tag array for the Data Marketplace Announcements describe block. |
| openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/DataMarketplacePermissions.spec.ts | Added @basic tag to the @Pages/@Discovery tag array for the Data Marketplace Permissions describe block. |
| openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/DescriptionVisibility.spec.ts | Wrapped the Long Description Visibility describe block with PLAYWRIGHT_BASIC_TEST_TAG_OBJ; indentation adjusted uniformly, no logic altered. |
| openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/Lineage/LineageRightPanel.spec.ts | Added PLAYWRIGHT_BASIC_TEST_TAG_OBJ to the first describe block (supported entity types); the second describe block (unsupported types) intentionally left untagged. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[CI Playwright run] --> B{Shard filter}
    B -->|Shard 1 — @basic| C["Tests now tagged @basic\n(9 spec files in this PR)"]
    B -->|Other shards| D[Other tagged tests]
    C --> E[TableTestCasePagination\nPlatformLineage\nServiceDocPanel\nUsersPagination\nDataMarketplace x3\nDescriptionVisibility\nLineageRightPanel]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[CI Playwright run] --> B{Shard filter}
    B -->|Shard 1 — @basic| C["Tests now tagged @basic\n(9 spec files in this PR)"]
    B -->|Other shards| D[Other tagged tests]
    C --> E[TableTestCasePagination\nPlatformLineage\nServiceDocPanel\nUsersPagination\nDataMarketplace x3\nDescriptionVisibility\nLineageRightPanel]
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["chore(test): balance shards 1 to pull mo..."](https://github.com/open-metadata/openmetadata/commit/8e8afe9f9395d566d06d05e0fa0adb4ac14af2fb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40930583)</sub>

<!-- /greptile_comment -->