### PR TITLE
Fixes #29473: fix(auto-classification): break sibling-tag score ties …

### DIFF
--- a/ingestion/src/metadata/pii/algorithms/tag_scoring.py
+++ b/ingestion/src/metadata/pii/algorithms/tag_scoring.py
@@ -87,6 +87,7 @@ class TagScorer:
                         score=analysis.score,
                         reason=analysis.explanation or "",
                         recognizer_metadata=recognizer_metadata,
+                        column_name_matched=analysis.column_name_matched,
                     )
                 )
 

--- a/ingestion/src/metadata/pii/conflict_resolver.py
+++ b/ingestion/src/metadata/pii/conflict_resolver.py
@@ -128,7 +128,9 @@ class ConflictResolver:
             # BirthDate both use DateRecognizer), so they tie on score. A column-name match
             # is the distinguishing per-column evidence and breaks the tie ahead of the
             # static priority prior; priority then disambiguates same-specificity ties.
-            winner = max(tags, key=lambda t: (t.score, t.column_name_matched, t.priority))
+            winner = max(
+                tags, key=lambda t: (t.score, t.column_name_matched, t.priority)
+            )
             logger.debug(
                 f"Strategy: highest_confidence -> {winner.tag.fullyQualifiedName} (score={winner.score:.3f})"
             )

--- a/ingestion/src/metadata/pii/conflict_resolver.py
+++ b/ingestion/src/metadata/pii/conflict_resolver.py
@@ -124,7 +124,11 @@ class ConflictResolver:
             return tags[0]
 
         if strategy == ConflictResolution.highest_confidence:
-            winner = max(tags, key=lambda t: (t.score, t.priority))
+            # Sibling tags often share a generic content recognizer (e.g. DateTime and
+            # BirthDate both use DateRecognizer), so they tie on score. A column-name match
+            # is the distinguishing per-column evidence and breaks the tie ahead of the
+            # static priority prior; priority then disambiguates same-specificity ties.
+            winner = max(tags, key=lambda t: (t.score, t.column_name_matched, t.priority))
             logger.debug(
                 f"Strategy: highest_confidence -> {winner.tag.fullyQualifiedName} (score={winner.score:.3f})"
             )

--- a/ingestion/src/metadata/pii/models.py
+++ b/ingestion/src/metadata/pii/models.py
@@ -43,12 +43,14 @@ class ScoredTag:
         score: Confidence score (0.0-1.0)
         reason: Explanation of why this tag was matched
         recognizer_metadata: Optional metadata about the recognizer that applied this tag
