### PR TITLE
Fixes #29818: Paginate GET /v1/events (cursor + optional endTs) to prevent Java heap OOM

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/ChangeEventRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/ChangeEventRepository.java
@@ -20,7 +20,6 @@ import static org.openmetadata.schema.type.EventType.ENTITY_SOFT_DELETED;
 import static org.openmetadata.schema.type.EventType.ENTITY_UPDATED;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import org.jdbi.v3.sqlobject.transaction.Transaction;
@@ -41,47 +40,7 @@ public class ChangeEventRepository {
 
   public ResultList<ChangeEvent> list(
       long timestamp,
-      List<String> entityCreatedList,
-      List<String> entityUpdatedList,
-      List<String> entityRestoredList,
-      List<String> entityDeletedList,
-      long afterOffset,
-      int from,
-      int limit) {
-    Long windowStartOffset = afterOffset;
-    if (from > 0) {
-      windowStartOffset =
-          resolvePositionOffset(
-              from,
-              timestamp,
-              entityCreatedList,
-              entityUpdatedList,
-              entityRestoredList,
-              entityDeletedList);
-    }
-
-    List<ChangeEvent> events = new ArrayList<>();
-    String afterCursor = null;
-    if (windowStartOffset != null) {
-      Page page =
-          fetchWindow(
-              timestamp,
-              entityCreatedList,
-              entityUpdatedList,
-              entityRestoredList,
-              entityDeletedList,
-              windowStartOffset,
-              limit);
-      for (ChangeEventRecord record : page.records()) {
-        events.add(JsonUtils.readValue(record.json(), ChangeEvent.class));
-      }
-      afterCursor = page.afterCursor();
-    }
-    return new ResultList<>(events, null, afterCursor, events.size());
-  }
-
-  private Page fetchWindow(
-      long timestamp,
+      long endTs,
       List<String> entityCreatedList,
       List<String> entityUpdatedList,
       List<String> entityRestoredList,
@@ -91,48 +50,27 @@ public class ChangeEventRepository {
     int fetchLimit = limit + 1;
     List<ChangeEventRecord> records = new ArrayList<>();
     records.addAll(
-        dao.listAfter(ENTITY_CREATED, entityCreatedList, timestamp, afterOffset, fetchLimit));
+        dao.listAfter(
+            ENTITY_CREATED, entityCreatedList, timestamp, endTs, afterOffset, fetchLimit));
     records.addAll(
-        dao.listAfter(ENTITY_UPDATED, entityUpdatedList, timestamp, afterOffset, fetchLimit));
+        dao.listAfter(
+            ENTITY_UPDATED, entityUpdatedList, timestamp, endTs, afterOffset, fetchLimit));
     records.addAll(
-        dao.listAfter(ENTITY_RESTORED, entityRestoredList, timestamp, afterOffset, fetchLimit));
+        dao.listAfter(
+            ENTITY_RESTORED, entityRestoredList, timestamp, endTs, afterOffset, fetchLimit));
     records.addAll(
-        dao.listAfter(ENTITY_DELETED, entityDeletedList, timestamp, afterOffset, fetchLimit));
+        dao.listAfter(
+            ENTITY_DELETED, entityDeletedList, timestamp, endTs, afterOffset, fetchLimit));
     records.addAll(
-        dao.listAfter(ENTITY_SOFT_DELETED, entityDeletedList, timestamp, afterOffset, fetchLimit));
-    return mergePage(records, limit);
-  }
+        dao.listAfter(
+            ENTITY_SOFT_DELETED, entityDeletedList, timestamp, endTs, afterOffset, fetchLimit));
 
