### PR TITLE
feat(ui): reusable AI-mode EntityDetailHeader on the Tag detail page

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/common/EntityDetailHeader/EntityDetailHeader.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/EntityDetailHeader/EntityDetailHeader.component.tsx
@@ -16,11 +16,13 @@ import { useMemo, useState } from 'react';
 import type { Key } from 'react-aria-components';
 import HeaderShell from '../HeaderShell/HeaderShell.component';
 import { EntityDetailHeaderProps } from './EntityDetailHeader.interface';
+import './EntityDetailHeader.less';
 
 const EntityDetailHeader = ({
   breadcrumb,
   serviceLogoUrl,
   icon,
+  leading,
   title,
   subtitle,
   badge,
@@ -62,26 +64,28 @@ const EntityDetailHeader = ({
     onTabChange?.(String(key));
   };
 
-  const leading = serviceLogoUrl ? (
-    <Box
-      align="center"
-      className="tw:size-10 tw:shrink-0 tw:rounded-md tw:border tw:border-secondary tw:bg-primary tw:p-1.5"
-      justify="center">
-      <img
-        alt=""
-        className="tw:size-full tw:object-contain"
-        src={serviceLogoUrl}
+  const resolvedLeading =
+    leading ??
+    (serviceLogoUrl ? (
+      <Box
+        align="center"
+        className="tw:size-10 tw:shrink-0 tw:rounded-md tw:border tw:border-secondary tw:bg-primary tw:p-1.5"
+        justify="center">
+        <img
+          alt=""
+          className="tw:size-full tw:object-contain"
+          src={serviceLogoUrl}
+        />
+      </Box>
+    ) : icon ? (
+      <FeaturedIcon
+        color="brand"
+        icon={icon}
+        shape="square"
+        size="md"
+        theme="gradient"
       />
-    </Box>
-  ) : icon ? (
-    <FeaturedIcon
-      color="brand"
-      icon={icon}
-      shape="square"
-      size="md"
-      theme="gradient"
-    />
-  ) : undefined;
+    ) : undefined);
 
   const actions =
     primaryAction || secondaryActions ? (
@@ -93,7 +97,7 @@ const EntityDetailHeader = ({
 
   const footer = (
     <Tabs
-      className="tw:mt-1"
+      className="tw:mt-1 entity-detail-header-tabs"
       selectedKey={selectedKey}
       onSelectionChange={handleSelectionChange}>
       <Tabs.List type={tabListType}>
@@ -123,7 +127,7 @@ const EntityDetailHeader = ({
       className={className}
       data-testid={dataTestId}
       footer={footer}
-      leading={leading}
+      leading={resolvedLeading}
       meta={meta}
       subtitle={subtitle}
       title={title}

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/EntityDetailHeader/EntityDetailHeader.interface.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/EntityDetailHeader/EntityDetailHeader.interface.ts
@@ -41,6 +41,11 @@ export interface EntityDetailHeaderProps {
   serviceLogoUrl?: string | null;
   /** Fallback leading icon (wrapped in a FeaturedIcon) when no logo is provided. */
   icon?: FC<{ className?: string }> | ReactNode;
+  /**
+   * Pre-rendered leading node the consumer fully controls; rendered as-is with
+   * no FeaturedIcon tile. Takes precedence over serviceLogoUrl/icon.
+   */
+  leading?: ReactNode;
   title: ReactNode;
   subtitle?: ReactNode;
   /** Inline badge next to the title (e.g. status / BETA). */

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/EntityDetailHeader/EntityDetailHeader.less
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/EntityDetailHeader/EntityDetailHeader.less
@@ -1,0 +1,19 @@
+/*
+ *  Copyright 2026 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+// The core underline TabList draws a full-width 1px rule under the tabs via a
+// ::before. In the entity detail header the tab strip sits at the bottom edge
+// of the gradient card, so drop that trailing line.
+.entity-detail-header-tabs [role='tablist']::before {
+  display: none;
+}

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/HeaderShell/HeaderShell.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/HeaderShell/HeaderShell.component.tsx
@@ -54,11 +54,19 @@ const HeaderShell = ({
   className,
   'data-testid': dataTestId = 'header-shell',
 }: HeaderShellProps) => {
+  // When the header renders a footer (the tab strip), the tabs sit flush at the
+  // bottom edge of the card — drop the card's bottom padding but keep the top.
+  const paddingClass = footer
+    ? padding === 'comfortable'
+      ? 'tw:pt-4 tw:pb-0'
+      : 'tw:pt-3 tw:pb-0'
+    : PADDING_CLASS[padding];
+
   return (
     <Card
       className={classNames(
-        'tw:mb-5 tw:px-5',
-        PADDING_CLASS[padding],
+        'tw:px-5',
+        paddingClass,
         // Fixed light-blue header treatment per Figma — intentionally NOT the
         // dynamic brand-* tokens (those follow the deployment's primary color and
         // would tint this header pink on Collate). The gradient stops and the

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/atoms/navigation/usePageHeader.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/atoms/navigation/usePageHeader.tsx
@@ -161,6 +161,7 @@ export const usePageHeader = (config: PageHeaderConfig) => {
         actions={actions}
         badge={badge}
         breadcrumb={config.breadcrumb}
+        className="tw:mb-5"
         data-testid="page-header-container"
         leading={leading}
         subtitle={displayDescription}

--- a/openmetadata-ui/src/main/resources/ui/src/pages/ColumnBulkOperations/ColumnBulkOperations.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/ColumnBulkOperations/ColumnBulkOperations.component.tsx
@@ -43,7 +43,6 @@ const ColumnBulkOperations = () => {
               />
             }
             className="tw:mb-5"
-            className="tw:mb-4"
             subtitle={t('message.column-bulk-operations-subtitle')}
             title={t('label.column-bulk-operations')}
             variant="gradient"

--- a/openmetadata-ui/src/main/resources/ui/src/pages/ColumnBulkOperations/ColumnBulkOperations.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/ColumnBulkOperations/ColumnBulkOperations.component.tsx
@@ -42,6 +42,7 @@ const ColumnBulkOperations = () => {
                 showHome={false}
               />
             }
+            className="tw:mb-5"
             className="tw:mb-4"
             subtitle={t('message.column-bulk-operations-subtitle')}
             title={t('label.column-bulk-operations')}

--- a/openmetadata-ui/src/main/resources/ui/src/pages/Glossary/GlossaryPage/GlossaryPage.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/Glossary/GlossaryPage/GlossaryPage.component.tsx
@@ -20,9 +20,6 @@ import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
 import { DeleteType } from '../../../components/common/DeleteWidget/DeleteWidget.interface';
 import ErrorPlaceHolder from '../../../components/common/ErrorWithPlaceholder/ErrorPlaceHolder';
-import HeaderBreadcrumb from '../../../components/common/HeaderBreadcrumb/HeaderBreadcrumb.component';
-import { getGlossaryHomeCrumb } from '../../../components/common/HeaderBreadcrumb/HeaderBreadcrumb.utils';
-import HeaderShell from '../../../components/common/HeaderShell/HeaderShell.component';
 import Loader from '../../../components/common/Loader/Loader';
 import ResizableLeftPanels from '../../../components/common/ResizablePanels/ResizableLeftPanels';
 import { VotingDataProps } from '../../../components/Entity/Voting/voting.interface';
@@ -52,7 +49,6 @@ import { GlossaryTerm } from '../../../generated/entity/data/glossaryTerm';
 import { Operation } from '../../../generated/entity/policies/policy';
 import { withPageLayout } from '../../../hoc/withPageLayout';
 import { usePaging } from '../../../hooks/paging/usePaging';
-import { useIsAiMode } from '../../../hooks/useAppMode';
 import { useElementInView } from '../../../hooks/useElementInView';
 import { useFqn } from '../../../hooks/useFqn';
 import {
@@ -80,7 +76,6 @@ const GlossaryPage = () => {
   const { permissions } = usePermissionProvider();
   const { fqn: glossaryFqn } = useFqn();
   const { t } = useTranslation();
-  const isAiMode = useIsAiMode();
   const navigate = useNavigate();
   const queryClient = useQueryClient();
   const { handleOnAsyncEntityDeleteConfirm } = useAsyncDeleteProvider();
@@ -595,24 +590,7 @@ const GlossaryPage = () => {
     glossaryElement
   );
 
-  return (
-    <div>
-      {isAiMode && (
-        <HeaderShell
-          breadcrumb={
-            <HeaderBreadcrumb
-              noMargin
-              items={[getGlossaryHomeCrumb(t), { label: t('label.glossary') }]}
-              showHome={false}
-            />
-          }
-          title={t('label.glossary')}
-          variant="gradient"
-        />
-      )}
-      {resizableLayout}
-    </div>
-  );
+  return <div>{resizableLayout}</div>;
 };
 
 export default withPageLayout(GlossaryPage);

--- a/openmetadata-ui/src/main/resources/ui/src/pages/OntologyExplorerPage/OntologyExplorerPage.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/OntologyExplorerPage/OntologyExplorerPage.tsx
@@ -120,6 +120,7 @@ const OntologyExplorerPage: React.FC = () => {
             hasStats
             badge={betaBadge}
             breadcrumb={breadcrumb}
+            className="tw:mb-5"
             meta={statsRow}
             title={heading}
             variant="gradient"

--- a/openmetadata-ui/src/main/resources/ui/src/pages/TagPage/TagPage.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/TagPage/TagPage.tsx
@@ -42,7 +42,11 @@ import {
 import { withActivityFeed } from '../../components/AppRouter/withActivityFeed';
 import withSuspenseFallback from '../../components/AppRouter/withSuspenseFallback';
 import DeleteModal from '../../components/common/DeleteModal/DeleteModal';
+import EntityDetailHeader from '../../components/common/EntityDetailHeader/EntityDetailHeader.component';
+import { EntityDetailTab } from '../../components/common/EntityDetailHeader/EntityDetailHeader.interface';
 import ErrorPlaceHolder from '../../components/common/ErrorWithPlaceholder/ErrorPlaceHolder';
+import HeaderBreadcrumb from '../../components/common/HeaderBreadcrumb/HeaderBreadcrumb.component';
+import { getGlossaryHomeCrumb } from '../../components/common/HeaderBreadcrumb/HeaderBreadcrumb.utils';
 import Loader from '../../components/common/Loader/Loader';
 import { ManageButtonItemLabel } from '../../components/common/ManageButtonContentItem/ManageButtonContentItem.component';
 import ResizablePanels from '../../components/common/ResizablePanels/ResizablePanels';
@@ -88,6 +92,7 @@ import { ProviderType, Tag } from '../../generated/entity/classification/tag';
 import { EntityStatus } from '../../generated/entity/data/glossaryTerm';
 import { PageType } from '../../generated/system/ui/page';
 import { Style } from '../../generated/type/tagLabel';
+import { useIsAiMode } from '../../hooks/useAppMode';
 import { useCustomPages } from '../../hooks/useCustomPages';
 import { useFqn } from '../../hooks/useFqn';
 import { FeedCounts } from '../../interface/feed.interface';
@@ -99,6 +104,7 @@ import {
 import { searchQuery } from '../../rest/searchAPI';
 import { deleteTag, patchTag } from '../../rest/tagAPI';
 import { getEntityMissingError } from '../../utils/EntityDisplayPureUtils';
+import { getEntityName } from '../../utils/EntityNameUtils';
 import entityUtilClassBase from '../../utils/EntityUtilClassBase';
 import {
   fetchEntityActivityCountInto,
@@ -134,6 +140,8 @@ const TagPage = () => {
   const { fqn: tagFqn } = useFqn();
   const navigate = useNavigate();
   const queryClient = useQueryClient();
+  const isAiMode = useIsAiMode();
+  const showAiHeader = isAiMode;
   const { tab: activeTab = EntityTabs.OVERVIEW } = useRequiredParams<{
     tab?: string;
   }>();
@@ -219,6 +227,22 @@ const TagPage = () => {
         ]
       : [];
   }, [tagItem]);
+
+  const aiBreadcrumbItems = useMemo(
+    () => [
+      getGlossaryHomeCrumb(t),
+      { label: t('label.classification-plural'), href: ROUTES.TAGS },
+      {
+        label: tagItem?.classification?.name ?? '',
+        href: tagItem?.classification?.fullyQualifiedName
+          ? getClassificationDetailsPath(
+              tagItem.classification.fullyQualifiedName
+            )
+          : '',
+      },
+    ],
+    [tagItem, t]
+  );
 
   const handleAssetClick = useCallback(
     (asset?: EntityDetailsObjectInterface) => {
@@ -712,6 +736,12 @@ const TagPage = () => {
     assetTabRef,
     t,
   ]);
+
+  const aiHeaderTabs = useMemo<EntityDetailTab[]>(
+    () => tabItems.map((tab) => ({ key: tab.key, label: tab.label })),
+    [tabItems]
+  );
+
   const icon = useMemo(() => {
     if (tagItem?.style?.iconURL) {
       return (
@@ -805,76 +835,111 @@ const TagPage = () => {
     );
   }
 
+  const learningIcon = (
+    <LearningIcon className="m-t-xss" pageId={LEARNING_PAGE_IDS.TAGS} />
+  );
+
+  const addAssetsButton =
+    !isCertificationClassification && !tagItem.disabled ? (
+      <Button
+        data-testid="data-classification-add-button"
+        type="primary"
+        onClick={() => setAssetModalVisible(true)}>
+        {t('label.add-entity', {
+          entity: t('label.asset-plural'),
+        })}
+      </Button>
+    ) : null;
+
+  const manageDropdown =
+    manageButtonContent.length > 0 ? (
+      <Dropdown
+        align={{ targetOffset: [-12, 0] }}
+        className="m-l-xs"
+        menu={{
+          items: manageButtonContent,
+        }}
+        open={showActions}
+        overlayStyle={{ width: '350px' }}
+        placement="bottomRight"
+        trigger={['click']}
+        onOpenChange={setShowActions}>
+        <Tooltip
+          placement="topRight"
+          title={t('label.manage-entity', {
+            entity: t('label.tag-lowercase'),
+          })}>
+          <Button
+            className="flex-center"
+            data-testid="manage-button"
+            icon={<IconDropdown className="manage-dropdown-icon" />}
+            onClick={() => setShowActions(true)}
+          />
+        </Tooltip>
+      </Dropdown>
+    ) : null;
+
   return (
     <PageLayoutV1 pageTitle={tagItem.name}>
       <Row gutter={[0, 12]}>
         <Col span={24}>
-          <Row
-            className="data-classification"
-            data-testid="data-classification"
-            gutter={[0, 12]}>
-            <Col className="p-x-md" flex="1">
-              <EntityHeader
-                badge={badge}
-                breadcrumb={breadcrumb}
-                entityData={tagItem}
-                entityType={EntityType.TAG}
-                icon={icon}
-                serviceName={tagItem.name}
-                suffix={
-                  <LearningIcon
-                    className="m-t-xss"
-                    pageId={LEARNING_PAGE_IDS.TAGS}
+          {showAiHeader ? (
+            <div>
+              <EntityDetailHeader
+                activeKey={activeTab}
+                badge={
+                  <>
+                    {badge}
+                    {learningIcon}
+                  </>
+                }
+                breadcrumb={
+                  <HeaderBreadcrumb
+                    items={aiBreadcrumbItems}
+                    showHome={false}
                   />
                 }
-                titleColor={tagItem.style?.color ?? BLACK_COLOR}
+                data-testid="tag-detail-header"
+                leading={icon}
+                primaryAction={
+                  haveAssetEditPermission ? addAssetsButton : undefined
+                }
+                renderPanels={false}
+                secondaryActions={
+                  haveAssetEditPermission ? manageDropdown : null
+                }
+                tabs={aiHeaderTabs}
+                title={getEntityName(tagItem)}
+                onTabChange={activeTabHandler}
               />
-            </Col>
-            {haveAssetEditPermission && (
-              <Col className="p-x-md">
-                <div className="d-flex self-end">
-                  {!isCertificationClassification && !tagItem.disabled && (
-                    <Button
-                      data-testid="data-classification-add-button"
-                      type="primary"
-                      onClick={() => setAssetModalVisible(true)}>
-                      {t('label.add-entity', {
-                        entity: t('label.asset-plural'),
-                      })}
-                    </Button>
-                  )}
-                  {manageButtonContent.length > 0 && (
-                    <Dropdown
-                      align={{ targetOffset: [-12, 0] }}
-                      className="m-l-xs"
-                      menu={{
-                        items: manageButtonContent,
-                      }}
-                      open={showActions}
-                      overlayStyle={{ width: '350px' }}
-                      placement="bottomRight"
-                      trigger={['click']}
-                      onOpenChange={setShowActions}>
-                      <Tooltip
-                        placement="topRight"
-                        title={t('label.manage-entity', {
-                          entity: t('label.tag-lowercase'),
-                        })}>
-                        <Button
-                          className="flex-center"
-                          data-testid="manage-button"
-                          icon={
-                            <IconDropdown className="manage-dropdown-icon" />
-                          }
-                          onClick={() => setShowActions(true)}
-                        />
-                      </Tooltip>
-                    </Dropdown>
-                  )}
-                </div>
+            </div>
+          ) : (
+            <Row
+              className="data-classification"
+              data-testid="data-classification"
+              gutter={[0, 12]}>
+              <Col className="p-x-md" flex="1">
+                <EntityHeader
+                  badge={badge}
+                  breadcrumb={breadcrumb}
+                  entityData={tagItem}
+                  entityType={EntityType.TAG}
+                  icon={icon}
+                  serviceName={tagItem.name}
+                  suffix={learningIcon}
+                  titleColor={tagItem.style?.color ?? BLACK_COLOR}
+                />
               </Col>
-            )}
-          </Row>
+              {haveAssetEditPermission && (
+                <Col className="p-x-md">
+                  <div className="d-flex self-end">
+                    {addAssetsButton}
+                    {manageDropdown}
+                  </div>
+                </Col>
+              )}
+            </Row>
+          )}
         </Col>
 
         <GenericProvider<Tag>
@@ -898,6 +963,7 @@ const TagPage = () => {
               activeKey={activeTab}
               className="tabs-new tag-page-tabs"
               items={tabItems}
+              renderTabBar={showAiHeader ? () => <></> : undefined}
               onChange={activeTabHandler}
             />
           </Col>

--- a/openmetadata-ui/src/main/resources/ui/src/pages/TagsPage/TagsPage.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/TagsPage/TagsPage.tsx
@@ -25,9 +25,6 @@ import ClassificationDetails from '../../components/Classifications/Classificati
 import { ClassificationDetailsRef } from '../../components/Classifications/ClassificationDetails/ClassificationDetails.interface';
 import DeleteModal from '../../components/common/DeleteModal/DeleteModal';
 import ErrorPlaceHolder from '../../components/common/ErrorWithPlaceholder/ErrorPlaceHolder';
-import HeaderBreadcrumb from '../../components/common/HeaderBreadcrumb/HeaderBreadcrumb.component';
-import { getGlossaryHomeCrumb } from '../../components/common/HeaderBreadcrumb/HeaderBreadcrumb.utils';
-import HeaderShell from '../../components/common/HeaderShell/HeaderShell.component';
 import Loader from '../../components/common/Loader/Loader';
 import ResizableLeftPanels from '../../components/common/ResizablePanels/ResizableLeftPanels';
 import TagsLeftPanelSkeleton from '../../components/common/Skeleton/Tags/TagsLeftPanelSkeleton.component';
@@ -46,7 +43,6 @@ import { Classification } from '../../generated/entity/classification/classifica
 import { Tag } from '../../generated/entity/classification/tag';
 import { Operation } from '../../generated/entity/policies/accessControl/rule';
 import { withPageLayout } from '../../hoc/withPageLayout';
-import { useIsAiMode } from '../../hooks/useAppMode';
 import { useFqn } from '../../hooks/useFqn';
 import {
   createClassification,
@@ -78,7 +74,6 @@ import {
 const TagsPage = () => {
   const { getEntityPermission, permissions } = usePermissionProvider();
   const { t } = useTranslation();
-  const isAiMode = useIsAiMode();
   const navigate = useNavigate();
   const { fqn: tagCategoryName } = useFqn();
   const tagForm = useForm<TagFormValues>({ defaultValues: TAG_FORM_DEFAULTS });
@@ -762,22 +757,6 @@ const TagsPage = () => {
 
   return (
     <div>
-      {isAiMode && (
-        <HeaderShell
-          breadcrumb={
-            <HeaderBreadcrumb
-              noMargin
-              items={[
-                getGlossaryHomeCrumb(t),
-                { label: t('label.classification-plural') },
-              ]}
-              showHome={false}
-            />
-          }
-          title={t('label.classification-plural')}
-          variant="gradient"
-        />
-      )}
       <ResizableLeftPanels
         showLearningIcon
         className="content-height-with-resizable-panel"

--- a/openmetadata-ui/src/main/resources/ui/src/pages/WorkflowDefinitions/WorkflowsPage/WorkflowsPage.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/WorkflowDefinitions/WorkflowsPage/WorkflowsPage.tsx
@@ -283,7 +283,6 @@ const WorkflowsPage = () => {
               />
             }
             className="tw:mb-5"
-            className="tw:mb-4"
             subtitle={t('message.workflow-subtitle')}
             title={t('label.workflow-plural')}
             variant="gradient"

--- a/openmetadata-ui/src/main/resources/ui/src/pages/WorkflowDefinitions/WorkflowsPage/WorkflowsPage.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/WorkflowDefinitions/WorkflowsPage/WorkflowsPage.tsx
@@ -282,6 +282,7 @@ const WorkflowsPage = () => {
                 showHome={false}
               />
             }
+            className="tw:mb-5"
             className="tw:mb-4"
             subtitle={t('message.workflow-subtitle')}
             title={t('label.workflow-plural')}


### PR DESCRIPTION
## What

In AI mode (`useIsAiMode`), the Tag detail page (`/tag/:fqn`) now renders the shared gradient
`EntityDetailHeader` instead of the legacy `EntityHeader` — breadcrumb + leading icon + title +
status/learning badges + manage actions, with the existing tab strip (Overview / Assets /
Activity Feed & Tasks / Data Observability / …) hosted **inside** the header card. Classic
OpenMetadata is unchanged (legacy `EntityHeader` + the standard tab bar).

This is the first real consumer of the reusable `EntityDetailHeader` (added in #29839), so it also
lands a few refinements to the shared header components:

### `EntityDetailHeader`
- New `leading?: ReactNode` slot — a consumer can supply a pre-rendered leading node rendered
  **as-is** (no `FeaturedIcon` tile); the Tag page uses it to render the tag icon exactly as
  `EntityHeaderTitle` did.
- Drops the underline tab strip's `::before` rule (scoped via a component `.less`) so the in-card
  tabs have no trailing full-width line.

### `HeaderShell`
- When a `footer` (the tab strip) is present, the card's **bottom padding is 0** so the tabs sit
  flush at the bottom edge.
- Moves the hardcoded bottom margin (`tw:mb-5`) **out of `HeaderShell`** into the consumers
  (`usePageHeader`, WorkflowsPage, ColumnBulkOperations, OntologyExplorerPage) so each header owns
  its own spacing (tab-in-card headers can be flush).

## Testing
- AI mode: `/tag/<classification>.<tag>` renders the gradient header with in-card tabs; switching
  tabs updates the URL and swaps panels. Classic mode (default app mode) is unchanged.
- Other `HeaderShell` consumers keep their 20px bottom margin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds the shared AI-mode detail header to the Tag detail page. The main changes are:

- AI mode on `/tag/:fqn` uses `EntityDetailHeader` with in-card tabs.
- `EntityDetailHeader` gains a custom `leading` slot and tab-strip styling.
- `HeaderShell` adjusts footer padding and moves default spacing to callers.
- Tags and Glossary list pages no longer render the temporary AI header.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge.

- No blocking issues found in the changed code.

</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-ui/src/main/resources/ui/src/components/common/EntityDetailHeader/EntityDetailHeader.component.tsx | Adds the custom leading slot and applies the header-specific tab-strip styling. |
| openmetadata-ui/src/main/resources/ui/src/components/common/HeaderShell/HeaderShell.component.tsx | Changes footer padding behavior and leaves outer spacing to each caller. |
| openmetadata-ui/src/main/resources/ui/src/pages/TagPage/TagPage.tsx | Switches the Tag detail page to the shared AI-mode header while keeping the existing tab panels. |
| openmetadata-ui/src/main/resources/ui/src/pages/ColumnBulkOperations/ColumnBulkOperations.component.tsx | Uses a single header spacing class on the `HeaderShell` call. |
| openmetadata-ui/src/main/resources/ui/src/pages/WorkflowDefinitions/WorkflowsPage/WorkflowsPage.tsx | Uses a single header spacing class on the `HeaderShell` call. |
| openmetadata-ui/src/main/resources/ui/src/pages/TagsPage/TagsPage.tsx | Removes the temporary AI-mode header block from the classifications list page. |
| openmetadata-ui/src/main/resources/ui/src/pages/Glossary/GlossaryPage/GlossaryPage.component.tsx | Removes the temporary AI-mode header block from the glossary page. |

</details>

<sub>Reviews (5): Last reviewed commit: ["Merge branch &#39;main&#39; into ai-mode-tag-det..."](https://github.com/open-metadata/openmetadata/commit/994a41fa4db7503320fb3c12ede6eb6a668d44d3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43798755)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Context used - CLAUDE.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=52f0d9d9-cad1-4e7d-b070-de181a0aa5e7))
- Context used - openmetadata-ui-core-components/CLAUDE.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=41754627-b2bf-474b-8082-f37ef1a07013))
- Context used - AGENTS.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=ef262f5f-911f-44f3-8d2d-e9cb1579c8c8))
</details>

<!-- /greptile_comment -->