### PR TITLE
Added includePipelineObservability flag

### DIFF
--- a/ingestion/src/metadata/ingestion/source/pipeline/airflow/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/pipeline/airflow/metadata.py
@@ -839,17 +839,6 @@ class AirflowSource(PipelineServiceSource):
             source=LineageSource.PipelineLineage,
         )
 
-        # Initialize context for observability tracking
-        self.context.get().current_pipeline_entity = pipeline_entity
-        self.context.get().current_table_fqns = []
-
-        # Get dag runs for caching observability data
-        dag_runs = self.get_pipeline_status(pipeline_details.dag_id)
-
-        # Cache dag runs in context
-        self.context.get().current_dag_runs = dag_runs
-        self.context.get().latest_dag_run = dag_runs[0] if dag_runs else None
-
         xlets: List[XLets] = get_xlets_from_dag(dag=pipeline_details) if pipeline_details else []  # noqa: UP006
 
         table_fqns = []
@@ -857,14 +846,12 @@ class AirflowSource(PipelineServiceSource):
             for from_xlet in xlet.inlets or []:
                 from_entity = self.metadata.get_by_name(entity=from_xlet.entity, fqn=from_xlet.fqn)
                 if from_entity:
-                    # Track table FQNs for observability
                     if from_xlet.entity == Table and from_xlet.fqn not in table_fqns:
                         table_fqns.append(from_xlet.fqn)
 
                     for to_xlet in xlet.outlets or []:
                         to_entity = self.metadata.get_by_name(entity=to_xlet.entity, fqn=to_xlet.fqn)
                         if to_entity:
-                            # Track table FQNs for observability
                             if to_xlet.entity == Table and to_xlet.fqn not in table_fqns:
                                 table_fqns.append(to_xlet.fqn)
 
@@ -899,19 +886,31 @@ class AirflowSource(PipelineServiceSource):
                         f"Ensure the entity exists in OpenMetadata before running lineage ingestion."
                     )
 
-        # Cache observability data for later use
-        self.context.get().current_table_fqns = table_fqns
+        if self.source_config.includePipelineObservability:
+            # Initialize context for observability tracking
+            self.context.get().current_pipeline_entity = pipeline_entity
+            self.context.get().current_table_fqns = []
 