+        column_name_matched: Whether the tag's own column-name recognizer matched the column name
     """
 
     tag: Tag
     score: float
     reason: str
     recognizer_metadata: Optional[TagLabelRecognizerMetadata] = None
+    column_name_matched: bool = False
 
     def __hash__(self) -> int:
         return hash(self.tag.fullyQualifiedName)

--- a/ingestion/src/metadata/pii/tag_analyzer.py
+++ b/ingestion/src/metadata/pii/tag_analyzer.py
@@ -42,6 +42,7 @@ class TagAnalysis(BaseModel):
     explanation: Optional[str]
     recognizer_results: List[RecognizerResult] = []
     target: Optional[recognizer.Target] = None
+    column_name_matched: bool = False
 
     @final
     class Config:
@@ -234,6 +235,7 @@ class TagAnalyzer:
             else None,
             recognizer_results=winning_results,
             target=target if winning_results else None,
+            column_name_matched=bool(column_results),
         )
 
     def __repr__(self) -> str:

--- a/ingestion/tests/unit/metadata/pii/test_conflict_resolver.py
+++ b/ingestion/tests/unit/metadata/pii/test_conflict_resolver.py
@@ -32,7 +32,9 @@ from metadata.pii.conflict_resolver import ConflictResolver
 from metadata.pii.models import ScoredTag
 
 
-def _scored_tag(name: str, score: float, column_name_matched: bool, priority: int) -> ScoredTag:
+def _scored_tag(
+    name: str, score: float, column_name_matched: bool, priority: int
+) -> ScoredTag:
     return ScoredTagFactory.create(
         tag__tag_name=name,
         tag__tag_classification__fqn="General",
@@ -292,30 +294,48 @@ class TestConflictResolver:
 
     def test_select_winner_column_name_match_breaks_score_tie(self):
         """Siblings tie on score (shared content recognizer); the column-name match wins."""
-        datetime_tag = _scored_tag("DateTime", score=1.0, column_name_matched=True, priority=50)
-        birthdate_tag = _scored_tag("BirthDate", score=1.0, column_name_matched=False, priority=50)
+        datetime_tag = _scored_tag(
+            "DateTime", score=1.0, column_name_matched=True, priority=50
+        )
+        birthdate_tag = _scored_tag(
+            "BirthDate", score=1.0, column_name_matched=False, priority=50
+        )
 
         resolver = ConflictResolver()
-        winner = resolver._select_winner([birthdate_tag, datetime_tag], ConflictResolution.highest_confidence)
+        winner = resolver._select_winner(
+            [birthdate_tag, datetime_tag], ConflictResolution.highest_confidence
+        )
 
         assert winner.tag.name.root == "DateTime"
 
     def test_select_winner_column_name_match_outranks_priority(self):
         """A column-name match beats a higher static priority: per-column evidence wins over the prior."""
-        location_tag = _scored_tag("Location", score=0.85, column_name_matched=True, priority=50)
-        address_tag = _scored_tag("Address", score=0.85, column_name_matched=False, priority=80)
+        location_tag = _scored_tag(
+            "Location", score=0.85, column_name_matched=True, priority=50
+        )
+        address_tag = _scored_tag(
+            "Address", score=0.85, column_name_matched=False, priority=80
+        )
 
         resolver = ConflictResolver()
-        winner = resolver._select_winner([address_tag, location_tag], ConflictResolution.highest_confidence)
+        winner = resolver._select_winner(
+            [address_tag, location_tag], ConflictResolution.highest_confidence
+        )
 
         assert winner.tag.name.root == "Location"
 
     def test_select_winner_priority_breaks_tie_when_both_match(self):
         """When both siblings match the column name, higher priority (more specific) wins."""
-        datetime_tag = _scored_tag("DateTime", score=1.0, column_name_matched=True, priority=50)
-        birthdate_tag = _scored_tag("BirthDate", score=1.0, column_name_matched=True, priority=60)
+        datetime_tag = _scored_tag(
+            "DateTime", score=1.0, column_name_matched=True, priority=50
+        )
+        birthdate_tag = _scored_tag(
+            "BirthDate", score=1.0, column_name_matched=True, priority=60
+        )
 
         resolver = ConflictResolver()
-        winner = resolver._select_winner([datetime_tag, birthdate_tag], ConflictResolution.highest_confidence)
+        winner = resolver._select_winner(
+            [datetime_tag, birthdate_tag], ConflictResolution.highest_confidence
+        )
 
         assert winner.tag.name.root == "BirthDate"

--- a/ingestion/tests/unit/metadata/pii/test_conflict_resolver.py
+++ b/ingestion/tests/unit/metadata/pii/test_conflict_resolver.py
@@ -32,6 +32,17 @@ from metadata.pii.conflict_resolver import ConflictResolver
 from metadata.pii.models import ScoredTag
 
 
+def _scored_tag(name: str, score: float, column_name_matched: bool, priority: int) -> ScoredTag:
+    return ScoredTagFactory.create(
+        tag__tag_name=name,
+        tag__tag_classification__fqn="General",
+        tag__autoClassificationPriority=priority,
+        score=score,
+        reason=f"{name} match",
+        column_name_matched=column_name_matched,
+    )
+
+
 class TestConflictResolver:
     """Tests for ConflictResolver."""
 
@@ -278,3 +289,33 @@ class TestConflictResolver:
         # With highest_confidence, should use priority as tie-breaker
         assert winner.tag.name.root == "Email"
         assert winner.priority == 80
+
+    def test_select_winner_column_name_match_breaks_score_tie(self):
+        """Siblings tie on score (shared content recognizer); the column-name match wins."""
+        datetime_tag = _scored_tag("DateTime", score=1.0, column_name_matched=True, priority=50)
+        birthdate_tag = _scored_tag("BirthDate", score=1.0, column_name_matched=False, priority=50)
+
+        resolver = ConflictResolver()
+        winner = resolver._select_winner([birthdate_tag, datetime_tag], ConflictResolution.highest_confidence)
+
+        assert winner.tag.name.root == "DateTime"
+
+    def test_select_winner_column_name_match_outranks_priority(self):
+        """A column-name match beats a higher static priority: per-column evidence wins over the prior."""
+        location_tag = _scored_tag("Location", score=0.85, column_name_matched=True, priority=50)
+        address_tag = _scored_tag("Address", score=0.85, column_name_matched=False, priority=80)
+
+        resolver = ConflictResolver()
+        winner = resolver._select_winner([address_tag, location_tag], ConflictResolution.highest_confidence)
+
+        assert winner.tag.name.root == "Location"
+
+    def test_select_winner_priority_breaks_tie_when_both_match(self):
+        """When both siblings match the column name, higher priority (more specific) wins."""
+        datetime_tag = _scored_tag("DateTime", score=1.0, column_name_matched=True, priority=50)
+        birthdate_tag = _scored_tag("BirthDate", score=1.0, column_name_matched=True, priority=60)
+
+        resolver = ConflictResolver()
+        winner = resolver._select_winner([datetime_tag, birthdate_tag], ConflictResolution.highest_confidence)
+
+        assert winner.tag.name.root == "BirthDate"


### PR DESCRIPTION
### Cherry-pick #29474 into 1.13 — fix sibling-tag score tie-breaking in auto-classification
#### What this does
- Cherry-picks upstream OpenMetadata PR #29474 (commit 49fdfa538c, "Fixes #29473: fix(auto-classification): break sibling-tag score ties by column-name match") onto the 1.13 .

### Conflicts faced during cherry-pick
- 3 of the 5 files conflicted; tag_scoring.py and the test file auto-merged. All conflicts were cosmetic — none involved the fix's logic — arising because the fix was authored on a newer base than 1.13:

1) models.py — conflict on the recognizer_metadata line: 1.13 has no # noqa: UP045 suffix, the fix's base does. Resolved by keeping 1.13's un-suffixed line and adding the new column_name_matched: bool = False field.

2) tag_analyzer.py (TagAnalysis field block) — same # noqa: UP045 / UP006 suffix difference on the explanation / recognizer_results / target lines. Resolved by keeping 1.13's un-suffixed lines and adding the new field. (The second hunk — column_name_matched=bool(column_results) in analyze() — auto-merged.)

3) conflict_resolver.py — the logger.debug(...) call is wrapped across multiple lines on 1.13 (black formatting) vs. single-line in the fix. Resolved by taking the fix's new sort key + explanatory comment while preserving 1.13's multi-line logger.debug formatting.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR updates PII auto-classification tie-breaking for sibling tags. The main changes are:

- Adds a `column_name_matched` flag to tag analysis and scored tags.
- Propagates the flag into conflict resolution.
- Breaks equal-score tag ties with column-name evidence before static priority.
- Adds unit tests for the new resolver ordering.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

This is close, but the tie-break fix should be corrected before merging.

- A tag can still carry column-name tie-break evidence when its column-name score lost to content evidence.
- Equal-score siblings can still be ordered by a weaker signal that did not produce the returned score.

ingestion/src/metadata/pii/tag_analyzer.py
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| ingestion/src/metadata/pii/tag_analyzer.py | Adds the column-name match flag, but it is still set for weaker column evidence that did not win. |
| ingestion/src/metadata/pii/algorithms/tag_scoring.py | Passes the new analysis flag into scored tag results. |
| ingestion/src/metadata/pii/conflict_resolver.py | Uses the new flag to break equal-score conflicts before priority. |
| ingestion/src/metadata/pii/models.py | Adds a backward-compatible default for the new scored tag field. |
| ingestion/tests/unit/metadata/pii/test_conflict_resolver.py | Adds direct tests for resolver ordering with column-name tie-breaks. |

</details>

<sub>Reviews (2): Last reviewed commit: ["pyformat fix"](https://github.com/open-metadata/openmetadata/commit/d10ab80ced087978624f1161a8d03a7746e40d9a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43829714)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Context used - CLAUDE.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=52f0d9d9-cad1-4e7d-b070-de181a0aa5e7))
- Context used - openmetadata-ui-core-components/CLAUDE.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=41754627-b2bf-474b-8082-f37ef1a07013))

<!-- /greptile_comment -->