### PR TITLE
test: fix IntakeForm 'pick admin user' Steward popper close hanging for 180s

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/IntakeForm.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/IntakeForm.spec.ts
@@ -711,7 +711,10 @@ test.describe(
         await expect(adminOption.first()).toBeVisible({ timeout: 15000 });
         await adminOption.first().click();
 
-        await stewardInput.press('Escape');
+        // Selecting the option collapses the Steward picker's input into a
+        // read-only chip, so `stewardInput` no longer resolves. Press Escape on
+        // the page (not the vanished input) to close the Autocomplete popper.
+        await page.keyboard.press('Escape');
         await expect(listbox).toBeHidden();
       });
 


### PR DESCRIPTION
## What / Why

The Playwright test **`IntakeForm.spec.ts` › _pick admin user → DP create succeeds with correct extension payload_** times out for the **full 180s on every retry** (3× with `test.slow()`), making the whole `IntakeForm` project red.

### Root cause

`#29513` added these two lines after the admin option is clicked, to dismiss the Steward Autocomplete popper before clicking **Save**:

```ts
await stewardInput.press('Escape');
await expect(listbox).toBeHidden();
```

But once an option is selected, the Steward entity-ref picker **collapses its input into a read-only selected-value chip** (`A admin ✕`), so the locator

```ts
getByRole('combobox', { name: 'Steward' }).or(getByRole('textbox', { name: 'Steward' }))
```

no longer resolves. `stewardInput.press('Escape')` then blocks on the vanished element until the test timeout.

Evidence from the failing run's captured artifacts:
- **Accessibility snapshot at failure:** the Steward field is a `group` rendering `avatar "A" → "admin" → clear button` — there is **no `combobox`/`textbox` named "Steward"** left (the other empty pickers — Owners/Experts/Reviewers — still expose theirs).
- **Failure screenshot:** the dialog is fully populated with `A admin ✕` in the required Steward field, ready to Save. The product works; only the test's teardown-of-the-popper step is broken.
- Failed **all 3 retries** identically (not flaky), each burning ~170s on `Press "Escape"`.

### Fix

Press <kbd>Escape</kbd> on the **page** (whatever is focused — i.e. the open popper) instead of on the now-detached input. This preserves the intent of #29513 (close the popper before Save) without depending on a locator that stops existing after selection.

```diff
-        await stewardInput.press('Escape');
+        // Selecting the option collapses the Steward picker's input into a
+        // read-only chip, so `stewardInput` no longer resolves. Press Escape on
+        // the page (not the vanished input) to close the Autocomplete popper.
+        await page.keyboard.press('Escape');
         await expect(listbox).toBeHidden();
```

`page` is already a fixture in the test signature; no new imports. The `await expect(listbox).toBeHidden()` assertion is kept.

### Testing

Local static verification only (single-line test change; the scenario needs a running server + a seeded intake form). Relying on CI's Playwright suite to exercise the `IntakeForm` project end-to-end.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a Playwright test that was timing out for 180 s on every retry because it attempted to press `Escape` on a Steward input element that no longer exists after a selection collapses it into a read-only chip.

- Replaces `stewardInput.press('Escape')` with `page.keyboard.press('Escape')` so the Escape keystroke is sent to whatever is currently focused (the open Autocomplete popper) rather than a stale locator.
- The subsequent `await expect(listbox).toBeHidden()` assertion is preserved unchanged, keeping the original intent of #29513 to verify the popper is dismissed before clicking Save.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — single-line test fix with no production code changes.

The change swaps a locator-based keypress that was targeting a now-detached DOM element for a page-level keypress that is always valid. The fix is minimal, well-commented, and preserves the follow-up assertion that confirms the popper actually closes. No risk to production code paths.

No files require special attention.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/IntakeForm.spec.ts | Replaces `stewardInput.press('Escape')` with `page.keyboard.press('Escape')` to avoid blocking on the Steward picker's input element, which is collapsed into a read-only chip after selection and no longer resolves. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Test
    participant StewardInput as stewardInput (combobox/textbox)
    participant Listbox as Autocomplete Listbox
    participant Page as page.keyboard

    Test->>StewardInput: click() + fill('admin')
    StewardInput->>Listbox: opens dropdown
    Test->>Listbox: click adminOption.first()
    Note over StewardInput: collapses into read-only chip (combobox/textbox no longer resolves)
    alt Before fix (broken)
        Test->>StewardInput: press('Escape') — blocks 180s (element gone)
    else After fix (correct)
        Test->>Page: press('Escape') — closes popper immediately
    end
    Test->>Listbox: expect(listbox).toBeHidden()
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Test
    participant StewardInput as stewardInput (combobox/textbox)
    participant Listbox as Autocomplete Listbox
    participant Page as page.keyboard

    Test->>StewardInput: click() + fill('admin')
    StewardInput->>Listbox: opens dropdown
    Test->>Listbox: click adminOption.first()
    Note over StewardInput: collapses into read-only chip (combobox/textbox no longer resolves)
    alt Before fix (broken)
        Test->>StewardInput: press('Escape') — blocks 180s (element gone)
    else After fix (correct)
        Test->>Page: press('Escape') — closes popper immediately
    end
    Test->>Listbox: expect(listbox).toBeHidden()
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["test: close Steward popper via page.keyb..."](https://github.com/open-metadata/openmetadata/commit/04e1b0129279a87e00becfb8eca53b2f2b84c5c6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42040116)</sub>

<!-- /greptile_comment -->