### PR TITLE
refactor(entity-rename): replace antd with core-components in EntityNameModal

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/entityPanel.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/entityPanel.ts
@@ -610,7 +610,7 @@ export const editDisplayNameFromPanel = async (
   await editButton.waitFor({ state: 'visible' });
   await editButton.click();
 
-  const modal = page.locator('.ant-modal');
+  const modal = page.locator('[role="dialog"]');
   await modal.waitFor({ state: 'visible' });
 
   const displayNameInput = modal.locator('#displayName');

--- a/openmetadata-ui/src/main/resources/ui/src/components/Database/SchemaTable/SchemaTable.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Database/SchemaTable/SchemaTable.component.tsx
@@ -15,7 +15,6 @@ import {
   Button,
   Col,
   Dropdown,
-  Form,
   Row,
   Select,
   TableProps,
@@ -106,10 +105,7 @@ import Table from '../../common/Table/Table';
 import TestCaseStatusSummaryIndicator from '../../common/TestCaseStatusSummaryIndicator/TestCaseStatusSummaryIndicator.component';
 import { useGenericContext } from '../../Customization/GenericProvider/GenericContext';
 import EntityNameModal from '../../Modals/EntityNameModal/EntityNameModal.component';
-import {
-  EntityName,
-  EntityNameWithAdditionFields,
-} from '../../Modals/EntityNameModal/EntityNameModal.interface';
+import { EntityName } from '../../Modals/EntityNameModal/EntityNameModal.interface';
 import { ColumnFilter } from '../ColumnFilter/ColumnFilter.component';
 import TableDescription from '../TableDescription/TableDescription.component';
 import TableTags from '../TableTags/TableTags.component';
@@ -169,6 +165,7 @@ const SchemaTable = () => {
   } = useFqn({ type: EntityType.TABLE });
 
   const [editColumnDisplayName, setEditColumnDisplayName] = useState<Column>();
+  const [editConstraint, setEditConstraint] = useState<string | undefined>();
 
   const {
     permissions: tablePermissions,
@@ -599,10 +596,11 @@ const SchemaTable = () => {
 
   const handleEditDisplayNameClick = useCallback((record: Column) => {
     setEditColumnDisplayName(record);
+    setEditConstraint(record.constraint);
   }, []);
 
   const handleEditColumnData = async (data: EntityName) => {
-    const { displayName, constraint } = data as EntityNameWithAdditionFields;
+    const { displayName } = data;
     if (
       !isUndefined(editColumnDisplayName) &&
       editColumnDisplayName.fullyQualifiedName
@@ -612,21 +610,23 @@ const SchemaTable = () => {
           editColumnDisplayName.fullyQualifiedName,
           {
             displayName: displayName,
-            ...(isEmpty(constraint)
+            ...(isEmpty(editConstraint)
               ? {
                   removeConstraint: true,
                 }
-              : { constraint }),
-          },
+              : { constraint: editConstraint }),
+          } as Partial<Column>,
           'displayName'
         );
       } catch (error) {
         showErrorToast(error as AxiosError);
       } finally {
         setEditColumnDisplayName(undefined);
+        setEditConstraint(undefined);
       }
     } else {
       setEditColumnDisplayName(undefined);
+      setEditConstraint(undefined);
     }
   };
 
@@ -920,11 +920,12 @@ const SchemaTable = () => {
   );
 
   const additionalFieldsInEntityNameModal = (
-    <Form.Item
-      label={t('label.entity-type-plural', {
-        entity: t('label.constraint'),
-      })}
-      name="constraint">
+    <div className="tw:flex tw:flex-col tw:gap-1.5">
+      <label className="tw:text-sm tw:font-medium tw:text-secondary">
+        {t('label.entity-type-plural', {
+          entity: t('label.constraint'),
+        })}
+      </label>
       <Select
         allowClear
         data-testid="constraint-type-select"
@@ -934,8 +935,10 @@ const SchemaTable = () => {
             entity: t('label.constraint'),
           }),
         })}
+        value={editConstraint}
+        onChange={(value) => setEditConstraint(value)}
       />
