### PR TITLE
Fixes #20753: replace non-schema jobStackTrace with IndexingError.stackTrace

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/apps/bundles/dataContracts/DataContractValidationApp.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/apps/bundles/dataContracts/DataContractValidationApp.java
@@ -3,9 +3,8 @@ package org.openmetadata.service.apps.bundles.dataContracts;
 import static org.openmetadata.common.utils.CommonUtil.nullOrEmpty;
 import static org.openmetadata.service.apps.scheduler.OmAppJobListener.APP_RUN_STATS;
 
-import java.util.HashMap;
+import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.openmetadata.schema.EntityInterface;
@@ -14,6 +13,8 @@ import org.openmetadata.schema.entity.app.FailureContext;
 import org.openmetadata.schema.entity.data.DataContract;
 import org.openmetadata.schema.entity.datacontract.DataContractResult;
 import org.openmetadata.schema.entity.domains.DataProduct;
+import org.openmetadata.schema.system.EntityError;
+import org.openmetadata.schema.system.IndexingError;
 import org.openmetadata.schema.system.Stats;
 import org.openmetadata.schema.system.StepStats;
 import org.openmetadata.schema.type.EntityReference;
@@ -36,7 +37,8 @@ public class DataContractValidationApp extends AbstractNativeApplication {
 
   private final Stats stats = new Stats();
   private JobExecutionContext jobExecutionContext;
-  private final Map<String, Object> failureDetails = new HashMap<>();
+  private final IndexingError failureDetails =
+      new IndexingError().withFailedEntities(new ArrayList<>());
 
   public DataContractValidationApp(CollectionDAO collectionDAO, SearchRepository searchRepository) {
     super(collectionDAO, searchRepository);
@@ -76,8 +78,10 @@ public class DataContractValidationApp extends AbstractNativeApplication {
       updateStatsRecord(AppRunRecord.Status.COMPLETED);
     } catch (Exception e) {
       LOG.error("Error running DataContractValidationApp", e);
-      failureDetails.put("message", e.getMessage());
-      failureDetails.put("stackTrace", ExceptionUtils.getStackTrace(e));
+      failureDetails
+          .withErrorSource(IndexingError.ErrorSource.JOB)
+          .withMessage(e.getMessage())
+          .withStackTrace(ExceptionUtils.getStackTrace(e));
       updateStatsRecord(AppRunRecord.Status.FAILED);
     }
   }
@@ -120,7 +124,7 @@ public class DataContractValidationApp extends AbstractNativeApplication {
                   "Failed to validate data contract %s: %s",
                   dataContract.getFullyQualifiedName(), e.getMessage());
           LOG.error(msg, e);
-          failureDetails.put(dataContract.getFullyQualifiedName(), msg);
+          recordEntityFailure(dataContract.getFullyQualifiedName(), msg);
           totalErrors++;
         }
       }
@@ -230,7 +234,7 @@ public class DataContractValidationApp extends AbstractNativeApplication {
                         "Failed to process asset %s from Data Product %s: %s",
                         assetRef.getName(), dataProduct.getName(), e.getMessage());
                 LOG.error(msg, e);
-                failureDetails.put(assetRef.getFullyQualifiedName(), msg);
+                recordEntityFailure(assetRef.getFullyQualifiedName(), msg);
                 totalErrors++;
               }
             }
@@ -244,13 +248,13 @@ public class DataContractValidationApp extends AbstractNativeApplication {
               String.format(
                   "Failed to process Data Product %s: %s", dataProduct.getName(), e.getMessage());
           LOG.error(msg, e);
-          failureDetails.put(dataProduct.getFullyQualifiedName(), msg);
+          recordEntityFailure(dataProduct.getFullyQualifiedName(), msg);
           totalErrors++;
         }
       }
     } catch (Exception e) {
       LOG.error("Error processing Data Products: {}", e.getMessage(), e);
-      failureDetails.put("dataProductProcessing", e.getMessage());
+      recordEntityFailure("dataProductProcessing", e.getMessage());
     }
 
     return new int[] {totalProcessed, totalErrors};
@@ -265,13 +269,22 @@ public class DataContractValidationApp extends AbstractNativeApplication {
     stats.setJobStats(jobStats);
   }
 
