### PR TITLE
Revamped metric ontology and workflow header

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/pages/MetricsPage/MetricListPage/MetricListHeader.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/MetricsPage/MetricListPage/MetricListHeader.tsx
@@ -1,0 +1,154 @@
+/*
+ *  Copyright 2024 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+import { Button, Dropdown } from '@openmetadata/ui-core-components';
+import {
+  Download01,
+  File06,
+  Plus,
+  Trash01,
+  UploadCloud01,
+} from '@untitledui/icons';
+import React, { FC } from 'react';
+import { useTranslation } from 'react-i18next';
+import PageHeader from '../../../components/PageHeader/PageHeader.component';
+import { LEARNING_PAGE_IDS } from '../../../constants/Learning.constants';
+import { OperationPermission } from '../../../context/PermissionProvider/PermissionProvider.interface';
+import LimitWrapper from '../../../hoc/LimitWrapper';
+
+export interface MetricListHeaderProps {
+  permission: OperationPermission;
+  isActionsOpen: boolean;
+  onActionsOpenChange: (open: boolean) => void;
+  isExporting: boolean;
+  onExport: () => void;
+  onImport: () => void;
+  onAddMetric: () => void;
+}
+
+const MetricListHeader: FC<MetricListHeaderProps> = ({
+  permission,
+  isActionsOpen,
+  onActionsOpenChange,
+  isExporting,
+  onExport,
+  onImport,
+  onAddMetric,
+}) => {
+  const { t } = useTranslation();
+
+  return (
+    <div className="d-flex justify-between">
+      <PageHeader
+        data={{
+          header: t('label.metric-plural'),
+          subHeader: t('message.metric-description'),
+        }}
+        learningPageId={LEARNING_PAGE_IDS.METRICS}
+        title={t('label.metric')}
+      />
+      <div className="d-flex gap-2 metric-list-actions">
+        {permission.Create && (
+          <LimitWrapper resource="metric">
+            <Button
+              className="metric-list-add-button"
+              color="primary"
+              data-testid="create-metric"
+              iconLeading={Plus}
+              size="sm"
+              onPress={onAddMetric}>
+              {t('label.add-entity', { entity: t('label.metric') })}
+            </Button>
+          </LimitWrapper>
+        )}
+        {permission.EditAll && (
+          <Dropdown.Root isOpen={isActionsOpen} onOpenChange={onActionsOpenChange}>
+            <Dropdown.DotsButton
+              className="metric-list-kebab"
+              data-testid="metric-actions"
+            />
+            <Dropdown.Popover className="metric-actions-menu">
+              <div className="metric-actions-menu-content">
+                <button
+                  aria-busy={isExporting}
+                  className="metric-actions-menu-item"
+                  disabled={isExporting}
+                  type="button"
+                  onClick={onExport}>
+                  <span className="metric-actions-icon">
+                    <Download01 size={18} />
+                  </span>
+                  <span>
+                    <span className="metric-actions-title">
+                      {t('label.export')}
+                    </span>
+                    <span className="metric-actions-description">
+                      {t('message.metrics-export-description')}
+                    </span>
+                  </span>
+                </button>
+                <button
+                  className="metric-actions-menu-item"
+                  type="button"
+                  onClick={onImport}>
+                  <span className="metric-actions-icon">
+                    <UploadCloud01 size={18} />
+                  </span>
+                  <span>
+                    <span className="metric-actions-title">
+                      {t('label.import')}
+                    </span>
+                    <span className="metric-actions-description">
+                      {t('message.metrics-import-description')}
+                    </span>
+                  </span>
+                </button>
+                <span className="metric-actions-separator" />
+                <button className="metric-actions-menu-item" type="button">
+                  <span className="metric-actions-icon">
+                    <File06 size={18} />
+                  </span>
+                  <span>
+                    <span className="metric-actions-title">
+                      {t('label.rename')}
+                    </span>
+                    <span className="metric-actions-description">
+                      {t('message.metrics-rename-collection-description')}
+                    </span>
+                  </span>
+                </button>
+                <button
+                  className="metric-actions-menu-item metric-actions-menu-item-danger"
+                  type="button">
+                  <span className="metric-actions-icon">
+                    <Trash01 size={18} />
+                  </span>
+                  <span>
+                    <span className="metric-actions-title">
+                      {t('label.delete')}
+                    </span>
+                    <span className="metric-actions-description">
+                      {t('message.metrics-delete-collection-description')}
+                    </span>
+                  </span>
+                </button>
+              </div>
+            </Dropdown.Popover>
+          </Dropdown.Root>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default MetricListHeader;

--- a/openmetadata-ui/src/main/resources/ui/src/pages/MetricsPage/MetricListPage/MetricListPage.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/MetricsPage/MetricListPage/MetricListPage.tsx
@@ -26,16 +26,12 @@ import {
   BarChartSquare02,
   Check,
   ChevronDown,
-  Download01,
   Edit03,
   Eye,
   EyeOff,
-  File06,
-  Plus,
   SearchLg,
   Settings01,
   Trash01,
-  UploadCloud01,
   XClose,
 } from '@untitledui/icons';
 import { AxiosError } from 'axios';
@@ -50,20 +46,19 @@ import {
 } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Link, useNavigate } from 'react-router-dom';
+import metricListPageClassBase from './MetricListPageClassBase';
 import {
-  CsvJobsTray,
   CSV_JOBS_REFRESH_EVENT,
+  CsvJobsTray,
 } from '../../../components/common/EntityImport/CsvJobsTray/CsvJobsTray.component';
 import ErrorPlaceHolder from '../../../components/common/ErrorWithPlaceholder/ErrorPlaceHolder';
 import Loader from '../../../components/common/Loader/Loader';
 import { PagingHandlerParams } from '../../../components/common/NextPrevious/NextPrevious.interface';
 import Table from '../../../components/common/Table/TableV2';
-import PageHeader from '../../../components/PageHeader/PageHeader.component';
 import PageLayoutV1 from '../../../components/PageLayoutV1/PageLayoutV1';
 import { WILD_CARD_CHAR } from '../../../constants/char.constants';
 import { ROUTES } from '../../../constants/constants';
 import { METRICS_DOCS } from '../../../constants/docs.constants';
-import { LEARNING_PAGE_IDS } from '../../../constants/Learning.constants';
 import { usePermissionProvider } from '../../../context/PermissionProvider/PermissionProvider';
 import {
   OperationPermission,
@@ -75,7 +70,6 @@ import { EntityStatus, Metric } from '../../../generated/entity/data/metric';
 import { Include } from '../../../generated/type/include';
 import { Paging } from '../../../generated/type/paging';
 import { TagLabel, TagSource } from '../../../generated/type/tagLabel';
-import LimitWrapper from '../../../hoc/LimitWrapper';
 import { usePaging } from '../../../hooks/paging/usePaging';
 import {
   deleteMetricAsync,
@@ -660,115 +654,20 @@ const MetricListPage = () => {
     );
   }
 
+  const MetricHeader = metricListPageClassBase.getHeader();
+
   return (
     <PageLayoutV1 pageTitle={t('label.metric-plural')}>
       <div className="p-b-md m-t-xs metric-list-page-stack">
-        <div>
-          <div className="d-flex justify-between">
-            <PageHeader
-              data={{
-                header: t('label.metric-plural'),
-                subHeader: t('message.metric-description'),
-              }}
-              learningPageId={LEARNING_PAGE_IDS.METRICS}
-              title={t('label.metric')}
-            />
-            <div className="d-flex gap-2 metric-list-actions">
-              {permission.Create && (
-                <LimitWrapper resource="metric">
-                  <Button
-                    className="metric-list-add-button"
-                    color="primary"
-                    data-testid="create-metric"
-                    iconLeading={Plus}
-                    size="sm"
-                    onPress={() => navigate(ROUTES.ADD_METRIC)}>
-                    {t('label.add-entity', { entity: t('label.metric') })}
-                  </Button>
-                </LimitWrapper>
-              )}
-              {permission.EditAll && (
-                <Dropdown.Root
-                  isOpen={isMetricActionsOpen}
-                  onOpenChange={setIsMetricActionsOpen}>
-                  <Dropdown.DotsButton
-                    className="metric-list-kebab"
-                    data-testid="metric-actions"
-                  />
-                  <Dropdown.Popover className="metric-actions-menu">
-                    <div className="metric-actions-menu-content">
-                      <button
-                        aria-busy={isExporting}
-                        className="metric-actions-menu-item"
-                        disabled={isExporting}
-                        type="button"
-                        onClick={handleExport}>
-                        <span className="metric-actions-icon">
-                          <Download01 size={18} />
-                        </span>
-                        <span>
-                          <span className="metric-actions-title">
-                            {t('label.export')}
-                          </span>
-                          <span className="metric-actions-description">
-                            {t('message.metrics-export-description')}
-                          </span>
-                        </span>
-                      </button>
-                      <button
-                        className="metric-actions-menu-item"
-                        type="button"
-                        onClick={handleImport}>
-                        <span className="metric-actions-icon">
-                          <UploadCloud01 size={18} />
-                        </span>
-                        <span>
-                          <span className="metric-actions-title">
-                            {t('label.import')}
-                          </span>
-                          <span className="metric-actions-description">
-                            {t('message.metrics-import-description')}
-                          </span>
-                        </span>
-                      </button>
-                      <span className="metric-actions-separator" />
-                      <button
-                        className="metric-actions-menu-item"
-                        type="button">
-                        <span className="metric-actions-icon">
-                          <File06 size={18} />
-                        </span>
-                        <span>
-                          <span className="metric-actions-title">
-                            {t('label.rename')}
-                          </span>
-                          <span className="metric-actions-description">
-                            {t('message.metrics-rename-collection-description')}
-                          </span>
-                        </span>
-                      </button>
-                      <button
-                        className="metric-actions-menu-item metric-actions-menu-item-danger"
-                        type="button">
-                        <span className="metric-actions-icon">
-                          <Trash01 size={18} />
-                        </span>
-                        <span>
-                          <span className="metric-actions-title">
-                            {t('label.delete')}
-                          </span>
-                          <span className="metric-actions-description">
-                            {t('message.metrics-delete-collection-description')}
-                          </span>
-                        </span>
-                      </button>
-                    </div>
-                  </Dropdown.Popover>
-                </Dropdown.Root>
-              )}
-            </div>
-          </div>
-        </div>
+        <MetricHeader
+          isActionsOpen={isMetricActionsOpen}
+          isExporting={isExporting}
+          permission={permission}
+          onActionsOpenChange={setIsMetricActionsOpen}
+          onAddMetric={() => navigate(ROUTES.ADD_METRIC)}
+          onExport={handleExport}
+          onImport={handleImport}
+        />
         <div>
           <div className="metric-list-table-card">
             {selectedMetricIds.length ? (

--- a/openmetadata-ui/src/main/resources/ui/src/pages/MetricsPage/MetricListPage/MetricListPageClassBase.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/MetricsPage/MetricListPage/MetricListPageClassBase.ts
@@ -1,0 +1,36 @@
+/*
+ *  Copyright 2024 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+import { type FC } from 'react';
+import MetricListHeader, {
+  MetricListHeaderProps,
+} from './MetricListHeader';
+
+/**
+ * Extension point for the Metric list page header. OSS default is the plain
+ * title + actions row; Collate overrides `getHeader` (via
+ * `MetricListPageClassCollate`, wired by the class-replacement Vite plugin)
+ * to wrap it in the gradient header. Keeps the shared page differing between
+ * Collate and OSS without a fork.
+ */
+class MetricListPageClassBase {
+  public getHeader(): FC<MetricListHeaderProps> {
+    return MetricListHeader;
+  }
+}
+
+const metricListPageClassBase = new MetricListPageClassBase();
+
+export default metricListPageClassBase;
+
+export { MetricListPageClassBase };

