### PR TITLE
fix(ui): use relative import for EntityUtils in VersionTable (1.13)

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/Entity/VersionTable/VersionTable.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Entity/VersionTable/VersionTable.component.tsx
@@ -16,16 +16,16 @@ import { ColumnsType } from 'antd/lib/table';
 import { isEmpty, isUndefined } from 'lodash';
 import { Key, useCallback, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import {
-  getFrequentlyJoinedColumns,
-  searchInColumns,
-} from 'src/utils/EntityUtils';
 import { NO_DATA_PLACEHOLDER } from '../../../constants/constants';
 import { TABLE_SCROLL_VALUE } from '../../../constants/Table.constants';
 import { TableConstraint } from '../../../generated/api/data/createTable';
 import { SearchIndexField } from '../../../generated/entity/data/searchIndex';
 import { Column } from '../../../generated/entity/data/table';
 import { usePaging } from '../../../hooks/paging/usePaging';
+import {
+  getFrequentlyJoinedColumns,
+  searchInColumns,
+} from '../../../utils/EntityUtils';
 import { getFilterTags } from '../../../utils/TableTags/TableTags.utils';
 import {
   getAllRowKeysByKeyName,


### PR DESCRIPTION
## Describe your changes

Fixes the Collate "Build and push Collate" CI failure on the 1.13 line.

#29411 (1.13 backport, `ab576f67c5`) introduced an absolute-style import in `VersionTable.component.tsx`:

```ts
import { getFrequentlyJoinedColumns, searchInColumns } from 'src/utils/EntityUtils';
```

This resolves in OpenMetadata's own build (tsconfig `baseUrl: "."`), but in the Collate build the OM UI tree is copied under `src/openmetadata-ui/` and vite/Rollup fails:

```
[vite]: Rollup failed to resolve import "src/utils/EntityUtils" from ".../src/openmetadata-ui/src/components/Entity/VersionTable/VersionTable.component.tsx"
```

This PR switches it to a relative import (`../../../utils/EntityUtils`), consistent with every other import in the file. 1.13-only: on `main` this import was already migrated to direct sources (#28919 / `126cd24064`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR is a targeted 1.13 backport fix that replaces an absolute import path (`src/utils/EntityUtils`) with the relative equivalent (`../../../utils/EntityUtils`) in `VersionTable.component.tsx`. The absolute path works under OpenMetadata's own tsconfig (`baseUrl: "."`), but breaks the Collate build where the OM UI tree is nested under `src/openmetadata-ui/`.

- **Single-line import fix**: the only change is swapping the import style for `getFrequentlyJoinedColumns` and `searchInColumns` in `VersionTable.component.tsx`, making it consistent with every other import in that file.
- **Build-environment scoped**: no logic, types, or runtime behaviour are affected; the same module is resolved in both cases for the OpenMetadata build and now also for the Collate build.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — a one-line import path correction with no behavioural change and no logic touched.

The change swaps a single absolute-style import for its relative equivalent, making the file consistent with every other import it contains. No logic, types, or runtime behaviour are modified; the same module is resolved in both cases for the OpenMetadata build, and the fix unblocks the Collate build where the absolute path could not be resolved.

No files require special attention.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-ui/src/main/resources/ui/src/components/Entity/VersionTable/VersionTable.component.tsx | Switches the EntityUtils import from an absolute src/utils/EntityUtils path to a relative ../../../utils/EntityUtils path, consistent with all other imports in the file and fixing a Collate build failure. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[VersionTable.component.tsx] -->|before: absolute path| B["src/utils/EntityUtils"]
    A -->|after: relative path| C["../../../utils/EntityUtils"]
    B -->|resolves in OM build\nbaseUrl: '.'| D[EntityUtils module]
    B -->|fails in Collate build\nOM tree under src/openmetadata-ui/| E[❌ Rollup resolution error]
    C -->|resolves in OM build| D
    C -->|resolves in Collate build| D
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[VersionTable.component.tsx] -->|before: absolute path| B["src/utils/EntityUtils"]
    A -->|after: relative path| C["../../../utils/EntityUtils"]
    B -->|resolves in OM build\nbaseUrl: '.'| D[EntityUtils module]
    B -->|fails in Collate build\nOM tree under src/openmetadata-ui/| E[❌ Rollup resolution error]
    C -->|resolves in OM build| D
    C -->|resolves in Collate build| D
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(ui): use relative import for EntityU..."](https://github.com/open-metadata/openmetadata/commit/8c323b33fc05ec5325cb17ad993ade9b533dd755) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42935708)</sub>

<!-- /greptile_comment -->