### PR TITLE
fix(tasks): honor startTs/endTs date filter on /visible, /owned, /created task endpoints

### DIFF
--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/TaskResourceIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/TaskResourceIT.java
@@ -2115,11 +2115,25 @@ public class TaskResourceIT extends BaseEntityIT<Task, CreateTask> {
     assertTrue(
         inRange.getData().stream().anyMatch(t -> t.getId().equals(taskId)),
         "Task should appear when its createdAt is inside the window");
+    assertEquals(
+        inRange.getData().size(),
+        inRange.getTotal(),
+        "paging.total must reflect the time-filtered rows, not an unfiltered count");
+
+    ListResponse<Task> boundary = lister.apply(createdAt, createdAt);
+    assertTrue(
+        boundary.getData().stream().anyMatch(t -> t.getId().equals(taskId)),
+        "Task should appear when the window bounds equal its createdAt (bounds are inclusive)");
 
     ListResponse<Task> pastRange = lister.apply(createdAt - 5000, createdAt - 1000);
     assertFalse(
         pastRange.getData().stream().anyMatch(t -> t.getId().equals(taskId)),
-        "Task should be excluded when the window ends before its createdAt");
+        "Task should be excluded when the window ends before its createdAt (endTs upper bound)");
+
+    ListResponse<Task> futureRange = lister.apply(createdAt + 1000, createdAt + 5000);
+    assertFalse(
+        futureRange.getData().stream().anyMatch(t -> t.getId().equals(taskId)),
+        "Task should be excluded when the window starts after its createdAt (startTs lower bound)");
   }
 
   // ==================== Entity Change Application Tests ====================

--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/TaskResourceIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/TaskResourceIT.java
@@ -20,6 +20,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import java.util.function.BiFunction;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.parallel.Execution;
@@ -2055,6 +2056,70 @@ public class TaskResourceIT extends BaseEntityIT<Task, CreateTask> {
     assertEquals(3, visibleTasks.getData().size(), "Visible list should de-duplicate the union");
     assertEquals(3, visibleCount.getTotal(), "All-view count should match the visible task union");
     assertEquals(3, visibleCount.getOpen(), "All-view open count should match visible open tasks");
+  }
+
+  @Test
+  void testScopedTaskEndpointsHonorTimeRange(TestNamespace ns) {
+    SharedEntities shared = SharedEntities.get();
+    Domain domain = createDomain(ns, "time-range-domain");
+    Table ownedTable =
+        createTableWithDomainAndOwners(ns, domain.getEntityReference(), List.of(shared.USER1_REF));
+
+    Task assignedTask =
+        SdkClients.adminClient()
+            .tasks()
+            .create(
+                createTaskRequestAboutTable(ns, "time-range-assigned", ownedTable)
+                    .withAssignees(List.of(shared.USER1.getFullyQualifiedName())));
+    Task createdTask =
+        SdkClients.user1Client()
+            .tasks()
+            .create(createTaskRequestAboutTable(ns, "time-range-created", ownedTable));
+
+    // assignedTask is visible to user1 both via /visible and /owned (about a
+    // user1-owned table); createdTask exercises /created (createdBy user1).
+    assertTimeRangeFilters(
+        (startTs, endTs) ->
+            SdkClients.user1Client()
+                .tasks()
+                .listVisible(null, null, null, "assignees,about", 1000, startTs, endTs),
+        assignedTask.getId(),
+        assignedTask.getCreatedAt());
+    assertTimeRangeFilters(
+        (startTs, endTs) ->
+            SdkClients.user1Client()
+                .tasks()
+                .listOwned(null, null, null, "about", 1000, startTs, endTs),
+        assignedTask.getId(),
+        assignedTask.getCreatedAt());
+    assertTimeRangeFilters(
+        (startTs, endTs) ->
+            SdkClients.user1Client()
+                .tasks()
+                .listCreated(null, null, null, "about", 1000, startTs, endTs),
+        createdTask.getId(),
+        createdTask.getCreatedAt());
+
+    assertThrows(
+        InvalidRequestException.class,
+        () ->
+            SdkClients.user1Client()
+                .tasks()
+                .listVisible(null, null, null, null, null, 2000L, 1000L),
+        "Inverted startTs > endTs should return 400");
+  }
+
+  private void assertTimeRangeFilters(
+      BiFunction<Long, Long, ListResponse<Task>> lister, UUID taskId, long createdAt) {
+    ListResponse<Task> inRange = lister.apply(createdAt - 1000, createdAt + 1000);
+    assertTrue(
+        inRange.getData().stream().anyMatch(t -> t.getId().equals(taskId)),
+        "Task should appear when its createdAt is inside the window");
+
+    ListResponse<Task> pastRange = lister.apply(createdAt - 5000, createdAt - 1000);
+    assertFalse(
+        pastRange.getData().stream().anyMatch(t -> t.getId().equals(taskId)),
+        "Task should be excluded when the window ends before its createdAt");
   }
 
   // ==================== Entity Change Application Tests ====================

