### PR TITLE
Fixes #29804: reuse source client in ServiceSpec test connection to avoid double sign-in (Tableau PAT 401)

### DIFF
--- a/ingestion/src/metadata/ingestion/connections/connection.py
+++ b/ingestion/src/metadata/ingestion/connections/connection.py
@@ -56,6 +56,7 @@ class BaseConnection(ABC, Generic[S, C]):
         self.service_connection = service_connection
         self._client = None
         self._closing = ExitStack()
+        self._owns_client = True
 
     @property
     def client(self) -> C:
@@ -63,6 +64,18 @@ class BaseConnection(ABC, Generic[S, C]):
         if self._client is None:
             self._client = self._get_client()
         return self._client
+
+    def adopt_client(self, client: C) -> None:
+        """Reuse an already-built client instead of building a new one.
+
+        The client is borrowed: its real owner (e.g. the ingestion source that
+        opened the session) keeps managing its lifecycle, so ``close()`` will
+        not tear it down. This lets a throwaway connection (such as the
+        test-connection step) run against the live client without opening a
+        second session — important for services like Tableau whose Personal
+        Access Tokens allow only one active session per token."""
+        self._client = client
+        self._owns_client = False
 
     @abstractmethod
     def _get_client(self) -> C:
@@ -106,10 +119,13 @@ class BaseConnection(ABC, Generic[S, C]):
         """Release the client and everything its build registered, then reset so
         the connection can be reused (the next ``client`` access rebuilds). The
         connection owns its lifecycle; callers use it as a context manager or
-        call ``close()`` when done."""
-        self._closing.close()
+        call ``close()`` when done. A borrowed client (see ``adopt_client``) is
+        detached but not torn down, since its real owner manages it."""
+        if self._owns_client:
+            self._closing.close()
         self._closing = ExitStack()
         self._client = None
+        self._owns_client = True
 
     def __enter__(self) -> "BaseConnection[S, C]":
         return self

--- a/ingestion/src/metadata/ingestion/source/connections.py
+++ b/ingestion/src/metadata/ingestion/source/connections.py
@@ -76,13 +76,24 @@ def _get_connection_fn_from_service_spec(connection: BaseModel) -> Optional[Call
     return None
 
 
-def _get_test_fn_from_service_spec(connection: BaseModel) -> Optional[Callable]:  # noqa: UP045
+def _get_test_fn_from_service_spec(
+    connection: BaseModel,
+    connection_obj: Optional[Any] = None,  # noqa: UP045
+) -> Optional[Callable]:  # noqa: UP045
     """
     Import the get_connection function from the source, or use ServiceSpec connection_class if defined.
+
+    When ``connection_obj`` (an already-built client) is provided, the test runs
+    against it instead of opening a second connection. This avoids a redundant
+    sign-in that can invalidate the source's live session on single-session
+    services such as Tableau Personal Access Tokens.
     """
     connection_class = _get_connection_class_from_spec(connection)
     if connection_class:
-        return connection_class(connection).test_connection
+        base_connection = connection_class(connection)
+        if connection_obj is not None:
+            base_connection.adopt_client(connection_obj)
+        return base_connection.test_connection
     return None
 
 
@@ -98,11 +109,14 @@ def get_connection_fn(connection: BaseModel) -> Callable:
     return import_connection_fn(connection=connection, function_name=GET_CONNECTION_FN_NAME)
 
 
-def get_test_connection_fn(connection: BaseModel) -> Callable:
+def get_test_connection_fn(connection: BaseModel, connection_obj: Optional[Any] = None) -> Callable:  # noqa: UP045
     """
     Import the test_connection function from the source
