### PR TITLE
feat: generic app-metadata workflow context

### DIFF
--- a/ingestion/src/metadata/workflow/context/app_metadata_context.py
+++ b/ingestion/src/metadata/workflow/context/app_metadata_context.py
@@ -11,7 +11,7 @@ from typing import Any, Union
 
 from pydantic import Field
 
-from .base import BaseContext, BaseContextFieldsEnum  # noqa: TID252
+from metadata.workflow.context.base import BaseContext, BaseContextFieldsEnum
 
 
 class AppMetadataContextFieldsEnum(BaseContextFieldsEnum):

--- a/ingestion/src/metadata/workflow/context/app_metadata_context.py
+++ b/ingestion/src/metadata/workflow/context/app_metadata_context.py
@@ -1,0 +1,33 @@
+"""
+Application metadata context definition.
+
+Generic, domain-agnostic context that an AppRunner can populate to surface
+app-specific structured data on the run's PipelineStatus.metadata (dumped under
+the ``appMetadata`` key). Kept intentionally free-form so any application can
+attach run metadata without the framework needing to know its shape.
+"""
+
+from typing import Any, Union
+
+from pydantic import Field
+
+from .base import BaseContext, BaseContextFieldsEnum  # noqa: TID252
+
+
+class AppMetadataContextFieldsEnum(BaseContextFieldsEnum):
+    """
+    Enum defining all available app-metadata context fields.
+    """
+
+    DATA = "data"
+
+
+class AppMetadataContext(BaseContext):
+    """
+    Context for arbitrary application-provided run metadata.
+    """
+
+    data: Union[dict[str, Any], None] = Field(  # noqa: UP007
+        default=None,
+        description="Arbitrary structured metadata attached by the application runner",
+    )

--- a/ingestion/src/metadata/workflow/context/context_manager.py
+++ b/ingestion/src/metadata/workflow/context/context_manager.py
@@ -10,6 +10,7 @@ import threading
 from enum import Enum
 from typing import Any, Optional
 
+from metadata.workflow.context.app_metadata_context import AppMetadataContext
 from metadata.workflow.context.base import BaseContext, BaseContextFieldsEnum
 from metadata.workflow.context.workflow_context import WorkflowContext
 
