### PR TITLE
Fixes #30037: refactor(ingestion): migrate Looker test-connection to the @check framework

### DIFF
--- a/ingestion/src/metadata/core/connections/test_connection/checks/dashboard.py
+++ b/ingestion/src/metadata/core/connections/test_connection/checks/dashboard.py
@@ -47,11 +47,14 @@ class DashboardStep(StepName):
     GetDashboards = "GetDashboards"
     ServerInfo = "ServerInfo"
     ValidateApiVersion = "ValidateApiVersion"
+    ValidateVersion = "ValidateVersion"
     ValidateSiteUrl = "ValidateSiteUrl"
     GetWorkbooks = "GetWorkbooks"
     GetViews = "GetViews"
     GetOwners = "GetOwners"
     GetDataModels = "GetDataModels"
+    ListDashboards = "ListDashboards"
+    ListLookMLModels = "ListLookMLModels"
 
 
 def _count(number: int, noun: str, cap: int | None = None) -> str:

--- a/ingestion/src/metadata/ingestion/source/dashboard/looker/connection.py
+++ b/ingestion/src/metadata/ingestion/source/dashboard/looker/connection.py
@@ -115,6 +115,10 @@ def _contains_any(*tokens: str) -> Matcher:
     return match
 
 
+# The statuses handled here are the ones the API spec documents for the endpoints
+# these checks call (/login, /user, /versions, /dashboards, /lookml_models): 400,
+# 404 and 429. It documents no 401 anywhere, and no 403 on any of them, so an
+# unmatched status keeps its raw errorLog rather than a made-up diagnosis.
 LOOKER_ERRORS = ErrorPack(
     # Ordered before the generic 404: Looker rejects credentials with a 404 on
     # /login, so the endpoint is what separates them from a wrong host.
@@ -128,19 +132,13 @@ LOOKER_ERRORS = ErrorPack(
         fix="Provide both the Client ID and the Client Secret.",
         doc=API_SDK_DOC,
     ),
-    when(_http_status(401)).diagnose(
-        "Authentication failed",
-        fix="Looker did not accept the credentials. Check the Client ID and Client Secret.",
-        doc=API_SDK_DOC,
-    ),
-    when(_http_status(403)).diagnose(
-        "Insufficient permissions",
-        fix="The credentials are valid but not authorized for this call. Grant the user access to "
-        "the dashboards and models to ingest.",
-    ),
     when(_http_status(404)).diagnose(
         "Resource not found",
         fix="Looker could not find the requested resource. Check that Host Port is the instance URL.",
+    ),
+    when(_http_status(429)).diagnose(
+        "Rate limited by Looker",
+        fix="Looker is throttling the requests. Retry once the instance is under less load.",
     ),
     when(Matchers.exception(UnsupportedApiVersionError)).diagnose(
         f"API {SDK_API_VERSION} is not supported by this instance",

--- a/ingestion/src/metadata/ingestion/source/dashboard/looker/connection.py
+++ b/ingestion/src/metadata/ingestion/source/dashboard/looker/connection.py
@@ -59,6 +59,10 @@ API_SDK_DOC = "https://cloud.google.com/looker/docs/api-sdk"
 # https://cloud.google.com/looker/docs/r/err/4.0/404/post/api/4.0/login
 _ERROR_DOC_URL = re.compile(r"/r/err/[^/]+/(?P<status>\d{3})/(?P<path>\S*)", re.IGNORECASE)
 
+# A 404 from a server that is not Looker. Word-bounded so a port or byte count
+# containing 404 does not match.
+_FOREIGN_404 = re.compile(r"\b404\b|not found", re.IGNORECASE)
+
 
 class UnsupportedApiVersionError(Exception):
     """The Looker instance does not list the API version the SDK speaks."""
@@ -67,10 +71,12 @@ class UnsupportedApiVersionError(Exception):
 def _error_doc(error: BaseException) -> re.Match[str] | None:
     """Parse the status and endpoint from the documentation URL the error carries.
 
-    Matches ``str(error)``: an API call deserializes the URL onto
-    ``documentation_url``, a failed login raises the raw body as the message.
+    Searches the message and the attribute: an API call deserializes the URL onto
+    ``documentation_url``, a failed login raises the raw body as the message, and
+    only newer ``looker-sdk`` renders the attribute in ``__str__``.
     """
-    return _ERROR_DOC_URL.search(str(error))
+    doc_url = getattr(error, "documentation_url", "") or ""
+    return _ERROR_DOC_URL.search(f"{error} {doc_url}")
 
 
 def _http_status(*codes: int) -> Matcher:
@@ -88,6 +94,11 @@ def _login_rejected(error: BaseException) -> bool:
         (match := _error_doc(current)) is not None and match["status"] == "404" and "login" in match["path"].lower()
         for current in exception_chain(error)
     )
+
+
+def _matches(pattern: re.Pattern[str]) -> Matcher:
+    """Match ``pattern`` against the error (or its cause chain)."""
+    return lambda error: any(pattern.search(str(current)) for current in exception_chain(error))
 
 
 def _contains_any(*tokens: str) -> Matcher:
@@ -166,8 +177,9 @@ LOOKER_ERRORS = ErrorPack(
         doc=API_SDK_DOC,
     ),
     # Last: a 404 from something that is not Looker - a real one carries an error
-    # document and is matched above.
-    when(_contains_any("404", "not found")).diagnose(
+    # document and is matched above. The status is matched on a word boundary so a
+    # port or byte count that happens to contain 404 does not look like one.
+    when(_matches(_FOREIGN_404)).diagnose(
         "The host is not serving the Looker API",
         fix="A server answered but did not return a Looker error. Check that Host Port points at the Looker instance.",
     ),

--- a/ingestion/src/metadata/ingestion/source/dashboard/looker/connection.py
+++ b/ingestion/src/metadata/ingestion/source/dashboard/looker/connection.py
@@ -45,6 +45,8 @@ from metadata.generated.schema.entity.services.connections.dashboard.lookerConne
 from metadata.ingestion.connections.connection import BaseConnection
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     from metadata.core.connections.test_connection import ChecksProvider
     from metadata.core.connections.test_connection.classifier import Matcher
 
@@ -186,20 +188,6 @@ LOOKER_ERRORS = ErrorPack(
 ).including(NETWORK_ERRORS)
 
 
-def get_connection(connection: LookerConnectionConfig) -> Looker40SDK:
-    """
-    Create connection
-    """
-    if not os.environ.get("LOOKERSDK_CLIENT_ID"):
-        os.environ["LOOKERSDK_CLIENT_ID"] = connection.clientId
-    if not os.environ.get("LOOKERSDK_CLIENT_SECRET"):
-        os.environ["LOOKERSDK_CLIENT_SECRET"] = connection.clientSecret.get_secret_value()
-    if not os.environ.get("LOOKERSDK_BASE_URL"):
-        os.environ["LOOKERSDK_BASE_URL"] = str(connection.hostPort)
-
-    return looker_sdk.init40()
-
-
 class LookerChecks:
     """Test-connection checks for Looker.
 
@@ -207,35 +195,28 @@ class LookerChecks:
     API3 credentials or an unreachable host fail there and the remaining steps are
     skipped rather than each re-dialling the instance.
 
-    The SDK is built lazily inside the first check, never at construction: it
-    reads credentials into the environment and the checks must not run before the
-    runner's gate, or a failure would surface as a raw workflow error instead of a
-    classified ``CheckAccess`` failure.
+    ``connect`` is ``BaseConnection.client`` underneath, so every step shares the
+    one client the connection owns and closes. It is a thunk rather than the
+    client itself so the build - which reads the credentials into the environment
+    - still happens inside the first check, never while the provider is assembled.
     """
 
     errors = LOOKER_ERRORS
 
-    def __init__(self, connection: LookerConnectionConfig) -> None:
-        self._connection = connection
-        self._looker_client: Looker40SDK | None = None
-
-    def _client(self) -> Looker40SDK:
-        """Build (once) and return the SDK. Only ever called from inside a check."""
-        if self._looker_client is None:
-            self._looker_client = get_connection(self._connection)
-        return self._looker_client
+    def __init__(self, connect: Callable[[], Looker40SDK]) -> None:
+        self._connect = connect
 
     @check(DashboardStep.CheckAccess)
     def check_access(self) -> Evidence:
         return verify_access(
-            lambda: self._client().me(),
+            lambda: self._connect().me(),
             command="log in and read the authenticated user",
         )
 
     @check(DashboardStep.ValidateVersion)
     def validate_version(self) -> Evidence:
         command = "list the API versions the instance supports"
-        versions = call_endpoint(lambda: self._client().versions(), command=command)
+        versions = call_endpoint(lambda: self._connect().versions(), command=command)
         supported = [version.version for version in versions.supported_versions or []]
         if SDK_API_VERSION not in supported:
             raise CheckError(
@@ -250,7 +231,7 @@ class LookerChecks:
     @check(DashboardStep.ListDashboards)
     def list_dashboards(self) -> Evidence:
         return fetch_list(
-            lambda: self._client().all_dashboards(fields="id,title"),
+            lambda: self._connect().all_dashboards(fields="id,title"),
             noun="dashboard",
             command="list dashboards",
             empty_caveat=Diagnosis(
@@ -264,7 +245,7 @@ class LookerChecks:
     @check(DashboardStep.ListLookMLModels)
     def list_lookml_models(self) -> Evidence:
         return fetch_list(
-            lambda: self._client().all_lookml_models(limit=1),
+            lambda: self._connect().all_lookml_models(limit=1),
             noun="LookML model",
             command="list LookML models",
             empty_caveat=Diagnosis(
@@ -278,7 +259,17 @@ class LookerChecks:
 
 class LookerConnection(BaseConnection[LookerConnectionConfig, Looker40SDK]):
     def _get_client(self) -> Looker40SDK:
-        return get_connection(self.service_connection)
+        connection = self.service_connection
+        if not os.environ.get("LOOKERSDK_CLIENT_ID"):
+            os.environ["LOOKERSDK_CLIENT_ID"] = connection.clientId
+        if not os.environ.get("LOOKERSDK_CLIENT_SECRET"):
+            os.environ["LOOKERSDK_CLIENT_SECRET"] = connection.clientSecret.get_secret_value()
+        if not os.environ.get("LOOKERSDK_BASE_URL"):
+            os.environ["LOOKERSDK_BASE_URL"] = str(connection.hostPort)
+
+        return looker_sdk.init40()
 
     def checks(self) -> ChecksProvider:
-        return LookerChecks(connection=self.service_connection)
+        # Pass a thunk, not self.client: the checks then run against the one
+        # client this connection owns, and its build still lands inside the gate.
+        return LookerChecks(connect=lambda: self.client)

--- a/ingestion/src/metadata/ingestion/source/dashboard/looker/connection.py
+++ b/ingestion/src/metadata/ingestion/source/dashboard/looker/connection.py
@@ -65,17 +65,16 @@ class UnsupportedApiVersionError(Exception):
 
 
 def _error_doc(error: BaseException) -> re.Match[str] | None:
-    """Parse the status and path out of a Looker SDKError's documentation URL.
+    """Parse the status and endpoint out of the Looker documentation URL an error carries.
 
-    ``SDKError`` carries no status code of its own: the response body is
-    deserialized into ``message``/``documentation_url``, and it is the latter that
-    encodes both the status and the endpoint that produced it. When Looker answers
-    with a non-JSON body (a proxy's HTML 404), deserialization fails and the raw
-    body becomes the message with no documentation URL - such errors fall through
-    to the text rules below.
+    ``SDKError`` has no status code of its own; the documentation URL Looker
+    returns with the error body encodes both the status and the endpoint that
+    produced it. It reaches us two ways: an API call deserializes it onto
+    ``documentation_url``, while a failed *login* raises the raw response body as
+    the message, leaving that attribute empty. Matching ``str(error)`` - which
+    renders both - covers the two shapes with one rule.
     """
-    doc_url = getattr(error, "documentation_url", None)
-    return _ERROR_DOC_URL.search(doc_url) if isinstance(doc_url, str) else None
+    return _ERROR_DOC_URL.search(str(error))
 
 
 def _http_status(*codes: int) -> Matcher:
@@ -144,9 +143,9 @@ LOOKER_ERRORS = ErrorPack(
     ),
     when(_http_status(404)).diagnose(
         "Resource not found",
-        fix="Looker could not find the requested resource (404). Check that Host Port is the URL of "
-        "the Looker API host, e.g. https://<instance>.cloud.looker.com (port 19999 for a hosted "
-        "instance that serves the API on its own port), with no trailing path.",
+        fix="Looker could not find the requested resource (404). Check that Host Port is the root URL "
+        "of the Looker API, e.g. https://<instance>.cloud.looker.com (port 19999 on a self-hosted "
+        "instance).",
     ),
     when(Matchers.exception(UnsupportedApiVersionError)).diagnose(
         f"API {SDK_API_VERSION} is not supported by this instance",
@@ -184,6 +183,14 @@ LOOKER_ERRORS = ErrorPack(
         "Cannot reach the host",
         fix="Check Host Port, the network route, and that the Looker instance is online and "
         "reachable from where ingestion runs.",
+    ),
+    # Last: something answered, but not as Looker - the body carries no Looker error
+    # document, so a real Looker 404 (which does, and is matched above) never lands here.
+    when(_contains_any("404", "not found")).diagnose(
+        "The host is not serving the Looker API",
+        fix="A server answered but did not return a Looker error, so Host Port does not reach the "
+        "Looker API. Check it points at the Looker instance, e.g. https://<instance>.cloud.looker.com "
+        "(port 19999 on a self-hosted instance).",
     ),
 ).including(NETWORK_ERRORS)
 

--- a/ingestion/src/metadata/ingestion/source/dashboard/looker/connection.py
+++ b/ingestion/src/metadata/ingestion/source/dashboard/looker/connection.py
@@ -43,6 +43,7 @@ from metadata.generated.schema.entity.services.connections.dashboard.lookerConne
     LookerConnection as LookerConnectionConfig,
 )
 from metadata.ingestion.connections.connection import BaseConnection
+from metadata.utils.constants import THREE_MIN
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -96,9 +97,16 @@ def _login_rejected(error: BaseException) -> bool:
     )
 
 
-def _matches(pattern: re.Pattern[str]) -> Matcher:
-    """Match ``pattern`` against the error (or its cause chain)."""
-    return lambda error: any(pattern.search(str(current)) for current in exception_chain(error))
+def _foreign_404(error: BaseException) -> bool:
+    """Match a 404 from a server that is not Looker.
+
+    Requires the absence of a Looker error document: a Looker error carrying a
+    status this pack does not diagnose (e.g. a 400 reading "parameter not found")
+    keeps its raw errorLog instead of being blamed on Host Port.
+    """
+    chain = list(exception_chain(error))
+    has_error_doc = any(_error_doc(current) is not None for current in chain)
+    return not has_error_doc and any(_FOREIGN_404.search(str(current)) for current in chain)
 
 
 def _contains_any(*tokens: str) -> Matcher:
@@ -176,10 +184,9 @@ LOOKER_ERRORS = ErrorPack(
         "instance. Check the Client ID and Client Secret, then Host Port.",
         doc=API_SDK_DOC,
     ),
-    # Last: a 404 from something that is not Looker - a real one carries an error
-    # document and is matched above. The status is matched on a word boundary so a
-    # port or byte count that happens to contain 404 does not look like one.
-    when(_matches(_FOREIGN_404)).diagnose(
+    # Last: a 404 from something that is not Looker - any Looker error carries an
+    # error document, whether or not this pack diagnoses its status.
+    when(_foreign_404).diagnose(
         "The host is not serving the Looker API",
         fix="A server answered but did not return a Looker error. Check that Host Port points at the Looker instance.",
     ),
@@ -271,6 +278,10 @@ class LookerSettings(ApiSettings):
 
 
 class LookerConnection(BaseConnection[LookerConnectionConfig, Looker40SDK]):
+    # Listing dashboards and LookML models can be slow on large instances; keep the
+    # legacy 3-minute budget the imperative handler used, now applied per step.
+    step_timeout_seconds = THREE_MIN
+
     def _get_client(self) -> Looker40SDK:
         return looker_sdk.init40(config_settings=LookerSettings(self.service_connection))
 

--- a/ingestion/src/metadata/ingestion/source/dashboard/looker/connection.py
+++ b/ingestion/src/metadata/ingestion/source/dashboard/looker/connection.py
@@ -86,7 +86,7 @@ def _http_status(*codes: int) -> Matcher:
 
 
 def _login_rejected(error: BaseException) -> bool:
-    """Match Looker rejecting the API3 credentials.
+    """Match Looker rejecting the credentials.
 
     The login endpoint answers a wrong client id or secret with ``404 Not found``
     rather than a 401, so the status alone cannot separate bad credentials from a
@@ -116,42 +116,35 @@ def _contains_any(*tokens: str) -> Matcher:
 
 
 LOOKER_ERRORS = ErrorPack(
-    # Ordered before the generic 404: Looker reports rejected API3 credentials as
-    # a 404 on /login, so the endpoint is what separates them from a wrong host.
+    # Ordered before the generic 404: Looker rejects credentials with a 404 on
+    # /login, so the endpoint is what separates them from a wrong host.
     when(_login_rejected).diagnose(
         "Authentication failed",
-        fix="Looker rejected the API3 credentials. Check the Client ID and Client Secret of the "
-        "API3 key (Admin > Users > Edit > API Keys) and that the key is still enabled.",
+        fix="Looker rejected the credentials. Check the Client ID and Client Secret.",
         doc=API_SDK_DOC,
     ),
     when(Matchers.contains("Required auth credentials not found")).diagnose(
         "Missing credentials",
-        fix="The SDK found no API3 credentials to log in with. Provide both the Client ID and the "
-        "Client Secret in the service configuration.",
+        fix="Provide both the Client ID and the Client Secret.",
         doc=API_SDK_DOC,
     ),
     when(_http_status(401)).diagnose(
         "Authentication failed",
-        fix="Looker did not accept the session (401). Check the Client ID and Client Secret of the "
-        "API3 key and that it has not been disabled.",
+        fix="Looker did not accept the credentials. Check the Client ID and Client Secret.",
         doc=API_SDK_DOC,
     ),
     when(_http_status(403)).diagnose(
         "Insufficient permissions",
-        fix="The API3 user is authenticated but not authorized for this call (403). Grant it a role "
-        "with the see_lookml, see_looks, and see_user_dashboards permissions on the models to ingest.",
+        fix="The credentials are valid but not authorized for this call. Grant the user access to "
+        "the dashboards and models to ingest.",
     ),
     when(_http_status(404)).diagnose(
         "Resource not found",
-        fix="Looker could not find the requested resource (404). Check that Host Port is the root URL "
-        "of the Looker API, e.g. https://<instance>.cloud.looker.com (port 19999 on a self-hosted "
-        "instance).",
+        fix="Looker could not find the requested resource. Check that Host Port is the instance URL.",
     ),
     when(Matchers.exception(UnsupportedApiVersionError)).diagnose(
         f"API {SDK_API_VERSION} is not supported by this instance",
-        fix=f"The instance does not list API {SDK_API_VERSION} among its supported versions, which "
-        "is the version this connector speaks. Upgrade the Looker instance, or enable the API "
-        f"{SDK_API_VERSION} endpoint on it.",
+        fix=f"This connector uses API {SDK_API_VERSION}, which the instance does not list as supported.",
         doc=API_SDK_DOC,
     ),
     # The transport flattens every IOError into an SDKError message, so these
@@ -162,45 +155,38 @@ LOOKER_ERRORS = ErrorPack(
         _contains_any("failed to resolve", "name or service not known", "nodename nor servname", "getaddrinfo failed")
     ).diagnose(
         "Host could not be resolved",
-        fix="Check Host Port for typos and that DNS can resolve it from where ingestion runs.",
+        fix="Check Host Port and that DNS resolves it from where ingestion runs.",
     ),
     when(_contains_any("connection refused")).diagnose(
         "Connection refused",
-        fix="The host answered but nothing is listening on that port; check the port in Host Port "
-        "and that the Looker API is served on it.",
+        fix="Nothing is listening on that port. Check the host and port in Host Port.",
     ),
     when(_contains_any("timed out", "timeout")).diagnose(
         "Connection timed out",
-        fix="The host did not answer in time; check that a firewall, security group, or network ACL "
-        "allows access to this host and port.",
+        fix="The host did not answer in time. Check that the network allows access to this host and port.",
     ),
     when(_contains_any("certificate verify failed", "sslerror", "ssl: ")).diagnose(
         "TLS verification failed",
-        fix="The Looker instance's certificate could not be verified. Install a certificate trusted "
-        "by the host running ingestion, or use a Host Port whose certificate validates.",
+        fix="The instance's certificate could not be verified from where ingestion runs.",
     ),
     when(_contains_any("max retries exceeded", "connection aborted", "connection error")).diagnose(
         "Cannot reach the host",
-        fix="Check Host Port, the network route, and that the Looker instance is online and "
-        "reachable from where ingestion runs.",
+        fix="Check Host Port and that the instance is reachable from where ingestion runs.",
     ),
     # Looker answers a rejected sign-in with a generic HTML 404 page carrying no
     # error document, and serves that same page for a host that is not a live
     # instance - the two are indistinguishable here, so the fix names both.
     when(_contains_any("looker is unavailable", "looker not found")).diagnose(
         "Authentication failed",
-        fix="Looker returned its generic 404 page, which it serves both for a wrong Client ID or "
-        "Client Secret and for a host that is not a live Looker instance. Check the API3 credentials "
-        "(Admin > Users > Edit > API Keys) and that Host Port points at the instance.",
+        fix="Looker returns this same page for wrong credentials and for a host that is not a live "
+        "instance. Check the Client ID and Client Secret, then Host Port.",
         doc=API_SDK_DOC,
     ),
     # Last: something answered, but not as Looker - the body carries no Looker error
     # document, so a real Looker 404 (which does, and is matched above) never lands here.
     when(_contains_any("404", "not found")).diagnose(
         "The host is not serving the Looker API",
-        fix="A server answered but did not return a Looker error, so Host Port does not reach the "
-        "Looker API. Check it points at the Looker instance, e.g. https://<instance>.cloud.looker.com "
-        "(port 19999 on a self-hosted instance).",
+        fix="A server answered but did not return a Looker error. Check that Host Port points at the Looker instance.",
     ),
 ).including(NETWORK_ERRORS)
 
@@ -209,7 +195,7 @@ class LookerChecks:
     """Test-connection checks for Looker.
 
     ``CheckAccess`` is the gate: the SDK logs in lazily on its first call, so bad
-    API3 credentials or an unreachable host fail there and the remaining steps are
+    credentials or an unreachable host fail there and the remaining steps are
     skipped rather than each re-dialling the instance.
 
     ``connect`` is ``BaseConnection.client`` underneath, so every step shares the
@@ -253,9 +239,8 @@ class LookerChecks:
             command="list dashboards",
             empty_caveat=Diagnosis(
                 title="No dashboards visible",
-                remediation="The connection works but returned no dashboards. Confirm the API3 user "
-                "has a role granting see_user_dashboards and access to the folders that hold them - "
-                "an empty result can also mean the listing was filtered rather than genuinely empty.",
+                remediation="The connection works but returned no dashboards. Confirm the user can see "
+                "the dashboards to ingest.",
             ),
         )
 
@@ -267,9 +252,8 @@ class LookerChecks:
             command="list LookML models",
             empty_caveat=Diagnosis(
                 title="No LookML models visible",
-                remediation="The connection works but returned no LookML model. Grant the API3 user "
-                "a role with the see_lookml permission on the models to ingest; without them, "
-                "lineage between dashboards and their source tables will not be present.",
+                remediation="The connection works but returned no LookML model. Grant the user access "
+                "to the models to ingest; without them, lineage will not be present.",
             ),
         )
 

--- a/ingestion/src/metadata/ingestion/source/dashboard/looker/connection.py
+++ b/ingestion/src/metadata/ingestion/source/dashboard/looker/connection.py
@@ -96,28 +96,36 @@ def _login_rejected(error: BaseException) -> bool:
     )
 
 
-def _foreign_404(error: BaseException) -> bool:
-    """Match a 404 from a server that is not Looker.
+def _has_error_doc(error: BaseException) -> bool:
+    """Whether any error in the chain carries a Looker error document.
 
-    Requires the absence of a Looker error document: a Looker error carrying a
-    status this pack does not diagnose (e.g. a 400 reading "parameter not found")
-    keeps its raw errorLog instead of being blamed on Host Port.
+    A real transport failure is flattened into a message with no such document, so
+    its presence marks a structured Looker answer that must keep its raw errorLog
+    rather than be diagnosed from incidental text.
     """
-    chain = list(exception_chain(error))
-    has_error_doc = any(_error_doc(current) is not None for current in chain)
-    return not has_error_doc and any(_FOREIGN_404.search(str(current)) for current in chain)
+    return any(_error_doc(current) is not None for current in exception_chain(error))
 
 
-def _contains_any(*tokens: str) -> Matcher:
-    """Match when any of ``tokens`` appears in the error (or its cause chain).
+def _foreign_404(error: BaseException) -> bool:
+    """Match a 404 from a server that is not Looker: a 404 token, but no Looker
+    error document (a Looker 404 carries one and is matched above)."""
+    return not _has_error_doc(error) and any(_FOREIGN_404.search(str(current)) for current in exception_chain(error))
 
-    The SDK's transport re-raises every ``IOError`` as an ``SDKError`` whose message
-    is the stringified original, so DNS, refused, TLS and timeout errors lose their
-    type and can only be matched on text.
+
+def _transport_text(*tokens: str) -> Matcher:
+    """Match a flattened transport error by text: the SDK re-raises every
+    ``IOError`` as an ``SDKError`` whose message is the stringified original, so
+    DNS, refused, TLS and timeout errors lose their type.
+
+    Guarded by the absence of a Looker error document, so a structured Looker
+    error whose message happens to contain a transport token (e.g. a 400 reading
+    "timeout") keeps its raw errorLog instead of being blamed on the network.
     """
     lowered = tuple(token.lower() for token in tokens)
 
     def match(error: BaseException) -> bool:
+        if _has_error_doc(error):
+            return False
         chain = " ".join(str(current) for current in exception_chain(error)).lower()
         return any(token in chain for token in lowered)
 
@@ -151,33 +159,34 @@ LOOKER_ERRORS = ErrorPack(
         fix=f"This connector uses API {SDK_API_VERSION}, which the instance does not list as supported.",
         doc=API_SDK_DOC,
     ),
-    # Matched on text: the transport flattens these into an SDKError message. They
-    # precede the type-based NETWORK_ERRORS, which only fires outside the transport.
+    # Matched on text: the transport flattens these into an SDKError message. Guarded
+    # so a structured Looker error is not read as a transport failure; the type-based
+    # NETWORK_ERRORS below only fires outside the transport.
     when(
-        _contains_any("failed to resolve", "name or service not known", "nodename nor servname", "getaddrinfo failed")
+        _transport_text("failed to resolve", "name or service not known", "nodename nor servname", "getaddrinfo failed")
     ).diagnose(
         "Host could not be resolved",
         fix="Check Host Port and that DNS resolves it from where ingestion runs.",
     ),
-    when(_contains_any("connection refused")).diagnose(
+    when(_transport_text("connection refused")).diagnose(
         "Connection refused",
         fix="Nothing is listening on that port. Check the host and port in Host Port.",
     ),
-    when(_contains_any("timed out", "timeout")).diagnose(
+    when(_transport_text("timed out", "timeout")).diagnose(
         "Connection timed out",
         fix="The host did not answer in time. Check that the network allows access to this host and port.",
     ),
-    when(_contains_any("certificate verify failed", "sslerror", "ssl: ")).diagnose(
+    when(_transport_text("certificate verify failed", "sslerror", "ssl: ")).diagnose(
         "TLS verification failed",
         fix="The instance's certificate could not be verified from where ingestion runs.",
     ),
-    when(_contains_any("max retries exceeded", "connection aborted", "connection error")).diagnose(
+    when(_transport_text("max retries exceeded", "connection aborted", "connection error")).diagnose(
         "Cannot reach the host",
         fix="Check Host Port and that the instance is reachable from where ingestion runs.",
     ),
     # Looker serves this page, with no error document, both for a rejected sign-in
     # and for a host that is not a live instance; the two cannot be told apart.
-    when(_contains_any("looker is unavailable", "looker not found")).diagnose(
+    when(_transport_text("looker is unavailable", "looker not found")).diagnose(
         "Authentication failed",
         fix="Looker returns this same page for wrong credentials and for a host that is not a live "
         "instance. Check the Client ID and Client Secret, then Host Port.",

--- a/ingestion/src/metadata/ingestion/source/dashboard/looker/connection.py
+++ b/ingestion/src/metadata/ingestion/source/dashboard/looker/connection.py
@@ -13,75 +13,272 @@
 Source connection handler
 """
 
+from __future__ import annotations
+
 import os
-from typing import Optional
+import re
+from typing import TYPE_CHECKING
 
 import looker_sdk
 from looker_sdk.sdk.api40.methods import Looker40SDK
 
-from metadata.generated.schema.entity.automations.workflow import (
-    Workflow as AutomationWorkflow,
+from metadata.core.connections.test_connection import (
+    Diagnosis,
+    ErrorPack,
+    Evidence,
+    Matchers,
+    check,
+    when,
 )
+from metadata.core.connections.test_connection.check import CheckError
+from metadata.core.connections.test_connection.checks.dashboard import (
+    DashboardStep,
+    call_endpoint,
+    fetch_list,
+    verify_access,
+)
+from metadata.core.connections.test_connection.classifier import exception_chain
+from metadata.core.connections.test_connection.network import NETWORK_ERRORS
 from metadata.generated.schema.entity.services.connections.dashboard.lookerConnection import (
     LookerConnection as LookerConnectionConfig,
 )
-from metadata.generated.schema.entity.services.connections.testConnectionResult import (
-    TestConnectionResult,
-)
 from metadata.ingestion.connections.connection import BaseConnection
-from metadata.ingestion.connections.test_connections import test_connection_steps
-from metadata.ingestion.ometa.ometa_api import OpenMetadata
-from metadata.utils.constants import THREE_MIN
+
+if TYPE_CHECKING:
+    from metadata.core.connections.test_connection import ChecksProvider
+    from metadata.core.connections.test_connection.classifier import Matcher
+
+SDK_API_VERSION = "4.0"
+
+API_SDK_DOC = "https://cloud.google.com/looker/docs/api-sdk"
+
+# Looker encodes the HTTP status of a failed call in the documentation URL it
+# returns with the error body, e.g.
+# https://cloud.google.com/looker/docs/r/err/4.0/404/post/api/4.0/login
+_ERROR_DOC_URL = re.compile(r"/r/err/[^/]+/(?P<status>\d{3})/(?P<path>\S*)", re.IGNORECASE)
+
+
+class UnsupportedApiVersionError(Exception):
+    """The Looker instance does not list the API version the SDK speaks."""
+
+
+def _error_doc(error: BaseException) -> re.Match[str] | None:
+    """Parse the status and path out of a Looker SDKError's documentation URL.
+
+    ``SDKError`` carries no status code of its own: the response body is
+    deserialized into ``message``/``documentation_url``, and it is the latter that
+    encodes both the status and the endpoint that produced it. When Looker answers
+    with a non-JSON body (a proxy's HTML 404), deserialization fails and the raw
+    body becomes the message with no documentation URL - such errors fall through
+    to the text rules below.
+    """
+    doc_url = getattr(error, "documentation_url", None)
+    return _ERROR_DOC_URL.search(doc_url) if isinstance(doc_url, str) else None
+
+
+def _http_status(*codes: int) -> Matcher:
+    """Match a Looker REST error by the HTTP status of the call that failed."""
+    wanted = frozenset(str(code) for code in codes)
+    return lambda error: any(
+        (match := _error_doc(current)) is not None and match["status"] in wanted for current in exception_chain(error)
+    )
+
+
+def _login_rejected(error: BaseException) -> bool:
+    """Match Looker rejecting the API3 credentials.
+
+    The login endpoint answers a wrong client id or secret with ``404 Not found``
+    rather than a 401, so the status alone cannot separate bad credentials from a
+    wrong host; the endpoint that produced it can.
+    """
+    return any(
+        (match := _error_doc(current)) is not None and match["status"] == "404" and "login" in match["path"].lower()
+        for current in exception_chain(error)
+    )
+
+
+def _contains_any(*tokens: str) -> Matcher:
+    """Match when any of ``tokens`` appears in the error (or its cause chain).
+
+    The SDK's transport catches every ``IOError`` - DNS failures, refused
+    connections, TLS errors, timeouts - and re-raises it as an ``SDKError`` whose
+    message is the stringified original, so the underlying exception *type* is
+    lost and these conditions can only be matched on text.
+    """
+    lowered = tuple(token.lower() for token in tokens)
+
+    def match(error: BaseException) -> bool:
+        chain = " ".join(str(current) for current in exception_chain(error)).lower()
+        return any(token in chain for token in lowered)
+
+    return match
+
+
+LOOKER_ERRORS = ErrorPack(
+    # Ordered before the generic 404: Looker reports rejected API3 credentials as
+    # a 404 on /login, so the endpoint is what separates them from a wrong host.
+    when(_login_rejected).diagnose(
+        "Authentication failed",
+        fix="Looker rejected the API3 credentials. Check the Client ID and Client Secret of the "
+        "API3 key (Admin > Users > Edit > API Keys) and that the key is still enabled.",
+        doc=API_SDK_DOC,
+    ),
+    when(Matchers.contains("Required auth credentials not found")).diagnose(
+        "Missing credentials",
+        fix="The SDK found no API3 credentials to log in with. Provide both the Client ID and the "
+        "Client Secret in the service configuration.",
+        doc=API_SDK_DOC,
+    ),
+    when(_http_status(401)).diagnose(
+        "Authentication failed",
+        fix="Looker did not accept the session (401). Check the Client ID and Client Secret of the "
+        "API3 key and that it has not been disabled.",
+        doc=API_SDK_DOC,
+    ),
+    when(_http_status(403)).diagnose(
+        "Insufficient permissions",
+        fix="The API3 user is authenticated but not authorized for this call (403). Grant it a role "
+        "with the see_lookml, see_looks, and see_user_dashboards permissions on the models to ingest.",
+    ),
+    when(_http_status(404)).diagnose(
+        "Resource not found",
+        fix="Looker could not find the requested resource (404). Check that Host Port is the URL of "
+        "the Looker API host, e.g. https://<instance>.cloud.looker.com (port 19999 for a hosted "
+        "instance that serves the API on its own port), with no trailing path.",
+    ),
+    when(Matchers.exception(UnsupportedApiVersionError)).diagnose(
+        f"API {SDK_API_VERSION} is not supported by this instance",
+        fix=f"The instance does not list API {SDK_API_VERSION} among its supported versions, which "
+        "is the version this connector speaks. Upgrade the Looker instance, or enable the API "
+        f"{SDK_API_VERSION} endpoint on it.",
+        doc=API_SDK_DOC,
+    ),
+    # The transport flattens every IOError into an SDKError message, so these
+    # network conditions are matched on the text of the original exception. They
+    # precede the type-based NETWORK_ERRORS fallback, which only fires for an
+    # error raised outside the transport.
+    when(
+        _contains_any("failed to resolve", "name or service not known", "nodename nor servname", "getaddrinfo failed")
+    ).diagnose(
+        "Host could not be resolved",
+        fix="Check Host Port for typos and that DNS can resolve it from where ingestion runs.",
+    ),
+    when(_contains_any("connection refused")).diagnose(
+        "Connection refused",
+        fix="The host answered but nothing is listening on that port; check the port in Host Port "
+        "and that the Looker API is served on it.",
+    ),
+    when(_contains_any("timed out", "timeout")).diagnose(
+        "Connection timed out",
+        fix="The host did not answer in time; check that a firewall, security group, or network ACL "
+        "allows access to this host and port.",
+    ),
+    when(_contains_any("certificate verify failed", "sslerror", "ssl: ")).diagnose(
+        "TLS verification failed",
+        fix="The Looker instance's certificate could not be verified. Install a certificate trusted "
+        "by the host running ingestion, or use a Host Port whose certificate validates.",
+    ),
+    when(_contains_any("max retries exceeded", "connection aborted", "connection error")).diagnose(
+        "Cannot reach the host",
+        fix="Check Host Port, the network route, and that the Looker instance is online and "
+        "reachable from where ingestion runs.",
+    ),
+).including(NETWORK_ERRORS)
+
+
+def get_connection(connection: LookerConnectionConfig) -> Looker40SDK:
+    """
+    Create connection
+    """
+    if not os.environ.get("LOOKERSDK_CLIENT_ID"):
+        os.environ["LOOKERSDK_CLIENT_ID"] = connection.clientId
+    if not os.environ.get("LOOKERSDK_CLIENT_SECRET"):
+        os.environ["LOOKERSDK_CLIENT_SECRET"] = connection.clientSecret.get_secret_value()
+    if not os.environ.get("LOOKERSDK_BASE_URL"):
+        os.environ["LOOKERSDK_BASE_URL"] = str(connection.hostPort)
+
+    return looker_sdk.init40()
+
+
+class LookerChecks:
+    """Test-connection checks for Looker.
+
+    ``CheckAccess`` is the gate: the SDK logs in lazily on its first call, so bad
+    API3 credentials or an unreachable host fail there and the remaining steps are
+    skipped rather than each re-dialling the instance.
+
+    The SDK is built lazily inside the first check, never at construction: it
+    reads credentials into the environment and the checks must not run before the
+    runner's gate, or a failure would surface as a raw workflow error instead of a
+    classified ``CheckAccess`` failure.
+    """
+
+    errors = LOOKER_ERRORS
+
+    def __init__(self, connection: LookerConnectionConfig) -> None:
+        self._connection = connection
+        self._looker_client: Looker40SDK | None = None
+
+    def _client(self) -> Looker40SDK:
+        """Build (once) and return the SDK. Only ever called from inside a check."""
+        if self._looker_client is None:
+            self._looker_client = get_connection(self._connection)
+        return self._looker_client
+
+    @check(DashboardStep.CheckAccess)
+    def check_access(self) -> Evidence:
+        return verify_access(
+            lambda: self._client().me(),
+            command="log in and read the authenticated user",
+        )
+
+    @check(DashboardStep.ValidateVersion)
+    def validate_version(self) -> Evidence:
+        command = "list the API versions the instance supports"
+        versions = call_endpoint(lambda: self._client().versions(), command=command)
+        supported = [version.version for version in versions.supported_versions or []]
+        if SDK_API_VERSION not in supported:
+            raise CheckError(
+                UnsupportedApiVersionError(
+                    f"API {SDK_API_VERSION} is not listed among the supported versions: "
+                    f"{', '.join(version for version in supported if version) or 'none'}"
+                ),
+                Evidence(command=command),
+            )
+        return Evidence(summary=f"API {SDK_API_VERSION} is supported", command=command)
+
+    @check(DashboardStep.ListDashboards)
+    def list_dashboards(self) -> Evidence:
+        return fetch_list(
+            lambda: self._client().all_dashboards(fields="id,title"),
+            noun="dashboard",
+            command="list dashboards",
+            empty_caveat=Diagnosis(
+                title="No dashboards visible",
+                remediation="The connection works but returned no dashboards. Confirm the API3 user "
+                "has a role granting see_user_dashboards and access to the folders that hold them - "
+                "an empty result can also mean the listing was filtered rather than genuinely empty.",
+            ),
+        )
+
+    @check(DashboardStep.ListLookMLModels)
+    def list_lookml_models(self) -> Evidence:
+        return fetch_list(
+            lambda: self._client().all_lookml_models(limit=1),
+            noun="LookML model",
+            command="list LookML models",
+            empty_caveat=Diagnosis(
+                title="No LookML models visible",
+                remediation="The connection works but returned no LookML model. Grant the API3 user "
+                "a role with the see_lookml permission on the models to ingest; without them, "
+                "lineage between dashboards and their source tables will not be present.",
+            ),
+        )
 
 
 class LookerConnection(BaseConnection[LookerConnectionConfig, Looker40SDK]):
     def _get_client(self) -> Looker40SDK:
-        connection = self.service_connection
-        if not os.environ.get("LOOKERSDK_CLIENT_ID"):
-            os.environ["LOOKERSDK_CLIENT_ID"] = connection.clientId
-        if not os.environ.get("LOOKERSDK_CLIENT_SECRET"):
-            os.environ["LOOKERSDK_CLIENT_SECRET"] = connection.clientSecret.get_secret_value()
-        if not os.environ.get("LOOKERSDK_BASE_URL"):
-            os.environ["LOOKERSDK_BASE_URL"] = str(connection.hostPort)
+        return get_connection(self.service_connection)
 
-        return looker_sdk.init40()
-
-    def test_connection(
-        self,
-        metadata: OpenMetadata,
-        automation_workflow: Optional[AutomationWorkflow] = None,  # noqa: UP045
-        timeout_seconds: Optional[int] = THREE_MIN,  # noqa: UP045
-    ) -> TestConnectionResult:
-        """
-        Test connection. This can be executed either as part
-        of a metadata workflow or during an Automation Workflow
-        """
-        client = self.client
-        service_connection = self.service_connection
-
-        def list_datamodels_test():
-            """
-            Make sure that we get a non-empty result
-            """
-            assert client.all_lookml_models(limit=1)
-
-        def validate_api_version():
-            """
-            Make sure we get a True
-            """
-            assert "4.0" in (api_version.version for api_version in client.versions().supported_versions)  # pyright: ignore[reportOptionalIterable]
-
-        test_fn = {
-            "CheckAccess": client.me,
-            "ValidateVersion": validate_api_version,
-            "ListDashboards": lambda: client.all_dashboards(fields="id,title"),
-            "ListLookMLModels": list_datamodels_test,
-        }
-
-        return test_connection_steps(
-            metadata=metadata,
-            test_fn=test_fn,
-            service_type=service_connection.type.value,  # pyright: ignore[reportOptionalMemberAccess]
-            automation_workflow=automation_workflow,
-            timeout_seconds=timeout_seconds,
-        )
+    def checks(self) -> ChecksProvider:
+        return LookerChecks(connection=self.service_connection)

--- a/ingestion/src/metadata/ingestion/source/dashboard/looker/connection.py
+++ b/ingestion/src/metadata/ingestion/source/dashboard/looker/connection.py
@@ -184,6 +184,13 @@ LOOKER_ERRORS = ErrorPack(
         fix="Check Host Port, the network route, and that the Looker instance is online and "
         "reachable from where ingestion runs.",
     ),
+    # Looker itself serves this page when the hostname does not reach a running
+    # instance, so it is a Looker answer even though it carries no error document.
+    when(_contains_any("looker is unavailable")).diagnose(
+        "The Looker instance is unavailable",
+        fix="Looker answered but reported the instance as unavailable. Check that the instance is "
+        "running and not in maintenance, and that Host Port matches its URL.",
+    ),
     # Last: something answered, but not as Looker - the body carries no Looker error
     # document, so a real Looker 404 (which does, and is matched above) never lands here.
     when(_contains_any("404", "not found")).diagnose(

--- a/ingestion/src/metadata/ingestion/source/dashboard/looker/connection.py
+++ b/ingestion/src/metadata/ingestion/source/dashboard/looker/connection.py
@@ -65,14 +65,10 @@ class UnsupportedApiVersionError(Exception):
 
 
 def _error_doc(error: BaseException) -> re.Match[str] | None:
-    """Parse the status and endpoint out of the Looker documentation URL an error carries.
+    """Parse the status and endpoint from the documentation URL the error carries.
 
-    ``SDKError`` has no status code of its own; the documentation URL Looker
-    returns with the error body encodes both the status and the endpoint that
-    produced it. It reaches us two ways: an API call deserializes it onto
-    ``documentation_url``, while a failed *login* raises the raw response body as
-    the message, leaving that attribute empty. Matching ``str(error)`` - which
-    renders both - covers the two shapes with one rule.
+    Matches ``str(error)``: an API call deserializes the URL onto
+    ``documentation_url``, a failed login raises the raw body as the message.
     """
     return _ERROR_DOC_URL.search(str(error))
 
@@ -86,12 +82,8 @@ def _http_status(*codes: int) -> Matcher:
 
 
 def _login_rejected(error: BaseException) -> bool:
-    """Match Looker rejecting the credentials.
-
-    The login endpoint answers a wrong client id or secret with ``404 Not found``
-    rather than a 401, so the status alone cannot separate bad credentials from a
-    wrong host; the endpoint that produced it can.
-    """
+    """Match Looker rejecting the credentials: a 404 on ``/login``, so the endpoint -
+    not the status - is what separates it from a wrong host."""
     return any(
         (match := _error_doc(current)) is not None and match["status"] == "404" and "login" in match["path"].lower()
         for current in exception_chain(error)
@@ -101,10 +93,9 @@ def _login_rejected(error: BaseException) -> bool:
 def _contains_any(*tokens: str) -> Matcher:
     """Match when any of ``tokens`` appears in the error (or its cause chain).
 
-    The SDK's transport catches every ``IOError`` - DNS failures, refused
-    connections, TLS errors, timeouts - and re-raises it as an ``SDKError`` whose
-    message is the stringified original, so the underlying exception *type* is
-    lost and these conditions can only be matched on text.
+    The SDK's transport re-raises every ``IOError`` as an ``SDKError`` whose message
+    is the stringified original, so DNS, refused, TLS and timeout errors lose their
+    type and can only be matched on text.
     """
     lowered = tuple(token.lower() for token in tokens)
 
@@ -115,13 +106,10 @@ def _contains_any(*tokens: str) -> Matcher:
     return match
 
 
-# The statuses handled here are the ones the API spec documents for the endpoints
-# these checks call (/login, /user, /versions, /dashboards, /lookml_models): 400,
-# 404 and 429. It documents no 401 anywhere, and no 403 on any of them, so an
-# unmatched status keeps its raw errorLog rather than a made-up diagnosis.
+# The API spec documents 400, 404 and 429 for the endpoints these checks call - no
+# 401 anywhere, no 403 on any of them. An unmatched status keeps its raw errorLog.
 LOOKER_ERRORS = ErrorPack(
-    # Ordered before the generic 404: Looker rejects credentials with a 404 on
-    # /login, so the endpoint is what separates them from a wrong host.
+    # Before the generic 404: a rejected login is itself a 404, on /login.
     when(_login_rejected).diagnose(
         "Authentication failed",
         fix="Looker rejected the credentials. Check the Client ID and Client Secret.",
@@ -145,10 +133,8 @@ LOOKER_ERRORS = ErrorPack(
         fix=f"This connector uses API {SDK_API_VERSION}, which the instance does not list as supported.",
         doc=API_SDK_DOC,
     ),
-    # The transport flattens every IOError into an SDKError message, so these
-    # network conditions are matched on the text of the original exception. They
-    # precede the type-based NETWORK_ERRORS fallback, which only fires for an
-    # error raised outside the transport.
+    # Matched on text: the transport flattens these into an SDKError message. They
+    # precede the type-based NETWORK_ERRORS, which only fires outside the transport.
     when(
         _contains_any("failed to resolve", "name or service not known", "nodename nor servname", "getaddrinfo failed")
     ).diagnose(
@@ -171,17 +157,16 @@ LOOKER_ERRORS = ErrorPack(
         "Cannot reach the host",
         fix="Check Host Port and that the instance is reachable from where ingestion runs.",
     ),
-    # Looker answers a rejected sign-in with a generic HTML 404 page carrying no
-    # error document, and serves that same page for a host that is not a live
-    # instance - the two are indistinguishable here, so the fix names both.
+    # Looker serves this page, with no error document, both for a rejected sign-in
+    # and for a host that is not a live instance; the two cannot be told apart.
     when(_contains_any("looker is unavailable", "looker not found")).diagnose(
         "Authentication failed",
         fix="Looker returns this same page for wrong credentials and for a host that is not a live "
         "instance. Check the Client ID and Client Secret, then Host Port.",
         doc=API_SDK_DOC,
     ),
-    # Last: something answered, but not as Looker - the body carries no Looker error
-    # document, so a real Looker 404 (which does, and is matched above) never lands here.
+    # Last: a 404 from something that is not Looker - a real one carries an error
+    # document and is matched above.
     when(_contains_any("404", "not found")).diagnose(
         "The host is not serving the Looker API",
         fix="A server answered but did not return a Looker error. Check that Host Port points at the Looker instance.",
@@ -192,14 +177,11 @@ LOOKER_ERRORS = ErrorPack(
 class LookerChecks:
     """Test-connection checks for Looker.
 
-    ``CheckAccess`` is the gate: the SDK logs in lazily on its first call, so bad
-    credentials or an unreachable host fail there and the remaining steps are
-    skipped rather than each re-dialling the instance.
+    ``CheckAccess`` is the gate: the SDK logs in on its first call, so bad
+    credentials and an unreachable host fail there and the rest are skipped.
 
-    ``connect`` is ``BaseConnection.client`` underneath, so every step shares the
-    one client the connection owns and closes. It is a thunk rather than the
-    client itself so the build - which reads the credentials into the environment
-    - still happens inside the first check, never while the provider is assembled.
+    ``connect`` is ``BaseConnection.client`` - a thunk, so the client is built
+    inside the first check rather than while the provider is assembled.
     """
 
     errors = LOOKER_ERRORS
@@ -257,14 +239,11 @@ class LookerChecks:
 
 
 class LookerSettings(ApiSettings):
-    """Feed the SDK this service's configuration directly.
+    """Configure the SDK from this service's connection.
 
-    The SDK otherwise reads its host and credentials from the process
-    environment, which a long-lived worker only populates once: every later
-    Looker connection in that process would silently reuse the first one's host
-    and credentials. Overriding ``read_config`` keeps each connection's settings
-    to itself - the base class reads it at construction, and the SDK reads it
-    again on each login.
+    Without it the SDK reads host and credentials from the process environment,
+    which a long-lived worker populates once: later connections in that process
+    would reuse the first one's.
     """
 
     def __init__(self, connection: LookerConnectionConfig) -> None:
@@ -284,6 +263,5 @@ class LookerConnection(BaseConnection[LookerConnectionConfig, Looker40SDK]):
         return looker_sdk.init40(config_settings=LookerSettings(self.service_connection))
 
     def checks(self) -> ChecksProvider:
-        # Pass a thunk, not self.client: the checks then run against the one
-        # client this connection owns, and its build still lands inside the gate.
+        # A thunk, not self.client: the build then lands inside the gate.
         return LookerChecks(connect=lambda: self.client)

--- a/ingestion/src/metadata/ingestion/source/dashboard/looker/connection.py
+++ b/ingestion/src/metadata/ingestion/source/dashboard/looker/connection.py
@@ -46,8 +46,7 @@ from metadata.ingestion.connections.connection import BaseConnection
 from metadata.utils.constants import THREE_MIN
 
 if TYPE_CHECKING:
-    from collections.abc import Callable
-
+    from metadata.core.connections.lifetime import Borrowed
     from metadata.core.connections.test_connection import ChecksProvider
     from metadata.core.connections.test_connection.classifier import Matcher
 
@@ -196,29 +195,29 @@ LOOKER_ERRORS = ErrorPack(
 class LookerChecks:
     """Test-connection checks for Looker.
 
-    ``CheckAccess`` is the gate: the SDK logs in on its first call, so bad
-    credentials and an unreachable host fail there and the rest are skipped.
-
-    ``connect`` is ``BaseConnection.client`` - a thunk, so the client is built
-    inside the first check rather than while the provider is assembled.
+    ``CheckAccess`` is the gate: reading the borrowed client logs in on its first
+    call, so bad credentials and an unreachable host fail there.
     """
 
     errors = LOOKER_ERRORS
 
-    def __init__(self, connect: Callable[[], Looker40SDK]) -> None:
-        self._connect = connect
+    def __init__(self, looker: Borrowed[Looker40SDK]) -> None:
+        self._looker = looker
+
+    def _client(self) -> Looker40SDK:
+        return self._looker.client
 
     @check(DashboardStep.CheckAccess)
     def check_access(self) -> Evidence:
         return verify_access(
-            lambda: self._connect().me(),
+            lambda: self._client().me(),
             command="log in and read the authenticated user",
         )
 
     @check(DashboardStep.ValidateVersion)
     def validate_version(self) -> Evidence:
         command = "list the API versions the instance supports"
-        versions = call_endpoint(lambda: self._connect().versions(), command=command)
+        versions = call_endpoint(lambda: self._client().versions(), command=command)
         supported = [version.version for version in versions.supported_versions or []]
         if SDK_API_VERSION not in supported:
             raise CheckError(
@@ -233,7 +232,7 @@ class LookerChecks:
     @check(DashboardStep.ListDashboards)
     def list_dashboards(self) -> Evidence:
         return fetch_list(
-            lambda: self._connect().all_dashboards(fields="id,title"),
+            lambda: self._client().all_dashboards(fields="id,title"),
             noun="dashboard",
             command="list dashboards",
             empty_caveat=Diagnosis(
@@ -246,7 +245,7 @@ class LookerChecks:
     @check(DashboardStep.ListLookMLModels)
     def list_lookml_models(self) -> Evidence:
         return fetch_list(
-            lambda: self._connect().all_lookml_models(limit=1),
+            lambda: self._client().all_lookml_models(limit=1),
             noun="LookML model",
             command="list LookML models",
             empty_caveat=Diagnosis(
@@ -286,5 +285,4 @@ class LookerConnection(BaseConnection[LookerConnectionConfig, Looker40SDK]):
         return looker_sdk.init40(config_settings=LookerSettings(self.service_connection))
 
     def checks(self) -> ChecksProvider:
-        # A thunk, not self.client: the build then lands inside the gate.
-        return LookerChecks(connect=lambda: self.client)
+        return LookerChecks(looker=self.borrow())

--- a/ingestion/src/metadata/ingestion/source/dashboard/looker/connection.py
+++ b/ingestion/src/metadata/ingestion/source/dashboard/looker/connection.py
@@ -184,12 +184,15 @@ LOOKER_ERRORS = ErrorPack(
         fix="Check Host Port, the network route, and that the Looker instance is online and "
         "reachable from where ingestion runs.",
     ),
-    # Looker itself serves this page when the hostname does not reach a running
-    # instance, so it is a Looker answer even though it carries no error document.
-    when(_contains_any("looker is unavailable")).diagnose(
-        "The Looker instance is unavailable",
-        fix="Looker answered but reported the instance as unavailable. Check that the instance is "
-        "running and not in maintenance, and that Host Port matches its URL.",
+    # Looker answers a rejected sign-in with a generic HTML 404 page carrying no
+    # error document, and serves that same page for a host that is not a live
+    # instance - the two are indistinguishable here, so the fix names both.
+    when(_contains_any("looker is unavailable", "looker not found")).diagnose(
+        "Authentication failed",
+        fix="Looker returned its generic 404 page, which it serves both for a wrong Client ID or "
+        "Client Secret and for a host that is not a live Looker instance. Check the API3 credentials "
+        "(Admin > Users > Edit > API Keys) and that Host Port points at the instance.",
+        doc=API_SDK_DOC,
     ),
     # Last: something answered, but not as Looker - the body carries no Looker error
     # document, so a real Looker 404 (which does, and is matched above) never lands here.

--- a/ingestion/src/metadata/ingestion/source/dashboard/looker/connection.py
+++ b/ingestion/src/metadata/ingestion/source/dashboard/looker/connection.py
@@ -15,11 +15,11 @@ Source connection handler
 
 from __future__ import annotations
 
-import os
 import re
 from typing import TYPE_CHECKING
 
 import looker_sdk
+from looker_sdk.rtl.api_settings import ApiSettings, SettingsConfig
 from looker_sdk.sdk.api40.methods import Looker40SDK
 
 from metadata.core.connections.test_connection import (
@@ -271,17 +271,32 @@ class LookerChecks:
         )
 
 
+class LookerSettings(ApiSettings):
+    """Feed the SDK this service's configuration directly.
+
+    The SDK otherwise reads its host and credentials from the process
+    environment, which a long-lived worker only populates once: every later
+    Looker connection in that process would silently reuse the first one's host
+    and credentials. Overriding ``read_config`` keeps each connection's settings
+    to itself - the base class reads it at construction, and the SDK reads it
+    again on each login.
+    """
+
+    def __init__(self, connection: LookerConnectionConfig) -> None:
+        self._config: SettingsConfig = {
+            "base_url": str(connection.hostPort),
+            "client_id": connection.clientId,
+            "client_secret": connection.clientSecret.get_secret_value(),
+        }
+        super().__init__()
+
+    def read_config(self) -> SettingsConfig:
+        return self._config
+
+
 class LookerConnection(BaseConnection[LookerConnectionConfig, Looker40SDK]):
     def _get_client(self) -> Looker40SDK:
-        connection = self.service_connection
-        if not os.environ.get("LOOKERSDK_CLIENT_ID"):
-            os.environ["LOOKERSDK_CLIENT_ID"] = connection.clientId
-        if not os.environ.get("LOOKERSDK_CLIENT_SECRET"):
-            os.environ["LOOKERSDK_CLIENT_SECRET"] = connection.clientSecret.get_secret_value()
-        if not os.environ.get("LOOKERSDK_BASE_URL"):
-            os.environ["LOOKERSDK_BASE_URL"] = str(connection.hostPort)
-
-        return looker_sdk.init40()
+        return looker_sdk.init40(config_settings=LookerSettings(self.service_connection))
 
     def checks(self) -> ChecksProvider:
         # Pass a thunk, not self.client: the checks then run against the one

--- a/ingestion/tests/unit/source/dashboard/looker/test_connection.py
+++ b/ingestion/tests/unit/source/dashboard/looker/test_connection.py
@@ -16,6 +16,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 from looker_sdk.error import SDKError
 
+from metadata.core.connections.lifetime import Borrowed
 from metadata.core.connections.test_connection.check import CheckError, collect_checks
 from metadata.core.connections.test_connection.checks.dashboard import DashboardStep
 from metadata.ingestion.connections.connection import BaseConnection
@@ -52,10 +53,10 @@ def _versions(*supported: str) -> MagicMock:
 
 
 def _checks() -> tuple[LookerChecks, MagicMock]:
-    """A provider whose ``connect`` thunk hands back the returned mock SDK."""
+    """A provider over a borrowed client - the one its connection owns."""
     client = MagicMock()
 
-    return LookerChecks(connect=lambda: client), client
+    return LookerChecks(looker=Borrowed.of(client)), client
 
 
 def test_looker_connection_is_base_connection():
@@ -98,8 +99,8 @@ def test_the_sdk_is_configured_from_this_service_not_the_environment(monkeypatch
 
 
 def test_checks_run_against_the_client_the_connection_owns():
-    # The provider holds no client of its own: every step shares the one the
-    # connection builds, caches, and closes.
+    # The provider borrows the client its connection owns, so every step shares the
+    # one the connection builds, caches, and closes.
     with patch(f"{CONNECTION_MODULE}.looker_sdk") as mock_sdk:
         conn = LookerConnection(MagicMock())
         provider = conn.checks()

--- a/ingestion/tests/unit/source/dashboard/looker/test_connection.py
+++ b/ingestion/tests/unit/source/dashboard/looker/test_connection.py
@@ -79,9 +79,8 @@ def test_get_client_initialises_the_sdk():
 
 
 def test_the_sdk_is_configured_from_this_service_not_the_environment(monkeypatch):
-    # The SDK reads its host and credentials from the environment by default, and a
-    # long-lived worker only populates those once - so a second Looker connection in
-    # the same process must not inherit the first one's host or credentials.
+    # A long-lived worker populates the SDK's env vars once, so a second connection
+    # in the same process must not inherit the first one's host or credentials.
     monkeypatch.setenv("LOOKERSDK_BASE_URL", "https://first.example.com")
     monkeypatch.setenv("LOOKERSDK_CLIENT_ID", "first-id")
     monkeypatch.setenv("LOOKERSDK_CLIENT_SECRET", "first-secret")
@@ -97,8 +96,8 @@ def test_the_sdk_is_configured_from_this_service_not_the_environment(monkeypatch
 
 
 def test_checks_run_against_the_client_the_connection_owns():
-    # The provider holds no client of its own: it reads BaseConnection.client, so
-    # every step shares the one client the connection builds, caches, and closes.
+    # The provider holds no client of its own: every step shares the one the
+    # connection builds, caches, and closes.
     with patch(f"{CONNECTION_MODULE}.looker_sdk") as mock_sdk:
         conn = LookerConnection(MagicMock())
         provider = conn.checks()
@@ -110,8 +109,7 @@ def test_checks_run_against_the_client_the_connection_owns():
 
 
 def test_building_the_provider_does_not_build_the_client():
-    # The SDK must not be built while the provider is assembled: that would run
-    # before the runner's gate.
+    # Building it while the provider is assembled would run before the gate.
     with patch(f"{CONNECTION_MODULE}.looker_sdk") as mock_sdk:
         conn = LookerConnection(MagicMock())
         conn.checks()
@@ -153,8 +151,8 @@ def test_check_access_reads_the_authenticated_user():
 
 
 def test_check_access_wraps_a_rejected_login_as_check_error():
-    # The SDK logs in lazily on its first call, so bad credentials surface as a
-    # classified CheckAccess failure instead of escaping while the provider is built.
+    # The SDK logs in on its first call, so bad credentials fail the gate rather
+    # than escaping while the provider is built.
     provider, client = _checks()
     client.me.side_effect = _sdk_error("Not found", documentation_url=LOGIN_404)
 
@@ -232,8 +230,8 @@ def test_list_lookml_models_wraps_a_failure_as_check_error():
 
 
 def test_rejected_credentials_are_diagnosed_as_an_auth_failure():
-    # Looker answers a wrong client id or secret with a 404 on /login, so the
-    # endpoint - not the status - is what separates it from a wrong host.
+    # A rejected login is a 404 on /login: the endpoint, not the status, tells it
+    # apart from a wrong host.
     diagnosis = LOOKER_ERRORS.classify(_sdk_error("Not found", documentation_url=LOGIN_404))
 
     assert diagnosis is not None
@@ -241,9 +239,8 @@ def test_rejected_credentials_are_diagnosed_as_an_auth_failure():
 
 
 def test_rejected_credentials_are_diagnosed_from_the_raw_login_body():
-    # The real shape: a failed login raises the undeserialized response body as the
-    # message, leaving documentation_url empty (only API calls populate it). The
-    # doc URL is still in the text, which is what the status rules read.
+    # A failed login raises the raw body as the message and leaves
+    # documentation_url empty; the URL is still in the text the rules read.
     diagnosis = LOOKER_ERRORS.classify(_sdk_error('{"message": "Not found", "documentation_url": "' + LOGIN_404 + '"}'))
 
     assert diagnosis is not None
@@ -265,16 +262,15 @@ def test_a_429_is_diagnosed_as_rate_limiting():
 
 
 def test_an_undocumented_status_keeps_its_raw_error():
-    # The API spec documents no 401 anywhere, and no 403 on any endpoint these
-    # checks call, so neither gets an invented diagnosis - the raw errorLog stands.
+    # The API spec has no 401 anywhere and no 403 on the endpoints these checks
+    # call, so neither gets an invented diagnosis.
     assert LOOKER_ERRORS.classify(_sdk_error("nope", documentation_url=DASHBOARDS_401)) is None
     assert LOOKER_ERRORS.classify(_sdk_error("nope", documentation_url=DASHBOARDS_403)) is None
 
 
 def test_lookers_generic_404_page_is_diagnosed_as_an_auth_failure():
-    # What a live Looker actually returns for a rejected sign-in: a generic HTML 404
-    # page with no error document. It serves the same page for a host that is not a
-    # live instance, so the two cannot be told apart here.
+    # What a live Looker returns for a rejected sign-in - and for a host that is not
+    # a live instance, so the two cannot be told apart.
     diagnosis = LOOKER_ERRORS.classify(
         _sdk_error(
             "<html><head><title>Looker Not Found (404)</title></head><body><h1>Looker is unavailable.</h1></body></html>"
@@ -286,8 +282,8 @@ def test_lookers_generic_404_page_is_diagnosed_as_an_auth_failure():
 
 
 def test_a_host_that_is_not_looker_is_diagnosed():
-    # A non-Looker server answers the login POST with its own 404 body, which
-    # carries no Looker error document - the shape a typo'd hostPort produces.
+    # A non-Looker server answers with its own 404 body, carrying no Looker error
+    # document.
     diagnosis = LOOKER_ERRORS.classify(_sdk_error('{"code":404,"message":"HTTP 404 Not Found"}'))
 
     assert diagnosis is not None
@@ -295,8 +291,8 @@ def test_a_host_that_is_not_looker_is_diagnosed():
 
 
 def test_a_looker_404_outranks_the_not_a_looker_host_fallback():
-    # Ordering guard: a genuine Looker 404 carries a documentation URL, so it must
-    # keep its sharper diagnosis rather than falling through to the text fallback.
+    # Ordering guard: a genuine Looker 404 carries a documentation URL and must keep
+    # the sharper diagnosis.
     diagnosis = LOOKER_ERRORS.classify(_sdk_error("Not found", documentation_url=DASHBOARDS_404))
 
     assert diagnosis is not None

--- a/ingestion/tests/unit/source/dashboard/looker/test_connection.py
+++ b/ingestion/tests/unit/source/dashboard/looker/test_connection.py
@@ -270,9 +270,10 @@ def test_a_403_is_diagnosed_as_missing_permissions():
     assert diagnosis.title == "Insufficient permissions"
 
 
-def test_an_unavailable_instance_is_diagnosed():
-    # Looker serves an HTML "Looker is unavailable" 404 when the hostname does not
-    # reach a running instance - a Looker answer, but with no error document.
+def test_lookers_generic_404_page_is_diagnosed_as_an_auth_failure():
+    # What a live Looker actually returns for a rejected sign-in: a generic HTML 404
+    # page with no error document. It serves the same page for a host that is not a
+    # live instance, so the two cannot be told apart here.
     diagnosis = LOOKER_ERRORS.classify(
         _sdk_error(
             "<html><head><title>Looker Not Found (404)</title></head><body><h1>Looker is unavailable.</h1></body></html>"
@@ -280,7 +281,7 @@ def test_an_unavailable_instance_is_diagnosed():
     )
 
     assert diagnosis is not None
-    assert diagnosis.title == "The Looker instance is unavailable"
+    assert diagnosis.title == "Authentication failed"
 
 
 def test_a_host_that_is_not_looker_is_diagnosed():

--- a/ingestion/tests/unit/source/dashboard/looker/test_connection.py
+++ b/ingestion/tests/unit/source/dashboard/looker/test_connection.py
@@ -215,6 +215,16 @@ def test_rejected_credentials_are_diagnosed_as_an_auth_failure():
     assert diagnosis.title == "Authentication failed"
 
 
+def test_rejected_credentials_are_diagnosed_from_the_raw_login_body():
+    # The real shape: a failed login raises the undeserialized response body as the
+    # message, leaving documentation_url empty (only API calls populate it). The
+    # doc URL is still in the text, which is what the status rules read.
+    diagnosis = LOOKER_ERRORS.classify(_sdk_error('{"message": "Not found", "documentation_url": "' + LOGIN_404 + '"}'))
+
+    assert diagnosis is not None
+    assert diagnosis.title == "Authentication failed"
+
+
 def test_a_404_away_from_login_is_diagnosed_as_a_missing_resource():
     diagnosis = LOOKER_ERRORS.classify(_sdk_error("Not found", documentation_url=DASHBOARDS_404))
 
@@ -234,6 +244,24 @@ def test_a_403_is_diagnosed_as_missing_permissions():
 
     assert diagnosis is not None
     assert diagnosis.title == "Insufficient permissions"
+
+
+def test_a_host_that_is_not_looker_is_diagnosed():
+    # A non-Looker server answers the login POST with its own 404 body, which
+    # carries no Looker error document - the shape a typo'd hostPort produces.
+    diagnosis = LOOKER_ERRORS.classify(_sdk_error('{"code":404,"message":"HTTP 404 Not Found"}'))
+
+    assert diagnosis is not None
+    assert diagnosis.title == "The host is not serving the Looker API"
+
+
+def test_a_looker_404_outranks_the_not_a_looker_host_fallback():
+    # Ordering guard: a genuine Looker 404 carries a documentation URL, so it must
+    # keep its sharper diagnosis rather than falling through to the text fallback.
+    diagnosis = LOOKER_ERRORS.classify(_sdk_error("Not found", documentation_url=DASHBOARDS_404))
+
+    assert diagnosis is not None
+    assert diagnosis.title == "Resource not found"
 
 
 def test_missing_credentials_are_diagnosed():

--- a/ingestion/tests/unit/source/dashboard/looker/test_connection.py
+++ b/ingestion/tests/unit/source/dashboard/looker/test_connection.py
@@ -30,9 +30,10 @@ from metadata.ingestion.source.dashboard.looker.connection import (
 CONNECTION_MODULE = "metadata.ingestion.source.dashboard.looker.connection"
 
 LOGIN_404 = "https://cloud.google.com/looker/docs/r/err/4.0/404/post/api/4.0/login"
+DASHBOARDS_404 = "https://cloud.google.com/looker/docs/r/err/4.0/404/get/api/4.0/dashboards"
+DASHBOARDS_429 = "https://cloud.google.com/looker/docs/r/err/4.0/429/get/api/4.0/dashboards"
 DASHBOARDS_401 = "https://cloud.google.com/looker/docs/r/err/4.0/401/get/api/4.0/dashboards"
 DASHBOARDS_403 = "https://cloud.google.com/looker/docs/r/err/4.0/403/get/api/4.0/dashboards"
-DASHBOARDS_404 = "https://cloud.google.com/looker/docs/r/err/4.0/404/get/api/4.0/dashboards"
 
 
 def _sdk_error(message: str, documentation_url: str = "") -> SDKError:
@@ -222,7 +223,7 @@ def test_list_lookml_models_warns_when_none_are_visible():
 
 def test_list_lookml_models_wraps_a_failure_as_check_error():
     provider, client = _checks()
-    client.all_lookml_models.side_effect = _sdk_error("Insufficient permissions", documentation_url=DASHBOARDS_403)
+    client.all_lookml_models.side_effect = _sdk_error("Not found", documentation_url=DASHBOARDS_404)
 
     with pytest.raises(CheckError) as exc_info:
         provider.list_lookml_models()
@@ -256,18 +257,18 @@ def test_a_404_away_from_login_is_diagnosed_as_a_missing_resource():
     assert diagnosis.title == "Resource not found"
 
 
-def test_a_401_is_diagnosed_as_an_auth_failure():
-    diagnosis = LOOKER_ERRORS.classify(_sdk_error("Not authenticated", documentation_url=DASHBOARDS_401))
+def test_a_429_is_diagnosed_as_rate_limiting():
+    diagnosis = LOOKER_ERRORS.classify(_sdk_error("Too many requests", documentation_url=DASHBOARDS_429))
 
     assert diagnosis is not None
-    assert diagnosis.title == "Authentication failed"
+    assert diagnosis.title == "Rate limited by Looker"
 
 
-def test_a_403_is_diagnosed_as_missing_permissions():
-    diagnosis = LOOKER_ERRORS.classify(_sdk_error("Insufficient permissions", documentation_url=DASHBOARDS_403))
-
-    assert diagnosis is not None
-    assert diagnosis.title == "Insufficient permissions"
+def test_an_undocumented_status_keeps_its_raw_error():
+    # The API spec documents no 401 anywhere, and no 403 on any endpoint these
+    # checks call, so neither gets an invented diagnosis - the raw errorLog stands.
+    assert LOOKER_ERRORS.classify(_sdk_error("nope", documentation_url=DASHBOARDS_401)) is None
+    assert LOOKER_ERRORS.classify(_sdk_error("nope", documentation_url=DASHBOARDS_403)) is None
 
 
 def test_lookers_generic_404_page_is_diagnosed_as_an_auth_failure():

--- a/ingestion/tests/unit/source/dashboard/looker/test_connection.py
+++ b/ingestion/tests/unit/source/dashboard/looker/test_connection.py
@@ -8,37 +8,300 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-"""Unit tests for Looker connection handling."""
+"""Unit tests for Looker test-connection checks."""
 
+import socket
 from unittest.mock import MagicMock, patch
 
+import pytest
+from looker_sdk.error import SDKError
+
+from metadata.core.connections.test_connection.check import CheckError, collect_checks
+from metadata.core.connections.test_connection.checks.dashboard import DashboardStep
 from metadata.ingestion.connections.connection import BaseConnection
-from metadata.ingestion.source.dashboard.looker.connection import LookerConnection
+from metadata.ingestion.source.dashboard.looker.connection import (
+    LOOKER_ERRORS,
+    LookerChecks,
+    LookerConnection,
+    UnsupportedApiVersionError,
+)
 
 CONNECTION_MODULE = "metadata.ingestion.source.dashboard.looker.connection"
+
+LOGIN_404 = "https://cloud.google.com/looker/docs/r/err/4.0/404/post/api/4.0/login"
+DASHBOARDS_401 = "https://cloud.google.com/looker/docs/r/err/4.0/401/get/api/4.0/dashboards"
+DASHBOARDS_403 = "https://cloud.google.com/looker/docs/r/err/4.0/403/get/api/4.0/dashboards"
+DASHBOARDS_404 = "https://cloud.google.com/looker/docs/r/err/4.0/404/get/api/4.0/dashboards"
+
+
+def _sdk_error(message: str, documentation_url: str = "") -> SDKError:
+    """A Looker SDK error: it carries no status code, only a message and the
+    documentation URL that encodes the status of the call that failed."""
+    return SDKError(message, documentation_url=documentation_url)
+
+
+def _versions(*supported: str) -> MagicMock:
+    versions = MagicMock()
+    versions.supported_versions = [MagicMock(version=version) for version in supported]
+
+    return versions
+
+
+def _checks(get_connection) -> tuple[LookerChecks, MagicMock]:
+    """A provider whose lazily-built SDK is the returned mock."""
+    client = MagicMock()
+    get_connection.return_value = client
+
+    return LookerChecks(connection=MagicMock()), client
 
 
 def test_looker_connection_is_base_connection():
     assert issubclass(LookerConnection, BaseConnection)
 
 
-def test_get_client_initialises_the_sdk():
-    config = MagicMock()
-    config.clientId = "client-id"
-    config.clientSecret.get_secret_value.return_value = "secret"
-    config.hostPort = "https://looker.example.com"
-    with patch(f"{CONNECTION_MODULE}.looker_sdk") as mock_sdk:
-        conn = LookerConnection(config)
+def test_get_client_delegates_to_get_connection():
+    with patch(f"{CONNECTION_MODULE}.get_connection") as mock_get:
+        conn = LookerConnection(MagicMock())
         client = conn.client
 
-    assert client is mock_sdk.init40.return_value
-    mock_sdk.init40.assert_called_once()
+    assert client is mock_get.return_value
+    mock_get.assert_called_once_with(conn.service_connection)
 
 
-def test_test_connection_runs_steps():
-    conn = LookerConnection(MagicMock())
-    conn._client = MagicMock()
-    with patch(f"{CONNECTION_MODULE}.test_connection_steps") as mock_step:
-        result = conn.test_connection(metadata=MagicMock())
+def test_checks_does_not_touch_the_network():
+    with patch(f"{CONNECTION_MODULE}.get_connection") as mock_get:
+        conn = LookerConnection(MagicMock())
+        provider = conn.checks()
 
-    assert result is mock_step.return_value
+    assert isinstance(provider, LookerChecks)
+    mock_get.assert_not_called()
+
+
+def test_collect_checks_maps_every_step():
+    with patch(f"{CONNECTION_MODULE}.get_connection") as mock_get:
+        provider, _ = _checks(mock_get)
+    collected = collect_checks(provider)
+
+    assert set(collected) == {
+        DashboardStep.CheckAccess,
+        DashboardStep.ValidateVersion,
+        DashboardStep.ListDashboards,
+        DashboardStep.ListLookMLModels,
+    }
+
+
+def test_client_is_built_once_and_shared_across_checks():
+    with patch(f"{CONNECTION_MODULE}.get_connection") as mock_get:
+        provider, client = _checks(mock_get)
+        client.versions.return_value = _versions("4.0")
+        provider.check_access()
+        provider.validate_version()
+
+    mock_get.assert_called_once_with(provider._connection)
+
+
+def test_check_access_reads_the_authenticated_user():
+    with patch(f"{CONNECTION_MODULE}.get_connection") as mock_get:
+        provider, client = _checks(mock_get)
+
+        evidence = provider.check_access()
+
+    client.me.assert_called_once_with()
+    assert evidence.summary == "authenticated"
+    assert evidence.command == "log in and read the authenticated user"
+
+
+def test_check_access_wraps_a_rejected_login_as_check_error():
+    # The SDK logs in lazily on its first call, so bad credentials surface as a
+    # classified CheckAccess failure instead of escaping while the provider is built.
+    with patch(f"{CONNECTION_MODULE}.get_connection") as mock_get:
+        provider, client = _checks(mock_get)
+        client.me.side_effect = _sdk_error("Not found", documentation_url=LOGIN_404)
+
+        with pytest.raises(CheckError) as exc_info:
+            provider.check_access()
+
+    assert isinstance(exc_info.value.cause, SDKError)
+    assert exc_info.value.evidence.command == "log in and read the authenticated user"
+
+
+def test_validate_version_passes_when_the_sdk_version_is_supported():
+    with patch(f"{CONNECTION_MODULE}.get_connection") as mock_get:
+        provider, client = _checks(mock_get)
+        client.versions.return_value = _versions("3.1", "4.0")
+
+        evidence = provider.validate_version()
+
+    assert evidence.summary == "API 4.0 is supported"
+    assert evidence.command == "list the API versions the instance supports"
+
+
+def test_validate_version_fails_when_the_sdk_version_is_missing():
+    with patch(f"{CONNECTION_MODULE}.get_connection") as mock_get:
+        provider, client = _checks(mock_get)
+        client.versions.return_value = _versions("3.1")
+
+        with pytest.raises(CheckError) as exc_info:
+            provider.validate_version()
+
+    assert isinstance(exc_info.value.cause, UnsupportedApiVersionError)
+    assert "3.1" in str(exc_info.value.cause)
+    assert exc_info.value.evidence.command == "list the API versions the instance supports"
+
+
+def test_list_dashboards_counts_what_it_enumerated():
+    with patch(f"{CONNECTION_MODULE}.get_connection") as mock_get:
+        provider, client = _checks(mock_get)
+        client.all_dashboards.return_value = [MagicMock(), MagicMock()]
+
+        evidence = provider.list_dashboards()
+
+    client.all_dashboards.assert_called_once_with(fields="id,title")
+    assert evidence.summary == "2 dashboards enumerated"
+    assert evidence.caveat is None
+
+
+def test_list_dashboards_warns_when_none_are_visible():
+    with patch(f"{CONNECTION_MODULE}.get_connection") as mock_get:
+        provider, client = _checks(mock_get)
+        client.all_dashboards.return_value = []
+
+        evidence = provider.list_dashboards()
+
+    assert evidence.summary == "0 dashboards enumerated"
+    assert evidence.caveat is not None
+    assert evidence.caveat.title == "No dashboards visible"
+
+
+def test_list_lookml_models_warns_when_none_are_visible():
+    # Not mandatory: unreadable models cost lineage, not the connection.
+    with patch(f"{CONNECTION_MODULE}.get_connection") as mock_get:
+        provider, client = _checks(mock_get)
+        client.all_lookml_models.return_value = []
+
+        evidence = provider.list_lookml_models()
+
+    client.all_lookml_models.assert_called_once_with(limit=1)
+    assert evidence.caveat is not None
+    assert evidence.caveat.title == "No LookML models visible"
+
+
+def test_list_lookml_models_wraps_a_failure_as_check_error():
+    with patch(f"{CONNECTION_MODULE}.get_connection") as mock_get:
+        provider, client = _checks(mock_get)
+        client.all_lookml_models.side_effect = _sdk_error("Insufficient permissions", documentation_url=DASHBOARDS_403)
+
+        with pytest.raises(CheckError) as exc_info:
+            provider.list_lookml_models()
+
+    assert exc_info.value.evidence.command == "list LookML models"
+
+
+def test_rejected_credentials_are_diagnosed_as_an_auth_failure():
+    # Looker answers a wrong client id or secret with a 404 on /login, so the
+    # endpoint - not the status - is what separates it from a wrong host.
+    diagnosis = LOOKER_ERRORS.classify(_sdk_error("Not found", documentation_url=LOGIN_404))
+
+    assert diagnosis is not None
+    assert diagnosis.title == "Authentication failed"
+
+
+def test_a_404_away_from_login_is_diagnosed_as_a_missing_resource():
+    diagnosis = LOOKER_ERRORS.classify(_sdk_error("Not found", documentation_url=DASHBOARDS_404))
+
+    assert diagnosis is not None
+    assert diagnosis.title == "Resource not found"
+
+
+def test_a_401_is_diagnosed_as_an_auth_failure():
+    diagnosis = LOOKER_ERRORS.classify(_sdk_error("Not authenticated", documentation_url=DASHBOARDS_401))
+
+    assert diagnosis is not None
+    assert diagnosis.title == "Authentication failed"
+
+
+def test_a_403_is_diagnosed_as_missing_permissions():
+    diagnosis = LOOKER_ERRORS.classify(_sdk_error("Insufficient permissions", documentation_url=DASHBOARDS_403))
+
+    assert diagnosis is not None
+    assert diagnosis.title == "Insufficient permissions"
+
+
+def test_missing_credentials_are_diagnosed():
+    diagnosis = LOOKER_ERRORS.classify(_sdk_error("Required auth credentials not found."))
+
+    assert diagnosis is not None
+    assert diagnosis.title == "Missing credentials"
+
+
+def test_an_unsupported_api_version_is_diagnosed():
+    diagnosis = LOOKER_ERRORS.classify(UnsupportedApiVersionError("API 4.0 is not listed"))
+
+    assert diagnosis is not None
+    assert diagnosis.title == "API 4.0 is not supported by this instance"
+
+
+def test_a_dns_failure_is_diagnosed_from_the_flattened_message():
+    # The SDK's transport catches every IOError and re-raises it as an SDKError
+    # whose message is the stringified original, so the exception type is gone and
+    # only the text can be matched.
+    error = _sdk_error(
+        "HTTPSConnectionPool(host='nope.cloud.looker.com', port=443): Max retries exceeded with "
+        'url: /api/4.0/login (Caused by NameResolutionError("Failed to resolve '
+        "'nope.cloud.looker.com' ([Errno 8] nodename nor servname provided, or not known)\"))"
+    )
+
+    diagnosis = LOOKER_ERRORS.classify(error)
+
+    assert diagnosis is not None
+    assert diagnosis.title == "Host could not be resolved"
+
+
+def test_a_refused_connection_is_diagnosed_from_the_flattened_message():
+    error = _sdk_error(
+        "HTTPSConnectionPool(host='looker.example.com', port=19999): Max retries exceeded with "
+        "url: /api/4.0/login (Caused by NewConnectionError('Connection refused'))"
+    )
+
+    diagnosis = LOOKER_ERRORS.classify(error)
+
+    assert diagnosis is not None
+    assert diagnosis.title == "Connection refused"
+
+
+def test_a_tls_failure_is_diagnosed_from_the_flattened_message():
+    error = _sdk_error(
+        "HTTPSConnectionPool(host='looker.example.com', port=443): Max retries exceeded with url: "
+        "/api/4.0/login (Caused by SSLError(SSLCertVerificationError(1, 'certificate verify "
+        "failed: self signed certificate')))"
+    )
+
+    diagnosis = LOOKER_ERRORS.classify(error)
+
+    assert diagnosis is not None
+    assert diagnosis.title == "TLS verification failed"
+
+
+def test_an_unreachable_host_is_diagnosed_from_the_flattened_message():
+    error = _sdk_error(
+        "HTTPSConnectionPool(host='looker.example.com', port=443): Max retries exceeded with url: "
+        "/api/4.0/login (Caused by NewConnectionError('Network is unreachable'))"
+    )
+
+    diagnosis = LOOKER_ERRORS.classify(error)
+
+    assert diagnosis is not None
+    assert diagnosis.title == "Cannot reach the host"
+
+
+def test_the_shared_network_pack_still_classifies_a_raw_socket_error():
+    # Anything raised outside the SDK's transport keeps its type, so the folded
+    # NETWORK_ERRORS rules remain the fallback.
+    diagnosis = LOOKER_ERRORS.classify(socket.gaierror("nodename nor servname provided"))
+
+    assert diagnosis is not None
+    assert diagnosis.title == "Host could not be resolved"
+
+
+def test_an_unknown_error_is_not_classified():
+    assert LOOKER_ERRORS.classify(_sdk_error("something entirely new")) is None

--- a/ingestion/tests/unit/source/dashboard/looker/test_connection.py
+++ b/ingestion/tests/unit/source/dashboard/looker/test_connection.py
@@ -47,39 +47,66 @@ def _versions(*supported: str) -> MagicMock:
     return versions
 
 
-def _checks(get_connection) -> tuple[LookerChecks, MagicMock]:
-    """A provider whose lazily-built SDK is the returned mock."""
+def _checks() -> tuple[LookerChecks, MagicMock]:
+    """A provider whose ``connect`` thunk hands back the returned mock SDK."""
     client = MagicMock()
-    get_connection.return_value = client
 
-    return LookerChecks(connection=MagicMock()), client
+    return LookerChecks(connect=lambda: client), client
 
 
 def test_looker_connection_is_base_connection():
     assert issubclass(LookerConnection, BaseConnection)
 
 
-def test_get_client_delegates_to_get_connection():
-    with patch(f"{CONNECTION_MODULE}.get_connection") as mock_get:
-        conn = LookerConnection(MagicMock())
+def test_get_client_initialises_the_sdk():
+    config = MagicMock()
+    config.clientId = "client-id"
+    config.clientSecret.get_secret_value.return_value = "secret"
+    config.hostPort = "https://looker.example.com"
+    with patch(f"{CONNECTION_MODULE}.looker_sdk") as mock_sdk:
+        conn = LookerConnection(config)
         client = conn.client
 
-    assert client is mock_get.return_value
-    mock_get.assert_called_once_with(conn.service_connection)
+    assert client is mock_sdk.init40.return_value
+    mock_sdk.init40.assert_called_once()
 
 
-def test_checks_does_not_touch_the_network():
-    with patch(f"{CONNECTION_MODULE}.get_connection") as mock_get:
+def test_checks_run_against_the_client_the_connection_owns():
+    # The provider holds no client of its own: it reads BaseConnection.client, so
+    # every step shares the one client the connection builds, caches, and closes.
+    with patch(f"{CONNECTION_MODULE}.looker_sdk") as mock_sdk:
         conn = LookerConnection(MagicMock())
         provider = conn.checks()
+        provider.check_access()
 
     assert isinstance(provider, LookerChecks)
-    mock_get.assert_not_called()
+    mock_sdk.init40.return_value.me.assert_called_once_with()
+    assert conn._client is mock_sdk.init40.return_value
+
+
+def test_building_the_provider_does_not_build_the_client():
+    # The SDK must not be built while the provider is assembled: that would run
+    # before the runner's gate.
+    with patch(f"{CONNECTION_MODULE}.looker_sdk") as mock_sdk:
+        conn = LookerConnection(MagicMock())
+        conn.checks()
+
+    mock_sdk.init40.assert_not_called()
+
+
+def test_the_client_is_built_once_and_shared_across_checks():
+    with patch(f"{CONNECTION_MODULE}.looker_sdk") as mock_sdk:
+        mock_sdk.init40.return_value.versions.return_value = _versions("4.0")
+        conn = LookerConnection(MagicMock())
+        provider = conn.checks()
+        provider.check_access()
+        provider.validate_version()
+
+    mock_sdk.init40.assert_called_once()
 
 
 def test_collect_checks_maps_every_step():
-    with patch(f"{CONNECTION_MODULE}.get_connection") as mock_get:
-        provider, _ = _checks(mock_get)
+    provider, _ = _checks()
     collected = collect_checks(provider)
 
     assert set(collected) == {
@@ -90,21 +117,10 @@ def test_collect_checks_maps_every_step():
     }
 
 
-def test_client_is_built_once_and_shared_across_checks():
-    with patch(f"{CONNECTION_MODULE}.get_connection") as mock_get:
-        provider, client = _checks(mock_get)
-        client.versions.return_value = _versions("4.0")
-        provider.check_access()
-        provider.validate_version()
-
-    mock_get.assert_called_once_with(provider._connection)
-
-
 def test_check_access_reads_the_authenticated_user():
-    with patch(f"{CONNECTION_MODULE}.get_connection") as mock_get:
-        provider, client = _checks(mock_get)
+    provider, client = _checks()
 
-        evidence = provider.check_access()
+    evidence = provider.check_access()
 
     client.me.assert_called_once_with()
     assert evidence.summary == "authenticated"
@@ -114,35 +130,32 @@ def test_check_access_reads_the_authenticated_user():
 def test_check_access_wraps_a_rejected_login_as_check_error():
     # The SDK logs in lazily on its first call, so bad credentials surface as a
     # classified CheckAccess failure instead of escaping while the provider is built.
-    with patch(f"{CONNECTION_MODULE}.get_connection") as mock_get:
-        provider, client = _checks(mock_get)
-        client.me.side_effect = _sdk_error("Not found", documentation_url=LOGIN_404)
+    provider, client = _checks()
+    client.me.side_effect = _sdk_error("Not found", documentation_url=LOGIN_404)
 
-        with pytest.raises(CheckError) as exc_info:
-            provider.check_access()
+    with pytest.raises(CheckError) as exc_info:
+        provider.check_access()
 
     assert isinstance(exc_info.value.cause, SDKError)
     assert exc_info.value.evidence.command == "log in and read the authenticated user"
 
 
 def test_validate_version_passes_when_the_sdk_version_is_supported():
-    with patch(f"{CONNECTION_MODULE}.get_connection") as mock_get:
-        provider, client = _checks(mock_get)
-        client.versions.return_value = _versions("3.1", "4.0")
+    provider, client = _checks()
+    client.versions.return_value = _versions("3.1", "4.0")
 
-        evidence = provider.validate_version()
+    evidence = provider.validate_version()
 
     assert evidence.summary == "API 4.0 is supported"
     assert evidence.command == "list the API versions the instance supports"
 
 
 def test_validate_version_fails_when_the_sdk_version_is_missing():
-    with patch(f"{CONNECTION_MODULE}.get_connection") as mock_get:
-        provider, client = _checks(mock_get)
-        client.versions.return_value = _versions("3.1")
+    provider, client = _checks()
+    client.versions.return_value = _versions("3.1")
 
-        with pytest.raises(CheckError) as exc_info:
-            provider.validate_version()
+    with pytest.raises(CheckError) as exc_info:
+        provider.validate_version()
 
     assert isinstance(exc_info.value.cause, UnsupportedApiVersionError)
     assert "3.1" in str(exc_info.value.cause)
@@ -150,11 +163,10 @@ def test_validate_version_fails_when_the_sdk_version_is_missing():
 
 
 def test_list_dashboards_counts_what_it_enumerated():
-    with patch(f"{CONNECTION_MODULE}.get_connection") as mock_get:
-        provider, client = _checks(mock_get)
-        client.all_dashboards.return_value = [MagicMock(), MagicMock()]
+    provider, client = _checks()
+    client.all_dashboards.return_value = [MagicMock(), MagicMock()]
 
-        evidence = provider.list_dashboards()
+    evidence = provider.list_dashboards()
 
     client.all_dashboards.assert_called_once_with(fields="id,title")
     assert evidence.summary == "2 dashboards enumerated"
@@ -162,11 +174,10 @@ def test_list_dashboards_counts_what_it_enumerated():
 
 
 def test_list_dashboards_warns_when_none_are_visible():
-    with patch(f"{CONNECTION_MODULE}.get_connection") as mock_get:
-        provider, client = _checks(mock_get)
-        client.all_dashboards.return_value = []
+    provider, client = _checks()
+    client.all_dashboards.return_value = []
 
-        evidence = provider.list_dashboards()
+    evidence = provider.list_dashboards()
 
     assert evidence.summary == "0 dashboards enumerated"
     assert evidence.caveat is not None
@@ -175,11 +186,10 @@ def test_list_dashboards_warns_when_none_are_visible():
 
 def test_list_lookml_models_warns_when_none_are_visible():
     # Not mandatory: unreadable models cost lineage, not the connection.
-    with patch(f"{CONNECTION_MODULE}.get_connection") as mock_get:
-        provider, client = _checks(mock_get)
-        client.all_lookml_models.return_value = []
+    provider, client = _checks()
+    client.all_lookml_models.return_value = []
 
-        evidence = provider.list_lookml_models()
+    evidence = provider.list_lookml_models()
 
     client.all_lookml_models.assert_called_once_with(limit=1)
     assert evidence.caveat is not None
@@ -187,12 +197,11 @@ def test_list_lookml_models_warns_when_none_are_visible():
 
 
 def test_list_lookml_models_wraps_a_failure_as_check_error():
-    with patch(f"{CONNECTION_MODULE}.get_connection") as mock_get:
-        provider, client = _checks(mock_get)
-        client.all_lookml_models.side_effect = _sdk_error("Insufficient permissions", documentation_url=DASHBOARDS_403)
+    provider, client = _checks()
+    client.all_lookml_models.side_effect = _sdk_error("Insufficient permissions", documentation_url=DASHBOARDS_403)
 
-        with pytest.raises(CheckError) as exc_info:
-            provider.list_lookml_models()
+    with pytest.raises(CheckError) as exc_info:
+        provider.list_lookml_models()
 
     assert exc_info.value.evidence.command == "list LookML models"
 

--- a/ingestion/tests/unit/source/dashboard/looker/test_connection.py
+++ b/ingestion/tests/unit/source/dashboard/looker/test_connection.py
@@ -247,6 +247,31 @@ def test_rejected_credentials_are_diagnosed_from_the_raw_login_body():
     assert diagnosis.title == "Authentication failed"
 
 
+def test_rejected_credentials_are_diagnosed_when_str_omits_the_doc_url():
+    # looker-sdk only renders documentation_url in __str__ from 24.x on; on the
+    # oldest supported version (22.20.0) it lives on the attribute alone.
+    class OldSdkError(Exception):
+        documentation_url = LOGIN_404
+
+    diagnosis = LOOKER_ERRORS.classify(OldSdkError("Not found"))
+
+    assert diagnosis is not None
+    assert diagnosis.title == "Authentication failed"
+
+
+def test_a_network_error_carrying_an_incidental_404_stays_a_network_error():
+    # "404" inside a port must not read as an HTTP 404 from a non-Looker host.
+    error = _sdk_error(
+        "HTTPConnectionPool(host='looker.example.com', port=8404): Max retries exceeded with url: "
+        "/api/4.0/login (Caused by NewConnectionError('Connection refused'))"
+    )
+
+    diagnosis = LOOKER_ERRORS.classify(error)
+
+    assert diagnosis is not None
+    assert diagnosis.title == "Connection refused"
+
+
 def test_a_404_away_from_login_is_diagnosed_as_a_missing_resource():
     diagnosis = LOOKER_ERRORS.classify(_sdk_error("Not found", documentation_url=DASHBOARDS_404))
 

--- a/ingestion/tests/unit/source/dashboard/looker/test_connection.py
+++ b/ingestion/tests/unit/source/dashboard/looker/test_connection.py
@@ -326,6 +326,14 @@ def test_a_looker_error_with_an_undiagnosed_status_keeps_its_raw_error():
     assert diagnosis is None
 
 
+def test_a_looker_error_whose_message_mentions_a_transport_word_keeps_its_raw_error():
+    # A structured Looker error (carries a doc) whose text happens to contain a
+    # transport token must not be read as a network failure.
+    diagnosis = LOOKER_ERRORS.classify(_sdk_error("Query exceeded the timeout", documentation_url=DASHBOARDS_400))
+
+    assert diagnosis is None
+
+
 def test_the_step_timeout_keeps_the_legacy_three_minute_budget():
     # Listing dashboards and LookML models can be slow on large instances.
     assert LookerConnection.step_timeout_seconds == THREE_MIN

--- a/ingestion/tests/unit/source/dashboard/looker/test_connection.py
+++ b/ingestion/tests/unit/source/dashboard/looker/test_connection.py
@@ -26,12 +26,14 @@ from metadata.ingestion.source.dashboard.looker.connection import (
     LookerSettings,
     UnsupportedApiVersionError,
 )
+from metadata.utils.constants import THREE_MIN
 
 CONNECTION_MODULE = "metadata.ingestion.source.dashboard.looker.connection"
 
 LOGIN_404 = "https://cloud.google.com/looker/docs/r/err/4.0/404/post/api/4.0/login"
 DASHBOARDS_404 = "https://cloud.google.com/looker/docs/r/err/4.0/404/get/api/4.0/dashboards"
 DASHBOARDS_429 = "https://cloud.google.com/looker/docs/r/err/4.0/429/get/api/4.0/dashboards"
+DASHBOARDS_400 = "https://cloud.google.com/looker/docs/r/err/4.0/400/get/api/4.0/dashboards"
 DASHBOARDS_401 = "https://cloud.google.com/looker/docs/r/err/4.0/401/get/api/4.0/dashboards"
 DASHBOARDS_403 = "https://cloud.google.com/looker/docs/r/err/4.0/403/get/api/4.0/dashboards"
 
@@ -313,6 +315,19 @@ def test_a_host_that_is_not_looker_is_diagnosed():
 
     assert diagnosis is not None
     assert diagnosis.title == "The host is not serving the Looker API"
+
+
+def test_a_looker_error_with_an_undiagnosed_status_keeps_its_raw_error():
+    # A Looker 400 whose message reads "parameter not found" must not be blamed on
+    # Host Port: it carries an error document, so it is a Looker answer.
+    diagnosis = LOOKER_ERRORS.classify(_sdk_error("parameter not found", documentation_url=DASHBOARDS_400))
+
+    assert diagnosis is None
+
+
+def test_the_step_timeout_keeps_the_legacy_three_minute_budget():
+    # Listing dashboards and LookML models can be slow on large instances.
+    assert LookerConnection.step_timeout_seconds == THREE_MIN
 
 
 def test_a_looker_404_outranks_the_not_a_looker_host_fallback():

--- a/ingestion/tests/unit/source/dashboard/looker/test_connection.py
+++ b/ingestion/tests/unit/source/dashboard/looker/test_connection.py
@@ -23,6 +23,7 @@ from metadata.ingestion.source.dashboard.looker.connection import (
     LOOKER_ERRORS,
     LookerChecks,
     LookerConnection,
+    LookerSettings,
     UnsupportedApiVersionError,
 )
 
@@ -58,17 +59,40 @@ def test_looker_connection_is_base_connection():
     assert issubclass(LookerConnection, BaseConnection)
 
 
-def test_get_client_initialises_the_sdk():
+def _config(host: str = "https://looker.example.com", client_id: str = "id", secret: str = "secret") -> MagicMock:
     config = MagicMock()
-    config.clientId = "client-id"
-    config.clientSecret.get_secret_value.return_value = "secret"
-    config.hostPort = "https://looker.example.com"
+    config.hostPort = host
+    config.clientId = client_id
+    config.clientSecret.get_secret_value.return_value = secret
+
+    return config
+
+
+def test_get_client_initialises_the_sdk():
     with patch(f"{CONNECTION_MODULE}.looker_sdk") as mock_sdk:
-        conn = LookerConnection(config)
+        conn = LookerConnection(_config())
         client = conn.client
 
     assert client is mock_sdk.init40.return_value
     mock_sdk.init40.assert_called_once()
+
+
+def test_the_sdk_is_configured_from_this_service_not_the_environment(monkeypatch):
+    # The SDK reads its host and credentials from the environment by default, and a
+    # long-lived worker only populates those once - so a second Looker connection in
+    # the same process must not inherit the first one's host or credentials.
+    monkeypatch.setenv("LOOKERSDK_BASE_URL", "https://first.example.com")
+    monkeypatch.setenv("LOOKERSDK_CLIENT_ID", "first-id")
+    monkeypatch.setenv("LOOKERSDK_CLIENT_SECRET", "first-secret")
+
+    settings = LookerSettings(_config(host="https://second.example.com", client_id="second-id", secret="second-secret"))
+
+    assert settings.base_url == "https://second.example.com"
+    assert settings.read_config() == {
+        "base_url": "https://second.example.com",
+        "client_id": "second-id",
+        "client_secret": "second-secret",
+    }
 
 
 def test_checks_run_against_the_client_the_connection_owns():

--- a/ingestion/tests/unit/source/dashboard/looker/test_connection.py
+++ b/ingestion/tests/unit/source/dashboard/looker/test_connection.py
@@ -246,6 +246,19 @@ def test_a_403_is_diagnosed_as_missing_permissions():
     assert diagnosis.title == "Insufficient permissions"
 
 
+def test_an_unavailable_instance_is_diagnosed():
+    # Looker serves an HTML "Looker is unavailable" 404 when the hostname does not
+    # reach a running instance - a Looker answer, but with no error document.
+    diagnosis = LOOKER_ERRORS.classify(
+        _sdk_error(
+            "<html><head><title>Looker Not Found (404)</title></head><body><h1>Looker is unavailable.</h1></body></html>"
+        )
+    )
+
+    assert diagnosis is not None
+    assert diagnosis.title == "The Looker instance is unavailable"
+
+
 def test_a_host_that_is_not_looker_is_diagnosed():
     # A non-Looker server answers the login POST with its own 404 body, which
     # carries no Looker error document - the shape a typo'd hostPort produces.

--- a/openmetadata-service/src/main/resources/json/data/testConnections/dashboard/looker.json
+++ b/openmetadata-service/src/main/resources/json/data/testConnections/dashboard/looker.json
@@ -8,7 +8,8 @@
             "description": "Validate that the API is accessible with the given credentials",
             "errorMessage": "Failed to connect to looker, please validate the credentials",
             "shortCircuit": true,
-            "mandatory": true
+            "mandatory": true,
+            "category": "ConnectionGate"
         },
         {
             "name": "ValidateVersion",


### PR DESCRIPTION
Migrates Looker's test connection off the imperative `test_connection_steps` helper onto the declarative `@check` / `ChecksProvider` / `ErrorPack` framework, following the merged PowerBI and Tableau connectors.

Closes #30037

## What changed

- **`LookerChecks` provider** — one `@check` per step (`CheckAccess`, `ValidateVersion`, `ListDashboards`, `ListLookMLModels`), reusing the shared dashboard helpers (`verify_access`, `call_endpoint`, `fetch_list`). The `test_connection` override is gone; `BaseConnection.test_connection` now drives the checks through the runner.
- **`BaseConnection` owns the client.** The provider builds nothing itself: it takes a `connect` thunk over `BaseConnection.client` (the same wiring as Athena, BigQuery, Glue, and S3), so every step shares the one client the connection builds, caches, and closes — one owner, one client, one lifetime. Passing a thunk rather than the client keeps the build inside the first check, so nothing dials the instance before the runner's gate.
- **`CheckAccess` is the `ConnectionGate`** in `testConnections/dashboard/looker.json`, so a failed gate short-circuits the remaining steps instead of each one re-dialling an unreachable host.
- **`LOOKER_ERRORS` pack** — maps the failures the SDK actually raises to actionable diagnoses. Two Looker-specific signals drive it:
  - `SDKError` carries **no status code**; the response body is deserialized into `message` / `documentation_url`, and it is the *documentation URL* that encodes the status and the endpoint (`.../r/err/4.0/404/post/api/4.0/login`). The pack parses the status from there. Because Looker answers rejected API3 credentials with a **404 on `/login`** rather than a 401, the endpoint — not the status — is what separates bad credentials from a wrong host, so that rule is ordered ahead of the generic 404.
  - The SDK's transport **catches every `IOError`** (DNS, refused, TLS, timeout) and re-raises it as an `SDKError` whose message is the stringified original, so the exception *type* is lost. Those conditions are therefore matched on text, ahead of the folded `NETWORK_ERRORS` type-based rules, which remain the fallback for anything raised outside the transport.
- **Extra `ListDashboards` / `ListLookMLModels` caveats** — an empty result now passes with a non-blocking Warning explaining what a missing permission would cost (dashboards not visible; no lineage without LookML models) instead of a bare `assert`.
- Adds `ValidateVersion`, `ListDashboards`, and `ListLookMLModels` to the shared `DashboardStep` enum (first occurrence of each; existing members untouched).

Step order, names, and `mandatory` flags are preserved exactly; only the gate `category` is added to the definition.

## Note for review

The error pack was derived by reading the `looker_sdk` transport and error-handling source, not against a live instance — the status-from-documentation-URL and the flattened-`IOError` text rules are the two behaviours worth confirming during live validation.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR moves Looker test-connection checks onto the shared check framework. The main changes are:

- New declarative Looker checks for access, API version, dashboards, and LookML models.
- Looker-specific error classification for SDK and transport failures.
- A shared SDK client owned by `BaseConnection`.
- A three-minute per-step timeout for Looker checks.
- `CheckAccess` marked as the connection gate in the test-connection definition.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge.

- No blocking issues found in the changed code.
- The timeout behavior now preserves the Looker three-minute budget through the base runner.
- The documented Looker error guards now keep structured Looker errors out of the generic network and host fallback rules.

</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| ingestion/src/metadata/ingestion/source/dashboard/looker/connection.py | Adds the Looker checks provider, SDK settings wrapper, error pack, and three-minute per-step timeout. |
| ingestion/src/metadata/core/connections/test_connection/checks/dashboard.py | Adds the Looker dashboard step names used by the new check provider. |
| openmetadata-service/src/main/resources/json/data/testConnections/dashboard/looker.json | Marks `CheckAccess` as the connection gate for Looker test connections. |
| ingestion/tests/unit/source/dashboard/looker/test_connection.py | Adds tests for the new Looker checks, SDK configuration, error classification, and timeout behavior. |

</details>

<sub>Reviews (4): Last reviewed commit: ["fix(ingestion): don&#39;t read a structured ..."](https://github.com/open-metadata/openmetadata/commit/4659e90d52d75c43ad97eb216b7ccb360a469cee) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44187720)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Context used - CLAUDE.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=52f0d9d9-cad1-4e7d-b070-de181a0aa5e7))
- Context used - openmetadata-ui-core-components/CLAUDE.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=41754627-b2bf-474b-8082-f37ef1a07013))
- Context used - AGENTS.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=ef262f5f-911f-44f3-8d2d-e9cb1579c8c8))
</details>

<!-- /greptile_comment -->