+  private void recordEntityFailure(String entity, String message) {
+    failureDetails
+        .getFailedEntities()
+        .add(new EntityError().withEntity(entity).withMessage(message));
+  }
+
+  private boolean hasFailures() {
+    return failureDetails.getMessage() != null || !nullOrEmpty(failureDetails.getFailedEntities());
+  }
+
   private void updateStatsRecord(AppRunRecord.Status status) {
     AppRunRecord appRecord = getJobRecord(jobExecutionContext);
     appRecord.setStatus(status);
 
-    if (!nullOrEmpty(failureDetails)) {
-      appRecord.setFailureContext(
-          new FailureContext().withAdditionalProperty("failure", failureDetails));
+    if (hasFailures()) {
+      appRecord.setFailureContext(new FailureContext().withFailure(failureDetails));
       appRecord.setStatus(AppRunRecord.Status.FAILED);
     }
 

--- a/openmetadata-service/src/main/java/org/openmetadata/service/apps/bundles/dataContracts/DataContractValidationApp.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/apps/bundles/dataContracts/DataContractValidationApp.java
@@ -77,7 +77,7 @@ public class DataContractValidationApp extends AbstractNativeApplication {
     } catch (Exception e) {
       LOG.error("Error running DataContractValidationApp", e);
       failureDetails.put("message", e.getMessage());
-      failureDetails.put("jobStackTrace", ExceptionUtils.getStackTrace(e));
+      failureDetails.put("stackTrace", ExceptionUtils.getStackTrace(e));
       updateStatsRecord(AppRunRecord.Status.FAILED);
     }
   }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/apps/bundles/dataRetention/DataRetention.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/apps/bundles/dataRetention/DataRetention.java
@@ -4,7 +4,6 @@ import static org.openmetadata.service.apps.scheduler.OmAppJobListener.APP_RUN_S
 
 import java.time.Duration;
 import java.time.Instant;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -18,6 +17,7 @@ import org.openmetadata.schema.entity.app.AppRunRecord;
 import org.openmetadata.schema.entity.app.FailureContext;
 import org.openmetadata.schema.entity.applications.configuration.internal.DataRetentionConfiguration;
 import org.openmetadata.schema.system.EntityStats;
+import org.openmetadata.schema.system.IndexingError;
 import org.openmetadata.schema.system.Stats;
 import org.openmetadata.schema.system.StepStats;
 import org.openmetadata.schema.utils.JsonUtils;
@@ -44,7 +44,7 @@ public class DataRetention extends AbstractNativeApplication {
   private JobExecutionContext jobExecutionContext;
 
   private AppRunRecord.Status internalStatus = AppRunRecord.Status.COMPLETED;
-  private Map<String, Object> failureDetails = null;
+  private IndexingError failureDetails = null;
 
   private final FeedRepository feedRepository;
   private final CollectionDAO.FeedDAO feedDAO;
@@ -93,9 +93,7 @@ public class DataRetention extends AbstractNativeApplication {
       LOG.error("DataRetention job failed.", ex);
       internalStatus = AppRunRecord.Status.FAILED;
 
-      failureDetails = new HashMap<>();
-      failureDetails.put("message", ex.getMessage());
-      failureDetails.put("jobStackTrace", ExceptionUtils.getStackTrace(ex));
+      failureDetails = toIndexingError(ex);
 
       updateRecordToDbAndNotify(ex);
     }
@@ -272,11 +270,7 @@ public class DataRetention extends AbstractNativeApplication {
       LOG.error("Failed to clean orphaned relationships and hierarchies", ex);
       internalStatus = AppRunRecord.Status.ACTIVE_ERROR;
 
-      if (failureDetails == null) {
-        failureDetails = new HashMap<>();
-        failureDetails.put("message", ex.getMessage());
-        failureDetails.put("jobStackTrace", ExceptionUtils.getStackTrace(ex));
-      }
+      recordFirstFailure(ex);
     }
   }
 
@@ -295,11 +289,7 @@ public class DataRetention extends AbstractNativeApplication {
       LOG.error("Failed to clean orphaned tag usages", ex);
       internalStatus = AppRunRecord.Status.ACTIVE_ERROR;
 
-      if (failureDetails == null) {
-        failureDetails = new HashMap<>();
-        failureDetails.put("message", ex.getMessage());
-        failureDetails.put("jobStackTrace", ExceptionUtils.getStackTrace(ex));
-      }
+      recordFirstFailure(ex);
     }
   }
 
@@ -317,11 +307,7 @@ public class DataRetention extends AbstractNativeApplication {
     } catch (Exception ex) {
       LOG.error("Failed to clean orphan test cases", ex);
       internalStatus = AppRunRecord.Status.ACTIVE_ERROR;
-      if (failureDetails == null) {
-        failureDetails = new HashMap<>();
-        failureDetails.put("message", ex.getMessage());
-        failureDetails.put("jobStackTrace", ExceptionUtils.getStackTrace(ex));
-      }
+      recordFirstFailure(ex);
     }
   }
 
@@ -349,11 +335,7 @@ public class DataRetention extends AbstractNativeApplication {
     } catch (Exception ex) {
       LOG.error("Failed to clean test cases with missing relationships", ex);
       internalStatus = AppRunRecord.Status.ACTIVE_ERROR;
-      if (failureDetails == null) {
-        failureDetails = new HashMap<>();
-        failureDetails.put("message", ex.getMessage());
-        failureDetails.put("jobStackTrace", ExceptionUtils.getStackTrace(ex));
-      }
+      recordFirstFailure(ex);
     }
   }
 
