### PR TITLE
improvement(datamodel): server-side column tag & glossary filter for Dashboard Data Models

### DIFF
--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/DashboardDataModelResourceIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/DashboardDataModelResourceIT.java
@@ -6,6 +6,8 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -41,11 +43,14 @@ import org.openmetadata.schema.type.DataModelType;
 import org.openmetadata.schema.type.EntityHistory;
 import org.openmetadata.schema.type.TagLabel;
 import org.openmetadata.schema.type.api.BulkOperationResult;
+import org.openmetadata.schema.utils.JsonUtils;
 import org.openmetadata.sdk.client.OpenMetadataClient;
 import org.openmetadata.sdk.exceptions.OpenMetadataException;
 import org.openmetadata.sdk.models.ListParams;
 import org.openmetadata.sdk.models.ListResponse;
+import org.openmetadata.sdk.network.HttpMethod;
 import org.openmetadata.service.resources.datamodels.DashboardDataModelResource;
+import org.openmetadata.service.resources.datamodels.DashboardDataModelResource.DataModelColumnList;
 
 /**
  * Integration tests for DashboardDataModel entity operations.
@@ -912,6 +917,109 @@ public class DashboardDataModelResourceIT
         readOnce(client, id, relationshipErrors);
       }
     }
+  }
+
+  @Test
+  void searchColumns_tagFilterReturnsMatchesAcrossPages(TestNamespace ns) throws Exception {
+    OpenMetadataClient client = SdkClients.adminClient();
+    DashboardService service = DashboardServiceTestFactory.createLooker(ns);
+
+    CreateClassification createClassification =
+        new CreateClassification()
+            .withName(ns.prefix("DmColTagFilter"))
+            .withDescription("Classification for data model column tag filter test");
+    Classification classification = client.classifications().create(createClassification);
+    CreateTag createTag =
+        new CreateTag()
+            .withName("Sensitive")
+            .withClassification(classification.getName())
+            .withDescription("Sensitive tag");
+    Tag tag = client.tags().create(createTag);
+    String tagFqn = tag.getFullyQualifiedName();
+
+    TagLabel sensitiveLabel =
+        new TagLabel()
+            .withTagFQN(tagFqn)
+            .withSource(TagLabel.TagSource.CLASSIFICATION)
+            .withLabelType(TagLabel.LabelType.MANUAL)
+            .withState(TagLabel.State.CONFIRMED);
+
+    int totalColumns = 60;
+    int taggedColumnIndex = 58;
+    List<Column> columns = new ArrayList<>();
+    for (int i = 0; i < totalColumns; i++) {
+      Column column =
+          new Column()
+              .withName(String.format("col_%02d", i))
+              .withDataType(ColumnDataType.VARCHAR)
+              .withDataLength(100);
+      if (i == taggedColumnIndex) {
+        column.withTags(List.of(sensitiveLabel));
+      }
+      columns.add(column);
+    }
+
+    CreateDashboardDataModel request =
+        new CreateDashboardDataModel()
+            .withName(ns.prefix("dm_col_tag_filter"))
+            .withService(service.getFullyQualifiedName())
+            .withDataModelType(DataModelType.LookMlView)
+            .withColumns(columns);
+    DashboardDataModel dataModel = createEntity(request);
+
+    String encodedFqn =
+        URLEncoder.encode(dataModel.getFullyQualifiedName(), StandardCharsets.UTF_8);
+    String taggedColumnName = String.format("col_%02d", taggedColumnIndex);
+
+    DataModelColumnList firstPage = searchDataModelColumns(client, encodedFqn, "limit=50&offset=0");
+    assertEquals(totalColumns, firstPage.getPaging().getTotal());
+    assertFalse(
+        firstPage.getData().stream().anyMatch(c -> taggedColumnName.equals(c.getName())),
+        "Tagged column should fall on a later page without a filter");
+
+    String encodedTag = URLEncoder.encode(tagFqn, StandardCharsets.UTF_8);
+    DataModelColumnList filtered =
+        searchDataModelColumns(
+            client, encodedFqn, "limit=50&offset=0&fields=tags&tags=" + encodedTag);
+    assertEquals(
+        1,
+        filtered.getPaging().getTotal(),
+        "Tag filter total should count all matches across pages, not a single page");
+    assertEquals(1, filtered.getData().size());
+    assertEquals(taggedColumnName, filtered.getData().get(0).getName());
+
+    DataModelColumnList filteredById =
+        searchDataModelColumnsById(
+            client,
+            dataModel.getId().toString(),
+            "limit=50&offset=0&fields=tags&tags=" + encodedTag);
+    assertEquals(
+        1, filteredById.getPaging().getTotal(), "By-id endpoint should honour the same tag filter");
+    assertEquals(taggedColumnName, filteredById.getData().get(0).getName());
+  }
+
+  private DataModelColumnList searchDataModelColumns(
+      OpenMetadataClient client, String encodedFqn, String queryParams) {
+    String response =
+        client
+            .getHttpClient()
+            .executeForString(
+                HttpMethod.GET,
+                "/v1/dashboard/datamodels/name/" + encodedFqn + "/columns/search?" + queryParams,
+                null);
+    return JsonUtils.readValue(response, DataModelColumnList.class);
+  }
+
+  private DataModelColumnList searchDataModelColumnsById(
+      OpenMetadataClient client, String id, String queryParams) {
+    String response =
+        client
+            .getHttpClient()
+            .executeForString(
+                HttpMethod.GET,
+                "/v1/dashboard/datamodels/" + id + "/columns/search?" + queryParams,
+                null);
+    return JsonUtils.readValue(response, DataModelColumnList.class);
   }
 
   private void readOnce(OpenMetadataClient client, String id, List<String> relationshipErrors) {

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/DashboardDataModelRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/DashboardDataModelRepository.java
@@ -13,6 +13,7 @@
 
 package org.openmetadata.service.jdbi3;
 
+import static org.openmetadata.common.utils.CommonUtil.nullOrEmpty;
 import static org.openmetadata.schema.type.Include.ALL;
 import static org.openmetadata.service.Entity.DASHBOARD_DATA_MODEL;
 import static org.openmetadata.service.Entity.FIELD_TAGS;
@@ -47,6 +48,8 @@ import org.openmetadata.service.jdbi3.FeedRepository.ThreadContext;
 import org.openmetadata.service.resources.databases.DatabaseUtil;
 import org.openmetadata.service.resources.datamodels.DashboardDataModelResource;
 import org.openmetadata.service.resources.feeds.MessageParser.EntityLink;
+import org.openmetadata.service.util.ColumnSearchUtil;
+import org.openmetadata.service.util.ColumnSearchUtil.ColumnTagFilter;
 import org.openmetadata.service.util.EntityUtil;
 import org.openmetadata.service.util.EntityUtil.Fields;
 import org.openmetadata.service.util.EntityUtil.RelationIncludes;
@@ -430,76 +433,79 @@ public class DashboardDataModelRepository extends EntityRepository<DashboardData
   }
 
   public ResultList<Column> searchDataModelColumnsById(
-      UUID id, String query, int limit, int offset, String fieldsParam, Include include) {
+      UUID id,
+      String query,
+      int limit,
+      int offset,
+      String fieldsParam,
+      Include include,
+      String sortBy,
+      String sortOrder,
+      ColumnTagFilter columnTagFilter) {
     DashboardDataModel dataModel = get(null, id, getFields(fieldsParam), include, false);
-    return searchDataModelColumnsInternal(dataModel, query, limit, offset, fieldsParam);
+    return searchDataModelColumnsInternal(
+        dataModel, query, limit, offset, fieldsParam, sortBy, sortOrder, columnTagFilter);
   }
 
   public ResultList<Column> searchDataModelColumnsByFQN(
-      String fqn, String query, int limit, int offset, String fieldsParam, Include include) {
+      String fqn,
+      String query,
+      int limit,
+      int offset,
+      String fieldsParam,
+      Include include,
+      String sortBy,
+      String sortOrder,
+      ColumnTagFilter columnTagFilter) {
     DashboardDataModel dataModel = getByName(null, fqn, getFields(fieldsParam), include, false);
-    return searchDataModelColumnsInternal(dataModel, query, limit, offset, fieldsParam);
+    return searchDataModelColumnsInternal(
+        dataModel, query, limit, offset, fieldsParam, sortBy, sortOrder, columnTagFilter);
   }
 
   private ResultList<Column> searchDataModelColumnsInternal(
-      DashboardDataModel dataModel, String query, int limit, int offset, String fieldsParam) {
-    List<Column> allColumns = dataModel.getColumns();
-    if (allColumns == null || allColumns.isEmpty()) {
+      DashboardDataModel dataModel,
+      String query,
+      int limit,
+      int offset,
+      String fieldsParam,
+      String sortBy,
+      String sortOrder,
+      ColumnTagFilter columnTagFilter) {
+    if (nullOrEmpty(dataModel.getColumns())) {
       return new ResultList<>(List.of(), null, null, 0);
     }
+    // Copy so pruning and field population never mutate the loaded entity's column tree.
+    List<Column> allColumns = JsonUtils.deepCopyList(dataModel.getColumns(), Column.class);
 
-    // Flatten nested columns for search
-    List<Column> flattenedColumns = flattenColumns(allColumns);
+    String searchTerm = nullOrEmpty(query) ? null : query.toLowerCase().trim();
+    boolean hasTagFilter = columnTagFilter != null && !columnTagFilter.isEmpty();
+    Map<String, List<TagLabel>> tagsByHash =
+        hasTagFilter
+            ? ColumnSearchUtil.resolveColumnTagsForFilter(
+                dataModel.getFullyQualifiedName(), daoCollection)
+            : Map.of();
 
-    List<Column> matchingColumns;
-    if (query == null || query.trim().isEmpty()) {
-      matchingColumns = flattenedColumns;
-    } else {
-      String searchTerm = query.toLowerCase().trim();
-      matchingColumns =
-          flattenedColumns.stream()
-              .filter(
-                  column -> {
-                    if (column.getName() != null
-                        && column.getName().toLowerCase().contains(searchTerm)) {
-                      return true;
-                    }
-                    if (column.getDisplayName() != null
-                        && column.getDisplayName().toLowerCase().contains(searchTerm)) {
-                      return true;
-                    }
-                    return column.getDescription() != null
-                        && column.getDescription().toLowerCase().contains(searchTerm);
-                  })
-              .toList();
-    }
+    List<Column> matchingTree =
+        ColumnSearchUtil.pruneColumnsToMatches(allColumns, searchTerm, columnTagFilter, tagsByHash);
+    matchingTree.sort(ColumnSearchUtil.columnComparator(sortBy, sortOrder));
 
-    int total = matchingColumns.size();
+    int total = matchingTree.size();
     int startIndex = Math.min(offset, total);
     int endIndex = Math.min(offset + limit, total);
+    List<Column> paginatedRoots =
+        startIndex < total
+            ? new ArrayList<>(matchingTree.subList(startIndex, endIndex))
+            : List.of();
 
-    List<Column> paginatedResults =
-        startIndex < total ? matchingColumns.subList(startIndex, endIndex) : List.of();
-
+    List<Column> paginatedColumns = ColumnSearchUtil.flattenColumns(paginatedRoots);
     Fields fields = getFields(fieldsParam);
     if (fields.contains("tags") || fields.contains("*")) {
       populateEntityFieldTags(
-          entityType, paginatedResults, dataModel.getFullyQualifiedName(), true);
+          entityType, paginatedColumns, dataModel.getFullyQualifiedName(), true);
     }
 
     String before = offset > 0 ? String.valueOf(Math.max(0, offset - limit)) : null;
     String after = endIndex < total ? String.valueOf(endIndex) : null;
-    return new ResultList<>(paginatedResults, before, after, total);
-  }
-
-  private List<Column> flattenColumns(List<Column> columns) {
-    List<Column> flattened = new ArrayList<>();
-    for (Column column : columns) {
-      flattened.add(column);
-      if (column.getChildren() != null && !column.getChildren().isEmpty()) {
-        flattened.addAll(flattenColumns(column.getChildren()));
-      }
-    }
-    return flattened;
+    return new ResultList<>(paginatedRoots, before, after, total);
   }
 }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/TableRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/TableRepository.java
@@ -34,8 +34,6 @@ import static org.openmetadata.service.Entity.getEntityReferenceById;
 import static org.openmetadata.service.Entity.populateEntityFieldTags;
 import static org.openmetadata.service.monitoring.RequestLatencyContext.phase;
 import static org.openmetadata.service.resources.tags.TagLabelUtil.addDerivedTagsGracefully;
-import static org.openmetadata.service.resources.tags.TagLabelUtil.addDerivedTagsWithPreFetched;
-import static org.openmetadata.service.resources.tags.TagLabelUtil.batchFetchDerivedTags;
 import static org.openmetadata.service.resources.tags.TagLabelUtil.mergeTagsWithIncomingPrecedence;
 import static org.openmetadata.service.search.SearchClient.GLOBAL_SEARCH_ALIAS;
 import static org.openmetadata.service.util.EntityUtil.getLocalColumnName;
@@ -129,6 +127,8 @@ import org.openmetadata.service.resources.feeds.MessageParser.EntityLink;
 import org.openmetadata.service.search.PropagationDescriptor;
 import org.openmetadata.service.security.Authorizer;
 import org.openmetadata.service.security.mask.PIIMasker;
+import org.openmetadata.service.util.ColumnSearchUtil;
+import org.openmetadata.service.util.ColumnSearchUtil.ColumnTagFilter;
 import org.openmetadata.service.util.EntityUtil;
 import org.openmetadata.service.util.EntityUtil.Fields;
 import org.openmetadata.service.util.EntityUtil.RelationIncludes;
@@ -3345,11 +3345,14 @@ public class TableRepository extends EntityRepository<Table> {
     String searchTerm = nullOrEmpty(query) ? null : query.toLowerCase().trim();
     boolean hasTagFilter = columnTagFilter != null && !columnTagFilter.isEmpty();
     Map<String, List<TagLabel>> tagsByHash =
-        hasTagFilter ? resolveColumnTagsForFilter(table) : Map.of();
+        hasTagFilter
+            ? ColumnSearchUtil.resolveColumnTagsForFilter(
+                table.getFullyQualifiedName(), daoCollection)
+            : Map.of();
 
     List<Column> matchingTree =
-        pruneColumnsToMatches(allColumns, searchTerm, columnTagFilter, tagsByHash);
-    matchingTree.sort(columnComparator(sortBy, sortOrder));
+        ColumnSearchUtil.pruneColumnsToMatches(allColumns, searchTerm, columnTagFilter, tagsByHash);
+    matchingTree.sort(ColumnSearchUtil.columnComparator(sortBy, sortOrder));
 
     int total = matchingTree.size();
     int startIndex = Math.min(offset, total);
@@ -3359,7 +3362,7 @@ public class TableRepository extends EntityRepository<Table> {
             ? new ArrayList<>(matchingTree.subList(startIndex, endIndex))
             : List.of();
 
-    List<Column> paginatedColumns = flattenTableColumns(paginatedRoots);
+    List<Column> paginatedColumns = ColumnSearchUtil.flattenColumns(paginatedRoots);
     Fields fields = getFields(fieldsParam);
     if (fields.contains("customMetrics") || fields.contains("*")) {
       Map<String, List<CustomMetric>> metricsByColumn =
@@ -3383,140 +3386,6 @@ public class TableRepository extends EntityRepository<Table> {
     String before = offset > 0 ? String.valueOf(Math.max(0, offset - limit)) : null;
     String after = endIndex < total ? String.valueOf(endIndex) : null;
     return new ResultList<>(paginatedRoots, before, after, total);
-  }
-
-  /**
-   * Prune the column tree to nodes that match the search term and tag filter, keeping every matched
-   * node at its real depth together with its ancestor path. Mirrors the UI's getFilteredTagsData so
-   * the server-side filter renders the same nested view, paginated across the whole table instead of
-   * the loaded page. A node is kept when it matches itself or has a kept descendant; a kept node's
-   * children are pruned to the matched paths only.
-   */
-  private List<Column> pruneColumnsToMatches(
-      List<Column> columns,
-      String searchTerm,
-      ColumnTagFilter columnTagFilter,
-      Map<String, List<TagLabel>> tagsByHash) {
-    List<Column> pruned = new ArrayList<>();
-    for (Column column : columns) {
-      List<Column> prunedChildren =
-          nullOrEmpty(column.getChildren())
-              ? new ArrayList<>()
-              : pruneColumnsToMatches(
-                  column.getChildren(), searchTerm, columnTagFilter, tagsByHash);
-      boolean matches = columnMatchesSearch(column, searchTerm, columnTagFilter, tagsByHash);
-      if (matches || !prunedChildren.isEmpty()) {
-        column.setChildren(prunedChildren);
-        pruned.add(column);
-      }
-    }
-    return pruned;
-  }
-
-  private boolean columnMatchesSearch(
-      Column column,
-      String searchTerm,
-      ColumnTagFilter columnTagFilter,
-      Map<String, List<TagLabel>> tagsByHash) {
-    boolean matchesQuery = searchTerm == null || columnNameMatches(column, searchTerm);
-    boolean matchesTags =
-        columnTagFilter == null
-            || columnTagFilter.isEmpty()
-            || columnMatchesTagFilter(column, columnTagFilter, tagsByHash);
-    return matchesQuery && matchesTags;
-  }
-
-  private boolean columnNameMatches(Column column, String searchTerm) {
-    boolean nameMatches =
-        column.getName() != null && column.getName().toLowerCase().contains(searchTerm);
-    boolean displayNameMatches =
-        column.getDisplayName() != null
-            && column.getDisplayName().toLowerCase().contains(searchTerm);
-    return nameMatches || displayNameMatches;
-  }
-
-  private Comparator<Column> columnComparator(String sortBy, String sortOrder) {
-    Comparator<Column> comparator;
-    if ("ordinalPosition".equals(sortBy)) {
-      comparator =
-          Comparator.comparing(
-              Column::getOrdinalPosition, Comparator.nullsLast(Comparator.naturalOrder()));
-    } else {
-      comparator =
-          Comparator.comparing(
-              Column::getName, Comparator.nullsLast(String.CASE_INSENSITIVE_ORDER));
-    }
-    if ("desc".equalsIgnoreCase(sortOrder)) {
-      comparator = comparator.reversed();
-    }
-    return comparator;
-  }
-
-  /**
-   * Column-level tag filter. {@code tagFQNs} and {@code glossaryTermFQNs} mirror the two
-   * independent column filters in the UI. Values within each group are OR-ed; the two groups are
-   * AND-ed when both are present (matching AntD's cross-column filter semantics).
-   */
-  public record ColumnTagFilter(Set<String> tagFQNs, Set<String> glossaryTermFQNs) {
-    public boolean isEmpty() {
-      return nullOrEmpty(tagFQNs) && nullOrEmpty(glossaryTermFQNs);
-    }
-  }
-
-  /**
-   * Resolve column tags the same way the column list responses (and therefore the UI filter
-   * dropdown) see them: direct tag_usage rows enriched with glossary-derived tags. The raw DAO is
-   * used instead of {@link #getTagsByPrefix} so certification-classification tags are not stripped,
-   * keeping the filter consistent with the tags shown on each column.
-   */
-  private Map<String, List<TagLabel>> resolveColumnTagsForFilter(Table table) {
-    Map<String, List<TagLabel>> directTagsByHash =
-        daoCollection.tagUsageDAO().getTagsByPrefix(table.getFullyQualifiedName(), ".%", true);
-    if (nullOrEmpty(directTagsByHash)) {
-      return Map.of();
-    }
-    List<TagLabel> allDirectTags =
-        directTagsByHash.values().stream().flatMap(List::stream).collect(Collectors.toList());
-    Map<String, List<TagLabel>> derivedTagsMap;
-    try {
-      derivedTagsMap = batchFetchDerivedTags(allDirectTags);
-    } catch (Exception ex) {
-      LOG.warn("Failed to fetch derived tags for column tag filter; matching direct tags only", ex);
-      derivedTagsMap = Map.of();
-    }
-    Map<String, List<TagLabel>> effectiveTagsByHash = new HashMap<>();
-    for (Map.Entry<String, List<TagLabel>> entry : directTagsByHash.entrySet()) {
-      effectiveTagsByHash.put(
-          entry.getKey(), addDerivedTagsWithPreFetched(entry.getValue(), derivedTagsMap));
-    }
-    return effectiveTagsByHash;
-  }
-
-  private boolean columnMatchesTagFilter(
-      Column column, ColumnTagFilter columnTagFilter, Map<String, List<TagLabel>> tagsByHash) {
-    List<TagLabel> tags =
-        tagsByHash.get(FullyQualifiedName.buildHash(column.getFullyQualifiedName()));
-    Set<String> columnTagFQNs =
-        nullOrEmpty(tags)
-            ? Set.of()
-            : tags.stream().map(TagLabel::getTagFQN).collect(Collectors.toSet());
-    return matchesTagGroup(columnTagFQNs, columnTagFilter.tagFQNs())
-        && matchesTagGroup(columnTagFQNs, columnTagFilter.glossaryTermFQNs());
-  }
-
-  private boolean matchesTagGroup(Set<String> columnTagFQNs, Set<String> filterGroup) {
-    return nullOrEmpty(filterGroup) || filterGroup.stream().anyMatch(columnTagFQNs::contains);
-  }
-
-  private List<Column> flattenTableColumns(List<Column> columns) {
-    List<Column> flattened = new ArrayList<>();
-    for (Column column : columns) {
-      flattened.add(column);
-      if (column.getChildren() != null && !column.getChildren().isEmpty()) {
-        flattened.addAll(flattenTableColumns(column.getChildren()));
-      }
-    }
-    return flattened;
   }
 
   private void indexPipelineStatus(Table table, PipelineObservability observability)

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/databases/TableResource.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/databases/TableResource.java
@@ -48,9 +48,7 @@ import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.SecurityContext;
 import jakarta.ws.rs.core.UriInfo;
 import java.io.IOException;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 import java.util.UUID;
 import org.openmetadata.schema.api.VoteRequest;
 import org.openmetadata.schema.api.data.CreateTable;
