### PR TITLE
MINOR: ownerName missing field after https://github.com/open-metadata/OpenMetadata/pull/19423

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/apps/bundles/insights/workflows/dataAssets/processors/DataInsightsEntityEnricherProcessor.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/apps/bundles/insights/workflows/dataAssets/processors/DataInsightsEntityEnricherProcessor.java
@@ -28,6 +28,7 @@ import org.openmetadata.service.apps.bundles.insights.workflows.dataAssets.proce
 import org.openmetadata.service.apps.bundles.insights.workflows.dataAssets.processors.enricher.steps.DescriptionStatsStep;
 import org.openmetadata.service.apps.bundles.insights.workflows.dataAssets.processors.enricher.steps.EntityStatusStep;
 import org.openmetadata.service.apps.bundles.insights.workflows.dataAssets.processors.enricher.steps.IdentityProjectionStep;
+import org.openmetadata.service.apps.bundles.insights.workflows.dataAssets.processors.enricher.steps.OwnerNameStep;
 import org.openmetadata.service.apps.bundles.insights.workflows.dataAssets.processors.enricher.steps.OwnerTeamStep;
 import org.openmetadata.service.apps.bundles.insights.workflows.dataAssets.processors.enricher.steps.TagAndTierSourcesStep;
 import org.openmetadata.service.apps.bundles.insights.workflows.dataAssets.processors.enricher.steps.TierStep;
@@ -75,6 +76,7 @@ public class DataInsightsEntityEnricherProcessor
               new DescriptionSourcesStep(),
               new TagAndTierSourcesStep(),
               new OwnerTeamStep(ownerResolver),
+              new OwnerNameStep(),
               new TierStep(),
               new DescriptionStatsStep(),
               new CustomPropertiesStep()));

--- a/openmetadata-service/src/main/java/org/openmetadata/service/apps/bundles/insights/workflows/dataAssets/processors/enricher/steps/OwnerNameStep.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/apps/bundles/insights/workflows/dataAssets/processors/enricher/steps/OwnerNameStep.java
@@ -1,0 +1,49 @@
+/*
+ *  Copyright 2024 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ *  except in compliance with the License. You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software distributed under the License
+ *  is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and limitations under
+ *  the License.
+ */
+package org.openmetadata.service.apps.bundles.insights.workflows.dataAssets.processors.enricher.steps;
+
+import static org.openmetadata.common.utils.CommonUtil.nullOrEmpty;
+
+import java.util.List;
+import org.openmetadata.schema.type.EntityReference;
+import org.openmetadata.service.apps.bundles.insights.workflows.dataAssets.processors.enricher.EnrichmentStep;
+import org.openmetadata.service.apps.bundles.insights.workflows.dataAssets.processors.enricher.EnrichmentTarget;
+
+/**
+ * Projects a flat {@code ownerName} keyword list onto the snapshot, mirroring the computed field
+ * the entity search index sets in {@code SearchIndex.populateCommonFields}. The DI document
+ * otherwise carries owners only as the {@code nested} {@code owners} array, which flat
+ * {@code query_string} DI filters (e.g. {@code ownerName: *}) cannot reach. Entities with no
+ * owners contribute no {@code ownerName} key rather than an empty list, so a
+ * {@code query_string} existence filter cleanly excludes unowned assets.
+ */
+public final class OwnerNameStep implements EnrichmentStep {
+
+  public static final String NAME = "ownerName";
+
+  @Override
+  public String name() {
+    return NAME;
+  }
+
+  @Override
+  public void apply(EnrichmentTarget target) {
+    List<EntityReference> owners = target.entity().getOwners();
+    if (nullOrEmpty(owners)) {
+      return;
+    }
+    List<String> ownerNames =
+        owners.stream().map(EntityReference::getName).filter(name -> !nullOrEmpty(name)).toList();
+    if (!ownerNames.isEmpty()) {
+      target.entityMap().put(NAME, ownerNames);
+    }
+  }
+}

--- a/openmetadata-service/src/main/resources/dataInsights/config.json
+++ b/openmetadata-service/src/main/resources/dataInsights/config.json
@@ -9,6 +9,7 @@
       "version",
       "owners",
       "tags",
+      "ownerName",
       "extension",
       "votes",
       "fullyQualifiedName",

--- a/openmetadata-service/src/test/java/org/openmetadata/service/apps/bundles/insights/workflows/dataAssets/processors/DataInsightsEntityEnricherProcessorTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/apps/bundles/insights/workflows/dataAssets/processors/DataInsightsEntityEnricherProcessorTest.java
@@ -34,6 +34,7 @@ import org.openmetadata.schema.EntityInterface;
 import org.openmetadata.schema.type.ChangeDescription;
 import org.openmetadata.schema.type.Column;
 import org.openmetadata.schema.type.ColumnDataType;
