### PR TITLE
Fixes 29921: reopen Matching Fields panel after reload in SearchSettings spec

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/SearchSettings.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/SearchSettings.spec.ts
@@ -10,7 +10,7 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-import { test as base, expect, Page } from '@playwright/test';
+import { expect, Page, test as base } from '@playwright/test';
 import { PLAYWRIGHT_BASIC_TEST_TAG_OBJ } from '../../constant/config';
 import { GlobalSettingOptions } from '../../constant/settings';
 import { TableClass } from '../../support/entity/TableClass';

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/SearchSettings.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/SearchSettings.spec.ts
@@ -10,7 +10,7 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-import { expect, Page, test as base } from '@playwright/test';
+import { test as base, expect, Page } from '@playwright/test';
 import { PLAYWRIGHT_BASIC_TEST_TAG_OBJ } from '../../constant/config';
 import { GlobalSettingOptions } from '../../constant/settings';
 import { TableClass } from '../../support/entity/TableClass';
@@ -478,7 +478,7 @@ test.describe('Search Settings', () => {
       await redirectToHomePage(page);
     });
 
-    test.fixme('Configure column search field settings', async ({ page }) => {
+    test('Configure column search field settings', async ({ page }) => {
       await settingClick(page, GlobalSettingOptions.SEARCH_SETTINGS);
 
       const columnCard = page.getByTestId('preferences.search-settings.column');

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/SearchSettings.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/SearchSettings.spec.ts
@@ -522,6 +522,8 @@ test.describe('Search Settings', () => {
       await previewResponse;
       await waitForAllLoadersToDisappear(page);
 
+      await openMatchingFieldsPanel(page);
+
       await firstFieldContainer.click();
       await expect(highlightToggle).toHaveAttribute(
         'aria-checked',


### PR DESCRIPTION
### Describe your changes:

Fixes #29921

PR #29853 changed the Search Settings entity page to open with the "Ranking Details" accordion expanded by default, which collapses the "Matching Fields" panel until it's explicitly opened. That PR added `openMatchingFieldsPanel(page)` calls before 4 of the 5 places the spec interacts with a `field-container-header` row, but missed the call after `page.reload()` inside `Column Search Settings Tests > Configure column search field settings`. After reload the panel re-collapses, so the next `field-container-header` click hung until the 60s test timeout — this was already failing in PR #29853's own CI check (job [86144340875](https://github.com/open-metadata/OpenMetadata/actions/runs/29024509670/job/86144340875)) and merged anyway.

Fix: reopen the panel via the existing `openMatchingFieldsPanel` helper right after the post-reload loader wait, before re-clicking the field row.

#
### Type of change:
- [x] Bug fix

#
### High-level design:

N/A — small change.

#
### Tests:

#### Use cases covered
- `Column Search Settings Tests > Configure column search field settings` in `SearchSettings.spec.ts` passes reliably after page reload instead of timing out.

#### Playwright (UI) tests
- [x] Existing spec fixed, no new test needed — this restores an existing test to a passing state.
- Files updated: `openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/SearchSettings.spec.ts`

#### Manual testing performed
1. Traced CI failure logs from job 86144340875 to the exact hang (`firstFieldContainer.click()` at line 525).
2. Confirmed the same reopen pattern is already used at the other 4 `field-container-header` interaction sites in this file, added the missing 5th.
3. Ran `yarn organize-imports-cli` / `eslint --fix` / `prettier --write` on the changed file — no diff beyond the intended fix, only a pre-existing unrelated warning.

#
### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] My PR title is `Fixes <issue-number>: <short explanation>`
- [x] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [x] I have added tests (unit / integration / Playwright as applicable) and listed them above.

<!-- Bug fix -->
- [x] I have added a test that covers the exact scenario we are fixing.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes the Search Settings Playwright flow after reloading the page.

- Re-enables the column search field settings test.
- Reopens the Matching Fields panel after `page.reload()`.
- Keeps the post-reload field row interaction aligned with the existing panel-opening helper pattern.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge.

- No blocking issues found in the changed code.

</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/SearchSettings.spec.ts | Re-enabled the Search Settings test and added the missing Matching Fields panel reopen step after reload. |

</details>

<sub>Reviews (4): Last reviewed commit: ["Fix checkstyle"](https://github.com/open-metadata/openmetadata/commit/57bd8b3e531d8e4a3e86774dd7e1dd175123ebad) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43256811)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Context used - CLAUDE.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=52f0d9d9-cad1-4e7d-b070-de181a0aa5e7))
- Context used - openmetadata-ui-core-components/CLAUDE.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=41754627-b2bf-474b-8082-f37ef1a07013))
- Context used - AGENTS.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=ef262f5f-911f-44f3-8d2d-e9cb1579c8c8))
</details>

<!-- /greptile_comment -->