@@ -2089,7 +2087,7 @@ public class TableResource extends EntityResource<Table, TableRepository> {
             include,
             sortBy,
             sortOrder,
-            parseColumnTagFilters(tags, glossaryTerms),
+            ColumnTagFilter.fromCsv(tags, glossaryTerms),
             authorizer,
             securityContext);
     TableColumnList tableColumnList = new TableColumnList();
@@ -2191,30 +2189,12 @@ public class TableResource extends EntityResource<Table, TableRepository> {
             include,
             sortBy,
             sortOrder,
-            parseColumnTagFilters(tags, glossaryTerms),
+            ColumnTagFilter.fromCsv(tags, glossaryTerms),
             authorizer,
             securityContext);
     TableColumnList tableColumnList = new TableColumnList();
     tableColumnList.setData(result.getData());
     tableColumnList.setPaging(result.getPaging());
     return tableColumnList;
-  }
-
-  private ColumnTagFilter parseColumnTagFilters(String tags, String glossaryTerms) {
-    return new ColumnTagFilter(parseFqnCsv(tags), parseFqnCsv(glossaryTerms));
-  }
-
-  private Set<String> parseFqnCsv(String csv) {
-    if (csv == null || csv.isBlank()) {
-      return Set.of();
-    }
-    Set<String> fqns = new HashSet<>();
-    for (String fqn : csv.split(",")) {
-      String trimmed = fqn.trim();
-      if (!trimmed.isEmpty()) {
-        fqns.add(trimmed);
-      }
-    }
-    return fqns;
   }
 }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/databases/TableResource.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/databases/TableResource.java
