### PR TITLE
Fixes #29520: [Oracle] preserve CTAS sqlQuery on lineage patch and fix SP name parsing

### DIFF
--- a/ingestion/src/metadata/ingestion/ometa/mixins/lineage_mixin.py
+++ b/ingestion/src/metadata/ingestion/ometa/mixins/lineage_mixin.py
@@ -316,6 +316,8 @@ class OMetaLineageMixin(Generic[T]):
                         if edge["edge"].get("pipeline")
                         else None
                     )
+                    # sqlQuery is intentionally left out so it defaults to None: that forces build_patch
+                    # to add/update the incoming query. Do not populate it from the stored edge here.
                     original = LineageDetails.model_validate(
                         {
                             "columnsLineage": [

--- a/ingestion/src/metadata/ingestion/ometa/mixins/lineage_mixin.py
+++ b/ingestion/src/metadata/ingestion/ometa/mixins/lineage_mixin.py
@@ -248,7 +248,9 @@ class OMetaLineageMixin(Generic[T]):
                         if edge["edge"].get("pipeline")
                         else None
                     )
-                    original.edge.lineageDetails.sqlQuery = edge["edge"].get("sqlQuery")
+                    # `original` mirrors `data`, so build_patch would see no sqlQuery diff. Null it so
+                    # the incoming query is added/updated, while a missing one keeps the stored value.
+                    original.edge.lineageDetails.sqlQuery = None
                     # merge the original and new column level lineage
                     data.edge.lineageDetails.columnsLineage = self._merge_column_lineage(
                         original.edge.lineageDetails.columnsLineage,
@@ -314,14 +316,12 @@ class OMetaLineageMixin(Generic[T]):
                         if edge["edge"].get("pipeline")
                         else None
                     )
-                    original_sql_query = edge["edge"].get("sqlQuery")
                     original = LineageDetails.model_validate(
                         {
                             "columnsLineage": [
                                 ColumnLineage.model_validate(column_lineage) for column_lineage in original_columns
                             ],
                             "pipeline": original_pipeline,
-                            "sqlQuery": original_sql_query,
                         }
                     )
                     updated_columns = [

--- a/ingestion/src/metadata/ingestion/ometa/mixins/lineage_mixin.py
+++ b/ingestion/src/metadata/ingestion/ometa/mixins/lineage_mixin.py
@@ -248,6 +248,7 @@ class OMetaLineageMixin(Generic[T]):
                         if edge["edge"].get("pipeline")
                         else None
                     )
+                    original.edge.lineageDetails.sqlQuery = edge["edge"].get("sqlQuery")
                     # merge the original and new column level lineage
                     data.edge.lineageDetails.columnsLineage = self._merge_column_lineage(
                         original.edge.lineageDetails.columnsLineage,
@@ -313,12 +314,14 @@ class OMetaLineageMixin(Generic[T]):
                         if edge["edge"].get("pipeline")
                         else None
                     )
+                    original_sql_query = edge["edge"].get("sqlQuery")
                     original = LineageDetails.model_validate(
                         {
                             "columnsLineage": [
                                 ColumnLineage.model_validate(column_lineage) for column_lineage in original_columns
                             ],
                             "pipeline": original_pipeline,
+                            "sqlQuery": original_sql_query,
                         }
                     )
                     updated_columns = [
@@ -408,7 +411,7 @@ class OMetaLineageMixin(Generic[T]):
             bool: True if the patch operation is successful, False otherwise.
         """
         try:
-            allowed_fields = {"columnsLineage": True, "pipeline": True}
+            allowed_fields = {"columnsLineage": True, "pipeline": True, "sqlQuery": True}
             patch = build_patch(
                 source=original.edge.lineageDetails,
                 destination=updated.edge.lineageDetails,
@@ -441,7 +444,7 @@ class OMetaLineageMixin(Generic[T]):
         updated: LineageDetails,
     ) -> Optional[bool]:  # noqa: UP045
         try:
-            allowed_fields = {"columnsLineage": True, "pipeline": True}
+            allowed_fields = {"columnsLineage": True, "pipeline": True, "sqlQuery": True}
             patch = build_patch(
                 source=original,
                 destination=updated,

--- a/ingestion/src/metadata/ingestion/ometa/mixins/lineage_mixin.py
+++ b/ingestion/src/metadata/ingestion/ometa/mixins/lineage_mixin.py
@@ -250,7 +250,7 @@ class OMetaLineageMixin(Generic[T]):
                     )
                     # `original` mirrors `data`, so build_patch would see no sqlQuery diff. Null it so
                     # the incoming query is added/updated, while a missing one keeps the stored value.
-                    original.edge.lineageDetails.sqlQuery = None
+                    original.edge.lineageDetails.sqlQuery = None  # pyright: ignore[reportOptionalMemberAccess]
                     # merge the original and new column level lineage
                     data.edge.lineageDetails.columnsLineage = self._merge_column_lineage(
                         original.edge.lineageDetails.columnsLineage,

--- a/ingestion/src/metadata/utils/stored_procedures.py
+++ b/ingestion/src/metadata/utils/stored_procedures.py
@@ -19,7 +19,7 @@ from metadata.utils.logger import utils_logger
 
 logger = utils_logger()
 
-NAME_PATTERN = r"(?<=call)(.*)(?=\()|(?<=begin)(.*)(?=\()|(?<=begin)(.*)(?=;\s*end)"
+NAME_PATTERN = r"(?<=call)(.*?)(?=\()|(?<=begin)(.*?)(?=\()|(?<=begin)(.*?)(?=;\s*end)"
 
 
 def get_procedure_name_from_call(query_text: str, sensitive_match: bool = False) -> Optional[str]:  # noqa: UP045

--- a/ingestion/tests/unit/ometa/test_lineage_sql_query_patch.py
+++ b/ingestion/tests/unit/ometa/test_lineage_sql_query_patch.py
@@ -11,10 +11,10 @@
 """
 Lineage sqlQuery patch tests (issue #29520).
 
-Patching an existing lineage edge must add or update the incoming run's sqlQuery,
-never drop an already-stored query, and never crash build_patch on an edge that
-already carries a query. Covered through both public entry points, add_lineage
-(by id) and add_lineage_by_name (by fqn).
+Patching an existing lineage edge must add or update the incoming sqlQuery, never
+drop an already-stored query, and never crash build_patch on an edge that already
+carries a query. Covered through both public entry points, add_lineage (by id) and
+add_lineage_by_name (by fqn).
 """
 
 import json
@@ -35,9 +35,9 @@ INCOMING_QUERY = "SELECT 2 FROM source_table"
 
 
 class StubbedLineage(OMetaLineageMixin):
-    """OMetaLineageMixin with only the HTTP boundaries stubbed, so add_lineage /
-    add_lineage_by_name run the real reconstruction, patch_lineage_edge* and
-    build_patch. `existing_edge` is what the server returns for the edge lookup."""
+    """OMetaLineageMixin with only the HTTP calls stubbed, so add_lineage and
+    add_lineage_by_name exercise the real patch reconstruction and build_patch.
+    `existing_edge` is what the edge lookup returns."""
 
     def __init__(self, existing_edge):
         self.client = MagicMock()
@@ -86,7 +86,7 @@ def sql_query_ops(client):
     return [op for op in patch if op.get("path") == "/sqlQuery"]
 
 
-# stored query on the edge, incoming query on the run, expected query after patch
+# (stored query on the existing edge, incoming query, expected query after patch)
 PATCH_CASES = [
     pytest.param(None, INCOMING_QUERY, INCOMING_QUERY, id="backfill-onto-query-less-edge"),
     pytest.param(STORED_QUERY, INCOMING_QUERY, INCOMING_QUERY, id="update-existing-query"),

--- a/ingestion/tests/unit/ometa/test_lineage_sql_query_patch.py
+++ b/ingestion/tests/unit/ometa/test_lineage_sql_query_patch.py
@@ -9,49 +9,133 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 """
-Test that a lineage edge's sqlQuery is preserved when patching an existing edge.
+Lineage sqlQuery patch tests (issue #29520).
 
-Regression for the CTAS lineage gap where the table edge is created but the SQL
-query is dropped on subsequent runs because the patch allowlist excluded sqlQuery.
+Patching an existing lineage edge must add or update the incoming run's sqlQuery,
+never drop an already-stored query, and never crash build_patch on an edge that
+already carries a query. Covered through both public entry points, add_lineage
+(by id) and add_lineage_by_name (by fqn).
 """
 
-from types import SimpleNamespace
-from unittest.mock import Mock
+import json
+from unittest.mock import MagicMock
 
-from metadata.generated.schema.type.entityLineage import LineageDetails
+import pytest
+
+from metadata.generated.schema.api.lineage.addLineage import AddLineageRequest
+from metadata.generated.schema.type.entityLineage import EntitiesEdge, LineageDetails
 from metadata.generated.schema.type.entityLineage import Source as LineageSource
+from metadata.generated.schema.type.entityReference import EntityReference
 from metadata.ingestion.ometa.mixins.lineage_mixin import OMetaLineageMixin
 
-CTAS_QUERY = "CREATE TABLE t AS SELECT * FROM s"
+FROM_ID = "d311bdf2-c4a9-4be3-9937-3b26309759af"
+TO_ID = "abea43f7-ccc2-4daf-9dfb-115549461244"
+STORED_QUERY = "SELECT 1 FROM source_table"
+INCOMING_QUERY = "SELECT 2 FROM source_table"
 
 
-def _fake_ometa():
-    """Mixin instance stand-in with only the HTTP client (a boundary) stubbed."""
-    return SimpleNamespace(
-        client=Mock(),
-        _lineage_edge_path_by_name=OMetaLineageMixin._lineage_edge_path_by_name,
+class StubbedLineage(OMetaLineageMixin):
+    """OMetaLineageMixin with only the HTTP boundaries stubbed, so add_lineage /
+    add_lineage_by_name run the real reconstruction, patch_lineage_edge* and
+    build_patch. `existing_edge` is what the server returns for the edge lookup."""
+
+    def __init__(self, existing_edge):
+        self.client = MagicMock()
+        self._existing_edge = existing_edge
+
+    def _get_lineage_edge_for_references(self, from_entity, to_entity):
+        return self._existing_edge
+
+    def get_lineage_edge_by_name(self, *args, **kwargs):
+        return self._existing_edge
+
+    def get_suffix(self, entity):
+        return "/lineage"
+
+    def get_lineage_by_id(self, *args, **kwargs):
+        return {}
+
+    def get_lineage_by_name(self, *args, **kwargs):
+        return {}
+
+    def _update_cache(self, *args, **kwargs):
+        return None
+
+
+def edge_lookup(stored_query=None):
+    """Server edge-lookup payload, optionally carrying an already-stored sqlQuery."""
+    details = {"columnsLineage": []}
+    if stored_query is not None:
+        details["sqlQuery"] = stored_query
+    return {"edge": details}
+
+
+def incoming_details(sql_query):
+    return (
+        LineageDetails(source=LineageSource.QueryLineage, sqlQuery=sql_query)
+        if sql_query is not None
+        else LineageDetails(source=LineageSource.QueryLineage)
     )
 
 
-class TestLineageSqlQueryPatch:
-    """patch_lineage_edge_by_name must carry sqlQuery onto an existing edge."""
+def sql_query_ops(client):
+    """JSON-patch ops targeting /sqlQuery from the single client.patch call."""
+    if not client.patch.called:
+        return []
+    patch = json.loads(client.patch.call_args.kwargs["data"])
+    return [op for op in patch if op.get("path") == "/sqlQuery"]
 
-    def test_sql_query_is_patched_onto_existing_edge_without_query(self):
-        fake = _fake_ometa()
-        original = LineageDetails(source=LineageSource.QueryLineage)
-        updated = LineageDetails(sqlQuery=CTAS_QUERY, source=LineageSource.QueryLineage)
 
-        OMetaLineageMixin.patch_lineage_edge_by_name(
-            fake,
-            from_entity_fqn="svc.db.sch.s",
-            from_entity_type="table",
-            to_entity_fqn="svc.db.sch.t",
-            to_entity_type="table",
-            original=original,
-            updated=updated,
+# stored query on the edge, incoming query on the run, expected query after patch
+PATCH_CASES = [
+    pytest.param(None, INCOMING_QUERY, INCOMING_QUERY, id="backfill-onto-query-less-edge"),
+    pytest.param(STORED_QUERY, INCOMING_QUERY, INCOMING_QUERY, id="update-existing-query"),
+    pytest.param(STORED_QUERY, None, None, id="keep-stored-query-when-incoming-empty"),
+]
+
+
+def assert_patched(client, expected_query):
+    assert not client.put.called
+    if expected_query is None:
+        assert sql_query_ops(client) == []
+    else:
+        assert sql_query_ops(client) == [{"op": "add", "path": "/sqlQuery", "value": expected_query}]
+
+
+class TestAddLineageSqlQuery:
+    """add_lineage (by id) reconstruction adds/updates the incoming query, keeps a
+    stored one when the run has none, and never crashes on an edge with a query."""
+
+    @pytest.mark.parametrize("stored, incoming, expected", PATCH_CASES)
+    def test_patches_sql_query(self, stored, incoming, expected):
+        service = StubbedLineage(edge_lookup(stored))
+        request = AddLineageRequest(
+            edge=EntitiesEdge(
+                fromEntity=EntityReference(id=FROM_ID, type="table"),
+                toEntity=EntityReference(id=TO_ID, type="table"),
+                lineageDetails=incoming_details(incoming),
+            )
         )
 
-        fake.client.patch.assert_called_once()
-        sent = str(fake.client.patch.call_args.kwargs.get("data"))
-        assert "sqlQuery" in sent
-        assert CTAS_QUERY in sent
+        service.add_lineage(request, check_patch=True)
+
+        assert_patched(service.client, expected)
+
+
+class TestAddLineageByNameSqlQuery:
+    """Same reconstruction through the add_lineage_by_name (by fqn) entry point."""
+
+    @pytest.mark.parametrize("stored, incoming, expected", PATCH_CASES)
+    def test_patches_sql_query(self, stored, incoming, expected):
+        service = StubbedLineage(edge_lookup(stored))
+
+        service.add_lineage_by_name(
+            from_entity_fqn="svc.db.sch.source",
+            from_entity_type="table",
+            to_entity_fqn="svc.db.sch.target",
+            to_entity_type="table",
+            lineage_details=incoming_details(incoming),
+            check_patch=True,
+        )
+
+        assert_patched(service.client, expected)

--- a/ingestion/tests/unit/ometa/test_lineage_sql_query_patch.py
+++ b/ingestion/tests/unit/ometa/test_lineage_sql_query_patch.py
@@ -1,0 +1,57 @@
+#  Copyright 2025 Collate
+#  Licensed under the Collate Community License, Version 1.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  https://github.com/open-metadata/OpenMetadata/blob/main/ingestion/LICENSE
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+"""
+Test that a lineage edge's sqlQuery is preserved when patching an existing edge.
+
+Regression for the CTAS lineage gap where the table edge is created but the SQL
+query is dropped on subsequent runs because the patch allowlist excluded sqlQuery.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+from metadata.generated.schema.type.entityLineage import LineageDetails
+from metadata.generated.schema.type.entityLineage import Source as LineageSource
+from metadata.ingestion.ometa.mixins.lineage_mixin import OMetaLineageMixin
+
+CTAS_QUERY = "CREATE TABLE t AS SELECT * FROM s"
+
+
+def _fake_ometa():
+    """Mixin instance stand-in with only the HTTP client (a boundary) stubbed."""
+    return SimpleNamespace(
+        client=Mock(),
+        _lineage_edge_path_by_name=OMetaLineageMixin._lineage_edge_path_by_name,
+    )
+
+
+class TestLineageSqlQueryPatch:
+    """patch_lineage_edge_by_name must carry sqlQuery onto an existing edge."""
+
+    def test_sql_query_is_patched_onto_existing_edge_without_query(self):
+        fake = _fake_ometa()
+        original = LineageDetails(source=LineageSource.QueryLineage)
+        updated = LineageDetails(sqlQuery=CTAS_QUERY, source=LineageSource.QueryLineage)
+
+        OMetaLineageMixin.patch_lineage_edge_by_name(
+            fake,
+            from_entity_fqn="svc.db.sch.s",
+            from_entity_type="table",
+            to_entity_fqn="svc.db.sch.t",
+            to_entity_type="table",
+            original=original,
+            updated=updated,
+        )
+
+        fake.client.patch.assert_called_once()
+        sent = str(fake.client.patch.call_args.kwargs.get("data"))
+        assert "sqlQuery" in sent
+        assert CTAS_QUERY in sent

--- a/ingestion/tests/unit/utils/test_stored_procedures.py
+++ b/ingestion/tests/unit/utils/test_stored_procedures.py
@@ -46,14 +46,10 @@ class TestStoredProcedures:
         """Oracle rewrites literal args as functions (e.g. TO_NUMBER(...)).
         The procedure name must still be parsed without capturing the argument."""
         assert (
-            get_procedure_name_from_call(query_text="BEGIN CDC.SP_INSERTA_NUMERO(TO_NUMBER(:1)); END;")
-            == "sp_inserta_numero"
+            get_procedure_name_from_call(query_text="BEGIN SALES.INSERT_NUMBER(TO_NUMBER(:1)); END;") == "insert_number"
         )
 
-        assert (
-            get_procedure_name_from_call(query_text="CALL CDC.SP_INSERTA_NUMERO(TO_NUMBER(12345))")
-            == "sp_inserta_numero"
-        )
+        assert get_procedure_name_from_call(query_text="CALL SALES.INSERT_NUMBER(TO_NUMBER(12345))") == "insert_number"
 
         assert (
             get_procedure_name_from_call(query_text="BEGIN SCHEMA.PROC(TO_DATE('2024-01-01'), NVL(x, 0)); END;")

--- a/ingestion/tests/unit/utils/test_stored_procedures.py
+++ b/ingestion/tests/unit/utils/test_stored_procedures.py
@@ -12,88 +12,50 @@
 Test Stored Procedures Utils
 """
 
-from unittest import TestCase
-
 from metadata.utils.stored_procedures import get_procedure_name_from_call
 
 
-class StoredProceduresTests(TestCase):
+class TestStoredProcedures:
     """Group stored procedures tests"""
 
     def test_get_procedure_name_from_call(self):
         """Check that we properly parse CALL queries"""
-        self.assertEqual(
-            get_procedure_name_from_call(
-                query_text="CALL db.schema.procedure_name(...)",
-            ),
-            "procedure_name",
+        assert get_procedure_name_from_call(query_text="CALL db.schema.procedure_name(...)") == "procedure_name"
+
+        assert get_procedure_name_from_call(query_text="CALL schema.procedure_name(...)") == "procedure_name"
+
+        assert get_procedure_name_from_call(query_text="CALL procedure_name(...)") == "procedure_name"
+
+        assert get_procedure_name_from_call(query_text="CALL DB.SCHEMA.PROCEDURE_NAME(...)") == "procedure_name"
+
+        assert get_procedure_name_from_call(query_text="BEGIN DB.SCHEMA.PROCEDURE_NAME; END;") == "procedure_name"
+
+        assert get_procedure_name_from_call(query_text="BEGIN schema.procedure_name; END;") == "procedure_name"
+
+        assert get_procedure_name_from_call(query_text="BEGIN procedure_name; END;") == "procedure_name"
+
+        assert get_procedure_name_from_call(query_text="BEGIN DB.SCHEMA.PROCEDURE_NAME(...); END;") == "procedure_name"
+
+        assert get_procedure_name_from_call(query_text="BEGIN schema.procedure_name(...); END;") == "procedure_name"
+
+        assert get_procedure_name_from_call(query_text="BEGIN procedure_name(...); END;") == "procedure_name"
+
+        assert get_procedure_name_from_call(query_text="something very random") is None
+
+    def test_get_procedure_name_with_nested_function_args(self):
+        """Oracle rewrites literal args as functions (e.g. TO_NUMBER(...)).
+        The procedure name must still be parsed without capturing the argument."""
+        assert (
+            get_procedure_name_from_call(query_text="BEGIN CDC.SP_INSERTA_NUMERO(TO_NUMBER(:1)); END;")
+            == "sp_inserta_numero"
         )
 
-        self.assertEqual(
-            get_procedure_name_from_call(
-                query_text="CALL schema.procedure_name(...)",
-            ),
-            "procedure_name",
+        assert (
+            get_procedure_name_from_call(query_text="CALL CDC.SP_INSERTA_NUMERO(TO_NUMBER(12345))")
+            == "sp_inserta_numero"
         )
 
-        self.assertEqual(
-            get_procedure_name_from_call(
-                query_text="CALL procedure_name(...)",
-            ),
-            "procedure_name",
-        )
-
-        self.assertEqual(
-            get_procedure_name_from_call(
-                query_text="CALL DB.SCHEMA.PROCEDURE_NAME(...)",
-            ),
-            "procedure_name",
-        )
-
-        self.assertEqual(
-            get_procedure_name_from_call(
-                query_text="BEGIN DB.SCHEMA.PROCEDURE_NAME; END;",
-            ),
-            "procedure_name",
-        )
-
-        self.assertEqual(
-            get_procedure_name_from_call(
-                query_text="BEGIN schema.procedure_name; END;",
-            ),
-            "procedure_name",
-        )
-
-        self.assertEqual(
-            get_procedure_name_from_call(
-                query_text="BEGIN procedure_name; END;",
-            ),
-            "procedure_name",
-        )
-
-        self.assertEqual(
-            get_procedure_name_from_call(
-                query_text="BEGIN DB.SCHEMA.PROCEDURE_NAME(...); END;",
-            ),
-            "procedure_name",
-        )
-
-        self.assertEqual(
-            get_procedure_name_from_call(
-                query_text="BEGIN schema.procedure_name(...); END;",
-            ),
-            "procedure_name",
-        )
-
-        self.assertEqual(
-            get_procedure_name_from_call(
-                query_text="BEGIN procedure_name(...); END;",
-            ),
-            "procedure_name",
-        )
-
-        self.assertIsNone(
-            get_procedure_name_from_call(
-                query_text="something very random",
-            )
+        assert (
+            get_procedure_name_from_call(query_text="BEGIN SCHEMA.PROC(TO_DATE('2024-01-01'), NVL(x, 0)); END;")
+            == "proc"
         )


### PR DESCRIPTION
### Describe your changes:

Fixes #29520

I worked on two Oracle stored procedure lineage issues, both ingestion-side:

1. **Procedure name parsing.** When Oracle rewrites a call argument as a function (e.g. `BEGIN SALES.INSERT_NUMBER(TO_NUMBER(:1)); END;`), the greedy `NAME_PATTERN` regex captured up to the last `(` and produced `insert_number(to_number`, which never matched the stored procedure entity, so no lineage was built. Made the three captures non-greedy (`.*?`) so the name parses correctly regardless of the argument expression.

2. **CTAS sqlQuery not updated on an existing edge.** The `sqlQuery` is set when an edge is first created, but the patch flow for an existing edge only allowed `columnsLineage` and `pipeline`, so a query was never added or updated on an edge that already existed. Added `sqlQuery` to the patch allowlist in both `patch_lineage_edge` and `patch_lineage_edge_by_name`, and forced the diff (the patch `original` carries no `sqlQuery`) so the incoming query is added or updated. An edge update that carries no query leaves the stored query untouched, so it is never removed.

#
### Type of change:
- [x] Bug fix

#
### High-level design:

N/A — small change.

#
### Tests:

#### Use cases covered
- An Oracle SP call whose argument is a function (`TO_NUMBER(...)`, `TO_DATE(...)`, `NVL(...)`) is matched to its stored procedure entity for lineage.
- A query-lineage edge that already exists gets its `sqlQuery` added or updated on re-ingestion; an update that carries no query leaves the existing query untouched.

#### Unit tests
- [x] Added unit tests for the changed logic.
- Files added/updated:
  - `ingestion/tests/unit/utils/test_stored_procedures.py` (nested function-call args; converted to pytest)
  - `ingestion/tests/unit/ometa/test_lineage_sql_query_patch.py` (patch carries `sqlQuery` onto an existing edge)
- Run: `make unit_ingestion`

#### Backend integration tests
- [x] Not applicable (no backend API changes).

#### Ingestion integration tests
- [x] Not applicable (covered by unit tests + manual live validation below).

#### Playwright (UI) tests
- [x] Not applicable (no UI changes).

#### Manual testing performed
1. Spun up Oracle (`gvenzl/oracle-free:23ai`) + a local OpenMetadata instance with a source table and two stored procedures, ran metadata + lineage ingestion.
2. A/B on an existing edge whose `sqlQuery` was empty: the released code left it empty after re-running lineage, the fixed code backfilled the query.

#
### UI screen recording / screenshots:

Not applicable.

#
### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] My PR title is `Fixes <issue-number>: <short explanation>`
- [x] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have added tests and listed them above.

Bug fix
- [x] I have added a test that covers the exact scenario we are fixing.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes two Oracle stored procedure lineage bugs: a greedy regex that incorrectly parsed procedure names when arguments contained nested function calls (e.g. `TO_NUMBER(:1)`), and a patch flow that never propagated `sqlQuery` to already-existing lineage edges.

- **Regex fix** (`stored_procedures.py`): Three `.*` captures in `NAME_PATTERN` are made non-greedy (`.*?`), so `BEGIN SALES.INSERT_NUMBER(TO_NUMBER(:1)); END;` correctly resolves to `insert_number` instead of the malformed `insert_number(to_number`.
- **Lineage patch fix** (`lineage_mixin.py`): `sqlQuery` is added to `allowed_fields` in both `patch_lineage_edge` and `patch_lineage_edge_by_name`; `original.edge.lineageDetails.sqlQuery` is explicitly nulled before calling `build_patch` in the `add_lineage` path so an incoming query always produces a diff, while a run with no query leaves the stored value untouched.
- **Tests**: New pytest test files cover nested-function-arg parsing and all three `sqlQuery` patch scenarios (backfill, update, and preserve) via both entry points.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — both changes are narrow, well-tested bug fixes with no API surface changes.

The regex change is a minimal, targeted fix that only affects how Oracle procedure names are extracted from nested-function-argument call expressions; all existing test cases still pass and three new ones are added. The lineage patch change correctly threads sqlQuery through the allowed-fields list and nulls the original value before diffing, covering the backfill, update, and preserve cases in both add_lineage entry points. No backend schema or API changes are involved.

No files require special attention.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| ingestion/src/metadata/utils/stored_procedures.py | Single-character regex change (greedy .* → non-greedy .*?) correctly fixes procedure name parsing when arguments contain nested function calls; no other logic changed. |
| ingestion/src/metadata/ingestion/ometa/mixins/lineage_mixin.py | Adds sqlQuery to allowed_fields in both patch methods and explicitly nulls original.sqlQuery before diffing so incoming queries are always written; the symmetrical comment in add_lineage_by_name explains the implicit null. Logic is correct and well-commented. |
| ingestion/tests/unit/ometa/test_lineage_sql_query_patch.py | New test file covering all three sqlQuery patch scenarios (backfill, update, preserve) through both add_lineage and add_lineage_by_name entry points; uses JSON-patch introspection to verify exact ops. |
| ingestion/tests/unit/utils/test_stored_procedures.py | Migrated from unittest.TestCase to plain pytest class; added new test method for nested-function-arg Oracle patterns, covering TO_NUMBER, TO_DATE, and multi-arg NVL cases. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[add_lineage / add_lineage_by_name\ncalled with check_patch=True] --> B{Existing edge\nfound?}
    B -- No --> C[PUT full lineage edge]
    B -- Yes --> D[Build original LineageDetails\ncolumnsLineage + pipeline only\nsqlQuery = None explicitly]
    D --> E[Merge column lineage]
    E --> F[build_patch\nallowed_fields: columnsLineage\npipeline, sqlQuery]
    F --> G{incoming\nsqlQuery set?}
    G -- Yes --> H[Patch op: add/replace\n/sqlQuery = incoming value]
    G -- No --> I[No sqlQuery patch op\nstored value preserved]
    H --> J[PATCH lineage edge]
    I --> J
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[add_lineage / add_lineage_by_name\ncalled with check_patch=True] --> B{Existing edge\nfound?}
    B -- No --> C[PUT full lineage edge]
    B -- Yes --> D[Build original LineageDetails\ncolumnsLineage + pipeline only\nsqlQuery = None explicitly]
    D --> E[Merge column lineage]
    E --> F[build_patch\nallowed_fields: columnsLineage\npipeline, sqlQuery]
    F --> G{incoming\nsqlQuery set?}
    G -- Yes --> H[Patch op: add/replace\n/sqlQuery = incoming value]
    G -- No --> I[No sqlQuery patch op\nstored value preserved]
    H --> J[PATCH lineage edge]
    I --> J
```

</a>
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `ingestion/src/metadata/ingestion/ometa/mixins/lineage_mixin.py`, line 319-326 ([link](https://github.com/open-metadata/openmetadata/blob/7919d27ab920401780760dca53e7cef70f38f42c/ingestion/src/metadata/ingestion/ometa/mixins/lineage_mixin.py#L319-L326)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Implicit sqlQuery=None relies on construction staying partial**

   The `add_lineage_by_name` path achieves the "force a diff" effect because `original` is constructed without `sqlQuery`, so it defaults to `None`. This is correct today, but is fragile: if a future change loads more fields from the stored edge into this dict (e.g. to preserve `source` or other `LineageDetails` fields), `sqlQuery` could inadvertently be populated from the stored edge, causing `build_patch` to see no diff again and silently dropping the incoming query. The explicit `original.edge.lineageDetails.sqlQuery = None` used in the parallel `add_lineage` path is more defensive. Consider adding the same explicit reset here — or at minimum a comment explaining the dependency.

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (3): Last reviewed commit: ["Document by-name sqlQuery reset"](https://github.com/open-metadata/openmetadata/commit/42047bd0650c982da0ce4ab19787c9579aac2853) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41021817)</sub>

<!-- /greptile_comment -->