### PR TITLE
Fixes #30006: Fix Data Contract alert filter search

### DIFF
--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/DataContractResourceIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/DataContractResourceIT.java
@@ -42,11 +42,15 @@ import org.openmetadata.schema.type.EntityHistory;
 import org.openmetadata.schema.type.EntityReference;
 import org.openmetadata.schema.type.EntityStatus;
 import org.openmetadata.schema.type.SemanticsRule;
+import org.openmetadata.schema.utils.ResultList;
+import org.openmetadata.sdk.client.OpenMetadataClient;
 import org.openmetadata.sdk.exceptions.OpenMetadataException;
 import org.openmetadata.sdk.fluent.DataContracts;
 import org.openmetadata.sdk.fluent.DataContracts.FluentDataContract;
 import org.openmetadata.sdk.models.ListParams;
 import org.openmetadata.sdk.models.ListResponse;
+import org.openmetadata.sdk.network.HttpMethod;
+import org.openmetadata.sdk.network.RequestOptions;
 import org.openmetadata.service.resources.data.DataContractResource;
 
 /**
@@ -653,6 +657,52 @@ public class DataContractResourceIT extends BaseEntityIT<DataContract, CreateDat
         foundRejectedContract,
         "Expected to find the rejected contract with matching entity and status");
   }
+
+  @Test
+  void testSearchDataContracts(TestNamespace ns) {
+    String searchToken = ns.prefix("contract_search");
+    DataContract contractByName =
+        createEntity(
+            new CreateDataContract()
+                .withName(searchToken + "_name")
+                .withEntity(createTestTable(ns).getEntityReference()));
+    DataContract contractByDisplayName =
+        createEntity(
+            new CreateDataContract()
+                .withName(ns.prefix("different_name"))
+                .withDisplayName(searchToken + " Display")
+                .withEntity(createTestTable(ns).getEntityReference()));
+
+    ResultList<DataContract> matches = searchDataContracts(searchToken);
+
+    assertTrue(matches.getData().stream().anyMatch(c -> c.getId().equals(contractByName.getId())));
+    assertTrue(
+        matches.getData().stream().anyMatch(c -> c.getId().equals(contractByDisplayName.getId())));
+    assertEquals(
+        matches.getData().size(), searchDataContracts(searchToken.toUpperCase()).getData().size());
+    assertTrue(searchDataContracts(ns.prefix("no_match")).getData().isEmpty());
+  }
+
+  private ResultList<DataContract> searchDataContracts(String query) {
+    OpenMetadataClient client = SdkClients.adminClient();
+    RequestOptions options =
+        RequestOptions.builder()
+            .queryParam("q", query)
+            .queryParam("limit", "50")
+            .queryParam("offset", "0")
+            .build();
+
+    return client
+        .getHttpClient()
+        .execute(
+            HttpMethod.GET,
+            "/v1/dataContracts/search",
+            null,
+            DataContractResultList.class,
+            options);
+  }
+
+  private static class DataContractResultList extends ResultList<DataContract> {}
 
   @Test
   void testDataContractWithEntityStatus(TestNamespace ns) {

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/data/DataContractResource.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/data/DataContractResource.java
@@ -113,6 +113,56 @@ public class DataContractResource extends EntityResource<DataContract, DataContr
     super(Entity.DATA_CONTRACT, authorizer, limits);
   }
 
+  @GET
+  @Path("/search")
+  @Valid
+  @Operation(
+      operationId = "searchDataContracts",
+      summary = "Search data contracts",
+      description =
+          "Search data contracts by name or display name. Use `q` parameter to provide the search query.",
+      responses = {
+        @ApiResponse(
+            responseCode = "200",
+            description = "List of matching data contracts",
+            content =
+                @Content(
+                    mediaType = "application/json",
+                    schema = @Schema(implementation = DataContractList.class)))
+      })
+  public ResultList<DataContract> search(
+      @Context UriInfo uriInfo,
+      @Context SecurityContext securityContext,
+      @Parameter(description = "Search query for data contract names or display names")
+          @QueryParam("q")
+          String query,
+      @Parameter(
+              description = "Fields requested in the returned resource",
+              schema = @Schema(type = "string", example = FIELDS))
+          @QueryParam("fields")
+          String fieldsParam,
+      @Parameter(description = "Limit the number of data contracts returned")
+          @DefaultValue("10")
+          @Min(value = 1, message = "must be greater than or equal to 1")
+          @Max(value = 1000, message = "must be less than or equal to 1000")
+          @QueryParam("limit")
+          int limitParam,
+      @Parameter(description = "Offset for pagination")
+          @DefaultValue("0")
+          @Min(value = 0, message = "must be greater than or equal to 0")
+          @QueryParam("offset")
+          int offsetParam,
+      @Parameter(
+              description = "Include all, deleted, or non-deleted entities",
+              schema = @Schema(implementation = Include.class))
+          @QueryParam("include")
+          @DefaultValue("non-deleted")
+          Include include) {
+    ListFilter filter = new ListFilter(include);
+    return searchInternal(
+        uriInfo, securityContext, fieldsParam, filter, query, limitParam, offsetParam);
+  }
+
   // Set the PipelineServiceClient so the repository can manage the Ingestion Pipelines for Test
   // Suites
   @Override

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Flow/ObservabilityAlerts.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Flow/ObservabilityAlerts.spec.ts
@@ -12,6 +12,7 @@
  */
 
 import { Page } from '@playwright/test';
