### PR TITLE
fix(playwright): retry logs viewer pipeline trigger

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/LogsViewer.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/LogsViewer.spec.ts
@@ -30,7 +30,7 @@ import { test } from '../fixtures/pages';
 let table: TableClass;
 let bundleTestSuite: BundleTestSuiteClass;
 
-test.describe.skip(
+test.describe(
   'Logs viewer page',
   {
     tag: [

--- a/openmetadata-ui/src/main/resources/ui/playwright/support/entity/BundleTestSuiteClass.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/support/entity/BundleTestSuiteClass.ts
@@ -15,6 +15,9 @@ import { APIRequestContext } from '@playwright/test';
 import { uuid } from '../../utils/common';
 import { ResponseDataType } from './Entity.interface';
 
+const PIPELINE_TRIGGER_MAX_ATTEMPTS = 3;
+const PIPELINE_TRIGGER_RETRY_DELAY_MS = 10_000;
+
 export class BundleTestSuiteClass {
   bundleTestSuiteResponseData: ResponseDataType = {} as ResponseDataType;
 
@@ -76,13 +79,31 @@ export class BundleTestSuiteClass {
       `/api/v1/services/ingestionPipelines/deploy/${pipelineId}`
     );
     await new Promise((resolve) => setTimeout(resolve, 5000));
-    const triggerResponse = await apiContext.post(
-      `/api/v1/services/ingestionPipelines/trigger/${pipelineId}`
-    );
-    if (triggerResponse.status() !== 200) {
-      throw new Error(
-        `Failed to trigger pipeline ${pipelineId}: ${triggerResponse.status()}`
+
+    let lastTriggerStatus: number | undefined;
+    let lastTriggerBody = '';
+
+    for (let attempt = 1; attempt <= PIPELINE_TRIGGER_MAX_ATTEMPTS; attempt++) {
+      const triggerResponse = await apiContext.post(
+        `/api/v1/services/ingestionPipelines/trigger/${pipelineId}`
       );
+      lastTriggerStatus = triggerResponse.status();
+
+      if (triggerResponse.status() === 200) {
+        return;
+      }
+
+      lastTriggerBody = await triggerResponse.text();
+
+      if (attempt < PIPELINE_TRIGGER_MAX_ATTEMPTS) {
+        await new Promise((resolve) =>
+          setTimeout(resolve, PIPELINE_TRIGGER_RETRY_DELAY_MS)
+        );
+      }
     }
+
+    throw new Error(
+      `Failed to trigger pipeline ${pipelineId} after ${PIPELINE_TRIGGER_MAX_ATTEMPTS} attempts: ${lastTriggerStatus} ${lastTriggerBody}`
+    );
   }
 }


### PR DESCRIPTION
## Summary
- Unskip the logs viewer Playwright suite.
- Retry logs viewer pipeline trigger up to three times with a 10 second delay between failures.

## Testing
- xargs ./node_modules/.bin/organize-imports-cli < /tmp/om_pw_files.txt
- xargs ./node_modules/.bin/eslint --no-error-on-unmatched-pattern --fix < /tmp/om_pw_files.txt
- xargs ./node_modules/.bin/prettier --config './.prettierrc.yaml' --ignore-path './.prettierignore' --write < /tmp/om_pw_files.txt
- git diff --check
- ./node_modules/.bin/playwright test playwright/e2e/Pages/LogsViewer.spec.ts --list

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR unskips the `LogsViewer` Playwright test suite and adds retry logic to the `runIngestionPipeline` helper to make pipeline triggering more resilient to transient API failures.

- **`BundleTestSuiteClass.ts`**: Wraps the pipeline trigger POST in a loop of up to 3 attempts with a 10-second delay between retries; on all-attempts exhaustion it throws with the last HTTP status and body for diagnostics.
- **`LogsViewer.spec.ts`**: Removes `test.describe.skip` so the suite now runs in CI, relying on the improved trigger reliability to prevent flaky failures.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the changes are confined to Playwright test helpers and add well-structured retry logic with no production code impact.

The retry loop is correctly bounded (3 attempts), the delay is applied only between attempts and never after the last one, the response body is read for diagnostics on every failed attempt from that iteration's response, and a clear error is thrown when all attempts are exhausted. Unskipping the suite is the natural follow-on once the flakiness root cause is addressed.

No files require special attention.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-ui/src/main/resources/ui/playwright/support/entity/BundleTestSuiteClass.ts | Adds retry loop (3 attempts, 10 s delay) around the pipeline trigger POST; preserves last HTTP status and body for the thrown error message on full failure. |
| openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/LogsViewer.spec.ts | Removes test.describe.skip to re-enable the Logs Viewer test suite; no other changes to test logic. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Test as Playwright Test
    participant API as OpenMetadata API

    Test->>API: "POST /deploy/{pipelineId}"
    API-->>Test: (response ignored)
    Note over Test: wait 5s

    loop up to 3 attempts
        Test->>API: "POST /trigger/{pipelineId}"
        alt status 200
            API-->>Test: 200 OK
            Note over Test: return (success)
        else "status != 200"
            API-->>Test: error status
            Note over Test: read body for diagnostics
            alt "attempt < 3"
                Note over Test: wait 10s then retry
            else "attempt == 3"
                Note over Test: throw Error with status + body
            end
        end
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Test as Playwright Test
    participant API as OpenMetadata API

    Test->>API: "POST /deploy/{pipelineId}"
    API-->>Test: (response ignored)
    Note over Test: wait 5s

    loop up to 3 attempts
        Test->>API: "POST /trigger/{pipelineId}"
        alt status 200
            API-->>Test: 200 OK
            Note over Test: return (success)
        else "status != 200"
            API-->>Test: error status
            Note over Test: read body for diagnostics
            alt "attempt < 3"
                Note over Test: wait 10s then retry
            else "attempt == 3"
                Note over Test: throw Error with status + body
            end
        end
    end
```

</a>
</details>

<sub>Reviews (2): Last reviewed commit: ["Merge branch &#39;main&#39; into fix/logs-viewer..."](https://github.com/open-metadata/openmetadata/commit/69d836947300f276363d8b468df06a5bf8433df2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41599150)</sub>

<!-- /greptile_comment -->