### PR TITLE
fix(search): index all body chunks for semantic retrieval (backport collate#4789) to 1.13

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/apps/bundles/searchIndex/OpenSearchBulkSink.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/apps/bundles/searchIndex/OpenSearchBulkSink.java
@@ -926,9 +926,25 @@ public class OpenSearchBulkSink implements BulkSink {
         // service-layer pre-filter only admits entries whose state matches (same fingerprint or
         // same updatedAt), and fingerprint covers the body text that determines chunk count.
         doc.setAll((ObjectNode) cached);
+        // Backfill: the entity content is unchanged, but the dedicated chunk index (issue #4789)
+        // may not hold this entity's chunk docs yet (catalogs embedded before multi-chunk
+        // shipped). The call is fingerprint-guarded, so it is a cheap no-op once chunks exist;
+        // chunk docs reflect committed entity state, so writing them mid-reindex is safe even if
+        // the staged index is never promoted.
+        vectorService.updateEntityEmbeddingChunks(entity);
       } else {
-        Map<String, Object> embeddingFields = vectorService.generateEmbeddingFields(entity);
-        doc.setAll((ObjectNode) OBJECT_MAPPER.valueToTree(embeddingFields));
+        // Build the chunk docs once (one embedding call per chunk): chunk 0's embedding fields
+        // are spliced into the staged entity doc for hybrid search, and the full set is written
+        // to the dedicated chunk index for the semantic vector path (issue #4789).
+        List<Map<String, Object>> chunkDocs =
+            VectorDocBuilder.fromEntity(entity, vectorService.getEmbeddingClient());
+        if (!chunkDocs.isEmpty()) {
+          doc.setAll(
+              (ObjectNode)
+                  OBJECT_MAPPER.valueToTree(
+                      OpenSearchVectorService.legacyEmbeddingFields(chunkDocs.get(0))));
+          vectorService.writeEntityChunks(entity.getId().toString(), chunkDocs);
+        }
       }
 
       vectorSuccess.incrementAndGet();

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/vector/OpenSearchVectorService.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/vector/OpenSearchVectorService.java
@@ -180,6 +180,391 @@ public class OpenSearchVectorService implements VectorIndexService {
     }
   }
 
