### PR TITLE
docs(claude): add ui-core-components skill

### DIFF
--- a/.claude/skills/ui-core-components/SKILL.md
+++ b/.claude/skills/ui-core-components/SKILL.md
@@ -1,0 +1,129 @@
+---
+name: ui-core-components
+description: Use when writing or editing React/TSX in `openmetadata-ui/src/main/resources/ui/src/` or `openmetadata-ui-core-components/`, before reaching for a raw `<div>` + Tailwind utility classes to build layout (flex rows/columns, grids, bordered panels with header/body/footer, separators). Applies whenever the change adds or restructures a layout container, not to every div.
+user-invocable: true
+argument-hint: "[component name to look up, e.g. Box, Grid, Card, Divider]"
+allowed-tools:
+  - Read
+  - Grep
+  - Glob
+---
+
+# UI Core Components
+
+`@openmetadata/ui-core-components` ships layout primitives that replace common
+`<div className="tw:flex ...">` / `<div className="tw:grid ...">` patterns.
+383+ files in `openmetadata-ui` already import from this package. Baseline
+testing shows agents default to raw `div` + Tailwind for layout unless told
+these exist — check this table before writing layout markup.
+
+## When to use a primitive vs. a raw div
+
+Only **layout container** divs (the ones whose `className` is mostly
+`flex`/`grid`/`gap`/`items-*`/`justify-*`/border-as-separator) go through a
+primitive. Leave alone: single non-layout divs, text wrappers, spans, icon
+wrappers, and anything built from antd/MUI form components — this is not a
+"replace every div" rule.
+
+## Quick reference
+
+| Raw pattern | Use instead |
+|---|---|
+| `<div className="tw:flex ...">` (row) | `<Box>` |
+| `<div className="tw:flex tw:flex-col ...">` | `<Box direction="col">` |
+| `<div className="tw:grid ...">` with column spans | `<Grid>` + `<Grid.Item span={n} start={n}>` |
+| Bordered container with a title/actions row, body, footer row | `<Card>` + `<Card.Header title=.. extra=..>` / `<Card.Content>` / `<Card.Footer>` |
+| `<hr>` or `<div className="tw:h-px tw:bg-...">` separator, optionally with a centered label | `<Divider>` (`orientation`, `label`, `labelAlign`) |
+
+Import from the package root:
+
+```tsx
+import { Box, Card, Divider, Grid } from '@openmetadata/ui-core-components';
+```
+
+## Box
+
+`Box` renders a `flex` (or `inline-flex`) div. Layout goes through props, not
+`className`:
+
+- `direction`: `'row' | 'col' | 'row-reverse' | 'col-reverse'` (default row)
+- `align`: `'start' | 'center' | 'end' | 'stretch' | 'baseline'`
+- `justify`: `'start' | 'center' | 'end' | 'between' | 'around' | 'evenly'`
+- `wrap`: `'wrap' | 'nowrap' | 'wrap-reverse'`
+- `gap` / `rowGap` / `colGap`: Tailwind spacing scale (`0`–`12`, `14`, `16`...`96`), not raw px
+- `inline`: boolean — `inline-flex` instead of `flex`
+
+`className` is still accepted for one-off overrides (margins, borders,
+backgrounds) — use it for what isn't a layout-direction/gap concern, not to
+re-add `tw:flex`.
+
+Real usage, `openmetadata-ui/src/main/resources/ui/src/components/DomainListing/DomainListPage.tsx:310-342`:
+
+```tsx
+<Box direction="col" style={isTreeView ? { height: 'calc(100vh - 80px)' } : {}}>
+  <HeaderBreadcrumb items={[...]} />
+  {pageHeader}
+  <Card style={{ marginBottom: 20 }} variant="elevated">
+    <Box
+      className="tw:px-6 tw:py-4 tw:border-b tw:border-secondary"
+      direction="col"
+      gap={4}>
+      <Box align="center" direction="row" gap={5}>
+        {titleAndCount}
+        {search}
+        {!isTreeView && quickFilters}
+        <Box className="tw:ml-auto" />
+        {viewToggle}
+        {deleteIconButton}
+      </Box>
+      {!isTreeView && filterSelectionDisplay}
+    </Box>
+    {content}
+  </Card>
+</Box>
+```
+
+## Grid / Grid.Item
+
+24-column grid. `Grid` takes `gap`/`rowGap`/`colGap` (scale `0`–`12`).
+`Grid.Item` takes `span` (default 24 = full width) and optional `start`
+(1-indexed column); both are clamped to the 24-column track.
+
+```tsx
+<Grid gap="4">
+  <Grid.Item span={16}>{main}</Grid.Item>
+  <Grid.Item span={8}>{sidebar}</Grid.Item>
+</Grid>
+```
+
+## Card
+
+`variant`: `default | elevated | outlined | ghost`. `color`:
+`default | brand | brandOutlined | error | warning | success`. `size`:
+`sm | md | lg` (controls `Card.Header`/`Card.Content`/`Card.Footer` padding).
+`isClickable` / `isSelected` add interactive/selected styling.
+
+```tsx
+<Card isClickable variant="elevated">
+  <Card.Header extra={<Button>Edit</Button>} subtitle="Updated 2h ago" title="orders" />
+  <Card.Content>{body}</Card.Content>
+  <Card.Footer>{footerActions}</Card.Footer>
+</Card>
+```
+
+## Divider
+
+`orientation`: `horizontal | vertical` (default horizontal). `label` +
+`labelAlign` (`start | center | end`) render a labeled separator instead of a
+plain line.
+
+```tsx
+<Divider label="or" labelAlign="center" />
+<Divider orientation="vertical" />
+```
+
+## Verify
+
+After using these, run the `ui-checkstyle` skill on the changed files before
+committing — it lints/formats both `openmetadata-ui` and
+`openmetadata-ui-core-components` trees.

