### PR TITLE
fix(data-retention): read relationType from json in getAllRelationshipsAfter

### DIFF
--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/EntityRelationshipCleanupIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/EntityRelationshipCleanupIT.java
@@ -15,6 +15,7 @@ package org.openmetadata.it.tests;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 import org.junit.jupiter.api.Test;
@@ -37,8 +38,6 @@ import org.openmetadata.schema.type.ColumnDataType;
 import org.openmetadata.schema.type.Relationship;
 import org.openmetadata.sdk.client.OpenMetadataClient;
 import org.openmetadata.service.Entity;
-import org.openmetadata.service.jdbi3.CollectionDAO;
-import org.openmetadata.service.jdbi3.CollectionDAO.EntityRelationshipObject;
 import org.openmetadata.service.util.EntityRelationshipCleanup;
 
 /**
@@ -62,9 +61,9 @@ public class EntityRelationshipCleanupIT {
     int validIncomingBefore = incomingRelationshipCount(table.getId());
     assertTrue(validIncomingBefore >= 1, "healthy table must have real incoming relationships");
 
-    String marker = "ITORPHAN_" + ns.uniqueShortId();
-    seedOrphans(marker, SEEDED_ORPHANS);
-    assertEquals(SEEDED_ORPHANS, orphanCount(marker), "seeded orphans must be present before run");
+    List<String> orphanIds = seedOrphans(SEEDED_ORPHANS);
+    assertEquals(
+        SEEDED_ORPHANS, orphanCount(orphanIds), "seeded orphans must be present before run");
 
     // Small batch forces multiple keyset pages with deletes happening between pages.
     EntityRelationshipCleanup.EntityCleanupResult result =
@@ -75,7 +74,7 @@ public class EntityRelationshipCleanupIT {
         "cleanup must find at least the seeded orphans");
     assertEquals(
         0,
-        orphanCount(marker),
+        orphanCount(orphanIds),
         "every seeded orphan must be deleted - keyset paging must not skip rows across deletes");
     assertEquals(
         validIncomingBefore,
@@ -85,10 +84,8 @@ public class EntityRelationshipCleanupIT {
 
   @Test
   void dryRun_reportsOrphansButDeletesNothing(TestNamespace ns) {
-    String marker = "ITDRYRUN_" + ns.uniqueShortId();
+    List<String> orphanIds = seedOrphans(SEEDED_ORPHANS);
     try {
-      seedOrphans(marker, SEEDED_ORPHANS);
-
       EntityRelationshipCleanup.EntityCleanupResult result =
           new EntityRelationshipCleanup(Entity.getCollectionDAO(), true).performCleanup(25);
 
@@ -96,43 +93,10 @@ public class EntityRelationshipCleanupIT {
           result.getOrphanedRelationshipsFound() >= SEEDED_ORPHANS,
           "dry run must still detect the seeded orphans");
       assertEquals(0, result.getRelationshipsDeleted(), "dry run must not delete anything");
-      assertEquals(SEEDED_ORPHANS, orphanCount(marker), "dry run must leave seeded orphans intact");
+      assertEquals(
+          SEEDED_ORPHANS, orphanCount(orphanIds), "dry run must leave seeded orphans intact");
     } finally {
-      deleteOrphans(marker);
-    }
-  }
-
-  /**
-   * Regression test for the keyset cursor. Two rows share the same (fromId, toId, relation) tuple
-   * and differ only in relationType - exactly how glossary-term RELATED_TO rows carry 'synonym' and
-   * 'seeAlso'. With a batch boundary (limit=1) falling between them, a cursor keyed only on
-   * (fromId, toId, relation) would advance past the tuple and permanently skip the second row. The
-   * full-primary-key cursor must return both.
-   */
-  @Test
-  void keysetPaging_doesNotSkipRowsSharingTupleButDifferentRelationType(TestNamespace ns) {
-    String fromId = UUID.randomUUID().toString();
-    String toId = UUID.randomUUID().toString();
-    int relation = Relationship.RELATED_TO.ordinal();
-    try {
-      insertOrphan(fromId, toId, Entity.GLOSSARY_TERM, Entity.GLOSSARY_TERM, relation, "seeAlso");
-      insertOrphan(fromId, toId, Entity.GLOSSARY_TERM, Entity.GLOSSARY_TERM, relation, "synonym");
-
-      CollectionDAO.EntityRelationshipDAO dao = Entity.getCollectionDAO().relationshipDAO();
-
-      List<EntityRelationshipObject> page1 =
-          dao.getAllRelationshipsAfter(fromId, toId, relation, "", 1);
-      assertEquals(1, page1.size(), "first page must return one row");
-      assertEquals(fromId, page1.getFirst().getFromId());
-      assertEquals("seeAlso", page1.getFirst().getRelationType());
-
-      List<EntityRelationshipObject> page2 =
-          dao.getAllRelationshipsAfter(fromId, toId, relation, "seeAlso", 1);
-      assertTrue(
-          page2.stream().anyMatch(r -> "synonym".equals(r.getRelationType())),
-          "the sibling row sharing the (fromId,toId,relation) tuple must not be skipped");
-    } finally {
-      deleteByFromId(fromId);
+      deleteOrphans(orphanIds);
     }
   }
 
