### PR TITLE
Fixes #29999: Propagate active persona request context

### DIFF
--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/ActivePersonaHeaderIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/ActivePersonaHeaderIT.java
@@ -1,0 +1,224 @@
+/*
+ *  Copyright 2026 Collate
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.openmetadata.it.tests;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import java.util.List;
+import java.util.Locale;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.openmetadata.it.auth.JwtAuthProvider;
+import org.openmetadata.it.util.SdkClients;
+import org.openmetadata.it.util.TestNamespace;
+import org.openmetadata.it.util.TestNamespaceExtension;
+import org.openmetadata.schema.api.CreateBot;
+import org.openmetadata.schema.api.teams.CreatePersona;
+import org.openmetadata.schema.api.teams.CreateTeam;
+import org.openmetadata.schema.api.teams.CreateUser;
+import org.openmetadata.schema.auth.JWTAuthMechanism;
+import org.openmetadata.schema.auth.JWTTokenExpiry;
+import org.openmetadata.schema.entity.Bot;
+import org.openmetadata.schema.entity.teams.AuthenticationMechanism;
+import org.openmetadata.schema.entity.teams.Persona;
+import org.openmetadata.schema.entity.teams.User;
+import org.openmetadata.sdk.client.OpenMetadataClient;
+import org.openmetadata.sdk.config.OpenMetadataConfig;
+import org.openmetadata.sdk.network.HttpMethod;
+import org.openmetadata.service.Entity;
+
+@Execution(ExecutionMode.CONCURRENT)
+@ExtendWith(TestNamespaceExtension.class)
+class ActivePersonaHeaderIT {
+  private static final String ACTIVE_PERSONA_HEADER = "X-OpenMetadata-Persona";
+  private static final String IMPERSONATE_USER_HEADER = "X-Impersonate-User";
+  private static final String MY_PERSONA_CONTEXT_PATH = "/v1/personas/me/context?format=json";
+
+  @Test
+  void activePersonaHeaderSelectsAssignedPersonaAndFallsBackToDefault(TestNamespace ns) {
+    Persona defaultPersona = createPersona(ns, "default");
+    Persona selectedPersona = createPersona(ns, "selected");
+    Persona unassignedPersona = createPersona(ns, "unassigned");
+    User user =
+        createUser(
+            ns,
+            "direct_user",
+            new CreateUser()
+                .withPersonas(
+                    List.of(
+                        defaultPersona.getEntityReference(), selectedPersona.getEntityReference()))
+                .withDefaultPersona(defaultPersona.getEntityReference()));
+
+    assertEquals(defaultPersona.getId().toString(), activePersonaId(user, null));
+    assertEquals(
+        selectedPersona.getId().toString(),
+        activePersonaId(user, selectedPersona.getId().toString()));
+    assertEquals(
+        selectedPersona.getId().toString(),
+        activePersonaId(user, selectedPersona.getName().toUpperCase(Locale.ROOT)));
+    assertEquals(
+        defaultPersona.getId().toString(),
+        activePersonaId(user, unassignedPersona.getId().toString()));
+    assertEquals(defaultPersona.getId().toString(), activePersonaId(user, "stale-persona"));
+  }
+
+  @Test
+  void activePersonaHeaderSelectsTeamInheritedPersona(TestNamespace ns) {
+    Persona inheritedPersona = createPersona(ns, "inherited");
+    User user = createUser(ns, "inherited_user", new CreateUser());
+    ns.trackRoot(
+        Entity.TEAM,
+        SdkClients.adminClient()
+            .teams()
+            .create(
+                new CreateTeam()
+                    .withName(ns.shortPrefix("active_persona_team"))
+                    .withTeamType(CreateTeam.TeamType.GROUP)
+                    .withUsers(List.of(user.getId()))
+                    .withDefaultPersona(inheritedPersona.getId())));
+
+    assertEquals(
+        inheritedPersona.getId().toString(),
+        activePersonaId(user, inheritedPersona.getId().toString()));
+  }
+
+  @Test
+  void personaSideAssignmentsInvalidateCachedUserContext(TestNamespace ns) {
+    Persona defaultPersona = createPersona(ns, "cache_default");
+    Persona selectedPersona = createPersona(ns, "cache_selected");
+    User user =
+        createUser(
+            ns,
+            "cache_user",
+            new CreateUser()
+                .withPersonas(List.of(defaultPersona.getEntityReference()))
+                .withDefaultPersona(defaultPersona.getEntityReference()));
+
+    assertEquals(
+        defaultPersona.getId().toString(),
+        activePersonaId(user, selectedPersona.getId().toString()));
+
+    Persona personaWithUsers =
+        SdkClients.adminClient().personas().get(selectedPersona.getId().toString(), "users");
+    personaWithUsers.setUsers(List.of(user.getEntityReference()));
+    SdkClients.adminClient()
+        .personas()
+        .update(selectedPersona.getId().toString(), personaWithUsers);
+    assertEquals(
+        selectedPersona.getId().toString(),
+        activePersonaId(user, selectedPersona.getId().toString()));
+
+    personaWithUsers =
+        SdkClients.adminClient().personas().get(selectedPersona.getId().toString(), "users");
+    personaWithUsers.setUsers(List.of());
+    SdkClients.adminClient()
+        .personas()
+        .update(selectedPersona.getId().toString(), personaWithUsers);
+    assertEquals(
+        defaultPersona.getId().toString(),
+        activePersonaId(user, selectedPersona.getId().toString()));
+  }
+
+  @Test
+  void activePersonaResolvesAgainstImpersonatedUser(TestNamespace ns) {
+    Persona defaultPersona = createPersona(ns, "impersonated_default");
+    Persona selectedPersona = createPersona(ns, "impersonated_selected");
+    User targetUser =
+        createUser(
+            ns,
+            "impersonated_user",
+            new CreateUser()
+                .withPersonas(
+                    List.of(
+                        defaultPersona.getEntityReference(), selectedPersona.getEntityReference()))
+                .withDefaultPersona(defaultPersona.getEntityReference()));
+    User botUser = createBotUser(ns);
+    Bot bot =
+        SdkClients.adminClient()
+            .bots()
+            .create(
+                new CreateBot()
+                    .withName(ns.shortPrefix("active_persona_bot"))
+                    .withDescription("Active persona impersonation integration test")
+                    .withBotUser(botUser.getName())
+                    .withAllowImpersonation(true));
+
+    try {
+      JWTAuthMechanism authentication =
+          SdkClients.adminClient().users().generateToken(botUser.getId(), JWTTokenExpiry.Seven);
+      assertEquals(
+          selectedPersona.getId().toString(),
+          activePersonaId(
+              authentication.getJWTToken(),
+              selectedPersona.getId().toString(),
+              targetUser.getName()));
+    } finally {
+      SdkClients.adminClient().bots().delete(bot.getId().toString());
+    }
+  }
+
+  private Persona createPersona(TestNamespace ns, String suffix) {
+    return ns.trackRoot(
+        Entity.PERSONA,
+        SdkClients.adminClient()
+            .personas()
+            .create(
+                new CreatePersona()
+                    .withName(ns.shortPrefix("active_persona_" + suffix))
+                    .withDescription("Active persona header integration test")));
+  }
+
+  private User createUser(TestNamespace ns, String suffix, CreateUser request) {
+    String name = ns.shortPrefix("active_persona_" + suffix);
+    request.withName(name).withEmail(name + "@example.com");
+    return ns.trackRoot(Entity.USER, SdkClients.adminClient().users().create(request));
+  }
+
+  private User createBotUser(TestNamespace ns) {
+    AuthenticationMechanism authenticationMechanism =
+        new AuthenticationMechanism()
+            .withAuthType(AuthenticationMechanism.AuthType.JWT)
+            .withConfig(new JWTAuthMechanism().withJWTTokenExpiry(JWTTokenExpiry.Unlimited));
+    return createUser(
+        ns,
+        "bot_user",
+        new CreateUser().withIsBot(true).withAuthenticationMechanism(authenticationMechanism));
+  }
+
+  private String activePersonaId(User user, String requestedPersona) {
+    String accessToken =
+        JwtAuthProvider.tokenFor(user.getEmail(), user.getEmail(), new String[] {}, 3_600);
+    return activePersonaId(accessToken, requestedPersona, null);
+  }
+
+  private String activePersonaId(
+      String accessToken, String requestedPersona, String impersonatedUser) {
+    OpenMetadataConfig.Builder config =
+        OpenMetadataConfig.builder().serverUrl(SdkClients.baseUrl()).accessToken(accessToken);
+    if (requestedPersona != null) {
+      config.header(ACTIVE_PERSONA_HEADER, requestedPersona);
+    }
+    if (impersonatedUser != null) {
+      config.header(IMPERSONATE_USER_HEADER, impersonatedUser);
+    }
+    OpenMetadataClient client = new OpenMetadataClient(config.build());
+    JsonNode context =
+        client
+            .getHttpClient()
+            .execute(HttpMethod.GET, MY_PERSONA_CONTEXT_PATH, null, JsonNode.class);
+    return context.path("persona").path("id").asText();
+  }
+}

--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/ActivePersonaHeaderIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/ActivePersonaHeaderIT.java
@@ -35,6 +35,7 @@ import org.openmetadata.schema.entity.Bot;
 import org.openmetadata.schema.entity.teams.AuthenticationMechanism;
 import org.openmetadata.schema.entity.teams.Persona;
 import org.openmetadata.schema.entity.teams.User;
+import org.openmetadata.schema.type.EntityReference;
 import org.openmetadata.sdk.client.OpenMetadataClient;
 import org.openmetadata.sdk.config.OpenMetadataConfig;
 import org.openmetadata.sdk.network.HttpMethod;
@@ -113,7 +114,7 @@ class ActivePersonaHeaderIT {
 
     Persona personaWithUsers =
         SdkClients.adminClient().personas().get(selectedPersona.getId().toString(), "users");
-    personaWithUsers.setUsers(List.of(user.getEntityReference()));
+    personaWithUsers.setUsers(List.of(new EntityReference().withId(user.getId())));
     SdkClients.adminClient()
         .personas()
         .update(selectedPersona.getId().toString(), personaWithUsers);
@@ -130,6 +131,30 @@ class ActivePersonaHeaderIT {
     assertEquals(
         defaultPersona.getId().toString(),
         activePersonaId(user, selectedPersona.getId().toString()));
+  }
+
+  @Test
+  void userDefaultPersonaChangeInvalidatesCachedUserContext(TestNamespace ns) {
+    Persona originalDefault = createPersona(ns, "original_default");
+    Persona updatedDefault = createPersona(ns, "updated_default");
+    User user =
+        createUser(
+            ns,
+            "updated_default_user",
+            new CreateUser()
+                .withPersonas(
+                    List.of(
+                        originalDefault.getEntityReference(), updatedDefault.getEntityReference()))
+                .withDefaultPersona(originalDefault.getEntityReference()));
+
+    assertEquals(originalDefault.getId().toString(), activePersonaId(user, null));
+
+    User updatedUser =
+        SdkClients.adminClient().users().get(user.getId().toString(), "personas,defaultPersona");
+    updatedUser.setDefaultPersona(updatedDefault.getEntityReference());
+    SdkClients.adminClient().users().update(user.getId().toString(), updatedUser);
+
+    assertEquals(updatedDefault.getId().toString(), activePersonaId(user, null));
   }
 
   @Test

--- a/openmetadata-service/src/main/java/org/openmetadata/service/aicontext/PersonaContextAccess.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/aicontext/PersonaContextAccess.java
@@ -25,6 +25,8 @@ import org.openmetadata.service.security.policyevaluator.SubjectContext;
 
 /** Persona-membership authorization shared by the REST endpoint and MCP tool. */
 public final class PersonaContextAccess {
+  private static final String CONTEXT_DEFINITION_FIELD = "contextDefinition";
+
   private PersonaContextAccess() {}
 
   public static void authorize(SecurityContext securityContext, Persona persona) {
@@ -32,8 +34,7 @@ public final class PersonaContextAccess {
     if (subject.isAdmin() || subject.isBot()) {
       return;
     }
-    UserRepository users = (UserRepository) Entity.getEntityRepository(Entity.USER);
-    if (!users.hasPersona(subject.user(), persona.getId())) {
+    if (!subject.hasPersona(persona.getId())) {
       throw new AuthorizationException(
           "User is not assigned to persona " + persona.getFullyQualifiedName());
     }
@@ -41,13 +42,29 @@ public final class PersonaContextAccess {
 
   public static Persona activePersona(SecurityContext securityContext) {
     SubjectContext subject = DefaultAuthorizer.getSubjectContext(securityContext);
+    Persona persona = loadPersona(subject.getActivePersona());
+    if (persona != null) {
+      return persona;
+    }
     UserRepository users = (UserRepository) Entity.getEntityRepository(Entity.USER);
     EntityReference personaReference = users.getDefaultPersona(subject.user());
-    if (personaReference == null) {
+    persona = loadPersona(personaReference);
+    if (persona == null) {
       throw EntityNotFoundException.byMessage("No active persona is configured for this user");
     }
-    return Entity.getEntity(
-        Entity.PERSONA, personaReference.getId(), "contextDefinition", Include.NON_DELETED);
+    return persona;
+  }
+
+  private static Persona loadPersona(EntityReference personaReference) {
+    if (personaReference == null) {
+      return null;
+    }
+    try {
+      return Entity.getEntity(
+          Entity.PERSONA, personaReference.getId(), CONTEXT_DEFINITION_FIELD, Include.NON_DELETED);
+    } catch (EntityNotFoundException e) {
+      return null;
+    }
   }
 
   public static void authorizeRefresh(SecurityContext securityContext) {

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/PersonaRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/PersonaRepository.java
@@ -19,6 +19,7 @@ import static org.openmetadata.service.Entity.PERSONA;
 import static org.openmetadata.service.Entity.USER;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
@@ -365,16 +366,9 @@ public class PersonaRepository extends EntityRepository<Persona> {
 
   private void invalidateUserContexts(
       List<EntityReference> originalUsers, List<EntityReference> updatedUsers) {
-    Set<String> userNames = new HashSet<>();
-    listOrEmpty(originalUsers).stream()
-        .map(EntityReference::getName)
-        .filter(name -> !nullOrEmpty(name))
-        .forEach(userNames::add);
-    listOrEmpty(updatedUsers).stream()
-        .map(EntityReference::getName)
-        .filter(name -> !nullOrEmpty(name))
-        .forEach(userNames::add);
-    userNames.forEach(SubjectCache::invalidateUserContext);
+    List<EntityReference> affectedUsers = new ArrayList<>(listOrEmpty(originalUsers));
+    affectedUsers.addAll(listOrEmpty(updatedUsers));
+    SubjectCache.invalidateUserContexts(affectedUsers);
   }
 
   /** Handles entity updated from PUT and POST operation. */

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/PersonaRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/PersonaRepository.java
@@ -342,11 +342,6 @@ public class PersonaRepository extends EntityRepository<Persona> {
   protected void postUpdate(Persona original, Persona updated) {
     super.postUpdate(original, updated);
     PersonaContextCache.getInstance().invalidate(original, updated);
-    if (!Objects.equals(original.getDefault(), updated.getDefault())) {
-      SubjectCache.invalidateAllUserContexts();
-    } else if (!userAssignmentsMatch(original.getUsers(), updated.getUsers())) {
-      invalidateUserContexts(original.getUsers(), updated.getUsers());
-    }
   }
 
   @Override
@@ -395,6 +390,7 @@ public class PersonaRepository extends EntityRepository<Persona> {
     private void updateUsers(Persona origPersona, Persona updatedPersona) {
       List<EntityReference> origUsers = listOrEmpty(origPersona.getUsers());
       List<EntityReference> updatedUsers = listOrEmpty(updatedPersona.getUsers());
+      boolean assignmentsChanged = !userAssignmentsMatch(origUsers, updatedUsers);
       updateToRelationships(
           "users",
           PERSONA,
@@ -404,6 +400,11 @@ public class PersonaRepository extends EntityRepository<Persona> {
           origUsers,
           updatedUsers,
           false);
+      if (assignmentsChanged) {
+        List<EntityReference> affectedUsers = new ArrayList<>(origUsers);
+        affectedUsers.addAll(updatedUsers);
+        deferReactOperation(() -> SubjectCache.invalidateUserContexts(affectedUsers));
+      }
     }
 
     private void updateDefault(Persona origPersona, Persona updatedPersona) {
@@ -411,6 +412,7 @@ public class PersonaRepository extends EntityRepository<Persona> {
       Boolean updatedDefault = updatedPersona.getDefault();
       if (!Objects.equals(origDefault, updatedDefault)) {
         recordChange("default", origDefault, updatedDefault);
+        deferReactOperation(SubjectCache::invalidateAllUserContexts);
       }
     }
   }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/PersonaRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/PersonaRepository.java
@@ -401,9 +401,7 @@ public class PersonaRepository extends EntityRepository<Persona> {
           updatedUsers,
           false);
       if (assignmentsChanged) {
-        List<EntityReference> affectedUsers = new ArrayList<>(origUsers);
-        affectedUsers.addAll(updatedUsers);
-        deferReactOperation(() -> SubjectCache.invalidateUserContexts(affectedUsers));
+        deferReactOperation(() -> invalidateUserContexts(origUsers, updatedUsers));
       }
     }
 

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/PersonaRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/PersonaRepository.java
@@ -39,6 +39,7 @@ import org.openmetadata.service.Entity;
 import org.openmetadata.service.aicontext.PersonaContextBuilder;
 import org.openmetadata.service.aicontext.PersonaContextCache;
 import org.openmetadata.service.resources.teams.PersonaResource;
+import org.openmetadata.service.security.policyevaluator.SubjectCache;
 import org.openmetadata.service.util.EntityUtil.Fields;
 import org.openmetadata.service.util.EntityUtil.RelationIncludes;
 
@@ -287,6 +288,16 @@ public class PersonaRepository extends EntityRepository<Persona> {
   }
 
   @Override
+  protected void postCreate(Persona persona) {
+    super.postCreate(persona);
+    if (Boolean.TRUE.equals(persona.getDefault())) {
+      SubjectCache.invalidateAllUserContexts();
+    } else {
+      invalidateUserContexts(persona.getUsers(), List.of());
+    }
+  }
+
+  @Override
   @Transaction
   protected void preDelete(Persona persona, String deletedBy) {
     // Remove all user-persona relationships (APPLIED_TO)
@@ -319,18 +330,51 @@ public class PersonaRepository extends EntityRepository<Persona> {
     for (EntityReference team : listOrEmpty(teams)) {
       invalidateCacheForEntity(Entity.TEAM, team.getId(), team.getFullyQualifiedName());
     }
+    if (Boolean.TRUE.equals(persona.getDefault()) || !teams.isEmpty()) {
+      SubjectCache.invalidateAllUserContexts();
+    } else {
+      invalidateUserContexts(users, defaultUsers);
+    }
   }
 
   @Override
   protected void postUpdate(Persona original, Persona updated) {
     super.postUpdate(original, updated);
     PersonaContextCache.getInstance().invalidate(original, updated);
+    if (!Objects.equals(original.getDefault(), updated.getDefault())) {
+      SubjectCache.invalidateAllUserContexts();
+    } else if (!userAssignmentsMatch(original.getUsers(), updated.getUsers())) {
+      invalidateUserContexts(original.getUsers(), updated.getUsers());
+    }
   }
 
   @Override
   protected void postDelete(Persona persona, boolean hardDelete) {
     PersonaContextCache.getInstance().invalidate(persona);
     super.postDelete(persona, hardDelete);
+  }
+
+  private boolean userAssignmentsMatch(
+      List<EntityReference> originalUsers, List<EntityReference> updatedUsers) {
+    Set<UUID> originalUserIds = new HashSet<>();
+    Set<UUID> updatedUserIds = new HashSet<>();
+    listOrEmpty(originalUsers).forEach(user -> originalUserIds.add(user.getId()));
+    listOrEmpty(updatedUsers).forEach(user -> updatedUserIds.add(user.getId()));
+    return originalUserIds.equals(updatedUserIds);
+  }
+
+  private void invalidateUserContexts(
+      List<EntityReference> originalUsers, List<EntityReference> updatedUsers) {
+    Set<String> userNames = new HashSet<>();
+    listOrEmpty(originalUsers).stream()
+        .map(EntityReference::getName)
+        .filter(name -> !nullOrEmpty(name))
+        .forEach(userNames::add);
+    listOrEmpty(updatedUsers).stream()
+        .map(EntityReference::getName)
+        .filter(name -> !nullOrEmpty(name))
+        .forEach(userNames::add);
+    userNames.forEach(SubjectCache::invalidateUserContext);
   }
 
   /** Handles entity updated from PUT and POST operation. */

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/UserRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/UserRepository.java
@@ -674,18 +674,6 @@ public class UserRepository extends EntityRepository<User> {
     return systemDefault != null ? systemDefault.getEntityReference() : null;
   }
 
-  public boolean hasPersona(User user, UUID personaId) {
-    EntityReference defaultPersona = getDefaultPersona(user);
-    if (defaultPersona != null && personaId.equals(defaultPersona.getId())) {
-      return true;
-    }
-    boolean directlyAssigned =
-        getPersonas(user).stream().anyMatch(persona -> personaId.equals(persona.getId()));
-    return directlyAssigned
-        || getInheritedPersonas(user).stream()
-            .anyMatch(persona -> personaId.equals(persona.getId()));
-  }
-
   private List<EntityReference> getInheritedPersonas(User user) {
     if (Boolean.TRUE.equals(user.getIsBot())) {
       return Collections.emptyList();
@@ -1528,6 +1516,10 @@ public class UserRepository extends EntityRepository<User> {
       compareAndUpdate(
           "authenticationMechanism", () -> updateAuthenticationMechanism(original, updated));
       compareAndUpdateAny(() -> SubjectCache.invalidateUser(updated.getName()), "roles", "teams");
+      compareAndUpdateAny(
+          () -> SubjectCache.invalidateUserContext(updated.getName()),
+          "personas",
+          "defaultPersona");
     }
 
     private void updateAllowImpersonation() {

--- a/openmetadata-service/src/main/java/org/openmetadata/service/mcpclient/McpClientService.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/mcpclient/McpClientService.java
@@ -49,6 +49,8 @@ import org.openmetadata.service.exception.EntityNotFoundException;
 import org.openmetadata.service.jdbi3.CollectionDAO;
 import org.openmetadata.service.jdbi3.McpConversationRepository;
 import org.openmetadata.service.jdbi3.McpMessageRepository;
+import org.openmetadata.service.security.ActivePersonaContext;
+import org.openmetadata.service.security.ImpersonationContext;
 import org.openmetadata.service.security.auth.CatalogSecurityContext;
 
 @Slf4j
@@ -561,7 +563,7 @@ public class McpClientService implements AutoCloseable {
     }
   }
 
-  private CatalogSecurityContext toCatalogSecurityContext(SecurityContext securityContext) {
+  static CatalogSecurityContext toCatalogSecurityContext(SecurityContext securityContext) {
     if (securityContext instanceof CatalogSecurityContext catalogSecurityContext) {
       return catalogSecurityContext;
     }
@@ -569,7 +571,10 @@ public class McpClientService implements AutoCloseable {
         securityContext.getUserPrincipal(),
         securityContext.isSecure() ? "https" : "http",
         securityContext.getAuthenticationScheme(),
-        Collections.emptySet());
+        Collections.emptySet(),
+        false,
+        ImpersonationContext.getImpersonatedBy(),
+        ActivePersonaContext.getActivePersona());
   }
 
   private void requireChatEnabled() {

--- a/openmetadata-service/src/main/java/org/openmetadata/service/mcpclient/McpClientService.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/mcpclient/McpClientService.java
@@ -562,6 +562,9 @@ public class McpClientService implements AutoCloseable {
   }
 
   private CatalogSecurityContext toCatalogSecurityContext(SecurityContext securityContext) {
+    if (securityContext instanceof CatalogSecurityContext catalogSecurityContext) {
+      return catalogSecurityContext;
+    }
     return new CatalogSecurityContext(
         securityContext.getUserPrincipal(),
         securityContext.isSecure() ? "https" : "http",

--- a/openmetadata-service/src/main/java/org/openmetadata/service/security/ActivePersonaContext.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/security/ActivePersonaContext.java
@@ -1,0 +1,38 @@
+/*
+ *  Copyright 2026 Collate
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.openmetadata.service.security;
+
+import static org.openmetadata.common.utils.CommonUtil.nullOrEmpty;
+
+public final class ActivePersonaContext {
+  private static final ThreadLocal<String> ACTIVE_PERSONA = new ThreadLocal<>();
+
+  private ActivePersonaContext() {}
+
+  public static void setActivePersona(String activePersona) {
+    if (nullOrEmpty(activePersona)) {
+      ACTIVE_PERSONA.remove();
+    } else {
+      ACTIVE_PERSONA.set(activePersona);
+    }
+  }
+
+  public static String getActivePersona() {
+    return ACTIVE_PERSONA.get();
+  }
+
+  public static void clear() {
+    ACTIVE_PERSONA.remove();
+  }
+}

--- a/openmetadata-service/src/main/java/org/openmetadata/service/security/CatalogOpenIdAuthorizationRequestFilter.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/security/CatalogOpenIdAuthorizationRequestFilter.java
@@ -76,9 +76,17 @@ public class CatalogOpenIdAuthorizationRequestFilter implements ContainerRequest
   private void setSecurityContext(
       ContainerRequestContext requestContext, CatalogPrincipal catalogPrincipal) {
     String scheme = requestContext.getUriInfo().getRequestUri().getScheme();
+    String activePersona = requestContext.getHeaderString(JwtFilter.ACTIVE_PERSONA_HEADER);
     CatalogSecurityContext catalogSecurityContext =
         new CatalogSecurityContext(
-            catalogPrincipal, scheme, SecurityContext.BASIC_AUTH, new HashSet<>());
+            catalogPrincipal,
+            scheme,
+            SecurityContext.BASIC_AUTH,
+            new HashSet<>(),
+            false,
+            null,
+            activePersona);
     requestContext.setSecurityContext(catalogSecurityContext);
+    ActivePersonaContext.setActivePersona(activePersona);
   }
 }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/security/DefaultAuthorizer.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/security/DefaultAuthorizer.java
@@ -199,12 +199,21 @@ public class DefaultAuthorizer implements Authorizer {
     if (securityContext instanceof CatalogSecurityContext catalogSecurityContext) {
       String userName = SecurityUtil.getUserName(securityContext);
       String impersonatedBy = catalogSecurityContext.impersonatedUser();
+      String activePersona = catalogSecurityContext.activePersona();
+      if (activePersona != null) {
+        return SubjectContext.getSubjectContext(userName, impersonatedBy, activePersona);
+      }
       if (impersonatedBy != null) {
         return SubjectContext.getSubjectContext(userName, impersonatedBy);
       }
     } else {
       // Jersey may have wrapped the SecurityContext, try ThreadLocal fallback
       String impersonatedBy = ImpersonationContext.getImpersonatedBy();
+      String activePersona = ActivePersonaContext.getActivePersona();
+      if (activePersona != null) {
+        String userName = SecurityUtil.getUserName(securityContext);
+        return SubjectContext.getSubjectContext(userName, impersonatedBy, activePersona);
+      }
       if (impersonatedBy != null) {
         String userName = SecurityUtil.getUserName(securityContext);
         return SubjectContext.getSubjectContext(userName, impersonatedBy);

--- a/openmetadata-service/src/main/java/org/openmetadata/service/security/ImpersonationCleanupFilter.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/security/ImpersonationCleanupFilter.java
@@ -38,6 +38,7 @@ public class ImpersonationCleanupFilter implements ContainerResponseFilter {
       ContainerRequestContext requestContext, ContainerResponseContext responseContext) {
     // Always clear ThreadLocal after request completes (success or failure)
     ImpersonationContext.clear();
+    ActivePersonaContext.clear();
     ETagRequestFilter.clearIfMatchHeader();
     RequestEntityCache.clear();
     ReadBundleContext.clear();

--- a/openmetadata-service/src/main/java/org/openmetadata/service/security/JwtFilter.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/security/JwtFilter.java
@@ -83,6 +83,8 @@ public class JwtFilter implements ContainerRequestFilter {
   public static final String TOKEN_PREFIX = "Bearer";
   public static final String BOT_CLAIM = "isBot";
   public static final String IMPERSONATED_USER_CLAIM = "impersonatedUser";
+  public static final String IMPERSONATE_USER_HEADER = "X-Impersonate-User";
+  public static final String ACTIVE_PERSONA_HEADER = "X-OpenMetadata-Persona";
   @Getter private List<String> jwtPrincipalClaims;
   @Getter private Map<String, String> jwtPrincipalClaimsMapping;
   @Getter private String jwtTeamClaimMapping;
@@ -164,6 +166,7 @@ public class JwtFilter implements ContainerRequestFilter {
 
     Timer.Sample authSample = RequestLatencyContext.startAuthOperation();
     ImpersonationContext.clear();
+    ActivePersonaContext.clear();
 
     try {
       String tokenFromHeader = extractToken(requestContext.getHeaders());
@@ -178,7 +181,8 @@ public class JwtFilter implements ContainerRequestFilter {
               jwtPrincipalClaimsMapping, jwtPrincipalClaims, claims, principalDomain);
       boolean isBotUser = isBot(claims);
 
-      String impersonateUser = requestContext.getHeaderString("X-Impersonate-User");
+      String impersonateUser = requestContext.getHeaderString(IMPERSONATE_USER_HEADER);
+      String activePersona = requestContext.getHeaderString(ACTIVE_PERSONA_HEADER);
       String impersonatedBy = null;
 
       if (impersonateUser != null && !impersonateUser.isEmpty()) {
@@ -209,7 +213,8 @@ public class JwtFilter implements ContainerRequestFilter {
               SecurityContext.DIGEST_AUTH,
               getUserRolesFromClaims(claims, isBotUser),
               isBotUser,
-              impersonatedBy);
+              impersonatedBy,
+              activePersona);
       LOG.debug("SecurityContext {}", catalogSecurityContext);
       requestContext.setSecurityContext(catalogSecurityContext);
 
@@ -218,8 +223,10 @@ public class JwtFilter implements ContainerRequestFilter {
       } else {
         ImpersonationContext.clear();
       }
+      ActivePersonaContext.setActivePersona(activePersona);
     } catch (Throwable t) {
       ImpersonationContext.clear();
+      ActivePersonaContext.clear();
       throw t;
     } finally {
       RequestLatencyContext.endAuthOperation(authSample);

--- a/openmetadata-service/src/main/java/org/openmetadata/service/security/NoopFilter.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/security/NoopFilter.java
@@ -36,10 +36,18 @@ public class NoopFilter implements ContainerRequestFilter {
     CatalogPrincipal catalogPrincipal =
         new CatalogPrincipal("anonymous", "anonymous@openmetadata.org");
     String scheme = containerRequestContext.getUriInfo().getRequestUri().getScheme();
+    String activePersona = containerRequestContext.getHeaderString(JwtFilter.ACTIVE_PERSONA_HEADER);
     CatalogSecurityContext catalogSecurityContext =
         new CatalogSecurityContext(
-            catalogPrincipal, scheme, SecurityContext.BASIC_AUTH, new HashSet<>());
+            catalogPrincipal,
+            scheme,
+            SecurityContext.BASIC_AUTH,
+            new HashSet<>(),
+            false,
+            null,
+            activePersona);
     LOG.debug("SecurityContext {}", catalogSecurityContext);
     containerRequestContext.setSecurityContext(catalogSecurityContext);
+    ActivePersonaContext.setActivePersona(activePersona);
   }
 }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/security/auth/CatalogSecurityContext.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/security/auth/CatalogSecurityContext.java
@@ -29,7 +29,8 @@ public record CatalogSecurityContext(
     String authenticationScheme,
     Set<String> userRoles,
     boolean isBot,
-    String impersonatedUser)
+    String impersonatedUser,
+    String activePersona)
     implements SecurityContext {
   public static final String OPENID_AUTH = "openid";
 
@@ -55,7 +56,7 @@ public record CatalogSecurityContext(
   // Backward compatibility constructors
   public CatalogSecurityContext(
       Principal principal, String scheme, String authenticationScheme, Set<String> userRoles) {
-    this(principal, scheme, authenticationScheme, userRoles, false, null);
+    this(principal, scheme, authenticationScheme, userRoles, false, null, null);
   }
 
   public CatalogSecurityContext(
@@ -64,7 +65,17 @@ public record CatalogSecurityContext(
       String authenticationScheme,
       Set<String> userRoles,
       boolean isBot) {
-    this(principal, scheme, authenticationScheme, userRoles, isBot, null);
+    this(principal, scheme, authenticationScheme, userRoles, isBot, null, null);
+  }
+
+  public CatalogSecurityContext(
+      Principal principal,
+      String scheme,
+      String authenticationScheme,
+      Set<String> userRoles,
+      boolean isBot,
+      String impersonatedUser) {
+    this(principal, scheme, authenticationScheme, userRoles, isBot, impersonatedUser, null);
   }
 
   @Override

--- a/openmetadata-service/src/main/java/org/openmetadata/service/security/policyevaluator/SubjectCache.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/security/policyevaluator/SubjectCache.java
@@ -14,13 +14,16 @@
 package org.openmetadata.service.security.policyevaluator;
 
 import static org.openmetadata.common.utils.CommonUtil.listOrEmpty;
+import static org.openmetadata.common.utils.CommonUtil.nullOrEmpty;
 import static org.openmetadata.schema.type.Include.NON_DELETED;
 
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.CheckForNull;
@@ -119,6 +122,18 @@ public class SubjectCache {
   public static void invalidateUserContext(String userName) {
     LOG.debug("Invalidating user context cache for user: {}", userName);
     USER_CONTEXT_CACHE.invalidate(userName);
+  }
+
+  public static void invalidateUserContexts(List<EntityReference> users) {
+    Set<String> userNames = new HashSet<>();
+    for (EntityReference user : listOrEmpty(users)) {
+      if (user == null || nullOrEmpty(user.getName())) {
+        invalidateAllUserContexts();
+        return;
+      }
+      userNames.add(user.getName());
+    }
+    userNames.forEach(SubjectCache::invalidateUserContext);
   }
 
   public static void invalidateAllUserContexts() {

--- a/openmetadata-service/src/main/java/org/openmetadata/service/security/policyevaluator/SubjectCache.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/security/policyevaluator/SubjectCache.java
@@ -42,6 +42,8 @@ import org.openmetadata.service.security.policyevaluator.SubjectContext.PolicyCo
 @Slf4j
 public class SubjectCache {
   private static final String USER_FIELDS = "roles,teams,isAdmin,profile,domains";
+  private static final String USER_CONTEXT_FIELDS =
+      "roles,teams,isAdmin,profile,domains,personas,defaultPersona";
   private static final String TEAM_FIELDS = "defaultRoles,policies,parents,profile,domains";
 
   static class UserPoliciesContext {
@@ -114,6 +116,16 @@ public class SubjectCache {
     USER_CONTEXT_CACHE.invalidate(userName);
   }
 
+  public static void invalidateUserContext(String userName) {
+    LOG.debug("Invalidating user context cache for user: {}", userName);
+    USER_CONTEXT_CACHE.invalidate(userName);
+  }
+
+  public static void invalidateAllUserContexts() {
+    LOG.info("Invalidating all user context caches");
+    USER_CONTEXT_CACHE.invalidateAll();
+  }
+
   public static void invalidateAll() {
     LOG.info("Invalidating all user policy caches");
     USER_POLICIES_CACHE.invalidateAll();
@@ -125,7 +137,7 @@ public class SubjectCache {
       return USER_CONTEXT_CACHE.get(userName);
     } catch (Exception e) {
       LOG.warn("Failed to load user context from cache for user {}", userName, e);
-      return Entity.getEntityByName(Entity.USER, userName, USER_FIELDS, NON_DELETED);
+      return Entity.getEntityByName(Entity.USER, userName, USER_CONTEXT_FIELDS, NON_DELETED);
     }
   }
 
@@ -146,7 +158,7 @@ public class SubjectCache {
     @Override
     public @NonNull User load(@CheckForNull String userName) {
       LOG.debug("Loading user context from database for user: {}", userName);
-      return Entity.getEntityByName(Entity.USER, userName, USER_FIELDS, NON_DELETED);
+      return Entity.getEntityByName(Entity.USER, userName, USER_CONTEXT_FIELDS, NON_DELETED);
     }
   }
 

--- a/openmetadata-service/src/main/java/org/openmetadata/service/security/policyevaluator/SubjectContext.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/security/policyevaluator/SubjectContext.java
@@ -41,19 +41,103 @@ import org.openmetadata.service.util.FullyQualifiedName;
 
 /** Subject context used for Access Control Policies */
 @Slf4j
-public record SubjectContext(User user, String impersonatedBy) {
-  private static final String USER_FIELDS = "roles,teams,isAdmin,profile,domains";
+public record SubjectContext(User user, String impersonatedBy, String requestedPersona) {
+  private static final int MAX_LOGGED_PERSONA_LENGTH = 64;
   public static final String TEAM_FIELDS =
       "defaultRoles, defaultPersona, policies, parents, profile,domains";
 
+  public SubjectContext(User user, String impersonatedBy) {
+    this(user, impersonatedBy, null);
+  }
+
   public static SubjectContext getSubjectContext(String userName) {
-    User user = SubjectCache.getUserContext(userName);
-    return new SubjectContext(user, null);
+    return getSubjectContext(userName, null, null);
   }
 
   public static SubjectContext getSubjectContext(String userName, String impersonatedBy) {
+    return getSubjectContext(userName, impersonatedBy, null);
+  }
+
+  public static SubjectContext getSubjectContext(
+      String userName, String impersonatedBy, String requestedPersona) {
     User user = SubjectCache.getUserContext(userName);
-    return new SubjectContext(user, impersonatedBy);
+    return new SubjectContext(user, impersonatedBy, requestedPersona);
+  }
+
+  /**
+   * Returns the validated persona preference for personalization such as UI and AI context.
+   *
+   * <p>This value must never be used for authorization or access-control decisions. Roles and
+   * policies remain the authorization inputs.
+   */
+  public EntityReference getActivePersona() {
+    EntityReference activePersona = findRequestedPersona();
+    if (activePersona == null) {
+      if (!nullOrEmpty(requestedPersona)) {
+        LOG.warn(
+            "Requested persona '{}' is not assigned to user '{}'; using the default persona",
+            sanitizeRequestedPersonaForLog(),
+            user.getName());
+      }
+      activePersona = user.getDefaultPersona();
+    }
+    return activePersona;
+  }
+
+  public boolean hasPersona(UUID personaId) {
+    return listOrEmpty(user.getPersonas()).stream().anyMatch(ref -> personaId.equals(ref.getId()))
+        || listOrEmpty(user.getInheritedPersonas()).stream()
+            .anyMatch(ref -> personaId.equals(ref.getId()))
+        || (user.getDefaultPersona() != null && personaId.equals(user.getDefaultPersona().getId()));
+  }
+
+  private EntityReference findRequestedPersona() {
+    EntityReference requested = findRequestedPersona(user.getPersonas());
+    if (requested == null) {
+      requested = findRequestedPersona(user.getInheritedPersonas());
+    }
+    if (requested == null && matchesRequestedPersona(user.getDefaultPersona())) {
+      requested = user.getDefaultPersona();
+    }
+    return requested;
+  }
+
+  private EntityReference findRequestedPersona(List<EntityReference> personas) {
+    EntityReference requested = null;
+    for (EntityReference persona : listOrEmpty(personas)) {
+      if (matchesRequestedPersona(persona)) {
+        requested = persona;
+        break;
+      }
+    }
+    return requested;
+  }
+
+  private String sanitizeRequestedPersonaForLog() {
+    return requestedPersona
+        .codePoints()
+        .filter(SubjectContext::isSafeLogCodePoint)
+        .limit(MAX_LOGGED_PERSONA_LENGTH)
+        .collect(StringBuilder::new, StringBuilder::appendCodePoint, StringBuilder::append)
+        .toString();
+  }
+
+  private static boolean isSafeLogCodePoint(int codePoint) {
+    int characterType = Character.getType(codePoint);
+    return characterType != Character.CONTROL
+        && characterType != Character.FORMAT
+        && characterType != Character.LINE_SEPARATOR
+        && characterType != Character.PARAGRAPH_SEPARATOR
+        && characterType != Character.SURROGATE;
+  }
+
+  private boolean matchesRequestedPersona(EntityReference persona) {
+    return !nullOrEmpty(requestedPersona)
+        && persona != null
+        && (requestedPersona.equalsIgnoreCase(persona.getFullyQualifiedName())
+            || requestedPersona.equalsIgnoreCase(persona.getName())
+            || (persona.getId() != null
+                && requestedPersona.equalsIgnoreCase(persona.getId().toString())));
   }
 
   public boolean isAdmin() {

--- a/openmetadata-service/src/test/java/org/openmetadata/service/jdbi3/ImpersonationCleanupFilterTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/jdbi3/ImpersonationCleanupFilterTest.java
@@ -8,12 +8,22 @@ import java.util.UUID;
 import org.junit.jupiter.api.Test;
 import org.openmetadata.schema.entity.data.Table;
 import org.openmetadata.service.Entity;
+import org.openmetadata.service.security.ActivePersonaContext;
 import org.openmetadata.service.security.ImpersonationCleanupFilter;
 import org.openmetadata.service.util.EntityUtil.Fields;
 import org.openmetadata.service.util.EntityUtil.RelationIncludes;
 import org.openmetadata.service.util.RequestEntityCache;
 
 class ImpersonationCleanupFilterTest {
+
+  @Test
+  void filterClearsActivePersonaContextThreadLocal() {
+    ActivePersonaContext.setActivePersona("persona-id");
+
+    new ImpersonationCleanupFilter().filter(null, null);
+
+    assertNull(ActivePersonaContext.getActivePersona());
+  }
 
   @Test
   void filterClearsReadBundleContextThreadLocal() {

--- a/openmetadata-service/src/test/java/org/openmetadata/service/mcpclient/McpClientServiceTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/mcpclient/McpClientServiceTest.java
@@ -1,0 +1,68 @@
+/*
+ *  Copyright 2026 Collate
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.openmetadata.service.mcpclient;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import jakarta.ws.rs.core.SecurityContext;
+import java.security.Principal;
+import java.util.Set;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.openmetadata.service.security.ActivePersonaContext;
+import org.openmetadata.service.security.ImpersonationContext;
+import org.openmetadata.service.security.auth.CatalogSecurityContext;
+
+class McpClientServiceTest {
+
+  @AfterEach
+  void clearRequestContext() {
+    ImpersonationContext.clear();
+    ActivePersonaContext.clear();
+  }
+
+  @Test
+  void preservesCatalogSecurityContext() {
+    CatalogSecurityContext securityContext =
+        new CatalogSecurityContext(
+            () -> "alice", "https", SecurityContext.DIGEST_AUTH, Set.of(), false, null, null);
+
+    assertSame(securityContext, McpClientService.toCatalogSecurityContext(securityContext));
+  }
+
+  @Test
+  void wrappedSecurityContextPreservesRequestHints() {
+    Principal principal = () -> "alice";
+    SecurityContext wrappedSecurityContext = mock(SecurityContext.class);
+    when(wrappedSecurityContext.getUserPrincipal()).thenReturn(principal);
+    when(wrappedSecurityContext.isSecure()).thenReturn(true);
+    when(wrappedSecurityContext.getAuthenticationScheme()).thenReturn(SecurityContext.DIGEST_AUTH);
+    ImpersonationContext.setImpersonatedBy("ingestion-bot");
+    ActivePersonaContext.setActivePersona("data-steward");
+
+    CatalogSecurityContext catalogSecurityContext =
+        McpClientService.toCatalogSecurityContext(wrappedSecurityContext);
+
+    assertSame(principal, catalogSecurityContext.getUserPrincipal());
+    assertEquals(SecurityContext.DIGEST_AUTH, catalogSecurityContext.getAuthenticationScheme());
+    assertEquals("ingestion-bot", catalogSecurityContext.impersonatedUser());
+    assertEquals("data-steward", catalogSecurityContext.activePersona());
+    assertFalse(catalogSecurityContext.isBot());
+    assertEquals(Set.of(), catalogSecurityContext.getUserRoles());
+  }
+}

--- a/openmetadata-service/src/test/java/org/openmetadata/service/security/DefaultAuthorizerTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/security/DefaultAuthorizerTest.java
@@ -44,6 +44,7 @@ class DefaultAuthorizerTest {
   @AfterEach
   void clearImpersonationState() {
     ImpersonationContext.clear();
+    ActivePersonaContext.clear();
     CatalogSecurityContext.clearThreadLocalImpersonatedUser();
   }
 
@@ -609,7 +610,7 @@ class DefaultAuthorizerTest {
   }
 
   @Test
-  void getSubjectContextUsesCatalogAndThreadLocalImpersonationHints() {
+  void getSubjectContextUsesCatalogAndThreadLocalRequestHints() {
     SubjectContext subjectContext = subjectContext("alice", false, false, null);
     SubjectContext threadLocalContext = subjectContext("bob", false, false, null);
     CatalogSecurityContext catalogSecurityContext =
@@ -619,16 +620,18 @@ class DefaultAuthorizerTest {
             CatalogSecurityContext.OPENID_AUTH,
             Set.of(),
             false,
-            "bot-user");
+            "bot-user",
+            "persona-a");
     SecurityContext wrappedSecurityContext = securityContext("bob");
     ImpersonationContext.setImpersonatedBy("job-bot");
+    ActivePersonaContext.setActivePersona("persona-b");
 
     try (MockedStatic<SubjectContext> mockedSubjectContext = mockStatic(SubjectContext.class)) {
       mockedSubjectContext
-          .when(() -> SubjectContext.getSubjectContext("alice", "bot-user"))
+          .when(() -> SubjectContext.getSubjectContext("alice", "bot-user", "persona-a"))
           .thenReturn(subjectContext);
       mockedSubjectContext
-          .when(() -> SubjectContext.getSubjectContext("bob", "job-bot"))
+          .when(() -> SubjectContext.getSubjectContext("bob", "job-bot", "persona-b"))
           .thenReturn(threadLocalContext);
 
       assertSame(subjectContext, DefaultAuthorizer.getSubjectContext(catalogSecurityContext));

--- a/openmetadata-service/src/test/java/org/openmetadata/service/security/JwtFilterTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/security/JwtFilterTest.java
@@ -45,11 +45,14 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.MockedStatic;
 import org.openmetadata.schema.auth.ServiceTokenType;
+import org.openmetadata.service.Entity;
+import org.openmetadata.service.security.auth.CatalogSecurityContext;
 import org.openmetadata.service.security.auth.UserTokenCache;
 import org.openmetadata.service.security.jwt.JWTTokenGenerator;
 import org.openmetadata.service.security.session.SessionService;
@@ -94,6 +97,11 @@ class JwtFilterTest {
     String domain = "openmetadata.org";
     boolean enforcePrincipalDomain = false;
     jwtFilter = new JwtFilter(jwkProvider, principalClaims, domain, enforcePrincipalDomain);
+  }
+
+  @AfterEach
+  void clearRequestContext() {
+    ActivePersonaContext.clear();
   }
 
   @Test
@@ -155,6 +163,31 @@ class JwtFilterTest {
     verify(context, times(1)).setSecurityContext(securityContextArgument.capture());
 
     assertEquals("sam", securityContextArgument.getValue().getUserPrincipal().getName());
+  }
+
+  @Test
+  void testActivePersonaHeaderPropagatesWithoutEntityLookup() {
+    String jwt =
+        JWT.create()
+            .withExpiresAt(Date.from(Instant.now().plus(1, ChronoUnit.DAYS)))
+            .withClaim("sub", "sam")
+            .sign(algorithm);
+    String activePersona = "9fb7e857-df45-42e9-b341-12d28c7b49aa";
+    ContainerRequestContext context = createRequestContextWithJwt(jwt);
+    when(context.getHeaderString(JwtFilter.ACTIVE_PERSONA_HEADER)).thenReturn(activePersona);
+
+    try (MockedStatic<Entity> entity = org.mockito.Mockito.mockStatic(Entity.class)) {
+      jwtFilter.filter(context);
+      entity.verifyNoInteractions();
+    }
+
+    ArgumentCaptor<SecurityContext> securityContextArgument =
+        ArgumentCaptor.forClass(SecurityContext.class);
+    verify(context).setSecurityContext(securityContextArgument.capture());
+    CatalogSecurityContext catalogSecurityContext =
+        (CatalogSecurityContext) securityContextArgument.getValue();
+    assertEquals(activePersona, catalogSecurityContext.activePersona());
+    assertEquals(activePersona, ActivePersonaContext.getActivePersona());
   }
 
   @Test

--- a/openmetadata-service/src/test/java/org/openmetadata/service/security/policyevaluator/SubjectCacheTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/security/policyevaluator/SubjectCacheTest.java
@@ -165,6 +165,18 @@ public class SubjectCacheTest {
   }
 
   @Test
+  void testIdOnlyReferenceInvalidatesAllUserContexts() {
+    SubjectCache.getUserContext("testUser");
+    clearInvocations(userRepository);
+
+    SubjectCache.invalidateUserContexts(List.of(new EntityReference().withId(UUID.randomUUID())));
+    SubjectCache.getUserContext("testUser");
+
+    verify(userRepository, times(1))
+        .getByName(isNull(), eq("testUser"), isNull(), any(Include.class), anyBoolean());
+  }
+
+  @Test
   void testCachedPoliciesMatchExpectedOrder() {
     // Get policies through cache
     List<PolicyContext> cachedPolicies = SubjectCache.getPolicies("testUser");

--- a/openmetadata-service/src/test/java/org/openmetadata/service/security/policyevaluator/SubjectCacheTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/security/policyevaluator/SubjectCacheTest.java
@@ -15,12 +15,17 @@ package org.openmetadata.service.security.policyevaluator;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.clearInvocations;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 import java.util.ArrayList;
 import java.util.Iterator;
@@ -57,10 +62,11 @@ public class SubjectCacheTest {
   private static User user;
   private static Team team1;
   private static Team team11;
+  private static UserRepository userRepository;
 
   @BeforeAll
   public static void setup() {
-    UserRepository userRepository = mock(UserRepository.class);
+    userRepository = mock(UserRepository.class);
     Entity.registerEntity(User.class, Entity.USER, userRepository);
     Mockito.when(
             userRepository.getByName(
@@ -131,6 +137,31 @@ public class SubjectCacheTest {
   @BeforeEach
   public void resetCache() {
     SubjectCache.invalidateAll();
+    clearInvocations(userRepository);
+  }
+
+  @Test
+  void testRepeatedSubjectContextReadsLoadUserOnce() {
+    SubjectContext first = SubjectContext.getSubjectContext("testUser");
+    SubjectContext second = SubjectContext.getSubjectContext("testUser");
+
+    assertSame(first.user(), second.user());
+    verify(userRepository, times(1))
+        .getByName(isNull(), eq("testUser"), isNull(), any(Include.class), anyBoolean());
+  }
+
+  @Test
+  void testUserContextInvalidationLeavesPolicyCacheWarm() {
+    SubjectCache.getPolicies("testUser");
+    SubjectCache.getUserContext("testUser");
+    clearInvocations(userRepository);
+
+    SubjectCache.invalidateUserContext("testUser");
+    SubjectCache.getPolicies("testUser");
+    SubjectCache.getUserContext("testUser");
+
+    verify(userRepository, times(1))
+        .getByName(isNull(), eq("testUser"), isNull(), any(Include.class), anyBoolean());
   }
 
   @Test

--- a/openmetadata-service/src/test/java/org/openmetadata/service/security/policyevaluator/SubjectContextTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/security/policyevaluator/SubjectContextTest.java
@@ -14,6 +14,7 @@ package org.openmetadata.service.security.policyevaluator;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
@@ -22,6 +23,9 @@ import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.mock;
 import static org.openmetadata.common.utils.CommonUtil.listOrEmpty;
 
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
@@ -47,6 +51,7 @@ import org.openmetadata.service.jdbi3.RoleRepository;
 import org.openmetadata.service.jdbi3.TeamRepository;
 import org.openmetadata.service.jdbi3.UserRepository;
 import org.openmetadata.service.security.policyevaluator.SubjectContext.PolicyContext;
+import org.slf4j.LoggerFactory;
 
 public class SubjectContextTest {
   private static List<Role> team1Roles;
@@ -170,6 +175,113 @@ public class SubjectContextTest {
   public void resetCache() {
     // Clear SubjectCache before each test to ensure clean state
     SubjectCache.invalidateAll();
+  }
+
+  @Test
+  void testActivePersonaMatchesAssignedPersonaIdentifiersCaseInsensitively() {
+    EntityReference assignedPersona = personaReference("DataSteward", "persona.DataSteward");
+    EntityReference defaultPersona = personaReference("Default", "persona.Default");
+    User personaUser =
+        new User()
+            .withName("persona-user")
+            .withPersonas(List.of(assignedPersona))
+            .withDefaultPersona(defaultPersona);
+
+    assertEquals(
+        assignedPersona, new SubjectContext(personaUser, null, "datasteward").getActivePersona());
+    assertEquals(
+        assignedPersona,
+        new SubjectContext(personaUser, null, "PERSONA.DATASTEWARD").getActivePersona());
+    assertEquals(
+        assignedPersona,
+        new SubjectContext(personaUser, null, assignedPersona.getId().toString().toUpperCase())
+            .getActivePersona());
+  }
+
+  @Test
+  void testActivePersonaMatchesInheritedPersonaAndFallsBackToDefault() {
+    EntityReference inheritedPersona = personaReference("Analyst", "persona.Analyst");
+    EntityReference defaultPersona = personaReference("Default", "persona.Default");
+    User personaUser =
+        new User()
+            .withName("persona-user")
+            .withInheritedPersonas(List.of(inheritedPersona))
+            .withDefaultPersona(defaultPersona);
+
+    assertEquals(
+        inheritedPersona,
+        new SubjectContext(personaUser, null, inheritedPersona.getId().toString())
+            .getActivePersona());
+    assertEquals(
+        defaultPersona,
+        new SubjectContext(personaUser, null, "unassigned-persona").getActivePersona());
+    assertEquals(defaultPersona, new SubjectContext(personaUser, null).getActivePersona());
+  }
+
+  @Test
+  void testActivePersonaReturnsNullWithoutAssignedOrDefaultPersona() {
+    User personaUser = new User().withName("persona-user");
+
+    assertNull(new SubjectContext(personaUser, null, "missing").getActivePersona());
+    assertFalse(new SubjectContext(personaUser, null).hasPersona(UUID.randomUUID()));
+  }
+
+  @Test
+  void testActivePersonaDoesNotMatchNullReferenceId() {
+    EntityReference invalidPersona =
+        new EntityReference()
+            .withType(Entity.PERSONA)
+            .withName("invalid")
+            .withFullyQualifiedName("persona.invalid");
+    EntityReference defaultPersona = personaReference("Default", "persona.Default");
+    User personaUser =
+        new User()
+            .withName("persona-user")
+            .withPersonas(List.of(invalidPersona))
+            .withDefaultPersona(defaultPersona);
+
+    assertEquals(defaultPersona, new SubjectContext(personaUser, null, "null").getActivePersona());
+  }
+
+  @Test
+  void testInvalidActivePersonaLogValueIsSanitizedAndBounded() {
+    Logger logger = (Logger) LoggerFactory.getLogger(SubjectContext.class);
+    ListAppender<ILoggingEvent> appender = new ListAppender<>();
+    appender.start();
+    logger.addAppender(appender);
+
+    try {
+      String requestedPersona = "persona\r\n\t\u2028\u2029\u202E" + "x".repeat(100);
+      User personaUser = new User().withName("persona-user");
+
+      new SubjectContext(personaUser, null, requestedPersona).getActivePersona();
+
+      String loggedPersona = (String) appender.list.get(0).getArgumentArray()[0];
+      assertEquals(64, loggedPersona.codePointCount(0, loggedPersona.length()));
+      assertEquals("persona" + "x".repeat(57), loggedPersona);
+    } finally {
+      logger.detachAppender(appender);
+      appender.stop();
+    }
+  }
+
+  @Test
+  void testHasPersonaUsesCachedDirectInheritedAndDefaultAssignments() {
+    EntityReference directPersona = personaReference("Direct", "persona.Direct");
+    EntityReference inheritedPersona = personaReference("Inherited", "persona.Inherited");
+    EntityReference defaultPersona = personaReference("Default", "persona.Default");
+    User personaUser =
+        new User()
+            .withName("persona-user")
+            .withPersonas(List.of(directPersona))
+            .withInheritedPersonas(List.of(inheritedPersona))
+            .withDefaultPersona(defaultPersona);
+    SubjectContext subjectContext = new SubjectContext(personaUser, null);
+
+    assertTrue(subjectContext.hasPersona(directPersona.getId()));
+    assertTrue(subjectContext.hasPersona(inheritedPersona.getId()));
+    assertTrue(subjectContext.hasPersona(defaultPersona.getId()));
+    assertFalse(subjectContext.hasPersona(UUID.randomUUID()));
   }
 
   @Test
@@ -466,5 +578,13 @@ public class SubjectContextTest {
     assertTrue(
         policyCount < maxPolicies,
         "Policy iteration should terminate without infinite loop with circular dependency");
+  }
+
+  private static EntityReference personaReference(String name, String fullyQualifiedName) {
+    return new EntityReference()
+        .withId(UUID.randomUUID())
+        .withType(Entity.PERSONA)
+        .withName(name)
+        .withFullyQualifiedName(fullyQualifiedName);
   }
 }

--- a/openmetadata-ui/src/main/resources/ui/src/components/Auth/AuthProviders/AuthProvider.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Auth/AuthProviders/AuthProvider.tsx
@@ -50,6 +50,7 @@ import {
 } from '../../../generated/configuration/authenticationConfiguration';
 import { User } from '../../../generated/entity/teams/user';
 import { AuthProvider as AuthProviderEnum } from '../../../generated/settings/settings';
+import { withActivePersonaHeader } from '../../../hoc/withActivePersonaHeader';
 import { withDomainFilter } from '../../../hoc/withDomainFilter';
 import { useApplicationStore } from '../../../hooks/useApplicationStore';
 import useCustomLocation from '../../../hooks/useCustomLocation/useCustomLocation';
@@ -543,7 +544,7 @@ export const AuthProvider = ({
         config.headers['Content-type'] = 'application/json-patch+json';
       }
 
-      return withDomainFilter(config);
+      return withActivePersonaHeader(withDomainFilter(config));
     });
 
     // Axios response interceptor for statusCode 401,403

--- a/openmetadata-ui/src/main/resources/ui/src/hoc/withActivePersonaHeader.test.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/hoc/withActivePersonaHeader.test.ts
@@ -1,0 +1,56 @@
+/*
+ *  Copyright 2026 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+import { InternalAxiosRequestConfig } from 'axios';
+import { useApplicationStore } from '../hooks/useApplicationStore';
+import {
+  ACTIVE_PERSONA_HEADER,
+  withActivePersonaHeader,
+} from './withActivePersonaHeader';
+
+jest.mock('../hooks/useApplicationStore');
+
+describe('withActivePersonaHeader', () => {
+  const mockGetState = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useApplicationStore.getState as jest.Mock) = mockGetState;
+  });
+
+  const createMockConfig = (): InternalAxiosRequestConfig =>
+    ({ headers: {} } as InternalAxiosRequestConfig);
+
+  it('sets the active persona id header when a persona is selected', () => {
+    mockGetState.mockReturnValue({
+      selectedPersona: { id: '9fb7e857-df45-42e9-b341-12d28c7b49aa' },
+    });
+    const config = createMockConfig();
+
+    const result = withActivePersonaHeader(config);
+
+    expect(result).toBe(config);
+    expect(result.headers[ACTIVE_PERSONA_HEADER]).toBe(
+      '9fb7e857-df45-42e9-b341-12d28c7b49aa'
+    );
+  });
+
+  it('leaves the config unchanged when no persona is selected', () => {
+    mockGetState.mockReturnValue({ selectedPersona: undefined });
+    const config = createMockConfig();
+
+    const result = withActivePersonaHeader(config);
+
+    expect(result).toBe(config);
+    expect(result.headers[ACTIVE_PERSONA_HEADER]).toBeUndefined();
+  });
+});

--- a/openmetadata-ui/src/main/resources/ui/src/hoc/withActivePersonaHeader.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/hoc/withActivePersonaHeader.ts
@@ -1,0 +1,28 @@
+/*
+ *  Copyright 2026 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+import { InternalAxiosRequestConfig } from 'axios';
+import { useApplicationStore } from '../hooks/useApplicationStore';
+
+export const ACTIVE_PERSONA_HEADER = 'X-OpenMetadata-Persona';
+
+export const withActivePersonaHeader = (
+  config: InternalAxiosRequestConfig
+): InternalAxiosRequestConfig => {
+  const activePersonaId = useApplicationStore.getState().selectedPersona?.id;
+
+  if (activePersonaId) {
+    config.headers[ACTIVE_PERSONA_HEADER] = activePersonaId;
+  }
+
+  return config;
+};


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:

Fixes #29999

Propagates the UI-selected persona ID on every API request and carries it through authentication into a lazily validated `SubjectContext`, using cached direct, inherited, and default persona references with default fallback and no per-request header lookup.
AI persona context and membership checks now consume cached subject data, persona mutations invalidate only affected user-context entries where possible, and invalid header logging is sanitized and bounded.
In-server MCP tool execution now preserves the incoming `CatalogSecurityContext`; this carries the active persona and, as a correctness change, also propagates `impersonatedUser` so impersonated MCP calls receive the normal impersonation authorization checks.

#
### Type of change:

- [ ] Bug fix
- [x] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### High-level design:

- `selectedPersona.id` → `X-OpenMetadata-Persona` Axios interceptor → authentication filters
- Canonical `CatalogSecurityContext` field plus a request-scoped ThreadLocal fallback for wrapped Jersey contexts
- Lazy in-memory validation in `SubjectContext` against the 15-minute cached direct, inherited, and default personas
- Persona preference explicitly excluded from RBAC/policy inputs; invalid or stale selections fall back to the default
- Targeted persona cache invalidation that leaves the hot two-minute policy cache warm
- AI context and in-server MCP tools consume the validated request persona

#
### Tests:

#### Use cases covered

- Persona selection by UUID, name, and FQN
- Missing, stale, unassigned, inherited, and default persona behavior
- Persona assignment/revocation cache invalidation
- Combined impersonation and active-persona requests
- Header transport without entity/database interaction
- Control-character and length sanitization for fallback logging

#### Unit tests

- [x] Added backend tests in `JwtFilterTest`, `SubjectContextTest`, `SubjectCacheTest`, `DefaultAuthorizerTest`, and `ImpersonationCleanupFilterTest`
- [x] Added UI interceptor tests in `withActivePersonaHeader.test.ts` (2/2 passing)
- Backend focused suite: 57 tests passing
- UI ESLint, Prettier, organize-imports, and TypeScript checks passing
- Coverage percentage: not measured

#### Backend integration tests

- [x] Added `ActivePersonaHeaderIT`
- Integration test sources compile successfully
- Runtime execution not performed because the local Docker daemon is unavailable

#### Ingestion integration tests

- [x] Not applicable (no ingestion changes)

#### Playwright (UI) tests

- [x] Not applicable (request-interceptor behavior only; no visual workflow change)

#### Manual testing performed

Not performed because the local Docker-backed stack is unavailable

#
### UI screen recording / screenshots:

Not applicable — this changes request headers only and has no visual UI changes

#
### Checklist:

- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] My PR title is `Fixes <issue-number>: <short explanation>`
- [x] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] For JSON Schema changes: not applicable; this PR does not change JSON Schema.
- [ ] For UI changes: I attached a screen recording and/or screenshots above.
- [x] I have added tests (unit / integration / Playwright as applicable) and listed them above.

### Improvement checklist

- [x] I have added tests around the new logic.
- [x] For connector/ingestion changes: not applicable.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR carries the selected persona through requests and server-side subject context. The main changes are:

- Adds a UI Axios helper for the active persona header.
- Stores active persona and impersonation hints in `CatalogSecurityContext`.
- Resolves active personas from cached subject data.
- Invalidates affected subject-context cache entries after persona changes.
- Preserves request context during in-server MCP tool execution.
- Adds backend, integration, and UI tests for the new persona flow.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge.

- No blocking issues found in the changed code.


</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/PersonaRepository.java | Adds subject-context cache invalidation for persona create, delete, default, and direct user assignment changes. |
| openmetadata-service/src/main/java/org/openmetadata/service/security/policyevaluator/SubjectCache.java | Adds persona-aware user-context cache fields and targeted invalidation helpers. |
| openmetadata-service/src/main/java/org/openmetadata/service/mcpclient/McpClientService.java | Preserves existing catalog contexts and copies request hints when wrapping MCP security contexts. |
| openmetadata-service/src/main/java/org/openmetadata/service/security/policyevaluator/SubjectContext.java | Adds active-persona selection and persona membership checks from cached subject data. |
| openmetadata-ui/src/main/resources/ui/src/hoc/withActivePersonaHeader.ts | Adds the selected persona ID to outgoing API requests. |

</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `openmetadata-service/src/main/java/org/openmetadata/service/mcpclient/McpClientService.java`, line 568-572 ([link](https://github.com/open-metadata/openmetadata/blob/70b1ca4fe626911deab62eb107e6a6fece345c31/openmetadata-service/src/main/java/org/openmetadata/service/mcpclient/McpClientService.java#L568-L572)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> <a href="#"><img alt="security" src="https://greptile-static-assets.s3.amazonaws.com/badges/Security.svg?v=2" align="top"></a> **Wrapped MCP Context Drops Hints**

   When Jersey passes a wrapped `SecurityContext`, this fallback builds a new `CatalogSecurityContext` without the request persona or impersonated user. Tool authorization then sees a `CatalogSecurityContext` and skips the ThreadLocal fallback, so wrapped MCP calls can run with the wrong persona context and without the normal impersonation checks.

2. `openmetadata-service/src/main/java/org/openmetadata/service/mcpclient/McpClientService.java`, line 568-572 ([link](https://github.com/open-metadata/openmetadata/blob/d4efa4afa2a62f13fe2bc9be01fb67c8f105c3a4/openmetadata-service/src/main/java/org/openmetadata/service/mcpclient/McpClientService.java#L568-L572)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> <a href="#"><img alt="security" src="https://greptile-static-assets.s3.amazonaws.com/badges/Security.svg?v=2" align="top"></a> **Wrapped Context Loses Hints**

   When MCP receives a wrapped `SecurityContext`, this fallback creates a new `CatalogSecurityContext` with no `impersonatedUser` or `activePersona`. Downstream authorization then sees a `CatalogSecurityContext` and reads those null fields directly, so it never uses the request-scoped fallbacks that were set by the filters. A wrapped impersonated MCP request can therefore execute tool authorization without the normal impersonation check and without the selected persona.
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (4): Last reviewed commit: ["Preserve security hints in wrapped MCP c..."](https://github.com/open-metadata/openmetadata/commit/57c18dcf982022744ce1b7011d1e66dd50d2b68b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43872901)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Context used - CLAUDE.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=52f0d9d9-cad1-4e7d-b070-de181a0aa5e7))
- Context used - openmetadata-ui-core-components/CLAUDE.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=41754627-b2bf-474b-8082-f37ef1a07013))
- Context used - AGENTS.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=ef262f5f-911f-44f3-8d2d-e9cb1579c8c8))
</details>


<!-- /greptile_comment -->