### PR TITLE
fix(ui): fire global search suggestion query on mount with search text

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/AppBar/Suggestions.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/AppBar/Suggestions.test.tsx
@@ -10,7 +10,7 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-import { fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { useTourProvider } from '../../context/TourProvider/TourProvider';
 import { SearchIndex } from '../../enums/search.enum';
 import { searchQuery } from '../../rest/searchAPI';
@@ -69,6 +69,7 @@ const defaultProps = {
 describe('Suggestions Component', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockSearchQuery.mockResolvedValue({ hits: { hits: [] } });
     mockUseTourProvider.mockReturnValue({
       isTourOpen: false,
       updateTourPage: jest.fn(),
@@ -129,12 +130,25 @@ describe('Suggestions Component', () => {
   });
 
   describe('Component Behavior', () => {
-    it('should show no results message when searchText is provided but no results', () => {
+    it('should fetch suggestions on mount when searchText is provided', async () => {
+      render(<Suggestions {...defaultProps} searchText="test" />);
+
+      await waitFor(() =>
+        expect(mockSearchQuery).toHaveBeenCalledWith(
+          expect.objectContaining({
+            query: 'test',
+            searchIndex: SearchIndex.TABLE,
+          })
+        )
+      );
+    });
+
+    it('should show no results message when searchText is provided but no results', async () => {
       render(<Suggestions {...defaultProps} />);
 
       // The component should show the no results message
       expect(
-        screen.getByText('message.please-enter-to-find-data-assets')
+        await screen.findByText('message.please-enter-to-find-data-assets')
       ).toBeInTheDocument();
     });
 

--- a/openmetadata-ui/src/main/resources/ui/src/components/AppBar/Suggestions.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/AppBar/Suggestions.tsx
@@ -15,7 +15,7 @@ import { Button, Typography } from 'antd';
 import { AxiosError } from 'axios';
 import { isEmpty, isString } from 'lodash';
 import Qs from 'qs';
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { ReactComponent as IconSuggestionsBlue } from '../../assets/svg/ic-suggestions-blue.svg';
 import { PAGE_SIZE_BASE } from '../../constants/constants';
@@ -131,8 +131,6 @@ const Suggestions = ({
     metricSuggestions,
     columnSuggestions,
   } = suggestions;
-
-  const isMounting = useRef(true);
 
   const updateSuggestions = (options: Array<Option>) => {
     setSuggestions(() => ({
@@ -363,6 +361,8 @@ const Suggestions = ({
 
   const fetchSearchData = useCallback(async () => {
     if (isNLPActive) {
+      setIsLoading(false);
+
       return;
     }
 
@@ -393,17 +393,12 @@ const Suggestions = ({
   }, [searchText, searchCriteria]);
 
   useEffect(() => {
-    if (!isMounting.current && searchText && !isTourOpen) {
+    if (searchText && !isTourOpen) {
       fetchSearchData();
     } else {
       setIsLoading(false);
     }
   }, [searchText, searchCriteria]);
-
-  // always Keep this useEffect at the end...
-  useEffect(() => {
-    isMounting.current = false;
-  }, []);
 
   // Add a function to render AI query suggestions
   const renderAIQuerySuggestions = () => {


### PR DESCRIPTION
## Problem

Playwright postgresql-e2e has a large flaky surge concentrated in the entity suites (`Entity.spec.ts`, `EntityDataConsumer.spec.ts`, `EntityDataSteward.spec.ts`). In one run, **114 of ~124 first-attempt failures land on the exact same line** — `playwright/utils/entity.ts:77`, the `page.waitForResponse('/api/v1/search/query' … 'index=dataAsset' … 'exclude_source_fields')` inside `visitEntityPage`. Shard 5 alone showed **115 flaky** (2.5h) vs shard 2's 7 (1.7h).

## Root cause

`Suggestions.tsx` skipped its fetch on the first render via an `isMounting` ref (latent since 2021–2023):

1. `visitEntityPage` does `searchBox.fill(term)` → `GlobalSearchBar` opens the popover (mounts `<Suggestions>`) **and** starts a 400ms debounce that later sets the suggestion text.
2. Normally `<Suggestions>` mounts with empty text, then the debounce updates it → fetch fires.
3. **Under load**, React commits the popover-open *after* the 400ms debounce has already set the final text, so `<Suggestions>` mounts already carrying a non-empty `searchText`. The `isMounting` guard skips that render's fetch, `searchText` never changes again, and **the suggestion request is never sent** → `waitForResponse` hangs 30s → flaky.

It's also a real UX bug: users can type in global search and see no suggestions until they press another key. The prior 30s timeout bump (#29560) didn't help because the request was *absent*, not slow.

## Fix

Remove the `isMounting` guard so a non-empty `searchText` on mount always fetches — the existing `searchText` / `isTourOpen` / `isNLPActive` checks already cover every legitimate no-fetch case. Also clear the loader on the NLP early-return so it can't get stuck.

## Tests

- Added a regression unit test (`should fetch suggestions on mount when searchText is provided`) — verified it **fails without this fix and passes with it**.
- Full `Suggestions.test.tsx` suite green (7/7); UI checkstyle clean.

> This is one of two independent PRs for the flakiness surge. The other makes the entity e2e helpers navigate directly by FQN (removing the dependency on global search entirely). They're intentionally separate so each PR's flaky-count impact can be measured on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Removes the `isMounting` ref guard in `Suggestions.tsx` that was causing the component to skip its initial fetch when it mounted already carrying a non-empty `searchText` — a race condition that triggered ~114 Playwright flaky failures per run. The loader stuck-state when `isNLPActive` is true is also fixed with a `setIsLoading(false)` call on the early-return path.

- **`Suggestions.tsx`**: Drops the two-`useEffect` `isMounting` pattern; the fetch-or-clear logic now always runs on mount, matching the same guards (`searchText && !isTourOpen`) that were already applied for subsequent renders.
- **`Suggestions.test.tsx`**: Adds a regression test asserting that `searchQuery` is called on mount when `searchText` is provided; moves the "no results" assertion to `findByText` (async) and adds a shared `mockSearchQuery.mockResolvedValue` in `beforeEach` to prevent cross-test state leakage.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is a minimal, well-targeted removal of a latent guard that was causing mount-time fetches to be skipped under load.

Both changed files are narrowly scoped to the race condition fix. The existing guards (searchText && !isTourOpen, isNLPActive check inside fetchSearchData) continue to prevent spurious fetches in every legitimate no-fetch case. The added setIsLoading(false) in the NLP early-return path closes a loader stuck-state that was independently reachable. The new regression test directly covers the mount-time fetch path and will catch a reintroduction of the bug.

No files require special attention.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-ui/src/main/resources/ui/src/components/AppBar/Suggestions.tsx | Removes the isMounting ref guard so fetchSearchData fires on mount when searchText is already non-empty; also adds the missing setIsLoading(false) in the isNLPActive early-return path to prevent a permanently stuck loader. |
| openmetadata-ui/src/main/resources/ui/src/components/AppBar/Suggestions.test.tsx | Adds a regression test that directly verifies searchQuery is called on mount when searchText is provided; also moves the existing no-results assertion to async (findByText) and seeds mockSearchQuery in beforeEach to prevent cross-test leakage. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant PW as Playwright test
    participant GSB as GlobalSearchBar
    participant S as Suggestions (mounted)
    participant API as /api/v1/search/query

    note over PW,API: Before fix (isMounting guard)
    PW->>GSB: fill(searchTerm)
    GSB->>GSB: 400ms debounce starts
    note over GSB,S: Under load: debounce fires BEFORE popover commit
    GSB->>S: "mount with searchText='term'"
    S->>S: "useEffect fires — isMounting=true → skip fetch"
    S->>S: isMounting set to false
    note over API: searchText never changes → fetch never sent
    PW-->>API: waitForResponse hangs 30s → FLAKY

    note over PW,API: After fix (no isMounting guard)
    PW->>GSB: fill(searchTerm)
    GSB->>GSB: 400ms debounce starts
    GSB->>S: "mount with searchText='term'"
    S->>S: "useEffect fires — searchText && !isTourOpen → fetch"
    S->>API: searchQuery(term)
    API-->>S: hits
    S-->>PW: waitForResponse resolves ✓
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant PW as Playwright test
    participant GSB as GlobalSearchBar
    participant S as Suggestions (mounted)
    participant API as /api/v1/search/query

    note over PW,API: Before fix (isMounting guard)
    PW->>GSB: fill(searchTerm)
    GSB->>GSB: 400ms debounce starts
    note over GSB,S: Under load: debounce fires BEFORE popover commit
    GSB->>S: "mount with searchText='term'"
    S->>S: "useEffect fires — isMounting=true → skip fetch"
    S->>S: isMounting set to false
    note over API: searchText never changes → fetch never sent
    PW-->>API: waitForResponse hangs 30s → FLAKY

    note over PW,API: After fix (no isMounting guard)
    PW->>GSB: fill(searchTerm)
    GSB->>GSB: 400ms debounce starts
    GSB->>S: "mount with searchText='term'"
    S->>S: "useEffect fires — searchText && !isTourOpen → fetch"
    S->>API: searchQuery(term)
    API-->>S: hits
    S-->>PW: waitForResponse resolves ✓
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(ui): fire global search suggestion q..."](https://github.com/open-metadata/openmetadata/commit/7b2f74d2223d3c0fb9e6275dfd36c77c1573a439) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41349081)</sub>

<!-- /greptile_comment -->