### PR TITLE
feat(dbtcloud): add column-level lineage from compiled SQL

### DIFF
--- a/ingestion/src/metadata/ingestion/source/pipeline/dbtcloud/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/pipeline/dbtcloud/metadata.py
@@ -259,12 +259,11 @@ class DbtcloudSource(PipelineServiceSource):
                         self.observability_cache[cache_key]["table_fqns"].add(to_entity_fqn)
 
                     if model.compiledCode and to_entity_fqn:
-                        # get_lineage_by_query is typed to return the LineageRequest union;
-                        # on this create-table path it only yields AddLineageRequest edges.
+                        # dialect is resolved from the resolved table FQN's service, not the
+                        # loop value, which may be the "*" wildcard when no dbServiceNames are set.
                         yield from self._yield_column_lineage(  # pyright: ignore[reportReturnType]
                             model=model,
                             to_entity_fqn=to_entity_fqn,
-                            db_service_name=dbservicename,
                         )
 
                     for unique_id in model.dependsOn or []:
@@ -353,9 +352,7 @@ class DbtcloudSource(PipelineServiceSource):
             self._dialect_cache[db_service_name] = dialect
         return self._dialect_cache[db_service_name]
 
-    def _yield_column_lineage(
-        self, model: DBTModel, to_entity_fqn: str, db_service_name: str
-    ) -> Iterable[Either[LineageRequest]]:
+    def _yield_column_lineage(self, model: DBTModel, to_entity_fqn: str) -> Iterable[Either[LineageRequest]]:
         """
         Parse the compiled dbt model SQL to build column-level lineage from the
         model's upstream tables to the model table.
@@ -371,7 +368,7 @@ class DbtcloudSource(PipelineServiceSource):
                 service_names=source_elements[0],
                 database_name=source_elements[1],
                 schema_name=source_elements[2],
-                dialect=self._resolve_dialect(db_service_name),
+                dialect=self._resolve_dialect(source_elements[0]),
                 timeout_seconds=LINEAGE_PARSING_TIMEOUT,
                 lineage_source=LineageSource.DbtLineage,
             )

--- a/ingestion/src/metadata/ingestion/source/pipeline/dbtcloud/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/pipeline/dbtcloud/metadata.py
@@ -17,6 +17,8 @@ from collections import defaultdict
 from datetime import datetime
 from typing import Any, Dict, Iterable, List, Optional, Tuple  # noqa: UP035
 
+from cachetools import LRUCache
+
 from metadata.generated.schema.api.data.createPipeline import CreatePipelineRequest
 from metadata.generated.schema.api.lineage.addLineage import AddLineageRequest
 from metadata.generated.schema.entity.data.pipeline import (
@@ -97,8 +99,8 @@ class DbtcloudSource(PipelineServiceSource):
         self.observability_cache: Dict[Tuple[int, str], Dict[str, Any]] = {}  # noqa: UP006
         # Cache for table entity lookups to avoid redundant API calls
         self._table_entity_cache: Dict[str, Optional[Table]] = {}  # noqa: UP006, UP045
-        # Cache for resolved SQL dialects keyed by database service name
-        self._dialect_cache: Dict[str, Dialect] = {}  # noqa: UP006
+        # Bounded cache for resolved SQL dialects keyed by database service name
+        self._dialect_cache: LRUCache = LRUCache(maxsize=128)
 
     def _get_table_entity(self, table_fqn: str) -> Optional[Table]:  # noqa: UP045
         """

--- a/ingestion/src/metadata/ingestion/source/pipeline/dbtcloud/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/pipeline/dbtcloud/metadata.py
@@ -15,7 +15,7 @@ DBTcloud source to extract metadata from OM UI
 import traceback
 from collections import defaultdict
 from datetime import datetime
-from typing import Any, Dict, Iterable, List, Optional, Tuple  # noqa: UP035
+from typing import Any, Dict, Iterable, List, Optional, Tuple, cast  # noqa: UP035
 
 from metadata.generated.schema.api.data.createPipeline import CreatePipelineRequest
 from metadata.generated.schema.api.lineage.addLineage import AddLineageRequest
@@ -30,6 +30,7 @@ from metadata.generated.schema.entity.data.table import Table
 from metadata.generated.schema.entity.services.connections.pipeline.dbtCloudConnection import (
     DBTCloudConnection,
 )
+from metadata.generated.schema.entity.services.databaseService import DatabaseService
 from metadata.generated.schema.entity.services.ingestionPipelines.status import (
     StackTraceError,
 )
@@ -49,9 +50,12 @@ from metadata.generated.schema.type.entityReference import EntityReference
 from metadata.generated.schema.type.pipelineObservability import PipelineObservability
 from metadata.ingestion.api.models import Either
 from metadata.ingestion.api.steps import InvalidSourceException
