### PR TITLE
fix(search): drop must_exist on remove_index so OpenSearch alias swap succeeds (backport #28700 to 1.12.13)

### DIFF
--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/AliasSwapConcreteRemovalIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/AliasSwapConcreteRemovalIT.java
@@ -1,0 +1,105 @@
+/*
+ *  Copyright 2026 Collate
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.openmetadata.it.tests;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.openmetadata.it.util.SdkClients;
+import org.openmetadata.service.Entity;
+import org.openmetadata.service.search.SearchClient;
+
+/**
+ * Reproduces the regression from PR #28667 where the atomic alias swap orphaned every canonical
+ * {@code *_search_index} alias on OpenSearch.
+ *
+ * <p>On a fresh install the canonical name (e.g. {@code table_search_index}) is a <em>concrete</em>
+ * index. The fix for missing aliases folded a {@code remove_index} action into the {@code _aliases}
+ * request so the delete and the alias-add happen atomically. The {@code remove_index} action was
+ * built with {@code must_exist(false)}, which OpenSearch's {@code _aliases} parser rejects with
+ * {@code [remove_index] unknown field [must_exist]} → {@code [aliases] failed to parse field
+ * [actions]} → HTTP 400. The whole request failed, so the alias-add never applied and the canonical
+ * name resolved to nothing — surfacing as "table_search_index missing embedding field" in the AI
+ * Platform validation.
+ *
+ * <p>This exercises {@link SearchClient#swapAliases(Set, String, Set, Set)} directly against the
+ * live cluster with the exact first-install shape (concrete canonical in {@code indicesToRemove}).
+ * It fails before the fix on OpenSearch and passes after; on Elasticsearch (which tolerates
+ * {@code must_exist}) it locks down the same correct atomic-swap behavior.
+ */
+public class AliasSwapConcreteRemovalIT {
+
+  private static final String CANONICAL = "om_it_alias_swap_concrete_search_index";
+  private static final String STAGED = CANONICAL + "_rebuild_it";
+  private static final String SHORT_ALIAS = "om_it_alias_swap_concrete";
+
+  @BeforeAll
+  static void setup() {
+    SdkClients.adminClient();
+  }
+
+  @AfterEach
+  void cleanup() {
+    SearchClient client = searchClient();
+    // Delete the staged index first so the canonical alias it carries is removed with it, leaving
+    // only a concrete canonical (if the swap never ran) for the second delete to clean up.
+    for (String index : List.of(STAGED, CANONICAL)) {
+      deleteIfExists(client, index);
+    }
+  }
+
+  private static void deleteIfExists(SearchClient client, String index) {
+    if (client.indexExists(index)) {
+      client.deleteIndex(index);
+    }
+  }
+
+  @Test
+  void atomicSwapRemovesConcreteCanonicalAndAttachesAlias() {
+    SearchClient client = searchClient();
+
+    deleteIfExists(client, STAGED);
+    deleteIfExists(client, CANONICAL);
+    client.createIndex(CANONICAL, "{}");
+    client.createIndex(STAGED, "{}");
+
+    assertTrue(client.indexExists(CANONICAL), "Concrete canonical index should exist before swap");
+    assertTrue(
+        client.getIndicesByAlias(CANONICAL).isEmpty(),
+        "Canonical name should be a concrete index, not an alias, before swap");
+
+    boolean swapped =
+        client.swapAliases(Set.of(), STAGED, Set.of(CANONICAL, SHORT_ALIAS), Set.of(CANONICAL));
+
+    assertTrue(
+        swapped,
+        "Atomic swap with a concrete index in indicesToRemove must succeed; before the fix "
+            + "OpenSearch rejected the remove_index must_exist field and returned false");
+    assertEquals(
+        Set.of(STAGED),
+        client.getIndicesByAlias(CANONICAL),
+        "Canonical alias must resolve to the staged index after the swap");
+    assertTrue(
+        client.getIndicesByAlias(SHORT_ALIAS).contains(STAGED),
+        "Short alias must resolve to the staged index after the swap");
+  }
+
+  private static SearchClient searchClient() {
+    return Entity.getSearchRepository().getSearchClient();
+  }
+}

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/elasticsearch/ElasticSearchIndexManager.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/elasticsearch/ElasticSearchIndexManager.java
@@ -354,12 +354,14 @@ public class ElasticSearchIndexManager implements IndexManagementClient {
                 }
                 // Then delete any concrete index sharing the alias name, atomically, so the alias
                 // add below cannot race a separate delete and orphan the canonical name.
+                // must_exist is intentionally omitted to stay byte-for-byte aligned with the
+                // OpenSearch path (which rejects it); it is unnecessary because
+                // resolveCanonicalRemoval only forwards indices already confirmed to exist.
                 for (String indexToRemove : finalIndicesToRemove) {
                   updateBuilder.actions(
                       actionBuilder ->
                           actionBuilder.removeIndex(
-                              removeIndexBuilder ->
-                                  removeIndexBuilder.index(indexToRemove).mustExist(false)));
+                              removeIndexBuilder -> removeIndexBuilder.index(indexToRemove)));
                 }
                 // Finally, add aliases to the new index
                 for (String alias : finalAliases) {

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/opensearch/OpenSearchIndexManager.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/opensearch/OpenSearchIndexManager.java
@@ -435,12 +435,15 @@ public class OpenSearchIndexManager implements IndexManagementClient {
                 }
                 // Then delete any concrete index sharing the alias name, atomically, so the alias
                 // add below cannot race a separate delete and orphan the canonical name.
+                // Do NOT set must_exist: OpenSearch's _aliases parser rejects it on remove_index
+                // ("unknown field [must_exist]") and fails the whole request. It is unnecessary
+                // here anyway — resolveCanonicalRemoval only forwards indices it has already
+                // confirmed exist via indexExists().
                 for (String indexToRemove : finalIndicesToRemove) {
                   updateBuilder.actions(
                       actionBuilder ->
                           actionBuilder.removeIndex(
-                              removeIndexBuilder ->
-                                  removeIndexBuilder.index(indexToRemove).mustExist(false)));
+                              removeIndexBuilder -> removeIndexBuilder.index(indexToRemove)));
                 }
                 // Finally, add aliases to the new index
                 for (String alias : finalAliases) {


### PR DESCRIPTION
Backport of #28700 to **1.12.13**.

## Problem (observed on 1.12.13)

The distributed reindex fails to promote any rebuilt index — every atomic alias swap is rejected by OpenSearch:

```
os...OpenSearchException: Request failed: [x_content_parse_exception] [1:99] [aliases] failed to parse field [actions]
  at OpenSearchIndexManager.swapAliases(OpenSearchIndexManager.java:454)
  at DefaultRecreateHandler.promoteEntityIndex(...)
Failed to atomically swap aliases for entity 'storedProcedure' / 'dataProduct' / 'classification' ...
```

## Root cause

#28667 added an atomic alias swap that folds the canonical concrete-index delete into the `_aliases` request via a `remove_index` action, built as `removeIndex(index).mustExist(false)`. OpenSearch's `_aliases` parser does **not** accept `must_exist` on `remove_index` and rejects the whole request (`[remove_index] unknown field [must_exist]` → `[aliases] failed to parse field [actions]`, HTTP 400), so the alias add in the same body never applies. Elasticsearch tolerates the field, which is why it passed review.

On a fresh install every canonical `*_search_index` is a concrete index, so the `remove_index` action fires for all entities and every swap fails → no canonical aliases attach → the canonical name resolves to nothing (surfacing downstream as missing fields / failed aggregations / search 500s).

## Fix

Drop `must_exist` from the `remove_index` action in both `OpenSearchIndexManager` and `ElasticSearchIndexManager`. It is unnecessary — `resolveCanonicalRemoval` only forwards indices already confirmed to exist via `indexExists()`. Both engine paths are now identical.

Includes `AliasSwapConcreteRemovalIT`, which exercises the first-install shape (concrete canonical in `indicesToRemove`) against a live cluster: fails before this fix on OpenSearch, passes after.

## Verification

- `openmetadata-service` compiles clean on the 1.12.13 branch.
- Clean cherry-pick of d800ba4187 (`git cherry-pick -x`); no conflicts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This backport (from #28700 to 1.12.13) removes `.mustExist(false)` from the `remove_index` action in the `_aliases` request for both `OpenSearchIndexManager` and `ElasticSearchIndexManager`. OpenSearch's `_aliases` parser does not accept the `must_exist` field on `remove_index` and rejects the entire request with a 400, preventing canonical alias promotion on fresh installs.

- **`OpenSearchIndexManager.java` / `ElasticSearchIndexManager.java`**: Drop the `.mustExist(false)` call from the `removeIndex` builder, keeping both paths identical. The field is safe to omit because `resolveCanonicalRemoval` already pre-confirms existence via `indexExists()` before populating `indicesToRemove`.
- **`AliasSwapConcreteRemovalIT.java`**: New integration test exercising the first-install shape (concrete canonical index in `indicesToRemove`) against a live cluster to prevent regression.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge. The change is a minimal, targeted removal of a single field that OpenSearch's `_aliases` parser explicitly rejects, and the Elasticsearch path is brought in line for consistency.

Both production changes are a single-line removal each, directly addressing the documented OpenSearch parse rejection. The `resolveCanonicalRemoval` pre-check via `indexExists()` ensures `indicesToRemove` is populated only with confirmed-live indices, so omitting `must_exist` does not introduce a new failure path. The new integration test covers the first-install shape on a live cluster. No new logic was added — only a field that caused unconditional 400s was dropped.

No files require special attention. The two index-manager files carry symmetric, low-risk changes, and the integration test provides direct regression coverage.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-service/src/main/java/org/openmetadata/service/search/opensearch/OpenSearchIndexManager.java | Removes `.mustExist(false)` from the `removeIndex` action in `swapAliases`; this field is rejected by OpenSearch's `_aliases` parser and caused every alias swap to fail on fresh installs. |
| openmetadata-service/src/main/java/org/openmetadata/service/search/elasticsearch/ElasticSearchIndexManager.java | Same one-line removal as the OpenSearch path for consistency; Elasticsearch tolerates `must_exist` but it was redundant given the prior `indexExists()` guard. |
| openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/AliasSwapConcreteRemovalIT.java | New IT covering the first-install swap shape; verifies the swap returns true and the alias resolves to the staged index. One minor gap: does not assert the concrete canonical index was actually deleted post-swap. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Caller as DefaultRecreateHandler
    participant SM as swapAliases()
    participant OS as OpenSearch _aliases API

    Caller->>SM: swapAliases(oldIndices, stagedIndex, aliases, indicesToRemove)
    Note over SM: indicesToRemove pre-confirmed<br/>via indexExists()

    SM->>OS: "POST _aliases { actions: [<br/>  remove(oldIndex, alias),<br/>  remove_index(canonicalIndex),<br/>  add(stagedIndex, alias)<br/>] }"

    Note over OS: Before fix: remove_index included<br/>must_exist=false → 400 rejected<br/>After fix: must_exist omitted → accepted

    OS-->>SM: 200 acknowledged: true
    SM-->>Caller: true (swap succeeded)
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Caller as DefaultRecreateHandler
    participant SM as swapAliases()
    participant OS as OpenSearch _aliases API

    Caller->>SM: swapAliases(oldIndices, stagedIndex, aliases, indicesToRemove)
    Note over SM: indicesToRemove pre-confirmed<br/>via indexExists()

    SM->>OS: "POST _aliases { actions: [<br/>  remove(oldIndex, alias),<br/>  remove_index(canonicalIndex),<br/>  add(stagedIndex, alias)<br/>] }"

    Note over OS: Before fix: remove_index included<br/>must_exist=false → 400 rejected<br/>After fix: must_exist omitted → accepted

    OS-->>SM: 200 acknowledged: true
    SM-->>Caller: true (swap succeeded)
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(search): drop must\_exist on remove\_i..."](https://github.com/open-metadata/openmetadata/commit/acb534805d89f8ab773b29cc3391ace0ada9dd72) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41592934)</sub>

<!-- /greptile_comment -->