### PR TITLE
Refactor: show proper toast for permission (403) errors

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/ar-sa.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/ar-sa.json
@@ -3558,6 +3558,7 @@
     "only-reviewers-can-approve-or-reject": "يمكن للمراجعين فقط الموافقة أو الرفض",
     "only-show-columns-with-lineage": "إظهار الأعمدة ذات سلسلة البيانات فقط",
     "openmetadata-docs-description": "Full setup guide, required privileges, and every supported field.",
+    "operation-forbidden-please-contact-admin": "ليس لديك الأذونات اللازمة لتنفيذ هذا الإجراء. يرجى الاتصال بالمسؤول.",
     "optional-configuration-update-description-dbt": "تكوين اختياري لتحديث الوصف من dbt أو لا",
     "optional-custom-error": "رسالة خطأ مخصصة اختيارية تظهر عند فشل التحقق",
     "optional-markdown-content": "اختياري: أضف محتوى Markdown لتضمينه مباشرة في المورد",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/de-de.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/de-de.json
@@ -3558,6 +3558,7 @@
     "only-reviewers-can-approve-or-reject": "Nur Prüfer können genehmigen oder ablehnen.",
     "only-show-columns-with-lineage": "Nur Spalten mit Lineage anzeigen",
     "openmetadata-docs-description": "Full setup guide, required privileges, and every supported field.",
+    "operation-forbidden-please-contact-admin": "Sie haben keine Berechtigung, diese Aktion auszuführen. Bitte wenden Sie sich an Ihren Administrator.",
     "optional-configuration-update-description-dbt": "Optionale Konfiguration, um die Beschreibung von dbt zu aktualisieren oder nicht.",
     "optional-custom-error": "Optionale benutzerdefinierte Fehlermeldung, die bei fehlgeschlagener Validierung angezeigt wird",
     "optional-markdown-content": "Optional: Markdown-Inhalt hinzufügen, der direkt in der Ressource eingebettet wird",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/en-us.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/en-us.json
@@ -3558,6 +3558,7 @@
     "only-reviewers-can-approve-or-reject": "Only Reviewers can Approve or Reject",
     "only-show-columns-with-lineage": "Only show columns with Lineage",
     "openmetadata-docs-description": "Full setup guide, required privileges, and every supported field.",
+    "operation-forbidden-please-contact-admin": "You don't have permissions to perform this action. Please contact your administrator.",
     "optional-configuration-update-description-dbt": "Optional configuration to update the description from dbt or not",
     "optional-custom-error": "Optional custom error message shown when validation fails",
     "optional-markdown-content": "Optional: Add markdown content to embed directly in the resource",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/es-es.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/es-es.json
@@ -3558,6 +3558,7 @@
     "only-reviewers-can-approve-or-reject": "Solo los Revisores pueden Aprobar o Rechazar",
     "only-show-columns-with-lineage": "Mostrar solo columnas con Lineage",
     "openmetadata-docs-description": "Full setup guide, required privileges, and every supported field.",
+    "operation-forbidden-please-contact-admin": "No tienes permisos para realizar esta acción. Ponte en contacto con tu administrador.",
     "optional-configuration-update-description-dbt": "Configuración opcional para actualizar la descripción de dbt",
     "optional-custom-error": "Mensaje de error personalizado opcional que se muestra cuando falla la validación",
     "optional-markdown-content": "Opcional: Añadir contenido markdown para incrustar directamente en el recurso",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/fr-fr.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/fr-fr.json
@@ -3558,6 +3558,7 @@
     "only-reviewers-can-approve-or-reject": "Seuls les réviseurs peuvent Valider ou Rejeter",
     "only-show-columns-with-lineage": "Afficher uniquement les colonnes avec Lineage",
     "openmetadata-docs-description": "Full setup guide, required privileges, and every supported field.",
+    "operation-forbidden-please-contact-admin": "Vous n'avez pas les autorisations nécessaires pour effectuer cette action. Veuillez contacter votre administrateur.",
     "optional-configuration-update-description-dbt": "Configuration optionnelle pour mettre à jour la description à partir de dbt ou non",
     "optional-custom-error": "Message d'erreur personnalisé facultatif affiché en cas d'échec de la validation",
     "optional-markdown-content": "Facultatif : Ajouter du contenu markdown à intégrer directement dans la ressource",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/gl-es.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/gl-es.json