+from metadata.ingestion.lineage.models import ConnectionTypeDialectMapper, Dialect
+from metadata.ingestion.lineage.parser import LINEAGE_PARSING_TIMEOUT
+from metadata.ingestion.lineage.sql_lineage import get_lineage_by_query
 from metadata.ingestion.models.pipeline_status import OMetaPipelineStatus
 from metadata.ingestion.ometa.ometa_api import OpenMetadata
-from metadata.ingestion.source.pipeline.dbtcloud.models import DBTJob
+from metadata.ingestion.source.pipeline.dbtcloud.models import DBTJob, DBTModel
 from metadata.ingestion.source.pipeline.pipeline_service import PipelineServiceSource
 from metadata.utils import fqn
 from metadata.utils.helpers import clean_uri, datetime_to_ts
@@ -92,6 +96,8 @@ class DbtcloudSource(PipelineServiceSource):
         self.observability_cache: Dict[Tuple[int, str], Dict[str, Any]] = {}  # noqa: UP006
         # Cache for table entity lookups to avoid redundant API calls
         self._table_entity_cache: Dict[str, Optional[Table]] = {}  # noqa: UP006, UP045
+        # Cache for resolved SQL dialects keyed by database service name
+        self._dialect_cache: Dict[str, Dialect] = {}  # noqa: UP006
 
     def _get_table_entity(self, table_fqn: str) -> Optional[Table]:  # noqa: UP045
         """
@@ -251,6 +257,13 @@ class DbtcloudSource(PipelineServiceSource):
                     if cache_key and cache_key in self.observability_cache:
                         self.observability_cache[cache_key]["table_fqns"].add(to_entity_fqn)
 
+                    if model.compiledCode and to_entity_fqn:
+                        yield from self._yield_column_lineage(
+                            model=model,
+                            to_entity_fqn=to_entity_fqn,
+                            db_service_name=dbservicename,
+                        )
+
                     for unique_id in model.dependsOn or []:
                         # Use dict lookup instead of list comprehension
                         parent = parent_by_unique_id.get(unique_id)
@@ -323,6 +336,46 @@ class DbtcloudSource(PipelineServiceSource):
                     stackTrace=traceback.format_exc(),
                 )
             )
+
+    def _resolve_dialect(self, db_service_name: str) -> Dialect:
+        """
+        Resolve the SQL dialect for a configured database service so the compiled
+        dbt model SQL can be parsed for column-level lineage.
+        """
+        if db_service_name not in self._dialect_cache:
+            dialect = Dialect.ANSI
+            db_service = self.metadata.get_by_name(entity=DatabaseService, fqn=db_service_name)
+            if db_service and db_service.serviceType:
+                dialect = ConnectionTypeDialectMapper.dialect_of(db_service.serviceType.value)
+            self._dialect_cache[db_service_name] = dialect
+        return self._dialect_cache[db_service_name]
+
+    def _yield_column_lineage(
+        self, model: DBTModel, to_entity_fqn: str, db_service_name: str
+    ) -> Iterable[Either[AddLineageRequest]]:
+        """
+        Parse the compiled dbt model SQL to build column-level lineage from the
+        model's upstream tables to the model table.
+        """
+        try:
+            source_elements = fqn.split(to_entity_fqn)
+            query_fqn = fqn._build(*source_elements[-3:])  # pylint: disable=protected-access
+            query_fqn = ".".join([f'"{element}"' for element in query_fqn.split(".")])
+            query = f"create table {query_fqn} as {model.compiledCode}"
+            for lineage in get_lineage_by_query(
+                self.metadata,
+                query=query,
+                service_names=source_elements[0],
+                database_name=source_elements[1],
+                schema_name=source_elements[2],
+                dialect=self._resolve_dialect(db_service_name),
+                timeout_seconds=LINEAGE_PARSING_TIMEOUT,
+                lineage_source=LineageSource.DbtLineage,
+            ):
+                yield cast("Either[AddLineageRequest]", lineage)
+        except Exception as exc:  # pylint: disable=broad-except
+            logger.debug(traceback.format_exc())
+            logger.warning(f"Failed to parse compiled SQL for column lineage of model {model.name}: {exc}")
 
     def get_pipelines_list(self) -> Iterable[DBTJob]:
         """

--- a/ingestion/src/metadata/ingestion/source/pipeline/dbtcloud/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/pipeline/dbtcloud/metadata.py
@@ -15,7 +15,7 @@ DBTcloud source to extract metadata from OM UI
 import traceback
 from collections import defaultdict
 from datetime import datetime
-from typing import Any, Dict, Iterable, List, Optional, Tuple, cast  # noqa: UP035
+from typing import Any, Dict, Iterable, List, Optional, Tuple  # noqa: UP035
 
 from metadata.generated.schema.api.data.createPipeline import CreatePipelineRequest
 from metadata.generated.schema.api.lineage.addLineage import AddLineageRequest
