### PR TITLE
Fix z-index issue while add rule form drawer open

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/Settings/Persona/PersonaAIContext/ContextPreviewModal/ContextPreviewModal.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Settings/Persona/PersonaAIContext/ContextPreviewModal/ContextPreviewModal.component.tsx
@@ -109,7 +109,6 @@ export const ContextPreviewModal = ({
   useEffect(() => {
     onDocumentLoadedRef.current = onDocumentLoaded;
   }, [onDocumentLoaded]);
-  
 
   const fetchPreview = useCallback(
     async (refresh = false) => {

--- a/openmetadata-ui/src/main/resources/ui/src/components/Settings/Persona/PersonaAIContext/ContextPreviewModal/ContextPreviewModal.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Settings/Persona/PersonaAIContext/ContextPreviewModal/ContextPreviewModal.component.tsx
@@ -32,6 +32,7 @@ import {
   useState,
 } from 'react';
 import { useTranslation } from 'react-i18next';
+import { CACHE_STATE_BADGE_COLOR } from '../../../../../constants/PersonaAIContext.constants';
 import { useClipboard } from '../../../../../hooks/useClipBoard';
 import {
   getPersonaAIContextDocument,
@@ -60,14 +61,14 @@ const FRONT_MATTER_CLASS = [
 ].join(' ');
 
 const HEADING_BASE_CLASS =
-  'tw:w-full tw:cursor-pointer tw:rounded-md tw:px-2.5 tw:py-1.5 tw:text-left tw:transition tw:hover:bg-secondary_hover';
+  'tw:block tw:cursor-pointer tw:rounded-md tw:text-left tw:transition tw:hover:bg-secondary_hover';
 
 const getHeadingStateClass = (isActive: boolean, isNested: boolean) => {
   let stateClass = 'tw:font-medium tw:text-secondary';
   if (isActive) {
     stateClass = 'tw:bg-brand-primary tw:font-semibold tw:text-brand-secondary';
   } else if (isNested) {
-    stateClass = 'tw:font-normal tw:text-tertiary';
+    stateClass = 'tw:font-normal tw:text-quaternary';
   }
 
   return stateClass;
@@ -75,8 +76,8 @@ const getHeadingStateClass = (isActive: boolean, isNested: boolean) => {
 
 const getHeadingClassName = (isActive: boolean, isNested: boolean) => {
   const sizeClass = isNested
-    ? 'tw:pl-5.5 tw:font-mono tw:text-[12px]'
-    : 'tw:text-[13px]';
+    ? 'tw:ml-5.5 tw:truncate tw:px-2 tw:py-0.75 tw:font-mono tw:text-[12px]'
+    : 'tw:w-full tw:truncate tw:px-2.5 tw:py-1.75 tw:text-[13px]';
 
   return [
     HEADING_BASE_CLASS,
@@ -271,9 +272,9 @@ export const ContextPreviewModal = ({
     return (
       <Box className="tw:grid! tw:min-h-0 tw:flex-1 tw:grid-cols-[240px_1fr] tw:overflow-hidden">
         <Box
-          className="tw:gap-0.5 tw:overflow-auto tw:border-r tw:border-secondary tw:bg-secondary tw:p-4"
+          className="tw:gap-0.5 tw:overflow-auto tw:border-r tw:border-secondary tw:bg-secondary_subtle tw:px-3 tw:py-4"
           direction="col">
-          <Box className="tw:mb-2 tw:px-2.5">
+          <Box className="tw:px-2.5 tw:pb-2">
             <Typography
               className="tw:text-[11px] tw:tracking-wider tw:text-quaternary tw:uppercase"
               weight="semibold">
@@ -387,7 +388,9 @@ export const ContextPreviewModal = ({
                   </Box>
                 ))}
                 {contextDocument?.cacheState && (
-                  <Badge color="gray" size="sm">
+                  <Badge
+                    color={CACHE_STATE_BADGE_COLOR[contextDocument.cacheState]}
+                    size="sm">
                     {contextDocument.cacheState.toLowerCase()}
                   </Badge>
                 )}

--- a/openmetadata-ui/src/main/resources/ui/src/components/Settings/Persona/PersonaAIContext/ContextPreviewModal/ContextPreviewModal.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Settings/Persona/PersonaAIContext/ContextPreviewModal/ContextPreviewModal.component.tsx
@@ -64,7 +64,7 @@ const HEADING_BASE_CLASS =
   'tw:block tw:cursor-pointer tw:rounded-md tw:text-left tw:transition tw:hover:bg-secondary_hover';
 
 const getHeadingStateClass = (isActive: boolean, isNested: boolean) => {
-  let stateClass = 'tw:font-medium tw:text-secondary';
+  let stateClass = 'tw:font-medium tw:text-primary';
   if (isActive) {
     stateClass = 'tw:bg-brand-primary tw:font-semibold tw:text-brand-secondary';
   } else if (isNested) {
@@ -76,7 +76,7 @@ const getHeadingStateClass = (isActive: boolean, isNested: boolean) => {
 
 const getHeadingClassName = (isActive: boolean, isNested: boolean) => {
   const sizeClass = isNested
-    ? 'tw:ml-5.5 tw:truncate tw:px-2 tw:py-0.75 tw:font-mono tw:text-[12px]'
+    ? 'tw:ml-5.5 tw:w-[calc(100%-1.375rem)] tw:truncate tw:px-2 tw:py-0.75 tw:font-mono tw:text-[12px]'
     : 'tw:w-full tw:truncate tw:px-2.5 tw:py-1.75 tw:text-[13px]';
 
   return [
@@ -109,6 +109,7 @@ export const ContextPreviewModal = ({
   useEffect(() => {
     onDocumentLoadedRef.current = onDocumentLoaded;
   }, [onDocumentLoaded]);
+  
 
   const fetchPreview = useCallback(
     async (refresh = false) => {
@@ -272,7 +273,7 @@ export const ContextPreviewModal = ({
     return (
       <Box className="tw:grid! tw:min-h-0 tw:flex-1 tw:grid-cols-[240px_1fr] tw:overflow-hidden">
         <Box
-          className="tw:gap-0.5 tw:overflow-auto tw:border-r tw:border-secondary tw:bg-secondary_subtle tw:px-3 tw:py-4"
+          className="tw:min-w-0 tw:gap-0.5 tw:overflow-auto tw:border-r tw:border-secondary tw:bg-secondary_subtle tw:px-3 tw:py-4"
           direction="col">
           <Box className="tw:px-2.5 tw:pb-2">
             <Typography
@@ -283,6 +284,7 @@ export const ContextPreviewModal = ({
           </Box>
           {headings.map((heading, index) => (
             <Typography
+              ellipsis
               as="button"
               className={getHeadingClassName(
                 activeHeading === index,

--- a/openmetadata-ui/src/main/resources/ui/src/components/Settings/Persona/PersonaAIContext/PersonaAIContext.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Settings/Persona/PersonaAIContext/PersonaAIContext.component.tsx
@@ -12,7 +12,6 @@
  */
 import {
   Badge,
-  BadgeColors,
   Box,
   Button,
   Card,
@@ -26,7 +25,10 @@ import { Clock, ClockRewind, Eye, FolderPlus, Plus } from '@untitledui/icons';
 import { AxiosError } from 'axios';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { DEFAULT_PERSONA_CONTEXT_DEFINITION } from '../../../../constants/PersonaAIContext.constants';
+import {
+  CACHE_STATE_BADGE_COLOR,
+  DEFAULT_PERSONA_CONTEXT_DEFINITION,
+} from '../../../../constants/PersonaAIContext.constants';
 import { Persona } from '../../../../generated/entity/teams/persona';
 import {
   CacheState,
@@ -65,12 +67,6 @@ const VERSION_BADGE_CLASS = [
   'tw:transition tw:hover:bg-primary_hover',
 ].join(' ');
 
-const CACHE_STATE_BADGE_COLOR: Record<CacheState, BadgeColors> = {
-  [CacheState.Fresh]: 'success',
-  [CacheState.Stale]: 'gray',
-  [CacheState.Generating]: 'warning',
-  [CacheState.Failed]: 'error',
-};
 
 export const PersonaAIContext = ({
   canEdit,

--- a/openmetadata-ui/src/main/resources/ui/src/components/Settings/Persona/PersonaAIContext/PersonaAIContext.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Settings/Persona/PersonaAIContext/PersonaAIContext.component.tsx
@@ -67,7 +67,6 @@ const VERSION_BADGE_CLASS = [
   'tw:transition tw:hover:bg-primary_hover',
 ].join(' ');
 
-
 export const PersonaAIContext = ({
   canEdit,
   persona,

--- a/openmetadata-ui/src/main/resources/ui/src/components/Settings/Persona/PersonaAIContext/VersionHistoryDrawer/VersionHistoryDrawer.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Settings/Persona/PersonaAIContext/VersionHistoryDrawer/VersionHistoryDrawer.component.tsx
@@ -313,23 +313,18 @@ export const VersionHistoryDrawer = ({
             }
           }}>
           <Modal>
-            <Dialog data-testid="restore-version-modal" width={440}>
-              <Box direction="col" gap={5}>
-                <Box direction="col" gap={2}>
-                  <Typography
-                    className="tw:text-primary"
-                    size="text-lg"
-                    weight="semibold">
-                    {t('label.restore-version', {
-                      version: restoreTarget.version,
-                    })}
-                  </Typography>
-                  <Typography className="tw:text-secondary" size="text-sm">
-                    {t('message.persona-context-restore-confirmation', {
-                      version: restoreTarget.version,
-                    })}
-                  </Typography>
-                </Box>
+            <Dialog data-testid="restore-version-modal" width={450}>
+              <Dialog.Header
+                title={t('label.restore-version', {
+                  version: restoreTarget.version,
+                })}
+              />
+              <Dialog.Content className="tw:pb-6">
+                <Typography className="tw:text-secondary" size="text-sm">
+                  {t('message.persona-context-restore-confirmation', {
+                    version: restoreTarget.version,
+                  })}
+                </Typography>
                 <Box gap={3} justify="end">
                   <Button
                     color="secondary"
@@ -344,7 +339,7 @@ export const VersionHistoryDrawer = ({
                     {t('label.restore')}
                   </Button>
                 </Box>
-              </Box>
+              </Dialog.Content>
             </Dialog>
           </Modal>
         </ModalOverlay>

--- a/openmetadata-ui/src/main/resources/ui/src/constants/PersonaAIContext.constants.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/constants/PersonaAIContext.constants.ts
@@ -10,11 +10,20 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
+import { BadgeColors } from '@openmetadata/ui-core-components';
 import { EntityType } from '../enums/entity.enum';
 import {
+  CacheState,
   ContextSection,
   PersonaContextDefinition,
 } from '../generated/type/personaContextDefinition';
+
+export const CACHE_STATE_BADGE_COLOR: Record<CacheState, BadgeColors> = {
+  [CacheState.Fresh]: 'gray',
+  [CacheState.Stale]: 'gray',
+  [CacheState.Generating]: 'warning',
+  [CacheState.Failed]: 'error',
+};
 
 export const PERSONA_CONTEXT_ASSET_SECTIONS = [
   ContextSection.Description,

--- a/openmetadata-ui/src/main/resources/ui/src/pages/Persona/PersonaDetailsPage/PersonaDetailsPage.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/Persona/PersonaDetailsPage/PersonaDetailsPage.tsx
@@ -343,7 +343,7 @@ export const PersonaDetailsPage = () => {
 
   return (
     <PageLayoutV1 pageTitle={personaDetails.name}>
-      <Row className="m-b-md" gutter={[0, 16]}>
+      <Row className="m-b-md tw:isolate" gutter={[0, 16]}>
         <Col span={24}>
           <div className="d-flex justify-between items-start">
             <div className="persona-details-title-container">


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:

<img width="1512" height="801" alt="Screenshot 2026-07-14 at 10 25 05 AM" src="https://github.com/user-attachments/assets/1d981eb4-69e3-476f-84b4-2daf6cf21e4f" />


#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### High-level design:
<!--
REQUIRED for large PRs (new features, refactors, breaking changes, or anything touching >5 files).
Skip for small bug fixes and trivial changes.

Cover:
- Architecture / approach you took and why
- Key components or files added/changed and how they interact
- Alternatives considered and why you rejected them
- Any migration, backward-compatibility, or rollout concerns
- Diagrams or links to design docs / RFCs if available
-->

N/A — small change. <!-- Or fill in the design above -->

#
### Tests:

#### Use cases covered
<!--
List the user-visible scenarios this PR exercises. Example:
- User with Admin role can create a Glossary Term with a parent term
- Ingestion run for Snowflake correctly extracts row counts for partitioned tables
-->

#### Unit tests
<!--
- [ ] I added unit tests for the new/changed logic.
- Files added/updated:
- Coverage on changed classes (run `mvn jacoco:report` for backend, `yarn test:coverage` for UI,
  `make unit_ingestion` for ingestion). Target is 90% line coverage on changed classes.
- Coverage %: <e.g., 92% on EntityRepository.java>
-->

#### Backend integration tests
<!--
- [ ] I added integration tests in `openmetadata-integration-tests/` for new/changed API endpoints.
- [ ] Not applicable (no backend API changes).
- Files added/updated:
-->

#### Ingestion integration tests
<!--
- [ ] I added/updated ingestion integration tests for connector changes.
- [ ] Not applicable (no ingestion changes).
- Files added/updated:
-->

#### Playwright (UI) tests
<!--
- [ ] I added Playwright E2E tests under `openmetadata-ui/.../ui/playwright/` for UI changes.
- [ ] Not applicable (no UI changes).
- Files added/updated:
-->

#### Manual testing performed
<!--
List the manual test steps you performed before requesting review. Example:
1. Started local stack via `./docker/run_local_docker.sh -m ui -d mysql`
2. Logged in as admin, created entity X, verified Y appears in the UI
3. Triggered ingestion for Snowflake source, confirmed lineage edges in the explore page
-->

#
### UI screen recording / screenshots:
<!--
REQUIRED for any PR that changes the UI. Drag-and-drop a short screen recording (.mov / .mp4 / .gif)
demonstrating the change end-to-end, plus before/after screenshots where relevant.
Mark "Not applicable" if there are no UI changes.
-->

Not applicable. <!-- Or attach recording/screenshots above -->

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.
- [ ] For UI changes: I attached a screen recording and/or screenshots above.
- [ ] I have added tests (unit / integration / Playwright as applicable) and listed them above.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->

----
## Summary by Gitar

- **UI enhancements:**
  - Isolated `PersonaDetailsPage` content row to fix z-index overlay issues.
  - Revamped `ContextPreviewModal` layout, sidebar styling, and heading truncation.
  - Updated `VersionHistoryDrawer` to use standardized `Dialog` subcomponents.
- **Shared logic:**
  - Moved cache-state badge colors into `PersonaAIContext.constants.ts` for consistent usage across components.
  - Updated `ContextPreviewModal` to utilize the centralized `CACHE_STATE_BADGE_COLOR` mapping.

<sub>This will update automatically on new commits.</sub>

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR updates Persona AI Context UI behavior and layout. The main changes are:

- Adds stacking isolation on the Persona details content row.
- Refreshes the Context Preview sidebar layout and heading truncation.
- Moves cache-state badge colors into a shared Persona AI Context constant.
- Updates the restore-version confirmation modal to use shared dialog sections.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge.

- No blocking issues found in the changed code.

</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-ui/src/main/resources/ui/src/pages/Persona/PersonaDetailsPage/PersonaDetailsPage.tsx | Adds isolation to the main Persona details row. |
| openmetadata-ui/src/main/resources/ui/src/components/Settings/Persona/PersonaAIContext/ContextPreviewModal/ContextPreviewModal.component.tsx | Updates preview modal navigation styling and cache-state badge colors. |
| openmetadata-ui/src/main/resources/ui/src/components/Settings/Persona/PersonaAIContext/PersonaAIContext.component.tsx | Uses the shared cache-state badge color map. |
| openmetadata-ui/src/main/resources/ui/src/constants/PersonaAIContext.constants.ts | Adds the shared cache-state badge color map. |
| openmetadata-ui/src/main/resources/ui/src/components/Settings/Persona/PersonaAIContext/VersionHistoryDrawer/VersionHistoryDrawer.component.tsx | Refactors the restore confirmation modal with shared dialog subcomponents. |

</details>

<sub>Reviews (4): Last reviewed commit: ["Merge branch &#39;persona-context-drawer&#39; of..."](https://github.com/open-metadata/openmetadata/commit/668c11b62b04b27509d155f12b5989938684b8d6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44040268)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Context used - CLAUDE.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=52f0d9d9-cad1-4e7d-b070-de181a0aa5e7))
- Context used - openmetadata-ui-core-components/CLAUDE.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=41754627-b2bf-474b-8082-f37ef1a07013))
- Context used - AGENTS.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=ef262f5f-911f-44f3-8d2d-e9cb1579c8c8))
</details>

<!-- /greptile_comment -->