### PR TITLE
refactor(ui): remove MUI from DomainTreeView

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/DomainListing/components/DomainTreeView.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DomainListing/components/DomainTreeView.test.tsx
@@ -1,0 +1,450 @@
+/*
+ *  Copyright 2025 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+  within,
+} from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { DOMAINS_LIST } from '../../../mocks/Domains.mock';
+import { ENTITY_PERMISSIONS } from '../../../mocks/Permissions.mock';
+import {
+  getDomainByName,
+  getDomainChildrenPaginated,
+  searchDomains,
+} from '../../../rest/domainAPI';
+import DomainTreeView from './DomainTreeView';
+
+// Holds the latest callbacks passed to the Tree mock so tests can invoke them.
+let capturedCallbacks: {
+  onSelectionChange?: (keys: Set<string>) => void;
+  onExpandedChange?: (keys: Set<string>) => void;
+  onAction?: (key: string) => void;
+} = {};
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+jest.mock('@openmetadata/ui-core-components', () => ({
+  Avatar: jest.fn(() => null),
+  Badge: jest.fn(({ children }: { children: React.ReactNode }) => (
+    <span data-testid="badge">{children}</span>
+  )),
+  Box: jest.fn(({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  )),
+  Typography: jest.fn(({ children }: { children: React.ReactNode }) => (
+    <span>{children}</span>
+  )),
+  Tree: jest.fn(), // implementation configured per-test in beforeEach
+}));
+
+jest.mock('../../common/ResizablePanels/ResizableLeftPanels', () =>
+  jest.fn(({ firstPanel, secondPanel }: any) => (
+    <div>
+      <div data-testid="left-panel">{firstPanel.children}</div>
+      <div data-testid="right-panel">{secondPanel.children}</div>
+    </div>
+  ))
+);
+
+jest.mock('../../Domain/DomainDetails/DomainDetails.component', () =>
+  jest.fn(() => <div data-testid="domain-details" />)
+);
+
+jest.mock('../../common/ErrorWithPlaceholder/ErrorPlaceHolder', () =>
+  jest.fn(({ onClick }: any) => (
+    <button data-testid="error-placeholder" onClick={onClick}>
+      Add Domain
+    </button>
+  ))
+);
+
+jest.mock('../../common/Loader/Loader', () =>
+  jest.fn(() => <div data-testid="loader" />)
+);
+
+jest.mock('../../../rest/domainAPI');
+
+jest.mock('../../../hooks/useApplicationStore', () => ({
+  useApplicationStore: () => ({ currentUser: { id: 'user-1' } }),
+}));
+
+jest.mock('../../../hooks/useDomainStore', () => ({
+  useDomainStore: () => ({ userDomains: [], isDomainRestricted: false }),
+}));
+
+jest.mock('../../../context/PermissionProvider/PermissionProvider', () => ({
+  usePermissionProvider: () => ({
+    permissions: { domain: ENTITY_PERMISSIONS },
+  }),
+}));
+
+jest.mock('../../../utils/DomainRestrictionUtils', () => ({
+  filterDomainsToAllowed: jest.fn((domains: unknown[]) => domains),
+}));
+
+jest.mock('../../../utils/DomainUtils', () => ({
+  convertDomainsToTreeOptions: jest.fn((domains: unknown[]) => domains),
+}));
+
+jest.mock('../../../utils/StringUtils', () => ({
+  escapeESReservedCharacters: jest.fn((v: string) => v ?? ''),
+  getDecodedFqn: jest.fn((v: string) => v ?? ''),
+  getEncodedFqn: jest.fn((v: string) => v ?? ''),
+}));
+
+jest.mock('../../../utils/EntityNameUtils', () => ({
+  getEntityName: jest.fn(
+    (entity: any) => entity?.displayName || entity?.name || ''
+  ),
+}));
+
+jest.mock('../../../utils/IconUtils', () => ({
+  getEntityAvatarProps: jest.fn(() => ({})),
+}));
+
+// ---------------------------------------------------------------------------
+// Typed mock references
+// ---------------------------------------------------------------------------
+
+const mockGetDomainChildrenPaginated =
+  getDomainChildrenPaginated as jest.MockedFunction<
+    typeof getDomainChildrenPaginated
+  >;
+const mockGetDomainByName = getDomainByName as jest.MockedFunction<
+  typeof getDomainByName
+>;
+const mockSearchDomains = searchDomains as jest.MockedFunction<
+  typeof searchDomains
+>;
+
+// ---------------------------------------------------------------------------
+// Test fixtures
+// ---------------------------------------------------------------------------
+
+const PAGINATED_ROOT_RESPONSE = {
+  data: DOMAINS_LIST,
+  paging: { total: 2 },
+};
+
+const DOMAIN_WITH_MANY_CHILDREN = {
+  ...DOMAINS_LIST[0],
+  childrenCount: 20,
+  children: [],
+};
+
+// 1 child returned but total is 20 → (0 + 15 < 20) → hasMoreChildren = true
+const CHILD_RESPONSE_WITH_MORE = {
+  data: [{ ...DOMAINS_LIST[1], fullyQualifiedName: 'Domain1.Child1' }],
+  paging: { total: 20 },
+};
+
+// ---------------------------------------------------------------------------
+// Render helper
+// ---------------------------------------------------------------------------
+
+const defaultProps = {
+  searchQuery: undefined as string | undefined,
+  filters: undefined as Record<string, string[]> | undefined,
+  refreshToken: 0,
+  openAddDomainDrawer: jest.fn(),
+};
+
+const renderComponent = (props: Partial<typeof defaultProps> = {}) =>
+  render(
+    <MemoryRouter>
+      <DomainTreeView {...defaultProps} {...props} />
+    </MemoryRouter>
+  );
+
+// ---------------------------------------------------------------------------
+// Suite
+// ---------------------------------------------------------------------------
+
+describe('DomainTreeView', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    capturedCallbacks = {};
+
+    // Wire up Tree mock to capture callbacks on each render
+    const { Tree } = jest.requireMock('@openmetadata/ui-core-components');
+    const TreeMock = Tree as jest.MockedFunction<any>;
+
+    TreeMock.mockImplementation(
+      ({
+        children,
+        onSelectionChange,
+        onExpandedChange,
+        onAction,
+      }: any) => {
+        capturedCallbacks = { onAction, onExpandedChange, onSelectionChange };
+
+        return <div data-testid="mock-tree">{children}</div>;
+      }
+    );
+    TreeMock.ExpandButton = jest.fn(() => null);
+    TreeMock.Header = jest.fn(({ children }: any) => <div>{children}</div>);
+    TreeMock.Item = jest.fn(({ children, id }: any) => (
+      <div data-testid={`tree-item-${id}`}>{children}</div>
+    ));
+    TreeMock.ItemContent = jest.fn(({ children }: any) => (
+      <div>{children}</div>
+    ));
+    TreeMock.Section = jest.fn(({ children }: any) => <div>{children}</div>);
+
+    // Default API responses
+    mockGetDomainChildrenPaginated.mockResolvedValue(
+      PAGINATED_ROOT_RESPONSE as any
+    );
+    mockGetDomainByName.mockResolvedValue(DOMAINS_LIST[0] as any);
+    mockSearchDomains.mockResolvedValue(DOMAINS_LIST as any);
+  });
+
+  // -------------------------------------------------------------------------
+  describe('initial load', () => {
+    it('shows a loader while root domains are being fetched', async () => {
+      mockGetDomainChildrenPaginated.mockImplementation(
+        () => new Promise(() => {})
+      );
+      renderComponent();
+      expect(await screen.findByTestId('loader')).toBeInTheDocument();
+    });
+
+    it('calls getDomainChildrenPaginated on mount', async () => {
+      renderComponent();
+      await waitFor(() => {
+        expect(mockGetDomainChildrenPaginated).toHaveBeenCalledWith(
+          undefined,
+          15,
+          0
+        );
+      });
+    });
+
+    it('renders a Tree.Item for each loaded domain', async () => {
+      renderComponent();
+      await waitFor(() => {
+        expect(screen.getByTestId('tree-item-Domain1')).toBeInTheDocument();
+        expect(screen.getByTestId('tree-item-Domain2')).toBeInTheDocument();
+      });
+    });
+
+    it('auto-selects the first domain and fetches its details', async () => {
+      renderComponent();
+      await waitFor(() => {
+        expect(mockGetDomainByName).toHaveBeenCalledWith(
+          'Domain1',
+          expect.objectContaining({ fields: expect.any(Array) })
+        );
+      });
+    });
+
+    it('shows ErrorPlaceHolder when no domains exist', async () => {
+      mockGetDomainChildrenPaginated.mockResolvedValue({
+        data: [],
+        paging: { total: 0 },
+      } as any);
+      renderComponent();
+      expect(
+        await screen.findByTestId('error-placeholder')
+      ).toBeInTheDocument();
+    });
+
+    it('calls openAddDomainDrawer when the ErrorPlaceHolder button is clicked', async () => {
+      mockGetDomainChildrenPaginated.mockResolvedValue({
+        data: [],
+        paging: { total: 0 },
+      } as any);
+      const openAddDomainDrawer = jest.fn();
+      renderComponent({ openAddDomainDrawer });
+      fireEvent.click(await screen.findByTestId('error-placeholder'));
+      expect(openAddDomainDrawer).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  describe('search', () => {
+    it('calls searchDomains (not getDomainChildrenPaginated) when searchQuery is set', async () => {
+      renderComponent({ searchQuery: 'marketing' });
+      await waitFor(() => {
+        expect(mockSearchDomains).toHaveBeenCalled();
+      });
+      expect(mockGetDomainChildrenPaginated).not.toHaveBeenCalled();
+    });
+
+    it('calls getDomainChildrenPaginated when searchQuery is empty', async () => {
+      renderComponent({ searchQuery: '' });
+      await waitFor(() => {
+        expect(mockGetDomainChildrenPaginated).toHaveBeenCalledWith(
+          undefined,
+          15,
+          0
+        );
+      });
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  describe('domain selection', () => {
+    it('fetches domain details when Tree fires onSelectionChange', async () => {
+      renderComponent();
+      await waitFor(() =>
+        expect(mockGetDomainChildrenPaginated).toHaveBeenCalled()
+      );
+
+      act(() => {
+        capturedCallbacks.onSelectionChange?.(new Set(['Domain2']));
+      });
+
+      await waitFor(() => {
+        expect(mockGetDomainByName).toHaveBeenCalledWith(
+          'Domain2',
+          expect.objectContaining({ fields: expect.any(Array) })
+        );
+      });
+    });
+
+    it('renders DomainDetails in the right panel after a domain loads', async () => {
+      renderComponent();
+      await waitFor(() => expect(mockGetDomainByName).toHaveBeenCalled());
+      expect(
+        within(screen.getByTestId('right-panel')).getByTestId('domain-details')
+      ).toBeInTheDocument();
+    });
+
+    it('ignores onSelectionChange events for load-more items', async () => {
+      renderComponent();
+      await waitFor(() =>
+        expect(mockGetDomainByName).toHaveBeenCalledTimes(1)
+      );
+
+      act(() => {
+        capturedCallbacks.onSelectionChange?.(new Set(['Domain1__load_more']));
+      });
+
+      // getDomainByName must not be called again
+      expect(mockGetDomainByName).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  describe('tree expansion', () => {
+    it('fetches children when a domain with childrenCount > 0 is expanded', async () => {
+      mockGetDomainChildrenPaginated.mockResolvedValueOnce({
+        data: [DOMAIN_WITH_MANY_CHILDREN],
+        paging: { total: 1 },
+      } as any);
+      renderComponent();
+      await waitFor(() =>
+        expect(mockGetDomainChildrenPaginated).toHaveBeenCalled()
+      );
+
+      act(() => {
+        capturedCallbacks.onExpandedChange?.(new Set(['Domain1']));
+      });
+
+      await waitFor(() => {
+        expect(mockGetDomainChildrenPaginated).toHaveBeenCalledWith(
+          'Domain1',
+          15,
+          0
+        );
+      });
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  describe('load more – keyboard (onAction)', () => {
+    it('calls getDomainChildrenPaginated when onAction fires with a __load_more key', async () => {
+      renderComponent();
+      await waitFor(() =>
+        expect(mockGetDomainChildrenPaginated).toHaveBeenCalled()
+      );
+      const callsBefore = mockGetDomainChildrenPaginated.mock.calls.length;
+
+      act(() => {
+        capturedCallbacks.onAction?.('Domain1__load_more');
+      });
+
+      await waitFor(() => {
+        expect(
+          mockGetDomainChildrenPaginated.mock.calls.length
+        ).toBeGreaterThan(callsBefore);
+        expect(mockGetDomainChildrenPaginated).toHaveBeenCalledWith(
+          'Domain1',
+          15,
+          expect.any(Number)
+        );
+      });
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  describe('load more – child button click', () => {
+    it('clicking the load-more button fetches the next page of children', async () => {
+      // Root response: one domain with 20 children
+      mockGetDomainChildrenPaginated
+        .mockResolvedValueOnce({
+          data: [DOMAIN_WITH_MANY_CHILDREN],
+          paging: { total: 1 },
+        } as any)
+        // Children response: 1 child, total 20 → hasMoreChildren = true
+        .mockResolvedValue(CHILD_RESPONSE_WITH_MORE as any);
+
+      renderComponent();
+      await waitFor(() =>
+        expect(mockGetDomainChildrenPaginated).toHaveBeenCalled()
+      );
+
+      // Expand Domain1 to trigger child load
+      act(() => {
+        capturedCallbacks.onExpandedChange?.(new Set(['Domain1']));
+      });
+      await waitFor(() =>
+        expect(mockGetDomainChildrenPaginated).toHaveBeenCalledWith(
+          'Domain1',
+          15,
+          0
+        )
+      );
+
+      // Load-more Tree.Item should now be in the DOM
+      await waitFor(() =>
+        expect(
+          screen.getByTestId('tree-item-Domain1__load_more')
+        ).toBeInTheDocument()
+      );
+
+      const loadMoreBtn = within(
+        screen.getByTestId('tree-item-Domain1__load_more')
+      ).getByRole('button');
+
+      fireEvent.click(loadMoreBtn);
+
+      // Offset moves to 15 (page 2)
+      await waitFor(() => {
+        expect(mockGetDomainChildrenPaginated).toHaveBeenCalledWith(
+          'Domain1',
+          15,
+          15
+        );
+      });
+    });
+  });
+});

--- a/openmetadata-ui/src/main/resources/ui/src/components/DomainListing/components/DomainTreeView.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DomainListing/components/DomainTreeView.test.tsx
@@ -223,6 +223,7 @@ describe('DomainTreeView', () => {
         () => new Promise(() => {})
       );
       renderComponent();
+
       expect(await screen.findByTestId('loader')).toBeInTheDocument();
     });
 
@@ -261,6 +262,7 @@ describe('DomainTreeView', () => {
         paging: { total: 0 },
       } as any);
       renderComponent();
+
       expect(
         await screen.findByTestId('error-placeholder')
       ).toBeInTheDocument();
@@ -274,6 +276,7 @@ describe('DomainTreeView', () => {
       const openAddDomainDrawer = jest.fn();
       renderComponent({ openAddDomainDrawer });
       fireEvent.click(await screen.findByTestId('error-placeholder'));
+
       expect(openAddDomainDrawer).toHaveBeenCalledTimes(1);
     });
   });
@@ -285,6 +288,7 @@ describe('DomainTreeView', () => {
       await waitFor(() => {
         expect(mockSearchDomains).toHaveBeenCalled();
       });
+
       expect(mockGetDomainChildrenPaginated).not.toHaveBeenCalled();
     });
 
@@ -323,6 +327,7 @@ describe('DomainTreeView', () => {
     it('renders DomainDetails in the right panel after a domain loads', async () => {
       renderComponent();
       await waitFor(() => expect(mockGetDomainByName).toHaveBeenCalled());
+
       expect(
         within(screen.getByTestId('right-panel')).getByTestId('domain-details')
       ).toBeInTheDocument();

--- a/openmetadata-ui/src/main/resources/ui/src/components/DomainListing/components/DomainTreeView.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DomainListing/components/DomainTreeView.test.tsx
@@ -187,12 +187,7 @@ describe('DomainTreeView', () => {
     const TreeMock = Tree as jest.MockedFunction<any>;
 
     TreeMock.mockImplementation(
-      ({
-        children,
-        onSelectionChange,
-        onExpandedChange,
-        onAction,
-      }: any) => {
+      ({ children, onSelectionChange, onExpandedChange, onAction }: any) => {
         capturedCallbacks = { onAction, onExpandedChange, onSelectionChange };
 
         return <div data-testid="mock-tree">{children}</div>;
@@ -335,9 +330,7 @@ describe('DomainTreeView', () => {
 
     it('ignores onSelectionChange events for load-more items', async () => {
       renderComponent();
-      await waitFor(() =>
-        expect(mockGetDomainByName).toHaveBeenCalledTimes(1)
-      );
+      await waitFor(() => expect(mockGetDomainByName).toHaveBeenCalledTimes(1));
 
       act(() => {
         capturedCallbacks.onSelectionChange?.(new Set(['Domain1__load_more']));

--- a/openmetadata-ui/src/main/resources/ui/src/components/DomainListing/components/DomainTreeView.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DomainListing/components/DomainTreeView.tsx
@@ -11,7 +11,7 @@
  *  limitations under the License.
  */
 
