### PR TITLE
fix(search): drop pipeline-level collapse from hybrid-rrf search pipeline

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/vector/OpenSearchVectorService.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/vector/OpenSearchVectorService.java
@@ -97,11 +97,6 @@ public class OpenSearchVectorService implements VectorIndexService {
                 "score-ranker-processor",
                 MAPPER.createObjectNode().set("combination", combination));
 
-    // Only RRF fusion here — no collapse response processor. Chunk dedup by parentId is applied by
-    // the caller: OSS vector search groups hits in Java (see #search), and Collate's NLQ hybrid
-    // search emits a query-level collapse{parentId} in the request body. A pipeline-level collapse
-    // on the same field double-collapses that request and OpenSearch rejects it with
-    // "Cannot collapse on parentId. Results already collapsed on parentId" (HTTP 500).
     var pipeline = MAPPER.createObjectNode();
     pipeline.set("phase_results_processors", MAPPER.createArrayNode().add(scoreRanker));
 

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/vector/OpenSearchVectorService.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/vector/OpenSearchVectorService.java
@@ -96,14 +96,14 @@ public class OpenSearchVectorService implements VectorIndexService {
             .set(
                 "score-ranker-processor",
                 MAPPER.createObjectNode().set("combination", combination));
-    var collapse =
-        MAPPER
-            .createObjectNode()
-            .set("collapse", MAPPER.createObjectNode().put("field", "parentId"));
 
+    // Only RRF fusion here — no collapse response processor. Chunk dedup by parentId is applied by
+    // the caller: OSS vector search groups hits in Java (see #search), and Collate's NLQ hybrid
+    // search emits a query-level collapse{parentId} in the request body. A pipeline-level collapse
+    // on the same field double-collapses that request and OpenSearch rejects it with
+    // "Cannot collapse on parentId. Results already collapsed on parentId" (HTTP 500).
     var pipeline = MAPPER.createObjectNode();
     pipeline.set("phase_results_processors", MAPPER.createArrayNode().add(scoreRanker));
-    pipeline.set("response_processors", MAPPER.createArrayNode().add(collapse));
 
     executeGenericRequest("PUT", "/_search/pipeline/" + HYBRID_PIPELINE_NAME, pipeline.toString());
     LOG.info(

--- a/openmetadata-service/src/test/java/org/openmetadata/service/search/vector/OpenSearchVectorServiceTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/search/vector/OpenSearchVectorServiceTest.java
@@ -1,6 +1,7 @@
 package org.openmetadata.service.search.vector;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -453,8 +454,16 @@ class OpenSearchVectorServiceTest {
     assertTrue(body.contains("\"weights\":[0.4,0.6]"));
     assertTrue(body.contains("\"technique\":\"rrf\""));
     assertTrue(body.contains("\"rank_constant\":30"));
-    assertTrue(body.contains("\"collapse\""));
-    assertTrue(body.contains("\"parentId\""));
+    assertTrue(body.contains("\"score-ranker-processor\""));
+    assertTrue(body.contains("\"phase_results_processors\""));
+    // The hybrid-rrf pipeline must NOT carry a collapse response processor. Collate's NLQ hybrid
+    // search applies a query-level collapse{parentId} in the request body; a pipeline-level
+    // collapse
+    // on the same field makes OpenSearch reject the request with
+    // "Cannot collapse on parentId. Results already collapsed on parentId" (HTTP 500).
+    assertFalse(body.contains("\"response_processors\""));
+    assertFalse(body.contains("\"collapse\""));
+    assertFalse(body.contains("\"parentId\""));
   }
 
   @Test


### PR DESCRIPTION
### Describe your changes:

Fixes #29967

I removed the pipeline-level `collapse{parentId}` response processor from the `hybrid-rrf` OpenSearch search pipeline because Collate's NLQ hybrid search already emits a query-level `collapse{parentId}` in the request body, so the pipeline-level collapse double-collapses the same field and OpenSearch rejects the request with `Cannot collapse on parentId. Results already collapsed on parentId` (HTTP 500). OSS vector search groups chunks by `parentId` in Java (see `#search`), so it never relied on the pipeline collapse either. Chunk dedup now lives entirely with the caller.

#
### Type of change:
- [x] Bug fix

#
### High-level design:

N/A — small change. The pipeline now carries only the RRF `phase_results_processors`; the `response_processors` (collapse) entry is dropped.

#
### Tests:

#### Use cases covered
- Collate NLQ hybrid search issues a query with `collapse{parentId}` and no longer errors with HTTP 500 "Results already collapsed on parentId".
- OSS vector search continues to dedup chunks by `parentId` in Java, unaffected by the pipeline change.

#### Unit tests
- [x] Updated `OpenSearchVectorServiceTest` — asserts the `hybrid-rrf` pipeline body contains the RRF `score-ranker-processor` / `phase_results_processors` and does NOT contain `response_processors` / `collapse` / `parentId`.
- Files updated: `openmetadata-service/src/test/java/org/openmetadata/service/search/vector/OpenSearchVectorServiceTest.java`

#### Backend integration tests
- [x] Not applicable (no API endpoint changes; pipeline definition change only).

#### Ingestion integration tests
- [x] Not applicable (no ingestion changes).

#### Playwright (UI) tests
- [x] Not applicable (no UI changes).

#### Manual testing performed
- Ran `mvn spotless:apply -pl openmetadata-service` (no formatting changes needed).

#
### UI screen recording / screenshots:

Not applicable.

#
### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] For JSON Schema changes: I updated the migration scripts or explained why it is not needed. (No schema changes.)
- [x] For UI changes: I attached a screen recording and/or screenshots above. (No UI changes.)
- [x] I have added tests (unit / integration / Playwright as applicable) and listed them above.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR removes pipeline-level collapse from the OpenSearch hybrid RRF pipeline. The main changes are:

- Drops the `response_processors` collapse on `parentId` from the pipeline body.
- Keeps the RRF `phase_results_processors` configuration.
- Updates the vector service test to assert collapse is no longer emitted.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge.

- No blocking issues found in the changed code.

</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-service/src/main/java/org/openmetadata/service/search/vector/OpenSearchVectorService.java | Removes the `parentId` collapse response processor from the hybrid RRF pipeline definition. |
| openmetadata-service/src/test/java/org/openmetadata/service/search/vector/OpenSearchVectorServiceTest.java | Updates the pipeline assertions to check that only the RRF phase results processor is sent. |

</details>

<sub>Reviews (2): Last reviewed commit: ["Clean up comments in OpenSearchVectorSer..."](https://github.com/open-metadata/openmetadata/commit/328b4d8a4ef5dfb3376cd09413a054b3ba8c1c0a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43751069)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Context used - CLAUDE.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=52f0d9d9-cad1-4e7d-b070-de181a0aa5e7))
- Context used - openmetadata-ui-core-components/CLAUDE.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=41754627-b2bf-474b-8082-f37ef1a07013))
- Context used - AGENTS.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=ef262f5f-911f-44f3-8d2d-e9cb1579c8c8))
</details>

<!-- /greptile_comment -->