@@ -3558,6 +3558,7 @@
     "only-reviewers-can-approve-or-reject": "Só os revisores poden aprobar ou rexeitar",
     "only-show-columns-with-lineage": "Mostrar só columnas con Lineage",
     "openmetadata-docs-description": "Full setup guide, required privileges, and every supported field.",
+    "operation-forbidden-please-contact-admin": "Non tes permisos para realizar esta acción. Ponte en contacto co teu administrador.",
     "optional-configuration-update-description-dbt": "Configuración opcional para actualizar ou non a descrición desde dbt",
     "optional-custom-error": "Mensaxe de erro personalizada opcional que se amosa cando falla a validación",
     "optional-markdown-content": "Opcional: Engadir contido markdown para incorporar directamente no recurso",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/he-he.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/he-he.json
@@ -3558,6 +3558,7 @@
     "only-reviewers-can-approve-or-reject": "רק בודקים יכולים לאשר או לדחות",
     "only-show-columns-with-lineage": "הצג רק עמודות עם Lineage",
     "openmetadata-docs-description": "Full setup guide, required privileges, and every supported field.",
+    "operation-forbidden-please-contact-admin": "אין לך הרשאות לבצע פעולה זו. אנא פנה אל מנהל המערכת.",
     "optional-configuration-update-description-dbt": "הגדרת אופציונלית לעדכון התיאור מ-dbT או לא",
     "optional-custom-error": "הודעת שגיאה מותאמת אישית אופציונלית המוצגת כאשר האימות נכשל",
     "optional-markdown-content": "אופציונלי: הוסף תוכן markdown להטמעה ישירות במשאב",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/ja-jp.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/ja-jp.json
@@ -3558,6 +3558,7 @@
     "only-reviewers-can-approve-or-reject": "承認または却下できるのはレビュアーのみです",
     "only-show-columns-with-lineage": "リネージを持つカラムのみを表示",
     "openmetadata-docs-description": "Full setup guide, required privileges, and every supported field.",
+    "operation-forbidden-please-contact-admin": "この操作を実行する権限がありません。管理者にお問い合わせください。",
     "optional-configuration-update-description-dbt": "dbt から説明文を更新するかどうかのオプション設定です",
     "optional-custom-error": "検証が失敗したときに表示される任意のカスタムエラーメッセージ",
     "optional-markdown-content": "オプション：リソースに直接埋め込むマークダウンコンテンツを追加",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/ko-kr.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/ko-kr.json
@@ -3558,6 +3558,7 @@
     "only-reviewers-can-approve-or-reject": "검토자만 승인 또는 거부할 수 있습니다",
     "only-show-columns-with-lineage": "리니지가 있는 컬럼만 표시",
     "openmetadata-docs-description": "Full setup guide, required privileges, and every supported field.",
+    "operation-forbidden-please-contact-admin": "이 작업을 수행할 권한이 없습니다. 관리자에게 문의하세요.",
     "optional-configuration-update-description-dbt": "dbt에서 설명을 업데이트할지 여부에 대한 선택적 구성",
     "optional-custom-error": "검증 실패 시 표시되는 선택적 사용자 지정 오류 메시지",
     "optional-markdown-content": "선택사항: 리소스에 직접 포함할 마크다운 콘텐츠 추가",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/mr-in.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/mr-in.json
@@ -3558,6 +3558,7 @@
     "only-reviewers-can-approve-or-reject": "फक्त पुनरावलोकक मंजूर किंवा नाकारू शकतात",
     "only-show-columns-with-lineage": "केवळ Lineage असलेले स्तंभ दाखवा",
     "openmetadata-docs-description": "Full setup guide, required privileges, and every supported field.",
+    "operation-forbidden-please-contact-admin": "ही क्रिया करण्यासाठी तुमच्याकडे परवानगी नाही. कृपया तुमच्या प्रशासकाशी संपर्क साधा.",
     "optional-configuration-update-description-dbt": "dbt मधून वर्णन अद्यतनित करण्यासाठी पर्यायी संरचना",
     "optional-custom-error": "प्रमाणीकरण अयशस्वी झाल्यावर दर्शविला जाणारा ऐच्छिक सानुकूल त्रुटी संदेश",
     "optional-markdown-content": "पर्यायी: संसाधनात थेट एम्बेड करण्यासाठी markdown सामग्री जोडा",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/nl-nl.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/nl-nl.json
@@ -3558,6 +3558,7 @@
     "only-reviewers-can-approve-or-reject": "Alleen reviewers kunnen goedkeuren of afwijzen",
     "only-show-columns-with-lineage": "Toon alleen kolommen met Lineage",
     "openmetadata-docs-description": "Full setup guide, required privileges, and every supported field.",