+import { DataContract } from '../../../src/generated/entity/data/dataContract';
 import {
   INGESTION_PIPELINE_NAME,
   TEST_CASE_NAME,
@@ -34,7 +35,7 @@ import {
   verifyAlertDetails,
   visitAlertDetailsPage,
 } from '../../utils/alert';
-import { getApiContext } from '../../utils/common';
+import { getApiContext, uuid } from '../../utils/common';
 import { waitForAllLoadersToDisappear } from '../../utils/entity';
 import {
   addExternalDestination,
@@ -317,6 +318,88 @@ for (const { source, sourceDisplayName } of OBSERVABILITY_SOURCES) {
     });
   });
 }
+
+test('Data Contract Name filter lists matching data contracts', async ({
+  page,
+}) => {
+  test.slow();
+  const { afterAction, apiContext } = await getApiContext(page);
+  let dataContract: DataContract | undefined;
+
+  try {
+    const dataContractName = `0-playwright-data-contract-${uuid()}`;
+    const createResponse = await apiContext.post('/api/v1/dataContracts', {
+      data: {
+        name: dataContractName,
+        description: 'Data contract for the observability alert filter test',
+        entity: {
+          id: table1.entityResponseData.id,
+          type: 'table',
+        },
+      },
+    });
+
+    test.expect(createResponse.ok()).toBeTruthy();
+    const createdDataContract: DataContract = await createResponse.json();
+    dataContract = createdDataContract;
+
+    if (!createdDataContract.fullyQualifiedName) {
+      throw new Error(
+        'Created data contract is missing its fully qualified name'
+      );
+    }
+    const dataContractFqn = createdDataContract.fullyQualifiedName;
+
+    await inputBasicAlertInformation({
+      page,
+      name: generateAlertName(),
+      sourceName: 'dataContract',
+      sourceDisplayName: 'Data Contract',
+      createButtonId: 'create-observability',
+    });
+
+    await page.getByTestId('add-filters').click();
+    await page.getByTestId('filter-select-0').click();
+    await page
+      .locator('.ant-select-dropdown:visible')
+      .getByTestId('Data Contract Name-filter-option')
+      .click();
+
+    const fqnInput = page.getByTestId('fqn-list-select').getByRole('combobox');
+    await fqnInput.click();
+    await fqnInput.fill(dataContractName);
+
+    const dataContractOption = page
+      .locator('.ant-select-dropdown:visible')
+      .getByTitle(dataContractFqn);
+    const searchFailureAlert = page
+      .getByTestId('alert-bar')
+      .filter({ hasText: 'Search failed' })
+      .first();
+
+    await test.expect
+      .poll(async () => {
+        if (await dataContractOption.isVisible()) {
+          return 'data-contract-option';
+        }
+
+        if (await searchFailureAlert.isVisible()) {
+          return (await searchFailureAlert.textContent())?.trim();
+        }
+
+        return 'waiting-for-data-contract-option';
+      })
+      .toBe('data-contract-option');
+  } finally {
+    if (dataContract) {
+      await apiContext.delete(
+        `/api/v1/dataContracts/${dataContract.id}?hardDelete=true&recursive=true`
+      );
+    }
+    await afterAction();
+  }
+});
+
 test('Alert operations for a user with and without permissions', async ({
   page,
   userWithPermissionsPage,

--- a/openmetadata-ui/src/main/resources/ui/src/rest/contractAPI.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/rest/contractAPI.ts
@@ -12,6 +12,7 @@
  */
 import { AxiosResponse } from 'axios';
 import { Operation } from 'fast-json-patch';
+import { PagingResponse } from 'Models';
 import {
   ContractAllResult,
   ContractResultFilter,
@@ -46,6 +47,24 @@ export const listContracts = async (params: ListContractsParams) => {
   });
 
   return response.data;
+};
+
+export const searchContracts = async (
+  query: string,
+  limit = 25
+): Promise<DataContract[]> => {
+  const response = await APIClient.get<PagingResponse<DataContract[]>>(
+    `${BASE_URL}/search`,
+    {
+      params: {
+        q: query || undefined,
+        limit,
+        offset: 0,
+      },
+    }
+  );
+
+  return response.data.data;
 };
 
 export const getContract = async (fqn: string) => {

--- a/openmetadata-ui/src/main/resources/ui/src/utils/Alerts/AlertsUtil.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/Alerts/AlertsUtil.test.tsx
@@ -36,6 +36,7 @@ import {
   mockTypedEvent4,
 } from '../../mocks/AlertUtil.mock';
 import { ModifiedDestination } from '../../pages/AddObservabilityPage/AddObservabilityPage.interface';
+import { searchContracts } from '../../rest/contractAPI';
 import { searchQuery } from '../../rest/searchAPI';
 import { getTermQuery } from '../SearchPureUtils';
 import {
@@ -83,6 +84,10 @@ jest.mock('../../components/common/AsyncSelect/AsyncSelect', () => ({
 
 jest.mock('../../rest/searchAPI', () => ({
   searchQuery: jest.fn(),
+}));
+
+jest.mock('../../rest/contractAPI', () => ({
+  searchContracts: jest.fn(),
 }));
 
 jest.mock('../ToastUtils', () => ({
@@ -359,6 +364,34 @@ describe('getFieldByArgumentType tests', () => {
         SearchIndex.DATABASE_SCHEMA,
       ],
     });
+  });
+
+  it('should use the Data Contract API for a dataContract fqnList', async () => {
+    const { AsyncSelect: MockedAsyncSelect } = jest.requireMock(
+      '../../components/common/AsyncSelect/AsyncSelect'
+    );
+    MockedAsyncSelect.mockClear();
+    (searchQuery as jest.Mock).mockClear();
+    (searchContracts as jest.Mock).mockResolvedValue([
+      {
+        fullyQualifiedName: 'service.database.schema.table.dataContract_test',
+      },
+    ]);
+
+    render(getFieldByArgumentType(0, 'fqnList', 0, 'dataContract'));
+
+    const api = MockedAsyncSelect.mock.calls[0][0].api as (
+      query: string
+    ) => Promise<unknown>;
+
+    await expect(api('test')).resolves.toEqual([
+      {
+        label: 'service.database.schema.table.dataContract_test',
+        value: 'service.database.schema.table.dataContract_test',
+      },
+    ]);
+    expect(searchContracts).toHaveBeenCalledWith('test', 50);
+    expect(searchQuery).not.toHaveBeenCalled();
   });
 
   it('should return correct fields for argumentType domainList', async () => {

--- a/openmetadata-ui/src/main/resources/ui/src/utils/Alerts/AlertsUtil.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/Alerts/AlertsUtil.tsx
@@ -58,6 +58,7 @@ import {
 import { PAGE_SIZE_LARGE } from '../../constants/constants';
 import { UUID_REGEX } from '../../constants/regex.constants';
 import { AlertRecentEventFilters } from '../../enums/Alerts.enum';
+import { EntityType } from '../../enums/entity.enum';
 import { SearchIndex } from '../../enums/search.enum';
 import { StatusType } from '../../generated/entity/data/pipeline';
 import { PipelineState } from '../../generated/entity/services/ingestionPipelines/ingestionPipeline';
@@ -74,6 +75,7 @@ import {
 import { Status as DestinationStatus } from '../../generated/events/testDestinationStatus';
 import { TestCaseStatus } from '../../generated/tests/testCase';
 import { EventType } from '../../generated/type/changeEvent';
+import { searchContracts } from '../../rest/contractAPI';
 import { searchQuery } from '../../rest/searchAPI';
 import { ExtraInfoLabel } from '../DataAssetsHeader.utils';
 import { getEntityName, getEntityNameLabel } from '../EntityNameUtils';
@@ -199,6 +201,29 @@ const getTableSuggestions = async (searchText: string) => {
     searchIndex: SearchIndex.TABLE,
     showDisplayNameAsLabel: false,
   });
+};
+
+const getDataContractSuggestions = async (searchText = '') => {
+  try {
+    const contracts = await searchContracts(searchText, PAGE_SIZE_LARGE);
+
+    return contracts
+      .map((contract) => contract.fullyQualifiedName ?? '')
+      .filter(Boolean)
+      .map((fullyQualifiedName) => ({
+        label: fullyQualifiedName,
+        value: fullyQualifiedName,
+      }));
+  } catch (error) {
+    showErrorToast(
+      error as AxiosError,
+      t('server.entity-fetch-error', {
+        entity: t('label.data-contract'),
+      })
+    );
+
+    return [];
+  }
 };
 
 const getTestSuiteSuggestions = async (searchText: string) => {
@@ -859,6 +884,10 @@ export const getFieldByArgumentType = (
   let field: JSX.Element;
 
   const getEntityByFQN = async (searchText: string) => {
+    if (selectedTrigger === EntityType.DATA_CONTRACT) {
+      return getDataContractSuggestions(searchText);
+    }
+
     return searchEntity({
       searchText,
       searchIndex: getFqnSearchIndexes(selectedTrigger, containerEntities),


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:

Fixes #30006

Routes Data Contract alert-filter suggestions through a paginated REST search endpoint because Data Contracts do not have a search index, preventing invalid root-index POST requests.

#
### Type of change:

- [x] Bug fix

#
### High-level design:

- Adds `/api/v1/dataContracts/search` using the existing case-insensitive name/display-name database filter and offset pagination.
- Uses that endpoint only for Data Contract FQN alert filters while retaining search indexes for other entity sources.
- Includes backend integration, frontend unit, and Playwright regression coverage.

#
### Tests:

#### Use cases covered

- Admin can search for and select a Data Contract in the **Data Contract Name** observability-alert filter without an HTTP 405 banner.

#### Unit tests

- [x] I added unit tests for the new/changed logic.
- Updated `AlertsUtil.test.tsx`; 112 focused tests passed.

#### Backend integration tests

- [x] I added integration tests in `openmetadata-integration-tests/` for new/changed API endpoints.
- Updated `DataContractResourceIT.java` for name, display-name, case-insensitive, and empty-result search behavior.

#### Ingestion integration tests

- [x] Not applicable (no ingestion changes).

#### Playwright (UI) tests

- [x] I added Playwright E2E tests under `openmetadata-ui/.../ui/playwright/` for UI changes.
- Updated `ObservabilityAlerts.spec.ts`; the focused Chromium run passed with setup and teardown (`4 passed`).

#### Manual testing performed

1. Reproduced the HTTP 405 banner on the Data Contract Name filter.
2. Rebuilt the local backend and verified the matching Data Contract appears without an error banner.

#
### UI screen recording / screenshots:

Not attached; this is a draft PR with automated Playwright coverage.

#
### Checklist:

- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] My PR title is `Fixes <issue-number>: <short explanation>`
- [x] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.
- [ ] For UI changes: I attached a screen recording and/or screenshots above.
- [x] I have added tests (unit / integration / Playwright as applicable) and listed them above.

- [x] I have added a test that covers the exact scenario we are fixing.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR routes Data Contract alert-filter search through a dedicated REST endpoint. The main changes are:

- Added `/dataContracts/search` with name and display-name filtering.
- Added a frontend `searchContracts` API wrapper.
- Routed Data Contract FQN alert suggestions away from the generic search index path.
- Added backend, unit, and Playwright coverage for the fixed alert filter flow.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge after checking the Data Contract resource name stays stable.

- The backend endpoint follows the existing resource search pattern.
- The frontend option shape matches the existing FQN filter contract.
- The remaining concern is a contained compatibility guard around the exact `dataContract` resource value.

openmetadata-ui/src/main/resources/ui/src/utils/Alerts/AlertsUtil.tsx
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-service/src/main/java/org/openmetadata/service/resources/data/DataContractResource.java | Adds a paginated Data Contract search endpoint using the existing resource search helper. |
| openmetadata-ui/src/main/resources/ui/src/rest/contractAPI.ts | Adds a REST wrapper that returns Data Contract search results as an array. |
| openmetadata-ui/src/main/resources/ui/src/utils/Alerts/AlertsUtil.tsx | Routes Data Contract FQN suggestions through the new API, with one small compatibility risk around exact resource naming. |
| openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/DataContractResourceIT.java | Adds integration coverage for Data Contract search by name, display name, casing, and empty results. |
| openmetadata-ui/src/main/resources/ui/src/utils/Alerts/AlertsUtil.test.tsx | Adds unit coverage for using the Data Contract API in FQN alert filters. |
| openmetadata-ui/src/main/resources/ui/playwright/e2e/Flow/ObservabilityAlerts.spec.ts | Adds an end-to-end alert-filter test for selecting a matching Data Contract. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
  participant User
  participant UI as Alert Filter UI
  participant API as searchContracts
  participant Backend as /api/v1/dataContracts/search
  participant Repo as DataContract Repository

  User->>UI: Type in Data Contract Name filter
  UI->>API: searchContracts(query, 50)
  API->>Backend: "GET /dataContracts/search?q=query&limit=50&offset=0"
  Backend->>Repo: Search by name or displayName
  Repo-->>Backend: Matching DataContracts
  Backend-->>API: Result list
  API-->>UI: DataContract array
  UI-->>User: FQN suggestions
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
  participant User
  participant UI as Alert Filter UI
  participant API as searchContracts
  participant Backend as /api/v1/dataContracts/search
  participant Repo as DataContract Repository

  User->>UI: Type in Data Contract Name filter
  UI->>API: searchContracts(query, 50)
  API->>Backend: "GET /dataContracts/search?q=query&limit=50&offset=0"
  Backend->>Repo: Search by name or displayName
  Repo-->>Backend: Matching DataContracts
  Backend-->>API: Result list
  API-->>UI: DataContract array
  UI-->>User: FQN suggestions
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["Fixes #30006: Data Contract alert filter..."](https://github.com/open-metadata/openmetadata/commit/29db54d7f194f9a5aebca3357dd636741efa9b67) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43924974)</sub>

> Greptile also left **1 inline comment** on this PR.

<details><summary><h4>Context used (3)</h4></summary>

- Context used - CLAUDE.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=52f0d9d9-cad1-4e7d-b070-de181a0aa5e7))
- Context used - openmetadata-ui-core-components/CLAUDE.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=41754627-b2bf-474b-8082-f37ef1a07013))
- Context used - AGENTS.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=ef262f5f-911f-44f3-8d2d-e9cb1579c8c8))
</details>

<!-- /greptile_comment -->