### PR TITLE
fix(table): server-side column tag filter across all pages (#25063) (#29324) [1.13 backport]

### DIFF
--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/TableResourceIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/TableResourceIT.java
@@ -13,6 +13,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import es.co.elastic.clients.transport.rest5_client.low_level.Request;
 import es.co.elastic.clients.transport.rest5_client.low_level.Response;
 import es.co.elastic.clients.transport.rest5_client.low_level.Rest5Client;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -40,6 +42,8 @@ import org.openmetadata.schema.api.classification.CreateClassification;
 import org.openmetadata.schema.api.classification.CreateTag;
 import org.openmetadata.schema.api.data.CreateDatabase;
 import org.openmetadata.schema.api.data.CreateDatabaseSchema;
+import org.openmetadata.schema.api.data.CreateGlossary;
+import org.openmetadata.schema.api.data.CreateGlossaryTerm;
 import org.openmetadata.schema.api.data.CreatePipeline;
 import org.openmetadata.schema.api.data.CreateQuery;
 import org.openmetadata.schema.api.data.CreateTable;
@@ -54,6 +58,8 @@ import org.openmetadata.schema.entity.classification.Classification;
 import org.openmetadata.schema.entity.classification.Tag;
 import org.openmetadata.schema.entity.data.Database;
 import org.openmetadata.schema.entity.data.DatabaseSchema;
+import org.openmetadata.schema.entity.data.Glossary;
+import org.openmetadata.schema.entity.data.GlossaryTerm;
 import org.openmetadata.schema.entity.data.Pipeline;
 import org.openmetadata.schema.entity.data.Query;
 import org.openmetadata.schema.entity.data.Table;
@@ -89,6 +95,7 @@ import org.openmetadata.schema.type.TableProfile;
 import org.openmetadata.schema.type.TableProfilerConfig;
 import org.openmetadata.schema.type.TableType;
 import org.openmetadata.schema.type.TagLabel;
+import org.openmetadata.schema.type.TagLabel.TagSource;
 import org.openmetadata.schema.type.api.BulkOperationResult;
 import org.openmetadata.schema.type.csv.CsvImportResult;
 import org.openmetadata.schema.utils.JsonUtils;
@@ -100,6 +107,7 @@ import org.openmetadata.sdk.fluent.builders.ColumnBuilder;
 import org.openmetadata.sdk.models.ListParams;
 import org.openmetadata.sdk.models.ListResponse;
 import org.openmetadata.sdk.models.TableColumnList;
+import org.openmetadata.sdk.network.HttpMethod;
 
 /**
  * Integration tests for Table entity operations.
@@ -766,6 +774,361 @@ public class TableResourceIT extends BaseEntityIT<Table, CreateTable> {
     Table updated = patchEntity(table.getId().toString(), table);
 
     assertEquals(2, updated.getColumns().size());
+  }
+
+  @Test
+  void searchColumns_tagFilterReturnsMatchesAcrossPages(TestNamespace ns) throws Exception {
+    OpenMetadataClient client = SdkClients.adminClient();
+    DatabaseService service = DatabaseServiceTestFactory.createPostgres(ns);
+    DatabaseSchema schema = DatabaseSchemaTestFactory.createSimple(ns, service);
+
+    String classificationName = ns.prefix("ColTagFilter");
+    String tagFqn = createClassificationWithTag(client, classificationName, "Sensitive");
+    TagLabel sensitiveLabel =
+        new TagLabel()
+            .withTagFQN(tagFqn)
+            .withSource(TagSource.CLASSIFICATION)
+            .withLabelType(TagLabel.LabelType.MANUAL)
+            .withState(TagLabel.State.CONFIRMED);
+
+    int totalColumns = 60;
+    int taggedColumnIndex = 58;
+    List<Column> columns = new ArrayList<>();
+    for (int i = 0; i < totalColumns; i++) {
+      Column column =
+          new Column()
+              .withName(String.format("col_%02d", i))
+              .withDataType(ColumnDataType.VARCHAR)
+              .withDataLength(100);
+      if (i == taggedColumnIndex) {
+        column.withTags(List.of(sensitiveLabel));
+      }
+      columns.add(column);
+    }
+
+    CreateTable request = new CreateTable();
+    request.setName(ns.prefix("col_tag_filter"));
+    request.setDatabaseSchema(schema.getFullyQualifiedName());
+    request.setColumns(columns);
+    Table table = createEntity(request);
+
+    String encodedFqn = URLEncoder.encode(table.getFullyQualifiedName(), StandardCharsets.UTF_8);
+    String taggedColumnName = String.format("col_%02d", taggedColumnIndex);
+
+    TableColumnList firstPage = searchColumns(client, encodedFqn, "limit=50&offset=0");
+    assertEquals(totalColumns, firstPage.getPaging().getTotal());
+    assertFalse(
+        firstPage.getData().stream().anyMatch(c -> taggedColumnName.equals(c.getName())),
+        "Tagged column should fall on a later page without a filter");
+
+    String encodedTag = URLEncoder.encode(tagFqn, StandardCharsets.UTF_8);
+    TableColumnList filtered =
+        searchColumns(client, encodedFqn, "limit=50&offset=0&fields=tags&tags=" + encodedTag);
+    assertEquals(
+        1,
+        filtered.getPaging().getTotal(),
+        "Tag filter total should count all matches, not a page");
+    assertEquals(1, filtered.getData().size());
+    assertEquals(taggedColumnName, filtered.getData().get(0).getName());
+
+    TableColumnList filteredById =
+        searchColumnsById(
+            client, table.getId().toString(), "limit=50&offset=0&fields=tags&tags=" + encodedTag);
+    assertEquals(
+        1, filteredById.getPaging().getTotal(), "By-id endpoint should honour the same tag filter");
+    assertEquals(taggedColumnName, filteredById.getData().get(0).getName());
+  }
+
+  @Test
+  void searchColumns_glossaryTermAndDerivedTagFilter(TestNamespace ns) throws Exception {
+    OpenMetadataClient client = SdkClients.adminClient();
+    DatabaseService service = DatabaseServiceTestFactory.createPostgres(ns);
+    DatabaseSchema schema = DatabaseSchemaTestFactory.createSimple(ns, service);
+
+    String classificationName = ns.prefix("DerivedTagFilter");
+    String classificationTagFqn = createClassificationWithTag(client, classificationName, "Pii");
+
+    String glossaryName = ns.prefix("ColFilterGlossary");
+    String termName = "CustomerData";
+    String glossaryTermFqn =
+        createGlossaryTermWithTag(client, glossaryName, termName, classificationTagFqn);
+
+    TagLabel glossaryLabel =
+        new TagLabel()
+            .withTagFQN(glossaryTermFqn)
+            .withSource(TagSource.GLOSSARY)
+            .withLabelType(TagLabel.LabelType.MANUAL)
+            .withState(TagLabel.State.CONFIRMED);
+
+    int totalColumns = 60;
+    int taggedColumnIndex = 58;
+    List<Column> columns = new ArrayList<>();
+    for (int i = 0; i < totalColumns; i++) {
+      Column column =
+          new Column()
+              .withName(String.format("col_%02d", i))
+              .withDataType(ColumnDataType.VARCHAR)
+              .withDataLength(100);
+      if (i == taggedColumnIndex) {
+        column.withTags(List.of(glossaryLabel));
+      }
+      columns.add(column);
+    }
+
+    CreateTable request = new CreateTable();
+    request.setName(ns.prefix("col_glossary_filter"));
+    request.setDatabaseSchema(schema.getFullyQualifiedName());
+    request.setColumns(columns);
+    Table table = createEntity(request);
+
+    String encodedFqn = URLEncoder.encode(table.getFullyQualifiedName(), StandardCharsets.UTF_8);
+    String taggedColumnName = String.format("col_%02d", taggedColumnIndex);
+
+    String encodedTerm = URLEncoder.encode(glossaryTermFqn, StandardCharsets.UTF_8);
+    TableColumnList byGlossaryTerm =
+        searchColumns(
+            client, encodedFqn, "limit=50&offset=0&fields=tags&glossaryTerms=" + encodedTerm);
+    assertEquals(
+        1,
+        byGlossaryTerm.getPaging().getTotal(),
+        "glossaryTerms filter should match the column tagged with the term across pages");
+    assertEquals(taggedColumnName, byGlossaryTerm.getData().get(0).getName());
+
+    String encodedDerivedTag = URLEncoder.encode(classificationTagFqn, StandardCharsets.UTF_8);
+    TableColumnList byDerivedTag =
+        searchColumns(
+            client, encodedFqn, "limit=50&offset=0&fields=tags&tags=" + encodedDerivedTag);
+    assertEquals(
+        1,
+        byDerivedTag.getPaging().getTotal(),
+        "tags filter should match the classification tag derived from the applied glossary term");
+    assertEquals(taggedColumnName, byDerivedTag.getData().get(0).getName());
+  }
+
+  @Test
+  void searchColumns_tagsAndGlossaryTermsCombineWithAnd(TestNamespace ns) throws Exception {
+    OpenMetadataClient client = SdkClients.adminClient();
+    DatabaseService service = DatabaseServiceTestFactory.createPostgres(ns);
+    DatabaseSchema schema = DatabaseSchemaTestFactory.createSimple(ns, service);
+
+    String classificationName = ns.prefix("AndFilter");
+    String tagFqn = createClassificationWithTag(client, classificationName, "Pii");
+    String glossaryTermFqn =
+        createGlossaryTermWithTag(client, ns.prefix("AndGlossary"), "CustomerData", null);
+
+    TagLabel classificationLabel =
+        new TagLabel()
+            .withTagFQN(tagFqn)
+            .withSource(TagSource.CLASSIFICATION)
+            .withLabelType(TagLabel.LabelType.MANUAL)
+            .withState(TagLabel.State.CONFIRMED);
+    TagLabel glossaryLabel =
+        new TagLabel()
+            .withTagFQN(glossaryTermFqn)
+            .withSource(TagSource.GLOSSARY)
+            .withLabelType(TagLabel.LabelType.MANUAL)
+            .withState(TagLabel.State.CONFIRMED);
+
+    Column tagOnly =
+        new Column()
+            .withName("col_tag_only")
+            .withDataType(ColumnDataType.VARCHAR)
+            .withDataLength(100)
+            .withTags(List.of(classificationLabel));
+    Column glossaryOnly =
+        new Column()
+            .withName("col_glossary_only")
+            .withDataType(ColumnDataType.VARCHAR)
+            .withDataLength(100)
+            .withTags(List.of(glossaryLabel));
+    Column both =
+        new Column()
+            .withName("col_both")
+            .withDataType(ColumnDataType.VARCHAR)
+            .withDataLength(100)
+            .withTags(List.of(classificationLabel, glossaryLabel));
+
+    CreateTable request = new CreateTable();
+    request.setName(ns.prefix("col_and_filter"));
+    request.setDatabaseSchema(schema.getFullyQualifiedName());
+    request.setColumns(List.of(tagOnly, glossaryOnly, both));
+    Table table = createEntity(request);
+
+    String encodedFqn = URLEncoder.encode(table.getFullyQualifiedName(), StandardCharsets.UTF_8);
+    String encodedTag = URLEncoder.encode(tagFqn, StandardCharsets.UTF_8);
+    String encodedTerm = URLEncoder.encode(glossaryTermFqn, StandardCharsets.UTF_8);
+
+    TableColumnList byTag =
+        searchColumns(client, encodedFqn, "limit=50&offset=0&fields=tags&tags=" + encodedTag);
+    assertEquals(
+        2, byTag.getPaging().getTotal(), "tags filter alone should match both tagged cols");
+
+    TableColumnList byTerm =
+        searchColumns(
+            client, encodedFqn, "limit=50&offset=0&fields=tags&glossaryTerms=" + encodedTerm);
+    assertEquals(
+        2, byTerm.getPaging().getTotal(), "glossaryTerms filter alone should match both term cols");
+
+    TableColumnList byBoth =
+        searchColumns(
+            client,
+            encodedFqn,
+            "limit=50&offset=0&fields=tags&tags=" + encodedTag + "&glossaryTerms=" + encodedTerm);
+    assertEquals(
+        1,
+        byBoth.getPaging().getTotal(),
+        "tags + glossaryTerms together should AND, matching only the column with both");
+    assertEquals("col_both", byBoth.getData().get(0).getName());
+  }
+
+  @Test
+  void searchColumns_nestedTagMatchKeepsAncestorAndCountsRoots(TestNamespace ns) throws Exception {
+    OpenMetadataClient client = SdkClients.adminClient();
+    DatabaseService service = DatabaseServiceTestFactory.createPostgres(ns);
+    DatabaseSchema schema = DatabaseSchemaTestFactory.createSimple(ns, service);
+
+    String classificationName = ns.prefix("NestedTagFilter");
+    String tagFqn = createClassificationWithTag(client, classificationName, "Sensitive");
+    TagLabel sensitiveLabel =
+        new TagLabel()
+            .withTagFQN(tagFqn)
+            .withSource(TagSource.CLASSIFICATION)
+            .withLabelType(TagLabel.LabelType.MANUAL)
+            .withState(TagLabel.State.CONFIRMED);
+
+    Column matchedChildOne =
+        new Column()
+            .withName("child_match_1")
+            .withDataType(ColumnDataType.VARCHAR)
+            .withDataLength(100)
+            .withTags(List.of(sensitiveLabel));
+    Column matchedChildTwo =
+        new Column()
+            .withName("child_match_2")
+            .withDataType(ColumnDataType.VARCHAR)
+            .withDataLength(100)
+            .withTags(List.of(sensitiveLabel));
+    Column unmatchedChild =
+        new Column()
+            .withName("child_plain")
+            .withDataType(ColumnDataType.VARCHAR)
+            .withDataLength(100);
+    Column structParent =
+        new Column()
+            .withName("struct_parent")
+            .withDataType(ColumnDataType.STRUCT)
+            .withChildren(List.of(matchedChildOne, unmatchedChild, matchedChildTwo));
+    Column siblingFlat =
+        new Column()
+            .withName("flat_plain")
+            .withDataType(ColumnDataType.VARCHAR)
+            .withDataLength(100);
+
+    CreateTable request = new CreateTable();
+    request.setName(ns.prefix("col_nested_filter"));
+    request.setDatabaseSchema(schema.getFullyQualifiedName());
+    request.setColumns(List.of(structParent, siblingFlat));
+    Table table = createEntity(request);
+
+    String encodedFqn = URLEncoder.encode(table.getFullyQualifiedName(), StandardCharsets.UTF_8);
+    String encodedTag = URLEncoder.encode(tagFqn, StandardCharsets.UTF_8);
+
+    TableColumnList filtered =
+        searchColumns(client, encodedFqn, "limit=50&offset=0&fields=tags&tags=" + encodedTag);
+
+    assertEquals(
+        1,
+        filtered.getPaging().getTotal(),
+        "Total should count top-level columns containing a match, not flattened matches");
+    assertEquals(1, filtered.getData().size());
+
+    Column returnedParent = filtered.getData().get(0);
+    assertEquals("struct_parent", returnedParent.getName());
+    assertNotNull(returnedParent.getChildren());
+    assertEquals(
+        2,
+        returnedParent.getChildren().size(),
+        "Matched children stay nested under their ancestor; the unmatched child is pruned");
+    List<String> childNames =
+        returnedParent.getChildren().stream().map(Column::getName).collect(Collectors.toList());
+    assertTrue(childNames.contains("child_match_1"));
+    assertTrue(childNames.contains("child_match_2"));
+    assertFalse(childNames.contains("child_plain"));
+    assertFalse(
+        filtered.getData().stream().anyMatch(c -> "flat_plain".equals(c.getName())),
+        "Non-matching top-level column should not appear");
+  }
+
+  private String createGlossaryTermWithTag(
+      OpenMetadataClient client, String glossaryName, String termName, String tagFqn) {
+    CreateGlossary createGlossary =
+        new CreateGlossary()
+            .withName(glossaryName)
+            .withDescription("Glossary for column tag filter test");
+    client
+        .getHttpClient()
+        .execute(HttpMethod.PUT, "/v1/glossaries", createGlossary, Glossary.class);
+
+    CreateGlossaryTerm createTerm =
+        new CreateGlossaryTerm()
+            .withName(termName)
+            .withGlossary(glossaryName)
+            .withDescription("Term for column tag filter test");
+    if (tagFqn != null) {
+      TagLabel classificationTag =
+          new TagLabel()
+              .withTagFQN(tagFqn)
+              .withSource(TagSource.CLASSIFICATION)
+              .withLabelType(TagLabel.LabelType.MANUAL)
+              .withState(TagLabel.State.CONFIRMED);
+      createTerm.withTags(List.of(classificationTag));
+    }
+    GlossaryTerm term =
+        client
+            .getHttpClient()
+            .execute(HttpMethod.PUT, "/v1/glossaryTerms", createTerm, GlossaryTerm.class);
+    return term.getFullyQualifiedName();
+  }
+
+  private String createClassificationWithTag(
+      OpenMetadataClient client, String classificationName, String tagName) {
+    CreateClassification createClassification =
+        new CreateClassification()
+            .withName(classificationName)
+            .withDescription("Classification for column tag filter test");
+    client
+        .getHttpClient()
+        .execute(HttpMethod.PUT, "/v1/classifications", createClassification, Classification.class);
+
+    CreateTag createTag =
+        new CreateTag()
+            .withName(tagName)
+            .withDescription("Tag for column tag filter test")
+            .withClassification(classificationName);
+    client.getHttpClient().execute(HttpMethod.PUT, "/v1/tags", createTag, Tag.class);
+    return classificationName + "." + tagName;
+  }
+
+  private TableColumnList searchColumns(
+      OpenMetadataClient client, String encodedFqn, String queryParams) {
+    String response =
+        client
+            .getHttpClient()
+            .executeForString(
+                HttpMethod.GET,
+                "/v1/tables/name/" + encodedFqn + "/columns/search?" + queryParams,
+                null);
+    return JsonUtils.readValue(response, TableColumnList.class);
+  }
+
+  private TableColumnList searchColumnsById(
+      OpenMetadataClient client, String tableId, String queryParams) {
+    String response =
+        client
+            .getHttpClient()
+            .executeForString(
+                HttpMethod.GET, "/v1/tables/" + tableId + "/columns/search?" + queryParams, null);
+    return JsonUtils.readValue(response, TableColumnList.class);
   }
 
   @Test

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/TableRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/TableRepository.java
@@ -34,6 +34,8 @@ import static org.openmetadata.service.Entity.getEntityReferenceById;
 import static org.openmetadata.service.Entity.populateEntityFieldTags;
 import static org.openmetadata.service.monitoring.RequestLatencyContext.phase;
 import static org.openmetadata.service.resources.tags.TagLabelUtil.addDerivedTagsGracefully;
+import static org.openmetadata.service.resources.tags.TagLabelUtil.addDerivedTagsWithPreFetched;
+import static org.openmetadata.service.resources.tags.TagLabelUtil.batchFetchDerivedTags;
 import static org.openmetadata.service.resources.tags.TagLabelUtil.mergeTagsWithIncomingPrecedence;
 import static org.openmetadata.service.search.SearchClient.GLOBAL_SEARCH_ALIAS;
 import static org.openmetadata.service.util.EntityUtil.getLocalColumnName;
@@ -3281,7 +3283,17 @@ public class TableRepository extends EntityRepository<Table> {
       Authorizer authorizer,
       SecurityContext securityContext) {
     return searchTableColumnsById(
-        id, query, limit, offset, fieldsParam, include, "name", "asc", authorizer, securityContext);
+        id,
+        query,
+        limit,
+        offset,
+        fieldsParam,
+        include,
+        "name",
+        "asc",
+        null,
+        authorizer,
+        securityContext);
   }
 
   public ResultList<Column> searchTableColumnsById(
@@ -3293,11 +3305,21 @@ public class TableRepository extends EntityRepository<Table> {
       Include include,
       String sortBy,
       String sortOrder,
+      ColumnTagFilter columnTagFilter,
       Authorizer authorizer,
       SecurityContext securityContext) {
     Table table = get(null, id, getFields(fieldsParam), include, false);
     return searchTableColumnsInternal(
-        table, query, limit, offset, fieldsParam, sortBy, sortOrder, authorizer, securityContext);
+        table,
+        query,
+        limit,
+        offset,
+        fieldsParam,
+        sortBy,
+        sortOrder,
+        columnTagFilter,
+        authorizer,
+        securityContext);
   }
 
   public ResultList<Column> searchTableColumnsByFQN(
@@ -3318,6 +3340,7 @@ public class TableRepository extends EntityRepository<Table> {
         include,
         "name",
         "asc",
+        null,
         authorizer,
         securityContext);
   }
@@ -3331,11 +3354,21 @@ public class TableRepository extends EntityRepository<Table> {
       Include include,
       String sortBy,
       String sortOrder,
+      ColumnTagFilter columnTagFilter,
       Authorizer authorizer,
       SecurityContext securityContext) {
     Table table = getByName(null, fqn, getFields(fieldsParam), include, false);
     return searchTableColumnsInternal(
-        table, query, limit, offset, fieldsParam, sortBy, sortOrder, authorizer, securityContext);
+        table,
+        query,
+        limit,
+        offset,
+        fieldsParam,
+        sortBy,
+        sortOrder,
+        columnTagFilter,
+        authorizer,
+        securityContext);
   }
 
   private ResultList<Column> searchTableColumnsInternal(
@@ -3346,86 +3379,179 @@ public class TableRepository extends EntityRepository<Table> {
       String fieldsParam,
       String sortBy,
       String sortOrder,
+      ColumnTagFilter columnTagFilter,
       Authorizer authorizer,
       SecurityContext securityContext) {
-    List<Column> allColumns = table.getColumns();
-    if (allColumns == null || allColumns.isEmpty()) {
+    if (nullOrEmpty(table.getColumns())) {
       return new ResultList<>(List.of(), null, null, 0);
     }
+    // Copy so pruning and field population never mutate the loaded entity's column tree.
+    List<Column> allColumns = JsonUtils.deepCopyList(table.getColumns(), Column.class);
 
-    // Flatten nested columns for search
-    List<Column> flattenedColumns = flattenTableColumns(allColumns);
+    String searchTerm = nullOrEmpty(query) ? null : query.toLowerCase().trim();
+    boolean hasTagFilter = columnTagFilter != null && !columnTagFilter.isEmpty();
+    Map<String, List<TagLabel>> tagsByHash =
+        hasTagFilter ? resolveColumnTagsForFilter(table) : Map.of();
 
-    List<Column> matchingColumns;
-    if (query == null || query.trim().isEmpty()) {
-      matchingColumns = new ArrayList<>(flattenedColumns);
-    } else {
-      String searchTerm = query.toLowerCase().trim();
-      matchingColumns =
-          new ArrayList<>(
-              flattenedColumns.stream()
-                  .filter(
-                      column -> {
-                        if (column.getName() != null
-                            && column.getName().toLowerCase().contains(searchTerm)) {
-                          return true;
-                        }
-                        return column.getDisplayName() != null
-                            && column.getDisplayName().toLowerCase().contains(searchTerm);
-                      })
-                  .toList());
+    List<Column> matchingTree =
+        pruneColumnsToMatches(allColumns, searchTerm, columnTagFilter, tagsByHash);
+    matchingTree.sort(columnComparator(sortBy, sortOrder));
+
+    int total = matchingTree.size();
+    int startIndex = Math.min(offset, total);
+    int endIndex = Math.min(offset + limit, total);
+    List<Column> paginatedRoots =
+        startIndex < total
+            ? new ArrayList<>(matchingTree.subList(startIndex, endIndex))
+            : List.of();
+
+    List<Column> paginatedColumns = flattenTableColumns(paginatedRoots);
+    Fields fields = getFields(fieldsParam);
+    if (fields.contains("customMetrics") || fields.contains("*")) {
+      Map<String, List<CustomMetric>> metricsByColumn =
+          batchFetchCustomMetricsByColumn(table.getId());
+      for (Column column : paginatedColumns) {
+        column.setCustomMetrics(metricsByColumn.getOrDefault(column.getName(), List.of()));
+      }
     }
 
-    // Sort matching columns based on sortBy and sortOrder parameters
+    if (fields.contains("tags") || fields.contains("*")) {
+      populateEntityFieldTags(entityType, paginatedColumns, table.getFullyQualifiedName(), true);
+    }
+
+    if (fieldsParam != null && fieldsParam.contains("profile")) {
+      setColumnProfile(paginatedColumns);
+      populateEntityFieldTags(entityType, paginatedColumns, table.getFullyQualifiedName(), true);
+      PIIMasker.getTableProfile(
+          table.getFullyQualifiedName(), paginatedColumns, authorizer, securityContext);
+    }
+
+    String before = offset > 0 ? String.valueOf(Math.max(0, offset - limit)) : null;
+    String after = endIndex < total ? String.valueOf(endIndex) : null;
+    return new ResultList<>(paginatedRoots, before, after, total);
+  }
+
+  /**
+   * Prune the column tree to nodes that match the search term and tag filter, keeping every matched
+   * node at its real depth together with its ancestor path. Mirrors the UI's getFilteredTagsData so
+   * the server-side filter renders the same nested view, paginated across the whole table instead of
+   * the loaded page. A node is kept when it matches itself or has a kept descendant; a kept node's
+   * children are pruned to the matched paths only.
+   */
+  private List<Column> pruneColumnsToMatches(
+      List<Column> columns,
+      String searchTerm,
+      ColumnTagFilter columnTagFilter,
+      Map<String, List<TagLabel>> tagsByHash) {
+    List<Column> pruned = new ArrayList<>();
+    for (Column column : columns) {
+      List<Column> prunedChildren =
+          nullOrEmpty(column.getChildren())
+              ? new ArrayList<>()
+              : pruneColumnsToMatches(
+                  column.getChildren(), searchTerm, columnTagFilter, tagsByHash);
+      boolean matches = columnMatchesSearch(column, searchTerm, columnTagFilter, tagsByHash);
+      if (matches || !prunedChildren.isEmpty()) {
+        column.setChildren(prunedChildren);
+        pruned.add(column);
+      }
+    }
+    return pruned;
+  }
+
+  private boolean columnMatchesSearch(
+      Column column,
+      String searchTerm,
+      ColumnTagFilter columnTagFilter,
+      Map<String, List<TagLabel>> tagsByHash) {
+    boolean matchesQuery = searchTerm == null || columnNameMatches(column, searchTerm);
+    boolean matchesTags =
+        columnTagFilter == null
+            || columnTagFilter.isEmpty()
+            || columnMatchesTagFilter(column, columnTagFilter, tagsByHash);
+    return matchesQuery && matchesTags;
+  }
+
+  private boolean columnNameMatches(Column column, String searchTerm) {
+    boolean nameMatches =
+        column.getName() != null && column.getName().toLowerCase().contains(searchTerm);
+    boolean displayNameMatches =
+        column.getDisplayName() != null
+            && column.getDisplayName().toLowerCase().contains(searchTerm);
+    return nameMatches || displayNameMatches;
+  }
+
+  private Comparator<Column> columnComparator(String sortBy, String sortOrder) {
     Comparator<Column> comparator;
     if ("ordinalPosition".equals(sortBy)) {
       comparator =
           Comparator.comparing(
               Column::getOrdinalPosition, Comparator.nullsLast(Comparator.naturalOrder()));
     } else {
-      // Default: sort by name
       comparator =
           Comparator.comparing(
               Column::getName, Comparator.nullsLast(String.CASE_INSENSITIVE_ORDER));
     }
-
-    // Apply sort order (desc reverses the comparator)
     if ("desc".equalsIgnoreCase(sortOrder)) {
       comparator = comparator.reversed();
     }
-    matchingColumns.sort(comparator);
+    return comparator;
+  }
 
-    int total = matchingColumns.size();
-    int startIndex = Math.min(offset, total);
-    int endIndex = Math.min(offset + limit, total);
-
-    List<Column> paginatedResults =
-        startIndex < total ? matchingColumns.subList(startIndex, endIndex) : List.of();
-
-    Fields fields = getFields(fieldsParam);
-    if (fields.contains("customMetrics") || fields.contains("*")) {
-      Map<String, List<CustomMetric>> metricsByColumn =
-          batchFetchCustomMetricsByColumn(table.getId());
-      for (Column column : paginatedResults) {
-        column.setCustomMetrics(metricsByColumn.getOrDefault(column.getName(), List.of()));
-      }
+  /**
+   * Column-level tag filter. {@code tagFQNs} and {@code glossaryTermFQNs} mirror the two
+   * independent column filters in the UI. Values within each group are OR-ed; the two groups are
+   * AND-ed when both are present (matching AntD's cross-column filter semantics).
+   */
+  public record ColumnTagFilter(Set<String> tagFQNs, Set<String> glossaryTermFQNs) {
+    public boolean isEmpty() {
+      return nullOrEmpty(tagFQNs) && nullOrEmpty(glossaryTermFQNs);
     }
+  }
 
-    if (fields.contains("tags") || fields.contains("*")) {
-      populateEntityFieldTags(entityType, paginatedResults, table.getFullyQualifiedName(), true);
+  /**
+   * Resolve column tags the same way the column list responses (and therefore the UI filter
+   * dropdown) see them: direct tag_usage rows enriched with glossary-derived tags. The raw DAO is
+   * used instead of {@link #getTagsByPrefix} so certification-classification tags are not stripped,
+   * keeping the filter consistent with the tags shown on each column.
+   */
+  private Map<String, List<TagLabel>> resolveColumnTagsForFilter(Table table) {
+    Map<String, List<TagLabel>> directTagsByHash =
+        daoCollection.tagUsageDAO().getTagsByPrefix(table.getFullyQualifiedName(), ".%", true);
+    if (nullOrEmpty(directTagsByHash)) {
+      return Map.of();
     }
-
-    if (fieldsParam != null && fieldsParam.contains("profile")) {
-      setColumnProfile(matchingColumns);
-      populateEntityFieldTags(entityType, matchingColumns, table.getFullyQualifiedName(), true);
-      matchingColumns =
-          PIIMasker.getTableProfile(
-              table.getFullyQualifiedName(), matchingColumns, authorizer, securityContext);
+    List<TagLabel> allDirectTags =
+        directTagsByHash.values().stream().flatMap(List::stream).collect(Collectors.toList());
+    Map<String, List<TagLabel>> derivedTagsMap;
+    try {
+      derivedTagsMap = batchFetchDerivedTags(allDirectTags);
+    } catch (Exception ex) {
+      LOG.warn("Failed to fetch derived tags for column tag filter; matching direct tags only", ex);
+      derivedTagsMap = Map.of();
     }
+    Map<String, List<TagLabel>> effectiveTagsByHash = new HashMap<>();
+    for (Map.Entry<String, List<TagLabel>> entry : directTagsByHash.entrySet()) {
+      effectiveTagsByHash.put(
+          entry.getKey(), addDerivedTagsWithPreFetched(entry.getValue(), derivedTagsMap));
+    }
+    return effectiveTagsByHash;
+  }
 
-    String before = offset > 0 ? String.valueOf(Math.max(0, offset - limit)) : null;
-    String after = endIndex < total ? String.valueOf(endIndex) : null;
-    return new ResultList<>(paginatedResults, before, after, total);
+  private boolean columnMatchesTagFilter(
+      Column column, ColumnTagFilter columnTagFilter, Map<String, List<TagLabel>> tagsByHash) {
+    List<TagLabel> tags =
+        tagsByHash.get(FullyQualifiedName.buildHash(column.getFullyQualifiedName()));
+    Set<String> columnTagFQNs =
+        nullOrEmpty(tags)
+            ? Set.of()
+            : tags.stream().map(TagLabel::getTagFQN).collect(Collectors.toSet());
+    return matchesTagGroup(columnTagFQNs, columnTagFilter.tagFQNs())
+        && matchesTagGroup(columnTagFQNs, columnTagFilter.glossaryTermFQNs());
+  }
+
+  private boolean matchesTagGroup(Set<String> columnTagFQNs, Set<String> filterGroup) {
+    return nullOrEmpty(filterGroup) || filterGroup.stream().anyMatch(columnTagFQNs::contains);
   }
 
   private List<Column> flattenTableColumns(List<Column> columns) {

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/databases/TableResource.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/databases/TableResource.java
@@ -47,7 +47,9 @@ import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.SecurityContext;
 import jakarta.ws.rs.core.UriInfo;
 import java.io.IOException;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.UUID;
 import org.openmetadata.schema.api.VoteRequest;
 import org.openmetadata.schema.api.data.CreateTable;
@@ -81,6 +83,7 @@ import org.openmetadata.schema.utils.ResultList;
 import org.openmetadata.service.Entity;
 import org.openmetadata.service.jdbi3.ListFilter;
 import org.openmetadata.service.jdbi3.TableRepository;
+import org.openmetadata.service.jdbi3.TableRepository.ColumnTagFilter;
 import org.openmetadata.service.limits.Limits;
 import org.openmetadata.service.monitoring.LatencyPhase;
 import org.openmetadata.service.resources.Collection;
@@ -2006,7 +2009,19 @@ public class TableResource extends EntityResource<Table, TableRepository> {
                       allowableValues = {"asc", "desc"}))
           @QueryParam("sortOrder")
           @DefaultValue("asc")
-          String sortOrder) {
+          String sortOrder,
+      @Parameter(
+              description =
+                  "Filter by classification tags at column level (comma-separated tag FQNs)",
+              example = "PII.Sensitive,PersonalData.Email")
+          @QueryParam("tags")
+          String tags,
+      @Parameter(
+              description =
+                  "Filter by glossary terms at column level (comma-separated glossary term FQNs)",
+              example = "Business.CustomerData,Business.Revenue")
+          @QueryParam("glossaryTerms")
+          String glossaryTerms) {
     OperationContext operationContext =
         new OperationContext(entityType, MetadataOperation.VIEW_BASIC);
     authorizer.authorize(securityContext, operationContext, getResourceContextById(id));
@@ -2020,6 +2035,7 @@ public class TableResource extends EntityResource<Table, TableRepository> {
             include,
             sortBy,
             sortOrder,
+            parseColumnTagFilters(tags, glossaryTerms),
             authorizer,
             securityContext);
     TableColumnList tableColumnList = new TableColumnList();
@@ -2095,7 +2111,19 @@ public class TableResource extends EntityResource<Table, TableRepository> {
                       allowableValues = {"asc", "desc"}))
           @QueryParam("sortOrder")
           @DefaultValue("asc")
-          String sortOrder) {
+          String sortOrder,
+      @Parameter(
+              description =
+                  "Filter by classification tags at column level (comma-separated tag FQNs)",
+              example = "PII.Sensitive,PersonalData.Email")
+          @QueryParam("tags")
+          String tags,
+      @Parameter(
+              description =
+                  "Filter by glossary terms at column level (comma-separated glossary term FQNs)",
+              example = "Business.CustomerData,Business.Revenue")
+          @QueryParam("glossaryTerms")
+          String glossaryTerms) {
     OperationContext operationContext =
         new OperationContext(entityType, MetadataOperation.VIEW_BASIC);
     authorizer.authorize(securityContext, operationContext, getResourceContextByName(fqn));
@@ -2109,11 +2137,30 @@ public class TableResource extends EntityResource<Table, TableRepository> {
             include,
             sortBy,
             sortOrder,
+            parseColumnTagFilters(tags, glossaryTerms),
             authorizer,
             securityContext);
     TableColumnList tableColumnList = new TableColumnList();
     tableColumnList.setData(result.getData());
     tableColumnList.setPaging(result.getPaging());
     return tableColumnList;
+  }
+
+  private ColumnTagFilter parseColumnTagFilters(String tags, String glossaryTerms) {
+    return new ColumnTagFilter(parseFqnCsv(tags), parseFqnCsv(glossaryTerms));
+  }
+
+  private Set<String> parseFqnCsv(String csv) {
+    if (csv == null || csv.isBlank()) {
+      return Set.of();
+    }
+    Set<String> fqns = new HashSet<>();
+    for (String fqn : csv.split(",")) {
+      String trimmed = fqn.trim();
+      if (!trimmed.isEmpty()) {
+        fqns.add(trimmed);
+      }
+    }
+    return fqns;
   }
 }

--- a/openmetadata-ui/src/main/resources/ui/src/components/Database/SchemaTable/SchemaTable.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Database/SchemaTable/SchemaTable.component.tsx
@@ -18,6 +18,7 @@ import {
   Form,
   Row,
   Select,
+  TableProps,
   Tooltip,
   Typography,
 } from 'antd';
@@ -69,7 +70,6 @@ import { useFqnDeepLink } from '../../../hooks/useFqnDeepLink';
 import { useSub } from '../../../hooks/usePubSub';
 import { useScrollToElement } from '../../../hooks/useScrollToElement';
 import { useTableFilters } from '../../../hooks/useTableFilters';
-import { useTreeTagFilter } from '../../../hooks/useTreeTagFilter';
 import {
   getTableColumnsByFQN,
   searchTableColumnsByFQN,
@@ -124,6 +124,10 @@ const SchemaTable = () => {
   const [editColumn, setEditColumn] = useState<Column>();
   const [sortBy, setSortBy] = useState<'name' | 'ordinalPosition'>('name');
   const [sortOrder, setSortOrder] = useState<'asc' | 'desc'>('asc');
+  const [activeTagFilter, setActiveTagFilter] = useState<{
+    tags: string[];
+    glossaryTerms: string[];
+  }>({ tags: [], glossaryTerms: [] });
 
   const {
     currentPage,
@@ -140,6 +144,10 @@ const SchemaTable = () => {
   });
 
   const searchText = filters.columnSearch ?? '';
+
+  const tagsParam = activeTagFilter.tags.join(',');
+  const glossaryTermsParam = activeTagFilter.glossaryTerms.join(',');
+  const hasTagFilter = Boolean(tagsParam || glossaryTermsParam);
 
   // Pagination state for columns
   const [tableColumns, setTableColumns] = useState<Column[]>([]);
@@ -237,6 +245,8 @@ const SchemaTable = () => {
           fields: 'tags,customMetrics,extension',
           sortBy: sortByParam,
           sortOrder: sortOrderParam,
+          ...(tagsParam ? { tags: tagsParam } : {}),
+          ...(glossaryTermsParam ? { glossaryTerms: glossaryTermsParam } : {}),
         });
 
         setTableColumns(pruneEmptyChildren(response.data) || []);
@@ -252,7 +262,15 @@ const SchemaTable = () => {
         setColumnsLoading(false);
       }
     },
-    [tableFqn, pageSize, handlePagingChange, sortBy, sortOrder]
+    [
+      tableFqn,
+      pageSize,
+      handlePagingChange,
+      sortBy,
+      sortOrder,
+      tagsParam,
+      glossaryTermsParam,
+    ]
   );
 
   const fetchTableColumns = useCallback(
@@ -302,6 +320,22 @@ const SchemaTable = () => {
     [handlePageChange]
   );
 
+  const handleColumnFilterChange = useCallback<
+    NonNullable<TableProps<Column>['onChange']>
+  >(
+    (_pagination, tableFilters) => {
+      const tags = (tableFilters?.[TABLE_COLUMNS_KEYS.TAGS] as string[]) ?? [];
+      const glossaryTerms =
+        (tableFilters?.[TABLE_COLUMNS_KEYS.GLOSSARY] as string[]) ?? [];
+      setActiveTagFilter({ tags, glossaryTerms });
+      handlePageChange(INITIAL_PAGING_VALUE, {
+        cursorType: null,
+        cursorValue: undefined,
+      });
+    },
+    [handlePageChange]
+  );
+
   const fetchTestCaseSummary = async () => {
     try {
       const response = await getTestCaseExecutionSummary(table?.testSuite?.id);
@@ -316,13 +350,20 @@ const SchemaTable = () => {
   }, [tableFqn]);
 
   useEffect(() => {
-    if (searchText) {
+    if (searchText || hasTagFilter) {
       searchTableColumns(searchText, currentPage, sortBy, sortOrder);
     }
-  }, [searchText, currentPage, searchTableColumns, sortBy, sortOrder]);
+  }, [
+    searchText,
+    hasTagFilter,
+    currentPage,
+    searchTableColumns,
+    sortBy,
+    sortOrder,
+  ]);
 
   useEffect(() => {
-    if (searchText) {
+    if (searchText || hasTagFilter) {
       return;
     }
     fetchTableColumns(currentPage, sortBy, sortOrder);
@@ -331,6 +372,7 @@ const SchemaTable = () => {
     pageSize,
     currentPage,
     searchText,
+    hasTagFilter,
     fetchTableColumns,
     sortBy,
     sortOrder,
@@ -583,13 +625,16 @@ const SchemaTable = () => {
   };
 
   const tagFilter = useMemo(() => {
-    const tags = getAllTags(tableColumns);
+    const tags = getAllTags([
+      ...((table?.columns as Column[]) ?? []),
+      ...tableColumns,
+    ]);
 
     return groupBy(tags, (tag) => tag.source) as Record<
       TagSource,
       TagFilterOptions[]
     >;
-  }, [tableColumns]);
+  }, [table?.columns, tableColumns]);
 
   const handleColumnClick = useCallback(
     (column: Column, event: React.MouseEvent) => {
@@ -733,9 +778,6 @@ const SchemaTable = () => {
     [testCaseCounts]
   );
 
-  const { tagFilterState, filteredData, handleTableChange } =
-    useTreeTagFilter<Column>(tableColumns);
-
   const columns: ColumnsType<Column> = useMemo(
     () => [
       {
@@ -807,7 +849,9 @@ const SchemaTable = () => {
         ),
         filters: tagFilter.Classification,
         filterDropdown: ColumnFilter,
-        filteredValue: tagFilterState[TABLE_COLUMNS_KEYS.TAGS] ?? null,
+        filteredValue: activeTagFilter.tags.length
+          ? activeTagFilter.tags
+          : null,
       },
       {
         title: t('label.glossary-term-plural'),
@@ -830,7 +874,9 @@ const SchemaTable = () => {
         ),
         filters: tagFilter.Glossary,
         filterDropdown: ColumnFilter,
-        filteredValue: tagFilterState[TABLE_COLUMNS_KEYS.GLOSSARY] ?? null,
+        filteredValue: activeTagFilter.glossaryTerms.length
+          ? activeTagFilter.glossaryTerms
+          : null,
       },
       {
         title: t('label.data-quality'),
@@ -851,7 +897,7 @@ const SchemaTable = () => {
       renderDisplayName,
       renderDataQuality,
       tagFilter,
-      tagFilterState,
+      activeTagFilter,
       sortBy,
       sortOrder,
       handleColumnHeaderSortToggle,
@@ -892,11 +938,12 @@ const SchemaTable = () => {
 
   useEffect(() => {
     setExpandedRowKeys((prev) => {
-      const autoKeys = getExpandAllKeysToDepth(tableColumns ?? [], 1);
+      const depth = searchText || hasTagFilter ? Number.MAX_SAFE_INTEGER : 1;
+      const autoKeys = getExpandAllKeysToDepth(tableColumns ?? [], depth);
 
       return [...new Set([...autoKeys, ...prev])];
     });
-  }, [tableColumns]);
+  }, [tableColumns, searchText, hasTagFilter]);
 
   // Sync displayed columns with GenericProvider for ColumnDetailPanel navigation
   useEffect(() => {
@@ -923,7 +970,7 @@ const SchemaTable = () => {
       currentPage,
       showPagination,
       isLoading: columnsLoading,
-      isNumberBased: Boolean(searchText),
+      isNumberBased: Boolean(searchText || hasTagFilter),
       pageSize,
       paging,
       pagingHandler: handleColumnsPageChange,
@@ -934,6 +981,7 @@ const SchemaTable = () => {
       showPagination,
       columnsLoading,
       searchText,
+      hasTagFilter,
       pageSize,
       paging,
       handleColumnsPageChange,
@@ -949,7 +997,7 @@ const SchemaTable = () => {
           columns={columns}
           customPaginationProps={paginationProps}
           data-testid="entity-table"
-          dataSource={filteredData}
+          dataSource={tableColumns}
           defaultVisibleColumns={DEFAULT_SCHEMA_TABLE_VISIBLE_COLUMNS}
           expandable={expandableConfig}
           extraTableFilters={
@@ -983,7 +1031,7 @@ const SchemaTable = () => {
           searchProps={searchProps}
           size="middle"
           staticVisibleColumns={COMMON_STATIC_TABLE_VISIBLE_COLUMNS}
-          onChange={handleTableChange}
+          onChange={handleColumnFilterChange}
         />
       </Col>
       {editColumn && (

--- a/openmetadata-ui/src/main/resources/ui/src/components/Database/SchemaTable/SchemaTable.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Database/SchemaTable/SchemaTable.test.tsx
@@ -16,8 +16,12 @@ import { MemoryRouter } from 'react-router-dom';
 import { Column } from '../../../generated/entity/data/container';
 import { Table } from '../../../generated/entity/data/table';
 import { MOCK_TABLE } from '../../../mocks/TableData.mock';
-import { getTableColumnsByFQN } from '../../../rest/tableAPI';
+import {
+  getTableColumnsByFQN,
+  searchTableColumnsByFQN,
+} from '../../../rest/tableAPI';
 import { DEFAULT_ENTITY_PERMISSION } from '../../../utils/PermissionsUtils';
+import { getAllTags } from '../../../utils/TableTags/TableTags.utils';
 import SchemaTable from './SchemaTable.component';
 
 const mockTableConstraints = [
@@ -426,6 +430,22 @@ describe('Test EntityTable Component', () => {
     const tableDescription = screen.getAllByText('TableDescription');
 
     expect(tableDescription).toHaveLength(3);
+  });
+
+  it('should source column tag filter options from the full table columns, not the loaded page', async () => {
+    (getTableColumnsByFQN as jest.Mock).mockResolvedValueOnce({
+      data: [mockColumns[0]],
+      paging: { total: mockColumns.length },
+    });
+
+    await act(async () => {
+      render(<SchemaTable />, {
+        wrapper: MemoryRouter,
+      });
+    });
+
+    expect(getAllTags).toHaveBeenCalledWith(mockColumns);
+    expect(searchTableColumnsByFQN).not.toHaveBeenCalled();
   });
 
   it('Table should load empty when no data present', async () => {

--- a/openmetadata-ui/src/main/resources/ui/src/rest/tableAPI.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/rest/tableAPI.ts
@@ -315,6 +315,8 @@ export const getTableColumnsByFQN = async (
 
 export interface SearchTableColumnsParams extends GetTableColumnsParams {
   q?: string; // Search query
+  tags?: string; // Comma-separated classification tag FQNs to filter columns by
+  glossaryTerms?: string; // Comma-separated glossary term FQNs to filter columns by
 }
 
 export const searchTableColumnsById = async (


### PR DESCRIPTION
Cherry-picks #29324 into `1.13`.

Original: `fix(table): server-side column tag filter across all pages (#25063)` — merge commit `3a66dae8eb9ea1dc60ae45e9d8e9e73a829af167` on `main`.

### Why
On the table **Schema** view, columns paginate server-side but tag filtering ran client-side over the loaded page only, so matches on later pages were hidden. This moves tag / glossary-term filtering into the same server-side layer as pagination, so it spans the whole table.

### What changed (identical to #29324)
- **Backend**: `tags` + `glossaryTerms` query params on both `/columns/search` endpoints; server-side tree pruning that keeps matches at their real nested depth; `total` counts top-level columns containing a match; within-group OR, across-group AND semantics.
- **Frontend**: Schema table filters call the server search and reset to page 1; dropdown options sourced from the full table; ancestors of matches auto-expand.

### Verification
- Cherry-pick applied cleanly (no conflicts).
- `git diff 3a66dae8 HEAD` over the 6 changed source files is empty — byte-identical to the original.
- `mvn clean install -pl openmetadata-service,openmetadata-integration-tests -am -DskipTests` → **BUILD SUCCESS** (both modules SUCCESS).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR moves schema-column tag filtering into the server-side column search path.

- Adds `tags` and `glossaryTerms` query params to both column search endpoints.
- Prunes matching column trees on the backend before pagination.
- Updates the schema table UI to call server search for tag filters.
- Adds integration and UI tests for cross-page tag filtering.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The backend column search path needs fixes before merging.

- Text-only column search can now return parent roots instead of flat matching child columns.
- Derived-tag lookup failures can return successful but incomplete filtered results.
- The UI expansion change can hurt large nested schemas, but it is contained to filtered or searched views.

openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/TableRepository.java
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/TableRepository.java | Adds the core server-side column filter logic, with issues around text-search compatibility and derived-tag failure handling. |
| openmetadata-service/src/main/java/org/openmetadata/service/resources/databases/TableResource.java | Adds tag and glossary query parameters and passes parsed filter sets into the repository. |
| openmetadata-ui/src/main/resources/ui/src/components/Database/SchemaTable/SchemaTable.component.tsx | Replaces client-side tag filtering with server search state and expands filtered result trees. |
| openmetadata-ui/src/main/resources/ui/src/rest/tableAPI.ts | Extends column search params with optional tag and glossary filter strings. |
| openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/TableResourceIT.java | Adds backend tests for tag, glossary, derived tag, AND, and nested filtering behavior. |
| openmetadata-ui/src/main/resources/ui/src/components/Database/SchemaTable/SchemaTable.test.tsx | Adds UI coverage for sourcing filter options from the full table column list. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
  participant UI as SchemaTable UI
  participant API as TableResource columns/search
  participant Repo as TableRepository
  participant Tags as tag usage and derived tags

  UI->>API: q, limit, offset, tags, glossaryTerms
  API->>Repo: ColumnTagFilter
  Repo->>Tags: load direct column tags
  Repo->>Tags: load derived tags
  Repo->>Repo: prune matching column tree
  Repo-->>API: TableColumnList with paging
  API-->>UI: filtered columns
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
  participant UI as SchemaTable UI
  participant API as TableResource columns/search
  participant Repo as TableRepository
  participant Tags as tag usage and derived tags

  UI->>API: q, limit, offset, tags, glossaryTerms
  API->>Repo: ColumnTagFilter
  Repo->>Tags: load direct column tags
  Repo->>Tags: load derived tags
  Repo->>Repo: prune matching column tree
  Repo-->>API: TableColumnList with paging
  API-->>UI: filtered columns
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(table): server-side column tag filte..."](https://github.com/open-metadata/openmetadata/commit/7f2cfc059a6460759e3fdd52a3dbbe8330978d31) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42687353)</sub>

> Greptile also left **3 inline comments** on this PR.

**Context used:**

- Context used - CLAUDE.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=52f0d9d9-cad1-4e7d-b070-de181a0aa5e7))
- Context used - openmetadata-ui-core-components/CLAUDE.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=41754627-b2bf-474b-8082-f37ef1a07013))

<!-- /greptile_comment -->