+import org.openmetadata.schema.type.EntityReference;
 import org.openmetadata.service.Entity;
 import org.openmetadata.service.apps.bundles.insights.workflows.dataAssets.processors.enricher.EnrichmentContext;
 import org.openmetadata.service.apps.bundles.insights.workflows.dataAssets.processors.enricher.EnrichmentTarget;
@@ -155,6 +156,33 @@ class DataInsightsEntityEnricherProcessorTest {
     assertFalse(result.containsKey("numberOfColumns"));
     assertFalse(result.containsKey("numberOfColumnsWithDescription"));
     assertFalse(result.containsKey("hasColumnDescription"));
+  }
+
+  @Test
+  void testOwnerNameProjectedForOwnedEntity() {
+    List<EntityReference> owners =
+        List.of(
+            new EntityReference().withName("alice").withType(Entity.USER),
+            new EntityReference().withName("data-team").withType(Entity.TEAM));
+    Map<String, Object> result = enrichEntity(new MockOwnedEntity(owners), "pipeline");
+
+    assertEquals(List.of("alice", "data-team"), result.get("ownerName"));
+  }
+
+  @Test
+  void testOwnerNameAbsentForUnownedEntity() {
+    Map<String, Object> result = enrichEntity(new MockEntity("test description"), "pipeline");
+
+    assertFalse(result.containsKey("ownerName"));
+  }
+
+  @Test
+  void testOwnerNameAbsentWhenOwnerNamesBlank() {
+    List<EntityReference> owners =
+        List.of(new EntityReference().withName(null).withType(Entity.USER));
+    Map<String, Object> result = enrichEntity(new MockOwnedEntity(owners), "pipeline");
+
+    assertFalse(result.containsKey("ownerName"));
   }
 
   @Test
@@ -524,6 +552,20 @@ class DataInsightsEntityEnricherProcessorTest {
     @Override
     public <T extends EntityInterface> T withHref(URI href) {
       return (T) this;
+    }
+  }
+
+  static class MockOwnedEntity extends MockEntity {
+    private final List<EntityReference> owners;
+
+    MockOwnedEntity(List<EntityReference> owners) {
+      super("test description");
+      this.owners = owners;
+    }
+
+    @Override
+    public List<EntityReference> getOwners() {
+      return owners;
     }
   }
 }


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:

Fixes #<issue-number>
<!--
Linking an issue is REQUIRED. Replace <issue-number> with the GitHub issue number this PR addresses
(e.g., `Fixes #12345`). GitHub will auto-link it. If no issue exists, please open one first so the
problem and design can be discussed before review.
-->

<!--
Short blurb explaining:
- What changes did you make?
- Why did you make them?
-->

I worked on ... because ...

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### High-level design:
<!--
REQUIRED for large PRs (new features, refactors, breaking changes, or anything touching >5 files).
Skip for small bug fixes and trivial changes.

Cover:
- Architecture / approach you took and why
- Key components or files added/changed and how they interact
- Alternatives considered and why you rejected them
- Any migration, backward-compatibility, or rollout concerns
- Diagrams or links to design docs / RFCs if available
-->

N/A — small change. <!-- Or fill in the design above -->

#
### Tests:

#### Use cases covered
<!--
List the user-visible scenarios this PR exercises. Example:
- User with Admin role can create a Glossary Term with a parent term
- Ingestion run for Snowflake correctly extracts row counts for partitioned tables
-->

#### Unit tests
<!--
- [ ] I added unit tests for the new/changed logic.
- Files added/updated:
- Coverage on changed classes (run `mvn jacoco:report` for backend, `yarn test:coverage` for UI,
  `make unit_ingestion` for ingestion). Target is 90% line coverage on changed classes.
- Coverage %: <e.g., 92% on EntityRepository.java>
-->

#### Backend integration tests
<!--
- [ ] I added integration tests in `openmetadata-integration-tests/` for new/changed API endpoints.
- [ ] Not applicable (no backend API changes).
- Files added/updated:
-->

#### Ingestion integration tests
<!--
- [ ] I added/updated ingestion integration tests for connector changes.
- [ ] Not applicable (no ingestion changes).
- Files added/updated:
-->

#### Playwright (UI) tests
<!--
- [ ] I added Playwright E2E tests under `openmetadata-ui/.../ui/playwright/` for UI changes.
- [ ] Not applicable (no UI changes).
- Files added/updated:
-->

