### PR TITLE
Add createAndRunAIAutomationTask governance workflow node

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/governance/workflows/elements/NodeFactory.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/governance/workflows/elements/NodeFactory.java
@@ -87,6 +87,16 @@ public class NodeFactory {
               () ->
                   new IllegalStateException(
                       "policyAgentTask is a Collate-only feature — handler not registered"));
+      case CREATE_AND_RUN_AI_AUTOMATION_TASK -> NodeFactoryRegistry.getInstance()
+          .create(
+              NodeSubType.CREATE_AND_RUN_AI_AUTOMATION_TASK,
+              nodeDefinition,
+              config,
+              workflowDefinitionName)
+          .orElseThrow(
+              () ->
+                  new IllegalStateException(
+                      "createAndRunAIAutomationTask is a Collate-only feature — handler not registered"));
       default -> throw new IllegalArgumentException(
           "Unsupported node subtype: " + nodeDefinition.getSubType());
     };

--- a/openmetadata-service/src/main/java/org/openmetadata/service/governance/workflows/elements/NodeFactoryRegistry.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/governance/workflows/elements/NodeFactoryRegistry.java
@@ -49,6 +49,10 @@ public class NodeFactoryRegistry {
     extensions.remove(subType);
   }
 
+  public Optional<NodeFactoryExtension> getExtension(NodeSubType subType) {
+    return Optional.ofNullable(extensions.get(subType));
+  }
+
   public Optional<NodeInterface> create(
       NodeSubType subType,
       WorkflowNodeDefinitionInterface nodeDefinition,

--- a/openmetadata-service/src/main/java/org/openmetadata/service/governance/workflows/elements/NodeFactoryRegistry.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/governance/workflows/elements/NodeFactoryRegistry.java
@@ -49,7 +49,8 @@ public class NodeFactoryRegistry {
     extensions.remove(subType);
   }
 
-  public Optional<NodeFactoryExtension> getExtension(NodeSubType subType) {
+  // Package-private: only tests read the registry (production uses register/create).
+  Optional<NodeFactoryExtension> getExtension(NodeSubType subType) {
     return Optional.ofNullable(extensions.get(subType));
   }
 

--- a/openmetadata-service/src/main/java/org/openmetadata/service/governance/workflows/elements/NodeFactoryRegistry.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/governance/workflows/elements/NodeFactoryRegistry.java
@@ -49,11 +49,6 @@ public class NodeFactoryRegistry {
     extensions.remove(subType);
   }
 
-  // Package-private: only tests read the registry (production uses register/create).
-  Optional<NodeFactoryExtension> getExtension(NodeSubType subType) {
-    return Optional.ofNullable(extensions.get(subType));
-  }
-
   public Optional<NodeInterface> create(
       NodeSubType subType,
       WorkflowNodeDefinitionInterface nodeDefinition,

--- a/openmetadata-service/src/test/java/org/openmetadata/service/governance/workflows/elements/NodeFactoryAIAutomationTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/governance/workflows/elements/NodeFactoryAIAutomationTest.java
@@ -1,0 +1,39 @@
+/*
+ *  Copyright 2026 Collate
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.openmetadata.service.governance.workflows.elements;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+import org.openmetadata.schema.governance.workflows.WorkflowConfiguration;
+import org.openmetadata.schema.governance.workflows.elements.NodeSubType;
+import org.openmetadata.schema.governance.workflows.elements.nodes.automatedTask.CreateAndRunAIAutomationTaskDefinition;
+
+class NodeFactoryAIAutomationTest {
+
+  @Test
+  void createNode_aiAutomation_withoutCollateHandler_throwsClearError() {
+    NodeFactoryRegistry.getInstance().deregister(NodeSubType.CREATE_AND_RUN_AI_AUTOMATION_TASK);
+    CreateAndRunAIAutomationTaskDefinition def = new CreateAndRunAIAutomationTaskDefinition();
+    def.setSubType("createAndRunAIAutomationTask");
+    def.setName("RunDescriptionAutomation");
+
+    IllegalStateException ex =
+        assertThrows(
+            IllegalStateException.class,
+            () -> NodeFactory.createNode(def, new WorkflowConfiguration(), "AutoPilotWorkflow"));
+    assertTrue(ex.getMessage().contains("Collate-only"), ex.getMessage());
+  }
+}

--- a/openmetadata-service/src/test/java/org/openmetadata/service/governance/workflows/elements/NodeFactoryAIAutomationTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/governance/workflows/elements/NodeFactoryAIAutomationTest.java
@@ -16,12 +16,35 @@ package org.openmetadata.service.governance.workflows.elements;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.Optional;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.openmetadata.schema.governance.workflows.WorkflowConfiguration;
 import org.openmetadata.schema.governance.workflows.elements.NodeSubType;
 import org.openmetadata.schema.governance.workflows.elements.nodes.automatedTask.CreateAndRunAIAutomationTaskDefinition;
+import org.openmetadata.service.governance.workflows.elements.NodeFactoryRegistry.NodeFactoryExtension;
 
 class NodeFactoryAIAutomationTest {
+
+  // NodeFactoryRegistry is a process-wide singleton. Snapshot any existing handler and restore it
+  // after each test so mutating it here cannot leak into other tests in the same JVM.
+  private Optional<NodeFactoryExtension> savedExtension = Optional.empty();
+
+  @BeforeEach
+  void snapshotRegistry() {
+    savedExtension =
+        NodeFactoryRegistry.getInstance()
+            .getExtension(NodeSubType.CREATE_AND_RUN_AI_AUTOMATION_TASK);
+  }
+
+  @AfterEach
+  void restoreRegistry() {
+    NodeFactoryRegistry registry = NodeFactoryRegistry.getInstance();
+    savedExtension.ifPresentOrElse(
+        ext -> registry.register(NodeSubType.CREATE_AND_RUN_AI_AUTOMATION_TASK, ext),
+        () -> registry.deregister(NodeSubType.CREATE_AND_RUN_AI_AUTOMATION_TASK));
+  }
 
   @Test
   void createNode_aiAutomation_withoutCollateHandler_throwsClearError() {

--- a/openmetadata-service/src/test/java/org/openmetadata/service/governance/workflows/elements/NodeFactoryAIAutomationTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/governance/workflows/elements/NodeFactoryAIAutomationTest.java
@@ -16,34 +16,20 @@ package org.openmetadata.service.governance.workflows.elements;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.util.Optional;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.openmetadata.schema.governance.workflows.WorkflowConfiguration;
 import org.openmetadata.schema.governance.workflows.elements.NodeSubType;
 import org.openmetadata.schema.governance.workflows.elements.nodes.automatedTask.CreateAndRunAIAutomationTaskDefinition;
-import org.openmetadata.service.governance.workflows.elements.NodeFactoryRegistry.NodeFactoryExtension;
 
 class NodeFactoryAIAutomationTest {
 
-  // NodeFactoryRegistry is a process-wide singleton. Snapshot any existing handler and restore it
-  // after each test so mutating it here cannot leak into other tests in the same JVM.
-  private Optional<NodeFactoryExtension> savedExtension = Optional.empty();
-
-  @BeforeEach
-  void snapshotRegistry() {
-    savedExtension =
-        NodeFactoryRegistry.getInstance()
-            .getExtension(NodeSubType.CREATE_AND_RUN_AI_AUTOMATION_TASK);
-  }
-
+  // createAndRunAIAutomationTask is a Collate-only subtype: nothing registers a handler for it in
+  // OSS. Deregister after each test so a stray registration cannot leak across the singleton
+  // registry into other tests in the same JVM.
   @AfterEach
-  void restoreRegistry() {
-    NodeFactoryRegistry registry = NodeFactoryRegistry.getInstance();
-    savedExtension.ifPresentOrElse(
-        ext -> registry.register(NodeSubType.CREATE_AND_RUN_AI_AUTOMATION_TASK, ext),
-        () -> registry.deregister(NodeSubType.CREATE_AND_RUN_AI_AUTOMATION_TASK));
+  void clearRegistry() {
+    NodeFactoryRegistry.getInstance().deregister(NodeSubType.CREATE_AND_RUN_AI_AUTOMATION_TASK);
   }
 
   @Test

--- a/openmetadata-spec/src/main/java/org/openmetadata/schema/governance/workflows/elements/WorkflowNodeDefinitionInterface.java
+++ b/openmetadata-spec/src/main/java/org/openmetadata/schema/governance/workflows/elements/WorkflowNodeDefinitionInterface.java
@@ -9,6 +9,7 @@ import org.openmetadata.common.utils.CommonUtil;
 import org.openmetadata.schema.governance.workflows.elements.nodes.automatedTask.ApplyRecognizerFeedbackTaskDefinition;
 import org.openmetadata.schema.governance.workflows.elements.nodes.automatedTask.CheckChangeDescriptionTaskDefinition;
 import org.openmetadata.schema.governance.workflows.elements.nodes.automatedTask.CheckEntityAttributesTaskDefinition;
+import org.openmetadata.schema.governance.workflows.elements.nodes.automatedTask.CreateAndRunAIAutomationTaskDefinition;
 import org.openmetadata.schema.governance.workflows.elements.nodes.automatedTask.CreateAndRunIngestionPipelineTaskDefinition;
 import org.openmetadata.schema.governance.workflows.elements.nodes.automatedTask.DataCompletenessTaskDefinition;
 import org.openmetadata.schema.governance.workflows.elements.nodes.automatedTask.PolicyAgentTaskDefinition;
@@ -50,6 +51,9 @@ import org.openmetadata.schema.governance.workflows.elements.nodes.userTask.User
   @JsonSubTypes.Type(
       value = CreateAndRunIngestionPipelineTaskDefinition.class,
       name = "createAndRunIngestionPipelineTask"),
+  @JsonSubTypes.Type(
+      value = CreateAndRunAIAutomationTaskDefinition.class,
+      name = "createAndRunAIAutomationTask"),
   @JsonSubTypes.Type(value = RunAppTaskDefinition.class, name = "runAppTask"),
   @JsonSubTypes.Type(value = ParallelGatewayDefinition.class, name = "parallelGateway"),
   @JsonSubTypes.Type(value = SinkTaskDefinition.class, name = "sinkTask"),

--- a/openmetadata-spec/src/main/resources/json/schema/api/governance/createWorkflowDefinition.json
+++ b/openmetadata-spec/src/main/resources/json/schema/api/governance/createWorkflowDefinition.json
@@ -80,6 +80,9 @@
           },
           {
             "$ref": "../../governance/workflows/elements/nodes/automatedTask/policyAgentTaskDefinition.json"
+          },
+          {
+            "$ref": "../../governance/workflows/elements/nodes/automatedTask/createAndRunAIAutomationTask.json"
           }
         ]
       }

--- a/openmetadata-spec/src/main/resources/json/schema/governance/workflows/elements/nodeSubType.json
+++ b/openmetadata-spec/src/main/resources/json/schema/governance/workflows/elements/nodeSubType.json
@@ -23,6 +23,7 @@
     "applyRecognizerFeedbackTask",
     "rejectRecognizerFeedbackTask",
     "checkChangeDescriptionTask",
-    "policyAgentTask"
+    "policyAgentTask",
+    "createAndRunAIAutomationTask"
   ]
 }

--- a/openmetadata-spec/src/main/resources/json/schema/governance/workflows/elements/nodes/automatedTask/createAndRunAIAutomationTask.json
+++ b/openmetadata-spec/src/main/resources/json/schema/governance/workflows/elements/nodes/automatedTask/createAndRunAIAutomationTask.json
@@ -1,0 +1,98 @@
+{
+  "$id": "https://open-metadata.org/schema/governance/workflows/elements/nodes/automatedTask/createAndRunAIAutomationTask.json",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "CreateAndRunAIAutomationTask",
+  "description": "Creates (or updates) a service-scoped AI Automation from a seed template and runs it.",
+  "javaInterfaces": [
+    "org.openmetadata.schema.governance.workflows.elements.WorkflowNodeDefinitionInterface"
+  ],
+  "javaType": "org.openmetadata.schema.governance.workflows.elements.nodes.automatedTask.CreateAndRunAIAutomationTaskDefinition",
+  "type": "object",
+  "definitions": {
+    "config": {
+      "type": "object",
+      "properties": {
+        "template": {
+          "title": "Automation Template",
+          "description": "Name of the seed AI Automation template to instantiate per service (e.g. DescriptionAutomation).",
+          "type": "string"
+        },
+        "shouldRun": {
+          "title": "Run the Automation",
+          "description": "If True, it will be created/updated and run. Otherwise it will only be created/updated.",
+          "type": "boolean",
+          "default": true
+        },
+        "waitForCompletion": {
+          "title": "Wait for Completion",
+          "description": "Set if this step should wait until the Automation run finishes.",
+          "type": "boolean",
+          "default": true
+        },
+        "timeoutSeconds": {
+          "title": "Timeout Seconds",
+          "description": "Seconds to wait before treating the run as timed out.",
+          "type": "integer",
+          "default": 3600
+        }
+      },
+      "additionalProperties": false,
+      "required": ["template", "waitForCompletion", "timeoutSeconds"]
+    }
+  },
+  "properties": {
+    "type": {
+      "type": "string",
+      "default": "automatedTask"
+    },
+    "subType": {
+      "type": "string",
+      "default": "createAndRunAIAutomationTask"
+    },
+    "name": {
+      "title": "Name",
+      "description": "Name that identifies this Node.",
+      "$ref": "../../../../../type/basic.json#/definitions/entityName"
+    },
+    "displayName": {
+      "title": "Display Name",
+      "description": "Display Name that identifies this Node.",
+      "type": "string"
+    },
+    "description": {
+      "title": "Description",
+      "description": "Description of the Node.",
+      "$ref": "../../../../../type/basic.json#/definitions/markdown"
+    },
+    "config": {
+      "$ref": "#/definitions/config"
+    },
+    "input": {
+      "type": "array",
+      "items": { "type": "string" },
+      "default": ["relatedEntity"],
+      "additionalItems": false,
+      "minItems": 1,
+      "maxItems": 1
+    },
+    "inputNamespaceMap": {
+      "type": "object",
+      "properties": {
+        "relatedEntity": {
+          "type": "string",
+          "default": "global"
+        }
+      },
+      "additionalProperties": false,
+      "required": ["relatedEntity"]
+    },
+    "branches": {
+      "type": "array",
+      "items": { "type": "string" },
+      "default": ["success", "failure"],
+      "additionalItems": false,
+      "minItems": 2,
+      "maxItems": 2
+    }
+  }
+}

--- a/openmetadata-ui/src/main/resources/ui/src/generated/api/governance/createWorkflowDefinition.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/api/governance/createWorkflowDefinition.ts
@@ -37,7 +37,7 @@ export interface CreateWorkflowDefinition {
     /**
      * List of processes used on the workflow.
      */
-    nodes?: Definition[];
+    nodes?: CheckEntityAttributesTaskDefinition[];
     /**
      * Owners of this API Collection
      */
@@ -87,8 +87,10 @@ export interface EdgeDefinition {
  *
  * Runs the Policy Agent to enforce data access on supported connectors, or falls back to a
  * manual grant step.
+ *
+ * Creates (or updates) a service-scoped AI Automation from a seed template and runs it.
  */
-export interface Definition {
+export interface CheckEntityAttributesTaskDefinition {
     /**
      * Outgoing branches this node's delegate can emit. Grant path uses ['granted', 'manual',
      * 'denied']; revoke path (accessType override = Revoke) uses ['revoked', 'manual']. Node
@@ -186,12 +188,25 @@ export interface NodeConfiguration {
     accessType?: AccessType;
     /**
      * Maximum seconds to wait for the Policy Agent pipeline to complete.
+     *
+     * Seconds to wait before treating the run as timed out.
      */
     timeoutSeconds?: number;
     /**
      * If true, waits for the Policy Agent ingestion pipeline to finish before continuing.
+     *
+     * Set if this step should wait until the Automation run finishes.
      */
     waitForCompletion?: boolean;
+    /**
+     * If True, it will be created/updated and run. Otherwise it will only be created/updated.
+     */
+    shouldRun?: boolean;
+    /**
+     * Name of the seed AI Automation template to instantiate per service (e.g.
+     * DescriptionAutomation).
+     */
+    template?: string;
 }
 
 /**

--- a/openmetadata-ui/src/main/resources/ui/src/generated/governance/workflows/elements/nodeSubType.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/governance/workflows/elements/nodeSubType.ts
@@ -17,6 +17,7 @@ export enum NodeSubType {
     ApplyRecognizerFeedbackTask = "applyRecognizerFeedbackTask",
     CheckChangeDescriptionTask = "checkChangeDescriptionTask",
     CheckEntityAttributesTask = "checkEntityAttributesTask",
+    CreateAndRunAIAutomationTask = "createAndRunAIAutomationTask",
     CreateAndRunIngestionPipelineTask = "createAndRunIngestionPipelineTask",
     CreateRecognizerFeedbackApprovalTask = "createRecognizerFeedbackApprovalTask",
     DataCompletenessTask = "dataCompletenessTask",

--- a/openmetadata-ui/src/main/resources/ui/src/generated/governance/workflows/elements/nodes/automatedTask/createAndRunAIAutomationTask.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/governance/workflows/elements/nodes/automatedTask/createAndRunAIAutomationTask.ts
@@ -1,0 +1,60 @@
+/*
+ *  Copyright 2026 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+/**
+ * Creates (or updates) a service-scoped AI Automation from a seed template and runs it.
+ */
+export interface CreateAndRunAIAutomationTask {
+    branches?: string[];
+    config?:   Config;
+    /**
+     * Description of the Node.
+     */
+    description?: string;
+    /**
+     * Display Name that identifies this Node.
+     */
+    displayName?:       string;
+    input?:             string[];
+    inputNamespaceMap?: InputNamespaceMap;
+    /**
+     * Name that identifies this Node.
+     */
+    name?:    string;
+    subType?: string;
+    type?:    string;
+    [property: string]: any;
+}
+
+export interface Config {
+    /**
+     * If True, it will be created/updated and run. Otherwise it will only be created/updated.
+     */
+    shouldRun?: boolean;
+    /**
+     * Name of the seed AI Automation template to instantiate per service (e.g.
+     * DescriptionAutomation).
+     */
+    template: string;
+    /**
+     * Seconds to wait before treating the run as timed out.
+     */
+    timeoutSeconds: number;
+    /**
+     * Set if this step should wait until the Automation run finishes.
+     */
+    waitForCompletion: boolean;
+}
+
+export interface InputNamespaceMap {
+    relatedEntity: string;
+}


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:

Fixes open-metadata/openmetadata-collate#4808
<!--
Linking an issue is REQUIRED. Replace <issue-number> with the GitHub issue number this PR addresses
(e.g., `Fixes #12345`). GitHub will auto-link it. If no issue exists, please open one first so the
problem and design can be discussed before review.
-->

<!--
Short blurb explaining:
- What changes did you make?
- Why did you make them?
-->

I added a new governance workflow node subtype, `createAndRunAIAutomationTask`, so that workflows can create/update and run an AI Automation as a step (mirroring the existing `createAndRunIngestionPipelineTask`). The node's schema, enum value, and definition POJO live here in OpenMetadata; the implementation and factory are registered downstream in Collate via the existing `NodeFactoryRegistry` (the same OSS/Collate split already used by `policyAgentTask`).

This is the OSS half of the Collate "AutoPilot 2.0" change (AutoPilot creating per-service AI Automations instead of running agent apps directly). It is self-contained and additive.

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->

- [x] New feature


#
### High-level design:
<!--
REQUIRED for large PRs (new features, refactors, breaking changes, or anything touching >5 files).
Skip for small bug fixes and trivial changes.

Cover:
- Architecture / approach you took and why
- Key components or files added/changed and how they interact
- Alternatives considered and why you rejected them
- Any migration, backward-compatibility, or rollout concerns
- Diagrams or links to design docs / RFCs if available
-->

- **Approach:** add `createAndRunAIAutomationTask` as a `NodeSubType`, define its schema + generated POJO, and route it through `NodeFactory` to `NodeFactoryRegistry` so a downstream module (Collate) can register the concrete node implementation. No behavior changes to any existing node.
- **Key files:**
- `openmetadata-spec/.../governance/workflows/elements/nodeSubType.json`: add the enum value (generates `NodeSubType.CREATE_AND_RUN_AI_AUTOMATION_TASK`).
- `openmetadata-spec/.../nodes/automatedTask/createAndRunAIAutomationTask.json`: new node definition schema (config: `template`, `shouldRun`, `waitForCompletion`, `timeoutSeconds`; input `relatedEntity`; branches `success`/`failure`).
- `openmetadata-spec/.../api/governance/createWorkflowDefinition.json`: add the definition to the `nodes` union.
- `WorkflowNodeDefinitionInterface.java`: `@JsonSubTypes` entry for polymorphic deserialization.
- `NodeFactory.java`: dispatch case delegating to `NodeFactoryRegistry` (same pattern as `POLICY_AGENT_TASK`); throws a clear error if no handler is registered (correct for an OSS-only build).
- `openmetadata-ui/.../jsons/governanceSchemas/automatedTask/createAndRunAIAutomationTask.json` and generated TS (`nodeSubType.ts`, `createAndRunAIAutomationTask.ts`).
- **Alternatives rejected:** implementing the node in OSS — rejected because the AI Automation entity is Collate-only; keeping the definition in OSS and the impl in Collate matches the established `policyAgentTask` split.
- **Backward compatibility:** purely additive. Verified every `NodeSubType` consumer: `NodeFactory` switch has a `default`; `TriggerFactory` is an `if ==`; UI `WorkflowSerializer` has a `default:` and already routes unknown/agent subtypes through it. No existing behavior changes.

#
### Tests:

#### Use cases covered
<!--
List the user-visible scenarios this PR exercises. Example:
- User with Admin role can create a Glossary Term with a parent term
- Ingestion run for Snowflake correctly extracts row counts for partitioned tables
-->

#### Unit tests
<!--
- [ ] I added unit tests for the new/changed logic.
- Files added/updated:
- Coverage on changed classes (run `mvn jacoco:report` for backend, `yarn test:coverage` for UI,
  `make unit_ingestion` for ingestion). Target is 90% line coverage on changed classes.
- Coverage %: <e.g., 92% on EntityRepository.java>
-->

- [x] Added unit tests for the new/changed logic.
- Files added/updated: 
- `openmetadata-service/.../governance/workflows/elements/NodeFactoryAIAutomationTest.java`
- Existing `NodeFactoryTest`, `NodeFactoryRegistryTest`, `WorkflowDefinitionGraphValidationTest` re-run green (no regressions).

#### Backend integration tests
<!--
- [ ] I added integration tests in `openmetadata-integration-tests/` for new/changed API endpoints.
- [ ] Not applicable (no backend API changes).
- Files added/updated:
-->
- [x] Not applicable (no backend API changes).
#### Ingestion integration tests
<!--
- [ ] I added/updated ingestion integration tests for connector changes.
- [ ] Not applicable (no ingestion changes).
- Files added/updated:
-->
- [x] Not applicable (no ingestion changes; Python model regenerates from the schema).

#### Playwright (UI) tests
<!--
- [ ] I added Playwright E2E tests under `openmetadata-ui/.../ui/playwright/` for UI changes.
- [ ] Not applicable (no UI changes).
- Files added/updated:
-->
- [x] Not applicable (no UI behavior change; only generated types added, rendered via the existing default node path).

#### Manual testing performed
<!--
List the manual test steps you performed before requesting review. Example:
1. Started local stack via `./docker/run_local_docker.sh -m ui -d mysql`
2. Logged in as admin, created entity X, verified Y appears in the UI
3. Triggered ingestion for Snowflake source, confirmed lineage edges in the explore page
-->

1. `mvn -pl openmetadata-spec clean install`: enum + `CreateAndRunAIAutomationTaskDefinition` generate correctly.
2. `make generate` (Python): `nodeSubType` + definition models regenerate without error.
3. Regenerated UI TS types; confirmed the new enum member and interface.
4. Full downstream (Collate) build + local stack: created a service, AutoPilot ran the node end-to-end (automations created + run).

#
### UI screen recording / screenshots:
<!--
REQUIRED for any PR that changes the UI. Drag-and-drop a short screen recording (.mov / .mp4 / .gif)
demonstrating the change end-to-end, plus before/after screenshots where relevant.
Mark "Not applicable" if there are no UI changes.
-->

Not applicable. <!-- Or attach recording/screenshots above -->

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] My PR title is `Fixes [open-metadata/openmetadata-collate#4808](https://github.com/open-metadata/openmetadata-collate/issues/4808): Update AutoPilot Application`
- [x] My PR is linked to a GitHub issue via `Fixes [open-metadata/openmetadata-collate#4808](https://github.com/open-metadata/openmetadata-collate/issues/4808)` above.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.
- [x] For UI changes: I attached a screen recording and/or screenshots above.
- [x] I have added tests (unit / integration / Playwright as applicable) and listed them above.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->
- [x] The issue describes why the feature is needed, the goal, and the approach.
- [ ] I have updated the documentation.
- [x] I have added tests around the new logic.
<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds `createAndRunAIAutomationTask` as a new governance workflow node subtype, mirroring the existing `policyAgentTask` OSS/Collate split: the schema, enum value, generated POJOs, and `NodeFactory` dispatch live in OSS, while the concrete implementation registers downstream in Collate via `NodeFactoryRegistry`.

- **Schema & codegen** — new JSON schema with `template` (required), `shouldRun` (optional, default `true`), `waitForCompletion`, and `timeoutSeconds`; added to the `nodeSubType` enum, the `createWorkflowDefinition` union, and the Jackson `@JsonSubTypes` list for polymorphic deserialization.
- **NodeFactory dispatch** — new `CREATE_AND_RUN_AI_AUTOMATION_TASK` switch case delegates to `NodeFactoryRegistry` and throws a clear `IllegalStateException` if no Collate handler is registered, exactly as `POLICY_AGENT_TASK` does.
- **Test** — `NodeFactoryAIAutomationTest` covers the no-handler OSS path with a proper `@AfterEach` teardown to prevent singleton registry leaks across the JVM.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — purely additive change with no modifications to existing node behavior.

Every changed path is additive: a new enum value, a new switch case, a new schema file, and a new test. No existing node types or dispatch logic were altered. The Collate-only split follows the established policyAgentTask pattern exactly, and the OSS error path is explicitly tested.

No files require special attention; the generated TypeScript rename from Definition to CheckEntityAttributesTaskDefinition is worth a glance but has no consumer impact.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-spec/src/main/resources/json/schema/governance/workflows/elements/nodes/automatedTask/createAndRunAIAutomationTask.json | New node schema defining config (template required, shouldRun/waitForCompletion/timeoutSeconds with defaults), input, branches — clean and follows policyAgentTask conventions. |
| openmetadata-service/src/main/java/org/openmetadata/service/governance/workflows/elements/NodeFactory.java | Adds CREATE_AND_RUN_AI_AUTOMATION_TASK case delegating to NodeFactoryRegistry; exactly mirrors the POLICY_AGENT_TASK pattern with a clear error when no Collate handler is registered. |
| openmetadata-service/src/test/java/org/openmetadata/service/governance/workflows/elements/NodeFactoryAIAutomationTest.java | Test verifies the Collate-only error path; has @AfterEach teardown plus a pre-test defensive deregister to guard against singleton state leaks. |
| openmetadata-spec/src/main/java/org/openmetadata/schema/governance/workflows/elements/WorkflowNodeDefinitionInterface.java | Adds @JsonSubTypes.Type entry for CreateAndRunAIAutomationTaskDefinition to enable polymorphic Jackson deserialization; correctly placed in the existing list. |
| openmetadata-ui/src/main/resources/ui/src/generated/api/governance/createWorkflowDefinition.ts | Generated TypeScript: the union interface was renamed from Definition to CheckEntityAttributesTaskDefinition and NodeConfiguration gained shouldRun/template fields; no existing consumers import Definition by name, so no compile breaks. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[NodeFactory.createNode] -->|NodeSubType.fromValue| B{Switch on NodeSubType}
    B -->|CREATE_AND_RUN_AI_AUTOMATION_TASK| C[NodeFactoryRegistry.getInstance.create]
    B -->|POLICY_AGENT_TASK| D[NodeFactoryRegistry.getInstance.create]
    B -->|other OSS subtypes| E[Direct constructor]
    C -->|Optional.empty| F[throw IllegalStateException Collate-only]
    C -->|Optional.of handler| G[Collate node]
    D -->|Optional.empty| H[throw IllegalStateException]
    D -->|Optional.of handler| I[Collate PolicyAgentTask]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[NodeFactory.createNode] -->|NodeSubType.fromValue| B{Switch on NodeSubType}
    B -->|CREATE_AND_RUN_AI_AUTOMATION_TASK| C[NodeFactoryRegistry.getInstance.create]
    B -->|POLICY_AGENT_TASK| D[NodeFactoryRegistry.getInstance.create]
    B -->|other OSS subtypes| E[Direct constructor]
    C -->|Optional.empty| F[throw IllegalStateException Collate-only]
    C -->|Optional.of handler| G[Collate node]
    D -->|Optional.empty| H[throw IllegalStateException]
    D -->|Optional.of handler| I[Collate PolicyAgentTask]
```

</a>
</details>

<sub>Reviews (7): Last reviewed commit: ["refactor(workflows): drop test-only getE..."](https://github.com/open-metadata/openmetadata/commit/ce0d3c2816a951ee4043925e331b1efdb1557f41) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41462621)</sub>

<!-- /greptile_comment -->