### PR TITLE
Backport #28655 to 1.13: preserve inherited domains in CSV bulk edit (#28523)

### DIFF
--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/DatabaseSchemaResourceIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/DatabaseSchemaResourceIT.java
@@ -7,9 +7,16 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
+import java.io.IOException;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import java.util.function.Consumer;
+import org.apache.commons.csv.CSVFormat;
+import org.apache.commons.csv.CSVParser;
+import org.apache.commons.csv.CSVPrinter;
+import org.apache.commons.csv.CSVRecord;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
@@ -1704,19 +1711,15 @@ public class DatabaseSchemaResourceIT extends BaseEntityIT<DatabaseSchema, Creat
             Void.class);
 
     String exportedCsv = client.databaseSchemas().exportCsv(schema.getFullyQualifiedName(), true);
-    java.util.List<String> csvLines = java.util.Arrays.asList(exportedCsv.split("\\n"));
-    java.util.List<String> modified = new java.util.ArrayList<>();
-    modified.add(csvLines.get(0));
-    for (String line : csvLines.subList(1, csvLines.size())) {
-      String[] cols = line.split(",", -1);
-      if (cols.length > 12 && "table".equals(cols[12].trim())) {
-        cols[2] = "Recursive Bulk Edited";
-        cols[10] = "";
-        line = String.join(",", cols);
-      }
-      modified.add(line);
-    }
-    String newCsv = String.join("\n", modified) + "\n";
+    String newCsv =
+        rewriteCsvRows(
+            exportedCsv,
+            cols -> {
+              if (cols.size() > 12 && "table".equals(cols.get(12).trim())) {
+                cols.set(2, "Recursive Bulk Edited");
+                cols.set(10, "");
+              }
+            });
 
     String dryRunRaw =
         client.databaseSchemas().importCsv(schema.getFullyQualifiedName(), newCsv, true, true);
@@ -1812,24 +1815,21 @@ public class DatabaseSchemaResourceIT extends BaseEntityIT<DatabaseSchema, Creat
             Void.class);
 
     String exportedCsv = client.databaseSchemas().exportCsv(schema.getFullyQualifiedName(), true);
-    java.util.List<String> csvLines = java.util.Arrays.asList(exportedCsv.split("\\n"));
-    java.util.List<String> modified = new java.util.ArrayList<>();
-    modified.add(csvLines.get(0));
-    boolean tableRowFound = false;
-    for (String line : csvLines.subList(1, csvLines.size())) {
-      String[] cols = line.split(",", -1);
-      if (cols.length > 12 && "table".equals(cols[12].trim())) {
-        assertTrue(
-            cols[10].trim().isEmpty(),
-            "Export must not write the inherited domain to the CSV domains column: " + line);
-        cols[2] = "Round Trip Edited";
-        line = String.join(",", cols);
-        tableRowFound = true;
-      }
-      modified.add(line);
-    }
-    assertTrue(tableRowFound, "Exported CSV should contain the table row");
-    String newCsv = String.join("\n", modified) + "\n";
+    boolean[] tableRowFound = {false};
+    String newCsv =
+        rewriteCsvRows(
+            exportedCsv,
+            cols -> {
+              if (cols.size() > 12 && "table".equals(cols.get(12).trim())) {
+                assertTrue(
+                    cols.get(10).trim().isEmpty(),
+                    "Export must not write the inherited domain to the CSV domains column: "
+                        + cols);
+                cols.set(2, "Round Trip Edited");
+                tableRowFound[0] = true;
+              }
+            });
+    assertTrue(tableRowFound[0], "Exported CSV should contain the table row");
 
     String dryRunRaw =
         client.databaseSchemas().importCsv(schema.getFullyQualifiedName(), newCsv, true, true);
@@ -2092,6 +2092,29 @@ public class DatabaseSchemaResourceIT extends BaseEntityIT<DatabaseSchema, Creat
         .map(org.openmetadata.schema.type.EntityReference::getName)
         .reduce((a, b) -> a + ";" + b)
         .orElse("");
+  }
+
+  /**
+   * Rewrites an exported CSV by applying {@code rowEditor} to every data row (header untouched),
+   * using Commons CSV so quoted fields containing commas or newlines survive the round trip.
+   */
+  private static String rewriteCsvRows(String csv, Consumer<List<String>> rowEditor)
+      throws IOException {
+    CSVFormat format = CSVFormat.DEFAULT.builder().setRecordSeparator('\n').build();
+    StringBuilder rewritten = new StringBuilder();
+    try (CSVParser parser = CSVParser.parse(csv, format);
+        CSVPrinter printer = new CSVPrinter(rewritten, format)) {
+      boolean isHeader = true;
+      for (CSVRecord csvRecord : parser) {
+        List<String> cols = new ArrayList<>(csvRecord.toList());
+        if (!isHeader) {
+          rowEditor.accept(cols);
+        }
+        isHeader = false;
+        printer.printRecord(cols);
+      }
+    }
+    return rewritten.toString();
   }
 
   private String formatExtensionForCsv(Object extension) {

--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/DatabaseSchemaResourceIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/DatabaseSchemaResourceIT.java
@@ -1746,6 +1746,119 @@ public class DatabaseSchemaResourceIT extends BaseEntityIT<DatabaseSchema, Creat
   }
 
   /**
+   * Export→import round-trip for #28523: an inherited domain must not be written to the CSV domains
+   * column on export. Otherwise re-import reads it back as a plain FQN (the inherited flag is lost in
+   * serialization), {@code dropInheritedDomains} cannot recognize it, and it gets materialized as a
+   * direct domain. Asserts the exported table row has an empty domain column, then re-imports the
+   * export verbatim (only the description edited) and confirms the domain stays inherited.
+   */
+  @Test
+  void test_exportCsv_inheritedDomainNotExported_roundTripDoesNotMaterialize(TestNamespace ns)
+      throws Exception {
+    OpenMetadataClient client = SdkClients.adminClient();
+    DatabaseService service = DatabaseServiceTestFactory.createPostgres(ns);
+
+    org.openmetadata.schema.entity.domains.Domain domain =
+        client
+            .domains()
+            .create(
+                new org.openmetadata.schema.api.domains.CreateDomain()
+                    .withName(ns.prefix("roundtrip_domain"))
+                    .withDomainType(
+                        org.openmetadata.schema.api.domains.CreateDomain.DomainType.AGGREGATE)
+                    .withDescription("Domain inherited by the round-trip table under test"));
+
+    CreateDatabase createDb = new CreateDatabase();
+    createDb.setName(ns.prefix("roundtrip_db"));
+    createDb.setService(service.getFullyQualifiedName());
+    createDb.setDomains(List.of(domain.getFullyQualifiedName()));
+    Database database = client.databases().create(createDb);
+
+    CreateDatabaseSchema createSchema = new CreateDatabaseSchema();
+    createSchema.setName(ns.prefix("roundtrip_schema"));
+    createSchema.setDatabase(database.getFullyQualifiedName());
+    DatabaseSchema schema = createEntity(createSchema);
+
+    org.openmetadata.schema.entity.domains.DataProduct dataProduct =
+        client
+            .dataProducts()
+            .create(
+                new org.openmetadata.schema.api.domains.CreateDataProduct()
+                    .withName(ns.prefix("roundtrip_product"))
+                    .withDescription("Data product sharing the table's inherited domain")
+                    .withDomains(List.of(domain.getFullyQualifiedName())));
+
+    String tableName = ns.prefix("roundtrip_table");
+    CreateTable createTable = new CreateTable();
+    createTable.setName(tableName);
+    createTable.setDatabaseSchema(schema.getFullyQualifiedName());
+    createTable.setDescription("Initial Table Description");
+    createTable.setColumns(
+        List.of(
+            new org.openmetadata.schema.type.Column()
+                .withName("id")
+                .withDataType(org.openmetadata.schema.type.ColumnDataType.BIGINT)));
+    org.openmetadata.schema.entity.data.Table table = client.tables().create(createTable);
+
+    org.openmetadata.schema.type.api.BulkAssets addAsset =
+        new org.openmetadata.schema.type.api.BulkAssets()
+            .withAssets(List.of(table.getEntityReference()));
+    client
+        .getHttpClient()
+        .execute(
+            org.openmetadata.sdk.network.HttpMethod.PUT,
+            "/v1/dataProducts/" + dataProduct.getFullyQualifiedName() + "/assets/add",
+            addAsset,
+            Void.class);
+
+    String exportedCsv = client.databaseSchemas().exportCsv(schema.getFullyQualifiedName(), true);
+    java.util.List<String> csvLines = java.util.Arrays.asList(exportedCsv.split("\\n"));
+    java.util.List<String> modified = new java.util.ArrayList<>();
+    modified.add(csvLines.get(0));
+    boolean tableRowFound = false;
+    for (String line : csvLines.subList(1, csvLines.size())) {
+      String[] cols = line.split(",", -1);
+      if (cols.length > 12 && "table".equals(cols[12].trim())) {
+        assertTrue(
+            cols[10].trim().isEmpty(),
+            "Export must not write the inherited domain to the CSV domains column: " + line);
+        cols[2] = "Round Trip Edited";
+        line = String.join(",", cols);
+        tableRowFound = true;
+      }
+      modified.add(line);
+    }
+    assertTrue(tableRowFound, "Exported CSV should contain the table row");
+    String newCsv = String.join("\n", modified) + "\n";
+
+    String dryRunRaw =
+        client.databaseSchemas().importCsv(schema.getFullyQualifiedName(), newCsv, true, true);
+    CsvImportResult dryRun = JsonUtils.readValue(dryRunRaw, CsvImportResult.class);
+    assertEquals(
+        0,
+        dryRun.getNumberOfRowsFailed(),
+        "Round-trip dry run must not fail with an inherited domain: " + dryRunRaw);
+    assertFalse(
+        dryRunRaw.contains("Data Product Domain Validation"),
+        "Inherited domain must satisfy Data Product Domain Validation: " + dryRunRaw);
+
+    String importRaw =
+        client.databaseSchemas().importCsv(schema.getFullyQualifiedName(), newCsv, false, true);
+    CsvImportResult importResult = JsonUtils.readValue(importRaw, CsvImportResult.class);
+    assertEquals(
+        0, importResult.getNumberOfRowsFailed(), "Round-trip import should pass: " + importRaw);
+
+    org.openmetadata.schema.entity.data.Table afterImport =
+        client.tables().get(table.getId().toString(), "domains");
+    assertTrue(
+        afterImport.getDomains() == null
+            || afterImport.getDomains().stream()
+                .allMatch(d -> Boolean.TRUE.equals(d.getInherited())),
+        "Inherited domain must not be materialized as a direct domain after round-trip import");
+    assertEquals("Round Trip Edited", afterImport.getDescription());
+  }
+
+  /**
    * Test that importing a table with APPROVED glossary terms as tags succeeds.
    */
   @Test