--- a/.claude/skills/ui-core-components/SKILL.md
+++ b/.claude/skills/ui-core-components/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ui-core-components
-description: Use when writing or editing React/TSX in `openmetadata-ui/src/main/resources/ui/src/` or `openmetadata-ui-core-components/`, before reaching for a raw `<div>` + Tailwind utility classes to build layout (flex rows/columns, grids, bordered panels with header/body/footer, separators). Applies whenever the change adds or restructures a layout container, not to every div.
+description: Use when writing or editing React/TSX in `openmetadata-ui/src/main/resources/ui/src/` or `openmetadata-ui-core-components/`, before reaching for a raw `<div>` + Tailwind utility classes to build layout (flex rows/columns, grids, bordered panels with header/body/footer, separators), and before writing any Tailwind color class (`tw:bg-*`, `tw:text-*`, `tw:border-*`) or hex color value. Applies whenever the change adds or restructures a layout container or touches color/dark-mode styling, not to every div.
 user-invocable: true
 argument-hint: "[component name to look up, e.g. Box, Grid, Card, Divider]"
 allowed-tools:
@@ -121,6 +121,32 @@ plain line.
 <Divider label="or" labelAlign="center" />
 <Divider orientation="vertical" />
 ```
+
+## Color usage
+
+Never write a raw Tailwind palette class (`tw:bg-gray-50`, `tw:text-red-600`,
+`tw:border-blue-500`, ...) or a hardcoded hex value (`style={{ color:
+'#1570ef' }}`). Use the semantic color tokens instead — they remap
+automatically in dark mode via the `.dark-mode` class, raw palette classes do
+not.
+
+**REQUIRED REFERENCE:** read
+`openmetadata-ui/src/main/resources/ui/docs/colors.md` before writing or
+reviewing any color class — it has the full token table (backgrounds, text,
+borders, foreground/icon, utility/badge colors) plus a `dark-gray-red-green`
+→ semantic-token cheat sheet. Highlights:
+
+| Raw pattern | Use instead |
+|---|---|
+| `tw:bg-white` / `tw:bg-gray-50` | `tw:bg-primary` / `tw:bg-secondary` |
+| `tw:text-gray-900` / `tw:text-gray-500` | `tw:text-primary` / `tw:text-quaternary` |
+| `tw:border-gray-300` | `tw:border-primary` |
+| `tw:text-red-600` / `tw:border-red-500` | `tw:text-error-primary` / `tw:border-error` |
+| `tw:bg-green-50 tw:text-green-700` (badge) | `tw:bg-utility-success-50 tw:text-utility-success-700` |
+| `style={{ color: '#1570ef' }}` | `tw:text-fg-brand-primary` |
+
+Icons use `tw:text-fg-*` tokens, not `tw:text-*` — foreground tokens are
+tuned for icon contrast, text tokens aren't.
 
 ## Verify
 


### PR DESCRIPTION
## Summary
- Adds `.claude/skills/ui-core-components/SKILL.md`, a reference skill for Claude Code that maps common `<div>` + Tailwind layout patterns (flex rows/cols, grids, bordered header/body/footer panels, separators) to the matching `@openmetadata/ui-core-components` primitive (`Box`, `Grid`/`Grid.Item`, `Card`, `Divider`).
- Also covers color usage: points to the existing `openmetadata-ui/src/main/resources/ui/docs/colors.md` handbook and gives a compact raw-palette → semantic-token cheat sheet, instead of duplicating that ~380-line doc.
- Follows the same `.claude/skills/` pattern as `ui-checkstyle`, `playwright`, and `java-checkstyle`.

## Why
Baseline test: asked Claude to build a small layout component with no skill present — it defaulted to raw `<div className="tw:flex...">`, unaware `ui-core-components` (already used in 380+ files across `openmetadata-ui`) had a `Box` primitive for exactly that. With the skill present, the same task correctly used `Box` with `align`/`justify`/`gap` props instead.

Second baseline check found 31 files using raw Tailwind palette classes (`tw:bg-gray-50`, `tw:text-red-600`) instead of the semantic tokens `colors.md` already documents — those break dark mode. Same fix: point the skill at the existing handbook.

## Test plan
- [x] RED: subagent without skill produced raw div + Tailwind for a flex-row layout task
- [x] GREEN: same subagent, same task, with skill present, produced `<Box align="center" justify="between">` / `<Box gap={2}>`
- [x] RED/GREEN repeated for color: with skill present, an error-banner task used the `bg-error-primary` / `border-error` / `text-error-primary` / `text-fg-error-primary` token trio from `colors.md` instead of raw `red-*` classes
- [x] Verified referenced components (`Box`, `Grid`, `Card`, `Divider`) are actually exported from `@openmetadata/ui-core-components`
- [x] Doc-only change, no build/lint impact expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds `.claude/skills/ui-core-components/SKILL.md`, a reference document for Claude Code agents that maps common raw `<div>` + Tailwind layout patterns to their `@openmetadata/ui-core-components` equivalents (`Box`, `Grid`, `Card`, `Divider`). It follows the existing `.claude/skills/` convention used by `ui-checkstyle`, `playwright`, and `java-checkstyle`.

- The component props, import path, and color-token guidance are verified against the actual source (`box.tsx`, `grid.tsx`, `card.tsx`, `divider.tsx`) and are accurate.
- The `Box` gap range description uses `16`...`96` notation that implies a continuous range, while only specific values (multiples of 4 up to 64, then 72, 80, 96) are in `GapValues` — an agent could generate TypeScript-invalid gap values.
- The skill cross-links `ui-checkstyle` for lint/format validation after use, which is the correct workflow.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Doc-only change with no build or runtime impact; safe to merge.

The change is a single Markdown skill file with no code execution path. All four component APIs (Box, Grid, Card, Divider) were verified against the actual source files and are accurately described. The one inaccuracy — the Box gap range notation — would surface as a TypeScript compile error before any code ships, not a silent runtime bug.

No files require special attention beyond the minor Box gap range description noted in the review comment.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .claude/skills/ui-core-components/SKILL.md | Adds a Claude skill doc mapping raw div/Tailwind patterns to ui-core-components primitives (Box, Grid, Card, Divider). Component props, import path, and color-token guidance are accurate. One minor inaccuracy: Box gap range description implies a continuous 16–96 range when only specific Tailwind scale values are valid per the GapValues type. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Need a layout container?] --> B{What kind?}
    B -->|flex row/col| C[Box\nalign/justify/gap/direction props]
    B -->|multi-column grid| D[Grid + Grid.Item\n24-col, gap as string]
    B -->|titled panel with\nheader/body/footer| E[Card\nvariant/color/size/isClickable]
    B -->|horizontal or vertical\nseparator line| F[Divider\norientation/label/labelAlign]
    C --> G{Color/border needed?}
    D --> G
    E --> G
    F --> G
    G -->|yes| H[Use semantic tokens\ntw:bg-primary, tw:text-quaternary...\nsee colors.md]
    G -->|no| I[Done — run ui-checkstyle skill]
    H --> I
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Need a layout container?] --> B{What kind?}
    B -->|flex row/col| C[Box\nalign/justify/gap/direction props]
    B -->|multi-column grid| D[Grid + Grid.Item\n24-col, gap as string]
    B -->|titled panel with\nheader/body/footer| E[Card\nvariant/color/size/isClickable]
    B -->|horizontal or vertical\nseparator line| F[Divider\norientation/label/labelAlign]
    C --> G{Color/border needed?}
    D --> G
    E --> G
    F --> G
    G -->|yes| H[Use semantic tokens\ntw:bg-primary, tw:text-quaternary...\nsee colors.md]
    G -->|no| I[Done — run ui-checkstyle skill]
    H --> I
```

</a>
</details>

<sub>Reviews (2): Last reviewed commit: ["docs(claude): add color usage guidance t..."](https://github.com/open-metadata/openmetadata/commit/6c789dee6425fdbf292aba2322854b33bb79f4be) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41366079)</sub>

<!-- /greptile_comment -->