### PR TITLE
fix(bigquery): GCP service account impersonation across BigQuery ADC …

### DIFF
--- a/ingestion/src/metadata/ingestion/source/database/bigquery/connection.py
+++ b/ingestion/src/metadata/ingestion/source/database/bigquery/connection.py
@@ -51,7 +51,11 @@ from metadata.ingestion.connections.test_connections import (
     test_query,
 )
 from metadata.ingestion.ometa.ometa_api import OpenMetadata
+from metadata.ingestion.source.database.bigquery.helper import (
+    get_impersonate_client_kwargs,
+)
 from metadata.ingestion.source.database.bigquery.queries import BIGQUERY_TEST_STATEMENT
+from metadata.utils.bigquery_utils import get_bigquery_client
 from metadata.utils.constants import THREE_MIN
 from metadata.utils.credentials import set_google_credentials
 from metadata.utils.logger import ingestion_logger
@@ -148,6 +152,56 @@ def get_connection_url(connection: BigQueryConnection) -> str:
     return _add_location(url, connection)
 
 
+def get_connection_args(connection: BigQueryConnection) -> dict:
+    """
+    Build the SQLAlchemy connect args for BigQuery.
+
+    When service account impersonation is configured, inject a pre-built
+    impersonated ``bigquery.Client`` so that every query issued through the
+    engine (Test Connection and information_schema reads) runs under the
+    target identity. Without impersonation this is identical to the common
+    connection args, preserving the previous behaviour.
+    """
+    connect_args = get_connection_args_common(connection)
+    impersonate_kwargs = get_impersonate_client_kwargs(connection)
+    if impersonate_kwargs:
+        billing_or_project_id = connection.billingProjectId or _get_first_project_id(
+            connection
+        )
+        if billing_or_project_id is None:
+            logger.warning(
+                "Could not resolve a project id for the impersonated BigQuery client from "
+                "billingProjectId or the credentials config. The project will be resolved from the "
+                "environment (e.g. GOOGLE_CLOUD_PROJECT) at query time; set billingProjectId or a "
+                "projectId to make this explicit."
+            )
+        connect_args = {
+            **connect_args,
+            "client": get_bigquery_client(
+                project_id=billing_or_project_id, **impersonate_kwargs
+            ),
+        }
+    return connect_args
+
+
+def _get_first_project_id(connection: BigQueryConnection) -> Optional[str]:
+    """
+    Return a single project id from the connection config to scope the
+    impersonated client. Falls back to None when it cannot be determined.
+    """
+    project_id = None
+    gcp_config = connection.credentials.gcpConfig
+    config_project_id = getattr(gcp_config, "projectId", None)
+    if config_project_id is not None:
+        if isinstance(config_project_id, SingleProjectId):
+            project_id = config_project_id.root
+        elif (
+            isinstance(config_project_id, MultipleProjectId) and config_project_id.root
+        ):
+            project_id = config_project_id.root[0]
+    return project_id
+
+
 def get_connection(connection: BigQueryConnection) -> Engine:
     """
     Prepare the engine and the GCP credentials
@@ -160,7 +214,7 @@ def get_connection(connection: BigQueryConnection) -> Engine:
     return create_generic_db_connection(
         connection=connection,
         get_connection_url_fn=get_connection_url,
-        get_connection_args_fn=get_connection_args_common,
+        get_connection_args_fn=get_connection_args,
         **kwargs,
     )
 

--- a/ingestion/src/metadata/ingestion/source/database/bigquery/helper.py
+++ b/ingestion/src/metadata/ingestion/source/database/bigquery/helper.py
@@ -59,6 +59,27 @@ class InspectorWrapper(BaseModel):
     inspector: Any
 
 
+def get_impersonate_client_kwargs(service_connection: BigQueryConnection) -> dict:
+    """
+    Build the impersonation kwargs for ``get_bigquery_client`` when a target
+    service account is configured.
+
+    ``gcpImpersonateServiceAccount`` lives on the parent credentials object and
+    is valid regardless of the selected ``gcpConfig`` type, so it must not be
+    gated on a specific type. A blank or whitespace-only target email is treated
+    as "not configured" and returns an empty dict, leaving the default
+    (non-impersonated) behaviour untouched.
+    """
+    kwargs = {}
+    impersonate = service_connection.credentials.gcpImpersonateServiceAccount
+    if impersonate and impersonate.impersonateServiceAccount:
+        target_service_account = impersonate.impersonateServiceAccount.strip()
+        if target_service_account:
+            kwargs["impersonate_service_account"] = target_service_account
+            kwargs["lifetime"] = impersonate.lifetime
+    return kwargs
+
+
 def get_inspector_details(
     database_name: str, service_connection: BigQueryConnection
 ) -> InspectorWrapper:
@@ -68,7 +89,7 @@ def get_inspector_details(
     # TODO support location property in JSON Schema
     # TODO support OAuth 2.0 scopes
     new_service_connection = deepcopy(service_connection)
-    kwargs = {}
+    kwargs = get_impersonate_client_kwargs(new_service_connection)
 
     if new_service_connection.usageLocation:
         kwargs["location"] = new_service_connection.usageLocation
@@ -77,16 +98,6 @@ def get_inspector_details(
         new_service_connection.credentials.gcpConfig.projectId = SingleProjectId(
             database_name
         )
-        if new_service_connection.credentials.gcpImpersonateServiceAccount:
-            kwargs[
-                "impersonate_service_account"
-            ] = (
-                new_service_connection.credentials.gcpImpersonateServiceAccount.impersonateServiceAccount
-            )
-
-            kwargs[
-                "lifetime"
-            ] = new_service_connection.credentials.gcpImpersonateServiceAccount.lifetime
 
     client = get_bigquery_client(
         project_id=new_service_connection.billingProjectId or database_name, **kwargs

--- a/ingestion/tests/unit/topology/database/test_bigquery_impersonation.py
+++ b/ingestion/tests/unit/topology/database/test_bigquery_impersonation.py
@@ -1,0 +1,347 @@
+#  Copyright 2025 Collate
+#  Licensed under the Collate Community License, Version 1.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  https://github.com/open-metadata/OpenMetadata/blob/main/ingestion/LICENSE
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+"""
+Unit tests for BigQuery service account impersonation across both the
+SQLAlchemy engine path (Test Connection + information_schema reads) and the
+BigQuery Python client path (dataset listing / policy tags).
+
+Regression coverage for
+https://github.com/open-metadata/OpenMetadata/issues/28204
+"""
+
+from copy import deepcopy
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from metadata.generated.schema.entity.services.connections.database.bigQueryConnection import (
+    BigQueryConnection,
+)
+from metadata.ingestion.source.database.bigquery.connection import get_connection_args
+from metadata.ingestion.source.database.bigquery.helper import (
+    get_impersonate_client_kwargs,
+)
+from metadata.utils.bigquery_utils import get_bigquery_client
+
+TARGET_SA = "target-reader@my-project.iam.gserviceaccount.com"
+
+VALID_PRIVATE_KEY = (
+    "-----BEGIN RSA PRIVATE KEY-----\n"
+    "MIIEpQIBAAKCAQEAw3vHG9fDIkcYB0xi2Mv4fS2gUzKR9ZRrcVNeKkqGFTT71AVB\n"
+    "OzgIqYVe8b2aWODuNye6sipcrqTqOt05Esj+sxhk5McM9bE2RlxXC5QH/Bp9zxMP\n"
+    "/Yksv9Ov7fdDt/loUk7sTXvI+7LDJfmRYU6MtVjyyLs7KpQIB2xBWEToU1xZY+v0\n"
+    "dRC1NA+YWc+FjXbAiFAf9d4gXkYO8VmU5meixVh4C8nsjokEXk0T/HEItpZCxadk\n"
+    "dZ7LKUE/HDmWCO2oNG6sCf4ET2crjSdYIfXuREopX1aQwnk7KbI4/YIdlRz1I369\n"
+    "Az3+Hxlf9lLJVH3+itN4GXrR9yWWKWKDnwDPbQIDAQABAoIBAQC3X5QuTR7SN8iV\n"
+    "iBUtc2D84+ECSmza5shG/UJW/6N5n0Mf53ICgBS4GNEwiYCRISa0/ILIgK6CcVb7\n"
+    "suvH8F3kWNzEMui4TO0x4YsR5GH9HkioCCS224frxkLBQnL20HIIy9ok8Rpe6Zjg\n"
+    "NZUnp4yczPyqSeA9l7FUbTt69uDM2Cx61m8REOpFukpnYLyZGbmNPYmikEO+rq9r\n"
+    "wNID5dkSeVuQYo4MQdRavOGFUWvUYXzkEQ0A6vPyraVBfolESX8WaLNVjic7nIa3\n"
+    "ujdSNojnJqGJ3gslntcmN1d4JOfydc4bja4/NdNlcOHpWDGLzY1QnaDe0Koxn8sx\n"
+    "LT9MVD2NAoGBAPy7r726bKVGWcwqTzUuq1OWh5c9CAc4N2zWBBldSJyUdllUq52L\n"
+    "WTyva6GRoRzCcYa/dKLLSM/k4eLf9tpxeIIfTOMsvzGtbAdm257ndMXNvfYpxCfU\n"
+    "K/gUFfAUGHZ3MucTHRY6DTkJg763Sf6PubA2fqv3HhVZDK/1HGDtHlTPAoGBAMYC\n"
+    "pdV7O7lAyXS/d9X4PQZ4BM+P8MbXEdGBbPPlzJ2YIb53TEmYfSj3z41u9+BNnhGP\n"
+    "4uzUyAR/E4sxrA2+Ll1lPSCn+KY14WWiVGfWmC5j1ftdpkbrXstLN8NpNYzrKZwx\n"
+    "jdR0ZkwvZ8B5+kJ1hK96giwWS+SJxJR3TohcQ18DAoGAJSfmv2r//BBqtURnHrd8\n"
+    "wq43wvlbC8ytAVg5hA0d1r9Q4vM6w8+vz+cuWLOTTyobDKdrG1/tlXrd5r/sh9L0\n"
+    "15SIdkGm3kPTxQbPNP5sQYRs8BrV1tEvoao6S3B45DnEBwrdVN42AXOvpcNGoqE4\n"
+    "uHpahyeuiY7s+ZV8lZdmxSsCgYEAolr5bpmk1rjwdfGoaKEqKGuwRiBX5DHkQkxE\n"
+    "8Zayt2VOBcX7nzyRI05NuEIMrLX3rZ61CktN1aH8fF02He6aRaoE/Qm9L0tujM8V\n"
+    "Ni8WiLMDeR/Ifs3u4/HAv1E8v1byv0dCa7klR8J257McJ/ID4X4pzcxaXgE4ViOd\n"
+    "GOHNu9ECgYEApq1zkZthEQymTUxs+lSFcubQpaXyf5ZC61cJewpWkqGDtSC+8DxE\n"
+    "F/jydybWuoNHXymnvY6QywxuIooivbuib6AlgpEJeybmnWlDOZklFOD0abNZ+aNO\n"
+    "dUk7XVGffCakXQ0jp1kmZA4lGsYK1h5dEU5DgXqu4UYJ88Vttax2W+Y=\n"
+    "-----END RSA PRIVATE KEY-----\n"
+)
+
+ADC_CONFIG = {
+    "type": "BigQuery",
+    "credentials": {"gcpConfig": {"type": "gcp_adc", "projectId": "proj-adc"}},
+}
+
+JSON_KEY_CONFIG = {
+    "type": "BigQuery",
+    "credentials": {
+        "gcpConfig": {
+            "type": "service_account",
+            "projectId": "proj-key",
+            "privateKeyId": "private_key_id",
+            "privateKey": VALID_PRIVATE_KEY,
+            "clientEmail": "svc@proj-key.iam.gserviceaccount.com",
+            "clientId": "1234",
+            "authUri": "https://accounts.google.com/o/oauth2/auth",
+            "tokenUri": "https://oauth2.googleapis.com/token",
+            "authProviderX509CertUrl": "https://www.googleapis.com/oauth2/v1/certs",
+            "clientX509CertUrl": "https://www.googleapis.com/oauth2/v1/certs",
+        }
+    },
+}
+
+
+def _with_impersonation(base_config: dict, lifetime: int = 1800) -> BigQueryConnection:
+    config = deepcopy(base_config)
+    config["credentials"]["gcpImpersonateServiceAccount"] = {
+        "impersonateServiceAccount": TARGET_SA,
+        "lifetime": lifetime,
+    }
+    return BigQueryConnection.model_validate(config)
+
+
+@pytest.mark.parametrize("base_config", [ADC_CONFIG, JSON_KEY_CONFIG])
+def test_impersonate_kwargs_built_for_all_config_types(base_config):
+    """Impersonation kwargs must be produced independently of the gcpConfig type."""
+    connection = _with_impersonation(base_config, lifetime=1800)
+
+    kwargs = get_impersonate_client_kwargs(connection)
+
+    assert kwargs == {
+        "impersonate_service_account": TARGET_SA,
+        "lifetime": 1800,
+    }
+
+
+@pytest.mark.parametrize("base_config", [ADC_CONFIG, JSON_KEY_CONFIG])
+def test_no_impersonation_returns_empty_kwargs(base_config):
+    """Without a target service account, no impersonation kwargs are emitted."""
+    connection = BigQueryConnection.model_validate(base_config)
+
+    assert get_impersonate_client_kwargs(connection) == {}
+
+
+@pytest.mark.parametrize("blank_email", ["", "   ", "\t", "\n  "])
+def test_blank_target_email_is_ignored(blank_email):
+    """An empty or whitespace-only impersonate email must not trigger impersonation."""
+    config = deepcopy(ADC_CONFIG)
+    config["credentials"]["gcpImpersonateServiceAccount"] = {
+        "impersonateServiceAccount": blank_email,
+        "lifetime": 3600,
+    }
+    connection = BigQueryConnection.model_validate(config)
+
+    assert get_impersonate_client_kwargs(connection) == {}
+
+
+def test_target_email_is_stripped():
+    """Surrounding whitespace on the target email is trimmed before use."""
+    config = deepcopy(ADC_CONFIG)
+    config["credentials"]["gcpImpersonateServiceAccount"] = {
+        "impersonateServiceAccount": f"  {TARGET_SA}  ",
+        "lifetime": 3600,
+    }
+    connection = BigQueryConnection.model_validate(config)
+
+    assert get_impersonate_client_kwargs(connection) == {
+        "impersonate_service_account": TARGET_SA,
+        "lifetime": 3600,
+    }
+
+
+@pytest.mark.parametrize(
+    "base_config,expected_project",
+    [(ADC_CONFIG, "proj-adc"), (JSON_KEY_CONFIG, "proj-key")],
+)
+@patch("metadata.ingestion.source.database.bigquery.connection.get_bigquery_client")
+@patch(
+    "metadata.ingestion.source.database.bigquery.connection.get_connection_args_common"
+)
+def test_engine_connect_args_inject_impersonated_client(
+    mock_common, mock_get_client, base_config, expected_project
+):
+    """
+    Path A: when impersonation is set, the SQLAlchemy connect args must carry a
+    pre-built impersonated client scoped to the configured project so that
+    queries run under the target identity.
+    """
+    mock_common.return_value = {}
+    sentinel_client = MagicMock(name="impersonated_bq_client")
+    mock_get_client.return_value = sentinel_client
+
+    connection = _with_impersonation(base_config, lifetime=1800)
+    connect_args = get_connection_args(connection)
+
+    assert connect_args["client"] is sentinel_client
+    mock_get_client.assert_called_once_with(
+        project_id=expected_project,
+        impersonate_service_account=TARGET_SA,
+        lifetime=1800,
+    )
+
+
+@patch("metadata.ingestion.source.database.bigquery.connection.get_bigquery_client")
+@patch(
+    "metadata.ingestion.source.database.bigquery.connection.get_connection_args_common"
+)
+def test_billing_project_id_scopes_impersonated_client(mock_common, mock_get_client):
+    """billingProjectId takes precedence over the credentials project id."""
+    mock_common.return_value = {}
+    mock_get_client.return_value = MagicMock()
+
+    config = deepcopy(ADC_CONFIG)
+    config["billingProjectId"] = "billing-proj"
+    config["credentials"]["gcpImpersonateServiceAccount"] = {
+        "impersonateServiceAccount": TARGET_SA,
+        "lifetime": 3600,
+    }
+    connection = BigQueryConnection.model_validate(config)
+
+    get_connection_args(connection)
+
+    mock_get_client.assert_called_once_with(
+        project_id="billing-proj",
+        impersonate_service_account=TARGET_SA,
+        lifetime=3600,
+    )
+
+
+@patch("metadata.ingestion.source.database.bigquery.connection.get_bigquery_client")
+@patch(
+    "metadata.ingestion.source.database.bigquery.connection.get_connection_args_common"
+)
+def test_credentials_path_scopes_impersonated_client(mock_common, mock_get_client):
+    """
+    A credentials-path config exposes a projectId, so the impersonated client is
+    scoped to it (guards the docstring's cross-type support claim).
+    """
+    mock_common.return_value = {}
+    mock_get_client.return_value = MagicMock()
+
+    config = {
+        "type": "BigQuery",
+        "credentials": {
+            "gcpConfig": {
+                "type": "gcp_credential_path",
+                "path": "/tmp/creds.json",
+                "projectId": "proj-path",
+            },
+            "gcpImpersonateServiceAccount": {
+                "impersonateServiceAccount": TARGET_SA,
+                "lifetime": 3600,
+            },
+        },
+    }
+    connection = BigQueryConnection.model_validate(config)
+
+    get_connection_args(connection)
+
+    mock_get_client.assert_called_once_with(
+        project_id="proj-path",
+        impersonate_service_account=TARGET_SA,
+        lifetime=3600,
+    )
+
+
+@patch("metadata.ingestion.source.database.bigquery.connection.logger")
+@patch("metadata.ingestion.source.database.bigquery.connection.get_bigquery_client")
+@patch(
+    "metadata.ingestion.source.database.bigquery.connection.get_connection_args_common"
+)
+def test_unresolved_project_id_logs_warning(mock_common, mock_get_client, mock_logger):
+    """
+    When neither billingProjectId nor a credentials projectId is available, the
+    impersonated client is still built (project resolved from the environment)
+    but a warning is logged to aid diagnosis.
+    """
+    mock_common.return_value = {}
+    mock_get_client.return_value = MagicMock()
+
+    config = {
+        "type": "BigQuery",
+        "credentials": {
+            "gcpConfig": {"type": "gcp_adc"},
+            "gcpImpersonateServiceAccount": {
+                "impersonateServiceAccount": TARGET_SA,
+                "lifetime": 3600,
+            },
+        },
+    }
+    connection = BigQueryConnection.model_validate(config)
+
+    get_connection_args(connection)
+
+    mock_logger.warning.assert_called_once()
+    mock_get_client.assert_called_once_with(
+        project_id=None,
+        impersonate_service_account=TARGET_SA,
+        lifetime=3600,
+    )
+
+
+@pytest.mark.parametrize("base_config", [ADC_CONFIG, JSON_KEY_CONFIG])
+@patch("metadata.ingestion.source.database.bigquery.connection.get_bigquery_client")
+@patch(
+    "metadata.ingestion.source.database.bigquery.connection.get_connection_args_common"
+)
+def test_engine_connect_args_unchanged_without_impersonation(
+    mock_common, mock_get_client, base_config
+):
+    """
+    Regression guard: without impersonation the connect args are exactly the
+    common args and NO client is injected, so existing behaviour is preserved.
+    """
+    mock_common.return_value = {"existing": "arg"}
+
+    connection = BigQueryConnection.model_validate(base_config)
+    connect_args = get_connection_args(connection)
+
+    assert connect_args == {"existing": "arg"}
+    assert "client" not in connect_args
+    mock_get_client.assert_not_called()
+
+
+@patch("metadata.utils.bigquery_utils.get_gcp_impersonate_credentials")
+@patch("metadata.utils.bigquery_utils.get_gcp_default_credentials")
+def test_get_bigquery_client_uses_impersonated_credentials(
+    mock_default, mock_impersonate
+):
+    """
+    The BigQuery client must be built with impersonated credentials targeting
+    the configured service account when impersonation is requested.
+    """
+    impersonated_creds = MagicMock(name="impersonated_creds")
+    mock_impersonate.return_value = impersonated_creds
+
+    with patch("google.cloud.bigquery.Client") as mock_bq_client:
+        get_bigquery_client(
+            project_id="proj-adc",
+            impersonate_service_account=TARGET_SA,
+            lifetime=1800,
+        )
+
+    mock_impersonate.assert_called_once_with(
+        impersonate_service_account=TARGET_SA,
+        quoted_project_id=None,
+        scopes=None,
+        lifetime=1800,
+    )
+    mock_default.assert_not_called()
+    _, client_kwargs = mock_bq_client.call_args
+    assert client_kwargs["credentials"] is impersonated_creds
+    assert client_kwargs["project"] == "proj-adc"
+
+
+@patch("metadata.utils.bigquery_utils.get_gcp_impersonate_credentials")
+@patch("metadata.utils.bigquery_utils.get_gcp_default_credentials")
+def test_get_bigquery_client_uses_default_credentials_without_impersonation(
+    mock_default, mock_impersonate
+):
+    """Without a target service account, default credentials are used as before."""
+    default_creds = MagicMock(name="default_creds")
+    mock_default.return_value = default_creds
+
+    with patch("google.cloud.bigquery.Client") as mock_bq_client:
+        get_bigquery_client(project_id="proj-adc")
+
+    mock_default.assert_called_once()
+    mock_impersonate.assert_not_called()
+    _, client_kwargs = mock_bq_client.call_args
+    assert client_kwargs["credentials"] is default_creds


### PR DESCRIPTION
cherry-pick(on 1.13): https://github.com/open-metadata/OpenMetadata/commit/e1873bc6f4719c08486805ae65e33e770b170fc5

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds BigQuery service account impersonation to more ingestion paths.

- Adds shared impersonation kwargs for BigQuery clients.
- Injects an impersonated BigQuery client into SQLAlchemy connect args.
- Adds unit tests for ADC, service account key, and credential-path impersonation cases.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The changed BigQuery impersonation engine path needs fixes before merging.

- A separate billing project can be used as the data project for the injected client.
- Regional datasets can be queried with a client that has no configured location.
- ADC-only configs can fall back to an implicit environment project.

ingestion/src/metadata/ingestion/source/database/bigquery/connection.py
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| ingestion/src/metadata/ingestion/source/database/bigquery/connection.py | Adds engine-side impersonation client injection; project and location handling can diverge from the SQLAlchemy URL. |
| ingestion/src/metadata/ingestion/source/database/bigquery/helper.py | Extracts impersonation kwargs and applies them to BigQuery inspector client creation. |
| ingestion/tests/unit/topology/database/test_bigquery_impersonation.py | Adds unit coverage for impersonation kwargs and client injection, but not separate billing projects or regional locations. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[BigQuery connection config] --> B[get_connection_args]
  B --> C{Impersonation target set?}
  C -- No --> D[Common connect args]
  C -- Yes --> E[Resolve project]
  E --> F[Build impersonated BigQuery client]
  F --> G[Inject client into SQLAlchemy connect args]
  G --> H[Engine queries and metadata reads use injected client]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
  A[BigQuery connection config] --> B[get_connection_args]
  B --> C{Impersonation target set?}
  C -- No --> D[Common connect args]
  C -- Yes --> E[Resolve project]
  E --> F[Build impersonated BigQuery client]
  F --> G[Inject client into SQLAlchemy connect args]
  G --> H[Engine queries and metadata reads use injected client]
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(bigquery): GCP service account imper..."](https://github.com/open-metadata/openmetadata/commit/6ecb77c00cd2fe6eb2f5c5cae5239fe50cc0bf43) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42283603)</sub>

> Greptile also left **3 inline comments** on this PR.

**Context used:**

- Context used - CLAUDE.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=52f0d9d9-cad1-4e7d-b070-de181a0aa5e7))

<!-- /greptile_comment -->