--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/DatabaseSchemaResourceIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/DatabaseSchemaResourceIT.java
@@ -1537,6 +1537,215 @@ public class DatabaseSchemaResourceIT extends BaseEntityIT<DatabaseSchema, Creat
   }
 
   /**
+   * Reproduces #28523: bulk-editing a table that inherits its domain and has a data product in that
+   * same domain must not fail "Data Product Domain Validation". The exported CSV carries no explicit
+   * domain (inherited domains are not exported), so an empty domain column must preserve the
+   * inherited domain for rule evaluation instead of wiping it.
+   */
+  @Test
+  void test_importCsv_tableWithInheritedDomainAndDataProduct_succeeds(TestNamespace ns)
+      throws Exception {
+    OpenMetadataClient client = SdkClients.adminClient();
+    DatabaseService service = DatabaseServiceTestFactory.createPostgres(ns);
+
+    org.openmetadata.schema.entity.domains.Domain domain =
+        client
+            .domains()
+            .create(
+                new org.openmetadata.schema.api.domains.CreateDomain()
+                    .withName(ns.prefix("inherited_dp_domain"))
+                    .withDomainType(
+                        org.openmetadata.schema.api.domains.CreateDomain.DomainType.AGGREGATE)
+                    .withDescription("Domain inherited by the table under test"));
+
+    CreateDatabase createDb = new CreateDatabase();
+    createDb.setName(ns.prefix("inherited_dp_db"));
+    createDb.setService(service.getFullyQualifiedName());
+    createDb.setDomains(List.of(domain.getFullyQualifiedName()));
+    Database database = client.databases().create(createDb);
+
+    CreateDatabaseSchema createSchema = new CreateDatabaseSchema();
+    createSchema.setName(ns.prefix("inherited_dp_schema"));
+    createSchema.setDatabase(database.getFullyQualifiedName());
+    DatabaseSchema schema = createEntity(createSchema);
+
+    org.openmetadata.schema.entity.domains.DataProduct dataProduct =
+        client
+            .dataProducts()
+            .create(
+                new org.openmetadata.schema.api.domains.CreateDataProduct()
+                    .withName(ns.prefix("inherited_dp_product"))
+                    .withDescription("Data product sharing the table's inherited domain")
+                    .withDomains(List.of(domain.getFullyQualifiedName())));
+
+    String tableName = ns.prefix("inherited_dp_table");
+    CreateTable createTable = new CreateTable();
+    createTable.setName(tableName);
+    createTable.setDatabaseSchema(schema.getFullyQualifiedName());
+    createTable.setColumns(
+        List.of(
+            new org.openmetadata.schema.type.Column()
+                .withName("id")
+                .withDataType(org.openmetadata.schema.type.ColumnDataType.BIGINT)));
+    org.openmetadata.schema.entity.data.Table table = client.tables().create(createTable);
+
+    org.openmetadata.schema.type.api.BulkAssets addAsset =
+        new org.openmetadata.schema.type.api.BulkAssets()
+            .withAssets(List.of(table.getEntityReference()));
+    client
+        .getHttpClient()
+        .execute(
+            org.openmetadata.sdk.network.HttpMethod.PUT,
+            "/v1/dataProducts/" + dataProduct.getFullyQualifiedName() + "/assets/add",
+            addAsset,
+            Void.class);
+
+    org.openmetadata.schema.entity.data.Table withDp =
+        client.tables().get(table.getId().toString(), "domains,dataProducts");
+    assertEquals(1, withDp.getDataProducts().size(), "Table should have the data product assigned");
+    assertNotNull(withDp.getDomains());
+    assertTrue(
+        withDp.getDomains().stream().anyMatch(d -> Boolean.TRUE.equals(d.getInherited())),
+        "Table should inherit its domain from the database");
+
+    String csv =
+        "name*,displayName,description,owner,tags,glossaryTerms,tiers,certification,retentionPeriod,sourceUrl,domains,extension\n"
+            + tableName
+            + ",Bulk Edited Table,Edited via bulk edit,,,,,,,,,";
+
+    String dryRunRaw =
+        client.databaseSchemas().importCsv(schema.getFullyQualifiedName(), csv, true, false);
+    CsvImportResult dryRun = JsonUtils.readValue(dryRunRaw, CsvImportResult.class);
+    assertEquals(
+        0,
+        dryRun.getNumberOfRowsFailed(),
+        "Bulk-edit dry run must not fail with an inherited domain: " + dryRunRaw);
+    assertFalse(
+        dryRunRaw.contains("Data Product Domain Validation"),
+        "Inherited domain must satisfy Data Product Domain Validation: " + dryRunRaw);
+
+    String importRaw =
+        client.databaseSchemas().importCsv(schema.getFullyQualifiedName(), csv, false, false);
+    CsvImportResult importResult = JsonUtils.readValue(importRaw, CsvImportResult.class);
+    assertEquals(0, importResult.getNumberOfRowsFailed(), "Bulk edit should pass: " + importRaw);
+
+    org.openmetadata.schema.entity.data.Table afterImport =
+        client.tables().get(table.getId().toString(), "domains");
+    assertTrue(
+        afterImport.getDomains() == null
+            || afterImport.getDomains().stream()
+                .allMatch(d -> Boolean.TRUE.equals(d.getInherited())),
+        "Inherited domain must not be materialized as a direct domain after import");
+    assertEquals("Edited via bulk edit", afterImport.getDescription());
+  }
+
+  /**
+   * Recursive variant of #28523: the recursive dry-run load excludes domains, so an empty domain
+   * column must still preserve the table's inherited domain for "Data Product Domain Validation".
+   * Exports the schema recursively, then forces the table row's domain column empty before re-import.
+   */
+  @Test
+  void test_importCsvRecursive_tableWithInheritedDomainAndDataProduct_succeeds(TestNamespace ns)
+      throws Exception {
+    OpenMetadataClient client = SdkClients.adminClient();
+    DatabaseService service = DatabaseServiceTestFactory.createPostgres(ns);
+
+    org.openmetadata.schema.entity.domains.Domain domain =
+        client
+            .domains()
+            .create(
+                new org.openmetadata.schema.api.domains.CreateDomain()
+                    .withName(ns.prefix("rec_inherited_domain"))
+                    .withDomainType(
+                        org.openmetadata.schema.api.domains.CreateDomain.DomainType.AGGREGATE)
+                    .withDescription("Domain inherited by the recursive table under test"));
+
+    CreateDatabase createDb = new CreateDatabase();
+    createDb.setName(ns.prefix("rec_inherited_db"));
+    createDb.setService(service.getFullyQualifiedName());
+    createDb.setDomains(List.of(domain.getFullyQualifiedName()));
+    Database database = client.databases().create(createDb);
+
+    CreateDatabaseSchema createSchema = new CreateDatabaseSchema();
+    createSchema.setName(ns.prefix("rec_inherited_schema"));
+    createSchema.setDatabase(database.getFullyQualifiedName());
+    DatabaseSchema schema = createEntity(createSchema);
+
+    org.openmetadata.schema.entity.domains.DataProduct dataProduct =
+        client
+            .dataProducts()
+            .create(
+                new org.openmetadata.schema.api.domains.CreateDataProduct()
+                    .withName(ns.prefix("rec_inherited_product"))
+                    .withDescription("Data product sharing the table's inherited domain")
+                    .withDomains(List.of(domain.getFullyQualifiedName())));
+
+    String tableName = ns.prefix("rec_inherited_table");
+    CreateTable createTable = new CreateTable();
+    createTable.setName(tableName);
+    createTable.setDatabaseSchema(schema.getFullyQualifiedName());
+    createTable.setDescription("Initial Table Description");
+    createTable.setColumns(
+        List.of(
+            new org.openmetadata.schema.type.Column()
+                .withName("id")
+                .withDataType(org.openmetadata.schema.type.ColumnDataType.BIGINT)));
+    org.openmetadata.schema.entity.data.Table table = client.tables().create(createTable);
+
+    org.openmetadata.schema.type.api.BulkAssets addAsset =
+        new org.openmetadata.schema.type.api.BulkAssets()
+            .withAssets(List.of(table.getEntityReference()));
+    client
+        .getHttpClient()
+        .execute(
+            org.openmetadata.sdk.network.HttpMethod.PUT,
+            "/v1/dataProducts/" + dataProduct.getFullyQualifiedName() + "/assets/add",
+            addAsset,
+            Void.class);
+
+    String exportedCsv = client.databaseSchemas().exportCsv(schema.getFullyQualifiedName(), true);
+    java.util.List<String> csvLines = java.util.Arrays.asList(exportedCsv.split("\\n"));
+    java.util.List<String> modified = new java.util.ArrayList<>();
+    modified.add(csvLines.get(0));
+    for (String line : csvLines.subList(1, csvLines.size())) {
+      String[] cols = line.split(",", -1);
+      if (cols.length > 12 && "table".equals(cols[12].trim())) {
+        cols[2] = "Recursive Bulk Edited";
+        cols[10] = "";
+        line = String.join(",", cols);
+      }
+      modified.add(line);
+    }
+    String newCsv = String.join("\n", modified) + "\n";
+
+    String dryRunRaw =
+        client.databaseSchemas().importCsv(schema.getFullyQualifiedName(), newCsv, true, true);
+    CsvImportResult dryRun = JsonUtils.readValue(dryRunRaw, CsvImportResult.class);
+    assertEquals(
+        0,
+        dryRun.getNumberOfRowsFailed(),
+        "Recursive bulk-edit dry run must not fail with an inherited domain: " + dryRunRaw);
+    assertFalse(
+        dryRunRaw.contains("Data Product Domain Validation"),
+        "Inherited domain must satisfy Data Product Domain Validation: " + dryRunRaw);
+
+    String importRaw =
+        client.databaseSchemas().importCsv(schema.getFullyQualifiedName(), newCsv, false, true);
+    CsvImportResult importResult = JsonUtils.readValue(importRaw, CsvImportResult.class);
+    assertEquals(
+        0, importResult.getNumberOfRowsFailed(), "Recursive bulk edit should pass: " + importRaw);
+
+    org.openmetadata.schema.entity.data.Table afterImport =
+        client.tables().get(table.getId().toString(), "domains");
+    assertTrue(
+        afterImport.getDomains() == null
+            || afterImport.getDomains().stream()
+                .allMatch(d -> Boolean.TRUE.equals(d.getInherited())),
+        "Inherited domain must not be materialized as a direct domain after recursive import");
+    assertEquals("Recursive Bulk Edited", afterImport.getDescription());
+  }
+
+  /**
    * Test that importing a table with APPROVED glossary terms as tags succeeds.
    */
   @Test

