### PR TITLE
Fixes #29667: preserve autoClassificationConfig on classification PUT (1.13 backport)

### DIFF
--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/ClassificationResourceIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/ClassificationResourceIT.java
@@ -31,6 +31,7 @@ import org.openmetadata.sdk.client.OpenMetadataClient;
 import org.openmetadata.sdk.exceptions.InvalidRequestException;
 import org.openmetadata.sdk.models.ListParams;
 import org.openmetadata.sdk.models.ListResponse;
+import org.openmetadata.sdk.network.HttpMethod;
 
 /**
  * Integration tests for Classification entity operations.
@@ -462,6 +463,50 @@ public class ClassificationResourceIT extends BaseEntityIT<Classification, Creat
         classification.getAutoClassificationConfig().getConflictResolution());
     assertFalse(classification.getAutoClassificationConfig().getRequireExplicitMatch());
     assertTrue(classification.getMutuallyExclusive());
+  }
+
+  @Test
+  void test_putPreservesAutoClassificationConfig_ingestionScenario(TestNamespace ns) {
+    // A metadata connector re-creates a source classification with a bare PUT
+    // (name + description only, no autoClassificationConfig). This must NOT wipe
+    // an existing config - the regression that disabled auto-classification for
+    // PII/PersonalData after every metadata ingestion.
+    CreateClassification createClassification = new CreateClassification();
+    createClassification.setName(ns.prefix("classification_put_preserve"));
+    createClassification.setDescription("Classification with auto-classification enabled");
+    createClassification.setAutoClassificationConfig(
+        new AutoClassificationConfig().withEnabled(true).withMinimumConfidence(0.6));
+
+    Classification classification = createEntity(createClassification);
+    assertNotNull(classification.getAutoClassificationConfig());
+    assertTrue(classification.getAutoClassificationConfig().getEnabled());
+
+    // Simulate the ingestion sink's create_or_update: PUT /v1/classifications with a
+    // CreateClassification carrying only name + description (no autoClassificationConfig).
+    CreateClassification bareUpsert =
+        new CreateClassification()
+            .withName(classification.getName())
+            .withDescription("Updated by metadata ingestion");
+    SdkClients.adminClient()
+        .getHttpClient()
+        .execute(HttpMethod.PUT, "/v1/classifications", bareUpsert, Classification.class);
+
+    // The config must survive the bare PUT
+    Classification afterIngestion =
+        getEntityWithFields(classification.getId().toString(), "autoClassificationConfig");
+    assertNotNull(
+        afterIngestion.getAutoClassificationConfig(),
+        "Bare PUT from ingestion must not delete autoClassificationConfig");
+    assertTrue(afterIngestion.getAutoClassificationConfig().getEnabled());
+
+    // An explicit PATCH clearing the config must still delete it
+    afterIngestion.setAutoClassificationConfig(null);
+    patchEntity(afterIngestion.getId().toString(), afterIngestion);
+    Classification afterPatch =
+        getEntityWithFields(classification.getId().toString(), "autoClassificationConfig");
+    assertNull(
+        afterPatch.getAutoClassificationConfig(),
+        "Explicit PATCH clearing the config must still delete it");
   }
 
   @Test

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/ClassificationRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/ClassificationRepository.java
@@ -295,6 +295,7 @@ public class ClassificationRepository extends EntityRepository<Classification> {
     public void entitySpecificUpdate(boolean consolidatingChanges) {
       // Mutually exclusive cannot be updated
       updated.setMutuallyExclusive(original.getMutuallyExclusive());
+      preserveAutoClassificationConfigOnPut();
       compareAndUpdate(
           "disabled",
           () -> recordChange("disabled", original.getDisabled(), updated.getDisabled()));
@@ -307,6 +308,12 @@ public class ClassificationRepository extends EntityRepository<Classification> {
                   updated.getAutoClassificationConfig(),
                   true));
       compareAndUpdate("name", () -> updateName(updated));
+    }
+
+    private void preserveAutoClassificationConfigOnPut() {
+      if (operation == Operation.PUT && updated.getAutoClassificationConfig() == null) {
+        updated.setAutoClassificationConfig(original.getAutoClassificationConfig());
+      }
     }
 
     public void updateName(Classification updated) {


### PR DESCRIPTION
Backport of #29668 to `1.13`.

## What

Preserve a classification's `autoClassificationConfig` when a `PUT /v1/classifications` omits it.

## Why

Metadata connectors re-create source classifications with a full-replace `PUT` carrying only `name` + `description`. `ClassificationUpdater.entitySpecificUpdate` recorded the absent `autoClassificationConfig` as a deletion, wiping it on every metadata ingestion and silently disabling the AutoClassification Agent for `PII`, `PersonalData`, etc. The updater already force-preserves `mutuallyExclusive`; `autoClassificationConfig` lacked the equivalent guard.

## Change

On `Operation.PUT`, restore `autoClassificationConfig` from the original entity when the incoming value is `null` — mirroring the existing `style`/`lifeCycle` handling. Explicit `PATCH` clearing still deletes it.

Fixes #29667

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This backport fixes a regression where metadata ingestion's bare `PUT /v1/classifications` (carrying only `name` + `description`) silently wiped any existing `autoClassificationConfig`, disabling auto-classification for system classifications like `PII`/`PersonalData` on every ingestion cycle.

- **Repository fix**: `ClassificationUpdater.entitySpecificUpdate` now calls `preserveAutoClassificationConfigOnPut()` before the field diff, restoring `autoClassificationConfig` from the stored entity when the incoming PUT value is `null` — matching the existing pattern for `mutuallyExclusive`, `style`, and `lifeCycle`. Explicit PATCH-based deletion is unaffected.
- **Integration test**: A new test (`test_putPreservesAutoClassificationConfig_ingestionScenario`) directly simulates the ingestion-sink path and asserts both that the bare PUT preserves the config and that an explicit PATCH still removes it.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is a minimal, targeted guard that prevents an existing regression without altering any other update path.

The two-line logic in preserveAutoClassificationConfigOnPut is easy to reason about: it acts only when operation is PUT and the incoming value is null, leaving all PATCH paths and non-null PUT payloads completely untouched. The integration test directly simulates the ingestion-sink PUT and also verifies that PATCH-based deletion continues to work, so both sides of the behavior are covered.

No files require special attention; both changed files are small and self-contained.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/ClassificationRepository.java | Adds a 6-line preserveAutoClassificationConfigOnPut() guard in ClassificationUpdater.entitySpecificUpdate that restores autoClassificationConfig from the original entity when the operation is PUT and the updated value is null — exactly mirroring the existing mutuallyExclusive pattern. |
| openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/ClassificationResourceIT.java | New integration test covers the ingestion-sink scenario end-to-end: creates a classification with autoClassificationConfig, simulates a bare PUT, asserts the config is preserved, then verifies an explicit PATCH can still clear it. |

</details>

<sub>Reviews (1): Last reviewed commit: ["Fixes #29667: preserve autoClassificatio..."](https://github.com/open-metadata/openmetadata/commit/68c1c6b3b02244ea62a2dbe66483cb924c645b8b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41625773)</sub>

<!-- /greptile_comment -->