@@ -85,7 +85,6 @@ import org.openmetadata.schema.utils.ResultList;
 import org.openmetadata.service.Entity;
 import org.openmetadata.service.jdbi3.ListFilter;
 import org.openmetadata.service.jdbi3.TableRepository;
-import org.openmetadata.service.jdbi3.TableRepository.ColumnTagFilter;
 import org.openmetadata.service.limits.Limits;
 import org.openmetadata.service.monitoring.LatencyPhase;
 import org.openmetadata.service.resources.Collection;
@@ -93,6 +92,7 @@ import org.openmetadata.service.resources.EntityResource;
 import org.openmetadata.service.security.Authorizer;
 import org.openmetadata.service.security.policyevaluator.OperationContext;
 import org.openmetadata.service.security.policyevaluator.ResourceContext;
+import org.openmetadata.service.util.ColumnSearchUtil.ColumnTagFilter;
 import org.openmetadata.service.util.FullyQualifiedName;
 
 @Path("/v1/tables")

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/datamodels/DashboardDataModelResource.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/datamodels/DashboardDataModelResource.java
@@ -45,7 +45,9 @@ import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.SecurityContext;
 import jakarta.ws.rs.core.UriInfo;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.UUID;
 import org.openmetadata.schema.api.VoteRequest;
 import org.openmetadata.schema.api.data.CreateDashboardDataModel;