--- a/openmetadata-service/src/main/java/org/openmetadata/csv/CsvUtil.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/csv/CsvUtil.java
@@ -339,10 +339,14 @@ public final class CsvUtil {
   }
 
   public static void addDomains(List<String> csvRecord, List<EntityReference> domains) {
+    List<EntityReference> directDomains =
+        listOrEmpty(domains).stream()
+            .filter(domain -> !Boolean.TRUE.equals(domain.getInherited()))
+            .toList();
     csvRecord.add(
-        nullOrEmpty(domains)
+        nullOrEmpty(directDomains)
             ? null
-            : domains.stream()
+            : directDomains.stream()
                 .map(EntityReference::getFullyQualifiedName)
                 .collect(Collectors.joining(FIELD_SEPARATOR)));
   }

--- a/openmetadata-service/src/main/java/org/openmetadata/csv/EntityCsv.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/csv/EntityCsv.java
@@ -416,12 +416,32 @@ public abstract class EntityCsv<T extends EntityInterface> {
    * entity's existing domains (which the importer already loaded, including inherited ones) keeps
    * platform rules such as "Data Product Domain Validation" from seeing an empty domain and
    * treating it as a mismatch, without an extra inheritance lookup. Inherited references are
-   * filtered out before persistence, so they are never materialized as a direct domain.
+   * dropped after rule evaluation (see {@link #dropInheritedDomains}), so they are never persisted
+   * as a direct domain.
    */
   public List<EntityReference> getDomains(
       CSVPrinter printer, CSVRecord csvRecord, int fieldNumber, List<EntityReference> current) {
     List<EntityReference> parsed = getDomains(printer, csvRecord, fieldNumber);
     return parsed != null ? parsed : current;
+  }
+
+  /**
+   * Inherited domains are supplied to an updated entity only so platform rules evaluate against its
+   * effective domain. The import persistence path stores whatever domains the entity carries as
+   * direct relationships, so the inherited ones must be removed once the rules have run; the entity
+   * keeps re-inheriting from its parent on read.
+   */
+  private void dropInheritedDomains(EntityInterface entity) {
+    List<EntityReference> domains = entity.getDomains();
+    if (!nullOrEmpty(domains)) {
+      List<EntityReference> directDomains = new ArrayList<>();
+      for (EntityReference domain : domains) {
+        if (!Boolean.TRUE.equals(domain.getInherited())) {
+          directDomains.add(domain);
+        }
+      }
+      entity.setDomains(directDomains.isEmpty() ? null : directDomains);
+    }
   }
 
   /** Owner field is in entityName format */
@@ -1073,6 +1093,7 @@ public abstract class EntityCsv<T extends EntityInterface> {
       } else {
         RuleEngine.getInstance().evaluate(entity);
       }
+      dropInheritedDomains(entity);
 
       if (Boolean.FALSE.equals(importResult.getDryRun())) { // If not dry run, create the entity
         if (isUpdate) {
@@ -1166,6 +1187,7 @@ public abstract class EntityCsv<T extends EntityInterface> {
       } else {
         RuleEngine.getInstance().evaluate(entity);
       }
+      dropInheritedDomains(entity);
 
       if (Boolean.FALSE.equals(importResult.getDryRun())) {
         if (isUpdate) {
@@ -1671,7 +1693,7 @@ public abstract class EntityCsv<T extends EntityInterface> {
       try {
         table =
             Entity.getEntityByNameWithExcludedFields(
-                TABLE, tableFqn, "owners,tags,domains,extension", Include.NON_DELETED);
+                TABLE, tableFqn, "owners,tags,extension", Include.NON_DELETED);
       } catch (EntityNotFoundException ex) {
         // Simulate a table for validation without persisting it
         table =
@@ -1725,7 +1747,7 @@ public abstract class EntityCsv<T extends EntityInterface> {
         .withCertification(certification)
         .withRetentionPeriod(csvRecord.get(8))
         .withSourceUrl(csvRecord.get(9))
-        .withDomains(getDomains(printer, csvRecord, 10))
+        .withDomains(getDomains(printer, csvRecord, 10, table.getDomains()))
         .withExtension(getExtension(printer, csvRecord, 11))
         .withUpdatedAt(System.currentTimeMillis())
         .withUpdatedBy(importedBy);

--- a/openmetadata-service/src/main/java/org/openmetadata/csv/EntityCsv.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/csv/EntityCsv.java
@@ -412,17 +412,28 @@ public abstract class EntityCsv<T extends EntityInterface> {
   }
 
   /**
-   * An empty domain column means "leave domains unchanged", not "clear domains". Returning the
-   * entity's existing domains (which the importer already loaded, including inherited ones) keeps
-   * platform rules such as "Data Product Domain Validation" from seeing an empty domain and
-   * treating it as a mismatch, without an extra inheritance lookup. Inherited references are
-   * dropped after rule evaluation (see {@link #dropInheritedDomains}), so they are never persisted
-   * as a direct domain.
+   * An empty domain column clears direct domains (unchanged behavior) but must not wipe the
+   * entity's inherited domains: they are never exported to the CSV, and rules such as "Data Product
+   * Domain Validation" need them to evaluate the entity's effective domain. So on an empty column
+   * only the inherited references from the already-loaded entity are carried over; they are dropped
+   * again after rule evaluation (see {@link #dropInheritedDomains}), so they are never persisted as
+   * a direct domain.
    */
   public List<EntityReference> getDomains(
-      CSVPrinter printer, CSVRecord csvRecord, int fieldNumber, List<EntityReference> current) {
-    List<EntityReference> parsed = getDomains(printer, csvRecord, fieldNumber);
-    return parsed != null ? parsed : current;
+      CSVPrinter printer,
+      CSVRecord csvRecord,
+      int fieldNumber,
+      List<EntityReference> existingDomains) {
+    List<EntityReference> parsedFromCsv = getDomains(printer, csvRecord, fieldNumber);
+    List<EntityReference> result = parsedFromCsv;
+    if (parsedFromCsv == null) {
+      List<EntityReference> inheritedDomains =
+          listOrEmpty(existingDomains).stream()
+              .filter(domain -> Boolean.TRUE.equals(domain.getInherited()))
+              .toList();
+      result = inheritedDomains.isEmpty() ? null : inheritedDomains;
+    }
+    return result;
   }
 
   /**
@@ -1599,7 +1610,7 @@ public abstract class EntityCsv<T extends EntityInterface> {
     try {
       schema =
           Entity.getEntityByNameWithExcludedFields(
-              DATABASE_SCHEMA, schemaFqn, "owners,tags,domains,extension", Include.NON_DELETED);
+              DATABASE_SCHEMA, schemaFqn, "owners,tags,extension", Include.NON_DELETED);
     } catch (Exception ex) {
       LOG.warn("Database Schema not found: {}, it will be created with Import.", schemaFqn);
       schema =
@@ -1631,7 +1642,7 @@ public abstract class EntityCsv<T extends EntityInterface> {
         .withCertification(certification)
         .withRetentionPeriod(csvRecord.get(8))
         .withSourceUrl(csvRecord.get(9))
-        .withDomains(getDomains(printer, csvRecord, 10))
+        .withDomains(getDomains(printer, csvRecord, 10, schema.getDomains()))
         .withExtension(getExtension(printer, csvRecord, 11))
         .withUpdatedAt(System.currentTimeMillis())
         .withUpdatedBy(importedBy);
@@ -1814,7 +1825,7 @@ public abstract class EntityCsv<T extends EntityInterface> {
             Entity.getEntityByName(
                 STORED_PROCEDURE,
                 entityFQN,
-                "name,displayName,fullyQualifiedName",
+                "name,displayName,fullyQualifiedName,domains",
                 Include.NON_DELETED);
       } catch (Exception ex) {
         // Simulate a stored procedure for validation without persisting it
@@ -1833,7 +1844,7 @@ public abstract class EntityCsv<T extends EntityInterface> {
             getEntityWithDependencyResolution(
                 STORED_PROCEDURE,
                 entityFQN,
-                "name,displayName,fullyQualifiedName",
+                "name,displayName,fullyQualifiedName,domains",
                 Include.NON_DELETED);
       } catch (Exception ex) {
         LOG.warn("Stored procedure not found: {}, it will be created with Import.", entityFQN);
@@ -1875,7 +1886,7 @@ public abstract class EntityCsv<T extends EntityInterface> {
         .withTags(tagLabels)
         .withCertification(certification)
         .withSourceUrl(csvRecord.get(9))
-        .withDomains(getDomains(printer, csvRecord, 10))
+        .withDomains(getDomains(printer, csvRecord, 10, sp.getDomains()))
         .withStoredProcedureCode(storedProcedureCode)
         .withExtension(getExtension(printer, csvRecord, 11));
 

--- a/openmetadata-service/src/main/java/org/openmetadata/csv/EntityCsv.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/csv/EntityCsv.java
@@ -424,14 +424,17 @@ public abstract class EntityCsv<T extends EntityInterface> {
       CSVRecord csvRecord,
       int fieldNumber,
       List<EntityReference> existingDomains) {
-    List<EntityReference> parsedFromCsv = getDomains(printer, csvRecord, fieldNumber);
-    List<EntityReference> result = parsedFromCsv;
-    if (parsedFromCsv == null) {
-      List<EntityReference> inheritedDomains =
-          listOrEmpty(existingDomains).stream()
-              .filter(domain -> Boolean.TRUE.equals(domain.getInherited()))
-              .toList();
-      result = inheritedDomains.isEmpty() ? null : inheritedDomains;
+    List<EntityReference> result = null;
+    if (processRecord) {
+      List<EntityReference> parsedFromCsv = getDomains(printer, csvRecord, fieldNumber);
+      result = parsedFromCsv;
+      if (parsedFromCsv == null) {
+        List<EntityReference> inheritedDomains =
+            listOrEmpty(existingDomains).stream()
+                .filter(domain -> Boolean.TRUE.equals(domain.getInherited()))
+                .toList();
+        result = inheritedDomains.isEmpty() ? null : inheritedDomains;
+      }
     }
     return result;
   }

--- a/openmetadata-service/src/main/java/org/openmetadata/csv/EntityCsv.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/csv/EntityCsv.java
@@ -411,6 +411,19 @@ public abstract class EntityCsv<T extends EntityInterface> {
     return refs;
   }
 
+  /**
+   * An empty domain column means "leave domains unchanged", not "clear domains". Returning the
+   * entity's existing domains (which the importer already loaded, including inherited ones) keeps
+   * platform rules such as "Data Product Domain Validation" from seeing an empty domain and
+   * treating it as a mismatch, without an extra inheritance lookup. Inherited references are
+   * filtered out before persistence, so they are never materialized as a direct domain.
+   */
+  public List<EntityReference> getDomains(
+      CSVPrinter printer, CSVRecord csvRecord, int fieldNumber, List<EntityReference> current) {
+    List<EntityReference> parsed = getDomains(printer, csvRecord, fieldNumber);
+    return parsed != null ? parsed : current;
+  }
+
   /** Owner field is in entityName format */
   public EntityReference getOwnerAsUser(CSVPrinter printer, CSVRecord csvRecord, int fieldNumber) {
     if (!processRecord) {

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/DatabaseRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/DatabaseRepository.java
@@ -797,7 +797,7 @@ public class DatabaseRepository extends EntityRepository<Database> {
           .withCertification(certification)
           .withRetentionPeriod(csvRecord.get(8))
           .withSourceUrl(csvRecord.get(9))
-          .withDomains(getDomains(printer, csvRecord, 10))
+          .withDomains(getDomains(printer, csvRecord, 10, schema.getDomains()))
           .withExtension(getExtension(printer, csvRecord, 11));
       if (processRecord) {
         createEntity(printer, csvRecord, schema, DATABASE_SCHEMA);

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/DatabaseSchemaRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/DatabaseSchemaRepository.java
@@ -971,7 +971,7 @@ public class DatabaseSchemaRepository extends EntityRepository<DatabaseSchema> {
           .withRetentionPeriod(csvRecord.get(8))
           .withSourceUrl(csvRecord.get(9))
           .withColumns(nullOrEmpty(table.getColumns()) ? new ArrayList<>() : table.getColumns())
-          .withDomains(getDomains(printer, csvRecord, 10))
+          .withDomains(getDomains(printer, csvRecord, 10, table.getDomains()))
           .withExtension(getExtension(printer, csvRecord, 11));
 
       if (processRecord) {

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/DatabaseServiceRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/DatabaseServiceRepository.java
@@ -287,7 +287,7 @@ public class DatabaseServiceRepository
           .withOwners(getOwners(printer, csvRecord, 3))
           .withTags(tagLabels)
           .withCertification(certification)
-          .withDomains(getDomains(printer, csvRecord, 8))
+          .withDomains(getDomains(printer, csvRecord, 8, database.getDomains()))
           .withExtension(getExtension(printer, csvRecord, 9));
 
       if (processRecord) {
@@ -371,7 +371,7 @@ public class DatabaseServiceRepository
           .withTags(tagLabels)
           .withCertification(certification)
           .withSourceUrl(csvRecord.get(9))
-          .withDomains(getDomains(printer, csvRecord, 10))
+          .withDomains(getDomains(printer, csvRecord, 10, database.getDomains()))
           .withExtension(getExtension(printer, csvRecord, 11));
 
       if (processRecord) {
@@ -448,7 +448,7 @@ public class DatabaseServiceRepository
           .withCertification(certification)
           .withRetentionPeriod(csvRecord.get(8))
           .withSourceUrl(csvRecord.get(9))
-          .withDomains(getDomains(printer, csvRecord, 10))
+          .withDomains(getDomains(printer, csvRecord, 10, schema.getDomains()))
           .withExtension(getExtension(printer, csvRecord, 11))
           .withUpdatedAt(System.currentTimeMillis())
           .withUpdatedBy(importedBy);

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/DirectoryRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/DirectoryRepository.java
@@ -417,7 +417,7 @@ public class DirectoryRepository extends EntityRepository<Directory> {
                   List.of(
                       Pair.of(8, TagLabel.TagSource.CLASSIFICATION),
                       Pair.of(9, TagLabel.TagSource.GLOSSARY))))
-          .withDomains(getDomains(printer, csvRecord, 10))
+          .withDomains(getDomains(printer, csvRecord, 10, newDirectory.getDomains()))
           .withDataProducts(getDataProducts(printer, csvRecord, 11));
 
       if (processRecord) {

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/DriveServiceRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/DriveServiceRepository.java
@@ -217,7 +217,7 @@ public class DriveServiceRepository extends ServiceEntityRepository<DriveService
                   List.of(
                       Pair.of(4, TagLabel.TagSource.CLASSIFICATION),
                       Pair.of(5, TagLabel.TagSource.GLOSSARY))))
-          .withDomains(getDomains(printer, csvRecord, 6))
+          .withDomains(getDomains(printer, csvRecord, 6, directory.getDomains()))
           .withExtension(getExtension(printer, csvRecord, 7));
 
       if (processRecord) {

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/DriveServiceRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/DriveServiceRepository.java
@@ -205,10 +205,10 @@ public class DriveServiceRepository extends ServiceEntityRepository<DriveService
                 .withFullyQualifiedName(directoryFqn);
       }
 
-      // Update directory fields from CSV
+      // Update directory fields from CSV (header order: name, displayName, description, ...)
       directory
-          .withDescription(csvRecord.get(1))
-          .withDisplayName(csvRecord.get(2))
+          .withDisplayName(csvRecord.get(1))
+          .withDescription(csvRecord.get(2))
           .withOwners(getOwners(printer, csvRecord, 3))
           .withTags(
               getTagLabels(

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/FileRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/FileRepository.java
@@ -417,7 +417,7 @@ public class FileRepository extends EntityRepository<File> {
                   List.of(
                       Pair.of(12, TagLabel.TagSource.CLASSIFICATION),
                       Pair.of(13, TagLabel.TagSource.GLOSSARY))))
-          .withDomains(getDomains(printer, csvRecord, 14))
+          .withDomains(getDomains(printer, csvRecord, 14, newFile.getDomains()))
           .withDataProducts(getDataProducts(printer, csvRecord, 15));
       if (processRecord) {
         createEntity(printer, csvRecord, newFile, FILE);

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/SecurityServiceRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/SecurityServiceRepository.java
@@ -219,7 +219,7 @@ public class SecurityServiceRepository
           .withTags(
               getTagLabels(
                   printer, csvRecord, List.of(Pair.of(5, TagLabel.TagSource.CLASSIFICATION))))
-          .withDomains(getDomains(printer, csvRecord, 6));
+          .withDomains(getDomains(printer, csvRecord, 6, newSecurityService.getDomains()));
 
       if (processRecord) {
         createEntity(printer, csvRecord, newSecurityService, Entity.SECURITY_SERVICE);

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/SpreadsheetRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/SpreadsheetRepository.java
@@ -369,7 +369,7 @@ public class SpreadsheetRepository extends EntityRepository<Spreadsheet> {
                   List.of(
                       Pair.of(9, TagLabel.TagSource.CLASSIFICATION),
                       Pair.of(10, TagLabel.TagSource.GLOSSARY))))
-          .withDomains(getDomains(printer, csvRecord, 11))
+          .withDomains(getDomains(printer, csvRecord, 11, newSpreadsheet.getDomains()))
           .withDataProducts(getDataProducts(printer, csvRecord, 12))
           .withCreatedTime(
               nullOrEmpty(csvRecord.get(15)) ? null : Long.parseLong(csvRecord.get(15)))

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/WorksheetRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/WorksheetRepository.java
@@ -455,7 +455,7 @@ public class WorksheetRepository extends EntityRepository<Worksheet> {
                   List.of(
                       Pair.of(11, TagLabel.TagSource.CLASSIFICATION),
                       Pair.of(12, TagLabel.TagSource.GLOSSARY))))
-          .withDomains(getDomains(printer, csvRecord, 13))
+          .withDomains(getDomains(printer, csvRecord, 13, newWorksheet.getDomains()))
           .withDataProducts(getDataProducts(printer, csvRecord, 14));
 
       if (processRecord) {

--- a/openmetadata-service/src/test/java/org/openmetadata/csv/EntityCsvTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/csv/EntityCsvTest.java
@@ -40,15 +40,18 @@ import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import org.openmetadata.common.utils.CommonUtil;
 import org.openmetadata.schema.EntityInterface;
+import org.openmetadata.schema.configuration.EntityRulesSettings;
 import org.openmetadata.schema.entity.data.DatabaseSchema;
 import org.openmetadata.schema.entity.data.GlossaryTerm;
 import org.openmetadata.schema.entity.data.StoredProcedure;
 import org.openmetadata.schema.entity.data.Table;
+import org.openmetadata.schema.entity.domains.DataProduct;
 import org.openmetadata.schema.entity.domains.Domain;
 import org.openmetadata.schema.entity.teams.AuthenticationMechanism;
 import org.openmetadata.schema.entity.teams.Team;
 import org.openmetadata.schema.entity.teams.User;
 import org.openmetadata.schema.exception.JsonParsingException;
+import org.openmetadata.schema.settings.SettingsType;
 import org.openmetadata.schema.type.ApiStatus;
 import org.openmetadata.schema.type.AssetCertification;
 import org.openmetadata.schema.type.ChangeEvent;
@@ -56,6 +59,8 @@ import org.openmetadata.schema.type.Column;
 import org.openmetadata.schema.type.EntityReference;
 import org.openmetadata.schema.type.EntityStatus;
 import org.openmetadata.schema.type.EventType;
+import org.openmetadata.schema.type.Include;
+import org.openmetadata.schema.type.SemanticsRule;
 import org.openmetadata.schema.type.StoredProcedureLanguage;
 import org.openmetadata.schema.type.TagLabel;
 import org.openmetadata.schema.type.csv.CsvDocumentation;
@@ -70,8 +75,10 @@ import org.openmetadata.service.jdbi3.CollectionDAO;
 import org.openmetadata.service.jdbi3.DatabaseSchemaRepository;
 import org.openmetadata.service.jdbi3.EntityRepository;
 import org.openmetadata.service.jdbi3.StoredProcedureRepository;
+import org.openmetadata.service.jdbi3.SystemRepository;
 import org.openmetadata.service.jdbi3.TableRepository;
 import org.openmetadata.service.jdbi3.UserRepository;
+import org.openmetadata.service.resources.settings.SettingsCache;
 import org.openmetadata.service.rules.RuleEngine;
 import org.openmetadata.service.search.SearchRepository;
 import org.openmetadata.service.util.AsyncService;
@@ -2925,5 +2932,147 @@ public class EntityCsvTest {
       }
       throw new RuntimeException(e.getCause());
     }
+  }
+
+  @Test
+  void test_getDomainsKeepsExistingDomainsWhenCsvColumnEmpty() {
+    TestCsv testCsv = new TestCsv();
+    testCsv.enableProcessing();
+    testCsv.addEntity(Entity.DOMAIN, "finance", domain("finance"));
+    List<EntityReference> existingDomains = List.of(ref(Entity.DOMAIN, "inheritedDomain"));
+
+    List<EntityReference> keptWhenEmpty =
+        testCsv.getDomains(
+            mock(CSVPrinter.class), singleRecord(testCsv, "", "", ""), 0, existingDomains);
+    assertEquals(
+        existingDomains, keptWhenEmpty, "Empty domain column must keep the existing domains");
+
+    List<EntityReference> parsedWhenPresent =
+        testCsv.getDomains(
+            mock(CSVPrinter.class), singleRecord(testCsv, "finance", "", ""), 0, existingDomains);
+    assertEquals(
+        List.of("finance"),
+        parsedWhenPresent.stream().map(EntityReference::getName).toList(),
+        "A provided domain column must override the existing domains");
+  }
+
+  @Test
+  void test_bulkEditInheritedDomainWithMatchingDataProductPassesRule() throws IOException {
+    EntityReference inheritedDomain = ref(Entity.DOMAIN, "finance");
+    DataProductImportScenario scenario =
+        importTableUpdateWithInheritedDomain(inheritedDomain, inheritedDomain);
+
+    assertEquals(0, scenario.testCsv().importResult.getNumberOfRowsFailed());
+    assertEquals(1, scenario.testCsv().importResult.getNumberOfRowsPassed());
+    assertEquals(ENTITY_UPDATED, scenario.testCsv().pendingCsvResults.get(scenario.csvRecord()));
+  }
+
+  @Test
+  void test_bulkEditInheritedDomainWithMismatchedDataProductFailsRule() throws IOException {
+    EntityReference inheritedDomain = ref(Entity.DOMAIN, "finance");
+    EntityReference unrelatedDomain = ref(Entity.DOMAIN, "marketing");
+    DataProductImportScenario scenario =
+        importTableUpdateWithInheritedDomain(inheritedDomain, unrelatedDomain);
+
+    assertSummary(scenario.testCsv().importResult, ApiStatus.FAILURE, 1, 0, 1);
+    String failureMessage = scenario.testCsv().pendingCsvResults.get(scenario.csvRecord());
+    assertNotNull(failureMessage);
+    assertTrue(
+        failureMessage.contains("Data Product Domain Validation"),
+        "Genuine Data Product / domain mismatch must still fail: " + failureMessage);
+  }
+
+  private record DataProductImportScenario(
+      TestCsv testCsv, CSVRecord csvRecord, EntityRepository<EntityInterface> repository) {}
+
+  /**
+   * Simulates the importer state after the fix: the entity reaching rule evaluation carries the
+   * inherited domain the importer already loaded (an empty CSV domain column no longer discards it).
+   * Validates that the platform rule then passes when the data product matches that domain.
+   */
+  @SuppressWarnings("unchecked")
+  private DataProductImportScenario importTableUpdateWithInheritedDomain(
+      EntityReference inheritedDomain, EntityReference dataProductDomain) throws IOException {
+    EntityReference dataProductRef = ref(Entity.DATA_PRODUCT, "salesDataProduct");
+    DataProduct dataProduct =
+        new DataProduct()
+            .withId(dataProductRef.getId())
+            .withName("salesDataProduct")
+            .withFullyQualifiedName("salesDataProduct")
+            .withDomains(List.of(dataProductDomain));
+    EntityReference resolvedInheritedDomain =
+        new EntityReference()
+            .withId(inheritedDomain.getId())
+            .withType(Entity.DOMAIN)
+            .withName(inheritedDomain.getName())
+            .withFullyQualifiedName(inheritedDomain.getName())
+            .withInherited(true);
+
+    Table originalEntity =
+        new Table().withId(UUID.randomUUID()).withFullyQualifiedName("service.db.schema.orders");
+    Table updatedEntity =
+        new Table()
+            .withId(UUID.randomUUID())
+            .withName("orders")
+            .withFullyQualifiedName("service.db.schema.orders")
+            .withDataProducts(new ArrayList<>(List.of(dataProductRef)))
+            .withDomains(new ArrayList<>(List.of(resolvedInheritedDomain)));
+
+    TestCsv testCsv = new TestCsv();
+    testCsv.enableProcessing();
+    testCsv.setDryRun(true);
+    CSVRecord csvRecord = singleRecord(testCsv, updatedEntity.getFullyQualifiedName(), "", "");
+
+    EntityRepository<EntityInterface> repository = mock(EntityRepository.class);
+    EntityRulesSettings rulesSettings =
+        new EntityRulesSettings().withEntitySemantics(List.of(dataProductDomainValidationRule()));
+
+    try (MockedStatic<Entity> entityStatic = Mockito.mockStatic(Entity.class);
+        MockedStatic<SettingsCache> settingsCache = Mockito.mockStatic(SettingsCache.class);
+        MockedStatic<ValidatorUtil> validatorUtil = Mockito.mockStatic(ValidatorUtil.class)) {
+      entityStatic.when(() -> Entity.getEntityRepository(Entity.TABLE)).thenReturn(repository);
+      for (String ignoredType : List.of(Entity.USER, Entity.TEAM, Entity.PERSONA, Entity.BOT)) {
+        EntityRepository<EntityInterface> ignoredRepo = mock(EntityRepository.class);
+        Mockito.doReturn(User.class).when(ignoredRepo).getEntityClass();
+        entityStatic.when(() -> Entity.getEntityRepository(ignoredType)).thenReturn(ignoredRepo);
+      }
+      entityStatic.when(Entity::getSystemRepository).thenReturn(mock(SystemRepository.class));
+      entityStatic
+          .when(
+              () ->
+                  Entity.getEntities(
+                      Mockito.anyList(), Mockito.eq("domains"), Mockito.eq(Include.NON_DELETED)))
+          .thenReturn(List.of(dataProduct));
+      settingsCache
+          .when(
+              () ->
+                  SettingsCache.getSetting(
+                      SettingsType.ENTITY_RULES_SETTINGS, EntityRulesSettings.class))
+          .thenReturn(rulesSettings);
+      validatorUtil.when(() -> ValidatorUtil.validate(Mockito.any())).thenReturn(null);
+
+      Mockito.when(repository.findMatchForImport(Mockito.any())).thenReturn(originalEntity);
+
+      testCsv.queueEntity(csvRecord, updatedEntity);
+    }
+    return new DataProductImportScenario(testCsv, csvRecord, repository);
+  }
+
+  private static SemanticsRule dataProductDomainValidationRule() {
+    return new SemanticsRule()
+        .withName("Data Product Domain Validation")
+        .withDescription("Validates that Data Products assigned to an entity match the domains.")
+        .withRule(
+            "{\"validateDataProductDomainMatch\":[{\"var\":\"dataProducts\"},{\"var\":\"domains\"}]}")
+        .withEnabled(true)
+        .withIgnoredEntities(List.of(Entity.USER, Entity.TEAM, Entity.PERSONA, Entity.BOT));
+  }
+
+  private static EntityReference ref(String type, String name) {
+    return new EntityReference()
+        .withId(UUID.randomUUID())
+        .withType(type)
+        .withName(name)
+        .withFullyQualifiedName(name);
   }
 }

--- a/openmetadata-service/src/test/java/org/openmetadata/csv/EntityCsvTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/csv/EntityCsvTest.java
@@ -73,6 +73,7 @@ import org.openmetadata.service.TypeRegistry;
 import org.openmetadata.service.formatter.util.FormatterUtil;
 import org.openmetadata.service.jdbi3.CollectionDAO;
 import org.openmetadata.service.jdbi3.DatabaseSchemaRepository;
+import org.openmetadata.service.jdbi3.EntityRelationshipRepository;
 import org.openmetadata.service.jdbi3.EntityRepository;
 import org.openmetadata.service.jdbi3.StoredProcedureRepository;
 import org.openmetadata.service.jdbi3.SystemRepository;
@@ -1736,7 +1737,7 @@ public class EntityCsvTest {
                   Entity.getEntityByNameWithExcludedFields(
                       Entity.DATABASE_SCHEMA,
                       "service.db.sales",
-                      "owners,tags,domains,extension",
+                      "owners,tags,extension",
                       org.openmetadata.schema.type.Include.NON_DELETED))
           .thenThrow(
               org.openmetadata.service.exception.EntityNotFoundException.byName(
@@ -2056,7 +2057,7 @@ public class EntityCsvTest {
                   Entity.getEntityByName(
                       Entity.STORED_PROCEDURE,
                       storedProcedureFqn,
-                      "name,displayName,fullyQualifiedName",
+                      "name,displayName,fullyQualifiedName,domains",
                       org.openmetadata.schema.type.Include.NON_DELETED))
           .thenThrow(
               org.openmetadata.service.exception.EntityNotFoundException.byName(
@@ -2130,7 +2131,7 @@ public class EntityCsvTest {
         .getEntityWithDependencyResolution(
             Entity.STORED_PROCEDURE,
             storedProcedureFqn,
-            "name,displayName,fullyQualifiedName",
+            "name,displayName,fullyQualifiedName,domains",
             org.openmetadata.schema.type.Include.NON_DELETED);
 
     try (MockedStatic<Entity> entity = Mockito.mockStatic(Entity.class);
@@ -2207,7 +2208,7 @@ public class EntityCsvTest {
                   Entity.getEntityByName(
                       Entity.STORED_PROCEDURE,
                       storedProcedureFqn,
-                      "name,displayName,fullyQualifiedName",
+                      "name,displayName,fullyQualifiedName,domains",
                       org.openmetadata.schema.type.Include.NON_DELETED))
           .thenThrow(
               org.openmetadata.service.exception.EntityNotFoundException.byName(
@@ -2935,17 +2936,28 @@ public class EntityCsvTest {
   }
 
   @Test
-  void test_getDomainsKeepsExistingDomainsWhenCsvColumnEmpty() {
+  void test_getDomainsEmptyColumnKeepsOnlyInheritedDomains() {
     TestCsv testCsv = new TestCsv();
     testCsv.enableProcessing();
     testCsv.addEntity(Entity.DOMAIN, "finance", domain("finance"));
-    List<EntityReference> existingDomains = List.of(ref(Entity.DOMAIN, "inheritedDomain"));
+    EntityReference inheritedDomain = ref(Entity.DOMAIN, "inheritedDomain").withInherited(true);
+    EntityReference directDomain = ref(Entity.DOMAIN, "directDomain");
+    List<EntityReference> existingDomains = List.of(inheritedDomain, directDomain);
 
     List<EntityReference> keptWhenEmpty =
         testCsv.getDomains(
             mock(CSVPrinter.class), singleRecord(testCsv, "", "", ""), 0, existingDomains);
     assertEquals(
-        existingDomains, keptWhenEmpty, "Empty domain column must keep the existing domains");
+        List.of(inheritedDomain),
+        keptWhenEmpty,
+        "Empty domain column must keep only inherited domains and clear direct ones");
+
+    List<EntityReference> clearedWhenNoInherited =
+        testCsv.getDomains(
+            mock(CSVPrinter.class), singleRecord(testCsv, "", "", ""), 0, List.of(directDomain));
+    assertNull(
+        clearedWhenNoInherited,
+        "Empty domain column with only direct domains must clear them (pre-existing behavior)");
 
     List<EntityReference> parsedWhenPresent =
         testCsv.getDomains(
@@ -3044,12 +3056,18 @@ public class EntityCsvTest {
         entityStatic.when(() -> Entity.getEntityRepository(ignoredType)).thenReturn(ignoredRepo);
       }
       entityStatic.when(Entity::getSystemRepository).thenReturn(mock(SystemRepository.class));
-      entityStatic
-          .when(
-              () ->
-                  Entity.getEntities(
-                      Mockito.anyList(), Mockito.eq("domains"), Mockito.eq(Include.NON_DELETED)))
-          .thenReturn(List.of(dataProduct));
+      CollectionDAO collectionDAO = mock(CollectionDAO.class);
+      CollectionDAO.EntityRelationshipDAO relationshipDAO =
+          mock(CollectionDAO.EntityRelationshipDAO.class);
+      EntityRelationshipRepository relationshipRepository =
+          mock(EntityRelationshipRepository.class);
+      entityStatic.when(Entity::getCollectionDAO).thenReturn(collectionDAO);
+      entityStatic.when(Entity::getEntityRelationshipRepository).thenReturn(relationshipRepository);
+      Mockito.when(collectionDAO.relationshipDAO()).thenReturn(relationshipDAO);
+      Mockito.when(
+              relationshipRepository.getEntityReferences(
+                  Mockito.anyList(), Mockito.eq(Include.NON_DELETED)))
+          .thenReturn(dataProduct.getDomains());
       settingsCache
           .when(
               () ->

--- a/openmetadata-service/src/test/java/org/openmetadata/csv/EntityCsvTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/csv/EntityCsvTest.java
@@ -2966,6 +2966,12 @@ public class EntityCsvTest {
         List.of("finance"),
         parsedWhenPresent.stream().map(EntityReference::getName).toList(),
         "A provided domain column must override the existing domains");
+
+    TestCsv deadRowCsv = new TestCsv();
+    assertNull(
+        deadRowCsv.getDomains(
+            mock(CSVPrinter.class), singleRecord(testCsv, "", "", ""), 0, existingDomains),
+        "A failed row (processRecord=false) must not carry over any domains");
   }
 
   @Test

--- a/openmetadata-service/src/test/java/org/openmetadata/csv/EntityCsvTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/csv/EntityCsvTest.java
@@ -1843,7 +1843,7 @@ public class EntityCsvTest {
                   Entity.getEntityByNameWithExcludedFields(
                       Entity.TABLE,
                       tableFqn,
-                      "owners,tags,domains,extension",
+                      "owners,tags,extension",
                       org.openmetadata.schema.type.Include.NON_DELETED))
           .thenThrow(org.openmetadata.service.exception.EntityNotFoundException.byName(tableFqn));
       entity.when(() -> Entity.getEntityRepository(Entity.TABLE)).thenReturn(repository);
@@ -2965,6 +2965,10 @@ public class EntityCsvTest {
     assertEquals(0, scenario.testCsv().importResult.getNumberOfRowsFailed());
     assertEquals(1, scenario.testCsv().importResult.getNumberOfRowsPassed());
     assertEquals(ENTITY_UPDATED, scenario.testCsv().pendingCsvResults.get(scenario.csvRecord()));
+    assertTrue(
+        scenario.updatedEntity().getDomains() == null
+            || scenario.updatedEntity().getDomains().isEmpty(),
+        "Inherited domain must be dropped before persistence, not materialized as a direct domain");
   }
 
   @Test
@@ -2983,7 +2987,10 @@ public class EntityCsvTest {
   }
 
   private record DataProductImportScenario(
-      TestCsv testCsv, CSVRecord csvRecord, EntityRepository<EntityInterface> repository) {}
+      TestCsv testCsv,
+      CSVRecord csvRecord,
+      EntityRepository<EntityInterface> repository,
+      Table updatedEntity) {}
 
   /**
    * Simulates the importer state after the fix: the entity reaching rule evaluation carries the
@@ -3055,7 +3062,7 @@ public class EntityCsvTest {
 
       testCsv.queueEntity(csvRecord, updatedEntity);
     }
-    return new DataProductImportScenario(testCsv, csvRecord, repository);
+    return new DataProductImportScenario(testCsv, csvRecord, repository, updatedEntity);
   }
 
   private static SemanticsRule dataProductDomainValidationRule() {

--- a/openmetadata-spec/src/main/resources/json/schema/api/data/createGlossaryTerm.json
+++ b/openmetadata-spec/src/main/resources/json/schema/api/data/createGlossaryTerm.json
@@ -87,6 +87,14 @@
     "extension": {
       "description": "Entity extension data with custom attributes added to the entity.",
       "$ref": "../../type/basic.json#/definitions/entityExtension"
+    },
+    "domains": {
+      "description": "Fully qualified names of the domains the Glossary Term belongs to.",
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "default": null
     }
   },
   "required": ["glossary", "name", "description"],

--- a/openmetadata-spec/src/main/resources/json/schema/api/data/createGlossaryTerm.json
+++ b/openmetadata-spec/src/main/resources/json/schema/api/data/createGlossaryTerm.json
@@ -93,8 +93,7 @@
       "type": "array",
       "items": {
         "type": "string"
-      },
-      "default": null
+      }
     }
   },
   "required": ["glossary", "name", "description"],

--- a/openmetadata-ui/src/main/resources/ui/src/generated/api/data/createGlossaryTerm.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/api/data/createGlossaryTerm.ts
@@ -27,6 +27,10 @@ export interface CreateGlossaryTerm {
      */
     displayName?: string;
     /**
+     * Fully qualified names of the domains the Glossary Term belongs to.
+     */
+    domains?: string[];
+    /**
      * Entity extension data with custom attributes added to the entity.
      */
     extension?: any;

--- a/openmetadata-ui/src/main/resources/ui/src/generated/api/data/loadGlossary.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/api/data/loadGlossary.ts
@@ -348,6 +348,10 @@ export interface CreateGlossaryTermRequest {
      */
     displayName?: string;
     /**
+     * Fully qualified names of the domains the Glossary Term belongs to.
+     */
+    domains?: string[];
+    /**
      * Entity extension data with custom attributes added to the entity.
      */
     extension?: any;


### PR DESCRIPTION
Backport of #28655 to `1.13` (Closes #28523 for 1.13).

## What this fixes
Bulk-editing a data asset via CSV import (tags, tier, certification, description, …) fails with **"Rule [Data Product Domain Validation] validation failed"** when the entity **inherits** its domain and has a data product in that same domain. Also fixes two adjacent CSV issues found while working on this (DriveService displayName/description swap, and `createGlossaryTerm` silently dropping `domains`).

## Cherry-picked from #28655 (10 of 12 functional commits)
- `keep inherited domain on bulk edit` + `extend to all importers and stop materializing it` (#28523 core)
- `empty domain column clears direct domains, keeps inherited only for rule validation`
- `never write inherited domains to the CSV domains column`
- `4-arg getDomains returns null on failed rows`
- `test: rewrite exported CSV with Commons CSV`
- `fix(drives): correct displayName/description mapping in driveService CSV import`
- `fix(glossary): add missing domains field to createGlossaryTerm schema` (+ generated types, aligned with sibling schemas)

The core logic (`EntityCsv` 4-arg `getDomains` + `dropInheritedDomains`, `CsvUtil.addDomains`, and every importer's 4-arg `getDomains`, including the Directory CSV **import** path) is byte-identical to #28655.

## Intentionally NOT backported (2 commits)
`4619dd8cce` and `d782b10c77` touch `DirectoryRepository.setFieldsInBulk` / `fetchAndSetParents` — the **bulk-list-read** parent-resolution path. **1.13's `DirectoryRepository` has no `setFieldsInBulk`** (that infrastructure was added later on `main`), so the nested-directory bulk-list inheritance bug they fix does not exist in 1.13. Including them would be dead code. The Directory **CSV-import** domain fix itself *is* included; only the unrelated bulk-read fix is omitted.

## Verification
- **`mvn clean install -DskipTests` → BUILD SUCCESS** (all 16 modules, locally).
- Backend + UI verified against an **isolated** fresh 1.13 stack (separate Postgres/OpenSearch/server on non-default ports):
  - #28523 end-to-end: table inheriting domain + matching data product → CSV bulk edit (dry-run + real) passes, inherited domain not materialized.
  - Domain-scenario matrix across DatabaseService/Database/Schema/Table/GlossaryTerm/Directory: **49/49**.
  - Regression guards: genuine domain mismatch still correctly rejected; blanking a direct-domain column still clears it; CSV value still overrides.
  - UI bulk-edit wizard on the inheriting table: **Passed 1 / Failed 0**, no rule error (dry-run + real).

## Note on CI
The 1.13 branch CI is currently red across the board (unit-test failures in `SearchRepositoryBehaviorTest` / `EntityRepositoryRestoreTest` / `SecurityConfigurationManagerTest`, `py-checkstyle`, flaky shard-2 ITs, and the `Validate PR Metadata` token check) — the **same failures appear on already-merged 1.13 backports** (e.g. #30030, #30021). These are pre-existing and unrelated to this change; the failing tests are in search/restore/security areas this PR doesn't touch, and `build` / `checkstyle` / `generate-types` all pass.
