### PR TITLE
fix(security): don't grant reviewer authz shortcut on CREATE

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/security/DefaultAuthorizer.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/security/DefaultAuthorizer.java
@@ -31,6 +31,7 @@ import org.openmetadata.service.OpenMetadataApplicationConfig;
 import org.openmetadata.service.jdbi3.EntityRepository;
 import org.openmetadata.service.monitoring.RequestLatencyContext;
 import org.openmetadata.service.security.auth.CatalogSecurityContext;
+import org.openmetadata.service.security.policyevaluator.CreateResourceContext;
 import org.openmetadata.service.security.policyevaluator.OperationContext;
 import org.openmetadata.service.security.policyevaluator.PolicyEvaluator;
 import org.openmetadata.service.security.policyevaluator.ResourceContext;
@@ -237,7 +238,9 @@ public class DefaultAuthorizer implements Authorizer {
 
   private boolean isReviewer(
       ResourceContextInterface resourceContext, SubjectContext subjectContext) {
-    if (resourceContext.getEntity() == null) {
+    // On CREATE the entity is caller-supplied and not yet persisted, so its fields (e.g. reviewers)
+    // cannot be trusted to grant authorization. Only evaluate against already persisted entities.
+    if (resourceContext instanceof CreateResourceContext || resourceContext.getEntity() == null) {
       return false;
     }
     String updatedBy = subjectContext.user().getName();

--- a/openmetadata-service/src/main/java/org/openmetadata/service/security/policyevaluator/RuleEvaluator.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/security/policyevaluator/RuleEvaluator.java
@@ -89,7 +89,12 @@ public class RuleEvaluator {
     if (expressionValidation) {
       return false;
     }
-    if (subjectContext == null || resourceContext == null || resourceContext.getEntity() == null) {
+    // On CREATE the entity is caller-supplied and not yet persisted, so its fields (e.g. reviewers)
+    // cannot be trusted to grant authorization. Only evaluate against already persisted entities.
+    if (subjectContext == null
+        || resourceContext == null
+        || resourceContext instanceof CreateResourceContext
+        || resourceContext.getEntity() == null) {
       return false;
     }
     return subjectContext.isReviewer(resourceContext.getEntity().getReviewers());

--- a/openmetadata-service/src/test/java/org/openmetadata/service/security/DefaultAuthorizerTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/security/DefaultAuthorizerTest.java
@@ -33,6 +33,7 @@ import org.openmetadata.service.Entity;
 import org.openmetadata.service.OpenMetadataApplicationConfig;
 import org.openmetadata.service.jdbi3.EntityRepository;
 import org.openmetadata.service.security.auth.CatalogSecurityContext;
+import org.openmetadata.service.security.policyevaluator.CreateResourceContext;
 import org.openmetadata.service.security.policyevaluator.OperationContext;
 import org.openmetadata.service.security.policyevaluator.PolicyEvaluator;
 import org.openmetadata.service.security.policyevaluator.ResourceContextInterface;
@@ -178,6 +179,32 @@ class DefaultAuthorizerTest {
           () -> authorizer.authorize(securityContext, operationContext, resourceContext));
 
       mockedPolicyEvaluator.verifyNoInteractions();
+    }
+  }
+
+  @Test
+  void authorizeDoesNotTreatSelfAssignedReviewerAsReviewerOnCreate() {
+    SecurityContext securityContext = securityContext("attacker");
+    SubjectContext attackerContext = subjectContext("attacker", false, false, null);
+    EntityInterface entity = mock(EntityInterface.class);
+    when(entity.getReviewers()).thenReturn(List.of(entityReference(Entity.USER, "attacker")));
+    CreateResourceContext<?> createResourceContext = mock(CreateResourceContext.class);
+    when(createResourceContext.getEntity()).thenReturn(entity);
+    OperationContext operationContext =
+        new OperationContext(Entity.DATA_PRODUCT, MetadataOperation.CREATE);
+
+    try (MockedStatic<DefaultAuthorizer> mockedAuthorizer = mockStatic(DefaultAuthorizer.class);
+        MockedStatic<PolicyEvaluator> mockedPolicyEvaluator = mockStatic(PolicyEvaluator.class)) {
+      mockedAuthorizer
+          .when(() -> DefaultAuthorizer.getSubjectContext(securityContext))
+          .thenReturn(attackerContext);
+
+      authorizer.authorize(securityContext, operationContext, createResourceContext);
+
+      mockedPolicyEvaluator.verify(
+          () ->
+              PolicyEvaluator.hasPermission(
+                  attackerContext, createResourceContext, operationContext));
     }
   }
 

--- a/openmetadata-service/src/test/java/org/openmetadata/service/security/policyevaluator/RuleEvaluatorTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/security/policyevaluator/RuleEvaluatorTest.java
@@ -382,6 +382,19 @@ class RuleEvaluatorTest {
     assertFalse(
         parseExpression("isReviewer()").getValue(evaluationContext, Boolean.class),
         "Non-reviewer user should return false for isReviewer()");
+
+    Glossary createGlossary =
+        new Glossary()
+            .withId(UUID.randomUUID())
+            .withName("createGlossary")
+            .withReviewers(List.of(reviewerRef));
+    CreateResourceContext<Glossary> createResourceContext =
+        new CreateResourceContext<>(Entity.GLOSSARY, createGlossary);
+    ruleEvaluator = new RuleEvaluator(null, subjectContext, createResourceContext);
+    evaluationContext = new StandardEvaluationContext(ruleEvaluator);
+    assertFalse(
+        parseExpression("isReviewer()").getValue(evaluationContext, Boolean.class),
+        "Self-assigned reviewer on CREATE should return false for isReviewer()");
   }
 
   @Test


### PR DESCRIPTION
## Fixes #29837

### Problem
`DefaultAuthorizer.authorize()` short-circuits policy evaluation when the caller is a reviewer of the resource:

```java
if (subjectContext.isAdmin()) return;
if (isReviewer(resourceContext, subjectContext)) return;   // <-- fires before RBAC
PolicyEvaluator.hasPermission(subjectContext, resourceContext, operationContext);
```

For **CREATE** operations the `ResourceContextInterface` is a `CreateResourceContext`, whose `getEntity()` returns the **unsaved, caller-supplied** request body. `isReviewer()` reads `entity.getReviewers()` from that in-flight entity, so a user can add **themselves** to the `reviewers` field of a create request, make `isReviewer()` return `true`, and skip RBAC entirely — creating entities (e.g. Data Products) they have **no `Create` permission** for.

Because the REST API and the MCP tool share this authorization path, both are affected. The UI's own gating masks it, but the server does not enforce it.

Scope is broader than Data Products: any reviewer-supporting entity (Glossary, GlossaryTerm, DataProduct, Metric, Tag, DataContract, …) created via the standard path is exposed.

### Reproduction (before this change)
Principal: a non-admin with only `DataConsumer` role → effective `Create` on `dataProduct` = `notAllow`.

| Request | Result |
|---|---|
| `POST /dataProducts` (no reviewers) | **403** `operations [Create] not allowed` |
| `POST /dataProducts` + `reviewers:[{self}]` | **201 Created** ← bypass |

### Fix
Gate the reviewer shortcut so it only applies to **already persisted** entities, never a `CreateResourceContext`:

1. `DefaultAuthorizer.isReviewer()` — the hard-coded shortcut (the reported vector).
2. `RuleEvaluator.isReviewer()` — the SpEL condition available to custom policies, which reads the same in-flight entity. No shipped policy uses it, but guarding it too closes the same bug class as defense-in-depth.

Reviewer-based authorization continues to work for Edit/View/approval operations on existing entities. Verified the legitimate paths are unaffected: glossary-term approval is an UPDATE on a persisted term (`checkUpdatedByReviewer`), and inherited parent reviewers are not present on the entity at authorize-time (`prepareInternal` never populates `reviewers`; storage runs in `repository.create()` after authorize).

### Tests
- `DefaultAuthorizerTest.authorizeDoesNotTreatSelfAssignedReviewerAsReviewerOnCreate` — policy evaluation still runs when a user self-assigns as reviewer during CREATE.
- `RuleEvaluatorTest.test_isReviewer` — extended so a self-assigned reviewer on a `CreateResourceContext` returns `false`.

Both fail without the corresponding guard and pass with it. Full security/policy unit suites green: `DefaultAuthorizerTest` (14), `RuleEvaluatorTest` (24), `SubjectContextTest` (11), `ExpressionValidatorTest` (35).

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes the reviewer authorization shortcut for create requests. The main changes are:

- Blocks reviewer shortcut evaluation for `CreateResourceContext` in `DefaultAuthorizer`.
- Applies the same create-time reviewer guard in `RuleEvaluator.isReviewer()`.
- Adds tests for self-assigned reviewers during create authorization and policy expression evaluation.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge.

- No blocking issues found in the changed code.

</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-service/src/main/java/org/openmetadata/service/security/DefaultAuthorizer.java | Adds a create-context guard before reviewer shortcut authorization. |
| openmetadata-service/src/main/java/org/openmetadata/service/security/policyevaluator/RuleEvaluator.java | Prevents `isReviewer()` from treating create-request reviewers as persisted reviewers. |
| openmetadata-service/src/test/java/org/openmetadata/service/security/DefaultAuthorizerTest.java | Adds coverage that create requests with self-assigned reviewers still call policy evaluation. |
| openmetadata-service/src/test/java/org/openmetadata/service/security/policyevaluator/RuleEvaluatorTest.java | Adds coverage that `isReviewer()` is false for self-assigned reviewers on create contexts. |

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(security): don&#39;t grant reviewer auth..."](https://github.com/open-metadata/openmetadata/commit/f75227cd3de7c340e34198ea0bf4c252eee22429) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44070063)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Context used - CLAUDE.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=52f0d9d9-cad1-4e7d-b070-de181a0aa5e7))
- Context used - openmetadata-ui-core-components/CLAUDE.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=41754627-b2bf-474b-8082-f37ef1a07013))
- Context used - AGENTS.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=ef262f5f-911f-44f3-8d2d-e9cb1579c8c8))
</details>

<!-- /greptile_comment -->