--- a/openmetadata-ui/src/main/resources/ui/src/pages/OntologyExplorerPage/OntologyExplorerHeader.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/OntologyExplorerPage/OntologyExplorerHeader.tsx
@@ -1,0 +1,103 @@
+/*
+ *  Copyright 2024 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+import {
+  Badge,
+  Card,
+  Divider,
+  Skeleton,
+  Typography,
+} from '@openmetadata/ui-core-components';
+import { Home02 } from '@untitledui/icons';
+import React, { FC } from 'react';
+import { useTranslation } from 'react-i18next';
+import TitleBreadcrumb from '../../components/common/TitleBreadcrumb/TitleBreadcrumb.component';
+
+export interface OntologyExplorerHeaderProps {
+  stats: string[];
+  isStatsLoading: boolean;
+}
+
+const OntologyExplorerHeader: FC<OntologyExplorerHeaderProps> = ({
+  stats,
+  isStatsLoading,
+}) => {
+  const { t } = useTranslation();
+
+  return (
+    <>
+      <TitleBreadcrumb
+        useCustomArrow
+        titleLinks={[
+          {
+            name: '',
+            icon: <Home02 size={12} />,
+            url: '/',
+            activeTitle: true,
+          },
+          {
+            name: t('label.ontology-explorer'),
+            url: '',
+          },
+        ]}
+      />
+
+      <Card className="tw:p-5">
+        <div className="tw:flex tw:items-center tw:gap-2">
+          <Typography
+            as="span"
+            data-testid="heading"
+            size="text-md"
+            weight="semibold">
+            {t('label.ontology-explorer')}
+          </Typography>
+          <Badge
+            color="blue-light"
+            data-testid="beta-badge"
+            size="sm"
+            type="pill-color">
+            {t('label.beta')}
+          </Badge>
+        </div>
+        <div
+          className="tw:mt-1 tw:flex tw:flex-wrap tw:items-center tw:gap-2"
+          data-testid="ontology-explorer-stats">
+          {isStatsLoading
+            ? [1, 2, 3].map((i) => (
+                <Skeleton height={20} key={i} variant="rounded" width={80} />
+              ))
+            : stats.map((item, index) => (
+                <React.Fragment key={item}>
+                  {index > 0 && (
+                    <Divider
+                      className="tw:h-4 tw:self-center"
+                      orientation="vertical"
+                    />
+                  )}
+                  <Typography
+                    data-testid={
+                      index === 0 ? 'ontology-explorer-stats-item' : undefined
+                    }
+                    size="text-sm"
+                    weight="regular">
+                    {item}
+                  </Typography>
+                </React.Fragment>
+              ))}
+        </div>
+      </Card>
+    </>
+  );
+};
+
+export default OntologyExplorerHeader;

--- a/openmetadata-ui/src/main/resources/ui/src/pages/OntologyExplorerPage/OntologyExplorerPage.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/OntologyExplorerPage/OntologyExplorerPage.tsx
@@ -11,24 +11,18 @@
  *  limitations under the License.
  */
 
