### PR TITLE
fix(data-insights): return 400 not 500 when a chart metric has no function or formula

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/elasticsearch/dataInsightAggregators/ElasticSearchDynamicChartAggregatorInterface.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/elasticsearch/dataInsightAggregators/ElasticSearchDynamicChartAggregatorInterface.java
@@ -194,6 +194,10 @@ public interface ElasticSearchDynamicChartAggregatorInterface {
       Map<String, Aggregation> aggregationsMap,
       String parentAggName,
       List<FormulaHolder> formulas) {
+    if (function == null && formula == null) {
+      throw new IllegalArgumentException(
+          "Data Insight chart metric must define either a function or a formula");
+    }
     if (formula != null) {
       if (filter != null && !filter.equals("{}")) {
         try {

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/opensearch/dataInsightAggregator/OpenSearchDynamicChartAggregatorInterface.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/opensearch/dataInsightAggregator/OpenSearchDynamicChartAggregatorInterface.java
@@ -188,6 +188,10 @@ public interface OpenSearchDynamicChartAggregatorInterface {
       Map<String, Aggregation> aggregations,
       String aggregationName,
       List<FormulaHolder> formulas) {
+    if (function == null && formula == null) {
+      throw new IllegalArgumentException(
+          "Data Insight chart metric must define either a function or a formula");
+    }
     if (formula != null) {
       if (filter != null && !filter.equals("{}")) {
         try {

--- a/openmetadata-service/src/test/java/org/openmetadata/service/search/elasticsearch/dataInsightAggregators/ElasticSearchLineChartAggregatorTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/search/elasticsearch/dataInsightAggregators/ElasticSearchLineChartAggregatorTest.java
@@ -3,6 +3,7 @@ package org.openmetadata.service.search.elasticsearch.dataInsightAggregators;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
@@ -83,6 +84,13 @@ class ElasticSearchLineChartAggregatorTest {
     assertEquals(SERVICE_NAME, serviceAgg.path("terms").path("include").asText());
   }
 
+  @Test
+  void nullFunctionAndFormulaMetricThrows() {
+    DataInsightCustomChart chart = incompleteMetricChart();
+
+    assertThrows(IllegalArgumentException.class, () -> prepare(chart));
+  }
+
   private SearchRequest prepare(DataInsightCustomChart chart) {
     return aggregator.prepareSearchRequest(
         chart, 0L, END_TIME, new ArrayList<>(), new HashMap<>(), true);
@@ -137,6 +145,16 @@ class ElasticSearchLineChartAggregatorTest {
             .withIncludeXAxisFiled(includeService);
     return new DataInsightCustomChart()
         .withName("total_data_assets_live")
+        .withChartDetails(lineChart);
+  }
+
+  private static DataInsightCustomChart incompleteMetricChart() {
+    LineChart lineChart =
+        new LineChart()
+            .withMetrics(List.of(new LineChartMetric().withField("id.keyword")))
+            .withxAxisField(X_AXIS_FIELD);
+    return new DataInsightCustomChart()
+        .withName("incomplete_metric_chart")
         .withChartDetails(lineChart);
   }
 

--- a/openmetadata-service/src/test/java/org/openmetadata/service/search/opensearch/dataInsightAggregator/OpenSearchLineChartAggregatorTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/search/opensearch/dataInsightAggregator/OpenSearchLineChartAggregatorTest.java
@@ -3,6 +3,7 @@ package org.openmetadata.service.search.opensearch.dataInsightAggregator;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
@@ -82,6 +83,13 @@ class OpenSearchLineChartAggregatorTest {
     assertEquals(SERVICE_NAME, serviceAgg.path("terms").path("include").asText());
   }
 
+  @Test
+  void nullFunctionAndFormulaMetricThrows() {
+    DataInsightCustomChart chart = incompleteMetricChart();
+
+    assertThrows(IllegalArgumentException.class, () -> prepare(chart));
+  }
+
   private SearchRequest prepare(DataInsightCustomChart chart) {
     return aggregator.prepareSearchRequest(
         chart, 0L, END_TIME, new ArrayList<>(), new HashMap<>(), true);
@@ -136,6 +144,16 @@ class OpenSearchLineChartAggregatorTest {
             .withIncludeXAxisFiled(includeService);
     return new DataInsightCustomChart()
         .withName("total_data_assets_live")
+        .withChartDetails(lineChart);
+  }
+
+  private static DataInsightCustomChart incompleteMetricChart() {
+    LineChart lineChart =
+        new LineChart()
+            .withMetrics(List.of(new LineChartMetric().withField("id.keyword")))
+            .withxAxisField(X_AXIS_FIELD);
+    return new DataInsightCustomChart()
+        .withName("incomplete_metric_chart")
         .withChartDetails(lineChart);
   }
 


### PR DESCRIPTION
Fixes #29889

## Problem
`getSubAggregationsByFunction` runs `switch (function)` with no null check, so a Data Insight chart metric with no function and no formula throws a NullPointerException and the request returns a 500 instead of a 400. The same code is in the OpenSearch and Elasticsearch interfaces, and both the LineChart and SummaryCard aggregators reach it through `populateDateHistogram`.

## Change
Guard at the top of `populateDateHistogram` in both engine interfaces:

```java
if (function == null && formula == null) {
  throw new IllegalArgumentException(
      "Data Insight chart metric must define either a function or a formula");
}
```

A formula-only metric still works (its function is null but it takes the formula branch), and a function-only metric still works. Only the case where both are null is rejected, and it maps to a 400.

## Tests
Added `nullFunctionAndFormulaMetricThrows` to `OpenSearchLineChartAggregatorTest` and `ElasticSearchLineChartAggregatorTest`. Both suites pass, 5 of 5 each.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a `NullPointerException` (500) that occurred when a Data Insight chart metric had neither a `function` nor a `formula` set. The fix adds an early guard in `populateDateHistogram` in both the Elasticsearch and OpenSearch aggregator interfaces, throwing an `IllegalArgumentException` which the existing `CatalogGenericExceptionMapper` correctly maps to HTTP 400.

- **Guard added** at the top of `populateDateHistogram` in both `ElasticSearchDynamicChartAggregatorInterface` and `OpenSearchDynamicChartAggregatorInterface`; formula-only and function-only metrics are unaffected.
- **Tests added** (`nullFunctionAndFormulaMetricThrows`) in both `ElasticSearchLineChartAggregatorTest` and `OpenSearchLineChartAggregatorTest`, exercising the new code path via `prepareSearchRequest`.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is a minimal, well-scoped guard that only triggers when both `function` and `formula` are null, leaving all valid metric configurations untouched.

The guard is placed before any existing logic and cannot affect formula-only or function-only metrics. `IllegalArgumentException` is explicitly caught by `CatalogGenericExceptionMapper` and returned as HTTP 400, confirming the intended behavior. Both search-engine implementations are updated symmetrically, and the fix is verified by dedicated unit tests.

No files require special attention.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-service/src/main/java/org/openmetadata/service/search/elasticsearch/dataInsightAggregators/ElasticSearchDynamicChartAggregatorInterface.java | Added null guard at the top of `populateDateHistogram` that throws `IllegalArgumentException` when both `function` and `formula` are null; correctly maps to HTTP 400 via `CatalogGenericExceptionMapper`. |
| openmetadata-service/src/main/java/org/openmetadata/service/search/opensearch/dataInsightAggregator/OpenSearchDynamicChartAggregatorInterface.java | Symmetric guard added to `populateDateHistogram` in the OpenSearch interface, identical to the Elasticsearch fix. |
| openmetadata-service/src/test/java/org/openmetadata/service/search/elasticsearch/dataInsightAggregators/ElasticSearchLineChartAggregatorTest.java | Added `nullFunctionAndFormulaMetricThrows` test with `incompleteMetricChart()` helper; correctly asserts `IllegalArgumentException` is thrown when a metric has neither function nor formula. |
| openmetadata-service/src/test/java/org/openmetadata/service/search/opensearch/dataInsightAggregator/OpenSearchLineChartAggregatorTest.java | Symmetric test added for OpenSearch; mirrors the Elasticsearch test structure exactly. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Client
    participant DataInsightsResource
    participant LineChartAggregator
    participant populateDateHistogram
    participant CatalogGenericExceptionMapper

    Client->>DataInsightsResource: GET /dataInsight/charts/...
    DataInsightsResource->>LineChartAggregator: prepareSearchRequest(chart, ...)
    LineChartAggregator->>populateDateHistogram: "function=null, formula=null"
    Note over populateDateHistogram: NEW: null check guard
    populateDateHistogram-->>LineChartAggregator: throws IllegalArgumentException
    LineChartAggregator-->>DataInsightsResource: exception propagates
    DataInsightsResource-->>CatalogGenericExceptionMapper: unhandled exception
    Note over CatalogGenericExceptionMapper: IllegalArgumentException → 400
    CatalogGenericExceptionMapper-->>Client: HTTP 400 Bad Request
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Client
    participant DataInsightsResource
    participant LineChartAggregator
    participant populateDateHistogram
    participant CatalogGenericExceptionMapper

    Client->>DataInsightsResource: GET /dataInsight/charts/...
    DataInsightsResource->>LineChartAggregator: prepareSearchRequest(chart, ...)
    LineChartAggregator->>populateDateHistogram: "function=null, formula=null"
    Note over populateDateHistogram: NEW: null check guard
    populateDateHistogram-->>LineChartAggregator: throws IllegalArgumentException
    LineChartAggregator-->>DataInsightsResource: exception propagates
    DataInsightsResource-->>CatalogGenericExceptionMapper: unhandled exception
    Note over CatalogGenericExceptionMapper: IllegalArgumentException → 400
    CatalogGenericExceptionMapper-->>Client: HTTP 400 Bad Request
```

</a>
</details>

<sub>Reviews (3): Last reviewed commit: ["fix(data-insights): return 400 not 500 w..."](https://github.com/open-metadata/openmetadata/commit/0f23e69f43aff72b631399145e32b845b0aea6fd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42999197)</sub>

<!-- /greptile_comment -->