### PR TITLE
Backport to 1.13: reclaim orphaned ingestion pipelines (#29836) + Data Retention build fix (#29984), realign DataRetention with main

### DIFF
--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/OrphanIngestionPipelineCleanupIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/OrphanIngestionPipelineCleanupIT.java
@@ -1,0 +1,104 @@
+/*
+ *  Copyright 2025 Collate
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.openmetadata.it.tests;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Date;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.openmetadata.it.bootstrap.SharedEntities;
+import org.openmetadata.it.bootstrap.TestSuiteBootstrap;
+import org.openmetadata.it.util.SdkClients;
+import org.openmetadata.it.util.TestNamespace;
+import org.openmetadata.it.util.TestNamespaceExtension;
+import org.openmetadata.schema.api.services.ingestionPipelines.CreateIngestionPipeline;
+import org.openmetadata.schema.entity.services.ingestionPipelines.AirflowConfig;
+import org.openmetadata.schema.entity.services.ingestionPipelines.IngestionPipeline;
+import org.openmetadata.schema.entity.services.ingestionPipelines.PipelineType;
+import org.openmetadata.schema.metadataIngestion.DatabaseServiceMetadataPipeline;
+import org.openmetadata.schema.metadataIngestion.SourceConfig;
+import org.openmetadata.schema.type.Relationship;
+import org.openmetadata.sdk.client.OpenMetadataClient;
+import org.openmetadata.service.Entity;
+import org.openmetadata.service.util.OrphanIngestionPipelineCleanup;
+
+/**
+ * End-to-end test for {@link OrphanIngestionPipelineCleanup} (the Data Retention cleanup of
+ * ingestion pipelines whose container {@code service -> pipeline} CONTAINS row is missing). Verifies
+ * that a pipeline with no container is hard-deleted, while a healthy pipeline is left untouched — the
+ * cleanup is selective, not a blanket wipe.
+ */
+@Execution(ExecutionMode.SAME_THREAD)
+@ExtendWith(TestNamespaceExtension.class)
+public class OrphanIngestionPipelineCleanupIT {
+
+  private static final int BATCH = 10_000;
+
+  @Test
+  void missingContainer_deletesPipeline_keepsHealthy(TestNamespace ns) throws Exception {
+    IngestionPipeline healthy = createPipeline("healthyPipe_" + ns.uniqueShortId());
+    IngestionPipeline broken = createPipeline("brokenPipe_" + ns.uniqueShortId());
+
+    assertEquals(1, pipelineRowCount(broken.getId().toString()), "broken pipeline should exist");
+    assertEquals(1, pipelineRowCount(healthy.getId().toString()), "healthy pipeline should exist");
+
+    // Break the broken pipeline: remove its service -> pipeline CONTAINS relationship row (leaving
+    // the service intact) — the exact data-drift state the cleanup targets.
+    Entity.getCollectionDAO()
+        .relationshipDAO()
+        .deleteTo(broken.getId(), Entity.INGESTION_PIPELINE, Relationship.CONTAINS.ordinal());
+
+    OrphanIngestionPipelineCleanup.Result result =
+        new OrphanIngestionPipelineCleanup(Entity.getCollectionDAO(), false).performCleanup(BATCH);
+
+    assertTrue(result.getOrphansDeleted() >= 1, "the broken pipeline must be counted as an orphan");
+
+    // Broken pipeline is gone; healthy pipeline survives — the cleanup is selective.
+    assertEquals(0, pipelineRowCount(broken.getId().toString()), "broken pipeline must be deleted");
+    assertEquals(1, pipelineRowCount(healthy.getId().toString()), "healthy pipeline must survive");
+  }
+
+  private IngestionPipeline createPipeline(String name) {
+    OpenMetadataClient client = SdkClients.adminClient();
+    SourceConfig sourceConfig =
+        new SourceConfig()
+            .withConfig(
+                new DatabaseServiceMetadataPipeline()
+                    .withMarkDeletedTables(true)
+                    .withIncludeViews(true));
+    return client
+        .ingestionPipelines()
+        .create(
+            new CreateIngestionPipeline()
+                .withName(name)
+                .withPipelineType(PipelineType.METADATA)
+                .withService(SharedEntities.get().MYSQL_SERVICE.getEntityReference())
+                .withSourceConfig(sourceConfig)
+                .withAirflowConfig(new AirflowConfig().withStartDate(new Date())));
+  }
+
+  private int pipelineRowCount(String id) {
+    return TestSuiteBootstrap.getJdbi()
+        .withHandle(
+            handle ->
+                handle
+                    .createQuery("SELECT COUNT(*) FROM ingestion_pipeline_entity WHERE id = :id")
+                    .bind("id", id)
+                    .mapTo(Integer.class)
+                    .one());
+  }
+}

--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/OrphanedTimeSeriesCleanupIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/OrphanedTimeSeriesCleanupIT.java
@@ -1,0 +1,362 @@
+/*
+ *  Copyright 2025 Collate
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.openmetadata.it.tests;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.openmetadata.it.bootstrap.SharedEntities;
+import org.openmetadata.it.bootstrap.TestSuiteBootstrap;
+import org.openmetadata.it.util.SdkClients;
+import org.openmetadata.it.util.TestNamespace;
+import org.openmetadata.it.util.TestNamespaceExtension;
+import org.openmetadata.schema.api.ai.CreateMcpServer;
+import org.openmetadata.schema.api.data.CreateDatabase;
+import org.openmetadata.schema.api.data.CreateDatabaseSchema;
+import org.openmetadata.schema.api.data.CreateQuery;
+import org.openmetadata.schema.api.data.CreateTable;
+import org.openmetadata.schema.api.services.CreateMcpService;
+import org.openmetadata.schema.api.tests.CreateTestCase;
+import org.openmetadata.schema.api.tests.CreateTestCaseResolutionStatus;
+import org.openmetadata.schema.entity.ai.AIApplication;
+import org.openmetadata.schema.entity.ai.ApplicationType;
+import org.openmetadata.schema.entity.ai.McpServer;
+import org.openmetadata.schema.entity.ai.McpServerType;
+import org.openmetadata.schema.entity.ai.McpTransportType;
+import org.openmetadata.schema.entity.data.Database;
+import org.openmetadata.schema.entity.data.DatabaseSchema;
+import org.openmetadata.schema.entity.data.Query;
+import org.openmetadata.schema.entity.data.Table;
+import org.openmetadata.schema.tests.TestCase;
+import org.openmetadata.schema.tests.type.TestCaseResolutionStatus;
+import org.openmetadata.schema.tests.type.TestCaseResolutionStatusTypes;
+import org.openmetadata.schema.type.Column;
+import org.openmetadata.schema.type.ColumnDataType;
+import org.openmetadata.sdk.client.OpenMetadataClient;
+import org.openmetadata.sdk.fluent.AIApplications;
+import org.openmetadata.sdk.models.ListParams;
+import org.openmetadata.sdk.network.HttpMethod;
+import org.openmetadata.sdk.network.RequestOptions;
+import org.openmetadata.service.Entity;
+import org.openmetadata.service.jdbi3.CollectionDAO;
+import org.openmetadata.service.util.FullyQualifiedName;
+
+/**
+ * Integration tests for {@link CollectionDAO} per-type orphan time-series cleanup queries used by
+ * {@code DataRetention.cleanOrphanedTimeSeriesRows()}.
+ *
+ * <p>Each test inserts one valid row (referencing a real parent entity) and one orphan row
+ * (referencing a non-existent parent), invokes {@code deleteOrphanedRecords(limit)} on the
+ * corresponding DAO, and verifies that only the orphan is deleted.
+ */
+@Execution(ExecutionMode.CONCURRENT)
+@ExtendWith(TestNamespaceExtension.class)
+public class OrphanedTimeSeriesCleanupIT {
+
+  private static final int BATCH = 10_000;
+  private static final String MCP_SERVICE_NAME = "mcp-orphan-cleanup-svc";
+
+  private static final ObjectMapper MAPPER =
+      new ObjectMapper().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+
+  @BeforeAll
+  public static void setup() throws Exception {
+    AIApplications.setDefaultClient(SdkClients.adminClient());
+
+    CreateMcpService createService =
+        new CreateMcpService()
+            .withName(MCP_SERVICE_NAME)
+            .withServiceType(CreateMcpService.McpServiceType.Mcp);
+    SdkClients.adminClient()
+        .getHttpClient()
+        .executeForString(
+            HttpMethod.PUT,
+            "/v1/services/mcpServices",
+            createService,
+            RequestOptions.builder().build());
+  }
+
+  @Test
+  void agentExecutionOrphans(TestNamespace ns) {
+    AIApplication app =
+        AIApplications.create()
+            .name("agentExecOrph_" + ns.uniqueShortId())
+            .withApplicationType(ApplicationType.Chatbot)
+            .withDescription("Parent app for orphan cleanup test")
+            .execute();
+    assertNotNull(app.getId());
+
+    UUID validId = UUID.randomUUID();
+    UUID orphanId = UUID.randomUUID();
+    UUID orphanAgentId = UUID.randomUUID();
+
+    insertAgentExecution(validId, app.getId());
+    insertAgentExecution(orphanId, orphanAgentId);
+
+    int deleted = Entity.getCollectionDAO().agentExecutionDAO().deleteOrphanedRecords(BATCH);
+
+    assertTrue(deleted >= 1, "Expected at least the inserted orphan row to be deleted");
+    assertEquals(0, countRowsById("agent_execution_entity", orphanId.toString()));
+    assertEquals(1, countRowsById("agent_execution_entity", validId.toString()));
+  }
+
+  @Test
+  void mcpExecutionOrphans(TestNamespace ns) throws Exception {
+    CreateMcpServer createServer =
+        new CreateMcpServer()
+            .withName("mcpOrph-" + ns.uniqueShortId())
+            .withService(MCP_SERVICE_NAME)
+            .withServerType(McpServerType.DataAccess)
+            .withTransportType(McpTransportType.Stdio)
+            .withDescription("Parent MCP server for orphan cleanup test");
+    String response =
+        SdkClients.adminClient()
+            .getHttpClient()
+            .executeForString(
+                HttpMethod.POST, "/v1/mcpServers", createServer, RequestOptions.builder().build());
+    McpServer server = MAPPER.readValue(response, McpServer.class);
+    assertNotNull(server.getId());
+
+    UUID validId = UUID.randomUUID();
+    UUID orphanId = UUID.randomUUID();
+    UUID orphanServerId = UUID.randomUUID();
+
+    insertMcpExecution(validId, server.getId());
+    insertMcpExecution(orphanId, orphanServerId);
+
+    int deleted = Entity.getCollectionDAO().mcpExecutionDAO().deleteOrphanedRecords(BATCH);
+
+    assertTrue(deleted >= 1, "Expected at least the inserted orphan row to be deleted");
+    assertEquals(0, countRowsById("mcp_execution_entity", orphanId.toString()));
+    assertEquals(1, countRowsById("mcp_execution_entity", validId.toString()));
+  }
+
+  @Test
+  void testCaseResolutionStatusOrphans(TestNamespace ns) throws Exception {
+    OpenMetadataClient client = SdkClients.adminClient();
+    Table table = createTable(ns, "tcrs");
+    TestCase testCase = createTestCase(table, "tcrsCase_" + ns.uniqueShortId());
+
+    CreateTestCaseResolutionStatus createStatus =
+        new CreateTestCaseResolutionStatus()
+            .withTestCaseResolutionStatusType(TestCaseResolutionStatusTypes.New)
+            .withTestCaseReference(testCase.getFullyQualifiedName());
+    TestCaseResolutionStatus validStatus = client.testCaseResolutionStatuses().create(createStatus);
+    assertNotNull(validStatus.getId());
+
+    UUID orphanId = UUID.randomUUID();
+    UUID orphanStateId = UUID.randomUUID();
+    insertResolutionStatus(orphanId, orphanStateId, testCase);
+
+    int deleted =
+        Entity.getCollectionDAO()
+            .testCaseResolutionStatusTimeSeriesDao()
+            .deleteOrphanedRecords(BATCH);
+
+    assertTrue(deleted >= 1, "Expected at least the inserted orphan row to be deleted");
+    assertEquals(0, countRowsById("test_case_resolution_status_time_series", orphanId.toString()));
+    assertEquals(
+        1,
+        countRowsById("test_case_resolution_status_time_series", validStatus.getId().toString()));
+  }
+
+  @Test
+  void profilerDataOrphans(TestNamespace ns) throws Exception {
+    Table table = createTable(ns, "prof");
+    String validFqn = table.getFullyQualifiedName();
+    String orphanFqn = "orphanTbl_" + ns.uniqueShortId() + ".profile";
+
+    String validJson =
+        String.format("{\"timestamp\":%d,\"rowCount\":42}", System.currentTimeMillis());
+    String orphanJson =
+        String.format("{\"timestamp\":%d,\"rowCount\":7}", System.currentTimeMillis());
+
+    Entity.getCollectionDAO()
+        .profilerDataTimeSeriesDao()
+        .insert(validFqn, "table.tableProfile", "tableProfile", validJson);
+    Entity.getCollectionDAO()
+        .profilerDataTimeSeriesDao()
+        .insert(orphanFqn, "table.tableProfile", "tableProfile", orphanJson);
+
+    int deleted =
+        Entity.getCollectionDAO().profilerDataTimeSeriesDao().deleteOrphanedRecords(BATCH);
+
+    assertTrue(deleted >= 1, "Expected at least the inserted orphan row to be deleted");
+    assertEquals(
+        0,
+        countRowsByFqnHash("profiler_data_time_series", FullyQualifiedName.buildHash(orphanFqn)));
+    assertTrue(
+        countRowsByFqnHash("profiler_data_time_series", FullyQualifiedName.buildHash(validFqn))
+            >= 1,
+        "Valid profiler row must be preserved");
+  }
+
+  @Test
+  void queryCostOrphans(TestNamespace ns) throws Exception {
+    Query query = createQuery(ns, "qc");
+    String validFqn = query.getFullyQualifiedName();
+    String orphanFqn = "orphanQc_" + ns.uniqueShortId();
+
+    String validJson =
+        String.format(
+            "{\"id\":\"%s\",\"timestamp\":%d,\"cost\":1.5,\"count\":3}",
+            UUID.randomUUID(), System.currentTimeMillis());
+    UUID orphanRowId = UUID.randomUUID();
+    String orphanJson =
+        String.format(
+            "{\"id\":\"%s\",\"timestamp\":%d,\"cost\":2.5,\"count\":1}",
+            orphanRowId, System.currentTimeMillis());
+
+    Entity.getCollectionDAO()
+        .queryCostRecordTimeSeriesDAO()
+        .insert(validFqn, "queryCostRecord", validJson);
+    Entity.getCollectionDAO()
+        .queryCostRecordTimeSeriesDAO()
+        .insert(orphanFqn, "queryCostRecord", orphanJson);
+
+    int deleted =
+        Entity.getCollectionDAO().queryCostRecordTimeSeriesDAO().deleteOrphanedRecords(BATCH);
+
+    assertTrue(deleted >= 1, "Expected at least the inserted orphan row to be deleted");
+    assertEquals(0, countRowsById("query_cost_time_series", orphanRowId.toString()));
+    assertTrue(
+        countRowsByFqnHash("query_cost_time_series", FullyQualifiedName.buildHash(validFqn)) >= 1,
+        "Valid query-cost row must be preserved");
+  }
+
+  private void insertAgentExecution(UUID id, UUID agentId) {
+    String json =
+        String.format(
+            "{\"id\":\"%s\",\"agentId\":\"%s\",\"timestamp\":%d,\"status\":\"Success\","
+                + "\"agent\":{\"id\":\"%s\",\"type\":\"aiApplication\"}}",
+            id, agentId, System.currentTimeMillis(), agentId);
+    Entity.getCollectionDAO().agentExecutionDAO().insertWithoutExtension(null, "", "", json);
+  }
+
+  private void insertMcpExecution(UUID id, UUID serverId) {
+    String json =
+        String.format(
+            "{\"id\":\"%s\",\"serverId\":\"%s\",\"timestamp\":%d,\"status\":\"Success\","
+                + "\"server\":{\"id\":\"%s\",\"type\":\"mcpServer\"}}",
+            id, serverId, System.currentTimeMillis(), serverId);
+    Entity.getCollectionDAO()
+        .mcpExecutionDAO()
+        .insertWithoutExtension("mcp_execution_entity", "", "", json);
+  }
+
+  private void insertResolutionStatus(UUID id, UUID stateId, TestCase testCase) {
+    String json =
+        String.format(
+            "{\"id\":\"%s\",\"stateId\":\"%s\",\"timestamp\":%d,"
+                + "\"testCaseResolutionStatusType\":\"New\","
+                + "\"testCaseReference\":{\"id\":\"%s\",\"type\":\"testCase\","
+                + "\"fullyQualifiedName\":\"%s\"}}",
+            id,
+            stateId,
+            System.currentTimeMillis(),
+            testCase.getId(),
+            testCase.getFullyQualifiedName());
+    Entity.getCollectionDAO()
+        .testCaseResolutionStatusTimeSeriesDao()
+        .insert(testCase.getFullyQualifiedName(), Entity.TEST_CASE_RESOLUTION_STATUS, json);
+  }
+
+  private Table createTable(TestNamespace ns, String prefix) throws Exception {
+    OpenMetadataClient client = SdkClients.adminClient();
+    String id = ns.uniqueShortId();
+    Database database =
+        client
+            .databases()
+            .create(
+                new CreateDatabase()
+                    .withName(prefix + "Db_" + id)
+                    .withService(SharedEntities.get().MYSQL_SERVICE.getFullyQualifiedName()));
+    DatabaseSchema schema =
+        client
+            .databaseSchemas()
+            .create(
+                new CreateDatabaseSchema()
+                    .withName(prefix + "Sc_" + id)
+                    .withDatabase(database.getFullyQualifiedName()));
+    return client
+        .tables()
+        .create(
+            new CreateTable()
+                .withName(prefix + "Tb_" + id)
+                .withDatabaseSchema(schema.getFullyQualifiedName())
+                .withColumns(
+                    List.of(new Column().withName("id").withDataType(ColumnDataType.BIGINT))));
+  }
+
+  private TestCase createTestCase(Table table, String name) throws Exception {
+    OpenMetadataClient client = SdkClients.adminClient();
+    String testDefFqn =
+        client
+            .testDefinitions()
+            .list(new ListParams().withLimit(1))
+            .getData()
+            .get(0)
+            .getFullyQualifiedName();
+    CreateTestCase createTestCase =
+        new CreateTestCase()
+            .withName(name)
+            .withEntityLink("<#E::table::" + table.getFullyQualifiedName() + "::columns::id>")
+            .withTestDefinition(testDefFqn);
+    return client.testCases().create(createTestCase);
+  }
+
+  private Query createQuery(TestNamespace ns, String prefix) throws Exception {
+    OpenMetadataClient client = SdkClients.adminClient();
+    Table table = createTable(ns, prefix);
+    return client
+        .queries()
+        .create(
+            new CreateQuery()
+                .withName(prefix + "Q_" + ns.uniqueShortId())
+                .withQuery("SELECT 1")
+                .withService(SharedEntities.get().MYSQL_SERVICE.getFullyQualifiedName())
+                .withQueryUsedIn(List.of(table.getEntityReference())));
+  }
+
+  private int countRowsById(String table, String id) {
+    return TestSuiteBootstrap.getJdbi()
+        .withHandle(
+            handle ->
+                handle
+                    .createQuery("SELECT COUNT(*) FROM " + table + " WHERE id = :id")
+                    .bind("id", id)
+                    .mapTo(Integer.class)
+                    .one());
+  }
+
+  private int countRowsByFqnHash(String table, String fqnHash) {
+    return TestSuiteBootstrap.getJdbi()
+        .withHandle(
+            handle ->
+                handle
+                    .createQuery("SELECT COUNT(*) FROM " + table + " WHERE entityFQNHash = :h")
+                    .bind("h", fqnHash)
+                    .mapTo(Integer.class)
+                    .one());
+  }
+}

--- a/openmetadata-service/src/main/java/org/openmetadata/service/apps/bundles/dataContracts/DataContractValidationApp.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/apps/bundles/dataContracts/DataContractValidationApp.java
@@ -3,9 +3,8 @@ package org.openmetadata.service.apps.bundles.dataContracts;
 import static org.openmetadata.common.utils.CommonUtil.nullOrEmpty;
 import static org.openmetadata.service.apps.scheduler.OmAppJobListener.APP_RUN_STATS;
 
-import java.util.HashMap;
+import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.openmetadata.schema.EntityInterface;
@@ -14,6 +13,8 @@ import org.openmetadata.schema.entity.app.FailureContext;
 import org.openmetadata.schema.entity.data.DataContract;
 import org.openmetadata.schema.entity.datacontract.DataContractResult;
 import org.openmetadata.schema.entity.domains.DataProduct;
+import org.openmetadata.schema.system.EntityError;
+import org.openmetadata.schema.system.IndexingError;
 import org.openmetadata.schema.system.Stats;
 import org.openmetadata.schema.system.StepStats;
 import org.openmetadata.schema.type.EntityReference;
@@ -36,7 +37,8 @@ public class DataContractValidationApp extends AbstractNativeApplication {
 
   private final Stats stats = new Stats();
   private JobExecutionContext jobExecutionContext;
-  private final Map<String, Object> failureDetails = new HashMap<>();
+  private final IndexingError failureDetails =
+      new IndexingError().withFailedEntities(new ArrayList<>());
 
   public DataContractValidationApp(CollectionDAO collectionDAO, SearchRepository searchRepository) {
     super(collectionDAO, searchRepository);
@@ -76,8 +78,10 @@ public class DataContractValidationApp extends AbstractNativeApplication {
       updateStatsRecord(AppRunRecord.Status.COMPLETED);
     } catch (Exception e) {
       LOG.error("Error running DataContractValidationApp", e);
-      failureDetails.put("message", e.getMessage());
-      failureDetails.put("jobStackTrace", ExceptionUtils.getStackTrace(e));
+      failureDetails
+          .withErrorSource(IndexingError.ErrorSource.JOB)
+          .withMessage(e.getMessage())
+          .withStackTrace(ExceptionUtils.getStackTrace(e));
       updateStatsRecord(AppRunRecord.Status.FAILED);
     }
   }
@@ -120,7 +124,7 @@ public class DataContractValidationApp extends AbstractNativeApplication {
                   "Failed to validate data contract %s: %s",
                   dataContract.getFullyQualifiedName(), e.getMessage());
           LOG.error(msg, e);
-          failureDetails.put(dataContract.getFullyQualifiedName(), msg);
+          recordEntityFailure(dataContract.getFullyQualifiedName(), msg);
           totalErrors++;
         }
       }
