### PR TITLE
Backport #29479 to 1.13: self-heal custom-property registry across replicas (#25532, #26729)

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/TypeRegistry.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/TypeRegistry.java
@@ -17,7 +17,10 @@ import static org.openmetadata.common.utils.CommonUtil.listOrEmpty;
 import static org.openmetadata.service.Entity.ADMIN_USER_NAME;
 import static org.openmetadata.service.resources.types.TypeResource.PROPERTIES_FIELD;
 
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
 import com.networknt.schema.Schema;
+import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -45,6 +48,35 @@ public class TypeRegistry {
 
   /** Custom property map (fully qualified customPropertyName) to (jsonSchema) */
   protected static final Map<String, Schema> CUSTOM_PROPERTY_SCHEMAS = new ConcurrentHashMap<>();
+
+  /**
+   * Negative cache of custom-property FQNs that were missing in this process even after a fresh
+   * read from the shared database. In a multi-replica deployment a custom property created on one
+   * replica is not pushed to the in-memory registry of its peers; this lets a peer self-heal by
+   * re-reading the owning type from the database on a cache miss, while the negative entry bounds
+   * how often a genuinely-unknown field re-triggers that database read.
+   *
+   * <p>Bounded staleness: an entry is only written after an actual database reload still did not
+   * find the property, so a property that already exists is never wrongly pinned. The one exception
+   * is a field queried <em>before</em> it is created on a peer (e.g. a typo'd-then-fixed name); it
+   * stays pinned as unknown until this entry expires. The common create-then-use ordering never
+   * queries the field before it exists, so it self-heals on first use.
+   */
+  protected static final Cache<String, Boolean> MISSING_CUSTOM_PROPERTIES =
+      Caffeine.newBuilder().maximumSize(10_000).expireAfterWrite(Duration.ofSeconds(60)).build();
+
+  /**
+   * Coalescing window of entity types whose custom properties were re-read from the database
+   * recently. A single self-heal reload pulls the <em>whole</em> owning type, so once a type has
+   * been refreshed, further misses for other fields of that same type within the window reuse that
+   * read instead of issuing one database round-trip per field. This bounds read amplification (a
+   * request or import with many distinct unknown fields, or a caller rotating field names, cannot
+   * fan out into one reload per field) and, via {@link Cache#get(Object, java.util.function.Function)},
+   * collapses a thundering herd of concurrent first-time misses for the same type into a single
+   * reload. The window is short so a newly-created property still propagates within seconds.
+   */
+  protected static final Cache<String, Boolean> RECENTLY_REFRESHED_TYPES =
+      Caffeine.newBuilder().maximumSize(1_000).expireAfterWrite(Duration.ofSeconds(2)).build();
 
   private static final TypeRegistry INSTANCE = new TypeRegistry();
 
@@ -108,6 +140,7 @@ public class TypeRegistry {
       String entityType, String propertyName, CustomProperty customProperty) {
     String customPropertyFQN = getCustomPropertyFQN(entityType, propertyName);
     CUSTOM_PROPERTIES.put(customPropertyFQN, customProperty);
+    MISSING_CUSTOM_PROPERTIES.invalidate(customPropertyFQN);
 
     try {
       Schema jsonSchema =
@@ -131,7 +164,71 @@ public class TypeRegistry {
 
   public Schema getSchema(String entityType, String propertyName) {
     String customPropertyFQN = getCustomPropertyFQN(entityType, propertyName);
+    ensureCustomPropertyLoaded(entityType, customPropertyFQN);
     return CUSTOM_PROPERTY_SCHEMAS.get(customPropertyFQN);
+  }
+
+  /**
+   * Self-heals the registry when a custom property is missing locally. Other replicas do not learn
+   * about a custom property created on a peer, so on a miss we re-read the owning type from the
+   * shared database (source of truth) and repopulate the registry. A short-lived negative cache
+   * prevents a genuinely-unknown field from re-reading the database on every request.
+   */
+  private void ensureCustomPropertyLoaded(String entityType, String customPropertyFQN) {
+    boolean missingLocally =
+        !CUSTOM_PROPERTIES.containsKey(customPropertyFQN)
+            && MISSING_CUSTOM_PROPERTIES.getIfPresent(customPropertyFQN) == null;
+    if (missingLocally) {
+      boolean reloaded = reloadTypeCoalesced(entityType);
+      if (reloaded && !CUSTOM_PROPERTIES.containsKey(customPropertyFQN)) {
+        MISSING_CUSTOM_PROPERTIES.put(customPropertyFQN, Boolean.TRUE);
+      }
+    }
+  }
+
+  /**
+   * Re-reads the owning type from the database at most once per coalescing window, sharing a single
+   * reload across concurrent callers for the same type. Returns {@code true} only when this call
+   * performed a successful reload, so the caller knows the registry was just repopulated and a
+   * still-missing property is genuinely unknown (safe to negative-cache). A failed reload returns
+   * {@code false} so a property that exists but could not be read is never wrongly pinned, and the
+   * coalescing entry is dropped so the next miss retries the database immediately instead of waiting
+   * out the window.
+   */
+  private boolean reloadTypeCoalesced(String entityType) {
+    boolean[] loaderRan = {false};
+    boolean[] loadSucceeded = {false};
+    RECENTLY_REFRESHED_TYPES.get(
+        entityType,
+        key -> {
+          loaderRan[0] = true;
+          loadSucceeded[0] = refreshTypeFromDb(key);
+          return Boolean.TRUE;
+        });
+    if (loaderRan[0] && !loadSucceeded[0]) {
+      RECENTLY_REFRESHED_TYPES.invalidate(entityType);
+    }
+    return loadSucceeded[0];
+  }
+
+  private boolean refreshTypeFromDb(String entityType) {
+    boolean refreshed = false;
+    TypeRepository repository = Entity.getTypeRepository();
+    if (repository != null) {
+      try {
+        EntityUtil.Fields fields = repository.getFields(PROPERTIES_FIELD);
+        Type type = repository.getByName(null, entityType, fields);
+        addType(type);
+        refreshed = true;
+        LOG.debug("Refreshed type '{}' from database after custom property cache miss", entityType);
+      } catch (RuntimeException e) {
+        LOG.debug(
+            "Could not refresh type '{}' from database on cache miss: {}",
+            entityType,
+            e.getMessage());
+      }
+    }
+    return refreshed;
   }
 
   public void validateCustomProperties(Type type) {
@@ -163,6 +260,7 @@ public class TypeRegistry {
 
   public static String getCustomPropertyType(String entityType, String propertyName) {
     String fqn = getCustomPropertyFQN(entityType, propertyName);
+    instance().ensureCustomPropertyLoaded(entityType, fqn);
     CustomProperty property = CUSTOM_PROPERTIES.get(fqn);
     if (property == null) {
       throw EntityNotFoundException.byMessage(
@@ -173,6 +271,7 @@ public class TypeRegistry {
 
   public static String getCustomPropertyConfig(String entityType, String propertyName) {
     String fqn = getCustomPropertyFQN(entityType, propertyName);
+    instance().ensureCustomPropertyLoaded(entityType, fqn);
     CustomProperty property = CUSTOM_PROPERTIES.get(fqn);
     if (property != null
         && property.getCustomPropertyConfig() != null

--- a/openmetadata-service/src/test/java/org/openmetadata/service/TypeRegistryTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/TypeRegistryTest.java
@@ -14,28 +14,177 @@
 package org.openmetadata.service;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
+import com.networknt.schema.Schema;
+import java.util.List;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
+import org.openmetadata.schema.entity.Type;
+import org.openmetadata.schema.entity.type.Category;
 import org.openmetadata.schema.entity.type.CustomProperty;
+import org.openmetadata.schema.type.EntityReference;
+import org.openmetadata.service.jdbi3.TypeRepository;
+import org.openmetadata.service.util.EntityUtil;
 
 /**
- * Tests {@link TypeRegistry#getPropertyName(String)}.
+ * Tests {@link TypeRegistry#getPropertyName(String)} and the self-healing custom-property lookup.
  *
  * <p>The OpenMetadata FQN system normalises quotes — a property named {@code "/random/"} (with
  * literal quote characters) and a property named {@code custom.test} (with dots) end up with FQN
  * segments that look the same after normalisation. To return the original name to API consumers,
  * {@code getPropertyName} prefers the registered {@link CustomProperty#getName()} over re-deriving
  * from the FQN. These tests pin that behaviour.
+ *
+ * <p>The remaining tests cover the multi-replica self-heal: a custom property created on a peer
+ * replica is absent from this process's registry, so a cache miss re-reads the owning type from the
+ * shared database, while a negative cache bounds repeated reads for genuinely-unknown fields.
  */
 class TypeRegistryTest {
 
   private static final String ENTITY_TYPE = "table";
   private static final String FQN_PREFIX_TABLE = "table.customProperties";
 
+  private static final String STRING_TYPE = "string";
+
   @AfterEach
   void cleanRegistry() {
     TypeRegistry.CUSTOM_PROPERTIES.clear();
+    TypeRegistry.CUSTOM_PROPERTY_SCHEMAS.clear();
+    TypeRegistry.TYPES.clear();
+    TypeRegistry.MISSING_CUSTOM_PROPERTIES.invalidateAll();
+    TypeRegistry.RECENTLY_REFRESHED_TYPES.invalidateAll();
+    Entity.setTypeRepository(null);
+  }
+
+  /**
+   * Simulates the multi-replica desync: a custom property created on a peer replica exists in the
+   * shared database but is absent from this process's registry. A cache miss must self-heal by
+   * re-reading the owning type from the database so the property resolves instead of surfacing as
+   * an unknown field.
+   */
+  @Test
+  void getSchema_selfHealsFromDatabaseOnCacheMiss() {
+    seedBasePropertyType();
+    String propertyName = "relationships";
+    repositoryReturningTableWith(propertyName);
+
+    String fqn = TypeRegistry.getCustomPropertyFQN(ENTITY_TYPE, propertyName);
+    assertNull(
+        TypeRegistry.CUSTOM_PROPERTY_SCHEMAS.get(fqn),
+        "Precondition: stale replica does not know the custom property");
+
+    Schema schema = TypeRegistry.instance().getSchema(ENTITY_TYPE, propertyName);
+
+    assertNotNull(schema, "Schema should be self-healed from the database on a cache miss");
+  }
+
+  /**
+   * A burst of misses for distinct unknown fields of the same type must reuse one database reload
+   * rather than one round-trip per field (read-amplification / thundering-herd guard).
+   */
+  @Test
+  void getSchema_coalescesDatabaseReadsAcrossDistinctUnknownFields() {
+    seedBasePropertyType();
+    TypeRepository repository = repositoryReturningTableWith("knownProp");
+
+    assertNull(TypeRegistry.instance().getSchema(ENTITY_TYPE, "unknownA"));
+    assertNull(TypeRegistry.instance().getSchema(ENTITY_TYPE, "unknownB"));
+    assertNull(TypeRegistry.instance().getSchema(ENTITY_TYPE, "unknownC"));
+
+    verify(repository, times(1)).getByName(any(), eq(ENTITY_TYPE), any());
+  }
+
+  /**
+   * The negative cache must stop a genuinely-unknown field from re-reading the database on every
+   * request. The coalescing window is cleared between calls so this asserts the negative cache
+   * itself bounds the reads, not the short-lived per-type refresh window.
+   */
+  @Test
+  void getSchema_negativeCacheStopsRepeatedDbReadsForUnknownField() {
+    seedBasePropertyType();
+    TypeRepository repository = repositoryReturningTableWith("knownProp");
+
+    assertNull(TypeRegistry.instance().getSchema(ENTITY_TYPE, "ghost"));
+    TypeRegistry.RECENTLY_REFRESHED_TYPES.invalidateAll();
+    assertNull(TypeRegistry.instance().getSchema(ENTITY_TYPE, "ghost"));
+
+    verify(repository, times(1)).getByName(any(), eq(ENTITY_TYPE), any());
+  }
+
+  /**
+   * Creating a property locally must drop any prior negative-cache entry for it, so a field that
+   * was reported unknown before it existed resolves immediately on create-then-use.
+   */
+  @Test
+  void addCustomProperty_clearsNegativeCacheEntryOnCreate() {
+    seedBasePropertyType();
+    String fqn = TypeRegistry.getCustomPropertyFQN(ENTITY_TYPE, "fresh");
+    TypeRegistry.MISSING_CUSTOM_PROPERTIES.put(fqn, Boolean.TRUE);
+
+    TypeRegistry.instance().addType(tableTypeWith("fresh"));
+
+    assertNull(
+        TypeRegistry.MISSING_CUSTOM_PROPERTIES.getIfPresent(fqn),
+        "Creating the property must clear its negative-cache entry");
+    assertNotNull(TypeRegistry.instance().getSchema(ENTITY_TYPE, "fresh"));
+  }
+
+  /**
+   * A transient database failure during the self-heal reload must neither pin an existing property
+   * as unknown nor occupy the coalescing window: the field is left out of the negative cache and
+   * the very next lookup retries the database immediately (no manual window clearing here).
+   */
+  @Test
+  void getSchema_retriesImmediatelyAndDoesNotPinPropertyWhenReloadFails() {
+    seedBasePropertyType();
+    String propertyName = "relationships";
+    TypeRepository repository = mock(TypeRepository.class);
+    when(repository.getFields(any())).thenReturn(EntityUtil.Fields.EMPTY_FIELDS);
+    when(repository.getByName(any(), eq(ENTITY_TYPE), any()))
+        .thenThrow(new RuntimeException("transient database error"))
+        .thenReturn(tableTypeWith(propertyName));
+    Entity.setTypeRepository(repository);
+
+    assertNull(
+        TypeRegistry.instance().getSchema(ENTITY_TYPE, propertyName),
+        "Failed reload returns no schema for this attempt");
+
+    assertNotNull(
+        TypeRegistry.instance().getSchema(ENTITY_TYPE, propertyName),
+        "Next lookup must retry the database immediately, not wait out the coalescing window");
+  }
+
+  private void seedBasePropertyType() {
+    TypeRegistry.TYPES.put(
+        STRING_TYPE, new Type().withName(STRING_TYPE).withSchema("{\"type\":\"string\"}"));
+  }
+
+  private Type tableTypeWith(String propertyName) {
+    return new Type()
+        .withName(ENTITY_TYPE)
+        .withCategory(Category.Entity)
+        .withCustomProperties(
+            List.of(
+                new CustomProperty()
+                    .withName(propertyName)
+                    .withPropertyType(new EntityReference().withName(STRING_TYPE))));
+  }
+
+  private TypeRepository repositoryReturningTableWith(String propertyName) {
+    TypeRepository repository = mock(TypeRepository.class);
+    when(repository.getFields(any())).thenReturn(EntityUtil.Fields.EMPTY_FIELDS);
+    when(repository.getByName(any(), eq(ENTITY_TYPE), any()))
+        .thenReturn(tableTypeWith(propertyName));
+    Entity.setTypeRepository(repository);
+    return repository;
   }
 
   @Test


### PR DESCRIPTION
Backport of #29479 to `1.13`. Fixes #25532, #26729 for the 1.13 line.

## Problem (multi-replica only)
`TypeRegistry` is a per-process singleton populated once at startup. A custom property created at runtime on one replica (`PUT /metadata/types/{id}`) is unknown to the others, which keep validating entity `extension` payloads against their stale local registry. Behind a non-sticky load balancer the write that *uses* the property lands on a different replica and is rejected with `400 Unknown custom field <name>`. Persistent (not a startup window), rate ≈ stale_replicas/total_replicas, does not reproduce single-replica. (`CACHE_PROVIDER=none` default → no Redis cross-invalidation.)

## Fix
On a custom-property miss, self-heal by re-reading the owning type from the shared DB and rebuilding the local registry entry (Caffeine negative-cache + short coalescing window, no new infra). Cherry-picked from `main` squash `45b78505ed`; applied cleanly to `1.13`.

## Verification
- `mvn clean install -DskipTests` — **BUILD SUCCESS** (all modules).
- `TypeRegistryTest` — passes.
- **Multi-replica end-to-end** (two 1.13 replicas sharing one Postgres + OpenSearch, `CACHE_PROVIDER=none`):
  - Create a custom property on replica A, then use it via `PATCH /tables/{id}` on replica B.
  - **No-fix build (1.13 base): replica rejects `400 Unknown custom field`** — bug reproduced.
  - **This backport: replica accepts (200), extension stored** — self-heal confirmed.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds self-healing for stale custom-property registries across replicas. The main changes are:

- Reload the owning type from the shared DB on custom-property misses.
- Add bounded Caffeine caches for missing fields and recent type refreshes.
- Clear negative-cache entries when properties are registered locally.
- Add unit tests for reload, coalescing, negative-cache, and retry behavior.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The changed flow is mostly mergeable, but the new cache windows can still reject newly created remote custom fields.

- The main create-then-use path now reloads the type from the shared DB.
- A miss observed before a remote create can suppress later reloads for the same field.
- A recent type refresh can hide fields created on another replica for a short window.

openmetadata-service/src/main/java/org/openmetadata/service/TypeRegistry.java
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-service/src/main/java/org/openmetadata/service/TypeRegistry.java | Adds DB-backed self-healing and bounded miss/coalescing caches for custom-property lookups. |
| openmetadata-service/src/test/java/org/openmetadata/service/TypeRegistryTest.java | Adds focused unit coverage for the new self-heal and cache behavior. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Stale as Stale replica
    participant DB as Shared DB
    participant Creator as Creator replica
    Stale->>DB: Reload type after miss
    DB-->>Stale: Type snapshot without new field
    Stale->>Stale: Cache miss / recent refresh
    Creator->>DB: Create custom property
    Stale->>Stale: Later validation skips reload
    Stale-->>Stale: Rejects field as unknown
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Stale as Stale replica
    participant DB as Shared DB
    participant Creator as Creator replica
    Stale->>DB: Reload type after miss
    DB-->>Stale: Type snapshot without new field
    Stale->>Stale: Cache miss / recent refresh
    Creator->>DB: Create custom property
    Stale->>Stale: Later validation skips reload
    Stale-->>Stale: Rejects field as unknown
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(types): self-heal custom-property re..."](https://github.com/open-metadata/openmetadata/commit/2af1ae3d244073539f26c8979834a54b01cd26a9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44135515)</sub>

> Greptile also left **2 inline comments** on this PR.

<details><summary><h4>Context used (3)</h4></summary>

- Context used - CLAUDE.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=52f0d9d9-cad1-4e7d-b070-de181a0aa5e7))
- Context used - openmetadata-ui-core-components/CLAUDE.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=41754627-b2bf-474b-8082-f37ef1a07013))
- Context used - AGENTS.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=ef262f5f-911f-44f3-8d2d-e9cb1579c8c8))
</details>

<!-- /greptile_comment -->