### PR TITLE
fix(ui): prevent dropdown popover from rendering with tiny height near viewport edge

### DIFF
--- a/openmetadata-ui-core-components/src/main/resources/ui/src/components/base/dropdown/dropdown.tsx
+++ b/openmetadata-ui-core-components/src/main/resources/ui/src/components/base/dropdown/dropdown.tsx
@@ -123,7 +123,7 @@ const DropdownMenu = <T extends object>(props: DropdownMenuProps<T>) => {
       {...props}
       className={(state) =>
         cx(
-          'tw:h-min tw:overflow-y-auto tw:py-1 tw:outline-hidden tw:select-none',
+          'tw:py-1 tw:outline-hidden tw:select-none',
           typeof props.className === 'function'
             ? props.className(state)
             : props.className
@@ -144,7 +144,7 @@ const DropdownPopover = (props: DropdownPopoverProps) => {
       {...rest}
       className={(state) =>
         cx(
-          'tw:w-62 tw:origin-(--trigger-anchor-point) tw:overflow-auto tw:rounded-lg tw:bg-primary tw:shadow-lg tw:ring-1 tw:ring-secondary_alt tw:will-change-transform',
+          'tw:w-62 tw:max-h-none! tw:origin-(--trigger-anchor-point) tw:overflow-hidden tw:rounded-lg tw:bg-primary tw:shadow-lg tw:ring-1 tw:ring-secondary_alt tw:will-change-transform',
           state.isEntering &&
             'tw:duration-150 tw:ease-out tw:animate-in tw:fade-in tw:placement-right:slide-in-from-left-0.5 tw:placement-top:slide-in-from-bottom-0.5 tw:placement-bottom:slide-in-from-top-0.5',
           state.isExiting &&


### PR DESCRIPTION
### Describe your changes:

When the dropdown trigger is near the bottom of the viewport, the popover was rendering with a very tiny height (showing only 1-2 items in a scrollable box) instead of flipping to open above the trigger. This fix removes the default overflow/scrolling behavior and overrides React Aria's auto-computed `max-height` so the dropdown always shows at its full content height, relying on React Aria's built-in `shouldFlip` to position it above when there isn't enough space below.

**Changes:**
- **DropdownPopover**: Replaced `overflow-auto` with `overflow-hidden` and added `max-h-none!` to override React Aria's inline `max-height` constraint
- **DropdownMenu**: Removed default `h-min` and `overflow-y-auto` — no scrolling by default; consumers can opt in by passing `max-h-[value] overflow-y-auto` via className

#
### Type of change:
- [x] Bug fix







#
### High-level design:

N/A — small change.

#
### Tests:

#### Use cases covered
- Dropdown trigger near bottom of viewport flips to open above with all items visible
- Dropdown trigger with sufficient space below opens normally below

#### Unit tests
- Not applicable (CSS-only change, no logic)

#### Backend integration tests
- Not applicable (no backend API changes)

#### Ingestion integration tests
- Not applicable (no ingestion changes)

#### Playwright (UI) tests
- Not applicable (visual behavior change, manually verified in Storybook)

#### Manual testing performed
1. Launched local Storybook on port 6006/6007
2. Opened Dropdown Docs page, scrolled to "With Disabled Item" story
3. Verified dropdown opens above with all items visible when trigger is near viewport bottom
4. Verified dropdown opens normally below when trigger has sufficient space
5. Confirmed popover CSS classes and computed `maxHeight: none` via DevTools

#
### UI screen recording / screenshots:

**Before**: Dropdown renders as a tiny scrollable box when trigger is near the viewport bottom.
https://github.com/user-attachments/assets/62d9bf6f-26a9-4bec-97bf-09b68cdf181b

**After**: Dropdown flips to open above the trigger with all items fully visible.
https://github.com/user-attachments/assets/a6631434-48ab-4f0a-bf2f-c569f486eee5

#
### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] My PR title is `fix(ui): prevent dropdown popover from rendering with tiny height near viewport edge`
- [ ] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.
- [ ] For UI changes: I attached a screen recording and/or screenshots above.
- [ ] I have added tests (unit / integration / Playwright as applicable) and listed them above.

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing.
-->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR updates dropdown popover sizing near viewport edges. The main changes are:

- Removes default scrolling classes from the dropdown menu.
- Forces the dropdown popover to ignore computed max height.
- Changes the popover overflow behavior from scrollable to clipped.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge.

- No blocking issues found in the changed code.

</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-ui-core-components/src/main/resources/ui/src/components/base/dropdown/dropdown.tsx | Updates the dropdown menu and popover default sizing and overflow classes. |

</details>

<sub>Reviews (2): Last reviewed commit: ["Merge branch &#39;main&#39; into dropdown-flip-p..."](https://github.com/open-metadata/openmetadata/commit/9f988edfec37914e86da4d36dcd5c5d32dc6fdba) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44092610)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Context used - CLAUDE.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=52f0d9d9-cad1-4e7d-b070-de181a0aa5e7))
- Context used - openmetadata-ui-core-components/CLAUDE.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=41754627-b2bf-474b-8082-f37ef1a07013))
- Context used - AGENTS.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=ef262f5f-911f-44f3-8d2d-e9cb1579c8c8))
</details>

<!-- /greptile_comment -->