### PR TITLE
ci: make Slack notifications opt-in in E2E nightly workflows

### DIFF
--- a/.github/workflows/mysql-nightly-e2e.yml
+++ b/.github/workflows/mysql-nightly-e2e.yml
@@ -21,6 +21,11 @@ on:
         required: true
         type: string
         default: "main"
+      send_slack_notification:
+        description: "Send Slack notification with test results"
+        required: false
+        type: boolean
+        default: false
 
 permissions:
   contents: read
@@ -213,12 +218,17 @@ jobs:
           pattern: blob-report-*
           merge-multiple: true
 
-      - name: Merge Reports and Generate Slack Notification
+      - name: Merge Reports
+        working-directory: openmetadata-ui/src/main/resources/ui/
+        run: |
+          npx playwright merge-reports --reporter json ./blob-reports > merged_tests_results.json
+
+      - name: Generate Slack Notification
+        if: ${{ inputs.send_slack_notification }}
         working-directory: openmetadata-ui/src/main/resources/ui/
         env:
           RUN_TITLE: "MySQL Test for OSS Release: ${{ inputs.branch }}"
           RUN_URL: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           SLACK_BOT_USER_OAUTH_TOKEN: ${{ secrets.E2E_SLACK_BOT_OAUTH_TOKEN }}
         run: |
-          npx playwright merge-reports --reporter json ./blob-reports > merged_tests_results.json
           npx playwright-slack-report -c playwright/slack-cli.config.json -j merged_tests_results.json > slack_report.json

--- a/.github/workflows/playwright-sso-login-nightly.yml
+++ b/.github/workflows/playwright-sso-login-nightly.yml
@@ -26,6 +26,11 @@ on:
           - keycloak-azure-saml
           - keycloak-azure-saml-crosssite
           - all
+      send_slack_notification:
+        description: "Send Slack notification with test results"
+        required: false
+        type: boolean
+        default: false
 
 permissions:
   contents: read
@@ -132,7 +137,7 @@ jobs:
           retention-days: 5
 
       - name: Send Slack Notification
-        if: always()
+        if: ${{ always() && (github.event_name == 'schedule' || inputs.send_slack_notification == true) }}
         working-directory: openmetadata-ui/src/main/resources/ui
         env:
           RUN_TITLE: "SSO Login Nightly: ${{ matrix.provider.name }} (${{ github.ref_name }})"

--- a/.github/workflows/postgresql-nightly-e2e.yml
+++ b/.github/workflows/postgresql-nightly-e2e.yml
@@ -21,6 +21,11 @@ on:
         required: true
         type: string
         default: "main"
+      send_slack_notification:
+        description: "Send Slack notification with test results"
+        required: false
+        type: boolean
+        default: false
 
 permissions:
   contents: read
@@ -213,12 +218,17 @@ jobs:
           pattern: blob-report-*
           merge-multiple: true
 
-      - name: Merge Reports and Generate Slack Notification
+      - name: Merge Reports
+        working-directory: openmetadata-ui/src/main/resources/ui/
+        run: |
+          npx playwright merge-reports --reporter json ./blob-reports > merged_tests_results.json
+
+      - name: Generate Slack Notification
+        if: ${{ inputs.send_slack_notification }}
         working-directory: openmetadata-ui/src/main/resources/ui/
         env:
           RUN_TITLE: "PostgreSQL Test for OSS Release: ${{ inputs.branch }}"
           RUN_URL: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           SLACK_BOT_USER_OAUTH_TOKEN: ${{ secrets.E2E_SLACK_BOT_OAUTH_TOKEN }}
         run: |
-          npx playwright merge-reports --reporter json ./blob-reports > merged_tests_results.json
           npx playwright-slack-report -c playwright/slack-cli.config.json -j merged_tests_results.json > slack_report.json


### PR DESCRIPTION
### Describe your changes:

I worked on making Slack notifications opt-in in the E2E nightly workflows because the Slack notification step was always firing, even when triggered by external callers that manage their own notification logic. Callers should decide whether notifications are sent.

- Adds a `send_slack_notification` boolean input (default: `false`) to `mysql-nightly-e2e.yml`, `postgresql-nightly-e2e.yml`, and `playwright-sso-login-nightly.yml`
- For MySQL/PostgreSQL workflows: splits the merged "Merge Reports and Generate Slack Notification" step into two separate steps — merging always runs, Slack only fires when `send_slack_notification: true`
- For the SSO nightly workflow: scheduled (`cron`) runs still notify automatically; `workflow_dispatch` defaults to silent unless the caller passes `true`

### Type of change:
- [x] Improvement

#
### High-level design:

N/A — small change.

#
### Tests:

#### Use cases covered
- Scheduled SSO nightly run → Slack notification sent automatically
- `workflow_dispatch` without `send_slack_notification` → no Slack notification
- `workflow_dispatch` with `send_slack_notification: true` → Slack notification sent

#### Unit tests
N/A — workflow-only change.

#### Backend integration tests
- [x] Not applicable (no backend API changes).

#### Ingestion integration tests
- [x] Not applicable (no ingestion changes).

#### Playwright (UI) tests
- [x] Not applicable (no UI changes).

#### Manual testing performed
Reviewed workflow YAML diffs and logic for all three trigger scenarios.

#
### UI screen recording / screenshots:

Not applicable.

#
### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.
- [ ] For UI changes: I attached a screen recording and/or screenshots above.
- [ ] I have added tests (unit / integration / Playwright as applicable) and listed them above.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR makes Slack notifications opt-in for nightly E2E workflow dispatches. The main changes are:

- Added `send_slack_notification` inputs to the MySQL, PostgreSQL, and SSO workflows.
- Split report merging from Slack generation in the database E2E workflows.
- Kept scheduled SSO runs sending Slack notifications automatically.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge.

- No blocking issues found in the changed code.

</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/mysql-nightly-e2e.yml | Adds a dispatch-only Slack opt-in input and separates report merging from Slack notification generation. |
| .github/workflows/postgresql-nightly-e2e.yml | Mirrors the MySQL workflow change with an opt-in Slack notification step after report merging. |
| .github/workflows/playwright-sso-login-nightly.yml | Adds manual Slack opt-in while preserving automatic Slack notifications for scheduled SSO runs. |

</details>

<sub>Reviews (1): Last reviewed commit: ["ci: make Slack notifications opt-in in E..."](https://github.com/open-metadata/openmetadata/commit/a9d07ac7c04b9d4132982e77ead560cc91f80592) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43260002)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Context used - CLAUDE.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=52f0d9d9-cad1-4e7d-b070-de181a0aa5e7))
- Context used - openmetadata-ui-core-components/CLAUDE.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=41754627-b2bf-474b-8082-f37ef1a07013))
- Context used - AGENTS.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=ef262f5f-911f-44f3-8d2d-e9cb1579c8c8))
</details>

<!-- /greptile_comment -->