@@ -66,6 +68,7 @@ import org.openmetadata.service.resources.Collection;
 import org.openmetadata.service.resources.EntityResource;
 import org.openmetadata.service.security.Authorizer;
 import org.openmetadata.service.security.policyevaluator.OperationContext;
+import org.openmetadata.service.util.ColumnSearchUtil.ColumnTagFilter;
 
 @Path("/v1/dashboard/datamodels")
 @Tag(
@@ -860,13 +863,52 @@ public class DashboardDataModelResource
               schema = @Schema(implementation = Include.class))
           @QueryParam("include")
           @DefaultValue("non-deleted")
-          Include include) {
+          Include include,
+      @Parameter(
+              description =
+                  "Sort columns by field. Supported values: 'name' (default), 'ordinalPosition'",
+              schema =
+                  @Schema(
+                      type = "string",
+                      allowableValues = {"name", "ordinalPosition"}))
+          @QueryParam("sortBy")
+          @DefaultValue("name")
+          String sortBy,
+      @Parameter(
+              description = "Sort order. Supported values: 'asc' (default), 'desc'",
+              schema =
+                  @Schema(
+                      type = "string",
+                      allowableValues = {"asc", "desc"}))
+          @QueryParam("sortOrder")
+          @DefaultValue("asc")
+          String sortOrder,
+      @Parameter(
+              description =
+                  "Filter by classification tags at column level (comma-separated tag FQNs)",
+              example = "PII.Sensitive,PersonalData.Email")
+          @QueryParam("tags")
+          String tags,
+      @Parameter(
+              description =
+                  "Filter by glossary terms at column level (comma-separated glossary term FQNs)",
+              example = "Business.CustomerData,Business.Revenue")
+          @QueryParam("glossaryTerms")
+          String glossaryTerms) {
     OperationContext operationContext =
         new OperationContext(entityType, MetadataOperation.VIEW_BASIC);
     authorizer.authorize(securityContext, operationContext, getResourceContextById(id));
     ResultList<Column> result =
         repository.searchDataModelColumnsById(
-            id, query, limitParam, offsetParam, fieldsParam, include);
+            id,
+            query,
+            limitParam,
+            offsetParam,
+            fieldsParam,
+            include,
+            sortBy,
+            sortOrder,
+            parseColumnTagFilters(tags, glossaryTerms));
     DataModelColumnList dataModelColumnList = new DataModelColumnList();
     dataModelColumnList.setData(result.getData());
     dataModelColumnList.setPaging(result.getPaging());
@@ -921,16 +963,72 @@ public class DashboardDataModelResource
               schema = @Schema(implementation = Include.class))
           @QueryParam("include")
           @DefaultValue("non-deleted")