+    "operation-forbidden-please-contact-admin": "U heeft geen rechten om deze actie uit te voeren. Neem contact op met uw beheerder.",
     "optional-configuration-update-description-dbt": "Optionele configuratie om de beschrijving van dbt eventueel bij te werken",
     "optional-custom-error": "Optioneel aangepast foutbericht dat wordt getoond wanneer validatie mislukt",
     "optional-markdown-content": "Optioneel: Voeg markdown-inhoud toe om direct in de bron in te sluiten",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/pr-pr.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/pr-pr.json
@@ -3558,6 +3558,7 @@
     "only-reviewers-can-approve-or-reject": "فقط بازبینان می‌توانند تأیید یا رد کنند.",
     "only-show-columns-with-lineage": "فقط ستون‌هایی با Lineage را نمایش بده",
     "openmetadata-docs-description": "Full setup guide, required privileges, and every supported field.",
+    "operation-forbidden-please-contact-admin": "شما اجازه انجام این عمل را ندارید. لطفاً با مدیر سیستم خود تماس بگیرید.",
     "optional-configuration-update-description-dbt": "پیکربندی اختیاری برای به‌روزرسانی توضیحات از dbt یا خیر.",
     "optional-custom-error": "پیام خطای سفارشی اختیاری که هنگام شکست اعتبارسنجی نمایش داده می‌شود",
     "optional-markdown-content": "اختیاری: محتوای Markdown را برای جاسازی مستقیم در منبع اضافه کنید",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/pt-br.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/pt-br.json
@@ -3558,6 +3558,7 @@
     "only-reviewers-can-approve-or-reject": "Apenas Revisores podem Aprovar ou Rejeitar",
     "only-show-columns-with-lineage": "Mostrar apenas colunas com Lineage",
     "openmetadata-docs-description": "Full setup guide, required privileges, and every supported field.",
+    "operation-forbidden-please-contact-admin": "Você não tem permissão para executar esta ação. Entre em contato com o administrador.",
     "optional-configuration-update-description-dbt": "Configuração opcional para atualizar a descrição do dbt ou não",
     "optional-custom-error": "Mensagem de erro personalizada opcional exibida quando a validação falha",
     "optional-markdown-content": "Opcional: Adicionar conteúdo markdown para incorporar diretamente no recurso",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/pt-pt.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/pt-pt.json
@@ -3558,6 +3558,7 @@
     "only-reviewers-can-approve-or-reject": "Apenas Revisores podem Aprovar ou Rejeitar",
     "only-show-columns-with-lineage": "Mostrar apenas colunas com Linhagem",
     "openmetadata-docs-description": "Full setup guide, required privileges, and every supported field.",
+    "operation-forbidden-please-contact-admin": "Não tem permissões para executar esta ação. Contacte o seu administrador.",
     "optional-configuration-update-description-dbt": "Configuração opcional para atualizar a descrição do dbt ou não",
     "optional-custom-error": "Mensagem de erro personalizada opcional apresentada quando a validação falha",
     "optional-markdown-content": "Opcional: Adicionar conteúdo markdown para incorporar diretamente no recurso",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/ru-ru.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/ru-ru.json
@@ -3558,6 +3558,7 @@
     "only-reviewers-can-approve-or-reject": "Только согласующие могут подтвердить или отклонить термин",
     "only-show-columns-with-lineage": "Показать только столбцы с Lineage",
     "openmetadata-docs-description": "Full setup guide, required privileges, and every supported field.",
+    "operation-forbidden-please-contact-admin": "У вас нет прав для выполнения этого действия. Обратитесь к администратору.",
     "optional-configuration-update-description-dbt": "Необязательная конфигурация для обновления описания из dbt или нет",
     "optional-custom-error": "Необязательное пользовательское сообщение об ошибке, отображаемое при сбое проверки",
     "optional-markdown-content": "Необязательно: Добавить markdown контент для встраивания непосредственно в ресурс",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/sv-se.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/sv-se.json
@@ -3558,6 +3558,7 @@
     "only-reviewers-can-approve-or-reject": "Endast granskare kan godkänna eller avslå",
     "only-show-columns-with-lineage": "Visa endast kolumner med härkomst",
     "openmetadata-docs-description": "Fullständig installationsguide, nödvändiga behörigheter och alla stödda fält.",
