### PR TITLE
fix: use sample config for data quality sample data ingestion

### DIFF
--- a/ingestion/src/metadata/data_quality/interface/test_suite_interface.py
+++ b/ingestion/src/metadata/data_quality/interface/test_suite_interface.py
@@ -26,6 +26,9 @@ from metadata.data_quality.validations.runtime_param_setter.param_setter import 
 from metadata.data_quality.validations.runtime_param_setter.param_setter_factory import (
     RuntimeParameterSetterFactory,
 )
+from metadata.generated.schema.configuration.profilerConfiguration import (
+    SampleDataIngestionConfig,
+)
 from metadata.generated.schema.entity.data.table import Table
 from metadata.generated.schema.entity.services.databaseService import DatabaseConnection
 from metadata.generated.schema.tests.basic import TestCaseStatus
@@ -51,6 +54,7 @@ class TestSuiteInterface(ABC):
         sampler: SamplerInterface,
         table_entity: Table,
         validator_builder: Type[ValidatorBuilder],  # noqa: UP006
+        sample_data_config: Optional[SampleDataIngestionConfig] = None,  # noqa: UP045
     ):
         """Required attribute for the interface"""
         self.ometa_client = ometa_client
@@ -58,6 +62,7 @@ class TestSuiteInterface(ABC):
         self.table_entity = table_entity
         self.sampler = sampler
         self.validator_builder_class = validator_builder