@@ -230,7 +234,7 @@ public class DataContractValidationApp extends AbstractNativeApplication {
                         "Failed to process asset %s from Data Product %s: %s",
                         assetRef.getName(), dataProduct.getName(), e.getMessage());
                 LOG.error(msg, e);
-                failureDetails.put(assetRef.getFullyQualifiedName(), msg);
+                recordEntityFailure(assetRef.getFullyQualifiedName(), msg);
                 totalErrors++;
               }
             }
@@ -244,13 +248,13 @@ public class DataContractValidationApp extends AbstractNativeApplication {
               String.format(
                   "Failed to process Data Product %s: %s", dataProduct.getName(), e.getMessage());
           LOG.error(msg, e);
-          failureDetails.put(dataProduct.getFullyQualifiedName(), msg);
+          recordEntityFailure(dataProduct.getFullyQualifiedName(), msg);
           totalErrors++;
         }
       }
     } catch (Exception e) {
       LOG.error("Error processing Data Products: {}", e.getMessage(), e);
-      failureDetails.put("dataProductProcessing", e.getMessage());
+      recordEntityFailure("dataProductProcessing", e.getMessage());
     }
 
     return new int[] {totalProcessed, totalErrors};
@@ -265,13 +269,22 @@ public class DataContractValidationApp extends AbstractNativeApplication {
     stats.setJobStats(jobStats);
   }
 
