### PR TITLE
perf(rdf): shard keyed-write ordering lock to cut submission contention

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/rdf/RdfUpdater.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/rdf/RdfUpdater.java
@@ -1,5 +1,6 @@
 package org.openmetadata.service.rdf;
 
+import com.google.common.util.concurrent.Striped;
 import io.micrometer.core.instrument.Timer;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -13,6 +14,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.locks.Lock;
 import lombok.extern.slf4j.Slf4j;
 import org.openmetadata.schema.EntityInterface;
 import org.openmetadata.schema.api.configuration.rdf.RdfConfiguration;
@@ -31,6 +33,13 @@ public class RdfUpdater {
   private static final AtomicLong droppedWrites = new AtomicLong(0L);
   private static final ConcurrentMap<UUID, CompletableFuture<Void>> keyedWriteTails =
       new ConcurrentHashMap<>();
+  // Per-key write ordering is guarded by a bounded pool of stripe locks rather
+  // than one global monitor over every submission: writes whose keys fall on
+  // disjoint stripes no longer block each other, while writes sharing a key
+  // still serialize. 64 stripes gives ample submission-path concurrency — the
+  // critical section is only a few map ops (the Fuseki write runs off-lock).
+  private static final int WRITE_LOCK_STRIPES = 64;
+  private static final Striped<Lock> writeLocks = Striped.lock(WRITE_LOCK_STRIPES);
 
   private static RdfRepository rdfRepository;
 
@@ -241,8 +250,13 @@ public class RdfUpdater {
   }
 
   private static void submitKeyedAsync(String description, Set<UUID> writeKeys, Runnable task) {
+    // Lock only the stripes these keys map to, acquired in Guava's canonical
+    // (ascending stripe-index) order so concurrent multi-key submissions can
+    // never deadlock. Submissions on disjoint stripes run this section
+    // concurrently; only those sharing a stripe serialize.
+    List<Lock> heldLocks = lockWriteStripes(writeKeys);
     CompletableFuture<Void> next;
-    synchronized (keyedWriteTails) {
+    try {
       CompletableFuture<?>[] previous =
           writeKeys.stream()
               .map(
@@ -260,20 +274,40 @@ public class RdfUpdater {
       for (UUID key : writeKeys) {
         keyedWriteTails.put(key, next);
       }
+    } finally {
+      unlockWriteStripes(heldLocks);
     }
 
+    // Cleanup needs no lock: remove(key, next) is a compare-and-remove on the
+    // ConcurrentHashMap, so it only clears the tail THIS write installed and is
+    // a no-op once a newer write has replaced it. It runs inside whenComplete,
+    // so any tail removed here is already complete — a concurrent submit that
+    // observes it still chains after a finished future, preserving ordering.
     next.whenComplete(
         (ignored, error) -> {
-          synchronized (keyedWriteTails) {
-            for (UUID key : writeKeys) {
-              keyedWriteTails.remove(key, next);
-            }
+          for (UUID key : writeKeys) {
+            keyedWriteTails.remove(key, next);
           }
           pendingWrites.decrementAndGet();
           if (error != null) {
             LOG.error("RDF {} failed while running in keyed async queue", description, error);
           }
         });
+  }
+
+  private static List<Lock> lockWriteStripes(Set<UUID> writeKeys) {
+    List<Lock> heldLocks = new ArrayList<>();
+    for (Lock lock : writeLocks.bulkGet(writeKeys)) {
+      lock.lock();
+      heldLocks.add(lock);
+    }
+    return heldLocks;
+  }
+
+  private static void unlockWriteStripes(List<Lock> heldLocks) {
+    for (int i = heldLocks.size() - 1; i >= 0; i--) {
+      heldLocks.get(i).unlock();
+    }
   }
 
   private static Set<UUID> writeKeys(UUID... keys) {

--- a/openmetadata-service/src/test/java/org/openmetadata/service/rdf/RdfUpdaterTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/rdf/RdfUpdaterTest.java
@@ -29,6 +29,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import org.awaitility.Awaitility;
@@ -217,6 +219,60 @@ class RdfUpdaterTest {
       Awaitility.await()
           .atMost(Duration.ofSeconds(5))
           .untilAsserted(() -> verify(mockRepository, times(1)).removeRelationship(rel));
+    }
+  }
+
+  @Nested
+  @DisplayName("keyed-write striped locking")
+  class KeyedWriteConcurrency {
+
+    /**
+     * Relationship writes lock two stripes each (from + to). If those stripe
+     * locks were acquired in inconsistent order, two threads submitting the
+     * same pair of ids in opposite directions would deadlock. Guava's {@code
+     * bulkGet} returns the locks in a canonical order, so a high-contention
+     * mix of overlapping multi-key writes must all drain. A regression that
+     * breaks the ordering hangs the submitter threads and trips the timeout.
+     */
+    @Test
+    @DisplayName("concurrent overlapping multi-key writes drain without deadlock")
+    void concurrentMultiKeyWritesDoNotDeadlock() throws Exception {
+      int poolSize = 6;
+      List<UUID> ids = new ArrayList<>();
+      for (int i = 0; i < poolSize; i++) {
+        ids.add(UUID.randomUUID());
+      }
+
+      int submissions = 300;
+      CountDownLatch completed = new CountDownLatch(submissions);
+      doAnswer(
+              ignored -> {
+                completed.countDown();
+                return null;
+              })
+          .when(mockRepository)
+          .addRelationship(any());
+
+      ExecutorService submitters = Executors.newFixedThreadPool(12);
+      try {
+        for (int i = 0; i < submissions; i++) {
+          UUID from = ids.get(i % poolSize);
+          UUID to = ids.get((i * 5 + 1) % poolSize);
+          EntityRelationship rel =
+              new EntityRelationship()
+                  .withFromId(from)
+                  .withToId(to)
+                  .withFromEntity(Entity.TABLE)
+                  .withToEntity(Entity.TABLE)
+                  .withRelationshipType(Relationship.CONTAINS);
+          submitters.submit(() -> RdfUpdater.addRelationship(rel));
+        }
+        assertTrue(
+            completed.await(30, TimeUnit.SECONDS),
+            "all writes should drain — striped-lock acquisition must be deadlock-free");
+      } finally {
+        submitters.shutdownNow();
+      }
     }
   }
 


### PR DESCRIPTION
### Describe your changes:

> ⚠️ No GitHub issue number was provided — please replace with `Fixes #<issue-number>` before merge.

`RdfUpdater.submitKeyedAsync` chains per-entity RDF writes so writes touching the same entity id run in submission order, but it did the tail lookup/chaining under a **single global monitor** (`synchronized (keyedWriteTails)`). Since every RDF write path supplies a write key, all entity CRUD / relationship submissions serialized their (short) bookkeeping section even for completely unrelated entities. This replaces the global monitor with a bounded **Guava `Striped<Lock>` (64 stripes)**: writes whose keys land on disjoint stripes no longer contend, while writes sharing a key still serialize so per-entity ordering is preserved. `bulkGet` returns the stripe locks in a canonical order, so concurrent multi-key (`from`+`to`) relationship writes cannot deadlock; cleanup runs lock-free because the compare-and-remove only clears a tail this write installed, and only after it has completed. Follow-up to the keyed-write model added in #29368.

#
### Type of change:
- [x] Improvement

#
### High-level design:

The invariant is unchanged: `keyedWriteTails[key]` holds the most recent write future touching `key`; a new write chains after `allOf` of its keys' current tails and becomes their new tail. Only the concurrency control around that read-modify-write changed — from one global monitor to per-stripe locks acquired in `bulkGet` order (deadlock-free for the ≤2-key relationship case). The actual Fuseki write already ran off-lock on `AsyncService`, so this only widens the submission path, not execution.

#
### Tests:

#### Unit tests
- [x] Added a high-contention **deadlock-freedom stress test** (`RdfUpdaterTest$KeyedWriteConcurrency` — 300 overlapping multi-key writes across 12 threads must all drain; a broken lock order would hang and trip the timeout).
- [x] The existing same-key ordering test (`writesForSameEntityIdAreSequenced`) still passes.
- 7 `RdfUpdaterTest` tests pass; `mvn spotless:check` clean.

#### Backend integration tests
- [x] Not applicable (internal concurrency change, no API surface change).

#### Playwright (UI) tests
- [x] Not applicable (no UI changes).

#
### UI screen recording / screenshots:

Not applicable.

#
### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have added tests around the new logic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR narrows submission-path contention in `RdfUpdater.submitKeyedAsync` by replacing a single global `synchronized (keyedWriteTails)` monitor with a 64-stripe `Guava Striped<Lock>`. Writes whose keys land on different stripes now proceed in parallel, while writes sharing a key still serialize in submission order; cleanup is made lock-free by relying on `ConcurrentHashMap.remove(key, next)` as a conditional compare-and-remove.

- **Striped locking**: `lockWriteStripes` delegates key→stripe mapping and canonical ordering to `Guava.bulkGet`, ensuring multi-key submissions always acquire stripes in the same ascending-index order and cannot deadlock; all tail map updates complete before any lock is released.
- **Lock-free cleanup**: `whenComplete` removes each key's tail without holding a lock — safe because `ConcurrentHashMap.remove(key, value)` is atomic and only clears the entry if the stored value is still the future this write installed.
- **Tests**: A new 12-thread, 300-submission stress test exercises overlapping multi-key (from+to) writes with a 30-second timeout to catch any lock-order regression; the existing per-entity ordering test continues to pass.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; the concurrency model is correct and well-tested. Two small hardening gaps — one in production code, one in test cleanup — are worth addressing but do not affect the happy path.

The lock acquisition for `lockWriteStripes` sits outside the `try-finally` guard, leaving a theoretical window where a partially-acquired lock set could never be released if an error fires between `lock()` calls. The test's `shutdownNow()` without `awaitTermination` can leave submission threads alive past `@AfterEach`, causing spurious side-effects in subsequent tests under slow CI.

Both changed files warrant a second look: `RdfUpdater.java` for the lock-acquisition placement, and `RdfUpdaterTest.java` for the executor shutdown pattern.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-service/src/main/java/org/openmetadata/service/rdf/RdfUpdater.java | Replaces single global synchronized monitor on keyedWriteTails with a 64-stripe Guava Striped<Lock>; lock acquisition uses bulkGet for canonical deadlock-free ordering; cleanup is now lock-free via ConcurrentHashMap.remove(key, next). Logic is sound, but lock acquisition in lockWriteStripes sits outside the try-finally guard. |
| openmetadata-service/src/test/java/org/openmetadata/service/rdf/RdfUpdaterTest.java | Adds a 300-submission, 12-thread deadlock stress test covering multi-key (from+to) relationship writes; existing ordering and short-circuit tests are retained. Missing awaitTermination after shutdownNow in the finally block may leave worker threads active past test teardown. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant T1 as Thread T1 (W1: K1+K2)
    participant T2 as Thread T2 (W2: K1)
    participant SL as Striped<Lock>
    participant KWT as keyedWriteTails (CHM)
    participant AS as AsyncService

    T1->>SL: "bulkGet({K1,K2}) canonical order"
    T1->>SL: lock(S1)
    T1->>SL: lock(S2)
    T2->>SL: lock(S1) BLOCKS
    T1->>KWT: getOrDefault(K1,K2) prev tails
    T1->>AS: thenRunAsync(task1) futureW1
    T1->>KWT: put(K1,futureW1) put(K2,futureW1)
    T1->>SL: unlock(S2) unlock(S1)
    T2->>SL: lock(S1) acquired
    T2->>KWT: getOrDefault(K1) futureW1
    T2->>AS: thenRunAsync(task2) futureW2
    T2->>KWT: put(K1,futureW2)
    T2->>SL: unlock(S1)
    AS-->>KWT: futureW1 completes remove(K1,futureW1) no-op
    AS-->>KWT: futureW2 completes remove(K1,futureW2) succeeds
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant T1 as Thread T1 (W1: K1+K2)
    participant T2 as Thread T2 (W2: K1)
    participant SL as Striped<Lock>
    participant KWT as keyedWriteTails (CHM)
    participant AS as AsyncService

    T1->>SL: "bulkGet({K1,K2}) canonical order"
    T1->>SL: lock(S1)
    T1->>SL: lock(S2)
    T2->>SL: lock(S1) BLOCKS
    T1->>KWT: getOrDefault(K1,K2) prev tails
    T1->>AS: thenRunAsync(task1) futureW1
    T1->>KWT: put(K1,futureW1) put(K2,futureW1)
    T1->>SL: unlock(S2) unlock(S1)
    T2->>SL: lock(S1) acquired
    T2->>KWT: getOrDefault(K1) futureW1
    T2->>AS: thenRunAsync(task2) futureW2
    T2->>KWT: put(K1,futureW2)
    T2->>SL: unlock(S1)
    AS-->>KWT: futureW1 completes remove(K1,futureW1) no-op
    AS-->>KWT: futureW2 completes remove(K1,futureW2) succeeds
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["perf(rdf): shard keyed-write ordering lo..."](https://github.com/open-metadata/openmetadata/commit/f53d7bd10f5a41ea051dc5dadc8262341af9e040) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41224702)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->