+    "operation-forbidden-please-contact-admin": "Du har inte behörighet att utföra den här åtgärden. Kontakta din administratör.",
     "optional-configuration-update-description-dbt": "Valfri konfiguration för att uppdatera beskrivningen från dbt eller inte",
     "optional-custom-error": "Optional custom error message shown when validation fails",
     "optional-markdown-content": "Valfritt: Lägg till markdown-innehåll för att bädda in direkt i resursen",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/th-th.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/th-th.json
@@ -3558,6 +3558,7 @@
     "only-reviewers-can-approve-or-reject": "เฉพาะผู้ตรวจสอบเท่านั้นที่สามารถอนุมัติหรือปฏิเสธ",
     "only-show-columns-with-lineage": "แสดงเฉพาะคอลัมน์ที่มี Lineage",
     "openmetadata-docs-description": "Full setup guide, required privileges, and every supported field.",
+    "operation-forbidden-please-contact-admin": "คุณไม่มีสิทธิ์ดำเนินการนี้ โปรดติดต่อผู้ดูแลระบบของคุณ",
     "optional-configuration-update-description-dbt": "การตั้งค่าเสริมเพื่ออัปเดตคำอธิบายจาก dbt หรือไม่",
     "optional-custom-error": "ข้อความแสดงข้อผิดพลาดที่กำหนดเองซึ่งเป็นทางเลือก แสดงเมื่อการตรวจสอบล้มเหลว",
     "optional-markdown-content": "ตัวเลือก: เพิ่มเนื้อหา markdown เพื่อฝังโดยตรงในทรัพยากร",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/tr-tr.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/tr-tr.json
@@ -3558,6 +3558,7 @@
     "only-reviewers-can-approve-or-reject": "Yalnızca İnceleyiciler Onaylayabilir veya Reddedebilir",
     "only-show-columns-with-lineage": "Yalnızca Lineage olan sütunları göster",
     "openmetadata-docs-description": "Full setup guide, required privileges, and every supported field.",
+    "operation-forbidden-please-contact-admin": "Bu işlemi gerçekleştirme izniniz yok. Lütfen yöneticinizle iletişime geçin.",
     "optional-configuration-update-description-dbt": "Açıklamayı dbt'den güncellemek veya güncellememek için isteğe bağlı yapılandırma",
     "optional-custom-error": "Doğrulama başarısız olduğunda gösterilen isteğe bağlı özel hata mesajı",
     "optional-markdown-content": "İsteğe bağlı: Doğrudan kaynağa gömülecek markdown içeriği ekleyin",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/zh-cn.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/zh-cn.json
@@ -3558,6 +3558,7 @@
     "only-reviewers-can-approve-or-reject": "只有审核员可以批准或拒绝",
     "only-show-columns-with-lineage": "仅显示具有血缘关系的列",
     "openmetadata-docs-description": "Full setup guide, required privileges, and every supported field.",
+    "operation-forbidden-please-contact-admin": "您没有执行此操作的权限。请联系您的管理员。",
     "optional-configuration-update-description-dbt": "可选配置, 选择是否从 dbt 更新描述",
     "optional-custom-error": "验证失败时显示的可选自定义错误消息",
     "optional-markdown-content": "可选：添加要直接嵌入资源的 markdown 内容",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/zh-tw.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/zh-tw.json
@@ -3558,6 +3558,7 @@
     "only-reviewers-can-approve-or-reject": "只有審核者可以核准或拒絕",
     "only-show-columns-with-lineage": "僅顯示具有血緣關係的欄位",
     "openmetadata-docs-description": "Full setup guide, required privileges, and every supported field.",
+    "operation-forbidden-please-contact-admin": "您沒有執行此操作的權限。請聯絡您的管理員。",
     "optional-configuration-update-description-dbt": "是否從 dbt 更新描述的選用組態",
     "optional-custom-error": "驗證失敗時顯示的選填自訂錯誤訊息",
     "optional-markdown-content": "可選：添加要直接嵌入資源的 markdown 內容",

--- a/openmetadata-ui/src/main/resources/ui/src/utils/StringUtils.test.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/StringUtils.test.ts
@@ -28,11 +28,13 @@ jest.mock('./i18next/LocalUtil', () => ({
   },
 }));
 