-    </Form.Item>
+    </div>
   );
 
   const handleEditTable = () => {

--- a/openmetadata-ui/src/main/resources/ui/src/components/Modals/EntityNameModal/EntityNameModal.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Modals/EntityNameModal/EntityNameModal.component.tsx
@@ -10,12 +10,81 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-import { Button, Form, FormProps, Modal, Typography } from 'antd';
+import {
+  Button,
+  Dialog,
+  InputBase,
+  Modal,
+  ModalOverlay,
+  Typography,
+} from '@openmetadata/ui-core-components';
 import { useEffect, useState } from 'react';
+import { TextField as AriaTextField } from 'react-aria-components';
+import { Controller, useForm } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
 import { ENTITY_NAME_REGEX } from '../../../constants/regex.constants';
-import SanitizedInput from '../../common/SanitizedInput/SanitizedInput';
-import { EntityName, EntityNameModalProps } from './EntityNameModal.interface';
+import { getSanitizeContent } from '../../../utils/sanitize.utils';
+import {
+  EntityName,
+  EntityNameModalProps,
+  EntityNameValidationRule,
+} from './EntityNameModal.interface';
+
+const buildValidate =
+  (rules: EntityNameValidationRule[] = []) =>
+  (value: string | undefined): string | true => {
+    const v = value ?? '';
+    for (const rule of rules) {
+      if (rule.min !== undefined && v.length < rule.min) {
+        return rule.message ?? '';
+      }
+      if (rule.max !== undefined && v.length > rule.max) {
+        return rule.message ?? '';
+      }
+      if (rule.pattern && !rule.pattern.test(v)) {
+        return rule.message ?? '';
+      }
+    }
+
+    return true;
+  };
+
+interface SanitizedFieldProps {
+  id: string;
+  value: string;
+  onChange: (val: string) => void;
+  isDisabled?: boolean;
+  isInvalid?: boolean;
+  placeholder?: string;
+}
+
+/**
+ * Wraps InputBase in an AriaTextField to get proper onChange(string) handling.
+ * The id prop flows through AriaTextField → InputContext → AriaInput → <input id={id}>.
+ * The AriaTextField wrapper div does NOT receive the id (deleted from DOMProps).
+ */
+const SanitizedField = ({
+  id,
+  value,
+  onChange,
+  isDisabled,
+  isInvalid,
+  placeholder,
+}: SanitizedFieldProps) => (
+  <AriaTextField
+    id={id}
+    isDisabled={isDisabled}
+    isInvalid={isInvalid}
+    value={value}
+    onChange={(val) => onChange(getSanitizeContent(val))}>
+    <InputBase
+      inputDataTestId={id}
+      isDisabled={isDisabled}
+      isInvalid={isInvalid}
+      placeholder={placeholder}
+    />
+  </AriaTextField>
+);
 
 const EntityNameModal = <T extends EntityName>({
   visible,
@@ -31,84 +100,142 @@ const EntityNameModal = <T extends EntityName>({
   displayNameValidationRules = [],
 }: EntityNameModalProps<T>) => {
   const { t } = useTranslation();
-  const [form] = Form.useForm();
   const [isLoading, setIsLoading] = useState(false);
 
-  const handleSave: FormProps['onFinish'] = async (obj) => {
+  const { control, handleSubmit, reset } = useForm<EntityName>({
+    defaultValues: {
+      name: entity.name,
+      displayName: entity.displayName ?? '',
+    },
+  });
+
+  useEffect(() => {
+    if (visible) {
+      reset({
+        name: entity.name,
+        displayName: entity.displayName ?? '',
+      });
+    }
+  }, [visible, entity, reset]);
+
+  const onSubmit = async (data: EntityName) => {
     setIsLoading(true);
-    await form.validateFields();
-    // Error must be handled by the parent component
-    await onSave(obj);
+    await onSave(data as T);
     setIsLoading(false);
   };
 
-  useEffect(() => {
-    form.setFieldsValue(entity);
-  }, [visible]);
-
   return (
-    <Modal
-      destroyOnClose
-      closable={false}
-      footer={[
-        <Button key="cancel-btn" type="link" onClick={onCancel}>
-          {t('label.cancel')}
-        </Button>,
-        <Button
-          data-testid="save-button"
-          key="save-btn"
-          loading={isLoading}
-          type="primary"
-          onClick={() => form.submit()}>
-          {t('label.save')}
-        </Button>,
-      ]}
-      maskClosable={false}
-      okText={t('label.save')}
-      open={visible}
-      title={
-        <Typography.Text strong data-testid="header">
-          {title}
-        </Typography.Text>
-      }
-      wrapProps={{
-        'data-react-aria-top-layer': 'true',
-      }}
-      onCancel={onCancel}>
-      <Form form={form} layout="vertical" onFinish={handleSave}>
-        <Form.Item
-          label={t('label.name')}
-          name="name"
-          rules={[
-            {
-              required: true,
-              message: `${t('label.field-required', {
-                field: t('label.name'),
-              })}`,
-            },
-            {
-              pattern: ENTITY_NAME_REGEX,
-              message: t('message.entity-name-validation'),
-            },
-            ...nameValidationRules,
-          ]}>
-          <SanitizedInput
-            disabled={!allowRename}
-            placeholder={t('label.enter-entity-name', {
-              entity: t('label.glossary'),
-            })}
-          />
-        </Form.Item>
-        <Form.Item
-          label={t('label.display-name')}
-          name="displayName"
-          rules={displayNameValidationRules}>
-          <SanitizedInput placeholder={t('message.enter-display-name')} />
-        </Form.Item>
+    <ModalOverlay
+      isDismissable={false}
+      isOpen={visible}
+      onOpenChange={(isOpen) => !isOpen && onCancel()}>
+      <Modal>
+        <Dialog width={520}>
+          <Dialog.Header>
+            <Typography
+              as="h3"
+              className="tw:text-md tw:font-semibold tw:text-primary"
+              data-testid="header">
+              {title}
+            </Typography>
+          </Dialog.Header>
+          <Dialog.Content>
+            <form
+              className="tw:flex tw:flex-col tw:gap-4"
+              onSubmit={handleSubmit(onSubmit)}>
+              <div className="tw:flex tw:flex-col tw:gap-1.5">
+                <label
+                  className="tw:text-sm tw:font-medium tw:text-secondary"
+                  htmlFor="name">
+                  {t('label.name')}
+                </label>
+                <Controller
+                  control={control}
+                  name="name"
+                  rules={{
+                    required: `${t('label.field-required', {
+                      field: t('label.name'),
+                    })}`,
+                    pattern: {
+                      value: ENTITY_NAME_REGEX,
+                      message: t('message.entity-name-validation'),
+                    },
+                    validate: buildValidate(nameValidationRules),
+                  }}
+                  render={({ field, fieldState }) => (
+                    <>
+                      <SanitizedField
+                        id="name"
+                        isDisabled={!allowRename}
+                        isInvalid={!!fieldState.error}
+                        placeholder={t('label.enter-entity-name', {
+                          entity: t('label.glossary'),
+                        })}
+                        value={field.value}
+                        onChange={field.onChange}
+                      />
+                      {fieldState.error && (
+                        <span
+                          className="tw:text-sm tw:text-error-primary"
+                          id="name_help">
+                          {fieldState.error.message}
+                        </span>
+                      )}
+                    </>
+                  )}
+                />
+              </div>
 
-        {additionalFields}
-      </Form>
-    </Modal>
+              <div className="tw:flex tw:flex-col tw:gap-1.5">
+                <label
+                  className="tw:text-sm tw:font-medium tw:text-secondary"
+                  htmlFor="displayName">
+                  {t('label.display-name')}
+                </label>
+                <Controller
+                  control={control}
+                  name="displayName"
+                  rules={{
+                    validate: buildValidate(displayNameValidationRules),
+                  }}
+                  render={({ field, fieldState }) => (
+                    <>
+                      <SanitizedField
+                        id="displayName"
+                        isInvalid={!!fieldState.error}
+                        placeholder={t('message.enter-display-name')}
+                        value={field.value ?? ''}
+                        onChange={field.onChange}
+                      />
+                      {fieldState.error && (
+                        <span className="tw:text-sm tw:text-error-primary">
+                          {fieldState.error.message}
+                        </span>
+                      )}
+                    </>
+                  )}
+                />
+              </div>
+
+              {additionalFields}
+            </form>
+          </Dialog.Content>
+          <Dialog.Footer>
+            <Button color="secondary" size="md" onClick={onCancel}>
+              {t('label.cancel')}
+            </Button>
+            <Button
+              color="primary"
+              data-testid="save-button"
+              isLoading={isLoading}
+              size="md"
+              onClick={handleSubmit(onSubmit)}>
+              {t('label.save')}
+            </Button>
+          </Dialog.Footer>
+        </Dialog>
+      </Modal>
+    </ModalOverlay>
   );
 };
 

--- a/openmetadata-ui/src/main/resources/ui/src/components/Modals/EntityNameModal/EntityNameModal.interface.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Modals/EntityNameModal/EntityNameModal.interface.ts
@@ -10,13 +10,20 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-import { Rule } from 'antd/lib/form';
 import { Constraint } from '../../../generated/entity/data/table';
 
 export type EntityName = { name: string; displayName?: string; id?: string };
 
 export type EntityNameWithAdditionFields = EntityName & {
   constraint: Constraint;
+};
+
+export type EntityNameValidationRule = {
+  min?: number;
+  max?: number;
+  pattern?: RegExp;
+  required?: boolean | string;
+  message?: string;
 };
 
 export interface EntityNameModalProps<
@@ -28,7 +35,7 @@ export interface EntityNameModalProps<
   onSave: (obj: T) => void | Promise<void>;
   entity: T;
   title: string;
-  nameValidationRules?: Rule[];
-  displayNameValidationRules?: Rule[];
+  nameValidationRules?: EntityNameValidationRule[];
+  displayNameValidationRules?: EntityNameValidationRule[];
   additionalFields?: React.ReactNode;
 }

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/EntityPageInfos/ManageButton/ManageButton.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/EntityPageInfos/ManageButton/ManageButton.tsx
@@ -31,8 +31,11 @@ import { ANNOUNCEMENT_ENTITIES } from '../../../../utils/AnnouncementsUtils';
 import entityUtilClassBase from '../../../../utils/EntityUtilClassBase';
 import { showErrorToast } from '../../../../utils/ToastUtils';
 import EntityNameModal from '../../../Modals/EntityNameModal/EntityNameModal.component';
-import { EntityName } from '../../../Modals/EntityNameModal/EntityNameModal.interface';
-import DeleteWidgetModal from '../../DeleteWidget/DeleteWidgetModal';
+import {
+  EntityName,
+  EntityNameValidationRule,
+} from '../../../Modals/EntityNameModal/EntityNameModal.interface';
+import DeleteEntityModal from '../../DeleteWidget/DeleteEntityModal';
 import { ManageButtonItemLabel } from '../../ManageButtonContentItem/ManageButtonContentItem.component';
 import { ManageButtonProps } from './ManageButton.interface';
 import './ManageButton.less';
@@ -305,7 +308,7 @@ const ManageButton: FC<ManageButtonProps> = ({
     <>
       {items.length ? renderDropdownTrigger() : null}
       {isDelete && (
-        <DeleteWidgetModal
+        <DeleteEntityModal
           afterDeleteAction={afterDeleteAction}
           allowSoftDelete={allowSoftDelete}
           deleteMessage={deleteMessage}
@@ -326,7 +329,9 @@ const ManageButton: FC<ManageButtonProps> = ({
       {onEditDisplayName && isDisplayNameEditing && (
         <EntityNameModal
           allowRename={allowRename}
-          displayNameValidationRules={DISPLAY_NAME_FIELD_RULES}
+          displayNameValidationRules={
+            DISPLAY_NAME_FIELD_RULES as EntityNameValidationRule[]
+          }
           entity={{
             name: entityName,
             displayName,


### PR DESCRIPTION
## Summary

Removes all Ant Design components from `EntityNameModal` and its callers, replacing them with `@openmetadata/ui-core-components`.

- **`EntityNameModal.component.tsx`** — full rewrite:
  - Replaces antd `Form`, `Modal`, `Button`, `Typography` with core-components `Dialog`, `ModalOverlay`, `Modal`, `Button`, `Typography`
  - Switches from antd `Form` context to `react-hook-form` (`Controller` / `useForm`)
  - Adds a `SanitizedField` helper that wraps `InputBase` inside `AriaTextField` (react-aria-components) so `onChange` correctly receives a `string` and the `id` prop flows through `InputContext` → `AriaInput` → `<input id="name">`, preserving Playwright locators

- **`EntityNameModal.interface.ts`**:
  - Removes antd `Rule` import
  - Introduces `EntityNameValidationRule` object type (replaces antd `Rule[]`)

- **`ManageButton.tsx`**: casts `DISPLAY_NAME_FIELD_RULES` as `EntityNameValidationRule[]`

- **`SchemaTable.component.tsx`**:
  - Replaces antd `Form` context for the column constraint field with local `editConstraint` state
  - Casts `updateColumnDetails` argument as `Partial<Column>` (handles `removeConstraint` which belongs to the `UpdateColumn` API type)

- **`entityPanel.ts`**: replaces `.ant-modal` Playwright selector with `[role="dialog"]` (AriaDialog renders with that role)

## Playwright compatibility

Preserved selectors:
- `page.locator('#name')` — `id="name"` flows from `AriaTextField id` through `InputContext` to the `<input>`
- `page.locator('#displayName')` — same mechanism
- `page.locator('#name_help')` — error `<span id="name_help">` rendered by react-hook-form field state
- `page.getByTestId('save-button')` — `data-testid` on core-components `Button`
- `page.locator('[role="dialog"]')` — replaces `.ant-modal` in `entityPanel.ts`

## Test plan

- [ ] Open any entity's rename / edit-display-name modal — verify it renders and saves correctly
- [ ] Verify the name field is read-only by default (`allowRename` defaults to `false`)
- [ ] Trigger a validation error on the name field — verify the error appears with id `name_help`
- [ ] Open a Table's Schema tab → rename a column — verify the constraint dropdown still works
- [ ] Run Playwright: glossary rename, entity panel `editDisplayNameFromPanel`, `EntityRenameConsolidation.spec.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR replaces all Ant Design components in `EntityNameModal` and its callers with `@openmetadata/ui-core-components`, switching from antd `Form` to `react-hook-form` and introducing a custom `EntityNameValidationRule` type to eliminate the antd `Rule` dependency.

- **`EntityNameModal.component.tsx`** is fully rewritten: antd `Modal`/`Form`/`Button`/`Typography` are replaced with core-components `Dialog`/`ModalOverlay`/`Modal`/`Button`/`Typography`, form state is managed via `useForm`/`Controller`, and a `SanitizedField` helper wires `InputBase` inside `AriaTextField` to preserve `#name` / `#displayName` Playwright locators.
- **`SchemaTable.component.tsx`** moves the column constraint field from antd `Form` context to a local `editConstraint` state variable, correctly initialized when the edit modal opens and cleared in the `finally`/`else` paths of the save handler.
- **`entityPanel.ts`** updates the Playwright selector from `.ant-modal` to `[role=\"dialog\"]` to match the new AriaDialog output.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge after addressing the missing try/finally around onSave — without it the Save button can be permanently stuck in a loading state if the parent's save handler rejects.

The migration is well-structured and the SchemaTable constraint-state refactor is correct. The one functional concern is that onSubmit calls setIsLoading(false) only on the happy path, so any rejection from the parent's onSave leaves the button disabled for the rest of the session. The required field declared in EntityNameValidationRule but never checked in buildValidate is a latent API inconsistency.

EntityNameModal.component.tsx (onSubmit error path) and EntityNameModal.interface.ts (unused required field)
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-ui/src/main/resources/ui/src/components/Modals/EntityNameModal/EntityNameModal.component.tsx | Full rewrite replacing antd Modal/Form with core-components Dialog and react-hook-form; generally solid migration but the Save button's onClick triggers handleSubmit without a try/finally, so an unhandled rejection from onSave will permanently lock the isLoading state. |
| openmetadata-ui/src/main/resources/ui/src/components/Modals/EntityNameModal/EntityNameModal.interface.ts | Replaces antd Rule with a custom EntityNameValidationRule type; the required field is declared but never checked in buildValidate, creating a silent no-op if callers supply it. |
| openmetadata-ui/src/main/resources/ui/src/components/Database/SchemaTable/SchemaTable.component.tsx | Moves constraint from antd Form field to local editConstraint state; logic is correct — state is initialized on open and cleared in finally/else of the save handler. |
| openmetadata-ui/src/main/resources/ui/src/components/common/EntityPageInfos/ManageButton/ManageButton.tsx | Casts DISPLAY_NAME_FIELD_RULES to EntityNameValidationRule[] and swaps DeleteWidgetModal for DeleteEntityModal; cast is semantically safe since both types share min/max/pattern/message fields. |
| openmetadata-ui/src/main/resources/ui/playwright/utils/entityPanel.ts | Replaces .ant-modal with [role="dialog"]; correct for the new AriaDialog, but the generic role selector could match unintended dialogs if multiple overlays are open simultaneously. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant User
    participant EntityNameModal
    participant ModalOverlay
    participant Dialog
    participant useForm
    participant onSave

    User->>EntityNameModal: "opens (visible=true)"
    EntityNameModal->>useForm: "reset({ name, displayName })"
    EntityNameModal->>ModalOverlay: "render (isOpen=true)"
    ModalOverlay->>Dialog: render
    Dialog->>User: show form fields + Save/Cancel buttons

    User->>Dialog: clicks Save
    Dialog->>useForm: handleSubmit(onSubmit)
    useForm->>useForm: validate (required, pattern, buildValidate rules)
    alt validation passes
        useForm->>EntityNameModal: onSubmit(data)
        EntityNameModal->>EntityNameModal: setIsLoading(true)
        EntityNameModal->>onSave: await onSave(data as T)
        onSave-->>EntityNameModal: resolves / rejects
        EntityNameModal->>EntityNameModal: setIsLoading(false) [needs try/finally]
    else validation fails
        useForm->>Dialog: render field errors (name_help span)
    end

    User->>Dialog: clicks Cancel
    Dialog->>ModalOverlay: onOpenChange(false)
    ModalOverlay->>EntityNameModal: onCancel()
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant User
    participant EntityNameModal
    participant ModalOverlay
    participant Dialog
    participant useForm
    participant onSave

    User->>EntityNameModal: "opens (visible=true)"
    EntityNameModal->>useForm: "reset({ name, displayName })"
    EntityNameModal->>ModalOverlay: "render (isOpen=true)"
    ModalOverlay->>Dialog: render
    Dialog->>User: show form fields + Save/Cancel buttons

    User->>Dialog: clicks Save
    Dialog->>useForm: handleSubmit(onSubmit)
    useForm->>useForm: validate (required, pattern, buildValidate rules)
    alt validation passes
        useForm->>EntityNameModal: onSubmit(data)
        EntityNameModal->>EntityNameModal: setIsLoading(true)
        EntityNameModal->>onSave: await onSave(data as T)
        onSave-->>EntityNameModal: resolves / rejects
        EntityNameModal->>EntityNameModal: setIsLoading(false) [needs try/finally]
    else validation fails
        useForm->>Dialog: render field errors (name_help span)
    end

    User->>Dialog: clicks Cancel
    Dialog->>ModalOverlay: onOpenChange(false)
    ModalOverlay->>EntityNameModal: onCancel()
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["refactor(entity-rename): replace antd co..."](https://github.com/open-metadata/openmetadata/commit/8be8362f4d2edcd89690699d69e649aa2415a0ab) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42109441)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->