-          Include include) {
+          Include include,
+      @Parameter(
+              description =
+                  "Sort columns by field. Supported values: 'name' (default), 'ordinalPosition'",
+              schema =
+                  @Schema(
+                      type = "string",
+                      allowableValues = {"name", "ordinalPosition"}))
+          @QueryParam("sortBy")
+          @DefaultValue("name")
+          String sortBy,
+      @Parameter(
+              description = "Sort order. Supported values: 'asc' (default), 'desc'",
+              schema =
+                  @Schema(
+                      type = "string",
+                      allowableValues = {"asc", "desc"}))
+          @QueryParam("sortOrder")
+          @DefaultValue("asc")
+          String sortOrder,
+      @Parameter(
+              description =
+                  "Filter by classification tags at column level (comma-separated tag FQNs)",
+              example = "PII.Sensitive,PersonalData.Email")
+          @QueryParam("tags")
+          String tags,
+      @Parameter(
+              description =
+                  "Filter by glossary terms at column level (comma-separated glossary term FQNs)",
+              example = "Business.CustomerData,Business.Revenue")
+          @QueryParam("glossaryTerms")
+          String glossaryTerms) {
     OperationContext operationContext =
         new OperationContext(entityType, MetadataOperation.VIEW_BASIC);
     authorizer.authorize(securityContext, operationContext, getResourceContextByName(fqn));
     ResultList<org.openmetadata.schema.type.Column> result =
         repository.searchDataModelColumnsByFQN(
-            fqn, query, limitParam, offsetParam, fieldsParam, include);
+            fqn,
+            query,
+            limitParam,
+            offsetParam,
+            fieldsParam,
+            include,
+            sortBy,
+            sortOrder,
+            parseColumnTagFilters(tags, glossaryTerms));
     DataModelColumnList dataModelColumnList = new DataModelColumnList();
     dataModelColumnList.setData(result.getData());
     dataModelColumnList.setPaging(result.getPaging());
     return dataModelColumnList;
+  }
+
+  private ColumnTagFilter parseColumnTagFilters(String tags, String glossaryTerms) {
+    return new ColumnTagFilter(parseFqnCsv(tags), parseFqnCsv(glossaryTerms));
+  }
+
+  private Set<String> parseFqnCsv(String csv) {
+    Set<String> fqns = new HashSet<>();
+    if (csv != null && !csv.isBlank()) {
+      for (String fqn : csv.split(",")) {
+        String trimmed = fqn.trim();
+        if (!trimmed.isEmpty()) {
+          fqns.add(trimmed);
+        }
+      }
+    }
+    return fqns;
   }
 }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/datamodels/DashboardDataModelResource.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/datamodels/DashboardDataModelResource.java
@@ -45,9 +45,7 @@ import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.SecurityContext;
 import jakarta.ws.rs.core.UriInfo;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 import java.util.UUID;
 import org.openmetadata.schema.api.VoteRequest;
 import org.openmetadata.schema.api.data.CreateDashboardDataModel;
@@ -908,7 +906,7 @@ public class DashboardDataModelResource
             include,
             sortBy,
             sortOrder,
-            parseColumnTagFilters(tags, glossaryTerms));
+            ColumnTagFilter.fromCsv(tags, glossaryTerms));
     DataModelColumnList dataModelColumnList = new DataModelColumnList();
     dataModelColumnList.setData(result.getData());
     dataModelColumnList.setPaging(result.getPaging());
@@ -1008,27 +1006,10 @@ public class DashboardDataModelResource
             include,
             sortBy,
             sortOrder,
-            parseColumnTagFilters(tags, glossaryTerms));
+            ColumnTagFilter.fromCsv(tags, glossaryTerms));
     DataModelColumnList dataModelColumnList = new DataModelColumnList();
     dataModelColumnList.setData(result.getData());
     dataModelColumnList.setPaging(result.getPaging());
     return dataModelColumnList;
-  }
-
-  private ColumnTagFilter parseColumnTagFilters(String tags, String glossaryTerms) {
-    return new ColumnTagFilter(parseFqnCsv(tags), parseFqnCsv(glossaryTerms));
-  }
-
-  private Set<String> parseFqnCsv(String csv) {
-    Set<String> fqns = new HashSet<>();
-    if (csv != null && !csv.isBlank()) {
-      for (String fqn : csv.split(",")) {
-        String trimmed = fqn.trim();
-        if (!trimmed.isEmpty()) {
-          fqns.add(trimmed);
-        }
-      }
-    }
-    return fqns;
   }
 }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/util/ColumnSearchUtil.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/util/ColumnSearchUtil.java
@@ -17,6 +17,7 @@ import static org.openmetadata.service.resources.tags.TagLabelUtil.addDerivedTag
 import static org.openmetadata.service.resources.tags.TagLabelUtil.batchFetchDerivedTags;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
