### PR TITLE
fix(ui): update explore deleted filter label

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/ExploreV1/ExploreV1.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/ExploreV1/ExploreV1.component.tsx
@@ -781,7 +781,7 @@ const ExploreV1: React.FC<ExploreProps> = ({
                     id="show-deleted"
                     onPress={() => onChangeShowDeleted(!showDeleted)}>
                     <Box justify="between">
-                      {t('label.deleted')}
+                      {t('label.show-deleted')}
                       <Toggle isSelected={showDeleted} />
                     </Box>
                   </Dropdown.Item>


### PR DESCRIPTION
## Summary
- Updated the Explore tools dropdown deleted filter label to use the existing Show Deleted translation key.

## Testing
- ./node_modules/.bin/organize-imports-cli src/components/ExploreV1/ExploreV1.component.tsx
- ./node_modules/.bin/eslint --no-error-on-unmatched-pattern --fix src/components/ExploreV1/ExploreV1.component.tsx
- ./node_modules/.bin/prettier --config ./.prettierrc.yaml --ignore-path ./.prettierignore --write src/components/ExploreV1/ExploreV1.component.tsx
- git diff --check
- ./node_modules/.bin/jest src/components/ExploreV1/ExploreV1.test.tsx --runInBand

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR updates the deleted filter wording in the Explore tools menu.

- Switches the dropdown label from `label.deleted` to `label.show-deleted`.
- Keeps the existing show-deleted toggle behavior unchanged.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge.

- No blocking issues found in the changed code.

</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-ui/src/main/resources/ui/src/components/ExploreV1/ExploreV1.component.tsx | Updates the Explore tools deleted-filter label to use the existing show-deleted translation key. |

</details>

<sub>Reviews (2): Last reviewed commit: ["Merge branch &#39;main&#39; into ui/show-deleted..."](https://github.com/open-metadata/openmetadata/commit/8cae8ee96cda3c6dad9331716f557d394da7e899) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43791565)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Context used - CLAUDE.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=52f0d9d9-cad1-4e7d-b070-de181a0aa5e7))
- Context used - openmetadata-ui-core-components/CLAUDE.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=41754627-b2bf-474b-8082-f37ef1a07013))
- Context used - AGENTS.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=ef262f5f-911f-44f3-8d2d-e9cb1579c8c8))
</details>

<!-- /greptile_comment -->