### PR TITLE
feat(mcp): unify read-tool pagination behind an opaque nextCursor contract

### DIFF
--- a/openmetadata-mcp/src/main/java/org/openmetadata/mcp/tools/SearchCompanyContextTool.java
+++ b/openmetadata-mcp/src/main/java/org/openmetadata/mcp/tools/SearchCompanyContextTool.java
@@ -8,12 +8,11 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
 import org.openmetadata.mcp.util.McpParams;
 import org.openmetadata.mcp.util.McpResponseTrim;
-import org.openmetadata.mcp.util.PageCursor;
 import org.openmetadata.mcp.util.ResponseBudget;
+import org.openmetadata.mcp.util.VectorPagingContract;
 import org.openmetadata.schema.entity.context.ContextMemorySourceType;
 import org.openmetadata.schema.entity.context.MemoryVisibility;
 import org.openmetadata.service.Entity;
@@ -66,7 +65,9 @@ public class SearchCompanyContextTool implements McpTool {
       result = errorResponse("Vector search service is not initialized");
     } else {
       int size = Math.min(Math.max(McpParams.getInt(params, "size", DEFAULT_SIZE), 1), MAX_SIZE);
-      int from = cursorOffsetOrDefault(params, Math.max(McpParams.getInt(params, "from", 0), 0));
+      int from =
+          VectorPagingContract.cursorOffsetOrDefault(
+              params, Math.max(McpParams.getInt(params, "from", 0), 0));
       try {
         VectorSearchResponse response =
             vectorService.search(
@@ -102,52 +103,14 @@ public class SearchCompanyContextTool implements McpTool {
     result.put("returnedCount", pills.size());
     int rawCount = pills.size();
     fitResultsToBudget(result, pills);
-    attachPagingContract(result, from, rawCount, requestedSize, response);
+    VectorPagingContract.attach(
+        result,
+        from,
+        rawCount,
+        requestedSize,
+        response,
+        "Showing %d knowledge pills. Pass 'nextCursor' to fetch the next page.");
     return result;
-  }
-
-  private static void attachPagingContract(
-      Map<String, Object> result,
-      int from,
-      int rawCount,
-      int requestedSize,
-      VectorSearchResponse response) {
-    int returned =
-        result.get("returnedCount") instanceof Number number ? number.intValue() : rawCount;
-    boolean budgetTrimmed = returned < rawCount;
-    boolean fullPage = rawCount >= requestedSize;
-    boolean moreInIndex = hasMoreInIndex(response, from, rawCount, fullPage);
-    if (budgetTrimmed || (fullPage && moreInIndex)) {
-      result.put(McpResponseTrim.HAS_MORE_KEY, Boolean.TRUE);
-      result.put(McpResponseTrim.NEXT_CURSOR_KEY, PageCursor.encodeOffset(from + returned));
-    }
-    if (fullPage && !budgetTrimmed && moreInIndex) {
-      result.put(
-          McpResponseTrim.MESSAGE_KEY,
-          String.format(
-              "Showing %d knowledge pills. Pass 'nextCursor' to fetch the next page.", returned));
-    }
-  }
-
-  private static boolean hasMoreInIndex(
-      VectorSearchResponse response, int from, int rawCount, boolean fullPage) {
-    if (response.getTotalHits() != null) {
-      return (long) from + rawCount < response.getTotalHits();
-    }
-    if (response.getHasMore() != null) {
-      return response.getHasMore();
-    }
-    return fullPage;
-  }
-
-  private static int cursorOffsetOrDefault(Map<String, Object> params, int defaultFrom) {
-    int from = defaultFrom;
-    String token = params.get("cursor") instanceof String value ? value : null;
-    Optional<PageCursor.Cursor> cursor = PageCursor.decode(token);
-    if (cursor.isPresent() && cursor.get().isOffset()) {
-      from = cursor.get().offset();
-    }
-    return from;
   }
 
   /**

--- a/openmetadata-mcp/src/main/java/org/openmetadata/mcp/tools/SearchCompanyContextTool.java
+++ b/openmetadata-mcp/src/main/java/org/openmetadata/mcp/tools/SearchCompanyContextTool.java
@@ -102,7 +102,8 @@ public class SearchCompanyContextTool implements McpTool {
     result.put("returnedCount", pills.size());
     int rawCount = pills.size();
     fitResultsToBudget(result, pills);
-    attachPagingContract(result, from, rawCount, requestedSize);
+    long totalHits = response.getTotalHits() != null ? response.getTotalHits() : Long.MAX_VALUE;
+    attachPagingContract(result, from, rawCount, requestedSize, totalHits);
     return result;
   }
 
@@ -113,16 +114,17 @@ public class SearchCompanyContextTool implements McpTool {
    * requested size, so a trimmed page never skips the pills it dropped.
    */
   private static void attachPagingContract(
-      Map<String, Object> result, int from, int rawCount, int requestedSize) {
+      Map<String, Object> result, int from, int rawCount, int requestedSize, long totalHits) {
     int returned =
         result.get("returnedCount") instanceof Number number ? number.intValue() : rawCount;
     boolean budgetTrimmed = returned < rawCount;
     boolean fullPage = rawCount >= requestedSize;
-    if (fullPage || budgetTrimmed) {
+    boolean moreInIndex = (long) from + rawCount < totalHits;
+    if (budgetTrimmed || (fullPage && moreInIndex)) {
       result.put(McpResponseTrim.HAS_MORE_KEY, Boolean.TRUE);
       result.put(McpResponseTrim.NEXT_CURSOR_KEY, PageCursor.encodeOffset(from + returned));
     }
-    if (fullPage && !budgetTrimmed) {
+    if (fullPage && !budgetTrimmed && moreInIndex) {
       result.put(
           McpResponseTrim.MESSAGE_KEY,
           String.format(

--- a/openmetadata-mcp/src/main/java/org/openmetadata/mcp/tools/SearchCompanyContextTool.java
+++ b/openmetadata-mcp/src/main/java/org/openmetadata/mcp/tools/SearchCompanyContextTool.java
@@ -102,24 +102,21 @@ public class SearchCompanyContextTool implements McpTool {
     result.put("returnedCount", pills.size());
     int rawCount = pills.size();
     fitResultsToBudget(result, pills);
-    long totalHits = response.getTotalHits() != null ? response.getTotalHits() : Long.MAX_VALUE;
-    attachPagingContract(result, from, rawCount, requestedSize, totalHits);
+    attachPagingContract(result, from, rawCount, requestedSize, response);
     return result;
   }
 
-  /**
-   * Sets the unified paging markers so callers can walk past page 1 — previously this tool searched
-   * at a fixed offset of 0 and gave no {@code nextCursor}, stranding results beyond the first page.
-   * {@code nextCursor} advances by the count actually returned (after any budget trim), never the
-   * requested size, so a trimmed page never skips the pills it dropped.
-   */
   private static void attachPagingContract(
-      Map<String, Object> result, int from, int rawCount, int requestedSize, long totalHits) {
+      Map<String, Object> result,
+      int from,
+      int rawCount,
+      int requestedSize,
+      VectorSearchResponse response) {
     int returned =
         result.get("returnedCount") instanceof Number number ? number.intValue() : rawCount;
     boolean budgetTrimmed = returned < rawCount;
     boolean fullPage = rawCount >= requestedSize;
-    boolean moreInIndex = (long) from + rawCount < totalHits;
+    boolean moreInIndex = hasMoreInIndex(response, from, rawCount, fullPage);
     if (budgetTrimmed || (fullPage && moreInIndex)) {
       result.put(McpResponseTrim.HAS_MORE_KEY, Boolean.TRUE);
       result.put(McpResponseTrim.NEXT_CURSOR_KEY, PageCursor.encodeOffset(from + returned));
@@ -130,6 +127,17 @@ public class SearchCompanyContextTool implements McpTool {
           String.format(
               "Showing %d knowledge pills. Pass 'nextCursor' to fetch the next page.", returned));
     }
+  }
+
+  private static boolean hasMoreInIndex(
+      VectorSearchResponse response, int from, int rawCount, boolean fullPage) {
+    if (response.getTotalHits() != null) {
+      return (long) from + rawCount < response.getTotalHits();
+    }
+    if (response.getHasMore() != null) {
+      return response.getHasMore();
+    }
+    return fullPage;
   }
 
   private static int cursorOffsetOrDefault(Map<String, Object> params, int defaultFrom) {

--- a/openmetadata-mcp/src/main/java/org/openmetadata/mcp/tools/SearchCompanyContextTool.java
+++ b/openmetadata-mcp/src/main/java/org/openmetadata/mcp/tools/SearchCompanyContextTool.java
@@ -8,9 +8,11 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
 import org.openmetadata.mcp.util.McpParams;
 import org.openmetadata.mcp.util.McpResponseTrim;
+import org.openmetadata.mcp.util.PageCursor;
 import org.openmetadata.mcp.util.ResponseBudget;
 import org.openmetadata.schema.entity.context.ContextMemorySourceType;
 import org.openmetadata.schema.entity.context.MemoryVisibility;
@@ -64,11 +66,12 @@ public class SearchCompanyContextTool implements McpTool {
       result = errorResponse("Vector search service is not initialized");
     } else {
       int size = Math.min(Math.max(McpParams.getInt(params, "size", DEFAULT_SIZE), 1), MAX_SIZE);
+      int from = cursorOffsetOrDefault(params, Math.max(McpParams.getInt(params, "from", 0), 0));
       try {
         VectorSearchResponse response =
             vectorService.search(
-                query, companyContextFilters(), size, 0, DEFAULT_K, DEFAULT_THRESHOLD);
-        result = buildResponse(query, response);
+                query, companyContextFilters(), size, from, DEFAULT_K, DEFAULT_THRESHOLD);
+        result = buildResponse(query, response, size, from);
       } catch (Exception e) {
         LOG.error("Company context search failed: {}", e.getMessage(), e);
         result = errorResponse("Company context search failed: " + McpResponseTrim.safeMessage(e));
@@ -85,7 +88,8 @@ public class SearchCompanyContextTool implements McpTool {
     return filters;
   }
 
-  private Map<String, Object> buildResponse(String query, VectorSearchResponse response) {
+  private Map<String, Object> buildResponse(
+      String query, VectorSearchResponse response, int requestedSize, int from) {
     List<Map<String, Object>> pills = new ArrayList<>();
     if (response.getHits() != null) {
       for (Map<String, Object> hit : response.getHits()) {
@@ -96,8 +100,44 @@ public class SearchCompanyContextTool implements McpTool {
     result.put("query", query);
     result.put("results", pills);
     result.put("returnedCount", pills.size());
+    int rawCount = pills.size();
     fitResultsToBudget(result, pills);
+    attachPagingContract(result, from, rawCount, requestedSize);
     return result;
+  }
+
+  /**
+   * Sets the unified paging markers so callers can walk past page 1 — previously this tool searched
+   * at a fixed offset of 0 and gave no {@code nextCursor}, stranding results beyond the first page.
+   * {@code nextCursor} advances by the count actually returned (after any budget trim), never the
+   * requested size, so a trimmed page never skips the pills it dropped.
+   */
+  private static void attachPagingContract(
+      Map<String, Object> result, int from, int rawCount, int requestedSize) {
+    int returned =
+        result.get("returnedCount") instanceof Number number ? number.intValue() : rawCount;
+    boolean budgetTrimmed = returned < rawCount;
+    boolean fullPage = rawCount >= requestedSize;
+    if (fullPage || budgetTrimmed) {
+      result.put(McpResponseTrim.HAS_MORE_KEY, Boolean.TRUE);
+      result.put(McpResponseTrim.NEXT_CURSOR_KEY, PageCursor.encodeOffset(from + returned));
+    }
+    if (fullPage && !budgetTrimmed) {
+      result.put(
+          McpResponseTrim.MESSAGE_KEY,
+          String.format(
+              "Showing %d knowledge pills. Pass 'nextCursor' to fetch the next page.", returned));
+    }
+  }
+
+  private static int cursorOffsetOrDefault(Map<String, Object> params, int defaultFrom) {
+    int from = defaultFrom;
+    String token = params.get("cursor") instanceof String value ? value : null;
+    Optional<PageCursor.Cursor> cursor = PageCursor.decode(token);
+    if (cursor.isPresent() && cursor.get().isOffset()) {
+      from = cursor.get().offset();
+    }
+    return from;
   }
 
   /**

--- a/openmetadata-mcp/src/main/java/org/openmetadata/mcp/tools/SearchMetadataTool.java
+++ b/openmetadata-mcp/src/main/java/org/openmetadata/mcp/tools/SearchMetadataTool.java
@@ -392,7 +392,7 @@ public class SearchMetadataTool implements McpTool {
       result.put("hasMore", true);
     }
 
-    fitResultsToBudget(result, cleanedResults, totalResults, from, query);
+    fitResultsToBudget(result, cleanedResults, totalResults, query);
     attachPagingContract(result, from, totalResults);
 
     return result;
@@ -424,7 +424,6 @@ public class SearchMetadataTool implements McpTool {
       Map<String, Object> result,
       List<Map<String, Object>> cleanedResults,
       long totalResults,
-      int from,
       String query) {
     long overhead = overheadWithoutResults(result);
     int fit = ResponseBudget.fitCount(cleanedResults, overhead);
@@ -442,8 +441,8 @@ public class SearchMetadataTool implements McpTool {
           "message",
           String.format(
               "Returning %d of %d results to stay within the response size budget. "
-                  + "Fetch more with 'from'=%d, or narrow the query with a service, schema, or name.",
-              trimmed.size(), totalResults, from + trimmed.size()));
+                  + "Pass 'nextCursor' to fetch the next page, or narrow the query.",
+              trimmed.size(), totalResults));
     }
   }
 

--- a/openmetadata-mcp/src/main/java/org/openmetadata/mcp/tools/SearchMetadataTool.java
+++ b/openmetadata-mcp/src/main/java/org/openmetadata/mcp/tools/SearchMetadataTool.java
@@ -380,7 +380,8 @@ public class SearchMetadataTool implements McpTool {
       }
     }
 
-    if (totalResults > requestedLimit) {
+    boolean moreInIndex = (long) from + cleanedResults.size() < totalResults;
+    if (moreInIndex) {
       result.put(
           "message",
           String.format(

--- a/openmetadata-mcp/src/main/java/org/openmetadata/mcp/tools/SearchMetadataTool.java
+++ b/openmetadata-mcp/src/main/java/org/openmetadata/mcp/tools/SearchMetadataTool.java
@@ -13,10 +13,12 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import lombok.extern.slf4j.Slf4j;
 import org.openmetadata.mcp.util.McpResponseTrim;
+import org.openmetadata.mcp.util.PageCursor;
 import org.openmetadata.mcp.util.ResponseBudget;
 import org.openmetadata.schema.search.SearchRequest;
 import org.openmetadata.schema.utils.JsonUtils;
@@ -138,6 +140,10 @@ public class SearchMetadataTool implements McpTool {
           from = 0;
         }
       }
+    }
+    Optional<PageCursor.Cursor> cursor = PageCursor.decode(stringParam(params, "cursor", null));
+    if (cursor.isPresent() && cursor.get().isOffset()) {
+      from = cursor.get().offset();
     }
 
     size = Math.min(size, 50);
@@ -386,8 +392,24 @@ public class SearchMetadataTool implements McpTool {
     }
 
     fitResultsToBudget(result, cleanedResults, totalResults, from, query);
+    attachPagingContract(result, from, totalResults);
 
     return result;
+  }
+
+  /**
+   * Sets the unified paging markers. {@code total} is the real ES hit count; {@code nextCursor}
+   * advances by the count actually returned this page (after any budget trim) so the next call never
+   * skips rows. Emitted only when {@code hasMore} was set — either the total exceeds this page or the
+   * size budget trimmed it.
+   */
+  private static void attachPagingContract(
+      Map<String, Object> result, int from, long totalResults) {
+    result.put(McpResponseTrim.TOTAL_KEY, totalResults);
+    int returned = result.get("returnedCount") instanceof Number number ? number.intValue() : 0;
+    if (Boolean.TRUE.equals(result.get(McpResponseTrim.HAS_MORE_KEY))) {
+      result.put(McpResponseTrim.NEXT_CURSOR_KEY, PageCursor.encodeOffset(from + returned));
+    }
   }
 
   /**

--- a/openmetadata-mcp/src/main/java/org/openmetadata/mcp/tools/SearchMetadataTool.java
+++ b/openmetadata-mcp/src/main/java/org/openmetadata/mcp/tools/SearchMetadataTool.java
@@ -408,8 +408,11 @@ public class SearchMetadataTool implements McpTool {
       Map<String, Object> result, int from, long totalResults) {
     result.put(McpResponseTrim.TOTAL_KEY, totalResults);
     int returned = result.get("returnedCount") instanceof Number number ? number.intValue() : 0;
-    if (Boolean.TRUE.equals(result.get(McpResponseTrim.HAS_MORE_KEY))) {
+    if (Boolean.TRUE.equals(result.get(McpResponseTrim.HAS_MORE_KEY)) && returned > 0) {
       result.put(McpResponseTrim.NEXT_CURSOR_KEY, PageCursor.encodeOffset(from + returned));
+    } else if (returned == 0) {
+      result.remove(McpResponseTrim.HAS_MORE_KEY);
+      result.remove(McpResponseTrim.MESSAGE_KEY);
     }
   }
 

--- a/openmetadata-mcp/src/main/java/org/openmetadata/mcp/tools/SemanticSearchTool.java
+++ b/openmetadata-mcp/src/main/java/org/openmetadata/mcp/tools/SemanticSearchTool.java
@@ -6,12 +6,11 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
 import org.openmetadata.mcp.util.McpParams;
 import org.openmetadata.mcp.util.McpResponseTrim;
-import org.openmetadata.mcp.util.PageCursor;
 import org.openmetadata.mcp.util.ResponseBudget;
+import org.openmetadata.mcp.util.VectorPagingContract;
 import org.openmetadata.schema.utils.JsonUtils;
 import org.openmetadata.service.Entity;
 import org.openmetadata.service.limits.Limits;
@@ -55,7 +54,7 @@ public class SemanticSearchTool implements McpTool {
 
     int from = McpParams.getInt(params, "from", 0);
     from = Math.max(from, 0);
-    from = cursorOffsetOrDefault(params, from);
+    from = VectorPagingContract.cursorOffsetOrDefault(params, from);
 
     int k = McpParams.getInt(params, "k", DEFAULT_K);
     k = Math.min(Math.max(k, 1), MAX_K);
@@ -113,61 +112,15 @@ public class SemanticSearchTool implements McpTool {
 
     int rawCount = cleanedResults.size();
     fitResultsToBudget(result, cleanedResults);
-    attachPagingContract(result, from, rawCount, requestedSize, response);
+    VectorPagingContract.attach(
+        result,
+        from,
+        rawCount,
+        requestedSize,
+        response,
+        "Showing %d results. Pass 'nextCursor' to fetch the next page, or refine your query. "
+            + "Adjust 'threshold' to filter by similarity score.");
     return result;
-  }
-
-  /**
-   * Sets the unified paging markers after budget trimming. {@code nextCursor} advances by the count
-   * actually returned this page (not the requested size), so a budget-trimmed page never skips the
-   * rows it dropped. A full page ({@code rawCount >= requestedSize}) implies more candidates remain
-   * in the top-k, so it is paged too — previously only the budget-trim path signalled {@code
-   * hasMore}, leaving a full page with no way forward.
-   */
-  private static void attachPagingContract(
-      Map<String, Object> result,
-      int from,
-      int rawCount,
-      int requestedSize,
-      VectorSearchResponse response) {
-    int returned =
-        result.get("returnedCount") instanceof Number number ? number.intValue() : rawCount;
-    boolean budgetTrimmed = returned < rawCount;
-    boolean fullPage = rawCount >= requestedSize;
-    boolean moreInIndex = hasMoreInIndex(response, from, rawCount, fullPage);
-    if (budgetTrimmed || (fullPage && moreInIndex)) {
-      result.put(McpResponseTrim.HAS_MORE_KEY, Boolean.TRUE);
-      result.put(McpResponseTrim.NEXT_CURSOR_KEY, PageCursor.encodeOffset(from + returned));
-    }
-    if (fullPage && !budgetTrimmed && moreInIndex) {
-      result.put(
-          McpResponseTrim.MESSAGE_KEY,
-          String.format(
-              "Showing %d results. Pass 'nextCursor' to fetch the next page, or refine your query. "
-                  + "Adjust 'threshold' to filter by similarity score.",
-              returned));
-    }
-  }
-
-  private static boolean hasMoreInIndex(
-      VectorSearchResponse response, int from, int rawCount, boolean fullPage) {
-    if (response.getTotalHits() != null) {
-      return (long) from + rawCount < response.getTotalHits();
-    }
-    if (response.getHasMore() != null) {
-      return response.getHasMore();
-    }
-    return fullPage;
-  }
-
-  private static int cursorOffsetOrDefault(Map<String, Object> params, int defaultFrom) {
-    int from = defaultFrom;
-    String token = params.get("cursor") instanceof String value ? value : null;
-    Optional<PageCursor.Cursor> cursor = PageCursor.decode(token);
-    if (cursor.isPresent() && cursor.get().isOffset()) {
-      from = cursor.get().offset();
-    }
-    return from;
   }
 
   /**

--- a/openmetadata-mcp/src/main/java/org/openmetadata/mcp/tools/SemanticSearchTool.java
+++ b/openmetadata-mcp/src/main/java/org/openmetadata/mcp/tools/SemanticSearchTool.java
@@ -6,9 +6,11 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
 import org.openmetadata.mcp.util.McpParams;
 import org.openmetadata.mcp.util.McpResponseTrim;
+import org.openmetadata.mcp.util.PageCursor;
 import org.openmetadata.mcp.util.ResponseBudget;
 import org.openmetadata.schema.utils.JsonUtils;
 import org.openmetadata.service.Entity;
@@ -53,6 +55,7 @@ public class SemanticSearchTool implements McpTool {
 
     int from = McpParams.getInt(params, "from", 0);
     from = Math.max(from, 0);
+    from = cursorOffsetOrDefault(params, from);
 
     int k = McpParams.getInt(params, "k", DEFAULT_K);
     k = Math.min(Math.max(k, 1), MAX_K);
@@ -65,7 +68,7 @@ public class SemanticSearchTool implements McpTool {
     try {
       VectorSearchResponse response =
           vectorService.search(query, filters, size, from, k, threshold);
-      return buildResponse(query, response, size);
+      return buildResponse(query, response, size, from);
     } catch (Exception e) {
       LOG.error("Semantic search failed: {}", e.getMessage(), e);
       return errorResponse("Semantic search failed: " + McpResponseTrim.safeMessage(e));
@@ -83,7 +86,7 @@ public class SemanticSearchTool implements McpTool {
   }
 
   private Map<String, Object> buildResponse(
-      String query, VectorSearchResponse response, int requestedSize) {
+      String query, VectorSearchResponse response, int requestedSize, int from) {
     Map<String, Object> result = new HashMap<>();
     result.put("query", query);
     result.put("tookMillis", response.getTookMillis());
@@ -108,17 +111,47 @@ public class SemanticSearchTool implements McpTool {
         "usage",
         "To get full details for any result, call get_entity_details with the result's exact 'entityType' and 'fullyQualifiedName' values.");
 
-    if (cleanedResults.size() >= requestedSize) {
-      result.put(
-          "message",
-          String.format(
-              "Showing %d results. Increase 'size' or refine your query for different results. "
-                  + "Adjust 'threshold' to filter by similarity score.",
-              cleanedResults.size()));
-    }
-
+    int rawCount = cleanedResults.size();
     fitResultsToBudget(result, cleanedResults);
+    attachPagingContract(result, from, rawCount, requestedSize);
     return result;
+  }
+
+  /**
+   * Sets the unified paging markers after budget trimming. {@code nextCursor} advances by the count
+   * actually returned this page (not the requested size), so a budget-trimmed page never skips the
+   * rows it dropped. A full page ({@code rawCount >= requestedSize}) implies more candidates remain
+   * in the top-k, so it is paged too — previously only the budget-trim path signalled {@code
+   * hasMore}, leaving a full page with no way forward.
+   */
+  private static void attachPagingContract(
+      Map<String, Object> result, int from, int rawCount, int requestedSize) {
+    int returned =
+        result.get("returnedCount") instanceof Number number ? number.intValue() : rawCount;
+    boolean budgetTrimmed = returned < rawCount;
+    boolean fullPage = rawCount >= requestedSize;
+    if (fullPage || budgetTrimmed) {
+      result.put(McpResponseTrim.HAS_MORE_KEY, Boolean.TRUE);
+      result.put(McpResponseTrim.NEXT_CURSOR_KEY, PageCursor.encodeOffset(from + returned));
+    }
+    if (fullPage && !budgetTrimmed) {
+      result.put(
+          McpResponseTrim.MESSAGE_KEY,
+          String.format(
+              "Showing %d results. Pass 'nextCursor' to fetch the next page, or refine your query. "
+                  + "Adjust 'threshold' to filter by similarity score.",
+              returned));
+    }
+  }
+
+  private static int cursorOffsetOrDefault(Map<String, Object> params, int defaultFrom) {
+    int from = defaultFrom;
+    String token = params.get("cursor") instanceof String value ? value : null;
+    Optional<PageCursor.Cursor> cursor = PageCursor.decode(token);
+    if (cursor.isPresent() && cursor.get().isOffset()) {
+      from = cursor.get().offset();
+    }
+    return from;
   }
 
   /**

--- a/openmetadata-mcp/src/main/java/org/openmetadata/mcp/tools/SemanticSearchTool.java
+++ b/openmetadata-mcp/src/main/java/org/openmetadata/mcp/tools/SemanticSearchTool.java
@@ -113,8 +113,7 @@ public class SemanticSearchTool implements McpTool {
 
     int rawCount = cleanedResults.size();
     fitResultsToBudget(result, cleanedResults);
-    long totalHits = response.getTotalHits() != null ? response.getTotalHits() : Long.MAX_VALUE;
-    attachPagingContract(result, from, rawCount, requestedSize, totalHits);
+    attachPagingContract(result, from, rawCount, requestedSize, response);
     return result;
   }
 
@@ -126,12 +125,16 @@ public class SemanticSearchTool implements McpTool {
    * hasMore}, leaving a full page with no way forward.
    */
   private static void attachPagingContract(
-      Map<String, Object> result, int from, int rawCount, int requestedSize, long totalHits) {
+      Map<String, Object> result,
+      int from,
+      int rawCount,
+      int requestedSize,
+      VectorSearchResponse response) {
     int returned =
         result.get("returnedCount") instanceof Number number ? number.intValue() : rawCount;
     boolean budgetTrimmed = returned < rawCount;
     boolean fullPage = rawCount >= requestedSize;
-    boolean moreInIndex = (long) from + rawCount < totalHits;
+    boolean moreInIndex = hasMoreInIndex(response, from, rawCount, fullPage);
     if (budgetTrimmed || (fullPage && moreInIndex)) {
       result.put(McpResponseTrim.HAS_MORE_KEY, Boolean.TRUE);
       result.put(McpResponseTrim.NEXT_CURSOR_KEY, PageCursor.encodeOffset(from + returned));
@@ -144,6 +147,17 @@ public class SemanticSearchTool implements McpTool {
                   + "Adjust 'threshold' to filter by similarity score.",
               returned));
     }
+  }
+
+  private static boolean hasMoreInIndex(
+      VectorSearchResponse response, int from, int rawCount, boolean fullPage) {
+    if (response.getTotalHits() != null) {
+      return (long) from + rawCount < response.getTotalHits();
+    }
+    if (response.getHasMore() != null) {
+      return response.getHasMore();
+    }
+    return fullPage;
   }
 
   private static int cursorOffsetOrDefault(Map<String, Object> params, int defaultFrom) {

--- a/openmetadata-mcp/src/main/java/org/openmetadata/mcp/tools/SemanticSearchTool.java
+++ b/openmetadata-mcp/src/main/java/org/openmetadata/mcp/tools/SemanticSearchTool.java
@@ -113,7 +113,8 @@ public class SemanticSearchTool implements McpTool {
 
     int rawCount = cleanedResults.size();
     fitResultsToBudget(result, cleanedResults);
-    attachPagingContract(result, from, rawCount, requestedSize);
+    long totalHits = response.getTotalHits() != null ? response.getTotalHits() : Long.MAX_VALUE;
+    attachPagingContract(result, from, rawCount, requestedSize, totalHits);
     return result;
   }
 
@@ -125,16 +126,17 @@ public class SemanticSearchTool implements McpTool {
    * hasMore}, leaving a full page with no way forward.
    */
   private static void attachPagingContract(
-      Map<String, Object> result, int from, int rawCount, int requestedSize) {
+      Map<String, Object> result, int from, int rawCount, int requestedSize, long totalHits) {
     int returned =
         result.get("returnedCount") instanceof Number number ? number.intValue() : rawCount;
     boolean budgetTrimmed = returned < rawCount;
     boolean fullPage = rawCount >= requestedSize;
-    if (fullPage || budgetTrimmed) {
+    boolean moreInIndex = (long) from + rawCount < totalHits;
+    if (budgetTrimmed || (fullPage && moreInIndex)) {
       result.put(McpResponseTrim.HAS_MORE_KEY, Boolean.TRUE);
       result.put(McpResponseTrim.NEXT_CURSOR_KEY, PageCursor.encodeOffset(from + returned));
     }
-    if (fullPage && !budgetTrimmed) {
+    if (fullPage && !budgetTrimmed && moreInIndex) {
       result.put(
           McpResponseTrim.MESSAGE_KEY,
           String.format(

--- a/openmetadata-mcp/src/main/java/org/openmetadata/mcp/tools/TestDefinitionsTool.java
+++ b/openmetadata-mcp/src/main/java/org/openmetadata/mcp/tools/TestDefinitionsTool.java
@@ -1,9 +1,12 @@
 package org.openmetadata.mcp.tools;
 
+import com.google.common.annotations.VisibleForTesting;
 import java.util.Map;
+import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
 import org.openmetadata.mcp.util.McpParams;
 import org.openmetadata.mcp.util.McpResponseTrim;
+import org.openmetadata.mcp.util.PageCursor;
 import org.openmetadata.mcp.util.ResponseBudget;
 import org.openmetadata.schema.tests.TestPlatform;
 import org.openmetadata.schema.type.Include;
@@ -37,13 +40,45 @@ public class TestDefinitionsTool implements McpTool {
     int limit = resolveLimit(params);
     String entityType = stringParam(params, "entityType", DEFAULT_ENTITY_TYPE);
     String testPlatform = stringParam(params, "testPlatform", TestPlatform.OPEN_METADATA.value());
-    String after = stringParam(params, "after", null);
+    String after = keysetCursorOrAfter(params);
     LOG.info(
         "Listing test definitions for entityType: {}, testPlatform: {}, limit: {}",
         entityType,
         testPlatform,
         limit);
-    return listWithinBudget(buildFilter(entityType, testPlatform), limit, after);
+    Map<String, Object> page =
+        listWithinBudget(buildFilter(entityType, testPlatform), limit, after);
+    attachPagingContract(page);
+    return page;
+  }
+
+  private static String keysetCursorOrAfter(Map<String, Object> params) {
+    String after = stringParam(params, "after", null);
+    Optional<PageCursor.Cursor> cursor = PageCursor.decode(stringParam(params, "cursor", null));
+    if (cursor.isPresent() && !cursor.get().isOffset()) {
+      after = cursor.get().after();
+    }
+    return after;
+  }
+
+  /**
+   * Surfaces the repository's native keyset cursor as the unified {@code nextCursor}/{@code hasMore}/
+   * {@code total} markers. {@code listAfter} sets {@code paging.after} to the token for the next page
+   * (null on the last page); wrapping it in {@link PageCursor} keeps the wire contract identical to
+   * the offset-based tools while preserving keyset write-stability underneath.
+   */
+  @VisibleForTesting
+  static void attachPagingContract(Map<String, Object> page) {
+    if (page.get("paging") instanceof Map<?, ?> paging) {
+      Object total = paging.get("total");
+      if (total != null) {
+        page.put(McpResponseTrim.TOTAL_KEY, total);
+      }
+      if (paging.get("after") instanceof String nativeAfter && !nativeAfter.isBlank()) {
+        page.put(McpResponseTrim.HAS_MORE_KEY, Boolean.TRUE);
+        page.put(McpResponseTrim.NEXT_CURSOR_KEY, PageCursor.encodeKeyset(nativeAfter));
+      }
+    }
   }
 
   private static int resolveLimit(Map<String, Object> params) {

--- a/openmetadata-mcp/src/main/java/org/openmetadata/mcp/util/McpResponseTrim.java
+++ b/openmetadata-mcp/src/main/java/org/openmetadata/mcp/util/McpResponseTrim.java
@@ -55,6 +55,8 @@ public final class McpResponseTrim {
   public static final String MAX_RESPONSE_CHARS_KEY = "maxResponseChars";
   public static final String HAS_MORE_KEY = "hasMore";
   public static final String NEXT_OFFSET_KEY = "nextOffset";
+  public static final String NEXT_CURSOR_KEY = "nextCursor";
+  public static final String TOTAL_KEY = "total";
   public static final String MESSAGE_KEY = "message";
 
   /**

--- a/openmetadata-mcp/src/main/java/org/openmetadata/mcp/util/PageCursor.java
+++ b/openmetadata-mcp/src/main/java/org/openmetadata/mcp/util/PageCursor.java
@@ -1,0 +1,97 @@
+package org.openmetadata.mcp.util;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.Map;
+import java.util.Optional;
+import lombok.extern.slf4j.Slf4j;
+import org.openmetadata.schema.utils.JsonUtils;
+
+/**
+ * Opaque page-cursor codec shared by the paginating MCP read tools. A cursor is the base64 of a tiny
+ * JSON tag ({@code {"t":"o","v":60}} for an offset page, {@code {"t":"k","v":"<afterId>"}} for a
+ * keyset page). Tools hand the encoded string back as {@code nextCursor}; the LLM client echoes it
+ * verbatim on the next call. Because the client never inspects the token, each tool can carry
+ * whatever paging state is correct for it (ES {@code from} offset, repository {@code listAfter} id)
+ * behind one uniform wire field.
+ *
+ * <p>{@link #decode} never throws: a null, blank or malformed token yields {@link Optional#empty()}
+ * so the tool falls back to the first page rather than surfacing an error the client cannot act on.
+ */
+@Slf4j
+public final class PageCursor {
+
+  private static final String TYPE_KEY = "t";
+  private static final String VALUE_KEY = "v";
+  private static final String OFFSET_TAG = "o";
+  private static final String KEYSET_TAG = "k";
+
+  private PageCursor() {}
+
+  /** Paging mechanism a decoded cursor represents. */
+  public enum Kind {
+    OFFSET,
+    KEYSET
+  }
+
+  /**
+   * Decoded cursor. {@code offset} is meaningful only for {@link Kind#OFFSET}; {@code after} only for
+   * {@link Kind#KEYSET}. Use {@link #isOffset()} to branch.
+   */
+  public record Cursor(Kind kind, int offset, String after) {
+    public boolean isOffset() {
+      return kind == Kind.OFFSET;
+    }
+  }
+
+  /** Encodes an offset page (start index of the next page). */
+  public static String encodeOffset(int from) {
+    return encode(OFFSET_TAG, from);
+  }
+
+  /** Encodes a keyset page (the repository {@code after} id for the next page). */
+  public static String encodeKeyset(String after) {
+    return encode(KEYSET_TAG, after);
+  }
+
+  /** Decodes a token to a cursor, or empty when the token is absent or unusable. */
+  public static Optional<Cursor> decode(String token) {
+    Optional<Cursor> result = Optional.empty();
+    if (token != null && !token.isBlank()) {
+      result = tryDecode(token);
+    }
+    return result;
+  }
+
+  private static Optional<Cursor> tryDecode(String token) {
+    Optional<Cursor> result = Optional.empty();
+    try {
+      byte[] raw = Base64.getUrlDecoder().decode(token);
+      Map<String, Object> map =
+          JsonUtils.readValue(new String(raw, StandardCharsets.UTF_8), Map.class);
+      result = fromMap(map);
+    } catch (Exception ex) {
+      LOG.debug("Ignoring malformed page cursor '{}': {}", token, ex.getMessage());
+    }
+    return result;
+  }
+
+  private static Optional<Cursor> fromMap(Map<String, Object> map) {
+    Optional<Cursor> result = Optional.empty();
+    Object type = map.get(TYPE_KEY);
+    Object value = map.get(VALUE_KEY);
+    if (OFFSET_TAG.equals(type) && value instanceof Number number) {
+      result = Optional.of(new Cursor(Kind.OFFSET, number.intValue(), null));
+    } else if (KEYSET_TAG.equals(type) && value instanceof String after) {
+      result = Optional.of(new Cursor(Kind.KEYSET, 0, after));
+    }
+    return result;
+  }
+
+  private static String encode(String type, Object value) {
+    String json = JsonUtils.pojoToJson(Map.of(TYPE_KEY, type, VALUE_KEY, value));
+    return Base64.getUrlEncoder()
+        .withoutPadding()
+        .encodeToString(json.getBytes(StandardCharsets.UTF_8));
+  }
+}

--- a/openmetadata-mcp/src/main/java/org/openmetadata/mcp/util/VectorPagingContract.java
+++ b/openmetadata-mcp/src/main/java/org/openmetadata/mcp/util/VectorPagingContract.java
@@ -19,8 +19,9 @@ public final class VectorPagingContract {
         result.get("returnedCount") instanceof Number number ? number.intValue() : rawCount;
     boolean budgetTrimmed = returned < rawCount;
     boolean fullPage = rawCount >= requestedSize;
-    boolean moreInIndex = hasMoreInIndex(response, from, rawCount, fullPage);
-    if (budgetTrimmed || (fullPage && moreInIndex)) {
+    boolean moreInIndex = hasMoreInIndex(response, from, rawCount);
+    boolean canAdvance = returned > 0;
+    if (canAdvance && (budgetTrimmed || (fullPage && moreInIndex))) {
       result.put(McpResponseTrim.HAS_MORE_KEY, Boolean.TRUE);
       result.put(McpResponseTrim.NEXT_CURSOR_KEY, PageCursor.encodeOffset(from + returned));
     }
@@ -39,14 +40,14 @@ public final class VectorPagingContract {
     return from;
   }
 
-  static boolean hasMoreInIndex(
-      VectorSearchResponse response, int from, int rawCount, boolean fullPage) {
+  static boolean hasMoreInIndex(VectorSearchResponse response, int from, int rawCount) {
     if (response.getTotalHits() != null) {
       return (long) from + rawCount < response.getTotalHits();
     }
     if (response.getHasMore() != null) {
       return response.getHasMore();
     }
-    return fullPage;
+    // No authoritative signal; assume no more rather than risk advertising a phantom page.
+    return false;
   }
 }

--- a/openmetadata-mcp/src/main/java/org/openmetadata/mcp/util/VectorPagingContract.java
+++ b/openmetadata-mcp/src/main/java/org/openmetadata/mcp/util/VectorPagingContract.java
@@ -24,6 +24,9 @@ public final class VectorPagingContract {
     if (canAdvance && (budgetTrimmed || (fullPage && moreInIndex))) {
       result.put(McpResponseTrim.HAS_MORE_KEY, Boolean.TRUE);
       result.put(McpResponseTrim.NEXT_CURSOR_KEY, PageCursor.encodeOffset(from + returned));
+    } else if (!canAdvance) {
+      result.remove(McpResponseTrim.HAS_MORE_KEY);
+      result.remove(McpResponseTrim.MESSAGE_KEY);
     }
     if (fullPage && !budgetTrimmed && moreInIndex && pageMessage != null) {
       result.put(McpResponseTrim.MESSAGE_KEY, String.format(pageMessage, returned));

--- a/openmetadata-mcp/src/main/java/org/openmetadata/mcp/util/VectorPagingContract.java
+++ b/openmetadata-mcp/src/main/java/org/openmetadata/mcp/util/VectorPagingContract.java
@@ -40,14 +40,15 @@ public final class VectorPagingContract {
     return from;
   }
 
+  // hasMore is preferred over totalHits because the vector service groups chunks by parent entity;
+  // totalHits reflects raw ES hits (multiple chunks per parent) and overstates paginable results.
   static boolean hasMoreInIndex(VectorSearchResponse response, int from, int rawCount) {
-    if (response.getTotalHits() != null) {
-      return (long) from + rawCount < response.getTotalHits();
-    }
     if (response.getHasMore() != null) {
       return response.getHasMore();
     }
-    // No authoritative signal; assume no more rather than risk advertising a phantom page.
+    if (response.getTotalHits() != null) {
+      return (long) from + rawCount < response.getTotalHits();
+    }
     return false;
   }
 }

--- a/openmetadata-mcp/src/main/java/org/openmetadata/mcp/util/VectorPagingContract.java
+++ b/openmetadata-mcp/src/main/java/org/openmetadata/mcp/util/VectorPagingContract.java
@@ -1,0 +1,52 @@
+package org.openmetadata.mcp.util;
+
+import java.util.Map;
+import java.util.Optional;
+import org.openmetadata.service.search.vector.utils.DTOs.VectorSearchResponse;
+
+public final class VectorPagingContract {
+
+  private VectorPagingContract() {}
+
+  public static void attach(
+      Map<String, Object> result,
+      int from,
+      int rawCount,
+      int requestedSize,
+      VectorSearchResponse response,
+      String pageMessage) {
+    int returned =
+        result.get("returnedCount") instanceof Number number ? number.intValue() : rawCount;
+    boolean budgetTrimmed = returned < rawCount;
+    boolean fullPage = rawCount >= requestedSize;
+    boolean moreInIndex = hasMoreInIndex(response, from, rawCount, fullPage);
+    if (budgetTrimmed || (fullPage && moreInIndex)) {
+      result.put(McpResponseTrim.HAS_MORE_KEY, Boolean.TRUE);
+      result.put(McpResponseTrim.NEXT_CURSOR_KEY, PageCursor.encodeOffset(from + returned));
+    }
+    if (fullPage && !budgetTrimmed && moreInIndex && pageMessage != null) {
+      result.put(McpResponseTrim.MESSAGE_KEY, String.format(pageMessage, returned));
+    }
+  }
+
+  public static int cursorOffsetOrDefault(Map<String, Object> params, int defaultFrom) {
+    String token = params.get("cursor") instanceof String value ? value : null;
+    Optional<PageCursor.Cursor> cursor = PageCursor.decode(token);
+    int from = defaultFrom;
+    if (cursor.isPresent() && cursor.get().isOffset()) {
+      from = cursor.get().offset();
+    }
+    return from;
+  }
+
+  static boolean hasMoreInIndex(
+      VectorSearchResponse response, int from, int rawCount, boolean fullPage) {
+    if (response.getTotalHits() != null) {
+      return (long) from + rawCount < response.getTotalHits();
+    }
+    if (response.getHasMore() != null) {
+      return response.getHasMore();
+    }
+    return fullPage;
+  }
+}

--- a/openmetadata-mcp/src/main/resources/json/data/mcp/tools.json
+++ b/openmetadata-mcp/src/main/resources/json/data/mcp/tools.json
@@ -15,6 +15,15 @@
             "type": "integer",
             "description": "Number of pills to return. Default is 10, maximum is 50.",
             "default": 10
+          },
+          "from": {
+            "type": "integer",
+            "description": "Offset to start results from. Default is 0. Prefer using 'cursor' for pagination.",
+            "default": 0
+          },
+          "cursor": {
+            "type": "string",
+            "description": "Opaque pagination token. Pass the 'nextCursor' value from a previous response to fetch the next page. Omit for the first page."
           }
         },
         "required": [
@@ -60,8 +69,12 @@
           },
           "from": {
             "type": "integer",
-            "description": "In case the request more than 'size' results, this is the offset from the first result you want to fetch. Default is 0.",
+            "description": "Offset from the first result. Default is 0. Prefer using 'cursor' for pagination.",
             "default": 0
+          },
+          "cursor": {
+            "type": "string",
+            "description": "Opaque pagination token. Pass the 'nextCursor' value from a previous response to fetch the next page. Omit for the first page."
           },
           "size": {
             "type": "integer",
@@ -193,6 +206,10 @@
             "type": "number",
             "description": "Minimum similarity score threshold (0.0 to 1.0). Results below this score are excluded. Default is 0.0 (no filtering). Use higher values like 0.5 or 0.7 to get only highly relevant results.",
             "default": 0.0
+          },
+          "cursor": {
+            "type": "string",
+            "description": "Opaque pagination token. Pass the 'nextCursor' value from a previous response to fetch the next page. Omit for the first page."
           }
         },
         "required": [
@@ -589,7 +606,11 @@
           },
           "after": {
             "type": "string",
-            "description": "This can be used to paginate the results. In the response you will get a nextCursor value, which can be used to get the next set of results. For the first call, this should be ignored."
+            "description": "Legacy pagination token. Prefer 'cursor' instead. For the first call, this should be ignored."
+          },
+          "cursor": {
+            "type": "string",
+            "description": "Opaque pagination token. Pass the 'nextCursor' value from a previous response to fetch the next page. Omit for the first page."
           },
           "limit": {
             "type": "integer",

--- a/openmetadata-mcp/src/test/java/org/openmetadata/mcp/tools/SearchCompanyContextToolTest.java
+++ b/openmetadata-mcp/src/test/java/org/openmetadata/mcp/tools/SearchCompanyContextToolTest.java
@@ -3,20 +3,32 @@ package org.openmetadata.mcp.tools;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyDouble;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.openmetadata.mcp.util.PageCursor;
 import org.openmetadata.service.Entity;
 import org.openmetadata.service.jdbi3.ContextMemoryRepository;
+import org.openmetadata.service.search.SearchRepository;
+import org.openmetadata.service.search.vector.OpenSearchVectorService;
+import org.openmetadata.service.search.vector.utils.DTOs.VectorSearchResponse;
 import org.openmetadata.service.security.AuthorizationException;
 import org.openmetadata.service.security.Authorizer;
 import org.openmetadata.service.security.auth.CatalogSecurityContext;
@@ -58,6 +70,34 @@ class SearchCompanyContextToolTest {
         tool.execute(mock(Authorizer.class), mock(CatalogSecurityContext.class), params);
 
     assertEquals("'query' parameter is required", result.get("error"));
+  }
+
+  @Test
+  void cursorThreadsOffsetIntoVectorSearchClosingThePagingGap() throws Exception {
+    SearchRepository searchRepository = mock(SearchRepository.class);
+    when(searchRepository.isVectorEmbeddingEnabled()).thenReturn(true);
+    entityMock.when(Entity::getSearchRepository).thenReturn(searchRepository);
+
+    OpenSearchVectorService vectorService = mock(OpenSearchVectorService.class);
+    VectorSearchResponse response = new VectorSearchResponse(5L, Collections.emptyList());
+
+    try (MockedStatic<OpenSearchVectorService> vectorMock =
+        mockStatic(OpenSearchVectorService.class)) {
+      vectorMock.when(OpenSearchVectorService::getInstance).thenReturn(vectorService);
+      ArgumentCaptor<Integer> fromCaptor = ArgumentCaptor.forClass(Integer.class);
+      when(vectorService.search(anyString(), anyMap(), anyInt(), anyInt(), anyInt(), anyDouble()))
+          .thenReturn(response);
+
+      Map<String, Object> params = new HashMap<>();
+      params.put("query", "refund policy");
+      params.put("cursor", PageCursor.encodeOffset(40));
+
+      tool.execute(mock(Authorizer.class), mock(CatalogSecurityContext.class), params);
+
+      verify(vectorService)
+          .search(anyString(), anyMap(), anyInt(), fromCaptor.capture(), anyInt(), anyDouble());
+      assertEquals(40, fromCaptor.getValue());
+    }
   }
 
   @Test

--- a/openmetadata-mcp/src/test/java/org/openmetadata/mcp/tools/SearchMetadataToolTest.java
+++ b/openmetadata-mcp/src/test/java/org/openmetadata/mcp/tools/SearchMetadataToolTest.java
@@ -380,7 +380,7 @@ class SearchMetadataToolTest {
   }
 
   @Test
-  void trimMessageUsesAbsoluteNextOffsetWhenPaging() {
+  void trimMessageMentionsNextCursorWhenPaging() {
     List<Map<String, Object>> hits = new ArrayList<>();
     for (int i = 0; i < 5000; i++) {
       hits.add(buildHit(1.0, "svc.db.schema.table_" + i));
@@ -401,8 +401,7 @@ class SearchMetadataToolTest {
     assertEquals(true, result.get("hasMore"));
     String message = (String) result.get("message");
     assertTrue(
-        message.contains("'from'=" + (from + returnedCount)),
-        "next-page hint must be absolute (from + returnedCount): " + message);
+        message.contains("nextCursor"), "trim message should reference nextCursor: " + message);
   }
 
   @Test

--- a/openmetadata-mcp/src/test/java/org/openmetadata/mcp/tools/SearchMetadataToolTest.java
+++ b/openmetadata-mcp/src/test/java/org/openmetadata/mcp/tools/SearchMetadataToolTest.java
@@ -17,6 +17,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -24,6 +25,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.openmetadata.mcp.util.PageCursor;
 import org.openmetadata.schema.entity.teams.User;
 import org.openmetadata.schema.search.SearchRequest;
 import org.openmetadata.schema.utils.JsonUtils;
@@ -401,6 +403,32 @@ class SearchMetadataToolTest {
     assertTrue(
         message.contains("'from'=" + (from + returnedCount)),
         "next-page hint must be absolute (from + returnedCount): " + message);
+  }
+
+  @Test
+  void nextCursorEncodesAbsoluteOffsetAfterBudgetTrim() {
+    List<Map<String, Object>> hits = new ArrayList<>();
+    for (int i = 0; i < 5000; i++) {
+      hits.add(buildHit(1.0, "svc.db.schema.table_" + i));
+    }
+    Map<String, Object> hitsContainer = new HashMap<>();
+    hitsContainer.put("hits", hits);
+    hitsContainer.put("total", Map.of("value", hits.size()));
+    Map<String, Object> searchResponse = new HashMap<>();
+    searchResponse.put("hits", hitsContainer);
+
+    int from = 20;
+    Map<String, Object> result =
+        SearchMetadataTool.buildEnhancedSearchResponse(
+            searchResponse, "tables", 5000, from, List.of(), false, 0);
+
+    int returnedCount = (int) result.get("returnedCount");
+    assertEquals(true, result.get("hasMore"));
+    assertEquals(5000, ((Number) result.get("total")).intValue());
+    Optional<PageCursor.Cursor> decoded = PageCursor.decode((String) result.get("nextCursor"));
+    assertTrue(decoded.isPresent());
+    assertTrue(decoded.get().isOffset());
+    assertEquals(from + returnedCount, decoded.get().offset());
   }
 
   private Map<String, Object> buildHit(double score, String fqn) {

--- a/openmetadata-mcp/src/test/java/org/openmetadata/mcp/tools/SemanticSearchToolTest.java
+++ b/openmetadata-mcp/src/test/java/org/openmetadata/mcp/tools/SemanticSearchToolTest.java
@@ -501,6 +501,33 @@ class SemanticSearchToolTest {
     }
   }
 
+  @Test
+  void fullPageWithNullTotalButHasMoreFalseDoesNotAdvertise() throws Exception {
+    when(searchRepository.isVectorEmbeddingEnabled()).thenReturn(true);
+
+    List<Map<String, Object>> hits = new ArrayList<>();
+    for (int i = 0; i < 3; i++) {
+      hits.add(createHit("table", "db.schema.t" + i, "Table " + i, 0.9 - i * 0.1));
+    }
+    VectorSearchResponse response = new VectorSearchResponse(10L, hits, null, false);
+
+    try (MockedStatic<OpenSearchVectorService> vectorMock =
+        mockStatic(OpenSearchVectorService.class)) {
+      vectorMock.when(OpenSearchVectorService::getInstance).thenReturn(vectorService);
+      when(vectorService.search(anyString(), anyMap(), anyInt(), anyInt(), anyInt(), anyDouble()))
+          .thenReturn(response);
+
+      Map<String, Object> params = new HashMap<>();
+      params.put("query", "test");
+      params.put("size", 3);
+
+      Map<String, Object> result = semanticSearchTool.execute(authorizer, securityContext, params);
+
+      assertNull(result.get("hasMore"));
+      assertNull(result.get("nextCursor"));
+    }
+  }
+
   private Map<String, Object> createHit(String entityType, String fqn, String name, double score) {
     Map<String, Object> hit = new HashMap<>();
     hit.put("entityType", entityType);

--- a/openmetadata-mcp/src/test/java/org/openmetadata/mcp/tools/SemanticSearchToolTest.java
+++ b/openmetadata-mcp/src/test/java/org/openmetadata/mcp/tools/SemanticSearchToolTest.java
@@ -2,6 +2,7 @@ package org.openmetadata.mcp.tools;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.anyDouble;
 import static org.mockito.ArgumentMatchers.anyInt;
@@ -470,6 +471,33 @@ class SemanticSearchToolTest {
       verify(vectorService)
           .search(anyString(), anyMap(), anyInt(), fromCaptor.capture(), anyInt(), anyDouble());
       assertEquals(30, fromCaptor.getValue());
+    }
+  }
+
+  @Test
+  void fullLastPageWithKnownTotalDoesNotAdvertiseMore() throws Exception {
+    when(searchRepository.isVectorEmbeddingEnabled()).thenReturn(true);
+
+    List<Map<String, Object>> hits = new ArrayList<>();
+    for (int i = 0; i < 3; i++) {
+      hits.add(createHit("table", "db.schema.t" + i, "Table " + i, 0.9 - i * 0.1));
+    }
+    VectorSearchResponse response = new VectorSearchResponse(10L, hits, 3L, false);
+
+    try (MockedStatic<OpenSearchVectorService> vectorMock =
+        mockStatic(OpenSearchVectorService.class)) {
+      vectorMock.when(OpenSearchVectorService::getInstance).thenReturn(vectorService);
+      when(vectorService.search(anyString(), anyMap(), anyInt(), anyInt(), anyInt(), anyDouble()))
+          .thenReturn(response);
+
+      Map<String, Object> params = new HashMap<>();
+      params.put("query", "test");
+      params.put("size", 3);
+
+      Map<String, Object> result = semanticSearchTool.execute(authorizer, securityContext, params);
+
+      assertNull(result.get("hasMore"));
+      assertNull(result.get("nextCursor"));
     }
   }
 

--- a/openmetadata-mcp/src/test/java/org/openmetadata/mcp/tools/SemanticSearchToolTest.java
+++ b/openmetadata-mcp/src/test/java/org/openmetadata/mcp/tools/SemanticSearchToolTest.java
@@ -9,6 +9,7 @@ import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.util.ArrayList;
@@ -16,11 +17,14 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.openmetadata.mcp.util.PageCursor;
 import org.openmetadata.service.Entity;
 import org.openmetadata.service.search.SearchRepository;
 import org.openmetadata.service.search.vector.OpenSearchVectorService;
@@ -412,6 +416,60 @@ class SemanticSearchToolTest {
       Map<String, Object> result = semanticSearchTool.execute(authorizer, securityContext, params);
 
       assertNotNull(result);
+    }
+  }
+
+  @Test
+  void fullPageEmitsNextCursorAtRequestedOffset() throws Exception {
+    when(searchRepository.isVectorEmbeddingEnabled()).thenReturn(true);
+
+    List<Map<String, Object>> hits = new ArrayList<>();
+    for (int i = 0; i < 3; i++) {
+      hits.add(createHit("table", "db.schema.t" + i, "Table " + i, 0.9 - i * 0.1));
+    }
+    VectorSearchResponse response = new VectorSearchResponse(10L, hits);
+
+    try (MockedStatic<OpenSearchVectorService> vectorMock =
+        mockStatic(OpenSearchVectorService.class)) {
+      vectorMock.when(OpenSearchVectorService::getInstance).thenReturn(vectorService);
+      when(vectorService.search(anyString(), anyMap(), anyInt(), anyInt(), anyInt(), anyDouble()))
+          .thenReturn(response);
+
+      Map<String, Object> params = new HashMap<>();
+      params.put("query", "test");
+      params.put("size", 3);
+
+      Map<String, Object> result = semanticSearchTool.execute(authorizer, securityContext, params);
+
+      assertEquals(Boolean.TRUE, result.get("hasMore"));
+      Optional<PageCursor.Cursor> decoded = PageCursor.decode((String) result.get("nextCursor"));
+      assertTrue(decoded.isPresent());
+      assertTrue(decoded.get().isOffset());
+      assertEquals(3, decoded.get().offset());
+    }
+  }
+
+  @Test
+  void cursorParamThreadsOffsetIntoVectorSearch() throws Exception {
+    when(searchRepository.isVectorEmbeddingEnabled()).thenReturn(true);
+    VectorSearchResponse response = new VectorSearchResponse(5L, Collections.emptyList());
+
+    try (MockedStatic<OpenSearchVectorService> vectorMock =
+        mockStatic(OpenSearchVectorService.class)) {
+      vectorMock.when(OpenSearchVectorService::getInstance).thenReturn(vectorService);
+      ArgumentCaptor<Integer> fromCaptor = ArgumentCaptor.forClass(Integer.class);
+      when(vectorService.search(anyString(), anyMap(), anyInt(), anyInt(), anyInt(), anyDouble()))
+          .thenReturn(response);
+
+      Map<String, Object> params = new HashMap<>();
+      params.put("query", "test");
+      params.put("cursor", PageCursor.encodeOffset(30));
+
+      semanticSearchTool.execute(authorizer, securityContext, params);
+
+      verify(vectorService)
+          .search(anyString(), anyMap(), anyInt(), fromCaptor.capture(), anyInt(), anyDouble());
+      assertEquals(30, fromCaptor.getValue());
     }
   }
 

--- a/openmetadata-mcp/src/test/java/org/openmetadata/mcp/tools/SemanticSearchToolTest.java
+++ b/openmetadata-mcp/src/test/java/org/openmetadata/mcp/tools/SemanticSearchToolTest.java
@@ -304,7 +304,7 @@ class SemanticSearchToolTest {
       hits.add(createHit("table", "db.schema.t" + i, "Table " + i, 0.9 - i * 0.1));
     }
 
-    VectorSearchResponse response = new VectorSearchResponse(10L, hits);
+    VectorSearchResponse response = new VectorSearchResponse(10L, hits, null, true);
 
     try (MockedStatic<OpenSearchVectorService> vectorMock =
         mockStatic(OpenSearchVectorService.class)) {
@@ -428,7 +428,7 @@ class SemanticSearchToolTest {
     for (int i = 0; i < 3; i++) {
       hits.add(createHit("table", "db.schema.t" + i, "Table " + i, 0.9 - i * 0.1));
     }
-    VectorSearchResponse response = new VectorSearchResponse(10L, hits);
+    VectorSearchResponse response = new VectorSearchResponse(10L, hits, null, true);
 
     try (MockedStatic<OpenSearchVectorService> vectorMock =
         mockStatic(OpenSearchVectorService.class)) {
@@ -525,6 +525,62 @@ class SemanticSearchToolTest {
 
       assertNull(result.get("hasMore"));
       assertNull(result.get("nextCursor"));
+    }
+  }
+
+  @Test
+  void fullPageWithNoSignalDoesNotAdvertisePhantomPage() throws Exception {
+    when(searchRepository.isVectorEmbeddingEnabled()).thenReturn(true);
+
+    List<Map<String, Object>> hits = new ArrayList<>();
+    for (int i = 0; i < 3; i++) {
+      hits.add(createHit("table", "db.schema.t" + i, "Table " + i, 0.9 - i * 0.1));
+    }
+    VectorSearchResponse response = new VectorSearchResponse(10L, hits, null, null);
+
+    try (MockedStatic<OpenSearchVectorService> vectorMock =
+        mockStatic(OpenSearchVectorService.class)) {
+      vectorMock.when(OpenSearchVectorService::getInstance).thenReturn(vectorService);
+      when(vectorService.search(anyString(), anyMap(), anyInt(), anyInt(), anyInt(), anyDouble()))
+          .thenReturn(response);
+
+      Map<String, Object> params = new HashMap<>();
+      params.put("query", "test");
+      params.put("size", 3);
+
+      Map<String, Object> result = semanticSearchTool.execute(authorizer, securityContext, params);
+
+      assertNull(result.get("hasMore"));
+      assertNull(result.get("nextCursor"));
+    }
+  }
+
+  @Test
+  void zeroReturnedAfterBudgetTrimDoesNotSelfLoop() throws Exception {
+    when(searchRepository.isVectorEmbeddingEnabled()).thenReturn(true);
+
+    List<Map<String, Object>> hits = new ArrayList<>();
+    Map<String, Object> huge = createHit("table", "db.schema.huge", "Huge", 0.99);
+    huge.put("description", "x".repeat(200_000));
+    hits.add(huge);
+    VectorSearchResponse response = new VectorSearchResponse(10L, hits, null, true);
+
+    try (MockedStatic<OpenSearchVectorService> vectorMock =
+        mockStatic(OpenSearchVectorService.class)) {
+      vectorMock.when(OpenSearchVectorService::getInstance).thenReturn(vectorService);
+      when(vectorService.search(anyString(), anyMap(), anyInt(), anyInt(), anyInt(), anyDouble()))
+          .thenReturn(response);
+
+      Map<String, Object> params = new HashMap<>();
+      params.put("query", "test");
+      params.put("size", 1);
+
+      Map<String, Object> result = semanticSearchTool.execute(authorizer, securityContext, params);
+
+      int returned = result.get("returnedCount") instanceof Number n ? n.intValue() : -1;
+      if (returned == 0) {
+        assertNull(result.get("nextCursor"), "cursor must not point back to the same page");
+      }
     }
   }
 

--- a/openmetadata-mcp/src/test/java/org/openmetadata/mcp/tools/TestDefinitionsToolTest.java
+++ b/openmetadata-mcp/src/test/java/org/openmetadata/mcp/tools/TestDefinitionsToolTest.java
@@ -1,0 +1,61 @@
+/*
+ *  Copyright 2025 Collate
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.openmetadata.mcp.tools;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.openmetadata.mcp.util.PageCursor;
+
+/**
+ * Pins the keyset arm of the unified pagination contract. {@code get_test_definitions} pages with
+ * the repository's native {@code listAfter} cursor, so the tool must surface {@code paging.after} as
+ * an opaque keyset {@code nextCursor} (identical wire shape to the offset tools) while a last page
+ * with no {@code after} emits neither {@code hasMore} nor {@code nextCursor}.
+ */
+class TestDefinitionsToolTest {
+
+  @Test
+  void nativeAfterBecomesKeysetNextCursorAndTotalSurfaces() {
+    Map<String, Object> page = new HashMap<>();
+    page.put("data", List.of(Map.of("name", "columnValuesToBeUnique")));
+    page.put("paging", Map.of("after", "AFTER_TOKEN_123", "total", 42));
+
+    TestDefinitionsTool.attachPagingContract(page);
+
+    assertThat(page.get("total")).isEqualTo(42);
+    assertThat(page.get("hasMore")).isEqualTo(Boolean.TRUE);
+    Optional<PageCursor.Cursor> decoded = PageCursor.decode((String) page.get("nextCursor"));
+    assertThat(decoded).isPresent();
+    assertThat(decoded.get().isOffset()).isFalse();
+    assertThat(decoded.get().after()).isEqualTo("AFTER_TOKEN_123");
+  }
+
+  @Test
+  void lastPageWithoutAfterEmitsNoCursor() {
+    Map<String, Object> page = new HashMap<>();
+    Map<String, Object> paging = new HashMap<>();
+    paging.put("total", 42);
+    page.put("paging", paging);
+
+    TestDefinitionsTool.attachPagingContract(page);
+
+    assertThat(page).doesNotContainKey("nextCursor").doesNotContainKey("hasMore");
+    assertThat(page.get("total")).isEqualTo(42);
+  }
+}

--- a/openmetadata-mcp/src/test/java/org/openmetadata/mcp/util/PageCursorTest.java
+++ b/openmetadata-mcp/src/test/java/org/openmetadata/mcp/util/PageCursorTest.java
@@ -1,0 +1,76 @@
+/*
+ *  Copyright 2025 Collate
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.openmetadata.mcp.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.openmetadata.mcp.util.PageCursor.Cursor;
+
+/**
+ * Pins the opaque page-cursor codec. The token is an implementation detail the client only echoes,
+ * so the guarantees under test are: an encoded offset/keyset round-trips to the same value, and any
+ * unusable token (null, blank, non-base64, base64 of non-cursor JSON) decodes to empty so the tool
+ * safely restarts at the first page instead of throwing at the caller.
+ */
+class PageCursorTest {
+
+  @Test
+  void offsetTokenRoundTrips() {
+    Optional<Cursor> decoded = PageCursor.decode(PageCursor.encodeOffset(60));
+
+    assertThat(decoded).isPresent();
+    assertThat(decoded.get().isOffset()).isTrue();
+    assertThat(decoded.get().offset()).isEqualTo(60);
+  }
+
+  @Test
+  void keysetTokenRoundTrips() {
+    Optional<Cursor> decoded = PageCursor.decode(PageCursor.encodeKeyset("svc.db.orders.id"));
+
+    assertThat(decoded).isPresent();
+    assertThat(decoded.get().isOffset()).isFalse();
+    assertThat(decoded.get().after()).isEqualTo("svc.db.orders.id");
+  }
+
+  @Test
+  void tokenIsOpaqueAndDoesNotLeakPlaintext() {
+    String token = PageCursor.encodeOffset(60);
+
+    assertThat(token).doesNotContain("offset").doesNotContain("60");
+  }
+
+  @Test
+  void decodeNullOrBlankReturnsEmpty() {
+    assertThat(PageCursor.decode(null)).isEmpty();
+    assertThat(PageCursor.decode("")).isEmpty();
+    assertThat(PageCursor.decode("   ")).isEmpty();
+  }
+
+  @Test
+  void decodeGarbageReturnsEmpty() {
+    assertThat(PageCursor.decode("!!!not-base64!!!")).isEmpty();
+    assertThat(PageCursor.decode(java.util.Base64.getUrlEncoder().encodeToString("hi".getBytes())))
+        .isEmpty();
+  }
+
+  @Test
+  void decodeCursorMissingTypeReturnsEmpty() {
+    String bad =
+        java.util.Base64.getUrlEncoder().withoutPadding().encodeToString("{\"v\":5}".getBytes());
+
+    assertThat(PageCursor.decode(bad)).isEmpty();
+  }
+}


### PR DESCRIPTION
## Summary

Follow-up to #29799. Part of #29801

Stacked on `mcp-protocol-conformance` (PR #29799).

| Change | What it does |
|--------|-------------|
| `PageCursor` codec | Opaque base64 token with two variants: offset (`{"t":"o","v":60}`) and keyset (`{"t":"k","v":"afterId"}`) - LLM just echoes it back |
| Uniform paging contract | Every read tool returns `hasMore`, `nextCursor`, `total` when there are more pages |
| `search_company_context` gap fix | `from` was hardcoded to 0; now accepts `cursor`/`from` and threads offset into vectorService.search() |
| `search_metadata` + `semantic_search` | Offset cursor support, advances by count actually returned (not requested size) so budget-trimmed rows never get skipped |
| `get_test_definitions` | Keyset cursor wrapping native `paging.after` token |
| Invalid cursor resilience | Malformed/garbage cursors silently fall back to page 1 instead of crashing |

Key design decision: `nextCursor` advances by `returned` count (post-budget-trim), not `requestedSize`. This prevents the silent skip bug where trimmed rows disappear between pages.

## Test plan

- [x] `PageCursorTest` (6 tests): offset/keyset round-trip, opaque encoding, null/blank/garbage/missing-type all return empty
- [x] Tool-level cursor tests for all 4 paginated tools
- [x] 379/379 module tests green
- [x] Live E2E: 3-page round-trip on `search_company_context` with 8 knowledge pills, all pages disjoint
- [x] `cursor` overrides `from` when both provided
- [x] Garbage cursor falls back gracefully (no crash)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR unifies MCP read-tool pagination behind opaque cursor tokens. The main changes are:

- Adds offset and keyset cursor encoding.
- Threads cursor offsets through metadata, semantic, and company-context search.
- Wraps test-definition keyset paging in the same `nextCursor` response shape.
- Updates tool schemas and tests for the new paging contract.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge.

- No blocking issues found in the changed code.

</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-mcp/src/main/java/org/openmetadata/mcp/util/PageCursor.java | Adds the shared opaque cursor codec for offset and keyset pagination. |
| openmetadata-mcp/src/main/java/org/openmetadata/mcp/util/VectorPagingContract.java | Centralizes vector paging markers and avoids non-advancing cursor responses. |
| openmetadata-mcp/src/main/java/org/openmetadata/mcp/tools/SearchMetadataTool.java | Adds cursor input handling and unified paging metadata for search results. |
| openmetadata-mcp/src/main/java/org/openmetadata/mcp/tools/SearchCompanyContextTool.java | Adds cursor-based offsets to company-context vector search responses. |
| openmetadata-mcp/src/main/java/org/openmetadata/mcp/tools/SemanticSearchTool.java | Adds cursor-based offsets to semantic vector search responses. |
| openmetadata-mcp/src/main/java/org/openmetadata/mcp/tools/TestDefinitionsTool.java | Wraps repository keyset paging as unified `nextCursor` output. |

</details>

<sub>Reviews (12): Last reviewed commit: ["fix(mcp): clear hasMore when zero-progre..."](https://github.com/open-metadata/openmetadata/commit/bb8fc5b56cf1eeeeaca3ee3b867724e97f843744) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42298971)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Context used - CLAUDE.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=52f0d9d9-cad1-4e7d-b070-de181a0aa5e7))
- Context used - openmetadata-ui-core-components/CLAUDE.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=41754627-b2bf-474b-8082-f37ef1a07013))
- Context used - AGENTS.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=ef262f5f-911f-44f3-8d2d-e9cb1579c8c8))
</details>

<!-- /greptile_comment -->