+
+    ``connection_obj`` is the source's already-built client; when provided, the
+    ServiceSpec test path reuses it rather than opening a second connection.
     """
-    test_fn = _get_test_fn_from_service_spec(connection)
+    test_fn = _get_test_fn_from_service_spec(connection, connection_obj)
     if test_fn:
         return test_fn
     # Fallback to default
@@ -118,7 +132,7 @@ def get_connection(connection: BaseModel) -> Any:
 
 
 def test_connection_common(metadata: OpenMetadata, connection_obj, service_connection):
-    test_connection_fn = get_test_connection_fn(service_connection)
+    test_connection_fn = get_test_connection_fn(service_connection, connection_obj)
     # TODO: Remove this once we migrate all connectors to use the new test connection function
     try:
         result = test_connection_fn(metadata)

--- a/ingestion/tests/unit/connections/test_test_connection_reuses_client.py
+++ b/ingestion/tests/unit/connections/test_test_connection_reuses_client.py
@@ -1,0 +1,97 @@
+#  Copyright 2025 Collate
+#  Licensed under the Collate Community License, Version 1.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  https://github.com/open-metadata/OpenMetadata/blob/main/ingestion/LICENSE
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+"""
+Regression tests: the ServiceSpec test-connection path must reuse the source's
+already-built client instead of opening a second connection.
+
+A second sign-in invalidates the source's live session on single-session
+services (e.g. Tableau Personal Access Tokens), so every subsequent ingestion
+call then fails with 401. See the BaseConnection migration regression.
+"""
+
+from unittest.mock import MagicMock, patch
+
+from metadata.generated.schema.entity.services.connections.testConnectionResult import (
+    TestConnectionResult,
+)
+from metadata.ingestion.connections.connection import BaseConnection
+from metadata.ingestion.source import connections as connections_module
+
+
+class FakeClient:
+    def __init__(self):
+        self.torn_down = False
+
+
+class FakeConnection(BaseConnection):
+    """Mimics a migrated connector: builds a client and runs the test against it."""
+
+    build_count = 0
+
+    def _get_client(self) -> FakeClient:
+        type(self).build_count += 1
+        client = FakeClient()
+        self._on_close(lambda: setattr(client, "torn_down", True))
+        return client
+
+    def test_connection(self, metadata, automation_workflow=None, timeout_seconds=None):
+        self._tested_client = self.client
+        return TestConnectionResult(steps=[])
+
+
+def _fake_service_connection():
+    service_connection = MagicMock()
+    service_connection.type.value = "Fake"
+    return service_connection
+
+
+def _run_with_fake_spec():
+    return patch.object(
+        connections_module,
+        "_get_connection_class_from_spec",
+        return_value=FakeConnection,
+    )
+
+
+class TestTestConnectionReusesClient:
+    def setup_method(self):
+        FakeConnection.build_count = 0
+
+    def test_reuses_existing_client_without_second_build(self):
+        existing_client = FakeClient()
+        service_connection = _fake_service_connection()
+
+        with _run_with_fake_spec():
+            connections_module.test_connection_common(MagicMock(), existing_client, service_connection)
+
+        assert FakeConnection.build_count == 0
+
+    def test_borrowed_client_is_not_torn_down(self):
+        existing_client = FakeClient()
+        service_connection = _fake_service_connection()
+
+        with _run_with_fake_spec():
+            base_connection = FakeConnection(service_connection)
+            base_connection.adopt_client(existing_client)
+            base_connection.close()
+
+        assert existing_client.torn_down is False
+
+    def test_standalone_test_builds_and_tears_down_own_client(self):
+        service_connection = _fake_service_connection()
+
+        with _run_with_fake_spec():
+            base_connection = FakeConnection(service_connection)
+            built_client = base_connection.client
+            base_connection.close()
+
+        assert FakeConnection.build_count == 1
+        assert built_client.torn_down is True


### PR DESCRIPTION
## Describe your changes

Fixes #29804.

After the [BaseConnection migration (#29005)](https://github.com/open-metadata/OpenMetadata/pull/29005), ingestion sources open **two** connections at startup: one for the working client and a second, redundant one for the test-connection step. On single-session auth — notably **Tableau Personal Access Tokens, which permit only one active session per token** — the second sign-in invalidates the first, so the test connection reports success but the actual ingestion fails with `401002 Unauthorized`.

### Root cause

`test_connection_common()` → `get_test_connection_fn()` → `_get_test_fn_from_service_spec()` built a **brand-new** `connection_class(connection)` and accessed `.client`, triggering a second sign-in and ignoring the already-built `connection_obj` passed in by the source.

### Fix

- `BaseConnection.adopt_client()`: lets a connection reuse an already-built client (borrowed — `close()` won't tear it down, since its real owner manages its lifecycle).
- Thread the source's `connection_obj` through `test_connection_common → get_test_connection_fn → _get_test_fn_from_service_spec`; when present, the throwaway test connection adopts it instead of opening a second connection.
- The UI/automation "Test Connection" path (`automations/runner.py`) passes no `connection_obj`, so it still builds + closes its own client — unchanged.
- Non-migrated connectors are unaffected (they already reuse `connection_obj` via the legacy `except TypeError` fallback).

This is a systemic fix: it covers every connector migrated to `BaseConnection`/ServiceSpec whose auth is single-session, not just Tableau.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How was this patch tested?

New regression test `ingestion/tests/unit/connections/test_test_connection_reuses_client.py`:
- `test_reuses_existing_client_without_second_build` — no second client is built when `connection_obj` is provided (fails on `main`: builds a 2nd client).
- `test_borrowed_client_is_not_torn_down` — an adopted client survives `close()`.
- `test_standalone_test_builds_and_tears_down_own_client` — the standalone (UI/automation) path still builds and closes its own client.

Verified the first test **fails without the fix** (`build_count == 1`) and passes with it. Existing suites green: 159 connection unit tests + 25 Tableau topology tests. `ruff format`/`check` clean.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/open-metadata/OpenMetadata/blob/main/CONTRIBUTING.md) documentation
- [x] I have added tests that prove my fix is effective

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR reuses existing ingestion clients during ServiceSpec test connections. The main changes are:

- Added borrowed-client ownership tracking to `BaseConnection`.
- Passed `connection_obj` through the ServiceSpec test-connection helpers.
- Added tests for client reuse and owned-client cleanup.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge after a small cleanup to `adopt_client()`.

- The main ingestion test path adopts a fresh throwaway connection before any client is built.
- Standalone test connections still build and close their own clients.
- `adopt_client()` can leak an already-built owned client if it is reused outside the current call pattern.

ingestion/src/metadata/ingestion/connections/connection.py
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| ingestion/src/metadata/ingestion/connections/connection.py | Adds borrowed-client support and ownership-aware cleanup to `BaseConnection`. |
| ingestion/src/metadata/ingestion/source/connections.py | Threads the existing source client into the ServiceSpec test-connection path. |
| ingestion/tests/unit/connections/test_test_connection_reuses_client.py | Adds tests for reused clients, borrowed-client detachment, and standalone cleanup. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Source as Ingestion Source
    participant Common as test_connection_common
    participant Spec as get_test_connection_fn
    participant Conn as ServiceSpec BaseConnection
    participant Client as Existing Client

    Source->>Common: connection_obj, service_connection
    Common->>Spec: get_test_connection_fn(service_connection, connection_obj)
    Spec->>Conn: connection_class(service_connection)
    Spec->>Conn: adopt_client(connection_obj)
    Conn->>Client: reuse borrowed client
    Common->>Conn: test_connection(metadata)
    Conn-->>Common: TestConnectionResult
    Conn->>Conn: close() detaches borrowed client
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Source as Ingestion Source
    participant Common as test_connection_common
    participant Spec as get_test_connection_fn
    participant Conn as ServiceSpec BaseConnection
    participant Client as Existing Client

    Source->>Common: connection_obj, service_connection
    Common->>Spec: get_test_connection_fn(service_connection, connection_obj)
    Spec->>Conn: connection_class(service_connection)
    Spec->>Conn: adopt_client(connection_obj)
    Conn->>Client: reuse borrowed client
    Common->>Conn: test_connection(metadata)
    Conn-->>Common: TestConnectionResult
    Conn->>Conn: close() detaches borrowed client
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["Fixes #29804: reuse source client in Ser..."](https://github.com/open-metadata/openmetadata/commit/134c536529690a855f00b270192304b6c2ae7b57) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42321145)</sub>

> Greptile also left **1 inline comment** on this PR.

<details><summary><h4>Context used (3)</h4></summary>

- Context used - CLAUDE.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=52f0d9d9-cad1-4e7d-b070-de181a0aa5e7))
- Context used - openmetadata-ui-core-components/CLAUDE.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=41754627-b2bf-474b-8082-f37ef1a07013))
- Context used - AGENTS.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=ef262f5f-911f-44f3-8d2d-e9cb1579c8c8))
</details>

<!-- /greptile_comment -->