--- a/openmetadata-sdk/src/main/java/org/openmetadata/sdk/services/tasks/TaskService.java
+++ b/openmetadata-sdk/src/main/java/org/openmetadata/sdk/services/tasks/TaskService.java
@@ -233,6 +233,82 @@ public class TaskService extends EntityServiceBase<Task> {
     return deserializeListResponse(responseStr);
   }
 
+  private ListResponse<Task> listScopedTasks(
+      String path,
+      TaskEntityStatus status,
+      String statusGroup,
+      String domain,
+      String fields,
+      Integer limit,
+      Long startTs,
+      Long endTs)
+      throws OpenMetadataException {
+    RequestOptions.Builder optionsBuilder = RequestOptions.builder();
+    if (status != null) {
+      optionsBuilder.queryParam("status", status.value());
+    }
+    if (statusGroup != null) {
+      optionsBuilder.queryParam("statusGroup", statusGroup);
+    }
+    if (domain != null) {
+      optionsBuilder.queryParam("domain", domain);
+    }
+    if (fields != null) {
+      optionsBuilder.queryParam("fields", fields);
+    }
+    if (limit != null) {
+      optionsBuilder.queryParam("limit", limit.toString());
+    }
+    if (startTs != null) {
+      optionsBuilder.queryParam("startTs", startTs.toString());
+    }
+    if (endTs != null) {
+      optionsBuilder.queryParam("endTs", endTs.toString());
+    }
+    String responseStr =
+        httpClient.executeForString(HttpMethod.GET, path, null, optionsBuilder.build());
+    return deserializeListResponse(responseStr);
+  }
+
+  public ListResponse<Task> listVisible(
+      TaskEntityStatus status,
+      String statusGroup,
+      String domain,
+      String fields,
+      Integer limit,
+      Long startTs,
+      Long endTs)
+      throws OpenMetadataException {
+    return listScopedTasks(
+        basePath + "/visible", status, statusGroup, domain, fields, limit, startTs, endTs);
+  }
+
+  public ListResponse<Task> listOwned(
+      TaskEntityStatus status,
+      String statusGroup,
+      String domain,
+      String fields,
+      Integer limit,
+      Long startTs,
+      Long endTs)
+      throws OpenMetadataException {
+    return listScopedTasks(
+        basePath + "/owned", status, statusGroup, domain, fields, limit, startTs, endTs);
+  }
+
+  public ListResponse<Task> listCreated(
+      TaskEntityStatus status,
+      String statusGroup,
+      String domain,
+      String fields,
+      Integer limit,
+      Long startTs,
+      Long endTs)
+      throws OpenMetadataException {
+    return listScopedTasks(
+        basePath + "/created", status, statusGroup, domain, fields, limit, startTs, endTs);
+  }
+
   /**
    * List Data Access Requests with DAR-specific filters and offset-based pagination.
    * Pre-applies category=DataAccess and type=DataAccessRequest server-side.

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/tasks/TaskResource.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/tasks/TaskResource.java
@@ -616,12 +616,19 @@ public class TaskResource extends EntityResource<Task, TaskRepository> {
           String before,
       @Parameter(description = "Returns list of tasks after this cursor") @QueryParam("after")
           String after,
+      @Parameter(description = "Filter by tasks created on or after this timestamp (epoch millis)")
+          @QueryParam("startTs")
+          Long startTs,
+      @Parameter(description = "Filter by tasks created on or before this timestamp (epoch millis)")
+          @QueryParam("endTs")
+          Long endTs,
       @Parameter(description = "Include deleted tasks")
           @QueryParam("include")
           @DefaultValue("non-deleted")
           Include include) {
     ListFilter filter = buildTaskListFilter(include, status, statusGroup, domain);
     addCurrentUserVisibleFilters(filter, uriInfo, securityContext);
+    applyTaskTimeRange(filter, startTs, endTs);
 
     return listInternal(uriInfo, securityContext, fieldsParam, filter, limitParam, before, after);
   }
@@ -667,6 +674,12 @@ public class TaskResource extends EntityResource<Task, TaskRepository> {
           String before,
       @Parameter(description = "Returns list of tasks after this cursor") @QueryParam("after")
           String after,
+      @Parameter(description = "Filter by tasks created on or after this timestamp (epoch millis)")
+          @QueryParam("startTs")
+          Long startTs,
+      @Parameter(description = "Filter by tasks created on or before this timestamp (epoch millis)")
+          @QueryParam("endTs")
+          Long endTs,
       @Parameter(description = "Include deleted tasks")
           @QueryParam("include")
           @DefaultValue("non-deleted")
@@ -685,6 +698,7 @@ public class TaskResource extends EntityResource<Task, TaskRepository> {
 
     ListFilter filter = buildTaskListFilter(include, status, statusGroup, domain);
     filter.addQueryParam("ownedByIds", String.join(",", ownerIds));
+    applyTaskTimeRange(filter, startTs, endTs);
 
     return listInternal(uriInfo, securityContext, fieldsParam, filter, limitParam, before, after);
   }
@@ -728,6 +742,12 @@ public class TaskResource extends EntityResource<Task, TaskRepository> {
           String before,
       @Parameter(description = "Returns list of tasks after this cursor") @QueryParam("after")
           String after,
+      @Parameter(description = "Filter by tasks created on or after this timestamp (epoch millis)")
+          @QueryParam("startTs")
+          Long startTs,
+      @Parameter(description = "Filter by tasks created on or before this timestamp (epoch millis)")
+          @QueryParam("endTs")
+          Long endTs,
       @Parameter(description = "Include deleted tasks")
           @QueryParam("include")
           @DefaultValue("non-deleted")
@@ -737,6 +757,7 @@ public class TaskResource extends EntityResource<Task, TaskRepository> {
 
     ListFilter filter = buildTaskListFilter(include, status, statusGroup, domain);
     filter.addQueryParam("createdById", user.getId().toString());
+    applyTaskTimeRange(filter, startTs, endTs);
 
     return listInternal(uriInfo, securityContext, fieldsParam, filter, limitParam, before, after);
   }


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:
<!--
Linking an issue is REQUIRED. Replace <issue-number> with the GitHub issue number this PR addresses
(e.g., `Fixes #12345`). GitHub will auto-link it. If no issue exists, please open one first so the
problem and design can be discussed before review.
-->

<!--
Short blurb explaining:
- What changes did you make?
- Why did you make them?
-->

## Problem

The scoped task-list endpoints `GET /v1/tasks/visible`, `/v1/tasks/owned`, and `/v1/tasks/created` accept no date-range parameters and never apply a time window. Callers that pass `startTs`/`endTs` (e.g. a personal task inbox with a "Last 30 days" filter) get their params silently dropped by JAX-RS, so the returned tasks — and the `paging.total` used for badge counts — ignore the selected date range entirely.

The sibling endpoints `/v1/tasks` (`listTasks`) and `/v1/tasks/assigned`
(`listMyAssignedTasks`) already support `startTs`/`endTs` via
`applyTaskTimeRange(...)`; the three scoped endpoints were simply missing the
same wiring.

## Fix

Add `startTs` / `endTs` `@QueryParam`s and an `applyTaskTimeRange(filter, startTs, endTs)`
call to:

- `listMyVisibleTasks` (`/visible`)
- `listMyOwnedTasks` (`/owned`)
- `listMyCreatedTasks` (`/created`)

Wording and behavior mirror the existing `/assigned` and `/tasks` handlers exactly — `startTs > endTs` still throws `400`, and both bounds are optional. No schema or client changes required; the generated params already exist on the
request path.

## Impact

- Personal task inboxes / any consumer of the visible/owned/created endpoints now filter by the requested date window.
- `paging.total` from these endpoints is now accurate for a given window, so count badges built on `limit=1` reads become correct.
- Backwards compatible: omitting `startTs`/`endTs` preserves current behavior (no time filter).

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### High-level design:
<!--
REQUIRED for large PRs (new features, refactors, breaking changes, or anything touching >5 files).
Skip for small bug fixes and trivial changes.

Cover:
- Architecture / approach you took and why
- Key components or files added/changed and how they interact
- Alternatives considered and why you rejected them
- Any migration, backward-compatibility, or rollout concerns
- Diagrams or links to design docs / RFCs if available
-->

N/A — small change. <!-- Or fill in the design above -->

#
### Tests:

#### Use cases covered
<!--
List the user-visible scenarios this PR exercises. Example:
- User with Admin role can create a Glossary Term with a parent term
- Ingestion run for Snowflake correctly extracts row counts for partitioned tables
-->

#### Unit tests
<!--
- [ ] I added unit tests for the new/changed logic.
- Files added/updated:
- Coverage on changed classes (run `mvn jacoco:report` for backend, `yarn test:coverage` for UI,
  `make unit_ingestion` for ingestion). Target is 90% line coverage on changed classes.
- Coverage %: <e.g., 92% on EntityRepository.java>
-->

#### Backend integration tests
<!--
- [ ] I added integration tests in `openmetadata-integration-tests/` for new/changed API endpoints.
- [ ] Not applicable (no backend API changes).
- Files added/updated:
-->

#### Ingestion integration tests
<!--
- [ ] I added/updated ingestion integration tests for connector changes.
- [ ] Not applicable (no ingestion changes).
- Files added/updated:
-->

#### Playwright (UI) tests
<!--
- [ ] I added Playwright E2E tests under `openmetadata-ui/.../ui/playwright/` for UI changes.
- [ ] Not applicable (no UI changes).
- Files added/updated:
-->

#### Manual testing performed
<!--
List the manual test steps you performed before requesting review. Example:
1. Started local stack via `./docker/run_local_docker.sh -m ui -d mysql`
2. Logged in as admin, created entity X, verified Y appears in the UI
3. Triggered ingestion for Snowflake source, confirmed lineage edges in the explore page
-->

#
### UI screen recording / screenshots:
<!--
REQUIRED for any PR that changes the UI. Drag-and-drop a short screen recording (.mov / .mp4 / .gif)
demonstrating the change end-to-end, plus before/after screenshots where relevant.
Mark "Not applicable" if there are no UI changes.
-->

Not applicable. <!-- Or attach recording/screenshots above -->

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.
- [ ] For UI changes: I attached a screen recording and/or screenshots above.
- [ ] I have added tests (unit / integration / Playwright as applicable) and listed them above.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds date filtering to scoped task list APIs. The main changes are:

- `startTs` and `endTs` support on `/visible`, `/owned`, and `/created` task endpoints.
- SDK overloads that pass the date range to those scoped endpoints.
- Integration coverage for filtered rows, inclusive bounds, invalid ranges, and filtered totals.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge.

- No blocking issues found in the changed code.

</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-service/src/main/java/org/openmetadata/service/resources/tasks/TaskResource.java | Adds date-range query params to the scoped task endpoints and applies the existing task time-range filter before listing. |
| openmetadata-sdk/src/main/java/org/openmetadata/sdk/services/tasks/TaskService.java | Adds scoped task-list overloads that send `startTs` and `endTs` with the request. |
| openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/TaskResourceIT.java | Adds integration coverage for the scoped endpoint date filters and totals. |

</details>

<sub>Reviews (3): Last reviewed commit: ["test(tasks): assert total, inclusive bou..."](https://github.com/open-metadata/openmetadata/commit/2de96aa870656e07ace7c6924bd562ac7c4cd229) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44053900)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Context used - CLAUDE.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=52f0d9d9-cad1-4e7d-b070-de181a0aa5e7))
- Context used - openmetadata-ui-core-components/CLAUDE.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=41754627-b2bf-474b-8082-f37ef1a07013))
- Context used - AGENTS.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=ef262f5f-911f-44f3-8d2d-e9cb1579c8c8))
</details>

<!-- /greptile_comment -->