### PR TITLE
Fix PowerBI BigQuery native query parsing for comment-like literals

### DIFF
--- a/ingestion/src/metadata/ingestion/source/dashboard/powerbi/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/dashboard/powerbi/metadata.py
@@ -1102,18 +1102,23 @@ class PowerbiSource(DashboardServiceSource):
             char = sql_query[index]
             next_char = sql_query[index + 1] if index + 1 < len(sql_query) else ""
 
+            if quote_delimiter and len(quote_delimiter) == 3:
+                if sql_query.startswith(quote_delimiter, index):
+                    cleaned_query.extend(quote_delimiter)
+                    index += 3
+                    quote_delimiter = None
+                    continue
+                cleaned_query.append(char)
+                index += 1
+                continue
+
             if quote_delimiter:
                 cleaned_query.append(char)
                 if char == "\\" and next_char:
                     cleaned_query.append(next_char)
                     index += 2
                     continue
-                if sql_query.startswith(quote_delimiter, index):
-                    if len(quote_delimiter) == 3:
-                        cleaned_query.extend(sql_query[index + 1 : index + 3])
-                        index += 3
-                        quote_delimiter = None
-                        continue
+                if char == quote_delimiter:
                     if next_char == quote_delimiter:
                         cleaned_query.append(next_char)
                         index += 2

--- a/ingestion/src/metadata/ingestion/source/dashboard/powerbi/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/dashboard/powerbi/metadata.py
@@ -1095,30 +1095,41 @@ class PowerbiSource(DashboardServiceSource):
     def _strip_sql_line_comments(sql_query: str) -> str:
         """Remove SQL -- comments without truncating string literals."""
         cleaned_query = []
-        quote_char = None
+        quote_delimiter = None
         index = 0
 
         while index < len(sql_query):
             char = sql_query[index]
             next_char = sql_query[index + 1] if index + 1 < len(sql_query) else ""
 
-            if quote_char:
+            if quote_delimiter:
                 cleaned_query.append(char)
                 if char == "\\" and next_char:
                     cleaned_query.append(next_char)
                     index += 2
                     continue
-                if char == quote_char:
-                    if next_char == quote_char:
+                if sql_query.startswith(quote_delimiter, index):
+                    if len(quote_delimiter) == 3:
+                        cleaned_query.extend(sql_query[index + 1 : index + 3])
+                        index += 3
+                        quote_delimiter = None
+                        continue
+                    if next_char == quote_delimiter:
                         cleaned_query.append(next_char)
                         index += 2
                         continue
-                    quote_char = None
+                    quote_delimiter = None
                 index += 1
                 continue
 
+            if sql_query.startswith(("'''", '"""'), index):
+                quote_delimiter = sql_query[index : index + 3]
+                cleaned_query.extend(quote_delimiter)
+                index += 3
+                continue
+
             if char in ("'", '"', "`"):
-                quote_char = char
+                quote_delimiter = char
                 cleaned_query.append(char)
                 index += 1
                 continue

--- a/ingestion/src/metadata/ingestion/source/dashboard/powerbi/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/dashboard/powerbi/metadata.py
@@ -1103,6 +1103,11 @@ class PowerbiSource(DashboardServiceSource):
             next_char = sql_query[index + 1] if index + 1 < len(sql_query) else ""
 
             if quote_delimiter and len(quote_delimiter) == 3:
+                if char == "\\" and next_char:
+                    cleaned_query.append(char)
+                    cleaned_query.append(next_char)
+                    index += 2
+                    continue
                 if sql_query.startswith(quote_delimiter, index):
                     cleaned_query.extend(quote_delimiter)
                     index += 3

--- a/ingestion/src/metadata/ingestion/source/dashboard/powerbi/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/dashboard/powerbi/metadata.py
@@ -1091,6 +1091,49 @@ class PowerbiSource(DashboardServiceSource):
             logger.debug(traceback.format_exc())
         return None
 