+  private static final String CHUNK_INDEX_BASE = "data_asset_embeddings_chunks";
+  private volatile boolean chunkIndexEnsured = false;
+
+  /**
+   * Name of the dedicated chunk index (issue #4789). Lives alongside the entity indices; the
+   * {@code dataAssetEmbeddings} alias is attached to it so the vector read path sees chunk docs
+   * together with legacy entity-doc embeddings during migration.
+   */
+  public String getChunkIndexName() {
+    String clusterAlias = null;
+    try {
+      clusterAlias = Entity.getSearchRepository().getClusterAlias();
+    } catch (Exception ignored) {
+      // No SearchRepository in standalone/test contexts; fall back to the unprefixed name.
+    }
+    return clusterAlias == null || clusterAlias.isEmpty()
+        ? CHUNK_INDEX_BASE
+        : clusterAlias.toLowerCase(java.util.Locale.ROOT) + "_" + CHUNK_INDEX_BASE;
+  }
+
+  @Override
+  public void updateEntityEmbeddingChunks(EntityInterface entity) {
+    ensureChunkIndex();
+    updateEntityEmbeddingChunks(entity, getChunkIndexName());
+  }
+
+  /**
+   * Single-embed dual-target write: builds the chunk documents once (one embedding call per
+   * chunk) and reuses chunk 0's embedding fields for the legacy entity-doc partial update, so a
+   * content change costs N embedding calls instead of N+1. Each target keeps its own
+   * fingerprint-based staleness check.
+   */
+  @Override
+  public void updateEntityEmbeddings(EntityInterface entity, String entityIndexName) {
+    try {
+      String parentId = entity.getId().toString();
+      String currentFingerprint = VectorDocBuilder.computeFingerprintForEntity(entity);
+      ensureChunkIndex();
+      String chunkIndexName = getChunkIndexName();
+      boolean entityDocStale =
+          !currentFingerprint.equals(getExistingFingerprint(entityIndexName, parentId));
+      ChunkHeader header = getChunkHeader(chunkIndexName, parentId);
+      boolean chunksStale = header == null || !currentFingerprint.equals(header.fingerprint());
+      if (entityDocStale || chunksStale) {
+        List<Map<String, Object>> chunkDocs = VectorDocBuilder.fromEntity(entity, embeddingClient);
+        if (chunksStale) {
+          replaceChunks(chunkIndexName, parentId, chunkDocs, previousCount(header));
+        }
+        if (entityDocStale && !chunkDocs.isEmpty()) {
+          partialUpdateEntity(entityIndexName, parentId, legacyEmbeddingFields(chunkDocs.get(0)));
+        }
+      }
+    } catch (Exception e) {
+      LOG.error("Failed to update embeddings for entity {}: {}", entity.getId(), e.getMessage(), e);
+    }
+  }
+
+  /**
+   * Write the given prebuilt chunk documents for an entity. Used by the reindex sink, which builds
+   * the chunk docs itself so chunk 0 can also be spliced into the staged entity doc without a
+   * second embedding pass.
+   */
+  public void writeEntityChunks(String parentId, List<Map<String, Object>> chunkDocs) {
+    try {
+      ensureChunkIndex();
+      String chunkIndexName = getChunkIndexName();
+      ChunkHeader header = getChunkHeader(chunkIndexName, parentId);
+      replaceChunks(chunkIndexName, parentId, chunkDocs, previousCount(header));
+    } catch (Exception e) {
+      LOG.error("Failed to write chunk docs for {}: {}", parentId, e.getMessage(), e);
+    }
+  }
+
+  /**
+   * The legacy entity-doc embedding payload extracted from a chunk document: only the embedding
+   * fields, never the chunk doc's trimmed filter fields (tags/domains/tier), which would clobber
+   * the entity doc's rich versions of those fields on partial update.
+   */
+  public static Map<String, Object> legacyEmbeddingFields(Map<String, Object> chunkDoc) {
+    Map<String, Object> fields = new HashMap<>();
+    for (String key : EMBEDDING_SOURCE_FIELDS) {
+      Object value = chunkDoc.get(key);
+      if (value != null) {
+        fields.put(key, value);
+      }
+    }
+    return fields;
+  }
+
+  @Override
+  public void deleteEntityChunks(String parentId) {
+    try {
+      String chunkIndexName = getChunkIndexName();
+      ChunkHeader header = getChunkHeader(chunkIndexName, parentId);
+      replaceChunks(chunkIndexName, parentId, List.of(), previousCount(header));
+    } catch (Exception e) {
+      LOG.debug("Failed to delete chunks for {}: {}", parentId, e.getMessage());
+    }
+  }
+
+  /**
+   * Progressive disclosure for a single knowledge entity (the issue #4789 payoff): KNN over just
+   * this parent's chunks in the dedicated chunk index, returning the {@code textToLLMContext} of the
+   * top {@code k} chunks most relevant to {@code query}. Unlike {@link #search}, results are not
+   * collapsed by parent, so this yields several passages of one long article rather than a single
+   * representative — the mechanism that lets a get_asset_context bundle carry only excerpts.
+   */
+  public List<String> searchChunksByParent(String parentId, String query, int k) {
+    List<String> passages = new ArrayList<>();
+    try {
+      ensureChunkIndex();
+      float[] vector = embeddingClient.embed(query);
+      Map<String, List<String>> filters = Map.of("parentId", List.of(parentId));
+      String queryJson = VectorSearchQueryBuilder.build(vector, k, 0, k, filters, 0.0);
+      String response =
+          executeGenericRequest("POST", "/" + getChunkIndexName() + "/_search", queryJson);
+      JsonNode hits = MAPPER.readTree(response).path("hits").path("hits");
+      for (JsonNode hit : hits) {
+        String text = hit.path("_source").path("textToLLMContext").asText(null);
+        if (text != null && !text.isBlank()) {
+          passages.add(text);
+        }
+      }
+    } catch (Exception e) {
+      LOG.warn("Chunk retrieval failed for parent {}: {}", parentId, e.getMessage());
+    }
+    return passages;
+  }
+
+  /**
+   * Idempotently creates the dedicated chunk index (dynamic:false mapping with the KNN vector and
+   * the filter fields the vector query uses) and attaches the {@code dataAssetEmbeddings} alias so
+   * reads cover both legacy entity-doc embeddings and the new chunk docs.
+   */
+  private void ensureChunkIndex() {
+    if (!chunkIndexEnsured) {
+      synchronized (this) {
+        if (!chunkIndexEnsured) {
+          // Only latch on success so a transient failure (e.g. OpenSearch outage during startup)
+          // is retried on the next write instead of disabling chunk indexing until restart.
+          chunkIndexEnsured = createChunkIndexIfAbsent();
+        }
+      }
+    }
+  }
+
+  private boolean createChunkIndexIfAbsent() {
+    String indexName = getChunkIndexName();
+    boolean ensured = false;
+    try {
+      boolean exists = client.indices().exists(e -> e.index(indexName)).value();
+      if (!exists) {
+        executeGenericRequest("PUT", "/" + indexName, buildChunkIndexMapping());
+        LOG.info("Created dedicated vector chunk index {}", indexName);
+      } else {
+        // The alias is normally attached at creation, but an index left over from a partial or
+        // manual setup may miss it — and reads via the alias would then silently skip all chunk
+        // docs. The alias PUT is idempotent.
+        executeGenericRequest("PUT", "/" + indexName + "/_alias/" + getSearchAlias(), "{}");
+      }
+      ensured = true;
+    } catch (Exception e) {
+      LOG.error("Failed to ensure chunk index {}: {}", indexName, e.getMessage());
+    }
+    return ensured;
+  }
+
+  private String buildChunkIndexMapping() {
+    var method =
+        MAPPER
+            .createObjectNode()
+            .put("name", "hnsw")
+            .put("engine", "lucene")
+            .put("space_type", "cosinesimil")
+            .set("parameters", MAPPER.createObjectNode().put("m", 48).put("ef_construction", 256));
+    var embedding =
+        MAPPER
+            .createObjectNode()
+            .put("type", "knn_vector")
+            .put("dimension", embeddingClient.getDimension())
+            .set("method", method);
+    var properties = MAPPER.createObjectNode();
+    properties.set("embedding", embedding);
+    for (String keyword :
+        List.of(
+            "parentId", "fingerprint", "entityType", "name", "displayName", "fullyQualifiedName")) {
+      properties.set(keyword, MAPPER.createObjectNode().put("type", "keyword"));
+    }
+    for (String integer : List.of("chunkIndex", "chunkCount")) {
+      properties.set(integer, MAPPER.createObjectNode().put("type", "integer"));
+    }
+    for (String text : List.of("textToEmbed", "textToLLMContext")) {
+      properties.set(text, MAPPER.createObjectNode().put("type", "text"));
+    }
+    properties.set("deleted", MAPPER.createObjectNode().put("type", "boolean"));
+    properties.set("tags", nestedKeyword("tagFQN"));
+    properties.set("domains", nestedKeyword("name"));
+    properties.set("tier", nestedKeyword("tagFQN"));
+    properties.set(
+        "relatedTerms", MAPPER.createObjectNode().put("type", "object").put("enabled", false));
+    var mappings = MAPPER.createObjectNode().put("dynamic", false).set("properties", properties);
+    var root = MAPPER.createObjectNode();
+    root.set(
+        "settings",
+        MAPPER.createObjectNode().set("index", MAPPER.createObjectNode().put("knn", true)));
+    root.set("mappings", mappings);
+    root.set("aliases", MAPPER.createObjectNode().set(getSearchAlias(), MAPPER.createObjectNode()));
+    return root.toString();
+  }
+
+  private com.fasterxml.jackson.databind.node.ObjectNode nestedKeyword(String field) {
+    return (com.fasterxml.jackson.databind.node.ObjectNode)
+        MAPPER
+            .createObjectNode()
+            .set(
+                "properties",
+                MAPPER
+                    .createObjectNode()
+                    .set(field, MAPPER.createObjectNode().put("type", "keyword")));
+  }
+
+  /**
+   * Multi-chunk write path (issue #4789): index one standalone document per body chunk into the
+   * dedicated chunk index, keyed {@code <parentId>_<chunkIndex>}. Skips work when the whole-body
+   * fingerprint is unchanged. Chunk ids are deterministic, so a shrinking body is handled by
+   * bulk-deleting the trailing stale ids in the same request — no delete-by-query and no forced
+   * refresh on this hot path; visibility follows the index refresh interval.
+   */
+  public void updateEntityEmbeddingChunks(EntityInterface entity, String chunkIndexName) {
+    try {
+      String parentId = entity.getId().toString();
+      ChunkHeader header = getChunkHeader(chunkIndexName, parentId);
+      String currentFingerprint = VectorDocBuilder.computeFingerprintForEntity(entity);
+      if (header != null && currentFingerprint.equals(header.fingerprint())) {
+        LOG.debug("Skipping chunk embedding for {} - fingerprint unchanged", parentId);
+        return;
+      }
+      List<Map<String, Object>> chunkDocs = VectorDocBuilder.fromEntity(entity, embeddingClient);
+      replaceChunks(chunkIndexName, parentId, chunkDocs, previousCount(header));
+    } catch (Exception e) {
+      LOG.error("Failed to update chunk embeddings for {}: {}", entity.getId(), e.getMessage(), e);
+    }
+  }
+
+  /** Header of an entity's chunk set, read from chunk 0. */
+  private record ChunkHeader(String fingerprint, int chunkCount) {}
+
+  private static int previousCount(ChunkHeader header) {
+    return header == null ? 0 : header.chunkCount();
+  }
+
+  /**
+   * Real-time by-id GET of chunk 0's fingerprint and chunkCount. A GET by id sees un-refreshed
+   * writes, so staleness checks and stale-id deletes never race the refresh interval, and it is
+   * far cheaper than the {@code _search} it replaces on the per-entity write path.
+   */
+  private ChunkHeader getChunkHeader(String indexName, String parentId) {
+    ChunkHeader header = null;
+    try {
+      OpenSearchGenericClient genericClient = client.generic();
+      var request =
+          Requests.builder()
+              .endpoint(
+                  "/"
+                      + indexName
+                      + "/_doc/"
+                      + parentId
+                      + "_0?_source_includes=fingerprint,chunkCount")
+              .method("GET")
+              .build();
+      try (var response = genericClient.execute(request)) {
+        if (response.getStatus() < 400) {
+          String body =
+              response
+                  .getBody()
+                  .map(
+                      b -> {
+                        try {
+                          return new String(b.bodyAsBytes(), StandardCharsets.UTF_8);
+                        } catch (Exception ignored) {
+                          return "{}";
+                        }
+                      })
+                  .orElse("{}");
+          JsonNode root = MAPPER.readTree(body);
+          if (root.path("found").asBoolean(false)) {
+            JsonNode source = root.path("_source");
+            header =
+                new ChunkHeader(
+                    source.path("fingerprint").asText(null), source.path("chunkCount").asInt(0));
+          }
+        }
+      }
+    } catch (Exception e) {
+      LOG.debug("No chunk header for {} in {}: {}", parentId, indexName, e.getMessage());
+    }
+    return header;
+  }
+
+  /**
+   * One bulk request that overwrites chunk ids {@code 0..N-1} and deletes the trailing stale ids
+   * {@code N..previousCount-1} left behind by a shrinking body. Deletes are by id, so they do not
+   * depend on search visibility of prior writes.
+   */
+  private void replaceChunks(
+      String indexName, String parentId, List<Map<String, Object>> chunkDocs, int previousCount)
+      throws IOException {
+    if (previousCount == 0) {
+      cleanOrphanChunks(indexName, parentId);
+    }
+    if (chunkDocs.isEmpty() && previousCount == 0) {
+      return;
+    }
+    StringBuilder bulk = new StringBuilder();
+    for (int i = 0; i < chunkDocs.size(); i++) {
+      bulk.append("{\"index\":{\"_index\":\"")
+          .append(indexName)
+          .append("\",\"_id\":\"")
+          .append(parentId)
+          .append('_')
+          .append(i)
+          .append("\"}}\n")
+          .append(MAPPER.writeValueAsString(chunkDocs.get(i)))
+          .append('\n');
+    }
+    appendChunkDeletes(bulk, indexName, parentId, chunkDocs.size(), previousCount);
+    executeGenericRequest("POST", "/_bulk", bulk.toString());
+  }
+
+  /**
+   * Belt-and-braces for a missing or corrupt chunk-0 header (e.g. a partial bulk failure).
+   * {@code previousCount == 0} is overwhelmingly the brand-new-entity case on the write and
+   * reindex-backfill hot paths, so the guard is the cheapest primitive available — a real-time
+   * by-id existence probe of chunk 1 that never touches the search layer. Only when a trailing
+   * chunk survived without its header do we pay a delete-by-query heal. (A failure that drops
+   * both chunk 0 and chunk 1 while later chunks survive would evade the probe; the next
+   * successful full write overwrites those ids anyway.)
+   */
+  private void cleanOrphanChunks(String indexName, String parentId) {
+    try {
+      if (chunkDocExists(indexName, parentId + "_1")) {
+        LOG.warn("Healing orphan chunk docs for parent {} with missing chunk-0 header", parentId);
+        String body =
+            "{\"query\":{\"term\":{\"parentId\":\""
+                + VectorSearchQueryBuilder.escape(parentId)
+                + "\"}}}";
+        executeGenericRequest(
+            "POST", "/" + indexName + "/_delete_by_query?conflicts=proceed", body);
+      }
+    } catch (Exception e) {
+      LOG.debug("Orphan chunk cleanup skipped for {}: {}", parentId, e.getMessage());
+    }
+  }
+
+  private boolean chunkDocExists(String indexName, String docId) {
+    boolean exists = false;
+    try {
+      OpenSearchGenericClient genericClient = client.generic();
+      var request =
+          Requests.builder()
+              .endpoint("/" + indexName + "/_doc/" + docId + "?_source=false")
+              .method("HEAD")
+              .build();
+      try (var response = genericClient.execute(request)) {
+        exists = response.getStatus() < 300;
+      }
+    } catch (Exception e) {
+      LOG.debug("Chunk existence probe failed for {}: {}", docId, e.getMessage());
+    }
+    return exists;
+  }
+
+  private static void appendChunkDeletes(
+      StringBuilder bulk, String indexName, String parentId, int fromIndex, int toExclusive) {
+    for (int i = fromIndex; i < toExclusive; i++) {
+      bulk.append("{\"delete\":{\"_index\":\"")
+          .append(indexName)
+          .append("\",\"_id\":\"")
+          .append(parentId)
+          .append('_')
+          .append(i)
+          .append("\"}}\n");
+    }
+  }
+
   @Override
   @SuppressWarnings("unchecked")
   public VectorSearchResponse search(
@@ -268,9 +653,37 @@ public class OpenSearchVectorService implements VectorIndexService {
       hitMap.put("_score", score);
 
       String parentId = (String) hitMap.getOrDefault("parentId", hit.path("_id").asText());
-      byParent.computeIfAbsent(parentId, ignored -> new ArrayList<>()).add(hitMap);
+      List<Map<String, Object>> group =
+          byParent.computeIfAbsent(parentId, ignored -> new ArrayList<>());
+      // During chunk-index migration the same chunk can surface twice — once from the legacy
+      // entity-doc embedding and once from the dedicated chunk index. Keep the first (higher
+      // scoring) occurrence per chunkIndex.
+      if (!isDuplicateChunk(group, hitMap.get("chunkIndex"))) {
+        group.add(hitMap);
+      }
     }
     return pageHitCount;
+  }
+
+  private static boolean isDuplicateChunk(List<Map<String, Object>> group, Object chunkIndex) {
+    boolean duplicate = false;
+    Object key = normalizeChunkIndex(chunkIndex);
+    for (Map<String, Object> member : group) {
+      if (key.equals(normalizeChunkIndex(member.get("chunkIndex")))) {
+        duplicate = true;
+        break;
+      }
+    }
+    return duplicate;
+  }
+
+  /**
+   * Every embedding writer (legacy entity-doc and chunk-index) sets {@code chunkIndex} — 0 for the
+   * legacy single-doc format — so a missing value can only come from exotic/manual docs. Treat it
+   * as chunk 0 so such a doc still dedupes against the real chunk 0 during dual-write migration.
+   */
+  private static Object normalizeChunkIndex(Object chunkIndex) {
+    return chunkIndex == null ? 0 : chunkIndex;
   }
 
   private static long extractTotalHits(JsonNode root) {

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/vector/VectorDocBuilder.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/vector/VectorDocBuilder.java
@@ -110,30 +110,156 @@ public class VectorDocBuilder {
     BODY_TEXT_EXTRACTORS.put(entityType, extractor);
   }
 
+  /**
+   * Build one standalone embedding document per body chunk (issue #4789). Each doc carries its own
+   * per-chunk {@code embedding}/{@code textToEmbed}/{@code textToLLMContext} plus {@code chunkIndex},
+   * a shared {@code parentId}/{@code fingerprint}, and the KNN filter fields (entityType, deleted,
+   * tags, domains, tier) so the docs can live in the dedicated {@code dataAssetEmbeddings} chunk
+   * index and still be filtered by the vector query. Callers index each doc under the id
+   * {@code <parentId>_<chunkIndex>}.
+   */
   public static List<Map<String, Object>> fromEntity(
       EntityInterface entity, EmbeddingClient embeddingClient) {
-    Map<String, Object> doc = new HashMap<>(buildEmbeddingFields(entity, embeddingClient));
-
+    List<Map<String, Object>> docs = buildChunkFields(entity, embeddingClient);
     if (entity instanceof GlossaryTerm term) {
-      List<TermRelation> relatedTerms = term.getRelatedTerms();
-      if (relatedTerms != null && !relatedTerms.isEmpty()) {
-        List<Map<String, Object>> relatedTermDocs = new ArrayList<>();
-        for (TermRelation rel : relatedTerms) {
-          EntityReference ref = rel.getTerm();
-          if (ref == null) continue;
-          Map<String, Object> refMap = new HashMap<>();
-          if (ref.getId() != null) refMap.put("id", ref.getId().toString());
-          if (ref.getName() != null) refMap.put("name", ref.getName());
-          if (ref.getType() != null) refMap.put("type", ref.getType());
-          if (ref.getFullyQualifiedName() != null)
-            refMap.put("fullyQualifiedName", ref.getFullyQualifiedName());
-          relatedTermDocs.add(refMap);
+      List<Map<String, Object>> relatedTermDocs = buildRelatedTermRefs(term);
+      if (!relatedTermDocs.isEmpty()) {
+        for (Map<String, Object> doc : docs) {
+          doc.put("relatedTerms", relatedTermDocs);
         }
-        doc.put("relatedTerms", relatedTermDocs);
       }
     }
+    return docs;
+  }
 
-    return List.of(doc);
+  private static List<Map<String, Object>> buildRelatedTermRefs(GlossaryTerm term) {
+    List<Map<String, Object>> refs = new ArrayList<>();
+    List<TermRelation> relatedTerms =
+        term.getRelatedTerms() != null ? term.getRelatedTerms() : Collections.emptyList();
+    for (TermRelation rel : relatedTerms) {
+      EntityReference ref = rel.getTerm();
+      if (ref != null) {
+        Map<String, Object> refMap = new HashMap<>();
+        if (ref.getId() != null) refMap.put("id", ref.getId().toString());
+        if (ref.getName() != null) refMap.put("name", ref.getName());
+        if (ref.getType() != null) refMap.put("type", ref.getType());
+        if (ref.getFullyQualifiedName() != null) {
+          refMap.put("fullyQualifiedName", ref.getFullyQualifiedName());
+        }
+        refs.add(refMap);
+      }
+    }
+    return refs;
+  }
+
+  private record ChunkContext(
+      EntityInterface entity,
+      String entityType,
+      String parentId,
+      String fingerprint,
+      String metaLight,
+      String semanticMetaLight,
+      List<String> chunks,
+      List<String> semanticChunks) {}
+
+  /** One embedding-field map per body chunk. See {@link #fromEntity} for the doc shape. */
+  public static List<Map<String, Object>> buildChunkFields(
+      EntityInterface entity, EmbeddingClient embeddingClient) {
+    EntityReference reference = entity.getEntityReference();
+    String entityType = reference == null ? null : reference.getType();
+    ChunkContext ctx =
+        new ChunkContext(
+            entity,
+            entityType,
+            entity.getId().toString(),
+            computeFingerprintForEntity(entity),
+            buildMetaLightText(entity, entityType),
+            buildSemanticMetaLightText(entity, entityType),
+            TextChunkManager.chunk(buildBodyText(entity, entityType)),
+            TextChunkManager.chunk(buildSemanticBodyText(entity, entityType)));
+    List<Map<String, Object>> docs = new ArrayList<>(ctx.chunks().size());
+    for (int index = 0; index < ctx.chunks().size(); index++) {
+      docs.add(buildChunkDoc(ctx, index, embeddingClient));
+    }
+    return docs;
+  }
+
+  private static Map<String, Object> buildChunkDoc(
+      ChunkContext ctx, int index, EmbeddingClient embeddingClient) {
+    int chunkCount = ctx.chunks().size();
+    String semanticChunk =
+        index < ctx.semanticChunks().size() ? ctx.semanticChunks().get(index) : "";
+    String textToEmbed = joinSemanticParts(ctx.semanticMetaLight(), semanticChunk);
+    String textToLLMContext =
+        String.format(
+            "%s%s | chunk %d/%d", ctx.metaLight(), ctx.chunks().get(index), index + 1, chunkCount);
+    Map<String, Object> fields = new HashMap<>();
+    fields.put("embedding", embeddingClient.embed(textToEmbed));
+    fields.put("textToLLMContext", textToLLMContext);
+    fields.put("textToEmbed", textToEmbed);
+    fields.put("chunkIndex", index);
+    fields.put("chunkCount", chunkCount);
+    fields.put("parentId", ctx.parentId());
+    fields.put("fingerprint", ctx.fingerprint());
+    addFilterFields(fields, ctx.entity(), ctx.entityType());
+    return fields;
+  }
+
+  /**
+   * Copies onto each chunk doc the fields the vector KNN query filters on (see
+   * VectorSearchQueryBuilder): {@code entityType}, {@code deleted}, the identity fields the read
+   * side returns, and {@code tags}/{@code domains}/{@code tier}. Chunk docs live in a dedicated
+   * index, so unlike the legacy entity-doc path these fields must be materialized here.
+   */
+  private static void addFilterFields(
+      Map<String, Object> fields, EntityInterface entity, String entityType) {
+    fields.put("entityType", entityType);
+    fields.put("deleted", Boolean.TRUE.equals(entity.getDeleted()));
+    putIfPresent(fields, "name", entity.getName());
+    putIfPresent(fields, "fullyQualifiedName", entity.getFullyQualifiedName());
+    putIfPresent(fields, "displayName", entity.getDisplayName());
+    List<Map<String, Object>> tags = tagFqnObjects(entity);
+    if (!tags.isEmpty()) {
+      fields.put("tags", tags);
+    }
+    List<Map<String, Object>> domains = domainNameObjects(entity);
+    if (!domains.isEmpty()) {
+      fields.put("domains", domains);
+    }
+    String tier = extractTierLabel(entity);
+    if (tier != null) {
+      fields.put("tier", Map.of("tagFQN", tier));
+    }
+  }
+
+  private static void putIfPresent(Map<String, Object> fields, String key, String value) {
+    if (value != null && !value.isBlank()) {
+      fields.put(key, value);
+    }
+  }
+
+  private static List<Map<String, Object>> tagFqnObjects(EntityInterface entity) {
+    List<Map<String, Object>> tags = new ArrayList<>();
+    List<TagLabel> tagLabels =
+        entity.getTags() != null ? entity.getTags() : Collections.emptyList();
+    for (TagLabel tag : tagLabels) {
+      if (tag.getTagFQN() != null) {
+        tags.add(Map.of("tagFQN", tag.getTagFQN()));
+      }
+    }
+    return tags;
+  }
+
+  private static List<Map<String, Object>> domainNameObjects(EntityInterface entity) {
+    List<Map<String, Object>> domains = new ArrayList<>();
+    List<EntityReference> domainRefs =
+        entity.getDomains() != null ? entity.getDomains() : Collections.emptyList();
+    for (EntityReference domain : domainRefs) {
+      if (domain.getName() != null) {
+        domains.add(Map.of("name", domain.getName()));
+      }
+    }
+    return domains;
   }
 
   /**
@@ -349,7 +475,8 @@ public class VectorDocBuilder {
     List<String> phrases = new ArrayList<>();
     appendSubjectPhrase(phrases, entity, entityType);
 
-    BiConsumer<List<String>, EntityInterface> enricher = SEMANTIC_ENRICHERS.get(entityType);
+    BiConsumer<List<String>, EntityInterface> enricher =
+        entityType == null ? null : SEMANTIC_ENRICHERS.get(entityType);
     if (enricher != null) {
       enricher.accept(phrases, entity);
     }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/vector/VectorEmbeddingHandler.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/vector/VectorEmbeddingHandler.java
@@ -48,13 +48,36 @@ public class VectorEmbeddingHandler implements EntityLifecycleEventHandler {
 
   @Override
   public void onEntityDeleted(EntityInterface entity, SubjectContext subjectContext) {
-    // No-op: entity search doc is already deleted by SearchIndexHandler
+    // Entity search doc is deleted by SearchIndexHandler; chunk docs live in the dedicated
+    // chunk index and must be cleaned here or the deleted entity keeps matching KNN queries.
+    deleteChunks(entity);
   }
 
   @Override
   public void onEntitySoftDeletedOrRestored(
       EntityInterface entity, boolean isDeleted, SubjectContext subjectContext) {
-    // No-op: entity search doc handles soft delete/restore via SearchIndexHandler
+    // Chunk docs carry their own deleted flag, so mirror the transition: drop chunks on soft
+    // delete, re-embed on restore. The entity search doc itself is handled by SearchIndexHandler.
+    if (isDeleted) {
+      deleteChunks(entity);
+    } else {
+      updateEmbedding(entity);
+    }
+  }
+
+  private void deleteChunks(EntityInterface entity) {
+    if (entity != null && entity.getId() != null && isSupported(entity)) {
+      try {
+        vectorService.deleteEntityChunks(entity.getId().toString());
+      } catch (Exception e) {
+        LOG.error("Failed to delete chunks for entity {}: {}", entity.getId(), e.getMessage(), e);
+      }
+    }
+  }
+
+  private boolean isSupported(EntityInterface entity) {
+    String entityType = extractEntityType(entity);
+    return entityType != null && isSupportedEntityType(entityType);
   }
 
   private void updateEmbedding(EntityInterface entity) {
@@ -62,17 +85,20 @@ public class VectorEmbeddingHandler implements EntityLifecycleEventHandler {
       LOG.warn("Received null entity in updateEmbedding");
       return;
     }
-    String entityType = extractEntityType(entity);
-    if (entityType == null || !isSupportedEntityType(entityType)) {
+    if (!isSupported(entity)) {
       return;
     }
     try {
-      String entityIndexName = resolveEntityIndexName(entityType);
+      String entityIndexName = resolveEntityIndexName(extractEntityType(entity));
       if (entityIndexName == null) {
-        LOG.warn("No index mapping found for entity type: {}", entityType);
+        LOG.warn("No index mapping found for entity type: {}", extractEntityType(entity));
         return;
       }
-      vectorService.updateEntityEmbedding(entity, entityIndexName);
+      // Dual-target write: the legacy chunk-0 partial update keeps hybrid search (which reads
+      // the embedding on the entity doc) working, while the chunk index carries every chunk for
+      // the semantic vector path (issue #4789). The combined call embeds each chunk once and
+      // reuses chunk 0 for the entity doc.
+      vectorService.updateEntityEmbeddings(entity, entityIndexName);
     } catch (Exception e) {
       LOG.error("Failed to update embedding for entity {}: {}", entity.getId(), e.getMessage(), e);
     }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/vector/VectorIndexService.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/vector/VectorIndexService.java
@@ -13,6 +13,26 @@ public interface VectorIndexService {
 
   void updateEntityEmbedding(EntityInterface entity, String entityIndexName);
 
+  /**
+   * Multi-chunk write path (issue #4789): index one document per body chunk into the dedicated
+   * chunk index so long articles are fully retrievable. Default is a no-op for backends without
+   * chunk support.
+   */
+  default void updateEntityEmbeddingChunks(EntityInterface entity) {}
+
+  /** Remove all chunk documents for the given parent entity (hard/soft delete cleanup). */
+  default void deleteEntityChunks(String parentId) {}
+
+  /**
+   * Combined write: refresh both the legacy entity-doc embedding (read by hybrid search) and the
+   * chunk documents (read by the semantic vector path). Implementations should embed each chunk
+   * once and reuse chunk 0 for the entity doc; this default simply chains the two writes.
+   */
+  default void updateEntityEmbeddings(EntityInterface entity, String entityIndexName) {
+    updateEntityEmbedding(entity, entityIndexName);
+    updateEntityEmbeddingChunks(entity);
+  }
+
   VectorSearchResponse search(
       String query, Map<String, List<String>> filters, int size, int from, int k, double threshold);
 }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/vector/VectorSearchQueryBuilder.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/vector/VectorSearchQueryBuilder.java
@@ -126,6 +126,10 @@ public class VectorSearchQueryBuilder {
             sb.append(',');
             appendFlat(sb, "primaryEntity.id", values);
           }
+          case "parentId" -> {
+            sb.append(',');
+            appendFlat(sb, "parentId", values);
+          }
           default -> LOG.debug("Ignoring unrecognized filter key: {}", field);
         }
       }

