### PR TITLE
fix(pipeline): default patch to 0 when version has no z component

### DIFF
--- a/openmetadata-service/src/test/java/org/openmetadata/service/pipelineService/PipelineServiceClientTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/pipelineService/PipelineServiceClientTest.java
@@ -30,13 +30,19 @@ public class PipelineServiceClientTest {
   }
 
   @Test
+  public void testGetVersionFromStringDefaultsPatchToZero() {
+    assertEquals("1.9.0", mockPipelineServiceClient.getVersionFromString("1.9"));
+    assertEquals("1.9.0", mockPipelineServiceClient.getVersionFromString("1.9.dev0"));
+  }
+
+  @Test
   public void testGetVersionFromStringRaises() {
     Exception exception =
         assertThrows(
             PipelineServiceVersionException.class,
             () -> mockPipelineServiceClient.getVersionFromString("random"));
 
-    String expectedMessage = "Cannot extract version x.y.z from random";
+    String expectedMessage = "Cannot extract version x.y from random";
     String actualMessage = exception.getMessage();
 
     assertEquals(expectedMessage, actualMessage);

--- a/openmetadata-spec/src/main/java/org/openmetadata/service/clients/pipeline/PipelineServiceClient.java
+++ b/openmetadata-spec/src/main/java/org/openmetadata/service/clients/pipeline/PipelineServiceClient.java
@@ -28,6 +28,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.function.Supplier;
+import java.util.regex.MatchResult;
 import java.util.regex.Pattern;
 import lombok.Getter;
 import lombok.Setter;
@@ -112,18 +113,23 @@ public abstract class PipelineServiceClient implements PipelineServiceClientInte
 
   public final String getVersionFromString(String version) {
     if (version != null) {
-      return Pattern.compile("(\\d+.\\d+.\\d+)")
+      return Pattern.compile("(\\d+)\\.(\\d+)(?:\\.(\\d+))?")
           .matcher(version)
           .results()
-          .map(m -> m.group(1))
+          .map(this::formatVersionMatch)
           .findFirst()
           .orElseThrow(
               () ->
                   new PipelineServiceVersionException(
-                      String.format("Cannot extract version x.y.z from %s", version)));
+                      String.format("Cannot extract version x.y from %s", version)));
     } else {
       throw new PipelineServiceVersionException("Received version as null");
     }
+  }
+
+  private String formatVersionMatch(MatchResult match) {
+    String patch = match.group(3) != null ? match.group(3) : "0";
+    return match.group(1) + "." + match.group(2) + "." + patch;
   }
 
   private String getMajorMinorVersion(String fullVersion) {


### PR DESCRIPTION
### Describe your changes:

Fixes #<issue-number>

I worked on `PipelineServiceClient.getVersionFromString` because it required a full `x.y.z` version and threw `Cannot extract version x.y.z from ...` for two-component versions like `1.9`. The regex now makes the patch component optional and defaults it to `0`, so `1.9` resolves to `1.9.0` while three-component versions (e.g. `0.12.0.dev0`) are unaffected.

#
### Type of change:
- [x] Bug fix

#
### High-level design:

N/A — small change.

#
### Tests:

#### Use cases covered
- A two-component ingestion/server version string (`1.9`, `1.9.dev0`) resolves to `1.9.0` instead of raising `PipelineServiceVersionException`.
- Three-component versions (`0.12.0.dev0`) still resolve to `0.12.0`.
- A non-version string (`random`) still raises with the updated `Cannot extract version x.y` message.

#### Unit tests
- [x] I added unit tests for the new/changed logic.
- Files added/updated: `PipelineServiceClientTest.java` (`testGetVersionFromStringDefaultsPatchToZero`, updated `testGetVersionFromStringRaises`). All 7 tests pass.

#### Backend integration tests
- [x] Not applicable (no backend API changes).

#### Ingestion integration tests
- [x] Not applicable (no ingestion changes).

#### Playwright (UI) tests
- [x] Not applicable (no UI changes).

#
### UI screen recording / screenshots:

Not applicable.

#
### Checklist:
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests (unit) and listed them above.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR makes pipeline service version parsing accept versions without a patch number. The main changes are:

- Optional patch parsing in `PipelineServiceClient.getVersionFromString`.
- Default patch value of `0` for `x.y` version strings.
- Unit coverage for `1.9`, `1.9.dev0`, existing three-part versions, and invalid input.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge.

- No blocking issues found in the changed code.

</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-spec/src/main/java/org/openmetadata/service/clients/pipeline/PipelineServiceClient.java | Normalizes two-part pipeline service versions to `x.y.0` while keeping three-part parsing behavior. |
| openmetadata-service/src/test/java/org/openmetadata/service/pipelineService/PipelineServiceClientTest.java | Adds tests for two-part versions and updates the invalid-version error assertion. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(pipeline): default patch to 0 when v..."](https://github.com/open-metadata/openmetadata/commit/784d695240d63f6528b31ee52cb44d22ed6e3122) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42159397)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Context used - CLAUDE.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=52f0d9d9-cad1-4e7d-b070-de181a0aa5e7))
- Context used - openmetadata-ui-core-components/CLAUDE.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=41754627-b2bf-474b-8082-f37ef1a07013))
- Context used - AGENTS.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=ef262f5f-911f-44f3-8d2d-e9cb1579c8c8))
</details>

<!-- /greptile_comment -->