### PR TITLE
fix(ui): enhance FormItemLabel with customizable class names for label and beta badge

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/common/Form/Form.interface.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/Form/Form.interface.ts
@@ -25,4 +25,6 @@ export interface FormItemLabelProps {
   overlayInnerStyle?: React.CSSProperties;
   align?: TooltipProps['align'];
   isBeta?: boolean;
+  labelClassName?: string;
+  betaBadgeClassName?: string;
 }

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/Form/FormItemLabel.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/Form/FormItemLabel.tsx
@@ -13,12 +13,12 @@
 
 import { InfoCircleOutlined } from '@ant-design/icons';
 import { Badge, Tooltip } from 'antd';
+import classNames from 'classnames';
 import { useTranslation } from 'react-i18next';
 import { GRAYED_OUT_COLOR } from '../../../constants/constants';
 import { useApplicationStore } from '../../../hooks/useApplicationStore';
 import { HelperTextType } from '../../../interface/FormUtils.interface';
 import { FormItemLabelProps } from './Form.interface';
-import classNames from 'classnames';
 
 const FormItemLabel = ({
   label,

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/Form/FormItemLabel.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/Form/FormItemLabel.tsx
@@ -18,6 +18,7 @@ import { GRAYED_OUT_COLOR } from '../../../constants/constants';
 import { useApplicationStore } from '../../../hooks/useApplicationStore';
 import { HelperTextType } from '../../../interface/FormUtils.interface';
 import { FormItemLabelProps } from './Form.interface';
+import classNames from 'classnames';
 
 const FormItemLabel = ({
   label,
@@ -29,13 +30,19 @@ const FormItemLabel = ({
   overlayClassName,
   placement = 'top',
   isBeta = false,
+  labelClassName,
+  betaBadgeClassName,
 }: FormItemLabelProps) => {
   const { t } = useTranslation();
   const { theme } = useApplicationStore();
 
   return (
     <>
-      <span data-testid="form-item-label">{label}</span>
+      <span
+        className={classNames('form-item-label', labelClassName)}
+        data-testid="form-item-label">
+        {label}
+      </span>
       {helperTextType === HelperTextType.Tooltip &&
         helperText &&
         showHelperText && (
@@ -55,7 +62,7 @@ const FormItemLabel = ({
         )}
       {isBeta && (
         <Badge
-          className="m-l-xs"
+          className={classNames('m-l-xs', betaBadgeClassName)}
           color={theme.primaryColor}
           count={t('label.beta')}
           size="small"


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:

Fixes #<issue-number>

support classnames for better overrides
<!--
Linking an issue is REQUIRED. Replace <issue-number> with the GitHub issue number this PR addresses
(e.g., `Fixes #12345`). GitHub will auto-link it. If no issue exists, please open one first so the
problem and design can be discussed before review.
-->

<!--
Short blurb explaining:
- What changes did you make?
- Why did you make them?
-->

I worked on ... because ...

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### High-level design:
<!--
REQUIRED for large PRs (new features, refactors, breaking changes, or anything touching >5 files).
Skip for small bug fixes and trivial changes.

Cover:
- Architecture / approach you took and why
- Key components or files added/changed and how they interact
- Alternatives considered and why you rejected them
- Any migration, backward-compatibility, or rollout concerns
- Diagrams or links to design docs / RFCs if available
-->

N/A — small change. <!-- Or fill in the design above -->

#
### Tests:

#### Use cases covered
<!--
List the user-visible scenarios this PR exercises. Example:
- User with Admin role can create a Glossary Term with a parent term
- Ingestion run for Snowflake correctly extracts row counts for partitioned tables
-->

#### Unit tests
<!--
- [ ] I added unit tests for the new/changed logic.
- Files added/updated:
- Coverage on changed classes (run `mvn jacoco:report` for backend, `yarn test:coverage` for UI,
  `make unit_ingestion` for ingestion). Target is 90% line coverage on changed classes.
- Coverage %: <e.g., 92% on EntityRepository.java>
-->

#### Backend integration tests
<!--
- [ ] I added integration tests in `openmetadata-integration-tests/` for new/changed API endpoints.
- [ ] Not applicable (no backend API changes).
- Files added/updated:
-->

#### Ingestion integration tests
<!--
- [ ] I added/updated ingestion integration tests for connector changes.
- [ ] Not applicable (no ingestion changes).
- Files added/updated:
-->

#### Playwright (UI) tests
<!--
- [ ] I added Playwright E2E tests under `openmetadata-ui/.../ui/playwright/` for UI changes.
- [ ] Not applicable (no UI changes).
- Files added/updated:
-->

#### Manual testing performed
<!--
List the manual test steps you performed before requesting review. Example:
1. Started local stack via `./docker/run_local_docker.sh -m ui -d mysql`
2. Logged in as admin, created entity X, verified Y appears in the UI
3. Triggered ingestion for Snowflake source, confirmed lineage edges in the explore page
-->

#
### UI screen recording / screenshots:
<!--
REQUIRED for any PR that changes the UI. Drag-and-drop a short screen recording (.mov / .mp4 / .gif)
demonstrating the change end-to-end, plus before/after screenshots where relevant.
Mark "Not applicable" if there are no UI changes.
-->

Not applicable. <!-- Or attach recording/screenshots above -->

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.
- [ ] For UI changes: I attached a screen recording and/or screenshots above.
- [ ] I have added tests (unit / integration / Playwright as applicable) and listed them above.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds two optional `className` props — `labelClassName` and `betaBadgeClassName` — to `FormItemLabel`, enabling callers to override styles on the label span and beta badge independently. The component now wraps both elements with the `classnames` utility for conditional class merging, and also introduces a hardcoded base class `form-item-label` on the span.

- `FormItemLabelProps` in `Form.interface.ts` gains `labelClassName?: string` and `betaBadgeClassName?: string`.
- `FormItemLabel.tsx` imports `classnames`, destructures the two new props, and applies them via `classNames(...)` alongside the existing default classes.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is purely additive, adding two optional className props with no effect on existing callers.

Both new props are optional with no defaults, so all existing usages are completely unaffected. The classnames merging logic is straightforward and the TypeScript interface change is backward-compatible. The only open question — already noted in a prior review comment — is whether organize-imports-cli reorders the new classnames import in CI; this is a cosmetic lint concern and not a logic risk.

No files require special attention.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| openmetadata-ui/src/main/resources/ui/src/components/common/Form/Form.interface.ts | Adds two optional string props (labelClassName, betaBadgeClassName) to FormItemLabelProps; purely additive, backward-compatible change. |
| openmetadata-ui/src/main/resources/ui/src/components/common/Form/FormItemLabel.tsx | Imports classnames, applies labelClassName and betaBadgeClassName props to the label span and Beta badge; import ordering of the new classnames entry may conflict with organize-imports-cli expectations. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[FormItemLabel] --> B{props}
    B --> C["label + labelClassName\n→ span.form-item-label"]
    B --> D{helperTextType === Tooltip\n&& helperText\n&& showHelperText}
    D -- Yes --> E[Tooltip + InfoCircleOutlined]
    D -- No --> F[nothing]
    B --> G{isBeta?}
    G -- Yes --> H["Badge\nm-l-xs + betaBadgeClassName"]
    G -- No --> I[nothing]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[FormItemLabel] --> B{props}
    B --> C["label + labelClassName\n→ span.form-item-label"]
    B --> D{helperTextType === Tooltip\n&& helperText\n&& showHelperText}
    D -- Yes --> E[Tooltip + InfoCircleOutlined]
    D -- No --> F[nothing]
    B --> G{isBeta?}
    G -- Yes --> H["Badge\nm-l-xs + betaBadgeClassName"]
    G -- No --> I[nothing]
```

</a>
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `openmetadata-ui/src/main/resources/ui/src/components/common/Form/FormItemLabel.tsx`, line 14-21 ([link](https://github.com/open-metadata/openmetadata/blob/21b50df7c4a500d7d0e2c9142507d75741d96583/openmetadata-ui/src/main/resources/ui/src/components/common/Form/FormItemLabel.tsx#L14-L21)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> The `classnames` import is an external library but is placed after all local relative imports, which violates the project's import ordering convention (external → internal absolute → relative). The `organize-imports-cli` CI check will flag this and the PR will fail lint.

   **Context Used:** CLAUDE.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=52f0d9d9-cad1-4e7d-b070-de181a0aa5e7))
   
   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["Merge branch &#39;main&#39; into chore/form-item..."](https://github.com/open-metadata/openmetadata/commit/8fcc19aaade6fb6cba011132692861f13cdf32ed) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41623783)</sub>

<!-- /greptile_comment -->