### PR TITLE
feat(contextCenter): filter drive files by updatedBy (archiver)

### DIFF
--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/drive/ContextFileIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/drive/ContextFileIT.java
@@ -2,6 +2,7 @@ package org.openmetadata.it.drive;
 
 import static org.awaitility.Awaitility.await;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -220,6 +221,50 @@ class ContextFileIT {
             Response.Status.BAD_REQUEST.getStatusCode(), orderByResponse.getStatus(), body);
         assertTrue(body.contains("Invalid cursor for orderBy pagination"));
       }
+    }
+  }
+
+  @Test
+  void testListArchivedFilesFilteredByUpdatedBy(TestNamespace ns) throws HttpResponseException {
+    RestClient adminRest = RestClient.admin();
+
+    ContextFile file =
+        createFile(
+            adminRest,
+            new CreateContextFile()
+                .withName(ns.prefix("archived"))
+                .withProcessingStatus(ProcessingStatus.Uploaded));
+    // Archiving is a soft-delete; the archiver is recorded in updatedBy (admin here, who deletes).
+    adminRest.delete(FILE_PATH, file.getId());
+    String archiver = getFileIncludeAll(adminRest, file.getId()).getUpdatedBy();
+
+    // Scoped to the archiver: the archived file is returned.
+    List<String> byArchiver =
+        listFileIds(adminRest, FILE_PATH + "?include=deleted&limit=1000&updatedBy=" + archiver);
+    assertTrue(
+        byArchiver.contains(file.getId().toString()),
+        "updatedBy filter must include files archived by that user");
+
+    // Scoped to a different user: the archived file is excluded.
+    List<String> byOther =
+        listFileIds(
+            adminRest, FILE_PATH + "?include=deleted&limit=1000&updatedBy=" + ns.prefix("nobody"));
+    assertFalse(
+        byOther.contains(file.getId().toString()),
+        "updatedBy filter must exclude files archived by a different user");
+
+    // Without the filter the archived file is still listed (proves the filter, not the delete,
+    // scopes).
+    List<String> unfiltered = listFileIds(adminRest, FILE_PATH + "?include=deleted&limit=1000");
+    assertTrue(
+        unfiltered.contains(file.getId().toString()),
+        "Unfiltered archive list must still contain the archived file");
+  }
+
+  private ContextFile getFileIncludeAll(RestClient rest, UUID id) {
+    try (Response response = rest.rawGet(FILE_PATH + "/" + id + "?include=all")) {
+      assertEquals(200, response.getStatus());
+      return JsonUtils.readValue(response.readEntity(String.class), ContextFile.class);
     }
   }
 

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/ListFilter.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/ListFilter.java
@@ -66,6 +66,7 @@ public class ListFilter extends Filter<ListFilter> {
     conditions.add(getFileTypeCondition(tableName));
     conditions.add(getAssignee());
     conditions.add(getCreatedByCondition());
+    conditions.add(getUpdatedByCondition());
     conditions.add(getAboutEntityCondition());
     conditions.add(getMentionedUserCondition());
     conditions.add(getEventSubscriptionAlertType());
@@ -312,6 +313,21 @@ public class ListFilter extends Filter<ListFilter> {
             + "AND u.nameHash IN (%s) "
             + "AND er.relation = %d))",
         inCondition, Relationship.CREATED.ordinal());
+  }
+
+  /**
+   * Filter by the user recorded in the entity's {@code updatedBy} column (the last writer). For a
+   * soft-deleted entity this is the user who archived it, since an archived entity cannot be edited.
+   * Matches the generated {@code updatedBy} column directly (plain username, comma-separated list
+   * supported).
+   */
+  private String getUpdatedByCondition() {
+    String updatedBy = queryParams.get("updatedBy");
+    if (nullOrEmpty(updatedBy)) {
+      return "";
+    }
+    String inCondition = buildIndexedBindParams("updatedBy", updatedBy);
+    return String.format("updatedBy IN (%s)", inCondition);
   }
 
   private String getWorkflowDefinitionIdCondition() {

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/drive/ContextFileResource.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/drive/ContextFileResource.java
@@ -175,10 +175,20 @@ public class ContextFileResource extends EntityResource<ContextFile, ContextFile
           @QueryParam("orderBy")
           String orderBy,
       @Parameter(description = "Filter files by folder ID.") @QueryParam("folderId")
-          String folderId) {
+          String folderId,
+      @Parameter(
+              description =
+                  "Filter files by the user who last updated them (their username). Combine with "
+                      + "include=deleted to scope the archive page to files archived by that user - "
+                      + "an archived file cannot be edited, so updatedBy stays the user who archived it.")
+          @QueryParam("updatedBy")
+          String updatedBy) {
     ListFilter filter = new ListFilter(include);
     if (folderId != null && !folderId.isBlank()) {
       filter.addQueryParam("folderId", folderId);
+    }
+    if (updatedBy != null && !updatedBy.isBlank()) {
+      filter.addQueryParam("updatedBy", updatedBy);
     }
     if (orderBy == null || orderBy.isBlank()) {
       return super.listInternal(


### PR DESCRIPTION
Issue: open-metadata/openmetadata-collate#4781

## What

`GET /v1/contextCenter/drive/files` now accepts an `updatedBy` query param (a username), backed by a new `updatedBy` condition in `ListFilter`. Combined with `include=deleted`, it scopes the archive listing to files **archived by** that user.

**Why `updatedBy`, not `createdBy`:** archiving a document is a soft-delete, so the person who archived it is recorded in `updatedBy`. An archived file can't be edited, so `updatedBy` stays pinned to whoever archived it. `createdBy` would wrongly match the original author even when someone else archived the file.

`updatedBy` is a plain username string (`json ->> 'updatedBy'`, a generated column on the entity table), so the filter matches it directly — no relationship join or hashing — and applies on both the cursor list path (`listInternal`) and the `orderBy` path (`listByUpdatedAt`).

## Tests

`ContextFileIT`: after archiving a file, the `updatedBy` filter (using the archiver captured post-delete) includes it, a different user excludes it, and the unfiltered `include=deleted` list still returns it.

## Context

Split out from #29871 (Context Center hierarchy `sortBy`/`sortOrder`) — independent OSS work, no downstream Collate coupling.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds an `updatedBy` query parameter to `GET /v1/contextCenter/drive/files`, allowing the archive page to scope results to files archived by a specific user. The filter is implemented as a direct column match on the `updatedBy` field (avoiding the relationship-table lookup used by `createdBy`), and applies on both the cursor list path and the `orderBy` path.

- **`ListFilter.getUpdatedByCondition()`** — new method emitting a parameterised `updatedBy IN (…)` predicate, registered in the global `getCondition()` list; it is a no-op for all entity types that don't explicitly populate the `updatedBy` query param.
- **`ContextFileResource.list()`** — new `updatedBy` `@QueryParam` forwarded to `ListFilter`; guard (`!= null && !isBlank`) is consistent with the existing `folderId` guard.
- **`ContextFileIT.testListArchivedFilesFilteredByUpdatedBy`** — integration test covering include/exclude and an unfiltered control check to confirm the filter (not the soft-delete flag) drives the scoping.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge; the change is a straightforward additive filter on a direct entity column with parameterised binding and targeted integration test coverage.

The filter uses JDBI named bind parameters throughout, so there is no SQL injection risk. The updatedBy column is a standard field present on all entity tables, and the condition is gated on an explicit addQueryParam call in the resource — making it a no-op for every other entity type. The only finding is a mismatch between the PR title/description (which say createdBy) and the actual parameter (updatedBy), which has no impact on runtime behaviour.

No files require special attention; all three changed files are straightforward.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-service/src/main/java/org/openmetadata/service/resources/drive/ContextFileResource.java | Adds updatedBy query parameter to the list endpoint and passes it to ListFilter; filter is applied on both the cursor (listInternal) and orderBy (listByUpdatedAt) code paths. |
| openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/ListFilter.java | New getUpdatedByCondition() generates a parameterised updatedBy IN predicate directly against the entity table column, registered in the global getCondition() list; safe because it only fires when the queryParam key is present. |
| openmetadata-integration-tests/src/test/java/org/openmetadata/it/drive/ContextFileIT.java | Adds testListArchivedFilesFilteredByUpdatedBy covering include/exclude behaviour and a control check that unfiltered archive still returns the file. |

</details>

<sub>Reviews (3): Last reviewed commit: ["feat(contextCenter): filter drive files ..."](https://github.com/open-metadata/openmetadata/commit/b902b856f825f23288f107e90f65ca1e9b831171) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42974001)</sub>

<!-- /greptile_comment -->