### PR TITLE
test(playwright): mark two flaky specs as fixme

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/Glossary.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/Glossary.spec.ts
@@ -1217,50 +1217,60 @@ test.describe('Glossary tests', () => {
     }
   });
 
-  test('Request description task for Glossary Term', async ({ browser }) => {
-    const { page, afterAction, apiContext } = await performAdminLogin(browser);
-    const glossary1 = new Glossary();
-    const user1 = new UserClass();
-    const glossaryTerm1 = new GlossaryTerm(glossary1);
-    glossary1.data.terms = [glossaryTerm1];
-
-    try {
-      await user1.create(apiContext);
-      await glossary1.create(apiContext);
-      await glossaryTerm1.create(apiContext);
-      await sidebarClick(page, SidebarItem.GLOSSARY);
-      await selectActiveGlossary(page, glossary1.data.displayName);
-      await selectActiveGlossaryTerm(page, glossaryTerm1.data.displayName);
-
-      const value: TaskDetails = {
-        term: glossaryTerm1.data.name,
-        assignee: user1.responseData.name,
-      };
-
-      await page.getByTestId('request-description').click();
-
-      await createDescriptionTaskForGlossary(page, value, glossaryTerm1, false);
-
-      const taskResolve = waitForTaskResolveResponse(page);
-      await page.getByTestId('approve-button').first().click();
-      await taskResolve;
-
-      await redirectToHomePage(page);
-      await sidebarClick(page, SidebarItem.GLOSSARY);
-      await selectActiveGlossary(page, glossary1.data.displayName);
-      await selectActiveGlossaryTerm(page, glossaryTerm1.data.displayName);
-
-      const viewerContainerText = await page.textContent(
-        '[data-testid="viewer-container"]'
+  test.fixme(
+    'Request description task for Glossary Term',
+    async ({ browser }) => {
+      const { page, afterAction, apiContext } = await performAdminLogin(
+        browser
       );
+      const glossary1 = new Glossary();
+      const user1 = new UserClass();
+      const glossaryTerm1 = new GlossaryTerm(glossary1);
+      glossary1.data.terms = [glossaryTerm1];
 
-      expect(viewerContainerText).toContain('Updated description');
-    } finally {
-      await glossaryTerm1.delete(apiContext);
-      await glossary1.delete(apiContext);
-      await afterAction();
+      try {
+        await user1.create(apiContext);
+        await glossary1.create(apiContext);
+        await glossaryTerm1.create(apiContext);
+        await sidebarClick(page, SidebarItem.GLOSSARY);
+        await selectActiveGlossary(page, glossary1.data.displayName);
+        await selectActiveGlossaryTerm(page, glossaryTerm1.data.displayName);
+
+        const value: TaskDetails = {
+          term: glossaryTerm1.data.name,
+          assignee: user1.responseData.name,
+        };
+
+        await page.getByTestId('request-description').click();
+
+        await createDescriptionTaskForGlossary(
+          page,
+          value,
+          glossaryTerm1,
+          false
+        );
+
+        const taskResolve = waitForTaskResolveResponse(page);
+        await page.getByTestId('approve-button').first().click();
+        await taskResolve;
+
+        await redirectToHomePage(page);
+        await sidebarClick(page, SidebarItem.GLOSSARY);
+        await selectActiveGlossary(page, glossary1.data.displayName);
+        await selectActiveGlossaryTerm(page, glossaryTerm1.data.displayName);
+
+        const viewerContainerText = await page.textContent(
+          '[data-testid="viewer-container"]'
+        );
+
+        expect(viewerContainerText).toContain('Updated description');
+      } finally {
+        await glossaryTerm1.delete(apiContext);
+        await glossary1.delete(apiContext);
+        await afterAction();
+      }
     }
-  });
+  );
 
   test('Request tags for Glossary', async ({ browser }) => {
     test.slow(true);

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/SearchSettings.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/SearchSettings.spec.ts
@@ -478,7 +478,7 @@ test.describe('Search Settings', () => {
       await redirectToHomePage(page);
     });
 
-    test('Configure column search field settings', async ({ page }) => {
+    test.fixme('Configure column search field settings', async ({ page }) => {
       await settingClick(page, GlobalSettingOptions.SEARCH_SETTINGS);
 
       const columnCard = page.getByTestId('preferences.search-settings.column');


### PR DESCRIPTION
## Summary

Marks two flaky Playwright E2E specs as `test.fixme` to unblock CI while their flakiness is investigated separately:

- `Glossary tests › Request description task for Glossary Term`
- `Search Settings › Column Search Settings Tests › Configure column search field settings`

The large diff in `Glossary.spec.ts` is purely Prettier reflow from the added indentation when wrapping the test body under `test.fixme(...)` — no logic changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR marks two flaky Playwright specs as skipped while the failures are investigated.

- Wraps the glossary term description task test with `test.fixme`.
- Wraps the column search settings test with `test.fixme`.
- Leaves the test bodies otherwise unchanged apart from formatting.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge.

- No blocking issues found in the changed code.

</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/Glossary.spec.ts | Changes the glossary term description task E2E test from `test` to `test.fixme`; no dependent setup or cleanup path was found. |
| openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/SearchSettings.spec.ts | Changes the column search settings E2E test from `test` to `test.fixme`; neighboring tests appear self-contained. |

</details>

<sub>Reviews (1): Last reviewed commit: ["test(playwright): mark two flaky specs a..."](https://github.com/open-metadata/openmetadata/commit/40b68c4ec7e027e0d6b07ed0f4472bc7eb064ed6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43249876)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Context used - CLAUDE.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=52f0d9d9-cad1-4e7d-b070-de181a0aa5e7))
- Context used - openmetadata-ui-core-components/CLAUDE.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=41754627-b2bf-474b-8082-f37ef1a07013))
- Context used - AGENTS.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=ef262f5f-911f-44f3-8d2d-e9cb1579c8c8))
</details>

<!-- /greptile_comment -->