### PR TITLE
Fix bundle suite tab click in 1.13 test

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/TestSuite.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/TestSuite.spec.ts
@@ -145,7 +145,7 @@ test('Test suite tab switching keeps active bundle suite data after stale table 
     );
   });
 
-  await page.getByTestId('bundle-suite-radio-btn').click();
+  await page.getByText('Bundle Suites', { exact: true }).click();
   await bundleSuiteListResponse;
 
   const bundleSuiteSearchResponse = page.waitForResponse((response) => {


### PR DESCRIPTION
### Description
- Click the visible Bundle Suites radio option in the 1.13 Playwright test.
- Avoid targeting AntD's hidden radio input via data-testid.

### Tests
- Not run.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This single-line change fixes a flaky Playwright test on the 1.13 branch by switching from a `data-testid` selector (which pointed to AntD's visually-hidden `<input type="radio">`) to a text-based selector that targets the visible "Bundle Suites" label the user would actually click.

- Replaces `page.getByTestId('bundle-suite-radio-btn')` with `page.getByText('Bundle Suites', { exact: true })` so Playwright interacts with the visible radio-button label rather than the hidden underlying input.
- The `exact: true` flag prevents accidental partial-text matches if other elements on the page contain "Bundle Suites" as a substring.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is a one-line targeted fix in a test file with no production code impact.

The fix correctly replaces a selector that was targeting a hidden AntD radio input (unreachable by Playwright's default visibility checks) with a text locator for the visible label. The logic of the test is unchanged; only the mechanism for clicking the tab differs. `exact: true` keeps the match precise, and 'Bundle Suites' is unlikely to collide with other elements on this page. No production code is touched.

No files require special attention.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/TestSuite.spec.ts | Replaces data-testid selector (on a hidden AntD radio input) with a visible-text locator to fix tab-click flakiness on the 1.13 branch |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Test as Playwright Test
    participant Page as Browser Page
    participant API as API Server

    Test->>Page: page.route intercept testSuites/search/list
    Test->>Page: page.goto table-suites
    Page->>API: "GET testSuites/search/list?testSuiteType=basic"
    Note over Page: Response held by route intercept
    Note over Page: table-suite-table + loader visible

    Test->>Page: getByText Bundle Suites exact click
    Note over Test: Old: getByTestId on hidden AntD input failed
    Page->>API: "GET testSuites/search/list?testSuiteType=logical"
    API-->>Test: bundleSuiteListResponse resolves

    Test->>Page: fill bundleSuiteName in search box
    Page->>API: "GET testSuites/search/list?testSuiteType=logical q=name"
    API-->>Test: bundleSuiteSearchResponse resolves

    Test->>Page: tableSuiteResponseRelease resolve
    API-->>Page: Stale table-suite response delivered late
    Test->>Page: assert bundleSuiteName still visible
    Test->>Page: assert tableFqn NOT visible
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Test as Playwright Test
    participant Page as Browser Page
    participant API as API Server

    Test->>Page: page.route intercept testSuites/search/list
    Test->>Page: page.goto table-suites
    Page->>API: "GET testSuites/search/list?testSuiteType=basic"
    Note over Page: Response held by route intercept
    Note over Page: table-suite-table + loader visible

    Test->>Page: getByText Bundle Suites exact click
    Note over Test: Old: getByTestId on hidden AntD input failed
    Page->>API: "GET testSuites/search/list?testSuiteType=logical"
    API-->>Test: bundleSuiteListResponse resolves

    Test->>Page: fill bundleSuiteName in search box
    Page->>API: "GET testSuites/search/list?testSuiteType=logical q=name"
    API-->>Test: bundleSuiteSearchResponse resolves

    Test->>Page: tableSuiteResponseRelease resolve
    API-->>Page: Stale table-suite response delivered late
    Test->>Page: assert bundleSuiteName still visible
    Test->>Page: assert tableFqn NOT visible
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["test(ui): click visible bundle suite tab..."](https://github.com/open-metadata/openmetadata/commit/3d9eafaf91f121d08bf3c7c22eb35aa1a20951e8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41311815)</sub>

<!-- /greptile_comment -->