### PR TITLE
test(data-quality): use antd searchbar testid in 1.13 Table filter test

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/Table.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/Table.spec.ts
@@ -146,10 +146,8 @@ test.describe('Table pagination sorting search scenarios ', () => {
         response.url().includes('/api/v1/dataQuality/testCases/search/list') &&
         response.url().includes(noMatchSearch)
     );
-    await page.locator('[data-testid="searchbar-component"] input').click();
-    await page
-      .locator('[data-testid="searchbar-component"] input')
-      .fill(noMatchSearch);
+    await page.getByTestId('searchbar').click();
+    await page.getByTestId('searchbar').fill(noMatchSearch);
     await emptySearchResponse;
     await page
       .getByTestId('test-case-container')


### PR DESCRIPTION
## Problem

The Table filter de-flake (#29995) added a no-match search step that targets the `searchbar-component` testid. That testid exists only on `main`, where the Data Quality header was revamped onto **core-ui** components — [`TestCaseListTableHeader.component.tsx`](https://github.com/open-metadata/OpenMetadata/blob/main/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/TestCases/TestCaseListTableHeader.component.tsx) renders `<div data-testid="searchbar-component">`.

On **1.13** the header still uses the **antd** `Searchbar` common component (`SearchBar.component.tsx`), whose input testid is `searchbar` (no `searchBarDataTestId` is passed). So `[data-testid="searchbar-component"] input` matches nothing, the `.fill()` finds no element, and *Table filter with sorting should work* fails before it can reach the empty-state placeholder.

## Fix

Target the `searchbar` testid instead — matching 1.13's antd component, and identical to what the sibling *"Table search with sorting should work"* test in this same file already uses (and which passes on 1.13):

```diff
-    await page.locator('[data-testid="searchbar-component"] input').click();
-    await page
-      .locator('[data-testid="searchbar-component"] input')
-      .fill(noMatchSearch);
+    await page.getByTestId('searchbar').click();
+    await page.getByTestId('searchbar').fill(noMatchSearch);
```

Test-only, 1.13-specific selector change. The Queued-filter + no-match-search logic and the placeholder assertion from #29995 are unchanged; `main` keeps `searchbar-component` and is unaffected.

## Note

Verified by parity with the sibling search test (same `getByTestId('searchbar')` selector, passing on 1.13). No 1.13 UI behavior changes — this only fixes the test selector.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR updates a 1.13 Playwright test selector for the Data Quality table filter flow. The main changes are:

- Replaces the `searchbar-component` wrapper lookup with `getByTestId('searchbar')`.
- Uses the same selector for clicking and filling the no-match search term.
- Keeps the existing empty-state response wait and placeholder assertion unchanged.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge.

- No blocking issues found in the changed code.

</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/Table.spec.ts | Updates the Data Quality table filter test to target the 1.13 antd SearchBar input test id. |

</details>

<sub>Reviews (1): Last reviewed commit: ["test(data-quality): use antd searchbar t..."](https://github.com/open-metadata/openmetadata/commit/c9af5f1114ebe042c6a55f9af5f2dd3e103fe18b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44048693)</sub>

**Context used:**

- Context used - CLAUDE.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=52f0d9d9-cad1-4e7d-b070-de181a0aa5e7))
- Context used - openmetadata-ui-core-components/CLAUDE.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=41754627-b2bf-474b-8082-f37ef1a07013))

<!-- /greptile_comment -->