### PR TITLE
fix(advanced-search): dateTime custom property between filter drops upper bound (#28829)

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/utils/QueryBuilderElasticsearchFormatUtils.js
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/QueryBuilderElasticsearchFormatUtils.js
@@ -609,30 +609,23 @@ function buildExtensionQuery(
       operator
     );
   } else if (isRangeOperator(operator)) {
-    // Range query: query longValue, doubleValue, and stringValue with OR
-    // since we don't know which field the value is stored in
-    // (dates are stored as strings, numbers as long/double)
-    const longValueQuery = buildNestedTypedQuery(
-      basePropertyName,
-      'longValue',
-      value,
-      operator
-    );
-    const doubleValueQuery = buildNestedTypedQuery(
-      basePropertyName,
-      'doubleValue',
-      value,
-      operator
-    );
-    const stringValueQuery = buildNestedTypedQuery(
-      basePropertyName,
-      'stringValue',
-      value,
-      operator
-    );
+    // Range query: OR across the typed value fields since we don't know which
+    // one holds the value. Date/time custom properties are stored only as
+    // formatted strings in stringValue — sending those strings into a numeric
+    // longValue/doubleValue range raises an ES number_format_exception that
+    // fails the whole search, so route date types to stringValue only.
+    const isDateOmType =
+      omPropertyType === 'date-cp' ||
+      omPropertyType === 'dateTime-cp' ||
+      omPropertyType === 'time-cp';
+    const rangeFields = isDateOmType
+      ? ['stringValue']
+      : ['longValue', 'doubleValue', 'stringValue'];
     mainQuery = {
       bool: {
-        should: [longValueQuery, doubleValueQuery, stringValueQuery],
+        should: rangeFields.map((field) =>
+          buildNestedTypedQuery(basePropertyName, field, value, operator)
+        ),
         minimum_should_match: 1,
       },
     };

--- a/openmetadata-ui/src/main/resources/ui/src/utils/QueryBuilderElasticsearchFormatUtils.js
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/QueryBuilderElasticsearchFormatUtils.js
@@ -833,17 +833,23 @@ function buildEsRule(fieldName, value, operator, config, valueSrc) {
     );
 
     // For range operators (between / not_between) the value is a two-element
-    // array [from, to]. Pass the full array so buildExtensionQuery can build
-    // a proper gte/lte range query. This is scoped to numeric types where ES
-    // range queries work correctly. Non-numeric types (e.g. dateTime-cp)
-    // store values as formatted strings where ES range comparison is unreliable.
+    // array [from, to]. Pass the full array so buildExtensionQuery can build a
+    // proper gte/lte range query. Numeric types (integer/number/timestamp) query
+    // longValue/doubleValue. Date types (date-cp/dateTime-cp/time-cp) are stored
+    // as formatted strings in stringValue; a keyword range is a lexicographic
+    // comparison, which is chronologically correct for the default big-endian,
+    // zero-padded formats (e.g. yyyy-MM-dd HH:mm:ss). Other types collapse to
+    // value[0] since only a single bound is meaningful.
     const isBetweenOp = op === 'between';
-    const isNumericOmType =
+    const isRangeableOmType =
       omPropertyType === 'integer' ||
       omPropertyType === 'number' ||
-      omPropertyType === 'timestamp';
+      omPropertyType === 'timestamp' ||
+      omPropertyType === 'date-cp' ||
+      omPropertyType === 'dateTime-cp' ||
+      omPropertyType === 'time-cp';
     const extensionValue = hasValue
-      ? isBetweenOp && isNumericOmType
+      ? isBetweenOp && isRangeableOmType
         ? value
         : value[0]
       : null;

--- a/openmetadata-ui/src/main/resources/ui/src/utils/QueryBuilderElasticsearchFormatUtils.test.js
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/QueryBuilderElasticsearchFormatUtils.test.js
@@ -16,7 +16,7 @@ import { elasticSearchFormat } from './QueryBuilderElasticsearchFormatUtils';
 
 // Minimal Immutable-compatible tree stub.
 // elasticSearchFormat only calls .get() on the tree and its properties map.
-const makeTree = (operator, value) => ({
+const makeTree = (operator, value, field = 'extension.table.myNumber') => ({
   get(key) {
     if (key === 'type') {
       return 'rule';
@@ -25,7 +25,7 @@ const makeTree = (operator, value) => ({
       return {
         get(k) {
           if (k === 'field') {
-            return 'extension.table.myNumber';
+            return field;
           }
           if (k === 'operator') {
             return operator;
@@ -59,6 +59,12 @@ const configWithNumberType = {
             myNumber: {
               __omPropertyType: 'number',
             },
+            myDateTime: {
+              __omPropertyType: 'dateTime-cp',
+            },
+            myDate: {
+              __omPropertyType: 'date-cp',
+            },
           },
         },
       },
@@ -87,5 +93,56 @@ describe('elasticSearchFormat – extension number field range operators (Issue 
     expect(result).toContain('"must_not"');
     expect(result).toContain('"gte":10');
     expect(result).toContain('"lte":50');
+  });
+});
+
+describe('elasticSearchFormat – extension dateTime field range operators (Issue #28829)', () => {
+  it('dateTime between: should include both gte (from) and lte (to) bounds', () => {
+    const result = JSON.stringify(
+      elasticSearchFormat(
+        makeTree(
+          'between',
+          ['2024-01-01 00:00:00', '2024-12-31 23:59:59'],
+          'extension.table.myDateTime'
+        ),
+        configWithNumberType
+      )
+    );
+
+    expect(result).toContain('"gte":"2024-01-01 00:00:00"');
+    expect(result).toContain('"lte":"2024-12-31 23:59:59"');
+  });
+
+  it('dateTime not_between: should wrap both gte/lte bounds in a must_not clause', () => {
+    const result = JSON.stringify(
+      elasticSearchFormat(
+        makeTree(
+          'not_between',
+          ['2024-01-01 00:00:00', '2024-12-31 23:59:59'],
+          'extension.table.myDateTime'
+        ),
+        configWithNumberType
+      )
+    );
+
+    expect(result).toContain('"must_not"');
+    expect(result).toContain('"gte":"2024-01-01 00:00:00"');
+    expect(result).toContain('"lte":"2024-12-31 23:59:59"');
+  });
+
+  it('date between: should include both gte (from) and lte (to) bounds', () => {
+    const result = JSON.stringify(
+      elasticSearchFormat(
+        makeTree(
+          'between',
+          ['2024-01-01', '2024-12-31'],
+          'extension.table.myDate'
+        ),
+        configWithNumberType
+      )
+    );
+
+    expect(result).toContain('"gte":"2024-01-01"');
+    expect(result).toContain('"lte":"2024-12-31"');
   });
 });

--- a/openmetadata-ui/src/main/resources/ui/src/utils/QueryBuilderElasticsearchFormatUtils.test.js
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/QueryBuilderElasticsearchFormatUtils.test.js
@@ -111,6 +111,10 @@ describe('elasticSearchFormat – extension dateTime field range operators (Issu
 
     expect(result).toContain('"gte":"2024-01-01 00:00:00"');
     expect(result).toContain('"lte":"2024-12-31 23:59:59"');
+    // Date strings must not be routed into numeric longValue/doubleValue ranges
+    // (that raises an ES number_format_exception and fails the whole search).
+    expect(result).not.toContain('customPropertiesTyped.longValue');
+    expect(result).not.toContain('customPropertiesTyped.doubleValue');
   });
 
   it('dateTime not_between: should wrap both gte/lte bounds in a must_not clause', () => {


### PR DESCRIPTION
## Description

Fixes #28829

Filtering data assets by a **dateTime / date custom property** with the `between` (or `not_between`) operator in Explore returned incorrect results — the filter matched every entity that had the property set, ignoring the specified range.

## Root cause

This is the same class of bug as the numeric-property fix in #27525, scoped one type too narrowly.

In `buildEsRule` (`QueryBuilderElasticsearchFormatUtils.js`), the `between`/`not_between` value is a two-element array `[from, to]`. The full array was only forwarded to `buildExtensionQuery` for **numeric** OM types (`integer`/`number`/`timestamp`). For `date-cp`/`dateTime-cp` the value collapsed to `value[0]`, so `buildNestedTypedQuery`'s between branch (which requires a 2-element array) fell through and emitted an **empty range**:

```json
{ "range": { "customPropertiesTyped.stringValue": {} } }
```

An empty ES range matches every document that has the field — hence "between doesn't work / returns all results".

## Fix

Broaden the range passthrough to include `date-cp` / `dateTime-cp` / `time-cp`. These are stored as formatted strings in `customPropertiesTyped.stringValue` (mapped as `keyword`), so a `gte`/`lte` range is a lexicographic comparison — chronologically correct for the default big-endian, zero-padded formats (e.g. `yyyy-MM-dd HH:mm:ss`, `yyyy-MM-dd`). Both the stored value and the query bounds use the same admin-configured format.

## Known limitation (pre-existing, not introduced here)

For a custom property configured with a **non-sortable format** (e.g. `dd-MM-yyyy`, `MM/dd/yyyy`, `hh:mm a`), lexicographic ordering != chronological ordering, so the range can still be wrong. This is a property of string storage and affects all operators equally; a format-independent fix would require indexing an epoch `long` sub-field plus a reindex (separate follow-up).

## Tests

Added unit tests in `QueryBuilderElasticsearchFormatUtils.test.js`:
- dateTime `between` — asserts both `gte` and `lte` bounds are present
- dateTime `not_between` — asserts both bounds wrapped in `must_not`
- date `between` — asserts both bounds present

Verified RED without the fix (empty range) and GREEN with it.

## Cherry-picks

Targets `1.13.x` and `1.12.13`.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes custom-property date range filters in advanced search. The main changes are:

- Preserves both bounds for date, dateTime, and time custom-property `between` filters.
- Routes date-like custom-property range queries through `stringValue` only.
- Adds unit tests for date and dateTime range query output.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge.

- No blocking issues found in the changed code.

</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-ui/src/main/resources/ui/src/utils/QueryBuilderElasticsearchFormatUtils.js | Updates custom-property range query generation for date-like values. |
| openmetadata-ui/src/main/resources/ui/src/utils/QueryBuilderElasticsearchFormatUtils.test.js | Adds tests for date and dateTime custom-property range filters. |

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(advanced-search): route date-type ra..."](https://github.com/open-metadata/openmetadata/commit/cf18652373450b7c0ac18950a05884981b23968a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44103133)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Context used - CLAUDE.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=52f0d9d9-cad1-4e7d-b070-de181a0aa5e7))
- Context used - openmetadata-ui-core-components/CLAUDE.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=41754627-b2bf-474b-8082-f37ef1a07013))
- Context used - AGENTS.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=ef262f5f-911f-44f3-8d2d-e9cb1579c8c8))
</details>

<!-- /greptile_comment -->