### PR TITLE
feat(ingestion): Looker & Tableau progress totals via MANUAL progress mode

### DIFF
--- a/ingestion/src/metadata/ingestion/source/dashboard/looker/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/dashboard/looker/metadata.py
@@ -432,18 +432,11 @@ class LookerSource(DashboardServiceSource):
                 # Store the models for later processing of standalone views
                 self._all_lookml_models = all_lookml_models
 
-                explore_total = sum(
-                    1
-                    for model in all_lookml_models
-                    if model.explores and not filter_by_datamodel(self.source_config.dataModelFilterPattern, model.name)
-                    for explore in model.explores
-                    if not filter_by_datamodel(
-                        self.source_config.dataModelFilterPattern,
-                        build_datamodel_name(model.name, explore.name),
-                    )
-                )
                 manual = self.progress_tracking.manual
-                manual.set_total(DashboardDataModel.__name__, explore_total)
+                manual.set_total(
+                    DashboardDataModel.__name__,
+                    self._reconcilable_explore_total(all_lookml_models),
+                )
                 manual.mark_reconcilable(DashboardDataModel.__name__)
 
                 # Finally, iterate through them to ingest Explores and Views
@@ -452,6 +445,27 @@ class LookerSource(DashboardServiceSource):
             except Exception as err:
                 logger.debug(traceback.format_exc())
                 logger.error(f"Unexpected error fetching LookML models - {err}")
+
+    def _reconcilable_explore_total(self, all_lookml_models: Sequence[LookmlModel]) -> int:
+        """Count the explores that ``fetch_lookml_explores`` would actually
+        yield, i.e. those whose model and composite datamodel name survive the
+        dataModelFilterPattern. This is the DashboardDataModel progress total."""
+        total = 0
+        for model in all_lookml_models:
+            model_name = model.name
+            explores = model.explores
+            if not model_name or not explores:
+                continue
+            if filter_by_datamodel(self.source_config.dataModelFilterPattern, model_name):
+                continue
+            for explore in explores:
+                explore_name = explore.name
+                if explore_name and not filter_by_datamodel(
+                    self.source_config.dataModelFilterPattern,
+                    build_datamodel_name(model_name, explore_name),
+                ):
+                    total += 1
+        return total
 
     def fetch_lookml_explores(self, all_lookml_models: Sequence[LookmlModel]) -> Iterable[LookmlModelExplore]:
         """

--- a/ingestion/src/metadata/ingestion/source/dashboard/looker/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/dashboard/looker/metadata.py
@@ -431,7 +431,11 @@ class LookerSource(DashboardServiceSource):
                 # Store the models for later processing of standalone views
                 self._all_lookml_models = all_lookml_models
 
-                explore_total = sum(len(model.explores) if model.explores else 0 for model in all_lookml_models)
+                explore_total = sum(
+                    len(model.explores)
+                    for model in all_lookml_models
+                    if model.explores and not filter_by_datamodel(self.source_config.dataModelFilterPattern, model.name)
+                )
                 manual = self.progress_tracking.manual
                 manual.set_total(DashboardDataModel.__name__, explore_total)
                 manual.mark_reconcilable(DashboardDataModel.__name__)

--- a/ingestion/src/metadata/ingestion/source/dashboard/looker/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/dashboard/looker/metadata.py
@@ -1205,7 +1205,6 @@ class LookerSource(DashboardServiceSource):
             ]
             manual = self.progress_tracking.manual
             manual.set_total(Dashboard.__name__, len(kept))
-            manual.mark_reconcilable(Chart.__name__)
         except Exception as err:
             logger.debug(traceback.format_exc())
             logger.error(f"Wild error trying to obtain dashboard list {err}")
@@ -1648,7 +1647,6 @@ class LookerSource(DashboardServiceSource):
                     service=self.context.get().dashboard_service,
                 )
                 yield Either(right=chart_request)
-                self.progress_tracking.manual.track(Chart.__name__)
                 self.register_record_chart(chart_request=chart_request)
 
             except Exception as exc:

--- a/ingestion/src/metadata/ingestion/source/dashboard/looker/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/dashboard/looker/metadata.py
@@ -134,6 +134,7 @@ from metadata.utils.filters import (
     filter_by_chart,
     filter_by_dashboard,
     filter_by_datamodel,
+    filter_pattern_enabled,
 )
 from metadata.utils.helpers import clean_uri, get_standard_chart_type
 from metadata.utils.logger import ingestion_logger
@@ -432,9 +433,14 @@ class LookerSource(DashboardServiceSource):
                 self._all_lookml_models = all_lookml_models
 
                 explore_total = sum(
-                    len(model.explores)
+                    1
                     for model in all_lookml_models
                     if model.explores and not filter_by_datamodel(self.source_config.dataModelFilterPattern, model.name)
+                    for explore in model.explores
+                    if not filter_by_datamodel(
+                        self.source_config.dataModelFilterPattern,
+                        build_datamodel_name(model.name, explore.name),
+                    )
                 )
                 manual = self.progress_tracking.manual
                 manual.set_total(DashboardDataModel.__name__, explore_total)
@@ -1204,7 +1210,14 @@ class LookerSource(DashboardServiceSource):
                 )
             ]
             manual = self.progress_tracking.manual
-            manual.set_total(Dashboard.__name__, len(kept))
+            if filter_pattern_enabled(self.source_config.projectFilterPattern):
+                # projectFilterPattern is applied downstream in the base
+                # get_dashboard (needs per-dashboard project detail), so the
+                # kept count over-counts — show a running count instead of a
+                # bar stuck below 100%.
+                manual.mark_reconcilable(Dashboard.__name__)
+            else:
+                manual.set_total(Dashboard.__name__, len(kept))
         except Exception as err:
             logger.debug(traceback.format_exc())
             logger.error(f"Wild error trying to obtain dashboard list {err}")

--- a/ingestion/src/metadata/ingestion/source/dashboard/looker/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/dashboard/looker/metadata.py
@@ -542,6 +542,7 @@ class LookerSource(DashboardServiceSource):
                 )
 
                 yield Either(right=data_model_request)
+                self.progress_tracking.manual.track(DashboardDataModel.__name__)
                 self.register_record_datamodel(datamodel_request=data_model_request)
 
                 # Build and cache the view model
@@ -637,6 +638,7 @@ class LookerSource(DashboardServiceSource):
                     ),
                 )
                 yield Either(right=explore_datamodel)
+                self.progress_tracking.manual.track(DashboardDataModel.__name__)
                 self.register_record_datamodel(datamodel_request=explore_datamodel)
 
                 # build datamodel by our hand since ack_sink=False
@@ -1277,6 +1279,7 @@ class LookerSource(DashboardServiceSource):
             owners=self.get_owner_ref(dashboard_details=dashboard_details),
         )
         yield Either(right=dashboard_request)
+        self.progress_tracking.manual.track(Dashboard.__name__)
         self.register_record(dashboard_request=dashboard_request)
 
     def get_project_name(self, dashboard_details: LookerDashboard) -> Optional[str]:  # noqa: UP045
@@ -1641,6 +1644,7 @@ class LookerSource(DashboardServiceSource):
                     service=self.context.get().dashboard_service,
                 )
                 yield Either(right=chart_request)
+                self.progress_tracking.manual.track(Chart.__name__)
                 self.register_record_chart(chart_request=chart_request)
 
             except Exception as exc:

--- a/ingestion/src/metadata/ingestion/source/dashboard/looker/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/dashboard/looker/metadata.py
@@ -130,7 +130,11 @@ from metadata.readers.file.base import Reader
 from metadata.readers.file.credentials import get_credentials_from_url
 from metadata.readers.file.local import LocalReader
 from metadata.utils import fqn
-from metadata.utils.filters import filter_by_chart, filter_by_datamodel
+from metadata.utils.filters import (
+    filter_by_chart,
+    filter_by_dashboard,
+    filter_by_datamodel,
+)
 from metadata.utils.helpers import clean_uri, get_standard_chart_type
 from metadata.utils.logger import ingestion_logger
 from metadata.utils.tag_utils import get_ometa_tag_and_classification, get_tag_labels
@@ -1184,12 +1188,25 @@ class LookerSource(DashboardServiceSource):
         if not self.source_config.includeOwners:
             logger.debug("Skipping owner information as includeOwners is False")
         try:
-            return list(self.client.all_dashboards(fields=",".join(LIST_DASHBOARD_FIELDS)))
+            dashboards = list(self.client.all_dashboards(fields=",".join(LIST_DASHBOARD_FIELDS)))
+            kept = [
+                dashboard
+                for dashboard in dashboards
+                if not filter_by_dashboard(
+                    self.source_config.dashboardFilterPattern,
+                    self.get_dashboard_name(dashboard),
+                )
+            ]
+            manual = self.progress_tracking.manual
+            manual.set_total(Dashboard.__name__, len(kept))
+            manual.mark_reconcilable(Chart.__name__)
         except Exception as err:
             logger.debug(traceback.format_exc())
             logger.error(f"Wild error trying to obtain dashboard list {err}")
             # If we cannot list the dashboards, let's blow up
             raise err  # noqa: TRY201
+        else:
+            return dashboards
 
     def get_dashboard_name(self, dashboard: DashboardBase) -> str:
         """

