### PR TITLE
Adjust Explore card metadata typography

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/ExploreV1/ExploreSearchCard/explore-search-card.less
+++ b/openmetadata-ui/src/main/resources/ui/src/components/ExploreV1/ExploreSearchCard/explore-search-card.less
@@ -85,6 +85,12 @@
 
   .entity-summary-details {
     font-size: 12px;
+    font-weight: @font-regular;
+
+    .ant-typography {
+      font-size: inherit;
+      font-weight: inherit;
+    }
 
     .no-owner {
       color: @text-grey-muted;

--- a/openmetadata-ui/src/main/resources/ui/src/components/ExploreV1/ExploreSearchCard/explore-search-card.less
+++ b/openmetadata-ui/src/main/resources/ui/src/components/ExploreV1/ExploreSearchCard/explore-search-card.less
@@ -89,7 +89,6 @@
 
     .ant-typography {
       font-size: inherit;
-      font-weight: inherit;
     }
 
     .no-owner {

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/DomainDisplay/DomainDisplay.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/DomainDisplay/DomainDisplay.component.tsx
@@ -69,7 +69,7 @@ export const DomainDisplay = ({
     }));
 
     return (
-      <div className={`d-flex items-center gap-2 ${className}`}>
+      <div className={`d-flex items-center gap-1 ${className}`}>
         {showIcon && (
           <div className="d-flex">
             <DomainIcon
@@ -106,7 +106,7 @@ export const DomainDisplay = ({
   }
 
   return (
-    <div className={`d-flex items-center gap-2 ${className}`}>
+    <div className={`d-flex items-center gap-1 ${className}`}>
       {showIcon && (
         <div className="d-flex">
           <DomainIcon

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/DomainDisplay/DomainDisplay.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/DomainDisplay/DomainDisplay.test.tsx
@@ -84,10 +84,11 @@ describe('DomainDisplay Component', () => {
   });
 
   it('should render single domain with icon by default', () => {
-    renderDomainDisplay({ domains: [mockDomain1] });
+    const { container } = renderDomainDisplay({ domains: [mockDomain1] });
 
     expect(screen.getByTestId('domain-icon')).toBeInTheDocument();
     expect(screen.getByText('Domain One')).toBeInTheDocument();
+    expect(container.firstChild).toHaveClass('gap-1');
     expect(screen.getByRole('link')).toHaveAttribute(
       'href',
       '/domain/domain.one'


### PR DESCRIPTION
## Summary
- Reduce Explore card metadata values to 12px.
- Set Explore card metadata values to regular font weight.
<img width="1004" height="252" alt="Screenshot 2026-07-10 at 5 41 30 PM" src="https://github.com/user-attachments/assets/f056d9a8-4939-4270-8ba4-f01f50121176" />



## Testing
- Ran formatting check for the changed Explore card style file.
- Ran whitespace validation with git diff check.


----
## Summary by Gitar

- **UI adjustments:**
  - Updated `DomainDisplay` component to use a tighter `gap-1` layout instead of `gap-2`.
- **Testing updates:**
  - Added verification to `DomainDisplay.test.tsx` to ensure the correct `gap-1` class is applied.

<sub>This will update automatically on new commits.</sub>

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adjusts Explore metadata typography and DomainDisplay spacing. The main changes are:

- Explore card metadata values now use regular 12px styling.
- Nested Ant Typography in metadata inherits the smaller font size.
- DomainDisplay uses the tighter `gap-1` spacing in both render paths.
- The DomainDisplay test checks the new spacing class.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge.

- No blocking issues found in the changed code.

</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-ui/src/main/resources/ui/src/components/ExploreV1/ExploreSearchCard/explore-search-card.less | Updates Explore card metadata typography while keeping nested Typography font weight controllable by direct classes. |
| openmetadata-ui/src/main/resources/ui/src/components/common/DomainDisplay/DomainDisplay.component.tsx | Reduces DomainDisplay spacing from `gap-2` to `gap-1` in both render branches. |
| openmetadata-ui/src/main/resources/ui/src/components/common/DomainDisplay/DomainDisplay.test.tsx | Adds a test assertion for the new DomainDisplay spacing class. |

</details>

<sub>Reviews (3): Last reviewed commit: ["Fix explore metadata constraint styling"](https://github.com/open-metadata/openmetadata/commit/69d3643177dd0818852fbb2aa5905f75f01f27ff) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43279610)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Context used - CLAUDE.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=52f0d9d9-cad1-4e7d-b070-de181a0aa5e7))
- Context used - openmetadata-ui-core-components/CLAUDE.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=41754627-b2bf-474b-8082-f37ef1a07013))
- Context used - AGENTS.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=ef262f5f-911f-44f3-8d2d-e9cb1579c8c8))
</details>

<!-- /greptile_comment -->