-import {
-  Badge,
-  Card,
-  Divider,
-  Skeleton,
-  Typography,
-} from '@openmetadata/ui-core-components';
-import { Home02 } from '@untitledui/icons';
 import React, { useCallback, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import TitleBreadcrumb from '../../components/common/TitleBreadcrumb/TitleBreadcrumb.component';
 import { OntologyExplorer } from '../../components/OntologyExplorer';
 import PageLayoutV1 from '../../components/PageLayoutV1/PageLayoutV1';
+import ontologyExplorerClassBase from '../../utils/OntologyExplorerClassBase';
 
 const OntologyExplorerPage: React.FC = () => {
   const { t } = useTranslation();
   const [stats, setStats] = useState<string[]>([]);
   const [isStatsLoading, setIsStatsLoading] = useState(true);
+
+  const OntologyHeader = ontologyExplorerClassBase.getHeader();
 
   const handleStatsChange = useCallback((newStats: string[]) => {
     setStats(newStats);
@@ -41,66 +35,7 @@ const OntologyExplorerPage: React.FC = () => {
   return (
     <PageLayoutV1 pageTitle={t('label.ontology-explorer')}>
       <div className="tw:flex tw:flex-col tw:gap-3">
-        <TitleBreadcrumb
-          useCustomArrow
-          titleLinks={[
-            {
-              name: '',
-              icon: <Home02 size={12} />,
-              url: '/',
-              activeTitle: true,
-            },
-            {
-              name: t('label.ontology-explorer'),
-              url: '',
-            },
-          ]}
-        />
-
-        <Card className="tw:p-5">
-          <div className="tw:flex tw:items-center tw:gap-2">
-            <Typography
-              as="span"
-              data-testid="heading"
-              size="text-md"
-              weight="semibold">
-              {t('label.ontology-explorer')}
-            </Typography>
-            <Badge
-              color="blue-light"
-              data-testid="beta-badge"
-              size="sm"
-              type="pill-color">
-              {t('label.beta')}
-            </Badge>
-          </div>
-          <div
-            className="tw:mt-1 tw:flex tw:flex-wrap tw:items-center tw:gap-2"
-            data-testid="ontology-explorer-stats">
-            {isStatsLoading
-              ? [1, 2, 3].map((i) => (
-                  <Skeleton height={20} key={i} variant="rounded" width={80} />
-                ))
-              : stats.map((item, index) => (
-                  <React.Fragment key={item}>
-                    {index > 0 && (
-                      <Divider
-                        className="tw:h-4 tw:self-center"
-                        orientation="vertical"
-                      />
-                    )}
-                    <Typography
-                      data-testid={
-                        index === 0 ? 'ontology-explorer-stats-item' : undefined
-                      }
-                      size="text-sm"
-                      weight="regular">
-                      {item}
-                    </Typography>
-                  </React.Fragment>
-                ))}
-          </div>
-        </Card>
+        <OntologyHeader isStatsLoading={isStatsLoading} stats={stats} />
 
         <OntologyExplorer
           height="calc(100vh - 230px)"

--- a/openmetadata-ui/src/main/resources/ui/src/pages/WorkflowDefinitions/WorkflowsPage/WorkflowsHeader.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/WorkflowDefinitions/WorkflowsPage/WorkflowsHeader.tsx
@@ -1,0 +1,62 @@
+/*
+ *  Copyright 2024 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+import { Button } from '@openmetadata/ui-core-components';
+import { Plus } from '@untitledui/icons';
+import React, { FC } from 'react';
+import { useTranslation } from 'react-i18next';
+import PageHeader from '../../../components/PageHeader/PageHeader.component';
+import { LEARNING_PAGE_IDS } from '../../../constants/Learning.constants';
+
+export interface WorkflowsHeaderProps {
+  allowCreateWorkflow: boolean;
+  onNewWorkflow: () => void;
+}
+
+/**
+ * Default (OSS) Workflows page header: the `bg-primary` rounded card with the
+ * title + "New workflow" action. Collate swaps this for the gradient header
+ * via `WorkflowClassCollate`. Must stay OSS-neutral.
+ */
+const WorkflowsHeader: FC<WorkflowsHeaderProps> = ({
+  allowCreateWorkflow,
+  onNewWorkflow,
+}) => {
+  const { t } = useTranslation();
+
+  return (
+    <div className="tw:px-6 tw:py-4 tw:bg-primary tw:rounded-xl tw:border tw:border-border-secondary tw:mb-4">
+      <div className="tw:flex tw:items-center tw:justify-between">
+        <PageHeader
+          data={{
+            header: t('label.workflow-plural'),
+            subHeader: t('message.workflow-subtitle'),
+          }}
+          learningPageId={LEARNING_PAGE_IDS.WORKFLOWS}
+          title={t('label.workflow-plural')}
+        />
+        {allowCreateWorkflow && (
+          <Button
+            data-testid="create-workflow-button"
+            iconLeading={Plus}
+            size="sm"
+            onPress={onNewWorkflow}>
+            {t('label.new-workflow')}
+          </Button>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default WorkflowsHeader;

--- a/openmetadata-ui/src/main/resources/ui/src/pages/WorkflowDefinitions/WorkflowsPage/WorkflowsPage.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/WorkflowDefinitions/WorkflowsPage/WorkflowsPage.tsx
@@ -18,7 +18,6 @@ import {
   TextArea,
   Typography,
 } from '@openmetadata/ui-core-components';
-import { Plus } from '@untitledui/icons';
 import { AxiosError } from 'axios';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -26,12 +25,10 @@ import { useNavigate } from 'react-router-dom';
 import { ReactComponent as WorkflowIcon } from '../../../assets/svg/workflow.svg';
 import ErrorPlaceHolder from '../../../components/common/ErrorWithPlaceholder/ErrorPlaceHolder';
 import Loader from '../../../components/common/Loader/Loader';
-import PageHeader from '../../../components/PageHeader/PageHeader.component';
 import PageLayoutV1 from '../../../components/PageLayoutV1/PageLayoutV1';
 import PaginationComponent from '../../../components/PaginationComponent/PaginationComponent';
 import WorkflowCard from '../../../components/WorkflowDefinitions/WorkflowCard/WorkflowCard.component';
 import { PAGE_SIZE_MEDIUM } from '../../../constants/constants';
-import { LEARNING_PAGE_IDS } from '../../../constants/Learning.constants';
 import { ERROR_PLACEHOLDER_TYPE } from '../../../enums/common.enum';
 import { WorkflowDefinition } from '../../../generated/governance/workflows/workflowDefinition';
 import { Paging } from '../../../generated/type/paging';
@@ -246,33 +243,18 @@ const WorkflowsPage = () => {
     );
   }
 
+  const WorkflowHeader = workflowClassBase.getHeader();
+
   return (
     <PageLayoutV1
       className="workflow-page"
       pageContainerStyle={{ paddingLeft: 0, paddingRight: 0 }}
       pageTitle={t('label.workflow-plural')}>
       <div className="tw:flex tw:flex-col tw:overflow-hidden tw:mx-6 tw:my-4">
-        <div className="tw:px-6 tw:py-4 tw:bg-primary tw:rounded-xl tw:border tw:border-border-secondary tw:mb-4">
-          <div className="tw:flex tw:items-center tw:justify-between">
-            <PageHeader
-              data={{
-                header: t('label.workflow-plural'),
-                subHeader: t('message.workflow-subtitle'),
-              }}
-              learningPageId={LEARNING_PAGE_IDS.WORKFLOWS}
-              title={t('label.workflow-plural')}
-            />
-            {allowCreateWorkflow && (
-              <Button
-                data-testid="create-workflow-button"
-                iconLeading={Plus}
-                size="sm"
-                onPress={handleNewWorkflowClick}>
-                {t('label.new-workflow')}
-              </Button>
-            )}
-          </div>
-        </div>
+        <WorkflowHeader
+          allowCreateWorkflow={allowCreateWorkflow}
+          onNewWorkflow={handleNewWorkflowClick}
+        />
 
         <div className="tw:px-6 tw:py-4 tw:bg-primary tw:rounded-xl tw:border tw:border-border-secondary tw:flex tw:flex-col tw:flex-1 tw:justify-between">
           <div className="tw:mb-4">

--- a/openmetadata-ui/src/main/resources/ui/src/utils/OntologyExplorerClassBase.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/OntologyExplorerClassBase.ts
@@ -1,0 +1,30 @@
+/*
+ *  Copyright 2024 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+import { type FC } from 'react';
+import OntologyExplorerHeader, {
+  OntologyExplorerHeaderProps,
+} from '../pages/OntologyExplorerPage/OntologyExplorerHeader';
+
+
+class OntologyExplorerClassBase {
+  public getHeader(): FC<OntologyExplorerHeaderProps> {
+    return OntologyExplorerHeader;
+  }
+}
+
+const ontologyExplorerClassBase = new OntologyExplorerClassBase();
+
+export default ontologyExplorerClassBase;
+
+export { OntologyExplorerClassBase };

--- a/openmetadata-ui/src/main/resources/ui/src/utils/WorkflowClassBase.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/WorkflowClassBase.ts
@@ -11,6 +11,11 @@
  *  limitations under the License.
  */
 
+import { FC } from 'react';
+import WorkflowsHeader, {
+  WorkflowsHeaderProps,
+} from '../pages/WorkflowDefinitions/WorkflowsPage/WorkflowsHeader';
+
 export interface WorkflowCapabilities {
   allowCreateWorkflow: boolean;
   allowDeleteWorkflow: boolean;
@@ -34,6 +39,10 @@ export class WorkflowClassBase {
       allowScheduledTrigger: false,
       allowViewModeDrag: false,
     };
+  }
+
+  public getHeader(): FC<WorkflowsHeaderProps> {
+    return WorkflowsHeader;
   }
 }
 


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:

Fixes #<issue-number>
<!--
Linking an issue is REQUIRED. Replace <issue-number> with the GitHub issue number this PR addresses
(e.g., `Fixes #12345`). GitHub will auto-link it. If no issue exists, please open one first so the
problem and design can be discussed before review.
-->

<!--
Short blurb explaining:
- What changes did you make?
- Why did you make them?
-->

I worked on ... because ...

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### High-level design:
<!--
REQUIRED for large PRs (new features, refactors, breaking changes, or anything touching >5 files).
Skip for small bug fixes and trivial changes.

Cover:
- Architecture / approach you took and why
- Key components or files added/changed and how they interact
- Alternatives considered and why you rejected them
- Any migration, backward-compatibility, or rollout concerns
- Diagrams or links to design docs / RFCs if available
-->

N/A — small change. <!-- Or fill in the design above -->

#
### Tests:

#### Use cases covered
<!--
List the user-visible scenarios this PR exercises. Example:
- User with Admin role can create a Glossary Term with a parent term
- Ingestion run for Snowflake correctly extracts row counts for partitioned tables
-->

#### Unit tests
<!--
- [ ] I added unit tests for the new/changed logic.
- Files added/updated:
- Coverage on changed classes (run `mvn jacoco:report` for backend, `yarn test:coverage` for UI,
  `make unit_ingestion` for ingestion). Target is 90% line coverage on changed classes.
- Coverage %: <e.g., 92% on EntityRepository.java>
-->

#### Backend integration tests
<!--
- [ ] I added integration tests in `openmetadata-integration-tests/` for new/changed API endpoints.
- [ ] Not applicable (no backend API changes).
- Files added/updated:
-->

#### Ingestion integration tests
<!--
- [ ] I added/updated ingestion integration tests for connector changes.
- [ ] Not applicable (no ingestion changes).
- Files added/updated:
-->

#### Playwright (UI) tests
<!--
- [ ] I added Playwright E2E tests under `openmetadata-ui/.../ui/playwright/` for UI changes.
- [ ] Not applicable (no UI changes).
- Files added/updated:
-->

#### Manual testing performed
<!--
List the manual test steps you performed before requesting review. Example:
1. Started local stack via `./docker/run_local_docker.sh -m ui -d mysql`
2. Logged in as admin, created entity X, verified Y appears in the UI
3. Triggered ingestion for Snowflake source, confirmed lineage edges in the explore page
-->

#
### UI screen recording / screenshots:
<!--
REQUIRED for any PR that changes the UI. Drag-and-drop a short screen recording (.mov / .mp4 / .gif)
demonstrating the change end-to-end, plus before/after screenshots where relevant.
Mark "Not applicable" if there are no UI changes.
-->

Not applicable. <!-- Or attach recording/screenshots above -->

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.
- [ ] For UI changes: I attached a screen recording and/or screenshots above.
- [ ] I have added tests (unit / integration / Playwright as applicable) and listed them above.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR refactors the Metric list page, Ontology Explorer page, and Workflows page headers by extracting inline JSX into dedicated `*Header.tsx` components and routing them through the class-base singleton pattern (`MetricListPageClassBase`, `OntologyExplorerClassBase`, updated `WorkflowClassBase`). This enables Collate builds to swap in gradient-styled headers via the Vite class-replacement plugin without forking the shared page components.

- **Three new header components** (`MetricListHeader`, `OntologyExplorerHeader`, `WorkflowsHeader`) extract previously inline JSX with no logic changes; all props and state management remain in the parent pages.
- **Three new/updated class-base files** expose a `getHeader(): FC<Props>` extension point so Collate overrides can inject a different header implementation without touching OSS code.
- **`MetricListHeader`** carries over two non-functional stub buttons (Rename, Delete) with no `onClick` handlers that were also stubs in the original `MetricListPage`; now that they're part of a typed component API, they should either be wired up or removed.
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge — the changes are a mechanical refactor that moves JSX into dedicated components with no logic alterations; the class-base wiring is straightforward and follows an established pattern in the codebase.

The Rename and Delete buttons in MetricListHeader are non-functional stubs (no onClick, not in the props interface), and getHeader() is called inside component render bodies rather than at module level, making all three pages mildly fragile against Collate overrides that return non-stable component references. Neither issue affects current behavior, but both deserve a follow-up before adding Collate overrides.

MetricListHeader.tsx — the stub Rename/Delete buttons and their absence from MetricListHeaderProps need resolution before adding Collate-side implementations.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| openmetadata-ui/src/main/resources/ui/src/pages/MetricsPage/MetricListPage/MetricListHeader.tsx | New component extracting the Metric page header. Contains two non-functional action buttons (Rename, Delete) with no onClick handlers and no corresponding props in the interface. |
| openmetadata-ui/src/main/resources/ui/src/pages/MetricsPage/MetricListPage/MetricListPageClassBase.ts | New class-base for the metrics page header to support OSS/Collate override via the Vite class-replacement plugin. Clean singleton pattern. |
| openmetadata-ui/src/main/resources/ui/src/pages/MetricsPage/MetricListPage/MetricListPage.tsx | Delegates header rendering to MetricListPageClassBase; getHeader() is called inside the component render body — works today with stable references but is fragile against inline-function overrides. |
| openmetadata-ui/src/main/resources/ui/src/pages/OntologyExplorerPage/OntologyExplorerHeader.tsx | Extracts the Ontology Explorer breadcrumb and stats card into a standalone component; code moved verbatim from OntologyExplorerPage with no logic changes. |
| openmetadata-ui/src/main/resources/ui/src/pages/OntologyExplorerPage/OntologyExplorerPage.tsx | Now delegates header to OntologyExplorerClassBase; same getHeader()-inside-render pattern as MetricListPage. |
| openmetadata-ui/src/main/resources/ui/src/pages/WorkflowDefinitions/WorkflowsPage/WorkflowsHeader.tsx | New component for the Workflows page header; clean extraction with all required props (allowCreateWorkflow, onNewWorkflow). |
| openmetadata-ui/src/main/resources/ui/src/pages/WorkflowDefinitions/WorkflowsPage/WorkflowsPage.tsx | Delegates header to WorkflowClassBase; same getHeader()-inside-render pattern as the other pages. |
| openmetadata-ui/src/main/resources/ui/src/utils/OntologyExplorerClassBase.ts | New class-base for the OntologyExplorer header; has an extra blank line between imports and the class declaration (style). |
| openmetadata-ui/src/main/resources/ui/src/utils/WorkflowClassBase.ts | Adds getHeader() method to the existing WorkflowClassBase; clean addition following existing patterns. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    subgraph OSS ["OSS Build"]
        MLP["MetricListPage"] -->|"getHeader()"| MLCB["MetricListPageClassBase"]
        MLCB -->|returns| MLH["MetricListHeader"]

        OEP["OntologyExplorerPage"] -->|"getHeader()"| OECB["OntologyExplorerClassBase"]
        OECB -->|returns| OEH["OntologyExplorerHeader"]

        WP["WorkflowsPage"] -->|"getHeader()"| WCB["WorkflowClassBase"]
        WCB -->|returns| WH["WorkflowsHeader"]
    end

    subgraph Collate ["Collate Build - Vite plugin swaps ClassBase"]
        MLCB_C["MetricListPageClassCollate"] -->|"getHeader()"| MLH_C["GradientMetricHeader"]
        OECB_C["OntologyExplorerClassCollate"] -->|"getHeader()"| OEH_C["GradientOntologyHeader"]
        WCB_C["WorkflowClassCollate"] -->|"getHeader()"| WH_C["GradientWorkflowsHeader"]
    end

    MLP -.->|Collate override| MLCB_C
    OEP -.->|Collate override| OECB_C
    WP -.->|Collate override| WCB_C
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    subgraph OSS ["OSS Build"]
        MLP["MetricListPage"] -->|"getHeader()"| MLCB["MetricListPageClassBase"]
        MLCB -->|returns| MLH["MetricListHeader"]

        OEP["OntologyExplorerPage"] -->|"getHeader()"| OECB["OntologyExplorerClassBase"]
        OECB -->|returns| OEH["OntologyExplorerHeader"]

        WP["WorkflowsPage"] -->|"getHeader()"| WCB["WorkflowClassBase"]
        WCB -->|returns| WH["WorkflowsHeader"]
    end

    subgraph Collate ["Collate Build - Vite plugin swaps ClassBase"]
        MLCB_C["MetricListPageClassCollate"] -->|"getHeader()"| MLH_C["GradientMetricHeader"]
        OECB_C["OntologyExplorerClassCollate"] -->|"getHeader()"| OEH_C["GradientOntologyHeader"]
        WCB_C["WorkflowClassCollate"] -->|"getHeader()"| WH_C["GradientWorkflowsHeader"]
    end

    MLP -.->|Collate override| MLCB_C
    OEP -.->|Collate override| OECB_C
    WP -.->|Collate override| WCB_C
```

</a>
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `openmetadata-ui/src/main/resources/ui/src/pages/MetricsPage/MetricListPage/MetricListPage.tsx`, line 217 ([link](https://github.com/open-metadata/openmetadata/blob/712d20f41ade5b7b42f94fc7086a1754dd7e8750/openmetadata-ui/src/main/resources/ui/src/pages/MetricsPage/MetricListPage/MetricListPage.tsx#L217)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **`getHeader()` called inside the render body — same pattern in all three pages**

   `metricListPageClassBase.getHeader()` (and the equivalent calls in `OntologyExplorerPage` and `WorkflowsPage`) runs on every render of the parent component. React uses reference equality to decide whether to reconcile or unmount+remount a child component: if `getHeader()` ever returns a different function reference between renders — e.g., an override that does `return (props) => <GradientHeader {...props}/>` inline — React sees a new component type and unmounts the entire header subtree, discarding its local state. The current base-class implementations always return a stable module-level reference so it works today, but the pattern is fragile for Collate overrides. Moving these calls outside the component function (at module level) eliminates the risk entirely.

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["Revamped metric ontology and workflow he..."](https://github.com/open-metadata/openmetadata/commit/712d20f41ade5b7b42f94fc7086a1754dd7e8750) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41362930)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->