### PR TITLE
playwright(fix): wait for ES re-index after bulk-edit update before asserting list view

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/BulkEditEntity.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/BulkEditEntity.spec.ts
@@ -359,6 +359,12 @@ test.describe('Bulk Edit Entity', () => {
       await navigationPromise;
       await toastNotification(page, /details updated successfully/);
 
+      await waitForSearchIndexed(
+        apiContext,
+        table.schemaResponseData.fullyQualifiedName,
+        'database_schema_search_index'
+      );
+
       // Verify Details updated. See sibling-row note in the Database step.
       await expect(
         page.getByTestId('column-name').filter({ hasText: table.schema.name })
@@ -499,6 +505,12 @@ test.describe('Bulk Edit Entity', () => {
       await updateButtonResponse;
       await navigationPromise;
       await toastNotification(page, /details updated successfully/);
+
+      await waitForSearchIndexed(
+        apiContext,
+        table.entityResponseData.fullyQualifiedName,
+        'table_search_index'
+      );
 
       // Verify Details updated. See sibling-row note in the Database step —
       // the schema listing can render 15+ table rows on redirect (each with a

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/BulkEditEntity.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/BulkEditEntity.spec.ts
@@ -166,9 +166,11 @@ test.describe('Bulk Edit Entity', () => {
         .first()
         .waitFor({ state: 'visible' });
 
-      // Click on first cell and edit
-
-      await page.click('.rdg-cell[role="gridcell"]');
+      const databaseNameCell = page
+        .locator('.rdg-cell-name')
+        .filter({ hasText: table.database.name });
+      // eslint-disable-next-line playwright/no-force-option -- fixed grid columns can intercept active-cell clicks
+      await databaseNameCell.click({ force: true });
       await fillRowDetails(
         {
           ...databaseDetails,
@@ -182,7 +184,7 @@ test.describe('Bulk Edit Entity', () => {
         },
         page,
         customPropertyRecord,
-        undefined,
+        true,
         true
       );
 
@@ -471,8 +473,11 @@ test.describe('Bulk Edit Entity', () => {
         .first()
         .waitFor({ state: 'visible' });
 
-      // Click on first cell and edit
-      await page.click('.rdg-cell[role="gridcell"]');
+      const tableNameCell = page
+        .locator('.rdg-cell-name')
+        .filter({ hasText: table.entity.name });
+      // eslint-disable-next-line playwright/no-force-option -- fixed grid columns can intercept active-cell clicks
+      await tableNameCell.click({ force: true });
       await fillRowDetails(
         {
           ...tableDetails1,
@@ -485,7 +490,7 @@ test.describe('Bulk Edit Entity', () => {
         },
         page,
         customPropertyRecord,
-        undefined,
+        true,
         true
       );
 

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/BulkEditEntity.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/BulkEditEntity.spec.ts
@@ -168,7 +168,7 @@ test.describe('Bulk Edit Entity', () => {
 
       const databaseNameCell = page
         .locator('.rdg-cell-name')
-        .filter({ hasText: table.database.name });
+        .getByText(table.database.name, { exact: true });
       // eslint-disable-next-line playwright/no-force-option -- fixed grid columns can intercept active-cell clicks
       await databaseNameCell.click({ force: true });
       await fillRowDetails(
@@ -475,7 +475,7 @@ test.describe('Bulk Edit Entity', () => {
 
       const tableNameCell = page
         .locator('.rdg-cell-name')
-        .filter({ hasText: table.entity.name });
+        .getByText(table.entity.name, { exact: true });
       // eslint-disable-next-line playwright/no-force-option -- fixed grid columns can intercept active-cell clicks
       await tableNameCell.click({ force: true });
       await fillRowDetails(


### PR DESCRIPTION
Fixes #29729

## Summary

- The **"Database"** and **"Database Schema"** tests in `BulkEditEntity.spec.ts` check the entity list view immediately after clicking **Update**. That list is search-indexed, so when Elasticsearch hasn't re-indexed the updated entity yet, `toHaveText` sees the old/empty `displayName` and fails.
- The **"Database service"** and **"Database Schema"** tests also fail when run concurrently: `fillRowDetails` uses `.rdg-cell-name.last().click()` which lands on the wrong entity's row when multiple test workers share the same OM instance. Fix: click the specific name cell by `hasText` filter and pass `isFirstCellClick=true`.

## Test plan

- [ ] Verify `BulkEditEntity › Database service` passes in CI without retries
- [ ] Verify `BulkEditEntity › Database` passes in CI without retries
- [ ] Verify `BulkEditEntity › Database Schema` passes in CI without retries
- [ ] No other BulkEditEntity tests regressed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR addresses two independent sources of flakiness in `BulkEditEntity.spec.ts`: ambiguous cell targeting in multi-row grids during concurrent test runs, and assertions that fire before Elasticsearch has re-indexed the just-updated entity.

- **Concurrency fix (Database service & Database Schema tests):** Instead of clicking the first/last `.rdg-cell-name` (which lands on the wrong row when sibling test workers share the same OM instance), the tests now locate the cell by exact entity name with `{ force: true }` and pass `isFirstCellClick=true` to skip the redundant internal click in `fillRowDetails`.
- **ES indexing wait (Database & Database Schema tests):** `waitForSearchIndexed` is called after the async `importAsync` completes and before the list-view assertion, giving ES time to process the update. Note that `waitForSearchIndexed` polls for `hits.total > 0` (entity presence), not for the updated `displayName` content — so if the entity was already indexed with old data before the Update, the poll may return immediately and the stale-data race is only partially closed.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is test-only, targets known flaky paths, and cannot affect production behaviour.

All changes are confined to a single Playwright spec file. The concurrency fix (specific cell targeting) is straightforward and well-scoped. The `waitForSearchIndexed` calls improve the situation versus no wait at all; the limitation (checking presence rather than updated content) means flakiness may persist in some environments but cannot cause incorrect test results on a clean run.

No files require special attention beyond the noted `waitForSearchIndexed` poll semantics in `BulkEditEntity.spec.ts`.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/BulkEditEntity.spec.ts | Fixes two classes of test flakiness: (1) concurrent-worker cell-click ambiguity resolved by targeting specific name cells with `hasText` + `force:true`, and (2) post-Update ES indexing race partially addressed by `waitForSearchIndexed`; the poll checks entity presence rather than updated content, which may not fully close the race when the entity was pre-indexed |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant T as Test Worker
    participant OM as OpenMetadata API
    participant ES as Elasticsearch

    T->>OM: table.create()
    OM-->>T: entity created (schema FQN)
    OM--)ES: async index (old displayName)

    T->>T: Navigate + bulk edit grid
    Note over T: Click specific name cell<br/>(getByText + force:true)
    T->>OM: "POST importAsync (dryRun=false)"
    OM-->>T: navigation / success toast
    OM--)ES: async re-index (new displayName)

    T->>OM: "GET search/query?q=FQN (waitForSearchIndexed)"
    loop "poll until hits.total > 0"
        OM-->>T: "hits.total (may be > 0 from old doc)"
    end

    T->>T: assert list view has new displayName
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant T as Test Worker
    participant OM as OpenMetadata API
    participant ES as Elasticsearch

    T->>OM: table.create()
    OM-->>T: entity created (schema FQN)
    OM--)ES: async index (old displayName)

    T->>T: Navigate + bulk edit grid
    Note over T: Click specific name cell<br/>(getByText + force:true)
    T->>OM: "POST importAsync (dryRun=false)"
    OM-->>T: navigation / success toast
    OM--)ES: async re-index (new displayName)

    T->>OM: "GET search/query?q=FQN (waitForSearchIndexed)"
    loop "poll until hits.total > 0"
        OM-->>T: "hits.total (may be > 0 from old doc)"
    end

    T->>T: assert list view has new displayName
```

</a>
</details>

<sub>Reviews (3): Last reviewed commit: ["playwright(fix): use exact text match wh..."](https://github.com/open-metadata/openmetadata/commit/6731c4e6e3499eaa549852b6d02a4e569cc384a6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41595443)</sub>

<!-- /greptile_comment -->