-  /**
-   * Resolves a positional {@code from} into the keyset offset the window starts after, fetching
-   * only the {@code offset} column (no event JSON) so a deep skip never materializes the skipped
-   * rows' payloads. Returns {@code null} when fewer than {@code from} events match.
-   */
-  private Long resolvePositionOffset(
-      int from,
-      long timestamp,
-      List<String> entityCreatedList,
-      List<String> entityUpdatedList,
-      List<String> entityRestoredList,
-      List<String> entityDeletedList) {
-    List<Long> offsets = new ArrayList<>();
-    offsets.addAll(dao.listOffsetsAfter(ENTITY_CREATED, entityCreatedList, timestamp, 0, from));
-    offsets.addAll(dao.listOffsetsAfter(ENTITY_UPDATED, entityUpdatedList, timestamp, 0, from));
-    offsets.addAll(dao.listOffsetsAfter(ENTITY_RESTORED, entityRestoredList, timestamp, 0, from));
-    offsets.addAll(dao.listOffsetsAfter(ENTITY_DELETED, entityDeletedList, timestamp, 0, from));
-    offsets.addAll(
-        dao.listOffsetsAfter(ENTITY_SOFT_DELETED, entityDeletedList, timestamp, 0, from));
-    return boundaryOffset(offsets, from);
-  }
-
-  /**
-   * Given the smallest matching offsets, returns the offset at position {@code from} (1-based) so
-   * the window is fetched with {@code offset > boundary}. Returns {@code null} when fewer than
-   * {@code from} offsets exist, i.e. the position is past the end.
-   */
-  static Long boundaryOffset(List<Long> offsets, int from) {
-    Collections.sort(offsets);
-    return offsets.size() >= from ? offsets.get(from - 1) : null;
+    Page page = mergePage(records, limit);
+    List<ChangeEvent> events = new ArrayList<>();
+    for (ChangeEventRecord record : page.records()) {
+      events.add(JsonUtils.readValue(record.json(), ChangeEvent.class));
+    }
+    return new ResultList<>(events, null, page.afterCursor(), events.size());
   }
 
   record Page(List<ChangeEventRecord> records, String afterCursor) {}

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/ChangeEventRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/ChangeEventRepository.java
@@ -75,11 +75,8 @@ public class ChangeEventRepository {
 
   record Page(List<ChangeEventRecord> records, String afterCursor) {}
 
-  /**
-   * Keyset-merges the bounded per-event-type result sets: sorts by monotonic {@code offset}, keeps
-   * the first {@code limit}, and derives the forward cursor from the last kept offset. The cursor is
-   * the raw offset value; {@link ResultList} base64 encodes it into {@code paging.after}.
-   */
+  // Sort merged pages by offset, keep the first `limit`, cursor = last kept offset (raw; ResultList
+  // base64-encodes it into paging.after).
   static Page mergePage(List<ChangeEventRecord> records, int limit) {
     records.sort(Comparator.comparingLong(ChangeEventRecord::offset));
     boolean hasMore = records.size() > limit;

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/ChangeEventRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/ChangeEventRepository.java
@@ -46,8 +46,9 @@ public class ChangeEventRepository {
       List<String> entityRestoredList,
       List<String> entityDeletedList,
       long afterOffset,
+      int from,
       int limit) {
-    int fetchLimit = limit + 1;
+    int fetchLimit = from + limit + 1;
     List<ChangeEventRecord> records = new ArrayList<>();
     records.addAll(
         dao.listAfter(ENTITY_CREATED, entityCreatedList, timestamp, afterOffset, fetchLimit));
@@ -60,7 +61,7 @@ public class ChangeEventRepository {
     records.addAll(
         dao.listAfter(ENTITY_SOFT_DELETED, entityDeletedList, timestamp, afterOffset, fetchLimit));
 
-    Page page = mergePage(records, limit);
+    Page page = mergePage(records, from, limit);
     List<ChangeEvent> events = new ArrayList<>();
     for (ChangeEventRecord record : page.records()) {
       events.add(JsonUtils.readValue(record.json(), ChangeEvent.class));
@@ -74,15 +75,21 @@ public class ChangeEventRepository {
   record Page(List<ChangeEventRecord> records, String afterCursor) {}
 
   /**
-   * Keyset-merges the bounded per-event-type result sets: sorts by monotonic {@code offset}, keeps
-   * the first {@code limit} records, and derives the forward cursor from the last kept offset.
+   * Keyset-merges the bounded per-event-type result sets: sorts by monotonic {@code offset}, skips
+   * {@code from} records, keeps the next {@code limit}, and derives the forward cursor from the last
+   * kept offset. The cursor path (offset &gt; afterOffset) uses {@code from = 0}; positional paging
+   * uses {@code afterOffset = 0}.
    */
-  static Page mergePage(List<ChangeEventRecord> records, int limit) {
+  static Page mergePage(List<ChangeEventRecord> records, int from, int limit) {
     records.sort(Comparator.comparingLong(ChangeEventRecord::offset));
-    boolean hasMore = records.size() > limit;
-    List<ChangeEventRecord> page = hasMore ? new ArrayList<>(records.subList(0, limit)) : records;
+    int windowStart = Math.min(from, records.size());
+    int windowEnd = Math.min(from + limit, records.size());
+    List<ChangeEventRecord> page = new ArrayList<>(records.subList(windowStart, windowEnd));
+    boolean hasMore = records.size() > from + limit;
     String afterCursor =
-        hasMore ? RestUtil.encodeCursor(String.valueOf(page.getLast().offset())) : null;
+        hasMore && !page.isEmpty()
+            ? RestUtil.encodeCursor(String.valueOf(page.getLast().offset()))
+            : null;
     return new Page(page, afterCursor);
   }
 

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/ChangeEventRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/ChangeEventRepository.java
@@ -20,6 +20,7 @@ import static org.openmetadata.schema.type.EventType.ENTITY_SOFT_DELETED;
 import static org.openmetadata.schema.type.EventType.ENTITY_UPDATED;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import org.jdbi.v3.sqlobject.transaction.Transaction;
@@ -47,7 +48,50 @@ public class ChangeEventRepository {
       long afterOffset,
       int from,
       int limit) {
-    int fetchLimit = from + limit + 1;
+    long total =
+        count(
+            timestamp, entityCreatedList, entityUpdatedList, entityRestoredList, entityDeletedList);
+    Long windowStartOffset = afterOffset;
+    if (from > 0) {
+      windowStartOffset =
+          resolvePositionOffset(
+              from,
+              timestamp,
+              entityCreatedList,
+              entityUpdatedList,
+              entityRestoredList,
+              entityDeletedList);
+    }
+
+    List<ChangeEvent> events = new ArrayList<>();
+    String afterCursor = null;
+    if (windowStartOffset != null) {
+      Page page =
+          fetchWindow(
+              timestamp,
+              entityCreatedList,
+              entityUpdatedList,
+              entityRestoredList,
+              entityDeletedList,
+              windowStartOffset,
+              limit);
+      for (ChangeEventRecord record : page.records()) {
+        events.add(JsonUtils.readValue(record.json(), ChangeEvent.class));
+      }
+      afterCursor = page.afterCursor();
+    }
+    return new ResultList<>(events, null, afterCursor, (int) Math.min(total, Integer.MAX_VALUE));
+  }
+
+  private Page fetchWindow(
+      long timestamp,
+      List<String> entityCreatedList,
+      List<String> entityUpdatedList,
+      List<String> entityRestoredList,
+      List<String> entityDeletedList,
+      long afterOffset,
+      int limit) {
+    int fetchLimit = limit + 1;
     List<ChangeEventRecord> records = new ArrayList<>();
     records.addAll(
         dao.listAfter(ENTITY_CREATED, entityCreatedList, timestamp, afterOffset, fetchLimit));
@@ -59,34 +103,52 @@ public class ChangeEventRepository {
         dao.listAfter(ENTITY_DELETED, entityDeletedList, timestamp, afterOffset, fetchLimit));
     records.addAll(
         dao.listAfter(ENTITY_SOFT_DELETED, entityDeletedList, timestamp, afterOffset, fetchLimit));
+    return mergePage(records, limit);
+  }
 
-    Page page = mergePage(records, from, limit);
-    List<ChangeEvent> events = new ArrayList<>();
-    for (ChangeEventRecord record : page.records()) {
-      events.add(JsonUtils.readValue(record.json(), ChangeEvent.class));
-    }
-    long total =
-        count(
-            timestamp, entityCreatedList, entityUpdatedList, entityRestoredList, entityDeletedList);
-    return new ResultList<>(
-        events, null, page.afterCursor(), (int) Math.min(total, Integer.MAX_VALUE));
+  /**
+   * Resolves a positional {@code from} into the keyset offset the window starts after, fetching
+   * only the {@code offset} column (no event JSON) so a deep skip never materializes the skipped
+   * rows' payloads. Returns {@code null} when fewer than {@code from} events match.
+   */
+  private Long resolvePositionOffset(
+      int from,
+      long timestamp,
+      List<String> entityCreatedList,
+      List<String> entityUpdatedList,
+      List<String> entityRestoredList,
+      List<String> entityDeletedList) {
+    List<Long> offsets = new ArrayList<>();
+    offsets.addAll(dao.listOffsetsAfter(ENTITY_CREATED, entityCreatedList, timestamp, 0, from));
+    offsets.addAll(dao.listOffsetsAfter(ENTITY_UPDATED, entityUpdatedList, timestamp, 0, from));
+    offsets.addAll(dao.listOffsetsAfter(ENTITY_RESTORED, entityRestoredList, timestamp, 0, from));
+    offsets.addAll(dao.listOffsetsAfter(ENTITY_DELETED, entityDeletedList, timestamp, 0, from));
+    offsets.addAll(
+        dao.listOffsetsAfter(ENTITY_SOFT_DELETED, entityDeletedList, timestamp, 0, from));
+    return boundaryOffset(offsets, from);
+  }
+
+  /**
+   * Given the smallest matching offsets, returns the offset at position {@code from} (1-based) so
+   * the window is fetched with {@code offset > boundary}. Returns {@code null} when fewer than
+   * {@code from} offsets exist, i.e. the position is past the end.
+   */
+  static Long boundaryOffset(List<Long> offsets, int from) {
+    Collections.sort(offsets);
+    return offsets.size() >= from ? offsets.get(from - 1) : null;
   }
 
   record Page(List<ChangeEventRecord> records, String afterCursor) {}
 
   /**
-   * Keyset-merges the bounded per-event-type result sets: sorts by monotonic {@code offset}, skips
-   * {@code from} records, keeps the next {@code limit}, and derives the forward cursor from the last
-   * kept offset. The cursor path (offset &gt; afterOffset) uses {@code from = 0}; positional paging
-   * uses {@code afterOffset = 0}. The cursor is the raw offset value; {@link ResultList} base64
-   * encodes it into {@code paging.after}.
+   * Keyset-merges the bounded per-event-type result sets: sorts by monotonic {@code offset}, keeps
+   * the first {@code limit}, and derives the forward cursor from the last kept offset. The cursor is
+   * the raw offset value; {@link ResultList} base64 encodes it into {@code paging.after}.
    */
-  static Page mergePage(List<ChangeEventRecord> records, int from, int limit) {
+  static Page mergePage(List<ChangeEventRecord> records, int limit) {
     records.sort(Comparator.comparingLong(ChangeEventRecord::offset));
-    int windowStart = Math.min(from, records.size());
-    int windowEnd = Math.min(from + limit, records.size());
-    List<ChangeEventRecord> page = new ArrayList<>(records.subList(windowStart, windowEnd));
-    boolean hasMore = records.size() > from + limit;
+    boolean hasMore = records.size() > limit;
+    List<ChangeEventRecord> page = hasMore ? new ArrayList<>(records.subList(0, limit)) : records;
     String afterCursor =
         hasMore && !page.isEmpty() ? String.valueOf(page.getLast().offset()) : null;
     return new Page(page, afterCursor);

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/ChangeEventRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/ChangeEventRepository.java
@@ -48,9 +48,6 @@ public class ChangeEventRepository {
       long afterOffset,
       int from,
       int limit) {
-    long total =
-        count(
-            timestamp, entityCreatedList, entityUpdatedList, entityRestoredList, entityDeletedList);
     Long windowStartOffset = afterOffset;
     if (from > 0) {
       windowStartOffset =
@@ -80,7 +77,7 @@ public class ChangeEventRepository {
       }
       afterCursor = page.afterCursor();
     }
-    return new ResultList<>(events, null, afterCursor, (int) Math.min(total, Integer.MAX_VALUE));
+    return new ResultList<>(events, null, afterCursor, events.size());
   }
 
   private Page fetchWindow(
@@ -152,19 +149,6 @@ public class ChangeEventRepository {
     String afterCursor =
         hasMore && !page.isEmpty() ? String.valueOf(page.getLast().offset()) : null;
     return new Page(page, afterCursor);
-  }
-
-  private long count(
-      long timestamp,
-      List<String> entityCreatedList,
-      List<String> entityUpdatedList,
-      List<String> entityRestoredList,
-      List<String> entityDeletedList) {
-    return dao.count(ENTITY_CREATED, entityCreatedList, timestamp)
-        + dao.count(ENTITY_UPDATED, entityUpdatedList, timestamp)
-        + dao.count(ENTITY_RESTORED, entityRestoredList, timestamp)
-        + dao.count(ENTITY_DELETED, entityDeletedList, timestamp)
-        + dao.count(ENTITY_SOFT_DELETED, entityDeletedList, timestamp);
   }
 
   @Transaction

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/ChangeEventRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/ChangeEventRepository.java
@@ -28,7 +28,6 @@ import org.openmetadata.schema.utils.JsonUtils;
 import org.openmetadata.schema.utils.ResultList;
 import org.openmetadata.service.Entity;
 import org.openmetadata.service.jdbi3.CollectionDAO.ChangeEventDAO.ChangeEventRecord;
-import org.openmetadata.service.util.RestUtil;
 
 @Repository
 public class ChangeEventRepository {
@@ -69,7 +68,8 @@ public class ChangeEventRepository {
     long total =
         count(
             timestamp, entityCreatedList, entityUpdatedList, entityRestoredList, entityDeletedList);
-    return new ResultList<>(events, null, page.afterCursor(), (int) total);
+    return new ResultList<>(
+        events, null, page.afterCursor(), (int) Math.min(total, Integer.MAX_VALUE));
   }
 
   record Page(List<ChangeEventRecord> records, String afterCursor) {}
@@ -78,7 +78,8 @@ public class ChangeEventRepository {
    * Keyset-merges the bounded per-event-type result sets: sorts by monotonic {@code offset}, skips
    * {@code from} records, keeps the next {@code limit}, and derives the forward cursor from the last
    * kept offset. The cursor path (offset &gt; afterOffset) uses {@code from = 0}; positional paging
-   * uses {@code afterOffset = 0}.
+   * uses {@code afterOffset = 0}. The cursor is the raw offset value; {@link ResultList} base64
+   * encodes it into {@code paging.after}.
    */
   static Page mergePage(List<ChangeEventRecord> records, int from, int limit) {
     records.sort(Comparator.comparingLong(ChangeEventRecord::offset));
@@ -87,9 +88,7 @@ public class ChangeEventRepository {
     List<ChangeEventRecord> page = new ArrayList<>(records.subList(windowStart, windowEnd));
     boolean hasMore = records.size() > from + limit;
     String afterCursor =
-        hasMore && !page.isEmpty()
-            ? RestUtil.encodeCursor(String.valueOf(page.getLast().offset()))
-            : null;
+        hasMore && !page.isEmpty() ? String.valueOf(page.getLast().offset()) : null;
     return new Page(page, afterCursor);
   }
 

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/ChangeEventRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/ChangeEventRepository.java
@@ -20,11 +20,15 @@ import static org.openmetadata.schema.type.EventType.ENTITY_SOFT_DELETED;
 import static org.openmetadata.schema.type.EventType.ENTITY_UPDATED;
 
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 import org.jdbi.v3.sqlobject.transaction.Transaction;
 import org.openmetadata.schema.type.ChangeEvent;
 import org.openmetadata.schema.utils.JsonUtils;
+import org.openmetadata.schema.utils.ResultList;
 import org.openmetadata.service.Entity;
+import org.openmetadata.service.jdbi3.CollectionDAO.ChangeEventDAO.ChangeEventRecord;
+import org.openmetadata.service.util.RestUtil;
 
 @Repository
 public class ChangeEventRepository {
@@ -35,24 +39,64 @@ public class ChangeEventRepository {
     Entity.setChangeEventRepository(this);
   }
 
-  public List<ChangeEvent> list(
+  public ResultList<ChangeEvent> list(
+      long timestamp,
+      List<String> entityCreatedList,
+      List<String> entityUpdatedList,
+      List<String> entityRestoredList,
+      List<String> entityDeletedList,
+      long afterOffset,
+      int limit) {
+    int fetchLimit = limit + 1;
+    List<ChangeEventRecord> records = new ArrayList<>();
+    records.addAll(
+        dao.listAfter(ENTITY_CREATED, entityCreatedList, timestamp, afterOffset, fetchLimit));
+    records.addAll(
+        dao.listAfter(ENTITY_UPDATED, entityUpdatedList, timestamp, afterOffset, fetchLimit));
+    records.addAll(
+        dao.listAfter(ENTITY_RESTORED, entityRestoredList, timestamp, afterOffset, fetchLimit));
+    records.addAll(
+        dao.listAfter(ENTITY_DELETED, entityDeletedList, timestamp, afterOffset, fetchLimit));
+    records.addAll(
+        dao.listAfter(ENTITY_SOFT_DELETED, entityDeletedList, timestamp, afterOffset, fetchLimit));
+
+    Page page = mergePage(records, limit);
+    List<ChangeEvent> events = new ArrayList<>();
+    for (ChangeEventRecord record : page.records()) {
+      events.add(JsonUtils.readValue(record.json(), ChangeEvent.class));
+    }
+    long total =
+        count(
+            timestamp, entityCreatedList, entityUpdatedList, entityRestoredList, entityDeletedList);
+    return new ResultList<>(events, null, page.afterCursor(), (int) total);
+  }
+
+  record Page(List<ChangeEventRecord> records, String afterCursor) {}
+
+  /**
+   * Keyset-merges the bounded per-event-type result sets: sorts by monotonic {@code offset}, keeps
+   * the first {@code limit} records, and derives the forward cursor from the last kept offset.
+   */
+  static Page mergePage(List<ChangeEventRecord> records, int limit) {
+    records.sort(Comparator.comparingLong(ChangeEventRecord::offset));
+    boolean hasMore = records.size() > limit;
+    List<ChangeEventRecord> page = hasMore ? new ArrayList<>(records.subList(0, limit)) : records;
+    String afterCursor =
+        hasMore ? RestUtil.encodeCursor(String.valueOf(page.getLast().offset())) : null;
+    return new Page(page, afterCursor);
+  }
+
+  private long count(
       long timestamp,
       List<String> entityCreatedList,
       List<String> entityUpdatedList,
       List<String> entityRestoredList,
       List<String> entityDeletedList) {
-    List<String> jsons = new ArrayList<>();
-    jsons.addAll(dao.list(ENTITY_CREATED, entityCreatedList, timestamp));
-    jsons.addAll(dao.list(ENTITY_UPDATED, entityUpdatedList, timestamp));
-    jsons.addAll(dao.list(ENTITY_RESTORED, entityRestoredList, timestamp));
-    jsons.addAll(dao.list(ENTITY_DELETED, entityDeletedList, timestamp));
-    jsons.addAll(dao.list(ENTITY_SOFT_DELETED, entityDeletedList, timestamp));
-
-    List<ChangeEvent> changeEvents = new ArrayList<>();
-    for (String json : jsons) {
-      changeEvents.add(JsonUtils.readValue(json, ChangeEvent.class));
-    }
-    return changeEvents;
+    return dao.count(ENTITY_CREATED, entityCreatedList, timestamp)
+        + dao.count(ENTITY_UPDATED, entityUpdatedList, timestamp)
+        + dao.count(ENTITY_RESTORED, entityRestoredList, timestamp)
+        + dao.count(ENTITY_DELETED, entityDeletedList, timestamp)
+        + dao.count(ENTITY_SOFT_DELETED, entityDeletedList, timestamp);
   }
 
   @Transaction

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/CollectionDAO.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/CollectionDAO.java
@@ -8837,31 +8837,6 @@ public interface CollectionDAO {
         @Bind("afterOffset") long afterOffset,
         @Bind("limit") int limit);
 
-    default long count(EventType eventType, List<String> entityTypes, long timestamp) {
-      long result;
-      if (nullOrEmpty(entityTypes)) {
-        result = 0;
-      } else if (entityTypes.getFirst().equals("*")) {
-        result = countWithoutEntityFilter(eventType.value(), timestamp);
-      } else {
-        result = countWithEntityFilter(eventType.value(), entityTypes, timestamp);
-      }
-      return result;
-    }
-
-    @SqlQuery(
-        "SELECT COUNT(*) FROM change_event WHERE eventType = :eventType "
-            + "AND entityType IN (<entityTypes>) AND eventTime >= :timestamp")
-    long countWithEntityFilter(
-        @Bind("eventType") String eventType,
-        @BindList("entityTypes") List<String> entityTypes,
-        @Bind("timestamp") long timestamp);
-
-    @SqlQuery(
-        "SELECT COUNT(*) FROM change_event WHERE eventType = :eventType AND eventTime >= :timestamp")
-    long countWithoutEntityFilter(
-        @Bind("eventType") String eventType, @Bind("timestamp") long timestamp);
-
     @SqlQuery(
         "SELECT json FROM change_event ce  WHERE ce.offset > :offset ORDER BY ce.offset ASC LIMIT :limit")
     List<String> list(@Bind("limit") long limit, @Bind("offset") long offset);

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/CollectionDAO.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/CollectionDAO.java
@@ -8735,17 +8735,23 @@ public interface CollectionDAO {
       return result;
     }
 
+    // Deferred join: the page is resolved index-only on `offset` in the derived table, then json is
+    // fetched by primary key for only the paged rows, so the json blob never enters the filesort
+    // (MySQL packs wide rows into sort_buffer_size and throws ER_OUT_OF_SORTMEMORY otherwise).
+    // The caller re-sorts the merged pages, so no outer ORDER BY is needed here.
     @ConnectionAwareSqlQuery(
         value =
-            "SELECT `offset` AS offset, json FROM change_event WHERE eventType = :eventType "
+            "SELECT c.`offset` AS offset, c.json AS json FROM change_event c INNER JOIN ("
+                + "SELECT `offset` FROM change_event WHERE eventType = :eventType "
                 + "AND entityType IN (<entityTypes>) AND eventTime >= :timestamp AND `offset` > :afterOffset "
-                + "ORDER BY `offset` ASC LIMIT :limit",
+                + "ORDER BY `offset` ASC LIMIT :limit) k ON c.`offset` = k.`offset`",
         connectionType = MYSQL)
     @ConnectionAwareSqlQuery(
         value =
-            "SELECT \"offset\" AS offset, json FROM change_event WHERE eventType = :eventType "
+            "SELECT c.\"offset\" AS offset, c.json AS json FROM change_event c INNER JOIN ("
+                + "SELECT \"offset\" FROM change_event WHERE eventType = :eventType "
                 + "AND entityType IN (<entityTypes>) AND eventTime >= :timestamp AND \"offset\" > :afterOffset "
-                + "ORDER BY \"offset\" ASC LIMIT :limit",
+                + "ORDER BY \"offset\" ASC LIMIT :limit) k ON c.\"offset\" = k.\"offset\"",
         connectionType = POSTGRES)
     @RegisterRowMapper(ChangeEventRecordMapper.class)
     List<ChangeEventRecord> listAfterWithEntityFilter(
@@ -8757,16 +8763,75 @@ public interface CollectionDAO {
 
     @ConnectionAwareSqlQuery(
         value =
-            "SELECT `offset` AS offset, json FROM change_event WHERE eventType = :eventType "
+            "SELECT c.`offset` AS offset, c.json AS json FROM change_event c INNER JOIN ("
+                + "SELECT `offset` FROM change_event WHERE eventType = :eventType "
+                + "AND eventTime >= :timestamp AND `offset` > :afterOffset "
+                + "ORDER BY `offset` ASC LIMIT :limit) k ON c.`offset` = k.`offset`",
+        connectionType = MYSQL)
+    @ConnectionAwareSqlQuery(
+        value =
+            "SELECT c.\"offset\" AS offset, c.json AS json FROM change_event c INNER JOIN ("
+                + "SELECT \"offset\" FROM change_event WHERE eventType = :eventType "
+                + "AND eventTime >= :timestamp AND \"offset\" > :afterOffset "
+                + "ORDER BY \"offset\" ASC LIMIT :limit) k ON c.\"offset\" = k.\"offset\"",
+        connectionType = POSTGRES)
+    @RegisterRowMapper(ChangeEventRecordMapper.class)
+    List<ChangeEventRecord> listAfterWithoutEntityFilter(
+        @Bind("eventType") String eventType,
+        @Bind("timestamp") long timestamp,
+        @Bind("afterOffset") long afterOffset,
+        @Bind("limit") int limit);
+
+    default List<Long> listOffsetsAfter(
+        EventType eventType,
+        List<String> entityTypes,
+        long timestamp,
+        long afterOffset,
+        int limit) {
+      List<Long> result;
+      if (nullOrEmpty(entityTypes)) {
+        result = Collections.emptyList();
+      } else if (entityTypes.getFirst().equals("*")) {
+        result =
+            listOffsetsAfterWithoutEntityFilter(eventType.value(), timestamp, afterOffset, limit);
+      } else {
+        result =
+            listOffsetsAfterWithEntityFilter(
+                eventType.value(), entityTypes, timestamp, afterOffset, limit);
+      }
+      return result;
+    }
+
+    @ConnectionAwareSqlQuery(
+        value =
+            "SELECT `offset` FROM change_event WHERE eventType = :eventType "
+                + "AND entityType IN (<entityTypes>) AND eventTime >= :timestamp AND `offset` > :afterOffset "
+                + "ORDER BY `offset` ASC LIMIT :limit",
+        connectionType = MYSQL)
+    @ConnectionAwareSqlQuery(
+        value =
+            "SELECT \"offset\" FROM change_event WHERE eventType = :eventType "
+                + "AND entityType IN (<entityTypes>) AND eventTime >= :timestamp AND \"offset\" > :afterOffset "
+                + "ORDER BY \"offset\" ASC LIMIT :limit",
+        connectionType = POSTGRES)
+    List<Long> listOffsetsAfterWithEntityFilter(
+        @Bind("eventType") String eventType,
+        @BindList("entityTypes") List<String> entityTypes,
+        @Bind("timestamp") long timestamp,
+        @Bind("afterOffset") long afterOffset,
+        @Bind("limit") int limit);
+
+    @ConnectionAwareSqlQuery(
+        value =
+            "SELECT `offset` FROM change_event WHERE eventType = :eventType "
                 + "AND eventTime >= :timestamp AND `offset` > :afterOffset ORDER BY `offset` ASC LIMIT :limit",
         connectionType = MYSQL)
     @ConnectionAwareSqlQuery(
         value =
-            "SELECT \"offset\" AS offset, json FROM change_event WHERE eventType = :eventType "
+            "SELECT \"offset\" FROM change_event WHERE eventType = :eventType "
                 + "AND eventTime >= :timestamp AND \"offset\" > :afterOffset ORDER BY \"offset\" ASC LIMIT :limit",
         connectionType = POSTGRES)
-    @RegisterRowMapper(ChangeEventRecordMapper.class)
-    List<ChangeEventRecord> listAfterWithoutEntityFilter(
+    List<Long> listOffsetsAfterWithoutEntityFilter(
         @Bind("eventType") String eventType,
         @Bind("timestamp") long timestamp,
         @Bind("afterOffset") long afterOffset,

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/CollectionDAO.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/CollectionDAO.java
@@ -8716,30 +8716,85 @@ public interface CollectionDAO {
     @SqlUpdate("DELETE FROM change_event WHERE entityType = :entityType")
     void deleteAll(@Bind("entityType") String entityType);
 
-    default List<String> list(EventType eventType, List<String> entityTypes, long timestamp) {
+    default List<ChangeEventRecord> listAfter(
+        EventType eventType,
+        List<String> entityTypes,
+        long timestamp,
+        long afterOffset,
+        int limit) {
+      List<ChangeEventRecord> result;
       if (nullOrEmpty(entityTypes)) {
-        return Collections.emptyList();
+        result = Collections.emptyList();
+      } else if (entityTypes.getFirst().equals("*")) {
+        result = listAfterWithoutEntityFilter(eventType.value(), timestamp, afterOffset, limit);
+      } else {
+        result =
+            listAfterWithEntityFilter(
+                eventType.value(), entityTypes, timestamp, afterOffset, limit);
       }
-      if (entityTypes.get(0).equals("*")) {
-        return listWithoutEntityFilter(eventType.value(), timestamp);
+      return result;
+    }
+
+    @ConnectionAwareSqlQuery(
+        value =
+            "SELECT `offset` AS offset, json FROM change_event WHERE eventType = :eventType "
+                + "AND entityType IN (<entityTypes>) AND eventTime >= :timestamp AND `offset` > :afterOffset "
+                + "ORDER BY `offset` ASC LIMIT :limit",
+        connectionType = MYSQL)
+    @ConnectionAwareSqlQuery(
+        value =
+            "SELECT \"offset\" AS offset, json FROM change_event WHERE eventType = :eventType "
+                + "AND entityType IN (<entityTypes>) AND eventTime >= :timestamp AND \"offset\" > :afterOffset "
+                + "ORDER BY \"offset\" ASC LIMIT :limit",
+        connectionType = POSTGRES)
+    @RegisterRowMapper(ChangeEventRecordMapper.class)
+    List<ChangeEventRecord> listAfterWithEntityFilter(
+        @Bind("eventType") String eventType,
+        @BindList("entityTypes") List<String> entityTypes,
+        @Bind("timestamp") long timestamp,
+        @Bind("afterOffset") long afterOffset,
+        @Bind("limit") int limit);
+
+    @ConnectionAwareSqlQuery(
+        value =
+            "SELECT `offset` AS offset, json FROM change_event WHERE eventType = :eventType "
+                + "AND eventTime >= :timestamp AND `offset` > :afterOffset ORDER BY `offset` ASC LIMIT :limit",
+        connectionType = MYSQL)
+    @ConnectionAwareSqlQuery(
+        value =
+            "SELECT \"offset\" AS offset, json FROM change_event WHERE eventType = :eventType "
+                + "AND eventTime >= :timestamp AND \"offset\" > :afterOffset ORDER BY \"offset\" ASC LIMIT :limit",
+        connectionType = POSTGRES)
+    @RegisterRowMapper(ChangeEventRecordMapper.class)
+    List<ChangeEventRecord> listAfterWithoutEntityFilter(
+        @Bind("eventType") String eventType,
+        @Bind("timestamp") long timestamp,
+        @Bind("afterOffset") long afterOffset,
+        @Bind("limit") int limit);
+
+    default long count(EventType eventType, List<String> entityTypes, long timestamp) {
+      long result;
+      if (nullOrEmpty(entityTypes)) {
+        result = 0;
+      } else if (entityTypes.getFirst().equals("*")) {
+        result = countWithoutEntityFilter(eventType.value(), timestamp);
+      } else {
+        result = countWithEntityFilter(eventType.value(), entityTypes, timestamp);
       }
-      return listWithEntityFilter(eventType.value(), entityTypes, timestamp);
+      return result;
     }
 
     @SqlQuery(
-        "SELECT json FROM change_event WHERE "
-            + "eventType = :eventType AND (entityType IN (<entityTypes>)) AND eventTime >= :timestamp "
-            + "ORDER BY eventTime ASC")
-    List<String> listWithEntityFilter(
+        "SELECT COUNT(*) FROM change_event WHERE eventType = :eventType "
+            + "AND entityType IN (<entityTypes>) AND eventTime >= :timestamp")
+    long countWithEntityFilter(
         @Bind("eventType") String eventType,
         @BindList("entityTypes") List<String> entityTypes,
         @Bind("timestamp") long timestamp);
 
     @SqlQuery(
-        "SELECT json FROM change_event WHERE "
-            + "eventType = :eventType AND eventTime >= :timestamp "
-            + "ORDER BY eventTime ASC")
-    List<String> listWithoutEntityFilter(
+        "SELECT COUNT(*) FROM change_event WHERE eventType = :eventType AND eventTime >= :timestamp")
+    long countWithoutEntityFilter(
         @Bind("eventType") String eventType, @Bind("timestamp") long timestamp);
 
     @SqlQuery(

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/CollectionDAO.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/CollectionDAO.java
@@ -8720,17 +8720,19 @@ public interface CollectionDAO {
         EventType eventType,
         List<String> entityTypes,
         long timestamp,
+        long endTs,
         long afterOffset,
         int limit) {
       List<ChangeEventRecord> result;
       if (nullOrEmpty(entityTypes)) {
         result = Collections.emptyList();
       } else if (entityTypes.getFirst().equals("*")) {
-        result = listAfterWithoutEntityFilter(eventType.value(), timestamp, afterOffset, limit);
+        result =
+            listAfterWithoutEntityFilter(eventType.value(), timestamp, endTs, afterOffset, limit);
       } else {
         result =
             listAfterWithEntityFilter(
-                eventType.value(), entityTypes, timestamp, afterOffset, limit);
+                eventType.value(), entityTypes, timestamp, endTs, afterOffset, limit);
       }
       return result;
     }
@@ -8743,21 +8745,24 @@ public interface CollectionDAO {
         value =
             "SELECT c.`offset` AS offset, c.json AS json FROM change_event c INNER JOIN ("
                 + "SELECT `offset` FROM change_event WHERE eventType = :eventType "
-                + "AND entityType IN (<entityTypes>) AND eventTime >= :timestamp AND `offset` > :afterOffset "
-                + "ORDER BY `offset` ASC LIMIT :limit) k ON c.`offset` = k.`offset`",
+                + "AND entityType IN (<entityTypes>) AND eventTime >= :timestamp AND eventTime <= :endTs "
+                + "AND `offset` > :afterOffset ORDER BY `offset` ASC LIMIT :limit) k "
+                + "ON c.`offset` = k.`offset`",
         connectionType = MYSQL)
     @ConnectionAwareSqlQuery(
         value =
             "SELECT c.\"offset\" AS offset, c.json AS json FROM change_event c INNER JOIN ("
                 + "SELECT \"offset\" FROM change_event WHERE eventType = :eventType "
-                + "AND entityType IN (<entityTypes>) AND eventTime >= :timestamp AND \"offset\" > :afterOffset "
-                + "ORDER BY \"offset\" ASC LIMIT :limit) k ON c.\"offset\" = k.\"offset\"",
+                + "AND entityType IN (<entityTypes>) AND eventTime >= :timestamp AND eventTime <= :endTs "
+                + "AND \"offset\" > :afterOffset ORDER BY \"offset\" ASC LIMIT :limit) k "
+                + "ON c.\"offset\" = k.\"offset\"",
         connectionType = POSTGRES)
     @RegisterRowMapper(ChangeEventRecordMapper.class)
     List<ChangeEventRecord> listAfterWithEntityFilter(
         @Bind("eventType") String eventType,
         @BindList("entityTypes") List<String> entityTypes,
         @Bind("timestamp") long timestamp,
+        @Bind("endTs") long endTs,
         @Bind("afterOffset") long afterOffset,
         @Bind("limit") int limit);
 
@@ -8765,75 +8770,21 @@ public interface CollectionDAO {
         value =
             "SELECT c.`offset` AS offset, c.json AS json FROM change_event c INNER JOIN ("
                 + "SELECT `offset` FROM change_event WHERE eventType = :eventType "
-                + "AND eventTime >= :timestamp AND `offset` > :afterOffset "
+                + "AND eventTime >= :timestamp AND eventTime <= :endTs AND `offset` > :afterOffset "
                 + "ORDER BY `offset` ASC LIMIT :limit) k ON c.`offset` = k.`offset`",
         connectionType = MYSQL)
     @ConnectionAwareSqlQuery(
         value =
             "SELECT c.\"offset\" AS offset, c.json AS json FROM change_event c INNER JOIN ("
                 + "SELECT \"offset\" FROM change_event WHERE eventType = :eventType "
-                + "AND eventTime >= :timestamp AND \"offset\" > :afterOffset "
+                + "AND eventTime >= :timestamp AND eventTime <= :endTs AND \"offset\" > :afterOffset "
                 + "ORDER BY \"offset\" ASC LIMIT :limit) k ON c.\"offset\" = k.\"offset\"",
         connectionType = POSTGRES)
     @RegisterRowMapper(ChangeEventRecordMapper.class)
     List<ChangeEventRecord> listAfterWithoutEntityFilter(
         @Bind("eventType") String eventType,
         @Bind("timestamp") long timestamp,
-        @Bind("afterOffset") long afterOffset,
-        @Bind("limit") int limit);
-
-    default List<Long> listOffsetsAfter(
-        EventType eventType,
-        List<String> entityTypes,
-        long timestamp,
-        long afterOffset,
-        int limit) {
-      List<Long> result;
-      if (nullOrEmpty(entityTypes)) {
-        result = Collections.emptyList();
-      } else if (entityTypes.getFirst().equals("*")) {
-        result =
-            listOffsetsAfterWithoutEntityFilter(eventType.value(), timestamp, afterOffset, limit);
-      } else {
-        result =
-            listOffsetsAfterWithEntityFilter(
-                eventType.value(), entityTypes, timestamp, afterOffset, limit);
-      }
-      return result;
-    }
-
-    @ConnectionAwareSqlQuery(
-        value =
-            "SELECT `offset` FROM change_event WHERE eventType = :eventType "
-                + "AND entityType IN (<entityTypes>) AND eventTime >= :timestamp AND `offset` > :afterOffset "
-                + "ORDER BY `offset` ASC LIMIT :limit",
-        connectionType = MYSQL)
-    @ConnectionAwareSqlQuery(
-        value =
-            "SELECT \"offset\" FROM change_event WHERE eventType = :eventType "
-                + "AND entityType IN (<entityTypes>) AND eventTime >= :timestamp AND \"offset\" > :afterOffset "
-                + "ORDER BY \"offset\" ASC LIMIT :limit",
-        connectionType = POSTGRES)
-    List<Long> listOffsetsAfterWithEntityFilter(
-        @Bind("eventType") String eventType,
-        @BindList("entityTypes") List<String> entityTypes,
-        @Bind("timestamp") long timestamp,
-        @Bind("afterOffset") long afterOffset,
-        @Bind("limit") int limit);
-
-    @ConnectionAwareSqlQuery(
-        value =
-            "SELECT `offset` FROM change_event WHERE eventType = :eventType "
-                + "AND eventTime >= :timestamp AND `offset` > :afterOffset ORDER BY `offset` ASC LIMIT :limit",
-        connectionType = MYSQL)
-    @ConnectionAwareSqlQuery(
-        value =
-            "SELECT \"offset\" FROM change_event WHERE eventType = :eventType "
-                + "AND eventTime >= :timestamp AND \"offset\" > :afterOffset ORDER BY \"offset\" ASC LIMIT :limit",
-        connectionType = POSTGRES)
-    List<Long> listOffsetsAfterWithoutEntityFilter(
-        @Bind("eventType") String eventType,
-        @Bind("timestamp") long timestamp,
+        @Bind("endTs") long endTs,
         @Bind("afterOffset") long afterOffset,
         @Bind("limit") int limit);
 

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/CollectionDAO.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/CollectionDAO.java
@@ -8737,10 +8737,9 @@ public interface CollectionDAO {
       return result;
     }
 
-    // Deferred join: the page is resolved index-only on `offset` in the derived table, then json is
-    // fetched by primary key for only the paged rows, so the json blob never enters the filesort
-    // (MySQL packs wide rows into sort_buffer_size and throws ER_OUT_OF_SORTMEMORY otherwise).
-    // The caller re-sorts the merged pages, so no outer ORDER BY is needed here.
+    // Deferred join: sort/limit on `offset` only, fetch json by PK — keeps the json blob out of
+    // MySQL's filesort (else ER_OUT_OF_SORTMEMORY on wide rows). Caller re-sorts; no outer ORDER
+    // BY.
     @ConnectionAwareSqlQuery(
         value =
             "SELECT c.`offset` AS offset, c.json AS json FROM change_event c INNER JOIN ("

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/events/EventResource.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/events/EventResource.java
@@ -73,11 +73,11 @@ public class EventResource {
       operationId = "listChangeEvents",
       summary = "Get change events",
       description =
-          "Get a paginated list of change events matching event types, entity type, from a given "
-              + "date. Results are ordered by the monotonic change-event offset (insertion order), "
-              + "not strictly by event time, so keyset pagination via `after` is stable. Use "
-              + "`limit` with the `after` cursor for forward paging, or `from` for positional "
-              + "access; `from` and `after` are mutually exclusive.",
+          "Get a paginated list of change events matching event types and entity type within a "
+              + "time window (`timestamp` lower bound, optional `endTs` upper bound). Results are "
+              + "ordered by the monotonic change-event offset (insertion order), not strictly by "
+              + "event time, so keyset pagination via `after` is stable. Page forward with `limit` "
+              + "and the `after` cursor until `paging.after` is null to drain the window.",
       responses = {
         @ApiResponse(
             responseCode = "200",

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/events/EventResource.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/events/EventResource.java
@@ -73,7 +73,11 @@ public class EventResource {
       operationId = "listChangeEvents",
       summary = "Get change events",
       description =
-          "Get a list of change events matching event types, entity type, from a given date",
+          "Get a paginated list of change events matching event types, entity type, from a given "
+              + "date. Results are ordered by the monotonic change-event offset (insertion order), "
+              + "not strictly by event time, so keyset pagination via `after` is stable. Use "
+              + "`limit` with the `after` cursor for forward paging, or `from` for positional "
+              + "access; `from` and `after` are mutually exclusive.",
       responses = {
         @ApiResponse(
             responseCode = "200",
@@ -155,6 +159,9 @@ public class EventResource {
     List<String> entityRestoredList = EntityList.getEntityList("entityRestored", entityRestored);
     List<String> entityDeletedList = EntityList.getEntityList("entityDeleted", entityDeleted);
     String decodedCursor = RestUtil.decodeCursor(after);
+    if (decodedCursor != null && from > 0) {
+      throw new IllegalArgumentException("Only one of 'from' or 'after' query parameter allowed");
+    }
     long afterOffset = decodedCursor == null ? 0 : Long.parseLong(decodedCursor);
     return repository.list(
         timestamp,

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/events/EventResource.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/events/EventResource.java
@@ -73,11 +73,8 @@ public class EventResource {
       operationId = "listChangeEvents",
       summary = "Get change events",
       description =
-          "Get a paginated list of change events matching event types and entity type within a "
-              + "time window (`timestamp` lower bound, optional `endTs` upper bound). Results are "
-              + "ordered by the monotonic change-event offset (insertion order), not strictly by "
-              + "event time, so keyset pagination via `after` is stable. Page forward with `limit` "
-              + "and the `after` cursor until `paging.after` is null to drain the window.",
+          "Get change events within a time range, one page at a time. Use `limit` to set the page "
+              + "size and `after` to fetch the next page.",
       responses = {
         @ApiResponse(
             responseCode = "200",
@@ -130,8 +127,8 @@ public class EventResource {
           long timestamp,
       @Parameter(
               description =
-                  "Optional inclusive upper bound: only events with `eventTime` at or before this "
-                      + "unix timestamp in milliseconds are returned. Defaults to no upper bound.",
+                  "Only return events up to this unix timestamp in milliseconds. "
+                      + "Defaults to no end limit.",
               schema = @Schema(type = "long", example = "1426349294842"))
           @DefaultValue("0")
           @QueryParam("endTs")
@@ -146,9 +143,8 @@ public class EventResource {
           int limitParam,
       @Parameter(
               description =
-                  "Opaque cursor returned as `paging.after` from a previous call; pass it back to "
-                      + "fetch the next page of events. Clients should echo this value rather than "
-                      + "construct it. Page forward until `paging.after` is null to drain the range.",
+                  "Cursor from the previous response's `paging.after`. Pass it back to get the next "
+                      + "page; keep going until it is empty.",
               schema = @Schema(type = "string"))
           @QueryParam("after")
           String after) {

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/events/EventResource.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/events/EventResource.java
@@ -20,7 +20,10 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
 import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.DefaultValue;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
@@ -37,7 +40,7 @@ import org.openmetadata.service.Entity.EntityList;
 import org.openmetadata.service.jdbi3.ChangeEventRepository;
 import org.openmetadata.service.resources.Collection;
 import org.openmetadata.service.security.Authorizer;
-import org.openmetadata.service.util.EntityUtil;
+import org.openmetadata.service.util.RestUtil;
 
 @Path("/v1/events")
 @Tag(
@@ -120,15 +123,33 @@ public class EventResource {
               required = true,
               schema = @Schema(type = "long", example = "1426349294842"))
           @QueryParam("timestamp")
-          long timestamp) {
+          long timestamp,
+      @Parameter(
+              description = "Limit the number of events returned. (1 to 1000, default = 100)",
+              schema = @Schema(type = "integer", example = "100"))
+          @DefaultValue("100")
+          @Min(value = 1, message = "must be greater than or equal to 1")
+          @Max(value = 1000, message = "must be less than or equal to 1000")
+          @QueryParam("limit")
+          int limitParam,
+      @Parameter(
+              description = "Returns list of change events after this cursor",
+              schema = @Schema(type = "string"))
+          @QueryParam("after")
+          String after) {
     List<String> entityCreatedList = EntityList.getEntityList("entityCreated", entityCreated);
     List<String> entityUpdatedList = EntityList.getEntityList("entityUpdated", entityUpdated);
     List<String> entityRestoredList = EntityList.getEntityList("entityRestored", entityRestored);
     List<String> entityDeletedList = EntityList.getEntityList("entityDeleted", entityDeleted);
-    List<ChangeEvent> events =
-        repository.list(
-            timestamp, entityCreatedList, entityUpdatedList, entityRestoredList, entityDeletedList);
-    events.sort(EntityUtil.compareChangeEvent); // Sort change events based on time
-    return new EventList(events, null, null, events.size());
+    String decodedCursor = RestUtil.decodeCursor(after);
+    long afterOffset = decodedCursor == null ? 0 : Long.parseLong(decodedCursor);
+    return repository.list(
+        timestamp,
+        entityCreatedList,
+        entityUpdatedList,
+        entityRestoredList,
+        entityDeletedList,
+        afterOffset,
+        limitParam);
   }
 }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/events/EventResource.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/events/EventResource.java
@@ -133,7 +133,20 @@ public class EventResource {
           @QueryParam("limit")
           int limitParam,
       @Parameter(
-              description = "Returns list of change events after this cursor",
+              description =
+                  "Number of matching events to skip for positional pagination, defaults to 0. "
+                      + "Prefer the `after` cursor for deep pagination on large event volumes.",
+              schema = @Schema(type = "integer", example = "0"))
+          @DefaultValue("0")
+          @Min(value = 0, message = "must be greater than or equal to 0")
+          @Max(value = 10000, message = "must be less than or equal to 10000")
+          @QueryParam("from")
+          int from,
+      @Parameter(
+              description =
+                  "Opaque cursor returned as `paging.after` from a previous call; pass it back to "
+                      + "fetch the next page of events. Clients should echo this value rather than "
+                      + "construct it.",
               schema = @Schema(type = "string"))
           @QueryParam("after")
           String after) {
@@ -150,6 +163,7 @@ public class EventResource {
         entityRestoredList,
         entityDeletedList,
         afterOffset,
+        from,
         limitParam);
   }
 }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/events/EventResource.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/events/EventResource.java
@@ -129,6 +129,14 @@ public class EventResource {
           @QueryParam("timestamp")
           long timestamp,
       @Parameter(
+              description =
+                  "Optional inclusive upper bound: only events with `eventTime` at or before this "
+                      + "unix timestamp in milliseconds are returned. Defaults to no upper bound.",
+              schema = @Schema(type = "long", example = "1426349294842"))
+          @DefaultValue("0")
+          @QueryParam("endTs")
+          long endTs,
+      @Parameter(
               description = "Limit the number of events returned. (1 to 1000, default = 100)",
               schema = @Schema(type = "integer", example = "100"))
           @DefaultValue("100")
@@ -138,19 +146,9 @@ public class EventResource {
           int limitParam,
       @Parameter(
               description =
-                  "Number of matching events to skip for positional pagination, defaults to 0. "
-                      + "Prefer the `after` cursor for deep pagination on large event volumes.",
-              schema = @Schema(type = "integer", example = "0"))
-          @DefaultValue("0")
-          @Min(value = 0, message = "must be greater than or equal to 0")
-          @Max(value = 10000, message = "must be less than or equal to 10000")
-          @QueryParam("from")
-          int from,
-      @Parameter(
-              description =
                   "Opaque cursor returned as `paging.after` from a previous call; pass it back to "
                       + "fetch the next page of events. Clients should echo this value rather than "
-                      + "construct it.",
+                      + "construct it. Page forward until `paging.after` is null to drain the range.",
               schema = @Schema(type = "string"))
           @QueryParam("after")
           String after) {
@@ -159,18 +157,16 @@ public class EventResource {
     List<String> entityRestoredList = EntityList.getEntityList("entityRestored", entityRestored);
     List<String> entityDeletedList = EntityList.getEntityList("entityDeleted", entityDeleted);
     String decodedCursor = RestUtil.decodeCursor(after);
-    if (decodedCursor != null && from > 0) {
-      throw new IllegalArgumentException("Only one of 'from' or 'after' query parameter allowed");
-    }
     long afterOffset = decodedCursor == null ? 0 : Long.parseLong(decodedCursor);
+    long upperBound = endTs <= 0 ? Long.MAX_VALUE : endTs;
     return repository.list(
         timestamp,
+        upperBound,
         entityCreatedList,
         entityUpdatedList,
         entityRestoredList,
         entityDeletedList,
         afterOffset,
-        from,
         limitParam);
   }
 }

--- a/openmetadata-service/src/test/java/org/openmetadata/service/jdbi3/ChangeEventRepositoryPaginationTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/jdbi3/ChangeEventRepositoryPaginationTest.java
@@ -1,0 +1,100 @@
+/*
+ *  Copyright 2021 Collate
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.openmetadata.service.jdbi3;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.openmetadata.service.jdbi3.ChangeEventRepository.Page;
+import org.openmetadata.service.jdbi3.CollectionDAO.ChangeEventDAO.ChangeEventRecord;
+import org.openmetadata.service.util.RestUtil;
+
+class ChangeEventRepositoryPaginationTest {
+
+  private static List<ChangeEventRecord> records(long... offsets) {
+    List<ChangeEventRecord> records = new ArrayList<>();
+    for (long offset : offsets) {
+      records.add(new ChangeEventRecord(offset, "{\"offset\":" + offset + "}"));
+    }
+    return records;
+  }
+
+  private static long decodeOffset(String afterCursor) {
+    return Long.parseLong(RestUtil.decodeCursor(afterCursor));
+  }
+
+  @Test
+  void mergePageSortsByOffsetAcrossEventTypes() {
+    Page page = ChangeEventRepository.mergePage(records(9, 2, 7, 1, 5), 10);
+
+    List<Long> offsets = page.records().stream().map(ChangeEventRecord::offset).toList();
+    assertEquals(List.of(1L, 2L, 5L, 7L, 9L), offsets, "records must be ordered by offset");
+    assertNull(page.afterCursor(), "no next page when everything fits in the limit");
+  }
+
+  @Test
+  void mergePageBoundsResultsToLimitAndEmitsCursor() {
+    Page page = ChangeEventRepository.mergePage(records(10, 20, 30, 40, 50), 3);
+
+    List<Long> offsets = page.records().stream().map(ChangeEventRecord::offset).toList();
+    assertEquals(List.of(10L, 20L, 30L), offsets, "page is capped at the requested limit");
+    assertNotNull(page.afterCursor(), "cursor is returned when more records remain");
+    assertEquals(30L, decodeOffset(page.afterCursor()), "cursor points at the last kept offset");
+  }
+
+  @Test
+  void mergePageWithExactlyLimitHasNoCursor() {
+    Page page = ChangeEventRepository.mergePage(records(1, 2, 3), 3);
+
+    assertEquals(3, page.records().size());
+    assertNull(page.afterCursor(), "no cursor when the result set exactly equals the limit");
+  }
+
+  @Test
+  void nextPageCursorContinuesWithoutGapsOrDuplicates() {
+    List<Long> allOffsets = new ArrayList<>();
+    for (long offset = 1; offset <= 25; offset++) {
+      allOffsets.add(offset);
+    }
+
+    int limit = 10;
+    long after = 0;
+    List<Long> paged = new ArrayList<>();
+    String cursor;
+    do {
+      List<ChangeEventRecord> fetched = new ArrayList<>();
+      for (long offset : allOffsets) {
+        if (offset > after && fetched.size() < limit + 1) {
+          fetched.add(new ChangeEventRecord(offset, "{}"));
+        }
+      }
+      Page page = ChangeEventRepository.mergePage(fetched, limit);
+      page.records().forEach(record -> paged.add(record.offset()));
+      cursor = page.afterCursor();
+      if (cursor != null) {
+        after = decodeOffset(cursor);
+      }
+    } while (cursor != null);
+
+    assertEquals(allOffsets, paged, "paging through the cursor visits every offset exactly once");
+    assertEquals(
+        paged.size(), paged.stream().distinct().count(), "no duplicate offsets across pages");
+    assertTrue(after > 0);
+  }
+}

--- a/openmetadata-service/src/test/java/org/openmetadata/service/jdbi3/ChangeEventRepositoryTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/jdbi3/ChangeEventRepositoryTest.java
@@ -69,27 +69,6 @@ class ChangeEventRepositoryTest {
   }
 
   @Test
-  void boundaryOffsetResolvesPositionalSkipToKeysetOffset() {
-    List<Long> offsets = new ArrayList<>(List.of(50L, 10L, 40L, 20L, 30L));
-
-    Long boundary = ChangeEventRepository.boundaryOffset(offsets, 2);
-
-    assertEquals(
-        20L,
-        boundary,
-        "from=2 resolves to the 2nd smallest offset; window is fetched with offset > 20");
-  }
-
-  @Test
-  void boundaryOffsetBeyondResultsReturnsNull() {
-    List<Long> offsets = new ArrayList<>(List.of(10L, 20L, 30L));
-
-    assertNull(
-        ChangeEventRepository.boundaryOffset(offsets, 10),
-        "from past the end has no boundary offset, so the window is empty");
-  }
-
-  @Test
   void cursorSurvivesResultListEncodingRoundTrip() {
     Page page = ChangeEventRepository.mergePage(records(10, 20, 30, 40), 2);
 

--- a/openmetadata-service/src/test/java/org/openmetadata/service/jdbi3/ChangeEventRepositoryTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/jdbi3/ChangeEventRepositoryTest.java
@@ -21,6 +21,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.util.ArrayList;
 import java.util.List;
 import org.junit.jupiter.api.Test;
+import org.openmetadata.schema.type.ChangeEvent;
+import org.openmetadata.schema.utils.ResultList;
 import org.openmetadata.service.jdbi3.ChangeEventRepository.Page;
 import org.openmetadata.service.jdbi3.CollectionDAO.ChangeEventDAO.ChangeEventRecord;
 import org.openmetadata.service.util.RestUtil;
@@ -36,7 +38,7 @@ class ChangeEventRepositoryTest {
   }
 
   private static long decodeOffset(String afterCursor) {
-    return Long.parseLong(RestUtil.decodeCursor(afterCursor));
+    return Long.parseLong(afterCursor);
   }
 
   @Test
@@ -83,6 +85,21 @@ class ChangeEventRepositoryTest {
 
     assertTrue(page.records().isEmpty(), "from past the end yields an empty page");
     assertNull(page.afterCursor(), "no cursor when the window is empty");
+  }
+
+  @Test
+  void cursorSurvivesResultListEncodingRoundTrip() {
+    Page page = ChangeEventRepository.mergePage(records(10, 20, 30, 40), 0, 2);
+
+    ResultList<ChangeEvent> result =
+        new ResultList<>(List.of(), null, page.afterCursor(), page.records().size());
+    String pagingAfter = result.getPaging().getAfter();
+    String decodedByResource = RestUtil.decodeCursor(pagingAfter);
+
+    assertEquals(
+        20L,
+        Long.parseLong(decodedByResource),
+        "paging.after must decode exactly once back to the raw offset the resource parses");
   }
 
   @Test

--- a/openmetadata-service/src/test/java/org/openmetadata/service/jdbi3/ChangeEventRepositoryTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/jdbi3/ChangeEventRepositoryTest.java
@@ -25,7 +25,7 @@ import org.openmetadata.service.jdbi3.ChangeEventRepository.Page;
 import org.openmetadata.service.jdbi3.CollectionDAO.ChangeEventDAO.ChangeEventRecord;
 import org.openmetadata.service.util.RestUtil;
 
-class ChangeEventRepositoryPaginationTest {
+class ChangeEventRepositoryTest {
 
   private static List<ChangeEventRecord> records(long... offsets) {
     List<ChangeEventRecord> records = new ArrayList<>();
@@ -41,7 +41,7 @@ class ChangeEventRepositoryPaginationTest {
 
   @Test
   void mergePageSortsByOffsetAcrossEventTypes() {
-    Page page = ChangeEventRepository.mergePage(records(9, 2, 7, 1, 5), 10);
+    Page page = ChangeEventRepository.mergePage(records(9, 2, 7, 1, 5), 0, 10);
 
     List<Long> offsets = page.records().stream().map(ChangeEventRecord::offset).toList();
     assertEquals(List.of(1L, 2L, 5L, 7L, 9L), offsets, "records must be ordered by offset");
@@ -50,7 +50,7 @@ class ChangeEventRepositoryPaginationTest {
 
   @Test
   void mergePageBoundsResultsToLimitAndEmitsCursor() {
-    Page page = ChangeEventRepository.mergePage(records(10, 20, 30, 40, 50), 3);
+    Page page = ChangeEventRepository.mergePage(records(10, 20, 30, 40, 50), 0, 3);
 
     List<Long> offsets = page.records().stream().map(ChangeEventRecord::offset).toList();
     assertEquals(List.of(10L, 20L, 30L), offsets, "page is capped at the requested limit");
@@ -60,10 +60,29 @@ class ChangeEventRepositoryPaginationTest {
 
   @Test
   void mergePageWithExactlyLimitHasNoCursor() {
-    Page page = ChangeEventRepository.mergePage(records(1, 2, 3), 3);
+    Page page = ChangeEventRepository.mergePage(records(1, 2, 3), 0, 3);
 
     assertEquals(3, page.records().size());
     assertNull(page.afterCursor(), "no cursor when the result set exactly equals the limit");
+  }
+
+  @Test
+  void mergePageWithFromSkipsToPositionalWindow() {
+    Page page = ChangeEventRepository.mergePage(records(1, 2, 3, 4, 5, 6, 7), 2, 3);
+
+    List<Long> offsets = page.records().stream().map(ChangeEventRecord::offset).toList();
+    assertEquals(List.of(3L, 4L, 5L), offsets, "from=2 limit=3 returns the 3rd..5th ordered rows");
+    assertNotNull(page.afterCursor(), "cursor still emitted when rows remain past the window");
+    assertEquals(
+        5L, decodeOffset(page.afterCursor()), "cursor points at the last row in the window");
+  }
+
+  @Test
+  void mergePageWithFromBeyondResultsReturnsEmpty() {
+    Page page = ChangeEventRepository.mergePage(records(1, 2, 3), 10, 5);
+
+    assertTrue(page.records().isEmpty(), "from past the end yields an empty page");
+    assertNull(page.afterCursor(), "no cursor when the window is empty");
   }
 
   @Test
@@ -84,7 +103,7 @@ class ChangeEventRepositoryPaginationTest {
           fetched.add(new ChangeEventRecord(offset, "{}"));
         }
       }
-      Page page = ChangeEventRepository.mergePage(fetched, limit);
+      Page page = ChangeEventRepository.mergePage(fetched, 0, limit);
       page.records().forEach(record -> paged.add(record.offset()));
       cursor = page.afterCursor();
       if (cursor != null) {

--- a/openmetadata-service/src/test/java/org/openmetadata/service/jdbi3/ChangeEventRepositoryTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/jdbi3/ChangeEventRepositoryTest.java
@@ -43,7 +43,7 @@ class ChangeEventRepositoryTest {
 
   @Test
   void mergePageSortsByOffsetAcrossEventTypes() {
-    Page page = ChangeEventRepository.mergePage(records(9, 2, 7, 1, 5), 0, 10);
+    Page page = ChangeEventRepository.mergePage(records(9, 2, 7, 1, 5), 10);
 
     List<Long> offsets = page.records().stream().map(ChangeEventRecord::offset).toList();
     assertEquals(List.of(1L, 2L, 5L, 7L, 9L), offsets, "records must be ordered by offset");
@@ -52,7 +52,7 @@ class ChangeEventRepositoryTest {
 
   @Test
   void mergePageBoundsResultsToLimitAndEmitsCursor() {
-    Page page = ChangeEventRepository.mergePage(records(10, 20, 30, 40, 50), 0, 3);
+    Page page = ChangeEventRepository.mergePage(records(10, 20, 30, 40, 50), 3);
 
     List<Long> offsets = page.records().stream().map(ChangeEventRecord::offset).toList();
     assertEquals(List.of(10L, 20L, 30L), offsets, "page is capped at the requested limit");
@@ -62,34 +62,36 @@ class ChangeEventRepositoryTest {
 
   @Test
   void mergePageWithExactlyLimitHasNoCursor() {
-    Page page = ChangeEventRepository.mergePage(records(1, 2, 3), 0, 3);
+    Page page = ChangeEventRepository.mergePage(records(1, 2, 3), 3);
 
     assertEquals(3, page.records().size());
     assertNull(page.afterCursor(), "no cursor when the result set exactly equals the limit");
   }
 
   @Test
-  void mergePageWithFromSkipsToPositionalWindow() {
-    Page page = ChangeEventRepository.mergePage(records(1, 2, 3, 4, 5, 6, 7), 2, 3);
+  void boundaryOffsetResolvesPositionalSkipToKeysetOffset() {
+    List<Long> offsets = new ArrayList<>(List.of(50L, 10L, 40L, 20L, 30L));
 
-    List<Long> offsets = page.records().stream().map(ChangeEventRecord::offset).toList();
-    assertEquals(List.of(3L, 4L, 5L), offsets, "from=2 limit=3 returns the 3rd..5th ordered rows");
-    assertNotNull(page.afterCursor(), "cursor still emitted when rows remain past the window");
+    Long boundary = ChangeEventRepository.boundaryOffset(offsets, 2);
+
     assertEquals(
-        5L, decodeOffset(page.afterCursor()), "cursor points at the last row in the window");
+        20L,
+        boundary,
+        "from=2 resolves to the 2nd smallest offset; window is fetched with offset > 20");
   }
 
   @Test
-  void mergePageWithFromBeyondResultsReturnsEmpty() {
-    Page page = ChangeEventRepository.mergePage(records(1, 2, 3), 10, 5);
+  void boundaryOffsetBeyondResultsReturnsNull() {
+    List<Long> offsets = new ArrayList<>(List.of(10L, 20L, 30L));
 
-    assertTrue(page.records().isEmpty(), "from past the end yields an empty page");
-    assertNull(page.afterCursor(), "no cursor when the window is empty");
+    assertNull(
+        ChangeEventRepository.boundaryOffset(offsets, 10),
+        "from past the end has no boundary offset, so the window is empty");
   }
 
   @Test
   void cursorSurvivesResultListEncodingRoundTrip() {
-    Page page = ChangeEventRepository.mergePage(records(10, 20, 30, 40), 0, 2);
+    Page page = ChangeEventRepository.mergePage(records(10, 20, 30, 40), 2);
 
     ResultList<ChangeEvent> result =
         new ResultList<>(List.of(), null, page.afterCursor(), page.records().size());
@@ -120,7 +122,7 @@ class ChangeEventRepositoryTest {
           fetched.add(new ChangeEventRecord(offset, "{}"));
         }
       }
-      Page page = ChangeEventRepository.mergePage(fetched, 0, limit);
+      Page page = ChangeEventRepository.mergePage(fetched, limit);
       page.records().forEach(record -> paged.add(record.offset()));
       cursor = page.afterCursor();
       if (cursor != null) {


### PR DESCRIPTION
## What & why

Closes #29818.

`GET /api/v1/events` took only a start `timestamp` and returned **every** matching event in one response — no limit, no paging. On the NBN instance a single call matched **270,603** events, ran ~57s, and failed with `500 / Java heap space`. One old-timestamp query could take down the whole instance.

This adds cursor pagination so clients can backfill and poll the event stream in bounded pages.

## Parameters

| Param | Required | Description |
|-------|----------|-------------|
| `timestamp` | ✅ | Start of the time range (unix ms). |
| `endTs` | — | End of the time range (unix ms). Omit for no end limit. |
| `entityCreated` / `entityUpdated` / `entityRestored` / `entityDeleted` | — | Comma-separated entity types to include per event type (`*` = all). |
| `limit` | — | Page size, 1–1000 (default 100). |
| `after` | — | Cursor from the previous response's `paging.after`. Pass it back for the next page; keep going until it's empty. |

## How it stays bounded

- `LIMIT` is pushed into SQL, so at most `5 × (limit+1)` rows are ever held in memory — regardless of table size.
- Each query is a **deferred join** (sort/limit on the `offset` key, fetch `json` by PK) so the large `json` column never enters MySQL's filesort (avoids `ER_OUT_OF_SORTMEMORY` on big tables).
- `paging.total` reports the page size, matching how the internal event-subscription consumer already paginates this same table. Clients page until `paging.after` is null.

## Notes

- **Behavior change:** callers that used to get everything now get 100 by default and page via `paging.after`. No internal UI/ingestion caller relied on the old behavior.
- **No DB migration:** the `offset` column and indexes already exist.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Tests

`ChangeEventRepositoryTest` covers offset-ordered merge, limit bounding, cursor emission, the exact-limit boundary, multi-page continuation (no gaps/duplicates), and the `ResultList` cursor encoding round-trip. Build green; `mvn spotless:apply` run.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds bounded pagination to the change-events endpoint. The main changes are:

- New `limit`, `after`, and optional `endTs` query parameters for `GET /v1/events`.
- Offset-based repository pagination with a merged page cursor.
- Deferred-join SQL queries for MySQL and PostgreSQL.
- Unit tests for cursor encoding, page limits, and multi-page continuation.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge.

- No blocking issues found in the changed code.

</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/ChangeEventRepository.java | Builds bounded event pages by fetching per event type, sorting by offset, and returning a cursor-backed ResultList. |
| openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/CollectionDAO.java | Adds dialect-specific deferred-join queries that fetch offset-limited change-event rows with timestamp bounds. |
| openmetadata-service/src/main/java/org/openmetadata/service/resources/events/EventResource.java | Adds pagination parameters to the events endpoint and decodes the cursor before calling the repository. |
| openmetadata-service/src/test/java/org/openmetadata/service/jdbi3/ChangeEventRepositoryTest.java | Covers offset sorting, page limiting, cursor encoding, exact-limit behavior, and multi-page continuation. |

</details>

<sub>Reviews (9): Last reviewed commit: ["Merge branch &#39;main&#39; into fix-29818-event..."](https://github.com/open-metadata/openmetadata/commit/bd959e26da82a2be9d3901d32ed92bd8b66f8a6f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43701952)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Context used - CLAUDE.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=52f0d9d9-cad1-4e7d-b070-de181a0aa5e7))
- Context used - openmetadata-ui-core-components/CLAUDE.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=41754627-b2bf-474b-8082-f37ef1a07013))
- Context used - AGENTS.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=ef262f5f-911f-44f3-8d2d-e9cb1579c8c8))
</details>

<!-- /greptile_comment -->