### PR TITLE
Removed bulk delete material ui component

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/common/atoms/actions/useDelete.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/atoms/actions/useDelete.tsx
@@ -11,25 +11,14 @@
  *  limitations under the License.
  */
 
-import {
-  Badge,
-  Box,
-  Button,
-  Dialog,
-  DialogActions,
-  DialogContent,
-  DialogTitle,
-  IconButton,
-  Typography,
-  useTheme,
-} from '@mui/material';
+import { Badge, ButtonUtility } from '@openmetadata/ui-core-components';
 import { Trash01 } from '@untitledui/icons';
 import { useCallback, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { deleteEntity } from '../../../../rest/miscAPI';
 import { getEntityName } from '../../../../utils/EntityNameUtils';
 import { showErrorToast, showSuccessToast } from '../../../../utils/ToastUtils';
-import Loader from '../../Loader/Loader';
+import { DeleteModal } from '../../DeleteModal/DeleteModal';
 
 interface UseDeleteConfig<
   T extends { id: string; name?: string; displayName?: string }
@@ -42,7 +31,7 @@ interface UseDeleteConfig<
 }
 
 /**
- * Generic delete hook for handling entity deletion with MUI components
+ * Generic delete hook for handling entity deletion with core-components
  *
  * @description
  * Provides a reusable delete functionality for any entity type with:
@@ -76,7 +65,6 @@ export const useDelete = <
   onDeleteComplete,
   onCancel,
 }: UseDeleteConfig<T>) => {
-  const theme = useTheme();
   const { t } = useTranslation();
   const [isOpen, setIsOpen] = useState(false);
   const [isDeleting, setIsDeleting] = useState(false);
@@ -114,22 +102,22 @@ export const useDelete = <
     }`;
   }, [selectedEntities, entityLabel]);
 
-  const getDeleteMessage = useCallback(() => {
-    if (selectedEntities.length === 0) {
-      return '';
+  const deleteConfirmationMessage = useMemo(() => {
+    if (selectedEntities.length > 1) {
+      return t('message.are-you-sure-you-want-to-delete-these-entities', {
+        count: selectedEntities.length,
+        entity: entityLabel?.toLowerCase() || 'items',
+      });
     }
 
     if (selectedEntities.length === 1) {
-      const name = getEntityName(selectedEntities[0]);
-
-      return name ? `"${name}"` : `this ${entityLabel || 'item'}`;
+      return t('message.are-you-sure-you-want-to-delete-this-entity', {
+        entity: entityLabel?.toLowerCase() || 'item',
+      });
     }
 
-    // For multiple, show count with entity type
-    return `these ${selectedEntities.length} ${entityLabel || 'item'}${
-      selectedEntities.length > 1 ? 's' : ''
-    }`;
-  }, [selectedEntities, entityLabel]);
+    return '';
+  }, [selectedEntities.length, entityLabel, t]);
 
   const handleDelete = useCallback(async () => {
     setIsDeleting(true);
@@ -170,166 +158,52 @@ export const useDelete = <
 
     setIsDeleting(false);
     setIsOpen(false);
-  }, [selectedEntities, entityType, entityLabel, onDeleteComplete]);
+  }, [selectedEntities, entityType, entityLabel, onDeleteComplete, t]);
 
   const deleteIconButton = useMemo(
-    () =>
-      selectedEntities.length > 1 ? (
-        <Badge
-          badgeContent={selectedEntities.length}
-          color="error"
-          sx={{
-            '& .MuiBadge-badge': {
-              backgroundColor: theme.palette.allShades?.error?.[600],
-            },
-          }}>
-          <IconButton
-            color="primary"
-            disabled={selectedEntities.length === 0}
-            size="small"
-            sx={{
-              color: theme.palette.allShades?.gray?.[600],
-            }}
-            onClick={openModal}>
-            <Trash01 size={20} />
-          </IconButton>
-        </Badge>
-      ) : (
-        <IconButton
-          color="primary"
-          disabled={selectedEntities.length === 0}
-          size="small"
-          sx={{
-            color: theme.palette.allShades?.gray?.[600],
-          }}
-          onClick={openModal}>
-          <Trash01 size={20} />
-        </IconButton>
-      ),
-    [selectedEntities.length, openModal, theme.palette.allShades]
+    () => (
+      <div className="tw:relative tw:inline-flex">
+        <ButtonUtility
+          color="tertiary"
+          data-testid="delete-selected"
+          icon={Trash01}
+          isDisabled={selectedEntities.length === 0}
+          size="sm"
+          tooltip={t('label.delete')}
+          onClick={openModal}
+        />
+        {selectedEntities.length > 1 && (
+          <Badge
+            className="tw:pointer-events-none tw:absolute tw:-right-1 tw:-top-1"
+            color="error"
+            size="xs"
+            type="pill-color">
+            {selectedEntities.length}
+          </Badge>
+        )}
+      </div>
+    ),
+    [selectedEntities.length, openModal, t]
   );
 
   const deleteModal = useMemo(
     () => (
-      <Dialog
+      <DeleteModal
+        entityTitle={getEntityTitle()}
+        isDeleting={isDeleting}
+        message={deleteConfirmationMessage}
         open={isOpen}
-        slotProps={{
-          paper: {
-            sx: {
-              borderRadius: 2,
-              width: 400,
-              maxWidth: '100%',
-            },
-          },
-        }}
-        onClose={handleCancel}>
-        <Box sx={{ p: 6 }}>
-          <Box
-            sx={{
-              alignItems: 'center',
-              backgroundColor: theme.palette.allShades?.error?.[50],
-              borderRadius: '50%',
-              display: 'flex',
-              height: 48,
-              justifyContent: 'center',
-              mb: 4,
-              width: 48,
-            }}>
-            <Trash01 color={theme.palette.allShades?.error?.[600]} size={24} />
-          </Box>
-
-          <DialogTitle
-            sx={{
-              mb: 0.5,
-              p: 0,
-              fontWeight: 600,
-              fontSize: '16px',
-              lineHeight: 1.5,
-              '&.MuiDialogTitle-root': {
-                padding: 0,
-                fontWeight: 600,
-                fontSize: '16px',
-                lineHeight: 1.5,
-              },
-            }}>
-            {t('label.delete')} {getEntityTitle()}
-          </DialogTitle>
-
-          <DialogContent
-            sx={{
-              mb: 8,
-              p: 0,
-              '&.MuiDialogContent-root': { padding: 0 },
-            }}>
-            <Typography
-              color="text.secondary"
-              sx={{
-                fontWeight: 400,
-                fontSize: '14px',
-                lineHeight: 1.43,
-              }}>
-              {selectedEntities.length > 1
-                ? t('message.are-you-sure-you-want-to-delete-these-entities', {
-                    count: selectedEntities.length,
-                    entity: entityLabel?.toLowerCase() || 'items',
-                  })
-                : selectedEntities.length === 1
-                ? t('message.are-you-sure-you-want-to-delete-this-entity', {
-                    entity: entityLabel?.toLowerCase() || 'item',
-                  })
-                : ''}
-            </Typography>
-          </DialogContent>
-
-          <DialogActions
-            sx={{
-              display: 'flex',
-              gap: 1,
-              p: 0,
-              '&.MuiDialogActions-root': {
-                padding: 0,
-              },
-            }}>
-            <Button
-              disabled={isDeleting}
-              size="large"
-              sx={{
-                flex: 1,
-                textTransform: 'none',
-              }}
-              variant="outlined"
-              onClick={handleCancel}>
-              {t('label.cancel')}
-            </Button>
-            <Button
-              color="error"
-              disabled={isDeleting}
-              size="large"
-              sx={{
-                flex: 1,
-                textTransform: 'none',
-              }}
-              variant="contained"
-              onClick={handleDelete}>
-              {isDeleting ? (
-                <Loader size="small" type="white" />
-              ) : (
-                t('label.delete')
-              )}
-            </Button>
-          </DialogActions>
-        </Box>
-      </Dialog>
+        onCancel={handleCancel}
+        onDelete={handleDelete}
+      />
     ),
     [
-      getDeleteMessage,
       getEntityTitle,
+      deleteConfirmationMessage,
       handleCancel,
       handleDelete,
       isDeleting,
       isOpen,
-      selectedEntities.length,
-      theme.palette.allShades,
     ]
   );
 

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/atoms/actions/useDelete.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/atoms/actions/useDelete.tsx
@@ -123,16 +123,16 @@ export const useDelete = <
     setIsDeleting(true);
     const errors: string[] = [];
 
-    for (let i = 0; i < selectedEntities.length; i++) {
+    for (const entity of selectedEntities) {
       try {
         await deleteEntity(
           entityType,
-          selectedEntities[i].id,
+          entity.id,
           false, // recursive: false (safe default)
           true // hardDelete: true (permanent)
         );
-      } catch (error) {
-        errors.push(getEntityName(selectedEntities[i]));
+      } catch {
+        errors.push(getEntityName(entity));
       }
     }
 


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:


https://github.com/user-attachments/assets/3a3d0ea2-a6fd-4076-aae0-fbd503a95d37



Fixes #<issue-number>
<!--
Linking an issue is REQUIRED. Replace <issue-number> with the GitHub issue number this PR addresses
(e.g., `Fixes #12345`). GitHub will auto-link it. If no issue exists, please open one first so the
problem and design can be discussed before review.
-->

<!--
Short blurb explaining:
- What changes did you make?
- Why did you make them?
-->

I worked on ... because ...

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### High-level design:
<!--
REQUIRED for large PRs (new features, refactors, breaking changes, or anything touching >5 files).
Skip for small bug fixes and trivial changes.

Cover:
- Architecture / approach you took and why
- Key components or files added/changed and how they interact
- Alternatives considered and why you rejected them
- Any migration, backward-compatibility, or rollout concerns
- Diagrams or links to design docs / RFCs if available
-->

N/A — small change. <!-- Or fill in the design above -->

#
### Tests:

#### Use cases covered
<!--
List the user-visible scenarios this PR exercises. Example:
- User with Admin role can create a Glossary Term with a parent term
- Ingestion run for Snowflake correctly extracts row counts for partitioned tables
-->

#### Unit tests
<!--
- [ ] I added unit tests for the new/changed logic.
- Files added/updated:
- Coverage on changed classes (run `mvn jacoco:report` for backend, `yarn test:coverage` for UI,
  `make unit_ingestion` for ingestion). Target is 90% line coverage on changed classes.
- Coverage %: <e.g., 92% on EntityRepository.java>
-->

#### Backend integration tests
<!--
- [ ] I added integration tests in `openmetadata-integration-tests/` for new/changed API endpoints.
- [ ] Not applicable (no backend API changes).
- Files added/updated:
-->

#### Ingestion integration tests
<!--
- [ ] I added/updated ingestion integration tests for connector changes.
- [ ] Not applicable (no ingestion changes).
- Files added/updated:
-->

#### Playwright (UI) tests
<!--
- [ ] I added Playwright E2E tests under `openmetadata-ui/.../ui/playwright/` for UI changes.
- [ ] Not applicable (no UI changes).
- Files added/updated:
-->

#### Manual testing performed
<!--
List the manual test steps you performed before requesting review. Example:
1. Started local stack via `./docker/run_local_docker.sh -m ui -d mysql`
2. Logged in as admin, created entity X, verified Y appears in the UI
3. Triggered ingestion for Snowflake source, confirmed lineage edges in the explore page
-->

#
### UI screen recording / screenshots:
<!--
REQUIRED for any PR that changes the UI. Drag-and-drop a short screen recording (.mov / .mp4 / .gif)
demonstrating the change end-to-end, plus before/after screenshots where relevant.
Mark "Not applicable" if there are no UI changes.
-->

Not applicable. <!-- Or attach recording/screenshots above -->

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.
- [ ] For UI changes: I attached a screen recording and/or screenshots above.
- [ ] I have added tests (unit / integration / Playwright as applicable) and listed them above.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->

----
## Summary by Gitar

- **Refactored `useDelete` hook:**
  - Replaced Material UI components with `@openmetadata/ui-core-components` for consistent styling.
  - Simplified the modal implementation by delegating to the reusable `DeleteModal` component.
- **UI enhancements:**
  - Updated the delete action button to use `ButtonUtility` and improved the badge positioning for bulk delete actions.

<sub>This will update automatically on new commits.</sub>

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR moves the shared delete UI away from MUI components. The main changes are:

- Replaces the delete action with `ButtonUtility` and the core `Badge` component.
- Uses the shared `DeleteModal` for delete confirmation.
- Simplifies the delete loop while keeping the same deletion flow.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge.

- No blocking issues found in the changed code.

</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-ui/src/main/resources/ui/src/components/common/atoms/actions/useDelete.tsx | Updates the shared delete hook to render core UI components and delegate confirmation UI to `DeleteModal`. |

</details>

<sub>Reviews (2): Last reviewed commit: ["nit"](https://github.com/open-metadata/openmetadata/commit/778c2edab4a57abbb34206c2755aa7ce577dce7a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42690075)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Context used - CLAUDE.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=52f0d9d9-cad1-4e7d-b070-de181a0aa5e7))
- Context used - openmetadata-ui-core-components/CLAUDE.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=41754627-b2bf-474b-8082-f37ef1a07013))
- Context used - AGENTS.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=ef262f5f-911f-44f3-8d2d-e9cb1579c8c8))
</details>

<!-- /greptile_comment -->