### PR TITLE
fix(ui): stop product tour Explore step from loading real data (pre-mount + tour-aware tree)

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/pages/TourPage/TourPage.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/TourPage/TourPage.component.tsx
@@ -153,21 +153,32 @@ const TourPage = () => {
     };
   }, [updateIsTourOpen]);
 
+  const isExplorePage = currentTourPage === CurrentTourPageType.EXPLORE_PAGE;
+  // Pre-mount Explore (hidden) during the MyData phase so it stays mounted into
+  // the Explore step — react-tour closes a step whose target is missing on
+  // activation, and the redesigned Explore can't mount within its stepWaitTimer.
+  const shouldRenderExplore =
+    currentTourPage === CurrentTourPageType.MY_DATA_PAGE || isExplorePage;
+  const exploreStyle = useMemo(
+    () => ({ display: isExplorePage ? undefined : 'none' }),
+    [isExplorePage]
+  );
+
   const currentPageComponent = useMemo(() => {
-    switch (currentTourPage) {
-      case CurrentTourPageType.MY_DATA_PAGE:
-        return <MyDataPage />;
-
-      case CurrentTourPageType.EXPLORE_PAGE:
-        return <ExplorePageV1Component pageTitle={t('label.explore')} />;
-
-      case CurrentTourPageType.DATASET_PAGE:
-        return <TableDetailsPageV1 />;
-
-      default:
-        return;
-    }
-  }, [currentTourPage]);
+    return (
+      <>
+        {currentTourPage === CurrentTourPageType.MY_DATA_PAGE && <MyDataPage />}
+        {shouldRenderExplore && (
+          <div style={exploreStyle}>
+            <ExplorePageV1Component pageTitle={t('label.explore')} />
+          </div>
+        )}
+        {currentTourPage === CurrentTourPageType.DATASET_PAGE && (
+          <TableDetailsPageV1 />
+        )}
+      </>
+    );
+  }, [currentTourPage, shouldRenderExplore, exploreStyle, t]);
 
   const tourSteps = useMemo(
     () =>


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:

<!--
Linking an issue is REQUIRED. Replace <issue-number> with the GitHub issue number this PR addresses
(e.g., `Fixes #12345`). GitHub will auto-link it. If no issue exists, please open one first so the
problem and design can be discussed before review.
-->

<!--
Short blurb explaining:
- What changes did you make?
- Why did you make them?
-->

## Description

The product tour (`/tour`) broke at the Explore step: after typing `dim_a` and advancing, the tour never highlighted the mocked `dim_address` card and instead rendered **real** backend search results, failing `Tour.spec.ts`.

### Root cause

react-tour (`@deuex-solutions/react-tour`) force-closes a step whose `selector` target is absent the moment the step activates:

```js
var t = e.selector ? document.querySelector(e.selector) : null;
(isNull(t) || isUndefined(t)) && e.actionType !== 'wait' && (ze() /* -> onRequestClose */);
```

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### High-level design:
<!--
REQUIRED for large PRs (new features, refactors, breaking changes, or anything touching >5 files).
Skip for small bug fixes and trivial changes.

Cover:
- Architecture / approach you took and why
- Key components or files added/changed and how they interact
- Alternatives considered and why you rejected them
- Any migration, backward-compatibility, or rollout concerns
- Diagrams or links to design docs / RFCs if available
-->

N/A — small change. <!-- Or fill in the design above -->

#
### Tests:

#### Use cases covered
<!--
List the user-visible scenarios this PR exercises. Example:
- User with Admin role can create a Glossary Term with a parent term
- Ingestion run for Snowflake correctly extracts row counts for partitioned tables
-->

#### Unit tests
<!--
- [ ] I added unit tests for the new/changed logic.
- Files added/updated:
- Coverage on changed classes (run `mvn jacoco:report` for backend, `yarn test:coverage` for UI,
  `make unit_ingestion` for ingestion). Target is 90% line coverage on changed classes.
- Coverage %: <e.g., 92% on EntityRepository.java>
-->

#### Backend integration tests
<!--
- [ ] I added integration tests in `openmetadata-integration-tests/` for new/changed API endpoints.
- [ ] Not applicable (no backend API changes).
- Files added/updated:
-->

#### Ingestion integration tests
<!--
- [ ] I added/updated ingestion integration tests for connector changes.
- [ ] Not applicable (no ingestion changes).
- Files added/updated:
-->

#### Playwright (UI) tests
<!--
- [ ] I added Playwright E2E tests under `openmetadata-ui/.../ui/playwright/` for UI changes.
- [ ] Not applicable (no UI changes).
- Files added/updated:
-->

#### Manual testing performed
<!--
List the manual test steps you performed before requesting review. Example:
1. Started local stack via `./docker/run_local_docker.sh -m ui -d mysql`
2. Logged in as admin, created entity X, verified Y appears in the UI
3. Triggered ingestion for Snowflake source, confirmed lineage edges in the explore page
-->

#
### UI screen recording / screenshots:
<!--
REQUIRED for any PR that changes the UI. Drag-and-drop a short screen recording (.mov / .mp4 / .gif)
demonstrating the change end-to-end, plus before/after screenshots where relevant.
Mark "Not applicable" if there are no UI changes.
-->

Not applicable. <!-- Or attach recording/screenshots above -->

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.
- [ ] For UI changes: I attached a screen recording and/or screenshots above.
- [ ] I have added tests (unit / integration / Playwright as applicable) and listed them above.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes the product tour's Explore step, which was silently closing because `ExplorePageV1Component` hadn't mounted by the time react-tour's selector check fired. The fix pre-mounts the Explore component (hidden via `display: none`) during the `MY_DATA_PAGE` phase so its DOM is already present when the tour advances, and seeds mock data early via a new `useEffect` to prevent real backend calls.

- **Pre-mount strategy**: `ExplorePageV1Component` is rendered with `display: none` during `MY_DATA_PAGE` so react-tour's `document.querySelector` finds its target immediately on step activation.
- **Mock data seeding**: `updateTourMockData` is called on TourPage mount; `ExplorePageV1Component` already guards real API calls behind `if (!isTourOpen)`, so no backend requests fire while hidden.
- **Transition logic**: `shouldRenderExplore` is `true` for `MY_DATA_PAGE` and `EXPLORE_PAGE`, `false` for `DATASET_PAGE`, giving clean mount/unmount boundaries across the three tour phases.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is narrowly scoped to the tour page, real API calls remain blocked by the existing isTourOpen guard in ExplorePageV1Component, and the three-phase mount/unmount transitions are all correct.

ExplorePageV1Component already skips real fetches when isTourOpen is true (confirmed at line 554), so pre-mounting it hidden during MY_DATA_PAGE introduces no backend traffic. Mock data arrives via TourProvider before react-tour activates the Explore step. All three tour-page transition branches produce the correct mount/unmount behaviour.

No files require special attention. The only changed file is TourPage.component.tsx, and its interaction with ExplorePageV1Component's existing tour-awareness is well-aligned.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-ui/src/main/resources/ui/src/pages/TourPage/TourPage.component.tsx | Pre-mounts ExplorePageV1Component during MY_DATA_PAGE (hidden) and seeds mock data on mount; transition logic across all three tour phases is correct and ExplorePageV1 already guards real fetches behind isTourOpen. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(ui): stop product tour Explore step ..."](https://github.com/open-metadata/openmetadata/commit/1b4a0f4274128f10a5fc0be626a0b5b4176acb01) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42949880)</sub>

<!-- /greptile_comment -->