-        # Cache for historical dag runs
-        for dag_run in dag_runs:
-            if dag_run.run_id:
-                cache_key = (pipeline_details.dag_id, dag_run.run_id)
-                self.observability_cache[cache_key] = {
-                    "pipeline_entity": pipeline_entity,
-                    "pipeline_details": pipeline_details,
-                    "table_fqns": table_fqns,
-                    "dag_run": dag_run,
-                }
+            # Get dag runs for caching observability data
+            dag_runs = self.get_pipeline_status(pipeline_details.dag_id)
+
+            # Cache dag runs in context
+            self.context.get().current_dag_runs = dag_runs
+            self.context.get().latest_dag_run = dag_runs[0] if dag_runs else None
+
+            # Track table FQNs for observability
+            self.context.get().current_table_fqns = table_fqns
+
+            # Cache for historical dag runs
+            for dag_run in dag_runs:
+                if dag_run.run_id:
+                    cache_key = (pipeline_details.dag_id, dag_run.run_id)
+                    self.observability_cache[cache_key] = {
+                        "pipeline_entity": pipeline_entity,
+                        "pipeline_details": pipeline_details,
+                        "table_fqns": table_fqns,
+                        "dag_run": dag_run,
+                    }
 
     def _build_observability_from_dag_run(
         self,
@@ -947,6 +946,12 @@ class AirflowSource(PipelineServiceSource):
         Extract pipeline observability data from cached lineage artifacts.
         Uses context data first (current dag), falls back to cache for historical data.
         """
+
+        # Check if pipeline observability is disabled
+        if not self.source_config.includePipelineObservability:
+            logger.info("Pipeline observability extraction is disabled via configuration")
+            return
+
         try:
             table_pipeline_map: Dict[str, List[PipelineObservability]] = defaultdict(list)  # noqa: UP006
 

--- a/ingestion/src/metadata/ingestion/source/pipeline/airflow/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/pipeline/airflow/metadata.py
@@ -949,7 +949,7 @@ class AirflowSource(PipelineServiceSource):
 
         # Check if pipeline observability is disabled
         if not self.source_config.includePipelineObservability:
-            logger.info("Pipeline observability extraction is disabled via configuration")
+            logger.debug("Pipeline observability extraction is disabled via configuration")
             return
 
         try:

--- a/ingestion/src/metadata/ingestion/source/pipeline/dbtcloud/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/pipeline/dbtcloud/metadata.py
@@ -415,7 +415,7 @@ class DbtcloudSource(PipelineServiceSource):
 
         # Check if pipeline observability is disabled
         if not self.source_config.includePipelineObservability:
-            logger.info("Pipeline observability extraction is disabled via configuration")
+            logger.debug("Pipeline observability extraction is disabled via configuration")
             return
 
         try:

--- a/ingestion/src/metadata/ingestion/source/pipeline/dbtcloud/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/pipeline/dbtcloud/metadata.py
@@ -194,26 +194,30 @@ class DbtcloudSource(PipelineServiceSource):
             # Build parent lookup dict for O(1) access instead of O(n) list search
             parent_by_unique_id = {p.uniqueId: p for p in dbt_parents if p.uniqueId}
 
-            # Cache observability details - store in context for current job
-            self.context.get().current_pipeline_entity = pipeline_entity
-            self.context.get().current_table_fqns = []
             # Store pipeline FQN from entity to ensure exact match for status updates
             self.context.get().pipeline_fqn = str(pipeline_entity.fullyQualifiedName.root)
 
-            # Create cache_key once at the start
-            cache_key = (
-                (pipeline_details.id, str(self.context.get().latest_run_id))
-                if self.context.get().latest_run_id
-                else None
-            )
+            if self.source_config.includePipelineObservability:
+                # Cache observability details - store in context for current job
+                self.context.get().current_pipeline_entity = pipeline_entity
+                self.context.get().current_table_fqns = []
 
-            if cache_key:
-                self.observability_cache[cache_key] = {
-                    "pipeline_entity": pipeline_entity,
-                    "job_details": pipeline_details,
-                    "table_fqns": set(),  # Use set for O(1) lookup
-                    "runs": self.context.get().current_runs,
-                }
+                # Create cache_key once at the start
+                cache_key = (
+                    (pipeline_details.id, str(self.context.get().latest_run_id))
+                    if self.context.get().latest_run_id
+                    else None
+                )
+
+                if cache_key:
+                    self.observability_cache[cache_key] = {
+                        "pipeline_entity": pipeline_entity,
+                        "job_details": pipeline_details,
+                        "table_fqns": set(),  # Use set for O(1) lookup
+                        "runs": self.context.get().current_runs,
+                    }
+            else:
+                cache_key = None
 
             for model in dbt_models or []:
                 if not model.runGeneratedAt:
@@ -243,13 +247,14 @@ class DbtcloudSource(PipelineServiceSource):
                     if to_entity is None:
                         continue
 
-                    # Add to context table FQNs
-                    if to_entity_fqn not in self.context.get().current_table_fqns:
-                        self.context.get().current_table_fqns.append(to_entity_fqn)
+                    if self.source_config.includePipelineObservability:
+                        # Add to context table FQNs for observability
+                        if to_entity_fqn not in self.context.get().current_table_fqns:
+                            self.context.get().current_table_fqns.append(to_entity_fqn)
 
-                    # Add to observability cache using set.add() for O(1)
-                    if cache_key and cache_key in self.observability_cache:
-                        self.observability_cache[cache_key]["table_fqns"].add(to_entity_fqn)
+                        # Add to observability cache using set.add() for O(1)
+                        if cache_key and cache_key in self.observability_cache:
+                            self.observability_cache[cache_key]["table_fqns"].add(to_entity_fqn)
 
                     for unique_id in model.dependsOn or []:
                         # Use dict lookup instead of list comprehension
@@ -286,13 +291,14 @@ class DbtcloudSource(PipelineServiceSource):
                         if from_entity is None:
                             continue
 
-                        # Add to context table FQNs
-                        if from_entity_fqn not in self.context.get().current_table_fqns:
-                            self.context.get().current_table_fqns.append(from_entity_fqn)
+                        if self.source_config.includePipelineObservability:
+                            # Add to context table FQNs for observability
+                            if from_entity_fqn not in self.context.get().current_table_fqns:
+                                self.context.get().current_table_fqns.append(from_entity_fqn)
 
-                        # Add to observability cache using set.add() for O(1)
-                        if cache_key and cache_key in self.observability_cache:
-                            self.observability_cache[cache_key]["table_fqns"].add(from_entity_fqn)
+                            # Add to observability cache using set.add() for O(1)
+                            if cache_key and cache_key in self.observability_cache:
+                                self.observability_cache[cache_key]["table_fqns"].add(from_entity_fqn)
 
                         lineage_details = LineageDetails(
                             pipeline=EntityReference(id=pipeline_entity.id.root, type="pipeline"),
@@ -406,6 +412,12 @@ class DbtcloudSource(PipelineServiceSource):
         Extract pipeline observability data from cached lineage artifacts.
         Uses context data first (current job), falls back to cache for historical data.
         """
+
+        # Check if pipeline observability is disabled
+        if not self.source_config.includePipelineObservability:
+            logger.info("Pipeline observability extraction is disabled via configuration")
+            return
+
         try:
             table_pipeline_map: Dict[str, List[PipelineObservability]] = defaultdict(list)  # noqa: UP006
 

--- a/ingestion/tests/unit/airflow/test_airflow_metadata.py
+++ b/ingestion/tests/unit/airflow/test_airflow_metadata.py
@@ -314,15 +314,13 @@ class TestGetTablePipelineObservability:
             current_pipeline_entity=None,
         )
         source.observability_cache = {}