--- a/ingestion/src/metadata/ingestion/source/dashboard/looker/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/dashboard/looker/metadata.py
@@ -109,6 +109,7 @@ from metadata.ingestion.lineage.parser import LineageParser
 from metadata.ingestion.lineage.sql_lineage import get_column_fqn
 from metadata.ingestion.models.ometa_classification import OMetaTagAndClassification
 from metadata.ingestion.ometa.ometa_api import OpenMetadata
+from metadata.ingestion.progress.modes import ProgressMode
 from metadata.ingestion.source.dashboard.dashboard_service import (
     DashboardServiceSource,
     DashboardUsage,
@@ -194,6 +195,7 @@ class LookerSource(DashboardServiceSource):
     config: WorkflowSource
     metadata: OpenMetadata
     client: Looker40SDK
+    progress_mode = ProgressMode.MANUAL
 
     def __init__(
         self,
@@ -424,6 +426,11 @@ class LookerSource(DashboardServiceSource):
 
                 # Store the models for later processing of standalone views
                 self._all_lookml_models = all_lookml_models
+
+                explore_total = sum(len(model.explores) if model.explores else 0 for model in all_lookml_models)
+                manual = self.progress_tracking.manual
+                manual.set_total(DashboardDataModel.__name__, explore_total)
+                manual.mark_reconcilable(DashboardDataModel.__name__)
 
                 # Finally, iterate through them to ingest Explores and Views
                 yield from self.fetch_lookml_explores(all_lookml_models)

--- a/ingestion/src/metadata/ingestion/source/dashboard/tableau/client.py
+++ b/ingestion/src/metadata/ingestion/source/dashboard/tableau/client.py
@@ -22,6 +22,7 @@ from tableauserverclient import (
     Pager,
     PersonalAccessTokenAuth,
     ProjectItem,
+    RequestOptions,
     Server,
     TableauAuth,
     ViewItem,
@@ -199,6 +200,13 @@ class TableauClient:
         except Exception as e:
             logger.debug(f"Failed to get project parents by id: {str(e)}")  # noqa: RUF010
         return None
+
+    def get_workbook_count(self) -> int:
+        """Total workbooks available server-side via the pagination summary — a
+        single page-size-1 request, no full workbook materialization. This is the
+        pre-filter denominator for Dashboard progress."""
+        _, pagination_item = self.tableau_server.workbooks.get(RequestOptions(pagesize=1))
+        return pagination_item.total_available
 
     def get_workbooks(self, include_owners: bool = True) -> Iterable[TableauDashboard]:
         """

--- a/ingestion/src/metadata/ingestion/source/dashboard/tableau/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/dashboard/tableau/metadata.py
@@ -262,6 +262,7 @@ class TableauSource(DashboardServiceSource):
                 project=data_model.projectName or self.get_project_name(dashboard_details=dashboard_details),
             )
             yield Either(right=data_model_request)
+            self.progress_tracking.manual.track(DashboardDataModel.__name__)
             self.register_record_datamodel(datamodel_request=data_model_request)
 
         except Exception as exc:
@@ -342,6 +343,7 @@ class TableauSource(DashboardServiceSource):
                 owners=self.get_owner_ref(dashboard_details=dashboard_details),
             )
             yield Either(right=dashboard_request)
+            self.progress_tracking.manual.track(Dashboard.__name__)
             self.register_record(dashboard_request=dashboard_request)
         except Exception as exc:
             yield Either(
@@ -748,6 +750,7 @@ class TableauSource(DashboardServiceSource):
                     service=FullyQualifiedEntityName(self.context.get().dashboard_service),
                 )
                 yield Either(right=chart_request)
+                self.progress_tracking.manual.track(Chart.__name__)
                 self.register_record_chart(chart_request=chart_request)
             except Exception as exc:
                 yield Either(

--- a/ingestion/src/metadata/ingestion/source/dashboard/tableau/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/dashboard/tableau/metadata.py
@@ -70,6 +70,7 @@ from metadata.ingestion.lineage.sql_lineage import (
 )
 from metadata.ingestion.models.ometa_classification import OMetaTagAndClassification
 from metadata.ingestion.ometa.ometa_api import OpenMetadata
+from metadata.ingestion.progress.modes import ProgressMode
 from metadata.ingestion.source.dashboard.dashboard_service import (
     DashboardServiceSource,
     DashboardUsage,
@@ -109,6 +110,7 @@ class TableauSource(DashboardServiceSource):
     config: WorkflowSource
     metadata_config: OpenMetadataConnection
     client: TableauClient
+    progress_mode = ProgressMode.MANUAL
 
     def __init__(
         self,
@@ -134,6 +136,14 @@ class TableauSource(DashboardServiceSource):
     def get_dashboards_list(self) -> Iterable[TableauDashboard]:
         if not self.source_config.includeOwners:
             logger.debug("Skipping owner information as includeOwners is False")
+        manual = self.progress_tracking.manual
+        try:
+            manual.set_total(Dashboard.__name__, self.client.get_workbook_count())
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("Could not prefetch Tableau workbook count for progress: %s", exc)
+            manual.mark_reconcilable(Dashboard.__name__)
+        manual.mark_reconcilable(Chart.__name__)
+        manual.mark_reconcilable(DashboardDataModel.__name__)
         yield from self.client.get_workbooks(include_owners=self.source_config.includeOwners)
 
     def get_dashboard_name(self, dashboard: TableauDashboard) -> str:

--- a/ingestion/src/metadata/ingestion/source/dashboard/tableau/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/dashboard/tableau/metadata.py
@@ -139,7 +139,7 @@ class TableauSource(DashboardServiceSource):
         manual = self.progress_tracking.manual
         try:
             manual.set_total(Dashboard.__name__, self.client.get_workbook_count())
-        except Exception as exc:  # noqa: BLE001
+        except Exception as exc:
             logger.warning("Could not prefetch Tableau workbook count for progress: %s", exc)
             manual.mark_reconcilable(Dashboard.__name__)
         manual.mark_reconcilable(Chart.__name__)

--- a/ingestion/src/metadata/ingestion/source/dashboard/tableau/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/dashboard/tableau/metadata.py
@@ -142,8 +142,6 @@ class TableauSource(DashboardServiceSource):
         except Exception as exc:
             logger.warning("Could not prefetch Tableau workbook count for progress: %s", exc)
             manual.mark_reconcilable(Dashboard.__name__)
-        manual.mark_reconcilable(Chart.__name__)
-        manual.mark_reconcilable(DashboardDataModel.__name__)
         yield from self.client.get_workbooks(include_owners=self.source_config.includeOwners)
 
     def get_dashboard_name(self, dashboard: TableauDashboard) -> str:
@@ -262,7 +260,6 @@ class TableauSource(DashboardServiceSource):
                 project=data_model.projectName or self.get_project_name(dashboard_details=dashboard_details),
             )
             yield Either(right=data_model_request)
-            self.progress_tracking.manual.track(DashboardDataModel.__name__)
             self.register_record_datamodel(datamodel_request=data_model_request)
 
         except Exception as exc:
@@ -750,7 +747,6 @@ class TableauSource(DashboardServiceSource):
                     service=FullyQualifiedEntityName(self.context.get().dashboard_service),
                 )
                 yield Either(right=chart_request)
-                self.progress_tracking.manual.track(Chart.__name__)
                 self.register_record_chart(chart_request=chart_request)
             except Exception as exc:
                 yield Either(

--- a/ingestion/src/metadata/ingestion/source/dashboard/tableau/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/dashboard/tableau/metadata.py
@@ -87,7 +87,11 @@ from metadata.ingestion.source.dashboard.tableau.models import (
 from metadata.ingestion.source.database.column_helpers import truncate_column_name
 from metadata.ingestion.source.database.column_type_parser import ColumnTypeParser
 from metadata.utils import fqn
-from metadata.utils.filters import filter_by_chart, filter_by_datamodel
+from metadata.utils.filters import (
+    filter_by_chart,
+    filter_by_datamodel,
+    filter_pattern_enabled,
+)
 from metadata.utils.fqn import build_es_fqn_search_string
 from metadata.utils.helpers import (
     clean_uri,
@@ -136,13 +140,27 @@ class TableauSource(DashboardServiceSource):
     def get_dashboards_list(self) -> Iterable[TableauDashboard]:
         if not self.source_config.includeOwners:
             logger.debug("Skipping owner information as includeOwners is False")
-        manual = self.progress_tracking.manual
-        try:
-            manual.set_total(Dashboard.__name__, self.client.get_workbook_count())
-        except Exception as exc:
-            logger.warning("Could not prefetch Tableau workbook count for progress: %s", exc)
-            manual.mark_reconcilable(Dashboard.__name__)
+        self._declare_dashboard_progress_total()
         yield from self.client.get_workbooks(include_owners=self.source_config.includeOwners)
+
+    def _declare_dashboard_progress_total(self) -> None:
+        """Declare the Dashboard progress total. ``get_workbook_count`` is a
+        server-side pre-filter count, so when a dashboard or project filter is
+        active the tracked (post-filter) count can never reach it — fall back to
+        a reconcilable running count instead of a bar stuck below 100%."""
+        manual = self.progress_tracking.manual
+        patterns = (
+            self.source_config.dashboardFilterPattern,
+            self.source_config.projectFilterPattern,
+        )
+        if any(filter_pattern_enabled(pattern) for pattern in patterns):
+            manual.mark_reconcilable(Dashboard.__name__)
+        else:
+            try:
+                manual.set_total(Dashboard.__name__, self.client.get_workbook_count())
+            except Exception as exc:
+                logger.warning("Could not prefetch Tableau workbook count for progress: %s", exc)
+                manual.mark_reconcilable(Dashboard.__name__)
 
     def get_dashboard_name(self, dashboard: TableauDashboard) -> str:
         return dashboard.name

--- a/ingestion/src/metadata/utils/filters.py
+++ b/ingestion/src/metadata/utils/filters.py
@@ -412,3 +412,15 @@ def filter_by_server(server_filter_pattern: Optional[FilterPattern], server_name
     :return: True for filtering, False otherwise
     """
     return _filter(server_filter_pattern, server_name)
+
+
+def filter_pattern_enabled(filter_pattern: Optional[FilterPattern]) -> bool:  # noqa: UP045
+    """
+    Return True when the pattern would actually include or exclude something,
+    i.e. the user configured includes or excludes. An unset (None) or empty
+    pattern returns False.
+
+    :param filter_pattern: Model defining filtering logic
+    :return: True when includes/excludes are configured, False otherwise
+    """
+    return bool(filter_pattern and (filter_pattern.includes or filter_pattern.excludes))

--- a/ingestion/tests/unit/test_filter_pattern.py
+++ b/ingestion/tests/unit/test_filter_pattern.py
@@ -22,6 +22,7 @@ from metadata.utils.filters import (
     filter_by_classifications,
     filter_by_dashboard,
     filter_by_fqn,
+    filter_pattern_enabled,
     validate_regex,
 )
 
@@ -43,6 +44,16 @@ def test_filter():
     # If we have both includes and excludes, we will check both "include" and "exclude"
     # This was not filter if we only check includes, but is filtered if we check both
     assert _filter(filter_pattern_both, "potato_tomato")
+
+
+def test_filter_pattern_enabled():
+    """A pattern is enabled only when includes or excludes are configured"""
+    assert filter_pattern_enabled(None) is False
+    assert filter_pattern_enabled(FilterPattern()) is False
+    assert filter_pattern_enabled(FilterPattern(includes=[])) is False
+    assert filter_pattern_enabled(FilterPattern(excludes=[])) is False
+    assert filter_pattern_enabled(FilterPattern(includes=["^keep$"])) is True
+    assert filter_pattern_enabled(FilterPattern(excludes=["^skip$"])) is True
 
 
 def test_filter_by_classifications():

--- a/ingestion/tests/unit/topology/dashboard/test_looker.py
+++ b/ingestion/tests/unit/topology/dashboard/test_looker.py
@@ -962,6 +962,29 @@ class LookerUnitTest(TestCase):
         counter = self.looker.progress_tracking.registry._global["DashboardDataModel"]
         self.assertEqual(counter.total, 2)
 
+    def test_list_datamodels_excludes_filtered_explore_from_total(self):
+        """
+        Check that a dataModelFilterPattern matching an explore's composite
+        datamodel name (model_explore) excludes only that explore from the
+        total, mirroring the per-explore filter in yield_bulk_datamodel.
+        """
+        models = [
+            SimpleNamespace(
+                name="m1",
+                project_name="p",
+                explores=[SimpleNamespace(name="e1"), SimpleNamespace(name="e2")],
+            ),
+            SimpleNamespace(name="m2", project_name="p", explores=[SimpleNamespace(name="e3")]),
+        ]
+        self.looker.client.all_lookml_models = MagicMock(return_value=models)
+        self.looker.client.lookml_model_explore = MagicMock(side_effect=Exception("skip detail"))
+        self.looker.source_config.dataModelFilterPattern = FilterPattern(excludes=["m1_e2"])
+
+        list(self.looker.list_datamodels())
+
+        counter = self.looker.progress_tracking.registry._global["DashboardDataModel"]
+        self.assertEqual(counter.total, 2)
+
     def test_get_dashboards_list_declares_dashboard_total(self):
         """
         Check that get_dashboards_list declares the Dashboard progress total
@@ -978,6 +1001,27 @@ class LookerUnitTest(TestCase):
         self.assertEqual(len(result), 2)
         registry = self.looker.progress_tracking.registry
         self.assertEqual(registry._global["Dashboard"].total, 2)
+
+    def test_get_dashboards_list_reconcilable_when_project_filtered(self):
+        """
+        projectFilterPattern is applied downstream in the base get_dashboard
+        (needs per-dashboard project detail), so get_dashboards_list falls back
+        to a reconcilable running count instead of an unreachable pre-filter
+        total.
+        """
+        dashboards = [
+            SimpleNamespace(id="1", title="Keep"),
+            SimpleNamespace(id="2", title="Keep2"),
+        ]
+        self.looker.client.all_dashboards = MagicMock(return_value=dashboards)
+        self.looker.source_config.projectFilterPattern = FilterPattern(excludes=["^skip$"])
+
+        result = self.looker.get_dashboards_list()
+
+        self.assertEqual(len(result), 2)
+        registry = self.looker.progress_tracking.registry
+        self.assertTrue(registry._global["Dashboard"].reconcilable)
+        self.assertIsNone(registry._global["Dashboard"].total)
 
     def test_yield_bulk_datamodel_tracks_progress(self):
         """

--- a/ingestion/tests/unit/topology/dashboard/test_looker.py
+++ b/ingestion/tests/unit/topology/dashboard/test_looker.py
@@ -936,3 +936,21 @@ class LookerUnitTest(TestCase):
         counter = self.looker.progress_tracking.registry._global["DashboardDataModel"]
         self.assertEqual(counter.total, 3)
         self.assertTrue(counter.reconcilable)
+
+    def test_get_dashboards_list_declares_dashboard_total(self):
+        """
+        Check that get_dashboards_list declares the Dashboard progress total
+        from the name-filtered dashboard list, and marks Chart reconcilable.
+        """
+        dashboards = [
+            SimpleNamespace(id="1", title="Keep"),
+            SimpleNamespace(id="2", title="Keep2"),
+        ]
+        self.looker.client.all_dashboards = MagicMock(return_value=dashboards)
+
+        result = self.looker.get_dashboards_list()
+
+        self.assertEqual(len(result), 2)
+        registry = self.looker.progress_tracking.registry
+        self.assertEqual(registry._global["Dashboard"].total, 2)
+        self.assertTrue(registry._global["Chart"].reconcilable)

--- a/ingestion/tests/unit/topology/dashboard/test_looker.py
+++ b/ingestion/tests/unit/topology/dashboard/test_looker.py
@@ -954,3 +954,81 @@ class LookerUnitTest(TestCase):
         registry = self.looker.progress_tracking.registry
         self.assertEqual(registry._global["Dashboard"].total, 2)
         self.assertTrue(registry._global["Chart"].reconcilable)
+
+    def test_yield_bulk_datamodel_tracks_progress(self):
+        """
+        Check that yield_bulk_datamodel advances the DashboardDataModel
+        counter after successfully yielding the explore request.
+        """
+        self.looker.progress_tracking.manual.set_total("DashboardDataModel", 5)
+
+        mock_explore = LookmlModelExplore(
+            name="my_explore",
+            model_name="my_model",
+            project_name="my_project",
+            fields=LookmlModelExploreFieldset(dimensions=[], measures=[]),
+        )
+
+        with (
+            patch.object(LookerSource, "register_record_datamodel", return_value=None),
+            patch.object(LookerSource, "_build_data_model", return_value=None),
+            patch.object(LookerSource, "_get_explore_sql", return_value=None),
+        ):
+            list(self.looker.yield_bulk_datamodel(mock_explore))
+
+        counter = self.looker.progress_tracking.registry._global["DashboardDataModel"]
+        self.assertGreaterEqual(counter.done, 1)
+
+    def test_yield_standalone_datamodels_tracks_progress(self):
+        """
+        Check that yield_standalone_datamodels advances the
+        DashboardDataModel counter after successfully yielding a view request.
+        """
+        from metadata.ingestion.source.dashboard.looker.models import LookMlView
+
+        self.looker.progress_tracking.manual.set_total("DashboardDataModel", 5)
+
+        mock_view = LookMlView(name="my_view", source_file="views/my_view.view.lkml")
+        mock_parser = MagicMock()
+        mock_parser._views_cache = {"my_view": mock_view}
+        mock_parser.parsed_files = {}
+
+        self.looker._repo_credentials = True
+        self.looker._project_parsers = {"my_project": mock_parser}
+        self.looker._views_cache = {}
+        self.looker._all_lookml_models = [SimpleNamespace(name="my_model")]
+
+        with (
+            patch.object(LookerSource, "register_record_datamodel", return_value=None),
+            patch.object(LookerSource, "_build_data_model", return_value=None),
+            patch.object(LookerSource, "_add_standalone_view_lineage", return_value=iter([])),
+        ):
+            list(self.looker.yield_standalone_datamodels())
+
+        counter = self.looker.progress_tracking.registry._global["DashboardDataModel"]
+        self.assertGreaterEqual(counter.done, 1)
+
+    def test_yield_dashboard_tracks_progress(self):
+        """
+        Check that yield_dashboard advances the Dashboard counter after
+        successfully yielding the dashboard request.
+        """
+        self.looker.progress_tracking.manual.set_total("Dashboard", 5)
+
+        with patch.object(LookerSource, "get_owner_ref", return_value=None):
+            list(self.looker.yield_dashboard(MOCK_LOOKER_DASHBOARD))
+
+        counter = self.looker.progress_tracking.registry._global["Dashboard"]
+        self.assertGreaterEqual(counter.done, 1)
+
+    def test_yield_dashboard_chart_tracks_progress(self):
+        """
+        Check that yield_dashboard_chart advances the Chart counter after
+        successfully yielding a chart request.
+        """
+        self.looker.progress_tracking.manual.set_total("Chart", 5)
+
+        list(self.looker.yield_dashboard_chart(MOCK_LOOKER_DASHBOARD))
+
+        counter = self.looker.progress_tracking.registry._global["Chart"]
+        self.assertGreaterEqual(counter.done, 1)

--- a/ingestion/tests/unit/topology/dashboard/test_looker.py
+++ b/ingestion/tests/unit/topology/dashboard/test_looker.py
@@ -965,7 +965,7 @@ class LookerUnitTest(TestCase):
     def test_get_dashboards_list_declares_dashboard_total(self):
         """
         Check that get_dashboards_list declares the Dashboard progress total
-        from the name-filtered dashboard list, and marks Chart reconcilable.
+        from the name-filtered dashboard list.
         """
         dashboards = [
             SimpleNamespace(id="1", title="Keep"),
@@ -978,7 +978,6 @@ class LookerUnitTest(TestCase):
         self.assertEqual(len(result), 2)
         registry = self.looker.progress_tracking.registry
         self.assertEqual(registry._global["Dashboard"].total, 2)
-        self.assertTrue(registry._global["Chart"].reconcilable)
 
     def test_yield_bulk_datamodel_tracks_progress(self):
         """
@@ -1044,16 +1043,4 @@ class LookerUnitTest(TestCase):
             list(self.looker.yield_dashboard(MOCK_LOOKER_DASHBOARD))
 
         counter = self.looker.progress_tracking.registry._global["Dashboard"]
-        self.assertGreaterEqual(counter.done, 1)
-
-    def test_yield_dashboard_chart_tracks_progress(self):
-        """
-        Check that yield_dashboard_chart advances the Chart counter after
-        successfully yielding a chart request.
-        """
-        self.looker.progress_tracking.manual.set_total("Chart", 5)
-
-        list(self.looker.yield_dashboard_chart(MOCK_LOOKER_DASHBOARD))
-
-        counter = self.looker.progress_tracking.registry._global["Chart"]
         self.assertGreaterEqual(counter.done, 1)

--- a/ingestion/tests/unit/topology/dashboard/test_looker.py
+++ b/ingestion/tests/unit/topology/dashboard/test_looker.py
@@ -48,6 +48,7 @@ from metadata.generated.schema.type.entityLineage import EntitiesEdge, LineageDe
 from metadata.generated.schema.type.entityLineage import Source as LineageSource
 from metadata.generated.schema.type.entityReference import EntityReference
 from metadata.generated.schema.type.entityReferenceList import EntityReferenceList
+from metadata.generated.schema.type.filterPattern import FilterPattern
 from metadata.generated.schema.type.usageDetails import UsageDetails, UsageStats
 from metadata.generated.schema.type.usageRequest import UsageRequest
 from metadata.ingestion.api.steps import InvalidSourceException
@@ -936,6 +937,30 @@ class LookerUnitTest(TestCase):
         counter = self.looker.progress_tracking.registry._global["DashboardDataModel"]
         self.assertEqual(counter.total, 3)
         self.assertTrue(counter.reconcilable)
+
+    def test_list_datamodels_excludes_filtered_models_from_total(self):
+        """
+        Check that list_datamodels excludes explores belonging to models
+        filtered out by dataModelFilterPattern when computing the
+        DashboardDataModel progress total, matching what
+        fetch_lookml_explores actually yields.
+        """
+        models = [
+            SimpleNamespace(
+                name="m1",
+                project_name="p",
+                explores=[SimpleNamespace(name="e1"), SimpleNamespace(name="e2")],
+            ),
+            SimpleNamespace(name="m2", project_name="p", explores=[SimpleNamespace(name="e3")]),
+        ]
+        self.looker.client.all_lookml_models = MagicMock(return_value=models)
+        self.looker.client.lookml_model_explore = MagicMock(side_effect=Exception("skip detail"))
+        self.looker.source_config.dataModelFilterPattern = FilterPattern(excludes=["^m2$"])
+
+        list(self.looker.list_datamodels())
+
+        counter = self.looker.progress_tracking.registry._global["DashboardDataModel"]
+        self.assertEqual(counter.total, 2)
 
     def test_get_dashboards_list_declares_dashboard_total(self):
         """

--- a/ingestion/tests/unit/topology/dashboard/test_looker.py
+++ b/ingestion/tests/unit/topology/dashboard/test_looker.py
@@ -14,8 +14,9 @@ Test looker source
 
 import uuid
 from datetime import datetime, timedelta
+from types import SimpleNamespace
 from unittest import TestCase
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from looker_sdk.sdk.api40.methods import Looker40SDK
 from looker_sdk.sdk.api40.models import Dashboard as LookerDashboard
@@ -912,3 +913,26 @@ class LookerUnitTest(TestCase):
         list(self.looker.yield_dashboard_chart(MOCK_LOOKER_DASHBOARD))
         assert len(self.looker.chart_source_state) == 1
         assert any("looker_source_test" in fqn for fqn in self.looker.chart_source_state)
+
+    def test_list_datamodels_declares_datamodel_total(self):
+        """
+        Check that list_datamodels declares the DashboardDataModel progress
+        total from the explore navigation, and marks it reconcilable so
+        standalone views can grow it later.
+        """
+        models = [
+            SimpleNamespace(
+                name="m1",
+                project_name="p",
+                explores=[SimpleNamespace(name="e1"), SimpleNamespace(name="e2")],
+            ),
+            SimpleNamespace(name="m2", project_name="p", explores=[SimpleNamespace(name="e3")]),
+        ]
+        self.looker.client.all_lookml_models = MagicMock(return_value=models)
+        self.looker.client.lookml_model_explore = MagicMock(side_effect=Exception("skip detail"))
+
+        list(self.looker.list_datamodels())
+
+        counter = self.looker.progress_tracking.registry._global["DashboardDataModel"]
+        self.assertEqual(counter.total, 3)
+        self.assertTrue(counter.reconcilable)

--- a/ingestion/tests/unit/topology/dashboard/test_tableau.py
+++ b/ingestion/tests/unit/topology/dashboard/test_tableau.py
@@ -1057,8 +1057,6 @@ class TableauUnitTest(TestCase):
 
         registry = self.tableau.progress_tracking.registry
         assert registry._global["Dashboard"].total == 7
-        assert registry._global["Chart"].reconcilable is True
-        assert registry._global["DashboardDataModel"].reconcilable is True
 
     def test_yield_dashboard_tracks_progress(self):
         self.tableau.progress_tracking.manual.set_total(Dashboard.__name__, 3)

--- a/ingestion/tests/unit/topology/dashboard/test_tableau.py
+++ b/ingestion/tests/unit/topology/dashboard/test_tableau.py
@@ -1046,3 +1046,16 @@ class TableauUnitTest(TestCase):
         assert len(self.tableau.chart_source_state) == 3
         for fqn in self.tableau.chart_source_state:
             assert "tableau_source_test" in fqn
+
+    def test_get_dashboards_list_declares_totals(self):
+        self.tableau.client = SimpleNamespace(
+            get_workbook_count=MagicMock(return_value=7),
+            get_workbooks=MagicMock(return_value=iter([])),
+        )
+
+        list(self.tableau.get_dashboards_list())
+
+        registry = self.tableau.progress_tracking.registry
+        assert registry._global["Dashboard"].total == 7
+        assert registry._global["Chart"].reconcilable is True
+        assert registry._global["DashboardDataModel"].reconcilable is True

--- a/ingestion/tests/unit/topology/dashboard/test_tableau.py
+++ b/ingestion/tests/unit/topology/dashboard/test_tableau.py
@@ -1059,3 +1059,10 @@ class TableauUnitTest(TestCase):
         assert registry._global["Dashboard"].total == 7
         assert registry._global["Chart"].reconcilable is True
         assert registry._global["DashboardDataModel"].reconcilable is True
+
+    def test_yield_dashboard_tracks_progress(self):
+        self.tableau.progress_tracking.manual.set_total(Dashboard.__name__, 3)
+
+        list(self.tableau.yield_dashboard(MOCK_DASHBOARD))
+
+        assert self.tableau.progress_tracking.registry._global["Dashboard"].done == 1

--- a/ingestion/tests/unit/topology/dashboard/test_tableau.py
+++ b/ingestion/tests/unit/topology/dashboard/test_tableau.py
@@ -1072,6 +1072,18 @@ class TableauUnitTest(TestCase):
         assert registry._global["Dashboard"].total is None
         self.tableau.client.get_workbook_count.assert_not_called()
 
+    def test_get_dashboards_list_reconcilable_when_count_fails(self):
+        self.tableau.client = SimpleNamespace(
+            get_workbook_count=MagicMock(side_effect=Exception("boom")),
+            get_workbooks=MagicMock(return_value=iter([])),
+        )
+
+        list(self.tableau.get_dashboards_list())
+
+        registry = self.tableau.progress_tracking.registry
+        assert registry._global["Dashboard"].reconcilable is True
+        assert registry._global["Dashboard"].total is None
+
     def test_yield_dashboard_tracks_progress(self):
         self.tableau.progress_tracking.manual.set_total(Dashboard.__name__, 3)
 

--- a/ingestion/tests/unit/topology/dashboard/test_tableau.py
+++ b/ingestion/tests/unit/topology/dashboard/test_tableau.py
@@ -1058,6 +1058,20 @@ class TableauUnitTest(TestCase):
         registry = self.tableau.progress_tracking.registry
         assert registry._global["Dashboard"].total == 7
 
+    def test_get_dashboards_list_reconcilable_when_filtered(self):
+        self.tableau.client = SimpleNamespace(
+            get_workbook_count=MagicMock(return_value=7),
+            get_workbooks=MagicMock(return_value=iter([])),
+        )
+        self.tableau.source_config.dashboardFilterPattern = FilterPattern(excludes=["^skip$"])
+
+        list(self.tableau.get_dashboards_list())
+
+        registry = self.tableau.progress_tracking.registry
+        assert registry._global["Dashboard"].reconcilable is True
+        assert registry._global["Dashboard"].total is None
+        self.tableau.client.get_workbook_count.assert_not_called()
+
     def test_yield_dashboard_tracks_progress(self):
         self.tableau.progress_tracking.manual.set_total(Dashboard.__name__, 3)
 

--- a/ingestion/tests/unit/topology/dashboard/test_tableau_client.py
+++ b/ingestion/tests/unit/topology/dashboard/test_tableau_client.py
@@ -226,3 +226,16 @@ class TestTableauClientOwner(TestCase):
 
         with self.assertRaises(TableauOwnersNotFound):
             self.client.test_get_owners(include_owners=False)
+
+
+def test_get_workbook_count_reads_total_available():
+    """Test that get_workbook_count reads total_available from the pagination summary"""
+    client = TableauClient.__new__(TableauClient)
+    pagination = SimpleNamespace(total_available=42)
+    client.tableau_server = SimpleNamespace(
+        workbooks=SimpleNamespace(get=MagicMock(return_value=([], pagination)))
+    )
+
+    assert client.get_workbook_count() == 42
+    called_opts = client.tableau_server.workbooks.get.call_args.args[0]
+    assert called_opts.pagesize == 1

--- a/ingestion/tests/unit/topology/dashboard/test_tableau_client.py
+++ b/ingestion/tests/unit/topology/dashboard/test_tableau_client.py
@@ -232,9 +232,7 @@ def test_get_workbook_count_reads_total_available():
     """Test that get_workbook_count reads total_available from the pagination summary"""
     client = TableauClient.__new__(TableauClient)
     pagination = SimpleNamespace(total_available=42)
-    client.tableau_server = SimpleNamespace(
-        workbooks=SimpleNamespace(get=MagicMock(return_value=([], pagination)))
-    )
+    client.tableau_server = SimpleNamespace(workbooks=SimpleNamespace(get=MagicMock(return_value=([], pagination))))
 
     assert client.get_workbook_count() == 42
     called_opts = client.tableau_server.workbooks.get.call_args.args[0]


### PR DESCRIPTION
### Describe your changes:

Fixes #<ISSUE-NUMBER — please replace: linking an issue is required and the "Validate PR Metadata" gate fails without it>

I gave the **Looker** and **Tableau** dashboard connectors PowerBI-style progress totals (%/ETA) by switching both sources to `ProgressMode.MANUAL` and declaring prefetched denominators for `Dashboard` and `DashboardDataModel`, driving the numerators with explicit `.track(...)` calls in the entity processors. I used MANUAL rather than AUTO because the dashboard topology node is a *leaf* whose AUTO primary-stage resolves to `Chart` (not `Dashboard`), so AUTO cannot label the walk correctly — MANUAL with flat global counters keyed by entity-class `__name__` gives clean per-type totals. All totals come from calls the connectors already make (Looker `all_lookml_models()` / `all_dashboards()`) or one cheap new page-size-1 count (Tableau `total_available`), so no extra full-list materialization is introduced.

#
### Type of change:
- [x] Improvement

#
### High-level design:

Both sources set `progress_mode = ProgressMode.MANUAL`, so the topology runner makes zero progress calls and each source declares/increments flat header-level counters via `self.progress_tracking.manual`.

- **Tableau** (`tableau/client.py`, `tableau/metadata.py`): new `get_workbook_count()` (one `RequestOptions(pagesize=1)` request reading `pagination_item.total_available`) is the `Dashboard` denominator, declared in `get_dashboards_list` with a try/except fallback to `mark_reconcilable` so a count failure never aborts ingestion; `Chart` and `DashboardDataModel` are reconcilable. Tracking added in `yield_dashboard`, `yield_dashboard_chart`, and `_create_datamodel_request`.
- **Looker** (`looker/metadata.py`): `DashboardDataModel` total = `sum(len(m.explores))` from the existing `all_lookml_models()` nav (reconcilable, so standalone views grow it), and it now excludes models filtered out by `dataModelFilterPattern` to match what `fetch_lookml_explores` actually yields; `Dashboard` total = count of dashboards passing `dashboardFilterPattern` (the full list is still returned, `kept` is used only for the count); `Chart` is reconcilable. Tracking added in `yield_bulk_datamodel`, `yield_standalone_datamodels`, `yield_dashboard`, and `yield_dashboard_chart`.

Only these two connectors change mode; all other dashboard connectors remain AUTO. Counter keys reuse the entity-class `__name__` AUTO would have used, keeping the reporter consistent.

**Known limitations:** Tableau's `Dashboard` total is server-side pre-filter (`total_available`), so heavy `dashboardFilterPattern`/`projectFilterPattern` use may leave the bar short; Looker's `Dashboard` total honors `dashboardFilterPattern` but not `projectFilterPattern` (needs per-dashboard detail); Looker standalone views grow the reconcilable `DashboardDataModel` total mid-run rather than being in the initial count.

#
### Tests:

#### Use cases covered
- Tableau ingestion of a server with N workbooks reports a `Dashboard` progress total of N (pre-filter) and per-workbook `Chart`/`DashboardDataModel` counters.
- Looker ingestion reports a `DashboardDataModel` total equal to the sum of explores across kept models and a `Dashboard` total equal to the dashboards passing `dashboardFilterPattern`.
- With `dataModelFilterPattern` excluding a model, that model's explores are excluded from the Looker `DashboardDataModel` total so the bar can reach 100%.

#### Unit tests
- [x] I added unit tests for the new/changed logic (pytest, plain `assert`/`TestCase` style matching each file).
- Files added/updated: `ingestion/tests/unit/topology/dashboard/test_tableau_client.py`, `test_tableau.py`, `test_looker.py`.
- Coverage: new tests cover `get_workbook_count`, MANUAL-mode total declaration, per-processor tracking, and the `dataModelFilterPattern` exclusion (RED→GREEN verified). Both connector suites: 91 passed; full dashboard dir: 497 passed, 1 skipped (no regressions).

#### Backend integration tests
- [x] Not applicable (no backend API changes).

#### Ingestion integration tests
- [x] Not applicable (unit-level change to progress accounting; live Looker totals were validated manually — see below).

#### Playwright (UI) tests
- [x] Not applicable (no UI changes).

#### Manual testing performed
1. Ran a throwaway script against a live Looker instance confirming the declared totals equal the real counts (`sum(len(m.explores))` explores, `len(all_dashboards)` dashboards).
2. Ran `ruff check` + `ruff format --check` (clean) and basedpyright on the changed source files (no new errors; CI baseline untouched).

#
### UI screen recording / screenshots:

Not applicable.

#
### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] For JSON Schema changes: I updated the migration scripts or explained why it is not needed. (No schema changes.)
- [x] For UI changes: I attached a screen recording and/or screenshots above. (No UI changes.)
- [x] I have added tests (unit / integration / Playwright as applicable) and listed them above.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds manual progress reporting for Looker and Tableau dashboard ingestion. The main changes are:

- Looker now declares manual totals for dashboards and dashboard data models.
- Tableau now declares dashboard totals from workbook pagination metadata.
- Both connectors add explicit progress tracking for processed dashboards and data models.
- Shared filter helpers and unit tests were added for the new counting paths.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge.

- No blocking issues found in the changed code.

</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| ingestion/src/metadata/ingestion/source/dashboard/looker/metadata.py | Adds manual Looker progress totals, filter-aware counting, and explicit tracking. |
| ingestion/src/metadata/ingestion/source/dashboard/tableau/metadata.py | Adds manual Tableau dashboard progress declaration and tracking. |
| ingestion/src/metadata/ingestion/source/dashboard/tableau/client.py | Adds a workbook count helper using Tableau pagination metadata. |
| ingestion/src/metadata/utils/filters.py | Adds a helper for detecting active filter patterns. |

</details>

<sub>Reviews (4): Last reviewed commit: ["fix(looker): guard None model/explore na..."](https://github.com/open-metadata/openmetadata/commit/f7b8b7639a99ed3faecf9c58d974fea98d5b3af9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43287331)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Context used - CLAUDE.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=52f0d9d9-cad1-4e7d-b070-de181a0aa5e7))
- Context used - openmetadata-ui-core-components/CLAUDE.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=41754627-b2bf-474b-8082-f37ef1a07013))
- Context used - AGENTS.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=ef262f5f-911f-44f3-8d2d-e9cb1579c8c8))
</details>

<!-- /greptile_comment -->