### PR TITLE
fix(workflows): treat expiryTimer.transitionId as a declared user-approval transition

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/WorkflowDefinitionRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/WorkflowDefinitionRepository.java
@@ -740,19 +740,21 @@ public class WorkflowDefinitionRepository extends EntityRepository<WorkflowDefin
 
   @SuppressWarnings("unchecked")
   private List<String> getConfiguredUserApprovalTransitions(WorkflowNodeDefinitionInterface node) {
-    if (node.getConfig() == null) {
-      return List.of();
+    List<String> transitionIds = new ArrayList<>();
+    if (node.getConfig() != null) {
+      Map<String, Object> config = JsonUtils.readOrConvertValue(node.getConfig(), Map.class);
+      collectTransitionMetadataIds(config.get("transitionMetadata"), transitionIds);
+      collectExpiryTimerTransitionId(config.get("expiryTimer"), transitionIds);
     }
+    return transitionIds;
+  }
 
-    Map<String, Object> config = JsonUtils.readOrConvertValue(node.getConfig(), Map.class);
-    Object transitionMetadata = config.get("transitionMetadata");
+  private void collectTransitionMetadataIds(Object transitionMetadata, List<String> transitionIds) {
     if (transitionMetadata == null) {
-      return List.of();
+      return;
     }
-
     List<Map<String, Object>> transitions =
         JsonUtils.readOrConvertValue(transitionMetadata, List.class);
-    List<String> transitionIds = new ArrayList<>();
     for (Map<String, Object> transition : transitions) {
       if (transition == null) {
         continue;
@@ -762,7 +764,21 @@ public class WorkflowDefinitionRepository extends EntityRepository<WorkflowDefin
         transitionIds.add(id.trim());
       }
     }
-    return transitionIds;
+  }
+
+  // expiryTimer.transitionId is a legitimate outgoing edge condition on a user approval task —
+  // it is emitted by the boundary timer's ExpireOnTimerImpl service task, not by a user click.
+  // Without this, workflows that use expiryTimer fail validation because the outgoing edge
+  // named after transitionId is not declared in transitionMetadata.
+  private void collectExpiryTimerTransitionId(Object expiryTimer, List<String> transitionIds) {
+    if (expiryTimer == null) {
+      return;
+    }
+    Map<String, Object> timerConfig = JsonUtils.readOrConvertValue(expiryTimer, Map.class);
+    Object transitionId = timerConfig.get("transitionId");
+    if (transitionId instanceof String id && !id.isBlank()) {
+      transitionIds.add(id.trim());
+    }
   }
 
   private void validateUserApprovalTransitions(

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/WorkflowDefinitionRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/WorkflowDefinitionRepository.java
@@ -749,6 +749,7 @@ public class WorkflowDefinitionRepository extends EntityRepository<WorkflowDefin
     return transitionIds;
   }
 
+  @SuppressWarnings("unchecked")
   private void collectTransitionMetadataIds(Object transitionMetadata, List<String> transitionIds) {
     if (transitionMetadata == null) {
       return;
@@ -770,6 +771,7 @@ public class WorkflowDefinitionRepository extends EntityRepository<WorkflowDefin
   // it is emitted by the boundary timer's ExpireOnTimerImpl service task, not by a user click.
   // Without this, workflows that use expiryTimer fail validation because the outgoing edge
   // named after transitionId is not declared in transitionMetadata.
+  @SuppressWarnings("unchecked")
   private void collectExpiryTimerTransitionId(Object expiryTimer, List<String> transitionIds) {
     if (expiryTimer == null) {
       return;

--- a/openmetadata-service/src/test/java/org/openmetadata/service/jdbi3/WorkflowDefinitionGraphValidationTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/jdbi3/WorkflowDefinitionGraphValidationTest.java
@@ -51,6 +51,63 @@ class WorkflowDefinitionGraphValidationTest {
         () -> validateGraph(workflow), "cycles are valid in workflow state machines");
   }
 
+  /**
+   * A userApprovalTask node with expiryTimer.transitionId set emits an outgoing edge condition
+   * named after that transitionId when the boundary timer fires. The validator must treat that
+   * transitionId as a declared transition so the edge condition doesn't fail the
+   * "conditions not declared in transitionMetadata" check.
+   */
+  @Test
+  void expiryTimerTransitionIdCountsAsDeclaredTransition() throws Exception {
+    WorkflowDefinition workflow =
+        JsonUtils.readValue(EXPIRY_TIMER_WORKFLOW_JSON, WorkflowDefinition.class);
+    assertDoesNotThrow(
+        () -> validateGraph(workflow),
+        "expiryTimer.transitionId should be treated as a declared transition");
+  }
+
+  private static final String EXPIRY_TIMER_WORKFLOW_JSON =
+      """
+      {
+        "name": "ExpiryTimerFixture",
+        "fullyQualifiedName": "ExpiryTimerFixture",
+        "displayName": "Expiry Timer Fixture",
+        "description": "Regression: expiryTimer.transitionId must satisfy validator.",
+        "trigger": {"type": "noOp", "config": {}, "output": ["relatedEntity"]},
+        "nodes": [
+          {"type": "startEvent", "subType": "startEvent",
+           "name": "Start", "displayName": "Start"},
+          {"type": "userTask", "subType": "userApprovalTask",
+           "name": "Review", "displayName": "Review",
+           "config": {
+             "assignees": {"addReviewers": true, "addOwners": false,
+                           "candidates": [], "emptyAssigneeStrategy": "assignAdmins"},
+             "approvalThreshold": 1, "rejectionThreshold": 1,
+             "stageId": "review", "stageDisplayName": "Review", "taskStatus": "Open",
+             "assigneeStrategy": "reviewers-and-assignees",
+             "transitionMetadata": [
+               {"id": "approve", "label": "Approve",
+                "targetStageId": "approved", "targetTaskStatus": "Approved",
+                "requiresComment": false}
+             ],
+             "expiryTimer": {"durationVariable": "reviewDuration",
+                             "transitionId": "expired",
+                             "closeAsResolution": "Expired"}
+           },
+           "inputNamespaceMap": {"relatedEntity": "global"}},
+          {"type": "endEvent", "subType": "endEvent",
+           "name": "ApprovedEnd", "displayName": "Approved"},
+          {"type": "endEvent", "subType": "endEvent",
+           "name": "ExpiredEnd", "displayName": "Expired"}
+        ],
+        "edges": [
+          {"from": "Start", "to": "Review"},
+          {"from": "Review", "to": "ApprovedEnd", "condition": "approve"},
+          {"from": "Review", "to": "ExpiredEnd", "condition": "expired"}
+        ]
+      }
+      """;
+
   private void validateGraph(WorkflowDefinition workflow) throws Throwable {
     try (MockedStatic<Entity> ignored = mockStatic(Entity.class, RETURNS_DEEP_STUBS)) {
       WorkflowDefinitionRepository repository = new WorkflowDefinitionRepository();


### PR DESCRIPTION
## Summary

The user-approval workflow validator introduced in the recent workflow-metadata refactor rejects every workflow that uses `expiryTimer` on a `userApprovalTask`. The boundary-timer's outgoing edge condition is fed by `expiryTimer.transitionId`, but `getConfiguredUserApprovalTransitions()` only looked at `transitionMetadata`, so the validator saw the timer's condition as an undeclared transition and threw:

```
Workflow 'X': User approval task 'Y' has outgoing sequence flows with conditions not declared in transitionMetadata: [expired]
```

Repro: collate's `DataAccessRequestTaskWorkflow.json` (post the auto-expire feature) has `expiryTimer.transitionId = "expired"` on both `ApprovedAccess` and `GrantedAccess` and outgoing edges with `condition: "expired"`. Since the OSS spec has no seeded workflow using `expiryTimer`, this was only caught downstream in collate CI (`DataAccessRequestIT` — workflow never registered → all downstream assertions fail).

## Fix

Extend `getConfiguredUserApprovalTransitions()` to collect **both**:
- `transitionMetadata[].id` (user-clickable transitions), and
- `expiryTimer.transitionId` (timer-fired transition).

Split into two focused helpers per the repo's Java style (`≤15 lines`, single-return).

Not declaring `expired` in `transitionMetadata`: that path leaks a fake "Expired" user action into the task's `availableTransitions` and the UI drawer buttons — timer-fired ≠ user-clickable.

## Test plan

- [x] `WorkflowDefinitionGraphValidationTest.expiryTimerTransitionIdCountsAsDeclaredTransition` — inline JSON fixture mirroring DAR `ApprovedAccess`: one user transition (`approve`) plus `expiryTimer.transitionId = "expired"` with matching outgoing edge. Fails without the fix; passes with it.
- [x] Existing `cyclicStateMachineWorkflowPassesGraphValidation` still green (regression check).
- [x] `TaskWorkflowHandlerTest`, `CreateTaskTest`, `TaskRepositoryTest` — 63 tests, all pass.
- [x] `mvn spotless:apply` clean.
- [ ] CI to confirm.

/safe-to-test

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes the workflow graph validator to accept `expiryTimer.transitionId` as a valid declared transition on `userApprovalTask` nodes, alongside the user-clickable entries in `transitionMetadata`. Without the fix, any workflow that uses the auto-expire boundary timer was rejected with a false-positive "conditions not declared in transitionMetadata" error.

- Refactors `getConfiguredUserApprovalTransitions()` into two focused helpers (`collectTransitionMetadataIds`, `collectExpiryTimerTransitionId`), each annotated with `@SuppressWarnings("unchecked")` for their own raw casts.
- Adds a targeted unit test (`expiryTimerTransitionIdCountsAsDeclaredTransition`) with an inline JSON fixture mirroring the real `DataAccessRequestTaskWorkflow` shape: one user-clickable transition (`approve`) plus `expiryTimer.transitionId = "expired"` with a matching outgoing edge.
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge for the common case; a degenerate workflow that lists the same ID in both transitionMetadata and expiryTimer.transitionId would surface an unhandled IllegalArgumentException from Set.copyOf rather than a clean validation error.

The fix logic is correct and the new test directly covers the regression. However, the Set.copyOf(configuredTransitions) call on line 791 of WorkflowDefinitionRepository.java throws IllegalArgumentException (not BadRequestException) when the two collection sources contribute the same string — a real gap on the changed path.

WorkflowDefinitionRepository.java — the validateUserApprovalTransitions method's Set.copyOf call on the now-combined list
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/WorkflowDefinitionRepository.java | Core fix: getConfiguredUserApprovalTransitions now collects both transitionMetadata IDs and expiryTimer.transitionId. The downstream Set.copyOf call (line 791) throws IllegalArgumentException if both sources contribute the same ID — a previously-flagged unresolved risk. |
| openmetadata-service/src/test/java/org/openmetadata/service/jdbi3/WorkflowDefinitionGraphValidationTest.java | New test expiryTimerTransitionIdCountsAsDeclaredTransition covers the regression case with an inline JSON fixture. Existing cyclicStateMachineWorkflowPassesGraphValidation unchanged. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[getConfiguredUserApprovalTransitions] --> B{config present?}
    B -- No --> C[return empty list]
    B -- Yes --> D[parse config Map]
    D --> E[collectTransitionMetadataIds]
    D --> F[collectExpiryTimerTransitionId]
    E --> G{transitionMetadata set?}
    G -- No --> H[skip]
    G -- Yes --> I[add each non-blank id]
    F --> J{expiryTimer set?}
    J -- No --> K[skip]
    J -- Yes --> L[extract transitionId]
    L --> M{non-blank String?}
    M -- No --> N[skip]
    M -- Yes --> O[add trimmed id]
    I --> P[combined configuredTransitions]
    O --> P
    H --> P
    K --> P
    N --> P
    P --> Q[validateUserApprovalTransitions]
    Q --> R[Set.copyOf - throws if duplicates]
    R --> S[check every configured ID has outgoing edge]
    R --> T[check every outgoing condition is declared]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[getConfiguredUserApprovalTransitions] --> B{config present?}
    B -- No --> C[return empty list]
    B -- Yes --> D[parse config Map]
    D --> E[collectTransitionMetadataIds]
    D --> F[collectExpiryTimerTransitionId]
    E --> G{transitionMetadata set?}
    G -- No --> H[skip]
    G -- Yes --> I[add each non-blank id]
    F --> J{expiryTimer set?}
    J -- No --> K[skip]
    J -- Yes --> L[extract transitionId]
    L --> M{non-blank String?}
    M -- No --> N[skip]
    M -- Yes --> O[add trimmed id]
    I --> P[combined configuredTransitions]
    O --> P
    H --> P
    K --> P
    N --> P
    P --> Q[validateUserApprovalTransitions]
    Q --> R[Set.copyOf - throws if duplicates]
    R --> S[check every configured ID has outgoing edge]
    R --> T[check every outgoing condition is declared]
```

</a>
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/WorkflowDefinitionRepository.java`, line 789 ([link](https://github.com/open-metadata/openmetadata/blob/aa8dc1d3f6c4df3dd4684564d9a8b6e4ee5d1bda/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/WorkflowDefinitionRepository.java#L789)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> `Set.copyOf(configuredTransitions)` throws `IllegalArgumentException` if the list contains duplicates. Before this PR, duplicates could only arise from duplicate IDs inside `transitionMetadata`. This PR introduces a second source: if `expiryTimer.transitionId` happens to equal any `transitionMetadata.id`, the list will contain that string twice and `Set.copyOf` will throw an unhandled `IllegalArgumentException` rather than a user-friendly `BadRequestException`. Consider deduplicating into a `LinkedHashSet` before building `configuredTransitionSet`, or asserting absence of the timer ID from `transitionMetadata` with an explicit validation error.
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["fix(workflows): @SuppressWarnings on the..."](https://github.com/open-metadata/openmetadata/commit/be3ff388f29a6c0ccdb4ead00bae5d837994754d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41461170)</sub>

<!-- /greptile_comment -->