-        source.metadata = MagicMock()
-        source.metadata.get_by_name.side_effect = Exception("Should not be reached with empty context")
 
         mock_details = MagicMock()
         mock_details.dag_id = "test_dag"
 
         result = list(source.get_table_pipeline_observability(mock_details))
 
-        assert len(result) >= 1
+        assert result == [{}]
 
 
 class TestTaskDetailAccess:

--- a/ingestion/tests/unit/airflow/test_airflow_metadata.py
+++ b/ingestion/tests/unit/airflow/test_airflow_metadata.py
@@ -276,6 +276,55 @@ class TestBuildObservabilityFromDagRun:
         assert observability.lastRunStatus.value == "Successful"
 
 
+class TestGetTablePipelineObservability:
+    """Test get_table_pipeline_observability respects includePipelineObservability flag."""
+
+    @patch(
+        "metadata.ingestion.source.pipeline.airflow.metadata.AirflowSource.__init__",
+        return_value=None,
+    )
+    def test_disabled_when_include_pipeline_observability_false(self, mock_init):
+        """Should yield nothing when includePipelineObservability is False."""
+        from metadata.ingestion.source.pipeline.airflow.metadata import AirflowSource
+
+        source = AirflowSource.__new__(AirflowSource)
+        source.source_config = MagicMock()
+        source.source_config.includePipelineObservability = False
+
+        mock_details = MagicMock()
+        result = list(source.get_table_pipeline_observability(mock_details))
+
+        assert result == []
+
+    @patch(
+        "metadata.ingestion.source.pipeline.airflow.metadata.AirflowSource.__init__",
+        return_value=None,
+    )
+    def test_enabled_by_default(self, mock_init):
+        """Should proceed past the guard clause when includePipelineObservability is True (default)."""
+        from metadata.ingestion.source.pipeline.airflow.metadata import AirflowSource
+
+        source = AirflowSource.__new__(AirflowSource)
+        source.source_config = MagicMock()
+        source.source_config.includePipelineObservability = True
+        source.context = MagicMock()
+        source.context.get.return_value = SimpleNamespace(
+            current_table_fqns=None,
+            current_dag_runs=None,
+            current_pipeline_entity=None,
+        )
+        source.observability_cache = {}
+        source.metadata = MagicMock()
+        source.metadata.get_by_name.side_effect = Exception("Should not be reached with empty context")
+
+        mock_details = MagicMock()
+        mock_details.dag_id = "test_dag"
+
+        result = list(source.get_table_pipeline_observability(mock_details))
+
+        assert len(result) >= 1
+
+
 class TestTaskDetailAccess:
     """Test _test_task_detail_access across Airflow versions."""
 

