### PR TITLE
Backport #30011 to 1.13: authorize MCP get_entity_details against the resolved entity

### DIFF
--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/mcp/McpIntegrationIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/mcp/McpIntegrationIT.java
@@ -7,6 +7,7 @@ import java.net.URI;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.CountDownLatch;
@@ -17,6 +18,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.openmetadata.it.auth.JwtAuthProvider;
 import org.openmetadata.schema.entity.data.Table;
 import org.openmetadata.service.Entity;
 
@@ -297,5 +299,92 @@ public class McpIntegrationIT extends McpTestBase {
 
     assertThat(allCompleted).isTrue();
     assertThat(successfulRequests.get()).isGreaterThan(totalRequests / 2);
+  }
+
+  @Test
+  void getEntityDetailsIsDeniedByTagBasedPolicy() throws Exception {
+    String suffix = UUID.randomUUID().toString().substring(0, 8);
+    String tagFqn = createRestrictedTag(suffix);
+    Table restricted = createServiceDatabaseSchemaTable("mcp_authz_" + suffix);
+    tagTable(restricted.getId().toString(), tagFqn);
+    String deniedToken = createUserDeniedByTag(suffix, tagFqn);
+
+    Map<String, Object> call =
+        McpTestUtils.createGetEntityToolCall(Entity.TABLE, restricted.getFullyQualifiedName());
+
+    // Admin bypasses the policy and sees the table — proves the denial below is real, not a fluke.
+    assertThat(executeMcpRequest(call).toString()).contains("created_at");
+
+    // The non-admin is hit by the tag Deny: no entity data must come back.
+    assertThat(executeMcpRequest(call, deniedToken).toString()).doesNotContain("created_at");
+  }
+
+  private String createRestrictedTag(String suffix) throws Exception {
+    String classification = "McpAuthz" + suffix;
+    post(
+        "classifications",
+        Map.of("name", classification, "description", "mcp authz"),
+        JsonNode.class);
+    JsonNode tag =
+        post(
+            "tags",
+            Map.of("classification", classification, "name", "Restricted", "description", "mcp"),
+            JsonNode.class);
+    return tag.get("fullyQualifiedName").asText();
+  }
+
+  private void tagTable(String tableId, String tagFqn) throws Exception {
+    patch(
+        "tables/" + tableId,
+        String.format(
+            "[{\"op\":\"add\",\"path\":\"/tags/0\",\"value\":{\"tagFQN\":\"%s\",\"source\":"
+                + "\"Classification\",\"labelType\":\"Manual\",\"state\":\"Confirmed\"}}]",
+            tagFqn));
+  }
+
+  private String createUserDeniedByTag(String suffix, String tagFqn) throws Exception {
+    String prefix = "mcpauthz_" + suffix;
+    JsonNode policy =
+        post(
+            "policies",
+            Map.of(
+                "name",
+                prefix + "_policy",
+                "rules",
+                List.of(
+                    Map.of(
+                        "name", prefix + "_rule",
+                        "resources", List.of("table"),
+                        "operations", List.of("ViewAll"),
+                        "effect", "deny",
+                        "condition", String.format("matchAnyTag('%s')", tagFqn)))),
+            JsonNode.class);
+    JsonNode role =
+        post(
+            "roles",
+            Map.of(
+                "name",
+                prefix + "_role",
+                "policies",
+                List.of(policy.get("fullyQualifiedName").asText())),
+            JsonNode.class);
+    JsonNode dataConsumer = get("roles/name/DataConsumer", JsonNode.class);
+    JsonNode team =
+        post(
+            "teams",
+            Map.of(
+                "name",
+                prefix + "_team",
+                "teamType",
+                "Group",
+                "defaultRoles",
+                List.of(dataConsumer.get("id").asText(), role.get("id").asText())),
+            JsonNode.class);
+    String email = prefix + "_u@test.openmetadata.org";
+    post(
+        "users",
+        Map.of("name", prefix + "_u", "email", email, "teams", List.of(team.get("id").asText())),
+        JsonNode.class);
+    return "Bearer " + JwtAuthProvider.tokenFor(email, email, new String[] {}, 3_600);
   }
 }

