### PR TITLE
fix(event-subscription): record failed webhook events on non-2xx delivery

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/apps/bundles/changeEvent/generic/GenericPublisher.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/apps/bundles/changeEvent/generic/GenericPublisher.java
@@ -107,8 +107,6 @@ public class GenericPublisher implements Destination<ChangeEvent> {
           }
         }
       }
-    } catch (EventPublisherException ex) {
-      throw ex;
     } catch (Exception ex) {
       if (ex.getCause() instanceof UnknownHostException) {
         String message =

--- a/openmetadata-service/src/test/java/org/openmetadata/service/apps/bundles/changeEvent/generic/GenericPublisherTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/apps/bundles/changeEvent/generic/GenericPublisherTest.java
@@ -1,0 +1,86 @@
+/*
+ *  Copyright 2021 Collate
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.openmetadata.service.apps.bundles.changeEvent.generic;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.openmetadata.schema.entity.events.SubscriptionDestination.SubscriptionType.WEBHOOK;
+
+import jakarta.ws.rs.client.Invocation;
+import jakarta.ws.rs.core.MultivaluedHashMap;
+import jakarta.ws.rs.core.Response;
+import java.net.URI;
+import java.util.Set;
+import java.util.UUID;
+import org.apache.commons.lang3.tuple.Pair;
+import org.junit.jupiter.api.Test;
+import org.openmetadata.schema.entity.events.EventSubscription;
+import org.openmetadata.schema.entity.events.SubscriptionDestination;
+import org.openmetadata.schema.type.ChangeEvent;
+import org.openmetadata.schema.type.Webhook;
+import org.openmetadata.service.events.errors.EventPublisherException;
+import org.openmetadata.service.notifications.recipients.context.WebhookRecipient;
+
+class GenericPublisherTest {
+
+  @Test
+  void sendMessageAttachesChangeEventWhenWebhookDeliveryFails() throws Exception {
+    UUID destinationId = UUID.randomUUID();
+    Webhook webhook = new Webhook().withEndpoint(URI.create("https://hooks.example.com/dead"));
+    SubscriptionDestination destination =
+        new SubscriptionDestination()
+            .withId(destinationId)
+            .withType(WEBHOOK)
+            .withTimeout(10)
+            .withReadTimeout(12)
+            .withEnabled(true)
+            .withConfig(webhook);
+    EventSubscription eventSubscription =
+        new EventSubscription().withId(UUID.randomUUID()).withName("test-alert");
+    ChangeEvent event = new ChangeEvent().withId(UUID.randomUUID()).withEntityType("table");
+
+    Response.StatusType statusInfo = mock(Response.StatusType.class);
+    when(statusInfo.getReasonPhrase()).thenReturn("Not Found");
+    Response response = mock(Response.class);
+    when(response.getStatus()).thenReturn(404);
+    when(response.getStatusInfo()).thenReturn(statusInfo);
+    when(response.getStringHeaders()).thenReturn(new MultivaluedHashMap<>());
+    when(response.hasEntity()).thenReturn(false);
+    when(response.getMediaType()).thenReturn(null);
+
+    Invocation.Builder builder = mock(Invocation.Builder.class);
+    when(builder.post(any())).thenReturn(response);
+    WebhookRecipient recipient = mock(WebhookRecipient.class);
+    when(recipient.getConfiguredRequest(any(), any())).thenReturn(builder);
+
+    GenericPublisher publisher = new GenericPublisher(eventSubscription, destination);
+
+    EventPublisherException exception =
+        assertThrows(
+            EventPublisherException.class, () -> publisher.sendMessage(event, Set.of(recipient)));
+
+    // Without the pair, AbstractEventConsumer.handleFailedEvent bails out and never records the
+    // failed event (logging "Change Event with Subscription is null ...").
+    Pair<UUID, ChangeEvent> changeEventWithSubscription =
+        exception.getChangeEventWithSubscription();
+    assertNotNull(changeEventWithSubscription);
+    assertEquals(destinationId, changeEventWithSubscription.getLeft());
+    assertSame(event, changeEventWithSubscription.getRight());
+  }
+}


### PR DESCRIPTION
Fixes #29807

### What
Non-2xx webhook (generic) alert deliveries were silently not recorded as failed events, logging `Change Event with Subscription is null in EventPublisherException: Webhook delivery failed with HTTP 404: Not Found` and skipping `upsertFailedEvent`.

### Why
`SubscriptionUtil.postWebhookMessage` throws `EventPublisherException` via the single-arg constructor, so it carries no change-event/subscription pair. The `catch (EventPublisherException ex) { throw ex; }` block in `GenericPublisher.sendMessage` — added in #26306 (webhook OAuth flow) — re-threw it unchanged, ahead of the existing `catch (Exception ex)` that wraps it with `Pair.of(destinationId, event)`. It then reached `AbstractEventConsumer.handleFailedEvent` with a null pair, which logs the error above and returns early.

### Fix
Remove the re-throw block so HTTP-status failures fall through to `catch (Exception ex)`, which attaches the change-event pair — matching the MS Teams / Slack / Google Chat / Email publishers, none of which have this block. The OAuth2-401 retry (inner try/catch) is untouched.

### Tests
Added `GenericPublisherTest.sendMessageAttachesChangeEventWhenWebhookDeliveryFails`: drives a mocked 404 webhook response through `sendMessage` and asserts the thrown `EventPublisherException` carries the change-event pair (destination id + event). Fails without the fix (`AssertionFailedError: expected: not <null>`), passes with it.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes failed generic webhook delivery recording. The main changes are:

- Removed the generic webhook exception rethrow that skipped failed-event wrapping.
- Added coverage for a non-2xx webhook response carrying the destination and change event.
- Kept the generic webhook send flow aligned with the existing failed-event recording path.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge.

- No blocking issues found in the changed code.


</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| openmetadata-service/src/main/java/org/openmetadata/service/apps/bundles/changeEvent/generic/GenericPublisher.java | Removes the outer `EventPublisherException` rethrow so failed generic webhook deliveries use the wrapping path that attaches the destination id and change event. |
| openmetadata-service/src/test/java/org/openmetadata/service/apps/bundles/changeEvent/generic/GenericPublisherTest.java | Adds a unit test for a 404 webhook response and verifies the thrown exception contains the expected destination and change event. |

</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `openmetadata-service/src/main/java/org/openmetadata/service/apps/bundles/changeEvent/generic/GenericPublisher.java`, line 98 ([link](https://github.com/open-metadata/openmetadata/blob/f592e203e2bd2e3a7bff26499a705795135b08ea/openmetadata-service/src/main/java/org/openmetadata/service/apps/bundles/changeEvent/generic/GenericPublisher.java#L98)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **OAuth retry removed** Removing the `EventPublisherException` catch also removes the OAuth2 401 refresh-and-retry path around this webhook post. When an OAuth2-configured webhook has a stale access token, `postWebhookMessage` throws for the 401 response; this now goes straight to the outer catch and records the delivery as failed instead of invalidating the token and retrying once. Please keep the final wrapping with the change-event pair, but preserve the 401 retry behavior for OAuth webhooks.
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (3): Last reviewed commit: ["fix(event-subscription): record failed w..."](https://github.com/open-metadata/openmetadata/commit/17c777e61db0781f533b68a68456773bd3d192b7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42329583)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Context used - CLAUDE.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=52f0d9d9-cad1-4e7d-b070-de181a0aa5e7))
- Context used - openmetadata-ui-core-components/CLAUDE.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=41754627-b2bf-474b-8082-f37ef1a07013))
- Context used - AGENTS.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=ef262f5f-911f-44f3-8d2d-e9cb1579c8c8))
</details>


<!-- /greptile_comment -->