### PR TITLE
feat(contextCenter): sortBy/sortOrder on page hierarchy search

### DIFF
--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/KnowledgePageHierarchyIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/KnowledgePageHierarchyIT.java
@@ -12,6 +12,7 @@
  */
 package org.openmetadata.it.tests;
 
+import static org.awaitility.Awaitility.await;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -19,6 +20,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import jakarta.ws.rs.core.Response;
+import java.time.Duration;
 import java.util.List;
 import java.util.UUID;
 import org.apache.http.client.HttpResponseException;
@@ -55,6 +57,7 @@ public class KnowledgePageHierarchyIT {
 
   private static final String KC_PATH = "v1/contextCenter/pages";
   private static final String KC_HIERARCHY_PATH = KC_PATH + "/hierarchy";
+  private static final String KC_SEARCH_HIERARCHY_PATH = KC_PATH + "/search/hierarchy";
   private static final String PARENT_FIELD = "parent";
   private static final String ORGANIZATION_NAME = "Organization";
 
@@ -106,6 +109,72 @@ public class KnowledgePageHierarchyIT {
 
   private boolean containsTopLevelId(ResultList<PageHierarchy> hierarchy, UUID id) {
     return hierarchy.getData().stream().anyMatch(node -> id.equals(node.getId()));
+  }
+
+  private ResultList<PageHierarchy> listSearchHierarchy(RestClient rest, String query) {
+    String path = KC_SEARCH_HIERARCHY_PATH + query;
+    try (Response response = rest.rawGet(path)) {
+      assertEquals(
+          200, response.getStatus(), "Search hierarchy call failed: " + response.getStatus());
+      String body = response.readEntity(String.class);
+      return JsonUtils.readValue(body, new TypeReference<ResultList<PageHierarchy>>() {});
+    }
+  }
+
+  private int indexOfId(List<PageHierarchy> nodes, UUID id) {
+    for (int i = 0; i < nodes.size(); i++) {
+      if (id.equals(nodes.get(i).getId())) {
+        return i;
+      }
+    }
+    return -1;
+  }
+
+  @Test
+  void testSearchHierarchyRejectsInvalidSortBy(TestNamespace ns) {
+    RestClient rest = RestClient.admin();
+    try (Response response = rest.rawGet(KC_SEARCH_HIERARCHY_PATH + "?sortBy=notAField")) {
+      assertEquals(400, response.getStatus(), response.readEntity(String.class));
+    }
+  }
+
+  @Test
+  void testSearchHierarchyRejectsInvalidSortOrder(TestNamespace ns) {
+    RestClient rest = RestClient.admin();
+    try (Response response =
+        rest.rawGet(KC_SEARCH_HIERARCHY_PATH + "?sortBy=name&sortOrder=sideways")) {
+      assertEquals(400, response.getStatus(), response.readEntity(String.class));
+    }
+  }
+
+  @Test
+  void testSearchHierarchySortsByName(TestNamespace ns) throws HttpResponseException {
+    RestClient rest = RestClient.admin();
+    Page pageA = createPage(rest, buildCreateRequest(ns.prefix("aaa-sort"), null));
+    Page pageM = createPage(rest, buildCreateRequest(ns.prefix("mmm-sort"), null));
+    Page pageZ = createPage(rest, buildCreateRequest(ns.prefix("zzz-sort"), null));
+
+    await()
+        .atMost(Duration.ofSeconds(30))
+        .pollInterval(Duration.ofSeconds(1))
+        .untilAsserted(
+            () -> {
+              List<PageHierarchy> asc =
+                  listSearchHierarchy(rest, "?limit=1000000&sortBy=name&sortOrder=asc").getData();
+              int a = indexOfId(asc, pageA.getId());
+              int m = indexOfId(asc, pageM.getId());
+              int z = indexOfId(asc, pageZ.getId());
+              assertTrue(
+                  a >= 0 && m >= 0 && z >= 0, "All created pages must be indexed and returned");
+              assertTrue(a < m && m < z, "Ascending name sort must order aaa < mmm < zzz");
+            });
+
+    List<PageHierarchy> desc =
+        listSearchHierarchy(rest, "?limit=1000000&sortBy=name&sortOrder=desc").getData();
+    int a = indexOfId(desc, pageA.getId());
+    int m = indexOfId(desc, pageM.getId());
+    int z = indexOfId(desc, pageZ.getId());
+    assertTrue(z < m && m < a, "Descending name sort must order zzz < mmm < aaa");
   }
 
   @Test

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/KnowledgePageRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/KnowledgePageRepository.java
@@ -67,6 +67,7 @@ import org.openmetadata.service.llm.LLMClientHolder;
 import org.openmetadata.service.resources.feeds.MessageParser;
 import org.openmetadata.service.resources.knowledge.KnowledgePageResource;
 import org.openmetadata.service.search.PropagationDescriptor;
+import org.openmetadata.service.search.SearchSortFilter;
 import org.openmetadata.service.search.vector.PageBodyTextContributor;
 import org.openmetadata.service.security.AuthorizationException;
 import org.openmetadata.service.util.AISettingsUtil;
@@ -428,19 +429,19 @@ public class KnowledgePageRepository extends EntityRepository<Page> {
   }
 
   public ResultList<PageHierarchy> getHierarchyWithSearch(
-      String parent, PageType pageType, int offset, int limit) {
+      String parent, PageType pageType, SearchSortFilter sortFilter, int offset, int limit) {
     String pageTypeValue = pageType != null ? pageType.value() : null;
     return searchRepository
         .getSearchClient()
-        .listPageHierarchy(parent, pageTypeValue, offset, limit);
+        .listPageHierarchy(parent, pageTypeValue, sortFilter, offset, limit);
   }
 
   public ResultList<PageHierarchy> getHierarchyWithSearchForActivePage(
-      String activeFqn, PageType pageType, int offset, int limit) {
+      String activeFqn, PageType pageType, SearchSortFilter sortFilter, int offset, int limit) {
     String pageTypeValue = pageType != null ? pageType.value() : null;
     return searchRepository
         .getSearchClient()
-        .listPageHierarchyForActivePage(activeFqn, pageTypeValue, offset, limit);
+        .listPageHierarchyForActivePage(activeFqn, pageTypeValue, sortFilter, offset, limit);
   }
 
   public List<PageHierarchy> listHierarchy(ListFilter filter, int limit) {

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/knowledge/KnowledgePageResource.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/knowledge/KnowledgePageResource.java
@@ -398,13 +398,37 @@ public class KnowledgePageResource extends EntityResource<Page, KnowledgePageRep
               description =
                   "FQN of the active page to show the active page correctly in  the hierarchy , while showing other root nodes at level 1.")
           @QueryParam("activeFqn")
-          String activeFqn) {
+          String activeFqn,
+      @Parameter(
+              description = "Field to sort by. Supported: name, createdAt, updatedAt.",
+              schema =
+                  @Schema(
+                      type = "string",
+                      allowableValues = {"name", "createdAt", "updatedAt"}))
+          @QueryParam("sortBy")
+          String sortBy,
+      @Parameter(
+              description = "Sort order. Supported: asc, desc. Defaults to desc.",
+              schema =
+                  @Schema(
+                      type = "string",
+                      allowableValues = {"asc", "desc"}))
+          @QueryParam("sortOrder")
+          String sortOrder) {
+    SearchSortFilter sortFilter = buildHierarchySortFilter(sortBy, sortOrder);
     if (!CommonUtil.nullOrEmpty(activeFqn)) {
       return repository.getHierarchyWithSearchForActivePage(
-          activeFqn, knowledgePageType, offset, limit);
+          activeFqn, knowledgePageType, sortFilter, offset, limit);
     } else {
-      return repository.getHierarchyWithSearch(parent, knowledgePageType, offset, limit);
+      return repository.getHierarchyWithSearch(
+          parent, knowledgePageType, sortFilter, offset, limit);
     }
+  }
+
+  private static SearchSortFilter buildHierarchySortFilter(String sortBy, String sortOrder) {
+    String effectiveSortBy = CommonUtil.nullOrEmpty(sortBy) ? "updatedAt" : sortBy;
+    return new SearchSortFilter(
+        resolveSortField(effectiveSortBy), resolveSortOrder(sortOrder), null, null);
   }
 
   @GET

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/SearchClient.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/SearchClient.java
@@ -786,7 +786,8 @@ public interface SearchClient
    Used for listing knowledge page hierarchy for a given parent and page type, used in Elastic/Open SearchClientExtension
   */
   @SuppressWarnings("unused")
