### PR TITLE
Migrate CoverImage component from MUI to Tailwind CSS

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/common/CoverImage/CoverImage.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/CoverImage/CoverImage.component.tsx
@@ -10,7 +10,6 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-import { Box, useTheme } from '@mui/material';
 import imageClassBase from '../../BlockEditor/Extensions/image/ImageClassBase';
 
 interface CoverImageProps {
@@ -19,8 +18,6 @@ interface CoverImageProps {
 }
 
 export const CoverImage = ({ imageUrl, position }: CoverImageProps) => {
-  const theme = useTheme();
-  // Get authenticated image hook from ImageClassBase (paid version override)
   const authenticatedImageUrl = imageClassBase.getAuthenticatedImageUrl();
 
   // Always call unconditionally to avoid React Hook Rules violation
@@ -35,45 +32,31 @@ export const CoverImage = ({ imageUrl, position }: CoverImageProps) => {
       imageSrc.startsWith('blob:'));
 
   return (
-    <Box
-      data-testid="cover-image-container"
-      sx={{
-        height: '131px',
-        borderRadius: 1.5,
-        margin: '-1px -1px -1px 0',
-        overflow: 'hidden',
-        position: 'relative',
-      }}>
+    <div
+      className="tw:h-[131px] tw:rounded-xl tw:-mt-px tw:-mr-px tw:-mb-px tw:ml-0 tw:overflow-hidden tw:relative"
+      data-testid="cover-image-container">
       {showImage ? (
-        <Box
+        <img
           alt="Cover"
-          component="img"
+          className="tw:w-full tw:h-auto tw:min-h-[131px] tw:object-cover tw:object-[center_top] tw:block"
           data-testid="cover-image"
           src={imageSrc}
-          sx={{
-            width: '100%',
-            height: 'auto',
-            minHeight: 131,
-            objectFit: 'cover',
-            objectPosition: 'center top',
-            transform: position?.y ? `translateY(${position.y})` : 'none',
-            display: 'block',
-          }}
+          style={
+            position?.y ? { transform: `translateY(${position.y})` } : undefined
+          }
         />
       ) : (
-        <Box
+        <div
+          className={
+            isLoading
+              ? 'tw:w-full tw:h-full tw:bg-tertiary'
+              : 'tw:w-full tw:h-full tw:bg-[linear-gradient(271.49deg,#00D2FF_-11.47%,#03A0FF_59.48%,#016AFB_115.84%)]'
+          }
           data-testid={
             isLoading ? 'cover-image-loading' : 'cover-image-placeholder'
           }
-          sx={{
-            width: '100%',
-            height: '100%',
-            background: isLoading
-              ? theme.palette.grey[100]
-              : 'linear-gradient(271.49deg, #00D2FF -11.47%, #03A0FF 59.48%, #016AFB 115.84%)',
-          }}
         />
       )}
-    </Box>
+    </div>
   );
 };

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/CoverImage/CoverImage.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/CoverImage/CoverImage.test.tsx
@@ -53,7 +53,9 @@ describe('CoverImage', () => {
 
     expect(image).toBeInTheDocument();
     expect(image).toHaveAttribute('src', 'https://example.com/img.png');
-    expect(image).not.toHaveStyle({ transform: expect.stringContaining('translateY') });
+    expect(image).not.toHaveStyle({
+      transform: expect.stringContaining('translateY'),
+    });
   });
 
   it('renders loading element while authenticated URL is resolving', () => {
@@ -100,6 +102,8 @@ describe('CoverImage', () => {
 
     const image = screen.getByTestId('cover-image');
 
-    expect(image).not.toHaveStyle({ transform: expect.stringContaining('translateY') });
+    expect(image).not.toHaveStyle({
+      transform: expect.stringContaining('translateY'),
+    });
   });
 });

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/CoverImage/CoverImage.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/CoverImage/CoverImage.test.tsx
@@ -1,0 +1,105 @@
+/*
+ *  Copyright 2025 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+import { render, screen } from '@testing-library/react';
+
+jest.mock('../../BlockEditor/Extensions/image/ImageClassBase', () => ({
+  __esModule: true,
+  default: {
+    getAuthenticatedImageUrl: jest.fn(),
+  },
+}));
+
+import imageClassBase from '../../BlockEditor/Extensions/image/ImageClassBase';
+import { CoverImage } from './CoverImage.component';
+
+const mockGetAuthenticatedImageUrl =
+  imageClassBase.getAuthenticatedImageUrl as jest.Mock;
+
+describe('CoverImage', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetAuthenticatedImageUrl.mockReturnValue(undefined);
+  });
+
+  it('renders gradient placeholder when no imageUrl is given', () => {
+    render(<CoverImage />);
+
+    expect(screen.getByTestId('cover-image-container')).toBeInTheDocument();
+    expect(screen.getByTestId('cover-image-placeholder')).toBeInTheDocument();
+    expect(screen.queryByTestId('cover-image')).not.toBeInTheDocument();
+  });
+
+  it('renders gradient placeholder when imageUrl is an empty string', () => {
+    render(<CoverImage imageUrl="" />);
+
+    expect(screen.getByTestId('cover-image-placeholder')).toBeInTheDocument();
+    expect(screen.queryByTestId('cover-image')).not.toBeInTheDocument();
+  });
+
+  it('renders the image for a public imageUrl when no auth hook is present', () => {
+    render(<CoverImage imageUrl="https://example.com/img.png" />);
+
+    const image = screen.getByTestId('cover-image');
+
+    expect(image).toBeInTheDocument();
+    expect(image).toHaveAttribute('src', 'https://example.com/img.png');
+    expect(image).not.toHaveStyle({ transform: expect.stringContaining('translateY') });
+  });
+
+  it('renders loading element while authenticated URL is resolving', () => {
+    mockGetAuthenticatedImageUrl.mockReturnValue(() => ({
+      imageSrc: '/api/v1/attachments/123',
+      isLoading: true,
+    }));
+
+    render(<CoverImage imageUrl="/api/v1/attachments/123" />);
+
+    expect(screen.getByTestId('cover-image-loading')).toBeInTheDocument();
+    expect(screen.queryByTestId('cover-image')).not.toBeInTheDocument();
+  });
+
+  it('renders image when authenticated blob URL is ready', () => {
+    mockGetAuthenticatedImageUrl.mockReturnValue(() => ({
+      imageSrc: 'blob:http://localhost/abc',
+      isLoading: false,
+    }));
+
+    render(<CoverImage imageUrl="/api/v1/attachments/123" />);
+
+    const image = screen.getByTestId('cover-image');
+
+    expect(image).toBeInTheDocument();
+    expect(image).toHaveAttribute('src', 'blob:http://localhost/abc');
+  });
+
+  it('applies translateY transform when position.y is provided', () => {
+    render(
+      <CoverImage
+        imageUrl="https://example.com/img.png"
+        position={{ y: '-16%' }}
+      />
+    );
+
+    const image = screen.getByTestId('cover-image');
+
+    expect(image).toHaveStyle({ transform: 'translateY(-16%)' });
+  });
+
+  it('does not apply transform when position.y is absent', () => {
+    render(<CoverImage imageUrl="https://example.com/img.png" />);
+
+    const image = screen.getByTestId('cover-image');
+
+    expect(image).not.toHaveStyle({ transform: expect.stringContaining('translateY') });
+  });
+});


### PR DESCRIPTION
### Describe your changes:

<img width="1512" height="826" alt="Screenshot 2026-07-13 at 7 57 13 PM" src="https://github.com/user-attachments/assets/a8b49bcd-e68a-49a4-84b2-7bca17a1ea81" />

Fixes [5006](https://github.com/open-metadata/openmetadata-collate/issues/5006)

I worked on migrating the `CoverImage` display component away from MUI (`Box`, `useTheme`, `sx` props) because the project is actively removing MUI in favour of `openmetadata-ui-core-components` + Tailwind CSS v4. All styling is now expressed as `tw:` Tailwind classes with semantic color tokens per `colors.md` (e.g. `tw:bg-tertiary` for the loading skeleton). The dynamic `translateY` for image repositioning retains a minimal `style` prop since it is a runtime value. Unit tests are added covering placeholder, loading, authenticated-URL, and position-transform cases.

### Type of change:
- [x] Improvement

#
### High-level design:

N/A — small change.

#
### Tests:

#### Use cases covered
- CoverImage renders gradient placeholder when no `imageUrl` is provided
- CoverImage renders loading skeleton (`tw:bg-tertiary`) while authenticated URL resolves
- CoverImage renders image for public URLs (no auth hook)
- CoverImage renders image once blob URL is ready for attachment URLs
- `translateY` transform applied / omitted based on `position.y` prop

#### Unit tests
- [x] I added unit tests for the new/changed logic.
- Files added/updated: `openmetadata-ui/src/main/resources/ui/src/components/common/CoverImage/CoverImage.test.tsx`

#### Backend integration tests
- [x] Not applicable (no backend API changes).

#### Ingestion integration tests
- [x] Not applicable (no ingestion changes).

#### Playwright (UI) tests
- [x] Not applicable (no UI changes).

#### Manual testing performed

N/A — component refactor with no behaviour change; covered by unit tests.

#
### UI screen recording / screenshots:

Not applicable.

#
### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] I have added tests (unit / integration / Playwright as applicable) and listed them above.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR migrates the `CoverImage` component from MUI styling to Tailwind classes. The main changes are:

- Native `div` and `img` elements replace MUI `Box`.
- Tailwind-prefixed classes replace `sx` styles for layout, clipping, and backgrounds.
- The image position transform remains inline because it uses runtime data.
- Unit tests cover placeholder, loading, public URL, blob URL, and transform behavior.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge.

- No blocking issues found in the changed code.

</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-ui/src/main/resources/ui/src/components/common/CoverImage/CoverImage.component.tsx | Migrates the component markup and styling from MUI to Tailwind while keeping authenticated image loading and position transforms. |
| openmetadata-ui/src/main/resources/ui/src/components/common/CoverImage/CoverImage.test.tsx | Adds unit tests for the main rendering states and transform behavior. |

</details>

<sub>Reviews (2): Last reviewed commit: ["lint fix"](https://github.com/open-metadata/openmetadata/commit/b244ba3370c3b00eeb98e80afafb7c7ced49b794) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43836338)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Context used - CLAUDE.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=52f0d9d9-cad1-4e7d-b070-de181a0aa5e7))
- Context used - openmetadata-ui-core-components/CLAUDE.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=41754627-b2bf-474b-8082-f37ef1a07013))
- Context used - AGENTS.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=ef262f5f-911f-44f3-8d2d-e9cb1579c8c8))
</details>

<!-- /greptile_comment -->