+  private void recordEntityFailure(String entity, String message) {
+    failureDetails
+        .getFailedEntities()
+        .add(new EntityError().withEntity(entity).withMessage(message));
+  }
+
+  private boolean hasFailures() {
+    return failureDetails.getMessage() != null || !nullOrEmpty(failureDetails.getFailedEntities());
+  }
+
   private void updateStatsRecord(AppRunRecord.Status status) {
     AppRunRecord appRecord = getJobRecord(jobExecutionContext);
     appRecord.setStatus(status);
 
-    if (!nullOrEmpty(failureDetails)) {
-      appRecord.setFailureContext(
-          new FailureContext().withAdditionalProperty("failure", failureDetails));
+    if (hasFailures()) {
+      appRecord.setFailureContext(new FailureContext().withFailure(failureDetails));
       appRecord.setStatus(AppRunRecord.Status.FAILED);
     }
 

--- a/openmetadata-service/src/main/java/org/openmetadata/service/apps/bundles/dataRetention/DataRetention.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/apps/bundles/dataRetention/DataRetention.java
@@ -364,9 +364,9 @@ public class DataRetention extends AbstractNativeApplication {
       LOG.error("Failed to clean orphan ingestion pipelines", ex);
       internalStatus = AppRunRecord.Status.ACTIVE_ERROR;
       if (failureDetails == null) {
-        failureDetails = new HashMap<>();
-        failureDetails.put("message", ex.getMessage());
-        failureDetails.put("jobStackTrace", ExceptionUtils.getStackTrace(ex));
+        failureDetails = new IndexingError();
+        failureDetails.setMessage(ex.getMessage());
+        failureDetails.setStackTrace(ExceptionUtils.getStackTrace(ex));
       }
     }
   }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/apps/bundles/dataRetention/DataRetention.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/apps/bundles/dataRetention/DataRetention.java
@@ -29,6 +29,7 @@ import org.openmetadata.service.jdbi3.FeedRepository;
 import org.openmetadata.service.search.SearchRepository;
 import org.openmetadata.service.socket.WebSocketManager;
 import org.openmetadata.service.util.EntityRelationshipCleanupUtil;
+import org.openmetadata.service.util.OrphanIngestionPipelineCleanup;
 import org.openmetadata.service.util.OrphanTestCaseCleanup;
 import org.openmetadata.service.util.OrphanTestCaseRelationshipCleanup;
 import org.openmetadata.service.util.TagUsageCleanup;
@@ -126,6 +127,7 @@ public class DataRetention extends AbstractNativeApplication {
     entityStats.withAdditionalProperty("orphaned_test_cases", new StepStats());
     entityStats.withAdditionalProperty("test_cases_missing_test_definition", new StepStats());
     entityStats.withAdditionalProperty("test_cases_missing_executable_suite", new StepStats());
+    entityStats.withAdditionalProperty("orphaned_ingestion_pipelines", new StepStats());
     entityStats.withAdditionalProperty("orphan_test_case_resolution_status", new StepStats());
     entityStats.withAdditionalProperty("orphan_agent_execution", new StepStats());
     entityStats.withAdditionalProperty("orphan_mcp_execution", new StepStats());
@@ -163,6 +165,16 @@ public class DataRetention extends AbstractNativeApplication {
     // repaired is not mistaken for missing.
     LOG.info("Starting cleanup for test cases with missing relationships.");
     cleanTestCasesWithMissingRelationships();
+
+    // Clean up ingestion pipelines whose container (service/test suite) CONTAINS row is gone. Such
+    // a pipeline can never run and breaks search indexing ("does not have expected relationship
+    // contains to/from entity type null"). Runs after the relationship/hierarchy cleanup above so a
+    // container relationship that was just repaired is not mistaken for missing.
+    LOG.info("Starting cleanup for orphaned ingestion pipelines.");
+    cleanOrphanedIngestionPipelines();
+
+    // Run after orphan test case cleanup so resolution-status rows for deleted test cases
+    // also get swept up.
     LOG.info("Starting cleanup for orphaned time-series rows.");
     cleanOrphanedTimeSeriesRows();
 
@@ -352,6 +364,31 @@ public class DataRetention extends AbstractNativeApplication {
         failureDetails.put("jobStackTrace", ExceptionUtils.getStackTrace(ex));
       }
     }
+  }
+
+  private void cleanOrphanedIngestionPipelines() {
+    try {
+      OrphanIngestionPipelineCleanup cleanup =
+          new OrphanIngestionPipelineCleanup(collectionDAO, false);
+      OrphanIngestionPipelineCleanup.Result result = cleanup.performCleanup(BATCH_SIZE);
+      updateStats(
+          "orphaned_ingestion_pipelines", result.getOrphansDeleted(), result.getOrphanFailures());
+      LOG.info(
+          "Orphan ingestion pipeline cleanup completed - Scanned: {}, Deleted: {}, Failed: {}",
+          result.getTotalScanned(),
+          result.getOrphansDeleted(),
+          result.getOrphanFailures());
+    } catch (Exception ex) {
+      LOG.error("Failed to clean orphan ingestion pipelines", ex);
+      internalStatus = AppRunRecord.Status.ACTIVE_ERROR;
+      if (failureDetails == null) {
+        failureDetails = new HashMap<>();
+        failureDetails.put("message", ex.getMessage());
+        failureDetails.put("jobStackTrace", ExceptionUtils.getStackTrace(ex));
+      }
+    }
+  }
+
   private void cleanOrphanedTimeSeriesRows() {
     LOG.info("Initiating orphaned time-series rows cleanup.");
 

--- a/openmetadata-service/src/main/java/org/openmetadata/service/apps/bundles/dataRetention/DataRetention.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/apps/bundles/dataRetention/DataRetention.java
@@ -126,6 +126,11 @@ public class DataRetention extends AbstractNativeApplication {
     entityStats.withAdditionalProperty("orphaned_test_cases", new StepStats());
     entityStats.withAdditionalProperty("test_cases_missing_test_definition", new StepStats());
     entityStats.withAdditionalProperty("test_cases_missing_executable_suite", new StepStats());
+    entityStats.withAdditionalProperty("orphan_test_case_resolution_status", new StepStats());
+    entityStats.withAdditionalProperty("orphan_agent_execution", new StepStats());
+    entityStats.withAdditionalProperty("orphan_mcp_execution", new StepStats());
+    entityStats.withAdditionalProperty("orphan_profile_data", new StepStats());
+    entityStats.withAdditionalProperty("orphan_query_cost_time_series", new StepStats());
     entityStats.withAdditionalProperty("audit_logs", new StepStats());
 
     retentionStats.setEntityStats(entityStats);
@@ -158,6 +163,8 @@ public class DataRetention extends AbstractNativeApplication {
     // repaired is not mistaken for missing.
     LOG.info("Starting cleanup for test cases with missing relationships.");
     cleanTestCasesWithMissingRelationships();
+    LOG.info("Starting cleanup for orphaned time-series rows.");
+    cleanOrphanedTimeSeriesRows();
 
     int retentionPeriod = config.getChangeEventRetentionPeriod();
     LOG.info("Starting cleanup for change events with retention period: {} days.", retentionPeriod);
@@ -345,6 +352,30 @@ public class DataRetention extends AbstractNativeApplication {
         failureDetails.put("jobStackTrace", ExceptionUtils.getStackTrace(ex));
       }
     }
+  private void cleanOrphanedTimeSeriesRows() {
+    LOG.info("Initiating orphaned time-series rows cleanup.");
+
+    CollectionDAO.TestCaseResolutionStatusTimeSeriesDAO resolutionStatusDao =
+        collectionDAO.testCaseResolutionStatusTimeSeriesDao();
+    CollectionDAO.AgentExecutionDAO agentExecutionDao = collectionDAO.agentExecutionDAO();
+    CollectionDAO.McpExecutionDAO mcpExecutionDao = collectionDAO.mcpExecutionDAO();
+    CollectionDAO.ProfilerDataTimeSeriesDAO profilerDao = collectionDAO.profilerDataTimeSeriesDao();
+    CollectionDAO.QueryCostTimeSeriesDAO queryCostDao =
+        collectionDAO.queryCostRecordTimeSeriesDAO();
+
+    executeOrphanCleanup(
+        "orphan_test_case_resolution_status",
+        () -> resolutionStatusDao.deleteOrphanedRecords(BATCH_SIZE));
+    executeOrphanCleanup(
+        "orphan_agent_execution", () -> agentExecutionDao.deleteOrphanedRecords(BATCH_SIZE));
+    executeOrphanCleanup(
+        "orphan_mcp_execution", () -> mcpExecutionDao.deleteOrphanedRecords(BATCH_SIZE));
+    executeOrphanCleanup(
+        "orphan_profile_data", () -> profilerDao.deleteOrphanedRecords(BATCH_SIZE));
+    executeOrphanCleanup(
+        "orphan_query_cost_time_series", () -> queryCostDao.deleteOrphanedRecords(BATCH_SIZE));
+
+    LOG.info("Orphaned time-series rows cleanup complete.");
   }
 
   @Transaction
@@ -379,6 +410,32 @@ public class DataRetention extends AbstractNativeApplication {
         "audit_logs", () -> auditLogDAO.deleteInBatches(cutoffMillis, BATCH_SIZE));
 
     LOG.info("Audit logs cleanup complete.");
+  }
+
+  private void executeOrphanCleanup(String entity, Supplier<Integer> deleteFunction) {
+    int totalDeleted = 0;
+    int totalFailed = 0;
+
+    while (true) {
+      try {
+        int deleted = deleteFunction.get();
+        totalDeleted += deleted;
+        if (deleted == 0) break;
+      } catch (Exception ex) {
+        LOG.error("Failed to clean orphan time-series rows for {}", entity, ex);
+        totalFailed += BATCH_SIZE;
+        internalStatus = AppRunRecord.Status.ACTIVE_ERROR;
+
+        if (failureDetails == null) {
+          failureDetails = new HashMap<>();
+          failureDetails.put("message", ex.getMessage());
+          failureDetails.put("jobStackTrace", ExceptionUtils.getStackTrace(ex));
+        }
+        break;
+      }
+    }
+
+    updateStats(entity, totalDeleted, totalFailed);
   }
 
   private void executeWithStatsTracking(String entity, Supplier<Integer> deleteFunction) {

--- a/openmetadata-service/src/main/java/org/openmetadata/service/apps/bundles/dataRetention/DataRetention.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/apps/bundles/dataRetention/DataRetention.java
@@ -4,7 +4,6 @@ import static org.openmetadata.service.apps.scheduler.OmAppJobListener.APP_RUN_S
 
 import java.time.Duration;
 import java.time.Instant;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -18,6 +17,7 @@ import org.openmetadata.schema.entity.app.AppRunRecord;
 import org.openmetadata.schema.entity.app.FailureContext;
 import org.openmetadata.schema.entity.applications.configuration.internal.DataRetentionConfiguration;
 import org.openmetadata.schema.system.EntityStats;
+import org.openmetadata.schema.system.IndexingError;
 import org.openmetadata.schema.system.Stats;
 import org.openmetadata.schema.system.StepStats;
 import org.openmetadata.schema.utils.JsonUtils;
@@ -45,7 +45,7 @@ public class DataRetention extends AbstractNativeApplication {
   private JobExecutionContext jobExecutionContext;
 
   private AppRunRecord.Status internalStatus = AppRunRecord.Status.COMPLETED;
-  private Map<String, Object> failureDetails = null;
+  private IndexingError failureDetails = null;
 
   private final FeedRepository feedRepository;
   private final CollectionDAO.FeedDAO feedDAO;
@@ -94,9 +94,7 @@ public class DataRetention extends AbstractNativeApplication {
       LOG.error("DataRetention job failed.", ex);
       internalStatus = AppRunRecord.Status.FAILED;
 
-      failureDetails = new HashMap<>();
-      failureDetails.put("message", ex.getMessage());
-      failureDetails.put("jobStackTrace", ExceptionUtils.getStackTrace(ex));
+      failureDetails = toIndexingError(ex);
 
       updateRecordToDbAndNotify(ex);
     }
@@ -281,11 +279,7 @@ public class DataRetention extends AbstractNativeApplication {
       LOG.error("Failed to clean orphaned relationships and hierarchies", ex);
       internalStatus = AppRunRecord.Status.ACTIVE_ERROR;
 
-      if (failureDetails == null) {
-        failureDetails = new HashMap<>();
-        failureDetails.put("message", ex.getMessage());
-        failureDetails.put("jobStackTrace", ExceptionUtils.getStackTrace(ex));
-      }
+      recordFirstFailure(ex);
     }
   }
 
@@ -304,11 +298,7 @@ public class DataRetention extends AbstractNativeApplication {
       LOG.error("Failed to clean orphaned tag usages", ex);
       internalStatus = AppRunRecord.Status.ACTIVE_ERROR;
 
-      if (failureDetails == null) {
-        failureDetails = new HashMap<>();
-        failureDetails.put("message", ex.getMessage());
-        failureDetails.put("jobStackTrace", ExceptionUtils.getStackTrace(ex));
-      }
+      recordFirstFailure(ex);
     }
   }
 
@@ -326,11 +316,7 @@ public class DataRetention extends AbstractNativeApplication {
     } catch (Exception ex) {
       LOG.error("Failed to clean orphan test cases", ex);
       internalStatus = AppRunRecord.Status.ACTIVE_ERROR;
-      if (failureDetails == null) {
-        failureDetails = new HashMap<>();
-        failureDetails.put("message", ex.getMessage());
-        failureDetails.put("jobStackTrace", ExceptionUtils.getStackTrace(ex));
-      }
+      recordFirstFailure(ex);
     }
   }
 
@@ -358,11 +344,7 @@ public class DataRetention extends AbstractNativeApplication {
     } catch (Exception ex) {
       LOG.error("Failed to clean test cases with missing relationships", ex);
       internalStatus = AppRunRecord.Status.ACTIVE_ERROR;
-      if (failureDetails == null) {
-        failureDetails = new HashMap<>();
-        failureDetails.put("message", ex.getMessage());
-        failureDetails.put("jobStackTrace", ExceptionUtils.getStackTrace(ex));
-      }
+      recordFirstFailure(ex);
     }
   }
 
