### PR TITLE
fix(ui): default schema columns to original order instead of alphabetical

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/Database/SchemaTable/SchemaTable.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Database/SchemaTable/SchemaTable.component.tsx
@@ -126,7 +126,9 @@ const SchemaTable = () => {
   const [testCaseSummary, setTestCaseSummary] = useState<TestSummary>();
   const [expandedRowKeys, setExpandedRowKeys] = useState<string[]>([]);
   const [editColumn, setEditColumn] = useState<Column>();
-  const [sortBy, setSortBy] = useState<'name' | 'ordinalPosition'>('name');
+  const [sortBy, setSortBy] = useState<'name' | 'ordinalPosition'>(
+    'ordinalPosition'
+  );
   const [sortOrder, setSortOrder] = useState<'asc' | 'desc'>('asc');
   const [activeTagFilter, setActiveTagFilter] = useState<{
     tags: string[];

--- a/openmetadata-ui/src/main/resources/ui/src/components/Database/SchemaTable/SchemaTable.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Database/SchemaTable/SchemaTable.test.tsx
@@ -401,7 +401,7 @@ describe('Test EntityTable Component', () => {
         fields: 'tags,customMetrics,extension',
         limit: 50,
         offset: 0,
-        sortBy: 'name',
+        sortBy: 'ordinalPosition',
         sortOrder: 'asc',
       }
     );
@@ -426,7 +426,7 @@ describe('Test EntityTable Component', () => {
         fields: 'tags,customMetrics,extension',
         limit: 50,
         offset: 0,
-        sortBy: 'name',
+        sortBy: 'ordinalPosition',
         sortOrder: 'asc',
       }
     );


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:

Fixes #29573 
<!--
Linking an issue is REQUIRED. Replace <issue-number> with the GitHub issue number this PR addresses
(e.g., `Fixes #12345`). GitHub will auto-link it. If no issue exists, please open one first so the
problem and design can be discussed before review.
-->

<!--
Short blurb explaining:
- What changes did you make?
- Why did you make them?
-->

## Description

The Schema/Columns table on the Table entity page defaulted its sort to **Alphabetical (A→Z)**. This changes the default to **Original Order** (`ordinalPosition`) — the order columns appear in the source table — which is what users expect when first viewing a table's schema.


https://github.com/user-attachments/assets/b57a1cdf-1866-413e-9d69-f8516d4c06ea



### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### High-level design:
<!--
REQUIRED for large PRs (new features, refactors, breaking changes, or anything touching >5 files).
Skip for small bug fixes and trivial changes.

Cover:
- Architecture / approach you took and why
- Key components or files added/changed and how they interact
- Alternatives considered and why you rejected them
- Any migration, backward-compatibility, or rollout concerns
- Diagrams or links to design docs / RFCs if available
-->

N/A — small change. <!-- Or fill in the design above -->

#
### Tests:

#### Use cases covered
<!--
List the user-visible scenarios this PR exercises. Example:
- User with Admin role can create a Glossary Term with a parent term
- Ingestion run for Snowflake correctly extracts row counts for partitioned tables
-->

#### Unit tests
<!--
- [ ] I added unit tests for the new/changed logic.
- Files added/updated:
- Coverage on changed classes (run `mvn jacoco:report` for backend, `yarn test:coverage` for UI,
  `make unit_ingestion` for ingestion). Target is 90% line coverage on changed classes.
- Coverage %: <e.g., 92% on EntityRepository.java>
-->

#### Backend integration tests
<!--
- [ ] I added integration tests in `openmetadata-integration-tests/` for new/changed API endpoints.
- [ ] Not applicable (no backend API changes).
- Files added/updated:
-->

#### Ingestion integration tests
<!--
- [ ] I added/updated ingestion integration tests for connector changes.
- [ ] Not applicable (no ingestion changes).
- Files added/updated:
-->

#### Playwright (UI) tests
<!--
- [ ] I added Playwright E2E tests under `openmetadata-ui/.../ui/playwright/` for UI changes.
- [ ] Not applicable (no UI changes).
- Files added/updated:
-->

#### Manual testing performed
<!--
List the manual test steps you performed before requesting review. Example:
1. Started local stack via `./docker/run_local_docker.sh -m ui -d mysql`
2. Logged in as admin, created entity X, verified Y appears in the UI
3. Triggered ingestion for Snowflake source, confirmed lineage edges in the explore page
-->

#
### UI screen recording / screenshots:
<!--
REQUIRED for any PR that changes the UI. Drag-and-drop a short screen recording (.mov / .mp4 / .gif)
demonstrating the change end-to-end, plus before/after screenshots where relevant.
Mark "Not applicable" if there are no UI changes.
-->

Not applicable. <!-- Or attach recording/screenshots above -->

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.
- [ ] For UI changes: I attached a screen recording and/or screenshots above.
- [ ] I have added tests (unit / integration / Playwright as applicable) and listed them above.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Changes the default column sort for the Schema/Columns table on the Table entity page from alphabetical (`name`) to original source order (`ordinalPosition`), fixing the mismatch between what users see and what they expect when viewing a table's schema for the first time.

- **`SchemaTable.component.tsx`**: `useState` initial value for `sortBy` flipped from `'name'` to `'ordinalPosition'`; no logic, API surface, or rendering changes are affected.
- **`SchemaTable.test.tsx`**: Two API-call assertions updated to expect `sortBy: 'ordinalPosition'` instead of `'name'`, keeping tests consistent with the new default.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — a single-line default state change that restores natural column ordering, with tests updated in lock-step.

The change is a one-line default value swap that makes the sort default match what the backend already supports. Both affected test cases were updated, and the new default (ordinalPosition ascending) is the correct semantic for original order. No other behaviour is touched.

No files require special attention.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-ui/src/main/resources/ui/src/components/Database/SchemaTable/SchemaTable.component.tsx | Default sort changed from 'name' (alphabetical) to 'ordinalPosition' (original order) — one-line fix with no side effects. |
| openmetadata-ui/src/main/resources/ui/src/components/Database/SchemaTable/SchemaTable.test.tsx | Two test assertions updated from sortBy 'name' to 'ordinalPosition', keeping tests aligned with the new default. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[SchemaTable mounts] --> B{sortBy initial state}
    B -- "before: 'name'" --> C["API: sortBy=name, sortOrder=asc\n→ alphabetical A–Z"]
    B -- "after: 'ordinalPosition'" --> D["API: sortBy=ordinalPosition, sortOrder=asc\n→ original source order"]
    C --> E[User sees columns A–Z ❌]
    D --> F[User sees columns in original order ✅]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[SchemaTable mounts] --> B{sortBy initial state}
    B -- "before: 'name'" --> C["API: sortBy=name, sortOrder=asc\n→ alphabetical A–Z"]
    B -- "after: 'ordinalPosition'" --> D["API: sortBy=ordinalPosition, sortOrder=asc\n→ original source order"]
    C --> E[User sees columns A–Z ❌]
    D --> F[User sees columns in original order ✅]
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(ui): default schema columns to origi..."](https://github.com/open-metadata/openmetadata/commit/1bc92ea195cac84b0ea1f9a05ae9decf89c81950) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42939644)</sub>

<!-- /greptile_comment -->