+import { AxiosError } from 'axios';
 import {
   decodeHtmlEntities,
   formatJsonString,
   getDecodedFqn,
   getEncodedFqn,
+  getPermissionErrorText,
   jsonToCSV,
   ordinalize,
   removeAttachmentsWithoutUrl,
@@ -383,6 +385,38 @@ describe('StringUtils', () => {
 
     it('should trim surrounding whitespace', () => {
       expect(stripMarkdown('  **hello world**  ')).toBe('hello world');
+    });
+  });
+
+  describe('getPermissionErrorText', () => {
+    it('should return the friendly permission message for a 403 error', () => {
+      const error = {
+        response: { status: 403, data: { message: "operations not allowed" } },
+      } as AxiosError;
+
+      expect(getPermissionErrorText(error, 'fallback')).toBe(
+        'message.operation-forbidden-please-contact-admin'
+      );
+    });
+
+    it('should return the backend message for a non-403 error', () => {
+      const error = {
+        response: { status: 500, data: { message: 'boom' } },
+      } as AxiosError;
+
+      expect(getPermissionErrorText(error, 'fallback')).toBe('boom');
+    });
+
+    it('should return the fallback text when a non-403 error has no message', () => {
+      const error = { response: { status: 500, data: {} } } as AxiosError;
+
+      expect(getPermissionErrorText(error, 'fallback')).toBe('fallback');
+    });
+
+    it('should return a plain string error unchanged', () => {
+      expect(getPermissionErrorText('plain error', 'fallback')).toBe(
+        'plain error'
+      );
     });
   });
 });

--- a/openmetadata-ui/src/main/resources/ui/src/utils/StringUtils.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/StringUtils.ts
@@ -16,6 +16,7 @@ import parse from 'html-react-parser';
 import { get, isString } from 'lodash';
 import removeMarkdown from 'remove-markdown';
 import { VALIDATE_ESCAPE_START_END_REGEX } from '../constants/regex.constants';
