### PR TITLE
feat(ui-core-components): add EmptyPlaceholder component

### DIFF
--- a/openmetadata-ui-core-components/src/main/resources/ui/src/components/application/empty-placeholder/blank-empty-placeholder.tsx
+++ b/openmetadata-ui-core-components/src/main/resources/ui/src/components/application/empty-placeholder/blank-empty-placeholder.tsx
@@ -18,6 +18,7 @@ import type {
   EmptyPlaceholderShellProps,
 } from './empty-placeholder-shell';
 import {
+  EMPTY_PLACEHOLDER_ICON_BOX,
   EmptyPlaceholderShell,
   renderEmptyPlaceholderIcon,
 } from './empty-placeholder-shell';
@@ -40,7 +41,7 @@ export const BlankEmptyPlaceholder = ({
 }: BlankEmptyPlaceholderProps) => (
   <EmptyPlaceholderShell width={width ?? DEFAULT_BLANK_WIDTH} {...rest}>
     {icon && (
-      <div className="tw:flex tw:size-16 tw:shrink-0 tw:items-center tw:justify-center tw:rounded-2xl tw:border tw:border-secondary tw:bg-primary tw:shadow-empty-placeholder-icon tw:*:data-icon:size-7">
+      <div className={EMPTY_PLACEHOLDER_ICON_BOX}>
         {renderEmptyPlaceholderIcon(icon, 'tw:size-7')}
       </div>
     )}

--- a/openmetadata-ui-core-components/src/main/resources/ui/src/components/application/empty-placeholder/blank-empty-placeholder.tsx
+++ b/openmetadata-ui-core-components/src/main/resources/ui/src/components/application/empty-placeholder/blank-empty-placeholder.tsx
@@ -40,7 +40,7 @@ export const BlankEmptyPlaceholder = ({
 }: BlankEmptyPlaceholderProps) => (
   <EmptyPlaceholderShell width={width ?? DEFAULT_BLANK_WIDTH} {...rest}>
     {icon && (
-      <div className="tw:flex tw:size-16 tw:shrink-0 tw:items-center tw:justify-center tw:rounded-2xl tw:border tw:border-secondary tw:bg-primary tw:shadow-[0_2px_10px_0_rgba(223,227,245,0.60)] tw:*:data-icon:size-7">
+      <div className="tw:flex tw:size-16 tw:shrink-0 tw:items-center tw:justify-center tw:rounded-2xl tw:border tw:border-secondary tw:bg-primary tw:shadow-empty-placeholder-icon tw:*:data-icon:size-7">
         {renderEmptyPlaceholderIcon(icon, 'tw:size-7')}
       </div>
     )}

--- a/openmetadata-ui-core-components/src/main/resources/ui/src/components/application/empty-placeholder/blank-empty-placeholder.tsx
+++ b/openmetadata-ui-core-components/src/main/resources/ui/src/components/application/empty-placeholder/blank-empty-placeholder.tsx
@@ -1,0 +1,68 @@
+/*
+ *  Copyright 2025 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+import type { ReactNode } from 'react';
+import { Box } from '@/components/base/box/box';
+import { Typography } from '@/components/foundations/typography';
+import type {
+  EmptyPlaceholderIcon,
+  EmptyPlaceholderShellProps,
+} from './empty-placeholder-shell';
+import {
+  EmptyPlaceholderShell,
+  renderEmptyPlaceholderIcon,
+} from './empty-placeholder-shell';
+
+const DEFAULT_BLANK_WIDTH = 300;
+
+export interface BlankEmptyPlaceholderProps
+  extends Omit<EmptyPlaceholderShellProps, 'children'> {
+  icon?: EmptyPlaceholderIcon;
+  title?: ReactNode;
+  description?: ReactNode;
+}
+
+export const BlankEmptyPlaceholder = ({
+  icon,
+  title,
+  description,
+  width,
+  ...rest
+}: BlankEmptyPlaceholderProps) => (
+  <EmptyPlaceholderShell width={width ?? DEFAULT_BLANK_WIDTH} {...rest}>
+    {icon && (
+      <div className="tw:flex tw:size-16 tw:shrink-0 tw:items-center tw:justify-center tw:rounded-2xl tw:border tw:border-secondary tw:bg-primary tw:shadow-[0_2px_10px_0_rgba(223,227,245,0.60)] tw:*:data-icon:size-7">
+        {renderEmptyPlaceholderIcon(icon, 'tw:size-7')}
+      </div>
+    )}
+    {(title || description) && (
+      <Box
+        align="center"
+        className="tw:max-w-lg tw:gap-1.5 tw:text-center"
+        direction="col">
+        {title && (
+          <Typography size="text-sm" weight="semibold">
+            {title}
+          </Typography>
+        )}
+        {description && (
+          <Typography
+            className="tw:text-secondary"
+            size="text-xs"
+            weight="regular">
+            {description}
+          </Typography>
+        )}
+      </Box>
+    )}
+  </EmptyPlaceholderShell>
+);

--- a/openmetadata-ui-core-components/src/main/resources/ui/src/components/application/empty-placeholder/empty-placeholder-shell.tsx
+++ b/openmetadata-ui-core-components/src/main/resources/ui/src/components/application/empty-placeholder/empty-placeholder-shell.tsx
@@ -10,8 +10,8 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-import type { FC, HTMLAttributes, ReactNode } from 'react';
-import { isValidElement } from 'react';
+import type { FC, HTMLAttributes, ReactElement, ReactNode } from 'react';
+import { cloneElement, isValidElement } from 'react';
 import { Box } from '@/components/base/box/box';
 import type { GapValues } from '@/components/base/box/box';
 import { Button } from '@/components/base/buttons/button';
@@ -65,7 +65,14 @@ export const renderEmptyPlaceholderIcon = (
     const Icon = icon as FC<{ className?: string }>;
     node = <Icon data-icon className={className} />;
   } else if (isValidElement(icon)) {
-    node = icon;
+    const element = icon as ReactElement<{
+      className?: string;
+      'data-icon'?: boolean;
+    }>;
+    node = cloneElement(element, {
+      'data-icon': true,
+      className: cx(element.props.className, className),
+    });
   }
 
   return node;

--- a/openmetadata-ui-core-components/src/main/resources/ui/src/components/application/empty-placeholder/empty-placeholder-shell.tsx
+++ b/openmetadata-ui-core-components/src/main/resources/ui/src/components/application/empty-placeholder/empty-placeholder-shell.tsx
@@ -10,8 +10,8 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-import type { FC, HTMLAttributes, ReactNode, Ref } from 'react';
-import { isValidElement } from 'react';
+import type { FC, HTMLAttributes, ReactNode } from 'react';
+import { forwardRef, isValidElement } from 'react';
 import { Box } from '@/components/base/box/box';
 import type { GapValues } from '@/components/base/box/box';
 import { Button } from '@/components/base/buttons/button';
@@ -41,7 +41,6 @@ export interface EmptyPlaceholderFeature {
 
 export interface EmptyPlaceholderShellProps
   extends Omit<HTMLAttributes<HTMLDivElement>, 'title'> {
-  ref?: Ref<HTMLDivElement>;
   /** Buttons rendered below the content */
   actions?: EmptyPlaceholderAction[];
   /** Replaces the generated action buttons entirely */
@@ -91,9 +90,11 @@ export const renderEmptyPlaceholderActions = (
   return node;
 };
 
-export const EmptyPlaceholderShell = (props: EmptyPlaceholderShellProps) => {
+export const EmptyPlaceholderShell = forwardRef<
+  HTMLDivElement,
+  EmptyPlaceholderShellProps
+>((props, ref) => {
   const {
-    ref,
     actions,
     footer,
     width,
@@ -120,4 +121,6 @@ export const EmptyPlaceholderShell = (props: EmptyPlaceholderShellProps) => {
       </Box>
     </Box>
   );
-};
+});
+
+EmptyPlaceholderShell.displayName = 'EmptyPlaceholderShell';

--- a/openmetadata-ui-core-components/src/main/resources/ui/src/components/application/empty-placeholder/empty-placeholder-shell.tsx
+++ b/openmetadata-ui-core-components/src/main/resources/ui/src/components/application/empty-placeholder/empty-placeholder-shell.tsx
@@ -15,16 +15,19 @@ import { isValidElement } from 'react';
 import { Box } from '@/components/base/box/box';
 import type { GapValues } from '@/components/base/box/box';
 import { Button } from '@/components/base/buttons/button';
-import type { CommonProps as ButtonCommonProps } from '@/components/base/buttons/button';
+import type { ButtonProps } from '@/components/base/buttons/button';
 import { cx } from '@/utils/cx';
 import { isReactComponent } from '@/utils/is-react-component';
 
 export type EmptyPlaceholderIcon = FC<{ className?: string }> | ReactNode;
 
-export interface EmptyPlaceholderAction extends ButtonCommonProps {
+/** Shared icon-container styling for both variants */
+export const EMPTY_PLACEHOLDER_ICON_BOX =
+  'tw:flex tw:size-16 tw:shrink-0 tw:items-center tw:justify-center tw:rounded-2xl tw:border tw:border-secondary tw:bg-primary tw:shadow-empty-placeholder-icon tw:*:data-icon:size-7';
+
+export interface EmptyPlaceholderAction extends Omit<ButtonProps, 'children'> {
   key: string;
   label: ReactNode;
-  onPress?: () => void;
 }
 
 export interface EmptyPlaceholderFeature {

--- a/openmetadata-ui-core-components/src/main/resources/ui/src/components/application/empty-placeholder/empty-placeholder-shell.tsx
+++ b/openmetadata-ui-core-components/src/main/resources/ui/src/components/application/empty-placeholder/empty-placeholder-shell.tsx
@@ -11,7 +11,7 @@
  *  limitations under the License.
  */
 import type { FC, HTMLAttributes, ReactNode } from 'react';
-import { forwardRef, isValidElement } from 'react';
+import { isValidElement } from 'react';
 import { Box } from '@/components/base/box/box';
 import type { GapValues } from '@/components/base/box/box';
 import { Button } from '@/components/base/buttons/button';
@@ -90,10 +90,7 @@ export const renderEmptyPlaceholderActions = (
   return node;
 };
 
-export const EmptyPlaceholderShell = forwardRef<
-  HTMLDivElement,
-  EmptyPlaceholderShellProps
->((props, ref) => {
+export const EmptyPlaceholderShell = (props: EmptyPlaceholderShellProps) => {
   const {
     actions,
     footer,
@@ -112,7 +109,6 @@ export const EmptyPlaceholderShell = forwardRef<
       data-testid="empty-placeholder"
       direction="col"
       justify="center"
-      ref={ref}
       style={style}
       {...otherProps}>
       <Box align="center" direction="col" gap={gap} style={{ width }}>
@@ -121,6 +117,4 @@ export const EmptyPlaceholderShell = forwardRef<
       </Box>
     </Box>
   );
-});
-
-EmptyPlaceholderShell.displayName = 'EmptyPlaceholderShell';
+};

--- a/openmetadata-ui-core-components/src/main/resources/ui/src/components/application/empty-placeholder/empty-placeholder-shell.tsx
+++ b/openmetadata-ui-core-components/src/main/resources/ui/src/components/application/empty-placeholder/empty-placeholder-shell.tsx
@@ -1,0 +1,116 @@
+/*
+ *  Copyright 2025 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+import type { FC, HTMLAttributes, ReactNode, Ref } from 'react';
+import { isValidElement } from 'react';
+import { Box } from '@/components/base/box/box';
+import type { GapValues } from '@/components/base/box/box';
+import { Button } from '@/components/base/buttons/button';
+import type { CommonProps as ButtonCommonProps } from '@/components/base/buttons/button';
+import { cx } from '@/utils/cx';
+import { isReactComponent } from '@/utils/is-react-component';
+
+export type EmptyPlaceholderIcon = FC<{ className?: string }> | ReactNode;
+
+export interface EmptyPlaceholderAction extends ButtonCommonProps {
+  key: string;
+  label: ReactNode;
+  onPress?: () => void;
+}
+
+export interface EmptyPlaceholderFeature {
+  key: string;
+  icon: EmptyPlaceholderIcon;
+  title: ReactNode;
+  description?: ReactNode;
+  /** Extra classes for the icon container (e.g. to override its size) */
+  iconClassName?: string;
+}
+
+export interface EmptyPlaceholderShellProps
+  extends Omit<HTMLAttributes<HTMLDivElement>, 'title'> {
+  ref?: Ref<HTMLDivElement>;
+  /** Buttons rendered below the content */
+  actions?: EmptyPlaceholderAction[];
+  /** Replaces the generated action buttons entirely */
+  footer?: ReactNode;
+  /** Container width. Full width when omitted. */
+  width?: number | string;
+  /** Vertical gap between the shell's direct children */
+  gap?: GapValues;
+  className?: string;
+  children?: ReactNode;
+}
+
+export const renderEmptyPlaceholderIcon = (
+  icon: EmptyPlaceholderIcon,
+  className?: string
+) => {
+  let node: ReactNode = null;
+  if (isReactComponent(icon)) {
+    const Icon = icon as FC<{ className?: string }>;
+    node = <Icon data-icon className={className} />;
+  } else if (isValidElement(icon)) {
+    node = icon;
+  }
+
+  return node;
+};
+
+export const renderEmptyPlaceholderActions = (
+  actions?: EmptyPlaceholderAction[]
+) => {
+  let node: ReactNode = null;
+  if (actions && actions.length > 0) {
+    node = (
+      <Box align="center" gap={3} justify="center" wrap="wrap">
+        {actions.map(({ key, label, size = 'sm', ...buttonProps }) => (
+          <Button key={key} size={size} {...buttonProps}>
+            {label}
+          </Button>
+        ))}
+      </Box>
+    );
+  }
+
+  return node;
+};
+
+export const EmptyPlaceholderShell = (props: EmptyPlaceholderShellProps) => {
+  const {
+    ref,
+    actions,
+    footer,
+    width,
+    gap = 5,
+    className,
+    children,
+    style,
+    ...otherProps
+  } = props;
+
+  return (
+    <Box
+      align="center"
+      className={cx('tw:w-full', className)}
+      data-testid="empty-placeholder"
+      direction="col"
+      gap={gap}
+      justify="center"
+      ref={ref}
+      style={{ width, ...style }}
+      {...otherProps}>
+      {children}
+      {footer ?? renderEmptyPlaceholderActions(actions)}
+    </Box>
+  );
+};

--- a/openmetadata-ui-core-components/src/main/resources/ui/src/components/application/empty-placeholder/empty-placeholder-shell.tsx
+++ b/openmetadata-ui-core-components/src/main/resources/ui/src/components/application/empty-placeholder/empty-placeholder-shell.tsx
@@ -43,9 +43,12 @@ export interface EmptyPlaceholderShellProps
   actions?: EmptyPlaceholderAction[];
   /** Replaces the generated action buttons entirely */
   footer?: ReactNode;
-  /** Container width. Full width when omitted. */
+  /**
+   * Content width. The root is absolutely positioned and fills its nearest
+   * positioned ancestor, so the host container MUST set `position: relative`.
+   */
   width?: number | string;
-  /** Vertical gap between the shell's direct children */
+  /** Vertical gap between the content items */
   gap?: GapValues;
   className?: string;
   children?: ReactNode;
@@ -101,16 +104,17 @@ export const EmptyPlaceholderShell = (props: EmptyPlaceholderShellProps) => {
   return (
     <Box
       align="center"
-      className={cx('tw:w-full', className)}
+      className={cx('tw:absolute tw:inset-0 tw:h-full tw:w-full', className)}
       data-testid="empty-placeholder"
       direction="col"
-      gap={gap}
       justify="center"
       ref={ref}
-      style={{ width, ...style }}
+      style={style}
       {...otherProps}>
-      {children}
-      {footer ?? renderEmptyPlaceholderActions(actions)}
+      <Box align="center" direction="col" gap={gap} style={{ width }}>
+        {children}
+        {footer ?? renderEmptyPlaceholderActions(actions)}
+      </Box>
     </Box>
   );
 };

--- a/openmetadata-ui-core-components/src/main/resources/ui/src/components/application/empty-placeholder/empty-placeholder.tsx
+++ b/openmetadata-ui-core-components/src/main/resources/ui/src/components/application/empty-placeholder/empty-placeholder.tsx
@@ -19,6 +19,13 @@ import type {
 } from './empty-placeholder-shell';
 import { FeaturesEmptyPlaceholder } from './features-empty-placeholder';
 
+export type {
+  EmptyPlaceholderAction,
+  EmptyPlaceholderFeature,
+  EmptyPlaceholderIcon,
+  EmptyPlaceholderShellProps,
+} from './empty-placeholder-shell';
+
 export type EmptyPlaceholderVariant = 'blank' | 'features';
 
 export interface EmptyPlaceholderProps

--- a/openmetadata-ui-core-components/src/main/resources/ui/src/components/application/empty-placeholder/empty-placeholder.tsx
+++ b/openmetadata-ui-core-components/src/main/resources/ui/src/components/application/empty-placeholder/empty-placeholder.tsx
@@ -1,0 +1,66 @@
+/*
+ *  Copyright 2025 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+import type { ReactNode } from 'react';
+import { BlankEmptyPlaceholder } from './blank-empty-placeholder';
+import type {
+  EmptyPlaceholderFeature,
+  EmptyPlaceholderIcon,
+  EmptyPlaceholderShellProps,
+} from './empty-placeholder-shell';
+import { FeaturesEmptyPlaceholder } from './features-empty-placeholder';
+
+export type EmptyPlaceholderVariant = 'blank' | 'features';
+
+export interface EmptyPlaceholderProps
+  extends Omit<EmptyPlaceholderShellProps, 'children'> {
+  /** Selects the layout. 'blank' = icon + title + description; 'features' = feature columns */
+  variant?: EmptyPlaceholderVariant;
+  /** Icon rendered above the title (only in the 'blank' variant) */
+  icon?: EmptyPlaceholderIcon;
+  title?: ReactNode;
+  description?: ReactNode;
+  /** Feature columns rendered in the 'features' variant */
+  features?: EmptyPlaceholderFeature[];
+}
+
+export const EmptyPlaceholder = ({
+  variant = 'blank',
+  icon,
+  title,
+  description,
+  features,
+  ...shellProps
+}: EmptyPlaceholderProps) => {
+  let node: ReactNode;
+  if (variant === 'features') {
+    node = (
+      <FeaturesEmptyPlaceholder
+        description={description}
+        features={features}
+        title={title}
+        {...shellProps}
+      />
+    );
+  } else {
+    node = (
+      <BlankEmptyPlaceholder
+        description={description}
+        icon={icon}
+        title={title}
+        {...shellProps}
+      />
+    );
+  }
+
+  return node;
+};

--- a/openmetadata-ui-core-components/src/main/resources/ui/src/components/application/empty-placeholder/features-empty-placeholder.tsx
+++ b/openmetadata-ui-core-components/src/main/resources/ui/src/components/application/empty-placeholder/features-empty-placeholder.tsx
@@ -37,7 +37,7 @@ const FeatureItem = ({
     gap={5}>
     <div
       className={cx(
-        'tw:flex tw:size-16 tw:shrink-0 tw:items-center tw:justify-center tw:rounded-2xl tw:border tw:border-secondary tw:bg-primary tw:shadow-[0_2px_10px_0_rgba(223,227,245,0.60)] tw:*:data-icon:size-7',
+        'tw:flex tw:size-16 tw:shrink-0 tw:items-center tw:justify-center tw:rounded-2xl tw:border tw:border-secondary tw:bg-primary tw:shadow-empty-placeholder-icon tw:*:data-icon:size-7',
         iconClassName
       )}>
       {renderEmptyPlaceholderIcon(icon, 'tw:size-7')}
@@ -62,8 +62,7 @@ export interface FeaturesEmptyPlaceholderProps
   features?: EmptyPlaceholderFeature[];
 }
 
-const FEATURES_BACKGROUND =
-  'linear-gradient(180deg, rgba(230, 241, 249, 0.50) 0%, #FFF 25%, #FFF 49.52%, #FFF 75%, #E6F1F9 100%)';
+const FEATURES_BACKGROUND = 'var(--gradient-empty-placeholder-features)';
 
 export const FeaturesEmptyPlaceholder = ({
   title,

--- a/openmetadata-ui-core-components/src/main/resources/ui/src/components/application/empty-placeholder/features-empty-placeholder.tsx
+++ b/openmetadata-ui-core-components/src/main/resources/ui/src/components/application/empty-placeholder/features-empty-placeholder.tsx
@@ -19,6 +19,7 @@ import type {
   EmptyPlaceholderShellProps,
 } from './empty-placeholder-shell';
 import {
+  EMPTY_PLACEHOLDER_ICON_BOX,
   EmptyPlaceholderShell,
   renderEmptyPlaceholderActions,
   renderEmptyPlaceholderIcon,
@@ -35,11 +36,7 @@ const FeatureItem = ({
     className="tw:max-w-[220px] tw:text-center"
     direction="col"
     gap={5}>
-    <div
-      className={cx(
-        'tw:flex tw:size-16 tw:shrink-0 tw:items-center tw:justify-center tw:rounded-2xl tw:border tw:border-secondary tw:bg-primary tw:shadow-empty-placeholder-icon tw:*:data-icon:size-7',
-        iconClassName
-      )}>
+    <div className={cx(EMPTY_PLACEHOLDER_ICON_BOX, iconClassName)}>
       {renderEmptyPlaceholderIcon(icon, 'tw:size-7')}
     </div>
     <Box align="center" direction="col" gap={1}>

--- a/openmetadata-ui-core-components/src/main/resources/ui/src/components/application/empty-placeholder/features-empty-placeholder.tsx
+++ b/openmetadata-ui-core-components/src/main/resources/ui/src/components/application/empty-placeholder/features-empty-placeholder.tsx
@@ -33,7 +33,7 @@ const FeatureItem = ({
 }: Omit<EmptyPlaceholderFeature, 'key'>) => (
   <Box
     align="center"
-    className="tw:max-w-[220px] tw:text-center"
+    className="tw:max-w-55 tw:text-center"
     direction="col"
     gap={5}>
     <div className={cx(EMPTY_PLACEHOLDER_ICON_BOX, iconClassName)}>
@@ -99,7 +99,7 @@ export const FeaturesEmptyPlaceholder = ({
       {hasFeatures && (
         <Box
           align="start"
-          className={cx(hasHeader && 'tw:mt-[30px]')}
+          className={cx(hasHeader && 'tw:mt-7.5')}
           gap={10}
           justify="center"
           wrap="wrap">
@@ -109,7 +109,7 @@ export const FeaturesEmptyPlaceholder = ({
         </Box>
       )}
       {footerNode && (
-        <div className={cx((hasHeader || hasFeatures) && 'tw:mt-[22px]')}>
+        <div className={cx((hasHeader || hasFeatures) && 'tw:mt-5.5')}>
           {footerNode}
         </div>
       )}

--- a/openmetadata-ui-core-components/src/main/resources/ui/src/components/application/empty-placeholder/features-empty-placeholder.tsx
+++ b/openmetadata-ui-core-components/src/main/resources/ui/src/components/application/empty-placeholder/features-empty-placeholder.tsx
@@ -1,0 +1,122 @@
+/*
+ *  Copyright 2025 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+import type { ReactNode } from 'react';
+import { Box } from '@/components/base/box/box';
+import { Typography } from '@/components/foundations/typography';
+import { cx } from '@/utils/cx';
+import type {
+  EmptyPlaceholderFeature,
+  EmptyPlaceholderShellProps,
+} from './empty-placeholder-shell';
+import {
+  EmptyPlaceholderShell,
+  renderEmptyPlaceholderActions,
+  renderEmptyPlaceholderIcon,
+} from './empty-placeholder-shell';
+
+const FeatureItem = ({
+  icon,
+  title,
+  description,
+  iconClassName,
+}: Omit<EmptyPlaceholderFeature, 'key'>) => (
+  <Box
+    align="center"
+    className="tw:max-w-[220px] tw:text-center"
+    direction="col"
+    gap={5}>
+    <div
+      className={cx(
+        'tw:flex tw:size-16 tw:shrink-0 tw:items-center tw:justify-center tw:rounded-2xl tw:border tw:border-secondary tw:bg-primary tw:shadow-[0_2px_10px_0_rgba(223,227,245,0.60)] tw:*:data-icon:size-7',
+        iconClassName
+      )}>
+      {renderEmptyPlaceholderIcon(icon, 'tw:size-7')}
+    </div>
+    <Box align="center" direction="col" gap={1}>
+      <Typography size="text-sm" weight="semibold">
+        {title}
+      </Typography>
+      {description && (
+        <Typography className="tw:text-tertiary" size="text-sm">
+          {description}
+        </Typography>
+      )}
+    </Box>
+  </Box>
+);
+
+export interface FeaturesEmptyPlaceholderProps
+  extends Omit<EmptyPlaceholderShellProps, 'children'> {
+  title?: ReactNode;
+  description?: ReactNode;
+  features?: EmptyPlaceholderFeature[];
+}
+
+const FEATURES_BACKGROUND =
+  'linear-gradient(180deg, rgba(230, 241, 249, 0.50) 0%, #FFF 25%, #FFF 49.52%, #FFF 75%, #E6F1F9 100%)';
+
+export const FeaturesEmptyPlaceholder = ({
+  title,
+  description,
+  features,
+  actions,
+  footer,
+  style,
+  ...rest
+}: FeaturesEmptyPlaceholderProps) => {
+  const hasHeader = Boolean(title || description);
+  const hasFeatures = Boolean(features && features.length > 0);
+  const footerNode = footer ?? renderEmptyPlaceholderActions(actions);
+
+  return (
+    <EmptyPlaceholderShell
+      gap={0}
+      style={{ background: FEATURES_BACKGROUND, ...style }}
+      {...rest}>
+      {hasHeader && (
+        <Box
+          align="center"
+          className="tw:max-w-lg tw:gap-1.5 tw:text-center"
+          direction="col">
+          {title && (
+            <Typography size="text-lg" weight="semibold">
+              {title}
+            </Typography>
+          )}
+          {description && (
+            <Typography className="tw:text-tertiary" size="text-sm">
+              {description}
+            </Typography>
+          )}
+        </Box>
+      )}
+      {hasFeatures && (
+        <Box
+          align="start"
+          className={cx(hasHeader && 'tw:mt-[30px]')}
+          gap={10}
+          justify="center"
+          wrap="wrap">
+          {features?.map(({ key, ...feature }) => (
+            <FeatureItem key={key} {...feature} />
+          ))}
+        </Box>
+      )}
+      {footerNode && (
+        <div className={cx((hasHeader || hasFeatures) && 'tw:mt-[22px]')}>
+          {footerNode}
+        </div>
+      )}
+    </EmptyPlaceholderShell>
+  );
+};

--- a/openmetadata-ui-core-components/src/main/resources/ui/src/components/application/empty-placeholder/features-empty-placeholder.tsx
+++ b/openmetadata-ui-core-components/src/main/resources/ui/src/components/application/empty-placeholder/features-empty-placeholder.tsx
@@ -59,7 +59,7 @@ export interface FeaturesEmptyPlaceholderProps
   features?: EmptyPlaceholderFeature[];
 }
 
-const FEATURES_BACKGROUND = 'var(--gradient-empty-placeholder-features)';
+const FEATURES_BACKGROUND = 'var(--tw-gradient-empty-placeholder-features)';
 
 export const FeaturesEmptyPlaceholder = ({
   title,

--- a/openmetadata-ui-core-components/src/main/resources/ui/src/components/index.ts
+++ b/openmetadata-ui-core-components/src/main/resources/ui/src/components/index.ts
@@ -127,6 +127,8 @@ export * from './application/date-picker/date-picker';
 export * from './application/date-picker/date-range-picker';
 export * from './application/date-picker/range-calendar';
 export * from './application/date-picker/range-preset';
+export * from './application/empty-placeholder/empty-placeholder';
+export * from './application/empty-placeholder/empty-placeholder-shell';
 export * from './application/modals/modal';
 export * from './application/pagination/pagination';
 export * from './application/pagination/pagination-base';

--- a/openmetadata-ui-core-components/src/main/resources/ui/src/components/index.ts
+++ b/openmetadata-ui-core-components/src/main/resources/ui/src/components/index.ts
@@ -128,7 +128,6 @@ export * from './application/date-picker/date-range-picker';
 export * from './application/date-picker/range-calendar';
 export * from './application/date-picker/range-preset';
 export * from './application/empty-placeholder/empty-placeholder';
-export * from './application/empty-placeholder/empty-placeholder-shell';
 export * from './application/modals/modal';
 export * from './application/pagination/pagination';
 export * from './application/pagination/pagination-base';

--- a/openmetadata-ui-core-components/src/main/resources/ui/src/stories/EmptyPlaceholder.stories.tsx
+++ b/openmetadata-ui-core-components/src/main/resources/ui/src/stories/EmptyPlaceholder.stories.tsx
@@ -1,0 +1,172 @@
+/*
+ *  Copyright 2025 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+import { Folder, Plus, Stars01, UploadCloud01 } from '@untitledui/icons';
+import type { Meta, StoryObj } from '@storybook/react';
+import { EmptyPlaceholder } from '../components/application/empty-placeholder/empty-placeholder';
+
+const meta = {
+  title: 'Components/EmptyPlaceholder',
+  component: EmptyPlaceholder,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+  argTypes: {
+    variant: {
+      control: 'inline-radio',
+      options: ['blank', 'features'],
+      table: { type: { summary: '"blank" | "features"' } },
+    },
+    width: {
+      control: 'number',
+      table: { type: { summary: 'number | string' } },
+    },
+    icon: { control: false },
+    features: { control: false },
+    actions: { control: false },
+    footer: { control: false },
+  },
+} satisfies Meta<typeof EmptyPlaceholder>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const DashboardIcon = (
+  <svg
+    className="tw:text-fg-brand-primary"
+    fill="none"
+    height="31"
+    viewBox="0 0 34 31"
+    width="34"
+    xmlns="http://www.w3.org/2000/svg">
+    <rect
+      height="29"
+      rx="6"
+      stroke="currentColor"
+      strokeWidth="2"
+      width="32"
+      x="1"
+      y="1"
+    />
+    <path
+      d="M23.8158 22V16.6471M17.5 22V14.3529M11.1842 22L11.1842 18.9412M18.6105 10.5504L22.6909 12.0326M16.5517 10.836L12.1318 14.0469M24.6532 11.6301C25.1156 12.078 25.1156 12.8043 24.6532 13.2523C24.1907 13.7002 23.4409 13.7002 22.9784 13.2523C22.516 12.8043 22.516 12.078 22.9784 11.6301C23.4409 11.1821 24.1907 11.1821 24.6532 11.6301ZM12.0216 13.9242C12.484 14.3722 12.484 15.0984 12.0216 15.5464C11.5591 15.9943 10.8093 15.9943 10.3468 15.5464C9.88438 15.0984 9.88438 14.3722 10.3468 13.9242C10.8093 13.4762 11.5591 13.4762 12.0216 13.9242ZM18.3374 9.33597C18.7998 9.78392 18.7998 10.5102 18.3374 10.9582C17.8749 11.4061 17.1251 11.4061 16.6626 10.9582C16.2002 10.5102 16.2002 9.78392 16.6626 9.33597C17.1251 8.88801 17.8749 8.88801 18.3374 9.33597Z"
+      stroke="currentColor"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth="2"
+    />
+  </svg>
+);
+
+const retrievalFeatures = [
+  {
+    key: 'upload',
+    icon: <UploadCloud01 className="tw:size-7 tw:text-fg-brand-primary" />,
+    title: 'Upload files',
+    description: 'Drag in the documents your team already relies on.',
+  },
+  {
+    key: 'organize',
+    icon: <Folder className="tw:size-7 tw:text-fg-warning-primary" />,
+    title: 'Organize with folders',
+    description: 'Group by topic or team so knowledge stays easy to manage.',
+  },
+  {
+    key: 'retrieve',
+    icon: <Stars01 className="tw:size-7 tw:text-fg-success-primary" />,
+    title: 'AI retrieves the rest',
+    description:
+      'Uploaded content is indexed and cited in answers automatically.',
+  },
+];
+
+export const Blank: Story = {
+  args: {
+    variant: 'blank',
+    icon: DashboardIcon,
+    title: "You haven't created a dashboard yet",
+    description:
+      'Dashboards you create or own will live here. Start one now, or explore what your team has already built in All Dashboards.',
+    actions: [
+      {
+        key: 'new-dashboard',
+        label: 'New Dashboard',
+        color: 'primary' as const,
+        iconLeading: Plus,
+      },
+    ],
+  },
+};
+
+export const BlankTextOnly: Story = {
+  args: {
+    variant: 'blank',
+    title: 'Nothing here',
+    description: 'This space is empty for now.',
+  },
+};
+
+export const BlankWithoutTitle: Story = {
+  args: {
+    variant: 'blank',
+    icon: DashboardIcon,
+    description:
+      'Dashboards you create or own will live here. Start one now, or explore what your team has already built in All Dashboards.',
+    actions: [
+      {
+        key: 'new-dashboard',
+        label: 'New Dashboard',
+        color: 'primary' as const,
+        iconLeading: Plus,
+      },
+    ],
+  },
+};
+
+export const Features: Story = {
+  args: {
+    variant: 'features',
+    title: 'Your files, ready for AI retrieval',
+    description:
+      'Upload the documents your organization already has — PDFs, specs, guides — and they become searchable knowledge the AI can cite.',
+    features: retrievalFeatures,
+    actions: [
+      {
+        key: 'article',
+        label: 'New Article',
+        color: 'primary' as const,
+        iconLeading: Plus,
+      },
+      {
+        key: 'folder',
+        label: 'New Folder',
+        color: 'secondary' as const,
+        iconLeading: Plus,
+      },
+    ],
+  },
+};
+
+export const FeaturesCustomFooter: Story = {
+  args: {
+    variant: 'features',
+    title: 'Your files, ready for AI retrieval',
+    description: 'Bring your own footer with any content you like.',
+    features: retrievalFeatures,
+    footer: (
+      <a className="tw:text-sm tw:text-fg-brand-primary" href="#">
+        Learn how AI retrieval works
+      </a>
+    ),
+  },
+};

--- a/openmetadata-ui-core-components/src/main/resources/ui/src/stories/EmptyPlaceholder.stories.tsx
+++ b/openmetadata-ui-core-components/src/main/resources/ui/src/stories/EmptyPlaceholder.stories.tsx
@@ -20,6 +20,21 @@ const meta = {
   parameters: {
     layout: 'centered',
   },
+  decorators: [
+    (Story) => (
+      <div
+        style={{
+          position: 'relative',
+          width: 960,
+          height: 620,
+          border: '1px solid var(--color-border-secondary)',
+          borderRadius: 12,
+          overflow: 'hidden',
+        }}>
+        <Story />
+      </div>
+    ),
+  ],
   tags: ['autodocs'],
   argTypes: {
     variant: {

--- a/openmetadata-ui-core-components/src/main/resources/ui/src/styles/globals.css
+++ b/openmetadata-ui-core-components/src/main/resources/ui/src/styles/globals.css
@@ -110,6 +110,18 @@
 
   --drop-shadow-iphone-mockup: 20px 12px 18px rgba(16, 24, 40, 0.2);
 
+  --shadow-empty-placeholder-icon: 0px 2px 10px 0px rgba(223, 227, 245, 0.6);
+
+  /* GRADIENTS */
+  --gradient-empty-placeholder-features: linear-gradient(
+    180deg,
+    rgba(230, 241, 249, 0.5) 0%,
+    #fff 25%,
+    #fff 49.52%,
+    #fff 75%,
+    #e6f1f9 100%
+  );
+
   /* ANIMATIONS */
   --animate-marquee: marquee 60s linear infinite;
   --animate-caret-blink: caret-blink 1s infinite;


### PR DESCRIPTION
## What

Adds a new **`EmptyPlaceholder`** component to `@openmetadata/ui-core-components` with two variants, driven by a single public `<EmptyPlaceholder variant="blank | features" />` API.

- **blank** — icon + optional title + optional description + actions. Defaults to 300px content width.
- **features** — header + feature columns + actions, on a design gradient background.

Everything is customizable: `icon` (FC or raw `<svg>` ReactNode), `title`, `description`, `features`, `actions` (full Button props) / `footer`, and `width`.

## Design

- Public `EmptyPlaceholder` dispatches to per-variant renderers (`blank-`/`features-empty-placeholder.tsx`) over a shared `EmptyPlaceholderShell`, so adding a variant is a new file + one case — no prop-surface bloat.
- Root is absolutely positioned and fills its parent, centering content. **Precondition: the host container must set `position: relative`** (documented on the `width` prop).
- Icons: 64px box, 16px radius, custom shadow; colors carried by the icon itself.
- Pixel-spec spacing per design (blank: 20/6/20; features: 30/22, 6px header, 20px icon→title, 4px title→subtitle).

## Stories

Storybook stories for both variants (`Blank`, `BlankTextOnly`, `BlankWithoutTitle`, `Features`, `FeaturesCustomFooter`) in a `position: relative` container decorator.

## Test

- `tsc --noEmit`: clean
- ESLint + Prettier (core-components): clean
- Verified rendering in Storybook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


https://github.com/user-attachments/assets/b9bc0a11-f24a-45d8-ba1e-1ea65f8fa929

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds a new empty-state component to the core UI package. The main changes are:

- New `EmptyPlaceholder` public component with `blank` and `features` variants.
- Shared shell, icon rendering, action rendering, and variant-specific renderers.
- Public component barrel export.
- Storybook examples for both variants.
- Supporting CSS tokens for the placeholder visuals.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge.

- No blocking issues found in the changed code.

</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-ui-core-components/src/main/resources/ui/src/components/application/empty-placeholder/empty-placeholder-shell.tsx | Adds the shared shell, icon helper, and action renderer used by both empty-state variants. |
| openmetadata-ui-core-components/src/main/resources/ui/src/components/application/empty-placeholder/empty-placeholder.tsx | Adds the public variant dispatcher and shared type exports. |
| openmetadata-ui-core-components/src/main/resources/ui/src/components/application/empty-placeholder/blank-empty-placeholder.tsx | Adds the blank empty-state renderer with optional icon, text, description, and actions. |
| openmetadata-ui-core-components/src/main/resources/ui/src/components/application/empty-placeholder/features-empty-placeholder.tsx | Adds the features empty-state renderer with header text, feature columns, and footer actions. |
| openmetadata-ui-core-components/src/main/resources/ui/src/components/index.ts | Exports the new empty-state component from the public components barrel. |
| openmetadata-ui-core-components/src/main/resources/ui/src/stories/EmptyPlaceholder.stories.tsx | Adds Storybook coverage for the blank and features empty-state variants. |
| openmetadata-ui-core-components/src/main/resources/ui/src/styles/globals.css | Adds the design tokens used by the new empty-state styling. |

</details>

<sub>Reviews (7): Last reviewed commit: ["fix review comments"](https://github.com/open-metadata/openmetadata/commit/e4e6ff98333fb7e86833563f7cc61485c6356403) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44054402)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Context used - CLAUDE.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=52f0d9d9-cad1-4e7d-b070-de181a0aa5e7))
- Context used - openmetadata-ui-core-components/CLAUDE.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=41754627-b2bf-474b-8082-f37ef1a07013))
- Context used - AGENTS.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=ef262f5f-911f-44f3-8d2d-e9cb1579c8c8))
</details>

<!-- /greptile_comment -->