@@ -163,64 +127,62 @@ public class EntityRelationshipCleanupIT {
                     List.of(new Column().withName("id").withDataType(ColumnDataType.BIGINT))));
   }
 
-  private void seedOrphans(String marker, int count) {
+  private List<String> seedOrphans(int count) {
+    List<String> fromIds = new ArrayList<>(count);
     for (int i = 0; i < count; i++) {
+      String fromId = UUID.randomUUID().toString();
       insertOrphan(
-          UUID.randomUUID().toString(),
+          fromId,
           UUID.randomUUID().toString(),
           Entity.DATABASE_SCHEMA,
           Entity.TABLE,
-          Relationship.CONTAINS.ordinal(),
-          marker);
+          Relationship.CONTAINS.ordinal());
+      fromIds.add(fromId);
     }
+    return fromIds;
   }
 
   private void insertOrphan(
-      String fromId, String toId, String fromEntity, String toEntity, int relation, String marker) {
+      String fromId, String toId, String fromEntity, String toEntity, int relation) {
     TestSuiteBootstrap.getJdbi()
         .useHandle(
             handle ->
                 handle
                     .createUpdate(
                         "INSERT INTO entity_relationship "
-                            + "(fromId, toId, fromEntity, toEntity, relation, relationType) "
-                            + "VALUES (:fromId, :toId, :fromEntity, :toEntity, :relation, :relationType)")
+                            + "(fromId, toId, fromEntity, toEntity, relation) "
+                            + "VALUES (:fromId, :toId, :fromEntity, :toEntity, :relation)")
                     .bind("fromId", fromId)
                     .bind("toId", toId)
                     .bind("fromEntity", fromEntity)
                     .bind("toEntity", toEntity)
                     .bind("relation", relation)
-                    .bind("relationType", marker)
                     .execute());
   }
 