--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/mcp/McpTestBase.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/mcp/McpTestBase.java
@@ -188,13 +188,18 @@ public abstract class McpTestBase {
   }
 
   protected JsonNode executeMcpRequest(java.util.Map<String, Object> mcpRequest) throws Exception {
+    return executeMcpRequest(mcpRequest, authToken);
+  }
+
+  protected JsonNode executeMcpRequest(java.util.Map<String, Object> mcpRequest, String token)
+      throws Exception {
     String requestBody = OBJECT_MAPPER.writeValueAsString(mcpRequest);
     HttpRequest request =
         HttpRequest.newBuilder()
             .uri(URI.create(getMcpUrl("/mcp")))
             .header("Content-Type", "application/json")
             .header("Accept", "application/json, text/event-stream")
-            .header("Authorization", authToken)
+            .header("Authorization", token)
             .POST(HttpRequest.BodyPublishers.ofString(requestBody))
             .timeout(Duration.ofSeconds(30))
             .build();
@@ -202,9 +207,7 @@ public abstract class McpTestBase {
     HttpResponse<String> response = HTTP_CLIENT.send(request, HttpResponse.BodyHandlers.ofString());
     assertThat(response.statusCode()).isEqualTo(200);
 
-    String responseBody = response.body();
-    String jsonContent = extractJsonFromResponse(responseBody);
-    return OBJECT_MAPPER.readTree(jsonContent);
+    return OBJECT_MAPPER.readTree(extractJsonFromResponse(response.body()));
   }
 
   protected static String extractJsonFromResponse(String responseBody) {

--- a/openmetadata-mcp/src/main/java/org/openmetadata/mcp/tools/GetEntityTool.java
+++ b/openmetadata-mcp/src/main/java/org/openmetadata/mcp/tools/GetEntityTool.java
@@ -103,10 +103,12 @@ public class GetEntityTool implements McpTool {
       throws IOException {
     String entityType = (String) params.get("entityType");
     String fqn = (String) params.get("fqn");
+    // Authorize by FQN so entity-scoped tag/owner/domain policies are evaluated, not just the
+    // resource-type permission.
     authorizer.authorize(
         securityContext,
         new OperationContext(entityType, VIEW_ALL),
-        new ResourceContext<>(entityType));
+        new ResourceContext<>(entityType, null, fqn));
     LOG.info("Getting details for entity type: {}, FQN: {}", entityType, fqn);
     int columnOffset =
         Math.max(0, McpParams.getInt(params, COLUMN_OFFSET_PARAM, DEFAULT_COLUMN_OFFSET));


### PR DESCRIPTION
Backports #30011 to the `1.13` branch.

### What
`GetEntityTool` (MCP `get_entity_details`) authorized `VIEW_ALL` against an entity-less `ResourceContext<>(entityType)`, so only the resource-type-level permission was evaluated and entity-scoped policies (tag / owner / domain based Deny rules) were skipped — a caller could read an entity a per-entity policy should hide.

Authorize by FQN (`new ResourceContext<>(entityType, null, fqn)`) so entity-scoped policies are evaluated, matching `PatchEntityTool` / `GetAssetContextTool`. Authorization runs before the full entity is loaded for the response; the minimal auth load does not fetch the full entity.

Fixes #29834 on 1.13.

### Cherry-pick
Clean cherry-pick (`-x`) of squash-merge commit `b1f2e385960eacbdfda367d7e6205ad28742c5fe`, no conflicts.

Files:
- `openmetadata-mcp/.../tools/GetEntityTool.java` — FQN-bound resource context
- `openmetadata-integration-tests/.../mcp/McpIntegrationIT.java` — tag-based deny policy enforcement test
- `openmetadata-integration-tests/.../mcp/McpTestBase.java` — token-aware MCP request helper

### Build
`mvn clean install -pl openmetadata-mcp,openmetadata-integration-tests -am -DskipTests` → **BUILD SUCCESS** (all 11 reactor modules green, incl. MCP + Integration Tests test-compile).

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR updates MCP entity-details authorization to check the resolved entity. The main changes are:

- FQN-bound authorization in `GetEntityTool`.
- A token-aware MCP request helper for integration tests.
- A new tag-based deny-policy integration test.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge after tightening one test assertion.

- The production authorization path now uses the requested entity FQN.
- No blocking issue was found in the changed runtime code.
- The new regression test can pass on unrelated MCP errors, so it should assert the expected denial shape.

openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/mcp/McpIntegrationIT.java
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-mcp/src/main/java/org/openmetadata/mcp/tools/GetEntityTool.java | Authorizes `get_entity_details` with an entity FQN so entity-scoped policies can be evaluated. |
| openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/mcp/McpTestBase.java | Adds an overload that sends MCP requests with a caller-provided authorization token. |
| openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/mcp/McpIntegrationIT.java | Adds a tag-based deny-policy test, but its final assertion can pass on unrelated MCP errors. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(mcp): authorize get\_entity\_details a..."](https://github.com/open-metadata/openmetadata/commit/f19a394cf3ef510e40da87a40fae0166aa626bef) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44135323)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Context used - CLAUDE.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=52f0d9d9-cad1-4e7d-b070-de181a0aa5e7))
- Context used - openmetadata-ui-core-components/CLAUDE.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=41754627-b2bf-474b-8082-f37ef1a07013))

<!-- /greptile_comment -->