@@ -442,11 +424,7 @@ public class DataRetention extends AbstractNativeApplication {
         totalFailed += BATCH_SIZE;
         internalStatus = AppRunRecord.Status.ACTIVE_ERROR;
 
-        if (failureDetails == null) {
-          failureDetails = new HashMap<>();
-          failureDetails.put("message", ex.getMessage());
-          failureDetails.put("jobStackTrace", ExceptionUtils.getStackTrace(ex));
-        }
+        recordFirstFailure(ex);
         stoppedByCondition = true;
         break;
       }
@@ -477,11 +455,7 @@ public class DataRetention extends AbstractNativeApplication {
         totalFailed += BATCH_SIZE;
         internalStatus = AppRunRecord.Status.ACTIVE_ERROR;
 
-        if (failureDetails == null) {
-          failureDetails = new HashMap<>();
-          failureDetails.put("message", ex.getMessage());
-          failureDetails.put("jobStackTrace", ExceptionUtils.getStackTrace(ex));
-        }
+        recordFirstFailure(ex);
         break;
       }
     }
@@ -514,13 +488,25 @@ public class DataRetention extends AbstractNativeApplication {
     jobStats.setFailedRecords(jobStats.getFailedRecords() + failureCount);
   }
 
+  private void recordFirstFailure(Exception ex) {
+    if (failureDetails == null) {
+      failureDetails = toIndexingError(ex);
+    }
+  }
+
+  private static IndexingError toIndexingError(Exception ex) {
+    return new IndexingError()
+        .withErrorSource(IndexingError.ErrorSource.JOB)
+        .withMessage(ex.getMessage())
+        .withStackTrace(ExceptionUtils.getStackTrace(ex));
+  }
+
   private void updateRecordToDbAndNotify(Exception error) {
     AppRunRecord appRecord = getJobRecord(jobExecutionContext);
     appRecord.setStatus(internalStatus);
 
     if (failureDetails != null) {
-      appRecord.setFailureContext(
-          new FailureContext().withAdditionalProperty("failure", failureDetails));
+      appRecord.setFailureContext(new FailureContext().withFailure(failureDetails));
     }
 
     if (WebSocketManager.getInstance() != null) {

--- a/openmetadata-service/src/main/java/org/openmetadata/service/apps/scheduler/OmAppJobListener.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/apps/scheduler/OmAppJobListener.java
@@ -4,8 +4,6 @@ import static org.openmetadata.common.utils.CommonUtil.nullOrEmpty;
 import static org.openmetadata.service.apps.scheduler.AppScheduler.APP_CONFIG_KEY;
 import static org.openmetadata.service.apps.scheduler.AppScheduler.APP_NAME;
 
-import java.util.HashMap;
-import java.util.Map;
 import java.util.UUID;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.exception.ExceptionUtils;
@@ -15,6 +13,7 @@ import org.openmetadata.schema.entity.app.AppRunRecord;
 import org.openmetadata.schema.entity.app.FailureContext;
 import org.openmetadata.schema.entity.app.SuccessContext;
 import org.openmetadata.schema.entity.applications.configuration.ApplicationConfig;
+import org.openmetadata.schema.system.IndexingError;
 import org.openmetadata.schema.system.Stats;
 import org.openmetadata.schema.type.EntityReference;
 import org.openmetadata.schema.type.Include;
@@ -225,10 +224,11 @@ public class OmAppJobListener implements JobListener {
           context = runRecord.getFailureContext();
         }
         if (jobException != null) {
-          Map<String, Object> failure = new HashMap<>();
-          failure.put("message", jobException.getMessage());
-          failure.put("jobStackTrace", ExceptionUtils.getStackTrace(jobException));
-          context.withAdditionalProperty("failure", failure);
+          context.withFailure(
+              new IndexingError()
+                  .withErrorSource(IndexingError.ErrorSource.JOB)
+                  .withMessage(jobException.getMessage())
+                  .withStackTrace(ExceptionUtils.getStackTrace(jobException)));
         }
 
         runRecord.setFailureContext(context);

--- a/openmetadata-service/src/test/java/org/openmetadata/service/apps/scheduler/OmAppJobListenerTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/apps/scheduler/OmAppJobListenerTest.java
@@ -25,6 +25,7 @@ import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
 import org.openmetadata.schema.entity.app.App;
 import org.openmetadata.schema.entity.app.AppRunRecord;
+import org.openmetadata.schema.system.IndexingError;
 import org.openmetadata.schema.system.Stats;
 import org.openmetadata.schema.type.Include;
 import org.openmetadata.schema.utils.JsonUtils;
@@ -287,6 +288,13 @@ class OmAppJobListenerTest {
         JsonUtils.readOrConvertValue(dataMap.get("AppScheduleRun"), AppRunRecord.class);
     assert updatedRecord.getStatus() == AppRunRecord.Status.FAILED;
     assert updatedRecord.getFailureContext() != null;
+
+    IndexingError failure = updatedRecord.getFailureContext().getFailure();
+    assert failure != null;
+    assert IndexingError.ErrorSource.JOB.equals(failure.getErrorSource());
+    assert "Something went wrong".equals(failure.getMessage());
+    assert failure.getStackTrace() != null
+        && failure.getStackTrace().contains("Something went wrong");
   }
 
   @Test


### PR DESCRIPTION
### Describe your changes:

Fixes #20753

I replaced the ad-hoc, non-schema `jobStackTrace` map key in the app failure paths with the schema-defined `IndexingError.stackTrace` field, because `failureContext.failure` is already typed as `IndexingError` and the informal key only landed in `additionalProperties`. `OmAppJobListener` and `DataRetention` now build a typed `IndexingError` (the canonical pattern used across the other apps), and `DataRetention`'s six duplicated failure blocks are collapsed into one helper. `DataContractValidationApp` keeps its genuinely-mixed error map but renames its top-level key to the schema field. No migration is required: `additionalProperties: true` keeps historical records valid, nothing reads the key, and the UI already renders `failureContext.failure` generically.

#
### Type of change:
- [x] Improvement

#
### High-level design:
N/A — small change.

#
### Tests:

#### Unit tests
- [x] Extended `OmAppJobListenerTest#jobWasExecuted_setsFailedStatusOnException` to assert the failure deserializes to a typed `IndexingError` with a populated schema `stackTrace` (fails if the old ad-hoc shape returns).

#### Backend integration tests
- [x] Not applicable (no API endpoint changes).

#### Ingestion integration tests
- [x] Not applicable (no ingestion changes).

#### Playwright (UI) tests
- [x] Not applicable (no UI changes — the UI reads `failureContext.failure` generically).

#### Manual testing performed
Built `openmetadata-service` (BUILD SUCCESS), ran the extended unit test (green), and verified `mvn spotless:check` passes.

#
### UI screen recording / screenshots:

Not applicable.

#
### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] My PR title is `Fixes <issue-number>: <short explanation>`
- [x] My PR is linked to a GitHub issue via `Fixes #20753` above.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [x] For JSON Schema changes: no schema change; explained above why no migration is needed.
- [x] For UI changes: not applicable.
- [x] I have added tests (unit) and listed them above.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR moves app failure details onto the typed `IndexingError` schema field. The main changes are:

- Replace ad-hoc `jobStackTrace` maps with `IndexingError.stackTrace`.
- Store DataRetention and job-listener failures through `FailureContext.failure`.
- Convert DataContractValidationApp entity failures into `failedEntities`.
- Extend the job-listener test for the typed failure payload.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

This is close, but the DataRetention failure path should be fixed before merging.

- A cleanup failure can still be replaced by the synthetic partial-failure exception.
- The final persisted run can hide the original cleanup error and stack trace.
- The other changed paths are schema-shape updates and test coverage for typed failure payloads.

openmetadata-service/src/main/java/org/openmetadata/service/apps/bundles/dataRetention/DataRetention.java
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-service/src/main/java/org/openmetadata/service/apps/bundles/dataRetention/DataRetention.java | Refactors failure capture to typed `IndexingError`, but the outer catch can still replace the saved cleanup failure. |
| openmetadata-service/src/main/java/org/openmetadata/service/apps/bundles/dataContracts/DataContractValidationApp.java | Changes failure details from a mixed map to a typed `IndexingError` with entity-level failures. |
| openmetadata-service/src/main/java/org/openmetadata/service/apps/scheduler/OmAppJobListener.java | Writes job exceptions as typed `IndexingError` values in the failure context. |
| openmetadata-service/src/test/java/org/openmetadata/service/apps/scheduler/OmAppJobListenerTest.java | Adds assertions for the typed failure payload and stack trace. |

</details>

<sub>Reviews (2): Last reviewed commit: ["Convert DataContractValidationApp failur..."](https://github.com/open-metadata/openmetadata/commit/a2932cf2061f1b168bf7d571b8224902f1df5f5d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43745352)</sub>

> Greptile also left **1 inline comment** on this PR.

<details><summary><h4>Context used (3)</h4></summary>

- Context used - CLAUDE.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=52f0d9d9-cad1-4e7d-b070-de181a0aa5e7))
- Context used - openmetadata-ui-core-components/CLAUDE.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=41754627-b2bf-474b-8082-f37ef1a07013))
- Context used - AGENTS.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=ef262f5f-911f-44f3-8d2d-e9cb1579c8c8))
</details>

<!-- /greptile_comment -->