### PR TITLE
fix(agents): show Policy Agent option in Add Agent dropdown for database services

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/ServiceAgents/components/MetadataAgentsView.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/ServiceAgents/components/MetadataAgentsView.component.tsx
@@ -33,6 +33,7 @@ import {
   getErrorPlaceHolder,
   getLogViewerStatusFromAgentStatus,
 } from '../../../utils/IngestionUtils';
+import serviceUtilClassBase from '../../../utils/ServiceUtilClassBase';
 import { showErrorToast } from '../../../utils/ToastUtils';
 import DeleteModal from '../../common/DeleteModal/DeleteModal';
 import LogViewerModal from '../../common/LogViewerModal/LogViewerModal.component';
@@ -181,6 +182,17 @@ const MetadataAgentsView: FC<MetadataAgentsViewProps> = ({
     [agents.length, platform, theme]
   );
 
+  const extraMenuItems = useMemo(
+    () =>
+      serviceUtilClassBase.getExtraIngestionMenuItems(
+        serviceCategory,
+        serviceName,
+        navigate,
+        serviceDetails
+      ),
+    [navigate, serviceCategory, serviceDetails, serviceName]
+  );
+
   const addAgentSlot = useMemo(() => {
     if (addAgentSlotProp) {
       return addAgentSlotProp;
@@ -188,6 +200,7 @@ const MetadataAgentsView: FC<MetadataAgentsViewProps> = ({
 
     return showAddAgent ? (
       <AddIngestionButton
+        extraMenuItems={extraMenuItems}
         ingestionList={ingestionPipelineList}
         serviceCategory={serviceCategory}
         serviceDetails={serviceDetails}
@@ -197,6 +210,7 @@ const MetadataAgentsView: FC<MetadataAgentsViewProps> = ({
   }, [
     addAgentSlotProp,
     showAddAgent,
+    extraMenuItems,
     ingestionPipelineList,
     serviceCategory,
     serviceDetails,


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:
## Why it happened

When the Agents tab was refactored to use the new `MetadataAgentsView` component, it rendered `AddIngestionButton` **without** the `extraMenuItems` prop. The old `MetadataAgentsWidget` used to pass it, but that wiring was not carried over.

We already have playwright test for this which runs in every nightly 

<img width="1314" height="690" alt="Screenshot 2026-07-13 at 11 41 19 PM" src="https://github.com/user-attachments/assets/52b5a909-3d57-4508-a55d-9bd7a7d4d5c1" />

Fixes #<issue-number>
<!--
Linking an issue is REQUIRED. Replace <issue-number> with the GitHub issue number this PR addresses
(e.g., `Fixes #12345`). GitHub will auto-link it. If no issue exists, please open one first so the
problem and design can be discussed before review.
-->

<!--
Short blurb explaining:
- What changes did you make?
- Why did you make them?
-->

I worked on ... because ...

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### High-level design:
<!--
REQUIRED for large PRs (new features, refactors, breaking changes, or anything touching >5 files).
Skip for small bug fixes and trivial changes.

Cover:
- Architecture / approach you took and why
- Key components or files added/changed and how they interact
- Alternatives considered and why you rejected them
- Any migration, backward-compatibility, or rollout concerns
- Diagrams or links to design docs / RFCs if available
-->

N/A — small change. <!-- Or fill in the design above -->

#
### Tests:

#### Use cases covered
<!--
List the user-visible scenarios this PR exercises. Example:
- User with Admin role can create a Glossary Term with a parent term
- Ingestion run for Snowflake correctly extracts row counts for partitioned tables
-->

#### Unit tests
<!--
- [ ] I added unit tests for the new/changed logic.
- Files added/updated:
- Coverage on changed classes (run `mvn jacoco:report` for backend, `yarn test:coverage` for UI,
  `make unit_ingestion` for ingestion). Target is 90% line coverage on changed classes.
- Coverage %: <e.g., 92% on EntityRepository.java>
-->

#### Backend integration tests
<!--
- [ ] I added integration tests in `openmetadata-integration-tests/` for new/changed API endpoints.
- [ ] Not applicable (no backend API changes).
- Files added/updated:
-->

#### Ingestion integration tests
<!--
- [ ] I added/updated ingestion integration tests for connector changes.
- [ ] Not applicable (no ingestion changes).
- Files added/updated:
-->

#### Playwright (UI) tests
<!--
- [ ] I added Playwright E2E tests under `openmetadata-ui/.../ui/playwright/` for UI changes.
- [ ] Not applicable (no UI changes).
- Files added/updated:
-->

#### Manual testing performed
<!--
List the manual test steps you performed before requesting review. Example:
1. Started local stack via `./docker/run_local_docker.sh -m ui -d mysql`
2. Logged in as admin, created entity X, verified Y appears in the UI
3. Triggered ingestion for Snowflake source, confirmed lineage edges in the explore page
-->

#
### UI screen recording / screenshots:
<!--
REQUIRED for any PR that changes the UI. Drag-and-drop a short screen recording (.mov / .mp4 / .gif)
demonstrating the change end-to-end, plus before/after screenshots where relevant.
Mark "Not applicable" if there are no UI changes.
-->

Not applicable. <!-- Or attach recording/screenshots above -->

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.
- [ ] For UI changes: I attached a screen recording and/or screenshots above.
- [ ] I have added tests (unit / integration / Playwright as applicable) and listed them above.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->

----
## Summary by Gitar

- **UI Improvements:**
  - Added `extraMenuItems` to the `AddIngestionButton` in `MetadataAgentsView` to allow selection of additional agent types.
  - Integrated `serviceUtilClassBase` to dynamically resolve ingestion menu items based on service category and details.

<sub>This will update automatically on new commits.</sub>

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds extra ingestion menu support to the metadata agents view. The main changes are:

- Imports the shared service utility singleton.
- Computes extra Add Agent menu items from service category, service name, navigation, and service details.
- Passes those extra menu items into `AddIngestionButton`.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge.

- No blocking issues found in the changed code.

</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-ui/src/main/resources/ui/src/components/ServiceAgents/components/MetadataAgentsView.component.tsx | Adds the existing extra ingestion menu hook to the metadata agents view and forwards its result to the add-agent dropdown. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(agents): show Policy Agent option in..."](https://github.com/open-metadata/openmetadata/commit/c0d59d53ddf82782e8285e9abfcd9afce155b70a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43891846)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Context used - CLAUDE.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=52f0d9d9-cad1-4e7d-b070-de181a0aa5e7))
- Context used - openmetadata-ui-core-components/CLAUDE.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=41754627-b2bf-474b-8082-f37ef1a07013))
- Context used - AGENTS.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=ef262f5f-911f-44f3-8d2d-e9cb1579c8c8))
</details>

<!-- /greptile_comment -->