### PR TITLE
Fixes #29873: refactor(ingestion): migrate Tableau test-connection to declarative framework

### DIFF
--- a/ingestion/src/metadata/core/connections/test_connection/checks/dashboard.py
+++ b/ingestion/src/metadata/core/connections/test_connection/checks/dashboard.py
@@ -22,13 +22,15 @@ their ``@check`` methods.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, TypeVar
 
 from metadata.core.connections.test_connection.check import CheckError, StepName
 from metadata.core.connections.test_connection.records import Diagnosis, Evidence
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Sized
+
+_T = TypeVar("_T")
 
 
 # A check only needs to prove the list endpoint is reachable and returns items,
@@ -43,6 +45,13 @@ class DashboardStep(StepName):
 
     CheckAccess = "CheckAccess"
     GetDashboards = "GetDashboards"
+    ServerInfo = "ServerInfo"
+    ValidateApiVersion = "ValidateApiVersion"
+    ValidateSiteUrl = "ValidateSiteUrl"
+    GetWorkbooks = "GetWorkbooks"
+    GetViews = "GetViews"
+    GetOwners = "GetOwners"
+    GetDataModels = "GetDataModels"
 
 
 def _count(number: int, noun: str, cap: int | None = None) -> str:
@@ -70,6 +79,20 @@ def verify_access(authenticate: Callable[[], object], command: str) -> Evidence:
     except Exception as cause:
         raise CheckError(cause, Evidence(command=command)) from cause
     return Evidence(summary="authenticated", command=command)