@@ -50,6 +51,25 @@ public final class ColumnSearchUtil {
     public boolean isEmpty() {
       return nullOrEmpty(tagFQNs) && nullOrEmpty(glossaryTermFQNs);
     }
+
+    /** Build a filter from comma-separated tag and glossary-term FQN query params. */
+    public static ColumnTagFilter fromCsv(String tags, String glossaryTerms) {
+      return new ColumnTagFilter(parseFqnCsv(tags), parseFqnCsv(glossaryTerms));
+    }
+  }
+
+  private static Set<String> parseFqnCsv(String csv) {
+    Set<String> result;
+    if (nullOrEmpty(csv) || csv.isBlank()) {
+      result = Set.of();
+    } else {
+      result =
+          Arrays.stream(csv.split(","))
+              .map(String::trim)
+              .filter(fqn -> !fqn.isEmpty())
+              .collect(Collectors.toSet());
+    }
+    return result;
   }
 
   /**
@@ -85,7 +105,7 @@ public final class ColumnSearchUtil {
       String searchTerm,
       ColumnTagFilter columnTagFilter,
       Map<String, List<TagLabel>> tagsByHash) {
-    boolean matchesQuery = searchTerm == null || columnNameMatches(column, searchTerm);
+    boolean matchesQuery = searchTerm == null || columnTextMatches(column, searchTerm);
     boolean matchesTags =
         columnTagFilter == null
             || columnTagFilter.isEmpty()
@@ -93,13 +113,16 @@ public final class ColumnSearchUtil {
     return matchesQuery && matchesTags;
   }
 
-  private static boolean columnNameMatches(Column column, String searchTerm) {
+  private static boolean columnTextMatches(Column column, String searchTerm) {
     boolean nameMatches =
         column.getName() != null && column.getName().toLowerCase().contains(searchTerm);
     boolean displayNameMatches =
         column.getDisplayName() != null
             && column.getDisplayName().toLowerCase().contains(searchTerm);
-    return nameMatches || displayNameMatches;
+    boolean descriptionMatches =
+        column.getDescription() != null
+            && column.getDescription().toLowerCase().contains(searchTerm);
+    return nameMatches || displayNameMatches || descriptionMatches;
   }
 
   public static Comparator<Column> columnComparator(String sortBy, String sortOrder) {

--- a/openmetadata-service/src/main/java/org/openmetadata/service/util/ColumnSearchUtil.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/util/ColumnSearchUtil.java
@@ -1,0 +1,178 @@
+/*
+ *  Copyright 2025 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.openmetadata.service.util;
+
+import static org.openmetadata.common.utils.CommonUtil.nullOrEmpty;
+import static org.openmetadata.service.resources.tags.TagLabelUtil.addDerivedTagsWithPreFetched;
+import static org.openmetadata.service.resources.tags.TagLabelUtil.batchFetchDerivedTags;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import lombok.extern.slf4j.Slf4j;
+import org.openmetadata.schema.type.Column;
+import org.openmetadata.schema.type.TagLabel;
+import org.openmetadata.service.jdbi3.CollectionDAO;
+
+/**
+ * Shared server-side column search + tag/glossary filtering for entities whose children are {@link
+ * Column} trees (Table, Dashboard Data Model). Keeps the paginated column search consistent across
+ * entities: a matched node is returned at its real depth under its ancestor path, and the tag
+ * filter resolves the same direct + glossary-derived tags shown on each column.
+ */
+@Slf4j
+public final class ColumnSearchUtil {
+  private ColumnSearchUtil() {}
+
+  private static final String SORT_BY_ORDINAL_POSITION = "ordinalPosition";
+  private static final String SORT_ORDER_DESC = "desc";
+
+  /**
+   * Column-level tag filter. {@code tagFQNs} and {@code glossaryTermFQNs} mirror the two independent
+   * column filters in the UI. Values within each group are OR-ed; the two groups are AND-ed when
+   * both are present (matching AntD's cross-column filter semantics).
+   */
+  public record ColumnTagFilter(Set<String> tagFQNs, Set<String> glossaryTermFQNs) {
+    public boolean isEmpty() {
+      return nullOrEmpty(tagFQNs) && nullOrEmpty(glossaryTermFQNs);
+    }
+  }
+
+  /**
+   * Prune the column tree to nodes that match the search term and tag filter, keeping every matched
+   * node at its real depth together with its ancestor path. Mirrors the UI's getFilteredTagsData so
+   * the server-side filter renders the same nested view, paginated across the whole entity instead
+   * of the loaded page. A node is kept when it matches itself or has a kept descendant; a kept
+   * node's children are pruned to the matched paths only.
+   */
+  public static List<Column> pruneColumnsToMatches(
+      List<Column> columns,
+      String searchTerm,
+      ColumnTagFilter columnTagFilter,
+      Map<String, List<TagLabel>> tagsByHash) {
+    List<Column> pruned = new ArrayList<>();
+    for (Column column : columns) {
+      List<Column> prunedChildren =
+          nullOrEmpty(column.getChildren())
+              ? new ArrayList<>()
+              : pruneColumnsToMatches(
+                  column.getChildren(), searchTerm, columnTagFilter, tagsByHash);
+      boolean matches = columnMatchesSearch(column, searchTerm, columnTagFilter, tagsByHash);
+      if (matches || !prunedChildren.isEmpty()) {
+        column.setChildren(prunedChildren);
+        pruned.add(column);
+      }
+    }
+    return pruned;
+  }
+
+  private static boolean columnMatchesSearch(
+      Column column,
+      String searchTerm,
+      ColumnTagFilter columnTagFilter,
+      Map<String, List<TagLabel>> tagsByHash) {
+    boolean matchesQuery = searchTerm == null || columnNameMatches(column, searchTerm);
+    boolean matchesTags =
+        columnTagFilter == null
+            || columnTagFilter.isEmpty()
+            || columnMatchesTagFilter(column, columnTagFilter, tagsByHash);
+    return matchesQuery && matchesTags;
+  }
+
+  private static boolean columnNameMatches(Column column, String searchTerm) {
+    boolean nameMatches =
+        column.getName() != null && column.getName().toLowerCase().contains(searchTerm);
+    boolean displayNameMatches =
+        column.getDisplayName() != null
+            && column.getDisplayName().toLowerCase().contains(searchTerm);
+    return nameMatches || displayNameMatches;
+  }
+
+  public static Comparator<Column> columnComparator(String sortBy, String sortOrder) {
+    Comparator<Column> comparator;
+    if (SORT_BY_ORDINAL_POSITION.equals(sortBy)) {
+      comparator =
+          Comparator.comparing(
+              Column::getOrdinalPosition, Comparator.nullsLast(Comparator.naturalOrder()));
+    } else {
+      comparator =
+          Comparator.comparing(
+              Column::getName, Comparator.nullsLast(String.CASE_INSENSITIVE_ORDER));
+    }
+    if (SORT_ORDER_DESC.equalsIgnoreCase(sortOrder)) {
+      comparator = comparator.reversed();
+    }
+    return comparator;
+  }
+
+  private static boolean columnMatchesTagFilter(
+      Column column, ColumnTagFilter columnTagFilter, Map<String, List<TagLabel>> tagsByHash) {
+    List<TagLabel> tags =
+        tagsByHash.get(FullyQualifiedName.buildHash(column.getFullyQualifiedName()));
+    Set<String> columnTagFQNs =
+        nullOrEmpty(tags)
+            ? Set.of()
+            : tags.stream().map(TagLabel::getTagFQN).collect(Collectors.toSet());
+    return matchesTagGroup(columnTagFQNs, columnTagFilter.tagFQNs())
+        && matchesTagGroup(columnTagFQNs, columnTagFilter.glossaryTermFQNs());
+  }
+
+  private static boolean matchesTagGroup(Set<String> columnTagFQNs, Set<String> filterGroup) {
+    return nullOrEmpty(filterGroup) || filterGroup.stream().anyMatch(columnTagFQNs::contains);
+  }
+
+  public static List<Column> flattenColumns(List<Column> columns) {
+    List<Column> flattened = new ArrayList<>();
+    for (Column column : columns) {
+      flattened.add(column);
+      if (!nullOrEmpty(column.getChildren())) {
+        flattened.addAll(flattenColumns(column.getChildren()));
+      }
+    }
+    return flattened;
+  }
+
+  /**
+   * Resolve column tags the same way the column list responses (and therefore the UI filter
+   * dropdown) see them: direct tag_usage rows enriched with glossary-derived tags. The raw DAO is
+   * used instead of the service-layer helper so certification-classification tags are not stripped,
+   * keeping the filter consistent with the tags shown on each column.
+   */
+  public static Map<String, List<TagLabel>> resolveColumnTagsForFilter(
+      String entityFqn, CollectionDAO daoCollection) {
+    Map<String, List<TagLabel>> directTagsByHash =
+        daoCollection.tagUsageDAO().getTagsByPrefix(entityFqn, ".%", true);
+    if (nullOrEmpty(directTagsByHash)) {
+      return Map.of();
+    }
+    List<TagLabel> allDirectTags =
+        directTagsByHash.values().stream().flatMap(List::stream).collect(Collectors.toList());
+    Map<String, List<TagLabel>> derivedTagsMap;
+    try {
+      derivedTagsMap = batchFetchDerivedTags(allDirectTags);
+    } catch (Exception ex) {
+      LOG.warn("Failed to fetch derived tags for column tag filter; matching direct tags only", ex);
+      derivedTagsMap = Map.of();
+    }
+    Map<String, List<TagLabel>> effectiveTagsByHash = new HashMap<>();
+    for (Map.Entry<String, List<TagLabel>> entry : directTagsByHash.entrySet()) {
+      effectiveTagsByHash.put(
+          entry.getKey(), addDerivedTagsWithPreFetched(entry.getValue(), derivedTagsMap));
+    }
+    return effectiveTagsByHash;
+  }
+}

