### PR TITLE
test(data-quality): de-flake Table filter test against migration data

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/Table.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/Table.spec.ts
@@ -155,6 +155,27 @@ test.describe('Table pagination sorting search scenarios ', () => {
       .first()
       .waitFor({ state: 'detached' });
 
+    // Migration static data seeds test cases across every status (including
+    // Queued), so the status filter alone no longer yields an empty list.
+    // Combine it with a search term that matches nothing to deterministically
+    // land on the empty-state placeholder.
+    const noMatchSearch = `no-match-${uuid()}`;
+    const emptySearchResponse = page.waitForResponse(
+      (response) =>
+        response.url().includes('/api/v1/dataQuality/testCases/search/list') &&
+        response.url().includes(noMatchSearch)
+    );
+    await page.locator('[data-testid="searchbar-component"] input').click();
+    await page
+      .locator('[data-testid="searchbar-component"] input')
+      .fill(noMatchSearch);
+    await emptySearchResponse;
+    await page
+      .getByTestId('test-case-container')
+      .getByTestId('loader')
+      .first()
+      .waitFor({ state: 'detached' });
+
     await expect(page.getByTestId('search-error-placeholder')).toBeVisible();
   });
 


### PR DESCRIPTION
## Problem

`playwright/e2e/Features/Table.spec.ts` › **Table filter with sorting should work** filters test cases by the **Queued** status and asserts the empty-state placeholder (`search-error-placeholder`). That assumption only holds when no test case is Queued.

When migration static data is seeded, the generator assigns test-case results across **every** status (Success → Failed → Aborted → Queued, round-robin), so the Queued filter now returns rows, the placeholder never renders, and the test fails at the 15s `toBeVisible()`:

```
Error: expect(getByTestId('search-error-placeholder')).toBeVisible() failed
  waiting for getByTestId('search-error-placeholder')  — element(s) not found
```

## Fix

Keep the Queued filter, then add a **no-match search term** (`no-match-<uuid>`) so the combined result set is deterministically empty regardless of how many Queued test cases exist — reliably reaching the empty-state placeholder. This mirrors the sibling *"Table search with sorting should work"* test, which already searches a non-matching term to reach the same placeholder.

## Verification

Reproduced locally by injecting Queued test-case results via the API, then running the test against a live server:

- **Original** + Queued data → ❌ fails (`search-error-placeholder` not found — matches the CI failure exactly)
- **Patched** + Queued data → ✅ passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR makes the table filter Playwright test deterministic when seeded data includes Queued test cases. The main changes are:

- Keeps the Queued status filter in the existing sorting test.
- Adds a unique no-match search term before checking the empty state.
- Waits for the matching test-case search response and loader dismissal.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge.

- No blocking issues found in the changed code.

</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/Table.spec.ts | Adds a unique no-match search after the Queued filter so the empty-state assertion no longer depends on seeded test-case status distribution. |

</details>

<sub>Reviews (1): Last reviewed commit: ["test(data-quality): de-flake Table filte..."](https://github.com/open-metadata/openmetadata/commit/e7bbe4c76ee609a04f701883d75d7347dfa428d7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43853841)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Context used - CLAUDE.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=52f0d9d9-cad1-4e7d-b070-de181a0aa5e7))
- Context used - openmetadata-ui-core-components/CLAUDE.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=41754627-b2bf-474b-8082-f37ef1a07013))
- Context used - AGENTS.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=ef262f5f-911f-44f3-8d2d-e9cb1579c8c8))
</details>

<!-- /greptile_comment -->