### PR TITLE
fix(column-bulk): make column grid sort null-safe (follow-up to #29699)

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/ColumnMetadataGrouper.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/ColumnMetadataGrouper.java
@@ -106,9 +106,12 @@ public class ColumnMetadataGrouper {
     // guaranteed (current callers build it as a HashMap), so sort here for a stable alphabetical
     // order. Case-insensitive for natural listing, with a case-sensitive tie-breaker so names that
     // differ only in case (e.g. "Name"/"name") stay stable instead of relying on map order.
+    // nullsLast guards against a null column name (e.g. a null map key) rather than throwing.
     gridItems.sort(
-        Comparator.comparing(ColumnGridItem::getColumnName, String.CASE_INSENSITIVE_ORDER)
-            .thenComparing(ColumnGridItem::getColumnName));
+        Comparator.comparing(
+                ColumnGridItem::getColumnName, Comparator.nullsLast(String.CASE_INSENSITIVE_ORDER))
+            .thenComparing(
+                ColumnGridItem::getColumnName, Comparator.nullsLast(Comparator.naturalOrder())));
 
     return gridItems;
   }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/ColumnMetadataGrouper.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/ColumnMetadataGrouper.java
@@ -40,6 +40,11 @@ public class ColumnMetadataGrouper {
 
     for (Map.Entry<String, List<ColumnWithContext>> entry : columnsByName.entrySet()) {
       String columnName = entry.getKey();
+      if (columnName == null) {
+        // A column with no name isn't a valid grid row (columnName is required in the response);
+        // skip the malformed bucket so we return the remaining valid columns.
+        continue;
+      }
       List<ColumnWithContext> occurrences = entry.getValue();
 
       Map<String, ColumnMetadataGroup> groups = new HashMap<>();

--- a/openmetadata-service/src/test/java/org/openmetadata/service/search/ColumnMetadataGrouperTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/search/ColumnMetadataGrouperTest.java
@@ -19,6 +19,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -401,6 +402,21 @@ class ColumnMetadataGrouperTest {
     List<String> actual = result.stream().map(ColumnGridItem::getColumnName).toList();
     // Natural String order: 'N' (0x4E) precedes 'n' (0x6E).
     assertEquals(List.of("Name", "name"), actual);
+  }
+
+  @Test
+  void testGroupColumns_nullColumnNameSortsLastWithoutError() {
+    // A null column name (e.g. a null map key) must not throw; it sorts last (nullsLast).
+    Map<String, List<ColumnMetadataGrouper.ColumnWithContext>> columnsByName =
+        new LinkedHashMap<>();
+    columnsByName.put("beta", singleOccurrence("beta"));
+    columnsByName.put(null, singleOccurrence(null));
+    columnsByName.put("alpha", singleOccurrence("alpha"));
+
+    List<ColumnGridItem> result = ColumnMetadataGrouper.groupColumns(columnsByName);
+
+    List<String> actual = result.stream().map(ColumnGridItem::getColumnName).toList();
+    assertEquals(Arrays.asList("alpha", "beta", null), actual);
   }
 
   private static List<ColumnMetadataGrouper.ColumnWithContext> singleOccurrence(String columnName) {

--- a/openmetadata-service/src/test/java/org/openmetadata/service/search/ColumnMetadataGrouperTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/search/ColumnMetadataGrouperTest.java
@@ -19,7 +19,6 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -405,8 +404,9 @@ class ColumnMetadataGrouperTest {
   }
 
   @Test
-  void testGroupColumns_nullColumnNameSortsLastWithoutError() {
-    // A null column name (e.g. a null map key) must not throw; it sorts last (nullsLast).
+  void testGroupColumns_nullColumnNameIsSkipped() {
+    // A null column name (e.g. a null map key) is dropped, not returned with a null required field,
+    // and must not throw. The remaining valid columns still come back sorted.
     Map<String, List<ColumnMetadataGrouper.ColumnWithContext>> columnsByName =
         new LinkedHashMap<>();
     columnsByName.put("beta", singleOccurrence("beta"));
@@ -416,7 +416,7 @@ class ColumnMetadataGrouperTest {
     List<ColumnGridItem> result = ColumnMetadataGrouper.groupColumns(columnsByName);
 
     List<String> actual = result.stream().map(ColumnGridItem::getColumnName).toList();
-    assertEquals(Arrays.asList("alpha", "beta", null), actual);
+    assertEquals(List.of("alpha", "beta"), actual);
   }
 
   private static List<ColumnMetadataGrouper.ColumnWithContext> singleOccurrence(String columnName) {


### PR DESCRIPTION
## Follow-up to #29699 — make the column grid sort null-safe

The alphabetical sort added in #29699 (`ColumnMetadataGrouper.groupColumns`) uses `Comparator.comparing(ColumnGridItem::getColumnName, String.CASE_INSENSITIVE_ORDER)`, which throws a `NullPointerException` if a column name is `null`. Column names are realistically non-null (callers guard the map key), but the sort introduced a new failure mode that didn't exist before — a single malformed bucket with a null key would fail the whole column-grid request instead of returning the remaining results.

### Fix
Wrap both key comparators in `Comparator.nullsLast(...)` so a null column name sorts last rather than crashing:

```java
gridItems.sort(
    Comparator.comparing(
            ColumnGridItem::getColumnName, Comparator.nullsLast(String.CASE_INSENSITIVE_ORDER))
        .thenComparing(
            ColumnGridItem::getColumnName, Comparator.nullsLast(Comparator.naturalOrder())));
```

Adds `testGroupColumns_nullColumnNameSortsLastWithoutError` covering the null case.

### Verification
- Backend build (`openmetadata-service` + deps) — BUILD SUCCESS.
- `ColumnMetadataGrouperTest` — 11/11 pass.

Also applied to the 1.13 backport (#29751) so the two lines stay aligned.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR makes column-grid grouping handle malformed null column names safely.

- Skips null column-name buckets before building grid rows.
- Keeps the alphabetical grid sort null-safe.
- Adds a test that null buckets are dropped while valid columns stay sorted.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge.

- No blocking issues found in the changed code.

</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-service/src/main/java/org/openmetadata/service/search/ColumnMetadataGrouper.java | Skips malformed null column-name buckets and preserves deterministic sorting for returned grid rows. |
| openmetadata-service/src/test/java/org/openmetadata/service/search/ColumnMetadataGrouperTest.java | Adds coverage for dropping a null column-name bucket without losing sorted valid results. |

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(column-bulk): skip null-named column..."](https://github.com/open-metadata/openmetadata/commit/6b7a7783f58ab704bd93c57ae3b9518a08078913) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41933533)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Context used - CLAUDE.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=52f0d9d9-cad1-4e7d-b070-de181a0aa5e7))
- Context used - openmetadata-ui-core-components/CLAUDE.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=41754627-b2bf-474b-8082-f37ef1a07013))
- Context used - AGENTS.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=ef262f5f-911f-44f3-8d2d-e9cb1579c8c8))
</details>

<!-- /greptile_comment -->