### PR TITLE
Fix explore URL state filter selection test

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/ExploreUrlState.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/ExploreUrlState.spec.ts
@@ -94,15 +94,16 @@ const selectOptionAndWaitForQuery = async (
 ) => {
   await ensureFilterOptionVisible(page, label, optionKey, searchText);
   const option = page.getByTestId('drop-down-menu').getByTestId(optionKey);
+  const queryValue = searchText ?? optionKey;
 
   const queryRes = page.waitForResponse((response) => {
     let isMatch = false;
     if (response.url().includes('/api/v1/search/query')) {
       const queryFilter =
         new URL(response.url()).searchParams.get('query_filter') ?? '';
-      // Match the quoted term value ("table") so short keys can't
-      // incidentally hit field names like "table.name" in the filter.
-      isMatch = queryFilter.includes(`"${optionKey}"`);
+      // Match the quoted query value so checkbox test ids like "table-checkbox"
+      // still assert the actual filter term, e.g. "table".
+      isMatch = queryFilter.includes(`"${queryValue}"`);
     }
 
     return isMatch;
@@ -220,7 +221,12 @@ test('reloading the page preserves composed filters', async ({ page }) => {
 
   await selectOptionAndWaitForQuery(page, 'Tier', TIER1_KEY);
   await page.keyboard.press('Escape');
-  await selectOptionAndWaitForQuery(page, 'Data Assets', 'table', 'table');
+  await selectOptionAndWaitForQuery(
+    page,
+    'Data Assets',
+    'table-checkbox',
+    'table'
+  );
   await page.keyboard.press('Escape');
 
   await expect(
@@ -308,7 +314,7 @@ test('selecting an asset type grays out and collapses incompatible categories', 
     await selectOptionAndWaitForQuery(
       page,
       'Data Assets',
-      'dashboard',
+      'dashboard-checkbox',
       'dashboard'
     );
     await page.keyboard.press('Escape');
@@ -345,7 +351,12 @@ test('an impossible filter combination shows the no-results placeholder and reco
     const ownerMust = readQuickFilterMust(page);
 
     await openExplore(page);
-    await selectOptionAndWaitForQuery(page, 'Data Assets', 'topic', 'topic');
+    await selectOptionAndWaitForQuery(
+      page,
+      'Data Assets',
+      'topic-checkbox',
+      'topic'
+    );
     await page.keyboard.press('Escape');
     const topicMust = readQuickFilterMust(page);
 
@@ -418,7 +429,12 @@ test('owner filter spans asset types and ANDs with an asset-type filter', async 
     // The previous step left the owned table's name in the search box, which
     // scopes the Data Assets facet to nothing — clear it before opening it.
     await clearGlobalSearch(page);
-    await selectOptionAndWaitForQuery(page, 'Data Assets', 'table', 'table');
+    await selectOptionAndWaitForQuery(
+      page,
+      'Data Assets',
+      'table-checkbox',
+      'table'
+    );
     await page.keyboard.press('Escape');
 
     await expect(

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/ExploreUrlState.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/ExploreUrlState.spec.ts
@@ -220,7 +220,7 @@ test('reloading the page preserves composed filters', async ({ page }) => {
 
   await selectOptionAndWaitForQuery(page, 'Tier', TIER1_KEY);
   await page.keyboard.press('Escape');
-  await selectOptionAndWaitForQuery(page, 'Data Assets', 'table');
+  await selectOptionAndWaitForQuery(page, 'Data Assets', 'table', 'table');
   await page.keyboard.press('Escape');
 
   await expect(
@@ -305,7 +305,12 @@ test('selecting an asset type grays out and collapses incompatible categories', 
   });
 
   await test.step('Selecting Dashboard grays out and collapses Databases', async () => {
-    await selectOptionAndWaitForQuery(page, 'Data Assets', 'dashboard');
+    await selectOptionAndWaitForQuery(
+      page,
+      'Data Assets',
+      'dashboard',
+      'dashboard'
+    );
     await page.keyboard.press('Escape');
 
     await expect(treeNode(page, 'Dashboards')).not.toHaveClass(
@@ -340,7 +345,7 @@ test('an impossible filter combination shows the no-results placeholder and reco
     const ownerMust = readQuickFilterMust(page);
 
     await openExplore(page);
-    await selectOptionAndWaitForQuery(page, 'Data Assets', 'topic');
+    await selectOptionAndWaitForQuery(page, 'Data Assets', 'topic', 'topic');
     await page.keyboard.press('Escape');
     const topicMust = readQuickFilterMust(page);
 
@@ -413,7 +418,7 @@ test('owner filter spans asset types and ANDs with an asset-type filter', async 
     // The previous step left the owned table's name in the search box, which
     // scopes the Data Assets facet to nothing — clear it before opening it.
     await clearGlobalSearch(page);
-    await selectOptionAndWaitForQuery(page, 'Data Assets', 'table');
+    await selectOptionAndWaitForQuery(page, 'Data Assets', 'table', 'table');
     await page.keyboard.press('Escape');
 
     await expect(


### PR DESCRIPTION
## Summary
- Update Explore URL state Playwright coverage to search Data Assets facet options before selecting them.
- Aligns the test flow with the current dropdown behavior for table, dashboard, and topic filters.

## Testing
- ./node_modules/.bin/eslint --no-error-on-unmatched-pattern playwright/e2e/Features/ExploreUrlState.spec.ts
- git diff --check -- openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/ExploreUrlState.spec.ts

----
## Summary by Gitar

- **Test framework improvements:**
  - Updated `ensureFilterOptionVisible` and `selectOptionAndWaitForQuery` to support custom `optionTestId` locators.
  - Added `selectDataAssetOptionAndWaitForQuery` helper to standardize Data Asset selection using `checkbox`-suffixed test IDs.

<sub>This will update automatically on new commits.</sub>

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR updates the Explore URL state Playwright coverage for Data Assets filters. The main changes are:

- Separates the clicked option test id from the expected query value.
- Uses checkbox test ids for table, dashboard, and topic options.
- Keeps the URL query assertions focused on the raw asset type value.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge.

- No blocking issues found in the changed code.

</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/ExploreUrlState.spec.ts | Updates the local filter-selection helper and Data Assets calls to use checkbox locators while asserting the raw asset type in the Explore query filter. |

</details>

<sub>Reviews (5): Last reviewed commit: ["Fix data asset option locators"](https://github.com/open-metadata/openmetadata/commit/ed5ae670a86fb072cae5bbb13319da453310b65e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43808998)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Context used - CLAUDE.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=52f0d9d9-cad1-4e7d-b070-de181a0aa5e7))
- Context used - openmetadata-ui-core-components/CLAUDE.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=41754627-b2bf-474b-8082-f37ef1a07013))
- Context used - AGENTS.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=ef262f5f-911f-44f3-8d2d-e9cb1579c8c8))
</details>

<!-- /greptile_comment -->