### PR TITLE
fix(migration): add audit_report_entity.requestSignature on existing 2.0.0 databases

### DIFF
--- a/bootstrap/sql/migrations/native/2.0.0/mysql/schemaChanges.sql
+++ b/bootstrap/sql/migrations/native/2.0.0/mysql/schemaChanges.sql
@@ -435,6 +435,47 @@ CREATE TABLE IF NOT EXISTS audit_report_entity (
     INDEX deleted_index (deleted),
     INDEX request_signature_index (requestSignature)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='AI Audit Report entities';
+
+-- For 2.0.0 environments that ran the CREATE TABLE above before the
+-- requestSignature generated column and its index were added inline. CREATE
+-- TABLE IF NOT EXISTS is a no-op on those environments so neither would ever
+-- appear. MySQL doesn't reliably support `ADD COLUMN IF NOT EXISTS` across
+-- 8.0 versions and has no `ADD KEY IF NOT EXISTS`, so guard both via
+-- information_schema.
+SET @ddl = (
+  SELECT IF(
+    EXISTS (
+      SELECT 1
+      FROM information_schema.columns
+      WHERE table_schema = DATABASE()
+        AND table_name = 'audit_report_entity'
+        AND column_name = 'requestSignature'
+    ),
+    'SELECT 1',
+    'ALTER TABLE audit_report_entity ADD COLUMN requestSignature VARCHAR(512) GENERATED ALWAYS AS (json_unquote(json_extract(`json`,_utf8mb4''$.requestSignature''))) STORED'
+  )
+);
+PREPARE stmt FROM @ddl;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+SET @ddl = (
+  SELECT IF(
+    EXISTS (
+      SELECT 1
+      FROM information_schema.statistics
+      WHERE table_schema = DATABASE()
+        AND table_name = 'audit_report_entity'
+        AND index_name = 'request_signature_index'
+    ),
+    'SELECT 1',
+    'ALTER TABLE audit_report_entity ADD KEY request_signature_index (requestSignature)'
+  )
+);
+PREPARE stmt FROM @ddl;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
 -- Database-backed user session store for multi-pod session management (issue #21971).
 CREATE TABLE IF NOT EXISTS `user_session` (
   `id` varchar(64) GENERATED ALWAYS AS (json_unquote(json_extract(`json`,_utf8mb4'$.id'))) STORED NOT NULL,

--- a/bootstrap/sql/migrations/native/2.0.0/postgres/schemaChanges.sql
+++ b/bootstrap/sql/migrations/native/2.0.0/postgres/schemaChanges.sql
@@ -386,6 +386,13 @@ CREATE TABLE IF NOT EXISTS audit_report_entity (
     PRIMARY KEY (id),
     UNIQUE (fqnHash)
 );
+-- For 2.0.0 environments that ran the CREATE TABLE above before the
+-- requestSignature generated column was added inline, attach it now. CREATE
+-- TABLE IF NOT EXISTS is a no-op on those environments so the column would
+-- never appear otherwise, and the index below would fail to create.
+ALTER TABLE audit_report_entity
+    ADD COLUMN IF NOT EXISTS requestSignature VARCHAR(512) GENERATED ALWAYS AS (json->>'requestSignature') STORED;
+
 CREATE INDEX IF NOT EXISTS audit_report_name_index ON audit_report_entity(name);
 CREATE INDEX IF NOT EXISTS audit_report_status_index ON audit_report_entity(status);
 CREATE INDEX IF NOT EXISTS audit_report_deleted_index ON audit_report_entity(deleted);


### PR DESCRIPTION
#29822 added the `requestSignature` column and its index inside `CREATE TABLE IF NOT EXISTS audit_report_entity (...)` in the 2.0.0 migration. The table was already created by #29710, so on any database that ran the 2.0.0 migration between those two PRs the `CREATE TABLE` is a no-op and the column never appears.

Symptoms:
- **Postgres**: migration fails with `column "requestsignature" does not exist` on `CREATE INDEX audit_report_request_signature_index`. Server won't start.
- **MySQL**: migration silently succeeds (the index is declared inside the `CREATE TABLE`), but neither the column nor the index exists. `CollectionDAO.getInFlightAuditReport` then fails at runtime on `WHERE requestSignature = :signature`.

Fresh 1.13.x → 2.0.0 upgrades are unaffected — they create the table with the column inline.

## Fix

Add the column after the `CREATE TABLE`, following the same pattern already used in this file for `task_entity.approvedById`:

- Postgres: `ALTER TABLE ... ADD COLUMN IF NOT EXISTS`.
- MySQL: `information_schema`-guarded prepared statements for the column and the index (`ADD COLUMN IF NOT EXISTS` only landed in 8.0.29, and there is no `ADD KEY IF NOT EXISTS`).

## Testing

- Postgres: applied against a legacy table (no column) and re-run — column and index created, re-run is a no-op.
- MySQL 8.0: applied against both a legacy table and a fresh `CREATE TABLE` from this migration. Both end with an identical generated expression `json_unquote(json_extract(json,_utf8mb4'$.requestSignature'))` and the `request_signature_index`. Re-run is idempotent.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR repairs the 2.0.0 audit report migration for databases that already created the table. The main changes are:

- Adds an idempotent MySQL column repair for `audit_report_entity.requestSignature`.
- Adds an independent MySQL index repair for `request_signature_index`.
- Adds a PostgreSQL `ADD COLUMN IF NOT EXISTS` step before the request-signature index.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge.

- No blocking issues found in the changed code.

</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| bootstrap/sql/migrations/native/2.0.0/mysql/schemaChanges.sql | Adds guarded MySQL DDL to create the missing generated column and request-signature index for legacy 2.0.0 databases. |
| bootstrap/sql/migrations/native/2.0.0/postgres/schemaChanges.sql | Adds an idempotent PostgreSQL column repair before the existing request-signature index creation. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(migration): add audit\_report\_entity...."](https://github.com/open-metadata/openmetadata/commit/d3fc0d4644803ffcbc0cce064a7d9d920a6c5096) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43251522)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Context used - CLAUDE.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=52f0d9d9-cad1-4e7d-b070-de181a0aa5e7))
- Context used - openmetadata-ui-core-components/CLAUDE.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=41754627-b2bf-474b-8082-f37ef1a07013))
- Context used - AGENTS.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=ef262f5f-911f-44f3-8d2d-e9cb1579c8c8))
</details>

<!-- /greptile_comment -->