@@ -53,6 +53,7 @@ from metadata.ingestion.api.steps import InvalidSourceException
 from metadata.ingestion.lineage.models import ConnectionTypeDialectMapper, Dialect
 from metadata.ingestion.lineage.parser import LINEAGE_PARSING_TIMEOUT
 from metadata.ingestion.lineage.sql_lineage import get_lineage_by_query
+from metadata.ingestion.models.ometa_lineage import LineageRequest
 from metadata.ingestion.models.pipeline_status import OMetaPipelineStatus
 from metadata.ingestion.ometa.ometa_api import OpenMetadata
 from metadata.ingestion.source.pipeline.dbtcloud.models import DBTJob, DBTModel
@@ -258,7 +259,9 @@ class DbtcloudSource(PipelineServiceSource):
                         self.observability_cache[cache_key]["table_fqns"].add(to_entity_fqn)
 
                     if model.compiledCode and to_entity_fqn:
-                        yield from self._yield_column_lineage(
+                        # get_lineage_by_query is typed to return the LineageRequest union;
+                        # on this create-table path it only yields AddLineageRequest edges.
+                        yield from self._yield_column_lineage(  # pyright: ignore[reportReturnType]
                             model=model,
                             to_entity_fqn=to_entity_fqn,
                             db_service_name=dbservicename,
@@ -352,7 +355,7 @@ class DbtcloudSource(PipelineServiceSource):
 
     def _yield_column_lineage(
         self, model: DBTModel, to_entity_fqn: str, db_service_name: str
-    ) -> Iterable[Either[AddLineageRequest]]:
+    ) -> Iterable[Either[LineageRequest]]:
         """
         Parse the compiled dbt model SQL to build column-level lineage from the
         model's upstream tables to the model table.
@@ -362,7 +365,7 @@ class DbtcloudSource(PipelineServiceSource):
             query_fqn = fqn._build(*source_elements[-3:])  # pylint: disable=protected-access
             query_fqn = ".".join([f'"{element}"' for element in query_fqn.split(".")])
             query = f"create table {query_fqn} as {model.compiledCode}"
-            for lineage in get_lineage_by_query(
+            yield from get_lineage_by_query(
                 self.metadata,
                 query=query,
                 service_names=source_elements[0],
@@ -371,8 +374,7 @@ class DbtcloudSource(PipelineServiceSource):
                 dialect=self._resolve_dialect(db_service_name),
                 timeout_seconds=LINEAGE_PARSING_TIMEOUT,
                 lineage_source=LineageSource.DbtLineage,
-            ):
-                yield cast("Either[AddLineageRequest]", lineage)
+            )
         except Exception as exc:  # pylint: disable=broad-except
             logger.debug(traceback.format_exc())
             logger.warning(f"Failed to parse compiled SQL for column lineage of model {model.name}: {exc}")

--- a/ingestion/src/metadata/ingestion/source/pipeline/dbtcloud/models.py
+++ b/ingestion/src/metadata/ingestion/source/pipeline/dbtcloud/models.py
@@ -81,6 +81,8 @@ class DBTModel(BaseModel):
     database: Optional[str] = None  # noqa: UP045
     runGeneratedAt: Optional[str] = None  # noqa: N815, UP045
     dependsOn: Optional[List[str]] = None  # noqa: N815, UP006, UP045
+    compiledCode: Optional[str] = None  # noqa: N815, UP045
+    rawCode: Optional[str] = None  # noqa: N815, UP045
 
 
 class DBTModelList(BaseModel):

--- a/ingestion/src/metadata/ingestion/source/pipeline/dbtcloud/models.py
+++ b/ingestion/src/metadata/ingestion/source/pipeline/dbtcloud/models.py
@@ -82,7 +82,6 @@ class DBTModel(BaseModel):
     runGeneratedAt: Optional[str] = None  # noqa: N815, UP045
     dependsOn: Optional[List[str]] = None  # noqa: N815, UP006, UP045
     compiledCode: Optional[str] = None  # noqa: N815, UP045
-    rawCode: Optional[str] = None  # noqa: N815, UP045
 
 
 class DBTModelList(BaseModel):

--- a/ingestion/src/metadata/ingestion/source/pipeline/dbtcloud/queries.py
+++ b/ingestion/src/metadata/ingestion/source/pipeline/dbtcloud/queries.py
@@ -22,6 +22,8 @@ query Query($jobId: BigInt!, $runId: BigInt) {
       schema
       dependsOn
       runGeneratedAt
+      compiledCode
+      rawCode
     }
     seeds {
       uniqueId

--- a/ingestion/src/metadata/ingestion/source/pipeline/dbtcloud/queries.py
+++ b/ingestion/src/metadata/ingestion/source/pipeline/dbtcloud/queries.py
@@ -23,7 +23,6 @@ query Query($jobId: BigInt!, $runId: BigInt) {
       dependsOn
       runGeneratedAt
       compiledCode
-      rawCode
     }
     seeds {
       uniqueId

--- a/ingestion/tests/unit/topology/pipeline/test_dbtcloud.py
+++ b/ingestion/tests/unit/topology/pipeline/test_dbtcloud.py
@@ -16,14 +16,16 @@ import json
 import uuid
 from datetime import datetime, timedelta
 from unittest import TestCase
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from metadata.generated.schema.api.data.createPipeline import CreatePipelineRequest
+from metadata.generated.schema.api.lineage.addLineage import AddLineageRequest
 from metadata.generated.schema.entity.data.pipeline import Pipeline, Task
 from metadata.generated.schema.entity.data.table import Table
 from metadata.generated.schema.entity.services.connections.metadata.openMetadataConnection import (
     OpenMetadataConnection,
 )
+from metadata.generated.schema.entity.services.databaseService import DatabaseService
 from metadata.generated.schema.entity.services.pipelineService import (
     PipelineConnection,
     PipelineService,
@@ -38,10 +40,17 @@ from metadata.generated.schema.type.basic import (
     Markdown,
     SourceUrl,
 )
+from metadata.generated.schema.type.entityLineage import (
+    ColumnLineage,
+    EntitiesEdge,
+    LineageDetails,
+)
 from metadata.generated.schema.type.entityReference import EntityReference
 from metadata.generated.schema.type.pipelineObservability import PipelineObservability
 from metadata.generated.schema.type.usageDetails import UsageDetails, UsageStats
 from metadata.generated.schema.type.usageRequest import UsageRequest
+from metadata.ingestion.api.models import Either
+from metadata.ingestion.lineage.models import Dialect
 from metadata.ingestion.ometa.ometa_api import OpenMetadata
 from metadata.ingestion.source.pipeline.dbtcloud.metadata import DbtcloudSource
 from metadata.ingestion.source.pipeline.dbtcloud.models import (
@@ -861,6 +870,201 @@ class DBTCloudUnitTest(TestCase):
                 # Verify we can call the method without errors
                 # Note: Lineage edges may or may not be generated depending on entity resolution
                 self.assertIsInstance(lineage_details, list)
+
+    def _build_lineage_mocks(self):
+        """
+        Prime the lineage context/config and return the pipeline, source table,
+        target table and a get_by_name side effect shared by column-lineage tests.
+        """
+        self.dbtcloud.context.get().__dict__["latest_run_id"] = 70403110257794
+        self.dbtcloud.context.get().__dict__["pipeline"] = "New job"
+        self.dbtcloud.context.get().__dict__["pipeline_service"] = "dbtcloud_pipeline_test"
+        self.dbtcloud.context.get().__dict__["current_runs"] = []
+        self.dbtcloud.source_config.lineageInformation = type("obj", (object,), {"dbServiceNames": ["local_redshift"]})
+        # fqn.build resolves tables via ES; stub it so it falls back to the
+        # concatenated FQN instead of making a real search call.
+        self.dbtcloud.metadata.es_search_from_fqn = lambda *args, **kwargs: None
+
+        mock_pipeline = Pipeline(
+            id=uuid.uuid4(),
+            name="New job",
+            fullyQualifiedName="dbtcloud_pipeline_test.New job",
+            service=EntityReference(id=uuid.uuid4(), type="pipelineService"),
+        )
+        mock_source_table = Table(
+            id=uuid.uuid4(),
+            name="model_15",
+            fullyQualifiedName="local_redshift.dev.dbt_test_new.model_15",
+            database=EntityReference(id=uuid.uuid4(), type="database"),
+            databaseSchema=EntityReference(id=uuid.uuid4(), type="databaseSchema"),
+            columns=[],
+        )
+        mock_target_table = Table(
+            id=uuid.uuid4(),
+            name="model_32",
+            fullyQualifiedName="local_redshift.dev.dbt_test_new.model_32",
+            database=EntityReference(id=uuid.uuid4(), type="database"),
+            databaseSchema=EntityReference(id=uuid.uuid4(), type="databaseSchema"),
+            columns=[],
+        )
+
+        def get_by_name_side_effect(entity, fqn):
+            if entity == Pipeline:
+                return mock_pipeline
+            if entity == DatabaseService:
+                service = MagicMock()
+                service.serviceType.value = "Redshift"
+                return service
+            if entity == Table:
+                fqn_str = str(fqn)
+                if "model_15" in fqn_str:
+                    return mock_source_table
+                if "model_32" in fqn_str:
+                    return mock_target_table
+            return None
+
+        return mock_pipeline, mock_source_table, mock_target_table, get_by_name_side_effect
+
+    def test_yield_pipeline_column_lineage_from_compiled_code(self):
+        """
+        Models exposing compiledCode should produce column-level lineage by
+        parsing the compiled SQL through get_lineage_by_query, using the dialect
+        resolved from the configured database service.
+        """
+        (
+            _,
+            mock_source_table,
+            mock_target_table,
+            get_by_name_side_effect,
+        ) = self._build_lineage_mocks()
+
+        compiled_sql = "select id from dbt_test_new.model_15"
+        column_lineage_edge = AddLineageRequest(
+            edge=EntitiesEdge(
+                fromEntity=EntityReference(id=mock_source_table.id, type="table"),
+                toEntity=EntityReference(id=mock_target_table.id, type="table"),
+                lineageDetails=LineageDetails(
+                    columnsLineage=[
+                        ColumnLineage(
+                            fromColumns=["local_redshift.dev.dbt_test_new.model_15.id"],
+                            toColumn="local_redshift.dev.dbt_test_new.model_32.id",
+                        )
+                    ],
+                ),
+            )
+        )
+
+        with (
+            patch.object(self.dbtcloud.metadata, "get_by_name", side_effect=get_by_name_side_effect),
+            patch.object(self.dbtcloud.client, "get_models_with_lineage") as mock_models,
+            patch("metadata.ingestion.source.pipeline.dbtcloud.metadata.get_lineage_by_query") as mock_parser,
+        ):
+            mock_models.return_value = (
+                [
+                    DBTModel.model_validate(
+                        {
+                            "uniqueId": "model.dbt_test_new.model_32",
+                            "name": "model_32",
+                            "schema": "dbt_test_new",
+                            "database": "dev",
+                            "runGeneratedAt": "2024-05-27T10:42:20.621788+00:00",
+                            "dependsOn": ["model.dbt_test_new.model_15"],
+                            "compiledCode": compiled_sql,
+                        }
+                    ),
+                    DBTModel.model_validate(
+                        {
+                            "uniqueId": "model.dbt_test_new.model_15",
+                            "name": "model_15",
+                            "schema": "dbt_test_new",
+                            "database": "dev",
+                            "runGeneratedAt": "2024-05-27T10:42:20.621788+00:00",
+                            "dependsOn": None,
+                        }
+                    ),
+                ],
+                [],
+                [],
+            )
+            mock_parser.return_value = iter([Either(right=column_lineage_edge)])
+
+            results = list(self.dbtcloud.yield_pipeline_lineage_details(EXPECTED_JOB_DETAILS))
+
+        mock_parser.assert_called_once()
+        call_kwargs = mock_parser.call_args.kwargs
+        self.assertIn(compiled_sql, call_kwargs["query"])
+        self.assertTrue(call_kwargs["query"].startswith("create table"))
+        self.assertEqual(call_kwargs["service_names"], "local_redshift")
+        self.assertEqual(call_kwargs["database_name"], "dev")
+        self.assertEqual(call_kwargs["schema_name"], "dbt_test_new")
+        self.assertEqual(call_kwargs["dialect"], Dialect.REDSHIFT)
+
+        column_edges = [
+            result.right
+            for result in results
+            if result.right is not None
+            and isinstance(result.right, AddLineageRequest)
+            and result.right.edge.lineageDetails is not None
+            and result.right.edge.lineageDetails.columnsLineage
+        ]
+        self.assertEqual(len(column_edges), 1)
+        details = column_edges[0].edge.lineageDetails
+        self.assertEqual(
+            details.columnsLineage[0].toColumn.root,
+            "local_redshift.dev.dbt_test_new.model_32.id",
+        )
+
+    def test_no_column_lineage_without_compiled_code(self):
+        """
+        Models without compiledCode must fall back to table-level lineage only
+        and never invoke the SQL parser.
+        """
+        _, _, _, get_by_name_side_effect = self._build_lineage_mocks()
+
+        with (
+            patch.object(self.dbtcloud.metadata, "get_by_name", side_effect=get_by_name_side_effect),
+            patch.object(self.dbtcloud.client, "get_models_with_lineage") as mock_models,
+            patch("metadata.ingestion.source.pipeline.dbtcloud.metadata.get_lineage_by_query") as mock_parser,
+        ):
+            mock_models.return_value = (
+                [
+                    DBTModel.model_validate(
+                        {
+                            "uniqueId": "model.dbt_test_new.model_32",
+                            "name": "model_32",
+                            "schema": "dbt_test_new",
+                            "database": "dev",
+                            "runGeneratedAt": "2024-05-27T10:42:20.621788+00:00",
+                            "dependsOn": ["model.dbt_test_new.model_15"],
+                        }
+                    ),
+                    DBTModel.model_validate(
+                        {
+                            "uniqueId": "model.dbt_test_new.model_15",
+                            "name": "model_15",
+                            "schema": "dbt_test_new",
+                            "database": "dev",
+                            "runGeneratedAt": "2024-05-27T10:42:20.621788+00:00",
+                            "dependsOn": None,
+                        }
+                    ),
+                ],
+                [],
+                [],
+            )
+
+            results = list(self.dbtcloud.yield_pipeline_lineage_details(EXPECTED_JOB_DETAILS))
+
+        mock_parser.assert_not_called()
+        column_edges = [
+            result.right
+            for result in results
+            if result.right is not None
+            and isinstance(result.right, AddLineageRequest)
+            and result.right.edge.lineageDetails is not None
+            and result.right.edge.lineageDetails.columnsLineage
+        ]
+        self.assertEqual(len(column_edges), 0)
 
     def test_yield_pipeline_status_uses_current_pipeline_fqn(self):
         """

--- a/ingestion/tests/unit/topology/pipeline/test_dbtcloud.py
+++ b/ingestion/tests/unit/topology/pipeline/test_dbtcloud.py
@@ -19,6 +19,7 @@ from unittest import TestCase
 from unittest.mock import MagicMock, patch
 
 from metadata.generated.schema.api.data.createPipeline import CreatePipelineRequest
+from metadata.generated.schema.api.lineage.addLineage import AddLineageRequest
 from metadata.generated.schema.entity.data.pipeline import Pipeline, Task
 from metadata.generated.schema.entity.data.table import Table
 from metadata.generated.schema.entity.services.connections.metadata.openMetadataConnection import (
@@ -1008,6 +1009,17 @@ class DBTCloudUnitTest(TestCase):
             details.columnsLineage[0].toColumn.root,
             "local_redshift.dev.dbt_test_new.model_32.id",
         )
+
+        # Column lineage augments, not replaces, the existing table-level pipeline edge.
+        table_edges = [
+            result.right
+            for result in results
+            if result.right is not None
+            and isinstance(result.right, AddLineageRequest)
+            and result.right.edge.lineageDetails is not None
+            and result.right.edge.lineageDetails.pipeline is not None
+        ]
+        self.assertEqual(len(table_edges), 1)
 
     def test_no_column_lineage_without_compiled_code(self):
         """

--- a/ingestion/tests/unit/topology/pipeline/test_dbtcloud.py
+++ b/ingestion/tests/unit/topology/pipeline/test_dbtcloud.py
@@ -19,7 +19,6 @@ from unittest import TestCase
 from unittest.mock import MagicMock, patch
 
 from metadata.generated.schema.api.data.createPipeline import CreatePipelineRequest
-from metadata.generated.schema.api.lineage.addLineage import AddLineageRequest
 from metadata.generated.schema.entity.data.pipeline import Pipeline, Task
 from metadata.generated.schema.entity.data.table import Table
 from metadata.generated.schema.entity.services.connections.metadata.openMetadataConnection import (
@@ -42,7 +41,6 @@ from metadata.generated.schema.type.basic import (
 )
 from metadata.generated.schema.type.entityLineage import (
     ColumnLineage,
-    EntitiesEdge,
     LineageDetails,
 )
 from metadata.generated.schema.type.entityReference import EntityReference
@@ -51,6 +49,7 @@ from metadata.generated.schema.type.usageDetails import UsageDetails, UsageStats
 from metadata.generated.schema.type.usageRequest import UsageRequest
 from metadata.ingestion.api.models import Either
 from metadata.ingestion.lineage.models import Dialect
+from metadata.ingestion.models.ometa_lineage import OMetaFQNLineageRequest
 from metadata.ingestion.ometa.ometa_api import OpenMetadata
 from metadata.ingestion.source.pipeline.dbtcloud.metadata import DbtcloudSource
 from metadata.ingestion.source.pipeline.dbtcloud.models import (
@@ -931,27 +930,23 @@ class DBTCloudUnitTest(TestCase):
         parsing the compiled SQL through get_lineage_by_query, using the dialect
         resolved from the configured database service.
         """
-        (
-            _,
-            mock_source_table,
-            mock_target_table,
-            get_by_name_side_effect,
-        ) = self._build_lineage_mocks()
+        *_, get_by_name_side_effect = self._build_lineage_mocks()
 
         compiled_sql = "select id from dbt_test_new.model_15"
-        column_lineage_edge = AddLineageRequest(
-            edge=EntitiesEdge(
-                fromEntity=EntityReference(id=mock_source_table.id, type="table"),
-                toEntity=EntityReference(id=mock_target_table.id, type="table"),
-                lineageDetails=LineageDetails(
-                    columnsLineage=[
-                        ColumnLineage(
-                            fromColumns=["local_redshift.dev.dbt_test_new.model_15.id"],
-                            toColumn="local_redshift.dev.dbt_test_new.model_32.id",
-                        )
-                    ],
-                ),
-            )
+        # get_lineage_by_query yields OMetaFQNLineageRequest on the create-table path.
+        column_lineage_edge = OMetaFQNLineageRequest(
+            from_entity_fqn="local_redshift.dev.dbt_test_new.model_15",
+            from_entity_type="table",
+            to_entity_fqn="local_redshift.dev.dbt_test_new.model_32",
+            to_entity_type="table",
+            lineage_details=LineageDetails(
+                columnsLineage=[
+                    ColumnLineage(
+                        fromColumns=["local_redshift.dev.dbt_test_new.model_15.id"],
+                        toColumn="local_redshift.dev.dbt_test_new.model_32.id",
+                    )
+                ],
+            ),
         )
 
         with (
@@ -1003,12 +998,12 @@ class DBTCloudUnitTest(TestCase):
             result.right
             for result in results
             if result.right is not None
-            and isinstance(result.right, AddLineageRequest)
-            and result.right.edge.lineageDetails is not None
-            and result.right.edge.lineageDetails.columnsLineage
+            and isinstance(result.right, OMetaFQNLineageRequest)
+            and result.right.lineage_details is not None
+            and result.right.lineage_details.columnsLineage
         ]
         self.assertEqual(len(column_edges), 1)
-        details = column_edges[0].edge.lineageDetails
+        details = column_edges[0].lineage_details
         self.assertEqual(
             details.columnsLineage[0].toColumn.root,
             "local_redshift.dev.dbt_test_new.model_32.id",
@@ -1060,9 +1055,9 @@ class DBTCloudUnitTest(TestCase):
             result.right
             for result in results
             if result.right is not None
-            and isinstance(result.right, AddLineageRequest)
-            and result.right.edge.lineageDetails is not None
-            and result.right.edge.lineageDetails.columnsLineage
+            and isinstance(result.right, OMetaFQNLineageRequest)
+            and result.right.lineage_details is not None
+            and result.right.lineage_details.columnsLineage
         ]
         self.assertEqual(len(column_edges), 0)
 


### PR DESCRIPTION
### Describe your changes:

Fixes #<issue-number>
<!-- TODO: link the GitHub issue for dbt Cloud column-level lineage. Required for the "Validate PR Metadata" gate. -->

I added **column-level lineage to the dbt Cloud connector** because it previously only produced table-level (pipeline) lineage — dbt's `dependsOn` graph is model-granular and the connector fetched no SQL to derive column mappings. The Discovery GraphQL query now also requests each model's `compiledCode`, which is parsed through the existing `get_lineage_by_query` column-lineage path (the same one the manifest-based dbt integration uses), with the SQL dialect resolved from the linked database service. When a model has no compiled SQL (sources, seeds, non-compiling runs) it falls back to the existing table-level lineage.

#
### Type of change:
- [x] New feature

#
### High-level design:

- `queries.py` — added `compiledCode`/`rawCode` to the job-level Discovery GraphQL `models` block (available at job level, so no environment-level API migration).
- `models.py` — added `compiledCode`/`rawCode` to `DBTModel`.
- `metadata.py` — `_resolve_dialect()` (bounded cache) maps the linked `DatabaseService.serviceType` to a SQL dialect; `_yield_column_lineage()` builds `create table <fqn> as <compiledCode>` and runs it through `get_lineage_by_query`, emitting `AddLineageRequest` edges with `columnsLineage` alongside the existing table-level pipeline edges. Wrapped in per-model try/except so a parse failure warns and continues.
- Reused the existing `includeLineage` gating (no schema change); emitted edges match the connector's existing raw `AddLineageRequest` style.

#
### Tests:

#### Use cases covered
- dbt Cloud model with compiled SQL produces column-level lineage edges with the correct dialect resolved from the DB service.
- Model without `compiledCode` falls back to table-level lineage and never invokes the SQL parser.

#### Unit tests
- [x] Added unit tests for the new/changed logic.
- Files updated: `ingestion/tests/unit/topology/pipeline/test_dbtcloud.py` (`test_yield_pipeline_column_lineage_from_compiled_code`, `test_no_column_lineage_without_compiled_code`).

#### Ingestion integration tests
- [x] Not applicable (covered by unit tests against mocked Discovery API).

#### Manual testing performed
1. Ran a dbt Cloud ingestion against a real project and confirmed column-level lineage edges render correctly in the Explore/lineage view.

#
### UI screen recording / screenshots:

Not applicable.

#
### Checklist:
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests and listed them above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds column-level lineage to the dbt Cloud pipeline connector by fetching each model's `compiledCode` from the Discovery GraphQL API and parsing it through the existing `get_lineage_by_query` path. A `_resolve_dialect()` helper maps the linked `DatabaseService.serviceType` to the correct SQL dialect (cached with an LRU cache), and `_yield_column_lineage()` wraps the compiled SQL in a synthetic `CREATE TABLE … AS …` statement before feeding it to the parser.

- **`queries.py` / `models.py`**: `compiledCode` is added to the GraphQL query and the `DBTModel` Pydantic schema; seeds and sources remain unchanged since they have no compiled SQL.
- **`metadata.py`**: `_resolve_dialect()` and `_yield_column_lineage()` are introduced; column lineage is gated on `model.compiledCode` presence and falls back gracefully to the existing table-level pipeline lineage; per-model exceptions are caught so a parse failure never aborts the rest of the job.
- **Tests**: Two new unit tests cover the happy-path (column edges produced, correct dialect, correct FQN decomposition) and the fallback path (no `compiledCode` → parser never called).
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge; the column lineage path is fully gated behind compiledCode presence, wrapped in per-model try/except, and falls back cleanly to existing table-level pipeline lineage when SQL is absent or unparseable.

The new code is a well-isolated addition: dialect resolution is LRU-cached, the synthetic CREATE TABLE wrapper follows the same pattern used by the manifest-based dbt connector, FQN decomposition is correct for standard 4-part table FQNs, and the broad exception handler prevents parse failures from aborting the job. Two targeted unit tests cover the happy path and the no-compiledCode fallback. No changes to existing logic paths.

No files require special attention.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| ingestion/src/metadata/ingestion/source/pipeline/dbtcloud/metadata.py | Core change: adds _resolve_dialect() (LRU-cached) and _yield_column_lineage(); integrates them into the model loop with correct gating, error handling, and FQN decomposition. |
| ingestion/src/metadata/ingestion/source/pipeline/dbtcloud/models.py | Adds optional compiledCode field to DBTModel; straightforward schema addition. |
| ingestion/src/metadata/ingestion/source/pipeline/dbtcloud/queries.py | Adds compiledCode to the models block of the Discovery GraphQL query; no rawCode field was added (only compiledCode). |
| ingestion/tests/unit/topology/pipeline/test_dbtcloud.py | Adds two well-structured unit tests: column lineage from compiled SQL (verifies dialect, FQN decomposition, parser invocation) and no-column-lineage fallback (verifies parser is never called). |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant TL as Topology Layer
    participant DS as DbtcloudSource
    participant GQL as dbt Cloud GraphQL API
    participant OM as OpenMetadata API

    TL->>DS: yield_pipeline_lineage_details(job)
    DS->>GQL: get_models_with_lineage(job_id, run_id)
    GQL-->>DS: models (with compiledCode), seeds, sources

    loop for each model with compiledCode
        DS->>DS: _resolve_dialect(service_name) [LRU cached]
        DS->>OM: get_by_name(DatabaseService)
        OM-->>DS: serviceType
        DS->>DS: _yield_column_lineage(model, to_entity_fqn)
        Note over DS: wrap compiledCode in CREATE TABLE AS
        DS->>DS: get_lineage_by_query(query, dialect, ...)
        DS-->>TL: Either[OMetaFQNLineageRequest] (with columnsLineage)
    end

    loop for each model.dependsOn
        DS-->>TL: Either[AddLineageRequest] (PipelineLineage, pipeline ref)
    end

    TL->>OM: persist column + table lineage edges
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant TL as Topology Layer
    participant DS as DbtcloudSource
    participant GQL as dbt Cloud GraphQL API
    participant OM as OpenMetadata API

    TL->>DS: yield_pipeline_lineage_details(job)
    DS->>GQL: get_models_with_lineage(job_id, run_id)
    GQL-->>DS: models (with compiledCode), seeds, sources

    loop for each model with compiledCode
        DS->>DS: _resolve_dialect(service_name) [LRU cached]
        DS->>OM: get_by_name(DatabaseService)
        OM-->>DS: serviceType
        DS->>DS: _yield_column_lineage(model, to_entity_fqn)
        Note over DS: wrap compiledCode in CREATE TABLE AS
        DS->>DS: get_lineage_by_query(query, dialect, ...)
        DS-->>TL: Either[OMetaFQNLineageRequest] (with columnsLineage)
    end

    loop for each model.dependsOn
        DS-->>TL: Either[AddLineageRequest] (PipelineLineage, pipeline ref)
    end

    TL->>OM: persist column + table lineage edges
```

</a>
</details>

<sub>Reviews (4): Last reviewed commit: ["fix(dbtcloud): drop unused rawCode, boun..."](https://github.com/open-metadata/openmetadata/commit/c0781cc852c58b87274552a2bbb11aad6774f8c0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41617198)</sub>

<!-- /greptile_comment -->