### PR TITLE
Fixes #29520: [Lineage] render query-lineage SQL on the edge drawer

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/Entity/EntityInfoDrawer/EdgeInfoDrawer.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Entity/EntityInfoDrawer/EdgeInfoDrawer.component.tsx
@@ -96,6 +96,24 @@ const EdgeInfoDrawer = ({
     return Boolean(sourceHandle && targetHandle);
   }, [edge]);
 
+  const resolvedSqlQuery = useMemo(() => {
+    const inlineQuery = edgeEntity?.sqlQuery;
+    if (inlineQuery) {
+      return inlineQuery;
+    }
+
+    // When the same SQL appears on multiple edges it is deduped into the target
+    // node's lineageSqlQueries map and referenced from the edge by sqlQueryKey.
+    const sqlQueryKey = edgeEntity?.sqlQueryKey;
+    if (!sqlQueryKey) {
+      return '';
+    }
+
+    const targetNode = nodes.find((node) => node.id === edge.target);
+
+    return targetNode?.data?.node?.lineageSqlQueries?.[sqlQueryKey] ?? '';
+  }, [edgeEntity, nodes, edge.target]);
+
   const onDescriptionUpdate = useCallback(
     async (updatedHTML: string) => {
       if (edgeEntity?.description !== updatedHTML && edge) {
@@ -360,8 +378,8 @@ const EdgeInfoDrawer = ({
   useEffect(() => {
     setIsLoading(true);
     getEdgeInfo();
-    setMysqlQuery(edge.data.edge?.sqlQuery);
-  }, [edge, visible, nodes]);
+    setMysqlQuery(resolvedSqlQuery);
+  }, [edge, visible, nodes, resolvedSqlQuery]);
 
   return (
     <>

--- a/openmetadata-ui/src/main/resources/ui/src/components/Entity/EntityInfoDrawer/EdgeInfoDrawer.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Entity/EntityInfoDrawer/EdgeInfoDrawer.test.tsx
@@ -266,6 +266,42 @@ describe('EdgeInfoDrawer Component', () => {
     expect(props?.componentType).toBe('');
   });
 
+  it('should resolve sqlQuery from target node lineageSqlQueries when edge only has sqlQueryKey', async () => {
+    const nodes = createMockNodes();
+    (
+      nodes[1].data.node as { lineageSqlQueries?: Record<string, string> }
+    ).lineageSqlQueries = {
+      '1': 'CREATE TABLE customers AS SELECT * FROM stg_orders',
+    };
+
+    render(
+      <EdgeInfoDrawer
+        {...mockEdgeInfoDrawer}
+        edge={
+          {
+            ...mockEdgeInfoDrawer.edge,
+            data: {
+              ...mockEdgeInfoDrawer.edge.data,
+              edge: {
+                ...mockEdgeInfoDrawer.edge.data?.edge,
+                sqlQuery: null,
+                sqlQueryKey: '1',
+              },
+            },
+          } as Edge
+        }
+        nodes={nodes}
+      />
+    );
+
+    expect(
+      await screen.findByText('SchemaEditor.component')
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText('server.no-query-available')
+    ).not.toBeInTheDocument();
+  });
+
   it('should format edge audit values from non-empty user and time parts', async () => {
     render(
       <EdgeInfoDrawer

--- a/openmetadata-ui/src/main/resources/ui/src/components/Entity/EntityInfoDrawer/EdgeInfoDrawer.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Entity/EntityInfoDrawer/EdgeInfoDrawer.test.tsx
@@ -298,9 +298,10 @@ describe('EdgeInfoDrawer Component', () => {
       />
     );
 
-    expect(
-      await screen.findByText('SchemaEditor.component')
-    ).toBeInTheDocument();
+    expect(await screen.findByTestId('sql-editor')).toHaveAttribute(
+      'data-value',
+      'CREATE TABLE customers AS SELECT * FROM stg_orders'
+    );
     expect(
       screen.queryByText('server.no-query-available')
     ).not.toBeInTheDocument();

--- a/openmetadata-ui/src/main/resources/ui/src/components/Entity/EntityInfoDrawer/EdgeInfoDrawer.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Entity/EntityInfoDrawer/EdgeInfoDrawer.test.tsx
@@ -68,7 +68,7 @@ jest.mock('../../common/Loader/Loader', () =>
 );
 
 jest.mock('../../Database/SchemaEditor/SchemaEditor', () => {
-  return jest.fn().mockImplementation(({ value }: { value: string }) => (
+  return jest.fn().mockImplementation(({ value }: { value?: string }) => (
     <div data-testid="sql-editor" data-value={value}>
       SchemaEditor.component
     </div>

--- a/openmetadata-ui/src/main/resources/ui/src/components/Entity/EntityInfoDrawer/EdgeInfoDrawer.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Entity/EntityInfoDrawer/EdgeInfoDrawer.test.tsx
@@ -68,7 +68,11 @@ jest.mock('../../common/Loader/Loader', () =>
 );
 
 jest.mock('../../Database/SchemaEditor/SchemaEditor', () => {
-  return jest.fn().mockImplementation(() => <div>SchemaEditor.component</div>);
+  return jest.fn().mockImplementation(({ value }: { value: string }) => (
+    <div data-testid="sql-editor" data-value={value}>
+      SchemaEditor.component
+    </div>
+  ));
 });
 
 jest.mock('../../Modals/ModalWithQueryEditor/ModalWithQueryEditor', () => {
@@ -300,6 +304,69 @@ describe('EdgeInfoDrawer Component', () => {
     expect(
       screen.queryByText('server.no-query-available')
     ).not.toBeInTheDocument();
+  });
+
+  it('should prefer the inline sqlQuery over the target node lineageSqlQueries map', async () => {
+    const nodes = createMockNodes();
+    (
+      nodes[1].data.node as { lineageSqlQueries?: Record<string, string> }
+    ).lineageSqlQueries = { '1': 'SELECT * FROM keyed_map' };
+
+    render(
+      <EdgeInfoDrawer
+        {...mockEdgeInfoDrawer}
+        edge={
+          {
+            ...mockEdgeInfoDrawer.edge,
+            data: {
+              ...mockEdgeInfoDrawer.edge.data,
+              edge: {
+                ...mockEdgeInfoDrawer.edge.data?.edge,
+                sqlQuery: 'SELECT * FROM inline_edge',
+                sqlQueryKey: '1',
+              },
+            },
+          } as Edge
+        }
+        nodes={nodes}
+      />
+    );
+
+    expect(await screen.findByTestId('sql-editor')).toHaveAttribute(
+      'data-value',
+      'SELECT * FROM inline_edge'
+    );
+  });
+
+  it('should show no query when the sqlQueryKey is not in the target node map', async () => {
+    const nodes = createMockNodes();
+    (
+      nodes[1].data.node as { lineageSqlQueries?: Record<string, string> }
+    ).lineageSqlQueries = { '1': 'SELECT * FROM keyed_map' };
+
+    render(
+      <EdgeInfoDrawer
+        {...mockEdgeInfoDrawer}
+        edge={
+          {
+            ...mockEdgeInfoDrawer.edge,
+            data: {
+              ...mockEdgeInfoDrawer.edge.data,
+              edge: {
+                ...mockEdgeInfoDrawer.edge.data?.edge,
+                sqlQuery: null,
+                sqlQueryKey: '99',
+              },
+            },
+          } as Edge
+        }
+        nodes={nodes}
+      />
+    );
+
+    expect(
+      await screen.findByText('server.no-query-available')
+    ).toBeInTheDocument();
   });
 
   it('should format edge audit values from non-empty user and time parts', async () => {

--- a/openmetadata-ui/src/main/resources/ui/src/utils/EntityLineageNodeUtils.test.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/EntityLineageNodeUtils.test.ts
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2025 Collate.
+ *  Copyright 2026 Collate.
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at

--- a/openmetadata-ui/src/main/resources/ui/src/utils/EntityLineageNodeUtils.test.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/EntityLineageNodeUtils.test.ts
@@ -1,0 +1,34 @@
+/*
+ *  Copyright 2025 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+import { EntityReference } from '../generated/type/entityReference';
+import { getNodeLineageData } from './EntityLineageNodeUtils';
+
+describe('getNodeLineageData', () => {
+  it('should keep lineageSqlQueries on the node so the edge drawer can resolve sqlQueryKey', () => {
+    const lineageSqlQueries = {
+      '1': 'CREATE TABLE t AS SELECT * FROM s',
+    };
+    const node = {
+      id: 'n1',
+      name: 'target',
+      fullyQualifiedName: 'svc.db.sch.target',
+      lineageSqlQueries,
+    } as unknown as EntityReference;
+
+    const result = getNodeLineageData(node) as {
+      lineageSqlQueries?: Record<string, string>;
+    };
+
+    expect(result.lineageSqlQueries).toEqual(lineageSqlQueries);
+  });
+});

--- a/openmetadata-ui/src/main/resources/ui/src/utils/EntityLineageNodeUtils.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/EntityLineageNodeUtils.ts
@@ -475,6 +475,7 @@ export const getNodeLineageData = (node: EntityReference) => {
       'database',
       'databaseSchema',
       'service',
+      'lineageSqlQueries',
     ]) as unknown as LineageEntityReference),
     flattenChildren: getFlattenChildrenFromEntity(node),
   };


### PR DESCRIPTION
### Describe your changes:

Fixes #29520

I worked on the lineage edge info drawer because query-lineage edges (CTAS, `INSERT ... SELECT`) showed **"No query available"** even though the SQL is in the lineage payload. The query is deduped into the target node's `lineageSqlQueries` map and referenced from the edge by `sqlQueryKey`, but the UI dropped that map from the node and the drawer only read the inline `edge.sqlQuery`:

- `getNodeLineageData` picked a fixed set of entity fields for each graph node and did not include `lineageSqlQueries`, so the map never reached the node.
- `EdgeInfoDrawer` read only the inline `edge.sqlQuery`.

Now the node keeps `lineageSqlQueries`, and the drawer resolves `sqlQueryKey` against it when there is no inline query. View lineage was unaffected since it stores the SQL inline on the edge.

#
### Type of change:
- [x] Bug fix

#
### High-level design:

N/A — small change.

#
### Tests:

#### Use cases covered
- Clicking a query-lineage edge (CTAS, `INSERT ... SELECT`) in an entity's Lineage tab shows its SQL in the Edge Information panel, instead of "No query available".
- The graph node keeps `lineageSqlQueries` (so the drawer can resolve `sqlQueryKey`), an inline `sqlQuery` still takes precedence, and an unknown key falls back to "No query available".

#### Unit tests
- [x] Added unit tests for the changed logic.
- Files added/updated:
  - `src/components/Entity/EntityInfoDrawer/EdgeInfoDrawer.test.tsx` (`sqlQueryKey` resolved from the target node's `lineageSqlQueries`; inline query takes precedence; unknown key → no query; existing no-query case still holds)
  - `src/utils/EntityLineageNodeUtils.test.ts` (`getNodeLineageData` keeps `lineageSqlQueries` on the node)
- Run: `yarn test EdgeInfoDrawer EntityLineageNodeUtils`

#### Backend integration tests
- [x] Not applicable (no backend changes).

#### Ingestion integration tests
- [x] Not applicable (no ingestion changes).

#### Playwright (UI) tests
- [ ] Not added in this PR (covered by the unit test above and manual verification).

#### Manual testing performed
1. Ran the UI dev server against a local OpenMetadata instance that had Oracle lineage ingested.
2. Opened the source table > Lineage, clicked the CTAS and `INSERT ... SELECT` edges, confirmed the SQL Query panel now renders the query (previously "No query available").

#
### UI screen recording / screenshots:

Before
<img width="1512" height="774" alt="image" src="https://github.com/user-attachments/assets/6b7403c9-c0bc-45ff-9cf1-aa6efec6fd0d" />

After
<img width="1512" height="773" alt="image" src="https://github.com/user-attachments/assets/ba38e74f-071b-4228-9a38-1e8a5debcb79" />


#
### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] My PR title is `Fixes <issue-number>: <short explanation>`
- [x] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] For UI changes: I attached a screen recording and/or screenshots above.
- [x] I have added tests and listed them above.

Bug fix
- [x] I have added a test that covers the exact scenario we are fixing.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a bug where query-lineage edges (CTAS, `INSERT ... SELECT`) showed \"No query available\" in the Edge Information panel even though the SQL was present in the lineage payload. The root cause was twofold: `getNodeLineageData` dropped `lineageSqlQueries` from the graph node during its `pick` pass, and `EdgeInfoDrawer` only read the inline `edge.sqlQuery` field rather than falling back to the deduplication map.

- **`EntityLineageNodeUtils.ts`**: adds `'lineageSqlQueries'` to the `pick` whitelist in `getNodeLineageData` so the map is preserved on each graph node.
- **`EdgeInfoDrawer.component.tsx`**: introduces a `resolvedSqlQuery` memo that returns the inline `sqlQuery` when present, otherwise looks up `sqlQueryKey` in the target node's `lineageSqlQueries` map; the `useEffect` now feeds this resolved value into `mysqlQuery` state.
- **Test files**: new unit tests cover the key lookup, inline-query precedence, missing-key fallback, and the `getNodeLineageData` preservation of `lineageSqlQueries`.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the fix is minimal, well-targeted, and adds no new state management complexity.

Both root causes are addressed precisely: the missing lineageSqlQueries field is now preserved through the pick pass, and the drawer correctly resolves it via the new resolvedSqlQuery memo. All fallback paths (no key, no target node, unknown key) return an empty string gracefully. The new unit tests cover the four key scenarios and the SchemaEditor mock is updated to expose the rendered value for reliable assertion. No regressions are expected since the inline sqlQuery path is still preferred and the view-lineage path is unaffected.

No files require special attention.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-ui/src/main/resources/ui/src/components/Entity/EntityInfoDrawer/EdgeInfoDrawer.component.tsx | Adds resolvedSqlQuery memo to fall back from inline sqlQuery to the target node's lineageSqlQueries map; correctly feeds it into mysqlQuery state via useEffect. |
| openmetadata-ui/src/main/resources/ui/src/utils/EntityLineageNodeUtils.ts | One-line fix: adds 'lineageSqlQueries' to the pick whitelist in getNodeLineageData so the SQL map is no longer dropped from each graph node. |
| openmetadata-ui/src/main/resources/ui/src/components/Entity/EntityInfoDrawer/EdgeInfoDrawer.test.tsx | New tests cover the sqlQueryKey resolution, inline-query precedence, and unknown-key fallback; SchemaEditor mock now exposes the rendered value for assertions. |
| openmetadata-ui/src/main/resources/ui/src/utils/EntityLineageNodeUtils.test.ts | New unit test validates that getNodeLineageData preserves lineageSqlQueries on the returned node object. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Edge clicked in Lineage tab] --> B[resolvedSqlQuery memo runs]
    B --> C{edgeEntity.sqlQuery present?}
    C -- yes --> D[Return inline sqlQuery]
    C -- no --> E{edgeEntity.sqlQueryKey present?}
    E -- no --> F[Return empty string]
    E -- yes --> G[Find target node in nodes array]
    G --> H{Target node found?}
    H -- no --> F
    H -- yes --> I{Key found in lineageSqlQueries map?}
    I -- yes --> J[Return SQL text from map]
    I -- no --> F
    D --> K[setMysqlQuery via useEffect]
    J --> K
    F --> K
    K --> L{mysqlQuery truthy?}
    L -- yes --> M[Render SchemaEditor with SQL]
    L -- no --> N[Render no-query-available message]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Edge clicked in Lineage tab] --> B[resolvedSqlQuery memo runs]
    B --> C{edgeEntity.sqlQuery present?}
    C -- yes --> D[Return inline sqlQuery]
    C -- no --> E{edgeEntity.sqlQueryKey present?}
    E -- no --> F[Return empty string]
    E -- yes --> G[Find target node in nodes array]
    G --> H{Target node found?}
    H -- no --> F
    H -- yes --> I{Key found in lineageSqlQueries map?}
    I -- yes --> J[Return SQL text from map]
    I -- no --> F
    D --> K[setMysqlQuery via useEffect]
    J --> K
    F --> K
    K --> L{mysqlQuery truthy?}
    L -- yes --> M[Render SchemaEditor with SQL]
    L -- no --> N[Render no-query-available message]
```

</a>
</details>

<sub>Reviews (3): Last reviewed commit: ["Make the SchemaEditor test mock value pr..."](https://github.com/open-metadata/openmetadata/commit/06d05abeabcf764f63de613ce92458ce11fffc24) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41029579)</sub>

<!-- /greptile_comment -->