### PR TITLE
fix(lineage): use namespace import for @dagrejs/dagre to avoid undefined graphlib

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/utils/EntityLineageLayoutUtils.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/EntityLineageLayoutUtils.ts
@@ -11,7 +11,7 @@
  *  limitations under the License.
  */
 
-import { graphlib, layout } from '@dagrejs/dagre';
+import * as dagre from '@dagrejs/dagre';
 import type { ElkExtendedEdge, ElkNode } from 'elkjs/lib/elk.bundled.js';
 import type { Edge, Node, ReactFlowInstance } from 'reactflow';
 import { Position } from 'reactflow';
@@ -55,7 +55,7 @@ export const getLayoutedElements = (
   direction = EntityLineageDirection.LEFT_RIGHT,
   isExpanded = true
 ): LayoutedElements => {
-  const Graph = graphlib.Graph;
+  const Graph = dagre.graphlib.Graph;
   const dagreGraph = new Graph();
   dagreGraph.setDefaultEdgeLabel(() => ({}));
   dagreGraph.setGraph({ rankdir: direction });
@@ -82,7 +82,7 @@ export const getLayoutedElements = (
   );
   edgesRequired.forEach((el) => dagreGraph.setEdge(el.source, el.target));
 
-  layout(dagreGraph);
+  dagre.layout(dagreGraph);
 
   const uNode = nodeData.map((el) => {
     const nodeWithPosition = dagreGraph.node(el.id);


### PR DESCRIPTION
Fixes #29556.

`EntityLineageLayoutUtils.ts` imports `@dagrejs/dagre` with named imports (`import { graphlib, layout }`), but that package is CommonJS and assigns everything through `module.exports = { graphlib, layout, ... }`. Under the dev bundler's CJS/ESM interop the named `graphlib` binding can resolve to `undefined`, so `graphlib.Graph` throws `Cannot read properties of undefined (reading 'Graph')` when the lineage layout runs. The sibling `WorkflowLayout.ts` already imports the module as a whole and reads `dagre.graphlib.Graph`, which is why it does not hit this.

This switches the file to a namespace import (`import * as dagre`) and accesses `dagre.graphlib.Graph` / `dagre.layout`, matching the working `WorkflowLayout.ts` and binding the full module object regardless of how the bundler handles the CJS named exports. I confirmed the pattern type-checks with the project's tsconfig flags and that `dagre.graphlib.Graph` / `dagre.layout` are defined at runtime; I could not reproduce the exact dev-server interop failure locally, so I mirrored the already-working import style rather than guessing at a bundler config change.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR changes how the lineage layout utility reads Dagre. The main changes are:

- Replaces named Dagre imports with a module namespace import.
- Reads `graphlib.Graph` from the Dagre module object.
- Calls `layout` through the Dagre module object.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge after checking the Dagre module shape used by the app bundler.

- The changed layout behavior is narrow and keeps the same Dagre calls.
- The only remaining concern is conditional on the resolved Dagre entry exposing the module object only as `default`.

openmetadata-ui/src/main/resources/ui/src/utils/EntityLineageLayoutUtils.ts
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-ui/src/main/resources/ui/src/utils/EntityLineageLayoutUtils.ts | Updates Dagre access in the lineage layout utility, with a remaining conditional risk around namespace import shape. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(lineage): use namespace import for @..."](https://github.com/open-metadata/openmetadata/commit/8e47e07c164d9b5639669498a8c0ba3df0608d9c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43474595)</sub>

> Greptile also left **1 inline comment** on this PR.

<details><summary><h4>Context used (3)</h4></summary>

- Context used - CLAUDE.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=52f0d9d9-cad1-4e7d-b070-de181a0aa5e7))
- Context used - openmetadata-ui-core-components/CLAUDE.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=41754627-b2bf-474b-8082-f37ef1a07013))
- Context used - AGENTS.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=ef262f5f-911f-44f3-8d2d-e9cb1579c8c8))
</details>

<!-- /greptile_comment -->