### PR TITLE
Fixes #29824: Ingest dbt pass results with null message

### DIFF
--- a/ingestion/src/metadata/ingestion/source/database/dbt/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/database/dbt/metadata.py
@@ -1716,8 +1716,12 @@ class DbtSource(DbtServiceSource):
 
                 # Skip compiled-only entries: `dbt run` includes test nodes in
                 # run_results.json with status="success" but message=null since
-                # no test SQL was executed. Real results always have a message.
-                if not dbt_test_result.message:
+                # no test SQL was executed. Executed dbt tests can also have
+                # message=null, e.g. passing tests with status="pass".
+                if (
+                    not dbt_test_result.message
+                    and dbt_test_result.status.value == DbtTestSuccessEnum.SUCCESS.value
+                ):
                     logger.debug(
                         "Skipping compiled-only test result for '%s' (message is null).",
                         manifest_node.name,

--- a/ingestion/tests/unit/test_dbt.py
+++ b/ingestion/tests/unit/test_dbt.py
@@ -3801,6 +3801,34 @@ class TestAddDbtTestResultSkipsCompiledOnly(TestCase):
 
         source.metadata.add_test_case_results.assert_called_once()
 
+    def test_real_pass_result_with_null_message_is_ingested(self):
+        """
+        Real test pass: status=pass, message=None.
+        Must call add_test_case_results exactly once.
+        """
+        from metadata.ingestion.source.database.dbt.constants import DbtCommonEnum
+
+        timing = MagicMock()
+        timing.name = "execute"
+        timing.completed_at = "2026-03-27T07:00:00.000000Z"
+
+        source = self._make_dbt_source()
+        dbt_test = {
+            DbtCommonEnum.MANIFEST_NODE.value: self._make_manifest_node(),
+            DbtCommonEnum.RESULTS.value: self._make_test_result(
+                status="pass", message=None, timing=[timing]
+            ),
+            DbtCommonEnum.UPSTREAM.value: ["snowflake.db.schema.orders"],
+        }
+        with patch("metadata.ingestion.source.database.dbt.metadata.fqn") as mock_fqn:
+            mock_fqn.split.return_value = ["snowflake", "db", "schema", "orders"]
+            mock_fqn.build.return_value = (
+                "snowflake.db.schema.orders.test_not_null_orders_id"
+            )
+            source.add_dbt_test_result(dbt_test)
+
+        source.metadata.add_test_case_results.assert_called_once()
+
     def test_real_failure_result_is_ingested(self):
         """
         Real test failure: status=fail, message populated.


### PR DESCRIPTION
### Describe your changes:

Fixes open-metadata/OpenMetadata#29824

### RCA

PR #26812 added a guard in `add_dbt_test_result()` to skip dbt run artifacts where `message` is null/empty. That fixed compiled-only dbt entries produced by `dbt run`, where test nodes can appear as `status=success` with `message=null` even though no test SQL executed.

The guard was broader than the RCA: dbt `run_results.json` can also contain executed data tests with `status=pass` and `message=null`. dbt's run-results docs show generic data test entries with `status: pass`, `message: null`, and `failures: 0`.

Because OpenMetadata strips non-required run-result keys before parsing, `failures` is not available in this method. `status` is the discriminator we still have here.

### Fix

- Keep skipping compiled-only entries with `status=success` and missing `message`.
- Allow executed passing test results with `status=pass` and missing `message` to be ingested.
- Add regression coverage for `status=pass, message=None`.

### Type of change:

- [x] Bug fix

### Checklist:

- [x] My PR title is `Fixes <issue-number>: <short explanation>`
- [x] I have added a test that covers the exact scenario we are fixing.
- [x] For JSON Schema changes: not applicable.

### Verification:

- [x] `python3 -m py_compile ingestion/src/metadata/ingestion/source/database/dbt/metadata.py ingestion/tests/unit/test_dbt.py`
- [x] `git diff --check`
- [ ] `python3 -m pytest ingestion/tests/unit/test_dbt.py::TestAddDbtTestResultSkipsCompiledOnly -q` not run locally: this shell does not have `pytest`, `metadata`, or `collate_dbt_artifacts_parser` installed.

### References:

- Regression issue: #29824
- Prior change that introduced the broad skip: #26812
- dbt run-results docs: https://docs.getdbt.com/reference/artifacts/run-results-json

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR narrows the dbt test-result skip behavior for null messages. The main changes are:

- Skip only compiled-only `status="success"` results with missing messages.
- Allow executed `status="pass"` results with `message=None` to be ingested.
- Add a unit test for the pass/null-message case.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge.

- No blocking issues found in the changed code.
- The nullable message is not used after the guard before the test result is posted.
- The new test exercises the intended pass-through path.

</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| ingestion/src/metadata/ingestion/source/database/dbt/metadata.py | Narrows the dbt compiled-only skip guard to `status="success"` with a missing message. |
| ingestion/tests/unit/test_dbt.py | Adds coverage for ingesting a real `status="pass"` dbt test result with `message=None`. |

</details>

<sub>Reviews (1): Last reviewed commit: ["Fixes #29824: Ingest dbt pass results wi..."](https://github.com/open-metadata/openmetadata/commit/5423378209b8a823e1a952b89f399cb5fe9464b8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42600837)</sub>

**Context used:**

- Context used - CLAUDE.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=52f0d9d9-cad1-4e7d-b070-de181a0aa5e7))
- Context used - openmetadata-ui-core-components/CLAUDE.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=41754627-b2bf-474b-8082-f37ef1a07013))

<!-- /greptile_comment -->