### PR TITLE
feat(search): chunk-index analyzer parity for multi-chunk hybrid ranking

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/vector/OpenSearchVectorService.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/vector/OpenSearchVectorService.java
@@ -434,7 +434,7 @@ public class OpenSearchVectorService implements VectorIndexService {
     if (!indexExists(physicalIndex)) {
       executeGenericRequest("PUT", "/" + physicalIndex, buildChunkIndexMapping());
     }
-    swapChunkAliases(null, physicalIndex, writeAlias);
+    swapChunkAliases(physicalIndex, writeAlias);
     LOG.info(
         "Provisioned chunk index {} behind aliases {} / {}",
         physicalIndex,
@@ -459,8 +459,10 @@ public class OpenSearchVectorService implements VectorIndexService {
    */
   private boolean recreateChunkIndex(String oldIndex, String desired, String writeAlias) {
     if (oldIndex.equals(desired)) {
-      // Same physical index (stale/absent _meta at the current-version name): reindexing from a
-      // just-deleted self would lose data, so only (re)attach the aliases.
+      // Same physical index at the current-version name: cannot reindex from itself. Re-stamp _meta
+      // so a partial create that set the fields but not the version marker becomes current (the
+      // schema probe then passes), then (re)attach the aliases.
+      executeGenericRequest("PUT", "/" + desired + "/_mapping", chunkMetaMappingBody());
       return ensureChunkAliases(desired, writeAlias);
     }
     if (!indexExists(desired)) {
@@ -476,7 +478,7 @@ public class OpenSearchVectorService implements VectorIndexService {
       deleteIndexQuietly(oldIndex);
       runAliasActions(MAPPER.createArrayNode().add(aliasAction("add", desired, writeAlias, true)));
     } else {
-      swapChunkAliases(oldIndex, desired, writeAlias);
+      swapChunkAliases(desired, writeAlias);
       deleteIndexQuietly(oldIndex);
     }
     LOG.info("Recreated chunk index {} -> {} (aliases swapped)", oldIndex, desired);
@@ -508,25 +510,40 @@ public class OpenSearchVectorService implements VectorIndexService {
   }
 
   private boolean ensureChunkAliases(String physicalIndex, String writeAlias) {
-    swapChunkAliases(null, physicalIndex, writeAlias);
+    swapChunkAliases(physicalIndex, writeAlias);
     return true;
   }
 
   /**
-   * Atomically point the chunk read ({@code dataAssetEmbeddings}) and write (base-name) aliases at
-   * {@code newIndex}, removing them from {@code oldIndex} in the same request so a reader never sees
-   * zero or two backing indices. The removes are index-scoped, so the shared read alias stays
-   * attached to the entity indices.
+   * Make {@code newIndex} the sole backing of both the chunk read ({@code dataAssetEmbeddings}) and
+   * write (base-name) aliases: detach them from every other index currently carrying the write alias,
+   * then attach both to {@code newIndex} in one atomic request. The write alias is chunk-only, so
+   * every index it backs is a chunk index — detaching the shared read alias from those never touches
+   * the entity indices. This also cleans up a partial rollover that left extra indices attached.
    */
-  private void swapChunkAliases(String oldIndex, String newIndex, String writeAlias) {
+  private void swapChunkAliases(String newIndex, String writeAlias) {
     var actions = MAPPER.createArrayNode();
-    if (oldIndex != null && !oldIndex.equals(newIndex)) {
-      actions.add(aliasAction("remove", oldIndex, getSearchAlias(), false));
-      actions.add(aliasAction("remove", oldIndex, writeAlias, false));
+    for (String member : currentWriteAliasMembers(writeAlias)) {
+      if (!member.equals(newIndex)) {
+        actions.add(aliasAction("remove", member, getSearchAlias(), false));
+        actions.add(aliasAction("remove", member, writeAlias, false));
+      }
     }
     actions.add(aliasAction("add", newIndex, getSearchAlias(), false));
     actions.add(aliasAction("add", newIndex, writeAlias, true));
     runAliasActions(actions);
+  }
+
+  private List<String> currentWriteAliasMembers(String writeAlias) {
+    List<String> members = new ArrayList<>();
+    String aliasJson = executeGenericRequestQuietly("GET", "/_alias/" + writeAlias);
+    if (aliasJson != null) {
+      JsonNode root = readTreeQuietly(aliasJson);
+      if (root != null) {
+        root.fieldNames().forEachRemaining(members::add);
+      }
+    }
+    return members;
   }
 
   private void runAliasActions(JsonNode actions) {
@@ -545,6 +562,10 @@ public class OpenSearchVectorService implements VectorIndexService {
     if (writeIndex) {
       spec.put("is_write_index", true);
     }
+    if ("remove".equals(op)) {
+      // Tolerate the alias/index already being gone (concurrent rollover, partial state).
+      spec.put("must_exist", false);
+    }
     return (ObjectNode) MAPPER.createObjectNode().set(op, spec);
   }
 
@@ -558,14 +579,38 @@ public class OpenSearchVectorService implements VectorIndexService {
     return exists;
   }
 
+  /**
+   * A {@code GET}/{@code DELETE} probe that never logs at ERROR: an expected non-2xx (e.g. a 404
+   * when probing a missing alias on a fresh cluster) returns {@code null} at DEBUG rather than the
+   * ERROR that {@link #executeGenericRequest} emits. Used by the alias/index resolution probes so
+   * normal startup and rollover stay quiet.
+   */
   private String executeGenericRequestQuietly(String method, String endpoint) {
     String result = null;
     try {
-      result = executeGenericRequest(method, endpoint, null);
+      OpenSearchGenericClient genericClient = client.generic();
+      var request = Requests.builder().endpoint(endpoint).method(method).build();
+      try (var response = genericClient.execute(request)) {
+        if (response.getStatus() < 400) {
+          result = response.getBody().map(this::bodyAsString).orElse(null);
+        } else {
+          LOG.debug("Quiet {} {} -> status {}", method, endpoint, response.getStatus());
+        }
+      }
     } catch (Exception e) {
-      LOG.debug("Quiet request {} {} returned no body: {}", method, endpoint, e.getMessage());
+      LOG.debug("Quiet request {} {} failed: {}", method, endpoint, e.getMessage());
     }
     return result;
+  }
+
+  private String bodyAsString(Body body) {
+    String text = null;
+    try {
+      text = new String(body.bodyAsBytes(), StandardCharsets.UTF_8);
+    } catch (Exception e) {
+      LOG.debug("Failed to read response body: {}", e.getMessage());
+    }
+    return text;
   }
 
   private JsonNode readTreeQuietly(String json) {
@@ -683,6 +728,13 @@ public class OpenSearchVectorService implements VectorIndexService {
     return MAPPER.createObjectNode().put("chunkDocVersion", VectorDocBuilder.CHUNK_DOC_VERSION);
   }
 
+  /** {@code PUT _mapping} body that re-stamps only {@code _meta.chunkDocVersion} (metadata only). */
+  private String chunkMetaMappingBody() {
+    var body = MAPPER.createObjectNode();
+    body.set("_meta", chunkMeta());
+    return body.toString();
+  }
+
   private ObjectNode buildChunkProperties() {
     var method =
         MAPPER
@@ -699,10 +751,13 @@ public class OpenSearchVectorService implements VectorIndexService {
             .set("method", method);
     var properties = MAPPER.createObjectNode();
     properties.set("embedding", embedding);
-    for (String keyword :
-        List.of("parentId", "fingerprint", "entityType", "fullyQualifiedName", "serviceType")) {
+    for (String keyword : List.of("parentId", "fingerprint", "entityType")) {
       properties.set(keyword, MAPPER.createObjectNode().put("type", "keyword"));
     }
+    // fullyQualifiedName/serviceType carry lowercase_normalizer in the entity indices, so term
+    // filters stay case-insensitive and consistent with entity behavior.
+    properties.set("fullyQualifiedName", normalizedKeyword());
+    properties.set("serviceType", normalizedKeyword());
     // name/displayName get the full entity-index treatment: an om_analyzer text root plus .keyword
     // (lowercase_normalizer), .ngram (om_ngram) and .compound (om_compound_analyzer) subfields, so
     // the shard-fair exact/phrase/compound clauses all resolve on chunk docs (Phase-4 parity).
@@ -716,12 +771,11 @@ public class OpenSearchVectorService implements VectorIndexService {
     for (String text : List.of("textToEmbed", "textToLLMContext")) {
       properties.set(text, MAPPER.createObjectNode().put("type", "text"));
     }
-    // description gets om_analyzer parity with the entity indices; fqnParts/synonyms gain a
-    // .keyword
-    // subfield to match. fullyQualifiedName stays a plain keyword (the entity indices map it so
-    // too).
+    // description gets om_analyzer parity with the entity indices. fqnParts holds FQN identifier
+    // tokens, so it stays keyword (matching the entity mapping) to preserve exact/aggregation
+    // behavior; only synonyms is analyzed text with a .keyword subfield.
     properties.set("description", descriptionMapping());
-    properties.set("fqnParts", textWithKeywordSub());
+    properties.set("fqnParts", MAPPER.createObjectNode().put("type", "keyword"));
     properties.set("synonyms", textWithKeywordSub());
     properties.set("deleted", MAPPER.createObjectNode().put("type", "boolean"));
     properties.set("tags", objectKeyword("tagFQN"));
@@ -782,6 +836,14 @@ public class OpenSearchVectorService implements VectorIndexService {
       keyword.put("normalizer", normalizer);
     }
     return keyword;
+  }
+
+  /** A top-level {@code keyword} with {@code lowercase_normalizer} (no {@code ignore_above}). */
+  private ObjectNode normalizedKeyword() {
+    return MAPPER
+        .createObjectNode()
+        .put("type", "keyword")
+        .put("normalizer", "lowercase_normalizer");
   }
 
   private ObjectNode objectKeyword(String field) {

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/vector/OpenSearchVectorService.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/vector/OpenSearchVectorService.java
@@ -447,10 +447,22 @@ public class OpenSearchVectorService implements VectorIndexService {
     body.set("dest", MAPPER.createObjectNode().put("index", dest));
     // wait_for_completion=true suits modest catalogs; for very large indices switch to
     // wait_for_completion=false and poll the returned task via GET /_tasks/{taskId}.
-    executeGenericRequest(
-        "POST",
-        "/_reindex?wait_for_completion=true&refresh=true&slices=auto&requests_per_second=-1",
-        body.toString());
+    String response =
+        executeGenericRequest(
+            "POST",
+            "/_reindex?wait_for_completion=true&refresh=true&slices=auto&requests_per_second=-1",
+            body.toString());
+    // _reindex returns HTTP 200 even when individual docs fail (reported in the body, not the
+    // status). recreateChunkIndex deletes the source right after this, and the chunk embeddings are
+    // the only stored copy of the vectors, so a partial copy is unrecoverable without a re-embed.
+    // Fail hard here so the delete never runs and the source stays intact.
+    JsonNode result = readTreeQuietly(response);
+    if (result == null
+        || result.path("failures").size() > 0
+        || result.path("timed_out").asBoolean(false)) {
+      throw new IllegalStateException(
+          "Chunk reindex " + source + " -> " + dest + " had failures: " + response);
+    }
   }
 
   private boolean ensureChunkAliases(String physicalIndex, String writeAlias) {

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/vector/OpenSearchVectorService.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/vector/OpenSearchVectorService.java
@@ -471,12 +471,15 @@ public class OpenSearchVectorService implements VectorIndexService {
     reindexChunks(oldIndex, desired);
     boolean legacyConcrete = oldIndex.equals(writeAlias);
     if (legacyConcrete) {
-      // The legacy concrete index occupies the write-alias name, so the write alias can only move
-      // once it is gone. Attach the shared read alias to the new index first to avoid a read gap.
-      runAliasActions(
-          MAPPER.createArrayNode().add(aliasAction("add", desired, getSearchAlias(), false)));
-      deleteIndexQuietly(oldIndex);
-      runAliasActions(MAPPER.createArrayNode().add(aliasAction("add", desired, writeAlias, true)));
+      // The legacy concrete index occupies the write-alias name. Delete it and attach both aliases
+      // to the new index in ONE atomic _aliases request, so the write-alias name is never an
+      // unresolved gap between the delete and the alias add. Deleting the index also detaches the
+      // shared read alias, which the same request re-adds to the new index (no orphan).
+      var actions = MAPPER.createArrayNode();
+      actions.add(removeIndexAction(oldIndex));
+      actions.add(aliasAction("add", desired, getSearchAlias(), false));
+      actions.add(aliasAction("add", desired, writeAlias, true));
+      runAliasActions(actions);
     } else {
       swapChunkAliases(desired, writeAlias);
       deleteIndexQuietly(oldIndex);
@@ -567,6 +570,18 @@ public class OpenSearchVectorService implements VectorIndexService {
       spec.put("must_exist", false);
     }
     return (ObjectNode) MAPPER.createObjectNode().set(op, spec);
+  }
+
+  /**
+   * A {@code remove_index} action that deletes a concrete index inside an {@code _aliases} request.
+   * Takes no {@code alias} and no {@code must_exist} — OpenSearch's parser rejects {@code must_exist}
+   * on {@code remove_index}.
+   */
+  private ObjectNode removeIndexAction(String index) {
+    return (ObjectNode)
+        MAPPER
+            .createObjectNode()
+            .set("remove_index", MAPPER.createObjectNode().put("index", index));
   }
 
   private boolean indexExists(String name) {

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/vector/OpenSearchVectorService.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/vector/OpenSearchVectorService.java
@@ -338,98 +338,277 @@ public class OpenSearchVectorService implements VectorIndexService {
   }
 
   private boolean createChunkIndexIfAbsent() {
-    String indexName = getChunkIndexName();
+    String writeAlias = getChunkIndexName();
+    boolean ready = false;
     try {
-      boolean exists = client.indices().exists(e -> e.index(indexName)).value();
-      if (!exists) {
-        executeGenericRequest("PUT", "/" + indexName, buildChunkIndexMapping());
-        LOG.info("Created dedicated vector chunk index {}", indexName);
-        return true;
+      String current = resolvePhysicalIndex(writeAlias);
+      String desired = chunkPhysicalIndexName();
+      if (current == null) {
+        ready = provisionFreshChunkIndex(desired, writeAlias);
+      } else if (current.equals(desired) && chunkSchemaCurrent(desired)) {
+        ready = ensureChunkAliases(desired, writeAlias);
+      } else {
+        ready = recreateChunkIndex(current, desired, writeAlias);
       }
-      // The alias is normally attached at creation, but an index left over from a partial or manual
-      // setup may miss it — and reads via the alias would then silently skip all chunk docs. The
-      // alias PUT is idempotent. Only report "ensured" once the mapping is at the current version
-      // so
-      // a failed upgrade does not latch (and so docs are not stamped with the new docVersion into a
-      // still-stale mapping).
-      executeGenericRequest("PUT", "/" + indexName + "/_alias/" + getSearchAlias(), "{}");
-      return applyChunkMappingUpgradeIfStale(indexName);
     } catch (Exception e) {
-      LOG.error("Failed to ensure chunk index {}: {}", indexName, e.getMessage());
-      return false;
+      LOG.error("Failed to ensure chunk index (alias {}): {}", writeAlias, e.getMessage());
     }
+    return ready;
   }
 
   /**
-   * When the chunk index already exists, compare its {@code _meta.chunkDocVersion} against the code
-   * {@link VectorDocBuilder#CHUNK_DOC_VERSION}; if the index is older, apply the additive
-   * {@code PUT _mapping} so the new denormalized fields become mappable. This is legal on a
-   * {@code dynamic:false} index and safe pre-backfill: old docs simply lack the new fields until a
-   * Search Reindex re-materializes them (the reindex reuses embeddings, so there is no re-embed
-   * cost — see {@link #updateEntityEmbeddingChunks(EntityInterface, String)}).
-   *
-   * @return {@code true} when the index is (already or now) at the current version; {@code false}
-   *     when the upgrade could not be applied, so the caller leaves the index un-ensured and the
-   *     PUT is retried on the next write rather than silently proceeding with a stale mapping.
+   * The versioned physical index the chunk write-alias fronts, e.g. {@code
+   * data_asset_embeddings_chunks_000002}. A new {@link VectorDocBuilder#CHUNK_DOC_VERSION} yields a
+   * new physical name so a rollover is idempotent and never collides with the outgoing index.
    */
-  private boolean applyChunkMappingUpgradeIfStale(String indexName) {
-    try {
-      String mappingJson = executeGenericRequest("GET", "/" + indexName + "/_mapping", null);
-      JsonNode mappings = MAPPER.readTree(mappingJson).path(indexName).path("mappings");
-      int existingVersion = mappings.path("_meta").path("chunkDocVersion").asInt(0);
-      if (existingVersion >= VectorDocBuilder.CHUNK_DOC_VERSION) {
-        return true;
+  private String chunkPhysicalIndexName() {
+    return getChunkIndexName()
+        + String.format(Locale.ROOT, "_%06d", VectorDocBuilder.CHUNK_DOC_VERSION);
+  }
+
+  /**
+   * What currently backs the chunk write-alias name: the physical index an alias points to, a legacy
+   * concrete index literally named like the alias (pre-rollover clusters), or {@code null} when
+   * nothing exists yet.
+   */
+  private String resolvePhysicalIndex(String writeAlias) {
+    String physical = null;
+    String aliasJson = executeGenericRequestQuietly("GET", "/_alias/" + writeAlias);
+    if (aliasJson != null) {
+      JsonNode root = readTreeQuietly(aliasJson);
+      if (root != null) {
+        var names = root.fieldNames();
+        if (names.hasNext()) {
+          physical = names.next();
+        }
       }
-      executeGenericRequest("PUT", "/" + indexName + "/_mapping", buildChunkMappingUpgradeBody());
-      LOG.info(
-          "Upgraded chunk index {} mapping chunkDocVersion {} -> {} (denormalized fields backfill "
-              + "on next Search Reindex)",
-          indexName,
-          existingVersion,
-          VectorDocBuilder.CHUNK_DOC_VERSION);
-      return true;
-    } catch (Exception e) {
-      LOG.error(
-          "Failed to upgrade chunk index {} mapping; leaving it un-ensured to retry on the next "
-              + "write rather than stamping docs with the new docVersion into a stale mapping: {}",
-          indexName,
-          e.getMessage());
-      return false;
     }
+    if (physical == null && indexExists(writeAlias)) {
+      physical = writeAlias;
+    }
+    return physical;
+  }
+
+  private boolean chunkSchemaCurrent(String physicalIndex) {
+    boolean current = false;
+    try {
+      String mappingJson = executeGenericRequest("GET", "/" + physicalIndex + "/_mapping", null);
+      JsonNode mappings = MAPPER.readTree(mappingJson).path(physicalIndex).path("mappings");
+      current =
+          mappings.path("_meta").path("chunkDocVersion").asInt(0)
+              >= VectorDocBuilder.CHUNK_DOC_VERSION;
+    } catch (Exception e) {
+      LOG.debug("Chunk schema probe failed for {}: {}", physicalIndex, e.getMessage());
+    }
+    return current;
+  }
+
+  private boolean provisionFreshChunkIndex(String physicalIndex, String writeAlias) {
+    executeGenericRequest("PUT", "/" + physicalIndex, buildChunkIndexMapping());
+    swapChunkAliases(null, physicalIndex, writeAlias);
+    LOG.info(
+        "Provisioned chunk index {} behind aliases {} / {}",
+        physicalIndex,
+        writeAlias,
+        getSearchAlias());
+    return true;
+  }
+
+  /**
+   * Rebuild the chunk index under a fresh physical name and swap the aliases at zero embedding cost:
+   * {@code _reindex} copies each doc's stored {@code embedding} vector and denormalized fields
+   * verbatim; the new index's analyzers apply at index time. Analyzers and field types cannot be
+   * changed on a live index, so this recreate is the only path to entity-index parity. Runs under the
+   * {@link #ensureChunkIndex()} monitor, so concurrent writers block until the swap completes rather
+   * than racing the alias move.
+   */
+  private boolean recreateChunkIndex(String oldIndex, String desired, String writeAlias) {
+    if (indexExists(desired)) {
+      executeGenericRequest("DELETE", "/" + desired, null);
+    }
+    executeGenericRequest("PUT", "/" + desired, buildChunkIndexMapping());
+    reindexChunks(oldIndex, desired);
+    boolean legacyConcrete = oldIndex.equals(writeAlias);
+    if (legacyConcrete) {
+      // The pre-rollover index occupies the write-alias name; free it before aliasing.
+      executeGenericRequest("DELETE", "/" + oldIndex, null);
+      swapChunkAliases(null, desired, writeAlias);
+    } else {
+      swapChunkAliases(oldIndex, desired, writeAlias);
+      executeGenericRequest("DELETE", "/" + oldIndex, null);
+    }
+    LOG.info("Recreated chunk index {} -> {} (aliases swapped)", oldIndex, desired);
+    return true;
+  }
+
+  private void reindexChunks(String source, String dest) {
+    var body = MAPPER.createObjectNode();
+    body.set("source", MAPPER.createObjectNode().put("index", source));
+    body.set("dest", MAPPER.createObjectNode().put("index", dest));
+    // wait_for_completion=true suits modest catalogs; for very large indices switch to
+    // wait_for_completion=false and poll the returned task via GET /_tasks/{taskId}.
+    executeGenericRequest(
+        "POST",
+        "/_reindex?wait_for_completion=true&refresh=true&slices=auto&requests_per_second=-1",
+        body.toString());
+  }
+
+  private boolean ensureChunkAliases(String physicalIndex, String writeAlias) {
+    swapChunkAliases(null, physicalIndex, writeAlias);
+    return true;
+  }
+
+  /**
+   * Atomically point the chunk read ({@code dataAssetEmbeddings}) and write (base-name) aliases at
+   * {@code newIndex}, removing them from {@code oldIndex} in the same request so a reader never sees
+   * zero or two backing indices. The removes are index-scoped, so the shared read alias stays
+   * attached to the entity indices.
+   */
+  private void swapChunkAliases(String oldIndex, String newIndex, String writeAlias) {
+    var actions = MAPPER.createArrayNode();
+    if (oldIndex != null && !oldIndex.equals(newIndex)) {
+      actions.add(aliasAction("remove", oldIndex, getSearchAlias(), false));
+      actions.add(aliasAction("remove", oldIndex, writeAlias, false));
+    }
+    actions.add(aliasAction("add", newIndex, getSearchAlias(), false));
+    actions.add(aliasAction("add", newIndex, writeAlias, true));
+    var body = MAPPER.createObjectNode();
+    body.set("actions", actions);
+    executeGenericRequest("POST", "/_aliases", body.toString());
+  }
+
+  private ObjectNode aliasAction(String op, String index, String alias, boolean writeIndex) {
+    var spec = MAPPER.createObjectNode().put("index", index).put("alias", alias);
+    if (writeIndex) {
+      spec.put("is_write_index", true);
+    }
+    return (ObjectNode) MAPPER.createObjectNode().set(op, spec);
+  }
+
+  private boolean indexExists(String name) {
+    boolean exists = false;
+    try {
+      exists = client.indices().exists(e -> e.index(name)).value();
+    } catch (Exception e) {
+      LOG.debug("Index exists probe failed for {}: {}", name, e.getMessage());
+    }
+    return exists;
+  }
+
+  private String executeGenericRequestQuietly(String method, String endpoint) {
+    String result = null;
+    try {
+      result = executeGenericRequest(method, endpoint, null);
+    } catch (Exception e) {
+      LOG.debug("Quiet request {} {} returned no body: {}", method, endpoint, e.getMessage());
+    }
+    return result;
+  }
+
+  private JsonNode readTreeQuietly(String json) {
+    JsonNode node = null;
+    try {
+      node = MAPPER.readTree(json);
+    } catch (Exception e) {
+      LOG.debug("Failed to parse JSON: {}", e.getMessage());
+    }
+    return node;
   }
 
   private String buildChunkIndexMapping() {
     var mappings = MAPPER.createObjectNode().put("dynamic", false);
     mappings.set("properties", buildChunkProperties());
     mappings.set("_meta", chunkMeta());
+    var settings = MAPPER.createObjectNode();
+    // max_ngram_diff must equal the om_ngram tokenizer span (max_gram 20 - min_gram 3 = 17); the
+    // default is 1, so index creation is REJECTED without it. Validation fires at creation time, so
+    // it has to live in settings.index here — it cannot be applied after the fact.
+    settings.set("index", MAPPER.createObjectNode().put("knn", true).put("max_ngram_diff", 17));
+    settings.set("analysis", buildChunkAnalysis());
     var root = MAPPER.createObjectNode();
-    root.set(
-        "settings",
-        MAPPER.createObjectNode().set("index", MAPPER.createObjectNode().put("knn", true)));
+    root.set("settings", settings);
     root.set("mappings", mappings);
-    root.set("aliases", MAPPER.createObjectNode().set(getSearchAlias(), MAPPER.createObjectNode()));
     return root.toString();
   }
 
   /**
-   * Additive {@code PUT _mapping} body applied by {@link #applyChunkMappingUpgradeIfStale}. Sends the
-   * property set <b>minus the {@code embedding} knn_vector</b> plus the bumped
-   * {@code _meta.chunkDocVersion}. Re-declaring the existing {@code knn_vector} is rejected by some
-   * OpenSearch versions/plugins even with identical parameters; because {@code PUT _mapping} is
-   * atomic, that would fail the whole request and silently leave the genuinely new denormalized
-   * fields unmapped (on a {@code dynamic:false} index) while docs are still stamped with the new
-   * {@code docVersion} — defeating the rollout. Omitting the unchanged vector avoids that
-   * all-or-nothing failure; the remaining fields are additive (new fields) or legal no-ops
-   * (unchanged keyword/text/integer). Absent-on-old-docs fields simply do not match until a Search
-   * Reindex backfills them, so there is zero regression before the backfill runs.
+   * The {@code settings.analysis} block — om_analyzer / om_ngram / om_compound_analyzer plus their
+   * filters, tokenizer and normalizer. Mirrors the block shipped in every entity {@code
+   * *_index_mapping.json}; keep it in lockstep with those, since a drift silently re-opens the
+   * keyword-parity gap on chunk docs.
    */
-  private String buildChunkMappingUpgradeBody() {
-    ObjectNode properties = buildChunkProperties();
-    properties.remove("embedding");
-    var body = MAPPER.createObjectNode();
-    body.set("properties", properties);
-    body.set("_meta", chunkMeta());
-    return body.toString();
+  private ObjectNode buildChunkAnalysis() {
+    var analysis = MAPPER.createObjectNode();
+    analysis.set("tokenizer", chunkTokenizers());
+    analysis.set("normalizer", chunkNormalizers());
+    analysis.set("analyzer", chunkAnalyzers());
+    analysis.set("filter", chunkFilters());
+    return analysis;
+  }
+
+  private ObjectNode chunkTokenizers() {
+    var ngram =
+        MAPPER.createObjectNode().put("type", "ngram").put("min_gram", 3).put("max_gram", 20);
+    ngram.set("token_chars", MAPPER.createArrayNode().add("letter").add("digit"));
+    return (ObjectNode) MAPPER.createObjectNode().set("n_gram_tokenizer", ngram);
+  }
+
+  private ObjectNode chunkNormalizers() {
+    var normalizer = MAPPER.createObjectNode().put("type", "custom");
+    normalizer.set("char_filter", MAPPER.createArrayNode());
+    normalizer.set("filter", MAPPER.createArrayNode().add("lowercase"));
+    return (ObjectNode) MAPPER.createObjectNode().set("lowercase_normalizer", normalizer);
+  }
+
+  private ObjectNode chunkAnalyzers() {
+    var analyzers = MAPPER.createObjectNode();
+    analyzers.set(
+        "om_analyzer", analyzer("standard", "lowercase", "word_delimiter_filter", "om_stemmer"));
+    analyzers.set("om_ngram", customAnalyzer("n_gram_tokenizer", "lowercase"));
+    analyzers.set(
+        "om_compound_analyzer",
+        analyzer("standard", "lowercase", "compound_word_delimiter_graph", "flatten_graph"));
+    return analyzers;
+  }
+
+  private ObjectNode analyzer(String tokenizer, String... filters) {
+    var node = MAPPER.createObjectNode().put("tokenizer", tokenizer);
+    var arr = MAPPER.createArrayNode();
+    for (String filter : filters) {
+      arr.add(filter);
+    }
+    node.set("filter", arr);
+    return node;
+  }
+
+  private ObjectNode customAnalyzer(String tokenizer, String... filters) {
+    return analyzer(tokenizer, filters).put("type", "custom");
+  }
+
+  private ObjectNode chunkFilters() {
+    var filters = MAPPER.createObjectNode();
+    filters.set(
+        "om_stemmer", MAPPER.createObjectNode().put("type", "stemmer").put("name", "kstem"));
+    filters.set(
+        "word_delimiter_filter",
+        MAPPER.createObjectNode().put("type", "word_delimiter").put("preserve_original", true));
+    filters.set("compound_word_delimiter_graph", compoundDelimiterFilter());
+    return filters;
+  }
+
+  private ObjectNode compoundDelimiterFilter() {
+    return MAPPER
+        .createObjectNode()
+        .put("type", "word_delimiter_graph")
+        .put("generate_word_parts", true)
+        .put("generate_number_parts", true)
+        .put("split_on_case_change", true)
+        .put("split_on_numerics", true)
+        .put("catenate_words", false)
+        .put("catenate_numbers", false)
+        .put("catenate_all", false)
+        .put("preserve_original", true)
+        .put("stem_english_possessive", true);
   }
 
   private ObjectNode chunkMeta() {
@@ -456,21 +635,26 @@ public class OpenSearchVectorService implements VectorIndexService {
         List.of("parentId", "fingerprint", "entityType", "fullyQualifiedName", "serviceType")) {
       properties.set(keyword, MAPPER.createObjectNode().put("type", "keyword"));
     }
-    // name/displayName keep a keyword root but gain a `.keyword` subfield so the shard-fair exact
-    // (case_insensitive term) clauses, which target `<field>.keyword`, resolve on chunk docs.
-    for (String keywordWithSub : List.of("name", "displayName")) {
-      properties.set(keywordWithSub, keywordWithKeywordSubfield());
-    }
+    // name/displayName get the full entity-index treatment: an om_analyzer text root plus .keyword
+    // (lowercase_normalizer), .ngram (om_ngram) and .compound (om_compound_analyzer) subfields, so
+    // the shard-fair exact/phrase/compound clauses all resolve on chunk docs (Phase-4 parity).
+    properties.set("name", analyzedIdentityField(false));
+    properties.set("displayName", analyzedIdentityField(true));
     for (String integer : List.of("chunkIndex", "chunkCount", "docVersion")) {
       properties.set(integer, MAPPER.createObjectNode().put("type", "integer"));
     }
-    // Analyzed lexical parity fields. The dedicated chunk index defines no custom analyzers, so
-    // these use the default standard analyzer; full om_analyzer/compound parity is a Phase 4
-    // index recreate.
-    for (String text :
-        List.of("textToEmbed", "textToLLMContext", "description", "fqnParts", "synonyms")) {
+    // textToEmbed/textToLLMContext are the embedding source + LLM context, never lexically scored,
+    // so they stay plain standard-analyzer text.
+    for (String text : List.of("textToEmbed", "textToLLMContext")) {
       properties.set(text, MAPPER.createObjectNode().put("type", "text"));
     }
+    // description gets om_analyzer parity with the entity indices; fqnParts/synonyms gain a
+    // .keyword
+    // subfield to match. fullyQualifiedName stays a plain keyword (the entity indices map it so
+    // too).
+    properties.set("description", descriptionMapping());
+    properties.set("fqnParts", textWithKeywordSub());
+    properties.set("synonyms", textWithKeywordSub());
     properties.set("deleted", MAPPER.createObjectNode().put("type", "boolean"));
     properties.set("tags", objectKeyword("tagFQN"));
     properties.set("domains", objectKeyword("name"));
@@ -490,16 +674,46 @@ public class OpenSearchVectorService implements VectorIndexService {
     return properties;
   }
 
-  private ObjectNode keywordWithKeywordSubfield() {
+  /**
+   * An {@code om_analyzer} text root with {@code .keyword} (lowercase_normalizer), {@code .ngram}
+   * (om_ngram) and {@code .compound} (om_compound_analyzer) subfields — the entity-index shape for
+   * {@code name}. {@code displayName} additionally carries {@code .actualCase}.
+   */
+  private ObjectNode analyzedIdentityField(boolean withActualCase) {
+    var fields = MAPPER.createObjectNode();
+    fields.set("keyword", keywordSub("lowercase_normalizer"));
+    if (withActualCase) {
+      fields.set("actualCase", keywordSub(null));
+    }
+    fields.set("ngram", textAnalyzed("om_ngram"));
+    fields.set("compound", textAnalyzed("om_compound_analyzer"));
+    return (ObjectNode) textAnalyzed("om_analyzer").set("fields", fields);
+  }
+
+  private ObjectNode descriptionMapping() {
+    return textAnalyzed("om_analyzer")
+        .put("similarity", "boolean")
+        .put("term_vector", "with_positions_offsets");
+  }
+
+  private ObjectNode textWithKeywordSub() {
     return (ObjectNode)
         MAPPER
             .createObjectNode()
-            .put("type", "keyword")
-            .set(
-                "fields",
-                MAPPER
-                    .createObjectNode()
-                    .set("keyword", MAPPER.createObjectNode().put("type", "keyword")));
+            .put("type", "text")
+            .set("fields", MAPPER.createObjectNode().set("keyword", keywordSub(null)));
+  }
+
+  private ObjectNode textAnalyzed(String analyzer) {
+    return MAPPER.createObjectNode().put("type", "text").put("analyzer", analyzer);
+  }
+
+  private ObjectNode keywordSub(String normalizer) {
+    var keyword = MAPPER.createObjectNode().put("type", "keyword").put("ignore_above", 256);
+    if (normalizer != null) {
+      keyword.put("normalizer", normalizer);
+    }
+    return keyword;
   }
 
   private ObjectNode objectKeyword(String field) {
@@ -542,7 +756,10 @@ public class OpenSearchVectorService implements VectorIndexService {
   }
 
   private ObjectNode columnsMapping() {
-    var name = keywordWithKeywordSubfield();
+    var fields = MAPPER.createObjectNode();
+    fields.set("keyword", keywordSub("lowercase_normalizer"));
+    fields.set("ngram", textAnalyzed("om_ngram"));
+    var name = (ObjectNode) textAnalyzed("om_analyzer").set("fields", fields);
     return (ObjectNode)
         MAPPER.createObjectNode().set("properties", MAPPER.createObjectNode().set("name", name));
   }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/vector/OpenSearchVectorService.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/vector/OpenSearchVectorService.java
@@ -377,16 +377,40 @@ public class OpenSearchVectorService implements VectorIndexService {
     if (aliasJson != null) {
       JsonNode root = readTreeQuietly(aliasJson);
       if (root != null) {
-        var names = root.fieldNames();
-        if (names.hasNext()) {
-          physical = names.next();
-        }
+        physical = writeIndexFor(root, writeAlias);
       }
     }
     if (physical == null && indexExists(writeAlias)) {
       physical = writeAlias;
     }
     return physical;
+  }
+
+  /**
+   * The physical index that is the write target of {@code writeAlias}. If the alias fans out over
+   * several indices (e.g. a partial rollover left the outgoing index attached), prefer the member
+   * whose {@code is_write_index} is true instead of an arbitrary first entry; fall back to the sole
+   * member otherwise.
+   */
+  private String writeIndexFor(JsonNode aliasRoot, String writeAlias) {
+    String first = null;
+    String writeTarget = null;
+    var names = aliasRoot.fieldNames();
+    while (names.hasNext()) {
+      String index = names.next();
+      first = first == null ? index : first;
+      boolean isWrite =
+          aliasRoot
+              .path(index)
+              .path("aliases")
+              .path(writeAlias)
+              .path("is_write_index")
+              .asBoolean(false);
+      if (isWrite) {
+        writeTarget = index;
+      }
+    }
+    return writeTarget != null ? writeTarget : first;
   }
 
   private boolean chunkSchemaCurrent(String physicalIndex) {
@@ -404,7 +428,12 @@ public class OpenSearchVectorService implements VectorIndexService {
   }
 
   private boolean provisionFreshChunkIndex(String physicalIndex, String writeAlias) {
-    executeGenericRequest("PUT", "/" + physicalIndex, buildChunkIndexMapping());
+    // Skip the PUT when a prior provision created the index but failed before the alias swap, so
+    // the
+    // retry completes the swap instead of erroring with resource_already_exists on every write.
+    if (!indexExists(physicalIndex)) {
+      executeGenericRequest("PUT", "/" + physicalIndex, buildChunkIndexMapping());
+    }
     swapChunkAliases(null, physicalIndex, writeAlias);
     LOG.info(
         "Provisioned chunk index {} behind aliases {} / {}",
@@ -419,23 +448,36 @@ public class OpenSearchVectorService implements VectorIndexService {
    * {@code _reindex} copies each doc's stored {@code embedding} vector and denormalized fields
    * verbatim; the new index's analyzers apply at index time. Analyzers and field types cannot be
    * changed on a live index, so this recreate is the only path to entity-index parity. Runs under the
-   * {@link #ensureChunkIndex()} monitor, so concurrent writers block until the swap completes rather
-   * than racing the alias move.
+   * {@link #ensureChunkIndex()} monitor within one JVM.
+   *
+   * <p>Rollover-safety across concurrent instances (e.g. a rolling deploy): the target is created
+   * only when absent — never delete-then-create — so a partial or in-flight {@code desired} is healed
+   * by the deterministic-id reindex rather than dropped from under another instance; the old index is
+   * deleted only after the reindex verified a complete copy (see {@link #reindexChunks}); and the
+   * legacy path attaches the shared read alias to the new index before dropping the old one so reads
+   * never see zero chunk indices.
    */
   private boolean recreateChunkIndex(String oldIndex, String desired, String writeAlias) {
-    if (indexExists(desired)) {
-      executeGenericRequest("DELETE", "/" + desired, null);
+    if (oldIndex.equals(desired)) {
+      // Same physical index (stale/absent _meta at the current-version name): reindexing from a
+      // just-deleted self would lose data, so only (re)attach the aliases.
+      return ensureChunkAliases(desired, writeAlias);
     }
-    executeGenericRequest("PUT", "/" + desired, buildChunkIndexMapping());
+    if (!indexExists(desired)) {
+      executeGenericRequest("PUT", "/" + desired, buildChunkIndexMapping());
+    }
     reindexChunks(oldIndex, desired);
     boolean legacyConcrete = oldIndex.equals(writeAlias);
     if (legacyConcrete) {
-      // The pre-rollover index occupies the write-alias name; free it before aliasing.
-      executeGenericRequest("DELETE", "/" + oldIndex, null);
-      swapChunkAliases(null, desired, writeAlias);
+      // The legacy concrete index occupies the write-alias name, so the write alias can only move
+      // once it is gone. Attach the shared read alias to the new index first to avoid a read gap.
+      runAliasActions(
+          MAPPER.createArrayNode().add(aliasAction("add", desired, getSearchAlias(), false)));
+      deleteIndexQuietly(oldIndex);
+      runAliasActions(MAPPER.createArrayNode().add(aliasAction("add", desired, writeAlias, true)));
     } else {
       swapChunkAliases(oldIndex, desired, writeAlias);
-      executeGenericRequest("DELETE", "/" + oldIndex, null);
+      deleteIndexQuietly(oldIndex);
     }
     LOG.info("Recreated chunk index {} -> {} (aliases swapped)", oldIndex, desired);
     return true;
@@ -484,9 +526,18 @@ public class OpenSearchVectorService implements VectorIndexService {
     }
     actions.add(aliasAction("add", newIndex, getSearchAlias(), false));
     actions.add(aliasAction("add", newIndex, writeAlias, true));
+    runAliasActions(actions);
+  }
+
+  private void runAliasActions(JsonNode actions) {
     var body = MAPPER.createObjectNode();
     body.set("actions", actions);
     executeGenericRequest("POST", "/_aliases", body.toString());
+  }
+
+  private void deleteIndexQuietly(String index) {
+    // Tolerate a concurrent rollover having already dropped the index.
+    executeGenericRequestQuietly("DELETE", "/" + index);
   }
 
   private ObjectNode aliasAction(String op, String index, String alias, boolean writeIndex) {
@@ -545,9 +596,14 @@ public class OpenSearchVectorService implements VectorIndexService {
 
   /**
    * The {@code settings.analysis} block — om_analyzer / om_ngram / om_compound_analyzer plus their
-   * filters, tokenizer and normalizer. Mirrors the block shipped in every entity {@code
-   * *_index_mapping.json}; keep it in lockstep with those, since a drift silently re-opens the
+   * filters, tokenizer and normalizer. Mirrors the block shipped in the default (English) entity
+   * {@code *_index_mapping.json}; keep it in lockstep, since a drift silently re-opens the
    * keyword-parity gap on chunk docs.
+   *
+   * <p>Localized deployments (jp/ru/zh) use different per-language analyzers/stemmers in their entity
+   * mappings. This restores full parity for the default analyzers and is a strict improvement for
+   * localized clusters too (chunk docs were on the built-in standard analyzer before), but per-language
+   * chunk parity — deriving this block from the configured search language — is a follow-up.
    */
   private ObjectNode buildChunkAnalysis() {
     var analysis = MAPPER.createObjectNode();

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/vector/VectorDocBuilder.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/vector/VectorDocBuilder.java
@@ -43,12 +43,17 @@ public class VectorDocBuilder {
   /**
    * Schema version of the denormalized chunk document (issue #862/#858). Stamped on every chunk doc
    * as {@code docVersion} and mirrored on the chunk index mapping as {@code _meta.chunkDocVersion}.
-   * Bump this whenever {@link #buildDenormalizedFields} materializes a new field or changes an existing one
-   * so {@code OpenSearchVectorService} triggers an additive {@code PUT _mapping} and an
-   * embedding-reuse backfill on the next Search Reindex — without forcing a re-embed (the
-   * fingerprint is deliberately left untouched, see {@link #computeFingerprintForEntity}).
+   * Bump this whenever {@link #buildDenormalizedFields} materializes a new field or changes an
+   * existing one so {@code OpenSearchVectorService} rebuilds the chunk index (recreate + reindex,
+   * reusing stored embeddings) and swaps the aliases on the next ensure — without forcing a re-embed
+   * (the fingerprint is deliberately left untouched, see {@link #computeFingerprintForEntity}).
+   *
+   * <p>v2: analyzer parity — name/displayName/columns.name gain an {@code om_analyzer} text root with
+   * {@code .ngram}/{@code .compound} subfields and {@code description} switches to {@code om_analyzer},
+   * matching the entity indices so the lexical clauses score chunk docs the same. Analyzers and field
+   * types cannot change on a live index, so the rollout is an index recreate.
    */
-  public static final int CHUNK_DOC_VERSION = 1;
+  public static final int CHUNK_DOC_VERSION = 2;
 
   /**
    * Upper bound on the denormalized {@code description} copied onto each chunk doc. The full body

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/vector/VectorDocBuilder.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/vector/VectorDocBuilder.java
@@ -48,10 +48,12 @@ public class VectorDocBuilder {
    * reusing stored embeddings) and swaps the aliases on the next ensure — without forcing a re-embed
    * (the fingerprint is deliberately left untouched, see {@link #computeFingerprintForEntity}).
    *
-   * <p>v2: analyzer parity — name/displayName/columns.name gain an {@code om_analyzer} text root with
-   * {@code .ngram}/{@code .compound} subfields and {@code description} switches to {@code om_analyzer},
-   * matching the entity indices so the lexical clauses score chunk docs the same. Analyzers and field
-   * types cannot change on a live index, so the rollout is an index recreate.
+   * <p>v2: analyzer parity — name/displayName gain an {@code om_analyzer} text root with
+   * {@code .keyword}/{@code .ngram}/{@code .compound} subfields, {@code columns.name} gains an
+   * {@code om_analyzer} root with {@code .keyword}/{@code .ngram} (no {@code .compound}, matching the
+   * entity mapping), and {@code description} switches to {@code om_analyzer} — so the lexical clauses
+   * score chunk docs the same. Analyzers and field types cannot change on a live index, so the rollout
+   * is an index recreate.
    */
   public static final int CHUNK_DOC_VERSION = 2;
 

--- a/openmetadata-service/src/test/java/org/openmetadata/service/search/vector/OpenSearchVectorServiceTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/search/vector/OpenSearchVectorServiceTest.java
@@ -9,6 +9,8 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
 import java.lang.reflect.Method;
 import java.util.List;
@@ -548,13 +550,11 @@ class OpenSearchVectorServiceTest {
     Method m = OpenSearchVectorService.class.getDeclaredMethod("buildChunkIndexMapping");
     m.setAccessible(true);
     String body = (String) m.invoke(vectorService);
-    com.fasterxml.jackson.databind.JsonNode root =
-        new com.fasterxml.jackson.databind.ObjectMapper().readTree(body);
+    JsonNode root = new ObjectMapper().readTree(body);
 
     // The om_* analyzers must be defined and max_ngram_diff must permit the 3..20 ngram span,
     // otherwise index creation is rejected.
-    com.fasterxml.jackson.databind.JsonNode analyzers =
-        root.path("settings").path("analysis").path("analyzer");
+    JsonNode analyzers = root.path("settings").path("analysis").path("analyzer");
     assertTrue(analyzers.has("om_analyzer"), "om_analyzer defined");
     assertTrue(analyzers.has("om_ngram"), "om_ngram defined");
     assertTrue(analyzers.has("om_compound_analyzer"), "om_compound_analyzer defined");
@@ -565,8 +565,7 @@ class OpenSearchVectorServiceTest {
 
     // name must carry an om_analyzer text root plus .compound/.ngram/.keyword subfields so the
     // phrase/compound lexical clauses resolve on chunk docs, not only the exact keyword clause.
-    com.fasterxml.jackson.databind.JsonNode name =
-        root.path("mappings").path("properties").path("name");
+    JsonNode name = root.path("mappings").path("properties").path("name");
     assertEquals("om_analyzer", name.path("analyzer").asText(), "name uses om_analyzer");
     assertTrue(name.path("fields").has("compound"), "name.compound subfield present");
     assertTrue(name.path("fields").has("ngram"), "name.ngram subfield present");
@@ -576,16 +575,27 @@ class OpenSearchVectorServiceTest {
         "description uses om_analyzer");
 
     // Denormalized parity fields still mapped (regression guard carried over from the v1 mapping).
-    com.fasterxml.jackson.databind.JsonNode props = root.path("mappings").path("properties");
+    JsonNode props = root.path("mappings").path("properties");
     assertTrue(props.has("owners"), "owners mapped");
     assertTrue(props.has("columns"), "columns mapped");
-    com.fasterxml.jackson.databind.JsonNode schema =
-        props.path("databaseSchema").path("properties");
+    JsonNode schema = props.path("databaseSchema").path("properties");
     assertTrue(
         schema.has("name") && schema.has("displayName"),
         "databaseSchema maps both name and displayName");
     assertTrue(
         root.path("mappings").path("_meta").has("chunkDocVersion"),
         "_meta.chunkDocVersion present");
+
+    // Keyword parity with the entity indices: fullyQualifiedName/serviceType carry the
+    // lowercase_normalizer, and fqnParts stays keyword (identifier tokens, not analyzed text).
+    assertEquals(
+        "lowercase_normalizer",
+        props.path("fullyQualifiedName").path("normalizer").asText(),
+        "fullyQualifiedName uses lowercase_normalizer");
+    assertEquals(
+        "lowercase_normalizer",
+        props.path("serviceType").path("normalizer").asText(),
+        "serviceType uses lowercase_normalizer");
+    assertEquals("keyword", props.path("fqnParts").path("type").asText(), "fqnParts stays keyword");
   }
 }

--- a/openmetadata-service/src/test/java/org/openmetadata/service/search/vector/OpenSearchVectorServiceTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/search/vector/OpenSearchVectorServiceTest.java
@@ -544,35 +544,48 @@ class OpenSearchVectorServiceTest {
   }
 
   @Test
-  void chunkMappingUpgradeBody_omitsKnnVectorButAddsDenormalizedFields() throws Exception {
-    Method m = OpenSearchVectorService.class.getDeclaredMethod("buildChunkMappingUpgradeBody");
+  void chunkIndexMapping_hasAnalyzerParityWithEntityIndices() throws Exception {
+    Method m = OpenSearchVectorService.class.getDeclaredMethod("buildChunkIndexMapping");
     m.setAccessible(true);
     String body = (String) m.invoke(vectorService);
+    com.fasterxml.jackson.databind.JsonNode root =
+        new com.fasterxml.jackson.databind.ObjectMapper().readTree(body);
 
-    // The unchanged embedding knn_vector must NOT be re-declared: PUT _mapping is atomic and some
-    // OpenSearch versions reject re-declaring an existing knn_vector, which would fail the whole
-    // additive upgrade and silently leave the new fields unmapped.
-    assertTrue(!body.contains("knn_vector"), "upgrade body must not re-declare the knn_vector");
-    assertTrue(
-        !body.contains("\"embedding\""), "embedding field excluded from the additive upgrade");
-    // The genuinely new denormalized fields and the version marker must be present.
-    assertTrue(body.contains("\"owners\""), "new nested owners field present");
-    assertTrue(body.contains("\"service\""), "new service field present");
-    assertTrue(body.contains("\"columns\""), "new columns field present");
-    assertTrue(body.contains("\"description\""), "new description field present");
-    assertTrue(body.contains("chunkDocVersion"), "_meta.chunkDocVersion bumped");
+    // The om_* analyzers must be defined and max_ngram_diff must permit the 3..20 ngram span,
+    // otherwise index creation is rejected.
+    com.fasterxml.jackson.databind.JsonNode analyzers =
+        root.path("settings").path("analysis").path("analyzer");
+    assertTrue(analyzers.has("om_analyzer"), "om_analyzer defined");
+    assertTrue(analyzers.has("om_ngram"), "om_ngram defined");
+    assertTrue(analyzers.has("om_compound_analyzer"), "om_compound_analyzer defined");
+    assertEquals(
+        17,
+        root.path("settings").path("index").path("max_ngram_diff").asInt(),
+        "max_ngram_diff must equal the ngram span (20 - 3)");
 
-    // databaseSchema must map both name and displayName (like service/database):
-    // buildDenormalizedFields
-    // copies both onto the chunk doc, so mapping only `name` would leave displayName unindexed.
+    // name must carry an om_analyzer text root plus .compound/.ngram/.keyword subfields so the
+    // phrase/compound lexical clauses resolve on chunk docs, not only the exact keyword clause.
+    com.fasterxml.jackson.databind.JsonNode name =
+        root.path("mappings").path("properties").path("name");
+    assertEquals("om_analyzer", name.path("analyzer").asText(), "name uses om_analyzer");
+    assertTrue(name.path("fields").has("compound"), "name.compound subfield present");
+    assertTrue(name.path("fields").has("ngram"), "name.ngram subfield present");
+    assertEquals(
+        "om_analyzer",
+        root.path("mappings").path("properties").path("description").path("analyzer").asText(),
+        "description uses om_analyzer");
+
+    // Denormalized parity fields still mapped (regression guard carried over from the v1 mapping).
+    com.fasterxml.jackson.databind.JsonNode props = root.path("mappings").path("properties");
+    assertTrue(props.has("owners"), "owners mapped");
+    assertTrue(props.has("columns"), "columns mapped");
     com.fasterxml.jackson.databind.JsonNode schema =
-        new com.fasterxml.jackson.databind.ObjectMapper()
-            .readTree(body)
-            .path("properties")
-            .path("databaseSchema")
-            .path("properties");
-    assertTrue(schema.has("name"), "databaseSchema.name mapped");
+        props.path("databaseSchema").path("properties");
     assertTrue(
-        schema.has("displayName"), "databaseSchema.displayName mapped (matches service/database)");
+        schema.has("name") && schema.has("displayName"),
+        "databaseSchema maps both name and displayName");
+    assertTrue(
+        root.path("mappings").path("_meta").has("chunkDocVersion"),
+        "_meta.chunkDocVersion present");
   }
 }


### PR DESCRIPTION
## What

Gives the dedicated `data_asset_embeddings_chunks` index full analyzer parity with the entity indices, so multi-chunk assets rank correctly in hybrid (RRF) search.

## Why

The chunk index mapped `name`/`displayName` as `keyword` and `description`/`columns.name` on the default standard analyzer, while the entity indices use `om_analyzer` with `.ngram`/`.compound` subfields. The `hybrid-rrf` pipeline fuses the lexical and kNN sub-queries **per document** and then collapses on `parentId`. Because the phrase and compound clauses only resolve against an analyzed `name`, they scored **0 on every chunk doc** while the entity doc (om_analyzer) earned the full boost. That keyword edge outweighed the semantic half, so collapse kept the entity doc — whose embedding is chunk 0 — even when a *later* chunk was the genuinely best semantic match.

Measured on a real 80-chunk asset (`performance_test_table`) against the live pipeline: using each chunk's own embedding as the query vector, the best semantic chunk was **discarded in 9 of 10** sampled queries (the entity doc's own semantic rank was 52–78 of 81, yet it still won collapse). A `_analyze` check confirms the root cause: `performance_test_table` stays one token under the standard/keyword mapping (so `[performance, test, table]` cannot match), but splits to `[performance, test, table]` under `om_analyzer`/`om_compound_analyzer`.

With parity, every chunk earns the same analyzed-name keyword mass as the entity doc → the keyword ranks **tie**, and the semantic half breaks the tie → the best-matching chunk wins.

## Changes

- Add `settings.analysis` (`om_analyzer` / `om_ngram` / `om_compound_analyzer` + filters/tokenizer/normalizer) and `index.max_ngram_diff: 17` to the chunk index mapping (the ngram tokenizer's 3–20 span is rejected without it).
- Map `name`/`displayName`/`columns.name` as `om_analyzer` text with `.keyword`/`.ngram`/`.compound` subfields (`displayName` also `.actualCase`); `description` on `om_analyzer`; `fqnParts`/`synonyms` gain a `.keyword` subfield. `fullyQualifiedName` stays `keyword` (the entity indices map it that way too).
- Bump `CHUNK_DOC_VERSION` to 2.

## Rollout

Analyzers and field types cannot be changed on a live index, so a version bump now rebuilds the index instead of an additive `PUT _mapping`. The base name becomes a **write alias** in front of a versioned physical index (`..._000002`), alongside the `dataAssetEmbeddings` read alias. `createChunkIndexIfAbsent` provisions fresh, reuses when current, or **recreates**: create the new physical index → `_reindex` (copies stored `embedding` vectors verbatim → **zero re-embed cost**) → atomic alias swap → drop the old index. The legacy concrete-index → alias transition is handled in the same path. The additive-upgrade methods are removed.

> For very large catalogs, `_reindex` should move to `wait_for_completion=false` + task polling (noted inline); current call is synchronous.

## Testing

- `mvn clean install -DskipTests` (full build) and `mvn -pl openmetadata-service test -Dtest=OpenSearchVectorServiceTest` pass.
- Replaced the obsolete additive-upgrade test with `chunkIndexMapping_hasAnalyzerParityWithEntityIndices`, asserting the analyzers, `max_ngram_diff: 17`, `name` on `om_analyzer` with `.compound`/`.ngram`, `description` on `om_analyzer`, and the retained denormalized-field regression guards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



Fixes https://github.com/open-metadata/ai-platform/issues/891

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR rebuilds the chunk vector index with analyzer parity for hybrid search. The main changes are:

- Adds versioned physical chunk indices behind read and write aliases.
- Recreates stale chunk indices with `_reindex` and an alias swap.
- Adds default `om_*` analyzers and matching chunk field mappings.
- Bumps the chunk document schema version to trigger the rebuild.
- Updates the vector service test to validate the new mapping shape.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge.

- No blocking issues found in the changed code.
- The latest alias changes address the write-alias transition and concurrent target handling in the reviewed paths.
- The mapping changes are covered by focused assertions for the new analyzer shape.

</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-service/src/main/java/org/openmetadata/service/search/vector/OpenSearchVectorService.java | Adds versioned chunk index provisioning, reindex validation, alias repair, and analyzer-backed chunk mappings. |
| openmetadata-service/src/main/java/org/openmetadata/service/search/vector/VectorDocBuilder.java | Bumps the chunk document version and documents the analyzer-parity rebuild. |
| openmetadata-service/src/test/java/org/openmetadata/service/search/vector/OpenSearchVectorServiceTest.java | Updates the mapping test to check analyzer settings and key chunk fields. |

</details>

<sub>Reviews (5): Last reviewed commit: ["fix(search): close write gap in legacy c..."](https://github.com/open-metadata/openmetadata/commit/2e4a0045fbff3e68762261ba581ff4b5b2e2c348) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43669809)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Context used - CLAUDE.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=52f0d9d9-cad1-4e7d-b070-de181a0aa5e7))
- Context used - openmetadata-ui-core-components/CLAUDE.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=41754627-b2bf-474b-8082-f37ef1a07013))
- Context used - AGENTS.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=ef262f5f-911f-44f3-8d2d-e9cb1579c8c8))
</details>

<!-- /greptile_comment -->