+import { ClientErrors } from '../enums/Axios.enum';
 import i18n from './i18next/LocalUtil';
 
 export const pluralize = (count: number, noun: string, suffix = 's') => {
@@ -196,6 +197,19 @@ export const getErrorText = (
 
   // if error text is still empty, return the fallback text
   return errorText || fallbackText;
+};
+
+export const getPermissionErrorText = (
+  value: AxiosError | string,
+  fallbackText: string
+): string => {
+  const isForbidden =
+    !isString(value) &&
+    get(value, 'response.status') === ClientErrors.FORBIDDEN;
+
+  return isForbidden
+    ? i18n.t('message.operation-forbidden-please-contact-admin')
+    : getErrorText(value, fallbackText);
 };
 
 /**


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:

When a user without the required permission submits a **Data Access Request** in the Data Marketplace, the backend returns a raw `403` with a technical message like:
> Principal: CatalogPrincipal{name='ram'} operations [CreateTask] not allowed

This surfaced verbatim in the error toast, which is confusing for end users.
This PR adds a small, reusable helper that prettifies any authorization (403) failure into a clear, actionable message.

https://github.com/user-attachments/assets/b4d916c3-e1b7-4329-880d-1a0ef6084711




#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [x] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### High-level design:
<!--
REQUIRED for large PRs (new features, refactors, breaking changes, or anything touching >5 files).
Skip for small bug fixes and trivial changes.

Cover:
- Architecture / approach you took and why
- Key components or files added/changed and how they interact
- Alternatives considered and why you rejected them
- Any migration, backward-compatibility, or rollout concerns
- Diagrams or links to design docs / RFCs if available
-->

N/A — small change. <!-- Or fill in the design above -->

#
### Tests:

#### Use cases covered
<!--
List the user-visible scenarios this PR exercises. Example:
- User with Admin role can create a Glossary Term with a parent term
- Ingestion run for Snowflake correctly extracts row counts for partitioned tables
-->

#### Unit tests
<!--
- [ ] I added unit tests for the new/changed logic.
- Files added/updated:
- Coverage on changed classes (run `mvn jacoco:report` for backend, `yarn test:coverage` for UI,
  `make unit_ingestion` for ingestion). Target is 90% line coverage on changed classes.
- Coverage %: <e.g., 92% on EntityRepository.java>
-->

#### Backend integration tests
<!--
- [ ] I added integration tests in `openmetadata-integration-tests/` for new/changed API endpoints.
- [ ] Not applicable (no backend API changes).
- Files added/updated:
-->

#### Ingestion integration tests
<!--
- [ ] I added/updated ingestion integration tests for connector changes.
- [ ] Not applicable (no ingestion changes).
- Files added/updated:
-->

#### Playwright (UI) tests
<!--
- [ ] I added Playwright E2E tests under `openmetadata-ui/.../ui/playwright/` for UI changes.
- [ ] Not applicable (no UI changes).
- Files added/updated:
-->

#### Manual testing performed
<!--
List the manual test steps you performed before requesting review. Example:
1. Started local stack via `./docker/run_local_docker.sh -m ui -d mysql`
2. Logged in as admin, created entity X, verified Y appears in the UI
3. Triggered ingestion for Snowflake source, confirmed lineage edges in the explore page
-->

#
### UI screen recording / screenshots:
<!--
REQUIRED for any PR that changes the UI. Drag-and-drop a short screen recording (.mov / .mp4 / .gif)
demonstrating the change end-to-end, plus before/after screenshots where relevant.
Mark "Not applicable" if there are no UI changes.
-->

Not applicable. <!-- Or attach recording/screenshots above -->

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.
- [ ] For UI changes: I attached a screen recording and/or screenshots above.
- [ ] I have added tests (unit / integration / Playwright as applicable) and listed them above.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR introduces a `getPermissionErrorText` helper in `StringUtils.ts` that intercepts 403 responses and substitutes a friendly i18n message in place of the raw backend authorization error, along with the corresponding translation key added to all 20 locale files.

- **`getPermissionErrorText`** wraps the existing `getErrorText`, checks for `ClientErrors.FORBIDDEN`, and returns `message.operation-forbidden-please-contact-admin`; four unit tests cover the happy path, non-403 errors, missing messages, and plain strings.
- **The helper has no call site in this PR** — the Data Access Request submit handler that triggers the 403 toast is not updated, so the user-facing bug described in the PR description remains present after merge.
</details>

<details open><summary><h3>Confidence Score: 3/5</h3></summary>

Safe to merge as an infrastructure change, but the user-facing bug it targets will not be fixed until the submit handler is updated to call the new helper.

The new utility function and its translations are correct and well-tested, but the Data Access Request submit flow is never updated to call `getPermissionErrorText`. Raw 403 messages will continue to appear in toasts for users without permissions, which is the exact problem this PR claims to solve.

The component or hook handling the Data Access Request form submission needs to be identified and updated to replace its current error handler with `getPermissionErrorText`.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-ui/src/main/resources/ui/src/utils/StringUtils.ts | Adds getPermissionErrorText helper that maps 403 errors to a friendly i18n message; however the function has no call sites in the PR, so the bug it targets remains unresolved. |
| openmetadata-ui/src/main/resources/ui/src/utils/StringUtils.test.ts | Adds four unit tests covering the 403 path, non-403 path with/without message, and plain-string input — good coverage of the new helper. |
| openmetadata-ui/src/main/resources/ui/src/locale/languages/en-us.json | Adds operation-forbidden-please-contact-admin i18n key; content is clear and actionable. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Data Access Request Submit] -->|API call| B{HTTP Response}
    B -->|200 OK| C[Success Toast]
    B -->|403 Forbidden| D[Error Handler]
    D -->|Current: calls getErrorText| E[Raw backend message shown]
    D -->|Intended: calls getPermissionErrorText| F[Friendly i18n message]
    F -->|NEW helper exists| G[getPermissionErrorText in StringUtils.ts]
    G -->|status === 403| H[i18n.t operation-forbidden-please-contact-admin]
    G -->|status !== 403| I[delegate to getErrorText]
    style E fill:#f88,stroke:#c00
    style F fill:#8f8,stroke:#090
    style G fill:#ff8,stroke:#990
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Data Access Request Submit] -->|API call| B{HTTP Response}
    B -->|200 OK| C[Success Toast]
    B -->|403 Forbidden| D[Error Handler]
    D -->|Current: calls getErrorText| E[Raw backend message shown]
    D -->|Intended: calls getPermissionErrorText| F[Friendly i18n message]
    F -->|NEW helper exists| G[getPermissionErrorText in StringUtils.ts]
    G -->|status === 403| H[i18n.t operation-forbidden-please-contact-admin]
    G -->|status !== 403| I[delegate to getErrorText]
    style E fill:#f88,stroke:#c00
    style F fill:#8f8,stroke:#090
    style G fill:#ff8,stroke:#990
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["Refactor: show proper toast for permissi..."](https://github.com/open-metadata/openmetadata/commit/36c1142b5e37bf42cb1311a301170fe46fc6d783) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41324493)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->