### PR TITLE
fix(apps): stop exposing app bot JWT and privateConfiguration secrets in API responses (1.13)

### DIFF
--- a/bootstrap/sql/migrations/native/1.13.2/mysql/postDataMigrationSQLScript.sql
+++ b/bootstrap/sql/migrations/native/1.13.2/mysql/postDataMigrationSQLScript.sql
@@ -1,0 +1,15 @@
+-- Security: openMetadataServerConnection (app bot JWT) and privateConfiguration (external
+-- tokens/passwords) are runtime-only fields, re-injected on demand by
+-- ApplicationHandler.setAppRuntimeProperties. They were previously persisted onto app rows
+-- and version snapshots and served in API responses. Strip them from stored data so the
+-- secrets no longer linger at rest.
+UPDATE installed_apps
+SET json = JSON_REMOVE(json, '$.openMetadataServerConnection', '$.privateConfiguration')
+WHERE JSON_EXTRACT(json, '$.openMetadataServerConnection') IS NOT NULL
+   OR JSON_EXTRACT(json, '$.privateConfiguration') IS NOT NULL;
+
+UPDATE entity_extension
+SET json = JSON_REMOVE(json, '$.openMetadataServerConnection', '$.privateConfiguration')
+WHERE extension LIKE 'app.version.%'
+  AND (JSON_EXTRACT(json, '$.openMetadataServerConnection') IS NOT NULL
+       OR JSON_EXTRACT(json, '$.privateConfiguration') IS NOT NULL);

--- a/bootstrap/sql/migrations/native/1.13.2/postgres/postDataMigrationSQLScript.sql
+++ b/bootstrap/sql/migrations/native/1.13.2/postgres/postDataMigrationSQLScript.sql
@@ -1,0 +1,15 @@
+-- Security: openMetadataServerConnection (app bot JWT) and privateConfiguration (external
+-- tokens/passwords) are runtime-only fields, re-injected on demand by
+-- ApplicationHandler.setAppRuntimeProperties. They were previously persisted onto app rows
+-- and version snapshots and served in API responses. Strip them from stored data so the
+-- secrets no longer linger at rest.
+UPDATE installed_apps
+SET json = (json::jsonb - 'openMetadataServerConnection' - 'privateConfiguration')
+WHERE jsonb_exists(json::jsonb, 'openMetadataServerConnection')
+   OR jsonb_exists(json::jsonb, 'privateConfiguration');
+
+UPDATE entity_extension
+SET json = (json::jsonb - 'openMetadataServerConnection' - 'privateConfiguration')
+WHERE extension LIKE 'app.version.%'
+  AND (jsonb_exists(json::jsonb, 'openMetadataServerConnection')
+       OR jsonb_exists(json::jsonb, 'privateConfiguration'));

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/AppRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/AppRepository.java
@@ -6,6 +6,7 @@ import static org.openmetadata.schema.type.Include.ALL;
 import static org.openmetadata.service.Entity.getEntityReferenceById;
 import static org.openmetadata.service.util.UserUtil.getUser;
 
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -175,12 +176,24 @@ public class AppRepository extends EntityRepository<App> {
     return daoCollection.applicationDAO().listAppsRef();
   }
 