+    @staticmethod
+    def _strip_sql_line_comments(sql_query: str) -> str:
+        """Remove SQL -- comments without truncating string literals."""
+        cleaned_query = []
+        quote_char = None
+        index = 0
+
+        while index < len(sql_query):
+            char = sql_query[index]
+            next_char = sql_query[index + 1] if index + 1 < len(sql_query) else ""
+
+            if quote_char:
+                cleaned_query.append(char)
+                if char == "\\" and next_char:
+                    cleaned_query.append(next_char)
+                    index += 2
+                    continue
+                if char == quote_char:
+                    if next_char == quote_char:
+                        cleaned_query.append(next_char)
+                        index += 2
+                        continue
+                    quote_char = None
+                index += 1
+                continue
+
+            if char in ("'", '"', "`"):
+                quote_char = char
+                cleaned_query.append(char)
+                index += 1
+                continue
+
+            if char == "-" and next_char == "-":
+                index += 2
+                while index < len(sql_query) and sql_query[index] != "\n":
+                    index += 1
+                continue
+
+            cleaned_query.append(char)
+            index += 1
+
+        return "".join(cleaned_query)
+
     def _parse_bigquery_query_source(self, source_expression: str) -> Optional[List[dict]]:  # noqa: UP006, UP045
         """
         Parse BigQuery Value.NativeQuery source expressions containing inline SQL.
@@ -1122,7 +1165,7 @@ class PowerbiSource(DashboardServiceSource):
             sql_query = sql_match.group(1).replace('""', '"')
             sql_query = sql_query.replace("#(lf)", "\n")
             sql_query = sql_query.replace("#(tab)", "\t")
-            sql_query = re.sub(r"--[^\n]*", "", sql_query)
+            sql_query = self._strip_sql_line_comments(sql_query)
             sql_query = re.sub(SQL_LINE_COMMENT_PATTERN, "", sql_query)
             sql_query = re.sub(r"\s+", " ", sql_query).strip()
 

--- a/ingestion/tests/unit/topology/dashboard/test_powerbi.py
+++ b/ingestion/tests/unit/topology/dashboard/test_powerbi.py
@@ -338,6 +338,24 @@ EXPECTED_BIGQUERY_NATIVE_QUERY_BLOCK_COMMENTS_RESULT = [
     },
 ]
 
+MOCK_BIGQUERY_NATIVE_QUERY_WITH_DASH_LITERAL_EXP = (
+    "let\n"
+    "    Source = Value.NativeQuery(GoogleBigQuery.Database("
+    '[BillingProject="my-gcp-project"])'
+    '{[Name="my-gcp-project"]}[Data], '
+    '"SELECT id#(lf)'
+    "FROM `analytics.orders`#(lf)"
+    "WHERE status <> '--' -- ignore placeholder statuses#(lf)"
+    'AND note = ""contains -- inside literal""", '
+    "null, [EnableFolding=true])\n"
+    "in\n"
+    "    Source"
+)
+
+EXPECTED_BIGQUERY_NATIVE_QUERY_WITH_DASH_LITERAL_RESULT = [
+    {"database": "my-gcp-project", "schema": "analytics", "table": "orders"}
+]
+
 # =============================================================================
 # Dataflow M Document Test Data
 # =============================================================================
@@ -828,6 +846,14 @@ class PowerBIUnitTest(TestCase):
         )
         self.assertEqual(result, EXPECTED_BIGQUERY_NATIVE_QUERY_BLOCK_COMMENTS_RESULT)
 
+        # Test with BigQuery NativeQuery containing -- inside SQL string literals
+        result = self.powerbi._parse_bigquery_source(
+            MOCK_BIGQUERY_NATIVE_QUERY_WITH_DASH_LITERAL_EXP,
+            MOCK_DASHBOARD_DATA_MODEL,
+            table,
+        )
+        self.assertEqual(result, EXPECTED_BIGQUERY_NATIVE_QUERY_WITH_DASH_LITERAL_RESULT)
+
         # Test with BigQuery NativeQuery using fully-qualified backtick-quoted tables
         # e.g. `project.dataset.table` — parser returns "project.dataset" as schema,
         # which must be split into database and schema
@@ -837,6 +863,21 @@ class PowerBIUnitTest(TestCase):
             table,
         )
         self.assertEqual(result, EXPECTED_BIGQUERY_NATIVE_QUERY_FQN_BACKTICK_RESULT)
+
+    def test_strip_sql_line_comments_preserves_backslash_escaped_quotes(self):
+        sql_query = (
+            "SELECT *\n"
+            "FROM `analytics.orders`\n"
+            r"WHERE note = 'contains \' -- inside literal' -- remove this comment"
+            "\n"
+            r'AND label = "contains \" -- inside literal" -- remove this comment'
+        )
+
+        result = self.powerbi._strip_sql_line_comments(sql_query)
+
+        self.assertIn(r"contains \' -- inside literal", result)
+        self.assertIn(r'contains \" -- inside literal', result)
+        self.assertNotIn("remove this comment", result)
 
     @pytest.mark.order(2)
     @patch("metadata.ingestion.ometa.ometa_api.OpenMetadata.get_reference_by_email")

--- a/ingestion/tests/unit/topology/dashboard/test_powerbi.py
+++ b/ingestion/tests/unit/topology/dashboard/test_powerbi.py
@@ -879,6 +879,22 @@ class PowerBIUnitTest(TestCase):
         self.assertIn(r'contains \" -- inside literal', result)
         self.assertNotIn("remove this comment", result)
 
+    def test_strip_sql_line_comments_preserves_bigquery_triple_quoted_literals(self):
+        sql_query = (
+            "SELECT *\n"
+            "FROM `analytics.orders`\n"
+            "WHERE note = '''contains -- inside triple single quote''' -- remove this comment\n"
+            'AND label = """contains -- inside triple double quote""" -- remove this comment\n'
+            "JOIN `analytics.customers` ON orders.customer_id = customers.id"
+        )
+
+        result = self.powerbi._strip_sql_line_comments(sql_query)
+
+        self.assertIn("'''contains -- inside triple single quote'''", result)
+        self.assertIn('"""contains -- inside triple double quote"""', result)
+        self.assertIn("JOIN `analytics.customers`", result)
+        self.assertNotIn("remove this comment", result)
+
     @pytest.mark.order(2)
     @patch("metadata.ingestion.ometa.ometa_api.OpenMetadata.get_reference_by_email")
     def test_owner_ingestion(self, get_reference_by_email):