@@ -449,27 +431,43 @@ public class DataRetention extends AbstractNativeApplication {
     LOG.info("Audit logs cleanup complete.");
   }
 
+  // Safety cap on the orphan-cleanup loop. With BATCH_SIZE=10k this allows up to 10M
+  // rows per entity per run — well above any healthy catalog's orphan count. A buggy
+  // delete query that always returns a non-zero count (e.g., rows it can't actually
+  // delete due to FK constraints) would otherwise spin forever and block the rest of
+  // the DataRetention job.
+  private static final int MAX_ORPHAN_CLEANUP_ITERATIONS = 1000;
+
   private void executeOrphanCleanup(String entity, Supplier<Integer> deleteFunction) {
     int totalDeleted = 0;
     int totalFailed = 0;
+    boolean stoppedByCondition = false;
 
-    while (true) {
+    for (int iteration = 0; iteration < MAX_ORPHAN_CLEANUP_ITERATIONS; iteration++) {
       try {
         int deleted = deleteFunction.get();
         totalDeleted += deleted;
-        if (deleted == 0) break;
+        if (deleted == 0) {
+          stoppedByCondition = true;
+          break;
+        }
       } catch (Exception ex) {
         LOG.error("Failed to clean orphan time-series rows for {}", entity, ex);
         totalFailed += BATCH_SIZE;
         internalStatus = AppRunRecord.Status.ACTIVE_ERROR;
 
-        if (failureDetails == null) {
-          failureDetails = new HashMap<>();
-          failureDetails.put("message", ex.getMessage());
-          failureDetails.put("jobStackTrace", ExceptionUtils.getStackTrace(ex));
-        }
+        recordFirstFailure(ex);
+        stoppedByCondition = true;
         break;
       }
+    }
+
+    if (!stoppedByCondition) {
+      LOG.warn(
+          "Orphan cleanup for {} hit the iteration cap ({}) before draining; "
+              + "remaining rows will be retried on the next DataRetention run.",
+          entity,
+          MAX_ORPHAN_CLEANUP_ITERATIONS);
     }
 
     updateStats(entity, totalDeleted, totalFailed);
@@ -489,11 +487,7 @@ public class DataRetention extends AbstractNativeApplication {
         totalFailed += BATCH_SIZE;
         internalStatus = AppRunRecord.Status.ACTIVE_ERROR;
 
-        if (failureDetails == null) {
-          failureDetails = new HashMap<>();
-          failureDetails.put("message", ex.getMessage());
-          failureDetails.put("jobStackTrace", ExceptionUtils.getStackTrace(ex));
-        }
+        recordFirstFailure(ex);
         break;
       }
     }
@@ -526,13 +520,25 @@ public class DataRetention extends AbstractNativeApplication {
     jobStats.setFailedRecords(jobStats.getFailedRecords() + failureCount);
   }
 
+  private void recordFirstFailure(Exception ex) {
+    if (failureDetails == null) {
+      failureDetails = toIndexingError(ex);
+    }
+  }
+
+  private static IndexingError toIndexingError(Exception ex) {
+    return new IndexingError()
+        .withErrorSource(IndexingError.ErrorSource.JOB)
+        .withMessage(ex.getMessage())
+        .withStackTrace(ExceptionUtils.getStackTrace(ex));
+  }
+
   private void updateRecordToDbAndNotify(Exception error) {
     AppRunRecord appRecord = getJobRecord(jobExecutionContext);
     appRecord.setStatus(internalStatus);
 
     if (failureDetails != null) {
-      appRecord.setFailureContext(
-          new FailureContext().withAdditionalProperty("failure", failureDetails));
+      appRecord.setFailureContext(new FailureContext().withFailure(failureDetails));
     }
 
     if (WebSocketManager.getInstance() != null) {

--- a/openmetadata-service/src/main/java/org/openmetadata/service/apps/scheduler/OmAppJobListener.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/apps/scheduler/OmAppJobListener.java
@@ -4,8 +4,6 @@ import static org.openmetadata.common.utils.CommonUtil.nullOrEmpty;
 import static org.openmetadata.service.apps.scheduler.AppScheduler.APP_CONFIG_KEY;
 import static org.openmetadata.service.apps.scheduler.AppScheduler.APP_NAME;
 
-import java.util.HashMap;
-import java.util.Map;
 import java.util.UUID;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.exception.ExceptionUtils;
@@ -15,6 +13,7 @@ import org.openmetadata.schema.entity.app.AppRunRecord;
 import org.openmetadata.schema.entity.app.FailureContext;
 import org.openmetadata.schema.entity.app.SuccessContext;
 import org.openmetadata.schema.entity.applications.configuration.ApplicationConfig;
+import org.openmetadata.schema.system.IndexingError;
 import org.openmetadata.schema.system.Stats;
 import org.openmetadata.schema.type.EntityReference;
 import org.openmetadata.schema.type.Include;
@@ -225,10 +224,11 @@ public class OmAppJobListener implements JobListener {
           context = runRecord.getFailureContext();
         }
         if (jobException != null) {
-          Map<String, Object> failure = new HashMap<>();
-          failure.put("message", jobException.getMessage());
-          failure.put("jobStackTrace", ExceptionUtils.getStackTrace(jobException));
-          context.withAdditionalProperty("failure", failure);
+          context.withFailure(
+              new IndexingError()
+                  .withErrorSource(IndexingError.ErrorSource.JOB)
+                  .withMessage(jobException.getMessage())
+                  .withStackTrace(ExceptionUtils.getStackTrace(jobException)));
         }
 
         runRecord.setFailureContext(context);

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/CollectionDAO.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/CollectionDAO.java
@@ -8665,6 +8665,33 @@ public interface CollectionDAO {
           getTimeSeriesTableName(), filter.getQueryParams(), filter.getCondition(), timestamp);
     }
 
+    // profiler_data_time_series has no id column (unique key is
+    // entityFQNHash + extension + operation + timestamp), so we limit by
+    // row count using single-table DELETE+LIMIT on MySQL and ctid IN (...) on Postgres.
+    // This bounds the rows deleted per batch, matching the other orphan-cleanup queries.
+    @ConnectionAwareSqlUpdate(
+        value =
+            "DELETE FROM profiler_data_time_series "
+                + "WHERE NOT EXISTS ("
+                + "  SELECT 1 FROM table_entity te "
+                + "  WHERE te.fqnHash = profiler_data_time_series.entityFQNHash"
+                + ") "
+                + "LIMIT :limit",
+        connectionType = MYSQL)
+    @ConnectionAwareSqlUpdate(
+        value =
+            "DELETE FROM profiler_data_time_series "
+                + "WHERE ctid IN ("
+                + "  SELECT pdts.ctid FROM profiler_data_time_series pdts "
+                + "  WHERE NOT EXISTS ("
+                + "    SELECT 1 FROM table_entity te "
+                + "    WHERE te.fqnHash = pdts.entityFQNHash"
+                + "  ) "
+                + "  LIMIT :limit"
+                + ")",
+        connectionType = POSTGRES)
+    int deleteOrphanedRecords(@Bind("limit") int limit);
+
     record LatestExtensionRecord(String entityFQNHash, String json) {}
 
     class LatestExtensionRecordMapper implements RowMapper<LatestExtensionRecord> {
@@ -8781,6 +8808,30 @@ public interface CollectionDAO {
 
     @SqlUpdate("DELETE FROM query_cost_time_series WHERE entityFQNHash = :entityFQNHash ")
     void deleteWithEntityFqnHash(@BindFQN("entityFQNHash") String entityFQNHash);
+
+    @ConnectionAwareSqlUpdate(
+        value =
+            "DELETE FROM query_cost_time_series "
+                + "WHERE id IN ("
+                + "  SELECT id FROM ("
+                + "    SELECT qcts.id FROM query_cost_time_series qcts "
+                + "    LEFT JOIN query_entity qe ON qcts.entityFQNHash = qe.fqnHash "
+                + "    WHERE qe.fqnHash IS NULL "
+                + "    LIMIT :limit"
+                + "  ) sub"
+                + ")",
+        connectionType = MYSQL)
+    @ConnectionAwareSqlUpdate(
+        value =
+            "DELETE FROM query_cost_time_series "
+                + "WHERE id IN ("
+                + "  SELECT qcts.id FROM query_cost_time_series qcts "
+                + "  LEFT JOIN query_entity qe ON qcts.entityFQNHash = qe.fqnHash "
+                + "  WHERE qe.fqnHash IS NULL "
+                + "  LIMIT :limit"
+                + ")",
+        connectionType = POSTGRES)
+    int deleteOrphanedRecords(@Bind("limit") int limit);
   }
 
   interface TestCaseResolutionStatusTimeSeriesDAO extends EntityTimeSeriesDAO {
@@ -8909,6 +8960,39 @@ public interface CollectionDAO {
       condition = TestCaseResolutionStatusRepository.addOriginEntityFQNJoin(filter, condition);
       return listCount(getTimeSeriesTableName(), filter.getQueryParams(), condition);
     }
+
+    // relation = 9 corresponds to Relationship.PARENT_OF (the enum ordinal is stable;
+    // see Relationship.java where new values must be appended). The annotation can't
+    // reference the enum at compile time, so we inline the ordinal here.
+    @ConnectionAwareSqlUpdate(
+        value =
+            "DELETE FROM test_case_resolution_status_time_series "
+                + "WHERE id IN ("
+                + "  SELECT id FROM ("
+                + "    SELECT ts.id FROM test_case_resolution_status_time_series ts "
+                + "    LEFT JOIN entity_relationship er "
+                + "      ON er.toId = ts.id AND er.relation = 9 " // 9 = Relationship.PARENT_OF
+                + "        AND er.fromEntity = 'testCase' "
+                + "        AND er.toEntity = 'testCaseResolutionStatus' "
+                + "    WHERE er.toId IS NULL "
+                + "    LIMIT :limit"
+                + "  ) sub"
+                + ")",
+        connectionType = MYSQL)
+    @ConnectionAwareSqlUpdate(
+        value =
+            "DELETE FROM test_case_resolution_status_time_series "
+                + "WHERE id IN ("
+                + "  SELECT ts.id FROM test_case_resolution_status_time_series ts "
+                + "  LEFT JOIN entity_relationship er "
+                + "    ON er.toId = ts.id AND er.relation = 9 " // 9 = Relationship.PARENT_OF
+                + "      AND er.fromEntity = 'testCase' "
+                + "      AND er.toEntity = 'testCaseResolutionStatus' "
+                + "  WHERE er.toId IS NULL "
+                + "  LIMIT :limit"
+                + ")",
+        connectionType = POSTGRES)
+    int deleteOrphanedRecords(@Bind("limit") int limit);
   }
 
   interface TestCaseResultTimeSeriesDAO extends EntityTimeSeriesDAO {
@@ -10461,6 +10545,30 @@ public interface CollectionDAO {
 
     @SqlQuery("SELECT count(*) FROM agent_execution_entity <cond>")
     int listCount(@Define("cond") String condition);
+
+    @ConnectionAwareSqlUpdate(
+        value =
+            "DELETE FROM agent_execution_entity "
+                + "WHERE id IN ("
+                + "  SELECT id FROM ("
+                + "    SELECT ae.id FROM agent_execution_entity ae "
+                + "    LEFT JOIN ai_application_entity ai ON ae.agentId = ai.id "
+                + "    WHERE ai.id IS NULL "
+                + "    LIMIT :limit"
+                + "  ) sub"
+                + ")",
+        connectionType = MYSQL)
+    @ConnectionAwareSqlUpdate(
+        value =
+            "DELETE FROM agent_execution_entity "
+                + "WHERE id IN ("
+                + "  SELECT ae.id FROM agent_execution_entity ae "
+                + "  LEFT JOIN ai_application_entity ai ON ae.agentId = ai.id "
+                + "  WHERE ai.id IS NULL "
+                + "  LIMIT :limit"
+                + ")",
+        connectionType = POSTGRES)
+    int deleteOrphanedRecords(@Bind("limit") int limit);
   }
 
   interface AIGovernancePolicyDAO
@@ -10565,6 +10673,30 @@ public interface CollectionDAO {
         value = "DELETE FROM <table> WHERE serverId = :serverId",
         connectionType = POSTGRES)
     void deleteByServerId(@Define("table") String table, @Bind("serverId") String serverId);
+
+    @ConnectionAwareSqlUpdate(
+        value =
+            "DELETE FROM mcp_execution_entity "
+                + "WHERE id IN ("
+                + "  SELECT id FROM ("
+                + "    SELECT me.id FROM mcp_execution_entity me "
+                + "    LEFT JOIN mcp_server_entity ms ON me.serverId = ms.id "
+                + "    WHERE ms.id IS NULL "
+                + "    LIMIT :limit"
+                + "  ) sub"
+                + ")",
+        connectionType = MYSQL)
+    @ConnectionAwareSqlUpdate(
+        value =
+            "DELETE FROM mcp_execution_entity "
+                + "WHERE id IN ("
+                + "  SELECT me.id FROM mcp_execution_entity me "
+                + "  LEFT JOIN mcp_server_entity ms ON me.serverId = ms.id "
+                + "  WHERE ms.id IS NULL "
+                + "  LIMIT :limit"
+                + ")",
+        connectionType = POSTGRES)
+    int deleteOrphanedRecords(@Bind("limit") int limit);
   }
 
   interface LLMServiceDAO extends EntityDAO<org.openmetadata.schema.entity.services.LLMService> {

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/indexes/TestCaseIndex.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/indexes/TestCaseIndex.java
@@ -59,18 +59,20 @@ public record TestCaseIndex(TestCase testCase) implements TaggableIndex {
   public Map<String, Object> buildSearchIndexDocInternal(Map<String, Object> doc) {
     doc.put(
         "originEntityFQN", MessageParser.EntityLink.parse(testCase.getEntityLink()).getEntityFQN());
-    try {
-      TestDefinition testDefinition =
-          Entity.getEntity(
-              Entity.TEST_DEFINITION, testCase.getTestDefinition().getId(), "", Include.ALL);
-      doc.put("testPlatforms", testDefinition.getTestPlatforms());
-      doc.put("dataQualityDimension", testDefinition.getDataQualityDimension());
-      doc.put("testCaseType", testDefinition.getEntityType());
-    } catch (EntityNotFoundException ex) {
-      LOG.warn(
-          "TestDefinition not found for TestCase [{}]: {}",
-          testCase.getFullyQualifiedName(),
-          ex.getMessage());
+    if (testCase.getTestDefinition() != null) {
+      try {
+        TestDefinition testDefinition =
+            Entity.getEntity(
+                Entity.TEST_DEFINITION, testCase.getTestDefinition().getId(), "", Include.ALL);
+        doc.put("testPlatforms", testDefinition.getTestPlatforms());
+        doc.put("dataQualityDimension", testDefinition.getDataQualityDimension());
+        doc.put("testCaseType", testDefinition.getEntityType());
+      } catch (EntityNotFoundException ex) {
+        LOG.warn(
+            "TestDefinition not found for TestCase [{}]: {}",
+            testCase.getFullyQualifiedName(),
+            ex.getMessage());
+      }
     }
     setParentRelationships(doc, testCase);
     return doc;

--- a/openmetadata-service/src/main/java/org/openmetadata/service/util/OrphanIngestionPipelineCleanup.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/util/OrphanIngestionPipelineCleanup.java
@@ -1,0 +1,222 @@
+/*
+ *  Copyright 2025 Collate
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.openmetadata.service.util;
+
+import static org.openmetadata.common.utils.CommonUtil.nullOrEmpty;
+import static org.openmetadata.service.Entity.INGESTION_PIPELINE;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.openmetadata.schema.entity.services.ingestionPipelines.IngestionPipeline;
+import org.openmetadata.schema.type.Relationship;
+import org.openmetadata.schema.utils.JsonUtils;
+import org.openmetadata.service.Entity;
+import org.openmetadata.service.jdbi3.CollectionDAO;
+import org.openmetadata.service.jdbi3.CollectionDAO.EntityRelationshipObject;
+
+/**
+ * Finds and hard-deletes ingestion pipelines whose container {@code CONTAINS} relationship row is
+ * missing. A pipeline is contained by its service (any service type) or by a test suite; when that
+ * parent is hard-deleted without the cascade reaching the pipeline, the pipeline row survives with
+ * no incoming {@code CONTAINS} row. Such a pipeline can no longer resolve its service, so it can
+ * never run and it breaks search indexing: {@code IngestionPipelineRepository.setFields} resolves
+ * the container via {@code getContainer} (which requires the relationship) and the reindex throws
+ * "does not have expected relationship contains to/from entity type null".
+ *
+ * <p>This complements {@link EntityRelationshipCleanup} (which removes relationship rows whose
+ * endpoints are gone). Here the pipeline row still exists but is unusable because the relationship
+ * row it depends on is absent.
+ *
+ * <p>Deletion first tries {@link Entity#deleteEntity} with {@code recursive=true, hardDelete=true}.
+ * A pipeline with a missing container can't be deleted that way — the delete path resolves the
+ * container and throws the same "does not have expected relationship" error — so it falls back to a
+ * direct delete of the pipeline's footprint (pipeline-status time series, relationship rows, search
+ * doc, row). Soft-deleted pipelines are skipped (the operator kept them on purpose).
+ */
+@Slf4j
+public class OrphanIngestionPipelineCleanup {
+
+  private static final String PIPELINE_STATUS_EXTENSION = "ingestionPipeline.pipelineStatus";
+
+  private final CollectionDAO collectionDAO;
+  private final boolean dryRun;
+
+  public OrphanIngestionPipelineCleanup(CollectionDAO collectionDAO, boolean dryRun) {
+    this.collectionDAO = collectionDAO;
+    this.dryRun = dryRun;
+  }
+
+  @Data
+  @Builder
+  @NoArgsConstructor
+  @AllArgsConstructor
+  public static class Result {
+    private int totalScanned;
+    private int orphansDeleted;
+    private int orphanFailures;
+  }
+
+  public Result performCleanup(int batchSize) {
+    LOG.info(
+        "Starting orphan ingestion pipeline cleanup. Dry run: {}, Batch size: {}",
+        dryRun,
+        batchSize);
+    Result result = Result.builder().build();
+
+    int offset = 0;
+    while (true) {
+      List<String> jsonBatch =
+          collectionDAO
+              .ingestionPipelineDAO()
+              .listAfterWithOffset(
+                  collectionDAO.ingestionPipelineDAO().getTableName(), batchSize, offset);
+      if (nullOrEmpty(jsonBatch)) {
+        break;
+      }
+      List<IngestionPipeline> pipelines = parsePipelines(jsonBatch);
+      result.setTotalScanned(result.getTotalScanned() + pipelines.size());
+
+      int deletedInBatch = cleanupBatch(pipelines, result);
+
+      if (jsonBatch.size() < batchSize) {
+        break;
+      }
+      // Hard deletes shift subsequent rows backward, so only advance past the rows we kept.
+      offset += batchSize - deletedInBatch;
+    }
+
+    LOG.info(
+        "Orphan ingestion pipeline cleanup done. Scanned: {}, Deleted: {}, Failed: {}",
+        result.getTotalScanned(),
+        result.getOrphansDeleted(),
+        result.getOrphanFailures());
+    return result;
+  }
+
+  private int cleanupBatch(List<IngestionPipeline> pipelines, Result result) {
+    List<String> ids = pipelines.stream().map(pipeline -> pipeline.getId().toString()).toList();
+    Set<String> withContainer = idsWithContainer(ids);
+
+    int deletedInBatch = 0;
+    for (IngestionPipeline pipeline : pipelines) {
+      if (!withContainer.contains(pipeline.getId().toString())) {
+        deletedInBatch += handleOrphan(pipeline, result);
+      }
+    }
+    return deletedInBatch;
+  }
+
+  /**
+   * Records and (unless dry run) deletes one orphan. Returns 1 if a row was actually removed (so the
+   * caller can adjust its paging offset), 0 otherwise.
+   */
+  private int handleOrphan(IngestionPipeline pipeline, Result result) {
+    boolean removed = !dryRun && deleteOrphan(pipeline);
+    int rowsRemoved = 0;
+    if (dryRun || removed) {
+      result.setOrphansDeleted(result.getOrphansDeleted() + 1);
+      if (removed) {
+        rowsRemoved = 1;
+      }
+    } else {
+      result.setOrphanFailures(result.getOrphanFailures() + 1);
+    }
+    return rowsRemoved;
+  }
+
+  private Set<String> idsWithContainer(List<String> pipelineIds) {
+    List<EntityRelationshipObject> records =
+        collectionDAO
+            .relationshipDAO()
+            .findFromBatch(pipelineIds, INGESTION_PIPELINE, Relationship.CONTAINS.ordinal());
+    Set<String> withContainer = new HashSet<>();
+    for (EntityRelationshipObject record : records) {
+      withContainer.add(record.getToId());
+    }
+    return withContainer;
+  }
+
+  private List<IngestionPipeline> parsePipelines(List<String> jsonBatch) {
+    List<IngestionPipeline> pipelines = new ArrayList<>(jsonBatch.size());
+    for (String json : jsonBatch) {
+      try {
+        IngestionPipeline pipeline = JsonUtils.readValue(json, IngestionPipeline.class);
+        // Skip soft-deleted pipelines — kept on purpose, and the cascade would no-op anyway.
+        if (!Boolean.TRUE.equals(pipeline.getDeleted())) {
+          pipelines.add(pipeline);
+        }
+      } catch (Exception ex) {
+        LOG.warn("Skipping unparseable ingestion pipeline row: {}", ex.getMessage());
+      }
+    }
+    return pipelines;
+  }
+
+  private boolean deleteOrphan(IngestionPipeline pipeline) {
+    UUID id = pipeline.getId();
+    boolean deleted;
+    try {
+      Entity.deleteEntity(Entity.ADMIN_USER_NAME, INGESTION_PIPELINE, id, true, true);
+      deleted = true;
+    } catch (Exception ex) {
+      // The standard delete resolves the pipeline's container; for a missing container that
+      // resolution itself throws "does not have expected relationship", so a broken pipeline cannot
+      // be removed the normal way. Fall back to a direct delete of its DB footprint.
+      LOG.warn(
+          "Standard delete failed for ingestion pipeline {} ({}); falling back to direct cleanup",
+          id,
+          ex.getMessage());
+      deleted = forceDelete(pipeline);
+    }
+    return deleted;
+  }
+
+  private boolean forceDelete(IngestionPipeline pipeline) {
+    UUID id = pipeline.getId();
+    boolean deleted;
+    try {
+      // Drop the search doc by id (no-op when the broken pipeline was never indexed; this does not
+      // rebuild the doc, so it won't re-trigger the container resolution).
+      try {
+        Entity.getSearchRepository().deleteEntityIndex(pipeline);
+      } catch (Exception ex) {
+        LOG.debug(
+            "Search-index cleanup skipped for ingestion pipeline {}: {}", id, ex.getMessage());
+      }
+      // Remove its pipeline-status time series, all relationship rows, then the row itself.
+      if (!nullOrEmpty(pipeline.getFullyQualifiedName())) {
+        collectionDAO
+            .entityExtensionTimeSeriesDao()
+            .delete(pipeline.getFullyQualifiedName(), PIPELINE_STATUS_EXTENSION);
+      }
+      collectionDAO.relationshipDAO().deleteAll(id, INGESTION_PIPELINE);
+      collectionDAO
+          .ingestionPipelineDAO()
+          .delete(collectionDAO.ingestionPipelineDAO().getTableName(), id);
+      deleted = true;
+    } catch (Exception ex) {
+      LOG.warn("Force delete failed for ingestion pipeline {}: {}", id, ex.getMessage());
+      deleted = false;
+    }
+    return deleted;
+  }
+}

--- a/openmetadata-service/src/test/java/org/openmetadata/service/apps/scheduler/OmAppJobListenerTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/apps/scheduler/OmAppJobListenerTest.java
@@ -25,6 +25,7 @@ import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
 import org.openmetadata.schema.entity.app.App;
 import org.openmetadata.schema.entity.app.AppRunRecord;
+import org.openmetadata.schema.system.IndexingError;
 import org.openmetadata.schema.system.Stats;
 import org.openmetadata.schema.type.Include;
 import org.openmetadata.schema.utils.JsonUtils;
@@ -287,6 +288,13 @@ class OmAppJobListenerTest {
         JsonUtils.readOrConvertValue(dataMap.get("AppScheduleRun"), AppRunRecord.class);
     assert updatedRecord.getStatus() == AppRunRecord.Status.FAILED;
     assert updatedRecord.getFailureContext() != null;
+
+    IndexingError failure = updatedRecord.getFailureContext().getFailure();
+    assert failure != null;
+    assert IndexingError.ErrorSource.JOB.equals(failure.getErrorSource());
+    assert "Something went wrong".equals(failure.getMessage());
+    assert failure.getStackTrace() != null
+        && failure.getStackTrace().contains("Something went wrong");
   }
 
   @Test


### PR DESCRIPTION
Backports the orphaned-ingestion-pipeline reindex fix to 1.13, and realigns `DataRetention.java` so it is **byte-identical to `main`**.

## Commits (cherry-picked with `-x`, in main's order)

| PR | Why it's here |
|----|---------------|
| #28384 `feat(dataRetention): sweep orphan time-series rows for per-type tables` | **Prerequisite.** Adds `deleteOrphanedRecords` to `CollectionDAO`; main's `DataRetention` calls it and 1.13 didn't have it. |
| #29836 `fix(search-indexing): reclaim orphaned ingestion pipelines and guard null testDefinition during reindex` | The requested fix. |
| #29965 `Fixes #20753: replace non-schema jobStackTrace with IndexingError.stackTrace` | **Prerequisite.** Changes `failureDetails` from raw `Map` to the schema-typed `IndexingError`. |
| #29984 `Fix Data Retention Build Issue` | The requested build fixup — it *is* the fixup for #29965, so it can't land without it. |

#29836 and #29984 cannot compile on 1.13 without #28384 and #29965, so all four are picked together.

## Note on the `executeOrphanCleanup` conflict

1.13 previously received a **partial** backport of #28159 (the test-case cleanup parts) which silently dropped its `MAX_ORPHAN_CLEANUP_ITERATIONS` guard — that guard protects `executeOrphanCleanup`, which only exists once #28384 lands.

Without the cap, `executeOrphanCleanup` is a bare `while (true)` that spins forever if a delete query keeps reporting non-zero deletions (e.g. rows blocked by an FK constraint), wedging the entire DataRetention job. Resolving that method to main's shape folds the cap back in, so 1.13 does not ship the uncapped loop.

## Result

`DataRetention.java`, `OrphanIngestionPipelineCleanup.java`, `TestCaseIndex.java`, `OmAppJobListener.java` and `DataContractValidationApp.java` are now identical to `main`.

## Verification

- `openmetadata-service` compiles (main + test sources)
- `openmetadata-integration-tests` compiles, including the two new ITs (`OrphanIngestionPipelineCleanupIT`, `OrphanedTimeSeriesCleanupIT`)
- `mvn spotless:check` clean
- `OmAppJobListenerTest` — 13/13 pass
- No `jobStackTrace` / `HashMap` failure-context residue left in `DataRetention`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR backports DataRetention cleanup and app failure-context fixes. The main changes are:

- Orphan ingestion pipelines are reclaimed during DataRetention.
- Orphan time-series and execution rows get per-table delete queries.
- Test-case indexing skips missing test-definition metadata.
- App failure details now use schema-typed `IndexingError` records.
- Integration and listener tests cover the new cleanup and failure shapes.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge after checking the query-cost cleanup edge case.

- The main cleanup paths are scoped to their expected parent rows or relationships.
- The remaining concern is limited to query-cost rows that already have a null parent hash.
- No blocking issues were found in the changed code.

openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/CollectionDAO.java
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-service/src/main/java/org/openmetadata/service/apps/bundles/dataRetention/DataRetention.java | Adds orphan ingestion-pipeline and orphan time-series cleanup to the scheduled DataRetention flow. |
| openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/CollectionDAO.java | Adds bounded orphan-delete queries for profiler data, query cost records, resolution statuses, agent executions, and MCP executions. |
| openmetadata-service/src/main/java/org/openmetadata/service/util/OrphanIngestionPipelineCleanup.java | Introduces hard cleanup for ingestion pipelines that no longer have a container relationship. |
| openmetadata-service/src/main/java/org/openmetadata/service/apps/bundles/dataContracts/DataContractValidationApp.java | Moves failure details from a raw map into `IndexingError` with per-entity failures. |
| openmetadata-service/src/main/java/org/openmetadata/service/apps/scheduler/OmAppJobListener.java | Stores Quartz job exceptions in `FailureContext.failure` as `IndexingError`. |
| openmetadata-service/src/main/java/org/openmetadata/service/search/indexes/TestCaseIndex.java | Adds a null guard before loading test-definition fields for search indexing. |

</details>

<sub>Reviews (1): Last reviewed commit: ["Fix Data Retention Build Issue (#29984)"](https://github.com/open-metadata/openmetadata/commit/44bb525d4b6abc7feaceb0fc9200546cf82fe676) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44084491)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Context used - CLAUDE.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=52f0d9d9-cad1-4e7d-b070-de181a0aa5e7))

<!-- /greptile_comment -->