-  private void deleteOrphans(String marker) {
+  private void deleteOrphans(List<String> fromIds) {
+    if (fromIds.isEmpty()) {
+      return;
+    }
     TestSuiteBootstrap.getJdbi()
         .useHandle(
             handle ->
                 handle
-                    .createUpdate("DELETE FROM entity_relationship WHERE relationType = :m")
-                    .bind("m", marker)
+                    .createUpdate("DELETE FROM entity_relationship WHERE fromId IN (<ids>)")
+                    .bindList("ids", fromIds)
                     .execute());
   }
 
-  private void deleteByFromId(String fromId) {
-    TestSuiteBootstrap.getJdbi()
-        .useHandle(
-            handle ->
-                handle
-                    .createUpdate("DELETE FROM entity_relationship WHERE fromId = :f")
-                    .bind("f", fromId)
-                    .execute());
-  }
-
-  private int orphanCount(String marker) {
+  private int orphanCount(List<String> fromIds) {
+    if (fromIds.isEmpty()) {
+      return 0;
+    }
     return TestSuiteBootstrap.getJdbi()
         .withHandle(
             handle ->
                 handle
-                    .createQuery("SELECT COUNT(*) FROM entity_relationship WHERE relationType = :m")
-                    .bind("m", marker)
+                    .createQuery("SELECT COUNT(*) FROM entity_relationship WHERE fromId IN (<ids>)")
+                    .bindList("ids", fromIds)
                     .mapTo(Integer.class)
                     .one());
   }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/CollectionDAO.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/CollectionDAO.java
@@ -2259,13 +2259,30 @@ public interface CollectionDAO {
     // page even when rows are deleted mid-scan, letting the relationship cleanup delete orphans
     // batch-by-batch without skipping rows or paying an ever-growing OFFSET cost. Seed the first
     // page with fromId='', toId='', relation=-1, relationType=''.
-    @SqlQuery(
-        "SELECT toId, toEntity, fromId, fromEntity, relation, relationType, json, jsonSchema FROM entity_relationship "
-            + "WHERE fromId > :fromId "
-            + "   OR (fromId = :fromId AND toId > :toId) "
-            + "   OR (fromId = :fromId AND toId = :toId AND relation > :relation) "
-            + "   OR (fromId = :fromId AND toId = :toId AND relation = :relation AND relationType > :relationType) "
-            + "ORDER BY fromId, toId, relation, relationType LIMIT :limit")
+    @ConnectionAwareSqlQuery(
+        value =
+            "SELECT toId, toEntity, fromId, fromEntity, relation, "
+                + "COALESCE(JSON_UNQUOTE(JSON_EXTRACT(json, '$.relationType')), 'relatedTo') AS relationType, "
+                + "json, jsonSchema FROM entity_relationship "
+                + "WHERE fromId > :fromId "
+                + "   OR (fromId = :fromId AND toId > :toId) "
+                + "   OR (fromId = :fromId AND toId = :toId AND relation > :relation) "
+                + "   OR (fromId = :fromId AND toId = :toId AND relation = :relation "
+                + "       AND COALESCE(JSON_UNQUOTE(JSON_EXTRACT(json, '$.relationType')), 'relatedTo') > :relationType) "
+                + "ORDER BY fromId, toId, relation, relationType LIMIT :limit",
+        connectionType = MYSQL)
+    @ConnectionAwareSqlQuery(
+        value =
+            "SELECT toId, toEntity, fromId, fromEntity, relation, "
+                + "COALESCE(json->>'relationType', 'relatedTo') AS relationType, "
+                + "json, jsonSchema FROM entity_relationship "
+                + "WHERE fromId > :fromId "
+                + "   OR (fromId = :fromId AND toId > :toId) "
+                + "   OR (fromId = :fromId AND toId = :toId AND relation > :relation) "
+                + "   OR (fromId = :fromId AND toId = :toId AND relation = :relation "
+                + "       AND COALESCE(json->>'relationType', 'relatedTo') > :relationType) "
+                + "ORDER BY fromId, toId, relation, relationType LIMIT :limit",
+        connectionType = POSTGRES)
     @RegisterRowMapper(RelationshipWithTypeObjectMapper.class)
     List<EntityRelationshipObject> getAllRelationshipsAfter(
         @Bind("fromId") String fromId,


### PR DESCRIPTION
## Problem
fixes: #29891

The DataRetention app fails with **"Partial failure occurred in DataRetention job"** on 1.12.x. The generic wrapper hides the real cause, which is logged as:

```
o.o.s.u.EntityRelationshipCleanup - Error during entity relationship cleanup
org.postgresql.util.PSQLException: ERROR: column "relationtype" does not exist
  ... /* EntityRelationshipDAO.getAllRelationshipsAfter */
      SELECT toId, toEntity, fromId, fromEntity, relation, relationType, json, jsonSchema FROM entity_relationship ...
```

Observed on `test-engg-v2.getcollate.io` and other 1.12.x deployments.

## Root cause

The keyset query introduced in #29363 (`getAllRelationshipsAfter`) treats `relationType` as a physical column of `entity_relationship`. It isn't — `relationType` lives inside the `json` blob (defaulting to `relatedTo`), exactly as the sibling `countByRelationType` query already reads it. The bare-column reference fails on **both** engines: Postgres (`column "relationtype" does not exist`) and MySQL (`Unknown column 'relationType'`).

It shipped undetected because `EntityRelationshipCleanupIT` referenced the same phantom column in its own INSERT/DELETE helpers (so it could never run against a real DB) and asserted an impossible scenario — two rows sharing the `(fromId, toId, relation)` **primary key**.

## Fix

- **`CollectionDAO.getAllRelationshipsAfter`** — extract `relationType` from `json`, connection-aware for both dialects, mirroring `countByRelationType`:
  - Postgres: `COALESCE(json->>'relationType', 'relatedTo')`
  - MySQL: `COALESCE(JSON_UNQUOTE(JSON_EXTRACT(json, '$.relationType')), 'relatedTo')`
- **`EntityRelationshipCleanupIT`** — seed/count/delete rows by `fromId` instead of the phantom column so the suite actually runs; removed the impossible same-PK regression test (its guarantee — no row-skipping across mid-scan deletes — is already covered by `actualCleanup_deletesScatteredOrphans`, which deletes 60 scattered orphans across keyset pages at batch size 25).

## Testing

- **Dual-engine SQL check** on real **Postgres 15** and **MySQL 8.3.0**: the old query reproduces the exact production error on both; the fixed query executes and returns the correct `relationType` (`synonym` / `seeAlso`, and `relatedTo` for NULL-json rows).
- **End-to-end `EntityRelationshipCleanupIT`** on the full Postgres + Elasticsearch + Dropwizard stack: `tests=2 failures=0 errors=0`; live run scanned 148 relationships and deleted 60 orphans via the previously-crashing keyset scan.
- `mvn spotless:apply` run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes relationship cleanup pagination to read relation types from the stored JSON payload. The main changes are:

- Adds MySQL and Postgres SQL variants for `getAllRelationshipsAfter`.
- Maps missing JSON relation types to the existing `relatedTo` default.
- Updates cleanup integration tests to seed and remove rows using real schema columns.
- Removes the invalid test path that referenced a non-existent `relationType` column.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge.

- No blocking issues found in the changed code.

</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/CollectionDAO.java | Replaces the phantom `relationType` column reference with dialect-specific JSON extraction in the keyset relationship query. |
| openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/EntityRelationshipCleanupIT.java | Updates test seeding, counting, and cleanup helpers to use generated `fromId` values instead of the removed `relationType` marker. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(data-retention): read relationType f..."](https://github.com/open-metadata/openmetadata/commit/bec2d53abee4fdde691bddfd42012cd655c609dd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43795846)</sub>

**Context used:**

- Context used - CLAUDE.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=52f0d9d9-cad1-4e7d-b070-de181a0aa5e7))

<!-- /greptile_comment -->