### PR TITLE
Migrated TagsV1 and TagsViewer components

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/Tag/TagsV1/TagsV1.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Tag/TagsV1/TagsV1.component.tsx
@@ -14,7 +14,7 @@ import {
   Badge,
   Tooltip,
   TooltipTrigger,
-  Typography
+  Typography,
 } from '@openmetadata/ui-core-components';
 import { Tag } from 'antd';
 import classNames from 'classnames';
@@ -256,10 +256,10 @@ const TagsV1 = ({
 
   const addTagChip = useMemo(
     () => (
-       <Tag
+      <Tag
         className="tag-chip tag-chip-add-button"
         icon={<PlusIcon height={16} name="plus" width={16} />}>
-       <Typography
+        <Typography
           ellipsis
           className="m-0"
           data-testid="add-tag"
@@ -303,9 +303,7 @@ const TagsV1 = ({
         arrow
         placement="top"
         title={tooltipOverride ?? getTagTooltip(tag.tagFQN, tag.description)}>
-        <TooltipTrigger>
-           {automatedTagChip}
-        </TooltipTrigger>
+        <TooltipTrigger>{automatedTagChip}</TooltipTrigger>
       </Tooltip>
     );
   }
@@ -317,9 +315,7 @@ const TagsV1 = ({
       arrow
       placement="top"
       title={tooltipOverride ?? getTagTooltip(tag.tagFQN, tag.description)}>
-        <TooltipTrigger>
-          {tagChip}
-        </TooltipTrigger>
+      <TooltipTrigger>{tagChip}</TooltipTrigger>
     </Tooltip>
   );
 };

--- a/openmetadata-ui/src/main/resources/ui/src/components/Tag/TagsV1/TagsV1.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Tag/TagsV1/TagsV1.component.tsx
@@ -10,8 +10,13 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-import { Tooltip, useTheme } from '@mui/material';
-import { Tag, Typography } from 'antd';
+import {
+  Badge,
+  Tooltip,
+  TooltipTrigger,
+  Typography
+} from '@openmetadata/ui-core-components';
+import { Tag } from 'antd';
 import classNames from 'classnames';
 import { useMemo } from 'react';
 import { Link } from 'react-router-dom';
@@ -34,7 +39,6 @@ import {
 import tagClassBase from '../../../utils/TagClassBase';
 import { getTagDisplay } from '../../../utils/TagsPureUtils';
 import { getTagTooltip } from '../../../utils/TagsUtils';
-import TagChip from '../../common/atoms/TagChip/TagChip';
 import { HighlightedTagLabel } from '../../Explore/EntitySummaryPanel/SummaryList/SummaryList.interface';
 import { TagsV1Props } from './TagsV1.interface';
 import './tagsV1.less';
@@ -54,10 +58,9 @@ const TagsV1 = ({
   newLook,
   entityFqn,
 }: TagsV1Props) => {
-  const theme = useTheme();
   const color = useMemo(
     () => (isVersionPage ? undefined : tag.style?.color),
-    [tag]
+    [isVersionPage, tag]
   );
 
   const isGlossaryTag = useMemo(
@@ -69,7 +72,7 @@ const TagsV1 = ({
     if (newLook && !isGlossaryTag) {
       return (
         <IconTagNew
-          className="flex-shrink m-r-xss"
+          className="tw:shrink-0 m-r-xss"
           data-testid="tags-icon"
           height={12}
           name="tag-icon"
@@ -80,25 +83,25 @@ const TagsV1 = ({
     if (isGlossaryTag) {
       return (
         <IconTerm
-          className="flex-shrink m-r-xss"
+          className="tw:shrink-0 m-r-xss"
           data-testid="glossary-icon"
           height={12}
           name="glossary-icon"
           width={12}
         />
       );
-    } else {
-      return (
-        <IconTag
-          className="flex-shrink m-r-xss"
-          data-testid="tags-icon"
-          height={12}
-          name="tag-icon"
-          width={12}
-        />
-      );
     }
-  }, [isGlossaryTag]);
+
+    return (
+      <IconTag
+        className="tw:shrink-0 m-r-xss"
+        data-testid="tags-icon"
+        height={12}
+        name="tag-icon"
+        width={12}
+      />
+    );
+  }, [isGlossaryTag, newLook]);
 
   const tagName = useMemo(
     () =>
@@ -166,17 +169,17 @@ const TagsV1 = ({
             tagChipStyleClass
           )}>
           {renderTagIcon}
-          <Typography.Text
-            className="m-0 tags-label text-truncate truncate w-max-full"
+          <Typography
+            ellipsis
+            className="tags-label"
             data-testid={`tag-${tag.tagFQN}`}
-            ellipsis={{ tooltip: false }}
             style={{ color: tag.style?.color }}>
             {tagName}
-          </Typography.Text>
+          </Typography>
         </div>
       </div>
     ),
-    [renderTagIcon, tagName, tag, tagColorBar]
+    [renderTagIcon, tagName, tag, tagColorBar, tagChipStyleClass]
   );
 
   const automatedTagChip = useMemo(
@@ -185,31 +188,26 @@ const TagsV1 = ({
         className="no-underline"
         data-testid="tag-redirect-link"
         to={redirectLink}>
-        <TagChip
-          icon={
+        <Badge
+          className="tw:cursor-pointer tw:text-utility-brand-700 tw:ring-utility-brand-100 tw:bg-utility-brand-50 hover:tw:bg-utility-brand-50"
+          color="brand"
+          size="sm"
+          type="color">
+          <span className="tw:flex tw:items-center tw:gap-1">
             <AutomatedTag
-              color={theme.palette.allShades.brand[900]}
+              className="tw:text-utility-brand-900 tw:shrink-0"
               width={16}
             />
-          }
-          label={tagName || ''}
-          labelDataTestId={`tag-${tag.tagFQN}`}
-          sx={{
-            pl: 1.5,
-            color: theme.palette.allShades.brand[900],
-            borderColor: theme.palette.allShades.brand[100],
-            backgroundColor: theme.palette.allShades.brand[50],
-            '&::before': {
-              display: 'none',
-            },
-            '&:hover': {
-              backgroundColor: theme.palette.allShades.brand[50],
-            },
-          }}
-        />
+            <span
+              className="tw:text-utility-brand-900"
+              data-testid={`tag-${tag.tagFQN}`}>
+              {tagName}
+            </span>
+          </span>
+        </Badge>
       </Link>
     ),
-    [tagName, tag, redirectLink, theme]
+    [tagName, tag.tagFQN, redirectLink]
   );
 
   const tagChip = useMemo(
@@ -244,20 +242,31 @@ const TagsV1 = ({
         </Link>
       </Tag>
     ),
-    [color, tagContent, redirectLink]
+    [
+      className,
+      color,
+      size,
+      tag,
+      tagChipStyleClass,
+      tagContent,
+      tagProps,
+      redirectLink,
+    ]
   );
 
   const addTagChip = useMemo(
     () => (
-      <Tag
+       <Tag
         className="tag-chip tag-chip-add-button"
         icon={<PlusIcon height={16} name="plus" width={16} />}>
-        <Typography.Text
-          className="m-0 text-xs font-medium text-primary text-truncate truncate w-max-full"
+       <Typography
+          ellipsis
+          className="m-0"
           data-testid="add-tag"
-          ellipsis={{ tooltip: false }}>
+          size="text-xs"
+          weight="medium">
           {getTagDisplay(tagName)}
-        </Typography.Text>
+        </Typography>
       </Tag>
     ),
     [tagName]
@@ -292,34 +301,26 @@ const TagsV1 = ({
     return (
       <Tooltip
         arrow
-        enterDelay={500}
         placement="top"
-        slotProps={{
-          tooltip: { className: 'tags-tooltip' },
-        }}
         title={tooltipOverride ?? getTagTooltip(tag.tagFQN, tag.description)}>
-        {automatedTagChip}
+        <TooltipTrigger>
+           {automatedTagChip}
+        </TooltipTrigger>
       </Tooltip>
     );
   }
 
-  return (
-    <>
-      {isEditTags ? (
-        tagChip
-      ) : (
-        <Tooltip
-          arrow
-          enterDelay={500}
-          placement="top"
-          slotProps={{
-            tooltip: { className: 'tags-tooltip' },
-          }}
-          title={tooltipOverride ?? getTagTooltip(tag.tagFQN, tag.description)}>
+  return isEditTags ? (
+    tagChip
+  ) : (
+    <Tooltip
+      arrow
+      placement="top"
+      title={tooltipOverride ?? getTagTooltip(tag.tagFQN, tag.description)}>
+        <TooltipTrigger>
           {tagChip}
-        </Tooltip>
-      )}
-    </>
+        </TooltipTrigger>
+    </Tooltip>
   );
 };
 

--- a/openmetadata-ui/src/main/resources/ui/src/components/Tag/TagsV1/TagsV1.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Tag/TagsV1/TagsV1.component.tsx
@@ -10,11 +10,7 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-import {
-  Badge,
-  Tooltip,
-  Typography,
-} from '@openmetadata/ui-core-components';
+import { Badge, Tooltip, Typography } from '@openmetadata/ui-core-components';
 import { Tag } from 'antd';
 import classNames from 'classnames';
 import { useMemo } from 'react';

--- a/openmetadata-ui/src/main/resources/ui/src/components/Tag/TagsV1/TagsV1.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Tag/TagsV1/TagsV1.component.tsx
@@ -13,12 +13,12 @@
 import {
   Badge,
   Tooltip,
-  TooltipTrigger,
   Typography,
 } from '@openmetadata/ui-core-components';
 import { Tag } from 'antd';
 import classNames from 'classnames';
 import { useMemo } from 'react';
+import { Focusable } from 'react-aria-components';
 import { Link } from 'react-router-dom';
 import { ReactComponent as AutomatedTag } from '../../../assets/svg/automated-tag.svg';
 import { ReactComponent as IconTerm } from '../../../assets/svg/book.svg';
@@ -234,12 +234,14 @@ const TagsV1 = ({
         }
         {...tagProps}>
         {/* Wrap only content to avoid redirect on closeable icons  */}
-        <Link
-          className="no-underline h-full w-max-stretch"
-          data-testid="tag-redirect-link"
-          to={redirectLink}>
-          {tagContent}
-        </Link>
+        <Focusable>
+          <Link
+            className="no-underline h-full w-max-stretch"
+            data-testid="tag-redirect-link"
+            to={redirectLink}>
+            {tagContent}
+          </Link>
+        </Focusable>
       </Tag>
     ),
     [
@@ -303,7 +305,7 @@ const TagsV1 = ({
         arrow
         placement="top"
         title={tooltipOverride ?? getTagTooltip(tag.tagFQN, tag.description)}>
-        <TooltipTrigger>{automatedTagChip}</TooltipTrigger>
+        <Focusable>{automatedTagChip}</Focusable>
       </Tooltip>
     );
   }
@@ -315,7 +317,7 @@ const TagsV1 = ({
       arrow
       placement="top"
       title={tooltipOverride ?? getTagTooltip(tag.tagFQN, tag.description)}>
-      <TooltipTrigger>{tagChip}</TooltipTrigger>
+      {tagChip}
     </Tooltip>
   );
 };

--- a/openmetadata-ui/src/main/resources/ui/src/components/Tag/TagsViewer/TagsViewer.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Tag/TagsViewer/TagsViewer.tsx
@@ -11,7 +11,7 @@
  *  limitations under the License.
  */
 
-import { Tooltip as MuiTooltip } from '@mui/material';
+import { Tooltip, TooltipTrigger } from '@openmetadata/ui-core-components';
 import { Button, Popover, Tag, Typography } from 'antd';
 import classNames from 'classnames';
 import { isEmpty, sortBy, uniqBy } from 'lodash';
@@ -55,37 +55,30 @@ const TagsViewer: FunctionComponent<TagsViewerProps> = ({
         const redirectLink = getTagRedirectLink(tag);
 
         return (
-          <MuiTooltip
-            enterDelay={500}
+          <Tooltip
+            delay={500}
             key={tag.tagFQN}
-            placement="bottom-start"
-            slotProps={{
-              tooltip: {
-                sx: {
-                  bgcolor: 'common.black',
-                  color: 'common.white',
-                },
-              },
-            }}
             title={getTagTooltip(tag.tagFQN, tag.description) ?? ''}>
-            <Link
-              className={classNames(
-                'w-full',
-                { 'diff-added tw-mx-1': tag?.added },
-                { 'diff-removed': tag?.removed }
-              )}
-              data-testid="tag-redirect-link"
-              to={redirectLink}>
-              <TagChip
-                data-testid="tags"
-                label={tagName}
-                labelDataTestId={`tag-${tag.tagFQN}`}
-                size="large"
-                tagColor={tag.style?.color}
-                variant="blueGray"
-              />
-            </Link>
-          </MuiTooltip>
+           <TooltipTrigger>
+              <Link
+                className={classNames(
+                  'w-full',
+                  { 'diff-added tw-mx-1': tag?.added },
+                  { 'diff-removed': tag?.removed }
+                )}
+                data-testid="tag-redirect-link"
+                to={redirectLink}>
+                <TagChip
+                  data-testid="tags"
+                  label={tagName}
+                  labelDataTestId={`tag-${tag.tagFQN}`}
+                  size="large"
+                  tagColor={tag.style?.color}
+                  variant="blueGray"
+                />
+              </Link>
+            </TooltipTrigger>
+          </Tooltip>
         );
       }
 

--- a/openmetadata-ui/src/main/resources/ui/src/components/Tag/TagsViewer/TagsViewer.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Tag/TagsViewer/TagsViewer.tsx
@@ -59,7 +59,7 @@ const TagsViewer: FunctionComponent<TagsViewerProps> = ({
             delay={500}
             key={tag.tagFQN}
             title={getTagTooltip(tag.tagFQN, tag.description) ?? ''}>
-           <TooltipTrigger>
+            <TooltipTrigger>
               <Link
                 className={classNames(
                   'w-full',

--- a/openmetadata-ui/src/main/resources/ui/src/components/Tag/TagsViewer/TagsViewer.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Tag/TagsViewer/TagsViewer.tsx
@@ -11,12 +11,13 @@
  *  limitations under the License.
  */
 
-import { Tooltip, TooltipTrigger } from '@openmetadata/ui-core-components';
+import { Tooltip } from '@openmetadata/ui-core-components';
 import { Button, Popover, Tag, Typography } from 'antd';
 import classNames from 'classnames';
 import { isEmpty, sortBy, uniqBy } from 'lodash';
 import { EntityTags } from 'Models';
 import { FunctionComponent, useCallback, useMemo, useState } from 'react';
+import { Focusable } from 'react-aria-components';
 import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router-dom';
 import { LIST_SIZE, NO_DATA_PLACEHOLDER } from '../../../constants/constants';
@@ -56,13 +57,15 @@ const TagsViewer: FunctionComponent<TagsViewerProps> = ({
 
         return (
           <Tooltip
+            arrow
             delay={500}
             key={tag.tagFQN}
+            placement="top"
             title={getTagTooltip(tag.tagFQN, tag.description) ?? ''}>
-            <TooltipTrigger>
+            <Focusable>
               <Link
                 className={classNames(
-                  'w-full',
+                  'tw:w-max',
                   { 'diff-added tw-mx-1': tag?.added },
                   { 'diff-removed': tag?.removed }
                 )}
@@ -77,7 +80,7 @@ const TagsViewer: FunctionComponent<TagsViewerProps> = ({
                   variant="blueGray"
                 />
               </Link>
-            </TooltipTrigger>
+            </Focusable>
           </Tooltip>
         );
       }


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:

Uploading Screen Recording 2026-07-06 at 6.44.03 PM.mov…





Fixes [4867](https://github.com/open-metadata/openmetadata-collate/issues/4867)
<!--
Linking an issue is REQUIRED. Replace <issue-number> with the GitHub issue number this PR addresses
(e.g., `Fixes #12345`). GitHub will auto-link it. If no issue exists, please open one first so the
problem and design can be discussed before review.
-->

<!--
Short blurb explaining:
- What changes did you make?
- Why did you make them?
-->

I worked on ... because ...

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### High-level design:
<!--
REQUIRED for large PRs (new features, refactors, breaking changes, or anything touching >5 files).
Skip for small bug fixes and trivial changes.

Cover:
- Architecture / approach you took and why
- Key components or files added/changed and how they interact
- Alternatives considered and why you rejected them
- Any migration, backward-compatibility, or rollout concerns
- Diagrams or links to design docs / RFCs if available
-->

N/A — small change. <!-- Or fill in the design above -->

#
### Tests:

#### Use cases covered
<!--
List the user-visible scenarios this PR exercises. Example:
- User with Admin role can create a Glossary Term with a parent term
- Ingestion run for Snowflake correctly extracts row counts for partitioned tables
-->

#### Unit tests
<!--
- [ ] I added unit tests for the new/changed logic.
- Files added/updated:
- Coverage on changed classes (run `mvn jacoco:report` for backend, `yarn test:coverage` for UI,
  `make unit_ingestion` for ingestion). Target is 90% line coverage on changed classes.
- Coverage %: <e.g., 92% on EntityRepository.java>
-->

#### Backend integration tests
<!--
- [ ] I added integration tests in `openmetadata-integration-tests/` for new/changed API endpoints.
- [ ] Not applicable (no backend API changes).
- Files added/updated:
-->

#### Ingestion integration tests
<!--
- [ ] I added/updated ingestion integration tests for connector changes.
- [ ] Not applicable (no ingestion changes).
- Files added/updated:
-->

#### Playwright (UI) tests
<!--
- [ ] I added Playwright E2E tests under `openmetadata-ui/.../ui/playwright/` for UI changes.
- [ ] Not applicable (no UI changes).
- Files added/updated:
-->

#### Manual testing performed
<!--
List the manual test steps you performed before requesting review. Example:
1. Started local stack via `./docker/run_local_docker.sh -m ui -d mysql`
2. Logged in as admin, created entity X, verified Y appears in the UI
3. Triggered ingestion for Snowflake source, confirmed lineage edges in the explore page
-->

#
### UI screen recording / screenshots:
<!--
REQUIRED for any PR that changes the UI. Drag-and-drop a short screen recording (.mov / .mp4 / .gif)
demonstrating the change end-to-end, plus before/after screenshots where relevant.
Mark "Not applicable" if there are no UI changes.
-->

Not applicable. <!-- Or attach recording/screenshots above -->

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.
- [ ] For UI changes: I attached a screen recording and/or screenshots above.
- [ ] I have added tests (unit / integration / Playwright as applicable) and listed them above.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->

----
## Summary by Gitar

- **Component Migration:**
  - Migrated `TagsV1` and `TagsViewer` to use custom components from `@openmetadata/ui-core-components`.
  - Replaced native `MuiTooltip` with `Tooltip` and `TooltipTrigger` for enhanced design consistency.
- **UI Refinements:**
  - Updated `TagsV1` to use `Badge` for automated tags and refined styling using `tw:` utility classes.
  - Standardized `Typography` components and icons in `TagsV1` for better alignment and responsiveness.

<sub>This will update automatically on new commits.</sub>

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR migrates `TagsV1` and `TagsViewer` components from MUI (`@mui/material`) and Antd primitives to the internal `@openmetadata/ui-core-components` library, replacing `MuiTooltip` with the custom `Tooltip`, `Typography.Text` with `Typography`, and `TagChip` (MUI-based) with `Badge` for automated tags.

- **`TagsV1`**: Removes `useTheme`, replaces `TagChip` with `Badge` for automated tag rendering, wraps the `Link` inside `tagChip` with `<Focusable>`, and updates icon classes from `flex-shrink` to `tw:shrink-0`. The `useMemo` dependency arrays are also corrected to include previously missing deps (`isVersionPage`, `newLook`, `tagChipStyleClass`).
- **`TagsViewer`**: Replaces `MuiTooltip` with the new `Tooltip` in the `muiTags` rendering branch, changes the tooltip placement from `bottom-start` to `top`, and switches the link width class from `w-full` to `tw:w-max`.
</details>


<details open><summary><h3>Confidence Score: 3/5</h3></summary>

Two tooltip trigger wiring issues could silently break tooltip display for ordinary and automated tags before merging.

The new `Tooltip` from `@openmetadata/ui-core-components` requires a `TooltipTrigger` child (confirmed by `EntityTitleSection.tsx` usage). Both changed files use `<Focusable>` instead, and the regular `tagChip` code path in `TagsV1` passes the Antd `<Tag>` directly — with no trigger wrapper at all. This means tag tooltips may not activate on hover or keyboard focus in these two paths after the migration.

`TagsV1.component.tsx` (regular tag tooltip path at line 312–317) and `TagsViewer.tsx` (muiTags tooltip path at lines 59–85) both need their tooltip trigger children corrected from `<Focusable>` / direct child to `<TooltipTrigger>`.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| openmetadata-ui/src/main/resources/ui/src/components/Tag/TagsV1/TagsV1.component.tsx | Migrates Tooltip and Typography from MUI/Antd to `@openmetadata/ui-core-components`; `tagChip` is passed to `<Tooltip>` without a `<TooltipTrigger>` or `<Focusable>` wrapper, inconsistent with `automatedTagChip` and the library's documented pattern. |
| openmetadata-ui/src/main/resources/ui/src/components/Tag/TagsViewer/TagsViewer.tsx | Replaces `MuiTooltip` with `Tooltip` from `@openmetadata/ui-core-components` in the `muiTags` render path; uses `<Focusable>` as the tooltip trigger child where `<TooltipTrigger>` is the expected pattern per other usages in the codebase. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[TagsViewer] -->|muiTags=true| B[Tooltip from ui-core-components]
    A -->|muiTags=false| C[TagsV1]

    B --> D["<Focusable> ⚠️ should be <TooltipTrigger>"]
    D --> E[Link → TagChip]

    C --> F{labelType === Generated?}
    F -->|yes + isEditTags| G[automatedTagChip - Link → Badge]
    F -->|yes + tooltip| H["Tooltip → <Focusable> → automatedTagChip"]
    F -->|no + isEditTags| I[tagChip - Tag → Focusable → Link]
    F -->|no + tooltip| J["Tooltip → tagChip ⚠️ missing trigger wrapper"]

    style D fill:#ffe0b2,stroke:#e65100
    style J fill:#ffe0b2,stroke:#e65100
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[TagsViewer] -->|muiTags=true| B[Tooltip from ui-core-components]
    A -->|muiTags=false| C[TagsV1]

    B --> D["<Focusable> ⚠️ should be <TooltipTrigger>"]
    D --> E[Link → TagChip]

    C --> F{labelType === Generated?}
    F -->|yes + isEditTags| G[automatedTagChip - Link → Badge]
    F -->|yes + tooltip| H["Tooltip → <Focusable> → automatedTagChip"]
    F -->|no + isEditTags| I[tagChip - Tag → Focusable → Link]
    F -->|no + tooltip| J["Tooltip → tagChip ⚠️ missing trigger wrapper"]

    style D fill:#ffe0b2,stroke:#e65100
    style J fill:#ffe0b2,stroke:#e65100
```

</a>
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `openmetadata-ui/src/main/resources/ui/src/components/Tag/TagsV1/TagsV1.component.tsx`, line 107-114 ([link](https://github.com/open-metadata/openmetadata/blob/69b8efbee087938212882d6762afceed74d18946/openmetadata-ui/src/main/resources/ui/src/components/Tag/TagsV1/TagsV1.component.tsx#L107-L114)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Dead CSS rule — tooltip paragraph colour lost**

   `tagsV1.less` line 107 has a rule targeting `.tags-tooltip.MuiTooltip-tooltip … p { color: @grey-700; }`. That rule fired because the old MUI `<Tooltip>` received `slotProps={{ tooltip: { className: 'tags-tooltip' } }}`, which caused MUI to attach both `.tags-tooltip` and `.MuiTooltip-tooltip` to the tooltip element. Both classes are now gone, so the compound selector never matches — any `p` element inside a tag tooltip that contains markdown/rich text will revert to the default colour instead of `grey-700`.

2. `openmetadata-ui/src/main/resources/ui/src/components/Tag/TagsV1/TagsV1.component.tsx`, line 257-273 ([link](https://github.com/open-metadata/openmetadata/blob/69b8efbee087938212882d6762afceed74d18946/openmetadata-ui/src/main/resources/ui/src/components/Tag/TagsV1/TagsV1.component.tsx#L257-L273)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> Inconsistent indentation in `addTagChip` — `<Tag>` and the opening `<Typography>` have an extra leading space compared to the surrounding code, which breaks the expected 2-space indent.

   

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (4): Last reviewed commit: ["lint fix"](https://github.com/open-metadata/openmetadata/commit/3c60a7e790a641936d00ad46ff59792098df8c95) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42068682)</sub>

<!-- /greptile_comment -->