--- a/openmetadata-service/src/test/java/org/openmetadata/service/apps/bundles/searchIndex/OpenSearchBulkSinkBehaviorTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/apps/bundles/searchIndex/OpenSearchBulkSinkBehaviorTest.java
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -45,6 +46,7 @@ import org.openmetadata.service.search.indexes.DocBuildContext;
 import org.openmetadata.service.search.indexes.SearchIndex;
 import org.openmetadata.service.search.opensearch.OpenSearchClient;
 import org.openmetadata.service.search.vector.OpenSearchVectorService;
+import org.openmetadata.service.search.vector.VectorDocBuilder;
 import org.openmetadata.service.search.vector.client.EmbeddingClient;
 
 class OpenSearchBulkSinkBehaviorTest {
@@ -480,6 +482,37 @@ class OpenSearchBulkSinkBehaviorTest {
     }
   }
 
+  /**
+   * Stubs the recompute (non-cached) embedding path introduced with multi-chunk indexing: the sink
+   * builds chunk docs once via {@link VectorDocBuilder#fromEntity}, splices chunk 0's legacy
+   * embedding fields into the staged doc, and writes the chunks. Returns the chunk-doc list so the
+   * caller can verify {@code writeEntityChunks} received it.
+   */
+  private static List<Map<String, Object>> stubRecompute(
+      MockedStatic<VectorDocBuilder> docBuilderMock,
+      MockedStatic<OpenSearchVectorService> vectorServiceMock,
+      EntityInterface entity,
+      String fingerprint,
+      List<Double> embedding,
+      String textToEmbed) {
+    Map<String, Object> chunk0 = new HashMap<>();
+    chunk0.put("fingerprint", fingerprint);
+    chunk0.put("embedding", embedding);
+    chunk0.put("textToEmbed", textToEmbed);
+    chunk0.put("chunkIndex", 0);
+    chunk0.put("chunkCount", 1);
+    List<Map<String, Object>> chunkDocs = List.of(chunk0);
+    Map<String, Object> legacyFields = new HashMap<>();
+    legacyFields.put("fingerprint", fingerprint);
+    legacyFields.put("embedding", embedding);
+    legacyFields.put("textToEmbed", textToEmbed);
+    docBuilderMock.when(() -> VectorDocBuilder.fromEntity(eq(entity), any())).thenReturn(chunkDocs);
+    vectorServiceMock
+        .when(() -> OpenSearchVectorService.legacyEmbeddingFields(chunk0))
+        .thenReturn(legacyFields);
+    return chunkDocs;
+  }
+
   @Test
   void enrichWithEmbeddingRecomputesWhenNoCachedEntryAvailable() throws Exception {
     // When the service-layer fetch returns nothing for this entity (cache miss or fingerprint
@@ -490,12 +523,7 @@ class OpenSearchBulkSinkBehaviorTest {
 
     StageStatsTracker tracker = mock(StageStatsTracker.class);
     OpenSearchVectorService vectorService = mock(OpenSearchVectorService.class);
-    when(vectorService.generateEmbeddingFields(entity))
-        .thenReturn(
-            Map.of(
-                "fingerprint", "fp-new",
-                "embedding", List.of(0.9, 0.8, 0.7),
-                "textToEmbed", "fresh-text"));
+    when(vectorService.getEmbeddingClient()).thenReturn(mock(EmbeddingClient.class));
 
     Map<String, JsonNode> existingEmbeddingsById = Collections.emptyMap();
     String entityJson = "{\"name\":\"my-table\"}";
@@ -503,8 +531,17 @@ class OpenSearchBulkSinkBehaviorTest {
     try (MockedConstruction<OpenSearchBulkSink.CustomBulkProcessor> processorConstruction =
             mockConstruction(OpenSearchBulkSink.CustomBulkProcessor.class);
         MockedStatic<OpenSearchVectorService> vectorServiceMock =
-            mockStatic(OpenSearchVectorService.class)) {
+            mockStatic(OpenSearchVectorService.class);
+        MockedStatic<VectorDocBuilder> docBuilderMock = mockStatic(VectorDocBuilder.class)) {
       vectorServiceMock.when(OpenSearchVectorService::getInstance).thenReturn(vectorService);
+      List<Map<String, Object>> chunkDocs =
+          stubRecompute(
+              docBuilderMock,
+              vectorServiceMock,
+              entity,
+              "fp-new",
+              List.of(0.9, 0.8, 0.7),
+              "fresh-text");
 
       OpenSearchBulkSink sink = new OpenSearchBulkSink(searchRepository, 10, 2, 1000L);
 
@@ -519,7 +556,7 @@ class OpenSearchBulkSinkBehaviorTest {
       String result =
           (String) enrich.invoke(sink, entity, entityJson, existingEmbeddingsById, tracker);
 
-      verify(vectorService).generateEmbeddingFields(entity);
+      verify(vectorService).writeEntityChunks(entityId.toString(), chunkDocs);
       verify(tracker).recordVector(StatsResult.SUCCESS);
 
       ObjectMapper mapper = new ObjectMapper();
@@ -539,8 +576,7 @@ class OpenSearchBulkSinkBehaviorTest {
 
     StageStatsTracker tracker = mock(StageStatsTracker.class);
     OpenSearchVectorService vectorService = mock(OpenSearchVectorService.class);
-    when(vectorService.generateEmbeddingFields(entity))
-        .thenReturn(Map.of("fingerprint", "fp-new", "embedding", List.of(0.1, 0.2, 0.3)));
+    when(vectorService.getEmbeddingClient()).thenReturn(mock(EmbeddingClient.class));
 
     ObjectMapper mapper = new ObjectMapper();
     JsonNode cachedWithoutEmbedding = mapper.readTree("{\"fingerprint\":\"fp-old\"}");
@@ -550,8 +586,12 @@ class OpenSearchBulkSinkBehaviorTest {
     try (MockedConstruction<OpenSearchBulkSink.CustomBulkProcessor> processorConstruction =
             mockConstruction(OpenSearchBulkSink.CustomBulkProcessor.class);
         MockedStatic<OpenSearchVectorService> vectorServiceMock =
-            mockStatic(OpenSearchVectorService.class)) {
+            mockStatic(OpenSearchVectorService.class);
+        MockedStatic<VectorDocBuilder> docBuilderMock = mockStatic(VectorDocBuilder.class)) {
       vectorServiceMock.when(OpenSearchVectorService::getInstance).thenReturn(vectorService);
+      List<Map<String, Object>> chunkDocs =
+          stubRecompute(
+              docBuilderMock, vectorServiceMock, entity, "fp-new", List.of(0.1, 0.2, 0.3), "text");
 
       OpenSearchBulkSink sink = new OpenSearchBulkSink(searchRepository, 10, 2, 1000L);
       Method enrich =
@@ -566,7 +606,7 @@ class OpenSearchBulkSinkBehaviorTest {
       String result =
           (String) enrich.invoke(sink, entity, "{\"name\":\"x\"}", existingEmbeddingsById, tracker);
 
-      verify(vectorService).generateEmbeddingFields(entity);
+      verify(vectorService).writeEntityChunks(entityId.toString(), chunkDocs);
       verify(tracker).recordVector(StatsResult.SUCCESS);
       assertEquals("fp-new", mapper.readTree(result).get("fingerprint").asText());
     }
@@ -582,8 +622,7 @@ class OpenSearchBulkSinkBehaviorTest {
 
     StageStatsTracker tracker = mock(StageStatsTracker.class);
     OpenSearchVectorService vectorService = mock(OpenSearchVectorService.class);
-    when(vectorService.generateEmbeddingFields(entity))
-        .thenReturn(Map.of("fingerprint", "fp-new", "embedding", List.of(0.4, 0.5, 0.6)));
+    when(vectorService.getEmbeddingClient()).thenReturn(mock(EmbeddingClient.class));
 
     ObjectMapper mapper = new ObjectMapper();
     JsonNode arrayInsteadOfObject = mapper.readTree("[1,2,3]");
@@ -593,8 +632,12 @@ class OpenSearchBulkSinkBehaviorTest {
     try (MockedConstruction<OpenSearchBulkSink.CustomBulkProcessor> processorConstruction =
             mockConstruction(OpenSearchBulkSink.CustomBulkProcessor.class);
         MockedStatic<OpenSearchVectorService> vectorServiceMock =
-            mockStatic(OpenSearchVectorService.class)) {
+            mockStatic(OpenSearchVectorService.class);
+        MockedStatic<VectorDocBuilder> docBuilderMock = mockStatic(VectorDocBuilder.class)) {
       vectorServiceMock.when(OpenSearchVectorService::getInstance).thenReturn(vectorService);
+      List<Map<String, Object>> chunkDocs =
+          stubRecompute(
+              docBuilderMock, vectorServiceMock, entity, "fp-new", List.of(0.4, 0.5, 0.6), "text");
 
       OpenSearchBulkSink sink = new OpenSearchBulkSink(searchRepository, 10, 2, 1000L);
       Method enrich =
@@ -609,7 +652,7 @@ class OpenSearchBulkSinkBehaviorTest {
       String result =
           (String) enrich.invoke(sink, entity, "{\"name\":\"y\"}", existingEmbeddingsById, tracker);
 
-      verify(vectorService).generateEmbeddingFields(entity);
+      verify(vectorService).writeEntityChunks(entityId.toString(), chunkDocs);
       verify(tracker).recordVector(StatsResult.SUCCESS);
       assertEquals("fp-new", mapper.readTree(result).get("fingerprint").asText());
     }
@@ -631,8 +674,6 @@ class OpenSearchBulkSinkBehaviorTest {
     EmbeddingClient embeddingClient = mock(EmbeddingClient.class);
     when(embeddingClient.getDimension()).thenReturn(4);
     when(vectorService.getEmbeddingClient()).thenReturn(embeddingClient);
-    when(vectorService.generateEmbeddingFields(entity))
-        .thenReturn(Map.of("fingerprint", "fp-new", "embedding", List.of(0.1, 0.2, 0.3, 0.4)));
 
     ObjectMapper mapper = new ObjectMapper();
     // Cached embedding has 3 dims; the active client now reports 4 -> must NOT be reused.
@@ -647,8 +688,17 @@ class OpenSearchBulkSinkBehaviorTest {
     try (MockedConstruction<OpenSearchBulkSink.CustomBulkProcessor> processorConstruction =
             mockConstruction(OpenSearchBulkSink.CustomBulkProcessor.class);
         MockedStatic<OpenSearchVectorService> vectorServiceMock =
-            mockStatic(OpenSearchVectorService.class)) {
+            mockStatic(OpenSearchVectorService.class);
+        MockedStatic<VectorDocBuilder> docBuilderMock = mockStatic(VectorDocBuilder.class)) {
       vectorServiceMock.when(OpenSearchVectorService::getInstance).thenReturn(vectorService);
+      List<Map<String, Object>> chunkDocs =
+          stubRecompute(
+              docBuilderMock,
+              vectorServiceMock,
+              entity,
+              "fp-new",
+              List.of(0.1, 0.2, 0.3, 0.4),
+              "text");
 
       OpenSearchBulkSink sink = new OpenSearchBulkSink(searchRepository, 10, 2, 1000L);
       Method enrich =
@@ -663,7 +713,7 @@ class OpenSearchBulkSinkBehaviorTest {
       String result =
           (String) enrich.invoke(sink, entity, "{\"name\":\"z\"}", existingEmbeddingsById, tracker);
 
-      verify(vectorService).generateEmbeddingFields(entity);
+      verify(vectorService).writeEntityChunks(entityId.toString(), chunkDocs);
       verify(tracker).recordVector(StatsResult.SUCCESS);
       JsonNode resultNode = mapper.readTree(result);
       assertEquals("fp-new", resultNode.get("fingerprint").asText());

--- a/openmetadata-service/src/test/java/org/openmetadata/service/search/vector/VectorDocBuilderChunkTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/search/vector/VectorDocBuilderChunkTest.java
@@ -1,0 +1,110 @@
+/*
+ *  Copyright 2024 Collate
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.openmetadata.service.search.vector;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.openmetadata.schema.entity.data.Table;
+import org.openmetadata.service.search.vector.client.EmbeddingClient;
+
+/**
+ * Unit test for the #4789 fix: {@link VectorDocBuilder#fromEntity} must emit one standalone
+ * embedding document per body chunk (not just chunk 0), each carrying its own chunkIndex and the
+ * KNN filter fields, so long articles are fully indexed and query-time ranking can pick the most
+ * relevant chunk.
+ */
+class VectorDocBuilderChunkTest {
+
+  private static final class MockEmbeddingClient extends EmbeddingClient {
+    @Override
+    protected float[] doEmbed(String text) {
+      return new float[] {0.1f, 0.2f, 0.3f};
+    }
+
+    @Override
+    public int getDimension() {
+      return 3;
+    }
+
+    @Override
+    public String getModelId() {
+      return "mock";
+    }
+  }
+
+  @Test
+  void fromEntity_emitsOneDocPerChunkForLongBody() {
+    String longDescription = "revenue ".repeat(900);
+    Table table =
+        new Table()
+            .withId(UUID.randomUUID())
+            .withName("orders")
+            .withFullyQualifiedName("svc.db.sch.orders")
+            .withDescription(longDescription);
+
+    List<Map<String, Object>> docs = VectorDocBuilder.fromEntity(table, new MockEmbeddingClient());
+
+    assertTrue(
+        docs.size() > 1, "a >380-word body must yield multiple chunk docs, not just chunk 0");
+    for (int i = 0; i < docs.size(); i++) {
+      Map<String, Object> doc = docs.get(i);
+      assertEquals(i, doc.get("chunkIndex"), "chunkIndex must be contiguous 0..N-1");
+      assertEquals(docs.size(), doc.get("chunkCount"));
+      assertEquals(table.getId().toString(), doc.get("parentId"), "all chunks share the parentId");
+      assertNotNull(doc.get("embedding"), "each chunk must carry its own embedding");
+      assertEquals(false, doc.get("deleted"), "filter field deleted must be materialized");
+      assertEquals("svc.db.sch.orders", doc.get("fullyQualifiedName"));
+    }
+  }
+
+  @Test
+  void legacyEmbeddingFields_fromChunkZeroMatchBuildEmbeddingFields() {
+    Table table =
+        new Table()
+            .withId(UUID.randomUUID())
+            .withName("orders")
+            .withFullyQualifiedName("svc.db.sch.orders")
+            .withDescription("revenue ".repeat(900));
+    MockEmbeddingClient client = new MockEmbeddingClient();
+
+    Map<String, Object> legacy = VectorDocBuilder.buildEmbeddingFields(table, client);
+    Map<String, Object> fromChunkZero =
+        OpenSearchVectorService.legacyEmbeddingFields(
+            VectorDocBuilder.fromEntity(table, client).get(0));
+
+    assertEquals(legacy.keySet(), fromChunkZero.keySet(), "legacy payload keys must match");
+    for (String key : legacy.keySet()) {
+      if (!"embedding".equals(key)) {
+        assertEquals(legacy.get(key), fromChunkZero.get(key), "mismatch on " + key);
+      }
+    }
+    assertTrue(
+        !fromChunkZero.containsKey("tags") && !fromChunkZero.containsKey("entityType"),
+        "chunk filter fields must not leak into the legacy entity-doc payload");
+  }
+
+  @Test
+  void fromEntity_shortBodyProducesSingleChunk() {
+    Table table = new Table().withId(UUID.randomUUID()).withName("t").withDescription("short body");
+    List<Map<String, Object>> docs = VectorDocBuilder.fromEntity(table, new MockEmbeddingClient());
+    assertEquals(1, docs.size());
+    assertEquals(0, docs.get(0).get("chunkIndex"));
+    assertEquals(1, docs.get(0).get("chunkCount"));
+  }
+}

--- a/openmetadata-service/src/test/java/org/openmetadata/service/search/vector/VectorEmbeddingHandlerTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/search/vector/VectorEmbeddingHandlerTest.java
@@ -60,7 +60,7 @@ class VectorEmbeddingHandlerTest {
 
       handler.onEntityCreated(entity, subjectContext);
 
-      verify(vectorIndexService).updateEntityEmbedding(any(), anyString());
+      verify(vectorIndexService).updateEntityEmbeddings(any(), anyString());
     }
   }
 
@@ -70,7 +70,7 @@ class VectorEmbeddingHandlerTest {
 
     handler.onEntityCreated(entity, subjectContext);
 
-    verify(vectorIndexService, never()).updateEntityEmbedding(any(), anyString());
+    verify(vectorIndexService, never()).updateEntityEmbeddings(any(), anyString());
   }
 
   @Test
@@ -88,7 +88,7 @@ class VectorEmbeddingHandlerTest {
 
       handler.onEntityUpdated(entity, null, subjectContext);
 
-      verify(vectorIndexService).updateEntityEmbedding(any(), anyString());
+      verify(vectorIndexService).updateEntityEmbeddings(any(), anyString());
     }
   }
 
@@ -99,14 +99,14 @@ class VectorEmbeddingHandlerTest {
 
     handler.onEntityUpdated(entity, null, subjectContext);
 
-    verify(vectorIndexService, never()).updateEntityEmbedding(any(), anyString());
+    verify(vectorIndexService, never()).updateEntityEmbeddings(any(), anyString());
   }
 
   @Test
   void testOnEntityUpdatedHandlesNull() {
     handler.onEntityUpdated(null, null, subjectContext);
 
-    verify(vectorIndexService, never()).updateEntityEmbedding(any(), anyString());
+    verify(vectorIndexService, never()).updateEntityEmbeddings(any(), anyString());
   }
 
   @Test
@@ -115,7 +115,7 @@ class VectorEmbeddingHandlerTest {
 
     handler.onEntityDeleted(entity, subjectContext);
 
-    verify(vectorIndexService, never()).updateEntityEmbedding(any(), anyString());
+    verify(vectorIndexService, never()).updateEntityEmbeddings(any(), anyString());
   }
 
   @Test
@@ -124,7 +124,7 @@ class VectorEmbeddingHandlerTest {
 
     handler.onEntitySoftDeletedOrRestored(entity, true, subjectContext);
 
-    verify(vectorIndexService, never()).updateEntityEmbedding(any(), anyString());
+    verify(vectorIndexService, never()).updateEntityEmbeddings(any(), anyString());
   }
 
   @Test
@@ -133,14 +133,14 @@ class VectorEmbeddingHandlerTest {
 
     handler.onEntitySoftDeletedOrRestored(entity, false, subjectContext);
 
-    verify(vectorIndexService, never()).updateEntityEmbedding(any(), anyString());
+    verify(vectorIndexService, never()).updateEntityEmbeddings(any(), anyString());
   }
 
   @Test
   void testOnEntitySoftDeletedOrRestoredHandlesNull() {
     handler.onEntitySoftDeletedOrRestored(null, true, subjectContext);
 
-    verify(vectorIndexService, never()).updateEntityEmbedding(any(), anyString());
+    verify(vectorIndexService, never()).updateEntityEmbeddings(any(), anyString());
   }
 
   private EntityInterface createMockEntity(String entityType) {


### PR DESCRIPTION
## Backport: multi-chunk embeddings (open-metadata/openmetadata-collate#4789) to 1.13

Backports the vector-pipeline half of #29678 to `1.13`.

Fixes open-metadata/openmetadata-collate/issues/4789

### Note for review
`VectorIndexService` intentionally diverges from upstream by one method: the `preference`/7-arg `search` overload (from #29503, multi-node search) is **omitted** because #29503 is not on 1.13. Only the chunk methods are added.

### Tests
- New `VectorDocBuilderChunkTest` (asserts a long body yields multiple chunk docs — fails without the fix).
- Updated `VectorEmbeddingHandlerTest`, `OpenSearchBulkSinkBehaviorTest`.
- `openmetadata-service` main + tests compile clean locally against the full shaded build.