+        self.sample_data_config = sample_data_config
 
     @classmethod
     def create(
@@ -106,6 +111,11 @@ class TestSuiteInterface(ABC):
         """
         cls.runtime_params_setter_fact = class_fact
 
+    def _should_collect_failed_rows_sample(self) -> bool:
+        """Failed row samples are persisted sample data. Skip collecting them
+        when the global profiler configuration disables storing sample data."""
+        return self.sample_data_config is None or bool(self.sample_data_config.storeSampleData)
+
     def run_test_case(self, test_case: TestCase) -> Optional[TestCaseResultResponse]:  # noqa: UP045
         """run column data quality tests"""
         runtime_params_setter_fact: RuntimeParameterSetterFactory = self._get_runtime_params_setter_fact()  # type: ignore
@@ -133,7 +143,14 @@ class TestSuiteInterface(ABC):
         try:
             test_result = validator.run_validation()
             response = TestCaseResultResponse(testCaseResult=test_result, testCase=test_case)
-            validator.result_with_failed_samples(response)
+            if self._should_collect_failed_rows_sample():
+                validator.result_with_failed_samples(response)
+            else:
+                logger.debug(
+                    "Global profiler configuration disables storing sample data. "
+                    "Skipping failed rows sample collection for %s.",
+                    test_case.name.root,
+                )
             return response  # noqa: TRY300
         except Exception as err:
             message = f"Error executing {test_case.testDefinition.fullyQualifiedName} - {err}"

--- a/ingestion/src/metadata/data_quality/runner/base_test_suite_source.py
+++ b/ingestion/src/metadata/data_quality/runner/base_test_suite_source.py
@@ -19,6 +19,10 @@ from typing import Optional, cast
 from metadata.data_quality.builders.validator_builder import ValidatorBuilder
 from metadata.data_quality.interface.test_suite_interface import TestSuiteInterface
 from metadata.data_quality.runner.core import DataTestsRunner
+from metadata.generated.schema.configuration.profilerConfiguration import (
+    ProfilerConfiguration,
+    SampleDataIngestionConfig,
+)
 from metadata.generated.schema.entity.data.table import Table
 from metadata.generated.schema.entity.services.connections.database.bigQueryConnection import (
     BigQueryConnection,
@@ -46,11 +50,14 @@ from metadata.sampler.sampler_config import DatabaseSamplerConfig
 from metadata.sampler.sampler_interface import SamplerInterface  # noqa: TC001
 from metadata.utils.bigquery_utils import copy_service_config
 from metadata.utils.constants import SAMPLE_DATA_DEFAULT_COUNT
+from metadata.utils.logger import test_suite_logger
 from metadata.utils.profiler_utils import get_context_entities
 from metadata.utils.service_spec.service_spec import (
     import_sampler_class,
     import_test_suite_class,
 )
+
+logger = test_suite_logger()
 
 
 class BaseTestSuiteRunner:
@@ -160,8 +167,21 @@ class BaseTestSuiteRunner:
             sampler=sampler_interface,
             table_entity=self.entity,
             validator_builder=self.validator_builder_class,
+            sample_data_config=self._get_sample_data_config(),
         )
         return self.interface
+
+    def _get_sample_data_config(self) -> SampleDataIngestionConfig | None:
+        """Fetch the global sample data ingestion config from the profiler settings."""
+        sample_data_config = None
+        try:
+            settings = self.ometa_client.get_profiler_config_settings()
+            if settings and settings.config_value:
+                profiler_config = cast("ProfilerConfiguration", settings.config_value)
+                sample_data_config = profiler_config.sampleDataConfig
+        except Exception as exc:
+            logger.debug(f"Could not fetch global profiler config: {exc}")
+        return sample_data_config
 
     def get_data_quality_runner(self) -> DataTestsRunner:
         """Get a data quality runner


### PR DESCRIPTION
### Describe your changes:
Use sampling preference for data quality sample

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [x] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### High-level design:
<!--
REQUIRED for large PRs (new features, refactors, breaking changes, or anything touching >5 files).
Skip for small bug fixes and trivial changes.

Cover:
- Architecture / approach you took and why
- Key components or files added/changed and how they interact
- Alternatives considered and why you rejected them
- Any migration, backward-compatibility, or rollout concerns
- Diagrams or links to design docs / RFCs if available
-->

N/A — small change. <!-- Or fill in the design above -->

#
### Tests:

#### Use cases covered
<!--
List the user-visible scenarios this PR exercises. Example:
- User with Admin role can create a Glossary Term with a parent term
- Ingestion run for Snowflake correctly extracts row counts for partitioned tables
-->

#### Unit tests
<!--
- [ ] I added unit tests for the new/changed logic.
- Files added/updated:
- Coverage on changed classes (run `mvn jacoco:report` for backend, `yarn test:coverage` for UI,
  `make unit_ingestion` for ingestion). Target is 90% line coverage on changed classes.
- Coverage %: <e.g., 92% on EntityRepository.java>
-->

#### Backend integration tests
<!--
- [ ] I added integration tests in `openmetadata-integration-tests/` for new/changed API endpoints.
- [ ] Not applicable (no backend API changes).
- Files added/updated:
-->

#### Ingestion integration tests
<!--
- [ ] I added/updated ingestion integration tests for connector changes.
- [ ] Not applicable (no ingestion changes).
- Files added/updated:
-->

#### Playwright (UI) tests
<!--
- [ ] I added Playwright E2E tests under `openmetadata-ui/.../ui/playwright/` for UI changes.
- [ ] Not applicable (no UI changes).
- Files added/updated:
-->

#### Manual testing performed
<!--
List the manual test steps you performed before requesting review. Example:
1. Started local stack via `./docker/run_local_docker.sh -m ui -d mysql`
2. Logged in as admin, created entity X, verified Y appears in the UI
3. Triggered ingestion for Snowflake source, confirmed lineage edges in the explore page
-->

#
### UI screen recording / screenshots:
<!--
REQUIRED for any PR that changes the UI. Drag-and-drop a short screen recording (.mov / .mp4 / .gif)
demonstrating the change end-to-end, plus before/after screenshots where relevant.
Mark "Not applicable" if there are no UI changes.
-->

Not applicable. <!-- Or attach recording/screenshots above -->

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.
- [ ] For UI changes: I attached a screen recording and/or screenshots above.
- [ ] I have added tests (unit / integration / Playwright as applicable) and listed them above.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR applies the global sample-data preference to data quality failed-row collection. The main changes are:

- Fetches `sampleDataConfig` from profiler settings in the test suite runner.
- Passes that config into the data quality test suite interface.
- Skips failed-row sample collection when `storeSampleData` is disabled.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The changed sample-data gate needs a fix before merging.

- The settings lookup failure path can still collect failed-row samples after storage was disabled.
- The new gate skips extra custom SQL result metadata along with sample storage.

ingestion/src/metadata/data_quality/runner/base_test_suite_source.py and ingestion/src/metadata/data_quality/interface/test_suite_interface.py
</details>

<details open><summary><h3>Security Review</h3></summary>

The settings-read failure path can still allow failed-row sample data to be persisted after sample storage was disabled.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| ingestion/src/metadata/data_quality/interface/test_suite_interface.py | Adds a `storeSampleData` gate around failed-row sample collection. |
| ingestion/src/metadata/data_quality/runner/base_test_suite_source.py | Fetches profiler sample-data settings and passes them to the test suite interface. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: use sample config for data quality ..."](https://github.com/open-metadata/openmetadata/commit/71526fed17d1fda2250eb7cffcea03ba16cbe65d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43155003)</sub>

> Greptile also left **2 inline comments** on this PR.

<details><summary><h4>Context used (3)</h4></summary>

- Context used - CLAUDE.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=52f0d9d9-cad1-4e7d-b070-de181a0aa5e7))
- Context used - openmetadata-ui-core-components/CLAUDE.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=41754627-b2bf-474b-8082-f37ef1a07013))
- Context used - AGENTS.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=ef262f5f-911f-44f3-8d2d-e9cb1579c8c8))
</details>

<!-- /greptile_comment -->