+
+
+def call_endpoint(call: Callable[[], _T], command: str) -> _T:
+    """Call a REST endpoint and hand its result back to the check.
+
+    For steps whose evidence is not a count: the check summarizes the returned
+    value itself (an API version, a resolved owner). On failure, re-raise as
+    ``CheckError`` carrying the attempted command so the failed step still
+    reports what it ran.
+    """
+    try:
+        return call()
+    except Exception as cause:
+        raise CheckError(cause, Evidence(command=command)) from cause
 
 
 def fetch_list(

--- a/ingestion/src/metadata/ingestion/source/dashboard/tableau/client.py
+++ b/ingestion/src/metadata/ingestion/source/dashboard/tableau/client.py
@@ -14,10 +14,9 @@ Wrapper module of TableauServerConnection client
 
 import math
 import traceback
-from typing import Callable, Dict, Iterable, List, Optional, Tuple, Union  # noqa: UP035
+from typing import Dict, Iterable, List, Optional, Tuple, Union  # noqa: UP035
 
 import validators
-from cached_property import cached_property
 from tableauserverclient import (
     Pager,
     PersonalAccessTokenAuth,
@@ -96,9 +95,8 @@ class TableauClient:
         self.all_projects: List[ProjectItem] = []  # noqa: UP006
         self.ssl_manager = ssl_manager
 
-    @cached_property
-    def server_info(self) -> Callable:
-        return self.tableau_server.server_info.get
+    def server_info(self):
+        return self.tableau_server.server_info.get()
 
     def server_api_version(self) -> str:
         return self.tableau_server.version

--- a/ingestion/src/metadata/ingestion/source/dashboard/tableau/connection.py
+++ b/ingestion/src/metadata/ingestion/source/dashboard/tableau/connection.py
@@ -54,6 +54,7 @@ from metadata.ingestion.source.dashboard.tableau.client import (
     TableauOwnersNotFound,
     TableauWorkBookException,
 )
+from metadata.utils.constants import THREE_MIN
 from metadata.utils.logger import ingestion_logger
 from metadata.utils.ssl_manager import SSLManager
 
@@ -305,6 +306,10 @@ class TableauChecks:
 
 
 class TableauConnection(BaseConnection[TableauConnectionConfig, TableauClient]):
+    # The workbook and Metadata API steps can be slow on large servers; keep the
+    # legacy 3-minute budget the imperative handler used, now applied per step.
+    step_timeout_seconds = THREE_MIN
+
     def _get_client(self) -> TableauClient:
         return get_connection(self.service_connection)
 

--- a/ingestion/src/metadata/ingestion/source/dashboard/tableau/connection.py
+++ b/ingestion/src/metadata/ingestion/source/dashboard/tableau/connection.py
@@ -100,9 +100,8 @@ TABLEAU_ERRORS = ErrorPack(
     when(_http_status(401)).diagnose(
         "Authentication failed",
         fix="Tableau rejected the credentials (401). Check the Personal Access Token name and "
-        "secret - a token expires after 15 consecutive days of no use and is revoked when "
-        "regenerated - or the username and password, and that the Site Name matches the site "
-        "those credentials belong to.",
+        "secret (or the username and password) and that it has not expired, and that the Site "
+        "Name matches the site those credentials belong to.",
     ),
     when(_http_status(403)).diagnose(
         "Insufficient permissions",

--- a/ingestion/src/metadata/ingestion/source/dashboard/tableau/connection.py
+++ b/ingestion/src/metadata/ingestion/source/dashboard/tableau/connection.py
@@ -8,41 +8,146 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-
 """
 Source connection handler
 """
 
+from __future__ import annotations
+
 import traceback
-from typing import Any, Dict, Optional, Union  # noqa: UP035
+from typing import TYPE_CHECKING, Any, Dict, Optional, Union  # noqa: UP035
 
 import tableauserverclient as TSC  # noqa: N812
+from requests.exceptions import SSLError
 
-from metadata.generated.schema.entity.automations.workflow import (
-    Workflow as AutomationWorkflow,
+from metadata.core.connections.test_connection import (
+    ErrorPack,
+    Evidence,
+    Matchers,
+    check,
+    when,
 )
+from metadata.core.connections.test_connection.checks.dashboard import (
+    DashboardStep,
+    call_endpoint,
+    verify_access,
+)
+from metadata.core.connections.test_connection.classifier import exception_chain
+from metadata.core.connections.test_connection.network import NETWORK_ERRORS
 from metadata.generated.schema.entity.services.connections.dashboard.tableauConnection import (
     TableauConnection as TableauConnectionConfig,
-)
-from metadata.generated.schema.entity.services.connections.testConnectionResult import (
-    TestConnectionResult,
 )
 from metadata.generated.schema.security.credentials.accessTokenAuth import (
     AccessTokenAuth,
 )
 from metadata.generated.schema.security.credentials.basicAuth import BasicAuth
 from metadata.ingestion.connections.connection import BaseConnection
-from metadata.ingestion.connections.test_connections import (
-    SourceConnectionException,
-    test_connection_steps,
+from metadata.ingestion.connections.test_connections import SourceConnectionException
+from metadata.ingestion.source.dashboard.tableau.client import (
+    TableauChartsException,
+    TableauClient,
+    TableauDataModelsException,
+    TableauOwnersNotFound,
+    TableauWorkBookException,
 )
-from metadata.ingestion.ometa.ometa_api import OpenMetadata
-from metadata.ingestion.source.dashboard.tableau.client import TableauClient
-from metadata.utils.constants import THREE_MIN
 from metadata.utils.logger import ingestion_logger
 from metadata.utils.ssl_manager import SSLManager
 
+if TYPE_CHECKING:
+    from metadata.core.connections.test_connection import ChecksProvider
+    from metadata.core.connections.test_connection.classifier import Matcher
+
 logger = ingestion_logger()
+
+METADATA_API_DOC = (
+    "https://help.tableau.com/current/api/metadata_api/en-us/docs/meta_api_start.html"
+    "#enable-the-tableau-metadata-api-for-tableau-server"
+)
+
+
+def _status_of(error: BaseException) -> int | None:
+    """Return the HTTP status a Tableau error carries, if any.
+
+    ``ServerResponseError`` reports a Tableau error code - a string whose first
+    three digits are the HTTP status, e.g. ``401002`` - while
+    ``InternalServerError`` puts the status itself on ``.code``. A raw ``requests``
+    error carries it at ``.response.status_code``.
+    """
+    code = getattr(error, "code", None)
+    if isinstance(code, bool):
+        status = None
+    elif isinstance(code, int):
+        status = code
+    elif isinstance(code, str) and code[:3].isdigit():
+        status = int(code[:3])
+    else:
+        response = getattr(error, "response", None)
+        status = getattr(response, "status_code", None)
+    return status if isinstance(status, int) else None
+
+
+def _http_status(*codes: int) -> Matcher:
+    """Match a Tableau REST error by HTTP status, across the cause chain.
+
+    The status is the stable signal - the summary and detail of a Tableau error
+    vary by endpoint and server version.
+    """
+    wanted = frozenset(codes)
+    return lambda error: any(_status_of(current) in wanted for current in exception_chain(error))
+
+
+TABLEAU_ERRORS = ErrorPack(
+    when(_http_status(401)).diagnose(
+        "Authentication failed",
+        fix="Tableau rejected the credentials (401). Check the Personal Access Token name and "
+        "secret - a token expires after 15 consecutive days of no use and is revoked when "
+        "regenerated - or the username and password, and that the Site Name matches the site "
+        "those credentials belong to.",
+    ),
+    when(_http_status(403)).diagnose(
+        "Insufficient permissions",
+        fix="The credentials are valid but not authorized for this resource (403). Grant the user "
+        "at least the Viewer site role and read access to the projects to ingest.",
+    ),
+    when(_http_status(404)).diagnose(
+        "Resource not found",
+        fix="Tableau could not find the requested resource (404). Check that Host Port points at "
+        "the Tableau server or Tableau Cloud pod, and that the Site Name exists - for "
+        "https://<server>/#/site/MarketingTeam/home the Site Name is 'MarketingTeam'.",
+    ),
+    when(Matchers.exception(SSLError)).diagnose(
+        "TLS verification failed",
+        fix="The server's certificate could not be verified. Provide the CA certificate under SSL "
+        "Config with Verify SSL set to 'validate', or set Verify SSL to 'ignore' for a "
+        "self-signed certificate.",
+    ),
+    when(Matchers.exception(TableauWorkBookException)).diagnose(
+        "No workbooks visible",
+        fix="The user is authenticated but no workbook could be read. Grant it access to at least "
+        "one project containing workbooks.",
+    ),
+    when(Matchers.exception(TableauChartsException)).diagnose(
+        "No views visible",
+        fix="Workbooks are readable but their views are not. Grant the user the View permission on "
+        "the workbooks to ingest; charts are ingested from workbook views.",
+    ),
+    when(Matchers.exception(TableauOwnersNotFound)).diagnose(
+        "Owner information not available",
+        fix="Owners could not be resolved. Grant the user permission to read users on the site, or "
+        "disable owner ingestion in the service configuration.",
+    ),
+    when(Matchers.exception(TableauDataModelsException)).diagnose(
+        "Data sources could not be read",
+        fix="The Tableau Metadata API returned no data sources for the workbook. Enable the "
+        "Metadata API on the Tableau instance.",
+        doc=METADATA_API_DOC,
+    ),
+    when(Matchers.contains("in incorrect format")).diagnose(
+        "Invalid Site Name",
+        fix="The Site Name must be the site identifier, not a URL - for "
+        "https://<server>/#/site/MarketingTeam/home enter 'MarketingTeam'.",
+    ),
+).including(NETWORK_ERRORS)
 
 
 def get_connection(connection: TableauConnectionConfig) -> TableauClient:
@@ -78,61 +183,25 @@ def set_verify_ssl(
         return False, None
 
     if connection.verifySSL.value == "validate":
-        # Use SSLManager to create temporary certificate files
         if not connection.sslConfig:
             raise ValueError(
                 "SSL Config is required when verifySSL is set to 'validate'. "
                 "Please provide CA certificate, SSL certificate, or SSL key."
             )
 
-        # Create SSLManager to handle certificate files
         ssl_manager = SSLManager(
             ca=connection.sslConfig.root.caCertificate,
             cert=connection.sslConfig.root.sslCertificate,
             key=connection.sslConfig.root.sslKey,
         )
 
-        # Return the CA certificate file path for verification
-        # If no CA certificate is provided, use default verification
         if ssl_manager.ca_file_path:
             return ssl_manager.ca_file_path, ssl_manager
         else:  # noqa: RET505
-            # If no CA certificate is provided but SSL is enabled, use default verification
             return True, ssl_manager
 
     raise ValueError(
         f"Unsupported verifySSL value: {connection.verifySSL.value}. Expected one of ['no-ssl', 'ignore', 'validate']."
-    )
-
-
-def test_connection(
-    metadata: OpenMetadata,
-    client: TableauClient,
-    service_connection: TableauConnectionConfig,
-    automation_workflow: Optional[AutomationWorkflow] = None,  # noqa: UP045
-    timeout_seconds: Optional[int] = THREE_MIN,  # noqa: UP045
-) -> TestConnectionResult:
-    """
-    Test connection. This can be executed either as part
-    of a metadata workflow or during an Automation Workflow
-    """
-
-    test_fn = {
-        "ServerInfo": client.server_info,
-        "ValidateApiVersion": client.server_api_version,
-        "ValidateSiteUrl": client.test_site_url,
-        "GetWorkbooks": client.test_get_workbooks,
-        "GetViews": client.test_get_workbook_views,
-        "GetOwners": client.test_get_owners,
-        "GetDataModels": client.test_get_datamodels,
-    }
-
-    return test_connection_steps(
-        metadata=metadata,
-        test_fn=test_fn,
-        service_type=service_connection.type.value,
-        automation_workflow=automation_workflow,
-        timeout_seconds=timeout_seconds,
     )
 
 
@@ -163,20 +232,79 @@ def build_server_config(connection: TableauConnectionConfig) -> Dict[str, Dict[s
     return tableau_auth
 
 
+class TableauChecks:
+    """Test-connection checks for Tableau.
+
+    ``ServerInfo`` is the gate: building the client signs in, so bad credentials,
+    a wrong site, or an unreachable server fail there and the remaining steps are
+    skipped rather than each re-dialling the host.
+
+    The client is built lazily inside the first check, never at construction: its
+    constructor signs in over the network, and doing that while the provider is
+    assembled would run before the runner's gate and surface as a raw workflow
+    error instead of a classified ``ServerInfo`` failure.
+    """
+
+    errors = TABLEAU_ERRORS
+
+    def __init__(self, connection: TableauConnectionConfig) -> None:
+        self._connection = connection
+        self._tableau_client: TableauClient | None = None
+
+    def _client(self) -> TableauClient:
+        """Build (once) and return the signed-in client. Only ever called from
+        inside a check, since signing in touches the network."""
+        if self._tableau_client is None:
+            self._tableau_client = get_connection(self._connection)
+        return self._tableau_client
+
+    @check(DashboardStep.ServerInfo)
+    def server_info(self) -> Evidence:
+        return verify_access(
+            lambda: self._client().server_info(),
+            command="sign in and read server info",
+        )
+
+    @check(DashboardStep.ValidateApiVersion)
+    def validate_api_version(self) -> Evidence:
+        command = "read the server REST API version"
+        version = call_endpoint(lambda: self._client().server_api_version(), command=command)
+        return Evidence(summary=f"REST API version {version}", command=command)
+
+    @check(DashboardStep.ValidateSiteUrl)
+    def validate_site_url(self) -> Evidence:
+        command = "validate the configured site name"
+        call_endpoint(lambda: self._client().test_site_url(), command=command)
+        return Evidence(summary="site name is well formed", command=command)
+
+    @check(DashboardStep.GetWorkbooks)
+    def get_workbooks(self) -> Evidence:
+        command = "fetch workbooks"
+        call_endpoint(lambda: self._client().test_get_workbooks(), command=command)
+        return Evidence(summary="workbooks are readable", command=command)
+
+    @check(DashboardStep.GetViews)
+    def get_views(self) -> Evidence:
+        command = "fetch the views of a workbook"
+        call_endpoint(lambda: self._client().test_get_workbook_views(), command=command)
+        return Evidence(summary="workbook views are readable", command=command)
+
+    @check(DashboardStep.GetOwners)
+    def get_owners(self) -> Evidence:
+        command = "fetch the owner of a workbook"
+        call_endpoint(lambda: self._client().test_get_owners(), command=command)
+        return Evidence(summary="workbook owners are resolvable", command=command)
+
+    @check(DashboardStep.GetDataModels)
+    def get_data_models(self) -> Evidence:
+        command = "query the Metadata API for the data sources of a workbook"
+        call_endpoint(lambda: self._client().test_get_datamodels(), command=command)
+        return Evidence(summary="data sources are readable", command=command)
+
+
 class TableauConnection(BaseConnection[TableauConnectionConfig, TableauClient]):
     def _get_client(self) -> TableauClient:
         return get_connection(self.service_connection)
 
-    def test_connection(
-        self,
-        metadata: OpenMetadata,
-        automation_workflow: Optional[AutomationWorkflow] = None,  # noqa: UP045
-        timeout_seconds: Optional[int] = THREE_MIN,  # noqa: UP045
-    ) -> TestConnectionResult:
-        return test_connection(
-            metadata,
-            self.client,
-            self.service_connection,
-            automation_workflow,
-            timeout_seconds,
-        )
+    def checks(self) -> ChecksProvider:
+        return TableauChecks(connection=self.service_connection)

--- a/ingestion/src/metadata/ingestion/source/dashboard/tableau/connection.py
+++ b/ingestion/src/metadata/ingestion/source/dashboard/tableau/connection.py
@@ -19,6 +19,10 @@ from typing import TYPE_CHECKING, Any, Dict, Optional, Union  # noqa: UP035
 
 import tableauserverclient as TSC  # noqa: N812
 from requests.exceptions import SSLError
+from tableauserverclient.server.endpoint.exceptions import (
+    InternalServerError,
+    ServerResponseError,
+)
 
 from metadata.core.connections.test_connection import (
     ErrorPack,
@@ -68,18 +72,17 @@ METADATA_API_DOC = (
 def _status_of(error: BaseException) -> int | None:
     """Return the HTTP status a Tableau error carries, if any.
 
-    ``ServerResponseError`` reports a Tableau error code - a string whose first
-    three digits are the HTTP status, e.g. ``401002`` - while
-    ``InternalServerError`` puts the status itself on ``.code``. A raw ``requests``
-    error carries it at ``.response.status_code``.
+    Only the two Tableau error types whose ``.code`` is HTTP-ish are trusted -
+    ``ServerResponseError.code`` is a string whose first three digits are the
+    status (e.g. ``401002``), ``InternalServerError.code`` is the status itself -
+    plus a raw ``requests`` error's ``.response.status_code``. Reading ``.code``
+    off any exception would misclassify an unrelated app code the chain happens
+    to carry.
     """
-    code = getattr(error, "code", None)
-    if isinstance(code, bool):
-        status = None
-    elif isinstance(code, int):
-        status = code
-    elif isinstance(code, str) and code[:3].isdigit():
-        status = int(code[:3])
+    if isinstance(error, ServerResponseError) and error.code[:3].isdigit():
+        status = int(error.code[:3])
+    elif isinstance(error, InternalServerError) and isinstance(error.code, int):
+        status = error.code
     else:
         response = getattr(error, "response", None)
         status = getattr(response, "status_code", None)

--- a/ingestion/tests/unit/source/dashboard/tableau/test_connection.py
+++ b/ingestion/tests/unit/source/dashboard/tableau/test_connection.py
@@ -1,21 +1,46 @@
-#  Copyright 2025 Collate
-#  Licensed under the Collate Community License, Version 1.0 (the "License");
-#  you may not use this file except in compliance with the License.
-#  You may obtain a copy of the License at
-#  https://github.com/open-metadata/OpenMetadata/blob/main/ingestion/LICENSE
-#  Unless required by applicable law or agreed to in writing, software
-#  distributed under the License is distributed on an "AS IS" BASIS,
-#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-#  See the License for the specific language governing permissions and
-#  limitations under the License.
-"""Unit tests for Tableau connection handling."""
+"""Unit tests for Tableau test-connection checks."""
 
+import socket
 from unittest.mock import MagicMock, patch
 
+import pytest
+from requests.exceptions import HTTPError, SSLError
+from tableauserverclient.server.endpoint.exceptions import ServerResponseError
+
+from metadata.core.connections.test_connection.check import CheckError, collect_checks
+from metadata.core.connections.test_connection.checks.dashboard import DashboardStep
 from metadata.ingestion.connections.connection import BaseConnection
-from metadata.ingestion.source.dashboard.tableau.connection import TableauConnection
+from metadata.ingestion.source.dashboard.tableau.client import (
+    TableauChartsException,
+    TableauDataModelsException,
+    TableauOwnersNotFound,
+    TableauWorkBookException,
+)
+from metadata.ingestion.source.dashboard.tableau.connection import (
+    TABLEAU_ERRORS,
+    TableauChecks,
+    TableauConnection,
+)
 
 CONNECTION_MODULE = "metadata.ingestion.source.dashboard.tableau.connection"
+
+
+def _server_error(code: str) -> ServerResponseError:
+    """A Tableau REST error: its code prefixes the HTTP status, e.g. 401002."""
+    return ServerResponseError(code, "summary", "detail")
+
+
+def _raw_http_error(status_code: int) -> HTTPError:
+    response = MagicMock()
+    response.status_code = status_code
+    return HTTPError("server said no", response=response)
+
+
+def _checks(get_connection) -> tuple[TableauChecks, MagicMock]:
+    """A provider whose lazily-built client is the returned mock."""
+    client = MagicMock()
+    get_connection.return_value = client
+    return TableauChecks(connection=MagicMock()), client
 
 
 def test_tableau_connection_is_base_connection():
@@ -31,10 +56,198 @@ def test_get_client_delegates_to_get_connection():
     mock_get.assert_called_once_with(conn.service_connection)
 
 
-def test_test_connection_runs_steps():
-    conn = TableauConnection(MagicMock())
-    conn._client = MagicMock()
-    with patch(f"{CONNECTION_MODULE}.test_connection") as mock_step:
-        result = conn.test_connection(metadata=MagicMock())
+def test_checks_does_not_touch_the_network():
+    with patch(f"{CONNECTION_MODULE}.get_connection") as mock_get:
+        conn = TableauConnection(MagicMock())
+        provider = conn.checks()
 
-    assert result is mock_step.return_value
+    assert isinstance(provider, TableauChecks)
+    mock_get.assert_not_called()
+
+
+def test_collect_checks_maps_every_step():
+    with patch(f"{CONNECTION_MODULE}.get_connection") as mock_get:
+        provider, _ = _checks(mock_get)
+    collected = collect_checks(provider)
+
+    assert set(collected) == {
+        DashboardStep.ServerInfo,
+        DashboardStep.ValidateApiVersion,
+        DashboardStep.ValidateSiteUrl,
+        DashboardStep.GetWorkbooks,
+        DashboardStep.GetViews,
+        DashboardStep.GetOwners,
+        DashboardStep.GetDataModels,
+    }
+
+
+def test_client_is_built_once_and_shared_across_checks():
+    with patch(f"{CONNECTION_MODULE}.get_connection") as mock_get:
+        provider, _ = _checks(mock_get)
+        provider.server_info()
+        provider.get_workbooks()
+
+    mock_get.assert_called_once_with(provider._connection)
+
+
+def test_server_info_signs_in():
+    with patch(f"{CONNECTION_MODULE}.get_connection") as mock_get:
+        provider, client = _checks(mock_get)
+
+        evidence = provider.server_info()
+
+    client.server_info.assert_called_once_with()
+    assert evidence.summary == "authenticated"
+    assert evidence.command == "sign in and read server info"
+
+
+def test_server_info_wraps_sign_in_failure_as_check_error():
+    # Signing in happens inside the gate check, so bad credentials surface as a
+    # classified ServerInfo failure instead of escaping while the provider is built.
+    with patch(f"{CONNECTION_MODULE}.get_connection") as mock_get:
+        provider = TableauChecks(connection=MagicMock())
+        mock_get.side_effect = _server_error("401001")
+
+        with pytest.raises(CheckError) as exc_info:
+            provider.server_info()
+
+    assert isinstance(exc_info.value.cause, ServerResponseError)
+    assert exc_info.value.evidence.command == "sign in and read server info"
+
+
+def test_validate_api_version_reports_the_version():
+    with patch(f"{CONNECTION_MODULE}.get_connection") as mock_get:
+        provider, client = _checks(mock_get)
+        client.server_api_version.return_value = "3.19"
+
+        evidence = provider.validate_api_version()
+
+    assert evidence.summary == "REST API version 3.19"
+    assert evidence.command == "read the server REST API version"
+
+
+def test_validate_site_url_passes():
+    with patch(f"{CONNECTION_MODULE}.get_connection") as mock_get:
+        provider, client = _checks(mock_get)
+
+        evidence = provider.validate_site_url()
+
+    client.test_site_url.assert_called_once_with()
+    assert evidence.summary == "site name is well formed"
+
+
+def test_validate_site_url_wraps_failure_as_check_error():
+    with patch(f"{CONNECTION_MODULE}.get_connection") as mock_get:
+        provider, client = _checks(mock_get)
+        client.test_site_url.side_effect = ValueError('The site url "https://x" is in incorrect format.')
+
+        with pytest.raises(CheckError) as exc_info:
+            provider.validate_site_url()
+
+    assert exc_info.value.evidence.command == "validate the configured site name"
+
+
+def test_get_workbooks_passes():
+    with patch(f"{CONNECTION_MODULE}.get_connection") as mock_get:
+        provider, client = _checks(mock_get)
+
+        evidence = provider.get_workbooks()
+
+    client.test_get_workbooks.assert_called_once_with()
+    assert evidence.summary == "workbooks are readable"
+
+
+def test_get_workbooks_wraps_failure_as_check_error():
+    with patch(f"{CONNECTION_MODULE}.get_connection") as mock_get:
+        provider, client = _checks(mock_get)
+        client.test_get_workbooks.side_effect = TableauWorkBookException("no workbooks")
+
+        with pytest.raises(CheckError) as exc_info:
+            provider.get_workbooks()
+
+    assert exc_info.value.evidence.command == "fetch workbooks"
+    assert isinstance(exc_info.value.cause, TableauWorkBookException)
+
+
+def test_get_views_passes():
+    with patch(f"{CONNECTION_MODULE}.get_connection") as mock_get:
+        provider, client = _checks(mock_get)
+
+        evidence = provider.get_views()
+
+    client.test_get_workbook_views.assert_called_once_with()
+    assert evidence.summary == "workbook views are readable"
+
+
+def test_get_owners_passes():
+    with patch(f"{CONNECTION_MODULE}.get_connection") as mock_get:
+        provider, client = _checks(mock_get)
+
+        evidence = provider.get_owners()
+
+    client.test_get_owners.assert_called_once_with()
+    assert evidence.summary == "workbook owners are resolvable"
+
+
+def test_get_data_models_passes():
+    with patch(f"{CONNECTION_MODULE}.get_connection") as mock_get:
+        provider, client = _checks(mock_get)
+
+        evidence = provider.get_data_models()
+
+    client.test_get_datamodels.assert_called_once_with()
+    assert evidence.summary == "data sources are readable"
+    assert evidence.command == "query the Metadata API for the data sources of a workbook"
+
+
+def test_get_data_models_wraps_failure_as_check_error():
+    with patch(f"{CONNECTION_MODULE}.get_connection") as mock_get:
+        provider, client = _checks(mock_get)
+        client.test_get_datamodels.side_effect = TableauDataModelsException("metadata api off")
+
+        with pytest.raises(CheckError) as exc_info:
+            provider.get_data_models()
+
+    assert isinstance(exc_info.value.cause, TableauDataModelsException)
+
+
+@pytest.mark.parametrize(
+    ("error", "title"),
+    [
+        (_server_error("401001"), "Authentication failed"),
+        (_server_error("401002"), "Authentication failed"),
+        (_server_error("403004"), "Insufficient permissions"),
+        (_server_error("404000"), "Resource not found"),
+        (_raw_http_error(401), "Authentication failed"),
+        (_raw_http_error(403), "Insufficient permissions"),
+        (_raw_http_error(404), "Resource not found"),
+        (SSLError("certificate verify failed"), "TLS verification failed"),
+        (TableauWorkBookException("nope"), "No workbooks visible"),
+        (TableauChartsException("nope"), "No views visible"),
+        (TableauOwnersNotFound("nope"), "Owner information not available"),
+        (TableauDataModelsException("nope"), "Data sources could not be read"),
+        (ValueError('The site url "https://x" is in incorrect format.'), "Invalid Site Name"),
+        (socket.gaierror("name resolution failed"), "Host could not be resolved"),
+    ],
+)
+def test_error_pack_classifies(error, title):
+    diagnosis = TABLEAU_ERRORS.classify(error)
+
+    assert diagnosis is not None
+    assert diagnosis.title == title
+
+
+def test_error_pack_classifies_a_wrapped_cause():
+    # get_connection re-raises a sign-in failure as SourceConnectionException; the
+    # Tableau error survives in the cause chain and still classifies.
+    wrapper = RuntimeError("Unknown error connecting")
+    wrapper.__cause__ = _server_error("401001")
+
+    diagnosis = TABLEAU_ERRORS.classify(wrapper)
+
+    assert diagnosis is not None
+    assert diagnosis.title == "Authentication failed"
+
+
+def test_error_pack_ignores_unknown_error():
+    assert TABLEAU_ERRORS.classify(ValueError("something else")) is None

--- a/ingestion/tests/unit/source/dashboard/tableau/test_connection.py
+++ b/ingestion/tests/unit/source/dashboard/tableau/test_connection.py
@@ -249,5 +249,14 @@ def test_error_pack_classifies_a_wrapped_cause():
     assert diagnosis.title == "Authentication failed"
 
 
+def test_error_pack_ignores_unrelated_code_attribute():
+    # A non-Tableau exception exposing an int .code must not be read as an HTTP
+    # status just because it happens to equal 401/403/404.
+    class _AppError(Exception):
+        code = 403
+
+    assert TABLEAU_ERRORS.classify(_AppError("application code, not HTTP")) is None
+
+
 def test_error_pack_ignores_unknown_error():
     assert TABLEAU_ERRORS.classify(ValueError("something else")) is None

--- a/openmetadata-service/src/main/resources/json/data/testConnections/dashboard/tableau.json
+++ b/openmetadata-service/src/main/resources/json/data/testConnections/dashboard/tableau.json
@@ -8,7 +8,8 @@
       "description": "Validate that the API can properly reach the server",
       "errorMessage": "Failed to connect to tableau, please validate the credentials",
       "shortCircuit": true,
-      "mandatory": true
+      "mandatory": true,
+      "category": "ConnectionGate"
     },
     {
       "name": "ValidateApiVersion",


### PR DESCRIPTION
Fixes #29873

Migrates the Tableau test connection off the imperative `test_connection_steps` helper onto the declarative `@check` / `ChecksProvider` / `ErrorPack` framework, following PowerBI.

**What changed**
- `TableauChecks` provider with one `@check` per existing step — `ServerInfo`, `ValidateApiVersion`, `ValidateSiteUrl`, `GetWorkbooks`, `GetViews`, `GetOwners`, `GetDataModels` — each returning `Evidence` (a summary plus the command it ran). `TableauConnection.test_connection` is gone; `BaseConnection.test_connection` drives `checks()`.
- `TABLEAU_ERRORS` `ErrorPack`: HTTP 401 / 403 / 404 (read off the Tableau error code, whose first three digits are the status, or off a raw `requests` error), TLS verification failures, the connector's own workbook/chart/owner/data-model exceptions, and a malformed Site Name — folding in the shared `NETWORK_ERRORS`.
- `ServerInfo` is now the `ConnectionGate` step in `tableau.json`, so bad credentials or an unreachable server short-circuit the remaining steps instead of each one re-dialling the host.
- The client is built lazily inside the first check: `TableauClient.__init__` signs in over the network, so building it while assembling the provider would run before the gate.
- Added the seven Tableau step names to the shared `DashboardStep` enum, plus a `call_endpoint` helper in `checks/dashboard.py` for steps whose evidence is not a count.
- `TableauClient.server_info` becomes a plain method rather than a `cached_property` returning a callable — its only caller was the test connection.

#29805 also touches `dashboard/tableau/connection.py`; this diff is kept minimal so it rebases cleanly.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR moves Tableau test connection checks onto the declarative framework. The main changes are:

- Adds Tableau declarative checks for server info, site validation, workbooks, views, owners, and data models.
- Adds Tableau-specific error classification for auth, permissions, TLS, site name, and connector errors.
- Marks `ServerInfo` as the connection gate in the Tableau test-connection definition.
- Keeps Tableau checks on the legacy three-minute timeout budget.
- Updates Tableau test coverage for the new checks provider and error pack.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge.

- No blocking issues found in the changed code.

</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| ingestion/src/metadata/ingestion/source/dashboard/tableau/connection.py | Adds the Tableau checks provider, error classification, lazy client creation, and per-step timeout override. |
| ingestion/src/metadata/core/connections/test_connection/checks/dashboard.py | Adds Tableau dashboard step names and a helper for checks that call endpoints directly. |
| ingestion/src/metadata/ingestion/source/dashboard/tableau/client.py | Changes `server_info` into a direct method call for the new check flow. |
| openmetadata-service/src/main/resources/json/data/testConnections/dashboard/tableau.json | Marks `ServerInfo` as the Tableau connection gate. |
| ingestion/tests/unit/source/dashboard/tableau/test_connection.py | Updates unit tests for declarative Tableau checks and error classification. |

</details>

<sub>Reviews (5): Last reviewed commit: ["Merge branch &#39;main&#39; into migrate-tableau..."](https://github.com/open-metadata/openmetadata/commit/797849b6938e56a3fb56ae7fd897b96d2c7541b9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43771846)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Context used - CLAUDE.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=52f0d9d9-cad1-4e7d-b070-de181a0aa5e7))
- Context used - openmetadata-ui-core-components/CLAUDE.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=41754627-b2bf-474b-8082-f37ef1a07013))
- Context used - AGENTS.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=ef262f5f-911f-44f3-8d2d-e9cb1579c8c8))
</details>

<!-- /greptile_comment -->