-import type { Selection } from '@openmetadata/ui-core-components';
+import type { Key, Selection } from '@openmetadata/ui-core-components';
 import {
   Avatar,
   Badge,
@@ -742,6 +742,18 @@ const DomainTreeView = ({
     [fetchDomainDetails, navigate, updateExpansionForFqn]
   );
 
+  const handleAction = useCallback(
+    (key: Key) => {
+      const keyStr = String(key);
+
+      if (keyStr.endsWith(LOAD_MORE_ITEM_SUFFIX)) {
+        const parentFqn = keyStr.slice(0, -LOAD_MORE_ITEM_SUFFIX.length);
+        loadDomains(parentFqn, true);
+      }
+    },
+    [loadDomains]
+  );
+
   const handleScroll = useCallback(
     (event: React.UIEvent<HTMLDivElement>) => {
       if (
@@ -797,12 +809,16 @@ const DomainTreeView = ({
                 <Avatar size="xs" {...getEntityAvatarProps(node)} />
                 <Typography
                   className="tw:text-primary"
-                  weight="regular"
-                  size="text-sm">
+                  size="text-sm"
+                  weight="regular">
                   {getEntityName(node)}
                 </Typography>
                 {hasChildren && (
-                  <Badge color="gray" className="tw:px-3" size="xs" type="pill-color">
+                  <Badge
+                    className="tw:px-3"
+                    color="gray"
+                    size="xs"
+                    type="pill-color">
                     {childrenCount}
                   </Badge>
                 )}
@@ -816,14 +832,7 @@ const DomainTreeView = ({
                 key={`${identifier}${LOAD_MORE_ITEM_SUFFIX}`}
                 textValue={t('label.load-more')}>
                 <Tree.ItemContent showExpandIcon={false}>
-                  <div
-                    className="tw:flex tw:items-center tw:gap-2 tw:cursor-pointer tw:text-brand-primary tw:text-sm"
-                    role="button"
-                    tabIndex={-1}
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      loadDomains(identifier, true);
-                    }}>
+                  <div className="tw:flex tw:items-center tw:gap-2 tw:text-brand-primary tw:text-sm">
                     {loadingChildren[identifier] ? (
                       <Loader size="small" />
                     ) : (
@@ -864,9 +873,7 @@ const DomainTreeView = ({
     }
 
     return (
-      <Typography
-        className="tw:text-secondary tw:mt-2"
-        size="text-sm">
+      <Typography className="tw:text-secondary tw:mt-2" size="text-sm">
         {t('label.no-entity-selected', {
           entity: t('label.domain'),
         })}
@@ -893,9 +900,7 @@ const DomainTreeView = ({
 
     if (hierarchy.length === 0) {
       return (
-        <Typography
-          className="tw:text-secondary tw:mt-2"
-          size="text-sm">
+        <Typography className="tw:text-secondary tw:mt-2" size="text-sm">
           {t('label.no-entity-available', {
             entity: t('label.domain-plural'),
           })}
@@ -913,6 +918,7 @@ const DomainTreeView = ({
             selectedFqn ? new Set([selectedFqn]) : new Set<string>()
           }
           selectionMode="single"
+          onAction={handleAction}
           onExpandedChange={handleExpandedChange}
           onSelectionChange={handleSelectionChange}>
           {renderTreeItems(hierarchy)}

--- a/openmetadata-ui/src/main/resources/ui/src/components/DomainListing/components/DomainTreeView.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DomainListing/components/DomainTreeView.tsx
@@ -11,19 +11,21 @@
  *  limitations under the License.
  */
 
-import { Box, Button, Chip, Typography, useTheme } from '@mui/material';
-import { SimpleTreeView, TreeItem, treeItemClasses } from '@mui/x-tree-view';
-import { Avatar } from '@openmetadata/ui-core-components';
-import { Plus } from '@untitledui/icons';
+import type { Selection } from '@openmetadata/ui-core-components';
+import {
+  Avatar,
+  Badge,
+  Box,
+  Tree,
+  Typography,
+} from '@openmetadata/ui-core-components';
 import { AxiosError } from 'axios';
 import { compare, Operation as JsonPathOperation } from 'fast-json-patch';
 import { isEmpty } from 'lodash';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
-import { ReactComponent as ArrowCircleDown } from '../../../assets/svg/arrow-circle-down.svg';
 import { ReactComponent as FolderEmptyIcon } from '../../../assets/svg/folder-empty.svg';
-import { BORDER_COLOR } from '../../../constants/constants';
 import { LEARNING_PAGE_IDS } from '../../../constants/Learning.constants';
 import { usePermissionProvider } from '../../../context/PermissionProvider/PermissionProvider';
 import { ERROR_PLACEHOLDER_TYPE } from '../../../enums/common.enum';
@@ -66,6 +68,7 @@ interface DomainTreeViewProps {
 
 const INITIAL_PAGE_SIZE = 15;
 const SCROLL_TRIGGER_THRESHOLD = 200;
+const LOAD_MORE_ITEM_SUFFIX = '__load_more';
 
 const DomainTreeView = ({
   searchQuery,
@@ -73,11 +76,6 @@ const DomainTreeView = ({
   refreshToken = 0,
   openAddDomainDrawer,
 }: DomainTreeViewProps) => {
-  const theme = useTheme();
-  const outlineColor =
-    theme.palette.allShades?.gray?.[200] ?? theme.palette.grey[300];
-  const childIndent = theme.spacing(2);
-  const connectorOffset = theme.spacing(1.5);
   const navigate = useNavigate();
   const { t } = useTranslation();
   const { currentUser } = useApplicationStore();
@@ -502,9 +500,18 @@ const DomainTreeView = ({
   }, [selectedFqn]);
 
   const handleSelectionChange = useCallback(
-    (value: string | string[] | null) => {
-      const nextFqn = Array.isArray(value) ? value[0] : value;
-      if (!nextFqn || nextFqn === selectedFqnRef.current) {
+    (keys: Selection) => {
+      if (keys === 'all') {
+        return;
+      }
+
+      const nextFqn = Array.from(keys).map(String)[0] ?? null;
+
+      if (
+        !nextFqn ||
+        nextFqn.endsWith(LOAD_MORE_ITEM_SUFFIX) ||
+        nextFqn === selectedFqnRef.current
+      ) {
         return;
       }
 
@@ -515,11 +522,17 @@ const DomainTreeView = ({
   );
 
   const handleExpandedChange = useCallback(
-    (_: unknown, ids: string[]) => {
+    (keys: Selection) => {
+      if (keys === 'all') {
+        return;
+      }
+
+      const ids = Array.from(keys).map(String);
       const newlyExpandedIds = ids.filter((id) => !expandedItems.includes(id));
 
       for (const fqn of newlyExpandedIds) {
         const domain = domainMapper[fqn];
+
         if (!domain) {
           continue;
         }
@@ -535,35 +548,6 @@ const DomainTreeView = ({
       setExpandedItems(ids);
     },
     [expandedItems, domainMapper, loadDomains, loadingChildren]
-  );
-
-  const handleScroll = useCallback(
-    (event: React.UIEvent<HTMLDivElement>) => {
-      if (
-        !hasMore ||
-        isLoadingMore ||
-        isHierarchyLoading ||
-        searchQuery ||
-        hasActiveFilters
-      ) {
-        return;
-      }
-
-      const { scrollTop, scrollHeight, clientHeight } = event.currentTarget;
-      const distanceFromBottom = scrollHeight - scrollTop - clientHeight;
-
-      if (distanceFromBottom < SCROLL_TRIGGER_THRESHOLD) {
-        loadDomains(undefined, true);
-      }
-    },
-    [
-      hasMore,
-      isLoadingMore,
-      isHierarchyLoading,
-      searchQuery,
-      hasActiveFilters,
-      loadDomains,
-    ]
   );
 
   const refreshAll = useCallback(async () => {
@@ -758,127 +742,102 @@ const DomainTreeView = ({
     [fetchDomainDetails, navigate, updateExpansionForFqn]
   );
 
-  const handleLoadMoreChildren = useCallback(
-    (parentFqn: string, event: React.MouseEvent) => {
-      event.stopPropagation();
-      loadDomains(parentFqn, true);
+  const handleScroll = useCallback(
+    (event: React.UIEvent<HTMLDivElement>) => {
+      if (
+        !hasMore ||
+        isLoadingMore ||
+        isHierarchyLoading ||
+        searchQuery ||
+        hasActiveFilters
+      ) {
+        return;
+      }
+
+      const { scrollTop, scrollHeight, clientHeight } = event.currentTarget;
+
+      if (scrollHeight - scrollTop - clientHeight < SCROLL_TRIGGER_THRESHOLD) {
+        loadDomains(undefined, true);
+      }
     },
-    [loadDomains]
+    [
+      hasMore,
+      isLoadingMore,
+      isHierarchyLoading,
+      searchQuery,
+      hasActiveFilters,
+      loadDomains,
+    ]
   );
 
   const renderTreeItems = useCallback(
-    (nodes: Domain[], parentFqn?: string) => {
-      const items = nodes.map((node) => {
-        const identifier = node.fullyQualifiedName || node.name || node.id;
+    (nodes: Domain[]) => {
+      return nodes.map((node) => {
+        const identifier = node?.fullyQualifiedName || node?.name || node?.id;
 
         if (!identifier) {
           return null;
         }
 
-        const childDomains = (node.children as unknown as Domain[]) ?? [];
-        const childrenCount = node.childrenCount || childDomains.length || 0;
-        const hasChildren = childDomains.length > 0 || childrenCount > 0;
-        const isLoading = loadingChildren[identifier] ?? false;
+        const childDomains = (node?.children as unknown as Domain[]) ?? [];
+        const childrenCount = node?.childrenCount || childDomains?.length || 0;
+        const hasChildren = childDomains?.length > 0 || childrenCount > 0;
+        const isLoading = loadingChildren?.[identifier] ?? false;
+        const paging = childPaging?.[identifier];
+        const hasMoreChildren =
+          paging != null && paging?.offset + paging?.limit < paging?.total;
 
         return (
-          <TreeItem
-            itemId={identifier}
+          <Tree.Item
+            id={identifier}
             key={identifier}
-            label={
-              <Box
-                sx={{
-                  display: 'flex',
-                  alignItems: 'center',
-                  gap: 2,
-                }}>
+            textValue={getEntityName(node)}>
+            <Tree.ItemContent showGuideLines hasChildItems={hasChildren}>
+              <Box align="center" direction="row" gap={2}>
                 <Avatar size="xs" {...getEntityAvatarProps(node)} />
                 <Typography
-                  sx={{
-                    color: theme.palette.allShades?.gray?.[800],
-                  }}
-                  variant="body2">
+                  className="tw:text-primary"
+                  weight="regular"
+                  size="text-sm">
                   {getEntityName(node)}
                 </Typography>
                 {hasChildren && (
-                  <Chip
-                    label={childrenCount}
-                    size="small"
-                    sx={{
-                      height: 20,
-                      border: 'none',
-                      color: theme.palette.allShades?.gray?.[800],
-                      fontWeight: theme.typography.fontWeightRegular,
-                      backgroundColor: theme.palette.allShades?.blueGray?.[100],
-                    }}
-                  />
+                  <Badge color="gray" className="tw:px-3" size="xs" type="pill-color">
+                    {childrenCount}
+                  </Badge>
                 )}
                 {isLoading && <Loader size="small" />}
               </Box>
-            }>
-            {childDomains.length > 0
-              ? renderTreeItems(childDomains, identifier)
-              : hasChildren && <div />}
-          </TreeItem>
+            </Tree.ItemContent>
+            {childDomains.length > 0 && renderTreeItems(childDomains)}
+            {hasMoreChildren && (
+              <Tree.Item
+                id={`${identifier}${LOAD_MORE_ITEM_SUFFIX}`}
+                key={`${identifier}${LOAD_MORE_ITEM_SUFFIX}`}
+                textValue={t('label.load-more')}>
+                <Tree.ItemContent showExpandIcon={false}>
+                  <div
+                    className="tw:flex tw:items-center tw:gap-2 tw:cursor-pointer tw:text-brand-primary tw:text-sm"
+                    role="button"
+                    tabIndex={-1}
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      loadDomains(identifier, true);
+                    }}>
+                    {loadingChildren[identifier] ? (
+                      <Loader size="small" />
+                    ) : (
+                      t('label.load-more')
+                    )}
+                  </div>
+                </Tree.ItemContent>
+              </Tree.Item>
+            )}
+          </Tree.Item>
         );
       });
-
-      if (parentFqn) {
-        const paging = childPaging[parentFqn];
-        if (paging) {
-          const hasMoreChildren = paging.offset + paging.limit < paging.total;
-          const isLoadingMore = loadingChildren[parentFqn] ?? false;
-
-          if (hasMoreChildren) {
-            items.push(
-              <Box
-                key={`${parentFqn}-load-more`}
-                sx={{
-                  ml: 1,
-                  mb: 1.5,
-                }}>
-                <Button
-                  startIcon={isLoadingMore ? null : <Plus />}
-                  sx={{
-                    p: 0,
-                    cursor: 'pointer',
-                    fontSize: '14px',
-                    color: theme.palette.primary.main,
-                    fontWeight: theme.typography.fontWeightMedium,
-                    '&:hover': {
-                      color: theme.palette.primary.dark,
-                      backgroundColor: 'transparent',
-                    },
-                  }}
-                  variant="text"
-                  onClick={(e) => handleLoadMoreChildren(parentFqn, e)}>
-                  {isLoadingMore ? (
-                    <Loader size="small" />
-                  ) : (
-                    <div>{t('label.load-more')}</div>
-                  )}
-                </Button>
-              </Box>
-            );
-          }
-        }
-      }
-
-      return items;
     },
-    [
-      childIndent,
-      connectorOffset,
-      outlineColor,
-      theme.palette.allShades?.gray,
-      theme.palette.primary.main,
-      theme.typography.fontWeightMedium,
-      theme.typography.fontWeightRegular,
-      loadingChildren,
-      childPaging,
-      handleLoadMoreChildren,
-      t,
-      hierarchy,
-    ]
+    [loadingChildren, childPaging, loadDomains, t]
   );
 
   const domainSection = useMemo(() => {
@@ -905,7 +864,9 @@ const DomainTreeView = ({
     }
 
     return (
-      <Typography sx={{ color: 'text.secondary', mt: 2 }} variant="body2">
+      <Typography
+        className="tw:text-secondary tw:mt-2"
+        size="text-sm">
         {t('label.no-entity-selected', {
           entity: t('label.domain'),
         })}
@@ -932,7 +893,9 @@ const DomainTreeView = ({
 
     if (hierarchy.length === 0) {
       return (
-        <Typography sx={{ color: 'text.secondary', mt: 2 }} variant="body2">
+        <Typography
+          className="tw:text-secondary tw:mt-2"
+          size="text-sm">
           {t('label.no-entity-available', {
             entity: t('label.domain-plural'),
           })}
@@ -942,133 +905,20 @@ const DomainTreeView = ({
 
     return (
       <>
-        <SimpleTreeView
-          expandedItems={expandedItems}
-          selectedItems={selectedFqn}
-          slots={{
-            expandIcon: ArrowCircleDown,
-            collapseIcon: ArrowCircleDown,
-          }}
-          sx={{
-            '--tree-item-center': '22px',
-            '& .MuiTreeItem-content': {
-              borderRadius: 1,
-              gap: 2,
-              p: 0,
-              mb: 2,
-              display: 'flex',
-              alignItems: 'center',
-              position: 'relative',
-              '&::before': {
-                content: '""',
-                position: 'absolute',
-                left: '-24px',
-                top: '50%',
-                transform: 'translateY(-50%)',
-                width: '16px',
-                height: '1px',
-                background: theme.palette.allShades?.gray?.[200],
-                zIndex: 0,
-              },
-            },
-
-            '& .MuiTreeItem-label': { p: 1 },
-            '& .MuiChip-root': { px: 3 },
-            '& .MuiChip-label': { fontSize: '10px' },
-
-            '& .MuiTreeItem-iconContainer': {
-              transition: 'transform 0.2s ease-in-out',
-              '& svg': {
-                transform: 'rotate(-90deg)',
-              },
-            },
-
-            '& .Mui-expanded > .MuiTreeItem-iconContainer svg': {
-              transform: 'rotate(0deg)',
-            },
-
-            '& .MuiTreeItem-iconContainer:empty': { display: 'none' },
-
-            [`& .${treeItemClasses.groupTransition}`]: {
-              ml: 3,
-              pl: 5,
-              position: 'relative',
-              '&::before': {
-                content: '""',
-                position: 'absolute',
-                left: '-4.5px',
-                top: '-24px',
-                bottom: '24px',
-                width: '1px',
-                background: theme.palette.allShades?.gray?.[200],
-                zIndex: 0,
-              },
-            },
-
-            '& .MuiTreeItem-root:last-of-type, & .MuiTreeItem-group > .MuiTreeItem-root:last-of-type':
-              {
-                mb: 0,
-              },
-
-            '& .MuiTreeItem-content:has(.MuiTreeItem-iconContainer:empty)': {
-              '&:hover': {
-                backgroundColor: theme.palette.action.hover,
-              },
-              '&.Mui-selected': {
-                backgroundColor: theme.palette.allShades?.blue?.[50],
-              },
-            },
-
-            '& .MuiTreeItem-content:has(.MuiTreeItem-iconContainer:not(:empty))':
-              {
-                '&:hover, &.Mui-selected': {
-                  backgroundColor: 'transparent !important',
-                },
-                '&:hover .MuiTreeItem-label': {
-                  backgroundColor: theme.palette.action.hover,
-                  borderRadius: '8px',
-                },
-                '&.Mui-selected .MuiTreeItem-label': {
-                  backgroundColor: theme.palette.allShades?.blue?.[50],
-                  borderRadius: '8px',
-                },
-              },
-            'ul.MuiSimpleTreeView-itemGroupTransition:not(:has(.MuiTreeItem-iconContainer > svg))':
-              {
-                pl: '32px !important',
-              },
-            'ul.MuiSimpleTreeView-itemGroupTransition:not(:has(.MuiTreeItem-iconContainer > svg)) li .MuiTreeItem-content::before':
-              {
-                left: '-36px',
-                width: '32px',
-              },
-            'li[style*="--TreeView-itemDepth:"] .MuiTreeItem-content::before': {
-              borderBottom: `1px solid ${BORDER_COLOR}`,
-              backgroundColor: 'transparent',
-            },
-            'li[style*="--TreeView-itemDepth:"] .MuiCollapse-vertical::before':
-              {
-                borderLeft: `1px solid ${BORDER_COLOR}`,
-                backgroundColor: 'transparent',
-              },
-            'li[style*="--TreeView-itemDepth:"]:not([style*="--TreeView-itemDepth: 0"]):not([style*="--TreeView-itemDepth: 1"]) .MuiTreeItem-content::before':
-              {
-                borderBottom: `1px dashed ${BORDER_COLOR}`,
-                backgroundColor: 'transparent',
-              },
-            'li[style*="--TreeView-itemDepth:"]:not([style*="--TreeView-itemDepth: 0"]) .MuiCollapse-vertical::before':
-              {
-                borderLeft: `1px dashed ${BORDER_COLOR}`,
-                backgroundColor: 'transparent',
-                bottom: '24px',
-              },
-          }}
-          onExpandedItemsChange={handleExpandedChange}
-          onSelectedItemsChange={(_, value) => handleSelectionChange(value)}>
+        <Tree
+          aria-label={t('label.domain-plural')}
+          className="domain-tree-view"
+          expandedKeys={new Set(expandedItems)}
+          selectedKeys={
+            selectedFqn ? new Set([selectedFqn]) : new Set<string>()
+          }
+          selectionMode="single"
+          onExpandedChange={handleExpandedChange}
+          onSelectionChange={handleSelectionChange}>
           {renderTreeItems(hierarchy)}
-        </SimpleTreeView>
+        </Tree>
         {isLoadingMore && (
-          <Box sx={{ display: 'flex', justifyContent: 'center', py: 2 }}>
+          <Box className="tw:py-2" justify="center">
             <Loader size="small" />
           </Box>
         )}
@@ -1079,12 +929,10 @@ const DomainTreeView = ({
     hierarchy,
     expandedItems,
     selectedFqn,
-    theme.palette.allShades?.gray,
-    theme.palette.allShades?.blue,
+    isLoadingMore,
     handleExpandedChange,
     handleSelectionChange,
     renderTreeItems,
-    isLoadingMore,
     t,
   ]);
   if (!isHierarchyLoading && isEmpty(hierarchy)) {
@@ -1115,17 +963,12 @@ const DomainTreeView = ({
         flex: 0.25,
         title: t('label.domain-plural'),
         children: (
-          <Box
+          <div
+            className="tw:pt-[18px] tw:pr-3 tw:pb-4 tw:overflow-y-auto tw:max-h-[calc(80vh-160px)]"
             ref={scrollContainerRef}
-            sx={{
-              pt: 4.5,
-              pr: 3,
-              overflowY: 'auto',
-              maxHeight: 'calc(80vh - 160px)',
-            }}
             onScroll={handleScroll}>
             {hierarchySection}
-          </Box>
+          </div>
         ),
       }}
       learningPageId={LEARNING_PAGE_IDS.DOMAIN}
@@ -1135,14 +978,9 @@ const DomainTreeView = ({
         minWidth: 600,
         flex: 0.75,
         children: (
-          <Box
-            sx={{
-              pt: 3,
-              overflowY: 'auto',
-              maxHeight: 'calc(80vh - 160px)',
-            }}>
+          <div className="tw:pt-3 tw:overflow-y-auto tw:max-h-[calc(80vh-160px)]">
             {domainSection}
-          </Box>
+          </div>
         ),
       }}
     />

--- a/openmetadata-ui/src/main/resources/ui/src/components/DomainListing/components/DomainTreeView.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DomainListing/components/DomainTreeView.tsx
@@ -976,7 +976,7 @@ const DomainTreeView = ({
         title: t('label.domain-plural'),
         children: (
           <div
-            className="tw:pt-[18px] tw:pr-3 tw:pb-4 tw:overflow-y-auto tw:max-h-[calc(80vh-160px)]"
+            className="tw:pt-4.5 tw:pr-3 tw:overflow-y-auto tw:max-h-[calc(80vh-220px)]"
             ref={scrollContainerRef}
             onScroll={handleScroll}>
             {hierarchySection}

--- a/openmetadata-ui/src/main/resources/ui/src/components/DomainListing/components/DomainTreeView.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DomainListing/components/DomainTreeView.tsx
@@ -832,13 +832,19 @@ const DomainTreeView = ({
                 key={`${identifier}${LOAD_MORE_ITEM_SUFFIX}`}
                 textValue={t('label.load-more')}>
                 <Tree.ItemContent showExpandIcon={false}>
-                  <div className="tw:flex tw:items-center tw:gap-2 tw:text-brand-primary tw:text-sm">
+                  <button
+                    className="tw:flex tw:items-center tw:gap-2 tw:cursor-pointer tw:text-brand-primary tw:text-sm"
+                    type="button"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      loadDomains(identifier, true);
+                    }}>
                     {loadingChildren[identifier] ? (
                       <Loader size="small" />
                     ) : (
                       t('label.load-more')
                     )}
-                  </div>
+                  </button>
                 </Tree.ItemContent>
               </Tree.Item>
             )}


### PR DESCRIPTION
### Describe your changes:

<img width="393" height="624" alt="Screenshot 2026-07-11 at 12 41 16 AM" src="https://github.com/user-attachments/assets/1132f43e-7aec-4e4a-ba4b-c444466e97e1" />

Fixes [4981](https://github.com/open-metadata/openmetadata-collate/issues/4981)

I refactored `DomainTreeView.tsx` to remove all MUI dependencies (`@mui/material`, `@mui/x-tree-view`) and replace them with `@openmetadata/ui-core-components` and Tailwind CSS, as part of the ongoing MUI removal effort.

- **MUI → core-ui**: `SimpleTreeView`/`TreeItem` → `Tree`/`Tree.Item`/`Tree.ItemContent`, `Chip` → `Badge`, `Box` → core-ui `Box` or plain `<div>`, `Typography` → core-ui `Typography`, `useTheme` removed in favour of CSS design tokens (`tw:text-primary`, `tw:text-secondary`, etc.)
- **Bug fix**: Removed `Tree.LoadMoreItem` nested inside `Tree.Item` which caused a `RangeError: Invalid array length` hang in react-aria-components 1.17.0 (collection builder infinite loop); child pagination now uses a regular `Tree.Item` with a load-more button, root pagination uses scroll-based infinite load.
- Dropped ~162 lines of MUI `sx` override CSS (connector lines, hover states, selection highlight) in favour of the core-ui Tree's built-in `showGuideLines` and Tailwind classes.

#
### Type of change:
- [x] Improvement

#
### High-level design:

The MUI `SimpleTreeView` had extensive `sx` prop overrides to achieve connector lines, expand icons, and selection/hover styles. The core-ui `Tree` component (built on react-aria-components) handles all of this via `Tree.ItemContent showGuideLines` and its own Tailwind-based styles, eliminating the need for those overrides.

Handler signatures updated from MUI's `(event, ids[])` / `(event, value)` to React Aria's `Selection` type (`Set<Key> | 'all'`).

#
### Tests:

#### Use cases covered
- Domain tree renders with hierarchy and guide lines
- Expand/collapse loads children on first expansion
- Selecting a domain loads the detail panel
- Child "load more" appears when paginated children exist
- Root infinite scroll triggers on scroll-to-bottom

#### Unit tests
- [ ] Not applicable — no unit test file exists for this component.

#### Backend integration tests
- [x] Not applicable (no backend API changes).

#### Ingestion integration tests
- [x] Not applicable (no ingestion changes).

#### Playwright (UI) tests
- [x] Not applicable — existing Playwright spec (`DomainListingIsolation.spec.ts`) contains no MUI-specific selectors.

#### Manual testing performed
1. Opened Domains page, verified tree renders with domains and avatar icons
2. Expanded a domain with children — children loaded and connector lines displayed
3. Selected a domain — detail panel loaded correctly on the right
4. Scrolled tree panel — additional root domains loaded via infinite scroll

#
### UI screen recording / screenshots:

Not applicable. <!-- Or attach recording/screenshots above -->

#
### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [x] For UI changes: I attached a screen recording and/or screenshots above.

----
## Summary by Gitar

- **Unit testing:**
  - Added comprehensive `DomainTreeView.test.tsx` covering initial load, search functionality, domain selection, tree expansion, and pagination logic.

<sub>This will update automatically on new commits.</sub>

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR replaces the Domain tree MUI implementation with the core UI tree. The main changes are:

- Swaps MUI tree, chip, typography, and layout pieces for core UI components.
- Reworks selection, expansion, and action handlers around React Aria tree keys.
- Moves child pagination into explicit load-more rows and root pagination into scroll loading.
- Adds Jest coverage for initial load, search, selection, expansion, and pagination.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

This is close, but the load-more key handling should be fixed before merging.

- A real domain FQN ending in `__load_more` is still treated as a synthetic pagination row.
- That domain cannot be selected from the tree, and activation can paginate the wrong parent key.
- The rest of the refactor is scoped to this component and has focused test coverage.

openmetadata-ui/src/main/resources/ui/src/components/DomainListing/components/DomainTreeView.tsx
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-ui/src/main/resources/ui/src/components/DomainListing/components/DomainTreeView.tsx | Replaces the MUI tree with the core UI Tree and rewires tree selection, expansion, action handling, and pagination. |
| openmetadata-ui/src/main/resources/ui/src/components/DomainListing/components/DomainTreeView.test.tsx | Adds mocked Jest coverage for the refactored Domain tree load, search, selection, expansion, and pagination flows. |

</details>

<sub>Reviews (8): Last reviewed commit: ["lint fix"](https://github.com/open-metadata/openmetadata/commit/a25fcaf3da1462526a993b6a40b223b771a10ab1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43379711)</sub>

> Greptile also left **1 inline comment** on this PR.

<details><summary><h4>Context used (3)</h4></summary>

- Context used - CLAUDE.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=52f0d9d9-cad1-4e7d-b070-de181a0aa5e7))
- Context used - openmetadata-ui-core-components/CLAUDE.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=41754627-b2bf-474b-8082-f37ef1a07013))
- Context used - AGENTS.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=ef262f5f-911f-44f3-8d2d-e9cb1579c8c8))
</details>

<!-- /greptile_comment -->