--- a/ingestion/tests/unit/test_workflow_parse.py
+++ b/ingestion/tests/unit/test_workflow_parse.py
@@ -364,7 +364,7 @@ class TestWorkflowParse(TestCase):
                         },
                     }
                 },
-                "sourceConfig": {"config": {"type": "PipelineMetadata", "includeLineage": True}},
+                "sourceConfig": {"config": {"type": "PipelineMetadata", "includeLineage": True, "includePipelineObservability": False}},
             },
             "sink": {"type": "metadata-rest", "config": {}},
             "workflowConfig": {

--- a/ingestion/tests/unit/topology/pipeline/test_dbtcloud.py
+++ b/ingestion/tests/unit/topology/pipeline/test_dbtcloud.py
@@ -1292,6 +1292,38 @@ class DBTCloudUnitTest(TestCase):
         self.assertIn("Successful", statuses)
         self.assertIn("Skipped", statuses)  # status 2 maps to Skipped
 
+    def test_include_pipeline_observability_disabled(self):
+        """
+        Test that setting includePipelineObservability to False disables extraction.
+        """
+        self.dbtcloud.context.get().__dict__["current_job_id"] = 70403103936332
+        self.dbtcloud.context.get().__dict__["latest_run_id"] = 70403110257794
+        self.dbtcloud.context.get().__dict__["current_pipeline_entity"] = MOCK_PIPELINE
+        self.dbtcloud.context.get().__dict__["current_table_fqns"] = [
+            "local_redshift.dev.dbt_test_new.model_15",
+            "local_redshift.dev.dbt_test_new.model_32",
+        ]
+
+        mock_run = DBTRun(
+            id=70403110257794,
+            status=1,
+            state="Success",
+            href="https://abc12.us1.dbt.com/deploy/70403103922125/projects/70403103926818/runs/70403110257794/",
+            started_at="2024-05-27 10:42:20.621788+00:00",
+            finished_at="2024-05-28 10:42:52.622408+00:00",
+        )
+        self.dbtcloud.context.get().__dict__["latest_run"] = mock_run
+        self.dbtcloud.context.get().__dict__["current_runs"] = [mock_run]
+
+        original_value = self.dbtcloud.source_config.includePipelineObservability
+        self.dbtcloud.source_config.includePipelineObservability = False
+
+        try:
+            result = list(self.dbtcloud.get_table_pipeline_observability(EXPECTED_JOB_DETAILS))
+            self.assertEqual(len(result), 0)
+        finally:
+            self.dbtcloud.source_config.includePipelineObservability = original_value
+
     def test_get_models_with_lineage(self):
         """
         Test the combined GraphQL call for models and seeds with lineage info

--- a/openmetadata-spec/src/main/resources/json/schema/metadataIngestion/pipelineServiceMetadataPipeline.json
+++ b/openmetadata-spec/src/main/resources/json/schema/metadataIngestion/pipelineServiceMetadataPipeline.json
@@ -108,6 +108,12 @@
       "description": "Set the 'Override Metadata' toggle to control whether to override the existing metadata in the OpenMetadata server with the metadata fetched from the source. If the toggle is set to true, the metadata fetched from the source will override the existing metadata in the OpenMetadata server. If the toggle is set to false, the metadata fetched from the source will not override the existing metadata in the OpenMetadata server. This is applicable for fields like description, tags, owner and displayName",
       "type": "boolean",
       "default": false
+    },
+    "includePipelineObservability": {
+      "title": "Include Pipeline Observability",
+      "description": "Optional configuration to turn off pipeline observability extraction.",
+      "type": "boolean",
+      "default": true
     }
   },
   "additionalProperties": false

--- a/openmetadata-spec/src/main/resources/json/schema/metadataIngestion/pipelineServiceMetadataPipeline.json
+++ b/openmetadata-spec/src/main/resources/json/schema/metadataIngestion/pipelineServiceMetadataPipeline.json
@@ -111,7 +111,7 @@
     },
     "includePipelineObservability": {
       "title": "Include Pipeline Observability",
-      "description": "Optional configuration to turn off pipeline observability extraction.",
+      "description": "Set the 'Include Pipeline Observability' toggle to control whether to extract pipeline observability data (e.g., table-level freshness and run history) during metadata ingestion. Disabling this can significantly reduce ingestion time for large deployments.",
       "type": "boolean",
       "default": true
     }

--- a/openmetadata-ui/src/main/resources/ui/public/locales/en-US/Pipeline/workflows/metadata.md
+++ b/openmetadata-ui/src/main/resources/ui/public/locales/en-US/Pipeline/workflows/metadata.md
@@ -38,6 +38,12 @@ Set the Include Lineage toggle to control whether to include lineage between pip
 $$
 
 $$section
+### Include Pipeline Observability $(id="includePipelineObservability")
+
+Set the Include Pipeline Observability toggle to control whether to extract pipeline observability data (e.g., table-level freshness, volume, quality signals) from pipeline runs as part of metadata ingestion.
+$$
+
+$$section
 ### Enable Debug Logs $(id="enableDebugLog")
 
 Set the `Enable Debug Log` toggle to set the logging level of the process to debug. You can check these logs in the Ingestion tab of the service and dig deeper into any errors you might find.

--- a/openmetadata-ui/src/main/resources/ui/src/generated/metadataIngestion/pipelineServiceMetadataPipeline.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/metadataIngestion/pipelineServiceMetadataPipeline.ts
@@ -19,6 +19,10 @@ export interface PipelineServiceMetadataPipeline {
      */
     includeLineage?: boolean;
     /**
+     * Optional configuration to turn off pipeline observability extraction.
+     */
+    includePipelineObservability?: boolean;
+    /**
      * Set the 'Include Owners' toggle to control whether to include owners to the ingested
      * entity if the owner email matches with a user stored in the OM server as part of metadata
      * ingestion. If the ingested entity already exists and has an owner, the owner will not be


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:

Added includePipelineObservability configuration flag to allow users to disable pipeline observability extraction during metadata ingestion. 

Pipeline observability has a significant performance impact on Airflow ingestion — it queries DagRun history, processes lineage artifacts, and caches observability data for each pipeline. Disabling it when not needed can substantially reduce ingestion time for large Airflow deployments with many DAGs and runs.

<!--
Linking an issue is REQUIRED. Replace <issue-number> with the GitHub issue number this PR addresses
(e.g., `Fixes #12345`). GitHub will auto-link it. If no issue exists, please open one first so the
problem and design can be discussed before review.
-->

<!--
Short blurb explaining:
- What changes did you make?
- Why did you make them?
-->



#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [ ] Improvement
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation



#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.
- [ ] For UI changes: I attached a screen recording and/or screenshots above.
- [ ] I have added tests (unit / integration / Playwright as applicable) and listed them above.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Adds an `includePipelineObservability` boolean flag (default `true`) to `PipelineServiceMetadataPipeline` that lets users skip pipeline observability extraction during metadata ingestion, addressing performance concerns for large Airflow and dbt Cloud deployments.

- **Airflow & dbt Cloud connectors**: observability context population and cache building are now gated on `source_config.includePipelineObservability`; `get_table_pipeline_observability` returns immediately (no yields) when the flag is `false`.
- **JSON schema + generated TypeScript + UI locale**: schema adds the new field with `"default": true`, ensuring backward compatibility; the TypeScript generated type and locale documentation are updated accordingly.
- **Tests**: new unit tests for both connectors verify that the method yields nothing when disabled and proceeds normally when enabled.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the new flag defaults to true so existing deployments are unaffected, and both connectors correctly skip all observability work when set to false.

The change is a straightforward opt-out flag added symmetrically to both the Airflow and dbt Cloud connectors. The JSON schema default of true preserves backward compatibility, the Python generator early-return pattern is correct, and the new tests directly verify both the disabled and enabled code paths.

No files require special attention.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| ingestion/src/metadata/ingestion/source/pipeline/airflow/metadata.py | Observability context initialization and cache population moved inside `if includePipelineObservability:` guard; `get_table_pipeline_observability` early-returns correctly when disabled. |
| ingestion/src/metadata/ingestion/source/pipeline/dbtcloud/metadata.py | Same guard pattern applied; `pipeline_fqn` context assignment correctly left outside the guard; `cache_key = None` in the else branch is defensive but harmless since it is only consumed inside the same flag guard. |
| openmetadata-spec/src/main/resources/json/schema/metadataIngestion/pipelineServiceMetadataPipeline.json | New `includePipelineObservability` field added with `"default": true` and a clear positive-framing description; backward-compatible. |
| openmetadata-ui/src/main/resources/ui/src/generated/metadataIngestion/pipelineServiceMetadataPipeline.ts | Generated TypeScript type updated with the new optional boolean field; JSDoc wording follows the same short-form pattern used by sibling fields such as `includeLineage`. |
| ingestion/tests/unit/airflow/test_airflow_metadata.py | New `TestGetTablePipelineObservability` class with two tests: one confirming zero yields when disabled, one confirming a single empty map is yielded when enabled with no context data. |
| ingestion/tests/unit/topology/pipeline/test_dbtcloud.py | New `test_include_pipeline_observability_disabled` test correctly asserts zero results and restores the original flag value via `try/finally`. |
| ingestion/tests/unit/test_workflow_parse.py | Existing workflow-parse test updated to explicitly include `includePipelineObservability: false` in the pipeline metadata config fixture. |
| openmetadata-ui/src/main/resources/ui/public/locales/en-US/Pipeline/workflows/metadata.md | New `$$section` block added for `includePipelineObservability` in the correct position between Include Lineage and Enable Debug Logs. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[yield_pipeline_details] --> B[_yield_pipeline_lineage]
    B --> C{includePipelineObservability?}
    C -- true --> D[Initialize context\ncurrent_pipeline_entity\ncurrent_table_fqns\ncurrent_dag_runs]
    C -- true --> E[Populate observability_cache\nper dag_run]
    C -- false --> F[Skip context init\nSkip cache population]
    B --> G[get_table_pipeline_observability]
    G --> H{includePipelineObservability?}
    H -- false --> I[return early\nyield nothing]
    H -- true --> J[Read context + cache]
    J --> K[Build PipelineObservability\nper table_fqn]
    K --> L[yield table_pipeline_map]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[yield_pipeline_details] --> B[_yield_pipeline_lineage]
    B --> C{includePipelineObservability?}
    C -- true --> D[Initialize context\ncurrent_pipeline_entity\ncurrent_table_fqns\ncurrent_dag_runs]
    C -- true --> E[Populate observability_cache\nper dag_run]
    C -- false --> F[Skip context init\nSkip cache population]
    B --> G[get_table_pipeline_observability]
    G --> H{includePipelineObservability?}
    H -- false --> I[return early\nyield nothing]
    H -- true --> J[Read context + cache]
    J --> K[Build PipelineObservability\nper table_fqn]
    K --> L[yield table_pipeline_map]
```

</a>
</details>

<sub>Reviews (4): Last reviewed commit: ["Merge branch &#39;feature-include-pipeline-o..."](https://github.com/open-metadata/openmetadata/commit/bf8c67f2822c1b737e2a1ff16648cdbfe3d93ee7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41035698)</sub>

<!-- /greptile_comment -->