-  default ResultList listPageHierarchy(String parent, String pageType, int offset, int limit) {
+  default ResultList listPageHierarchy(
+      String parent, String pageType, SearchSortFilter sortFilter, int offset, int limit) {
     throw new CustomExceptionMessage(
         Response.Status.NOT_IMPLEMENTED, NOT_IMPLEMENTED_ERROR_TYPE, NOT_IMPLEMENTED_METHOD);
   }
@@ -796,7 +797,7 @@ public interface SearchClient
   */
   @SuppressWarnings("unused")
   default ResultList listPageHierarchyForActivePage(
-      String activeFqn, String pageType, int offset, int limit) {
+      String activeFqn, String pageType, SearchSortFilter sortFilter, int offset, int limit) {
     throw new CustomExceptionMessage(
         Response.Status.NOT_IMPLEMENTED, NOT_IMPLEMENTED_ERROR_TYPE, NOT_IMPLEMENTED_METHOD);
   }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/elasticsearch/ElasticSearchClient.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/elasticsearch/ElasticSearchClient.java
@@ -1129,23 +1129,70 @@ public class ElasticSearchClient implements SearchClient {
   @Override
   @lombok.SneakyThrows
   public org.openmetadata.schema.utils.ResultList<org.openmetadata.schema.entity.data.PageHierarchy>
-      listPageHierarchy(String parentFqn, String pageType, int offset, int limit) {
-    return getPageHierarchyFromSearch(parentFqn, pageType, offset, limit);
+      listPageHierarchy(
+          String parentFqn,
+          String pageType,
+          org.openmetadata.service.search.SearchSortFilter sortFilter,
+          int offset,
+          int limit) {
+    return getPageHierarchyFromSearch(parentFqn, pageType, sortFilter, offset, limit);
   }
 
   @Override
   @lombok.SneakyThrows
   public org.openmetadata.schema.utils.ResultList<org.openmetadata.schema.entity.data.PageHierarchy>
-      listPageHierarchyForActivePage(String activeFqn, String pageType, int offset, int limit) {
-    return getPageHierarchyFromSearchForActivePage(activeFqn, pageType, offset, limit);
+      listPageHierarchyForActivePage(
+          String activeFqn,
+          String pageType,
+          org.openmetadata.service.search.SearchSortFilter sortFilter,
+          int offset,
+          int limit) {
+    return getPageHierarchyFromSearchForActivePage(activeFqn, pageType, sortFilter, offset, limit);
+  }
+
+  private java.util.List<es.co.elastic.clients.elasticsearch._types.SortOptions>
+      buildPageHierarchySortOptions(org.openmetadata.service.search.SearchSortFilter sortFilter) {
+    java.util.List<es.co.elastic.clients.elasticsearch._types.SortOptions> sortOptions =
+        new java.util.ArrayList<>();
+    if (sortFilter != null
+        && sortFilter.getSortField() != null
+        && !"fullyQualifiedName".equals(sortFilter.getSortField())) {
+      String field = sortFilter.getSortField();
+      es.co.elastic.clients.elasticsearch._types.SortOrder order =
+          "desc".equalsIgnoreCase(sortFilter.getSortType())
+              ? es.co.elastic.clients.elasticsearch._types.SortOrder.Desc
+              : es.co.elastic.clients.elasticsearch._types.SortOrder.Asc;
+      sortOptions.add(
+          es.co.elastic.clients.elasticsearch._types.SortOptions.of(
+              so -> so.field(f -> f.field(field).order(order))));
+    }
+    // Always append a stable tiebreaker on fullyQualifiedName (keyword, unique per page) so
+    // from/size pagination cannot miss/duplicate hits when the primary sort field is non-unique.
+    // _id cannot be used as a sort field on ES 9.x / OpenSearch 3.x without setting
+    // indices.id_field_data.enabled=true at the cluster level.
+    sortOptions.add(
+        es.co.elastic.clients.elasticsearch._types.SortOptions.of(
+            so ->
+                so.field(
+                    f ->
+                        f.field("fullyQualifiedName")
+                            .order(es.co.elastic.clients.elasticsearch._types.SortOrder.Asc))));
+    return sortOptions;
   }
 
   private org.openmetadata.schema.utils.ResultList<
           org.openmetadata.schema.entity.data.PageHierarchy>
-      getPageHierarchyFromSearch(String parentFqn, String pageType, int offset, int limit)
+      getPageHierarchyFromSearch(
+          String parentFqn,
+          String pageType,
+          org.openmetadata.service.search.SearchSortFilter sortFilter,
+          int offset,
+          int limit)
           throws java.io.IOException {
     es.co.elastic.clients.elasticsearch._types.query_dsl.Query boolQuery =
         buildPageHierarchyBoolQuery(parentFqn, pageType);
+    java.util.List<es.co.elastic.clients.elasticsearch._types.SortOptions> sortOptions =
+        buildPageHierarchySortOptions(sortFilter);
 
     es.co.elastic.clients.elasticsearch.core.SearchRequest searchRequest =
         es.co.elastic.clients.elasticsearch.core.SearchRequest.of(
@@ -1156,19 +1203,7 @@ public class ElasticSearchClient implements SearchClient {
                                 org.openmetadata.service.jdbi3.KnowledgePageRepository
                                     .KNOWLEDGE_PAGE_TERM_SEARCH_INDEX))
                     .query(boolQuery)
-                    // Stable sort so from/size pagination cannot miss/duplicate hits.
-                    // fullyQualifiedName is a keyword field with doc_values and is unique per
-                    // page (name is unique within a parent's children), so no tiebreaker is
-                    // needed. _id cannot be used as a sort field on ES 9.x / OpenSearch 3.x
-                    // without setting indices.id_field_data.enabled=true at the cluster level.
-                    .sort(
-                        sort ->
-                            sort.field(
-                                f ->
-                                    f.field("fullyQualifiedName")
-                                        .order(
-                                            es.co.elastic.clients.elasticsearch._types.SortOrder
-                                                .Asc)))
+                    .sort(sortOptions)
                     .from(offset)
                     .size(limit));
 
@@ -1189,9 +1224,16 @@ public class ElasticSearchClient implements SearchClient {
   private org.openmetadata.schema.utils.ResultList<
           org.openmetadata.schema.entity.data.PageHierarchy>
       getPageHierarchyFromSearchForActivePage(
-          String activeFqn, String pageType, int offset, int limit) throws java.io.IOException {
+          String activeFqn,
+          String pageType,
+          org.openmetadata.service.search.SearchSortFilter sortFilter,
+          int offset,
+          int limit)
+          throws java.io.IOException {
     es.co.elastic.clients.elasticsearch._types.query_dsl.Query boolQuery =
         buildPageHierarchyBoolQueryForActivePage(activeFqn, pageType);
+    java.util.List<es.co.elastic.clients.elasticsearch._types.SortOptions> sortOptions =
+        buildPageHierarchySortOptions(sortFilter);
 
     es.co.elastic.clients.elasticsearch.core.SearchRequest searchRequest =
         es.co.elastic.clients.elasticsearch.core.SearchRequest.of(
@@ -1202,15 +1244,7 @@ public class ElasticSearchClient implements SearchClient {
                                 org.openmetadata.service.jdbi3.KnowledgePageRepository
                                     .KNOWLEDGE_PAGE_TERM_SEARCH_INDEX))
                     .query(boolQuery)
-                    // Stable sort by fqn (keyword, unique per page). See note above on _id.
-                    .sort(
-                        sort ->
-                            sort.field(
-                                f ->
-                                    f.field("fullyQualifiedName")
-                                        .order(
-                                            es.co.elastic.clients.elasticsearch._types.SortOrder
-                                                .Asc)))
+                    .sort(sortOptions)
                     .from(offset)
                     .size(limit));
 

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/opensearch/OpenSearchClient.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/opensearch/OpenSearchClient.java
@@ -1154,23 +1154,70 @@ public class OpenSearchClient implements SearchClient {
   @Override
   @lombok.SneakyThrows
   public org.openmetadata.schema.utils.ResultList<org.openmetadata.schema.entity.data.PageHierarchy>
-      listPageHierarchy(String parentFqn, String pageType, int offset, int limit) {
-    return getPageHierarchyFromSearch(parentFqn, pageType, offset, limit);
+      listPageHierarchy(
+          String parentFqn,
+          String pageType,
+          org.openmetadata.service.search.SearchSortFilter sortFilter,
+          int offset,
+          int limit) {
+    return getPageHierarchyFromSearch(parentFqn, pageType, sortFilter, offset, limit);
   }
 
   @Override
   @lombok.SneakyThrows
   public org.openmetadata.schema.utils.ResultList<org.openmetadata.schema.entity.data.PageHierarchy>
-      listPageHierarchyForActivePage(String activeFqn, String pageType, int offset, int limit) {
-    return getPageHierarchyFromSearchForActivePage(activeFqn, pageType, offset, limit);
+      listPageHierarchyForActivePage(
+          String activeFqn,
+          String pageType,
+          org.openmetadata.service.search.SearchSortFilter sortFilter,
+          int offset,
+          int limit) {
+    return getPageHierarchyFromSearchForActivePage(activeFqn, pageType, sortFilter, offset, limit);
+  }
+
+  private java.util.List<os.org.opensearch.client.opensearch._types.SortOptions>
+      buildPageHierarchySortOptions(org.openmetadata.service.search.SearchSortFilter sortFilter) {
+    java.util.List<os.org.opensearch.client.opensearch._types.SortOptions> sortOptions =
+        new java.util.ArrayList<>();
+    if (sortFilter != null
+        && sortFilter.getSortField() != null
+        && !"fullyQualifiedName".equals(sortFilter.getSortField())) {
+      String field = sortFilter.getSortField();
+      os.org.opensearch.client.opensearch._types.SortOrder order =
+          "desc".equalsIgnoreCase(sortFilter.getSortType())
+              ? os.org.opensearch.client.opensearch._types.SortOrder.Desc
+              : os.org.opensearch.client.opensearch._types.SortOrder.Asc;
+      sortOptions.add(
+          os.org.opensearch.client.opensearch._types.SortOptions.of(
+              so -> so.field(f -> f.field(field).order(order))));
+    }
+    // Always append a stable tiebreaker on fullyQualifiedName (keyword, unique per page) so
+    // from/size pagination cannot miss/duplicate hits when the primary sort field is non-unique.
+    // _id cannot be used as a sort field on ES 9.x / OpenSearch 3.x without setting
+    // indices.id_field_data.enabled=true at the cluster level.
+    sortOptions.add(
+        os.org.opensearch.client.opensearch._types.SortOptions.of(
+            so ->
+                so.field(
+                    f ->
+                        f.field("fullyQualifiedName")
+                            .order(os.org.opensearch.client.opensearch._types.SortOrder.Asc))));
+    return sortOptions;
   }
 
   private org.openmetadata.schema.utils.ResultList<
           org.openmetadata.schema.entity.data.PageHierarchy>
-      getPageHierarchyFromSearch(String parentFqn, String pageType, int offset, int limit)
+      getPageHierarchyFromSearch(
+          String parentFqn,
+          String pageType,
+          org.openmetadata.service.search.SearchSortFilter sortFilter,
+          int offset,
+          int limit)
           throws java.io.IOException {
     os.org.opensearch.client.opensearch._types.query_dsl.Query boolQuery =
         buildPageHierarchyBoolQuery(parentFqn, pageType);
+    java.util.List<os.org.opensearch.client.opensearch._types.SortOptions> sortOptions =
+        buildPageHierarchySortOptions(sortFilter);
 
     os.org.opensearch.client.opensearch.core.SearchRequest searchRequest =
         os.org.opensearch.client.opensearch.core.SearchRequest.of(
@@ -1181,19 +1228,7 @@ public class OpenSearchClient implements SearchClient {
                                 org.openmetadata.service.jdbi3.KnowledgePageRepository
                                     .KNOWLEDGE_PAGE_TERM_SEARCH_INDEX))
                     .query(boolQuery)
-                    // Stable sort so from/size pagination cannot miss/duplicate hits.
-                    // fullyQualifiedName is a keyword field with doc_values and is unique per
-                    // page (name is unique within a parent's children), so no tiebreaker is
-                    // needed. _id cannot be used as a sort field on ES 9.x / OpenSearch 3.x
-                    // without setting indices.id_field_data.enabled=true at the cluster level.
-                    .sort(
-                        sort ->
-                            sort.field(
-                                f ->
-                                    f.field("fullyQualifiedName")
-                                        .order(
-                                            os.org.opensearch.client.opensearch._types.SortOrder
-                                                .Asc)))
+                    .sort(sortOptions)
                     .from(offset)
                     .size(limit));
 
@@ -1215,9 +1250,16 @@ public class OpenSearchClient implements SearchClient {
   private org.openmetadata.schema.utils.ResultList<
           org.openmetadata.schema.entity.data.PageHierarchy>
       getPageHierarchyFromSearchForActivePage(
-          String activeFqn, String pageType, int offset, int limit) throws java.io.IOException {
+          String activeFqn,
+          String pageType,
+          org.openmetadata.service.search.SearchSortFilter sortFilter,
+          int offset,
+          int limit)
+          throws java.io.IOException {
     os.org.opensearch.client.opensearch._types.query_dsl.Query boolQuery =
         buildPageHierarchyBoolQueryForActivePage(activeFqn, pageType);
+    java.util.List<os.org.opensearch.client.opensearch._types.SortOptions> sortOptions =
+        buildPageHierarchySortOptions(sortFilter);
 
     os.org.opensearch.client.opensearch.core.SearchRequest searchRequest =
         os.org.opensearch.client.opensearch.core.SearchRequest.of(
@@ -1228,15 +1270,7 @@ public class OpenSearchClient implements SearchClient {
                                 org.openmetadata.service.jdbi3.KnowledgePageRepository
                                     .KNOWLEDGE_PAGE_TERM_SEARCH_INDEX))
                     .query(boolQuery)
-                    // Stable sort by fqn (keyword, unique per page). See note above on _id.
-                    .sort(
-                        sort ->
-                            sort.field(
-                                f ->
-                                    f.field("fullyQualifiedName")
-                                        .order(
-                                            os.org.opensearch.client.opensearch._types.SortOrder
-                                                .Asc)))
+                    .sort(sortOptions)
                     .from(offset)
                     .size(limit));
 


### PR DESCRIPTION
Issue: open-metadata/openmetadata-collate#4781

## Companion / related PRs

- **open-metadata/openmetadata-collate#4932** — applies the same sort in the Collate ES/OpenSearch client extensions (depends on this PR).
- **#29875** — Context Center archive page current-user filter for drive files (independent OSS change, split out of this PR).

## What

`GET /v1/contextCenter/pages/search/hierarchy` now accepts:

- `sortBy` — one of `name`, `createdAt`, `updatedAt`
- `sortOrder` — `asc` | `desc`

**Default is `updatedAt` `desc`**, so a newly created article or quick link surfaces at the top of the left-tree hierarchy. `fullyQualifiedName` is always appended as a secondary sort key, keeping `from`/`size` pagination stable when the primary field (e.g. `updatedAt`) is non-unique. Invalid `sortBy`/`sortOrder` values return `400`.

The sort is threaded through `KnowledgePageRepository` → `SearchClient` → the Elastic/OpenSearch hierarchy queries (both the parent-scoped and active-page paths).

## Tests

`KnowledgePageHierarchyIT`: ascending/descending name ordering via `/search/hierarchy`; `400` on invalid `sortBy` and `sortOrder`.

## Notes

Not addressed here (flagged as "to be discussed" in the design review): how a **child** page update should reflect in the main hierarchy ordering.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR wires `sortBy`/`sortOrder` query parameters into the `/v1/contextCenter/pages/search/hierarchy` endpoint, defaulting to `updatedAt desc` so newly created articles surface at the top of the left-tree. It also threads a stable `fullyQualifiedName` tiebreaker through both ES and OS clients to keep `from`/`size` pagination deterministic.

- **Sort parameter plumbing** — `KnowledgePageResource` validates the sort params (`IllegalArgumentException` → 400 for unknown values), builds a `SearchSortFilter`, and forwards it through `KnowledgePageRepository` → `SearchClient` → `ElasticSearchClient`/`OpenSearchClient`, where `buildPageHierarchySortOptions` produces the final sort list.
- **`fullyQualifiedName` tiebreaker preserved** — both hierarchy query paths always append `fullyQualifiedName asc` as a secondary sort after the user-requested primary, keeping pagination stable when the primary field (e.g. `updatedAt`) is non-unique.
- **Integration tests** — cover 400 rejection for invalid `sortBy`/`sortOrder` and ascending name ordering via an `await`-backed retry loop.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The sort plumbing is clean and the tiebreaker logic is correct, but the documented contract for createdAt sort is violated — callers requesting sortBy=createdAt receive updatedAt ordering instead, which is already flagged on the PR.

The sort validation, default handling, and ES/OS client integration are all consistent and well-tested. The one outstanding concern — createdAt mapping silently to the updatedAt field — means the API advertises a sort option that does not behave as documented, and this has not been addressed in the current diff.

KnowledgePageResource.java — the resolveSortField switch where createdAt and updatedAt resolve to the same ES field.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-service/src/main/java/org/openmetadata/service/resources/knowledge/KnowledgePageResource.java | Adds sortBy/sortOrder params to the /search/hierarchy endpoint; resolveSortField maps createdAt and updatedAt to the same ES field, so the two values are indistinguishable (already flagged in a previous comment). Validation path correctly throws IllegalArgumentException to 400 for unrecognised values. |
| openmetadata-service/src/main/java/org/openmetadata/service/search/elasticsearch/ElasticSearchClient.java | New buildPageHierarchySortOptions helper produces a primary sort from the provided SearchSortFilter and always appends fullyQualifiedName asc as a stable tiebreaker; threaded into both getPageHierarchyFromSearch and getPageHierarchyFromSearchForActivePage. |
| openmetadata-service/src/main/java/org/openmetadata/service/search/opensearch/OpenSearchClient.java | Mirror of ElasticSearchClient changes: identical buildPageHierarchySortOptions logic using OpenSearch client types; both hierarchy query paths updated consistently. |
| openmetadata-service/src/main/java/org/openmetadata/service/search/SearchClient.java | Interface default method signatures for listPageHierarchy and listPageHierarchyForActivePage updated to accept SearchSortFilter; Collate extension implementations are covered by the companion PR. |
| openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/KnowledgePageRepository.java | Pass-through change only: SearchSortFilter forwarded to the search client on both hierarchy query paths. |
| openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/KnowledgePageHierarchyIT.java | Three new tests cover invalid sortBy, invalid sortOrder, and ascending name sort with await; the descending assertion runs outside the retry window (pre-existing review thread). |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Client
    participant Resource as KnowledgePageResource
    participant Repo as KnowledgePageRepository
    participant SC as SearchClient
    participant ES as ElasticSearch/OpenSearch

    Client->>Resource: "GET /search/hierarchy?sortBy=name&sortOrder=asc"
    Resource->>Resource: buildHierarchySortFilter(sortBy, sortOrder)
    Note over Resource: resolveSortField returns name.keyword<br/>resolveSortOrder returns asc<br/>SearchSortFilter created
    Resource->>Repo: getHierarchyWithSearch(parent, pageType, sortFilter, offset, limit)
    Repo->>SC: listPageHierarchy(parent, pageType, sortFilter, offset, limit)
    SC->>ES: buildPageHierarchySortOptions(sortFilter)
    Note over ES: Primary sort: name.keyword ASC<br/>Tiebreaker: fullyQualifiedName ASC
    ES-->>SC: ResultList of PageHierarchy
    SC-->>Repo: ResultList of PageHierarchy
    Repo-->>Resource: ResultList of PageHierarchy
    Resource-->>Client: 200 OK sorted hierarchy
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Client
    participant Resource as KnowledgePageResource
    participant Repo as KnowledgePageRepository
    participant SC as SearchClient
    participant ES as ElasticSearch/OpenSearch

    Client->>Resource: "GET /search/hierarchy?sortBy=name&sortOrder=asc"
    Resource->>Resource: buildHierarchySortFilter(sortBy, sortOrder)
    Note over Resource: resolveSortField returns name.keyword<br/>resolveSortOrder returns asc<br/>SearchSortFilter created
    Resource->>Repo: getHierarchyWithSearch(parent, pageType, sortFilter, offset, limit)
    Repo->>SC: listPageHierarchy(parent, pageType, sortFilter, offset, limit)
    SC->>ES: buildPageHierarchySortOptions(sortFilter)
    Note over ES: Primary sort: name.keyword ASC<br/>Tiebreaker: fullyQualifiedName ASC
    ES-->>SC: ResultList of PageHierarchy
    SC-->>Repo: ResultList of PageHierarchy
    Repo-->>Resource: ResultList of PageHierarchy
    Resource-->>Client: 200 OK sorted hierarchy
```

</a>
</details>

<sub>Reviews (2): Last reviewed commit: ["feat(contextCenter): sortBy/sortOrder on..."](https://github.com/open-metadata/openmetadata/commit/390f53196ee20958397b5c0aa490b5d1e7cce070) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42966137)</sub>

<!-- /greptile_comment -->