--- a/ingestion/tests/unit/topology/dashboard/test_powerbi.py
+++ b/ingestion/tests/unit/topology/dashboard/test_powerbi.py
@@ -897,6 +897,33 @@ class PowerBIUnitTest(TestCase):
         self.assertIn("JOIN `analytics.customers`", result)
         self.assertNotIn("remove this comment", result)
 
+    def test_strip_sql_line_comments_preserves_bigquery_escaped_triple_delimiters(
+        self,
+    ):
+        sql_query = (
+            r"SELECT '''contains \''' -- inside escaped delimiter''' AS note "
+            "FROM `analytics.orders` "
+            "JOIN `analytics.customers` ON orders.customer_id = customers.id "
+            "-- remove this comment\n"
+            'SELECT """contains \\""" -- inside escaped delimiter""" AS label '
+            "FROM `analytics.labels` -- remove this comment"
+        )
+
+        result = self.powerbi._strip_sql_line_comments(sql_query)
+
+        self.assertIn(
+            r"'''contains \''' -- inside escaped delimiter''' AS note "
+            "FROM `analytics.orders`",
+            result,
+        )
+        self.assertIn("JOIN `analytics.customers`", result)
+        self.assertIn(
+            '"""contains \\""" -- inside escaped delimiter""" AS label '
+            "FROM `analytics.labels`",
+            result,
+        )
+        self.assertNotIn("remove this comment", result)
+
     @pytest.mark.order(2)
     @patch("metadata.ingestion.ometa.ometa_api.OpenMetadata.get_reference_by_email")
     def test_owner_ingestion(self, get_reference_by_email):

--- a/ingestion/tests/unit/topology/dashboard/test_powerbi.py
+++ b/ingestion/tests/unit/topology/dashboard/test_powerbi.py
@@ -885,6 +885,7 @@ class PowerBIUnitTest(TestCase):
             "FROM `analytics.orders`\n"
             "WHERE note = '''contains -- inside triple single quote''' -- remove this comment\n"
             'AND label = """contains -- inside triple double quote""" -- remove this comment\n'
+            "AND compact_note = '''a---b''' -- remove this comment\n"
             "JOIN `analytics.customers` ON orders.customer_id = customers.id"
         )
 
@@ -892,6 +893,7 @@ class PowerBIUnitTest(TestCase):
 
         self.assertIn("'''contains -- inside triple single quote'''", result)
         self.assertIn('"""contains -- inside triple double quote"""', result)
+        self.assertIn("'''a---b'''", result)
         self.assertIn("JOIN `analytics.customers`", result)
         self.assertNotIn("remove this comment", result)
 


### PR DESCRIPTION
## Problem
#29504
PowerBI BigQuery `Value.NativeQuery` parsing stripped `--` sequences with a regex before SQL lineage extraction. That removed valid SQL string literal content when a query contained values such as `'--'`, `"contains -- text"`, or escaped quotes before comment-like text.

## Solution
- Replace regex-only SQL line comment removal with a small scanner that skips `--` comments only outside quoted SQL literals.
- Preserve doubled SQL quotes and backslash-escaped quote characters while tracking quoted strings.
- Preserve existing Power Query unescaping and BigQuery lineage parsing behavior.
- Add regression coverage for BigQuery native queries with `--` inside string literals and escaped quotes before comment-like text.

## Validation
- `python -m pytest ingestion/tests/unit/topology/dashboard/test_powerbi.py::PowerBIUnitTest::test_parse_database_source ingestion/tests/unit/topology/dashboard/test_powerbi.py::PowerBIUnitTest::test_strip_sql_line_comments_preserves_backslash_escaped_quotes -q`

Fixes #29504

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes PowerBI BigQuery native query parsing when SQL literals contain comment-like text. The main changes are:

- A scanner replaces regex-only removal of SQL `--` comments.
- Quoted SQL literals keep embedded `--` text during lineage extraction.
- BigQuery triple-quoted literals and escaped delimiters are covered by tests.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge.

- No blocking issues found in the changed code.

</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| ingestion/src/metadata/ingestion/source/dashboard/powerbi/metadata.py | Adds scanner-based SQL comment stripping for BigQuery native queries while preserving quoted literal content. |
| ingestion/tests/unit/topology/dashboard/test_powerbi.py | Adds tests for dash literals, triple-quoted literals, and escaped triple delimiters. |

</details>

<sub>Reviews (5): Last reviewed commit: ["Handle escaped BigQuery triple quote del..."](https://github.com/open-metadata/openmetadata/commit/5e3d66cc023b240a6373e6b91edbd129ccd99ac1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43437519)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Context used - CLAUDE.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=52f0d9d9-cad1-4e7d-b070-de181a0aa5e7))
- Context used - openmetadata-ui-core-components/CLAUDE.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=41754627-b2bf-474b-8082-f37ef1a07013))
- Context used - AGENTS.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=ef262f5f-911f-44f3-8d2d-e9cb1579c8c8))
</details>

<!-- /greptile_comment -->