+  // openMetadataServerConnection and privateConfiguration are runtime-only fields
+  // (re-injected on demand by ApplicationHandler.setAppRuntimeProperties). They carry
+  // secrets (app bot JWT, external tokens) and must never be persisted or serialized.
+  private static final List<String> RUNTIME_SECRET_FIELDS =
+      List.of("openMetadataServerConnection", "privateConfiguration");
+
   @Override
   protected List<String> getFieldsStrippedFromStorageJson() {
-    // openMetadataServerConnection and privateConfiguration are runtime-only fields
-    // (re-injected on demand by ApplicationHandler.setAppRuntimeProperties). They carry
-    // secrets (app bot JWT, external tokens) and must never be persisted or serialized.
-    return List.of("bot", "openMetadataServerConnection", "privateConfiguration");
+    List<String> strippedFields = new ArrayList<>(RUNTIME_SECRET_FIELDS);
+    strippedFields.add("bot");
+    return strippedFields;
+  }
+
+  @Override
+  protected String serializeForVersionHistory(App entity) {
+    ObjectNode node = (ObjectNode) JsonUtils.valueToTree(entity);
+    node.remove(RUNTIME_SECRET_FIELDS);
+    return node.toString();
   }
 
   @Override

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/AppRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/AppRepository.java
@@ -177,7 +177,10 @@ public class AppRepository extends EntityRepository<App> {
 
   @Override
   protected List<String> getFieldsStrippedFromStorageJson() {
-    return List.of("bot");
+    // openMetadataServerConnection and privateConfiguration are runtime-only fields
+    // (re-injected on demand by ApplicationHandler.setAppRuntimeProperties). They carry
+    // secrets (app bot JWT, external tokens) and must never be persisted or serialized.
+    return List.of("bot", "openMetadataServerConnection", "privateConfiguration");
   }
 
   @Override

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/AppRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/AppRepository.java
@@ -179,7 +179,7 @@ public class AppRepository extends EntityRepository<App> {
   // openMetadataServerConnection and privateConfiguration are runtime-only fields
   // (re-injected on demand by ApplicationHandler.setAppRuntimeProperties). They carry
   // secrets (app bot JWT, external tokens) and must never be persisted or serialized.
-  private static final List<String> RUNTIME_SECRET_FIELDS =
+  public static final List<String> RUNTIME_SECRET_FIELDS =
       List.of("openMetadataServerConnection", "privateConfiguration");
 
   @Override

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/EntityRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/EntityRepository.java
@@ -4697,6 +4697,10 @@ public abstract class EntityRepository<T extends EntityInterface> {
     return storageJsonNode(entity).toString();
   }
 
+  protected String serializeForVersionHistory(T entity) {
+    return JsonUtils.pojoToJson(entity);
+  }
+
   @Transaction
   protected void store(T entity, boolean update) {
     store(entity, update, null);
@@ -6351,7 +6355,7 @@ public abstract class EntityRepository<T extends EntityInterface> {
           historyIds.add(u.getOriginal().getId());
           historyExtensions.add(
               EntityUtil.getVersionExtension(entityType, u.getOriginal().getVersion()));
-          historyJsons.add(JsonUtils.pojoToJson(u.getOriginal()));
+          historyJsons.add(serializeForVersionHistory(u.getOriginal()));
         }
       }
       if (!historyIds.isEmpty()) {
@@ -9389,7 +9393,8 @@ public abstract class EntityRepository<T extends EntityInterface> {
       String extensionName = EntityUtil.getVersionExtension(entityType, original.getVersion());
       daoCollection
           .entityExtensionDAO()
-          .insert(original.getId(), extensionName, entityType, JsonUtils.pojoToJson(original));
+          .insert(
+              original.getId(), extensionName, entityType, serializeForVersionHistory(original));
     }
 
     private void removeEntityHistory(Double version) {
@@ -11345,7 +11350,7 @@ public abstract class EntityRepository<T extends EntityInterface> {
     String extensionName = EntityUtil.getVersionExtension(entityType, original.getVersion());
     daoCollection
         .entityExtensionDAO()
-        .insert(original.getId(), extensionName, entityType, JsonUtils.pojoToJson(original));
+        .insert(original.getId(), extensionName, entityType, serializeForVersionHistory(original));
 
     // Directly update the entity in the database without calling other versioning methods
     dao.update(updated.getId(), updated.getFullyQualifiedName(), JsonUtils.pojoToJson(updated));

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/apps/AppResource.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/apps/AppResource.java
@@ -721,6 +721,13 @@ public class AppResource extends EntityResource<App, AppRepository> {
                     unsetAppRuntimeProperties(app);
                     return JsonUtils.pojoToJson(app);
                   } catch (Exception e) {
+                    // Fallback returns the original snapshot, which could still carry runtime
+                    // secrets if a snapshot ever escaped the storage/migration guards — log so a
+                    // parse regression in this defense-in-depth path is observable.
+                    LOG.warn(
+                        "Failed to strip runtime secrets from app version snapshot; "
+                            + "returning snapshot as-is",
+                        e);
                     return json;
                   }
                 })

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/apps/AppResource.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/apps/AppResource.java
@@ -737,11 +737,12 @@ public class AppResource extends EntityResource<App, AppRepository> {
           Include include) {
     App app = getInternal(uriInfo, securityContext, id, fieldsParam, include);
     if (include != Include.DELETED && !Boolean.TRUE.equals(app.getDeleted())) {
-      return ApplicationHandler.getInstance()
-          .appWithDecryptedAppConfiguration(app, Entity.getCollectionDAO(), searchRepository);
-    } else {
-      return app;
+      app =
+          ApplicationHandler.getInstance()
+              .appWithDecryptedAppConfiguration(app, Entity.getCollectionDAO(), searchRepository);
     }
+    unsetAppRuntimeProperties(app);
+    return app;
   }
 
   @GET
@@ -779,11 +780,12 @@ public class AppResource extends EntityResource<App, AppRepository> {
           Include include) {
     App app = getByNameInternal(uriInfo, securityContext, name, fieldsParam, include);
     if (include != Include.DELETED && !Boolean.TRUE.equals(app.getDeleted())) {
-      return ApplicationHandler.getInstance()
-          .appWithDecryptedAppConfiguration(app, Entity.getCollectionDAO(), searchRepository);
-    } else {
-      return app;
+      app =
+          ApplicationHandler.getInstance()
+              .appWithDecryptedAppConfiguration(app, Entity.getCollectionDAO(), searchRepository);
     }
+    unsetAppRuntimeProperties(app);
+    return app;
   }
 
   @GET

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/apps/AppResource.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/apps/AppResource.java
@@ -67,6 +67,7 @@ import org.openmetadata.schema.type.EntityHistory;
 import org.openmetadata.schema.type.EntityReference;
 import org.openmetadata.schema.type.Include;
 import org.openmetadata.schema.type.MetadataOperation;
+import org.openmetadata.schema.utils.JsonUtils;
 import org.openmetadata.schema.utils.ResultList;
 import org.openmetadata.sdk.PipelineServiceClientInterface;
 import org.openmetadata.service.Entity;
@@ -276,7 +277,13 @@ public class AppResource extends EntityResource<App, AppRepository> {
             uriInfo, securityContext, fieldsParam, filter, limitParam, before, after);
     applications
         .getData()
-        .forEach(app -> app.setEnabled(ApplicationHandler.getInstance().isEnabled(app.getName())));
+        .forEach(
+            app -> {
+              app.setEnabled(ApplicationHandler.getInstance().isEnabled(app.getName()));
+              // Defense-in-depth: the list path does not inject runtime secrets today, but strip
+              // them unconditionally so a future change that decrypts here cannot leak them.
+              unsetAppRuntimeProperties(app);
+            });
     return applications;
   }
 
@@ -701,7 +708,25 @@ public class AppResource extends EntityResource<App, AppRepository> {
       @Context SecurityContext securityContext,
       @Parameter(description = "Id of the app", schema = @Schema(type = "UUID")) @PathParam("id")
           UUID id) {
-    return super.listVersionsInternal(securityContext, id);
+    EntityHistory entityHistory = super.listVersionsInternal(securityContext, id);
+    // Defense-in-depth: version snapshots are already stripped at storage time
+    // (AppRepository.serializeForVersionHistory) and by the 2.0.0 migration, but strip each
+    // returned snapshot too so this path never depends on those guarantees alone.
+    List<Object> versions =
+        entityHistory.getVersions().stream()
+            .map(
+                json -> {
+                  try {
+                    App app = JsonUtils.readValue((String) json, App.class);
+                    unsetAppRuntimeProperties(app);
+                    return JsonUtils.pojoToJson(app);
+                  } catch (Exception e) {
+                    return json;
+                  }
+                })
+            .collect(Collectors.toList());
+    entityHistory.setVersions(versions);
+    return entityHistory;
   }
 
   @GET
@@ -816,7 +841,11 @@ public class AppResource extends EntityResource<App, AppRepository> {
               schema = @Schema(type = "string", example = "0.1 or 1.1"))
           @PathParam("version")
           String version) {
-    return super.getVersionInternal(securityContext, id, version);
+    App app = super.getVersionInternal(securityContext, id, version);
+    // Defense-in-depth: no upstream code sets runtime secrets on the version path today, but strip
+    // them so the guarantee holds structurally rather than by that assumption.
+    unsetAppRuntimeProperties(app);
+    return app;
   }
 
   @POST

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/apps/AppResource.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/apps/AppResource.java
@@ -9,6 +9,8 @@ import static org.openmetadata.service.Entity.FIELD_OWNERS;
 import static org.openmetadata.service.jdbi3.EntityRepository.getEntitiesFromSeedData;
 import static org.openmetadata.service.security.DefaultAuthorizer.getSubjectContext;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.swagger.v3.oas.annotations.ExternalDocumentation;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -113,6 +115,7 @@ import org.quartz.SchedulerException;
 @Slf4j
 public class AppResource extends EntityResource<App, AppRepository> {
   public static final String COLLECTION_PATH = "/v1/apps/";
+  private static final String REDACTED_APP_SNAPSHOT = "{}";
   private OpenMetadataApplicationConfig openMetadataApplicationConfig;
   private PipelineServiceClientInterface pipelineServiceClient;
   static final String FIELDS = "owners";
@@ -214,6 +217,37 @@ public class AppResource extends EntityResource<App, AppRepository> {
   private void unsetAppRuntimeProperties(App app) {
     app.setOpenMetadataServerConnection(null);
     app.setPrivateConfiguration(null);
+  }
+
+  private Object stripRuntimeSecretsFromSnapshot(Object snapshot) {
+    Object stripped;
+    try {
+      App app = JsonUtils.readValue((String) snapshot, App.class);
+      unsetAppRuntimeProperties(app);
+      stripped = JsonUtils.pojoToJson(app);
+    } catch (Exception e) {
+      LOG.warn(
+          "Failed to parse app version snapshot as App; redacting runtime secrets from raw JSON",
+          e);
+      stripped = redactRuntimeSecretsFromRawSnapshot(snapshot);
+    }
+    return stripped;
+  }
+
+  static Object redactRuntimeSecretsFromRawSnapshot(Object snapshot) {
+    Object redacted = REDACTED_APP_SNAPSHOT;
+    try {
+      JsonNode node = JsonUtils.readTree(snapshot.toString());
+      if (node instanceof ObjectNode objectNode) {
+        objectNode.remove(AppRepository.RUNTIME_SECRET_FIELDS);
+        redacted = objectNode.toString();
+      }
+    } catch (Exception e) {
+      LOG.warn(
+          "Failed to redact runtime secrets from raw app version snapshot; dropping snapshot body",
+          e);
+    }
+    return redacted;
   }
 
   @GET
@@ -710,27 +744,11 @@ public class AppResource extends EntityResource<App, AppRepository> {
           UUID id) {
     EntityHistory entityHistory = super.listVersionsInternal(securityContext, id);
     // Defense-in-depth: version snapshots are already stripped at storage time
-    // (AppRepository.serializeForVersionHistory) and by the 2.0.0 migration, but strip each
+    // (AppRepository.serializeForVersionHistory) and by the 1.13.2 migration, but strip each
     // returned snapshot too so this path never depends on those guarantees alone.
     List<Object> versions =
         entityHistory.getVersions().stream()
-            .map(
-                json -> {
-                  try {
-                    App app = JsonUtils.readValue((String) json, App.class);
-                    unsetAppRuntimeProperties(app);
-                    return JsonUtils.pojoToJson(app);
-                  } catch (Exception e) {
-                    // Fallback returns the original snapshot, which could still carry runtime
-                    // secrets if a snapshot ever escaped the storage/migration guards — log so a
-                    // parse regression in this defense-in-depth path is observable.
-                    LOG.warn(
-                        "Failed to strip runtime secrets from app version snapshot; "
-                            + "returning snapshot as-is",
-                        e);
-                    return json;
-                  }
-                })
+            .map(this::stripRuntimeSecretsFromSnapshot)
             .collect(Collectors.toList());
     entityHistory.setVersions(versions);
     return entityHistory;

--- a/openmetadata-service/src/test/java/org/openmetadata/service/jdbi3/AppRepositoryStorageStrippingTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/jdbi3/AppRepositoryStorageStrippingTest.java
@@ -14,55 +14,54 @@ package org.openmetadata.service.jdbi3;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.CALLS_REAL_METHODS;
+import static org.mockito.Mockito.mock;
 
 import com.fasterxml.jackson.databind.node.ObjectNode;
-import java.lang.reflect.Field;
 import java.util.Map;
 import java.util.UUID;
 import org.junit.jupiter.api.Test;
 import org.openmetadata.schema.entity.app.App;
 import org.openmetadata.schema.security.client.OpenMetadataJWTClientConfig;
 import org.openmetadata.schema.services.connections.metadata.OpenMetadataConnection;
-import sun.misc.Unsafe;
+import org.openmetadata.schema.utils.JsonUtils;
 
 /**
  * Regression guard for the app runtime-secret exposure fix. {@code openMetadataServerConnection}
  * (app bot JWT) and {@code privateConfiguration} (external tokens/passwords) are runtime-only
  * fields re-injected by ApplicationHandler.setAppRuntimeProperties. They must never be written to
- * storage, so AppRepository declares them in getFieldsStrippedFromStorageJson and the base
- * serializer drops them.
+ * current-entity storage or to version-history snapshots.
  */
 class AppRepositoryStorageStrippingTest {
 
-  private static AppRepository allocateRepository() throws Exception {
-    Field unsafeField = Unsafe.class.getDeclaredField("theUnsafe");
-    unsafeField.setAccessible(true);
-    Unsafe unsafe = (Unsafe) unsafeField.get(null);
-    return (AppRepository) unsafe.allocateInstance(AppRepository.class);
+  private static AppRepository testRepository() {
+    return mock(AppRepository.class, CALLS_REAL_METHODS);
+  }
+
+  private static App appWithRuntimeSecrets() {
+    return new App()
+        .withId(UUID.randomUUID())
+        .withName("SecretMaskingTestApp")
+        .withPrivateConfiguration(Map.of("token", "waii-secret-token"))
+        .withOpenMetadataServerConnection(
+            new OpenMetadataConnection()
+                .withSecurityConfig(
+                    new OpenMetadataJWTClientConfig().withJwtToken("app-bot-jwt-secret")));
   }
 
   @Test
-  void getFieldsStrippedFromStorageJson_declaresRuntimeSecretFields() throws Exception {
-    AppRepository repository = allocateRepository();
+  void getFieldsStrippedFromStorageJson_declaresRuntimeSecretFields() {
+    AppRepository repository = testRepository();
     assertTrue(
         repository.getFieldsStrippedFromStorageJson().contains("openMetadataServerConnection"));
     assertTrue(repository.getFieldsStrippedFromStorageJson().contains("privateConfiguration"));
   }
 
   @Test
-  void storageJson_dropsRuntimeSecretFields() throws Exception {
-    AppRepository repository = allocateRepository();
-    App app =
-        new App()
-            .withId(UUID.randomUUID())
-            .withName("SecretMaskingTestApp")
-            .withPrivateConfiguration(Map.of("token", "waii-secret-token"))
-            .withOpenMetadataServerConnection(
-                new OpenMetadataConnection()
-                    .withSecurityConfig(
-                        new OpenMetadataJWTClientConfig().withJwtToken("app-bot-jwt-secret")));
+  void storageJson_dropsRuntimeSecretFields() {
+    AppRepository repository = testRepository();
 
-    ObjectNode stored = repository.storageJsonNode(app);
+    ObjectNode stored = repository.storageJsonNode(appWithRuntimeSecrets());
 
     assertFalse(
         stored.has("privateConfiguration"),
@@ -70,5 +69,22 @@ class AppRepositoryStorageStrippingTest {
     assertFalse(
         stored.has("openMetadataServerConnection"),
         "openMetadataServerConnection must not be persisted to storage");
+  }
+
+  @Test
+  void versionHistoryJson_dropsRuntimeSecretFields() {
+    AppRepository repository = testRepository();
+
+    ObjectNode snapshot =
+        (ObjectNode)
+            JsonUtils.readTree(repository.serializeForVersionHistory(appWithRuntimeSecrets()));
+
+    assertFalse(
+        snapshot.has("privateConfiguration"),
+        "privateConfiguration must not appear in version-history snapshots");
+    assertFalse(
+        snapshot.has("openMetadataServerConnection"),
+        "openMetadataServerConnection must not appear in version-history snapshots");
+    assertTrue(snapshot.has("name"), "non-secret fields must remain in version-history snapshots");
   }
 }

--- a/openmetadata-service/src/test/java/org/openmetadata/service/jdbi3/AppRepositoryStorageStrippingTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/jdbi3/AppRepositoryStorageStrippingTest.java
@@ -1,0 +1,74 @@
+/*
+ *  Copyright 2024 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.openmetadata.service.jdbi3;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import java.lang.reflect.Field;
+import java.util.Map;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.openmetadata.schema.entity.app.App;
+import org.openmetadata.schema.security.client.OpenMetadataJWTClientConfig;
+import org.openmetadata.schema.services.connections.metadata.OpenMetadataConnection;
+import sun.misc.Unsafe;
+
+/**
+ * Regression guard for the app runtime-secret exposure fix. {@code openMetadataServerConnection}
+ * (app bot JWT) and {@code privateConfiguration} (external tokens/passwords) are runtime-only
+ * fields re-injected by ApplicationHandler.setAppRuntimeProperties. They must never be written to
+ * storage, so AppRepository declares them in getFieldsStrippedFromStorageJson and the base
+ * serializer drops them.
+ */
+class AppRepositoryStorageStrippingTest {
+
+  private static AppRepository allocateRepository() throws Exception {
+    Field unsafeField = Unsafe.class.getDeclaredField("theUnsafe");
+    unsafeField.setAccessible(true);
+    Unsafe unsafe = (Unsafe) unsafeField.get(null);
+    return (AppRepository) unsafe.allocateInstance(AppRepository.class);
+  }
+
+  @Test
+  void getFieldsStrippedFromStorageJson_declaresRuntimeSecretFields() throws Exception {
+    AppRepository repository = allocateRepository();
+    assertTrue(
+        repository.getFieldsStrippedFromStorageJson().contains("openMetadataServerConnection"));
+    assertTrue(repository.getFieldsStrippedFromStorageJson().contains("privateConfiguration"));
+  }
+
+  @Test
+  void storageJson_dropsRuntimeSecretFields() throws Exception {
+    AppRepository repository = allocateRepository();
+    App app =
+        new App()
+            .withId(UUID.randomUUID())
+            .withName("SecretMaskingTestApp")
+            .withPrivateConfiguration(Map.of("token", "waii-secret-token"))
+            .withOpenMetadataServerConnection(
+                new OpenMetadataConnection()
+                    .withSecurityConfig(
+                        new OpenMetadataJWTClientConfig().withJwtToken("app-bot-jwt-secret")));
+
+    ObjectNode stored = repository.storageJsonNode(app);
+
+    assertFalse(
+        stored.has("privateConfiguration"),
+        "privateConfiguration must not be persisted to storage");
+    assertFalse(
+        stored.has("openMetadataServerConnection"),
+        "openMetadataServerConnection must not be persisted to storage");
+  }
+}

--- a/openmetadata-service/src/test/java/org/openmetadata/service/resources/apps/AppResourceSnapshotRedactionTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/resources/apps/AppResourceSnapshotRedactionTest.java
@@ -1,0 +1,46 @@
+package org.openmetadata.service.resources.apps;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import org.junit.jupiter.api.Test;
+import org.openmetadata.schema.utils.JsonUtils;
+
+class AppResourceSnapshotRedactionTest {
+
+  @Test
+  void rawSnapshotWithSecretsGetsRedacted() {
+    String snapshot =
+        """
+        {"name":"myapp","openMetadataServerConnection":{"securityConfig":{"jwtToken":"secret"}},\
+        "privateConfiguration":{"token":"abc"},"appConfiguration":{"keep":"me"}}""";
+
+    JsonNode result =
+        JsonUtils.readTree((String) AppResource.redactRuntimeSecretsFromRawSnapshot(snapshot));
+
+    assertFalse(result.has("openMetadataServerConnection"));
+    assertFalse(result.has("privateConfiguration"));
+    assertTrue(result.has("appConfiguration"));
+    assertEquals("myapp", result.get("name").asText());
+  }
+
+  @Test
+  void rawSnapshotWithoutSecretsIsPreserved() {
+    String snapshot = "{\"name\":\"myapp\",\"appConfiguration\":{\"keep\":\"me\"}}";
+
+    JsonNode result =
+        JsonUtils.readTree((String) AppResource.redactRuntimeSecretsFromRawSnapshot(snapshot));
+
+    assertEquals("myapp", result.get("name").asText());
+    assertTrue(result.has("appConfiguration"));
+  }
+
+  @Test
+  void unparseableSnapshotFailsClosed() {
+    Object result = AppResource.redactRuntimeSecretsFromRawSnapshot("not-json");
+
+    assertEquals("{}", result);
+  }
+}


### PR DESCRIPTION
Backport of #29675 to `1.13`.

### Describe your changes:

App read endpoints (`GET /v1/apps`, `/v1/apps/{id}`, `/v1/apps/name/{name}`, and version snapshots) returned two runtime-only fields in plaintext to any authenticated caller:

- `openMetadataServerConnection.securityConfig.jwtToken` — the app bot's OpenMetadata JWT (non-expiring)
- `privateConfiguration` — external secrets (e.g. tokens/passwords) loaded at runtime

Both are re-injected on demand by `ApplicationHandler.setAppRuntimeProperties`, so they never need to be persisted or serialized. Write paths already stripped them via `unsetAppRuntimeProperties`; the read paths did not.

Fix, defense-in-depth:
1. `AppRepository.getFieldsStrippedFromStorageJson` now also strips `openMetadataServerConnection` and `privateConfiguration`, so they are never written to storage; new `serializeForVersionHistory` override strips them from version snapshots.
2. `AppResource` read paths (`list`, `get`, `getByName`, `getVersion`, `listVersions`) call `unsetAppRuntimeProperties` after decryption, so responses never carry the runtime secrets (decrypted `appConfiguration` is preserved).
3. `1.13.2` post-data migration (MySQL + Postgres) removes the fields already persisted in `installed_apps` and app version snapshots in `entity_extension`.

The Postgres migration uses `jsonb_exists(json::jsonb, 'key')` rather than the `?` operator, since JDBI parses `?` in SQL as a positional bind parameter (which fails migration with `Superfluous positional param`).

Regression test `AppRepositoryStorageStrippingTest` asserts both fields are dropped from stored JSON.

#
### Type of change:
- [x] Bug fix

#
### Checklist:
- [x] I have read the [CONTRIBUTING](https://github.com/open-metadata/OpenMetadata/blob/main/CONTRIBUTING.md) document.
- [x] My PR includes tests for the changes made.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR stops app runtime secrets from being stored or returned by app read APIs. The main changes are:

- Strip app bot JWT and private configuration fields from app storage JSON.
- Strip the same fields from app version-history snapshots.
- Redact runtime secrets from app list, get, get-by-name, and version responses.
- Add database migrations to remove already-persisted secret fields.
- Add tests for storage stripping and raw snapshot redaction.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge.

- No blocking issues found in the changed code.

</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-service/src/main/java/org/openmetadata/service/resources/apps/AppResource.java | Adds response-time redaction for app runtime secrets, including a fail-closed path for raw version snapshots. |
| openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/AppRepository.java | Strips runtime-only secret fields from app storage and version-history serialization. |
| openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/EntityRepository.java | Routes version-history serialization through an overridable repository hook. |
| bootstrap/sql/migrations/native/1.13.2/mysql/postDataMigrationSQLScript.sql | Removes persisted app runtime secret fields from MySQL app rows and app version snapshots. |
| bootstrap/sql/migrations/native/1.13.2/postgres/postDataMigrationSQLScript.sql | Removes persisted app runtime secret fields from PostgreSQL app rows and app version snapshots. |
| openmetadata-service/src/test/java/org/openmetadata/service/jdbi3/AppRepositoryStorageStrippingTest.java | Covers storage and version-history stripping for app runtime secret fields. |
| openmetadata-service/src/test/java/org/openmetadata/service/resources/apps/AppResourceSnapshotRedactionTest.java | Covers raw snapshot redaction, non-secret field preservation, and fail-closed handling for invalid snapshots. |

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(apps): fail closed on unparseable ve..."](https://github.com/open-metadata/openmetadata/commit/f0c47da1c683f07b0e4e65ac0d01947882410349) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42249264)</sub>

**Context used:**

- Context used - CLAUDE.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=52f0d9d9-cad1-4e7d-b070-de181a0aa5e7))
- Context used - openmetadata-ui-core-components/CLAUDE.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=41754627-b2bf-474b-8082-f37ef1a07013))

<!-- /greptile_comment -->