### PR TITLE
Fix stale description source badge when clearing a nested field's description

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/ChangeSummarizer.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/ChangeSummarizer.java
@@ -72,51 +72,53 @@ public class ChangeSummarizer<T extends EntityInterface> {
   }
 
   /**
-   * Given a list of fields that were deleted, process the fields and return the set of keys to delete
+   * Given a list of fields that were deleted, return the change-summary keys to remove. A key is
+   * removed when either the tracked field itself was deleted (for example clearing a single
+   * column's description) or when a parent list holding tracked fields was deleted (for example
+   * removing a whole column). The keys mirror the ones produced by {@link #summarizeChanges}, which
+   * uses the raw {@link FieldChange#getName()} as the map key.
    */
   public Set<String> processDeleted(List<FieldChange> fieldsDeleted) {
+    Set<String> keysToDelete = new HashSet<>(directlyDeletedKeys(fieldsDeleted));
+    keysToDelete.addAll(nestedListDeletedKeys(fieldsDeleted));
+    return keysToDelete;
+  }
+
+  private Set<String> directlyDeletedKeys(List<FieldChange> fieldsDeleted) {
+    return fieldsDeleted.stream()
+        .map(FieldChange::getName)
+        .filter(this::isFieldTracked)
+        .collect(Collectors.toSet());
+  }
+
+  private Set<String> nestedListDeletedKeys(List<FieldChange> fieldsDeleted) {
     Set<String> keysToDelete = new HashSet<>();
     for (String field : fields) {
-      // process top level fields
-      List<String> topLevel =
-          fieldsDeleted.stream()
-              .filter(fieldChange -> fieldChange.getName().equals(field))
-              .map(
-                  fieldChange ->
-                      FullyQualifiedName.build(
-                          fieldChange.getName(), (String) fieldChange.getOldValue()))
-              .toList();
-      if (!topLevel.isEmpty()) {
-        keysToDelete.addAll(topLevel);
-        continue;
-      }
-
-      // process nested fields
-      Set<FieldChange> nestedFields =
+      Set<FieldChange> deletedParentLists =
           fieldsDeleted.stream()
               .filter(fieldChange -> field.startsWith(fieldChange.getName() + "."))
+              .filter(fieldChange -> isListField(clazz, fieldChange.getName()))
               .collect(Collectors.toSet());
-
-      for (FieldChange fieldChange : nestedFields) {
-        if (!isListField(clazz, fieldChange.getName())) {
-          continue;
-        }
-
-        try {
-          String nestedField = field.substring(fieldChange.getName().length() + 1);
-          JsonUtils.readObjects((String) fieldChange.getOldValue(), Map.class).stream()
-              .map(map -> (Map<String, Object>) map)
-              .map(map -> (String) map.get("name"))
-              .forEach(
-                  name ->
-                      keysToDelete.add(
-                          FullyQualifiedName.build(fieldChange.getName(), name, nestedField)));
-        } catch (JsonParsingException e) {
-          LOG.warn("Error processing deleted fields", e);
-        }
+      for (FieldChange fieldChange : deletedParentLists) {
+        keysToDelete.addAll(expandListItemKeys(field, fieldChange));
       }
     }
     return keysToDelete;
+  }
+
+  private Set<String> expandListItemKeys(String trackedField, FieldChange deletedList) {
+    Set<String> keys = new HashSet<>();
+    try {
+      String nestedField = trackedField.substring(deletedList.getName().length() + 1);
+      JsonUtils.readObjects((String) deletedList.getOldValue(), Map.class).stream()
+          .map(map -> (Map<String, Object>) map)
+          .map(map -> (String) map.get("name"))
+          .forEach(
+              name -> keys.add(FullyQualifiedName.build(deletedList.getName(), name, nestedField)));
+    } catch (JsonParsingException e) {
+      LOG.warn("Error processing deleted fields", e);
+    }
+    return keys;
   }
 
   private boolean matchesTrackedField(String trackedField, String fieldName) {

--- a/openmetadata-service/src/test/java/org/openmetadata/service/jdbi3/ChangeSummarizerTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/jdbi3/ChangeSummarizerTest.java
@@ -145,4 +145,28 @@ public class ChangeSummarizerTest {
     assertEquals(1, result.size());
     assertEquals("columns.c'_+# 1.description", result.iterator().next());
   }
+
+  @Test
+  public void test_deleteColumnDescription() {
+    FieldChange fieldChange =
+        new FieldChange().withName("columns.column1.description").withOldValue("some description");
+
+    Set<String> result = changeSummarizer.processDeleted(List.of(fieldChange));
+    assertEquals(1, result.size());
+    assertEquals("columns.column1.description", result.iterator().next());
+  }
+
+  @Test
+  public void test_deleteMultiLevelNestedColumnDescription() {
+    ChangeSummarizer<Container> containerChangeSummarizer =
+        new ChangeSummarizer<>(Container.class, Set.of("dataModel.columns.description"));
+    FieldChange fieldChange =
+        new FieldChange()
+            .withName("dataModel.columns.column1.description")
+            .withOldValue("some description");
+
+    Set<String> result = containerChangeSummarizer.processDeleted(List.of(fieldChange));
+    assertEquals(1, result.size());
+    assertEquals("dataModel.columns.column1.description", result.iterator().next());
+  }
 }


### PR DESCRIPTION
### Describe your changes:

Fixes #29841

`ChangeSummarizer.processDeleted` never produced the change-summary key for a deleted nested list-item field (e.g. `columns.<col>.description`). It only handled a deleted whole top-level field and a deleted whole list (an entire column removed). Clearing a single column's description stores it as `null`, which is recorded as a `fieldsDeleted` change — so the stale `columns.<col>.description` entry survived and the "Accepted by ingestion-bot" source badge remained on an empty description.

Replaced the old top-level branch (it built `name.oldValue`, a key that never matches what `summarizeChanges` writes) with `directlyDeletedKeys`: any deleted field whose own name is tracked has that exact key removed — symmetric with `summarizeChanges`, which keys entries by the raw `FieldChange.getName()`. Whole-list handling is preserved in `nestedListDeletedKeys` / `expandListItemKeys`.

Before the fix: deleting column desc, stale badge entry remains
<img width="900" height="132" alt="Screenshot 2026-07-08 at 5 59 26 PM" src="https://github.com/user-attachments/assets/7d942f41-7d1f-41df-83e7-68d1855e1a7f" />

After the fix: no stale badge
<img width="901" height="225" alt="Screenshot 2026-07-08 at 6 00 23 PM" src="https://github.com/user-attachments/assets/dfec1e29-b453-4aec-b7ba-814587294a7d" />

#
### Type of change:
- [x] Bug fix

#
### High-level design:

N/A — small change.

#
### Tests:

#### Use cases covered
- Clearing a single column's AI-generated description also clears its source badge.
- Same for multi-level nested descriptions (e.g. Container `dataModel.columns.<col>.description`).
- Whole-column deletion and top-level table description clearing are unchanged.

#### Unit tests
- [x] Added `test_deleteColumnDescription` and `test_deleteMultiLevelNestedColumnDescription` in `ChangeSummarizerTest` (both fail without the fix). 8/8 pass.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes stale source badges when descriptions are cleared from nested fields. The main changes are:

- Directly deleted tracked fields now remove their exact change-summary key.
- Whole-list deletion still expands removed list items into nested summary keys.
- Tests cover clearing nested column descriptions and multi-level nested descriptions.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge.

- No blocking issues found in the changed code.
- The direct deletion path now matches the key shape written by the summary path.
- The existing whole-list deletion behavior is preserved.

</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/ChangeSummarizer.java | Splits deleted-field processing into exact tracked-key removal and preserved parent-list expansion. |
| openmetadata-service/src/test/java/org/openmetadata/service/jdbi3/ChangeSummarizerTest.java | Adds regression coverage for clearing nested and multi-level nested description fields. |

</details>

<sub>Reviews (1): Last reviewed commit: ["Fix stale description source badge when ..."](https://github.com/open-metadata/openmetadata/commit/04a08a31e2aa81d8fe31923d226b2d4a9c322b0d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42686582)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Context used - CLAUDE.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=52f0d9d9-cad1-4e7d-b070-de181a0aa5e7))
- Context used - openmetadata-ui-core-components/CLAUDE.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=41754627-b2bf-474b-8082-f37ef1a07013))
- Context used - AGENTS.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=ef262f5f-911f-44f3-8d2d-e9cb1579c8c8))
</details>

<!-- /greptile_comment -->