@@ -25,6 +26,7 @@ class ContextsEnum(Enum):
     """
 
     WORKFLOW = "workflow"
+    APP_METADATA = "appMetadata"
 
 
 class ContextManager:
@@ -37,6 +39,7 @@ class ContextManager:
 
     # List of Contexts
     workflow: WorkflowContext = WorkflowContext()
+    appMetadata: AppMetadataContext = AppMetadataContext()  # noqa: N815
 
     def __new__(cls):
         if cls._instance is None:

--- a/ingestion/tests/unit/workflow/test_context_manager.py
+++ b/ingestion/tests/unit/workflow/test_context_manager.py
@@ -1,3 +1,7 @@
+from metadata.workflow.context.app_metadata_context import (
+    AppMetadataContext,
+    AppMetadataContextFieldsEnum,
+)
 from metadata.workflow.context.context_manager import ContextManager, ContextsEnum
 from metadata.workflow.context.workflow_context import (
     WorkflowContext,
@@ -47,3 +51,19 @@ def test_thread_safety():
     # The final value should be one of the set values
     final_value = ContextManager.get_context_attr(ContextsEnum.WORKFLOW, WorkflowContextFieldsEnum.SERVICE_NAME)
     assert final_value in {f"service_{i}" for i in range(10)}
+
+
+def test_app_metadata_context_registered():
+    ctx = ContextManager.get_context(ContextsEnum.APP_METADATA)
+    assert isinstance(ctx, AppMetadataContext)
+
+
+def test_app_metadata_dumps_under_app_metadata_key():
+    data = {"impact": {"proposed": 9, "autoApplied": 0, "awaitingReview": 9, "rejected": 0}}
+    ContextManager.set_context_attr(ContextsEnum.APP_METADATA, AppMetadataContextFieldsEnum.DATA, data)
+
+    dumped = ContextManager.dump_contexts()
+
+    assert dumped["appMetadata"]["data"] == data
+    # reset so we don't leak into other tests via the singleton
+    ContextManager.set_context_attr(ContextsEnum.APP_METADATA, AppMetadataContextFieldsEnum.DATA, None)

--- a/ingestion/tests/unit/workflow/test_context_manager.py
+++ b/ingestion/tests/unit/workflow/test_context_manager.py
@@ -1,3 +1,5 @@
+import pytest
+
 from metadata.workflow.context.app_metadata_context import (
     AppMetadataContext,
     AppMetadataContextFieldsEnum,
@@ -58,12 +60,18 @@ def test_app_metadata_context_registered():
     assert isinstance(ctx, AppMetadataContext)
 
 
-def test_app_metadata_dumps_under_app_metadata_key():
+@pytest.fixture
+def reset_app_metadata():
+    """ContextManager is a process-wide singleton, so app-metadata state set by one
+    test would otherwise leak into every test that runs after it."""
+    yield
+    ContextManager.set_context_attr(ContextsEnum.APP_METADATA, AppMetadataContextFieldsEnum.DATA, None)
+
+
+def test_app_metadata_dumps_under_app_metadata_key(reset_app_metadata):
     data = {"impact": {"proposed": 9, "autoApplied": 0, "awaitingReview": 9, "rejected": 0}}
     ContextManager.set_context_attr(ContextsEnum.APP_METADATA, AppMetadataContextFieldsEnum.DATA, data)
 
     dumped = ContextManager.dump_contexts()
 
     assert dumped["appMetadata"]["data"] == data
-    # reset so we don't leak into other tests via the singleton
-    ContextManager.set_context_attr(ContextsEnum.APP_METADATA, AppMetadataContextFieldsEnum.DATA, None)


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:

Fixes [open-metadata/openmetadata-collate#4937](https://github.com/open-metadata/openmetadata-collate/issues/4937)
<!--
Linking an issue is REQUIRED. Replace <issue-number> with the GitHub issue number this PR addresses
(e.g., `Fixes #12345`). GitHub will auto-link it. If no issue exists, please open one first so the
problem and design can be discussed before review.
-->

<!--
Short blurb explaining:
- What changes did you make?
- Why did you make them?
-->

I added a generic `AppMetadataContext` to the ingestion workflow `ContextManager` so an `AppRunner` can attach arbitrary structured, app-specific data to a run, and have the framework persist it on `PipelineStatus.metadata` under the `appMetadata` key.

Today an application has no supported way to surface its own run metadata. The framework rebuilds `PipelineStatus.metadata` from the `ContextManager` on the end-of-run status write, so anything an app writes onto the run status directly is clobbered. This adds the missing context so apps can write through the same path the framework already uses. The context is intentionally free-form (`data: dict[str, Any] | None`), so the framework does not need to know the shape of what any given application attaches.

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->

- [x] Improvement


#
### High-level design:
<!--
REQUIRED for large PRs (new features, refactors, breaking changes, or anything touching >5 files).
Skip for small bug fixes and trivial changes.

Cover:
- Architecture / approach you took and why
- Key components or files added/changed and how they interact
- Alternatives considered and why you rejected them
- Any migration, backward-compatibility, or rollout concerns
- Diagrams or links to design docs / RFCs if available
-->

N/A — small change. <!-- Or fill in the design above -->
Three files: a new `AppMetadataContext` (mirrors the existing `WorkflowContext` shape), its registration in `ContextsEnum` / `ContextManager`, and unit tests.

#
### Tests:

#### Use cases covered
<!--
List the user-visible scenarios this PR exercises. Example:
- User with Admin role can create a Glossary Term with a parent term
- Ingestion run for Snowflake correctly extracts row counts for partitioned tables
-->

- An `AppRunner` calls `ContextManager.set_context_attr(ContextsEnum.APP_METADATA, AppMetadataContextFieldsEnum.DATA, {...})` and the payload appears under `appMetadata.data` in the dumped contexts written to `PipelineStatus.metadata`.
- `ContextManager.get_context(ContextsEnum.APP_METADATA)` returns an `AppMetadataContext` (context is registered on the singleton).

#### Unit tests
<!--
- [ ] I added unit tests for the new/changed logic.
- Files added/updated:
- Coverage on changed classes (run `mvn jacoco:report` for backend, `yarn test:coverage` for UI,
  `make unit_ingestion` for ingestion). Target is 90% line coverage on changed classes.
- Coverage %: <e.g., 92% on EntityRepository.java>
-->

- [x] I added unit tests for the new/changed logic.
- Files updated: `ingestion/tests/unit/workflow/test_context_manager.py` (`test_app_metadata_context_registered`, `test_app_metadata_dumps_under_app_metadata_key`)

#### Backend integration tests
<!--
- [ ] I added integration tests in `openmetadata-integration-tests/` for new/changed API endpoints.
- [ ] Not applicable (no backend API changes).
- Files added/updated:
-->
- [x] Not applicable (no backend API changes).
#### Ingestion integration tests
<!--
- [ ] I added/updated ingestion integration tests for connector changes.
- [ ] Not applicable (no ingestion changes).
- Files added/updated:
-->
- [x] Not applicable (no connector changes; covered by unit tests).
#### Playwright (UI) tests
<!--
- [ ] I added Playwright E2E tests under `openmetadata-ui/.../ui/playwright/` for UI changes.
- [ ] Not applicable (no UI changes).
- Files added/updated:
-->
- [x] Not applicable (no UI changes).
#### Manual testing performed
<!--
List the manual test steps you performed before requesting review. Example:
1. Started local stack via `./docker/run_local_docker.sh -m ui -d mysql`
2. Logged in as admin, created entity X, verified Y appears in the UI
3. Triggered ingestion for Snowflake source, confirmed lineage edges in the explore page
-->

#
### UI screen recording / screenshots:
<!--
REQUIRED for any PR that changes the UI. Drag-and-drop a short screen recording (.mov / .mp4 / .gif)
demonstrating the change end-to-end, plus before/after screenshots where relevant.
Mark "Not applicable" if there are no UI changes.
-->

Not applicable. <!-- Or attach recording/screenshots above -->

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] My PR title is `Fixes [#4937](https://github.com/open-metadata/openmetadata-collate/issues/4937): Populate AI Automation run-impact snapshot`
- [x] My PR is linked to a GitHub issue via `Fixes [#4937](https://github.com/open-metadata/openmetadata-collate/issues/4937)` above.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] For JSON Schema changes: I updated the migration scripts or explained why it is not needed. (No JSON Schema change — this is a Python-side workflow context.)
- [ ] For UI changes: I attached a screen recording and/or screenshots above.
- [x] I have added tests (unit / integration / Playwright as applicable) and listed them above.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->
- [x] I have added tests around the new logic.
<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR introduces a generic `AppMetadataContext` that `AppRunner` implementations can use to attach arbitrary structured metadata to a workflow run, which the framework then persists under the `appMetadata` key in `PipelineStatus.metadata` via the existing `dump_contexts` path. Previously, apps writing directly to run status had their data clobbered when the framework rebuilt `PipelineStatus.metadata` from `ContextManager`.

- **`app_metadata_context.py`**: New `AppMetadataContext` Pydantic model with a free-form `data: dict[str, Any] | None` field and its corresponding `AppMetadataContextFieldsEnum`, mirroring the existing `WorkflowContext` shape.
- **`context_manager.py`**: Adds `APP_METADATA = \"appMetadata\"` to `ContextsEnum` and registers `appMetadata: AppMetadataContext` as a class-level attribute on `ContextManager`, following the identical pattern already used for `workflow`.
- **`test_context_manager.py`**: Two new tests — one asserting the context is registered, and one verifying the dump key — with a `yield`-based pytest fixture handling singleton cleanup correctly.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge; the change is additive, follows established patterns, and is well-tested.

The PR adds one new context type and wires it into the singleton following an identical pattern already in production for WorkflowContext. No existing code paths are modified, dump_contexts correctly excludes the new context when data is None, and the tests use a pytest yield fixture that guarantees teardown even on assertion failure.

No files require special attention.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| ingestion/src/metadata/workflow/context/app_metadata_context.py | New context class; correctly mirrors WorkflowContext shape with a free-form `data` field. Uses absolute imports consistent with context_manager.py. |
| ingestion/src/metadata/workflow/context/context_manager.py | Adds APP_METADATA enum entry and class-level appMetadata attribute; follows existing pattern for WORKFLOW/WorkflowContext exactly. No logic changes to dump_contexts or thread-safety mechanisms. |
| ingestion/tests/unit/workflow/test_context_manager.py | Two new tests with proper yield-fixture teardown; pytest guarantees teardown runs even on assertion failure, so singleton leak is handled correctly. |

</details>

<sub>Reviews (3): Last reviewed commit: ["Merge branch &#39;main&#39; into feat/ai-automat..."](https://github.com/open-metadata/openmetadata/commit/82071352f295847b5e5df1d9dd61be9ba94887b5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43065194)</sub>

<!-- /greptile_comment -->