--- a/openmetadata-ui/src/main/resources/ui/src/components/Dashboard/DataModel/DataModels/ModelTab/ModelTab.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Dashboard/DataModel/DataModels/ModelTab/ModelTab.component.tsx
@@ -191,7 +191,12 @@ const ModelTab = () => {
   const handleColumnFilterChange = useCallback<
     NonNullable<TableProps<Column>['onChange']>
   >(
-    (_pagination, tableFilters) => {
+    (_pagination, tableFilters, _sorter, extra) => {
+      // AntD fires onChange for sort/paginate too; only react to filter changes
+      if (extra.action !== 'filter') {
+        return;
+      }
+
       const tags = (tableFilters?.[TABLE_COLUMNS_KEYS.TAGS] as string[]) ?? [];
       const glossaryTerms =
         (tableFilters?.[TABLE_COLUMNS_KEYS.GLOSSARY] as string[]) ?? [];

--- a/openmetadata-ui/src/main/resources/ui/src/components/Dashboard/DataModel/DataModels/ModelTab/ModelTab.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Dashboard/DataModel/DataModels/ModelTab/ModelTab.component.tsx
@@ -10,7 +10,7 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-import { Typography } from 'antd';
+import { TableProps, Typography } from 'antd';
 import { ColumnsType } from 'antd/lib/table';
 import { groupBy, isEmpty, omit, uniqBy } from 'lodash';
 import { EntityTags, TagFilterOptions } from 'Models';
@@ -31,7 +31,6 @@ import { TagLabel, TagSource } from '../../../../../generated/type/tagLabel';
 import { usePaging } from '../../../../../hooks/paging/usePaging';
 import { useFqn } from '../../../../../hooks/useFqn';
 import { useFqnDeepLink } from '../../../../../hooks/useFqnDeepLink';
-import { useTreeTagFilter } from '../../../../../hooks/useTreeTagFilter';
 import {
   getDataModelColumnsByFQN,
   searchDataModelColumnsByFQN,
@@ -41,6 +40,7 @@ import { getEntityName } from '../../../../../utils/EntityNameUtils';
 import { getColumnSorter } from '../../../../../utils/EntitySortUtils';
 import { columnFilterIcon } from '../../../../../utils/TableColumn.util';
 import {
+  getExpandAllKeysToDepth,
   getHighlightedRowClassName,
   pruneEmptyChildren,
   updateColumnInNestedStructure,
@@ -76,6 +76,14 @@ const ModelTab = () => {
   const [editColumnDescription, setEditColumnDescription] = useState<Column>();
   const [_expandedRowKeys, setExpandedRowKeys] = useState<string[]>([]);
   const [searchText, setSearchText] = useState('');
+  const [activeTagFilter, setActiveTagFilter] = useState<{
+    tags: string[];
+    glossaryTerms: string[];
+  }>({ tags: [], glossaryTerms: [] });
+
+  const tagsParam = activeTagFilter.tags.join(',');
+  const glossaryTermsParam = activeTagFilter.glossaryTerms.join(',');
+  const hasTagFilter = Boolean(tagsParam || glossaryTermsParam);
   const { openColumnDetailPanel, selectedColumn, setDisplayedColumns } =
     useGenericContext<DashboardDataModel>();
 
@@ -128,19 +136,25 @@ const ModelTab = () => {
       try {
         const offset = (page - 1) * pageSize;
 
-        // Use search API if there's a search query, otherwise use regular pagination
-        const response = searchQuery
-          ? await searchDataModelColumnsByFQN(entityFqn, {
-              limit: pageSize,
-              offset,
-              fields: TabSpecificField.TAGS,
-              q: searchQuery,
-            })
-          : await getDataModelColumnsByFQN(entityFqn, {
-              limit: pageSize,
-              offset,
-              fields: TabSpecificField.TAGS,
-            });
+        // Use search API when there's a search query or an active tag filter,
+        // otherwise use regular pagination
+        const response =
+          searchQuery || hasTagFilter
+            ? await searchDataModelColumnsByFQN(entityFqn, {
+                limit: pageSize,
+                offset,
+                fields: TabSpecificField.TAGS,
+                q: searchQuery ?? '',
+                ...(tagsParam ? { tags: tagsParam } : {}),
+                ...(glossaryTermsParam
+                  ? { glossaryTerms: glossaryTermsParam }
+                  : {}),
+              })
+            : await getDataModelColumnsByFQN(entityFqn, {
+                limit: pageSize,
+                offset,
+                fields: TabSpecificField.TAGS,
+              });
 
         const data = pruneEmptyChildren(response.data) || [];
         setPaginatedColumns(data);
@@ -155,7 +169,14 @@ const ModelTab = () => {
       }
       setColumnsLoading(false);
     },
-    [entityFqn, pageSize, handlePagingChange]
+    [
+      entityFqn,
+      pageSize,
+      handlePagingChange,
+      hasTagFilter,
+      tagsParam,
+      glossaryTermsParam,
+    ]
   );
 
   const handleColumnsPageChange = useCallback(
@@ -165,6 +186,19 @@ const ModelTab = () => {
       handlePageChange(currentPage);
     },
     [paging, fetchPaginatedColumns, searchText, handlePageChange]
+  );
+
+  const handleColumnFilterChange = useCallback<
+    NonNullable<TableProps<Column>['onChange']>
+  >(
+    (_pagination, tableFilters) => {
+      const tags = (tableFilters?.[TABLE_COLUMNS_KEYS.TAGS] as string[]) ?? [];
+      const glossaryTerms =
+        (tableFilters?.[TABLE_COLUMNS_KEYS.GLOSSARY] as string[]) ?? [];
+      setActiveTagFilter({ tags, glossaryTerms });
+      handlePageChange(1);
+    },
+    [handlePageChange]
   );
 
   const { deleted } = useMemo(
@@ -191,19 +225,28 @@ const ModelTab = () => {
   }, [permissions]);
 
   const tagFilter = useMemo(() => {
-    const tags = getAllTags(data ?? []);
+    const tags = getAllTags([...(dataModel?.columns ?? []), ...(data ?? [])]);
 
     return groupBy(uniqBy(tags, 'value'), (tag) => tag.source) as Record<
       TagSource,
       TagFilterOptions[]
     >;
-  }, [data]);
+  }, [dataModel?.columns, data]);
 
   useEffect(() => {
     if (entityFqn) {
       fetchPaginatedColumns(1, searchText || undefined);
     }
   }, [entityFqn, searchText, fetchPaginatedColumns, pageSize, dataModel]);
+
+  useEffect(() => {
+    setExpandedRowKeys((prev) => {
+      const depth = searchText || hasTagFilter ? Number.MAX_SAFE_INTEGER : 1;
+      const autoKeys = getExpandAllKeysToDepth(paginatedColumns ?? [], depth);
+
+      return [...new Set([...autoKeys, ...prev])];
+    });
+  }, [paginatedColumns, searchText, hasTagFilter]);
 
   // Sync displayed columns with GenericProvider for ColumnDetailPanel navigation
   useEffect(() => {
@@ -311,7 +354,7 @@ const ModelTab = () => {
       currentPage,
       showPagination,
       isLoading: columnsLoading,
-      isNumberBased: Boolean(searchText),
+      isNumberBased: Boolean(searchText || hasTagFilter),
       pageSize,
       paging,
       pagingHandler: handleColumnsPageChange,
@@ -322,14 +365,13 @@ const ModelTab = () => {
       showPagination,
       columnsLoading,
       searchText,
+      hasTagFilter,
       pageSize,
       paging,
       handleColumnsPageChange,
       handlePageSizeChange,
     ]
   );
-  const { tagFilterState, filteredData, handleTableChange } =
-    useTreeTagFilter(data);
 
   const tableColumn: ColumnsType<Column> = useMemo(
     () => [
@@ -401,7 +443,9 @@ const ModelTab = () => {
         filters: tagFilter.Classification,
         filterIcon: columnFilterIcon,
         filterDropdown: ColumnFilter,
-        filteredValue: tagFilterState[TABLE_COLUMNS_KEYS.TAGS] ?? null,
+        filteredValue: activeTagFilter.tags.length
+          ? activeTagFilter.tags
+          : null,
         render: (tags: TagLabel[], record: Column, index: number) => (
           <TableTags<Column>
             entityFqn={entityFqn ?? ''}
@@ -424,7 +468,9 @@ const ModelTab = () => {
         filterIcon: columnFilterIcon,
         filters: tagFilter.Glossary,
         filterDropdown: ColumnFilter,
-        filteredValue: tagFilterState[TABLE_COLUMNS_KEYS.GLOSSARY] ?? null,
+        filteredValue: activeTagFilter.glossaryTerms.length
+          ? activeTagFilter.glossaryTerms
+          : null,
         render: (tags: TagLabel[], record: Column, index: number) => (
           <TableTags<Column>
             entityFqn={entityFqn ?? ''}
@@ -444,7 +490,7 @@ const ModelTab = () => {
       entityFqn,
       isReadOnly,
       tagFilter,
-      tagFilterState,
+      activeTagFilter,
       hasEditTagsPermission,
       hasEditGlossaryTermPermission,
       editColumnDescription,
@@ -463,7 +509,7 @@ const ModelTab = () => {
         columns={tableColumn}
         customPaginationProps={paginationProps}
         data-testid="data-model-column-table"
-        dataSource={filteredData}
+        dataSource={data}
         defaultVisibleColumns={DEFAULT_DASHBOARD_DATA_MODEL_VISIBLE_COLUMNS}
         expandable={{
           ...getTableExpandableConfig<Column>(false, 'text-link-color'),
@@ -480,7 +526,7 @@ const ModelTab = () => {
         searchProps={searchProps}
         size="small"
         staticVisibleColumns={COMMON_STATIC_TABLE_VISIBLE_COLUMNS}
-        onChange={handleTableChange}
+        onChange={handleColumnFilterChange}
       />
 
       {editColumnDescription && (

--- a/openmetadata-ui/src/main/resources/ui/src/rest/dataModelsAPI.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/rest/dataModelsAPI.ts
@@ -116,6 +116,8 @@ export interface SearchDataModelColumnsParams extends DataModelColumnParams {
   q?: string; // Search query
   tags?: string; // Comma-separated classification tag FQNs
   glossaryTerms?: string; // Comma-separated glossary term FQNs
+  sortBy?: 'name' | 'ordinalPosition';
+  sortOrder?: 'asc' | 'desc';
 }
 
 export const getDataModelColumnsByFQN = async (

--- a/openmetadata-ui/src/main/resources/ui/src/rest/dataModelsAPI.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/rest/dataModelsAPI.ts
@@ -114,6 +114,8 @@ export interface DataModelColumnParams {
 
 export interface SearchDataModelColumnsParams extends DataModelColumnParams {
   q?: string; // Search query
+  tags?: string; // Comma-separated classification tag FQNs
+  glossaryTerms?: string; // Comma-separated glossary term FQNs
 }
 
 export const getDataModelColumnsByFQN = async (


### PR DESCRIPTION
## Related to #25063

#25063 added a server-side column tag/glossary filter to the **Table** schema view (implemented in #29324), fixing a cross-page bug where a tag applied to a column on a later page could not be found because filtering ran client-side over the loaded page only.

**Dashboard Data Models have the identical setup** — columns paginate server-side (`PAGE_SIZE_LARGE`), the schema table exposes Tags/Glossary column filters — but their `/columns/search` endpoint never got the filter, so data models still exhibit the original bug. This PR brings them to parity and extracts the logic into a shared util so the two entities stay consistent.

### Why data models specifically
Table and Dashboard Data Model are the only two entities whose children are the `Column` type **and** fetched page-by-page from a `/columns/search` endpoint. Every other entity with a column/field tag filter (Container, Topic, SearchIndex, API Endpoint, File, Worksheet, Dashboard, Pipeline) loads all children inline, so its client-side filter already spans everything — no server-side change needed.

### Backend
- **New `ColumnSearchUtil`** — the column search + tag/glossary filtering (`pruneColumnsToMatches`, `columnComparator`, `resolveColumnTagsForFilter`, `ColumnTagFilter`) is extracted from `TableRepository` into a shared util. `TableRepository` now delegates to it (no behavior change for Tables).
- **`DashboardDataModelResource`** — both `/columns/search` endpoints gain `tags`, `glossaryTerms`, `sortBy`, `sortOrder` params.
- **`DashboardDataModelRepository`** — replaces the old flat search with server-side tree pruning + direct-and-derived tag resolution across all pages, on a deep copy of the column tree.

### Frontend (`ModelTab`)
- Replaces the client-side `useTreeTagFilter` with a server-side filter that calls `searchDataModelColumnsByFQN` with `tags`/`glossaryTerms`, resets to page 1 on change, sources filter options from the full entity columns, and auto-expands ancestors of matches — mirroring `SchemaTable`.

### Behavior notes
- Data-model text search now returns the **nested tree** (a matched nested column under its ancestor path) instead of a flat list — consistent with the Table endpoint and required to show hierarchy.
- Search matches `name`/`displayName` only (the old data-model search also matched `description`); this aligns it with the Table endpoint.

### Tests
- Integration test asserting the tag filter finds a column tagged on a later page, via both by-FQN and by-ID endpoints.
- Backend `mvn install` (service + integration-tests) passes; frontend `tsc --noEmit` clean.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds server-side column tag and glossary filtering for Dashboard Data Models. The main changes are:

- Shared column search and tag filtering in `ColumnSearchUtil`.
- Dashboard Data Model `/columns/search` support for tag, glossary, and sort parameters.
- Model tab filtering moved from client-side tree filtering to server-backed search.
- Integration coverage for finding a tagged data model column beyond the first page.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge.

- No blocking issues found in the changed code.

</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-service/src/main/java/org/openmetadata/service/util/ColumnSearchUtil.java | Adds shared column tree search, tag filtering, sorting, flattening, and tag resolution. |
| openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/DashboardDataModelRepository.java | Uses the shared utility to search, filter, sort, paginate, and populate data model columns. |
| openmetadata-service/src/main/java/org/openmetadata/service/resources/datamodels/DashboardDataModelResource.java | Adds tag, glossary, and sort query parameters to both data model column search routes. |
| openmetadata-ui/src/main/resources/ui/src/components/Dashboard/DataModel/DataModels/ModelTab/ModelTab.component.tsx | Switches data model column tag filtering to server-backed search and keeps matching paths expanded. |
| openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/DashboardDataModelResourceIT.java | Adds integration coverage for tag filtering across paginated data model columns. |

</details>

<sub>Reviews (4): Last reviewed commit: ["review: expose sortBy/sortOrder on Searc..."](https://github.com/open-metadata/openmetadata/commit/39bd605e78e116578fe35b649c030b5d588d06d4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42777247)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Context used - CLAUDE.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=52f0d9d9-cad1-4e7d-b070-de181a0aa5e7))
- Context used - openmetadata-ui-core-components/CLAUDE.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=41754627-b2bf-474b-8082-f37ef1a07013))
- Context used - AGENTS.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=ef262f5f-911f-44f3-8d2d-e9cb1579c8c8))
</details>

<!-- /greptile_comment -->