#### Manual testing performed
<!--
List the manual test steps you performed before requesting review. Example:
1. Started local stack via `./docker/run_local_docker.sh -m ui -d mysql`
2. Logged in as admin, created entity X, verified Y appears in the UI
3. Triggered ingestion for Snowflake source, confirmed lineage edges in the explore page
-->

#
### UI screen recording / screenshots:
<!--
REQUIRED for any PR that changes the UI. Drag-and-drop a short screen recording (.mov / .mp4 / .gif)
demonstrating the change end-to-end, plus before/after screenshots where relevant.
Mark "Not applicable" if there are no UI changes.
-->

Not applicable. <!-- Or attach recording/screenshots above -->

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.
- [ ] For UI changes: I attached a screen recording and/or screenshots above.
- [ ] I have added tests (unit / integration / Playwright as applicable) and listed them above.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->

----
## Summary by Gitar

- **Data insights enrichment:**
  - Added `OwnerNameStep` to project flat `ownerName` list onto data insight snapshots.
  - Registered `OwnerNameStep` in `DataInsightsEntityEnricherProcessor` and configured it in `config.json`.
- **Testing:**
  - Added unit tests in `DataInsightsEntityEnricherProcessorTest` covering owned, unowned, and missing owner name scenarios.

<sub>This will update automatically on new commits.</sub>

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR restores the `ownerName` flat keyword field that was dropped from Data Insights snapshots after PR #19423 refactored owner handling. A new `OwnerNameStep` is introduced that mirrors what `SearchIndex.populateCommonFields` does, projecting each owner's name into a flat list so `query_string` DI filters (e.g. `ownerName: *`) can reach it without traversing the nested `owners` array.

- **`OwnerNameStep`**: reads `entity.getOwners()`, filters out null names, and writes the result under the `ownerName` key — absent entirely when no owners or all names are null, so existence filters correctly exclude unowned assets.
- **Pipeline wiring**: `OwnerNameStep` is inserted after `OwnerTeamStep` in `DataInsightsEntityEnricherProcessor`, and `ownerName` is added to the `common` mapping fields in `config.json`.
- **Tests**: three focused unit tests cover the owned, unowned, and all-null-name edge cases with a lightweight `MockOwnedEntity` helper.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is a targeted restoration of a missing field with no side effects on existing enrichment steps.

All four files are small and focused. OwnerNameStep is purely additive, guards null/empty owners and null individual names, and the pipeline contract (additive-only, no cross-step reads) is respected. Three unit tests cover the key behavioral cases. The config.json addition is consistent with the existing field list. No data loss or behavioural regression is possible — absent ownerName was the prior broken state.

No files require special attention.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-service/src/main/java/org/openmetadata/service/apps/bundles/insights/workflows/dataAssets/processors/enricher/steps/OwnerNameStep.java | New enrichment step that projects a flat ownerName keyword list from the nested owners array. Correctly guards against null/empty owners and null individual names. |
| openmetadata-service/src/main/java/org/openmetadata/service/apps/bundles/insights/workflows/dataAssets/processors/DataInsightsEntityEnricherProcessor.java | Wires OwnerNameStep into the enrichment pipeline after OwnerTeamStep, restoring the missing field. |
| openmetadata-service/src/main/resources/dataInsights/config.json | Adds ownerName to the common mappingFields list so the projected field is included in data insights documents. |
| openmetadata-service/src/test/java/org/openmetadata/service/apps/bundles/insights/workflows/dataAssets/processors/DataInsightsEntityEnricherProcessorTest.java | Adds three unit tests covering the owned, unowned, and all-null-name cases for OwnerNameStep, plus a supporting MockOwnedEntity helper class. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[EnrichmentPipeline] --> B[IdentityProjectionStep]
    B --> C[DescriptionSourcesStep]
    C --> D[TagAndTierSourcesStep]
    D --> E[OwnerTeamStep - writes 'team']
    E --> F[OwnerNameStep - writes 'ownerName' NEW]
    F --> G[TierStep]
    G --> H[DescriptionStatsStep]
    H --> I[CustomPropertiesStep]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[EnrichmentPipeline] --> B[IdentityProjectionStep]
    B --> C[DescriptionSourcesStep]
    C --> D[TagAndTierSourcesStep]
    D --> E[OwnerTeamStep - writes 'team']
    E --> F[OwnerNameStep - writes 'ownerName' NEW]
    F --> G[TierStep]
    G --> H[DescriptionStatsStep]
    H --> I[CustomPropertiesStep]
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: ownerName missing field after https..."](https://github.com/open-metadata/openmetadata/commit/a2bd7c235fa488700789bdb2bae8e63a808e7a93) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43060695)</sub>

<!-- /greptile_comment -->