### PR TITLE
fix(policy): grant application bots CreateTask so automations can create suggestions

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/migration/mysql/v200/Migration.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/migration/mysql/v200/Migration.java
@@ -2,6 +2,7 @@ package org.openmetadata.service.migration.mysql.v200;
 
 import static org.openmetadata.service.jdbi3.locator.ConnectionType.MYSQL;
 import static org.openmetadata.service.migration.utils.v1130.MigrationUtil.addTableColumnSearchSettings;
+import static org.openmetadata.service.migration.utils.v200.MigrationUtil.addCreateTaskOperationToApplicationBotPolicy;
 import static org.openmetadata.service.migration.utils.v200.MigrationUtil.addCreateTaskRuleToDataConsumerPolicy;
 import static org.openmetadata.service.migration.utils.v200.MigrationUtil.addTaskAuthorPolicyToDataConsumerRole;
 import static org.openmetadata.service.migration.utils.v200.MigrationUtil.addTaskRuleToDataConsumerPolicy;
@@ -43,6 +44,7 @@ public class Migration extends MigrationProcessImpl {
     addTaskAuthorPolicyToDataConsumerRole(collectionDAO);
     addCreateTaskRuleToDataConsumerPolicy(collectionDAO);
     addTaskRuleToDataConsumerPolicy(collectionDAO);
+    addCreateTaskOperationToApplicationBotPolicy(collectionDAO);
     SearchIndexMappingsSeeder.seedIfAbsent();
 
     // Wrap WorkflowHandler init + task workflow steps so a handler failure logs and continues

--- a/openmetadata-service/src/main/java/org/openmetadata/service/migration/postgres/v200/Migration.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/migration/postgres/v200/Migration.java
@@ -2,6 +2,7 @@ package org.openmetadata.service.migration.postgres.v200;
 
 import static org.openmetadata.service.jdbi3.locator.ConnectionType.POSTGRES;
 import static org.openmetadata.service.migration.utils.v1130.MigrationUtil.addTableColumnSearchSettings;
+import static org.openmetadata.service.migration.utils.v200.MigrationUtil.addCreateTaskOperationToApplicationBotPolicy;
 import static org.openmetadata.service.migration.utils.v200.MigrationUtil.addCreateTaskRuleToDataConsumerPolicy;
 import static org.openmetadata.service.migration.utils.v200.MigrationUtil.addTaskAuthorPolicyToDataConsumerRole;
 import static org.openmetadata.service.migration.utils.v200.MigrationUtil.addTaskRuleToDataConsumerPolicy;
@@ -43,6 +44,7 @@ public class Migration extends MigrationProcessImpl {
     addTaskAuthorPolicyToDataConsumerRole(collectionDAO);
     addCreateTaskRuleToDataConsumerPolicy(collectionDAO);
     addTaskRuleToDataConsumerPolicy(collectionDAO);
+    addCreateTaskOperationToApplicationBotPolicy(collectionDAO);
     SearchIndexMappingsSeeder.seedIfAbsent();
 
     // Wrap WorkflowHandler init + task workflow steps so a handler failure logs and continues

--- a/openmetadata-service/src/main/java/org/openmetadata/service/migration/utils/v200/MigrationUtil.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/migration/utils/v200/MigrationUtil.java
@@ -7,6 +7,7 @@ import static org.openmetadata.service.governance.workflows.Workflow.RELATED_ENT
 import static org.openmetadata.service.governance.workflows.Workflow.UPDATED_BY_VARIABLE;
 import static org.openmetadata.service.governance.workflows.WorkflowVariableHandler.getNamespacedVariableName;
 import static org.openmetadata.service.governance.workflows.elements.TriggerFactory.getTriggerWorkflowId;
+import static org.openmetadata.service.migration.utils.v160.MigrationUtil.addOperationsToPolicyRule;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
@@ -356,6 +357,23 @@ public class MigrationUtil {
       LOG.error(
           "Failed to add {} to {}: {}", TASK_RULE_NAME, DATA_CONSUMER_POLICY, ex.getMessage(), ex);
     }
+  }
+
+  /**
+   * Backfill the {@code CreateTask} operation onto an existing tenant's {@code ApplicationBotPolicy}.
+   * The operation is added to the seed JSON in this release but seed policies are
+   * create-if-not-exists, so without this migration upgraded deployments would leave application
+   * bots (e.g. the AI automation bot) unable to file suggestions as task entities — {@link
+   * org.openmetadata.service.resources.tasks.TaskResource} rejects the create with 403. Idempotent:
+   * {@link org.openmetadata.service.migration.utils.v160.MigrationUtil#addOperationsToPolicyRule}
+   * skips the operation when it is already present.
+   */
+  public static void addCreateTaskOperationToApplicationBotPolicy(CollectionDAO collectionDAO) {
+    addOperationsToPolicyRule(
+        "ApplicationBotPolicy",
+        "ApplicationBotRule-Allow",
+        List.of(MetadataOperation.CREATE_TASK),
+        collectionDAO);
   }
 
   private static Policy ensureTaskAuthorPolicySeeded(PolicyRepository repository) {

--- a/openmetadata-service/src/main/resources/json/data/policy/ApplicationBotPolicy.json
+++ b/openmetadata-service/src/main/resources/json/data/policy/ApplicationBotPolicy.json
@@ -11,7 +11,7 @@
       "name": "ApplicationBotRule-Allow",
       "description" : "Allow application bots to perform operations on data entities including triggering agents",
       "resources" : ["All"],
-      "operations": ["Create", "EditAll", "ViewAll", "Delete", "Trigger"],
+      "operations": ["Create", "EditAll", "ViewAll", "Delete", "Trigger", "CreateTask"],
       "effect": "allow"
     },
     {


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:

Fixes [open-metadata/ai-platform#856](https://github.com/open-metadata/ai-platform/issues/856)
<!--
Linking an issue is REQUIRED. Replace <issue-number> with the GitHub issue number this PR addresses
(e.g., `Fixes #12345`). GitHub will auto-link it. If no issue exists, please open one first so the
problem and design can be discussed before review.
-->

<!--
Short blurb explaining:
- What changes did you make?
- Why did you make them?
-->

- Application bots lacked the `CreateTask` permission, so AI automations (e.g. the Documentation Agent) failed to create description suggestions via `POST /tasks` and silently persisted nothing. Added `CreateTask` to `ApplicationBotPolicy` so automation bots can create suggestions.
- Also added a v200 data migration (addCreateTaskOperationToApplicationBotPolicy) so existing deployments get the grant on upgrade as seed policies are create-if-not-exists and won't patch a policy already in the DB.
#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix


#
### High-level design:
<!--
REQUIRED for large PRs (new features, refactors, breaking changes, or anything touching >5 files).
Skip for small bug fixes and trivial changes.

Cover:
- Architecture / approach you took and why
- Key components or files added/changed and how they interact
- Alternatives considered and why you rejected them
- Any migration, backward-compatibility, or rollout concerns
- Diagrams or links to design docs / RFCs if available
-->

N/A — small change. <!-- Or fill in the design above -->

#
### Tests:

#### Use cases covered
<!--
List the user-visible scenarios this PR exercises. Example:
- User with Admin role can create a Glossary Term with a parent term
- Ingestion run for Snowflake correctly extracts row counts for partitioned tables
-->

#### Unit tests
<!--
- [ ] I added unit tests for the new/changed logic.
- Files added/updated:
- Coverage on changed classes (run `mvn jacoco:report` for backend, `yarn test:coverage` for UI,
  `make unit_ingestion` for ingestion). Target is 90% line coverage on changed classes.
- Coverage %: <e.g., 92% on EntityRepository.java>
-->

#### Backend integration tests
<!--
- [ ] I added integration tests in `openmetadata-integration-tests/` for new/changed API endpoints.
- [ ] Not applicable (no backend API changes).
- Files added/updated:
-->
- [x] Not applicable (declarative policy config, no code path; task-creation authz already covered by existing OSS tests).
#### Ingestion integration tests
<!--
- [ ] I added/updated ingestion integration tests for connector changes.
- [ ] Not applicable (no ingestion changes).
- Files added/updated:
-->
- [x] Not applicable.

#### Playwright (UI) tests
<!--
- [ ] I added Playwright E2E tests under `openmetadata-ui/.../ui/playwright/` for UI changes.
- [ ] Not applicable (no UI changes).
- Files added/updated:
-->
- [x] Not applicable (no UI changes).
#### Manual testing performed
<!--
List the manual test steps you performed before requesting review. Example:
1. Started local stack via `./docker/run_local_docker.sh -m ui -d mysql`
2. Logged in as admin, created entity X, verified Y appears in the UI
3. Triggered ingestion for Snowflake source, confirmed lineage edges in the explore page
-->

#
### UI screen recording / screenshots:
<!--
REQUIRED for any PR that changes the UI. Drag-and-drop a short screen recording (.mov / .mp4 / .gif)
demonstrating the change end-to-end, plus before/after screenshots where relevant.
Mark "Not applicable" if there are no UI changes.
-->

Not applicable. <!-- Or attach recording/screenshots above -->

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [x] For JSON Schema changes: added a v200 data migration to backfill CreateTask onto the persisted ApplicationBotPolicy for upgrades (seed JSON only covers fresh installs).
- [ ] For UI changes: I attached a screen recording and/or screenshots above.
- [ ] I have added tests (unit / integration / Playwright as applicable) and listed them above.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a permissions gap where application bots (e.g., the AI Documentation Agent) lacked `CreateTask` authorization, causing silent 403 failures when attempting to create description suggestions via `POST /tasks`.

- **Seed data**: Adds `CreateTask` to `ApplicationBotPolicy.json` so fresh installs include the permission.
- **Migration**: Adds `addCreateTaskOperationToApplicationBotPolicy` in `v200/MigrationUtil.java` (backed by the existing idempotent `addOperationsToPolicyRule` helper from v160), and wires it into both the MySQL and Postgres v200 migration classes so existing deployments are patched on upgrade.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is small, additive, and idempotent; both fresh installs and existing upgraded deployments will receive the CreateTask permission for application bots.

The fix correctly addresses both code paths: the seed JSON handles new installations, and the v200 migration (wired into both MySQL and Postgres runners) patches existing deployments using the well-proven addOperationsToPolicyRule helper from v160, which handles the not-found and already-present cases gracefully.

No files require special attention.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-service/src/main/resources/json/data/policy/ApplicationBotPolicy.json | Adds CreateTask to the ApplicationBotRule-Allow operations list for fresh installations. |
| openmetadata-service/src/main/java/org/openmetadata/service/migration/utils/v200/MigrationUtil.java | Adds addCreateTaskOperationToApplicationBotPolicy — a well-documented, idempotent method that patches existing deployments by delegating to the established v160.addOperationsToPolicyRule helper. |
| openmetadata-service/src/main/java/org/openmetadata/service/migration/mysql/v200/Migration.java | Wires the new migration method into the MySQL v200 migration execution sequence. |
| openmetadata-service/src/main/java/org/openmetadata/service/migration/postgres/v200/Migration.java | Wires the new migration method into the Postgres v200 migration execution sequence. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant OM as OpenMetadata Server
    participant M as v200 Migration
    participant MU as MigrationUtil (v200)
    participant H as addOperationsToPolicyRule (v160)
    participant DB as Policy Database

    OM->>M: runMigration()
    M->>MU: addCreateTaskOperationToApplicationBotPolicy(collectionDAO)
    MU->>H: addOperationsToPolicyRule("ApplicationBotPolicy", "ApplicationBotRule-Allow", [CREATE_TASK], collectionDAO)
    H->>DB: findByName("ApplicationBotPolicy")
    DB-->>H: Policy (existing rules)
    H->>H: Check if CREATE_TASK already present (idempotent)
    H->>DB: policyDAO.update(id, fqn, updatedJson)
    DB-->>H: OK
    H-->>MU: Done
    MU-->>M: Done

    Note over OM,DB: Fresh installs: ApplicationBotPolicy.json seed already includes CreateTask
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant OM as OpenMetadata Server
    participant M as v200 Migration
    participant MU as MigrationUtil (v200)
    participant H as addOperationsToPolicyRule (v160)
    participant DB as Policy Database

    OM->>M: runMigration()
    M->>MU: addCreateTaskOperationToApplicationBotPolicy(collectionDAO)
    MU->>H: addOperationsToPolicyRule("ApplicationBotPolicy", "ApplicationBotRule-Allow", [CREATE_TASK], collectionDAO)
    H->>DB: findByName("ApplicationBotPolicy")
    DB-->>H: Policy (existing rules)
    H->>H: Check if CREATE_TASK already present (idempotent)
    H->>DB: policyDAO.update(id, fqn, updatedJson)
    DB-->>H: OK
    H-->>MU: Done
    MU-->>M: Done

    Note over OM,DB: Fresh installs: ApplicationBotPolicy.json seed already includes CreateTask
```

</a>
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(migration): backfill CreateTask on A..."](https://github.com/open-metadata/openmetadata/commit/1e28e26b8a1fc1f731a62671ace617b976b422fb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43097083)</sub>

<!-- /greptile_comment -->